### PR TITLE
ENH add time to DatetimeIndex

### DIFF
--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1266,6 +1266,13 @@ class DatetimeIndex(Int64Index):
     dayofyear = _field_accessor('dayofyear', 'doy')
     quarter = _field_accessor('quarter', 'q')
 
+    @property
+    def time(self):
+        """
+        Returns array of datetime.time. The time of the day
+        """
+        return self.map(lambda t: t.time())
+
     def normalize(self):
         """
         Return DatetimeIndex with times to midnight. Length is unaltered

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1778,6 +1778,12 @@ class TestDatetimeIndex(unittest.TestCase):
         i1.union(i2)  # Works
         i2.union(i1)  # Fails with "AttributeError: can't set attribute"
 
+    def test_time(self):
+        rng = pd.date_range('1/1/2000', freq='12min', periods=10)
+        result = pd.Index(rng).time
+        expected = [t.time() for t in rng]
+        self.assert_((result == expected).all())
+
 
 class TestLegacySupport(unittest.TestCase):
     _multiprocess_can_split_ = True


### PR DESCRIPTION
This adds a convenience property (`.time`) to DatetimeIndex, implementation is not very clever, but it means you can extract an array of time objects similar to `.hour` et al.

Thoughts?
