### PR TITLE
BUG:  Formatting of an index that has nan was inconsistent or wrong

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -145,6 +145,8 @@ pandas 0.11.0
   - Bug in DataFrame column insertion when the column creation fails, existing frame is left in
     an irrecoverable state (GH3010_)
   - Bug in DataFrame update where non-specified values could cause dtype changes (GH3016_)
+  - Formatting of an index that has ``nan`` was inconsistent or wrong (would fill from 
+    other values), (GH2850_)
 
 .. _GH622: https://github.com/pydata/pandas/issues/622
 .. _GH797: https://github.com/pydata/pandas/issues/797
@@ -161,6 +163,7 @@ pandas 0.11.0
 .. _GH2867: https://github.com/pydata/pandas/issues/2867
 .. _GH2807: https://github.com/pydata/pandas/issues/2807
 .. _GH2849: https://github.com/pydata/pandas/issues/2849
+.. _GH2850: https://github.com/pydata/pandas/issues/2850
 .. _GH2898: https://github.com/pydata/pandas/issues/2898
 .. _GH2892: https://github.com/pydata/pandas/issues/2892
 .. _GH2909: https://github.com/pydata/pandas/issues/2909

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -603,6 +603,31 @@ class TestDataFrameFormatting(unittest.TestCase):
         nmatches = len(re.findall('dtype',str_rep))
         self.assert_(nmatches == 1)
 
+    def test_index_with_nan(self):
+        #  GH 2850
+        df = DataFrame({'id1': {0: '1a3', 1: '9h4'}, 'id2': {0: np.nan, 1: 'd67'},
+                        'id3': {0: '78d', 1: '79d'}, 'value': {0: 123, 1: 64}})
+
+        # multi-index
+        y = df.set_index(['id1', 'id2', 'id3'])
+        result = y.to_string()
+        expected = u'             value\nid1 id2 id3       \n1a3 NaN 78d    123\n9h4 d67 79d     64'
+        self.assert_(result == expected)
+
+        # index
+        y = df.set_index('id2')
+        result = y.to_string()
+        expected = u'     id1  id3  value\nid2                 \nNaN  1a3  78d    123\nd67  9h4  79d     64'
+        self.assert_(result == expected)
+
+        # all-nan in mi
+        df2 = df.copy()
+        df2.ix[:,'id2'] = np.nan
+        y = df2.set_index('id2')
+        result = y.to_string()
+        expected = u'     id1  id3  value\nid2                 \nNaN  1a3  78d    123\nNaN  9h4  79d     64'
+        self.assert_(result == expected)
+        
     def test_to_string(self):
         from pandas import read_table
         import re
@@ -1234,8 +1259,14 @@ class TestSeriesFormatting(unittest.TestCase):
         result = s.to_string()
         self.assertTrue('2013-01-02' in result)
 
-        s = Series(2, index=[ Timestamp('20130111'), NaT ]).append(s)
+        # nat in index
+        s2 = Series(2, index=[ Timestamp('20130111'), NaT ])
+        s = s2.append(s)
         result = s.to_string()
+        self.assertTrue('NaT' in result)
+
+        # nat in summary
+        result = str(s2.index)
         self.assertTrue('NaT' in result)
 
     def test_timedelta64(self):

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -351,12 +351,13 @@ class TestIndex(unittest.TestCase):
         # 2845
         index = Index([1, 2.0+3.0j, np.nan])
         formatted = index.format()
-        expected = [str(index[0]), str(index[1]), str(index[2])]
+        expected = [str(index[0]), str(index[1]), u'NaN']
         self.assertEquals(formatted, expected)
 
+        # is this really allowed?
         index = Index([1, 2.0+3.0j, None])
         formatted = index.format()
-        expected = [str(index[0]), str(index[1]), '']
+        expected = [str(index[0]), str(index[1]), u'NaN']
         self.assertEquals(formatted, expected)
 
         self.strIndex[:0].format()


### PR DESCRIPTION
 Formatting of an index that has `nan` was inconsistent or wrong,
(would fill from last value), closes GH #2850

Also changed in test_format.py/test_index
1) printing of 'nan' rather than the na_rep (NaN) is inconcsistent
     with everywhere else
2) a 'None' in the index is defacto treated as NaN, is this wrong?
