### PR TITLE
EHN: Add filter methods to SeriesGroupBy, DataFrameGroupBy GH919

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -48,6 +48,8 @@ pandas 0.11.1
   - Add iterator to ``Series.str`` (GH3638_)
   - ``pd.set_option()`` now allows N option, value pairs (GH3667_).
   - Added keyword parameters for different types of scatter_matrix subplots
+  - A ``filter`` method on grouped Series or DataFrames returns a subset of
+    the original (GH3680_, GH919_)
 
 **Improvements to existing features**
 

--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -41,6 +41,12 @@ following:
     - Standardizing data (zscore) within group
     - Filling NAs within groups with a value derived from each group
 
+ - **Filtration**: discard some groups, according to a group-wise computation
+   that evaluates True or False. Some examples:
+
+    - Discarding data that belongs to groups with only a few members
+    - Filtering out data based on the group sum or mean
+
  - Some combination of the above: GroupBy will examine the results of the apply
    step and try to return a sensibly combined result if it doesn't fit into
    either of the above two categories
@@ -488,6 +494,39 @@ and that the transformed data contains no NAs.
    grouped.count() # original has some missing data points
    grouped_trans.count() # counts after transformation
    grouped_trans.size() # Verify non-NA count equals group size
+
+.. _groupby.filter:
+
+Filtration
+----------
+
+The ``filter`` method returns a subset of the original object. Suppose we
+want to take only elements that belong to groups with a group sum greater
+than 2.
+
+.. ipython:: python
+
+   s = Series([1, 1, 2, 3, 3, 3])
+   s.groupby(s).filter(lambda x: x.sum() > 2)
+
+The argument of ``filter`` must a function that, applied to the group as a 
+whole, returns ``True`` or ``False``.
+
+Another useful operation is filtering out elements that belong to groups
+with only a couple members.
+
+.. ipython:: python
+
+   df = DataFrame({'A': arange(8), 'B': list('aabbbbcc')})
+   df.groupby('B').filter(lambda x: len(x) > 2)
+
+Alternatively, instead of dropping the offending groups, we can return a
+like-indexed objects where the groups that do not pass the filter are filled
+with NaNs.
+
+.. ipython:: python
+
+   df.groupby('B').filter(lambda x: len(x) > 2, dropna=False)
 
 .. _groupby.dispatch:
 

--- a/doc/source/v0.11.1.txt
+++ b/doc/source/v0.11.1.txt
@@ -237,6 +237,35 @@ Enhancements
          pd.get_option('a.b')
          pd.get_option('b.c')
 
+  - The ``filter`` method for group objects returns a subset of the original 
+    object. Suppose we want to take only elements that belong to groups with a 
+    group sum greater than 2.
+
+    .. ipython:: python
+
+       s = Series([1, 1, 2, 3, 3, 3])
+       s.groupby(s).filter(lambda x: x.sum() > 2)
+
+    The argument of ``filter`` must a function that, applied to the group as a
+    whole, returns ``True`` or ``False``.
+
+    Another useful operation is filtering out elements that belong to groups
+    with only a couple members.
+
+    .. ipython:: python
+
+       df = DataFrame({'A': arange(8), 'B': list('aabbbbcc')})
+       df.groupby('B').filter(lambda x: len(x) > 2)
+
+    Alternatively, instead of dropping the offending groups, we can return a
+    like-indexed objects where the groups that do not pass the filter are 
+    filled with NaNs.
+
+    .. ipython:: python
+
+       df.groupby('B').filter(lambda x: len(x) > 2, dropna=False)
+
+
 Bug Fixes
 ~~~~~~~~~
 


### PR DESCRIPTION
closes #919

I have been using Wes' workaround (see #919) for filtering groups. Finally, for brevity's sake, I wrote a real filter method. In the one simple case I checked, it performs faster than the workaround.

On a small (~10) Series:

```
In [7]: %timeit grouped.filter(lambda x: x.mean() > 10)  # my method
1000 loops, best of 3: 346 us per loop

In [8]: %timeit grouped.obj[grouped.transform(lambda x: x.mean() > 10)]  # workaround
1000 loops, best of 3: 462 us per loop
```

On a large (1000000) Series:

```
In [18]: %timeit grouped.filter(lambda x: x.mean() > 0) # my method
1 loops, best of 3: 213 ms per loop

In [19]: %timeit grouped.obj[grouped.transform(lambda x: x.mean() > 0)]
1 loops, best of 3: 696 ms per loop
```

This PR only handles Series, and I included one simple test. If I am on the right track, I'll write one for DataFrames also and write additional tests. If this is a job for Cython, I'm out of my depth, but I think numpy is sufficient. Does this look OK?
