### PR TITLE
ENH: improve DataFrame read_csv / to_csv for Index/MultiIndex

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -431,8 +431,9 @@ class DataFrame(NDFrame):
         header : int, default 0
             Row to use at header (skip prior rows)
         delimiter : string, default ','
-        index_col : int, default 0
-            Column to use for index
+        index_col : int or sequence, default 0
+            Column to use for index. If a sequence is given, a MultiIndex
+            is used.
 
         Notes
         -----
@@ -482,8 +483,10 @@ class DataFrame(NDFrame):
             Write out column names
         index : boolean, default True
             Write row names (index)
-        index_label : string, default None
-            Column label for index column if desired
+        index_label : string or sequence, default None
+            Column label for index column(s) if desired. If None is given, and
+            `header` and `index` are True, then the index names are used. A
+            sequence should be given if the DataFrame uses MultiIndex.
         mode : Python write mode, default 'wb'
         """
         f = open(path, mode)
@@ -494,15 +497,25 @@ class DataFrame(NDFrame):
         series = self._series
         if header:
             joined_cols = ','.join([str(c) for c in cols])
-            if index and index_label:
-                f.write('%s,%s' % (index_label, joined_cols))
+            if index:
+                # should write something for index label
+                if index_label is None:
+                    index_label = getattr(self.index, 'names', ['index'])
+                elif not isinstance(index_label, (list, tuple, np.ndarray)):
+                    # given a string for a DF with Index
+                    index_label = [index_label]
+                f.write('%s,%s' % (",".join(index_label), joined_cols))
             else:
                 f.write(joined_cols)
             f.write('\n')
 
+        nlevels = getattr(self.index, 'nlevels', 1)
         for idx in self.index:
             if index:
-                f.write(str(idx))
+                if nlevels == 1:
+                    f.write(str(idx))
+                else: # handle MultiIndex
+                    f.write(",".join([str(i) for i in idx]))
             for i, col in enumerate(cols):
                 val = series[col].get(idx)
                 if isnull(val):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -13,7 +13,8 @@ import numpy as np
 
 import pandas.core.datetools as datetools
 from pandas.core.index import NULL_INDEX
-from pandas.core.api import (DataFrame, Index, Series, notnull, isnull)
+from pandas.core.api import (DataFrame, Index, Series, notnull, isnull,
+                             MultiIndex)
 
 from pandas.util.testing import (assert_almost_equal,
                                  assert_series_equal,
@@ -1459,6 +1460,48 @@ class TestDataFrame(unittest.TestCase, CheckIndexing):
         dm.to_csv(path)
         recons = DataFrame.from_csv(path)
         assert_frame_equal(dm, recons)
+
+        os.remove(path)
+
+    def test_to_csv_multiindex(self):
+        path = '__tmp__'
+
+        frame = self.frame
+        old_index = frame.index
+        new_index = MultiIndex.from_arrays(np.arange(len(old_index)*2).reshape(2,-1))
+        frame.index = new_index
+        frame.to_csv(path, header=False)
+        frame.to_csv(path, cols=['A', 'B'])
+
+
+        # round trip
+        frame.to_csv(path)
+
+        df = DataFrame.from_csv(path, index_col=[0,1])
+
+        assert_frame_equal(frame, df)
+        self.frame.index = old_index # needed if setUP becomes a classmethod
+
+        # try multiindex with dates
+        tsframe = self.tsframe
+        old_index = tsframe.index
+        new_index = [old_index, np.arange(len(old_index))]
+        tsframe.index = MultiIndex.from_arrays(new_index)
+
+        tsframe.to_csv(path, index_label = ['time','foo'])
+        recons = DataFrame.from_csv(path, index_col=[0,1])
+        assert_frame_equal(tsframe, recons)
+
+        # do not load index
+        tsframe.to_csv(path)
+        recons = DataFrame.from_csv(path, index_col=None)
+        np.testing.assert_equal(len(recons.columns), len(tsframe.columns) + 2)
+
+        # no index
+        tsframe.to_csv(path, index=False)
+        recons = DataFrame.from_csv(path, index_col=None)
+        assert_almost_equal(recons.values, self.tsframe.values)
+        self.tsframe.index = old_index # needed if setUP becomes classmethod
 
         os.remove(path)
 


### PR DESCRIPTION
2 issues for DataFrame.to_csv

1 ) If header and index are True, you should write something for an index header, even if index_level is None.
2) If given a MultiIndex, don't want to just call str() on each element.

Also fixed read_csv to take an iterable for index_col so that I could write tests.

I haven't looked at the similar methods in Series or the other to_\* methods yet. This is all I needed at the moment.

Aside: it looks like in test_frame setUp isn't a classmethod and is called for each test method. Not a big deal, but might be a little heavy in the test suite.
