### PR TITLE
CLN: Change bare exceptions pt 1

### DIFF
--- a/pandas/sparse/array.py
+++ b/pandas/sparse/array.py
@@ -261,7 +261,7 @@ to sparse
             loc += n
 
         if loc >= len(self) or loc < 0:
-            raise Exception('Out of bounds access')
+            raise IndexError('out of bounds access')
 
         sp_loc = self.sp_index.lookup(loc)
         if sp_loc == -1:
@@ -283,7 +283,7 @@ to sparse
 
         n = len(self)
         if (indices < 0).any() or (indices >= n).any():
-            raise Exception('out of bounds access')
+            raise IndexError('out of bounds access')
 
         if self.sp_index.npoints > 0:
             locs = np.array([self.sp_index.lookup(loc) for loc in indices])
@@ -296,10 +296,10 @@ to sparse
         return result
 
     def __setitem__(self, key, value):
-        raise Exception('SparseArray objects are immutable')
+        raise TypeError('%r object does not support item assignment' % self.__class__.__name__)
 
     def __setslice__(self, i, j, value):
-        raise Exception('SparseArray objects are immutable')
+        raise TypeError('%r object does not support item assignment' % self.__class__.__name__)
 
     def to_dense(self):
         """
@@ -313,7 +313,7 @@ to sparse
         """
         dtype = np.dtype(dtype)
         if dtype is not None and dtype not in (np.float_, float):
-            raise Exception('Can only support floating point data for now')
+            raise TypeError('Can only support floating point data for now')
         return self.copy()
 
     def copy(self, deep=True):

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -195,10 +195,10 @@ class SparseDataFrame(DataFrame):
             columns = _default_index(K)
 
         if len(columns) != K:
-            raise Exception('Column length mismatch: %d vs. %d' %
+            raise ValueError('Column length mismatch: %d vs. %d' %
                             (len(columns), K))
         if len(index) != N:
-            raise Exception('Index length mismatch: %d vs. %d' %
+            raise ValueError('Index length mismatch: %d vs. %d' %
                             (len(index), N))
 
         data = dict([(idx, data[:, i]) for i, idx in enumerate(columns)])
@@ -585,7 +585,7 @@ class SparseDataFrame(DataFrame):
     def _reindex_index(self, index, method, copy, level, fill_value=np.nan,
                        limit=None):
         if level is not None:
-            raise Exception('Reindex by level not supported for sparse')
+            raise TypeError('Reindex by level not supported for sparse')
 
         if self.index.equals(index):
             if copy:
@@ -616,7 +616,7 @@ class SparseDataFrame(DataFrame):
 
     def _reindex_columns(self, columns, copy, level, fill_value, limit=None):
         if level is not None:
-            raise Exception('Reindex by level not supported for sparse')
+            raise TypeError('Reindex by level not supported for sparse')
 
         if com.notnull(fill_value):
             raise NotImplementedError
@@ -889,9 +889,12 @@ def stack_sparse_frame(frame):
 
     inds_to_concat = []
     vals_to_concat = []
+    # TODO: Figure out whether this can be reached.
+    # I think this currently can't be reached because you can't build a SparseDataFrame
+    # with a non-np.NaN fill value (fails earlier).
     for _, series in frame.iteritems():
         if not np.isnan(series.fill_value):
-            raise Exception('This routine assumes NaN fill value')
+            raise TypeError('This routine assumes NaN fill value')
 
         int_index = series.sp_index.to_int_index()
         inds_to_concat.append(int_index.indices)
@@ -931,7 +934,7 @@ def homogenize(series_dict):
 
     for _, series in series_dict.iteritems():
         if not np.isnan(series.fill_value):
-            raise Exception('this method is only valid with NaN fill values')
+            raise TypeError('this method is only valid with NaN fill values')
 
         if index is None:
             index = series.sp_index

--- a/pandas/sparse/panel.py
+++ b/pandas/sparse/panel.py
@@ -249,7 +249,7 @@ class SparsePanel(Panel):
         frame : DataFrame
         """
         if not filter_observations:
-            raise Exception('filter_observations=False not supported for '
+            raise TypeError('filter_observations=False not supported for '
                             'SparsePanel.to_long')
 
         I, N, K = self.shape
@@ -325,7 +325,7 @@ class SparsePanel(Panel):
                 if item in self._frames:
                     new_frames[item] = self._frames[item]
                 else:
-                    raise Exception('Reindexing with new items not yet '
+                    raise NotImplementedError('Reindexing with new items not yet '
                                     'supported')
         else:
             new_frames = self._frames
@@ -488,7 +488,7 @@ def _stack_sparse_info(frame):
         series = frame[col]
 
         if not np.isnan(series.fill_value):
-            raise Exception('This routine assumes NaN fill value')
+            raise TypeError('This routine assumes NaN fill value')
 
         int_index = series.sp_index.to_int_index()
         inds_to_concat.append(int_index.indices)

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -133,7 +133,7 @@ class SparseSeries(SparseArray, Series):
                     raise AssertionError()
         else:
             if index is None:
-                raise Exception('must pass index!')
+                raise TypeError('must pass index!')
 
             length = len(index)
 
@@ -388,7 +388,7 @@ class SparseSeries(SparseArray, Series):
 
         """
         if dtype is not None and dtype not in (np.float_, float):
-            raise Exception('Can only support floating point data')
+            raise TypeError('Can only support floating point data')
 
         return self.copy()
 

--- a/pandas/sparse/tests/test_array.py
+++ b/pandas/sparse/tests/test_array.py
@@ -1,3 +1,4 @@
+import re
 from numpy import nan, ndarray
 import numpy as np
 
@@ -8,7 +9,7 @@ import unittest
 from pandas.core.series import Series
 from pandas.core.common import notnull
 from pandas.sparse.api import SparseArray
-from pandas.util.testing import assert_almost_equal
+from pandas.util.testing import assert_almost_equal, assertRaisesRegexp
 
 
 def assert_sp_array_equal(left, right):
@@ -27,6 +28,24 @@ class TestSparseArray(unittest.TestCase):
         self.arr_data = np.array([nan, nan, 1, 2, 3, nan, 4, 5, nan, 6])
         self.arr = SparseArray(self.arr_data)
         self.zarr = SparseArray([0, 0, 1, 2, 3, 0, 4, 5, 0, 6], fill_value=0)
+
+    def test_get_item(self):
+        errmsg = re.compile("bounds")
+        assertRaisesRegexp(IndexError, errmsg, lambda : self.arr[11])
+        assertRaisesRegexp(IndexError, errmsg, lambda : self.arr[-11])
+        self.assertEqual(self.arr[-1], self.arr[len(self.arr) - 1])
+
+    def test_bad_take(self):
+        assertRaisesRegexp(IndexError, "bounds", lambda : self.arr.take(11))
+        self.assertRaises(IndexError, lambda : self.arr.take(-11))
+
+    def test_set_item(self):
+        def setitem():
+            self.arr[5] = 3
+        def setslice():
+            self.arr[1:5] = 2
+        assertRaisesRegexp(TypeError, "item assignment", setitem)
+        assertRaisesRegexp(TypeError, "item assignment", setslice)
 
     def test_constructor_from_sparse(self):
         res = SparseArray(self.zarr)
@@ -47,7 +66,7 @@ class TestSparseArray(unittest.TestCase):
         res.sp_values[:3] = 27
         self.assert_(not (self.arr.sp_values[:3] == 27).any())
 
-        self.assertRaises(Exception, self.arr.astype, 'i8')
+        assertRaisesRegexp(TypeError, "floating point", self.arr.astype, 'i8')
 
     def test_copy_shallow(self):
         arr2 = self.arr.copy(deep=False)

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -13,7 +13,7 @@ import pandas as pd
 dec = np.testing.dec
 
 from pandas.util.testing import (assert_almost_equal, assert_series_equal,
-                                 assert_frame_equal, assert_panel_equal)
+                                 assert_frame_equal, assert_panel_equal, assertRaisesRegexp)
 from numpy.testing import assert_equal
 
 from pandas import Series, DataFrame, bdate_range, Panel
@@ -641,7 +641,7 @@ class TestSparseSeries(TestCase,
         # must have NaN fill value
         data = {'a': SparseSeries(np.arange(7), sparse_index=expected2,
                                   fill_value=0)}
-        nose.tools.assert_raises(Exception, spf.homogenize, data)
+        assertRaisesRegexp(TypeError, "NaN fill value", spf.homogenize, data)
 
     def test_fill_value_corner(self):
         cop = self.zbseries.copy()
@@ -791,7 +791,7 @@ class TestSparseDataFrame(TestCase, test_frame.SafeForSparse):
         assert_sp_frame_equal(cons, reindexed)
 
         # assert level parameter breaks reindex
-        self.assertRaises(Exception, self.frame.reindex, idx, level=0)
+        self.assertRaises(TypeError, self.frame.reindex, idx, level=0)
 
         repr(self.frame)
 
@@ -805,14 +805,14 @@ class TestSparseDataFrame(TestCase, test_frame.SafeForSparse):
         assert_sp_frame_equal(sp, self.frame.reindex(columns=['A']))
 
         # raise on level argument
-        self.assertRaises(Exception, self.frame.reindex, columns=['A'],
+        self.assertRaises(TypeError, self.frame.reindex, columns=['A'],
                           level=1)
 
         # wrong length index / columns
-        self.assertRaises(Exception, SparseDataFrame, self.frame.values,
-                          index=self.frame.index[:-1])
-        self.assertRaises(Exception, SparseDataFrame, self.frame.values,
-                          columns=self.frame.columns[:-1])
+        assertRaisesRegexp(ValueError, "^Index length", SparseDataFrame, self.frame.values,
+                           index=self.frame.index[:-1])
+        assertRaisesRegexp(ValueError, "^Column length", SparseDataFrame, self.frame.values,
+                           columns=self.frame.columns[:-1])
 
     def test_constructor_empty(self):
         sp = SparseDataFrame()
@@ -840,11 +840,17 @@ class TestSparseDataFrame(TestCase, test_frame.SafeForSparse):
 
         x = Series(np.random.randn(10000), name ='a')
         y = Series(np.random.randn(10000), name ='b')
-        x.ix[:9998] = 0
-        x = x.to_sparse(fill_value=0)
+        x2 = x.astype(float)
+        x2.ix[:9998] = np.NaN
+        x_sparse = x2.to_sparse(fill_value=np.NaN)
         
-        # currently fails
-        #df1 = SparseDataFrame([x, y])
+        # Currently fails too with weird ufunc error
+        # df1 = SparseDataFrame([x_sparse, y])
+
+        y.ix[:9998] = 0
+        y_sparse = y.to_sparse(fill_value=0)
+        # without sparse value raises error
+        # df2 = SparseDataFrame([x2_sparse, y])
 
     def test_dtypes(self):
         df = DataFrame(np.random.randn(10000, 4))

--- a/pandas/stats/common.py
+++ b/pandas/stats/common.py
@@ -1,42 +1,33 @@
-def _get_cluster_type(cluster_type):
-    cluster_type = _WINDOW_TYPES.get(cluster_type, cluster_type)
-    if cluster_type is None:
-        return cluster_type
-
-    cluster_type_up = cluster_type.upper()
-
-    if cluster_type_up == 'ENTITY':
-        return 'entity'
-    elif cluster_type_up == 'TIME':
-        return 'time'
-    else:  # pragma: no cover
-        raise ValueError('Unrecognized cluster type: %s' % cluster_type)
-
-_CLUSTER_TYPES = {
-    0: 'time',
-    1: 'entity'
-}
 
 _WINDOW_TYPES = {
     0: 'full_sample',
     1: 'rolling',
     2: 'expanding'
 }
+# also allow 'rolling' as key
+_WINDOW_TYPES.update((v, v) for k,v in _WINDOW_TYPES.items())
+_ADDITIONAL_CLUSTER_TYPES = set(("entity", "time"))
 
+def _get_cluster_type(cluster_type):
+    # this was previous behavior
+    if cluster_type is None:
+        return cluster_type
+    try:
+        return _get_window_type(cluster_type)
+    except ValueError:
+        final_type = str(cluster_type).lower().replace("_", " ")
+        if final_type in _ADDITIONAL_CLUSTER_TYPES:
+            return final_type
+        raise ValueError('Unrecognized cluster type: %s' % cluster_type)
 
 def _get_window_type(window_type):
-    window_type = _WINDOW_TYPES.get(window_type, window_type)
-    window_type_up = window_type.upper()
-
-    if window_type_up in ('FULL SAMPLE', 'FULL_SAMPLE'):
-        return 'full_sample'
-    elif window_type_up == 'ROLLING':
-        return 'rolling'
-    elif window_type_up == 'EXPANDING':
-        return 'expanding'
-    else:  # pragma: no cover
+    # e.g., 0, 1, 2
+    final_type = _WINDOW_TYPES.get(window_type)
+    # e.g., 'full_sample'
+    final_type = final_type or _WINDOW_TYPES.get(str(window_type).lower().replace(" ", "_"))
+    if final_type is None:
         raise ValueError('Unrecognized window type: %s' % window_type)
-
+    return final_type
 
 def banner(text, width=80):
     """

--- a/pandas/stats/common.py
+++ b/pandas/stats/common.py
@@ -10,7 +10,7 @@ def _get_cluster_type(cluster_type):
     elif cluster_type_up == 'TIME':
         return 'time'
     else:  # pragma: no cover
-        raise Exception('Unrecognized cluster type: %s' % cluster_type)
+        raise ValueError('Unrecognized cluster type: %s' % cluster_type)
 
 _CLUSTER_TYPES = {
     0: 'time',
@@ -35,7 +35,7 @@ def _get_window_type(window_type):
     elif window_type_up == 'EXPANDING':
         return 'expanding'
     else:  # pragma: no cover
-        raise Exception('Unrecognized window type: %s' % window_type)
+        raise ValueError('Unrecognized window type: %s' % window_type)
 
 
 def banner(text, width=80):

--- a/pandas/stats/ols.py
+++ b/pandas/stats/ols.py
@@ -634,8 +634,8 @@ class MovingOLS(OLS):
         self._window_type = scom._get_window_type(window_type)
 
         if self._is_rolling:
-            if not ((window is not None)):
-                raise AssertionError()
+            if window is None:
+                raise AssertionError("Must specify window.")
             if min_periods is None:
                 min_periods = window
         else:

--- a/pandas/stats/tests/test_ols.py
+++ b/pandas/stats/tests/test_ols.py
@@ -692,6 +692,10 @@ class TestPanelOLS(BaseTest):
         self.checkNonPooled(y=self.panel_y, x=self.panel_x)
         self.checkNonPooled(y=self.panel_y, x=self.panel_x,
                             window_type='rolling', window=25, min_periods=10)
+    def testUnknownWindowType(self):
+        self.assertRaisesRegexp(ValueError, "window.*ridiculous",
+                self.checkNonPooled, y=self.panel_y, x=self.panel_x,
+                window_type='ridiculous', window=25, min_periods=10)
 
     def checkNonPooled(self, x, y, **kwds):
         # For now, just check that it doesn't crash

--- a/pandas/stats/tests/test_ols.py
+++ b/pandas/stats/tests/test_ols.py
@@ -19,7 +19,7 @@ from pandas.stats.api import ols
 from pandas.stats.ols import _filter_data
 from pandas.stats.plm import NonPooledPanelOLS, PanelOLS
 from pandas.util.testing import (assert_almost_equal, assert_series_equal,
-                                 assert_frame_equal)
+                                 assert_frame_equal, assertRaisesRegexp)
 import pandas.util.testing as tm
 
 from common import BaseTest
@@ -663,7 +663,10 @@ class TestPanelOLS(BaseTest):
     def testRollingWithEntityCluster(self):
         self.checkMovingOLS(self.panel_x, self.panel_y,
                             cluster='entity')
-
+    def testUnknownClusterRaisesValueError(self):
+        assertRaisesRegexp(ValueError, "Unrecognized cluster.*ridiculous",
+                           self.checkMovingOLS, self.panel_x, self.panel_y,
+                                               cluster='ridiculous')
     def testRollingWithTimeEffectsAndEntityCluster(self):
         self.checkMovingOLS(self.panel_x, self.panel_y,
                             time_effects=True, cluster='entity')

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5455,7 +5455,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
                        columns=['foo', 'bar', 'baz', 'qux'])
 
         series = df.ix[4]
-        self.assertRaises(Exception, df.append, series, verify_integrity=True)
+        self.assertRaises(ValueError, df.append, series, verify_integrity=True)
         series.name = None
         self.assertRaises(Exception, df.append, series, verify_integrity=True)
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1681,7 +1681,7 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
             else:
                 self.fail("orphaned index!")
 
-        self.assertRaises(Exception, self.ts.append, self.ts,
+        self.assertRaises(ValueError, self.ts.append, self.ts,
                           verify_integrity=True)
 
     def test_append_many(self):

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1184,7 +1184,7 @@ class _Concatenator(object):
         if self.verify_integrity:
             if not concat_index.is_unique:
                 overlap = concat_index.get_duplicates()
-                raise Exception('Indexes have overlapping values: %s'
+                raise ValueError('Indexes have overlapping values: %s'
                                 % str(overlap))
 
 

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -16,7 +16,7 @@ from pandas.core.index import (Index, MultiIndex, _get_combined_index,
 from pandas.core.internals import (IntBlock, BoolBlock, BlockManager,
                                    make_block, _consolidate)
 from pandas.util.decorators import cache_readonly, Appender, Substitution
-
+from pandas.core.common import PandasError
 from pandas.sparse.frame import SparseDataFrame
 import pandas.core.common as com
 
@@ -1002,7 +1002,8 @@ class _Concatenator(object):
                 blk.ref_items = self.new_axes[0]
 
             new_data = BlockManager(new_blocks, self.new_axes)
-        except Exception:  # EAFP
+        # Eventual goal would be to move everything to PandasError or other explicit error
+        except (Exception, PandasError):  # EAFP
             # should not be possible to fail here for the expected reason with
             # axis = 0
             if self.axis == 0:  # pragma: no cover
@@ -1039,8 +1040,11 @@ class _Concatenator(object):
         if self.axis > 0:
             # Not safe to remove this check, need to profile
             if not _all_indexes_same([b.items for b in blocks]):
-                raise Exception('dtypes are not consistent throughout '
-                                'DataFrames')
+                # TODO: Either profile this piece or remove.
+                # FIXME: Need to figure out how to test whether this line exists or does not...(unclear if even possible
+                #        or maybe would require performance test)
+                raise PandasError('dtypes are not consistent throughout '
+                                  'DataFrames')
             return make_block(concat_values, blocks[0].items, self.new_axes[0])
         else:
 

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -1078,7 +1078,7 @@ class TestConcatenate(unittest.TestCase):
         self.assert_(appended is not self.frame)
 
         # overlap
-        self.assertRaises(Exception, self.frame.append, self.frame,
+        self.assertRaises(ValueError, self.frame.append, self.frame,
                           verify_integrity=True)
 
     def test_append_length0_frame(self):

--- a/pandas/tools/tests/test_tile.py
+++ b/pandas/tools/tests/test_tile.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from pandas import DataFrame, Series, unique
 import pandas.util.testing as tm
+from pandas.util.testing import assertRaisesRegexp
 import pandas.core.common as com
 
 from pandas.core.algorithms import quantile
@@ -136,7 +137,7 @@ class TestCut(unittest.TestCase):
         self.assert_(factor.equals(expected))
 
     def test_qcut_all_bins_same(self):
-        self.assertRaises(Exception, qcut, [0,0,0,0,0,0,0,0,0,0], 3)
+        assertRaisesRegexp(ValueError, "edges.*unique", qcut, [0,0,0,0,0,0,0,0,0,0], 3)
 
     def test_cut_out_of_bounds(self):
         arr = np.random.randn(100)

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -151,7 +151,7 @@ def _bins_to_cuts(x, bins, right=True, labels=None, retbins=False,
     ids = bins.searchsorted(x, side=side)
 
     if len(algos.unique(bins)) < len(bins):
-        raise Exception('Bin edges must be unique: %s' % repr(bins))
+        raise ValueError('Bin edges must be unique: %s' % repr(bins))
 
     if include_lowest:
         ids[x == bins[0]] = 1

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -499,7 +499,7 @@ def get_offset(name):
     if offset is not None:
         return offset
     else:
-        raise Exception('Bad rule name requested: %s!' % name)
+        raise ValueError('Bad rule name requested: %s.' % name)
 
 
 getOffset = get_offset
@@ -522,7 +522,7 @@ def get_offset_name(offset):
     if name is not None:
         return name
     else:
-        raise Exception('Bad rule given: %s!' % offset)
+        raise ValueError('Bad rule given: %s.' % offset)
 
 
 def get_legacy_offset_name(offset):

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -428,7 +428,7 @@ class DatetimeIndex(Int64Index):
             end = Timestamp(end)
 
         if offset is None:
-            raise Exception('Must provide a DateOffset!')
+            raise TypeError('Must provide a DateOffset!')
 
         drc = _daterange_cache
         if offset not in _daterange_cache:
@@ -922,10 +922,10 @@ class DatetimeIndex(Int64Index):
         if isinstance(other, DatetimeIndex):
             if self.tz is not None:
                 if other.tz is None:
-                    raise Exception('Cannot join tz-naive with tz-aware '
+                    raise TypeError('Cannot join tz-naive with tz-aware '
                                     'DatetimeIndex')
             elif other.tz is not None:
-                raise Exception('Cannot join tz-naive with tz-aware '
+                raise TypeError('Cannot join tz-naive with tz-aware '
                                 'DatetimeIndex')
 
             if self.tz != other.tz:
@@ -1492,7 +1492,7 @@ class DatetimeIndex(Int64Index):
 
         if self.tz is None:
             # tz naive, use tz_localize
-            raise Exception('Cannot convert tz-naive timestamps, use '
+            raise TypeError('Cannot convert tz-naive timestamps, use '
                             'tz_localize to localize')
 
         # No conversion since timestamps are all UTC to begin with

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -422,13 +422,20 @@ class DatetimeIndex(Int64Index):
     @classmethod
     def _cached_range(cls, start=None, end=None, periods=None, offset=None,
                       name=None):
+        if start is None and end is None:
+            # I somewhat believe this should never be raised externally and therefore
+            # should be a `PandasError` but whatever...
+            raise TypeError('Must specify either start or end.')
         if start is not None:
             start = Timestamp(start)
         if end is not None:
             end = Timestamp(end)
+        if (start is None or end is None) and periods is None:
+            raise TypeError('Must either specify period or provide both start and end.')
 
         if offset is None:
-            raise TypeError('Must provide a DateOffset!')
+            # This can't happen with external-facing code, therefore PandasError
+            raise TypeError('Must provide offset.')
 
         drc = _daterange_cache
         if offset not in _daterange_cache:

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1507,7 +1507,7 @@ class DatetimeIndex(Int64Index):
         localized : DatetimeIndex
         """
         if self.tz is not None:
-            raise ValueError("Already tz-aware, use tz_convert to convert.")
+            raise TypeError("Already tz-aware, use tz_convert to convert.")
         tz = tools._maybe_get_tz(tz)
 
         # Convert to UTC

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1678,7 +1678,7 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
         Frequency strings can have multiples, e.g. '5H'
     tz : string or None
         Time zone name for returning localized DatetimeIndex, for example
-        Asia/Beijing
+        Asia/Hong_Kong
     normalize : bool, default False
         Normalize start/end dates to midnight before generating date range
     name : str, default None

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -351,7 +351,7 @@ class BusinessDay(CacheableOffset, DateOffset):
             return BDay(self.n, offset=self.offset + other,
                         normalize=self.normalize)
         else:
-            raise Exception('Only know how to combine business day with '
+            raise TypeError('Only know how to combine business day with '
                             'datetime or timedelta!')
 
     @classmethod
@@ -487,7 +487,7 @@ class Week(DateOffset, CacheableOffset):
 
         if self.weekday is not None:
             if self.weekday < 0 or self.weekday > 6:
-                raise Exception('Day must be 0<=day<=6, got %d' %
+                raise ValueError('Day must be 0<=day<=6, got %d' %
                                 self.weekday)
 
         self._inc = timedelta(weeks=1)
@@ -562,13 +562,13 @@ class WeekOfMonth(DateOffset, CacheableOffset):
         self.week = kwds['week']
 
         if self.n == 0:
-            raise Exception('N cannot be 0')
+            raise ValueError('N cannot be 0')
 
         if self.weekday < 0 or self.weekday > 6:
-            raise Exception('Day must be 0<=day<=6, got %d' %
+            raise ValueError('Day must be 0<=day<=6, got %d' %
                             self.weekday)
         if self.week < 0 or self.week > 3:
-            raise Exception('Week must be 0<=day<=3, got %d' %
+            raise ValueError('Week must be 0<=day<=3, got %d' %
                             self.week)
 
         self.kwds = kwds

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -13,6 +13,7 @@ from pandas.tseries.index import bdate_range, date_range
 import pandas.tseries.tools as tools
 
 import pandas.core.datetools as datetools
+from pandas.util.testing import assertRaisesRegexp
 
 
 def _skip_if_no_pytz():
@@ -65,6 +66,12 @@ class TestDateRange(unittest.TestCase):
         self.assertRaises(ValueError, date_range, '2011-1-1', '2012-1-1', 'B')
         self.assertRaises(ValueError, bdate_range, '2011-1-1', '2012-1-1', 'B')
 
+    def test_naive_aware_conflicts(self):
+        naive = bdate_range(START, END, freq=datetools.bday, tz=None)
+        aware = bdate_range(START, END, freq=datetools.bday, tz="Asia/Hong_Kong")
+        assertRaisesRegexp(TypeError, "tz-naive.*tz-aware", naive.join, aware)
+        assertRaisesRegexp(TypeError, "tz-naive.*tz-aware", aware.join, naive)
+
     def test_cached_range(self):
         rng = DatetimeIndex._cached_range(START, END,
                                           offset=datetools.bday)
@@ -73,16 +80,16 @@ class TestDateRange(unittest.TestCase):
         rng = DatetimeIndex._cached_range(end=START, periods=20,
                                           offset=datetools.bday)
 
-        self.assertRaises(Exception, DatetimeIndex._cached_range, START, END)
+        assertRaisesRegexp(TypeError, "offset", DatetimeIndex._cached_range, START, END)
 
-        self.assertRaises(Exception, DatetimeIndex._cached_range, START,
-                          freq=datetools.bday)
+        assertRaisesRegexp(TypeError, "specify period", DatetimeIndex._cached_range, START,
+                          offset=datetools.bday)
 
-        self.assertRaises(Exception, DatetimeIndex._cached_range, end=END,
-                          freq=datetools.bday)
+        assertRaisesRegexp(TypeError, "specify period", DatetimeIndex._cached_range, end=END,
+                          offset=datetools.bday)
 
-        self.assertRaises(Exception, DatetimeIndex._cached_range, periods=20,
-                          freq=datetools.bday)
+        assertRaisesRegexp(TypeError, "start or end", DatetimeIndex._cached_range, periods=20,
+                          offset=datetools.bday)
 
     def test_cached_range_bug(self):
         rng = date_range('2010-09-01 05:00:00', periods=50,

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -20,6 +20,7 @@ from nose.tools import assert_raises
 
 from pandas.tslib import monthrange
 from pandas.lib import Timestamp
+from pandas.util.testing import assertRaisesRegexp
 
 _multiprocess_can_split_ = True
 
@@ -44,7 +45,7 @@ def test_ole2datetime():
     actual = ole2datetime(60000)
     assert actual == datetime(2064, 4, 8)
 
-    assert_raises(Exception, ole2datetime, 60)
+    assert_raises(ValueError, ole2datetime, 60)
 
 
 def test_to_datetime1():
@@ -285,7 +286,7 @@ class TestBusinessDay(unittest.TestCase):
         self.assertEqual(rs, xp)
 
     def test_apply_corner(self):
-        self.assertRaises(Exception, BDay().apply, BMonthEnd())
+        self.assertRaises(TypeError, BDay().apply, BMonthEnd())
 
     def test_offsets_compare_equal(self):
         # root cause of #456
@@ -301,8 +302,8 @@ def assertOnOffset(offset, date, expected):
 
 class TestWeek(unittest.TestCase):
     def test_corner(self):
-        self.assertRaises(Exception, Week, weekday=7)
-        self.assertRaises(Exception, Week, weekday=-1)
+        self.assertRaises(ValueError, Week, weekday=7)
+        assertRaisesRegexp(ValueError, "Day must be", Week, weekday=-1)
 
     def test_isAnchored(self):
         self.assert_(Week(weekday=0).isAnchored())
@@ -366,11 +367,11 @@ class TestWeek(unittest.TestCase):
 class TestWeekOfMonth(unittest.TestCase):
 
     def test_constructor(self):
-        self.assertRaises(Exception, WeekOfMonth, n=0, week=1, weekday=1)
-        self.assertRaises(Exception, WeekOfMonth, n=1, week=4, weekday=0)
-        self.assertRaises(Exception, WeekOfMonth, n=1, week=-1, weekday=0)
-        self.assertRaises(Exception, WeekOfMonth, n=1, week=0, weekday=-1)
-        self.assertRaises(Exception, WeekOfMonth, n=1, week=0, weekday=7)
+        assertRaisesRegexp(ValueError, "^N cannot be 0", WeekOfMonth, n=0, week=1, weekday=1)
+        assertRaisesRegexp(ValueError, "^Week", WeekOfMonth, n=1, week=4, weekday=0)
+        assertRaisesRegexp(ValueError, "^Week", WeekOfMonth, n=1, week=-1, weekday=0)
+        assertRaisesRegexp(ValueError, "^Day", WeekOfMonth, n=1, week=0, weekday=-1)
+        assertRaisesRegexp(ValueError, "^Day", WeekOfMonth, n=1, week=0, weekday=7)
 
     def test_offset(self):
         date1 = datetime(2011, 1, 4)  # 1st Tuesday of Month
@@ -1445,7 +1446,7 @@ def test_hasOffsetName():
 
 
 def test_get_offset_name():
-    assert_raises(Exception, get_offset_name, BDay(2))
+    assertRaisesRegexp(ValueError, 'Bad rule.*BusinessDays', get_offset_name, BDay(2))
 
     assert get_offset_name(BDay()) == 'B'
     assert get_offset_name(BMonthEnd()) == 'BM'
@@ -1457,7 +1458,7 @@ def test_get_offset_name():
 
 
 def test_get_offset():
-    assert_raises(Exception, get_offset, 'gibberish')
+    assertRaisesRegexp(ValueError, "rule.*GIBBERISH", get_offset, 'gibberish')
 
     assert get_offset('B') == BDay()
     assert get_offset('b') == BDay()

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -18,8 +18,9 @@ import pandas.core.datetools as datetools
 import pandas.tseries.offsets as offsets
 from pandas.tseries.index import bdate_range, date_range
 import pandas.tseries.tools as tools
+from pytz import NonExistentTimeError
 
-from pandas.util.testing import assert_series_equal, assert_almost_equal
+from pandas.util.testing import assert_series_equal, assert_almost_equal, assertRaisesRegexp
 import pandas.util.testing as tm
 
 import pandas.lib as lib
@@ -93,7 +94,8 @@ class TestTimeZoneSupport(unittest.TestCase):
 
         # DST ambiguity, this should fail
         rng = date_range('3/11/2012', '3/12/2012', freq='30T')
-        self.assertRaises(Exception, rng.tz_localize, 'US/Eastern')
+        # Is this really how it should fail??
+        self.assertRaises(NonExistentTimeError, rng.tz_localize, 'US/Eastern')
 
     def test_timestamp_tz_localize(self):
         stamp = Timestamp('3/11/2012 04:00')
@@ -672,7 +674,7 @@ class TestTimeZones(unittest.TestCase):
         # Can't localize if already tz-aware
         rng = date_range('1/1/2011', periods=100, freq='H', tz='utc')
         ts = Series(1, index=rng)
-        self.assertRaises(Exception, ts.tz_localize, 'US/Eastern')
+        assertRaisesRegexp(TypeError, 'Already tz-aware', ts.tz_localize, 'US/Eastern')
 
     def test_series_frame_tz_convert(self):
         rng = date_range('1/1/2011', periods=200, freq='D',
@@ -696,7 +698,7 @@ class TestTimeZones(unittest.TestCase):
         # can't convert tz-naive
         rng = date_range('1/1/2011', periods=200, freq='D')
         ts = Series(1, index=rng)
-        self.assertRaises(Exception, ts.tz_convert, 'US/Eastern')
+        assertRaisesRegexp(TypeError, "Cannot convert tz-naive", ts.tz_convert, 'US/Eastern')
 
     def test_join_utc_convert(self):
         rng = date_range('1/1/2011', periods=100, freq='H', tz='utc')

--- a/pandas/tseries/tools.py
+++ b/pandas/tseries/tools.py
@@ -344,6 +344,6 @@ def ole2datetime(oledt):
     # Excel has a bug where it thinks the date 2/29/1900 exists
     # we just reject any date before 3/1/1900.
     if val < 61:
-        raise Exception("Value is outside of acceptable range: %s " % val)
+        raise ValueError("Value is outside of acceptable range: %s " % val)
 
     return OLE_TIME_ZERO + timedelta(days=val)


### PR DESCRIPTION
Relates to #3954. In addition to changing exceptions types returned to be more explicit, this pull incorporates the following changes:
1. Adds a new `assertRaisesRegexp` to `util/testing.py` to port the `assertRaisesRegexp` helper from 2.7+ unittest
2. Cleans up stats/common.
3. Fix up initial assertions in `tseries.offset._cached_range` that were all off + fix the test cases which were all just raising TypeErrors because they were calling with the wrong arguments.
4. Changes the example timezone from Asia/Beijing to Asia/Hong+Kong b/c `Asia/Beijing` is not supported by pytz.
5. Any tz-aware : tz-naive comparison fails with TypeError, as will mismatched, localize, etc. calls.
6. Changes `SparseArray` indexing error messages to match tuple message for completeness.
7. Improves the window check in ols.

After you all say it's okay to merge, I'll update the docs to reflect changes.
