### PR TITLE
BLD: use the wheel url for scikits timeseries

### DIFF
--- a/ci/requirements-2.7.txt
+++ b/ci/requirements-2.7.txt
@@ -12,4 +12,4 @@ xlrd==0.9.2
 patsy==0.1.0
 html5lib==1.0b2
 lxml==3.2.1
-http://downloads.sourceforge.net/project/pytseries/scikits.timeseries/0.91.3/scikits.timeseries-0.91.3.tar.gz?r=
+scikits.timeseries==0.91.3


### PR DESCRIPTION
was previously downloading from sourceforge, now uses the wheel
