### PR TITLE
BUG: Add import for 'is_datetime64_dtype'

### DIFF
--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -13,7 +13,7 @@ from pandas.util.decorators import cache_readonly, Appender
 from pandas.util.compat import OrderedDict
 import pandas.core.algorithms as algos
 import pandas.core.common as com
-from pandas.core.common import _possibly_downcast_to_dtype, notnull
+from pandas.core.common import _possibly_downcast_to_dtype, notnull, is_datetime64_dtype
 
 import pandas.lib as lib
 import pandas.algos as _algos


### PR DESCRIPTION
This import was missing from `core/groupby.py`. This also suggests that there is an issue with the test cases, given that no test triggers this issue (suggesting that there is no current test that triggers the `elif` condition below).

``` python
    def _try_cast(self, result, obj):
        """ try to cast the result to our obj original type,
        we may have roundtripped thru object in the mean-time """
        try:
            if obj.ndim > 1:
                dtype = obj.values.dtype
            else:
                dtype = obj.dtype

            if _is_numeric_dtype(dtype):

                # need to respect a non-number here (e.g. Decimal)
                if len(result) and issubclass(type(result[0]),(np.number,float,int)):
                    result = _possibly_downcast_to_dtype(result, dtype)

            elif issubclass(dtype.type, np.datetime64):
                if is_datetime64_dtype(obj.dtype):
                    result = result.astype(obj.dtype)
```
