### PR TITLE
BUG: fixes for GH4377

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -83,6 +83,10 @@ pandas 0.13
   - In ``to_json``, raise if a passed ``orient`` would cause loss of data because
     of a duplicate index (:issue:`4359`)
   - Fixed passing ``keep_default_na=False`` when ``na_values=None`` (:issue:`4318`)
+  - Fixed bug with ``values`` raising an error on a DataFrame with duplicate columns and mixed
+    dtypes, surfaced in (:issue:`4377`)
+  - Fixed bug with duplicate columns and type conversion in ``read_json`` when
+    ``orient='split'`` (:issue:`4377`)
 
 pandas 0.12
 ===========

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -61,9 +61,6 @@ Bug Fixes
   - Fixed bug where ``network`` testing was throwing ``NameError`` because a
     local variable was undefined (:issue:`4381`)
 
-  - In ``to_json``, raise if a passed ``orient`` would cause loss of data because
-    of a duplicate index (:issue:`4359`)
-
   - Suppressed DeprecationWarning associated with internal calls issued by repr() (:issue:`4391`)
 
 See the :ref:`full release notes

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1538,23 +1538,23 @@ class BlockManager(PandasObject):
         # By construction, all of the item should be covered by one of the
         # blocks
         if items.is_unique:
+
             for block in self.blocks:
                 indexer = items.get_indexer(block.items)
                 if (indexer == -1).any():
                     raise AssertionError('Items must contain all block items')
                 result[indexer] = block.get_values(dtype)
                 itemmask[indexer] = 1
-        else:
-            for block in self.blocks:
-                mask = items.isin(block.items)
-                indexer = mask.nonzero()[0]
-                if (len(indexer) != len(block.items)):
-                    raise AssertionError('All items must be in block items')
-                result[indexer] = block.get_values(dtype)
-                itemmask[indexer] = 1
 
-        if not itemmask.all():
-            raise AssertionError('Some items were not contained in blocks')
+            if not itemmask.all():
+                raise AssertionError('Some items were not contained in blocks')
+
+        else:
+
+            # non-unique, must use ref_locs
+            rl = self._set_ref_locs()
+            for i, (block, idx) in enumerate(rl):
+                result[i] = block.iget(idx)
 
         return result
 

--- a/pandas/io/tests/test_json/test_pandas.py
+++ b/pandas/io/tests/test_json/test_pandas.py
@@ -83,6 +83,21 @@ class TestPandasContainer(unittest.TestCase):
         unser = read_json(df.to_json(orient='values'), orient='values')
         np.testing.assert_equal(df.values, unser.values)
 
+        # GH4377; duplicate columns not processing correctly
+        df = DataFrame([['a','b'],['c','d']], index=[1,2], columns=['x','y'])
+        result = read_json(df.to_json(orient='split'), orient='split')
+        assert_frame_equal(result, df)
+
+        def _check(df):
+            result = read_json(df.to_json(orient='split'), orient='split', convert_dates=['x'])
+            assert_frame_equal(result, df)
+
+        for o in [[['a','b'],['c','d']],
+                  [[1.5,2.5],[3.5,4.5]],
+                  [[1,2.5],[3,4.5]],
+                  [[Timestamp('20130101'),3.5],[Timestamp('20130102'),4.5]]]:
+            _check(DataFrame(o, index=[1,2], columns=['x','x']))
+
     def test_frame_from_json_to_json(self):
 
         def _check_orient(df, orient, dtype=None, numpy=False, convert_axes=True, check_dtype=True, raise_ok=None):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2950,6 +2950,12 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         expected = DataFrame([[1],[1],[1]],columns=['bar'])
         check(df,expected)
 
+        # values
+        df = DataFrame([[1,2.5],[3,4.5]], index=[1,2], columns=['x','x'])
+        result = df.values
+        expected = np.array([[1,2.5],[3,4.5]])
+        self.assert_((result == expected).all().all())
+
     def test_insert_benchmark(self):
         # from the vb_suite/frame_methods/frame_insert_columns
         N = 10


### PR DESCRIPTION
closes #4377
- Fixed bug with `.values` raising an error on a DataFrame with duplicate columns and 
  mixed dtypes, surfaced in GH4377
- Fixed bug with duplicate columns and type conversion in `read_json` when
  `orient='split'`
