### PR TITLE
TST/CI: remove html5lib from 3.2 build

### DIFF
--- a/ci/requirements-3.2.txt
+++ b/ci/requirements-3.2.txt
@@ -2,7 +2,6 @@ python-dateutil==2.1
 pytz==2013b
 openpyxl==1.6.2
 xlrd==0.9.2
-html5lib==1.0b2
 numpy==1.6.2
 cython==0.19.1
 numexpr==2.1


### PR DESCRIPTION
closes #4277
