### PR TITLE
Frame corr

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3841,7 +3841,9 @@ class DataFrame(NDFrame):
             for i, ac in enumerate(mat):
                 for j, bc  in enumerate(mat):
                     valid = mask[i] & mask[j]
-                    if not valid.all():
+                    if not valid.any():
+                        c = np.nan
+                    elif not valid.all():
                         c = corrf(ac[valid], bc[valid])
                     else:
                         c = corrf(ac, bc)

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -347,7 +347,10 @@ def get_corr_func(method):
     def _pearson(a, b):
         return np.corrcoef(a, b)[0, 1]
     def _kendall(a, b):
-        return kendalltau(a, b)[0]
+        rs = kendalltau(a, b)
+        if isinstance(rs, tuple):
+            return rs[0]
+        return rs
     def _spearman(a, b):
         return spearmanr(a, b)[0]
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3591,6 +3591,14 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         expected = self.mixed_frame.ix[:, ['A', 'B', 'C', 'D']].corr()
         assert_frame_equal(result, expected)
 
+        # nothing in common
+        for meth in ['pearson', 'kendall', 'spearman']:
+            df = DataFrame({'A': [1, 1, 1, np.nan, np.nan, np.nan],
+                            'B': [np.nan, np.nan, np.nan, 1, 1, 1]})
+            rs = df.corr(meth)
+            self.assert_(isnull(rs.ix['A', 'B']))
+            self.assert_(isnull(rs.ix['B', 'A']))
+
     def test_cov(self):
         self.frame['A'][:5] = nan
         self.frame['B'][:10] = nan

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -333,6 +333,27 @@ class TestDataFramePlots(unittest.TestCase):
     def _check_plot_fails(self, f, *args, **kwargs):
         self.assertRaises(Exception, f, *args, **kwargs)
 
+    @slow
+    def test_style_by_column(self):
+        import matplotlib.pyplot as plt
+        fig = plt.gcf()
+        fig.clf()
+        fig.add_subplot(111)
+
+        df = DataFrame(np.random.randn(100, 3))
+        markers = {0: '^', 1: '+', 2: 'o'}
+        ax = df.plot(style=markers)
+        for i, l in enumerate(ax.get_lines()):
+            self.assertEqual(l.get_marker(), markers[i])
+
+        fig.clf()
+        fig.add_subplot(111)
+        df = DataFrame(np.random.randn(100, 3))
+        markers = ['^', '+', 'o']
+        ax = df.plot(style=markers)
+        for i, l in enumerate(ax.get_lines()):
+            self.assertEqual(l.get_marker(), markers[i])
+
 class TestDataFrameGroupByPlots(unittest.TestCase):
 
     @classmethod


### PR DESCRIPTION
kendalltau usually returns a tuple but for kendalltau([1, 1, 1], [1, 1, 1]) it returns int, so _kendall in nanops.get_corr_func was failing

if empty arrays are passed in, kendalltau leads to max recursion depth exceeded in mergesort, so must check valid.any before valid.all case.
