### PR TITLE
TST: remove test_yahoo options test skipping

### DIFF
--- a/pandas/io/tests/test_yahoo.py
+++ b/pandas/io/tests/test_yahoo.py
@@ -104,9 +104,6 @@ class TestYahoo(unittest.TestCase):
         except ImportError:
             raise nose.SkipTest
 
-        ##### FAILING #####
-        raise nose.SkipTest('this test is currently failing')
-
         # aapl has monthlies
         aapl = web.Options('aapl', 'yahoo')
         today = datetime.today()


### PR DESCRIPTION
closes #4028

just a reversal of the warnings - seem ok now
