### PR TITLE
ENH: speed up testing when --processes arg is given to test_fast.sh

### DIFF
--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -66,6 +66,7 @@ tables.parameters.MAX_THREADS   = 1
 
 
 class TestHDFStore(unittest.TestCase):
+    _multiprocess_shared_ = True
 
     def setUp(self):
         warnings.filterwarnings(action='ignore', category=FutureWarning)


### PR DESCRIPTION
I know this is a stupid one liner but...this allows the pytables fixtures to be shared, but not split (because PyTables is not reentrant [only reading is thread-safe]), during a test run with multiple processors. I get a 3x speed up (75 secs to 25 secs) just by adding this single class variable.
