### PR TITLE
DataFrame.from_items clean-up

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1104,20 +1104,19 @@ class DataFrame(NDFrame):
         """
         Convert (key, value) pairs to DataFrame. The keys will be the axis
         index (usually the columns, but depends on the specified
-        orientation). The values should be arrays or Series
+        orientation). The values should be arrays or Series.
 
         Parameters
         ----------
         items : sequence of (key, value) pairs
-            Values should be arrays or Series
-        columns : sequence, optional
-            Must be passed in the
-        orient : {'columns', 'index'}, default 'items'
-            The "orientation" of the data. If the keys of the passed dict
-            should be the items of the result panel, pass 'items'
-            (default). Otherwise if the columns of the values of the passed
-            DataFrame objects should be the items (which in the case of
-            mixed-dtype data you should do), instead pass 'minor'
+            Values should be arrays or Series.
+        columns : sequence of column labels, optional
+            Must be passed if orient='index'.
+        orient : {'columns', 'index'}, default 'columns'
+            The "orientation" of the data. If the keys of the
+            input correspond to column labels, pass 'columns'
+            (default). Otherwise if the keys correspond to the index,
+            pass 'index'.
 
         Returns
         -------
@@ -1151,8 +1150,8 @@ class DataFrame(NDFrame):
             arr = np.array(values, dtype=object).T
             data = [lib.maybe_convert_objects(v) for v in arr]
             return cls._from_arrays(data, columns, keys)
-        elif orient != 'columns':  # pragma: no cover
-            raise ValueError('only recognize index or columns for orient')
+        else:  # pragma: no cover
+            raise ValueError("'orient' must be either 'columns' or 'index'")
 
     @classmethod
     def _from_arrays(cls, arrays, columns, index, dtype=None):


### PR DESCRIPTION
- Improve docstrings and error messages
- Convert final `elif` to `else`: the `elif` condition was guaranteed to be true, so this is a silent code cleanup -- it does not change the behavior of the code.
### Testing

I checked that the `from_items` method was working as usual, and that the new docstrings and error messages looked OK, in the following session.

``` python
>>> pd.DataFrame.from_items([('a', [1,2]), ('b', [3,4])])

   a  b
0  1  3
1  2  4

>>> pd.DataFrame.from_items([('a', [1,2]), ('b', [3,4])], orient='columns')

   a  b
0  1  3
1  2  4

>>> pd.DataFrame.from_items([('a', [1,2]), ('b', [3,4])], orient='index')
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-14-42f50cd4d05d> in <module>()
----> 1 pd.DataFrame.from_items([('a', [1,2]), ('b', [3,4])], orient='index')

/Users/dan/lib/python/pandas/pandas/core/frame.pyc in from_items(cls, items, columns, orient)
   1144         elif orient == 'index':
   1145             if columns is None:
-> 1146                 raise ValueError("Must pass columns with orient='index'")
   1147
   1148             keys = _ensure_index(keys)

ValueError: Must pass columns with orient='index'

>>> pd.DataFrame.from_items([('a', [1,2]), ('b', [3,4])], orient='index', columns=['col1', 'col2'])

   col1  col2
a     1     2
b     3     4

>>> pd.DataFrame.from_items([('a', [1,2]), ('b', [3,4])], orient='indexXXX', columns=['col1', 'col2'])                                                                            ---------------------------------------------------------------------------ValueError                                Traceback (most recent call last)<ipython-input-17-c3448a7551f4> in <module>()----> 1 pd.DataFrame.from_items([('a', [1,2]), ('b', [3,4])], orient='indexXXX', columns=['col1', 'col2'])/Users/dan/lib/python/pandas/pandas/core/frame.pyc in from_items(cls, items, columns, orient)
   1152             return cls._from_arrays(data, columns, keys)
   1153         else:  # pragma: no cover
-> 1154             raise ValueError("'orient' must be either 'columns' or 'index'")
   1155 
   1156     @classmethod

ValueError: 'orient' must be either 'columns' or 'index'

>>> pd.DataFrame.from_items?
Type:       instancemethod
String Form:<bound method type.from_items of <class 'pandas.core.frame.DataFrame'>>
File:       /Users/dan/lib/python/pandas/pandas/core/frame.py
Definition: pd.DataFrame.from_items(cls, items, columns=None, orient='columns')
Docstring:
Convert (key, value) pairs to DataFrame. The keys will be the axis
index (usually the columns, but depends on the specified
orientation). The values should be arrays or Series.

Parameters
----------
items : sequence of (key, value) pairs
    Values should be arrays or Series.
columns : sequence of column labels, optional
    Must be passed if orient='index'.
orient : {'columns', 'index'}, default 'columns'
    The "orientation" of the data. If the keys of the
    input correspond to column labels, pass 'columns'
    (default). Otherwise if the keys correspond to the index,
    pass 'index'.

Returns
-------
frame : DataFrame

>>>
```
