### PR TITLE
ENH: added numexpr support for where operations

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3720,7 +3720,8 @@ class DataFrame(NDFrame):
         -------
         combined : DataFrame
         """
-        combiner = lambda x, y: np.where(isnull(x), y, x)
+        def combiner(x, y):
+            return expressions.where(isnull(x), y, x, raise_on_error=True)
         return self.combine(other, combiner, overwrite=False)
 
     def update(self, other, join='left', overwrite=True, filter_func=None,
@@ -3771,7 +3772,7 @@ class DataFrame(NDFrame):
                 else:
                     mask = notnull(this)
 
-            self[col] = np.where(mask, this, that)
+            self[col] = expressions.where(mask, this, that, raise_on_error=True)
 
     #----------------------------------------------------------------------
     # Misc methods

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -10,6 +10,7 @@ from pandas.core.indexing import _check_slice_bounds, _maybe_convert_indices
 import pandas.core.common as com
 import pandas.lib as lib
 import pandas.tslib as tslib
+import pandas.core.expressions as expressions
 
 from pandas.tslib import Timestamp
 from pandas.util import py3compat
@@ -506,7 +507,7 @@ class Block(object):
                 return v
             
             try:
-                return np.where(c,v,o)
+                return expressions.where(c, v, o, raise_on_error=True)
             except (Exception), detail:
                 if raise_on_error:
                     raise TypeError('Could not operate [%s] with block values [%s]'


### PR DESCRIPTION
Added support for numexpr to do where operations, so this will have an
effect on most boolean indexing operations themselves
(inital commit would speedup ops like `df>0`)

this PR is in effect speeding up `np.where`

`df[(df>0)&(df2>0)]` (100k x 100 columns)

`no_ne` is no numexpr at all
`st` is single threaded

This operation is restricted to int64/float64 dtypes
(others would be upcasted, which we could deal with, but
not now)

note: _the above operation could (and should) be much faster
if done as a single operation, but for now this is basically
4 calls to numexpr (3 boolean, then the where), but that's
for another day_

```
----------------------------------------------------------------
Test name                      | target[ms] | base[ms] |   ratio
----------------------------------------------------------------
frame_multi_and                       128.5169   385.2890     0.3336
frame_multi_and_st                    215.7741   417.0649     0.5174
frame_multi_and_no_ne                 397.3501   401.0870     0.9907
```
