### PR TITLE
BUG: loses nano precision when converting Timestamp objects #2252

### DIFF
--- a/pandas/src/datetime.pyx
+++ b/pandas/src/datetime.pyx
@@ -605,6 +605,9 @@ cpdef convert_to_tsobject(object ts, object tz=None):
             if obj.tzinfo is not None and not _is_utc(obj.tzinfo):
                 offset = _get_utcoffset(obj.tzinfo, ts)
                 obj.value -= _delta_to_nanoseconds(offset)
+
+        if isinstance(ts, _Timestamp):
+            obj.value += ts.nanosecond
         _check_dts_bounds(obj.value, &obj.dts)
         return obj
     elif PyDate_Check(ts):
@@ -810,6 +813,8 @@ def array_to_datetime(ndarray[object] values, raise_=False, dayfirst=False,
                                          'utc=True')
                 else:
                     iresult[i] = _pydatetime_to_dts(val, &dts)
+                    if isinstance(val, _Timestamp):
+                        iresult[i] += val.nanosecond
                     _check_dts_bounds(iresult[i], &dts)
             elif PyDate_Check(val):
                 iresult[i] = _date_to_datetime64(val, &dts)

--- a/pandas/src/datetime.pyx
+++ b/pandas/src/datetime.pyx
@@ -606,7 +606,7 @@ cpdef convert_to_tsobject(object ts, object tz=None):
                 offset = _get_utcoffset(obj.tzinfo, ts)
                 obj.value -= _delta_to_nanoseconds(offset)
 
-        if isinstance(ts, _Timestamp):
+        if is_timestamp(ts):
             obj.value += ts.nanosecond
         _check_dts_bounds(obj.value, &obj.dts)
         return obj
@@ -813,7 +813,7 @@ def array_to_datetime(ndarray[object] values, raise_=False, dayfirst=False,
                                          'utc=True')
                 else:
                     iresult[i] = _pydatetime_to_dts(val, &dts)
-                    if isinstance(val, _Timestamp):
+                    if is_timestamp(val):
                         iresult[i] += val.nanosecond
                     _check_dts_bounds(iresult[i], &dts)
             elif PyDate_Check(val):

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1333,6 +1333,14 @@ class TestDatetimeIndex(unittest.TestCase):
                             freq='infer')
         idx.to_period()
 
+    def test_000constructor_resolution(self):
+        #2252
+        t1 = Timestamp((1352934390*1000000000)+1000000+1000+1)
+        idx = DatetimeIndex([t1])
+
+        self.assert_(idx.nanosecond[0] == t1.nanosecond)
+
+
     def test_constructor_coverage(self):
         rng = date_range('1/1/2000', periods=10.5)
         exp = date_range('1/1/2000', periods=10)


### PR DESCRIPTION
quick and dirty: add nanoseconds after conversion to datetimestruct #2252
