### PR TITLE
BUG: adjust to_latex column format when no index

### DIFF
--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -356,7 +356,10 @@ class DataFrameFormatter(TableFormatter):
 
         if column_format is None:
             dtypes = self.frame.dtypes.values
-            column_format = 'l%s' % ''.join(map(get_col_type, dtypes))
+            if self.index:
+                column_format = 'l%s' % ''.join(map(get_col_type, dtypes))
+            else:
+                column_format = '%s' % ''.join(map(get_col_type, dtypes))
         elif not isinstance(column_format, basestring):
             raise AssertionError(('column_format must be str or unicode, not %s'
                                   % type(column_format)))

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -1355,6 +1355,31 @@ c  10  11  12  13  14\
         # it works!
         self.frame.to_latex()
 
+        df = DataFrame({'a': [1, 2],
+                        'b': ['b1', 'b2']})
+        withindex_result = df.to_latex()
+        withindex_expected = r"""\begin{tabular}{lrl}
+\toprule
+{} &  a &   b \\
+\midrule
+0 &  1 &  b1 \\
+1 &  2 &  b2 \\
+\bottomrule
+\end{tabular}
+"""
+        self.assertEqual(withindex_result, withindex_expected)
+
+        withoutindex_result = df.to_latex(index=False)
+        withoutindex_expected = r"""\begin{tabular}{rl}
+\toprule
+ a &   b \\
+\midrule
+ 1 &  b1 \\
+ 2 &  b2 \\
+\bottomrule
+\end{tabular}
+"""
+        self.assertEqual(withoutindex_result, withoutindex_expected)
 
 class TestSeriesFormatting(unittest.TestCase):
     _multiprocess_can_split_ = True


### PR DESCRIPTION
`to_latex` was adding an extra alignment to `column_format` when the
`index` argument was False
