### PR TITLE
Where/mask methods for Series

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -16,6 +16,7 @@ import sys, os
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.append(os.path.abspath('.'))
+sys.path.insert(0,'/home/jreback/pandas')
 sys.path.insert(0, os.path.abspath('../sphinxext'))
 
 sys.path.extend([

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -16,7 +16,6 @@ import sys, os
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.append(os.path.abspath('.'))
-sys.path.insert(0,'/home/jreback/pandas')
 sys.path.insert(0, os.path.abspath('../sphinxext'))
 
 sys.path.extend([

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -231,22 +231,49 @@ Note, with the :ref:`advanced indexing <indexing.advanced>` ``ix`` method, you
 may select along more than one axis using boolean vectors combined with other
 indexing expressions.
 
-Indexing a DataFrame with a boolean DataFrame
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Where and Masking
+~~~~~~~~~~~~~~~~~
 
-You may wish to set values on a DataFrame based on some boolean criteria
-derived from itself or another DataFrame or set of DataFrames. This can be done
-intuitively like so:
+Selecting values from a DataFrame is accomplished in a similar manner to a Series.
+You index the Frame with a boolean DataFrame of the same size. This is accomplished 
+via the method `where` under the hood. The returned view of the DataFrame is the
+same size as the original.
+
+.. ipython:: python
+
+   df < 0
+   df[df < 0]
+
+In addition, `where` takes an optional `other` argument for replacement in the
+returned copy.
+
+.. ipython:: python
+
+   df.where(df < 0, -df)
+
+You may wish to set values on a DataFrame based on some boolean criteria.
+This can be done intuitively like so:
 
 .. ipython:: python
 
    df2 = df.copy()
-   df2 < 0
    df2[df2 < 0] = 0
    df2
 
-Note that such an operation requires that the boolean DataFrame is indexed
-exactly the same.
+Furthermore, `where` aligns the input boolean condition (ndarray or DataFrame), such that partial selection
+with setting is possible. This is analagous to partial setting via `.ix` (but on the contents rather than the axis labels)
+
+.. ipython:: python
+
+   df2 = df.copy()
+   df2[ df2[1:4] > 0 ] = 3
+   df2
+
+`DataFrame.mask` is the inverse boolean operation of `where`.
+
+.. ipython:: python
+
+   df.mask(df >= 0)
 
 
 Take Methods

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -818,7 +818,8 @@ Storing in Table format
 
 ```HDFStore``` supports another *PyTables* format on disk, the *table* format. Conceptually a *table* is shaped
 very much like a DataFrame, with rows and columns. A *table* may be appended to in the same or other sessions.
-In addition, delete and query type operations are supported.
+In addition, delete, query type operations are supported. You can create an index with ```create_table_index```
+after data is already in the table (this may become automatic in the future or an option on appending/putting a *table*).
 
 .. ipython:: python
    :suppress:
@@ -836,6 +837,9 @@ In addition, delete and query type operations are supported.
 
    store.select('df')
 
+   store.create_table_index('df')
+   store.handle.root.df.table
+
 .. ipython:: python
    :suppress:
 
@@ -848,7 +852,7 @@ Querying objects stored in Table format
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `select` and `delete` operations have an optional criteria that can be specified to select/delete only
-a subset of the data. This allows one to have very large on-table disks and retrieve only a portion of the data.
+a subset of the data. This allows one to have a very large on-disk table and retrieve only a portion of the data.
 
 A query is specified using the `Term` class under the hood. 
 
@@ -900,6 +904,8 @@ Notes & Caveats
 ~~~~~~~~~~~~~~~
 
    - Selection by items (the top level panel dimension) is not possible; you always get all of the items in the returned Panel
+   - Currently the sizes of the *column* items are governed by the first table creation
+      (this should be specified at creation time or use the largest available) - otherwise subsequent appends can truncate the column names
    - Mixed-Type Panels/DataFrames are not currently supported - coming soon!
    - Once a *table* is created its items (Panel) / columns (DataFrame) are fixed; only exactly the same columns can be appended
    - To delete a lot of data, it is sometimes better to erase the table and rewrite it (after say an indexing operation)

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -831,7 +831,7 @@ In addition, delete and query type operations are supported.
    store = HDFStore('store.h5')
    df1 = df[0:4]
    df2 = df[4:]
-   store.put('df', df1, table=True)
+   store.append('df', df1)
    store.append('df', df2)
 
    store.select('df')
@@ -878,7 +878,7 @@ This is roughly translated to: index must be greater than the date 20121114 and 
 .. ipython:: python
 
    store = HDFStore('store.h5')
-   store.put('wp',wp,table=True)
+   store.append('wp',wp)
    store.select('wp',[ 'index>20000102', ('column', ['A','B']) ])
 
 Delete objects stored in Table format

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -562,6 +562,44 @@ copy : boolean, default False
         except Exception:
             return self.values[indexer]
 
+    def where(self, cond, other=nan, inplace=False):
+        """
+        Return a Series where cond is True; otherwise values are from other
+
+        Parameters
+        ----------
+        cond: boolean Series or array
+        other: scalar or Series
+
+        Returns
+        -------
+        wh: Series
+        """
+        if not hasattr(cond, 'shape'):
+            raise ValueError('where requires an ndarray like object for its '
+                             'condition')
+
+        if inplace:
+            self._set_with(~cond, other)
+            return self
+
+        return self._get_values(cond).reindex_like(self).fillna(other)
+
+    def mask(self, cond):
+        """
+        Returns copy of self whose values are replaced with nan if the
+        inverted condition is True
+
+        Parameters
+        ----------
+        cond: boolean Series or array
+
+        Returns
+        -------
+        wh: Series
+        """
+        return self.where(~cond, nan)
+
     def __setitem__(self, key, value):
         try:
             try:

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -778,8 +778,8 @@ class HDFStore(object):
 
         # check for backwards incompatibility
         if append:
-            existing_kind = table._v_attrs.index_kind
-            if existing_kind != index_kind:
+            existing_kind = getattr(table._v_attrs,'index_kind',None)
+            if existing_kind is not None and existing_kind != index_kind:
                 raise TypeError("incompatible kind in index [%s - %s]" %
                                 (existing_kind, index_kind))
 

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -150,6 +150,26 @@ class TestHDFStore(unittest.TestCase):
         self.store.append('d', df[10:])
         tm.assert_frame_equal(self.store['d'], df)
 
+    def test_create_table_index(self):
+        wp = tm.makePanel()
+        self.store.append('p5', wp)
+        self.store.create_table_index('p5')
+
+        assert(self.store.handle.root.p5.table.cols.index.is_indexed == True)
+        assert(self.store.handle.root.p5.table.cols.column.is_indexed == False)
+
+        df = tm.makeTimeDataFrame()
+        self.store.append('f', df[:10])
+        self.store.append('f', df[10:])
+        self.store.create_table_index('f')
+
+        # create twice
+        self.store.create_table_index('f')
+
+        # try to index a non-table
+        self.store.put('f2', df)
+        self.assertRaises(Exception, self.store.create_table_index, 'f2')
+
     def test_append_diff_item_order(self):
         wp = tm.makePanel()
         wp1 = wp.ix[:, :10, :]

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -142,9 +142,13 @@ class TestHDFStore(unittest.TestCase):
 
     def test_append(self):
         df = tm.makeTimeDataFrame()
-        self.store.put('c', df[:10], table=True)
+        self.store.append('c', df[:10])
         self.store.append('c', df[10:])
         tm.assert_frame_equal(self.store['c'], df)
+
+        self.store.put('d', df[:10], table=True)
+        self.store.append('d', df[10:])
+        tm.assert_frame_equal(self.store['d'], df)
 
     def test_append_diff_item_order(self):
         wp = tm.makePanel()

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -939,6 +939,37 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         result = self.series.ix[idx]
         assert_series_equal(result, self.series[:10])
 
+    def test_where(self):
+        s = Series(np.random.randn(5))
+        cond = s > 0
+
+        rs  = s.where(cond).dropna()
+        rs2 = s[cond]
+        assert_series_equal(rs, rs2)
+
+        rs  = s.where(cond,-s)
+        assert_series_equal(rs, s.abs())
+
+        rs  = s.where(cond)
+        assert(s.shape == rs.shape)
+
+        self.assertRaises(ValueError, s.where, 1)
+
+    def test_where_inplace(self):
+        s = Series(np.random.randn(5))
+        cond = s > 0
+
+        rs = s.copy()
+        rs.where(cond,inplace=True)
+        assert_series_equal(rs.dropna(), s[cond])
+
+    def test_mask(self):
+        s = Series(np.random.randn(5))
+        cond = s > 0
+
+        rs = s.where(cond, np.nan)
+        assert_series_equal(rs, s.mask(~cond))
+
     def test_ix_setitem(self):
         inds = self.series.index[[3,4,7]]
 


### PR DESCRIPTION
add where and mask methods for Series, analagous to DataFrame methods added for 0.9.1
passes all tests

where is equivalent to: `s[cond].reindex_like(s).fillna(other)`

```
In [7]: s = pd.Series(np.random.rand(5))

In [8]: s
Out[8]: 
0    0.638664
1    0.574688
2    0.460510
3    0.641840
4    0.044129

In [10]: s[0:2] = -s[0:2]

In [11]: s
Out[11]: 
0   -0.638664
1   -0.574688
2    0.460510
3    0.641840
4    0.044129
```

boolean selection

```
In [12]: s[s>0]
Out[12]: 
2    0.460510
3    0.641840
4    0.044129

In [13]: s.where(s>0)
Out[13]: 
0         NaN
1         NaN
2    0.460510
3    0.641840
4    0.044129

In [14]: s.where(s>0,-s)
Out[14]: 
0    0.638664
1    0.574688
2    0.460510
3    0.641840
4    0.044129

In [15]: s.mask(s<=0)
Out[15]: 
0         NaN
1         NaN
2    0.460510
3    0.641840
4    0.044129

```

support setting as well (though not used anywhere explicity)

```
In [16]: s2 = s.copy()

In [17]: s2.where(s2>0,inplace=True)
Out[17]: 
0         NaN
1         NaN
2    0.460510
3    0.641840
4    0.044129

In [18]: s2
Out[18]: 
0         NaN
1         NaN
2    0.460510
3    0.641840
4    0.044129

```
