### PR TITLE
ENH: support min/max on timedelta64[ns] Series

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -131,7 +131,7 @@ pandas 0.11.0
     - Support null checking on timedelta64, representing (and formatting) with NaT
     - Support setitem with np.nan value, converts to NaT
     - Support min/max ops in a Dataframe (abs not working, nor do we error on non-supported ops)
-    - Support idxmin/idxmax/abs in a Series (but with no NaT)
+    - Support idxmin/idxmax/abs/max/min in a Series (GH2989_, GH2982_)
 
   - Bug on in-place putmasking on an ``integer`` series that needs to be converted to ``float`` (GH2746_)
   - Bug in argsort of ``datetime64[ns]`` Series with ``NaT`` (GH2967_)
@@ -160,6 +160,7 @@ pandas 0.11.0
 .. _GH2973: https://github.com/pydata/pandas/issues/2973
 .. _GH2967: https://github.com/pydata/pandas/issues/2967
 .. _GH2982: https://github.com/pydata/pandas/issues/2982
+.. _GH2989: https://github.com/pydata/pandas/issues/2989
 
 
 pandas 0.10.1

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -966,14 +966,30 @@ Some timedelta numeric like operations are supported.
 
 .. ipython:: python
 
-    s  = Series(date_range('2012-1-1', periods=3, freq='D'))
+    td - timedelta(minutes=5,seconds=5,microseconds=5)
+
+``min, max`` and the corresponding ``idxmin, idxmax`` operations are support on frames
+
+.. ipython:: python
+
     df = DataFrame(dict(A = s - Timestamp('20120101')-timedelta(minutes=5,seconds=5),
                         B = s - Series(date_range('2012-1-2', periods=3, freq='D'))))
     df
 
-    # timedelta arithmetic
-    td - timedelta(minutes=5,seconds=5,microseconds=5)
 
-    # min/max operations
     df.min()
     df.min(axis=1)
+
+    df.idxmin()
+    df.idxmax()
+
+``min, max`` operations are support on series, these return a single element ``timedelta64[ns]`` Series (this avoids
+having to deal with numpy timedelta64 issues). ``idxmin, idxmax`` are supported as well.
+
+.. ipython:: python
+
+    df.min().max()
+    df.min(axis=1).min()
+
+    df.min().idxmax()
+    df.min(axis=1).idxmin()

--- a/doc/source/v0.11.0.txt
+++ b/doc/source/v0.11.0.txt
@@ -258,8 +258,6 @@ Bug Fixes
         df = DataFrame(dict(A = s, B = td))
         df
         s - s.max()
-        s - datetime(2011,1,1,3,5)
-        s + timedelta(minutes=5)
         df['C'] = df['A'] + df['B']
         df
         df.dtypes
@@ -274,10 +272,11 @@ Bug Fixes
 
         # works on lhs too
    	s.max() - s
-        datetime(2011,1,1,3,5) - s
-        timedelta(minutes=5) + s
 
-  - Fix pretty-printing of infinite data structures, GH2978
+        # some timedelta numeric operations are supported
+        td - timedelta(minutes=5,seconds=5,microseconds=5)
+
+  - Fix pretty-printing of infinite data structures (closes GH2978_)
 
 
 See the `full release notes

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -146,7 +146,13 @@ def _wrap_results(result,dtype):
             result = result.view(dtype)
     elif issubclass(dtype.type, np.timedelta64):
         if not isinstance(result, np.ndarray):
-            pass
+
+            # this is a scalar timedelta result!
+            # we have series convert then take the element (scalar)
+            # as series will do the right thing in py3 (and deal with numpy 1.6.2
+            # bug in that it results dtype of timedelta64[us]
+            from pandas import Series
+            result = Series([result],dtype='timedelta64[ns]')
         else:
             result = result.view(dtype)
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1838,6 +1838,15 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         result = (s1-s2).abs()
         assert_series_equal(result,expected)
 
+        # max/min
+        result = td.max()
+        expected = Series([timedelta(2)],dtype='timedelta64[ns]')
+        assert_series_equal(result,expected)
+
+        result = td.min()
+        expected = Series([timedelta(1)],dtype='timedelta64[ns]')
+        assert_series_equal(result,expected)
+
     def test_sub_of_datetime_from_TimeSeries(self): 
         from pandas.core import common as com
         from datetime import datetime 


### PR DESCRIPTION
closes GH #2989

```
In [168]: df = DataFrame(dict(A = s - Timestamp('20120101')-timedelta(minutes=5,seconds=5),
   .....:                     B = s - Series(date_range('2012-1-2', periods=3, freq='D'))))
   .....:

In [169]: df
Out[169]: 
                 A                 B
0        -00:05:05 -1 days, 00:00:00
1         23:54:55 -1 days, 00:00:00
2 1 days, 23:54:55 -1 days, 00:00:00

In [170]: df.min()
Out[170]: 
A           -00:05:05
B   -1 days, 00:00:00
dtype: timedelta64[ns]

In [171]: df.min(axis=1)
Out[171]: 
0   -1 days, 00:00:00
1   -1 days, 00:00:00
2   -1 days, 00:00:00
dtype: timedelta64[ns]

In [172]: df.idxmin()
Out[172]: 
A    0
B    0
dtype: int64

In [173]: df.idxmax()
Out[173]: 
A    2
B    0
dtype: int64

min, max operations are support on series, these return a single element timedelta64[ns] Series 
(this avoids having to deal with numpy timedelta64 issues). idxmin, idxmax are supported as well.

In [306]: df.min().max()
Out[306]: 
0   -00:05:05
dtype: timedelta64[ns]

In [307]: df.min(axis=1).min()
Out[307]: 
0   -1 days, 00:00:00
dtype: timedelta64[ns]

In [308]: df.min().idxmax()
Out[308]: 'A'

In [309]: df.min(axis=1).idxmin()
Out[309]: 0
```
