### PR TITLE
DOC: Indicate that to_csv and from_csv methods can handle string file pa...

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -997,7 +997,7 @@ class DataFrame(NDFrame):
 
         Parameters
         ----------
-        path : string
+        path : string file path or file handle / StringIO
         header : int, default 0
             Row to use at header (skip prior rows)
         sep : string, default ','

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2346,7 +2346,7 @@ copy : boolean, default False
 
         Parameters
         ----------
-        path : string
+        path : string file path or file handle / StringIO
         sep : string, default ','
             Field delimiter
         parse_dates : boolean, default True
@@ -2377,8 +2377,7 @@ copy : boolean, default False
 
         Parameters
         ----------
-        path : string
-            File path
+        path : string file path or file handle / StringIO
         nanRep : string, default ''
             Missing data rep'n
         header : boolean, default False


### PR DESCRIPTION
...th and file-like objects for io.

It also seems a good idea to align the argument names: _path_, _path_or_buffer_, _filepath_or_buffer_ are all three used among `to_csv()`, `from_csv()`, `read_table()` to indicate the same. I did not touch those since that is an api change.
