### PR TITLE
Close SQL cursors before committing a connection.

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -77,6 +77,7 @@ def tquery(sql, con=None, cur=None, retry=True):
 
     if con is not None:
         try:
+            cur.close()
             con.commit()
         except Exception, e:
             excName = e.__class__.__name__
@@ -136,9 +137,11 @@ def read_frame(sql, con, index_col=None, coerce_float=True):
     """
     cur = execute(sql, con)
     rows = _safe_fetch(cur)
+    columns = [col_desc[0] for col_desc in cur.description]
+
+    cur.close()
     con.commit()
 
-    columns = [col_desc[0] for col_desc in cur.description]
     result = DataFrame.from_records(rows, columns=columns,
                                     coerce_float=coerce_float)
 


### PR DESCRIPTION
Cursor must always be closed before committing a connection
(http://stackoverflow.com/questions/9173073/python-mysql-mysqldb-testing-the-insert-function-its-not-adding-rows),
otherwise some DB client libraries will complain (specifically,
MySQLdb).
