### PR TITLE
allow HDFStore to remain open when TableIterator is returned from read_hdf

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -155,7 +155,7 @@ def h5_open(path, mode):
     
 @contextmanager
 def get_store(path, mode='a', complevel=None, complib=None,
-              fletcher32=False):
+              fletcher32=False, iterator=False):
     """
     Creates an HDFStore instance. This function can be used in a with statement
 
@@ -175,7 +175,7 @@ def get_store(path, mode='a', complevel=None, complib=None,
                          complib=complib, fletcher32=False)
         yield store
     finally:
-        if store is not None:
+        if store is not None and not iterator:
             store.close()
 
 
@@ -199,7 +199,7 @@ def read_hdf(path_or_buf, key, **kwargs):
     f = lambda store: store.select(key, **kwargs)
 
     if isinstance(path_or_buf, basestring):
-        with get_store(path_or_buf) as store:
+        with get_store(path_or_buf, iterator=kwargs.get("iterator")) as store:
             return f(store)
     f(path_or_buf)
     


### PR DESCRIPTION
Hi,
I'm using a TableIterator from pandas.read_hdf function (with the keyword argument iterator=True), I am unable to retrieve any data due to the error "ClosedNodeError: the node object is closed".

For instance:

```
pandas.DataFrame({'a':[1,2,3], 'b':[4,5,6]}).to_hdf("test.h5", "test", append=True)
it = pandas.read_hdf("test.h5","test",iterator=True)
iter(it).next()

Traceback (most recent call last):
  File "<ipython-input-22-5634d86698ab>", line 1, in <module>
    iter(it).next()
  File "/usr/local/lib/python2.7/site-packages/pandas/io/pytables.py", line 912, in __iter__
    v = self.func(current, stop)
  ...
  File "/usr/local/lib/python2.7/site-packages/tables/node.py", line 355, in _g_check_open
    raise ClosedNodeError("the node object is closed")
ClosedNodeError: the node object is closed
```

I looked through source code of panda.io.pytables and found that in the
get_store function, store.close() is always run when read_hdf returns, even if
it returns an TableIterator. My assumption is that store should remain open in
order for TableIterator to work. Can you please let me know if this fix is
acceptable, or is there an easier way to do this?

Thanks,
Sean
