### PR TITLE
BUG: Fix an issue with the csv cparser when usecols is used

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -92,6 +92,8 @@ pandas 0.13
   - Fixed an issue where ``PeriodIndex`` joining with self was returning a new
     instance rather than the same instance (:issue:`4379`); also adds a test
     for this for the other index types
+  - Fixed a bug with all the dtypes being converted to object when using the CSV cparser 
+    with the usecols parameter (:issue: `3192`)
 
 pandas 0.12
 ===========

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -2138,6 +2138,28 @@ a,b,c
         self.assertRaises(ValueError, self.read_csv, StringIO(data),
                           names=['a', 'b'], usecols=[1], header=None)
 
+    def test_usecols_dtypes(self):
+        data = """\
+1,2,3
+4,5,6
+7,8,9
+10,11,12"""
+        result = self.read_csv(StringIO(data), usecols=(0, 1, 2), 
+                               names=('a', 'b', 'c'), 
+                               header=None,
+                               converters={'a': str},
+                               dtype={'b': int, 'c': float},
+                              )                               
+        result2 = self.read_csv(StringIO(data), usecols=(0, 2),
+                               names=('a', 'b', 'c'), 
+                               header=None,
+                               converters={'a': str},
+                               dtype={'b': int, 'c': float},
+                              )
+        self.assertTrue((result.dtypes == [object, np.int, np.float]).all())
+        self.assertTrue((result2.dtypes == [object, np.float]).all())
+
+
     def test_usecols_implicit_index_col(self):
         # #2654
         data = 'a,b,c\n4,apple,bat,5.7\n8,orange,cow,10'

--- a/pandas/parser.pyx
+++ b/pandas/parser.pyx
@@ -869,6 +869,7 @@ cdef class TextReader:
                 if self.has_usecols and not (i in self.usecols or
                                              name in self.usecols):
                     continue
+                nused += 1
 
             conv = self._get_converter(i, name)
 
@@ -906,10 +907,6 @@ cdef class TextReader:
                 raise Exception('Unable to parse column %d' % i)
 
             results[i] = col_res
-
-            # number of used column names
-            if i > self.leading_cols:
-                nused += 1
 
         self.parser_start += end - start
 


### PR DESCRIPTION
closes #3192

This pull request fixes a problem arising from using the csv parser with the usecols option. In that case, all the dtypes will be converted to object. This code fixes that issue, resulting in the correct dtypes.

Thanks,
Tiago
