### PR TITLE
TST: test fixes for various builds (debian)

### DIFF
--- a/pandas/io/json.py
+++ b/pandas/io/json.py
@@ -268,6 +268,15 @@ class Parser(object):
             except:
                 pass
 
+        if data.dtype == 'float':
+            
+            # coerce floats to 64
+            try:
+                data = data.astype('float64')
+                result = True
+            except:
+                pass
+
         # do't coerce 0-len data
         if len(data) and (data.dtype == 'float' or data.dtype == 'object'):
 
@@ -277,6 +286,16 @@ class Parser(object):
                 if (new_data == data).all():
                     data = new_data
                     result = True
+            except:
+                pass
+
+        # coerce ints to 64
+        if data.dtype == 'int':
+            
+            # coerce floats to 64
+            try:
+                data = data.astype('int64')
+                result = True
             except:
                 pass
 

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -808,11 +808,7 @@ class ExcelTests(unittest.TestCase):
     #         self.assertTrue(ws.cell(maddr).merged)
     #     os.remove(filename)
     def test_excel_010_hemstring(self):
-        try:
-            import xlwt
-            import openpyxl
-        except ImportError:
-            raise nose.SkipTest
+        _skip_if_no_excelsuite()
 
         from pandas.util.testing import makeCustomDataframe as mkdf
         # ensure limited functionality in 0.10

--- a/pandas/io/tests/test_json/test_pandas.py
+++ b/pandas/io/tests/test_json/test_pandas.py
@@ -26,7 +26,7 @@ _tsd = tm.getTimeSeriesData()
 
 _frame = DataFrame(_seriesd)
 _frame2 = DataFrame(_seriesd, columns=['D', 'C', 'B', 'A'])
-_intframe = DataFrame(dict((k, v.astype(int))
+_intframe = DataFrame(dict((k, v.astype(np.int64))
                            for k, v in _seriesd.iteritems()))
 
 _tsframe = DataFrame(_tsd)
@@ -70,6 +70,9 @@ class TestPandasObjects(unittest.TestCase):
                     raise
                     
             unser = unser.sort()
+
+            if dtype is False:
+                check_dtype=False
 
             if not convert_axes and df.index.dtype.type == np.datetime64:
                 unser.index = DatetimeIndex(unser.index.values.astype('i8'))
@@ -288,7 +291,7 @@ class TestPandasObjects(unittest.TestCase):
 
     def test_typ(self):
 
-        s = Series(range(6), index=['a','b','c','d','e','f'])
+        s = Series(range(6), index=['a','b','c','d','e','f'], dtype='int64')
         result = read_json(s.to_json(),typ=None)
         assert_series_equal(result,s)
 

--- a/pandas/io/tests/test_pickle.py
+++ b/pandas/io/tests/test_pickle.py
@@ -8,7 +8,6 @@ import pickle
 import unittest
 import nose
 import os
-import sys
 
 import numpy as np
 import pandas.util.testing as tm
@@ -16,9 +15,8 @@ import pandas as pd
 from pandas import Index
 from pandas.sparse.tests import test_sparse
 from pandas.util import py3compat
-
-if sys.byteorder != 'little':
-    raise nose.SkipTest('system byteorder is not little!')
+from pandas.util.decorators import knownfailureif
+from pandas.util.misc import is_little_endian
 
 class TestPickle(unittest.TestCase):
     _multiprocess_can_split_ = True
@@ -60,6 +58,7 @@ class TestPickle(unittest.TestCase):
                     comparator = getattr(tm,"assert_%s_equal" % typ)
                     comparator(result,expected)
 
+    @knownfailureif(not is_little_endian(), "known failure of test_read_pickles_0_10_1 on non-little endian")
     def test_read_pickles_0_10_1(self):
 
         pth = tm.get_data_path('legacy_pickle/0.10.1')
@@ -67,6 +66,7 @@ class TestPickle(unittest.TestCase):
             vf = os.path.join(pth,f)
             self.compare(vf)
 
+    @knownfailureif(not is_little_endian(), "known failure of test_read_pickles_0_11_0 on non-little endian")
     def test_read_pickles_0_11_0(self):
 
         pth = tm.get_data_path('legacy_pickle/0.11.0')

--- a/pandas/io/tests/test_pickle.py
+++ b/pandas/io/tests/test_pickle.py
@@ -8,6 +8,7 @@ import pickle
 import unittest
 import nose
 import os
+import sys
 
 import numpy as np
 import pandas.util.testing as tm
@@ -15,6 +16,9 @@ import pandas as pd
 from pandas import Index
 from pandas.sparse.tests import test_sparse
 from pandas.util import py3compat
+
+if sys.byteorder != 'little':
+    raise nose.SkipTest('system byteorder is not little!')
 
 class TestPickle(unittest.TestCase):
     _multiprocess_can_split_ = True

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -477,6 +477,9 @@ class TestHDFStore(unittest.TestCase):
 
     def test_encoding(self):
         
+        if sys.byteorder != 'little':
+            raise nose.SkipTest('system byteorder is not little, skipping test_encoding!')
+
         with ensure_clean(self.path) as store:
             df = DataFrame(dict(A='foo',B='bar'),index=range(5))
             df.loc[2,'A'] = np.nan

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -14,10 +14,8 @@ from pandas.io.parsers import read_csv
 from pandas.io.stata import read_stata, StataReader, StataWriter
 import pandas.util.testing as tm
 from pandas.util.testing import ensure_clean
-
-def _skip_if_not_little(name):
-    if sys.byteorder != 'little':
-        raise nose.SkipTest('system byteorder is not little, skipping %s' % name)
+from pandas.util.decorators import knownfailureif
+from pandas.util.misc import is_little_endian
 
 class StataTests(unittest.TestCase):
 
@@ -131,8 +129,8 @@ class StataTests(unittest.TestCase):
 
         tm.assert_frame_equal(parsed, expected)
 
+    @knownfailureif(not is_little_endian(), "known failure of test_write_dta5 on non-little endian")
     def test_write_dta5(self):
-        _skip_if_not_little('write_dta5')
         original = DataFrame([(np.nan, np.nan, np.nan, np.nan, np.nan)],
                              columns=['float_miss', 'double_miss', 'byte_miss', 'int_miss', 'long_miss'])
         original.index.name = 'index'
@@ -142,8 +140,8 @@ class StataTests(unittest.TestCase):
             written_and_read_again = self.read_dta(path)
             tm.assert_frame_equal(written_and_read_again.set_index('index'), original)
 
+    @knownfailureif(not is_little_endian(), "known failure of test_write_dta6 on non-little endian")
     def test_write_dta6(self):
-        _skip_if_not_little('write_dta6')
         original = self.read_csv(self.csv3)
         original.index.name = 'index'
 

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 import os
 import unittest
-
+import sys
 import warnings
 import nose
 
@@ -14,6 +14,10 @@ from pandas.io.parsers import read_csv
 from pandas.io.stata import read_stata, StataReader, StataWriter
 import pandas.util.testing as tm
 from pandas.util.testing import ensure_clean
+
+def _skip_if_not_little(name):
+    if sys.byteorder != 'little':
+        raise nose.SkipTest('system byteorder is not little, skipping %s' % name)
 
 class StataTests(unittest.TestCase):
 
@@ -128,6 +132,7 @@ class StataTests(unittest.TestCase):
         tm.assert_frame_equal(parsed, expected)
 
     def test_write_dta5(self):
+        _skip_if_not_little('write_dta5')
         original = DataFrame([(np.nan, np.nan, np.nan, np.nan, np.nan)],
                              columns=['float_miss', 'double_miss', 'byte_miss', 'int_miss', 'long_miss'])
         original.index.name = 'index'
@@ -138,6 +143,7 @@ class StataTests(unittest.TestCase):
             tm.assert_frame_equal(written_and_read_again.set_index('index'), original)
 
     def test_write_dta6(self):
+        _skip_if_not_little('write_dta6')
         original = self.read_csv(self.csv3)
         original.index.name = 'index'
 

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1381,7 +1381,11 @@ class TestPanel(unittest.TestCase, PanelTests, CheckIndexing,
             path = '__tmp__.' + ext
             with ensure_clean(path) as path:
                 self.panel.to_excel(path)
-                reader = ExcelFile(path)
+                try:
+                    reader = ExcelFile(path)
+                except ImportError:
+                    raise nose.SkipTest
+                
                 for item, df in self.panel.iterkv():
                     recdf = reader.parse(str(item), index_col=0)
                     assert_frame_equal(df, recdf)

--- a/pandas/util/misc.py
+++ b/pandas/util/misc.py
@@ -1,3 +1,10 @@
+""" various miscellaneous utilities """
+
+def is_little_endian():
+    """ am I little endian """
+    import sys
+    return sys.byteorder == 'little'
+
 def exclusive(*args):
     count = sum([arg is not None for arg in args])
     return count == 1


### PR DESCRIPTION
TST: json tests to int64 to avoid dtype issues, closes #3895
TST: skip tests if xlrd has lower than needed version, closes #3897
TST: skip pickle tests on not-little endianess , closes #3894
TST: skip test_encoding on non-little endian in test_pytables , closes #3892
TST: skip some stata tests on non-little endian, closes #3896
