### PR TITLE
Add simple attribute access to DataFrame columns

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -860,6 +860,14 @@ class DataFrame(NDFrame):
         res = Series(values, index=self.index, name=key)
         self._series_cache[key] = res
         return res
+    
+    def __getattr__(self, name):
+        """After regular attribute access, try looking up the name of a column.
+        This allows simpler access to columns for interactive use."""
+        if name in self.columns:
+            return self[name]
+        raise AttributeError("'%s' object has no attribute '%s'" % \
+                                                    (type(self).__name__, name))
 
     def __setitem__(self, key, value):
         # support boolean setting with DataFrame input, e.g.

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -67,6 +67,10 @@ class CheckIndexing(object):
 
         subframe_obj = self.tsframe[indexer_obj]
         assert_frame_equal(subframe_obj, subframe)
+    
+    def test_getattr(self):
+        tm.assert_series_equal(self.frame.A, self.frame['A'])
+        self.assertRaises(AttributeError, getattr, self.frame, 'NONEXISTENT_NAME')
 
     def test_setitem(self):
         # not sure what else to do here


### PR DESCRIPTION
This one might need some discussion, but I think it makes sense.

If a column name in a dataframe is a valid Python name and doesn't conflict with any DataFrame attributes, this lets you type `df.MyColumn` than `df['MyColumn']`. That's much handier for interactive use, especially because IPython will tab complete `df.MyColumn.<tab>`, while it won't by default tab complete `df['MyColumn'].<tab>`.

This doesn't interfere with accessing columns through the dictionary interface.
