### PR TITLE
ENH: Adding argmin, argmax to Series and DataFrame.

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2488,9 +2488,10 @@ class DataFrame(NDFrame):
             np.putmask(values, -np.isfinite(values), np.inf)
         return Series(values.min(axis), index=self._get_agg_axis(axis))
 
-    def max(self, axis=0, skipna=True):
+    def argmin(self, axis=0, skipna=True):
         """
-        Return maximum over requested axis. NA/null values are excluded
+        Return index of first occurence of minimum over requested axis.
+        NA/null values are excluded.
 
         Parameters
         ----------
@@ -2502,12 +2503,59 @@ class DataFrame(NDFrame):
 
         Returns
         -------
+        argmin : Series
+        """
+        values = self.values.copy()
+        if skipna and not issubclass(values.dtype.type, np.integer):
+            np.putmask(values, -np.isfinite(values), np.inf)
+        argmin_index = self._get_agg_axis([1, 0][axis])
+        return Series([argmin_index[i] for i in values.argmin(axis)],
+                      index=self._get_agg_axis(axis))
+
+    def max(self, axis=0, skipna=True):
+        """
+        Return maximum over requested axis. NA/null values are excluded
+
+        Parameters
+        ----------
+        axis : {0, 1}
+            0 for row-wise, 1 for column-wise
+        skipna : boolean, default True
+            Exclude NA/null values. If an entire row/column is NA, the result
+            will be first index.
+
+        Returns
+        -------
         max : Series
         """
         values = self.values.copy()
         if skipna and not issubclass(values.dtype.type, np.integer):
             np.putmask(values, -np.isfinite(values), -np.inf)
         return Series(values.max(axis), index=self._get_agg_axis(axis))
+
+    def argmax(self, axis=0, skipna=True):
+        """
+        Return index of first occurence of maximum over requested axis.
+        NA/null values are excluded.
+
+        Parameters
+        ----------
+        axis : {0, 1}
+            0 for row-wise, 1 for column-wise
+        skipna : boolean, default True
+            Exclude NA/null values. If an entire row/column is NA, the result
+            will be first index.
+
+        Returns
+        -------
+        max : Series
+        """
+        values = self.values.copy()
+        if skipna and not issubclass(values.dtype.type, np.integer):
+            np.putmask(values, -np.isfinite(values), -np.inf)
+        argmax_index = self._get_agg_axis([1, 0][axis])
+        return Series([argmax_index[i] for i in values.argmax(axis)],
+                      index=self._get_agg_axis(axis))
 
     def prod(self, axis=0, skipna=True):
         """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -718,6 +718,25 @@ copy : boolean, default False
                 np.putmask(arr, isnull(arr), np.inf)
         return arr.min()
 
+    def argmin(self, axis=None, out=None, skipna=True):
+        """
+        Index of first occurence of minimum of values.
+
+        Parameters
+        ----------
+        skipna : boolean, default True
+            Exclude NA/null values
+
+        Returns
+        -------
+        Index of mimimum of values.
+        """
+        arr = self.values.copy()
+        if skipna:
+            if not issubclass(arr.dtype.type, np.integer):
+                np.putmask(arr, isnull(arr), np.inf)
+        return self.index[arr.argmin()]
+
     def max(self, axis=None, out=None, skipna=True):
         """
         Maximum of values
@@ -736,6 +755,25 @@ copy : boolean, default False
             if not issubclass(arr.dtype.type, np.integer):
                 np.putmask(arr, isnull(arr), -np.inf)
         return arr.max()
+
+    def argmax(self, axis=None, out=None, skipna=True):
+        """
+        Index of first occurence of maximum of values.
+
+        Parameters
+        ----------
+        skipna : boolean, default True
+            Exclude NA/null values
+
+        Returns
+        -------
+        Index of mimimum of values.
+        """
+        arr = self.values.copy()
+        if skipna:
+            if not issubclass(arr.dtype.type, np.integer):
+                np.putmask(arr, isnull(arr), -np.inf)
+        return self.index[arr.argmax()]
 
     def std(self, axis=None, dtype=None, out=None, ddof=1, skipna=True):
         """

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2729,9 +2729,73 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self._check_stat_op('min', np.min)
         self._check_stat_op('min', np.min, frame=self.intframe)
 
+    def test_argmin(self):
+        def validate(f, s, axis, skipna):
+            def get_result(f, i, v, axis, skipna):
+                if axis == 0:
+                    return (f[i][v], f[i].min(skipna=skipna))
+                else:
+                    return (f[v][i], f.ix[i].min(skipna=skipna))
+            for i, v in s.iteritems():
+                (r1, r2) = get_result(f, i, v, axis, skipna)
+                if np.isnan(r1) or np.isinf(r1):
+                    self.assert_(np.isnan(r2) or np.isinf(r2))
+                elif np.isnan(r2) or np.isinf(r2):
+                    self.assert_(np.isnan(r1) or np.isinf(r1))
+                else:
+                    self.assertEqual(r1, r2)
+
+        frame = self.frame
+        frame.ix[5:10] = np.nan
+        frame.ix[15:20, -2:] = np.nan
+        for skipna in [True, False]:
+            for axis in [0, 1]:
+                validate(frame,
+                         frame.argmin(axis=axis, skipna=skipna),
+                         axis,
+                         skipna)
+                validate(self.intframe,
+                         self.intframe.argmin(axis=axis, skipna=skipna),
+                         axis,
+                         skipna)
+
+        self.assertRaises(Exception, frame.argmin, axis=2)
+
     def test_max(self):
         self._check_stat_op('max', np.max)
         self._check_stat_op('max', np.max, frame=self.intframe)
+
+    def test_argmax(self):
+        def validate(f, s, axis, skipna):
+            def get_result(f, i, v, axis, skipna):
+                if axis == 0:
+                    return (f[i][v], f[i].max(skipna=skipna))
+                else:
+                    return (f[v][i], f.ix[i].max(skipna=skipna))
+            for i, v in s.iteritems():
+                (r1, r2) = get_result(f, i, v, axis, skipna)
+                if np.isnan(r1) or np.isinf(r1):
+                    self.assert_(np.isnan(r2) or np.isinf(r2))
+                elif np.isnan(r2) or np.isinf(r2):
+                    self.assert_(np.isnan(r1) or np.isinf(r1))
+                else:
+                    self.assertEqual(r1, r2)
+
+        frame = self.frame
+        frame.ix[5:10] = np.nan
+        frame.ix[15:20, -2:] = np.nan
+        for skipna in [True, False]:
+            for axis in [0, 1]:
+                validate(frame,
+                         frame.argmax(axis=axis, skipna=skipna),
+                         axis,
+                         skipna)
+                validate(self.intframe,
+                         self.intframe.argmax(axis=axis, skipna=skipna),
+                         axis,
+                         skipna)
+
+        self.assertRaises(Exception, frame.argmax, axis=2)
 
     def test_mad(self):
         f = lambda x: np.abs(x - x.mean()).mean()

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -492,8 +492,52 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
     def test_min(self):
         self._check_stat_op('min', np.min)
 
+    def test_argmin(self):
+        """
+        test argmin
+        _check_stat_op approach can not be used here because of isnull check.
+        """
+        # add some NaNs
+        self.series[5:15] = np.NaN
+
+        # skipna or no
+        self.assertEqual(self.series[self.series.argmin()], self.series.min())
+        self.assert_(isnull(self.series[self.series.argmin(skipna=False)]))
+
+        # no NaNs
+        nona = self.series.dropna()
+        self.assertEqual(nona[nona.argmin()], nona.min())
+        self.assertEqual(nona.index.values.tolist().index(nona.argmin()),
+                         nona.values.argmin())
+
+        # all NaNs
+        allna = self.series * nan
+        self.assertEqual(allna.argmin(), allna.index[0])
+
     def test_max(self):
         self._check_stat_op('max', np.max)
+
+    def test_argmax(self):
+        """
+        test argmax
+        _check_stat_op approach can not be used here because of isnull check.
+        """
+        # add some NaNs
+        self.series[5:15] = np.NaN
+
+        # skipna or no
+        self.assertEqual(self.series[self.series.argmax()], self.series.max())
+        self.assert_(isnull(self.series[self.series.argmax(skipna=False)]))
+
+        # no NaNs
+        nona = self.series.dropna()
+        self.assertEqual(nona[nona.argmax()], nona.max())
+        self.assertEqual(nona.index.values.tolist().index(nona.argmax()),
+                         nona.values.argmax())
+
+        # all NaNs
+        allna = self.series * nan
+        self.assertEqual(allna.argmax(), allna.index[0])
 
     def test_std(self):
         alt = lambda x: np.std(x, ddof=1)


### PR DESCRIPTION
Hi Wess,

Pull request to let you know that i added argmin and argmax methods to Series and DataFrame.
I also included unit tests. It`s not that much work/code, but anyway an interesting enhancement i think.

some examples:
In [23]: s
Out[23]:
a    0.80015881463
b    0.983432892599
c    0.965122593504
d    0.81910825442
e    0.726239458506
Name: None, Length: 5

In [24]: s.argmin()
Out[24]: 'e'

In [25]: s[s.argmax()] == s.max()
Out[25]: True

In [26]: df
Out[26]:
               A       B       C        D       E
one two three
a   b   10    -0.6155  1.237   1.371    1.24   -0.7725
p   q   20     1.14   -0.3743  0.5251   0.2426  1.81
x   y   30     0.6626  2.004  -0.01327  1.587   0.3524

In [27]: df.argmax(axis=0)
Out[27]:
A    ('p', 'q', 20)
B    ('x', 'y', 30)
C    ('a', 'b', 10)
D    ('x', 'y', 30)
E    ('p', 'q', 20)
Name: None, Length: 5

In [28]: df.argmin(axis=1)
Out[28]:
a  b  10    E
p  q  20    B
x  y  30    C
Name: None, Length: 3

What do you think?

Wouter
