### PR TITLE
API: implement non-unique indexing in series (GH4246)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -235,6 +235,7 @@ pandas 0.12
       names (:issue:`3873`)
     - Bug in non-unique indexing via ``iloc`` (:issue:`4017`); added ``takeable`` argument to
       ``reindex`` for location-based taking
+    - Allow non-unique indexing in series via ``.ix/.loc`` and ``__getitem`` (:issue:`4246)
 
   - Fixed bug in groupby with empty series referencing a variable before assignment. (:issue:`3510`)
   - Allow index name to be used in groupby for non MultiIndex (:issue:`4014`)

--- a/doc/source/v0.12.0.txt
+++ b/doc/source/v0.12.0.txt
@@ -437,6 +437,7 @@ Bug Fixes
       names (:issue:`3873`)
     - Bug in non-unique indexing via ``iloc`` (:issue:`4017`); added ``takeable`` argument to
       ``reindex`` for location-based taking
+    - Allow non-unique indexing in series via ``.ix/.loc`` and ``__getitem`` (:issue:`4246)
 
   - ``DataFrame.from_records`` did not accept empty recarrays (:issue:`3682`)
   - ``read_html`` now correctly skips tests (:issue:`3741`)
@@ -462,7 +463,7 @@ Bug Fixes
     (:issue:`4089`)
   - Fixed bug in ``DataFrame.replace`` where a nested dict wasn't being
     iterated over when regex=False (:issue:`4115`)
-  - Fixed bug in the parsing of microseconds when using the ``format`` 
+  - Fixed bug in the parsing of microseconds when using the ``format``
     argument in ``to_datetime`` (:issue:`4152`)
   - Fixed bug in ``PandasAutoDateLocator`` where ``invert_xaxis`` triggered
     incorrectly ``MilliSecondLocator``  (:issue:`3990`)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -928,7 +928,7 @@ class Index(PandasObject, np.ndarray):
                     if method is not None or limit is not None:
                         raise ValueError("cannot reindex a non-unique index "
                                          "with a method or limit")
-                    indexer, _ = self.get_indexer_non_unique(target)
+                    indexer, missing = self.get_indexer_non_unique(target)
 
         return target, indexer
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -481,12 +481,12 @@ class _NDFrameIndexer(object):
                     new_indexer = (Index(cur_indexer) + Index(missing_indexer)).values
                     new_indexer[missing_indexer] = -1
 
-                    # need to reindex with an indexer on a specific axis
-                    from pandas.core.frame import DataFrame
-                    if not (type(self.obj) == DataFrame):
-                        raise NotImplementedError("cannot handle non-unique indexing for non-DataFrame (yet)")
+                    # reindex with the specified axis
+                    ndim = self.obj.ndim
+                    if axis+1 > ndim:
+                        raise AssertionError("invalid indexing error with non-unique index")
 
-                    args = [None] * 4
+                    args = [None] * (2*ndim)
                     args[2*axis] = new_labels
                     args[2*axis+1] = new_indexer
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -788,6 +788,15 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         self.assert_(np.isscalar(obj['c']))
         self.assert_(obj['c'] == 0)
 
+    def test_getitem_dups_with_missing(self):
+
+        # breaks reindex, so need to use .ix internally
+        # GH 4246
+        s = Series([1,2,3,4],['foo','bar','foo','bah'])
+        expected = s.ix[['foo','bar','bah','bam']]
+        result = s[['foo','bar','bah','bam']]
+        assert_series_equal(result,expected)
+
     def test_setitem_ambiguous_keyerror(self):
         s = Series(range(10), index=range(0, 20, 2))
         self.assertRaises(KeyError, s.__setitem__, 1, 5)
@@ -1141,7 +1150,7 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         s = Series(np.arange(10))
         mask = s > 5
         self.assertRaises(ValueError, s.__setitem__, mask, ([0]*5,))
-        
+
     def test_where_broadcast(self):
         # Test a variety of differently sized series
         for size in range(2, 6):


### PR DESCRIPTION
closes #4246

```
In [3]: s = Series([1,2,3,4],['foo','bar','foo','bah'])

In [4]: s.ix[['foo','bar','bah','bam']]
Out[4]: 
foo     1
foo     3
bar     2
bah     4
bam   NaN
dtype: float64

In [5]: s[['foo','bar','bah','bam']]
Out[5]: 
foo     1
foo     3
bar     2
bah     4
bam   NaN
dtype: float64
```
