### PR TITLE
ENH: Allow flags in str.replace keywords

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -692,8 +692,9 @@ class StringMethods(object):
         return self._wrap_result(result)
 
     @copy(str_replace)
-    def replace(self, pat, repl, n=-1, case=True):
-        result = str_replace(self.series, pat, repl, n=n, case=case)
+    def replace(self, pat, repl, n=-1, case=True, flags=0):
+        result = str_replace(self.series, pat, repl, n=n, case=case,
+                             flags=flags)
         return self._wrap_result(result)
 
     @copy(str_repeat)

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -271,6 +271,13 @@ class TestStringMethods(unittest.TestCase):
         exp = Series([u'foobarBAD', NA])
         tm.assert_series_equal(result, exp)
 
+        #flags + unicode
+        values = Series(["abcd,\xc3\xa0".decode("utf-8")])
+        exp = Series(["abcd, \xc3\xa0".decode("utf-8")])
+        result = values.str.replace("(?<=\w),(?=\w)", ", ", flags=re.UNICODE)
+        tm.assert_series_equal(result, exp)
+
+
     def test_repeat(self):
         values = Series(['a', 'b', NA, 'c', NA, 'd'])
 


### PR DESCRIPTION
Fix what appears to be an oversight.
