### PR TITLE
document read_csv's usecols argument.

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -110,6 +110,8 @@ They can take a number of arguments:
   - ``verbose``: show number of NA values inserted in non-numeric columns
   - ``squeeze``: if True then output with only one column is turned into Series
   - ``error_bad_lines``: if False then any lines causing an error will be skipped :ref:`bad lines <io.bad_lines>`
+  - ``usecols``: a subset of columns to return, results in much faster parsing 
+    time and lower memory usage.
 
 .. ipython:: python
    :suppress:

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -122,6 +122,9 @@ na_filter: boolean, default True
     Detect missing value markers (empty strings and the value of na_values). In
     data without any NAs, passing na_filter=False can improve the performance
     of reading a large file
+usecols : array-like
+    Return a subset of the columns.
+    Results in much faster parsing time and lower memory usage.
 
 Returns
 -------


### PR DESCRIPTION
read_csv's usecols is currently not documented here:

http://pandas.pydata.org/pandas-docs/stable/generated/pandas.io.parsers.read_csv.html

This patch fixes that.
