### PR TITLE
Parse raised exceptions and their error messages sans interpolation/format spec

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -710,8 +710,9 @@ class DataFrame(NDFrame):
                 self.info(buf=buf, verbose=verbose)
 
         value = buf.getvalue()
-        if not  type(value) == unicode:
-            raise AssertionError()
+        if not isinstance(value, unicode):
+            raise AssertionError("'{0}' is not of type 'unicode', it has "
+                                 "type '{0}'".format(type(value)))
 
         return value
 

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -631,8 +631,10 @@ class Panel(NDFrame):
         value : scalar value
         """
         # require an arg for each axis
-        if not ((len(args) == self._AXIS_LEN)):
-            raise AssertionError()
+        if len(args) != self._AXIS_LEN:
+            raise AssertionError('There must be an argument for each axis, '
+                                 'you gave {0} args, but {1} are '
+                                 'required'.format(len(args), self._AXIS_LEN))
 
         # hm, two layers to the onion
         frame = self._get_item_cache(args[0])
@@ -656,8 +658,12 @@ class Panel(NDFrame):
             otherwise a new object
         """
         # require an arg for each axis and the value
-        if not ((len(args) == self._AXIS_LEN + 1)):
-            raise AssertionError()
+        if len(args) != self._AXIS_LEN + 1:
+            raise AssertionError('There must be an argument for each axis plus'
+                                 ' the value provided, you gave {0} args, '
+                                 'but {1} are required'.format(len(args),
+                                                               self._AXIS_LEN
+                                                               + 1))
 
         try:
             frame = self._get_item_cache(args[0])
@@ -667,7 +673,7 @@ class Panel(NDFrame):
             axes = self._expand_axes(args)
             d = self._construct_axes_dict_from(self, axes, copy=False)
             result = self.reindex(**d)
-            args  = list(args)
+            args = list(args)
             likely_dtype, args[-1] = _infer_dtype_from_scalar(args[-1])
             made_bigger = not np.array_equal(
                 axes[0], getattr(self, self._info_axis))
@@ -702,8 +708,10 @@ class Panel(NDFrame):
                 **self._construct_axes_dict_for_slice(self._AXIS_ORDERS[1:]))
             mat = value.values
         elif isinstance(value, np.ndarray):
-            if not ((value.shape == shape[1:])):
-                raise AssertionError()
+            if value.shape != shape[1:]:
+                raise AssertionError('shape of value must be {0}, shape of '
+                                     'given object was '
+                                     '{1}'.format(shape[1:], value.shape))
             mat = np.asarray(value)
         elif np.isscalar(value):
             dtype, value = _infer_dtype_from_scalar(value)
@@ -1513,8 +1521,9 @@ class Panel(NDFrame):
     @staticmethod
     def _extract_axes_for_slice(self, axes):
         """ return the slice dictionary for these axes """
-        return dict([(self._AXIS_SLICEMAP[i], a) for i, a
-                     in zip(self._AXIS_ORDERS[self._AXIS_LEN - len(axes):], axes)])
+        return dict([(self._AXIS_SLICEMAP[i], a)
+                     for i, a in zip(self._AXIS_ORDERS[self._AXIS_LEN -
+                                                       len(axes):], axes)])
 
     @staticmethod
     def _prep_ndarray(self, values, copy=True):
@@ -1526,8 +1535,11 @@ class Panel(NDFrame):
         else:
             if copy:
                 values = values.copy()
-        if not ((values.ndim == self._AXIS_LEN)):
-            raise AssertionError()
+        if values.ndim != self._AXIS_LEN:
+            raise AssertionError("The number of dimensions required is {0}, "
+                                 "but the number of dimensions of the "
+                                 "ndarray given was {1}".format(self._AXIS_LEN,
+                                                                values.ndim))
         return values
 
     @staticmethod

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1146,8 +1146,9 @@ class Series(pa.Array, generic.PandasObject):
         else:
             result = u'Series([], dtype: %s)' % self.dtype
 
-        if not ( type(result) == unicode):
-            raise AssertionError()
+        if not isinstance(result, unicode):
+            raise AssertionError("result must be of type unicode, type"
+                                 " of result is '{0}'".format(type(result)))
         return result
 
     def __repr__(self):
@@ -1216,9 +1217,9 @@ class Series(pa.Array, generic.PandasObject):
                                   length=length, dtype=dtype, name=name)
 
         # catch contract violations
-        if not  type(the_repr) == unicode:
-            raise AssertionError("expected unicode string")
-
+        if not isinstance(the_repr, unicode):
+            raise AssertionError("result must be of type unicode, type"
+                                 " of result is '{0}'".format(type(the_repr)))
         if buf is None:
             return the_repr
         else:
@@ -1228,19 +1229,21 @@ class Series(pa.Array, generic.PandasObject):
                 with open(buf, 'w') as f:
                     f.write(the_repr)
 
-    def _get_repr(self, name=False, print_header=False, length=True, dtype=True,
-                  na_rep='NaN', float_format=None):
+    def _get_repr(self, name=False, print_header=False, length=True,
+                  dtype=True, na_rep='NaN', float_format=None):
         """
 
         Internal function, should always return unicode string
         """
 
         formatter = fmt.SeriesFormatter(self, name=name, header=print_header,
-                                        length=length, dtype=dtype, na_rep=na_rep,
+                                        length=length, dtype=dtype,
+                                        na_rep=na_rep,
                                         float_format=float_format)
         result = formatter.to_string()
-        if not ( type(result) == unicode):
-            raise AssertionError()
+        if not isinstance(result, unicode):
+            raise AssertionError("result must be of type unicode, type"
+                                 " of result is '{0}'".format(type(result)))
         return result
 
     def __iter__(self):

--- a/pandas/io/date_converters.py
+++ b/pandas/io/date_converters.py
@@ -46,12 +46,14 @@ def _maybe_cast(arr):
 
 
 def _check_columns(cols):
-    if not ((len(cols) > 0)):
-        raise AssertionError()
+    if not len(cols):
+        raise AssertionError("There must be at least 1 column")
 
     N = len(cols[0])
     for c in cols[1:]:
-        if not ((len(c) == N)):
-            raise AssertionError()
+        if len(c) != N:
+            raise AssertionError('All columns must have the same length: '
+                                 '{0}, at least one column has '
+                                 'length {1}'.format(N, len(c)))
 
     return N

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -630,8 +630,10 @@ class TextFileReader(object):
 
         # type conversion-related
         if converters is not None:
-            if not (isinstance(converters, dict)):
-                raise AssertionError()
+            if not isinstance(converters, dict):
+                raise AssertionError('Type converters must be a dict or'
+                                     ' subclass, input was '
+                                     'a {0}'.format(type(converters)))
         else:
             converters = {}
 
@@ -1649,8 +1651,8 @@ class PythonParser(ParserBase):
         if self._implicit_index:
             col_len += len(self.index_col)
 
-        if not ((self.skip_footer >= 0)):
-            raise AssertionError()
+        if self.skip_footer < 0:
+            raise AssertionError('skip footer cannot be negative')
 
         if col_len != zip_len and self.index_col is not False:
             row_num = -1
@@ -1946,15 +1948,18 @@ class FixedWidthReader(object):
         self.filler = filler  # Empty characters between fields.
         self.thousands = thousands
 
-        if not ( isinstance(colspecs, (tuple, list))):
-            raise AssertionError()
+        if not isinstance(colspecs, (tuple, list)):
+            raise AssertionError("column specifications must be a list or"
+                                 " tuple, input was "
+                                 "a {0}".format(type(colspecs)))
 
         for colspec in colspecs:
-            if not ( isinstance(colspec, (tuple, list)) and
-                       len(colspec) == 2 and
-                       isinstance(colspec[0], int) and
-                       isinstance(colspec[1], int) ):
-                raise AssertionError()
+            if not (isinstance(colspec, (tuple, list)) and
+                    len(colspec) == 2 and
+                    isinstance(colspec[0], int) and
+                    isinstance(colspec[1], int)):
+                raise AssertionError('Each column specification must be '
+                                     '2 element tuple or list of integers')
 
     def next(self):
         line = next(self.f)

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -8,7 +8,7 @@ with float64 data
 from numpy import nan
 import numpy as np
 
-from pandas.core.common import _pickle_array, _unpickle_array, _try_sort
+from pandas.core.common import _unpickle_array, _try_sort
 from pandas.core.index import Index, MultiIndex, _ensure_index
 from pandas.core.indexing import _check_slice_bounds, _maybe_convert_indices
 from pandas.core.series import Series
@@ -16,11 +16,9 @@ from pandas.core.frame import (DataFrame, extract_index, _prep_ndarray,
                                _default_index)
 from pandas.util.decorators import cache_readonly
 import pandas.core.common as com
-import pandas.core.datetools as datetools
 
 from pandas.sparse.series import SparseSeries
 from pandas.util.decorators import Appender
-import pandas.lib as lib
 
 
 class _SparseMockBlockManager(object):
@@ -713,8 +711,8 @@ class SparseDataFrame(DataFrame):
 
     def _join_index(self, other, how, lsuffix, rsuffix):
         if isinstance(other, Series):
-            if not (other.name is not None):
-                raise AssertionError()
+            if other.name is None:
+                raise AssertionError('Cannot join series with no name')
 
             other = SparseDataFrame({other.name: other},
                                     default_fill_value=self.default_fill_value)

--- a/pandas/sparse/panel.py
+++ b/pandas/sparse/panel.py
@@ -72,7 +72,8 @@ class SparsePanel(Panel):
             frames = new_frames
 
         if not (isinstance(frames, dict)):
-            raise AssertionError()
+            raise AssertionError('input must be a dict, a {0} was'
+                                 ' passed'.format(type(frames)))
 
         self.default_fill_value = fill_value = default_fill_value
         self.default_kind = kind = default_kind

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -110,8 +110,11 @@ class SparseSeries(SparseArray, Series):
             if isinstance(data, SparseSeries) and index is None:
                 index = data.index
             elif index is not None:
-                if not (len(index) == len(data)):
-                    raise AssertionError()
+                if len(index) != len(data):
+                    raise AssertionError('Passed index and data must have the '
+                                         'same length, len(data) == {0}, '
+                                         'len(index) == '
+                                         '{1}'.format(len(data), len(index)))
 
             sparse_index = data.sp_index
             values = np.asarray(data)
@@ -129,8 +132,14 @@ class SparseSeries(SparseArray, Series):
                                                    fill_value=fill_value)
             else:
                 values = data
-                if not (len(values) == sparse_index.npoints):
-                    raise AssertionError()
+                if len(values) != sparse_index.npoints:
+                    raise AssertionError('length of input must the same as the'
+                                         ' length of the given index, '
+                                         'len(values) == {0}, '
+                                         'sparse_index.npoints'
+                                         ' == '
+                                         '{1}'.format(len(values),
+                                                      sparse_index.npoints))
         else:
             if index is None:
                 raise Exception('must pass index!')
@@ -449,7 +458,7 @@ class SparseSeries(SparseArray, Series):
         reindexed : SparseSeries
         """
         if not (isinstance(new_index, splib.SparseIndex)):
-            raise AssertionError()
+            raise AssertionError('new index must be a SparseIndex')
 
         new_values = self.sp_index.to_int_index().reindex(self.sp_values,
                                                           self.fill_value,

--- a/pandas/stats/ols.py
+++ b/pandas/stats/ols.py
@@ -634,8 +634,8 @@ class MovingOLS(OLS):
         self._window_type = scom._get_window_type(window_type)
 
         if self._is_rolling:
-            if not ((window is not None)):
-                raise AssertionError()
+            if window is None:
+                raise AssertionError("'window' cannot be None")
             if min_periods is None:
                 min_periods = window
         else:
@@ -1212,8 +1212,9 @@ class MovingOLS(OLS):
         return result.astype(int)
 
     def _beta_matrix(self, lag=0):
-        if not ((lag >= 0)):
-            raise AssertionError()
+        if lag < 0:
+            raise AssertionError("'lag' must be greater than or equal to 0, "
+                                 "input was {0}".format(lag))
 
         betas = self._beta_raw
 
@@ -1276,8 +1277,8 @@ def _filter_data(lhs, rhs, weights=None):
         Cleaned lhs and rhs
     """
     if not isinstance(lhs, Series):
-        if not ((len(lhs) == len(rhs))):
-            raise AssertionError()
+        if len(lhs) != len(rhs):
+            raise AssertionError("length of lhs must equal length of rhs")
         lhs = Series(lhs, index=rhs.index)
 
     rhs = _combine_rhs(rhs)

--- a/pandas/stats/plm.py
+++ b/pandas/stats/plm.py
@@ -101,10 +101,12 @@ class PanelOLS(OLS):
             y_regressor = y
 
         if weights is not None:
-            if not ((y_regressor.index.equals(weights.index))):
-                raise AssertionError()
-            if not ((x_regressor.index.equals(weights.index))):
-                raise AssertionError()
+            if not y_regressor.index.equals(weights.index):
+                raise AssertionError("y_regressor and weights must have the "
+                                     "same index")
+            if not x_regressor.index.equals(weights.index):
+                raise AssertionError("x_regressor and weights must have the "
+                                     "same index")
 
             rt_weights = np.sqrt(weights)
             y_regressor = y_regressor * rt_weights
@@ -171,8 +173,10 @@ class PanelOLS(OLS):
         # .iteritems
         iteritems = getattr(x, 'iteritems', x.items)
         for key, df in iteritems():
-            if not ((isinstance(df, DataFrame))):
-                raise AssertionError()
+            if not isinstance(df, DataFrame):
+                raise AssertionError("all input items must be DataFrames, "
+                                     "at least one is of "
+                                     "type {0}".format(type(df)))
 
             if _is_numeric(df):
                 x_converted[key] = df
@@ -640,8 +644,9 @@ class MovingPanelOLS(MovingOLS, PanelOLS):
         return (betas * x).sum(1)
 
     def _beta_matrix(self, lag=0):
-        if not ((lag >= 0)):
-            raise AssertionError()
+        if lag < 0:
+            raise AssertionError("'lag' must be greater than or equal to 0, "
+                                 "input was {0}".format(lag))
 
         index = self._y_trans.index
         major_labels = index.labels[0]

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -404,17 +404,19 @@ class _MergeOperation(object):
         elif self.left_on is not None:
             n = len(self.left_on)
             if self.right_index:
-                if not ((len(self.left_on) == self.right.index.nlevels)):
-                    raise AssertionError()
+                if len(self.left_on) != self.right.index.nlevels:
+                    raise AssertionError('len(left_on) must equal the number '
+                                         'of levels in the index of "right"')
                 self.right_on = [None] * n
         elif self.right_on is not None:
             n = len(self.right_on)
             if self.left_index:
-                if not ((len(self.right_on) == self.left.index.nlevels)):
-                    raise AssertionError()
+                if len(self.right_on) != self.left.index.nlevels:
+                    raise AssertionError('len(right_on) must equal the number '
+                                         'of levels in the index of "left"')
                 self.left_on = [None] * n
-        if not ((len(self.right_on) == len(self.left_on))):
-            raise AssertionError()
+        if len(self.right_on) != len(self.left_on):
+            raise AssertionError("len(right_on) must equal len(left_on)")
 
 
 def _get_join_indexers(left_keys, right_keys, sort=False, how='inner'):
@@ -427,8 +429,8 @@ def _get_join_indexers(left_keys, right_keys, sort=False, how='inner'):
     -------
 
     """
-    if not ((len(left_keys) == len(right_keys))):
-        raise AssertionError()
+    if len(left_keys) != len(right_keys):
+        raise AssertionError('left_key and right_keys must be the same length')
 
     left_labels = []
     right_labels = []
@@ -542,8 +544,11 @@ def _left_join_on_index(left_ax, right_ax, join_keys, sort=False):
 
     if len(join_keys) > 1:
         if not ((isinstance(right_ax, MultiIndex) and
-               len(join_keys) == right_ax.nlevels) ):
-            raise AssertionError()
+                 len(join_keys) == right_ax.nlevels)):
+            raise AssertionError("If more than one join key is given then "
+                                 "'right_ax' must be a MultiIndex and the "
+                                 "number of join keys must be the number of "
+                                 "levels in right_ax")
 
         left_tmp, right_indexer = \
             _get_multiindex_indexer(join_keys, right_ax,
@@ -642,8 +647,9 @@ class _BlockJoinOperation(object):
         if axis <= 0:  # pragma: no cover
             raise MergeError('Only axis >= 1 supported for this operation')
 
-        if not ((len(data_list) == len(indexers))):
-            raise AssertionError()
+        if len(data_list) != len(indexers):
+            raise AssertionError("data_list and indexers must have the same "
+                                 "length")
 
         self.units = []
         for data, indexer in zip(data_list, indexers):
@@ -936,8 +942,9 @@ class _Concatenator(object):
             axis = 1 if axis == 0 else 0
 
         self._is_series = isinstance(sample, Series)
-        if not ((0 <= axis <= sample.ndim)):
-            raise AssertionError()
+        if not 0 <= axis <= sample.ndim:
+            raise AssertionError("axis must be between 0 and {0}, "
+                                 "input was {1}".format(sample.ndim, axis))
 
         # note: this is the BlockManager axis (since DataFrame is transposed)
         self.axis = axis
@@ -1106,8 +1113,9 @@ class _Concatenator(object):
                 to_concat.append(item_values)
 
         # this method only gets called with axis >= 1
-        if not ((self.axis >= 1)):
-            raise AssertionError()
+        if self.axis < 1:
+            raise AssertionError("axis must be >= 1, input was"
+                                 " {0}".format(self.axis))
         return com._concat_compat(to_concat, axis=self.axis - 1)
 
     def _get_result_dim(self):
@@ -1126,8 +1134,9 @@ class _Concatenator(object):
                     continue
                 new_axes[i] = self._get_comb_axis(i)
         else:
-            if not ((len(self.join_axes) == ndim - 1)):
-                raise AssertionError()
+            if len(self.join_axes) != ndim - 1:
+                raise AssertionError("length of join_axes must not be "
+                                     "equal to {0}".format(ndim - 1))
 
             # ufff...
             indices = range(ndim)

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -2,7 +2,6 @@
 
 from pandas import Series, DataFrame
 from pandas.core.index import MultiIndex
-from pandas.core.reshape import _unstack_multiple
 from pandas.tools.merge import concat
 import pandas.core.common as com
 import numpy as np
@@ -300,8 +299,8 @@ def _get_names(arrs, names, prefix='row'):
             else:
                 names.append('%s_%d' % (prefix, i))
     else:
-        if not ((len(names) == len(arrs))):
-            raise AssertionError()
+        if len(names) != len(arrs):
+            raise AssertionError('arrays and names must have the same length')
         if not isinstance(names, list):
             names = list(names)
 

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -306,11 +306,11 @@ class DatetimeIndex(Int64Index):
 
         if tz is not None and inferred_tz is not None:
             if not inferred_tz == tz:
-                raise AssertionError()
+                raise AssertionError("Inferred time zone not equal to passed "
+                                     "time zone")
 
         elif inferred_tz is not None:
             tz = inferred_tz
-
 
         if start is not None:
             if normalize:
@@ -450,16 +450,16 @@ class DatetimeIndex(Int64Index):
             cachedRange = drc[offset]
 
         if start is None:
-            if not (isinstance(end, Timestamp)):
-                raise AssertionError()
+            if not isinstance(end, Timestamp):
+                raise AssertionError('end must be an instance of Timestamp')
 
             end = offset.rollback(end)
 
             endLoc = cachedRange.get_loc(end) + 1
             startLoc = endLoc - periods
         elif end is None:
-            if not (isinstance(start, Timestamp)):
-                raise AssertionError()
+            if not isinstance(start, Timestamp):
+                raise AssertionError('start must be an instance of Timestamp')
 
             start = offset.rollforward(start)
 
@@ -586,14 +586,15 @@ class DatetimeIndex(Int64Index):
         zero_time = time(0, 0)
         for d in data:
             if d.time() != zero_time or d.tzinfo is not None:
-                return [u'%s' % x for x in data ]
+                return [u'%s' % x for x in data]
 
-        values = np.array(data,dtype=object)
+        values = np.array(data, dtype=object)
         mask = isnull(self.values)
         values[mask] = na_rep
 
         imask = -mask
-        values[imask] = np.array([ u'%d-%.2d-%.2d' % (dt.year, dt.month, dt.day) for dt in values[imask] ])
+        values[imask] = np.array([u'%d-%.2d-%.2d' % (dt.year, dt.month, dt.day)
+                                  for dt in values[imask]])
         return values.tolist()
 
     def isin(self, values):
@@ -1067,7 +1068,6 @@ class DatetimeIndex(Int64Index):
             return self._view_like(left_chunk)
 
     def _partial_date_slice(self, reso, parsed, use_lhs=True, use_rhs=True):
-        
         is_monotonic = self.is_monotonic
 
         if reso == 'year':
@@ -1104,18 +1104,22 @@ class DatetimeIndex(Int64Index):
         else:
             raise KeyError
 
-
         stamps = self.asi8
 
         if is_monotonic:
 
             # a monotonic (sorted) series can be sliced
-            left = stamps.searchsorted(t1.value, side='left') if use_lhs else None
-            right = stamps.searchsorted(t2.value, side='right') if use_rhs else None
+            left = None
+            if use_lhs:
+                left = stamps.searchsorted(t1.value, side='left')
+
+            right = None
+            if use_rhs:
+                right = stamps.searchsorted(t2.value, side='right')
             return slice(left, right)
 
-        lhs_mask = (stamps>=t1.value) if use_lhs else True
-        rhs_mask = (stamps<=t2.value) if use_rhs else True
+        lhs_mask = (stamps >= t1.value) if use_lhs else True
+        rhs_mask = (stamps <= t2.value) if use_rhs else True
 
         # try to find a the dates
         return (lhs_mask & rhs_mask).nonzero()[0]
@@ -1188,7 +1192,8 @@ class DatetimeIndex(Int64Index):
         freq = getattr(self, 'freqstr',
                        getattr(self, 'inferred_freq', None))
         _, parsed, reso = parse_time_string(key, freq)
-        loc = self._partial_date_slice(reso, parsed, use_lhs=use_lhs, use_rhs=use_rhs)
+        loc = self._partial_date_slice(reso, parsed, use_lhs=use_lhs,
+                                       use_rhs=use_rhs)
         return loc
 
     def slice_indexer(self, start=None, end=None, step=None):
@@ -1217,7 +1222,6 @@ class DatetimeIndex(Int64Index):
                         start_loc = self._get_string_slice(start).start
                     else:
                         start_loc = 0
-                        
                     if end:
                         end_loc = self._get_string_slice(end).stop
                     else:
@@ -1232,12 +1236,12 @@ class DatetimeIndex(Int64Index):
                 # so create an indexer directly
                 try:
                     if start:
-                        start_loc = self._get_string_slice(start,use_rhs=False)
+                        start_loc = self._get_string_slice(start,
+                                                           use_rhs=False)
                     else:
                         start_loc = np.arange(len(self))
-                        
                     if end:
-                        end_loc = self._get_string_slice(end,use_lhs=False)
+                        end_loc = self._get_string_slice(end, use_lhs=False)
                     else:
                         end_loc = np.arange(len(self))
 

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -119,8 +119,9 @@ class TimeGrouper(CustomGrouper):
         return binner, grouper
 
     def _get_time_bins(self, axis):
-        if not (isinstance(axis, DatetimeIndex)):
-            raise AssertionError()
+        if not isinstance(axis, DatetimeIndex):
+            raise AssertionError('axis must be a DatetimeIndex, but got '
+                                 'a {0}'.format(type(axis)))
 
         if len(axis) == 0:
             binner = labels = DatetimeIndex(data=[], freq=self.freq)
@@ -179,8 +180,9 @@ class TimeGrouper(CustomGrouper):
         return binner, bin_edges
 
     def _get_time_period_bins(self, axis):
-        if not(isinstance(axis, DatetimeIndex)):
-            raise AssertionError()
+        if not isinstance(axis, DatetimeIndex):
+            raise AssertionError('axis must be a DatetimeIndex, '
+                                 'but was a {0}'.format(type(axis)))
 
         if len(axis) == 0:
             binner = labels = PeriodIndex(data=[], freq=self.freq)
@@ -210,8 +212,8 @@ class TimeGrouper(CustomGrouper):
                 result = grouped.aggregate(self._agg_method)
             else:
                 # upsampling shortcut
-                if not (self.axis == 0):
-                    raise AssertionError()
+                if self.axis:
+                    raise AssertionError('axis must be 0')
 
                 if self.closed == 'right':
                     res_index = binner[1:]
@@ -277,7 +279,6 @@ class TimeGrouper(CustomGrouper):
 
 def _take_new_index(obj, indexer, new_index, axis=0):
     from pandas.core.api import Series, DataFrame
-    from pandas.core.internals import BlockManager
 
     if isinstance(obj, Series):
         new_values = com.take_1d(obj.values, indexer)
@@ -285,7 +286,7 @@ def _take_new_index(obj, indexer, new_index, axis=0):
     elif isinstance(obj, DataFrame):
         if axis == 1:
             raise NotImplementedError
-        return DataFrame(obj._data.take(indexer,new_index=new_index,axis=1))
+        return DataFrame(obj._data.take(indexer, new_index=new_index, axis=1))
     else:
         raise NotImplementedError
 

--- a/pandas/tseries/tools.py
+++ b/pandas/tseries/tools.py
@@ -29,7 +29,8 @@ def _infer_tzinfo(start, end):
         tz = a.tzinfo
         if b and b.tzinfo:
             if not (tslib.get_timezone(tz) == tslib.get_timezone(b.tzinfo)):
-                raise AssertionError()
+                raise AssertionError('Inputs must both have the same timezone,'
+                                     ' {0} != {1}'.format(tz, b.tzinfo))
         return tz
     tz = None
     if start is not None:

--- a/scripts/parse_asserts.py
+++ b/scripts/parse_asserts.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python
+
+import re
+import os
+import fnmatch
+import ast
+import argparse
+import inspect
+import sys
+import tempfile
+import subprocess
+import operator
+
+try:
+    from importlib import import_module
+except ImportError:
+    import_module = __import__
+
+
+from numpy import nan as NA
+from pandas import DataFrame
+from pandas.core.config import option_context
+
+
+def parse_interp_string(node):
+    assert isinstance(node, ast.BinOp)
+    assert isinstance(node.op, ast.Mod)
+    assert isinstance(node.left, ast.Str)
+    return node.left.s
+
+
+def parse_format_string(node):
+    assert isinstance(node, ast.Call)
+    assert isinstance(node.func, ast.Attribute)
+    assert isinstance(node.func.value, ast.Str)
+    return node.func.value.s
+
+
+def try_parse_raise_arg(node):
+    try:
+        # string
+        v = node.s
+    except AttributeError:
+        try:
+            # interpolated string
+            v = parse_interp_string(node)
+        except AssertionError:
+            try:
+                # format spec string
+                v = parse_format_string(node)
+            except AssertionError:
+                # otherwise forget it (general expr node)
+                v = node
+    return v
+
+
+def parse_file(pyfile, asserts):
+    with open(pyfile, 'r') as pyf:
+        source = pyf.read()
+
+    try:
+        parsed = ast.parse(source, pyfile, 'exec')
+    except SyntaxError:
+        return
+
+    for node in ast.walk(parsed):
+        if isinstance(node, ast.Raise):
+            k = pyfile, node.lineno, node.col_offset
+
+            try:
+                # try to get the name of the exception constructor
+                asserts[k] = [node.type.func.id]
+            except AttributeError:
+                # not a constructor
+                asserts[k] = [NA]
+            else:
+                # is constructor, try parsing its contents
+                try:
+                    # function arguments
+                    args = node.type.args
+
+                    try:
+                        # try to get the first argument
+                        arg = args[0]
+                        v = try_parse_raise_arg(arg)
+                        asserts[k].append(v)
+                    except IndexError:
+                        # no arguments (e.g., raise Exception())
+                        asserts[k].append(NA)
+
+                except AttributeError:
+                    # no arguments (e.g., raise Exception)
+                    asserts[k].append(NA)
+
+
+def path_matches(path, pattern):
+    return re.search(pattern, path) is not None
+
+
+def regex_or(*patterns):
+    return '({0})'.format('|'.join(patterns))
+
+
+def get_asserts_from_path(path, file_filters, dir_filters):
+    if file_filters is None:
+        file_filters = 'test', '__init__.py'
+
+    file_filters = regex_or(*file_filters)
+
+    if dir_filters is None:
+        dir_filters = 'build', '.tox', 'test', '.*\.egg.*'
+
+    dir_filters = regex_or(*dir_filters)
+
+    asserts = {}
+
+    if os.path.isfile(path):
+        parse_file(path, asserts)
+        return asserts
+
+    for root, _, filenames in os.walk(path):
+        full_names = []
+
+        if not path_matches(root, dir_filters):
+            full_names = [os.path.join(root, fn) for fn in filenames
+                          if not path_matches(fn, file_filters)]
+
+        if full_names:
+            pyfiles = fnmatch.filter(full_names, '*.py')
+
+            if pyfiles:
+                for pyfile in pyfiles:
+                    parse_file(pyfile, asserts)
+
+    return asserts
+
+
+def obj_path_from_string(dotted_name, full_path):
+    try:
+        obj = import_module(dotted_name)
+    except ImportError:
+        splits_ville = dotted_name.split('.')
+        module_name, obj_name = splits_ville[:-1], splits_ville[-1]
+        module_name = '.'.join(module_name)
+
+        try:
+            module = import_module(module_name)
+        except ImportError:
+            raise ImportError("'{0}' is not a valid Python "
+                              "module".format(module_name))
+        else:
+            try:
+                obj = getattr(module, obj_name)
+            except AttributeError:
+                raise AttributeError("")
+
+    if full_path:
+        path = inspect.getabsfile(obj)
+    else:
+        path = inspect.getfile(obj)
+
+    if path.endswith('pyc'):
+        path = path.strip('c')
+    return os.path.dirname(path)
+
+
+def get_asserts_from_obj(dotted_name, file_filters, dir_filters, full_path):
+    path = obj_path_from_string(dotted_name, full_path)
+    return get_asserts_from_path(path, file_filters, dir_filters)
+
+
+def asserts_to_frame(asserts):
+    index, values = zip(*asserts.iteritems())
+    values = map(lambda x: list(reduce(operator.concat, map(list, x))),
+                 asserts.iteritems())
+    columns = 'filename', 'line', 'col', 'code', 'msg'
+    df = DataFrame(values, columns=columns).fillna(NA)
+    return df
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-t', '--type', default='all',
+                        choices=('all', 'a', 'empty', 'e', 'nonempty', 'n'),
+                        help='The type of nodes you want to look for')
+    parser.add_argument('-m', '--module', default='pandas',
+                        help=('The name of a module or file to search for '
+                              'nodes in'))
+    parser.add_argument('-i', '--file-filters', default=None, nargs='*',
+                        help=("A list of regular expressions describing files "
+                              "you want to ignore"))
+    parser.add_argument('-d', '--dir-filters', default=None, nargs='*',
+                        help=('A list of regular expressions describing'
+                              ' directories you want to ignore'))
+    parser.add_argument('-s', '--sparse-filename', action='store_true',
+                        help=('Use multi_sparse = False to show the '
+                              'resulting DataFrame'))
+    parser.add_argument('-p', '--full-path', action='store_true',
+                        help=('Display the entire path of the file if this '
+                              'is given'))
+    parser.add_argument('-k', '--exception-types', nargs='*',
+                        help='The types of exceptions to report')
+    parser.add_argument('-b', '--sort-by', default='line', nargs='*',
+                        help=('A list of columns or index levels you want to '
+                              'sort by'))
+    return parser.parse_args()
+
+
+def _build_exc_regex(exc_list):
+    return r'(.*(?:{0}).*)'.format('|'.join(exc_list))
+
+
+def main(args):
+    asserts = get_asserts_from_obj(args.module, args.file_filters,
+                                   args.dir_filters, args.full_path)
+
+    if not asserts:
+        print "No asserts found in '{0}'".format(args.module)
+        return 0
+
+    df = asserts_to_frame(asserts)
+
+    try:
+        df.sortlevel(args.sort_by, inplace=True)
+    except Exception:
+        df.sort(args.sort_by, inplace=True)
+
+    atype = args.type
+
+    msg = 'No'
+
+    if atype.startswith('e'):
+        ind = df.msg.isnull()
+        msg += ' empty'
+    elif atype.startswith('n'):
+        ind = df.msg.notnull()
+        msg += ' nonempty'
+    else:
+        ind = slice(None)
+
+    df = df[ind]
+    df.sort_index(inplace=True)
+
+    if df.empty:
+        print "{0} {1} found in '{2}'".format(msg, args.exception_types,
+                                              args.module)
+        return 0
+    max_cols = int(df.msg.map(lambda x: len(repr(x))).max())
+    with option_context('display.multi_sparse', args.sparse_filename,
+                        'display.max_colwidth', max_cols,
+                        'display.max_seq_items', max_cols):
+        if args.exception_types is not None:
+            regex = _build_exc_regex(args.exception_types)
+            vals = df.code.str.match(regex, re.I)
+            df = df[vals.str[0].notnull()]
+
+            if df.empty:
+                msg = "{0} {1} found in '{2}'".format(msg,
+                                                      args.exception_types,
+                                                      args.module)
+                print msg
+                return 0
+
+            with tempfile.NamedTemporaryFile() as tmpf:
+                df.to_string(buf=tmpf)
+                return subprocess.call([os.environ.get('PAGER', 'less'),
+                                        tmpf.name])
+    return df
+
+
+if __name__ == '__main__':
+    sys.exit(main(parse_args()))


### PR DESCRIPTION
This PR partially addresses #3024. It also provides a shiny new script useful looking at the current state of the messages in raised exceptions. Here's an example of some output:
# Example

![pandas-shiny-new-parse-asserts](https://f.cloud.github.com/assets/417981/457480/70282b60-b39e-11e2-8db1-f5cfb4f0c5bf.png)

You can reproduce this with

``` sh
scripts/parse_except.py --type empty --module pandas --kind assert
```

from the top level pandas directory.
# Description

The above line searches for all empty raises in the module `pandas` whose constructor matches the regular expression `'.*assert.*'`--not case sensitive.

Note: **This assumes you have installed pandas with `python setup.py develop`**. This will not work without that (well, that's not strictly true, but it will search for pandas code that's installed wherever you installed it `/usr/*/site-packages/*/pandas` or `$VIRTUAL_ENV/*/pandas`, for example, which is probably not what you want).

To see all of the options and a short description you can do the usual:

``` sh
scripts/parse_except.py --help
```
