### PR TITLE
Autodep

### DIFF
--- a/pandas/core/datetools.py
+++ b/pandas/core/datetools.py
@@ -15,6 +15,7 @@ try:
                         'install version 1.5!')
 except ImportError: # pragma: no cover
     print 'Please install python-dateutil via easy_install or some method!'
+    raise # otherwise a 2nd import won't show the message
 
 import calendar
 

--- a/requirments.txt
+++ b/requirments.txt
@@ -1,4 +1,0 @@
-# so python-dateutil2 is for py3!
-python-dateutil < 2  
-numpy
-

--- a/requirments.txt
+++ b/requirments.txt
@@ -1,0 +1,4 @@
+# so python-dateutil2 is for py3!
+python-dateutil < 2  
+numpy
+

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,13 @@ if sys.version_info[0] >= 3:
     except ImportError:
         raise ImportError('require setuptools/distribute for Py3k')
     setuptools_args = {'use_2to3': True,
-                       'zip_safe': False,}
+                       'zip_safe': False,
+                       'install_requires': ['python-dateutil > 2','numpy'],
+                        }
 else:
-    setuptools_args = {}
-
+    setuptools_args = {
+        'install_requires': ['python-dateutil < 2','numpy'],
+    }
 
 import numpy as np
 


### PR DESCRIPTION
still need numpy for setup, but at least we get the right version of `python-dateutil`
