### PR TITLE
Handle masked arrays in DataFrame constructor

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -20,6 +20,7 @@ import sys
 
 from numpy import nan
 import numpy as np
+import numpy.ma as ma
 
 from pandas.core.common import (isnull, notnull, PandasError, adjoin,
                                 _try_sort, _pfixed, _default_index,
@@ -186,6 +187,12 @@ class DataFrame(NDFrame):
                 mgr = mgr.astype(dtype)
         elif isinstance(data, dict):
             mgr = self._init_dict(data, index, columns, dtype=dtype)
+        elif isinstance(data, ma.MaskedArray):
+            mask = ma.getmaskarray(data)
+            datacopy = ma.copy(data)
+            datacopy[mask] = np.nan
+            mgr = self._init_ndarray(datacopy, index, columns, dtype=dtype,
+                                     copy=copy)
         elif isinstance(data, np.ndarray):
             if data.dtype.names:
                 data_columns, data = _rec_to_dict(data)


### PR DESCRIPTION
If passing a masked array to DataFrame constructor, my expectation was that the masked entries would end up as NAN's in the DataFrame.  This does not appear to be the case.  The commits in the pull request try toe address that.

as always, comments welcome.

thanks
