### PR TITLE
unify API in regards to column-vs-columns

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2149,10 +2149,10 @@ class DataFrame(NDFrame):
     #----------------------------------------------------------------------
     # Sorting
 
-    def sort(self, column=None, axis=0, ascending=True):
+    def sort(self, columns=None, axis=0, ascending=True):
         """
         Sort DataFrame either by labels (along either axis) or by the values in
-        a column
+        column(s)
 
         Parameters
         ----------
@@ -2168,7 +2168,7 @@ class DataFrame(NDFrame):
         -------
         sorted : DataFrame
         """
-        return self.sort_index(by=column, axis=axis, ascending=ascending)
+        return self.sort_index(by=columns, axis=axis, ascending=ascending)
 
     def sort_index(self, axis=0, by=None, ascending=True):
         """


### PR DESCRIPTION
This is the "fix" only for 1 case out of few other possible:

```
$> git grep 'def.*column=' 
pandas/core/frame.py:    def boxplot(self, column=None, by=None, ax=None, fontsize=None,
pandas/stats/misc.py:def percentileRank(frame, column=None, kind='mean'):
pandas/tools/plotting.py:def boxplot(data, column=None, by=None, ax=None, fontsize=None,
```
