### PR TITLE
Resample docstring default values changed

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -231,9 +231,9 @@ class PandasObject(object):
               downsampling
         axis : int, optional, default 0
         fill_method : string, fill_method for upsampling, default None
-        closed : {'right', 'left'}, default 'left'
+        closed : {'right', 'left'}
             Which side of bin interval is closed
-        label : {'right', 'left'}, default 'left'
+        label : {'right', 'left'}
             Which bin edge label to label bucket with
         convention : {'start', 'end', 's', 'e'}
         kind: "period"/"timestamp"

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -231,9 +231,9 @@ class PandasObject(object):
               downsampling
         axis : int, optional, default 0
         fill_method : string, fill_method for upsampling, default None
-        closed : {'right', 'left'}, default None
+        closed : {'right', 'left'}, default 'left'
             Which side of bin interval is closed
-        label : {'right', 'left'}, default None
+        label : {'right', 'left'}, default 'left'
             Which bin edge label to label bucket with
         convention : {'start', 'end', 's', 'e'}
         kind: "period"/"timestamp"

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -24,8 +24,8 @@ class TimeGrouper(CustomGrouper):
     Parameters
     ----------
     freq : pandas date offset or offset alias for identifying bin edges
-    closed : closed end of interval; left (default) or right
-    label : interval boundary to use for labeling; left (default) or right
+    closed : closed end of interval; left or right
+    label : interval boundary to use for labeling; left or right
     nperiods : optional, integer
     convention : {'start', 'end', 'e', 's'}
         If axis is PeriodIndex


### PR DESCRIPTION
This docstring seems better, since TimeGrouper specifies it [that way](https://github.com/pydata/pandas/blob/master/pandas/tseries/resample.py#L27) too:
