### PR TITLE
BUG: Make secondary_y work properly for bar plots GH3598

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -232,6 +232,7 @@ pandas 0.11.1
     is a ``list`` or ``tuple``.
   - Fixed bug where a time-series was being selected in preference to an actual column name
     in a frame (:issue:`3594`)
+  - Make secondary_y work properly for bar plots (:issue:`3598`)
   - Fix modulo and integer division on Series,DataFrames to act similary to ``float`` dtypes to return
     ``np.nan`` or ``np.inf`` as appropriate (:issue:`3590`)
   - Fix incorrect dtype on groupby with ``as_index=False`` (:issue:`3610`)

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -616,6 +616,16 @@ class TestTSPlot(unittest.TestCase):
         self.assert_(axes[2].get_yaxis().get_ticks_position() == 'right')
 
     @slow
+    def test_secondary_bar_frame(self):
+        import matplotlib.pyplot as plt
+        plt.close('all')
+        df = DataFrame(np.random.randn(5, 3), columns=['a', 'b', 'c'])
+        axes = df.plot(kind='bar', secondary_y=['a', 'c'], subplots=True)
+        self.assert_(axes[0].get_yaxis().get_ticks_position() == 'right')
+        self.assert_(axes[1].get_yaxis().get_ticks_position() == 'default')
+        self.assert_(axes[2].get_yaxis().get_ticks_position() == 'right')
+
+    @slow
     def test_mixed_freq_regular_first(self):
         import matplotlib.pyplot as plt
         plt.close('all')
@@ -863,6 +873,18 @@ class TestTSPlot(unittest.TestCase):
         self.assert_(leg.get_texts()[1].get_text() == 'B')
         self.assert_(leg.get_texts()[2].get_text() == 'C')
         self.assert_(leg.get_texts()[3].get_text() == 'D')
+
+        plt.clf()
+        ax = df.plot(kind='bar', secondary_y=['A'])
+        leg = ax.get_legend()
+        self.assert_(leg.get_texts()[0].get_text() == 'A (right)')
+        self.assert_(leg.get_texts()[1].get_text() == 'B')
+
+        plt.clf()
+        ax = df.plot(kind='bar', secondary_y=['A'], mark_right=False)
+        leg = ax.get_legend()
+        self.assert_(leg.get_texts()[0].get_text() == 'A')
+        self.assert_(leg.get_texts()[1].get_text() == 'B')
 
         plt.clf()
         ax = fig.add_subplot(211)


### PR DESCRIPTION
As far as I'm aware this seems to work properly, but I'm not sure if this was done the previous way for a reason I don't understand.

Fixes: https://github.com/pydata/pandas/issues/3598
