### PR TITLE
Added ind and bw_method kwargs to KdePlot

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -30,6 +30,10 @@ pandas 0.13
 **Release date:** not-yet-released
 
 **New features**
+  - ``plot(kind='kde')`` now accepts the optional parameters ``bw_method`` and
+    ``ind``, passed to scipy.stats.gaussian_kde() (for scipy >= 0.11.0) to set
+    the bandwidth, and to gkde.evaluate() to specify the indicies at which it
+    is evaluated, respecttively. See scipy docs.
 
   - Added ``isin`` method to DataFrame (:issue:`4211`)
   - Clipboard functionality now works with PySide (:issue:`4282`)

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -163,6 +163,11 @@ Enhancements
          from pandas import offsets
          td + offsets.Minute(5) + offsets.Milli(5)
 
+    - ``plot(kind='kde')`` now accepts the optional parameters ``bw_method`` and
+      ``ind``, passed to scipy.stats.gaussian_kde() (for scipy >= 0.11.0) to set
+      the bandwidth, and to gkde.evaluate() to specify the indicies at which it
+      is evaluated, respecttively. See scipy docs.
+
 .. _whatsnew_0130.refactoring:
 
 Internal Refactoring

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -257,8 +257,18 @@ class TestSeriesPlots(unittest.TestCase):
         _check_plot_works(self.ts.plot, kind='kde')
         _check_plot_works(self.ts.plot, kind='density')
         ax = self.ts.plot(kind='kde', logy=True)
-        self.assert_(ax.get_yscale() == 'log')
+        self.assertEqual(ax.get_yscale(), 'log')
 
+    @slow
+    def test_kde_kwargs(self):
+        _skip_if_no_scipy()
+        from numpy import linspace
+        _check_plot_works(self.ts.plot, kind='kde', bw_method=.5, ind=linspace(-100,100,20))
+        _check_plot_works(self.ts.plot, kind='density', bw_method=.5, ind=linspace(-100,100,20))
+        ax = self.ts.plot(kind='kde', logy=True, bw_method=.5, ind=linspace(-100,100,20))
+        self.assertEqual(ax.get_yscale(), 'log')
+
+    @slow
     def test_kde_color(self):
         _skip_if_no_scipy()
         ax = self.ts.plot(kind='kde', logy=True, color='r')


### PR DESCRIPTION
Adds ability to set the bandwidth used for the kde and the indices at which it is evaluated. The first is passed to the bw_method kwarg for scipy.stats.gaussian_kde (for scipy >= 0.11.0); the second is passed to gkde.evaluate. For the case when scipy < 0.11.0 but bw_method is specified, bw_method is ignored (not passed to scipy.stats.gaussian_kde), but a warning is issued to alert the user.

https://github.com/pydata/pandas/issues/4298
