### PR TITLE
CLN: Small fix to clean_pyc task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ clean: clean_pyc
 	-find . -name '*.so' -exec rm {} \;
 
 clean_pyc:
-	-find . -name '*.pyc' -or -name '*.pyo' -exec rm {} \;
+	-find . -name '*.pyc' -exec rm {} \; -or -name '*.pyo' -exec rm {} \;
 
 tseries: pandas/lib.pyx pandas/tslib.pyx pandas/hashtable.pyx
 	python setup.py build_ext --inplace


### PR DESCRIPTION
The previous `clean_pyc` wasn't actually removing `*.pyc` files - apparently each branch of find needs its own exec (I guess?). Anyways this works now.
