### PR TITLE
Update install docs now that pandas works on Python 3

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -16,9 +16,9 @@ compiler (MinGW or Visual Studio) installed. `How-to install MinGW on Windows
 Python version support
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Officially Python 2.5 to 2.7. I will aim for Python 3.x support in the next
-release. Python 2.4 support is being phased out since the userbase has shrunk
-significantly. Continuing Python 2.4 support will require either monetary
+Officially Python 2.5 to 2.7 and Python 3.1+, although Python 3 support is less
+well tested. Python 2.4 support is being phased out since the userbase has
+shrunk significantly. Continuing Python 2.4 support will require either monetary
 development support or someone contributing to the project to maintain
 compatibility.
 


### PR DESCRIPTION
I realised I'd forgotten to update the docs when I did the Python 3 support. Feel free to tweak the wording, and let me know if there are other bits of the docs I should update.
