### PR TITLE
BUG: allow DataFrame.from_records to accept empty recarrays

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -173,6 +173,7 @@ pandas 0.11.1
   - ``read_html()`` now only allows a single backend: ``html5lib`` (GH3616_)
   - ``convert_objects`` with ``convert_dates='coerce'`` was parsing some single-letter strings
      into today's date
+  - ``DataFrame.from_records`` did not accept empty recarrays (GH3682_)
 
 .. _GH3164: https://github.com/pydata/pandas/issues/3164
 .. _GH2786: https://github.com/pydata/pandas/issues/2786
@@ -246,6 +247,7 @@ pandas 0.11.1
 .. _GH3582: https://github.com/pydata/pandas/issues/3582
 .. _GH3676: https://github.com/pydata/pandas/issues/3676
 .. _GH3675: https://github.com/pydata/pandas/issues/3675
+.. _GH3682: https://github.com/pydata/pandas/issues/3682
 
 pandas 0.11.0
 =============

--- a/doc/source/v0.11.1.txt
+++ b/doc/source/v0.11.1.txt
@@ -208,6 +208,8 @@ Bug Fixes
 
     to replace all occurrences of the string ``'.'`` with ``NaN``.
 
+  - ``DataFrame.from_records`` did not accept empty recarrays (GH3682_)
+
 See the `full release notes
 <https://github.com/pydata/pandas/blob/master/RELEASE.rst>`__ or issue tracker
 on GitHub for a complete list.
@@ -247,3 +249,4 @@ on GitHub for a complete list.
 .. _GH3582: https://github.com/pydata/pandas/issues/3582
 .. _GH3676: https://github.com/pydata/pandas/issues/3676
 .. _GH3675: https://github.com/pydata/pandas/issues/3675
+.. _GH3682: https://github.com/pydata/pandas/issues/3682

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5756,7 +5756,11 @@ def _to_arrays(data, columns, coerce_float=False, dtype=None):
 
         return arrays, columns
 
-    if len(data) == 0:
+    if not len(data):
+        if isinstance(data, np.ndarray):
+            columns = data.dtype.names
+            if columns is not None:
+                return [[]] * len(columns), columns
         return [], []  # columns if columns is not None else []
     if isinstance(data[0], (list, tuple)):
         return _list_to_arrays(data, columns, coerce_float=coerce_float,

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3522,6 +3522,18 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         expected = DataFrame(columns=['a','b','b'])
         assert_frame_equal(result, expected)
 
+    def test_from_records_empty_with_nonempty_fields_gh3682(self):
+        a = np.array([(1, 2)], dtype=[('id', np.int64), ('value', np.int64)])
+        df = DataFrame.from_records(a, index='id')
+        assert_array_equal(df.index, Index([1], name='id'))
+        self.assertEqual(df.index.name, 'id')
+        assert_array_equal(df.columns, Index(['value']))
+
+        b = np.array([], dtype=[('id', np.int64), ('value', np.int64)])
+        df = DataFrame.from_records(b, index='id')
+        assert_array_equal(df.index, Index([], name='id'))
+        self.assertEqual(df.index.name, 'id')
+
     def test_to_records_floats(self):
         df = DataFrame(np.random.rand(10, 10))
         df.to_records()


### PR DESCRIPTION
 closes #3682.
