### PR TITLE
BUG: provide for automatic conversion of object -> datetime64

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -628,6 +628,29 @@ def _consensus_name_attr(objs):
 #----------------------------------------------------------------------
 # Lots of little utilities
 
+def _possibly_cast_to_datetime(value, dtype):
+    """ try to cast the array/value to a datetimelike dtype, converting float nan to iNaT """
+
+    if dtype == 'M8[ns]':
+        import pandas.tslib as tslib
+        if np.isscalar(value):
+            if value == tslib.iNaT or isnull(value):
+                value = tslib.iNaT
+        else:
+            value = np.array(value)
+
+            # have a scalar array-like (e.g. NaT)
+            if value.ndim == 0:
+                value = tslib.iNaT
+
+            # we have an array of datetime & nulls
+            elif np.prod(value.shape):
+                try:
+                    value = tslib.array_to_datetime(value)
+                except:
+                    pass
+            
+    return value
 
 def _infer_dtype(value):
     if isinstance(value, (float, np.floating)):

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -632,7 +632,6 @@ def _possibly_cast_to_datetime(value, dtype):
     """ try to cast the array/value to a datetimelike dtype, converting float nan to iNaT """
 
     if dtype == 'M8[ns]':
-        import pandas.tslib as tslib
         if np.isscalar(value):
             if value == tslib.iNaT or isnull(value):
                 value = tslib.iNaT

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4222,8 +4222,7 @@ class DataFrame(NDFrame):
         # if we have a dtype == 'M8[ns]', provide boxed values
         def infer(x):
             if x.dtype == 'M8[ns]':
-                from pandas import Timestamp
-                return [ func(Timestamp(e)) for e in x ]
+                x = lib.map_infer(x, lib.Timestamp)
             return lib.map_infer(x, func)
         return self.apply(infer)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4218,7 +4218,14 @@ class DataFrame(NDFrame):
         -------
         applied : DataFrame
         """
-        return self.apply(lambda x: lib.map_infer(x, func))
+        
+        # if we have a dtype == 'M8[ns]', provide boxed values
+        def infer(x):
+            if x.dtype == 'M8[ns]':
+                from pandas import Timestamp
+                return [ func(Timestamp(e)) for e in x ]
+            return lib.map_infer(x, func)
+        return self.apply(infer)
 
     #----------------------------------------------------------------------
     # Merging / joining methods

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -4,7 +4,6 @@ from pandas.core.common import _asarray_tuplesafe
 from pandas.core.index import Index, MultiIndex
 import pandas.core.common as com
 import pandas.lib as lib
-import pandas.tslib as tslib
 
 import numpy as np
 
@@ -112,24 +111,15 @@ class _NDFrameIndexer(object):
                     data = self.obj[item]
                     values = data.values
                     if np.prod(values.shape):
+                        value = com._possibly_cast_to_datetime(value,getattr(data,'dtype',None))
                         values[plane_indexer] = value
             except ValueError:
+                for item, v in zip(item_labels[het_idx], value):
+                    data = self.obj[item]
+                    values = data.values
+                    if np.prod(values.shape):
+                        values[plane_indexer] = v
 
-                # convert nan to iNaT if possible
-                if data.dtype == 'M8[ns]':
-                    mask = com._isnull(value)
-                    if np.isscalar(value) and com.isnull(value):
-                        value = tslib.iNaT
-                        values[plane_indexer] = value
-                    else:
-                        raise ValueError("Cannot set indexer value of datetime64[ns] with [%s]" % value)
-
-                else:
-                    for item, v in zip(item_labels[het_idx], value):
-                        data = self.obj[item]
-                        values = data.values
-                        if np.prod(values.shape):
-                            values[plane_indexer] = v
         else:
             if isinstance(indexer, tuple):
                 indexer = _maybe_convert_ix(*indexer)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -4,6 +4,7 @@ from pandas.core.common import _asarray_tuplesafe
 from pandas.core.index import Index, MultiIndex
 import pandas.core.common as com
 import pandas.lib as lib
+import pandas.tslib as tslib
 
 import numpy as np
 
@@ -117,15 +118,12 @@ class _NDFrameIndexer(object):
                 # convert nan to iNaT if possible
                 if data.dtype == 'M8[ns]':
                     mask = com._isnull(value)
-                    if np.isscalar(value) and mask:
-                        from pandas import tslib
+                    if np.isscalar(value) and com.isnull(value):
                         value = tslib.iNaT
                         values[plane_indexer] = value
-                    elif isinstance(value, np.array) and mask.any():
-                        from pandas import tslib
-                        value = value.copy()
-                        value.putmask(iNat,mask)
-                        values[plane_indexer] = value
+                    else:
+                        raise ValueError("Cannot set indexer value of datetime64[ns] with [%s]" % value)
+
                 else:
                     for item, v in zip(item_labels[het_idx], value):
                         data = self.obj[item]

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -113,11 +113,25 @@ class _NDFrameIndexer(object):
                     if np.prod(values.shape):
                         values[plane_indexer] = value
             except ValueError:
-                for item, v in zip(item_labels[het_idx], value):
-                    data = self.obj[item]
-                    values = data.values
-                    if np.prod(values.shape):
-                        values[plane_indexer] = v
+
+                # convert nan to iNaT if possible
+                if data.dtype == 'M8[ns]':
+                    mask = com._isnull(value)
+                    if np.isscalar(value) and mask:
+                        from pandas import tslib
+                        value = tslib.iNaT
+                        values[plane_indexer] = value
+                    elif isinstance(value, np.array) and mask.any():
+                        from pandas import tslib
+                        value = value.copy()
+                        value.putmask(iNat,mask)
+                        values[plane_indexer] = value
+                else:
+                    for item, v in zip(item_labels[het_idx], value):
+                        data = self.obj[item]
+                        values = data.values
+                        if np.prod(values.shape):
+                            values[plane_indexer] = v
         else:
             if isinstance(indexer, tuple):
                 indexer = _maybe_convert_ix(*indexer)

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -463,12 +463,13 @@ def make_block(values, items, ref_items):
 
     # try to infer a datetimeblock
     if klass is None and np.prod(values.shape):
-        inferred_type = lib.infer_dtype(values.flatten())
+        flat = values.flatten()
+        inferred_type = lib.infer_dtype(flat)
         if inferred_type == 'datetime':
 
             # we have an object array that has been inferred as datetime, so convert it
             try:
-                values = tslib.array_to_datetime(values.flatten()).reshape(values.shape)
+                values = tslib.array_to_datetime(flat).reshape(values.shape)
                 klass = DatetimeBlock
             except: # it already object, so leave it
                 pass

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2983,12 +2983,13 @@ def _sanitize_array(data, index, dtype=None, copy=False,
 
     def _try_cast(arr):
         try:
-            subarr = np.array(data, dtype=dtype, copy=copy)
+            arr = com._possibly_cast_to_datetime(arr, dtype)
+            subarr = np.array(arr, dtype=dtype, copy=copy)
         except (ValueError, TypeError):
             if dtype is not None and raise_cast_failure:
                 raise
             else:  # pragma: no cover
-                subarr = np.array(data, dtype=object, copy=copy)
+                subarr = np.array(arr, dtype=object, copy=copy)
         return subarr
 
     # GH #846
@@ -3047,6 +3048,8 @@ def _sanitize_array(data, index, dtype=None, copy=False,
                 value, dtype = _dtype_from_scalar(value)
                 subarr = np.empty(len(index), dtype=dtype)
             else:
+                # need to possibly convert the value here
+                value  = com._possibly_cast_to_datetime(value, dtype)
                 subarr = np.empty(len(index), dtype=dtype)
             subarr.fill(value)
         else:

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1087,9 +1087,14 @@ class CheckIndexing(object):
         # set an allowable datetime64 type
         from pandas import tslib
         df.ix['b','timestamp'] = tslib.iNaT
+        self.assert_(com.isnull(df.ix['b','timestamp']))
 
-        # this fails because nan is a float type
-        df.ix['b','timestamp'] = nan
+        # allow this syntax
+        df.ix['c','timestamp'] = nan
+        self.assert_(com.isnull(df.ix['c','timestamp']))
+
+        # try to set with a list like item
+        self.assertRaises(Exception,  df.ix.__setitem__, ('d','timestamp'), [nan])
 
         # prior to 0.10.1 this failed
         #self.assertRaises(TypeError, df.ix.__setitem__, ('c','timestamp'), nan)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1093,6 +1093,10 @@ class CheckIndexing(object):
         df.ix['c','timestamp'] = nan
         self.assert_(com.isnull(df.ix['c','timestamp']))
 
+        # allow this syntax
+        df.ix['d',:] = nan
+        self.assert_(com.isnull(df.ix['c',:]).all() == False)
+
         # try to set with a list like item
         self.assertRaises(Exception,  df.ix.__setitem__, ('d','timestamp'), [nan])
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -351,6 +351,26 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         s2[1] = 5
         self.assertEquals(s[1], 5)
 
+    def test_constructor_dtype_datetime64(self):
+        import pandas.tslib as tslib
+
+        s = Series(tslib.iNaT,dtype='M8[ns]',index=range(5))
+        self.assert_(isnull(s).all() == True)
+
+        s = Series(tslib.NaT,dtype='M8[ns]',index=range(5))
+        self.assert_(isnull(s).all() == True)
+
+        s = Series(nan,dtype='M8[ns]',index=range(5))
+        self.assert_(isnull(s).all() == True)
+
+        s = Series([ datetime(2001,1,2,0,0), tslib.iNaT ],dtype='M8[ns]')
+        self.assert_(isnull(s[1]) == True)
+        self.assert_(s.dtype == 'M8[ns]')
+
+        s = Series([ datetime(2001,1,2,0,0), nan ],dtype='M8[ns]')
+        self.assert_(isnull(s[1]) == True)
+        self.assert_(s.dtype == 'M8[ns]')
+
     def test_constructor_dict(self):
         d = {'a' : 0., 'b' : 1., 'c' : 2.}
         result = Series(d, index=['b', 'c', 'd', 'a'])

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -2070,7 +2070,7 @@ class TestLegacySupport(unittest.TestCase):
         df = df.applymap(lambda x: x+BDay())
         df = df.applymap(lambda x: x+BDay())
 
-        self.assertTrue(df.x1.dtype == object)
+        self.assertTrue(df.x1.dtype == 'M8[ns]')
 
 
 class TestLegacyCompat(unittest.TestCase):

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1235,9 +1235,9 @@ class TestTimeSeries(unittest.TestCase):
 
     def test_set_dataframe_column_ns_dtype(self):
         x = DataFrame([datetime.now(), datetime.now()])
-        self.assert_(x[0].dtype == object)
+        #self.assert_(x[0].dtype == object)
 
-        x[0] = to_datetime(x[0])
+        #x[0] = to_datetime(x[0])
         self.assert_(x[0].dtype == np.dtype('M8[ns]'))
 
     def test_groupby_count_dateparseerror(self):
@@ -2066,6 +2066,7 @@ class TestLegacySupport(unittest.TestCase):
     def test_frame_apply_dont_convert_datetime64(self):
         from pandas.tseries.offsets import BDay
         df = DataFrame({'x1': [datetime(1996,1,1)]})
+
         df = df.applymap(lambda x: x+BDay())
         df = df.applymap(lambda x: x+BDay())
 


### PR DESCRIPTION
- construct series that have M8[ns] dtype even in the presence of NaN (rather than object)
  see below. 
- allow np.nan to be used in place of NaT in series construction (requires explicity dtype to be passed)
  e.g. `Series(np.nan,index=range(5),dtype='M8[ns]')`
- bug fix in applymap (tseries/tests/test_timeseries/test_frame_apply_dont_convert_datetime64), because explicit
  conversion of the series to M8ns, now has the function operating on datetime64 values and ufuncs dont' work for some reason,
  explicity required conversion to Timestamp values make this work (same issue as in GH #2591)

```
In [1]: import numpy as np

In [2]: import pandas as pd
```

This currently works

```
In [12]: df = pd.DataFrame(np.random.randn(8,2),pd.date_range('20010102',periods=8),columns=['A','B'])

In [13]: df['timestamp'] = pd.Timestamp('20010103')

In [14]: x = df.convert_objects()

In [15]: x
Out[15]: 
                   A         B           timestamp
2001-01-02 -0.228005 -1.376432 2001-01-03 00:00:00
2001-01-03 -0.555251  0.277356 2001-01-03 00:00:00
2001-01-04 -0.295289  0.534981 2001-01-03 00:00:00
2001-01-05 -0.332815 -1.436975 2001-01-03 00:00:00
2001-01-06 -1.848818  0.405773 2001-01-03 00:00:00
2001-01-07 -0.734903 -0.174140 2001-01-03 00:00:00
2001-01-08 -0.388864 -0.765329 2001-01-03 00:00:00
2001-01-09 -0.341015  0.170630 2001-01-03 00:00:00

In [16]: x.get_dtype_counts()
Out[16]: 
datetime64[ns]    1
float64           2

In [21]: x.ix[3,'timestamp'] = iNaT

In [22]: x
Out[22]: 
                   A         B           timestamp
2001-01-02 -0.228005 -1.376432 2001-01-03 00:00:00
2001-01-03 -0.555251  0.277356 2001-01-03 00:00:00
2001-01-04 -0.295289  0.534981 2001-01-03 00:00:00
2001-01-05 -0.332815 -1.436975                 NaT
2001-01-06 -1.848818  0.405773 2001-01-03 00:00:00
2001-01-07 -0.734903 -0.174140 2001-01-03 00:00:00
2001-01-08 -0.388864 -0.765329 2001-01-03 00:00:00
2001-01-09 -0.341015  0.170630 2001-01-03 00:00:00

```

This leaves you in limbo, as you have basically a datatime64 column, but with a float nan in it (so it has to stay object)

```
In [3]: df = pd.DataFrame(np.random.randn(8,2),pd.date_range('20010102',periods=8),columns=['A','B'])

In [4]: df
Out[4]: 
                   A         B
2001-01-02  0.939393 -2.524448
2001-01-03 -1.059561  0.104651
2001-01-04 -0.842478  1.033888
2001-01-05 -1.009903 -0.334782
2001-01-06 -0.452043 -0.382408
2001-01-07 -0.058516  1.162884
2001-01-08  0.660251  0.688290
2001-01-09  0.069637  0.366915

In [5]: df['timestamp'] = pd.Timestamp('20010103')

In [6]: df
Out[6]: 
                   A         B            timestamp
2001-01-02  0.939393 -2.524448  2001-01-03 00:00:00
2001-01-03 -1.059561  0.104651  2001-01-03 00:00:00
2001-01-04 -0.842478  1.033888  2001-01-03 00:00:00
2001-01-05 -1.009903 -0.334782  2001-01-03 00:00:00
2001-01-06 -0.452043 -0.382408  2001-01-03 00:00:00
2001-01-07 -0.058516  1.162884  2001-01-03 00:00:00
2001-01-08  0.660251  0.688290  2001-01-03 00:00:00
2001-01-09  0.069637  0.366915  2001-01-03 00:00:00

In [7]: df.get_dtype_counts()
Out[7]: 
float64    2
object     1

In [9]: df.ix[3,'timestamp'] = np.nan

In [10]: df
Out[10]: 
                   A         B            timestamp
2001-01-02  0.939393 -2.524448  2001-01-03 00:00:00
2001-01-03 -1.059561  0.104651  2001-01-03 00:00:00
2001-01-04 -0.842478  1.033888  2001-01-03 00:00:00
2001-01-05 -1.009903 -0.334782                  NaN
2001-01-06 -0.452043 -0.382408  2001-01-03 00:00:00
2001-01-07 -0.058516  1.162884  2001-01-03 00:00:00
2001-01-08  0.660251  0.688290  2001-01-03 00:00:00
2001-01-09  0.069637  0.366915  2001-01-03 00:00:00

In [11]: df.convert_objects().get_dtype_counts()
Out[11]: 
float64    2
object     1
```

This PR enables this syntax:

```
In [3]: df = pd.DataFrame(np.random.randn(8,2),pd.date_range('20010102',periods=8),columns=['A','B'])

In [4]: df['timestamp'] = pd.Timestamp('20010103')

# datetime64[ns] out of the box
In [5]: df.get_dtype_counts()
Out[5]: 
datetime64[ns]    1
float64           2

# use the traditional nan, which is mapped to iNaT internally
In [6]: df.ix[2:4,'timestamp'] = np.nan

In [7]: df
Out[7]: 
                   A         B           timestamp
2001-01-02  0.234354 -3.167626 2001-01-03 00:00:00
2001-01-03  0.141300 -0.548670 2001-01-03 00:00:00
2001-01-04  0.738884 -0.104497                 NaT
2001-01-05  0.873046  1.193593                 NaT
2001-01-06  1.174226  1.697421 2001-01-03 00:00:00
2001-01-07 -0.069534 -0.145611 2001-01-03 00:00:00
2001-01-08 -0.951426 -1.158884 2001-01-03 00:00:00
2001-01-09 -0.322041 -0.800181 2001-01-03 00:00:00

```
