### PR TITLE
Added support for read_fwf() as in R.

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -688,9 +688,6 @@ class FixedWidthFieldParser(TextParser):
     """
     Specialization that Converts fixed-width fields into DataFrames.
     See TextParser for details.
-
-    Note: this class is hijacking the 'delimiter' attribute to store the list of
-    column specs.
     """
     def __init__(self, f, **kwds):
         # Support iterators, convert to a list.

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -720,23 +720,47 @@ bar"""
         assert_frame_equal(result, result2)
 
     def test_fwf(self):
-        data = """\
-2011 58   360.242940   149.910199   11950.7
-2011 59   444.953632   166.985655   11788.4
-2011 60   364.136849   183.628767   11806.2
-2011 61   413.836124   184.375703   11916.8
-2011 62   502.953953   173.237159   12468.3
-"""
-        data2 = """\
+        data_expected = """\
 2011,58,360.242940,149.910199,11950.7
 2011,59,444.953632,166.985655,11788.4
 2011,60,364.136849,183.628767,11806.2
 2011,61,413.836124,184.375703,11916.8
 2011,62,502.953953,173.237159,12468.3
 """
-        widths = [(0, 3), (5, 6), (8, 19), (21, 32), (34, 42)]
-        df = read_fwf(StringIO(data), widths)
-        expected = read_csv(StringIO(data2), header=None)
+        expected = read_csv(StringIO(data_expected), header=None)
+
+        data1 = """\
+201158    360.242940   149.910199   11950.7
+201159    444.953632   166.985655   11788.4
+201160    364.136849   183.628767   11806.2
+201161    413.836124   184.375703   11916.8
+201162    502.953953   173.237159   12468.3
+"""
+        colspecs = [(0, 4), (4, 8), (8, 20), (21, 33), (34, 43)]
+        df = read_fwf(StringIO(data1), colspecs=colspecs, header=None)
+        assert_frame_equal(df, expected)
+
+        data2 = """\
+2011 58   360.242940   149.910199   11950.7
+2011 59   444.953632   166.985655   11788.4
+2011 60   364.136849   183.628767   11806.2
+2011 61   413.836124   184.375703   11916.8
+2011 62   502.953953   173.237159   12468.3
+"""
+        df = read_fwf(StringIO(data2), widths=[5, 5, 13, 13, 7], header=None)
+        assert_frame_equal(df, expected)
+
+        # From Thomas Kluyver: apparently some non-space filler characters can
+        # be seen, this is supported by specifying the 'delimiter' character:
+        # http://publib.boulder.ibm.com/infocenter/dmndhelp/v6r1mx/index.jsp?topic=/com.ibm.wbit.612.help.config.doc/topics/rfixwidth.html
+        data3 = """\
+201158~~~~360.242940~~~149.910199~~~11950.7
+201159~~~~444.953632~~~166.985655~~~11788.4
+201160~~~~364.136849~~~183.628767~~~11806.2
+201161~~~~413.836124~~~184.375703~~~11916.8
+201162~~~~502.953953~~~173.237159~~~12468.3
+"""
+        df = read_fwf(StringIO(data3), colspecs=colspecs, delimiter='~', header=None)
         assert_frame_equal(df, expected)
 
 

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -18,7 +18,7 @@ from numpy import nan
 import numpy as np
 
 from pandas import DataFrame, Index, isnull
-from pandas.io.parsers import read_csv, read_table, ExcelFile, TextParser
+from pandas.io.parsers import read_csv, read_table, read_fwf, ExcelFile, TextParser
 from pandas.util.testing import assert_almost_equal, assert_frame_equal
 import pandas._tseries as lib
 from pandas.util import py3compat
@@ -718,6 +718,27 @@ bar"""
                                                   'days':convert_days_sentinel},
                                   na_values=[-1,'',None])
         assert_frame_equal(result, result2)
+
+    def test_fwf(self):
+        data = """\
+2011 58   360.242940   149.910199   11950.7
+2011 59   444.953632   166.985655   11788.4
+2011 60   364.136849   183.628767   11806.2
+2011 61   413.836124   184.375703   11916.8
+2011 62   502.953953   173.237159   12468.3
+"""
+        data2 = """\
+2011,58,360.242940,149.910199,11950.7
+2011,59,444.953632,166.985655,11788.4
+2011,60,364.136849,183.628767,11806.2
+2011,61,413.836124,184.375703,11916.8
+2011,62,502.953953,173.237159,12468.3
+"""
+        widths = [(0, 3), (5, 6), (8, 19), (21, 32), (34, 42)]
+        df = read_fwf(StringIO(data), widths)
+        expected = read_csv(StringIO(data2), header=None)
+        assert_frame_equal(df, expected)
+
 
 class TestParseSQL(unittest.TestCase):
 


### PR DESCRIPTION
I added a simple function like R's read_fwf().

It also made sense to refactor read_csv() and read_table() to redirect to a new function _read() which takes the parser's class as input. I needed this for the FixedWidthFieldParser which needs to override the TextParser in order to provide a custom reader for the fields. Please review; the tests pass.

Also, I made the column spec ("widths") 
- zero-based, and
- inclusive on both the from and to fields (e.g., a colspec of (1,2) has two characters)
  I'm not sure that's the best; I think in practice a lot of column format specs start counting at one, but I haven't done a survey or anything, feel free to change it.  Maybe we should support both.
