### PR TITLE
CLN: Remove a useless parameter in Series.iteritem method.

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1054,7 +1054,7 @@ copy : boolean, default False
         else:
             return iter(self.values)
 
-    def iteritems(self, index=True):
+    def iteritems(self):
         """
         Lazily iterate over (index, value) tuples
         """


### PR DESCRIPTION
Hi,

I was reading some docstring of some `Series` & `DataFrame` methods from IPython. I wondered what the parameter `index` of the method `Series.iteritems` -- and thus the `iterkv` method -- did. I think it's not used. Tests passed.

Cheers,
Damien G.
