### PR TITLE
Fixed Unbound Variable `edge` access when BinGrouper is empty

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -58,6 +58,7 @@ pandas 0.11.1
   - Duplicate indexes with getitem will return items in the correct order (GH3455_, GH3457_)
   - Fix sorting in a frame with a list of columns which contains datetime64[ns] dtypes (GH3461_)
   - DataFrames fetched via FRED now handle '.' as a NaN. (GH3469_)
+  - Fixed bug in groupby with empty series referencing a variable before assignment. (GH3510_)
 
 .. _GH3164: https://github.com/pydata/pandas/issues/3164
 .. _GH3251: https://github.com/pydata/pandas/issues/3251
@@ -73,6 +74,7 @@ pandas 0.11.1
 .. _GH3461: https://github.com/pydata/pandas/issues/3461
 .. _GH3448: https://github.com/pydata/pandas/issues/3448
 .. _GH3449: https://github.com/pydata/pandas/issues/3449
+.. _GH3510: https://github.com/pydata/pandas/issues/3510
 
 
 pandas 0.11.0

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1012,8 +1012,8 @@ class BinGrouper(Grouper):
                 yield label, data[start:edge]
                 start = edge
 
-            if edge < len(data):
-                yield self.binlabels[-1], data[edge:]
+            if start < len(data):
+                yield self.binlabels[-1], data[start:]
         else:
             start = 0
             for edge, label in izip(self.bins, self.binlabels):
@@ -1022,8 +1022,8 @@ class BinGrouper(Grouper):
                 start = edge
 
             n = len(data.axes[axis])
-            if edge < n:
-                inds = range(edge, n)
+            if start < n:
+                inds = range(start, n)
                 yield self.binlabels[-1], data.take(inds, axis=axis)
 
     def apply(self, f, data, axis=0, keep_internal=False):

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -2427,6 +2427,16 @@ class TestGroupBy(unittest.TestCase):
         # don't die
         no_toes = df_grouped.apply(lambda x: noddy(x.value, x.weight ))
 
+    def test_groupby_with_empty(self):
+        import pandas as pd
+        index = pd.DatetimeIndex(())
+        data = ()
+        series = pd.Series(data, index)
+        grouper = pd.tseries.resample.TimeGrouper('D')
+        grouped = series.groupby(grouper)
+        assert next(iter(grouped), None) is None
+
+
 def assert_fp_equal(a, b):
     assert((np.abs(a - b) < 1e-12).all())
 


### PR DESCRIPTION
Incorrectly accessed variable `edge` instead of pre-filled value `start`.

Signed-off-by: Kevin Stone kevinastone@gmail.com
