### PR TITLE
Fix compilation on MSVC, signbit not in math.h

### DIFF
--- a/pandas/algos.pyx
+++ b/pandas/algos.pyx
@@ -40,7 +40,7 @@ cdef inline int int_max(int a, int b): return a if a >= b else b
 cdef inline int int_min(int a, int b): return a if a <= b else b
 
 
-cdef extern from "math.h":
+cdef extern from "src/headers/math.h":
     double sqrt(double x)
     double fabs(double)
     int signbit(double)

--- a/pandas/src/headers/math.h
+++ b/pandas/src/headers/math.h
@@ -1,0 +1,11 @@
+#ifndef _PANDAS_MATH_H_
+#define _PANDAS_MATH_H_
+
+#if defined(_MSC_VER)
+#include <math.h>
+__inline int signbit(double num) { return _copysign(1.0, num) < 0; }
+#else
+#include <math.h>
+#endif
+
+#endif


### PR DESCRIPTION
Another MSVC hack, this time to deal with the fact that signbit is not in math.h.

By using the _copysign, you can avoid potential issues with "negative zeros"
