### PR TITLE
Reenable py31 and py32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - 2.5
   - 2.6
   - 2.7
+  - 3.1
   - 3.2
 
 install:
@@ -11,6 +12,5 @@ install:
   - pip install --use-mirrors cython numpy nose pytz
 
 script:
-  - python setup.py build_ext --inplace
-  - python setup.py install
-  - nosetests pandas
+  - python setup.py build_ext install
+  - nosetests --exe -w /tmp pandas.tests

--- a/setup.py
+++ b/setup.py
@@ -201,11 +201,14 @@ if not ISRELEASED:
 else:
     FULLVERSION += QUALIFIER
 
-def write_version_py(filename='pandas/version.py'):
+def write_version_py(filename=None):
     cnt = """\
 version = '%s'
 short_version = '%s'
 """
+    if not filename:
+        filename = os.path.join(os.path.dirname(__file__), 'pandas', 'version.py')
+
     a = open(filename, 'w')
     try:
         a.write(cnt % (FULLVERSION, VERSION))

--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,32 @@ envlist = py25, py26, py27, py31, py32
 
 [testenv]
 commands =
-    {envpython} setup.py clean
-    {envpython} setup.py build_ext --inplace
-    nosetests pandas
+    {envpython} setup.py clean build_ext install
+    {envbindir}/nosetests tests
+    rm -rf {toxinidir}/build {toxinidir}/tests
 deps =
     cython
     numpy >= 1.6.1
     nose
     pytz
+
+[testenv:py25]
+changedir = .tox/py25/lib/python2.5/site-packages/pandas
+deps =
+    cython
+    numpy >= 1.6.1
+    nose
+    pytz
+    simplejson
+
+[testenv:py26]
+changedir = .tox/py26/lib/python2.6/site-packages/pandas
+
+[testenv:py27]
+changedir = .tox/py27/lib/python2.7/site-packages/pandas
+
+[testenv:py31]
+changedir = .tox/py31/lib/python3.1/site-packages/pandas
+
+[testenv:py32]
+changedir = .tox/py32/lib/python3.2/site-packages/pandas


### PR DESCRIPTION
Here is a Travis run that was successful for Python 2.6, 2.7, 3.1, and 3.2:

http://travis-ci.org/#!/msabramo/pandas/builds/1596467
