### PR TITLE
BUG: GH3094, timedelta64 failing on numpy 1.7.0 (on 2.7)

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -179,7 +179,7 @@ pandas 0.11.0
     - Series ops with a Timestamp on the rhs was throwing an exception (GH2898_)
       added tests for Series ops with datetimes,timedeltas,Timestamps, and datelike
       Series on both lhs and rhs
-    - Fixed subtle timedelta64 inference issue on py3
+    - Fixed subtle timedelta64 inference issue on py3 & numpy 1.7.0 (GH3094_)
     - Fixed some formatting issues on timedelta when negative
     - Support null checking on timedelta64, representing (and formatting) with NaT
     - Support setitem with np.nan value, converts to NaT
@@ -293,6 +293,7 @@ pandas 0.11.0
 .. _GH3115: https://github.com/pydata/pandas/issues/3115
 .. _GH3070: https://github.com/pydata/pandas/issues/3070
 .. _GH3075: https://github.com/pydata/pandas/issues/3075
+.. _GH3094: https://github.com/pydata/pandas/issues/3094
 .. _GH3130: https://github.com/pydata/pandas/issues/3130
 
 pandas 0.10.1

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -104,6 +104,11 @@ def _arith_method(op, name):
                         pass
                     else:
                         values = com._possibly_cast_to_timedelta(values)
+                elif inferred_type in set(['integer']):
+                    if values.dtype == 'timedelta64[ns]':
+                        pass
+                    elif values.dtype.kind == 'm':
+                        values = values.astype('timedelta64[ns]')
                 else:
                     values = pa.array(values)
                 return values


### PR DESCRIPTION
closes #3094

as np.array(timedelta64[ns] series) converts to int64 dtype for some weird reason
