### PR TITLE
Fixed bug in ewmcov

### DIFF
--- a/pandas/stats/moments.py
+++ b/pandas/stats/moments.py
@@ -317,7 +317,7 @@ def ewmcov(arg1, arg2, com=None, span=None, min_periods=0, bias=False,
     mean = lambda x: ewma(x, com=com, span=span, min_periods=min_periods)
 
     result = (mean(X*Y) - mean(X) * mean(Y))
-
+    com = _get_center_of_mass(com, span)
     if not bias:
         result *= (1.0 + 2.0 * com) / (2.0 * com)
 


### PR DESCRIPTION
If com is None, an error is returned because result requires com when bias is false.
