### PR TITLE
ENH: Use given name for DataFrame column name for FRED API

### DIFF
--- a/pandas/io/data.py
+++ b/pandas/io/data.py
@@ -178,7 +178,8 @@ def get_data_fred(name=None, start=dt.datetime(2010, 1, 1),
 
     url = fred_URL + '%s' % name + \
       '/downloaddata/%s' % name + '.csv'
-    data = read_csv(urllib.urlopen(url), index_col=0, parse_dates=True)
+    data = read_csv(urllib.urlopen(url), index_col=0, parse_dates=True, header=None,
+                    skiprows=1, names=["DATE", name])
     return data.truncate(start, end)
 
 


### PR DESCRIPTION
Go ahead and use the given name for the series name instead of the generic VALUE. Makes grabbing and joining multiple series a bit easier, though I suspect there's a way to do this through the API.
