### PR TITLE
multiindex xs slicing bug fix

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2226,8 +2226,9 @@ class DataFrame(NDFrame):
                 raise ValueError('Cannot retrieve view (copy=False)')
 
             # level = 0
-            if not isinstance(loc, slice):
-                indexer = [slice(None, None)] * 2
+            loc_is_slice = isinstance(loc, slice)
+            if not loc_is_slice:
+                indexer = [slice(None)] * 2
                 indexer[axis] = loc
                 indexer = tuple(indexer)
             else:
@@ -2237,10 +2238,9 @@ class DataFrame(NDFrame):
                     indexer = self.index[loc]
 
             # select on the correct axis
-            if axis == 1:
-                result = self.ix[:, indexer]
-            else:
-                result = self.ix[indexer]
+            if axis == 1 and loc_is_slice:
+                indexer = slice(None), indexer
+            result = self.ix[indexer]
             setattr(result, result._get_axis_name(axis), new_ax)
             return result
 

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -724,6 +724,11 @@ class TestIndexing(unittest.TestCase):
         expected = df.iloc[:,0:2].loc[:,'a']
         assert_frame_equal(result,expected)
 
+        result = df.xs('foo', level='lvl1', axis=1)
+        expected = df.iloc[:, 1:2].copy()
+        expected.columns = expected.columns.droplevel('lvl1')
+        assert_frame_equal(result, expected)
+
     def test_setitem_dtype_upcast(self):
  
         # GH3216


### PR DESCRIPTION
#2903 solves the case for the first level but using the same variables from that issue, the following code raises a `TypeError` for the second level:

``` python
import pandas as pd
from numpy.random import rand
columns = pd.MultiIndex.from_tuples([('a', 'foo'), ('a', 'bar'), ('b', 'hello'), ('b', 'world')], names=['lvl0', 'lvl1'])
df = pd.DataFrame(rand(4, 4), columns=columns)
df.xs('foo', level='lvl1', axis=1)
```

This pull request fixes that.
