### PR TITLE
Creating DatetimeIndex from empty array with datetime64 dtype raises IndexError

### DIFF
--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -106,6 +106,10 @@ def test_isnull_datetime():
     assert(mask[0])
     assert(not mask[1:].any())
 
+def test_datetimeindex_from_empty_datetime64_array():
+    for unit in [ 'ms', 'us', 'ns' ]:
+        idx = DatetimeIndex(np.array([], dtype='datetime64[%s]' % unit))
+        assert(len(idx) == 0)
 
 def test_any_none():
     assert(com._any_none(1, 2, 3, None))

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -227,7 +227,7 @@ class DatetimeIndex(Int64Index):
                     offset = data.offset
                     verify_integrity = False
             else:
-                if data.dtype != _NS_DTYPE:
+                if data.dtype != _NS_DTYPE and data.size:
                     subarr = tslib.cast_to_nanoseconds(data)
                 else:
                     subarr = data


### PR DESCRIPTION
using pandas from master:

``` python
import numpy as np
import pandas as pd
pd.DatetimeIndex(np.array([], dtype='datetime64'))
```

I get the following stack trace:

``` python
/data/python/pandas/pandas/tseries/index.pyc in __new__(cls, data, freq, start, end, periods, copy, name, tz, verify_integrity, normalize, **kwds)
    229             else:
    230                 if data.dtype != _NS_DTYPE:
--> 231                     subarr = tslib.cast_to_nanoseconds(data)
    232                 else:
    233                     subarr = data

/data/python/pandas/pandas/tslib.so in pandas.tslib.cast_to_nanoseconds (pandas/tslib.c:14151)()

IndexError: invalid index
```

This happens because pandas.tslib.cast_to_nanoseconds expects the array to be not empty to get the datetime64 unit of the first element.

One way to fix it would be to check whether `data` is empty before trying the conversion. 

It would be nice to have a better error inside `pd.tslib.cast_to_nanoseconds` saying that it expects a non-empty array as well.
