### PR TITLE
Make sparse DataFrame and Series construction more efficient

### DIFF
--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -92,7 +92,9 @@ class SparseDataFrame(DataFrame):
                 columns = Index([])
             else:
                 for c in columns:
-                    sdict[c] = Series(np.nan, index=index)
+                    sdict[c] = SparseSeries(np.nan, index=index,
+                                            kind=self.default_kind,
+                                            fill_value=self.default_fill_value)
 
         self._series = sdict
         self.columns = columns

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -108,13 +108,23 @@ class SparseSeries(SparseArray, Series):
             if index is None:
                 raise Exception('must pass index!')
 
-            values = np.empty(len(index))
-            values.fill(data)
+            length = len(index)
 
-            # TODO: more efficient
-
-            values, sparse_index = make_sparse(values, kind=kind,
-                                               fill_value=fill_value)
+            if data == fill_value or (np.isnan(data)
+                    and np.isnan(fill_value)):
+                if kind == 'block':
+                    sparse_index = BlockIndex(length, [], [])
+                else:
+                    sparse_index = IntIndex(length, [])
+                values = np.array([])
+            else:
+                if kind == 'block':
+                    locs, lens = ([0], [length]) if length else ([], [])
+                    sparse_index = BlockIndex(length, locs, lens)
+                else:
+                    sparse_index = IntIndex(length, index)
+                values = np.empty(length)
+                values.fill(data)
 
         else:
             # array-like

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -730,6 +730,12 @@ class TestSparseDataFrame(TestCase, test_frame.SafeForSparse):
         assert_almost_equal([0, 0, 0, 0, 1, 2, 3, 4, 5, 6],
                             self.zframe['A'].values)
 
+        # construct no data
+        sdf = SparseDataFrame(columns=np.arange(10), index=np.arange(10))
+        for col, series in sdf.iteritems():
+            self.assert_(isinstance(series, SparseSeries))
+        
+
         # construct from nested dict
         data = {}
         for c, s in self.frame.iteritems():


### PR DESCRIPTION
Cleans up SparseSeries and SparseDataFrame initialization code so no objects are created unnecessarily. Currently if you run the (potentially useless) statement:

```
SparseDataFrame(columns=np.arange(100000), index=np.arange(100000))
```

pandas will consume memory and time filling in empty Series objects only to then compress them away.

Added to test to ensure SparseDataFrame always initializes with SparseSeries. Otherwise functionality should be preserved.
