### PR TITLE
BLD: add setup_requires in setup.py so pandas can be used with buildout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,9 @@ except ImportError:
     _have_setuptools = False
 
 setuptools_kwargs = {}
+min_numpy_ver = '1.6'
 if sys.version_info[0] >= 3:
 
-    min_numpy_ver = 1.6
     if sys.version_info[1] >= 3:  # 3.3 needs numpy 1.7+
         min_numpy_ver = "1.7.0b2"
 
@@ -45,6 +45,7 @@ if sys.version_info[0] >= 3:
                          'install_requires': ['python-dateutil >= 2',
                                               'pytz',
                                               'numpy >= %s' % min_numpy_ver],
+                         'setup_requires': ['numpy >= %s' % min_numpy_ver],
                          'use_2to3_exclude_fixers': ['lib2to3.fixes.fix_next',
                                                      ],
                          }
@@ -53,10 +54,12 @@ if sys.version_info[0] >= 3:
                  "\n$ pip install distribute")
 
 else:
+    min_numpy_ver = '1.6.1'
     setuptools_kwargs = {
         'install_requires': ['python-dateutil',
                              'pytz',
-                             'numpy >= 1.6.1'],
+                             'numpy >= %s' % min_numpy_ver],
+        'setup_requires': ['numpy >= %s' % min_numpy_ver],
         'zip_safe': False,
     }
 


### PR DESCRIPTION
Numpy is a setup-time dependency due to some .h files, but is not declared as such. This causes tools like buildout ( http://buildout.org/ ) to fail.

Adding the `setup_requires` kwarg to the setuptools config shoud fix this: buildout will correctly assemble any declared setup-time dependencies, before executing the pandas build.

closes #3861
