### PR TITLE
BUG: (GH3795) better error messages for invalid dtype specifications in read_csv

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -219,6 +219,7 @@ pandas 0.11.1
   - Incorrectly read a HDFStore multi-index Frame witha column specification (GH3748_)
   - ``read_html`` now correctly skips tests (GH3741_)
   - Fix incorrect arguments passed to concat that are not list-like (e.g. concat(df1,df2)) (GH3481_)
+  - Correctly parse when passed the ``dtype=str`` (or other variable-len string dtypes) in ``read_csv`` (GH3795_)
 
 .. _GH3164: https://github.com/pydata/pandas/issues/3164
 .. _GH2786: https://github.com/pydata/pandas/issues/2786
@@ -307,6 +308,7 @@ pandas 0.11.1
 .. _GH3741: https://github.com/pydata/pandas/issues/3741
 .. _GH3750: https://github.com/pydata/pandas/issues/3750
 .. _GH3726: https://github.com/pydata/pandas/issues/3726
+.. _GH3795: https://github.com/pydata/pandas/issues/3795
 
 pandas 0.11.0
 =============

--- a/pandas/parser.pyx
+++ b/pandas/parser.pyx
@@ -990,20 +990,36 @@ cdef class TextReader:
                                              na_filter, na_hashset)
             return result, na_count
         elif dtype[1] == 'c':
-            raise NotImplementedError
+            raise NotImplementedError("the dtype %s is not supported for parsing" % dtype)
 
         elif dtype[1] == 'S':
             # TODO: na handling
             width = int(dtype[2:])
-            result = _to_fw_string(self.parser, i, start, end, width)
-            return result, 0
+            if width > 0:
+                result = _to_fw_string(self.parser, i, start, end, width)
+                return result, 0
+
+            # treat as a regular string parsing
+            return self._string_convert(i, start, end, na_filter,
+                                       na_hashset)
         elif dtype[1] == 'U':
             width = int(dtype[2:])
-            raise NotImplementedError
+            if width > 0:
+                raise NotImplementedError("the dtype %s is not supported for parsing" % dtype)
+
+            # unicode variable width
+            return self._string_convert(i, start, end, na_filter,
+                                        na_hashset)
+
 
         elif dtype[1] == 'O':
             return self._string_convert(i, start, end, na_filter,
                                         na_hashset)
+        else:
+            if dtype[1] == 'M':
+                 raise TypeError("the dtype %s is not supported for parsing, "
+                                 "pass this column using parse_dates instead" % dtype)
+            raise TypeError("the dtype %s is not supported for parsing" % dtype)
 
     cdef _string_convert(self, Py_ssize_t i, int start, int end,
                          bint na_filter, kh_str_t *na_hashset):


### PR DESCRIPTION
ENH: accept 'str' as a dtype in read_csv to provide correct parsing

closes #3795

```
In [1]: df = DataFrame(np.random.rand(5,2),columns=list('AB'),index=['1A','1B','1C','1D','1E'])

In [2]: df
Out[2]: 
           A         B
1A  0.096563  0.761440
1B  0.623102  0.538810
1C  0.498820  0.277789
1D  0.113544  0.723437
1E  0.381104  0.061758

In [3]: df.dtypes
Out[3]: 
A    float64
B    float64
dtype: object

In [4]: path='test.csv'

In [5]: df.to_csv(path)

In [6]: pd.read_csv(path, dtype=str, index_col=0)
Out[6]: 
                      A                    B
1A  0.09656290409114332    0.761440208545324
1B   0.6231015058315575   0.5388097714651147
1C  0.49881957371373464  0.27778943212477014
1D  0.11354443109778356    0.723437196012621
1E  0.38110436826261596  0.06175758774696094

In [7]: pd.read_csv(path, dtype=str, index_col=0).dtypes
Out[7]: 
A    object
B    object
dtype: object
```

Invalid dtype specifciation, all `TypeError`, slightly different messages depending on what you are doing (e.g. if its completely invalid or really a date spec)

```
In [8]: pd.read_csv(path, index_col=0, dtype={'A' : 'foo'})
TypeError: data type "foo" not understood

In [9]: pd.read_csv(path, index_col=0, dtype={'A' : 'datetime64'})
TypeError: the dtype <M8 is not supported for parsing, pass this column using parse_dates instead

In [10]: pd.read_csv(path, index_col=0, dtype={'A' : 'timedelta64'})
TypeError: the dtype <m8 is not supported for parsing

```
