### PR TITLE
DOC: document non-preservation of dtypes across rows with iterrows

### DIFF
--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -835,7 +835,6 @@ containing the data in each row:
       ...:     print '%s\n%s' % (row_index, row)
       ...:
 
-
 For instance, a contrived way to transpose the dataframe would be:
 
 .. ipython:: python
@@ -846,6 +845,18 @@ For instance, a contrived way to transpose the dataframe would be:
 
    df2_t = DataFrame(dict((idx,values) for idx, values in df2.iterrows()))
    print df2_t
+
+.. note::
+
+   ``iterrows`` does **not** preserve dtypes across the rows (dtypes are
+   preserved across columns for DataFrames). For example,
+
+    .. ipython:: python
+
+      df = DataFrame([[1, 1.0]], columns=['x', 'y'])
+      row = next(df.iterrows())[1]
+      print row['x'].dtype
+      print df['x'].dtype
 
 itertuples
 ~~~~~~~~~~

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -772,7 +772,25 @@ class DataFrame(NDFrame):
 
     def iterrows(self):
         """
-        Iterate over rows of DataFrame as (index, Series) pairs
+        Iterate over rows of DataFrame as (index, Series) pairs.
+
+        Notes
+        -----
+
+        * ``iterrows`` does **not** preserve dtypes across the rows (dtypes
+          are preserved across columns for DataFrames). For example,
+
+            >>> df = DataFrame([[1, 1.0]], columns=['x', 'y'])
+            >>> row = next(df.iterrows())[1]
+            >>> print row['x'].dtype
+            float64
+            >>> print df['x'].dtype
+            int64
+
+        Returns
+        -------
+        it : generator
+            A generator that iterates over the rows of the frame.
         """
         columns = self.columns
         for k, v in izip(self.index, self.values):


### PR DESCRIPTION
iterrows doesn't preserve dtypes across rows, document it, #3566. i learned that you can nest ..ipython:: blocks in ..note:: blocks in sphinx. sweet.
