### PR TITLE
Fix tostring unicode

### DIFF
--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -227,7 +227,11 @@ class DataFrameFormatter(object):
 
         if not py3compat.PY3:
             if force_unicode:
-                strcols = map(lambda col: map(unicode, col), strcols)
+                def make_unicode(x):
+                    if isinstance(x, unicode):
+                        return x
+                    return x.decode('utf-8')
+                strcols = map(lambda col: map(make_unicode, col), strcols)
             else:
                 # generally everything is plain strings, which has ascii
                 # encoding.  problem is when there is a char with value over 127
@@ -235,7 +239,11 @@ class DataFrameFormatter(object):
                 try:
                     map(lambda col: map(str, col), strcols)
                 except UnicodeError:
-                    strcols = map(lambda col: map(unicode, col), strcols)
+                    def make_unicode(x):
+                        if isinstance(x, unicode):
+                            return x
+                        return x.decode('utf-8')
+                    strcols = map(lambda col: map(make_unicode, col), strcols)
 
         return strcols
 

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 try:
     from StringIO import StringIO
 except:
@@ -109,6 +111,12 @@ class TestDataFrameFormatting(unittest.TestCase):
         dm = DataFrame(['\xc2'])
         buf = StringIO()
         dm.to_string(buf)
+
+    def test_to_string_force_unicode(self):
+        #given string with non-ascii characters
+        df = DataFrame([["aaää", 1], ["bbbb", 2]])
+        result = df.to_string(force_unicode=True)
+        self.assertEqual(result, u'      0  1\n0  aa\xe4\xe4  1\n1  bbbb  2')
 
     def test_to_string_with_formatters(self):
         df = DataFrame({'int': [1, 2, 3],


### PR DESCRIPTION
I'm not sure if this is perfect (or where else things like this might come up), but this fixes the failing test I added and the rest of the test suite passes. The issue arises when you give a string containing non-ascii characters. You have to decode to unicode (which I force to be utf-8...). I don't know the Python 3 issues, if any (it's in a Python 2 protected block of code). See issue #1620.
