### PR TITLE
BUG: allow itertuples to work with frames with duplicate column names

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -223,6 +223,8 @@ pandas 0.11.1
   - ``read_html`` now correctly skips tests (GH3741_)
   - Fix incorrect arguments passed to concat that are not list-like (e.g. concat(df1,df2)) (GH3481_)
   - Correctly parse when passed the ``dtype=str`` (or other variable-len string dtypes) in ``read_csv`` (GH3795_)
+  - ``DataFrame.itertuples()`` now works with frames with duplicate column
+    names (GH3873_)
 
 .. _GH3164: https://github.com/pydata/pandas/issues/3164
 .. _GH2786: https://github.com/pydata/pandas/issues/2786
@@ -314,6 +316,7 @@ pandas 0.11.1
 .. _GH3795: https://github.com/pydata/pandas/issues/3795
 .. _GH3814: https://github.com/pydata/pandas/issues/3814
 .. _GH3834: https://github.com/pydata/pandas/issues/3834
+.. _GH3873: https://github.com/pydata/pandas/issues/3873
 
 
 pandas 0.11.0

--- a/doc/source/v0.11.1.txt
+++ b/doc/source/v0.11.1.txt
@@ -349,6 +349,8 @@ Bug Fixes
 
   - ``DataFrame.from_records`` did not accept empty recarrays (GH3682_)
   - ``read_html`` now correctly skips tests (GH3741_)
+  - ``DataFrame.itertuples()`` now works with frames with duplicate column
+    names (GH3873_)
 
 See the `full release notes
 <https://github.com/pydata/pandas/blob/master/RELEASE.rst>`__ or issue tracker
@@ -399,3 +401,4 @@ on GitHub for a complete list.
 .. _GH3726: https://github.com/pydata/pandas/issues/3726
 .. _GH3425: https://github.com/pydata/pandas/issues/3425
 .. _GH3834: https://github.com/pydata/pandas/issues/3834
+.. _GH3873: https://github.com/pydata/pandas/issues/3873

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -818,7 +818,9 @@ class DataFrame(NDFrame):
         arrays = []
         if index:
             arrays.append(self.index)
-        arrays.extend(self[k] for k in self.columns)
+
+        # use integer indexing because of possible duplicate column names
+        arrays.extend(self.iloc[:, k] for k in xrange(len(self.columns)))
         return izip(*arrays)
 
     iterkv = iteritems

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3951,6 +3951,10 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         for tup in df.itertuples(index=False):
             self.assert_(isinstance(tup[1], np.integer))
 
+        df = DataFrame(data={"a": [1, 2, 3], "b": [4, 5, 6]})
+        dfaa = df[['a', 'a']]
+        self.assertEqual(list(dfaa.itertuples()), [(0, 1, 1), (1, 2, 2), (2, 3, 3)])
+
     def test_len(self):
         self.assertEqual(len(self.frame), len(self.frame.index))
 


### PR DESCRIPTION
closes #3873.
