### PR TITLE
'Mixed depth' hierarchical column labels

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1427,6 +1427,11 @@ class DataFrame(NDFrame):
                 new_values = self.values[:, loc]
                 result = DataFrame(new_values, index=self.index,
                                    columns=result_columns)
+            if len(result.columns) == 1:
+                top = result.columns[0]
+                if (type(top) == str and top == '' or
+                        type(top) == tuple and top[0] == ''):
+                    result = Series(result[''], index=self.index, name=key)
             return result
         else:
             return self._get_item_cache(key)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -302,7 +302,21 @@ class NDFrame(PandasObject):
         """
         Delete item
         """
-        self._data.delete(key)
+        deleted = False
+        if key not in self.columns:
+            # If column labels are tuples, allow shorthand to delete
+            # all columns whose first len(key) elements match key:
+            if not isinstance(key,tuple):
+                key = (key,)
+            for col in self.columns:
+                if isinstance(col,tuple) and col[:len(key)] == key:
+                    del self[col]
+                    deleted = True
+        if not deleted:
+            # If the above loop ran and didn't delete anything because
+            # there was no match, this call should raise the appropriate
+            # exception:
+            self._data.delete(key)
 
         try:
             del self._item_cache[key]

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -291,7 +291,7 @@ class NDFrame(PandasObject):
         self._item_cache.clear()
 
     def _set_item(self, key, value):
-        if isinstance(self.columns, MultiIndex):
+        if hasattr(self,'columns') and isinstance(self.columns, MultiIndex):
             # Pad the key with empty strings if lower levels of the key
             # aren't specified:
             if not isinstance(key, tuple):
@@ -310,7 +310,9 @@ class NDFrame(PandasObject):
         Delete item
         """
         deleted = False
-        if isinstance(self.columns, MultiIndex) and key not in self.columns:
+        if (hasattr(self,'columns') and 
+                isinstance(self.columns, MultiIndex)
+                and key not in self.columns):
             # Allow shorthand to delete all columns whose first len(key)
             # elements match key:
             if not isinstance(key,tuple):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -291,6 +291,13 @@ class NDFrame(PandasObject):
         self._item_cache.clear()
 
     def _set_item(self, key, value):
+        if isinstance(self.columns, MultiIndex):
+            # Pad the key with empty strings if lower levels of the key
+            # aren't specified:
+            if not isinstance(key, tuple):
+                key = (key,)
+            if len(key) != self.columns.nlevels:
+                key += ('',)*(self.columns.nlevels - len(key))
         self._data.set(key, value)
 
         try:
@@ -303,9 +310,9 @@ class NDFrame(PandasObject):
         Delete item
         """
         deleted = False
-        if key not in self.columns:
-            # If column labels are tuples, allow shorthand to delete
-            # all columns whose first len(key) elements match key:
+        if isinstance(self.columns, MultiIndex) and key not in self.columns:
+            # Allow shorthand to delete all columns whose first len(key)
+            # elements match key:
             if not isinstance(key,tuple):
                 key = (key,)
             for col in self.columns:

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1083,6 +1083,86 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         expected = self.ymd.reindex(s.index[5:])
         assert_frame_equal(result, expected)
 
+    def test_mixed_depth_get(self):
+        arrays = [[  'a', 'top', 'top', 'routine1', 'routine1', 'routine2'],
+                  [   '',  'OD',  'OD', 'result1',   'result2',  'result1'],
+                  [   '',  'wx',  'wy',        '',          '',         '']]
+
+        tuples = zip(*arrays)
+        tuples.sort()
+        index = MultiIndex.from_tuples(tuples)
+        df = DataFrame(randn(4,6),columns = index)
+            
+        result = df['a']
+        expected = df['a','','']
+        assert_series_equal(result, expected)
+        self.assertEquals(result.name, 'a')
+        
+        result = df['routine1','result1']
+        expected = df['routine1','result1','']
+        assert_series_equal(result, expected)
+        self.assertEquals(result.name, ('routine1', 'result1'))
+
+    def test_mixed_depth_insert(self):  
+        arrays = [[  'a', 'top', 'top', 'routine1', 'routine1', 'routine2'],
+                  [   '',  'OD',  'OD', 'result1',   'result2',  'result1'],
+                  [   '',  'wx',  'wy',        '',          '',         '']]
+
+        tuples = zip(*arrays)
+        tuples.sort()
+        index = MultiIndex.from_tuples(tuples)
+        df = DataFrame(randn(4,6),columns = index)     
+
+        result = df.copy()
+        expected = df.copy()
+        result['b'] = [1,2,3,4]
+        expected['b','',''] = [1,2,3,4]
+        assert_frame_equal(result, expected)
+ 
+    def test_mixed_depth_drop(self):  
+        arrays = [[  'a', 'top', 'top', 'routine1', 'routine1', 'routine2'],
+                  [   '',  'OD',  'OD', 'result1',   'result2',  'result1'],
+                  [   '',  'wx',  'wy',        '',          '',         '']]
+
+        tuples = zip(*arrays)
+        tuples.sort()
+        index = MultiIndex.from_tuples(tuples)
+        df = DataFrame(randn(4,6),columns = index)     
+
+        result = df.drop('a',axis=1)
+        expected = df.drop([('a','','')],axis=1)
+        assert_frame_equal(expected, result)
+        
+        result = df.drop(['top'],axis=1)
+        expected = df.drop([('top','OD','wx')], axis=1)
+        expected = expected.drop([('top','OD','wy')], axis=1)
+        assert_frame_equal(expected, result)
+               
+    def test_mixed_depth_pop(self):  
+        arrays = [[  'a', 'top', 'top', 'routine1', 'routine1', 'routine2'],
+                  [   '',  'OD',  'OD', 'result1',   'result2',  'result1'],
+                  [   '',  'wx',  'wy',        '',          '',         '']]
+
+        tuples = zip(*arrays)
+        tuples.sort()
+        index = MultiIndex.from_tuples(tuples)
+        df = DataFrame(randn(4,6),columns = index)     
+
+        df1 = df.copy()
+        df2 = df.copy()
+        result = df1.pop('a')
+        expected = df2.pop(('a','',''))
+        assert_series_equal(expected, result)
+        assert_frame_equal(df1, df2)
+        self.assertEquals(result.name,'a')
+        
+        expected = df1['top']
+        df1 = df1.drop(['top'],axis=1)
+        result = df2.pop('top')
+        assert_frame_equal(expected, result)
+        assert_frame_equal(df1, df2)
+            
+        
 if __name__ == '__main__':
 
     # unittest.main()


### PR DESCRIPTION
Modifications to column-hierarchical behaviour as per "'Mixed depth' hierarchical column labels" discussion on pystatsmodels.

If column label tuples contain only empty strings at the lower levels, allows the DataFrame to be indexed with only the higher levels. So for example if a column has the hierarchical label ('a','',''), and there are no other columns with 'a' at their top level, then this change allows the column to be pulled out with df['a'], rather than df['a','','']. It also names the resulting series 'a'. 
The use case for this is when some columns have a deeper hierarchy than others, and you want to treat the shallower columns as if the lower levels of the hierarchy weren't there.

If column label tuples contain only empty strings at the lower levels, allows the DataFrame to be indexed with only the higher levels. So for example if a column has the hierarchical label ('a','',''), and there are no other columns with 'a' at their top level, then this change allows the column to be pulled out with df['a'], rather than df['a','','']. It also names the resulting series 'a'. 
The use case for this is when some columns have a deeper hierarchy than others, and you want to treat the shallower columns as if the lower levels of the hierarchy weren't there.
