### PR TITLE
BUG: fix Series repr when name is tuple holding non string-type

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -22,6 +22,20 @@ Where to get it
 * Binary installers on PyPI: http://pypi.python.org/pypi/pandas
 * Documentation: http://pandas.pydata.org
 
+pandas 0.10.0
+=============
+
+**Release date:** not yet released
+
+**New features**
+
+**Improvements to existing features**
+
+**Bug fixes**
+
+  - fix Series repr when name is tuple holding non string-type (#2051)
+
+
 pandas 0.9.0
 ============
 

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -8,7 +8,8 @@ try:
 except:
     from io import StringIO
 
-from pandas.core.common import adjoin, isnull, notnull, _stringify
+from pandas.core.common import (adjoin, isnull, notnull, _stringify,
+                                _stringify_seq)
 from pandas.core.index import MultiIndex, _ensure_index
 from pandas.util import py3compat
 
@@ -85,7 +86,8 @@ class SeriesFormatter(object):
                 if isinstance(self.series.name, basestring):
                     series_name = self.series.name
                 elif isinstance(self.series.name, tuple):
-                    series_name = "('%s')" % "', '".join(self.series.name)
+                    series_name = "('%s')" % "', '".join(
+                            _stringify_seq(self.series.name))
                 else:
                     series_name = str(self.series.name)
             else:

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1011,9 +1011,16 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         ots[::2] = None
         repr(ots)
 
-        # tuple name, e.g. from hierarchical index
-        self.series.name = ('foo', 'bar', 'baz')
-        repr(self.series)
+        # various names
+        for name in ['', 1, 1.2, 'foo', u'\u03B1\u03B2\u03B3',
+                     'loooooooooooooooooooooooooooooooooooooooooooooooooooong',
+                     ('foo', 'bar', 'baz'),
+                     (1, 2),
+                     ('foo', 1, 2.3),
+                     (u'\u03B1', u'\u03B2', u'\u03B3'),
+                     (u'\u03B1', 'bar')]:
+            self.series.name = name
+            repr(self.series)
 
         biggie = Series(tm.randn(1000), index=np.arange(1000),
                         name=('foo', 'bar', 'baz'))


### PR DESCRIPTION
Not sure if this is in line with latest unicode work, @y-p?
