### PR TITLE
CLN: DataFrame move doc from __init__ to cls

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -331,6 +331,7 @@ def _comp_method(func, name, str_rep):
 #----------------------------------------------------------------------
 # DataFrame class
 
+
 class DataFrame(NDFrame):
     """ Two-dimensional size-mutable, potentially heterogeneous tabular data
     structure with labeled axes (rows and columns). Arithmetic operations

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -331,8 +331,42 @@ def _comp_method(func, name, str_rep):
 #----------------------------------------------------------------------
 # DataFrame class
 
-
 class DataFrame(NDFrame):
+    """ Two-dimensional size-mutable, potentially heterogeneous tabular data
+    structure with labeled axes (rows and columns). Arithmetic operations
+    align on both row and column labels. Can be thought of as a dict-like
+    container for Series objects. The primary pandas data structure
+
+    Parameters
+    ----------
+    data : numpy ndarray (structured or homogeneous), dict, or DataFrame
+        Dict can contain Series, arrays, constants, or list-like objects
+    index : Index or array-like
+        Index to use for resulting frame. Will default to np.arange(n) if
+        no indexing information part of input data and no index provided
+    columns : Index or array-like
+        Will default to np.arange(n) if not column labels provided
+    dtype : dtype, default None
+        Data type to force, otherwise infer
+    copy : boolean, default False
+        Copy data from inputs. Only affects DataFrame / 2d ndarray input
+
+    Examples
+    --------
+    >>> d = {'col1': ts1, 'col2': ts2}
+    >>> df = DataFrame(data=d, index=index)
+    >>> df2 = DataFrame(np.random.randn(10, 5))
+    >>> df3 = DataFrame(np.random.randn(10, 5),
+    ...                 columns=['a', 'b', 'c', 'd', 'e'])
+
+    See also
+    --------
+    DataFrame.from_records: constructor from tuples, also record arrays
+    DataFrame.from_dict: from dicts of Series, arrays, or dicts
+    DataFrame.from_csv: from CSV files
+    DataFrame.from_items: from sequence of (key, value) pairs
+    read_csv / read_table / read_clipboard
+    """
     _auto_consolidate = True
     _het_axis = 1
     _info_axis = 'columns'
@@ -347,41 +381,6 @@ class DataFrame(NDFrame):
 
     def __init__(self, data=None, index=None, columns=None, dtype=None,
                  copy=False):
-        """Two-dimensional size-mutable, potentially heterogeneous tabular data
-        structure with labeled axes (rows and columns). Arithmetic operations
-        align on both row and column labels. Can be thought of as a dict-like
-        container for Series objects. The primary pandas data structure
-
-        Parameters
-        ----------
-        data : numpy ndarray (structured or homogeneous), dict, or DataFrame
-            Dict can contain Series, arrays, constants, or list-like objects
-        index : Index or array-like
-            Index to use for resulting frame. Will default to np.arange(n) if
-            no indexing information part of input data and no index provided
-        columns : Index or array-like
-            Will default to np.arange(n) if not column labels provided
-        dtype : dtype, default None
-            Data type to force, otherwise infer
-        copy : boolean, default False
-            Copy data from inputs. Only affects DataFrame / 2d ndarray input
-
-        Examples
-        --------
-        >>> d = {'col1': ts1, 'col2': ts2}
-        >>> df = DataFrame(data=d, index=index)
-        >>> df2 = DataFrame(np.random.randn(10, 5))
-        >>> df3 = DataFrame(np.random.randn(10, 5),
-        ...                 columns=['a', 'b', 'c', 'd', 'e'])
-
-        See also
-        --------
-        DataFrame.from_records: constructor from tuples, also record arrays
-        DataFrame.from_dict: from dicts of Series, arrays, or dicts
-        DataFrame.from_csv: from CSV files
-        DataFrame.from_items: from sequence of (key, value) pairs
-        read_csv / read_table / read_clipboard
-        """
         if data is None:
             data = {}
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1,7 +1,5 @@
 # pylint: disable=E1101,E1103,W0232
 
-from datetime import time
-
 from itertools import izip
 
 import numpy as np

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -147,6 +147,24 @@ def _comp_method(func, name):
 
 
 class Panel(NDFrame):
+    """
+    Represents wide format panel data, stored as 3-dimensional array
+
+    Parameters
+    ----------
+    data : ndarray (items x major x minor), or dict of DataFrames
+    items : Index or array-like
+        axis=1
+    major_axis : Index or array-like
+        axis=1
+    minor_axis : Index or array-like
+        axis=2
+    dtype : dtype, default None
+        Data type to force, otherwise infer
+    copy : boolean, default False
+        Copy data from inputs. Only affects DataFrame / 2d ndarray input
+    """
+
     _AXIS_ORDERS = ['items', 'major_axis', 'minor_axis']
     _AXIS_NUMBERS = dict([(a, i) for i, a in enumerate(_AXIS_ORDERS)])
     _AXIS_ALIASES = {
@@ -218,23 +236,6 @@ class Panel(NDFrame):
 
     def __init__(self, data=None, items=None, major_axis=None, minor_axis=None,
                  copy=False, dtype=None):
-        """
-        Represents wide format panel data, stored as 3-dimensional array
-
-        Parameters
-        ----------
-        data : ndarray (items x major x minor), or dict of DataFrames
-        items : Index or array-like
-            axis=1
-        major_axis : Index or array-like
-            axis=1
-        minor_axis : Index or array-like
-            axis=2
-        dtype : dtype, default None
-            Data type to force, otherwise infer
-        copy : boolean, default False
-            Copy data from inputs. Only affects DataFrame / 2d ndarray input
-        """
         self._init_data(
             data=data, items=items, major_axis=major_axis, minor_axis=minor_axis,
             copy=copy, dtype=dtype)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -386,6 +386,33 @@ def _make_stat_func(nanop, name, shortname, na_action=_doc_exclude_na,
 
 
 class Series(pa.Array, generic.PandasObject):
+    """
+    One-dimensional ndarray with axis labels (including time series).
+    Labels need not be unique but must be any hashable type. The object
+    supports both integer- and label-based indexing and provides a host of
+    methods for performing operations involving the index. Statistical
+    methods from ndarray have been overridden to automatically exclude
+    missing data (currently represented as NaN)
+
+    Operations between Series (+, -, /, *, **) align values based on their
+    associated index values-- they need not be the same length. The result
+    index will be the sorted union of the two indexes.
+
+    Parameters
+    ----------
+    data : array-like, dict, or scalar value
+        Contains data stored in Series
+    index : array-like or Index (1d)
+        Values must be unique and hashable, same length as data. Index
+        object (or other iterable of same length as data) Will default to
+        np.arange(len(data)) if not provided. If both a dict and index
+        sequence are used, the index will override the keys found in the
+        dict.
+    dtype : numpy.dtype or None
+        If None, dtype will be inferred copy : boolean, default False Copy
+        input data
+    copy : boolean, default False
+    """
     _AXIS_NUMBERS = {
         'index': 0
     }
@@ -411,7 +438,7 @@ class Series(pa.Array, generic.PandasObject):
         elif isinstance(data, dict):
             if index is None:
                 from pandas.util.compat import OrderedDict
-                if isinstance(data,OrderedDict):
+                if isinstance(data, OrderedDict):
                     index = Index(data)
                 else:
                     index = Index(sorted(data))
@@ -482,33 +509,6 @@ class Series(pa.Array, generic.PandasObject):
 
     def __init__(self, data=None, index=None, dtype=None, name=None,
                  copy=False):
-        """
-        One-dimensional ndarray with axis labels (including time series).
-        Labels need not be unique but must be any hashable type. The object
-        supports both integer- and label-based indexing and provides a host of
-        methods for performing operations involving the index. Statistical
-        methods from ndarray have been overridden to automatically exclude
-        missing data (currently represented as NaN)
-
-        Operations between Series (+, -, /, *, **) align values based on their
-        associated index values-- they need not be the same length. The result
-        index will be the sorted union of the two indexes.
-
-        Parameters
-        ----------
-        data : array-like, dict, or scalar value
-            Contains data stored in Series
-        index : array-like or Index (1d)
-            Values must be unique and hashable, same length as data. Index
-            object (or other iterable of same length as data) Will default to
-            np.arange(len(data)) if not provided. If both a dict and index
-            sequence are used, the index will override the keys found in the
-            dict.
-        dtype : numpy.dtype or None
-            If None, dtype will be inferred copy : boolean, default False Copy
-            input data
-        copy : boolean, default False
-        """
         pass
 
     @property

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -74,6 +74,23 @@ def _sparse_series_op(left, right, op, name):
 
 
 class SparseSeries(SparseArray, Series):
+    """Data structure for labeled, sparse floating point data
+
+    Parameters
+    ----------
+    data : {array-like, Series, SparseSeries, dict}
+    kind : {'block', 'integer'}
+    fill_value : float
+        Defaults to NaN (code for missing)
+    sparse_index : {BlockIndex, IntIndex}, optional
+        Only if you have one. Mainly used internally
+
+    Notes
+    -----
+    SparseSeries objects are immutable via the typical Python means. If you
+    must change values, convert to dense, make your changes, then convert back
+    to sparse
+    """
     __array_priority__ = 15
 
     sp_index = None
@@ -168,23 +185,6 @@ class SparseSeries(SparseArray, Series):
 
     def __init__(self, data, index=None, sparse_index=None, kind='block',
                  fill_value=None, name=None, copy=False):
-        """Data structure for labeled, sparse floating point data
-
-Parameters
-----------
-data : {array-like, Series, SparseSeries, dict}
-kind : {'block', 'integer'}
-fill_value : float
-    Defaults to NaN (code for missing)
-sparse_index : {BlockIndex, IntIndex}, optional
-    Only if you have one. Mainly used internally
-
-Notes
------
-SparseSeries objects are immutable via the typical Python means. If you
-must change values, convert to dense, make your changes, then convert back
-to sparse
-        """
         pass
 
     @property

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -40,29 +40,28 @@ def _field_accessor(name, alias):
 
 
 class Period(object):
+    """
+    Represents an period of time
 
+    Parameters
+    ----------
+    value : Period or basestring, default None
+        The time period represented (e.g., '4Q2005')
+    freq : str, default None
+        e.g., 'B' for businessday, ('T', 5) or '5T' for 5 minutes
+    year : int, default None
+    month : int, default 1
+    quarter : int, default None
+    day : int, default 1
+    hour : int, default 0
+    minute : int, default 0
+    second : int, default 0
+    """
     __slots__ = ['freq', 'ordinal']
 
     def __init__(self, value=None, freq=None, ordinal=None,
                  year=None, month=1, quarter=None, day=1,
                  hour=0, minute=0, second=0):
-        """
-        Represents an period of time
-
-        Parameters
-        ----------
-        value : Period or basestring, default None
-            The time period represented (e.g., '4Q2005')
-        freq : str, default None
-            e.g., 'B' for businessday, ('T', 5) or '5T' for 5 minutes
-        year : int, default None
-        month : int, default 1
-        quarter : int, default None
-        day : int, default 1
-        hour : int, default 0
-        minute : int, default 0
-        second : int, default 0
-        """
         # freq points to a tuple (base, mult);  base is one of the defined
         # periods such as A, Q, etc. Every five minutes would be, e.g.,
         # ('T', 5) but may be passed in as a string like '5T'


### PR DESCRIPTION
This, in part addresses our discussion from #3337.
This PR moves the doc string  from **init** to the more common class location.
(cf.. numpy, rest of pandas classes that have a doc string)
Besides STY / consistency  this would allow for more directly accessing the doc string in a debugging (pdb) session: 

``` Python
print mydf.__doc__
```
