### PR TITLE
TST: skip if no html5lib since bs4 needs it

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -341,6 +341,7 @@ pandas 0.12
     (:issue:`4226`)
   - Fixed bug in initializing ``DatetimeIndex`` with an array of strings
     in a certain time zone (:issue:`4229`)
+  - Fixed bug where html5lib wasn't being properly skipped (:issue:`4265`)
 
 pandas 0.11.0
 =============

--- a/doc/source/v0.12.0.txt
+++ b/doc/source/v0.12.0.txt
@@ -474,6 +474,7 @@ Bug Fixes
     (:issue:`4226`)
   - Fixed bug in initializing ``DatetimeIndex`` with an array of strings
     in a certain time zone (:issue:`4229`)
+  - Fixed bug where html5lib wasn't being properly skipped (:issue:`4265`)
 
 See the :ref:`full release notes
 <release>` or issue tracker

--- a/pandas/io/tests/test_html.py
+++ b/pandas/io/tests/test_html.py
@@ -77,7 +77,7 @@ def assert_framelist_equal(list1, list2, *args, **kwargs):
 
 
 def test_bs4_version_fails():
-    _skip_if_no('bs4')
+    _skip_if_none_of(('bs4', 'html5lib'))
     import bs4
     if bs4.__version__ == LooseVersion('4.2.0'):
         assert_raises(AssertionError, read_html, os.path.join(DATA_PATH,


### PR DESCRIPTION
closes #4265.
