### PR TITLE
Minor fix for simpler indexing syntax in array of subplots.

### DIFF
--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -77,12 +77,12 @@ You can pass an ``ax`` argument to ``Series.plot`` to plot on a particular axis:
 .. ipython:: python
 
    fig, axes = plt.subplots(nrows=2, ncols=2, figsize=(8, 5))
-   df['A'].plot(ax=axes[0][0]); axes[0][0].set_title('A')
-   df['B'].plot(ax=axes[0][1]); axes[0][1].set_title('B')
-   df['C'].plot(ax=axes[1][0]); axes[1][0].set_title('C')
+   df['A'].plot(ax=axes[0,0]); axes[0,0].set_title('A')
+   df['B'].plot(ax=axes[0,1]); axes[0,1].set_title('B')
+   df['C'].plot(ax=axes[1,0]); axes[1,0].set_title('C')
 
    @savefig series_plot_multi.png width=4.5in
-   df['D'].plot(ax=axes[1][1]); axes[1][1].set_title('D')
+   df['D'].plot(ax=axes[1,1]); axes[1,1].set_title('D')
 
 Other plotting features
 -----------------------


### PR DESCRIPTION
`plt.subplots()` returns a numpy array, so it's OK to use the more compact/familiar/efficient `a[i,j]` indexing syntax instead of `a[i][j]`.
