### PR TITLE
BUG: fixes in replace to deal with block upcasting

### DIFF
--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -880,10 +880,23 @@ class BlockManager(object):
                                  'block items')
 
     def apply(self, f, *args, **kwargs):
-        """ iterate over the blocks, collect and create a new block manager """
+        """ iterate over the blocks, collect and create a new block manager
+        
+        Parameters
+        ----------
+        f : the callable or function name to operate on at the block level
+        axes : optional (if not supplied, use self.axes)
+        filter : callable, if supplied, only call the block if the filter is True
+        """
+
         axes = kwargs.pop('axes',None)
+        filter = kwargs.pop('filter',None)
         result_blocks = []
         for blk in self.blocks:
+            if filter is not None:
+                if not blk.items.isin(filter).any():
+                    result_blocks.append(blk)
+                    continue
             if callable(f):
                 applied = f(blk, *args, **kwargs)
             else:

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5621,6 +5621,16 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         result = df.replace([1,2], ['foo','bar'])
         assert_frame_equal(result,expected)
 
+        # test case from 
+        from pandas.util.testing import makeCustomDataframe as mkdf
+        df = DataFrame({'A' : Series([3,0],dtype='int64'), 'B' : Series([0,3],dtype='int64') })
+        result = df.replace(3, df.mean().to_dict())
+        expected = df.copy().astype('float64')
+        m = df.mean()
+        expected.iloc[0,0] = m[0]
+        expected.iloc[1,1] = m[1]
+        assert_frame_equal(result,expected)
+
     def test_replace_interpolate(self):
         padded = self.tsframe.replace(nan, method='pad')
         assert_frame_equal(padded, self.tsframe.fillna(method='pad'))


### PR DESCRIPTION
ENH: 
- _maybe_upcast_putmask now has the keyword, change to provide inline putmask changes to an object (series)
- apply in BlockManager now has a keyword, filter to allow acting on only those items contained in the filter (if supplied)

CLN: 
- consolidated all replace subs to main replace in DataFrame (which calls replace in BlockManager)

now passed test in GH #3064
