### PR TITLE
print exception when importing pandas.lib

### DIFF
--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -8,7 +8,8 @@ import numpy as np
 
 try:
     import pandas.lib as lib
-except Exception:  # pragma: no cover
+except Exception,e :  # pragma: no cover
+    print e
     import sys
     e = sys.exc_info()[1] # Py25 and Py3 current exception syntax conflict
     if 'No module named' in str(e):


### PR DESCRIPTION
I was trying to install pandas and kept getting the error:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Python/2.7/site-packages/pandas/**init**.py", line 16, in <module>
    raise ImportError('C extensions not built: if you installed already '
ImportError: C extensions not built: if you installed already verify that you are not importing from the source directory

I couldn't figure out what was happening until I made this change and saw from the printed out exception that I  didn't have the dateutils package installed.
