### PR TITLE
ENH: Allow read_frame to use parameterized queries

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -22,6 +22,15 @@ def execute(sql, con, retry=True, cur=None, params=None):
     ----------
     sql: string
         Query to be executed
+    con: database connection instance
+        Database connection.  Must implement PEP249 (Database API v2.0).
+    retry: bool
+        Not currently implemented
+    cur: database cursor, optional
+        Must implement PEP249 (Datbase API v2.0).  If cursor is not provided,
+        one will be obtained from the database connection.
+    params: list or tuple, optional
+        List of parameters to pass to execute method.
 
     Returns
     -------
@@ -102,7 +111,7 @@ def tquery(sql, con=None, cur=None, retry=True):
     return result
 
 
-def uquery(sql, con=None, cur=None, retry=True, params=()):
+def uquery(sql, con=None, cur=None, retry=True, params=None):
     """
     Does the same thing as tquery, but instead of returning results, it
     returns the number of rows affected.  Good for update queries.
@@ -124,7 +133,7 @@ def uquery(sql, con=None, cur=None, retry=True, params=()):
     return result
 
 
-def read_frame(sql, con, index_col=None, coerce_float=True):
+def read_frame(sql, con, index_col=None, coerce_float=True, params=None):
     """
     Returns a DataFrame corresponding to the result set of the query
     string.
@@ -139,8 +148,10 @@ def read_frame(sql, con, index_col=None, coerce_float=True):
     con: DB connection object, optional
     index_col: string, optional
         column name to use for the returned DataFrame object.
+    params: list or tuple, optional
+        List of parameters to pass to execute method.
     """
-    cur = execute(sql, con)
+    cur = execute(sql, con, params=params)
     rows = _safe_fetch(cur)
     columns = [col_desc[0] for col_desc in cur.description]
 


### PR DESCRIPTION
Added params argument to read_frame that is passed directly to the
execute method.  This allows users to use a parameterized query
rather than having to pre-format the SQL themselves.
