### PR TITLE
Handle subclasses of dicts in DataFrame constructor, with tests

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4028,6 +4028,8 @@ def _homogenize(data, index, columns, dtype=None):
             if isinstance(v, dict):
                 if oindex is None:
                     oindex = index.astype('O')
+                if type(v) != dict:
+                    v = dict(v)
                 v = lib.fast_multiget(v, oindex, default=np.nan)
 
             v = _sanitize_array(v, index, dtype=dtype, copy=False,

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1216,6 +1216,18 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         frame = DataFrame({'A' : [], 'B' : []}, columns=['A', 'B'])
         self.assert_(frame.index is NULL_INDEX)
 
+    def test_constructor_subclass_dict(self):
+        #Test for passing dict subclass to constructor
+        data = {'col1': tm.TestSubDict((x, 10.0 * x) for x in xrange(10)), 
+                'col2': tm.TestSubDict((x, 20.0 * x) for x in xrange(10))}
+        df = DataFrame(data)
+        refdf = DataFrame(dict((col, dict(val.iteritems())) for col, val in data.iteritems()))
+        assert_frame_equal(refdf, df)
+
+        data = tm.TestSubDict(data.iteritems())
+        df = DataFrame(data)
+        assert_frame_equal(refdf, df)
+
     def test_constructor_dict_block(self):
         expected = [[4., 3., 2., 1.]]
         df = DataFrame({'d' : [4.],'c' : [3.],'b' : [2.],'a' : [1.]},

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -253,6 +253,12 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         expected = Series([1, 2, nan, 0], index=['b', 'c', 'd', 'a'])
         assert_series_equal(result, expected)
 
+    def test_constructor_subclass_dict(self):
+        data = tm.TestSubDict((x, 10.0 * x) for x in xrange(10))
+        series = Series(data)
+        refseries = Series(dict(data.iteritems()))
+        assert_series_equal(refseries, series)
+
     def test_constructor_list_of_tuples(self):
         data = [(1, 1), (2, 2), (2, 3)]
         s = Series(data)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -222,6 +222,10 @@ def add_nans(panel):
         for j, col in enumerate(dm.columns):
             dm[col][:i + j] = np.NaN
 
+class TestSubDict(dict):
+    def __init__(self, *args, **kwargs):
+        dict.__init__(self, *args, **kwargs)
+
 
 # Dependency checks.  Copied this from Nipy/Nipype (Copyright of
 # respective developers, license: BSD-3)


### PR DESCRIPTION
Minor change to allow passing subclasses of dict into DataFrame constructor.  I assume there is no way to pass these directly to cython, we have to make a copy first?
