### PR TITLE
ENH: do not convert mixed-integer type indexes to datetimeindex

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -80,6 +80,8 @@ pandas 0.11.1
   - Added Faq section on repr display options, to help users customize their setup.
   - ``where`` operations that result in block splitting are much faster (GH3733_)
   - Series and DataFrame hist methods now take a ``figsize`` argument (GH3834_)
+  - DatetimeIndexes no longer try to convert mixed-integer indexes during join
+    operations (GH3877_)
 
 **API Changes**
 
@@ -317,6 +319,7 @@ pandas 0.11.1
 .. _GH3814: https://github.com/pydata/pandas/issues/3814
 .. _GH3834: https://github.com/pydata/pandas/issues/3834
 .. _GH3873: https://github.com/pydata/pandas/issues/3873
+.. _GH3877: https://github.com/pydata/pandas/issues/3877
 
 
 pandas 0.11.0

--- a/doc/source/v0.11.1.txt
+++ b/doc/source/v0.11.1.txt
@@ -289,6 +289,8 @@ Enhancements
        dff.groupby('B').filter(lambda x: len(x) > 2, dropna=False)
 
   - Series and DataFrame hist methods now take a ``figsize`` argument (GH3834_)
+  - DatetimeIndexes no longer try to convert mixed-integer indexes during join
+    operations (GH3877_)
 
 
 Bug Fixes
@@ -402,3 +404,4 @@ on GitHub for a complete list.
 .. _GH3425: https://github.com/pydata/pandas/issues/3425
 .. _GH3834: https://github.com/pydata/pandas/issues/3834
 .. _GH3873: https://github.com/pydata/pandas/issues/3873
+.. _GH3877: https://github.com/pydata/pandas/issues/3877

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -910,7 +910,8 @@ class DatetimeIndex(Int64Index):
         """
         See Index.join
         """
-        if not isinstance(other, DatetimeIndex) and len(other) > 0:
+        if (not isinstance(other, DatetimeIndex) and len(other) > 0 and
+            other.inferred_type != 'mixed-integer'):
             try:
                 other = DatetimeIndex(other)
             except TypeError:

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -18,7 +18,6 @@ from pandas.core.daterange import DateRange
 import pandas.core.datetools as datetools
 import pandas.tseries.offsets as offsets
 import pandas.tseries.frequencies as fmod
-from pandas.tseries.index import TimeSeriesError
 import pandas as pd
 
 from pandas.util.testing import assert_series_equal, assert_almost_equal
@@ -1853,6 +1852,14 @@ class TestDatetimeIndex(unittest.TestCase):
         expected = [t.date() for t in rng]
         self.assert_((result == expected).all())
 
+    def test_does_not_convert_mixed_integer(self):
+        df = tm.makeCustomDataframe(10, 10, data_gen_f=lambda *args, **kwargs:
+                                    randn(), r_idx_type='i', c_idx_type='dt')
+        cols = df.columns.join(df.index, how='outer')
+        joined = cols.join(df.columns)
+        self.assertEqual(cols.dtype, np.dtype('O'))
+        self.assertEqual(cols.dtype, joined.dtype)
+        self.assert_(np.array_equal(cols.values, joined.values))
 
 class TestLegacySupport(unittest.TestCase):
     _multiprocess_can_split_ = True


### PR DESCRIPTION
closes #3877.
