### PR TITLE
BUG/CLN: Allow the BlockManager to have a non-unique items (axis 0)

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -61,16 +61,15 @@ pandas 0.11.1
   - Fix regression in a DataFrame apply with axis=1, objects were not being converted back
     to base dtypes correctly (GH3480_)
   - Fix issue when storing uint dtypes in an HDFStore. (GH3493_)
-  - Fix assigning a new index to a duplicate index in a DataFrame would fail (GH3468_)
-  - ref_locs support to allow duplicative indices across dtypes (GH3468_)
   - Non-unique index support clarified (GH3468_)
 
-    - Fix assigning a new index to a duplicate index in a DataFrame would fail
+    - Fix assigning a new index to a duplicate index in a DataFrame would fail (GH3468_)
     - Fix construction of a DataFrame with a duplicate index
-    - ref_locs support to allow duplicative indices across dtypes
-      (GH2194_)
+    - ref_locs support to allow duplicative indices across dtypes,
+      allows iget support to always find the index (even across dtypes) (GH2194_)
     - applymap on a DataFrame with a non-unique index now works
       (removed warning) (GH2786_), and fix (GH3230_)
+    - Fix to_csv to handle non-unique columns (GH3495_)
 
 .. _GH3164: https://github.com/pydata/pandas/issues/3164
 .. _GH2786: https://github.com/pydata/pandas/issues/2786
@@ -91,6 +90,7 @@ pandas 0.11.1
 .. _GH3468: https://github.com/pydata/pandas/issues/3468
 .. _GH3448: https://github.com/pydata/pandas/issues/3448
 .. _GH3449: https://github.com/pydata/pandas/issues/3449
+.. _GH3495: https://github.com/pydata/pandas/issues/3495
 .. _GH3493: https://github.com/pydata/pandas/issues/3493
 
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -68,8 +68,14 @@ pandas 0.11.1
     - Fix assigning a new index to a duplicate index in a DataFrame would fail
     - Fix construction of a DataFrame with a duplicate index
     - ref_locs support to allow duplicative indices across dtypes
+      (GH2194_)
+    - applymap on a DataFrame with a non-unique index now works
+      (removed warning) (GH2786_), and fix (GH3230_)
 
 .. _GH3164: https://github.com/pydata/pandas/issues/3164
+.. _GH2786: https://github.com/pydata/pandas/issues/2786
+.. _GH2194: https://github.com/pydata/pandas/issues/2194
+.. _GH3230: https://github.com/pydata/pandas/issues/3230
 .. _GH3251: https://github.com/pydata/pandas/issues/3251
 .. _GH3379: https://github.com/pydata/pandas/issues/3379
 .. _GH3480: https://github.com/pydata/pandas/issues/3480

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -61,6 +61,7 @@ pandas 0.11.1
   - Fix regression in a DataFrame apply with axis=1, objects were not being converted back
     to base dtypes correctly (GH3480_)
   - Fix issue when storing uint dtypes in an HDFStore. (GH3493_)
+  - Fix assigning a new index to a duplicate index in a DataFrame would fail (GH3468_)
 
 .. _GH3164: https://github.com/pydata/pandas/issues/3164
 .. _GH3251: https://github.com/pydata/pandas/issues/3251
@@ -75,6 +76,7 @@ pandas 0.11.1
 .. _GH3455: https://github.com/pydata/pandas/issues/3455
 .. _GH3457: https://github.com/pydata/pandas/issues/3457
 .. _GH3461: https://github.com/pydata/pandas/issues/3461
+.. _GH3468: https://github.com/pydata/pandas/issues/3468
 .. _GH3448: https://github.com/pydata/pandas/issues/3448
 .. _GH3449: https://github.com/pydata/pandas/issues/3449
 .. _GH3493: https://github.com/pydata/pandas/issues/3493

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -62,6 +62,12 @@ pandas 0.11.1
     to base dtypes correctly (GH3480_)
   - Fix issue when storing uint dtypes in an HDFStore. (GH3493_)
   - Fix assigning a new index to a duplicate index in a DataFrame would fail (GH3468_)
+  - ref_locs support to allow duplicative indices across dtypes (GH3468_)
+  - Non-unique index support clarified (GH3468_)
+
+    - Fix assigning a new index to a duplicate index in a DataFrame would fail
+    - Fix construction of a DataFrame with a duplicate index
+    - ref_locs support to allow duplicative indices across dtypes
 
 .. _GH3164: https://github.com/pydata/pandas/issues/3164
 .. _GH3251: https://github.com/pydata/pandas/issues/3251

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1156,6 +1156,7 @@ def _default_index(n):
     values = np.arange(n, dtype=np.int64)
     result = values.view(Int64Index)
     result.name = None
+    result.is_unique = True
     return result
 
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4261,9 +4261,6 @@ class DataFrame(NDFrame):
             if com.is_datetime64_dtype(x):
                 x = lib.map_infer(x, lib.Timestamp)
             return lib.map_infer(x, func)
-        #GH2786
-        if not self.columns.is_unique:
-            raise ValueError("applymap does not support dataframes having duplicate column labels")
         return self.apply(infer)
 
     #----------------------------------------------------------------------

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -278,7 +278,7 @@ class Index(np.ndarray):
     def is_lexsorted_for_tuple(self, tup):
         return True
 
-    @cache_readonly
+    @cache_readonly(allow_setting=True)
     def is_unique(self):
         return self._engine.is_unique
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -56,11 +56,16 @@ class Block(object):
     @property
     def ref_locs(self):
         if self._ref_locs is None:
-            indexer = self.ref_items.get_indexer(self.items)
-            indexer = com._ensure_platform_int(indexer)
-            if (indexer == -1).any():
-                raise AssertionError('Some block items were not in block '
-                                     'ref_items')
+            ri = self.ref_items
+            if ri.is_unique:
+                indexer = ri.get_indexer(self.items)
+                indexer = com._ensure_platform_int(indexer)
+                if (indexer == -1).any():
+                    raise AssertionError('Some block items were not in block '
+                                         'ref_items')
+            else:
+                indexer = np.arange(len(ri))
+
             self._ref_locs = indexer
         return self._ref_locs
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -9201,6 +9201,21 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         assert_series_equal(self.frame['C'], frame['baz'])
         assert_series_equal(self.frame['hi'], frame['foo2'])
 
+    def test_assign_columns_with_dups(self):
+
+        # GH 3468 related
+        df = DataFrame([[1,2]], columns=['a','a'])
+        df.columns = ['a','a.1']
+
+        expected = DataFrame([[1,2]], columns=['a','a.1'])
+        assert_frame_equal(df, expected)
+
+        df = DataFrame([[1,2]], columns=['a','a'])
+        df.columns = ['b','b']
+
+        expected = DataFrame([[1,2]], columns=['b','b'])
+        assert_frame_equal(df, expected)
+
     def test_cast_internals(self):
         casted = DataFrame(self.frame._data, dtype=int)
         expected = DataFrame(self.frame._series, dtype=int)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -7492,12 +7492,15 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self.assert_(result.dtypes[0] == object)
 
         # GH2786
-        df = DataFrame(np.random.random((3,4)))
-        df.columns = ['a','a','a','a']
-        try:
-            df.applymap(str)
-        except ValueError as e:
-            self.assertTrue("support" in str(e))
+        df  = DataFrame(np.random.random((3,4)))
+        df2 = df.copy()
+        cols = ['a','a','a','a']
+        df.columns = cols
+
+        expected = df2.applymap(str)
+        expected.columns = cols
+        result = df.applymap(str)
+        assert_frame_equal(result,expected)
 
     def test_filter(self):
         # items
@@ -9201,7 +9204,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         assert_series_equal(self.frame['C'], frame['baz'])
         assert_series_equal(self.frame['hi'], frame['foo2'])
 
-    def test_assign_columns_with_dups(self):
+    def test_columns_with_dups(self):
 
         # GH 3468 related
 
@@ -9245,6 +9248,17 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
         result = df._data.set_ref_locs()
         self.assert_(len(result) == len(df.columns))
+
+        # testing iget
+        for i in range(len(df.columns)):
+             df.iloc[:,i]
+
+        # dup columns across dtype GH 2079/2194
+        vals = [[1, -1, 2.], [2, -2, 3.]] 
+        rs = DataFrame(vals, columns=['A', 'A', 'B']) 
+        xp = DataFrame(vals) 
+        xp.columns = ['A', 'A', 'B'] 
+        assert_frame_equal(rs, xp) 
 
     def test_cast_internals(self):
         casted = DataFrame(self.frame._data, dtype=int)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -9204,17 +9204,47 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
     def test_assign_columns_with_dups(self):
 
         # GH 3468 related
+
+        # basic
         df = DataFrame([[1,2]], columns=['a','a'])
         df.columns = ['a','a.1']
-
+        str(df)
         expected = DataFrame([[1,2]], columns=['a','a.1'])
         assert_frame_equal(df, expected)
 
+        df = DataFrame([[1,2,3]], columns=['b','a','a'])
+        df.columns = ['b','a','a.1']
+        str(df)
+        expected = DataFrame([[1,2,3]], columns=['b','a','a.1'])
+        assert_frame_equal(df, expected)
+
+        # with a dup index
         df = DataFrame([[1,2]], columns=['a','a'])
         df.columns = ['b','b']
-
+        str(df)
         expected = DataFrame([[1,2]], columns=['b','b'])
         assert_frame_equal(df, expected)
+
+        # multi-dtype
+        df = DataFrame([[1,2,1.,2.,3.,'foo','bar']], columns=['a','a','b','b','d','c','c'])
+        df.columns = list('ABCDEFG')
+        str(df)
+        expected = DataFrame([[1,2,1.,2.,3.,'foo','bar']], columns=list('ABCDEFG'))
+        assert_frame_equal(df, expected)
+
+        # this is an error because we cannot disambiguate the dup columns
+        self.assertRaises(Exception, lambda x: DataFrame([[1,2,'foo','bar']], columns=['a','a','a','a']))
+
+        # dups across blocks
+        df_float  = DataFrame(np.random.randn(10, 3),dtype='float64')
+        df_int    = DataFrame(np.random.randn(10, 3),dtype='int64')
+        df_bool   = DataFrame(True,index=df_float.index,columns=df_float.columns)
+        df_object = DataFrame('foo',index=df_float.index,columns=df_float.columns)
+        df_dt     = DataFrame(Timestamp('20010101'),index=df_float.index,columns=df_float.columns)
+        df        = pan.concat([ df_float, df_int, df_bool, df_object, df_dt ], axis=1)
+
+        result = df._data.set_ref_locs()
+        self.assert_(len(result) == len(df.columns))
 
     def test_cast_internals(self):
         casted = DataFrame(self.frame._data, dtype=int)

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -772,6 +772,13 @@ class TestIndexing(unittest.TestCase):
         expected = Index(['b','a','a'])
         self.assert_(result.equals(expected))
 
+        # across dtypes
+        df = DataFrame([[1,2,1.,2.,3.,'foo','bar']], columns=list('aaaaaaa'))
+        result = DataFrame([[1,2,1.,2.,3.,'foo','bar']])
+        result.columns = list('aaaaaaa')
+        assert_frame_equal(df,result)
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -774,8 +774,14 @@ class TestIndexing(unittest.TestCase):
 
         # across dtypes
         df = DataFrame([[1,2,1.,2.,3.,'foo','bar']], columns=list('aaaaaaa'))
+        df.head()
+        str(df)
         result = DataFrame([[1,2,1.,2.,3.,'foo','bar']])
         result.columns = list('aaaaaaa')
+
+        df_v  = df.iloc[:,4]
+        res_v = result.iloc[:,4]
+
         assert_frame_equal(df,result)
 
 

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -268,7 +268,7 @@ class TestBlockManager(unittest.TestCase):
             b.ref_items = items
 
         mgr = BlockManager(blocks, [items, np.arange(N)])
-        self.assertRaises(Exception, mgr.iget, 1)
+        mgr.iget(1)
 
     def test_contains(self):
         self.assert_('a' in self.mgr)


### PR DESCRIPTION
- Non-unique index support clarified #3092
  - Fix assigning a new index to a duplicate index in a DataFrame would fail #3468
  - Fix construction of a DataFrame with a duplicate index
  - ref_locs support to allow duplicative indices across dtypes,
    allows iget support to always find the index (even across dtypes) #2194
  - applymap on a DataFrame with a non-unique index now works
    (removed warning) #2786, and fix #3230
  - Fix to_csv to handle non-unique columns #3495
  - Modification to cache_readonly to allow you to pass an argument (allow_setting), to 'set'
    this value (useful in order to avoid a computation you know to be true, e.g. is_unique = True
    for a default index

partially fixes #3468

This would previously raise (same dtype assignment to a non-multi dtype frame with dup indicies)

```
In [6]: df = DataFrame([[1,2]], columns=['a','a'])

In [7]: df.columns = ['a','a.1']

In [8]: df
Out[8]: 
   a  a.1
0  1    2

```

construction of a multi-dtype frame with a dup index (#2194) is fixed

```
In [18]: DataFrame([[1,2,1.,2.,3.,'foo','bar']], columns=list('aaaaaaa'))
Out[18]: 
   a  a  a  a  a    a    a
0  1  2  1  2  3  foo  bar
```

This was also previously would raise

```
In [3]: df_float  = DataFrame(np.random.randn(10, 3),dtype='float64')

In [4]: df_int    = DataFrame(np.random.randn(10, 3),dtype='int64')

In [5]: df_bool   = DataFrame(True,index=df_float.index,columns=df_float.columns)

In [6]: df_object = DataFrame('foo',index=df_float.index,columns=df_float.columns)

In [7]: df_dt     = DataFrame(Timestamp('20010101'),index=df_float.index,columns=df_float.columns)

In [9]: df        = pan.concat([ df_float, df_int, df_bool, df_object, df_dt ], axis=1)

In [14]: cols = []

In [15]: for i in range(5):
   ....:     cols.extend([0,1,2])
   ....:     

In [16]: df.columns = cols

In [17]: df
Out[17]: 
          0         1         2  0  1  2     0     1     2    0    1    2                   0                   1                   2
0  0.586610  0.369944  1.341337  1  1  1  True  True  True  foo  foo  foo 2001-01-01 00:00:00 2001-01-01 00:00:00 2001-01-01 00:00:00
1 -1.944284 -0.813987  0.061306  0  0  1  True  True  True  foo  foo  foo 2001-01-01 00:00:00 2001-01-01 00:00:00 2001-01-01 00:00:00
2 -1.688694  1.644802  0.659083  0  0  0  True  True  True  foo  foo  foo 2001-01-01 00:00:00 2001-01-01 00:00:00 2001-01-01 00:00:00
3  1.422893  0.712382  0.749263 -1  0 -1  True  True  True  foo  foo  foo 2001-01-01 00:00:00 2001-01-01 00:00:00 2001-01-01 00:00:00
4 -0.453802  0.228886 -0.339753  2  0 -2  True  True  True  foo  foo  foo 2001-01-01 00:00:00 2001-01-01 00:00:00 2001-01-01 00:00:00
5 -0.189643  1.309407 -0.386121  0  0  0  True  True  True  foo  foo  foo 2001-01-01 00:00:00 2001-01-01 00:00:00 2001-01-01 00:00:00
6  0.455658  0.822050 -0.741014  0  0  0  True  True  True  foo  foo  foo 2001-01-01 00:00:00 2001-01-01 00:00:00 2001-01-01 00:00:00
7 -0.484678 -1.089146  0.774849  0  1  0  True  True  True  foo  foo  foo 2001-01-01 00:00:00 2001-01-01 00:00:00 2001-01-01 00:00:00
8  0.720365  1.696400 -0.604040 -1  0  0  True  True  True  foo  foo  foo 2001-01-01 00:00:00 2001-01-01 00:00:00 2001-01-01 00:00:00
9 -0.344480  0.886489  0.274428  1  0  0  True  True  True  foo  foo  foo 2001-01-01 00:00:00 2001-01-01 00:00:00 2001-01-01 00:00:00

```

For those of you interested.....here is the new ref_loc indexer for duplicate columns
its by necessity a block oriented indexer, returns the column map (by column number) to a tuple of the block and the index in the block, only created when needed (e.g. when trying to get a column via iget and the index is non-unique, and the results are cached), this is #3092

```
In [1]: df = pd.DataFrame(np.random.randn(8,4),columns=['a']*4)

In [2]: df._data.blocks
Out[2]: [FloatBlock: [a, a, a, a], 4 x 8, dtype float64]

In [3]: df._data.blocks[0]._ref_locs

In [4]: df._data._set_ref_locs()
Out[4]: 
array([(FloatBlock: [a, a, a, a], 4 x 8, dtype float64, 0),
       (FloatBlock: [a, a, a, a], 4 x 8, dtype float64, 1),
       (FloatBlock: [a, a, a, a], 4 x 8, dtype float64, 2),
       (FloatBlock: [a, a, a, a], 4 x 8, dtype float64, 3)], dtype=object)
```

Fixed the #2786, #3230 bug that caused applymap to not work (we temp worked around by raising a ValueError; removed that check)

```
n [3]: In [3]: df = pd.DataFrame(np.random.random((3,4)))

In [4]: In [4]: cols = pd.Index(['a','a','a','a'])

In [5]: In [5]: df.columns = cols

In [6]: In [6]: df.applymap(str)
Out[6]: 
                a                a               a               a
0  0.494204195164   0.534601503195  0.471870025143  0.880092879641
1  0.860369768954  0.0472931994392  0.775532754792  0.822046777859
2  0.478775855962   0.623584943227  0.932012693593  0.739502590395

```

Finally, to_csv writing has been fixed to use a single column mapper (which is derived from the ref_locs if the index is non-unique or the column numbering if it is unique)
