### PR TITLE
Support different delimiters for to_csv

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -489,6 +489,10 @@ class DataFrame(NDFrame):
             `header` and `index` are True, then the index names are used. A
             sequence should be given if the DataFrame uses MultiIndex.
         mode : Python write mode, default 'w'
+        delimiter : character, default ","
+            Field delimiter for the output file.
+
+
         """
         f = open(path, mode)
         csvout = csv.writer(f, lineterminator='\n', delimiter=delimiter)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -469,7 +469,7 @@ class DataFrame(NDFrame):
                                default_fill_value=fill_value)
 
     def to_csv(self, path, nanRep='', cols=None, header=True,
-              index=True, index_label=None, mode='w'):
+              index=True, index_label=None, mode='w', delimiter=","):
         """
         Write DataFrame to a comma-separated values (csv) file
 
@@ -491,7 +491,7 @@ class DataFrame(NDFrame):
         mode : Python write mode, default 'w'
         """
         f = open(path, mode)
-        csvout = csv.writer(f, lineterminator='\n')
+        csvout = csv.writer(f, lineterminator='\n', delimiter=delimiter)
 
         if cols is None:
             cols = self.columns

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -491,8 +491,6 @@ class DataFrame(NDFrame):
         mode : Python write mode, default 'w'
         delimiter : character, default ","
             Field delimiter for the output file.
-
-
         """
         f = open(path, mode)
         csvout = csv.writer(f, lineterminator='\n', delimiter=delimiter)


### PR DESCRIPTION
This pull requests implements delimter support into to_csv. A number of analysis tools expects TSV files rather than CSV files, and this is a simple solution to the problem.

The delimiter parameter is by default ",", hence there are no side effects with existing code.
