### PR TITLE
ENH: assure elements of list are of base dict class while converting list of dicts to a DataFrame

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4297,6 +4297,11 @@ def _list_of_dict_to_sdict(data, columns, coerce_float=False):
         gen = (x.keys() for x in data)
         columns = lib.fast_unique_multiple_list_gen(gen)
 
+    # assure that they are of the base dict class and not of derived
+    # classes
+    data = [(type(d) is dict) and d or dict(d)
+            for d in data]
+
     content = list(lib.dicts_to_array(data, list(columns)).T)
     return _convert_object_array(content, columns,
                                  coerce_float=coerce_float)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1592,6 +1592,18 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         expected = DataFrame.from_dict(sdict, orient='index')
         assert_frame_equal(result, expected)
 
+    def test_constructor_list_of_derived_dicts(self):
+        class CustomDict(dict):
+            pass
+        d = {'a': 1.5, 'b': 3}
+
+        data_custom = [CustomDict(d)]
+        data = [d]
+
+        result_custom = DataFrame(data_custom)
+        result = DataFrame(data)
+        assert_frame_equal(result, result_custom)
+
     def test_constructor_ragged(self):
         data = {'A' : randn(10),
                 'B' : randn(8)}


### PR DESCRIPTION
There might be a better  and more generic solution for this -- I just didn't know it and didn't want just to file yet another bug report ;)

Cheers
