### PR TITLE
BUG: GH3216 Upcast when needed to DataFrame when setitem with indexer

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -122,6 +122,8 @@ pandas 0.11.0
   - Handle "ragged" CSV files missing trailing delimiters in rows with missing
     fields when also providing explicit list of column names (so the parser
     knows how many columns to expect in the result) (GH2981_)
+  - On a mixed DataFrame, allow setting with indexers with ndarray/DataFrame
+    on rhs (GH3216_)
 
 **API Changes**
 
@@ -249,9 +251,11 @@ pandas 0.11.0
   - Add comparison operators to Period object (GH2781_)
   - Fix bug when concatenating two Series into a DataFrame when they have the
     same name (GH2797_)
-  - fix automatic color cycling when plotting consecutive timeseries
+  - Fix automatic color cycling when plotting consecutive timeseries
     without color arguments (GH2816_)
   - fixed bug in the pickling of PeriodIndex (GH2891_)
+  - Upcast/split blocks when needed in a mixed DataFrame when setitem 
+    with an indexer (GH3216_)
 
 .. _GH622: https://github.com/pydata/pandas/issues/622
 .. _GH797: https://github.com/pydata/pandas/issues/797
@@ -340,6 +344,7 @@ pandas 0.11.0
 .. _GH2751: https://github.com/pydata/pandas/issues/2751
 .. _GH2747: https://github.com/pydata/pandas/issues/2747
 .. _GH2816: https://github.com/pydata/pandas/issues/2816
+.. _GH3216: https://github.com/pydata/pandas/issues/2816
 
 pandas 0.10.1
 =============

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2065,7 +2065,7 @@ class Series(pa.Array, generic.PandasObject):
         """
         other = other.reindex_like(self)
         mask = notnull(other)
-        np.putmask(self.values, mask, other.values)
+        com._maybe_upcast_putmask(self.values,mask,other,change=self.values)
 
     #----------------------------------------------------------------------
     # Reindexing, sorting

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -724,6 +724,18 @@ class TestIndexing(unittest.TestCase):
         expected = df.iloc[:,0:2].loc[:,'a']
         assert_frame_equal(result,expected)
 
+    def test_setitem_dtype_upcast(self):
+ 
+        # GH3216
+        df = DataFrame([{"a": 1}, {"a": 3, "b": 2}])
+        df['c'] = np.nan
+        self.assert_(df['c'].dtype == np.float64)
+
+        df.ix[0,'c'] = 'foo'
+        expected = DataFrame([{"a": 1, "c" : 'foo'}, {"a": 3, "b": 2, "c" : np.nan}])
+        assert_frame_equal(df,expected)
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -2314,6 +2314,13 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         expected = Series([1.5, 3.5, 3., 5., np.nan])
         assert_series_equal(s, expected)
 
+        # GH 3217
+        df = DataFrame([{"a": 1}, {"a": 3, "b": 2}])
+        df['c'] = np.nan
+
+        # this will fail as long as series is a sub-class of ndarray
+        ##### df['c'].update(Series(['foo'],index=[0])) #####
+
     def test_corr(self):
         _skip_if_no_scipy()
 


### PR DESCRIPTION
closes #3216

BUG: GH3216 Upcast when needed to DataFrame when setitem with indexer

The following would raise previously

```
In [8]: df = pd.DataFrame([{"a": 1}, {"a": 3, "b": 2}])
In [9]: df['c'] = np.nan
In [10]: df.ix[0,'c'] = 'foo'

In [11]: df
Out[11]: 
   a   b    c
0  1 NaN  foo
1  3   2  NaN

In [12]: df.dtypes
Out[12]: 
a      int64
b    float64
c     object
dtype: object
```

ENH: On a mixed DataFrame, allow setting with indexers with 
          ndarray/DataFrame on rhs (this was disallowed in the code previously)

```
In [8]: df = DataFrame([[1,2,'foo'],[3,4,'bar']],columns=['A','B','C'])
In [9]: df2 = df.copy()
In [10]: df2.ix[:,['A','B']] = df.ix[:,['A','B']]+0.5
In [11]: df2
Out[11]: 
     A    B    C
0  1.5  2.5  foo
1  3.5  4.5  bar

In [12]: df2.dtypes
Out[12]: 
A    float64
B    float64
C     object
dtype: object

In [13]: df.dtypes
Out[13]: 
A     int64
B     int64
C    object
dtype: object
```
