### PR TITLE
ENH: Pass **kwargs through to matplotlib .scatter()

### DIFF
--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1703,7 +1703,7 @@ def format_date_labels(ax, rot):
         pass
 
 
-def scatter_plot(data, x, y, by=None, ax=None, figsize=None, grid=False):
+def scatter_plot(data, x, y, by=None, ax=None, figsize=None, grid=False, **kwargs):
     """
 
     Returns
@@ -1715,7 +1715,7 @@ def scatter_plot(data, x, y, by=None, ax=None, figsize=None, grid=False):
     def plot_group(group, ax):
         xvals = group[x].values
         yvals = group[y].values
-        ax.scatter(xvals, yvals)
+        ax.scatter(xvals, yvals, **kwargs)
         ax.grid(grid)
 
     if by is not None:


### PR DESCRIPTION
Allow for more configurability to making scatter plots.  Most of the other plotting functions already do this, just giving .scatter_plot() the same power.  Works for both single scatters and grouped scatters.

I didn't make a test because anything that would be tested would be matplotlib specific, but I'd be happy to do so if you'd like (test_graphics.py: TestDataFramePlots.test_scatter is a good spot).
