### PR TITLE
BUG : Io sql one column (issue #3628)

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -228,7 +228,11 @@ def _write_sqlite(frame, table, names, cur):
     wildcards = ','.join(['?'] * len(names))
     insert_query = 'INSERT INTO %s (%s) VALUES (%s)' % (
         table, col_names, wildcards)
-    data = [tuple(x) for x in frame.values]
+    # pandas types are badly handled if there is only 1 column ( Issue #3628 )
+    if   not len(frame.columns  )==1 :
+        data = [tuple(x) for x in frame.values]
+    else :
+        data = [tuple(x) for x in frame.values.tolist()]
     cur.executemany(insert_query, data)
 
 def _write_mysql(frame, table, names, cur):

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -219,6 +219,18 @@ class TestSQLite(unittest.TestCase):
         df = DataFrame({'From':np.ones(5)})
         sql.write_frame(df, con = self.db, name = 'testkeywords')
 
+    def test_onecolumn_of_integer(self):
+        '''
+        a column_of_integers dataframe should transfer well to sql
+        '''
+        mono_df=DataFrame([1 , 2], columns=['c0'])
+        sql.write_frame(mono_df, con = self.db, name = 'mono_df')
+        # computing the sum via sql
+        con_x=self.db
+        the_sum=sum([my_c0[0] for  my_c0 in con_x.execute("select * from mono_df")])
+        # it should not fail, and gives 3 ( Issue #3628 )
+        self.assertEqual(the_sum , 3)
+
 
 class TestMySQL(unittest.TestCase):
 


### PR DESCRIPTION
closes #3628

This should be the proper pull request to 
- TST test the problem,
- BUG the problem of panda fail to write a single column of integer to sqlite
  Test successfully on Travis CI 
