### PR TITLE
TST/BLD: add proper skips for bad bs4 version

### DIFF
--- a/ci/requirements-2.6.txt
+++ b/ci/requirements-2.6.txt
@@ -2,3 +2,5 @@ numpy==1.6.1
 cython==0.19.1
 python-dateutil==2.1
 pytz==2013b
+http://www.crummy.com/software/BeautifulSoup/bs4/download/4.2/beautifulsoup4-4.2.0.tar.gz
+html5lib==1.0b2

--- a/pandas/io/tests/test_html.py
+++ b/pandas/io/tests/test_html.py
@@ -37,7 +37,7 @@ def _have_module(module_name):
 
 def _skip_if_no(module_name):
     if not _have_module(module_name):
-        raise nose.SkipTest
+        raise nose.SkipTest("{0} not found".format(module_name))
 
 
 def _skip_if_none_of(module_names):
@@ -46,14 +46,16 @@ def _skip_if_none_of(module_names):
         if module_names == 'bs4':
             import bs4
             if bs4.__version__ == LooseVersion('4.2.0'):
-                raise nose.SkipTest
+                raise nose.SkipTest("Bad version of bs4: 4.2.0")
     else:
-        if not all(_have_module(module_name) for module_name in module_names):
-            raise nose.SkipTest
+        not_found = [module_name for module_name in module_names if not
+                     _have_module(module_name)]
+        if not_found == module_names:
+            raise nose.SkipTest("{0} not found".format(not_found))
         if 'bs4' in module_names:
             import bs4
             if bs4.__version__ == LooseVersion('4.2.0'):
-                raise nose.SkipTest
+                raise nose.SkipTest("Bad version of bs4: 4.2.0")
 
 
 DATA_PATH = get_data_path()


### PR DESCRIPTION
Make sure things are being properly skipped because of a bad bs4 version.

Also adds a 4.2.0 known bad version of bs4 to 26 travis build so that we can verify that tests are being skipped when the version is bad.
