### PR TITLE
Bug: Fixed Issue 2993, Incorrect Timestamp Construction by datetime.date and tz

### DIFF
--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -1,5 +1,5 @@
 # pylint: disable-msg=E1101,W0612
-from datetime import datetime, time, timedelta, tzinfo
+from datetime import datetime, time, timedelta, tzinfo, date
 import sys
 import os
 import unittest
@@ -79,6 +79,7 @@ class TestTimeZoneSupport(unittest.TestCase):
 
         self.assert_(rng_eastern.tz == pytz.timezone('US/Eastern'))
 
+
     def test_localize_utc_conversion(self):
         # Localizing to time zone should:
         #  1) check for DST ambiguities
@@ -99,6 +100,15 @@ class TestTimeZoneSupport(unittest.TestCase):
 
         result = stamp.tz_localize('US/Eastern')
         expected = Timestamp('3/11/2012 04:00', tz='US/Eastern')
+        self.assertEquals(result.hour, expected.hour)
+        self.assertEquals(result, expected)
+
+    def test_timestamp_constructed_by_date_and_tz(self):
+        """ Fix Issue 2993, Timestamp cannot be constructed by datetime.date and tz correctly """
+
+        result = Timestamp(date(2012, 3, 11), tz='US/Eastern')
+
+        expected = Timestamp('3/11/2012', tz='US/Eastern')
         self.assertEquals(result.hour, expected.hour)
         self.assertEquals(result, expected)
 

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -22,6 +22,7 @@ from khash cimport *
 cimport cython
 
 from datetime import timedelta, datetime
+from datetime import time as datetime_time
 from dateutil.parser import parse as parse_date
 
 cdef extern from "Python.h":
@@ -668,7 +669,9 @@ cdef convert_to_tsobject(object ts, object tz):
         _check_dts_bounds(obj.value, &obj.dts)
         return obj
     elif PyDate_Check(ts):
-        obj.value  = _date_to_datetime64(ts, &obj.dts)
+        # Keep the converter same as PyDateTime's
+        ts = datetime.combine(ts, datetime_time())
+        return convert_to_tsobject(ts, tz)
     else:
         raise ValueError("Could not construct Timestamp from argument %s" %
                          type(ts))


### PR DESCRIPTION
`Timestamp` cannot be constructed correctly by given an `datetime.date` instance and `tz`.
The issued has been solved in this patch and the test case is add in `pandas/tseries/test/test_timezones.py`
