### PR TITLE
PERF: optimize iloc for unique case

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1981,7 +1981,8 @@ class DataFrame(NDFrame):
                 if isinstance(label, Index):
 
                     # a location index by definition
-                    return self.reindex(label, takeable=True)
+                    i = _maybe_convert_indices(i, len(self._get_axis(axis)))
+                    return self.reindex(i, takeable=True)
                 else:
                     try:
                         new_values = self._data.fast_2d_xs(i, copy=copy)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -938,15 +938,23 @@ class Index(np.ndarray):
             _, indexer, _ = self._join_level(target, level, how='right',
                                              return_indexers=True)
         else:
+
             if self.equals(target):
                 indexer = None
-
+                
                 # to avoid aliasing an existing index
                 if copy_if_needed and target.name != self.name and self.name is not None:
                     if target.name is None:
                         target = self.copy()
 
             else:
+
+                if takeable:
+                    if method is not None or limit is not None:
+                        raise ValueError("cannot do a takeable reindex with "
+                                         "with a method or limit")
+                    return self[target], target
+
                 if self.is_unique:
                     indexer = self.get_indexer(target, method=method,
                                                limit=limit)
@@ -954,11 +962,7 @@ class Index(np.ndarray):
                     if method is not None or limit is not None:
                         raise ValueError("cannot reindex a non-unique index "
                                          "with a method or limit")
-                    if takeable:
-                        indexer = target
-                        missing = (target>=len(target)).nonzero()[0]
-                    else:
-                        indexer, missing = self.get_indexer_non_unique(target)
+                    indexer, _ = self.get_indexer_non_unique(target)
 
         return target, indexer
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -21,7 +21,8 @@ from pandas.core.common import (isnull, notnull, _is_bool_indexer,
                                 _NS_DTYPE, _TD_DTYPE)
 from pandas.core.index import (Index, MultiIndex, InvalidIndexError,
                                _ensure_index, _handle_legacy_indexes)
-from pandas.core.indexing import _SeriesIndexer, _check_bool_indexer, _check_slice_bounds
+from pandas.core.indexing import (_SeriesIndexer, _check_bool_indexer,
+                                  _check_slice_bounds, _maybe_convert_indices)
 from pandas.tseries.index import DatetimeIndex
 from pandas.tseries.period import PeriodIndex, Period
 from pandas.util import py3compat
@@ -598,7 +599,8 @@ class Series(pa.Array, generic.PandasObject):
             else:
                 label = self.index[i]
                 if isinstance(label, Index):
-                    return self.reindex(label, takeable=True)
+                    i = _maybe_convert_indices(i, len(self))
+                    return self.reindex(i, takeable=True)
                 else:
                     return _index.get_value_at(self, i)
 


### PR DESCRIPTION
related #4017, #4018

optimize the iloc case (which should be the same for unique and non-unique indicies)

```
In [1]: df = DataFrame({'A' : [0.1] * 30000000, 'B' : [1] * 30000000})

In [6]: idx = np.array(range(30000)) * 99

In [7]: df2 = DataFrame({'A' : [0.1] * 10000000, 'B' : [1] * 10000000})

In [8]: df2 = concat([df2, df2, df2])

In [9]: %timeit df.iloc[idx]
1000 loops, best of 3: 1.49 ms per loop

In [10]: %timeit df2.iloc[idx]
1000 loops, best of 3: 1.41 ms per loop
```
