### PR TITLE
BUG: week as top-level iterator overwrites week instance

### DIFF
--- a/pandas/core/datetools.py
+++ b/pandas/core/datetools.py
@@ -707,9 +707,9 @@ _offsetMap = {
 
 
 for i, weekday in enumerate(['MON', 'TUE', 'WED', 'THU', 'FRI']):
-    for week in xrange(4):
-        _offsetMap['WOM@%d%s' % (week + 1, weekday)] = \
-            WeekOfMonth(week=week, weekday=i)
+    for iweek in xrange(4):
+        _offsetMap['WOM@%d%s' % (iweek + 1, weekday)] = \
+            WeekOfMonth(week=iweek, weekday=i)
 
 _offsetNames = dict([(v, k) for k, v in _offsetMap.iteritems()])
 


### PR DESCRIPTION
week is defined above as week = Week(). Using it as the iterator here was overwriting this.
