### PR TITLE
BUG: negative timedeltas not printing correctly

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -115,10 +115,12 @@ pandas 0.11.0
     - Series ops with a Timestamp on the rhs was throwing an exception (GH2898_)
       added tests for Series ops with datetimes,timedeltas,Timestamps, and datelike 
       Series on both lhs and rhs
-    - Series will now set its dtype automatically to ``timedelta64[ns]``
-      if all passed objects are timedelta objects
+    - Fixed subtle timedelta64 inference issue on py3
+    - Fixed some formatting issues on timedelta when negative
     - Support null checking on timedelta64, representing (and formatting) with NaT
     - Support setitem with np.nan value, converts to NaT
+    - Support min/max ops in a Dataframe (abs not working, nor do we error on non-supported ops)
+    - Support idxmin/idxmax in a Series (but with no NaT)
 
 .. _GH622: https://github.com/pydata/pandas/issues/622
 .. _GH797: https://github.com/pydata/pandas/issues/797

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -961,3 +961,19 @@ Operands can also appear in a reversed order (a singluar object operated with a 
     s.max() - s
     datetime(2011,1,1,3,5) - s
     timedelta(minutes=5) + s
+
+Some timedelta numeric like operations are supported.
+
+.. ipython:: python
+
+    s  = Series(date_range('2012-1-1', periods=3, freq='D'))
+    df = DataFrame(dict(A = s - Timestamp('20120101')-timedelta(minutes=5,seconds=5),
+                        B = s - Series(date_range('2012-1-2', periods=3, freq='D'))))
+    df
+
+    # timedelta arithmetic
+    td - timedelta(minutes=5,seconds=5,microseconds=5)
+
+    # min/max operations
+    df.min()
+    df.min(axis=1)

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -904,6 +904,13 @@ def _possibly_convert_platform(values):
 
 def _possibly_cast_to_timedelta(value):
     """ try to cast to timedelta64 w/o coercion """
+
+    # deal with numpy not being able to handle certain timedelta operations
+    if isinstance(value,np.ndarray) and value.dtype.kind == 'm':
+        if value.dtype != 'timedelta64[ns]':
+            value = value.astype('timedelta64[ns]')
+        return value
+
     new_value = tslib.array_to_timedelta64(value.astype(object), coerce=False)
     if new_value.dtype == 'i8':
         value = np.array(new_value,dtype='timedelta64[ns]')

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -77,8 +77,10 @@ def _isfinite(values):
 def _na_ok_dtype(dtype):
     return not issubclass(dtype.type, (np.integer, np.datetime64, np.timedelta64))
 
-def _needs_view_dtype(dtype):
-    return issubclass(dtype.type, (np.datetime64,np.timedelta64))
+def _view_if_needed(values):
+    if issubclass(values.dtype.type, (np.datetime64,np.timedelta64)):
+        return values.view(np.int64)
+    return values
 
 def _wrap_results(result,dtype):
     """ wrap our results if needed """
@@ -192,8 +194,7 @@ def _nanmin(values, axis=None, skipna=True):
         values = values.copy()
         np.putmask(values, mask, np.inf)
 
-    if _needs_view_dtype(dtype):
-        values = values.view(np.int64)
+    values = _view_if_needed(values)
 
     # numpy 1.6.1 workaround in Python 3.x
     if (values.dtype == np.object_
@@ -225,8 +226,7 @@ def _nanmax(values, axis=None, skipna=True):
         values = values.copy()
         np.putmask(values, mask, -np.inf)
 
-    if _needs_view_dtype(dtype):
-        values = values.view(np.int64)
+    values = _view_if_needed(values)
 
     # numpy 1.6.1 workaround in Python 3.x
     if (values.dtype == np.object_
@@ -255,6 +255,7 @@ def nanargmax(values, axis=None, skipna=True):
     Returns -1 in the NA case
     """
     mask = _isfinite(values)
+    values = _view_if_needed(values)
     if not issubclass(values.dtype.type, np.integer):
         values = values.copy()
         np.putmask(values, mask, -np.inf)
@@ -268,6 +269,7 @@ def nanargmin(values, axis=None, skipna=True):
     Returns -1 in the NA case
     """
     mask = _isfinite(values)
+    values = _view_if_needed(values)
     if not issubclass(values.dtype.type, np.integer):
         values = values.copy()
         np.putmask(values, mask, np.inf)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -81,10 +81,10 @@ def _arith_method(op, name):
 
         lvalues, rvalues = self, other
 
-        is_timedelta = com.is_timedelta64_dtype(self)
-        is_datetime  = com.is_datetime64_dtype(self)
+        is_timedelta_lhs = com.is_timedelta64_dtype(self)
+        is_datetime_lhs  = com.is_datetime64_dtype(self)
 
-        if is_datetime or is_timedelta:
+        if is_datetime_lhs or is_timedelta_lhs:
 
             # convert the argument to an ndarray
             def convert_to_array(values):
@@ -96,26 +96,27 @@ def _arith_method(op, name):
                         pass
                     else:
                         values = tslib.array_to_datetime(values)
+                elif inferred_type in set(['timedelta','timedelta64']):
+                    # need to convert timedelta to ns here
+                    # safest to convert it to an object arrany to process
+                    if isinstance(values, pa.Array) and com.is_timedelta64_dtype(values):
+                        pass
+                    else:
+                        values = com._possibly_cast_to_timedelta(values)
                 else:
                     values = pa.array(values)
                 return values
 
-            # swap the valuesor com.is_timedelta64_dtype(self):
-            if is_timedelta:
-                lvalues, rvalues = rvalues, lvalues
-                lvalues = convert_to_array(lvalues)
-                is_timedelta = False
-
+            # convert lhs and rhs
+            lvalues = convert_to_array(lvalues)
             rvalues = convert_to_array(rvalues)
 
-            # rhs is either a timedelta or a series/ndarray
-            if lib.is_timedelta_or_timedelta64_array(rvalues):
+            is_timedelta_rhs = com.is_timedelta64_dtype(rvalues)
+            is_datetime_rhs  = com.is_datetime64_dtype(rvalues)
 
-                # need to convert timedelta to ns here
-                # safest to convert it to an object arrany to process
-                rvalues = tslib.array_to_timedelta64(rvalues.astype(object))
-                dtype = 'M8[ns]'
-            elif com.is_datetime64_dtype(rvalues):
+            # 2 datetimes or 2 timedeltas
+            if (is_timedelta_lhs and is_timedelta_rhs) or (is_datetime_lhs and is_datetime_rhs):
+                
                 dtype = 'timedelta64[ns]'
 
                 # we may have to convert to object unfortunately here
@@ -125,6 +126,10 @@ def _arith_method(op, name):
                         x = pa.array(x,dtype='timedelta64[ns]')
                         np.putmask(x,mask,tslib.iNaT)
                         return x
+
+            # datetime and timedelta
+            elif (is_timedelta_lhs and is_datetime_rhs) or (is_timedelta_rhs and is_datetime_lhs):
+                dtype = 'M8[ns]'
 
             else:
                 raise ValueError('cannot operate on a series with out a rhs '

--- a/pandas/src/inference.pyx
+++ b/pandas/src/inference.pyx
@@ -24,6 +24,7 @@ try:
     _TYPE_MAP[np.complex256] = 'complex'
     _TYPE_MAP[np.float16] = 'floating'
     _TYPE_MAP[np.datetime64] = 'datetime64'
+    _TYPE_MAP[np.timedelta64] = 'timedelta64'
 except AttributeError:
     pass
 

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -1209,24 +1209,57 @@ class TestSeriesFormatting(unittest.TestCase):
     def test_timedelta64(self):
 
         from pandas import date_range
-        from datetime import datetime
+        from datetime import datetime, timedelta
 
         Series(np.array([1100, 20], dtype='timedelta64[s]')).to_string()
-        # check this works
+
+        s = Series(date_range('2012-1-1', periods=3, freq='D'))
+
         # GH2146
 
         # adding NaTs
-        s = Series(date_range('2012-1-1', periods=3, freq='D'))
         y = s-s.shift(1)
         result = y.to_string()
         self.assertTrue('1 days, 00:00:00' in result)
         self.assertTrue('NaT' in result)
 
         # with frac seconds
-        s = Series(date_range('2012-1-1', periods=3, freq='D'))
-        y = s-datetime(2012,1,1,microsecond=150)
+        o = Series([datetime(2012,1,1,microsecond=150)]*3)
+        y = s-o
         result = y.to_string()
-        self.assertTrue('00:00:00.000150' in result)
+        self.assertTrue('-00:00:00.000150' in result)
+
+        # rounding?
+        o = Series([datetime(2012,1,1,1)]*3)
+        y = s-o
+        result = y.to_string()
+        self.assertTrue('-01:00:00' in result)
+        self.assertTrue('1 days, 23:00:00' in result)
+
+        o = Series([datetime(2012,1,1,1,1)]*3)
+        y = s-o
+        result = y.to_string()
+        self.assertTrue('-01:01:00' in result)
+        self.assertTrue('1 days, 22:59:00' in result)
+
+        o = Series([datetime(2012,1,1,1,1,microsecond=150)]*3)
+        y = s-o
+        result = y.to_string()
+        self.assertTrue('-01:01:00.000150' in result)
+        self.assertTrue('1 days, 22:58:59.999850' in result)
+
+        # neg time
+        td = timedelta(minutes=5,seconds=3)
+        s2 = Series(date_range('2012-1-1', periods=3, freq='D')) + td
+        y = s - s2
+        result = y.to_string()
+        self.assertTrue('-00:05:03' in result)
+
+        td = timedelta(microseconds=550)
+        s2 = Series(date_range('2012-1-1', periods=3, freq='D')) + td
+        y = s - td
+        result = y.to_string()
+        self.assertTrue('2012-01-01 23:59:59.999450' in result)
 
     def test_mixed_datetime64(self):
         df = DataFrame({'A': [1, 2],

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -928,25 +928,50 @@ def repr_timedelta64(object value):
    
    ivalue = value.view('i8')
 
+   # put frac in seconds
    frac   = float(ivalue)/1e9
-   days   = int(frac) / 86400
-   frac  -= days*86400
-   hours  = int(frac) / 3600
-   frac  -= hours * 3600
-   minutes  = int(frac) / 60
-   seconds  = frac - minutes * 60
-   nseconds = int(seconds)
+   sign   = np.sign(frac)
+   frac   = np.abs(frac)
 
-   if nseconds == seconds:
-      seconds_pretty = "%02d" % nseconds
+   if frac >= 86400:
+      days   = int(frac / 86400)
+      frac  -= days * 86400
    else:
-      sp = abs(int(1e6*(seconds-nseconds)))
-      seconds_pretty = "%02d.%06d" % (nseconds,sp)
+      days   = 0
+
+   if frac >= 3600:
+      hours  = int(frac / 3600)
+      frac  -= hours * 3600
+   else:
+      hours  = 0
+
+   if frac >= 60:
+      minutes = int(frac / 60)
+      frac   -= minutes * 60
+   else:
+      minutes  = 0
+
+   if frac >= 1:
+      seconds = int(frac)
+      frac   -= seconds
+   else:
+      seconds = 0
+
+   if frac == int(frac):
+      seconds_pretty = "%02d" % seconds
+   else:
+      sp = abs(round(1e6*frac))
+      seconds_pretty = "%02d.%06d" % (seconds,sp)
+
+   if sign < 0:
+       sign_pretty = "-"
+   else:
+       sign_pretty = ""
 
    if days:
-       return "%d days, %02d:%02d:%s" % (days,hours,minutes,seconds_pretty)
+       return "%s%d days, %02d:%02d:%s" % (sign_pretty,days,hours,minutes,seconds_pretty)
 
-   return "%02d:%02d:%s" % (hours,minutes,seconds_pretty)
+   return "%s%02d:%02d:%s" % (sign_pretty,hours,minutes,seconds_pretty)
 
 def array_strptime(ndarray[object] values, object fmt):
     cdef:


### PR DESCRIPTION
ENH: timedelta ops with other timedelta fixed to produce timedeltas

BUG: fixed timedelta (in nanops.py) to work with min/max....abs still not working
