### PR TITLE
ENH: time slicing on datetime indicies (closes #2681)

### DIFF
--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1117,6 +1117,30 @@ class Index(np.ndarray):
         name = self.name if self.name == other.name else None
         return Index(joined, name=name)
 
+    def slice_indexer(self, start=None, end=None, step=None):
+        """
+        For an ordered Index, compute the slice indexer for input labels and
+        step
+
+        Parameters
+        ----------
+        start : label, default None
+            If None, defaults to the beginning
+        end : label, default None
+            If None, defaults to the end
+        step : int, default None 
+
+        Returns
+        -------
+        indexer : ndarray or slice
+
+        Notes
+        -----
+        This function assumes that the data is sorted, so use at your own peril
+        """
+        start_slice, end_slice = self.slice_locs(start, end)
+        return slice(start_slice, end_slice, step)
+
     def slice_locs(self, start=None, end=None):
         """
         For an ordered Index, compute the slice locations for input labels
@@ -1125,27 +1149,27 @@ class Index(np.ndarray):
         ----------
         start : label, default None
             If None, defaults to the beginning
-        end : label
+        end : label, default None
             If None, defaults to the end
 
         Returns
         -------
-        (begin, end) : (int, int)
+        (start, end) : (int, int)
 
         Notes
         -----
         This function assumes that the data is sorted, so use at your own peril
         """
         if start is None:
-            beg_slice = 0
+            start_slice = 0
         else:
             try:
-                beg_slice = self.get_loc(start)
-                if isinstance(beg_slice, slice):
-                    beg_slice = beg_slice.start
+                start_slice = self.get_loc(start)
+                if isinstance(start_slice, slice):
+                    start_slice = start_slice.start
             except KeyError:
                 if self.is_monotonic:
-                    beg_slice = self.searchsorted(start, side='left')
+                    start_slice = self.searchsorted(start, side='left')
                 else:
                     raise
 
@@ -1164,7 +1188,7 @@ class Index(np.ndarray):
                 else:
                     raise
 
-        return beg_slice, end_slice
+        return start_slice, end_slice
 
     def delete(self, loc):
         """
@@ -2106,7 +2130,7 @@ class MultiIndex(Index):
 
         Returns
         -------
-        (begin, end) : (int, int)
+        (start, end) : (int, int)
 
         Notes
         -----

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1,6 +1,6 @@
 # pylint: disable-msg=W0612,E1101
 from copy import deepcopy
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, time
 from StringIO import StringIO
 import cPickle as pickle
 import operator
@@ -4552,7 +4552,6 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self.assert_(result is not zero_length)
 
     def test_asfreq_datetimeindex(self):
-        from pandas import DatetimeIndex
         df = DataFrame({'A': [1, 2, 3]},
                        index=[datetime(2011, 11, 01), datetime(2011, 11, 2),
                               datetime(2011, 11, 3)])
@@ -4561,6 +4560,44 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
         ts = df['A'].asfreq('B')
         self.assert_(isinstance(ts.index, DatetimeIndex))
+
+    def test_attime_betweentime_datetimeindex(self):
+        index = pan.date_range("2012-01-01", "2012-01-05", freq='30min')
+        df = DataFrame(randn(len(index), 5), index=index)
+
+        result = df.at_time(time(12, 0, 0))
+        expected = df.ix[time(12, 0, 0)]
+        assert_frame_equal(result, expected)
+        self.assert_(len(result) == 4)
+
+        result = df.between_time(time(13, 0, 0), time(14, 0, 0))
+        expected = df.ix[time(13, 0, 0):time(14, 0, 0)]
+        assert_frame_equal(result, expected)
+        self.assert_(len(result) == 12)
+
+        result = df.copy()
+        result.ix[time(12, 0, 0)] = 0
+        result = result.ix[time(12, 0, 0)]
+        expected = df.ix[time(12, 0, 0)].copy()
+        expected.ix[:] = 0
+        assert_frame_equal(result, expected)
+
+        result = df.copy()
+        result.ix[time(12, 0, 0)] = 0
+        result.ix[time(12, 0, 0)] = df # also checks reindexing
+        assert_frame_equal(result, df)
+
+        result = df.copy()
+        result.ix[time(13, 0, 0):time(14, 0, 0)] = 0
+        result = result.ix[time(13, 0, 0):time(14, 0, 0)]
+        expected = df.ix[time(13, 0, 0):time(14, 0, 0)].copy()
+        expected.ix[:] = 0
+        assert_frame_equal(result, expected)
+
+        result = df.copy()
+        result.ix[time(13, 0, 0):time(14, 0, 0)] = 0
+        result.ix[time(13, 0, 0):time(14, 0, 0)] = df # also checks reindexing
+        assert_frame_equal(result, df)
 
     def test_as_matrix(self):
         frame = self.frame

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4561,42 +4561,50 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         ts = df['A'].asfreq('B')
         self.assert_(isinstance(ts.index, DatetimeIndex))
 
-    def test_attime_betweentime_datetimeindex(self):
+    def test_at_time_between_time_datetimeindex(self):
         index = pan.date_range("2012-01-01", "2012-01-05", freq='30min')
         df = DataFrame(randn(len(index), 5), index=index)
+        akey = time(12, 0, 0)
+        bkey = slice(time(13, 0, 0), time(14, 0, 0))
+        ainds = [24, 72, 120, 168]
+        binds = [26, 27, 28, 74, 75, 76, 122, 123, 124, 170, 171, 172]
 
-        result = df.at_time(time(12, 0, 0))
-        expected = df.ix[time(12, 0, 0)]
+        result = df.at_time(akey)
+        expected = df.ix[akey]
+        expected2 = df.ix[ainds]
         assert_frame_equal(result, expected)
+        assert_frame_equal(result, expected2)
         self.assert_(len(result) == 4)
 
-        result = df.between_time(time(13, 0, 0), time(14, 0, 0))
-        expected = df.ix[time(13, 0, 0):time(14, 0, 0)]
+        result = df.between_time(bkey.start, bkey.stop)
+        expected = df.ix[bkey]
+        expected2 = df.ix[binds]
         assert_frame_equal(result, expected)
+        assert_frame_equal(result, expected2)
         self.assert_(len(result) == 12)
 
         result = df.copy()
-        result.ix[time(12, 0, 0)] = 0
-        result = result.ix[time(12, 0, 0)]
-        expected = df.ix[time(12, 0, 0)].copy()
+        result.ix[akey] = 0
+        result = result.ix[akey]
+        expected = df.ix[akey].copy()
         expected.ix[:] = 0
         assert_frame_equal(result, expected)
 
         result = df.copy()
-        result.ix[time(12, 0, 0)] = 0
-        result.ix[time(12, 0, 0)] = df # also checks reindexing
+        result.ix[akey] = 0
+        result.ix[akey] = df.ix[ainds]
         assert_frame_equal(result, df)
 
         result = df.copy()
-        result.ix[time(13, 0, 0):time(14, 0, 0)] = 0
-        result = result.ix[time(13, 0, 0):time(14, 0, 0)]
-        expected = df.ix[time(13, 0, 0):time(14, 0, 0)].copy()
+        result.ix[bkey] = 0
+        result = result.ix[bkey]
+        expected = df.ix[bkey].copy()
         expected.ix[:] = 0
         assert_frame_equal(result, expected)
 
         result = df.copy()
-        result.ix[time(13, 0, 0):time(14, 0, 0)] = 0
-        result.ix[time(13, 0, 0):time(14, 0, 0)] = df # also checks reindexing
+        result.ix[bkey] = 0
+        result.ix[bkey] = df.ix[binds]
         assert_frame_equal(result, df)
 
     def test_as_matrix(self):

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1152,6 +1152,20 @@ class DatetimeIndex(Int64Index):
         loc = self._partial_date_slice(reso, parsed)
         return loc
 
+    def slice_indexer(self, start=None, end=None, step=None):
+        """
+        Index.slice_indexer, customized to handle time slicing
+        """
+        if isinstance(start, time) and isinstance(end, time):
+            if step is not None and step != 1:
+                raise ValueError('Must have step size of 1 with time slices')
+            return self.indexer_between_time(start, end)
+
+        if isinstance(start, time) or isinstance(end, time):
+            raise KeyError('Cannot mix time and non-time slice keys')
+
+        return Index.slice_indexer(self, start, end, step)
+
     def slice_locs(self, start=None, end=None):
         """
         Index.slice_locs, customized to handle partial ISO-8601 string slicing
@@ -1171,6 +1185,9 @@ class DatetimeIndex(Int64Index):
                 return start_loc, end_loc
             except KeyError:
                 pass
+
+        if isinstance(start, time) or isinstance(end, time):
+            raise KeyError('Cannot use slice_locs with time slice keys')
 
         return Index.slice_locs(self, start, end)
 


### PR DESCRIPTION
closes #2681 

Added support for `df.ix[start_time:end_time]`, where `df.index` is a `DateTimeIndex`, both on the `__getitem__` and `__setitem__` side; test coverage in test_frame.py
