### PR TITLE
BLD: remove after_script.sh from travis since it does not exist anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,3 @@ script:
 
 after_script:
   - ci/print_versions.py
-  - ci/after_script.sh


### PR DESCRIPTION
closes #3857
