### PR TITLE
ENH: Keep original stack when exception happened in dataframe.apply

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4488,7 +4488,7 @@ class DataFrame(NDFrame):
                 except (NameError, UnboundLocalError):  # pragma: no cover
                     # no k defined yet
                     pass
-                raise e
+                raise
 
 
         if len(results) > 0 and _is_sequence(results[0]):


### PR DESCRIPTION
when using raise e, the error stack app user received will begin in  _apply_standard method.

Use raise instead, so that user could received error stack in funv(v) call. Easier for user to debug.
