### PR TITLE
add comparisons operator to the Period object and fixes issue 2781

### DIFF
--- a/pandas/tests/test_tseries.py
+++ b/pandas/tests/test_tseries.py
@@ -2,7 +2,7 @@ import unittest
 
 from numpy import nan
 import numpy as np
-from pandas import Index, isnull
+from pandas import Index, isnull, Period
 from pandas.util.testing import assert_almost_equal
 import pandas.util.testing as common
 import pandas.lib as lib
@@ -61,6 +61,35 @@ class TestTseriesUtil(unittest.TestCase):
         expect_filler = [-1, -1, -1, -1, -1]
         self.assert_(np.array_equal(filler, expect_filler))
 
+class TestPeriod(unittest.TestCase):
+    def setUp(self):
+        self.january1 = Period('2000-01', 'M')
+        self.january2 = Period('2000-01', 'M')
+        self.february = Period('2000-02', 'M')
+        self.march = Period('2000-03', 'M')
+
+    def test_equal(self):
+        self.assertEqual(self.january1,self.january2)
+
+    def test_notEqual(self):
+        self.assertNotEqual(self.january1, self.february)
+
+    def test_greater(self):
+        self.assertGreater(self.february, self.january1)
+
+    def test_greaterEqual(self):
+        self.assertGreaterEqual(self.january1, self.january2)
+
+    def test_smallerEqual(self):
+        self.assertLessEqual(self.january1, self.january2)
+
+    def test_smaller(self):
+        self.assertLess(self.january1, self.february)
+
+    def test_sort(self):
+        periods = [self.march, self.january1, self.february]
+        correctPeriods = [self.january1, self.february, self.march]
+        self.assertListEqual(sorted(periods), correctPeriods)
 
 def test_left_join_indexer_unique():
     a = np.array([1, 2, 3, 4, 5], dtype=np.int64)

--- a/pandas/tests/test_tseries.py
+++ b/pandas/tests/test_tseries.py
@@ -2,7 +2,7 @@ import unittest
 
 from numpy import nan
 import numpy as np
-from pandas import Index, isnull, Period
+from pandas import Index, isnull
 from pandas.util.testing import assert_almost_equal
 import pandas.util.testing as common
 import pandas.lib as lib
@@ -61,35 +61,6 @@ class TestTseriesUtil(unittest.TestCase):
         expect_filler = [-1, -1, -1, -1, -1]
         self.assert_(np.array_equal(filler, expect_filler))
 
-class TestPeriod(unittest.TestCase):
-    def setUp(self):
-        self.january1 = Period('2000-01', 'M')
-        self.january2 = Period('2000-01', 'M')
-        self.february = Period('2000-02', 'M')
-        self.march = Period('2000-03', 'M')
-
-    def test_equal(self):
-        self.assertEqual(self.january1,self.january2)
-
-    def test_notEqual(self):
-        self.assertNotEqual(self.january1, self.february)
-
-    def test_greater(self):
-        self.assertGreater(self.february, self.january1)
-
-    def test_greaterEqual(self):
-        self.assertGreaterEqual(self.january1, self.january2)
-
-    def test_smallerEqual(self):
-        self.assertLessEqual(self.january1, self.january2)
-
-    def test_smaller(self):
-        self.assertLess(self.january1, self.february)
-
-    def test_sort(self):
-        periods = [self.march, self.january1, self.february]
-        correctPeriods = [self.january1, self.february, self.march]
-        self.assertListEqual(sorted(periods), correctPeriods)
 
 def test_left_join_indexer_unique():
     a = np.array([1, 2, 3, 4, 5], dtype=np.int64)

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -152,6 +152,26 @@ class Period(object):
         else:  # pragma: no cover
             raise TypeError(other)
 
+    def __lt__(self, other):
+        if other.freq != self.freq:
+            raise ValueError("Cannot compare non-conforming periods")
+        return self.ordinal < other.ordinal
+
+    def __le__(self, other):
+        if other.freq != self.freq:
+            raise ValueError("Cannot compare non-conforming periods")
+        return self.ordinal <= other.ordinal
+
+    def __gt__(self, other):
+        if other.freq != self.freq:
+            raise ValueError("Cannot compare non-conforming periods")
+        return self.ordinal > other.ordinal
+
+    def __ge__(self, other):
+        if other.freq != self.freq:
+            raise ValueError("Cannot compare non-conforming periods")
+        return self.ordinal >= other.ordinal
+
     def asfreq(self, freq, how='E'):
         """
         Convert Period to desired frequency, either at the start or end of the

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -128,8 +128,12 @@ class Period(object):
 
     def __eq__(self, other):
         if isinstance(other, Period):
+            if other.freq != self.freq:
+                raise ValueError("Cannot compare non-conforming periods")
             return (self.ordinal == other.ordinal
                     and _gfc(self.freq) == _gfc(other.freq))
+        else:
+            raise TypeError(other)
         return False
 
     def __hash__(self):
@@ -153,24 +157,36 @@ class Period(object):
             raise TypeError(other)
 
     def __lt__(self, other):
-        if other.freq != self.freq:
-            raise ValueError("Cannot compare non-conforming periods")
-        return self.ordinal < other.ordinal
+        if isinstance(other, Period):
+            if other.freq != self.freq:
+                raise ValueError("Cannot compare non-conforming periods")
+            return self.ordinal < other.ordinal
+        else:
+            raise TypeError(other)
 
     def __le__(self, other):
-        if other.freq != self.freq:
-            raise ValueError("Cannot compare non-conforming periods")
-        return self.ordinal <= other.ordinal
+        if isinstance(other, Period):
+            if other.freq != self.freq:
+                raise ValueError("Cannot compare non-conforming periods")
+            return self.ordinal <= other.ordinal
+        else:
+            raise TypeError(other)
 
     def __gt__(self, other):
-        if other.freq != self.freq:
-            raise ValueError("Cannot compare non-conforming periods")
-        return self.ordinal > other.ordinal
+        if isinstance(other, Period):
+            if other.freq != self.freq:
+                raise ValueError("Cannot compare non-conforming periods")
+            return self.ordinal > other.ordinal
+        else:
+            raise TypeError(other)
 
     def __ge__(self, other):
-        if other.freq != self.freq:
-            raise ValueError("Cannot compare non-conforming periods")
-        return self.ordinal >= other.ordinal
+        if isinstance(other, Period):
+            if other.freq != self.freq:
+                raise ValueError("Cannot compare non-conforming periods")
+            return self.ordinal >= other.ordinal
+        else:
+            raise TypeError(other)
 
     def asfreq(self, freq, how='E'):
         """

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -156,37 +156,22 @@ class Period(object):
         else:  # pragma: no cover
             raise TypeError(other)
 
-    def __lt__(self, other):
-        if isinstance(other, Period):
-            if other.freq != self.freq:
-                raise ValueError("Cannot compare non-conforming periods")
-            return self.ordinal < other.ordinal
-        else:
-            raise TypeError(other)
+    def _comp_method(func, name):
+        def f(self, other):
+            if isinstance(other, Period):
+                if other.freq != self.freq:
+                    raise ValueError("Cannot compare non-conforming periods")
+                return func(self.ordinal, other.ordinal)
+            else:
+                raise TypeError(other)
 
-    def __le__(self, other):
-        if isinstance(other, Period):
-            if other.freq != self.freq:
-                raise ValueError("Cannot compare non-conforming periods")
-            return self.ordinal <= other.ordinal
-        else:
-            raise TypeError(other)
+        f.__name__ = name
+        return f
 
-    def __gt__(self, other):
-        if isinstance(other, Period):
-            if other.freq != self.freq:
-                raise ValueError("Cannot compare non-conforming periods")
-            return self.ordinal > other.ordinal
-        else:
-            raise TypeError(other)
-
-    def __ge__(self, other):
-        if isinstance(other, Period):
-            if other.freq != self.freq:
-                raise ValueError("Cannot compare non-conforming periods")
-            return self.ordinal >= other.ordinal
-        else:
-            raise TypeError(other)
+    __lt__ = _comp_method(operator.lt, '__lt__')
+    __le__ = _comp_method(operator.le, '__le__')
+    __gt__ = _comp_method(operator.gt, '__gt__')
+    __ge__ = _comp_method(operator.ge, '__ge__')
 
     def asfreq(self, freq, how='E'):
         """

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -449,12 +449,6 @@ class TestPeriodProperties(TestCase):
 
         self.assertRaises(ValueError, Period, '2007-01-01 07:10:15.123456')
 
-    def test_comparisons(self):
-        p = Period('2007-01-01')
-        self.assertEquals(p, p)
-        self.assert_(not p == 1)
-
-
 def noWrap(item):
     return item
 
@@ -1999,6 +1993,67 @@ class TestPeriodRepresentation(unittest.TestCase):
         period = Period(ordinal=-1, freq='W')
         repr(period)
 
+
+class TestComparisons(unittest.TestCase):
+    def setUp(self):
+        self.january1 = Period('2000-01', 'M')
+        self.january2 = Period('2000-01', 'M')
+        self.february = Period('2000-02', 'M')
+        self.march = Period('2000-03', 'M')
+        self.day = Period('2012-01-01', 'D')
+
+    def test_equal(self):
+        self.assertEqual(self.january1, self.january2)
+
+    def test_equal_Raises_Value(self):
+        self.assertRaises(ValueError, self.january1.__eq__, self.day)
+
+    def test_equal_Raises_Type(self):
+        self.assertRaises(TypeError, self.january1.__eq__, 1)
+
+    def test_notEqual(self):
+        self.assertNotEqual(self.january1, self.february)
+
+    def test_greater(self):
+        self.assertGreater(self.february, self.january1)
+
+    def test_greater_Raises_Value(self):
+        self.assertRaises(ValueError, self.january1.__gt__, self.day)
+
+    def test_greater_Raises_Type(self):
+        self.assertRaises(TypeError, self.january1.__gt__, 1)
+
+    def test_greaterEqual(self):
+        self.assertGreaterEqual(self.january1, self.january2)
+
+    def test_greaterEqual_Raises_Value(self):
+        self.assertRaises(ValueError, self.january1.__ge__, self.day)
+
+    def test_greaterEqual_Raises_Value(self):
+        self.assertRaises(TypeError, self.january1.__ge__, 1)
+
+    def test_smallerEqual(self):
+        self.assertLessEqual(self.january1, self.january2)
+
+    def test_smallerEqual_Raises_Value(self):
+        self.assertRaises(ValueError, self.january1.__le__, self.day)
+
+    def test_smallerEqual_Raises_Type(self):
+        self.assertRaises(TypeError, self.january1.__le__, 1)
+
+    def test_smaller(self):
+        self.assertLess(self.january1, self.february)
+
+    def test_smaller_Raises_Value(self):
+        self.assertRaises(ValueError, self.january1.__lt__, self.day)
+
+    def test_smaller_Raises_Type(self):
+        self.assertRaises(TypeError, self.january1.__lt__, 1)
+
+    def test_sort(self):
+        periods = [self.march, self.january1, self.february]
+        correctPeriods = [self.january1, self.february, self.march]
+        self.assertListEqual(sorted(periods), correctPeriods)
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
This commit should fix [issue 2781](https://github.com/pydata/pandas/issues/2781). The Period object couldn't be sorted because it didn't have any **le**, **gt**, **lt**, **ge** or **cmp** methods.
