### PR TITLE
BUG: Bug in idxmin/idxmax of ``datetime64[ns]`` Series with ``NaT`` (GH2982)

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -126,6 +126,7 @@ pandas 0.11.0
 
   - Bug on in-place putmasking on an ``integer`` series that needs to be converted to ``float`` (GH2746_)
   - Bug in argsort of ``datetime64[ns]`` Series with ``NaT`` (GH2967_)
+  - Bug in idxmin/idxmax of ``datetime64[ns]`` Series with ``NaT`` (GH2982__)
 
 .. _GH622: https://github.com/pydata/pandas/issues/622
 .. _GH797: https://github.com/pydata/pandas/issues/797
@@ -147,6 +148,7 @@ pandas 0.11.0
 .. _GH2931: https://github.com/pydata/pandas/issues/2931
 .. _GH2973: https://github.com/pydata/pandas/issues/2973
 .. _GH2967: https://github.com/pydata/pandas/issues/2967
+.. _GH2982: https://github.com/pydata/pandas/issues/2982
 
 
 pandas 0.10.1

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1186,7 +1186,7 @@ A query is specified using the ``Term`` class under the hood.
 
 Valid terms can be created from ``dict, list, tuple, or
 string``. Objects can be embeded as values. Allowed operations are: ``<,
-<=, >, >=, =``. ``=`` will be inferred as an implicit set operation
+<=, >, >=, =, !=``. ``=`` will be inferred as an implicit set operation
 (e.g. if 2 or more values are provided). The following are all valid
 terms.
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2112,13 +2112,13 @@ class Series(pa.Array, generic.PandasObject):
         mask = isnull(values)
 
         if mask.any():
-            result = Series(-1,index=self.index,name=self.name)
+            result = Series(-1,index=self.index,name=self.name,dtype='int64')
             notmask = -mask
             result.values[notmask] = np.argsort(self.values[notmask], kind=kind)
             return result
         else:
             return Series(np.argsort(values, kind=kind), index=self.index,
-                          name=self.name)
+                          name=self.name,dtype='int64')
 
     def rank(self, method='average', na_option='keep', ascending=True):
         """

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1816,14 +1816,15 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         result = td.idxmax()
         self.assert_(result == 2)
 
-        # with NaT (broken)
+        # GH 2982
+        # with NaT 
         td[0] = np.nan
 
-        #result = td.idxmin()
-        #self.assert_(result == 1)
+        result = td.idxmin()
+        self.assert_(result == 1)
 
-        #result = td.idxmax()
-        #self.assert_(result == 2)
+        result = td.idxmax()
+        self.assert_(result == 2)
 
         # abs
         s1 = Series(date_range('20120101',periods=3))
@@ -2065,6 +2066,16 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         allna = self.series * nan
         self.assert_(isnull(allna.idxmin()))
 
+        # datetime64[ns]
+        from pandas import date_range
+        s = Series(date_range('20130102',periods=6))
+        result = s.idxmin()
+        self.assert_(result == 0)
+
+        s[0] = np.nan
+        result = s.idxmin()
+        self.assert_(result == 1)
+
     def test_idxmax(self):
         # test idxmax
         # _check_stat_op approach can not be used here because of isnull check.
@@ -2085,6 +2096,15 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         # all NaNs
         allna = self.series * nan
         self.assert_(isnull(allna.idxmax()))
+
+        from pandas import date_range
+        s = Series(date_range('20130102',periods=6))
+        result = s.idxmax()
+        self.assert_(result == 5)
+
+        s[5] = np.nan
+        result = s.idxmax()
+        self.assert_(result == 4)
 
     def test_operators_corner(self):
         series = self.ts


### PR DESCRIPTION
fixes GH #2982
- Bug in idxmin/idxmax of `datetime64[ns]` Series with `NaT`
- refactor in core/nanops.py to generically handle ops with
  datetime64[ns]/timedelta64[ns]
- Series.argsort to always return int64 dtype (and ignore numpy dtype on ints),
  was failing a test, indicated in a711db075d5835f45f04867752f3db64be359490
- minor doc update in io.rst (pytables)
