### PR TITLE
BUG: test case showing why assigning to dtype is unsafe

### DIFF
--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1127,12 +1127,21 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         self.assertRaises(ValueError, s.__setitem__, tuple([[[True, False]]]), [0,2,3])
         self.assertRaises(ValueError, s.__setitem__, tuple([[[True, False]]]), [])
 
+
+        s = Series(np.arange(10), dtype=np.int32)
+        mask = s < 5
+        s[mask] = range(5)
+        expected = Series(np.arange(10), dtype=np.int32)
+        assert_series_equal(s, expected)
+        self.assertEquals(s.dtype, expected.dtype)
+
         # GH3235
         s = Series(np.arange(10))
         mask = s < 5
         s[mask] = range(5)
-        expected = Series(np.arange(10),dtype='float64')
-        assert_series_equal(s,expected)
+        expected = Series(np.arange(10))
+        assert_series_equal(s, expected)
+        self.assertEquals(s.dtype, expected.dtype)
 
         s = Series(np.arange(10))
         mask = s > 5


### PR DESCRIPTION
@jreback this is a test case that shows why assigning to `dtype` is unsafe, namely that the dtype item sizes have to be compatible obviously =P Could you take a look at this and fix? This came up when I booted the windows box back up because Windows uses int32 by default.

There is a secondary bug here that the test case in question probably _should not_ cause the dtype of the resulting Series to change from int64 to float64, agreed?
