### PR TITLE
Better error message for mixed series/nonseries DataFrame construction

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4841,7 +4841,10 @@ def extract_index(data):
                                  'ambiguous ordering.')
 
             if have_series:
-                assert(lengths[0] == len(index))
+                if lengths[0] != len(index):
+                    msg = ('array length %d does not match index length %d'
+                          % (lengths[0], len(index)))
+                    raise ValueError(msg)
             else:
                 index = Index(np.arange(lengths[0]))
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2173,7 +2173,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
                         'B' : list(self.frame['B'])}, columns=['A', 'B'])
         assert_frame_equal(df, self.frame.ix[:, ['A', 'B']])
 
-        self.assertRaises(Exception, DataFrame,
+        self.assertRaises(ValueError, DataFrame,
                           {'A' : self.frame['A'],
                            'B' : list(self.frame['B'])[:-2]})
 


### PR DESCRIPTION
While trying the tutorial, I decided to see what happens when I break things. I got a bare `AssertionError`, which I don't like, so I decided to replace it with a `ValueError` holding an appropriate error message.
