### PR TITLE
ENH: Add support for converting DataFrames to R data.frames and matrices

### DIFF
--- a/pandas/rpy/common.py
+++ b/pandas/rpy/common.py
@@ -315,7 +315,7 @@ def test_convert_r_matrix():
     assert np.array_equal(convert_robj(r_dataframe.colnames), frame.columns)
 
     for column in r_dataframe.colnames:
-        coldata = r_dataframe.rx2(column)
+        coldata = r_dataframe.rx(True, column)
         original_data = frame[column]
         assert np.array_equal(convert_robj(coldata), original_data)
 


### PR DESCRIPTION
Finally I got around to implement this properly in pandas, and I added also a conversion to R matrices if need be. Notice that this doesn't handle MultiIndex and similar functionalities, but since I don't use them I'm not sure how they'd fit into R data frames.

The biggest drawback here is the use of an intermediate, but other solutions would probably involve hacking around the rpy2 internals (so far all the alternative solutions I found where worse, performance-wise).

Two (smallish) unit tests are included. This code has also been extensively used in production where I work. 

All other unit tests pass after this change.

closes #350
