### PR TITLE
ENH: Optimize take_*; improve non-NA fill_value support

### DIFF
--- a/pandas/algos.pyx
+++ b/pandas/algos.pyx
@@ -2018,7 +2018,7 @@ def group_median(ndarray[float64_t, ndim=2] out,
     data = np.empty((K, N), dtype=np.float64)
     ptr = <float64_t*> data.data
 
-    take_2d_axis1_float64(values.T, indexer, out=data)
+    take_2d_axis1_float64_float64(values.T, indexer, out=data)
 
     for i in range(K):
         # exclude NA group

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1,12 +1,14 @@
 """
 Misc tools for implementing data structures
 """
+# XXX: HACK for NumPy 1.5.1 to suppress warnings
 try:
     import cPickle as pickle
 except ImportError:  # pragma: no cover
     import pickle
 
 import itertools
+from datetime import datetime
 
 from numpy.lib.format import read_array, write_array
 import numpy as np
@@ -244,230 +246,332 @@ def _unpickle_array(bytes):
     return arr
 
 
-def _view_wrapper(f, wrap_dtype, na_override=None):
+def _view_wrapper(f, arr_dtype, out_dtype, fill_wrap=None):
     def wrapper(arr, indexer, out, fill_value=np.nan):
-        if na_override is not None and np.isnan(fill_value):
-            fill_value = na_override
-        view = arr.view(wrap_dtype)
-        outview = out.view(wrap_dtype)
-        f(view, indexer, outview, fill_value=fill_value)
+        if arr_dtype is not None:
+            arr = arr.view(arr_dtype)
+        if out_dtype is not None:
+            out = out.view(out_dtype)
+        if fill_wrap is not None:
+            fill_value = fill_wrap(fill_value)
+        f(arr, indexer, out, fill_value=fill_value)
     return wrapper
 
 
-_take1d_dict = {
-    'float64': algos.take_1d_float64,
-    'float32': algos.take_1d_float32,
-    'int8': algos.take_1d_int8,
-    'int16': algos.take_1d_int16,
-    'int32': algos.take_1d_int32,
-    'int64': algos.take_1d_int64,
-    'object': algos.take_1d_object,
-    'bool': _view_wrapper(algos.take_1d_bool, np.uint8),
-    'datetime64[ns]': _view_wrapper(algos.take_1d_int64, np.int64,
-                                    na_override=tslib.iNaT),
+def _datetime64_fill_wrap(fill_value):
+    if isnull(fill_value):
+        return tslib.iNaT
+    try:
+        return lib.Timestamp(fill_value).value
+    except:
+        # the proper thing to do here would probably be to upcast to object
+        # (but numpy 1.6.1 doesn't do this properly)
+        return tslib.iNaT
+
+
+def _convert_wrapper(f, conv_dtype):
+    def wrapper(arr, indexer, out, fill_value=np.nan):
+        arr = arr.astype(conv_dtype)
+        f(arr, indexer, out, fill_value=fill_value)
+    return wrapper
+
+
+def _take_2d_multi_generic(arr, indexer, out, fill_value=np.nan):
+    # this is not ideal, performance-wise, but it's better than
+    #   raising an exception
+    if arr.shape[0] == 0 or arr.shape[1] == 0:
+        return
+    row_idx, col_idx = indexer
+    row_mask = row_idx == -1
+    col_mask = col_idx == -1
+    if fill_value is not None:
+        if row_mask.any():
+            out[row_mask, :] = fill_value
+        if col_mask.any():
+            out[:, col_mask] = fill_value
+    for i in range(len(row_idx)):
+        u = row_idx[i]
+        for j in range(len(col_idx)):
+            v = col_idx[j]
+            out[i, j] = arr[u, v]
+
+
+def _take_nd_generic(arr, indexer, out, axis=0, fill_value=np.nan):
+    if arr.shape[axis] == 0:
+        return
+    mask = indexer == -1
+    needs_masking = mask.any()
+    if arr.dtype != out.dtype:
+        arr = arr.astype(out.dtype)
+    ndtake(arr, indexer, axis=axis, out=out)
+    if needs_masking:
+        outindexer = [slice(None)] * arr.ndim
+        outindexer[axis] = mask
+        out[tuple(outindexer)] = fill_value
+
+
+_take_1d_dict = {
+    ('int8', 'int8'): algos.take_1d_int8_int8,
+    ('int8', 'int32'): algos.take_1d_int8_int32,
+    ('int8', 'int64'): algos.take_1d_int8_int64,
+    ('int8', 'float64'): algos.take_1d_int8_float64,
+    ('int16', 'int16'): algos.take_1d_int16_int16,
+    ('int16', 'int32'): algos.take_1d_int16_int32,
+    ('int16', 'int64'): algos.take_1d_int16_int64,
+    ('int16', 'float64'): algos.take_1d_int16_float64,
+    ('int32', 'int32'): algos.take_1d_int32_int32,
+    ('int32', 'int64'): algos.take_1d_int32_int64,
+    ('int32', 'float64'): algos.take_1d_int32_float64,
+    ('int64', 'int64'): algos.take_1d_int64_int64,
+    ('int64', 'float64'): algos.take_1d_int64_float64,
+    ('float32', 'float32'): algos.take_1d_float32_float32,
+    ('float32', 'float64'): algos.take_1d_float32_float64,
+    ('float64', 'float64'): algos.take_1d_float64_float64,
+    ('object', 'object'): algos.take_1d_object_object,
+    ('bool', 'bool'):
+        _view_wrapper(algos.take_1d_bool_bool, np.uint8, np.uint8),
+    ('bool', 'object'):
+        _view_wrapper(algos.take_1d_bool_object, np.uint8, None),
+    ('datetime64[ns]','datetime64[ns]'):
+        _view_wrapper(algos.take_1d_int64_int64, np.int64, np.int64,
+                      fill_wrap=_datetime64_fill_wrap)
 }
 
-_take2d_axis0_dict = {
-    'float64': algos.take_2d_axis0_float64,
-    'float32': algos.take_2d_axis0_float32,
-    'int8': algos.take_2d_axis0_int8,
-    'int16': algos.take_2d_axis0_int16,
-    'int32': algos.take_2d_axis0_int32,
-    'int64': algos.take_2d_axis0_int64,
-    'object': algos.take_2d_axis0_object,
-    'bool': _view_wrapper(algos.take_2d_axis0_bool, np.uint8),
-    'datetime64[ns]': _view_wrapper(algos.take_2d_axis0_int64, np.int64,
-                                    na_override=tslib.iNaT),
+
+_take_2d_axis0_dict = {
+    ('int8', 'int8'): algos.take_2d_axis0_int8_int8,
+    ('int8', 'int32'): algos.take_2d_axis0_int8_int32,
+    ('int8', 'int64'): algos.take_2d_axis0_int8_int64,
+    ('int8', 'float64'): algos.take_2d_axis0_int8_float64,
+    ('int16', 'int16'): algos.take_2d_axis0_int16_int16,
+    ('int16', 'int32'): algos.take_2d_axis0_int16_int32,
+    ('int16', 'int64'): algos.take_2d_axis0_int16_int64,
+    ('int16', 'float64'): algos.take_2d_axis0_int16_float64,
+    ('int32', 'int32'): algos.take_2d_axis0_int32_int32,
+    ('int32', 'int64'): algos.take_2d_axis0_int32_int64,
+    ('int32', 'float64'): algos.take_2d_axis0_int32_float64,
+    ('int64', 'int64'): algos.take_2d_axis0_int64_int64,
+    ('int64', 'float64'): algos.take_2d_axis0_int64_float64,
+    ('float32', 'float32'): algos.take_2d_axis0_float32_float32,
+    ('float32', 'float64'): algos.take_2d_axis0_float32_float64,
+    ('float64', 'float64'): algos.take_2d_axis0_float64_float64,
+    ('object', 'object'): algos.take_2d_axis0_object_object,
+    ('bool', 'bool'):
+        _view_wrapper(algos.take_2d_axis0_bool_bool, np.uint8, np.uint8),
+    ('bool', 'object'):
+        _view_wrapper(algos.take_2d_axis0_bool_object, np.uint8, None),
+    ('datetime64[ns]','datetime64[ns]'):
+        _view_wrapper(algos.take_2d_axis0_int64_int64, np.int64, np.int64,
+                      fill_wrap=_datetime64_fill_wrap)
 }
 
-_take2d_axis1_dict = {
-    'float64': algos.take_2d_axis1_float64,
-    'float32': algos.take_2d_axis1_float32,
-    'int8': algos.take_2d_axis1_int8,
-    'int16': algos.take_2d_axis1_int16,
-    'int32': algos.take_2d_axis1_int32,
-    'int64': algos.take_2d_axis1_int64,
-    'object': algos.take_2d_axis1_object,
-    'bool': _view_wrapper(algos.take_2d_axis1_bool, np.uint8),
-    'datetime64[ns]': _view_wrapper(algos.take_2d_axis1_int64, np.int64,
-                                    na_override=tslib.iNaT),
+
+_take_2d_axis1_dict = {
+    ('int8', 'int8'): algos.take_2d_axis1_int8_int8,
+    ('int8', 'int32'): algos.take_2d_axis1_int8_int32,
+    ('int8', 'int64'): algos.take_2d_axis1_int8_int64,
+    ('int8', 'float64'): algos.take_2d_axis1_int8_float64,
+    ('int16', 'int16'): algos.take_2d_axis1_int16_int16,
+    ('int16', 'int32'): algos.take_2d_axis1_int16_int32,
+    ('int16', 'int64'): algos.take_2d_axis1_int16_int64,
+    ('int16', 'float64'): algos.take_2d_axis1_int16_float64,
+    ('int32', 'int32'): algos.take_2d_axis1_int32_int32,
+    ('int32', 'int64'): algos.take_2d_axis1_int32_int64,
+    ('int32', 'float64'): algos.take_2d_axis1_int32_float64,
+    ('int64', 'int64'): algos.take_2d_axis1_int64_int64,
+    ('int64', 'float64'): algos.take_2d_axis1_int64_float64,
+    ('float32', 'float32'): algos.take_2d_axis1_float32_float32,
+    ('float32', 'float64'): algos.take_2d_axis1_float32_float64,
+    ('float64', 'float64'): algos.take_2d_axis1_float64_float64,
+    ('object', 'object'): algos.take_2d_axis1_object_object,
+    ('bool', 'bool'):
+        _view_wrapper(algos.take_2d_axis1_bool_bool, np.uint8, np.uint8),
+    ('bool', 'object'):
+        _view_wrapper(algos.take_2d_axis1_bool_object, np.uint8, None),
+    ('datetime64[ns]','datetime64[ns]'):
+        _view_wrapper(algos.take_2d_axis1_int64_int64, np.int64, np.int64,
+                      fill_wrap=_datetime64_fill_wrap)
 }
 
-_take2d_multi_dict = {
-    'float64': algos.take_2d_multi_float64,
-    'float32': algos.take_2d_multi_float32,
-    'int8': algos.take_2d_multi_int8,
-    'int16': algos.take_2d_multi_int16,
-    'int32': algos.take_2d_multi_int32,
-    'int64': algos.take_2d_multi_int64,
-    'object': algos.take_2d_multi_object,
-    'bool': _view_wrapper(algos.take_2d_multi_bool, np.uint8),
-    'datetime64[ns]': _view_wrapper(algos.take_2d_multi_int64, np.int64,
-                                    na_override=tslib.iNaT),
+
+_take_2d_multi_dict = {
+    ('int8', 'int8'): algos.take_2d_multi_int8_int8,
+    ('int8', 'int32'): algos.take_2d_multi_int8_int32,
+    ('int8', 'int64'): algos.take_2d_multi_int8_int64,
+    ('int8', 'float64'): algos.take_2d_multi_int8_float64,
+    ('int16', 'int16'): algos.take_2d_multi_int16_int16,
+    ('int16', 'int32'): algos.take_2d_multi_int16_int32,
+    ('int16', 'int64'): algos.take_2d_multi_int16_int64,
+    ('int16', 'float64'): algos.take_2d_multi_int16_float64,
+    ('int32', 'int32'): algos.take_2d_multi_int32_int32,
+    ('int32', 'int64'): algos.take_2d_multi_int32_int64,
+    ('int32', 'float64'): algos.take_2d_multi_int32_float64,
+    ('int64', 'int64'): algos.take_2d_multi_int64_int64,
+    ('int64', 'float64'): algos.take_2d_multi_int64_float64,
+    ('float32', 'float32'): algos.take_2d_multi_float32_float32,
+    ('float32', 'float64'): algos.take_2d_multi_float32_float64,
+    ('float64', 'float64'): algos.take_2d_multi_float64_float64,
+    ('object', 'object'): algos.take_2d_multi_object_object,
+    ('bool', 'bool'):
+        _view_wrapper(algos.take_2d_multi_bool_bool, np.uint8, np.uint8),
+    ('bool', 'object'):
+        _view_wrapper(algos.take_2d_multi_bool_object, np.uint8, None),
+    ('datetime64[ns]','datetime64[ns]'):
+        _view_wrapper(algos.take_2d_multi_int64_int64, np.int64, np.int64,
+                      fill_wrap=_datetime64_fill_wrap)
 }
 
-_dtypes_no_na = set(['int8','int16','int32', 'int64', 'bool'])
-_dtypes_na    = set(['float32', 'float64', 'object', 'datetime64[ns]'])
 
-def _get_take2d_function(dtype_str, axis=0):
-    if axis == 0:
-        return _take2d_axis0_dict[dtype_str]
-    elif axis == 1:
-        return _take2d_axis1_dict[dtype_str]
-    elif axis == 'multi':
-        return _take2d_multi_dict[dtype_str]
-    else:  # pragma: no cover
-        raise ValueError('bad axis: %s' % axis)
+def _get_take_1d_function(dtype, out_dtype):
+    try:
+        return _take_1d_dict[dtype.name, out_dtype.name]
+    except KeyError:
+        pass
+
+    if dtype != out_dtype: 
+        try:
+            func = _take_1d_dict[out_dtype.name, out_dtype.name]
+            return _convert_wrapper(func, out_dtype)
+        except KeyError:
+            pass
+
+    def wrapper(arr, indexer, out, fill_value=np.nan):
+        return _take_nd_generic(arr, indexer, out, axis=0,
+                                fill_value=fill_value)
+    return wrapper
+
+
+def _get_take_2d_function(dtype, out_dtype, axis=0):
+    try:
+        if axis == 0:
+            return _take_2d_axis0_dict[dtype.name, out_dtype.name]
+        elif axis == 1:
+            return _take_2d_axis1_dict[dtype.name, out_dtype.name]
+        elif axis == 'multi':
+            return _take_2d_multi_dict[dtype.name, out_dtype.name]
+        else:  # pragma: no cover
+            raise ValueError('bad axis: %s' % axis)
+    except KeyError:
+        pass
+
+    if dtype != out_dtype: 
+        try:
+            if axis == 0:
+                func = _take_2d_axis0_dict[out_dtype.name, out_dtype.name]
+            elif axis == 1:
+                func = _take_2d_axis1_dict[out_dtype.name, out_dtype.name]
+            else:
+                func = _take_2d_multi_dict[out_dtype.name, out_dtype.name]
+            return _convert_wrapper(func, out_dtype)
+        except KeyError:
+            pass
+
+    if axis == 'multi':
+        return _take_2d_multi_generic
+
+    def wrapper(arr, indexer, out, fill_value=np.nan):
+        return _take_nd_generic(arr, indexer, out, axis=axis,
+                                fill_value=fill_value)
+    return wrapper
+
+
+def _get_take_nd_function(ndim, dtype, out_dtype, axis=0):
+    if ndim == 2:
+        return _get_take_2d_function(dtype, out_dtype, axis=axis)
+    elif ndim == 1:
+        if axis != 0:
+            raise ValueError('axis must be 0 for one dimensional array')
+        return _get_take_1d_function(dtype, out_dtype)
+    elif ndim <= 0:
+        raise ValueError('ndim must be >= 1')
+
+    def wrapper(arr, indexer, out, fill_value=np.nan):
+        return _take_nd_generic(arr, indexer, out, axis=axis,
+                                fill_value=fill_value)
+    if (dtype.name, out_dtype.name) == ('datetime64[ns]','datetime64[ns]'):
+        wrapper = _view_wrapper(wrapper, np.int64, np.int64,
+                                fill_wrap=_datetime64_fill_wrap)
+    return wrapper
 
 
 def take_1d(arr, indexer, out=None, fill_value=np.nan):
     """
     Specialized Cython take which sets NaN values in one pass
     """
-    dtype_str = arr.dtype.name
-
-    n = len(indexer)
-
-    indexer = _ensure_int64(indexer)
-
-    out_passed = out is not None
-    take_f = _take1d_dict.get(dtype_str)
-
-    if dtype_str in _dtypes_no_na:
-        try:
-            if out is None:
-                out = np.empty(n, dtype=arr.dtype)
-            take_f(arr, _ensure_int64(indexer), out=out, fill_value=fill_value)
-        except ValueError:
-            mask = indexer == -1
-            if len(arr) == 0:
-                if not out_passed:
-                    out = np.empty(n, dtype=arr.dtype)
-            else:
-                out = ndtake(arr, indexer, out=out)
-            if mask.any():
-                if out_passed:
-                    raise Exception('out with dtype %s does not support NA' %
-                                    out.dtype)
-                out = _maybe_upcast(out)
-                np.putmask(out, mask, fill_value)
-    elif dtype_str in _dtypes_na:
-        if out is None:
-            out = np.empty(n, dtype=arr.dtype)
-        take_f(arr, _ensure_int64(indexer), out=out, fill_value=fill_value)
+    if indexer is None:
+        indexer = np.arange(len(arr), dtype=np.int64)
+        dtype, fill_value = arr.dtype, arr.dtype.type()
     else:
-        out = ndtake(arr, indexer, out=out)
-        mask = indexer == -1
-        if mask.any():
-            if out_passed:
-                raise Exception('out with dtype %s does not support NA' %
-                                out.dtype)
-            out = _maybe_upcast(out)
-            np.putmask(out, mask, fill_value)
+        indexer = _ensure_int64(indexer)
+        dtype = _maybe_promote(arr.dtype, fill_value)
+        if dtype != arr.dtype:
+            mask = indexer == -1
+            needs_masking = mask.any()
+            if needs_masking:
+                if out is not None and out.dtype != dtype:
+                    raise Exception('Incompatible type for fill_value')
+            else:
+                dtype, fill_value = arr.dtype, arr.dtype.type()
 
+    if out is None:
+        out = np.empty(len(indexer), dtype=dtype)
+    take_f = _get_take_1d_function(arr.dtype, out.dtype)
+    take_f(arr, indexer, out=out, fill_value=fill_value)
     return out
 
 
-def take_2d_multi(arr, row_idx, col_idx, fill_value=np.nan, out=None):
-
-    dtype_str = arr.dtype.name
-
-    out_shape = len(row_idx), len(col_idx)
-
-    if dtype_str in _dtypes_no_na:
-        row_mask = row_idx == -1
-        col_mask = col_idx == -1
-        needs_masking = row_mask.any() or col_mask.any()
-
-        if needs_masking:
-            return take_2d_multi(_maybe_upcast(arr), row_idx, col_idx,
-                                 fill_value=fill_value, out=out)
-        else:
-            if out is None:
-                out = np.empty(out_shape, dtype=arr.dtype)
-            take_f = _get_take2d_function(dtype_str, axis='multi')
-            take_f(arr, _ensure_int64(row_idx),
-                   _ensure_int64(col_idx), out=out,
-                   fill_value=fill_value)
-            return out
-    elif dtype_str in _dtypes_na:
-        if out is None:
-            out = np.empty(out_shape, dtype=arr.dtype)
-        take_f = _get_take2d_function(dtype_str, axis='multi')
-        take_f(arr, _ensure_int64(row_idx), _ensure_int64(col_idx), out=out,
-               fill_value=fill_value)
-        return out
-    else:
-        if out is not None:
-            raise ValueError('Cannot pass out in this case')
-
-        return take_2d(take_2d(arr, row_idx, axis=0, fill_value=fill_value),
-                       col_idx, axis=1, fill_value=fill_value)
-
-
-def take_2d(arr, indexer, out=None, mask=None, needs_masking=None, axis=0,
-            fill_value=np.nan):
+def take_nd(arr, indexer, out=None, axis=0, fill_value=np.nan):
     """
     Specialized Cython take which sets NaN values in one pass
     """
-    dtype_str = arr.dtype.name
-
-    out_shape = list(arr.shape)
-    out_shape[axis] = len(indexer)
-    out_shape = tuple(out_shape)
-
-    if not isinstance(indexer, np.ndarray):
-        indexer = np.array(indexer, dtype=np.int64)
-
-    if dtype_str in _dtypes_no_na:
-        if mask is None:
-            mask = indexer == -1
-            needs_masking = mask.any()
-
-        if needs_masking:
-            # upcasting may be required
-            result = ndtake(arr, indexer, axis=axis, out=out)
-            result = _maybe_mask(result, mask, needs_masking, axis=axis,
-                                 out_passed=out is not None,
-                                 fill_value=fill_value)
-            return result
-        else:
-            if out is None:
-                out = np.empty(out_shape, dtype=arr.dtype)
-            take_f = _get_take2d_function(dtype_str, axis=axis)
-            take_f(arr, _ensure_int64(indexer), out=out, fill_value=fill_value)
-            return out
-    elif dtype_str in _dtypes_na:
-        if out is None:
-            out = np.empty(out_shape, dtype=arr.dtype)
-        take_f = _get_take2d_function(dtype_str, axis=axis)
-        take_f(arr, _ensure_int64(indexer), out=out, fill_value=fill_value)
-        return out
+    if indexer is None:
+        mask = None
+        needs_masking = False
+        fill_value = arr.dtype.type()
     else:
-        if mask is None:
-            mask = indexer == -1
-            needs_masking = mask.any()
+        indexer = _ensure_int64(indexer)
+        mask = indexer == -1
+        needs_masking = mask.any()
+        if not needs_masking:
+            fill_value = arr.dtype.type()
+    return take_fast(arr, indexer, mask, needs_masking, axis, out, fill_value)
 
-        # GH #486
-        if out is not None and arr.dtype != out.dtype:
-            arr = arr.astype(out.dtype)
 
-        result = ndtake(arr, indexer, axis=axis, out=out)
-        result = _maybe_mask(result, mask, needs_masking, axis=axis,
-                             out_passed=out is not None,
-                             fill_value=fill_value)
-        return result
+def take_2d_multi(arr, row_idx, col_idx, fill_value=np.nan, out=None):
+    """
+    Specialized Cython take which sets NaN values in one pass
+    """
+    if row_idx is None:
+        row_idx = np.arange(arr.shape[0], dtype=np.int64)
+    else:
+        row_idx = _ensure_int64(row_idx)
+
+    if col_idx is None:
+        col_idx = np.arange(arr.shape[1], dtype=np.int64)
+    else:
+        col_idx = _ensure_int64(col_idx)
+
+    dtype = _maybe_promote(arr.dtype, fill_value)
+    if dtype != arr.dtype:
+        row_mask = row_idx == -1
+        col_mask = col_idx == -1
+        needs_masking = row_mask.any() or col_mask.any()
+        if needs_masking:
+            if out is not None and out.dtype != dtype:
+                raise Exception('Incompatible type for fill_value')
+        else:
+            dtype, fill_value = arr.dtype, arr.dtype.type()
+    if out is None:
+        out_shape = len(row_idx), len(col_idx)
+        out = np.empty(out_shape, dtype=dtype)
+    take_f = _get_take_2d_function(arr.dtype, out.dtype, axis='multi')
+    take_f(arr, (row_idx, col_idx), out=out, fill_value=fill_value)
+    return out
 
 
 def ndtake(arr, indexer, axis=0, out=None):
     return arr.take(_ensure_platform_int(indexer), axis=axis, out=out)
 
-
-def mask_out_axis(arr, mask, axis, fill_value=np.nan):
-    indexer = [slice(None)] * arr.ndim
-    indexer[axis] = mask
-
-    arr[tuple(indexer)] = fill_value
 
 _diff_special = {
     'float64': algos.diff_2d_float64,
@@ -483,7 +587,7 @@ def diff(arr, n, axis=0):
     n = int(n)
     dtype = arr.dtype
     if issubclass(dtype.type, np.integer):
-        dtype = np.float64
+        dtype = np.float_
     elif issubclass(dtype.type, np.bool_):
         dtype = np.object_
 
@@ -512,49 +616,84 @@ def diff(arr, n, axis=0):
 
 def take_fast(arr, indexer, mask, needs_masking, axis=0, out=None,
               fill_value=np.nan):
-    if arr.ndim == 2:
-        return take_2d(arr, indexer, out=out, mask=mask,
-                       needs_masking=needs_masking,
-                       axis=axis, fill_value=fill_value)
-    indexer = _ensure_platform_int(indexer)
-    result = ndtake(arr, indexer, axis=axis, out=out)
-    result = _maybe_mask(result, mask, needs_masking, axis=axis,
-                         out_passed=out is not None, fill_value=fill_value)
-    return result
+    """
+    Specialized Cython take which sets NaN values in one pass
 
-
-def _maybe_mask(result, mask, needs_masking, axis=0, out_passed=False,
-                fill_value=np.nan):
-    if needs_masking:
-        if out_passed and _need_upcast(result):
-            raise Exception('incompatible type for NAs')
+    (equivalent to take_nd but requires mask and needs_masking
+     to be set appropriately already; slightly more efficient)
+    """
+    if indexer is None:
+        indexer = np.arange(arr.shape[axis], dtype=np.int64)
+        dtype = arr.dtype
+    else:
+        indexer = _ensure_int64(indexer)
+        if needs_masking:
+            dtype = _maybe_promote(arr.dtype, fill_value)
+            if dtype != arr.dtype and out is not None and out.dtype != dtype:
+                raise Exception('Incompatible type for fill_value')
         else:
-            # a bit spaghettified
-            result = _maybe_upcast(result)
-            mask_out_axis(result, mask, axis, fill_value)
-    return result
+            dtype = arr.dtype
+
+    if out is None:
+        out_shape = list(arr.shape)
+        out_shape[axis] = len(indexer)
+        out_shape = tuple(out_shape)
+        out = np.empty(out_shape, dtype=dtype)
+    take_f = _get_take_nd_function(arr.ndim, arr.dtype, out.dtype, axis=axis)
+    take_f(arr, indexer, out=out, fill_value=fill_value)
+    return out
+
+
+def _maybe_promote(dtype, fill_value=np.nan):
+    if issubclass(dtype.type, np.datetime64):
+        # for now: refuse to upcast
+        # (this is because datetime64 will not implicitly upconvert
+        #  to object correctly as of numpy 1.6.1)
+        return dtype
+    elif is_float(fill_value):
+        if issubclass(dtype.type, np.bool_):
+            return np.object_
+        elif issubclass(dtype.type, np.integer):
+            return np.float_
+        return dtype
+    elif is_bool(fill_value):
+        if issubclass(dtype.type, np.bool_):
+            return dtype
+        return np.object_
+    elif is_integer(fill_value):
+        if issubclass(dtype.type, np.bool_):
+            return np.object_
+        elif issubclass(dtype.type, np.integer):
+            # upcast to prevent overflow
+            arr = np.asarray(fill_value)
+            if arr != arr.astype(dtype):
+                return arr.dtype
+            return dtype
+        return dtype
+    elif is_complex(fill_value):
+        if issubclass(dtype.type, np.bool_):
+            return np.object_
+        elif issubclass(dtype.type, (np.integer, np.floating)):
+            return np.complex_
+        return dtype
+    return np.object_
 
 
 def _maybe_upcast(values):
+    # TODO: convert remaining usage of _maybe_upcast to _maybe_promote
     if issubclass(values.dtype.type, np.integer):
-        values = values.astype(float)
+        values = values.astype(np.float_)
     elif issubclass(values.dtype.type, np.bool_):
-        values = values.astype(object)
-
+        values = values.astype(np.object_)
     return values
-
-
-def _need_upcast(values):
-    if issubclass(values.dtype.type, (np.integer, np.bool_)):
-        return True
-    return False
-
+ 
 
 def _interp_wrapper(f, wrap_dtype, na_override=None):
     def wrapper(arr, mask, limit=None):
         view = arr.view(wrap_dtype)
         f(view, mask, limit=limit)
     return wrapper
+
 
 _pad_1d_datetime = _interp_wrapper(algos.pad_inplace_int64, np.int64)
 _pad_2d_datetime = _interp_wrapper(algos.pad_2d_inplace_int64, np.int64)
@@ -728,8 +867,10 @@ def _infer_dtype(value):
         return np.float_
     elif isinstance(value, (bool, np.bool_)):
         return np.bool_
-    elif isinstance(value, (int, np.integer)):
+    elif isinstance(value, (int, long, np.integer)):
         return np.int_
+    elif isinstance(value, (complex, np.complexfloating)):
+        return np.complex_
     else:
         return np.object_
 
@@ -1028,6 +1169,10 @@ def _maybe_make_list(obj):
     return obj
 
 
+def is_bool(obj):
+    return isinstance(obj, (bool, np.bool_))
+
+
 def is_integer(obj):
     return isinstance(obj, (int, long, np.integer))
 
@@ -1036,13 +1181,17 @@ def is_float(obj):
     return isinstance(obj, (float, np.floating))
 
 
+def is_complex(obj):
+    return isinstance(obj, (complex, np.complexfloating))
+
+
 def is_iterator(obj):
     # python 3 generators have __next__ instead of next
     return hasattr(obj, 'next') or hasattr(obj, '__next__')
 
 
 def is_number(obj):
-    return isinstance(obj, (np.number, int, long, float))
+    return isinstance(obj, (np.number, int, long, float, complex))
 
 
 def is_integer_dtype(arr_or_dtype):

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -93,7 +93,7 @@ class _Unstacker(object):
         indexer = algos.groupsort_indexer(comp_index, ngroups)[0]
         indexer = _ensure_platform_int(indexer)
 
-        self.sorted_values = com.take_2d(self.values, indexer, axis=0)
+        self.sorted_values = com.take_nd(self.values, indexer, axis=0)
         self.sorted_labels = [l.take(indexer) for l in to_sort]
 
     def _make_selectors(self):
@@ -136,7 +136,7 @@ class _Unstacker(object):
             # rare case, level values not observed
             if len(obs_ids) < self.full_shape[1]:
                 inds = (value_mask.sum(0) > 0).nonzero()[0]
-                values = com.take_2d(values, inds, axis=1)
+                values = com.take_nd(values, inds, axis=1)
                 columns = columns[inds]
 
         return DataFrame(values, index=index, columns=columns)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -794,7 +794,9 @@ copy : boolean, default False
         converted : Series
         """
         if self.dtype == np.object_:
-            return Series(com._possibly_convert_objects(self.values,convert_dates=convert_dates,convert_numeric=convert_numeric), index=self.index, name=self.name)
+            return Series(com._possibly_convert_objects(self.values,
+                convert_dates=convert_dates, convert_numeric=convert_numeric),
+                index=self.index, name=self.name)
         return self.copy()
 
     def repeat(self, reps):

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -286,59 +286,295 @@ class TestTake(unittest.TestCase):
     _multiprocess_can_split_ = True
 
     def test_1d_with_out(self):
-        def _test_dtype(dtype):
-            out = np.empty(5, dtype=dtype)
-            arr = np.random.randn(10).astype(dtype)
-            indexer = [0, 2, 4, 7, 1]
+        def _test_dtype(dtype, can_hold_na):
+            data = np.random.randint(0, 2, 4).astype(dtype)
 
-            arr.take(indexer, out=out)
-            expected = arr.take(indexer)
+            indexer = [2, 1, 0, 1]
+            out = np.empty(4, dtype=dtype)
+            com.take_1d(data, indexer, out=out)
+            expected = data.take(indexer)
             tm.assert_almost_equal(out, expected)
 
-        _test_dtype(np.float64)
-        _test_dtype(np.float32)
-        _test_dtype(np.int32)
-        _test_dtype(np.int64)
-        _test_dtype(np.object_)
-        _test_dtype(np.bool)
-
-    def test_1d_upcast_with_out(self):
-        def _test_dtype(dtype):
+            indexer = [2, 1, 0, -1]
             out = np.empty(4, dtype=dtype)
-            data = np.random.randint(0, 2, 5).astype(dtype)
+            if can_hold_na:
+                com.take_1d(data, indexer, out=out)
+                expected = data.take(indexer)
+                expected[3] = np.nan
+                tm.assert_almost_equal(out, expected)
+            else:
+                self.assertRaises(Exception, com.take_1d, data,
+                                  indexer, out=out)
+                # no exception o/w
+                data.take(indexer, out=out)
+
+        _test_dtype(np.float64, True)
+        _test_dtype(np.float32, True)
+        _test_dtype(np.uint64, False)
+        _test_dtype(np.uint32, False)
+        _test_dtype(np.uint16, False)
+        _test_dtype(np.uint8, False)
+        _test_dtype(np.int64, False)
+        _test_dtype(np.int32, False)
+        _test_dtype(np.int16, False)
+        _test_dtype(np.int8, False)
+        _test_dtype(np.object_, True)
+        _test_dtype(np.bool, False)
+
+    def test_1d_fill_nonna(self):
+        def _test_dtype(dtype, fill_value, out_dtype):
+            data = np.random.randint(0, 2, 4).astype(dtype)
 
             indexer = [2, 1, 0, -1]
-            self.assertRaises(Exception, com.take_1d, data,
-                              indexer, out=out)
 
-        _test_dtype(np.int64)
-        _test_dtype(np.int32)
-        _test_dtype(np.int16)
-        _test_dtype(np.int8)
-        _test_dtype(np.bool)
+            result = com.take_1d(data, indexer, fill_value=fill_value)
+            assert((result[[0, 1, 2]] == data[[2, 1, 0]]).all())
+            assert(result[3] == fill_value)
+            assert(result.dtype == out_dtype)
 
-    def test_2d_upcast_with_out(self):
-        def _test_dtype(dtype):
+            indexer = [2, 1, 0, 1]
+
+            result = com.take_1d(data, indexer, fill_value=fill_value)
+            assert((result[[0, 1, 2, 3]] == data[indexer]).all())
+            assert(result.dtype == dtype)
+
+        _test_dtype(np.int8, np.int16(127), np.int8)
+        _test_dtype(np.int8, np.int16(128), np.int16)
+        _test_dtype(np.int32, 1, np.int32)
+        _test_dtype(np.int32, 2.0, np.float64)
+        _test_dtype(np.int32, 3.0 + 4.0j, np.complex128)
+        _test_dtype(np.int32, True, np.object_)
+        _test_dtype(np.int32, '', np.object_)
+        _test_dtype(np.float64, 1, np.float64)
+        _test_dtype(np.float64, 2.0, np.float64)
+        _test_dtype(np.float64, 3.0 + 4.0j, np.complex128)
+        _test_dtype(np.float64, True, np.object_)
+        _test_dtype(np.float64, '', np.object_)
+        _test_dtype(np.complex128, 1, np.complex128)
+        _test_dtype(np.complex128, 2.0, np.complex128)
+        _test_dtype(np.complex128, 3.0 + 4.0j, np.complex128)
+        _test_dtype(np.complex128, True, np.object_)
+        _test_dtype(np.complex128, '', np.object_)
+        _test_dtype(np.bool_, 1, np.object_)
+        _test_dtype(np.bool_, 2.0, np.object_)
+        _test_dtype(np.bool_, 3.0 + 4.0j, np.object_)
+        _test_dtype(np.bool_, True, np.bool_)
+        _test_dtype(np.bool_, '', np.object_)
+
+    def test_2d_with_out(self):
+        def _test_dtype(dtype, can_hold_na):
+            data = np.random.randint(0, 2, (5, 3)).astype(dtype)
+
+            indexer = [2, 1, 0, 1]
             out0 = np.empty((4, 3), dtype=dtype)
             out1 = np.empty((5, 4), dtype=dtype)
+            com.take_nd(data, indexer, out=out0, axis=0)
+            com.take_nd(data, indexer, out=out1, axis=1)
+            expected0 = data.take(indexer, axis=0)
+            expected1 = data.take(indexer, axis=1)
+            tm.assert_almost_equal(out0, expected0)
+            tm.assert_almost_equal(out1, expected1)
 
+            indexer = [2, 1, 0, -1]
+            out0 = np.empty((4, 3), dtype=dtype)
+            out1 = np.empty((5, 4), dtype=dtype)
+            if can_hold_na:
+                com.take_nd(data, indexer, out=out0, axis=0)
+                com.take_nd(data, indexer, out=out1, axis=1)
+                expected0 = data.take(indexer, axis=0)
+                expected1 = data.take(indexer, axis=1)
+                expected0[3, :] = np.nan
+                expected1[:, 3] = np.nan
+                tm.assert_almost_equal(out0, expected0)
+                tm.assert_almost_equal(out1, expected1)
+            else:
+                self.assertRaises(Exception, com.take_nd, data,
+                                  indexer, out=out0, axis=0)
+                self.assertRaises(Exception, com.take_nd, data,
+                                  indexer, out=out1, axis=1)
+                # no exception o/w
+                data.take(indexer, out=out0, axis=0)
+                data.take(indexer, out=out1, axis=1)
+
+        _test_dtype(np.float64, True)
+        _test_dtype(np.float32, True)
+        _test_dtype(np.uint64, False)
+        _test_dtype(np.uint32, False)
+        _test_dtype(np.uint16, False)
+        _test_dtype(np.uint8, False)
+        _test_dtype(np.int64, False)
+        _test_dtype(np.int32, False)
+        _test_dtype(np.int16, False)
+        _test_dtype(np.int8, False)
+        _test_dtype(np.object_, True)
+        _test_dtype(np.bool, False)
+
+    def test_2d_fill_nonna(self):
+        def _test_dtype(dtype, fill_value, out_dtype):
             data = np.random.randint(0, 2, (5, 3)).astype(dtype)
 
             indexer = [2, 1, 0, -1]
-            self.assertRaises(Exception, com.take_2d, data,
-                              indexer, out=out0, axis=0)
-            self.assertRaises(Exception, com.take_2d, data,
-                              indexer, out=out1, axis=1)
 
-            # no exception o/w
-            data.take(indexer, out=out0, axis=0)
-            data.take(indexer, out=out1, axis=1)
+            result = com.take_nd(data, indexer, axis=0, fill_value=fill_value)
+            assert((result[[0, 1, 2], :] == data[[2, 1, 0], :]).all())
+            assert((result[3, :] == fill_value).all())
+            assert(result.dtype == out_dtype)
 
-        _test_dtype(np.int64)
-        _test_dtype(np.int32)
-        _test_dtype(np.int16)
-        _test_dtype(np.int8)
-        _test_dtype(np.bool)
+            result = com.take_nd(data, indexer, axis=1, fill_value=fill_value)
+            assert((result[:, [0, 1, 2]] == data[:, [2, 1, 0]]).all())
+            assert((result[:, 3] == fill_value).all())
+            assert(result.dtype == out_dtype)
+
+            indexer = [2, 1, 0, 1]
+
+            result = com.take_nd(data, indexer, axis=0, fill_value=fill_value)
+            assert((result[[0, 1, 2, 3], :] == data[indexer, :]).all())
+            assert(result.dtype == dtype)
+
+            result = com.take_nd(data, indexer, axis=1, fill_value=fill_value)
+            assert((result[:, [0, 1, 2, 3]] == data[:, indexer]).all())
+            assert(result.dtype == dtype)
+
+        _test_dtype(np.int8, np.int16(127), np.int8)
+        _test_dtype(np.int8, np.int16(128), np.int16)
+        _test_dtype(np.int32, 1, np.int32)
+        _test_dtype(np.int32, 2.0, np.float64)
+        _test_dtype(np.int32, 3.0 + 4.0j, np.complex128)
+        _test_dtype(np.int32, True, np.object_)
+        _test_dtype(np.int32, '', np.object_)
+        _test_dtype(np.float64, 1, np.float64)
+        _test_dtype(np.float64, 2.0, np.float64)
+        _test_dtype(np.float64, 3.0 + 4.0j, np.complex128)
+        _test_dtype(np.float64, True, np.object_)
+        _test_dtype(np.float64, '', np.object_)
+        _test_dtype(np.complex128, 1, np.complex128)
+        _test_dtype(np.complex128, 2.0, np.complex128)
+        _test_dtype(np.complex128, 3.0 + 4.0j, np.complex128)
+        _test_dtype(np.complex128, True, np.object_)
+        _test_dtype(np.complex128, '', np.object_)
+        _test_dtype(np.bool_, 1, np.object_)
+        _test_dtype(np.bool_, 2.0, np.object_)
+        _test_dtype(np.bool_, 3.0 + 4.0j, np.object_)
+        _test_dtype(np.bool_, True, np.bool_)
+        _test_dtype(np.bool_, '', np.object_)
+
+    def test_3d_with_out(self):
+        def _test_dtype(dtype, can_hold_na):
+            data = np.random.randint(0, 2, (5, 4, 3)).astype(dtype)
+
+            indexer = [2, 1, 0, 1]
+            out0 = np.empty((4, 4, 3), dtype=dtype)
+            out1 = np.empty((5, 4, 3), dtype=dtype)
+            out2 = np.empty((5, 4, 4), dtype=dtype)
+            com.take_nd(data, indexer, out=out0, axis=0)
+            com.take_nd(data, indexer, out=out1, axis=1)
+            com.take_nd(data, indexer, out=out2, axis=2)
+            expected0 = data.take(indexer, axis=0)
+            expected1 = data.take(indexer, axis=1)
+            expected2 = data.take(indexer, axis=2)
+            tm.assert_almost_equal(out0, expected0)
+            tm.assert_almost_equal(out1, expected1)
+            tm.assert_almost_equal(out2, expected2)
+
+            indexer = [2, 1, 0, -1]
+            out0 = np.empty((4, 4, 3), dtype=dtype)
+            out1 = np.empty((5, 4, 3), dtype=dtype)
+            out2 = np.empty((5, 4, 4), dtype=dtype)
+            if can_hold_na:
+                com.take_nd(data, indexer, out=out0, axis=0)
+                com.take_nd(data, indexer, out=out1, axis=1)
+                com.take_nd(data, indexer, out=out2, axis=2)
+                expected0 = data.take(indexer, axis=0)
+                expected1 = data.take(indexer, axis=1)
+                expected2 = data.take(indexer, axis=2)
+                expected0[3, :, :] = np.nan
+                expected1[:, 3, :] = np.nan
+                expected2[:, :, 3] = np.nan
+                tm.assert_almost_equal(out0, expected0)
+                tm.assert_almost_equal(out1, expected1)
+                tm.assert_almost_equal(out2, expected2)
+            else:
+                self.assertRaises(Exception, com.take_nd, data,
+                                  indexer, out=out0, axis=0)
+                self.assertRaises(Exception, com.take_nd, data,
+                                  indexer, out=out1, axis=1)
+                self.assertRaises(Exception, com.take_nd, data,
+                                  indexer, out=out2, axis=2)
+                # no exception o/w
+                data.take(indexer, out=out0, axis=0)
+                data.take(indexer, out=out1, axis=1)
+                data.take(indexer, out=out2, axis=2)
+
+        _test_dtype(np.float64, True)
+        _test_dtype(np.float32, True)
+        _test_dtype(np.uint64, False)
+        _test_dtype(np.uint32, False)
+        _test_dtype(np.uint16, False)
+        _test_dtype(np.uint8, False)
+        _test_dtype(np.int64, False)
+        _test_dtype(np.int32, False)
+        _test_dtype(np.int16, False)
+        _test_dtype(np.int8, False)
+        _test_dtype(np.object_, True)
+        _test_dtype(np.bool, False)
+
+    def test_3d_fill_nonna(self):
+        def _test_dtype(dtype, fill_value, out_dtype):
+            data = np.random.randint(0, 2, (5, 4, 3)).astype(dtype)
+
+            indexer = [2, 1, 0, -1]
+
+            result = com.take_nd(data, indexer, axis=0, fill_value=fill_value)
+            assert((result[[0, 1, 2], :, :] == data[[2, 1, 0], :, :]).all())
+            assert((result[3, :, :] == fill_value).all())
+            assert(result.dtype == out_dtype)
+
+            result = com.take_nd(data, indexer, axis=1, fill_value=fill_value)
+            assert((result[:, [0, 1, 2], :] == data[:, [2, 1, 0], :]).all())
+            assert((result[:, 3, :] == fill_value).all())
+            assert(result.dtype == out_dtype)
+
+            result = com.take_nd(data, indexer, axis=2, fill_value=fill_value)
+            assert((result[:, :, [0, 1, 2]] == data[:, :, [2, 1, 0]]).all())
+            assert((result[:, :, 3] == fill_value).all())
+            assert(result.dtype == out_dtype)
+
+            indexer = [2, 1, 0, 1]
+
+            result = com.take_nd(data, indexer, axis=0, fill_value=fill_value)
+            assert((result[[0, 1, 2, 3], :, :] == data[indexer, :, :]).all())
+            assert(result.dtype == dtype)
+
+            result = com.take_nd(data, indexer, axis=1, fill_value=fill_value)
+            assert((result[:, [0, 1, 2, 3], :] == data[:, indexer, :]).all())
+            assert(result.dtype == dtype)
+
+            result = com.take_nd(data, indexer, axis=2, fill_value=fill_value)
+            assert((result[:, :, [0, 1, 2, 3]] == data[:, :, indexer]).all())
+            assert(result.dtype == dtype)
+
+        _test_dtype(np.int8, np.int16(127), np.int8)
+        _test_dtype(np.int8, np.int16(128), np.int16)
+        _test_dtype(np.int32, 1, np.int32)
+        _test_dtype(np.int32, 2.0, np.float64)
+        _test_dtype(np.int32, 3.0 + 4.0j, np.complex128)
+        _test_dtype(np.int32, True, np.object_)
+        _test_dtype(np.int32, '', np.object_)
+        _test_dtype(np.float64, 1, np.float64)
+        _test_dtype(np.float64, 2.0, np.float64)
+        _test_dtype(np.float64, 3.0 + 4.0j, np.complex128)
+        _test_dtype(np.float64, True, np.object_)
+        _test_dtype(np.float64, '', np.object_)
+        _test_dtype(np.complex128, 1, np.complex128)
+        _test_dtype(np.complex128, 2.0, np.complex128)
+        _test_dtype(np.complex128, 3.0 + 4.0j, np.complex128)
+        _test_dtype(np.complex128, True, np.object_)
+        _test_dtype(np.complex128, '', np.object_)
+        _test_dtype(np.bool_, 1, np.object_)
+        _test_dtype(np.bool_, 2.0, np.object_)
+        _test_dtype(np.bool_, 3.0 + 4.0j, np.object_)
+        _test_dtype(np.bool_, True, np.bool_)
+        _test_dtype(np.bool_, '', np.object_)
 
     def test_1d_other_dtypes(self):
         arr = np.random.randn(10).astype(np.float32)
@@ -355,13 +591,13 @@ class TestTake(unittest.TestCase):
         indexer = [1, 2, 3, -1]
 
         # axis=0
-        result = com.take_2d(arr, indexer, axis=0)
+        result = com.take_nd(arr, indexer, axis=0)
         expected = arr.take(indexer, axis=0)
         expected[-1] = np.nan
         tm.assert_almost_equal(result, expected)
 
         # axis=1
-        result = com.take_2d(arr, indexer, axis=1)
+        result = com.take_nd(arr, indexer, axis=1)
         expected = arr.take(indexer, axis=1)
         expected[:, -1] = np.nan
         tm.assert_almost_equal(result, expected)
@@ -381,15 +617,15 @@ class TestTake(unittest.TestCase):
                         [1, 0, 1],
                         [0, 1, 1]], dtype=bool)
 
-        result = com.take_2d(arr, [0, 2, 2, 1])
+        result = com.take_nd(arr, [0, 2, 2, 1])
         expected = arr.take([0, 2, 2, 1], axis=0)
         self.assert_(np.array_equal(result, expected))
 
-        result = com.take_2d(arr, [0, 2, 2, 1], axis=1)
+        result = com.take_nd(arr, [0, 2, 2, 1], axis=1)
         expected = arr.take([0, 2, 2, 1], axis=1)
         self.assert_(np.array_equal(result, expected))
 
-        result = com.take_2d(arr, [0, 2, -1])
+        result = com.take_nd(arr, [0, 2, -1])
         self.assert_(result.dtype == np.object_)
 
     def test_2d_float32(self):
@@ -397,27 +633,75 @@ class TestTake(unittest.TestCase):
         indexer = [0, 2, -1, 1, -1]
 
         # axis=0
-        result = com.take_2d(arr, indexer)
+        result = com.take_nd(arr, indexer, axis=0)
         result2 = np.empty_like(result)
-        com.take_2d(arr, indexer, out=result2)
-        tm.assert_almost_equal(result, result)
+        com.take_nd(arr, indexer, axis=0, out=result2)
+        tm.assert_almost_equal(result, result2)
 
         expected = arr.take(indexer, axis=0)
-        expected[[2, 4]] = np.nan
+        expected[[2, 4], :] = np.nan
         tm.assert_almost_equal(result, expected)
 
         #### this now accepts a float32! # test with float64 out buffer
         out = np.empty((len(indexer), arr.shape[1]), dtype='float32')
-        com.take_2d(arr, indexer, out=out)  # it works!
+        com.take_nd(arr, indexer, out=out)  # it works!
 
         # axis=1
-        result = com.take_2d(arr, indexer, axis=1)
+        result = com.take_nd(arr, indexer, axis=1)
         result2 = np.empty_like(result)
-        com.take_2d(arr, indexer, axis=1, out=result2)
-        tm.assert_almost_equal(result, result)
+        com.take_nd(arr, indexer, axis=1, out=result2)
+        tm.assert_almost_equal(result, result2)
 
         expected = arr.take(indexer, axis=1)
         expected[:, [2, 4]] = np.nan
+        tm.assert_almost_equal(result, expected)
+    
+    def test_2d_datetime64(self):
+        # 2005/01/01 - 2006/01/01
+        arr = np.random.randint(11045376L, 11360736L, (5,3))*100000000000
+        arr = arr.view(dtype='datetime64[ns]')
+        indexer = [0, 2, -1, 1, -1]
+
+        # axis=0
+        result = com.take_nd(arr, indexer, axis=0)
+        result2 = np.empty_like(result)
+        com.take_nd(arr, indexer, axis=0, out=result2)
+        tm.assert_almost_equal(result, result2)
+
+        expected = arr.take(indexer, axis=0)
+        expected.view(np.int64)[[2, 4], :] = iNaT
+        tm.assert_almost_equal(result, expected)
+
+        result = com.take_nd(arr, indexer, axis=0,
+                             fill_value=datetime(2007, 1, 1))
+        result2 = np.empty_like(result)
+        com.take_nd(arr, indexer, out=result2, axis=0,
+                    fill_value=datetime(2007, 1, 1))
+        tm.assert_almost_equal(result, result2)
+
+        expected = arr.take(indexer, axis=0)
+        expected[[2, 4], :] = datetime(2007, 1, 1)
+        tm.assert_almost_equal(result, expected)
+
+        # axis=1
+        result = com.take_nd(arr, indexer, axis=1)
+        result2 = np.empty_like(result)
+        com.take_nd(arr, indexer, axis=1, out=result2)
+        tm.assert_almost_equal(result, result2)
+
+        expected = arr.take(indexer, axis=1)
+        expected.view(np.int64)[:, [2, 4]] = iNaT
+        tm.assert_almost_equal(result, expected)
+
+        result = com.take_nd(arr, indexer, axis=1,
+                             fill_value=datetime(2007, 1, 1))
+        result2 = np.empty_like(result)
+        com.take_nd(arr, indexer, out=result2, axis=1,
+                    fill_value=datetime(2007, 1, 1))
+        tm.assert_almost_equal(result, result2)
+
+        expected = arr.take(indexer, axis=1)
+        expected[:, [2, 4]] = datetime(2007, 1, 1)
         tm.assert_almost_equal(result, expected)
 
 if __name__ == '__main__':

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -8033,10 +8033,6 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self.frame[self.frame > 1] = 2
         assert_almost_equal(expected, self.frame.values)
 
-    def test_boolean_set_mixed_type(self):
-        bools = self.mixed_frame.applymap(lambda x: x != 2).astype(bool)
-        self.assertRaises(Exception, self.mixed_frame.__setitem__, bools, 2)
-
     def test_xs_view(self):
         dm = DataFrame(np.arange(20.).reshape(4, 5),
                        index=range(4), columns=range(5))

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -715,18 +715,9 @@ class _BlockJoinOperation(object):
         sofar = 0
         for unit, blk in merge_chunks:
             out_chunk = out[sofar: sofar + len(blk)]
-
-            if unit.indexer is None:
-            # is this really faster than assigning to arr.flat?
-                com.take_fast(blk.values, np.arange(n, dtype=np.int64),
-                              None, False,
-                              axis=self.axis, out=out_chunk)
-            else:
-                # write out the values to the result array
-                com.take_fast(blk.values, unit.indexer,
-                              None, False,
-                              axis=self.axis, out=out_chunk)
-
+            com.take_fast(blk.values, unit.indexer,
+                          None, False, axis=self.axis,
+                          out=out_chunk)
             sofar += len(blk)
 
         # does not sort
@@ -771,10 +762,7 @@ class _JoinUnit(object):
         mask, need_masking = self.mask_info
 
         if self.indexer is None:
-            if copy:
-                result = block.copy()
-            else:
-                result = block
+            result = block.copy() if copy else block
         else:
             result = block.reindex_axis(self.indexer, mask, need_masking,
                                         axis=axis)

--- a/vb_suite/frame_methods.py
+++ b/vb_suite/frame_methods.py
@@ -55,6 +55,19 @@ frame_reindex_both_axes_ix = Benchmark('df.ix[idx, idx]', setup,
                                        start_date=datetime(2011, 1, 1))
 
 #----------------------------------------------------------------------
+# reindex with upcasts
+setup = common_setup + """
+df=DataFrame(dict([(c, {
+        0: randint(0, 2, 1000).astype(np.bool_),
+        1: randint(0, 1000, 1000).astype(np.int16),
+        2: randint(0, 1000, 1000).astype(np.int32),
+        3: randint(0, 1000, 1000).astype(np.int64)
+    }[randint(0, 4)]) for c in range(1000)]))
+"""
+
+frame_reindex_upcast = Benchmark('df.reindex(permutation(range(1200)))', setup)
+
+#----------------------------------------------------------------------
 # boolean indexing
 
 setup = common_setup + """
@@ -71,6 +84,7 @@ frame_boolean_row_select = Benchmark('df[bool_arr]', setup,
 
 setup = common_setup + """
 df = DataFrame(randn(10000, 100))
+
 def f():
     if hasattr(df, '_item_cache'):
         df._item_cache.clear()

--- a/vb_suite/pandas_vb_common.py
+++ b/vb_suite/pandas_vb_common.py
@@ -2,6 +2,8 @@ from pandas import *
 from pandas.util.testing import rands
 from datetime import timedelta
 from numpy.random import randn
+from numpy.random import randint
+from numpy.random import permutation
 import pandas.util.testing as tm
 import random
 import numpy as np


### PR DESCRIPTION
Optimizes/improves `common.take_1d`, `common.take_2d`, `common.take_2d_multi`, and `common.take_fast` in the following ways:
- For common cases, no intermediate buffer is required anymore to convert between two different dtypes (i.e. when upcasting is necessary): the data is taken and upcasted in one step. These cases are optimized in Cython and more can be added if desired.
- Better support for `fill_value` parameters other than NaN: previously, all upcasting was done assuming NaN as the `fill_value`: now, the correct upcast will be chosen based on the type of the `fill_value`. (Ex. integers stay as integers with integer `fill_value` if the value can fit in the existing size without overflow, integers and floats upcast to complex with complex `fill_value`, all numerics upcast to objects with boolean or string `fill_value`, etc.)
- ~~Added option of `fill_value` of `None`, which means that the corresponding entries in the output are left unchanged (only really makes sense when `out` is also provided)~~

~~The last option is used to optimize `internals._merge_blocks` (i.e. the function internally called to do block consolidation): instead of `vstack`-ing the arrays together in an intermediate buffer and then rearranging into the output with a separate operation, the output buffer is allocated uninitialized and directly filled from the inputs using one call to `common.take_fast` per input block, even when they are not contiguous. (However, the special case of contiguous and already properly ordered blocks is still handed with `vstack`, since no other operation is required after that)~~

**EDIT: took out `fill_value` of `None` option and reverted `internals._merge_blocks`: it wasn't actually helping. Upcasting within take functions is definitely faster though.**

The existing vb_suite tests were not really testing upcasting, so I added one for it. Here are the results vs. master:

```
Results:
                                            t_head t_baseline      ratio
name
frame_reindex_upcast                       26.7874    34.3973     0.7788
```

and against jrebacks/dtypes:

```
Results:
                                            t_head t_baseline      ratio
name
frame_reindex_upcast                       23.8220    28.0891     0.8481
```
