### PR TITLE
CLN: refactor of frame.py/panel.py to move common code to generic.py

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -177,6 +177,7 @@ pandas 0.11.0
 
   - Bug showing up in applymap where some object type columns are converted (GH2909_)
     had an incorrect default in convert_objects
+  - Reindex called with no arguments will now return a copy of the input object
 
   - TimeDeltas
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -22,6 +22,42 @@ Where to get it
 * Binary installers on PyPI: http://pypi.python.org/pypi/pandas
 * Documentation: http://pandas.pydata.org
 
+pandas 0.12.0
+=============
+
+**Release date:** 2013-??-??
+
+**New features**
+
+**Improvements to existing features**
+
+**API Changes**
+
+  - Refactor of frame.py/panel.py to move common code to generic.py
+    all axis creation code is common (including Series), most common
+    code is moved to generic.py
+
+    - added _setup_axes to created generic NDFrame structures
+    - moved methods
+
+      - from_axes,_wrap_array,axes,ix,shape,empty,swapaxes,transpose,pop
+      - __str__,__bytes__,__repr__
+      - __iter__,keys,__contains__,__len__,__neg__,__invert__
+      - convert_objects,as_blocks,as_matrix,values
+      - __getstate__,__setstate__ (though compat remains in frame/panel)
+      - __getattr__,__setattr__
+      - _indexed_same,reindex_like,reindex,align,where,mask
+      - filter (also added axis argument to selectively filter on a different axis)
+      - reindex,reindex_axis (which was the biggest change to make generic)
+      - truncate (moved to become part of PandasObject)
+
+    These are API changes which make Panel more consistent with DataFrame
+    - swapaxes on a Panel with the same axes specified now return a copy 
+    - support attribute access for setting
+    - filter supports same api as original DataFrame filter
+
+  - Reindex called with no arguments will now return a copy of the input object
+
 pandas 0.11.0
 =============
 
@@ -130,30 +166,6 @@ pandas 0.11.0
 
   - arguments to DataFrame.clip were inconsistent to numpy and Series clipping
     (GH2747_)
-  - Refactor of frame.py/panel.py to move common code to generic.py
-    all axis creation code is common (including Series), most common
-    code is moved to generic.py
-
-    - added _setup_axes to created generic NDFrame structures
-    - moved methods
-
-      - from_axes,_wrap_array,axes,ix,shape,empty,swapaxes,transpose,pop
-      - __str__,__bytes__,__repr__
-      - __iter__,keys,__contains__,__len__,__neg__,__invert__
-      - convert_objects,as_blocks,as_matrix,values
-      - __getstate__,__setstate__ (though compat remains in frame/panel)
-      - __getattr__,__setattr__
-      - _indexed_same,reindex_like,reindex,align,where,mask
-      - filter (also added axis argument to selectively filter on a different axis)
-      - reindex,reindex_axis (which was the biggest change to make generic)
-      - truncate (moved to become part of PandasObject)
-
-    These are API changes which make Panel more consistent with DataFrame
-    - swapaxes on a Panel with the same axes specified now return a copy 
-    - support attribute access for setting
-    - filter supports same api as original DataFrame filter
-
-  - Reindex called with no arguments will now return a copy of the input object
 
 **Bug Fixes**
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -131,10 +131,11 @@ pandas 0.11.0
   - arguments to DataFrame.clip were inconsistent to numpy and Series clipping
     (GH2747_)
   - Refactor of frame.py/panel.py to move common code to generic.py
-    all axis creation and manipulation code is now common (except for Series)
+    all axis creation code is common (including Series), most common
+    code is moved to generic.py
 
     - added _setup_axes to created generic NDFrame structures
-    - moved methods (some methods moved from series as well)
+    - moved methods
 
       - from_axes,_wrap_array,axes,ix,shape,empty,swapaxes,transpose,pop
       - __str__,__bytes__,__repr__
@@ -142,14 +143,17 @@ pandas 0.11.0
       - convert_objects,as_blocks,as_matrix,values
       - __getstate__,__setstate__ (though compat remains in frame/panel)
       - __getattr__,__setattr__
-      - _indexed_same,reindex_like,reindex
-        (sparse.py required some changes)
+      - _indexed_same,reindex_like,reindex,align,where,mask
+      - filter (also added axis argument to selectively filter on a different axis)
+      - reindex,reindex_axis (which was the biggest change to make generic)
+      - truncate (moved to become part of PandasObject)
 
     These are API changes which make Panel more consistent with DataFrame
     - swapaxes on a Panel with the same axes specified now return a copy 
     - support attribute access for setting
+    - filter supports same api as original DataFrame filter
 
-
+  - Reindex called with no arguments will now return a copy of the input object
 
 **Bug Fixes**
 
@@ -177,7 +181,6 @@ pandas 0.11.0
 
   - Bug showing up in applymap where some object type columns are converted (GH2909_)
     had an incorrect default in convert_objects
-  - Reindex called with no arguments will now return a copy of the input object
 
   - TimeDeltas
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -130,6 +130,22 @@ pandas 0.11.0
 
   - arguments to DataFrame.clip were inconsistent to numpy and Series clipping
     (GH2747_)
+  - Refactor of series.py/frame.py/panel.py to move common code to generic.py
+    all axis creation and manipulation code is now common (except for Series)
+
+    - added _setup_axes to created generic NDFrame structures
+    - moved methods
+
+      - from_axes,_wrap_array,axes,ix,shape,empty,swapaxes,transpose,pop
+      - __str__,__bytes__,__repr__
+      - __iter__,keys,__contains__,__len__,__neg__,__invert__
+      - convert_objects,as_blocks
+      - _indexed_same
+
+    - swapaxes on a Panel with the same axes specified now return a copy 
+      (consistent with DataFrame)
+
+
 
 **Bug Fixes**
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -130,20 +130,24 @@ pandas 0.11.0
 
   - arguments to DataFrame.clip were inconsistent to numpy and Series clipping
     (GH2747_)
-  - Refactor of series.py/frame.py/panel.py to move common code to generic.py
+  - Refactor of frame.py/panel.py to move common code to generic.py
     all axis creation and manipulation code is now common (except for Series)
 
     - added _setup_axes to created generic NDFrame structures
-    - moved methods
+    - moved methods (some methods moved from series as well)
 
       - from_axes,_wrap_array,axes,ix,shape,empty,swapaxes,transpose,pop
       - __str__,__bytes__,__repr__
       - __iter__,keys,__contains__,__len__,__neg__,__invert__
-      - convert_objects,as_blocks
-      - _indexed_same
+      - convert_objects,as_blocks,as_matrix,values
+      - __getstate__,__setstate__ (though compat remains in frame/panel)
+      - __getattr__,__setattr__
+      - _indexed_same,reindex_like,reindex
+        (sparse.py required some changes)
 
+    These are API changes which make Panel more consistent with DataFrame
     - swapaxes on a Panel with the same axes specified now return a copy 
-      (consistent with DataFrame)
+    - support attribute access for setting
 
 
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1553,22 +1553,6 @@ class DataFrame(NDFrame):
     #----------------------------------------------------------------------
     # Picklability
 
-    def __getstate__(self):
-        return self._data
-
-    def __setstate__(self, state):
-        # old DataFrame pickle
-        if isinstance(state, BlockManager):
-            self._data = state
-        elif isinstance(state[0], dict):  # pragma: no cover
-            self._unpickle_frame_compat(state)
-        else:  # pragma: no cover
-            # old pickling format, for compatibility
-            self._unpickle_matrix_compat(state)
-
-        # ordinarily created in NDFrame
-        self._item_cache = {}
-
     # legacy pickle formats
     def _unpickle_frame_compat(self, state):  # pragma: no cover
         from pandas.core.common import _unpickle_array
@@ -1602,15 +1586,6 @@ class DataFrame(NDFrame):
         self._data = dm._data
 
     #----------------------------------------------------------------------
-    # Array interface
-
-    def __array__(self, dtype=None):
-        return self.values
-
-    def __array_wrap__(self, result):
-        return self._constructor(result, index=self.index,
-                                 columns=self.columns, copy=False)
-
     #----------------------------------------------------------------------
     # Getting and setting elements
 
@@ -1799,12 +1774,9 @@ class DataFrame(NDFrame):
         return self.where(key)
 
     def _slice(self, slobj, axis=0, raise_on_error=False):
-        if axis == 0:
-            mgr_axis = 1
-        else:
-            mgr_axis = 0
-
-        new_data = self._data.get_slice(slobj, axis=mgr_axis, raise_on_error=raise_on_error)
+        axis = self._get_block_manager_axis(axis)
+        new_data = self._data.get_slice(slobj, axis=axis)
+        new_data = self._data.get_slice(slobj, axis=axis, raise_on_error=raise_on_error)
         return self._constructor(new_data)
 
     def _box_item_values(self, key, values):
@@ -1813,31 +1785,6 @@ class DataFrame(NDFrame):
             return DataFrame(values.T, columns=items, index=self.index)
         else:
             return Series.from_array(values, index=self.index, name=items)
-
-    def __getattr__(self, name):
-        """After regular attribute access, try looking up the name of a column.
-        This allows simpler access to columns for interactive use."""
-        if name in self.columns:
-            return self[name]
-        raise AttributeError("'%s' object has no attribute '%s'" %
-                             (type(self).__name__, name))
-
-    def __setattr__(self, name, value):
-        """After regular attribute access, try looking up the name of a column.
-        This allows simpler access to columns for interactive use."""
-        if name == '_data':
-            super(DataFrame, self).__setattr__(name, value)
-        else:
-            try:
-                existing = getattr(self, name)
-                if isinstance(existing, Index):
-                    super(DataFrame, self).__setattr__(name, value)
-                elif name in self.columns:
-                    self[name] = value
-                else:
-                    object.__setattr__(self, name, value)
-            except (AttributeError, TypeError):
-                object.__setattr__(self, name, value)
 
     def __setitem__(self, key, value):
         if isinstance(key, slice):
@@ -2224,12 +2171,13 @@ class DataFrame(NDFrame):
                     self.columns.join(other.columns, how=join, level=level,
                                       return_indexers=True)
 
-        left = self._reindex_with_indexers(join_index, ilidx,
-                                           join_columns, clidx, copy,
-                                           fill_value=fill_value)
-        right = other._reindex_with_indexers(join_index, iridx,
-                                             join_columns, cridx, copy,
-                                             fill_value=fill_value)
+        left  = self._reindex_with_indexers({ 0 : [ join_index,   ilidx ],
+                                              1 : [ join_columns, clidx ] },
+                                            copy=copy, fill_value=fill_value)
+        right = other._reindex_with_indexers({ 0 : [ join_index,   iridx ],
+                                               1 : [ join_columns, cridx ] }, 
+                                             copy=copy, fill_value=fill_value)
+            
 
         if method is not None:
             left = left.fillna(axis=fill_axis, method=method, limit=limit)
@@ -2278,115 +2226,40 @@ class DataFrame(NDFrame):
         else:
             return left_result, right_result
 
-    def reindex(self, index=None, columns=None, method=None, level=None,
-                fill_value=NA, limit=None, copy=True):
-        """Conform DataFrame to new index with optional filling logic, placing
-        NA/NaN in locations having no value in the previous index. A new object
-        is produced unless the new index is equivalent to the current one and
-        copy=False
+    def _reindex_axes(self, axes, level, limit, method, fill_value, copy):
+      frame = self
 
-        Parameters
-        ----------
-        index : array-like, optional
-            New labels / index to conform to. Preferably an Index object to
-            avoid duplicating data
-        columns : array-like, optional
-            Same usage as index argument
-        method : {'backfill', 'bfill', 'pad', 'ffill', None}, default None
-            Method to use for filling holes in reindexed DataFrame
-            pad / ffill: propagate last valid observation forward to next valid
-            backfill / bfill: use NEXT valid observation to fill gap
-        copy : boolean, default True
-            Return a new object, even if the passed indexes are the same
-        level : int or name
-            Broadcast across a level, matching Index values on the
-            passed MultiIndex level
-        fill_value : scalar, default np.NaN
-            Value to use for missing values. Defaults to NaN, but can be any
-            "compatible" value
-        limit : int, default None
-            Maximum size gap to forward or backward fill
-
-        Examples
-        --------
-        >>> df.reindex(index=[date1, date2, date3], columns=['A', 'B', 'C'])
-
-        Returns
-        -------
-        reindexed : same type as calling instance
-        """
-        self._consolidate_inplace()
-        frame = self
-
-        if (index is not None and columns is not None
-            and method is None and level is None
-                and not self._is_mixed_type):
-            return self._reindex_multi(index, columns, copy, fill_value)
-
-        if columns is not None:
-            frame = frame._reindex_columns(columns, copy, level,
-                                           fill_value, limit)
-
-        if index is not None:
-            frame = frame._reindex_index(index, method, copy, level,
+      columns = axes['columns']
+      if columns is not None:
+          frame = frame._reindex_columns(columns, copy, level,
                                          fill_value, limit)
 
-        return frame
+      index = axes['index']
+      if index is not None:
+          frame = frame._reindex_index(index, method, copy, level,
+                                       fill_value, limit)
 
-    def reindex_axis(self, labels, axis=0, method=None, level=None, copy=True,
-                     limit=None, fill_value=NA):
-        """Conform DataFrame to new index with optional filling logic, placing
-        NA/NaN in locations having no value in the previous index. A new object
-        is produced unless the new index is equivalent to the current one and
-        copy=False
+      return frame
 
-        Parameters
-        ----------
-        index : array-like, optional
-            New labels / index to conform to. Preferably an Index object to
-            avoid duplicating data
-        axis : {0, 1}
-            0 -> index (rows)
-            1 -> columns
-        method : {'backfill', 'bfill', 'pad', 'ffill', None}, default None
-            Method to use for filling holes in reindexed DataFrame
-            pad / ffill: propagate last valid observation forward to next valid
-            backfill / bfill: use NEXT valid observation to fill gap
-        copy : boolean, default True
-            Return a new object, even if the passed indexes are the same
-        level : int or name
-            Broadcast across a level, matching Index values on the
-            passed MultiIndex level
-        limit : int, default None
-            Maximum size gap to forward or backward fill
+    def _reindex_index(self, new_index, method, copy, level, fill_value=NA,
+                       limit=None):
+        new_index, indexer = self.index.reindex(new_index, method, level,
+                                                limit=limit)
+        return self._reindex_with_indexers({ 0 : [ new_index, indexer ] }, 
+                                           copy=copy, fill_value=fill_value)
 
-        Examples
-        --------
-        >>> df.reindex_axis(['A', 'B', 'C'], axis=1)
+    def _reindex_columns(self, new_columns, copy, level, fill_value=NA,
+                         limit=None):
+        new_columns, indexer = self.columns.reindex(new_columns, level=level,
+                                                    limit=limit)
+        return self._reindex_with_indexers({ 1 : [ new_columns, indexer ] }, 
+                                           copy=copy, fill_value=fill_value)
 
-        See also
-        --------
-        DataFrame.reindex, DataFrame.reindex_like
+    def _reindex_multi(self, axes, copy, fill_value):
+        """ we are guaranteed non-Nones in the axes! """
 
-        Returns
-        -------
-        reindexed : same type as calling instance
-        """
-        self._consolidate_inplace()
-        if axis == 0:
-            return self._reindex_index(labels, method, copy, level,
-                                       fill_value=fill_value,
-                                       limit=limit)
-        elif axis == 1:
-            return self._reindex_columns(labels, copy, level,
-                                         fill_value=fill_value,
-                                         limit=limit)
-        else:  # pragma: no cover
-            raise ValueError('Must specify axis=0 or 1')
-
-    def _reindex_multi(self, new_index, new_columns, copy, fill_value):
-        new_index, row_indexer = self.index.reindex(new_index)
-        new_columns, col_indexer = self.columns.reindex(new_columns)
+        new_index, row_indexer = self.index.reindex(axes['index'])
+        new_columns, col_indexer = self.columns.reindex(axes['columns'])
 
         if row_indexer is not None and col_indexer is not None:
             indexer = row_indexer, col_indexer
@@ -2394,80 +2267,11 @@ class DataFrame(NDFrame):
                                            fill_value=fill_value)
             return DataFrame(new_values, index=new_index, columns=new_columns)
         elif row_indexer is not None:
-            return self._reindex_with_indexers(new_index, row_indexer,
-                                               None, None, copy, fill_value)
+            return self._reindex_with_indexers({ 0 : [ new_index,   row_indexer ] }, copy=copy, fill_value=fill_value)
         elif col_indexer is not None:
-            return self._reindex_with_indexers(None, None,
-                                               new_columns, col_indexer,
-                                               copy, fill_value)
+            return self._reindex_with_indexers({ 1 : [ new_columns, col_indexer ] }, copy=copy, fill_value=fill_value)
         else:
             return self.copy() if copy else self
-
-    def _reindex_index(self, new_index, method, copy, level, fill_value=NA,
-                       limit=None):
-        new_index, indexer = self.index.reindex(new_index, method, level,
-                                                limit=limit)
-        return self._reindex_with_indexers(new_index, indexer, None, None,
-                                           copy, fill_value)
-
-    def _reindex_columns(self, new_columns, copy, level, fill_value=NA,
-                         limit=None):
-        new_columns, indexer = self.columns.reindex(new_columns, level=level,
-                                                    limit=limit)
-        return self._reindex_with_indexers(None, None, new_columns, indexer,
-                                           copy, fill_value)
-
-    def _reindex_with_indexers(self, index, row_indexer, columns, col_indexer,
-                               copy, fill_value):
-        new_data = self._data
-        if row_indexer is not None:
-            row_indexer = com._ensure_int64(row_indexer)
-            new_data = new_data.reindex_indexer(index, row_indexer, axis=1,
-                                                fill_value=fill_value)
-        elif index is not None and index is not new_data.axes[1]:
-            new_data = new_data.copy(deep=copy)
-            new_data.axes[1] = index
-
-        if col_indexer is not None:
-            # TODO: speed up on homogeneous DataFrame objects
-            col_indexer = com._ensure_int64(col_indexer)
-            new_data = new_data.reindex_indexer(columns, col_indexer, axis=0,
-                                                fill_value=fill_value)
-        elif columns is not None and columns is not new_data.axes[0]:
-            new_data = new_data.reindex_items(columns, copy=copy,
-                                              fill_value=fill_value)
-
-        if copy and new_data is self._data:
-            new_data = new_data.copy()
-
-        return DataFrame(new_data)
-
-    def reindex_like(self, other, method=None, copy=True, limit=None,
-                     fill_value=NA):
-        """
-        Reindex DataFrame to match indices of another DataFrame, optionally
-        with filling logic
-
-        Parameters
-        ----------
-        other : DataFrame
-        method : string or None
-        copy : boolean, default True
-        limit : int, default None
-            Maximum size gap to forward or backward fill
-
-        Notes
-        -----
-        Like calling s.reindex(index=other.index, columns=other.columns,
-                               method=...)
-
-        Returns
-        -------
-        reindexed : DataFrame
-        """
-        return self.reindex(index=other.index, columns=other.columns,
-                            method=method, copy=copy, limit=limit,
-                            fill_value=fill_value)
 
     truncate = generic.truncate
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -544,6 +544,13 @@ class DataFrame(NDFrame):
         block = make_block(values.T, columns, columns)
         return BlockManager([block], [columns, index])
 
+    @property
+    def _verbose_info(self):
+        import warnings
+        warnings.warn('The _verbose_info property will be removed in version '
+                      '0.12', FutureWarning)
+        return get_option('display.max_info_rows') is None
+
     @_verbose_info.setter
     def _verbose_info(self, value):
         import warnings

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1,14 +1,17 @@
 # pylint: disable=W0231,E1101
 
+import operator
 import numpy as np
 
 from pandas.core.index import MultiIndex
 import pandas.core.indexing as indexing
 from pandas.core.indexing import _maybe_convert_indices
 from pandas.tseries.index import DatetimeIndex
+from pandas.core.internals import BlockManager
+from pandas.core.indexing import _NDFrameIndexer
 import pandas.core.common as com
 import pandas.lib as lib
-
+from pandas.util import py3compat
 
 class PandasError(Exception):
     pass
@@ -16,23 +19,93 @@ class PandasError(Exception):
 
 class PandasObject(object):
 
-    _AXIS_NUMBERS = {
-        'index': 0,
-        'columns': 1
-    }
+    #----------------------------------------------------------------------
+    # Construction
 
-    _AXIS_ALIASES = {}
-    _AXIS_NAMES = dict((v, k) for k, v in _AXIS_NUMBERS.iteritems())
+    @property
+    def _constructor(self):
+        raise NotImplementedError
 
-    def save(self, path):
-        com.save(self, path)
-
-    @classmethod
-    def load(cls, path):
-        return com.load(path)
+    @property
+    def _constructor_sliced(self):
+        raise NotImplementedError
 
     #----------------------------------------------------------------------
-    # Axis name business
+    # Axis
+
+    @classmethod
+    def _setup_axes(cls, axes, info_axis = None, stat_axis = None, aliases = None, slicers = None,
+                    axes_are_reversed = False, build_axes = True):
+        """ provide axes setup for the major PandasObjects
+
+            axes : the names of the axes in order (lowest to highest)
+            info_axis_num : the axis of the selector dimension (int)
+            stat_axis_num : the number of axis for the default stats (int)
+            aliases : other names for a single axis (dict)
+            slicers : how axes slice to others (dict)
+            axes_are_reversed : boolean whether to treat passed axes as reversed (DataFrame)
+            build_axes : setup the axis properties (default True)
+            """
+
+        cls._AXIS_ORDERS  = axes
+        cls._AXIS_NUMBERS = dict([(a, i) for i, a in enumerate(axes) ])
+        cls._AXIS_LEN     = len(axes)
+        cls._AXIS_ALIASES = aliases or dict()
+        cls._AXIS_NAMES   = dict([(i, a) for i, a in enumerate(axes) ])
+        cls._AXIS_SLICEMAP = slicers or None
+        cls._AXIS_REVERSED = axes_are_reversed
+
+        # indexing support
+        cls._ix = None
+
+        if info_axis is not None:
+            cls._info_axis_number = info_axis
+            cls._info_axis_name   = axes[info_axis]
+
+        if stat_axis is not None:
+            cls._stat_axis_number = stat_axis
+            cls._stat_axis_name   = axes[stat_axis]
+
+        # setup the actual axis
+        if build_axes:
+            if axes_are_reversed:
+                m = cls._AXIS_LEN-1
+                for i, a in cls._AXIS_NAMES.items():
+                    setattr(cls,a,lib.AxisProperty(m-i))
+            else:
+                for i, a in cls._AXIS_NAMES.items():
+                    setattr(cls,a,lib.AxisProperty(i))
+
+    def _construct_axes_dict(self, axes=None, **kwargs):
+        """ return an axes dictionary for myself """
+        d = dict([(a, getattr(self, a)) for a in (axes or self._AXIS_ORDERS)])
+        d.update(kwargs)
+        return d
+
+    @staticmethod
+    def _construct_axes_dict_from(self, axes, **kwargs):
+        """ return an axes dictionary for the passed axes """
+        d = dict([(a, ax) for a, ax in zip(self._AXIS_ORDERS, axes)])
+        d.update(kwargs)
+        return d
+
+    def _construct_axes_dict_for_slice(self, axes=None, **kwargs):
+        """ return an axes dictionary for myself """
+        d = dict([(self._AXIS_SLICEMAP[a], getattr(self, a))
+                 for a in (axes or self._AXIS_ORDERS)])
+        d.update(kwargs)
+        return d
+
+    @classmethod
+    def _from_axes(cls, data, axes):
+        # for construction from BlockManager
+        if isinstance(data, BlockManager):
+            return cls(data)
+        else:
+            if cls._AXIS_REVERSED:
+                axes = axes[::-1]
+            d = cls._construct_axes_dict_from(cls, axes, copy=False)
+            return cls(data, **d)
 
     @classmethod
     def _get_axis_number(cls, axis):
@@ -42,7 +115,7 @@ class PandasObject(object):
             if axis in cls._AXIS_NAMES:
                 return axis
             else:
-                raise Exception('No %d axis' % axis)
+                raise ValueError('No %d axis' % axis)
         else:
             return cls._AXIS_NUMBERS[axis]
 
@@ -53,13 +126,21 @@ class PandasObject(object):
             if axis in cls._AXIS_NUMBERS:
                 return axis
             else:
-                raise Exception('No axis named %s' % axis)
+                raise ValueError('No axis named %s' % axis)
         else:
             return cls._AXIS_NAMES[axis]
 
     def _get_axis(self, axis):
         name = self._get_axis_name(axis)
         return getattr(self, name)
+
+    @property
+    def _info_axis(self):
+        return getattr(self, self._info_axis_name)
+
+    @property
+    def _stat_axis(self):
+        return getattr(self, self._stat_axis_name)
 
     #----------------------------------------------------------------------
     # Indexers
@@ -75,6 +156,105 @@ class PandasObject(object):
             return getattr(self,iname)
 
         setattr(cls,name,property(_indexer))
+
+    #----------------------------------------------------------------------
+    # Reconstruction
+
+    def save(self, path):
+        com.save(self, path)
+
+    @classmethod
+    def load(cls, path):
+        return com.load(path)
+
+    #----------------------------------------------------------------------
+    # Comparisons
+
+    def _indexed_same(self, other):
+        return all([getattr(self, a).equals(getattr(other, a)) for a in self._AXIS_ORDERS])
+
+    def reindex(self, *args, **kwds):
+        raise NotImplementedError
+
+    def __neg__(self):
+        arr = operator.neg(self.values)
+        return self._wrap_array(arr, self.axes, copy=False)
+
+    def __invert__(self):
+        arr = operator.inv(self.values)
+        return self._wrap_array(arr, self.axes, copy=False)
+
+    #----------------------------------------------------------------------
+    # Iteration
+
+    def __iter__(self):
+        """
+        Iterate over infor axis
+        """
+        return iter(self._info_axis)
+
+    def keys(self):
+        """ return the info axis names """
+        return self._info_axis
+
+    def iteritems(self):
+        for h in self._info_axis:
+            yield h, self[h]
+
+    # Name that won't get automatically converted to items by 2to3. items is
+    # already in use for the first axis.
+    iterkv = iteritems
+
+    def __len__(self):
+        """Returns length of info axis """
+        return len(self._info_axis)
+
+    def __contains__(self, key):
+        """True if the key is in the info axis """
+        return key in self._info_axis
+
+    @property
+    def empty(self):
+        return not all(len(getattr(self, a)) > 0 for a in self._AXIS_ORDERS)
+
+    #----------------------------------------------------------------------
+    # Formatting
+
+    def __unicode__(self):
+        raise NotImplementedError
+
+    def __str__(self):
+        """
+        Return a string representation for a particular Object
+
+        Invoked by str(df) in both py2/py3.
+        Yields Bytestring in Py2, Unicode String in py3.
+        """
+
+        if py3compat.PY3:
+            return self.__unicode__()
+        return self.__bytes__()
+
+    def __bytes__(self):
+        """
+        Return a string representation for a particular Object
+
+        Invoked by bytes(df) in py3 only.
+        Yields a bytestring in both py2/py3.
+        """
+        encoding = com.get_option("display.encoding")
+        return self.__unicode__().encode(encoding, 'replace')
+
+    def __repr__(self):
+        """
+        Return a string representation for a particular Object
+
+        Yields Bytestring in Py2, Unicode String in py3.
+        """
+        return str(self)
+
+    #----------------------------------------------------------------------
+    # Methods
 
     def abs(self):
         """
@@ -413,9 +593,6 @@ class PandasObject(object):
         new_axis = labels.take(sort_index)
         return self.reindex(**{axis_name: new_axis})
 
-    def reindex(self, *args, **kwds):
-        raise NotImplementedError
-
     def tshift(self, periods=1, freq=None, **kwds):
         """
         Shift the time index, using the index's frequency if available
@@ -494,8 +671,6 @@ class NDFrame(PandasObject):
     axes : list
     copy : boolean, default False
     """
-    # kludge
-    _default_stat_axis = 0
 
     def __init__(self, data, axes=None, copy=False, dtype=None):
         if dtype is not None:
@@ -510,46 +685,194 @@ class NDFrame(PandasObject):
         object.__setattr__(self, '_data', data)
         object.__setattr__(self, '_item_cache', {})
 
-    def astype(self, dtype, copy = True, raise_on_error = True):
-        """
-        Cast object to input numpy.dtype
-        Return a copy when copy = True (be really careful with this!)
-
-        Parameters
-        ----------
-        dtype : numpy.dtype or Python type
-        raise_on_error : raise on invalid input
-
-        Returns
-        -------
-        casted : type of caller
-        """
-
-        mgr = self._data.astype(dtype, copy = copy, raise_on_error = raise_on_error)
-        return self._constructor(mgr)
+    #----------------------------------------------------------------------
+    # Axes
 
     @property
-    def _constructor(self):
-        return NDFrame
+    def shape(self):
+        return tuple(len(getattr(self, a)) for a in self._AXIS_ORDERS)
 
     @property
     def axes(self):
-        return self._data.axes
-
-    def __repr__(self):
-        return 'NDFrame'
-
-    @property
-    def values(self):
-        return self._data.as_matrix()
+        """ we do it this way because if we have reversed axes, then 
+        the block manager shows then reversed """
+        return [getattr(self, a) for a in self._AXIS_ORDERS]
 
     @property
     def ndim(self):
         return self._data.ndim
 
+    def _expand_axes(self, key):
+        new_axes = []
+        for k, ax in zip(key, self.axes):
+            if k not in ax:
+                if type(k) != ax.dtype.type:
+                    ax = ax.astype('O')
+                new_axes.append(ax.insert(len(ax), k))
+            else:
+                new_axes.append(ax)
+
+        return new_axes
+
     def _set_axis(self, axis, labels):
         self._data.set_axis(axis, labels)
         self._clear_item_cache()
+
+    def transpose(self, *args, **kwargs):
+        """
+        Permute the dimensions of the Object
+
+        Parameters
+        ----------
+        axes : int or name (or alias)
+        copy : boolean, default False
+            Make a copy of the underlying data. Mixed-dtype data will
+            always result in a copy
+
+        Examples
+        --------
+        >>> p.transpose(2, 0, 1)
+        >>> p.transpose(2, 0, 1, copy=True)
+
+        Returns
+        -------
+        y : same as input
+        """
+
+        # construct the args
+        args = list(args)
+        for a in self._AXIS_ORDERS:
+            if not a in kwargs:
+                try:
+                    kwargs[a] = args.pop(0)
+                except (IndexError):
+                    raise ValueError(
+                        "not enough arguments specified to transpose!")
+
+        axes = [self._get_axis_number(kwargs[a]) for a in self._AXIS_ORDERS]
+
+        # we must have unique axes
+        if len(axes) != len(set(axes)):
+            raise ValueError('Must specify %s unique axes' % self._AXIS_LEN)
+
+        new_axes = self._construct_axes_dict_from(
+            self, [self._get_axis(x) for x in axes])
+        new_values = self.values.transpose(tuple(axes))
+        if kwargs.get('copy') or (len(args) and args[-1]):
+            new_values = new_values.copy()
+        return self._constructor(new_values, **new_axes)
+
+    def swapaxes(self, axis1, axis2, copy=True):
+        """
+        Interchange axes and swap values axes appropriately
+
+        Returns
+        -------
+        y : same as input
+        """
+        i = self._get_axis_number(axis1)
+        j = self._get_axis_number(axis2)
+
+        if i == j:
+            if copy:
+                return self.copy()
+            return self
+
+        mapping = {i: j, j: i}
+
+        new_axes = (self._get_axis(mapping.get(k, k))
+                    for k in range(self._AXIS_LEN))
+        new_values = self.values.swapaxes(i, j)
+        if copy:
+            new_values = new_values.copy()
+
+        return self._constructor(new_values, *new_axes)
+
+    def pop(self, item):
+        """
+        Return item and drop from frame. Raise KeyError if not found.
+        """
+        result = self[item]
+        del self[item]
+        return result
+
+    def squeeze(self):
+        """ squeeze length 1 dimensions """
+        try:
+            return self.ix[tuple([ slice(None) if len(a) > 1 else a[0] for a in self.axes ])]
+        except:
+            return self
+
+    def swaplevel(self, i, j, axis=0):
+        """
+        Swap levels i and j in a MultiIndex on a particular axis
+
+        Parameters
+        ----------
+        i, j : int, string (can be mixed)
+            Level of index to be swapped. Can pass level name as string.
+
+        Returns
+        -------
+        swapped : type of caller (new object)
+        """
+        axis = self._get_axis_number(axis)
+        result = self.copy()
+        labels = result._data.axes[axis]
+        result._data.set_axis(axis, labels.swaplevel(i, j))
+        return result
+
+    def rename_axis(self, mapper, axis=0, copy=True):
+        """
+        Alter index and / or columns using input function or functions.
+        Function / dict values must be unique (1-to-1). Labels not contained in
+        a dict / Series will be left as-is.
+
+        Parameters
+        ----------
+        mapper : dict-like or function, optional
+        axis : int, default 0
+        copy : boolean, default True
+            Also copy underlying data
+
+        See also
+        --------
+        DataFrame.rename
+
+        Returns
+        -------
+        renamed : type of caller
+        """
+        # should move this at some point
+        from pandas.core.series import _get_rename_function
+
+        mapper_f = _get_rename_function(mapper)
+
+        if axis == 0:
+            new_data = self._data.rename_items(mapper_f, copydata=copy)
+        else:
+            new_data = self._data.rename_axis(mapper_f, axis=axis)
+            if copy:
+                new_data = new_data.copy()
+
+        return self._constructor(new_data)
+
+    #----------------------------------------------------------------------
+    # Array Interface
+
+    def _wrap_array(self, arr, axes, copy=False):
+        d = self._construct_axes_dict_from(self, axes, copy=copy)
+        return self._constructor(arr, **d)
+
+    def __array__(self, dtype=None):
+        return self.values
+
+    def __array_wrap__(self, result):
+        d = self._construct_axes_dict(self._AXIS_ORDERS, copy=False)
+        return self._constructor(result, **d)
+
+    #----------------------------------------------------------------------
+    # Fancy Indexing
 
     def __getitem__(self, item):
         return self._get_item_cache(item)
@@ -612,32 +935,14 @@ class NDFrame(PandasObject):
         from pandas import Series
         return Series(self._data.get_dtype_counts())
 
-    def pop(self, item):
-        """
-        Return item and drop from frame. Raise KeyError if not found.
-        """
-        result = self[item]
-        del self[item]
-        return result
+    def _reindex_axis(self, new_index, fill_method, axis, copy):
+        new_data = self._data.reindex_axis(new_index, axis=axis,
+                                           method=fill_method, copy=copy)
 
-    def squeeze(self):
-        """ squeeze length 1 dimensions """
-        try:
-            return self.ix[tuple([ slice(None) if len(a) > 1 else a[0] for a in self.axes ])]
-        except:
+        if new_data is self._data and not copy:
             return self
-
-    def _expand_axes(self, key):
-        new_axes = []
-        for k, ax in zip(key, self.axes):
-            if k not in ax:
-                if type(k) != ax.dtype.type:
-                    ax = ax.astype('O')
-                new_axes.append(ax.insert(len(ax), k))
-            else:
-                new_axes.append(ax)
-
-        return new_axes
+        else:
+            return self._constructor(new_data)
 
     #----------------------------------------------------------------------
     # Consolidation of internals
@@ -677,14 +982,83 @@ class NDFrame(PandasObject):
     def _is_numeric_mixed_type(self):
         return self._data.is_numeric_mixed_type
 
-    def _reindex_axis(self, new_index, fill_method, axis, copy):
-        new_data = self._data.reindex_axis(new_index, axis=axis,
-                                           method=fill_method, copy=copy)
+    #----------------------------------------------------------------------
+    # Methods
 
-        if new_data is self._data and not copy:
-            return self
-        else:
-            return self._constructor(new_data)
+    def as_matrix(self):
+        raise NotImplementedError
+
+    @property
+    def values(self):
+        return self.as_matrix()
+
+    @property
+    def _get_values(self):
+        # compat
+        return self.values
+
+    def as_blocks(self, columns=None):
+        """
+        Convert the frame to a dict of dtype -> Constructor Types that each has a homogeneous dtype.
+        are presented in sorted order unless a specific list of columns is
+        provided.
+
+        NOTE: the dtypes of the blocks WILL BE PRESERVED HERE (unlike in as_matrix)
+
+        Parameters
+        ----------
+        columns : array-like
+            Specific column order
+
+        Returns
+        -------
+        values : a list of Object
+        """
+        self._consolidate_inplace()
+
+        bd = dict()
+        for b in self._data.blocks:
+            b = b.reindex_items_from(columns or b.items)
+            bd[str(b.dtype)] = self._constructor(BlockManager([ b ], [ b.items, self.index ]))
+        return bd
+
+    @property
+    def blocks(self):
+        return self.as_blocks()
+
+    def astype(self, dtype, copy = True, raise_on_error = True):
+        """
+        Cast object to input numpy.dtype
+        Return a copy when copy = True (be really careful with this!)
+
+        Parameters
+        ----------
+        dtype : numpy.dtype or Python type
+        raise_on_error : raise on invalid input
+
+        Returns
+        -------
+        casted : type of caller
+        """
+
+        mgr = self._data.astype(dtype, copy = copy, raise_on_error = raise_on_error)
+        return self._constructor(mgr)
+
+    def convert_objects(self, convert_dates=True, convert_numeric=True):
+        """
+        Attempt to infer better dtype for object columns
+        Always returns a copy (even if no object columns)
+
+        Parameters
+        ----------
+        convert_dates : if True, attempt to soft convert_dates, if 'coerce', force conversion (and non-convertibles get NaT)
+        convert_numeric : if True attempt to coerce to numerbers (including strings), non-convertibles get NaN
+
+        Returns
+        -------
+        converted : DataFrame
+        """
+        return self._constructor(self._data.convert(convert_dates=convert_dates, convert_numeric=convert_numeric))
 
     def cumsum(self, axis=None, skipna=True):
         """
@@ -703,7 +1077,7 @@ class NDFrame(PandasObject):
         y : DataFrame
         """
         if axis is None:
-            axis = self._default_stat_axis
+            axis = self._stat_axis_number
         else:
             axis = self._get_axis_number(axis)
 
@@ -722,9 +1096,6 @@ class NDFrame(PandasObject):
             result = y.cumsum(axis)
         return self._wrap_array(result, self.axes, copy=False)
 
-    def _wrap_array(self, array, axes, copy=False):
-        raise NotImplementedError
-
     def cumprod(self, axis=None, skipna=True):
         """
         Return cumulative product over requested axis as DataFrame
@@ -742,7 +1113,7 @@ class NDFrame(PandasObject):
         y : DataFrame
         """
         if axis is None:
-            axis = self._default_stat_axis
+            axis = self._stat_axis_number
         else:
             axis = self._get_axis_number(axis)
 
@@ -777,7 +1148,7 @@ class NDFrame(PandasObject):
         y : DataFrame
         """
         if axis is None:
-            axis = self._default_stat_axis
+            axis = self._stat_axis_number
         else:
             axis = self._get_axis_number(axis)
 
@@ -813,7 +1184,7 @@ class NDFrame(PandasObject):
         y : DataFrame
         """
         if axis is None:
-            axis = self._default_stat_axis
+            axis = self._stat_axis_number
         else:
             axis = self._get_axis_number(axis)
 
@@ -850,25 +1221,6 @@ class NDFrame(PandasObject):
             data = data.copy()
         return self._constructor(data)
 
-    def swaplevel(self, i, j, axis=0):
-        """
-        Swap levels i and j in a MultiIndex on a particular axis
-
-        Parameters
-        ----------
-        i, j : int, string (can be mixed)
-            Level of index to be swapped. Can pass level name as string.
-
-        Returns
-        -------
-        swapped : type of caller (new object)
-        """
-        axis = self._get_axis_number(axis)
-        result = self.copy()
-        labels = result._data.axes[axis]
-        result._data.set_axis(axis, labels.swaplevel(i, j))
-        return result
-
     def add_prefix(self, prefix):
         """
         Concatenate prefix string with panel items names.
@@ -897,41 +1249,6 @@ class NDFrame(PandasObject):
         with_suffix : type of caller
         """
         new_data = self._data.add_suffix(suffix)
-        return self._constructor(new_data)
-
-    def rename_axis(self, mapper, axis=0, copy=True):
-        """
-        Alter index and / or columns using input function or functions.
-        Function / dict values must be unique (1-to-1). Labels not contained in
-        a dict / Series will be left as-is.
-
-        Parameters
-        ----------
-        mapper : dict-like or function, optional
-        axis : int, default 0
-        copy : boolean, default True
-            Also copy underlying data
-
-        See also
-        --------
-        DataFrame.rename
-
-        Returns
-        -------
-        renamed : type of caller
-        """
-        # should move this at some point
-        from pandas.core.series import _get_rename_function
-
-        mapper_f = _get_rename_function(mapper)
-
-        if axis == 0:
-            new_data = self._data.rename_items(mapper_f, copydata=copy)
-        else:
-            new_data = self._data.rename_axis(mapper_f, axis=axis)
-            if copy:
-                new_data = new_data.copy()
-
         return self._constructor(new_data)
 
     def take(self, indices, axis=0, convert=True):

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1751,7 +1751,7 @@ class NDFrameGroupBy(GroupBy):
         obj = self._obj_with_exclusions
 
         result = {}
-        if axis != obj._het_axis:
+        if axis != obj._info_axis_number:
             try:
                 for name, data in self:
                     # for name in self.indices:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -110,21 +110,21 @@ class _NDFrameIndexer(object):
             if isinstance(value, Series):
                 value = self._align_series(indexer, value)
 
-            het_axis = self.obj._het_axis
-            het_idx = indexer[het_axis]
+            info_axis = self.obj._info_axis_number
+            info_idx = indexer[info_axis]
 
-            if isinstance(het_idx, (int, long)):
-                het_idx = [het_idx]
+            if isinstance(info_idx, (int, long)):
+                info_idx = [info_idx]
 
-            plane_indexer = indexer[:het_axis] + indexer[het_axis + 1:]
-            item_labels = self.obj._get_axis(het_axis)
+            plane_indexer = indexer[:info_axis] + indexer[info_axis + 1:]
+            item_labels = self.obj._get_axis(info_axis)
 
             if isinstance(value, (np.ndarray, DataFrame)) and value.ndim > 1:
                 raise ValueError('Setting mixed-type DataFrames with '
                                  'array/DataFrame pieces not yet supported')
 
             try:
-                for item in item_labels[het_idx]:
+                for item in item_labels[info_idx]:
                     data = self.obj[item]
                     values = data.values
                     if np.prod(values.shape):
@@ -132,7 +132,7 @@ class _NDFrameIndexer(object):
                             value, getattr(data, 'dtype', None))
                         values[plane_indexer] = value
             except ValueError:
-                for item, v in zip(item_labels[het_idx], value):
+                for item, v in zip(item_labels[info_idx], value):
                     data = self.obj[item]
                     values = data.values
                     if np.prod(values.shape):

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -294,12 +294,12 @@ class Block(object):
 
         # may need to align the new
         if hasattr(new, 'reindex_axis'):
-            axis = getattr(new, '_het_axis', 0)
+            axis = getattr(new, '_info_axis_number', 0)
             new = new.reindex_axis(self.items, axis=axis, copy=False).values.T
 
         # may need to align the mask
         if hasattr(mask, 'reindex_axis'):
-            axis = getattr(mask, '_het_axis', 0)
+            axis = getattr(mask, '_info_axis_number', 0)
             mask = mask.reindex_axis(self.items, axis=axis, copy=False).values.T
 
         if self._can_hold_element(new):
@@ -420,7 +420,7 @@ class Block(object):
 
         # see if we can align other
         if hasattr(other, 'reindex_axis'):
-            axis = getattr(other, '_het_axis', 0)
+            axis = getattr(other, '_info_axis_number', 0)
             other = other.reindex_axis(self.items, axis=axis, copy=True).values
 
         # make sure that we can broadcast
@@ -475,7 +475,7 @@ class Block(object):
 
         # see if we can align other
         if hasattr(other,'reindex_axis'):
-            axis = getattr(other,'_het_axis',0)
+            axis = getattr(other,'_info_axis_number',0)
             other = other.reindex_axis(self.items, axis=axis, copy=True).values
 
         # make sure that we can broadcast
@@ -489,7 +489,7 @@ class Block(object):
         if not hasattr(cond,'shape'):
             raise ValueError("where must have a condition that is ndarray like")
         if hasattr(cond,'reindex_axis'):
-            axis = getattr(cond,'_het_axis',0)
+            axis = getattr(cond,'_info_axis_number',0)
             cond = cond.reindex_axis(self.items, axis=axis, copy=True).values
         else:
             cond = cond.values

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -108,11 +108,13 @@ class Block(object):
     def dtype(self):
         return self.values.dtype
 
-    def copy(self, deep=True):
+    def copy(self, deep=True, ref_items=None):
         values = self.values
         if deep:
             values = values.copy()
-        return make_block(values, self.items, self.ref_items)
+        if ref_items is None:
+            ref_items = self.ref_items
+        return make_block(values, self.items, ref_items)
 
     def merge(self, other):
         if not self.ref_items.equals(other.ref_items):
@@ -933,6 +935,8 @@ class BlockManager(object):
 
         axes = kwargs.pop('axes',None)
         filter = kwargs.get('filter')
+        do_integrity_check = kwargs.pop('do_integrity_check',False)
+
         result_blocks = []
         for blk in self.blocks:
             if filter is not None:
@@ -949,7 +953,7 @@ class BlockManager(object):
                 result_blocks.extend(applied)
             else:
                 result_blocks.append(applied)
-        bm = self.__class__(result_blocks, axes or self.axes)
+        bm = self.__class__(result_blocks, axes or self.axes, do_integrity_check=do_integrity_check)
         bm._consolidate_inplace()
         return bm
 
@@ -1155,10 +1159,8 @@ class BlockManager(object):
         -------
         copy : BlockManager
         """
-        copy_blocks = [block.copy(deep=deep) for block in self.blocks]
-        # copy_axes = [ax.copy() for ax in self.axes]
-        copy_axes = list(self.axes)
-        return BlockManager(copy_blocks, copy_axes, do_integrity_check=False)
+        new_axes = list(self.axes)
+        return self.apply('copy', axes=new_axes, deep=deep, do_integrity_check=False)
 
     def as_matrix(self, items=None):
         if len(self.blocks) == 0:
@@ -1444,7 +1446,7 @@ class BlockManager(object):
         if item not in self.items:
             raise KeyError('no item named %s' % com.pprint_thing(item))
 
-    def reindex_axis(self, new_axis, method=None, axis=0, copy=True):
+    def reindex_axis(self, new_axis, method=None, axis=0, fill_value=np.nan, copy=True):
         new_axis = _ensure_index(new_axis)
         cur_axis = self.axes[axis]
 
@@ -1466,10 +1468,10 @@ class BlockManager(object):
             if method is not None:
                 raise AssertionError('method argument not supported for '
                                      'axis == 0')
-            return self.reindex_items(new_axis)
+            return self.reindex_items(new_axis, copy=copy, fill_value=fill_value)
 
         new_axis, indexer = cur_axis.reindex(new_axis, method)
-        return self.reindex_indexer(new_axis, indexer, axis=axis)
+        return self.reindex_indexer(new_axis, indexer, axis=axis, fill_value=fill_value)
 
     def reindex_indexer(self, new_axis, indexer, axis=1, fill_value=np.nan):
         """
@@ -1518,7 +1520,7 @@ class BlockManager(object):
             new_blocks.append(na_block)
             new_blocks = _consolidate(new_blocks, new_items)
 
-        return BlockManager(new_blocks, [new_items] + self.axes[1:])
+        return BlockManager(new_blocks, [new_items] + list(self.axes[1:]))
 
     def reindex_items(self, new_items, copy=True, fill_value=np.nan):
         """
@@ -1528,7 +1530,7 @@ class BlockManager(object):
         data = self
         if not data.is_consolidated():
             data = data.consolidate()
-            return data.reindex_items(new_items)
+            return data.reindex_items(new_items, copy=copy, fill_value=fill_value)
 
         # TODO: this part could be faster (!)
         new_items, indexer = self.items.reindex(new_items)

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -145,74 +145,12 @@ def _comp_method(func, name):
 
 
 class Panel(NDFrame):
-    _AXIS_ORDERS = ['items', 'major_axis', 'minor_axis']
-    _AXIS_NUMBERS = dict([(a, i) for i, a in enumerate(_AXIS_ORDERS)])
-    _AXIS_ALIASES = {
-        'major': 'major_axis',
-        'minor': 'minor_axis'
-    }
-    _AXIS_NAMES = dict([(i, a) for i, a in enumerate(_AXIS_ORDERS)])
-    _AXIS_SLICEMAP = {
-        'major_axis': 'index',
-        'minor_axis': 'columns'
-    }
-    _AXIS_LEN = len(_AXIS_ORDERS)
-
-    # major
-    _default_stat_axis = 1
-
-    # info axis
-    _het_axis = 0
-    _info_axis = _AXIS_ORDERS[_het_axis]
-
-    items = lib.AxisProperty(0)
-    major_axis = lib.AxisProperty(1)
-    minor_axis = lib.AxisProperty(2)
 
     @property
     def _constructor(self):
         return type(self)
 
-    # return the type of the slice constructor
     _constructor_sliced = DataFrame
-
-    def _construct_axes_dict(self, axes=None, **kwargs):
-        """ return an axes dictionary for myself """
-        d = dict([(a, getattr(self, a)) for a in (axes or self._AXIS_ORDERS)])
-        d.update(kwargs)
-        return d
-
-    @staticmethod
-    def _construct_axes_dict_from(self, axes, **kwargs):
-        """ return an axes dictionary for the passed axes """
-        d = dict([(a, ax) for a, ax in zip(self._AXIS_ORDERS, axes)])
-        d.update(kwargs)
-        return d
-
-    def _construct_axes_dict_for_slice(self, axes=None, **kwargs):
-        """ return an axes dictionary for myself """
-        d = dict([(self._AXIS_SLICEMAP[a], getattr(self, a))
-                 for a in (axes or self._AXIS_ORDERS)])
-        d.update(kwargs)
-        return d
-
-    __add__ = _arith_method(operator.add, '__add__')
-    __sub__ = _arith_method(operator.sub, '__sub__')
-    __truediv__ = _arith_method(operator.truediv, '__truediv__')
-    __floordiv__ = _arith_method(operator.floordiv, '__floordiv__')
-    __mul__ = _arith_method(operator.mul, '__mul__')
-    __pow__ = _arith_method(operator.pow, '__pow__')
-
-    __radd__ = _arith_method(operator.add, '__radd__')
-    __rmul__ = _arith_method(operator.mul, '__rmul__')
-    __rsub__ = _arith_method(lambda x, y: y - x, '__rsub__')
-    __rtruediv__ = _arith_method(lambda x, y: y / x, '__rtruediv__')
-    __rfloordiv__ = _arith_method(lambda x, y: y // x, '__rfloordiv__')
-    __rpow__ = _arith_method(lambda x, y: y ** x, '__rpow__')
-
-    if not py3compat.PY3:
-        __div__ = _arith_method(operator.div, '__div__')
-        __rdiv__ = _arith_method(lambda x, y: y / x, '__rdiv__')
 
     def __init__(self, data=None, items=None, major_axis=None, minor_axis=None,
                  copy=False, dtype=None):
@@ -262,17 +200,8 @@ class Panel(NDFrame):
 
         NDFrame.__init__(self, mgr, axes=axes, copy=copy, dtype=dtype)
 
-    @classmethod
-    def _from_axes(cls, data, axes):
-        # for construction from BlockManager
-        if isinstance(data, BlockManager):
-            return cls(data)
-        else:
-            d = cls._construct_axes_dict_from(cls, axes, copy=False)
-            return cls(data, **d)
-
     def _init_dict(self, data, axes, dtype=None):
-        haxis = axes.pop(self._het_axis)
+        haxis = axes.pop(self._info_axis_number)
 
         # prefilter if haxis passed
         if haxis is not None:
@@ -315,10 +244,6 @@ class Panel(NDFrame):
         mgr = BlockManager(blocks, axes).consolidate()
         return mgr
 
-    @property
-    def shape(self):
-        return [len(getattr(self, a)) for a in self._AXIS_ORDERS]
-
     @classmethod
     def from_dict(cls, data, intersect=False, orient='items', dtype=None):
         """
@@ -355,16 +280,35 @@ class Panel(NDFrame):
             raise ValueError('only recognize items or minor for orientation')
 
         d = cls._homogenize_dict(cls, data, intersect=intersect, dtype=dtype)
-        d[cls._info_axis] = Index(sorted(d['data'].keys()))
+        d[cls._info_axis_name] = Index(sorted(d['data'].keys()))
         return cls(**d)
 
+    # Comparison methods
+    __add__ = _arith_method(operator.add, '__add__')
+    __sub__ = _arith_method(operator.sub, '__sub__')
+    __truediv__ = _arith_method(operator.truediv, '__truediv__')
+    __floordiv__ = _arith_method(operator.floordiv, '__floordiv__')
+    __mul__ = _arith_method(operator.mul, '__mul__')
+    __pow__ = _arith_method(operator.pow, '__pow__')
+
+    __radd__ = _arith_method(operator.add, '__radd__')
+    __rmul__ = _arith_method(operator.mul, '__rmul__')
+    __rsub__ = _arith_method(lambda x, y: y - x, '__rsub__')
+    __rtruediv__ = _arith_method(lambda x, y: y / x, '__rtruediv__')
+    __rfloordiv__ = _arith_method(lambda x, y: y // x, '__rfloordiv__')
+    __rpow__ = _arith_method(lambda x, y: y ** x, '__rpow__')
+
+    if not py3compat.PY3:
+        __div__ = _arith_method(operator.div, '__div__')
+        __rdiv__ = _arith_method(lambda x, y: y / x, '__rdiv__')
+
     def __getitem__(self, key):
-        if isinstance(getattr(self, self._info_axis), MultiIndex):
+        if isinstance(self._info_axis, MultiIndex):
             return self._getitem_multilevel(key)
         return super(Panel, self).__getitem__(key)
 
     def _getitem_multilevel(self, key):
-        info = getattr(self, self._info_axis)
+        info = self._info_axis
         loc = info.get_loc(key)
         if isinstance(loc, (slice, np.ndarray)):
             new_index = info[loc]
@@ -374,7 +318,7 @@ class Panel(NDFrame):
             new_values = self.values[slices]
 
             d = self._construct_axes_dict(self._AXIS_ORDERS[1:])
-            d[self._info_axis] = result_index
+            d[self._info_axis_name] = result_index
             result = self._constructor(new_values, **d)
             return result
         else:
@@ -403,20 +347,7 @@ class Panel(NDFrame):
         return BlockManager([block], fixed_axes)
 
     #----------------------------------------------------------------------
-    # Array interface
-
-    def __array__(self, dtype=None):
-        return self.values
-
-    def __array_wrap__(self, result):
-        d = self._construct_axes_dict(self._AXIS_ORDERS, copy=False)
-        return self._constructor(result, **d)
-
-    #----------------------------------------------------------------------
     # Comparison methods
-
-    def _indexed_same(self, other):
-        return all([getattr(self, a).equals(getattr(other, a)) for a in self._AXIS_ORDERS])
 
     def _compare_constructor(self, other, func):
         if not self._indexed_same(other):
@@ -424,7 +355,7 @@ class Panel(NDFrame):
                             'same type objects')
 
         new_data = {}
-        for col in getattr(self, self._info_axis):
+        for col in self._info_axis:
             new_data[col] = func(self[col], other[col])
 
         d = self._construct_axes_dict(copy=False)
@@ -434,12 +365,6 @@ class Panel(NDFrame):
     __and__ = _arith_method(operator.and_, '__and__')
     __or__ = _arith_method(operator.or_, '__or__')
     __xor__ = _arith_method(operator.xor, '__xor__')
-
-    def __neg__(self):
-        return -1 * self
-
-    def __invert__(self):
-        return -1 * self
 
     # Comparison methods
     __eq__ = _comp_method(operator.eq, '__eq__')
@@ -458,28 +383,6 @@ class Panel(NDFrame):
 
     #----------------------------------------------------------------------
     # Magic methods
-
-    def __str__(self):
-        """
-        Return a string representation for a particular Panel
-
-        Invoked by str(df) in both py2/py3.
-        Yields Bytestring in Py2, Unicode String in py3.
-        """
-
-        if py3compat.PY3:
-            return self.__unicode__()
-        return self.__bytes__()
-
-    def __bytes__(self):
-        """
-        Return a string representation for a particular Panel
-
-        Invoked by bytes(df) in py3 only.
-        Yields a bytestring in both py2/py3.
-        """
-        encoding = com.get_option("display.encoding")
-        return self.__unicode__().encode(encoding, 'replace')
 
     def __unicode__(self):
         """
@@ -505,25 +408,6 @@ class Panel(NDFrame):
             [class_name, dims] + [axis_pretty(a) for a in self._AXIS_ORDERS])
         return output
 
-    def __repr__(self):
-        """
-        Return a string representation for a particular Panel
-
-        Yields Bytestring in Py2, Unicode String in py3.
-        """
-        return str(self)
-
-    def __iter__(self):
-        return iter(getattr(self, self._info_axis))
-
-    def iteritems(self):
-        for h in getattr(self, self._info_axis):
-            yield h, self[h]
-
-    # Name that won't get automatically converted to items by 2to3. items is
-    # already in use for the first axis.
-    iterkv = iteritems
-
     def _get_plane_axes(self, axis):
         """ get my plane axes: these are already (as compared with higher level planes), as we are returning a DataFrame axes """
         axis = self._get_axis_name(axis)
@@ -539,10 +423,6 @@ class Panel(NDFrame):
             columns = self.minor_axis
 
         return index, columns
-
-    def _wrap_array(self, arr, axes, copy=False):
-        d = self._construct_axes_dict_from(self, axes, copy=copy)
-        return self._constructor(arr, **d)
 
     fromDict = from_dict
 
@@ -585,15 +465,9 @@ class Panel(NDFrame):
             df.to_excel(writer, name, na_rep=na_rep)
         writer.save()
 
-    # TODO: needed?
-    def keys(self):
-        return list(getattr(self, self._info_axis))
-
-    def _get_values(self):
+    def as_matrix(self):
         self._consolidate_inplace()
         return self._data.as_matrix()
-
-    values = property(fget=_get_values)
 
     #----------------------------------------------------------------------
     # Getting and setting elements
@@ -650,7 +524,7 @@ class Panel(NDFrame):
             args  = list(args)
             likely_dtype, args[-1] = _infer_dtype_from_scalar(args[-1])
             made_bigger = not np.array_equal(
-                axes[0], getattr(self, self._info_axis))
+                axes[0], self._info_axis)
             # how to make this logic simpler?
             if made_bigger:
                 com._possibly_cast_item(result, args[0], likely_dtype)
@@ -664,7 +538,7 @@ class Panel(NDFrame):
     def __getattr__(self, name):
         """After regular attribute access, try looking up the name of an item.
         This allows simpler access to items for interactive use."""
-        if name in getattr(self, self._info_axis):
+        if name in self._info_axis:
             return self[name]
         raise AttributeError("'%s' object has no attribute '%s'" %
                              (type(self).__name__, name))
@@ -691,21 +565,6 @@ class Panel(NDFrame):
 
         mat = mat.reshape(tuple([1]) + shape[1:])
         NDFrame._set_item(self, key, mat)
-
-    def pop(self, item):
-        """
-        Return item slice from panel and delete from panel
-
-        Parameters
-        ----------
-        key : object
-            Must be contained in panel's items
-
-        Returns
-        -------
-        y : DataFrame
-        """
-        return NDFrame.pop(self, item)
 
     def __getstate__(self):
         "Returned pickled representation of the panel"
@@ -1096,76 +955,6 @@ class Panel(NDFrame):
         axis = self._get_axis_number(axis)
         return PanelGroupBy(self, function, axis=axis)
 
-    def swapaxes(self, axis1='major', axis2='minor', copy=True):
-        """
-        Interchange axes and swap values axes appropriately
-
-        Returns
-        -------
-        y : Panel (new object)
-        """
-        i = self._get_axis_number(axis1)
-        j = self._get_axis_number(axis2)
-
-        if i == j:
-            raise ValueError('Cannot specify the same axis')
-
-        mapping = {i: j, j: i}
-
-        new_axes = (self._get_axis(mapping.get(k, k))
-                    for k in range(self._AXIS_LEN))
-        new_values = self.values.swapaxes(i, j)
-        if copy:
-            new_values = new_values.copy()
-
-        return self._constructor(new_values, *new_axes)
-
-    def transpose(self, *args, **kwargs):
-        """
-        Permute the dimensions of the Panel
-
-        Parameters
-        ----------
-        items : int or one of {'items', 'major', 'minor'}
-        major : int or one of {'items', 'major', 'minor'}
-        minor : int or one of {'items', 'major', 'minor'}
-        copy : boolean, default False
-            Make a copy of the underlying data. Mixed-dtype data will
-            always result in a copy
-
-        Examples
-        --------
-        >>> p.transpose(2, 0, 1)
-        >>> p.transpose(2, 0, 1, copy=True)
-
-        Returns
-        -------
-        y : Panel (new object)
-        """
-
-        # construct the args
-        args = list(args)
-        for a in self._AXIS_ORDERS:
-            if not a in kwargs:
-                try:
-                    kwargs[a] = args.pop(0)
-                except (IndexError):
-                    raise ValueError(
-                        "not enough arguments specified to transpose!")
-
-        axes = [self._get_axis_number(kwargs[a]) for a in self._AXIS_ORDERS]
-
-        # we must have unique axes
-        if len(axes) != len(set(axes)):
-            raise ValueError('Must specify %s unique axes' % self._AXIS_LEN)
-
-        new_axes = self._construct_axes_dict_from(
-            self, [self._get_axis(x) for x in axes])
-        new_values = self.values.transpose(tuple(axes))
-        if kwargs.get('copy') or (len(args) and args[-1]):
-            new_values = new_values.copy()
-        return self._constructor(new_values, **new_axes)
-
     def to_frame(self, filter_observations=True):
         """
         Transform wide format into long (stacked) format as DataFrame
@@ -1256,7 +1045,7 @@ class Panel(NDFrame):
         result = f(self.values)
 
         axes = self._get_plane_axes(axis_name)
-        if result.ndim == 2 and axis_name != self._info_axis:
+        if result.ndim == 2 and axis_name != self._info_axis_name:
             result = result.T
 
         return self._constructor_sliced(result, **self._extract_axes_for_slice(self, axes))
@@ -1264,7 +1053,7 @@ class Panel(NDFrame):
     def _wrap_result(self, result, axis):
         axis = self._get_axis_name(axis)
         axes = self._get_plane_axes(axis)
-        if result.ndim == 2 and axis != self._info_axis:
+        if result.ndim == 2 and axis != self._info_axis_name:
             result = result.T
 
         # do we have reduced dimensionalility?
@@ -1432,9 +1221,9 @@ class Panel(NDFrame):
         if not isinstance(other, self._constructor):
             other = self._constructor(other)
 
-        axis = self._info_axis
-        axis_values = getattr(self, axis)
-        other = other.reindex(**{axis: axis_values})
+        axis_name   = self._info_axis_name
+        axis_values = self._info_axis
+        other = other.reindex(**{axis_name: axis_values})
 
         for frame in axis_values:
             self[frame].update(other[frame], join, overwrite, filter_func,
@@ -1673,6 +1462,13 @@ If all values are NA, result will be NA"""
             return self._reduce(nanops.nanmin, axis=axis, skipna=skipna)
         cls.min = min
 
+Panel._setup_axes(axes      = ['items', 'major_axis', 'minor_axis'], 
+                  info_axis = 0,
+                  stat_axis = 1,
+                  aliases   = { 'major': 'major_axis',
+                                'minor': 'minor_axis' },
+                  slicers   = { 'major_axis': 'index',
+                                'minor_axis': 'columns' })
 Panel._add_aggregate_operations()
 
 WidePanel = Panel

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -6,7 +6,7 @@ Contains data structures designed for manipulating panel (3-dimensional) data
 import operator
 import sys
 import numpy as np
-from pandas.core.common import (PandasError, _mut_exclusive,
+from pandas.core.common import (PandasError, 
                                 _try_sort, _default_index, _infer_dtype_from_scalar,
                                 notnull)
 from pandas.core.categorical import Factor
@@ -535,14 +535,6 @@ class Panel(NDFrame):
         d = self._construct_axes_dict_for_slice(self._AXIS_ORDERS[1:])
         return self._constructor_sliced(values, **d)
 
-    def __getattr__(self, name):
-        """After regular attribute access, try looking up the name of an item.
-        This allows simpler access to items for interactive use."""
-        if name in self._info_axis:
-            return self[name]
-        raise AttributeError("'%s' object has no attribute '%s'" %
-                             (type(self).__name__, name))
-
     def _slice(self, slobj, axis=0, raise_on_error=False):
         new_data = self._data.get_slice(slobj, axis=axis, raise_on_error=raise_on_error)
         return self._constructor(new_data)
@@ -565,20 +557,6 @@ class Panel(NDFrame):
 
         mat = mat.reshape(tuple([1]) + shape[1:])
         NDFrame._set_item(self, key, mat)
-
-    def __getstate__(self):
-        "Returned pickled representation of the panel"
-        return self._data
-
-    def __setstate__(self, state):
-        # old Panel pickle
-        if isinstance(state, BlockManager):
-            self._data = state
-        elif len(state) == 4:  # pragma: no cover
-            self._unpickle_panel_compat(state)
-        else:  # pragma: no cover
-            raise ValueError('unrecognized pickle')
-        self._item_cache = {}
 
     def _unpickle_panel_compat(self, state):  # pragma: no cover
         "Unpickle the panel"
@@ -612,62 +590,15 @@ class Panel(NDFrame):
         axes = self._get_plane_axes(axis)
         return frame.reindex(**self._extract_axes_for_slice(self, axes))
 
-    def reindex(self, major=None, minor=None, method=None,
-                major_axis=None, minor_axis=None, copy=True, **kwargs):
-        """
-        Conform panel to new axis or axes
-
-        Parameters
-        ----------
-        major : Index or sequence, default None
-            Can also use 'major_axis' keyword
-        items : Index or sequence, default None
-        minor : Index or sequence, default None
-            Can also use 'minor_axis' keyword
-        method : {'backfill', 'bfill', 'pad', 'ffill', None}, default None
-            Method to use for filling holes in reindexed Series
-
-            pad / ffill: propagate last valid observation forward to next valid
-            backfill / bfill: use NEXT valid observation to fill gap
-        copy : boolean, default True
-            Return a new object, even if the passed indexes are the same
-
-        Returns
-        -------
-        Panel (new object)
-        """
-        result = self
-
-        major = _mut_exclusive(major, major_axis)
-        minor = _mut_exclusive(minor, minor_axis)
-        al = self._AXIS_LEN
-
+    def _needs_reindex_multi(self, axes, method, level):
         # only allowing multi-index on Panel (and not > dims)
-        if (method is None and not self._is_mixed_type and al <= 3):
-            items = kwargs.get('items')
-            if com._count_not_none(items, major, minor) == 3:
-                try:
-                    return self._reindex_multi(items, major, minor)
-                except:
-                    pass
+        return method is None and not self._is_mixed_type and self._AXIS_LEN <= 3 and com._count_not_none(*axes.values()) == 3
 
-        if major is not None:
-            result = result._reindex_axis(major, method, al - 2, copy)
-
-        if minor is not None:
-            result = result._reindex_axis(minor, method, al - 1, copy)
-
-        for i, a in enumerate(self._AXIS_ORDERS[0:al - 2]):
-            a = kwargs.get(a)
-            if a is not None:
-                result = result._reindex_axis(a, method, i, copy)
-
-        if result is self and copy:
-            raise ValueError('Must specify at least one axis')
-
-        return result
-
-    def _reindex_multi(self, items, major, minor):
+    def _reindex_multi(self, axes, copy, fill_value):
+        """ we are guaranteed non-Nones in the axes! """
+        items = axes['items']
+        major = axes['major_axis']
+        minor = axes['minor_axis']
         a0, a1, a2 = len(items), len(major), len(minor)
 
         values = self.values
@@ -693,52 +624,6 @@ class Panel(NDFrame):
         return Panel(new_values, items=new_items, major_axis=new_major,
                      minor_axis=new_minor)
 
-    def reindex_axis(self, labels, axis=0, method=None, level=None, copy=True):
-        """Conform Panel to new index with optional filling logic, placing
-        NA/NaN in locations having no value in the previous index. A new object
-        is produced unless the new index is equivalent to the current one and
-        copy=False
-
-        Parameters
-        ----------
-        index : array-like, optional
-            New labels / index to conform to. Preferably an Index object to
-            avoid duplicating data
-        axis : {0, 1}
-            0 -> index (rows)
-            1 -> columns
-        method : {'backfill', 'bfill', 'pad', 'ffill', None}, default None
-            Method to use for filling holes in reindexed DataFrame
-            pad / ffill: propagate last valid observation forward to next valid
-            backfill / bfill: use NEXT valid observation to fill gap
-        copy : boolean, default True
-            Return a new object, even if the passed indexes are the same
-        level : int or name
-            Broadcast across a level, matching Index values on the
-            passed MultiIndex level
-
-        Returns
-        -------
-        reindexed : Panel
-        """
-        self._consolidate_inplace()
-        return self._reindex_axis(labels, method, axis, copy)
-
-    def reindex_like(self, other, method=None):
-        """ return an object with matching indicies to myself
-
-        Parameters
-        ----------
-        other : Panel
-        method : string or None
-
-        Returns
-        -------
-        reindexed : Panel
-        """
-        d = other._construct_axes_dict(method=method)
-        return self.reindex(**d)
-
     def dropna(self, axis=0, how='any'):
         """
         Drop 2D from panel, holding passed axis constant
@@ -761,7 +646,7 @@ class Panel(NDFrame):
         values = self.values
         mask = com.notnull(values)
 
-        for ax in reversed(sorted(set(range(3)) - set([axis]))):
+        for ax in reversed(sorted(set(range(self._AXIS_LEN)) - set([axis]))):
             mask = mask.sum(ax)
 
         per_slice = np.prod(values.shape[:axis] + values.shape[axis + 1:])

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -887,21 +887,6 @@ class Panel(NDFrame):
     to_long = deprecate('to_long', to_frame)
     toLong = deprecate('toLong', to_frame)
 
-    def filter(self, items):
-        """
-        Restrict items in panel to input list
-
-        Parameters
-        ----------
-        items : sequence
-
-        Returns
-        -------
-        y : Panel
-        """
-        intersection = self.items.intersection(items)
-        return self.reindex(items=intersection)
-
     def apply(self, func, axis='major'):
         """
         Apply
@@ -1358,10 +1343,6 @@ Panel._add_aggregate_operations()
 
 WidePanel = Panel
 LongPanel = DataFrame
-
-
-def _monotonic(arr):
-    return not (arr[1:] < arr[:-1]).any()
 
 
 def install_ipython_completers():  # pragma: no cover

--- a/pandas/core/panel4d.py
+++ b/pandas/core/panel4d.py
@@ -4,14 +4,14 @@ from pandas.core.panelnd import create_nd_panel_factory
 from pandas.core.panel import Panel
 
 Panel4D = create_nd_panel_factory(
-    klass_name='Panel4D',
-    axis_orders=['labels', 'items', 'major_axis', 'minor_axis'],
-    axis_slices={'labels': 'labels', 'items': 'items',
-                 'major_axis': 'major_axis',
-                 'minor_axis': 'minor_axis'},
-    slicer=Panel,
-    axis_aliases={'major': 'major_axis', 'minor': 'minor_axis'},
-    stat_axis=2)
+    klass_name   = 'Panel4D',
+    axis_orders  = ['labels', 'items', 'major_axis', 'minor_axis'],
+    axis_slices  = {'labels': 'labels', 'items': 'items',
+                    'major_axis': 'major_axis',
+                    'minor_axis': 'minor_axis'},
+    slicer       = Panel,
+    axis_aliases = {'major': 'major_axis', 'minor': 'minor_axis'},
+    stat_axis    = 2)
 
 
 def panel4d_init(self, data=None, labels=None, items=None, major_axis=None,

--- a/pandas/core/panel4d.py
+++ b/pandas/core/panel4d.py
@@ -4,14 +4,14 @@ from pandas.core.panelnd import create_nd_panel_factory
 from pandas.core.panel import Panel
 
 Panel4D = create_nd_panel_factory(
-    klass_name   = 'Panel4D',
-    axis_orders  = ['labels', 'items', 'major_axis', 'minor_axis'],
-    axis_slices  = {'labels': 'labels', 'items': 'items',
+    klass_name = 'Panel4D',
+    orders     = ['labels', 'items', 'major_axis', 'minor_axis'],
+    slices     = {'labels': 'labels', 'items': 'items',
                     'major_axis': 'major_axis',
                     'minor_axis': 'minor_axis'},
-    slicer       = Panel,
-    axis_aliases = {'major': 'major_axis', 'minor': 'minor_axis'},
-    stat_axis    = 2)
+    slicer     = Panel,
+    aliases    = {'major': 'major_axis', 'minor': 'minor_axis'},
+    stat_axis  = 2)
 
 
 def panel4d_init(self, data=None, labels=None, items=None, major_axis=None,

--- a/pandas/core/panelnd.py
+++ b/pandas/core/panelnd.py
@@ -3,20 +3,20 @@
 import pandas.lib as lib
 
 
-def create_nd_panel_factory(klass_name, axis_orders, axis_slices, slicer, axis_aliases=None, stat_axis=2):
+def create_nd_panel_factory(klass_name, orders, slices, slicer, aliases=None, stat_axis=2, info_axis=0):
     """ manufacture a n-d class:
 
         parameters
         ----------
-        klass_name  : the klass name
-        axis_orders : the names of the axes in order (highest to lowest)
-        axis_slices : a dictionary that defines how the axes map to the sliced axis
-        slicer      : the class representing a slice of this panel
-        axis_aliases: a dictionary defining aliases for various axes
+        klass_name : the klass name
+        orders     : the names of the axes in order (highest to lowest)
+        slices     : a dictionary that defines how the axes map to the sliced axis
+        slicer     : the class representing a slice of this panel
+        aliases    : a dictionary defining aliases for various axes
                         default = { major : major_axis, minor : minor_axis }
-        stat_axis   : the default statistic axis
+        stat_axis  : the default statistic axis
                         default = 2
-        het_axis    : the info axis
+        info_axis  : the info axis
 
 
         returns
@@ -37,22 +37,14 @@ def create_nd_panel_factory(klass_name, axis_orders, axis_slices, slicer, axis_a
     # build the klass
     klass = type(klass_name, (slicer,), {})
 
-    # add the class variables
-    klass._AXIS_ORDERS = axis_orders
-    klass._AXIS_NUMBERS = dict([(a, i) for i, a in enumerate(axis_orders)])
-    klass._AXIS_ALIASES = axis_aliases or dict()
-    klass._AXIS_NAMES = dict([(i, a) for i, a in enumerate(axis_orders)])
-    klass._AXIS_SLICEMAP = axis_slices
-    klass._AXIS_LEN = len(axis_orders)
-    klass._default_stat_axis = stat_axis
-    klass._het_axis = 0
-    klass._info_axis = axis_orders[klass._het_axis]
+    # setup the axes
+    klass._setup_axes(axes      = orders,
+                      info_axis = info_axis,
+                      stat_axis = stat_axis,
+                      aliases   = aliases,
+                      slicers   = slices)
 
     klass._constructor_sliced = slicer
-
-    # add the axes
-    for i, a in enumerate(axis_orders):
-        setattr(klass, a, lib.AxisProperty(i))
 
     #### define the methods ####
     def __init__(self, *args, **kwargs):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2521,30 +2521,6 @@ class Series(pa.Array, generic.PandasObject):
             raise ValueError("cannot reindex series on non-zero axis!")
         return self.reindex(index=labels,**kwargs)
 
-    def reindex_like(self, other, method=None, limit=None, fill_value=pa.NA):
-        """
-        Reindex Series to match index of another Series, optionally with
-        filling logic
-
-        Parameters
-        ----------
-        other : Series
-        method : string or None
-            See Series.reindex docstring
-        limit : int, default None
-            Maximum size gap to forward or backward fill
-
-        Notes
-        -----
-        Like calling s.reindex(other.index, method=...)
-
-        Returns
-        -------
-        reindexed : Series
-        """
-        return self.reindex(other.index, method=method, limit=limit,
-                            fill_value=fill_value)
-
     def take(self, indices, axis=0, convert=True):
         """
         Analogous to ndarray.take, return Series corresponding to requested

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2540,7 +2540,7 @@ class Series(pa.Array, generic.PandasObject):
         new_values = self.values.take(indices)
         return Series(new_values, index=new_index, name=self.name)
 
-    truncate = generic.truncate
+    truncate = generic.PandasObject.truncate
 
     def fillna(self, value=None, method=None, inplace=False,
                limit=None):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -381,11 +381,6 @@ def _make_stat_func(nanop, name, shortname, na_action=_doc_exclude_na,
 
 
 class Series(pa.Array, generic.PandasObject):
-    _AXIS_NUMBERS = {
-        'index': 0
-    }
-
-    _AXIS_NAMES = dict((v, k) for k, v in _AXIS_NUMBERS.iteritems())
 
     def __new__(cls, data=None, index=None, dtype=None, name=None,
                 copy=False):
@@ -3163,6 +3158,7 @@ class Series(pa.Array, generic.PandasObject):
         from pandas.core.strings import StringMethods
         return StringMethods(self)
 
+Series._setup_axes(['index'], build_axes = False)
 _INDEX_TYPES = ndarray, Index, list, tuple
 
 #------------------------------------------------------------------------------

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -602,8 +602,11 @@ class SparseDataFrame(DataFrame):
         return SparseDataFrame(sdict, index=self.index, columns=columns,
                                default_fill_value=self.default_fill_value)
 
-    def _reindex_with_indexers(self, index, row_indexer, columns, col_indexer,
-                               copy, fill_value):
+    def _reindex_with_indexers(self, reindexers, method=None, copy=False, fill_value=np.nan):
+
+        index,   row_indexer = reindexers.get(0,(None,None))
+        columns, col_indexer = reindexers.get(1,(None, None))
+
         if columns is None:
             columns = self.columns
 

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -69,11 +69,13 @@ class SparseDataFrame(DataFrame):
     _columns = None
     _series = None
     _is_mixed_type = False
-    _col_klass = SparseSeries
     ndim = 2
 
+    _constructor_sliced = SparseSeries
+
     def __init__(self, data=None, index=None, columns=None,
-                 default_kind='block', default_fill_value=None):
+                 default_kind='block', default_fill_value=None,
+                 copy=False):
         if default_fill_value is None:
             default_fill_value = np.nan
 
@@ -383,7 +385,7 @@ class SparseDataFrame(DataFrame):
 
             return self[label]
             # values = self._data.iget(i)
-            # return self._col_klass.from_array(
+            # return self._constructor_sliced.from_array(
             #     values, index=self.index, name=label,
             #     fill_value= self.default_fill_value)
 

--- a/pandas/sparse/panel.py
+++ b/pandas/sparse/panel.py
@@ -60,7 +60,8 @@ class SparsePanel(Panel):
     ndim = 3
 
     def __init__(self, frames, items=None, major_axis=None, minor_axis=None,
-                 default_fill_value=np.nan, default_kind='block'):
+                 default_fill_value=np.nan, default_kind='block',
+                 copy=False):
         if isinstance(frames, np.ndarray):
             new_frames = {}
             for item, vals in zip(items, frames):

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -570,6 +570,5 @@ to sparse
         dense_combined = self.to_dense().combine_first(other)
         return dense_combined.to_sparse(fill_value=self.fill_value)
 
-
 class SparseTimeSeries(SparseSeries, TimeSeries):
     pass

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -7172,10 +7172,19 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
     def test_filter(self):
         # items
-
         filtered = self.frame.filter(['A', 'B', 'E'])
         self.assertEqual(len(filtered.columns), 2)
         self.assert_('E' not in filtered)
+
+        filtered = self.frame.filter(['A', 'B', 'E'], axis='columns')
+        self.assertEqual(len(filtered.columns), 2)
+        self.assert_('E' not in filtered)
+
+        # other axis
+        idx = self.frame.index[0:4]
+        filtered = self.frame.filter(idx, axis='index')
+        expected = self.frame.reindex(index=idx)
+        assert_frame_equal(filtered,expected)
 
         # like
         fcopy = self.frame.copy()

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -6242,6 +6242,11 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         newFrame = self.frame.reindex(list(self.ts1.index))
         self.assert_(newFrame.index.equals(self.ts1.index))
 
+        # copy with no axes
+        result = self.frame.reindex()
+        assert_frame_equal(result,self.frame)
+        self.assert_((result is self.frame) == False)
+
     def test_reindex_name_remains(self):
         s = Series(random.rand(10))
         df = DataFrame(s, index=np.arange(len(s)))

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -6329,6 +6329,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         assert_frame_equal(result, expected)
 
     def test_align(self):
+
         af, bf = self.frame.align(self.frame)
         self.assert_(af._data is not self.frame._data)
 

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -326,8 +326,14 @@ class TestBlockManager(unittest.TestCase):
     def test_copy(self):
         shallow = self.mgr.copy(deep=False)
 
-        for cp_blk, blk in zip(shallow.blocks, self.mgr.blocks):
-            self.assert_(cp_blk.values is blk.values)
+        # we don't guaranteee block ordering
+        for blk in self.mgr.blocks:
+            found = False
+            for cp_blk in shallow.blocks:
+                if cp_blk.values is blk.values:
+                    found = True
+                    break
+            self.assert_(found == True)
 
     def test_as_matrix_float(self):
 

--- a/pandas/tests/test_ndframe.py
+++ b/pandas/tests/test_ndframe.py
@@ -14,21 +14,6 @@ class TestNDFrame(unittest.TestCase):
         tdf = t.makeTimeDataFrame()
         self.ndf = NDFrame(tdf._data)
 
-    def test_constructor(self):
-        # with cast
-        ndf = NDFrame(self.ndf._data, dtype=np.int64)
-        self.assert_(ndf.values.dtype == np.int64)
-
-    def test_ndim(self):
-        self.assertEquals(self.ndf.ndim, 2)
-
-    def test_astype(self):
-        casted = self.ndf.astype(int)
-        self.assert_(casted.values.dtype == np.int_)
-
-        casted = self.ndf.astype(np.int32)
-        self.assert_(casted.values.dtype == np.int32)
-
     def test_squeeze(self):
         # noop
         for s in [ t.makeFloatSeries(), t.makeStringSeries(), t.makeObjectSeries() ]:

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -980,7 +980,8 @@ class TestPanel(unittest.TestCase, PanelTests, CheckIndexing,
 
         # this ok
         result = self.panel.reindex()
-        self.assert_(result == self.panel)
+        assert_panel_equal(result,self.panel)
+        self.assert_((result is self.panel) == False)
 
         # with filling
         smaller_major = self.panel.major_axis[::5]

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1103,8 +1103,10 @@ class TestPanel(unittest.TestCase, PanelTests, CheckIndexing,
         result = self.panel.swapaxes(0, 1)
         self.assert_(result.items is self.panel.major_axis)
 
-        # this should not work
-        self.assertRaises(Exception, self.panel.swapaxes, 'items', 'items')
+        # this works, but return a copy
+        result = self.panel.swapaxes('items', 'items')
+        assert_panel_equal(self.panel,result)
+        self.assert_(id(self.panel) != id(result))
 
     def test_transpose(self):
         result = self.panel.transpose('minor', 'major', 'items')

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1703,15 +1703,18 @@ class TestLongPanel(unittest.TestCase):
 def test_monotonic():
     pos = np.array([1, 2, 3, 5])
 
-    assert panelm._monotonic(pos)
+    def _monotonic(arr):
+        return not (arr[1:] < arr[:-1]).any()
+
+    assert _monotonic(pos)
 
     neg = np.array([1, 2, 3, 4, 3])
 
-    assert not panelm._monotonic(neg)
+    assert not _monotonic(neg)
 
     neg2 = np.array([5, 1, 2, 3, 4, 5])
 
-    assert not panelm._monotonic(neg2)
+    assert not _monotonic(neg2)
 
 
 def test_panel_index():

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -974,11 +974,13 @@ class TestPanel(unittest.TestCase, PanelTests, CheckIndexing,
                                     major=self.panel.major_axis,
                                     minor=self.panel.minor_axis)
 
-        assert(result.items is self.panel.items)
-        assert(result.major_axis is self.panel.major_axis)
-        assert(result.minor_axis is self.panel.minor_axis)
+        self.assert_(result.items is self.panel.items)
+        self.assert_(result.major_axis is self.panel.major_axis)
+        self.assert_(result.minor_axis is self.panel.minor_axis)
 
-        self.assertRaises(Exception, self.panel.reindex)
+        # this ok
+        result = self.panel.reindex()
+        self.assert_(result == self.panel)
 
         # with filling
         smaller_major = self.panel.major_axis[::5]
@@ -992,7 +994,8 @@ class TestPanel(unittest.TestCase, PanelTests, CheckIndexing,
 
         # don't necessarily copy
         result = self.panel.reindex(major=self.panel.major_axis, copy=False)
-        self.assert_(result is self.panel)
+        assert_panel_equal(result,self.panel)
+        self.assert_((result is self.panel) == False)
 
     def test_reindex_like(self):
         # reindex_like

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -771,7 +771,8 @@ class TestPanel4d(unittest.TestCase, CheckIndexing, SafeForSparse,
 
         # don't necessarily copy
         result = self.panel4d.reindex()
-        self.assert_(result is self.panel4d)
+        assert_panel4d_equal(result,self.panel4d)
+        self.assert_((result is self.panel4d) == False)
 
         # with filling
         smaller_major = self.panel4d.major_axis[::5]

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -769,7 +769,9 @@ class TestPanel4d(unittest.TestCase, CheckIndexing, SafeForSparse,
         assert(result.major_axis is self.panel4d.major_axis)
         assert(result.minor_axis is self.panel4d.minor_axis)
 
-        self.assertRaises(Exception, self.panel4d.reindex)
+        # don't necessarily copy
+        result = self.panel4d.reindex()
+        self.assert_(result is self.panel4d)
 
         # with filling
         smaller_major = self.panel4d.major_axis[::5]
@@ -784,7 +786,8 @@ class TestPanel4d(unittest.TestCase, CheckIndexing, SafeForSparse,
         # don't necessarily copy
         result = self.panel4d.reindex(
             major=self.panel4d.major_axis, copy=False)
-        self.assert_(result is self.panel4d)
+        assert_panel4d_equal(result,self.panel4d)
+        self.assert_((result is self.panel4d) == False)
 
     def test_reindex_like(self):
         # reindex_like

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -880,8 +880,10 @@ class TestPanel4d(unittest.TestCase, CheckIndexing, SafeForSparse,
         result = self.panel4d.swapaxes(0, 1)
         self.assert_(result.labels is self.panel4d.items)
 
-        # this should also work
-        self.assertRaises(Exception, self.panel4d.swapaxes, 'items', 'items')
+        # this works, but return a copy
+        result = self.panel4d.swapaxes('items', 'items')
+        assert_panel4d_equal(self.panel4d,result)
+        self.assert_(id(self.panel4d) != id(result))
 
     def test_to_frame(self):
         raise nose.SkipTest

--- a/pandas/tests/test_panelnd.py
+++ b/pandas/tests/test_panelnd.py
@@ -29,11 +29,11 @@ class TestPanelnd(unittest.TestCase):
         # create a 4D
         Panel4D = panelnd.create_nd_panel_factory(
             klass_name='Panel4D',
-            axis_orders=['labels', 'items', 'major_axis', 'minor_axis'],
-            axis_slices={'items': 'items', 'major_axis': 'major_axis',
-                         'minor_axis': 'minor_axis'},
+            orders=['labels', 'items', 'major_axis', 'minor_axis'],
+            slices={'items': 'items', 'major_axis': 'major_axis',
+                    'minor_axis': 'minor_axis'},
             slicer=Panel,
-            axis_aliases={'major': 'major_axis', 'minor': 'minor_axis'},
+            aliases={'major': 'major_axis', 'minor': 'minor_axis'},
             stat_axis=2)
 
         p4d = Panel4D(dict(L1=tm.makePanel(), L2=tm.makePanel()))
@@ -43,11 +43,11 @@ class TestPanelnd(unittest.TestCase):
         # create a 4D
         Panel4D = panelnd.create_nd_panel_factory(
             klass_name='Panel4D',
-            axis_orders=['labels', 'items', 'major_axis', 'minor_axis'],
-            axis_slices={'items': 'items', 'major_axis': 'major_axis',
-                         'minor_axis': 'minor_axis'},
+            orders=['labels', 'items', 'major_axis', 'minor_axis'],
+            slices={'items': 'items', 'major_axis': 'major_axis',
+                    'minor_axis': 'minor_axis'},
             slicer='Panel',
-            axis_aliases={'major': 'major_axis', 'minor': 'minor_axis'},
+            aliases={'major': 'major_axis', 'minor': 'minor_axis'},
             stat_axis=2)
 
         p4d = Panel4D(dict(L1=tm.makePanel(), L2=tm.makePanel()))
@@ -58,14 +58,14 @@ class TestPanelnd(unittest.TestCase):
         self.assertRaises(Exception,
                           panelnd.create_nd_panel_factory,
                           klass_name='Panel4D',
-                          axis_orders=['labels', 'items', 'major_axis',
-                                       'minor_axis'],
-                          axis_slices={'items': 'items',
-                                       'major_axis': 'major_axis',
-                                       'minor_axis': 'minor_axis'},
+                          orders=['labels', 'items', 'major_axis',
+                                  'minor_axis'],
+                          slices={'items': 'items',
+                                  'major_axis': 'major_axis',
+                                  'minor_axis': 'minor_axis'},
                           slicer='foo',
-                          axis_aliases={'major': 'major_axis',
-                                        'minor': 'minor_axis'},
+                          aliases={'major': 'major_axis',
+                                   'minor': 'minor_axis'},
                           stat_axis=2)
 
     def test_5d_construction(self):
@@ -73,11 +73,11 @@ class TestPanelnd(unittest.TestCase):
         # create a 4D
         Panel4D = panelnd.create_nd_panel_factory(
             klass_name='Panel4D',
-            axis_orders=['labels1', 'items', 'major_axis', 'minor_axis'],
-            axis_slices={'items': 'items', 'major_axis': 'major_axis',
-                         'minor_axis': 'minor_axis'},
+            orders=['labels1', 'items', 'major_axis', 'minor_axis'],
+            slices={'items': 'items', 'major_axis': 'major_axis',
+                    'minor_axis': 'minor_axis'},
             slicer=Panel,
-            axis_aliases={'major': 'major_axis', 'minor': 'minor_axis'},
+            aliases={'major': 'major_axis', 'minor': 'minor_axis'},
             stat_axis=2)
 
         p4d = Panel4D(dict(L1=tm.makePanel(), L2=tm.makePanel()))
@@ -85,13 +85,13 @@ class TestPanelnd(unittest.TestCase):
         # create a 5D
         Panel5D = panelnd.create_nd_panel_factory(
             klass_name='Panel5D',
-            axis_orders=['cool1', 'labels1', 'items', 'major_axis',
-                         'minor_axis'],
-            axis_slices={'labels1': 'labels1', 'items': 'items',
-                         'major_axis': 'major_axis',
-                         'minor_axis': 'minor_axis'},
+            orders=['cool1', 'labels1', 'items', 'major_axis',
+                    'minor_axis'],
+            slices={'labels1': 'labels1', 'items': 'items',
+                    'major_axis': 'major_axis',
+                    'minor_axis': 'minor_axis'},
             slicer=Panel4D,
-            axis_aliases={'major': 'major_axis', 'minor': 'minor_axis'},
+            aliases={'major': 'major_axis', 'minor': 'minor_axis'},
             stat_axis=2)
 
         p5d = Panel5D(dict(C1=p4d))

--- a/vb_suite/frame_methods.py
+++ b/vb_suite/frame_methods.py
@@ -40,8 +40,8 @@ frame_fillna_inplace = Benchmark('df.fillna(0, inplace=True)', setup,
 # reindex both axes
 
 setup = common_setup + """
-df = DataFrame(randn(1000, 1000))
-idx = np.arange(400, 700)
+df = DataFrame(randn(10000, 10000))
+idx = np.arange(4000, 7000)
 """
 
 frame_reindex_axis0 = Benchmark('df.reindex(idx)', setup)


### PR DESCRIPTION
- Refactor of frame.py/panel.py to move common code to generic.py
  all axis creation and manipulation code is now common (except for Series)
  - added _setup_axes to create generic NDFrame structures
  - moved methods (some methods moved from series as well)
    - from_axes,_wrap_array,axes,ix,shape,empty,swapaxes,transpose,pop
    - **str**,**bytes**,**repr**
    - **iter**,keys,**contains**,**len**,**neg**,**invert**
    - convert_objects,as_blocks,as_matrix,values
    - **getstate**,**setstate** (though compat remains in frame/panel)
    - **getattr**,**setattr**
    - _indexed_same,reindex_like,reindex,align,where,mask
    - filter (added axis argument to selectively filter on a different axis)
    - reindex : changed a fair amount
    - truncate (moved to become part of PandasObject)
  - API Changes in Panel which make Panel more consistent with DataFrame
    - swapaxes on a Panel with the same axes specified now return a copy 
    - support attribute access for setting
    - filter supports same api as original DataFrame filter
- API change in that reindex called with no arguments will now return a copy of the input object (e.g. `df.reindex()`)

_performance is comparable to the existing codebase_

Reasoning for this change:
1. this is in preparation for a change in series to sub-class NDFrame, rather than ndarray directly, with proper support for BlockManager. _this will also theoretically allow a way to do `integer NaNs`, via a mask in the IntBlock_
2. preparation for adding SparseBlocks to BlockManager
3. future changes/additions in indexing will be more straightforward, e.g. adding an integer like `ix` can be done, hopefully in one place
4. future API compatibiliy across objects (e.g. won't have to add methods to both Frame and Panel, and there API can be pretty consistent)
