### PR TITLE
BUG/ENH Index sub names

### DIFF
--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -715,13 +715,16 @@ class Index(np.ndarray):
             raise Exception('Input must be iterable!')
 
         if self.equals(other):
-            return Index([])
+            return Index([], name=self.name)
 
         if not isinstance(other, Index):
             other = np.asarray(other)
+            result_name = self.name
+        else:
+            result_name = self.name if self.name == other.name else None
 
         theDiff = sorted(set(self) - set(other))
-        return Index(theDiff)
+        return Index(theDiff, name=result_name)
 
     def unique(self):
         """
@@ -2508,7 +2511,16 @@ class MultiIndex(Index):
         """
         self._assert_can_do_setop(other)
 
-        result_names = self.names if self.names == other.names else None
+        if not isinstance(other, MultiIndex):
+            if len(other) == 0:
+                return self
+            try:
+                other = MultiIndex.from_tuples(other)
+            except:
+                raise TypeError("other should be a MultiIndex or a list of tuples")
+            result_names = self.names
+        else:
+            result_names = self.names if self.names == other.names else None
 
         if self.equals(other):
             return MultiIndex(levels=[[]] * self.nlevels,

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -17,7 +17,7 @@ import pandas.core.common as com
 import pandas.algos as algos
 
 
-from pandas.core.index import MultiIndex
+from pandas.core.index import MultiIndex, Index
 
 
 class ReshapeError(Exception):
@@ -506,12 +506,14 @@ def _stack_multi_columns(frame, level=-1, dropna=True):
     new_data = {}
     level_vals = this.columns.levels[-1]
     levsize = len(level_vals)
+    drop_cols = []
     for key in unique_groups:
         loc = this.columns.get_loc(key)
         slice_len = loc.stop - loc.start
         # can make more efficient?
 
         if slice_len == 0:
+            drop_cols.append(key)
             continue
         elif slice_len != levsize:
             chunk = this.ix[:, this.columns[loc]]
@@ -524,6 +526,9 @@ def _stack_multi_columns(frame, level=-1, dropna=True):
                 value_slice = this.values[:, loc]
 
         new_data[key] = value_slice.ravel()
+
+    if len(drop_cols) > 0:
+        new_columns = new_columns - drop_cols
 
     N = len(this)
 

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -159,7 +159,7 @@ class _Unstacker(object):
             dtype, fill_value = _maybe_promote(values.dtype)
             new_values = np.empty(result_shape, dtype=dtype)
             new_values.fill(fill_value)
- 
+
         new_mask = np.zeros(result_shape, dtype=bool)
 
         # is there a simpler / faster way of doing this?
@@ -508,9 +508,12 @@ def _stack_multi_columns(frame, level=-1, dropna=True):
     levsize = len(level_vals)
     for key in unique_groups:
         loc = this.columns.get_loc(key)
-
+        slice_len = loc.stop - loc.start
         # can make more efficient?
-        if loc.stop - loc.start != levsize:
+
+        if slice_len == 0:
+            continue
+        elif slice_len != levsize:
             chunk = this.ix[:, this.columns[loc]]
             chunk.columns = level_vals.take(chunk.columns.labels[-1])
             value_slice = chunk.reindex(columns=level_vals).values

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -299,12 +299,27 @@ class TestIndex(unittest.TestCase):
         first = self.strIndex[5:20]
         second = self.strIndex[:10]
         answer = self.strIndex[10:20]
+        first.name = 'name'
+        # different names
         result = first - second
 
         self.assert_(tm.equalContents(result, answer))
+        self.assertEqual(result.name, None)
 
-        diff = first.diff(first)
-        self.assert_(len(diff) == 0)
+        # same names
+        second.name = 'name'
+        result = first - second
+        self.assertEqual(result.name, 'name')
+
+        # with empty
+        result = first.diff([])
+        self.assert_(tm.equalContents(result, first))
+        self.assertEqual(result.name, first.name)
+
+        # with everythin
+        result = first.diff(first)
+        self.assert_(len(result) == 0)
+        self.assertEqual(result.name, first.name)
 
         # non-iterable input
         self.assertRaises(Exception, first.diff, 0.5)
@@ -1510,6 +1525,18 @@ class TestMultiIndex(unittest.TestCase):
         # raise Exception called with non-MultiIndex
         result = first.diff(first._tuple_index)
         self.assertTrue(result.equals(first[:0]))
+
+        # name from empty array
+        result = first.diff([])
+        self.assert_(first.equals(result))
+        self.assertEqual(first.names, result.names)
+
+        # name from non-empty array 
+        result = first.diff([('foo', 'one')])
+        expected = pd.MultiIndex.from_tuples([('bar', 'one'), ('baz', 'two'), ('foo', 'two'),
+                                              ('qux', 'one'), ('qux', 'two')])
+        expected.names = first.names
+        self.assertEqual(first.names, result.names)
 
     def test_from_tuples(self):
         self.assertRaises(Exception, MultiIndex.from_tuples, [])

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -939,11 +939,13 @@ Thur,Lunch,Yes,51.51,17"""
         df = DataFrame(dict(ID=id_col, NAME=name, DATE=date, VAR1=var1))
 
         multi = df.set_index(['DATE', 'ID'])
+        multi.columns.name = 'Params'
         unst = multi.unstack('ID')
         down = unst.resample('W-THU')
 
         rs = down.stack('ID')
         xp = unst.ix[:, ['VAR1']].resample('W-THU').stack('ID')
+        xp.columns.name = 'Params'
         assert_frame_equal(rs, xp)
 
     def test_unstack_multiple_hierarchical(self):

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -942,8 +942,9 @@ Thur,Lunch,Yes,51.51,17"""
         unst = multi.unstack('ID')
         down = unst.resample('W-THU')
 
-        rs = down.stack('ID') # It works!
-
+        rs = down.stack('ID')
+        xp = unst.ix[:, ['VAR1']].resample('W-THU').stack('ID')
+        assert_frame_equal(rs, xp)
 
     def test_unstack_multiple_hierarchical(self):
         df = DataFrame(index=[[0, 0, 0, 0, 1, 1, 1, 1],

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -930,6 +930,21 @@ Thur,Lunch,Yes,51.51,17"""
         expected = self.ymd.unstack(2).unstack(1).dropna(axis=1, how='all')
         assert_frame_equal(unstacked, expected.ix[:, unstacked.columns])
 
+    def test_stack_multiple_bug(self):
+        """ bug when some uniques are not present in the data #3170"""
+        id_col = ([1] * 3) + ([2] * 3)
+        name = (['a'] * 3) + (['b'] * 3)
+        date = pd.to_datetime(['2013-01-03', '2013-01-04', '2013-01-05'] * 2)
+        var1 = np.random.randint(0, 100, 6)
+        df = DataFrame(dict(ID=id_col, NAME=name, DATE=date, VAR1=var1))
+
+        multi = df.set_index(['DATE', 'ID'])
+        unst = multi.unstack('ID')
+        down = unst.resample('W-THU')
+
+        rs = down.stack('ID') # It works!
+
+
     def test_unstack_multiple_hierarchical(self):
         df = DataFrame(index=[[0, 0, 0, 0, 1, 1, 1, 1],
                               [0, 0, 1, 1, 0, 0, 1, 1],


### PR DESCRIPTION
Extends #3218 slightly to fix #3170.

Subtract list of tuples from MultiIndexs (without it dropping the names), and also no name dropping with subtracting arrays from Indexs.
