### PR TITLE
BUG: fix unicode -> str cast in tslib

### DIFF
--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -465,7 +465,8 @@ cdef class _Timestamp(datetime):
             elif op == 3:
                 return True
             else:
-                raise TypeError('Cannot compare Timestamp with %s' % str(other))
+                raise TypeError('Cannot compare Timestamp with '
+                                '{0!r}'.format(other.__class__.__name__))
 
         self._assert_tzawareness_compat(other)
 


### PR DESCRIPTION
This should use format since calling str on a unicode string is a _bad_ idea 
because it may or may not repr correctly.

closes #3875.

another error is created from fixing this issue.
