### PR TITLE
v0.10.1 bug fixes not displaying properly on website, PDF

### DIFF
--- a/doc/source/v0.10.1.txt
+++ b/doc/source/v0.10.1.txt
@@ -176,31 +176,31 @@ combined result, by using ``where`` on a selector table.
   mixed with ``float64`` however)
 - Fixed Google Analytics prefix when specifying request segment (GH2713_).
 - Function to reset Google Analytics token store so users can recover from
-improperly setup client secrets (GH2687_).
+  improperly setup client secrets (GH2687_).
 - Fixed groupby bug resulting in segfault when passing in MultiIndex (GH2706_)
 - Fixed bug where passing a Series with datetime64 values into `to_datetime`
-results in bogus output values (GH2699_)
+  results in bogus output values (GH2699_)
 - Fixed bug in ``pattern in HDFStore`` expressions when pattern is not a valid
-regex (GH2694_)
+  regex (GH2694_)
 - Fixed performance issues while aggregating boolean data (GH2692_)
 - When given a boolean mask key and a Series of new values, Series __setitem__
-will now align the incoming values with the original Series (GH2686_)
+  will now align the incoming values with the original Series (GH2686_)
 - Fixed MemoryError caused by performing counting sort on sorting MultiIndex
-levels with a very large number of combinatorial values (GH2684_)
+  levels with a very large number of combinatorial values (GH2684_)
 - Fixed bug that causes plotting to fail when the index is a DatetimeIndex with
-a fixed-offset timezone (GH2683_)
+  a fixed-offset timezone (GH2683_)
 - Corrected businessday subtraction logic when the offset is more than 5 bdays
-and the starting date is on a weekend (GH2680_)
+  and the starting date is on a weekend (GH2680_)
 - Fixed C file parser behavior when the file has more columns than data
-(GH2668_)
+  (GH2668_)
 - Fixed file reader bug that misaligned columns with data in the presence of an
-implicit column and a specified `usecols` value
+  implicit column and a specified `usecols` value
 - DataFrames with numerical or datetime indices are now sorted prior to
-plotting (GH2609_)
+  plotting (GH2609_)
 - Fixed DataFrame.from_records error when passed columns, index, but empty
-records (GH2633_)
+  records (GH2633_)
 - Several bug fixed for Series operations when dtype is datetime64 (GH2689_,
-GH2629_, GH2626_)
+  GH2629_, GH2626_)
 
 
 See the `full release notes


### PR DESCRIPTION
The Bug Fixes list on the ["What's New" page](http://pandas.pydata.org/pandas-docs/stable/whatsnew.html) is a bit broken, as is the corresponding section of the PDF.

I've added some missing indentation, which fixes the issue for me.
