### PR TITLE
ENH: change flatten to ravel (in internals/pytables)

### DIFF
--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -486,7 +486,7 @@ class Block(object):
 
         # our where function
         def func(c,v,o):
-            if c.flatten().all():
+            if c.ravel().all():
                 return v
             
             try:
@@ -649,7 +649,7 @@ class ObjectBlock(Block):
     @property
     def is_bool(self):
         """ we can be a bool if we have only bool values but are of type object """
-        return lib.is_bool_array(self.values.flatten())
+        return lib.is_bool_array(self.values.ravel())
 
     def convert(self, convert_dates = True, convert_numeric = True, copy = True):
         """ attempt to coerce any object types to better types
@@ -751,7 +751,7 @@ def make_block(values, items, ref_items):
 
     # try to infer a datetimeblock
     if klass is None and np.prod(values.shape):
-        flat = values.flatten()
+        flat = values.ravel()
         inferred_type = lib.infer_dtype(flat)
         if inferred_type == 'datetime':
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1088,7 +1088,7 @@ class DataCol(IndexCol):
 
         self.values = list(block.items)
         dtype = block.dtype.name
-        inferred_type = lib.infer_dtype(block.values.flatten())
+        inferred_type = lib.infer_dtype(block.values.ravel())
 
         if inferred_type == 'datetime64':
             self.set_atom_datetime64(block)
@@ -1116,7 +1116,7 @@ class DataCol(IndexCol):
         data = block.fillna(nan_rep).values
 
         # itemsize is the maximum length of a string (along any dimension)
-        itemsize = lib.max_len_string_array(data.flatten())
+        itemsize = lib.max_len_string_array(data.ravel())
 
         # specified min_itemsize?
         if isinstance(min_itemsize, dict):
@@ -1209,7 +1209,7 @@ class DataCol(IndexCol):
         # convert nans
         if self.kind == 'string':
             self.data = lib.array_replace_from_nan_rep(
-                self.data.flatten(), nan_rep).reshape(self.data.shape)
+                self.data.ravel(), nan_rep).reshape(self.data.shape)
         return self
 
     def get_attr(self):
@@ -1628,7 +1628,7 @@ class GenericStorer(Storer):
         if value.dtype.type == np.object_:
 
             # infer the type, warn if we have a non-string type here (for performance)
-            inferred_type = lib.infer_dtype(value.flatten())
+            inferred_type = lib.infer_dtype(value.ravel())
             if empty_array:
                 pass
             elif inferred_type == 'string':

--- a/pandas/stats/var.py
+++ b/pandas/stats/var.py
@@ -342,7 +342,7 @@ BIC:                            %(bic).3f
 
             for t in xrange(T + 1):
                 index = t + p
-                y = values.take(xrange(index, index - p, -1), axis=0).flatten()
+                y = values.take(xrange(index, index - p, -1), axis=0).ravel()
                 trans_Z = np.hstack(([1], y))
                 trans_Z = trans_Z.reshape(1, len(trans_Z))
 

--- a/vb_suite/io_bench.py
+++ b/vb_suite/io_bench.py
@@ -45,6 +45,20 @@ df = DataFrame(np.random.randn(3000, 30))
 frame_to_csv = Benchmark("df.to_csv('__test__.csv')", setup,
                          start_date=datetime(2011, 1, 1))
 
+#----------------------------------
+setup = common_setup + """
+from pandas import concat, Timestamp
+
+df_float  = DataFrame(np.random.randn(1000, 30),dtype='float64')
+df_int    = DataFrame(np.random.randn(1000, 30),dtype='int64')
+df_bool   = DataFrame(True,index=df_float.index,columns=df_float.columns)
+df_object = DataFrame('foo',index=df_float.index,columns=df_float.columns)
+df_dt     = DataFrame(Timestamp('20010101'),index=df_float.index,columns=df_float.columns)
+df        = concat([ df_float, df_int, df_bool, df_object, df_dt ], axis=1)
+"""
+frame_to_csv_mixed = Benchmark("df.to_csv('__test__.csv')", setup,
+                               start_date=datetime(2012, 6, 1))
+
 #----------------------------------------------------------------------
 # parse dates, ISO8601 format
 


### PR DESCRIPTION
- micro-tweak yields small but non-zero perf gains, as ravel doesn't copy uncessarily
- added frame_to_csv_mixed to vbench
