### PR TITLE
BUG: GH3480 Fix regression in a DataFrame apply with axis=1

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -58,10 +58,13 @@ pandas 0.11.1
   - Duplicate indexes with getitem will return items in the correct order (GH3455_, GH3457_)
   - Fix sorting in a frame with a list of columns which contains datetime64[ns] dtypes (GH3461_)
   - DataFrames fetched via FRED now handle '.' as a NaN. (GH3469_)
+  - Fix regression in a DataFrame apply with axis=1, objects were not being converted back
+    to base dtypes correctly (GH3480_)
 
 .. _GH3164: https://github.com/pydata/pandas/issues/3164
 .. _GH3251: https://github.com/pydata/pandas/issues/3251
 .. _GH3379: https://github.com/pydata/pandas/issues/3379
+.. _GH3480: https://github.com/pydata/pandas/issues/3480
 .. _GH3454: https://github.com/pydata/pandas/issues/3454
 .. _GH3457: https://github.com/pydata/pandas/issues/3457
 .. _GH3426: https://github.com/pydata/pandas/issues/3426

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4210,7 +4210,7 @@ class DataFrame(NDFrame):
 
             if axis == 1:
                 result = result.T
-            result = result.convert_objects(convert_dates=False)
+            result = result.convert_objects()
 
             return result
         else:

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -1826,6 +1826,13 @@ class TestGroupBy(unittest.TestCase):
         self.assert_(result.dtype == np.object_)
         self.assert_(isinstance(result[0], Decimal))
 
+    def test_apply_with_mixed_dtype(self):
+        # GH3480, apply with mixed dtype on axis=1 breaks in 0.11
+        df = DataFrame({'foo1' : ['one', 'two', 'two', 'three', 'one', 'two'],
+                        'foo2' : np.random.randn(6)})
+        result = df.apply(lambda x: x, axis=1)
+        assert_series_equal(df.get_dtype_counts(), result.get_dtype_counts())
+
     def test_groupby_list_infer_array_like(self):
         result = self.df.groupby(list(self.df['A'])).mean()
         expected = self.df.groupby(self.df['A']).mean()


### PR DESCRIPTION
objects were not being converted back to base dtypes correctly

closes #3480
