### PR TITLE
CLN: Remove unused Exceptions

### DIFF
--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -90,10 +90,6 @@ def panel_index(time, panels, names=['time', 'panel']):
     return MultiIndex(levels, labels, sortorder=None, names=names)
 
 
-class PanelError(Exception):
-    pass
-
-
 def _arith_method(func, name):
     # work only for scalars
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -24,10 +24,6 @@ import pandas.tslib as tslib
 import pandas.parser as _parser
 from pandas.tseries.period import Period
 
-
-class DateConversionError(Exception):
-    pass
-
 _parser_params = """Also supports optionally iterating or breaking of the file
 into chunks.
 
@@ -1752,10 +1748,7 @@ def _try_convert_dates(parser, colspec, data_dict, columns):
     new_name = '_'.join([str(x) for x in colnames])
     to_parse = [data_dict[c] for c in colnames if c in data_dict]
 
-    try:
-        new_col = parser(*to_parse)
-    except DateConversionError:
-        new_col = parser(_concat_date_cols(to_parse))
+    new_col = parser(*to_parse)
     return new_name, new_col, colnames
 
 

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -87,10 +87,6 @@ def _ensure_datetime64(other):
     raise TypeError('%s type object %s' % (type(other), str(other)))
 
 
-class TimeSeriesError(Exception):
-    pass
-
-
 _midnight = time(0, 0)
 
 class DatetimeIndex(Int64Index):


### PR DESCRIPTION
There are at least 3 `Exception`s that are _never_ raised anywhere, so they can be removed without issue. (There are other exceptions that probably should be removed or refactored, but this is just a basic commit to make sure that these don't get used going forward.)

CLN: Remove 'DateConversionError' that is never raised anywhere

CLN: Remove TimeSeriesError that was never used

CLN: Remove unused 'PanelError'
