### PR TITLE
DOC: use na_rep not nanRep in .to_csv()

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -871,7 +871,7 @@ allows storing the contents of the object as a comma-separated-values file. The
 function takes a number of arguments. Only the first is required.
 
   - ``path``: A string path to the file to write
-  - ``nanRep``: A string representation of a missing value (default '')
+  - ``na_rep``: A string representation of a missing value (default '')
   - ``cols``: Columns to write (default None)
   - ``header``: Whether to write out the column names (default True)
   - ``index``: whether to write row (index) names (default True)


### PR DESCRIPTION
nanRep works but is deprecated and emits a FutureWarning.
