### PR TITLE
BUG: fillna with method segfaults on zero-length input (fixes #2775)

### DIFF
--- a/pandas/src/generate_code.py
+++ b/pandas/src/generate_code.py
@@ -388,6 +388,7 @@ def pad_inplace_%(name)s(ndarray[%(c_type)s] values,
 
     N = len(values)
 
+    # GH 2778
     if N == 0:
         return
 
@@ -422,6 +423,7 @@ def pad_2d_inplace_%(name)s(ndarray[%(c_type)s, ndim=2] values,
 
     K, N = (<object> values).shape
 
+    # GH 2778
     if N == 0:
         return
 
@@ -457,6 +459,7 @@ def backfill_2d_inplace_%(name)s(ndarray[%(c_type)s, ndim=2] values,
 
     K, N = (<object> values).shape
 
+    # GH 2778
     if N == 0:
         return
 
@@ -492,6 +495,7 @@ def backfill_inplace_%(name)s(ndarray[%(c_type)s] values,
 
     N = len(values)
 
+    # GH 2778
     if N == 0:
         return
 

--- a/pandas/src/generate_code.py
+++ b/pandas/src/generate_code.py
@@ -388,6 +388,9 @@ def pad_inplace_%(name)s(ndarray[%(c_type)s] values,
 
     N = len(values)
 
+    if N == 0:
+        return
+
     if limit is None:
         lim = N
     else:
@@ -418,6 +421,9 @@ def pad_2d_inplace_%(name)s(ndarray[%(c_type)s, ndim=2] values,
     cdef int lim, fill_count = 0
 
     K, N = (<object> values).shape
+
+    if N == 0:
+        return
 
     if limit is None:
         lim = N
@@ -451,6 +457,9 @@ def backfill_2d_inplace_%(name)s(ndarray[%(c_type)s, ndim=2] values,
 
     K, N = (<object> values).shape
 
+    if N == 0:
+        return
+
     if limit is None:
         lim = N
     else:
@@ -482,6 +491,9 @@ def backfill_inplace_%(name)s(ndarray[%(c_type)s] values,
     cdef int lim, fill_count = 0
 
     N = len(values)
+
+    if N == 0:
+        return
 
     if limit is None:
         lim = N

--- a/pandas/src/generated.pyx
+++ b/pandas/src/generated.pyx
@@ -826,6 +826,7 @@ def pad_inplace_float64(ndarray[float64_t] values,
 
     N = len(values)
 
+    # GH 2778
     if N == 0:
         return
 
@@ -858,6 +859,7 @@ def pad_inplace_object(ndarray[object] values,
 
     N = len(values)
 
+    # GH 2778
     if N == 0:
         return
 
@@ -890,6 +892,7 @@ def pad_inplace_int32(ndarray[int32_t] values,
 
     N = len(values)
 
+    # GH 2778
     if N == 0:
         return
 
@@ -922,6 +925,7 @@ def pad_inplace_int64(ndarray[int64_t] values,
 
     N = len(values)
 
+    # GH 2778
     if N == 0:
         return
 
@@ -954,6 +958,7 @@ def pad_inplace_bool(ndarray[uint8_t] values,
 
     N = len(values)
 
+    # GH 2778
     if N == 0:
         return
 
@@ -987,6 +992,7 @@ def backfill_inplace_float64(ndarray[float64_t] values,
 
     N = len(values)
 
+    # GH 2778
     if N == 0:
         return
 
@@ -1018,6 +1024,7 @@ def backfill_inplace_object(ndarray[object] values,
 
     N = len(values)
 
+    # GH 2778
     if N == 0:
         return
 
@@ -1049,6 +1056,7 @@ def backfill_inplace_int32(ndarray[int32_t] values,
 
     N = len(values)
 
+    # GH 2778
     if N == 0:
         return
 
@@ -1080,6 +1088,7 @@ def backfill_inplace_int64(ndarray[int64_t] values,
 
     N = len(values)
 
+    # GH 2778
     if N == 0:
         return
 
@@ -1111,6 +1120,7 @@ def backfill_inplace_bool(ndarray[uint8_t] values,
 
     N = len(values)
 
+    # GH 2778
     if N == 0:
         return
 
@@ -1143,6 +1153,7 @@ def pad_2d_inplace_float64(ndarray[float64_t, ndim=2] values,
 
     K, N = (<object> values).shape
 
+    # GH 2778
     if N == 0:
         return
 
@@ -1176,6 +1187,7 @@ def pad_2d_inplace_object(ndarray[object, ndim=2] values,
 
     K, N = (<object> values).shape
 
+    # GH 2778
     if N == 0:
         return
 
@@ -1209,6 +1221,7 @@ def pad_2d_inplace_int32(ndarray[int32_t, ndim=2] values,
 
     K, N = (<object> values).shape
 
+    # GH 2778
     if N == 0:
         return
 
@@ -1242,6 +1255,7 @@ def pad_2d_inplace_int64(ndarray[int64_t, ndim=2] values,
 
     K, N = (<object> values).shape
 
+    # GH 2778
     if N == 0:
         return
 
@@ -1275,6 +1289,7 @@ def pad_2d_inplace_bool(ndarray[uint8_t, ndim=2] values,
 
     K, N = (<object> values).shape
 
+    # GH 2778
     if N == 0:
         return
 
@@ -1309,6 +1324,7 @@ def backfill_2d_inplace_float64(ndarray[float64_t, ndim=2] values,
 
     K, N = (<object> values).shape
 
+    # GH 2778
     if N == 0:
         return
 
@@ -1342,6 +1358,7 @@ def backfill_2d_inplace_object(ndarray[object, ndim=2] values,
 
     K, N = (<object> values).shape
 
+    # GH 2778
     if N == 0:
         return
 
@@ -1375,6 +1392,7 @@ def backfill_2d_inplace_int32(ndarray[int32_t, ndim=2] values,
 
     K, N = (<object> values).shape
 
+    # GH 2778
     if N == 0:
         return
 
@@ -1408,6 +1426,7 @@ def backfill_2d_inplace_int64(ndarray[int64_t, ndim=2] values,
 
     K, N = (<object> values).shape
 
+    # GH 2778
     if N == 0:
         return
 
@@ -1441,6 +1460,7 @@ def backfill_2d_inplace_bool(ndarray[uint8_t, ndim=2] values,
 
     K, N = (<object> values).shape
 
+    # GH 2778
     if N == 0:
         return
 

--- a/pandas/src/generated.pyx
+++ b/pandas/src/generated.pyx
@@ -826,6 +826,9 @@ def pad_inplace_float64(ndarray[float64_t] values,
 
     N = len(values)
 
+    if N == 0:
+        return
+
     if limit is None:
         lim = N
     else:
@@ -854,6 +857,9 @@ def pad_inplace_object(ndarray[object] values,
     cdef int lim, fill_count = 0
 
     N = len(values)
+
+    if N == 0:
+        return
 
     if limit is None:
         lim = N
@@ -884,6 +890,9 @@ def pad_inplace_int32(ndarray[int32_t] values,
 
     N = len(values)
 
+    if N == 0:
+        return
+
     if limit is None:
         lim = N
     else:
@@ -913,6 +922,9 @@ def pad_inplace_int64(ndarray[int64_t] values,
 
     N = len(values)
 
+    if N == 0:
+        return
+
     if limit is None:
         lim = N
     else:
@@ -941,6 +953,9 @@ def pad_inplace_bool(ndarray[uint8_t] values,
     cdef int lim, fill_count = 0
 
     N = len(values)
+
+    if N == 0:
+        return
 
     if limit is None:
         lim = N
@@ -972,6 +987,9 @@ def backfill_inplace_float64(ndarray[float64_t] values,
 
     N = len(values)
 
+    if N == 0:
+        return
+
     if limit is None:
         lim = N
     else:
@@ -999,6 +1017,9 @@ def backfill_inplace_object(ndarray[object] values,
     cdef int lim, fill_count = 0
 
     N = len(values)
+
+    if N == 0:
+        return
 
     if limit is None:
         lim = N
@@ -1028,6 +1049,9 @@ def backfill_inplace_int32(ndarray[int32_t] values,
 
     N = len(values)
 
+    if N == 0:
+        return
+
     if limit is None:
         lim = N
     else:
@@ -1055,6 +1079,9 @@ def backfill_inplace_int64(ndarray[int64_t] values,
     cdef int lim, fill_count = 0
 
     N = len(values)
+
+    if N == 0:
+        return
 
     if limit is None:
         lim = N
@@ -1084,6 +1111,9 @@ def backfill_inplace_bool(ndarray[uint8_t] values,
 
     N = len(values)
 
+    if N == 0:
+        return
+
     if limit is None:
         lim = N
     else:
@@ -1112,6 +1142,9 @@ def pad_2d_inplace_float64(ndarray[float64_t, ndim=2] values,
     cdef int lim, fill_count = 0
 
     K, N = (<object> values).shape
+
+    if N == 0:
+        return
 
     if limit is None:
         lim = N
@@ -1143,6 +1176,9 @@ def pad_2d_inplace_object(ndarray[object, ndim=2] values,
 
     K, N = (<object> values).shape
 
+    if N == 0:
+        return
+
     if limit is None:
         lim = N
     else:
@@ -1172,6 +1208,9 @@ def pad_2d_inplace_int32(ndarray[int32_t, ndim=2] values,
     cdef int lim, fill_count = 0
 
     K, N = (<object> values).shape
+
+    if N == 0:
+        return
 
     if limit is None:
         lim = N
@@ -1203,6 +1242,9 @@ def pad_2d_inplace_int64(ndarray[int64_t, ndim=2] values,
 
     K, N = (<object> values).shape
 
+    if N == 0:
+        return
+
     if limit is None:
         lim = N
     else:
@@ -1232,6 +1274,9 @@ def pad_2d_inplace_bool(ndarray[uint8_t, ndim=2] values,
     cdef int lim, fill_count = 0
 
     K, N = (<object> values).shape
+
+    if N == 0:
+        return
 
     if limit is None:
         lim = N
@@ -1264,6 +1309,9 @@ def backfill_2d_inplace_float64(ndarray[float64_t, ndim=2] values,
 
     K, N = (<object> values).shape
 
+    if N == 0:
+        return
+
     if limit is None:
         lim = N
     else:
@@ -1293,6 +1341,9 @@ def backfill_2d_inplace_object(ndarray[object, ndim=2] values,
     cdef int lim, fill_count = 0
 
     K, N = (<object> values).shape
+
+    if N == 0:
+        return
 
     if limit is None:
         lim = N
@@ -1324,6 +1375,9 @@ def backfill_2d_inplace_int32(ndarray[int32_t, ndim=2] values,
 
     K, N = (<object> values).shape
 
+    if N == 0:
+        return
+
     if limit is None:
         lim = N
     else:
@@ -1354,6 +1408,9 @@ def backfill_2d_inplace_int64(ndarray[int64_t, ndim=2] values,
 
     K, N = (<object> values).shape
 
+    if N == 0:
+        return
+
     if limit is None:
         lim = N
     else:
@@ -1383,6 +1440,9 @@ def backfill_2d_inplace_bool(ndarray[uint8_t, ndim=2] values,
     cdef int lim, fill_count = 0
 
     K, N = (<object> values).shape
+
+    if N == 0:
+        return
 
     if limit is None:
         lim = N

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4670,6 +4670,12 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self.assertRaises(ValueError, self.tsframe.fillna)
         self.assertRaises(ValueError, self.tsframe.fillna, 5, method='ffill')
 
+        # empty frame (GH #2778)
+        df = DataFrame(columns=['x'])
+        for m in ['pad','backfill']:
+            df.x.fillna(method=m,inplace=1)
+            df.x.fillna(method=m)
+
     def test_ffill(self):
         self.tsframe['A'][:5] = nan
         self.tsframe['A'][-5:] = nan


### PR DESCRIPTION
fixes #2775

just added a check for zero-length data to the backfill and pad templates

not sure if I should add test coverage? the problem is that the tests will not fail without the fix, but rather segfault, so it might not be a good idea
