### PR TITLE
BUG: support data column indexers that have a large numbers of values

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -98,6 +98,8 @@ pandas 0.11.0
   - ``HDFStore``
 
     - Fix weird PyTables error when using too many selectors in a where
+      also correctly filter on any number of values in a Term expression
+      (so not using numexpr filtering, but isin filtering)
     - Provide dotted attribute access to ``get`` from stores
       (e.g. store.df == store['df'])
     - Internally, change all variables to be private-like (now have leading


### PR DESCRIPTION
This is conceptually (and implemented) like an `isin`

You can give a list of values that you want for a particular column, rather
than a boolean expression. This was already speced in the API, just
not implemented correctly!

Something like this

```
store.select('df',[pd.Term('users',[ 'a%03d' % i for i in xrange(60) ])])
```

originally from the mailing list
https://groups.google.com/forum/?fromgroups#!topic/pystatsmodels/oTjfOb0gazw
