### PR TITLE
DOC: increased width of text area (#4159)

### DIFF
--- a/doc/source/themes/nature_with_gtoc/static/nature.css_t
+++ b/doc/source/themes/nature_with_gtoc/static/nature.css_t
@@ -30,7 +30,8 @@ div.documentwrapper {
 div.bodywrapper {
 /* ugly hack, probably not attractive with other font size for re*/
     margin: 0 0 0 {{ theme_sidebarwidth|toint}}px;
-    max-width: 600px;
+    min-width: 540px;
+    max-width: 720px;
 }
 
 

--- a/doc/sphinxext/ipython_directive.py
+++ b/doc/sphinxext/ipython_directive.py
@@ -621,6 +621,8 @@ class IpythonDirective(Directive):
 
     shell = EmbeddedSphinxShell()
 
+    seen_docs = set()
+
     def get_config_options(self):
         # contains sphinx configuration variables
         config = self.state.document.settings.env.config
@@ -644,6 +646,12 @@ class IpythonDirective(Directive):
         return savefig_dir, source_dir, rgxin, rgxout, promptin, promptout
 
     def setup(self):
+
+        if not self.state.document.current_source in self.seen_docs:
+            self.shell.IP.history_manager.reset()
+            self.shell.IP.execution_count = 1
+            self.seen_docs.add(self.state.document.current_source)
+
         # get config values
         (savefig_dir, source_dir, rgxin,
                 rgxout, promptin, promptout) = self.get_config_options()


### PR DESCRIPTION
See #4159

This adds a minimum and maximum width of the text area (instead of one fixed value of, at the moment 600px), and I also increased the maximum value (from 600 to 840). 

I took the values of the standard sphinx docs which are 780-1080 (minus 240 for the sidebar, in the standard sphinx docs the width is defined for the whole body, here only for the main text area)
