### PR TITLE
BUG: initialize DatetimeIndex with array of strings (#4229)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -338,6 +338,8 @@ pandas 0.12
   - Fixed the legend displaying in ``DataFrame.plot(kind='kde')`` (:issue:`4216`)
   - Fixed bug where Index slices weren't carrying the name attribute
     (:issue:`4226`)
+  - Fixed bug in initializing ``DatetimeIndex`` with an array of strings
+    in a certain time zone (:issue:`4229`)
 
 pandas 0.11.0
 =============

--- a/doc/source/v0.12.0.txt
+++ b/doc/source/v0.12.0.txt
@@ -471,7 +471,9 @@ Bug Fixes
   - Fixed the legend displaying in ``DataFrame.plot(kind='kde')`` (:issue:`4216`)
   - Fixed bug where Index slices weren't carrying the name attribute
     (:issue:`4226`)
-    
+  - Fixed bug in initializing ``DatetimeIndex`` with an array of strings
+    in a certain time zone (:issue:`4229`)
+
 See the :ref:`full release notes
 <release>` or issue tracker
 on GitHub for a complete list.

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -208,9 +208,10 @@ class DatetimeIndex(Int64Index):
                     return data
 
         if issubclass(data.dtype.type, basestring):
-            subarr = _str_to_dt_array(data, offset, dayfirst=dayfirst,
+            data = _str_to_dt_array(data, offset, dayfirst=dayfirst,
                                       yearfirst=yearfirst)
-        elif issubclass(data.dtype.type, np.datetime64):
+
+        if issubclass(data.dtype.type, np.datetime64):
             if isinstance(data, DatetimeIndex):
                 if tz is None:
                     tz = data.tz

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -631,6 +631,22 @@ class TestTimeZoneSupport(unittest.TestCase):
 
         self.assertTrue(ind.tz is not None)
 
+    def test_datetimeindex_tz(self):
+        """ Test different DatetimeIndex constructions with timezone
+        Follow-up of #4229
+        """
+        
+        arr = ['11/10/2005 08:00:00', '11/10/2005 09:00:00']
+        
+        idx1 = to_datetime(arr).tz_localize('US/Eastern')
+        idx2 = DatetimeIndex(start="2005-11-10 08:00:00", freq='H', periods=2, tz='US/Eastern')
+        idx3 = DatetimeIndex(arr, tz='US/Eastern')
+        idx4 = DatetimeIndex(np.array(arr), tz='US/Eastern')
+        
+        for other in [idx2, idx3, idx4]:
+            self.assert_(idx1.equals(other))
+
+
 class TestTimeZones(unittest.TestCase):
     _multiprocess_can_split_ = True
 


### PR DESCRIPTION
Possibly a fix for #4229.

The rationale is that an array of strings should be handled in the same way as a list of strings (after applying `np.asarray(list)`), and I supposed that the list was handling the timezone correctly.
## 

More in detail:
- handling of the list of strings: https://github.com/pydata/pandas/blob/master/pandas/tseries/index.py#L196 => returning `data`
- handling of an array of strings: https://github.com/pydata/pandas/blob/master/pandas/tseries/index.py#L211 =>  returning directly `subarr`

Because in the case of an array `subarr` is set as a DatetimeIndex (instead of as `.values` attribute of it => array of datetime64), the array is not localized to UTC (https://github.com/pydata/pandas/blob/master/pandas/tseries/index.py#L249) but assumed to be UTC. So, in fact, the `tz` keyword is ignored.
## 

Something else: it is not completely clear what the `tz` keyword is supposed to do (it is not documented in the DatetimeIndex docstring). But I assumed it is to say that the given values to DatetimeIndex are in that timezone (and so the behaviour with a list is correct). However, it is also a little bit strange that eg `to_datetime` has not such of a keyword then.
## 

PS: the PR is not ready (I want to add some tests, release notes, and there is too much whitespace in the commit), but I just wanted to submit it already to see if this makes sense.
