### PR TITLE
Document read_csv's usecols parameter.

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -114,6 +114,9 @@ encoding : string, default None
     Encoding to use for UTF when reading/writing (ex. 'utf-8')
 squeeze : boolean, default False
     If the parsed data only contains one column then return a Series
+usecols : array-like, default None
+    Specify a subset of columns to return.
+    This can result in much faster parsing time and lower memory usage.
 
 Returns
 -------


### PR DESCRIPTION
read_csv's usecols argument is currently undocumented.
This patch fixes this:

http://pandas.pydata.org/pandas-docs/stable/generated/pandas.io.parsers.read_csv.html
