### PR TITLE
API: (GH3888) more consistency in the to_datetime return types (given string/array of string inputs)

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -159,6 +159,7 @@ pandas 0.11.1
   - ``read_html`` now defaults to ``None`` when reading, and falls back on
     ``bs4`` + ``html5lib`` when lxml fails to parse. a list of parsers to try
     until success is also valid
+  - more consistency in the to_datetime return types (give string/array of string inputs) (GH3888_)
 
 **Bug Fixes**
 
@@ -355,6 +356,8 @@ pandas 0.11.1
 .. _GH3911: https://github.com/pydata/pandas/issues/3911
 .. _GH3912: https://github.com/pydata/pandas/issues/3912
 .. _GH3764: https://github.com/pydata/pandas/issues/3764
+.. _GH3888: https://github.com/pydata/pandas/issues/3888
+
 
 pandas 0.11.0
 =============

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1159,9 +1159,13 @@ def truncate(self, before=None, after=None, copy=True):
     -------
     truncated : type of caller
     """
-    from pandas.tseries.tools import to_datetime
-    before = to_datetime(before)
-    after = to_datetime(after)
+
+    # if we have a date index, convert to dates, otherwise
+    # treat like a slice
+    if self.index.is_all_dates:
+        from pandas.tseries.tools import to_datetime
+        before = to_datetime(before)
+        after = to_datetime(after)
 
     if before is not None and after is not None:
         if before > after:

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -846,7 +846,7 @@ class TestTimeSeries(unittest.TestCase):
 
         ### array = ['2012','20120101','20120101 12:01:01']
         array = ['20120101','20120101 12:01:01']
-        expected = to_datetime(array)
+        expected = list(to_datetime(array))
         result = map(Timestamp,array)
         tm.assert_almost_equal(result,expected)
 

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -825,12 +825,35 @@ class TestTimeSeries(unittest.TestCase):
 
         self.assertEquals(NaT.weekday(), -1)
 
-    def test_to_datetime_empty_string(self):
+    def test_to_datetime_types(self):
+
+        # empty string
         result = to_datetime('')
-        self.assert_(result == '')
+        self.assert_(result is NaT)
 
         result = to_datetime(['', ''])
         self.assert_(isnull(result).all())
+
+        # ints
+        result = Timestamp(0)
+        expected = to_datetime(0)
+        self.assert_(result == expected)
+
+        # GH 3888 (strings)
+        expected = to_datetime(['2012'])[0]
+        result = to_datetime('2012')
+        self.assert_(result == expected)
+
+        ### array = ['2012','20120101','20120101 12:01:01']
+        array = ['20120101','20120101 12:01:01']
+        expected = to_datetime(array)
+        result = map(Timestamp,array)
+        tm.assert_almost_equal(result,expected)
+
+        ### currently fails ###
+        ### result = Timestamp('2012')
+        ### expected = to_datetime('2012')
+        ### self.assert_(result == expected)
 
     def test_to_datetime_other_datetime64_units(self):
         # 5/25/2012

--- a/pandas/tseries/tools.py
+++ b/pandas/tseries/tools.py
@@ -99,16 +99,7 @@ def to_datetime(arg, errors='ignore', dayfirst=False, utc=None, box=True,
             except (ValueError, TypeError):
                 raise e
 
-    if arg is None:
-        return arg
-    elif isinstance(arg, datetime):
-        return arg
-    elif isinstance(arg, Series):
-        values = arg.values
-        if not com.is_datetime64_dtype(values):
-            values = _convert_f(values)
-        return Series(values, index=arg.index, name=arg.name)
-    elif isinstance(arg, (np.ndarray, list)):
+    def _convert_listlike(arg):        
         if isinstance(arg, list):
             arg = np.array(arg, dtype='O')
 
@@ -122,24 +113,23 @@ def to_datetime(arg, errors='ignore', dayfirst=False, utc=None, box=True,
                         return DatetimeIndex._simple_new(values, None, tz=tz)
                     except (ValueError, TypeError):
                         raise e
-            return arg
+                return arg
 
-        try:
-            return _convert_f(arg)
-        except ValueError:
-            raise
+        return _convert_f(arg)
+
+    if arg is None:
         return arg
-
-    try:
-        if not arg:
-            return arg
-        default = datetime(1, 1, 1)
-        return parse(arg, dayfirst=dayfirst, default=default)
-    except Exception:
-        if errors == 'raise':
-            raise
+    elif isinstance(arg, datetime):
         return arg
+    elif isinstance(arg, Series):
+        values = arg.values
+        if not com.is_datetime64_dtype(values):
+            values = _convert_f(values)
+        return Series(values, index=arg.index, name=arg.name)
+    elif isinstance(arg, (np.ndarray, list)):
+        return _convert_listlike(arg)
 
+    return _convert_listlike(np.array([ arg ], dtype='O'))[0]
 
 class DateParseError(ValueError):
     pass


### PR DESCRIPTION
closes #3888

resolves the following inconsistencies in the Timestamp/to_datetime interface
Things that do the same thing will now _do the same thing_!

```
In [1]: to_datetime = pd.to_datetime

In [2]: to_datetime('')
Out[2]: NaT

In [3]: to_datetime(['', ''])
Out[3]: 
<class 'pandas.tseries.index.DatetimeIndex'>
[NaT, NaT]
Length: 2, Freq: None, Timezone: None

In [4]: Timestamp(0)
Out[4]: Timestamp('1970-01-01 00:00:00', tz=None)

In [5]: to_datetime(0)
Out[5]: Timestamp('1970-01-01 00:00:00', tz=None)

In [6]: to_datetime(['2012'])[0]
Out[6]: Timestamp('2012-01-01 00:00:00', tz=None)

In [8]: to_datetime('2012')
Out[8]: Timestamp('2012-01-01 00:00:00', tz=None)

In [9]: array = ['20120101','20120101 12:01:01']

In [11]: list(to_datetime(array))
Out[11]: 
[Timestamp('2012-01-01 00:00:00', tz=None),
 Timestamp('2012-01-01 12:01:01', tz=None)]

In [13]: map(Timestamp,array)
Out[13]: 
[Timestamp('2012-01-01 00:00:00', tz=None),
 Timestamp('2012-01-01 12:01:01', tz=None)]
```

Note that the following is still inconsisten and will be fixed in a future PR

```
In [14]: Timestamp('2012')
Out[14]: Timestamp('2012-06-18 00:00:00', tz=None)

In [15]: to_datetime('2012')
Out[15]: Timestamp('2012-01-01 00:00:00', tz=None)
```
