### PR TITLE
ENH: pivot_annual with a better exception message

### DIFF
--- a/pandas/tseries/util.py
+++ b/pandas/tseries/util.py
@@ -65,7 +65,7 @@ def pivot_annual(series, freq=None):
     if not np.issubdtype(series.dtype, np.integer):
         values.fill(np.nan)
     else:
-        raise Exception('need to upcast')
+        raise Exception('need to upcast: convert dtype to -- which is necessary for the leap year adjustment.')
 
     values.put(flat_index, series.values)
 


### PR DESCRIPTION
Without the extended message the user hardly understand why no integers are allowed.

Actually, I do not even understand it by now.

Can we not use _values.fill(np.nan)_ with integers?
