### PR TITLE
Index out of bounds error raised for negative indices.

### DIFF
--- a/pandas/src/util.pxd
+++ b/pandas/src/util.pxd
@@ -34,9 +34,9 @@ cdef inline object get_value_at(ndarray arr, object loc):
     i = <Py_ssize_t> loc
     sz = cnp.PyArray_SIZE(arr)
 
-    if i < 0 and sz > 0:
+    if i < 0 and -sz < i and sz > 0:
         i += sz
-    elif i >= sz or sz == 0:
+    elif i >= sz or i < -sz:
         raise IndexError('index out of bounds')
 
     return get_value_1d(arr, i)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -764,6 +764,9 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         s = Series([])
         self.assertRaises(IndexError, s.__getitem__, -1)
 
+        # GH #
+        self.assertRaises(IndexError, s.__getitem__, - len(self.ts) - 1)
+
     def test_getitem_setitem_integers(self):
         # caused bug without test
         s = Series([1, 2, 3], ['a', 'b', 'c'])


### PR DESCRIPTION
Accessing out of bounds negative timeseries indices silently return nonsense values.
