### PR TITLE
DOC: skipna not an argument of drop_duplicates

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2532,8 +2532,6 @@ class DataFrame(NDFrame):
             default use all of the columns
         take_last : boolean, default False
             Take the last observed row in a row. Defaults to the first row
-        skipna : boolean, default True
-            If True then keep NaN
         inplace : boolean, default False
             Whether to drop duplicates in place or to return a copy
 


### PR DESCRIPTION
From what I can tell, `skipna` keyword was both added and subsequently
removed in #1244. However, the docstring for DataFrame.drop_duplicates
still lists it as a parameter.

I remove this from the docs, so they accurately represent the code.
An alternative to this would be to put back the skipna functionality.

pinging @changhiskhan, since he was the one that worked on this.
