### PR TITLE
BUG: invert_xaxis (negative tot_sec) triggers MilliSecondLocator (#3990)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -324,6 +324,8 @@ pandas 0.12
     (:issue:`4145`, :issue:`4146`)
   - Fixed bug in the parsing of microseconds when using the ``format`` 
     argument in ``to_datetime`` (:issue:`4152`)
+  - Fixed bug in ``PandasAutoDateLocator`` where ``invert_xaxis`` triggered
+    incorrectly ``MilliSecondLocator``  (:issue:`3990`)
 
 pandas 0.11.0
 =============

--- a/doc/source/v0.12.0.txt
+++ b/doc/source/v0.12.0.txt
@@ -461,6 +461,8 @@ Bug Fixes
     iterated over when regex=False (:issue:`4115`)
   - Fixed bug in the parsing of microseconds when using the ``format`` 
     argument in ``to_datetime`` (:issue:`4152`)
+  - Fixed bug in ``PandasAutoDateLocator`` where ``invert_xaxis`` triggered
+    incorrectly ``MilliSecondLocator``  (:issue:`3990`)
     
 See the :ref:`full release notes
 <release>` or issue tracker

--- a/pandas/tseries/converter.py
+++ b/pandas/tseries/converter.py
@@ -244,7 +244,7 @@ class PandasAutoDateLocator(dates.AutoDateLocator):
         num_sec = (delta.hours * 60.0 + delta.minutes) * 60.0 + delta.seconds
         tot_sec = num_days * 86400. + num_sec
 
-        if tot_sec < self.minticks:
+        if abs(tot_sec) < self.minticks:
             self._freq = -1
             locator = MilliSecondLocator(self.tz)
             locator.set_axis(self.axis)


### PR DESCRIPTION
Solves issue #3990. 
Negative timedelta for xaxis range will no longer trigger MilliSecondLocator.
