### PR TITLE
Minor change to csv reading

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -12,8 +12,8 @@ import numpy as np
 from pandas.core.index import Index
 from pandas.core.frame import DataFrame
 
-def read_csv(filepath_or_buffer, header=0, skiprows=None, index_col=0,
-             na_values=None, date_parser=None, names=None):
+def read_csv(filepath_or_buffer, sep=None, header=0, skiprows=None, index_col=0,
+             na_values=None, date_parser=None, names=None, sniff_sep=True):
     """
     Read CSV file into DataFrame
 
@@ -34,6 +34,9 @@ def read_csv(filepath_or_buffer, header=0, skiprows=None, index_col=0,
         dateutil.parser
     names : array-like
         List of column names
+    sniff_sep : boolean, default True
+        Attempt to automatically determine the separator for the data. Defaults 
+        to True, however if sep is defined then it will take precedence
 
     Returns
     -------
@@ -50,7 +53,19 @@ def read_csv(filepath_or_buffer, header=0, skiprows=None, index_col=0,
         except Exception: # pragma: no cover
             f = open(filepath_or_buffer, 'r')
 
-    reader = csv.reader(f, dialect='excel')
+    # default dialect
+    dia = csv.excel
+    if sep is not None:
+        sniff_sep = False
+        dia.delimiter = sep
+    # attempt to sniff the delimiter
+    if sniff_sep:
+        sample = f.readline()
+        sniffed = csv.Sniffer().sniff(sample)
+        dia.delimiter = sniffed.delimiter
+        f.seek(0)
+        
+    reader = csv.reader(f, dialect=dia)
 
     if skiprows is not None:
         skiprows = set(skiprows)
@@ -63,8 +78,7 @@ def read_csv(filepath_or_buffer, header=0, skiprows=None, index_col=0,
                           date_parser=date_parser)
 
 def read_table(filepath_or_buffer, sep='\t', header=0, skiprows=None,
-               index_col=0, na_values=None, names=None,
-               date_parser=None):
+               index_col=0, na_values=None, date_parser=None, names=None):
     """
     Read delimited file into DataFrame
 
@@ -92,25 +106,8 @@ def read_table(filepath_or_buffer, sep='\t', header=0, skiprows=None,
     -------
     parsed : DataFrame
     """
-    if hasattr(filepath_or_buffer, 'read'):
-        reader = filepath_or_buffer
-    else:
-        try:
-            # universal newline mode
-            reader = open(filepath_or_buffer, 'U')
-        except Exception: # pragma: no cover
-            reader = open(filepath_or_buffer, 'r')
-
-    if skiprows is not None:
-        skiprows = set(skiprows)
-        lines = [l for i, l in enumerate(reader) if i not in skiprows]
-    else:
-        lines = [l for l in reader]
-
-    lines = [re.split(sep, l.rstrip()) for l in lines]
-    return _simple_parser(lines, header=header, indexCol=index_col,
-                          colNames=names, na_values=na_values,
-                          date_parser=date_parser)
+    return read_csv(filepath_or_buffer, sep, header, skiprows, 
+                    index_col, na_values, date_parser, names)
 
 def _simple_parser(lines, colNames=None, header=0, indexCol=0,
                    na_values=None, date_parser=None, parse_dates=True):

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -13,7 +13,7 @@ from pandas.core.index import Index
 from pandas.core.frame import DataFrame
 
 def read_csv(filepath_or_buffer, sep=None, header=0, skiprows=None, index_col=0,
-             na_values=None, date_parser=None, names=None, sniff_sep=True):
+             na_values=None, date_parser=None, names=None):
     """
     Read CSV file into DataFrame
 
@@ -37,9 +37,6 @@ def read_csv(filepath_or_buffer, sep=None, header=0, skiprows=None, index_col=0,
         dateutil.parser
     names : array-like
         List of column names
-    sniff_sep : boolean, default True
-        Attempt to automatically determine the separator for the data. Defaults 
-        to True, however if sep is defined then it will take precedence
 
     Returns
     -------
@@ -56,6 +53,7 @@ def read_csv(filepath_or_buffer, sep=None, header=0, skiprows=None, index_col=0,
         except Exception: # pragma: no cover
             f = open(filepath_or_buffer, 'r')
 
+    sniff_sep = True
     # default dialect
     dia = csv.excel
     if sep is not None:

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -20,6 +20,9 @@ def read_csv(filepath_or_buffer, sep=None, header=0, skiprows=None, index_col=0,
     Parameters
     ----------
     filepath_or_buffer : string or file handle / StringIO
+    sep : string, default None
+        Delimiter to use. By default will try to automatically determine
+        this
     header : int, default 0
         Row to use for the column labels of the parsed DataFrame
     skiprows : list-like


### PR DESCRIPTION
Hi Wes

Firstly, congrats on such an amazing project! I love prototyping in python / numpy / ipython, but I always envy some of R's features. I tried pandas out about 9 months ago and although it was interesting, it seemed very rough around the edges. Now, however, it is looking really polished and I've been using it for prototyping and testing some trading models, and everything works extremely well. I hope it keeps growing, together with the integration with scikits statsmodels/timeseries and maybe even scikits.learn in future ...

Anyway, as I was starting to dive into the code, I came across the <code>read_csv</code> functions and noticed that there was full duplication in <code>read_table</code>. The <code>csv</code> module in python actually has full support for arbitrary delimiters, so there is no need for the duplication. Also, there is <code>csv.Sniffer().sniff(sample)</code> that attempts to sniff out the delimiter automatically. This commit tries to "magically" handle any arbitrary CSV file without needing to specify a separator, whether separated by blank spaces, tabs, commas, semicolons or other weird separators (I have a file at work with "^" separators :). If it doesn't work, one can fall back on specifying the separator (so <code>read_csv</code> looks more like <code>read_table</code>). In future it could make sense to simply have one <code>read_data</code> or <code>read_table</code> function.

Incidentally, the <code>csv.Sniffer()</code> also tries to sniff out other things like quote escaping and double quoting, but this commit effectively only uses it for the delimiter. If problems with quote / string escaping crop up with users one could always let the sniffer try to figure out the full dialect.
