### PR TITLE
BUG: Fix .iat indexing with a PeriodIndex GH4390

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -62,6 +62,7 @@ pandas 0.13
   - deprecated ``iterkv``, which will be removed in a future release (was just
     an alias of iteritems used to get around ``2to3``'s changes).
     (:issue:`4384`, :issue:`4375`, :issue:`4372`)
+  - ``Series.get`` with negative indexers now returns the same as ``[]`` (:issue:`4390`)
 
 **Experimental Features**
 
@@ -87,6 +88,7 @@ pandas 0.13
     dtypes, surfaced in (:issue:`4377`)
   - Fixed bug with duplicate columns and type conversion in ``read_json`` when
     ``orient='split'`` (:issue:`4377`)
+  - Fix ``.iat`` indexing with a ``PeriodIndex`` (:issue:`4390`)
 
 pandas 0.12
 ===========

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -29,6 +29,7 @@ API changes
   - deprecated ``iterkv``, which will be removed in a future release (was just
     an alias of iteritems used to get around ``2to3``'s changes).
     (:issue:`4384`, :issue:`4375`, :issue:`4372`)
+  - ``Series.get`` with negative indexers now returns the same as ``[]`` (:issue:`4390`)
 
 Enhancements
 ~~~~~~~~~~~~

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1018,7 +1018,7 @@ class Series(generic.PandasContainer, pa.Array):
         -------
         value : scalar value
         """
-        return self.index._engine.get_value(self, label)
+        return self.index.get_value(self, label)
 
     def set_value(self, label, value):
         """

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -629,7 +629,7 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         self.assertEqual(self.series[idx1], self.series[5])
         self.assertEqual(self.objSeries[idx2], self.objSeries[5])
 
-        self.assert_(self.series.get(-1) is None)
+        self.assertEqual(self.series.get(-1), self.series.get(self.series.index[-1]))
         self.assertEqual(self.series[5], self.series.get(self.series.index[5]))
 
         # missing

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -1323,6 +1323,15 @@ class TestPeriodIndex(TestCase):
         ts = df['1/1/2000']
         assert_series_equal(ts, df.ix[:, 0])
 
+    def test_indexing(self):
+
+        # GH 4390, iat incorrectly indexing
+        index = period_range('1/1/2001', periods=10)
+        s = Series(randn(10), index=index)
+        expected = s[index[0]]
+        result = s.iat[0]
+        self.assert_(expected == result)
+
     def test_frame_setitem(self):
         rng = period_range('1/1/2000', periods=5)
         rng.name = 'index'


### PR DESCRIPTION
closes #4390

Interesting fixed this as well (only affects `get`)

```
In [1]: s = Series(randn(10),date_range('20130101',periods=10))

In [2]: s[0]
Out[2]: 1.1755210838393764

In [3]: s
Out[3]: 
2013-01-01    1.175521
2013-01-02    0.007910
2013-01-03   -1.235595
2013-01-04    0.478245
2013-01-05   -0.140616
2013-01-06   -2.317585
2013-01-07    0.609555
2013-01-08    1.204914
2013-01-09   -0.589893
2013-01-10   -2.017237
Freq: D, dtype: float64

In [4]: s[-1]
Out[4]: -2.0172365222181257

In [5]: s[-5]
Out[5]: -2.3175847263447964
```

This was before this PR returning `None` (while `s[-5]` worked)

```
In [6]: s.get(-5)
```
