### PR TITLE
TST: pandas/util/testing : test improvements and cleanups

### DIFF
--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -1763,7 +1763,10 @@ class TestHDFStore(unittest.TestCase):
 
         values = np.random.randn(2)
 
-        func = lambda l, r: tm.assert_series_equal(l, r, True, True, True)
+        func = lambda l, r: tm.assert_series_equal(l, r,
+                                                   check_dtype=True,
+                                                   check_index_type=True,
+                                                   check_series_type=True)
 
         with tm.assert_produces_warning(expected_warning=PerformanceWarning):
             ser = Series(values, [0, 'y'])


### PR DESCRIPTION
A few things
1. Make with-statement-capable `assertRaises` and `assertRaisesRegexp` (which I want to use later in a cleanup of some of the parser tests).
2. Earlier introduction of `assert_attr_equal` changed it so that, if one object had an attribute that was `None` and the other did not have that attribute at all, it would pass. This is now fixed.
3. combines `assert_panel_equal` and `assert_panel4d_equal`, because they are both doing the same thing. Now it's just `assert_panelnd_equal` with specific assert functions for each.
4. Switched unnecessary `check_index_freq` check in `pandas.io.tests.test_pytables:TestHDFStore.test_index_types` to be `check_series_type`, (because none of the tests ever produce objects with `freqstr`)
5. Removed `check_index_freq` argument and corresponding code from `assert_series_equal` since it's not being actively used anywhere in the test suite
