### PR TITLE
Get dummies

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -126,6 +126,13 @@ Data manipulations
    merge
    concat
 
+.. currentmodule:: pandas.core.reshape
+
+.. autosummary::
+   :toctree: generated/
+
+   get_dummies
+
 Top-level missing data
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -44,6 +44,7 @@ pandas 0.13
     ``ValueError`` (:issue:`4303`, :issue:`4305`)
   - ``read_excel`` now supports an integer in its ``sheetname`` argument giving
     the index of the sheet to read in (:issue:`4301`).
+  - ``get_dummies`` works with NaN (:issue:`4446`)
   - Added a test for ``read_clipboard()`` and ``to_clipboard()`` (:issue:`4282`)
   - Text parser now treats anything that reads like inf ("inf", "Inf", "-Inf",
     "iNf", etc.) to infinity. (:issue:`4220`, :issue:`4219`), affecting

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -129,6 +129,17 @@ Enhancements
   - Added a more informative error message when plot arguments contain
     overlapping color and style arguments (:issue:`4402`)
 
+  - NaN handing in get_dummies (:issue:`4446`) with `dummy_na`
+
+    .. ipython:: python
+       # previously, nan was erroneously counted as 2 here
+       # now it is not counted at all
+       get_dummies([1, 2, np.nan])
+
+       # unless requested
+       get_dummies([1, 2, np.nan], dummy_na=True)
+
+
   - ``timedelta64[ns]`` operations
 
     - A Series of dtype ``timedelta64[ns]`` can now be divided by another


### PR DESCRIPTION
fixes #4446, #4444

Added new functionality dummy_na (thoughts?). it's slightly different to a possible dropna argument, which I haven't included (which can be achieved using `pd.get_dummies(s.dropna())`.

Example:

```
In [3]: s = ['a', 'b', np.nan]

In [4]: pd.get_dummies(s)
Out[4]:
   a  b
0  1  0
1  0  1
2  0  0

In [5]: pd.get_dummies(s, dummy_na=True)
Out[5]:
   a  b  NaN
0  1  0    0
1  0  1    0
2  0  0    1

In [6]: pd.get_dummies(pd.Series(s).dropna())  # different
Out[6]:
   a  b
0  1  0
1  0  1
```

Note: atm there is a (strange) test Failure with above example, not quite sure what's going on:

```
res_na = get_dummies(s, dummy_na=True)
exp_na = DataFrame({nan: {0: 0.0, 1: 0.0, 2: 1.0},
                            'a': {0: 1.0, 1: 0.0, 2: 0.0},
                            'b': {0: 0.0, 1: 1.0, 2: 0.0}}).iloc[:, [1, 2, 0]]  # need to reorder cols
assert_frame_equal(res_na, exp_na)

-> assert(left.columns.equals(right.columns))
(Pdb) left
   a  b  NaN
0  1  0    0
1  0  1    0
2  0  0    1
(Pdb) right
   a  b  NaN
0  1  0    0
1  0  1    0
2  0  0    1
```
