### PR TITLE
systematic failure when writing a dataframe of 1 column of integer. this should solve issue Issue #3628

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -228,7 +228,11 @@ def _write_sqlite(frame, table, names, cur):
     wildcards = ','.join(['?'] * len(names))
     insert_query = 'INSERT INTO %s (%s) VALUES (%s)' % (
         table, col_names, wildcards)
-    data = [tuple(x) for x in frame.values]
+    # pandas types are badly handled if there is only 1 column ( Issue #3628 )
+    if   not len(frame.columns  )==1 :
+        data = [tuple(x) for x in frame.values]
+    else :
+        data = [tuple(x) for x in frame.values.tolist()]
     cur.executemany(insert_query, data)
 
 def _write_mysql(frame, table, names, cur):

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -219,6 +219,17 @@ class TestSQLite(unittest.TestCase):
         df = DataFrame({'From':np.ones(5)})
         sql.write_frame(df, con = self.db, name = 'testkeywords')
 
+    def test_onecolumn_of_integer(self):
+        '''
+        a column_of_integers dataframe should transfer well to sql
+        '''
+        mono_df=DataFrame([1 , 2], columns=['c0'])
+        sql.write_frame(mono_df, con = self.db, name = 'mono_df')
+        # computing the sum via sql
+        the_sum=sum([my_c0[0] for  my_c0 in con.execute("select * from mono_df")])
+        # it should not fail, and gives 3 ( Issue #3628 )
+        self.assertEqual(the_sum , 3)
+
 
 class TestMySQL(unittest.TestCase):
 

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -226,7 +226,8 @@ class TestSQLite(unittest.TestCase):
         mono_df=DataFrame([1 , 2], columns=['c0'])
         sql.write_frame(mono_df, con = self.db, name = 'mono_df')
         # computing the sum via sql
-        the_sum=sum([my_c0[0] for  my_c0 in con.execute("select * from mono_df")])
+        con_x=self.db
+        the_sum=sum([my_c0[0] for  my_c0 in con_x.execute("select * from mono_df")])
         # it should not fail, and gives 3 ( Issue #3628 )
         self.assertEqual(the_sum , 3)
 


### PR DESCRIPTION
...lite ( Issue #3628 )

A push of a dataframe of one column of integers fail ungraciously, because sqlite doesn't recognize well the data type.
This should solve the problem by converting back to normal types
