### PR TITLE
ENH: Dataframe isin2

### DIFF
--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -456,11 +456,9 @@ and :ref:`Advanced Indexing <indexing.advanced>` you may select along more than 
 
    df2.loc[criterion & (df2['b'] == 'x'),'b':'c']
 
-*New in 0.12.0*
-
 DataFrame also has an ``isin`` method.  When calling ``isin``, pass a set of
-values as either an array or dict.  If values is just an array, ``isin`` returns
-a DataFrame of booleans that is the same shape as the original DataFrame, with Trues
+values as either an array or dict.  If values is an array, ``isin`` returns
+a DataFrame of booleans that is the same shape as the original DataFrame, with True
 wherever the element is in the sequence of values.
 
 .. ipython:: python
@@ -472,10 +470,9 @@ wherever the element is in the sequence of values.
 
    df.isin(values)
 
-Oftentimes you'll want to match certain values with certain columns or rows.
-Just make values a ``dict`` where the key is the row or column, and the value is
-a list of items you want to check for.  Make sure to set axis equal to 0 for
-row-wise or 1 for column-wise matching.
+Oftentimes you'll want to match certain values with certain columns.
+Just make values a ``dict`` where the key is the column, and the value is
+a list of items you want to check for.
 
 .. ipython:: python
 
@@ -484,7 +481,7 @@ row-wise or 1 for column-wise matching.
 
    values = {'ids': ['a', 'b'], 'vals': [1, 3]}
 
-   df.isin(values, axis=1)
+   df.isin(values)
 
 Where and Masking
 ~~~~~~~~~~~~~~~~~

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -476,12 +476,18 @@ a list of items you want to check for.
 
 .. ipython:: python
 
-   df = DataFrame({'vals': [1, 2, 3, 4], 'ids': ['a', 'b', 'f', 'n'],
-                   'ids2': ['a', 'n', 'c', 'n']})
-
    values = {'ids': ['a', 'b'], 'vals': [1, 3]}
 
    df.isin(values)
+
+You can also describe columns using integer location:
+
+.. ipython:: python
+
+   values = {0: ['a', 'b']}
+
+   df.isin(values, iloc=True)
+
 
 Where and Masking
 ~~~~~~~~~~~~~~~~~

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -456,6 +456,36 @@ and :ref:`Advanced Indexing <indexing.advanced>` you may select along more than 
 
    df2.loc[criterion & (df2['b'] == 'x'),'b':'c']
 
+*New in 0.12.0*
+
+DataFrame also has an ``isin`` method.  When calling ``isin``, pass a set of
+values as either an array or dict.  If values is just an array, ``isin`` returns
+a DataFrame of booleans that is the same shape as the original DataFrame, with Trues
+wherever the element is in the sequence of values.
+
+.. ipython:: python
+
+   df = DataFrame({'vals': [1, 2, 3, 4], 'ids': ['a', 'b', 'f', 'n'],
+                'ids2': ['a', 'n', 'c', 'n']})
+
+   values = ['a', 'b', 1, 3]
+
+   df.isin(values)
+
+Oftentimes you'll want to match certain values with certain columns or rows.
+Just make values a ``dict`` where the key is the row or column, and the value is
+a list of items you want to check for.  Make sure to set axis equal to 0 for
+row-wise or 1 for column-wise matching.
+
+.. ipython:: python
+
+   df = DataFrame({'vals': [1, 2, 3, 4], 'ids': ['a', 'b', 'f', 'n'],
+                   'ids2': ['a', 'n', 'c', 'n']})
+
+   values = {'ids': ['a', 'b'], 'vals': [1, 3]}
+
+   df.isin(values, axis=1)
+
 Where and Masking
 ~~~~~~~~~~~~~~~~~
 

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -54,6 +54,7 @@ pandas 0.12
   - Access to historical Google Finance data in pandas.io.data (:issue:`3814`)
   - DataFrame plotting methods can sample column colors from a Matplotlib
     colormap via the ``colormap`` keyword. (:issue:`3860`)
+  - Added ``isin`` method to DataFrame (:issue:`4211`)
 
 **Improvements to existing features**
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5481,6 +5481,38 @@ class DataFrame(NDFrame):
 
         return self._constructor(new_data)
 
+    def isin(self, values, axis=None):
+        """
+        Return boolean vector showing whether elements in the DataFrame are
+        exactly contained in the passed sequence of values.
+
+        Parameters
+        ----------
+        values : sequence (array-like) or dict of {label: sequence}.
+        axis : {None, 0, 1}
+            Compute isin row-wise (axis=0) or column-wise (axis=1)
+            Mandatory if values is a dict, ignored otherwise.
+
+        Returns
+        -------
+
+        bools : Series of booleans
+        """
+        if not isinstance(values, dict):
+            return self.applymap(values.__contains__)
+
+        else:
+            from pandas.tools.merge import concat
+            if axis == 1:
+                return concat((self[col].isin(vals) for col, vals in
+                               values.iteritems()), axis=1)
+            elif axis == 0:
+                return concat((self.loc[row].isin(vals) for row, vals in
+                               values.iteritems()), axis=1).T
+            else:
+                raise TypeError('Axis must be "0" or "1" when values is a dict '
+                                'Got "%s" instead.' % str(axis))
+
     #----------------------------------------------------------------------
     # Deprecated stuff
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5482,14 +5482,16 @@ class DataFrame(NDFrame):
         return self._constructor(new_data)
 
 
-    def isin(self, values):
+    def isin(self, values, iloc=False):
         """
-        Return boolean DataFrame showing whether each elements in the DataFrame is
-        contained in items.
+        Return boolean DataFrame showing whether each element in the DataFrame is
+        contained in values.
 
         Parameters
         ----------
         values : iterable or dictionary of columns to values
+        iloc : boolean, if passing a dict as values, describe columns using integer
+                        locations (default is to use labels)
 
         Returns
         -------
@@ -5500,8 +5502,13 @@ class DataFrame(NDFrame):
             from collections import defaultdict
             from pandas.tools.merge import concat
             values = defaultdict(list, values)
-            return concat((self.iloc[:, [i]].isin(values[ind] or values[i])
-                             for i, ind in enumerate(self.columns)), axis=1)
+            if iloc:
+                return concat((self.iloc[:, [i]].isin(values[i])
+                                 for i, col in enumerate(self.columns)), axis=1)
+            else:
+                return concat((self.iloc[:, [i]].isin(values[col])
+                                 for i, col in enumerate(self.columns)), axis=1)
+
 
         else:
             return DataFrame(lib.ismember(self.values.ravel(),

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -10661,11 +10661,26 @@ starting,ending,measure
         assert_frame_equal(result, expected)
 
         # non unique columns
+        df = DataFrame({'A': ['a', 'b', 'c'], 'B': ['a', 'e', 'f']})
         df.columns = ['A', 'A']
         expected = DataFrame(False, df.index, df.columns)
         expected.loc[0, 'A'] = True
         result = df.isin(d)
         assert_frame_equal(result, expected)
+
+        # iloc
+        df = DataFrame({'A': ['a', 'b', 'c'], 'B': ['a', 'e', 'f']})
+        d = {0: ['a']}
+        expected = DataFrame(False, df.index, df.columns)
+
+        # without using iloc
+        result = df.isin(d)
+        assert_frame_equal(result, expected)        
+
+        # using iloc
+        result = df.isin(d, iloc=True)
+        expected.iloc[0, 0] = True
+        assert_frame_equal(result, expected)        
 
 
 if __name__ == '__main__':

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -10633,6 +10633,56 @@ starting,ending,measure
         f = lambda x: x.rename({1: 'foo'}, inplace=True)
         _check_f(data.copy()['c'], f)
 
+    def test_isin(self):
+        # GH #4211
+        df = DataFrame({'vals': [1, 2, 3, 4], 'ids': ['a', 'b', 'f', 'n'],
+                        'ids2': ['a', 'n', 'c', 'n']},
+                        index=['foo', 'bar', 'baz', 'qux'])
+        other = ['a', 'b', 'c']
+        result_none = df[['ids', 'ids2']].isin(other)
+        expected_none = DataFrame({'ids':  [True, True, False, False],
+                                  'ids2': [True, False, True, False]},
+                                  index=['foo', 'bar', 'baz', 'qux'])
+
+        assert_frame_equal(result_none, expected_none)
+
+        # axis = None
+        result_none_full = df.isin(other)
+        expected_none_full = DataFrame({'ids': [True, True, False, False],
+                                        'ids2': [True, False, True, False],
+                                        'vals': [False, False, False, False]},
+                                        index=['foo', 'bar', 'baz', 'qux'])
+
+        assert_frame_equal(result_none_full, expected_none_full)
+
+    def test_isin_dict(self):
+        df = DataFrame({'A': ['a', 'b', 'c', 'd'], 'B': [1, 2, 3, 4],
+                        'C': [1, 5, 7, 8]},
+                        index=['foo', 'bar', 'baz', 'qux'])
+        other = {'A': ('a', 'b'), 'B': (1, 3)}
+        result = df.isin(other, axis=1)
+        expected = DataFrame({'A': [True, True, False, False],
+                              'B': [True, False, True, False]},
+                              index=['foo', 'bar', 'baz', 'qux'])
+        assert_frame_equal(result, expected)
+
+    def test_isin_row(self):
+        df = DataFrame({'A': ['a', 'b', 'c', 'd'], 'B': [1, 2, 3, 4],
+                        'C': [1, 5, 7, 8]},
+                        index=['foo', 'bar', 'baz', 'qux'])
+        ind_other = {'foo': ['a', 1, 1],
+                     'bar': ['d', 2, 1],
+                     'baz': ['nn', 'nn', 'nn']}
+
+        result_ind = df.isin(ind_other, axis=0)
+        expected_ind = DataFrame({'A': [True, False, False],
+                                  'B': [True, True, False],
+                                  'C': [True, False, False]},
+                            index=['foo', 'bar', 'baz']).reindex_like(result_ind)
+
+        assert_frame_equal(result_ind, expected_ind)
+
+        self.assertRaises(TypeError, df.isin, ind_other)
 
 if __name__ == '__main__':
     # unittest.main()

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -10639,50 +10639,34 @@ starting,ending,measure
                         'ids2': ['a', 'n', 'c', 'n']},
                         index=['foo', 'bar', 'baz', 'qux'])
         other = ['a', 'b', 'c']
-        result_none = df[['ids', 'ids2']].isin(other)
-        expected_none = DataFrame({'ids':  [True, True, False, False],
-                                  'ids2': [True, False, True, False]},
-                                  index=['foo', 'bar', 'baz', 'qux'])
 
-        assert_frame_equal(result_none, expected_none)
-
-        # axis = None
-        result_none_full = df.isin(other)
-        expected_none_full = DataFrame({'ids': [True, True, False, False],
-                                        'ids2': [True, False, True, False],
-                                        'vals': [False, False, False, False]},
-                                        index=['foo', 'bar', 'baz', 'qux'])
-
-        assert_frame_equal(result_none_full, expected_none_full)
-
-    def test_isin_dict(self):
-        df = DataFrame({'A': ['a', 'b', 'c', 'd'], 'B': [1, 2, 3, 4],
-                        'C': [1, 5, 7, 8]},
-                        index=['foo', 'bar', 'baz', 'qux'])
-        other = {'A': ('a', 'b'), 'B': (1, 3)}
-        result = df.isin(other, axis=1)
-        expected = DataFrame({'A': [True, True, False, False],
-                              'B': [True, False, True, False]},
-                              index=['foo', 'bar', 'baz', 'qux'])
+        result = df.isin(other)
+        expected = DataFrame([df.loc[s].isin(other) for s in df.index])
         assert_frame_equal(result, expected)
 
-    def test_isin_row(self):
-        df = DataFrame({'A': ['a', 'b', 'c', 'd'], 'B': [1, 2, 3, 4],
-                        'C': [1, 5, 7, 8]},
-                        index=['foo', 'bar', 'baz', 'qux'])
-        ind_other = {'foo': ['a', 1, 1],
-                     'bar': ['d', 2, 1],
-                     'baz': ['nn', 'nn', 'nn']}
+    def test_isin_empty(self):
+        df = DataFrame({'A': ['a', 'b', 'c'], 'B': ['a', 'e', 'f']})
+        result = df.isin([])
+        expected = pd.DataFrame(False, df.index, df.columns)
+        assert_frame_equal(result, expected)
 
-        result_ind = df.isin(ind_other, axis=0)
-        expected_ind = DataFrame({'A': [True, False, False],
-                                  'B': [True, True, False],
-                                  'C': [True, False, False]},
-                            index=['foo', 'bar', 'baz']).reindex_like(result_ind)
+    def test_isin_dict(self):
+        df = DataFrame({'A': ['a', 'b', 'c'], 'B': ['a', 'e', 'f']})
+        d = {'A': ['a']}
 
-        assert_frame_equal(result_ind, expected_ind)
+        expected = DataFrame(False, df.index, df.columns)
+        expected.loc[0, 'A'] = True
 
-        self.assertRaises(TypeError, df.isin, ind_other)
+        result = df.isin(d)
+        assert_frame_equal(result, expected)
+
+        # non unique columns
+        df.columns = ['A', 'A']
+        expected = DataFrame(False, df.index, df.columns)
+        expected.loc[0, 'A'] = True
+        result = df.isin(d)
+        assert_frame_equal(result, expected)
+
 
 if __name__ == '__main__':
     # unittest.main()


### PR DESCRIPTION
fixes #4211, an alternative (on top of) #4237

DataFrame isin method:

```
In [11]: df = pd.DataFrame([['a', 'a', 'c'], ['b', 'e', 'a'], ['c', 'a', 'f']], columns=['A', 'A', 'B'])

In [12]: df
Out[12]:
   A  A  B
0  a  a  c
1  b  e  a
2  c  a  f

In [13]: df.isin(['a'])
Out[13]:
       A      A      B
0   True   True  False
1  False  False   True
2  False   True  False

In [14]: df.isin({'A': ['a']})
Out[14]:
       A      A      B
0   True   True  False
1  False  False  False
2  False   True  False

In [15]: df.isin({0: ['a']}, iloc=True)
Out[15]:
       A      A      B
0   True  False  False
1  False  False  False
2  False  False  False
```

cc @TomAugspurger 
