### PR TITLE
BUG: Series ops with a rhs of a Timestamp raising exception (#2898)

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -77,6 +77,8 @@ pandas 0.11.0
       correctly
     - astype on datetimes to object are now handled (as well as NaT
       conversions to np.nan)
+    - all timedelta like objects will be correctly assigned to ``timedelta64``
+      with mixed ``NaN`` and/or ``NaT`` allowed
 
   - arguments to DataFrame.clip were inconsistent to numpy and Series clipping
     (GH2747_)
@@ -108,6 +110,16 @@ pandas 0.11.0
   - Bug showing up in applymap where some object type columns are converted (GH2909_)
     had an incorrect default in convert_objects
 
+  - TimeDeltas
+
+    - Series ops with a Timestamp on the rhs was throwing an exception (GH2898_)
+      added tests for Series ops with datetimes,timedeltas,Timestamps, and datelike 
+      Series on both lhs and rhs
+    - Series will now set its dtype automatically to ``timedelta64[ns]``
+      if all passed objects are timedelta objects
+    - Support null checking on timedelta64, representing (and formatting) with NaT
+    - Support setitem with np.nan value, converts to NaT
+
 .. _GH622: https://github.com/pydata/pandas/issues/622
 .. _GH797: https://github.com/pydata/pandas/issues/797
 .. _GH2681: https://github.com/pydata/pandas/issues/2681
@@ -121,6 +133,7 @@ pandas 0.11.0
 .. _GH2845: https://github.com/pydata/pandas/issues/2845
 .. _GH2867: https://github.com/pydata/pandas/issues/2867
 .. _GH2807: https://github.com/pydata/pandas/issues/2807
+.. _GH2898: https://github.com/pydata/pandas/issues/2898
 .. _GH2909: https://github.com/pydata/pandas/issues/2909
 
 pandas 0.10.1

--- a/doc/source/dsintro.rst
+++ b/doc/source/dsintro.rst
@@ -912,6 +912,8 @@ method:
    panel.to_frame()
 
 
+.. _dsintro.panel4d:
+
 Panel4D (Experimental)
 ----------------------
 

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -917,3 +917,47 @@ TimeSeries, aligning the data on the UTC timestamps:
    result = eastern + berlin
    result
    result.index
+
+.. _timeseries.timedeltas:
+
+Time Deltas
+-----------
+
+Timedeltas are differences in times, expressed in difference units, e.g. days,hours,minutes,seconds.
+They can be both positive and negative.
+
+.. ipython:: python
+
+    from datetime import datetime, timedelta
+    s  = Series(date_range('2012-1-1', periods=3, freq='D'))
+    td = Series([ timedelta(days=i) for i in range(3) ])
+    df = DataFrame(dict(A = s, B = td))
+    df
+    df['C'] = df['A'] + df['B']
+    df
+    df.dtypes
+
+    s - s.max()
+    s - datetime(2011,1,1,3,5)
+    s + timedelta(minutes=5)
+
+Series of timedeltas with ``NaT`` values are supported
+
+.. ipython:: python
+
+    y = s - s.shift()
+    y
+The can be set to ``NaT`` using ``np.nan`` analagously to datetimes
+
+.. ipython:: python
+
+    y[1] = np.nan
+    y
+
+Operands can also appear in a reversed order (a singluar object operated with a Series)
+
+.. ipython:: python
+
+    s.max() - s
+    datetime(2011,1,1,3,5) - s
+    timedelta(minutes=5) + s

--- a/doc/source/v0.10.0.txt
+++ b/doc/source/v0.10.0.txt
@@ -330,7 +330,7 @@ N Dimensional Panels (Experimental)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Adding experimental support for Panel4D and factory functions to create n-dimensional named panels.
-:ref:`Docs <dsintro-panel4d>` for NDim. Here is a taste of what to expect.
+:ref:`Docs <dsintro.panel4d>` for NDim. Here is a taste of what to expect.
 
      .. ipython:: python
 

--- a/doc/source/v0.11.0.txt
+++ b/doc/source/v0.11.0.txt
@@ -140,10 +140,8 @@ Astype conversion on ``datetime64[ns]`` to ``object``, implicity converts ``NaT`
    s.dtype
 
 
-New features
+Enhancements
 ~~~~~~~~~~~~
-
-**Enhancements**
 
   - In ``HDFStore``, provide dotted attribute access to ``get`` from stores
     (e.g. store.df == store['df'])
@@ -178,7 +176,37 @@ New features
       price. This just obtains the data from Options.get_near_stock_price
       instead of Options.get_xxx_data().
 
-**Bug Fixes**
+Bug Fixes
+~~~~~~~~~
+
+  - Timedeltas are now fully operational (closes GH2898_)
+
+    .. ipython:: python
+
+        from datetime import datetime, timedelta
+        s  = Series(date_range('2012-1-1', periods=3, freq='D'))
+        td = Series([ timedelta(days=i) for i in range(3) ])
+        df = DataFrame(dict(A = s, B = td))
+        df
+        s - s.max()
+        s - datetime(2011,1,1,3,5)
+        s + timedelta(minutes=5)
+        df['C'] = df['A'] + df['B']
+        df
+        df.dtypes
+
+        # timedelta are representas as ``NaT``
+        y = s - s.shift()
+	y
+
+	# can be set via ``np.nan``
+	y[1] = np.nan
+	y
+
+        # works on lhs too
+   	s.max() - s
+        datetime(2011,1,1,3,5) - s
+        timedelta(minutes=5) + s
 
 See the `full release notes
 <https://github.com/pydata/pandas/blob/master/RELEASE.rst>`__ or issue tracker
@@ -187,4 +215,5 @@ on GitHub for a complete list.
 .. _GH2809: https://github.com/pydata/pandas/issues/2809
 .. _GH2810: https://github.com/pydata/pandas/issues/2810
 .. _GH2837: https://github.com/pydata/pandas/issues/2837
+.. _GH2898: https://github.com/pydata/pandas/issues/2898
 

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -1012,6 +1012,8 @@ def format_array(values, formatter, float_format=None, na_rep='NaN',
         fmt_klass = IntArrayFormatter
     elif com.is_datetime64_dtype(values.dtype):
         fmt_klass = Datetime64Formatter
+    elif com.is_timedelta64_dtype(values.dtype):
+        fmt_klass = Timedelta64Formatter
     else:
         fmt_klass = GenericArrayFormatter
 
@@ -1170,7 +1172,6 @@ class Datetime64Formatter(GenericArrayFormatter):
         fmt_values = [formatter(x) for x in self.values]
         return _make_fixed_width(fmt_values, self.justify)
 
-
 def _format_datetime64(x, tz=None):
     if isnull(x):
         return 'NaT'
@@ -1178,6 +1179,24 @@ def _format_datetime64(x, tz=None):
     stamp = lib.Timestamp(x, tz=tz)
     return stamp._repr_base
 
+
+class Timedelta64Formatter(Datetime64Formatter):
+
+    def get_result(self):
+        if self.formatter:
+            formatter = self.formatter
+        else:
+
+            formatter = _format_timedelta64
+
+        fmt_values = [formatter(x) for x in self.values]
+        return _make_fixed_width(fmt_values, self.justify)
+
+def _format_timedelta64(x):
+    if isnull(x):
+        return 'NaT'
+
+    return lib.repr_timedelta64(x)
 
 def _make_fixed_width(strings, justify='right', minimum=None):
     if len(strings) == 0:

--- a/pandas/index.pyx
+++ b/pandas/index.pyx
@@ -482,7 +482,9 @@ cdef class DatetimeEngine(Int64Engine):
 
 cpdef convert_scalar(ndarray arr, object value):
     if arr.descr.type_num == NPY_DATETIME:
-        if isinstance(value, Timestamp):
+        if isinstance(value,np.ndarray):
+            pass
+        elif isinstance(value, Timestamp):
             return value.value
         elif value is None or value != value:
             return iNaT

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -32,7 +32,7 @@ from datetime cimport *
 
 from tslib cimport convert_to_tsobject
 import tslib
-from tslib import NaT, Timestamp
+from tslib import NaT, Timestamp, repr_timedelta64
 
 cdef int64_t NPY_NAT = util.get_nat()
 
@@ -160,6 +160,9 @@ def time64_to_datetime(ndarray[int64_t, ndim=1] arr):
 
     return result
 
+cdef inline int64_t get_timedelta64_value(val):
+    return val.view('i8')
+
 #----------------------------------------------------------------------
 # isnull / notnull related
 
@@ -174,6 +177,8 @@ cpdef checknull(object val):
         return get_datetime64_value(val) == NPY_NAT
     elif val is NaT:
         return True
+    elif util.is_timedelta64_object(val):
+        return get_timedelta64_value(val) == NPY_NAT
     elif is_array(val):
         return False
     else:
@@ -186,6 +191,8 @@ cpdef checknull_old(object val):
         return get_datetime64_value(val) == NPY_NAT
     elif val is NaT:
         return True
+    elif util.is_timedelta64_object(val):
+        return get_timedelta64_value(val) == NPY_NAT
     elif is_array(val):
         return False
     else:

--- a/pandas/src/inference.pyx
+++ b/pandas/src/inference.pyx
@@ -92,6 +92,10 @@ def infer_dtype(object _values):
         if is_unicode_array(values):
             return 'unicode'
 
+    elif is_timedelta(val):
+        if is_timedelta_or_timedelta64_array(values):
+            return 'timedelta'
+
     for i in range(n):
         val = util.get_value_1d(values, i)
         if util.is_integer_object(val):
@@ -265,6 +269,10 @@ def is_datetime64_array(ndarray values):
             return False
     return True
 
+def is_timedelta(object o):
+    import datetime
+    return isinstance(o,datetime.timedelta) or isinstance(o,np.timedelta64)
+
 def is_timedelta_array(ndarray values):
     import datetime
     cdef int i, n = len(values)
@@ -275,6 +283,24 @@ def is_timedelta_array(ndarray values):
             return False
     return True
 
+def is_timedelta64_array(ndarray values):
+    cdef int i, n = len(values)
+    if n == 0:
+        return False
+    for i in range(n):
+        if not isinstance(values[i],np.timedelta64):
+            return False
+    return True
+
+def is_timedelta_or_timedelta64_array(ndarray values):
+    import datetime
+    cdef int i, n = len(values)
+    if n == 0:
+        return False
+    for i in range(n):
+        if not (isinstance(values[i],datetime.timedelta) or isinstance(values[i],np.timedelta64)):
+            return False
+    return True
 
 def is_date_array(ndarray[object] values):
     cdef int i, n = len(values)

--- a/pandas/src/numpy.pxd
+++ b/pandas/src/numpy.pxd
@@ -82,6 +82,7 @@ cdef extern from "numpy/arrayobject.h":
         NPY_COMPLEX512
 
         NPY_DATETIME
+        NPY_TIMEDELTA
 
         NPY_INTP
 

--- a/pandas/src/numpy_helper.h
+++ b/pandas/src/numpy_helper.h
@@ -54,7 +54,6 @@ get_datetime64_value(PyObject* obj) {
 
 }
 
-
 PANDAS_INLINE int
 is_integer_object(PyObject* obj) {
   return (!PyBool_Check(obj)) && PyArray_IsIntegerScalar(obj);
@@ -83,6 +82,11 @@ is_string_object(PyObject* obj) {
 PANDAS_INLINE int
 is_datetime64_object(PyObject *obj) {
   return PyArray_IsScalar(obj, Datetime);
+}
+
+PANDAS_INLINE int
+is_timedelta64_object(PyObject *obj) {
+  return PyArray_IsScalar(obj, Timedelta);
 }
 
 PANDAS_INLINE int

--- a/pandas/src/util.pxd
+++ b/pandas/src/util.pxd
@@ -12,6 +12,7 @@ cdef extern from "numpy_helper.h":
     inline int is_bool_object(object)
     inline int is_string_object(object)
     inline int is_datetime64_object(object)
+    inline int is_timedelta64_object(object)
     inline int assign_value_1d(ndarray, Py_ssize_t, object) except -1
     inline cnp.int64_t get_nat()
     inline object get_value_1d(ndarray, Py_ssize_t)

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -1202,9 +1202,28 @@ class TestSeriesFormatting(unittest.TestCase):
                 self.assert_('+10' in line)
 
     def test_timedelta64(self):
+
+        from pandas import date_range
+        from datetime import datetime
+
         Series(np.array([1100, 20], dtype='timedelta64[s]')).to_string()
         # check this works
         # GH2146
+
+        # adding NaTs
+        s = Series(date_range('2012-1-1', periods=3, freq='D'))
+        y = s-s.shift(1)
+        result = y.to_string()
+        self.assertTrue('1 days, 00:00:00' in result)
+        self.assertTrue('NaT' in result)
+        self.assertTrue('timedelta64[ns]' in result)
+
+        # with frac seconds
+        s = Series(date_range('2012-1-1', periods=3, freq='D'))
+        y = s-datetime(2012,1,1,microsecond=150)
+        result = y.to_string()
+        self.assertTrue('00:00:00.000150' in result)
+        self.assertTrue('timedelta64[ns]' in result)
 
     def test_mixed_datetime64(self):
         df = DataFrame({'A': [1, 2],

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2859,6 +2859,32 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         expected.sort()
         assert_series_equal(result, expected)
 
+    def test_timedeltas(self):
+
+        from pandas import date_range
+        df = DataFrame(dict(A = Series(date_range('2012-1-1', periods=3, freq='D')),
+                            B = Series([ timedelta(days=i) for i in range(3) ])))
+        result = df.get_dtype_counts()
+        expected = Series({'datetime64[ns]': 1, 'timedelta64[ns]' : 1 })
+        result.sort()
+        expected.sort()
+        assert_series_equal(result, expected)
+
+        df['C'] = df['A'] + df['B']
+        expected = Series({'datetime64[ns]': 2, 'timedelta64[ns]' : 1 })
+        result = df.get_dtype_counts()
+        result.sort()
+        expected.sort()
+        assert_series_equal(result, expected)
+
+        # mixed int types
+        df['D'] = 1
+        expected = Series({'datetime64[ns]': 2, 'timedelta64[ns]' : 1, 'int64' : 1 })
+        result = df.get_dtype_counts()
+        result.sort()
+        expected.sort()
+        assert_series_equal(result, expected)
+
     def test_new_empty_index(self):
         df1 = DataFrame(randn(0, 3))
         df2 = DataFrame(randn(0, 3))

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -443,8 +443,10 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         s = Series(tslib.iNaT, dtype='M8[ns]', index=range(5))
         self.assert_(isnull(s).all() == True)
 
-        s = Series(tslib.NaT, dtype='M8[ns]', index=range(5))
-        self.assert_(isnull(s).all() == True)
+        #### in theory this should be all nulls, but since
+        #### we are not specifying a dtype is ambiguous
+        s = Series(tslib.iNaT, index=range(5))
+        self.assert_(isnull(s).all() == False)
 
         s = Series(nan, dtype='M8[ns]', index=range(5))
         self.assert_(isnull(s).all() == True)
@@ -1667,12 +1669,126 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         # it works!
         _ = s1 * s2
 
-    def test_operators_datetime64(self):
+    def test_constructor_dtype_timedelta64(self):
+
+        td = Series([ timedelta(days=i) for i in range(3) ])
+        self.assert_(td.dtype=='timedelta64[ns]')
+
+        # mixed with NaT
+        from pandas import tslib
+        td = Series([ timedelta(days=i) for i in range(3) ] + [ tslib.NaT ], dtype='m8[ns]' )
+        self.assert_(td.dtype=='timedelta64[ns]')
+
+        td = Series([ timedelta(days=i) for i in range(3) ] + [ tslib.iNaT ], dtype='m8[ns]' )
+        self.assert_(td.dtype=='timedelta64[ns]')
+
+        td = Series([ timedelta(days=i) for i in range(3) ] + [ np.nan ], dtype='m8[ns]' )
+        self.assert_(td.dtype=='timedelta64[ns]')
+
+        # this is an invalid casting
+        self.assertRaises(Exception, Series, [ timedelta(days=i) for i in range(3) ] + [ 'foo' ], dtype='m8[ns]' )
+
+        # leave as object here
+        td = Series([ timedelta(days=i) for i in range(3) ] + [ 'foo' ])
+        self.assert_(td.dtype=='object')
+
+    def test_operators_timedelta64(self):
+
+        # invalid ops
+        self.assertRaises(Exception, self.objSeries.__add__, 1)
+        self.assertRaises(Exception, self.objSeries.__add__, np.array(1,dtype=np.int64))
+        self.assertRaises(Exception, self.objSeries.__sub__, 1)
+        self.assertRaises(Exception, self.objSeries.__sub__, np.array(1,dtype=np.int64))
+
+        # seriese ops
         v1 = date_range('2012-1-1', periods=3, freq='D')
         v2 = date_range('2012-1-2', periods=3, freq='D')
         rs = Series(v2) - Series(v1)
         xp = Series(1e9 * 3600 * 24, rs.index).astype('timedelta64[ns]')
         assert_series_equal(rs, xp)
+        self.assert_(rs.dtype=='timedelta64[ns]')
+
+        df = DataFrame(dict(A = v1))
+        td = Series([ timedelta(days=i) for i in range(3) ])
+        self.assert_(td.dtype=='timedelta64[ns]')
+
+        # series on the rhs
+        result = df['A'] - df['A'].shift()
+        self.assert_(result.dtype=='timedelta64[ns]')
+
+        result = df['A'] + td
+        self.assert_(result.dtype=='M8[ns]')
+
+        # scalar Timestamp on rhs
+        maxa = df['A'].max()
+        self.assert_(isinstance(maxa,Timestamp))
+
+        resultb = df['A']- df['A'].max()
+        self.assert_(resultb.dtype=='timedelta64[ns]')
+
+        # timestamp on lhs
+        result = resultb + df['A']
+        expected = Series([Timestamp('20111230'),Timestamp('20120101'),Timestamp('20120103')])
+        assert_series_equal(result,expected)
+
+        # datetimes on rhs
+        result = df['A'] - datetime(2001,1,1)
+        self.assert_(result.dtype=='timedelta64[ns]')
+        
+        result = df['A'] + datetime(2001,1,1)
+        self.assert_(result.dtype=='timedelta64[ns]')
+
+        td = datetime(2001,1,1,3,4)
+        resulta = df['A'] - td
+        self.assert_(resulta.dtype=='timedelta64[ns]')
+        
+        resultb = df['A'] + td
+        self.assert_(resultb.dtype=='timedelta64[ns]')
+
+        # timedelta on lhs
+        result = resultb + td
+        self.assert_(resultb.dtype=='timedelta64[ns]')
+
+        # timedeltas on rhs
+        td = timedelta(days=1)
+        resulta = df['A'] + td
+        resultb = resulta - td
+        assert_series_equal(resultb,df['A'])
+
+        td = timedelta(minutes=5,seconds=3)
+        resulta = df['A'] + td
+        resultb = resulta - td
+        self.assert_(resultb.dtype=='M8[ns]')
+
+    def test_timedelta64_nan(self):
+
+        from pandas import tslib
+        td = Series([ timedelta(days=i) for i in range(10) ])
+
+        # nan ops on timedeltas
+        td1 = td.copy()
+        td1[0] = np.nan
+        self.assert_(isnull(td1[0]) == True)
+        self.assert_(td1[0].view('i8') == tslib.iNaT)
+        td1[0] = td[0]
+        self.assert_(isnull(td1[0]) == False)
+
+        td1[1] = tslib.iNaT
+        self.assert_(isnull(td1[1]) == True)
+        self.assert_(td1[1].view('i8') == tslib.iNaT)
+        td1[1] = td[1]
+        self.assert_(isnull(td1[1]) == False)
+
+        td1[2] = tslib.NaT
+        self.assert_(isnull(td1[2]) == True)
+        self.assert_(td1[2].view('i8') == tslib.iNaT)
+        td1[2] = td[2]
+        self.assert_(isnull(td1[2]) == False)
+
+        ####  boolean setting
+        #### this doesn't work, not sure numpy even supports it
+        #result = td[(td>np.timedelta64(timedelta(days=3))) & (td<np.timedelta64(timedelta(days=7)))] = np.nan
+        #self.assert_(isnull(result).sum() == 7)
 
     # NumPy limitiation =(
 
@@ -1883,10 +1999,6 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         # all NaNs
         allna = self.series * nan
         self.assert_(isnull(allna.idxmax()))
-
-    def test_operators_date(self):
-        result = self.objSeries + timedelta(1)
-        result = self.objSeries - timedelta(1)
 
     def test_operators_corner(self):
         series = self.ts
@@ -2170,6 +2282,7 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         assert_series_equal(hist, expected)
 
     def test_unique(self):
+
         # 714 also, dtype=float
         s = Series([1.2345] * 100)
         s[::2] = np.nan


### PR DESCRIPTION
- Series ops with a rhs of a Timestamp was throwing an exception (#2898)
- fixed issue in _index.convert_scalar where the rhs was a non-scalar, lhs was dtype of M8[ns], and was trying
  to convert to a scalar (but didn't need conversion)
- added some utilities in tslib.pyx, inference.pyx to detect and convert timedelta/timedelta64
- added timedelta64 to checknull routines, representing timedelta64 as NaT
- aded setitem support to set NaT via np.nan (analagously to datetime64)
- added ability for Series to detect and set a `timedelta64[ns]` dtype (if all passed objects are timedelta like)
- added correct printing of timedelta64[ns](looks like py3.3 changed the default for str%28x%29, so rolled a new one)

```
In [149]: from datetime import datetime, timedelta

In [150]: s  = Series(date_range('2012-1-1', periods=3, freq='D'))

In [151]: td = Series([ timedelta(days=i) for i in range(3) ])

In [152]: df = DataFrame(dict(A = s, B = td))

In [153]: df
Out[153]: 
                    A                B
0 2012-01-01 00:00:00          0:00:00
1 2012-01-02 00:00:00   1 day, 0:00:00
2 2012-01-03 00:00:00  2 days, 0:00:00

In [154]: df['C'] = df['A'] + df['B']

In [155]: df
Out[155]: 
                    A                B                   C
0 2012-01-01 00:00:00          0:00:00 2012-01-01 00:00:00
1 2012-01-02 00:00:00   1 day, 0:00:00 2012-01-03 00:00:00
2 2012-01-03 00:00:00  2 days, 0:00:00 2012-01-05 00:00:00

In [156]: df.dtypes
Out[156]: 
A     datetime64[ns]
B    timedelta64[ns]
C     datetime64[ns]
Dtype: object

In [60]: s - s.max()
Out[60]: 
0    -2 days, 0:00:00
1     -1 day, 0:00:00
2             0:00:00
Dtype: timedelta64[ns]

In [61]: s - datetime(2011,1,1,3,5)
Out[61]: 
0    364 days, 20:55:00
1    365 days, 20:55:00
2    366 days, 20:55:00
Dtype: timedelta64[ns]

In [62]: s + timedelta(minutes=5)
Out[62]: 
0   2012-01-01 00:05:00
1   2012-01-02 00:05:00
2   2012-01-03 00:05:00
Dtype: datetime64[ns]

In [160]: y = s - s.shift()

In [161]: y
Out[161]: 
0              NaT
1   1 day, 0:00:00
2   1 day, 0:00:00
Dtype: timedelta64[ns]

The can be set to NaT using np.nan analagously to datetimes

In [162]: y[1] = np.nan

In [163]: y
Out[163]: 
0              NaT
1              NaT
2   1 day, 0:00:00
Dtype: timedelta64[ns]

# works on lhs too
In [64]: s.max() - s
Out[64]: 
0    2 days, 0:00:00
1     1 day, 0:00:00
2            0:00:00
Dtype: timedelta64[ns]

In [65]: datetime(2011,1,1,3,5) - s
Out[65]: 
0    -365 days, 3:05:00
1    -366 days, 3:05:00
2    -367 days, 3:05:00
Dtype: timedelta64[ns]

In [66]: timedelta(minutes=5) + s
Out[66]: 
0   2012-01-01 00:05:00
1   2012-01-02 00:05:00
2   2012-01-03 00:05:00
Dtype: datetime64[ns]
```
