### PR TITLE
DOC: Moved note about cursor position in TS plots out of changes to pd.data.io.Options in v0.11.0

### DIFF
--- a/doc/source/v0.11.0.txt
+++ b/doc/source/v0.11.0.txt
@@ -309,7 +309,8 @@ Enhancements
       only return forward looking data for options near the current stock
       price. This just obtains the data from Options.get_near_stock_price
       instead of Options.get_xxx_data() (GH2758_).
-    + Cursor coordinate information is now displayed in time-series plots.
+
+  - Cursor coordinate information is now displayed in time-series plots.
 
   - added option `display.max_seq_items` to control the number of
     elements printed per sequence pprinting it.  (GH2979_)


### PR DESCRIPTION
Very simple formatting change. 

Note about cursor position in time series plots should not have been a part of changes to Options class in data.io.
