### PR TITLE
DOC: Improve excel docs

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1494,7 +1494,8 @@ any pickled pandas object (or any other pickled object) from file:
 Excel files
 -----------
 
-The ``read_excel`` method can read an Excel 2003 file using the ``xlrd`` Python
+The ``read_excel`` method can read Excel 2003 (``.xls``) and
+Excel 2007 (``.xlsx``) files using the ``xlrd`` Python
 module and use the same parsing code as the above to convert tabular data into
 a DataFrame. See the :ref:`cookbook<cookbook.excel>` for some
 advanced strategies
@@ -1515,9 +1516,6 @@ advanced strategies
      .. code-block:: python
 
         read_excel('path_to_file.xls', 'Sheet1', index_col=None, na_values=['NA'])
-
-To read sheets from an Excel 2007 file, you can pass a filename with a ``.xlsx``
-extension, in which case the ``openpyxl`` module will be used to read the file.
 
 It is often the case that users will insert columns to do temporary computations
 in Excel and you may not want to read in those columns. `read_excel` takes

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -37,6 +37,11 @@ def read_excel(path_or_buf, sheetname, kind=None, **kwds):
           column ranges (e.g. "A:E" or "A,C,E:F")
     na_values : list-like, default None
         List of additional strings to recognize as NA/NaN
+    keep_default_na : bool, default True
+        If na_values are specified and keep_default_na is False the default NaN
+        values are overridden, otherwise they're appended to
+    verbose : boolean, default False
+        Indicate number of NA values placed in non-numeric columns
 
     Returns
     -------
@@ -101,6 +106,11 @@ class ExcelFile(object):
               column ranges (e.g. "A:E" or "A,C,E:F")
         na_values : list-like, default None
             List of additional strings to recognize as NA/NaN
+        keep_default_na : bool, default True
+            If na_values are specified and keep_default_na is False the default NaN
+            values are overridden, otherwise they're appended to
+        verbose : boolean, default False
+            Indicate number of NA values placed in non-numeric columns
 
         Returns
         -------


### PR DESCRIPTION
I simply updated the docs to reflect that `xlrd` handles reading of both `.xls` and `.xlsx` files, and I updated docstrings affected functions by #4131 so that their docstrings stand on their own.  
