### PR TITLE
Use new GlobalPrintConfig also when setting engineering float formatter.

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -505,15 +505,15 @@ def set_eng_float_format(precision=None, accuracy=3, use_eng_prefix=False):
                       "being renamed to 'accuracy'" , FutureWarning)
         accuracy = precision
 
-    global _float_format, _column_space
-    _float_format = EngFormatter(accuracy, use_eng_prefix)
-    _column_space = max(12, accuracy + 9)
+    global GlobalPrintConfig
+    GlobalPrintConfig.float_format = EngFormatter(accuracy, use_eng_prefix)
+    GlobalPrintConfig.column_space = max(12, accuracy + 9)
 
-_float_format = None
-_column_space = 12
-_precision = 4
-_max_rows = 500
-_max_columns = 0
+#_float_format = None
+#_column_space = 12
+#_precision = 4
+#_max_rows = 500
+#_max_columns = 0
 
 def _stringify(col):
     # unicode workaround


### PR DESCRIPTION
Before, the following global variables in pandas.core.common were used to store print options:
- _float_format
- _column_space
- _precision
- _max_rows
- _max_columns

Now these are stored in pandas.core.common.GlobalPrintConfig, when setting the engineering float formatter it should alter GlobalPrintConfig and not the above variables (which i commented out by the way sine i think they are no longer used). Otherwise it has no effect.
