### PR TITLE
TST: properly raise the quoted exception when trying to unpickle on py2

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1584,6 +1584,8 @@ def load(path):
         with open(path,'rb') as fh:
             return pickle.load(fh)
     except:
+        if not py3compat.PY3:
+            raise
         with open(path,'rb') as fh:
             return pickle.load(fh, encoding='latin1')
 


### PR DESCRIPTION
should throw the error in the unpickle if on py2, rather than try to decode
as the try: except: is mainly to catch a decoding error
