### PR TITLE
fix for issue 1548, remove import of matplotlib.pyplot

### DIFF
--- a/pandas/tseries/converter.py
+++ b/pandas/tseries/converter.py
@@ -5,7 +5,6 @@ import numpy as np
 import matplotlib.units as units
 import matplotlib.dates as dates
 import matplotlib.cbook as cbook
-from matplotlib import pylab
 from matplotlib.ticker import Formatter, AutoLocator, Locator
 from matplotlib.transforms import nonsingular
 


### PR DESCRIPTION
not sure how to craft a test for this, especially given as we may not be able to presume which backends are present on a system, nor does there seem to be an easy way to find out, but local run of the above code ceased raising the warning.
