### PR TITLE
BUG: ujson fix sniffing of dtype when decoding

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -786,6 +786,9 @@ class DataFrame(NDFrame):
         from pandas._ujson import loads
         df = None
 
+        if dtype is not None and orient == "split":
+            numpy = False
+
         if numpy:
             try:
                 if orient == "columns":

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -957,6 +957,9 @@ copy : boolean, default False
         from pandas._ujson import loads
         s = None
 
+        if dtype is not None and orient == "split":
+            numpy = False
+
         if numpy:
             try:
                 if orient == "split":

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2195,7 +2195,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
         df = DataFrame([['1', '2'], ['4', '5', '6']])
         unser = DataFrame.from_json(df.to_json())
-        self.assert_(np.isnan(unser['2'][0]))
+        self.assert_(unser['2'][0] is None)
 
         unser = DataFrame.from_json(df.to_json(), numpy=False)
         self.assert_(unser['2'][0] is None)


### PR DESCRIPTION
ujson was never auto-sniffing the dtype because `PyArray_DescrConverter` converts `None` to the numpy default dtype. It should instead use `PyArray_DescrConverter2` which converts `None` to `NULL`.

The rest of the changes are to fix tests related to this "new" behaviour.

Tested with Python 2.7 on 64 bit OSX, 32 bit Ubuntu and 32 bit WinXP with Mingw32 and MSVC. EPD is still seg faulting.
