### PR TITLE
BUG: GH3416 properly convert np.datetime64 objects in the _possibily_convert_datetimes

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -58,8 +58,10 @@ pandas 0.11.1
   - Duplicate indexes with getitem will return items in the correct order (GH3455_, GH3457_)
   - Fix sorting in a frame with a list of columns which contains datetime64[ns] dtypes (GH3461_)
   - DataFrames fetched via FRED now handle '.' as a NaN. (GH3469_)
+  - Properly convert np.datetime64 objects in a Series (GH3416_)
 
 .. _GH3164: https://github.com/pydata/pandas/issues/3164
+.. _GH3416: https://github.com/pydata/pandas/issues/3416
 .. _GH3251: https://github.com/pydata/pandas/issues/3251
 .. _GH3379: https://github.com/pydata/pandas/issues/3379
 .. _GH3454: https://github.com/pydata/pandas/issues/3454

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1119,12 +1119,12 @@ def _possibly_cast_to_datetime(value, dtype, coerce = False):
                 v = [ v ]
             if len(v):
                 inferred_type = lib.infer_dtype(v)
-                if inferred_type == 'datetime':
+                if inferred_type in ['datetime','datetime64']:
                     try:
                         value = tslib.array_to_datetime(np.array(v))
                     except:
                         pass
-                elif inferred_type == 'timedelta':
+                elif inferred_type in ['timedelta','timedelta64']:
                     value = _possibly_cast_to_timedelta(value)
 
     return value

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -469,6 +469,20 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         self.assert_(isnull(s[1]) == True)
         self.assert_(s.dtype == 'M8[ns]')
 
+        # GH3416
+        import pdb; pdb.set_trace()
+        dates = [
+            np.datetime64(datetime(2013, 1, 1)),
+            np.datetime64(datetime(2013, 1, 2)),
+            np.datetime64(datetime(2013, 1, 3)),
+            ]
+        
+        s = Series(dates)
+        self.assert_(s.dtype == 'M8[ns]')
+
+        s.ix[0] = np.nan
+        self.assert_(s.dtype == 'M8[ns]')
+
     def test_constructor_dict(self):
         d = {'a': 0., 'b': 1., 'c': 2.}
         result = Series(d, index=['b', 'c', 'd', 'a'])


### PR DESCRIPTION
closes #3416
