### PR TITLE
BUG: raise on invalid operations for timedelta/datetime

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -94,6 +94,8 @@ pandas 0.11.1
   - Fixed bug in selecting month/quarter/year from a series would not select the time element
     on the last day (GH3546_)
   - Properly convert np.datetime64 objects in a Series (GH3416_)
+  - Raise a TypeError on invalid datetime/timedelta operations
+    e.g. add datetimes, multiple timedelta x datetime
 
 .. _GH3164: https://github.com/pydata/pandas/issues/3164
 .. _GH2786: https://github.com/pydata/pandas/issues/2786

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -75,7 +75,7 @@ def _arith_method(op, name):
 
         return result
 
-    def wrapper(self, other):
+    def wrapper(self, other, name=name):
         from pandas.core.frame import DataFrame
         dtype = None
         wrap_results = lambda x: x
@@ -123,6 +123,13 @@ def _arith_method(op, name):
             # 2 datetimes or 2 timedeltas
             if (is_timedelta_lhs and is_timedelta_rhs) or (is_datetime_lhs and is_datetime_rhs):
 
+                if is_datetime_lhs and name not in ['__sub__']:
+                    raise TypeError("can only operate on a datetimes for subtraction, "
+                                    "but the operator [%s] was passed" % name)
+                elif is_timedelta_lhs and name not in ['__add__','__sub__']:
+                    raise TypeError("can only operate on a timedeltas for "
+                                    "addition and subtraction, but the operator [%s] was passed" % name)
+
                 dtype = 'timedelta64[ns]'
 
                 # we may have to convert to object unfortunately here
@@ -135,6 +142,10 @@ def _arith_method(op, name):
 
             # datetime and timedelta
             elif (is_timedelta_lhs and is_datetime_rhs) or (is_timedelta_rhs and is_datetime_lhs):
+
+                if name not in ['__add__','__sub__']:
+                    raise TypeError("can only operate on a timedelta and a datetime for "
+                                    "addition and subtraction, but the operator [%s] was passed" % name)
                 dtype = 'M8[ns]'
 
             else:

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1889,25 +1889,13 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         assert_series_equal(result,expected)
         self.assert_(result.dtype=='m8[ns]')
 
-        result = df['A'] + datetime(2001,1,1)
-        expected = Series([timedelta(days=26663+i) for i in range(3)])
-        assert_series_equal(result,expected)
-        self.assert_(result.dtype=='m8[ns]')
-
         d = datetime(2001,1,1,3,4)
         resulta = df['A'] - d
         self.assert_(resulta.dtype=='m8[ns]')
 
-        resultb = df['A'] + d
-        self.assert_(resultb.dtype=='m8[ns]')
-
         # roundtrip
         resultb = resulta + d
         assert_series_equal(df['A'],resultb)
-
-        # timedelta on lhs
-        result = resultb + d
-        self.assert_(result.dtype=='m8[ns]')
 
         # timedeltas on rhs
         td = timedelta(days=1)
@@ -1931,6 +1919,42 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         self.assert_(result.dtype=='m8[ns]')
         assert_series_equal(result,expected)
 
+    def test_operators_datetimelike(self):
+
+        ### timedelta64 ###
+        td1 = Series([timedelta(minutes=5,seconds=3)]*3)
+        td2 = timedelta(minutes=5,seconds=4)
+        for op in ['__mul__','__floordiv__','__truediv__','__div__','__pow__']:
+            op = getattr(td1,op,None)
+            if op is not None:
+                self.assertRaises(TypeError, op, td2)
+        td1 + td2
+        td1 - td2
+
+        ### datetime64 ###
+        dt1 = Series([Timestamp('20111230'),Timestamp('20120101'),Timestamp('20120103')])
+        dt2 = Series([Timestamp('20111231'),Timestamp('20120102'),Timestamp('20120104')])
+        for op in ['__add__','__mul__','__floordiv__','__truediv__','__div__','__pow__']:
+            op = getattr(dt1,op,None)
+            if op is not None:
+                self.assertRaises(TypeError, op, dt2)
+        dt1 - dt2
+
+        ### datetime64 with timetimedelta ###
+        for op in ['__mul__','__floordiv__','__truediv__','__div__','__pow__']:
+            op = getattr(dt1,op,None)
+            if op is not None:
+                self.assertRaises(TypeError, op, td1)
+        dt1 + td1
+        dt1 - td1
+
+        ### timetimedelta with datetime64 ###
+        for op in ['__mul__','__floordiv__','__truediv__','__div__','__pow__']:
+            op = getattr(td1,op,None)
+            if op is not None:
+                self.assertRaises(TypeError, op, dt1)
+        td1 + dt1
+        td1 - dt1
 
     def test_timedelta64_functions(self):
 


### PR DESCRIPTION
e.g. can't add 2 datetimes, nor multiply timedelta \* datetime
