### PR TITLE
API: deprecate DataFrame.interpolate

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -96,6 +96,9 @@ pandas 0.11.1
   - The ``raise_on_error`` option to plotting methods is obviated by GH3572_,
     so it is removed. Plots now always raise when data cannot be plotted or the
     object being plotted has a dtype of ``object``.
+  - ``DataFrame.interpolate()`` is now deprecated. Please use
+    ``DataFrame.fillna()`` and ``DataFrame.replace()`` instead (GH3582_,
+    GH3675_, GH3676_).
 
 **Bug Fixes**
 
@@ -233,9 +236,11 @@ pandas 0.11.1
 .. _GH3606: https://github.com/pydata/pandas/issues/3606
 .. _GH3659: https://github.com/pydata/pandas/issues/3659
 .. _GH3649: https://github.com/pydata/pandas/issues/3649
-.. _Gh3616: https://github.com/pydata/pandas/issues/3616
 .. _GH1818: https://github.com/pydata/pandas/issues/1818
 .. _GH3572: https://github.com/pydata/pandas/issues/3572
+.. _GH3582: https://github.com/pydata/pandas/issues/3582
+.. _GH3676: https://github.com/pydata/pandas/issues/3676
+.. _GH3675: https://github.com/pydata/pandas/issues/3675
 
 pandas 0.11.0
 =============

--- a/doc/source/v0.11.1.txt
+++ b/doc/source/v0.11.1.txt
@@ -67,6 +67,9 @@ API changes
     and thus you should cast to an appropriate numeric dtype if you need to
     plot something.
 
+  - ``DataFrame.interpolate()`` is now deprecated. Please use
+    ``DataFrame.fillna()`` and ``DataFrame.replace()`` instead. (GH3582_,
+    GH3675_, GH3676_)
 
 
 Enhancements
@@ -241,3 +244,6 @@ on GitHub for a complete list.
 .. _GH3656: https://github.com/pydata/pandas/issues/3656
 .. _GH1818: https://github.com/pydata/pandas/issues/1818
 .. _GH3572: https://github.com/pydata/pandas/issues/3572
+.. _GH3582: https://github.com/pydata/pandas/issues/3582
+.. _GH3676: https://github.com/pydata/pandas/issues/3676
+.. _GH3675: https://github.com/pydata/pandas/issues/3675

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3506,7 +3506,7 @@ class DataFrame(NDFrame):
 
         See also
         --------
-        reindex, asfreq, fillna, interpolate
+        reindex, asfreq, fillna
 
         Returns
         -------
@@ -3678,6 +3678,10 @@ class DataFrame(NDFrame):
         --------
         reindex, replace, fillna
         """
+        from warnings import warn
+        warn('DataFrame.interpolate will be removed in v0.12, please use '
+             'either DataFrame.fillna or DataFrame.replace instead',
+             FutureWarning)
         if self._is_mixed_type and axis == 1:
             return self.T.replace(to_replace, method=method, limit=limit).T
 


### PR DESCRIPTION
closes #3582.
