### PR TITLE
Make _get_terminal_size_linux() work inside Emacs

### DIFF
--- a/pandas/util/terminal.py
+++ b/pandas/util/terminal.py
@@ -93,9 +93,10 @@ def _get_terminal_size_linux():
             os.close(fd)
         except:
             pass
-    if not cr:
+    if not cr or cr == (0, 0):
         try:
-            cr = (env['LINES'], env['COLUMNS'])
+           from os import environ as env
+           cr = (env['LINES'], env['COLUMNS'])
         except:
             return None
     return int(cr[1]), int(cr[0])


### PR DESCRIPTION
I'm using ipython inside Emacs. Detection of the console width and height is not working with the current implementation. ioctl seems to return (0,0). Therefore, performing an explicit check for cr == (0,0) (in addition to the check for not cr) before falling back to environment variables is a quick fix that I think shouldn't make any negative impact on non-emacs users.
I've also added the import of os.environ line since env previously wasn't defined.
