### PR TITLE
DOC add dayfirst to to_datetime

### DIFF
--- a/pandas/tseries/tools.py
+++ b/pandas/tseries/tools.py
@@ -58,9 +58,15 @@ def to_datetime(arg, errors='ignore', dayfirst=False, utc=None, box=True,
     arg : string, datetime, array of strings (with possible NAs)
     errors : {'ignore', 'raise'}, default 'ignore'
         Errors are ignored by default (values left untouched)
+    dayfirst : boolean, default False
+        If True parses dates with the day first, eg 20/01/2005
     utc : boolean, default None
         Return UTC DatetimeIndex if True (converting any tz-aware
         datetime.datetime objects as well)
+    box : boolean, default True
+        If True returns a DatetimeIndex, if False returns ndarray of values
+    format : string, default None
+        strftime to parse time, eg "%d/%m/%Y"
 
     Returns
     -------


### PR DESCRIPTION
At the moment only some of the arguments are shown in the docstring for to_datetime, which can [lead to unnecessary confusion](http://stackoverflow.com/questions/15929861/pandas-to-datetime-inconsistent-time-string-format/15937890#15937890). This adds all of them to the docstring.

~~Also a cheeky enhancement to use print configs default to set date (copied from `parse_time_string`), not sure how to test that one.... tbh **I think it would make sense to default dayfirst to None**, the current behaviour can be strange (as seen in the above question).~~

Thoughts?
