### PR TITLE
Change wording in `corr` doc string

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1677,7 +1677,7 @@ copy : boolean, default False
     def corr(self, other, method='pearson',
              min_periods=None):
         """
-        Compute correlation two Series, excluding missing values
+        Compute correlation to other Series, excluding missing values
 
         Parameters
         ----------


### PR DESCRIPTION
Not sure if this is the best option, another one might be:
"Compute correlation between two Series"
