### PR TITLE
Get JSON extension to work with Python 3 #1319

### DIFF
--- a/pandas/src/ujson/python/JSONtoObj.c
+++ b/pandas/src/ujson/python/JSONtoObj.c
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "py_defines.h"
 #define PY_ARRAY_UNIQUE_SYMBOL UJSON_NUMPY
 #define NO_IMPORT_ARRAY
 #include <numpy/arrayobject.h>

--- a/pandas/src/ujson/python/py_defines.h
+++ b/pandas/src/ujson/python/py_defines.h
@@ -1,24 +1,15 @@
 #include <Python.h>
 
 #if PY_MAJOR_VERSION >= 3
-#define PyIntObject                  PyLongObject
-#define PyInt_Type                   PyLong_Type
-#define PyInt_Check(op)              PyLong_Check(op)
-#define PyInt_CheckExact(op)         PyLong_CheckExact(op)
-#define PyInt_FromString             PyLong_FromString
-#define PyInt_FromUnicode            PyLong_FromUnicode
-#define PyInt_FromLong               PyLong_FromLong
-#define PyInt_FromSize_t             PyLong_FromSize_t
-#define PyInt_FromSsize_t            PyLong_FromSsize_t
-#define PyInt_AsLong                 PyLong_AsLong
-#define PyInt_AS_LONG                PyLong_AS_LONG
-#define PyInt_AsSsize_t              PyLong_AsSsize_t
-#define PyInt_AsUnsignedLongMask     PyLong_AsUnsignedLongMask
-#define PyInt_AsUnsignedLongLongMask PyLong_AsUnsignedLongLongMask
 
-#define PyString_Check       PyUnicode_Check
-#define PyString_GET_SIZE    PyBytes_GET_SIZE
-#define PyString_AS_STRING   PyBytes_AS_STRING
-#define PyString_FromString  PyUnicode_FromString
+#define PyInt_Check             PyLong_Check
+#define PyInt_AS_LONG           PyLong_AsLong
+#define PyInt_FromLong          PyLong_FromLong
+
+#define PyString_Check          PyBytes_Check
+#define PyString_GET_SIZE       PyBytes_GET_SIZE
+#define PyString_AS_STRING      PyBytes_AS_STRING
+
+#define PyString_FromString     PyUnicode_FromString
 
 #endif

--- a/pandas/src/ujson/python/ujson.c
+++ b/pandas/src/ujson/python/ujson.c
@@ -1,4 +1,4 @@
-#include <Python.h>
+#include "py_defines.h"
 #include "version.h"
 
 /* objToJSON */
@@ -25,17 +25,49 @@ static PyMethodDef ujsonMethods[] = {
     {NULL, NULL, 0, NULL}       /* Sentinel */
 };
 
+#if PY_MAJOR_VERSION >= 3
 
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "_ujson",
+    0,              /* m_doc */
+    -1,             /* m_size */
+    ujsonMethods,   /* m_methods */
+    NULL,           /* m_reload */
+    NULL,           /* m_traverse */
+    NULL,           /* m_clear */
+    NULL            /* m_free */
+};
 
-PyMODINIT_FUNC
-init_ujson(void)
+#define PYMODINITFUNC       PyObject *PyInit__ujson(void)
+#define PYMODULE_CREATE()   PyModule_Create(&moduledef)
+#define MODINITERROR        return NULL
+
+#else
+
+#define PYMODINITFUNC       PyMODINIT_FUNC init_ujson(void)
+#define PYMODULE_CREATE()   Py_InitModule("_ujson", ujsonMethods)
+#define MODINITERROR        return
+
+#endif
+
+PYMODINITFUNC
 {
     PyObject *module;
     PyObject *version_string;
 
-    initObjToJSON();
-    module = Py_InitModule("_ujson", ujsonMethods);
+    initObjToJSON();   
+    module = PYMODULE_CREATE();
+
+    if (module == NULL)
+    {
+        MODINITERROR;
+    }
 
     version_string = PyString_FromString (UJSON_VERSION);
     PyModule_AddObject (module, "__version__", version_string);
+
+#if PY_MAJOR_VERSION >= 3
+    return module;
+#endif
 }


### PR DESCRIPTION
Python 3 fixes for ujson lib. All relevant tests pass (see below).

Tested on 64 bit OSX on Python 2.5, 2.6, 2.7, 3.1 & 3.2
Tested on 32 bit Ubuntu on Python 3.2

Apart from the define macros the handling for attribute / key names and the module initialisation code needed to be updated.

Some other notes:
1. I did not install scipy so the scipy tests failed but this should have no relevance for ujson
2. The `test_encodeBigEscape` in `test_ujson` seems to consume a lot of memory (or is more memory limited) in Python 3. It only passed in my Ubuntu VM when I upped its RAM to 2GB.
3. Several unicode tests now skipped for Python 2.6 (mostly the same as those skipped for 2.5). I didn't investigate this too much apart from checking that they failed with 2.6 for the original ujson library as well (they did).
4. `test_encodeListLongConversion` needs to pass `dtype=np.int64` to succeed for Python 3 on 32 bit. Under Python 3 numpy converts `int` to `np.int32` on 32 bit machines (whereas under Python 2 it's `long` -> `np.int64`).
5. I did not test on Windows :-/
