### PR TITLE
BUG: suppress error raise by nonnumeric columns when plotting DataFrame ...

### DIFF
--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -235,6 +235,14 @@ class TestDataFramePlots(unittest.TestCase):
         _check_plot_works(df.plot, title=u'\u03A3')
 
     @slow
+    def test_nonnumeric_exclude(self):
+        import matplotlib.pyplot as plt
+        plt.close('all')
+
+        ax = DataFrame({'A': ["x", "y", "z"], 'B': [1,2,3]}).plot() # it works
+        self.assert_(len(ax.get_lines()) == 1) #B was plotted
+
+    @slow
     def test_label(self):
         import matplotlib.pyplot as plt
         plt.close('all')

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -239,8 +239,11 @@ class TestDataFramePlots(unittest.TestCase):
         import matplotlib.pyplot as plt
         plt.close('all')
 
-        ax = DataFrame({'A': ["x", "y", "z"], 'B': [1,2,3]}).plot() # it works
+        df = DataFrame({'A': ["x", "y", "z"], 'B': [1,2,3]})
+        ax = df.plot(raise_on_error=False) # it works
         self.assert_(len(ax.get_lines()) == 1) #B was plotted
+
+        self.assertRaises(Exception, df.plot)
 
     @slow
     def test_label(self):

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -691,8 +691,10 @@ class MPLPlot(object):
     """
     _default_rot = 0
 
-    _pop_attributes = ['label', 'style', 'logy', 'logx', 'loglog']
-    _attr_defaults = {'logy': False, 'logx': False, 'loglog': False}
+    _pop_attributes = ['label', 'style', 'logy', 'logx', 'loglog',
+                       'raise_on_error']
+    _attr_defaults = {'logy': False, 'logx': False, 'loglog': False,
+                      'raise_on_error': True}
 
     def __init__(self, data, kind=None, by=None, subplots=False, sharex=True,
                  sharey=False, use_index=True,
@@ -1185,7 +1187,12 @@ class LinePlot(MPLPlot):
                 except AttributeError as inst: # non-numeric
                     msg = ('Unable to plot data %s vs index %s,\n'
                            'error was: %s' % (str(y), str(x), str(inst)))
-                    print msg
+                    if not self.raise_on_error:
+                        print msg
+                    else:
+                        msg = msg + ('\nConsider setting raise_on_error=False'
+                                     'to suppress')
+                        raise Exception(msg)
 
             self._make_legend(lines, labels)
 
@@ -1214,7 +1221,12 @@ class LinePlot(MPLPlot):
             except AttributeError as inst: #non-numeric
                 msg = ('Unable to plot %s,\n'
                        'error was: %s' % (str(data), str(inst)))
-                print msg
+                if not self.raise_on_error:
+                    print msg
+                else:
+                    msg = msg + ('\nConsider setting raise_on_error=False'
+                                 'to suppress')
+                    raise Exception(msg)
 
         if isinstance(data, Series):
             ax = self._get_ax(0)  # self.axes[0]

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1170,17 +1170,22 @@ class LinePlot(MPLPlot):
                 else:
                     args = (ax, x, y, style)
 
-                newline = plotf(*args, **kwds)[0]
-                lines.append(newline)
-                leg_label = label
-                if self.mark_right and self.on_right(i):
-                    leg_label += ' (right)'
-                labels.append(leg_label)
-                ax.grid(self.grid)
+                try:
+                    newline = plotf(*args, **kwds)[0]
+                    lines.append(newline)
+                    leg_label = label
+                    if self.mark_right and self.on_right(i):
+                        leg_label += ' (right)'
+                    labels.append(leg_label)
+                    ax.grid(self.grid)
 
-                if self._is_datetype():
-                    left, right = _get_xlim(lines)
-                    ax.set_xlim(left, right)
+                    if self._is_datetype():
+                        left, right = _get_xlim(lines)
+                        ax.set_xlim(left, right)
+                except AttributeError as inst: # non-numeric
+                    msg = ('Unable to plot data %s vs index %s,\n'
+                           'error was: %s' % (str(y), str(x), str(inst)))
+                    print msg
 
             self._make_legend(lines, labels)
 
@@ -1198,6 +1203,19 @@ class LinePlot(MPLPlot):
                 return label + ' (right)'
             return label
 
+        def _plot(data, col_num, ax, label, style, **kwds):
+            try:
+                newlines = tsplot(data, plotf, ax=ax, label=label,
+                                  style=style, **kwds)
+                ax.grid(self.grid)
+                lines.append(newlines[0])
+                leg_label = to_leg_label(label, col_num)
+                labels.append(leg_label)
+            except AttributeError as inst: #non-numeric
+                msg = ('Unable to plot %s,\n'
+                       'error was: %s' % (str(data), str(inst)))
+                print msg
+
         if isinstance(data, Series):
             ax = self._get_ax(0)  # self.axes[0]
             style = self.style or ''
@@ -1205,12 +1223,7 @@ class LinePlot(MPLPlot):
             kwds = kwargs.copy()
             self._maybe_add_color(colors, kwds, style, 0)
 
-            newlines = tsplot(data, plotf, ax=ax, label=label,
-                              style=self.style, **kwds)
-            ax.grid(self.grid)
-            lines.append(newlines[0])
-            leg_label = to_leg_label(label, 0)
-            labels.append(leg_label)
+            _plot(data, 0, ax, label, self.style, **kwds)
         else:
             for i, col in enumerate(data.columns):
                 label = com.pprint_thing(col)
@@ -1220,13 +1233,7 @@ class LinePlot(MPLPlot):
 
                 self._maybe_add_color(colors, kwds, style, i)
 
-                newlines = tsplot(data[col], plotf, ax=ax, label=label,
-                                  style=style, **kwds)
-
-                lines.append(newlines[0])
-                leg_label = to_leg_label(label, i)
-                labels.append(leg_label)
-                ax.grid(self.grid)
+                _plot(data[col], i, ax, label, style, **kwds)
 
         self._make_legend(lines, labels)
 

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -81,6 +81,20 @@ class TestTSPlot(unittest.TestCase):
         df.plot()
 
     @slow
+    def test_nonnumeric_exclude(self):
+        import matplotlib.pyplot as plt
+        plt.close('all')
+
+        idx = date_range('1/1/1987', freq='A', periods=3)
+        df = DataFrame({'A': ["x", "y", "z"], 'B': [1,2,3]}, idx)
+        ax = df.plot() # it works
+        self.assert_(len(ax.get_lines()) == 1) #B was plotted
+
+        plt.close('all')
+        ax = df['A'].plot() # it works
+        self.assert_(len(ax.get_lines()) == 0)
+
+    @slow
     def test_tsplot(self):
         from pandas.tseries.plotting import tsplot
         import matplotlib.pyplot as plt

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -87,11 +87,17 @@ class TestTSPlot(unittest.TestCase):
 
         idx = date_range('1/1/1987', freq='A', periods=3)
         df = DataFrame({'A': ["x", "y", "z"], 'B': [1,2,3]}, idx)
-        ax = df.plot() # it works
+        self.assertRaises(Exception, df.plot)
+
+        plt.close('all')
+        ax = df.plot(raise_on_error=False) # it works
         self.assert_(len(ax.get_lines()) == 1) #B was plotted
 
         plt.close('all')
-        ax = df['A'].plot() # it works
+        self.assertRaises(Exception, df.A.plot)
+
+        plt.close('all')
+        ax = df['A'].plot(raise_on_error=False) # it works
         self.assert_(len(ax.get_lines()) == 0)
 
     @slow


### PR DESCRIPTION
...#3108

suppressing AttributeError here so you can plot the DataFrame and automatically exclude non-numeric columns. @y-p @wesm @jreback any thoughts on 1) whether it should raise instead of exclude and 2) whether catching the AttributeError here is too dangerously broad?
