### PR TITLE
Removed warnings when compiling using MSVC/Mingw under 64bit Windows

### DIFF
--- a/pandas/src/common.pyx
+++ b/pandas/src/common.pyx
@@ -90,7 +90,7 @@ cpdef map_indices(ndarray index):
 
     Better to do this with Cython because of the enormous speed boost.
     '''
-    cdef int i, length
+    cdef npy_intp i, length
     cdef flatiter iter
     cdef dict result
     cdef object idx
@@ -200,7 +200,7 @@ cdef class MultiMap:
 
 
 def isAllDates(ndarray index):
-    cdef int i, length
+    cdef npy_intp i, length
     cdef flatiter iter
     cdef object date
 
@@ -224,7 +224,7 @@ def isAllDates2(ndarray[object, ndim=1] arr):
     cannot use
     '''
 
-    cdef int i, size = len(arr)
+    cdef Py_ssize_t i, size = len(arr)
     cdef object date
 
     if size == 0:

--- a/pandas/src/groupby.pyx
+++ b/pandas/src/groupby.pyx
@@ -6,8 +6,8 @@ cdef inline _isnan(object o):
 
 @cython.boundscheck(False)
 def arrmap(ndarray[object] index, object func):
-    cdef int length = index.shape[0]
-    cdef int i = 0
+    cdef Py_ssize_t length = index.shape[0]
+    cdef Py_ssize_t i = 0
 
     cdef ndarray[object] result = np.empty(length, dtype=np.object_)
 
@@ -22,7 +22,7 @@ def groupby_func(object index, object mapper):
     cdef ndarray[object] mapped_index
     cdef ndarray[object] index_buf
     cdef ndarray[int8_t] mask
-    cdef int i, length
+    cdef Py_ssize_t i, length
     cdef list members
     cdef object idx, key
 
@@ -50,7 +50,7 @@ def groupby_func(object index, object mapper):
 def groupby(ndarray[object] index, ndarray[object] labels):
     cdef dict result = {}
     cdef ndarray[int8_t] mask
-    cdef int i, length
+    cdef Py_ssize_t i, length
     cdef list members
     cdef object idx, key
 
@@ -100,22 +100,22 @@ cpdef groupby_indices_naive(ndarray[object] values):
 def groupby_indices(ndarray values):
     cdef:
         Py_ssize_t i, n = len(values)
-        ndarray[int32_t] labels, counts, arr, seen
-        int32_t loc
+        ndarray[Py_ssize_t] labels, counts, arr, seen
+        Py_ssize_t loc
         dict ids = {}
         object val
-        int32_t k
+        Py_ssize_t k
 
     ids, labels, counts = group_labels(values)
     seen = np.zeros_like(counts)
 
     # try not to get in trouble here...
-    cdef int32_t **vecs = <int32_t **> malloc(len(ids) * sizeof(int32_t*))
+    cdef Py_ssize_t **vecs = <Py_ssize_t **> malloc(len(ids) * sizeof(Py_ssize_t*))
     result = {}
     for i from 0 <= i < len(counts):
         arr = np.empty(counts[i], dtype=np.int32)
         result[ids[i]] = arr
-        vecs[i] = <int32_t *> arr.data
+        vecs[i] = <Py_ssize_t *> arr.data
 
     for i from 0 <= i < n:
         k = labels[i]
@@ -265,7 +265,7 @@ def fast_unique(ndarray[object] values):
 @cython.wraparound(False)
 @cython.boundscheck(False)
 def get_unique_labels(ndarray[object] values, dict idMap):
-    cdef int i, length
+    cdef Py_ssize_t i, length
     cdef object idx
     cdef ndarray[int32_t] fillVec
     length = len(values)
@@ -323,7 +323,7 @@ def fast_unique_multiple(list arrays):
 #     return np.asarray(sorted(uniques), dtype=object)
 
 ctypedef double_t (* agg_func)(double_t *out, int32_t *counts, double_t *values,
-                               int32_t *labels, int start, int end,
+                               int32_t *labels, Py_ssize_t start, Py_ssize_t end,
                                Py_ssize_t offset)
 
 cdef agg_func get_agg_func(object how):
@@ -366,7 +366,7 @@ def _group_reorder(values, label_list):
     return sorted_values, sorted_labels
 
 cdef void _aggregate_group(double_t *out, int32_t *counts, double_t *values,
-                           list labels, int start, int end, tuple shape,
+                           list labels, Py_ssize_t start, Py_ssize_t end, tuple shape,
                            Py_ssize_t which, Py_ssize_t offset,
                            agg_func func):
     cdef:
@@ -399,7 +399,7 @@ cdef void _aggregate_group(double_t *out, int32_t *counts, double_t *values,
 # TODO: aggregate multiple columns in single pass
 
 cdef double_t _group_add(double_t *out, int32_t *counts, double_t *values,
-                         int32_t *labels, int start, int end,
+                         int32_t *labels, Py_ssize_t start, Py_ssize_t end,
                          Py_ssize_t offset):
     cdef:
         Py_ssize_t i, it = start
@@ -432,7 +432,7 @@ cdef double_t _group_add(double_t *out, int32_t *counts, double_t *values,
         it += 1
 
 cdef double_t _group_mean(double_t *out, int32_t *counts, double_t *values,
-                          int32_t *labels, int start, int end,
+                          int32_t *labels, Py_ssize_t start, Py_ssize_t end,
                           Py_ssize_t offset):
     cdef:
         Py_ssize_t i, it = start

--- a/pandas/src/io.pyx
+++ b/pandas/src/io.pyx
@@ -22,7 +22,7 @@ cpdef object to_timestamp(object dt):
     return gmtime(dt)
 
 def array_to_timestamp(ndarray[object, ndim=1] arr):
-    cdef int i, n
+    cdef Py_ssize_t i, n
     cdef ndarray[int64_t, ndim=1] result
 
     n = len(arr)
@@ -34,7 +34,7 @@ def array_to_timestamp(ndarray[object, ndim=1] arr):
     return result
 
 def array_to_datetime(ndarray[int64_t, ndim=1] arr):
-    cdef int i, n
+    cdef Py_ssize_t i, n
     cdef ndarray[object, ndim=1] result
 
     n = len(arr)

--- a/pandas/src/isnull.pyx
+++ b/pandas/src/isnull.pyx
@@ -12,7 +12,7 @@ cpdef checknull(object val):
     return _checknull(val)
 
 def isnullobj(ndarray input):
-    cdef int i, length
+    cdef npy_intp i, length
     cdef object val
     cdef ndarray[npy_int8, ndim=1] result
     cdef flatiter iter
@@ -21,7 +21,7 @@ def isnullobj(ndarray input):
 
     result = <ndarray> np.zeros(length, dtype=np.int8)
 
-    iter= PyArray_IterNew(input)
+    iter = PyArray_IterNew(input)
 
     for i from 0 <= i < length:
         val = PyArray_GETITEM(input, PyArray_ITER_DATA(iter))

--- a/pandas/src/moments.pyx
+++ b/pandas/src/moments.pyx
@@ -25,9 +25,9 @@
 #               Series: Prentice-Hall Series in Automatic Computation
 
 
-def kth_smallest(ndarray[double_t, ndim=1] a, int k):
+def kth_smallest(ndarray[double_t, ndim=1] a, Py_ssize_t k):
     cdef:
-        int i,j,l,m,n
+        Py_ssize_t i,j,l,m,n
         double_t x, t
 
     n = len(a)
@@ -59,7 +59,7 @@ def median(ndarray arr):
     '''
     A faster median
     '''
-    cdef int n = len(arr)
+    cdef Py_ssize_t n = len(arr)
 
     if len(arr) == 0:
         return np.NaN
@@ -75,10 +75,11 @@ def median(ndarray arr):
 #-------------------------------------------------------------------------------
 # Rolling sum
 
-def roll_sum(ndarray[double_t] input, int win, int minp):
+def roll_sum(ndarray[double_t] input, int win, Py_ssize_t minp):
     cdef double val, prev, sum_x = 0
-    cdef int nobs = 0, i
-    cdef int N = len(input)
+    cdef int nobs = 0
+    cdef Py_ssize_t i
+    cdef Py_ssize_t N = len(input)
 
     cdef ndarray[double_t] output = np.empty(N, dtype=float)
 
@@ -119,10 +120,11 @@ def roll_sum(ndarray[double_t] input, int win, int minp):
 # Rolling mean
 
 def roll_mean(ndarray[double_t] input,
-               int win, int minp):
+               int win, Py_ssize_t minp):
     cdef double val, prev, sum_x = 0
-    cdef int nobs = 0, i
-    cdef int N = len(input)
+    cdef int nobs = 0
+    cdef Py_ssize_t i
+    cdef Py_ssize_t N = len(input)
 
     cdef ndarray[double_t] output = np.empty(N, dtype=float)
 
@@ -177,8 +179,8 @@ def ewma(ndarray[double_t] input, double_t com):
     '''
 
     cdef double cur, prev, neww, oldw, adj
-    cdef int i
-    cdef int N = len(input)
+    cdef Py_ssize_t i
+    cdef Py_ssize_t N = len(input)
 
     cdef ndarray[double_t] output = np.empty(N, dtype=float)
 
@@ -213,10 +215,10 @@ def ewma(ndarray[double_t] input, double_t com):
 #-------------------------------------------------------------------------------
 # Rolling variance
 
-def roll_var(ndarray[double_t] input, int win, int minp):
+def roll_var(ndarray[double_t] input, int win, Py_ssize_t minp):
     cdef double val, prev, sum_x = 0, sum_xx = 0, nobs = 0
-    cdef int i
-    cdef int N = len(input)
+    cdef Py_ssize_t i
+    cdef Py_ssize_t N = len(input)
 
     cdef ndarray[double_t] output = np.empty(N, dtype=float)
 
@@ -259,11 +261,12 @@ def roll_var(ndarray[double_t] input, int win, int minp):
 #-------------------------------------------------------------------------------
 # Rolling skewness
 
-def roll_skew(ndarray[double_t] input, int win, int minp):
+def roll_skew(ndarray[double_t] input, int win, Py_ssize_t minp):
     cdef double val, prev
     cdef double x = 0, xx = 0, xxx = 0
-    cdef int nobs = 0, i
-    cdef int N = len(input)
+    cdef int nobs = 0
+    cdef Py_ssize_t i
+    cdef Py_ssize_t N = len(input)
 
     cdef ndarray[double_t] output = np.empty(N, dtype=float)
 
@@ -322,11 +325,12 @@ def roll_skew(ndarray[double_t] input, int win, int minp):
 
 
 def roll_kurt(ndarray[double_t] input,
-               int win, int minp):
+               int win, Py_ssize_t minp):
     cdef double val, prev
     cdef double x = 0, xx = 0, xxx = 0, xxxx = 0
-    cdef int nobs = 0, i
-    cdef int N = len(input)
+    cdef int nobs = 0
+    cdef Py_ssize_t i
+    cdef Py_ssize_t N = len(input)
 
     cdef ndarray[double_t] output = np.empty(N, dtype=float)
 
@@ -392,15 +396,16 @@ def roll_kurt(ndarray[double_t] input,
 #-------------------------------------------------------------------------------
 # Rolling median, min, max
 
-ctypedef double_t (* skiplist_f)(object sl, int n, int p)
+ctypedef double_t (* skiplist_f)(object sl, int n, Py_ssize_t p)
 
-cdef _roll_skiplist_op(ndarray arg, int win, int minp, skiplist_f op):
+cdef _roll_skiplist_op(ndarray arg, int win, Py_ssize_t minp, skiplist_f op):
     cdef ndarray[double_t] input = arg
     cdef double val, prev, midpoint
     cdef IndexableSkiplist skiplist
-    cdef int nobs = 0, i
+    cdef Py_ssize_t int = 0
+    cdef Py_ssize_t i
 
-    cdef int N = len(input)
+    cdef Py_ssize_t N = len(input)
     cdef ndarray[double_t] output = np.empty(N, dtype=float)
 
     skiplist = IndexableSkiplist(win)
@@ -436,7 +441,7 @@ cdef _roll_skiplist_op(ndarray arg, int win, int minp, skiplist_f op):
 
     return output
 
-def roll_median(ndarray input, int win, int minp):
+def roll_median(ndarray input, int win, Py_ssize_t minp):
     '''
     O(N log(window)) implementation using skip list
     '''
@@ -445,7 +450,7 @@ def roll_median(ndarray input, int win, int minp):
 # Unfortunately had to resort to some hackery here, would like for
 # Cython to be able to get this right.
 
-cdef double_t _get_median(object sl, int nobs, int minp):
+cdef double_t _get_median(object sl, int nobs, Py_ssize_t minp):
     cdef int midpoint
     cdef IndexableSkiplist skiplist = <IndexableSkiplist> sl
     if nobs >= minp:
@@ -458,39 +463,40 @@ cdef double_t _get_median(object sl, int nobs, int minp):
     else:
         return NaN
 
-def roll_max(ndarray input, int win, int minp):
+def roll_max(ndarray input, int win, Py_ssize_t minp):
     '''
     O(N log(window)) implementation using skip list
     '''
     return _roll_skiplist_op(input, win, minp, _get_max)
 
-cdef double_t _get_max(object skiplist, int nobs, int minp):
+cdef double_t _get_max(object skiplist, int nobs, Py_ssize_t minp):
     if nobs >= minp:
         return <IndexableSkiplist> skiplist.get(nobs - 1)
     else:
         return NaN
 
-def roll_min(ndarray input, int win, int minp):
+def roll_min(ndarray input, int win, Py_ssize_t minp):
     '''
     O(N log(window)) implementation using skip list
     '''
     return _roll_skiplist_op(input, win, minp, _get_min)
 
-cdef double_t _get_min(object skiplist, int nobs, int minp):
+cdef double_t _get_min(object skiplist, int nobs, Py_ssize_t minp):
     if nobs >= minp:
         return <IndexableSkiplist> skiplist.get(0)
     else:
         return NaN
 
 def roll_quantile(ndarray[float64_t, cast=True] input, int win,
-                  int minp, double quantile):
+                  Py_ssize_t minp, double quantile):
    '''
    O(N log(window)) implementation using skip list
    '''
    cdef double val, prev, midpoint
    cdef IndexableSkiplist skiplist
-   cdef int nobs = 0, i
-   cdef int N = len(input)
+   cdef int nobs = 0
+   cdef Py_ssize_t i
+   cdef Py_ssize_t N = len(input)
    cdef ndarray[double_t] output = np.empty(N, dtype=float)
 
    skiplist = IndexableSkiplist(win)
@@ -531,7 +537,7 @@ def roll_quantile(ndarray[float64_t, cast=True] input, int win,
    return output
 
 def roll_generic(ndarray[float64_t, cast=True] input, int win,
-                 int minp, object func):
+                 Py_ssize_t minp, object func):
     cdef ndarray[double_t] output, counts, bufarr
     cdef Py_ssize_t i, n
     cdef float64_t *buf, *oldbuf

--- a/pandas/src/reindex.pyx
+++ b/pandas/src/reindex.pyx
@@ -39,18 +39,19 @@ def _backfill(ndarray[object] oldIndex, ndarray[object] newIndex,
              .                        0
     D
     '''
-    cdef int i, j, oldLength, newLength, curLoc
+    cdef int i, j
+    cdef Py_ssize_t oldLength, newLength, curLoc
     # Make empty vectors
-    cdef ndarray[int32_t, ndim=1] fillVec
+    cdef ndarray[Py_ssize_t, ndim=1] fillVec
     cdef ndarray[int8_t, ndim=1] mask
-    cdef int newPos, oldPos
+    cdef Py_ssize_t newPos, oldPos
     cdef object prevOld, curOld
 
     # Get the size
     oldLength = len(oldIndex)
     newLength = len(newIndex)
 
-    fillVec = np.empty(len(newIndex), dtype = np.int32)
+    fillVec = np.empty(len(newIndex), dtype = np.intp)
     fillVec.fill(-1)
 
     mask = np.zeros(len(newIndex), dtype = np.int8)
@@ -126,18 +127,19 @@ def _pad(ndarray[object] oldIndex, ndarray[object] newIndex,
              .        1               1
     C        C        2               1
     '''
-    cdef int i, j, oldLength, newLength, curLoc
+    cdef int i, j
+    cdef Py_ssize_t oldLength, newLength, curLoc
     # Make empty vectors
-    cdef ndarray[int32_t, ndim=1] fillVec
+    cdef ndarray[Py_ssize_t, ndim=1] fillVec
     cdef ndarray[int8_t, ndim=1] mask
-    cdef int newPos, oldPos
+    cdef Py_ssize_t newPos, oldPos
     cdef object prevOld, curOld
 
     # Get the size
     oldLength = len(oldIndex)
     newLength = len(newIndex)
 
-    fillVec = np.empty(len(newIndex), dtype = np.int32)
+    fillVec = np.empty(len(newIndex), dtype = np.intp)
     fillVec.fill(-1)
 
     mask = np.zeros(len(newIndex), dtype = np.int8)
@@ -229,11 +231,11 @@ def get_pad_indexer(ndarray[np.uint8_t, cast=True] mask):
     '''
     cdef:
         Py_ssize_t i, n
-        int32_t idx
-        ndarray[int32_t] indexer
+        Py_ssize_t idx
+        ndarray[Py_ssize_t] indexer
 
     n = len(mask)
-    indexer = np.empty(n, dtype=np.int32)
+    indexer = np.empty(n, dtype=np.intp)
 
     idx = 0
     for i from 0 <= i < n:
@@ -252,11 +254,11 @@ def get_backfill_indexer(ndarray[np.uint8_t, cast=True] mask):
     '''
     cdef:
         Py_ssize_t i, n
-        int32_t idx
-        ndarray[int32_t] indexer
+        Py_ssize_t idx
+        ndarray[Py_ssize_t] indexer
 
     n = len(mask)
-    indexer = np.empty(n, dtype=np.int32)
+    indexer = np.empty(n, dtype=np.intp)
 
     idx = n - 1
     i = n - 1
@@ -290,13 +292,13 @@ def backfill_inplace_float64(ndarray[float64_t] values,
 @cython.wraparound(False)
 @cython.boundscheck(False)
 def getMergeVec(ndarray[object] values, dict oldMap):
-    cdef int i, j, length, newLength
+    cdef Py_ssize_t i, j, length, newLength
     cdef object idx
     cdef ndarray[int32_t] fillVec
     cdef ndarray[int8_t] mask
 
     newLength = len(values)
-    fillVec = np.empty(newLength, dtype=np.int32)
+    fillVec = np.empty(newLength, dtype=np.intp)
     mask = np.zeros(newLength, dtype=np.int8)
     for i from 0 <= i < newLength:
         idx = values[i]

--- a/pandas/src/skiplist.pyx
+++ b/pandas/src/skiplist.pyx
@@ -117,7 +117,8 @@ cdef class IndexableSkiplist:
         self.size += 1
 
     cpdef remove(self, double value):
-        cdef int level, d
+        cdef Py_ssize_t level
+        cdef Py_ssize_t d
         cdef Node node, prevnode, tmpnode, next_at_level
         cdef list chain
 


### PR DESCRIPTION
BUG: changed index types to Py_ssize_t to use 64-bit indexes on 64 bit machines.

Compiles on Windows-7 64bit with just a few warnings remaining (of initially hundreds) that I cannot fix since they seem to be upstream in cython.

C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\BIN\amd64\cl.exe /c /nologo /Ox /MD /W3 /GS- /DNDEBUG -ID:\Python27\lib\site-packages\numpy\core\include -ID:\Python27\include -ID:\Python27\PC /Tcpandas\src\tseries.c /Fobuild\temp.win-amd64-2.7\Release\pandas\src\tseries.obj
tseries.c
pandas\src\tseries.c(13717) : warning C4244: '+=' : conversion from 'Py_ssize_t' to 'long', possible loss of data
pandas\src\tseries.c(13727) : warning C4244: '+=' : conversion from 'Py_ssize_t' to 'long', possible loss of data
pandas\src\tseries.c(17890) : warning C4244: 'function' : conversion from 'Py_ssize_t' to 'int', possible loss of data
pandas\src\tseries.c(23257) : warning C4244: 'function' : conversion from '__int64' to 'long', possible loss of data
pandas\src\tseries.c(26305) : warning C4267: '=' : conversion from 'size_t' to 'char', possible loss of data
pandas\src\tseries.c(26316) : warning C4267: 'initializing' : conversion from 'size_t' to 'int', possible loss of data
C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\BIN\amd64\link.exe /DLL /nologo /INCREMENTAL:NO /LIBPATH:D:\Python27\libs /LIBPATH:D:\Python27\PCbuild\amd64 /EXPORT:init_tseries build\temp.win-amd64-2.7\Release\pandas\src\tseries.obj /OUT:build\lib.win-amd64-2.7\pandas_tseries.pyd /IMPLIB:build\temp.win-amd64-2.7\Release\pandas\src_tseries.lib /MANIFESTFILE:build\temp.win-amd64-2.7\Release\pandas\src_tseries.pyd.manifest
tseries.obj : warning LNK4197: export 'init_tseries' specified multiple times; using first specification
   Creating library build\temp.win-amd64-2.7\Release\pandas\src_tseries.lib and object build\temp.win-amd64-2.7\Release\pandas\src_tseries.exp
C:\Program Files\Microsoft SDKs\Windows\v6.0A\bin\x64\mt.exe -nologo -manifest build\temp.win-amd64-2.7\Release\pandas\src_tseries.pyd.manifest -outputresource:build\lib.win-amd64-2.7\pandas_tseries.pyd;2
cythoning pandas\src\sparse.pyx to pandas\src\sparse.c
building 'pandas._sparse' extension
C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\BIN\amd64\cl.exe /c /nologo /Ox /MD /W3 /GS- /DNDEBUG -ID:\Python27\lib\site-packages\numpy\core\include -ID:\Python27\include -ID:\Python27\PC /Tcpandas\src\sparse.c /Fobuild\temp.win-amd64-2.7\Release\pandas\src\sparse.obj
sparse.c
pandas\src\sparse.c(4846) : warning C4244: '+=' : conversion from 'Py_ssize_t' to 'long', possible loss of data
pandas\src\sparse.c(7557) : warning C4244: '+=' : conversion from 'Py_ssize_t' to 'long', possible loss of data
pandas\src\sparse.c(16613) : warning C4244: 'function' : conversion from '__int64' to 'long', possible loss of data
pandas\src\sparse.c(19732) : warning C4267: '=' : conversion from 'size_t' to 'char', possible loss of data
pandas\src\sparse.c(19743) : warning C4267: 'initializing' : conversion from 'size_t' to 'int', possible loss of data
C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\BIN\amd64\link.exe /DLL /nologo /INCREMENTAL:NO /LIBPATH:D:\Python27\libs /LIBPATH:D:\Python27\PCbuild\amd64 /EXPORT:init_sparse build\temp.win-amd64-2.7\Release\pandas\src\sparse.obj /OUT:build\lib.win-amd64-2.7\pandas_sparse.pyd /IMPLIB:build\temp.win-amd64-2.7\Release\pandas\src_sparse.lib /MANIFESTFILE:build\temp.win-amd64-2.7\Release\pandas\src_sparse.pyd.manifest
