### PR TITLE
TST: added testing and error messages for passing datetimes with timezones

### DIFF
--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -1150,14 +1150,18 @@ class TestHDFStore(unittest.TestCase):
             df1['float322'] = 1.
             df1['float322'] = df1['float322'].astype('float32')
             df1['bool']     = df1['float32'] > 0
+            df1['time1']    = Timestamp('20130101')
+            df1['time2']    = Timestamp('20130102')
 
             store.append('df_mixed_dtypes1', df1)
             result = store.select('df_mixed_dtypes1').get_dtype_counts()
             expected = Series({ 'float32' : 2, 'float64' : 1,'int32' : 1, 'bool' : 1,
-                                'int16' : 1, 'int8' : 1, 'int64' : 1, 'object' : 1 })
+                                'int16' : 1, 'int8' : 1, 'int64' : 1, 'object' : 1,
+                                'datetime64[ns]' : 2})
             result.sort()
             expected.sort()
             tm.assert_series_equal(result,expected)
+
 
     def test_table_mixed_dtypes(self):
 
@@ -1230,6 +1234,17 @@ class TestHDFStore(unittest.TestCase):
         with ensure_clean(self.path) as store:
             # this fails because we have a date in the object block......
             self.assertRaises(TypeError, store.append, 'df_unimplemented', df)
+
+    def test_table_append_with_timezones(self):
+        # not implemented yet
+
+        with ensure_clean(self.path) as store:
+            
+            # check with mixed dtypes
+            df = DataFrame(dict(A = Timestamp('20130102',tz='US/Eastern')),index=range(5))
+
+            # timezones not yet supported
+            self.assertRaises(TypeError, store.append, 'df_tz', df)
 
     def test_remove(self):
 


### PR DESCRIPTION
(not yet implemented, and error message was a little misleading)

CLN: better error messages on invalid appends
