### PR TITLE
BUG: fill_value is ignored when reindexing empty series

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -44,6 +44,9 @@ pandas 0.13
 
 **Bug Fixes**
 
+  - ``fill_value`` parameter was ignored in ``Series.reindex()`` if the object
+    was empty (:issue:`4346`)
+
 pandas 0.12
 ===========
 

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -18,6 +18,9 @@ Enhancements
 Bug Fixes
 ~~~~~~~~~
 
+  - ``fill_value`` parameter was ignored in ``Series.reindex()`` if the object
+    was empty (:issue:`4346`)
+
 See the :ref:`full release notes
 <release>` or issue tracker
 on GitHub for a complete list.

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2636,7 +2636,7 @@ class Series(generic.PandasContainer, pa.Array):
                 return self
 
         if len(self.index) == 0:
-            return Series(nan, index=index, name=self.name)
+            return Series(fill_value, index=index, name=self.name)
 
         new_index, indexer = self.index.reindex(index, method=method,
                                                 level=level, limit=limit,

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -3795,6 +3795,18 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         expected = Series([False, True, False], index=[1, 2, 3])
         assert_series_equal(result, expected)
 
+        #------------------------------------------------------------
+        # empty
+        empty = Series()
+
+        result = empty.reindex([1, 2, 3])
+        expected = Series([np.nan, np.nan, np.nan], index=[1, 2, 3])
+        assert_series_equal(result, expected)
+
+        result = empty.reindex([1, 2, 3], fill_value=0.0)
+        expected = Series([0.0, 0.0, 0.0], index=[1, 2, 3])
+        assert_series_equal(result, expected)
+
     def test_rename(self):
         renamer = lambda x: x.strftime('%Y%m%d')
         renamed = self.ts.rename(renamer)


### PR DESCRIPTION
Here's a snippet depicting the, probably, buggy behaviour:

``` python
>>> import pandas as pd
>>> s = pd.Series()
>>> s.reindex([1,2,3])
1   NaN
2   NaN
3   NaN
dtype: float64
>>> s.reindex([1,2,3], fill_value=0.0)
1   NaN
2   NaN
3   NaN
dtype: float64
>>> pd.version.version
'0.12.0.dev-d7c6eb1'
```

I'd expect the last output to contain `0.0` values instead of `NaN`.
