### PR TITLE
A way to get alternative percentiles into describe

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3403,11 +3403,17 @@ class DataFrame(NDFrame):
 
         return correl
 
-    def describe(self):
+    def describe(self, percentile_width=50):
         """
-        Generate various summary statistics of each column, excluding NaN
-        values. These include: count, mean, std, min, max, and 10%/50%/90%
-        quantiles
+        Generate various summary statistics of each column, excluding
+        NaN values. These include: count, mean, std, min, max, and
+        lower%/50%/upper% percentiles
+
+        Parameters
+        ----------
+        percentile_width : float, optional
+            width of the desired uncertainty interval, default is 50,
+            which corresponds to lower=25, upper=75
 
         Returns
         -------
@@ -3420,16 +3426,27 @@ class DataFrame(NDFrame):
                                   for k, v in self.iteritems()),
                                   columns=self.columns)
 
+        lb = .5 * (1. - percentile_width/100.)
+        ub = 1. - lb
+
+        def pretty_name(x):
+            x *= 100
+            if x == int(x):
+                return '%.0f%%' % x
+            else:
+                return '%.1f%%' % x
+
         destat_columns = ['count', 'mean', 'std', 'min',
-                          '25%', '50%', '75%', 'max']
+                          pretty_name(lb), '50%', pretty_name(ub),
+                          'max']
 
         destat = []
 
         for column in numdata.columns:
             series = self[column]
             destat.append([series.count(), series.mean(), series.std(),
-                           series.min(), series.quantile(.25), series.median(),
-                           series.quantile(.75), series.max()])
+                           series.min(), series.quantile(lb), series.median(),
+                           series.quantile(ub), series.max()])
 
         return self._constructor(map(list, zip(*destat)), index=destat_columns,
                                  columns=numdata.columns)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1223,11 +1223,17 @@ copy : boolean, default False
             return np.nan
         return scoreatpercentile(valid_values, q * 100)
 
-    def describe(self):
+    def describe(self, percentile_width=50):
         """
         Generate various summary statistics of Series, excluding NaN
-        values. These include: count, mean, std, min, max, and 10%/50%/90%
-        quantiles
+        values. These include: count, mean, std, min, max, and 
+        lower%/50%/upper% percentiles
+
+        Parameters
+        ----------
+        percentile_width : float, optional
+            width of the desired uncertainty interval, default is 50,
+            which corresponds to lower=25, upper=75
 
         Returns
         -------
@@ -1247,11 +1253,24 @@ copy : boolean, default False
             data = [self.count(), len(objcounts), top, freq]
 
         else:
+
+            lb = .5 * (1. - percentile_width/100.)
+            ub = 1. - lb
+
+
+            def pretty_name(x):
+                x *= 100
+                if x == int(x):
+                    return '%.0f%%' % x
+                else:
+                    return '%.1f%%' % x
+
             names = ['count', 'mean', 'std', 'min',
-                     '25%', '50%', '75%', 'max']
+                     pretty_name(lb), '50%', pretty_name(ub),
+                     'max']
 
             data = [self.count(), self.mean(), self.std(), self.min(),
-                    self.quantile(.25), self.median(), self.quantile(.75),
+                    self.quantile(lb), self.median(), self.quantile(ub),
                     self.max()]
 
         return Series(data, index=names)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4524,6 +4524,15 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         desc = self.mixed_frame.describe()
         desc = self.frame.describe()
 
+    def test_describe_percentiles(self):
+        desc = self.frame.describe(percentile_width=50)
+        assert '75%' in desc.index
+        assert '25%' in desc.index
+
+        desc = self.frame.describe(percentile_width=95)
+        assert '97.5%' in desc.index
+        assert '2.5%' in desc.index
+
     def test_describe_no_numeric(self):
         df = DataFrame({'A' : ['foo', 'foo', 'bar'] * 8,
                         'B' : ['a', 'b', 'c', 'd'] * 6})

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1022,6 +1022,15 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         _ = self.series.describe()
         _ = self.ts.describe()
 
+    def test_describe_percentiles(self):
+        desc = self.series.describe(percentile_width=50)
+        assert '75%' in desc.index
+        assert '25%' in desc.index
+
+        desc = self.series.describe(percentile_width=95)
+        assert '97.5%' in desc.index
+        assert '2.5%' in desc.index
+
     def test_describe_objects(self):
         s = Series(['a', 'b', 'b', np.nan, np.nan, np.nan, 'c', 'd', 'a', 'a'])
         result = s.describe()


### PR DESCRIPTION
Here is a small enhancement that adds a percentile_width parameter to the describe method of series and dataframes objects. I like to see 95% uncertainty intervals, so now I can say df.describe(95).
