### PR TITLE
ENH: support HDFStore in Python3 (via PyTables 3.0.0)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,6 @@ Optional dependencies
   - `Cython <http://www.cython.org>`__: Only necessary to build development version. Version 0.17.1 or higher.
   - `SciPy <http://www.scipy.org>`__: miscellaneous statistical functions
   - `PyTables <http://www.pytables.org>`__: necessary for HDF5-based storage
-     - Not yet supported on python >= 3
   - `matplotlib <http://matplotlib.sourceforge.net/>`__: for plotting
   - `statsmodels <http://statsmodels.sourceforge.net/>`__
      - Needed for parts of :mod:`pandas.stats`

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -63,14 +63,7 @@ pandas 0.11.1
       to append an index with a different name than the existing
     - support datelike columns with a timezone as data_columns (GH2852_)
     - table writing performance improvements.
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-    - support python3 (via ``PyTables 3.0.0``)
->>>>>>> 116ab91... DOC: docstring/release notes updates for py3k
-=======
-    - support py3 (via ``PyTables 3.0.0``)
->>>>>>> ab16d43... ENH: partial py3k support
+    - support python3 (via ``PyTables 3.0.0``) (GH3750_)
   - Add modulo operator to Series, DataFrame
   - Add ``date`` method to DatetimeIndex
   - Simplified the API and added a describe method to Categorical
@@ -87,29 +80,14 @@ pandas 0.11.1
 
 **API Changes**
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-  - When removing an object from a ``HDFStore``, ``remove(key)`` raises
-    ``KeyError`` if the key is not a valid store object.
-  - In an ``HDFStore``, raise a ``TypeError`` on passing ``where`` or ``columns`` 
-    to select with a Storer; these are invalid parameters at this time
-=======
-=======
->>>>>>> ab16d43... ENH: partial py3k support
   - ``HDFStore``
 
     - When removing an object, ``remove(key)`` raises
       ``KeyError`` if the key is not a valid store object.
     - raise a ``TypeError`` on passing ``where`` or ``columns`` 
       to select with a Storer; these are invalid parameters at this time
-<<<<<<< HEAD
     - can now specify an ``encoding`` option to ``append/put`` 
-      to enable alternate encodings
->>>>>>> 116ab91... DOC: docstring/release notes updates for py3k
-=======
-    - can now specify an ``encoding`` option to ``append`` and ``select`` 
-      to enable alternate encodings
->>>>>>> ab16d43... ENH: partial py3k support
+      to enable alternate encodings (GH3750_)
   - The repr() for (Multi)Index now obeys display.max_seq_items rather
     then numpy threshold print options. (GH3426_, GH3466_)
   - Added mangle_dupe_cols option to read_table/csv, allowing users
@@ -315,6 +293,7 @@ pandas 0.11.1
 .. _GH3740: https://github.com/pydata/pandas/issues/3740
 .. _GH3748: https://github.com/pydata/pandas/issues/3748
 .. _GH3741: https://github.com/pydata/pandas/issues/3741
+.. _GH3750: https://github.com/pydata/pandas/issues/3750
 
 pandas 0.11.0
 =============

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -64,9 +64,13 @@ pandas 0.11.1
     - support datelike columns with a timezone as data_columns (GH2852_)
     - table writing performance improvements.
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
     - support python3 (via ``PyTables 3.0.0``)
 >>>>>>> 116ab91... DOC: docstring/release notes updates for py3k
+=======
+    - support py3 (via ``PyTables 3.0.0``)
+>>>>>>> ab16d43... ENH: partial py3k support
   - Add modulo operator to Series, DataFrame
   - Add ``date`` method to DatetimeIndex
   - Simplified the API and added a describe method to Categorical
@@ -84,20 +88,28 @@ pandas 0.11.1
 **API Changes**
 
 <<<<<<< HEAD
+<<<<<<< HEAD
   - When removing an object from a ``HDFStore``, ``remove(key)`` raises
     ``KeyError`` if the key is not a valid store object.
   - In an ``HDFStore``, raise a ``TypeError`` on passing ``where`` or ``columns`` 
     to select with a Storer; these are invalid parameters at this time
 =======
+=======
+>>>>>>> ab16d43... ENH: partial py3k support
   - ``HDFStore``
 
     - When removing an object, ``remove(key)`` raises
       ``KeyError`` if the key is not a valid store object.
     - raise a ``TypeError`` on passing ``where`` or ``columns`` 
       to select with a Storer; these are invalid parameters at this time
+<<<<<<< HEAD
     - can now specify an ``encoding`` option to ``append/put`` 
       to enable alternate encodings
 >>>>>>> 116ab91... DOC: docstring/release notes updates for py3k
+=======
+    - can now specify an ``encoding`` option to ``append`` and ``select`` 
+      to enable alternate encodings
+>>>>>>> ab16d43... ENH: partial py3k support
   - The repr() for (Multi)Index now obeys display.max_seq_items rather
     then numpy threshold print options. (GH3426_, GH3466_)
   - Added mangle_dupe_cols option to read_table/csv, allowing users

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -63,6 +63,10 @@ pandas 0.11.1
       to append an index with a different name than the existing
     - support datelike columns with a timezone as data_columns (GH2852_)
     - table writing performance improvements.
+<<<<<<< HEAD
+=======
+    - support python3 (via ``PyTables 3.0.0``)
+>>>>>>> 116ab91... DOC: docstring/release notes updates for py3k
   - Add modulo operator to Series, DataFrame
   - Add ``date`` method to DatetimeIndex
   - Simplified the API and added a describe method to Categorical
@@ -79,10 +83,21 @@ pandas 0.11.1
 
 **API Changes**
 
+<<<<<<< HEAD
   - When removing an object from a ``HDFStore``, ``remove(key)`` raises
     ``KeyError`` if the key is not a valid store object.
   - In an ``HDFStore``, raise a ``TypeError`` on passing ``where`` or ``columns`` 
     to select with a Storer; these are invalid parameters at this time
+=======
+  - ``HDFStore``
+
+    - When removing an object, ``remove(key)`` raises
+      ``KeyError`` if the key is not a valid store object.
+    - raise a ``TypeError`` on passing ``where`` or ``columns`` 
+      to select with a Storer; these are invalid parameters at this time
+    - can now specify an ``encoding`` option to ``append/put`` 
+      to enable alternate encodings
+>>>>>>> 116ab91... DOC: docstring/release notes updates for py3k
   - The repr() for (Multi)Index now obeys display.max_seq_items rather
     then numpy threshold print options. (GH3426_, GH3466_)
   - Added mangle_dupe_cols option to read_table/csv, allowing users

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -69,13 +69,11 @@ if ( ! $VENV_FILE_AVAILABLE ); then
         pip install $PIP_ARGS  cython
 
         if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then
-            # installed explicitly above, to get the library as well
-        #    sudo apt-get $APT_ARGS install libhdf5-serial-dev;
-            pip install numexpr
-            pip install tables
             pip install $PIP_ARGS xlwt
         fi
 
+        pip install numexpr
+        pip install tables
         pip install $PIP_ARGS matplotlib
         pip install $PIP_ARGS openpyxl
         pip install $PIP_ARGS xlrd>=0.9.0

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -95,7 +95,6 @@ Optional Dependencies
     version. Version 0.17.1 or higher.
   * `SciPy <http://www.scipy.org>`__: miscellaneous statistical functions
   * `PyTables <http://www.pytables.org>`__: necessary for HDF5-based storage
-     * Not yet supported on python >= 3
   * `matplotlib <http://matplotlib.sourceforge.net/>`__: for plotting
   * `statsmodels <http://statsmodels.sourceforge.net/>`__
      * Needed for parts of :mod:`pandas.stats`

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1300,12 +1300,11 @@ the high performance HDF5 format using the excellent `PyTables
 <http://www.pytables.org/>`__ library. See the :ref:`cookbook<cookbook.hdf>`
 for some advanced strategies
 
-.. warning::
+.. note::
 
-   ``PyTables`` 3.0.0 was recently released. This enables support for Python 3,
-   however, it has not been integrated into pandas as of yet. (Under Python 2,
-   ``PyTables`` version >= 2.3 is supported).
-    
+   ``PyTables`` 3.0.0 was recently released to enables support for Python 3.
+   Pandas should be fully compatible (and previously written stores should be
+   backwards compatible) with all ``PyTables`` >= 2.3
 
 .. ipython:: python
    :suppress:

--- a/doc/source/v0.11.1.txt
+++ b/doc/source/v0.11.1.txt
@@ -237,6 +237,9 @@ Enhancements
          pd.get_option('a.b')
          pd.get_option('b.c')
 
+  - Support for ``HDFStore`` (via ``PyTables 3.0.0``) on Python3
+
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -218,7 +218,7 @@ class HDFStore(object):
     complevel : int, 1-9, default 0
             If a complib is specified compression will be applied
             where possible
-    complib : {'zliu', 'bzip2', 'lzo', 'blosc', None}, default None
+    complib : {'zlib', 'bzip2', 'lzo', 'blosc', None}, default None
             If complevel is > 0 apply compression to objects written
             in the store wherever possible
     fletcher32 : bool, default False
@@ -711,7 +711,8 @@ class HDFStore(object):
     def groups(self):
         """ return a list of all the top-level nodes (that are not themselves a pandas storage object) """
         _tables()
-        return [ g for g in self._handle.walkNodes() if getattr(g._v_attrs,'pandas_type',None) or getattr(g,'table',None) or (isinstance(g,_table_mod.table.Table) and g._v_name != u'table') ]
+        return [ g for g in self._handle.walkNodes() if getattr(g._v_attrs,'pandas_type',None) or getattr(
+            g,'table',None) or (isinstance(g,_table_mod.table.Table) and g._v_name != u'table') ]
 
     def get_node(self, key):
         """ return the node with the key or None if it does not exist """
@@ -731,7 +732,8 @@ class HDFStore(object):
         s.infer_axes()
         return s
 
-    def copy(self, file, mode = 'w', propindexes = True, keys = None, complib = None, complevel = None, fletcher32 = False, overwrite = True):
+    def copy(self, file, mode = 'w', propindexes = True, keys = None, complib = None, complevel = None,
+             fletcher32 = False, overwrite = True):
         """ copy the existing store to a new file, upgrading in place
 
             Parameters
@@ -845,7 +847,8 @@ class HDFStore(object):
         except:
             error('_TABLE_MAP')
 
-    def _write_to_group(self, key, value, index=True, table=False, append=False, complib=None, encoding=None, **kwargs):
+    def _write_to_group(self, key, value, index=True, table=False, append=False,
+                        complib=None, encoding=None, **kwargs):
         group = self.get_node(key)
 
         # remove the node if we are not appending
@@ -870,7 +873,8 @@ class HDFStore(object):
                     group = self._handle.createGroup(path, p)
                 path = new_path
 
-        s = self._create_storer(group, value, table=table, append=append, encoding=encoding, **kwargs)
+        s = self._create_storer(group, value, table=table, append=append,
+                                encoding=encoding, **kwargs)
         if append:
             # raise if we are trying to append to a non-table,
             #       or a table that exists (and we are putting)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -522,15 +522,16 @@ class HDFStore(object):
 
         Parameters
         ----------
-        key : object
-        value : {Series, DataFrame, Panel}
-        table : boolean, default False
+        key      : object
+        value    : {Series, DataFrame, Panel}
+        table    : boolean, default False
             Write as a PyTables Table structure which may perform worse but
             allow more flexible operations like searching / selecting subsets
             of the data
-        append : boolean, default False
+        append   : boolean, default False
             For table data structures, append the input data to the existing
             table
+        encoding : default None, provide an encoding for strings
         """
         self._write_to_group(key, value, table=table, append=append, **kwargs)
 
@@ -595,6 +596,7 @@ class HDFStore(object):
         nan_rep      : string to use as string nan represenation
         chunksize    : size to chunk the writing
         expectedrows : expected TOTAL row size of this table
+        encoding     : default None, provide an encoding for strings
 
         Notes
         -----

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -115,7 +115,7 @@ class TestHDFStore(unittest.TestCase):
             
             o = tm.makeTimeSeries()
             assert_series_equal(o, roundtrip('series',o))
-            
+
             o = tm.makeStringSeries()
             assert_series_equal(o, roundtrip('string_series',o))
             
@@ -570,7 +570,7 @@ class TestHDFStore(unittest.TestCase):
     def test_append_frame_column_oriented(self):
 
         with ensure_clean(self.path) as store:
-            import pdb; pdb.set_trace()
+
             # column oriented
             df = tm.makeTimeDataFrame()
             _maybe_remove(store, 'df1')
@@ -2560,6 +2560,7 @@ class TestHDFStore(unittest.TestCase):
         # legacy from 0.10
         try:
             store = HDFStore(tm.get_data_path('legacy_hdf/legacy_0.10.h5'), 'r')
+            str(store)
             for k in store.keys():
                 store.select(k)
         finally:
@@ -2569,6 +2570,7 @@ class TestHDFStore(unittest.TestCase):
         # legacy from 0.11
         try:
             store = HDFStore(tm.get_data_path('legacy_hdf/legacy_table_0.11.h5'), 'r')
+            str(store)
             df = store.select('df')
             df1 = store.select('df1')
             mi = store.select('mi')

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -474,6 +474,20 @@ class TestHDFStore(unittest.TestCase):
             store.append('uints', uint_data, data_columns=['u08','u16','u32']) # 64-bit indices not yet supported
             tm.assert_frame_equal(store['uints'], uint_data)
 
+    def test_encoding(self):
+        
+        with ensure_clean(self.path) as store:
+            df = DataFrame(dict(A='foo',B='bar'),index=range(5))
+            df.loc[2,'A'] = np.nan
+            df.loc[3,'B'] = np.nan
+            _maybe_remove(store, 'df')
+            store.append('df', df, encoding='ascii')
+            tm.assert_frame_equal(store['df'], df)
+
+            expected = df.reindex(columns=['A'])
+            result = store.select('df',Term('columns=A',encoding='ascii'))
+            tm.assert_frame_equal(result,expected)
+
     def test_append_some_nans(self):
 
         with ensure_clean(self.path) as store:
@@ -556,6 +570,7 @@ class TestHDFStore(unittest.TestCase):
     def test_append_frame_column_oriented(self):
 
         with ensure_clean(self.path) as store:
+            import pdb; pdb.set_trace()
             # column oriented
             df = tm.makeTimeDataFrame()
             _maybe_remove(store, 'df1')

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -14,6 +14,7 @@ from cpython cimport (PyDict_New, PyDict_GetItem, PyDict_SetItem,
                       Py_INCREF, PyTuple_SET_ITEM,
                       PyList_Check, PyFloat_Check,
                       PyString_Check,
+		      PyBytes_Check,
                       PyTuple_SetItem,
                       PyTuple_New,
                       PyObject_SetAttrString)
@@ -762,7 +763,7 @@ def max_len_string_array(ndarray[object, ndim=1] arr):
     m = 0
     for i from 0 <= i < length:
         v = arr[i]
-        if PyString_Check(v):
+        if PyString_Check(v) or PyBytes_Check(v):
             l = len(v)
 
             if l > m:
@@ -772,11 +773,10 @@ def max_len_string_array(ndarray[object, ndim=1] arr):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def array_replace_from_nan_rep(ndarray[object, ndim=1] arr, object nan_rep, object replace = None):
+def string_array_replace_from_nan_rep(ndarray[object, ndim=1] arr, object nan_rep, object replace = None):
     """ replace the values in the array with replacement if they are nan_rep; return the same array """
 
-    cdef int length = arr.shape[0]
-    cdef int i = 0
+    cdef int length = arr.shape[0], i = 0
     if replace is None:
         replace = np.nan
 
@@ -788,7 +788,6 @@ def array_replace_from_nan_rep(ndarray[object, ndim=1] arr, object nan_rep, obje
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-
 def write_csv_rows(list data, list data_index, int nlevels, list cols, object writer):
 
     cdef int N, j, i, ncols


### PR DESCRIPTION
closes #3750

recently released PyTables 3.0.0 (and numexpr 2.1), which now support python3
were completely broken

These changed all data to be stored as bytes (with to/from encoding/decoding)

This PR supports an encoding argument (if you really want to encode your data),
and provides transparent access for python3 (and backwards compat) to 
even python2 written stores
