### PR TITLE
Add an attach method to DataFrame

### DIFF
--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4955,6 +4955,41 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         exp = Y['g'].sum()
         self.assert_(isnull(Y['g']['c']))
 
+    def test_attach(self):
+        Y = DataFrame(np.random.random((4, 4)), index=('a', 'b','c','d'),
+                      columns=('e','f','g','h'))
+        #t his is just to fool nose
+        Y.attach(conflicts='ignore')
+        assert_series_equal(Y['e'], e)
+        assert_series_equal(Y['f'], f)
+        assert_series_equal(Y['g'], g)
+        assert_series_equal(Y['h'], h)
+
+    def test_attach_raises(self):
+        Y = DataFrame(np.random.random((4, 4)), index=('a', 'b','c','d'),
+                      columns=('e','f','g','h'))
+        e = 'I exist locally'
+        np.testing.assert_raises(AttributeError, Y.attach, conflicts='raises')
+
+    def test_attach_warns(self):
+        Y = DataFrame(np.random.random((4, 4)), index=('a', 'b','c','d'),
+                      columns=('e','f','g','h'))
+        e = 'I exist locally'
+        np.testing.assert_warns(Warning, Y.attach, conflicts='raises')
+
+    def test_attach_namespace(self):
+        Y = DataFrame(np.random.random((4, 4)), index=('a', 'b','c','d'),
+                      columns=('e','f','g','h'))
+        Y.attach(namespace='myspace')
+        assert_series_equal(Y['e'], myspace.e)
+        assert_series_equal(Y['f'], myspace.f)
+        assert_series_equal(Y['g'], mypsace.g)
+        assert_series_equal(Y['h'], myspace.h)
+
+
+
+
+
 
 if __name__ == '__main__':
     # unittest.main()

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4958,7 +4958,6 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
     def test_attach(self):
         Y = DataFrame(np.random.random((4, 4)), index=('a', 'b','c','d'),
                       columns=('e','f','g','h'))
-        #t his is just to fool nose
         Y.attach(conflicts='ignore')
         assert_series_equal(Y['e'], e)
         assert_series_equal(Y['f'], f)
@@ -4969,13 +4968,13 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         Y = DataFrame(np.random.random((4, 4)), index=('a', 'b','c','d'),
                       columns=('e','f','g','h'))
         e = 'I exist locally'
-        np.testing.assert_raises(AttributeError, Y.attach, conflicts='raises')
+        np.testing.assert_raises(AttributeError, Y.attach, conflicts='raise')
 
     def test_attach_warns(self):
         Y = DataFrame(np.random.random((4, 4)), index=('a', 'b','c','d'),
                       columns=('e','f','g','h'))
         e = 'I exist locally'
-        np.testing.assert_warns(Warning, Y.attach, conflicts='raises')
+        np.testing.assert_warns(Warning, Y.attach, conflicts='warn')
 
     def test_attach_namespace(self):
         Y = DataFrame(np.random.random((4, 4)), index=('a', 'b','c','d'),


### PR DESCRIPTION
This is a method that injects the columns of a DataFrame into the calling namespace. As far as I can tell it works, even if it is hackish. However, the nosetests do not like the trickery and throw errors and failures. But, if you do

nosetests test_frame.py --pdb --pdb-failure

You can indeed see that the tests will pass from inside the debugger. I'm not really sure why. Does anyone have any ideas?

Am I missing anything about injecting variables into the calling local variables of the calling frame? I'm sure this is bad form, but it's functionality I've missed in Python.

Am I safe in assuming that column names are valid python variable names? If not, I may need to use a name validator.
