### PR TITLE
BUG: Series dtype casting to platform numeric (GH #2751)

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -53,6 +53,9 @@ pandas 0.11.0
 
   - Do not automatically upcast numeric specified dtypes to ``int64`` or
     ``float64`` (GH622_ and GH797_)
+  - DataFrame construction of lists will no longer be platform dependent when
+    dtype is NOT specified, e.g. DataFrame([1,2]) will be ``int64``
+    like DataFrame({'a' : [1,2]})
   - Guarantee that ``convert_objects()`` for Series/DataFrame always returns a
     copy
   - groupby operations will respect dtypes for numeric float operations

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -53,9 +53,9 @@ pandas 0.11.0
 
   - Do not automatically upcast numeric specified dtypes to ``int64`` or
     ``float64`` (GH622_ and GH797_)
-  - DataFrame construction of lists will no longer be platform dependent when
-    dtype is NOT specified, e.g. DataFrame([1,2]) will be ``int64``
-    like DataFrame({'a' : [1,2]})
+  - DataFrame construction of lists and scalars, with no dtype present, will
+    result in casting to ``int64`` or ``float64``, regardless of platform.
+    This is not an apparent change in the API, but noting it.
   - Guarantee that ``convert_objects()`` for Series/DataFrame always returns a
     copy
   - groupby operations will respect dtypes for numeric float operations

--- a/doc/source/v0.11.0.txt
+++ b/doc/source/v0.11.0.txt
@@ -3,7 +3,7 @@
 v0.11.0 (March ??, 2013)
 ------------------------
 
-This is a minor release from 0.10.1 and includes many new features and
+This is a major release from 0.10.1 and includes many new features and
 enhancements along with a large number of bug fixes. There are also a number of
 important API changes that long-time pandas users should pay close attention
 to.
@@ -54,6 +54,18 @@ Numeric dtypes will propagate and can coexist in DataFrames. If a dtype is passe
                Timestamp('20010104'), '20010105'],dtype='O')
    s.convert_objects(convert_dates='coerce')
 
+
+**Platform Gotchas**
+
+In versions prior to 0.11.0, DataFrame construction with lists was platform dependent (meaning 32-bit vs 64-bit). 
+``DataFrame([1,2],columns=['a'])`` would have a dtype of ``int32``, 
+while ``DataFrame({'a' : [1,2] })`` would be ``int64``. 
+Now construction dtype defaults will be handled in a platform independent manor, 
+resulting in defaults for integers of ``int64`` and floats of ``float64`` dtypes.
+
+Keep in mind that ``DataFrame(np.array([1,2]))`` **WILL** result in ``int32`` on 32-bit platforms!
+
+
 **Upcasting Gotchas**
 
 Performing indexing operations on integer type data can easily upcast the data.
@@ -82,21 +94,11 @@ While float dtypes are unchanged.
    casted
    casted.dtypes
 
-New features
-~~~~~~~~~~~~
+**Datetimes conversion**
 
-**Enhancements**
-
-  - In ``HDFStore``, provide dotted attribute access to ``get`` from stores (e.g. store.df == store['df'])
-
-**Bug Fixes**
-
-See the `full release notes
-<https://github.com/pydata/pandas/blob/master/RELEASE.rst>`__ or issue tracker
-on GitHub for a complete list.
-
-
-Datetime64[ns] columns in a DataFrame (or a Series) allow the use of ``np.nan`` to indicate a nan value, in addition to the traditional ``NaT``, or not-a-time. This allows convenient nan setting in a generic way. Furthermore datetime64 columns are created by default, when passed datetimelike objects (*this change was introduced in 0.10.1*)
+Datetime64[ns] columns in a DataFrame (or a Series) allow the use of ``np.nan`` to indicate a nan value, 
+in addition to the traditional ``NaT``, or not-a-time. This allows convenient nan setting in a generic way.
+Furthermore ``datetime64[ns]`` columns are created by default, when passed datetimelike objects (*this change was introduced in 0.10.1*)
 
 .. ipython:: python
 
@@ -111,8 +113,7 @@ Datetime64[ns] columns in a DataFrame (or a Series) allow the use of ``np.nan`` 
    df.ix[2:4,['A','timestamp']] = np.nan
    df
 
-Astype conversion on datetime64[ns] to object, implicity converts ``NaT`` to ``np.nan``
-
+Astype conversion on ``datetime64[ns]`` to ``object``, implicity converts ``NaT`` to ``np.nan``
 
 .. ipython:: python
 
@@ -127,6 +128,13 @@ Astype conversion on datetime64[ns] to object, implicity converts ``NaT`` to ``n
    s.dtype
 
 
+New features
+~~~~~~~~~~~~
+
+**Enhancements**
+
+  - In ``HDFStore``, provide dotted attribute access to ``get`` from stores (e.g. store.df == store['df'])
+
 ``Squeeze`` to possibly remove length 1 dimensions from an object.
 
 .. ipython:: python
@@ -137,3 +145,11 @@ Astype conversion on datetime64[ns] to object, implicity converts ``NaT`` to ``n
    p
    p.reindex(items=['ItemA']).squeeze()
    p.reindex(items=['ItemA'],minor=['B']).squeeze()
+
+**Bug Fixes**
+
+See the `full release notes
+<https://github.com/pydata/pandas/blob/master/RELEASE.rst>`__ or issue tracker
+on GitHub for a complete list.
+
+

--- a/doc/source/v0.11.0.txt
+++ b/doc/source/v0.11.0.txt
@@ -13,7 +13,8 @@ API changes
 
 Numeric dtypes will propagate and can coexist in DataFrames. If a dtype is passed (either directly via the ``dtype`` keyword, a passed ``ndarray``, or a passed ``Series``, then it will be preserved in DataFrame operations. Furthermore, different numeric dtypes will **NOT** be combined. The following example will give you a taste.
 
-**Dtype Specification**
+Dtype Specification
+~~~~~~~~~~~~~~~~~~~
 
 .. ipython:: python
 
@@ -29,7 +30,8 @@ Numeric dtypes will propagate and can coexist in DataFrames. If a dtype is passe
    df3
    df3.dtypes
 
-**Dtype conversion**
+Dtype Conversion
+~~~~~~~~~~~~~~~~
 
 .. ipython:: python
 
@@ -54,20 +56,22 @@ Numeric dtypes will propagate and can coexist in DataFrames. If a dtype is passe
                Timestamp('20010104'), '20010105'],dtype='O')
    s.convert_objects(convert_dates='coerce')
 
+Dtype Gotchas
+~~~~~~~~~~~~~
 
 **Platform Gotchas**
 
 Starting in 0.11.0, construction of DataFrame/Series will use default dtypes of ``int64`` and ``float64``,
 *regardless of platform*. This is not an apparent change from earlier versions of pandas. If you specify
-dtypes, they *WILL* be respected, however.
+dtypes, they *WILL* be respected, however (GH2837_)
 
 The following will all result in ``int64`` dtypes
 
 .. ipython:: python
 
     DataFrame([1,2],columns=['a']).dtypes
-    DataFrame({'a' : [1,2] }.dtypes
-    DataFrame({'a' : 1).dtypes
+    DataFrame({'a' : [1,2] }).dtypes
+    DataFrame({'a' : 1 }, index=range(2)).dtypes
 
 Keep in mind that ``DataFrame(np.array([1,2]))`` **WILL** result in ``int32`` on 32-bit platforms!
 
@@ -100,11 +104,13 @@ While float dtypes are unchanged.
    casted
    casted.dtypes
 
-**Datetimes conversion**
+Datetimes Conversion
+~~~~~~~~~~~~~~~~~~~~
 
 Datetime64[ns] columns in a DataFrame (or a Series) allow the use of ``np.nan`` to indicate a nan value, 
 in addition to the traditional ``NaT``, or not-a-time. This allows convenient nan setting in a generic way.
 Furthermore ``datetime64[ns]`` columns are created by default, when passed datetimelike objects (*this change was introduced in 0.10.1*)
+(GH2809_, GH2810_)
 
 .. ipython:: python
 
@@ -139,18 +145,19 @@ New features
 
 **Enhancements**
 
-  - In ``HDFStore``, provide dotted attribute access to ``get`` from stores (e.g. store.df == store['df'])
+  - In ``HDFStore``, provide dotted attribute access to ``get`` from stores
+    (e.g. store.df == store['df'])
 
-``Squeeze`` to possibly remove length 1 dimensions from an object.
+  - ``Squeeze`` to possibly remove length 1 dimensions from an object.
 
-.. ipython:: python
+    .. ipython:: python
 
-   p = Panel(randn(3,4,4),items=['ItemA','ItemB','ItemC'],
+       p = Panel(randn(3,4,4),items=['ItemA','ItemB','ItemC'],
                           major_axis=date_range('20010102',periods=4),
                           minor_axis=['A','B','C','D'])
-   p
-   p.reindex(items=['ItemA']).squeeze()
-   p.reindex(items=['ItemA'],minor=['B']).squeeze()
+       p
+       p.reindex(items=['ItemA']).squeeze()
+       p.reindex(items=['ItemA'],minor=['B']).squeeze()
 
 **Bug Fixes**
 
@@ -158,4 +165,7 @@ See the `full release notes
 <https://github.com/pydata/pandas/blob/master/RELEASE.rst>`__ or issue tracker
 on GitHub for a complete list.
 
+.. _GH2809: https://github.com/pydata/pandas/issues/2809
+.. _GH2810: https://github.com/pydata/pandas/issues/2810
+.. _GH2837: https://github.com/pydata/pandas/issues/2837
 

--- a/doc/source/v0.11.0.txt
+++ b/doc/source/v0.11.0.txt
@@ -57,11 +57,17 @@ Numeric dtypes will propagate and can coexist in DataFrames. If a dtype is passe
 
 **Platform Gotchas**
 
-In versions prior to 0.11.0, DataFrame construction with lists was platform dependent (meaning 32-bit vs 64-bit). 
-``DataFrame([1,2],columns=['a'])`` would have a dtype of ``int32``, 
-while ``DataFrame({'a' : [1,2] })`` would be ``int64``. 
-Now construction dtype defaults will be handled in a platform independent manor, 
-resulting in defaults for integers of ``int64`` and floats of ``float64`` dtypes.
+Starting in 0.11.0, construction of DataFrame/Series will use default dtypes of ``int64`` and ``float64``,
+*regardless of platform*. This is not an apparent change from earlier versions of pandas. If you specify
+dtypes, they *WILL* be respected, however.
+
+The following will all result in ``int64`` dtypes
+
+.. ipython:: python
+
+    DataFrame([1,2],columns=['a']).dtypes
+    DataFrame({'a' : [1,2] }.dtypes
+    DataFrame({'a' : 1).dtypes
 
 Keep in mind that ``DataFrame(np.array([1,2]))`` **WILL** result in ``int32`` on 32-bit platforms!
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -717,7 +717,6 @@ def _maybe_promote(dtype, fill_value=np.nan):
         return dtype
     return np.object_
 
-
 def _maybe_upcast(values):
     """ provide explicty type promotion and coercion """
     new_dtype = _maybe_promote(values.dtype)

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -805,10 +805,11 @@ def _consensus_name_attr(objs):
 # Lots of little utilities
 
 
-def _possibly_convert_objects(values, convert_dates=True, convert_numeric=True):
+def _possibly_convert_objects(values, convert_dates=True, convert_numeric=True, convert_platform=False):
     """ if we have an object dtype, try to coerce dates and/or numers """
 
-    if values.dtype == np.object_ and convert_dates:
+    # convert dates
+    if convert_dates and getattr(values,'dtype',None) == np.object_:
 
         # we take an aggressive stance and convert to datetime64[ns]
         if convert_dates == 'coerce':
@@ -821,7 +822,8 @@ def _possibly_convert_objects(values, convert_dates=True, convert_numeric=True):
         else:
             values = lib.maybe_convert_objects(values, convert_datetime=convert_dates)
 
-    if values.dtype == np.object_ and convert_numeric:
+    # convert to numeric
+    if convert_numeric and getattr(values,'dtype',None) == np.object_:
         try:
             new_values = lib.maybe_convert_numeric(values,set(),coerce_numeric=True)
             
@@ -831,6 +833,14 @@ def _possibly_convert_objects(values, convert_dates=True, convert_numeric=True):
 
         except:
             pass
+
+    # platform conversion
+    #   allow ndarray or list here
+    if convert_platform:
+        if isinstance(values, (list,tuple)):
+            values = lib.list_to_object_array(values)
+        if values.dtype == np.object_:
+            values = lib.maybe_convert_objects(values)
 
     return values
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5460,11 +5460,21 @@ def _prep_ndarray(values, copy=True):
         if len(values) == 0:
             return np.empty((0, 0), dtype=object)
 
-        arr = np.asarray(values)
-        # NumPy strings are a pain, convert to object
-        if issubclass(arr.dtype.type, basestring):
-            arr = np.array(values, dtype=object, copy=True)
-        values = arr
+        def convert(v):
+            return com._possibly_convert_objects(v,
+                                                 convert_dates=False,
+                                                 convert_numeric=False,
+                                                 convert_platform=True)
+
+
+        # we could have a 1-dim or 2-dim list here
+        # this is equiv of np.asarray, but does object conversion
+        # and platform dtype preservation
+        if com.is_list_like(values[0]) or hasattr(values[0],'len'):
+            values = np.array([ convert(v) for v in values])
+        else:
+            values = convert(values)
+
     else:
         # drop subclass info, do not copy data
         values = np.asarray(values)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1234,7 +1234,7 @@ class DataFrame(NDFrame):
         panel : Panel
         """
         from pandas.core.panel import Panel
-        from pandas.core.reshape import block2d_to_block3d
+        from pandas.core.reshape import block2d_to_blocknd
 
         # only support this kind for now
         if (not isinstance(self.index, MultiIndex) or
@@ -1261,8 +1261,8 @@ class DataFrame(NDFrame):
 
         new_blocks = []
         for block in selfsorted._data.blocks:
-            newb = block2d_to_block3d(block.values.T, block.items, shape,
-                                      major_labels, minor_labels,
+            newb = block2d_to_blocknd(block.values.T, block.items, shape,
+                                      [ major_labels, minor_labels ],
                                       ref_items=selfsorted.columns)
             new_blocks.append(newb)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -23,7 +23,7 @@ import numpy as np
 import numpy.ma as ma
 
 from pandas.core.common import (isnull, notnull, PandasError, _try_sort,
-                                _default_index, _is_sequence, _dtype_from_scalar)
+                                _default_index, _is_sequence, _infer_dtype_from_scalar)
 from pandas.core.generic import NDFrame
 from pandas.core.index import Index, MultiIndex, _ensure_index
 from pandas.core.indexing import (_NDFrameIndexer, _maybe_droplevels,
@@ -437,7 +437,7 @@ class DataFrame(NDFrame):
                 if isinstance(data, basestring) and dtype is None:
                     dtype = np.object_
                 if dtype is None:
-                    data, dtype = _dtype_from_scalar(data)
+                    data, dtype = _infer_dtype_from_scalar(data)
 
                 values = np.empty((len(index), len(columns)), dtype=dtype)
                 values.fill(data)
@@ -1878,7 +1878,7 @@ class DataFrame(NDFrame):
             new_index, new_columns = self._expand_axes((index, col))
             result = self.reindex(index=new_index, columns=new_columns,
                                   copy=False)
-            likely_dtype = com._infer_dtype(value)
+            value, likely_dtype = _infer_dtype_from_scalar(value)
 
             made_bigger = not np.array_equal(new_columns, self.columns)
 
@@ -2208,7 +2208,7 @@ class DataFrame(NDFrame):
                 existing_piece = self[key]
 
                 # upcast the scalar
-                value, dtype = _dtype_from_scalar(value)
+                value, dtype = _infer_dtype_from_scalar(value)
 
                 # transpose hack
                 if isinstance(existing_piece, DataFrame):
@@ -2226,7 +2226,7 @@ class DataFrame(NDFrame):
 
             else:
                 # upcast the scalar
-                value, dtype = _dtype_from_scalar(value)
+                value, dtype = _infer_dtype_from_scalar(value)
                 value = np.array(np.repeat(value, len(self.index)), dtype=dtype)
 
             value = com._possibly_cast_to_datetime(value, dtype)

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -377,11 +377,11 @@ class Block(object):
         new_values = self.values.take(indexer, axis=1)
         # convert integer to float if necessary. need to do a lot more than
         # that, handle boolean etc also
-        new_values = com._maybe_upcast(new_values)
+        new_values, fill_value = com._maybe_upcast(new_values)
         if periods > 0:
-            new_values[:, :periods] = np.nan
+            new_values[:, :periods] = fill_value
         else:
-            new_values[:, periods:] = np.nan
+            new_values[:, periods:] = fill_value
         return make_block(new_values, self.items, self.ref_items)
 
     def where(self, func, other, cond = None, raise_on_error = True, try_cast = False):
@@ -1412,7 +1412,7 @@ class BlockManager(object):
         block_shape = list(self.shape)
         block_shape[0] = len(items)
 
-        fill_value, dtype = com._infer_dtype_from_scalar(fill_value)
+        dtype, fill_value = com._infer_dtype_from_scalar(fill_value)
         block_values = np.empty(block_shape, dtype=dtype)
         block_values.fill(fill_value)
         na_block = make_block(block_values, items, ref_items)

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1412,7 +1412,7 @@ class BlockManager(object):
         block_shape = list(self.shape)
         block_shape[0] = len(items)
 
-        dtype = com._infer_dtype(fill_value)
+        fill_value, dtype = com._infer_dtype_from_scalar(fill_value)
         block_values = np.empty(block_shape, dtype=dtype)
         block_values.fill(fill_value)
         na_block = make_block(block_values, items, ref_items)

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -658,7 +658,7 @@ class Panel(NDFrame):
             d = self._construct_axes_dict_from(self, axes, copy=False)
             result = self.reindex(**d)
             args  = list(args)
-            args[-1], likely_dtype = _infer_dtype_from_scalar(args[-1])
+            likely_dtype, args[-1] = _infer_dtype_from_scalar(args[-1])
             made_bigger = not np.array_equal(
                 axes[0], getattr(self, self._info_axis))
             # how to make this logic simpler?
@@ -693,7 +693,7 @@ class Panel(NDFrame):
             assert(value.shape == shape[1:])
             mat = np.asarray(value)
         elif np.isscalar(value):
-            value, dtype = _infer_dtype_from_scalar(value)
+            dtype, value = _infer_dtype_from_scalar(value)
             mat = np.empty(shape[1:], dtype=dtype)
             mat.fill(value)
         else:

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -7,7 +7,7 @@ import operator
 import sys
 import numpy as np
 from pandas.core.common import (PandasError, _mut_exclusive,
-                                _try_sort, _default_index, _infer_dtype,
+                                _try_sort, _default_index, _infer_dtype_from_scalar,
                                 notnull)
 from pandas.core.categorical import Factor
 from pandas.core.index import (Index, MultiIndex, _ensure_index,
@@ -657,8 +657,8 @@ class Panel(NDFrame):
             axes = self._expand_axes(args)
             d = self._construct_axes_dict_from(self, axes, copy=False)
             result = self.reindex(**d)
-
-            likely_dtype = com._infer_dtype(args[-1])
+            args  = list(args)
+            args[-1], likely_dtype = _infer_dtype_from_scalar(args[-1])
             made_bigger = not np.array_equal(
                 axes[0], getattr(self, self._info_axis))
             # how to make this logic simpler?
@@ -693,7 +693,7 @@ class Panel(NDFrame):
             assert(value.shape == shape[1:])
             mat = np.asarray(value)
         elif np.isscalar(value):
-            dtype = _infer_dtype(value)
+            value, dtype = _infer_dtype_from_scalar(value)
             mat = np.empty(shape[1:], dtype=dtype)
             mat.fill(value)
         else:

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -149,8 +149,9 @@ class _Unstacker(object):
         stride = values.shape[1]
         result_width = width * stride
 
-        new_values = np.empty((length, result_width), dtype=_maybe_promote(values.dtype))
-        new_values.fill(np.nan)
+        dtype, fill_value = _maybe_promote(values.dtype)
+        new_values = np.empty((length, result_width), dtype=dtype)
+        new_values.fill(fill_value)
         new_mask = np.zeros((length, result_width), dtype=bool)
 
         # is there a simpler / faster way of doing this?
@@ -773,12 +774,12 @@ def block2d_to_blocknd(values, items, shape, labels, ref_items=None):
     mask = np.zeros(np.prod(shape), dtype=bool)
     mask.put(selector, True)
 
-    pvalues = np.empty(panel_shape, dtype=values.dtype)
-    if not issubclass(pvalues.dtype.type, (np.integer, np.bool_)):
-        pvalues.fill(np.nan)
-    elif not mask.all():
-        pvalues = _maybe_upcast(pvalues)
-        pvalues.fill(np.nan)
+    if mask.all():
+        pvalues = np.empty(panel_shape, dtype=values.dtype)
+    else:
+        dtype, fill_value = _maybe_promote(values.dtype)
+        pvalues = np.empty(panel_shape, dtype=dtype)
+        pvalues.fill(fill_value)
 
     values = values
     for i in xrange(len(items)):

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -9,7 +9,8 @@ from pandas.core.series import Series
 from pandas.core.frame import DataFrame
 
 from pandas.core.categorical import Categorical
-from pandas.core.common import notnull, _ensure_platform_int
+from pandas.core.common import (notnull, _ensure_platform_int, _maybe_promote,
+                                _maybe_upcast)
 from pandas.core.groupby import (get_group_index, _compress_group_index,
                                  decons_group_index)
 import pandas.core.common as com
@@ -148,11 +149,9 @@ class _Unstacker(object):
         stride = values.shape[1]
         result_width = width * stride
 
-        new_values = np.empty((length, result_width), dtype=values.dtype)
-        new_mask = np.zeros((length, result_width), dtype=bool)
-
-        new_values = com._maybe_upcast(new_values)
+        new_values = np.empty((length, result_width), dtype=_maybe_promote(values.dtype))
         new_values.fill(np.nan)
+        new_mask = np.zeros((length, result_width), dtype=bool)
 
         # is there a simpler / faster way of doing this?
         for i in xrange(values.shape[1]):
@@ -761,40 +760,6 @@ def make_axis_dummies(frame, axis='minor', transform=None):
     return DataFrame(values, columns=items, index=frame.index)
 
 
-def block2d_to_block3d(values, items, shape, major_labels, minor_labels,
-                       ref_items=None):
-    """
-    Developer method for pivoting DataFrame -> Panel. Used in HDFStore and
-    DataFrame.to_panel
-    """
-    from pandas.core.internals import make_block
-    panel_shape = (len(items),) + shape
-
-    # TODO: lexsort depth needs to be 2!!
-
-    # Create observation selection vector using major and minor
-    # labels, for converting to panel format.
-    selector = minor_labels + shape[1] * major_labels
-    mask = np.zeros(np.prod(shape), dtype=bool)
-    mask.put(selector, True)
-
-    pvalues = np.empty(panel_shape, dtype=values.dtype)
-    if not issubclass(pvalues.dtype.type, (np.integer, np.bool_)):
-        pvalues.fill(np.nan)
-    elif not mask.all():
-        pvalues = com._maybe_upcast(pvalues)
-        pvalues.fill(np.nan)
-
-    values = values
-    for i in xrange(len(items)):
-        pvalues[i].flat[mask] = values[:, i]
-
-    if ref_items is None:
-        ref_items = items
-
-    return make_block(pvalues, items, ref_items)
-
-
 def block2d_to_blocknd(values, items, shape, labels, ref_items=None):
     """ pivot to the labels shape """
     from pandas.core.internals import make_block
@@ -812,7 +777,7 @@ def block2d_to_blocknd(values, items, shape, labels, ref_items=None):
     if not issubclass(pvalues.dtype.type, (np.integer, np.bool_)):
         pvalues.fill(np.nan)
     elif not mask.all():
-        pvalues = com._maybe_upcast(pvalues)
+        pvalues = _maybe_upcast(pvalues)
         pvalues.fill(np.nan)
 
     values = values

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -16,7 +16,8 @@ import numpy.ma as ma
 
 from pandas.core.common import (isnull, notnull, _is_bool_indexer,
                                 _default_index, _maybe_upcast,
-                                _asarray_tuplesafe, is_integer_dtype)
+                                _asarray_tuplesafe, is_integer_dtype,
+                                _infer_dtype_from_scalar)
 from pandas.core.index import (Index, MultiIndex, InvalidIndexError,
                                _ensure_index, _handle_legacy_indexes)
 from pandas.core.indexing import _SeriesIndexer, _check_bool_indexer
@@ -3129,7 +3130,7 @@ def _sanitize_array(data, index, dtype=None, copy=False,
 
             # figure out the dtype from the value (upcast if necessary)
             if dtype is None:
-                value, dtype = com._dtype_from_scalar(value)
+                value, dtype = _infer_dtype_from_scalar(value)
             else:
                 # need to possibly convert the value here
                 value = com._possibly_cast_to_datetime(value, dtype)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2818,14 +2818,15 @@ copy : boolean, default False
             return values
 
         if offset is None:
-            new_values = pa.empty(len(self), dtype=_maybe_promote(self.dtype))
+            dtype, fill_value = _maybe_promote(self.dtype)
+            new_values = pa.empty(len(self), dtype=dtype)
 
             if periods > 0:
                 new_values[periods:] = self.values[:-periods]
-                new_values[:periods] = nan
+                new_values[:periods] = fill_value
             elif periods < 0:
                 new_values[:periods] = self.values[-periods:]
-                new_values[periods:] = nan
+                new_values[periods:] = fill_value
 
             return Series(new_values, index=self.index, name=self.name)
         elif isinstance(self.index, PeriodIndex):
@@ -3129,7 +3130,7 @@ def _sanitize_array(data, index, dtype=None, copy=False,
 
             # figure out the dtype from the value (upcast if necessary)
             if dtype is None:
-                value, dtype = _infer_dtype_from_scalar(value)
+                dtype, value = _infer_dtype_from_scalar(value)
             else:
                 # need to possibly convert the value here
                 value = com._possibly_cast_to_datetime(value, dtype)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3111,11 +3111,15 @@ def _sanitize_array(data, index, dtype=None, copy=False,
                     raise
                 subarr = pa.array(data, dtype=object, copy=copy)
                 subarr = lib.maybe_convert_objects(subarr)
-                subarr = com._possibly_cast_to_datetime(subarr, dtype)
+            
         else:
-            subarr = lib.list_to_object_array(data)
-            subarr = lib.maybe_convert_objects(subarr)
-            subarr = com._possibly_cast_to_datetime(subarr, dtype)
+            subarr = com._possibly_convert_objects(data,
+                                                   convert_dates=False,
+                                                   convert_numeric=False,
+                                                   convert_platform=True)
+
+        subarr = com._possibly_cast_to_datetime(subarr, dtype)
+
     else:
         subarr = _try_cast(data)
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -15,7 +15,7 @@ import numpy as np
 import numpy.ma as ma
 
 from pandas.core.common import (isnull, notnull, _is_bool_indexer,
-                                _default_index, _maybe_upcast,
+                                _default_index, _maybe_promote,
                                 _asarray_tuplesafe, is_integer_dtype,
                                 _infer_dtype_from_scalar)
 from pandas.core.index import (Index, MultiIndex, InvalidIndexError,
@@ -2818,8 +2818,7 @@ copy : boolean, default False
             return values
 
         if offset is None:
-            new_values = pa.empty(len(self), dtype=self.dtype)
-            new_values = _maybe_upcast(new_values)
+            new_values = pa.empty(len(self), dtype=_maybe_promote(self.dtype))
 
             if periods > 0:
                 new_values[periods:] = self.values[:-periods]

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3127,29 +3127,16 @@ def _sanitize_array(data, index, dtype=None, copy=False,
         elif index is not None:
             value = data
 
-            # If we create an empty array using a string to infer
-            # the dtype, NumPy will only allocate one character per entry
-            # so this is kind of bad. Alternately we could use np.repeat
-            # instead of np.empty (but then you still don't want things
-            # coming out as np.str_!
-            if isinstance(value, basestring) and dtype is None:
-                dtype = np.object_
-
+            # figure out the dtype from the value (upcast if necessary)
             if dtype is None:
-
-                # a 1-element ndarray
-                if isinstance(value, pa.Array):
-                    dtype = value.dtype
-                    value = value.item()
-                else:
-                    value, dtype = com._dtype_from_scalar(value)
-
-                subarr = pa.empty(len(index), dtype=dtype)
+                value, dtype = com._dtype_from_scalar(value)
             else:
                 # need to possibly convert the value here
                 value = com._possibly_cast_to_datetime(value, dtype)
-                subarr = pa.empty(len(index), dtype=dtype)
+
+            subarr = pa.empty(len(index), dtype=dtype)
             subarr.fill(value)
+
         else:
             return subarr.item()
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3113,10 +3113,7 @@ def _sanitize_array(data, index, dtype=None, copy=False,
                 subarr = lib.maybe_convert_objects(subarr)
             
         else:
-            subarr = com._possibly_convert_objects(data,
-                                                   convert_dates=False,
-                                                   convert_numeric=False,
-                                                   convert_platform=True)
+            subarr = com._possibly_convert_platform(data)
 
         subarr = com._possibly_cast_to_datetime(subarr, dtype)
 
@@ -3145,7 +3142,7 @@ def _sanitize_array(data, index, dtype=None, copy=False,
                     dtype = value.dtype
                     value = value.item()
                 else:
-                    value, dtype = _dtype_from_scalar(value)
+                    value, dtype = com._dtype_from_scalar(value)
 
                 subarr = pa.empty(len(index), dtype=dtype)
             else:
@@ -3178,14 +3175,6 @@ def _sanitize_array(data, index, dtype=None, copy=False,
         subarr = pa.array(data, dtype=object, copy=copy)
 
     return subarr
-
-
-def _dtype_from_scalar(val):
-    if isinstance(val, np.datetime64):
-        # ugly hacklet
-        val = lib.Timestamp(val).value
-        return val, np.dtype('M8[ns]')
-    return val, type(val)
 
 
 def _get_rename_function(mapper):

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -23,7 +23,7 @@ from pandas.core.algorithms import match, unique, factorize
 from pandas.core.categorical import Categorical
 from pandas.core.common import _asarray_tuplesafe, _try_sort
 from pandas.core.internals import BlockManager, make_block, form_blocks
-from pandas.core.reshape import block2d_to_block3d, block2d_to_blocknd, factor_indexer
+from pandas.core.reshape import block2d_to_blocknd, factor_indexer
 from pandas.core.index import Int64Index
 import pandas.core.common as com
 from pandas.tools.merge import concat

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -441,8 +441,10 @@ class CheckIndexing(object):
         self.assert_(self.frame['D'].dtype == np.int64)
 
         # #669, should not cast?
+        # this is now set to int64, which means a replacement of the column to
+        # the value dtype (and nothing to do with the existing dtype)
         self.frame['B'] = 0
-        self.assert_(self.frame['B'].dtype == np.float64)
+        self.assert_(self.frame['B'].dtype == np.int64)
 
         # cast if pass array of course
         self.frame['B'] = np.arange(len(self.frame))

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2903,12 +2903,8 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         casted = mn.astype('float32')
         _check_cast(casted, 'float32')
 
-        # this is platform dependent overflow
-        if np.int_ == np.int32:
-            self.assertRaises(OverflowError, mn.astype, 'int32')
-        else:
-            casted = mn.astype('int32')
-            _check_cast(casted, 'int32')
+        casted = mn.astype('int32')
+        _check_cast(casted, 'int32')
 
         # to object
         casted = mn.astype('O')

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -418,7 +418,7 @@ class CheckIndexing(object):
         # scalar
         self.panel['ItemG'] = 1
         self.panel['ItemE'] = True
-        self.assert_(self.panel['ItemG'].values.dtype == np.int_)
+        self.assert_(self.panel['ItemG'].values.dtype == np.int64)
         self.assert_(self.panel['ItemE'].values.dtype == np.bool_)
 
         # object dtype

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -358,7 +358,7 @@ class CheckIndexing(object):
         # scalar
         self.panel4d['lG'] = 1
         self.panel4d['lE'] = True
-        self.assert_(self.panel4d['lG'].values.dtype == np.int_)
+        self.assert_(self.panel4d['lG'].values.dtype == np.int64)
         self.assert_(self.panel4d['lE'].values.dtype == np.bool_)
 
         # object dtype

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -287,7 +287,7 @@ class TestMerge(unittest.TestCase):
         df1 = DataFrame({'A': 1., 'B': 2, 'C': 'foo', 'D': True},
                         index=np.arange(10),
                         columns=['A', 'B', 'C', 'D'])
-        self.assert_(df1['B'].dtype == np.int)
+        self.assert_(df1['B'].dtype == np.int64)
         self.assert_(df1['D'].dtype == np.bool_)
 
         df2 = DataFrame({'A': 1., 'B': 2, 'C': 'foo', 'D': True},


### PR DESCRIPTION
use int64/float64 defaults in construction when dtype is not specified
this removes a platform dependency issue that caused dataframe and series to
have different dtypes on 32- bit

fixes issues raised in PR #2837 
