### PR TITLE
FIX: change initObjToJSON return type

### DIFF
--- a/pandas/src/ujson/python/objToJSON.c
+++ b/pandas/src/ujson/python/objToJSON.c
@@ -100,7 +100,11 @@ enum PANDAS_FORMAT
 //#define PRINTMARK() fprintf(stderr, "%s: MARK(%d)\n", __FILE__, __LINE__)
 #define PRINTMARK()
 
+#if (PY_VERSION_HEX >= 0x03000000)
 void initObjToJSON(void)
+#else
+int initObjToJSON(void)
+#endif
 {
     PyObject *mod_frame;
     PyDateTime_IMPORT;


### PR DESCRIPTION
This is necessary because clang complains about the return type. There's a
call to the macro import_array() which injects a return statement into
wherever it's used.

closes #3872.
