### PR TITLE
BUG: Fix the rename function for Series and DataFrame, #3165

### DIFF
--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -5,7 +5,7 @@ from numpy import nan
 import numpy as np
 
 from pandas.core.common import _possibly_downcast_to_dtype, isnull
-from pandas.core.index import Index, _ensure_index, _handle_legacy_indexes
+from pandas.core.index import Index, MultiIndex, _ensure_index, _handle_legacy_indexes
 from pandas.core.indexing import _check_slice_bounds, _maybe_convert_indices
 import pandas.core.common as com
 import pandas.lib as lib
@@ -1646,7 +1646,13 @@ class BlockManager(object):
         return True
 
     def rename_axis(self, mapper, axis=1):
-        new_axis = Index([mapper(x) for x in self.axes[axis]])
+
+        index = self.axes[axis]
+        if isinstance(index, MultiIndex):
+            new_axis = MultiIndex.from_tuples([tuple(mapper(y) for y in x) for x in index], names=index.names)
+        else:
+            new_axis = Index([mapper(x) for x in index], name=index.name)
+
         if not new_axis.is_unique:
             raise AssertionError('New axis must be unique to rename')
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3108,7 +3108,7 @@ class Series(pa.Array, generic.PandasObject):
         """
         mapper_f = _get_rename_function(mapper)
         result = self if inplace else self.copy()
-        result.index = [mapper_f(x) for x in self.index]
+        result.index = Index([mapper_f(x) for x in self.index], name=self.index.name)
 
         if inplace:
             import warnings

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -6742,6 +6742,20 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         renamed = self.frame.T.rename(index={'C': 'foo', 'D': 'bar'})
         self.assert_(np.array_equal(renamed.index, ['A', 'B', 'foo', 'bar']))
 
+        # index with name
+        index = Index(['foo', 'bar'], name='name')
+        renamer = DataFrame(data, index=index)
+        renamed = renamer.rename(index={'foo': 'bar', 'bar': 'foo'})
+        self.assert_(np.array_equal(renamed.index, ['bar', 'foo']))
+        self.assertEquals(renamed.index.name, renamer.index.name)
+
+        # MultiIndex
+        index = MultiIndex.from_tuples([('foo1', 'bar1'), ('foo2', 'bar2')], names=['foo', 'bar'])
+        renamer = DataFrame(data, index=index)
+        renamed = renamer.rename(index={'foo1': 'foo3', 'bar2': 'bar3'})
+        self.assert_(np.array_equal(renamed.index, MultiIndex.from_tuples([('foo3', 'bar1'), ('foo2', 'bar3')])))
+        self.assertEquals(renamed.index.names, renamer.index.names)
+
     def test_rename_nocopy(self):
         renamed = self.frame.rename(columns={'C': 'foo'}, copy=False)
         renamed['foo'] = 1.

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -3576,6 +3576,11 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         renamed = s.rename({'b': 'foo', 'd': 'bar'})
         self.assert_(np.array_equal(renamed.index, ['a', 'foo', 'c', 'bar']))
 
+        # index with name
+        renamer = Series(np.arange(4), index=Index(['a', 'b', 'c', 'd'], name='name'))
+        renamed = renamer.rename({})
+        self.assertEqual(renamed.index.name, renamer.index.name)
+
     def test_rename_inplace(self):
         renamer = lambda x: x.strftime('%Y%m%d')
         expected = renamer(self.ts.index[0])


### PR DESCRIPTION
### Bug 1: After `rename`, the `name` of the `index` is missing:

```
In [1]: import pandas as pd

In [2]: data = [1, 2]

In [3]: index = pd.Index(['a', 'b'], name='name')

In [4]: df = pd.DataFrame(data, index=index)

In [5]: df 
Out[5]: 
      0
name   
a     1
b     2

In [6]: df.rename({'a': 'c'})
Out[6]: 
   0
c  1
b  2
```

Both `Series` and `DataFrame` has the same problems. The reason is that we didn't set the `name` of the `index` while reconstructing the `DataFrame/Series` by `rename` .
### Bug 2: `rename` cannot work for the `MultiIndex` case, the `index` becomes tuples, the `names` of the index are gone

```
In [1]: import pandas as pd

In [2]: data = [1, 2]

In [3]: index = pd.MultiIndex.from_tuples([('a', 'b'), ('c', 'd')], names=['name1', 'name2'])

In [4]: df = pd.DataFrame(data, index=index)

In [5]: df
Out[5]: 
             0
name1 name2   
a     b      1
c     d      2

In [6]: df.rename({'a': 'e'}) 
Out[6]: 
        0
(a, b)  1
(c, d)  2
```

The missing name issue is same as Bug1. The original `rename` function convert the dict to the mapper function and map each tuple but not each index, and doesn't reconstruct it as `MultiIndex`, so it becomes a `Index` with some tuples.
### Fix

I've fixed the above two bugs, the `rename` will also pass the `name` of the `index` too, the `rename` mapper will go through each index for the `MultiIndex` case now.
I also added some test cases in `test_series.py` and `test_frame.py`
