### PR TITLE
BUG: Fix incorrect dtype on groupby with ``as_index=False`` (GH3610_)

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -114,6 +114,7 @@ pandas 0.11.1
     in a frame (GH3594_)
   - Fix modulo and integer division on Series,DataFrames to act similary to ``float`` dtypes to return 
     ``np.nan`` or ``np.inf`` as appropriate (GH3590_)
+  - Fix incorrect dtype on groupby with ``as_index=False`` (GH3610_)
 
 .. _GH3164: https://github.com/pydata/pandas/issues/3164
 .. _GH2786: https://github.com/pydata/pandas/issues/2786
@@ -159,6 +160,7 @@ pandas 0.11.1
 .. _GH3556: https://github.com/pydata/pandas/issues/3556
 .. _GH3594: https://github.com/pydata/pandas/issues/3594
 .. _GH3590: https://github.com/pydata/pandas/issues/3590
+.. _GH3610: https://github.com/pydata/pandas/issues/3610
 .. _GH3435: https://github.com/pydata/pandas/issues/3435
 
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1713,7 +1713,7 @@ class NDFrameGroupBy(GroupBy):
                 result.insert(0, name, values)
             result.index = np.arange(len(result))
 
-        return result
+        return result.convert_objects()
 
     def _aggregate_multiple_funcs(self, arg):
         from pandas.tools.merge import concat
@@ -2054,7 +2054,7 @@ class DataFrameGroupBy(NDFrameGroupBy):
         if self.axis == 1:
             result = result.T
 
-        return result
+        return result.convert_objects()
 
     def _wrap_agged_blocks(self, blocks):
         obj = self._obj_with_exclusions
@@ -2094,7 +2094,7 @@ class DataFrameGroupBy(NDFrameGroupBy):
         if self.axis == 1:
             result = result.T
 
-        return result
+        return result.convert_objects()
 
 
 from pandas.tools.plotting import boxplot_frame_groupby

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -1842,6 +1842,14 @@ class TestGroupBy(unittest.TestCase):
         result = df.apply(lambda x: x, axis=1)
         assert_series_equal(df.get_dtype_counts(), result.get_dtype_counts())
 
+
+        # GH 3610 incorrect dtype conversion with as_index=False
+        df = DataFrame({"c1" : [1,2,6,6,8]})
+        df["c2"] = df.c1/2.0
+        result1 = df.groupby("c2").mean().reset_index().c2
+        result2 = df.groupby("c2", as_index=False).mean().c2
+        assert_series_equal(result1,result2)
+
     def test_groupby_list_infer_array_like(self):
         result = self.df.groupby(list(self.df['A'])).mean()
         expected = self.df.groupby(self.df['A']).mean()


### PR DESCRIPTION
closes #3610
