### PR TITLE
ENH: drop_level argument for xs

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -48,6 +48,7 @@ pandas 0.13
     overlapping color and style arguments (:issue:`4402`)
   - Significant table writing performance improvements in ``HDFStore``
   - JSON date serialisation now performed in low-level C code.
+  - Add ``drop_level`` argument to xs (:issue:`4180`)
   - ``Index.copy()`` and ``MultiIndex.copy()`` now accept keyword arguments to
     change attributes (i.e., ``names``, ``levels``, ``labels``)
     (:issue:`4039`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2063,7 +2063,7 @@ class DataFrame(NDFrame):
     def _series(self):
         return self._data.get_series_dict()
 
-    def xs(self, key, axis=0, level=None, copy=True):
+    def xs(self, key, axis=0, level=None, copy=True, drop_level=True):
         """
         Returns a cross-section (row(s) or column(s)) from the DataFrame.
         Defaults to cross-section on the rows (axis=0).
@@ -2079,6 +2079,8 @@ class DataFrame(NDFrame):
             which levels are used. Levels can be referred by label or position.
         copy : boolean, default True
             Whether to make a copy of the data
+        drop_level, default True
+            If False, returns object with same levels as self.
 
         Examples
         --------
@@ -2130,11 +2132,13 @@ class DataFrame(NDFrame):
         Returns
         -------
         xs : Series or DataFrame
+
         """
         axis = self._get_axis_number(axis)
         labels = self._get_axis(axis)
         if level is not None:
-            loc, new_ax = labels.get_loc_level(key, level=level)
+            loc, new_ax = labels.get_loc_level(key, level=level,
+                                    drop_level=drop_level)
 
             if not copy and not isinstance(loc, slice):
                 raise ValueError('Cannot retrieve view (copy=False)')
@@ -2168,7 +2172,8 @@ class DataFrame(NDFrame):
 
         index = self.index
         if isinstance(index, MultiIndex):
-            loc, new_index = self.index.get_loc_level(key)
+            loc, new_index = self.index.get_loc_level(key,
+                                    drop_level=drop_level)
         else:
             loc = self.index.get_loc(key)
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -7261,6 +7261,18 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         exp = df.irow(2)
         assert_series_equal(cross, exp)
 
+    def test_xs_keep_level(self):
+        df = DataFrame({'day': {0: 'sat', 1: 'sun'},
+                        'flavour': {0: 'strawberry', 1: 'strawberry'},
+                        'sales': {0: 10, 1: 12},
+                        'year': {0: 2008, 1: 2008}}).set_index(['year','flavour','day'])
+        result = df.xs('sat', level='day', drop_level=False)
+        expected = df[:1]
+        assert_frame_equal(result, expected)
+
+        result = df.xs([2008, 'sat'], level=['year', 'day'], drop_level=False)
+        assert_frame_equal(result, expected)
+
     def test_pivot(self):
         data = {
             'index': ['A', 'B', 'C', 'C', 'B', 'A'],


### PR DESCRIPTION
As discussed [here](http://stackoverflow.com/questions/17552997/how-to-update-a-subset-of-a-multiindexed-pandas-dataframe), xs usually remove the level which you are accessing. This commit allows you to explicitly say you don't want that (and want to keep the same levels in the result).

```
In [4]: df = DataFrame({'day': {0: 'sat', 1: 'sun'},
                                   'flavour': {0: 'strawberry', 1: 'strawberry'},
                                   'sales': {0: 10, 1: 12},
                                   'year': {0: 2008, 1: 2008}}).set_index(['year','flavour','day'])

In [5]: df
Out[5]:
                     sales
year flavour    day
2008 strawberry sat     10
                sun     12

In [6]: df.xs('sat', level='day')
Out[6]:
                 sales
year flavour
2008 strawberry     10

In [7]: df.xs('sat', level='day', drop_level=False)
Out[7]:
                     sales
year flavour    day
2008 strawberry sat     10

In [8]: df.xs([2008, 'sat'], level=['year', 'day'], drop_level=False)
Out[8]:
                     sales
year flavour    day
2008 strawberry sat     10
```
