### PR TITLE
ujson remove link dependence on npymath

### DIFF
--- a/pandas/src/ujson/lib/ultrajson.h
+++ b/pandas/src/ujson/lib/ultrajson.h
@@ -80,7 +80,9 @@ Dictates and limits how much stack space for buffers UltraJSON will use before r
 typedef __int64 JSINT64;
 typedef unsigned __int64 JSUINT64;
 
+#ifndef __MINGW32__
 typedef unsigned __int32 uint32_t;
+#endif
 typedef __int32 JSINT32;
 typedef uint32_t JSUINT32;
 typedef unsigned __int8 JSUINT8;

--- a/pandas/src/ujson/python/objToJSON.c
+++ b/pandas/src/ujson/python/objToJSON.c
@@ -2,8 +2,8 @@
 
 #include "py_defines.h"
 #include <numpy/arrayobject.h>
+#include <numpy/npy_math.h>
 #include <np_datetime.h>
-#include <numpy/halffloat.h>
 #include <stdio.h>
 #include <datetime.h>
 #include <ultrajson.h>
@@ -135,15 +135,6 @@ static void *PyIntToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_
 static void *PyLongToINT64(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
 {
     *((JSINT64 *) outValue) = GET_TC(tc)->longValue;
-    return NULL;
-}
-
-static void *NpyHalfToDOUBLE(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)
-{
-    PyObject *obj = (PyObject *) _obj;
-    unsigned long ctype;
-    PyArray_ScalarAsCtype(obj, &ctype);
-    *((double *) outValue) = npy_half_to_double (ctype);
     return NULL;
 }
 
@@ -1142,13 +1133,6 @@ void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc)
     {
         PRINTMARK();
         pc->PyTypeToJSON = NpyFloatToDOUBLE; tc->type = JT_DOUBLE;
-        return;
-    }
-    else
-    if (PyArray_IsScalar(obj, Half))
-    {
-        PRINTMARK();
-        pc->PyTypeToJSON = NpyHalfToDOUBLE; tc->type = JT_DOUBLE;
         return;
     }
     else

--- a/pandas/tests/test_ujson.py
+++ b/pandas/tests/test_ujson.py
@@ -802,9 +802,6 @@ class NumpyJSONTests(TestCase):
         num = np.float(256.2013)
         self.assertEqual(np.float(ujson.decode(ujson.encode(num))), num)
 
-        num = np.float16(256.2013)
-        self.assertEqual(np.float16(ujson.decode(ujson.encode(num))), num)
-
         num = np.float32(256.2013)
         self.assertEqual(np.float32(ujson.decode(ujson.encode(num))), num)
 
@@ -820,16 +817,9 @@ class NumpyJSONTests(TestCase):
             outp = np.array(ujson.decode(ujson.encode(inpt, double_precision=15)), dtype=dtype)
             assert_array_almost_equal_nulp(inpt, outp)
 
-        inpt = np.arange(1.5, 21.5, 0.2, dtype=np.float16)
-        outp = np.array(ujson.decode(ujson.encode(inpt)), dtype=np.float16)
-        assert_array_almost_equal_nulp(inpt, outp)
-
     def testFloatMax(self):
         num = np.float(np.finfo(np.float).max/10)
         assert_approx_equal(np.float(ujson.decode(ujson.encode(num))), num, 15)
-
-        num = np.float16(np.finfo(np.float16).max/10)
-        assert_approx_equal(np.float16(ujson.decode(ujson.encode(num))), num, 15)
 
         num = np.float32(np.finfo(np.float32).max/10)
         assert_approx_equal(np.float32(ujson.decode(ujson.encode(num))), num, 15)

--- a/setup.py
+++ b/setup.py
@@ -74,8 +74,6 @@ if np.__version__ < '1.6.1':
     msg = "pandas requires NumPy >= 1.6 due to datetime64 dependency"
     sys.exit(msg)
 
-from numpy.distutils.misc_util import get_pkg_info, get_info
-
 from distutils.extension import Extension
 from distutils.command.build import build
 from distutils.command.build_ext import build_ext
@@ -378,11 +376,6 @@ sparse_ext = Extension('pandas._sparse',
                        sources=[srcpath('sparse', suffix=suffix)],
                        include_dirs=[np.get_include()])
 
-npymath_info = get_info('npymath')
-
-npymath_libdir = npymath_info['library_dirs'][0]
-npymath_libdir = npymath_libdir.replace('\\\\', '\\')
-
 ujson_ext = Extension('pandas._ujson',
                       sources=['pandas/src/ujson/python/ujson.c',
                                'pandas/src/ujson/python/objToJSON.c',
@@ -395,10 +388,6 @@ ujson_ext = Extension('pandas._ujson',
                                     'pandas/src/ujson/lib',
                                     'pandas/src/datetime',
                                     np.get_include()],
-                      libraries=['npymath'],
-                      library_dirs=[npymath_libdir],
-                      # extra_link_args=[get_pkg_info('npymath').libs()]
-                      #extra_info=get_info('npymath')
                       )
 
 sandbox_ext = Extension('pandas._sandbox',


### PR DESCRIPTION
npymath causing build woes on win32 (#1309 and #1360)

Removed half float support. `npy_isnan` and `npy_isinf` are macros defined in the npymath header so linking isn't necessary. 

Also, build fix for mingw32.

Tested on Python 2.7 on 64-bit OSX, 32-bit Ubuntu and 32-bit WinXP (VS 2008 and mingw32). 
