### PR TITLE
Datetime tweaks to improve numpy 1.6/1.7 datetime64 compatibility

### DIFF
--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1013,7 +1013,7 @@ def form_blocks(data, axes):
         blocks.append(int_block)
 
     if len(datetime_dict):
-        datetime_block = _simple_blockify(datetime_dict, items, np.datetime64)
+        datetime_block = _simple_blockify(datetime_dict, items, np.dtype('M8[ms]'))
         blocks.append(datetime_block)
 
     if len(bool_dict):

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1013,7 +1013,7 @@ def form_blocks(data, axes):
         blocks.append(int_block)
 
     if len(datetime_dict):
-        datetime_block = _simple_blockify(datetime_dict, items, np.dtype('M8[ms]'))
+        datetime_block = _simple_blockify(datetime_dict, items, np.dtype('M8[us]'))
         blocks.append(datetime_block)
 
     if len(bool_dict):

--- a/pandas/src/datetime.pxd
+++ b/pandas/src/datetime.pxd
@@ -35,39 +35,12 @@ cdef extern from "numpy/ndarrayobject.h":
     ctypedef int64_t npy_timedelta
     ctypedef int64_t npy_datetime
 
-    ctypedef struct npy_datetimestruct:
-        int64_t year
-        int month, day, hour, min, sec, us, ps, as
-
-    ctypedef enum NPY_DATETIMEUNIT:
-        #NPY_FR_Y
-        #NPY_FR_M
-        #NPY_FR_W
-        #NPY_FR_B
-        #NPY_FR_D
-        #NPY_FR_h
-        #NPY_FR_m
-        #NPY_FR_s
-        #NPY_FR_ms
-        NPY_FR_us
-        #NPY_FR_ns
-        #NPY_FR_ps
-        #NPY_FR_fs
-        #NPY_FR_as
-
     ctypedef enum NPY_CASTING:
             NPY_NO_CASTING
             NPY_EQUIV_CASTING
             NPY_SAFE_CASTING
             NPY_SAME_KIND_CASTING
             NPY_UNSAFE_CASTING
-
-    npy_datetime PyArray_DatetimeStructToDatetime(NPY_DATETIMEUNIT fr,
-                                                  npy_datetimestruct *d)
-
-    void PyArray_DatetimeToDatetimeStruct(npy_datetime val,
-                                          NPY_DATETIMEUNIT fr,
-                                          npy_datetimestruct *result)
 
 cdef extern from "numpy_helper.h":
     npy_datetime unbox_datetime64_scalar(object o)
@@ -78,9 +51,32 @@ cdef extern from "numpy/npy_common.h":
 
 cdef extern from "np_datetime.h":
 
-    int convert_pydatetime_to_datetimestruct(PyObject *obj, npy_datetimestruct *out,
-                                             NPY_DATETIMEUNIT *out_bestunit,
+    ctypedef enum PANDAS_DATETIMEUNIT:
+        PANDAS_FR_Y
+        PANDAS_FR_M
+        PANDAS_FR_W
+        PANDAS_FR_D
+        PANDAS_FR_B
+        PANDAS_FR_h
+        PANDAS_FR_m
+        PANDAS_FR_s
+        PANDAS_FR_ms
+        PANDAS_FR_us
+        PANDAS_FR_ns
+        PANDAS_FR_ps
+        PANDAS_FR_fs
+        PANDAS_FR_as
+
+    ctypedef struct pandas_datetimestruct:
+        int64_t year
+        int month, day, hour, min, sec, us, ps, as
+
+    int convert_pydatetime_to_datetimestruct(PyObject *obj, pandas_datetimestruct *out,
+                                             PANDAS_DATETIMEUNIT *out_bestunit,
                                              int apply_tzinfo)
+
+    npy_datetime pandas_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT fr, pandas_datetimestruct *d)
+    void pandas_datetime_to_datetimestruct(npy_datetime val, PANDAS_DATETIMEUNIT fr, pandas_datetimestruct *result)
     int _days_per_month_table[2][12]
 
     int dayofweek(int y, int m, int d)
@@ -88,18 +84,18 @@ cdef extern from "np_datetime.h":
 
 cdef extern from "np_datetime_strings.h":
 
-    int parse_iso_8601_datetime(char *str, int len, NPY_DATETIMEUNIT unit,
-                                NPY_CASTING casting, npy_datetimestruct *out,
-                                npy_bool *out_local, NPY_DATETIMEUNIT *out_bestunit,
+    int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
+                                NPY_CASTING casting, pandas_datetimestruct *out,
+                                npy_bool *out_local, PANDAS_DATETIMEUNIT *out_bestunit,
                                 npy_bool *out_special)
 
-    int make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
-                               int local, NPY_DATETIMEUNIT base, int tzoffset,
+    int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
+                               int local, PANDAS_DATETIMEUNIT base, int tzoffset,
                                NPY_CASTING casting)
 
-    int get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base)
+    int get_datetime_iso_8601_strlen(int local, PANDAS_DATETIMEUNIT base)
 
-    # int parse_python_string(object obj, npy_datetimestruct *out) except -1
+    # int parse_python_string(object obj, pandas_datetimestruct *out) except -1
 
 cdef extern from "period.h":
     ctypedef struct date_info:

--- a/pandas/src/datetime.pyx
+++ b/pandas/src/datetime.pyx
@@ -12,9 +12,12 @@ from util cimport is_integer_object, is_datetime64_object
 from dateutil.parser import parse as parse_date
 cimport util
 
+from khash cimport *
+import cython
+
 # initialize numpy
 import_array()
-import_ufunc()
+#import_ufunc()
 
 # import datetime C API
 PyDateTime_IMPORT
@@ -219,7 +222,7 @@ cdef class _Timestamp(datetime):
 # lightweight C object to hold datetime & int64 pair
 cdef class _TSObject:
     cdef:
-        npy_datetimestruct dts      # npy_datetimestruct
+        pandas_datetimestruct dts      # pandas_datetimestruct
         int64_t value               # numpy dt64
         object tzinfo
 
@@ -246,13 +249,13 @@ cpdef convert_to_tsobject(object ts, object tz=None):
 
     if is_datetime64_object(ts):
         obj.value = unbox_datetime64_scalar(ts)
-        PyArray_DatetimeToDatetimeStruct(obj.value, NPY_FR_us, &obj.dts)
+        pandas_datetime_to_datetimestruct(obj.value, PANDAS_FR_us, &obj.dts)
     elif is_integer_object(ts):
         obj.value = ts
-        PyArray_DatetimeToDatetimeStruct(ts, NPY_FR_us, &obj.dts)
+        pandas_datetime_to_datetimestruct(ts, PANDAS_FR_us, &obj.dts)
     elif util.is_string_object(ts):
         _string_to_dts(ts, &obj.dts)
-        obj.value = PyArray_DatetimeStructToDatetime(NPY_FR_us, &obj.dts)
+        obj.value = pandas_datetimestruct_to_datetime(PANDAS_FR_us, &obj.dts)
     elif PyDateTime_Check(ts):
         obj.value = _pydatetime_to_dts(ts, &obj.dts)
         obj.tzinfo = ts.tzinfo
@@ -276,7 +279,7 @@ cpdef convert_to_tsobject(object ts, object tz=None):
             obj.value = obj.value + deltas[pos]
 
             if utc_convert:
-                PyArray_DatetimeToDatetimeStruct(obj.value, NPY_FR_us,
+                pandas_datetime_to_datetimestruct(obj.value, PANDAS_FR_us,
                                                  &obj.dts)
                 obj.tzinfo = tz._tzinfos[inf]
 
@@ -292,16 +295,16 @@ cpdef convert_to_tsobject(object ts, object tz=None):
 #     obj.dtval = _dts_to_pydatetime(&obj.dts)
 
 cdef inline object _datetime64_to_datetime(int64_t val):
-    cdef npy_datetimestruct dts
-    PyArray_DatetimeToDatetimeStruct(val, NPY_FR_us, &dts)
+    cdef pandas_datetimestruct dts
+    pandas_datetime_to_datetimestruct(val, PANDAS_FR_us, &dts)
     return _dts_to_pydatetime(&dts)
 
-cdef inline object _dts_to_pydatetime(npy_datetimestruct *dts):
+cdef inline object _dts_to_pydatetime(pandas_datetimestruct *dts):
     return <object> PyDateTime_FromDateAndTime(dts.year, dts.month,
                                                dts.day, dts.hour,
                                                dts.min, dts.sec, dts.us)
 
-cdef inline int64_t _pydatetime_to_dts(object val, npy_datetimestruct *dts):
+cdef inline int64_t _pydatetime_to_dts(object val, pandas_datetimestruct *dts):
     dts.year = PyDateTime_GET_YEAR(val)
     dts.month = PyDateTime_GET_MONTH(val)
     dts.day = PyDateTime_GET_DAY(val)
@@ -309,10 +312,10 @@ cdef inline int64_t _pydatetime_to_dts(object val, npy_datetimestruct *dts):
     dts.min = PyDateTime_DATE_GET_MINUTE(val)
     dts.sec = PyDateTime_DATE_GET_SECOND(val)
     dts.us = PyDateTime_DATE_GET_MICROSECOND(val)
-    return PyArray_DatetimeStructToDatetime(NPY_FR_us, dts)
+    return pandas_datetimestruct_to_datetime(PANDAS_FR_us, dts)
 
 cdef inline int64_t _dtlike_to_datetime64(object val,
-                                          npy_datetimestruct *dts):
+                                          pandas_datetimestruct *dts):
     dts.year = val.year
     dts.month = val.month
     dts.day = val.day
@@ -320,10 +323,10 @@ cdef inline int64_t _dtlike_to_datetime64(object val,
     dts.min = val.minute
     dts.sec = val.second
     dts.us = val.microsecond
-    return PyArray_DatetimeStructToDatetime(NPY_FR_us, dts)
+    return pandas_datetimestruct_to_datetime(PANDAS_FR_us, dts)
 
 cdef inline int64_t _date_to_datetime64(object val,
-                                        npy_datetimestruct *dts):
+                                        pandas_datetimestruct *dts):
     dts.year = PyDateTime_GET_YEAR(val)
     dts.month = PyDateTime_GET_MONTH(val)
     dts.day = PyDateTime_GET_DAY(val)
@@ -331,17 +334,17 @@ cdef inline int64_t _date_to_datetime64(object val,
     dts.min = 0
     dts.sec = 0
     dts.us = 0
-    return PyArray_DatetimeStructToDatetime(NPY_FR_us, dts)
+    return pandas_datetimestruct_to_datetime(PANDAS_FR_us, dts)
 
 
-cdef inline int _string_to_dts(object val, npy_datetimestruct* dts) except -1:
+cdef inline int _string_to_dts(object val, pandas_datetimestruct* dts) except -1:
     cdef:
         npy_bool islocal, special
-        NPY_DATETIMEUNIT out_bestunit
+        PANDAS_DATETIMEUNIT out_bestunit
 
     if PyUnicode_Check(val):
         val = PyUnicode_AsASCIIString(val);
-    parse_iso_8601_datetime(val, len(val), NPY_FR_us, NPY_UNSAFE_CASTING,
+    parse_iso_8601_datetime(val, len(val), PANDAS_FR_us, NPY_UNSAFE_CASTING,
                             dts, &islocal, &out_bestunit, &special)
     return 0
 
@@ -740,12 +743,12 @@ def string_to_datetime(ndarray[object] strings, raise_=False, dayfirst=False):
         for i in range(n):
             val = strings[i]
             if util._checknull(val):
-                result[i] = NaT
+                result[i] = 'NaT'
             elif PyDateTime_Check(val):
                 result[i] = val
             else:
                 if len(val) == 0:
-                    result[i] = NaT
+                    result[i] = 'NaT'
                     continue
                 try:
                     result[i] = parse(val, dayfirst=dayfirst)
@@ -761,7 +764,7 @@ def string_to_datetime(ndarray[object] strings, raise_=False, dayfirst=False):
                 oresult[i] = val
             else:
                 if len(val) == 0:
-                    oresult[i] = NaT
+                    oresult[i] = 'NaT'
                     continue
                 try:
                     oresult[i] = parse(val, dayfirst=dayfirst)
@@ -982,7 +985,7 @@ def build_field_sarray(ndarray[int64_t] dtindex):
     cdef:
         Py_ssize_t i, count = 0
         int isleap
-        npy_datetimestruct dts
+        pandas_datetimestruct dts
         ndarray[int32_t] years, months, days, hours, minutes, seconds, mus
 
     count = len(dtindex)
@@ -1006,7 +1009,7 @@ def build_field_sarray(ndarray[int64_t] dtindex):
     mus = out['u']
 
     for i in range(count):
-        PyArray_DatetimeToDatetimeStruct(dtindex[i], NPY_FR_us, &dts)
+        pandas_datetime_to_datetimestruct(dtindex[i], PANDAS_FR_us, &dts)
         years[i] = dts.year
         months[i] = dts.month
         days[i] = dts.day
@@ -1029,7 +1032,7 @@ def fast_field_accessor(ndarray[int64_t] dtindex, object field):
         ndarray[int32_t] out
         ndarray[int32_t, ndim=2] _month_offset
         int isleap
-        npy_datetimestruct dts
+        pandas_datetimestruct dts
 
     _month_offset = np.array(
         [[ 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365 ],
@@ -1041,49 +1044,49 @@ def fast_field_accessor(ndarray[int64_t] dtindex, object field):
 
     if field == 'Y':
         for i in range(count):
-            PyArray_DatetimeToDatetimeStruct(dtindex[i], NPY_FR_us, &dts)
+            pandas_datetime_to_datetimestruct(dtindex[i], PANDAS_FR_us, &dts)
             out[i] = dts.year
         return out
 
     elif field == 'M':
         for i in range(count):
-            PyArray_DatetimeToDatetimeStruct(dtindex[i], NPY_FR_us, &dts)
+            pandas_datetime_to_datetimestruct(dtindex[i], PANDAS_FR_us, &dts)
             out[i] = dts.month
         return out
 
     elif field == 'D':
         for i in range(count):
-            PyArray_DatetimeToDatetimeStruct(dtindex[i], NPY_FR_us, &dts)
+            pandas_datetime_to_datetimestruct(dtindex[i], PANDAS_FR_us, &dts)
             out[i] = dts.day
         return out
 
     elif field == 'h':
         for i in range(count):
-            PyArray_DatetimeToDatetimeStruct(dtindex[i], NPY_FR_us, &dts)
+            pandas_datetime_to_datetimestruct(dtindex[i], PANDAS_FR_us, &dts)
             out[i] = dts.hour
         return out
 
     elif field == 'm':
         for i in range(count):
-            PyArray_DatetimeToDatetimeStruct(dtindex[i], NPY_FR_us, &dts)
+            pandas_datetime_to_datetimestruct(dtindex[i], PANDAS_FR_us, &dts)
             out[i] = dts.min
         return out
 
     elif field == 's':
         for i in range(count):
-            PyArray_DatetimeToDatetimeStruct(dtindex[i], NPY_FR_us, &dts)
+            pandas_datetime_to_datetimestruct(dtindex[i], PANDAS_FR_us, &dts)
             out[i] = dts.sec
         return out
 
     elif field == 'us':
         for i in range(count):
-            PyArray_DatetimeToDatetimeStruct(dtindex[i], NPY_FR_us, &dts)
+            pandas_datetime_to_datetimestruct(dtindex[i], PANDAS_FR_us, &dts)
             out[i] = dts.us
         return out
 
     elif field == 'doy':
         for i in range(count):
-            PyArray_DatetimeToDatetimeStruct(dtindex[i], NPY_FR_us, &dts)
+            pandas_datetime_to_datetimestruct(dtindex[i], PANDAS_FR_us, &dts)
             isleap = is_leapyear(dts.year)
             out[i] = _month_offset[isleap, dts.month-1] + dts.day
         return out
@@ -1096,7 +1099,7 @@ def fast_field_accessor(ndarray[int64_t] dtindex, object field):
 
     elif field == 'woy':
         for i in range(count):
-            PyArray_DatetimeToDatetimeStruct(dtindex[i], NPY_FR_us, &dts)
+            pandas_datetime_to_datetimestruct(dtindex[i], PANDAS_FR_us, &dts)
             isleap = is_leapyear(dts.year)
             out[i] = _month_offset[isleap, dts.month - 1] + dts.day
             out[i] = ((out[i] - 1) / 7) + 1
@@ -1104,7 +1107,7 @@ def fast_field_accessor(ndarray[int64_t] dtindex, object field):
 
     elif field == 'q':
         for i in range(count):
-            PyArray_DatetimeToDatetimeStruct(dtindex[i], NPY_FR_us, &dts)
+            pandas_datetime_to_datetimestruct(dtindex[i], PANDAS_FR_us, &dts)
             out[i] = dts.month
             out[i] = ((out[i] - 1) / 3) + 1
         return out
@@ -1164,25 +1167,25 @@ def date_normalize(ndarray[int64_t] stamps):
     cdef:
         Py_ssize_t i, n = len(stamps)
         ndarray[int64_t] result = np.empty(n, dtype=np.int64)
-        npy_datetimestruct dts
+        pandas_datetimestruct dts
 
     for i in range(n):
-        PyArray_DatetimeToDatetimeStruct(stamps[i], NPY_FR_us, &dts)
+        pandas_datetime_to_datetimestruct(stamps[i], PANDAS_FR_us, &dts)
         dts.hour = 0
         dts.min = 0
         dts.sec = 0
         dts.us = 0
-        result[i] = PyArray_DatetimeStructToDatetime(NPY_FR_us, &dts)
+        result[i] = pandas_datetimestruct_to_datetime(PANDAS_FR_us, &dts)
 
     return result
 
 def dates_normalized(ndarray[int64_t] stamps):
     cdef:
         Py_ssize_t i, n = len(stamps)
-        npy_datetimestruct dts
+        pandas_datetimestruct dts
 
     for i in range(n):
-        PyArray_DatetimeToDatetimeStruct(stamps[i], NPY_FR_us, &dts)
+        pandas_datetime_to_datetimestruct(stamps[i], PANDAS_FR_us, &dts)
         if (dts.hour + dts.min + dts.sec + dts.us) > 0:
             return False
 
@@ -1240,14 +1243,14 @@ def dt64arr_to_periodarr(ndarray[int64_t] dtarr, int freq, int64_t mult):
     cdef:
         ndarray[int64_t] out
         Py_ssize_t i, l
-        npy_datetimestruct dts
+        pandas_datetimestruct dts
 
     l = len(dtarr)
 
     out = np.empty(l, dtype='i8')
 
     for i in range(l):
-        PyArray_DatetimeToDatetimeStruct(dtarr[i], NPY_FR_us, &dts)
+        pandas_datetime_to_datetimestruct(dtarr[i], PANDAS_FR_us, &dts)
         out[i] = get_period_ordinal(dts.year, dts.month, dts.day,
                                   dts.hour, dts.min, dts.sec, freq)
         out[i] = apply_mult(out[i], mult)
@@ -1343,7 +1346,7 @@ cpdef int64_t period_ordinal_to_dt64(int64_t period_ordinal, int freq,
                                      int64_t mult):
     cdef:
         int64_t ordinal
-        npy_datetimestruct dts
+        pandas_datetimestruct dts
         date_info dinfo
 
     ordinal = remove_mult(period_ordinal, mult)
@@ -1358,7 +1361,7 @@ cpdef int64_t period_ordinal_to_dt64(int64_t period_ordinal, int freq,
     dts.sec = int(dinfo.second)
     dts.us = 0
 
-    return PyArray_DatetimeStructToDatetime(NPY_FR_us, &dts)
+    return pandas_datetimestruct_to_datetime(PANDAS_FR_us, &dts)
 
 def period_ordinal_to_string(int64_t value, int freq, int64_t mult):
     cdef:

--- a/pandas/src/np_datetime.c
+++ b/pandas/src/np_datetime.c
@@ -56,7 +56,7 @@ int dayofweek(int y, int m, int d)
  * the current values are valid.
  */
 void
-add_minutes_to_datetimestruct(npy_datetimestruct *dts, int minutes)
+add_minutes_to_datetimestruct(pandas_datetimestruct *dts, int minutes)
 {
     int isleap;
 
@@ -108,7 +108,7 @@ add_minutes_to_datetimestruct(npy_datetimestruct *dts, int minutes)
  * Calculates the days offset from the 1970 epoch.
  */
 npy_int64
-get_datetimestruct_days(const npy_datetimestruct *dts)
+get_datetimestruct_days(const pandas_datetimestruct *dts)
 {
     int i, month;
     npy_int64 year, days = 0;
@@ -214,7 +214,7 @@ days_to_yearsdays(npy_int64 *days_)
  * the current values are valid.
  */
 NPY_NO_EXPORT void
-add_seconds_to_datetimestruct(npy_datetimestruct *dts, int seconds)
+add_seconds_to_datetimestruct(pandas_datetimestruct *dts, int seconds)
 {
     int minutes;
 
@@ -240,7 +240,7 @@ add_seconds_to_datetimestruct(npy_datetimestruct *dts, int seconds)
  * offset from 1970.
  */
 static void
-set_datetimestruct_days(npy_int64 days, npy_datetimestruct *dts)
+set_datetimestruct_days(npy_int64 days, pandas_datetimestruct *dts)
 {
     int *month_lengths, i;
 
@@ -262,7 +262,7 @@ set_datetimestruct_days(npy_int64 days, npy_datetimestruct *dts)
 /*
  *
  * Tests for and converts a Python datetime.datetime or datetime.date
- * object into a NumPy npy_datetimestruct.
+ * object into a NumPy pandas_datetimestruct.
  *
  * While the C API has PyDate_* and PyDateTime_* functions, the following
  * implementation just asks for attributes, and thus supports
@@ -279,15 +279,15 @@ set_datetimestruct_days(npy_int64 days, npy_datetimestruct *dts)
  * if obj doesn't have the neeeded date or datetime attributes.
  */
 int
-convert_pydatetime_to_datetimestruct(PyObject *obj, npy_datetimestruct *out,
-                                     NPY_DATETIMEUNIT *out_bestunit,
+convert_pydatetime_to_datetimestruct(PyObject *obj, pandas_datetimestruct *out,
+                                     PANDAS_DATETIMEUNIT *out_bestunit,
                                      int apply_tzinfo)
 {
     PyObject *tmp;
     int isleap;
 
     /* Initialize the output to all zeros */
-    memset(out, 0, sizeof(npy_datetimestruct));
+    memset(out, 0, sizeof(pandas_datetimestruct));
     out->month = 1;
     out->day = 1;
 
@@ -351,7 +351,7 @@ convert_pydatetime_to_datetimestruct(PyObject *obj, npy_datetimestruct *out,
             !PyObject_HasAttrString(obj, "microsecond")) {
         /* The best unit for date is 'D' */
         if (out_bestunit != NULL) {
-            *out_bestunit = NPY_FR_D;
+            *out_bestunit = PANDAS_FR_D;
         }
         return 0;
     }
@@ -456,7 +456,7 @@ convert_pydatetime_to_datetimestruct(PyObject *obj, npy_datetimestruct *out,
 
     /* The resolution of Python's datetime is 'us' */
     if (out_bestunit != NULL) {
-        *out_bestunit = NPY_FR_us;
+        *out_bestunit = PANDAS_FR_us;
     }
 
     return 0;
@@ -475,6 +475,28 @@ invalid_time:
     return -1;
 }
 
+npy_datetime pandas_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT fr, pandas_datetimestruct *d)
+{
+    pandas_datetime_metadata meta;
+    npy_datetime result = PANDAS_DATETIME_NAT;
+
+    meta.base = fr;
+    meta.num = 1;
+
+    convert_datetimestruct_to_datetime(&meta, d, &result);
+    return result;
+}
+
+void pandas_datetime_to_datetimestruct(npy_datetime val, PANDAS_DATETIMEUNIT fr, npy_datetimestruct *result)
+{
+    pandas_datetime_metadata meta;
+
+    meta.base = fr;
+    meta.num = 1;
+
+    convert_datetime_to_datetimestruct(&meta, val, result);
+}
+
 /*
  * Converts a datetime from a datetimestruct to a datetime based
  * on some metadata. The date is assumed to be valid.
@@ -484,18 +506,18 @@ invalid_time:
  * Returns 0 on success, -1 on failure.
  */
 int
-convert_datetimestruct_to_datetime(PyArray_DatetimeMetaData *meta,
-                                    const npy_datetimestruct *dts,
+convert_datetimestruct_to_datetime(pandas_datetime_metadata *meta,
+                                    const pandas_datetimestruct *dts,
                                     npy_datetime *out)
 {
     npy_datetime ret;
-    NPY_DATETIMEUNIT base = meta->base;
+    PANDAS_DATETIMEUNIT base = meta->base;
 
-    if (base == NPY_FR_Y) {
+    if (base == PANDAS_FR_Y) {
         /* Truncate to the year */
         ret = dts->year - 1970;
     }
-    else if (base == NPY_FR_M) {
+    else if (base == PANDAS_FR_M) {
         /* Truncate to the month */
         ret = 12 * (dts->year - 1970) + (dts->month - 1);
     }
@@ -504,7 +526,7 @@ convert_datetimestruct_to_datetime(PyArray_DatetimeMetaData *meta,
         npy_int64 days = get_datetimestruct_days(dts);
 
         switch (base) {
-            case NPY_FR_W:
+            case PANDAS_FR_W:
                 /* Truncate to weeks */
                 if (days >= 0) {
                     ret = days / 7;
@@ -513,39 +535,39 @@ convert_datetimestruct_to_datetime(PyArray_DatetimeMetaData *meta,
                     ret = (days - 6) / 7;
                 }
                 break;
-            case NPY_FR_D:
+            case PANDAS_FR_D:
                 ret = days;
                 break;
-            case NPY_FR_h:
+            case PANDAS_FR_h:
                 ret = days * 24 +
                       dts->hour;
                 break;
-            case NPY_FR_m:
+            case PANDAS_FR_m:
                 ret = (days * 24 +
                       dts->hour) * 60 +
                       dts->min;
                 break;
-            case NPY_FR_s:
+            case PANDAS_FR_s:
                 ret = ((days * 24 +
                       dts->hour) * 60 +
                       dts->min) * 60 +
                       dts->sec;
                 break;
-            case NPY_FR_ms:
+            case PANDAS_FR_ms:
                 ret = (((days * 24 +
                       dts->hour) * 60 +
                       dts->min) * 60 +
                       dts->sec) * 1000 +
                       dts->us / 1000;
                 break;
-            case NPY_FR_us:
+            case PANDAS_FR_us:
                 ret = (((days * 24 +
                       dts->hour) * 60 +
                       dts->min) * 60 +
                       dts->sec) * 1000000 +
                       dts->us;
                 break;
-            case NPY_FR_ns:
+            case PANDAS_FR_ns:
                 ret = ((((days * 24 +
                       dts->hour) * 60 +
                       dts->min) * 60 +
@@ -553,7 +575,7 @@ convert_datetimestruct_to_datetime(PyArray_DatetimeMetaData *meta,
                       dts->us) * 1000 +
                       dts->ps / 1000;
                 break;
-            case NPY_FR_ps:
+            case PANDAS_FR_ps:
                 ret = ((((days * 24 +
                       dts->hour) * 60 +
                       dts->min) * 60 +
@@ -561,7 +583,7 @@ convert_datetimestruct_to_datetime(PyArray_DatetimeMetaData *meta,
                       dts->us) * 1000000 +
                       dts->ps;
                 break;
-            case NPY_FR_fs:
+            case PANDAS_FR_fs:
                 /* only 2.6 hours */
                 ret = (((((days * 24 +
                       dts->hour) * 60 +
@@ -571,7 +593,7 @@ convert_datetimestruct_to_datetime(PyArray_DatetimeMetaData *meta,
                       dts->ps) * 1000 +
                       dts->as / 1000;
                 break;
-            case NPY_FR_as:
+            case PANDAS_FR_as:
                 /* only 9.2 secs */
                 ret = (((((days * 24 +
                       dts->hour) * 60 +
@@ -612,8 +634,8 @@ convert_datetimestruct_to_datetime(PyArray_DatetimeMetaData *meta,
  * months units, and all the other units.
  */
 npy_bool
-can_cast_timedelta64_units(NPY_DATETIMEUNIT src_unit,
-                          NPY_DATETIMEUNIT dst_unit,
+can_cast_timedelta64_units(PANDAS_DATETIMEUNIT src_unit,
+                          PANDAS_DATETIMEUNIT dst_unit,
                           NPY_CASTING casting)
 {
     switch (casting) {
@@ -626,8 +648,8 @@ can_cast_timedelta64_units(NPY_DATETIMEUNIT src_unit,
          * 'same_kind' casting.
          */
         case NPY_SAME_KIND_CASTING:
-            return (src_unit <= NPY_FR_M && dst_unit <= NPY_FR_M) ||
-                    (src_unit > NPY_FR_M && dst_unit > NPY_FR_M);
+            return (src_unit <= PANDAS_FR_M && dst_unit <= PANDAS_FR_M) ||
+                    (src_unit > PANDAS_FR_M && dst_unit > PANDAS_FR_M);
 
         /*
          * Enforce the 'date units' vs 'time units' barrier and that
@@ -636,8 +658,8 @@ can_cast_timedelta64_units(NPY_DATETIMEUNIT src_unit,
          */
         case NPY_SAFE_CASTING:
             return (src_unit <= dst_unit) &&
-                    ((src_unit <= NPY_FR_M && dst_unit <= NPY_FR_M) ||
-                    (src_unit > NPY_FR_M && dst_unit > NPY_FR_M));
+                    ((src_unit <= PANDAS_FR_M && dst_unit <= PANDAS_FR_M) ||
+                    (src_unit > PANDAS_FR_M && dst_unit > PANDAS_FR_M));
 
         /* Enforce equality with 'no' or 'equiv' casting */
         default:
@@ -652,8 +674,8 @@ can_cast_timedelta64_units(NPY_DATETIMEUNIT src_unit,
  * for all but 'unsafe' casting.
  */
 npy_bool
-can_cast_datetime64_units(NPY_DATETIMEUNIT src_unit,
-                          NPY_DATETIMEUNIT dst_unit,
+can_cast_datetime64_units(PANDAS_DATETIMEUNIT src_unit,
+                          PANDAS_DATETIMEUNIT dst_unit,
                           NPY_CASTING casting)
 {
     switch (casting) {
@@ -666,8 +688,8 @@ can_cast_datetime64_units(NPY_DATETIMEUNIT src_unit,
          * 'same_kind' casting.
          */
         case NPY_SAME_KIND_CASTING:
-            return (src_unit <= NPY_FR_D && dst_unit <= NPY_FR_D) ||
-                    (src_unit > NPY_FR_D && dst_unit > NPY_FR_D);
+            return (src_unit <= PANDAS_FR_D && dst_unit <= PANDAS_FR_D) ||
+                    (src_unit > PANDAS_FR_D && dst_unit > PANDAS_FR_D);
 
         /*
          * Enforce the 'date units' vs 'time units' barrier and that
@@ -676,8 +698,8 @@ can_cast_datetime64_units(NPY_DATETIMEUNIT src_unit,
          */
         case NPY_SAFE_CASTING:
             return (src_unit <= dst_unit) &&
-                    ((src_unit <= NPY_FR_D && dst_unit <= NPY_FR_D) ||
-                    (src_unit > NPY_FR_D && dst_unit > NPY_FR_D));
+                    ((src_unit <= PANDAS_FR_D && dst_unit <= PANDAS_FR_D) ||
+                    (src_unit > PANDAS_FR_D && dst_unit > PANDAS_FR_D));
 
         /* Enforce equality with 'no' or 'equiv' casting */
         default:
@@ -689,14 +711,14 @@ can_cast_datetime64_units(NPY_DATETIMEUNIT src_unit,
  * Converts a datetime based on the given metadata into a datetimestruct
  */
 int
-convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
+convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,
                                     npy_datetime dt,
-                                    npy_datetimestruct *out)
+                                    pandas_datetimestruct *out)
 {
     npy_int64 perday;
 
     /* Initialize the output to all zeros */
-    memset(out, 0, sizeof(npy_datetimestruct));
+    memset(out, 0, sizeof(pandas_datetimestruct));
     out->year = 1970;
     out->month = 1;
     out->day = 1;
@@ -709,11 +731,11 @@ convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
      * for negative values.
      */
     switch (meta->base) {
-        case NPY_FR_Y:
+        case PANDAS_FR_Y:
             out->year = 1970 + dt;
             break;
 
-        case NPY_FR_M:
+        case PANDAS_FR_M:
             if (dt >= 0) {
                 out->year  = 1970 + dt / 12;
                 out->month = dt % 12 + 1;
@@ -724,16 +746,16 @@ convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
             }
             break;
 
-        case NPY_FR_W:
+        case PANDAS_FR_W:
             /* A week is 7 days */
             set_datetimestruct_days(dt * 7, out);
             break;
 
-        case NPY_FR_D:
+        case PANDAS_FR_D:
             set_datetimestruct_days(dt, out);
             break;
 
-        case NPY_FR_h:
+        case PANDAS_FR_h:
             perday = 24LL;
 
             if (dt >= 0) {
@@ -747,7 +769,7 @@ convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
             out->hour = dt;
             break;
 
-        case NPY_FR_m:
+        case PANDAS_FR_m:
             perday = 24LL * 60;
 
             if (dt >= 0) {
@@ -762,7 +784,7 @@ convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
             out->min = dt % 60;
             break;
 
-        case NPY_FR_s:
+        case PANDAS_FR_s:
             perday = 24LL * 60 * 60;
 
             if (dt >= 0) {
@@ -778,7 +800,7 @@ convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
             out->sec = dt % 60;
             break;
 
-        case NPY_FR_ms:
+        case PANDAS_FR_ms:
             perday = 24LL * 60 * 60 * 1000;
 
             if (dt >= 0) {
@@ -795,7 +817,7 @@ convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
             out->us = (dt % 1000LL) * 1000;
             break;
 
-        case NPY_FR_us:
+        case PANDAS_FR_us:
             perday = 24LL * 60LL * 60LL * 1000LL * 1000LL;
 
             if (dt >= 0) {
@@ -812,7 +834,7 @@ convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
             out->us = dt % 1000000LL;
             break;
 
-        case NPY_FR_ns:
+        case PANDAS_FR_ns:
             perday = 24LL * 60LL * 60LL * 1000LL * 1000LL * 1000LL;
 
             if (dt >= 0) {
@@ -830,7 +852,7 @@ convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
             out->ps = (dt % 1000LL) * 1000;
             break;
 
-        case NPY_FR_ps:
+        case PANDAS_FR_ps:
             perday = 24LL * 60 * 60 * 1000 * 1000 * 1000 * 1000;
 
             if (dt >= 0) {
@@ -848,7 +870,7 @@ convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
             out->ps = dt % 1000000LL;
             break;
 
-        case NPY_FR_fs:
+        case PANDAS_FR_fs:
             /* entire range is only +- 2.6 hours */
             if (dt >= 0) {
                 out->hour = dt / (60*60*1000000000000000LL);
@@ -876,7 +898,7 @@ convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
             }
             break;
 
-        case NPY_FR_as:
+        case PANDAS_FR_as:
             /* entire range is only +- 9.2 seconds */
             if (dt >= 0) {
                 out->sec = (dt / 1000000000000000000LL) % 60;

--- a/pandas/src/np_datetime.h
+++ b/pandas/src/np_datetime.h
@@ -6,14 +6,49 @@
 #ifndef _PANDAS_DATETIME_H_
 #define _PANDAS_DATETIME_H_
 
-#define NPY_DATETIME_MAX_ISO8601_STRLEN (21+3*5+1+3*6+6+1)
+typedef enum {
+        PANDAS_FR_Y, /* Years */
+        PANDAS_FR_M, /* Months */
+        PANDAS_FR_W, /* Weeks */
+        PANDAS_FR_D, /* Days */
+        PANDAS_FR_B, /* Business days */
+        PANDAS_FR_h, /* hours */
+        PANDAS_FR_m, /* minutes */
+        PANDAS_FR_s, /* seconds */
+        PANDAS_FR_ms,/* milliseconds */
+        PANDAS_FR_us,/* microseconds */
+        PANDAS_FR_ns,/* nanoseconds */
+        PANDAS_FR_ps,/* picoseconds */
+        PANDAS_FR_fs,/* femtoseconds */
+        PANDAS_FR_as,/* attoseconds */
+} PANDAS_DATETIMEUNIT;
+
+#define PANDAS_DATETIME_NUMUNITS 14
+
+#define PANDAS_DATETIME_MAX_ISO8601_STRLEN (21+3*5+1+3*6+6+1)
+
+#define PANDAS_DATETIME_NAT NPY_MIN_INT64
+
+typedef struct {
+        npy_int64 year;
+        npy_int32 month, day, hour, min, sec, us, ps, as;
+} pandas_datetimestruct;
+
+typedef struct {
+    PANDAS_DATETIMEUNIT base;
+    int num;
+} pandas_datetime_metadata;
 
 // stuff pandas needs
 // ----------------------------------------------------------------------------
 
-int convert_pydatetime_to_datetimestruct(PyObject *obj, npy_datetimestruct *out,
-                                         NPY_DATETIMEUNIT *out_bestunit,
+int convert_pydatetime_to_datetimestruct(PyObject *obj, pandas_datetimestruct *out,
+                                         PANDAS_DATETIMEUNIT *out_bestunit,
                                          int apply_tzinfo);
+
+npy_datetime pandas_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT fr, pandas_datetimestruct *d);
+
+void pandas_datetime_to_datetimestruct(npy_datetime val, PANDAS_DATETIMEUNIT fr, npy_datetimestruct *result);
 
 int dayofweek(int y, int m, int d);
 
@@ -22,7 +57,7 @@ static int _days_per_month_table[2][12] = {
     { 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }
 };
 
-// stuff numpy needs in header
+// stuff numpy-derived code needs in header
 // ----------------------------------------------------------------------------
 
 int is_leapyear(npy_int64 year);
@@ -36,22 +71,22 @@ int is_leapyear(npy_int64 year);
  * Returns 0 on success, -1 on failure.
  */
 int
-convert_datetimestruct_to_datetime(PyArray_DatetimeMetaData *meta,
-                                   const npy_datetimestruct *dts,
+convert_datetimestruct_to_datetime(pandas_datetime_metadata *meta,
+                                   const pandas_datetimestruct *dts,
                                    npy_datetime *out);
 
 /*
  * Calculates the days offset from the 1970 epoch.
  */
 npy_int64
-get_datetimestruct_days(const npy_datetimestruct *dts);
+get_datetimestruct_days(const pandas_datetimestruct *dts);
 
 /*
  * Adjusts a datetimestruct based on a minutes offset. Assumes
  * the current values are valid.
  */
 void
-add_minutes_to_datetimestruct(npy_datetimestruct *dts, int minutes);
+add_minutes_to_datetimestruct(pandas_datetimestruct *dts, int minutes);
 
 /*
  * This provides the casting rules for the TIMEDELTA data type units.
@@ -60,19 +95,21 @@ add_minutes_to_datetimestruct(npy_datetimestruct *dts, int minutes);
  * months units, and all the other units.
  */
 //npy_bool
-//can_cast_timedelta64_units(NPY_DATETIMEUNIT src_unit,
-//                          NPY_DATETIMEUNIT dst_unit,
+//can_cast_timedelta64_units(PANDAS_DATETIMEUNIT src_unit,
+//                          PANDAS_DATETIMEUNIT dst_unit,
 //                          NPY_CASTING casting);
 
 npy_bool
-can_cast_datetime64_units(NPY_DATETIMEUNIT src_unit,
-                          NPY_DATETIMEUNIT dst_unit,
+can_cast_datetime64_units(PANDAS_DATETIMEUNIT src_unit,
+                          PANDAS_DATETIMEUNIT dst_unit,
                           NPY_CASTING casting);
 
 
 int
-convert_datetime_to_datetimestruct(PyArray_DatetimeMetaData *meta,
+convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,
                                     npy_datetime dt,
-                                    npy_datetimestruct *out);
+                                    pandas_datetimestruct *out);
+
+
 
 #endif

--- a/pandas/src/np_datetime_strings.c
+++ b/pandas/src/np_datetime_strings.c
@@ -57,21 +57,21 @@ typedef time_t NPY_TIME_T;
 /*}*/
 
 /* Exported as DATETIMEUNITS in multiarraymodule.c */
-static char *_datetime_strings[NPY_DATETIME_NUMUNITS] = {
-    NPY_STR_Y,
-    NPY_STR_M,
-    NPY_STR_W,
-    NPY_STR_D,
-    NPY_STR_h,
-    NPY_STR_m,
-    NPY_STR_s,
-    NPY_STR_ms,
-    NPY_STR_us,
-    NPY_STR_ns,
-    NPY_STR_ps,
-    NPY_STR_fs,
-    NPY_STR_as,
-    "generic"
+static char *_datetime_strings[PANDAS_DATETIME_NUMUNITS] = {
+    "Y",
+    "M",
+    "W",
+    "D",
+    "B",
+    "h",
+    "m",
+    "s",
+    "ms",
+    "us",
+    "ns",
+    "ps",
+    "fs",
+    "as",
 };
 /*
  * Wraps `localtime` functionality for multiple platforms. This
@@ -170,8 +170,8 @@ fail:
  * Returns 0 on success, -1 on failure.
  */
 static int
-convert_datetimestruct_utc_to_local(npy_datetimestruct *out_dts_local,
-                const npy_datetimestruct *dts_utc, int *out_timezone_offset)
+convert_datetimestruct_utc_to_local(pandas_datetimestruct *out_dts_local,
+                const pandas_datetimestruct *dts_utc, int *out_timezone_offset)
 {
     NPY_TIME_T rawtime = 0, localrawtime;
     struct tm tm_;
@@ -197,7 +197,7 @@ convert_datetimestruct_utc_to_local(npy_datetimestruct *out_dts_local,
     /*
      * Convert everything in 'dts' to a time_t, to minutes precision.
      * This is POSIX time, which skips leap-seconds, but because
-     * we drop the seconds value from the npy_datetimestruct, everything
+     * we drop the seconds value from the pandas_datetimestruct, everything
      * is ok for this operation.
      */
     rawtime = (time_t)get_datetimestruct_days(out_dts_local) * 24 * 60 * 60;
@@ -236,8 +236,8 @@ convert_datetimestruct_utc_to_local(npy_datetimestruct *out_dts_local,
  * Returns 0 on success, -1 on failure.
  */
 static int
-convert_datetimestruct_local_to_utc(npy_datetimestruct *out_dts_utc,
-                const npy_datetimestruct *dts_local)
+convert_datetimestruct_local_to_utc(pandas_datetimestruct *out_dts_utc,
+                const pandas_datetimestruct *dts_local)
 {
     npy_int64 year_correction = 0;
 
@@ -306,11 +306,11 @@ convert_datetimestruct_local_to_utc(npy_datetimestruct *out_dts_utc,
 }
 
 /* int */
-/* parse_python_string(PyObject* obj, npy_datetimestruct *dts) { */
+/* parse_python_string(PyObject* obj, pandas_datetimestruct *dts) { */
 /*     PyObject *bytes = NULL; */
 /*     char *str = NULL; */
 /*     Py_ssize_t len = 0; */
-/*     NPY_DATETIMEUNIT bestunit = -1; */
+/*     PANDAS_DATETIMEUNIT bestunit = -1; */
 
 /*     /\* Convert to an ASCII string for the date parser *\/ */
 /*     if (PyUnicode_Check(obj)) { */
@@ -329,7 +329,7 @@ convert_datetimestruct_local_to_utc(npy_datetimestruct *out_dts_utc,
 /*     } */
 
 /*     /\* Parse the ISO date *\/ */
-/*     if (parse_iso_8601_datetime(str, len, NPY_FR_us, NPY_UNSAFE_CASTING, */
+/*     if (parse_iso_8601_datetime(str, len, PANDAS_FR_us, NPY_UNSAFE_CASTING, */
 /*                             dts, NULL, &bestunit, NULL) < 0) { */
 /*         Py_DECREF(bytes); */
 /*         return -1; */
@@ -377,20 +377,20 @@ convert_datetimestruct_local_to_utc(npy_datetimestruct *out_dts_utc,
  */
 int
 parse_iso_8601_datetime(char *str, int len,
-                    NPY_DATETIMEUNIT unit,
+                    PANDAS_DATETIMEUNIT unit,
                     NPY_CASTING casting,
-                    npy_datetimestruct *out,
+                    pandas_datetimestruct *out,
                     npy_bool *out_local,
-                    NPY_DATETIMEUNIT *out_bestunit,
+                    PANDAS_DATETIMEUNIT *out_bestunit,
                     npy_bool *out_special)
 {
     int year_leap = 0;
     int i, numdigits;
     char *substr, sublen;
-    NPY_DATETIMEUNIT bestunit;
+    PANDAS_DATETIMEUNIT bestunit;
 
     /* Initialize the output to all zeros */
-    memset(out, 0, sizeof(npy_datetimestruct));
+    memset(out, 0, sizeof(pandas_datetimestruct));
     out->month = 1;
     out->day = 1;
 
@@ -420,7 +420,7 @@ parse_iso_8601_datetime(char *str, int len,
         out->month = tm_.tm_mon + 1;
         out->day = tm_.tm_mday;
 
-        bestunit = NPY_FR_D;
+        bestunit = PANDAS_FR_D;
 
         /*
          * Indicate that this was a special value, and
@@ -454,15 +454,15 @@ parse_iso_8601_datetime(char *str, int len,
                     tolower(str[1]) == 'o' &&
                     tolower(str[2]) == 'w') {
         NPY_TIME_T rawtime = 0;
-        PyArray_DatetimeMetaData meta;
+        pandas_datetime_metadata meta;
 
         time(&rawtime);
 
         /* Set up a dummy metadata for the conversion */
-        meta.base = NPY_FR_s;
+        meta.base = PANDAS_FR_s;
         meta.num = 1;
 
-        bestunit = NPY_FR_s;
+        bestunit = PANDAS_FR_s;
 
         /*
          * Indicate that this was a special value, and
@@ -536,7 +536,7 @@ parse_iso_8601_datetime(char *str, int len,
         if (out_local != NULL) {
             *out_local = 0;
         }
-        bestunit = NPY_FR_Y;
+        bestunit = PANDAS_FR_Y;
         goto finish;
     }
     else if (*substr == '-') {
@@ -573,7 +573,7 @@ parse_iso_8601_datetime(char *str, int len,
         if (out_local != NULL) {
             *out_local = 0;
         }
-        bestunit = NPY_FR_M;
+        bestunit = PANDAS_FR_M;
         goto finish;
     }
     else if (*substr == '-') {
@@ -611,7 +611,7 @@ parse_iso_8601_datetime(char *str, int len,
         if (out_local != NULL) {
             *out_local = 0;
         }
-        bestunit = NPY_FR_D;
+        bestunit = PANDAS_FR_D;
         goto finish;
     }
     else if (*substr != 'T' && *substr != ' ') {
@@ -644,7 +644,7 @@ parse_iso_8601_datetime(char *str, int len,
         --sublen;
     }
     else {
-        bestunit = NPY_FR_h;
+        bestunit = PANDAS_FR_h;
         goto parse_timezone;
     }
 
@@ -675,7 +675,7 @@ parse_iso_8601_datetime(char *str, int len,
         --sublen;
     }
     else {
-        bestunit = NPY_FR_m;
+        bestunit = PANDAS_FR_m;
         goto parse_timezone;
     }
 
@@ -706,7 +706,7 @@ parse_iso_8601_datetime(char *str, int len,
         --sublen;
     }
     else {
-        bestunit = NPY_FR_s;
+        bestunit = PANDAS_FR_s;
         goto parse_timezone;
     }
 
@@ -724,10 +724,10 @@ parse_iso_8601_datetime(char *str, int len,
 
     if (sublen == 0 || !isdigit(*substr)) {
         if (numdigits > 3) {
-            bestunit = NPY_FR_us;
+            bestunit = PANDAS_FR_us;
         }
         else {
-            bestunit = NPY_FR_ms;
+            bestunit = PANDAS_FR_ms;
         }
         goto parse_timezone;
     }
@@ -746,10 +746,10 @@ parse_iso_8601_datetime(char *str, int len,
 
     if (sublen == 0 || !isdigit(*substr)) {
         if (numdigits > 3) {
-            bestunit = NPY_FR_ps;
+            bestunit = PANDAS_FR_ps;
         }
         else {
-            bestunit = NPY_FR_ns;
+            bestunit = PANDAS_FR_ns;
         }
         goto parse_timezone;
     }
@@ -767,10 +767,10 @@ parse_iso_8601_datetime(char *str, int len,
     }
 
     if (numdigits > 3) {
-        bestunit = NPY_FR_as;
+        bestunit = PANDAS_FR_as;
     }
     else {
-        bestunit = NPY_FR_fs;
+        bestunit = PANDAS_FR_fs;
     }
 
 parse_timezone:
@@ -911,49 +911,49 @@ error:
  * objects with the given local and unit settings.
  */
 int
-get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base)
+get_datetime_iso_8601_strlen(int local, PANDAS_DATETIMEUNIT base)
 {
     int len = 0;
 
     /* If no unit is provided, return the maximum length */
     if (base == -1) {
-        return NPY_DATETIME_MAX_ISO8601_STRLEN;
+        return PANDAS_DATETIME_MAX_ISO8601_STRLEN;
     }
 
     switch (base) {
         /* Generic units can only be used to represent NaT */
-        /*case NPY_FR_GENERIC:*/
+        /*case PANDAS_FR_GENERIC:*/
         /*    return 4;*/
-        case NPY_FR_as:
+        case PANDAS_FR_as:
             len += 3;  /* "###" */
-        case NPY_FR_fs:
+        case PANDAS_FR_fs:
             len += 3;  /* "###" */
-        case NPY_FR_ps:
+        case PANDAS_FR_ps:
             len += 3;  /* "###" */
-        case NPY_FR_ns:
+        case PANDAS_FR_ns:
             len += 3;  /* "###" */
-        case NPY_FR_us:
+        case PANDAS_FR_us:
             len += 3;  /* "###" */
-        case NPY_FR_ms:
+        case PANDAS_FR_ms:
             len += 4;  /* ".###" */
-        case NPY_FR_s:
+        case PANDAS_FR_s:
             len += 3;  /* ":##" */
-        case NPY_FR_m:
+        case PANDAS_FR_m:
             len += 3;  /* ":##" */
-        case NPY_FR_h:
+        case PANDAS_FR_h:
             len += 3;  /* "T##" */
-        case NPY_FR_D:
-        case NPY_FR_B:
-        case NPY_FR_W:
+        case PANDAS_FR_D:
+        case PANDAS_FR_B:
+        case PANDAS_FR_W:
             len += 3;  /* "-##" */
-        case NPY_FR_M:
+        case PANDAS_FR_M:
             len += 3;  /* "-##" */
-        case NPY_FR_Y:
+        case PANDAS_FR_Y:
             len += 21; /* 64-bit year */
             break;
     }
 
-    if (base >= NPY_FR_h) {
+    if (base >= PANDAS_FR_h) {
         if (local) {
             len += 5;  /* "+####" or "-####" */
         }
@@ -971,49 +971,49 @@ get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base)
  * Finds the largest unit whose value is nonzero, and for which
  * the remainder for the rest of the units is zero.
  */
-static NPY_DATETIMEUNIT
-lossless_unit_from_datetimestruct(npy_datetimestruct *dts)
+static PANDAS_DATETIMEUNIT
+lossless_unit_from_datetimestruct(pandas_datetimestruct *dts)
 {
     if (dts->as % 1000 != 0) {
-        return NPY_FR_as;
+        return PANDAS_FR_as;
     }
     else if (dts->as != 0) {
-        return NPY_FR_fs;
+        return PANDAS_FR_fs;
     }
     else if (dts->ps % 1000 != 0) {
-        return NPY_FR_ps;
+        return PANDAS_FR_ps;
     }
     else if (dts->ps != 0) {
-        return NPY_FR_ns;
+        return PANDAS_FR_ns;
     }
     else if (dts->us % 1000 != 0) {
-        return NPY_FR_us;
+        return PANDAS_FR_us;
     }
     else if (dts->us != 0) {
-        return NPY_FR_ms;
+        return PANDAS_FR_ms;
     }
     else if (dts->sec != 0) {
-        return NPY_FR_s;
+        return PANDAS_FR_s;
     }
     else if (dts->min != 0) {
-        return NPY_FR_m;
+        return PANDAS_FR_m;
     }
     else if (dts->hour != 0) {
-        return NPY_FR_h;
+        return PANDAS_FR_h;
     }
     else if (dts->day != 1) {
-        return NPY_FR_D;
+        return PANDAS_FR_D;
     }
     else if (dts->month != 1) {
-        return NPY_FR_M;
+        return PANDAS_FR_M;
     }
     else {
-        return NPY_FR_Y;
+        return PANDAS_FR_Y;
     }
 }
 
 /*
- * Converts an npy_datetimestruct to an (almost) ISO 8601
+ * Converts an pandas_datetimestruct to an (almost) ISO 8601
  * NULL-terminated string. If the string fits in the space exactly,
  * it leaves out the NULL terminator and returns success.
  *
@@ -1039,11 +1039,11 @@ lossless_unit_from_datetimestruct(npy_datetimestruct *dts)
  *  string was too short).
  */
 int
-make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
-                    int local, NPY_DATETIMEUNIT base, int tzoffset,
+make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
+                    int local, PANDAS_DATETIMEUNIT base, int tzoffset,
                     NPY_CASTING casting)
 {
-    npy_datetimestruct dts_local;
+    pandas_datetimestruct dts_local;
     int timezone_offset = 0;
 
     char *substr = outstr, sublen = outlen;
@@ -1061,12 +1061,12 @@ make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
          * If there's a timezone, use at least minutes precision,
          * and never split up hours and minutes by default
          */
-        if ((base < NPY_FR_m && local) || base == NPY_FR_h) {
-            base = NPY_FR_m;
+        if ((base < PANDAS_FR_m && local) || base == PANDAS_FR_h) {
+            base = PANDAS_FR_m;
         }
         /* Don't split up dates by default */
-        else if (base < NPY_FR_D) {
-            base = NPY_FR_D;
+        else if (base < PANDAS_FR_D) {
+            base = PANDAS_FR_D;
         }
     }
     /*
@@ -1075,8 +1075,8 @@ make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
      * TODO: Could print weeks with YYYY-Www format if the week
      *       epoch is a Monday.
      */
-    else if (base == NPY_FR_W) {
-        base = NPY_FR_D;
+    else if (base == PANDAS_FR_W) {
+        base = PANDAS_FR_D;
     }
 
     /* Use the C API to convert from UTC to local time */
@@ -1091,7 +1091,7 @@ make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
     }
     /* Use the manually provided tzoffset */
     else if (local) {
-        /* Make a copy of the npy_datetimestruct we can modify */
+        /* Make a copy of the pandas_datetimestruct we can modify */
         dts_local = *dts;
         dts = &dts_local;
 
@@ -1107,7 +1107,7 @@ make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
      */
     if (casting != NPY_UNSAFE_CASTING) {
         /* Producing a date as a local time is always 'unsafe' */
-        if (base <= NPY_FR_D && local) {
+        if (base <= PANDAS_FR_D && local) {
             PyErr_SetString(PyExc_TypeError, "Cannot create a local "
                         "timezone-based date string from a NumPy "
                         "datetime without forcing 'unsafe' casting");
@@ -1115,7 +1115,7 @@ make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
         }
         /* Only 'unsafe' and 'same_kind' allow data loss */
         else {
-            NPY_DATETIMEUNIT unitprec;
+            PANDAS_DATETIMEUNIT unitprec;
 
             unitprec = lossless_unit_from_datetimestruct(dts);
             if (casting != NPY_SAME_KIND_CASTING && unitprec > base) {
@@ -1150,7 +1150,7 @@ make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
     sublen -= tmplen;
 
     /* Stop if the unit is years */
-    if (base == NPY_FR_Y) {
+    if (base == PANDAS_FR_Y) {
         if (sublen > 0) {
             *substr = '\0';
         }
@@ -1174,7 +1174,7 @@ make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is months */
-    if (base == NPY_FR_M) {
+    if (base == PANDAS_FR_M) {
         if (sublen > 0) {
             *substr = '\0';
         }
@@ -1198,7 +1198,7 @@ make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is days */
-    if (base == NPY_FR_D) {
+    if (base == PANDAS_FR_D) {
         if (sublen > 0) {
             *substr = '\0';
         }
@@ -1222,7 +1222,7 @@ make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is hours */
-    if (base == NPY_FR_h) {
+    if (base == PANDAS_FR_h) {
         goto add_time_zone;
     }
 
@@ -1243,7 +1243,7 @@ make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is minutes */
-    if (base == NPY_FR_m) {
+    if (base == PANDAS_FR_m) {
         goto add_time_zone;
     }
 
@@ -1264,7 +1264,7 @@ make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is seconds */
-    if (base == NPY_FR_s) {
+    if (base == PANDAS_FR_s) {
         goto add_time_zone;
     }
 
@@ -1289,7 +1289,7 @@ make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 4;
 
     /* Stop if the unit is milliseconds */
-    if (base == NPY_FR_ms) {
+    if (base == PANDAS_FR_ms) {
         goto add_time_zone;
     }
 
@@ -1310,7 +1310,7 @@ make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is microseconds */
-    if (base == NPY_FR_us) {
+    if (base == PANDAS_FR_us) {
         goto add_time_zone;
     }
 
@@ -1331,7 +1331,7 @@ make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is nanoseconds */
-    if (base == NPY_FR_ns) {
+    if (base == PANDAS_FR_ns) {
         goto add_time_zone;
     }
 
@@ -1352,7 +1352,7 @@ make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is picoseconds */
-    if (base == NPY_FR_ps) {
+    if (base == PANDAS_FR_ps) {
         goto add_time_zone;
     }
 
@@ -1373,7 +1373,7 @@ make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is femtoseconds */
-    if (base == NPY_FR_fs) {
+    if (base == PANDAS_FR_fs) {
         goto add_time_zone;
     }
 

--- a/pandas/src/np_datetime_strings.h
+++ b/pandas/src/np_datetime_strings.h
@@ -42,11 +42,11 @@
  */
 int
 parse_iso_8601_datetime(char *str, int len,
-                    NPY_DATETIMEUNIT unit,
+                    PANDAS_DATETIMEUNIT unit,
                     NPY_CASTING casting,
-                    npy_datetimestruct *out,
+                    pandas_datetimestruct *out,
                     npy_bool *out_local,
-                    NPY_DATETIMEUNIT *out_bestunit,
+                    PANDAS_DATETIMEUNIT *out_bestunit,
                     npy_bool *out_special);
 
 /*
@@ -54,10 +54,10 @@ parse_iso_8601_datetime(char *str, int len,
  * objects with the given local and unit settings.
  */
 int
-get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base);
+get_datetime_iso_8601_strlen(int local, PANDAS_DATETIMEUNIT base);
 
 /*
- * Converts an npy_datetimestruct to an (almost) ISO 8601
+ * Converts an pandas_datetimestruct to an (almost) ISO 8601
  * NULL-terminated string.
  *
  * If 'local' is non-zero, it produces a string in local time with
@@ -79,8 +79,8 @@ get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base);
  *  string was too short).
  */
 int
-make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
-                    int local, NPY_DATETIMEUNIT base, int tzoffset,
+make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
+                    int local, PANDAS_DATETIMEUNIT base, int tzoffset,
                     NPY_CASTING casting);
 
 #endif

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -18,6 +18,7 @@ from collections import defaultdict
 import pandas.core.common as com
 import pandas.core.datetools as dt
 import numpy as np
+from numpy.testing import assert_equal
 
 import pandas.util.testing as tm
 
@@ -484,7 +485,7 @@ class TestGroupBy(unittest.TestCase):
                           'F' : np.random.randn(11)})
 
         def bad(x):
-            assert(len(x.base) == len(x))
+            assert_equal(len(x.base), len(x))
             return 'foo'
 
         result = data.groupby(['A', 'B']).agg(bad)

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1226,7 +1226,10 @@ def _to_m8(key):
         # this also converts strings
         key = Timestamp(key)
 
-    return np.datetime64(lib.pydt_to_i8(key))
+    if np.__version__[:3] == '1.6':
+        return np.datetime64(lib.pydt_to_i8(key))
+    else:
+        return np.datetime64(lib.pydt_to_i8(key), 'us')
 
 
 def _to_m8_array(arr):


### PR DESCRIPTION
I've tried to isolate pandas usage of the datetime64 from the aspects of the numpy
API which would be nice to evolve. Pandas wasn't directly using this API for
functionality or interoperability, but more as a consequence of borrowing some
of the functional datetime operations from the numpy codebase.

As a result of doing this, some datetime64-related bugs were exposed in numpy
master, and I've submitted pull requests to fix them.
