### PR TITLE
ENH: add escape parameter to to_html()

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -131,6 +131,9 @@ pandas 0.11.0
   - Add ``time()`` method to DatetimeIndex (GH3180_)
   - Return NA when using Series.str[...] for values that are not long enough
     (GH3223_)
+  - to_html() now accepts an optional "escape" argument to control reserved
+    HTML character escaping (enabled by default) and escapes ``&``, in addition
+    to ``<`` and ``>``.  (GH2919_)
 
 **API Changes**
 
@@ -390,6 +393,7 @@ pandas 0.11.0
 .. _GH3238: https://github.com/pydata/pandas/issues/3238
 .. _GH3258: https://github.com/pydata/pandas/issues/3258
 .. _GH3283: https://github.com/pydata/pandas/issues/3283
+.. _GH2919: https://github.com/pydata/pandas/issues/2919
 
 pandas 0.10.1
 =============

--- a/doc/source/v0.11.0.txt
+++ b/doc/source/v0.11.0.txt
@@ -325,6 +325,10 @@ Enhancements
   - Treat boolean values as integers (values 1 and 0) for numeric
     operations. (GH2641_)
 
+  - to_html() now accepts an optional "escape" argument to control reserved
+    HTML character escaping (enabled by default) and escapes ``&``, in addition
+    to ``<`` and ``>``.  (GH2919_)
+
 See the `full release notes
 <https://github.com/pydata/pandas/blob/master/RELEASE.rst>`__ or issue tracker
 on GitHub for a complete list.
@@ -350,3 +354,4 @@ on GitHub for a complete list.
 .. _GH3070: https://github.com/pydata/pandas/issues/3070
 .. _GH3075: https://github.com/pydata/pandas/issues/3075
 .. _GH2641: https://github.com/pydata/pandas/issues/2641
+.. _GH2919: https://github.com/pydata/pandas/issues/2919

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -495,6 +495,7 @@ class HTMLFormatter(TableFormatter):
         self.columns = formatter.columns
         self.elements = []
         self.bold_rows = self.fmt.kwds.get('bold_rows', False)
+        self.escape = self.fmt.kwds.get('escape', True)
 
     def write(self, s, indent=0):
         rs = com.pprint_thing(s)
@@ -517,7 +518,10 @@ class HTMLFormatter(TableFormatter):
         else:
             start_tag = '<%s>' % kind
 
-        esc = {'<' : r'&lt;', '>' : r'&gt;'}
+        if self.escape:
+            esc = {'<' : r'&lt;', '>' : r'&gt;', '&' : r'&amp;'}
+        else:
+            esc = {}
         rs = com.pprint_thing(s, escape_chars=esc)
         self.write(
             '%s%s</%s>' % (start_tag, rs, kind), indent)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1459,13 +1459,15 @@ class DataFrame(NDFrame):
                 header=True, index=True, na_rep='NaN', formatters=None,
                 float_format=None, sparsify=None, index_names=True,
                 justify=None, force_unicode=None, bold_rows=True,
-                classes=None):
+                classes=None, escape=True):
         """
         to_html-specific options
         bold_rows : boolean, default True
             Make the row labels bold in the output
         classes : str or list or tuple, default None
             CSS class(es) to apply to the resulting html table
+        escape : boolean, default True
+            Convert the characters <, >, and & to HTML-safe sequences.
 
         Render a DataFrame to an html table.
         """
@@ -1488,7 +1490,8 @@ class DataFrame(NDFrame):
                                            justify=justify,
                                            index_names=index_names,
                                            header=header, index=index,
-                                           bold_rows=bold_rows)
+                                           bold_rows=bold_rows,
+                                           escape=escape)
         formatter.to_html(classes=classes)
 
         if buf is None:

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -275,8 +275,8 @@ class TestDataFrameFormatting(unittest.TestCase):
         df.to_html()
 
     def test_to_html_escaped(self):
-        a = 'str<ing1'
-        b = 'stri>ng2'
+        a = 'str<ing1 &amp;'
+        b = 'stri>ng2 &amp;'
 
         test_dict = {'co<l1': {a: "<type 'str'>",
                                b: "<type 'str'>"},
@@ -293,14 +293,46 @@ class TestDataFrameFormatting(unittest.TestCase):
   </thead>
   <tbody>
     <tr>
-      <th>str&lt;ing1</th>
+      <th>str&lt;ing1 &amp;amp;</th>
       <td> &lt;type 'str'&gt;</td>
       <td> &lt;type 'str'&gt;</td>
     </tr>
     <tr>
-      <th>stri&gt;ng2</th>
+      <th>stri&gt;ng2 &amp;amp;</th>
       <td> &lt;type 'str'&gt;</td>
       <td> &lt;type 'str'&gt;</td>
+    </tr>
+  </tbody>
+</table>"""
+        self.assertEqual(xp, rs)
+
+    def test_to_html_escape_disabled(self):
+        a = 'str<ing1 &amp;'
+        b = 'stri>ng2 &amp;'
+
+        test_dict = {'co<l1': {a: "<b>bold</b>",
+                               b: "<b>bold</b>"},
+                     'co>l2': {a: "<b>bold</b>",
+                               b: "<b>bold</b>"}}
+        rs = pd.DataFrame(test_dict).to_html(escape=False)
+        xp = """<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>co<l1</th>
+      <th>co>l2</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>str<ing1 &amp;</th>
+      <td> <b>bold</b></td>
+      <td> <b>bold</b></td>
+    </tr>
+    <tr>
+      <th>stri>ng2 &amp;</th>
+      <td> <b>bold</b></td>
+      <td> <b>bold</b></td>
     </tr>
   </tbody>
 </table>"""


### PR DESCRIPTION
Treating DataFrame content as plain text, rather than HTML markup, by escaping
everything (#2617) seems like the right default for `to_html()`, however, if a DataFrame contains HTML ([example](http://stackoverflow.com/questions/14627380/pandas-html-output-with-conditional-formatting)) or text already HTML escaped, it results in either unwanted escaping or double-escaping.

Changes in this PR:
- make HTML escaping programmable through a new `to_html()` parameter named
  `escape` (default True), allowing users to restore old `to_html()` behavior (<=0.10.0) by setting `escape=False`.
- add `&` to the list of HTML chars escaped, so strings that happen to contain
  HTML escape sequences or reserved entities, such as `"&lt;"`, are displayed
  properly.
