### PR TITLE
BUG: Allow indexing with namedtuple, close #1026

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -24,7 +24,7 @@ class _NDFrameIndexer(object):
         raise NotImplementedError('ix is not iterable')
 
     def __getitem__(self, key):
-        if isinstance(key, tuple):
+        if type(key) is tuple:
             try:
                 return self.obj.get_value(*key)
             except Exception:

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5114,6 +5114,15 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         exp = Y['g'].sum()
         self.assert_(isnull(Y['g']['c']))
 
+    def test_index_namedtuple(self):
+        from collections import namedtuple
+        IndexType = namedtuple("IndexType", ["a", "b"])
+        idx1 = IndexType("foo", "bar")
+        idx2 = IndexType("baz", "bof")
+        index = Index([idx1, idx2], name="composite_index")
+        df = DataFrame([(1, 2), (3, 4)], index=index, columns=["A", "B"])
+        self.assertEqual(df.ix[IndexType("foo", "bar")], (1, 2))
+
 if __name__ == '__main__':
     # unittest.main()
     import nose


### PR DESCRIPTION
This patch allow indexing with namedtuple and other tuple subclasses while retaining the comma-separated **getitem** functionality.
