### PR TITLE
Fix groupby.median documentation

### DIFF
--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -303,7 +303,7 @@ class GroupBy(object):
 
     def median(self):
         """
-        Compute mean of groups, excluding missing values
+        Compute median of groups, excluding missing values
 
         For multiple groupings, the result index will be a MultiIndex
         """


### PR DESCRIPTION
Minor oversight - looks like when the documentation was copied to median from mean the function name didn't get updated.
