### PR TITLE
ENH: support for nanosecond time in offset and period

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,15 +30,11 @@ pandas/io/*.dat
 pandas/io/*.json
 *.log
 .noseids
-
-.idea/libraries/sass_stdlib.xml
-
-.idea/pandas.iml
 .build_cache_dir
 .vagrant
 *.whl
 **/wheelhouse/*
-
 .project
 .pydevproject
 .settings
+.idea

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -425,6 +425,29 @@ Enhancements
     the file if the data has correctly separated and properly aligned columns
     using the delimiter provided to the function (:issue:`4488`). 
 
+  - support for nanosecond times in periods
+
+    .. warning::
+
+       These operations require ``numpy >= 1.7``
+
+    Period conversions in the range of seconds and below were reworked and extended
+    up to nanoseconds. Periods in the nanosecond range are now available.
+
+      .. ipython:: python
+        date_range('2013-01-01', periods=5, freq='5N')
+
+    or with frequency as offset
+
+      .. ipython:: python
+        date_range('2013-01-01', periods=5, freq=pd.offsets.Nano(5))
+
+    Timestamps can be modified in the nanosecond range
+
+      .. ipython:: python
+        t = Timestamp('20130101 09:01:02')
+        t + pd.datetools.Nano(123)
+
 .. _whatsnew_0130.experimental:
 
 Experimental

--- a/pandas/src/period.h
+++ b/pandas/src/period.h
@@ -85,6 +85,9 @@
 #define FR_HR   7000  /* Hourly */
 #define FR_MIN  8000  /* Minutely */
 #define FR_SEC  9000  /* Secondly */
+#define FR_MS 10000  /* Millisecondly */
+#define FR_US 11000  /* Microsecondly */
+#define FR_NS 12000  /* Nanosecondly */
 
 #define FR_UND  -10000 /* Undefined */
 
@@ -102,6 +105,9 @@ typedef struct asfreq_info {
 
     int from_q_year_end; // month the year ends on in the "from" frequency
     int to_q_year_end;   // month the year ends on in the "to" frequency
+
+    int sourceFreq;
+    int targetFreq; 
 } asfreq_info;
 
 
@@ -130,7 +136,7 @@ typedef npy_int64 (*freq_conv_func)(npy_int64, char, asfreq_info*);
 npy_int64 asfreq(npy_int64 period_ordinal, int freq1, int freq2, char relation);
 
 npy_int64 get_period_ordinal(int year, int month, int day,
-                      int hour, int minute, int second,
+                      int hour, int minute, int second, int microseconds, int picoseconds,
                       int freq);
 
 npy_int64 get_python_ordinal(npy_int64 period_ordinal, int freq);

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -1664,7 +1664,7 @@ class TestSeriesFormatting(unittest.TestCase):
         from pandas import date_range
         from datetime import datetime, timedelta
 
-        Series(np.array([1100, 20], dtype='timedelta64[s]')).to_string()
+        Series(np.array([1100, 20], dtype='timedelta64[ns]')).to_string()
 
         s = Series(date_range('2012-1-1', periods=3, freq='D'))
 

--- a/pandas/tseries/converter.py
+++ b/pandas/tseries/converter.py
@@ -458,7 +458,13 @@ def _daily_finder(vmin, vmax, freq):
     periodsperday = -1
 
     if freq >= FreqGroup.FR_HR:
-        if freq == FreqGroup.FR_SEC:
+        if freq == FreqGroup.FR_NS:
+            periodsperday = 24 * 60 * 60 * 1000000000
+        elif freq == FreqGroup.FR_US:
+            periodsperday = 24 * 60 * 60 * 1000000
+        elif freq == FreqGroup.FR_MS:
+            periodsperday = 24 * 60 * 60 * 1000
+        elif freq == FreqGroup.FR_SEC:
             periodsperday = 24 * 60 * 60
         elif freq == FreqGroup.FR_MIN:
             periodsperday = 24 * 60

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -12,6 +12,7 @@ import pandas.tseries.offsets as offsets
 import pandas.core.common as com
 import pandas.lib as lib
 import pandas.tslib as tslib
+from pandas import _np_version_under1p7
 
 
 class FreqGroup(object):
@@ -24,6 +25,9 @@ class FreqGroup(object):
     FR_HR = 7000
     FR_MIN = 8000
     FR_SEC = 9000
+    FR_MS = 10000
+    FR_US = 11000
+    FR_NS = 12000
 
 
 class Resolution(object):
@@ -116,7 +120,7 @@ def _get_freq_str(base, mult=1):
 # Offset names ("time rules") and related functions
 
 
-from pandas.tseries.offsets import (Micro, Milli, Second, Minute, Hour,
+from pandas.tseries.offsets import (Nano, Micro, Milli, Second, Minute, Hour,
                                     Day, BDay, CDay, Week, MonthBegin,
                                     MonthEnd, BMonthBegin, BMonthEnd,
                                     QuarterBegin, QuarterEnd, BQuarterBegin,
@@ -275,6 +279,9 @@ _offset_map = {
 
 }
 
+if not _np_version_under1p7:
+    _offset_map['N'] = Nano()
+
 _offset_to_period_map = {
     'WEEKDAY': 'D',
     'EOM': 'M',
@@ -291,6 +298,9 @@ _offset_to_period_map = {
     'B': 'B',
     'T': 'T',
     'S': 'S',
+    'L': 'L',
+    'U': 'U',
+    'N': 'N',
     'H': 'H',
     'Q': 'Q',
     'A': 'A',
@@ -609,6 +619,9 @@ _period_code_map = {
     "H": 7000,        # Hourly
     "T": 8000,        # Minutely
     "S": 9000,        # Secondly
+    "L": 10000,       # Millisecondly
+    "U": 11000,       # Microsecondly
+    "N": 12000,       # Nanosecondly
 }
 
 _reverse_period_code_map = {}
@@ -636,7 +649,10 @@ def _period_alias_dictionary():
     H_aliases = ["H", "HR", "HOUR", "HRLY", "HOURLY"]
     T_aliases = ["T", "MIN", "MINUTE", "MINUTELY"]
     S_aliases = ["S", "SEC", "SECOND", "SECONDLY"]
-
+    L_aliases = ["L", "MS", "MILLISECOND", "MILLISECONDLY"]
+    U_aliases = ["U", "US", "MICROSECOND", "MICROSECONDLY"]
+    N_aliases = ["N", "NS", "NANOSECOND", "NANOSECONDLY"]
+    
     for k in M_aliases:
         alias_dict[k] = 'M'
 
@@ -655,6 +671,15 @@ def _period_alias_dictionary():
     for k in S_aliases:
         alias_dict[k] = 'S'
 
+    for k in L_aliases:
+        alias_dict[k] = 'L'
+
+    for k in U_aliases:
+        alias_dict[k] = 'U'
+
+    for k in N_aliases:
+        alias_dict[k] = 'N'
+        
     A_prefixes = ["A", "Y", "ANN", "ANNUAL", "ANNUALLY", "YR", "YEAR",
                   "YEARLY"]
 
@@ -722,6 +747,9 @@ _reso_period_map = {
     "hour": "H",
     "minute": "T",
     "second": "S",
+    "millisecond": "L",
+    "microsecond": "U",
+    "nanosecond": "N",
 }
 
 

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1162,8 +1162,16 @@ class DatetimeIndex(Int64Index):
         Fast lookup of value from 1-dimensional ndarray. Only use this if you
         know what you're doing
         """
+        timestamp = None
+        #if isinstance(key, Timestamp):
+        #    timestamp = key
+        #el
         if isinstance(key, datetime):
-            return self.get_value_maybe_box(series, key)
+            # needed to localize naive datetimes
+            timestamp = Timestamp(key, tz=self.tz)
+
+        if timestamp:
+            return self.get_value_maybe_box(series, timestamp)
 
         try:
             return _maybe_box(self, Index.get_value(self, series, key), series, key)

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -8,6 +8,8 @@ from pandas.tseries.tools import to_datetime
 # import after tools, dateutil check
 from dateutil.relativedelta import relativedelta
 import pandas.tslib as tslib
+import numpy as np
+from pandas import _np_version_under1p7
 
 __all__ = ['Day', 'BusinessDay', 'BDay', 'CustomBusinessDay', 'CDay',
            'MonthBegin', 'BMonthBegin', 'MonthEnd', 'BMonthEnd',
@@ -25,7 +27,6 @@ class ApplyTypeError(TypeError):
 
 
 class CacheableOffset(object):
-
     _cacheable = True
 
 
@@ -107,7 +108,7 @@ class DateOffset(object):
     def _params(self):
         attrs = [(k, v) for k, v in compat.iteritems(vars(self))
                  if k not in ['kwds', '_offset', 'name', 'normalize',
-                 'busdaycalendar']]
+                              'busdaycalendar']]
         attrs.extend(list(self.kwds.items()))
         attrs = sorted(set(attrs))
 
@@ -123,7 +124,7 @@ class DateOffset(object):
         attrs = []
         for attr in sorted(self.__dict__):
             if ((attr == 'kwds' and len(self.kwds) == 0)
-                    or attr.startswith('_')):
+                or attr.startswith('_')):
                 continue
             elif attr == 'kwds':
                 kwds_new = {}
@@ -157,6 +158,7 @@ class DateOffset(object):
 
         if isinstance(other, compat.string_types):
             from pandas.tseries.frequencies import to_offset
+
             other = to_offset(other)
 
         if not isinstance(other, DateOffset):
@@ -255,6 +257,7 @@ class BusinessDay(CacheableOffset, DateOffset):
     """
     DateOffset subclass representing possibly n business days
     """
+
     def __init__(self, n=1, **kwds):
         self.n = int(n)
         self.kwds = kwds
@@ -412,6 +415,7 @@ class CustomBusinessDay(BusinessDay):
     def __init__(self, n=1, **kwds):
         # Check we have the required numpy version
         from distutils.version import LooseVersion
+
         if LooseVersion(np.__version__) < '1.7.0':
             raise NotImplementedError("CustomBusinessDay requires numpy >= "
                                       "1.7.0. Current version: " +
@@ -476,7 +480,7 @@ class CustomBusinessDay(BusinessDay):
         day64 = dt64.astype('datetime64[D]')
         time = dt64 - day64
 
-        if self.n<=0:
+        if self.n <= 0:
             roll = 'forward'
         else:
             roll = 'backward'
@@ -558,7 +562,7 @@ class BusinessMonthEnd(CacheableOffset, DateOffset):
 
         wkday, days_in_month = tslib.monthrange(other.year, other.month)
         lastBDay = days_in_month - max(((wkday + days_in_month - 1)
-                                       % 7) - 4, 0)
+                                        % 7) - 4, 0)
 
         if n > 0 and not other.day >= lastBDay:
             n = n - 1
@@ -621,6 +625,7 @@ class Week(CacheableOffset, DateOffset):
     weekday : int, default None
         Always generate specific day of week. 0 for Monday
     """
+
     def __init__(self, n=1, **kwds):
         self.n = n
         self.weekday = kwds.get('weekday', None)
@@ -628,7 +633,7 @@ class Week(CacheableOffset, DateOffset):
         if self.weekday is not None:
             if self.weekday < 0 or self.weekday > 6:
                 raise ValueError('Day must be 0<=day<=6, got %d' %
-                                self.weekday)
+                                 self.weekday)
 
         self._inc = timedelta(weeks=1)
         self.kwds = kwds
@@ -667,6 +672,7 @@ class Week(CacheableOffset, DateOffset):
             suffix = '-%s' % (_weekday_dict[self.weekday])
         return 'W' + suffix
 
+
 _weekday_dict = {
     0: 'MON',
     1: 'TUE',
@@ -696,6 +702,7 @@ class WeekOfMonth(CacheableOffset, DateOffset):
         5: Saturdays
         6: Sundays
     """
+
     def __init__(self, n=1, **kwds):
         self.n = n
         self.weekday = kwds['weekday']
@@ -706,10 +713,10 @@ class WeekOfMonth(CacheableOffset, DateOffset):
 
         if self.weekday < 0 or self.weekday > 6:
             raise ValueError('Day must be 0<=day<=6, got %d' %
-                            self.weekday)
+                             self.weekday)
         if self.week < 0 or self.week > 3:
             raise ValueError('Week must be 0<=day<=3, got %d' %
-                            self.week)
+                             self.week)
 
         self.kwds = kwds
 
@@ -773,7 +780,7 @@ class BQuarterEnd(CacheableOffset, DateOffset):
 
         wkday, days_in_month = tslib.monthrange(other.year, other.month)
         lastBDay = days_in_month - max(((wkday + days_in_month - 1)
-                                       % 7) - 4, 0)
+                                        % 7) - 4, 0)
 
         monthsToGo = 3 - ((other.month - self.startingMonth) % 3)
         if monthsToGo == 3:
@@ -1068,7 +1075,7 @@ class YearEnd(CacheableOffset, DateOffset):
 
         def _rollf(date):
             if (date.month != self.month or
-                    date.day < tslib.monthrange(date.year, date.month)[1]):
+                        date.day < tslib.monthrange(date.year, date.month)[1]):
                 date = _increment(date)
             return date
 
@@ -1120,7 +1127,7 @@ class YearBegin(CacheableOffset, DateOffset):
         def _decrement(date):
             year = date.year
             if date.month < self.month or (date.month == self.month and
-                                           date.day == 1):
+                                                   date.day == 1):
                 year -= 1
             return datetime(year, self.month, 1, date.hour, date.minute,
                             date.second, date.microsecond)
@@ -1164,6 +1171,7 @@ import operator
 def _tick_comp(op):
     def f(self, other):
         return op(self.delta, other.delta)
+
     return f
 
 
@@ -1191,6 +1199,7 @@ class Tick(DateOffset):
     def __eq__(self, other):
         if isinstance(other, compat.string_types):
             from pandas.tseries.frequencies import to_offset
+
             other = to_offset(other)
 
         if isinstance(other, Tick):
@@ -1206,6 +1215,7 @@ class Tick(DateOffset):
     def __ne__(self, other):
         if isinstance(other, compat.string_types):
             from pandas.tseries.frequencies import to_offset
+
             other = to_offset(other)
 
         if isinstance(other, Tick):
@@ -1265,8 +1275,11 @@ def _delta_to_tick(delta):
 
 
 def _delta_to_nanoseconds(delta):
-    if isinstance(delta, Tick):
+    if isinstance(delta, np.timedelta64):
+        return delta.astype('timedelta64[ns]').item()
+    elif isinstance(delta, Tick):
         delta = delta.delta
+
     return (delta.days * 24 * 60 * 60 * 1000000
             + delta.seconds * 1000000
             + delta.microseconds) * 1000
@@ -1302,8 +1315,9 @@ class Micro(Tick):
 
 
 class Nano(Tick):
-    _inc = 1
+    _inc = np.timedelta64(1, 'ns') if not _np_version_under1p7 else 1
     _rule_base = 'N'
+
 
 BDay = BusinessDay
 BMonthEnd = BusinessMonthEnd
@@ -1355,6 +1369,7 @@ def generate_range(start=None, end=None, periods=None,
     """
     if time_rule is not None:
         from pandas.tseries.frequencies import get_offset
+
         offset = get_offset(time_rule)
 
     start = to_datetime(start)

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -125,7 +125,7 @@ class Period(PandasObject):
 
         if self.ordinal is None:
             self.ordinal = tslib.period_ordinal(dt.year, dt.month, dt.day,
-                                                dt.hour, dt.minute, dt.second,
+                                                dt.hour, dt.minute, dt.second, dt.microsecond, 0,
                                                 base)
 
         self.freq = _freq_mod._get_freq_str(base)
@@ -447,6 +447,11 @@ def _get_date_and_freq(value, freq):
             freq = 'T'
         elif reso == 'second':
             freq = 'S'
+        elif reso == 'microsecond':
+            if dt.microsecond % 1000 == 0:
+                freq = 'L'
+            else:
+                freq = 'U'
         else:
             raise ValueError("Invalid frequency or could not infer: %s" % reso)
 
@@ -1238,7 +1243,7 @@ def _range_from_fields(year=None, month=None, quarter=None, day=None,
         year, quarter = _make_field_arrays(year, quarter)
         for y, q in zip(year, quarter):
             y, m = _quarter_to_myear(y, q, freq)
-            val = tslib.period_ordinal(y, m, 1, 1, 1, 1, base)
+            val = tslib.period_ordinal(y, m, 1, 1, 1, 1, 0, 0, base)
             ordinals.append(val)
     else:
         base, mult = _gfc(freq)
@@ -1247,7 +1252,7 @@ def _range_from_fields(year=None, month=None, quarter=None, day=None,
 
         arrays = _make_field_arrays(year, month, day, hour, minute, second)
         for y, mth, d, h, mn, s in zip(*arrays):
-            ordinals.append(tslib.period_ordinal(y, mth, d, h, mn, s, base))
+            ordinals.append(tslib.period_ordinal(y, mth, d, h, mn, s, 0, 0, base))
 
     return np.array(ordinals, dtype=np.int64), freq
 
@@ -1276,7 +1281,7 @@ def _ordinal_from_fields(year, month, quarter, day, hour, minute,
     if quarter is not None:
         year, month = _quarter_to_myear(year, quarter, freq)
 
-    return tslib.period_ordinal(year, month, day, hour, minute, second, base)
+    return tslib.period_ordinal(year, month, day, hour, minute, second, 0, 0, base)
 
 
 def _quarter_to_myear(year, quarter, freq):

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -195,7 +195,7 @@ class TestPeriodProperties(TestCase):
 
         self.assertRaises(ValueError, Period, ordinal=200701)
 
-        self.assertRaises(KeyError, Period, '2007-1-1', freq='U')
+        self.assertRaises(KeyError, Period, '2007-1-1', freq='X')
 
     def test_freq_str(self):
         i1 = Period('1982', freq='Min')
@@ -207,6 +207,16 @@ class TestPeriodProperties(TestCase):
 
         p = Period('2000-12-15')
         self.assert_('2000-12-15' in repr(p))
+
+    def test_millisecond_repr(self):
+        p = Period('2000-01-01 12:15:02.123')
+
+        self.assertEquals("Period('2000-01-01 12:15:02.123', 'L')", repr(p))
+
+    def test_microsecond_repr(self):
+        p = Period('2000-01-01 12:15:02.123567')
+
+        self.assertEquals("Period('2000-01-01 12:15:02.123567', 'U')", repr(p))
 
     def test_strftime(self):
         p = Period('2000-1-1 12:34:12', freq='S')
@@ -466,7 +476,14 @@ class TestPeriodProperties(TestCase):
         p = Period('2007-01-01 07:10:15')
         self.assert_(p.freq == 'S')
 
-        self.assertRaises(ValueError, Period, '2007-01-01 07:10:15.123456')
+        p = Period('2007-01-01 07:10:15.123')
+        self.assert_(p.freq == 'L')
+
+        p = Period('2007-01-01 07:10:15.123000')
+        self.assert_(p.freq == 'L')
+
+        p = Period('2007-01-01 07:10:15.123400')
+        self.assert_(p.freq == 'U')
 
 
 def noWrap(item):
@@ -1115,9 +1132,9 @@ class TestPeriodIndex(TestCase):
         self.assert_(idx.equals(exp))
 
     def test_constructor_U(self):
-        # U was used as undefined period
+        # X was used as undefined period
         self.assertRaises(KeyError, period_range, '2007-1-1', periods=500,
-                          freq='U')
+                          freq='X')
 
     def test_constructor_arrays_negative_year(self):
         years = np.arange(1960, 2000).repeat(4)
@@ -2168,6 +2185,15 @@ class TestPeriodRepresentation(unittest.TestCase):
 
     def test_secondly(self):
         self._check_freq('S', '1970-01-01')
+        
+    def test_millisecondly(self):
+        self._check_freq('L', '1970-01-01')
+
+    def test_microsecondly(self):
+        self._check_freq('U', '1970-01-01')
+        
+    def test_nanosecondly(self):
+        self._check_freq('N', '1970-01-01')        
 
     def _check_freq(self, freq, base_date):
         rng = PeriodIndex(start=base_date, periods=10, freq=freq)

--- a/pandas/tseries/tests/test_timeseries_legacy.py
+++ b/pandas/tseries/tests/test_timeseries_legacy.py
@@ -255,6 +255,7 @@ class LegacySupport(object):
         rule = datetools.to_offset('10us')
         self.assert_(rule == datetools.Micro(10))
 
+
 class TestLegacyCompat(unittest.TestCase):
 
     def setUp(self):

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-coverage erase
+command -v coverage >/dev/null && coverage erase
+command -v python-coverage >/dev/null && python-coverage erase
 # nosetests pandas/tests/test_index.py --with-coverage --cover-package=pandas.core --pdb-failure --pdb
 #nosetests -w pandas --with-coverage --cover-package=pandas --pdb-failure --pdb #--cover-inclusive
 #nosetests -A "not slow" -w pandas/tseries --with-coverage --cover-package=pandas.tseries $* #--cover-inclusive


### PR DESCRIPTION
closes #1812

This pull request fixes handling of nanosecond times in periods and offsets. In addition it simplifies the internal processing of intraday periods.

``` python
In []: pd.date_range('2013-01-01', periods=5, freq=pd.offsets.Nano(5))
Out[]: 
<class 'pandas.tseries.index.DatetimeIndex'>
[2013-01-01 00:00:00, ..., 2013-01-01 00:00:00.000000020]
Length: 5, Freq: 5N, Timezone: None
```

It requires Numpy 1.7 to work, using Numpy 1.6 yields the original behaviour before this PR.

This is the continuation of #2555 after it was merged without effect fixing issue #1812.

The biggest part is a refactoring of pandas/src/period.c to use a conversion factor matrix for intraday conversion. This minimizes the impact of adding three more intraday time units (ms, us and ns). Thus the amount of frequency conversion methods is reduced to one per intraday frequency source or target. The intraday conversion factor is looked up in the conversion factor matrix inside the method.

Nanosecond support is only available when using numpy >= 1.7. When using with numpy < 1.7 everything except nanosecond support should work as expected.
