### PR TITLE
PERF: fixed int64 indexing perf issue when conversion to int64

### DIFF
--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1332,11 +1332,6 @@ class Int64Index(Index):
     def _constructor(self):
         return Int64Index
 
-    @cache_readonly
-    def _engine(self):
-        # property, for now, slow to look up
-        return self._engine_type(lambda: com._ensure_int64(self.values), len(self))
-
     @property
     def asi8(self):
         # do not cache or you'll create a memory leak

--- a/pandas/index.pyx
+++ b/pandas/index.pyx
@@ -272,6 +272,9 @@ cdef class IndexEngine:
 
 cdef class Int64Engine(IndexEngine):
 
+    cdef _get_index_values(self):
+        return algos.ensure_int64(self.vgetter())
+
     cdef _make_hash_table(self, n):
         return _hash.Int64HashTable(n)
 


### PR DESCRIPTION
fixes an issue I when using non-int64 Int64Indexes (which is very rare) anyhow

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
timeseries_large_lookup_value                |   0.0213 |   2.5117 |   0.0085 |
Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [0933ba3] : PERF: fixed int64 indexing perf issue when conversion to int64
Base   [8f92d9a] : Merge PR #2881 and fix unit test

```
