### PR TITLE
Raise more specific exceptions when parsing fails

### DIFF
--- a/pandas/src/parser.pyx
+++ b/pandas/src/parser.pyx
@@ -508,8 +508,8 @@ cdef class TextReader:
 
             if ptr == NULL:
                 if not os.path.exists(source):
-                    raise Exception('File %s does not exist' % source)
-                raise Exception('Initializing from file failed')
+                    raise IOError('File %s does not exist' % source)
+                raise IOError('Initializing from file failed')
 
             self.parser.source = ptr
 
@@ -518,15 +518,15 @@ cdef class TextReader:
 
             ptr = new_rd_source(source)
             if ptr == NULL:
-                raise Exception('Initializing parser from file-like '
-                                'object failed')
+                raise IOError('Initializing parser from file-like '
+                              'object failed')
 
             self.parser.source = ptr
             self.parser.cb_io = &buffer_rd_bytes
             self.parser.cb_cleanup = &del_rd_source
         else:
-            raise Exception('Expected file path name or file-like object,'
-                            ' got %s type' % type(source))
+            raise IOError('Expected file path name or file-like object,'
+                          ' got %s type' % type(source))
 
     cdef _get_header(self):
         cdef:


### PR DESCRIPTION
The pandas.io.parsers module raises a generic exception when a file cannot be
found or opened.  This is not consistent with other Python modules which
typically raise the more informative (and specific) IOError.  This change should
make the exception handling more consistent and more informative.
