### PR TITLE
BUG: fix period index object instantiation when joining with self

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -89,6 +89,9 @@ pandas 0.13
   - Fixed bug with duplicate columns and type conversion in ``read_json`` when
     ``orient='split'`` (:issue:`4377`)
   - Fix ``.iat`` indexing with a ``PeriodIndex`` (:issue:`4390`)
+  - Fixed an issue where ``PeriodIndex`` joining with self was returning a new
+    instance rather than the same instance (:issue:`4379`); also adds a test
+    for this for the other index types
 
 pandas 0.12
 ===========

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -555,6 +555,15 @@ class TestIndex(unittest.TestCase):
         idx = Index(['a', 'b'], name='asdf')
         self.assertEqual(idx.name, idx[1:].name)
 
+    def test_join_self(self):
+        indices = 'unicode', 'str', 'date', 'int', 'float'
+        kinds = 'outer', 'inner', 'left', 'right'
+        for index_kind in indices:
+            for kind in kinds:
+                res = getattr(self, '{0}Index'.format(index_kind))
+                joined = res.join(res, how=kind)
+                self.assert_(res is joined)
+
 
 class TestInt64Index(unittest.TestCase):
     _multiprocess_can_split_ = True
@@ -833,6 +842,12 @@ class TestInt64Index(unittest.TestCase):
 
         exp_ridx = np.array([2, 3, 2, 3, 0, 1, 0, 1], dtype=np.int64)
         self.assert_(np.array_equal(ridx, exp_ridx))
+
+    def test_join_self(self):
+        kinds = 'outer', 'inner', 'left', 'right'
+        for kind in kinds:
+            joined = self.index.join(self.index, how=kind)
+            self.assert_(self.index is joined)
 
     def test_intersection(self):
         other = Index([1, 2, 3, 4, 5])
@@ -1726,6 +1741,13 @@ class TestMultiIndex(unittest.TestCase):
         tm.assert_isinstance(result, MultiIndex)
 
         self.assertRaises(Exception, self.index.join, self.index, level=1)
+
+    def test_join_self(self):
+        kinds = 'outer', 'inner', 'left', 'right'
+        for kind in kinds:
+            res = self.index
+            joined = res.join(res, how=kind)
+            self.assert_(res is joined)
 
     def test_reindex(self):
         result, indexer = self.index.reindex(list(self.index[:4]))

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -1864,6 +1864,13 @@ class TestPeriodIndex(TestCase):
             tm.assert_isinstance(joined, PeriodIndex)
             self.assert_(joined.freq == index.freq)
 
+    def test_join_self(self):
+        index = period_range('1/1/2000', '1/20/2000', freq='D')
+
+        for kind in ['inner', 'outer', 'left', 'right']:
+            res = index.join(index, how=kind)
+            self.assert_(index is res)
+
     def test_align_series(self):
         rng = period_range('1/1/2000', '1/1/2010', freq='A')
         ts = Series(np.random.randn(len(rng)), index=rng)

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1960,6 +1960,12 @@ class TestDatetimeIndex(unittest.TestCase):
         dr = pd.date_range(st, et, freq='H', name='timebucket')
         self.assertEqual(dr[1:].name, dr.name)
 
+    def test_join_self(self):
+        index = date_range('1/1/2000', periods=10)
+        kinds = 'outer', 'inner', 'left', 'right'
+        for kind in kinds:
+            joined = index.join(index, how=kind)
+            self.assert_(index is joined)
 
 class TestLegacySupport(unittest.TestCase):
     _multiprocess_can_split_ = True


### PR DESCRIPTION
This PR fixes an issue where joining a PeriodIndex with itself resulted in a
new object.
