### PR TITLE
BUG: DataFrame.filter(like=*) should treat non-string values as strings

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2886,7 +2886,7 @@ class DataFrame(NDFrame):
         if items is not None:
             return self.reindex(columns=[r for r in items if r in self])
         elif like:
-            return self.select(lambda x: like in x, axis=1)
+            return self.select(lambda x: like in str(x), axis=1)
         elif regex:
             matcher = re.compile(regex)
             return self.select(lambda x: matcher.search(x) is not None, axis=1)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5888,6 +5888,11 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self.assertEqual(len(filtered.columns), 2)
         self.assert_('AA' in filtered)
 
+        # like with ints in column names
+        df = DataFrame(0., index=[0,1,2], columns=[0,1,'_A','_B'])
+        filtered = df.filter(like='_')
+        self.assertEqual(len(filtered.columns), 2)
+
         # pass in None
         self.assertRaises(Exception, self.frame.filter, items=None)
 


### PR DESCRIPTION
...(issue #2464)
