### PR TITLE
Use stdlib csv module to write csv

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -5,6 +5,7 @@ Data structure for 1-dimensional cross-sectional and time series data
 # pylint: disable=E1101,E1103
 # pylint: disable=W0703,W0622,W0613,W0201
 
+import csv
 import itertools
 import operator
 import sys
@@ -1589,8 +1590,8 @@ copy : boolean, default False
             Output filepath. If None, write to stdout
         """
         f = open(path, 'wb')
-        for idx, value in self.iteritems():
-            f.write(str(idx) + ',' + str(value) + '\n')
+        csvout = csv.writer(f)
+        csvout.writerows(self.iteritems())
         f.close()
 
     def dropna(self):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1582,6 +1582,16 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         lines = open(pth).readlines()
         self.assert_(lines[1].split(',')[2] == '999')
         os.remove(pth)
+    
+    def test_to_csv_withcommas(self):
+        "Commas inside fields should be correctly escaped when saving as CSV."
+        path = '__tmp__'
+        df = DataFrame({'A':[1,2,3], 'B':['5,6','7,8','9,0']})
+        df.to_csv(path)
+        df2 = DataFrame.from_csv(path)
+        assert_frame_equal(df2, df)
+        
+        os.remove(path)
 
     def test_info(self):
         io = StringIO()


### PR DESCRIPTION
I noticed while using pandas that data with commas in the fields wasn't getting escaped properly when written to CSV (data in biology often has bits of text as well as numbers). This causes the data to spread out over extra columns. This commit uses the `csv` module from the standard library to write out CSV 'properly'.

I've also added a simple test for this case.
