### PR TITLE
Fix naming of ewmvar and ewmstd in documentation

### DIFF
--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -397,8 +397,8 @@ available:
     :widths: 20, 80
 
     ``ewma``, EW moving average
-    ``ewvar``, EW moving variance
-    ``ewstd``, EW moving standard deviation
+    ``ewmvar``, EW moving variance
+    ``ewmstd``, EW moving standard deviation
     ``ewmcorr``, EW moving correlation
     ``ewmcov``, EW moving covariance
 


### PR DESCRIPTION
These functions were misnamed in the documentation, I was quite confused for a while until I figured out where they were so I thought I'd fix it. ewstd should have been ewmstd and ewvar should have been ewmvar.
