### PR TITLE
ENH: add dropna argument to pivot_table

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -72,6 +72,7 @@ pandas 0.12
     - support python3 (via ``PyTables 3.0.0``) (:issue:`3750`)
   - Add modulo operator to Series, DataFrame
   - Add ``date`` method to DatetimeIndex
+  - Add ``dropna`` argument to pivot_table (:issue: `3820`) 
   - Simplified the API and added a describe method to Categorical
   - ``melt`` now accepts the optional parameters ``var_name`` and ``value_name``
     to specify custom column names of the returned DataFrame (:issue:`3649`),

--- a/pandas/tools/tests/test_util.py
+++ b/pandas/tools/tests/test_util.py
@@ -1,0 +1,21 @@
+import os
+import nose
+import unittest
+
+import numpy as np
+from numpy.testing import assert_equal
+
+from pandas.tools.util import cartesian_product
+
+class TestCartesianProduct(unittest.TestCase):
+
+    def test_simple(self):
+        x, y = list('ABC'), [1, 22]
+        result = cartesian_product([x, y])
+        expected = [np.array(['A', 'A', 'B', 'B', 'C', 'C']),
+                    np.array([ 1, 22,  1, 22,  1, 22])]
+        assert_equal(result, expected)
+
+if __name__ == '__main__':
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   exit=False)

--- a/pandas/tools/util.py
+++ b/pandas/tools/util.py
@@ -18,11 +18,15 @@ def cartesian_product(X):
  	array([1, 2, 1, 2, 1, 2])]
 
     '''
-    lenX = map(len, X)
-    cumprodX = np.cumproduct(lenX)
-    a = np.insert(cumprodX, 0, 1)
-    b = a[-1] / a[1:]
-    return [np.tile(np.repeat(x, b[i]), 
-    	            np.product(a[i]))
-               for i, x in enumerate(X)]
 
+    lenX = np.fromiter((len(x) for x in X), dtype=int)
+    cumprodX = np.cumproduct(lenX)
+
+    a = np.roll(cumprodX, 1)
+    a[0] = 1
+
+    b = cumprodX[-1] / cumprodX
+
+    return [np.tile(np.repeat(x, b[i]), 
+                    np.product(a[i]))
+               for i, x in enumerate(X)]

--- a/pandas/tools/util.py
+++ b/pandas/tools/util.py
@@ -1,6 +1,28 @@
 from pandas.core.index import Index
+import numpy as np
 
 def match(needles, haystack):
     haystack = Index(haystack)
     needles = Index(needles)
     return haystack.get_indexer(needles)
+
+def cartesian_product(X):
+    '''
+    Numpy version of itertools.product or pandas.util.compat.product.
+    Sometimes faster (for large inputs)...
+
+    Examples
+    --------
+    >>> cartesian_product([list('ABC'), [1, 2]])
+    [array(['A', 'A', 'B', 'B', 'C', 'C'], dtype='|S1'),
+ 	array([1, 2, 1, 2, 1, 2])]
+
+    '''
+    lenX = map(len, X)
+    cumprodX = np.cumproduct(lenX)
+    a = np.insert(cumprodX, 0, 1)
+    b = a[-1] / a[1:]
+    return [np.tile(np.repeat(x, b[i]), 
+    	            np.product(a[i]))
+               for i, x in enumerate(X)]
+


### PR DESCRIPTION
fixes #3820

```
a = np.array(['foo', 'foo', 'foo', 'bar', 'bar', 'foo', 'foo'], dtype=object)
b = np.array(['one', 'one', 'two', 'one', 'two', 'two', 'two'], dtype=object)
c = np.array(['dull', 'dull', 'dull', 'dull', 'dull', 'shiny', 'shiny'], dtype=object)

In [11]: pd.crosstab(a, [b, c], rownames=['a'], colnames=['b', 'c'], drop_na=False)
Out[11]:
b     one          two
c    dull  shiny  dull  shiny
a
bar     1      0     1      0
foo     2      0     1      2
```

Also same argument for `pivot_table`.
