### PR TITLE
ENH: Add default_index method to DataFrame

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2456,6 +2456,29 @@ class DataFrame(NDFrame):
         frame.index = index
         return frame
 
+    def default_index(self, inplace=False):
+        """
+        Resets index to default of consecutive integers.
+
+        Parameters
+        ----------
+        inplace : bool
+            Modify the DataFrame in place (do not create a new object)
+
+        Returns
+        -------
+        df : DataFrame
+            DataFrame with new index
+        """
+        if inplace:
+            new_obj = self
+        else:
+            new_obj = self.copy()
+        N, _ = new_obj.shape
+        new_obj.index = _default_index(N)
+        return new_obj
+
+
     def reset_index(self, level=None, drop=False, inplace=False):
         """
         For DataFrame with multi-level index, return new DataFrame with

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1454,6 +1454,13 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self.assert_(self.frame._get_axis(0) is self.frame.index)
         self.assert_(self.frame._get_axis(1) is self.frame.columns)
 
+    def test_default_index(self):
+        frame = DataFrame([[1,2,3],[1,3,4],[2,5,6],[8,9,10]],
+                        columns=['A','B','C'])
+        frame.drop_duplicates('A', inplace=True)
+        frame.default_index(inplace=True)
+        self.assert_(np.array_equal(frame.index, range(3)))
+
     def test_set_index(self):
         idx = Index(np.arange(len(self.mixed_frame)))
 


### PR DESCRIPTION
This partially addresses #1894. Just a method to reset the index in the sense of give me the default np.range index.
