### PR TITLE
BUG: no longer ignore given axes in boxplot

### DIFF
--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1037,7 +1037,8 @@ def boxplot(data, column=None, by=None, ax=None, fontsize=None,
             by = [by]
 
         fig, axes = _grouped_plot_by_column(plot_group, data, columns=columns,
-                                            by=by, grid=grid, figsize=figsize)
+                                            by=by, grid=grid, figsize=figsize,
+                                            ax=ax)
 
         # Return axes in multiplot case, maybe revisit later # 985
         ret = axes


### PR DESCRIPTION
If by is specified, boxplot was ignoring the given axes.
