### PR TITLE
Fix for Python 3.3

### DIFF
--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -25,6 +25,7 @@ class Block(object):
         assert(values.ndim == ndim)
         assert(len(items) == len(values))
 
+        self._ref_locs = None
         self.values = values
         self.ndim = ndim
         self.items = _ensure_index(items)
@@ -39,7 +40,6 @@ class Block(object):
         # monotonicity
         return (self.ref_locs[1:] > self.ref_locs[:-1]).all()
 
-    _ref_locs = None
     @property
     def ref_locs(self):
         if self._ref_locs is None:
@@ -479,7 +479,7 @@ class BlockManager(object):
     -----
     This is *not* a public API class
     """
-    __slots__ = ['axes', 'blocks', 'ndim']
+    __slots__ = ['axes', 'blocks']
 
     def __init__(self, blocks, axes, do_integrity_check=True):
         self.axes = [_ensure_index(ax) for ax in axes]


### PR DESCRIPTION
There were two problems with a simple 'import pandas' on python 3.3, that have to do with slots.
For the first one, I converted the class initializer into an instance variable.
For the second one, there seems to be a property to compute 'ndim' so I simply removed it.

(I couldn't figure out quickly how to run the tests under Python 3; a number of problems are in the way.)
