### PR TITLE
providing kwargs to create_index at store.append()

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -927,7 +927,7 @@ class HDFStore(StringMixin):
 
         s.write(obj = value, append=append, complib=complib, **kwargs)
         if s.is_table and index:
-            s.create_index(columns = index)
+            s.create_index(columns=index, **kwargs)
 
     def _read_group(self, group, **kwargs):
         s = self._create_storer(group)


### PR DESCRIPTION
This should enable the creation of a 'full' index at append time.
