### PR TITLE
Change Series default float formatter.

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -417,7 +417,7 @@ copy : boolean, default False
         padSpace = min(maxlen, 60)
 
         if float_format is None:
-            float_format = str
+            float_format = common._float_format
 
         def _format(k, v):
             if isnull(v):


### PR DESCRIPTION
Series now uses _pandas.core.common._float_format()_ as default float formatter instead of _str()_.
_pandas.core.common._float_format()_ is also default float formatter for DataFrame.
