### PR TITLE
BUG: DataFrame.hist passes keyword arguments to mpl.hist; closes #3296

### DIFF
--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -645,9 +645,9 @@ def autocorrelation_plot(series, ax=None):
     return ax
 
 
-def grouped_hist(data, column=None, by=None, ax=None, bins=50, log=False,
+def grouped_hist(data, column=None, by=None, ax=None, bins=50,
                  figsize=None, layout=None, sharex=False, sharey=False,
-                 rot=90, **kwargs):
+                 rot=90, grid=True, **kwargs):
     """
     Grouped histogram
 
@@ -658,19 +658,20 @@ def grouped_hist(data, column=None, by=None, ax=None, bins=50, log=False,
     by: object, optional
     ax: axes, optional
     bins: int, default 50
-    log: boolean, default False
     figsize: tuple, optional
     layout: optional
     sharex: boolean, default False
     sharey: boolean, default False
     rot: int, default 90
+    grid: bool, default True
+    kwargs: dict, keyword arguments passed to matplotlib.Axes.hist
 
     Returns
     -------
     axes: collection of Matplotlib Axes
     """
     def plot_group(group, ax):
-        ax.hist(group.dropna().values, bins=bins)
+        ax.hist(group.dropna().values, bins=bins, **kwargs)
 
     fig, axes = _grouped_plot(plot_group, data, column=column,
                               by=by, sharex=sharex, sharey=sharey,


### PR DESCRIPTION
This is a fix for https://github.com/pydata/pandas/issues/3296 .

Now keyword arguments to `plotting.grouped_hist` are passed to `matplotlib.Axes.hist`. This allows you to create e.g. normalized, cumulative, or log scaled histograms::

```
df = pd.DataFrame(np.random.randn(500, 2), columns=['A', 'B'])
df['C'] = np.random.randint(0, 4, 500)
df.hist(column=['A'], by=df.C, normed=True)
```

PS: the guideline says I should enable Travis-CI on my fork - is there a tutorial how to do that? thx!
