### PR TITLE
BUG: create correctly named indexables in HDFStore Tables

### DIFF
--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -207,14 +207,14 @@ class TestHDFStore(unittest.TestCase):
         tm.assert_panel_equal(self.store['s1'], expected)
 
         # test dict format
-        self.store.append('s2', wp, min_itemsize = { 'column' : 20 })
+        self.store.append('s2', wp, min_itemsize = { 'minor_axis' : 20 })
         self.store.append('s2', wp2)
         expected = concat([ wp, wp2], axis = 2)
         expected = expected.reindex(minor_axis = sorted(expected.minor_axis))
         tm.assert_panel_equal(self.store['s2'], expected)
 
         # apply the wrong field (similar to #1)
-        self.store.append('s3', wp, min_itemsize = { 'index' : 20 })
+        self.store.append('s3', wp, min_itemsize = { 'major_axis' : 20 })
         self.assertRaises(Exception, self.store.append, 's3')
 
         # test truncation of bigger strings
@@ -226,8 +226,8 @@ class TestHDFStore(unittest.TestCase):
         self.store.append('p5', wp)
         self.store.create_table_index('p5')
 
-        assert(self.store.handle.root.p5.table.cols.index.is_indexed == True)
-        assert(self.store.handle.root.p5.table.cols.column.is_indexed == False)
+        assert(self.store.handle.root.p5.table.cols.major_axis.is_indexed == True)
+        assert(self.store.handle.root.p5.table.cols.minor_axis.is_indexed == False)
 
         df = tm.makeTimeDataFrame()
         self.store.append('f', df[:10])

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -749,26 +749,26 @@ from cpython cimport (PyDict_New, PyDict_GetItem, PyDict_SetItem,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def create_hdf_rows_2d(ndarray index, ndarray[np.uint8_t, ndim=1] mask,
+def create_hdf_rows_2d(ndarray indexer0, ndarray[np.uint8_t, ndim=1] mask,
                        list values):
     """ return a list of objects ready to be converted to rec-array format """
 
     cdef:
-        unsigned int i, b, n_index, n_blocks, tup_size
+        unsigned int i, b, n_indexer0, n_blocks, tup_size
         ndarray v
         list l
         object tup, val
 
-    n_index   = index.shape[0]
-    n_blocks  = len(values)
-    tup_size  = n_blocks+1
+    n_indexer0 = indexer0.shape[0]
+    n_blocks   = len(values)
+    tup_size   = n_blocks+1
     l = []
-    for i from 0 <= i < n_index:
+    for i from 0 <= i < n_indexer0:
 
         if not mask[i]:
 
             tup = PyTuple_New(tup_size)
-            val  = index[i]
+            val  = indexer0[i]
             PyTuple_SET_ITEM(tup, 0, val)
             Py_INCREF(val)
 
@@ -784,40 +784,40 @@ def create_hdf_rows_2d(ndarray index, ndarray[np.uint8_t, ndim=1] mask,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def create_hdf_rows_3d(ndarray index, ndarray columns,
+def create_hdf_rows_3d(ndarray indexer0, ndarray indexer1,
                        ndarray[np.uint8_t, ndim=2] mask, list values):
     """ return a list of objects ready to be converted to rec-array format """
 
     cdef:
-        unsigned int i, j, n_columns, n_index, n_blocks, tup_size
+        unsigned int i, j, b, n_indexer0, n_indexer1, n_blocks, tup_size
         ndarray v
         list l
         object tup, val
 
-    n_index   = index.shape[0]
-    n_columns = columns.shape[0]
-    n_blocks  = len(values)
-    tup_size  = n_blocks+2
+    n_indexer0 = indexer0.shape[0]
+    n_indexer1 = indexer1.shape[0]
+    n_blocks   = len(values)
+    tup_size   = n_blocks+2
     l = []
-    for i from 0 <= i < n_index:
+    for i from 0 <= i < n_indexer0:
 
-        for c from 0 <= c < n_columns:
+        for j from 0 <= j < n_indexer1:
 
-            if not mask[i, c]:
+            if not mask[i, j]:
 
                 tup = PyTuple_New(tup_size)
 
-                val  = index[i]
+                val  = indexer0[i]
                 PyTuple_SET_ITEM(tup, 0, val)
                 Py_INCREF(val)
 
-                val  = columns[c]
+                val  = indexer1[j]
                 PyTuple_SET_ITEM(tup, 1, val)
                 Py_INCREF(val)
 
                 for b from 0 <= b < n_blocks:
 
-                    v   = values[b][:, i, c]
+                    v   = values[b][:, i, j]
                     PyTuple_SET_ITEM(tup, b+2, v)
                     Py_INCREF(v)
 

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -807,11 +807,11 @@ def create_hdf_rows_3d(ndarray index, ndarray columns,
 
                 tup = PyTuple_New(tup_size)
 
-                val  = columns[c]
+                val  = index[i]
                 PyTuple_SET_ITEM(tup, 0, val)
                 Py_INCREF(val)
 
-                val  = index[i]
+                val  = columns[c]
                 PyTuple_SET_ITEM(tup, 1, val)
                 Py_INCREF(val)
 


### PR DESCRIPTION
- indexable columns were created and named in a legacy format, now named like the
  indexable in the object, e.g. 'index' for DataFrame, or 'major_axis'/'minor_axis' for Panel
- fixes an issue if we want to support say a 'column' oriented Table
   (e.g. instead of storing the transpose,
  store with a 'column' indexables) - not implemented yet, but supported now
