### PR TITLE
Alter imports in pandas/__init__.py to be explicit

### DIFF
--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -24,11 +24,39 @@ from pandas.info import __doc__
 # let init-time option registration happen
 import pandas.core.config_init
 
-from pandas.core.api import *
-from pandas.sparse.api import *
-from pandas.stats.api import *
-from pandas.tseries.api import *
-from pandas.io.api import *
+from pandas.core.api import (
+        factorize, match, unique, value_counts, isnull, notnull, save, load,
+        Categorical, Factor, set_printoptions, reset_printoptions,
+        set_eng_float_format, Index, Int64Index, MultiIndex, Series, TimeSeries,
+        DataFrame, Panel, Panel4D, groupby, pivot, get_dummies, lreshape, WidePanel,
+        DateOffset, to_datetime, DatetimeIndex, Timestamp, date_range, bdate_range,
+        Period, PeriodIndex, datetools, get_option, set_option, reset_option,
+        describe_option, options, DateRange # deprecated
+        )
+from pandas.sparse.api import (
+        SparseArray, SparseList, SparseSeries, SparseTimeSeries,
+        SparseDataFrame, SparsePanel
+        )
+from pandas.stats.api import (
+        ols, fama_macbeth, rolling_count, rolling_max, rolling_min,
+        rolling_sum, rolling_mean, rolling_std, rolling_cov, rolling_corr,
+        rolling_var, rolling_skew, rolling_kurt, rolling_quantile,
+        rolling_median, rolling_apply, rolling_corr_pairwise, rolling_window,
+        ewma, ewmvar, ewmstd, ewmvol, ewmcorr, ewmcov, expanding_count,
+        expanding_max, expanding_min, expanding_sum, expanding_mean,
+        expanding_std, expanding_cov, expanding_corr, expanding_var,
+        expanding_skew, expanding_kurt, expanding_quantile, expanding_median,
+        expanding_apply, expanding_corr_pairwise
+        )
+from pandas.tseries.api import (
+    DatetimeIndex, date_range, bdate_range, infer_freq, Period, PeriodIndex,
+    period_range, pnow, TimeGrouper, NaT, offsets
+    )
+from pandas.io.api import (
+        read_csv, read_table, read_clipboard, read_fwf, to_clipboard, ExcelFile,
+        ExcelWriter, read_excel, HDFStore, Term, get_store, read_hdf, read_html,
+        read_sql, read_stata
+        )
 
 from pandas.util.testing import debug
 
@@ -38,3 +66,18 @@ from pandas.tools.pivot import pivot_table, crosstab
 from pandas.tools.plotting import scatter_matrix, plot_params
 from pandas.tools.tile import cut, qcut
 from pandas.core.reshape import melt
+
+# import these so we can add them to __all__
+import pandas.core.api as core_api
+import pandas.sparse.api as sparse_api
+import pandas.stats.api as stats_api
+import pandas.tseries.api as tseries_api
+import pandas.io.api as io_api
+__all__ = ["debug", "value_range", "merge", "concat", "ordered_merge",
+        "pivot_table", "crosstab", "scatter_matrix", "plot_params",
+        "cut", "qcut", "melt"]
+__all__.extend(core_api.__all__)
+__all__.extend(sparse_api.__all__)
+__all__.extend(stats_api.__all__)
+__all__.extend(tseries_api.__all__)
+__all__.extend(io_api.__all__)

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -75,7 +75,7 @@ import pandas.tseries.api as tseries_api
 import pandas.io.api as io_api
 __all__ = ["debug", "value_range", "merge", "concat", "ordered_merge",
         "pivot_table", "crosstab", "scatter_matrix", "plot_params",
-        "cut", "qcut", "melt"]
+        "cut", "qcut", "melt", "np"]
 __all__.extend(core_api.__all__)
 __all__.extend(sparse_api.__all__)
 __all__.extend(stats_api.__all__)

--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -32,3 +32,11 @@ import pandas.core.datetools as datetools
 
 from pandas.core.config import get_option, set_option, reset_option,\
     describe_option, options
+
+__all__ = ['factorize', 'match', 'unique', 'value_counts', 'isnull', 'notnull', 'save', 'load',
+        'Categorical', 'Factor', 'set_printoptions', 'reset_printoptions',
+        'set_eng_float_format', 'Index', 'Int64Index', 'MultiIndex', 'Series', 'TimeSeries',
+        'DataFrame', 'Panel', 'Panel4D', 'groupby', 'pivot', 'get_dummies', 'lreshape', 'WidePanel',
+        'DateOffset', 'to_datetime', 'DatetimeIndex', 'Timestamp', 'date_range', 'bdate_range',
+        'Period', 'PeriodIndex', 'datetools', 'get_option', 'set_option', 'reset_option',
+        'describe_option', 'options', 'DateRange']

--- a/pandas/io/api.py
+++ b/pandas/io/api.py
@@ -9,3 +9,7 @@ from pandas.io.pytables import HDFStore, Term, get_store, read_hdf
 from pandas.io.html import read_html
 from pandas.io.sql import read_sql
 from pandas.io.stata import read_stata
+
+__all__ = ['read_csv', 'read_table', 'read_clipboard', 'read_fwf',
+        'to_clipboard', 'ExcelFile', 'ExcelWriter', 'read_excel', 'HDFStore', 'Term',
+        'get_store', 'read_hdf', 'read_html', 'read_sql', 'read_stata']

--- a/pandas/sparse/api.py
+++ b/pandas/sparse/api.py
@@ -5,3 +5,6 @@ from pandas.sparse.list import SparseList
 from pandas.sparse.series import SparseSeries, SparseTimeSeries
 from pandas.sparse.frame import SparseDataFrame
 from pandas.sparse.panel import SparsePanel
+
+__all__ = ['SparseArray', 'SparseList', 'SparseSeries', 'SparseTimeSeries',
+        'SparseDataFrame', 'SparsePanel']

--- a/pandas/stats/api.py
+++ b/pandas/stats/api.py
@@ -7,3 +7,13 @@ Common namespace of statistical functions
 from pandas.stats.moments import *
 from pandas.stats.interface import ols
 from pandas.stats.fama_macbeth import fama_macbeth
+
+__all__ = ['ols', 'fama_macbeth', 'rolling_count', 'rolling_max', 'rolling_min',
+        'rolling_sum', 'rolling_mean', 'rolling_std', 'rolling_cov', 'rolling_corr',
+        'rolling_var', 'rolling_skew', 'rolling_kurt', 'rolling_quantile',
+        'rolling_median', 'rolling_apply', 'rolling_corr_pairwise', 'rolling_window',
+        'ewma', 'ewmvar', 'ewmstd', 'ewmvol', 'ewmcorr', 'ewmcov', 'expanding_count',
+        'expanding_max', 'expanding_min', 'expanding_sum', 'expanding_mean',
+        'expanding_std', 'expanding_cov', 'expanding_corr', 'expanding_var',
+        'expanding_skew', 'expanding_kurt', 'expanding_quantile', 'expanding_median',
+        'expanding_apply', 'expanding_corr_pairwise']

--- a/pandas/stats/api.py
+++ b/pandas/stats/api.py
@@ -4,7 +4,17 @@ Common namespace of statistical functions
 
 # pylint: disable-msg=W0611,W0614,W0401
 
-from pandas.stats.moments import *
+from pandas.stats.moments import (
+        rolling_count, rolling_max, rolling_min, rolling_sum, rolling_mean,
+        rolling_std, rolling_cov, rolling_corr, rolling_var, rolling_skew,
+        rolling_kurt, rolling_quantile, rolling_median, rolling_apply,
+        rolling_corr_pairwise, rolling_window, ewma, ewmvar, ewmstd, ewmvol,
+        ewmcorr, ewmcov, expanding_count, expanding_max, expanding_min,
+        expanding_sum, expanding_mean, expanding_std, expanding_cov,
+        expanding_corr, expanding_var, expanding_skew, expanding_kurt,
+        expanding_quantile, expanding_median, expanding_apply,
+        expanding_corr_pairwise
+        )
 from pandas.stats.interface import ols
 from pandas.stats.fama_macbeth import fama_macbeth
 

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -539,6 +539,20 @@ class TestBlockManager(unittest.TestCase):
         except KeyError:
             pass  # this is the expected exception
 
+class TestTopLevelImports(object):
+    def test_pandas_imports_all__all__(self):
+        # import these so we can add them to __all__
+        import pandas.core.api as core_api
+        import pandas.sparse.api as sparse_api
+        import pandas.stats.api as stats_api
+        import pandas.tseries.api as tseries_api
+        import pandas.io.api as io_api
+        import pandas
+        missing = []
+        for api in (core_api, sparse_api, stats_api, tseries_api, io_api):
+            missing.extend([attr for attr in api.__all__ if not hasattr(pandas, attr)])
+        assert not missing, "Expected pandas to import all `__all__` from api files. Missing: %r" % missing
+
 if __name__ == '__main__':
     # unittest.main()
     import nose

--- a/pandas/tseries/api.py
+++ b/pandas/tseries/api.py
@@ -2,10 +2,13 @@
 
 """
 
-
 from pandas.tseries.index import DatetimeIndex, date_range, bdate_range
 from pandas.tseries.frequencies import infer_freq
 from pandas.tseries.period import Period, PeriodIndex, period_range, pnow
 from pandas.tseries.resample import TimeGrouper
 from pandas.lib import NaT
 import pandas.tseries.offsets as offsets
+
+__all__ = ['DatetimeIndex', 'date_range', 'bdate_range', 'infer_freq',
+        'Period', 'PeriodIndex', 'period_range', 'pnow', 'TimeGrouper',
+        'NaT', 'offsets']


### PR DESCRIPTION
Also adds an `__all__` to all the api files as well as a test case that
checks that everything in the api files ends up in the toplevel pandas
namespace. I personally find it hard to trace back the top level pandas
functions because of the `from xyz import *` calls. I changed everything
to be explicit. I think it's better, but it's your call.

The only large change with this is that the `pandas` module/package no
longer exports `numpy/np` at the top level.
