### PR TITLE
Support for HTML class'es on DataFrame.to_html().

### DIFF
--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -355,12 +355,16 @@ class DataFrameFormatter(object):
                 fmt_values[i] = self._format_col(i)
 
             # write values
+            index_formatter = self.formatters.get('__index__', None)
             for i in range(len(frame)):
                 row = []
+                index_value = frame.index[i]
+                if index_formatter:
+                    index_value = index_formatter(index_value)
                 if isinstance(frame.index, MultiIndex):
-                    row.extend(_maybe_bold_row(frame.index[i]))
+                    row.extend(_maybe_bold_row(index_value))
                 else:
-                    row.append(_maybe_bold_row(frame.index[i]))
+                    row.append(_maybe_bold_row(index_value))
                 for j in range(len(self.columns)):
                     row.append(fmt_values[j][i])
                 write_tr(row, indent, indent_delta)
@@ -415,6 +419,7 @@ class DataFrameFormatter(object):
         return _has_names(self.frame.columns)
 
     def _get_formatted_index(self):
+        # Note: this is only used by to_string(), not by to_html().
         index = self.frame.index
         columns = self.frame.columns
 

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -255,7 +255,7 @@ class DataFrameFormatter(object):
                             na_rep=self.na_rep,
                             space=self.col_space)
 
-    def to_html(self):
+    def to_html(self, classes=None):
         """
         Render a DataFrame to a html table.
         """
@@ -291,7 +291,13 @@ class DataFrameFormatter(object):
         indent_delta = 2
         frame = self.frame
 
-        write('<table border="1">', indent)
+        _classes = ['dataframe'] # Default class.
+        if classes is not None:
+            if isinstance(classes, str):
+                classes = classes.split()
+            assert isinstance(classes, (list, tuple))
+            _classes.extend(classes)
+        write('<table border="1" class="%s">' % ' '.join(_classes), indent)
 
         def _column_header():
             row = [''] * (frame.index.nlevels - 1)

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -281,7 +281,7 @@ class DataFrameFormatter(object):
         for i, row in enumerate(izip(*strcols)):
             if i == nlevels:
                 self.buf.write('\\hline\n') # End of header
-            crow = [(x.replace('_', '\\_') if x else '{}') for x in row]
+            crow = [(x.replace('_', '\\_').replace('%', '\\%').replace('&', '\\&') if x else '{}') for x in row]
             self.buf.write(' & '.join(crow))
             self.buf.write(' \\\\\n')
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1240,7 +1240,7 @@ class DataFrame(NDFrame):
     def to_html(self, buf=None, columns=None, col_space=None, colSpace=None,
                 header=True, index=True, na_rep='NaN', formatters=None,
                 float_format=None, sparsify=None, index_names=True,
-                bold_rows=True):
+                bold_rows=True, classes=None):
         """
         to_html-specific options
         bold_rows : boolean, default True
@@ -1263,7 +1263,7 @@ class DataFrame(NDFrame):
                                            bold_rows=bold_rows,
                                            sparsify=sparsify,
                                            index_names=index_names)
-        formatter.to_html()
+        formatter.to_html(classes=classes)
 
         if buf is None:
             return formatter.buf.getvalue()

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1268,6 +1268,32 @@ class DataFrame(NDFrame):
         if buf is None:
             return formatter.buf.getvalue()
 
+    @Appender(fmt.docstring_to_string, indents=1)
+    def to_latex(self, buf=None, columns=None, col_space=None, colSpace=None,
+                 header=True, index=True, na_rep='NaN', formatters=None,
+                 float_format=None, sparsify=None, index_names=True,
+                 bold_rows=True):
+        """
+        to_latex-specific options
+        bold_rows : boolean, default True
+            Make the row labels bold in the output
+
+        Render a DataFrame to a tabular environment table.
+        You can splice this into a LaTeX document.
+        """
+        formatter = fmt.DataFrameFormatter(self, buf=buf, columns=columns,
+                                           col_space=col_space, na_rep=na_rep,
+                                           header=header, index=index,
+                                           formatters=formatters,
+                                           float_format=float_format,
+                                           bold_rows=bold_rows,
+                                           sparsify=sparsify,
+                                           index_names=index_names)
+        formatter.to_latex()
+
+        if buf is None:
+            return formatter.buf.getvalue()
+
     def info(self, verbose=True, buf=None):
         """
         Concise summary of a DataFrame, used in __repr__ when very large.

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -6,6 +6,7 @@ except:
 import os
 import sys
 import unittest
+from textwrap import dedent
 
 from numpy import nan
 from numpy.random import randn
@@ -413,7 +414,7 @@ class TestDataFrameFormatting(unittest.TestCase):
                                                 names=['CL0', 'CL1'])
         df = pandas.DataFrame([list('abcd'), list('efgh')], columns=columns)
         result = df.to_html()
-        expected = ('<table border="1">\n'
+        expected = ('<table border="1" class="dataframe">\n'
                     '  <thead>\n'
                     '    <tr>\n'
                     '      <th><table><tbody><tr><td>CL0</td></tr><tr>'
@@ -451,7 +452,7 @@ class TestDataFrameFormatting(unittest.TestCase):
                                                     np.mod(range(4), 2)))
         df = pandas.DataFrame([list('abcd'), list('efgh')], columns=columns)
         result = df.to_html()
-        expected = ('<table border="1">\n'
+        expected = ('<table border="1" class="dataframe">\n'
                     '  <thead>\n'
                     '    <tr>\n'
                     '      <th></th>\n'
@@ -494,6 +495,27 @@ class TestDataFrameFormatting(unittest.TestCase):
         self.frame._repr_html_()
 
         fmt.reset_printoptions()
+
+    def test_to_html_with_classes(self):
+        df = pandas.DataFrame()
+        result = df.to_html(classes="sortable draggable")
+        expected = dedent("""
+
+            <table border="1" class="dataframe sortable draggable">
+              <tbody>
+                <tr>
+                  <td>Index([], dtype=object)</td>
+                  <td>Empty DataFrame</td>
+                </tr>
+              </tbody>
+            </table>
+
+        """).strip()
+        self.assertEqual(result, expected)
+
+        result = df.to_html(classes=["sortable", "draggable"])
+        self.assertEqual(result, expected)
+
 
 class TestSeriesFormatting(unittest.TestCase):
 


### PR DESCRIPTION
I really like to use sorttable.js and dragtable.js.
I need to be able to customize the HTML classes.
I also added a default class, so that people can use css on all Pandas generated tables by default.
Default class is "dataframe"
