### PR TITLE
ENH Assert_frame_equal check_names to True

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2241,7 +2241,7 @@ class DataFrame(NDFrame):
         column : Series
         """
         return NDFrame.pop(self, item)
-
+        
     # to support old APIs
     @property
     def _series(self):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -340,7 +340,7 @@ class PandasObject(object):
         dropped : type of caller
         """
         axis_name = self._get_axis_name(axis)
-        axis = self._get_axis(axis)
+        axis, axis_ = self._get_axis(axis), axis
 
         if axis.is_unique:
             if level is not None:
@@ -349,8 +349,13 @@ class PandasObject(object):
                 new_axis = axis.drop(labels, level=level)
             else:
                 new_axis = axis.drop(labels)
+            dropped = self.reindex(**{axis_name: new_axis})
+            try:
+                dropped.axes[axis_].names = axis.names
+            except AttributeError:
+                pass
+            return dropped
 
-            return self.reindex(**{axis_name: new_axis})
         else:
             if level is not None:
                 if not isinstance(axis, MultiIndex):

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -103,8 +103,8 @@ class ExcelTests(unittest.TestCase):
             df2 = df2.reindex(columns=['A', 'B', 'C'])
             df3 = xls.parse('Sheet2', skiprows=[1], index_col=0,
                             parse_dates=True, parse_cols=3)
-            tm.assert_frame_equal(df, df2)
-            tm.assert_frame_equal(df3, df2)
+            tm.assert_frame_equal(df, df2, check_names=False)  # TODO add index to xls file)
+            tm.assert_frame_equal(df3, df2, check_names=False)
 
     def test_parse_cols_list(self):
         _skip_if_no_openpyxl()
@@ -122,8 +122,8 @@ class ExcelTests(unittest.TestCase):
             df3 = xls.parse('Sheet2', skiprows=[1], index_col=0,
                             parse_dates=True,
                             parse_cols=[0, 2, 3])
-            tm.assert_frame_equal(df, df2)
-            tm.assert_frame_equal(df3, df2)
+            tm.assert_frame_equal(df, df2, check_names=False)  # TODO add index to xls file
+            tm.assert_frame_equal(df3, df2, check_names=False)
 
     def test_parse_cols_str(self):
         _skip_if_no_openpyxl()
@@ -142,8 +142,8 @@ class ExcelTests(unittest.TestCase):
             df2 = df2.reindex(columns=['A', 'B', 'C'])
             df3 = xls.parse('Sheet2', skiprows=[1], index_col=0,
                             parse_dates=True, parse_cols='A:D')
-            tm.assert_frame_equal(df, df2)
-            tm.assert_frame_equal(df3, df2)
+            tm.assert_frame_equal(df, df2, check_names=False)  # TODO add index to xls, read xls ignores index name ?
+            tm.assert_frame_equal(df3, df2, check_names=False)
             del df, df2, df3
 
             df = xls.parse('Sheet1', index_col=0, parse_dates=True,
@@ -153,8 +153,8 @@ class ExcelTests(unittest.TestCase):
             df3 = xls.parse('Sheet2', skiprows=[1], index_col=0,
                             parse_dates=True,
                             parse_cols='A,C,D')
-            tm.assert_frame_equal(df, df2)
-            tm.assert_frame_equal(df3, df2)
+            tm.assert_frame_equal(df, df2, check_names=False)  # TODO add index to xls file
+            tm.assert_frame_equal(df3, df2, check_names=False)
             del df, df2, df3
 
             df = xls.parse('Sheet1', index_col=0, parse_dates=True,
@@ -164,8 +164,8 @@ class ExcelTests(unittest.TestCase):
             df3 = xls.parse('Sheet2', skiprows=[1], index_col=0,
                             parse_dates=True,
                             parse_cols='A,C:D')
-            tm.assert_frame_equal(df, df2)
-            tm.assert_frame_equal(df3, df2)
+            tm.assert_frame_equal(df, df2, check_names=False)
+            tm.assert_frame_equal(df3, df2, check_names=False)
 
     def test_excel_stop_iterator(self):
         _skip_if_no_xlrd()
@@ -191,8 +191,8 @@ class ExcelTests(unittest.TestCase):
         df = xls.parse('Sheet1', index_col=0, parse_dates=True)
         df2 = self.read_csv(self.csv1, index_col=0, parse_dates=True)
         df3 = xls.parse('Sheet2', skiprows=[1], index_col=0, parse_dates=True)
-        tm.assert_frame_equal(df, df2)
-        tm.assert_frame_equal(df3, df2)
+        tm.assert_frame_equal(df, df2, check_names=False)
+        tm.assert_frame_equal(df3, df2, check_names=False)
 
         df4 = xls.parse('Sheet1', index_col=0, parse_dates=True,
                         skipfooter=1)
@@ -224,8 +224,9 @@ class ExcelTests(unittest.TestCase):
         df = xlsx.parse('Sheet1', index_col=0, parse_dates=True)
         df2 = self.read_csv(self.csv1, index_col=0, parse_dates=True)
         df3 = xlsx.parse('Sheet2', skiprows=[1], index_col=0, parse_dates=True)
-        tm.assert_frame_equal(df, df2)
-        tm.assert_frame_equal(df3, df2)
+
+        tm.assert_frame_equal(df, df2, check_names=False)  # TODO add index to xlsx file
+        tm.assert_frame_equal(df3, df2, check_names=False)
 
         df4 = xlsx.parse('Sheet1', index_col=0, parse_dates=True,
                          skipfooter=1)
@@ -632,7 +633,9 @@ class ExcelTests(unittest.TestCase):
         tsframe.to_excel(path, 'test1', index_label=['time', 'foo'])
         reader = ExcelFile(path)
         recons = reader.parse('test1', index_col=[0, 1])
-        tm.assert_frame_equal(tsframe, recons)
+
+        tm.assert_frame_equal(tsframe, recons, check_names=False)
+        self.assertEquals(recons.index.names, ['time', 'foo'])
 
         # infer index
         tsframe.to_excel(path, 'test1')

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -514,6 +514,7 @@ ignore,this,row
                              columns=[1, 2, 3],
                              index=[datetime(2000, 1, 1), datetime(2000, 1, 2),
                                     datetime(2000, 1, 3)])
+        expected.index.name = 0
         tm.assert_frame_equal(data, expected)
         tm.assert_frame_equal(data, data2)
 
@@ -627,7 +628,7 @@ c,4,5
         idx = DatetimeIndex([datetime(2009, 1, 31, 0, 10, 0),
                              datetime(2009, 2, 28, 10, 20, 0),
                              datetime(2009, 3, 31, 8, 30, 0)]).asobject
-        idx.name = 'date'
+        idx.name = 'date_time'
         xp = DataFrame({'B': [1, 3, 5], 'C': [2, 4, 6]}, idx)
         tm.assert_frame_equal(rs, xp)
 
@@ -636,7 +637,7 @@ c,4,5
         idx = DatetimeIndex([datetime(2009, 1, 31, 0, 10, 0),
                              datetime(2009, 2, 28, 10, 20, 0),
                              datetime(2009, 3, 31, 8, 30, 0)]).asobject
-        idx.name = 'date'
+        idx.name = 'date_time'
         xp = DataFrame({'B': [1, 3, 5], 'C': [2, 4, 6]}, idx)
         tm.assert_frame_equal(rs, xp)
 
@@ -967,7 +968,7 @@ bar,two,12,13,14,15
         df = self.read_csv(StringIO(no_header), index_col=[0, 1],
                            header=None, names=names)
         expected = self.read_csv(StringIO(data), index_col=[0, 1])
-        tm.assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected, check_names=False)
 
         # 2 implicit first cols
         df2 = self.read_csv(StringIO(data2))
@@ -977,7 +978,7 @@ bar,two,12,13,14,15
         df = self.read_csv(StringIO(no_header), index_col=[1, 0], names=names,
                            header=None)
         expected = self.read_csv(StringIO(data), index_col=[1, 0])
-        tm.assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected, check_names=False)
 
     def test_multi_index_parse_dates(self):
         data = """index1,index2,A,B,C
@@ -1162,11 +1163,13 @@ a,b,c,d
 
         xp = DataFrame({'b': [np.nan], 'd': [5]},
                        MultiIndex.from_tuples([(0, 1)]))
+        xp.index.names = ['a', 'c']
         df = self.read_csv(StringIO(data), na_values={}, index_col=[0, 2])
         tm.assert_frame_equal(df, xp)
 
         xp = DataFrame({'b': [np.nan], 'd': [5]},
                        MultiIndex.from_tuples([(0, 1)]))
+        xp.index.names = ['a', 'c']
         df = self.read_csv(StringIO(data), na_values={}, index_col=['a', 'c'])
         tm.assert_frame_equal(df, xp)
 
@@ -1249,7 +1252,7 @@ KORD6,19990127, 23:00:00, 22:56:00, -0.5900, 1.7100, 4.6000, 0.0000, 280.0000"""
         tm.assert_frame_equal(df2, df)
 
         df3 = self.read_csv(StringIO(data), parse_dates=[[1, 2]], index_col=0)
-        tm.assert_frame_equal(df3, df)
+        tm.assert_frame_equal(df3, df, check_names=False)
 
     def test_multiple_date_cols_chunked(self):
         df = self.read_csv(StringIO(self.ts_data), parse_dates={

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -174,6 +174,7 @@ class TestSQLite(unittest.TestCase):
                                 index_col='Idx')
         expected = frame.copy()
         expected.index = Index(range(len(frame2))) + 10
+        expected.index.name = 'Idx'
         tm.assert_frame_equal(expected, result)
 
     def test_tquery(self):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5103,6 +5103,16 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
         assert_series_equal(result, expected)
 
+    def test_drop_names(self):
+        df = DataFrame([[1, 2, 3],[3, 4, 5],[5, 6, 7]], index=['a', 'b', 'c'], columns=['d', 'e', 'f'])
+        df.index.name, df.columns.name = 'first', 'second'
+        df_dropped_b = df.drop('b')
+        df_dropped_e = df.drop('e', axis=1)
+        self.assert_(df_dropped_b.index.name == 'first')
+        self.assert_(df_dropped_e.index.name == 'first')
+        self.assert_(df_dropped_b.columns.name == 'second')
+        self.assert_(df_dropped_e.columns.name == 'second')
+
     def test_dropEmptyRows(self):
         N = len(self.frame.index)
         mat = randn(N)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -133,6 +133,8 @@ class CheckIndexing(object):
         result2 = self.frame[Index(['B', 'A'])]
 
         expected = self.frame.ix[:, ['B', 'A']]
+        expected.columns.name = 'foo'
+
         assert_frame_equal(result, expected)
         assert_frame_equal(result2, expected)
 
@@ -1678,7 +1680,8 @@ class SafeForSparse(object):
         df = self.frame.copy()
         s = df.pop(self.frame.columns[-1])
         joined = df.join(s)
-        assert_frame_equal(joined, self.frame)
+
+        assert_frame_equal(joined, self.frame, check_names=False) # TODO should this check_names ?
 
         s.name = None
         self.assertRaises(Exception, df.join, s)
@@ -1896,7 +1899,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         # multiple columns
         result = df.set_index(['A', df['B'].values], drop=False)
         expected = df.set_index(['A', 'B'], drop=False)
-        assert_frame_equal(result, expected)
+        assert_frame_equal(result, expected, check_names=False) # TODO should set_index check_names ?
 
     def test_set_index_cast_datetimeindex(self):
         df = DataFrame({'A': [datetime(2000, 1, 1) + timedelta(i)
@@ -3720,12 +3723,15 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self.assert_('A' not in self.frame)
 
     def test_pop(self):
+        self.frame.columns.name = 'baz'
+
         A = self.frame.pop('A')
         self.assert_('A' not in self.frame)
 
         self.frame['foo'] = 'bar'
         foo = self.frame.pop('foo')
         self.assert_('foo' not in self.frame)
+        # TODO self.assert_(self.frame.columns.name == 'baz')
 
     def test_pop_non_unique_cols(self):
         df = DataFrame({0: [0, 1], 1: [0, 1], 2: [4, 5]})
@@ -4409,7 +4415,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         df.to_csv(path)
         result = DataFrame.from_csv(path, index_col=[0, 1, 2],
                                     parse_dates=False)
-        assert_frame_equal(result, df)
+        assert_frame_equal(result, df, check_names=False)  # TODO from_csv names index ['Unnamed: 1', 'Unnamed: 2'] should it ?
 
         # column aliases
         col_aliases = Index(['AA', 'X', 'Y', 'Z'])
@@ -4436,8 +4442,8 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self.frame.to_csv(path)
         recons = DataFrame.from_csv(path)
 
-        assert_frame_equal(self.frame, recons)
-        assert_frame_equal(np.isinf(self.frame), np.isinf(recons))
+        assert_frame_equal(self.frame, recons, check_names=False)  # TODO to_csv drops column name 
+        assert_frame_equal(np.isinf(self.frame), np.isinf(recons), check_names=False)
 
         try:
             os.remove(path)
@@ -4456,8 +4462,8 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self.frame.to_csv(path)
         recons = DataFrame.from_csv(path)
 
-        assert_frame_equal(self.frame, recons)
-        assert_frame_equal(np.isinf(self.frame), np.isinf(recons))
+        assert_frame_equal(self.frame, recons, check_names=False)  # TODO to_csv drops column name 
+        assert_frame_equal(np.isinf(self.frame), np.isinf(recons), check_names=False)
 
         os.remove(path)
 
@@ -4476,7 +4482,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         frame.to_csv(path)
         df = DataFrame.from_csv(path, index_col=[0, 1], parse_dates=False)
 
-        assert_frame_equal(frame, df)
+        assert_frame_equal(frame, df, check_names=False)  # TODO to_csv drops column name
         self.assertEqual(frame.index.names, df.index.names)
         self.frame.index = old_index  # needed if setUP becomes a classmethod
 
@@ -4488,7 +4494,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
         tsframe.to_csv(path, index_label=['time', 'foo'])
         recons = DataFrame.from_csv(path, index_col=[0, 1])
-        assert_frame_equal(tsframe, recons)
+        assert_frame_equal(tsframe, recons, check_names=False)  # TODO to_csv drops column name
 
         # do not load index
         tsframe.to_csv(path)
@@ -4545,7 +4551,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         newdf.to_csv(path)
 
         recons = pan.read_csv(path, index_col=0)
-        assert_frame_equal(recons, newdf)
+        assert_frame_equal(recons, newdf, check_names=False)  # don't check_names as t != 1 
 
         os.remove(path)
 
@@ -4581,7 +4587,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self.frame.to_csv(buf)
         buf.seek(0)
         recons = pan.read_csv(buf, index_col=0)
-        assert_frame_equal(recons, self.frame)
+        assert_frame_equal(recons, self.frame, check_names=False)  # TODO to_csv drops column name
 
     def test_to_csv_float_format(self):
         filename = '__tmp_to_csv_float_format__.csv'
@@ -5867,6 +5873,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
             'One': {'A': 1., 'B': 2., 'C': 3.},
             'Two': {'A': 1., 'B': 2., 'C': 3.}
         })
+        expected.index.name, expected.columns.name = 'index', 'columns'
 
         assert_frame_equal(pivoted, expected)
 
@@ -5895,7 +5902,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         df = DataFrame({}, columns=['a', 'b', 'c'])
         result = df.pivot('a', 'b', 'c')
         expected = DataFrame({})
-        assert_frame_equal(result, expected)
+        assert_frame_equal(result, expected, check_names=False)
 
     def test_pivot_integer_bug(self):
         df = DataFrame(data=[("A", "1", "A1"), ("B", "2", "B2")])
@@ -6401,10 +6408,9 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
         assert_frame_equal(renamed, renamed2)
         assert_frame_equal(renamed2.rename(columns=str.upper),
-                           self.frame)
+                           self.frame, check_names=False)
 
         # index
-
         data = {
             'A': {'foo': 0, 'bar': 1}
         }
@@ -6953,7 +6959,8 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
         result = self.frame.select(lambda x: x in ('B', 'D'), axis=1)
         expected = self.frame.reindex(columns=['B', 'D'])
-        assert_frame_equal(result, expected)
+
+        assert_frame_equal(result, expected, check_names=False)  # TODO should reindex check_names?
 
     def test_sort_index(self):
         frame = DataFrame(np.random.randn(4, 4), index=[1, 2, 3, 4],
@@ -8238,30 +8245,31 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         # only remove certain columns
         frame = self.frame.reset_index().set_index(['index', 'A', 'B'])
         rs = frame.reset_index(['A', 'B'])
-        assert_frame_equal(rs, self.frame)
+
+        assert_frame_equal(rs, self.frame, check_names=False)  # TODO should reset_index check_names ?
 
         rs = frame.reset_index(['index', 'A', 'B'])
-        assert_frame_equal(rs, self.frame.reset_index())
+        assert_frame_equal(rs, self.frame.reset_index(), check_names=False)
 
         rs = frame.reset_index(['index', 'A', 'B'])
-        assert_frame_equal(rs, self.frame.reset_index())
+        assert_frame_equal(rs, self.frame.reset_index(), check_names=False)
 
         rs = frame.reset_index('A')
         xp = self.frame.reset_index().set_index(['index', 'B'])
-        assert_frame_equal(rs, xp)
+        assert_frame_equal(rs, xp, check_names=False)
 
         # test resetting in place
         df = self.frame.copy()
         resetted = self.frame.reset_index()
         df.reset_index(inplace=True)
-        assert_frame_equal(df, resetted)
+        assert_frame_equal(df, resetted, check_names=False)
 
         frame = self.frame.reset_index().set_index(['index', 'A', 'B'])
         rs = frame.reset_index('A', drop=True)
         xp = self.frame.copy()
         del xp['A']
         xp = xp.set_index(['B'], append=True)
-        assert_frame_equal(rs, xp)
+        assert_frame_equal(rs, xp, check_names=False)
 
     def test_reset_index_right_dtype(self):
         time = np.arange(0.0, 10, np.sqrt(2) / 2)

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1015,7 +1015,7 @@ Thur,Lunch,Yes,51.51,17"""
 
         self.assert_(not np.isnan(joined.values).all())
 
-        assert_frame_equal(joined, expected)
+        assert_frame_equal(joined, expected, check_names=False)  # TODO what should join do with names ?
 
     def test_swaplevel(self):
         swapped = self.frame['A'].swaplevel(0, 1)
@@ -1276,7 +1276,7 @@ Thur,Lunch,Yes,51.51,17"""
 
         expected = self.ymd.groupby([k1, k2]).mean()
 
-        assert_frame_equal(result, expected)
+        assert_frame_equal(result, expected, check_names=False)  # TODO groupby with level_values drops names
         self.assertEquals(result.index.names, self.ymd.index.names[:2])
 
         result2 = self.ymd.groupby(level=self.ymd.index.names[:2]).mean()

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1562,17 +1562,17 @@ class TestLongPanel(unittest.TestCase):
         trunced = self.panel.truncate(start, end).to_panel()
         expected = self.panel.to_panel()['ItemA'].truncate(start, end)
 
-        assert_frame_equal(trunced['ItemA'], expected)
+        assert_frame_equal(trunced['ItemA'], expected, check_names=False)  # TODO trucate drops index.names
 
         trunced = self.panel.truncate(before=start).to_panel()
         expected = self.panel.to_panel()['ItemA'].truncate(before=start)
 
-        assert_frame_equal(trunced['ItemA'], expected)
+        assert_frame_equal(trunced['ItemA'], expected, check_names=False)  # TODO trucate drops index.names
 
         trunced = self.panel.truncate(after=end).to_panel()
         expected = self.panel.to_panel()['ItemA'].truncate(after=end)
 
-        assert_frame_equal(trunced['ItemA'], expected)
+        assert_frame_equal(trunced['ItemA'], expected, check_names=False)  # TODO trucate drops index.names
 
         # truncate on dates that aren't in there
         wp = self.panel.to_panel()

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -357,6 +357,7 @@ class TestMerge(unittest.TestCase):
         joined = df1.join(df2, how='outer')
         ex_index = index1._tuple_index + index2._tuple_index
         expected = df1.reindex(ex_index).join(df2.reindex(ex_index))
+        expected.index.names = index1.names
         assert_frame_equal(joined, expected)
         self.assertEqual(joined.index.names, index1.names)
 
@@ -366,6 +367,7 @@ class TestMerge(unittest.TestCase):
         joined = df1.join(df2, how='outer').sortlevel(0)
         ex_index = index1._tuple_index + index2._tuple_index
         expected = df1.reindex(ex_index).join(df2.reindex(ex_index))
+        expected.index.names = index1.names
 
         assert_frame_equal(joined, expected)
         self.assertEqual(joined.index.names, index1.names)
@@ -739,7 +741,7 @@ def _check_merge(x, y):
                          sort=True)
         expected = expected.set_index('index')
 
-        assert_frame_equal(result, expected)
+        assert_frame_equal(result, expected, check_names=False)  # TODO check_names on merge?
 
 
 class TestMergeMulti(unittest.TestCase):

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -158,7 +158,7 @@ class TestPivotTable(unittest.TestCase):
         df2 = df.rename(columns=str)
         table2 = df2.pivot_table(values='4', rows=['0', '1', '3'], cols=['2'])
 
-        tm.assert_frame_equal(table, table2)
+        tm.assert_frame_equal(table, table2, check_names=False)
 
     def test_pivot_no_level_overlap(self):
         # GH #1181

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -2348,7 +2348,7 @@ class TestDatetime64(unittest.TestCase):
         d2 = d1.reset_index()
         self.assert_(d2.dtypes[0] == np.dtype('M8[ns]'))
         d3 = d2.set_index('index')
-        assert_frame_equal(d1, d3)
+        assert_frame_equal(d1, d3, check_names=False)
 
         # #2329
         stamp = datetime(2012, 11, 22)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -179,7 +179,7 @@ def assert_frame_equal(left, right, check_dtype=True,
                        check_column_type=False,
                        check_frame_type=False,
                        check_less_precise=False,
-                       check_names=False):
+                       check_names=True):
     if check_frame_type:
         assert(type(left) == type(right))
     assert(isinstance(left, DataFrame))
@@ -222,7 +222,7 @@ def assert_panel_equal(left, right,
 
     for col, series in left.iterkv():
         assert(col in right)
-        assert_frame_equal(series, right[col], check_less_precise=check_less_precise)
+        assert_frame_equal(series, right[col], check_less_precise=check_less_precise, check_names=False)  # TODO strangely check_names fails in py3 ?
 
     for col in right:
         assert(col in left)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -178,7 +178,8 @@ def assert_frame_equal(left, right, check_dtype=True,
                        check_index_type=False,
                        check_column_type=False,
                        check_frame_type=False,
-                       check_less_precise=False):
+                       check_less_precise=False,
+                       check_names=False):
     if check_frame_type:
         assert(type(left) == type(right))
     assert(isinstance(left, DataFrame))
@@ -204,6 +205,9 @@ def assert_frame_equal(left, right, check_dtype=True,
         assert(type(left.columns) == type(right.columns))
         assert(left.columns.dtype == right.columns.dtype)
         assert(left.columns.inferred_type == right.columns.inferred_type)
+    if check_names:
+        assert(left.index.names == right.index.names)
+        assert(left.columns.names == right.columns.names)
 
 
 def assert_panel_equal(left, right, 


### PR DESCRIPTION
This is a follow up to #2962, where I added a `check_names=False` argument to `assert_frame_equal`, this defaults it to `True`. That is, when asserting two DataFrames are equal, it compares `.columns.names` and `.index.names`, unless explicitly passing `check_names=False`.

I've added in `check_names=False` where it wouldn't make sense to check names. I've added a TODO comment (and `check_names=False`) where I think it probably _should_ work but isn't... This was in the following cases:

```
to_csv
reindex
reset_index
groupy-a-get
pop
join (dataframe to a series)
from_xls (when setting index as first column)
```

i.e. these appear to drop column names  (`df.columns.names`). Whether this behaviour is correct / desired in these cases, I'm not sure, but here they all are. :)

_Note: By changing the A1 cells to 'index', I had all but one test (labelled "read xls ignores index name ?") in `test_excel.py` working locally (with `check_names=True`) , however Travis was less convinced  throwing:_

```
InvalidFileException: "There is no item named 'xl/theme/theme1.xml' in the archive"
```

_so I reverted to the previous xls and xlsx, and added back in `check_names=False`. I suspect LibreOffice wasn't saving it properly...?_
