### PR TITLE
BUG: allow insertion/deletion of columns in non-unique column DataFrames

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -102,6 +102,8 @@ pandas 0.11.1
     GH3675_, GH3676_).
   - Deprecated display.height, display.width is now only a formatting option
     does not control triggering of summary, similar to < 0.11.0.
+  - Add the keyword ``allow_duplicates`` to ``DataFrame.insert`` to allow a duplicate column
+    to be inserted if ``True``, default is ``False`` (same as prior to 0.11.1) (GH3679_)
 
 **Bug Fixes**
 
@@ -133,6 +135,7 @@ pandas 0.11.1
     - Duplicate indexes with and empty DataFrame.from_records will return a correct frame (GH3562_)
     - Concat to produce a non-unique columns when duplicates are across dtypes is fixed (GH3602_)
     - Non-unique indexing with a slice via ``loc`` and friends fixed (GH3659_)
+    - Allow insert/delete to non-unique columns (GH3679_)
   - Fixed bug in groupby with empty series referencing a variable before assignment. (GH3510_)
   - Fixed bug in mixed-frame assignment with aligned series (GH3492_)
   - Fixed bug in selecting month/quarter/year from a series would not select the time element
@@ -242,6 +245,8 @@ pandas 0.11.1
 .. _GH3606: https://github.com/pydata/pandas/issues/3606
 .. _GH3659: https://github.com/pydata/pandas/issues/3659
 .. _GH3649: https://github.com/pydata/pandas/issues/3649
+.. _GH3679: https://github.com/pydata/pandas/issues/3679
+.. _Gh3616: https://github.com/pydata/pandas/issues/3616
 .. _GH1818: https://github.com/pydata/pandas/issues/1818
 .. _GH3572: https://github.com/pydata/pandas/issues/3572
 .. _GH3582: https://github.com/pydata/pandas/issues/3582

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -136,6 +136,7 @@ pandas 0.11.1
     - Concat to produce a non-unique columns when duplicates are across dtypes is fixed (GH3602_)
     - Non-unique indexing with a slice via ``loc`` and friends fixed (GH3659_)
     - Allow insert/delete to non-unique columns (GH3679_)
+    - Extend ``reindex`` to correctly deal with non-unique indices (GH3679_)
   - Fixed bug in groupby with empty series referencing a variable before assignment. (GH3510_)
   - Fixed bug in mixed-frame assignment with aligned series (GH3492_)
   - Fixed bug in selecting month/quarter/year from a series would not select the time element

--- a/doc/source/v0.11.1.txt
+++ b/doc/source/v0.11.1.txt
@@ -71,6 +71,8 @@ API changes
     ``DataFrame.fillna()`` and ``DataFrame.replace()`` instead. (GH3582_,
     GH3675_, GH3676_)
 
+  - Add the keyword ``allow_duplicates`` to ``DataFrame.insert`` to allow a duplicate column
+    to be inserted if ``True``, default is ``False`` (same as prior to 0.11.1) (GH3679_)
 
 Enhancements
 ~~~~~~~~~~~~
@@ -209,6 +211,7 @@ Bug Fixes
       and handle missing elements like unique indices (GH3561_)
     - Duplicate indexes with and empty DataFrame.from_records will return a correct frame (GH3562_)
     - Concat to produce a non-unique columns when duplicates are across dtypes is fixed (GH3602_)
+    - Allow insert/delete to non-unique columns (GH3679_)
 
     For example you can do
 
@@ -270,3 +273,4 @@ on GitHub for a complete list.
 .. _GH3676: https://github.com/pydata/pandas/issues/3676
 .. _GH3675: https://github.com/pydata/pandas/issues/3675
 .. _GH3682: https://github.com/pydata/pandas/issues/3682
+.. _GH3679: https://github.com/pydata/pandas/issues/3679

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2162,10 +2162,10 @@ class DataFrame(NDFrame):
         value = self._sanitize_column(key, value)
         NDFrame._set_item(self, key, value)
 
-    def insert(self, loc, column, value):
+    def insert(self, loc, column, value, allow_duplicates=False):
         """
-        Insert column into DataFrame at specified location. Raises Exception if
-        column is already contained in the DataFrame
+        Insert column into DataFrame at specified location.
+        if allow_duplicates is False, Raises Exception if column is already contained in the DataFrame
 
         Parameters
         ----------
@@ -2175,7 +2175,7 @@ class DataFrame(NDFrame):
         value : int, Series, or array-like
         """
         value = self._sanitize_column(column, value)
-        self._data.insert(loc, column, value)
+        self._data.insert(loc, column, value, allow_duplicates=allow_duplicates)
 
     def _sanitize_column(self, key, value):
         # Need to make sure new columns (which go into the BlockManager as new

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2003,7 +2003,11 @@ class DataFrame(NDFrame):
             return self._getitem_multilevel(key)
         else:
             # get column
-            return self._get_item_cache(key)
+            if self.columns.is_unique:
+                return self._get_item_cache(key)
+
+            # duplicate columns
+            return self._constructor(self._data.get(key))
 
     def _getitem_slice(self, key):
         return self._slice(key, axis=0)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -940,8 +940,15 @@ class Index(np.ndarray):
             if self.equals(target):
                 indexer = None
             else:
-                indexer = self.get_indexer(target, method=method,
-                                           limit=limit)
+                if self.is_unique:
+                    indexer = self.get_indexer(target, method=method,
+                                               limit=limit)
+                else:
+                    if method is not None or limit is not None:
+                        raise ValueError("cannot reindex a non-unique index "
+                                         "with a method or limit")
+                    indexer, missing = self.get_indexer_non_unique(target)
+
         return target, indexer
 
     def join(self, other, how='left', level=None, return_indexers=False):

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -457,7 +457,7 @@ class _NDFrameIndexer(object):
             else:
                 level = None
 
-            if labels.is_unique:
+            if labels.is_unique and Index(keyarr).is_unique:
                 return _reindex(keyarr, level=level)
             else:
                 indexer, missing = labels.get_indexer_non_unique(keyarr)
@@ -991,7 +991,6 @@ class _SeriesIndexer(_NDFrameIndexer):
     def _setitem_with_indexer(self, indexer, value):
         self.obj._set_values(indexer, value)
 
-
 def _check_bool_indexer(ax, key):
     # boolean indexing, need to check that the data are aligned, otherwise
     # disallowed
@@ -1009,7 +1008,6 @@ def _check_bool_indexer(ax, key):
     # object array key, so no check needed here
     result = np.asarray(result, dtype=bool)
     return result
-
 
 def _is_series(obj):
     from pandas.core.series import Series

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2825,6 +2825,67 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
                           [('a', [8]), ('a', [5]), ('b', [6])],
                           columns=['b', 'a', 'a'])
 
+
+    def test_column_duplicates_operations(self):
+        df = DataFrame([[1,1,1,5],[1,1,2,5],[2,1,3,5]],columns=['foo','bar','foo','hello'])
+
+        # insert
+        df['string'] = 'bah'
+        expected = DataFrame([[1,1,1,5,'bah'],[1,1,2,5,'bah'],[2,1,3,5,'bah']],columns=['foo','bar','foo','hello','string'])
+        assert_frame_equal(df,expected)
+        df.dtypes
+        str(df)
+
+        # insert same dtype
+        df['foo2'] = 3
+        expected = DataFrame([[1,1,1,5,'bah',3],[1,1,2,5,'bah',3],[2,1,3,5,'bah',3]],columns=['foo','bar','foo','hello','string','foo2'])
+        assert_frame_equal(df,expected)
+        df.dtypes
+        str(df)
+
+        # delete (non dup)
+        del df['bar']
+        expected = DataFrame([[1,1,5,'bah',3],[1,2,5,'bah',3],[2,3,5,'bah',3]],columns=['foo','foo','hello','string','foo2'])
+        assert_frame_equal(df,expected)
+        df.dtypes
+        str(df)
+
+        # try to delete again (its not consolidated)
+        del df['hello']
+        expected = DataFrame([[1,1,'bah',3],[1,2,'bah',3],[2,3,'bah',3]],columns=['foo','foo','string','foo2'])
+        assert_frame_equal(df,expected)
+        df.dtypes
+        str(df)
+
+        # consolidate
+        df = df.consolidate()
+        expected = DataFrame([[1,1,'bah',3],[1,2,'bah',3],[2,3,'bah',3]],columns=['foo','foo','string','foo2'])
+        assert_frame_equal(df,expected)
+        df.dtypes
+        str(df)
+
+        # insert
+        df.insert(2,'new_col',5.)
+        expected = DataFrame([[1,1,5.,'bah',3],[1,2,5.,'bah',3],[2,3,5.,'bah',3]],columns=['foo','foo','new_col','string','foo2'])
+        assert_frame_equal(df,expected)
+        df.dtypes
+        str(df)
+
+        # insert a dup
+        self.assertRaises(Exception, df.insert, 2, 'new_col', 4.)
+        df.insert(2,'new_col',4.,allow_duplicates=True)
+        expected = DataFrame([[1,1,4.,5.,'bah',3],[1,2,4.,5.,'bah',3],[2,3,4.,5.,'bah',3]],columns=['foo','foo','new_col','new_col','string','foo2'])
+        assert_frame_equal(df,expected)
+        df.dtypes
+        str(df)
+
+        # delete (dup)
+        del df['foo']
+        expected = DataFrame([[4.,5.,'bah',3],[4.,5.,'bah',3],[4.,5.,'bah',3]],columns=['new_col','new_col','string','foo2'])
+        assert_frame_equal(df,expected)
+        df.dtypes
+        str(df)
+
     def test_constructor_single_value(self):
 
         # expecting single value upcasting here

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2860,6 +2860,12 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         expected = DataFrame([[1,1,1,5,'bah',3],[1,1,2,5,'bah',3],[2,1,3,5,'bah',3]],columns=['foo','bar','foo','hello','string','foo2'])
         check(df,expected)
 
+        # set (non-dup)
+        df['foo2'] = 4
+        expected = DataFrame([[1,1,1,5,'bah',4],[1,1,2,5,'bah',4],[2,1,3,5,'bah',4]],columns=['foo','bar','foo','hello','string','foo2'])
+        check(df,expected)
+        df['foo2'] = 3
+
         # delete (non dup)
         del df['bar']
         expected = DataFrame([[1,1,5,'bah',3],[1,2,5,'bah',3],[2,3,5,'bah',3]],columns=['foo','foo','hello','string','foo2'])
@@ -2911,6 +2917,33 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         del df['foo']
         expected = DataFrame([[1,5,7.],[1,5,7.],[1,5,7.]],columns=['bar','hello','foo2'])
         check(df,expected)
+
+        # reindex
+        df = DataFrame([[1,5,7.],[1,5,7.],[1,5,7.]],columns=['bar','a','a'])
+        expected = DataFrame([[1],[1],[1]],columns=['bar'])
+        result = df.reindex(columns=['bar'])
+        check(result,expected)
+
+        result1 = DataFrame([[1],[1],[1]],columns=['bar']).reindex(columns=['bar','foo'])
+        result2 = df.reindex(columns=['bar','foo'])
+        check(result2,result1)
+
+        # drop
+        df = DataFrame([[1,5,7.],[1,5,7.],[1,5,7.]],columns=['bar','a','a'])
+        df = df.drop(['a'],axis=1)
+        expected = DataFrame([[1],[1],[1]],columns=['bar'])
+        check(df,expected)
+
+    def test_insert_benchmark(self):
+        # from the vb_suite/frame_methods/frame_insert_columns
+        N = 10
+        K = 5
+        df = DataFrame(index=range(N))
+        new_col = np.random.randn(N)
+        for i in range(K):
+            df[i] = new_col
+        expected = DataFrame(np.repeat(new_col,K).reshape(N,K),index=range(N))
+        assert_frame_equal(df,expected)
 
     def test_constructor_single_value(self):
 

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -272,8 +272,20 @@ class TestBlockManager(unittest.TestCase):
         for b in blocks:
             b.ref_items = items
 
+        # test trying to create _ref_locs with/o ref_locs set on the blocks
+        self.assertRaises(AssertionError, BlockManager, blocks, [items, np.arange(N)])
+
+        blocks[0].set_ref_locs([0])
+        blocks[1].set_ref_locs([1])
         mgr = BlockManager(blocks, [items, np.arange(N)])
         mgr.iget(1)
+
+        # invalidate the _ref_locs
+        for b in blocks:
+            b._ref_locs = None
+        mgr._ref_locs = None
+        mgr._items_map = None
+        self.assertRaises(AssertionError, mgr._set_ref_locs, do_refs=True)
 
     def test_contains(self):
         self.assert_('a' in self.mgr)

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -1,7 +1,7 @@
 # pylint: disable=W0102
 
 import unittest
-
+import nose
 import numpy as np
 
 from pandas import Index, MultiIndex, DataFrame, Series
@@ -173,6 +173,11 @@ class TestBlock(unittest.TestCase):
         self.assertRaises(Exception, self.fblock.delete, 'b')
 
     def test_split_block_at(self):
+
+        # with dup column support this method was taken out
+        # GH3679
+        raise nose.SkipTest
+
         bs = list(self.fblock.split_block_at('a'))
         self.assertEqual(len(bs), 1)
         self.assertTrue(np.array_equal(bs[0].items, ['c', 'e']))

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -781,10 +781,10 @@ def _upcast_blocks(blocks):
     for block in blocks:
         if isinstance(block, IntBlock):
             newb = make_block(block.values.astype(float), block.items,
-                              block.ref_items)
+                              block.ref_items, placement=block._ref_locs)
         elif isinstance(block, BoolBlock):
             newb = make_block(block.values.astype(object), block.items,
-                              block.ref_items)
+                              block.ref_items, placement=block._ref_locs)
         else:
             newb = block
         new_blocks.append(newb)


### PR DESCRIPTION
closes #3679, #3687

Here's example of various operations

```
In [3]: df = DataFrame([[1,1,1,5],[1,1,2,5],[2,1,3,5]],
             columns=['foo','bar','foo','hello'])

In [27]: df.columns.is_unique
Out[27]: False

In [4]: # insert

In [5]: df['string'] = 'bah'

In [6]: df
Out[6]: 
   foo  bar  foo  hello string
0    1    1    1      5    bah
1    1    1    2      5    bah
2    2    1    3      5    bah

In [7]: # insert same dtype

In [8]: df['foo2'] = 3

In [9]: df
Out[9]: 
   foo  bar  foo  hello string  foo2
0    1    1    1      5    bah     3
1    1    1    2      5    bah     3
2    2    1    3      5    bah     3

In [10]: # delete (non dup)

In [11]: del df['bar']

In [12]: df
Out[12]: 
   foo  foo  hello string  foo2
0    1    1      5    bah     3
1    1    2      5    bah     3
2    2    3      5    bah     3

In [13]: # try to delete again (its not consolidated)

In [14]: del df['hello']

In [15]: df
Out[15]: 
   foo  foo string  foo2
0    1    1    bah     3
1    1    2    bah     3
2    2    3    bah     3

In [16]: # insert

In [17]: df.insert(2,'new_col',5.)

In [18]: df
Out[18]: 
   foo  foo  new_col string  foo2
0    1    1        5    bah     3
1    1    2        5    bah     3
2    2    3        5    bah     3
```

This is the current default behavior now

```
In [19]: # insert a dup

In [20]: df.insert(2,'new_col',4.)
Exception: cannot insert new_col, already exists

In [21]: # insert a dup

In [22]: df.insert(2,'new_col',4.,allow_duplicates=True)

In [23]: df
Out[23]: 
   foo  foo  new_col  new_col string  foo2
0    1    1        4        5    bah     3
1    1    2        4        5    bah     3
2    2    3        4        5    bah     3
```

```
In [24]: # delete (dup)

In [25]: del df['foo']

In [26]: df
Out[26]: 
   new_col  new_col string  foo2
0        4        5    bah     3
1        4        5    bah     3
2        4        5    bah     3
```

Don't try this at home
1) duplicates across dtypes
2) assigning those duplicates

```
In [5]: df = DataFrame([[1,1,1.,5],[1,1,2.,5],[2,1,3.,5]],columns=['foo','bar','foo','hello'])

In [6]: df.dtypes
Out[6]: 
foo        int64
bar        int64
foo      float64
hello      int64
dtype: object

In [7]: df['foo'] = 'string'

In [8]: df
Out[8]: 
      foo  bar     foo  hello
0  string    1  string      5
1  string    1  string      5
2  string    1  string      5
```
