### PR TITLE
BUG: various bug fixes for DataFrame/Series construction

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -22,6 +22,20 @@ Where to get it
 * Binary installers on PyPI: http://pypi.python.org/pypi/pandas
 * Documentation: http://pandas.pydata.org
 
+**API Changes**
+
+  - Series now automatically will try to set the correct dtype based on passed datetimelike objects (datetime/Timestamp)
+     - timedelta64 are returned in appropriate cases (e.g. Series - Series, when both are datetime64)
+     - mixed datetimes and objects (GH2751_) in a constructor witll be casted correctly
+     - astype on datetimes to object are now handled (as well as NaT conversions to np.nan)
+
+**Bug fixes**
+
+  - Single element ndarrays of datetimelike objects are handled (e.g. np.array(datetime(2001,1,1,0,0))), w/o dtype being passed
+  - 0-dim ndarrays with a passed dtype are handled correctly (e.g. np.array(0.,dtype='float32'))
+
+.. _GH2751: https://github.com/pydata/pandas/issues/2751
+
 pandas 0.10.1
 =============
 

--- a/doc/source/missing_data.rst
+++ b/doc/source/missing_data.rst
@@ -80,6 +80,23 @@ pandas provides the :func:`~pandas.core.common.isnull` and
 missing by the ``isnull`` and ``notnull`` functions. ``inf`` and
 ``-inf`` are no longer considered missing by default.
 
+Datetimes
+---------
+
+For datetime64[ns] types, ``NaT`` represents missing values. This is a pseudo-native
+sentinal value that can be represented by numpy in a singular dtype (datetime64[ns]).
+Pandas objects provide intercompatibility between ``NaT`` and ``NaN``.
+
+.. ipython:: python
+
+   df2 = df.copy()
+   df2['timestamp'] = Timestamp('20120101')
+   df2
+   df2.ix[['a','c','h'],['one','timestamp']] = np.nan
+   df2
+   df2.get_dtype_counts()
+
+
 Calculations with missing data
 ------------------------------
 

--- a/doc/source/v0.10.2.txt
+++ b/doc/source/v0.10.2.txt
@@ -1,0 +1,54 @@
+.. _whatsnew_0102:
+
+v0.10.2 (February ??, 2013)
+---------------------------
+
+This is a minor release from 0.10.1 and includes many new features and
+enhancements along with a large number of bug fixes. There are also a number of
+important API changes that long-time pandas users should pay close attention
+to.
+
+API changes
+~~~~~~~~~~~
+
+Datetime64[ns] columns in a DataFrame (or a Series) allow the use of ``np.nan`` to indicate a nan value, in addition to the traditional ``NaT``, or not-a-time. This allows convenient nan setting in a generic way. Furthermore datetime64 columns are created by default, when passed datetimelike objects (*this change was introduced in 0.10.1*)
+
+.. ipython:: python
+
+   df = DataFrame(randn(6,2),date_range('20010102',periods=6),columns=['A','B'])
+   df['timestamp'] = Timestamp('20010103')
+   df
+
+   # datetime64[ns] out of the box
+   df.get_dtype_counts()
+
+   # use the traditional nan, which is mapped to NaT internally
+   df.ix[2:4,['A','timestamp']] = np.nan
+   df
+
+Astype conversion on datetime64[ns] to object, implicity converts ``NaT`` to ``np.nan``
+
+
+.. ipython:: python
+
+   import datetime
+   s = Series([datetime.datetime(2001, 1, 2, 0, 0) for i in range(3)])
+   s.dtype
+   s[1] = np.nan
+   s
+   s.dtype
+   s = s.astype('O')
+   s
+   s.dtype
+
+New features
+~~~~~~~~~~~~
+
+**Enhancements**
+
+**Bug Fixes**
+
+See the `full release notes
+<https://github.com/pydata/pandas/blob/master/RELEASE.rst>`__ or issue tracker
+on GitHub for a complete list.
+

--- a/doc/source/whatsnew.rst
+++ b/doc/source/whatsnew.rst
@@ -16,6 +16,8 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: v0.10.2.txt
+
 .. include:: v0.10.1.txt
 
 .. include:: v0.10.0.txt

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -654,6 +654,20 @@ def _possibly_cast_to_datetime(value, dtype):
                 except:
                     pass
 
+    elif dtype is None:
+        # we might have a array (or single object) that is datetime like, and no dtype is passed
+        # don't change the value unless we find a datetime set
+        v = value
+        if not (is_list_like(v) or hasattr(v,'len')):
+            v = [ v ]
+        if len(v):
+            inferred_type = lib.infer_dtype(v)
+            if inferred_type == 'datetime':
+                try:
+                    value = tslib.array_to_datetime(np.array(v))
+                except:
+                    pass
+
     return value
 
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4289,7 +4289,7 @@ class DataFrame(NDFrame):
 
         # if we have a dtype == 'M8[ns]', provide boxed values
         def infer(x):
-            if x.dtype == 'M8[ns]':
+            if com.is_datetime64_dtype(x):
                 x = lib.map_infer(x, lib.Timestamp)
             return lib.map_infer(x, func)
         return self.apply(infer)
@@ -4980,7 +4980,7 @@ class DataFrame(NDFrame):
     def _get_numeric_data(self):
         if self._is_mixed_type:
             num_data = self._data.get_numeric_data()
-            return DataFrame(num_data, copy=False)
+            return DataFrame(num_data, index=self.index, copy=False)
         else:
             if (self.values.dtype != np.object_ and
                     not issubclass(self.values.dtype.type, np.datetime64)):
@@ -4991,7 +4991,7 @@ class DataFrame(NDFrame):
     def _get_bool_data(self):
         if self._is_mixed_type:
             bool_data = self._data.get_bool_data()
-            return DataFrame(bool_data, copy=False)
+            return DataFrame(bool_data, index=self.index, copy=False)
         else:  # pragma: no cover
             if self.values.dtype == np.bool_:
                 return self

--- a/pandas/src/inference.pyx
+++ b/pandas/src/inference.pyx
@@ -265,6 +265,17 @@ def is_datetime64_array(ndarray values):
             return False
     return True
 
+def is_timedelta_array(ndarray values):
+    import datetime
+    cdef int i, n = len(values)
+    if n == 0:
+        return False
+    for i in range(n):
+        if not isinstance(values[i],datetime.timedelta):
+            return False
+    return True
+
+
 def is_date_array(ndarray[object] values):
     cdef int i, n = len(values)
     if n == 0:

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -520,6 +520,7 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         pass
 
     def test_fromValue(self):
+
         nans = Series(np.NaN, index=self.ts.index)
         self.assert_(nans.dtype == np.float_)
         self.assertEqual(len(nans), len(self.ts))
@@ -530,7 +531,7 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
 
         d = datetime.now()
         dates = Series(d, index=self.ts.index)
-        self.assert_(dates.dtype == np.object_)
+        self.assert_(dates.dtype == 'M8[ns]')
         self.assertEqual(len(dates), len(self.ts))
 
     def test_contains(self):
@@ -2295,8 +2296,6 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         # datetime64
         s = Series(self.ts.index)
         rs = s.tolist()
-        xp = s.astype(object).values.tolist()
-        assert_almost_equal(rs, xp)
         self.assertEqual(self.ts.index[0], rs[0])
 
     def test_to_dict(self):
@@ -2619,6 +2618,23 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         arr = Series(['1', '2', '3', '4'], dtype=object)
         result = arr.astype(int)
         self.assert_(np.array_equal(result, np.arange(1, 5)))
+
+    def test_astype_datetimes(self):
+        import pandas.tslib as tslib
+
+        s = Series(tslib.iNaT, dtype='M8[ns]', index=range(5))
+        s = s.astype('O')
+        self.assert_(s.dtype == np.object_)
+
+        s = Series([datetime(2001, 1, 2, 0, 0)])
+        s = s.astype('O')
+        self.assert_(s.dtype == np.object_)
+
+        s = Series([datetime(2001, 1, 2, 0, 0) for i in range(3)])
+        s[1] = np.nan
+        self.assert_(s.dtype == 'M8[ns]')
+        s = s.astype('O')
+        self.assert_(s.dtype == np.object_)
 
     def test_map(self):
         index, data = tm.getMixedTypeDict()

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1254,9 +1254,6 @@ class TestTimeSeries(unittest.TestCase):
 
     def test_set_dataframe_column_ns_dtype(self):
         x = DataFrame([datetime.now(), datetime.now()])
-        # self.assert_(x[0].dtype == object)
-
-        # x[0] = to_datetime(x[0])
         self.assert_(x[0].dtype == np.dtype('M8[ns]'))
 
     def test_groupby_count_dateparseerror(self):
@@ -2391,7 +2388,7 @@ class TestSeriesDatetime64(unittest.TestCase):
 
     def test_auto_conversion(self):
         series = Series(list(date_range('1/1/2000', periods=10)))
-        self.assert_(series.dtype == object)
+        self.assert_(series.dtype == 'M8[ns]')
 
     def test_constructor_cant_cast_datetime64(self):
         self.assertRaises(TypeError, Series,
@@ -2441,13 +2438,17 @@ class TestSeriesDatetime64(unittest.TestCase):
         self.assert_(self.series[6] is NaT)
 
     def test_intercept_astype_object(self):
-        # Work around NumPy 1.6 bugs
-        result = self.series.astype(object)
-        result2 = self.series.astype('O')
-        expected = Series([x for x in self.series], dtype=object)
 
-        assert_series_equal(result, expected)
-        assert_series_equal(result2, expected)
+        # this test no longer makes sense as series is by default already M8[ns]
+
+        # Work around NumPy 1.6 bugs
+        #result = self.series.astype(object)
+        #result2 = self.series.astype('O')
+ 
+        expected = Series(self.series, dtype=object)
+
+        #assert_series_equal(result, expected)
+        #assert_series_equal(result2, expected)
 
         df = DataFrame({'a': self.series,
                         'b': np.random.randn(len(self.series))})

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -494,7 +494,7 @@ class TestTimeZoneSupport(unittest.TestCase):
         dr = date_range('2011/1/1', '2012/1/1', freq='W-FRI')
         dr_tz = dr.tz_localize('US/Eastern')
         e = DataFrame({'A': 'foo', 'B': dr_tz}, index=dr)
-        self.assert_(e['B'].dtype == object)
+        self.assert_(e['B'].dtype == 'M8[ns]')
 
     def test_hongkong_tz_convert(self):
         # #1673


### PR DESCRIPTION
0 and 1 len ndarrays not inferring dtype correctly
datetimes that are single objects not inferring dtype
mixed datetimes and objects (GH #2751), casting datetimes to object
timedelta64 creation on series subtraction (of datetime64[ns])
astype on datetimes to object are now handled (as well as NaT conversions to np.nan)

astype conversion

```
In [4]: s = pd.Series([datetime.datetime(2001, 1, 2, 0, 0) for i in range(3)])

In [5]: s.dtype
Out[5]: dtype('datetime64[ns]')

In [6]: s[1] = np.nan

In [7]: s
Out[7]: 
0   2001-01-02 00:00:00
1                   NaT
2   2001-01-02 00:00:00

In [8]: s.dtype
Out[8]: dtype('datetime64[ns]')

In [9]: s = s.astype('O')

In [10]: s
Out[10]: 
0    2001-01-02 00:00:00
1                    NaN
2    2001-01-02 00:00:00

In [11]: s.dtype
Out[11]: dtype('object')
```

construction with datetimes

```
In [7]: pd.DataFrame({'A' : 1, 'B' : 'foo', 'C' : 'bar', 
    'D' : pd.Timestamp("20010101"),
    'E' : datetime.datetime(2001,1,2,0,0) }, index=np.arange(5)).get_dtype_counts()
Out[7]: 
datetime64[ns]    2
int64             1
object            2

In [16]: pd.DataFrame({'a':[1,2,4,7], 'b':[1.2, 2.3, 5.1, 6.3], 
    'c':list('abcd'), 
    'd':[datetime.datetime(2000,1,1) for i in range(4)] }).get_dtype_counts()
Out[16]: 
datetime64[ns]    1
float64           1
int64             1
object            1
```

1 len  ndarrays

```
In [16]: pd.DataFrame({'a': 1., 'b': 2, 'c': 'foo', 'float64' : np.array(1.,dtype='float64'),
    'int64' : np.array(1,dtype='int64')}, index=np.arange(10)).get_dtype_counts()
Out[16]: 
float64    2
int64      2
object     1
```
