### PR TITLE
Fixes for tests on Python 3

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1,7 +1,11 @@
 """
 Misc tools for implementing data structures
 """
-import cPickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
 try:
     from io import BytesIO
 except ImportError:  # pragma: no cover
@@ -16,6 +20,7 @@ import decimal
 import math
 
 import pandas._tseries as lib
+from pandas.util import py3compat
 
 # XXX: HACK for NumPy 1.5.1 to suppress warnings
 try:
@@ -788,7 +793,7 @@ def save(obj, path):
     """
     f = open(path, 'wb')
     try:
-        cPickle.dump(obj, f, protocol=cPickle.HIGHEST_PROTOCOL)
+        pickle.dump(obj, f, protocol=pickle.HIGHEST_PROTOCOL)
     finally:
         f.close()
 
@@ -809,13 +814,13 @@ def load(path):
     """
     f = open(path, 'rb')
     try:
-        return cPickle.load(f)
+        return pickle.load(f)
     finally:
         f.close()
 
 
 def console_encode(value):
-    if not isinstance(value, unicode):
+    if py3compat.PY3 or not isinstance(value, unicode):
         return value
 
     try:

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -24,6 +24,7 @@ from pandas.util.testing import (assert_almost_equal,
                                  assert_frame_equal)
 
 import pandas.util.testing as tm
+from pandas.util import py3compat
 import pandas._tseries as lib
 
 #-------------------------------------------------------------------------------
@@ -1844,7 +1845,10 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
     def test_to_string_with_formatters_unicode(self):
         df = DataFrame({u'c/\u03c3':[1,2,3]})
         result = df.to_string(formatters={u'c/\u03c3': lambda x: '%s' % x})
-        assert(result in ('  c/\xcf\x83\n0 1   \n1 2   \n2 3   ',
+        if py3compat.PY3:
+            self.assertEqual(result, u'  c/\u03c3\n0 1  \n1 2  \n2 3  ')
+        else:
+            assert(result in ('  c/\xcf\x83\n0 1   \n1 2   \n2 3   ',
                           '  c/?\n0 1   \n1 2   \n2 3   ' ))
 
     def test_head_tail(self):


### PR DESCRIPTION
This fixes up the unicode situation on Python 3.
