### PR TITLE
FIX py3ing some print statements

### DIFF
--- a/examples/regressions.py
+++ b/examples/regressions.py
@@ -31,7 +31,7 @@ Y = makeSeries()
 
 model = ols(y=Y, x=X)
 
-print model
+print (model)
 
 #-------------------------------------------------------------------------------
 # Panel regression
@@ -48,4 +48,4 @@ panelModel = ols(y=Y, x=data, window=50)
 
 model = ols(y=Y, x=data)
 
-print panelModel
+print (panelModel)

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -3,10 +3,17 @@
 __docformat__ = 'restructuredtext'
 
 try:
-    from pandas import hashtable, tslib, lib
-except ImportError as e:  # pragma: no cover
-    module = str(e).lstrip('cannot import name ')  # hack but overkill to use re
-    raise ImportError("C extensions: {0} not built".format(module))
+    from . import hashtable, tslib, lib
+except Exception:  # pragma: no cover
+    import sys
+    e = sys.exc_info()[1]  # Py25 and Py3 current exception syntax conflict
+    print (e)
+    if 'No module named lib' in str(e):
+        raise ImportError('C extensions not built: if you installed already '
+                          'verify that you are not importing from the source '
+                          'directory')
+    else:
+        raise
 
 from datetime import datetime
 import numpy as np

--- a/pandas/core/config.py
+++ b/pandas/core/config.py
@@ -154,7 +154,7 @@ def _describe_option(pat='', _print_desc=True):
         s += _build_option_description(k)
 
     if _print_desc:
-        print s
+        print (s)
     else:
         return s
 
@@ -631,7 +631,7 @@ def pp_options_list(keys, width=80, _print=False):
         ls += pp(k, ks)
     s = '\n'.join(ls)
     if _print:
-        print s
+        print (s)
     else:
         return s
 

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -1899,4 +1899,4 @@ if __name__ == '__main__':
                     1134250., 1219550., 855736.85, 1042615.4286,
                     722621.3043, 698167.1818, 803750.])
     fmt = FloatArrayFormatter(arr, digits=7)
-    print fmt.get_result()
+    print (fmt.get_result())

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1420,7 +1420,7 @@ class SeriesGroupBy(GroupBy):
             ret = Series(result, index=index)
 
         if not self.as_index:  # pragma: no cover
-            print 'Warning, ignoring as_index=True'
+            print ('Warning, ignoring as_index=True')
 
         return ret
 

--- a/pandas/io/auth.py
+++ b/pandas/io/auth.py
@@ -55,7 +55,7 @@ def process_flags(flags=[]):
     try:
         FLAGS(flags)
     except gflags.FlagsError, e:
-        print '%s\nUsage: %s ARGS\n%s' % (e, str(flags), FLAGS)
+        print ('%s\nUsage: %s ARGS\n%s' % (e, str(flags), FLAGS))
         sys.exit(1)
 
     # Set the logging according to the command-line flag.

--- a/pandas/io/data.py
+++ b/pandas/io/data.py
@@ -115,7 +115,7 @@ def get_quote_yahoo(symbols):
         lines = urllib2.urlopen(urlStr).readlines()
     except Exception, e:
         s = "Failed to download:\n{0}".format(e)
-        print s
+        print (s)
         return None
 
     for line in lines:
@@ -467,7 +467,7 @@ def get_data_fred(name=None, start=dt.datetime(2010, 1, 1),
     start, end = _sanitize_dates(start, end)
 
     if(name is None):
-        print "Need to provide a name"
+        print ("Need to provide a name")
         return None
 
     fred_URL = "http://research.stlouisfed.org/fred2/series/"

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -508,7 +508,7 @@ class TextFileReader(object):
         sep = options['delimiter']
         if (sep is None and not options['delim_whitespace']):
             if engine == 'c':
-                print 'Using Python parser to sniff delimiter'
+                print ('Using Python parser to sniff delimiter')
                 engine = 'python'
         elif sep is not None and len(sep) > 1:
             # wait until regex engine integrated
@@ -867,7 +867,7 @@ class ParserBase(object):
                                                   coerce_type)
             result[c] = cvals
             if verbose and na_count:
-                print 'Filled %d NA values in column %s' % (na_count, str(c))
+                print ('Filled %d NA values in column %s' % (na_count, str(c)))
         return result
 
     def _convert_types(self, values, na_values, try_num_bool=True):

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -386,7 +386,7 @@ class HDFStore(object):
             self._handle = h5_open(self._path, self._mode)
         except IOError, e:  # pragma: no cover
             if 'can not be written' in str(e):
-                print 'Opening %s in read-only mode' % self._path
+                print ('Opening %s in read-only mode' % self._path)
                 self._handle = h5_open(self._path, 'r')
             else:
                 raise

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -51,7 +51,7 @@ def execute(sql, con, retry=True, cur=None, params=None):
         except Exception:  # pragma: no cover
             pass
 
-        print 'Error on sql %s' % sql
+        print ('Error on sql %s' % sql)
         raise
 
 
@@ -94,7 +94,7 @@ def tquery(sql, con=None, cur=None, retry=True):
         except Exception, e:
             excName = e.__class__.__name__
             if excName == 'OperationalError':  # pragma: no cover
-                print 'Failed to commit, may need to restart interpreter'
+                print ('Failed to commit, may need to restart interpreter')
             else:
                 raise
 
@@ -128,7 +128,7 @@ def uquery(sql, con=None, cur=None, retry=True, params=None):
 
         traceback.print_exc()
         if retry:
-            print 'Looks like your connection failed, reconnecting...'
+            print ('Looks like your connection failed, reconnecting...')
             return uquery(sql, con, retry=False)
     return result
 

--- a/pandas/io/tests/test_html.py
+++ b/pandas/io/tests/test_html.py
@@ -86,8 +86,8 @@ class TestReadHtmlBase(TestCase):
         out = df.to_html()
         res = self.run_read_html(out, attrs={'class': 'dataframe'},
                                  index_col=0)[0]
-        print df.dtypes
-        print res.dtypes
+        print (df.dtypes)
+        print (res.dtypes)
         assert_frame_equal(res, df)
 
     @network
@@ -125,7 +125,7 @@ class TestReadHtmlBase(TestCase):
         df2 = self.run_read_html(self.spam_data, 'Unit', infer_types=False)
 
         assert_framelist_equal(df1, df2)
-        print df1[0]
+        print (df1[0])
 
         self.assertEqual(df1[0].ix[0, 0], 'Proximates')
         self.assertEqual(df1[0].columns[0], 'Nutrient')

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -987,7 +987,7 @@ class TestHDFStore(unittest.TestCase):
             rows = store.root.df.table.nrows
             recons = store.select('df')
 
-        print "\nbig_table frame [%s] -> %5.2f" % (rows, time.time() - x)
+        print ("\nbig_table frame [%s] -> %5.2f" % (rows, time.time() - x))
 
     def test_big_table2_frame(self):
         # this is a really big table: 1m rows x 60 float columns, 20 string, 20 datetime
@@ -995,7 +995,7 @@ class TestHDFStore(unittest.TestCase):
         raise nose.SkipTest('no big table2 frame')
 
         # create and write a big table
-        print "\nbig_table2 start"
+        print ("\nbig_table2 start")
         import time
         start_time = time.time()
         df = DataFrame(np.random.randn(1000 * 1000, 60), index=xrange(int(
@@ -1005,7 +1005,8 @@ class TestHDFStore(unittest.TestCase):
         for x in xrange(20):
             df['datetime%03d' % x] = datetime.datetime(2001, 1, 2, 0, 0)
 
-        print "\nbig_table2 frame (creation of df) [rows->%s] -> %5.2f" % (len(df.index), time.time() - start_time)
+        print ("\nbig_table2 frame (creation of df) [rows->%s] -> %5.2f"
+                    % (len(df.index), time.time() - start_time))
 
         def f(chunksize):
             with ensure_clean(self.path,mode='w') as store:
@@ -1015,14 +1016,15 @@ class TestHDFStore(unittest.TestCase):
 
         for c in [10000, 50000, 250000]:
             start_time = time.time()
-            print "big_table2 frame [chunk->%s]" % c
+            print ("big_table2 frame [chunk->%s]" % c)
             rows = f(c)
-            print "big_table2 frame [rows->%s,chunk->%s] -> %5.2f" % (rows, c, time.time() - start_time)
+            print ("big_table2 frame [rows->%s,chunk->%s] -> %5.2f" 
+                    % (rows, c, time.time() - start_time))
 
     def test_big_put_frame(self):
         raise nose.SkipTest('no big put frame')
 
-        print "\nbig_put start"
+        print ("\nbig_put start")
         import time
         start_time = time.time()
         df = DataFrame(np.random.randn(1000 * 1000, 60), index=xrange(int(
@@ -1032,15 +1034,17 @@ class TestHDFStore(unittest.TestCase):
         for x in xrange(20):
             df['datetime%03d' % x] = datetime.datetime(2001, 1, 2, 0, 0)
 
-        print "\nbig_put frame (creation of df) [rows->%s] -> %5.2f" % (len(df.index), time.time() - start_time)
+        print ("\nbig_put frame (creation of df) [rows->%s] -> %5.2f" 
+                % (len(df.index), time.time() - start_time))
 
         with ensure_clean(self.path, mode='w') as store:
             start_time = time.time()
             store = HDFStore(fn, mode='w')
             store.put('df', df)
 
-            print df.get_dtype_counts()
-            print "big_put frame [shape->%s] -> %5.2f" % (df.shape, time.time() - start_time)
+            print (df.get_dtype_counts())
+            print ("big_put frame [shape->%s] -> %5.2f" 
+                    % (df.shape, time.time() - start_time))
 
     def test_big_table_panel(self):
         raise nose.SkipTest('no big table panel')
@@ -1064,7 +1068,7 @@ class TestHDFStore(unittest.TestCase):
             rows = store.root.wp.table.nrows
             recons = store.select('wp')
 
-        print "\nbig_table panel [%s] -> %5.2f" % (rows, time.time() - x)
+        print ("\nbig_table panel [%s] -> %5.2f" % (rows, time.time() - x))
 
     def test_append_diff_item_order(self):
 
@@ -2461,10 +2465,10 @@ class TestHDFStore(unittest.TestCase):
                 expected = expected[5:]
                 tm.assert_frame_equal(result, expected)
             except (Exception), detail:
-                print "error in select_as_multiple %s" % str(detail)
-                print "store: ", store
-                print "df1: ", df1
-                print "df2: ", df2
+                print ("error in select_as_multiple %s" % str(detail))
+                print ("store: %s" % store)
+                print ("df1: %s" % df1)
+                print ("df2: %s" % df2)
 
 
             # test excpection for diff rows

--- a/pandas/io/wb.py
+++ b/pandas/io/wb.py
@@ -65,10 +65,10 @@ def download(country=['MX', 'CA', 'US'], indicator=['GDPPCKD', 'GDPPCKN'],
             bad_indicators.append(ind)
     # Warn
     if len(bad_indicators) > 0:
-        print 'Failed to obtain indicator(s): ' + '; '.join(bad_indicators)
-        print 'The data may still be available for download at http://data.worldbank.org'
+        print ('Failed to obtain indicator(s): %s' % '; '.join(bad_indicators))
+        print ('The data may still be available for download at http://data.worldbank.org')
     if len(bad_countries) > 0:
-        print 'Invalid ISO-2 codes: ' + ' '.join(bad_countries)
+        print ('Invalid ISO-2 codes: %s' % ' '.join(bad_countries))
     # Merge WDI series
     if len(data) > 0:
         out = reduce(lambda x, y: x.merge(y, how='outer'), data)

--- a/pandas/rpy/common.py
+++ b/pandas/rpy/common.py
@@ -73,7 +73,7 @@ def _convert_array(obj):
                             major_axis=name_list[0],
                             minor_axis=name_list[1])
         else:
-            print 'Cannot handle dim=%d' % len(dim)
+            print ('Cannot handle dim=%d' % len(dim))
     else:
         return arr
 

--- a/pandas/stats/plm.py
+++ b/pandas/stats/plm.py
@@ -56,7 +56,7 @@ class PanelOLS(OLS):
 
     def log(self, msg):
         if self._verbose:  # pragma: no cover
-            print msg
+            print (msg)
 
     def _prepare_data(self):
         """Cleans and stacks input data into DataFrame objects

--- a/pandas/stats/tests/test_var.py
+++ b/pandas/stats/tests/test_var.py
@@ -124,10 +124,10 @@ class RVAR(object):
         return rpy.convert_robj(r.coef(self._estimate))
 
     def summary(self, equation=None):
-        print r.summary(self._estimate, equation=equation)
+        print (r.summary(self._estimate, equation=equation))
 
     def output(self):
-        print self._estimate
+        print (self._estimate)
 
     def estimate(self):
         self._estimate = r.VAR(self.rdata, p=self.p, type=self.type)
@@ -144,7 +144,7 @@ class RVAR(object):
         return test
 
     def data_summary(self):
-        print r.summary(self.rdata)
+        print (r.summary(self.rdata))
 
 
 class TestVAR(TestCase):

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -337,8 +337,8 @@ class TestDataFrameFormatting(unittest.TestCase):
         empty = DataFrame({u'c/\u03c3': Series()})
         nonempty = DataFrame({u'c/\u03c3': Series([1, 2, 3])})
 
-        print >>buf, empty  # TODO py3?
-        print >>buf, nonempty  # TODO py3?
+        print >>buf, empty
+        print >>buf, nonempty
 
         # this should work
         buf.getvalue()

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -337,8 +337,8 @@ class TestDataFrameFormatting(unittest.TestCase):
         empty = DataFrame({u'c/\u03c3': Series()})
         nonempty = DataFrame({u'c/\u03c3': Series([1, 2, 3])})
 
-        print >>buf, empty
-        print >>buf, nonempty
+        print >>buf, empty  # TODO py3?
+        print >>buf, nonempty  # TODO py3?
 
         # this should work
         buf.getvalue()

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -9079,7 +9079,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         if not ('max' in name or 'min' in name or 'count' in name):
             df = DataFrame({'b': date_range('1/1/2001', periods=2)})
             _f = getattr(df, name)
-            print df
+            print (df)
             self.assertFalse(len(_f()))
 
             df['a'] = range(len(df))

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -499,8 +499,8 @@ class TestGroupBy(unittest.TestCase):
         df = DataFrame(randint(10, size=(20, 10)))
 
         def raiseException(df):
-          print '----------------------------------------'
-          print df.to_string()
+          print ('----------------------------------------')
+          print (df.to_string())
           raise TypeError
 
         self.assertRaises(TypeError, df.groupby(0).agg,

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -85,7 +85,7 @@ class TimeGrouper(CustomGrouper):
             offset = to_offset(self.freq)
             if offset.n > 1:
                 if self.kind == 'period':  # pragma: no cover
-                    print 'Warning: multiple of frequency -> timestamps'
+                    print ('Warning: multiple of frequency -> timestamps')
                 # Cannot have multiple of periods, convert to timestamp
                 self.kind = 'timestamp'
 

--- a/pandas/tseries/tools.py
+++ b/pandas/tseries/tools.py
@@ -20,7 +20,7 @@ try:
         raise Exception('dateutil 2.0 incompatible with Python 2.x, you must '
                         'install version 1.5 or 2.1+!')
 except ImportError:  # pragma: no cover
-    print 'Please install python-dateutil via easy_install or some method!'
+    print ('Please install python-dateutil via easy_install or some method!')
     raise  # otherwise a 2nd import won't show the message
 
 

--- a/pandas/util/terminal.py
+++ b/pandas/util/terminal.py
@@ -117,4 +117,4 @@ def _get_terminal_size_linux():
 
 if __name__ == "__main__":
     sizex, sizey = get_terminal_size()
-    print 'width =', sizex, 'height =', sizey
+    print ('width = %s height = %s' % (sizex, sizey))


### PR DESCRIPTION
I just grepped where there was python 2 print statement. There are still some in vbench/scripts/ez_setup and sphinxext/src (as well as in the rst docs), but these are all all from the main codebase.

```
grep "print [^(]" . -r
```

I don't know how to deal with the `print >>buf, empty` etc. (or whether we need to, ~~I've only labelled~~ there's only the two of these).... ?

_I found one by trying to use py3 before building, where I got a `print e` syntax error._
