### PR TITLE
ENH: Declare a BoolBlock as a NumericBlock

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -124,6 +124,8 @@ pandas 0.11.0
     knows how many columns to expect in the result) (GH2981_)
   - On a mixed DataFrame, allow setting with indexers with ndarray/DataFrame
     on rhs (GH3216_)
+  - Treat boolean values as integers (values 1 and 0) for numeric
+    operations. (GH2641_)
 
 **API Changes**
 
@@ -350,6 +352,7 @@ pandas 0.11.0
 .. _GH2747: https://github.com/pydata/pandas/issues/2747
 .. _GH2816: https://github.com/pydata/pandas/issues/2816
 .. _GH3216: https://github.com/pydata/pandas/issues/3216
+.. _GH2641: https://github.com/pydata/pandas/issues/2641
 
 pandas 0.10.1
 =============

--- a/doc/source/v0.11.0.txt
+++ b/doc/source/v0.11.0.txt
@@ -304,6 +304,9 @@ Enhancements
   - added option `display.with_wmp_style` providing a sleeker visual style
     for plots. Based on https://gist.github.com/huyng/816622 (GH3075_).
 
+  - Treat boolean values as integers (values 1 and 0) for numeric
+    operations. (GH2641_)
+
 See the `full release notes
 <https://github.com/pydata/pandas/blob/master/RELEASE.rst>`__ or issue tracker
 on GitHub for a complete list.
@@ -328,3 +331,4 @@ on GitHub for a complete list.
 .. _GH3059: https://github.com/pydata/pandas/issues/3059
 .. _GH3070: https://github.com/pydata/pandas/issues/3070
 .. _GH3075: https://github.com/pydata/pandas/issues/3075
+.. _GH2641: https://github.com/pydata/pandas/issues/2641

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -628,7 +628,7 @@ class IntBlock(NumericBlock):
         return com.is_integer_dtype(value) and value.dtype == self.dtype
 
 
-class BoolBlock(Block):
+class BoolBlock(NumericBlock):
     is_bool = True
     _can_hold_na = False
 
@@ -640,9 +640,6 @@ class BoolBlock(Block):
             return bool(element)
         except:  # pragma: no cover
             return element
-
-    def _try_cast_result(self, result):
-        return _possibly_downcast_to_dtype(result, self.dtype)
 
     def should_store(self, value):
         return issubclass(value.dtype.type, np.bool_)

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -497,7 +497,7 @@ class TestBlockManager(unittest.TestCase):
                         'bool': bool_ser, 'obj': obj_ser,
                         'dt': dt_ser})
         xp = DataFrame({'int': int_ser, 'float': float_ser,
-                        'complex': complex_ser})
+                        'complex': complex_ser, 'bool': bool_ser})
         rs = DataFrame(df._data.get_numeric_data())
         assert_frame_equal(xp, rs)
 


### PR DESCRIPTION
BUG: #2641 fixes "df.decribe() with boolean column"

Numpy refers to a boolean type as a "numerical type", and both Python
and numpy cast True bools into the value 1 and False bools into the
value 0, so all numpy numerical operations always work.

---

This basically is to solve this issue, which I always found a bit puzzling:

import pandas

df = pandas.DataFrame({
    'int1': [1, 2, 3],
    'bool1': [False, False, True],
    'bool2': [True, True, False],
})

print df.corr()

```
       int1
int1     1
```

print df[['bool1', 'bool2']].corr()

```
       bool1  bool2
bool1      1     -1
bool2     -1      1
```

After the change:

print df.corr()

```
          bool1     bool2      int1
bool1  1.000000 -1.000000  0.866025
bool2 -1.000000  1.000000 -0.866025
int1   0.866025 -0.866025  1.000000
```

This also applies to quite a few other numeric operations on dataframes, which when the dataframe is mixed type defaults to using "is_numeric" to decide which ones to perform the operation on.

I'm not sure how deep the rabbit hole goes for this change and how much stuff it might affect, but all of the tests pass (after of course editing the one that specifically tested this functionality).  If there are other potential issues I'd be happy to look into them and make other related fixes.
