### PR TITLE
BUG: (GH3925) partial string selection with seconds resolution

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -254,6 +254,7 @@ pandas 0.11.1
     in the ``to_replace`` argument wasn't working (GH3907_)
   - Fixed ``__truediv__`` in Python 2.7 with ``numexpr`` installed to actually do true division when dividing
     two integer arrays with at least 10000 cells total (GH3764_)
+  - Indexing with a string with seconds resolution not selecting from a time index (GH3925_)
 
 .. _GH3164: https://github.com/pydata/pandas/issues/3164
 .. _GH2786: https://github.com/pydata/pandas/issues/2786
@@ -355,9 +356,13 @@ pandas 0.11.1
 .. _GH3907: https://github.com/pydata/pandas/issues/3907
 .. _GH3911: https://github.com/pydata/pandas/issues/3911
 .. _GH3912: https://github.com/pydata/pandas/issues/3912
+<<<<<<< HEAD
 .. _GH3764: https://github.com/pydata/pandas/issues/3764
 .. _GH3888: https://github.com/pydata/pandas/issues/3888
 
+=======
+.. _GH3925: https://github.com/pydata/pandas/issues/3925
+>>>>>>> BUG: (GH3925) Indexing with a string with seconds resolution not selecting from a time index
 
 pandas 0.11.0
 =============

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1,5 +1,6 @@
 # pylint: disable=W0223
 
+from datetime import datetime
 from pandas.core.common import _asarray_tuplesafe
 from pandas.core.index import Index, MultiIndex, _ensure_index
 import pandas.core.common as com

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -251,6 +251,15 @@ class TestTimeSeriesDuplicates(unittest.TestCase):
         expected = ts['2013']
         assert_series_equal(expected,ts)
 
+        # GH 3925, indexing with a seconds resolution string / datetime object
+        df = DataFrame(randn(5,5),columns=['open','high','low','close','volume'],index=date_range('2012-01-02 18:01:00',periods=5,tz='US/Central',freq='s'))
+        expected = df.loc[[df.index[2]]]
+        result = df['2012-01-02 18:01:02']
+        self.assert_(result == expected)
+
+        # this is a single date, so will raise
+        self.assertRaises(KeyError, df.__getitem__, df.index[2],)
+
 def assert_range_equal(left, right):
     assert(left.equals(right))
     assert(left.freq == right.freq)


### PR DESCRIPTION
this no longer has much to do with #3925, and is only fixing a bug

Minor revision to select on second frequency

```
In [11]: df = DataFrame(randn(5,5),columns=['open','high','low','close','volume'],index=date_range('2012-01-02 18:01:00',periods=5,tz='US/Central',freq='s'))

In [12]: df
Out[12]: 
                               open      high       low     close    volume
2012-01-02 18:01:00-06:00  0.131243  0.301542  0.128027  0.804162  1.296658
2012-01-02 18:01:01-06:00  0.341487  1.548695  0.703234  0.904201  1.422337
2012-01-02 18:01:02-06:00 -1.050453 -1.884035  1.537788 -0.821058  0.558631
2012-01-02 18:01:03-06:00  0.846885  1.045378 -0.722903 -0.613625 -0.476531
2012-01-02 18:01:04-06:00  1.186823 -0.018299 -0.513886 -1.103269 -0.311907

In [14]: df['2012-01-02 18:01:02']
Out[14]: 
                               open      high       low     close    volume
2012-01-02 18:01:02-06:00 -1.050453 -1.884035  1.537788 -0.821058  0.558631

```
