### PR TITLE
BUG: align Series repr when unicode index is present #1279

### DIFF
--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -112,8 +112,14 @@ class SeriesFormatter(object):
 
         maxlen = max(len(x) for x in fmt_index)
         pad_space = min(maxlen, 60)
-        result = ['%s   %s' % (k.ljust(pad_space), v)
-                  for (k, v) in izip(fmt_index[1:], fmt_values)]
+
+        result = ['%s   %s'] * len(fmt_values)
+        for i, (k, v) in enumerate(izip(fmt_index[1:], fmt_values)):
+            try:
+                idx = k.ljust(pad_space + (len(k) - len(k.decode('utf-8'))))
+            except UnicodeEncodeError:
+                idx = k.ljust(pad_space)
+            result[i] = result[i] % (idx, v)
 
         if self.header and have_header:
             result.insert(0, fmt_index[0])

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -69,6 +69,17 @@ class TestDataFrameFormatting(unittest.TestCase):
         # it works!
         repr(df)
 
+        idx = Index(['abc', u'\u03c3a', 'aegdvg'])
+        ser = Series(np.random.randn(len(idx)), idx)
+        rs = repr(ser).split('\n')
+        line_len = len(rs[0])
+        for line in rs[1:]:
+            try:
+                line = line.decode('utf-8')
+            except:
+                pass
+            self.assert_(len(line) == line_len)
+
         # it works even if sys.stdin in None
         sys.stdin = None
         repr(df)


### PR DESCRIPTION
adds amount of padding equal to the difference between len(x) and len(x.decode('utf-8')). #1279
