### PR TITLE
Fix for EOF issue on c-parser branch

### DIFF
--- a/pandas/src/parser/parser.c
+++ b/pandas/src/parser/parser.c
@@ -1738,6 +1738,11 @@ int parser_handle_eof(parser_t *self) {
 
         return 0;
     }
+    else if (self->datalen == 0 && (self->state == START_RECORD)) {
+        return 0;
+    }
+
+    return -1;
 }
 
 int parser_consume_rows(parser_t *self, size_t nrows) {


### PR DESCRIPTION
Fix EOF issue on c-parser branch due to parser_handle_eof() not explicitely returning a value if state is START_RECORD. This results in the return value sometimes incorrectly set to -1 on Mac OS (seems to work okay on linux though). As a result, a parser exception is raised even though the file is read correctly.

Patch returns 0 if parser state is START_RECORD, since that should mean that a line has just been finished being parsed correctly and it's at a valid end of the file. Also added a default return value of -1 if none of the other tests pass.
