### PR TITLE
BUG: series assignment with a boolean indexer

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -55,6 +55,7 @@ pandas 0.10.1
   - Add ``logx`` option to DataFrame/Series.plot (GH2327_, #2565)
   - Support reading gzipped data from file-like object
   - ``pivot_table`` aggfunc can be anything used in GroupBy.aggregate (GH2643_)
+  - Add methods ``neg`` and ``inv`` to Series
 
 **Bug fixes**
 
@@ -78,6 +79,7 @@ pandas 0.10.1
   - Exclude non-numeric data from DataFrame.quantile by default (GH2625_)
   - Fix a Cython C int64 boxing issue causing read_csv to return incorrect
     results (GH2599_)
+  - Fix setitem on a Series with a boolean key and a non-scalar as value (GH2686_)
 
 **API Changes**
 
@@ -98,6 +100,7 @@ pandas 0.10.1
 .. _GH2625: https://github.com/pydata/pandas/issues/2625
 .. _GH2643: https://github.com/pydata/pandas/issues/2643
 .. _GH2637: https://github.com/pydata/pandas/issues/2637
+.. _GH2686: https://github.com/pydata/pandas/issues/2686
 
 pandas 0.10.0
 =============

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -695,7 +695,13 @@ copy : boolean, default False
                 else:
                     return self._set_values(key, value)
             elif key_type == 'boolean':
-                self._set_values(key, value)
+
+                # scalar setting with boolean key
+                if np.isscalar(value):
+                    self._set_values(key, value)
+                # we have a key mask and a value that is np.array like
+                else:
+                    np.putmask(self.values, key, value)
             else:
                 self._set_labels(key, value)
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -604,7 +604,7 @@ copy : boolean, default False
         if len(cond) != len(self):
             raise ValueError('condition must have same length as series')
 
-        if not cond.dtype == np.bool_:
+        if cond.dtype != np.bool_:
             cond = cond.astype(np.bool_)
 
         ser = self if inplace else self.copy()
@@ -663,7 +663,6 @@ copy : boolean, default False
             # Could not hash item
 
         if _is_bool_indexer(key):
-            #import pdb; pdb.set_
             key = self._check_bool_indexer(key)
             self.where(~key,value,inplace=True)
         else:
@@ -747,7 +746,7 @@ copy : boolean, default False
         # coerce to bool type
         if not hasattr(result, 'shape'):
             result = np.array(result)
-        if not result.dtype == np.bool_:
+        if result.dtype != np.bool_:
             result = result.astype(np.bool_)
 
         return result

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -604,6 +604,9 @@ copy : boolean, default False
         if len(cond) != len(self):
             raise ValueError('condition must have same length as series')
 
+        if not cond.dtype == np.bool_:
+            cond = cond.astype(np.bool_)
+
         ser = self if inplace else self.copy()
         if not isinstance(other, (list, tuple, np.ndarray)):
             ser._set_with(~cond, other)
@@ -660,10 +663,11 @@ copy : boolean, default False
             # Could not hash item
 
         if _is_bool_indexer(key):
+            #import pdb; pdb.set_
             key = self._check_bool_indexer(key)
-            key = np.asarray(key, dtype=bool)
-
-        self._set_with(key, value)
+            self.where(~key,value,inplace=True)
+        else:
+            self._set_with(key, value)
 
     def _set_with(self, key, value):
         # other: fancy integer or otherwise
@@ -695,13 +699,7 @@ copy : boolean, default False
                 else:
                     return self._set_values(key, value)
             elif key_type == 'boolean':
-
-                # scalar setting with boolean key
-                if np.isscalar(value):
                     self._set_values(key, value)
-                # we have a key mask and a value that is np.array like
-                else:
-                    np.putmask(self.values, key, value)
             else:
                 self._set_labels(key, value)
 
@@ -745,6 +743,12 @@ copy : boolean, default False
             if mask.any():
                 raise ValueError('cannot index with vector containing '
                                  'NA / NaN values')
+
+        # coerce to bool type
+        if not hasattr(result, 'shape'):
+            result = np.array(result)
+        if not result.dtype == np.bool_:
+            result = result.astype(np.bool_)
 
         return result
 
@@ -1103,6 +1107,15 @@ copy : boolean, default False
     __le__ = _comp_method(operator.le, '__le__')
     __eq__ = _comp_method(operator.eq, '__eq__')
     __ne__ = _comp_method(operator.ne, '__ne__')
+    
+    # inversion
+    def __neg__(self):
+        arr = operator.neg(self.values)
+        return Series(arr, self.index, name=self.name)
+
+    def __invert__(self):
+        arr = operator.inv(self.values)
+        return Series(arr, self.index, name=self.name)
 
     # binary logic
     __or__ = _bool_method(operator.or_, '__or__')

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1047,9 +1047,17 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
     def test_setitem_boolean(self):
         mask = self.series > self.series.median()
 
+        # similiar indexed series
         result = self.series.copy()
         result[mask] = self.series*2
         expected = self.series*2
+        assert_series_equal(result[mask], expected[mask])
+
+        # needs alignment
+        result = self.series.copy()
+        result[mask] = (self.series*2)[0:5]
+        expected = (self.series*2)[0:5].reindex_like(self.series)
+        expected[-mask] = self.series[mask]
         assert_series_equal(result[mask], expected[mask])
 
     def test_ix_setitem_boolean(self):
@@ -1524,6 +1532,12 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         check(self.ts, self.ts * 2)
         check(self.ts, self.ts[::2])
         check(self.ts, 5)
+
+    def test_neg(self):
+        assert_series_equal(-self.series, -1 * self.series)
+
+    def test_invert(self):
+        assert_series_equal(-(self.series < 0), ~(self.series < 0))
 
     def test_operators(self):
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1044,6 +1044,14 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         self.assertEquals(self.series[d1], 4)
         self.assertEquals(self.series[d2], 6)
 
+    def test_setitem_boolean(self):
+        mask = self.series > self.series.median()
+
+        result = self.series.copy()
+        result[mask] = self.series*2
+        expected = self.series*2
+        assert_series_equal(result[mask], expected[mask])
+
     def test_ix_setitem_boolean(self):
         mask = self.series > self.series.median()
 
@@ -3211,9 +3219,9 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         expected = s.copy()
         bad = isnull(expected.values)
         good = -bad
-        expected[bad] = np.interp(vals[bad], vals[good], s.values[good])
+        expected = Series(np.interp(vals[bad], vals[good], s.values[good]), index=s.index[bad])
 
-        assert_series_equal(result, expected)
+        assert_series_equal(result[bad], expected)
 
     def test_weekday(self):
         # Just run the function


### PR DESCRIPTION
- fixed assignment with a boolean indexer and a non-scalar as the value (see below)
- 2nd commit fixed the alignment issue; that is if the value is not a full series, align first (using where machinery)
- add neg and inv methods
- _check_bool_indexer now coerces to bool if needed (otherwise weird effects when doing neg/inv on boolean series)

```
In [1]: import numpy as np

In [2]: import pandas as pd

In [3]: x = pd.Series(index=np.arange(10))

In [4]: y = pd.Series(np.random.rand(10),index=np.arange(10))

In [5]: y
Out[5]: 
0    0.197830
1    0.134425
2    0.766618
3    0.057765
4    0.790927
5    0.153636
6    0.585305
7    0.906787
8    0.647155
9    0.494154

In [6]: x[y>0.5] = y

In [7]: x
Out[7]: 
0         NaN
1         NaN
2    0.197830
3         NaN
4    0.134425
5         NaN
6    0.766618
7    0.057765
8    0.790927
9         NaN
```
