### PR TITLE
ER:  HDFStore raising an invalid TypeError rather than ValueError when appending with a diff block ordering (GH4096)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -44,6 +44,9 @@ pandas 0.13
 
 **Bug Fixes**
 
+  - ``HDFStore`` raising an invalid ``TypeError`` rather than ``ValueError`` when appending
+    with a different block ordering (:issue:`4096`)
+
 pandas 0.12
 ===========
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2672,7 +2672,7 @@ class Table(Storer):
                     b = by_items.pop(items)
                     new_blocks.append(b)
                 except:
-                    raise ValueError("cannot match existing table structure for [%s] on appending data" % items)
+                    raise ValueError("cannot match existing table structure for [%s] on appending data" % ','.join(items))
             blocks = new_blocks
 
         # add my values

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -620,6 +620,21 @@ class TestHDFStore(unittest.TestCase):
 
                 store.append('df',df)
 
+        # test a different ordering but with more fields (like invalid combinate)
+        with ensure_clean(self.path) as store:
+
+            df = DataFrame(np.random.randn(10,2),columns=list('AB'), dtype='float64')
+            df['int64'] = Series([1]*len(df),dtype='int64')
+            df['int16'] = Series([1]*len(df),dtype='int16')
+            store.append('df',df)
+
+            # store additonal fields in different blocks
+            df['int16_2'] = Series([1]*len(df),dtype='int16')
+            self.assertRaises(ValueError, store.append, 'df', df)
+
+            # store multile additonal fields in different blocks
+            df['float_3'] = Series([1.]*len(df),dtype='float64')
+            self.assertRaises(ValueError, store.append, 'df', df)
 
     def test_ndim_indexables(self):
         """ test using ndim tables in new ways"""


### PR DESCRIPTION
related to #4096 (fixes error printing)
