### PR TITLE
TST fix broken tests (which were using fancy asserts, broke travis py2.6...

### DIFF
--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -2039,7 +2039,7 @@ class TestComparisons(unittest.TestCase):
         self.assertNotEqual(self.january1, self.february)
 
     def test_greater(self):
-        self.assertGreater(self.february, self.january1)
+        self.assert_(self.february > self.january1)
 
     def test_greater_Raises_Value(self):
         self.assertRaises(ValueError, self.january1.__gt__, self.day)
@@ -2048,7 +2048,7 @@ class TestComparisons(unittest.TestCase):
         self.assertRaises(TypeError, self.january1.__gt__, 1)
 
     def test_greaterEqual(self):
-        self.assertGreaterEqual(self.january1, self.january2)
+        self.assert_(self.january1 >= self.january2)
 
     def test_greaterEqual_Raises_Value(self):
         self.assertRaises(ValueError, self.january1.__ge__, self.day)
@@ -2057,7 +2057,7 @@ class TestComparisons(unittest.TestCase):
         self.assertRaises(TypeError, self.january1.__ge__, 1)
 
     def test_smallerEqual(self):
-        self.assertLessEqual(self.january1, self.january2)
+        self.assert_(self.january1 <= self.january2)
 
     def test_smallerEqual_Raises_Value(self):
         self.assertRaises(ValueError, self.january1.__le__, self.day)
@@ -2066,7 +2066,7 @@ class TestComparisons(unittest.TestCase):
         self.assertRaises(TypeError, self.january1.__le__, 1)
 
     def test_smaller(self):
-        self.assertLess(self.january1, self.february)
+        self.assert_(self.january1 < self.february)
 
     def test_smaller_Raises_Value(self):
         self.assertRaises(ValueError, self.january1.__lt__, self.day)
@@ -2077,7 +2077,7 @@ class TestComparisons(unittest.TestCase):
     def test_sort(self):
         periods = [self.march, self.january1, self.february]
         correctPeriods = [self.january1, self.february, self.march]
-        self.assertListEqual(sorted(periods), correctPeriods)
+        self.assertEqual(sorted(periods), correctPeriods)
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
... and py3)

Master is not passing travis.

For py2.6: cleared up assertGreater etc. which don't work in py2.6 :(.
For py3: one test is broken in py3 (not sure how to fix):

```
ERROR: test_period_constructor (pandas.tseries.tests.test_period.TestPeriodProperties)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.3_with_system_site_packages/lib/python3.3/site-packages/pandas-0.11.0.dev_4b61349-py3.3-linux-x86_64.egg/pandas/tseries/tests/test_period.py", line 102, in test_period_constructor
    self.assert_(i1 != i4)
  File "/home/travis/virtualenv/python3.3_with_system_site_packages/lib/python3.3/site-packages/pandas-0.11.0.dev_4b61349-py3.3-linux-x86_64.egg/pandas/tseries/period.py", line 132, in __eq__
    raise ValueError("Cannot compare non-conforming periods")
ValueError: Cannot compare non-conforming periods
```
