### PR TITLE
scatter_matrix bug

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -40,11 +40,12 @@ pandas 0.11.1
     list of the rows from which to read the index. Added the option,
     ``tupleize_cols`` to provide compatiblity for the pre 0.11.1 behavior of
     writing and reading multi-index columns via a list of tuples. The default in
-    0.11.1 is to write lists of tuples and *not* interpret list of tuples as a 
-    multi-index column.  
+    0.11.1 is to write lists of tuples and *not* interpret list of tuples as a
+    multi-index column.
     Note: The default value will change in 0.12 to make the default *to* write and
     read multi-index columns in the new format. (GH3571_, GH1651_, GH3141_)
   - Add iterator to ``Series.str`` (GH3638_)
+  - Added keyword parameters for different types of scatter_matrix subplots
 
 **Improvements to existing features**
 
@@ -63,7 +64,7 @@ pandas 0.11.1
   - Add modulo operator to Series, DataFrame
   - Add ``date`` method to DatetimeIndex
   - Simplified the API and added a describe method to Categorical
-  - ``melt`` now accepts the optional parameters ``var_name`` and ``value_name`` 
+  - ``melt`` now accepts the optional parameters ``var_name`` and ``value_name``
     to specify custom column names of the returned DataFrame (GH3649_),
     thanks @hoechenberger
 
@@ -82,8 +83,8 @@ pandas 0.11.1
     ``timedelta64[ns]`` to ``object/int`` (GH3425_)
   - Do not allow datetimelike/timedeltalike creation except with valid types
     (e.g. cannot pass ``datetime64[ms]``) (GH3423_)
-  - Add ``squeeze`` keyword to ``groupby`` to allow reduction from 
-    DataFrame -> Series if groups are unique. Regression from 0.10.1, 
+  - Add ``squeeze`` keyword to ``groupby`` to allow reduction from
+    DataFrame -> Series if groups are unique. Regression from 0.10.1,
     partial revert on (GH2893_) with (GH3596_)
   - Raise on ``iloc`` when boolean indexing with a label based indexer mask
     e.g. a boolean Series, even with integer labels, will raise. Since ``iloc``
@@ -137,7 +138,7 @@ pandas 0.11.1
     is a ``list`` or ``tuple``.
   - Fixed bug where a time-series was being selected in preference to an actual column name
     in a frame (GH3594_)
-  - Fix modulo and integer division on Series,DataFrames to act similary to ``float`` dtypes to return 
+  - Fix modulo and integer division on Series,DataFrames to act similary to ``float`` dtypes to return
     ``np.nan`` or ``np.inf`` as appropriate (GH3590_)
   - Fix incorrect dtype on groupby with ``as_index=False`` (GH3610_)
   - Fix ``read_csv`` to correctly encode identical na_values, e.g. ``na_values=[-999.0,-999]``

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -159,7 +159,8 @@ plot_params = _Options()
 
 
 def scatter_matrix(frame, alpha=0.5, figsize=None, ax=None, grid=False,
-                   diagonal='hist', marker='.', **kwds):
+                   diagonal='hist', marker='.', density_kwds={}, hist_kwds={},
+                   **kwds):
     """
     Draw a matrix of scatter plots.
 
@@ -174,6 +175,10 @@ def scatter_matrix(frame, alpha=0.5, figsize=None, ax=None, grid=False,
         either Kernel Density Estimation or Histogram
         plot in the diagonal
     marker : Matplotlib marker type, default '.'
+    hist_kwds : other plotting keyword arguments
+        To be passed to hist function
+    density_kwds : other plotting keyword arguments
+        To be passed to kernel density estimate plot
     kwds : other plotting keyword arguments
         To be passed to scatter function
 
@@ -205,13 +210,13 @@ def scatter_matrix(frame, alpha=0.5, figsize=None, ax=None, grid=False,
 
                 # Deal with the diagonal by drawing a histogram there.
                 if diagonal == 'hist':
-                    ax.hist(values)
+                    ax.hist(values, hist_kwds)
                 elif diagonal in ('kde', 'density'):
                     from scipy.stats import gaussian_kde
                     y = values
                     gkde = gaussian_kde(y)
                     ind = np.linspace(y.min(), y.max(), 1000)
-                    ax.plot(ind, gkde.evaluate(ind), **kwds)
+                    ax.plot(ind, gkde.evaluate(ind), **density_kwds)
             else:
                 common = (mask[a] & mask[b]).values
 
@@ -368,16 +373,16 @@ def andrews_curves(data, class_column, ax=None, samples=200):
     """
     Parameters:
     -----------
-    data : DataFrame 
+    data : DataFrame
         Data to be plotted, preferably normalized to (0.0, 1.0)
     class_column : Name of the column containing class names
     ax : matplotlib axes object, default None
     samples : Number of points to plot in each curve
-    
+
     Returns:
     --------
     ax: Matplotlib axis object
-    
+
     """
     from math import sqrt, pi, sin, cos
     import matplotlib.pyplot as plt
@@ -1805,7 +1810,7 @@ def scatter_plot(data, x, y, by=None, ax=None, figsize=None, grid=False, **kwarg
     grid : Setting this to True will show the grid
     kwargs : other plotting keyword arguments
         To be passed to scatter function
-    
+
     Returns
     -------
     fig : matplotlib.Figure
@@ -2198,9 +2203,9 @@ def _subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
 
     data : DataFrame, optional
         If secondary_y is a sequence, data is used to select columns.
-     
-    fig_kw : Other keyword arguments to be passed to the figure() call.  
-        Note that all keywords not recognized above will be 
+
+    fig_kw : Other keyword arguments to be passed to the figure() call.
+        Note that all keywords not recognized above will be
         automatically included here.
 
 


### PR DESCRIPTION
Currently scatter_matrix passes all unmatched keyword arguments to both scatter and line subplots (off-diagonal plots are scatter, diagonal plots are discrete or continuous histograms). I needed to color the points on the scatter plots but could not pass a "c" argument or pandas would try to pass the "c" argument to the line plots and barf. This change scratches my itch and doesn't break backward compatibility.
