### PR TITLE
Keep name after DataFrame drop (issue 2939)

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -340,7 +340,7 @@ class PandasObject(object):
         dropped : type of caller
         """
         axis_name = self._get_axis_name(axis)
-        axis = self._get_axis(axis)
+        axis, axis_ = self._get_axis(axis), axis
 
         if axis.is_unique:
             if level is not None:
@@ -349,8 +349,13 @@ class PandasObject(object):
                 new_axis = axis.drop(labels, level=level)
             else:
                 new_axis = axis.drop(labels)
+            dropped = self.reindex(**{axis_name: new_axis})
+            try:
+                dropped.axes[axis_].names = axis.names
+            except AttributeError:
+                pass
+            return dropped
 
-            return self.reindex(**{axis_name: new_axis})
         else:
             if level is not None:
                 if not isinstance(axis, MultiIndex):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5103,6 +5103,17 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
         assert_series_equal(result, expected)
 
+    def test_drop_names_axis(self):
+        df = DataFrame([[1, 2, 3],[3, 4, 5],[5, 6, 7]], index=['a', 'b', 'c'], columns=['d', 'e', 'f'])
+        dropped_b = DataFrame([[1, 2, 3],[5, 6, 7]], index=['a', 'c'], columns=['d', 'e', 'f'])
+        dropped_e = DataFrame([[1, 3], [3, 5], [5, 7]], index=['a', 'b', 'c'], columns=['d', 'f'])
+        for frame in [df, dropped_e, dropped_e]:
+            frame.index.name, frame.columns.name = 'first', 'second'
+        df_dropped_b = df.drop('b')
+        df_dropped_e = df.drop('e', axis=1)
+        assert_frame_equal(df_dropped_b, dropped_b)
+        assert_frame_equal(df_dropped_e, dropped_e)
+
     def test_dropEmptyRows(self):
         N = len(self.frame.index)
         mat = randn(N)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5103,16 +5103,15 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
         assert_series_equal(result, expected)
 
-    def test_drop_names_axis(self):
+    def test_drop_names(self):
         df = DataFrame([[1, 2, 3],[3, 4, 5],[5, 6, 7]], index=['a', 'b', 'c'], columns=['d', 'e', 'f'])
-        dropped_b = DataFrame([[1, 2, 3],[5, 6, 7]], index=['a', 'c'], columns=['d', 'e', 'f'])
-        dropped_e = DataFrame([[1, 3], [3, 5], [5, 7]], index=['a', 'b', 'c'], columns=['d', 'f'])
-        for frame in [df, dropped_e, dropped_e]:
-            frame.index.name, frame.columns.name = 'first', 'second'
+        df.index.name, df.columns.name = 'first', 'second'
         df_dropped_b = df.drop('b')
         df_dropped_e = df.drop('e', axis=1)
-        assert_frame_equal(df_dropped_b, dropped_b)
-        assert_frame_equal(df_dropped_e, dropped_e)
+        self.assert_(df_dropped_b.index.name == 'first')
+        self.assert_(df_dropped_e.index.name == 'first')
+        self.assert_(df_dropped_b.columns.name == 'second')
+        self.assert_(df_dropped_e.columns.name == 'second')
 
     def test_dropEmptyRows(self):
         N = len(self.frame.index)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -200,10 +200,12 @@ def assert_frame_equal(left, right, check_dtype=True,
         assert(type(left.index) == type(right.index))
         assert(left.index.dtype == right.index.dtype)
         assert(left.index.inferred_type == right.index.inferred_type)
+        assert(left.index.names == right.index.names)
     if check_column_type:
         assert(type(left.columns) == type(right.columns))
         assert(left.columns.dtype == right.columns.dtype)
         assert(left.columns.inferred_type == right.columns.inferred_type)
+        assert(left.columns.names == right.columns.names)
 
 
 def assert_panel_equal(left, right, 


### PR DESCRIPTION
This should fix #2939.
