### PR TITLE
BUG: Fix tz handling in date_range when start arg has tz, #2926

### DIFF
--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -300,12 +300,14 @@ class DatetimeIndex(Int64Index):
 
         inferred_tz = tools._infer_tzinfo(start, end)
 
+        inferred_tz = tools._maybe_get_tz(inferred_tz)
+        tz = tools._maybe_get_tz(tz)
+
         if tz is not None and inferred_tz is not None:
             assert(inferred_tz == tz)
         elif inferred_tz is not None:
             tz = inferred_tz
 
-        tz = tools._maybe_get_tz(tz)
 
         if start is not None:
             if normalize:

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -82,6 +82,17 @@ class TestDateRange(unittest.TestCase):
         self.assertEquals(len(rng), 50)
         self.assertEquals(rng[0], datetime(2010, 9, 1, 5))
 
+    def test_timezone_comparaison_bug(self):
+        start = Timestamp('20130220 10:00', tz='US/Eastern')
+        try:
+            date_range(start, periods=2, tz='US/Eastern')
+        except AssertionError:
+            self.fail()
+
+    def test_timezone_comparaison_assert(self):
+        start = Timestamp('20130220 10:00', tz='US/Eastern')
+        self.assertRaises(AssertionError, date_range, start, periods=2, tz='Europe/Berlin')
+
     def test_comparison(self):
         d = self.rng[10]
 


### PR DESCRIPTION
This commit should fix [issue 2926](https://github.com/pydata/pandas/issues/2926).
