### PR TITLE
various HDFStore fixes regarding tables

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -308,18 +308,22 @@ class HDFStore(object):
         root = self.handle.root
         if key not in root._v_children:
             group = self.handle.createGroup(root, key)
+            created = True
         else:
             group = getattr(root, key)
-
+            created = False
+            
         kind = _TYPE_MAP[type(value)]
+        if append:
+            if not (_is_table_type(group) or created):
+                raise ValueError('Can only append to Tables')
+                
         if table or (append and _is_table_type(group)):
             kind = '%s_table' % kind
             handler = self._get_handler(op='write', kind=kind)
             wrapper = lambda value: handler(group, value, append=append,
                                             comp=comp, itemsize=itemsize)
         else:
-            if append:
-                raise ValueError('Can only append to Tables')
             if comp:
                 raise ValueError('Compression only supported on Tables')
 


### PR DESCRIPTION
commit d1f439c: added optional keyword argument 'itemsize' to HDFStore.put and HDFStore.append to control string length; default 255

it sets the string length of strings in the index and columns for the table (rather than the previous behavior, which was to take the max string length from the longest index/column string in the dataset that is used to create the table). Default is 255.

commit 2b13848: nicer error message for store.put('ccc', DataFrame(['hi'], ['a'], ['col']), table=True); also fixes a bug in d1f439

commit 2bce685: before this commit, the following would discard column1:
store.put('eee', DataFrame([0], ['a'], ['column1'])); store.append('eee', DataFrame([1], ['a'], ['column2'])); store['eee']
even with this commit, strings such as column names which are longer than "itemsize" and which are .appended in the future will be silently truncated. I recommend that a warning be raised when this happens, but i didn't add that myself because i couldn't easily find the place where the truncation occurs, or how to extract the current string length.

i'm having trouble building so i won't be able to try writing unit tests. however, here are tests for these commits:

from pandas import *; store = HDFStore('test.h5')

store.put('ccc', DataFrame(['hi'], ['a'], ['col']), table=True); 
 # should raise "TypeError: At this time, Pandas HDFStore tables only support floating point values."

store.put('fff', DataFrame(['0'], ['a'], ['column1'])); store.append('fff', DataFrame([1], ['a'], ['column2'])); 
 # should raise "ValueError: Can only append to Tables"

store.put('fff', DataFrame([0], ['a'], ['column1']), table=True); store.append('fff', DataFrame([1], ['a'], ['column2'])); store['fff']
 # should yield
 #    column1  column2
 # a  0        1  
 #   (this was true even before the present commits)

store.append('j', DataFrame([0], ['a'], ['column1'])); store.append('j', DataFrame([1], ['a'], ['column2'])); store['j'] 
 # should yield:
 #    column1  column2
 # a  0        1  
 #   (this was true even before the present commits)
