### PR TITLE
BUG: series timedelta arithmetic is not being converted to ns with numpy 1.6

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -135,6 +135,8 @@ pandas 0.13
   - Raise on set indexing with a Panel and a Panel as a value which needs alignment (:issue:`3777`)
   - frozenset objects now raise in the ``Series`` constructor (:issue:`4482`,
     :issue:`4480`)
+  - Fixed bug where timedelta and timedelta64 were treated differently when
+    being add to a Series (:issue:`4135`)
 
 pandas 0.12
 ===========
@@ -460,6 +462,7 @@ pandas 0.12
   - Fixed bug where html5lib wasn't being properly skipped (:issue:`4265`)
   - Fixed bug where get_data_famafrench wasn't using the correct file edges
     (:issue:`4281`)
+
 
 pandas 0.11.0
 =============

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -110,6 +110,9 @@ Bug Fixes
 
   - Suppressed DeprecationWarning associated with internal calls issued by repr() (:issue:`4391`)
 
+  - Fixed bug where timedelta and timedelta64 were treated differently when
+    being add to a Series (:issue:`4135`)
+
 See the :ref:`full release notes
 <release>` or issue tracker
 on GitHub for a complete list.


### PR DESCRIPTION
closes #4135.
