### PR TITLE
BUG/CLN: datetime64/timedelta64

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -87,11 +87,14 @@ pandas 0.11.1
   - Fixed bug in mixed-frame assignment with aligned series (GH3492_)
   - Fixed bug in selecting month/quarter/year from a series would not select the time element
     on the last day (GH3546_)
+  - Properly convert np.datetime64 objects in a Series (GH3416_)
 
 .. _GH3164: https://github.com/pydata/pandas/issues/3164
 .. _GH2786: https://github.com/pydata/pandas/issues/2786
 .. _GH2194: https://github.com/pydata/pandas/issues/2194
 .. _GH3230: https://github.com/pydata/pandas/issues/3230
+.. _GH3164: https://github.com/pydata/pandas/issues/3164
+.. _GH3416: https://github.com/pydata/pandas/issues/3416
 .. _GH3251: https://github.com/pydata/pandas/issues/3251
 .. _GH3379: https://github.com/pydata/pandas/issues/3379
 .. _GH3480: https://github.com/pydata/pandas/issues/3480

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -56,6 +56,10 @@ pandas 0.11.1
     Note: The default value will change in 0.12 to the "no mangle" behaviour,
     If your code relies on this behaviour, explicitly specify mangle_dupe_cols=True
     in your calls.
+  - Do not allow astypes on ``datetime64[ns]`` except to ``object``, and
+    ``timedelta64[ns]`` to ``object/int`` (GH3425_)
+  - Do not allow datetimelike/timedeltalike creation except with valid types
+    (e.g. cannot pass ``datetime64[ms]``) (GH3423_)
 
 **Bug Fixes**
 
@@ -93,8 +97,9 @@ pandas 0.11.1
 .. _GH2786: https://github.com/pydata/pandas/issues/2786
 .. _GH2194: https://github.com/pydata/pandas/issues/2194
 .. _GH3230: https://github.com/pydata/pandas/issues/3230
-.. _GH3164: https://github.com/pydata/pandas/issues/3164
+.. _GH3425: https://github.com/pydata/pandas/issues/3425
 .. _GH3416: https://github.com/pydata/pandas/issues/3416
+.. _GH3423: https://github.com/pydata/pandas/issues/3423
 .. _GH3251: https://github.com/pydata/pandas/issues/3251
 .. _GH3379: https://github.com/pydata/pandas/issues/3379
 .. _GH3480: https://github.com/pydata/pandas/issues/3480

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -43,6 +43,9 @@ class AmbiguousIndexError(PandasError, KeyError):
 
 
 _POSSIBLY_CAST_DTYPES = set([ np.dtype(t) for t in ['M8[ns]','m8[ns]','O','int8','uint8','int16','uint16','int32','uint32','int64','uint64'] ])
+_NS_DTYPE = np.dtype('M8[ns]')
+_TD_DTYPE = np.dtype('m8[ns]')
+_INT64_DTYPE = np.dtype(np.int64)
 
 def isnull(obj):
     '''
@@ -1085,10 +1088,10 @@ def _possibly_cast_to_datetime(value, dtype, coerce = False):
         if is_datetime64 or is_timedelta64:
 
             # force the dtype if needed
-            #if is_datetime64 and dtype != 'datetime64[ns]':
-            #    dtype = np.dtype('datetime64[ns]')
-            #elif is_timedelta64 and dtype != 'timedelta64[ns]':
-            #    dtype = np.dtype('timedelta64[ns]')
+            if is_datetime64 and dtype != _NS_DTYPE:
+                  raise TypeError("cannot convert datetimelike to dtype [%s]" % dtype)
+            elif is_timedelta64 and dtype != _TD_DTYPE:
+                raise TypeError("cannot convert timedeltalike to dtype [%s]" % dtype)
 
             if np.isscalar(value):
                 if value == tslib.iNaT or isnull(value):
@@ -1106,7 +1109,6 @@ def _possibly_cast_to_datetime(value, dtype, coerce = False):
                         if is_datetime64:
                             from pandas.tseries.tools import to_datetime
                             value = to_datetime(value, coerce=coerce).values
-                            #value = tslib.array_to_datetime(value, coerce = coerce)
                         elif is_timedelta64:
                             value = _possibly_cast_to_timedelta(value)
                     except:
@@ -1523,9 +1525,24 @@ def _astype_nansafe(arr, dtype, copy = True):
     if not isinstance(dtype, np.dtype):
         dtype = np.dtype(dtype)
 
-    if issubclass(arr.dtype.type, np.datetime64):
+    if is_datetime64_dtype(arr):
         if dtype == object:
             return tslib.ints_to_pydatetime(arr.view(np.int64))
+        elif issubclass(dtype.type, np.int):
+            return arr.view(dtype)
+        elif dtype != _NS_DTYPE:
+            raise TypeError("cannot astype a datetimelike from [%s] to [%s]" % (arr.dtype,dtype))
+        return arr.astype(_NS_DTYPE)
+    elif is_timedelta64_dtype(arr):
+        if issubclass(dtype.type, np.int):
+            return arr.view(dtype)
+        elif dtype == object:
+            return arr.astype(object)
+
+        # in py3, timedelta64[ns] are int64
+        elif (py3compat.PY3 and dtype not in [_INT64_DTYPE,_TD_DTYPE]) or (not py3compat.PY3 and dtype != _TD_DTYPE):
+            raise TypeError("cannot astype a timedelta from [%s] to [%s]" % (arr.dtype,dtype))
+        return arr.astype(_TD_DTYPE)
     elif (np.issubdtype(arr.dtype, np.floating) and
           np.issubdtype(dtype, np.integer)):
 
@@ -1729,9 +1746,6 @@ else:
             self.queue.truncate(0)
 
 
-_NS_DTYPE = np.dtype('M8[ns]')
-
-
 def _concat_compat(to_concat, axis=0):
     # filter empty arrays
     to_concat = [x for x in to_concat if x.shape[axis] > 0]
@@ -1758,7 +1772,6 @@ def _to_pydatetime(x):
         x = x.reshape(shape)
 
     return x
-
 
 def _where_compat(mask, arr1, arr2):
     if arr1.dtype == _NS_DTYPE and arr2.dtype == _NS_DTYPE:

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1119,12 +1119,12 @@ def _possibly_cast_to_datetime(value, dtype, coerce = False):
                 v = [ v ]
             if len(v):
                 inferred_type = lib.infer_dtype(v)
-                if inferred_type == 'datetime':
+                if inferred_type in ['datetime','datetime64']:
                     try:
                         value = tslib.array_to_datetime(np.array(v))
                     except:
                         pass
-                elif inferred_type == 'timedelta':
+                elif inferred_type in ['timedelta','timedelta64']:
                     value = _possibly_cast_to_timedelta(value)
 
     return value

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1084,6 +1084,12 @@ def _possibly_cast_to_datetime(value, dtype, coerce = False):
 
         if is_datetime64 or is_timedelta64:
 
+            # force the dtype if needed
+            #if is_datetime64 and dtype != 'datetime64[ns]':
+            #    dtype = np.dtype('datetime64[ns]')
+            #elif is_timedelta64 and dtype != 'timedelta64[ns]':
+            #    dtype = np.dtype('timedelta64[ns]')
+
             if np.isscalar(value):
                 if value == tslib.iNaT or isnull(value):
                     value = tslib.iNaT
@@ -1098,7 +1104,9 @@ def _possibly_cast_to_datetime(value, dtype, coerce = False):
                 elif np.prod(value.shape) and value.dtype != dtype:
                     try:
                         if is_datetime64:
-                            value = tslib.array_to_datetime(value, coerce = coerce)
+                            from pandas.tseries.tools import to_datetime
+                            value = to_datetime(value, coerce=coerce).values
+                            #value = tslib.array_to_datetime(value, coerce = coerce)
                         elif is_timedelta64:
                             value = _possibly_cast_to_timedelta(value)
                     except:

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from numpy import nan
 import numpy as np
 
-from pandas.core.common import _possibly_downcast_to_dtype, isnull
+from pandas.core.common import _possibly_downcast_to_dtype, isnull, _NS_DTYPE, _TD_DTYPE
 from pandas.core.index import Index, MultiIndex, _ensure_index, _handle_legacy_indexes
 from pandas.core.indexing import _check_slice_bounds, _maybe_convert_indices
 import pandas.core.common as com
@@ -739,10 +739,6 @@ class ObjectBlock(Block):
         return not issubclass(value.dtype.type,
                               (np.integer, np.floating, np.complexfloating,
                                np.datetime64, np.bool_))
-
-_NS_DTYPE = np.dtype('M8[ns]')
-_TD_DTYPE = np.dtype('m8[ns]')
-
 
 class DatetimeBlock(Block):
     _can_hold_na = True

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -482,13 +482,13 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         s.ix[0] = np.nan
         self.assert_(s.dtype == 'M8[ns]')
 
-        # GH3414 related
-        #import pdb; pdb.set_trace()
-        #result = Series(Series(dates).astype('int')/1e6,dtype='M8[ms]')
-        #self.assert_(result.dtype == 'M8[ns]')
+        # invalid astypes
+        for t in ['s','D','us','ms']:
+            self.assertRaises(TypeError, s.astype, 'M8[%s]' % t)
 
-        #s = Series(dates, dtype='datetime64')
-        #self.assert_(s.dtype == 'M8[ns]')
+        # GH3414 related
+        self.assertRaises(TypeError, lambda x: Series(Series(dates).astype('int')/1000000,dtype='M8[ms]'))
+        self.assertRaises(TypeError, lambda x: Series(dates, dtype='datetime64'))
 
     def test_constructor_dict(self):
         d = {'a': 0., 'b': 1., 'c': 2.}
@@ -1829,6 +1829,13 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
 
         td = Series([ timedelta(days=i) for i in range(3) ] + [ np.nan ], dtype='m8[ns]' )
         self.assert_(td.dtype=='timedelta64[ns]')
+
+        # invalid astypes
+        for t in ['s','D','us','ms']:
+            self.assertRaises(TypeError, td.astype, 'm8[%s]' % t)
+
+        # valid astype
+        td.astype('int')
 
         # this is an invalid casting
         self.assertRaises(Exception, Series, [ timedelta(days=i) for i in range(3) ] + [ 'foo' ], dtype='m8[ns]' )

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -469,6 +469,20 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         self.assert_(isnull(s[1]) == True)
         self.assert_(s.dtype == 'M8[ns]')
 
+        # GH3416
+        import pdb; pdb.set_trace()
+        dates = [
+            np.datetime64(datetime(2013, 1, 1)),
+            np.datetime64(datetime(2013, 1, 2)),
+            np.datetime64(datetime(2013, 1, 3)),
+            ]
+        
+        s = Series(dates)
+        self.assert_(s.dtype == 'M8[ns]')
+
+        s.ix[0] = np.nan
+        self.assert_(s.dtype == 'M8[ns]')
+
     def test_constructor_dict(self):
         d = {'a': 0., 'b': 1., 'c': 2.}
         result = Series(d, index=['b', 'c', 'd', 'a'])

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -470,7 +470,6 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         self.assert_(s.dtype == 'M8[ns]')
 
         # GH3416
-        import pdb; pdb.set_trace()
         dates = [
             np.datetime64(datetime(2013, 1, 1)),
             np.datetime64(datetime(2013, 1, 2)),
@@ -482,6 +481,14 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
 
         s.ix[0] = np.nan
         self.assert_(s.dtype == 'M8[ns]')
+
+        # GH3414 related
+        #import pdb; pdb.set_trace()
+        #result = Series(Series(dates).astype('int')/1e6,dtype='M8[ms]')
+        #self.assert_(result.dtype == 'M8[ns]')
+
+        #s = Series(dates, dtype='datetime64')
+        #self.assert_(s.dtype == 'M8[ns]')
 
     def test_constructor_dict(self):
         d = {'a': 0., 'b': 1., 'c': 2.}

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 
 import numpy as np
 
-from pandas.core.common import isnull
+from pandas.core.common import isnull, _NS_DTYPE, _INT64_DTYPE
 from pandas.core.index import Index, Int64Index
 from pandas.tseries.frequencies import (
     infer_freq, to_offset, get_period_alias,
@@ -92,9 +92,6 @@ class TimeSeriesError(Exception):
 
 
 _midnight = time(0, 0)
-_NS_DTYPE = np.dtype('M8[ns]')
-_INT64_DTYPE = np.dtype(np.int64)
-
 
 class DatetimeIndex(Int64Index):
     """

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -12,7 +12,7 @@ from pandas.tseries.tools import parse_time_string
 import pandas.tseries.frequencies as _freq_mod
 
 import pandas.core.common as com
-from pandas.core.common import isnull
+from pandas.core.common import isnull, _NS_DTYPE, _INT64_DTYPE
 from pandas.util import py3compat
 
 from pandas.lib import Timestamp
@@ -515,10 +515,6 @@ def _period_index_cmp(opname):
 
         return result
     return wrapper
-
-_INT64_DTYPE = np.dtype(np.int64)
-_NS_DTYPE = np.dtype('M8[ns]')
-
 
 class PeriodIndex(Int64Index):
     """

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1470,7 +1470,7 @@ class TestTimeSeries(unittest.TestCase):
                         (3, np.datetime64('2012-07-04'))],
                        columns=['a', 'date'])
         result = df.groupby('a').first()
-        self.assertEqual(result['date'][3], np.datetime64('2012-07-03'))
+        self.assertEqual(result['date'][3], datetime(2012,7,3))
 
     def test_series_interpolate_intraday(self):
         # #1698

--- a/pandas/tseries/tools.py
+++ b/pandas/tseries/tools.py
@@ -50,7 +50,7 @@ def _maybe_get_tz(tz):
 
 
 def to_datetime(arg, errors='ignore', dayfirst=False, utc=None, box=True,
-                format=None):
+                format=None, coerce=False):
     """
     Convert argument to datetime
 
@@ -68,6 +68,7 @@ def to_datetime(arg, errors='ignore', dayfirst=False, utc=None, box=True,
         If True returns a DatetimeIndex, if False returns ndarray of values
     format : string, default None
         strftime to parse time, eg "%d/%m/%Y"
+    coerce : force errors to NaT (False by default)
 
     Returns
     -------
@@ -84,7 +85,8 @@ def to_datetime(arg, errors='ignore', dayfirst=False, utc=None, box=True,
                 result = tslib.array_strptime(arg, format)
             else:
                 result = tslib.array_to_datetime(arg, raise_=errors == 'raise',
-                                                 utc=utc, dayfirst=dayfirst)
+                                                 utc=utc, dayfirst=dayfirst,
+                                                 coerce=coerce)
             if com.is_datetime64_dtype(result) and box:
                 result = DatetimeIndex(result, tz='utc' if utc else None)
             return result


### PR DESCRIPTION
Various bugs related to datetime64s
- Properly convert np.datetime64 objects in a Series, #3416

This would convert to object dtype previously

```
In [1]: dates = [
   ...:     np.datetime64(datetime.date(2013, 1, 1)),
   ...:     np.datetime64(datetime.date(2013, 1, 2)),
   ...:     np.datetime64(datetime.date(2013, 1, 3)),
   ...: ]

In [2]: s = pd.Series(dates)

In [3]: s
Out[3]: 
0   2013-01-01 00:00:00
1   2013-01-02 00:00:00
2   2013-01-03 00:00:00
dtype: datetime64[ns]
```
- Do not allow astypes on `datetime64[ns]` except to `object`, and
  `timedelta64[ns]` to `object/int`, #3425
- Do not allow datetimelike/timedeltalike creation except with valid types
  (e.g. cannot pass `datetime64[ms]`, #3423

Any creation/astype of a datetimelike to a non accepted dtype will raise

```
In [6]: Series([Timestamp('20130101'),Timestamp('20130102')],dtype='datetime64[s]')
TypeError: cannot convert datetimelike to dtype [datetime64[s]]
```
