### PR TITLE
BUG: GH3468 Fix assigning a new index to a duplicate index in a DataFrame would fail

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -68,8 +68,14 @@ pandas 0.11.1
     - Fix assigning a new index to a duplicate index in a DataFrame would fail
     - Fix construction of a DataFrame with a duplicate index
     - ref_locs support to allow duplicative indices across dtypes
+      (GH2194_)
+    - applymap on a DataFrame with a non-unique index now works
+      (removed warning) (GH2786_), and fix (GH3230_)
 
 .. _GH3164: https://github.com/pydata/pandas/issues/3164
+.. _GH2786: https://github.com/pydata/pandas/issues/2786
+.. _GH2194: https://github.com/pydata/pandas/issues/2194
+.. _GH3230: https://github.com/pydata/pandas/issues/3230
 .. _GH3251: https://github.com/pydata/pandas/issues/3251
 .. _GH3379: https://github.com/pydata/pandas/issues/3379
 .. _GH3480: https://github.com/pydata/pandas/issues/3480

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -61,6 +61,7 @@ pandas 0.11.1
   - Fix regression in a DataFrame apply with axis=1, objects were not being converted back
     to base dtypes correctly (GH3480_)
   - Fix issue when storing uint dtypes in an HDFStore. (GH3493_)
+  - Fix assigning a new index to a duplicate index in a DataFrame would fail (GH3468_)
 
 .. _GH3164: https://github.com/pydata/pandas/issues/3164
 .. _GH3251: https://github.com/pydata/pandas/issues/3251
@@ -75,6 +76,7 @@ pandas 0.11.1
 .. _GH3455: https://github.com/pydata/pandas/issues/3455
 .. _GH3457: https://github.com/pydata/pandas/issues/3457
 .. _GH3461: https://github.com/pydata/pandas/issues/3461
+.. _GH3468: https://github.com/pydata/pandas/issues/3468
 .. _GH3448: https://github.com/pydata/pandas/issues/3448
 .. _GH3449: https://github.com/pydata/pandas/issues/3449
 .. _GH3493: https://github.com/pydata/pandas/issues/3493

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -63,6 +63,11 @@ pandas 0.11.1
   - Fix issue when storing uint dtypes in an HDFStore. (GH3493_)
   - Fix assigning a new index to a duplicate index in a DataFrame would fail (GH3468_)
   - ref_locs support to allow duplicative indices across dtypes (GH3468_)
+  - Non-unique index support clarified (GH3468_)
+
+    - Fix assigning a new index to a duplicate index in a DataFrame would fail
+    - Fix construction of a DataFrame with a duplicate index
+    - ref_locs support to allow duplicative indices across dtypes
 
 .. _GH3164: https://github.com/pydata/pandas/issues/3164
 .. _GH3251: https://github.com/pydata/pandas/issues/3251

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -62,6 +62,7 @@ pandas 0.11.1
     to base dtypes correctly (GH3480_)
   - Fix issue when storing uint dtypes in an HDFStore. (GH3493_)
   - Fix assigning a new index to a duplicate index in a DataFrame would fail (GH3468_)
+  - ref_locs support to allow duplicative indices across dtypes (GH3468_)
 
 .. _GH3164: https://github.com/pydata/pandas/issues/3164
 .. _GH3251: https://github.com/pydata/pandas/issues/3251

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4261,9 +4261,6 @@ class DataFrame(NDFrame):
             if com.is_datetime64_dtype(x):
                 x = lib.map_infer(x, lib.Timestamp)
             return lib.map_infer(x, func)
-        #GH2786
-        if not self.columns.is_unique:
-            raise ValueError("applymap does not support dataframes having duplicate column labels")
         return self.apply(infer)
 
     #----------------------------------------------------------------------

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -56,11 +56,16 @@ class Block(object):
     @property
     def ref_locs(self):
         if self._ref_locs is None:
-            indexer = self.ref_items.get_indexer(self.items)
-            indexer = com._ensure_platform_int(indexer)
-            if (indexer == -1).any():
-                raise AssertionError('Some block items were not in block '
-                                     'ref_items')
+            ri = self.ref_items
+            if ri.is_unique:
+                indexer = ri.get_indexer(self.items)
+                indexer = com._ensure_platform_int(indexer)
+                if (indexer == -1).any():
+                    raise AssertionError('Some block items were not in block '
+                                         'ref_items')
+            else:
+                indexer = np.arange(len(ri))
+
             self._ref_locs = indexer
         return self._ref_locs
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2021,7 +2021,12 @@ def _stack_arrays(tuples, ref_items, dtype):
         stacked[i] = _asarray_compat(arr)
 
     # index may box values
-    items = ref_items[ref_items.isin(names)]
+    if ref_items.is_unique:
+        items = ref_items[ref_items.isin(names)]
+    else:
+        items = _ensure_index([ n for n in names if n in ref_items ])
+        if len(items) != len(stacked):
+            raise Exception("invalid names passed _stack_arrays")
 
     return items, stacked
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -56,15 +56,11 @@ class Block(object):
     @property
     def ref_locs(self):
         if self._ref_locs is None:
-            ri = self.ref_items
-            if ri.is_unique:
-                indexer = ri.get_indexer(self.items)
-                indexer = com._ensure_platform_int(indexer)
-                if (indexer == -1).any():
-                    raise AssertionError('Some block items were not in block '
-                                         'ref_items')
-            else:
-                indexer = np.arange(len(ri))
+            indexer = self.ref_items.get_indexer(self.items)
+            indexer = com._ensure_platform_int(indexer)
+            if (indexer == -1).any():
+                raise AssertionError('Some block items were not in block '
+                                     'ref_items')
 
             self._ref_locs = indexer
         return self._ref_locs
@@ -884,7 +880,7 @@ class BlockManager(object):
     -----
     This is *not* a public API class
     """
-    __slots__ = ['axes', 'blocks', '_known_consolidated', '_is_consolidated']
+    __slots__ = ['axes', 'blocks', '_known_consolidated', '_is_consolidated', '_ref_locs']
 
     def __init__(self, blocks, axes, do_integrity_check=True):
         self.axes = [_ensure_index(ax) for ax in axes]
@@ -920,11 +916,83 @@ class BlockManager(object):
         if len(value) != len(cur_axis):
             raise Exception('Length mismatch (%d vs %d)'
                             % (len(value), len(cur_axis)))
+
         self.axes[axis] = value
 
         if axis == 0:
-            for block in self.blocks:
-                block.set_ref_items(self.items, maybe_rename=True)
+            # unique, we can take
+            if cur_axis.is_unique:
+                for block in self.blocks:
+                    block.set_ref_items(self.items, maybe_rename=True)
+
+            # compute a duplicate indexer that we can use to take
+            # the new items from ref_items (in place of _ref_items)
+            else:
+                self.set_ref_locs(cur_axis)
+                for block in self.blocks:
+                    block.set_ref_items(self.items, maybe_rename=True)
+
+    def set_ref_locs(self, labels = None):
+        # if we have a non-unique index on this axis, set the indexers
+        # we need to set an absolute indexer for the blocks
+        # return the indexer if we are not unique
+        if labels is None:
+            labels = self.items
+
+        if labels.is_unique: 
+            return None
+
+        #### THIS IS POTENTIALLY VERY SLOW #####
+
+        # if we are already computed, then we are done
+        if getattr(self,'_ref_locs',None) is not None:
+            return self._ref_locs
+
+        blocks = self.blocks
+
+        # initialize
+        blockmap = dict()
+        for b in blocks:
+            arr = np.empty(len(b.items),dtype='int64')
+            arr.fill(-1)
+            b._ref_locs = arr
+
+            # add this block to the blockmap for each
+            # of the items in the block
+            for item in b.items:
+               if item not in blockmap:
+                   blockmap[item] = []
+               blockmap[item].append(b)
+
+        rl = np.empty(len(labels),dtype=object)
+        for i, item in enumerate(labels.values):
+
+            try:
+                block = blockmap[item].pop(0)
+            except:
+                raise Exception("not enough items in set_ref_locs")
+
+            indexer = np.arange(len(block.items))
+            mask = (block.items == item) & (block._ref_locs == -1)
+            if not mask.any():
+
+                # this case will catch a comparison of a index of tuples
+                mask = np.empty(len(block.items),dtype=bool)
+                mask.fill(False)
+                for j, (bitem, brl) in enumerate(zip(block.items,block._ref_locs)):
+                    mask[j] = bitem == item and brl == -1
+
+            indices = indexer[mask]
+            if len(indices):
+                idx = indices[0]
+            else:
+                raise Exception("already set too many items in set_ref_locs")
+
+            block._ref_locs[idx] = i
+            rl[i] = (block,idx)
+           
+        self._ref_locs = rl
+        return rl
 
     # make items read only for now
     def _get_items(self):
@@ -1392,26 +1460,11 @@ class BlockManager(object):
         item = self.items[i]
         if self.items.is_unique:
             return self.get(item)
-        else:
-            # ugh
-            try:
-                inds, = (self.items == item).nonzero()
-            except AttributeError:  # MultiIndex
-                inds, = self.items.map(lambda x: x == item).nonzero()
 
-            _, block = self._find_block(item)
-
-            try:
-                binds, = (block.items == item).nonzero()
-            except AttributeError:  # MultiIndex
-                binds, = block.items.map(lambda x: x == item).nonzero()
-
-            for j, (k, b) in enumerate(zip(inds, binds)):
-                if i == k:
-                    return block.values[b]
-
-            raise Exception('Cannot have duplicate column names '
-                            'split across dtypes')
+        # compute the duplicative indexer if needed
+        ref_locs = self.set_ref_locs()
+        b, loc = ref_locs[i]
+        return b.values[loc]
 
     def get_scalar(self, tup):
         """
@@ -1587,6 +1640,8 @@ class BlockManager(object):
         # keep track of what items aren't found anywhere
         mask = np.zeros(len(item_order), dtype=bool)
 
+        new_axes = [new_items] + self.axes[1:]
+
         new_blocks = []
         for blk in self.blocks:
             blk_indexer = blk.items.get_indexer(item_order)
@@ -1610,7 +1665,7 @@ class BlockManager(object):
             new_blocks.append(na_block)
             new_blocks = _consolidate(new_blocks, new_items)
 
-        return BlockManager(new_blocks, [new_items] + self.axes[1:])
+        return BlockManager(new_blocks, new_axes)
 
     def reindex_items(self, new_items, copy=True, fill_value=np.nan):
         """
@@ -1624,6 +1679,7 @@ class BlockManager(object):
 
         # TODO: this part could be faster (!)
         new_items, indexer = self.items.reindex(new_items)
+        new_axes = [new_items] + self.axes[1:]
 
         # could have so me pathological (MultiIndex) issues here
         new_blocks = []
@@ -1648,7 +1704,7 @@ class BlockManager(object):
                 new_blocks.append(na_block)
                 new_blocks = _consolidate(new_blocks, new_items)
 
-        return BlockManager(new_blocks, [new_items] + self.axes[1:])
+        return BlockManager(new_blocks, new_axes)
 
     def _make_na_block(self, items, ref_items, fill_value=np.nan):
         # TODO: infer dtypes other than float64 from fill_value
@@ -1690,10 +1746,10 @@ class BlockManager(object):
         this, other = self._maybe_rename_join(other, lsuffix, rsuffix)
 
         cons_items = this.items + other.items
-        consolidated = _consolidate(this.blocks + other.blocks, cons_items)
-
         new_axes = list(this.axes)
         new_axes[0] = cons_items
+
+        consolidated = _consolidate(this.blocks + other.blocks, cons_items)
 
         return BlockManager(consolidated, new_axes)
 
@@ -1907,7 +1963,6 @@ def form_blocks(arrays, names, axes):
 
         na_block = make_block(block_values, extra_items, items)
         blocks.append(na_block)
-        blocks = _consolidate(blocks, items)
 
     return blocks
 
@@ -1958,15 +2013,15 @@ def _stack_arrays(tuples, ref_items, dtype):
 
     names, arrays = zip(*tuples)
 
-    # index may box values
-    items = ref_items[ref_items.isin(names)]
-
     first = arrays[0]
     shape = (len(arrays),) + _shape_compat(first)
 
     stacked = np.empty(shape, dtype=dtype)
     for i, arr in enumerate(arrays):
         stacked[i] = _asarray_compat(arr)
+
+    # index may box values
+    items = ref_items[ref_items.isin(names)]
 
     return items, stacked
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -9201,6 +9201,21 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         assert_series_equal(self.frame['C'], frame['baz'])
         assert_series_equal(self.frame['hi'], frame['foo2'])
 
+    def test_assign_columns_with_dups(self):
+
+        # GH 3468 related
+        df = DataFrame([[1,2]], columns=['a','a'])
+        df.columns = ['a','a.1']
+
+        expected = DataFrame([[1,2]], columns=['a','a.1'])
+        assert_frame_equal(df, expected)
+
+        df = DataFrame([[1,2]], columns=['a','a'])
+        df.columns = ['b','b']
+
+        expected = DataFrame([[1,2]], columns=['b','b'])
+        assert_frame_equal(df, expected)
+
     def test_cast_internals(self):
         casted = DataFrame(self.frame._data, dtype=int)
         expected = DataFrame(self.frame._series, dtype=int)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -7492,12 +7492,15 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self.assert_(result.dtypes[0] == object)
 
         # GH2786
-        df = DataFrame(np.random.random((3,4)))
-        df.columns = ['a','a','a','a']
-        try:
-            df.applymap(str)
-        except ValueError as e:
-            self.assertTrue("support" in str(e))
+        df  = DataFrame(np.random.random((3,4)))
+        df2 = df.copy()
+        cols = ['a','a','a','a']
+        df.columns = cols
+
+        expected = df2.applymap(str)
+        expected.columns = cols
+        result = df.applymap(str)
+        assert_frame_equal(result,expected)
 
     def test_filter(self):
         # items
@@ -9201,7 +9204,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         assert_series_equal(self.frame['C'], frame['baz'])
         assert_series_equal(self.frame['hi'], frame['foo2'])
 
-    def test_assign_columns_with_dups(self):
+    def test_columns_with_dups(self):
 
         # GH 3468 related
 
@@ -9245,6 +9248,17 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
         result = df._data.set_ref_locs()
         self.assert_(len(result) == len(df.columns))
+
+        # testing iget
+        for i in range(len(df.columns)):
+             df.iloc[:,i]
+
+        # dup columns across dtype GH 2079/2194
+        vals = [[1, -1, 2.], [2, -2, 3.]] 
+        rs = DataFrame(vals, columns=['A', 'A', 'B']) 
+        xp = DataFrame(vals) 
+        xp.columns = ['A', 'A', 'B'] 
+        assert_frame_equal(rs, xp) 
 
     def test_cast_internals(self):
         casted = DataFrame(self.frame._data, dtype=int)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -9204,17 +9204,47 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
     def test_assign_columns_with_dups(self):
 
         # GH 3468 related
+
+        # basic
         df = DataFrame([[1,2]], columns=['a','a'])
         df.columns = ['a','a.1']
-
+        str(df)
         expected = DataFrame([[1,2]], columns=['a','a.1'])
         assert_frame_equal(df, expected)
 
+        df = DataFrame([[1,2,3]], columns=['b','a','a'])
+        df.columns = ['b','a','a.1']
+        str(df)
+        expected = DataFrame([[1,2,3]], columns=['b','a','a.1'])
+        assert_frame_equal(df, expected)
+
+        # with a dup index
         df = DataFrame([[1,2]], columns=['a','a'])
         df.columns = ['b','b']
-
+        str(df)
         expected = DataFrame([[1,2]], columns=['b','b'])
         assert_frame_equal(df, expected)
+
+        # multi-dtype
+        df = DataFrame([[1,2,1.,2.,3.,'foo','bar']], columns=['a','a','b','b','d','c','c'])
+        df.columns = list('ABCDEFG')
+        str(df)
+        expected = DataFrame([[1,2,1.,2.,3.,'foo','bar']], columns=list('ABCDEFG'))
+        assert_frame_equal(df, expected)
+
+        # this is an error because we cannot disambiguate the dup columns
+        self.assertRaises(Exception, lambda x: DataFrame([[1,2,'foo','bar']], columns=['a','a','a','a']))
+
+        # dups across blocks
+        df_float  = DataFrame(np.random.randn(10, 3),dtype='float64')
+        df_int    = DataFrame(np.random.randn(10, 3),dtype='int64')
+        df_bool   = DataFrame(True,index=df_float.index,columns=df_float.columns)
+        df_object = DataFrame('foo',index=df_float.index,columns=df_float.columns)
+        df_dt     = DataFrame(Timestamp('20010101'),index=df_float.index,columns=df_float.columns)
+        df        = pan.concat([ df_float, df_int, df_bool, df_object, df_dt ], axis=1)
+
+        result = df._data.set_ref_locs()
+        self.assert_(len(result) == len(df.columns))
 
     def test_cast_internals(self):
         casted = DataFrame(self.frame._data, dtype=int)

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -772,6 +772,13 @@ class TestIndexing(unittest.TestCase):
         expected = Index(['b','a','a'])
         self.assert_(result.equals(expected))
 
+        # across dtypes
+        df = DataFrame([[1,2,1.,2.,3.,'foo','bar']], columns=list('aaaaaaa'))
+        result = DataFrame([[1,2,1.,2.,3.,'foo','bar']])
+        result.columns = list('aaaaaaa')
+        assert_frame_equal(df,result)
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -268,7 +268,7 @@ class TestBlockManager(unittest.TestCase):
             b.ref_items = items
 
         mgr = BlockManager(blocks, [items, np.arange(N)])
-        self.assertRaises(Exception, mgr.iget, 1)
+        mgr.iget(1)
 
     def test_contains(self):
         self.assert_('a' in self.mgr)


### PR DESCRIPTION
partially fixes #3468

This would previously raise (same dtype assignment to a non-multi dtype frame with dup indicies)

```
In [6]: df = DataFrame([[1,2]], columns=['a','a'])

In [7]: df.columns = ['a','a.1']

In [8]: df
Out[8]: 
   a  a.1
0  1    2

```

construction of a multi-dtype frame with a dup index (#2194) is fixed

```
In [1]: DataFrame([[1,2,1.,2.,3.,'foo','bar']], columns=list('aaaaaaa'))
Out[1]: 
   a  a  a  a  a    a    a
0  1  2  3  1  2  foo  bar
```

This was also previously would raise

```
In [2]: %cpaste
Pasting code; enter '--' alone on the line to stop or use Ctrl-D.
:        df_float  = DataFrame(np.random.randn(10, 3),dtype='float64')
:        df_int    = DataFrame(np.random.randn(10, 3),dtype='int64')
:        df_bool   = DataFrame(True,index=df_float.index,columns=df_float.columns)
:        df_object = DataFrame('foo',index=df_float.index,columns=df_float.columns)
:        df_dt     = DataFrame(Timestamp('20010101'),index=df_float.index,columns=df_float.columns)
:        df        = pan.concat([ df_float, df_int, df_bool, df_object, df_dt ], axis=1)
:--

In [3]: df
Out[3]: 
      0     1     2                   0                   1  \
0  True  True  True 2001-01-01 00:00:00 2001-01-01 00:00:00   
1  True  True  True 2001-01-01 00:00:00 2001-01-01 00:00:00   
2  True  True  True 2001-01-01 00:00:00 2001-01-01 00:00:00   
3  True  True  True 2001-01-01 00:00:00 2001-01-01 00:00:00   
4  True  True  True 2001-01-01 00:00:00 2001-01-01 00:00:00   
5  True  True  True 2001-01-01 00:00:00 2001-01-01 00:00:00   
6  True  True  True 2001-01-01 00:00:00 2001-01-01 00:00:00   
7  True  True  True 2001-01-01 00:00:00 2001-01-01 00:00:00   
8  True  True  True 2001-01-01 00:00:00 2001-01-01 00:00:00   
9  True  True  True 2001-01-01 00:00:00 2001-01-01 00:00:00   

                    2    0    1    2  0  1  2         0         1         2  
0 2001-01-01 00:00:00  foo  foo  foo  0  0  0  0.431857 -0.131747 -1.039563  
1 2001-01-01 00:00:00  foo  foo  foo  0  0 -1  0.516910 -0.683163  0.736468  
2 2001-01-01 00:00:00  foo  foo  foo  0  0  0 -0.147417 -0.305452  0.006213  
3 2001-01-01 00:00:00  foo  foo  foo  0 -1  0  1.443031  0.082710 -0.335054  
4 2001-01-01 00:00:00  foo  foo  foo  1  0  0 -1.349293  0.645316  0.305524  
5 2001-01-01 00:00:00  foo  foo  foo -1  0  0  0.571095  0.756571 -0.773880  
6 2001-01-01 00:00:00  foo  foo  foo  0  0  0 -0.285091  1.196018  0.882786  
7 2001-01-01 00:00:00  foo  foo  foo  2  0  0  0.003610  0.549072 -0.823217  
8 2001-01-01 00:00:00  foo  foo  foo -1  1  0 -0.348279 -0.728958 -0.397435  
9 2001-01-01 00:00:00  foo  foo  foo -1  0  0  0.363489  2.154132  0.494673  

```

For those of you interested.....here is the new ref_loc indexer for duplicate columns
its by necessity a block oriented indexer, returns the column map (by column number) to a tuple of the block and the index in the block, only created when needed (e.g. when trying to get a column via iget and the index is non-unique, and the results are cached), this is #3092

```
In [1]: df = pd.DataFrame(np.random.randn(8,4),columns=['a']*4)

In [2]: df._data.blocks
Out[2]: [FloatBlock: [a, a, a, a], 4 x 8, dtype float64]

In [3]: df._data.blocks[0]._ref_locs

In [4]: df._data.set_ref_locs()
Out[4]: 
array([(FloatBlock: [a, a, a, a], 4 x 8, dtype float64, 0),
       (FloatBlock: [a, a, a, a], 4 x 8, dtype float64, 1),
       (FloatBlock: [a, a, a, a], 4 x 8, dtype float64, 2),
       (FloatBlock: [a, a, a, a], 4 x 8, dtype float64, 3)], dtype=object)
```

Fixed the #2786, #3230 bug that caused applymap to not work (we temp worked around by raising a ValueError; removed that check)

```
n [3]: In [3]: df = pd.DataFrame(np.random.random((3,4)))

In [4]: In [4]: cols = pd.Index(['a','a','a','a'])

In [5]: In [5]: df.columns = cols

In [6]: In [6]: df.applymap(str)
Out[6]: 
                a                a               a               a
0  0.494204195164   0.534601503195  0.471870025143  0.880092879641
1  0.860369768954  0.0472931994392  0.775532754792  0.822046777859
2  0.478775855962   0.623584943227  0.932012693593  0.739502590395

```
