### PR TITLE
BUG: ExcelWriter raises exception on PeriodIndex #2240

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1174,8 +1174,12 @@ class DataFrame(NDFrame):
                 encoded_cols = list(cols)
                 writer.writerow(encoded_cols)
 
-        nlevels = getattr(self.index, 'nlevels', 1)
-        for j, idx in enumerate(self.index):
+        data_index = self.index
+        if isinstance(self.index, PeriodIndex):
+            data_index = self.index.to_timestamp()
+
+        nlevels = getattr(data_index, 'nlevels', 1)
+        for j, idx in enumerate(data_index):
             row_fields = []
             if index:
                 if nlevels == 1:

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3780,6 +3780,24 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         assert_frame_equal(frame, recons)
         os.remove(path)
 
+    def test_to_excel_periodindex(self):
+        try:
+            import xlwt
+            import xlrd
+            import openpyxl
+        except ImportError:
+            raise nose.SkipTest
+
+        for ext in ['xls', 'xlsx']:
+            path = '__tmp__.' + ext
+            frame = self.tsframe
+            xp = frame.resample('M', kind='period')
+            xp.to_excel(path, 'sht1')
+
+            reader = ExcelFile(path)
+            rs = reader.parse('sht1', index_col=0, parse_dates=True)
+            assert_frame_equal(xp, rs.to_period('M'))
+            os.remove(path)
 
     def test_to_excel_multiindex(self):
         try:


### PR DESCRIPTION
convert to_timestamp first
otherwise roundtripping is hard and the output isn't all that useful for processing in Excel
