### PR TITLE
BUG: wrong parsing of microseconds with format arg (#4152)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -321,7 +321,8 @@ pandas 0.12
     object Series/Frame was not converting properly (:issue:`4119`)
   - Fixed bugs in multi-index selection with column multi-index and duplicates
     (:issue:`4145`, :issue:`4146`)
-
+  - Fixed bug in the parsing of microseconds when using the ``format`` 
+    argument in ``to_datetime`` (:issue:`4152`)
 
 pandas 0.11.0
 =============

--- a/doc/source/v0.12.0.txt
+++ b/doc/source/v0.12.0.txt
@@ -459,7 +459,9 @@ Bug Fixes
     (:issue:`4089`)
   - Fixed bug in ``DataFrame.replace`` where a nested dict wasn't being
     iterated over when regex=False (:issue:`4115`)
-
+  - Fixed bug in the parsing of microseconds when using the ``format`` 
+    argument in ``to_datetime`` (:issue:`4152`)
+    
 See the :ref:`full release notes
 <release>` or issue tracker
 on GitHub for a complete list.

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -805,6 +805,13 @@ class TestTimeSeries(unittest.TestCase):
             expected = _parse_format(fmt, values)
             self.assert_(result.equals(expected))
 
+    def test_to_datetime_format_microsecond(self):
+        val = '01-Apr-2011 00:00:01.978'
+        format = '%d-%b-%Y %H:%M:%S.%f'
+        result = to_datetime(val, format=format)
+        exp = dt.datetime.strptime(val, format)
+        self.assert_(result == exp)
+
     def test_to_datetime_on_datetime64_series(self):
         # #2699
         s = Series(date_range('1/1/2000', periods=10))

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -1049,8 +1049,7 @@ def array_strptime(ndarray[object] values, object fmt):
         Py_ssize_t i, n = len(values)
         pandas_datetimestruct dts
         ndarray[int64_t] iresult
-        int year, month, day, minute, hour, second, weekday, julian
-        float64_t fraction
+        int year, month, day, minute, hour, second, fraction, weekday, julian
 
     global _TimeRE_cache, _regex_cache
     with _cache_lock:
@@ -1247,7 +1246,7 @@ def array_strptime(ndarray[object] values, object fmt):
         dts.hour = hour
         dts.min = minute
         dts.sec = second
-        dts.us = int(fraction * 1000000)
+        dts.us = fraction
 
         iresult[i] = pandas_datetimestruct_to_datetime(PANDAS_FR_ns, &dts)
         _check_dts_bounds(iresult[i], &dts)


### PR DESCRIPTION
Closes #4152.

`fraction` was already in microseconds, so no need to multiply it with 1000000, which caused faulty parsing of dates with microseconds.

With this commit I get:

```
pandas version: 0.12.0.dev
Value to parse: 01-Apr-2011 00:00:01.978
datetime.strptime        : 2011-04-01 00:00:01.978000
to_datetime, w/out format: 2011-04-01 00:00:01.978000
to_datetime, w/ format   : 2011-04-01 00:00:01.978000
```

for 

```
import datetime as dt
import pandas as pd
val = '01-Apr-2011 00:00:01.978'
print 'pandas version:',pd.__version__
print 'Value to parse:',val
format = '%d-%b-%Y %H:%M:%S.%f'
print 'datetime.strptime        :',dt.datetime.strptime(val, format)
print 'to_datetime, w/out format:',pd.to_datetime(val)
print 'to_datetime, w/ format   :', pd.to_datetime(val, format=format)
```
