### PR TITLE
BUG: fix unsafe dtype conversion in Series

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -739,7 +739,13 @@ class Series(pa.Array, generic.PandasObject):
         if isinstance(other, Series):
             other = other.reindex(ser.index)
         elif isinstance(other, (tuple,list)):
-            other = np.array(other)
+
+            # try to set the same dtype as ourselves
+            new_other = np.array(other,dtype=self.dtype)
+            if not (new_other == np.array(other)).all():
+                other = np.array(other)
+            else:
+                other = new_other
 
         if len(other) != len(ser):
             icond = ~cond

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1127,12 +1127,21 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         self.assertRaises(ValueError, s.__setitem__, tuple([[[True, False]]]), [0,2,3])
         self.assertRaises(ValueError, s.__setitem__, tuple([[[True, False]]]), [])
 
+
+        s = Series(np.arange(10), dtype=np.int32)
+        mask = s < 5
+        s[mask] = range(5)
+        expected = Series(np.arange(10), dtype=np.int32)
+        assert_series_equal(s, expected)
+        self.assertEquals(s.dtype, expected.dtype)
+
         # GH3235
         s = Series(np.arange(10))
         mask = s < 5
         s[mask] = range(5)
-        expected = Series(np.arange(10),dtype='float64')
-        assert_series_equal(s,expected)
+        expected = Series(np.arange(10))
+        assert_series_equal(s, expected)
+        self.assertEquals(s.dtype, expected.dtype)
 
         s = Series(np.arange(10))
         mask = s > 5


### PR DESCRIPTION
fixes assignment to smaller itemsizes on dtype upcasting
