### PR TITLE
Doc: Add documentation for the classes parameter of the to_html method

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1539,6 +1539,8 @@ class DataFrame(NDFrame):
         to_html-specific options
         bold_rows : boolean, default True
             Make the row labels bold in the output
+        classes : str or list or tuple, default None
+            CSS class(es) to apply to the resulting html table
 
         Render a DataFrame to an html table.
         """


### PR DESCRIPTION
It seems that there is no documentation about the classes parameter in `to_html`.

Current output of documentation in IPython:

```
Docstring:
to_html-specific options
bold_rows : boolean, default True
    Make the row labels bold in the output

Render a DataFrame to an html table.

 Parameters
 ----------
 frame : DataFrame
     object to render
buf : StringIO-like, optional
    buffer to write to
columns : sequence, optional
    the subset of columns to write; default None writes all columns
col_space : int, optional
    the minimum width of each column
header : bool, optional
    whether to print column labels, default True
index : bool, optional
    whether to print index (row) labels, default True
na_rep : string, optional
    string representation of NAN to use, default 'NaN'
formatters : list or dict of one-parameter functions, optional
    formatter functions to apply to columns' elements by position or name,
    default None, if the result is a string , it must be a unicode
    string. List must be of length equal to the number of columns.
float_format : one-parameter function, optional
    formatter function to apply to columns' elements if they are floats
    default None
sparsify : bool, optional
    Set to False for a DataFrame with a hierarchical index to print every
    multiindex key at each row, default True
justify : {'left', 'right'}, default None
    Left or right-justify the column labels. If None uses the option from
    the print configuration (controlled by set_printoptions), 'right' out
    of the box.
index_names : bool, optional
    Prints the names of the indexes, default True
force_unicode : bool, default False
    Always return a unicode result
```
