### PR TITLE
CLN: Remove unused and cleanup imports throughout.

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -4,23 +4,20 @@ Misc tools for implementing data structures
 
 import itertools
 import re
-from datetime import datetime
+import codecs
+import csv
 
 from numpy.lib.format import read_array, write_array
 import numpy as np
-
 import pandas.algos as algos
 import pandas.lib as lib
 import pandas.tslib as tslib
 
 from pandas.util import py3compat
-import codecs
-import csv
-
 from pandas.util.py3compat import StringIO, BytesIO
-
 from pandas.core.config import get_option
 from pandas.core import array as pa
+
 
 # XXX: HACK for NumPy 1.5.1 to suppress warnings
 try:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -22,13 +22,15 @@ import itertools
 from numpy import nan as NA
 import numpy as np
 import numpy.ma as ma
+import pandas.lib as lib
+import pandas.algos as _algos
 
 from pandas.core.common import (isnull, notnull, PandasError, _try_sort,
                                 _default_index, _maybe_upcast, _is_sequence,
                                 _infer_dtype_from_scalar)
 from pandas.core.generic import NDFrame
 from pandas.core.index import Index, MultiIndex, _ensure_index
-from pandas.core.indexing import (_NDFrameIndexer, _maybe_droplevels,
+from pandas.core.indexing import (_maybe_droplevels,
                                   _convert_to_index_sliceable, _check_bool_indexer,
                                   _maybe_convert_indices)
 from pandas.core.internals import (BlockManager,
@@ -39,24 +41,17 @@ import pandas.core.expressions as expressions
 from pandas.compat.scipy import scoreatpercentile as _quantile
 from pandas.util.compat import OrderedDict
 from pandas.util import py3compat
-from pandas.util.terminal import get_terminal_size
 from pandas.util.decorators import deprecate, Appender, Substitution
-
 from pandas.tseries.period import PeriodIndex
 from pandas.tseries.index import DatetimeIndex
-
 import pandas.core.algorithms as algos
 import pandas.core.datetools as datetools
 import pandas.core.common as com
 import pandas.core.format as fmt
 import pandas.core.generic as generic
 import pandas.core.nanops as nanops
-
-import pandas.lib as lib
-import pandas.tslib as tslib
-import pandas.algos as _algos
-
 from pandas.core.config import get_option, set_option
+
 
 #----------------------------------------------------------------------
 # Docstring templates

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1,6 +1,10 @@
 from itertools import izip
 import types
+
 import numpy as np
+import pandas.lib as lib
+import pandas.algos as _algos
+import pandas.hashtable as _hash
 
 from pandas.core.base import PandasObject
 from pandas.core.categorical import Categorical
@@ -16,9 +20,6 @@ import pandas.core.algorithms as algos
 import pandas.core.common as com
 from pandas.core.common import _possibly_downcast_to_dtype, notnull
 
-import pandas.lib as lib
-import pandas.algos as _algos
-import pandas.hashtable as _hash
 
 _agg_doc = """Aggregate using input function or dict of {column -> function}
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1,12 +1,11 @@
 # pylint: disable=W0223
 
-from datetime import datetime
+import numpy as np
+
 from pandas.core.common import _asarray_tuplesafe
 from pandas.core.index import Index, MultiIndex, _ensure_index
 import pandas.core.common as com
-import pandas.lib as lib
 
-import numpy as np
 
 # the supported indexers
 def get_indexers_list():

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -4,20 +4,18 @@ from datetime import datetime
 
 from numpy import nan
 import numpy as np
-from pandas.core.base import PandasObject
+import pandas.lib as lib
+import pandas.tslib as tslib
+from pandas.tslib import Timestamp
 
+from pandas.core.base import PandasObject
 from pandas.core.common import (_possibly_downcast_to_dtype, isnull, _NS_DTYPE,
                                 _TD_DTYPE)
 from pandas.core.index import (Index, MultiIndex, _ensure_index,
                                _handle_legacy_indexes)
 from pandas.core.indexing import _check_slice_bounds, _maybe_convert_indices
 import pandas.core.common as com
-import pandas.lib as lib
-import pandas.tslib as tslib
 import pandas.core.expressions as expressions
-
-from pandas.tslib import Timestamp
-from pandas.util import py3compat
 
 
 class Block(PandasObject):

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -5,7 +5,10 @@ Contains data structures designed for manipulating panel (3-dimensional) data
 
 import operator
 import sys
+
 import numpy as np
+import pandas.lib as lib
+
 from pandas.core.common import (PandasError, _mut_exclusive,
                                 _try_sort, _default_index,
                                 _infer_dtype_from_scalar,
@@ -24,7 +27,6 @@ from pandas.util import py3compat
 from pandas.util.decorators import deprecate, Appender, Substitution
 import pandas.core.common as com
 import pandas.core.nanops as nanops
-import pandas.lib as lib
 
 
 def _ensure_like_indices(time, panels):

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -4,18 +4,17 @@
 import itertools
 
 import numpy as np
+import six
+import pandas.algos as algos
 
 from pandas.core.series import Series
 from pandas.core.frame import DataFrame
-
 from pandas.core.categorical import Categorical
 from pandas.core.common import (notnull, _ensure_platform_int, _maybe_promote,
                                 isnull)
 from pandas.core.groupby import (get_group_index, _compress_group_index,
                                  decons_group_index)
 import pandas.core.common as com
-import pandas.algos as algos
-
 from pandas.core.index import MultiIndex
 
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -13,6 +13,9 @@ import types
 from numpy import nan, ndarray
 import numpy as np
 import numpy.ma as ma
+import pandas.lib as lib
+import pandas.tslib as tslib
+import pandas.index as _index
 
 from pandas.core.common import (isnull, notnull, _is_bool_indexer,
                                 _default_index, _maybe_promote, _maybe_upcast,
@@ -27,22 +30,16 @@ from pandas.tseries.index import DatetimeIndex
 from pandas.tseries.period import PeriodIndex, Period
 from pandas.util import py3compat
 from pandas.util.terminal import get_terminal_size
-
 import pandas.core.array as pa
-
 import pandas.core.common as com
 import pandas.core.datetools as datetools
 import pandas.core.format as fmt
 import pandas.core.generic as generic
 import pandas.core.nanops as nanops
 from pandas.util.decorators import Appender, Substitution, cache_readonly
-
-import pandas.lib as lib
-import pandas.tslib as tslib
-import pandas.index as _index
-
 from pandas.compat.scipy import scoreatpercentile as _quantile
 from pandas.core.config import get_option
+
 
 __all__ = ['Series', 'TimeSeries']
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1,10 +1,11 @@
-import numpy as np
-
 from itertools import izip
+import re
+
+import numpy as np
+import pandas.lib as lib
+
 from pandas.core.common import isnull
 from pandas.core.series import Series
-import re
-import pandas.lib as lib
 
 
 def _get_array_list(arr, others):

--- a/pandas/io/ga.py
+++ b/pandas/io/ga.py
@@ -9,8 +9,6 @@ import numpy as np
 from pandas import DataFrame
 import pandas as pd
 import pandas.io.parsers as psr
-import pandas.lib as lib
-from pandas.io.date_converters import generic_parser
 import pandas.io.auth as auth
 from pandas.util.decorators import Appender, Substitution
 

--- a/pandas/io/json.py
+++ b/pandas/io/json.py
@@ -1,17 +1,16 @@
 
 # pylint: disable-msg=E1101,W0613,W0603
-from StringIO import StringIO
 import os
+
+import pandas.json as _json
 
 from pandas import Series, DataFrame, to_datetime
 from pandas.io.common import get_filepath_or_buffer
-import pandas.json as _json
 loads = _json.loads
 dumps = _json.dumps
 
 import numpy as np
 from pandas.tslib import iNaT
-import pandas.lib as lib
 
 ### interface to/from ###
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -6,23 +6,21 @@ import re
 from itertools import izip
 import csv
 from warnings import warn
+import datetime
 
 import numpy as np
+import pandas.lib as lib
+import pandas.tslib as tslib
+import pandas.parser as _parser
 
 from pandas.core.index import Index, MultiIndex
 from pandas.core.frame import DataFrame
-import datetime
 import pandas.core.common as com
 from pandas.util import py3compat
 from pandas.io.date_converters import generic_parser
 from pandas.io.common import get_filepath_or_buffer
-
 from pandas.util.decorators import Appender
 
-import pandas.lib as lib
-import pandas.tslib as tslib
-import pandas.parser as _parser
-from pandas.tseries.period import Period
 
 _parser_params = """Also supports optionally iterating or breaking of the file
 into chunks.

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -10,8 +10,13 @@ import re
 import copy
 import itertools
 import warnings
+from contextlib import contextmanager
 
 import numpy as np
+import pandas.lib as lib
+import pandas.algos as algos
+import pandas.tslib as tslib
+
 from pandas import (Series, TimeSeries, DataFrame, Panel, Panel4D, Index,
                     MultiIndex, Int64Index, Timestamp)
 from pandas.sparse.api import SparseSeries, SparseDataFrame, SparsePanel
@@ -30,11 +35,6 @@ from pandas.tools.merge import concat
 from pandas.util import py3compat
 from pandas.io.common import PerformanceWarning
 
-import pandas.lib as lib
-import pandas.algos as algos
-import pandas.tslib as tslib
-
-from contextlib import contextmanager
 
 # versioning attribute
 _version = '0.10.1'

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -2,10 +2,10 @@
 Collection of query wrappers / abstractions to both facilitate data
 retrieval and to reduce dependency on DB-specific API.
 """
-from datetime import datetime, date
+from datetime import datetime
+import traceback
 
 import numpy as np
-import traceback
 
 from pandas.core.datetools import format as date_format
 from pandas.core.api import DataFrame, isnull

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -10,16 +10,16 @@ You can find more information on http://presbrey.mit.edu/PyDTA and
 http://statsmodels.sourceforge.net/devel/
 """
 
-from StringIO import StringIO
-import numpy as np
-
 import sys
 import struct
+import datetime
+
+import numpy as np
+
 from pandas.core.base import StringMixin
 from pandas.core.frame import DataFrame
 from pandas.core.series import Series
 from pandas.core.categorical import Categorical
-import datetime
 from pandas.util import py3compat
 from pandas import isnull
 from pandas.io.parsers import _parser_params, Appender

--- a/pandas/io/tests/generate_legacy_pickles.py
+++ b/pandas/io/tests/generate_legacy_pickles.py
@@ -36,7 +36,6 @@ def create_data():
     """ create the pickle data """
     
     import numpy as np
-    import pandas
     from pandas import (Series,DataFrame,Panel,
                         SparseSeries,SparseDataFrame,SparsePanel,
                         Index,MultiIndex,PeriodIndex,
@@ -82,9 +81,7 @@ def write_legacy_pickles():
     sys.path.insert(0,'.')
 
     import os
-    import numpy as np
     import pandas
-    import pandas.util.testing as tm
     import platform as pl
     import cPickle as pickle
 

--- a/pandas/io/tests/test_cparser.py
+++ b/pandas/io/tests/test_cparser.py
@@ -2,33 +2,17 @@
 C/Cython ascii file parser tests
 """
 
-from pandas.util.py3compat import StringIO, BytesIO
-from datetime import datetime
-import csv
 import os
 import sys
-import re
 import unittest
 
 import nose
-
-from numpy import nan
 import numpy as np
-
-from pandas import DataFrame, Series, Index, isnull, MultiIndex
-import pandas.io.parsers as parsers
-from pandas.io.parsers import (read_csv, read_table, read_fwf,
-                               TextParser)
-from pandas.util.testing import (assert_almost_equal, assert_frame_equal,
-                                 assert_series_equal, network)
-import pandas.lib as lib
-from pandas.util import py3compat
-from pandas.lib import Timestamp
-
-import pandas.util.testing as tm
-
 from pandas.parser import TextReader
 import pandas.parser as parser
+
+from pandas.util.py3compat import StringIO, BytesIO
+import pandas.util.testing as tm
 
 
 class TestCParser(unittest.TestCase):

--- a/pandas/io/tests/test_data.py
+++ b/pandas/io/tests/test_data.py
@@ -1,10 +1,12 @@
 import unittest
 import warnings
-import nose
-from nose.tools import assert_equal
 from datetime import datetime
 
+import nose
+from nose.tools import assert_equal
 import numpy as np
+from numpy.testing import assert_array_equal
+
 import pandas as pd
 from pandas import DataFrame
 from pandas.io import data as web

--- a/pandas/io/tests/test_date_converters.py
+++ b/pandas/io/tests/test_date_converters.py
@@ -1,26 +1,11 @@
-from pandas.util.py3compat import StringIO, BytesIO
 from datetime import date, datetime
-import csv
-import os
-import sys
-import re
 import unittest
 
 import nose
-
-from numpy import nan
 import numpy as np
-from numpy.testing.decorators import slow
 
-from pandas import DataFrame, Series, Index, isnull
-import pandas.io.parsers as parsers
-from pandas.io.parsers import (read_csv, read_table, read_fwf,
-                               TextParser)
-from pandas.util.testing import (assert_almost_equal, assert_frame_equal,
-                                 assert_series_equal, network)
-import pandas.lib as lib
-from pandas.util import py3compat
-from pandas.lib import Timestamp
+from pandas.util.py3compat import StringIO
+from pandas.io.parsers import (read_csv, read_table )
 import pandas.io.date_converters as conv
 
 

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -1,12 +1,6 @@
 # pylint: disable=E1101
 
-from pandas.util.py3compat import StringIO, BytesIO, PY3
-from datetime import datetime
-from os.path import split as psplit
-import csv
 import os
-import sys
-import re
 import unittest
 
 import nose
@@ -15,26 +9,12 @@ from numpy import nan
 import numpy as np
 
 from pandas import DataFrame, Series, Index, MultiIndex, DatetimeIndex
-import pandas.io.parsers as parsers
-from pandas.io.parsers import (read_csv, read_table, read_fwf,
-                                TextParser, TextFileReader)
+from pandas.io.parsers import (read_csv )
 from pandas.io.excel import ExcelFile, ExcelWriter, read_excel
-from pandas.util.testing import (assert_almost_equal,
-                                 assert_series_equal,
-                                 network,
-                                 ensure_clean)
+from pandas.util.testing import (  ensure_clean)
 import pandas.util.testing as tm
 import pandas as pd
 
-import pandas.lib as lib
-from pandas.util import py3compat
-from pandas.lib import Timestamp
-from pandas.tseries.index import date_range
-import pandas.tseries.tools as tools
-
-from numpy.testing.decorators import slow
-
-from pandas.parser import OverflowError
 
 def _skip_if_no_xlrd():
     try:

--- a/pandas/io/tests/test_ga.py
+++ b/pandas/io/tests/test_ga.py
@@ -3,10 +3,12 @@ import unittest
 from datetime import datetime
 
 import nose
+from numpy.testing.decorators import slow
+
 import pandas as pd
 from pandas import DataFrame
 from pandas.util.testing import network, assert_frame_equal, with_connectivity_check
-from numpy.testing.decorators import slow
+
 
 try:
     import httplib2

--- a/pandas/io/tests/test_json/test_pandas.py
+++ b/pandas/io/tests/test_json/test_pandas.py
@@ -1,11 +1,6 @@
 
 # pylint: disable-msg=W0612,E1101
-from copy import deepcopy
-from datetime import datetime, timedelta
 from StringIO import StringIO
-import cPickle as pickle
-import operator
-import os
 import unittest
 
 import nose

--- a/pandas/io/tests/test_json/test_ujson.py
+++ b/pandas/io/tests/test_json/test_ujson.py
@@ -1,5 +1,4 @@
-﻿import unittest
-from unittest import TestCase
+﻿from unittest import TestCase
 
 import pandas.json as ujson
 try:
@@ -10,18 +9,13 @@ import math
 import nose
 import platform
 import sys
-import time
-import datetime
-import calendar
 import StringIO
 import re
-import random
 import decimal
 from functools import partial
 import pandas.util.py3compat as py3compat
 
 import numpy as np
-from pandas.util.testing import assert_almost_equal
 from numpy.testing import (assert_array_equal,
                            assert_array_almost_equal_nulp,
                            assert_approx_equal)

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -1,6 +1,5 @@
 # pylint: disable=E1101
 
-from pandas.util.py3compat import StringIO, BytesIO, PY3
 from datetime import datetime
 import csv
 import os
@@ -11,10 +10,14 @@ from contextlib import closing
 from urllib2 import urlopen
 
 import nose
-
 from numpy import nan
 import numpy as np
+import pandas.lib as lib
+from pandas.lib import Timestamp
+from numpy.testing.decorators import slow
+from pandas.parser import OverflowError
 
+from pandas.util.py3compat import StringIO, BytesIO, PY3
 from pandas import DataFrame, Series, Index, MultiIndex, DatetimeIndex
 import pandas.io.parsers as parsers
 from pandas.io.parsers import (read_csv, read_table, read_fwf,
@@ -26,16 +29,9 @@ from pandas.util.testing import (assert_almost_equal,
                                  ensure_clean)
 import pandas.util.testing as tm
 import pandas as pd
-
-import pandas.lib as lib
 from pandas.util import py3compat
-from pandas.lib import Timestamp
 from pandas.tseries.index import date_range
 import pandas.tseries.tools as tools
-
-from numpy.testing.decorators import slow
-
-from pandas.parser import OverflowError
 
 
 class ParserTests(object):

--- a/pandas/io/tests/test_pickle.py
+++ b/pandas/io/tests/test_pickle.py
@@ -2,20 +2,18 @@
 
 """ manage legacy pickle tests """
 
-from datetime import datetime, timedelta
-import operator
 import pickle
 import unittest
-import nose
 import os
 
-import numpy as np
+import nose
+
 import pandas.util.testing as tm
-import pandas as pd
 from pandas import Index
 from pandas.sparse.tests import test_sparse
 from pandas.util import py3compat
 from pandas.util.misc import is_little_endian
+
 
 class TestPickle(unittest.TestCase):
     _multiprocess_can_split_ = True

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -1,10 +1,9 @@
-import nose
 import unittest
-import os
 import sys
 import warnings
-
 import datetime
+
+import nose
 import numpy as np
 
 import pandas
@@ -19,7 +18,6 @@ from pandas.tests.test_frame import assert_frame_equal
 from pandas import concat, Timestamp
 from pandas.util import py3compat
 
-from numpy.testing.decorators import slow
 
 try:
     import tables

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -1,22 +1,20 @@
 from __future__ import with_statement
-from pandas.util.py3compat import StringIO
 import unittest
 import sqlite3
 import sys
-
 import warnings
+from datetime import datetime
 
 import nose
-
 import numpy as np
 
+from pandas.util.py3compat import StringIO
 from pandas.core.datetools import format as date_format
 from pandas.core.api import DataFrame, isnull
-
 import pandas.io.sql as sql
 import pandas.util.testing as tm
 from pandas import Series, Index, DataFrame
-from datetime import datetime
+
 
 _formatters = {
     datetime: lambda dt: "'%s'" % date_format(dt),

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from pandas.core.frame import DataFrame, Series
 from pandas.io.parsers import read_csv
-from pandas.io.stata import read_stata, StataReader, StataWriter
+from pandas.io.stata import read_stata, StataReader
 import pandas.util.testing as tm
 from pandas.util.testing import ensure_clean
 from pandas.util.misc import is_little_endian

--- a/pandas/io/tests/test_wb.py
+++ b/pandas/io/tests/test_wb.py
@@ -1,9 +1,9 @@
 import nose
+from numpy.testing.decorators import slow
 
 import pandas
 from pandas.util.testing import network
 from pandas.util.testing import assert_frame_equal
-from numpy.testing.decorators import slow
 from pandas.io.wb import search, download
 
 

--- a/pandas/io/wb.py
+++ b/pandas/io/wb.py
@@ -1,8 +1,10 @@
 from urllib2 import urlopen
-import json
 from contextlib import closing
-import pandas
+
 import numpy as np
+
+import json
+import pandas
 
 
 def download(country=['MX', 'CA', 'US'], indicator=['GDPPCKD', 'GDPPCKN'],

--- a/pandas/sparse/array.py
+++ b/pandas/sparse/array.py
@@ -4,19 +4,17 @@ SparseArray data structure
 
 # pylint: disable=E1101,E1103,W0231
 
+import operator
+
 from numpy import nan, ndarray
 import numpy as np
-
-import operator
-from pandas.core.base import PandasObject
-import pandas.core.common as com
-
-from pandas.util import py3compat
-
 from pandas._sparse import BlockIndex, IntIndex
 import pandas._sparse as splib
-import pandas.lib as lib
 import pandas.index as _index
+
+from pandas.core.base import PandasObject
+import pandas.core.common as com
+from pandas.util import py3compat
 
 
 def _sparse_op_wrap(op, name):

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -8,7 +8,7 @@ with float64 data
 from numpy import nan
 import numpy as np
 
-from pandas.core.common import _pickle_array, _unpickle_array, _try_sort
+from pandas.core.common import _unpickle_array, _try_sort
 from pandas.core.index import Index, MultiIndex, _ensure_index
 from pandas.core.indexing import _check_slice_bounds, _maybe_convert_indices
 from pandas.core.series import Series
@@ -16,11 +16,9 @@ from pandas.core.frame import (DataFrame, extract_index, _prep_ndarray,
                                _default_index)
 from pandas.util.decorators import cache_readonly
 import pandas.core.common as com
-import pandas.core.datetools as datetools
 
 from pandas.sparse.series import SparseSeries
 from pandas.util.decorators import Appender
-import pandas.lib as lib
 
 
 class _SparseMockBlockManager(object):

--- a/pandas/sparse/list.py
+++ b/pandas/sparse/list.py
@@ -1,9 +1,9 @@
 import numpy as np
+import pandas._sparse as splib
+
 from pandas.core.base import PandasObject
 from pandas.core.common import pprint_thing
-
 from pandas.sparse.array import SparseArray
-import pandas._sparse as splib
 
 
 class SparseList(PandasObject):

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -5,25 +5,22 @@ with float64 data
 
 # pylint: disable=E1101,E1103,W0231
 
+import operator
+
 from numpy import nan, ndarray
 import numpy as np
-
-import operator
+from pandas._sparse import BlockIndex, IntIndex
+import pandas._sparse as splib
 
 from pandas.core.common import isnull
 from pandas.core.index import Index, _ensure_index
 from pandas.core.series import Series, TimeSeries, _maybe_match_name
 from pandas.core.frame import DataFrame
 import pandas.core.common as com
-import pandas.core.datetools as datetools
-
 from pandas.util import py3compat
-
 from pandas.sparse.array import (make_sparse, _sparse_array_op, SparseArray)
-from pandas._sparse import BlockIndex, IntIndex
-import pandas._sparse as splib
-
 from pandas.util.decorators import Appender
+
 
 #------------------------------------------------------------------------------
 # Wrapper function for Series arithmetic methods

--- a/pandas/sparse/tests/test_array.py
+++ b/pandas/sparse/tests/test_array.py
@@ -1,13 +1,11 @@
 import re
-from numpy import nan, ndarray
-import numpy as np
-
 import operator
 import pickle
 import unittest
 
-from pandas.core.series import Series
-from pandas.core.common import notnull
+from numpy import nan
+import numpy as np
+
 from pandas.sparse.api import SparseArray
 from pandas.util.testing import assert_almost_equal, assertRaisesRegexp
 

--- a/pandas/sparse/tests/test_libsparse.py
+++ b/pandas/sparse/tests/test_libsparse.py
@@ -1,18 +1,13 @@
 from unittest import TestCase
-
-from pandas import Series
+import operator
 
 import nose
-from numpy import nan
 import numpy as np
-import operator
-from numpy.testing import assert_almost_equal, assert_equal
-
-from pandas.core.sparse import SparseSeries
-from pandas import DataFrame
-
+from numpy.testing import assert_equal
 from pandas._sparse import IntIndex, BlockIndex
 import pandas._sparse as splib
+
+from pandas import Series
 
 TEST_LENGTH = 20
 

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -3,13 +3,12 @@
 from unittest import TestCase
 import cPickle as pickle
 import operator
-from datetime import datetime
 
 import nose
 
 from numpy import nan
 import numpy as np
-import pandas as pd
+
 dec = np.testing.dec
 
 from pandas.util.testing import (assert_almost_equal, assert_series_equal,

--- a/pandas/stats/fama_macbeth.py
+++ b/pandas/stats/fama_macbeth.py
@@ -1,8 +1,7 @@
-from pandas.core.base import StringMixin
-from pandas.util.py3compat import StringIO
-
 import numpy as np
 
+from pandas.core.base import StringMixin
+from pandas.util.py3compat import StringIO
 from pandas.core.api import Series, DataFrame
 import pandas.stats.common as common
 from pandas.util.decorators import cache_readonly

--- a/pandas/stats/misc.py
+++ b/pandas/stats/misc.py
@@ -1,7 +1,7 @@
 from numpy import NaN
 import numpy as np
 
-from pandas.core.api import Series, DataFrame, isnull, notnull
+from pandas.core.api import Series, DataFrame
 from pandas.core.series import remove_na
 
 

--- a/pandas/stats/moments.py
+++ b/pandas/stats/moments.py
@@ -3,16 +3,14 @@ Provides rolling statistical moments and related descriptive
 statistics implemented in Cython
 """
 from __future__ import division
-
 from functools import wraps
 
 from numpy import NaN
 import numpy as np
+import pandas.algos as algos
 
 from pandas.core.api import DataFrame, Series, Panel, notnull
-import pandas.algos as algos
 import pandas.core.common as com
-
 from pandas.util.decorators import Substitution, Appender
 
 __all__ = ['rolling_count', 'rolling_max', 'rolling_min',

--- a/pandas/stats/ols.py
+++ b/pandas/stats/ols.py
@@ -11,7 +11,6 @@ import numpy as np
 
 from pandas.core.api import DataFrame, Series, isnull
 from pandas.core.base import StringMixin
-from pandas.core.common import _ensure_float64
 from pandas.core.index import MultiIndex
 from pandas.core.panel import Panel
 from pandas.util.decorators import cache_readonly

--- a/pandas/stats/tests/common.py
+++ b/pandas/stats/tests/common.py
@@ -8,7 +8,7 @@ import nose
 import numpy as np
 
 from pandas import DataFrame, bdate_range
-from pandas.util.testing import assert_almost_equal  # imported in other tests
+
 N = 100
 K = 4
 

--- a/pandas/stats/tests/test_fama_macbeth.py
+++ b/pandas/stats/tests/test_fama_macbeth.py
@@ -1,8 +1,9 @@
+import numpy as np
+
 from pandas import DataFrame, Panel
 from pandas.stats.api import fama_macbeth
-from common import assert_almost_equal, BaseTest
-
-import numpy as np
+from pandas.util.testing import assert_almost_equal
+from common import BaseTest
 
 
 class TestFamaMacBeth(BaseTest):

--- a/pandas/stats/tests/test_math.py
+++ b/pandas/stats/tests/test_math.py
@@ -1,18 +1,14 @@
 import unittest
-import nose
-
 from datetime import datetime
+
+import nose
 from numpy.random import randn
 import numpy as np
 
 from pandas.core.api import Series, DataFrame, date_range
-from pandas.util.testing import assert_almost_equal
-import pandas.core.datetools as datetools
-import pandas.stats.moments as mom
-import pandas.util.testing as tm
 import pandas.stats.math as pmath
-import pandas.tests.test_series as ts
 from pandas import ols
+
 
 N, K = 100, 10
 

--- a/pandas/stats/tests/test_moments.py
+++ b/pandas/stats/tests/test_moments.py
@@ -1,9 +1,9 @@
 import unittest
-import nose
 import sys
 import functools
-
 from datetime import datetime
+
+import nose
 from numpy.random import randn
 import numpy as np
 
@@ -15,6 +15,7 @@ from pandas.util.py3compat import PY3
 import pandas.core.datetools as datetools
 import pandas.stats.moments as mom
 import pandas.util.testing as tm
+
 
 N, K = 100, 10
 

--- a/pandas/stats/tests/test_ols.py
+++ b/pandas/stats/tests/test_ols.py
@@ -12,7 +12,7 @@ import nose
 import numpy as np
 from numpy.testing.decorators import slow
 
-from pandas import date_range, bdate_range
+from pandas import date_range
 from pandas.core.panel import Panel
 from pandas import DataFrame, Index, Series, notnull, datetools
 from pandas.stats.api import ols

--- a/pandas/stats/tests/test_var.py
+++ b/pandas/stats/tests/test_var.py
@@ -1,9 +1,9 @@
-from numpy.testing import run_module_suite, assert_equal, TestCase
+import unittest
+
+from numpy.testing import assert_equal, TestCase
+import nose
 
 from pandas.util.testing import assert_almost_equal
-
-import nose
-import unittest
 
 raise nose.SkipTest('skipping this for now')
 

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -8,9 +8,7 @@ import numpy as np
 
 from pandas.core.api import value_counts
 from pandas.core.categorical import Categorical
-from pandas.core.index import Index, Int64Index, MultiIndex
 from pandas.core.frame import DataFrame
-from pandas.util.testing import assert_almost_equal
 import pandas.core.common as com
 
 import pandas.util.testing as tm

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -1,9 +1,10 @@
 from datetime import datetime
-import sys
 import re
+import unittest
 
 import nose
-import unittest
+import numpy as np
+from pandas.tslib import iNaT
 
 from pandas import Series, DataFrame, date_range, DatetimeIndex
 from pandas.core.common import notnull, isnull
@@ -11,10 +12,6 @@ import pandas.core.common as com
 import pandas.util.testing as tm
 import pandas.core.config as cf
 
-import numpy as np
-
-from pandas.tslib import iNaT
-from pandas.util import py3compat
 
 _multiprocess_can_split_ = True
 

--- a/pandas/tests/test_config.py
+++ b/pandas/tests/test_config.py
@@ -1,10 +1,12 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 from __future__ import with_statement  # support python 2.5
-import pandas as pd
 import unittest
 import warnings
+
 import nose
+
+import pandas as pd
 
 
 class TestConfig(unittest.TestCase):

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -1,27 +1,18 @@
 # pylint: disable-msg=W0612,E1101
 
 import unittest
-import nose
-
 import operator
-from numpy import random, nan
-from numpy.random import randn
+
+import nose
 import numpy as np
 from numpy.testing import assert_array_equal
 
-import pandas as pan
-from pandas.core.api import DataFrame, Series, notnull, isnull
+from pandas.core.api import DataFrame
 from pandas.core import expressions as expr
-
-from pandas.util.testing import (assert_almost_equal,
-                                 assert_series_equal,
+from pandas.util.testing import (assert_series_equal,
                                  assert_frame_equal)
 from pandas.util import py3compat
 
-import pandas.util.testing as tm
-import pandas.lib as lib
-
-from numpy.testing.decorators import slow
 
 if not expr._USE_NUMEXPR:
     raise nose.SkipTest
@@ -127,11 +118,11 @@ class TestExpressions(unittest.TestCase):
                         result   = expr.evaluate(op, op_str, f, f, use_numexpr=True)
                         expected = expr.evaluate(op, op_str, f, f, use_numexpr=False)
                         assert_array_equal(result,expected.values)
-                
+
                         result   = expr._can_use_numexpr(op, op_str, f2, f2, 'evaluate')
                         self.assert_(result == False)
 
-        
+
         expr.set_use_numexpr(False)
         testit()
         expr.set_use_numexpr(True)
@@ -148,7 +139,7 @@ class TestExpressions(unittest.TestCase):
 
                 f11 = f
                 f12 = f + 1
-            
+
                 f21 = f2
                 f22 = f2 + 1
 
@@ -162,7 +153,7 @@ class TestExpressions(unittest.TestCase):
                     result   = expr.evaluate(op, op_str, f11, f12, use_numexpr=True)
                     expected = expr.evaluate(op, op_str, f11, f12, use_numexpr=False)
                     assert_array_equal(result,expected.values)
-                    
+
                     result   = expr._can_use_numexpr(op, op_str, f21, f22, 'evaluate')
                     self.assert_(result == False)
 
@@ -179,7 +170,7 @@ class TestExpressions(unittest.TestCase):
         def testit():
             for f in [ self.frame, self.frame2, self.mixed, self.mixed2 ]:
 
-                
+
                 for cond in [ True, False ]:
 
                     c = np.empty(f.shape,dtype=np.bool_)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -6,13 +6,16 @@ import cPickle as pickle
 import operator
 import re
 import unittest
-import nose
 
+import nose
 from numpy import random, nan
 from numpy.random import randn
 import numpy as np
 import numpy.ma as ma
 from numpy.testing import assert_array_equal
+from pandas.parser import CParserError
+import pandas.lib as lib
+from numpy.testing.decorators import slow
 
 import pandas as pan
 import pandas.core.nanops as nanops
@@ -20,12 +23,10 @@ import pandas.core.common as com
 import pandas.core.format as fmt
 import pandas.core.datetools as datetools
 from pandas.core.api import (DataFrame, Index, Series, notnull, isnull,
-                             MultiIndex, DatetimeIndex, Timestamp, Period)
+                             MultiIndex, DatetimeIndex, Timestamp)
 from pandas import date_range
 import pandas as pd
 from pandas.io.parsers import read_csv
-from pandas.parser import CParserError
-
 from pandas.util.testing import (assert_almost_equal,
                                  assert_series_equal,
                                  assert_frame_equal,
@@ -34,11 +35,8 @@ from pandas.util.testing import (assert_almost_equal,
                                  ensure_clean)
 from pandas.util import py3compat
 from pandas.util.compat import OrderedDict
-
 import pandas.util.testing as tm
-import pandas.lib as lib
 
-from numpy.testing.decorators import slow
 
 def _skip_if_no_scipy():
     try:
@@ -3142,7 +3140,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
     def test_operators_timedelta64(self):
 
-        from datetime import datetime, timedelta
+        from datetime import timedelta
         df = DataFrame(dict(A = date_range('2012-1-1', periods=3, freq='D'),
                             B = date_range('2012-1-2', periods=3, freq='D'),
                             C = Timestamp('20120101')-timedelta(minutes=5,seconds=5)))
@@ -6910,7 +6908,6 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         assert_frame_equal(result,expected)
 
         # test case from
-        from pandas.util.testing import makeCustomDataframe as mkdf
         df = DataFrame({'A' : Series([3,0],dtype='int64'), 'B' : Series([0,3],dtype='int64') })
         result = df.replace(3, df.mean().to_dict())
         expected = df.copy().astype('float64')
@@ -8453,7 +8450,6 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         assert_frame_equal(df, expected)
 
     def test_sort_index_different_sortorder(self):
-        import random
         A = np.arange(20).repeat(5)
         B = np.tile(np.arange(5), 20)
 

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1,21 +1,18 @@
-import nose
 import os
 import string
 import unittest
-
 from datetime import datetime, date
+
+import nose
+import numpy as np
+from numpy import random
+from numpy.testing import assert_array_equal
+from numpy.testing.decorators import slow
 
 from pandas import Series, DataFrame, MultiIndex, PeriodIndex, date_range
 import pandas.util.testing as tm
 from pandas.util.testing import ensure_clean
 from pandas.core.config import set_option
-
-
-import numpy as np
-from numpy import random
-
-from numpy.testing import assert_array_equal
-from numpy.testing.decorators import slow
 import pandas.tools.plotting as plotting
 
 

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -1,27 +1,23 @@
-import nose
 import unittest
-
 from datetime import datetime
+from collections import defaultdict
+
+import nose
 from numpy import nan
+import numpy as np
 
 from pandas import bdate_range
 from pandas.core.index import Index, MultiIndex
 from pandas.core.common import rands
 from pandas.core.api import Categorical, DataFrame
-from pandas.core.groupby import GroupByError, SpecificationError, DataError
+from pandas.core.groupby import SpecificationError, DataError
 from pandas.core.series import Series
 from pandas.util.testing import (assert_panel_equal, assert_frame_equal,
                                  assert_series_equal, assert_almost_equal)
 from pandas.core.panel import Panel
 from pandas.tools.merge import concat
-from collections import defaultdict
 import pandas.core.common as com
-import pandas.core.datetools as dt
-import numpy as np
-from numpy.testing import assert_equal
-
 import pandas.core.nanops as nanops
-
 import pandas.util.testing as tm
 
 

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -4,24 +4,21 @@ from datetime import datetime, timedelta
 import operator
 import pickle
 import unittest
-import nose
 import os
 
+import nose
 import numpy as np
 from numpy.testing import assert_array_equal
+from pandas.lib import Timestamp
 
 from pandas.core.index import Index, Int64Index, MultiIndex
 from pandas.util.testing import assert_almost_equal
 from pandas.util import py3compat
-
 import pandas.util.testing as tm
 import pandas.core.config as cf
-
 from pandas.tseries.index import _to_m8
 import pandas.tseries.offsets as offsets
-
 import pandas as pd
-from pandas.lib import Timestamp
 
 
 class TestIndex(unittest.TestCase):

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -1,26 +1,20 @@
 # pylint: disable-msg=W0612,E1101
 import unittest
-import nose
 import itertools
 from StringIO import StringIO
 
-from numpy import random, nan
+import nose
+from numpy import nan
 from numpy.random import randn
 import numpy as np
-from numpy.testing import assert_array_equal
 
 import pandas as pd
-import pandas.core.common as com
-from pandas.core.api import (DataFrame, Index, Series, Panel, notnull, isnull,
-                             MultiIndex, DatetimeIndex, Timestamp)
+from pandas.core.api import (DataFrame, Index, Series, Panel, MultiIndex, Timestamp)
 from pandas.util.testing import (assert_almost_equal, assert_series_equal,
                                  assert_frame_equal, assert_panel_equal)
-from pandas.util import py3compat
-
 import pandas.util.testing as tm
-import pandas.lib as lib
 from pandas import date_range
-from numpy.testing.decorators import slow
+
 
 _verbose = False
 

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -6,7 +6,6 @@ import numpy as np
 
 from pandas import Index, MultiIndex, DataFrame, Series
 from pandas.core.internals import *
-import pandas.core.internals as internals
 import pandas.util.testing as tm
 
 from pandas.util.testing import (

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1,14 +1,14 @@
 # pylint: disable-msg=W0612,E1101,W0141
-from pandas.util.py3compat import StringIO
-import nose
 import unittest
 
+import nose
 from numpy.random import randn
 import numpy as np
+import pandas.index as _index
 
+from pandas.util.py3compat import StringIO
 from pandas.core.index import Index, MultiIndex
 from pandas import Panel, DataFrame, Series, notnull, isnull
-
 from pandas.util.testing import (assert_almost_equal,
                                  assert_series_equal,
                                  assert_frame_equal)
@@ -16,8 +16,6 @@ import pandas.core.common as com
 import pandas.util.testing as tm
 from pandas.util.compat import product as cart_product
 import pandas as pd
-
-import pandas.index as _index
 
 
 class TestMultiLevel(unittest.TestCase):

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -1,20 +1,17 @@
 from datetime import datetime
-import os
 import operator
 import unittest
 import nose
 
 import numpy as np
 
-from pandas import DataFrame, Index, isnull, notnull, pivot, MultiIndex
+from pandas import Index, isnull, notnull
 from pandas.core.datetools import bday
 from pandas.core.frame import group_agg
 from pandas.core.panel import Panel
 from pandas.core.panel4d import Panel4D
 from pandas.core.series import remove_na
 import pandas.core.common as com
-import pandas.core.panel as panelmod
-from pandas.util import py3compat
 
 from pandas.util.testing import (assert_panel_equal,
                                  assert_panel4d_equal,

--- a/pandas/tests/test_panelnd.py
+++ b/pandas/tests/test_panelnd.py
@@ -1,21 +1,9 @@
-from datetime import datetime
-import os
-import operator
 import unittest
 import nose
 
-import numpy as np
-
 from pandas.core import panelnd
 from pandas.core.panel import Panel
-import pandas.core.common as com
-from pandas.util import py3compat
-
-from pandas.util.testing import (assert_panel_equal,
-                                 assert_panel4d_equal,
-                                 assert_frame_equal,
-                                 assert_series_equal,
-                                 assert_almost_equal)
+from pandas.util.testing import assert_panel_equal
 import pandas.util.testing as tm
 
 

--- a/pandas/tests/test_reshape.py
+++ b/pandas/tests/test_reshape.py
@@ -1,20 +1,12 @@
 # pylint: disable-msg=W0612,E1101
-from copy import deepcopy
-from datetime import datetime, timedelta
-from StringIO import StringIO
-import cPickle as pickle
-import operator
-import os
 import unittest
 
 import nose
-
-from pandas import DataFrame
-import pandas as pd
-
 from numpy import nan
 import numpy as np
 
+from pandas import DataFrame
+import pandas as pd
 from pandas.core.reshape import melt, convert_dummies, lreshape
 import pandas.util.testing as tm
 

--- a/pandas/tests/test_rplot.py
+++ b/pandas/tests/test_rplot.py
@@ -1,9 +1,10 @@
 import unittest
-import pandas.tools.rplot as rplot
-from pandas import read_csv
 import os
 
 import nose
+
+import pandas.tools.rplot as rplot
+from pandas import read_csv
 
 
 try:

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1,28 +1,24 @@
 # pylint: disable-msg=E1101,W0612
 
-from datetime import datetime, timedelta, date
-import os
+from datetime import datetime, timedelta
 import operator
 import unittest
 
 import nose
-
 from numpy import nan
 import numpy as np
 import numpy.ma as ma
-import pandas as pd
+import pandas.lib as lib
 
+import pandas as pd
 from pandas import (Index, Series, TimeSeries, DataFrame, isnull, notnull,
                     bdate_range, date_range)
 from pandas.core.index import MultiIndex
 from pandas.tseries.index import Timestamp, DatetimeIndex
 import pandas.core.config as cf
 import pandas.core.series as smod
-import pandas.lib as lib
-
 import pandas.core.datetools as datetools
 import pandas.core.nanops as nanops
-
 from pandas.util.py3compat import StringIO
 from pandas.util import py3compat
 from pandas.util.testing import (assert_series_equal,
@@ -3210,7 +3206,8 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         assert_series_equal(result, ts)
 
     def test_getitem_setitem_periodindex(self):
-        from pandas import period_range, Period
+        from pandas import period_range
+
         N = 50
         rng = period_range('1/1/1990', periods=N, freq='H')
         ts = Series(np.random.randn(N), index=rng)

--- a/pandas/tests/test_stats.py
+++ b/pandas/tests/test_stats.py
@@ -1,11 +1,10 @@
-import nose
 import unittest
 
+import nose
 from numpy import nan
 import numpy as np
 
 from pandas import Series, DataFrame
-
 from pandas.util.compat import product
 from pandas.util.testing import (assert_frame_equal,
                                  assert_series_equal,

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -1,8 +1,6 @@
 # pylint: disable-msg=E1101,W0612
 
-from datetime import datetime, timedelta, date
-import os
-import operator
+from datetime import datetime
 import re
 import unittest
 
@@ -13,11 +11,10 @@ import numpy as np
 from numpy.testing import assert_array_equal
 from numpy.random import randint
 
-from pandas import (Index, Series, TimeSeries, DataFrame, isnull, notnull,
-                    bdate_range, date_range)
+from pandas import Series, isnull
 import pandas.core.common as com
 
-from pandas.util.testing import assert_series_equal, assert_almost_equal
+from pandas.util.testing import assert_series_equal
 import pandas.util.testing as tm
 
 import pandas.core.strings as strings
@@ -776,7 +773,6 @@ class TestStringMethods(unittest.TestCase):
 
     def test_more_contains(self):
         # PR #1179
-        import re
 
         s = Series(['A', 'B', 'C', 'Aaba', 'Baca', '', NA,
                     'CABA', 'dog', 'cat'])
@@ -808,7 +804,6 @@ class TestStringMethods(unittest.TestCase):
 
     def test_more_replace(self):
         # PR #1179
-        import re
         s = Series(['A', 'B', 'C', 'Aaba', 'Baca',
                     '', NA, 'CABA', 'dog', 'cat'])
 

--- a/pandas/tests/test_tests.py
+++ b/pandas/tests/test_tests.py
@@ -1,10 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 from __future__ import with_statement  # support python 2.5
-import pandas as pd
 import unittest
-import warnings
-import nose
 
 from pandas.util.testing import assert_almost_equal
 

--- a/pandas/tests/test_tseries.py
+++ b/pandas/tests/test_tseries.py
@@ -2,12 +2,11 @@ import unittest
 
 from numpy import nan
 import numpy as np
-from pandas import Index, isnull, Timestamp
-from pandas.util.testing import assert_almost_equal
-import pandas.util.testing as common
 import pandas.lib as lib
 import pandas.algos as algos
-from datetime import datetime
+
+from pandas import Index, isnull, Timestamp
+from pandas.util.testing import assert_almost_equal
 
 
 class TestTseriesUtil(unittest.TestCase):

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -3,8 +3,13 @@ SQL-style merge routines
 """
 
 import itertools
-import numpy as np
 import types
+
+import numpy as np
+import pandas.lib as lib
+import pandas.algos as algos
+import pandas.hashtable as _hash
+
 from pandas.core.categorical import Categorical
 from pandas.core.frame import DataFrame, _merge_doc
 from pandas.core.generic import NDFrame
@@ -19,10 +24,6 @@ from pandas.util.decorators import cache_readonly, Appender, Substitution
 from pandas.core.common import PandasError
 from pandas.sparse.frame import SparseDataFrame
 import pandas.core.common as com
-
-import pandas.lib as lib
-import pandas.algos as algos
-import pandas.hashtable as _hash
 
 
 @Substitution('\nleft : DataFrame')

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -1,12 +1,12 @@
 # pylint: disable=E1103
 
+import numpy as np
+
 from pandas import Series, DataFrame
 from pandas.core.index import MultiIndex
-from pandas.core.reshape import _unstack_multiple
 from pandas.tools.merge import concat
 from pandas.tools.util import cartesian_product
 import pandas.core.common as com
-import numpy as np
 
 
 def pivot_table(data, values=None, rows=None, cols=None, aggfunc='mean',

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -1,13 +1,14 @@
 # pylint: disable=E1103
 
-import nose
 import unittest
-
 from datetime import datetime
+
+import nose
 from numpy.random import randn
 from numpy import nan
 import numpy as np
 import random
+import pandas.algos as algos
 
 from pandas import *
 from pandas.tseries.index import DatetimeIndex
@@ -15,8 +16,8 @@ from pandas.tools.merge import merge, concat, ordered_merge, MergeError
 from pandas.util.testing import (assert_frame_equal, assert_series_equal,
                                  assert_almost_equal, rands,
                                  makeCustomDataframe as mkdf)
-import pandas.algos as algos
 import pandas.util.testing as tm
+
 
 a_ = np.array
 

--- a/pandas/tools/tests/test_tile.py
+++ b/pandas/tools/tests/test_tile.py
@@ -1,19 +1,17 @@
 import os
-import nose
 import unittest
 
+import nose
 import numpy as np
+from numpy.testing import assert_equal, assert_almost_equal
 
-from pandas import DataFrame, Series, unique
+from pandas import Series
 import pandas.util.testing as tm
 from pandas.util.testing import assertRaisesRegexp
 import pandas.core.common as com
-
 from pandas.core.algorithms import quantile
 from pandas.tools.tile import cut, qcut
 import pandas.tools.tile as tmod
-
-from numpy.testing import assert_equal, assert_almost_equal
 
 
 class TestCut(unittest.TestCase):

--- a/pandas/tools/tests/test_tools.py
+++ b/pandas/tools/tests/test_tools.py
@@ -1,9 +1,9 @@
 # import unittest
 
+import numpy as np
+
 from pandas import DataFrame
 from pandas.tools.describe import value_range
-
-import numpy as np
 
 
 def test_value_range():

--- a/pandas/tools/tests/test_util.py
+++ b/pandas/tools/tests/test_util.py
@@ -1,11 +1,11 @@
-import os
-import nose
 import unittest
 
+import nose
 import numpy as np
 from numpy.testing import assert_equal
 
 from pandas.tools.util import cartesian_product
+
 
 class TestCartesianProduct(unittest.TestCase):
 

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -2,14 +2,13 @@
 Quantilization functions and related stuff
 """
 
-from pandas.core.api import DataFrame, Series
+import numpy as np
+
+from pandas.core.api import Series
 from pandas.core.categorical import Categorical
-from pandas.core.index import _ensure_index
 import pandas.core.algorithms as algos
 import pandas.core.common as com
 import pandas.core.nanops as nanops
-
-import numpy as np
 
 
 def cut(x, bins, right=True, labels=None, retbins=False, precision=3,

--- a/pandas/tools/util.py
+++ b/pandas/tools/util.py
@@ -1,5 +1,7 @@
-from pandas.core.index import Index
 import numpy as np
+
+from pandas.core.index import Index
+
 
 def match(needles, haystack):
     haystack = Index(haystack)

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -2,14 +2,14 @@ from datetime import datetime
 import re
 
 import numpy as np
+import pandas.lib as lib
+import pandas.tslib as tslib
 
 from pandas.core.algorithms import unique
 from pandas.tseries.offsets import DateOffset
 from pandas.util.decorators import cache_readonly
 import pandas.tseries.offsets as offsets
 import pandas.core.common as com
-import pandas.lib as lib
-import pandas.tslib as tslib
 
 
 class FreqGroup(object):

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1,10 +1,14 @@
 # pylint: disable=E1101
 import operator
-
 from datetime import time, datetime
 from datetime import timedelta
 
 import numpy as np
+from pandas.lib import Timestamp
+import pandas.lib as lib
+import pandas.tslib as tslib
+import pandas.algos as _algos
+import pandas.index as _index
 
 from pandas.core.common import isnull, _NS_DTYPE, _INT64_DTYPE
 from pandas.core.index import Index, Int64Index
@@ -17,12 +21,6 @@ from pandas.util.decorators import cache_readonly
 import pandas.core.common as com
 import pandas.tseries.offsets as offsets
 import pandas.tseries.tools as tools
-
-from pandas.lib import Timestamp
-import pandas.lib as lib
-import pandas.tslib as tslib
-import pandas.algos as _algos
-import pandas.index as _index
 
 
 def _utc():

--- a/pandas/tseries/interval.py
+++ b/pandas/tseries/interval.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from pandas.core.index import Index
 
 

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -1,25 +1,22 @@
 # pylint: disable=E1101,E1103,W0232
 import operator
-
 from datetime import datetime, date
-import numpy as np
-from pandas.core.base import PandasObject
 
-import pandas.tseries.offsets as offsets
+import numpy as np
+import pandas.lib as lib
+import pandas.tslib as tslib
+import pandas.algos as _algos
+import pandas.core.common as com
+import pandas.tseries.frequencies as _freq_mod
+
+from pandas.lib import Timestamp
+from pandas.core.base import PandasObject
 from pandas.tseries.frequencies import (get_freq_code as _gfc,
                                         _month_numbers, FreqGroup)
 from pandas.tseries.index import DatetimeIndex, Int64Index, Index
 from pandas.tseries.tools import parse_time_string
-import pandas.tseries.frequencies as _freq_mod
-
-import pandas.core.common as com
-from pandas.core.common import isnull, _NS_DTYPE, _INT64_DTYPE
+from pandas.core.common import isnull, _INT64_DTYPE
 from pandas.util import py3compat
-
-from pandas.lib import Timestamp
-import pandas.lib as lib
-import pandas.tslib as tslib
-import pandas.algos as _algos
 
 
 #---------------

--- a/pandas/tseries/plotting.py
+++ b/pandas/tseries/plotting.py
@@ -4,22 +4,18 @@ Pierre GF Gerard-Marchant & Matt Knox
 """
 
 #!!! TODO: Use the fact that axis can have units to simplify the process
-import datetime as pydt
 from datetime import datetime
 
 from matplotlib import pylab
-import matplotlib.units as units
 
 import numpy as np
 
-from pandas import isnull
-from pandas.tseries.period import Period
-from pandas.tseries.offsets import DateOffset
-import pandas.tseries.frequencies as frequencies
-from pandas.tseries.index import DatetimeIndex
 import pandas.core.common as com
-
-from pandas.tseries.converter import (PeriodConverter, TimeSeries_DateLocator,
+import pandas.tseries.frequencies as frequencies
+from pandas import isnull
+from pandas.tseries.offsets import DateOffset
+from pandas.tseries.index import DatetimeIndex
+from pandas.tseries.converter import (TimeSeries_DateLocator,
                                       TimeSeries_DateFormatter)
 
 #----------------------------------------------------------------------

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -1,6 +1,8 @@
 from datetime import timedelta
 
 import numpy as np
+from pandas.lib import Timestamp
+import pandas.lib as lib
 
 from pandas.core.groupby import BinGrouper, CustomGrouper
 from pandas.tseries.frequencies import to_offset, is_subperiod, is_superperiod
@@ -9,9 +11,6 @@ from pandas.tseries.offsets import DateOffset, Tick, _delta_to_nanoseconds
 from pandas.tseries.period import PeriodIndex, period_range
 import pandas.tseries.tools as tools
 import pandas.core.common as com
-
-from pandas.lib import Timestamp
-import pandas.lib as lib
 
 
 _DEFAULT_METHOD = 'mean'
@@ -277,7 +276,6 @@ class TimeGrouper(CustomGrouper):
 
 def _take_new_index(obj, indexer, new_index, axis=0):
     from pandas.core.api import Series, DataFrame
-    from pandas.core.internals import BlockManager
 
     if isinstance(obj, Series):
         new_values = com.take_1d(obj.values, indexer)

--- a/pandas/tseries/tests/test_converter.py
+++ b/pandas/tseries/tests/test_converter.py
@@ -1,11 +1,7 @@
-from datetime import datetime, time, timedelta, date
-import sys
-import os
+from datetime import datetime, date
 import unittest
 
 import nose
-
-import numpy as np
 
 try:
     import pandas.tseries.converter as converter

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -11,7 +11,6 @@ from pandas.tseries.index import DatetimeIndex
 from pandas import Timestamp
 from pandas.tseries.offsets import generate_range
 from pandas.tseries.index import cdate_range, bdate_range, date_range
-import pandas.tseries.tools as tools
 
 import pandas.core.datetools as datetools
 from pandas.util.testing import assertRaisesRegexp

--- a/pandas/tseries/tests/test_frequencies.py
+++ b/pandas/tseries/tests/test_frequencies.py
@@ -1,6 +1,4 @@
-from datetime import datetime, time, timedelta
-import sys
-import os
+from datetime import datetime, timedelta
 import unittest
 
 import nose
@@ -13,8 +11,6 @@ from pandas.tseries.frequencies import to_offset, infer_freq
 from pandas.tseries.tools import to_datetime
 import pandas.tseries.frequencies as fmod
 import pandas.tseries.offsets as offsets
-
-import pandas.lib as lib
 
 
 def test_to_offset_multiple():

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -1,9 +1,11 @@
 from datetime import date, datetime, timedelta
 import unittest
+
 import nose
 from nose.tools import assert_raises
-
 import numpy as np
+from pandas.tslib import monthrange
+from pandas.lib import Timestamp
 
 from pandas.core.datetools import (
     bday, BDay, cday, CDay, BQuarterEnd, BMonthEnd, BYearEnd, MonthEnd,
@@ -11,17 +13,14 @@ from pandas.core.datetools import (
     DateOffset, Week, YearBegin, YearEnd, Hour, Minute, Second, Day, Micro,
     Milli, Nano,
     WeekOfMonth, format, ole2datetime, QuarterEnd, to_datetime, normalize_date,
-    get_offset, get_offset_name, inferTimeRule, hasOffsetName,
+    get_offset, get_offset_name, hasOffsetName,
     get_standard_freq)
-
 from pandas.tseries.frequencies import _offset_map
 from pandas.tseries.index import _to_m8
 from pandas.tseries.tools import parse_time_string
 import pandas.tseries.offsets as offsets
-
-from pandas.tslib import monthrange
-from pandas.lib import Timestamp
 from pandas.util.testing import assertRaisesRegexp
+
 
 _multiprocess_can_split_ = True
 

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -11,6 +11,7 @@ from datetime import datetime, date, timedelta
 import unittest
 
 from numpy.ma.testutils import assert_equal
+import numpy as np
 
 from pandas import Timestamp
 from pandas.tseries.frequencies import MONTHS, DAYS
@@ -18,10 +19,9 @@ from pandas.tseries.period import Period, PeriodIndex, period_range
 from pandas.tseries.index import DatetimeIndex, date_range, Index
 from pandas.tseries.tools import to_datetime
 import pandas.tseries.period as pmod
-
 import pandas.core.datetools as datetools
 import pandas as pd
-import numpy as np
+
 randn = np.random.randn
 
 from pandas import Series, TimeSeries, DataFrame

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -1,4 +1,3 @@
-import os
 from datetime import datetime, timedelta, date, time
 
 import unittest

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -1,21 +1,18 @@
 # pylint: disable=E1101
 
 from datetime import datetime, timedelta
+import unittest
 
 import numpy as np
+import nose
 
 from pandas import Series, TimeSeries, DataFrame, Panel, isnull, notnull, Timestamp
-
 from pandas.tseries.index import date_range
 from pandas.tseries.offsets import Minute, BDay
 from pandas.tseries.period import period_range, PeriodIndex, Period
 from pandas.tseries.resample import DatetimeIndex, TimeGrouper
 import pandas.tseries.offsets as offsets
 import pandas as pd
-
-import unittest
-import nose
-
 from pandas.util.testing import (assert_series_equal, assert_almost_equal,
                                  assert_frame_equal)
 import pandas.util.testing as tm

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1,13 +1,14 @@
 # pylint: disable-msg=E1101,W0612
-import pandas.util.compat as itertools
 from datetime import datetime, time, timedelta
 import sys
 import os
 import unittest
 
 import nose
-
 import numpy as np
+
+import pandas.util.compat as itertools
+
 randn = np.random.randn
 
 from pandas import (Index, Series, TimeSeries, DataFrame,

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -1,36 +1,21 @@
 # pylint: disable-msg=E1101,W0612
-from datetime import datetime, time, timedelta, tzinfo, date
-import sys
-import os
+from datetime import datetime, timedelta, tzinfo, date
 import unittest
-import nose
 
+import nose
 import numpy as np
 import pytz
-
-from pandas import (Index, Series, TimeSeries, DataFrame, isnull,
-                    date_range, Timestamp)
-
-from pandas import DatetimeIndex, Int64Index, to_datetime
-
-from pandas.core.daterange import DateRange
-import pandas.core.datetools as datetools
-import pandas.tseries.offsets as offsets
-from pandas.tseries.index import bdate_range, date_range
-import pandas.tseries.tools as tools
 from pytz import NonExistentTimeError
 
-from pandas.util.testing import assert_series_equal, assert_almost_equal, assertRaisesRegexp
+from pandas import (Index, Series, DataFrame, date_range, Timestamp)
+from pandas import DatetimeIndex, to_datetime
+import pandas.core.datetools as datetools
+import pandas.tseries.offsets as offsets
+from pandas.tseries.index import bdate_range
+import pandas.tseries.tools as tools
+from pandas.util.testing import assert_series_equal, assertRaisesRegexp
 import pandas.util.testing as tm
-
-import pandas.lib as lib
-import cPickle as pickle
-import pandas.core.datetools as dt
-from numpy.random import rand
 from pandas.util.testing import assert_frame_equal
-import pandas.util.py3compat as py3compat
-from pandas.core.datetools import BDay
-import pandas.core.common as com
 
 
 def _skip_if_no_pytz():
@@ -139,7 +124,6 @@ class TestTimeZoneSupport(unittest.TestCase):
         self.assertEquals(result, expected)
 
     def test_tz_localize_dti(self):
-        from pandas.tseries.offsets import Hour
 
         dti = DatetimeIndex(start='1/1/2005', end='1/1/2005 0:00:30.256',
                             freq='L')

--- a/pandas/tseries/tests/test_util.py
+++ b/pandas/tseries/tests/test_util.py
@@ -1,14 +1,11 @@
-import nose
 import unittest
+from datetime import datetime, date
 
+import nose
 import numpy as np
-from numpy.testing.decorators import slow
 
 from pandas import Series, date_range
 import pandas.util.testing as tm
-
-from datetime import datetime, date
-
 from pandas.tseries.tools import normalize_date
 from pandas.tseries.util import pivot_annual, isleapyear
 

--- a/pandas/tseries/tools.py
+++ b/pandas/tseries/tools.py
@@ -4,7 +4,6 @@ import sys
 
 import numpy as np
 
-import pandas.lib as lib
 import pandas.tslib as tslib
 import pandas.core.common as com
 from pandas.util.py3compat import StringIO
@@ -161,9 +160,7 @@ def parse_time_string(arg, freq=None, dayfirst=None, yearfirst=None):
     datetime, datetime/dateutil.parser._result, str
     """
     from pandas.core.config import get_option
-    from pandas.tseries.offsets import DateOffset
-    from pandas.tseries.frequencies import (_get_rule_month, _month_numbers,
-                                            _get_freq_str)
+    from pandas.tseries.frequencies import (_get_rule_month, _month_numbers)
 
     if not isinstance(arg, basestring):
         return arg

--- a/pandas/tseries/util.py
+++ b/pandas/tseries/util.py
@@ -1,7 +1,5 @@
 import numpy as np
 
-import pandas as pd
-
 import pandas.core.common as com
 from pandas.core.frame import DataFrame
 import pandas.core.nanops as nanops

--- a/pandas/util/clipboard.py
+++ b/pandas/util/clipboard.py
@@ -42,7 +42,9 @@
 # 1.2 Use the platform module to help determine OS.
 # 1.3 Changed ctypes.windll.user32.OpenClipboard(None) to ctypes.windll.user32.OpenClipboard(0), after some people ran into some TypeError
 
-import platform, os
+import platform
+import os
+
 
 def winGetClipboard():
     ctypes.windll.user32.OpenClipboard(0)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -12,7 +12,7 @@ import os
 
 from datetime import datetime
 from functools import wraps
-from contextlib import contextmanager, closing
+from contextlib import contextmanager
 from httplib import HTTPException
 from urllib2 import urlopen
 from distutils.version import LooseVersion
@@ -30,8 +30,6 @@ import pandas.core.panel4d as panel4d
 from pandas import bdate_range
 from pandas.tseries.index import DatetimeIndex
 from pandas.tseries.period import PeriodIndex
-
-from pandas.io.common import urlopen
 
 Index = index.Index
 MultiIndex = index.MultiIndex


### PR DESCRIPTION
Cleans up imports throughout pandas, removing unused and reordering to
better match PEP8 where reasonable. Thanks to PyCharm for making this much
easier. Doesn't change any .pyx or .pyd files. (inspired by import issue
in #4249)
