### PR TITLE
FIX disallow MultiIndex in Series constructor GH4187

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -199,6 +199,7 @@ pandas 0.12
   - Fixed an esoteric excel reading bug, xlrd>= 0.9.0 now required for excel
     support. Should provide python3 support (for reading) which has been
     lacking. (:issue:`3164`)
+  - Disallow Series constructor called with MultiIndex which caused segfault (:issue:`4187`)
   - Allow unioning of date ranges sharing a timezone (:issue:`3491`)
   - Fix to_csv issue when having a large number of rows and ``NaT`` in some
     columns (:issue:`3437`)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -432,6 +432,9 @@ class Series(generic.PandasContainer, pa.Array):
         if data is None:
             data = {}
 
+        if isinstance(data, MultiIndex):
+            raise NotImplementedError
+
         if index is not None:
             index = _ensure_index(index)
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -311,6 +311,10 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         xp = 'Series'
         self.assertEqual(rs, xp)
 
+        # raise on MultiIndex GH4187
+        m = MultiIndex.from_arrays([[1, 2], [3,4]])
+        self.assertRaises(NotImplementedError, Series, m)
+
     def test_constructor_empty(self):
         empty = Series()
         empty2 = Series([])


### PR DESCRIPTION
fixes #4187 (at least the segfault part).

Constructing Series with a MultiIndex raises NotImplementedError, the option (to implement this) is to return `.to_series()` ?
