### PR TITLE
BUG: Series.argsort failing on datetime64[ns] when NaT present, GH #2967

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -125,6 +125,7 @@ pandas 0.11.0
     - Support idxmin/idxmax in a Series (but with no NaT)
 
   - Bug on in-place putmasking on an ``integer`` series that needs to be converted to ``float`` (GH2746_)
+  - Bug in argsort of ``datetime64[ns]`` Series with ``NaT`` (GH2967_)
 
 .. _GH622: https://github.com/pydata/pandas/issues/622
 .. _GH797: https://github.com/pydata/pandas/issues/797
@@ -145,6 +146,7 @@ pandas 0.11.0
 .. _GH2909: https://github.com/pydata/pandas/issues/2909
 .. _GH2931: https://github.com/pydata/pandas/issues/2931
 .. _GH2973: https://github.com/pydata/pandas/issues/2973
+.. _GH2967: https://github.com/pydata/pandas/issues/2967
 
 
 pandas 0.10.1

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2092,16 +2092,17 @@ class Series(pa.Array, generic.PandasObject):
 
         Returns
         -------
-        argsorted : Series
+        argsorted : Series, with -1 indicated where nan values are present
+
         """
         values = self.values
         mask = isnull(values)
 
         if mask.any():
-            result = values.copy()
+            result = Series(-1,index=self.index,name=self.name)
             notmask = -mask
-            result[notmask] = np.argsort(values[notmask], kind=kind)
-            return Series(result, index=self.index, name=self.name)
+            result.values[notmask] = np.argsort(self.values[notmask], kind=kind)
+            return result
         else:
             return Series(np.argsort(values, kind=kind), index=self.index,
                           name=self.name)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1404,6 +1404,21 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         argsorted = self.ts.argsort()
         self.assert_(issubclass(argsorted.dtype.type, np.integer))
 
+        # GH 2967 (introduced bug in 0.11-dev I think)
+        s = Series([Timestamp('201301%02d'% (i+1)) for i in range(5)])
+        self.assert_(s.dtype == 'datetime64[ns]')
+        shifted = s.shift(-1)
+        self.assert_(shifted.dtype == 'datetime64[ns]')
+        self.assert_(isnull(shifted[4]) == True)
+
+        result = s.argsort()
+        expected = Series(range(5),dtype='int64')
+        assert_series_equal(result,expected)
+
+        result = shifted.argsort()
+        expected = Series(range(4) + [-1],dtype='int64')
+        assert_series_equal(result,expected)
+
     def test_argsort_stable(self):
         s = Series(np.random.randint(0, 100, size=10000))
         mindexer = s.argsort(kind='mergesort')


### PR DESCRIPTION
should close GH #2967
