### PR TITLE
ENH: extend selection semantics on ordered timeseries to unordered

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -98,7 +98,7 @@ pandas 0.11.0
     histograms. (GH2710_).
   - DataFrame.from_records now accepts not only dicts but any instance of
     the collections.Mapping ABC.
-  - Allow selection semantics for via a string with a datelike index to work in both
+  - Allow selection semantics via a string with a datelike index to work in both
     Series and DataFrames (GH3070_)
 
     .. ipython:: python

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -98,6 +98,17 @@ pandas 0.11.0
     histograms. (GH2710_).
   - DataFrame.from_records now accepts not only dicts but any instance of
     the collections.Mapping ABC.
+  - Allow selection semantics for via a string with a datelike index to work in both
+    Series and DataFrames (GH3070_)
+
+    .. ipython:: python
+
+        idx = date_range("2001-10-1", periods=5, freq='M')
+        ts = Series(np.random.rand(len(idx)),index=idx)
+        ts['2001']
+
+        df = DataFrame(dict(A = ts))
+        df['2001']
 
 
 **API Changes**
@@ -262,6 +273,7 @@ pandas 0.11.0
 .. _GH3059: https://github.com/pydata/pandas/issues/3059
 .. _GH2993: https://github.com/pydata/pandas/issues/2993
 .. _GH3115: https://github.com/pydata/pandas/issues/3115
+.. _GH3070: https://github.com/pydata/pandas/issues/3070
 
 pandas 0.10.1
 =============

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -202,6 +202,8 @@ pandas 0.11.0
   - Fixed bug in Timestamp(d,tz=foo) when d is date() rather then datetime() (GH2993_)
   - series.plot(kind='bar') now respects pylab color schem (GH3115_)
   - Fixed bug in reshape if not passed correct input, now raises TypeError (GH2719_)
+  - Allow selection in an *unordered* timeseries to work similary 
+    to an *ordered* timeseries (GH2437_). Fix NameError issue on RESO_US (GH2787_)
 
  .. _GH2758: https://github.com/pydata/pandas/issues/2758
 .. _GH2809: https://github.com/pydata/pandas/issues/2809
@@ -227,6 +229,8 @@ pandas 0.11.0
 .. _GH2751: https://github.com/pydata/pandas/issues/2751
 .. _GH2776: https://github.com/pydata/pandas/issues/2776
 .. _GH2778: https://github.com/pydata/pandas/issues/2778
+.. _GH2437: https://github.com/pydata/pandas/issues/2437
+.. _GH2787: https://github.com/pydata/pandas/issues/2787
 .. _GH2793: https://github.com/pydata/pandas/issues/2793
 .. _GH2795: https://github.com/pydata/pandas/issues/2795
 .. _GH2819: https://github.com/pydata/pandas/issues/2819

--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -105,6 +105,9 @@ Expanding Data
 `Alignment and to-date
 <http://stackoverflow.com/questions/15489011/python-time-series-alignment-and-to-date-functions>`__
 
+`Rolling Computation window based on values instead of counts
+<http://stackoverflow.com/questions/14300768/pandas-rolling-computation-with-window-based-on-values-instead-of-counts>`__
+
 Splitting
 ~~~~~~~~~
 
@@ -170,6 +173,9 @@ CSV
 
 `Reading the first few lines of a frame
 <http://stackoverflow.com/questions/15008970/way-to-read-first-few-lines-for-pandas-dataframe>`__
+
+`Inferring dtypes from a file
+<http://stackoverflow.com/questions/15555005/get-inferred-dataframe-types-iteratively-using-chunksize>`__
 
 SQL
 ~~~

--- a/doc/source/v0.11.0.txt
+++ b/doc/source/v0.11.0.txt
@@ -243,6 +243,8 @@ Enhancements
   - In ``HDFStore``, new keywords ``iterator=boolean``, and ``chunksize=number_in_a_chunk`` are
     provided to support iteration on ``select`` and ``select_as_multiple`` (GH3076_)
 
+  - You can now select timestamps from an *unordered* timeseries similarly to an *ordered* timeseries (GH2437_)
+
   - ``Squeeze`` to possibly remove length 1 dimensions from an object.
 
     .. ipython:: python
@@ -293,6 +295,7 @@ See the `full release notes
 <https://github.com/pydata/pandas/blob/master/RELEASE.rst>`__ or issue tracker
 on GitHub for a complete list.
 
+.. _GH2437: https://github.com/pydata/pandas/issues/2437
 .. _GH2809: https://github.com/pydata/pandas/issues/2809
 .. _GH2810: https://github.com/pydata/pandas/issues/2810
 .. _GH2837: https://github.com/pydata/pandas/issues/2837

--- a/doc/source/v0.11.0.txt
+++ b/doc/source/v0.11.0.txt
@@ -245,7 +245,7 @@ Enhancements
 
   - You can now select timestamps from an *unordered* timeseries similarly to an *ordered* timeseries (GH2437_)
 
-  - You can now select with a string from a DataFrame with a datelike index, in a similar way to a Series (GH3070_
+  - You can now select with a string from a DataFrame with a datelike index, in a similar way to a Series (GH3070_)
 
     .. ipython:: python
 

--- a/doc/source/v0.11.0.txt
+++ b/doc/source/v0.11.0.txt
@@ -245,6 +245,17 @@ Enhancements
 
   - You can now select timestamps from an *unordered* timeseries similarly to an *ordered* timeseries (GH2437_)
 
+  - You can now select with a string from a DataFrame with a datelike index, in a similar way to a Series (GH3070_
+
+    .. ipython:: python
+
+        idx = date_range("2001-10-1", periods=5, freq='M')
+        ts = Series(np.random.rand(len(idx)),index=idx)
+        ts['2001']
+
+        df = DataFrame(dict(A = ts))
+        df['2001']
+
   - ``Squeeze`` to possibly remove length 1 dimensions from an object.
 
     .. ipython:: python
@@ -313,3 +324,4 @@ on GitHub for a complete list.
 .. _GH3011: https://github.com/pydata/pandas/issues/3011
 .. _GH3076: https://github.com/pydata/pandas/issues/3076
 .. _GH3059: https://github.com/pydata/pandas/issues/3059
+.. _GH3070: https://github.com/pydata/pandas/issues/3070

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -827,6 +827,30 @@ class _iAtIndexer(_ScalarAccessIndexer):
 _eps = np.finfo('f4').eps
 
 
+def _convert_to_index_sliceable(obj, key):
+    """ if we are index sliceable, then return my slicer, otherwise return None """
+    idx = obj.index
+    if isinstance(key, slice):
+        idx_type = idx.inferred_type
+        if idx_type == 'floating':
+            indexer = obj.ix._convert_to_indexer(key, axis=0)
+        elif idx_type == 'integer' or _is_index_slice(key):
+            indexer = key
+        else:
+            indexer = obj.ix._convert_to_indexer(key, axis=0)
+        return indexer
+
+    elif isinstance(key, basestring):
+
+        # we need a timelike key here
+        if idx.is_all_dates:
+            try:
+                return idx._get_string_slice(key)
+            except:
+                return None
+
+    return None
+
 def _is_index_slice(obj):
     def _is_valid_index(x):
         return (com.is_integer(x) or com.is_float(x)

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -34,11 +34,11 @@ class Resolution(object):
 
     @classmethod
     def get_str(cls, reso):
-        return {RESO_US: 'microsecond',
-                RESO_SEC: 'second',
-                RESO_MIN: 'minute',
-                RESO_HR: 'hour',
-                RESO_DAY: 'day'}.get(reso, 'day')
+        return {cls.RESO_US: 'microsecond',
+                cls.RESO_SEC: 'second',
+                cls.RESO_MIN: 'minute',
+                cls.RESO_HR: 'hour',
+                cls.RESO_DAY: 'day'}.get(reso, 'day')
 
 
 def get_reso_string(reso):

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1042,9 +1042,6 @@ class DatetimeIndex(Int64Index):
             return self._view_like(left_chunk)
 
     def _partial_date_slice(self, reso, parsed):
-        if not self.is_monotonic:
-            raise TimeSeriesError('Partial indexing only valid for ordered '
-                                  'time series.')
 
         if reso == 'year':
             t1 = Timestamp(datetime(parsed.year, 1, 1), tz=self.tz)
@@ -1079,11 +1076,19 @@ class DatetimeIndex(Int64Index):
                                      tz=self.tz).value - 1)
         else:
             raise KeyError
+        
 
         stamps = self.asi8
-        left = stamps.searchsorted(t1.value, side='left')
-        right = stamps.searchsorted(t2.value, side='right')
-        return slice(left, right)
+
+        if self.is_monotonic:
+
+            # a monotonic (sorted) series can be sliced
+            left = stamps.searchsorted(t1.value, side='left')
+            right = stamps.searchsorted(t2.value, side='right')
+            return slice(left, right)
+
+        # try to find a the dates
+        return np.where((stamps>=t1.value) & (stamps<=t2.value))[0]
 
     def _possibly_promote(self, other):
         if other.inferred_type == 'date':

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1088,7 +1088,7 @@ class DatetimeIndex(Int64Index):
             return slice(left, right)
 
         # try to find a the dates
-        return np.where((stamps>=t1.value) & (stamps<=t2.value))[0]
+        return ((stamps>=t1.value) & (stamps<=t2.value)).nonzero()[0]
 
     def _possibly_promote(self, other):
         if other.inferred_type == 'date':

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -171,7 +171,7 @@ class TestTimeSeriesDuplicates(unittest.TestCase):
 
     def test_indexing_unordered(self):
 
-        # GH 2437
+        # GH 2437 (series)
         from pandas import concat
         rng = date_range(start='2011-01-01', end='2011-01-15')
         ts  = Series(randn(len(rng)), index=rng)
@@ -196,11 +196,35 @@ class TestTimeSeriesDuplicates(unittest.TestCase):
         for t in result.index:
             self.assertTrue(t.year == 2005)
 
+    def test_indexing(self):
+
+        idx = date_range("2001-1-1", periods=20, freq='M')
+        ts = Series(np.random.rand(len(idx)),index=idx)
+
+        # getting
+
+        # GH 3070, make sure semantics work on Series/Frame
+        expected = ts['2001']
+        
+        df = DataFrame(dict(A = ts))
+        result = df['2001']['A']
+        assert_series_equal(expected,result)
+
+        # setting
+        ts['2001'] = 1
+        expected = ts['2001']
+
+        df.loc['2001','A'] = 1
+
+        result = df['2001']['A']
+        assert_series_equal(expected,result)
+
+
+
 def assert_range_equal(left, right):
     assert(left.equals(right))
     assert(left.freq == right.freq)
     assert(left.tz == right.tz)
-
 
 class TestTimeSeries(unittest.TestCase):
     _multiprocess_can_split_ = True


### PR DESCRIPTION
closes #2437
closes #2787
closes #3070
