### PR TITLE
BUG: Fixed non-unique indexing memory allocation issue with .ix/.loc (GH4280)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -235,7 +235,8 @@ pandas 0.12
       names (:issue:`3873`)
     - Bug in non-unique indexing via ``iloc`` (:issue:`4017`); added ``takeable`` argument to
       ``reindex`` for location-based taking
-    - Allow non-unique indexing in series via ``.ix/.loc`` and ``__getitem`` (:issue:`4246)
+    - Allow non-unique indexing in series via ``.ix/.loc`` and ``__getitem__`` (:issue:`4246`)
+    - Fixed non-unique indexing memory allocation issue with ``.ix/.loc`` (:issue:`4280`)
 
   - Fixed bug in groupby with empty series referencing a variable before assignment. (:issue:`3510`)
   - Allow index name to be used in groupby for non MultiIndex (:issue:`4014`)

--- a/doc/source/v0.12.0.txt
+++ b/doc/source/v0.12.0.txt
@@ -437,7 +437,8 @@ Bug Fixes
       names (:issue:`3873`)
     - Bug in non-unique indexing via ``iloc`` (:issue:`4017`); added ``takeable`` argument to
       ``reindex`` for location-based taking
-    - Allow non-unique indexing in series via ``.ix/.loc`` and ``__getitem`` (:issue:`4246)
+    - Allow non-unique indexing in series via ``.ix/.loc`` and ``__getitem__`` (:issue:`4246`)
+    - Fixed non-unique indexing memory allocation issue with ``.ix/.loc`` (:issue:`4280`)
 
   - ``DataFrame.from_records`` did not accept empty recarrays (:issue:`3682`)
   - ``read_html`` now correctly skips tests (:issue:`3741`)


### PR DESCRIPTION
closes #4280

Had a weird memory allocation scheme (that's why is a _scheme_!) when determining
a non-unique indexer. Fixed to use a dynamic schema

```
In [1]: columns = list('ABCDEFG')

def gen_test(l,l2):
            return pd.concat([ DataFrame(randn(l,len(columns)),index=range(l),columns=columns),
                               DataFrame(np.ones((l2,len(columns))),index=[0]*l2,columns=columns) ])

In [3]: df = gen_test(900000,100000)

In [5]: mask = np.arange(100000)

In [6]: df
Out[6]: 
<class 'pandas.core.frame.DataFrame'>
Int64Index: 1000000 entries, 0 to 0
Data columns (total 7 columns):
A    1000000  non-null values
B    1000000  non-null values
C    1000000  non-null values
D    1000000  non-null values
E    1000000  non-null values
F    1000000  non-null values
G    1000000  non-null values
dtypes: float64(7)

In [7]: df.loc[mask]
Out[7]: 
<class 'pandas.core.frame.DataFrame'>
Int64Index: 200000 entries, 0 to 99999
Data columns (total 7 columns):
A    200000  non-null values
B    200000  non-null values
C    200000  non-null values
D    200000  non-null values
E    200000  non-null values
F    200000  non-null values
G    200000  non-null values
dtypes: float64(7)

```
