### PR TITLE
BUG:  convert_objects with convert_dates=coerce was parsing `a` into a date

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -155,6 +155,8 @@ pandas 0.11.1
   - Fix running of bs4 tests when it is not installed (GH3605_)
   - Fix parsing of html table (GH3606_)
   - ``read_html()`` now only allows a single backend: ``html5lib`` (GH3616_)
+  - ``convert_objects`` with ``convert_dates='coerce'`` was parsing some single-letter strings
+     into today's date
 
 .. _GH3164: https://github.com/pydata/pandas/issues/3164
 .. _GH2786: https://github.com/pydata/pandas/issues/2786

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -3509,6 +3509,15 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         #result = r.convert_objects(convert_dates=True,convert_numeric=False)
         #self.assert_(result.dtype == 'M8[ns]')
 
+        # dateutil parses some single letters into today's value as a date
+        for x in 'abcdefghijklmnopqrstuvwxyz':
+                  s = Series([x])
+                  result = s.convert_objects(convert_dates='coerce')
+                  assert_series_equal(result,s)
+                  s = Series([x.upper()])
+                  result = s.convert_objects(convert_dates='coerce')
+                  assert_series_equal(result,s)
+
     def test_apply_args(self):
         s = Series(['foo,bar'])
 

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -319,6 +319,7 @@ class Timestamp(_Timestamp):
 
 
 _nat_strings = set(['NaT','nat','NAT','nan','NaN','NAN'])
+_not_datelike_strings = set(['a','A','m','M','p','P','t','T'])
 class NaTType(_NaT):
     """(N)ot-(A)-(T)ime, the time equivalent of NaN"""
 
@@ -876,6 +877,14 @@ def array_to_datetime(ndarray[object] values, raise_=False, dayfirst=False,
                                                                    &dts)
                     _check_dts_bounds(iresult[i], &dts)
                 except ValueError:
+
+                    # for some reason, dateutil parses some single letter len-1 strings into today's date
+                    if len(val) == 1 and val in _not_datelike_strings:
+                        if coerce:
+                            iresult[i] = iNaT
+                            continue
+                        elif raise_:
+                            raise
                     try:
                         result[i] = parse(val, dayfirst=dayfirst)
                     except Exception:


### PR DESCRIPTION
this is a 'bug' in dateutil:

`a,t,m,p` are the offenders

```
In [1]: import dateutil

In [2]: dateutil.parser.parse('a')
Out[2]: datetime.datetime(2013, 5, 21, 0, 0)

```
