### PR TITLE
TST: Fix missing import in io/tests/test_json

### DIFF
--- a/pandas/io/tests/test_json/test_pandas.py
+++ b/pandas/io/tests/test_json/test_pandas.py
@@ -8,6 +8,7 @@ import operator
 import os
 import unittest
 
+import nose
 import numpy as np
 
 from pandas import Series, DataFrame, DatetimeIndex, Timestamp


### PR DESCRIPTION
Nose import is missing. If you get to the error at the last line, it throws an error because nose is never imported.
