### PR TITLE
BUG: exclude timedelta64 from integer dtypes #2146

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -90,6 +90,8 @@ def _isnull_ndarraylike(obj):
     elif values.dtype == np.dtype('M8[ns]'):
         # this is the NaT pattern
         result = values.view('i8') == lib.iNaT
+    elif issubclass(values.dtype.type, np.timedelta64):
+        result = -np.isfinite(values.view('i8'))
     else:
         result = -np.isfinite(obj)
     return result
@@ -800,7 +802,8 @@ def is_integer_dtype(arr_or_dtype):
     else:
         tipo = arr_or_dtype.dtype.type
     return (issubclass(tipo, np.integer) and not
-            issubclass(tipo, np.datetime64))
+            (issubclass(tipo, np.datetime64) or
+             issubclass(tipo, np.timedelta64)))
 
 
 def is_datetime64_dtype(arr_or_dtype):

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -879,6 +879,11 @@ class TestSeriesFormatting(unittest.TestCase):
         for line in repr(Series(vals)).split('\n'):
             self.assert_('+10' in line)
 
+    def test_timedelta64(self):
+        Series(np.array([1100, 20], dtype='timedelta64[s]')).to_string()
+        #check this works
+        #GH2146
+
 
 class TestEngFormatter(unittest.TestCase):
 


### PR DESCRIPTION
com.is_integer_dtype now returns False for dtype timedelta64 #2146
