### PR TITLE
DOC: added a note for behavior of append

### DIFF
--- a/doc/source/merging.rst
+++ b/doc/source/merging.rst
@@ -163,6 +163,12 @@ need to be:
    df2
    df1.append(df2)
 
+.. note::
+
+   Unlike `list.append` method, which appends to the original list and
+   returns nothing, ``append`` here **does not** modify ``df1`` and
+   returns its copy with ``df2`` appended.
+
 .. _merging.ignore_index:
 
 Ignoring indexes on the concatenation axis


### PR DESCRIPTION
it took me some time to realize what is happening since my python-oriented mind was expecting operation in-place on the original dataframe like Python does on lists...  imho it is worth a note in documentation.  unfortunately blunt attempt to build docs failed, so I don't know if it builds nicely, and may be utilizes intersphinx to point to list.append doc.  Here is what I get upon make.py:

```
$> cd doc 
build/  data/  make.py*  plots/  source/  sphinxext/
3 41392.....................................:Wed 11 Jan 2012 01:23:38 PM EST:.
(git)novo:~exppsy/pandas[enh/doc-append]doc
$> ./make.py 
Running Sphinx v1.0.8
Exception occurred while building, starting debugger:
Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.7/sphinx/cmdline.py", line 187, in main
    warningiserror, tags)
  File "/usr/lib/pymodules/python2.7/sphinx/application.py", line 116, in __init__
    self.setup_extension(extension)
  File "/usr/lib/pymodules/python2.7/sphinx/application.py", line 253, in setup_extension
    err)
ExtensionError: Could not import extension ipython_directive (exception: cannot import name Config)
> /usr/lib/pymodules/python2.7/sphinx/application.py(253)setup_extension()
-> err)
(Pdb) 

```

quick grepping didn't help in my attempt to find how to build docs correctly (I think I recall some discussion on the list a while ago but don't remember details now), and 

```
$> python setup.py build_sphinx
setup.py:26: UserWarning: Module paste was already imported from None, but /usr/lib/python2.7/dist-packages is being added to sys.path
  import pkg_resources
running build_sphinx
creating build/sphinx
creating build/sphinx/doctrees
creating build/sphinx/html
Running Sphinx v1.0.8
Traceback (most recent call last):
  File "setup.py", line 402, in <module>
    **setuptools_kwargs)
  File "/usr/lib/python2.7/distutils/core.py", line 152, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/usr/lib/pymodules/python2.7/sphinx/setup_command.py", line 136, in run
    freshenv=self.fresh_env)
  File "/usr/lib/pymodules/python2.7/sphinx/application.py", line 116, in __init__
    self.setup_extension(extension)
  File "/usr/lib/pymodules/python2.7/sphinx/application.py", line 253, in setup_extension
    err)
sphinx.errors.ExtensionError: Could not import extension ipython_directive (exception: cannot import name Config)
```

gives the same result
