### PR TITLE
BUG: ensure index casting works even in Int64Index

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -293,6 +293,7 @@ pandas 0.11.0
   - fixed pretty priniting of sets (GH3294_)
   - Panel() and Panel.from_dict() now respects ordering when give OrderedDict (GH3303_)
   - DataFrame where with a datetimelike incorrectly selecting (GH3311_)
+  - Ensure index casts work even in Int64Index
 
 .. _GH3294: https://github.com/pydata/pandas/issues/3294
 .. _GH622: https://github.com/pydata/pandas/issues/622

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1332,6 +1332,11 @@ class Int64Index(Index):
     def _constructor(self):
         return Int64Index
 
+    @cache_readonly
+    def _engine(self):
+        # property, for now, slow to look up
+        return self._engine_type(lambda: com._ensure_int64(self.values), len(self))
+
     @property
     def asi8(self):
         # do not cache or you'll create a memory leak

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1836,6 +1836,17 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self.assertRaises(Exception, setattr, self.mixed_frame, 'index',
                           idx[::2])
 
+    def test_set_index_cast(self):
+
+        # issue casting an index then set_index
+        df = DataFrame({'A' : [1.1,2.2,3.3], 'B' : [5.0,6.1,7.2]},
+                       index = [2010,2011,2012])
+        expected = df.ix[2010]
+        new_index = df.index.astype(np.int32)
+        df.index = new_index
+        result = df.ix[2010]
+        assert_series_equal(result,expected)
+
     def test_set_index2(self):
         df = DataFrame({'A': ['foo', 'foo', 'foo', 'bar', 'bar'],
                         'B': ['one', 'two', 'three', 'one', 'two'],


### PR DESCRIPTION
```
df = DataFrame({'A' : [1.1,2.2,3.3], 'B' : [5.0,6.1,7.2]}, index = [2010, 2011, 2012])
df.index = df.index.astype(int)
df.ix[2010]
```

was failing - fixed up

from the mailing list
https://groups.google.com/forum/?fromgroups#!topic/pydata/ClJA5ldNQNQ
