### PR TITLE
Fix graphics tests under Python 3

### DIFF
--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -64,7 +64,7 @@ class TestDataFramePlots(unittest.TestCase):
 
     def test_plot_bar(self):
         df = DataFrame(np.random.randn(6, 4),
-                       index=list(string.letters[:6]),
+                       index=list(string.ascii_letters[:6]),
                        columns=['one', 'two', 'three', 'four'])
 
         _check_plot_works(df.plot, kind='bar')
@@ -72,13 +72,13 @@ class TestDataFramePlots(unittest.TestCase):
         _check_plot_works(df.plot, kind='bar', subplots=True)
 
         df = DataFrame(np.random.randn(10, 15),
-                       index=list(string.letters[:10]),
+                       index=list(string.ascii_letters[:10]),
                        columns=range(15))
         _check_plot_works(df.plot, kind='bar')
 
     def test_boxplot(self):
         df = DataFrame(np.random.randn(6, 4),
-                       index=list(string.letters[:6]),
+                       index=list(string.ascii_letters[:6]),
                        columns=['one', 'two', 'three', 'four'])
         df['indic'] = ['foo', 'bar'] * 3
         df['indic2'] = ['foo', 'bar', 'foo'] * 2


### PR DESCRIPTION
A simple switch from `string.letters` to `string.ascii_letters`. The latter is present on Python 2 as well, so nothing clever is needed.
