### PR TITLE
ENH: allow to_csv to write multi-index columns, read_csv to read with header=list arg

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -34,6 +34,15 @@ pandas 0.11.1
     courtesy of @cpcloud. (GH3477_)
   - Support for reading Amazon S3 files. (GH3504_)
   - Added module for reading and writing Stata files: pandas.io.stata (GH1512_)
+  - Added support for writing in ``to_csv`` and reading in ``read_csv``,
+    multi-index columns. The ``header`` option in ``read_csv`` now accepts a
+    list of the rows from which to read the index. Added the option,
+    ``tupleize_cols`` to provide compatiblity for the pre 0.11.1 behavior of
+    writing and reading multi-index columns via a list of tuples. The default in
+    0.11.1 is to write lists of tuples and *not* interpret list of tuples as a 
+    multi-index column.  
+    Note: The default value will change in 0.12 to make the default *to* write and
+    read multi-index columns in the new format. (GH3571_, GH1651_, GH3141_)
 
 **Improvements to existing features**
 
@@ -180,6 +189,7 @@ pandas 0.11.1
 .. _GH3596: https://github.com/pydata/pandas/issues/3596
 .. _GH3617: https://github.com/pydata/pandas/issues/3617
 .. _GH3435: https://github.com/pydata/pandas/issues/3435
+<<<<<<< HEAD
 .. _GH3611: https://github.com/pydata/pandas/issues/3611
 .. _GH3062: https://github.com/pydata/pandas/issues/3062
 .. _GH3624: https://github.com/pydata/pandas/issues/3624
@@ -187,6 +197,11 @@ pandas 0.11.1
 .. _GH3601: https://github.com/pydata/pandas/issues/3601
 .. _GH3631: https://github.com/pydata/pandas/issues/3631
 .. _GH1512: https://github.com/pydata/pandas/issues/1512
+=======
+.. _GH3571: https://github.com/pydata/pandas/issues/3571
+.. _GH1651: https://github.com/pydata/pandas/issues/1651
+.. _GH3141: https://github.com/pydata/pandas/issues/3141
+>>>>>>> DOC: updated releasenotes, v0.11.1 whatsnew, io.rst
 
 
 pandas 0.11.0

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -115,6 +115,10 @@ They can take a number of arguments:
   - ``error_bad_lines``: if False then any lines causing an error will be skipped :ref:`bad lines <io.bad_lines>`
   - ``usecols``: a subset of columns to return, results in much faster parsing 
     time and lower memory usage.
+  - ``mangle_dup_columns``: boolean, default True, then duplicate columns will be specified 
+    as 'X.0'...'X.N', rather than 'X'...'X'
+  - ``multi_index_columns_compat``: boolean, default False, leave a list of tuples on columns
+    as is (default is to convert to a Multi Index on the columns)
 
 .. ipython:: python
    :suppress:
@@ -270,6 +274,9 @@ specified.
 
     data = 'C0,C_l0_g0,C_l0_g1\nC1,C_l1_g0,C_l1_g1\nR0,,\nR_l0_g0,R0C0,R0C1\nR_l0_g1,R1C0,R1C1\nR_l0_g2,R2C0,R2C1\n'
     pd.read_csv(StringIO(data), header=[0,1], index_col=[0])
+
+You can pass ``multi_index_columns_compat=True`` to preserve the pre-0.12 behavior of
+not converting a list of tuples in the columns to a Multi Index.
 
 .. _io.usecols:
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -57,7 +57,10 @@ They can take a number of arguments:
     specified, data types will be inferred.
   - ``header``: row number to use as the column names, and the start of the
     data.  Defaults to 0 if no ``names`` passed, otherwise ``None``. Explicitly
-    pass ``header=0`` to be able to replace existing names.
+    pass ``header=0`` to be able to replace existing names. The header can be
+    a list of integers that specify row locations for a multi-index on the columns
+    E.g. [0,1,3]. Interveaning rows that are not specified will be skipped.
+    (E.g. 2 in this example are skipped)
   - ``skiprows``: A collection of numbers for rows in the file to skip. Can
     also be an integer to skip the first ``n`` rows
   - ``index_col``: column number, column name, or list of column numbers/names,
@@ -252,6 +255,21 @@ If the header is in a row other than the first, pass the row number to
 
     data = 'skip this skip it\na,b,c\n1,2,3\n4,5,6\n7,8,9'
     pd.read_csv(StringIO(data), header=1)
+
+.. _io.multi_index_columns:
+
+Specifying a multi-index columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By specifying list of row locations for the ``header`` argument, you
+can read in a multi-index for the columns. Specifying non-consecutive
+rows will skip the interveaing rows. The ``index_col`` must also be
+specified.
+
+.. ipython:: python
+
+    data = 'C0,C_l0_g0,C_l0_g1\nC1,C_l1_g0,C_l1_g1\nR0,,\nR_l0_g0,R0C0,R0C1\nR_l0_g1,R1C0,R1C1\nR_l0_g2,R2C0,R2C1\n'
+    pd.read_csv(StringIO(data), header=[0,1], index_col=[0])
 
 .. _io.usecols:
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -115,10 +115,10 @@ They can take a number of arguments:
   - ``error_bad_lines``: if False then any lines causing an error will be skipped :ref:`bad lines <io.bad_lines>`
   - ``usecols``: a subset of columns to return, results in much faster parsing 
     time and lower memory usage.
-  - ``mangle_dup_columns``: boolean, default True, then duplicate columns will be specified 
+  - ``mangle_dupe_cols``: boolean, default True, then duplicate columns will be specified 
     as 'X.0'...'X.N', rather than 'X'...'X'
-  - ``multi_index_columns_compat``: boolean, default False, leave a list of tuples on columns
-    as is (default is to convert to a Multi Index on the columns)
+  - ``tupleize_cols``: boolean, default True, if False, convert a list of tuples
+    to a multi-index of columns, otherwise, leave the column index as a list of tuples
 
 .. ipython:: python
    :suppress:
@@ -259,24 +259,6 @@ If the header is in a row other than the first, pass the row number to
 
     data = 'skip this skip it\na,b,c\n1,2,3\n4,5,6\n7,8,9'
     pd.read_csv(StringIO(data), header=1)
-
-.. _io.multi_index_columns:
-
-Specifying a multi-index columns
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-By specifying list of row locations for the ``header`` argument, you
-can read in a multi-index for the columns. Specifying non-consecutive
-rows will skip the interveaing rows. The ``index_col`` must also be
-specified.
-
-.. ipython:: python
-
-    data = 'C0,C_l0_g0,C_l0_g1\nC1,C_l1_g0,C_l1_g1\nR0,,\nR_l0_g0,R0C0,R0C1\nR_l0_g1,R1C0,R1C1\nR_l0_g2,R2C0,R2C1\n'
-    pd.read_csv(StringIO(data), header=[0,1], index_col=[0])
-
-You can pass ``multi_index_columns_compat=True`` to preserve the pre-0.12 behavior of
-not converting a list of tuples in the columns to a Multi Index.
 
 .. _io.usecols:
 
@@ -787,6 +769,36 @@ column numbers to turn multiple columns into a ``MultiIndex``:
    df
    df.ix[1978]
 
+.. _io.multi_index_columns:
+
+Specifying a multi-index columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By specifying list of row locations for the ``header`` argument, you
+can read in a multi-index for the columns. Specifying non-consecutive
+rows will skip the interveaing rows.
+
+.. ipython:: python
+
+   from pandas.util.testing import makeCustomDataframe as mkdf
+   df = mkdf(5,3,r_idx_nlevels=2,c_idx_nlevels=4)
+   df.to_csv('mi.csv',tupleize_cols=False)
+   print open('mi.csv').read()
+   pd.read_csv('mi.csv',header=[0,1,2,3],index_col=[0,1],tupleize_cols=False)
+
+Note: The default behavior in 0.11.1 remains unchanged (``tupleize_cols=True``),
+but starting with 0.12, the default *to* write and read multi-index columns will be in the new 
+format (``tupleize_cols=False``)
+
+Note: If an ``index_col`` is not specified (e.g. you don't have an index, or wrote it
+with ``df.to_csv(..., index=False``), then any ``names`` on the columns index will be *lost*.
+
+.. ipython:: python
+   :suppress:
+
+   import os
+   os.remove('mi.csv')
+
 .. _io.sniff:
 
 Automatically "sniffing" the delimiter
@@ -870,6 +882,8 @@ function takes a number of arguments. Only the first is required.
   - ``sep`` : Field delimiter for the output file (default ",")
   - ``encoding``: a string representing the encoding to use if the contents are
     non-ascii, for python versions prior to 3
+  - ``tupleize_cols``: boolean, default True, if False, write as a list of tuples,
+    otherwise write in an expanded line format suitable for ``read_csv``
 
 Writing a formatted string
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -900,6 +914,9 @@ The Series object also has a ``to_string`` method, but with only the ``buf``,
 ``na_rep``, ``float_format`` arguments. There is also a ``length`` argument
 which, if set to ``True``, will additionally output the length of the Series.
 
+
+HTML
+----
 
 Reading HTML format
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/v0.11.1.txt
+++ b/doc/source/v0.11.1.txt
@@ -73,12 +73,46 @@ Enhancements
       an index with a different frequency than the existing, or attempting
       to append an index with a different name than the existing
     - support datelike columns with a timezone as data_columns (GH2852_)
+
   - ``fillna`` methods now raise a ``TypeError`` if the ``value`` parameter is
     a list or tuple.
   - Added module for reading and writing Stata files: pandas.io.stata (GH1512_)
   - ``DataFrame.replace()`` now allows regular expressions on contained
     ``Series`` with object dtype. See the examples section in the regular docs
     :ref:`Replacing via String Expression <missing_data.replace_expression>`
+
+  - Multi-index column support for reading and writing csvs
+
+    - The ``header`` option in ``read_csv`` now accepts a
+      list of the rows from which to read the index.
+
+    - The option, ``tupleize_cols`` can now be specified in both ``to_csv`` and
+      ``read_csv``, to provide compatiblity for the pre 0.11.1 behavior of
+      writing and reading multi-index columns via a list of tuples. The default in
+      0.11.1 is to write lists of tuples and *not* interpret list of tuples as a 
+      multi-index column.  
+
+      Note: The default behavior in 0.11.1 remains unchanged, but starting with 0.12,
+      the default *to* write and read multi-index columns will be in the new 
+      format. (GH3571_, GH1651_, GH3141_)
+
+    - If an ``index_col`` is not specified (e.g. you don't have an index, or wrote it
+      with ``df.to_csv(..., index=False``), then any ``names`` on the columns index will 
+      be *lost*.
+
+    .. ipython:: python
+
+       from pandas.util.testing import makeCustomDataframe as mkdf
+       df = mkdf(5,3,r_idx_nlevels=2,c_idx_nlevels=4)
+       df.to_csv('mi.csv',tupleize_cols=False)
+       print open('mi.csv').read()
+       pd.read_csv('mi.csv',header=[0,1,2,3],index_col=[0,1],tupleize_cols=False)
+
+    .. ipython:: python
+       :suppress:
+
+       import os
+       os.remove('mi.csv')
 
 See the `full release notes
 <https://github.com/pydata/pandas/blob/master/RELEASE.rst>`__ or issue tracker
@@ -96,3 +130,6 @@ on GitHub for a complete list.
 .. _GH1512: https://github.com/pydata/pandas/issues/1512
 .. _GH2285: https://github.com/pydata/pandas/issues/2285
 .. _GH3631: https://github.com/pydata/pandas/issues/3631
+.. _GH3571: https://github.com/pydata/pandas/issues/3571
+.. _GH1651: https://github.com/pydata/pandas/issues/1651
+.. _GH3141: https://github.com/pydata/pandas/issues/3141

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -963,48 +963,49 @@ class CSVFormatter(object):
         encoded_labels = []
 
         has_aliases = isinstance(header, (tuple, list, np.ndarray))
-        if has_aliases or self.header:
+        if not (has_aliases or self.header):
+            return
 
-            if self.index:
-                # should write something for index label
-                if index_label is not False:
-                    if index_label is None:
-                        if isinstance(obj.index, MultiIndex):
-                            index_label = []
-                            for i, name in enumerate(obj.index.names):
-                                if name is None:
-                                    name = ''
-                                index_label.append(name)
-                        else:
-                            index_label = obj.index.name
-                            if index_label is None:
-                                index_label = ['']
-                            else:
-                                index_label = [index_label]
-                    elif not isinstance(index_label, (list, tuple, np.ndarray)):
-                        # given a string for a DF with Index
-                        index_label = [index_label]
-
-                    encoded_labels = list(index_label)
-                else:
-                    encoded_labels = []
-
-                if has_aliases:
-                    if len(header) != len(cols):
-                        raise ValueError(('Writing %d cols but got %d aliases'
-                                          % (len(cols), len(header))))
+        if self.index:
+            # should write something for index label
+            if index_label is not False:
+                if index_label is None:
+                    if isinstance(obj.index, MultiIndex):
+                        index_label = []
+                        for i, name in enumerate(obj.index.names):
+                            if name is None:
+                                name = ''
+                            index_label.append(name)
                     else:
-                        write_cols = header
-                else:
-                    write_cols = cols
+                        index_label = obj.index.name
+                        if index_label is None:
+                            index_label = ['']
+                        else:
+                            index_label = [index_label]
+                elif not isinstance(index_label, (list, tuple, np.ndarray)):
+                    # given a string for a DF with Index
+                    index_label = [index_label]
 
-                if not has_mi_columns:
-                    encoded_labels += list(write_cols)
-
+                encoded_labels = list(index_label)
             else:
+                encoded_labels = []
 
-                if not has_mi_columns:
-                    encoded_labels += list(cols)
+            if has_aliases:
+                if len(header) != len(cols):
+                    raise ValueError(('Writing %d cols but got %d aliases'
+                                      % (len(cols), len(header))))
+                else:
+                    write_cols = header
+            else:
+                write_cols = cols
+
+            if not has_mi_columns:
+                encoded_labels += list(write_cols)
+
+        else:
+
+            if not has_mi_columns:
+                encoded_labels += list(cols)
 
         # write out the mi
         if has_mi_columns:

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -772,9 +772,10 @@ def _get_level_lengths(levels,sentinal=''):
 class CSVFormatter(object):
 
     def __init__(self, obj, path_or_buf, sep=",", na_rep='', float_format=None,
-               cols=None, header=True, index=True, index_label=None,
-               mode='w', nanRep=None, encoding=None, quoting=None,
-               line_terminator='\n', chunksize=None, engine=None):
+                 cols=None, header=True, index=True, index_label=None,
+                 mode='w', nanRep=None, encoding=None, quoting=None,
+                 line_terminator='\n', chunksize=None, engine=None,
+                 multi_index_columns_compat=False):
 
         self.engine = engine  # remove for 0.12
 
@@ -803,6 +804,7 @@ class CSVFormatter(object):
             msg= "columns.is_unique == False not supported with engine='python'"
             raise NotImplementedError(msg)
 
+        self.multi_index_columns_compat=multi_index_columns_compat
         if cols is not None:
             if isinstance(cols,Index):
                 cols = cols.to_native_types(na_rep=na_rep,float_format=float_format)
@@ -959,7 +961,8 @@ class CSVFormatter(object):
         index_label = self.index_label
         cols = self.cols
         header = self.header
-        has_mi_columns = isinstance(obj.columns, MultiIndex)
+        has_mi_columns = isinstance(obj.columns, MultiIndex
+                                    ) and not self.multi_index_columns_compat
         encoded_labels = []
 
         has_aliases = isinstance(header, (tuple, list, np.ndarray))

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1250,7 +1250,7 @@ class DataFrame(NDFrame):
 
     @classmethod
     def from_csv(cls, path, header=0, sep=',', index_col=0,
-                 parse_dates=True, encoding=None):
+                 parse_dates=True, encoding=None, tupleize_cols=False):
         """
         Read delimited file into DataFrame
 
@@ -1266,6 +1266,9 @@ class DataFrame(NDFrame):
             is used. Different default from read_table
         parse_dates : boolean, default True
             Parse dates. Different default from read_table
+        tupleize_cols : boolean, default True
+            write multi_index columns as a list of tuples (if True)
+            or new (expanded format) if False)
 
         Notes
         -----
@@ -1280,7 +1283,7 @@ class DataFrame(NDFrame):
         from pandas.io.parsers import read_table
         return read_table(path, header=header, sep=sep,
                           parse_dates=parse_dates, index_col=index_col,
-                          encoding=encoding)
+                          encoding=encoding,tupleize_cols=False)
 
     @classmethod
     def from_dta(dta, path, parse_dates=True, convert_categoricals=True, encoding=None, index_col=None):
@@ -1392,7 +1395,7 @@ class DataFrame(NDFrame):
                cols=None, header=True, index=True, index_label=None,
                mode='w', nanRep=None, encoding=None, quoting=None,
                line_terminator='\n', chunksize=None,
-               multi_index_columns_compat=False, **kwds):
+               tupleize_cols=True, **kwds):
         """
         Write DataFrame to a comma-separated values (csv) file
 
@@ -1430,9 +1433,9 @@ class DataFrame(NDFrame):
         quoting : optional constant from csv module
             defaults to csv.QUOTE_MINIMAL
         chunksize : rows to write at a time
-        multi_index_columns_compat : boolean, default False
+        tupleize_cols : boolean, default True
             write multi_index columns as a list of tuples (if True)
-            or new (expanded format)m if False)
+            or new (expanded format) if False)
         """
         if nanRep is not None:  # pragma: no cover
             import warnings
@@ -1450,7 +1453,7 @@ class DataFrame(NDFrame):
                                          header=header, index=index,
                                          index_label=index_label,mode=mode,
                                          chunksize=chunksize,engine=kwds.get("engine"),
-                                         multi_index_columns_compat=multi_index_columns_compat)
+                                         tupleize_cols=tupleize_cols)
             formatter.save()
 
     def to_excel(self, excel_writer, sheet_name='sheet1', na_rep='',

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1391,7 +1391,8 @@ class DataFrame(NDFrame):
     def to_csv(self, path_or_buf, sep=",", na_rep='', float_format=None,
                cols=None, header=True, index=True, index_label=None,
                mode='w', nanRep=None, encoding=None, quoting=None,
-               line_terminator='\n', chunksize=None,**kwds):
+               line_terminator='\n', chunksize=None,
+               multi_index_columns_compat=False, **kwds):
         """
         Write DataFrame to a comma-separated values (csv) file
 
@@ -1429,6 +1430,9 @@ class DataFrame(NDFrame):
         quoting : optional constant from csv module
             defaults to csv.QUOTE_MINIMAL
         chunksize : rows to write at a time
+        multi_index_columns_compat : boolean, default False
+            write multi_index columns as a list of tuples (if True)
+            or new (expanded format)m if False)
         """
         if nanRep is not None:  # pragma: no cover
             import warnings
@@ -1445,7 +1449,8 @@ class DataFrame(NDFrame):
                                          float_format=float_format, cols=cols,
                                          header=header, index=index,
                                          index_label=index_label,mode=mode,
-                                         chunksize=chunksize,engine=kwds.get("engine") )
+                                         chunksize=chunksize,engine=kwds.get("engine"),
+                                         multi_index_columns_compat=multi_index_columns_compat)
             formatter.save()
 
     def to_excel(self, excel_writer, sheet_name='sheet1', na_rep='',

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -809,8 +809,8 @@ class ParserBase(object):
         # if we find 'Unnamed' all of a single level, then our header was too long
         for n in range(len(columns[0])):
             if all([ 'Unnamed' in c[n] for c in columns ]):
-                raise Exception("Passed header=[%s] are too many rows for this "
-                                "multi_index of columns" % ','.join([ str(x) for x in self.header ]))
+                raise _parser.CParserError("Passed header=[%s] are too many rows for this "
+                                           "multi_index of columns" % ','.join([ str(x) for x in self.header ]))
 
         # clean the column names (if we have an index_col)
         if len(ic):

--- a/pandas/io/tests/test_cparser.py
+++ b/pandas/io/tests/test_cparser.py
@@ -179,7 +179,7 @@ class TestCParser(unittest.TestCase):
         reader = TextReader(StringIO(data), delimiter=',', header=2,
                             as_recarray=True)
         header = reader.header
-        expected = ['a', 'b', 'c']
+        expected = [['a', 'b', 'c']]
         self.assertEquals(header, expected)
 
         recs = reader.read()

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -1014,20 +1014,30 @@ R_l0_g4,R_l1_g4,R4C0,R4C1,R4C2
 
         # basic test with both engines
         for engine in ['c','python']:
-            df = read_csv(StringIO(data), header=[0,2,3,4],index_col=[0,1], engine=engine)
+            df = read_csv(StringIO(data), header=[0,2,3,4],index_col=[0,1], tupleize_cols=False,
+                          engine=engine)
             tm.assert_frame_equal(df, expected)
 
-        # must specify index_col
-        self.assertRaises(Exception, read_csv, StringIO(data), header=[0,1,2,3])
+        # skipping lines in the header
+        df = read_csv(StringIO(data), header=[0,2,3,4],index_col=[0,1], tupleize_cols=False)
+        tm.assert_frame_equal(df, expected)
+
+        #### invalid options ####
 
         # no as_recarray
         self.assertRaises(Exception, read_csv, StringIO(data), header=[0,1,2,3], 
-                          index_col=[0,1], as_recarray=True)
+                          index_col=[0,1], as_recarray=True, tupleize_cols=False)
 
-        # skipping lines in the header
-        df = read_csv(StringIO(data), header=[0,2,3,4],index_col=[0,1])
-        tm.assert_frame_equal(df, expected)
-
+        # names
+        self.assertRaises(Exception, read_csv, StringIO(data), header=[0,1,2,3], 
+                          index_col=[0,1], names=['foo','bar'], tupleize_cols=False)
+        # usecols
+        self.assertRaises(Exception, read_csv, StringIO(data), header=[0,1,2,3], 
+                          index_col=[0,1], usecols=['foo','bar'], tupleize_cols=False)
+        # non-numeric index_col
+        self.assertRaises(Exception, read_csv, StringIO(data), header=[0,1,2,3], 
+                          index_col=['foo','bar'], tupleize_cols=False)
+        
     def test_pass_names_with_index(self):
         lines = self.data1.split('\n')
         no_header = '\n'.join(lines[1:])

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -1012,9 +1012,10 @@ R_l0_g3,R_l1_g3,R3C0,R3C1,R3C2
 R_l0_g4,R_l1_g4,R4C0,R4C1,R4C2
 """
 
-        # python-engine
-        self.assertRaises(Exception, read_csv, StringIO(data), header=[0,1,2,3], 
-                          index_col=[0,1], engine='python')
+        # basic test with both engines
+        for engine in ['c','python']:
+            df = read_csv(StringIO(data), header=[0,2,3,4],index_col=[0,1], engine=engine)
+            tm.assert_frame_equal(df, expected)
 
         # must specify index_col
         self.assertRaises(Exception, read_csv, StringIO(data), header=[0,1,2,3])

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -20,6 +20,7 @@ from pandas.io.parsers import (read_csv, read_table, read_fwf,
                                TextFileReader, TextParser)
 from pandas.util.testing import (assert_almost_equal,
                                  assert_series_equal,
+                                 makeCustomDataframe as mkdf,
                                  network,
                                  ensure_clean)
 import pandas.util.testing as tm
@@ -992,6 +993,38 @@ baz,12,13,14,15
 
         df = self.read_csv(StringIO(data), header=2, index_col=0)
         expected = self.read_csv(StringIO(data2), header=0, index_col=0)
+        tm.assert_frame_equal(df, expected)
+
+    def test_header_multi_index(self):
+        expected = mkdf(5,3,r_idx_nlevels=2,c_idx_nlevels=4)
+
+        data = """\
+C0,,C_l0_g0,C_l0_g1,C_l0_g2
+
+C1,,C_l1_g0,C_l1_g1,C_l1_g2
+C2,,C_l2_g0,C_l2_g1,C_l2_g2
+C3,,C_l3_g0,C_l3_g1,C_l3_g2
+R0,R1,,,
+R_l0_g0,R_l1_g0,R0C0,R0C1,R0C2
+R_l0_g1,R_l1_g1,R1C0,R1C1,R1C2
+R_l0_g2,R_l1_g2,R2C0,R2C1,R2C2
+R_l0_g3,R_l1_g3,R3C0,R3C1,R3C2
+R_l0_g4,R_l1_g4,R4C0,R4C1,R4C2
+"""
+
+        # python-engine
+        self.assertRaises(Exception, read_csv, StringIO(data), header=[0,1,2,3], 
+                          index_col=[0,1], engine='python')
+
+        # must specify index_col
+        self.assertRaises(Exception, read_csv, StringIO(data), header=[0,1,2,3])
+
+        # no as_recarray
+        self.assertRaises(Exception, read_csv, StringIO(data), header=[0,1,2,3], 
+                          index_col=[0,1], as_recarray=True)
+
+        # skipping lines in the header
+        df = read_csv(StringIO(data), header=[0,2,3,4],index_col=[0,1])
         tm.assert_frame_equal(df, expected)
 
     def test_pass_names_with_index(self):

--- a/pandas/src/parser.pyx
+++ b/pandas/src/parser.pyx
@@ -252,7 +252,7 @@ cdef class TextReader:
         object encoding
         object compression
         object mangle_dupe_cols
-        object multi_index_columns_compat
+        object tupleize_cols
         set noconvert, usecols
 
     def __cinit__(self, source,
@@ -306,13 +306,13 @@ cdef class TextReader:
                   skip_footer=0,
                   verbose=False,
                   mangle_dupe_cols=True,
-                  multi_index_columns_compat=False):
+                  tupleize_cols=True):
 
         self.parser = parser_new()
         self.parser.chunksize = tokenize_chunksize
 
         self.mangle_dupe_cols=mangle_dupe_cols
-        self.multi_index_columns_compat=multi_index_columns_compat
+        self.tupleize_cols=tupleize_cols
 
         # For timekeeping
         self.clocks = []
@@ -452,6 +452,7 @@ cdef class TextReader:
             if isinstance(header, list) and len(header):
                 # need to artifically skip the final line
                 # which is still a header line
+                header = list(header)
                 header.append(header[-1]+1)
 
                 self.parser.header_start = header[0]
@@ -611,7 +612,7 @@ cdef class TextReader:
                             name = 'Unnamed: %d' % i
 
                     count = counts.get(name, 0)
-                    if count > 0 and self.mangle_dupe_cols:
+                    if count > 0 and self.mangle_dupe_cols and not self.has_mi_columns:
                         this_header.append('%s.%d' % (name, count))
                     else:
                         this_header.append(name)

--- a/pandas/src/parser.pyx
+++ b/pandas/src/parser.pyx
@@ -143,6 +143,8 @@ cdef extern from "parser/tokenizer.h":
         char thousands
 
         int header # Boolean: 1: has header, 0: no header
+        int header_start # header row start
+        int header_end # header row end
 
         void *skipset
         int skip_footer
@@ -242,7 +244,7 @@ cdef class TextReader:
         object na_values, true_values, false_values
         object memory_map
         object as_recarray
-        object header, names
+        object header, names, header_start, header_end
         object low_memory
         object skiprows
         object compact_ints, use_unsigned
@@ -256,6 +258,8 @@ cdef class TextReader:
                   delimiter=b',',
 
                   header=0,
+                  header_start=0,
+                  header_end=0,
                   names=None,
 
                   memory_map=False,
@@ -435,11 +439,28 @@ cdef class TextReader:
         # TODO: no header vs. header is not the first row
         if header is None:
             # sentinel value
+            self.parser.header_start = -1
+            self.parser.header_end = -1
             self.parser.header = -1
             self.parser_start = 0
+            self.header = []
         else:
-            self.parser.header = header
-            self.parser_start = header + 1
+            if isinstance(header, list) and len(header):
+                # need to artifically skip the final line
+                # which is still a header line
+                header.append(header[-1]+1)
+
+                self.parser.header_start = header[0]
+                self.parser.header_end = header[-1]
+                self.parser.header = header[0]
+                self.parser_start = header[-1] + 1
+                self.header = header
+            else:
+                self.parser.header_start = header
+                self.parser.header_end = header
+                self.parser.header = header
+                self.parser_start = header + 1
+                self.header = [ header ]
 
         self.names = names
         self.header, self.table_width = self._get_header()
@@ -534,8 +555,10 @@ cdef class TextReader:
                           ' got %s type' % type(source))
 
     cdef _get_header(self):
+        # header is now a list of lists, so field_count should use header[0]
+
         cdef:
-            size_t i, start, data_line, field_count, passed_count
+            size_t i, start, data_line, field_count, passed_count, hr
             char *word
             object name
             int status
@@ -544,49 +567,53 @@ cdef class TextReader:
 
         header = []
 
-        if self.parser.header >= 0:
+        if self.parser.header_start >= 0:
+
             # Header is in the file
+            for hr in self.header:
 
-            if self.parser.lines < self.parser.header + 1:
-                self._tokenize_rows(self.parser.header + 2)
+                this_header = []
 
-            # e.g., if header=3 and file only has 2 lines
-            if self.parser.lines < self.parser.header + 1:
-                raise CParserError('Passed header=%d but only %d lines in file'
-                                   % (self.parser.header, self.parser.lines))
+                if self.parser.lines < hr + 1:
+                    self._tokenize_rows(hr + 2)
 
-            field_count = self.parser.line_fields[self.parser.header]
-            start = self.parser.line_start[self.parser.header]
+                # e.g., if header=3 and file only has 2 lines
+                if self.parser.lines < hr + 1:
+                    raise CParserError('Passed header=%d but only %d lines in file'
+                                       % (self.parser.header, self.parser.lines))
 
-            # TODO: Py3 vs. Py2
-            counts = {}
-            for i in range(field_count):
-                word = self.parser.words[start + i]
+                field_count = self.parser.line_fields[hr]
+                start = self.parser.line_start[hr]
 
-                if self.c_encoding == NULL and not PY3:
-                    name = PyBytes_FromString(word)
-                else:
-                    if self.c_encoding == NULL or self.c_encoding == b'utf-8':
-                        name = PyUnicode_FromString(word)
+                # TODO: Py3 vs. Py2
+                counts = {}
+                for i in range(field_count):
+                    word = self.parser.words[start + i]
+
+                    if self.c_encoding == NULL and not PY3:
+                        name = PyBytes_FromString(word)
                     else:
-                        name = PyUnicode_Decode(word, strlen(word),
-                                                self.c_encoding, errors)
+                        if self.c_encoding == NULL or self.c_encoding == b'utf-8':
+                            name = PyUnicode_FromString(word)
+                        else:
+                            name = PyUnicode_Decode(word, strlen(word),
+                                                    self.c_encoding, errors)
 
-                if name == '':
-                    name = 'Unnamed: %d' % i
+                    if name == '':
+                        name = 'Unnamed: %d' % i
 
+                    count = counts.get(name, 0)
+                    if count > 0 and self.mangle_dupe_cols:
+                        this_header.append('%s.%d' % (name, count))
+                    else:
+                        this_header.append(name)
+                    counts[name] = count + 1
 
-                count = counts.get(name, 0)
-                if count > 0 and self.mangle_dupe_cols:
-                    header.append('%s.%d' % (name, count))
-                else:
-                    header.append(name)
-                counts[name] = count + 1
-
-            data_line = self.parser.header + 1
+                data_line = hr + 1
+                header.append(this_header)
 
             if self.names is not None:
-                header = self.names
+                header = [ self.names ]
 
         elif self.names is not None:
             # Enforce this unless usecols
@@ -597,11 +624,11 @@ cdef class TextReader:
             if self.parser.lines < 1:
                 self._tokenize_rows(1)
 
-            header = self.names
+            header = [ self.names ]
             data_line = 0
 
             if self.parser.lines < 1:
-                field_count = len(header)
+                field_count = len(header[0])
             else:
                 field_count = self.parser.line_fields[data_line]
         else:
@@ -613,7 +640,7 @@ cdef class TextReader:
 
         # Corner case, not enough lines in the file
         if self.parser.lines < data_line + 1:
-            field_count = len(header)
+            field_count = len(header[0])
         else: # not self.has_usecols:
 
             field_count = self.parser.line_fields[data_line]
@@ -622,7 +649,7 @@ cdef class TextReader:
             if self.names is not None:
                 field_count = max(field_count, len(self.names))
 
-            passed_count = len(header)
+            passed_count = len(header[0])
 
             # if passed_count > field_count:
             #     raise CParserError('Column names have %d fields, '
@@ -1038,10 +1065,10 @@ cdef class TextReader:
             if self.header is not None:
                 j = i - self.leading_cols
                 # hack for #2442
-                if j == len(self.header):
+                if j == len(self.header[0]):
                     return j
                 else:
-                    return self.header[j]
+                    return self.header[0][j]
             else:
                 return None
 

--- a/pandas/src/parser.pyx
+++ b/pandas/src/parser.pyx
@@ -1789,6 +1789,9 @@ def _to_structured_array(dict columns, object names):
 
     if names is None:
         names = ['%d' % i for i in range(len(columns))]
+    else:
+        # single line header
+        names = names[0]
 
     dt = np.dtype([(str(name), columns[i].dtype)
                    for i, name in enumerate(names)])

--- a/pandas/src/parser.pyx
+++ b/pandas/src/parser.pyx
@@ -244,7 +244,7 @@ cdef class TextReader:
         object na_values, true_values, false_values
         object memory_map
         object as_recarray
-        object header, names, header_start, header_end
+        object header, orig_header, names, header_start, header_end
         object low_memory
         object skiprows
         object compact_ints, use_unsigned
@@ -441,6 +441,7 @@ cdef class TextReader:
 
         # TODO: no header vs. header is not the first row
         self.has_mi_columns = 0
+        self.orig_header = header
         if header is None:
             # sentinel value
             self.parser.header_start = -1
@@ -585,8 +586,11 @@ cdef class TextReader:
 
                 # e.g., if header=3 and file only has 2 lines
                 if self.parser.lines < hr + 1:
-                    raise CParserError('Passed header=%d but only %d lines in file'
-                                       % (self.parser.header, self.parser.lines))
+                    msg = self.orig_header
+                    if isinstance(msg,list):
+                           msg = "[%s], len of %d," % (','.join([ str(m) for m in msg ]),len(msg))
+                    raise CParserError('Passed header=%s but only %d lines in file'
+                                       % (msg, self.parser.lines))
 
                 field_count = self.parser.line_fields[hr]
                 start = self.parser.line_start[hr]

--- a/pandas/src/parser/tokenizer.c
+++ b/pandas/src/parser/tokenizer.c
@@ -463,7 +463,7 @@ static int end_line(parser_t *self) {
 
     /* printf("Line: %d, Fields: %d, Ex-fields: %d\n", self->lines, fields, ex_fields); */
 
-    if (!(self->lines <= self->header + 1)
+    if (!(self->lines <= self->header_end + 1)
         && (self->expected_fields < 0 && fields > ex_fields)) {
         // increment file line count
         self->file_lines++;
@@ -498,7 +498,7 @@ static int end_line(parser_t *self) {
     }
     else {
         /* missing trailing delimiters */
-        if ((self->lines >= self->header + 1) && fields < ex_fields) {
+        if ((self->lines >= self->header_end + 1) && fields < ex_fields) {
 
             /* Might overrun the buffer when closing fields */
             if (make_stream_space(self, ex_fields - fields) < 0) {

--- a/pandas/src/parser/tokenizer.h
+++ b/pandas/src/parser/tokenizer.h
@@ -195,6 +195,8 @@ typedef struct parser_t {
     char thousands;
 
     int header; // Boolean: 1: has header, 0: no header
+    int header_start; // header row start
+    int header_end;   // header row end
 
     void *skipset;
     int skip_footer;

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4991,7 +4991,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         with ensure_clean(pname) as path:
             # GH3571, GH1651, GH3141
 
-            # column & index are multi-iindex
+            # column & index are multi-index
             df = mkdf(5,3,r_idx_nlevels=2,c_idx_nlevels=4)
             df.to_csv(path)
             result = read_csv(path,header=[0,1,2,3],index_col=[0,1])
@@ -5001,6 +5001,22 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
             df = mkdf(5,3,r_idx_nlevels=1,c_idx_nlevels=4)
             df.to_csv(path)
             result = read_csv(path,header=[0,1,2,3],index_col=0)
+            assert_frame_equal(df,result)
+
+            # dup column names?
+            df = mkdf(5,3,r_idx_nlevels=3,c_idx_nlevels=4)
+            df.to_csv(path)
+            result = read_csv(path,header=[0,1,2,3],index_col=[0,1])
+            result.columns = ['R2','A','B','C']
+            new_result = result.reset_index().set_index(['R0','R1','R2'])
+            new_result.columns = df.columns
+            assert_frame_equal(df,new_result)
+
+            # column & index are multi-index (compatibility)
+            df = mkdf(5,3,r_idx_nlevels=2,c_idx_nlevels=4)
+            df.to_csv(path,multi_index_columns_compat=True)
+            result = read_csv(path,header=0,index_col=[0,1],multi_index_columns_compat=True)
+            result.columns = df.columns
             assert_frame_equal(df,result)
 
         with ensure_clean(pname) as path:

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5037,6 +5037,13 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
             result.columns.names = df.columns.names
             assert_frame_equal(df,result)
 
+            # tupleize_cols=True and index=False
+            df = _make_frame(True)
+            df.to_csv(path,tupleize_cols=True,index=False)
+            result = read_csv(path,header=0,tupleize_cols=True,index_col=None)
+            result.columns = df.columns
+            assert_frame_equal(df,result)
+
             # whatsnew example
             df = _make_frame()
             df.to_csv(path,tupleize_cols=False)
@@ -5060,6 +5067,18 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
             df.to_csv(path,tupleize_cols=False)
 
             # catch invalid headers
+            try:
+                read_csv(path,tupleize_cols=False,header=range(3),index_col=0)
+            except (Exception), detail:
+                if not str(detail).startswith('Passed header=[0,1,2] are too many rows for this multi_index of columns'):
+                    raise AssertionError("failure in read_csv header=range(3)")
+
+            try:
+                read_csv(path,tupleize_cols=False,header=range(7),index_col=0)  
+            except (Exception), detail:
+                if not str(detail).startswith('Passed header=[0,1,2,3,4,5,6], len of 7, but only 6 lines in file'):
+                    raise AssertionError("failure in read_csv header=range(7)")
+
             for i in [3,4,5,6,7]: 
                  self.assertRaises(Exception, read_csv, path, tupleize_cols=False, header=range(i), index_col=0)
             self.assertRaises(Exception, read_csv, path, tupleize_cols=False, header=[0,2], index_col=0)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4755,9 +4755,13 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         def _do_test(df,path,r_dtype=None,c_dtype=None,rnlvl=None,cnlvl=None,
                      dupe_col=False):
 
+               header = 0
+               if cnlvl:
+                    header = range(cnlvl)
+
                with ensure_clean(path) as path:
                     df.to_csv(path,encoding='utf8',chunksize=chunksize)
-                    recons = DataFrame.from_csv(path,parse_dates=False)
+                    recons = DataFrame.from_csv(path,header=header,parse_dates=False)
 
                def _to_uni(x):
                    if not isinstance(x,unicode):
@@ -4772,16 +4776,6 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
                    ix=MultiIndex.from_arrays([list(recons.index)]+delta_lvl)
                    recons.index = ix
                    recons = recons.iloc[:,rnlvl-1:]
-
-               if cnlvl:
-                   def stuple_to_tuple(x):
-                       import re
-                       x = x.split(",")
-                       x = map(lambda x: re.sub("[\'\"\s\(\)]","",x),x)
-                       return x
-
-                   cols=MultiIndex.from_tuples(map(stuple_to_tuple,recons.columns))
-                   recons.columns = cols
 
                type_map = dict(i='i',f='f',s='O',u='O',dt='O',p='O')
                if r_dtype:
@@ -4826,7 +4820,6 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
                         df.columns = np.array(df.columns,dtype=c_dtype )
 
                assert_frame_equal(df, recons,check_names=False,check_less_precise=True)
-
 
         N = 100
         chunksize=1000

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4996,13 +4996,19 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
              self.tsframe.index = old_index  # needed if setUP becomes classmethod
 
         with ensure_clean(pname) as path:
-            # column & index are mi
-            import pdb; pdb.set_trace()
+            # GH3571, GH1651, GH3141
+
+            # column & index are multi-iindex
             df = mkdf(5,3,r_idx_nlevels=2,c_idx_nlevels=4)
             df.to_csv(path)
+            result = read_csv(path,header=[0,1,2,3],index_col=[0,1])
+            assert_frame_equal(df,result)
 
-            result = pd.read_csv(path,header=[0,1,2,3],index_col=[0,1])
-
+            # column is mi
+            df = mkdf(5,3,r_idx_nlevels=1,c_idx_nlevels=4)
+            df.to_csv(path)
+            result = read_csv(path,header=[0,1,2,3],index_col=0)
+            assert_frame_equal(df,result)
 
         with ensure_clean(pname) as path:
             # empty

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4962,6 +4962,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         frame.index = new_index
 
         with ensure_clean(pname) as path:
+
              frame.to_csv(path, header=False)
              frame.to_csv(path, cols=['A', 'B'])
 
@@ -4973,7 +4974,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
              self.assertEqual(frame.index.names, df.index.names)
              self.frame.index = old_index  # needed if setUP becomes a classmethod
 
-              # try multiindex with dates
+             # try multiindex with dates
              tsframe = self.tsframe
              old_index = tsframe.index
              new_index = [old_index, np.arange(len(old_index))]
@@ -4993,6 +4994,15 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
              recons = DataFrame.from_csv(path, index_col=None)
              assert_almost_equal(recons.values, self.tsframe.values)
              self.tsframe.index = old_index  # needed if setUP becomes classmethod
+
+        with ensure_clean(pname) as path:
+            # column & index are mi
+            import pdb; pdb.set_trace()
+            df = mkdf(5,3,r_idx_nlevels=2,c_idx_nlevels=4)
+            df.to_csv(path)
+
+            result = pd.read_csv(path,header=[0,1,2,3],index_col=[0,1])
+
 
         with ensure_clean(pname) as path:
             # empty


### PR DESCRIPTION
In theory should close:
#3571, #1651, #3141

Works, but a couple of issues/caveats:
-  ~~index_col needs to be specified as an integer list (can be fixed)~~
- header is a list of rows to read that contain the multi-index,
  a row that is skipped (e.g. [0,1,3,5], will just be skipped, like a comment)
- the writing format might be a bit odd: the col names go in the first column,
  other index_cols are blanks (they are separated, just == '')
  The names of an multi-index on the index are after the columns and before the data,
  and are a full row (but blank after the row names).
- ~~I am not sure if we should allow `df.to_csv('path',index=False)` when have a multi-index columns, could just ban it I guess (mainly as it screws up the write format, and then where do you put the names?)~~
- ~~The `cols` argument needs testing and prob is broken when using multi-index on the columns (it really should be specified as a tuple I think, but that is work, so maybe just ban it when using multi-index columns)~~
- needs more testing 

```
In [14]: df = mkdf(5,3,r_idx_nlevels=2,c_idx_nlevels=4)

In [15]: df.to_csv('test.csv')

In [16]: !cat 'test.csv'
C0,,C_l0_g0,C_l0_g1,C_l0_g2
C1,,C_l1_g0,C_l1_g1,C_l1_g2
C2,,C_l2_g0,C_l2_g1,C_l2_g2
C3,,C_l3_g0,C_l3_g1,C_l3_g2
R0,R1,,,
R_l0_g0,R_l1_g0,R0C0,R0C1,R0C2
R_l0_g1,R_l1_g1,R1C0,R1C1,R1C2
R_l0_g2,R_l1_g2,R2C0,R2C1,R2C2
R_l0_g3,R_l1_g3,R3C0,R3C1,R3C2
R_l0_g4,R_l1_g4,R4C0,R4C1,R4C2

In [17]: res = read_csv('test.csv',header=[0,1,2,3],index_col=[0,1])

In [18]: res.index
Out[18]: 
MultiIndex
[(u'R_l0_g0', u'R_l1_g0'), (u'R_l0_g1', u'R_l1_g1'), (u'R_l0_g2', u'R_l1_g2'), (u'R_l0_g3', u'R_l1_g3'), (u'R_l0_g4', u'R_l1_g4')]

In [19]: res.columns
Out[19]: 
MultiIndex
[(u'C_l0_g0', u'C_l1_g0', u'C_l2_g0', u'C_l3_g0'), (u'C_l0_g1', u'C_l1_g1', u'C_l2_g1', u'C_l3_g1'), (u'C_l0_g2', u'C_l1_g2', u'C_l2_g2', u'C_l3_g2')]

In [20]: res
Out[20]: 
C0              C_l0_g0 C_l0_g1 C_l0_g2
C1              C_l1_g0 C_l1_g1 C_l1_g2
C2              C_l2_g0 C_l2_g1 C_l2_g2
C3              C_l3_g0 C_l3_g1 C_l3_g2
R0      R1                             
R_l0_g0 R_l1_g0    R0C0    R0C1    R0C2
R_l0_g1 R_l1_g1    R1C0    R1C1    R1C2
R_l0_g2 R_l1_g2    R2C0    R2C1    R2C2
R_l0_g3 R_l1_g3    R3C0    R3C1    R3C2
R_l0_g4 R_l1_g4    R4C0    R4C1    R4C2

In [21]: res.index.names
Out[21]: ['R0', 'R1']

In [22]: res.columns.names
Out[22]: ['C0', 'C1', 'C2', 'C3']
```
