### PR TITLE
ujson fix compile error using clang on Mac OS Lion

### DIFF
--- a/pandas/src/ujson/python/JSONtoObj.c
+++ b/pandas/src/ujson/python/JSONtoObj.c
@@ -156,7 +156,7 @@ JSOBJ Object_npyEndArray(JSOBJ obj)
             Npy_releaseContext(npyarr);
             return NULL;
         }
-        ((char*)PyArray_DATA(ret)) = new_data;
+        PyArray_BYTES(ret) = new_data;
     }
 
     if (npyarr->dec->curdim <= 0)
@@ -289,7 +289,7 @@ int Object_npyArrayAddItem(JSOBJ obj, JSOBJ value)
             PyErr_NoMemory();
             goto fail;
         }
-        ((char*)PyArray_DATA(npyarr->ret)) = new_data;
+        PyArray_BYTES(npyarr->ret) = new_data;
     }
 
     PyArray_DIMS(npyarr->ret)[0] = i + 1;


### PR DESCRIPTION
I had the compile error below when I built 0.8.0 beta1.  The build was on Mac OS X 10.7.3, using python.org's python version 2.7.3, numpy version 1.6.2, Apple clang version 3.1.

<pre>
clang: pandas/src/ujson/python/JSONtoObj.c
pandas/src/ujson/python/JSONtoObj.c:159:36: error: expression is not assignable
        ((char*)PyArray_DATA(ret)) = new_data;
        ~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
pandas/src/ujson/python/JSONtoObj.c:292:44: error: expression is not assignable
        ((char*)PyArray_DATA(npyarr->ret)) = new_data;
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
</pre>


This patch changes those lines to use PyArray_BYTES instead, so that the assignment is to an lvalue.  The build then succeeds, and nose tests pass.  I also successfully tested on a linux box (Scientific Linux 6.0), running python 2.6.6, numpy 1.6.2, and gcc 4.4.4. (I don't have a windows box to test on)
