### PR TITLE
Failing Unit Test and Patch for Fixing MonthEnd DateRange Unions with Timezones

### DIFF
--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -363,7 +363,7 @@ class MonthEnd(DateOffset, CacheableOffset):
     """DateOffset of one month end"""
 
     def apply(self, other):
-        other = datetime(other.year, other.month, other.day)
+        other = datetime(other.year, other.month, other.day, tzinfo=other.tzinfo)
 
         n = self.n
         _, days_in_month = tslib.monthrange(other.year, other.month)

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -340,6 +340,22 @@ class TestDateRange(unittest.TestCase):
         self.assert_(dr[0] == start)
         self.assert_(dr[2] == end)
 
+    def test_month_range_union_tz(self):
+        _skip_if_no_pytz()
+        from pytz import timezone
+        tz = timezone('US/Eastern')
+
+        early_start = datetime(2011, 1, 1)
+        early_end = datetime(2011, 3, 1)
+        
+        late_start = datetime(2011, 3, 1)
+        late_end = datetime(2011, 5, 1)
+
+        early_dr = date_range(start=early_start, end=early_end, tz=tz, freq=datetools.monthEnd)
+        late_dr = date_range(start=late_start, end=late_end, tz=tz, freq=datetools.monthEnd)
+        
+        early_dr.union(late_dr)
+
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
This patch preserves the timezone information when applying an offset to `DatetimeIndex` with a timezone applied.  The `MonthEnd` Offset wasn't retaining the timezone information resulting in an error even when both indexes had timezones.

```
TypeError: can't compare offset-naive and offset-aware datetimes
```
