### PR TITLE
ENH: to_csv() date formatting

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -60,6 +60,9 @@ New features
   - Clipboard functionality now works with PySide (:issue:`4282`)
   - New ``extract`` string method returns regex matches more conveniently (:issue:`4685`)
   - Auto-detect field widths in read_fwf when unspecified (:issue:`4488`)
+  - ``to_csv()`` now outputs datetime objects according to a specified format string
+    via the ``date_format`` keyword (:issue:`4313`)
+
 
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -87,6 +87,9 @@ API changes
     and arithmetic flex methods (add, sub, mul, etc.). ``SparsePanel`` does not
     support ``pow`` or ``mod`` with non-scalars. (:issue:`3765`)
 
+  - ``to_csv`` now takes a ``date_format`` keyword argument that specifies how
+    output datetime objects should be formatted. Datetimes encountered in the
+    index, columns, and values will all have this formatting applied. (:issue:`4313`)
 
 Prior Version Deprecations/Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1030,7 +1030,7 @@ class DataFrame(NDFrame):
                cols=None, header=True, index=True, index_label=None,
                mode='w', nanRep=None, encoding=None, quoting=None,
                line_terminator='\n', chunksize=None,
-               tupleize_cols=False, **kwds):
+               tupleize_cols=False, date_format=None, **kwds):
         r"""Write DataFrame to a comma-separated values (csv) file
 
         Parameters
@@ -1073,6 +1073,8 @@ class DataFrame(NDFrame):
         tupleize_cols : boolean, default False
             write multi_index columns as a list of tuples (if True)
             or new (expanded format) if False)
+        date_format : string, default None
+            Format string for datetime objects.
         """
         if nanRep is not None:  # pragma: no cover
             warnings.warn("nanRep is deprecated, use na_rep",
@@ -1088,7 +1090,8 @@ class DataFrame(NDFrame):
                                      index_label=index_label, mode=mode,
                                      chunksize=chunksize, engine=kwds.get(
                                          "engine"),
-                                     tupleize_cols=tupleize_cols)
+                                     tupleize_cols=tupleize_cols,
+                                     date_format=date_format)
         formatter.save()
 
     def to_excel(self, excel_writer, sheet_name='Sheet1', na_rep='',

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2129,7 +2129,8 @@ class Series(generic.NDFrame):
 
     def to_csv(self, path, index=True, sep=",", na_rep='',
                float_format=None, header=False,
-               index_label=None, mode='w', nanRep=None, encoding=None):
+               index_label=None, mode='w', nanRep=None, encoding=None,
+               date_format=None):
         """
         Write Series to a comma-separated values (csv) file
 
@@ -2154,13 +2155,15 @@ class Series(generic.NDFrame):
         encoding : string, optional
             a string representing the encoding to use if the contents are
             non-ascii, for python versions prior to 3
+        date_format: string, default None
+            Format string for datetime objects.
         """
         from pandas.core.frame import DataFrame
         df = DataFrame(self)
         df.to_csv(path, index=index, sep=sep, na_rep=na_rep,
                   float_format=float_format, header=header,
                   index_label=index_label, mode=mode, nanRep=nanRep,
-                  encoding=encoding)
+                  encoding=encoding, date_format=date_format)
 
     def dropna(self):
         """

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -11407,6 +11407,53 @@ starting,ending,measure
         with tm.assertRaises(TypeError):
             df.isin('aaa')
 
+    def test_to_csv_date_format(self):
+        from pandas import to_datetime
+        pname = '__tmp_to_csv_date_format__'
+        with ensure_clean(pname) as path:
+            for engine in [None, 'python']:
+                dt_index = self.tsframe.index
+                datetime_frame = DataFrame({'A': dt_index, 'B': dt_index.shift(1)}, index=dt_index)
+
+                datetime_frame.to_csv(path, date_format='%Y%m%d', engine=engine)
+                # Check that the data was put in the specified format
+                test = read_csv(path, index_col=0)
+
+                datetime_frame_int = datetime_frame.applymap(lambda x: int(x.strftime('%Y%m%d')))
+                datetime_frame_int.index = datetime_frame_int.index.map(lambda x: int(x.strftime('%Y%m%d')))
+
+                assert_frame_equal(test, datetime_frame_int)
+
+                datetime_frame.to_csv(path, date_format='%Y-%m-%d', engine=engine)
+                # Check that the data was put in the specified format
+                test = read_csv(path, index_col=0)
+                datetime_frame_str = datetime_frame.applymap(lambda x: x.strftime('%Y-%m-%d'))
+                datetime_frame_str.index = datetime_frame_str.index.map(lambda x: x.strftime('%Y-%m-%d'))
+
+                assert_frame_equal(test, datetime_frame_str)
+
+                # Check that columns get converted
+                datetime_frame_columns = datetime_frame.T
+
+                datetime_frame_columns.to_csv(path, date_format='%Y%m%d', engine=engine)
+
+                test = read_csv(path, index_col=0)
+
+                datetime_frame_columns = datetime_frame_columns.applymap(lambda x: int(x.strftime('%Y%m%d')))
+                # Columns don't get converted to ints by read_csv
+                datetime_frame_columns.columns = datetime_frame_columns.columns.map(lambda x: x.strftime('%Y%m%d'))
+
+                assert_frame_equal(test, datetime_frame_columns)
+
+                # test NaTs
+                nat_index = to_datetime(['NaT'] * 10 + ['2000-01-01', '1/1/2000', '1-1-2000'])
+                nat_frame = DataFrame({'A': nat_index}, index=nat_index)
+
+                nat_frame.to_csv(path, date_format='%Y-%m-%d', engine=engine)
+
+                test = read_csv(path, parse_dates=[0, 1], index_col=0)
+
+                assert_frame_equal(test, nat_frame)
 
 def skip_if_no_ne(engine='numexpr'):
     if engine == 'numexpr':

--- a/vb_suite/io_bench.py
+++ b/vb_suite/io_bench.py
@@ -88,3 +88,13 @@ stmt = ("read_csv(StringIO(data), header=None, names=['foo'], "
         "         parse_dates=['foo'])")
 read_parse_dates_iso8601 = Benchmark(stmt, setup,
                                      start_date=datetime(2012, 3, 1))
+
+setup = common_setup + """
+rng = date_range('1/1/2000', periods=1000)
+data = DataFrame(rng, index=rng)
+"""
+
+stmt = ("data.to_csv('__test__.csv', date_format='%Y%m%d')")
+
+frame_to_csv_date_formatting = Benchmark(stmt, setup,
+                                     start_date=datetime(2013, 9, 1))


### PR DESCRIPTION
This commit adds support for formatting datetime object output from to_csv()
closes #2583

``` python
In [3]: spx = DataReader('^GSPC', data_source='yahoo')

In [4]: spx.head()
Out[4]: 
               Open     High      Low    Close      Volume  Adj Close
Date                                                                 
2010-01-04  1116.56  1133.87  1116.56  1132.99  3991400000    1132.99
2010-01-05  1132.66  1136.63  1129.66  1136.52  2491020000    1136.52
2010-01-06  1135.71  1139.19  1133.95  1137.14  4972660000    1137.14
2010-01-07  1136.27  1142.46  1131.32  1141.69  5270680000    1141.69
2010-01-08  1140.52  1145.39  1136.22  1144.98  4389590000    1144.98

In [5]: spx.to_csv('spx_temp.csv', date_format='%Y%m%d')

In [6]: !head spx_temp.csv
Date,Open,High,Low,Close,Volume,Adj Close
20100104,1116.56,1133.87,1116.56,1132.99,3991400000,1132.99
20100105,1132.66,1136.63,1129.66,1136.52,2491020000,1136.52
20100106,1135.71,1139.19,1133.95,1137.14,4972660000,1137.14
20100107,1136.27,1142.46,1131.32,1141.69,5270680000,1141.69
20100108,1140.52,1145.39,1136.22,1144.98,4389590000,1144.98
20100111,1145.96,1149.74,1142.02,1146.98,4255780000,1146.98
20100112,1143.81,1143.81,1131.77,1136.22,4716160000,1136.22
20100113,1137.31,1148.4,1133.18,1145.68,4170360000,1145.68
20100114,1145.68,1150.41,1143.8,1148.46,3915200000,1148.46
```

The `date_format=` keyword will be applied to every element of a DatetimeIndex (index or columns) and DatetimeBlock (values). It works for both the Python engine and the new Cython engine:

``` python
In [7]: datetimes = DataFrame({spx.index[0]: spx.index}, index=spx.index).head()

In [8]: datetimes
Out[8]: 
                    2010-01-04
Date                          
2010-01-04 2010-01-04 00:00:00
2010-01-05 2010-01-05 00:00:00
2010-01-06 2010-01-06 00:00:00
2010-01-07 2010-01-07 00:00:00
2010-01-08 2010-01-08 00:00:00

In [9]: datetimes.to_csv('datetimes_temp.csv', date_format='%m/%d/%Y')

In [10]: !head datetimes_temp.csv
Date,01/04/2010
01/04/2010,01/04/2010
01/05/2010,01/05/2010
01/06/2010,01/06/2010
01/07/2010,01/07/2010
01/08/2010,01/08/2010

In [11]: datetimes.to_csv('datetimes_temp.csv', date_format='%m/%d/%Y', engine='python')

In [12]: !head datetimes_temp.csvDate,01/04/2010
01/04/2010,01/04/2010
01/05/2010,01/05/2010
01/06/2010,01/06/2010
01/07/2010,01/07/2010
01/08/2010,01/08/2010
```

Let me know if there are any questions or issues.
