### PR TITLE
BUG/TST: Yahoo Finance (a foundational resolve of GH: #2847,  #2853)

### DIFF
--- a/pandas/io/data.py
+++ b/pandas/io/data.py
@@ -14,6 +14,7 @@ import time
 from zipfile import ZipFile
 from pandas.util.py3compat import StringIO, BytesIO, bytes_to_str
 
+import pandas as pd
 from pandas import Panel, DataFrame, Series, read_csv, concat
 from pandas.io.parsers import TextParser
 
@@ -115,7 +116,7 @@ def get_quote_yahoo(symbols):
         return None
 
     for line in lines:
-        fields = line.strip().split(',')
+        fields = line.decode().strip().split(',')
         for i, field in enumerate(fields):
             if field[-2:] == '%"':
                 data[header[i]].append(float(field.strip('"%')))
@@ -133,7 +134,7 @@ def get_quote_yahoo(symbols):
 
 
 def _get_hist_yahoo(sym=None, start=None, end=None, retry_count=3,
-                    pause=0):
+                    pause=0, **kwargs):
     """
     Get historical data for the given name from yahoo.
     Date format is datetime
@@ -195,11 +196,22 @@ def _adjust_prices(hist_data, price_list=['Open', 'High', 'Low', 'Close']):
 
 def _calc_return_index(price_df):
     """
-    Return a returns index from a input price df or series.
+    Return a returns index from a input price df or series. Intial value
+    (typically NaN) is set to 1.
     """
+    df = price_df.pct_change().add(1).cumprod()
+    mask = ~df.ix[1].isnull() & df.ix[0].isnull()
+    df.ix[0][mask] = 1
 
-    ret_index =  price_df.pct_change().add(1).cumprod()
-    ret_index.ix[0] = 1
+    #Check for first stock listings after starting date of index in ret_index
+    #If True, find first_valid_index and set previous entry to 1.
+    if(~mask).any:
+        for sym in mask.index[~mask]:
+            tstamp = df[sym].first_valid_index()
+            t_idx = df.index.get_loc(tstamp) - 1
+            df[sym].ix[t_idx] = 1
+
+    ret_index = df
     return ret_index
 
 
@@ -241,7 +253,7 @@ def get_components_yahoo(idx_sym):
     #break when no new components are found
     while (True in mask):
         urlStr = url.format(idx_mod, stats,  comp_idx)
-        lines = (urllib.urlopen(urlStr).read().strip().
+        lines = (urllib.urlopen(urlStr).read().decode().strip().
                  strip('"').split('"\r\n"'))
 
         lines = [line.strip().split('","') for line in lines]
@@ -258,7 +270,8 @@ def get_components_yahoo(idx_sym):
 
 
 def get_data_yahoo(symbols=None, start=None, end=None, retry_count=3, pause=0,
-                   adjust_price=False, ret_index=False, chunksize=25, **kwargs):
+                   adjust_price=False, ret_index=False, chunksize=25,
+                   log_info=False, **kwargs):
     """
     Returns DataFrame/Panel of historical stock prices from symbols, over date
     range, start to end. To avoid being penalized by Yahoo! Finance servers,
@@ -266,8 +279,8 @@ def get_data_yahoo(symbols=None, start=None, end=None, retry_count=3, pause=0,
 
     Parameters
     ----------
-    symbols : string, list-like object (list, tupel, Series), or DataFrame
-        Single stock symbol (ticker), list-like object of symbols or
+    symbols : string, array-like object (list, tupel, Series), or DataFrame
+        Single stock symbol (ticker), array-like object of symbols or
         DataFrame with index containing stock symbols.
     start : string, (defaults to '1/1/2010')
         Starting date, timestamp. Parses many different kind of date
@@ -290,7 +303,7 @@ def get_data_yahoo(symbols=None, start=None, end=None, retry_count=3, pause=0,
 
     Returns
     -------
-    hist_data : DataFrame (str) or Panel (list-like object, DataFrame)
+    hist_data : DataFrame (str) or Panel (array-like object, DataFrame)
     """
 
     def dl_mult_symbols(symbols):

--- a/pandas/io/data.py
+++ b/pandas/io/data.py
@@ -116,7 +116,7 @@ def get_quote_yahoo(symbols):
         return None
 
     for line in lines:
-        fields = line.decode().strip().split(',')
+        fields = line.decode('utf-8').strip().split(',')
         for i, field in enumerate(fields):
             if field[-2:] == '%"':
                 data[header[i]].append(float(field.strip('"%')))
@@ -253,7 +253,7 @@ def get_components_yahoo(idx_sym):
     #break when no new components are found
     while (True in mask):
         urlStr = url.format(idx_mod, stats,  comp_idx)
-        lines = (urllib.urlopen(urlStr).read().decode().strip().
+        lines = (urllib.urlopen(urlStr).read().decode('utf-8').strip().
                  strip('"').split('"\r\n"'))
 
         lines = [line.strip().split('","') for line in lines]
@@ -271,7 +271,7 @@ def get_components_yahoo(idx_sym):
 
 def get_data_yahoo(symbols=None, start=None, end=None, retry_count=3, pause=0,
                    adjust_price=False, ret_index=False, chunksize=25,
-                   log_info=False, **kwargs):
+                   **kwargs):
     """
     Returns DataFrame/Panel of historical stock prices from symbols, over date
     range, start to end. To avoid being penalized by Yahoo! Finance servers,

--- a/pandas/io/tests/test_yahoo.py
+++ b/pandas/io/tests/test_yahoo.py
@@ -43,12 +43,14 @@ class TestYahoo(unittest.TestCase):
                 raise
 
 
+    @slow
     @network
     def test_get_quote(self):
         df = web.get_quote_yahoo(pd.Series(['GOOG', 'AAPL', 'GOOG']))
         assert_series_equal(df.ix[0], df.ix[2])
 
 
+    @slow
     @network
     def test_get_components(self):
 
@@ -70,8 +72,10 @@ class TestYahoo(unittest.TestCase):
         assert 'AMZN' in df.index
 
 
+    @slow
     @network
     def test_get_data(self):
+        import numpy as np
         #single symbol
         #http://finance.yahoo.com/q/hp?s=GOOG&a=09&b=08&c=2010&d=09&e=10&f=2010&g=d
         df = web.get_data_yahoo('GOOG')
@@ -88,6 +92,11 @@ class TestYahoo(unittest.TestCase):
         result = pan.Close.ix['01-18-12'][['GE', 'MSFT', 'INTC']].tolist()
         assert result == expected
 
+        # sanity checking
+        t= np.array(result)
+        assert     np.issubdtype(t.dtype, np.floating)
+        assert     t.shape == (3,)
+
         expected = [[ 18.99,  28.4 ,  25.18],
                     [ 18.58,  28.31,  25.13],
                     [ 19.03,  28.16,  25.52],
@@ -102,6 +111,10 @@ class TestYahoo(unittest.TestCase):
         result = pan.Ret_Index.ix[tstamp]['INTC']
         expected = 1.0
         assert result == expected
+
+        # sanity checking
+        t= np.array(result)
+        assert     np.issubdtype(t.dtype, np.floating)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolve issues in `pandas.io.data.py` and `test_yahoo.py`.
- BUG: Fixed decode issue in `get_data_yahoo()` for python 3.3 (resolves #2847)
- ENH: Updated `_calc_return_index()` function to properly handle groups of multiple stocks that do not share the first valid price on the same date (i.e., stocks whose IPO's dates exist within the query date range). Ensures that all stock's first values in `ret_index` are set to 1, regardless of actual initial starting date.
- TST: Modify test suite for yahoo finance functions in `test_yahoo.py` to accurately test queries to yahoo finance (resolves #2853/#2847)
