### PR TITLE
BUG: Non-unique indexing via loc and friends fixed when slicing (GH3659_)

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -115,6 +115,7 @@ pandas 0.11.1
       and handle missing elements like unique indices (GH3561_)
     - Duplicate indexes with and empty DataFrame.from_records will return a correct frame (GH3562_)
     - Concat to produce a non-unique columns when duplicates are across dtypes is fixed (GH3602_)
+    - Non-unique indexing with a slice via ``loc`` and friends fixed (GH3659_)
   - Fixed bug in groupby with empty series referencing a variable before assignment. (GH3510_)
   - Fixed bug in mixed-frame assignment with aligned series (GH3492_)
   - Fixed bug in selecting month/quarter/year from a series would not select the time element
@@ -215,6 +216,7 @@ pandas 0.11.1
 .. _GH3638: https://github.com/pydata/pandas/issues/3638
 .. _GH3605: https://github.com/pydata/pandas/issues/3605
 .. _GH3606: https://github.com/pydata/pandas/issues/3606
+.. _GH3659: https://github.com/pydata/pandas/issues/3659
 .. _Gh3616: https://github.com/pydata/pandas/issues/3616
 
 pandas 0.11.0

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1222,10 +1222,7 @@ class Index(np.ndarray):
 
         is_unique = self.is_unique
         if start is None:
-            if is_unique:
-                start_slice = 0
-            else:
-                start_slice = np.arange(len(self))
+            start_slice = 0
         else:
             try:
                 start_slice = self.get_loc(start)
@@ -1235,21 +1232,10 @@ class Index(np.ndarray):
                     # get_loc will return a boolean array for non_uniques
                     # if we are not monotonic
                     if isinstance(start_slice,np.ndarray):
-                        if not self.is_monotonic:
-                            raise KeyError("cannot peform a slice operation "
-                                           "on a non-unique non-monotonic index")
-                        start_slice = np.arange(len(self))[start_slice]
+                        raise KeyError("cannot peform a slice operation "
+                                       "on a non-unique non-monotonic index")
 
-                    # select all in the slice + all the rest of the entries
-                    # to the right
-                    elif isinstance(start_slice, slice):
-                        ss = np.arange(start_slice.stop,len(self))
-                        start_slice = np.arange(len(self))[start_slice]
-                        start_slice = (Index(ss) | Index(start_slice)).values
-                    else:
-                        start_slice = np.arange(start_slice,len(self))
-
-                elif isinstance(start_slice, slice):
+                if isinstance(start_slice, slice):
                     start_slice = start_slice.start
 
             except KeyError:
@@ -1259,10 +1245,7 @@ class Index(np.ndarray):
                     raise
 
         if end is None:
-            if is_unique:
-                end_slice = len(self)
-            else:
-                end_slice = np.arange(len(self))
+            end_slice = len(self)
         else:
             try:
                 end_slice = self.get_loc(end)
@@ -1271,20 +1254,10 @@ class Index(np.ndarray):
 
                     # get_loc will return a boolean array for non_uniques
                     if isinstance(end_slice,np.ndarray):
-                        if not self.is_monotonic:
-                            raise KeyError("cannot perform a slice operation "
-                                           "on a non-unique non-monotonic index")
-                        end_slice = np.arange(len(self))[end_slice]
-                        
-                    # select all in the slice + all to the left of the entries
-                    elif isinstance(end_slice, slice):
-                        es = np.arange(0,end_slice.start)
-                        end_slice = np.arange(len(self))[end_slice]
-                        end_slice = (Index(es) | Index(end_slice)).values
-                    else:
-                        end_slice = np.arange(0,end_slice+1)
+                        raise KeyError("cannot perform a slice operation "
+                                       "on a non-unique non-monotonic index")
 
-                elif isinstance(end_slice, slice):
+                if isinstance(end_slice, slice):
                     end_slice = end_slice.stop
                 else:
                     end_slice += 1
@@ -1294,16 +1267,6 @@ class Index(np.ndarray):
                     end_slice = self.searchsorted(end, side='right')
                 else:
                     raise
-
-        if not is_unique:
-            # see if we can convert back to and edge slice
-            if len(start_slice) == len(end_slice) and (start_slice == end_slice).all():
-                start_slice, end_slice = start_slice[0], start_slice[-1]+1
-            # partial slice
-            elif (len(start_slice) == start_slice[-1]-start_slice[0]+1) and (
-                len(end_slice) == end_slice[-1]-end_slice[0]+1):
-                res = (Index(start_slice) & Index(end_slice)).values
-                start_slice, end_slice = res[0],res[-1]+1
 
         return start_slice, end_slice
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1219,13 +1219,39 @@ class Index(np.ndarray):
         -----
         This function assumes that the data is sorted, so use at your own peril
         """
+
+        is_unique = self.is_unique
         if start is None:
-            start_slice = 0
+            if is_unique:
+                start_slice = 0
+            else:
+                start_slice = np.arange(len(self))
         else:
             try:
                 start_slice = self.get_loc(start)
-                if isinstance(start_slice, slice):
+                
+                if not is_unique:
+
+                    # get_loc will return a boolean array for non_uniques
+                    # if we are not monotonic
+                    if isinstance(start_slice,np.ndarray):
+                        if not self.is_monotonic:
+                            raise KeyError("cannot peform a slice operation "
+                                           "on a non-unique non-monotonic index")
+                        start_slice = np.arange(len(self))[start_slice]
+
+                    # select all in the slice + all the rest of the entries
+                    # to the right
+                    elif isinstance(start_slice, slice):
+                        ss = np.arange(start_slice.stop,len(self))
+                        start_slice = np.arange(len(self))[start_slice]
+                        start_slice = (Index(ss) | Index(start_slice)).values
+                    else:
+                        start_slice = np.arange(start_slice,len(self))
+
+                elif isinstance(start_slice, slice):
                     start_slice = start_slice.start
+
             except KeyError:
                 if self.is_monotonic:
                     start_slice = self.searchsorted(start, side='left')
@@ -1233,19 +1259,51 @@ class Index(np.ndarray):
                     raise
 
         if end is None:
-            end_slice = len(self)
+            if is_unique:
+                end_slice = len(self)
+            else:
+                end_slice = np.arange(len(self))
         else:
             try:
                 end_slice = self.get_loc(end)
-                if isinstance(end_slice, slice):
+
+                if not is_unique:
+
+                    # get_loc will return a boolean array for non_uniques
+                    if isinstance(end_slice,np.ndarray):
+                        if not self.is_monotonic:
+                            raise KeyError("cannot perform a slice operation "
+                                           "on a non-unique non-monotonic index")
+                        end_slice = np.arange(len(self))[end_slice]
+                        
+                    # select all in the slice + all to the left of the entries
+                    elif isinstance(end_slice, slice):
+                        es = np.arange(0,end_slice.start)
+                        end_slice = np.arange(len(self))[end_slice]
+                        end_slice = (Index(es) | Index(end_slice)).values
+                    else:
+                        end_slice = np.arange(0,end_slice+1)
+
+                elif isinstance(end_slice, slice):
                     end_slice = end_slice.stop
                 else:
                     end_slice += 1
+
             except KeyError:
                 if self.is_monotonic:
                     end_slice = self.searchsorted(end, side='right')
                 else:
                     raise
+
+        if not is_unique:
+            # see if we can convert back to and edge slice
+            if len(start_slice) == len(end_slice) and (start_slice == end_slice).all():
+                start_slice, end_slice = start_slice[0], start_slice[-1]+1
+            # partial slice
+            elif (len(start_slice) == start_slice[-1]-start_slice[0]+1) and (
+                len(end_slice) == end_slice[-1]-end_slice[0]+1):
+                res = (Index(start_slice) & Index(end_slice)).values
+                start_slice, end_slice = res[0],res[-1]+1
 
         return start_slice, end_slice
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -759,6 +759,7 @@ class _LocIndexer(_LocationIndexer):
         labels = self.obj._get_axis(axis)
 
         if isinstance(key, slice):
+            self._has_valid_type(key,axis)
             return self._get_slice_axis(key, axis=axis)
         elif com._is_bool_indexer(key):
             return self._getbool_axis(key, axis=axis)


### PR DESCRIPTION
closes #3659

This is if you try a non_monotonic selection on a non_unique index (a mouthful)!
The reason is we cannot determinate a proper start/end point on what to include

```
In [11]: df = DataFrame({'A' : [1,2,3,4,5,6], 'B' : [3,4,5,6,7,8]}, 
           index = [0,1,0,1,2,3])

In [18]: df
Out[18]: 
   A  B
0  1  3
1  2  4
0  3  5
1  4  6
2  5  7
3  6  8

In [12]: df.loc[1:]
KeyError: 'cannot perform a slice operation on a non-unique non-monotonic index'
```

On a non_unique, but monotonic index, however, slicing works normally
(notice, since we are using loc, that both endpoints ARE included)

```
In [13]: df = DataFrame({'A' : [1,2,3,4,5,6], 'B' : [3,4,5,6,7,8]}, 
       index = [0,1,0,1,2,3]).sort(axis=0)

In [14]: df
Out[14]: 
   A  B
0  1  3
0  3  5
1  2  4
1  4  6
2  5  7
3  6  8

In [15]: df.loc[1:]
Out[15]: 
   A  B
1  2  4
1  4  6
2  5  7
3  6  8

In [16]: df.loc[1:2]
Out[16]: 
   A  B
1  2  4
1  4  6
2  5  7
```
