### PR TITLE
FIX hash of DataFrame raises Typerror

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -220,6 +220,7 @@ pandas 0.11.1
   - Groupby transform with item-by-item not upcasting correctly (GH3740_)
   - Incorrectly read a HDFStore multi-index Frame witha column specification (GH3748_)
   - ``read_html`` now correctly skips tests (GH3741_)
+  - DataFrames/Panel raise Type error when trying to hash (GH3882_)
   - Fix incorrect arguments passed to concat that are not list-like (e.g. concat(df1,df2)) (GH3481_)
   - Correctly parse when passed the ``dtype=str`` (or other variable-len string dtypes) in ``read_csv`` (GH3795_)
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -220,7 +220,7 @@ pandas 0.11.1
   - Groupby transform with item-by-item not upcasting correctly (GH3740_)
   - Incorrectly read a HDFStore multi-index Frame witha column specification (GH3748_)
   - ``read_html`` now correctly skips tests (GH3741_)
-  - DataFrames/Panel raise Type error when trying to hash (GH3882_)
+  - PandasObjects raise TypeError when trying to hash (GH3882_)
   - Fix incorrect arguments passed to concat that are not list-like (e.g. concat(df1,df2)) (GH3481_)
   - Correctly parse when passed the ``dtype=str`` (or other variable-len string dtypes) in ``read_csv`` (GH3795_)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -594,6 +594,10 @@ class NDFrame(PandasObject):
     def __repr__(self):
         return 'NDFrame'
 
+    def __hash__(self):
+        raise TypeError('{0!r} objects are mutable, thus they cannot be'
+                              ' hashed'.format(self.__class__.__name__))
+
     @property
     def values(self):
         return self._data.as_matrix()

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -31,6 +31,11 @@ class PandasObject(object):
     def load(cls, path):
         return com.load(path)
 
+    def __hash__(self):
+        raise TypeError('{0!r} objects are mutable, thus they cannot be'
+                              ' hashed'.format(self.__class__.__name__))
+
+
     #----------------------------------------------------------------------
     # Axis name business
 
@@ -593,10 +598,6 @@ class NDFrame(PandasObject):
 
     def __repr__(self):
         return 'NDFrame'
-
-    def __hash__(self):
-        raise TypeError('{0!r} objects are mutable, thus they cannot be'
-                              ' hashed'.format(self.__class__.__name__))
 
     @property
     def values(self):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -528,7 +528,8 @@ class Series(pa.Array, generic.PandasObject):
         return not is_integer_dtype(self.dtype)
 
     def __hash__(self):
-        raise TypeError('unhashable type')
+        raise TypeError('{0!r} objects are mutable, thus they cannot be'
+                              ' hashed'.format(self.__class__.__name__))
 
     _index = None
     index = lib.SeriesIndex()

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -527,10 +527,6 @@ class Series(pa.Array, generic.PandasObject):
     def _can_hold_na(self):
         return not is_integer_dtype(self.dtype)
 
-    def __hash__(self):
-        raise TypeError('{0!r} objects are mutable, thus they cannot be'
-                              ' hashed'.format(self.__class__.__name__))
-
     _index = None
     index = lib.SeriesIndex()
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3109,6 +3109,11 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         expected.sort()
         assert_series_equal(result, expected)
 
+    def test_not_hashable(self):
+        df = pd.DataFrame([1])
+        self.assertRaises(TypeError, hash, df)
+        self.assertRaises(TypeError, hash, self.empty)
+
     def test_timedeltas(self):
 
         df = DataFrame(dict(A = Series(date_range('2012-1-1', periods=3, freq='D')),

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -46,6 +46,12 @@ class PanelTests(object):
         cumsum = self.panel.cumsum()
         assert_frame_equal(cumsum['ItemA'], self.panel['ItemA'].cumsum())
 
+    def not_hashable(self):
+        c_empty = Panel()
+        c = Panel(pd.Panel([[[1]]]))
+        self.assertRaises(TypeError, hash, c_empty)
+        self.assertRaises(TypeError, hash, c)
+
 
 class SafeForLongAndSparse(object):
     _multiprocess_can_split_ = True

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -785,6 +785,11 @@ class TestPanel4d(unittest.TestCase, CheckIndexing, SafeForSparse,
             major=self.panel4d.major_axis, copy=False)
         self.assert_(result is self.panel4d)
 
+    def test_not_hashable(self):
+        p4D_empty = Panel4D()
+        self.assertRaises(TypeError, hash, p4D_empty)
+        self.assertRaises(TypeError, hash, self.panel4d)
+
     def test_reindex_like(self):
         # reindex_like
         smaller = self.panel4d.reindex(labels=self.panel4d.labels[:-1],

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -579,6 +579,12 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
     def test_array_finalize(self):
         pass
 
+    def test_not_hashable(self):
+        s_empty = Series()
+        s = Series([1])
+        self.assertRaises(TypeError, hash, s_empty)
+        self.assertRaises(TypeError, hash, s)
+
     def test_fromValue(self):
 
         nans = Series(np.NaN, index=self.ts.index)


### PR DESCRIPTION
fixes #3882

raise TypeError if trying to hash a DataFrame (or Panel etc.).
