### PR TITLE
PERF: get_numeric_data now a bit faster

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4930,25 +4930,10 @@ class DataFrame(NDFrame):
             raise Exception('Must have 0<= axis <= 1')
 
     def _get_numeric_data(self):
-        if self._is_mixed_type:
-            num_data = self._data.get_numeric_data()
-            return DataFrame(num_data, index=self.index, copy=False)
-        else:
-            if (self.values.dtype != np.object_ and
-                    not issubclass(self.values.dtype.type, np.datetime64)):
-                return self
-            else:
-                return self.ix[:, []]
+        return self._constructor(self._data.get_numeric_data(), index=self.index, copy=False)
 
     def _get_bool_data(self):
-        if self._is_mixed_type:
-            bool_data = self._data.get_bool_data()
-            return DataFrame(bool_data, index=self.index, copy=False)
-        else:  # pragma: no cover
-            if self.values.dtype == np.bool_:
-                return self
-            else:
-                return self.ix[:, []]
+        return self._constructor(self._data.get_bool_data(), index=self.index, copy=False)
 
     def quantile(self, q=0.5, axis=0, numeric_only=True):
         """

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -46,8 +46,14 @@ class _SparseMockBlockManager(object):
     @property
     def blocks(self):
         """ return our series in the column order """
-        s = self.sp_frame._series
-        return [ self.iget(i) for i in self.sp_frame.columns ]
+        return [ self.iget(i) for i, c in enumerate(self.sp_frame.columns) ]
+
+    def get_numeric_data(self):
+        # does not check, but assuming all numeric for now
+        return self.sp_frame
+
+    def get_bool_data(self):
+        raise NotImplementedError
 
 class SparseDataFrame(DataFrame):
     """
@@ -125,10 +131,13 @@ class SparseDataFrame(DataFrame):
 
     @property
     def _constructor(self):
-        def wrapper(data, index=None, columns=None):
-            return SparseDataFrame(data, index=index, columns=columns,
-                                   default_fill_value=self.default_fill_value,
-                                   default_kind=self.default_kind)
+        def wrapper(data, index=None, columns=None, copy=False):
+            sf = SparseDataFrame(data, index=index, columns=columns,
+                                 default_fill_value=self.default_fill_value,
+                                 default_kind=self.default_kind)
+            if copy:
+                sf = sf.copy()
+            return sf
         return wrapper
 
     def _init_dict(self, data, index, columns, dtype=None):

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -282,13 +282,7 @@ def _take_new_index(obj, indexer, new_index, axis=0):
     elif isinstance(obj, DataFrame):
         if axis == 1:
             raise NotImplementedError
-        data = obj._data
-
-        new_blocks = [b.take(indexer, axis=1) for b in data.blocks]
-        new_axes = list(data.axes)
-        new_axes[1] = new_index
-        new_data = BlockManager(new_blocks, new_axes)
-        return DataFrame(new_data)
+        return DataFrame(obj._data.take(indexer,new_index=new_index,axis=1))
     else:
         raise NotImplementedError
 


### PR DESCRIPTION
CLN: cleaned up take in tseries/resample and core/internals to use interenals take

```
 (which wasn't using the block level take)
```

This is not a big diff on get_numeric_data, about 5us on avg when I test it,
but its non-zero! (and there is some other code cleanups)
The other tests might be noise, not sure.

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
join_dataframe_index_single_key_bigger       |   5.0523 |   5.8804 |   0.8592 |
frame_drop_dup_na_inplace                    |   2.3123 |   2.4796 |   0.9325 |
frame_get_numeric_data                       |   0.0637 |   0.0664 |   0.9593 |

Target [ff6501e] : PERF: get_numeric_data now a bit faster
Base   [c45e769] : Merge pull request #3357 from jreback/hdf_fix
```
