### PR TITLE
Fix syntax error in map.py.

### DIFF
--- a/pandas/util/map.py
+++ b/pandas/util/map.py
@@ -62,7 +62,7 @@ def auto_map(arr, f, otherargs, n_results=1, required='all'):
 
 def mapwrap(f, n_results_default=1, required='all'):
     @wraps(f)
-    def wrapped(arr, *otherargs, n_results=None):
+    def wrapped(arr, n_results=None, *otherargs):
         n_results = n_results or n_results_default
         return auto_map(arr, f, otherargs, n_results, required)
     


### PR DESCRIPTION
This commit fixes a SyntaxError observed when installing (as in: running `python setup.py install`) on Linux (python 2.7): the original error I saw was

```
Extracting pandas-0.7.0.dev_6253b07-py2.7-linux-x86_64.egg to /usr/lib64/python2.7/site-packages
SyntaxError: ('invalid syntax', ('/usr/lib64/python2.7/site-packages/pandas-0.7.0.dev_6253b07-py2.7-linux-x86_64.egg/pandas/util/map.py', 65, 42, '    def wrapped(arr, *otherargs, n_results=None):\n'))
```

and a check showed that `*args` was put before a keyword expression in the function. Reversing the order fixed the error.
