### PR TITLE
BUG: work around missing NPY_FR_B in numpy 1.7

### DIFF
--- a/pandas/src/np_datetime_strings.c
+++ b/pandas/src/np_datetime_strings.c
@@ -926,30 +926,43 @@ get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base)
         /*    return 4;*/
         case NPY_FR_as:
             len += 3;  /* "###" */
+            break;
         case NPY_FR_fs:
             len += 3;  /* "###" */
+            break;
         case NPY_FR_ps:
             len += 3;  /* "###" */
+            break;
         case NPY_FR_ns:
             len += 3;  /* "###" */
+            break;
         case NPY_FR_us:
             len += 3;  /* "###" */
+            break;
         case NPY_FR_ms:
             len += 4;  /* ".###" */
+            break;
         case NPY_FR_s:
             len += 3;  /* ":##" */
+            break;
         case NPY_FR_m:
             len += 3;  /* ":##" */
+            break;
         case NPY_FR_h:
             len += 3;  /* "T##" */
+            break;
         case NPY_FR_D:
-        case NPY_FR_B:
         case NPY_FR_W:
             len += 3;  /* "-##" */
+            break;
         case NPY_FR_M:
             len += 3;  /* "-##" */
+            break;
         case NPY_FR_Y:
             len += 21; /* 64-bit year */
+            break;
+        default:
+            len += 3; /* handle the now defunct NPY_FR_B */
             break;
     }
 


### PR DESCRIPTION
This is one potential work-around for the missing NPY_FR_B enum definition in numpy 1.7.  Maybe there's a cleaner work-around, but this fixes the compilation problem for now.
