### PR TITLE
PERF/CLN: infer Period in infer_dtype, later index inference is faster

### DIFF
--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -127,8 +127,8 @@ class Index(np.ndarray):
                     from pandas.tseries.index import DatetimeIndex
                     return DatetimeIndex(subarr, copy=copy, name=name)
 
-            if lib.is_period_array(subarr):
-                return PeriodIndex(subarr, name=name)
+                elif inferred == 'period':
+                    return PeriodIndex(subarr, name=name)
 
         subarr = subarr.view(cls)
         subarr.name = name

--- a/pandas/src/inference.pyx
+++ b/pandas/src/inference.pyx
@@ -97,6 +97,10 @@ def infer_dtype(object _values):
         if is_timedelta_or_timedelta64_array(values):
             return 'timedelta'
 
+    elif is_period(val):
+        if is_period_array(values):
+            return 'period'
+
     for i in range(n):
         val = util.get_value_1d(values, i)
         if util.is_integer_object(val):
@@ -320,6 +324,10 @@ def is_time_array(ndarray[object] values):
         if not is_time(values[i]):
             return False
     return True
+
+def is_period(object o):
+    from pandas import Period
+    return isinstance(o,Period)
 
 def is_period_array(ndarray[object] values):
     cdef int i, n = len(values)


### PR DESCRIPTION
This was meant to fix the vbench: ctor_index_array_string

see #3326

not sure if this is that stable of a perf fix

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
frame_get_dtype_counts                       |   0.0960 |   0.1700 |   0.5647 |
frame_insert_500_columns                     |  87.8456 | 142.5257 |   0.6163 |
frame_iteritems_cached                       |   0.0820 |   0.1043 |   0.7860 |
stat_ops_level_frame_sum                     |   2.5051 |   2.8849 |   0.8683 |
ctor_index_array_string                      |   0.0333 |   0.0383 |   0.8693 |
stat_ops_level_series_sum_multiple           |   5.6090 |   6.4037 |   0.8759 |
frame_fancy_lookup                           |   2.7517 |   3.1263 |   0.8802 |

Target [f3b19d6] : PERF/CLN: infer Period in infer_dtype, later index inference is faster
Base   [df2c21c] : Merge pull request #3327 from jreback/index_perf

```
