### PR TITLE
Py3 unicode fixes 2

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -854,6 +854,8 @@ class UnicodeReader:
     """
     A CSV reader which will iterate over lines in the CSV file "f",
     which is encoded in the given encoding.
+    
+    On Python 3, this is replaced (below) by csv.reader, which handles unicode.
     """
 
     def __init__(self, f, dialect=csv.excel, encoding="utf-8", **kwds):
@@ -866,4 +868,7 @@ class UnicodeReader:
 
     def __iter__(self):
         return self
+
+if py3compat.PY3:
+    UnicodeReader = csv.reader
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1870,7 +1870,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         print >>buf, nonempty
 
         # this should work
-        ''.join(buf.buflist)
+        buf.getvalue()
 
     def test_unicode_problem_decoding_as_ascii(self):
         dm = DataFrame({u'c/\u03c3': Series({'test':np.NaN})})


### PR DESCRIPTION
The code to let Python 2 use Unicode for CSV had broken reading CSV for Python 3. This simply makes it use the standard `csv.reader` in Python 3, which is unicode aware.
