### PR TITLE
Excel writing

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -976,7 +976,7 @@ class DataFrame(NDFrame):
         need_save = False
         if isinstance(excel_writer, str):
             excel_writer = ExcelWriter(excel_writer)
-            needSave = True
+            need_save = True
         excel_writer.cur_sheet = sheet_name
         self._helper_csvexcel(excel_writer, na_rep=na_rep, cols=cols, header=header,
                               index=index, index_label=index_label, encoding=None)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -971,6 +971,16 @@ class DataFrame(NDFrame):
             Column label for index column(s) if desired. If None is given, and
             `header` and `index` are True, then the index names are used. A
             sequence should be given if the DataFrame uses MultiIndex.
+        
+        Notes
+        -----
+        If passing an existing ExcelWriter object, then the sheet will be added
+        to the existing workbook.  This can be used to save different DataFrames
+        to one workbook
+        >>> writer = ExcelWriter('output.xlsx')
+        >>> df1.to_excel(writer,'sheet1')
+        >>> df2.to_excel(writer,'sheet2')
+        >>> writer.save()
         """
         from pandas.io.parsers import ExcelWriter
         need_save = False

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -950,7 +950,7 @@ class DataFrame(NDFrame):
                          index=index, index_label=index_label, encoding=encoding)
         f.close()
 
-    def to_excel(self, excel_writer, sheet_name, na_rep='', cols=None, header=True,
+    def to_excel(self, excel_writer, sheet_name = 'sheet1', na_rep='', cols=None, header=True,
                  index=True, index_label=None):
         """
         Write DataFrame to a excel sheet 
@@ -959,6 +959,8 @@ class DataFrame(NDFrame):
         ----------
         excel_writer : string or ExcelWriter object
             File path or existing ExcelWriter 
+        sheet_name : string, default 'sheet1'
+            Name of sheet which will contain DataFrame
         na_rep : string, default ''
             Missing data rep'n
         cols : sequence, optional

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -973,14 +973,14 @@ class DataFrame(NDFrame):
             sequence should be given if the DataFrame uses MultiIndex.
         """
         from pandas.io.parsers import ExcelWriter
-        needSave = False
+        need_save = False
         if isinstance(excel_writer, str):
             excel_writer = ExcelWriter(excel_writer)
             needSave = True
         excel_writer.cur_sheet = sheet_name
         self._helper_csvexcel(excel_writer, na_rep=na_rep, cols=cols, header=header,
                               index=index, index_label=index_label, encoding=None)
-        if needSave:
+        if need_save:
             excel_writer.save()
 
     @Appender(docstring_to_string, indents=1)

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -441,6 +441,24 @@ class Panel(NDFrame):
                            default_kind=kind,
                            default_fill_value=fill_value)
 
+    def to_excel(self, path, na_rep=''):
+        """
+        Write each DataFrame in Panel to a separate excel sheet 
+
+        Parameters
+        ----------
+        excel_writer : string or ExcelWriter object
+            File path or existing ExcelWriter 
+        na_rep : string, default ''
+            Missing data rep'n
+        """
+        from pandas.io.parsers import ExcelWriter
+        writer = ExcelWriter(path)
+        for item, df in self.iteritems():
+            name = str(item)
+            df.to_excel(writer, name, na_rep=na_rep)
+        writer.save()
+
     # TODO: needed?
     def keys(self):
         return list(self.items)

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -642,9 +642,6 @@ class ExcelWriter(object):
         self.fm_datetime = xlwt.easyxf(num_format_str='YYYY-MM-DD HH:MM:SS')
         self.fm_date = xlwt.easyxf(num_format_str='YYYY-MM-DD')
 
-    def __repr__(self):
-        return object.__repr__(self)
-
     def save(self):
         """
         Save workbook to disk

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -676,6 +676,8 @@ class ExcelWriter(object):
                     sheetrow.write(i,val,self.fm_datetime)
                 else:
                     sheetrow.write(i,val,self.fm_date)
+            elif isinstance(val, np.int64):
+                sheetrow.write(i,int(val))
             else:
                 sheetrow.write(i,val)
         row_idx += 1

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -3,6 +3,7 @@ Module contains tools for processing files into DataFrames or other objects
 """
 from StringIO import StringIO
 import re
+from itertools import izip
 
 import numpy as np
 
@@ -469,7 +470,7 @@ class TextParser(object):
         if len(self.columns) != len(zipped_content):
             raise Exception('wrong number of columns')
 
-        data = dict((k, v) for k, v in zip(self.columns, zipped_content))
+        data = dict((k, v) for k, v in izip(self.columns, zipped_content))
 
         # apply converters
         for col, f in self.converters.iteritems():
@@ -601,7 +602,7 @@ class ExcelFile(object):
         data = []
         for i in range(sheet.nrows):
             row = []
-            for value, typ in zip(sheet.row_values(i), sheet.row_types(i)):
+            for value, typ in izip(sheet.row_values(i), sheet.row_types(i)):
                 if typ == XL_CELL_DATE:
                     dt = xldate_as_tuple(value, datemode)
                     # how to produce this first case?

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -590,7 +590,7 @@ class ExcelFile(object):
             Row to use for the column labels of the parsed DataFrame
         skiprows : list-like
             Row numbers to skip (0-indexed)
-        index_col : int, default 0
+        index_col : int, default None
             Column to use as the row labels of the DataFrame. Pass None if there
             is no such column
         na_values : list-like, default None
@@ -659,8 +659,8 @@ class ExcelFile(object):
 
 class ExcelWriter(object):
     """
-    Class for writing DataFrame objects into excel sheets, uses xlwt. See
-    ExcelWriter.write for more documentation
+    Class for writing DataFrame objects into excel sheets, uses xlwt for xls, 
+    openpyxl for xlsx.  See DataFrame.to_excel for typical usage.
 
     Parameters
     ----------

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from pandas.core.index import Index, MultiIndex
 from pandas.core.frame import DataFrame
+import datetime
 import pandas.core.common as com
 import pandas._tseries as lib
 
@@ -621,3 +622,67 @@ class ExcelFile(object):
                             chunksize=chunksize)
 
         return parser.get_chunk()
+
+class ExcelWriter(object):
+    """
+    Class for writing DataFrame objects into excel sheets, uses xlwt. See
+    ExcelWriter.write for more documentation
+
+    Parameters
+    ----------
+    path : string
+        Path to xls file
+    """
+    def __init__(self, path):
+        import xlwt
+        self.path = path
+        self.book = xlwt.Workbook()
+        self.sheets = {}
+        self.cur_sheet = None
+        self.fm_datetime = xlwt.easyxf(num_format_str='YYYY-MM-DD HH:MM:SS')
+        self.fm_date = xlwt.easyxf(num_format_str='YYYY-MM-DD')
+
+    def __repr__(self):
+        return object.__repr__(self)
+
+    def save(self):
+        """
+        Save workbook to disk
+        """
+        self.book.save(self.path)
+
+
+    def writerow(self, row, sheet_name=None):
+        """
+        Write the given row into Excel an excel sheet
+
+        Parameters
+        ----------
+        row : list
+            Row of data to save to Excel sheet 
+        sheet_name : string, default None
+            Name of Excel sheet, if None, then use self.cur_sheet
+        """
+        if sheet_name is None:
+            sheet_name = self.cur_sheet
+        if sheet_name is None:
+            raise Exception('Must pass explicit sheet_name or set cur_sheet property')
+        if sheet_name in self.sheets:
+            sheet, row_idx = self.sheets[sheet_name]
+        else:
+            sheet = self.book.add_sheet(sheet_name)
+            row_idx = 0
+        sheetrow = sheet.row(row_idx) 
+        for i, val in enumerate(row):
+            if isinstance(val, (datetime.datetime, datetime.date)):
+                if isinstance(val, datetime.datetime):
+                    sheetrow.write(i,val,self.fm_datetime)
+                else:
+                    sheetrow.write(i,val,self.fm_date)
+            else:
+                sheetrow.write(i,val)
+        row_idx += 1
+        if row_idx == 1000:
+            sheet.flush_row_data()
+        self.sheets[sheet_name] = (sheet, row_idx)
+

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -563,9 +563,15 @@ class ExcelFile(object):
         Path to xls file
     """
     def __init__(self, path):
-        import xlrd
+        self.use_xlsx = True
+        if path.endswith('.xls'):
+            self.use_xlsx = False
+            import xlrd
+            self.book = xlrd.open_workbook(path)
+        else:
+            from openpyxl import load_workbook
+            self.book = load_workbook(path, use_iterators=True)
         self.path = path
-        self.book = xlrd.open_workbook(path)
 
     def __repr__(self):
         return object.__repr__(self)
@@ -594,6 +600,34 @@ class ExcelFile(object):
         -------
         parsed : DataFrame
         """
+        if self.use_xlsx:
+            return self._parse_xlsx(sheetname, header=header, skiprows=skiprows, index_col=index_col,
+              parse_dates=parse_dates, date_parser=date_parser, na_values=na_values,
+              chunksize=chunksize)
+        else:
+            return self._parse_xls(sheetname, header=header, skiprows=skiprows, index_col=index_col,
+              parse_dates=parse_dates, date_parser=date_parser, na_values=na_values,
+              chunksize=chunksize)
+
+    def _parse_xlsx(self, sheetname, header=0, skiprows=None, index_col=None,
+              parse_dates=False, date_parser=None, na_values=None,
+              chunksize=None):
+        sheet = self.book.get_sheet_by_name(name=sheetname)
+        data = []
+        for row in sheet.iter_rows(): # it brings a new method: iter_rows()
+            data.append([cell.internal_value for cell in row])
+        parser = TextParser(data, header=header, index_col=index_col,
+                            na_values=na_values,
+                            parse_dates=parse_dates,
+                            date_parser=date_parser,
+                            skiprows=skiprows,
+                            chunksize=chunksize)
+
+        return parser.get_chunk()
+        
+    def _parse_xls(self, sheetname, header=0, skiprows=None, index_col=None,
+              parse_dates=False, date_parser=None, na_values=None,
+              chunksize=None):
         from datetime import MINYEAR, time, datetime
         from xlrd import xldate_as_tuple, XL_CELL_DATE
 
@@ -634,20 +668,25 @@ class ExcelWriter(object):
         Path to xls file
     """
     def __init__(self, path):
-        import xlwt
+        self.use_xlsx = True
+        if path.endswith('.xls'):
+            self.use_xlsx = False
+            import xlwt
+            self.book = xlwt.Workbook()
+            self.fm_datetime = xlwt.easyxf(num_format_str='YYYY-MM-DD HH:MM:SS')
+            self.fm_date = xlwt.easyxf(num_format_str='YYYY-MM-DD')
+        else:
+            from openpyxl import Workbook
+            self.book = Workbook(optimized_write = True)
         self.path = path
-        self.book = xlwt.Workbook()
         self.sheets = {}
         self.cur_sheet = None
-        self.fm_datetime = xlwt.easyxf(num_format_str='YYYY-MM-DD HH:MM:SS')
-        self.fm_date = xlwt.easyxf(num_format_str='YYYY-MM-DD')
 
     def save(self):
         """
         Save workbook to disk
         """
         self.book.save(self.path)
-
 
     def writerow(self, row, sheet_name=None):
         """
@@ -664,6 +703,12 @@ class ExcelWriter(object):
             sheet_name = self.cur_sheet
         if sheet_name is None:
             raise Exception('Must pass explicit sheet_name or set cur_sheet property')
+        if self.use_xlsx:
+            self._writerow_xlsx(row, sheet_name)
+        else:
+            self._writerow_xls(row, sheet_name)
+
+    def _writerow_xls(self, row, sheet_name):
         if sheet_name in self.sheets:
             sheet, row_idx = self.sheets[sheet_name]
         else:
@@ -685,3 +730,14 @@ class ExcelWriter(object):
             sheet.flush_row_data()
         self.sheets[sheet_name] = (sheet, row_idx)
 
+    def _writerow_xlsx(self, row, sheet_name):
+        if sheet_name in self.sheets:
+            sheet, row_idx = self.sheets[sheet_name]
+        else:
+            sheet = self.book.create_sheet()
+            sheet.title = sheet_name
+            row_idx = 0
+
+        sheet.append([int(val) if isinstance(val, np.int64) else val for val in row])
+        row_idx += 1
+        self.sheets[sheet_name] = (sheet, row_idx)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2512,6 +2512,13 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         recons = reader.parse('test1',index_col=0)
         assert_frame_equal(self.tsframe, recons)
 
+        #Test np.int64
+        frame = DataFrame(np.random.randn(10,2))
+        frame.to_excel(path,'test1')
+        reader = ExcelFile(path)
+        recons = reader.parse('test1',index_col=0)
+        assert_frame_equal(frame, recons)
+
         # Test writing to separate sheets
         writer = ExcelWriter(path)
         self.frame.to_excel(writer,'test1')

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2532,6 +2532,51 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
         os.remove(path)
 
+    def test_to_excel_multiindex(self):
+        path = '__tmp__.xls'
+
+        frame = self.frame
+        old_index = frame.index
+        arrays = np.arange(len(old_index)*2).reshape(2,-1)
+        new_index = MultiIndex.from_arrays(arrays, names=['first', 'second'])
+        frame.index = new_index
+        frame.to_excel(path, 'test1', header=False)
+        frame.to_excel(path, 'test1', cols=['A', 'B'])
+
+        # round trip
+        frame.to_excel(path, 'test1')
+        reader = ExcelFile(path)
+        df = reader.parse('test1', index_col=[0,1], parse_dates=False)
+        assert_frame_equal(frame, df)
+        self.assertEqual(frame.index.names, df.index.names)
+        self.frame.index = old_index # needed if setUP becomes a classmethod
+
+        # try multiindex with dates
+        tsframe = self.tsframe
+        old_index = tsframe.index
+        new_index = [old_index, np.arange(len(old_index))]
+        tsframe.index = MultiIndex.from_arrays(new_index)
+
+        tsframe.to_excel(path, 'test1', index_label = ['time','foo'])
+        reader = ExcelFile(path)
+        recons = reader.parse('test1', index_col=[0,1])
+        assert_frame_equal(tsframe, recons)
+
+        # do not load index
+        tsframe.to_excel(path, 'test1')
+        reader = ExcelFile(path)
+        recons = reader.parse('test1', index_col=None)
+        np.testing.assert_equal(len(recons.columns), len(tsframe.columns) + 2)
+
+        # no index
+        tsframe.to_excel(path, 'test1', index=False)
+        reader = ExcelFile(path)
+        recons = reader.parse('test1', index_col=None)
+        assert_almost_equal(recons.values, self.tsframe.values)
+        self.tsframe.index = old_index # needed if setUP becomes classmethod
+
+        os.remove(path)
+
     def test_to_excel2007_from_excel2007(self):
         path = '__tmp__.xlsx'
 
@@ -2570,6 +2615,51 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         assert_frame_equal(self.frame, recons)
         recons = reader.parse('test2',index_col=0)
         assert_frame_equal(self.tsframe, recons)
+
+        os.remove(path)
+
+    def test_to_excel2007_multiindex(self):
+        path = '__tmp__.xlsx'
+
+        frame = self.frame
+        old_index = frame.index
+        arrays = np.arange(len(old_index)*2).reshape(2,-1)
+        new_index = MultiIndex.from_arrays(arrays, names=['first', 'second'])
+        frame.index = new_index
+        frame.to_excel(path, 'test1', header=False)
+        frame.to_excel(path, 'test1', cols=['A', 'B'])
+
+        # round trip
+        frame.to_excel(path, 'test1')
+        reader = ExcelFile(path)
+        df = reader.parse('test1', index_col=[0,1], parse_dates=False)
+        assert_frame_equal(frame, df)
+        self.assertEqual(frame.index.names, df.index.names)
+        self.frame.index = old_index # needed if setUP becomes a classmethod
+
+        # try multiindex with dates
+        tsframe = self.tsframe
+        old_index = tsframe.index
+        new_index = [old_index, np.arange(len(old_index))]
+        tsframe.index = MultiIndex.from_arrays(new_index)
+
+        tsframe.to_excel(path, 'test1', index_label = ['time','foo'])
+        reader = ExcelFile(path)
+        recons = reader.parse('test1', index_col=[0,1])
+        assert_frame_equal(tsframe, recons)
+
+        # do not load index
+        tsframe.to_excel(path, 'test1')
+        reader = ExcelFile(path)
+        recons = reader.parse('test1', index_col=None)
+        np.testing.assert_equal(len(recons.columns), len(tsframe.columns) + 2)
+
+        # no index
+        tsframe.to_excel(path, 'test1', index=False)
+        reader = ExcelFile(path)
+        recons = reader.parse('test1', index_col=None)
+        assert_almost_equal(recons.values, self.tsframe.values)
+        self.tsframe.index = old_index # needed if setUP becomes classmethod
 
         os.remove(path)
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2492,218 +2492,113 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         os.remove(path)
 
     def test_to_excel_from_excel(self):
-        path = '__tmp__.xls'
+        for ext in ['xls', 'xlsx']:
+            path = '__tmp__.' + ext
 
-        self.frame['A'][:5] = nan
+            self.frame['A'][:5] = nan
 
-        self.frame.to_excel(path,'test1')
-        self.frame.to_excel(path,'test1', cols=['A', 'B'])
-        self.frame.to_excel(path,'test1', header=False)
-        self.frame.to_excel(path,'test1', index=False)
+            self.frame.to_excel(path,'test1')
+            self.frame.to_excel(path,'test1', cols=['A', 'B'])
+            self.frame.to_excel(path,'test1', header=False)
+            self.frame.to_excel(path,'test1', index=False)
 
-        # test roundtrip
-        self.frame.to_excel(path,'test1')
-        reader = ExcelFile(path)
-        recons = reader.parse('test1',index_col=0)
-        assert_frame_equal(self.frame, recons)
-        
-        self.frame.to_excel(path,'test1', index=False)
-        reader = ExcelFile(path)
-        recons = reader.parse('test1',index_col=None)
-        recons.index = self.frame.index
-        assert_frame_equal(self.frame, recons)
+            # test roundtrip
+            self.frame.to_excel(path,'test1')
+            reader = ExcelFile(path)
+            recons = reader.parse('test1',index_col=0)
+            assert_frame_equal(self.frame, recons)
+            
+            self.frame.to_excel(path,'test1', index=False)
+            reader = ExcelFile(path)
+            recons = reader.parse('test1',index_col=None)
+            recons.index = self.frame.index
+            assert_frame_equal(self.frame, recons)
 
-        self.frame.to_excel(path,'test1')
-        reader = ExcelFile(path)
-        recons = reader.parse('test1',index_col=0,skiprows=[1])
-        assert_frame_equal(self.frame.ix[1:], recons)
+            self.frame.to_excel(path,'test1')
+            reader = ExcelFile(path)
+            recons = reader.parse('test1',index_col=0,skiprows=[1])
+            assert_frame_equal(self.frame.ix[1:], recons)
 
-        self.frame.to_excel(path,'test1',na_rep='NA')
-        reader = ExcelFile(path)
-        recons = reader.parse('test1',index_col=0,na_values=['NA'])
-        assert_frame_equal(self.frame, recons)
-        
-        self.mixed_frame.to_excel(path,'test1')
-        reader = ExcelFile(path)
-        recons = reader.parse('test1',index_col=0)
-        assert_frame_equal(self.mixed_frame, recons)
+            self.frame.to_excel(path,'test1',na_rep='NA')
+            reader = ExcelFile(path)
+            recons = reader.parse('test1',index_col=0,na_values=['NA'])
+            assert_frame_equal(self.frame, recons)
+            
+            self.mixed_frame.to_excel(path,'test1')
+            reader = ExcelFile(path)
+            recons = reader.parse('test1',index_col=0)
+            assert_frame_equal(self.mixed_frame, recons)
 
-        self.tsframe.to_excel(path,'test1')
-        reader = ExcelFile(path)
-        recons = reader.parse('test1',index_col=0)
-        assert_frame_equal(self.tsframe, recons)
+            self.tsframe.to_excel(path,'test1')
+            reader = ExcelFile(path)
+            recons = reader.parse('test1',index_col=0)
+            assert_frame_equal(self.tsframe, recons)
 
-        #Test np.int64
-        frame = DataFrame(np.random.randn(10,2))
-        frame.to_excel(path,'test1')
-        reader = ExcelFile(path)
-        recons = reader.parse('test1',index_col=0)
-        assert_frame_equal(frame, recons)
+            #Test np.int64
+            frame = DataFrame(np.random.randn(10,2))
+            frame.to_excel(path,'test1')
+            reader = ExcelFile(path)
+            recons = reader.parse('test1',index_col=0)
+            assert_frame_equal(frame, recons)
 
-        # Test writing to separate sheets
-        writer = ExcelWriter(path)
-        self.frame.to_excel(writer,'test1')
-        self.tsframe.to_excel(writer,'test2')
-        writer.save()
-        reader = ExcelFile(path)
-        recons = reader.parse('test1',index_col=0)
-        assert_frame_equal(self.frame, recons)
-        recons = reader.parse('test2',index_col=0)
-        assert_frame_equal(self.tsframe, recons)
+            # Test writing to separate sheets
+            writer = ExcelWriter(path)
+            self.frame.to_excel(writer,'test1')
+            self.tsframe.to_excel(writer,'test2')
+            writer.save()
+            reader = ExcelFile(path)
+            recons = reader.parse('test1',index_col=0)
+            assert_frame_equal(self.frame, recons)
+            recons = reader.parse('test2',index_col=0)
+            assert_frame_equal(self.tsframe, recons)
 
-        os.remove(path)
+            os.remove(path)
 
     def test_to_excel_multiindex(self):
-        path = '__tmp__.xls'
+        for ext in ['xls', 'xlsx']:
+            path = '__tmp__.' + ext
 
-        frame = self.frame
-        old_index = frame.index
-        arrays = np.arange(len(old_index)*2).reshape(2,-1)
-        new_index = MultiIndex.from_arrays(arrays, names=['first', 'second'])
-        frame.index = new_index
-        frame.to_excel(path, 'test1', header=False)
-        frame.to_excel(path, 'test1', cols=['A', 'B'])
+            frame = self.frame
+            old_index = frame.index
+            arrays = np.arange(len(old_index)*2).reshape(2,-1)
+            new_index = MultiIndex.from_arrays(arrays, names=['first', 'second'])
+            frame.index = new_index
+            frame.to_excel(path, 'test1', header=False)
+            frame.to_excel(path, 'test1', cols=['A', 'B'])
 
-        # round trip
-        frame.to_excel(path, 'test1')
-        reader = ExcelFile(path)
-        df = reader.parse('test1', index_col=[0,1], parse_dates=False)
-        assert_frame_equal(frame, df)
-        self.assertEqual(frame.index.names, df.index.names)
-        self.frame.index = old_index # needed if setUP becomes a classmethod
+            # round trip
+            frame.to_excel(path, 'test1')
+            reader = ExcelFile(path)
+            df = reader.parse('test1', index_col=[0,1], parse_dates=False)
+            assert_frame_equal(frame, df)
+            self.assertEqual(frame.index.names, df.index.names)
+            self.frame.index = old_index # needed if setUP becomes a classmethod
 
-        # try multiindex with dates
-        tsframe = self.tsframe
-        old_index = tsframe.index
-        new_index = [old_index, np.arange(len(old_index))]
-        tsframe.index = MultiIndex.from_arrays(new_index)
+            # try multiindex with dates
+            tsframe = self.tsframe
+            old_index = tsframe.index
+            new_index = [old_index, np.arange(len(old_index))]
+            tsframe.index = MultiIndex.from_arrays(new_index)
 
-        tsframe.to_excel(path, 'test1', index_label = ['time','foo'])
-        reader = ExcelFile(path)
-        recons = reader.parse('test1', index_col=[0,1])
-        assert_frame_equal(tsframe, recons)
+            tsframe.to_excel(path, 'test1', index_label = ['time','foo'])
+            reader = ExcelFile(path)
+            recons = reader.parse('test1', index_col=[0,1])
+            assert_frame_equal(tsframe, recons)
 
-        # do not load index
-        tsframe.to_excel(path, 'test1')
-        reader = ExcelFile(path)
-        recons = reader.parse('test1', index_col=None)
-        np.testing.assert_equal(len(recons.columns), len(tsframe.columns) + 2)
+            # do not load index
+            tsframe.to_excel(path, 'test1')
+            reader = ExcelFile(path)
+            recons = reader.parse('test1', index_col=None)
+            np.testing.assert_equal(len(recons.columns), len(tsframe.columns) + 2)
 
-        # no index
-        tsframe.to_excel(path, 'test1', index=False)
-        reader = ExcelFile(path)
-        recons = reader.parse('test1', index_col=None)
-        assert_almost_equal(recons.values, self.tsframe.values)
-        self.tsframe.index = old_index # needed if setUP becomes classmethod
+            # no index
+            tsframe.to_excel(path, 'test1', index=False)
+            reader = ExcelFile(path)
+            recons = reader.parse('test1', index_col=None)
+            assert_almost_equal(recons.values, self.tsframe.values)
+            self.tsframe.index = old_index # needed if setUP becomes classmethod
 
-        os.remove(path)
-
-    def test_to_excel2007_from_excel2007(self):
-        path = '__tmp__.xlsx'
-
-        self.frame['A'][:5] = nan
-
-        self.frame.to_excel(path,'test1')
-        self.frame.to_excel(path,'test1', cols=['A', 'B'])
-        self.frame.to_excel(path,'test1', header=False)
-        self.frame.to_excel(path,'test1', index=False)
-
-        # test roundtrip
-        self.frame.to_excel(path,'test1')
-        reader = ExcelFile(path)
-        recons = reader.parse('test1',index_col=0)
-        assert_frame_equal(self.frame, recons)
-
-        self.frame.to_excel(path,'test1', index=False)
-        reader = ExcelFile(path)
-        recons = reader.parse('test1',index_col=None)
-        recons.index = self.frame.index
-        assert_frame_equal(self.frame, recons)
-
-        self.frame.to_excel(path,'test1')
-        reader = ExcelFile(path)
-        recons = reader.parse('test1',index_col=0,skiprows=[1])
-        assert_frame_equal(self.frame.ix[1:], recons)
-
-        self.frame.to_excel(path,'test1',na_rep='NA')
-        reader = ExcelFile(path)
-        recons = reader.parse('test1',index_col=0,na_values=['NA'])
-        assert_frame_equal(self.frame, recons)
-        
-        self.mixed_frame.to_excel(path,'test1')
-        reader = ExcelFile(path)
-        recons = reader.parse('test1',index_col=0)
-        assert_frame_equal(self.mixed_frame, recons)
-
-        self.tsframe.to_excel(path,'test1')
-        reader = ExcelFile(path)
-        recons = reader.parse('test1',index_col=0)
-        assert_frame_equal(self.tsframe, recons)
-
-        #Test np.int64
-        frame = DataFrame(np.random.randn(10,2))
-        frame.to_excel(path,'test1')
-        reader = ExcelFile(path)
-        recons = reader.parse('test1',index_col=0)
-        assert_frame_equal(frame, recons)
-
-        # Test writing to separate sheets
-        writer = ExcelWriter(path)
-        self.frame.to_excel(writer,'test1')
-        self.tsframe.to_excel(writer,'test2')
-        writer.save()
-        reader = ExcelFile(path)
-        recons = reader.parse('test1',index_col=0)
-        assert_frame_equal(self.frame, recons)
-        recons = reader.parse('test2',index_col=0)
-        assert_frame_equal(self.tsframe, recons)
-
-        os.remove(path)
-
-    def test_to_excel2007_multiindex(self):
-        path = '__tmp__.xlsx'
-
-        frame = self.frame
-        old_index = frame.index
-        arrays = np.arange(len(old_index)*2).reshape(2,-1)
-        new_index = MultiIndex.from_arrays(arrays, names=['first', 'second'])
-        frame.index = new_index
-        frame.to_excel(path, 'test1', header=False)
-        frame.to_excel(path, 'test1', cols=['A', 'B'])
-
-        # round trip
-        frame.to_excel(path, 'test1')
-        reader = ExcelFile(path)
-        df = reader.parse('test1', index_col=[0,1], parse_dates=False)
-        assert_frame_equal(frame, df)
-        self.assertEqual(frame.index.names, df.index.names)
-        self.frame.index = old_index # needed if setUP becomes a classmethod
-
-        # try multiindex with dates
-        tsframe = self.tsframe
-        old_index = tsframe.index
-        new_index = [old_index, np.arange(len(old_index))]
-        tsframe.index = MultiIndex.from_arrays(new_index)
-
-        tsframe.to_excel(path, 'test1', index_label = ['time','foo'])
-        reader = ExcelFile(path)
-        recons = reader.parse('test1', index_col=[0,1])
-        assert_frame_equal(tsframe, recons)
-
-        # do not load index
-        tsframe.to_excel(path, 'test1')
-        reader = ExcelFile(path)
-        recons = reader.parse('test1', index_col=None)
-        np.testing.assert_equal(len(recons.columns), len(tsframe.columns) + 2)
-
-        # no index
-        tsframe.to_excel(path, 'test1', index=False)
-        reader = ExcelFile(path)
-        recons = reader.parse('test1', index_col=None)
-        assert_almost_equal(recons.values, self.tsframe.values)
-        self.tsframe.index = old_index # needed if setUP becomes classmethod
-
-        os.remove(path)
+            os.remove(path)
 
     def test_info(self):
         io = StringIO()

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2506,6 +2506,27 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         reader = ExcelFile(path)
         recons = reader.parse('test1',index_col=0)
         assert_frame_equal(self.frame, recons)
+        
+        self.frame.to_excel(path,'test1', index=False)
+        reader = ExcelFile(path)
+        recons = reader.parse('test1',index_col=None)
+        recons.index = self.frame.index
+        assert_frame_equal(self.frame, recons)
+
+        self.frame.to_excel(path,'test1')
+        reader = ExcelFile(path)
+        recons = reader.parse('test1',index_col=0,skiprows=[1])
+        assert_frame_equal(self.frame.ix[1:], recons)
+
+        self.frame.to_excel(path,'test1',na_rep='NA')
+        reader = ExcelFile(path)
+        recons = reader.parse('test1',index_col=0,na_values=['NA'])
+        assert_frame_equal(self.frame, recons)
+        
+        self.mixed_frame.to_excel(path,'test1')
+        reader = ExcelFile(path)
+        recons = reader.parse('test1',index_col=0)
+        assert_frame_equal(self.mixed_frame, recons)
 
         self.tsframe.to_excel(path,'test1')
         reader = ExcelFile(path)
@@ -2592,6 +2613,27 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         reader = ExcelFile(path)
         recons = reader.parse('test1',index_col=0)
         assert_frame_equal(self.frame, recons)
+
+        self.frame.to_excel(path,'test1', index=False)
+        reader = ExcelFile(path)
+        recons = reader.parse('test1',index_col=None)
+        recons.index = self.frame.index
+        assert_frame_equal(self.frame, recons)
+
+        self.frame.to_excel(path,'test1')
+        reader = ExcelFile(path)
+        recons = reader.parse('test1',index_col=0,skiprows=[1])
+        assert_frame_equal(self.frame.ix[1:], recons)
+
+        self.frame.to_excel(path,'test1',na_rep='NA')
+        reader = ExcelFile(path)
+        recons = reader.parse('test1',index_col=0,na_values=['NA'])
+        assert_frame_equal(self.frame, recons)
+        
+        self.mixed_frame.to_excel(path,'test1')
+        reader = ExcelFile(path)
+        recons = reader.parse('test1',index_col=0)
+        assert_frame_equal(self.mixed_frame, recons)
 
         self.tsframe.to_excel(path,'test1')
         reader = ExcelFile(path)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2532,6 +2532,47 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
         os.remove(path)
 
+    def test_to_excel2007_from_excel2007(self):
+        path = '__tmp__.xlsx'
+
+        self.frame['A'][:5] = nan
+
+        self.frame.to_excel(path,'test1')
+        self.frame.to_excel(path,'test1', cols=['A', 'B'])
+        self.frame.to_excel(path,'test1', header=False)
+        self.frame.to_excel(path,'test1', index=False)
+
+        # test roundtrip
+        self.frame.to_excel(path,'test1')
+        reader = ExcelFile(path)
+        recons = reader.parse('test1',index_col=0)
+        assert_frame_equal(self.frame, recons)
+
+        self.tsframe.to_excel(path,'test1')
+        reader = ExcelFile(path)
+        recons = reader.parse('test1',index_col=0)
+        assert_frame_equal(self.tsframe, recons)
+
+        #Test np.int64
+        frame = DataFrame(np.random.randn(10,2))
+        frame.to_excel(path,'test1')
+        reader = ExcelFile(path)
+        recons = reader.parse('test1',index_col=0)
+        assert_frame_equal(frame, recons)
+
+        # Test writing to separate sheets
+        writer = ExcelWriter(path)
+        self.frame.to_excel(writer,'test1')
+        self.tsframe.to_excel(writer,'test2')
+        writer.save()
+        reader = ExcelFile(path)
+        recons = reader.parse('test1',index_col=0)
+        assert_frame_equal(self.frame, recons)
+        recons = reader.parse('test2',index_col=0)
+        assert_frame_equal(self.tsframe, recons)
+
+        os.remove(path)
+
     def test_info(self):
         io = StringIO()
         self.frame.info(buf=io)

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -16,6 +16,7 @@ from pandas.core.series import remove_na
 import pandas.core.common as com
 import pandas.core.panel as panelmod
 from pandas.util import py3compat
+from pandas.io.parsers import (ExcelFile, ExcelWriter)
 
 from pandas.util.testing import (assert_panel_equal,
                                  assert_frame_equal,
@@ -973,6 +974,14 @@ class TestPanel(unittest.TestCase, PanelTests, CheckIndexing,
         p = df.to_panel()
         assert_frame_equal(p.minor_xs(2), df.ix[:,2].sort_index())
 
+    def test_to_excel(self):
+        path = '__tmp__.xlsx'
+        self.panel.to_excel(path)
+        reader = ExcelFile(path)
+        for item, df in self.panel.iteritems():
+            recdf = reader.parse(str(item),index_col=0) 
+            assert_frame_equal(df, recdf)
+    
 class TestLongPanel(unittest.TestCase):
     """
     LongPanel no longer exists, but...


### PR DESCRIPTION
I added a ExcelWriter class to io/parsers.py
Added a to_excel method to DataFrame and refactored to_csv to use a helper method that also serves to_excel.

I still need to add some tests, but wanted to get feedback before spending any more time.

There are still some issues, like xlwt throws exceptions when writing np.int64 types, but we should be able to special case some of that.  I also didn't add any encoding handling, although that should be reasonably easy.
