### PR TITLE
rename multi-index

### DIFF
--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2148,7 +2148,7 @@ class BlockManager(PandasObject):
 
         index = self.axes[axis]
         if isinstance(index, MultiIndex):
-            new_axis = MultiIndex.from_tuples([tuple(mapper(y) for y in x) for x in index], names=index.names)
+            new_axis = MultiIndex.from_tuples([mapper(x) for x in index], names=index.names)
         else:
             new_axis = Index([mapper(x) for x in index], name=index.name)
 
@@ -2161,7 +2161,7 @@ class BlockManager(PandasObject):
 
     def rename_items(self, mapper, copydata=True):
         if isinstance(self.items, MultiIndex):
-            items = [tuple(mapper(y) for y in x) for x in self.items]
+            items = [mapper(x) for x in self.items]
             new_items = MultiIndex.from_tuples(items, names=self.items.names)
         else:
             items = [mapper(x) for x in self.items]

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -7804,10 +7804,10 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         index = MultiIndex.from_tuples(tuples_index, names=['foo', 'bar'])
         columns = MultiIndex.from_tuples(tuples_columns, names=['fizz', 'buzz'])
         renamer = DataFrame([(0,0),(1,1)], index=index, columns=columns)
-        renamed = renamer.rename(index={'foo1': 'foo3', 'bar2': 'bar3'},
-                                 columns={'fizz1': 'fizz3', 'buzz2': 'buzz3'})
-        new_index = MultiIndex.from_tuples([('foo3', 'bar1'), ('foo2', 'bar3')])
-        new_columns = MultiIndex.from_tuples([('fizz3', 'buzz1'), ('fizz2', 'buzz3')])
+        renamed = renamer.rename(index={('foo1', 'bar1'): ('foo3', 'bar3')},
+                                 columns={('fizz1', 'buzz1'): ('fizz2', 'buzz2')})
+        new_index = MultiIndex.from_tuples([('foo3', 'bar3'), ('foo2', 'bar2')])
+        new_columns = MultiIndex.from_tuples([('fizz3', 'buzz3'), ('fizz2', 'buzz2')])
         self.assert_(np.array_equal(renamed.index, new_index))
         self.assert_(np.array_equal(renamed.columns, new_columns))
         self.assertEquals(renamed.index.names, renamer.index.names)


### PR DESCRIPTION
## Fix Issue #4160

While renamed a `MultiIndex`, the `mapper` walk through every tuple in the MultiIndex and every element in a tuple. So the mapper { (index1, index2): (new_index1, new_index2) } didn't work for the MultiIndex case.

This pull request is to modify it to walk through every tuple in a MultiIndex and use the mapper to map each tuple.
Also, the test case has been added.
