### PR TITLE
ENH: Provide a default key name in read_hdf and to_hdf

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -486,7 +486,7 @@ class PandasObject(object):
             np.putmask(rs.values, mask, np.nan)
         return rs
 
-    def to_hdf(self, path_or_buf, key, **kwargs):
+    def to_hdf(self, path_or_buf, key="data", **kwargs):
         """ activate the HDFStore """
         from pandas.io import pytables
         return pytables.to_hdf(path_or_buf, key, self, **kwargs)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -487,7 +487,16 @@ class PandasObject(object):
         return rs
 
     def to_hdf(self, path_or_buf, key="data", **kwargs):
-        """ activate the HDFStore """
+        """ 
+        Write to HDF5
+
+        Parameters
+        ----------
+        path_or_buf : string or file handle / StringIO
+            File path
+        key : string
+            Key used to reference the object in the file, default is "data"
+        """
         from pandas.io import pytables
         return pytables.to_hdf(path_or_buf, key, self, **kwargs)
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -181,7 +181,7 @@ def to_hdf(path_or_buf, key, value, mode=None, complevel=None, complib=None, app
     else:
         f(path_or_buf)
 
-def read_hdf(path_or_buf, key, **kwargs):
+def read_hdf(path_or_buf, key="data", **kwargs):
     """ read from the store, closeit if we opened it """
     f = lambda store: store.select(key, **kwargs)
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -182,7 +182,17 @@ def to_hdf(path_or_buf, key, value, mode=None, complevel=None, complib=None, app
         f(path_or_buf)
 
 def read_hdf(path_or_buf, key="data", **kwargs):
-    """ read from the store, closeit if we opened it """
+    """
+    Read from HDFStore
+    
+    Reads pandas objects from HDFStore, the HDFStore is closed if we opened it
+
+    Parameters:
+    path_or_buf : string or file handle / StringIO
+        File path
+    key : string
+        Key used to reference the object in the file, default is "data"
+    """
     f = lambda store: store.select(key, **kwargs)
 
     if isinstance(path_or_buf, basestring):


### PR DESCRIPTION
For convenience, provide a default name ("data") to quickly store and retrieve data from HDF5.

Now for csv:

``` python
df3 = pd.DataFrame(np.random.randn(10, 5), columns=['a', 'b', 'c', 'd', 'e'])
df3.to_csv("df3.csv")
print df3.from_csv("df3.csv")
```

for HDF5:

``` python
df3 = pd.DataFrame(np.random.randn(10, 5), columns=['a', 'b', 'c', 'd', 'e'])
df3.to_hdf("df3.h5", "data")
print pd.read_hdf("df3.h5", "data")
```

I would suggest to provide a default key name that would make it more convenient to read and write to HDF5 when it contains only one dataset.

In this PR:

``` python
df3 = pd.DataFrame(np.random.randn(10, 5), columns=['a', 'b', 'c', 'd', 'e'])
df3.to_hdf("df3.h5")
print pd.read_hdf("df3.h5")
```

Instead I would not provide a default key in `pd.read_hdf` because it would break backward compatibility.
