### PR TITLE
Fix issue #4345: graphics test failure

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -74,6 +74,8 @@ pandas 0.13
     (:issue:`4102`, :issue:`4014`) in ``*.hist`` plotting methods
   - Fixed bug in ``PeriodIndex.map`` where using ``str`` would return the str
     representation of the index (:issue:`4136`)
+  - Fixed test failure ``test_time_series_plot_color_with_empty_kwargs`` when
+    using custom matplotlib default colors (:issue:`4345`)
   - Fix running of stata IO tests. Now uses temporary files to write
     (:issue:`4353`)
   - Fixed an issue where ``DataFrame.sum`` was slower than ``DataFrame.mean``

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -51,6 +51,9 @@ Bug Fixes
   - Fixed bug in ``PeriodIndex.map`` where using ``str`` would return the str
     representation of the index (:issue:`4136`)
 
+  - Fixed test failure ``test_time_series_plot_color_with_empty_kwargs`` when
+    using custom matplotlib default colors (:issue:`4345`)
+
   - Fix running of stata IO tests. Now uses temporary files to write
     (:issue:`4353`)
 

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -917,7 +917,10 @@ class TestDataFrameGroupByPlots(unittest.TestCase):
         self.assert_(line.get_color() == 'green')
 
     def test_time_series_plot_color_with_empty_kwargs(self):
+        import matplotlib as mpl
         import matplotlib.pyplot as plt
+        
+        def_colors = mpl.rcParams['axes.color_cycle']
 
         plt.close('all')
         for i in range(3):
@@ -925,7 +928,7 @@ class TestDataFrameGroupByPlots(unittest.TestCase):
                                                             periods=12)).plot()
 
         line_colors = [l.get_color() for l in ax.get_lines()]
-        self.assert_(line_colors == ['b', 'g', 'r'])
+        self.assertEqual(line_colors, def_colors[:3])
 
     @slow
     def test_grouped_hist(self):


### PR DESCRIPTION
closes #4345
The `test_time_series_plot_color_with_empty_kwargs` method in `test_graphics.py` uses the matplotlib default color cycle rather than 'r', 'g', and 'b'.
