### PR TITLE
Enh tests compat pytables 2.1

### DIFF
--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -5,6 +5,8 @@ import random
 import string
 import sys
 
+from distutils.version import LooseVersion
+
 from numpy.random import randn
 import numpy as np
 
@@ -216,3 +218,66 @@ def makeLongPanel():
 
     return wp.to_long()
 
+# Dependency checks.  Copied this from Nipy/Nipype (Copyright of
+# respective developers, license: BSD-3)
+def package_check(pkg_name, version=None, app='pandas', checker=LooseVersion,
+                  exc_failed_import=ImportError,
+                  exc_failed_check=RuntimeError):
+    """Check that the minimal version of the required package is installed.
+
+    Parameters
+    ----------
+    pkg_name : string
+        Name of the required package.
+    version : string, optional
+        Minimal version number for required package.
+    app : string, optional
+        Application that is performing the check.  For instance, the
+        name of the tutorial being executed that depends on specific
+        packages.
+    checker : object, optional
+        The class that will perform the version checking.  Default is
+        distutils.version.LooseVersion.
+    exc_failed_import : Exception, optional
+        Class of the exception to be thrown if import failed.
+    exc_failed_check : Exception, optional
+        Class of the exception to be thrown if version check failed.
+
+    Examples
+    --------
+    package_check('numpy', '1.3')
+    package_check('networkx', '1.0', 'tutorial1')
+
+    """
+
+    if app:
+        msg = '%s requires %s' % (app, pkg_name)
+    else:
+        msg = 'module requires %s' % pkg_name
+    if version:
+      msg += ' with version >= %s' % (version,)
+    try:
+        mod = __import__(pkg_name)
+    except ImportError:
+        raise exc_failed_import(msg)
+    if not version:
+        return
+    try:
+        have_version = mod.__version__
+    except AttributeError:
+        raise exc_failed_check('Cannot find version for %s' % pkg_name)
+    if checker(have_version) < checker(version):
+        raise exc_failed_check(msg)
+
+def skip_if_no_package(*args, **kwargs):
+    """Raise SkipTest if package_check fails
+
+    Parameters
+    ----------
+    *args Positional parameters passed to `package_check`
+    *kwargs Keyword parameters passed to `package_check`
+    """
+    from nose import SkipTest
+    package_check(exc_failed_import=SkipTest,
+                  exc_failed_check=SkipTest,
+                  *args, **kwargs)


### PR DESCRIPTION
unfortunately on Debian systems we still have pytables 2.1; but it still would be nice to have pandas' unittests to pass with skips but without an error or failure -- major incompatibility is absense of blosc compressor.   This changes make those tests conditional on the version of pytables being at least 2.2 to test blosc
