### PR TITLE
ENH add date to DatetimeIndex

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -49,6 +49,7 @@ pandas 0.11.1
     - support datelike columns with a timezone as data_columns (GH2852_)
     - table writing performance improvements.
   - Add modulo operator to Series, DataFrame
+  - Add ``date`` method to DatetimeIndex
 
 **API Changes**
 
@@ -275,7 +276,7 @@ pandas 0.11.0
     on rhs (GH3216_)
   - Treat boolean values as integers (values 1 and 0) for numeric
     operations. (GH2641_)
-  - Add ``time()`` method to DatetimeIndex (GH3180_)
+  - Add ``time`` method to DatetimeIndex (GH3180_)
   - Return NA when using Series.str[...] for values that are not long enough
     (GH3223_)
   - Display cursor coordinate information in time-series plots (GH1670_)

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1319,11 +1319,18 @@ class DatetimeIndex(Int64Index):
     @property
     def time(self):
         """
-        Returns array of datetime.time. The time of the day
+        Returns numpy array of datetime.time. The time part of the Timestamps.
         """
         # can't call self.map() which tries to treat func as ufunc
         # and causes recursion warnings on python 2.6
-        return _algos.arrmap_object(self.asobject, lambda x:x.time())
+        return _algos.arrmap_object(self.asobject, lambda x: x.time())
+
+    @property
+    def date(self):
+        """
+        Returns numpy array of datetime.date. The date part of the Timestamps.
+        """
+        return _algos.arrmap_object(self.asobject, lambda x: x.date())
 
 
     def normalize(self):

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1847,6 +1847,12 @@ class TestDatetimeIndex(unittest.TestCase):
         expected = [t.time() for t in rng]
         self.assert_((result == expected).all())
 
+    def test_date(self):
+        rng = pd.date_range('1/1/2000', freq='12H', periods=10)
+        result = pd.Index(rng).date
+        expected = [t.date() for t in rng]
+        self.assert_((result == expected).all())
+
 
 class TestLegacySupport(unittest.TestCase):
     _multiprocess_can_split_ = True


### PR DESCRIPTION
Allows the date to be pulled out from a DatetimeIndex easily/efficiently.

Similar to #3180, which was for the time-part to be extracted.

_From SO question: http://stackoverflow.com/questions/16563552/pandas-fancy-indexing-a-dataframe_.

~~I haven't added this to release notes, as maybe too late for 11.1?~~
