### PR TITLE
BUG: Series construction from MaskedArray fails for non-floating, non-object types

### DIFF
--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -40,7 +40,7 @@ def _skip_if_no_pytz():
     except ImportError:
         raise nose.SkipTest
 
-#-------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Series test cases
 
 JOIN_TYPES = ['inner', 'outer', 'left', 'right']
@@ -340,6 +340,65 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         index = ['a', 'b', 'c']
         result = Series(data, index=index)
         expected = Series([0.0, nan, 2.0], index=index)
+        assert_series_equal(result, expected)
+
+        data[1] = 1.0
+        result = Series(data, index=index)
+        expected = Series([0.0, 1.0, 2.0], index=index)
+        assert_series_equal(result, expected)
+
+        data = ma.masked_all((3,), dtype=int)
+        result = Series(data)
+        expected = Series([nan, nan, nan], dtype=float)
+        assert_series_equal(result, expected)
+
+        data[0] = 0
+        data[2] = 2
+        index = ['a', 'b', 'c']
+        result = Series(data, index=index)
+        expected = Series([0, nan, 2], index=index, dtype=float)
+        assert_series_equal(result, expected)
+
+        data[1] = 1
+        result = Series(data, index=index)
+        expected = Series([0, 1, 2], index=index, dtype=int)
+        assert_series_equal(result, expected)
+
+        data = ma.masked_all((3,), dtype=bool)
+        result = Series(data)
+        expected = Series([nan, nan, nan], dtype=object)
+        assert_series_equal(result, expected)
+
+        data[0] = True
+        data[2] = False
+        index = ['a', 'b', 'c']
+        result = Series(data, index=index)
+        expected = Series([True, nan, False], index=index, dtype=object)
+        assert_series_equal(result, expected)
+
+        data[1] = True
+        result = Series(data, index=index)
+        expected = Series([True, True, False], index=index, dtype=bool)
+        assert_series_equal(result, expected)
+
+        from pandas import tslib
+        data = ma.masked_all((3,), dtype='M8[ns]')
+        result = Series(data)
+        expected = Series([tslib.iNaT, tslib.iNaT, tslib.iNaT], dtype='M8[ns]')
+        assert_series_equal(result, expected)
+
+        data[0] = datetime(2001, 1, 1)
+        data[2] = datetime(2001, 1, 3)
+        index = ['a', 'b', 'c']
+        result = Series(data, index=index)
+        expected = Series([datetime(2001, 1, 1), tslib.iNaT,
+                           datetime(2001, 1, 3)], index=index, dtype='M8[ns]')
+        assert_series_equal(result, expected)
+
+        data[1] = datetime(2001, 1, 2)
+        result = Series(data, index=index)
+        expected = Series([datetime(2001, 1, 1), datetime(2001, 1, 2),
+                           datetime(2001, 1, 3)], index=index, dtype='M8[ns]')
         assert_series_equal(result, expected)
 
     def test_constructor_default_index(self):
@@ -2922,7 +2981,7 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         result = s.convert_objects(convert_dates=True,convert_numeric=False)
         expected = Series([Timestamp('20010101'),Timestamp('20010102'),Timestamp('20010103')],dtype='M8[ns]')
         assert_series_equal(expected,result)
-        
+
         result = s.convert_objects(convert_dates='coerce',convert_numeric=False)
         assert_series_equal(expected,result)
         result = s.convert_objects(convert_dates='coerce',convert_numeric=True)
@@ -3306,7 +3365,7 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         s.fillna(method='ffill', inplace=True)
         assert_series_equal(s.fillna(method='ffill', inplace=False), s)
 
-#-------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # TimeSeries-specific
 
     def test_fillna(self):
@@ -3569,7 +3628,7 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         expected = self.ts.values[:, np.newaxis]
         assert_almost_equal(result, expected)
 
-#-------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # GroupBy
 
     def test_select(self):
@@ -3582,7 +3641,7 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         expected = self.ts[self.ts.weekday == 2]
         assert_series_equal(result, expected)
 
-#----------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Misc not safe for sparse
 
     def test_dropna_preserve_name(self):


### PR DESCRIPTION
Currently Series constructor is throwing exceptions or ignoring the mask for non-floating, non-object MaskedArray input:

``` python
In [1]: from numpy.ma import MaskedArray as ma
In [2]: from pandas import Series, DataFrame
In [3]: from datetime import datetime as dt

In [4]: mask = [True, False]

In [5]: Series(ma([2, 0], mask=mask, dtype=int))
(exception)

In [6]: Series(ma([True, False], mask=mask, dtype=bool))
Out[6]: 
0     True
1    False

In [7]: Series(ma([dt(2006, 1, 1), dt(2007, 1, 1)],
   ...:        mask=mask, dtype='M8[ns]'))
(exception)
```

After fix:

``` python
In [1]: from numpy.ma import MaskedArray as ma
In [2]: from pandas import Series, DataFrame
In [3]: from datetime import datetime as dt

In [4]: mask = [True, False]

In [5]: Series(ma([2, 0], mask=mask, dtype=int))
Out[5]: 
0   NaN
1     0
Dtype: float64

In [6]: Series(ma([True, False], mask=mask, dtype=bool))
Out[6]: 
0      NaN
1    False
Dtype: object

In [7]: Series(ma([dt(2006, 1, 1), dt(2007, 1, 1)],
   ...:        mask=mask, dtype='M8[ns]'))
Out[7]: 
0                   NaT
1   2007-01-01 00:00:00
Dtype: datetime64[ns]
```

The upcasting will only be done if necessary (i.e. if the mask has any `True` elements):

``` python
In [8]: Series(ma([2, 3], mask=[False, False], dtype=int))
Out[8]: 
0    2
1    3
Dtype: int32

In [9]: DataFrame(ma([2, 3], mask=[False, False], dtype=int))
Out[9]: 
   0
0  2
1  3
```

This latter is a minor change to the previous behavior of the DataFrame constructor, which was upcasting correctly but was doing it even if the mask was all `False`: I've changed it to only upcast when necessary because this is more consistent with how masks are treated elsewhere.

Also made some PEP8 line length fixes
