### PR TITLE
Weighted rolling average

### DIFF
--- a/pandas/src/moments.pyx
+++ b/pandas/src/moments.pyx
@@ -158,6 +158,52 @@ def roll_mean(ndarray[double_t] input,
     return output
 
 #-------------------------------------------------------------------------------
+# Weighted moving average 
+
+def weighted_mean(ndarray[double_t] input, ndarray[double_t] weights, int minp):
+    cdef double val, prev, sum_x = 0
+    cdef Py_ssize_t nobs = 0, i, j
+    cdef Py_ssize_t N = len(input)
+    cdef Py_ssize_t w_n = len(weights)
+
+    cdef ndarray[double_t] output = np.empty(N, dtype=float)
+
+    for i from 0 <= i < minp - 1:
+        val = input[i]
+
+        if val == val:
+            nobs += 1
+        output[i] = NaN
+
+    for i from minp - 1 <= i < N:
+        sum_x = 0 
+        val = input[i]
+
+        if i > w_n - 1:
+            prev = input[i - w_n]
+            if prev == prev:
+                nobs -= 1
+
+        if val == val:
+            nobs += 1
+
+        if nobs >= minp:
+            for j from 0 <= j < w_n:
+                t_val = input[i - j]
+                # Not the right way to go about handling NAs
+                # Do some sort of re-weighting?
+                if t_val == t_val:
+                    sum_x += weights[j] * t_val 
+            output[i] = sum_x 
+        else:
+            output[i] = NaN
+
+    return output
+
+
+
+
+#-------------------------------------------------------------------------------
 # Exponentially weighted moving average
 
 def ewma(ndarray[double_t] input, double_t com):

--- a/pandas/stats/moments.py
+++ b/pandas/stats/moments.py
@@ -372,6 +372,12 @@ def _use_window(minp, window):
     else:
         return minp
 
+def _use_weights(minp, weights):
+    if minp is None:
+        return len(weights)
+    else:
+        return minp
+
 def _rolling_func(func, desc, check_minp=_use_window):
     @Substitution(desc, _unary_arg, _type_of_input)
     @Appender(_doc_template)
@@ -390,6 +396,8 @@ rolling_min = _rolling_func(_tseries.roll_min, 'Moving minimum')
 rolling_sum = _rolling_func(_tseries.roll_sum, 'Moving sum')
 rolling_mean = _rolling_func(_tseries.roll_mean, 'Moving mean')
 rolling_median = _rolling_func(_tseries.roll_median_cython, 'Moving median')
+rolling_weighted_mean = _rolling_func(_tseries.weighted_mean,'Movinweighted',
+        check_minp = _use_weights)
 
 _ts_std = lambda *a, **kw: np.sqrt(_tseries.roll_var(*a, **kw))
 rolling_std = _rolling_func(_ts_std, 'Unbiased moving standard deviation',
@@ -400,6 +408,7 @@ rolling_skew = _rolling_func(_tseries.roll_skew, 'Unbiased moving skewness',
                              check_minp=_require_min_periods(3))
 rolling_kurt = _rolling_func(_tseries.roll_kurt, 'Unbiased moving kurtosis',
                              check_minp=_require_min_periods(4))
+
 
 def rolling_quantile(arg, window, quantile, min_periods=None, time_rule=None):
     """Moving quantile

--- a/pandas/stats/tests/test_moments.py
+++ b/pandas/stats/tests/test_moments.py
@@ -42,6 +42,12 @@ class TestMoments(unittest.TestCase):
     def test_rolling_mean(self):
         self._check_moment_func(mom.rolling_mean, np.mean)
 
+    def test_weighted_rolling_mean(self):
+        weights = np.array([0.4, 0.2, 0.2, 0.1, 0.1])
+        result = mom.rolling_weighted_mean(self.arr, weights)
+        assert_almost_equal(result[-1], np.dot(self.arr[-len(weights):],
+            weights[::-1]))
+
     def test_rolling_median(self):
         self._check_moment_func(mom.rolling_median, np.median)
 


### PR DESCRIPTION
My attempt at a weighted rolling average.  Doesn't force the weights to sum to 1.  If the min period is less than the length of the arrays, the nan value is skipped along with weighted value.  Should the weights be re-normed somehow?  
