### PR TITLE
TST: raise an error json serialization of floats that cannot be accurate represented

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1020,6 +1020,11 @@ Writing to a file, with a date index and a date column
    dfj2.to_json('test.json')
    open('test.json').read()
 
+.. warning::
+
+   Currently ``usjon`` cannot format small float numbers (< 1e15). A ``ValueError``
+   will be raised in these cases.
+
 Reading JSON
 ~~~~~~~~~~~~
 

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -37,6 +37,8 @@ pandas 0.12
   - Support for reading Amazon S3 files. (:issue:`3504`)
   - Added module for reading and writing Stata files: pandas.io.stata (:issue:`1512`)
     includes ``to_stata`` DataFrame method, and a ``read_stata`` top-level reader
+  - Added module for reading and writing JSON strings/files: pandas.io.json (:issue:`3876`)
+    includes ``to_json`` DataFrame/Series method, and a ``read_json`` top-level reader
   - Added support for writing in ``to_csv`` and reading in ``read_csv``,
     multi-index columns. The ``header`` option in ``read_csv`` now accepts a
     list of the rows from which to read the index. Added the option,
@@ -345,6 +347,7 @@ pandas 0.12
   - Fixed bug where html5lib wasn't being properly skipped (:issue:`4265`)
   - Fixed bug where get_data_famafrench wasn't using the correct file edges
     (:issue:`4281`)
+  - Raise a ``ValueError`` if trying to format small floats with ``to_json`` (:issue:`4042`)
 
 pandas 0.11.0
 =============

--- a/pandas/io/tests/test_json/test_pandas.py
+++ b/pandas/io/tests/test_json/test_pandas.py
@@ -409,6 +409,18 @@ class TestPandasContainer(unittest.TestCase):
         expected = DataFrame([[1,2],[1,2]],columns=['a','b'])
         assert_frame_equal(result,expected)
 
+    def test_small_floats(self):
+
+        # raise
+        df = DataFrame([[1e-16,'foo',1e-8]],columns=list('ABC'))
+        self.assertRaises(ValueError, df.to_json)
+        s = Series([1e-16])
+        self.assertRaises(ValueError, s.to_json)
+
+        # ok
+        df = DataFrame([[1e-15,'foo',1e-8]],columns=list('ABC'))
+        df.to_json()
+
     @network
     @slow
     def test_round_trip_exception_(self):


### PR DESCRIPTION
related to #4042

```
In [1]: DataFrame([[1e-16,'foo',1e-8]],columns=list('ABC')).to_json()

ValueError: ujson currently cannot accurately format float data less
than 1e-15. A work-around is to multiply the data by
a large positive factor and divide on deseriliazation
```
