### PR TITLE
BUG  (GH3967) csv parsers would loop infinitely if iterator=True but no chunksize specified

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -258,6 +258,8 @@ pandas 0.11.1
   - Fixed ``__truediv__`` in Python 2.7 with ``numexpr`` installed to actually do true division when dividing
     two integer arrays with at least 10000 cells total (:issue:`3764`)
   - Indexing with a string with seconds resolution not selecting from a time index (:issue:`3925`)
+  - csv parsers would loop infinitely if ``iterator=True`` but no ``chunksize`` was 
+    specified (:issue:`3967`), python parser failing with ``chunksize=1``
 
 .. _Gh3616: https://github.com/pydata/pandas/issues/3616
 

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -1037,6 +1037,24 @@ baz,7,8,9
                                   iterator=True)
         self.assert_(isinstance(treader, TextFileReader))
 
+        # stopping iteration when on chunksize is specified, GH 3967
+        data = """A,B,C
+foo,1,2,3
+bar,4,5,6
+baz,7,8,9
+"""
+        reader = self.read_csv(StringIO(data), iterator=True)
+        result = list(reader)
+        expected = DataFrame(dict(A = [1,4,7], B = [2,5,8], C = [3,6,9]), index=['foo','bar','baz'])
+        tm.assert_frame_equal(result[0], expected)
+
+        # chunksize = 1
+        reader = self.read_csv(StringIO(data), chunksize=1)
+        result = list(reader)
+        expected = DataFrame(dict(A = [1,4,7], B = [2,5,8], C = [3,6,9]), index=['foo','bar','baz'])
+        self.assert_(len(result) == 3)
+        tm.assert_frame_equal(pd.concat(result), expected)
+
     def test_header_not_first_line(self):
         data = """got,to,ignore,this,line
 got,to,ignore,this,line


### PR DESCRIPTION
BUG: python parser failing with `chunksize=1`

closes #3967
