### PR TITLE
ENH/BUG: Fix names, levels and labels handling in MultiIndex

### DIFF
--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -1229,7 +1229,9 @@ However:
 ::
 
    >>> s.ix[('a', 'b'):('b', 'a')]
-   Exception: MultiIndex lexsort depth 1, key was length 2
+   Traceback (most recent call last)
+        ...
+   KeyError: Key length (3) was greater than MultiIndex lexsort depth (2)
 
 Swapping levels with ``swaplevel``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -868,66 +868,6 @@ convert to an integer index:
     df_new[(df_new['index'] >= 1.0) & (df_new['index'] < 2)]
 
 
-.. _indexing.class:
-
-Index objects
--------------
-
-The pandas Index class and its subclasses can be viewed as implementing an
-*ordered set* in addition to providing the support infrastructure necessary for
-lookups, data alignment, and reindexing. The easiest way to create one directly
-is to pass a list or other sequence to ``Index``:
-
-.. ipython:: python
-
-   index = Index(['e', 'd', 'a', 'b'])
-   index
-   'd' in index
-
-You can also pass a ``name`` to be stored in the index:
-
-
-.. ipython:: python
-
-   index = Index(['e', 'd', 'a', 'b'], name='something')
-   index.name
-
-Starting with pandas 0.5, the name, if set, will be shown in the console
-display:
-
-.. ipython:: python
-
-   index = Index(list(range(5)), name='rows')
-   columns = Index(['A', 'B', 'C'], name='cols')
-   df = DataFrame(np.random.randn(5, 3), index=index, columns=columns)
-   df
-   df['A']
-
-
-Set operations on Index objects
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. _indexing.set_ops:
-
-The three main operations are ``union (|)``, ``intersection (&)``, and ``diff
-(-)``. These can be directly called as instance methods or used via overloaded
-operators:
-
-.. ipython:: python
-
-   a = Index(['c', 'b', 'a'])
-   b = Index(['c', 'e', 'd'])
-   a.union(b)
-   a | b
-   a & b
-   a - b
-
-``isin`` method of Index objects
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-One additional operation is the ``isin`` method that works analogously to the
-``Series.isin`` method found :ref:`here <indexing.boolean>`.
-
 .. _indexing.hierarchical:
 
 Hierarchical indexing (MultiIndex)
@@ -1189,7 +1129,7 @@ are named.
 
 .. ipython:: python
 
-   s.index.names = ['L1', 'L2']
+   s.index.set_names(['L1', 'L2'], inplace=True)
    s.sortlevel(level='L1')
    s.sortlevel(level='L2')
 
@@ -1275,6 +1215,88 @@ note that sortedness is determined **solely** from the integer labels and does
 not check (or care) whether the levels themselves are sorted. Fortunately, the
 constructors ``from_tuples`` and ``from_arrays`` ensure that this is true, but
 if you compute the levels and labels yourself, please be careful.
+
+.. _indexing.class:
+
+Index objects
+-------------
+
+The pandas Index class and its subclasses can be viewed as implementing an
+*ordered set* in addition to providing the support infrastructure necessary for
+lookups, data alignment, and reindexing. The easiest way to create one directly
+is to pass a list or other sequence to ``Index``:
+
+.. ipython:: python
+
+   index = Index(['e', 'd', 'a', 'b'])
+   index
+   'd' in index
+
+You can also pass a ``name`` to be stored in the index:
+
+
+.. ipython:: python
+
+   index = Index(['e', 'd', 'a', 'b'], name='something')
+   index.name
+
+Starting with pandas 0.5, the name, if set, will be shown in the console
+display:
+
+.. ipython:: python
+
+   index = Index(list(range(5)), name='rows')
+   columns = Index(['A', 'B', 'C'], name='cols')
+   df = DataFrame(np.random.randn(5, 3), index=index, columns=columns)
+   df
+   df['A']
+
+
+Set operations on Index objects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. _indexing.set_ops:
+
+The three main operations are ``union (|)``, ``intersection (&)``, and ``diff
+(-)``. These can be directly called as instance methods or used via overloaded
+operators:
+
+.. ipython:: python
+
+   a = Index(['c', 'b', 'a'])
+   b = Index(['c', 'e', 'd'])
+   a.union(b)
+   a | b
+   a & b
+   a - b
+
+``isin`` method of Index objects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+One additional operation is the ``isin`` method that works analogously to the
+``Series.isin`` method found :ref:`here <indexing.boolean>`.
+
+Setting index metadata (``name(s)``, ``levels``, ``labels``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. _indexing.set_metadata:
+
+Indexes are "mostly immutable", but it is possible to set and change their
+metadata, like the index ``name`` (or, for ``MultiIndex``, ``levels`` and
+``labels``).
+
+You can use the ``rename``, ``set_names``, ``set_levels``, and ``set_labels``
+to set these attributes directly. They default to returning a copy; however,
+you can specify ``inplace=True`` to have the data change inplace.
+
+.. ipython:: python
+
+  ind = Index([1, 2, 3])
+  ind.rename("apple")
+  ind
+  ind.set_names(["apple"], inplace=True)
+  ind.name = "bob"
+  ind
 
 Adding an index to an existing DataFrame
 ----------------------------------------

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -47,6 +47,9 @@ pandas 0.13
   - Added a more informative error message when plot arguments contain
     overlapping color and style arguments (:issue:`4402`)
   - Significant table writing performance improvements in ``HDFStore``
+  - ``Index.copy()`` and ``MultiIndex.copy()`` now accept keyword arguments to
+    change attributes (i.e., ``names``, ``levels``, ``labels``)
+    (:issue:`4039`)
   - Add ``rename`` and ``set_names`` methods to ``Index`` as well as
     ``set_names``, ``set_levels``, ``set_labels`` to ``MultiIndex``.
     (:issue:`4039`)

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -47,6 +47,9 @@ pandas 0.13
   - Added a more informative error message when plot arguments contain
     overlapping color and style arguments (:issue:`4402`)
   - Significant table writing performance improvements in ``HDFStore``
+  - Add ``rename`` and ``set_names`` methods to ``Index`` as well as
+    ``set_names``, ``set_levels``, ``set_labels`` to ``MultiIndex``.
+    (:issue:`4039`)
 
 **API Changes**
 
@@ -66,6 +69,7 @@ pandas 0.13
     an alias of iteritems used to get around ``2to3``'s changes).
     (:issue:`4384`, :issue:`4375`, :issue:`4372`)
   - ``Series.get`` with negative indexers now returns the same as ``[]`` (:issue:`4390`)
+
   - ``HDFStore``
 
     - added an ``is_open`` property to indicate if the underlying file handle is_open;
@@ -82,6 +86,21 @@ pandas 0.13
     - removed the ``warn`` argument from ``open``. Instead a ``PossibleDataLossError`` exception will
       be raised if you try to use ``mode='w'`` with an OPEN file handle (:issue:`4367`)
     - allow a passed locations array or mask as a ``where`` condition (:issue:`4467`)
+
+  - ``Index`` and ``MultiIndex`` changes (:issue:`4039`):
+
+    - Setting ``levels`` and ``labels`` directly on ``MultiIndex`` is now
+      deprecated. Instead, you can use the ``set_levels()`` and
+      ``set_labels()`` methods.
+    - ``levels``, ``labels`` and ``names`` properties no longer return lists,
+      but instead return containers that do not allow setting of items
+      ('mostly immutable')
+    - ``levels``, ``labels`` and ``names`` are validated upon setting and are
+      either copied or shallow-copied.
+    - ``__deepcopy__`` now returns a shallow copy (currently: a view) of the
+      data - allowing metadata changes.
+    - ``MultiIndex.astype()`` now only allows ``np.object_``-like dtypes and
+      now returns a ``MultiIndex`` rather than an ``Index``. (:issue:`4039`)
 
 **Experimental Features**
 
@@ -136,6 +155,10 @@ pandas 0.13
   - frozenset objects now raise in the ``Series`` constructor (:issue:`4482`,
     :issue:`4480`)
   - Fixed issue with sorting a duplicate multi-index that has multiple dtypes (:issue:`4516`)
+  - Fixed bug in ``DataFrame.set_values`` which was causing name attributes to
+    be lost when expanding the index. (:issue:`3742`, :issue:`4039`)
+  - Fixed issue where individual ``names``, ``levels`` and ``labels`` could be
+    set on ``MultiIndex`` without validation (:issue:`3714`, :issue:`4039`)
 
 pandas 0.12
 ===========

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -72,6 +72,24 @@ API changes
          import os
          os.remove(path)
 
+  - Changes to how ``Index`` and ``MultiIndex`` handle metadata (``levels``,
+    ``labels``, and ``names``) (:issue:`4039`):
+
+    ..code-block ::
+
+        # previously, you would have set levels or labels directly
+        index.levels = [[1, 2, 3, 4], [1, 2, 4, 4]]
+
+        # now, you use the set_levels or set_labels methods
+        index = index.set_levels([[1, 2, 3, 4], [1, 2, 4, 4]])
+
+        # similarly, for names, you can rename the object
+        # but setting names is not deprecated.
+        index = index.set_names(["bob", "cranberry"])
+
+        # and all methods take an inplace kwarg
+        index.set_names(["bob", "cranberry"], inplace=True)
+
 Enhancements
 ~~~~~~~~~~~~
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1,7 +1,8 @@
 """
-Base class(es) for all pandas objects.
+Base and utility classes for pandas objects.
 """
 from pandas import compat
+import numpy as np
 
 class StringMixin(object):
     """implements string methods so long as object defines a `__unicode__` method.
@@ -56,3 +57,88 @@ class PandasObject(StringMixin):
         """
         # Should be overwritten by base classes
         return object.__repr__(self)
+
+class FrozenList(PandasObject, list):
+    """
+    Container that doesn't allow setting item *but*
+    because it's technically non-hashable, will be used
+    for lookups, appropriately, etc.
+    """
+    # Sidenote: This has to be of type list, otherwise it messes up PyTables typechecks
+
+    def __add__(self, other):
+        if isinstance(other, tuple):
+            other = list(other)
+        return self.__class__(super(FrozenList, self).__add__(other))
+
+    __iadd__ = __add__
+
+    # Python 2 compat
+    def __getslice__(self, i, j):
+        return self.__class__(super(FrozenList, self).__getslice__(i, j))
+
+    def __getitem__(self, n):
+        # Python 3 compat
+        if isinstance(n, slice):
+            return self.__class__(super(FrozenList, self).__getitem__(n))
+        return super(FrozenList, self).__getitem__(n)
+
+    def __radd__(self, other):
+        if isinstance(other, tuple):
+            other = list(other)
+        return self.__class__(other + list(self))
+
+    def __eq__(self, other):
+        if isinstance(other, (tuple, FrozenList)):
+            other = list(other)
+        return super(FrozenList, self).__eq__(other)
+
+    __req__ = __eq__
+
+    def __mul__(self, other):
+        return self.__class__(super(FrozenList, self).__mul__(other))
+
+    __imul__ = __mul__
+
+    def __hash__(self):
+        return hash(tuple(self))
+
+    def _disabled(self, *args, **kwargs):
+        """This method will not function because object is immutable."""
+        raise TypeError("'%s' does not support mutable operations." %
+                        self.__class__)
+
+    def __unicode__(self):
+        from pandas.core.common import pprint_thing
+        return "%s(%s)" % (self.__class__.__name__,
+                           pprint_thing(self, quote_strings=True,
+                                        escape_chars=('\t', '\r', '\n')))
+
+    __setitem__ = __setslice__ = __delitem__ = __delslice__ = _disabled
+    pop = append = extend = remove = sort = insert = _disabled
+
+
+class FrozenNDArray(PandasObject, np.ndarray):
+
+    # no __array_finalize__ for now because no metadata
+    def __new__(cls, data, dtype=None, copy=False):
+        if copy is None:
+            copy = not isinstance(data, FrozenNDArray)
+        res = np.array(data, dtype=dtype, copy=copy).view(cls)
+        return res
+
+    def _disabled(self, *args, **kwargs):
+        """This method will not function because object is immutable."""
+        raise TypeError("'%s' does not support mutable operations." %
+                        self.__class__)
+
+    __setitem__ = __setslice__ = __delitem__ = __delslice__ = _disabled
+    put = itemset = fill = _disabled
+
+    def _shallow_copy(self):
+        return self.view()
+
+    def values(self):
+        """returns *copy* of underlying array"""
+        arr = self.view(np.ndarray).copy()
+        return arr

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -8,17 +8,15 @@ import csv
 
 from numpy.lib.format import read_array, write_array
 import numpy as np
-
 import pandas.algos as algos
 import pandas.lib as lib
 import pandas.tslib as tslib
 
 from pandas import compat
 from pandas.compat import StringIO, BytesIO, range, long, u, zip, map
-
-
 from pandas.core.config import get_option
 from pandas.core import array as pa
+
 
 # XXX: HACK for NumPy 1.5.1 to suppress warnings
 try:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1150,7 +1150,7 @@ class DataFrame(NDFrame):
             arrays = ix_vals+ [self[c].values for c in self.columns]
 
             count = 0
-            index_names = self.index.names
+            index_names = list(self.index.names)
             if isinstance(self.index, MultiIndex):
                 for i, n in enumerate(index_names):
                     if n is None:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -404,7 +404,7 @@ class PandasContainer(PandasObject):
                 new_axis = axis.drop(labels)
             dropped = self.reindex(**{axis_name: new_axis})
             try:
-                dropped.axes[axis_].names = axis.names
+                dropped.axes[axis_].set_names(axis.names, inplace=True)
             except AttributeError:
                 pass
             return dropped

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -9,7 +9,7 @@ import pandas.lib as lib
 import pandas.algos as _algos
 import pandas.index as _index
 from pandas.lib import Timestamp
-from pandas.core.base import PandasObject
+from pandas.core.base import FrozenList, FrozenNDArray
 
 from pandas.util.decorators import cache_readonly
 from pandas.core.common import isnull
@@ -47,7 +47,7 @@ def _shouldbe_timestamp(obj):
             or tslib.is_timestamp_array(obj))
 
 
-class Index(PandasObject, np.ndarray):
+class Index(FrozenNDArray):
     """
     Immutable ndarray implementing an ordered, sliceable set. The basic object
     storing axis labels for all pandas objects
@@ -313,7 +313,7 @@ class Index(PandasObject, np.ndarray):
         """
         Index is not mutable, so disabling deepcopy
         """
-        return self
+        return self._shallow_copy()
 
     def __contains__(self, key):
         hash(key)
@@ -325,9 +325,6 @@ class Index(PandasObject, np.ndarray):
 
     def __hash__(self):
         return hash(self.view(np.ndarray))
-
-    def __setitem__(self, key, value):
-        raise TypeError(str(self.__class__) + ' does not support item assignment')
 
     def __getitem__(self, key):
         """Override numpy.ndarray's __getitem__ method to work as desired"""

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -92,8 +92,8 @@ class _Unstacker(object):
     def _make_sorted_values_labels(self):
         v = self.level
 
-        labs = self.index.labels
-        levs = self.index.levels
+        labs = list(self.index.labels)
+        levs = list(self.index.levels)
         to_sort = labs[:v] + labs[v + 1:] + [labs[v]]
         sizes = [len(x) for x in levs[:v] + levs[v + 1:] + [levs[v]]]
 
@@ -206,8 +206,8 @@ class _Unstacker(object):
         width = len(self.value_columns)
         propagator = np.repeat(np.arange(width), stride)
         if isinstance(self.value_columns, MultiIndex):
-            new_levels = self.value_columns.levels + [self.removed_level]
-            new_names = self.value_columns.names + [self.removed_name]
+            new_levels = self.value_columns.levels + (self.removed_level,)
+            new_names = self.value_columns.names + (self.removed_name,)
 
             new_labels = [lab.take(propagator)
                           for lab in self.value_columns.labels]

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1309,16 +1309,31 @@ class Series(generic.PandasContainer, pa.Array):
         """
         return self.view(ndarray)
 
-    def copy(self, order='C'):
+    def copy(self, order='C', deep=False):
         """
         Return new Series with copy of underlying values
+
+        Parameters
+        ----------
+        deep : boolean, default False
+            deep copy index along with data
+        order : boolean, default 'C'
+            order for underlying numpy array
 
         Returns
         -------
         cp : Series
         """
-        return Series(self.values.copy(order), index=self.index,
-                      name=self.name)
+        if deep:
+            from copy import deepcopy
+            index = self.index.copy(deep=deep)
+            name = deepcopy(self.name)
+        else:
+            index = self.index
+            name = self.name
+
+        return Series(self.values.copy(order), index=index,
+                      name=name)
 
     def tolist(self):
         """

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -774,7 +774,7 @@ class ParserBase(object):
         # add names for the index
         if indexnamerow:
             coffset = len(indexnamerow) - len(columns)
-            index.names = indexnamerow[:coffset]
+            index = index.set_names(indexnamerow[:coffset])
 
         # maybe create a mi on the columns
         columns = self._maybe_make_multi_index_columns(columns, self.col_names)

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -675,7 +675,7 @@ class ExcelTests(unittest.TestCase):
             recons = reader.parse('test1', index_col=[0, 1])
 
             tm.assert_frame_equal(tsframe, recons, check_names=False)
-            self.assertEquals(recons.index.names, ['time', 'foo'])
+            self.assertEquals(recons.index.names, ('time', 'foo'))
 
             # infer index
             tsframe.to_excel(path, 'test1')

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -821,7 +821,7 @@ c,4,5
         levels[0] = lev.to_datetime(dayfirst=True)
         # hack to get this to work - remove for final test
         levels[0].name = lev.name
-        expected.index.levels = levels
+        expected.index.set_levels(levels, inplace=True)
         expected['aux_date'] = to_datetime(expected['aux_date'],
                                            dayfirst=True)
         expected['aux_date'] = lmap(Timestamp, expected['aux_date'])
@@ -1339,7 +1339,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 
         # it works!
         df = self.read_table(StringIO(text), sep='\s+')
-        self.assertEquals(df.index.names, ['one', 'two', 'three', 'four'])
+        self.assertEquals(df.index.names, ('one', 'two', 'three', 'four'))
 
     def test_read_csv_parse_simple_list(self):
         text = """foo

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -817,7 +817,11 @@ c,4,5
         expected = self.read_csv(StringIO(data), sep=";", index_col=lrange(4))
 
         lev = expected.index.levels[0]
-        expected.index.levels[0] = lev.to_datetime(dayfirst=True)
+        levels = list(expected.index.levels)
+        levels[0] = lev.to_datetime(dayfirst=True)
+        # hack to get this to work - remove for final test
+        levels[0].name = lev.name
+        expected.index.levels = levels
         expected['aux_date'] = to_datetime(expected['aux_date'],
                                            dayfirst=True)
         expected['aux_date'] = lmap(Timestamp, expected['aux_date'])
@@ -2144,14 +2148,14 @@ a,b,c
 4,5,6
 7,8,9
 10,11,12"""
-        result = self.read_csv(StringIO(data), usecols=(0, 1, 2), 
-                               names=('a', 'b', 'c'), 
+        result = self.read_csv(StringIO(data), usecols=(0, 1, 2),
+                               names=('a', 'b', 'c'),
                                header=None,
                                converters={'a': str},
                                dtype={'b': int, 'c': float},
-                              )                               
+                              )
         result2 = self.read_csv(StringIO(data), usecols=(0, 2),
-                               names=('a', 'b', 'c'), 
+                               names=('a', 'b', 'c'),
                                header=None,
                                converters={'a': str},
                                dtype={'b': int, 'c': float},

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -1921,7 +1921,7 @@ class TestHDFStore(unittest.TestCase):
         with ensure_clean(self.path) as store:
             store['frame'] = frame
             recons = store['frame']
-            assert(recons.index.names == ['foo', 'bar'])
+            assert(recons.index.names == ('foo', 'bar'))
 
     def test_store_index_name(self):
         df = tm.makeDataFrame()

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -1,0 +1,108 @@
+import re
+import unittest
+import numpy as np
+from pandas.core.base import FrozenList, FrozenNDArray
+from pandas.util.testing import assertRaisesRegexp, assert_isinstance
+
+
+class CheckImmutable(object):
+    mutable_regex = re.compile('does not support mutable operations')
+
+    def check_mutable_error(self, *args, **kwargs):
+        # pass whatever functions you normally would to assertRaises (after the Exception kind)
+        assertRaisesRegexp(TypeError, self.mutable_regex, *args, **kwargs)
+
+    def test_no_mutable_funcs(self):
+        def setitem(): self.container[0] = 5
+
+        self.check_mutable_error(setitem)
+
+        def setslice(): self.container[1:2] = 3
+
+        self.check_mutable_error(setslice)
+
+        def delitem(): del self.container[0]
+
+        self.check_mutable_error(delitem)
+
+        def delslice(): del self.container[0:3]
+
+        self.check_mutable_error(delslice)
+        mutable_methods = getattr(self, "mutable_methods", [])
+        for meth in mutable_methods:
+            self.check_mutable_error(getattr(self.container, meth))
+
+    def test_slicing_maintains_type(self):
+        result = self.container[1:2]
+        expected = self.lst[1:2]
+        self.check_result(result, expected)
+
+    def check_result(self, result, expected, klass=None):
+        klass = klass or self.klass
+        assert_isinstance(result, klass)
+        self.assertEqual(result, expected)
+
+
+class TestFrozenList(CheckImmutable, unittest.TestCase):
+    mutable_methods = ('extend', 'pop', 'remove', 'insert')
+
+    def setUp(self):
+        self.lst = [1, 2, 3, 4, 5]
+        self.container = FrozenList(self.lst)
+        self.klass = FrozenList
+
+    def test_add(self):
+        result = self.container + (1, 2, 3)
+        expected = FrozenList(self.lst + [1, 2, 3])
+        self.check_result(result, expected)
+
+        result = (1, 2, 3) + self.container
+        expected = FrozenList([1, 2, 3] + self.lst)
+        self.check_result(result, expected)
+
+    def test_inplace(self):
+        q = r = self.container
+        q += [5]
+        self.check_result(q, self.lst + [5])
+        # other shouldn't be mutated
+        self.check_result(r, self.lst)
+
+
+class TestFrozenNDArray(CheckImmutable, unittest.TestCase):
+    mutable_methods = ('put', 'itemset', 'fill')
+
+    def setUp(self):
+        self.lst = [3, 5, 7, -2]
+        self.container = FrozenNDArray(self.lst)
+        self.klass = FrozenNDArray
+
+    def test_shallow_copying(self):
+        original = self.container.copy()
+        assert_isinstance(self.container.view(), FrozenNDArray)
+        self.assert_(not isinstance(self.container.view(np.ndarray), FrozenNDArray))
+        self.assert_(self.container.view() is not self.container)
+        self.assert_(np.array_equal(self.container, original))
+        # shallow copy should be the same too
+        assert_isinstance(self.container._shallow_copy(), FrozenNDArray)
+        # setting should not be allowed
+        def testit(container): container[0] = 16
+
+        self.check_mutable_error(testit, self.container)
+
+    def test_values(self):
+        original = self.container.view(np.ndarray).copy()
+        n = original[0] + 15
+        vals = self.container.values()
+        self.assert_(np.array_equal(original, vals))
+        self.assert_(original is not vals)
+        vals[0] = n
+        self.assert_(np.array_equal(self.container, original))
+        self.assertEqual(vals[0], n)
+
+
+if __name__ == '__main__':
+    import nose
+
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   # '--with-coverage', '--cover-package=pandas.core'],
+                   exit=False)

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -9,6 +9,7 @@ import numpy as np
 from pandas.tslib import iNaT
 
 from pandas import Series, DataFrame, date_range, DatetimeIndex, Timestamp
+import pandas.compat as compat
 from pandas.compat import range, long, lrange, lmap, u
 from pandas.core.common import notnull, isnull
 import pandas.compat as compat

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -1,21 +1,20 @@
 from datetime import datetime
 import re
+import unittest
 
 import nose
 from nose.tools import assert_equal
 import unittest
+import numpy as np
+from pandas.tslib import iNaT
 
 from pandas import Series, DataFrame, date_range, DatetimeIndex, Timestamp
 from pandas.compat import range, long, lrange, lmap, u
 from pandas.core.common import notnull, isnull
+import pandas.compat as compat
 import pandas.core.common as com
 import pandas.util.testing as tm
 import pandas.core.config as cf
-
-import numpy as np
-
-from pandas.tslib import iNaT
-from pandas import compat
 
 _multiprocess_can_split_ = True
 
@@ -781,6 +780,7 @@ class TestTake(unittest.TestCase):
         expected = arr.take(indexer, axis=1)
         expected[:, [2, 4]] = datetime(2007, 1, 1)
         tm.assert_almost_equal(result, expected)
+
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3526,7 +3526,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         # MultiIndex
         result = DataFrame.from_records(documents,
                                         index=['order_id', 'quantity'])
-        self.assert_(result.index.names == ['order_id', 'quantity'])
+        self.assert_(result.index.names == ('order_id', 'quantity'))
 
     def test_from_records_misc_brokenness(self):
         # #2179
@@ -7239,7 +7239,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         # don't specify values
         pivoted = frame.pivot(index='index', columns='columns')
         self.assertEqual(pivoted.index.name, 'index')
-        self.assertEqual(pivoted.columns.names, [None, 'columns'])
+        self.assertEqual(pivoted.columns.names, (None, 'columns'))
 
         # pivot multiple columns
         wp = tm.makePanel()

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5920,14 +5920,15 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         assert_series_equal(result, expected)
 
     def test_drop_names(self):
-        df = DataFrame([[1, 2, 3],[3, 4, 5],[5, 6, 7]], index=['a', 'b', 'c'], columns=['d', 'e', 'f'])
+        df = DataFrame([[1, 2, 3],[3, 4, 5],[5, 6, 7]], index=['a', 'b', 'c'],
+                       columns=['d', 'e', 'f'])
         df.index.name, df.columns.name = 'first', 'second'
         df_dropped_b = df.drop('b')
         df_dropped_e = df.drop('e', axis=1)
-        self.assert_(df_dropped_b.index.name == 'first')
-        self.assert_(df_dropped_e.index.name == 'first')
-        self.assert_(df_dropped_b.columns.name == 'second')
-        self.assert_(df_dropped_e.columns.name == 'second')
+        self.assertEqual(df_dropped_b.index.name, 'first')
+        self.assertEqual(df_dropped_e.index.name, 'first')
+        self.assertEqual(df_dropped_b.columns.name, 'second')
+        self.assertEqual(df_dropped_e.columns.name, 'second')
 
     def test_dropEmptyRows(self):
         N = len(self.frame.index)

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -1283,13 +1283,13 @@ class TestGroupBy(unittest.TestCase):
             return result
 
         result = grouped.apply(desc)
-        self.assertEquals(result.index.names, ['A', 'B', 'stat'])
+        self.assertEquals(result.index.names, ('A', 'B', 'stat'))
 
         result2 = grouped.apply(desc2)
-        self.assertEquals(result2.index.names, ['A', 'B', 'stat'])
+        self.assertEquals(result2.index.names, ('A', 'B', 'stat'))
 
         result3 = grouped.apply(desc3)
-        self.assertEquals(result3.index.names, ['A', 'B', None])
+        self.assertEquals(result3.index.names, ('A', 'B', None))
 
     def test_nonsense_func(self):
         df = DataFrame([0])
@@ -1519,7 +1519,7 @@ class TestGroupBy(unittest.TestCase):
 
     def test_apply_series_yield_constant(self):
         result = self.df.groupby(['A', 'B'])['C'].apply(len)
-        self.assertEquals(result.index.names[:2], ['A', 'B'])
+        self.assertEquals(result.index.names[:2], ('A', 'B'))
 
     def test_apply_frame_to_series(self):
         grouped = self.df.groupby(['A', 'B'])
@@ -1836,7 +1836,7 @@ class TestGroupBy(unittest.TestCase):
         result = self.df.groupby([self.df['A'], self.df['B']]).mean()
         result2 = self.df.groupby([self.df['A'], self.df['B']],
                                   as_index=False).mean()
-        self.assertEquals(result.index.names, ['A', 'B'])
+        self.assertEquals(result.index.names, ('A', 'B'))
         self.assert_('A' in result2)
         self.assert_('B' in result2)
 
@@ -2332,7 +2332,7 @@ class TestGroupBy(unittest.TestCase):
 
         result = self.df.groupby([self.df['A'].values,
                                   self.df['B'].values]).sum()
-        self.assert_(result.index.names == [None, None])
+        self.assert_(result.index.names == (None, None))
 
     def test_groupby_categorical(self):
         levels = ['foo', 'bar', 'baz', 'qux']

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -57,7 +57,8 @@ class TestIndex(unittest.TestCase):
         from copy import deepcopy
 
         copy = deepcopy(self.strIndex)
-        self.assert_(copy is self.strIndex)
+        self.assert_(copy is not self.strIndex)
+        self.assert_(copy.equals(self.strIndex))
 
     def test_duplicates(self):
         idx = Index([0, 0, 0])

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -55,9 +55,11 @@ class TestMultiLevel(unittest.TestCase):
                                      lambda x: x.day]).sum()
 
         # use Int64Index, to make sure things work
-        self.ymd.index.levels = [lev.astype('i8')
-                                 for lev in self.ymd.index.levels]
-        self.ymd.index.names = ['year', 'month', 'day']
+        self.ymd.index.set_levels([lev.astype('i8')
+                                 for lev in self.ymd.index.levels],
+                                 inplace=True)
+        self.ymd.index.set_names(['year', 'month', 'day'],
+                                 inplace=True)
 
     def test_append(self):
         a, b = self.frame[:5], self.frame[5:]
@@ -1667,7 +1669,7 @@ Thur,Lunch,Yes,51.51,17"""
         df = DataFrame(np.random.randn(6, 3), index=index)
 
         result = df.drop([(0, 2)])
-        self.assert_(result.index.names == ['one', 'two'])
+        self.assert_(result.index.names == ('one', 'two'))
 
     def test_unicode_repr_issues(self):
         levels = [Index([u('a/\u03c3'), u('b/\u03c3'), u('c/\u03c3')]),

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1255,7 +1255,8 @@ class TestPanel(unittest.TestCase, PanelTests, CheckIndexing,
         lp = panel.to_frame()
         wp = lp.to_panel()
         self.assertEqual(wp['bool'].values.dtype, np.bool_)
-        assert_frame_equal(wp['bool'], panel['bool'])
+        # Previously, this was mutating the underlying index and changing its name
+        assert_frame_equal(wp['bool'], panel['bool'], check_names=False)
 
     def test_to_panel_na_handling(self):
         df = DataFrame(np.random.randint(0, 10, size=20).reshape((10, 2)),

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1227,7 +1227,7 @@ class TestPanel(unittest.TestCase, PanelTests, CheckIndexing,
         assert_panel_equal(unfiltered.to_panel(), self.panel)
 
         # names
-        self.assertEqual(unfiltered.index.names, ['major', 'minor'])
+        self.assertEqual(unfiltered.index.names, ('major', 'minor'))
 
         # unsorted, round trip
         df = self.panel.to_frame(filter_observations=False)

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -898,7 +898,7 @@ class TestPanel4d(unittest.TestCase, CheckIndexing, SafeForSparse,
     #    assert_panel_equal(unfiltered.to_panel(), self.panel)
 
     #    # names
-    #    self.assertEqual(unfiltered.index.names, ['major', 'minor'])
+    #    self.assertEqual(unfiltered.index.names, ('major', 'minor'))
 
     def test_to_frame_mixed(self):
         raise nose.SkipTest

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -217,7 +217,7 @@ def _add_margins(table, data, values, rows=None, cols=None, aggfunc=np.mean):
 
     row_names = result.index.names
     result = result.append(margin_dummy)
-    result.index.names = row_names
+    result.index = result.index.set_names(row_names)
 
     return result
 

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -1299,7 +1299,7 @@ class TestConcatenate(unittest.TestCase):
                           columns=Index(['A', 'B', 'C'], name='exp'))
         result = concat([frame, frame], keys=[0, 1], names=['iteration'])
 
-        self.assertEqual(result.index.names, ['iteration'] + index.names)
+        self.assertEqual(result.index.names, ('iteration',) + index.names)
         tm.assert_frame_equal(result.ix[0], frame)
         tm.assert_frame_equal(result.ix[1], frame)
         self.assertEqual(result.index.nlevels, 3)
@@ -1330,14 +1330,14 @@ class TestConcatenate(unittest.TestCase):
                         keys=[('foo', 'one'), ('foo', 'two'),
                               ('baz', 'one'), ('baz', 'two')],
                         levels=levels)
-        self.assertEqual(result.index.names, [None] * 3)
+        self.assertEqual(result.index.names, (None,) * 3)
 
         # no levels
         result = concat([df, df2, df, df2],
                         keys=[('foo', 'one'), ('foo', 'two'),
                               ('baz', 'one'), ('baz', 'two')],
                         names=['first', 'second'])
-        self.assertEqual(result.index.names, ['first', 'second'] + [None])
+        self.assertEqual(result.index.names, ('first', 'second') + (None,))
         self.assert_(np.array_equal(result.index.levels[0], ['baz', 'foo']))
 
     def test_concat_keys_levels_no_overlap(self):
@@ -1363,7 +1363,9 @@ class TestConcatenate(unittest.TestCase):
                         names=['lvl0', 'lvl1'])
 
         exp = concat([a, b], keys=['key0', 'key1'], names=['lvl0'])
-        exp.index.names[1] = 'lvl1'
+        names = list(exp.index.names)
+        names[1] = 'lvl1'
+        exp.index.set_names(names, inplace=True)
 
         tm.assert_frame_equal(result, exp)
         self.assertEqual(result.index.names, exp.index.names)
@@ -1391,7 +1393,7 @@ class TestConcatenate(unittest.TestCase):
         df2 = DataFrame(np.random.randn(1, 4), index=['b'])
         result = concat(
             [df, df2], keys=['one', 'two'], names=['first', 'second'])
-        self.assertEqual(result.index.names, ['first', 'second'])
+        self.assertEqual(result.index.names, ('first', 'second'))
 
     def test_handle_empty_objects(self):
         df = DataFrame(np.random.randn(10, 4), columns=list('abcd'))

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -42,7 +42,7 @@ class TestPivotTable(unittest.TestCase):
         pivot_table(self.data, values='D', rows=rows)
 
         if len(rows) > 1:
-            self.assertEqual(table.index.names, rows)
+            self.assertEqual(table.index.names, tuple(rows))
         else:
             self.assertEqual(table.index.name, rows[0])
 
@@ -365,7 +365,7 @@ class TestCrosstab(unittest.TestCase):
         result = crosstab(a, [b, c], rownames=['a'], colnames=('b', 'c'),
                           margins=True)
 
-        self.assertEqual(result.index.names, ['a'])
+        self.assertEqual(result.index.names, ('a',))
         self.assertEqual(result.columns.names, ['b', 'c'])
 
         all_cols = result['All', '']

--- a/pandas/util/decorators.py
+++ b/pandas/util/decorators.py
@@ -4,8 +4,8 @@ import sys
 import warnings
 
 
-def deprecate(name, alternative):
-    alt_name = alternative.__name__
+def deprecate(name, alternative, alt_name=None):
+    alt_name = alt_name or alternative.__name__
 
     def wrapper(*args, **kwargs):
         warnings.warn("%s is deprecated. Use %s instead" % (name, alt_name),

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -176,7 +176,9 @@ def assert_almost_equal(a, b, check_less_precise=False):
         np.testing.assert_(isiterable(b))
         na, nb = len(a), len(b)
         assert na == nb, "%s != %s" % (na, nb)
-
+        # TODO: Figure out why I thought this needed instance cheacks...
+        # if (isinstance(a, np.ndarray) and isinstance(b, np.ndarray) and
+        #     np.array_equal(a, b)):
         if np.array_equal(a, b):
             return True
         else:
@@ -320,6 +322,18 @@ assert_panel4d_equal = partial(assert_panelnd_equal,
 def assert_contains_all(iterable, dic):
     for k in iterable:
         assert k in dic, "Did not contain item: '%r'" % k
+
+def assert_copy(iter1, iter2, **eql_kwargs):
+    """
+    iter1, iter2: iterables that produce elements comparable with assert_almost_equal
+
+    Checks that the elements are equal, but not the same object. (Does not
+    check that items in sequences are also not the same object)
+    """
+    for elem1, elem2 in zip(iter1, iter2):
+        assert_almost_equal(elem1, elem2, **eql_kwargs)
+        assert elem1 is not elem2, "Expected object %r and object %r to be different objects, were same." % (
+                                    type(elem1), type(elem2))
 
 
 def getCols(k):


### PR DESCRIPTION
This PR covers:

Fixes: #4202, #3714, #3742 (there are might be some others, but I've blanked on them...)

Bug fixes:
- `MultiIndex` preserves names as much as possible and it's now harder to overwrite index metadata by making changes down the line.
- `set_values` no longer messes up names.

External API Changes:
- Names, levels and labels are now validated each time and 'mostly' immutable.
- names, levels and labels produce containers that are immutable (using new containers `FrozenList` and `FrozenNDArray`)
- `MultiIndex` now shallow copies levels and labels before storing them.
- Adds `astype` method to `MultiIndex` to resolve issue with `set_values` in `NDFrame`
- Direct setting of levels and labels is "deprecated" with a setter that raises a DeprecationWarning (but still functions)
- New `set_names`, `set_labels`, and `set_levels` methods allow setting of these attributes and take an `inplace=True` keyword argument to mutate in place.
- `Index` has a `rename` method that works similarly to the `set_*` methods.
- Improved exceptions on `Index` methods to be more descriptive / more specific (e.g., replacing `Exception` with `ValueError`, etc.)
- `Index.copy()` now accepts keyword arguments (`name=`,`names=`, `levels=`, `labels=`,) which return a new copy with those attributes set. It also accepts `deep`, which is there for compatibility with other `copy()` methods, but doesn't actually change what copy does (though, for MultiIndex, it makes the copy operation slower)

Internal changes:
- `MultiIndex` now uses `_set_levels`, `_get_levels`, `_set_labels`, `_get_labels` internally to handle labels and levels (and uses that directly in `__array_finalize__` and `__setstate__`, etc.)
- `MultiIndex.copy(deep=True)` will deepcopy levels, labels, and names.
- `Index` objects handle names with `_set_names` and `_get_names`.
- `Index` now inherits from `FrozenNDArray` which (mostly) blocks mutable methods (except for `view()` and `reshape()`)
- `Index` now actually copies ndarrays when copy=True is passed to constructor and dtype=None
