### PR TITLE
fixed row/col orientation for 2D arrays

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -686,7 +686,10 @@ class HDFStore(object):
     def _write_array(self, group, key, value):
         if key in group:
             self.handle.removeNode(group, key)
-
+        
+        #Transform needed to interface with pytables row/col notation
+        value = value.T
+        
         if self.filters is not None:
             atom = None
             try:


### PR DESCRIPTION
Pytables uses the opposite convention to pandas for row/col. Using the numpy transpose .T corrects for this without copying the data and keeping the orientation of 1D arrays intact.
