### PR TITLE
BUG: Append the empty frame with columns, #3121

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1667,6 +1667,9 @@ def _concat_compat(to_concat, axis=0):
     # filter empty arrays
     to_concat = [x for x in to_concat if x.shape[axis] > 0]
 
+    # return the empty np array, if nothing to concatenate, #3121
+    if not to_concat: return np.array([], dtype=object)
+
     is_datetime64 = [x.dtype == _NS_DTYPE for x in to_concat]
     if all(is_datetime64):
         # work around NumPy 1.6 bug

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5183,54 +5183,6 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         result = df.between_time(bkey.start, bkey.stop)
         expected = df.ix[bkey]
         expected2 = df.ix[binds]
-
-        # Non-Empty df with columns append empty df
-
-    def test_asfreq(self):
-        offset_monthly = self.tsframe.asfreq(datetools.bmonthEnd)
-        rule_monthly = self.tsframe.asfreq('BM')
-
-        assert_almost_equal(offset_monthly['A'], rule_monthly['A'])
-
-        filled = rule_monthly.asfreq('B', method='pad')
-        # TODO: actually check that this worked.
-
-        # don't forget!
-        filled_dep = rule_monthly.asfreq('B', method='pad')
-
-        # test does not blow up on length-0 DataFrame
-        zero_length = self.tsframe.reindex([])
-        result = zero_length.asfreq('BM')
-        self.assert_(result is not zero_length)
-
-    def test_asfreq_datetimeindex(self):
-        df = DataFrame({'A': [1, 2, 3]},
-                       index=[datetime(2011, 11, 01), datetime(2011, 11, 2),
-                              datetime(2011, 11, 3)])
-        df = df.asfreq('B')
-        self.assert_(isinstance(df.index, DatetimeIndex))
-
-        ts = df['A'].asfreq('B')
-        self.assert_(isinstance(ts.index, DatetimeIndex))
-
-    def test_at_time_between_time_datetimeindex(self):
-        index = pan.date_range("2012-01-01", "2012-01-05", freq='30min')
-        df = DataFrame(randn(len(index), 5), index=index)
-        akey = time(12, 0, 0)
-        bkey = slice(time(13, 0, 0), time(14, 0, 0))
-        ainds = [24, 72, 120, 168]
-        binds = [26, 27, 28, 74, 75, 76, 122, 123, 124, 170, 171, 172]
-
-        result = df.at_time(akey)
-        expected = df.ix[akey]
-        expected2 = df.ix[ainds]
-        assert_frame_equal(result, expected)
-        assert_frame_equal(result, expected2)
-        self.assert_(len(result) == 4)
-
-        result = df.between_time(bkey.start, bkey.stop)
-        expected = df.ix[bkey]
-        expected2 = df.ix[binds]
         assert_frame_equal(result, expected)
         assert_frame_equal(result, expected2)
         self.assert_(len(result) == 12)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5108,6 +5108,84 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         expected = df.append(DataFrame(dicts), ignore_index=True)
         assert_frame_equal(result, expected)
 
+    def test_append_empty_dataframe(self):
+
+        # Empty df append empty df
+        df1 = DataFrame([])
+        df2 = DataFrame([])
+        result = df1.append(df2)
+        expected = df1.copy()
+        assert_frame_equal(result, expected)
+
+        # Non-empty df append empty df
+        df1 = DataFrame(np.random.randn(5, 2))
+        df2 = DataFrame()
+        result = df1.append(df2)
+        expected = df1.copy()
+        assert_frame_equal(result, expected)
+
+        # Empty df with columns append empty df
+        df1 = DataFrame(columns=['bar', 'foo'])
+        df2 = DataFrame()
+        result = df1.append(df2)
+        expected = df1.copy()
+        assert_frame_equal(result, expected)
+
+        # Non-Empty df with columns append empty df
+        df1 = DataFrame(np.random.randn(5, 2), columns=['bar', 'foo'])
+        df2 = DataFrame()
+        result = df1.append(df2)
+        expected = df1.copy()
+        assert_frame_equal(result, expected)
+
+    def test_asfreq(self):
+        offset_monthly = self.tsframe.asfreq(datetools.bmonthEnd)
+        rule_monthly = self.tsframe.asfreq('BM')
+
+        assert_almost_equal(offset_monthly['A'], rule_monthly['A'])
+
+        filled = rule_monthly.asfreq('B', method='pad')
+        # TODO: actually check that this worked.
+
+        # don't forget!
+        filled_dep = rule_monthly.asfreq('B', method='pad')
+
+        # test does not blow up on length-0 DataFrame
+        zero_length = self.tsframe.reindex([])
+        result = zero_length.asfreq('BM')
+        self.assert_(result is not zero_length)
+
+    def test_asfreq_datetimeindex(self):
+        df = DataFrame({'A': [1, 2, 3]},
+                       index=[datetime(2011, 11, 01), datetime(2011, 11, 2),
+                              datetime(2011, 11, 3)])
+        df = df.asfreq('B')
+        self.assert_(isinstance(df.index, DatetimeIndex))
+
+        ts = df['A'].asfreq('B')
+        self.assert_(isinstance(ts.index, DatetimeIndex))
+
+    def test_at_time_between_time_datetimeindex(self):
+        index = pan.date_range("2012-01-01", "2012-01-05", freq='30min')
+        df = DataFrame(randn(len(index), 5), index=index)
+        akey = time(12, 0, 0)
+        bkey = slice(time(13, 0, 0), time(14, 0, 0))
+        ainds = [24, 72, 120, 168]
+        binds = [26, 27, 28, 74, 75, 76, 122, 123, 124, 170, 171, 172]
+
+        result = df.at_time(akey)
+        expected = df.ix[akey]
+        expected2 = df.ix[ainds]
+        assert_frame_equal(result, expected)
+        assert_frame_equal(result, expected2)
+        self.assert_(len(result) == 4)
+
+        result = df.between_time(bkey.start, bkey.stop)
+        expected = df.ix[bkey]
+        expected2 = df.ix[binds]
+
+        # Non-Empty df with columns append empty df
+
     def test_asfreq(self):
         offset_monthly = self.tsframe.asfreq(datetools.bmonthEnd)
         rule_monthly = self.tsframe.asfreq('BM')


### PR DESCRIPTION
From [issue3121](https://github.com/pydata/pandas/issues/3121)
### Bug

```
In [1]: import pandas as pd

In [2]: df1 = pd.DataFrame(columns=['test'])

In [3]: df2 = pd.DataFrame()

In [4]: df1.append(df2)

ValueError: need at least one array to concatenate
```
### Reason

numpy cannot concatenate nothing:

```
In [10]: import numpy as np

In [11]: np.concatenate([])

ValueError: need at least one array to concatenate
```
### Fix

Return an empty numpy array if we find that the arrays to be concatenated are empty

```
# return the empty np array, if nothing to concatenate, #3121
    if not to_concat: return np.array([], dtype=object)
```
### Test

Test case `test_append_empty_frame` is added in `test_frame.py`
