### PR TITLE
BUG: HDFStore bug when appending to a table, .typ not recreated on subsequent appends

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1162,6 +1162,10 @@ class DataCol(IndexCol):
             elif self.dtype.startswith('bool'):
                 self.kind = 'bool'
 
+            # set my typ if we need
+            if self.typ is None:
+                self.typ = getattr(self.description,self.cname,None)
+
     def set_atom(self, block, existing_col, min_itemsize, nan_rep, **kwargs):
         """ create and setup my atom from the block b """
 

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -659,6 +659,15 @@ class TestHDFStore(unittest.TestCase):
             result = store.select('df')
             tm.assert_frame_equal(result, df)
 
+        with ensure_clean(self.path) as store:
+
+            # infer the .typ on subsequent appends
+            df = DataFrame(dict(A = 'foo', B = 'bar'),index=range(10))
+            store.remove('df')
+            store.append('df', df[:5], min_itemsize=200)
+            store.append('df', df[5:], min_itemsize=200)
+            tm.assert_frame_equal(store['df'], df)
+
     def test_append_with_data_columns(self):
 
         with ensure_clean(self.path) as store:


### PR DESCRIPTION
not correctctly recreating string columns so that could test the min_itemsize if its passed on subsequent appends, see:

http://stackoverflow.com/questions/15488809/how-to-trouble-shoot-hdfstore-exception-cannot-find-the-correct-atom-type?noredirect=1#comment22032050_15488809
