### PR TITLE
ENH: autocov function for Series

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1513,6 +1513,38 @@ copy : boolean, default False
         """
         return self.corr(self.shift(1))
 
+    def autocov(self, j=1, unbiased=False):
+        """
+        j-lag autocovariance
+
+        Parameters
+        ----------
+        j: int, default 1
+            Periods to lag the covariance calculation by
+        unbiased : boolean, default False
+            If true return an unbiased estimator of the autocovariance
+
+        Returns
+        -------
+        autocov : float
+        """
+        n = len(self)
+
+        if abs(j) >= n:
+            raise Exception('lag parameter must be within the bounds of n')
+        if n == 0:
+            return np.nan
+
+        this = self - self.mean()
+        shifted = this.shift(-j)
+
+        if unbiased:
+            d = n - j
+        else:
+            d = n
+
+        return float(np.correlate(self[:n - j], shifted[:n - j]) / d)
+
     def clip(self, lower=None, upper=None, out=None):
         """
         Trim values at input threshold(s)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1524,6 +1524,11 @@ copy : boolean, default False
         unbiased : boolean, default False
             If true return an unbiased estimator of the autocovariance
 
+        See Also
+        --------
+        statsmodels.tsa.statstools.acovf for autocovariance function, which
+        returns an array of lagged autocovariances
+
         Returns
         -------
         autocov : float

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1530,7 +1530,7 @@ copy : boolean, default False
         """
         n = len(self)
 
-        if abs(j) >= n or n == 0
+        if abs(j) >= n or n == 0:
             return np.nan
 
         this = self - self.mean()
@@ -1541,7 +1541,8 @@ copy : boolean, default False
         else:
             d = n
 
-        return float(np.correlate(self[:n - j], shifted[:n - j]) / d)
+        return float(np.correlate(this[:n - j].values,
+                                  shifted[:n - j].values)) / d
 
     def clip(self, lower=None, upper=None, out=None):
         """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1530,9 +1530,7 @@ copy : boolean, default False
         """
         n = len(self)
 
-        if abs(j) >= n:
-            raise Exception('lag parameter must be within the bounds of n')
-        if n == 0:
+        if abs(j) >= n or n == 0
             return np.nan
 
         this = self - self.mean()

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1841,6 +1841,18 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         cp[:] = np.nan
         self.assert_(isnull(cp.cov(cp)))
 
+    def test_autocov(self):
+
+        ts = Series([1, 2, 3] * 1000)
+
+        #too big of lag
+        self.assert_(np.isnan(ts.autocov(j=len(ts) + 1)))
+
+        lag = 1
+        n = len(ts)
+        self.assertAlmostEqual(ts.var(), ts.autocov() / ts.autocorr())
+
+
     def test_copy(self):
         ts = self.ts.copy()
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1848,8 +1848,7 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         #too big of lag
         self.assert_(np.isnan(ts.autocov(j=len(ts) + 1)))
 
-        lag = 1
-        n = len(ts)
+        #test calculations
         self.assertAlmostEqual(ts.autocov(j=0), 2.0/3)
         self.assertAlmostEqual(ts.autocov(j=1), -1.0/6)
         self.assertAlmostEqual(ts.autocov(j=2), -1.0/3)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1843,14 +1843,16 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
 
     def test_autocov(self):
 
-        ts = Series([1, 2, 3] * 1000)
+        ts = Series([1, 2, 3] * 2)
 
         #too big of lag
         self.assert_(np.isnan(ts.autocov(j=len(ts) + 1)))
 
         lag = 1
         n = len(ts)
-        self.assertAlmostEqual(ts.var(), ts.autocov() / ts.autocorr())
+        self.assertAlmostEqual(ts.autocov(j=0), 2.0/3)
+        self.assertAlmostEqual(ts.autocov(j=1), -1.0/6)
+        self.assertAlmostEqual(ts.autocov(j=2), -1.0/3)
 
 
     def test_copy(self):


### PR DESCRIPTION
Add an autocov function to Series.

Default is single lag w/ bias, but those are configurable.
