### PR TITLE
Add columns to IPython tab completions of DataFrame attributes

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -15,6 +15,7 @@ labeling information
 from StringIO import StringIO
 import csv
 import operator
+import sys
 import warnings
 
 from numpy import nan
@@ -550,7 +551,6 @@ class DataFrame(NDFrame):
                   nanRep='NaN', formatters=None, float_format=None,
                   sparsify=True):
         from pandas.core.common import _format, adjoin
-        import sys
 
         if buf is None:  # pragma: no cover
             buf = sys.stdout
@@ -629,7 +629,6 @@ class DataFrame(NDFrame):
             If False, don't print column count summary
         buf : writable buffer, defaults to sys.stdout
         """
-        import sys
         if buf is None:  # pragma: no cover
             buf = sys.stdout
 
@@ -3303,6 +3302,22 @@ def _homogenize(data, index, columns, dtype=None):
 
 def _put_str(s, space):
     return ('%s' % s)[:space].ljust(space)
+
+def install_ipython_completers():
+    """Register the DataFrame type with IPython's tab completion machinery, so
+    that it knows about accessing column names as attributes."""
+    from IPython.utils.generics import complete_object
+    
+    @complete_object.when_type(DataFrame)
+    def complete_dataframe(obj, prev_completions):
+        return prev_completions + [c for c in obj.columns \
+                                                if py3compat.isidentifier(c)]
+
+# Importing IPython brings in about 200 modules, so we want to avoid it unless
+# we're in IPython (when those modules are loaded anyway).
+if "IPython" in sys.modules:
+    install_ipython_completers()
+
 
 if __name__ == '__main__':
     import nose

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3316,7 +3316,10 @@ def install_ipython_completers():
 # Importing IPython brings in about 200 modules, so we want to avoid it unless
 # we're in IPython (when those modules are loaded anyway).
 if "IPython" in sys.modules:
-    install_ipython_completers()
+    try:
+        install_ipython_completers()
+    except Exception:
+        pass
 
 
 if __name__ == '__main__':

--- a/pandas/util/py3compat.py
+++ b/pandas/util/py3compat.py
@@ -1,3 +1,14 @@
 import sys
 
 PY3 = (sys.version_info[0] >= 3)
+
+if PY3:
+    def isidentifier(s):
+        return s.isidentifier()
+
+else:
+    # Python 2
+    import re
+    _name_re = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*$")
+    def isidentifier(s, dotted=False):
+        return bool(_name_re.match(s))


### PR DESCRIPTION
This addresses #230.

I'm not entirely happy about how we check whether IPython is imported, but it's the best option I could see, and I don't think we should unconditionally import IPython and dependent modules just because it's installed.
