### PR TITLE
Ensure accurate encoding/decoding of big and small floats

### DIFF
--- a/pandas/io/tests/test_json/test_ujson.py
+++ b/pandas/io/tests/test_json/test_ujson.py
@@ -104,6 +104,30 @@ class UltraJSONTests(TestCase):
         decoded = ujson.decode(encoded, precise_float=True)
         self.assertEqual(sut, decoded)
 
+    def test_decimalDecodeTestPreciseDoubleBig(self):
+        sut = {u'a': 4.56e300}
+        encoded = ujson.encode(sut)
+        decoded = ujson.decode(encoded, precise_float=True)
+        self.assertEqual(sut, decoded)
+
+    def test_decimalDecodeTestPreciseDoubleSmall(self):
+        sut = {u'a': 4.56e-300}
+        encoded = ujson.encode(sut)
+        decoded = ujson.decode(encoded, precise_float=True)
+        self.assertEqual(sut, decoded)
+
+    def test_decimalDecodeTestPreciseSingleBig(self):
+        sut = {u'a': 4.56e35}
+        encoded = ujson.encode(sut)
+        decoded = ujson.decode(encoded, precise_float=True)
+        self.assertEqual(sut, decoded)
+
+    def test_decimalDecodeTestPreciseSingleSmall(self):
+        sut = {u'a': 4.56e-35}
+        encoded = ujson.encode(sut)
+        decoded = ujson.decode(encoded, precise_float=True)
+        self.assertEqual(sut, decoded)
+
     def test_encodeDictWithUnicodeKeys(self):
         input = { u"key1": u"value1", u"key1": u"value1", u"key1": u"value1", u"key1": u"value1", u"key1": u"value1", u"key1": u"value1" }
         output = ujson.encode(input)
@@ -1415,6 +1439,26 @@ class PandasJSONTests(TestCase):
         self.assertEquals(1.7893, ujson.loads("1.7893"))
         self.assertEquals(1.893, ujson.loads("1.893"))
         self.assertEquals(1.3, ujson.loads("1.3"))
+
+        self.assertEquals(1.1234567893e-300, ujson.loads("1.1234567893e-300"))
+        self.assertEquals(1.234567893e-300, ujson.loads("1.234567893e-300"))
+        self.assertEquals(1.34567893e-300, ujson.loads("1.34567893e-300"))
+        self.assertEquals(1.4567893e-300, ujson.loads("1.4567893e-300"))
+        self.assertEquals(1.567893e-300, ujson.loads("1.567893e-300"))
+        self.assertEquals(1.67893e-300, ujson.loads("1.67893e-300"))
+        self.assertEquals(1.7893e-300, ujson.loads("1.7893e-300"))
+        self.assertEquals(1.893e-300, ujson.loads("1.893e-300"))
+        self.assertEquals(1.3e-300, ujson.loads("1.3e-300"))
+
+        self.assertEquals(1.1234567893e300, ujson.loads("1.1234567893e300"))
+        self.assertEquals(1.234567893e300, ujson.loads("1.234567893e300"))
+        self.assertEquals(1.34567893e300, ujson.loads("1.34567893e300"))
+        self.assertEquals(1.4567893e300, ujson.loads("1.4567893e300"))
+        self.assertEquals(1.567893e300, ujson.loads("1.567893e300"))
+        self.assertEquals(1.67893e300, ujson.loads("1.67893e300"))
+        self.assertEquals(1.7893e300, ujson.loads("1.7893e300"))
+        self.assertEquals(1.893e300, ujson.loads("1.893e300"))
+        self.assertEquals(1.3e300, ujson.loads("1.3e300"))
 
     def test_encodeBigSet(self):
         s = set()


### PR DESCRIPTION
ujson has trouble with very big, and especially very small, floats:

esnme/ultrajson#69
esnme/ultrajson#83
esnme/ultrajson#90

From: https://github.com/pydata/pandas/pull/1263#issuecomment-20024006

```
>>> import ujson
>>> ujson.dumps(1e-40)
'0.0'
>>> ujson.dumps(1e-40, double_precision=17)
'0.0'
```

I believe this makes ujson inappropriate for inclusion in pandas. 

This pull requests adds tests that ujson should, but won't, completely pass. I don't feel yet sufficiently familiar with pandas' design to substitute in (e.g.) simplejson.
