### PR TITLE
CLN: conform read_clipboard / to_clipboard to new io standards

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -127,6 +127,7 @@ pandas 0.11.1
     - added ``pandas.io.api`` for i/o imports
     - removed ``Excel`` support to ``pandas.io.excel``
     - added top-level ``pd.read_sql`` and ``to_sql`` DataFrame methods
+    - removed ``clipboard`` support to ``pandas.io.clipboard``
   - the ``method`` and ``axis`` arguments of ``DataFrame.replace()`` are
     deprecated
   - Implement ``__nonzero__`` for ``NDFrame`` objects (GH3691_, GH3696_)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -492,8 +492,8 @@ class PandasObject(object):
         return pytables.to_hdf(path_or_buf, key, self, **kwargs)
 
     def to_clipboard(self):
-        from pandas.io import parsers
-        parsers.to_clipboard(self)
+        from pandas.io import clipboard
+        clipboard.to_clipboard(self)
 
 # install the indexerse
 for _name, _indexer in indexing.get_indexers_list():

--- a/pandas/io/api.py
+++ b/pandas/io/api.py
@@ -2,8 +2,8 @@
 Data IO api
 """
 
-from pandas.io.parsers import (read_csv, read_table, read_clipboard,
-                               read_fwf, to_clipboard)
+from pandas.io.parsers import read_csv, read_table, read_fwf
+from pandas.io.clipboard import read_clipboard
 from pandas.io.excel import ExcelFile, ExcelWriter, read_excel
 from pandas.io.pytables import HDFStore, Term, get_store, read_hdf
 from pandas.io.html import read_html

--- a/pandas/io/clipboard.py
+++ b/pandas/io/clipboard.py
@@ -1,0 +1,31 @@
+""" io on the clipboard """
+
+def read_clipboard(**kwargs):  # pragma: no cover
+    """
+    Read text from clipboard and pass to read_table. See read_table for the
+    full argument list
+
+    Returns
+    -------
+    parsed : DataFrame
+    """
+    from pandas.util.clipboard import clipboard_get
+    text = clipboard_get()
+    return read_table(StringIO(text), **kwargs)
+
+
+def to_clipboard(obj):  # pragma: no cover
+    """
+    Attempt to write text representation of object to the system clipboard
+
+    Notes
+    -----
+    Requirements for your platform
+      - Linux: xsel command line tool
+      - Windows: Python win32 extensions
+      - OS X:
+    """
+    from pandas.util.clipboard import clipboard_set
+    clipboard_set(str(obj))
+
+

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -5,6 +5,7 @@ from StringIO import StringIO
 import re
 from itertools import izip
 import csv
+from warnings import warn
 
 import numpy as np
 
@@ -425,35 +426,6 @@ def read_fwf(filepath_or_buffer, colspecs=None, widths=None, **kwds):
     kwds['colspecs'] = colspecs
     kwds['engine'] = 'python-fwf'
     return _read(filepath_or_buffer, kwds)
-
-
-def read_clipboard(**kwargs):  # pragma: no cover
-    """
-    Read text from clipboard and pass to read_table. See read_table for the
-    full argument list
-
-    Returns
-    -------
-    parsed : DataFrame
-    """
-    from pandas.util.clipboard import clipboard_get
-    text = clipboard_get()
-    return read_table(StringIO(text), **kwargs)
-
-
-def to_clipboard(obj):  # pragma: no cover
-    """
-    Attempt to write text representation of object to the system clipboard
-
-    Notes
-    -----
-    Requirements for your platform
-      - Linux: xsel command line tool
-      - Windows: Python win32 extensions
-      - OS X:
-    """
-    from pandas.util.clipboard import clipboard_set
-    clipboard_set(str(obj))
 
 
 # common NA values
@@ -1940,15 +1912,25 @@ class FixedWidthFieldParser(PythonParser):
         self.data = FixedWidthReader(f, self.colspecs, self.delimiter)
 
 
+##### deprecations in 0.11.1 #####
+##### remove in 0.12         #####
+
+from pandas.io import clipboard
+def read_clipboard(**kwargs):
+    warn("read_clipboard is now a top-level accessible via pandas.read_clipboard", FutureWarning)
+    clipboard.read_clipboard(**kwargs)
+
+def to_clipboard(obj):
+    warn("to_clipboard is now an object level method accessible via obj.to_clipboard()", FutureWarning)
+    clipboard.to_clipboard(obj)
+
 from pandas.io import excel
 class ExcelWriter(excel.ExcelWriter):
     def __init__(self, path):
-        from warnings import warn
         warn("ExcelWriter can now be imported from: pandas.io.excel", FutureWarning)
         super(ExcelWriter, self).__init__(path)
 
 class ExcelFile(excel.ExcelFile):
     def __init__(self, path_or_buf, kind=None, **kwds):
-        from warnings import warn
         warn("ExcelFile can now be imported from: pandas.io.excel", FutureWarning)
         super(ExcelFile, self).__init__(path_or_buf, kind=kind, **kwds)


### PR DESCRIPTION
removed to io.clipboard (from io.parsers)
