### PR TITLE
PERF: added convert=boolean to take to enable negative index conversion

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -44,6 +44,8 @@ pandas 0.11.0
   - Moved functionaility from ``irow,icol,iget_value/iset_value`` to ``.iloc`` indexer
     (via ``_ixs`` methods in each object)
   - Added support for expression evaluation using the ``numexpr`` library
+  - Added ``convert=boolean`` to ``take`` routines to translate negative indices to positive,
+    defaults to True
 
 **Improvements to existing features**
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -189,7 +189,7 @@ class PandasObject(object):
         """
         try:
             indexer = self.index.indexer_at_time(time, asof=asof)
-            return self.take(indexer)
+            return self.take(indexer, convert=False)
         except AttributeError:
             raise TypeError('Index must be DatetimeIndex')
 
@@ -213,7 +213,7 @@ class PandasObject(object):
             indexer = self.index.indexer_between_time(
                 start_time, end_time, include_start=include_start,
                 include_end=include_end)
-            return self.take(indexer)
+            return self.take(indexer, convert=False)
         except AttributeError:
             raise TypeError('Index must be DatetimeIndex')
 
@@ -934,7 +934,7 @@ class NDFrame(PandasObject):
 
         return self._constructor(new_data)
 
-    def take(self, indices, axis=0):
+    def take(self, indices, axis=0, convert=True):
         """
         Analogous to ndarray.take
 
@@ -942,6 +942,7 @@ class NDFrame(PandasObject):
         ----------
         indices : list / array of ints
         axis : int, default 0
+        convert : translate neg to pos indices (default)
 
         Returns
         -------
@@ -949,7 +950,8 @@ class NDFrame(PandasObject):
         """
 
         # check/convert indicies here
-        indices = _maybe_convert_indices(indices, len(self._get_axis(axis)))
+        if convert:
+            indices = _maybe_convert_indices(indices, len(self._get_axis(axis)))
 
         if axis == 0:
             labels = self._get_axis(axis)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -391,7 +391,7 @@ class _NDFrameIndexer(object):
         if com._is_bool_indexer(key):
             key = _check_bool_indexer(labels, key)
             inds, = key.nonzero()
-            return self.obj.take(inds, axis=axis)
+            return self.obj.take(inds, axis=axis, convert=False)
         else:
             if isinstance(key, Index):
                 # want Index objects to pass through untouched
@@ -408,7 +408,7 @@ class _NDFrameIndexer(object):
                 if labels.inferred_type == 'mixed-integer':
                     indexer = labels.get_indexer(keyarr)
                     if (indexer >= 0).all():
-                        self.obj.take(indexer, axis=axis)
+                        self.obj.take(indexer, axis=axis, convert=True)
                     else:
                         return self.obj.take(keyarr, axis=axis)
                 elif not labels.inferred_type == 'integer':
@@ -426,7 +426,7 @@ class _NDFrameIndexer(object):
                 return _reindex(keyarr, level=level)
             else:
                 mask = labels.isin(keyarr)
-                return self.obj.take(mask.nonzero()[0], axis=axis)
+                return self.obj.take(mask.nonzero()[0], axis=axis, convert=False)
 
     def _convert_to_indexer(self, obj, axis=0):
         """
@@ -644,7 +644,7 @@ class _LocationIndexer(_NDFrameIndexer):
             key = _check_bool_indexer(labels, key)
             inds, = key.nonzero()
             try:
-                return self.obj.take(inds, axis=axis)
+                return self.obj.take(inds, axis=axis, convert=False)
             except (Exception), detail:
                 raise self._exception(detail)
     def _get_slice_axis(self, slice_obj, axis=0):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2550,7 +2550,7 @@ class Series(pa.Array, generic.PandasObject):
         return self.reindex(other.index, method=method, limit=limit,
                             fill_value=fill_value)
 
-    def take(self, indices, axis=0):
+    def take(self, indices, axis=0, convert=True):
         """
         Analogous to ndarray.take, return Series corresponding to requested
         indices
@@ -2558,6 +2558,7 @@ class Series(pa.Array, generic.PandasObject):
         Parameters
         ----------
         indices : list / array of ints
+        convert : translate negative to positive indices (default)
 
         Returns
         -------

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from pandas.core.common import _pickle_array, _unpickle_array, _try_sort
 from pandas.core.index import Index, MultiIndex, _ensure_index
-from pandas.core.indexing import _check_slice_bounds
+from pandas.core.indexing import _check_slice_bounds, _maybe_convert_indices
 from pandas.core.series import Series
 from pandas.core.frame import (DataFrame, extract_index, _prep_ndarray,
                                _default_index)
@@ -634,7 +634,7 @@ class SparseDataFrame(DataFrame):
         self.columns = new_columns
         self._series = new_series
 
-    def take(self, indices, axis=0):
+    def take(self, indices, axis=0, convert=True):
         """
         Analogous to ndarray.take, return SparseDataFrame corresponding to
         requested indices along an axis
@@ -643,12 +643,20 @@ class SparseDataFrame(DataFrame):
         ----------
         indices : list / array of ints
         axis : {0, 1}
+        convert : convert indices for negative values, check bounds, default True
+                  mainly useful for an user routine calling
 
         Returns
         -------
         taken : SparseDataFrame
         """
+
         indices = com._ensure_platform_int(indices)
+
+        # check/convert indicies here
+        if convert:
+            indices = _maybe_convert_indices(indices, len(self._get_axis(axis)))
+
         new_values = self.values.take(indices, axis=axis)
         if axis == 0:
             new_columns = self.columns

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -468,7 +468,7 @@ to sparse
         else:
             return result
 
-    def take(self, indices, axis=0):
+    def take(self, indices, axis=0, convert=True):
         """
         Sparse-compatible version of ndarray.take
 


### PR DESCRIPTION
mainly for user facing routines (defaults to True)

was causing a perf regression (see #3089)
#3033 will 'fix' this as will create a new internal routine to do takes

(and make DataFrame/take) user facing only
