### PR TITLE
Fixes bug in tools.scatter_plot

### DIFF
--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1611,6 +1611,7 @@ def _grouped_plot(plotf, data, column=None, by=None, numeric_only=True,
                   figsize=None, sharex=True, sharey=True, layout=None,
                   rot=0, ax=None):
     from pandas.core.frame import DataFrame
+    import matplotlib.pyplot as plt
 
     # allow to specify mpl default with 'default'
     if figsize is None or figsize == 'default':
@@ -1631,9 +1632,15 @@ def _grouped_plot(plotf, data, column=None, by=None, numeric_only=True,
     fig, axes = _subplots(nrows=nrows, ncols=ncols, figsize=figsize,
                           sharex=sharex, sharey=sharey, ax=ax)
 
-    ravel_axes = []
-    for row in axes:
-        ravel_axes.extend(row)
+    if isinstance(axes, plt.Axes):
+        ravel_axes = [axes]
+    else:
+        ravel_axes = []
+        for row in axes:
+            if isinstance(row, plt.Axes):
+                ravel_axes.append(row)
+            else:
+                ravel_axes.extend(row)
 
     for i, (key, group) in enumerate(grouped):
         ax = ravel_axes[i]


### PR DESCRIPTION
```
In [1]: import pandas

In [2]: from pandas.tools.plotting import scatter_plot

In [7]: df = pandas.DataFrame(np.random.randn(5,2), columns=['a','b'])

In [8]: df
Out[8]: 
          a         b
0  0.032454  0.057020
1 -0.292223 -0.265303
2 -0.118943  1.315302
3 -2.754867  0.827289
4  0.497206 -1.360892

In [9]: df['c'] = [True, True, False, True, False]

In [10]: df
Out[10]: 
          a         b      c
0  0.032454  0.057020   True
1 -0.292223 -0.265303   True
2 -0.118943  1.315302  False
3 -2.754867  0.827289   True
4  0.497206 -1.360892  False

In [11]: scatter_plot(df, "a", "b", by="c")
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/Users/johnnybrown/Desktop/src/pandas/pandas/<ipython-input-11-95d97e8283db> in <module>()
----> 1 scatter_plot(df, "a", "b", by="c")

/Users/johnnybrown/Desktop/src/pandas/pandas/tools/plotting.py in scatter_plot(data, x, y, by, ax, figsize, grid)
   1419 
   1420     if by is not None:
-> 1421         fig = _grouped_plot(plot_group, data, by=by, figsize=figsize, ax=ax)
   1422     else:
   1423         if ax is None:

/Users/johnnybrown/Desktop/src/pandas/pandas/tools/plotting.py in _grouped_plot(plotf, data, column, by, numeric_only, figsize, sharex, sharey, layout, rot, ax)
   1634     ravel_axes = []
   1635     for row in axes:
-> 1636         ravel_axes.extend(row)
   1637 
   1638     for i, (key, group) in enumerate(grouped):

TypeError: 'AxesSubplot' object is not iterable

```
