### PR TITLE
Bugfix: Couldn't subclass Panel

### DIFF
--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -320,7 +320,7 @@ class Panel(NDFrame):
         data, index, columns = _homogenize_dict(data, intersect=intersect,
                                                 dtype=dtype)
         items = Index(sorted(data.keys()))
-        return __class__(data, items, index, columns)
+        return cls(data, items, index, columns)
 
     def __getitem__(self, key):
         if isinstance(self.items, MultiIndex):

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -11,7 +11,7 @@ from pandas.core.common import (PandasError, _mut_exclusive,
                                 _try_sort, _default_index, _infer_dtype)
 from pandas.core.index import (Factor, Index, MultiIndex, _ensure_index,
                                _get_combined_index, NULL_INDEX)
-from pandas.core.indexing import _NDFrameIndexer, _maybe_droplevels
+from pandas.core.indexing import _NDFrameIndexer
 from pandas.core.internals import BlockManager, make_block, form_blocks
 from pandas.core.frame import DataFrame
 from pandas.core.generic import NDFrame
@@ -320,30 +320,7 @@ class Panel(NDFrame):
         data, index, columns = _homogenize_dict(data, intersect=intersect,
                                                 dtype=dtype)
         items = Index(sorted(data.keys()))
-        return Panel(data, items, index, columns)
-
-    def __getitem__(self, key):
-        if isinstance(self.items, MultiIndex):
-            return self._getitem_multilevel(key)
-        return super(Panel, self).__getitem__(key)
-
-    def _getitem_multilevel(self, key):
-        loc = self.items.get_loc(key)
-        if isinstance(loc, (slice, np.ndarray)):
-            new_index = self.items[loc]
-            result_index = _maybe_droplevels(new_index, key)
-            if self._is_mixed_type:
-                result = self.reindex(items=new_index)
-                result.index = result_index
-            else:
-                new_values = self.values[loc, :, :]
-                result = Panel(new_values, 
-                               items=self.items[loc],
-                               major_axis=self.major_axis,
-                               minor_axis=self.minor_axis)
-            return result
-        else:
-            return self._get_item_cache(key)
+        return __class__(data, items, index, columns)
 
     def _init_matrix(self, data, axes, dtype=None, copy=False):
         values = _prep_ndarray(data, copy=copy)
@@ -438,14 +415,14 @@ class Panel(NDFrame):
             columns = self.minor_axis
 
         return index, columns
-
+    
     @property
     def _constructor(self):
-        return Panel
+        return self.__class__
 
     # Fancy indexing
     _ix = None
-
+    
     @property
     def ix(self):
         if self._ix is None:
@@ -723,7 +700,7 @@ class Panel(NDFrame):
             return self._combine_frame(other, func, axis=axis)
         elif np.isscalar(other):
             new_values = func(self.values, other)
-            return Panel(new_values, self.items, self.major_axis,
+            return self._constructor(new_values, self.items, self.major_axis,
                              self.minor_axis)
 
     def __neg__(self):
@@ -744,7 +721,7 @@ class Panel(NDFrame):
             new_values = func(self.values.swapaxes(0, 2), other.values)
             new_values = new_values.swapaxes(0, 2)
 
-        return Panel(new_values, self.items, self.major_axis,
+        return self._constructor(new_values, self.items, self.major_axis,
                      self.minor_axis)
 
     def _combine_panel(self, other, func):
@@ -758,7 +735,7 @@ class Panel(NDFrame):
 
         result_values = func(this.values, other.values)
 
-        return Panel(result_values, items, major, minor)
+        return self._constructor(result_values, items, major, minor)
 
     def fillna(self, value=None, method='pad'):
         """
@@ -790,10 +767,10 @@ class Panel(NDFrame):
             for col, s in self.iterkv():
                 result[col] = s.fillna(method=method, value=value)
 
-            return Panel.from_dict(result)
+            return self._constructor.from_dict(result)
         else:
             new_data = self._data.fillna(value)
-            return Panel(new_data)
+            return self._constructor(new_data)
 
     add = _panel_arith_method(operator.add, 'add')
     subtract = sub = _panel_arith_method(operator.sub, 'subtract')
@@ -882,7 +859,7 @@ class Panel(NDFrame):
         """
         from pandas.core.groupby import PanelGroupBy
         axis = self._get_axis_number(axis)
-        return PanelGroupBy(self, function, axis=axis)
+        return self._constructorGroupBy(self, function, axis=axis)
 
     def swapaxes(self, axis1='major', axis2='minor'):
         """
@@ -904,7 +881,7 @@ class Panel(NDFrame):
                     for k in range(3))
         new_values = self.values.swapaxes(i, j).copy()
 
-        return Panel(new_values, *new_axes)
+        return self._constructor(new_values, *new_axes)
 
     def to_frame(self, filter_observations=True):
         """
@@ -1105,7 +1082,7 @@ class Panel(NDFrame):
         else:
             raise ValueError('Invalid axis')
 
-        return Panel(values, items=items, major_axis=major_axis,
+        return self._constructor(values, items=items, major_axis=major_axis,
                          minor_axis=minor_axis)
 
     def truncate(self, before=None, after=None, axis='major'):

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -441,7 +441,7 @@ class Panel(NDFrame):
 
     @property
     def _constructor(self):
-        return self.__class__
+        return type(self)
 
     # Fancy indexing
     _ix = None
@@ -882,7 +882,7 @@ class Panel(NDFrame):
         """
         from pandas.core.groupby import PanelGroupBy
         axis = self._get_axis_number(axis)
-        return self._constructorGroupBy(self, function, axis=axis)
+        return self._PanelGroupBy(self, function, axis=axis)
 
     def swapaxes(self, axis1='major', axis2='minor'):
         """

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -320,7 +320,7 @@ class Panel(NDFrame):
         data, index, columns = _homogenize_dict(data, intersect=intersect,
                                                 dtype=dtype)
         items = Index(sorted(data.keys()))
-        return Panel(data, items, index, columns)
+        return __class__(data, items, index, columns)
 
     def __getitem__(self, key):
         if isinstance(self.items, MultiIndex):
@@ -441,7 +441,7 @@ class Panel(NDFrame):
 
     @property
     def _constructor(self):
-        return Panel
+        return self.__class__
 
     # Fancy indexing
     _ix = None
@@ -723,7 +723,7 @@ class Panel(NDFrame):
             return self._combine_frame(other, func, axis=axis)
         elif np.isscalar(other):
             new_values = func(self.values, other)
-            return Panel(new_values, self.items, self.major_axis,
+            return self._constructor(new_values, self.items, self.major_axis,
                              self.minor_axis)
 
     def __neg__(self):
@@ -744,7 +744,7 @@ class Panel(NDFrame):
             new_values = func(self.values.swapaxes(0, 2), other.values)
             new_values = new_values.swapaxes(0, 2)
 
-        return Panel(new_values, self.items, self.major_axis,
+        return self._constructor(new_values, self.items, self.major_axis,
                      self.minor_axis)
 
     def _combine_panel(self, other, func):
@@ -758,7 +758,7 @@ class Panel(NDFrame):
 
         result_values = func(this.values, other.values)
 
-        return Panel(result_values, items, major, minor)
+        return self._constructor(result_values, items, major, minor)
 
     def fillna(self, value=None, method='pad'):
         """
@@ -790,10 +790,10 @@ class Panel(NDFrame):
             for col, s in self.iterkv():
                 result[col] = s.fillna(method=method, value=value)
 
-            return Panel.from_dict(result)
+            return self._constructor.from_dict(result)
         else:
             new_data = self._data.fillna(value)
-            return Panel(new_data)
+            return self._constructor(new_data)
 
     add = _panel_arith_method(operator.add, 'add')
     subtract = sub = _panel_arith_method(operator.sub, 'subtract')
@@ -882,7 +882,7 @@ class Panel(NDFrame):
         """
         from pandas.core.groupby import PanelGroupBy
         axis = self._get_axis_number(axis)
-        return PanelGroupBy(self, function, axis=axis)
+        return self._constructorGroupBy(self, function, axis=axis)
 
     def swapaxes(self, axis1='major', axis2='minor'):
         """
@@ -904,7 +904,7 @@ class Panel(NDFrame):
                     for k in range(3))
         new_values = self.values.swapaxes(i, j).copy()
 
-        return Panel(new_values, *new_axes)
+        return self._constructor(new_values, *new_axes)
 
     def to_frame(self, filter_observations=True):
         """
@@ -1105,7 +1105,7 @@ class Panel(NDFrame):
         else:
             raise ValueError('Invalid axis')
 
-        return Panel(values, items=items, major_axis=major_axis,
+        return self._constructor(values, items=items, major_axis=major_axis,
                          minor_axis=minor_axis)
 
     def truncate(self, before=None, after=None, axis='major'):

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -11,7 +11,7 @@ from pandas.core.common import (PandasError, _mut_exclusive,
                                 _try_sort, _default_index, _infer_dtype)
 from pandas.core.index import (Factor, Index, MultiIndex, _ensure_index,
                                _get_combined_index, NULL_INDEX)
-from pandas.core.indexing import _NDFrameIndexer
+from pandas.core.indexing import _NDFrameIndexer, _maybe_droplevels
 from pandas.core.internals import BlockManager, make_block, form_blocks
 from pandas.core.frame import DataFrame
 from pandas.core.generic import NDFrame
@@ -320,7 +320,30 @@ class Panel(NDFrame):
         data, index, columns = _homogenize_dict(data, intersect=intersect,
                                                 dtype=dtype)
         items = Index(sorted(data.keys()))
-        return __class__(data, items, index, columns)
+        return Panel(data, items, index, columns)
+
+    def __getitem__(self, key):
+        if isinstance(self.items, MultiIndex):
+            return self._getitem_multilevel(key)
+        return super(Panel, self).__getitem__(key)
+
+    def _getitem_multilevel(self, key):
+        loc = self.items.get_loc(key)
+        if isinstance(loc, (slice, np.ndarray)):
+            new_index = self.items[loc]
+            result_index = _maybe_droplevels(new_index, key)
+            if self._is_mixed_type:
+                result = self.reindex(items=new_index)
+                result.index = result_index
+            else:
+                new_values = self.values[loc, :, :]
+                result = Panel(new_values, 
+                               items=self.items[loc],
+                               major_axis=self.major_axis,
+                               minor_axis=self.minor_axis)
+            return result
+        else:
+            return self._get_item_cache(key)
 
     def _init_matrix(self, data, axes, dtype=None, copy=False):
         values = _prep_ndarray(data, copy=copy)
@@ -415,14 +438,14 @@ class Panel(NDFrame):
             columns = self.minor_axis
 
         return index, columns
-    
+
     @property
     def _constructor(self):
-        return self.__class__
+        return Panel
 
     # Fancy indexing
     _ix = None
-    
+
     @property
     def ix(self):
         if self._ix is None:
@@ -700,7 +723,7 @@ class Panel(NDFrame):
             return self._combine_frame(other, func, axis=axis)
         elif np.isscalar(other):
             new_values = func(self.values, other)
-            return self._constructor(new_values, self.items, self.major_axis,
+            return Panel(new_values, self.items, self.major_axis,
                              self.minor_axis)
 
     def __neg__(self):
@@ -721,7 +744,7 @@ class Panel(NDFrame):
             new_values = func(self.values.swapaxes(0, 2), other.values)
             new_values = new_values.swapaxes(0, 2)
 
-        return self._constructor(new_values, self.items, self.major_axis,
+        return Panel(new_values, self.items, self.major_axis,
                      self.minor_axis)
 
     def _combine_panel(self, other, func):
@@ -735,7 +758,7 @@ class Panel(NDFrame):
 
         result_values = func(this.values, other.values)
 
-        return self._constructor(result_values, items, major, minor)
+        return Panel(result_values, items, major, minor)
 
     def fillna(self, value=None, method='pad'):
         """
@@ -767,10 +790,10 @@ class Panel(NDFrame):
             for col, s in self.iterkv():
                 result[col] = s.fillna(method=method, value=value)
 
-            return self._constructor.from_dict(result)
+            return Panel.from_dict(result)
         else:
             new_data = self._data.fillna(value)
-            return self._constructor(new_data)
+            return Panel(new_data)
 
     add = _panel_arith_method(operator.add, 'add')
     subtract = sub = _panel_arith_method(operator.sub, 'subtract')
@@ -859,7 +882,7 @@ class Panel(NDFrame):
         """
         from pandas.core.groupby import PanelGroupBy
         axis = self._get_axis_number(axis)
-        return self._constructorGroupBy(self, function, axis=axis)
+        return PanelGroupBy(self, function, axis=axis)
 
     def swapaxes(self, axis1='major', axis2='minor'):
         """
@@ -881,7 +904,7 @@ class Panel(NDFrame):
                     for k in range(3))
         new_values = self.values.swapaxes(i, j).copy()
 
-        return self._constructor(new_values, *new_axes)
+        return Panel(new_values, *new_axes)
 
     def to_frame(self, filter_observations=True):
         """
@@ -1082,7 +1105,7 @@ class Panel(NDFrame):
         else:
             raise ValueError('Invalid axis')
 
-        return self._constructor(values, items=items, major_axis=major_axis,
+        return Panel(values, items=items, major_axis=major_axis,
                          minor_axis=minor_axis)
 
     def truncate(self, before=None, after=None, axis='major'):

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -882,7 +882,7 @@ class Panel(NDFrame):
         """
         from pandas.core.groupby import PanelGroupBy
         axis = self._get_axis_number(axis)
-        return self._PanelGroupBy(self, function, axis=axis)
+        return PanelGroupBy(self, function, axis=axis)
 
     def swapaxes(self, axis1='major', axis2='minor'):
         """


### PR DESCRIPTION
I was trying to create a subclass from Panel and came into this snag. I'm not sure if there was a reason Panel was using a hard coded _constructor method, but I changed it to be more generic. I'm new to open source, so constructive criticism is welcome. Am I doing this right?
