### PR TITLE
TST/BUG: fix 2to3 import rewrite of import pickle

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -294,6 +294,8 @@ pandas 0.12
   - ``Series.hist`` will now take the figure from the current environment if
     one is not passed
   - Fixed bug where a 1xN DataFrame would barf on a 1xN mask (:issue:`4071`)
+  - Fixed running of ``tox`` under python3 where the pickle import was getting
+    rewritten in an incompatible way (:issue:`4062`, :issue:`4063`)
 
 
 pandas 0.11.0

--- a/doc/source/v0.12.0.txt
+++ b/doc/source/v0.12.0.txt
@@ -437,6 +437,8 @@ Bug Fixes
   - ``Series.hist`` will now take the figure from the current environment if
     one is not passed
   - Fixed bug where a 1xN DataFrame would barf on a 1xN mask (:issue:`4071`)
+  - Fixed running of ``tox`` under python3 where the pickle import was getting
+    rewritten in an incompatible way (:issue:`4062`, :issue:`4063`)
 
 See the :ref:`full release notes
 <release>` or issue tracker

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -1,8 +1,5 @@
-# XXX: HACK for NumPy 1.5.1 to suppress warnings
-try:
-    import cPickle as pickle
-except ImportError:  # pragma: no cover
-    import pickle
+import cPickle as pkl
+
 
 def to_pickle(obj, path):
     """
@@ -14,11 +11,9 @@ def to_pickle(obj, path):
     path : string
         File path
     """
-    f = open(path, 'wb')
-    try:
-        pickle.dump(obj, f, protocol=pickle.HIGHEST_PROTOCOL)
-    finally:
-        f.close()
+    with open(path, 'wb') as f:
+        pkl.dump(obj, f, protocol=pkl.HIGHEST_PROTOCOL)
+
 
 def read_pickle(path):
     """
@@ -38,11 +33,11 @@ def read_pickle(path):
     unpickled : type of object stored in file
     """
     try:
-        with open(path,'rb') as fh:
-            return pickle.load(fh)
+        with open(path, 'rb') as fh:
+            return pkl.load(fh)
     except:
-        from pandas.util import py3compat
-        if not py3compat.PY3:
-            raise
-        with open(path,'rb') as fh:
-            return pickle.load(fh, encoding='latin1')
+        from pandas.util.py3compat import PY3
+        if PY3:
+            with open(path, 'rb') as fh:
+                return pkl.load(fh, encoding='latin1')
+        raise

--- a/tox_prll.sh
+++ b/tox_prll.sh
@@ -25,3 +25,4 @@ for e in $ENVS; do
     echo "[launching tox for $e]"
     tox -c "$TOX_INI_PAR" -e "$e" &
 done
+wait


### PR DESCRIPTION
In pandas.io.pickle the following statement will not allow python to import 
anything due to the following rewrite by 2to3

import pickle -> from . import pickle

This makes the import try to import itself ad infinitum and thus fails.

closes #4062
