### PR TITLE
BUG: values array for non-unique, interleaved cols incorrect

### DIFF
--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1546,15 +1546,16 @@ class BlockManager(PandasObject):
                 result[indexer] = block.get_values(dtype)
                 itemmask[indexer] = 1
 
-            if not itemmask.all():
-                raise AssertionError('Some items were not contained in blocks')
-
         else:
 
             # non-unique, must use ref_locs
             rl = self._set_ref_locs()
             for i, (block, idx) in enumerate(rl):
-                result[i] = block.iget(idx)
+                result[i] = block.get_values(dtype)[idx]
+                itemmask[i] = 1
+
+        if not itemmask.all():
+            raise AssertionError('Some items were not contained in blocks')
 
         return result
 

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -457,6 +457,17 @@ class TestBlockManager(unittest.TestCase):
     def test_interleave(self):
         pass
 
+    def test_interleave_non_unique_cols(self):
+        df = DataFrame([
+            [Timestamp('20130101'), 3.5],
+            [Timestamp('20130102'), 4.5]],
+            columns=['x', 'x'],
+            index=[1, 2])
+
+        df_unique = df.copy()
+        df_unique.columns = ['x', 'y']
+        np.testing.assert_array_equal(df_unique.values, df.values)
+
     def test_consolidate(self):
         pass
 


### PR DESCRIPTION
I came across this problem when I was doing some work for #4362. When a frame with mixed dtypes including Timestamps has dupe column labels the values array returned is different, as illustrated below (master branch):

``` python
In [3]: df = pd.DataFrame([[pd.Timestamp('20130101'),3.5],[pd.Timestamp('20130102'),4.5]], columns=['x', 'x'], index=[1,2])

In [4]: df
Out[4]: 
                    x    x
1 2013-01-01 00:00:00  3.5
2 2013-01-02 00:00:00  4.5

In [5]: df.values
Out[5]: 
array([[1356998400000000000L, 3.5],
       [1357084800000000000L, 4.5]], dtype=object)

In [6]: df = pd.DataFrame([[pd.Timestamp('20130101'),3.5],[pd.Timestamp('20130102'),4.5]], columns=['x', 'y'], index=[1,2])

In [7]: df
Out[7]: 
                    x    y
1 2013-01-01 00:00:00  3.5
2 2013-01-02 00:00:00  4.5

In [8]: df.values
Out[8]: 
array([[datetime.datetime(2013, 1, 1, 0, 0), 3.5],
       [datetime.datetime(2013, 1, 2, 0, 0), 4.5]], dtype=object)
```

The included changes should fix the problem. This is my first time messing about in pandas internals so any feedback is appreciated!

Possibly related to #4377
