### PR TITLE
Add some default parameters to TextParser in _parse_options_data()

### DIFF
--- a/pandas/io/data.py
+++ b/pandas/io/data.py
@@ -223,7 +223,8 @@ def _parse_options_data(table):
     rows = table.findAll('tr')
     header = _unpack(rows[0], kind='th')
     data = [_unpack(r) for r in rows[1:]]
-    return TextParser(data, names=header).get_chunk()
+    # Use ',' as a thousands separator as we're pulling from the US site. 
+    return TextParser(data, names=header, na_values=['N/A'], thousands=',').get_chunk()
 
 
 class Options(object):


### PR DESCRIPTION
The Options class can return some awkward dtypes:

``` python
In [1]: from pandas.io.data import *

In [2]: aapl = Options('aapl')

In [3]: a = aapl.get_put_data(1,2013)     

In [4]: a.dtypes
Out[4]: 
Strike       object
Symbol       object
Last        float64
Chg         float64
Bid          object
Ask         float64
Vol          object
Open Int     object
```

There are two causes for Strike/Bid/Vol/Open Int having `object` dtypes: not parsing the NaN value and not passing a thousands separator.

``` python
In [5]: a.Bid[:5]
Out[5]: 
0    0.01
1     N/A
2     N/A
3     N/A
4     N/A
Name: Bid

In [6]: a['Open Int'][:5]
Out[6]: 
0    8,744
1    2,381
2    1,117
3    4,586
4    1,535
Name: Open Int
```

I've checked with a couple non-US proxies and it seems that finance.yahoo.com (the hardcoded url) does not redirect to the local version (yahoo.com does redirect). Since we're getting the US site, we can pass `','` as the thousands separator and `'N/A'`as the NaN value.

These changes yield the following dtypes:

``` python
In [4]: a.dtypes
Out[4]: 
Strike      float64
Symbol       object
Last        float64
Chg         float64
Bid         float64
Ask         float64
Vol           int64
Open Int      int64

In [5]: a[:5]
Out[5]: 
   Strike               Symbol  Last   Chg   Bid   Ask  Vol  Open Int
0     135  AAPL130119P00135000  0.02  0.01  0.01  0.03    5      8744
1     140  AAPL130119P00140000  0.02  0.00   NaN  0.04   11      2381
2     145  AAPL130119P00145000  0.01  0.03   NaN  0.11    3      1117
3     150  AAPL130119P00150000  0.01  0.00   NaN  0.11   20      4586
4     155  AAPL130119P00155000  0.01  0.00   NaN  0.11    4      1535
```
