### PR TITLE
ENH: provide squeeze method for removing 1-len dimensions, close (GH #2544)

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -22,6 +22,19 @@ Where to get it
 * Binary installers on PyPI: http://pypi.python.org/pypi/pandas
 * Documentation: http://pandas.pydata.org
 
+**New features**
+
+  - added ``squeeze`` method that will reduce dimensionality of the object by squeezing any len-1 dimensions
+
+pandas 0.10.2
+=============
+
+**Release date:** 2013-02-??
+
+**New features**
+
+  - Add ``squeeze`` function to reduce dimensionality of 1-len objects
+
 pandas 0.10.1
 =============
 

--- a/doc/source/dsintro.rst
+++ b/doc/source/dsintro.rst
@@ -819,6 +819,17 @@ For example, using the earlier example data, we could do:
     wp.minor_axis
     wp.minor_xs('C')
 
+Squeezing
+~~~~~~~~~
+
+Another way to change the dimensionality of an object is to ``squeeze`` a 1-len object, similar to ``wp['Item1']``
+
+.. ipython:: python
+
+   wp.reindex(items=['Item1']).squeeze()
+   wp.reindex(items=['Item1'],minor=['B']).squeeze()
+
+
 Conversion to DataFrame
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -833,6 +844,7 @@ method:
                  major_axis=date_range('1/1/2000', periods=5),
                  minor_axis=['a', 'b', 'c', 'd'])
    panel.to_frame()
+
 
 Panel4D (Experimental)
 ----------------------

--- a/doc/source/v0.10.2.txt
+++ b/doc/source/v0.10.2.txt
@@ -1,0 +1,29 @@
+.. _whatsnew_0102:
+
+v0.10.2 (February ??, 2013)
+---------------------------
+
+This is a minor release from 0.10.1 and includes many new features and
+enhancements along with a large number of bug fixes. There are also a number of
+important API changes that long-time pandas users should pay close attention
+to.
+
+New features
+~~~~~~~~~~~~
+
+``Squeeze`` to possibly remove length 1 dimensions from an object.
+
+.. ipython:: python
+
+   p = Panel(randn(3,4,4),items=['ItemA','ItemB','ItemC'],
+                          major_axis=date_range('20010102',periods=4),
+                          minor_axis=['A','B','C','D'])
+   p
+   p.reindex(items=['ItemA']).squeeze()
+   p.reindex(items=['ItemA'],minor=['B']).squeeze()
+
+
+See the `full release notes
+<https://github.com/pydata/pandas/blob/master/RELEASE.rst>`__ or issue tracker
+on GitHub for a complete list.
+

--- a/doc/source/whatsnew.rst
+++ b/doc/source/whatsnew.rst
@@ -16,6 +16,8 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: v0.10.2.txt
+
 .. include:: v0.10.1.txt
 
 .. include:: v0.10.0.txt

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -587,6 +587,13 @@ class NDFrame(PandasObject):
         del self[item]
         return result
 
+    def squeeze(self):
+        """ squeeze length 1 dimensions """
+        try:
+            return self.ix[tuple([ slice(None) if len(a) > 1 else a[0] for a in self.axes ])]
+        except:
+            return self
+
     def _expand_axes(self, key):
         new_axes = []
         for k, ax in zip(key, self.axes):

--- a/pandas/tests/test_ndframe.py
+++ b/pandas/tests/test_ndframe.py
@@ -26,6 +26,33 @@ class TestNDFrame(unittest.TestCase):
         casted = self.ndf.astype(int)
         self.assert_(casted.values.dtype == np.int64)
 
+    def test_squeeze(self):
+        # noop
+        for s in [ t.makeFloatSeries(), t.makeStringSeries(), t.makeObjectSeries() ]:
+            t.assert_series_equal(s.squeeze(),s)
+        for df in [ t.makeTimeDataFrame() ]:
+            t.assert_frame_equal(df.squeeze(),df)
+        for p in [ t.makePanel() ]:
+            t.assert_panel_equal(p.squeeze(),p)
+        for p4d in [ t.makePanel4D() ]:
+            t.assert_panel4d_equal(p4d.squeeze(),p4d)
+
+        # squeezing
+        df = t.makeTimeDataFrame().reindex(columns=['A'])
+        t.assert_series_equal(df.squeeze(),df['A'])
+
+        p = t.makePanel().reindex(items=['ItemA'])
+        t.assert_frame_equal(p.squeeze(),p['ItemA'])
+
+        p = t.makePanel().reindex(items=['ItemA'],minor_axis=['A'])
+        t.assert_series_equal(p.squeeze(),p.ix['ItemA',:,'A'])
+
+        p4d = t.makePanel4D().reindex(labels=['label1'])
+        t.assert_panel_equal(p4d.squeeze(),p4d['label1'])
+
+        p4d = t.makePanel4D().reindex(labels=['label1'],items=['ItemA'])
+        t.assert_frame_equal(p4d.squeeze(),p4d.ix['label1','ItemA'])
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
```
In [1]: p = Panel(randn(3,4,4),items=['ItemA','ItemB','ItemC'],
   ...:                        major_axis=date_range('20010102',periods=4),
   ...:                        minor_axis=['A','B','C','D'])
   ...:

In [2]: p
Out[2]: 
<class 'pandas.core.panel.Panel'>
Dimensions: 3 (items) x 4 (major_axis) x 4 (minor_axis)
Items axis: ItemA to ItemC
Major_axis axis: 2001-01-02 00:00:00 to 2001-01-05 00:00:00
Minor_axis axis: A to D

In [3]: p.reindex(items=['ItemA']).squeeze()
Out[3]: 
                   A         B         C         D
2001-01-02 -1.182806 -1.835015 -0.008415  1.665945
2001-01-03 -0.347332 -0.257820  0.167772 -1.193518
2001-01-04 -0.502643  0.055733  0.733034 -1.070536
2001-01-05 -1.900588 -1.728706  1.060564 -1.138837

In [4]: p.reindex(items=['ItemA'],minor=['B']).squeeze()
Out[4]: 
2001-01-02   -1.835015
2001-01-03   -0.257820
2001-01-04    0.055733
2001-01-05   -1.728706
Freq: D, Name: B
```
