### PR TITLE
ENH: Import DataReader and Options into namespace

### DIFF
--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -30,6 +30,7 @@ from pandas.tseries.api import *
 from pandas.io.parsers import (read_csv, read_table, read_clipboard,
                                read_fwf, to_clipboard, ExcelFile,
                                ExcelWriter)
+from pandas.io.data import DataReader, Options
 from pandas.io.pytables import HDFStore
 from pandas.util.testing import debug
 


### PR DESCRIPTION
Don't know if there's any reason not to import these. I thought maybe they'd be better off in the data namespace though. Thoughts? 
