### PR TITLE
BLD: Add useful shortcuts to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,27 @@
-clean:
+.PHONY : clean develop build clean clean_pyc tseries doc
+
+clean: clean_pyc
 	-rm -rf build dist
+	-find . -name '*.so' -exec rm -f {} \;
+
+clean_pyc:
+	-find . -name '*.pyc' -exec rm -f {} \;
 
 tseries: pandas/lib.pyx pandas/tslib.pyx pandas/hashtable.pyx
 	python setup.py build_ext --inplace
 
 sparse: pandas/src/sparse.pyx
-	-python setup.py build_ext --inplace
+	python setup.py build_ext --inplace
 
-test: sparse
-	-python pandas/tests/test_libsparse.py
+build: clean_pyc
+	python setup.py build_ext --inplace
+
+develop: build
+	-python setup.py develop
+
+doc:
+	-rm -rf doc/build
+	-rm -rf doc/source/generated
+	cd doc; \
+	python make.py clean; \
+	python make.py html


### PR DESCRIPTION
Add some shortcuts to make it easier to develop with pandas.

now there's a set of commands in the `Makefile` in the top-level pandas directory with the following functionality
- `make clean` will delete the `build` and `dist` directories + all `*.pyc` and `*.so` files
- `make clean_pyc` just removes `*.pyc` files
- `make build` will build extensions inplace
- `make develop` will install `pandas` in your environment but will place a link to the dev dir so that you can make changes and they will show up immediately
- `make doc` will build the documentation from scratch (erases generated and build directories)
