### PR TITLE
ENH: line_terminator parameter for DataFrame.to_csv

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1305,7 +1305,8 @@ class DataFrame(NDFrame):
 
     def to_csv(self, path_or_buf, sep=",", na_rep='', float_format=None,
                cols=None, header=True, index=True, index_label=None,
-               mode='w', nanRep=None, encoding=None, quoting=None, line_terminator='\n'):
+               mode='w', nanRep=None, encoding=None, quoting=None,
+               line_terminator='\n'):
         """
         Write DataFrame to a comma-separated values (csv) file
 
@@ -1337,7 +1338,8 @@ class DataFrame(NDFrame):
             a string representing the encoding to use if the contents are
             non-ascii, for python versions prior to 3
         line_terminator: string, default '\n'
-            The newline character or character sequence to use in the output file
+            The newline character or character sequence to use in the
+            output file
         """
         if nanRep is not None:  # pragma: no cover
             import warnings
@@ -1361,8 +1363,8 @@ class DataFrame(NDFrame):
                                            delimiter=sep, encoding=encoding,
                                            quoting=quoting)
             else:
-                csvout = csv.writer(f, lineterminator=line_terminator, delimiter=sep,
-                                    quoting=quoting)
+                csvout = csv.writer(f, lineterminator=line_terminator,
+                                    delimiter=sep, quoting=quoting)
             self._helper_csvexcel(csvout, na_rep=na_rep,
                                   float_format=float_format, cols=cols,
                                   header=header, index=index,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1305,7 +1305,7 @@ class DataFrame(NDFrame):
 
     def to_csv(self, path_or_buf, sep=",", na_rep='', float_format=None,
                cols=None, header=True, index=True, index_label=None,
-               mode='w', nanRep=None, encoding=None, quoting=None):
+               mode='w', nanRep=None, encoding=None, quoting=None, line_terminator='\n'):
         """
         Write DataFrame to a comma-separated values (csv) file
 
@@ -1336,6 +1336,8 @@ class DataFrame(NDFrame):
         encoding : string, optional
             a string representing the encoding to use if the contents are
             non-ascii, for python versions prior to 3
+        line_terminator: string, default '\n'
+            The newline character or character sequence to use in the output file
         """
         if nanRep is not None:  # pragma: no cover
             import warnings
@@ -1355,11 +1357,11 @@ class DataFrame(NDFrame):
 
         try:
             if encoding is not None:
-                csvout = com.UnicodeWriter(f, lineterminator='\n',
+                csvout = com.UnicodeWriter(f, lineterminator=line_terminator,
                                            delimiter=sep, encoding=encoding,
                                            quoting=quoting)
             else:
-                csvout = csv.writer(f, lineterminator='\n', delimiter=sep,
+                csvout = csv.writer(f, lineterminator=line_terminator, delimiter=sep,
                                     quoting=quoting)
             self._helper_csvexcel(csvout, na_rep=na_rep,
                                   float_format=float_format, cols=cols,

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3839,6 +3839,19 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
                     'three,3,6\n')
         self.assertEqual(buf.getvalue(), expected)
 
+    def test_to_csv_line_terminators(self):
+        df = DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]},
+                       index=['one', 'two', 'three'])
+
+        buf = StringIO()
+        df.to_csv(buf, line_terminator='\r\n')
+        expected = ('A,B\r\n'
+                    'one,1,4\r\n'
+                    'two,2,5\r\n'
+                    'three,3,6\r\n')
+        self.assertEqual(buf.getvalue(), expected)
+
+
     def test_to_excel_from_excel(self):
         try:
             import xlwt

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3851,6 +3851,16 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
                     'three,3,6\r\n')
         self.assertEqual(buf.getvalue(), expected)
 
+        buf = StringIO()
+        df.to_csv(buf) # The default line terminator remains \n
+        expected = ('A,B\n'
+                    'one,1,4\n'
+                    'two,2,5\n'
+                    'three,3,6\n')
+        self.assertEqual(buf.getvalue(), expected)
+
+
+
 
     def test_to_excel_from_excel(self):
         try:

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3845,7 +3845,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
         buf = StringIO()
         df.to_csv(buf, line_terminator='\r\n')
-        expected = ('A,B\r\n'
+        expected = (',A,B\r\n'
                     'one,1,4\r\n'
                     'two,2,5\r\n'
                     'three,3,6\r\n')
@@ -3853,7 +3853,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
         buf = StringIO()
         df.to_csv(buf) # The default line terminator remains \n
-        expected = ('A,B\n'
+        expected = (',A,B\n'
                     'one,1,4\n'
                     'two,2,5\n'
                     'three,3,6\n')


### PR DESCRIPTION
In response to #2326

(Changes are now PEP8-compliant!)
