### PR TITLE
DataFrame_repr_html changes according to #772 discussion.

### DIFF
--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -581,7 +581,8 @@ def _has_names(index):
 # Global formatting options
 
 def set_printoptions(precision=None, column_space=None, max_rows=None,
-                     max_columns=None, colheader_justify='right'):
+                     max_columns=None, colheader_justify='right',
+                     notebook_repr_html=None):
     """
     Alter default behavior of DataFrame.toString
 
@@ -597,6 +598,10 @@ def set_printoptions(precision=None, column_space=None, max_rows=None,
         Either one, or both can be set to 0 (experimental). Pandas will figure
         out how big the terminal is and will not display more rows or/and
         columns that can fit on it.
+    colheader_justify
+    notebook_repr_html : boolean
+        When True (default), IPython notebook will use html representation for
+        pandas objects (if it is available).
     """
     if precision is not None:
         print_config.precision = precision
@@ -608,6 +613,8 @@ def set_printoptions(precision=None, column_space=None, max_rows=None,
         print_config.max_columns = max_columns
     if colheader_justify is not None:
         print_config.colheader_justify = colheader_justify
+    if notebook_repr_html is not None:
+        print_config.notebook_repr_html = notebook_repr_html
 
 def reset_printoptions():
     print_config.reset()
@@ -733,6 +740,7 @@ class _GlobalPrintConfig(object):
         self.max_rows = 200
         self.max_columns = 0
         self.colheader_justify = 'right'
+        self.notebook_repr_html = True
 
     def reset(self):
         self.__init__()


### PR DESCRIPTION
cc @ellisonbg

Implemented changes as discussed in #772.
Not so crazy on the scrollable div. For now i left the div max sizes as they were, could use suggestion on _good_ values.

I don't use the notebook often, what i noticed just now is that in combination with the IPython notebook `get_terminal_size()` returns the size of the terminal where the notebook was launched, not the size of the notebook display area. Don't know if there is a way to get the notebook size.
