### PR TITLE
Minor change to CleanCommand so build works with stdeb

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,9 +92,10 @@ version = '%s'
 class CleanCommand(Command):
     """Custom distutils command to clean the .so and .pyc files."""
 
-    user_options = [ ]
+    user_options = [("all", "a", "") ]
 
     def initialize_options(self):
+        self.all = True
         self._clean_me = []
         self._clean_trees = []
         for root, dirs, files in list(os.walk('pandas')):


### PR DESCRIPTION
Hi Wes, i've been following your pandas work for a while, and regularly install it on my ubuntu based systems.  I generally use the stdeb (https://github.com/astraw/stdeb) package for creating .deb files from python packages.  Unfortunately, some of your recent changes in setup.py in pandas caused a problem with building using stdeb.  Essentially the problem is that debhelper tries to run "python setup.py clean -a" at some point, which doesn't work because the customized clean command does not have a "-a" option.  I just added a dummy argument "--all, -a" argument that has no effect.

No worries if you'd rather not merge it, just wanted to check.

thanks
