### PR TITLE
ENH: Allow DataFrame.update to work on non DataFrame object if coercible

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3359,7 +3359,7 @@ class DataFrame(NDFrame):
 
         Parameters
         ----------
-        other : DataFrame
+        other : DataFrame, or object coercible into a DataFrame
         join : {'left', 'right', 'outer', 'inner'}, default 'left'
         overwrite : boolean, default True
             If True then overwrite values for common keys in the calling frame
@@ -3373,7 +3373,11 @@ class DataFrame(NDFrame):
         if join != 'left':
             raise NotImplementedError
 
+        if not isinstance(other, DataFrame):
+            other = DataFrame(other)
+
         other = other.reindex_like(self)
+
         for col in self.columns:
             this = self[col].values
             that = other[col].values

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5784,11 +5784,6 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
                               [1.5, nan, 7.]])
         assert_frame_equal(df, expected)
 
-
-
-
-
-
     def test_update_nooverwrite(self):
         df = DataFrame([[1.5, nan, 3.],
                         [1.5, nan, 3.],

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5762,6 +5762,11 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
                               [1.5, nan, 7.]])
         assert_frame_equal(df, expected)
 
+
+
+
+
+
     def test_update_nooverwrite(self):
         df = DataFrame([[1.5, nan, 3.],
                         [1.5, nan, 3.],
@@ -5807,6 +5812,27 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
         np.testing.assert_raises(Exception, df.update, *(other,),
                 **{'raise_conflict' : True})
+
+    def test_update_from_non_df(self):
+        d = {'a': Series([1, 2, 3, 4]), 'b': Series([5, 6, 7, 8])}
+        df = DataFrame(d)
+
+        d['a'] = Series([5, 6, 7, 8])
+        df.update(d)
+
+        expected = DataFrame(d)
+
+        assert_frame_equal(df, expected)
+
+        d = {'a': [1, 2, 3, 4], 'b': [5, 6, 7, 8]}
+        df = DataFrame(d)
+
+        d['a'] = [5, 6, 7, 8]
+        df.update(d)
+
+        expected = DataFrame(d)
+
+        assert_frame_equal(df, expected)
 
     def test_combineAdd(self):
         # trivial


### PR DESCRIPTION
On issue #1988, a new Panel.update function should accept a dict of DataFrames.  Right now, DataFrame.update can't accept a dict of Series (or a dict of arrays for example).  To me, it wouldn't make much sense for Panel.update to have the functionality while a DataFrame does not.

Currently:

```
>>> df.update(s) #s is a dict of arrays or of Series
...
AttributeError: 'dict' object has no attribute 'reindex_like'
```
