### PR TITLE
Fix figsize issue when using matplotlib locally

### DIFF
--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -63,6 +63,15 @@ class TestSeriesPlots(unittest.TestCase):
 
         Series(np.random.randn(10)).plot(kind='bar', color='black')
 
+        # figsize and title
+        import matplotlib.pyplot as plt
+        plt.close('all')
+        ax = self.series.plot(title='Test', figsize=(16, 8))
+
+        self.assert_(ax.title.get_text() == 'Test')
+        self.assert_((np.round(ax.figure.get_size_inches())
+                      == np.array((16., 8.))).all())
+
     @slow
     def test_bar_colors(self):
         import matplotlib.pyplot as plt

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -750,6 +750,7 @@ class MPLPlot(object):
         if (sec_true or has_sec) and not hasattr(ax, 'right_ax'):
             orig_ax, new_ax = ax, ax.twinx()
             orig_ax.right_ax, new_ax.left_ax = new_ax, orig_ax
+            new_ax.right_ax = new_ax
 
             if len(orig_ax.get_lines()) == 0:  # no data on left y
                 orig_ax.get_yaxis().set_visible(False)
@@ -1500,6 +1501,7 @@ def plot_series(series, label=None, kind='line', use_index=True, rot=None,
         For line plots, use log scaling on y axis
     secondary_y : boolean or sequence of ints, default False
         If True then y-axis will be on the right
+    figsize : a tuple (width, height) in inches
     kwds : keywords
         Options to pass to matplotlib plotting method
 
@@ -1515,7 +1517,18 @@ def plot_series(series, label=None, kind='line', use_index=True, rot=None,
     elif kind == 'kde':
         klass = KdePlot
 
-    if ax is None:
+    """
+    If no axis is specified, we check whether there are existing figures.
+    If so, we get the current axis and check whether yaxis ticks are on the
+    right. Ticks for the plot of the series will be on the right unless
+    there is at least one axis with ticks on the left.
+
+    If we do not check for whether there are existing figures, _gca() will
+    create a figure with the default figsize, causing the figsize= parameter to
+    be ignored.
+    """
+    import matplotlib.pyplot as plt
+    if ax is None and len(plt.get_fignums()) > 0:
         ax = _gca()
         if ax.get_yaxis().get_ticks_position().strip().lower() == 'right':
             fig = _gcf()
@@ -1539,7 +1552,8 @@ def plot_series(series, label=None, kind='line', use_index=True, rot=None,
     plot_obj.generate()
     plot_obj.draw()
 
-    return plot_obj.ax
+    # plot_obj.ax is None if we created the first figure
+    return plot_obj.axes[0]
 
 
 def boxplot(data, column=None, by=None, ax=None, fontsize=None,


### PR DESCRIPTION
This is a pretty minor issue, but I'm seeing the following when passing `figsize=(20,10)` when plotting a Series in the `ipython --pylab` environment:

![Series_figsize](https://f.cloud.github.com/assets/440095/267751/46f8b184-8ebd-11e2-8631-2131ce0421f6.png)

Everything's there - the window is just initialized to the wrong size. Without the `--pylab` flag and manually calling `plt.show()`, the window shows up as the default size (which is incorrect).

The issue appears to be that `plot_series()` will call `plt.gca()` before `figsize=` has been passed to `plt.figure()`. This initializes the window to the default size and it apparently isn't updated when redrawn.

What this patch does is use `plt.get_fignums()` to see if we have any existing figures. If so, we can call `plt.gca()` without automatically creating a figure and window at the default sizes.

The addition of `new_ax.right_axis = new_ax` is to accommodate Series plotted with `secondary_y=True` and thus getting `new_ax` as their `Axes`. It renders fine without it but a few tests expect `right_axis` to exist. This could be handled differently if this is inappropriate.

Finally, there's a test to check that `figsize=` is at least implemented on the figure. I don't know of a way to test this bug in a backend-independent way, so this only checks that we're not regressing to the pre-v0.10.0 state where `figsize=` was silently ignored by `plot_series()`.
