### PR TITLE
Timeseries

### DIFF
--- a/pandas/core/daterange.py
+++ b/pandas/core/daterange.py
@@ -81,3 +81,8 @@ def bdate_range(start=None, end=None, periods=None, freq='B', tz=None):
 
     return DatetimeIndex(start=start, end=end, periods=periods,
                          freq=freq, tz=tz)
+
+def interval_range():
+    """
+    Return a fixed frequency interval index
+    """

--- a/pandas/core/datetools.py
+++ b/pandas/core/datetools.py
@@ -65,7 +65,6 @@ def _str_to_dt_array(arr):
     data = p_ufunc(arr)
     return np.array(data, dtype='M8[us]')
 
-
 def to_datetime(arg):
     """Attempts to convert arg to datetime"""
     if arg is None:
@@ -695,6 +694,9 @@ def _interval_group(freqstr):
     return base // 1000 * 1000
 
 def _get_freq_code(freqstr):
+    if isinstance(freqstr, DateOffset):
+        freqstr = (getOffsetName(freqstr), freqstr.n)
+
     if isinstance(freqstr, tuple):
         if (isinstance(freqstr[0], (int, long)) and
             isinstance(freqstr[1], (int, long))):
@@ -737,11 +739,34 @@ def _get_freq_str(base, mult):
     code = _reverse_interval_code_map.get(base)
     if code is None:
         return _unknown_freq
+    if mult == 1:
+        return code
     return str(mult) + code
 
 _gfs = _get_freq_str
 
 _unknown_freq = 'Unknown'
+
+def get_standard_freq(freq):
+    """
+    Return the standardized frequency string
+    """
+    if freq is None:
+        return None
+
+    if isinstance(freq, basestring):
+        try:
+            freq = to_offset(freq)
+        except:
+            pass
+
+    if isinstance(freq, DateOffset):
+        if freq.n == 1:
+            return getOffsetName(freq)
+        return str(freq.n) + getOffsetName(freq)
+
+    code, stride = _get_freq_code(freq)
+    return _get_freq_str(code, stride)
 
 
 #-------------------------------------------------------------------------------

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -2087,12 +2087,7 @@ class IntervalIndex(Int64Index):
         return subarr
 
     def resample(self, freq=None, how='E'):
-        how_dict = {'S': 'S', 'E': 'E',
-                    'START': 'S', 'FINISH': 'E',
-                    'BEGIN': 'S', 'END': 'E'}
-        how = how_dict.get(str(how).upper())
-        if how not in set(['S', 'E']):
-            raise ValueError('How must be one of S or E')
+        how = datetools.validate_end_alias(how)
 
         base1, mult1 = datetools._get_freq_code(self.freq)
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -326,9 +326,9 @@ class Index(np.ndarray):
             zero_time = time(0, 0)
             result = []
             for dt in self:
-                if dt.time() != zero_time or dt.tzinfo is not None:
+                if dt.time() != zero_time or datetools.tzinfo is not None:
                     return header + ['%s' % x for x in self]
-                result.append(dt.strftime("%Y-%m-%d"))
+                result.append(datetools.strftime("%Y-%m-%d"))
             return header + result
 
         values = self.values
@@ -1211,6 +1211,9 @@ class DatetimeIndex(Int64Index):
             freq = kwds['offset']
             warn = True
 
+        if not isinstance(freq, datetools.DateOffset):
+            freq = datetools.get_standard_freq(freq)
+
         if warn:
             import warnings
             warnings.warn("parameter 'offset' is deprecated, "
@@ -1978,10 +1981,7 @@ class IntervalIndex(Int64Index):
                 freq=None, start=None, end=None, periods=None,
                 copy=False, name=None):
 
-        if isinstance(freq, basestring):
-            freq = freq.upper()
-        elif isinstance(freq, (int, long)):
-            freq = datetools._reverse_interval_code_map[freq]
+        freq = datetools.get_standard_freq(freq)
 
         if data is None:
             if start is None and end is None:
@@ -2064,9 +2064,6 @@ class IntervalIndex(Int64Index):
             else:
                 if freq is None:
                     raise ValueError('freq cannot be none')
-
-                if isinstance(freq, datetools.DateOffset):
-                    freq = datetools.getOffsetName(freq)
 
                 if data.dtype == np.datetime64:
                     data = datetools.dt64arr_to_sktsarr(data, freq)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1420,6 +1420,24 @@ class DatetimeIndex(Int64Index):
             self.offset = own_state[1]
             self.tz = own_state[2]
             np.ndarray.__setstate__(self, nd_state)
+        elif len(state) == 3:
+            # legacy format: daterange
+            offset = state[1]
+
+            if len(state) > 2:
+                tzinfo = state[2]
+            else: # pragma: no cover
+                tzinfo = None
+
+            self.offset = offset
+            self.tzinfo = tzinfo
+
+            # extract the raw datetime data, turn into datetime64
+            index_state = state[0]
+            raw_data = index_state[0][4]
+            raw_data = np.array(raw_data, dtype='M8[us]')
+            new_state = raw_data.__reduce__()
+            np.ndarray.__setstate__(self, new_state[2])
         else:  # pragma: no cover
             np.ndarray.__setstate__(self, state)
 
@@ -1960,29 +1978,49 @@ class IntervalIndex(Int64Index):
                 freq=None, start=None, end=None, periods=None,
                 copy=False, name=None):
 
-        if data is None and freq is None:
-            raise ValueError("Must provide freq argument if no data is "
-                             "supplied")
-
         if isinstance(freq, basestring):
             freq = freq.upper()
         elif isinstance(freq, (int, long)):
             freq = datetools._reverse_interval_code_map[freq]
 
         if data is None:
+            if start is None and end is None:
+                raise ValueError('Must specify start, end, or data')
+
             start = to_interval(start, freq)
             end = to_interval(end, freq)
 
-            if (start is not None and not isinstance(start, Interval)):
+            is_start_intv = isinstance(start, Interval)
+            is_end_intv = isinstance(end, Interval)
+            if (start is not None and not is_start_intv):
                 raise ValueError('Failed to convert %s to interval' % start)
 
-            if (end is not None and not isinstance(end, Interval)):
+            if (end is not None and not is_end_intv):
                 raise ValueError('Failed to convert %s to interval' % end)
 
+            if is_start_intv and is_end_intv and (start.freq != end.freq):
+                raise ValueError('Start and end must have same freq')
+
+            if freq is None:
+                if is_start_intv:
+                    freq = start.freq
+                elif is_end_intv:
+                    freq = end.freq
+                else:
+                    raise ValueError('Could not infer freq from start/end')
+
             if periods is not None:
-                data = np.arange(start.ordinal, start.ordinal + periods,
-                                 dtype=np.int64)
+                if start is None:
+                    data = np.arange(end.ordinal - periods + 1,
+                                     end.ordinal + 1,
+                                     dtype=np.int64)
+                else:
+                    data = np.arange(start.ordinal, start.ordinal + periods,
+                                     dtype=np.int64)
             else:
+                if start is None or end is None:
+                    msg = 'Must specify both start and end if periods is None'
+                    raise ValueError(msg)
                 data = np.arange(start.ordinal, end.ordinal+1, dtype=np.int64)
 
             subarr = data.view(cls)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -326,9 +326,9 @@ class Index(np.ndarray):
             zero_time = time(0, 0)
             result = []
             for dt in self:
-                if dt.time() != zero_time or datetools.tzinfo is not None:
+                if dt.time() != zero_time or dt.tzinfo is not None:
                     return header + ['%s' % x for x in self]
-                result.append(datetools.strftime("%Y-%m-%d"))
+                result.append(dt.strftime("%Y-%m-%d"))
             return header + result
 
         values = self.values
@@ -1212,7 +1212,7 @@ class DatetimeIndex(Int64Index):
             warn = True
 
         if not isinstance(freq, datetools.DateOffset):
-            freq = datetools.get_standard_freq(freq)
+            freq = datetools.to_offset(freq)
 
         if warn:
             import warnings
@@ -1981,7 +1981,10 @@ class IntervalIndex(Int64Index):
                 freq=None, start=None, end=None, periods=None,
                 copy=False, name=None):
 
-        freq = datetools.get_standard_freq(freq)
+        if isinstance(freq, Interval):
+            freq = freq.freq
+        else:
+            freq = datetools.get_standard_freq(freq)
 
         if data is None:
             if start is None and end is None:
@@ -2088,7 +2091,7 @@ class IntervalIndex(Int64Index):
                     'START': 'S', 'FINISH': 'E',
                     'BEGIN': 'S', 'END': 'E'}
         how = how_dict.get(str(how).upper())
-        if how not in set('S', 'E'):
+        if how not in set(['S', 'E']):
             raise ValueError('How must be one of S or E')
 
         base1, mult1 = datetools._get_freq_code(self.freq)
@@ -2098,9 +2101,10 @@ class IntervalIndex(Int64Index):
         else:
             base2, mult2 = freq
 
+
         new_data = lib.skts_resample_arr(self.values,
                                          base1, mult1,
-                                         base2, mult2, how.upper())
+                                         base2, mult2, how)
 
         return IntervalIndex(new_data, freq=freq)
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -2084,7 +2084,11 @@ class IntervalIndex(Int64Index):
         return subarr
 
     def resample(self, freq=None, how='E'):
-        if how not in ('S', 'E'):
+        how_dict = {'S': 'S', 'E': 'E',
+                    'START': 'S', 'FINISH': 'E',
+                    'BEGIN': 'S', 'END': 'E'}
+        how = how_dict.get(str(how).upper())
+        if how not in set('S', 'E'):
             raise ValueError('How must be one of S or E')
 
         base1, mult1 = datetools._get_freq_code(self.freq)
@@ -2096,7 +2100,7 @@ class IntervalIndex(Int64Index):
 
         new_data = lib.skts_resample_arr(self.values,
                                          base1, mult1,
-                                         base2, mult2, how)
+                                         base2, mult2, how.upper())
 
         return IntervalIndex(new_data, freq=freq)
 

--- a/pandas/tests/test_datetime64.py
+++ b/pandas/tests/test_datetime64.py
@@ -3,10 +3,9 @@ from datetime import datetime
 
 import cPickle as pickle
 
-from pandas.core.index import DatetimeIndex, Index
+import pandas.core.datetools as dt
+from pandas.core.index import Index, DatetimeIndex, Int64Index
 from pandas.core.frame import DataFrame
-
-from pandas.core.index import Int64Index
 
 import unittest
 import numpy as np
@@ -550,6 +549,19 @@ class TestDatetime64(unittest.TestCase):
 
         for other in [idx2, idx3, idx4, idx5, idx6]:
             self.assert_( (idx1.values == other.values).all() )
+
+        sdate = datetime(1999, 12, 25)
+        edate = datetime(2000, 1, 1)
+        idx = DatetimeIndex(start=sdate, freq='B', periods=20)
+        self.assertEquals(len(idx), 20)
+        self.assertEquals(idx[0], sdate + 0 * dt.bday)
+
+        idx = DatetimeIndex(end=edate, freq='D', periods=20)
+        self.assertEquals(len(idx), 20)
+        self.assertEquals(idx[-1], edate)
+
+        idx1 = DatetimeIndex(start=sdate, end=edate, freq='W')
+
 
     def test_dti_slicing(self):
         dti = DatetimeIndex(start='1/1/2005', end='12/1/2005', freq='M')

--- a/pandas/tests/test_datetime64.py
+++ b/pandas/tests/test_datetime64.py
@@ -552,15 +552,21 @@ class TestDatetime64(unittest.TestCase):
 
         sdate = datetime(1999, 12, 25)
         edate = datetime(2000, 1, 1)
-        idx = DatetimeIndex(start=sdate, freq='B', periods=20)
+        idx = DatetimeIndex(start=sdate, freq='1B', periods=20)
         self.assertEquals(len(idx), 20)
         self.assertEquals(idx[0], sdate + 0 * dt.bday)
+        self.assertEquals(idx.freq, 'B')
 
-        idx = DatetimeIndex(end=edate, freq='D', periods=20)
+        idx = DatetimeIndex(end=edate, freq=('D', 5), periods=20)
         self.assertEquals(len(idx), 20)
         self.assertEquals(idx[-1], edate)
+        self.assertEquals(idx.freq, '5D')
 
         idx1 = DatetimeIndex(start=sdate, end=edate, freq='W')
+        idx2 = DatetimeIndex(start=sdate, end=edate,
+                             freq=dt.Week(weekday=6))
+        self.assertEquals(len(idx1), len(idx2))
+        self.assertEquals(idx1.offset, idx2.offset)
 
 
     def test_dti_slicing(self):

--- a/pandas/tests/test_datetools.py
+++ b/pandas/tests/test_datetools.py
@@ -8,7 +8,7 @@ from pandas.core.datetools import (
     DateOffset, Week, YearBegin, YearEnd, Hour, Minute, Second,
     WeekOfMonth, format, ole2datetime, QuarterEnd, to_datetime, normalize_date,
     getOffset, getOffsetName, inferTimeRule, hasOffsetName,
-    _dt_box, _dt_unbox)
+    _dt_box, _dt_unbox, parse_time_string)
 
 from nose.tools import assert_raises
 
@@ -1281,13 +1281,22 @@ def test_getOffset():
     assert_raises(Exception, getOffset, 'gibberish')
 
     assert getOffset('WEEKDAY') == BDay()
+    assert getOffset('weEkDaY') == BDay()
     assert getOffset('EOM') == BMonthEnd()
+    assert getOffset('eOM') == BMonthEnd()
     assert getOffset('W@MON') == Week(weekday=0)
     assert getOffset('W@TUE') == Week(weekday=1)
     assert getOffset('W@WED') == Week(weekday=2)
     assert getOffset('W@THU') == Week(weekday=3)
     assert getOffset('W@FRI') == Week(weekday=4)
+    assert getOffset('w@Sat') == Week(weekday=5)
 
+def test_parse_time_string():
+    (date, parsed, reso) = parse_time_string('4Q1984')
+    (date_lower, parsed_lower, reso_lower) = parse_time_string('4q1984')
+    assert date == date_lower
+    assert parsed == parsed_lower
+    assert reso == reso_lower
 
 if __name__ == '__main__':
     import nose

--- a/pandas/tests/test_datetools.py
+++ b/pandas/tests/test_datetools.py
@@ -8,7 +8,8 @@ from pandas.core.datetools import (
     DateOffset, Week, YearBegin, YearEnd, Hour, Minute, Second,
     WeekOfMonth, format, ole2datetime, QuarterEnd, to_datetime, normalize_date,
     getOffset, getOffsetName, inferTimeRule, hasOffsetName,
-    _dt_box, _dt_unbox, parse_time_string, get_standard_freq)
+    _dt_box, _dt_unbox, parse_time_string, get_standard_freq,
+    _offset_map)
 
 from nose.tools import assert_raises
 
@@ -1309,6 +1310,30 @@ def test_get_standard_freq():
     assert fstr == get_standard_freq('5q')
     assert fstr == get_standard_freq('5QuarTer')
     assert fstr == get_standard_freq(('q', 5))
+
+def test_rule_code():
+    lst = ['M', 'MS', 'BM', 'BMS', 'D', 'B', 'H', 'Min', 'S', 'L', 'U']
+    for k in lst:
+        assert k == _offset_map[k].rule_code()
+        assert k == (_offset_map[k] * 3).rule_code()
+
+    suffix_lst = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
+    base = 'W'
+    for v in suffix_lst:
+        alias = '@'.join([base, v])
+        assert alias == _offset_map[alias].rule_code()
+        assert alias == (_offset_map[alias] * 5).rule_code()
+
+    suffix_lst = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG',
+                  'SEP', 'OCT', 'NOV', 'DEC']
+    base_lst = ['A', 'AS', 'BA', 'BAS', 'Q', 'QS', 'BQ', 'BQS']
+    for base in base_lst:
+        for v in suffix_lst:
+            alias = '@'.join([base, v])
+            assert alias == _offset_map[alias].rule_code()
+            assert alias == (_offset_map[alias] * 5).rule_code()
+
+
 
 
 if __name__ == '__main__':

--- a/pandas/tests/test_datetools.py
+++ b/pandas/tests/test_datetools.py
@@ -8,7 +8,7 @@ from pandas.core.datetools import (
     DateOffset, Week, YearBegin, YearEnd, Hour, Minute, Second,
     WeekOfMonth, format, ole2datetime, QuarterEnd, to_datetime, normalize_date,
     getOffset, getOffsetName, inferTimeRule, hasOffsetName,
-    _dt_box, _dt_unbox, parse_time_string)
+    _dt_box, _dt_unbox, parse_time_string, get_standard_freq)
 
 from nose.tools import assert_raises
 
@@ -1297,6 +1297,18 @@ def test_parse_time_string():
     assert date == date_lower
     assert parsed == parsed_lower
     assert reso == reso_lower
+
+def test_get_standard_freq():
+    fstr = get_standard_freq('W')
+    assert fstr == get_standard_freq('w')
+    assert fstr == get_standard_freq('1w')
+    assert fstr == get_standard_freq(('W', 1))
+    assert fstr == get_standard_freq('WeEk')
+
+    fstr = get_standard_freq('5Q')
+    assert fstr == get_standard_freq('5q')
+    assert fstr == get_standard_freq('5QuarTer')
+    assert fstr == get_standard_freq(('q', 5))
 
 if __name__ == '__main__':
     import nose

--- a/pandas/tests/test_datetools.py
+++ b/pandas/tests/test_datetools.py
@@ -1310,6 +1310,7 @@ def test_get_standard_freq():
     assert fstr == get_standard_freq('5QuarTer')
     assert fstr == get_standard_freq(('q', 5))
 
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=[__file__,'-vvs','-x','--pdb', '--pdb-failure'],

--- a/pandas/tests/test_interval.py
+++ b/pandas/tests/test_interval.py
@@ -109,6 +109,13 @@ class TestIntervalProperties(TestCase):
         i2 = Interval('1982', freq=('Min', 1))
         self.assertEquals(i1, i2)
 
+    def test_freq_str(self):
+        i1 = Interval('1982', freq='Min')
+        self.assert_(i1.freq[0] != '1')
+
+        i2 = Interval('11/30/2005', freq='2Q')
+        self.assertEquals(i2.freq[0], '2')
+
     def test_to_timestamp(self):
         intv = Interval('1982', freq='A')
         start_ts = intv.to_timestamp(which_end='S')

--- a/pandas/tests/test_interval.py
+++ b/pandas/tests/test_interval.py
@@ -908,10 +908,10 @@ class TestIntervalIndex(TestCase):
         ii7 = IntervalIndex(freq='S', start='1/1/2001', end='1/1/2001 00:00:00')
 
         self.assertEquals(ii1.resample('Q', 'S'), ii2)
-        self.assertEquals(ii1.resample('Q', 'S'), ii2)
-        self.assertEquals(ii1.resample('M', 'S'), ii3)
-        self.assertEquals(ii1.resample('D', 'S'), ii4)
-        self.assertEquals(ii1.resample('H', 'S'), ii5)
+        self.assertEquals(ii1.resample('Q', 's'), ii2)
+        self.assertEquals(ii1.resample('M', 'start'), ii3)
+        self.assertEquals(ii1.resample('D', 'StarT'), ii4)
+        self.assertEquals(ii1.resample('H', 'beGIN'), ii5)
         self.assertEquals(ii1.resample('Min', 'S'), ii6)
         self.assertEquals(ii1.resample('S', 'S'), ii7)
 
@@ -956,6 +956,8 @@ class TestIntervalIndex(TestCase):
         self.assertEquals(ii7.resample('D', 'S'), ii4)
         self.assertEquals(ii7.resample('H', 'S'), ii5)
         self.assertEquals(ii7.resample('Min', 'S'), ii6)
+
+        #self.assertEquals(ii7.resample('A', 'E'), i_end)
 
     def test_badinput(self):
         self.assertRaises(datetools.DateParseError, Interval, '1/1/-2000', 'A')

--- a/pandas/tests/test_interval.py
+++ b/pandas/tests/test_interval.py
@@ -109,6 +109,30 @@ class TestIntervalProperties(TestCase):
         i2 = Interval('1982', freq=('Min', 1))
         self.assertEquals(i1, i2)
 
+    def test_to_timestamp(self):
+        intv = Interval('1982', freq='A')
+        start_ts = intv.to_timestamp(which_end='S')
+        aliases = ['s', 'StarT', 'BEGIn']
+        for a in aliases:
+            self.assertEquals(start_ts, intv.to_timestamp(which_end=a))
+
+        end_ts = intv.to_timestamp(which_end='E')
+        aliases = ['e', 'end', 'FINIsH']
+        for a in aliases:
+            self.assertEquals(end_ts, intv.to_timestamp(which_end=a))
+
+        from_lst = ['A', 'Q', 'M', 'W', 'B',
+                    'D', 'H', 'Min', 'S']
+        for i, fcode in enumerate(from_lst):
+            intv = Interval('1982', freq=fcode)
+            result = intv.to_timestamp().to_interval(fcode)
+            self.assertEquals(result, intv)
+
+            self.assertEquals(intv.start_time(), intv.to_timestamp('S'))
+
+            self.assertEquals(intv.end_time(), intv.to_timestamp('E'))
+
+
     def test_properties_annually(self):
         # Test properties on Intervals with annually frequency.
         a_date = Interval(freq='A', year=2007)

--- a/pandas/tests/test_interval.py
+++ b/pandas/tests/test_interval.py
@@ -840,7 +840,7 @@ class TestIntervalIndex(TestCase):
         assert_equal(i1.freq, end_intv.freq)
         assert_equal(i1[-1], end_intv)
 
-        end_intv = Interval('2006-12-31', 'w')
+        end_intv = Interval('2006-12-31', '1w')
         i2 = IntervalIndex(end=end_intv, periods=10)
         assert_equal(len(i1), len(i2))
         self.assert_((i1 == i2).all())

--- a/pandas/tests/test_timeseries.py
+++ b/pandas/tests/test_timeseries.py
@@ -48,6 +48,7 @@ class TestTimeSeriesDuplicates(unittest.TestCase):
         uniques = self.dups.index.unique()
         self.assert_(uniques.dtype == 'M8') # sanity
 
+
     def test_duplicate_dates_indexing(self):
         ts = self.dups
 


### PR DESCRIPTION
IntervalIndex constructor now allows you to omit freq argument if interval start/end is passed
Handle lower case time rules. 
Parsing tuples e.g., ('Min', 5) as freq
Interval supports aliasing for frequency names
