### PR TITLE
ENH/CLN: give all AssertionErrors and nose.SkipTest raises an informative message

### DIFF
--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -528,9 +528,14 @@ class Panel(NDFrame):
         -------
         value : scalar value
         """
+        nargs = len(args)
+        nreq = self._AXIS_LEN
+
         # require an arg for each axis
-        if not ((len(args) == self._AXIS_LEN)):
-            raise AssertionError()
+        if nargs != nreq:
+            raise TypeError('There must be an argument for each axis, you gave'
+                            ' {0} args, but {1} are required'.format(nargs,
+                                                                     nreq))
 
         # hm, two layers to the onion
         frame = self._get_item_cache(args[0])
@@ -554,8 +559,13 @@ class Panel(NDFrame):
             otherwise a new object
         """
         # require an arg for each axis and the value
-        if not ((len(args) == self._AXIS_LEN + 1)):
-            raise AssertionError()
+        nargs = len(args)
+        nreq = self._AXIS_LEN + 1
+
+        if nargs != nreq:
+            raise TypeError('There must be an argument for each axis plus the '
+                            'value provided, you gave {0} args, but {1} are '
+                            'required'.format(nargs, nreq))
 
         try:
             frame = self._get_item_cache(args[0])
@@ -592,8 +602,10 @@ class Panel(NDFrame):
                 **self._construct_axes_dict_for_slice(self._AXIS_ORDERS[1:]))
             mat = value.values
         elif isinstance(value, np.ndarray):
-            if not ((value.shape == shape[1:])):
-                raise AssertionError()
+            if value.shape != shape[1:]:
+                raise ValueError('shape of value must be {0}, shape of given '
+                                 'object was {1}'.format(shape[1:],
+                                                         value.shape))
             mat = np.asarray(value)
         elif np.isscalar(value):
             dtype, value = _infer_dtype_from_scalar(value)
@@ -1144,8 +1156,9 @@ class Panel(NDFrame):
     @staticmethod
     def _extract_axes_for_slice(self, axes):
         """ return the slice dictionary for these axes """
-        return dict([(self._AXIS_SLICEMAP[i], a) for i, a
-                     in zip(self._AXIS_ORDERS[self._AXIS_LEN - len(axes):], axes)])
+        return dict([(self._AXIS_SLICEMAP[i], a)
+                     for i, a in zip(self._AXIS_ORDERS[self._AXIS_LEN -
+                                                       len(axes):], axes)])
 
     @staticmethod
     def _prep_ndarray(self, values, copy=True):
@@ -1157,8 +1170,11 @@ class Panel(NDFrame):
         else:
             if copy:
                 values = values.copy()
-        if not ((values.ndim == self._AXIS_LEN)):
-            raise AssertionError()
+        if values.ndim != self._AXIS_LEN:
+            raise ValueError("The number of dimensions required is {0}, "
+                             "but the number of dimensions of the "
+                             "ndarray given was {1}".format(self._AXIS_LEN,
+                                                            values.ndim))
         return values
 
     @staticmethod

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1299,9 +1299,6 @@ class Series(generic.NDFrame):
                                     dtype=True)
         else:
             result = u('Series([], dtype: %s)') % self.dtype
-
-        if not (isinstance(result, compat.text_type)):
-            raise AssertionError()
         return result
 
     def _tidy_repr(self, max_vals=20):
@@ -1377,7 +1374,9 @@ class Series(generic.NDFrame):
 
         # catch contract violations
         if not isinstance(the_repr, compat.text_type):
-            raise AssertionError("expected unicode string")
+            raise AssertionError("result must be of type unicode, type"
+                                 " of result is {0!r}"
+                                 "".format(the_repr.__class__.__name__))
 
         if buf is None:
             return the_repr
@@ -1397,11 +1396,16 @@ class Series(generic.NDFrame):
         """
 
         formatter = fmt.SeriesFormatter(self, name=name, header=print_header,
-                                        length=length, dtype=dtype, na_rep=na_rep,
+                                        length=length, dtype=dtype,
+                                        na_rep=na_rep,
                                         float_format=float_format)
         result = formatter.to_string()
-        if not (isinstance(result, compat.text_type)):
-            raise AssertionError()
+
+        # TODO: following check prob. not neces.
+        if not isinstance(result, compat.text_type):
+            raise AssertionError("result must be of type unicode, type"
+                                 " of result is {0!r}"
+                                 "".format(result.__class__.__name__))
         return result
 
     def __iter__(self):

--- a/pandas/io/date_converters.py
+++ b/pandas/io/date_converters.py
@@ -1,5 +1,5 @@
 """This module is designed for community supported date conversion functions"""
-from pandas.compat import range
+from pandas.compat import range, map
 import numpy as np
 import pandas.lib as lib
 
@@ -47,12 +47,16 @@ def _maybe_cast(arr):
 
 
 def _check_columns(cols):
-    if not ((len(cols) > 0)):
-        raise AssertionError()
+    if not len(cols):
+        raise AssertionError("There must be at least 1 column")
 
-    N = len(cols[0])
-    for c in cols[1:]:
-        if not ((len(c) == N)):
-            raise AssertionError()
+    head, tail = cols[0], cols[1:]
+
+    N = len(head)
+
+    for i, n in enumerate(map(len, tail)):
+        if n != N:
+            raise AssertionError('All columns must have the same length: {0}; '
+                                 'column {1} has length {2}'.format(N, i, n))
 
     return N

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -552,8 +552,10 @@ class TextFileReader(object):
 
         # type conversion-related
         if converters is not None:
-            if not (isinstance(converters, dict)):
-                raise AssertionError()
+            if not isinstance(converters, dict):
+                raise TypeError('Type converters must be a dict or'
+                                ' subclass, input was '
+                                'a {0!r}'.format(type(converters).__name__))
         else:
             converters = {}
 
@@ -630,6 +632,7 @@ class TextFileReader(object):
         if size is None:
             size = self.chunksize
         return self.read(nrows=size)
+
 
 def _is_index_col(col):
     return col is not None and col is not False
@@ -1174,6 +1177,7 @@ def TextParser(*args, **kwds):
     kwds['engine'] = 'python'
     return TextFileReader(*args, **kwds)
 
+
 # delimiter=None, dialect=None, names=None, header=0,
 # index_col=None,
 # na_values=None,
@@ -1653,8 +1657,8 @@ class PythonParser(ParserBase):
         if self._implicit_index:
             col_len += len(self.index_col)
 
-        if not ((self.skip_footer >= 0)):
-            raise AssertionError()
+        if self.skip_footer < 0:
+            raise ValueError('skip footer cannot be negative')
 
         if col_len != zip_len and self.index_col is not False:
             i = 0
@@ -1883,6 +1887,7 @@ def _clean_na_values(na_values, keep_default_na=True):
 
     return na_values, na_fvalues
 
+
 def _clean_index_names(columns, index_col):
     if not _is_index_col(index_col):
         return None, columns, index_col
@@ -1941,6 +1946,7 @@ def _floatify_na_values(na_values):
             pass
     return result
 
+
 def _stringify_na_values(na_values):
     """ return a stringified and numeric for these values """
     result = []
@@ -1964,6 +1970,7 @@ def _stringify_na_values(na_values):
         except:
             pass
     return set(result)
+
 
 def _get_na_values(col, na_values, na_fvalues):
     if isinstance(na_values, dict):
@@ -2014,15 +2021,17 @@ class FixedWidthReader(object):
             encoding = get_option('display.encoding')
         self.encoding = encoding
 
-        if not ( isinstance(colspecs, (tuple, list))):
-            raise AssertionError()
+        if not isinstance(colspecs, (tuple, list)):
+            raise TypeError("column specifications must be a list or tuple, "
+                            "input was a %r" % type(colspecs).__name__)
 
         for colspec in colspecs:
-            if not ( isinstance(colspec, (tuple, list)) and
-                       len(colspec) == 2 and
-                       isinstance(colspec[0], int) and
-                       isinstance(colspec[1], int) ):
-                raise AssertionError()
+            if not (isinstance(colspec, (tuple, list)) and
+                    len(colspec) == 2 and
+                    isinstance(colspec[0], int) and
+                    isinstance(colspec[1], int)):
+                raise TypeError('Each column specification must be '
+                                '2 element tuple or list of integers')
 
     def next(self):
         line = next(self.f)

--- a/pandas/io/tests/test_data.py
+++ b/pandas/io/tests/test_data.py
@@ -16,6 +16,13 @@ from pandas.util.testing import (assert_series_equal, assert_produces_warning,
 from numpy.testing import assert_array_equal
 
 
+def _skip_if_no_lxml():
+    try:
+        import lxml
+    except ImportError:
+        raise nose.SkipTest("no lxml")
+
+
 def assert_n_failed_equals_n_null_columns(wngs, obj, cls=SymbolWarning):
     all_nan_cols = pd.Series(dict((k, pd.isnull(v).all()) for k, v in
                                   compat.iteritems(obj)))
@@ -88,10 +95,7 @@ class TestGoogle(unittest.TestCase):
 class TestYahoo(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        try:
-            import lxml
-        except ImportError:
-            raise nose.SkipTest
+        _skip_if_no_lxml()
 
     @network
     def test_yahoo(self):
@@ -210,10 +214,7 @@ class TestYahoo(unittest.TestCase):
 class TestYahooOptions(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        try:
-            import lxml
-        except ImportError:
-            raise nose.SkipTest
+        _skip_if_no_lxml()
 
         # aapl has monthlies
         cls.aapl = web.Options('aapl', 'yahoo')
@@ -272,10 +273,7 @@ class TestYahooOptions(unittest.TestCase):
 class TestOptionsWarnings(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        try:
-            import lxml
-        except ImportError:
-            raise nose.SkipTest
+        _skip_if_no_lxml()
 
         with assert_produces_warning(FutureWarning):
             cls.aapl = web.Options('aapl')

--- a/pandas/io/tests/test_ga.py
+++ b/pandas/io/tests/test_ga.py
@@ -14,7 +14,7 @@ try:
     from pandas.io.auth import AuthenticationConfigError, reset_token_store
     from pandas.io import auth
 except ImportError:
-    raise nose.SkipTest
+    raise nose.SkipTest("need httplib2 and auth libs")
 
 class TestGoogle(unittest.TestCase):
 
@@ -68,7 +68,7 @@ class TestGoogle(unittest.TestCase):
             assert_frame_equal(df, df2)
 
         except AuthenticationConfigError:
-            raise nose.SkipTest
+            raise nose.SkipTest("authentication error")
 
     @slow
     @with_connectivity_check("http://www.google.com")
@@ -96,7 +96,7 @@ class TestGoogle(unittest.TestCase):
             assert (df2.index > df1.index).all()
 
         except AuthenticationConfigError:
-            raise nose.SkipTest
+            raise nose.SkipTest("authentication error")
 
     @slow
     @with_connectivity_check("http://www.google.com")
@@ -150,7 +150,8 @@ class TestGoogle(unittest.TestCase):
             assert 'pageviewsPerVisit' in df
 
         except AuthenticationConfigError:
-            raise nose.SkipTest
+            raise nose.SkipTest("authentication error")
+
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/pandas/io/tests/test_json/test_pandas.py
+++ b/pandas/io/tests/test_json/test_pandas.py
@@ -567,17 +567,11 @@ class TestPandasContainer(unittest.TestCase):
         assert_frame_equal(result.reindex(index=df.index,columns=df.columns),df)
 
     @network
-    @slow
     def test_url(self):
-        try:
+        url = 'https://api.github.com/repos/pydata/pandas/issues?per_page=5'
+        result = read_json(url,convert_dates=True)
+        for c in ['created_at','closed_at','updated_at']:
+            self.assert_(result[c].dtype == 'datetime64[ns]')
 
-            url = 'https://api.github.com/repos/pydata/pandas/issues?per_page=5'
-            result = read_json(url,convert_dates=True)
-            for c in ['created_at','closed_at','updated_at']:
-                self.assert_(result[c].dtype == 'datetime64[ns]')
-
-            url = 'http://search.twitter.com/search.json?q=pandas%20python'
-            result = read_json(url)
-
-        except URLError:
-            raise nose.SkipTest
+        url = 'http://search.twitter.com/search.json?q=pandas%20python'
+        result = read_json(url)

--- a/pandas/io/tests/test_json/test_ujson.py
+++ b/pandas/io/tests/test_json/test_ujson.py
@@ -29,7 +29,7 @@ import pandas.util.testing as tm
 def _skip_if_python_ver(skip_major, skip_minor=None):
     major, minor = sys.version_info[:2]
     if major == skip_major and (skip_minor is None or minor == skip_minor):
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping Python version %d.%d" % (major, minor))
 
 json_unicode = (json.dumps if sys.version_info[0] >= 3
                 else partial(json.dumps, encoding="utf-8"))
@@ -363,7 +363,8 @@ class UltraJSONTests(TestCase):
     def test_npy_nat(self):
         from distutils.version import LooseVersion
         if LooseVersion(np.__version__) < '1.7.0':
-            raise nose.SkipTest
+            raise nose.SkipTest("numpy version < 1.7.0, is "
+                                "{0}".format(np.__version__))
 
         input = np.datetime64('NaT')
         assert ujson.encode(input) == 'null', "Expected null"

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -2295,7 +2295,7 @@ class TestHDFStore(unittest.TestCase):
     def test_timeseries_preepoch(self):
 
         if sys.version_info[0] == 2 and sys.version_info[1] < 7:
-            raise nose.SkipTest
+            raise nose.SkipTest("won't work on Python < 2.7")
 
         dr = bdate_range('1/1/1940', '1/1/1960')
         ts = Series(np.random.randn(len(dr)), index=dr)
@@ -3599,7 +3599,7 @@ class TestHDFStore(unittest.TestCase):
             safe_remove(self.path)
 
     def test_legacy_table_write(self):
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping for now")
 
         store = HDFStore(tm.get_data_path('legacy_hdf/legacy_table_%s.h5' % pandas.__version__), 'a')
 

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -431,7 +431,7 @@ class TestMySQL(unittest.TestCase):
         try:
             import MySQLdb
         except ImportError:
-            raise nose.SkipTest
+            raise nose.SkipTest("no MySQLdb")
         frame = tm.makeTimeDataFrame()
         drop_sql = "DROP TABLE IF EXISTS test_table"
         cur = self.db.cursor()
@@ -456,7 +456,7 @@ class TestMySQL(unittest.TestCase):
         try:
             import MySQLdb
         except ImportError:
-            raise nose.SkipTest
+            raise nose.SkipTest("no MySQLdb")
         frame = tm.makeTimeDataFrame()
         drop_sql = "DROP TABLE IF EXISTS test_table"
         cur = self.db.cursor()

--- a/pandas/io/tests/test_wb.py
+++ b/pandas/io/tests/test_wb.py
@@ -10,7 +10,7 @@ from pandas.io.wb import search, download
 @slow
 @network
 def test_wdi_search():
-    raise nose.SkipTest
+    raise nose.SkipTest("skipping for now")
     expected = {u('id'): {2634: u('GDPPCKD'),
                         4649: u('NY.GDP.PCAP.KD'),
                         4651: u('NY.GDP.PCAP.KN'),
@@ -30,7 +30,7 @@ def test_wdi_search():
 @slow
 @network
 def test_wdi_download():
-    raise nose.SkipTest
+    raise nose.SkipTest("skipping for now")
     expected = {'GDPPCKN': {(u('United States'), u('2003')): u('40800.0735367688'), (u('Canada'), u('2004')): u('37857.1261134552'), (u('United States'), u('2005')): u('42714.8594790102'), (u('Canada'), u('2003')): u('37081.4575704003'), (u('United States'), u('2004')): u('41826.1728310667'), (u('Mexico'), u('2003')): u('72720.0691255285'), (u('Mexico'), u('2004')): u('74751.6003347038'), (u('Mexico'), u('2005')): u('76200.2154469437'), (u('Canada'), u('2005')): u('38617.4563629611')}, 'GDPPCKD': {(u('United States'), u('2003')): u('40800.0735367688'), (u('Canada'), u('2004')): u('34397.055116118'), (u('United States'), u('2005')): u('42714.8594790102'), (u('Canada'), u('2003')): u('33692.2812368928'), (u('United States'), u('2004')): u('41826.1728310667'), (u('Mexico'), u('2003')): u('7608.43848670658'), (u('Mexico'), u('2004')): u('7820.99026814334'), (u('Mexico'), u('2005')): u('7972.55364129367'), (u('Canada'), u('2005')): u('35087.8925933298')}}
     expected = pandas.DataFrame(expected)
     result = download(country=['CA', 'MX', 'US', 'junk'], indicator=['GDPPCKD',

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -25,7 +25,6 @@ from pandas.core.internals import BlockManager, create_block_manager_from_arrays
 from pandas.core.generic import NDFrame
 from pandas.sparse.series import SparseSeries, SparseArray
 from pandas.util.decorators import Appender
-import pandas.lib as lib
 
 
 class SparseDataFrame(DataFrame):
@@ -601,20 +600,15 @@ class SparseDataFrame(DataFrame):
 
     def _join_compat(self, other, on=None, how='left', lsuffix='', rsuffix='',
                      sort=False):
-        if isinstance(other, Series):
-            if other.name is None:
-                raise ValueError('Other Series must have a name')
-            other = SparseDataFrame({other.name: other},
-                                    default_fill_value=self._default_fill_value)
         if on is not None:
-            raise NotImplementedError
-        else:
-            return self._join_index(other, how, lsuffix, rsuffix)
+            raise NotImplementedError("'on' keyword parameter is not yet "
+                                      "implemented")
+        return self._join_index(other, how, lsuffix, rsuffix)
 
     def _join_index(self, other, how, lsuffix, rsuffix):
         if isinstance(other, Series):
-            if not (other.name is not None):
-                raise AssertionError()
+            if other.name is None:
+                raise ValueError('Other Series must have a name')
 
             other = SparseDataFrame({other.name: other},
                                     default_fill_value=self._default_fill_value)

--- a/pandas/sparse/panel.py
+++ b/pandas/sparse/panel.py
@@ -77,8 +77,9 @@ class SparsePanel(Panel):
                                     default_kind=default_kind)
             frames = new_frames
 
-        if not (isinstance(frames, dict)):
-            raise AssertionError()
+        if not isinstance(frames, dict):
+            raise TypeError('input must be a dict, a %r was passed' %
+                            type(frames).__name__)
 
         self.default_fill_value = fill_value = default_fill_value
         self.default_kind = kind = default_kind
@@ -99,7 +100,7 @@ class SparsePanel(Panel):
         # do we want to fill missing ones?
         for item in items:
             if item not in clean_frames:
-                raise Exception('column %s not found in data' % item)
+                raise ValueError('column %r not found in data' % item)
 
         self._items = items
         self.major_axis = major_axis

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -555,8 +555,8 @@ class SparseSeries(Series):
         -------
         reindexed : SparseSeries
         """
-        if not (isinstance(new_index, splib.SparseIndex)):
-            raise AssertionError()
+        if not isinstance(new_index, splib.SparseIndex):
+            raise TypeError('new index must be a SparseIndex')
 
         block = self.block.sparse_reindex(new_index)
         new_data = SingleBlockManager(block, block.ref_items)

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -488,7 +488,7 @@ class TestSparseSeries(TestCase,
     def test_binary_operators(self):
 
         # skipping for now #####
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping sparse binary operators test")
 
         def _check_inplace_op(iop, op):
             tmp = self.bseries.copy()
@@ -539,7 +539,7 @@ class TestSparseSeries(TestCase,
 
         reindexed = self.bseries.reindex(self.bseries.index, copy=False)
         reindexed.sp_values[:] = 1.
-        self.assert_((self.bseries.sp_values == 1.).all())
+        np.testing.assert_array_equal(self.bseries.sp_values, 1.)
 
     def test_sparse_reindex(self):
         length = 10
@@ -582,6 +582,13 @@ class TestSparseSeries(TestCase,
         _check_all(values1, index1, [0, 1])
         _check_all(values1, index1, [0, 1, 7, 8, 9])
         _check_all(values1, index1, [])
+
+        first_series = SparseSeries(values1, sparse_index=IntIndex(length,
+                                                                   index1),
+                                    fill_value=nan)
+        with tm.assertRaisesRegexp(TypeError,
+                                   'new index must be a SparseIndex'):
+            reindexed = first_series.sparse_reindex(0)
 
     def test_repr(self):
         bsrepr = repr(self.bseries)
@@ -1308,6 +1315,10 @@ class TestSparseDataFrame(TestCase, test_frame.SafeForSparse):
         right = self.frame.ix[:, ['B', 'D']]
         self.assertRaises(Exception, left.join, right)
 
+        with tm.assertRaisesRegexp(ValueError, 'Other Series must have a name'):
+            self.frame.join(Series(np.random.randn(len(self.frame)),
+                                   index=self.frame.index))
+
     def test_reindex(self):
 
         def _check_frame(frame):
@@ -1576,8 +1587,11 @@ class TestSparsePanel(TestCase,
         assert_sp_frame_equal(result['ItemA'], op(panel['ItemA'], 1))
 
     def test_constructor(self):
-        self.assertRaises(Exception, SparsePanel, self.data_dict,
+        self.assertRaises(ValueError, SparsePanel, self.data_dict,
                           items=['Item0', 'ItemA', 'ItemB'])
+        with tm.assertRaisesRegexp(TypeError,
+                                   "input must be a dict, a 'list' was passed"):
+            SparsePanel(['a', 'b', 'c'])
 
     def test_from_dict(self):
         fd = SparsePanel.from_dict(self.data_dict)

--- a/pandas/stats/ols.py
+++ b/pandas/stats/ols.py
@@ -1216,8 +1216,9 @@ class MovingOLS(OLS):
         return result.astype(int)
 
     def _beta_matrix(self, lag=0):
-        if not ((lag >= 0)):
-            raise AssertionError()
+        if lag < 0:
+            raise AssertionError("'lag' must be greater than or equal to 0, "
+                                 "input was {0}".format(lag))
 
         betas = self._beta_raw
 
@@ -1280,8 +1281,8 @@ def _filter_data(lhs, rhs, weights=None):
         Cleaned lhs and rhs
     """
     if not isinstance(lhs, Series):
-        if not ((len(lhs) == len(rhs))):
-            raise AssertionError()
+        if len(lhs) != len(rhs):
+            raise AssertionError("length of lhs must equal length of rhs")
         lhs = Series(lhs, index=rhs.index)
 
     rhs = _combine_rhs(rhs)

--- a/pandas/stats/plm.py
+++ b/pandas/stats/plm.py
@@ -103,10 +103,12 @@ class PanelOLS(OLS):
             y_regressor = y
 
         if weights is not None:
-            if not ((y_regressor.index.equals(weights.index))):
-                raise AssertionError()
-            if not ((x_regressor.index.equals(weights.index))):
-                raise AssertionError()
+            if not y_regressor.index.equals(weights.index):
+                raise AssertionError("y_regressor and weights must have the "
+                                     "same index")
+            if not x_regressor.index.equals(weights.index):
+                raise AssertionError("x_regressor and weights must have the "
+                                     "same index")
 
             rt_weights = np.sqrt(weights)
             y_regressor = y_regressor * rt_weights
@@ -173,8 +175,10 @@ class PanelOLS(OLS):
         # .iteritems
         iteritems = getattr(x, 'iteritems', x.items)
         for key, df in iteritems():
-            if not ((isinstance(df, DataFrame))):
-                raise AssertionError()
+            if not isinstance(df, DataFrame):
+                raise AssertionError("all input items must be DataFrames, "
+                                     "at least one is of "
+                                     "type {0}".format(type(df)))
 
             if _is_numeric(df):
                 x_converted[key] = df
@@ -642,8 +646,9 @@ class MovingPanelOLS(MovingOLS, PanelOLS):
         return (betas * x).sum(1)
 
     def _beta_matrix(self, lag=0):
-        if not ((lag >= 0)):
-            raise AssertionError()
+        if lag < 0:
+            raise AssertionError("'lag' must be greater than or equal to 0, "
+                                 "input was {0}".format(lag))
 
         index = self._y_trans.index
         major_labels = index.labels[0]

--- a/pandas/stats/tests/test_math.py
+++ b/pandas/stats/tests/test_math.py
@@ -49,7 +49,7 @@ class TestMath(unittest.TestCase):
 
     def test_solve_rect(self):
         if not _have_statsmodels:
-            raise nose.SkipTest
+            raise nose.SkipTest("no statsmodels")
 
         b = Series(np.random.randn(N), self.frame.index)
         result = pmath.solve(self.frame, b)

--- a/pandas/stats/tests/test_moments.py
+++ b/pandas/stats/tests/test_moments.py
@@ -22,7 +22,7 @@ def _skip_if_no_scipy():
     try:
         import scipy.stats
     except ImportError:
-        raise nose.SkipTest
+        raise nose.SkipTest("no scipy.stats")
 
 class TestMoments(unittest.TestCase):
 
@@ -73,7 +73,7 @@ class TestMoments(unittest.TestCase):
         try:
             from scikits.timeseries.lib import cmov_mean
         except ImportError:
-            raise nose.SkipTest
+            raise nose.SkipTest("no scikits.timeseries")
 
         vals = np.random.randn(10)
         xp = cmov_mean(vals, 5)
@@ -91,7 +91,7 @@ class TestMoments(unittest.TestCase):
         try:
             from scikits.timeseries.lib import cmov_window
         except ImportError:
-            raise nose.SkipTest
+            raise nose.SkipTest("no scikits.timeseries")
 
         vals = np.random.randn(10)
         xp = cmov_window(vals, 5, 'boxcar')
@@ -109,7 +109,7 @@ class TestMoments(unittest.TestCase):
         try:
             from scikits.timeseries.lib import cmov_window
         except ImportError:
-            raise nose.SkipTest
+            raise nose.SkipTest("no scikits.timeseries")
 
         # all nan
         vals = np.empty(10, dtype=float)
@@ -133,7 +133,7 @@ class TestMoments(unittest.TestCase):
         try:
             from scikits.timeseries.lib import cmov_window
         except ImportError:
-            raise nose.SkipTest
+            raise nose.SkipTest("no scikits.timeseries")
 
         # DataFrame
         vals = np.random.randn(10, 2)
@@ -146,7 +146,7 @@ class TestMoments(unittest.TestCase):
         try:
             from scikits.timeseries.lib import cmov_window
         except ImportError:
-            raise nose.SkipTest
+            raise nose.SkipTest("no scikits.timeseries")
 
         # min_periods
         vals = Series(np.random.randn(10))
@@ -163,7 +163,7 @@ class TestMoments(unittest.TestCase):
         try:
             from scikits.timeseries.lib import cmov_window
         except ImportError:
-            raise nose.SkipTest
+            raise nose.SkipTest("no scikits.timeseries")
 
         win_types = ['triang', 'blackman', 'hamming', 'bartlett', 'bohman',
                      'blackmanharris', 'nuttall', 'barthann']
@@ -179,7 +179,7 @@ class TestMoments(unittest.TestCase):
         try:
             from scikits.timeseries.lib import cmov_window
         except ImportError:
-            raise nose.SkipTest
+            raise nose.SkipTest("no scikits.timeseries")
 
         win_types = ['kaiser', 'gaussian', 'general_gaussian', 'slepian']
         kwds = [{'beta': 1.}, {'std': 1.}, {'power': 2., 'width': 2.},
@@ -319,7 +319,7 @@ class TestMoments(unittest.TestCase):
     def test_fperr_robustness(self):
         # TODO: remove this once python 2.5 out of picture
         if PY3:
-            raise nose.SkipTest
+            raise nose.SkipTest("doesn't work on python 3")
 
         # #2114
         data = '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x1a@\xaa\xaa\xaa\xaa\xaa\xaa\x02@8\x8e\xe38\x8e\xe3\xe8?z\t\xed%\xb4\x97\xd0?\xa2\x0c<\xdd\x9a\x1f\xb6?\x82\xbb\xfa&y\x7f\x9d?\xac\'\xa7\xc4P\xaa\x83?\x90\xdf\xde\xb0k8j?`\xea\xe9u\xf2zQ?*\xe37\x9d\x98N7?\xe2.\xf5&v\x13\x1f?\xec\xc9\xf8\x19\xa4\xb7\x04?\x90b\xf6w\x85\x9f\xeb>\xb5A\xa4\xfaXj\xd2>F\x02\xdb\xf8\xcb\x8d\xb8>.\xac<\xfb\x87^\xa0>\xe8:\xa6\xf9_\xd3\x85>\xfb?\xe2cUU\xfd?\xfc\x7fA\xed8\x8e\xe3?\xa5\xaa\xac\x91\xf6\x12\xca?n\x1cs\xb6\xf9a\xb1?\xe8%D\xf3L-\x97?5\xddZD\x11\xe7~?#>\xe7\x82\x0b\x9ad?\xd9R4Y\x0fxK?;7x;\nP2?N\xf4JO\xb8j\x18?4\xf81\x8a%G\x00?\x9a\xf5\x97\r2\xb4\xe5>\xcd\x9c\xca\xbcB\xf0\xcc>3\x13\x87(\xd7J\xb3>\x99\x19\xb4\xe0\x1e\xb9\x99>ff\xcd\x95\x14&\x81>\x88\x88\xbc\xc7p\xddf>`\x0b\xa6_\x96|N>@\xb2n\xea\x0eS4>U\x98\x938i\x19\x1b>\x8eeb\xd0\xf0\x10\x02>\xbd\xdc-k\x96\x16\xe8=(\x93\x1e\xf2\x0e\x0f\xd0=\xe0n\xd3Bii\xb5=*\xe9\x19Y\x8c\x8c\x9c=\xc6\xf0\xbb\x90]\x08\x83=]\x96\xfa\xc0|`i=>d\xfc\xd5\xfd\xeaP=R0\xfb\xc7\xa7\x8e6=\xc2\x95\xf9_\x8a\x13\x1e=\xd6c\xa6\xea\x06\r\x04=r\xda\xdd8\t\xbc\xea<\xf6\xe6\x93\xd0\xb0\xd2\xd1<\x9d\xdeok\x96\xc3\xb7<&~\xea9s\xaf\x9f<UUUUUU\x13@q\x1c\xc7q\x1c\xc7\xf9?\xf6\x12\xdaKh/\xe1?\xf2\xc3"e\xe0\xe9\xc6?\xed\xaf\x831+\x8d\xae?\xf3\x1f\xad\xcb\x1c^\x94?\x15\x1e\xdd\xbd>\xb8\x02@\xc6\xd2&\xfd\xa8\xf5\xe8?\xd9\xe1\x19\xfe\xc5\xa3\xd0?v\x82"\xa8\xb2/\xb6?\x9dX\x835\xee\x94\x9d?h\x90W\xce\x9e\xb8\x83?\x8a\xc0th~Kj?\\\x80\xf8\x9a\xa9\x87Q?%\xab\xa0\xce\x8c_7?1\xe4\x80\x13\x11*\x1f? \x98\x00\r\xb6\xc6\x04?\x80u\xabf\x9d\xb3\xeb>UNrD\xbew\xd2>\x1c\x13C[\xa8\x9f\xb8>\x12b\xd7<pj\xa0>m-\x1fQ@\xe3\x85>\xe6\x91)l\x00/m>Da\xc6\xf2\xaatS>\x05\xd7]\xee\xe3\xf09>'

--- a/pandas/stats/tests/test_ols.py
+++ b/pandas/stats/tests/test_ols.py
@@ -6,9 +6,9 @@ Unit test suite for OLS and PanelOLS classes
 
 from __future__ import division
 
-from distutils.version import LooseVersion
 from datetime import datetime
 from pandas import compat
+from distutils.version import LooseVersion
 import unittest
 import nose
 import numpy as np
@@ -77,7 +77,7 @@ class TestOLS(BaseTest):
             pass
 
         if not _have_statsmodels:
-            raise nose.SkipTest
+            raise nose.SkipTest("no statsmodels")
 
     def testOLSWithDatasets_ccard(self):
         self.checkDataSet(sm.datasets.ccard.load(), skip_moving=True)
@@ -262,7 +262,7 @@ class TestOLSMisc(unittest.TestCase):
     @classmethod
     def setupClass(cls):
         if not _have_statsmodels:
-            raise nose.SkipTest
+            raise nose.SkipTest("no statsmodels")
 
     def test_f_test(self):
         x = tm.makeTimeDataFrame()

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -35,7 +35,7 @@ class TestCategorical(unittest.TestCase):
         tm.assert_almost_equal(subf.labels, [2, 2, 2])
 
     def test_constructor_unsortable(self):
-        raise nose.SkipTest
+        raise nose.SkipTest('skipping for now')
 
         arr = np.array([1, 2, 3, datetime.now()], dtype='O')
 

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -18,8 +18,13 @@ from pandas import compat
 
 
 if not expr._USE_NUMEXPR:
-    raise nose.SkipTest("numexpr not available")
-
+    try:
+        import numexpr
+    except ImportError:
+        msg = "don't have"
+    else:
+        msg = "not using"
+    raise nose.SkipTest("{0} numexpr".format(msg))
 
 _frame  = DataFrame(randn(10000, 4), columns=list('ABCD'), dtype='float64')
 _frame2 = DataFrame(randn(100, 4),   columns = list('ABCD'), dtype='float64')

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -202,7 +202,8 @@ class TestDataFrameFormatting(unittest.TestCase):
     def test_repr_max_columns_max_rows(self):
         term_width, term_height = get_terminal_size()
         if term_width < 10 or term_height < 10:
-            raise nose.SkipTest
+            raise nose.SkipTest("terminal size too small, "
+                                "{0} x {1}".format(term_width, term_height))
 
         def mkframe(n):
             index = ['%05d' % i for i in range(n)]
@@ -766,7 +767,7 @@ class TestDataFrameFormatting(unittest.TestCase):
         from pandas.core.common import pprint_thing as pp_t
 
         if PY3:
-            raise nose.SkipTest()
+            raise nose.SkipTest("doesn't work on Python 3")
 
         self.assertEquals(pp_t('a') , u('a'))
         self.assertEquals(pp_t(u('a')) , u('a'))

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -60,7 +60,7 @@ def _skip_if_no_scipy():
     try:
         import scipy.stats
     except ImportError:
-        raise nose.SkipTest
+        raise nose.SkipTest("no scipy.stats module")
 
 #---------------------------------------------------------------------
 # DataFrame test cases
@@ -9498,7 +9498,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self._check_stat_op('sum', np.sum, has_numeric_only=True)
 
     def test_sum_mixed_numeric(self):
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping for now")
         # mixed types
         self._check_stat_op('sum', np.sum, frame = self.mixed_float, has_numeric_only=True)
 
@@ -10910,10 +10910,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self.assert_(isnull(Y['g']['c']))
 
     def test_index_namedtuple(self):
-        try:
-            from collections import namedtuple
-        except ImportError:
-            raise nose.SkipTest
+        from collections import namedtuple
         IndexType = namedtuple("IndexType", ["a", "b"])
         idx1 = IndexType("foo", "bar")
         idx2 = IndexType("baz", "bof")

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -26,7 +26,7 @@ def _skip_if_no_scipy():
     try:
         import scipy
     except ImportError:
-        raise nose.SkipTest
+        raise nose.SkipTest("no scipy")
 
 
 @tm.mplskip

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -1414,7 +1414,7 @@ class TestMultiIndex(unittest.TestCase):
 
     def test_legacy_pickle(self):
         if compat.PY3:
-            raise nose.SkipTest
+            raise nose.SkipTest("doesn't work on Python 3")
 
         def curpath():
             pth, _ = os.path.split(os.path.abspath(__file__))

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -195,7 +195,7 @@ class TestBlock(unittest.TestCase):
 
         # with dup column support this method was taken out
         # GH3679
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping for now")
 
         bs = list(self.fblock.split_block_at('a'))
         self.assertEqual(len(bs), 1)

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1419,7 +1419,7 @@ Thur,Lunch,Yes,51.51,17"""
     # AMBIGUOUS CASES!
 
     def test_partial_ix_missing(self):
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping for now")
 
         result = self.ymd.ix[2000, 0]
         expected = self.ymd.ix[2000]['A']

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -73,7 +73,7 @@ class SafeForLongAndSparse(object):
         try:
             from scipy.stats import skew
         except ImportError:
-            raise nose.SkipTest
+            raise nose.SkipTest("no scipy.stats.skew")
 
         def this_skew(x):
             if len(x) < 3:
@@ -397,7 +397,7 @@ class CheckIndexing(object):
         test_comp(operator.le)
 
     def test_setitem_ndarray(self):
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping for now")
     #    from pandas import DateRange, datetools
 
     #    timeidx = DateRange(start=datetime(2009,1,1),
@@ -510,7 +510,7 @@ class CheckIndexing(object):
         pass
 
     def test_getitem_fancy_xs(self):
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping for now")
         # self.assertRaises(NotImplementedError, self.panel4d.major_xs)
         # self.assertRaises(NotImplementedError, self.panel4d.minor_xs)
 
@@ -706,7 +706,7 @@ class TestPanel4d(unittest.TestCase, CheckIndexing, SafeForSparse,
         assert_panel4d_equal(result, expected)
 
     def test_from_dict_mixed_orient(self):
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping for now")
     #    df = tm.makeDataFrame()
     #    df['foo'] = 'bar'
 
@@ -798,7 +798,7 @@ class TestPanel4d(unittest.TestCase, CheckIndexing, SafeForSparse,
         assert_panel4d_equal(smaller, smaller_like)
 
     def test_take(self):
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping for now")
 
     #    # axis == 0
     #    result = self.panel.take([2, 0, 1], axis=0)
@@ -876,7 +876,7 @@ class TestPanel4d(unittest.TestCase, CheckIndexing, SafeForSparse,
         self.assert_(id(self.panel4d) != id(result))
 
     def test_to_frame(self):
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping for now")
     #    # filtered
     #    filtered = self.panel.to_frame()
     #    expected = self.panel.to_frame().dropna(how='any')
@@ -890,7 +890,7 @@ class TestPanel4d(unittest.TestCase, CheckIndexing, SafeForSparse,
     #    self.assertEqual(unfiltered.index.names, ('major', 'minor'))
 
     def test_to_frame_mixed(self):
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping for now")
     #    panel = self.panel.fillna(0)
     #    panel['str'] = 'foo'
     #    panel['bool'] = panel['ItemA'] > 0
@@ -928,20 +928,20 @@ class TestPanel4d(unittest.TestCase, CheckIndexing, SafeForSparse,
         assert_panel4d_equal(p4d, expected)
 
     def test_filter(self):
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping for now")
 
     def test_apply(self):
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping for now")
 
     def test_compound(self):
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping for now")
     #    compounded = self.panel.compound()
 
     #    assert_series_equal(compounded['ItemA'],
     #                        (1 + self.panel['ItemA']).product(0) - 1)
 
     def test_shift(self):
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping for now")
     #    # major
     #    idx = self.panel.major_axis[0]
     #    idx_lag = self.panel.major_axis[1]
@@ -963,7 +963,7 @@ class TestPanel4d(unittest.TestCase, CheckIndexing, SafeForSparse,
     #    self.assertRaises(Exception, self.panel.shift, 1, axis='items')
 
     def test_multiindex_get(self):
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping for now")
     #    ind = MultiIndex.from_tuples([('a', 1), ('a', 2), ('b', 1), ('b',2)],
     #                                 names=['first', 'second'])
     #    wp = Panel(np.random.random((4,5,5)),
@@ -981,7 +981,7 @@ class TestPanel4d(unittest.TestCase, CheckIndexing, SafeForSparse,
     #                                 names=['first', 'second'])
 
     def test_multiindex_blocks(self):
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping for now")
     #    ind = MultiIndex.from_tuples([('a', 1), ('a', 2), ('b', 1)],
     #                                 names=['first', 'second'])
     #    wp = Panel(self.panel._data)
@@ -1034,10 +1034,10 @@ class TestPanel4d(unittest.TestCase, CheckIndexing, SafeForSparse,
         self.assertRaises(Exception, group_agg, values, bounds, f2)
 
     def test_from_frame_level1_unsorted(self):
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping for now")
 
     def test_to_excel(self):
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping for now")
 
 
 if __name__ == '__main__':

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -5,6 +5,7 @@ import operator
 import unittest
 import string
 from itertools import product, starmap
+from distutils.version import LooseVersion
 
 import nose
 
@@ -37,14 +38,14 @@ def _skip_if_no_scipy():
     try:
         import scipy.stats
     except ImportError:
-        raise nose.SkipTest
+        raise nose.SkipTest("scipy not installed")
 
 
 def _skip_if_no_pytz():
     try:
         import pytz
     except ImportError:
-        raise nose.SkipTest
+        raise nose.SkipTest("pytz not installed")
 
 #------------------------------------------------------------------------------
 # Series test cases
@@ -1772,7 +1773,8 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         self.assert_(np.array_equal(result, expected))
 
     def test_npdiff(self):
-        raise nose.SkipTest
+        raise nose.SkipTest("skipping due to Series no longer being an "
+                            "ndarray")
 
         # no longer works as the return type of np.diff is now nd.array
         s = Series(np.arange(5))
@@ -3098,8 +3100,9 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         self.assertAlmostEqual(result, expected)
 
         # these methods got rewritten in 0.8
-        if int(scipy.__version__.split('.')[1]) < 9:
-            raise nose.SkipTest
+        if scipy.__version__ < LooseVersion('0.9'):
+            raise nose.SkipTest("skipping corr rank because of scipy version "
+                                "{0}".format(scipy.__version__))
 
         # results from R
         A = Series([-0.89926396, 0.94209606, -1.03289164, -0.95445587,

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -407,17 +407,19 @@ class _MergeOperation(object):
         elif self.left_on is not None:
             n = len(self.left_on)
             if self.right_index:
-                if not ((len(self.left_on) == self.right.index.nlevels)):
-                    raise AssertionError()
+                if len(self.left_on) != self.right.index.nlevels:
+                    raise ValueError('len(left_on) must equal the number '
+                                         'of levels in the index of "right"')
                 self.right_on = [None] * n
         elif self.right_on is not None:
             n = len(self.right_on)
             if self.left_index:
-                if not ((len(self.right_on) == self.left.index.nlevels)):
-                    raise AssertionError()
+                if len(self.right_on) != self.left.index.nlevels:
+                    raise ValueError('len(right_on) must equal the number '
+                                         'of levels in the index of "left"')
                 self.left_on = [None] * n
-        if not ((len(self.right_on) == len(self.left_on))):
-            raise AssertionError()
+        if len(self.right_on) != len(self.left_on):
+            raise ValueError("len(right_on) must equal len(left_on)")
 
 
 def _get_join_indexers(left_keys, right_keys, sort=False, how='inner'):
@@ -430,8 +432,8 @@ def _get_join_indexers(left_keys, right_keys, sort=False, how='inner'):
     -------
 
     """
-    if not ((len(left_keys) == len(right_keys))):
-        raise AssertionError()
+    if len(left_keys) != len(right_keys):
+        raise AssertionError('left_key and right_keys must be the same length')
 
     left_labels = []
     right_labels = []
@@ -545,8 +547,11 @@ def _left_join_on_index(left_ax, right_ax, join_keys, sort=False):
 
     if len(join_keys) > 1:
         if not ((isinstance(right_ax, MultiIndex) and
-               len(join_keys) == right_ax.nlevels) ):
-            raise AssertionError()
+                 len(join_keys) == right_ax.nlevels)):
+            raise AssertionError("If more than one join key is given then "
+                                 "'right_ax' must be a MultiIndex and the "
+                                 "number of join keys must be the number of "
+                                 "levels in right_ax")
 
         left_tmp, right_indexer = \
             _get_multiindex_indexer(join_keys, right_ax,
@@ -645,8 +650,9 @@ class _BlockJoinOperation(object):
         if axis <= 0:  # pragma: no cover
             raise MergeError('Only axis >= 1 supported for this operation')
 
-        if not ((len(data_list) == len(indexers))):
-            raise AssertionError()
+        if len(data_list) != len(indexers):
+            raise AssertionError("data_list and indexers must have the same "
+                                 "length")
 
         self.units = []
         for data, indexer in zip(data_list, indexers):
@@ -977,8 +983,9 @@ class _Concatenator(object):
             axis = 1 if axis == 0 else 0
 
         self._is_series = isinstance(sample, ABCSeries)
-        if not ((0 <= axis <= sample.ndim)):
-            raise AssertionError()
+        if not 0 <= axis <= sample.ndim:
+            raise AssertionError("axis must be between 0 and {0}, "
+                                 "input was {1}".format(sample.ndim, axis))
 
         # note: this is the BlockManager axis (since DataFrame is transposed)
         self.axis = axis
@@ -1202,8 +1209,9 @@ class _Concatenator(object):
                 to_concat.append(item_values)
 
         # this method only gets called with axis >= 1
-        if not ((self.axis >= 1)):
-            raise AssertionError()
+        if self.axis < 1:
+            raise AssertionError("axis must be >= 1, input was"
+                                 " {0}".format(self.axis))
         return com._concat_compat(to_concat, axis=self.axis - 1)
 
     def _get_result_dim(self):
@@ -1222,8 +1230,9 @@ class _Concatenator(object):
                     continue
                 new_axes[i] = self._get_comb_axis(i)
         else:
-            if not ((len(self.join_axes) == ndim - 1)):
-                raise AssertionError()
+            if len(self.join_axes) != ndim - 1:
+                raise AssertionError("length of join_axes must not be "
+                                     "equal to {0}".format(ndim - 1))
 
             # ufff...
             indices = lrange(ndim)

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -386,8 +386,8 @@ def _get_names(arrs, names, prefix='row'):
             else:
                 names.append('%s_%d' % (prefix, i))
     else:
-        if not ((len(names) == len(arrs))):
-            raise AssertionError()
+        if len(names) != len(arrs):
+            raise AssertionError('arrays and names must have the same length')
         if not isinstance(names, list):
             names = list(names)
 

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -231,6 +231,33 @@ class TestMerge(unittest.TestCase):
         source_copy['A'] = 0
         self.assertRaises(Exception, target.join, source_copy, on='A')
 
+    def test_join_on_fails_with_different_right_index(self):
+        with tm.assertRaises(ValueError):
+            df = DataFrame({'a': tm.choice(['m', 'f'], size=3),
+                            'b': np.random.randn(3)})
+            df2 = DataFrame({'a': tm.choice(['m', 'f'], size=10),
+                             'b': np.random.randn(10)},
+                            index=tm.makeCustomIndex(10, 2))
+            merge(df, df2, left_on='a', right_index=True)
+
+    def test_join_on_fails_with_different_left_index(self):
+        with tm.assertRaises(ValueError):
+            df = DataFrame({'a': tm.choice(['m', 'f'], size=3),
+                            'b': np.random.randn(3)},
+                           index=tm.makeCustomIndex(10, 2))
+            df2 = DataFrame({'a': tm.choice(['m', 'f'], size=10),
+                             'b': np.random.randn(10)})
+            merge(df, df2, right_on='b', left_index=True)
+
+    def test_join_on_fails_with_different_column_counts(self):
+        with tm.assertRaises(ValueError):
+            df = DataFrame({'a': tm.choice(['m', 'f'], size=3),
+                            'b': np.random.randn(3)})
+            df2 = DataFrame({'a': tm.choice(['m', 'f'], size=10),
+                             'b': np.random.randn(10)},
+                            index=tm.makeCustomIndex(10, 2))
+            merge(df, df2, right_on='a', left_on=['a', 'b'])
+
     def test_join_on_pass_vector(self):
         expected = self.target.join(self.source, on='C')
         del expected['C']

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -309,11 +309,11 @@ class DatetimeIndex(Int64Index):
 
         if tz is not None and inferred_tz is not None:
             if not inferred_tz == tz:
-                raise AssertionError()
+                raise AssertionError("Inferred time zone not equal to passed "
+                                     "time zone")
 
         elif inferred_tz is not None:
             tz = inferred_tz
-
 
         if start is not None:
             if normalize:
@@ -456,16 +456,16 @@ class DatetimeIndex(Int64Index):
             cachedRange = drc[offset]
 
         if start is None:
-            if not (isinstance(end, Timestamp)):
-                raise AssertionError()
+            if not isinstance(end, Timestamp):
+                raise AssertionError('end must be an instance of Timestamp')
 
             end = offset.rollback(end)
 
             endLoc = cachedRange.get_loc(end) + 1
             startLoc = endLoc - periods
         elif end is None:
-            if not (isinstance(start, Timestamp)):
-                raise AssertionError()
+            if not isinstance(start, Timestamp):
+                raise AssertionError('start must be an instance of Timestamp')
 
             start = offset.rollforward(start)
 
@@ -601,14 +601,14 @@ class DatetimeIndex(Int64Index):
             if d.time() != zero_time or d.tzinfo is not None:
                 return [u('%s') % x for x in data]
 
-        values = np.array(data,dtype=object)
+        values = np.array(data, dtype=object)
         mask = isnull(self.values)
         values[mask] = na_rep
 
         imask = -mask
-        values[imask] = np.array([u('%d-%.2d-%.2d') % (
-                                  dt.year, dt.month, dt.day)
-                                  for dt in values[imask] ])
+        values[imask] = np.array([u('%d-%.2d-%.2d') % (dt.year, dt.month,
+                                                       dt.day)
+                                  for dt in values[imask]])
         return values.tolist()
 
     def isin(self, values):
@@ -1130,7 +1130,6 @@ class DatetimeIndex(Int64Index):
         else:
             raise KeyError
 
-
         stamps = self.asi8
 
         if is_monotonic:
@@ -1147,8 +1146,8 @@ class DatetimeIndex(Int64Index):
 
             return slice(left, right)
 
-        lhs_mask = (stamps>=t1.value) if use_lhs else True
-        rhs_mask = (stamps<=t2.value) if use_rhs else True
+        lhs_mask = (stamps >= t1.value) if use_lhs else True
+        rhs_mask = (stamps <= t2.value) if use_rhs else True
 
         # try to find a the dates
         return (lhs_mask & rhs_mask).nonzero()[0]
@@ -1227,7 +1226,8 @@ class DatetimeIndex(Int64Index):
         freq = getattr(self, 'freqstr',
                        getattr(self, 'inferred_freq', None))
         _, parsed, reso = parse_time_string(key, freq)
-        loc = self._partial_date_slice(reso, parsed, use_lhs=use_lhs, use_rhs=use_rhs)
+        loc = self._partial_date_slice(reso, parsed, use_lhs=use_lhs,
+                                       use_rhs=use_rhs)
         return loc
 
     def slice_indexer(self, start=None, end=None, step=None):
@@ -1274,12 +1274,13 @@ class DatetimeIndex(Int64Index):
                 # so create an indexer directly
                 try:
                     if start:
-                        start_loc = self._get_string_slice(start,use_rhs=False)
+                        start_loc = self._get_string_slice(start,
+                                                           use_rhs=False)
                     else:
                         start_loc = np.arange(len(self))
 
                     if end:
-                        end_loc = self._get_string_slice(end,use_lhs=False)
+                        end_loc = self._get_string_slice(end, use_lhs=False)
                     else:
                         end_loc = np.arange(len(self))
 

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -120,8 +120,9 @@ class TimeGrouper(CustomGrouper):
         return binner, grouper
 
     def _get_time_bins(self, axis):
-        if not (isinstance(axis, DatetimeIndex)):
-            raise AssertionError()
+        if not isinstance(axis, DatetimeIndex):
+            raise TypeError('axis must be a DatetimeIndex, but got '
+                            'an instance of %r' % type(axis).__name__)
 
         if len(axis) == 0:
             binner = labels = DatetimeIndex(data=[], freq=self.freq)
@@ -180,10 +181,11 @@ class TimeGrouper(CustomGrouper):
         return binner, bin_edges
 
     def _get_time_period_bins(self, axis):
-        if not(isinstance(axis, DatetimeIndex)):
-            raise AssertionError()
+        if not isinstance(axis, DatetimeIndex):
+            raise TypeError('axis must be a DatetimeIndex, but got '
+                            'an instance of %r' % type(axis).__name__)
 
-        if len(axis) == 0:
+        if not len(axis):
             binner = labels = PeriodIndex(data=[], freq=self.freq)
             return binner, [], labels
 
@@ -211,8 +213,8 @@ class TimeGrouper(CustomGrouper):
                 result = grouped.aggregate(self._agg_method)
             else:
                 # upsampling shortcut
-                if not (self.axis == 0):
-                    raise AssertionError()
+                if self.axis:
+                    raise AssertionError('axis must be 0')
 
                 if self.closed == 'right':
                     res_index = binner[1:]
@@ -278,7 +280,6 @@ class TimeGrouper(CustomGrouper):
 
 def _take_new_index(obj, indexer, new_index, axis=0):
     from pandas.core.api import Series, DataFrame
-    from pandas.core.internals import BlockManager
 
     if isinstance(obj, Series):
         new_values = com.take_1d(obj.values, indexer)
@@ -286,7 +287,7 @@ def _take_new_index(obj, indexer, new_index, axis=0):
     elif isinstance(obj, DataFrame):
         if axis == 1:
             raise NotImplementedError
-        return DataFrame(obj._data.take(indexer,new_index=new_index,axis=1))
+        return DataFrame(obj._data.take(indexer, new_index=new_index, axis=1))
     else:
         raise NotImplementedError
 

--- a/pandas/tseries/tests/test_converter.py
+++ b/pandas/tseries/tests/test_converter.py
@@ -11,7 +11,7 @@ from pandas.compat import u
 try:
     import pandas.tseries.converter as converter
 except ImportError:
-    raise nose.SkipTest
+    raise nose.SkipTest("no pandas.tseries.converter, skipping")
 
 
 def test_timtetonum_accepts_unicode():

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -23,7 +23,7 @@ def _skip_if_no_pytz():
     try:
         import pytz
     except ImportError:
-        raise nose.SkipTest
+        raise nose.SkipTest("pytz not installed")
 
 
 def _skip_if_no_cday():

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -23,7 +23,7 @@ def _skip_if_no_scipy():
     try:
         import scipy
     except ImportError:
-        raise nose.SkipTest
+        raise nose.SkipTest("scipy not installed")
 
 
 @tm.mplskip

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -5,6 +5,8 @@ import os
 import unittest
 import operator
 
+from distutils.version import LooseVersion
+
 import nose
 
 import numpy as np
@@ -49,7 +51,7 @@ def _skip_if_no_pytz():
     try:
         import pytz
     except ImportError:
-        raise nose.SkipTest
+        raise nose.SkipTest("pytz not installed")
 
 
 class TestTimeSeriesDuplicates(unittest.TestCase):
@@ -661,8 +663,8 @@ class TestTimeSeries(unittest.TestCase):
     def test_index_astype_datetime64(self):
         idx = Index([datetime(2012, 1, 1)], dtype=object)
 
-        if np.__version__ >= '1.7':
-            raise nose.SkipTest("Test requires numpy < 1.7")
+        if np.__version__ >= LooseVersion('1.7'):
+            raise nose.SkipTest("test only valid in numpy < 1.7")
 
         casted = idx.astype(np.dtype('M8[D]'))
         expected = DatetimeIndex(idx.values)

--- a/pandas/tseries/tests/test_timeseries_legacy.py
+++ b/pandas/tseries/tests/test_timeseries_legacy.py
@@ -48,7 +48,7 @@ def _skip_if_no_pytz():
     try:
         import pytz
     except ImportError:
-        raise nose.SkipTest
+        raise nose.SkipTest("pytz not installed")
 
 # infortunately, too much has changed to handle these legacy pickles
 # class TestLegacySupport(unittest.TestCase):
@@ -59,7 +59,7 @@ class LegacySupport(object):
     @classmethod
     def setUpClass(cls):
         if compat.PY3:
-            raise nose.SkipTest
+            raise nose.SkipTest("not compatible with Python >= 3")
 
         pth, _ = os.path.split(os.path.abspath(__file__))
         filepath = os.path.join(pth, 'data', 'frame.pickle')

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -37,7 +37,7 @@ def _skip_if_no_pytz():
     try:
         import pytz
     except ImportError:
-        raise nose.SkipTest
+        raise nose.SkipTest("pytz not installed")
 
 try:
     import pytz

--- a/pandas/tseries/tools.py
+++ b/pandas/tseries/tools.py
@@ -30,7 +30,8 @@ def _infer_tzinfo(start, end):
         tz = a.tzinfo
         if b and b.tzinfo:
             if not (tslib.get_timezone(tz) == tslib.get_timezone(b.tzinfo)):
-                raise AssertionError()
+                raise AssertionError('Inputs must both have the same timezone,'
+                                     ' {0} != {1}'.format(tz, b.tzinfo))
         return tz
     tz = None
     if start is not None:


### PR DESCRIPTION
continuation of #3519 because of a branch rename.
### UPDATE: The exception parsing script has been moved to [a Gist](https://gist.github.com/cpcloud/6745173)

This PR partially addresses #3024. 
- all `AssertionError` exceptions now have an informative error message in them
- some `AssertionErrors` have been converted to different `Exception` subclasses, where it makes sense, and there's a corresponding test wherever these were changed.
- all `nose.SkipTest` exceptions now have an informative message
