### PR TITLE
Add _repr_html method to make DataFrames nice in IPython notebook.

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -462,6 +462,9 @@ class DataFrame(NDFrame):
                 return com.console_encode(value)
         return com.console_encode(buf.getvalue())
 
+    def _repr_html_(self):
+        return self.to_html()
+
     def __iter__(self):
         """
         Iterate over columns of the frame.


### PR DESCRIPTION
This makes DataFrame's show up and nice HTML tables in the IPython notebook.  This initial implementation is very plain - but better than the plaintext output.  We need to think more about how we want to handle these things, but this is a start.
