### PR TITLE
Handle NoneType docstrings to support the -OO interpreter option

### DIFF
--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -156,6 +156,7 @@ class DataFrameFormatter(object):
 
     """
 
+    __doc__ = __doc__ if __doc__ else ''
     __doc__ += docstring_to_string
 
     def __init__(self, frame, buf=None, columns=None, col_space=None,

--- a/pandas/util/decorators.py
+++ b/pandas/util/decorators.py
@@ -93,7 +93,9 @@ class Appender(object):
         self.join = join
 
     def __call__(self, func):
-        docitems = [func.__doc__ if func.__doc__ else '', self.addendum]
+        func.__doc__ = func.__doc__ if func.__doc__ else ''
+        self.addendum = self.addendum if self.addendum else ''
+        docitems = [func.__doc__, self.addendum]
         func.__doc__ = ''.join(docitems)
         return func
 


### PR DESCRIPTION
This fixes the issue I described in #1741.

When running uWSGI with the `--optimize` option set to `2`, it passes the `-OO` option to the interpreter and then there are no docstrings and pandas errors out during import.

I also noticed there was a note about this [here](https://github.com/pydata/pandas/blob/master/pandas/util/decorators.py#L74).
