### PR TITLE
TST: Fix assert_almost_equal error message

### DIFF
--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -141,7 +141,7 @@ def assert_almost_equal(a, b, check_less_precise = False):
                 assert_almost_equal(a[i], b[i], check_less_precise)
         return True
 
-    err_msg = lambda a, b: 'expected %.5f but got %.5f' % (a, b)
+    err_msg = lambda a, b: 'expected %.5f but got %.5f' % (b, a)
 
     if isnull(a):
         np.testing.assert_(isnull(b))


### PR DESCRIPTION
Most tests (in pandas' test suite and in general) are of form
`assert_almost_equal(result, expected)`.  Verbose error message was
treating its first argument as expected, this is now fixed.

Previous message was:

``` python
err_msg = lambda a, b: 'expected %.5f but got %.5f' % (a, b)
```

But a, the first argument, is actually `actual`, not expected.

Everywhere else, it makes sense to display `"%s != %s" % (a,b)`
