### PR TITLE
BUG: GH3235 fix setitem on Series with boolean indexing and rhs of list

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -239,6 +239,7 @@ pandas 0.11.0
   - Fix implemented ``.xs`` when called with ``axes=1`` and a level parameter (GH2903_)
   - Timestamp now supports the class method fromordinal similar to datetimes (GH3042_)
   - Fix issue with indexing a series with a boolean key and specifiying a 1-len list on the rhs (GH2745_)
+    or a list on the rhs (GH3235_)
   - Fixed bug in groupby apply when kernel generate list of arrays having unequal len (GH1738_)
   - fixed handling of rolling_corr with center=True which could produce corr>1 (GH3155_)
   - Fixed issues where indices can be passed as 'index/column' in addition to 0/1 for the axis parameter

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -736,12 +736,24 @@ class Series(pa.Array, generic.PandasObject):
             other = other.reindex(ser.index)
         elif isinstance(other, (tuple,list)):
             other = np.array(other)
+
         if len(other) != len(ser):
+            icond = ~cond
 
             # GH 2745
             # treat like a scalar
             if len(other) == 1:
                 other = np.array(other[0]*len(ser))
+
+            # GH 3235 
+            # match True cond to other
+            elif len(icond[icond]) == len(other):
+                dtype, fill_value = _maybe_promote(other.dtype)
+                new_other = np.empty(len(cond),dtype=dtype)
+                new_other.fill(fill_value)
+                new_other[icond] = other
+                other = new_other
+
             else:
                 raise ValueError('Length of replacements must equal series length')
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1092,7 +1092,6 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
 
         self.assertRaises(ValueError, s.where, 1)
         self.assertRaises(ValueError, s.where, cond[:3].values, -s)
-        self.assertRaises(ValueError, s.where, cond, s[:3].values)
 
         # GH 2745
         s = Series([1,2])
@@ -1108,6 +1107,23 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         # failures
         self.assertRaises(ValueError, s.__setitem__, tuple([[[True, False]]]), [0,2,3])
         self.assertRaises(ValueError, s.__setitem__, tuple([[[True, False]]]), [])
+
+        # GH3235
+        s = Series(np.arange(10))
+        mask = s < 5
+        s[mask] = range(5)
+        expected = Series(np.arange(10),dtype='float64')
+        assert_series_equal(s,expected)
+
+        s = Series(np.arange(10))
+        mask = s > 5
+        s[mask] = [0]*4
+        expected = Series([0,1,2,3,4,5] + [0]*4,dtype='float64')
+        assert_series_equal(s,expected)
+
+        s = Series(np.arange(10))
+        mask = s > 5
+        self.assertRaises(ValueError, s.__setitem__, mask, ([0]*5,))
 
     def test_where_inplace(self):
         s = Series(np.random.randn(5))


### PR DESCRIPTION
closes #3235, related to #2745
