### PR TITLE
ENH: numexpr on boolean frames

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,11 @@ Dependencies
   * `pytz <http://pytz.sourceforge.net/>`__
      * Needed for time zone support with ``date_range``
 
+Highly Recommended Dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  * `numexpr <http://code.google.com/p/numexpr/>`__: to accelerate some expression evaluation operations
+  * `bottleneck <http://berkeleyanalytics.com/>`__: to accelerate certain numerical operations
+
 Optional dependencies
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,7 @@ Dependencies
 Highly Recommended Dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   * `numexpr <http://code.google.com/p/numexpr/>`__: to accelerate some expression evaluation operations
+       also required by `PyTables`
   * `bottleneck <http://berkeleyanalytics.com/>`__: to accelerate certain numerical operations
 
 Optional dependencies

--- a/doc/source/v0.11.0.txt
+++ b/doc/source/v0.11.0.txt
@@ -224,6 +224,12 @@ API changes
 Enhancements
 ~~~~~~~~~~~~
 
+  - Numexpr is now a 'highly recommended dependency', to accelerate certain
+    types of expression evaluation
+
+  - Bottleneck is now a 'highly recommended dependency', to accelerate certain
+    types of numerical evaluations
+
   - In ``HDFStore``, provide dotted attribute access to ``get`` from stores
     (e.g. ``store.df == store['df']``)
 

--- a/pandas/core/expressions.py
+++ b/pandas/core/expressions.py
@@ -1,0 +1,101 @@
+"""
+Expressions
+-----------
+
+Offer fast expression evaluation thru numexpr
+
+"""
+import numpy as np
+
+try:
+    import numexpr as ne
+    _USE_NUMEXPR = True
+except ImportError:  # pragma: no cover
+    _USE_NUMEXPR = False
+
+# the set of dtypes that we will allow pass to numexpr
+_ALLOWED_DTYPES = set(['int64','int32','float64','float32','bool'])
+
+# the minimum prod shape that we will use numexpr
+_MIN_ELEMENTS   = 10000
+
+def _evaluate_standard(op, op_str, a, b, raise_on_error=True):
+    """ standard evaluation """
+    return op(a,b)
+
+def _can_use_numexpr(op, op_str, a, b):
+    """ return a boolean if we WILL be using numexpr """
+    if op_str is not None:
+        
+        # required min elements (otherwise we are adding overhead)
+        if np.prod(a.shape) > _MIN_ELEMENTS:
+
+            # check for dtype compatiblity
+            dtypes = set()
+            for o in [ a, b ]:
+                if hasattr(o,'get_dtype_counts'):
+                    s = o.get_dtype_counts()
+                    if len(s) > 1:
+                        return False
+                    dtypes |= set(s.index)
+                elif isinstance(o,np.ndarray):
+                    dtypes |= set([o.dtype.name])
+
+            # allowed are a superset
+            if not len(dtypes) or _ALLOWED_DTYPES >= dtypes:
+                return True
+
+    return False
+
+def _evaluate_numexpr(op, op_str, a, b, raise_on_error = False):
+    result = None
+
+    if _can_use_numexpr(op, op_str, a, b):
+        try:
+            a_value, b_value = a, b
+            if hasattr(a_value,'values'):
+                a_value = a_value.values
+            if hasattr(b_value,'values'):
+                b_value = b_value.values
+            result = ne.evaluate('a_value %s b_value' % op_str, 
+                                 local_dict={ 'a_value' : a_value, 
+                                              'b_value' : b_value }, 
+                                 casting='safe')
+        except (ValueError), detail:
+            if 'unknown type object' in str(detail):
+                pass
+        except (Exception), detail:
+            if raise_on_error:
+                raise TypeError(str(detail))
+
+    if result is None:
+        result = _evaluate_standard(op,op_str,a,b,raise_on_error)
+
+    return result
+
+# choose what we are going to do
+if not _USE_NUMEXPR:
+    _evaluate = _evaluate_standard
+else:
+    _evaluate = _evaluate_numexpr
+
+def evaluate(op, op_str, a, b, raise_on_error=False, use_numexpr=True):
+    """ evaluate and return the expression of the op on a and b
+
+        Parameters
+        ----------
+
+        op :    the actual operand
+        op_str: the string version of the op
+        a :     left operand
+        b :     right operand
+        raise_on_error : pass the error to the higher level if indicated (default is False),
+                         otherwise evaluate the op with and return the results
+        use_numexpr : whether to try to use numexpr (default True)
+        """
+
+    if use_numexpr:
+        return _evaluate(op, op_str, a, b, raise_on_error=raise_on_error)
+    return _evaluate_standard(op, op_str, a, b, raise_on_error=raise_on_error)
+
+ 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -606,6 +606,11 @@ class NDFrame(PandasObject):
         except KeyError:
             pass
 
+    def get_dtype_counts(self):
+        """ return the counts of dtypes in this frame """
+        from pandas import Series
+        return Series(self._data.get_dtype_counts())
+
     def pop(self, item):
         """
         Return item and drop from frame. Raise KeyError if not found.

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -418,17 +418,17 @@ class Block(object):
         args = [ values, other ]
         try:
             result = func(*args)
-        except:
+        except (Exception), detail:
             if raise_on_error:
-                raise TypeError('Coulnd not operate %s with block values'
-                                % repr(other))
+                raise TypeError('Could not operate [%s] with block values [%s]'
+                                % (repr(other),str(detail)))
             else:
                 # return the values
                 result = np.empty(values.shape,dtype='O')
                 result.fill(np.nan)
 
         if not isinstance(result, np.ndarray):
-            raise TypeError('Could not compare %s with block values'
+            raise TypeError('Could not compare [%s] with block values'
                             % repr(other))
 
         if is_transposed:
@@ -492,10 +492,10 @@ class Block(object):
             
             try:
                 return np.where(c,v,o)
-            except:
+            except (Exception), detail:
                 if raise_on_error:
-                    raise TypeError('Coulnd not operate %s with block values'
-                                    % repr(o))
+                    raise TypeError('Could not operate [%s] with block values [%s]'
+                                    % (repr(o),str(detail)))
                 else:
                     # return the values
                     result = np.empty(v.shape,dtype='float64')
@@ -504,7 +504,7 @@ class Block(object):
 
         def create_block(result, items, transpose = True):
             if not isinstance(result, np.ndarray):
-                raise TypeError('Could not compare %s with block values'
+                raise TypeError('Could not compare [%s] with block values'
                                 % repr(other))
 
             if transpose and is_transposed:
@@ -842,6 +842,14 @@ class BlockManager(object):
     def _get_items(self):
         return self.axes[0]
     items = property(fget=_get_items)
+
+    def get_dtype_counts(self):
+        """ return a dict of the counts of dtypes in BlockManager """
+        self._consolidate_inplace()
+        counts = dict()
+        for b in self.blocks:
+            counts[b.dtype.name] = counts.get(b.dtype,0) + b.shape[0]
+        return counts
 
     def __getstate__(self):
         block_values = [b.values for b in self.blocks]

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -695,6 +695,9 @@ class Series(pa.Array, generic.PandasObject):
         except Exception:
             return self.values[indexer]
 
+    def get_dtype_counts(self):
+        return Series({ self.dtype.name : 1 })
+
     def where(self, cond, other=nan, inplace=False):
         """
         Return a Series where cond is True; otherwise values are from other

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -1,0 +1,109 @@
+# pylint: disable-msg=W0612,E1101
+
+import unittest
+import nose
+
+import operator
+from numpy import random, nan
+from numpy.random import randn
+import numpy as np
+from numpy.testing import assert_array_equal
+
+import pandas as pan
+from pandas.core.api import DataFrame, Series, notnull, isnull
+from pandas.core import expressions
+
+from pandas.util.testing import (assert_almost_equal,
+                                 assert_series_equal,
+                                 assert_frame_equal)
+from pandas.util import py3compat
+
+import pandas.util.testing as tm
+import pandas.lib as lib
+
+from numpy.testing.decorators import slow
+
+if not expressions._USE_NUMEXPR:
+    raise nose.SkipTest
+
+_frame  = DataFrame(np.random.randn(10000, 4), columns = list('ABCD'), dtype='float64')
+_frame2 = DataFrame(np.random.randn(100, 4),   columns = list('ABCD'), dtype='float64')
+_mixed  = DataFrame({ 'A' : _frame['A'].copy(), 'B' : _frame['B'].astype('float32'), 'C' : _frame['C'].astype('int64'), 'D' : _frame['D'].astype('int32') })
+_mixed2 = DataFrame({ 'A' : _frame2['A'].copy(), 'B' : _frame2['B'].astype('float32'), 'C' : _frame2['C'].astype('int64'), 'D' : _frame2['D'].astype('int32') })
+
+class TestExpressions(unittest.TestCase):
+
+    _multiprocess_can_split_ = False
+
+    def setUp(self):
+
+        self.frame  = _frame.copy()
+        self.frame2 = _frame2.copy()
+        self.mixed  = _mixed.copy()
+        self.mixed2 = _mixed2.copy()
+
+
+    def test_invalid(self):
+
+        # no op
+        result   = expressions._can_use_numexpr(operator.add, None, self.frame, self.frame)
+        self.assert_(result == False)
+
+        # mixed
+        result   = expressions._can_use_numexpr(operator.add, '+', self.mixed, self.frame)
+        self.assert_(result == False)
+
+        # min elements
+        result   = expressions._can_use_numexpr(operator.add, '+', self.frame2, self.frame2)
+        self.assert_(result == False)
+
+        # ok, we only check on first part of expression
+        result   = expressions._can_use_numexpr(operator.add, '+', self.frame, self.frame2)
+        self.assert_(result == True)
+
+    def test_binary_ops(self):
+
+        for f, f2 in [ (self.frame, self.frame2), (self.mixed, self.mixed2) ]:
+
+            for op, op_str in [('add','+'),('sub','-'),('mul','*'),('div','/'),('pow','**')]:
+
+                op = getattr(operator,op)
+                result   = expressions._can_use_numexpr(op, op_str, f, f)
+                self.assert_(result == (not f._is_mixed_type))
+
+                result   = expressions.evaluate(op, op_str, f, f, use_numexpr=True)
+                expected = expressions.evaluate(op, op_str, f, f, use_numexpr=False)
+                assert_array_equal(result,expected.values)
+                
+                result   = expressions._can_use_numexpr(op, op_str, f2, f2)
+                self.assert_(result == False)
+
+    def test_boolean_ops(self):
+
+        for f, f2 in [ (self.frame, self.frame2), (self.mixed, self.mixed2) ]:
+
+            f11 = f
+            f12 = f + 1
+            
+            f21 = f2
+            f22 = f2 + 1
+
+            for op, op_str in [('gt','>'),('lt','<'),('ge','>='),('le','<='),('eq','=='),('ne','!=')]:
+
+                op = getattr(operator,op)
+
+                result   = expressions._can_use_numexpr(op, op_str, f11, f12)
+                self.assert_(result == (not f11._is_mixed_type))
+
+                result   = expressions.evaluate(op, op_str, f11, f12, use_numexpr=True)
+                expected = expressions.evaluate(op, op_str, f11, f12, use_numexpr=False)
+                assert_array_equal(result,expected.values)
+                
+                result   = expressions._can_use_numexpr(op, op_str, f21, f22)
+                self.assert_(result == False)
+
+if __name__ == '__main__':
+    # unittest.main()
+    import nose
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   exit=False)

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,8 @@ if sys.version_info[0] >= 3:
                          'install_requires': ['python-dateutil >= 2',
                                               'pytz',
                                               'numpy >= %s' % min_numpy_ver],
+                         'extras_require' : { 'numexpr' : ['numexpr>=1.4.2'], 
+                                              'bottleneck' : ['bottleneck>=0.5.0'] },
                          'use_2to3_exclude_fixers': ['lib2to3.fixes.fix_next',
                                                      ],
                          }

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,6 @@ if sys.version_info[0] >= 3:
                          'install_requires': ['python-dateutil >= 2',
                                               'pytz',
                                               'numpy >= %s' % min_numpy_ver],
-                         'extras_require' : { 'numexpr' : ['numexpr>=1.4.2'], 
-                                              'bottleneck' : ['bottleneck>=0.5.0'] },
                          'use_2to3_exclude_fixers': ['lib2to3.fixes.fix_next',
                                                      ],
                          }

--- a/vb_suite/binary_ops.py
+++ b/vb_suite/binary_ops.py
@@ -3,3 +3,33 @@ from datetime import datetime
 
 common_setup = """from pandas_vb_common import *
 """
+
+SECTION = 'Binary ops'
+
+#----------------------------------------------------------------------
+# binary ops
+
+setup = common_setup + """
+df  = DataFrame(np.random.randn(100000, 100))
+df2 = DataFrame(np.random.randn(100000, 100))
+"""
+frame_add = \
+    Benchmark("df + df2", setup, name='frame_add',
+              start_date=datetime(2012, 1, 1))
+
+setup = common_setup + """
+df  = DataFrame(np.random.randn(100000, 100))
+df2 = DataFrame(np.random.randn(100000, 100))
+"""
+frame_mult = \
+    Benchmark("df * df2", setup, name='frame_mult',
+              start_date=datetime(2012, 1, 1))
+
+setup = common_setup + """
+df  = DataFrame(np.random.randn(100000, 100))
+df2 = DataFrame(np.random.randn(100000, 100))
+"""
+frame_multi_and = \
+    Benchmark("df[(df>0) & (df2>0)]", setup, name='frame_multi_and',
+              start_date=datetime(2012, 1, 1))
+

--- a/vb_suite/binary_ops.py
+++ b/vb_suite/binary_ops.py
@@ -9,6 +9,9 @@ SECTION = 'Binary ops'
 #----------------------------------------------------------------------
 # binary ops
 
+#----------------------------------------------------------------------
+# add
+
 setup = common_setup + """
 df  = DataFrame(np.random.randn(100000, 100))
 df2 = DataFrame(np.random.randn(100000, 100))
@@ -16,6 +19,30 @@ df2 = DataFrame(np.random.randn(100000, 100))
 frame_add = \
     Benchmark("df + df2", setup, name='frame_add',
               start_date=datetime(2012, 1, 1))
+
+setup = common_setup + """
+import pandas.core.expressions as expr
+df  = DataFrame(np.random.randn(100000, 100))
+df2 = DataFrame(np.random.randn(100000, 100))
+expr.set_numexpr_threads(1)
+"""
+
+frame_add_st = \
+    Benchmark("df + df2", setup, name='frame_add_st',cleanup="expr.set_numexpr_threads()",
+              start_date=datetime(2012, 1, 1))
+
+setup = common_setup + """
+import pandas.core.expressions as expr
+df  = DataFrame(np.random.randn(100000, 100))
+df2 = DataFrame(np.random.randn(100000, 100))
+expr.set_use_numexpr(False)
+"""
+frame_add_no_ne = \
+    Benchmark("df + df2", setup, name='frame_add_no_ne',cleanup="expr.set_use_numexpr(True)",
+              start_date=datetime(2012, 1, 1))
+
+#----------------------------------------------------------------------
+# mult
 
 setup = common_setup + """
 df  = DataFrame(np.random.randn(100000, 100))
@@ -26,10 +53,53 @@ frame_mult = \
               start_date=datetime(2012, 1, 1))
 
 setup = common_setup + """
+import pandas.core.expressions as expr
+df  = DataFrame(np.random.randn(100000, 100))
+df2 = DataFrame(np.random.randn(100000, 100))
+expr.set_numexpr_threads(1)
+"""
+frame_mult_st = \
+    Benchmark("df * df2", setup, name='frame_mult_st',cleanup="expr.set_numexpr_threads()",
+              start_date=datetime(2012, 1, 1))
+
+setup = common_setup + """
+import pandas.core.expressions as expr
+df  = DataFrame(np.random.randn(100000, 100))
+df2 = DataFrame(np.random.randn(100000, 100))
+expr.set_use_numexpr(False)
+"""
+frame_mult_no_ne = \
+    Benchmark("df * df2", setup, name='frame_mult_no_ne',cleanup="expr.set_use_numexpr(True)",
+              start_date=datetime(2012, 1, 1))
+
+#----------------------------------------------------------------------
+# multi and
+
+setup = common_setup + """
 df  = DataFrame(np.random.randn(100000, 100))
 df2 = DataFrame(np.random.randn(100000, 100))
 """
 frame_multi_and = \
     Benchmark("df[(df>0) & (df2>0)]", setup, name='frame_multi_and',
+              start_date=datetime(2012, 1, 1))
+
+setup = common_setup + """
+import pandas.core.expressions as expr
+df  = DataFrame(np.random.randn(100000, 100))
+df2 = DataFrame(np.random.randn(100000, 100))
+expr.set_numexpr_threads(1)
+"""
+frame_multi_and_st = \
+    Benchmark("df[(df>0) & (df2>0)]", setup, name='frame_multi_and_st',cleanup="expr.set_numexpr_threads()",
+              start_date=datetime(2012, 1, 1))
+
+setup = common_setup + """
+import pandas.core.expressions as expr
+df  = DataFrame(np.random.randn(100000, 100))
+df2 = DataFrame(np.random.randn(100000, 100))
+expr.set_use_numexpr(False)
+"""
+frame_multi_and_no_ne = \
+    Benchmark("df[(df>0) & (df2>0)]", setup, name='frame_multi_and_no_ne',cleanup="expr.set_use_numexpr(True)",
               start_date=datetime(2012, 1, 1))
 

--- a/vb_suite/indexing.py
+++ b/vb_suite/indexing.py
@@ -102,6 +102,28 @@ indexing_dataframe_boolean = \
     Benchmark("df > df2", setup, name='indexing_dataframe_boolean',
               start_date=datetime(2012, 1, 1))
 
+setup = common_setup + """
+import pandas.core.expressions as expr
+df  = DataFrame(np.random.randn(100000, 100))
+df2 = DataFrame(np.random.randn(100000, 100))
+expr.set_numexpr_threads(1)
+"""
+
+indexing_dataframe_boolean_st = \
+    Benchmark("df > df2", setup, name='indexing_dataframe_boolean_st',cleanup="expr.set_numexpr_threads()",
+              start_date=datetime(2012, 1, 1))
+
+setup = common_setup + """
+import pandas.core.expressions as expr
+df  = DataFrame(np.random.randn(100000, 100))
+df2 = DataFrame(np.random.randn(100000, 100))
+expr.set_use_numexpr(False)
+"""
+
+indexing_dataframe_boolean_no_ne = \
+    Benchmark("df > df2", setup, name='indexing_dataframe_boolean_no_ne',cleanup="expr.set_use_numexpr(True)",
+              start_date=datetime(2012, 1, 1))
+
 #----------------------------------------------------------------------
 # MultiIndex sortlevel
 

--- a/vb_suite/indexing.py
+++ b/vb_suite/indexing.py
@@ -83,7 +83,7 @@ bm_df_getitem3 = Benchmark(statement, setup,
 # Boolean DataFrame row selection
 
 setup = common_setup + """
-df = DataFrame(np.random.randn(10000, 4), columns=['A', 'B', 'C', 'D'])
+df  = DataFrame(np.random.randn(10000, 4), columns=['A', 'B', 'C', 'D'])
 indexer = df['B'] > 0
 obj_indexer = indexer.astype('O')
 """
@@ -93,6 +93,14 @@ indexing_dataframe_boolean_rows = \
 indexing_dataframe_boolean_rows_object = \
     Benchmark("df[obj_indexer]", setup,
               name='indexing_dataframe_boolean_rows_object')
+
+setup = common_setup + """
+df  = DataFrame(np.random.randn(100000, 100))
+df2 = DataFrame(np.random.randn(100000, 100))
+"""
+indexing_dataframe_boolean = \
+    Benchmark("df > df2", setup, name='indexing_dataframe_boolean',
+              start_date=datetime(2012, 1, 1))
 
 #----------------------------------------------------------------------
 # MultiIndex sortlevel


### PR DESCRIPTION
simple usage of using numexpr on boolean type frame comparison

```
name                                                                    
indexing_dataframe_boolean                 13.3200   125.3521     0.1063
frame_mult                                 21.7157    36.6353     0.5928
frame_add                                  22.0432    36.5021     0.6039
frame_multi_and                           385.4241   407.4359     0.9460
```
- optional use of numexpr (though out to suggest it highly)
- example usage, many more cases like this

_frame_multi_and is the case we are talking about below, a boolean express anded with another,
can only optimize each sub-expression, and not the 3 terms together_

original issue is #724

here some runs (on travis ci), for these 4 routines
- with no numexpr (no_ne)
- with numexpr single threaded (_st)
- with numexpr (no suffix)

So numexpr helps in boolean case with and w/o parallelization
add/multiply the parallelization helps (and just numexpr doesn't do much)

```
frame_mult                              :    27.0671 [ms]
frame_mult_st                           :    85.1929 [ms]
frame_mult_no_ne                        :    86.2602 [ms]
frame_add                               :    26.3325 [ms]
frame_add_st                            :    74.8805 [ms]
frame_add_no_ne                         :    73.9357 [ms]
indexing_dataframe_boolean              :    15.0413 [ms]
indexing_dataframe_boolean_st           :    25.8873 [ms]
indexing_dataframe_boolean_no_ne        :   288.4722 [ms]
frame_multi_and                         :   637.8641 [ms]
frame_multi_and_st                      :   675.7760 [ms]
frame_multi_and_no_ne                   :   589.3791 [ms]
```
