### PR TITLE
BUG: dtype=object should stop conversion from object in frame constructo...

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -402,7 +402,7 @@ class DataFrame(NDFrame):
                     index = _get_names_from_index(data)
 
                 if isinstance(data[0], (list, tuple, dict, Series)):
-                    arrays, columns = _to_arrays(data, columns, dtype)
+                    arrays, columns = _to_arrays(data, columns, dtype=dtype)
 
                     columns = _ensure_index(columns)
 
@@ -5159,7 +5159,7 @@ def _rec_to_dict(arr):
     return columns, sdict
 
 
-def _to_arrays(data, columns, dtype=None, coerce_float=False):
+def _to_arrays(data, columns, coerce_float=False, dtype=None):
     """
     Return list of arrays, columns
     """
@@ -5167,21 +5167,25 @@ def _to_arrays(data, columns, dtype=None, coerce_float=False):
     if len(data) == 0:
         return [], columns if columns is not None else []
     if isinstance(data[0], (list, tuple)):
-        return _list_to_arrays(data, columns, dtype=dtype, coerce_float=coerce_float)
+        return _list_to_arrays(data, columns, coerce_float=coerce_float,
+                               dtype=dtype)
     elif isinstance(data[0], dict):
-        return _list_of_dict_to_arrays(data, columns, dtype=dtype,
-                                       coerce_float=coerce_float)
+        return _list_of_dict_to_arrays(data, columns,
+                                       coerce_float=coerce_float,
+                                       dtype=dtype)
     elif isinstance(data[0], Series):
-        return _list_of_series_to_arrays(data, columns, dtype=dtype,
-                                        coerce_float=coerce_float)
+        return _list_of_series_to_arrays(data, columns,
+                                         coerce_float=coerce_float,
+                                         dtype=dtype)
     else:
         # last ditch effort
         data = map(tuple, data)
-        return _list_to_arrays(data, columns, dtype=dtype,
-                               coerce_float=coerce_float)
+        return _list_to_arrays(data, columns,
+                               coerce_float=coerce_float,
+                               dtype=dtype)
 
 
-def _list_to_arrays(data, columns, dtype=None, coerce_float=False):
+def _list_to_arrays(data, columns, coerce_float=False, dtype=None):
     if len(data) > 0 and isinstance(data[0], tuple):
         content = list(lib.to_object_array_tuples(data).T)
     else:
@@ -5191,7 +5195,7 @@ def _list_to_arrays(data, columns, dtype=None, coerce_float=False):
                                  coerce_float=coerce_float)
 
 
-def _list_of_series_to_arrays(data, columns, dtype=None, coerce_float=False):
+def _list_of_series_to_arrays(data, columns, coerce_float=False, dtype=None):
     from pandas.core.index import _get_combined_index
 
     if columns is None:
@@ -5218,7 +5222,7 @@ def _list_of_series_to_arrays(data, columns, dtype=None, coerce_float=False):
         return values.T, columns
 
 
-def _list_of_dict_to_arrays(data, columns, dtype=None, coerce_float=False):
+def _list_of_dict_to_arrays(data, columns, coerce_float=False, dtype=None):
     if columns is None:
         gen = (x.keys() for x in data)
         columns = lib.fast_unique_multiple_list_gen(gen)
@@ -5233,7 +5237,7 @@ def _list_of_dict_to_arrays(data, columns, dtype=None, coerce_float=False):
                                  coerce_float=coerce_float)
 
 
-def _convert_object_array(content, columns, dtype=None, coerce_float=False):
+def _convert_object_array(content, columns, coerce_float=False, dtype=None):
     if columns is None:
         columns = _default_index(len(content))
     else:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -403,7 +403,6 @@ class DataFrame(NDFrame):
 
                 if isinstance(data[0], (list, tuple, dict, Series)):
                     arrays, columns = _to_arrays(data, columns, dtype=dtype)
-
                     columns = _ensure_index(columns)
 
                     if index is None:

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1730,6 +1730,12 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         should_be_view[0][0] = 97
         self.assertEqual(df.values[0, 0], 97)
 
+    def test_constructor_dtype_list_data(self):
+        df = DataFrame([[1, '2'],
+                        [None, 'a']], dtype=object)
+        self.assert_(df.ix[1, 0] is None)
+        self.assert_(df.ix[0, 1] == '2')
+
     def test_constructor_rec(self):
         rec = self.frame.to_records(index=False)
 


### PR DESCRIPTION
...r #2255

don't call maybe_convert_objects in _convert_object_array if dtype is object.

Note that it also stops other type conversions too.
