### PR TITLE
Add parentheses to a print statement so it compiles under Python 3

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -79,7 +79,7 @@ def latex():
 
         os.chdir('../..')
     else:
-        print 'latex build has not been tested on windows'
+        print('latex build has not been tested on windows')
 
 def check_build():
     build_dirs = [


### PR DESCRIPTION
Just fixing a Python 2-style print statement in docs/make.py so it'll compile under Python 3. (Untested but I can't imagine how this would break anything)
