### PR TITLE
Remove deprecation warning about 'display.height' option.

### DIFF
--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -140,11 +140,6 @@ pc_width_doc = """
     terminal and hence it is not possible to correctly detect the width.
 """
 
-pc_height_doc = """
-: int
-    Deprecated.
-"""
-
 pc_chop_threshold_doc = """
 : float or None
     if set to a float value, all float values smaller then the given threshold
@@ -239,8 +234,6 @@ with cf.config_prefix('display'):
     cf.register_option('mpl_style', None, pc_mpl_style_doc,
                        validator=is_one_of_factory([None, False, 'default']),
                        cb=mpl_style_cb)
-    cf.register_option('height', 60, pc_height_doc,
-                       validator=is_instance_factory([type(None), int]))
     cf.register_option('width',80, pc_width_doc,
                        validator=is_instance_factory([type(None), int]))
     # redirected to width, make defval identical
@@ -252,7 +245,7 @@ cf.deprecate_option('display.line_width',
 
 cf.deprecate_option('display.height',
                     msg=pc_height_deprecation_warning,
-                    rkey='display.height')
+                    rkey='display.max_rows')
 
 tc_sim_interactive_doc = """
 : boolean

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -1721,7 +1721,7 @@ def get_console_size():
     Returns (None,None) in non-interactive session.
     """
     display_width = get_option('display.width')
-    display_height = get_option('display.height')
+    display_height = get_option('display.max_rows')
 
     # Consider
     # interactive shell terminal, can detect term size
@@ -1739,7 +1739,7 @@ def get_console_size():
             # match default for width,height in config_init
             from pandas.core.config import get_default_val
             terminal_width = get_default_val('display.width')
-            terminal_height = get_default_val('display.height')
+            terminal_height = get_default_val('display.max_rows')
         else:
             # pure terminal
             terminal_width, terminal_height = get_terminal_size()

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -196,7 +196,6 @@ class TestDataFrameFormatting(unittest.TestCase):
 
         with option_context('mode.sim_interactive', False,
                             'display.width', 0,
-                            'display.height', 0,
                             'display.max_rows',5000):
             self.assertFalse(has_info_repr(df))
             self.assertFalse(has_expanded_repr(df))


### PR DESCRIPTION
Hi,

See the related issue at https://github.com/pydata/pandas/issues/4026

Best regards,
Damien
