### PR TITLE
BUG: Don't mutate DataFrame.from_records columns

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -678,6 +678,10 @@ class DataFrame(NDFrame):
         """
         import warnings
 
+        # Make a copy of the input columns so we can modify it
+        if columns is not None:
+            columns = list(columns)
+
         if names is not None:  # pragma: no cover
             columns = names
             warnings.warn("'names' parameter to DataFrame.from_records is "

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1798,6 +1798,16 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         df = DataFrame.from_records(tuples, columns=['a', 'b', 'c', 'd'])
         self.assert_(np.isnan(df['c'][0]))
 
+    def test_from_records_columns_not_modified(self):
+        tuples = [(1, 2, 3),
+                  (1, 2, 3),
+                  (2, 5, 3)]
+
+        columns = ['a', 'b', 'c']
+        original_columns = list(columns)
+        df = DataFrame.from_records(tuples, columns=columns, index='a')
+        self.assertEqual(columns, original_columns)
+
     def test_from_records_decimal(self):
         from decimal import Decimal
 


### PR DESCRIPTION
This also lets you use non-list types for the columns.
