### PR TITLE
BUG: resolve left/right key names overlap in merge

### DIFF
--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -177,6 +177,14 @@ class TestMerge(unittest.TestCase):
         self.assert_('key1.foo' in joined)
         self.assert_('key1.bar' in joined)
 
+    def test_handle_overlap_arbitrary_key(self):
+        joined = merge(self.df, self.df2,
+                       left_on='key2', right_on='key1',
+                       suffixes=['.foo', '.bar'])
+
+        self.assert_('key1.foo' in joined)
+        self.assert_('key2.bar' in joined)
+
     def test_merge_common(self):
         joined = merge(self.df, self.df2)
         exp = merge(self.df, self.df2, on=['key1', 'key2'])


### PR DESCRIPTION
Here is an attempt at fully resolving name conflict in merges when `left_on` or `right_on` keys are passed explicitly.

I am not sure my fix is correct but I include a new non-regression test to highlight the issue and the resolution does not introduce any regression findable by running `nosetests`.
