### PR TITLE
BUG: start_time end_time to_timestamp bugs #2124 #2125 #1764

### DIFF
--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -4,7 +4,8 @@ import operator
 from datetime import datetime, date
 import numpy as np
 
-from pandas.tseries.frequencies import (get_freq_code as _gfc, to_offset,
+import pandas.tseries.offsets as offsets
+from pandas.tseries.frequencies import (get_freq_code as _gfc,
                                         _month_numbers, FreqGroup)
 from pandas.tseries.index import DatetimeIndex, Int64Index, Index
 from pandas.tseries.tools import parse_time_string
@@ -180,19 +181,20 @@ class Period(object):
 
     @property
     def start_time(self):
-        return self.to_timestamp(how='S')
+        return self.to_timestamp('s', how='S')
 
     @property
     def end_time(self):
-        return self.to_timestamp(how='E')
+        return self.to_timestamp('s', how='E')
 
-    def to_timestamp(self, freq=None, how='S'):
+    def to_timestamp(self, freq='s', how='start'):
         """
-        Return the Timestamp at the start/end of the period
+        Return the Timestamp representation of the Period at the target
+        frequency
 
         Parameters
         ----------
-        freq : string or DateOffset, default frequency of PeriodIndex
+        freq : string or DateOffset, default is second
             Target frequency
         how: str, default 'S' (start)
             'S', 'E'. Can be aliased as case insensitive
@@ -202,20 +204,16 @@ class Period(object):
         -------
         Timestamp
         """
+        how = _validate_end_alias(how)
+
         if freq is None:
             base, mult = _gfc(self.freq)
-            how = _validate_end_alias(how)
-            if how == 'S':
-                base = _freq_mod.get_to_timestamp_base(base)
-                freq = _freq_mod._get_freq_str(base)
-                new_val = self.asfreq(freq, how)
-            else:
-                new_val = self
+            val = self
         else:
             base, mult = _gfc(freq)
-            new_val = self.asfreq(freq, how)
+            val = self.asfreq(freq, how)
 
-        dt64 = plib.period_ordinal_to_dt64(new_val.ordinal, base)
+        dt64 = plib.period_ordinal_to_dt64(val.ordinal, base)
         return Timestamp(dt64)
 
     year = _period_field_accessor('year', 0)
@@ -759,13 +757,13 @@ class PeriodIndex(Int64Index):
         # how to represent ourselves to matplotlib
         return self._get_object_array()
 
-    def to_timestamp(self, freq=None, how='start'):
+    def to_timestamp(self, freq='s', how='start'):
         """
         Cast to DatetimeIndex
 
         Parameters
         ----------
-        freq : string or DateOffset, default 'D'
+        freq : string or DateOffset, default 's'
             Target frequency
         how : {'s', 'e', 'start', 'end'}
 

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -187,14 +187,15 @@ class Period(object):
     def end_time(self):
         return self.to_timestamp('s', how='E')
 
-    def to_timestamp(self, freq='s', how='start'):
+    def to_timestamp(self, freq=None, how='start'):
         """
         Return the Timestamp representation of the Period at the target
-        frequency
+        frequency at the specified end (how) of the Period
 
         Parameters
         ----------
-        freq : string or DateOffset, default is second
+        freq : string or DateOffset, default is 'D' if self.freq is week or
+               longer and 'S' otherwise
             Target frequency
         how: str, default 'S' (start)
             'S', 'E'. Can be aliased as case insensitive
@@ -208,10 +209,10 @@ class Period(object):
 
         if freq is None:
             base, mult = _gfc(self.freq)
-            val = self
-        else:
-            base, mult = _gfc(freq)
-            val = self.asfreq(freq, how)
+            freq = _freq_mod.get_to_timestamp_base(base)
+
+        base, mult = _gfc(freq)
+        val = self.asfreq(freq, how)
 
         dt64 = plib.period_ordinal_to_dt64(val.ordinal, base)
         return Timestamp(dt64)
@@ -757,13 +758,14 @@ class PeriodIndex(Int64Index):
         # how to represent ourselves to matplotlib
         return self._get_object_array()
 
-    def to_timestamp(self, freq='s', how='start'):
+    def to_timestamp(self, freq=None, how='start'):
         """
         Cast to DatetimeIndex
 
         Parameters
         ----------
-        freq : string or DateOffset, default 's'
+        freq : string or DateOffset, default 'D' for week or longer, 'S'
+               otherwise
             Target frequency
         how : {'s', 'e', 'start', 'end'}
 

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -773,12 +773,14 @@ class PeriodIndex(Int64Index):
         -------
         DatetimeIndex
         """
+        how = _validate_end_alias(how)
+
         if freq is None:
             base, mult = _gfc(self.freq)
-            new_data = self
-        else:
-            base, mult = _gfc(freq)
-            new_data = self.asfreq(freq, how)
+            freq = _freq_mod.get_to_timestamp_base(base)
+
+        base, mult = _gfc(freq)
+        new_data = self.asfreq(freq, how)
 
         new_data = plib.periodarr_to_dt64arr(new_data.values, base)
         return DatetimeIndex(new_data, freq='infer', name=self.name)

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -272,28 +272,30 @@ class TestPeriodProperties(TestCase):
 
     def test_end_time(self):
         p = Period('2012', freq='A')
-        xp = datetime(2012, 12, 31)
+        xp = datetime(2012, 12, 31, 23, 59, 59)
         self.assertEquals(xp, p.end_time)
 
         p = Period('2012', freq='Q')
-        xp = datetime(2012, 3, 31)
+        xp = datetime(2012, 3, 31, 23, 59, 59)
         self.assertEquals(xp, p.end_time)
 
         p = Period('2012', freq='M')
-        xp = datetime(2012, 1, 31)
+        xp = datetime(2012, 1, 31, 23, 59, 59)
         self.assertEquals(xp, p.end_time)
 
-        xp = datetime(2012, 1, 1)
-        freq_lst = ['D', 'H', 'T', 'S']
-        for f in freq_lst:
-            p = Period('2012', freq=f)
-            self.assertEquals(p.end_time, xp)
+        xp = datetime(2012, 1, 1, 23, 59, 59)
+        p = Period('2012', freq='D')
+        self.assertEquals(p.end_time, xp)
+
+        xp = datetime(2012, 1, 1, 0, 59, 59)
+        p = Period('2012', freq='H')
+        self.assertEquals(p.end_time, xp)
 
         self.assertEquals(Period('2012', freq='B').end_time,
-                          datetime(2011, 12, 30))
+                          datetime(2011, 12, 30, 23, 59, 59))
 
         self.assertEquals(Period('2012', freq='W').end_time,
-                          datetime(2012, 1, 1))
+                          datetime(2012, 1, 1, 23, 59, 59))
 
 
     def test_properties_annually(self):

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -1202,12 +1202,12 @@ class TestPeriodIndex(TestCase):
         series = Series(1, index=index, name='foo')
 
         exp_index = date_range('1/1/2001', end='12/31/2009', freq='A-DEC')
-        result = series.to_timestamp('D', 'end')
+        result = series.to_timestamp(how='end')
         self.assert_(result.index.equals(exp_index))
         self.assertEquals(result.name, 'foo')
 
         exp_index = date_range('1/1/2001', end='1/1/2009', freq='AS-DEC')
-        result = series.to_timestamp('D', 'start')
+        result = series.to_timestamp(how='start')
         self.assert_(result.index.equals(exp_index))
 
 
@@ -1231,6 +1231,15 @@ class TestPeriodIndex(TestCase):
         self.assert_(result.index.equals(exp_index))
 
         self.assertRaises(ValueError, index.to_timestamp, '5t')
+
+        index = PeriodIndex(freq='H', start='1/1/2001', end='1/2/2001')
+        series = Series(1, index=index, name='foo')
+
+        exp_index = date_range('1/1/2001 00:59:59', end='1/2/2001 00:59:59',
+                               freq='H')
+        result = series.to_timestamp(how='end')
+        self.assert_(result.index.equals(exp_index))
+        self.assertEquals(result.name, 'foo')
 
     def test_to_timestamp_quarterly_bug(self):
         years = np.arange(1960, 2000).repeat(4)

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -215,12 +215,12 @@ class TestPeriodProperties(TestCase):
         start_ts = p.to_timestamp(how='S')
         aliases = ['s', 'StarT', 'BEGIn']
         for a in aliases:
-            self.assertEquals(start_ts, p.to_timestamp(how=a))
+            self.assertEquals(start_ts, p.to_timestamp('D', how=a))
 
         end_ts = p.to_timestamp(how='E')
         aliases = ['e', 'end', 'FINIsH']
         for a in aliases:
-            self.assertEquals(end_ts, p.to_timestamp(how=a))
+            self.assertEquals(end_ts, p.to_timestamp('D', how=a))
 
         from_lst = ['A', 'Q', 'M', 'W', 'B',
                     'D', 'H', 'Min', 'S']
@@ -231,7 +231,7 @@ class TestPeriodProperties(TestCase):
 
             self.assertEquals(p.start_time, p.to_timestamp(how='S'))
 
-            self.assertEquals(p.end_time, p.to_timestamp(how='E'))
+            self.assertEquals(p.end_time, p.to_timestamp('s', how='E'))
 
         # Frequency other than daily
 
@@ -245,8 +245,8 @@ class TestPeriodProperties(TestCase):
         expected = datetime(1985, 12, 31, 23, 59)
         self.assertEquals(result, expected)
 
-        result = p.to_timestamp('S', how='end')
-        expected = datetime(1985, 12, 31, 23, 59, 59)
+        result = p.to_timestamp(how='end')
+        expected = datetime(1985, 12, 31)
         self.assertEquals(result, expected)
 
         expected = datetime(1985, 1, 1)


### PR DESCRIPTION
@wesm can you review this plz?

The main change is I have to_timestamp default to second frequency now to get the first and last second of the Period. This doesn't **quite** solve #2125 since Timestamp resolution goes down to Nanos. So the question is is it appropriate to add 999999999ns to the end_time when ns doesn't exist asa period freq? 
