### PR TITLE
Tiny str() fix, pandas/stats/ols.py

### DIFF
--- a/pandas/stats/ols.py
+++ b/pandas/stats/ols.py
@@ -538,7 +538,7 @@ Degrees of Freedom: model %(df_model)d, resid %(df_resid)d
 
         f_stat = results['f_stat']
 
-        bracketed = ['<%s>' % c for c in results['beta'].index]
+        bracketed = ['<%s>' %str(c) for c in results['beta'].index]
 
         formula = StringIO()
         formula.write(bracketed[0])


### PR DESCRIPTION
Fix for unexpected behaviour (TypeError: not all arguments converted during string formatting) if c is a tuple, as it can be when having collapsed the multiindex columns like df_with_tuple_columns = df_with_multiindex.columns.tolist()
