### PR TITLE
BUG: Possibly invalidate the item_cache when numpy implicty converts a v...

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -287,7 +287,7 @@ pandas 0.12
   - Fixed insertion issue into DataFrame, after rename (:issue:`4032`)
   - Fixed testing issue where too many sockets where open thus leading to a
     connection reset issue (:issue:`3982`, :issue:`3985`)
-
+  - Possibly invalidate the item_cache when numpy implicty converts a view to a copy (:issue:`3970`)
 
 pandas 0.11.0
 =============

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1,5 +1,6 @@
 # pylint: disable=W0231,E1101
 
+import weakref
 import numpy as np
 
 from pandas.core.index import MultiIndex
@@ -666,6 +667,7 @@ class NDFrame(PandasObject):
             values = self._data.get(item)
             res = self._box_item_values(item, values)
             cache[item] = res
+            res._cacher = weakref.ref(self)
             return res
 
     def _box_item_values(self, key, values):
@@ -1065,6 +1067,7 @@ class NDFrame(PandasObject):
             new_data = self._data.reindex_axis(new_items, axis=0)
         else:
             new_data = self._data.take(indices, axis=axis, verify=False)
+
         return self._constructor(new_data)
 
     def tz_convert(self, tz, axis=0, copy=True):

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -184,6 +184,14 @@ class _NDFrameIndexer(object):
             if np.prod(values.shape):
                 values[indexer] = value
 
+            # we might need to invalidate a cached version of myself
+            cacher = getattr(self.obj,'_cacher',None)
+            if cacher is not None:
+                try:
+                    cacher()._clear_item_cache()
+                except:
+                    pass
+
     def _align_series(self, indexer, ser):
         # indexer to assign Series can be tuple or scalar
         if isinstance(indexer, tuple):
@@ -709,6 +717,7 @@ class _LocationIndexer(_NDFrameIndexer):
                 return self.obj.take(inds, axis=axis, convert=False)
             except (Exception), detail:
                 raise self._exception(detail)
+
     def _get_slice_axis(self, slice_obj, axis=0):
         """ this is pretty simple as we just have to deal with labels """
         obj = self.obj

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1650,6 +1650,7 @@ class BlockManager(object):
             self._known_consolidated = True
 
     def get(self, item):
+
         if self.items.is_unique:
             _, block = self._find_block(item)
             return block.get(item)

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -1066,7 +1066,18 @@ class TestIndexing(unittest.TestCase):
         result = df2.loc[idx]
         assert_frame_equal(result, expected)
 
+    def test_series_iloc(self):
+        # GH 3970
 
+        df = DataFrame({ "aa":range(5), "bb":[2.2]*5})
+        df["cc"] = 0.0
+        ck = [True]*len(df)
+        df["bb"].loc[0] = .13 # works
+        df_tmp = df.iloc[ck]
+        df["bb"].loc[0] = .15 # doesn't work
+        expected = DataFrame({ "aa":range(5), "bb":[0.15,2.2,2.2,2.2,2.2], "cc": 0.0 })
+        assert_frame_equal(df, expected)
+        
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
closes #3970

`df['bb'].iloc[0] = 0.13`
here `bb` is put into the `_item_cache` and the first element assigned 0.13; `bb` is still a view onto the frame block

`df_tmp = df.iloc[[True]*len(df)]`
`df_tmp` is now a copy of df, but built up as a take block-by-block from `df`. I believe numpy then decides to invalidate the views to the memory in the float block (why I have no idea); `bb` in `df` is still holding the view in the `_item_cache` to the old memory location.

`df['bb'].iloc[0] = 0.15`
grabs `bb` from the cache and assigns 0.15 to it, BUT it is not longer a view onto the float block in `df` so nothing appears to get updated

I tried 2 fixes:

1) when getting an item from the `_item_cache` check if its a view of the underlying data - this works, but makes lookups way slow 
2) clear the cache when `taking` ON THE ORIGINAL frame, so future lookups will cache-miss and get the correct data from the block manager

Fundamentally we COULD do this in the first statement `df['bb'].iloc[0] = 0.13`, where we don't reset the cache, except we don't have a reference to df (well we do, but by the time the operation is carried out we have an operation on the series, so have lost the frame reference)

So this is fixed in this case, but not sure what other numpy ops implicity convert view-> copy (and we are holding onto the cached view).
