### PR TITLE
BUG: setitem with list elements in the indexer broken

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -215,9 +215,9 @@ class _NDFrameIndexer(object):
                 ax = self.obj.axes[i]
                 if com._is_sequence(ix) or isinstance(ix, slice):
                     if idx is None:
-                        idx = ax[ix]
+                        idx = ax[ix].ravel()
                     elif cols is None:
-                        cols = ax[ix]
+                        cols = ax[ix].ravel()
                     else:
                         break
 

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -735,6 +735,17 @@ class TestIndexing(unittest.TestCase):
         expected = DataFrame([{"a": 1, "c" : 'foo'}, {"a": 3, "b": 2, "c" : np.nan}])
         assert_frame_equal(df,expected)
 
+    def test_setitem_iloc(self):
+
+        
+        # setitem with an iloc list
+        df = DataFrame(np.arange(9).reshape((3, 3)), index=["A", "B", "C"], columns=["A", "B", "C"])
+        df.iloc[[0,1],[1,2]]
+        df.iloc[[0,1],[1,2]] += 100
+
+        expected = DataFrame(np.array([0,101,102,3,104,105,6,7,8]).reshape((3, 3)), index=["A", "B", "C"], columns=["A", "B", "C"])
+        assert_frame_equal(df,expected)
+
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
```
In [4]: df = DataFrame(np.arange(9).reshape((3, 3)),
                  index=["A", "B", "C"], columns=["A", "B", "C"])

In [5]: df.iloc[[0,1],[1,2]] += 100

In [6]: df.iloc[[0,1],[1,2]]
Out[6]: 
     B    C
A  101  102
B  104  105

In [7]: df
Out[7]: 
   A    B    C
A  0  101  102
B  3  104  105
C  6    7    8
```
