### PR TITLE
ENH: plot only numeric data and raise an exception *before* plotting if there is no numeric data

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -68,9 +68,9 @@ pandas 0.11.1
     thanks @hoechenberger
   - ``read_html`` no longer performs hard date conversion
   - Plotting functions now raise a ``TypeError`` before trying to plot anything
-    if the associated objects have have a dtype of ``object`` (GH1818_). This
-    happens before any drawing takes place which elimnates any spurious plots
-    from showing up.
+    if the associated objects have have a dtype of ``object`` (GH1818_,
+    GH3572_). This happens before any drawing takes place which elimnates any
+    spurious plots from showing up.
 
 **API Changes**
 
@@ -93,6 +93,9 @@ pandas 0.11.1
   - Raise on ``iloc`` when boolean indexing with a label based indexer mask
     e.g. a boolean Series, even with integer labels, will raise. Since ``iloc``
     is purely positional based, the labels on the Series are not alignable (GH3631_)
+  - The ``raise_on_error`` option to plotting methods is obviated by GH3572_,
+    so it is removed. Plots now always raise when data cannot be plotted or the
+    object being plotted has a dtype of ``object``.
 
 **Bug Fixes**
 
@@ -232,6 +235,7 @@ pandas 0.11.1
 .. _GH3649: https://github.com/pydata/pandas/issues/3649
 .. _Gh3616: https://github.com/pydata/pandas/issues/3616
 .. _GH1818: https://github.com/pydata/pandas/issues/1818
+.. _GH3572: https://github.com/pydata/pandas/issues/3572
 
 pandas 0.11.0
 =============

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -67,6 +67,10 @@ pandas 0.11.1
     to specify custom column names of the returned DataFrame (GH3649_),
     thanks @hoechenberger
   - ``read_html`` no longer performs hard date conversion
+  - Plotting functions now raise a ``TypeError`` before trying to plot anything
+    if the associated objects have have a dtype of ``object`` (GH1818_). This
+    happens before any drawing takes place which elimnates any spurious plots
+    from showing up.
 
 **API Changes**
 
@@ -227,6 +231,7 @@ pandas 0.11.1
 .. _GH3659: https://github.com/pydata/pandas/issues/3659
 .. _GH3649: https://github.com/pydata/pandas/issues/3649
 .. _Gh3616: https://github.com/pydata/pandas/issues/3616
+.. _GH1818: https://github.com/pydata/pandas/issues/1818
 
 pandas 0.11.0
 =============

--- a/doc/source/v0.11.1.txt
+++ b/doc/source/v0.11.1.txt
@@ -62,6 +62,7 @@ API changes
     ``df.iloc[mask]`` will raise a ``ValueError``
 
 
+
 Enhancements
 ~~~~~~~~~~~~
 
@@ -158,6 +159,11 @@ Enhancements
   - ``pd.melt()`` now accepts the optional parameters ``var_name`` and ``value_name``
     to specify custom column names of the returned DataFrame.
 
+  - Plotting functions now raise a ``TypeError`` before trying to plot anything
+    if the associated objects have have a ``dtype`` of ``object`` (GH1818_).
+    This happens before any drawing takes place which elimnates any spurious
+    plots from showing up.
+
 Bug Fixes
 ~~~~~~~~~
 
@@ -227,3 +233,4 @@ on GitHub for a complete list.
 .. _GH3605: https://github.com/pydata/pandas/issues/3605
 .. _GH3606: https://github.com/pydata/pandas/issues/3606
 .. _GH3656: https://github.com/pydata/pandas/issues/3656
+.. _GH1818: https://github.com/pydata/pandas/issues/1818

--- a/doc/source/v0.11.1.txt
+++ b/doc/source/v0.11.1.txt
@@ -61,6 +61,12 @@ API changes
 
     ``df.iloc[mask]`` will raise a ``ValueError``
 
+  - The ``raise_on_error`` argument to plotting functions is removed. Instead,
+    plotting functions raise a ``TypeError`` when the ``dtype`` of the object
+    is ``object`` to remind you to avoid ``object`` arrays whenever possible
+    and thus you should cast to an appropriate numeric dtype if you need to
+    plot something.
+
 
 
 Enhancements
@@ -119,7 +125,7 @@ Enhancements
 
     The last element yielded by the iterator will be a ``Series`` containing
     the last element of the longest string in the ``Series`` with all other
-    elements being ``NaN``. Here since ``'slow`` is the longest string
+    elements being ``NaN``. Here since ``'slow'`` is the longest string
     and there are no other strings with the same length ``'w'`` is the only
     non-null string in the yielded ``Series``.
 
@@ -160,9 +166,9 @@ Enhancements
     to specify custom column names of the returned DataFrame.
 
   - Plotting functions now raise a ``TypeError`` before trying to plot anything
-    if the associated objects have have a ``dtype`` of ``object`` (GH1818_).
-    This happens before any drawing takes place which elimnates any spurious
-    plots from showing up.
+    if the associated objects have have a ``dtype`` of ``object`` (GH1818_,
+    GH3572_).  This happens before any drawing takes place which elimnates any
+    spurious plots from showing up.
 
 Bug Fixes
 ~~~~~~~~~
@@ -234,3 +240,4 @@ on GitHub for a complete list.
 .. _GH3606: https://github.com/pydata/pandas/issues/3606
 .. _GH3656: https://github.com/pydata/pandas/issues/3656
 .. _GH1818: https://github.com/pydata/pandas/issues/1818
+.. _GH3572: https://github.com/pydata/pandas/issues/3572

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -187,6 +187,27 @@ class TestSeriesPlots(unittest.TestCase):
         from pandas.tools.plotting import bootstrap_plot
         _check_plot_works(bootstrap_plot, self.ts, size=10)
 
+    @slow
+    def test_all_invalid_plot_data(self):
+        s = Series(list('abcd'))
+        kinds = 'line', 'bar', 'barh', 'kde', 'density'
+
+        for kind in kinds:
+            self.assertRaises(TypeError, s.plot, kind=kind)
+
+    @slow
+    def test_partially_invalid_plot_data(self):
+        s = Series(['a', 'b', 1.0, 2])
+        kinds = 'line', 'bar', 'barh', 'kde', 'density'
+
+        for kind in kinds:
+            self.assertRaises(TypeError, s.plot, kind=kind)
+
+    @slow
+    def test_invalid_kind(self):
+        s = Series([1, 2])
+        self.assertRaises(ValueError, s.plot, kind='aasdf')
+
 
 class TestDataFramePlots(unittest.TestCase):
 
@@ -249,10 +270,8 @@ class TestDataFramePlots(unittest.TestCase):
         plt.close('all')
 
         df = DataFrame({'A': ["x", "y", "z"], 'B': [1,2,3]})
-        ax = df.plot(raise_on_error=False) # it works
+        ax = df.plot()
         self.assert_(len(ax.get_lines()) == 1) #B was plotted
-
-        self.assertRaises(Exception, df.plot)
 
     @slow
     def test_label(self):
@@ -687,6 +706,26 @@ class TestDataFramePlots(unittest.TestCase):
         self.assert_(xticks[0] < xticks[1])
         ydata = ax.lines[0].get_ydata()
         self.assert_(np.all(ydata == np.array([1.0, 2.0, 3.0])))
+
+    @slow
+    def test_all_invalid_plot_data(self):
+        kinds = 'line', 'bar', 'barh', 'kde', 'density'
+        df = DataFrame(list('abcd'))
+        for kind in kinds:
+            self.assertRaises(TypeError, df.plot, kind=kind)
+
+    @slow
+    def test_partially_invalid_plot_data(self):
+        kinds = 'line', 'bar', 'barh', 'kde', 'density'
+        df = DataFrame(np.random.randn(10, 2), dtype=object)
+        df[np.random.rand(df.shape[0]) > 0.5] = 'a'
+        for kind in kinds:
+            self.assertRaises(TypeError, df.plot, kind=kind)
+
+    @slow
+    def test_invalid_kind(self):
+        df = DataFrame(np.random.randn(10, 2))
+        self.assertRaises(ValueError, df.plot, kind='aasdf')
 
 class TestDataFrameGroupByPlots(unittest.TestCase):
 

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -700,10 +700,8 @@ class MPLPlot(object):
     """
     _default_rot = 0
 
-    _pop_attributes = ['label', 'style', 'logy', 'logx', 'loglog',
-                       'raise_on_error']
-    _attr_defaults = {'logy': False, 'logx': False, 'loglog': False,
-                      'raise_on_error': True}
+    _pop_attributes = ['label', 'style', 'logy', 'logx', 'loglog']
+    _attr_defaults = {'logy': False, 'logx': False, 'loglog': False}
 
     def __init__(self, data, kind=None, by=None, subplots=False, sharex=True,
                  sharey=False, use_index=True,
@@ -1203,27 +1201,17 @@ class LinePlot(MPLPlot):
                 else:
                     args = (ax, x, y, style)
 
-                try:
-                    newline = plotf(*args, **kwds)[0]
-                    lines.append(newline)
-                    leg_label = label
-                    if self.mark_right and self.on_right(i):
-                        leg_label += ' (right)'
-                    labels.append(leg_label)
-                    ax.grid(self.grid)
+                newline = plotf(*args, **kwds)[0]
+                lines.append(newline)
+                leg_label = label
+                if self.mark_right and self.on_right(i):
+                    leg_label += ' (right)'
+                labels.append(leg_label)
+                ax.grid(self.grid)
 
-                    if self._is_datetype():
-                        left, right = _get_xlim(lines)
-                        ax.set_xlim(left, right)
-                except AttributeError as inst: # non-numeric
-                    msg = ('Unable to plot data %s vs index %s,\n'
-                           'error was: %s' % (str(y), str(x), str(inst)))
-                    if not self.raise_on_error:
-                        print msg
-                    else:
-                        msg = msg + ('\nConsider setting raise_on_error=False'
-                                     'to suppress')
-                        raise TypeError(msg)
+                if self._is_datetype():
+                    left, right = _get_xlim(lines)
+                    ax.set_xlim(left, right)
 
             self._make_legend(lines, labels)
 
@@ -1242,22 +1230,12 @@ class LinePlot(MPLPlot):
             return label
 
         def _plot(data, col_num, ax, label, style, **kwds):
-            try:
-                newlines = tsplot(data, plotf, ax=ax, label=label,
-                                  style=style, **kwds)
-                ax.grid(self.grid)
-                lines.append(newlines[0])
-                leg_label = to_leg_label(label, col_num)
-                labels.append(leg_label)
-            except AttributeError as inst: #non-numeric
-                msg = ('Unable to plot %s,\n'
-                       'error was: %s' % (str(data), str(inst)))
-                if not self.raise_on_error:
-                    print msg
-                else:
-                    msg = msg + ('\nConsider setting raise_on_error=False'
-                                 'to suppress')
-                    raise TypeError(msg)
+            newlines = tsplot(data, plotf, ax=ax, label=label,
+                                style=style, **kwds)
+            ax.grid(self.grid)
+            lines.append(newlines[0])
+            leg_label = to_leg_label(label, col_num)
+            labels.append(leg_label)
 
         if isinstance(data, Series):
             ax = self._get_ax(0)  # self.axes[0]

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -87,18 +87,14 @@ class TestTSPlot(unittest.TestCase):
 
         idx = date_range('1/1/1987', freq='A', periods=3)
         df = DataFrame({'A': ["x", "y", "z"], 'B': [1,2,3]}, idx)
-        self.assertRaises(Exception, df.plot)
 
         plt.close('all')
         ax = df.plot(raise_on_error=False) # it works
         self.assert_(len(ax.get_lines()) == 1) #B was plotted
 
         plt.close('all')
-        self.assertRaises(Exception, df.A.plot)
 
-        plt.close('all')
-        ax = df['A'].plot(raise_on_error=False) # it works
-        self.assert_(len(ax.get_lines()) == 0)
+        self.assertRaises(TypeError, df['A'].plot)
 
     @slow
     def test_tsplot(self):

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -89,7 +89,7 @@ class TestTSPlot(unittest.TestCase):
         df = DataFrame({'A': ["x", "y", "z"], 'B': [1,2,3]}, idx)
 
         plt.close('all')
-        ax = df.plot(raise_on_error=False) # it works
+        ax = df.plot() # it works
         self.assert_(len(ax.get_lines()) == 1) #B was plotted
 
         plt.close('all')


### PR DESCRIPTION
Raise a `TypeError` alerting the user to the fact that they are trying to plot nonnumeric data, or if there are any numeric data plot those. closes #1818.
