### PR TITLE
Arguably better handling of input data in constructor for DataFrame (fix for #4297)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5705,7 +5705,7 @@ def extract_index(data):
                 raw_lengths.append(len(v))
 
         if not indexes and not raw_lengths:
-            raise ValueError('If using all scalar values, you must must pass'
+            raise ValueError('If using all scalar values, you must pass'
                              ' an index')
 
         if have_series or have_dicts:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5688,7 +5688,7 @@ def extract_index(data):
     index = None
     if len(data) == 0:
         index = Index([])
-    elif len(data) > 0 and index is None:
+    elif len(data) > 0:
         raw_lengths = []
         indexes = []
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5712,11 +5712,9 @@ def extract_index(data):
                 have_raw_arrays = True
                 raw_lengths.append(len(v))
             else:
-                # Item v silently ignored (to conserve
-                # the original behaviour - see also
-                # test of __getitem__ below).
-                # This behaviour is kept, but I think
-                # that an exception (TypeError) should be raised instead.
+                # Item v is silently ignored,
+                # as it is not anything an index can be inferred
+                # from.
                 pass
 
         if not indexes and not raw_lengths:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5705,29 +5705,19 @@ def extract_index(data):
             elif isinstance(v, dict):
                 have_dicts = True
                 indexes.append(v.keys())
-            elif not (isinstance(v, str) or \
-                          isinstance(v, unicode)):
+            elif com._is_sequence(v):
+                # This is a sequence-but-not-a-string
                 # Although strings have a __len__,
-                # they are likely to be considered scalars.
-                try:
-                    l = len(v)
-                except TypeError:
-                    # Item v silently ignored (to conserve
-                    # the original behaviour - see also
-                    # test of __getitem__ below).
-                    # This behaviour is kept, but I think
-                    # that an exception (TypeError) should be raised instead.
-                    continue
-                # Anything else with a __len__ is considered
-                # a sequence (to be safe, we check
-                # that there is __getitem__)
-                if hasattr(v, '__getitem__'):
-                    have_raw_arrays = True
-                    raw_lengths.append(l)
-                else:
-                    # The original code skipped silently invalid
-                    # objects (see note at TypeError above).
-                    pass
+                # they will be considered scalar.
+                have_raw_arrays = True
+                raw_lengths.append(len(v))
+            else:
+                # Item v silently ignored (to conserve
+                # the original behaviour - see also
+                # test of __getitem__ below).
+                # This behaviour is kept, but I think
+                # that an exception (TypeError) should be raised instead.
+                pass
 
         if not indexes and not raw_lengths:
             raise ValueError('If using all scalar values, you must pass'

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5700,9 +5700,20 @@ def extract_index(data):
             elif isinstance(v, dict):
                 have_dicts = True
                 indexes.append(v.keys())
-            elif isinstance(v, (list, tuple, np.ndarray)):
-                have_raw_arrays = True
-                raw_lengths.append(len(v))
+            elif not (isinstance(v, str) or \
+                          isinstance(v, unicode)):
+                # Although strings have a __len__,
+                # they are likely to be considered scalars.
+                try:
+                    l = len(v)
+                except TypeError:
+                    continue
+                # Anything else with a __len__ is considered
+                # a sequence (to be safe, we check
+                # that there is __getitem__)
+                if hasattr(v, '__getitem__'):
+                    have_raw_arrays = True
+                    raw_lengths.append(l)
 
         if not indexes and not raw_lengths:
             raise ValueError('If using all scalar values, you must pass'

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2236,7 +2236,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
         def testit():
             DataFrame({'a': False, 'b': True})
-        assertRaisesRegexp(ValueError, 'If using all scalar values, you must must pass an index', testit)
+        assertRaisesRegexp(ValueError, 'If using all scalar values, you must pass an index', testit)
 
     def test_insert_error_msmgs(self):
 
@@ -2774,6 +2774,17 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         # pass some columns
         recons = DataFrame.from_items(items, columns=['C', 'B', 'A'])
         assert_frame_equal(recons, self.frame.ix[:, ['C', 'B', 'A']])
+        # not any column either a dict, a list, a tuple, or a numpy.ndarray
+        import array
+        recons_ar = DataFrame.from_items([('A', array.array('i', range(10)))])
+        recons_rg = DataFrame.from_items([('A', range(10))])
+        recons_np = DataFrame.from_items([('A', np.array(range(10)))])
+        self.assertEquals(tuple(recons_ar['A']),
+                          tuple(recons_rg['A']))
+        self.assertEquals(tuple(recons_ar['A']),
+                          tuple(recons_np['A']))
+
+        
 
         # orient='index'
 


### PR DESCRIPTION
The problem was basically an odd restriction to `list` ,`tuple`, `dict`, or `numpy.ndarray` for data structure given as input to any constructor for DataFrame. Much cruder than a possible issue around buffer protocols I thought (the whole issue report went off on a tangent anyway ;-) ).

The source did not have much (any, actually) comments in that region, and I could not find unit tests documenting the behaviour, but I am guessing that the restriction stemmed from the fact that a string is a sequence in Python while the constructors should consider one string passed as data a scalar rather than a sequence.

The change made goes the other way around and accepts any sequence (not just `tuple`, `list`, or `numpy.ndarray`), except `str` or `unicode` (the later only applies to Python 2.x). `bytes` and `bytearray` are allowed (but I am not sure they should).

The pull request was tested (only `tests/test_frame.py` was run) on Python 2.7.4 and 3.3.1
