### PR TITLE
ENH: ndim tables in HDFStore (allow indexables to be passed in)

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1001,7 +1001,7 @@ Objects can be written to the file just like adding key-value pairs to a dict:
    store['wp'] = wp
 
    # the type of stored data
-   store.handle.root.wp._v_attrs.pandas_type
+   store.root.wp._v_attrs.pandas_type
 
    store
 
@@ -1037,8 +1037,7 @@ Storing in Table format
 
 ``HDFStore`` supports another ``PyTables`` format on disk, the ``table`` format. Conceptually a ``table`` is shaped
 very much like a DataFrame, with rows and columns. A ``table`` may be appended to in the same or other sessions.
-In addition, delete & query type operations are supported. You can create an index with ``create_table_index``
-after data is already in the table (this may become automatic in the future or an option on appending/putting a ``table``).
+In addition, delete & query type operations are supported.
 
 .. ipython:: python
    :suppress:
@@ -1061,11 +1060,7 @@ after data is already in the table (this may become automatic in the future or a
    store.select('df')
 
    # the type of stored data
-   store.handle.root.df._v_attrs.pandas_type
-
-   # create an index
-   store.create_table_index('df')
-   store.handle.root.df.table
+   store.root.df._v_attrs.pandas_type
 
 Hierarchical Keys
 ~~~~~~~~~~~~~~~~~
@@ -1090,8 +1085,7 @@ Storing Mixed Types in a Table
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Storing mixed-dtype data is supported. Strings are store as a fixed-width using the maximum size of the appended column. Subsequent appends will truncate strings at this length.
-Passing ``min_itemsize = { column_name : size }`` as a paremeter to append will set a larger minimum for the column. Storing ``floats, strings, ints, bools`` are currently supported.
-Pass ``min_itemsize`` with a ``column_name`` of values to effect a minimum pre-allocation of space for strings in the dataset.
+Passing ``min_itemsize = { `values` : size }`` as a parameter to append will set a larger minimum for the string columns. Storing ``floats, strings, ints, bools`` are currently supported.
 
 .. ipython:: python
 
@@ -1100,10 +1094,13 @@ Pass ``min_itemsize`` with a ``column_name`` of values to effect a minimum pre-a
     df_mixed['int']      = 1
     df_mixed['bool']     = True
 
-    store.append('df_mixed',df_mixed)
+    store.append('df_mixed', df_mixed, min_itemsize = { 'values' : 50 })
     df_mixed1 = store.select('df_mixed')
     df_mixed1
     df_mixed1.get_dtype_counts()
+
+    # we have provided a minimum string column size
+    store.root.df_mixed.table
 
 
 Querying a Table
@@ -1136,6 +1133,23 @@ Queries are built up using a list of ``Terms`` (currently only **anding** of ter
    store
    store.select('wp',[ 'major_axis>20000102', ('minor_axis', '=', ['A','B']) ])
 
+Indexing
+~~~~~~~~
+You can create an index for a table with ``create_table_index`` after data is already in the table (after and ``append/put`` operation). Creating a table index is **highly** encouraged. This will speed your queries a great deal when you use a ``select`` with the indexed dimension as the ``where``. It is not automagically done now because you may want to index different axes than the default (except in the case of a DataFrame, where it almost always makes sense to index the ``index``.
+
+.. ipython:: python
+
+   # create an index
+   store.create_table_index('df')
+   i = store.root.df.table.cols.index.index
+   i.optlevel, i.kind
+
+   # change an index by passing new parameters
+   store.create_table_index('df', optlevel = 9, kind = 'full')
+   i = store.root.df.table.cols.index.index
+   i.optlevel, i.kind
+
+
 Delete from a Table
 ~~~~~~~~~~~~~~~~~~~
 
@@ -1152,27 +1166,30 @@ Notes & Caveats
    - You can not append/select/delete to a non-table (table creation is determined on the first append, or by passing ``table=True`` in a put operation)
    - ``HDFStore`` is **not-threadsafe for writing**. The underlying ``PyTables`` only supports concurrent reads (via threading or processes). If you need reading and writing *at the same time*, you need to serialize these operations in a single thread in a single process. You will corrupt your data otherwise. See the issue <https://github.com/pydata/pandas/issues/2397> for more information.
 
-   - ``PyTables`` only supports fixed-width string columns in ``tables``. The sizes of a string based indexing column (e.g. *column* or *minor_axis*) are determined as the maximum size of the elements in that axis or by passing the parameter ``min_itemsize`` on the first table creation (``min_itemsize`` can be an integer or a dict of column name to an integer). If subsequent appends introduce elements in the indexing axis that are larger than the supported indexer, an Exception will be raised (otherwise you could have a silent truncation of these indexers, leading to loss of information).
+   - ``PyTables`` only supports fixed-width string columns in ``tables``. The sizes of a string based indexing column (e.g. *columns* or *minor_axis*) are determined as the maximum size of the elements in that axis or by passing the parameter ``min_itemsize`` on the first table creation (``min_itemsize`` can be an integer or a dict of column name to an integer). If subsequent appends introduce elements in the indexing axis that are larger than the supported indexer, an Exception will be raised (otherwise you could have a silent truncation of these indexers, leading to loss of information). Just to be clear, this fixed-width restriction applies to **indexables** (the indexing columns) and **string values** in a mixed_type table.
 
      .. ipython:: python
 
-        store.append('wp_big_strings', wp, min_itemsize = 30)
+        store.append('wp_big_strings', wp, min_itemsize = { 'minor_axis' : 30 })
 	wp = wp.rename_axis(lambda x: x + '_big_strings', axis=2)
         store.append('wp_big_strings', wp)
         store.select('wp_big_strings')
+
+	# we have provided a minimum minor_axis indexable size
+	store.root.wp_big_strings.table
 
 Compatibility
 ~~~~~~~~~~~~~
 
 0.10 of ``HDFStore`` is backwards compatible for reading tables created in a prior version of pandas,
-however, query terms using the prior (undocumented) methodology are unsupported. You must read in the entire
-file and write it out using the new format to take advantage of the updates.
+however, query terms using the prior (undocumented) methodology are unsupported. ``HDFStore`` will issue a warning if you try to use a prior-version format file. You must read in the entire
+file and write it out using the new format to take advantage of the updates. The group attribute ``pandas_version`` contains the version information.
 
 
 Performance
 ~~~~~~~~~~~
 
-   - ``Tables`` come with a performance penalty as compared to regular stores. The benefit is the ability to append/delete and query (potentially very large amounts of data).
+   - ``Tables`` come with a writing performance penalty as compared to regular stores. The benefit is the ability to append/delete and query (potentially very large amounts of data).
      Write times are generally longer as compared with regular stores. Query times can be quite fast, especially on an indexed axis.
    - ``Tables`` can (as of 0.10.0) be expressed as different types.
 
@@ -1180,8 +1197,6 @@ Performance
      - ``WORMTable`` (pending implementation) - is available to faciliate very fast writing of tables that are also queryable (but CANNOT support appends)
 
    - To delete a lot of data, it is sometimes better to erase the table and rewrite it. ``PyTables`` tends to increase the file size with deletions
-   - In general it is best to store Panels with the most frequently selected dimension in the minor axis and a time/date like dimension in the major axis, but this is not required. Panels can have any major_axis and minor_axis type that is a valid Panel indexer.
-   - No dimensions are currently indexed automagically (in the ``PyTables`` sense); these require an explict call to ``create_table_index``
    - ``Tables`` offer better performance when compressed after writing them (as opposed to turning on compression at the very beginning)
      use the pytables utilities ``ptrepack`` to rewrite the file (and also can change compression methods)
    - Duplicate rows can be written, but are filtered out in selection (with the last items being selected; thus a table is unique on major, minor pairs)

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1091,6 +1091,7 @@ Storing Mixed Types in a Table
 
 Storing mixed-dtype data is supported. Strings are store as a fixed-width using the maximum size of the appended column. Subsequent appends will truncate strings at this length.
 Passing ``min_itemsize = { column_name : size }`` as a paremeter to append will set a larger minimum for the column. Storing ``floats, strings, ints, bools`` are currently supported.
+Pass ``min_itemsize`` with a ``column_name`` of values to effect a minimum pre-allocation of space for strings in the dataset.
 
 .. ipython:: python
 
@@ -1151,7 +1152,7 @@ Notes & Caveats
    - You can not append/select/delete to a non-table (table creation is determined on the first append, or by passing ``table=True`` in a put operation)
    - ``HDFStore`` is **not-threadsafe for writing**. The underlying ``PyTables`` only supports concurrent reads (via threading or processes). If you need reading and writing *at the same time*, you need to serialize these operations in a single thread in a single process. You will corrupt your data otherwise. See the issue <https://github.com/pydata/pandas/issues/2397> for more information.
 
-   - ``PyTables`` only supports fixed-width string columns in ``tables``. The sizes of a string based indexing column (e.g. *column* or *minor_axis*) are determined as the maximum size of the elements in that axis or by passing the parameter ``min_itemsize`` on the first table creation (``min_itemsize`` can be an integer or a dict of column name to an integer). If subsequent appends introduce elements in the indexing axis that are larger than the supported indexer, an Exception will be raised (otherwise you could have a silent truncation of these indexers, leading to loss of information). This is **ONLY** necessary for storing ``Panels`` (as the indexing column is stored directly in a column)
+   - ``PyTables`` only supports fixed-width string columns in ``tables``. The sizes of a string based indexing column (e.g. *column* or *minor_axis*) are determined as the maximum size of the elements in that axis or by passing the parameter ``min_itemsize`` on the first table creation (``min_itemsize`` can be an integer or a dict of column name to an integer). If subsequent appends introduce elements in the indexing axis that are larger than the supported indexer, an Exception will be raised (otherwise you could have a silent truncation of these indexers, leading to loss of information).
 
      .. ipython:: python
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1403,8 +1403,16 @@ class Table(object):
 
             # a string column
             if b.dtype.name == 'object':
-                atom  = _tables().StringCol(itemsize = values.dtype.itemsize, shape = shape)
-                utype = 'S8'
+                
+                # specified min_itemsize?
+                if isinstance(min_itemsize, dict):
+                    min_itemsize = int(min_itemsize.get('values'))
+
+                if min_itemsize is None:
+                    min_itemsize = values.dtype.itemsize
+
+                atom  = _tables().StringCol(itemsize = min_itemsize, shape = shape)
+                utype = 'S%s' % min_itemsize
             else:
                 atom  = getattr(_tables(),"%sCol" % b.dtype.name.capitalize())(shape = shape)
                 utype = atom._deftype

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -503,6 +503,7 @@ class HDFStore(object):
         wrapper(value)
         group._v_attrs.pandas_type = kind
         group._v_attrs.pandas_version = _version
+        group._v_attrs.meta = getattr(value,'meta',None)
 
     def _write_series(self, group, series):
         self._write_index(group, 'index', series.index)
@@ -842,7 +843,12 @@ class HDFStore(object):
         kind = group._v_attrs.pandas_type
         kind = _LEGACY_MAP.get(kind, kind)
         handler = self._get_handler(op='read', kind=kind)
-        return handler(group, where)
+        v = handler(group, where)
+        if v is not None:
+            meta = getattr(group._v_attrs,'meta',None)
+            if meta is not None:
+                v.meta = meta
+        return v
 
     def _read_series(self, group, where=None):
         index = self._read_index(group, 'index')

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1325,8 +1325,27 @@ class Table(object):
         table = self.table
         for c in columns:
             v = getattr(table.cols,c,None)
-            if v is not None and not v.is_indexed:
-                v.createIndex(**kw)
+            if v is not None:
+
+                # remove the index if the kind/optlevel have changed
+                if v.is_indexed:
+                    index = v.index
+                    cur_optlevel = index.optlevel
+                    cur_kind     = index.kind
+
+                    if kind is not None and cur_kind != kind:
+                        v.removeIndex()
+                    else:
+                        kw['kind'] = cur_kind
+
+                    if optlevel is not None and cur_optlevel != optlevel:
+                        v.removeIndex()
+                    else:
+                        kw['optlevel'] = cur_optlevel
+
+                # create the index
+                if not v.is_indexed:
+                    v.createIndex(**kw)
 
     def read_axes(self, where):
         """ create and return the axes sniffed from the table: return boolean for success """

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2157,8 +2157,14 @@ class Term(object):
         if self.field == 'index' or self.field == 'major_axis':
             if self.kind == 'datetime64' :
                 return [lib.Timestamp(v).value, None]
-            elif isinstance(v, datetime) or hasattr(v,'timetuple'):
+            elif isinstance(v, datetime) or hasattr(v,'timetuple') or self.kind == 'date':
                 return [time.mktime(v.timetuple()), None]
+            elif self.kind == 'integer':
+                v = int(float(v))
+                return [v, v]
+            elif self.kind == 'float':
+                v = float(v)
+                return [v, v]
         elif not isinstance(v, basestring):
             return [str(v), None]
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -91,9 +91,12 @@ def _tables():
         _table_mod = tables
 
         # version requirements
-        major, minor, subv = tables.__version__.split('.')
-        if int(major) >= 2 and int(minor[0]) >= 3:
-            _table_supports_index = True
+        ver = tables.__version__.split('.')
+        try:
+            if int(ver[0]) >= 2 and int(ver[1][0]) >= 3:
+                _table_supports_index = True
+        except:
+            pass
 
     return _table_mod
 
@@ -437,8 +440,9 @@ class HDFStore(object):
         """
 
         # version requirements
+        _tables()
         if not _table_supports_index:
-            raise("PyTables >= 2.3 is required for table indexing")
+            raise Exception("PyTables >= 2.3 is required for table indexing")
 
         group = self.get_node(key)
         if group is None: return

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -320,6 +320,16 @@ class TestHDFStore(unittest.TestCase):
         self.store.append('s4', wp)
         self.assertRaises(Exception, self.store.append, 's4', wp2)
 
+        # avoid truncation on elements
+        df = DataFrame([[123,'asdqwerty'], [345,'dggnhebbsdfbdfb']])
+        self.store.append('df_big',df, min_itemsize = { 'values' : 1024 })
+        tm.assert_frame_equal(self.store.select('df_big'), df)
+
+        # avoid truncation on elements
+        df = DataFrame([[123,'asdqwerty'], [345,'dggnhebbsdfbdfb']])
+        self.store.append('df_big2',df, min_itemsize = { 'values' : 300 })
+        tm.assert_frame_equal(self.store.select('df_big2'), df)
+
     def test_create_table_index(self):
         wp = tm.makePanel()
         self.store.append('p5', wp)

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -1039,6 +1039,9 @@ class TestHDFStore(unittest.TestCase):
         store.select('df2')
         store.select('wp1')
 
+        # force the frame
+        store.select('df2', typ = 'legacy_frame')
+
         # old version (this still throws an exception though)
         import warnings
         warnings.filterwarnings('ignore', category=IncompatibilityWarning)

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -97,6 +97,13 @@ class TestHDFStore(unittest.TestCase):
         self.assert_(self.store.root.b._v_attrs.pandas_version == '0.10')
         self.assert_(self.store.root.df1._v_attrs.pandas_version == '0.10')
 
+        # write a file and wipe its versioning
+        self.store.remove('df2')
+        self.store.append('df2', df)
+        self.store.get_node('df2')._v_attrs.pandas_version = None
+        self.store.select('df2')
+        self.store.select('df2', [ Term('index','>',df.index[2]) ])
+
     def test_meta(self):
         raise nose.SkipTest('no meta')
 

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -996,6 +996,17 @@ class TestHDFStore(unittest.TestCase):
         expected = df.ix[:, ['A']]
         tm.assert_frame_equal(result, expected)
 
+        # other indicies for a frame
+
+        # integer
+        df = DataFrame(dict(A = np.random.rand(20), B = np.random.rand(20)))
+        self.store.append('df_int', df)
+        self.store.select('df_int', [ Term("index<10"), Term("columns", "=", ["A"]) ])
+
+        df = DataFrame(dict(A = np.random.rand(20), B = np.random.rand(20), index = np.arange(20,dtype='f8')))
+        self.store.append('df_float', df)
+        self.store.select('df_float', [ Term("index<10.0"), Term("columns", "=", ["A"]) ])
+
         # can't select if not written as table
         #self.store['frame'] = df
         #self.assertRaises(Exception, self.store.select,

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -345,6 +345,25 @@ class TestHDFStore(unittest.TestCase):
         pytables._table_supports_index = False
         self.assertRaises(Exception, self.store.create_table_index, 'f')
 
+        # test out some versions
+        original = tables.__version__
+
+        for v in ['2.2','2.2b']:
+            pytables._table_mod = None
+            pytables._table_supports_index = False
+            tables.__version__ = v
+            self.assertRaises(Exception, self.store.create_table_index, 'f')
+
+        for v in ['2.3.1','2.3.1b','2.4dev','2.4',original]:
+            pytables._table_mod = None
+            pytables._table_supports_index = False
+            tables.__version__ = v
+            self.store.create_table_index('f')
+        pytables._table_mod = None
+        pytables._table_supports_index = False
+        tables.__version__ = original
+        
+
     def test_append_diff_item_order(self):
         wp = tm.makePanel()
         wp1 = wp.ix[:, :10, :]

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -97,6 +97,30 @@ class TestHDFStore(unittest.TestCase):
         self.assert_(self.store.root.b._v_attrs.pandas_version == '0.10')
         self.assert_(self.store.root.df1._v_attrs.pandas_version == '0.10')
 
+    def test_meta(self):
+        meta = { 'foo' : [ 'I love pandas ' ] }
+        s = tm.makeTimeSeries()
+        s.meta = meta
+        self.store['a'] = s
+        self.assert_(self.store['a'].meta == meta)
+
+        df = tm.makeDataFrame()
+        df.meta = meta
+        self.store['b'] = df
+        self.assert_(self.store['b'].meta == meta)
+
+        # this should work, but because slicing doesn't propgate meta it doesn
+        self.store.remove('df1')
+        self.store.append('df1', df[:10])
+        self.store.append('df1', df[10:])
+        results = self.store['df1']
+        #self.assert_(getattr(results,'meta',None) == meta)
+
+        # no meta
+        df = tm.makeDataFrame()
+        self.store['b'] = df
+        self.assert_(hasattr(self.store['b'],'meta') == False)
+
     def test_reopen_handle(self):
         self.store['a'] = tm.makeTimeSeries()
         self.store.open('w', warn=False)

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -381,12 +381,27 @@ class TestHDFStore(unittest.TestCase):
         assert(self.store.handle.root.p5.table.cols.major_axis.is_indexed == True)
         assert(self.store.handle.root.p5.table.cols.minor_axis.is_indexed == False)
 
+        # default optlevels
+        assert(self.store.handle.root.p5.table.cols.major_axis.index.optlevel == 6)
+        assert(self.store.handle.root.p5.table.cols.major_axis.index.kind == 'medium')
+
+        # let's change the indexing scheme
+        self.store.create_table_index('p5')
+        assert(self.store.handle.root.p5.table.cols.major_axis.index.optlevel == 6)
+        assert(self.store.handle.root.p5.table.cols.major_axis.index.kind == 'medium')
+        self.store.create_table_index('p5', optlevel=9)
+        assert(self.store.handle.root.p5.table.cols.major_axis.index.optlevel == 9)
+        assert(self.store.handle.root.p5.table.cols.major_axis.index.kind == 'medium')
+        self.store.create_table_index('p5', kind='full')
+        assert(self.store.handle.root.p5.table.cols.major_axis.index.optlevel == 9)
+        assert(self.store.handle.root.p5.table.cols.major_axis.index.kind == 'full')
+        self.store.create_table_index('p5', optlevel=1, kind='light')
+        assert(self.store.handle.root.p5.table.cols.major_axis.index.optlevel == 1)
+        assert(self.store.handle.root.p5.table.cols.major_axis.index.kind == 'light')
+
         df = tm.makeTimeDataFrame()
         self.store.append('f', df[:10])
         self.store.append('f', df[10:])
-        self.store.create_table_index('f')
-
-        # create twice
         self.store.create_table_index('f')
 
         # try to index a non-table

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -364,6 +364,23 @@ class TestHDFStore(unittest.TestCase):
         tables.__version__ = original
         
 
+    def test_big_table(self):
+        
+        # create and write a big table
+        wp = Panel(np.random.randn(20, 1000, 1000), items= [ 'Item%s' % i for i in xrange(20) ],
+                   major_axis=date_range('1/1/2000', periods=1000), minor_axis = [ 'E%s' % i for i in xrange(1000) ])
+
+        wp.ix[:,100:200,300:400] = np.nan
+
+        try:
+            store = HDFStore(self.scratchpath)
+            store._debug_memory = True
+            store.append('wp',wp)
+            recons = store.select('wp')
+        finally:
+            store.close()
+            os.remove(self.scratchpath)
+
     def test_append_diff_item_order(self):
         wp = tm.makePanel()
         wp1 = wp.ix[:, :10, :]


### PR DESCRIPTION
- ENH: changes axes_to_index keyword in table creation to axes
- ENH: allow passing of numeric or named axes (e.g. 0 or 'minor_axis') in axes
- BUG: create_axes now checks for current table scheme; raises if this indexing scheme is violated
- TST: added many p4d tests for appending/selection/partial selection/and axis permuation
- TST: added addition Term tests to include p4d
- BUG: add **eq** operators to IndexCol/DataCol/Table to comparisons
- DOC: updated docs with Panel4D saving & issues relating to threading
- ENH: supporting non-regular indexables:
  - can index a Panel4D on say [labels,major_axis,minor_axis], rather
        than the default of [items,major_axis,minor_axis]
  - support column oriented DataFrames (e.g. queryable by the columns
- REMOVED: support metadata serializing via 'meta' attribute on an object
- ENH: supporting a data versioning scheme, warns if this is non-existant or old (only if trying a query)
           as soon as the data is written again, this won't be warned again
- BUG: ixed PyTables version checking (and now correctly raises the error msg)
- BUG/DOC: added min_itemsize for strings in the values block (added TST and BUG fixes)
- BUG: handle int/float in indexes in the Term specification correctly
- ENH/DOC: allow changing of the table indexing scheme by calling create_table_index with new parameters

turned off memory testing: enable big_table test to turn it on
