### PR TITLE
TST: Move explicit connectivity checks to decorator.

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -91,6 +91,11 @@ pandas 0.11.1
     integers or floats that are in an epoch unit of ``D, s, ms, us, ns``, thanks @mtkini (:issue:`3969`)
     (e.g. unix timestamps or epoch ``s``, with fracional seconds allowed) (:issue:`3540`)
   - DataFrame corr method (spearman) is now cythonized.
+  - Improved ``network`` test decorator to catch ``IOError`` (and therefore
+    ``URLError`` as well). Added ``with_connectivity_check`` decorator to allow
+    explicitly checking a website as a proxy for seeing if there is network
+    connectivity. Plus, new ``optional_args`` decorator factory for decorators.
+    (:issue:`3910`, :issue:`3914`)
 
 **API Changes**
 

--- a/doc/source/v0.11.1.txt
+++ b/doc/source/v0.11.1.txt
@@ -386,6 +386,11 @@ Bug Fixes
   - ``read_html`` now correctly skips tests (:issue:`3741`)
   - Fixed a bug where ``DataFrame.replace`` with a compiled regular expression
     in the ``to_replace`` argument wasn't working (:issue:`3907`)
+  - Improved ``network`` test decorator to catch ``IOError`` (and therefore
+    ``URLError`` as well). Added ``with_connectivity_check`` decorator to allow
+    explicitly checking a website as a proxy for seeing if there is network
+    connectivity. Plus, new ``optional_args`` decorator factory for decorators.
+    (:issue:`3910`, :issue:`3914`)
 
 See the :ref:`full release notes
 <release>` or issue tracker

--- a/pandas/io/tests/test_fred.py
+++ b/pandas/io/tests/test_fred.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pandas.io.data as web
 from pandas.util.testing import (network, assert_frame_equal,
                                  assert_series_equal,
-                                 assert_almost_equal)
+                                 assert_almost_equal, with_connectivity_check)
 from numpy.testing.decorators import slow
 
 import urllib2
@@ -17,7 +17,7 @@ import urllib2
 class TestFred(unittest.TestCase):
 
     @slow
-    @network
+    @with_connectivity_check("http://www.google.com")
     def test_fred(self):
         """
         Throws an exception when DataReader can't get a 200 response from

--- a/pandas/io/tests/test_fred.py
+++ b/pandas/io/tests/test_fred.py
@@ -26,22 +26,14 @@ class TestFred(unittest.TestCase):
         start = datetime(2010, 1, 1)
         end = datetime(2013, 01, 27)
 
-        try:
-            self.assertEquals(
-                web.DataReader("GDP", "fred", start, end)['GDP'].tail(1),
-                16004.5)
+        self.assertEquals(
+            web.DataReader("GDP", "fred", start, end)['GDP'].tail(1),
+            16004.5)
 
-            self.assertRaises(
-                Exception,
-                lambda: web.DataReader("NON EXISTENT SERIES", 'fred',
-                                       start, end))
-        except urllib2.URLError:
-            try:
-                urllib2.urlopen('http://google.com')
-            except urllib2.URLError:
-                raise nose.SkipTest
-            else:
-                raise
+        self.assertRaises(
+            Exception,
+            lambda: web.DataReader("NON EXISTENT SERIES", 'fred',
+                                   start, end))
 
     @slow
     @network

--- a/pandas/io/tests/test_ga.py
+++ b/pandas/io/tests/test_ga.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import nose
 import pandas as pd
 from pandas import DataFrame
-from pandas.util.testing import network, assert_frame_equal
+from pandas.util.testing import network, assert_frame_equal, with_connectivity_check
 from numpy.testing.decorators import slow
 
 try:
@@ -71,7 +71,7 @@ class TestGoogle(unittest.TestCase):
             raise nose.SkipTest
 
     @slow
-    @network
+    @with_connectivity_check("http://www.google.com")
     def test_iterator(self):
         try:
             reader = GAnalytics()
@@ -97,16 +97,9 @@ class TestGoogle(unittest.TestCase):
 
         except AuthenticationConfigError:
             raise nose.SkipTest
-        except httplib2.ServerNotFoundError:
-            try:
-                h = httplib2.Http()
-                response, content = h.request("http://www.google.com")
-                raise
-            except httplib2.ServerNotFoundError:
-                raise nose.SkipTest
 
     @slow
-    @network
+    @with_connectivity_check("http://www.google.com")
     def test_segment(self):
         try:
             end_date = datetime.now()

--- a/pandas/io/tests/test_ga.py
+++ b/pandas/io/tests/test_ga.py
@@ -1,26 +1,26 @@
+import os
 import unittest
-import nose
 from datetime import datetime
 
+import nose
 import pandas as pd
-import pandas.core.common as com
 from pandas import DataFrame
 from pandas.util.testing import network, assert_frame_equal
 from numpy.testing.decorators import slow
 
+try:
+    import httplib2
+    from pandas.io.ga import GAnalytics, read_ga
+    from pandas.io.auth import AuthenticationConfigError, reset_token_store
+    from pandas.io import auth
+except ImportError:
+    raise nose.SkipTest
 
 class TestGoogle(unittest.TestCase):
 
     _multiprocess_can_split_ = True
 
     def test_remove_token_store(self):
-        import os
-        try:
-            import pandas.io.auth as auth
-            from pandas.io.ga import reset_token_store
-        except ImportError:
-            raise nose.SkipTest
-
         auth.DEFAULT_TOKEN_FILE = 'test.dat'
         with open(auth.DEFAULT_TOKEN_FILE, 'w') as fh:
             fh.write('test')
@@ -31,13 +31,6 @@ class TestGoogle(unittest.TestCase):
     @slow
     @network
     def test_getdata(self):
-        try:
-            import httplib2
-            from pandas.io.ga import GAnalytics, read_ga
-            from pandas.io.auth import AuthenticationConfigError
-        except ImportError:
-            raise nose.SkipTest
-
         try:
             end_date = datetime.now()
             start_date = end_date - pd.offsets.Day() * 5
@@ -76,24 +69,10 @@ class TestGoogle(unittest.TestCase):
 
         except AuthenticationConfigError:
             raise nose.SkipTest
-        except httplib2.ServerNotFoundError:
-            try:
-                h = httplib2.Http()
-                response, content = h.request("http://www.google.com")
-                raise
-            except httplib2.ServerNotFoundError:
-                raise nose.SkipTest
 
     @slow
     @network
     def test_iterator(self):
-        try:
-            import httplib2
-            from pandas.io.ga import GAnalytics, read_ga
-            from pandas.io.auth import AuthenticationConfigError
-        except ImportError:
-            raise nose.SkipTest
-
         try:
             reader = GAnalytics()
 
@@ -129,13 +108,6 @@ class TestGoogle(unittest.TestCase):
     @slow
     @network
     def test_segment(self):
-        try:
-            import httplib2
-            from pandas.io.ga import GAnalytics, read_ga
-            from pandas.io.auth import AuthenticationConfigError
-        except ImportError:
-            raise nose.SkipTest
-
         try:
             end_date = datetime.now()
             start_date = end_date - pd.offsets.Day() * 5
@@ -186,16 +158,7 @@ class TestGoogle(unittest.TestCase):
 
         except AuthenticationConfigError:
             raise nose.SkipTest
-        except httplib2.ServerNotFoundError:
-            try:
-                h = httplib2.Http()
-                response, content = h.request("http://www.google.com")
-                raise
-            except httplib2.ServerNotFoundError:
-                raise nose.SkipTest
-
 
 if __name__ == '__main__':
-    import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
                    exit=False)

--- a/pandas/io/tests/test_google.py
+++ b/pandas/io/tests/test_google.py
@@ -2,18 +2,15 @@ import unittest
 import nose
 from datetime import datetime
 
+import numpy as np
 import pandas as pd
 import pandas.io.data as web
-from pandas.util.testing import (network, assert_series_equal)
-from numpy.testing.decorators import slow
-import numpy as np
-
-import urllib2
+from pandas.util.testing import network, with_connectivity_check
 
 
 class TestGoogle(unittest.TestCase):
 
-    @with_connectivity_check('http://www.google.com')
+    @with_connectivity_check("http://www.google.com")
     def test_google(self):
         # asserts that google is minimally working and that it throws
         # an exception when DataReader can't get a 200 response from

--- a/pandas/io/tests/test_google.py
+++ b/pandas/io/tests/test_google.py
@@ -13,46 +13,22 @@ import urllib2
 
 class TestGoogle(unittest.TestCase):
 
-    @network
+    @with_connectivity_check('http://www.google.com')
     def test_google(self):
         # asserts that google is minimally working and that it throws
-        # an excecption when DataReader can't get a 200 response from
+        # an exception when DataReader can't get a 200 response from
         # google
         start = datetime(2010, 1, 1)
         end = datetime(2013, 01, 27)
 
-        try:
-            self.assertEquals(
-                web.DataReader("F", 'google', start, end)['Close'][-1],
-                13.68)
-        except urllib2.URLError:
-            try:
-                urllib2.urlopen('http://www.google.com')
-            except urllib2.URLError:
-                raise nose.SkipTest
-            else:
-                raise
+        self.assertEquals(
+            web.DataReader("F", 'google', start, end)['Close'][-1],
+            13.68)
 
-    @network
-    def test_google_non_existent(self):
-        # asserts that google is minimally working and that it throws
-        # an excecption when DataReader can't get a 200 response from
-        # google
-        start = datetime(2010, 1, 1)
-        end = datetime(2013, 01, 27)
-
-        try:
-            self.assertRaises(
-                Exception,
-                lambda: web.DataReader("NON EXISTENT TICKER", 'google',
-                                      start, end))
-        except urllib2.URLError:
-            try:
-                urllib2.urlopen('http://www.google.com')
-            except urllib2.URLError:
-                raise nose.SkipTest
-            else:
-                raise
+        self.assertRaises(
+            Exception,
+            lambda: web.DataReader("NON EXISTENT TICKER", 'google',
+                                start, end))
 
 
     @network
@@ -60,64 +36,40 @@ class TestGoogle(unittest.TestCase):
         self.assertRaises(NotImplementedError,
                 lambda: web.get_quote_google(pd.Series(['GOOG', 'AAPL', 'GOOG'])))
 
-    @network
+    @with_connectivity_check('http://www.google.com')
     def test_get_goog_volume(self):
-        try:
-            df = web.get_data_google('GOOG')
-            assert df.Volume.ix['OCT-08-2010'] == 2863473
-        except IOError:
-            try:
-                urllib2.urlopen('http://www.google.com')
-            except IOError:
-                raise nose.SkipTest
-            else:
-                raise
+        df = web.get_data_google('GOOG')
+        assert df.Volume.ix['OCT-08-2010'] == 2863473
 
-    @network
+    @with_connectivity_check('http://www.google.com')
     def test_get_multi1(self):
-        try:
-            sl = ['AAPL', 'AMZN', 'GOOG']
-            pan = web.get_data_google(sl, '2012')
-            ts = pan.Close.GOOG.index[pan.Close.AAPL > pan.Close.GOOG]
-            assert ts[0].dayofyear == 96
-        except IOError:
-            try:
-                urllib2.urlopen('http://www.google.com')
-            except IOError:
-                raise nose.SkipTest
-            else:
-                raise
+        sl = ['AAPL', 'AMZN', 'GOOG']
+        pan = web.get_data_google(sl, '2012')
+        ts = pan.Close.GOOG.index[pan.Close.AAPL > pan.Close.GOOG]
+        assert ts[0].dayofyear == 96
 
-    @network
+    @with_connectivity_check('http://www.google.com')
     def test_get_multi2(self):
-        try:
-            pan = web.get_data_google(['GE', 'MSFT', 'INTC'], 'JAN-01-12', 'JAN-31-12')
-            expected = [19.02, 28.23, 25.39]
-            result = pan.Close.ix['01-18-12'][['GE', 'MSFT', 'INTC']].tolist()
-            assert result == expected
+        pan = web.get_data_google(['GE', 'MSFT', 'INTC'], 'JAN-01-12', 'JAN-31-12')
+        expected = [19.02, 28.23, 25.39]
+        result = pan.Close.ix['01-18-12'][['GE', 'MSFT', 'INTC']].tolist()
+        assert result == expected
 
-            # sanity checking
-            t= np.array(result)
-            assert     np.issubdtype(t.dtype, np.floating)
-            assert     t.shape == (3,)
+        # sanity checking
+        t= np.array(result)
+        assert     np.issubdtype(t.dtype, np.floating)
+        assert     t.shape == (3,)
 
-            expected = [[ 18.99,  28.4 ,  25.18],
-                        [ 18.58,  28.31,  25.13],
-                        [ 19.03,  28.16,  25.52],
-                        [ 18.81,  28.82,  25.87]]
-            result = pan.Open.ix['Jan-15-12':'Jan-20-12'][['GE', 'MSFT', 'INTC']].values
-            assert (result == expected).all()
+        expected = [[ 18.99,  28.4 ,  25.18],
+                    [ 18.58,  28.31,  25.13],
+                    [ 19.03,  28.16,  25.52],
+                    [ 18.81,  28.82,  25.87]]
+        result = pan.Open.ix['Jan-15-12':'Jan-20-12'][['GE', 'MSFT', 'INTC']].values
+        assert (result == expected).all()
 
-            # sanity checking
-            t= np.array(pan)
-            assert     np.issubdtype(t.dtype, np.floating)
-        except IOError:
-            try:
-                urllib2.urlopen('http://www.google.com')
-            except IOError:
-                raise nose.SkipTest
-            else:
-                raise
+        # sanity checking
+        t= np.array(pan)
+        assert np.issubdtype(t.dtype, np.floating)
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/pandas/io/tests/test_yahoo.py
+++ b/pandas/io/tests/test_yahoo.py
@@ -4,15 +4,15 @@ from datetime import datetime
 
 import pandas as pd
 import pandas.io.data as web
-from pandas.util.testing import network, assert_series_equal
+from pandas.util.testing import network, assert_series_equal, with_connectivity_check
 
 
 class TestYahoo(unittest.TestCase):
 
-    @network
+    @with_connectivity_check("http://www.google.com")
     def test_yahoo(self):
         # asserts that yahoo is minimally working and that it throws
-        # an excecption when DataReader can't get a 200 response from
+        # an exception when DataReader can't get a 200 response from
         # yahoo
         start = datetime(2010, 1, 1)
         end = datetime(2013, 01, 27)

--- a/pandas/io/tests/test_yahoo.py
+++ b/pandas/io/tests/test_yahoo.py
@@ -4,12 +4,7 @@ from datetime import datetime
 
 import pandas as pd
 import pandas.io.data as web
-from pandas.util.testing import (network, assert_frame_equal,
-                                 assert_series_equal,
-                                 assert_almost_equal)
-from numpy.testing.decorators import slow
-
-import urllib2
+from pandas.util.testing import network, assert_series_equal
 
 
 class TestYahoo(unittest.TestCase):
@@ -22,23 +17,14 @@ class TestYahoo(unittest.TestCase):
         start = datetime(2010, 1, 1)
         end = datetime(2013, 01, 27)
 
-        try:
-            self.assertEquals(
-                web.DataReader("F", 'yahoo', start, end)['Close'][-1],
-                13.68)
+        self.assertEquals(
+            web.DataReader("F", 'yahoo', start, end)['Close'][-1],
+            13.68)
 
-            self.assertRaises(
-                Exception,
-                lambda: web.DataReader("NON EXISTENT TICKER", 'yahoo',
+        self.assertRaises(
+            Exception,
+            lambda: web.DataReader("NON EXISTENT TICKER", 'yahoo',
                                       start, end))
-        except urllib2.URLError:
-            try:
-                urllib2.urlopen('http://www.google.com')
-            except urllib2.URLError:
-                raise nose.SkipTest
-            else:
-                raise
-
 
     @network
     def test_get_quote(self):

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -41,6 +41,7 @@ N = 30
 K = 4
 _RAISE_NETWORK_ERROR_DEFAULT = False
 
+
 def rands(n):
     choices = string.ascii_letters + string.digits
     return ''.join(random.choice(choices) for _ in xrange(n))
@@ -675,10 +676,12 @@ def optional_args(decorator):
         def function(): pass
 
     Calls decorator with decorator(f, *args, **kwargs)"""
+
     @wraps(decorator)
     def wrapper(*args, **kwargs):
         def dec(f):
             return decorator(f, *args, **kwargs)
+
         is_decorating = not kwargs and len(args) == 1 and callable(args[0])
         if is_decorating:
             f = args[0]
@@ -686,11 +689,13 @@ def optional_args(decorator):
             return dec(f)
         else:
             return dec
+
     return wrapper
+
 
 @optional_args
 def network(t, raise_on_error=_RAISE_NETWORK_ERROR_DEFAULT,
-        error_classes=(IOError,)):
+            error_classes=(IOError,)):
     """
     Label a test as requiring network connection and skip test if it encounters a ``URLError``.
 
@@ -751,6 +756,7 @@ def network(t, raise_on_error=_RAISE_NETWORK_ERROR_DEFAULT,
     ``pandas/util/testing.py`` sets the default behavior (currently False).
     """
     t.network = True
+
     @wraps(t)
     def network_wrapper(*args, **kwargs):
         if raise_on_error:
@@ -760,7 +766,97 @@ def network(t, raise_on_error=_RAISE_NETWORK_ERROR_DEFAULT,
                 return t(*args, **kwargs)
             except error_classes as e:
                 raise nose.SkipTest("Skipping test %s" % e)
+
     return network_wrapper
+
+
+def can_connect(url):
+    """tries to connect to the given url. True if succeeds, False if IOError raised"""
+    try:
+        urllib2.urlopen(url)
+    except IOError:
+        return False
+    else:
+        return True
+
+
+@optional_args
+def with_connectivity_check(t, url="http://www.google.com",
+                            raise_on_error=_RAISE_NETWORK_ERROR_DEFAULT, check_before_test=False,
+                            error_classes=IOError):
+    """
+    Label a test as requiring network connection and, if an error is
+    encountered, only raise if it does not find a network connection.
+
+    In comparison to ``network``, this assumes an added contract to your test:
+    you must assert that, under normal conditions, your test will ONLY fail if
+    it does not have network connectivity.
+
+    You can call this in 3 ways: as a standard decorator, with keyword
+    arguments, or with a positional argument that is the url to check.
+
+    Parameters
+    ----------
+    t : callable
+        The test requiring network connectivity.
+    url : path
+        The url to test via ``urllib2.urlopen`` to check for connectivity.
+        Defaults to 'http://www.google.com'.
+    raise_on_error : bool
+        If True, never catches errors.
+    check_before_test : bool
+        If True, checks connectivity before running the test case.
+    error_classes : tuple or Exception
+        error classes to ignore. If not in ``error_classes``, raises the error.
+        defaults to IOError. Be careful about changing the error classes here.
+
+    NOTE: ``raise_on_error`` supercedes ``check_before_test``
+    Returns
+    -------
+    t : callable
+        The decorated test ``t``, with checks for connectivity errors.
+
+    Example
+    -------
+
+    In this example, you see how it will raise the error if it can connect to
+    the url::
+        >>> @with_connectivity_check("http://www.yahoo.com")
+        ... def test_something_with_yahoo():
+        ...    raise IOError("Failure Message")
+        >>> test_something_with_yahoo()
+        Traceback (most recent call last):
+            ...
+        IOError: Failure Message
+
+    I you set check_before_test, it will check the url first and not run the test on failure::
+        >>> @with_connectivity_check("failing://url.blaher", check_before_test=True)
+        ... def test_something():
+        ...     print("I ran!")
+        ...     raise ValueError("Failure")
+        >>> test_something()
+        Traceback (most recent call last):
+            ...
+        SkipTest
+    """
+    t.network = True
+
+    @wraps(t)
+    def wrapper(*args, **kwargs):
+        if check_before_test and not raise_on_error:
+            if not can_connect(url):
+                raise nose.SkipTest
+        try:
+            return t(*args, **kwargs)
+        except error_classes as e:
+            if raise_on_error or can_connect(url):
+                raise
+            else:
+                raise nose.SkipTest("Skipping test due to lack of connectivity"
+                                    " and error %s" % e)
+
+    return wrapper
+
 
 class SimpleMock(object):
     """
@@ -806,10 +902,12 @@ def stdin_encoding(encoding=None):
 
     """
     import sys
+
     _stdin = sys.stdin
     sys.stdin = SimpleMock(sys.stdin, "encoding", encoding)
     yield
     sys.stdin = _stdin
+
 
 def assertRaisesRegexp(exception, regexp, callable, *args, **kwargs):
     """ Port of assertRaisesRegexp from unittest in Python 2.7 - used in with statement.
@@ -842,6 +940,7 @@ def assertRaisesRegexp(exception, regexp, callable, *args, **kwargs):
     """
 
     import re
+
     try:
         callable(*args, **kwargs)
     except Exception as e:
@@ -855,7 +954,7 @@ def assertRaisesRegexp(exception, regexp, callable, *args, **kwargs):
             expected_regexp = re.compile(regexp)
         if not expected_regexp.search(str(e)):
             raise AssertionError('"%s" does not match "%s"' %
-                     (expected_regexp.pattern, str(e)))
+                                 (expected_regexp.pattern, str(e)))
     else:
         # Apparently some exceptions don't have a __name__ attribute? Just aping unittest library here
         name = getattr(exception, "__name__", str(exception))


### PR DESCRIPTION
Instead, `network` decorator in pandas.util.testing catches `IOError` instead.
You have to opt into failing on tests by setting
`pandas.util.testing._RAISE_NETWORK_ERROR_DEFAULT` to `True`.

Also adds a `with_network_connectivity_check` that can automatically check for a connection.

Fixes #3910.

This version of the fix ignores all IOErrors and assumes there are connectivity problems
with any URLError.
