### PR TITLE
Fix rename for MultiIndex columns DataFrame

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -277,6 +277,7 @@ pandas 0.11.1
     specified (:issue:`3967`), python parser failing with ``chunksize=1``
 	- Fix index name not propogating when using ``shift`` 
 	- Fixed dropna=False being ignored with multi-index stack (:issue:`3997`)
+  - Fixed flattening of columns when renaming MultiIndex columns DataFrame (:issue:`4004`)
 
 .. _Gh3616: https://github.com/pydata/pandas/issues/3616
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2140,7 +2140,12 @@ class BlockManager(object):
         return BlockManager(self.blocks, new_axes)
 
     def rename_items(self, mapper, copydata=True):
-        new_items = Index([mapper(x) for x in self.items])
+        if isinstance(self.items, MultiIndex):
+            items = [tuple(mapper(y) for y in x) for x in self.items]
+            new_items = MultiIndex.from_tuples(items, names=self.items.names)
+        else:
+            items = [mapper(x) for x in self.items]
+            new_items = Index(items, names=self.items.names)
 
         new_blocks = []
         for block in self.blocks:

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -7736,11 +7736,19 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self.assertEquals(renamed.index.name, renamer.index.name)
 
         # MultiIndex
-        index = MultiIndex.from_tuples([('foo1', 'bar1'), ('foo2', 'bar2')], names=['foo', 'bar'])
-        renamer = DataFrame(data, index=index)
-        renamed = renamer.rename(index={'foo1': 'foo3', 'bar2': 'bar3'})
-        self.assert_(np.array_equal(renamed.index, MultiIndex.from_tuples([('foo3', 'bar1'), ('foo2', 'bar3')])))
+        tuples_index = [('foo1', 'bar1'), ('foo2', 'bar2')]
+        tuples_columns = [('fizz1', 'buzz1'), ('fizz2', 'buzz2')]
+        index = MultiIndex.from_tuples(tuples_index, names=['foo', 'bar'])
+        columns = MultiIndex.from_tuples(tuples_columns, names=['fizz', 'buzz'])
+        renamer = DataFrame([(0,0),(1,1)], index=index, columns=columns)
+        renamed = renamer.rename(index={'foo1': 'foo3', 'bar2': 'bar3'},
+                                 columns={'fizz1': 'fizz3', 'buzz2': 'buzz3'})
+        new_index = MultiIndex.from_tuples([('foo3', 'bar1'), ('foo2', 'bar3')])
+        new_columns = MultiIndex.from_tuples([('fizz3', 'buzz1'), ('fizz2', 'buzz3')])
+        self.assert_(np.array_equal(renamed.index, new_index))
+        self.assert_(np.array_equal(renamed.columns, new_columns))
         self.assertEquals(renamed.index.names, renamer.index.names)
+        self.assertEquals(renamed.columns.names, renamer.columns.names)
 
     def test_rename_nocopy(self):
         renamed = self.frame.rename(columns={'C': 'foo'}, copy=False)


### PR DESCRIPTION
DataFrame rename doesn't rename a MultiIndex column and it flattens the columns. Closes https://github.com/pydata/pandas/issues/3165 which is a fix for index but not columns.
