### PR TITLE
use boolean indexing via getitem to trigger masking; add inplace keyword to where

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1776,7 +1776,7 @@ class DataFrame(NDFrame):
             return self._getitem_multilevel(key)
         elif isinstance(key, DataFrame):
             if key.values.dtype == bool:
-                return self.mask(key)
+                return self.where(key)
             else:
                 raise ValueError('Cannot index using non-boolean DataFrame')
         else:
@@ -4867,7 +4867,7 @@ class DataFrame(NDFrame):
         """
         return self.mul(other, fill_value=1.)
 
-    def where(self, cond, other, inplace=False):
+    def where(self, cond, other=NA, inplace=False):
         """
         Return a DataFrame with the same shape as self and whose corresponding
         entries are from self where cond is True and otherwise are from other.
@@ -4901,21 +4901,6 @@ class DataFrame(NDFrame):
         rs = np.where(cond, self, other)
         return self._constructor(rs, self.index, self.columns)
         
-    def mask(self, cond):
-        """
-        Returns copy of self whose values are replaced with nan if the
-        corresponding entry in cond is False
-
-        Parameters
-        ----------
-        cond: boolean DataFrame or array
-
-        Returns
-        -------
-        wh: DataFrame
-        """
-        return self.where(cond, NA)
-
 _EMPTY_SERIES = Series([])
 
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1775,9 +1775,8 @@ class DataFrame(NDFrame):
         elif isinstance(self.columns, MultiIndex):
             return self._getitem_multilevel(key)
         elif isinstance(key, DataFrame):
-            values = key.values
-            if values.dtype == bool:
-                return self.values[values]
+            if key.values.dtype == bool:
+                return self.mask(key)
             else:
                 raise ValueError('Cannot index using non-boolean DataFrame')
         else:
@@ -1891,11 +1890,7 @@ class DataFrame(NDFrame):
         if self._is_mixed_type:
             raise ValueError('Cannot do boolean setting on mixed-type frame')
 
-        if isinstance(value, DataFrame):
-            assert(value._indexed_same(self))
-            np.putmask(self.values, mask, value.values)
-        else:
-            self.values[mask] = value
+        self.where(key, value, inplace=True)
 
     def _set_item_multiple(self, keys, value):
         if isinstance(value, DataFrame):
@@ -4878,7 +4873,7 @@ class DataFrame(NDFrame):
         """
         return self.mul(other, fill_value=1.)
 
-    def where(self, cond, other):
+    def where(self, cond, other, inplace=False):
         """
         Return a DataFrame with the same shape as self and whose corresponding
         entries are from self where cond is True and otherwise are from other.
@@ -4905,9 +4900,13 @@ class DataFrame(NDFrame):
         if isinstance(other, DataFrame):
             _, other = self.align(other, join='left', fill_value=NA)
 
+        if inplace:
+            np.putmask(self.values, cond, other)
+            return self
+
         rs = np.where(cond, self, other)
         return self._constructor(rs, self.index, self.columns)
-
+        
     def mask(self, cond):
         """
         Returns copy of self whose values are replaced with nan if the

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1870,11 +1870,6 @@ class DataFrame(NDFrame):
         # support boolean setting with DataFrame input, e.g.
         # df[df > df2] = 0
         if isinstance(key, DataFrame):
-            if not (key.index.equals(self.index) and
-                    key.columns.equals(self.columns)):
-                raise PandasError('Can only index with like-indexed '
-                                  'DataFrame objects')
-
             self._boolean_set(key, value)
         elif isinstance(key, (np.ndarray, list)):
             return self._set_item_multiple(key, value)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1878,8 +1878,7 @@ class DataFrame(NDFrame):
             self._set_item(key, value)
 
     def _boolean_set(self, key, value):
-        mask = key.values
-        if mask.dtype != np.bool_:
+        if key.values.dtype != np.bool_:
             raise ValueError('Must pass DataFrame with boolean values only')
 
         if self._is_mixed_type:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4882,6 +4882,9 @@ class DataFrame(NDFrame):
         -------
         wh: DataFrame
         """
+        if not hasattr(cond,'shape'):
+            raise ValueError('where requires an ndarray like object for its condition')
+
         if isinstance(cond, np.ndarray):
             if cond.shape != self.shape:
                 raise ValueError('Array onditional must be same shape as self')
@@ -4901,6 +4904,21 @@ class DataFrame(NDFrame):
         rs = np.where(cond, self, other)
         return self._constructor(rs, self.index, self.columns)
         
+    def mask(self, cond):
+        """
+        Returns copy of self whose values are replaced with nan if the
+        inverted condition is True
+
+        Parameters
+        ----------
+        cond: boolean DataFrame or array
+
+        Returns
+        -------
+        wh: DataFrame
+        """
+        return self.where(~cond, NA)
+
 _EMPTY_SERIES = Series([])
 
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -141,6 +141,12 @@ class CheckIndexing(object):
 
         self.assertRaises(ValueError, self.tsframe.__getitem__, self.tsframe)
 
+        # test df[df >0] works
+        bif = self.tsframe[self.tsframe > 0]
+        bifw = DataFrame(np.where(self.tsframe>0,self.tsframe,np.nan),index=self.tsframe.index,columns=self.tsframe.columns)
+        self.assert_(isinstance(bif,DataFrame))
+        self.assert_(bif.shape == self.tsframe.shape)
+        assert_frame_equal(bif,bifw)
 
     def test_getitem_boolean_list(self):
         df = DataFrame(np.arange(12).reshape(3,4))

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5220,6 +5220,18 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         err2 = cond.ix[:2, :].values
         self.assertRaises(ValueError, df.where, err2, other1)
 
+        # invalid conditions
+        self.assertRaises(ValueError, df.mask, True)
+        self.assertRaises(ValueError, df.mask, 0)
+
+    def test_mask(self):
+        df = DataFrame(np.random.randn(5, 3))
+        cond = df > 0
+
+        rs = df.where(cond, np.nan)
+        assert_frame_equal(rs, df.mask(df <= 0))
+        assert_frame_equal(rs, df.mask(~cond))
+
 
     #----------------------------------------------------------------------
     # Transposing

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -142,6 +142,7 @@ class CheckIndexing(object):
         self.assertRaises(ValueError, self.tsframe.__getitem__, self.tsframe)
 
         # test df[df >0] works
+
         bif = self.tsframe[self.tsframe > 0]
         bifw = DataFrame(np.where(self.tsframe>0,self.tsframe,np.nan),index=self.tsframe.index,columns=self.tsframe.columns)
         self.assert_(isinstance(bif,DataFrame))

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -284,7 +284,11 @@ class CheckIndexing(object):
         values[values == 5] = 0
         assert_almost_equal(df.values, values)
 
-        self.assertRaises(Exception, df.__setitem__, df[:-1] > 0, 2)
+        # a df that needs alignment first
+        df[df[:-1]<0] = 2
+        np.putmask(values[:-1],values[:-1]<0,2)
+        assert_almost_equal(df.values, values)
+
         self.assertRaises(Exception, df.__setitem__, df * 0, 2)
 
         # index with DataFrame

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -142,7 +142,6 @@ class CheckIndexing(object):
         self.assertRaises(ValueError, self.tsframe.__getitem__, self.tsframe)
 
         # test df[df >0] works
-
         bif = self.tsframe[self.tsframe > 0]
         bifw = DataFrame(np.where(self.tsframe>0,self.tsframe,np.nan),index=self.tsframe.index,columns=self.tsframe.columns)
         self.assert_(isinstance(bif,DataFrame))
@@ -5214,8 +5213,6 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         rs = df.where(cond, other5)
         for k, v in rs.iteritems():
             assert_series_equal(v, np.where(cond[k], df[k], other5))
-
-        assert_frame_equal(rs, df.mask(cond))
 
         err1 = (df + 1).values[0:2, :]
         self.assertRaises(ValueError, df.where, cond, err1)


### PR DESCRIPTION
in core/frame.py

changed method _getitem_ to use _mask_ directly (e.g. df.mask(df > 0) is equivalent semantically to df[df>0])
  this would be a small API change as before df[df >0] returned a boolean np array

added inplace keyword to _where_ method (to update the dataframe in place, default is NOT to use inplace, and return a new dataframe)

changed method _boolean_set_ to use where and inplace=True (this allows alignment of the passed values and is slightly less strict than the current method)

all tests pass (as well as an added test in boolean frame indexing)

if included in 0.9.1 would be great (sorry for the late addition)
