### PR TITLE
Add a test case to io.test_parsers about issue #2733

### DIFF
--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -1868,11 +1868,12 @@ a,b,c
 
         tm.assert_frame_equal(result, expected)
 
-    def test_usecols_regexp_separator(self):
+    def test_usecols_with_whitespace(self):
         # #2733
         data = 'a  b  c\n4  apple  bat  5.7\n8  orange  cow  10'
 
-        result = self.read_csv(StringIO(data), sep='\s+', usecols=('a', 'b'))
+        result = self.read_csv(StringIO(data), delim_whitespace=True,
+                               usecols=('a', 'b'))
         expected = DataFrame({'a': ['apple', 'orange'],
                               'b': ['bat', 'cow']}, index=[4, 8])
 

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -1868,6 +1868,16 @@ a,b,c
 
         tm.assert_frame_equal(result, expected)
 
+    def test_usecols_regexp_separator(self):
+        # #2733
+        data = 'a  b  c\n4  apple  bat  5.7\n8  orange  cow  10'
+
+        result = self.read_csv(StringIO(data), sep='\s+', usecols=('a', 'b'))
+        expected = DataFrame({'a': ['apple', 'orange'],
+                              'b': ['bat', 'cow']}, index=[4, 8])
+
+        tm.assert_frame_equal(result, expected)
+
     def test_pure_python_failover(self):
         data = "a,b,c\n1,2,3#ignore this!\n4,5,6#ignorethistoo"
 


### PR DESCRIPTION
The test case doesn't fix the issue. Just a test about the  `usecols` parameter in `read_csv` when there are whitespaces in the reading data. I'm not sure the test case is worth it. Let me know.
