### PR TITLE
BUG: Series op with datetime64 values misbehaves in numpy 1.6 #2629

### DIFF
--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1543,6 +1543,13 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         # it works!
         _ = s1 * s2
 
+    def test_operators_datetime64(self):
+        v1 = date_range('2012-1-1', periods=3, freq='D')
+        v2 = date_range('2012-1-2', periods=3, freq='D')
+        rs = Series(v2) - Series(v1)
+        xp = Series(1e9 * 3600 * 24, rs.index).astype('timedelta64[ns]')
+        assert_series_equal(rs, xp)
+
     # NumPy limitiation =(
 
     # def test_logical_range_select(self):


### PR DESCRIPTION
converts to i8 then back to timedelta64[ns] if both datetime64
