### PR TITLE
Enable display of cursor coordinate info in t-series plots

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -51,6 +51,7 @@ pandas 0.11.0
   - ``describe_option()`` now reports the default and current value of options.
   - Add ``format`` option to ``pandas.to_datetime`` with faster conversion of
     strings that can be parsed with datetime.strptime
+  - Display cursor coordinate information in time-series plots (GH1670_)
 
 **API Changes**
 
@@ -126,6 +127,7 @@ pandas 0.11.0
 
 .. _GH622: https://github.com/pydata/pandas/issues/622
 .. _GH797: https://github.com/pydata/pandas/issues/797
+.. _GH1670: https://github.com/pydata/pandas/issues/1670
 .. _GH2681: https://github.com/pydata/pandas/issues/2681
 .. _GH2746: https://github.com/pydata/pandas/issues/2746
 .. _GH2747: https://github.com/pydata/pandas/issues/2747

--- a/doc/source/v0.11.0.txt
+++ b/doc/source/v0.11.0.txt
@@ -175,6 +175,7 @@ Enhancements
       only return forward looking data for options near the current stock
       price. This just obtains the data from Options.get_near_stock_price
       instead of Options.get_xxx_data().
+    + Cursor coordinate information is now displayed in time-series plots.
 
 Bug Fixes
 ~~~~~~~~~

--- a/pandas/tseries/plotting.py
+++ b/pandas/tseries/plotting.py
@@ -82,6 +82,10 @@ def tsplot(series, plotf, **kwargs):
     left, right = _get_xlim(ax.get_lines())
     ax.set_xlim(left, right)
 
+    # x and y coord info
+    tz = series.index.to_datetime().tz
+    ax.format_coord = lambda t, y : "t = {}    y = {:8f}".format(datetime.fromtimestamp(t, tz), y)
+
     return lines
 
 


### PR DESCRIPTION
See Github Issue [#1670](https://github.com/pydata/pandas/issues/1670).

Apologies for not having squashed my commits together; got rather confused by the process.
