### PR TITLE
to_execl xlwt fails on large files

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -21,6 +21,8 @@ from pandas.util.decorators import Appender
 import pandas.lib as lib
 import pandas._parser as _parser
 from pandas.tseries.period import Period
+import json
+
 
 class DateConversionError(Exception):
     pass
@@ -2111,13 +2113,23 @@ class ExcelWriter(object):
             wks = self.book.add_sheet(sheet_name)
             self.sheets[sheet_name] = wks
 
+        style_dict = {}
+
         for cell in cells:
             val = _conv_value(cell.val)
-            style = CellStyleConverter.to_xls(cell.style)
+
+            stylekey = json.dumps(cell.style)
+            if stylekey in style_dict:
+                style = style_dict[stylekey]
+            else:
+                style = CellStyleConverter.to_xls(cell.style)
+                style_dict[stylekey] = style
+
             if isinstance(val, datetime.datetime):
                 style.num_format_str = "YYYY-MM-DD HH:MM:SS"
             elif isinstance(val, datetime.date):
                 style.num_format_str = "YYYY-MM-DD"
+
 
             if cell.mergestart is not None and cell.mergeend is not None:
                 wks.write_merge(startrow + cell.row,

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1931,7 +1931,7 @@ class CellStyleConverter(object):
     """
 
     @staticmethod
-    def to_xls(style_dict):
+    def to_xls(style_dict, num_format_str=None):
         """
         converts a style_dict to an xlwt style object
         Parameters
@@ -1973,9 +1973,13 @@ class CellStyleConverter(object):
 
         if style_dict:
             xlwt_stylestr = style_to_xlwt(style_dict)
-            return xlwt.easyxf(xlwt_stylestr, field_sep=',', line_sep=';')
+            style = xlwt.easyxf(xlwt_stylestr, field_sep=',', line_sep=';')
         else:
-            return xlwt.XFStyle()
+            style = xlwt.XFStyle()
+        if num_format_str is not None:
+            style.num_format_str = num_format_str
+
+        return style
 
     @staticmethod
     def to_xlsx(style_dict):
@@ -2118,18 +2122,21 @@ class ExcelWriter(object):
         for cell in cells:
             val = _conv_value(cell.val)
 
+            num_format_str = None
+            if isinstance(cell.val, datetime.datetime):
+                num_format_str = "YYYY-MM-DD HH:MM:SS"
+            if isinstance(cell.val, datetime.date):
+                num_format_str = "YYYY-MM-DD"
+
             stylekey = json.dumps(cell.style)
+            if num_format_str:
+                stylekey += num_format_str
+
             if stylekey in style_dict:
                 style = style_dict[stylekey]
             else:
-                style = CellStyleConverter.to_xls(cell.style)
+                style = CellStyleConverter.to_xls(cell.style, num_format_str)
                 style_dict[stylekey] = style
-
-            if isinstance(val, datetime.datetime):
-                style.num_format_str = "YYYY-MM-DD HH:MM:SS"
-            elif isinstance(val, datetime.date):
-                style.num_format_str = "YYYY-MM-DD"
-
 
             if cell.mergestart is not None and cell.mergeend is not None:
                 wks.write_merge(startrow + cell.row,


### PR DESCRIPTION
``` python
import pandas as pd
df = pd.DataFrame([tuple([i for i in range(200)]) for i in range(10000)], columns=["%s" % i for i in range(200)])
df.to_excel('test.xls')

python testlarge.py                                                                      ⏎
Traceback (most recent call last):
  File "testlarge.py", line 9, in <module>
    df.to_excel('test.xls')
  File "/Volumes/Locodrive/Dev/.virtualenvs/pandasdev/lib/python2.7/site-packages/pandas-0.10.0.dev_67ef67f-py2.7-macosx-10.8-x86_64.egg/pandas/core/frame.py", line 1445, in to_excel
    startrow=startrow, startcol=startcol)
  File "/Volumes/Locodrive/Dev/.virtualenvs/pandasdev/lib/python2.7/site-packages/pandas-0.10.0.dev_67ef67f-py2.7-macosx-10.8-x86_64.egg/pandas/io/parsers.py", line 2068, in write_cells
    self._writecells_xls(cells, sheet_name, startrow, startcol)
  File "/Volumes/Locodrive/Dev/.virtualenvs/pandasdev/lib/python2.7/site-packages/pandas-0.10.0.dev_67ef67f-py2.7-macosx-10.8-x86_64.egg/pandas/io/parsers.py", line 2131, in _writecells_xls
    val, style)
  File "/Volumes/Locodrive/Dev/.virtualenvs/pandasdev/lib/python2.7/site-packages/xlwt/Worksheet.py", line 1032, in write
    self.row(r).write(c, label, style)
  File "/Volumes/Locodrive/Dev/.virtualenvs/pandasdev/lib/python2.7/site-packages/xlwt/Row.py", line 236, in write
    style_index = self.__parent_wb.add_style(style)
  File "/Volumes/Locodrive/Dev/.virtualenvs/pandasdev/lib/python2.7/site-packages/xlwt/Workbook.py", line 303, in add_style
    return self.__styles.add(style)
  File "/Volumes/Locodrive/Dev/.virtualenvs/pandasdev/lib/python2.7/site-packages/xlwt/Style.py", line 90, in add
    return self._add_style(style)[1]
  File "/Volumes/Locodrive/Dev/.virtualenvs/pandasdev/lib/python2.7/site-packages/xlwt/Style.py", line 149, in _add_style
    raise ValueError("More than 4094 XFs (styles)")
V
```
