### PR TITLE
ENH: Experimental CustomBusinessDay DateOffset class. fixes #2301

### DIFF
--- a/doc/source/v0.11.1.txt
+++ b/doc/source/v0.11.1.txt
@@ -319,6 +319,32 @@ Other Enhancements
   - DatetimeIndexes no longer try to convert mixed-integer indexes during join
     operations (:issue:`3877`)
 
+Experimental Features
+~~~~~~~~~~~~~~~~~~~~~
+
+  - Added experimental ``CustomBusinessDay`` class to support ``DateOffsets``
+    with custom holiday calendars and custom weekmasks. (GH2301_)
+    
+  .. note::
+        
+        This uses the ``numpy.busdaycalendar`` API introduced in Numpy 1.7 and
+        therefore requires Numpy 1.7.0 or newer.
+
+  .. ipython:: python
+
+     from pandas.tseries.offsets import CustomBusinessDay
+     # As an interesting example, let's look at Egypt where
+     # a Friday-Saturday weekend is observed.
+     weekmask_egypt = 'Sun Mon Tue Wed Thu'
+     # They also observe International Workers' Day so let's
+     # add that for a couple of years
+     holidays = ['2012-05-01', datetime(2013, 5, 1), np.datetime64('2014-05-01')]
+     bday_egypt = CustomBusinessDay(holidays=holidays, weekmask=weekmask_egypt)
+     dt = datetime(2013, 4, 30)
+     print dt + 2 * bday_egypt
+     dts = date_range(dt, periods=5, freq=bday_egypt).to_series()
+     print Series(dts.weekday, dts).map(Series('Mon Tue Wed Thu Fri Sat Sun'.split()))
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/pandas/core/datetools.py
+++ b/pandas/core/datetools.py
@@ -8,6 +8,12 @@ from dateutil import parser
 day = DateOffset()
 bday = BDay()
 businessDay = bday
+try:
+    cday = CDay()
+    customBusinessDay = CustomBusinessDay()
+except ImportError:
+    # Don't create CustomBusinessDay instances when not available
+    pass
 monthEnd = MonthEnd()
 yearEnd = YearEnd()
 yearBegin = YearBegin()

--- a/pandas/core/datetools.py
+++ b/pandas/core/datetools.py
@@ -11,9 +11,9 @@ businessDay = bday
 try:
     cday = CDay()
     customBusinessDay = CustomBusinessDay()
-except ImportError:
-    # Don't create CustomBusinessDay instances when not available
-    pass
+except NotImplementedError:
+    cday = None
+    customBusinessDay = None
 monthEnd = MonthEnd()
 yearEnd = YearEnd()
 yearBegin = YearBegin()

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -114,14 +114,17 @@ def _get_freq_str(base, mult=1):
 # Offset names ("time rules") and related functions
 
 
-from pandas.tseries.offsets import (Day, BDay, Hour, Minute, Second, Milli,
-                                    Week, Micro, MonthEnd, MonthBegin,
-                                    BMonthBegin, BMonthEnd, YearBegin, YearEnd,
-                                    BYearBegin, BYearEnd, QuarterBegin,
-                                    QuarterEnd, BQuarterBegin, BQuarterEnd)
+from pandas.tseries.offsets import (Micro, Milli, Second, Minute, Hour,
+                                    Day, BDay, CDay, Week, MonthBegin,
+                                    MonthEnd, BMonthBegin, BMonthEnd,
+                                    QuarterBegin, QuarterEnd, BQuarterBegin,
+                                    BQuarterEnd, YearBegin, YearEnd,
+                                    BYearBegin, BYearEnd,
+                                    )
 
 _offset_map = {
     'D': Day(),
+    'C': CDay(),
     'B': BDay(),
     'H': Hour(),
     'T': Minute(),
@@ -278,6 +281,7 @@ _offset_to_period_map = {
     'BAS': 'A',
     'MS': 'M',
     'D': 'D',
+    'C': 'C',
     'B': 'B',
     'T': 'T',
     'S': 'S',
@@ -1004,15 +1008,17 @@ def is_subperiod(source, target):
         if _is_quarterly(source):
             return _quarter_months_conform(_get_rule_month(source),
                                            _get_rule_month(target))
-        return source in ['D', 'B', 'M', 'H', 'T', 'S']
+        return source in ['D', 'C', 'B', 'M', 'H', 'T', 'S']
     elif _is_quarterly(target):
-        return source in ['D', 'B', 'M', 'H', 'T', 'S']
+        return source in ['D', 'C', 'B', 'M', 'H', 'T', 'S']
     elif target == 'M':
-        return source in ['D', 'B', 'H', 'T', 'S']
+        return source in ['D', 'C', 'B', 'H', 'T', 'S']
     elif _is_weekly(target):
-        return source in [target, 'D', 'B', 'H', 'T', 'S']
+        return source in [target, 'D', 'C', 'B', 'H', 'T', 'S']
     elif target == 'B':
         return source in ['B', 'H', 'T', 'S']
+    elif target == 'C':
+        return source in ['C', 'H', 'T', 'S']
     elif target == 'D':
         return source in ['D', 'H', 'T', 'S']
     elif target == 'H':
@@ -1055,17 +1061,19 @@ def is_superperiod(source, target):
             smonth = _get_rule_month(source)
             tmonth = _get_rule_month(target)
             return _quarter_months_conform(smonth, tmonth)
-        return target in ['D', 'B', 'M', 'H', 'T', 'S']
+        return target in ['D', 'C', 'B', 'M', 'H', 'T', 'S']
     elif _is_quarterly(source):
-        return target in ['D', 'B', 'M', 'H', 'T', 'S']
+        return target in ['D', 'C', 'B', 'M', 'H', 'T', 'S']
     elif source == 'M':
-        return target in ['D', 'B', 'H', 'T', 'S']
+        return target in ['D', 'C', 'B', 'H', 'T', 'S']
     elif _is_weekly(source):
-        return target in [source, 'D', 'B', 'H', 'T', 'S']
+        return target in [source, 'D', 'C', 'B', 'H', 'T', 'S']
     elif source == 'B':
-        return target in ['D', 'B', 'H', 'T', 'S']
+        return target in ['D', 'C', 'B', 'H', 'T', 'S']
+    elif source == 'C':
+        return target in ['D', 'C', 'B', 'H', 'T', 'S']
     elif source == 'D':
-        return target in ['D', 'B', 'H', 'T', 'S']
+        return target in ['D', 'C', 'B', 'H', 'T', 'S']
     elif source == 'H':
         return target in ['H', 'T', 'S']
     elif source == 'T':

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -121,10 +121,14 @@ from pandas.tseries.offsets import (Micro, Milli, Second, Minute, Hour,
                                     BQuarterEnd, YearBegin, YearEnd,
                                     BYearBegin, BYearEnd,
                                     )
+try:
+    cday = CDay()
+except NotImplementedError:
+    cday = None
 
 _offset_map = {
     'D': Day(),
-    'C': CDay(),
+    'C': cday,
     'B': BDay(),
     'H': Hour(),
     'T': Minute(),

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1743,8 +1743,13 @@ def bdate_range(start=None, end=None, periods=None, freq='B', tz=None,
 def cdate_range(start=None, end=None, periods=None, freq='C', tz=None,
                 normalize=True, name=None, **kwargs):
     """
-    Return a fixed frequency datetime index, with CustomBusinessDay as the
-    default frequency
+    **EXPERIMENTAL** Return a fixed frequency datetime index, with
+    CustomBusinessDay as the default frequency
+
+    .. warning:: EXPERIMENTAL
+
+        The CustomBusinessDay class is not officially supported and the API is
+        likely to change in future versions. Use this at your own risk.
 
     Parameters
     ----------

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -11,7 +11,7 @@ from pandas.core.index import Index, Int64Index
 from pandas.tseries.frequencies import (
     infer_freq, to_offset, get_period_alias,
     Resolution, get_reso_string)
-from pandas.tseries.offsets import DateOffset, generate_range, Tick
+from pandas.tseries.offsets import DateOffset, generate_range, Tick, CDay
 from pandas.tseries.tools import parse_time_string, normalize_date
 from pandas.util.decorators import cache_readonly
 import pandas.core.common as com
@@ -1738,6 +1738,52 @@ def bdate_range(start=None, end=None, periods=None, freq='B', tz=None,
 
     return DatetimeIndex(start=start, end=end, periods=periods,
                          freq=freq, tz=tz, normalize=normalize, name=name)
+
+
+def cdate_range(start=None, end=None, periods=None, freq='C', tz=None,
+                normalize=True, name=None, **kwargs):
+    """
+    Return a fixed frequency datetime index, with CustomBusinessDay as the
+    default frequency
+
+    Parameters
+    ----------
+    start : string or datetime-like, default None
+        Left bound for generating dates
+    end : string or datetime-like, default None
+        Right bound for generating dates
+    periods : integer or None, default None
+        If None, must specify start and end
+    freq : string or DateOffset, default 'C' (CustomBusinessDay)
+        Frequency strings can have multiples, e.g. '5H'
+    tz : string or None
+        Time zone name for returning localized DatetimeIndex, for example
+        Asia/Beijing
+    normalize : bool, default False
+        Normalize start/end dates to midnight before generating date range
+    name : str, default None
+        Name for the resulting index
+    weekmask : str, Default 'Mon Tue Wed Thu Fri'
+        weekmask of valid business days, passed to ``numpy.busdaycalendar``
+    holidays : list
+        list/array of dates to exclude from the set of valid business days,
+        passed to ``numpy.busdaycalendar``
+
+    Notes
+    -----
+    2 of start, end, or periods must be specified
+
+    Returns
+    -------
+    rng : DatetimeIndex
+    """
+
+    if freq=='C':
+        holidays = kwargs.pop('holidays', [])
+        weekmask = kwargs.pop('weekmask', 'Mon Tue Wed Thu Fri')
+        freq = CDay(holidays=holidays, weekmask=weekmask)
+    return DatetimeIndex(start=start, end=end, periods=periods, freq=freq,
+                         tz=tz, normalize=normalize, name=name, **kwargs)
 
 
 def _to_m8(key, tz=None):

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -363,8 +363,13 @@ class BusinessDay(CacheableOffset, DateOffset):
 
 class CustomBusinessDay(BusinessDay):
     """
-    DateOffset subclass representing possibly n business days excluding
-    holidays
+    **EXPERIMENTAL** DateOffset subclass representing possibly n business days
+    excluding holidays
+
+    .. warning:: EXPERIMENTAL
+
+        This class is not officially supported and the API is likely to change
+        in future versions. Use this at your own risk.
 
     Parameters
     ----------

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -385,8 +385,9 @@ class CustomBusinessDay(BusinessDay):
         # Check we have the required numpy version
         from distutils.version import LooseVersion
         if LooseVersion(np.__version__) < '1.7.0':
-            raise ImportError("CustomBusinessDay requires numpy >= 1.7.0. "
-                              "Current version: "+np.__version__)
+            raise NotImplementedError("CustomBusinessDay requires numpy >= "
+                                      "1.7.0. Current version: " +
+                                      np.__version__)
 
         self.n = int(n)
         self.kwds = kwds

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -1,10 +1,13 @@
 from datetime import date, datetime, timedelta
 import unittest
+import nose
+from nose.tools import assert_raises
+
 import numpy as np
 
 from pandas.core.datetools import (
-    bday, BDay, BQuarterEnd, BMonthEnd, BYearEnd, MonthEnd, MonthBegin,
-    BYearBegin, QuarterBegin, BQuarterBegin, BMonthBegin,
+    bday, BDay, cday, CDay, BQuarterEnd, BMonthEnd, BYearEnd, MonthEnd,
+    MonthBegin, BYearBegin, QuarterBegin, BQuarterBegin, BMonthBegin,
     DateOffset, Week, YearBegin, YearEnd, Hour, Minute, Second, Day, Micro,
     Milli, Nano,
     WeekOfMonth, format, ole2datetime, QuarterEnd, to_datetime, normalize_date,
@@ -15,8 +18,6 @@ from pandas.tseries.frequencies import _offset_map
 from pandas.tseries.index import _to_m8
 from pandas.tseries.tools import parse_time_string
 import pandas.tseries.offsets as offsets
-
-from nose.tools import assert_raises
 
 from pandas.tslib import monthrange
 from pandas.lib import Timestamp
@@ -30,6 +31,12 @@ def test_monthrange():
     for y in range(2000, 2013):
         for m in range(1, 13):
             assert monthrange(y, m) == calendar.monthrange(y, m)
+
+
+def _skip_if_no_cday():
+    if cday is None:
+        raise nose.SkipTest("CustomBusinessDay not available.")
+
 
 ####
 ## Misc function tests
@@ -293,6 +300,220 @@ class TestBusinessDay(unittest.TestCase):
         offset1 = BDay()
         offset2 = BDay()
         self.assertFalse(offset1 != offset2)
+
+
+class TestCustomBusinessDay(unittest.TestCase):
+    _multiprocess_can_split_ = True
+
+    def setUp(self):
+        self.d = datetime(2008, 1, 1)
+
+        _skip_if_no_cday()
+        self.offset = CDay()
+        self.offset2 = CDay(2)
+
+    def test_different_normalize_equals(self):
+        # equivalent in this special case
+        offset = CDay()
+        offset2 = CDay()
+        offset2.normalize = True
+        self.assertEqual(offset, offset2)
+
+    def test_repr(self):
+        assert repr(self.offset) == '<1 CustomBusinessDay>'
+        assert repr(self.offset2) == '<2 CustomBusinessDays>'
+
+        expected = '<1 BusinessDay: offset=datetime.timedelta(1)>'
+        assert repr(self.offset + timedelta(1)) == expected
+
+    def test_with_offset(self):
+        offset = self.offset + timedelta(hours=2)
+
+        assert (self.d + offset) == datetime(2008, 1, 2, 2)
+
+    def testEQ(self):
+        self.assertEqual(self.offset2, self.offset2)
+
+    def test_mul(self):
+        pass
+
+    def test_hash(self):
+        self.assertEqual(hash(self.offset2), hash(self.offset2))
+
+    def testCall(self):
+        self.assertEqual(self.offset2(self.d), datetime(2008, 1, 3))
+
+    def testRAdd(self):
+        self.assertEqual(self.d + self.offset2, self.offset2 + self.d)
+
+    def testSub(self):
+        off = self.offset2
+        self.assertRaises(Exception, off.__sub__, self.d)
+        self.assertEqual(2 * off - off, off)
+
+        self.assertEqual(self.d - self.offset2, self.d + CDay(-2))
+
+    def testRSub(self):
+        self.assertEqual(self.d - self.offset2, (-self.offset2).apply(self.d))
+
+    def testMult1(self):
+        self.assertEqual(self.d + 10 * self.offset, self.d + CDay(10))
+
+    def testMult2(self):
+        self.assertEqual(self.d + (-5 * CDay(-10)),
+                         self.d + CDay(50))
+
+    def testRollback1(self):
+        self.assertEqual(CDay(10).rollback(self.d), self.d)
+
+    def testRollback2(self):
+        self.assertEqual(
+            CDay(10).rollback(datetime(2008, 1, 5)), datetime(2008, 1, 4))
+
+    def testRollforward1(self):
+        self.assertEqual(CDay(10).rollforward(self.d), self.d)
+
+    def testRollforward2(self):
+        self.assertEqual(
+            CDay(10).rollforward(datetime(2008, 1, 5)), datetime(2008, 1, 7))
+
+    def test_roll_date_object(self):
+        offset = CDay()
+
+        dt = date(2012, 9, 15)
+
+        result = offset.rollback(dt)
+        self.assertEqual(result, datetime(2012, 9, 14))
+
+        result = offset.rollforward(dt)
+        self.assertEqual(result, datetime(2012, 9, 17))
+
+        offset = offsets.Day()
+        result = offset.rollback(dt)
+        self.assertEqual(result, datetime(2012, 9, 15))
+
+        result = offset.rollforward(dt)
+        self.assertEqual(result, datetime(2012, 9, 15))
+
+    def test_onOffset(self):
+        tests = [(CDay(), datetime(2008, 1, 1), True),
+                 (CDay(), datetime(2008, 1, 5), False)]
+
+        for offset, date, expected in tests:
+            assertOnOffset(offset, date, expected)
+
+    def test_apply(self):
+        from pandas.core.datetools import cday
+        tests = []
+
+        tests.append((cday,
+                      {datetime(2008, 1, 1): datetime(2008, 1, 2),
+                       datetime(2008, 1, 4): datetime(2008, 1, 7),
+                       datetime(2008, 1, 5): datetime(2008, 1, 7),
+                       datetime(2008, 1, 6): datetime(2008, 1, 7),
+                       datetime(2008, 1, 7): datetime(2008, 1, 8)}))
+
+        tests.append((2 * cday,
+                      {datetime(2008, 1, 1): datetime(2008, 1, 3),
+                       datetime(2008, 1, 4): datetime(2008, 1, 8),
+                       datetime(2008, 1, 5): datetime(2008, 1, 8),
+                       datetime(2008, 1, 6): datetime(2008, 1, 8),
+                       datetime(2008, 1, 7): datetime(2008, 1, 9)}))
+
+        tests.append((-cday,
+                      {datetime(2008, 1, 1): datetime(2007, 12, 31),
+                       datetime(2008, 1, 4): datetime(2008, 1, 3),
+                       datetime(2008, 1, 5): datetime(2008, 1, 4),
+                       datetime(2008, 1, 6): datetime(2008, 1, 4),
+                       datetime(2008, 1, 7): datetime(2008, 1, 4),
+                       datetime(2008, 1, 8): datetime(2008, 1, 7)}))
+
+        tests.append((-2 * cday,
+                      {datetime(2008, 1, 1): datetime(2007, 12, 28),
+                       datetime(2008, 1, 4): datetime(2008, 1, 2),
+                       datetime(2008, 1, 5): datetime(2008, 1, 3),
+                       datetime(2008, 1, 6): datetime(2008, 1, 3),
+                       datetime(2008, 1, 7): datetime(2008, 1, 3),
+                       datetime(2008, 1, 8): datetime(2008, 1, 4),
+                       datetime(2008, 1, 9): datetime(2008, 1, 7)}))
+
+        tests.append((CDay(0),
+                      {datetime(2008, 1, 1): datetime(2008, 1, 1),
+                       datetime(2008, 1, 4): datetime(2008, 1, 4),
+                       datetime(2008, 1, 5): datetime(2008, 1, 7),
+                       datetime(2008, 1, 6): datetime(2008, 1, 7),
+                       datetime(2008, 1, 7): datetime(2008, 1, 7)}))
+
+        for offset, cases in tests:
+            for base, expected in cases.iteritems():
+                assertEq(offset, base, expected)
+
+    def test_apply_large_n(self):
+        dt = datetime(2012, 10, 23)
+
+        result = dt + CDay(10)
+        self.assertEqual(result, datetime(2012, 11, 6))
+
+        result = dt + CDay(100) - CDay(100)
+        self.assertEqual(result, dt)
+
+        off = CDay() * 6
+        rs = datetime(2012, 1, 1) - off
+        xp = datetime(2011, 12, 23)
+        self.assertEqual(rs, xp)
+
+        st = datetime(2011, 12, 18)
+        rs = st + off
+        xp = datetime(2011, 12, 26)
+        self.assertEqual(rs, xp)
+
+    def test_apply_corner(self):
+        self.assertRaises(Exception, CDay().apply, BMonthEnd())
+
+    def test_offsets_compare_equal(self):
+        # root cause of #456
+        offset1 = CDay()
+        offset2 = CDay()
+        self.assertFalse(offset1 != offset2)
+
+    def test_holidays(self):
+        # Define a TradingDay offset
+        holidays = ['2012-05-01', datetime(2013, 5, 1),
+                    np.datetime64('2014-05-01')]
+        tday = CDay(holidays=holidays)
+        for year in range(2012, 2015):
+            dt = datetime(year, 4, 30)
+            xp = datetime(year, 5, 2)
+            rs = dt + tday
+            self.assertEqual(rs, xp)
+
+    def test_weekmask(self):
+        weekmask_saudi = 'Sat Sun Mon Tue Wed'  # Thu-Fri Weekend
+        weekmask_uae = '1111001'                # Fri-Sat Weekend
+        weekmask_egypt = [1,1,1,1,0,0,1]        # Fri-Sat Weekend
+        bday_saudi = CDay(weekmask=weekmask_saudi)
+        bday_uae = CDay(weekmask=weekmask_uae)
+        bday_egypt = CDay(weekmask=weekmask_egypt)
+        dt = datetime(2013, 5, 1)
+        xp_saudi = datetime(2013, 5, 4)
+        xp_uae = datetime(2013, 5, 2)
+        xp_egypt = datetime(2013, 5, 2)
+        self.assertEqual(xp_saudi, dt + bday_saudi)
+        self.assertEqual(xp_uae, dt + bday_uae)
+        self.assertEqual(xp_egypt, dt + bday_egypt)
+        xp2 = datetime(2013, 5, 5)
+        self.assertEqual(xp2, dt + 2 * bday_saudi)
+        self.assertEqual(xp2, dt + 2 * bday_uae)
+        self.assertEqual(xp2, dt + 2 * bday_egypt)
+
+    def test_weekmask_and_holidays(self):
+        weekmask_egypt = 'Sun Mon Tue Wed Thu'  # Fri-Sat Weekend
+        holidays = ['2012-05-01', datetime(2013, 5, 1),
+                    np.datetime64('2014-05-01')]
+        bday_egypt = CDay(holidays=holidays, weekmask=weekmask_egypt)
+        dt = datetime(2013, 4, 30)
+        xp_egypt = datetime(2013, 5, 5)
+        self.assertEqual(xp_egypt, dt + 2 * bday_egypt)
 
 
 def assertOnOffset(offset, date, expected):
@@ -1159,7 +1380,6 @@ class TestYearBegin(unittest.TestCase):
                        datetime(2007, 3, 1): datetime(2006, 4, 1),
                        datetime(2007, 12, 15): datetime(2007, 4, 1),
                        datetime(2012, 1, 31): datetime(2011, 4, 1), }))
-
 
         for offset, cases in tests:
             for base, expected in cases.iteritems():


### PR DESCRIPTION
I took a stab at issue #2301 using the busdaycalendar functionality in numpy 1.7.
### Caveats

There are a few issues with this:
- It requires Numpy 1.7 (I've only tested it on numpy 1.7.1).
- The timezone handling in nump 1.7 is broken (according to [this discussion](http://numpy-discussion.10968.n7.nabble.com/timezones-and-datetime64-td33407.html) ) and the datetime64 and timezone API will change in numpy 1.8. So from what I understand the current code as I've written it might move you onto a different day if you're in a UTC-0?00 timezone (I'm in UTC+0200 so it didn't affect me).

That said I didn't want to reinvent the wheel and since the numpy datetime64 api does cater for this usecase I thought it would be good to standardise on that in the long term.

The code does what I need it to do and I'm putting it out there in case it's useful to anyone else. Also, with some feedback maybe we can get it to the point where it could be included in Pandas as an optional DateOffset class for users who have Numpy 1.7.
### Possible Improvements

I can think of:
- Guard in the constructor to raise a meaningful exception when the user doesn't is on Numpy < 1.7.
- Better handling for the timezone issue.
- Unit tests for the CustomBusinessDay behaviour.
### Notes
- I picked the frequency code 'C' because it was available and fit nicely between 'D' and 'B'. I had originally named the class TradingDay and wanted to use 'T' but that's already used for Minutes.
- I have no idea what goes on in frequencies.py and I simply put a 'C' wherever I found a 'B' using the reasoning that as a BusinessDay subclass it should work in all the same places.
