### PR TITLE
ENH: Adding DataFrame.boxplot()

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2887,6 +2887,25 @@ class DataFrame(NDFrame):
             ax.set_title(col)
             ax.grid(grid)
 
+    def boxplot(self, grid=True, **kwds):  # pragma: no cover
+        """
+        Draw boxplot of the DataFrame's series using matplotlib / pylab.
+
+        Parameters
+        ----------
+        grid : boolean, default True
+            Add grid to plot.
+        kwds : other plotting keyword arguments
+            To be passed to boxplot function
+        """
+        import matplotlib.pyplot as plt
+
+        _, ax = plt.subplots(nrows=1, ncols=1)
+        ax.boxplot(self.dropna().values, **kwds)
+        ax.set_xticklabels(self.columns)
+        ax.grid(grid)
+        plt.draw_if_interactive()
+
     #----------------------------------------------------------------------
     # Deprecated stuff
 


### PR DESCRIPTION
Added DataFrame.boxplot() in similar way as DataFrame.plot() and DataFrame.hist().
Some syntactic sugar ;-)

Thinking about adding DataFrameGroupBy.boxplot(), now this call is transfered to DataFrame.boxplot().
But i would prefer the behavior to be different. When groupby is used i`m interested to see in a single plot boxplots for one particular column for all groupby keys and not in one plot to have boxpots for all columns for one groupby key. An input argument can be used to so both ways of boxplotting can be used.
