### PR TITLE
ENH: implement Block splitting to avoid upcasts where possible (GH #2794)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3714,14 +3714,14 @@ class DataFrame(NDFrame):
         if fill_value is not None:
             raise NotImplementedError
 
-        new_data = left._data.where(func, right, axes = [left.columns, self.index])
+        new_data = left._data.eval(func, right, axes = [left.columns, self.index])
         return self._constructor(new_data)
 
     def _combine_const(self, other, func, raise_on_error = True):
         if self.empty:
             return self
 
-        new_data = self._data.where(func, other, raise_on_error=raise_on_error)
+        new_data = self._data.eval(func, other, raise_on_error=raise_on_error)
         return self._constructor(new_data)
 
     def _compare_frame(self, other, func):
@@ -5293,8 +5293,7 @@ class DataFrame(NDFrame):
             self._data = self._data.putmask(cond,other,inplace=True)
 
         else:
-            func = lambda values, others, conds: np.where(conds, values, others)
-            new_data = self._data.where(func, other, cond, raise_on_error=raise_on_error, try_cast=try_cast)
+            new_data = self._data.where(other, cond, raise_on_error=raise_on_error, try_cast=try_cast)
 
             return self._constructor(new_data)
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -496,7 +496,7 @@ class Block(object):
                                     % repr(o))
                 else:
                     # return the values
-                    result = np.empty(v.shape,dtype='O')
+                    result = np.empty(v.shape,dtype='float64')
                     result.fill(np.nan)
                     return result
 


### PR DESCRIPTION
- provides an implementation of IntBlock splitting that can avoid upcasting (to float) these blocks if a boolean condition does not affect the column, closes GH #2794)
- bugfix in internals.Block.putmask; was upcasting always on an int; and upcasting to float, (now float64)

```
In [6]: df = pd.DataFrame(1,columns=['a','b'],index=range(3))

In [7]: df.ix[1,'b'] = 0

In [8]: df
Out[8]: 
   a  b
0  1  1
1  1  0
2  1  1

In [9]: df.dtypes
Out[9]: 
a    int64
b    int64
Dtype: object

In [10]: df[df>0].dtypes
Out[10]: 
a      int64
b    float64
Dtype: object

In [11]: df[df>0]
Out[11]: 
   a   b
0  1   1
1  1 NaN
2  1   1
```
