### PR TITLE
Bug Fix for Issue #513 Fractional seconds lost in HDFStore for datetime indexes

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -720,7 +720,7 @@ def _convert_index(index):
         else:
             kind = 'date'
             converted = np.array([time.mktime(v.timetuple()) for v in values],
-                              dtype=np.float64)
+                              dtype=np.int64)
             return converted, kind, _tables().Time64Col()
     elif isinstance(values[0], basestring):
         converted = np.array(list(values), dtype=np.str_)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -715,8 +715,9 @@ def _convert_index(index):
             kind = 'datetime'
         else:
             kind = 'date'
-        converted = np.array([time.mktime(v.timetuple()) for v in values],
-                             dtype=np.int64)
+        converted = np.array([(time.mktime(v.timetuple()) +
+                               v.microsecond / 1E6) for v in values],
+                               dtype=np.float64)
         return converted, kind, _tables().Time64Col()
     elif isinstance(values[0], basestring):
         converted = np.array(list(values), dtype=np.str_)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -710,18 +710,15 @@ def _convert_index(index):
     # Let's assume the index is homogeneous
     values = np.asarray(index)
 
-    if isinstance(values[0], (datetime, date)):
-        if isinstance(values[0], datetime):
-            kind = 'datetime'
-            converted = np.array([(time.mktime(v.timetuple()) +
-                                   v.microsecond / 1E6) for v in values],
-                                   dtype=np.float64)
-            return converted, kind, _tables().Time64Col()
-        else:
-            kind = 'date'
-            converted = np.array([time.mktime(v.timetuple()) for v in values],
-                              dtype=np.int64)
-            return converted, kind, _tables().Time64Col()
+    if isinstance(values[0], datetime):
+        converted = np.array([(time.mktime(v.timetuple()) +
+                               v.microsecond / 1E6) for v in values],
+                               dtype=np.float64)
+        return converted, 'datetime', _tables().Time64Col()
+    elif isinstance(values[0], date):
+        converted = np.array([time.mktime(v.timetuple()) for v in values],
+                             dtype=np.int64)
+        return converted, 'date', _tables().Time64Col()
     elif isinstance(values[0], basestring):
         converted = np.array(list(values), dtype=np.str_)
         itemsize = converted.dtype.itemsize

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -713,12 +713,15 @@ def _convert_index(index):
     if isinstance(values[0], (datetime, date)):
         if isinstance(values[0], datetime):
             kind = 'datetime'
+            converted = np.array([(time.mktime(v.timetuple()) +
+                                   v.microsecond / 1E6) for v in values],
+                                   dtype=np.float64)
+            return converted, kind, _tables().Time64Col()
         else:
             kind = 'date'
-        converted = np.array([(time.mktime(v.timetuple()) +
-                               v.microsecond / 1E6) for v in values],
-                               dtype=np.float64)
-        return converted, kind, _tables().Time64Col()
+            converted = np.array([time.mktime(v.timetuple()) for v in values],
+                              dtype=np.float64)
+            return converted, kind, _tables().Time64Col()
     elif isinstance(values[0], basestring):
         converted = np.array(list(values), dtype=np.str_)
         itemsize = converted.dtype.itemsize

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -717,8 +717,8 @@ def _convert_index(index):
         return converted, 'datetime', _tables().Time64Col()
     elif isinstance(values[0], date):
         converted = np.array([time.mktime(v.timetuple()) for v in values],
-                             dtype=np.int64)
-        return converted, 'date', _tables().Time64Col()
+                             dtype=np.int32)
+        return converted, 'date', _tables().Time32Col()
     elif isinstance(values[0], basestring):
         converted = np.array(list(values), dtype=np.str_)
         itemsize = converted.dtype.itemsize

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -468,9 +468,10 @@ class TesttHDFStore(unittest.TestCase):
         store.close()
 
     def test_store_datetime_fractional_secs(self):
-        series = Series([0], [datetime(2012, 1, 2, 3, 4, 5, 123456)])
+        dt = datetime(2012, 1, 2, 3, 4, 5, 123456)
+        series = Series([0], [dt])
         self.store['a'] = series
-        self.assertEquals(self.store['a'].index[0].microsecond, 123456)
+        self.assertEquals(self.store['a'].index[0], dt)
 
 def curpath():
     pth, _ = os.path.split(os.path.abspath(__file__))

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -3,6 +3,7 @@ import unittest
 import os
 import sys
 
+from datetime import datetime
 import numpy as np
 
 from pandas import Series, DataFrame, Panel, DateRange, MultiIndex
@@ -465,6 +466,11 @@ class TesttHDFStore(unittest.TestCase):
         store['c']
         store['d']
         store.close()
+
+    def test_store_datetime_fractional_secs(self):
+        series = Series([0], [datetime(2012, 1, 2, 3, 4, 5, 123456)])
+        self.store['a'] = series
+        self.assertEquals(self.store['a'].index[0].microsecond, 123456)
 
 def curpath():
     pth, _ = os.path.split(os.path.abspath(__file__))


### PR DESCRIPTION
PyTables Time64Col is in fact a float64 alias so adding fractional seconds and using the correct dtype fixes this issue
#513
