### PR TITLE
BUG: Fix Panel instance variable namespace issue GH3440

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -121,6 +121,8 @@ pandas 0.13
     (:issue:`4405`, :issue:`4437`)
   - Fixed a py3 compat issue where bytes were being repr'd as tuples
     (:issue:`4455`)
+  - Fixed Panel attribute naming conflict if item is named 'a'
+    (:issue:`3440`)
 
 pandas 0.12
 ===========

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -165,12 +165,12 @@ class Panel(NDFrame):
     """
 
     _AXIS_ORDERS = ['items', 'major_axis', 'minor_axis']
-    _AXIS_NUMBERS = dict([(a, i) for i, a in enumerate(_AXIS_ORDERS)])
+    _AXIS_NUMBERS = dict((a, i) for i, a in enumerate(_AXIS_ORDERS))
     _AXIS_ALIASES = {
         'major': 'major_axis',
         'minor': 'minor_axis'
     }
-    _AXIS_NAMES = dict([(i, a) for i, a in enumerate(_AXIS_ORDERS)])
+    _AXIS_NAMES = dict(enumerate(_AXIS_ORDERS))
     _AXIS_SLICEMAP = {
         'major_axis': 'index',
         'minor_axis': 'columns'

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1340,6 +1340,12 @@ class TestPanel(unittest.TestCase, PanelTests, CheckIndexing,
     def test_get_attr(self):
         assert_frame_equal(self.panel['ItemA'], self.panel.ItemA)
 
+        # specific cases from #3440
+        self.panel['a'] = self.panel['ItemA']
+        assert_frame_equal(self.panel['a'], self.panel.a)
+        self.panel['i'] = self.panel['ItemA']
+        assert_frame_equal(self.panel['i'], self.panel.i)
+
     def test_group_agg(self):
         values = np.ones((10, 2)) * np.arange(10).reshape((10, 1))
         bounds = np.arange(5) * 2


### PR DESCRIPTION
The change is minor but so easy I thought I'd submit it: If you switch the list comprehensions to generators, it sidesteps leaking the temporary variables into the class variable scope.

This will be microscopically slower, but they are just class variables so it really doesn't matter.
fixes #3440

https://travis-ci.org/danbirken/pandas/builds/9836459

```
import numpy as np
from pandas import DataFrame, Panel

df0 = DataFrame(np.zeros([3,4]))
df1 = DataFrame(np.ones([3,4]))

p = Panel({'a':df0, 'b':df1})

In [1]: p.a
Out[1]:
   0  1  2  3
0  0  0  0  0
1  0  0  0  0
2  0  0  0  0

In [2]: p.b
Out[2]:
   0  1  2  3
0  1  1  1  1
1  1  1  1  1
2  1  1  1  1
```
