### PR TITLE
DOC: Update computation.rst

### DIFF
--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -450,7 +450,7 @@ average as
 
 .. math::
 
-    y_t = \alpha y_{t-1} + (1 - \alpha) x_t
+    y_t = (1 - \alpha) y_{t-1} + \alpha x_t
 
 One must have :math:`0 < \alpha \leq 1`, but rather than pass :math:`\alpha`
 directly, it's easier to think about either the **span** or **center of mass


### PR DESCRIPTION
A wider span means a smaller alpha, which means each x_t has less impact on the ewma.
