### PR TITLE
add .head() and .tail() to Series

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -553,6 +553,16 @@ copy : boolean, default False
         else:
             return default
 
+    def head(self, n=5):
+        """Returns first n rows of Series
+        """
+        return self[:n]
+
+    def tail(self, n=5):
+        """Returns last n rows of Series
+        """
+        return self[-n:]
+
     #----------------------------------------------------------------------
     # Statistics, overridden ndarray methods
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1244,6 +1244,10 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         unstacked = s.unstack(0)
         assert_frame_equal(unstacked, expected)
 
+    def test_head_tail(self):
+        assert_frame_equal(self.series.head(), self.series[:5])
+        assert_frame_equal(self.series.tail(), self.series[-5:])
+
 #-------------------------------------------------------------------------------
 # TimeSeries-specific
 


### PR DESCRIPTION
These methods are convenient when working with DataFrame. For consistency and convenience, it would be nice to have them on Series as well.
