### PR TITLE
ENH: Add method Panel.update

### DIFF
--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -1318,6 +1318,36 @@ class Panel(NDFrame):
             return concat([self] + list(other), axis=0, join=how,
                           join_axes=join_axes, verify_integrity=True)
 
+    def update(self, other, join='left', overwrite=True, filter_func=None,
+                     raise_conflict=False):
+        """
+        Modify Panel in place using non-NA values from passed
+        Panel, or object coercible to Panel. Aligns on items
+
+        Parameters
+        ----------
+        other : Panel, or object coercible to Panel
+        join : How to join individual DataFrames
+            {'left', 'right', 'outer', 'inner'}, default 'left'
+        overwrite : boolean, default True
+            If True then overwrite values for common keys in the calling panel
+        filter_func : callable(1d-array) -> 1d-array<boolean>, default None
+            Can choose to replace values other than NA. Return True for values
+            that should be updated
+        raise_conflict : bool
+            If True, will raise an error if a DataFrame and other both
+            contain data in the same place.
+        """
+
+        if not isinstance(other, Panel):
+            other = Panel(other)
+
+        other = other.reindex(items=self.items)
+
+        for frame in self.items:
+            self[frame].update(other[frame], join, overwrite, filter_func,
+                               raise_conflict)
+
     def _get_join_index(self, other, how):
         if how == 'left':
             join_major, join_minor = self.major_axis, self.minor_axis

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1187,6 +1187,122 @@ class TestPanel(unittest.TestCase, PanelTests, CheckIndexing,
         exp = p.ix[['a', 'c', 'd']]
         assert_panel_equal(result, exp)
 
+    def test_update(self):
+        pan = Panel([[[1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.]],
+                   [[1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.]]])
+
+        other = Panel([[[3.6, 2., np.nan],
+                           [np.nan, np.nan, 7]]], items=[1])
+
+        pan.update(other)
+
+        expected = Panel([[[1.5, np.nan, 3.],
+                              [1.5, np.nan, 3.],
+                              [1.5, np.nan, 3.],
+                              [1.5, np.nan, 3.]],
+                             [[3.6, 2., 3],
+                              [1.5, np.nan, 7],
+                              [1.5, np.nan, 3.],
+                              [1.5, np.nan, 3.]]])
+
+        assert_panel_equal(pan, expected)
+
+    def test_update_from_dict(self):
+        pan = Panel({'one': DataFrame([[1.5, np.nan, 3],
+                              [1.5, np.nan, 3],
+                              [1.5, np.nan, 3.],
+                              [1.5, np.nan, 3.]]),
+                      'two': DataFrame([[1.5, np.nan, 3.],
+                              [1.5, np.nan, 3.],
+                              [1.5, np.nan, 3.],
+                              [1.5, np.nan, 3.]])})
+
+        other = {'two': DataFrame([[3.6, 2., np.nan],
+                               [np.nan, np.nan, 7]])}
+
+        pan.update(other)
+
+        expected = Panel({'two': DataFrame([[3.6, 2., 3],
+                              [1.5, np.nan, 7],
+                              [1.5, np.nan, 3.],
+                              [1.5, np.nan, 3.]]),
+                          'one': DataFrame([[1.5, np.nan, 3.],
+                              [1.5, np.nan, 3.],
+                              [1.5, np.nan, 3.],
+                              [1.5, np.nan, 3.]])})
+
+        assert_panel_equal(pan, expected)
+
+    def test_update_nooverwrite(self):
+        pan = Panel([[[1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.]],
+                   [[1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.]]]) 
+
+        other = Panel([[[3.6, 2., np.nan],
+                        [np.nan, np.nan, 7]]], items=[1])
+
+        pan.update(other, overwrite=False)
+
+        expected = Panel([[[1.5, np.nan, 3],
+                              [1.5, np.nan, 3],
+                              [1.5, np.nan, 3.],
+                              [1.5, np.nan, 3.]],
+                             [[1.5, 2., 3.],
+                              [1.5, np.nan, 3.],
+                              [1.5, np.nan, 3.],
+                              [1.5, np.nan, 3.]]])
+
+        assert_panel_equal(pan, expected)
+
+    def test_update_filtered(self):
+        pan = Panel([[[1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.]],
+                   [[1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.]]])
+
+        other = Panel([[[3.6, 2., np.nan],
+                           [np.nan, np.nan, 7]]], items=[1])
+
+        pan.update(other, filter_func=lambda x: x > 2)
+
+        expected = Panel([[[1.5, np.nan, 3.],
+                              [1.5, np.nan, 3.],
+                              [1.5, np.nan, 3.],
+                              [1.5, np.nan, 3.]],
+                             [[1.5, np.nan, 3],
+                              [1.5, np.nan, 7],
+                              [1.5, np.nan, 3.],
+                              [1.5, np.nan, 3.]]])
+
+        assert_panel_equal(pan, expected)
+
+    def test_update_raise(self):
+        pan = Panel([[[1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.]],
+                   [[1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.],
+                    [1.5, np.nan, 3.]]])
+
+        np.testing.assert_raises(Exception, pan.update, *(pan,),
+            **{'raises_conflick': True})
 
 class TestLongPanel(unittest.TestCase):
     """

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1302,7 +1302,7 @@ class TestPanel(unittest.TestCase, PanelTests, CheckIndexing,
                     [1.5, np.nan, 3.]]])
 
         np.testing.assert_raises(Exception, pan.update, *(pan,),
-            **{'raises_conflick': True})
+            **{'raise_conflict': True})
 
 class TestLongPanel(unittest.TestCase):
     """


### PR DESCRIPTION
```
panel_one.update(panel_two)
```

Addresses Issue #1988.
Delegates most the work to DataFrame.update.  Aligns on items whereas DataFrame.update aligns on indices. 
