### PR TITLE
Series methods isnull and notnull

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1603,7 +1603,7 @@ copy : boolean, default False
         path : string or None
             Output filepath. If None, write to stdout
         """
-        f = open(path, 'wb')
+        f = open(path, 'w')
         csvout = csv.writer(f)
         csvout.writerows(self.iteritems())
         f.close()

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1619,6 +1619,9 @@ copy : boolean, default False
         return remove_na(self)
 
     valid = dropna
+    
+    isnull = isnull
+    notnull = notnull
 
     def first_valid_index(self):
         """

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -824,6 +824,18 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         self.assertEqual(len(result), ts.count())
 
         common.assert_dict_equal(result, ts, compare_keys=False)
+    
+    def test_isnull(self):
+        ser = Series([0,5.4,3,nan,-0.001])
+        assert_series_equal(ser.isnull(), Series([False,False,False,True,False]))
+        ser = Series(["hi","",nan])
+        assert_series_equal(ser.isnull(), Series([False,False,True]))
+    
+    def test_notnull(self):
+        ser = Series([0,5.4,3,nan,-0.001])
+        assert_series_equal(ser.notnull(), Series([True,True,True,False,True]))
+        ser = Series(["hi","",nan])
+        assert_series_equal(ser.notnull(), Series([True,True,False]))
 
     def test_shift(self):
         shifted = self.ts.shift(1)

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,8 @@ CLASSIFIERS = [
     'Operating System :: OS Independent',
     'Intended Audience :: Science/Research',
     'Programming Language :: Python',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 3',
     'Programming Language :: Cython',
     'Topic :: Scientific/Engineering',
 ]


### PR DESCRIPTION
Fulfils enhancement #203: isnull and notnull methods for series (especially for use with columns in dataframes).

I've also slipped in a couple of other small tweaks - fixing a bug with writing series CSV, and adding trove classifiers to indicate Python 3 compatibility.
