### PR TITLE
adding DataFrame.reorder_levels()

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1795,6 +1795,32 @@ class DataFrame(NDFrame):
             result.columns = result.columns.swaplevel(i, j)
         return result
 
+    def reorder_levels(self, order, axis=0):
+        """
+        Rearrange index levels using input order.
+        May not drop or duplicate levels
+
+        Parameters
+        ----------
+        order: list of int representing new level order.
+               (reference level by number not by key)
+        axis: where to reorder levels
+
+        Returns
+        -------
+        type of caller (new object)
+        """
+        if not isinstance(self._get_axis(axis), MultiIndex):
+            raise Exception('Can only reorder levels on a hierarchical axis.')
+
+        result = self.copy()
+
+        if axis == 0:
+            result.index = result.index.reorder_levels(order)
+        else:
+            result.columns = result.columns.reorder_levels(order)
+        return result
+
     #----------------------------------------------------------------------
     # Filling NA's
 


### PR DESCRIPTION
Convenience method to reorder the levels of a DataFrame hierarchical axis.
It uses `MultiIndex.reorder_levels()`. Neither of them can work with levels referenced by key, in contrast to _swaplevel()_ method.
