### PR TITLE
BUG: Index shift drops index name

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -270,6 +270,7 @@ pandas 0.11.1
   - Indexing with a string with seconds resolution not selecting from a time index (:issue:`3925`)
   - csv parsers would loop infinitely if ``iterator=True`` but no ``chunksize`` was 
     specified (:issue:`3967`), python parser failing with ``chunksize=1``
+	- Fix index name not propogating when using ``shift`` 
 
 .. _Gh3616: https://github.com/pydata/pandas/issues/3616
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -563,7 +563,7 @@ class Index(np.ndarray):
             return self
 
         offset = periods * freq
-        return Index([idx + offset for idx in self])
+        return Index([idx + offset for idx in self], name=self.name)
 
     def argsort(self, *args, **kwargs):
         """

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -204,6 +204,9 @@ class TestIndex(unittest.TestCase):
         shifted = self.dateIndex.shift(1, 'B')
         self.assert_(np.array_equal(shifted, self.dateIndex + offsets.BDay()))
 
+        shifted.name = 'shifted'
+        self.assertEqual(shifted.name, shifted.shift(1, 'D').name)
+
     def test_intersection(self):
         first = self.strIndex[:20]
         second = self.strIndex[:10]


### PR DESCRIPTION
```
>>> idx = pd.Index([pd.to_datetime('2013-06-21')], name='idx')
>>> idx.name
'idx'
>>> idx.shift(1, freq='B').name == None
True
```
