### PR TITLE
.describe() for series of objects

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2497,7 +2497,7 @@ class DataFrame(NDFrame):
         min : Series
         """
         values = self.values.copy()
-        if skipna:
+        if skipna and not issubclass(values.dtype.type, np.int_):
             np.putmask(values, -np.isfinite(values), np.inf)
         return Series(values.min(axis), index=self._get_agg_axis(axis))
 
@@ -2518,7 +2518,7 @@ class DataFrame(NDFrame):
         max : Series
         """
         values = self.values.copy()
-        if skipna:
+        if skipna and not issubclass(values.dtype.type, np.int_):
             np.putmask(values, -np.isfinite(values), -np.inf)
         return Series(values.max(axis), index=self._get_agg_axis(axis))
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -5,6 +5,7 @@ Data structure for 1-dimensional cross-sectional and time series data
 # pylint: disable=E1101,E1103
 # pylint: disable=W0703,W0622,W0613,W0201
 
+import collections
 import csv
 import itertools
 import operator
@@ -873,12 +874,20 @@ copy : boolean, default False
         -------
         desc : Series
         """
-        names = ['count', 'mean', 'std', 'min',
-                 '25%', '50%', '75%', 'max']
+        if self.dtype == object:
+            names = ['count', 'unique', 'top', 'freq']
+            
+            objcounts = collections.Counter(self)
+            top, freq = objcounts.most_common(1)[0]
+            data = [self.count(), len(objcounts), top, freq]
+            
+        else:    
+            names = ['count', 'mean', 'std', 'min',
+                     '25%', '50%', '75%', 'max']
 
-        data = [self.count(), self.mean(), self.std(), self.min(),
-                self.quantile(.25), self.median(), self.quantile(.75),
-                self.max()]
+            data = [self.count(), self.mean(), self.std(), self.min(),
+                    self.quantile(.25), self.median(), self.quantile(.75),
+                    self.max()]
 
         return Series(data, index=names)
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2721,9 +2721,11 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
     def test_min(self):
         self._check_stat_op('min', np.min)
+        self._check_stat_op('min', np.min, frame=self.intframe)
 
     def test_max(self):
         self._check_stat_op('max', np.max)
+        self._check_stat_op('max', np.max, frame=self.intframe)
 
     def test_mad(self):
         f = lambda x: np.abs(x - x.mean()).mean()

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -550,6 +550,7 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
     def test_describe(self):
         _ = self.series.describe()
         _ = self.ts.describe()
+        _ = self.objSeries.describe()
 
     def test_append(self):
         appendedSeries = self.series.append(self.ts)


### PR DESCRIPTION
See #210.

I don't know if `series.dtype == object` is the best way to check for non-numeric data, but it appears to work.

At present, I've used fields 'count', 'unique', 'top' (i.e. most common) and 'freq' (i.e. count of the most common). These seem like obvious things for a summary.

I also noticed a problem doing `df.describe()` if df has integer columns, so I copied some code from series to fix that.
