### PR TITLE
added a compression argument to to_csv to be sent to _get_handle

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1343,7 +1343,7 @@ class DataFrame(NDFrame):
     def to_csv(self, path_or_buf, sep=",", na_rep='', float_format=None,
                cols=None, header=True, index=True, index_label=None,
                mode='w', nanRep=None, encoding=None, quoting=None,
-               line_terminator='\n'):
+               line_terminator='\n', compression=None):
         """
         Write DataFrame to a comma-separated values (csv) file
 
@@ -1380,6 +1380,10 @@ class DataFrame(NDFrame):
             file
         quoting : optional constant from csv module
             defaults to csv.QUOTE_MINIMAL
+        compression : string, optional
+            a string representing the compression to use in the output file, 
+            currently only supports gzip and bz2 (see core.common._get_handle), 
+            only used when the first argument is a filename
         """
         if nanRep is not None:  # pragma: no cover
             import warnings
@@ -1391,7 +1395,7 @@ class DataFrame(NDFrame):
             f = path_or_buf
             close = False
         else:
-            f = com._get_handle(path_or_buf, mode, encoding=encoding)
+            f = com._get_handle(path_or_buf, mode, encoding=encoding, compression=compression)
             close = True
 
         if quoting is None:


### PR DESCRIPTION
Writing csv files with gzip compression is very useful as it both minimized the disk size taken by large data files, and can be easily read by _R_, often faster than the same csv file without compression. 
Reading compressed csv files in _R_ is done without any additional input by the user, and is also already supported in _Pandas_
