### PR TITLE
DOC: Clarify quote behavior parameters

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -42,7 +42,11 @@ filepath_or_buffer : string or file handle / StringIO. The string could be
 lineterminator : string (length 1), default None
     Character to break file into lines. Only valid with C parser
 quotechar : string
-quoting : string
+    The character to used to denote the start and end of a quoted item. Quoted items can include the delimiter and it will be ignored.
+quoting : int
+    Controls whether quotes should be recognized. Values are taken from
+    `csv.QUOTE_*` values. Acceptable values are 0, 1, 2, and 3 for
+    QUOTE_MINIMAL, QUOTE_ALL, QUOTE_NONE, and QUOTE_NONNUMERIC, respectively.
 skipinitialspace : boolean, default False
     Skip spaces after delimiter
 escapechar : string


### PR DESCRIPTION
I've been bit many times recently by mal-formed CSV. Non-closing quotes across lines. This clarifies how to avoid the problem a bit.
