### PR TITLE
BUG: Add squeeze keyword to groupby to allow reduction in returned type

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -65,6 +65,9 @@ pandas 0.11.1
     ``timedelta64[ns]`` to ``object/int`` (GH3425_)
   - Do not allow datetimelike/timedeltalike creation except with valid types
     (e.g. cannot pass ``datetime64[ms]``) (GH3423_)
+  - Add ``squeeze`` keyword to ``groupby`` to allow reduction from 
+    DataFrame -> Series if groups are unique. Regression from 0.10.1, 
+    partial revert on (GH2893_) with (GH3596_)
 
 **Bug Fixes**
 
@@ -161,6 +164,7 @@ pandas 0.11.1
 .. _GH3594: https://github.com/pydata/pandas/issues/3594
 .. _GH3590: https://github.com/pydata/pandas/issues/3590
 .. _GH3610: https://github.com/pydata/pandas/issues/3610
+.. _GH3596: https://github.com/pydata/pandas/issues/3596
 .. _GH3435: https://github.com/pydata/pandas/issues/3435
 
 

--- a/doc/source/v0.11.1.txt
+++ b/doc/source/v0.11.1.txt
@@ -21,6 +21,26 @@ API changes
         p / p
         p / 0
 
+  - Add ``squeeze`` keyword to ``groupby`` to allow reduction from 
+    DataFrame -> Series if groups are unique. This is a Regression from 0.10.1.
+    We are reverting back to the prior behavior. This means groupby will return the 
+    same shaped objects whether the groups are unique or not. revert on (GH2893_) 
+    with (GH3596_).
+
+    .. ipython:: python
+
+        df2 = DataFrame([{"val1": 1, "val2" : 20}, {"val1":1, "val2": 19}, 
+                         {"val1":1, "val2": 27}, {"val1":1, "val2": 12}])
+        def func(dataf):
+            return dataf["val2"]  - dataf["val2"].mean()
+
+        # squeezing the result frame to a series (because we have unique groups)
+        df2.groupby("val1", squeeze=True).apply(func)
+
+        # no squeezing (the default, and behavior in 0.10.1)
+        df2.groupby("val1").apply(func)
+
+
 Enhancements
 ~~~~~~~~~~~~
   - ``pd.read_html()`` can now parse HTML string, files or urls and return dataframes
@@ -44,5 +64,7 @@ on GitHub for a complete list.
 .. _GH3477: https://github.com/pydata/pandas/issues/3477
 .. _GH3492: https://github.com/pydata/pandas/issues/3492
 .. _GH3499: https://github.com/pydata/pandas/issues/3499
+.. _GH2893: https://github.com/pydata/pandas/issues/2893
+.. _GH3596: https://github.com/pydata/pandas/issues/3596
 .. _GH3590: https://github.com/pydata/pandas/issues/3590
 .. _GH3435: https://github.com/pydata/pandas/issues/3435

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -107,7 +107,7 @@ class PandasObject(object):
             return default
 
     def groupby(self, by=None, axis=0, level=None, as_index=True, sort=True,
-                group_keys=True):
+                group_keys=True, squeeze=False):
         """
         Group series using mapper (dict or key function, apply given function
         to group, return result as series) or by a series of columns
@@ -131,6 +131,9 @@ class PandasObject(object):
             Sort group keys. Get better performance by turning this off
         group_keys : boolean, default True
             When calling apply, add group keys to index to identify pieces
+        squeeze : boolean, default False
+            reduce the dimensionaility of the return type if possible, otherwise
+            return a consistent type
 
         Examples
         --------
@@ -150,7 +153,8 @@ class PandasObject(object):
         from pandas.core.groupby import groupby
         axis = self._get_axis_number(axis)
         return groupby(self, by, axis=axis, level=level, as_index=as_index,
-                       sort=sort, group_keys=group_keys)
+                       sort=sort, group_keys=group_keys,
+                       squeeze=squeeze)
 
     def asfreq(self, freq, method=None, how=None, normalize=False):
         """

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -263,14 +263,14 @@ class TestGroupBy(unittest.TestCase):
 
     def test_groupby_return_type(self):
 
-        # GH2893
+        # GH2893, return a reduced type
         df1 = DataFrame([{"val1": 1, "val2" : 20}, {"val1":1, "val2": 19}, 
                          {"val1":2, "val2": 27}, {"val1":2, "val2": 12}])
 
         def func(dataf):
             return dataf["val2"]  - dataf["val2"].mean()
 
-        result = df1.groupby("val1").apply(func)
+        result = df1.groupby("val1", squeeze=True).apply(func)
         self.assert_(isinstance(result,Series))
 
         df2 = DataFrame([{"val1": 1, "val2" : 20}, {"val1":1, "val2": 19}, 
@@ -278,8 +278,13 @@ class TestGroupBy(unittest.TestCase):
         def func(dataf):
             return dataf["val2"]  - dataf["val2"].mean()
 
-        result = df2.groupby("val1").apply(func)
+        result = df2.groupby("val1", squeeze=True).apply(func)
         self.assert_(isinstance(result,Series))
+
+        # GH3596, return a consistent type (regression in 0.11 from 0.10.1)
+        df = DataFrame([[1,1],[1,1]],columns=['X','Y'])
+        result = df.groupby('X',squeeze=False).count()
+        self.assert_(isinstance(result,DataFrame))
 
     def test_agg_regression1(self):
         grouped = self.tsframe.groupby([lambda x: x.year, lambda x: x.month])


### PR DESCRIPTION
This will allow a reduction in the returned type from DataFrame -> Series
if the groups are unique.

This is a fix for a regression from 0.10.1.

Allows functionaility in #2893, by specifying `squeeze=True` 
in groupby call. #3596 functionaility is back as the default

This returns a Series because we are passing `squeeze=True`

```
In [9]: df2 = DataFrame([{"val1": 1, "val2" : 20}, 
{"val1":1, "val2": 19},{"val1":1, "val2": 27}, {"val1":1, "val2": 12}])

In [10]: df2
Out[10]: 
   val1  val2
0     1    20
1     1    19
2     1    27
3     1    12

In [11]: def func(dataf):
   ....:     return dataf["val2"]  - dataf["val2"].mean()
   ....: 

In [12]: df2.groupby("val1", squeeze=True).apply(func)
Out[12]: 
0    0.5
1   -0.5
2    7.5
3   -7.5
Name: 1, dtype: float64
```

Traditionally returns a DataFrame (even though have unique groups)
Implicity (`squeeze=False`)

```
In [13]: df = DataFrame([[1,1],[1,1]],columns=['X','Y'])

In [14]: df
Out[14]: 
   X  Y
0  1  1
1  1  1

In [15]: df.groupby('X').count()
Out[15]: 
   X  Y
X      
1  2  2
```
