### PR TITLE
BUG: nanops.var produces incorrect results due to int64 overflow (fixes #2888)

### DIFF
--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -138,6 +138,9 @@ def _nanmedian(values, axis=None, skipna=True):
 
 
 def _nanvar(values, axis=None, skipna=True, ddof=1):
+    if not isinstance(values.dtype.type, np.floating):
+        values = values.astype('f8')
+
     mask = isnull(values)
 
     if axis is not None:

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1401,7 +1401,8 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
 
             # check the result is correct
             nona = self.series.dropna()
-            assert_almost_equal(f(nona), alternate(nona))
+            assert_almost_equal(f(nona), alternate(nona.values))
+            assert_almost_equal(f(self.series), alternate(nona.values))
 
             allna = self.series * nan
             self.assert_(np.isnan(f(allna)))
@@ -1409,6 +1410,12 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
             # dtype=object with None, it works!
             s = Series([1, 2, 3, None, 5])
             f(s)
+
+            # 2888
+            l = [0]
+            l.extend(list(range(2**40,2**40+1000)))
+            s = Series(l, dtype='int64')
+            assert_almost_equal(float(f(s)), float(alternate(s.values)))
 
             # check date range
             if check_objects:


### PR DESCRIPTION
fixes #2888
