### PR TITLE
Patched _safe_fetch to ensure a list of tuples is returned.

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -46,7 +46,7 @@ def execute(sql, con, retry=True, cur=None, params=None):
 
 def _safe_fetch(cur):
     try:
-        return cur.fetchall()
+        return [tuple(row) for row in cur]
     except Exception, e: # pragma: no cover
         excName = e.__class__.__name__
         if excName == 'OperationalError':


### PR DESCRIPTION
When MSSQL is used via pyodbc, Cursor.fetchall() returns a list of pyodbc.Row instances.  This just casts the rows as tuples so they don't give a TypeError in DataFrame.from_records.
