### PR TITLE
Make div use truediv instead of div

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -840,6 +840,7 @@ class DataFrame(NDFrame):
     mul = _arith_method(operator.mul, 'multiply', '*')
     sub = _arith_method(operator.sub, 'subtract', '-')
     div = divide = _arith_method(lambda x, y: x / y, 'divide', '/')
+    floordiv = _arith_method(lambda x, y: x // y, 'floor division', '//')
     pow = _arith_method(operator.pow, 'pow', '**')
 
     radd = _arith_method(_radd_compat, 'radd')

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -839,7 +839,11 @@ class DataFrame(NDFrame):
     add = _arith_method(operator.add, 'add', '+')
     mul = _arith_method(operator.mul, 'multiply', '*')
     sub = _arith_method(operator.sub, 'subtract', '-')
-    div = divide = _arith_method(lambda x, y: x / y, 'divide', '/')
+    if not py3compat.PY3:
+        # only need to explicitly cast to float in python 2
+        truediv = div = divide = _arith_method(lambda x, y: x / (y + 0.), 'divide', '/')
+    else:
+        truediv = div = divide = _arith_method(lambda x, y: x / y, 'divide', '/')
     floordiv = _arith_method(lambda x, y: x // y, 'floor division', '//')
     pow = _arith_method(operator.pow, 'pow', '**')
 
@@ -877,6 +881,9 @@ class DataFrame(NDFrame):
     __xor__ = _arith_method(operator.xor, '__xor__')
 
     # Python 2 division methods
+    # behaves similarly to numpy when not
+    # using the future import here, making the use
+    # of `div` different than `__div__`
     if not py3compat.PY3:
         __div__ = _arith_method(operator.div, '__div__', '/',
                                 default_axis=None, fill_zeros=np.inf)

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -1643,14 +1643,8 @@ Returns
         cls.add = _panel_arith_method(operator.add, 'add')
         cls.subtract = cls.sub = _panel_arith_method(operator.sub, 'subtract')
         cls.multiply = cls.mul = _panel_arith_method(operator.mul, 'multiply')
-
-        try:
-            cls.divide = cls.div = _panel_arith_method(operator.div, 'divide')
-        except AttributeError:  # pragma: no cover
-            # Python 3
-            cls.divide = cls.div = _panel_arith_method(
-                operator.truediv, 'divide')
         cls.floordiv = _panel_arith_method(operator.floordiv, 'floor division')
+        cls.truediv = cls.divide = cls.div = _panel_arith_method(operator.truediv, 'divide')
 
         _agg_doc = """
 Return %(desc)s over requested axis

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -1650,6 +1650,7 @@ Returns
             # Python 3
             cls.divide = cls.div = _panel_arith_method(
                 operator.truediv, 'divide')
+        cls.floordiv = _panel_arith_method(operator.floordiv, 'floor division')
 
         _agg_doc = """
 Return %(desc)s over requested axis

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2131,6 +2131,7 @@ class Series(pa.Array, generic.PandasObject):
     except AttributeError:  # pragma: no cover
         # Python 3
         div = _flex_method(operator.truediv, 'divide')
+    floordiv = _flex_method(operator.floordiv, 'floor division')
 
     def combine(self, other, func, fill_value=nan):
         """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2126,11 +2126,7 @@ class Series(pa.Array, generic.PandasObject):
     add = _flex_method(operator.add, 'add')
     sub = _flex_method(operator.sub, 'subtract')
     mul = _flex_method(operator.mul, 'multiply')
-    try:
-        div = _flex_method(operator.div, 'divide')
-    except AttributeError:  # pragma: no cover
-        # Python 3
-        div = _flex_method(operator.truediv, 'divide')
+    div = truediv = _flex_method(operator.truediv, 'divide')
     floordiv = _flex_method(operator.floordiv, 'floor division')
 
     def combine(self, other, func, fill_value=nan):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4191,6 +4191,24 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         result2 = DataFrame(p.values.astype('float64')/0,index=p.index,columns=p.columns).fillna(np.inf)
         assert_frame_equal(result2,expected)
 
+    def test_truediv(self):
+        import operator
+        p = DataFrame(tm.getIntegerSeriesData())
+        result = p.truediv(2)
+        expected = operator.truediv(p, 2)
+        assert_frame_equal(result, expected)
+
+        # set up dataframe divisble by 3
+        p = (p / 10.).astype(int) * 3
+        result = p.truediv(3)
+        expected = operator.truediv(p, 3)
+        assert_frame_equal(result, expected)
+
+        # test out axes
+        result = p.truediv(3, axis=1)
+        assert_frame_equal(result, expected)
+
+
     def test_logical_operators(self):
         import operator
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4282,7 +4282,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self.assert_(index == frame.index[-6])
 
     def test_arith_flex_frame(self):
-        ops = ['add', 'sub', 'mul', 'div', 'pow']
+        ops = ['add', 'sub', 'mul', 'div', 'pow', 'floordiv']
         aliases = {'div': 'truediv'}
 
         for op in ops:

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -303,6 +303,7 @@ class SafeForSparse(object):
         check_op(operator.sub, 'subtract')
         check_op(operator.mul, 'multiply')
         check_op(operator.floordiv, 'floordiv')
+        check_op(operator.truediv, 'truediv')
         if py3compat.PY3:
             check_op(operator.truediv, 'divide')
         else:

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -302,6 +302,7 @@ class SafeForSparse(object):
         check_op(operator.add, 'add')
         check_op(operator.sub, 'subtract')
         check_op(operator.mul, 'multiply')
+        check_op(operator.floordiv, 'floordiv')
         if py3compat.PY3:
             check_op(operator.truediv, 'divide')
         else:

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -2433,11 +2433,7 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         b = Series([nan, 1, nan, 3, nan, 4.], index=np.arange(6))
 
         ops = [Series.add, Series.sub, Series.mul, Series.floordiv, Series.div]
-        equivs = [operator.add, operator.sub, operator.mul, operator.floordiv]
-        if py3compat.PY3:
-            equivs.append(operator.truediv)
-        else:
-            equivs.append(operator.div)
+        equivs = [operator.add, operator.sub, operator.mul, operator.floordiv, operator.truediv]
         fillvals = [0, 0, 1, 1]
 
         for op, equiv_op, fv in zip(ops, equivs, fillvals):

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1809,6 +1809,22 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         else:
             assert_series_equal(result,p['first'])
 
+
+    # only matters for Python 2.x, otherwise always truediv
+    def test_truediv(self):
+        arr = np.array([1,2,3,4,5])
+        p = Series(arr)
+        result = p.truediv(2)
+        expected = Series(operator.truediv(arr, 2))
+        assert_series_equal(result, expected)
+
+        arr = np.arange(0,10) * 3
+        p = Series(arr)
+        result = p.truediv(3)
+        expected = Series(operator.truediv(arr, 3))
+        assert_series_equal(result, expected)
+
+
     def test_operators(self):
 
         def _check_op(series, other, op, pos_only=False):

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -2416,8 +2416,8 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         a = Series([nan, 1., 2., 3., nan], index=np.arange(5))
         b = Series([nan, 1, nan, 3, nan, 4.], index=np.arange(6))
 
-        ops = [Series.add, Series.sub, Series.mul, Series.div]
-        equivs = [operator.add, operator.sub, operator.mul]
+        ops = [Series.add, Series.sub, Series.mul, Series.floordiv, Series.div]
+        equivs = [operator.add, operator.sub, operator.mul, operator.floordiv]
         if py3compat.PY3:
             equivs.append(operator.truediv)
         else:

--- a/pandas/tests/test_truediv.py
+++ b/pandas/tests/test_truediv.py
@@ -1,0 +1,41 @@
+from __future__ import division
+# pylint: disable-msg=W0612,E1101
+import numpy as np
+import pandas as pan
+import pandas.util.testing as tm
+from pandas.core.api import (DataFrame, Index, Series, notnull, isnull,
+                             MultiIndex, DatetimeIndex, Timestamp, Period)
+from pandas.util.testing import (assert_almost_equal,
+                                 assert_series_equal,
+                                 assert_frame_equal,
+                                 makeCustomDataframe as mkdf,
+                                 ensure_clean)
+
+class TestDivUnderTruediv(object):
+    def test_frame_div_dtype(self):
+        p = DataFrame({"A": np.arange(10)})
+        result = p.div(5)
+        assert result.A.dtype.kind == "f", "Expected float dtype, instead saw %r" % result.A.dtype
+
+    def test_series_div_dtype(self):
+        p = Series(np.arange(10))
+        result = p.div(4)
+        assert result.dtype.kind == "f", "Expected float dtype, instead saw %r" % result.dtype
+
+    def test_frame_div(self):
+        p = DataFrame(tm.getIntegerSeriesData())
+        result = p.div(3)
+        expected = p.truediv(3)
+        assert_frame_equal(result, expected)
+
+        result = p.div(p.irow(0), axis=1)
+        expected = p.truediv(p.irow(0), axis=1)
+        assert_frame_equal(result, expected)
+
+    def test_series_div(self):
+        p = DataFrame(tm.getIntegerSeriesData())
+        series = p.icol(0)
+        result = series.div(5)
+        expected = series.truediv(5)
+        assert_series_equal(result, expected)
+

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager  # contextlib is available since 2.5
 from distutils.version import LooseVersion
 
 from numpy.random import randn
+from numpy.random import randint
 import numpy as np
 
 from pandas.core.common import isnull, _is_sequence
@@ -330,6 +331,11 @@ def getSeriesData():
     index = makeStringIndex(N)
     return dict((c, Series(randn(N), index=index)) for c in getCols(K))
 
+def getIntegerSeriesData():
+    """same as `getSeriesData` but returns random  positive and negative *integers* instead"""
+    index = makeStringIndex(N)
+    maxint = np.iinfo('i').max
+    return dict((c, Series(randint(-maxint, maxint, N), index=index)) for c in getCols(K))
 
 def makeDataFrame():
     data = getSeriesData()


### PR DESCRIPTION
This changes the `div()` method in pandas on Python 2.x to always do
`truediv` rather than integer division. Currently, pandas doesn't
respect  `from __future__ import division` (it's defined in a file that
doesn't start with the import, so it always does integer division).
`__div__`, `__rdiv__`, and `__idiv__` remain the same, so that the `/`
operator still works as expected. This PR also adds `truediv()` and
`floordiv()` methods to series, panel and frame, plus a test utility
to generate integer series.

This change makes `div()` behave the same way in Python 2 and in
Python 3. It also limits the surprise that comes from using the
future import with pandas in Python 2.

You can see the difference between Python 2 and 3 with the following
snippet:

```

from __future__ import division
import pandas
from pandas.util.testing import assert_frame_equal
df = pandas.DataFrame({"A": range(4)})
result = df.div(4)
expected = df / 4
assert_frame_equal(result, expected)

```

It's not easy (or particularly useful) to detect which division setting
is currently active. Plus, if you were to check it, the actual behavior
would depend on [which file imports `pandas`
first](http://stackoverflow.com/questions/16880552/dynamically-detecting-division-future-import).

There might be too many tests associated with this, so if you'd like me
to slim them down, I'd be happy to do so.

Another alternative would to this patch would be to follow the python
`operator` convention and remove `div()` altogether from Python 3, while
leaving `div()` as it previously was in Python 2; however, I think that
will continue to suprise users.
