### PR TITLE
Add support for tox (http://tox.testrun.org/) and Travis CI (http://travis-ci.org/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ scikits
 .coverage
 pandas.egg-info
 *\#*\#
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+
+python:
+  - 2.5
+  - 2.6
+  - 2.7
+  - 3.2
+
+install:
+  - "if [[ $TRAVIS_PYTHON_VERSION == '2.5' ]]; then pip install --use-mirrors simplejson; fi"
+  - pip install --use-mirrors cython numpy nose
+
+script:
+  - python setup.py build_ext --inplace
+  - python setup.py install
+  - nosetests pandas

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py25, py26, py27, py31, py32
+
+[testenv]
+commands =
+    {envpython} setup.py clean
+    {envpython} setup.py build_ext --inplace
+    nosetests pandas
+deps =
+    cython
+    numpy >= 1.6.1
+    nose


### PR DESCRIPTION
These are testing tools.

Tox is run locally and can be used on code that is not even checked in. It runs the test suite on various Python versions.

Travis CI is a hosted CI system that can run tests whenever new commits are pushed to the GitHub repo.

You can see the Travis CI status for my fork at http://travis-ci.org/#!/msabramo/pandas -- it's failing at the moment -- it probably needs some tweaks as I am completely new to pandas and I'm probably not building it correctly.
