### PR TITLE
Cookbook epoch handling

### DIFF
--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -268,7 +268,7 @@ The :ref:`CSV <io.read_csv_table>` docs
 <https://github.com/pydata/pandas/issues/2886>`__
 
 `Reading CSV with Unix timestamps and converting to local timezone
-<http://nbviewer.ipython.org/5714493>` __
+<http://nbviewer.ipython.org/5714493>`__
 
 .. _cookbook.sql:
 

--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -267,6 +267,9 @@ The :ref:`CSV <io.read_csv_table>` docs
 `Dealing with bad lines
 <https://github.com/pydata/pandas/issues/2886>`__
 
+`Reading CSV with Unix timestamps and converting to local timezone
+<http://nbviewer.ipython.org/5714493>` __
+
 .. _cookbook.sql:
 
 SQL


### PR DESCRIPTION
Added link to cookbook explaining how to use `read_csv` to parse files containing epoch timestamps and how to add local timezone information. Closes #3757 
