### PR TITLE
attempting to deflect more issues to the github tracker via the docs

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -10,11 +10,15 @@ pandas: powerful Python data analysis toolkit
 
 **Date**: |today| **Version**: |version|
 
-**Installers:** http://pypi.python.org/pypi/pandas
+**Binary Installers:** http://pypi.python.org/pypi/pandas
 
-**Code Repository:** http://github.com/pydata/pandas
+**Source Repository:** http://github.com/pydata/pandas
 
-**Mailing List:** http://groups.google.com/group/pystatsmodels
+**Issues & Ideas:** https://github.com/pydata/pandas/issues
+
+**Q&A Support:** http://stackoverflow.com/questions/tagged/pandas
+
+**Developer Mailing List:** http://groups.google.com/group/pystatsmodels
 
 **pandas** is a `Python <http://www.python.org>`__ package providing fast,
 flexible, and expressive data structures designed to make working with

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -81,12 +81,14 @@ sensible.
 Getting Support
 ---------------
 
-For community support, please join us on the `pystatsmodels mailing list
-<http://groups.google.com/group/pystatsmodels>`__.
+The first stop for pandas issues and ideas is the `Github Issue Tracker
+<https://github.com/pydata/pandas/issues>`__. If you have a general question,
+pandas community experts can answer through `Stack Overflow
+<http://stackoverflow.com/questions/tagged/pandas>`__.
 
-For commercial support from Lambda Foundry, please send inquiries to:
-
-support@lambdafoundry.com
+Longer discussions occur on the `developer mailing list
+<http://groups.google.com/group/pystatsmodels>`__, and commercial support
+inquiries for Lambda Foundry should be sent to: support@lambdafoundry.com
 
 Credits
 -------


### PR DESCRIPTION
made it clearer that users should first look to github for issues and, if possible, try stack overflow, before bringing the discussion to the mailing list - updates to index and overview
