### PR TITLE
PERF: series construction perf enhancements, use a fast path based on dt...

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -42,6 +42,8 @@ class AmbiguousIndexError(PandasError, KeyError):
     pass
 
 
+_POSSIBLY_CAST_DTYPES = set([ np.dtype(t) for t in ['M8[ns]','m8[ns]','O','int8','uint8','int16','uint16','int32','uint32','int64','uint64'] ])
+
 def isnull(obj):
     '''
     Detect missing values (NaN in numeric arrays, None/NaN in object arrays)
@@ -1037,6 +1039,9 @@ def _possibly_convert_objects(values, convert_dates=True, convert_numeric=True):
             pass
 
     return values
+
+def _possibly_castable(arr):
+    return arr.dtype not in _POSSIBLY_CAST_DTYPES
 
 def _possibly_convert_platform(values):
     """ try to do platform conversion, allow ndarray or list here """


### PR DESCRIPTION
This is only 1us improvement, but non-zero
(I measure the existing one at 9us, this puts it at 10, before
this change was about 11)

difference is 3 function calls, so not much more we can do I think
(as this is handling more cases)

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
series_constructor_ndarray                   |   0.0106 |   0.0120 |   0.8874 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [c54848f] : PERF: series construction perf enhancements, use a fast path based on dtype
Base   [9764ea6] : Merge pull request #3332 from jreback/period_perf2
```
