### PR TITLE
Pytables selection enhancement & docs update for HDF5 tables

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -16,6 +16,7 @@ import sys, os
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.append(os.path.abspath('.'))
+sys.path.insert(0,'/home/jreback/pandas')
 sys.path.insert(0, os.path.abspath('../sphinxext'))
 
 sys.path.extend([

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -16,7 +16,6 @@ import sys, os
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.append(os.path.abspath('.'))
-sys.path.insert(0,'/home/jreback/pandas')
 sys.path.insert(0, os.path.abspath('../sphinxext'))
 
 sys.path.extend([

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -231,22 +231,49 @@ Note, with the :ref:`advanced indexing <indexing.advanced>` ``ix`` method, you
 may select along more than one axis using boolean vectors combined with other
 indexing expressions.
 
-Indexing a DataFrame with a boolean DataFrame
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Where and Masking
+~~~~~~~~~~~~~~~~~
 
-You may wish to set values on a DataFrame based on some boolean criteria
-derived from itself or another DataFrame or set of DataFrames. This can be done
-intuitively like so:
+Selecting values from a DataFrame is accomplished in a similar manner to a Series.
+You index the Frame with a boolean DataFrame of the same size. This is accomplished 
+via the method `where` under the hood. The returned view of the DataFrame is the
+same size as the original.
+
+.. ipython:: python
+
+   df < 0
+   df[df < 0]
+
+In addition, `where` takes an optional `other` argument for replacement in the
+returned copy.
+
+.. ipython:: python
+
+   df.where(df < 0, -df)
+
+You may wish to set values on a DataFrame based on some boolean criteria.
+This can be done intuitively like so:
 
 .. ipython:: python
 
    df2 = df.copy()
-   df2 < 0
    df2[df2 < 0] = 0
    df2
 
-Note that such an operation requires that the boolean DataFrame is indexed
-exactly the same.
+Furthermore, `where` aligns the input boolean condition (ndarray or DataFrame), such that partial selection
+with setting is possible. This is analagous to partial setting via `.ix` (but on the contents rather than the axis labels)
+
+.. ipython:: python
+
+   df2 = df.copy()
+   df2[ df2[1:4] > 0 ] = 3
+   df2
+
+`DataFrame.mask` is the inverse boolean operation of `where`.
+
+.. ipython:: python
+
+   df.mask(df >= 0)
 
 
 Take Methods

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -818,7 +818,8 @@ Storing in Table format
 
 ```HDFStore``` supports another *PyTables* format on disk, the *table* format. Conceptually a *table* is shaped
 very much like a DataFrame, with rows and columns. A *table* may be appended to in the same or other sessions.
-In addition, delete and query type operations are supported.
+In addition, delete, query type operations are supported. You can create an index with ```create_table_index```
+after data is already in the table (this may become automatic in the future or an option on appending/putting a *table*).
 
 .. ipython:: python
    :suppress:
@@ -836,6 +837,9 @@ In addition, delete and query type operations are supported.
 
    store.select('df')
 
+   store.create_table_index('df')
+   store.handle.root.df.table
+
 .. ipython:: python
    :suppress:
 
@@ -848,7 +852,7 @@ Querying objects stored in Table format
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `select` and `delete` operations have an optional criteria that can be specified to select/delete only
-a subset of the data. This allows one to have very large on-table disks and retrieve only a portion of the data.
+a subset of the data. This allows one to have a very large on-disk table and retrieve only a portion of the data.
 
 A query is specified using the `Term` class under the hood. 
 
@@ -900,6 +904,8 @@ Notes & Caveats
 ~~~~~~~~~~~~~~~
 
    - Selection by items (the top level panel dimension) is not possible; you always get all of the items in the returned Panel
+   - Currently the sizes of the *column* items are governed by the first table creation
+      (this should be specified at creation time or use the largest available) - otherwise subsequent appends can truncate the column names
    - Mixed-Type Panels/DataFrames are not currently supported - coming soon!
    - Once a *table* is created its items (Panel) / columns (DataFrame) are fixed; only exactly the same columns can be appended
    - To delete a lot of data, it is sometimes better to erase the table and rewrite it (after say an indexing operation)

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -831,7 +831,7 @@ In addition, delete and query type operations are supported.
    store = HDFStore('store.h5')
    df1 = df[0:4]
    df2 = df[4:]
-   store.put('df', df1, table=True)
+   store.append('df', df1)
    store.append('df', df2)
 
    store.select('df')
@@ -878,7 +878,7 @@ This is roughly translated to: index must be greater than the date 20121114 and 
 .. ipython:: python
 
    store = HDFStore('store.h5')
-   store.put('wp',wp,table=True)
+   store.append('wp',wp)
    store.select('wp',[ 'index>20000102', ('column', ['A','B']) ])
 
 Delete objects stored in Table format

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -778,8 +778,8 @@ class HDFStore(object):
 
         # check for backwards incompatibility
         if append:
-            existing_kind = table._v_attrs.index_kind
-            if existing_kind != index_kind:
+            existing_kind = getattr(table._v_attrs,'index_kind',None)
+            if existing_kind is not None and existing_kind != index_kind:
                 raise TypeError("incompatible kind in index [%s - %s]" %
                                 (existing_kind, index_kind))
 

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -150,6 +150,26 @@ class TestHDFStore(unittest.TestCase):
         self.store.append('d', df[10:])
         tm.assert_frame_equal(self.store['d'], df)
 
+    def test_create_table_index(self):
+        wp = tm.makePanel()
+        self.store.append('p5', wp)
+        self.store.create_table_index('p5')
+
+        assert(self.store.handle.root.p5.table.cols.index.is_indexed == True)
+        assert(self.store.handle.root.p5.table.cols.column.is_indexed == False)
+
+        df = tm.makeTimeDataFrame()
+        self.store.append('f', df[:10])
+        self.store.append('f', df[10:])
+        self.store.create_table_index('f')
+
+        # create twice
+        self.store.create_table_index('f')
+
+        # try to index a non-table
+        self.store.put('f2', df)
+        self.assertRaises(Exception, self.store.create_table_index, 'f2')
+
     def test_append_diff_item_order(self):
         wp = tm.makePanel()
         wp1 = wp.ix[:, :10, :]

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -142,9 +142,13 @@ class TestHDFStore(unittest.TestCase):
 
     def test_append(self):
         df = tm.makeTimeDataFrame()
-        self.store.put('c', df[:10], table=True)
+        self.store.append('c', df[:10])
         self.store.append('c', df[10:])
         tm.assert_frame_equal(self.store['c'], df)
+
+        self.store.put('d', df[:10], table=True)
+        self.store.append('d', df[10:])
+        tm.assert_frame_equal(self.store['d'], df)
 
     def test_append_diff_item_order(self):
         wp = tm.makePanel()


### PR DESCRIPTION
1. added **str** (to do **repr**)
2. row removal in tables is much faster if rows are consecutive
3. added Term class, refactored Selection (this is backwards compatible)
    Term is a concise way of specifying conditions for queries, e.g.
   
   ```
   Term(dict(field = 'index', op = '>', value = '20121114'))
   Term('index', '20121114')
   Term('index', '>', '20121114')
   Term('index', ['20121114','20121114'])
   Term('index', datetime(2012,11,14))
   Term('index>20121114')
   ```
   
    updated tests for same
   
     this should close GH #1996
4. added docs for HDF5 table in io.html
5. append on a table that didn't exist was failing (because of testing of the index_kind attribute first - which may not exist)
    fixed & added test
6. added create_table_index method to create indicies on tables (which, btw now works quite well as Int64 indicies are used as opposed to the Time64Col which has a bug); includes a check on the pytables version requirement
   
   this should close GH #698
7. added min_itemsize as a paremeter to append; allows bigger default indexer columns upon table creation (even if you don't append something that big - but might later, avoid the truncation issue)
8. incorporated 0.9.1 whatsnew docs for where & mask into Indexing Section of main docs
