### PR TITLE
FIX: resample to single group with custom function

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -380,6 +380,7 @@ Bug Fixes
     (:issue:`4170`, :issue:`4440`)
   - Fixed Panel slicing issued in ``xs`` that was returning an incorrect dimmed object
     (:issue:`4016`)
+  - Fix resampling bug where custom reduce function not used if only one group (:issue:`3849`, :issue:`4494`)
   - Fixed Panel assignment with a transposed frame (:issue:`3830`)
   - Raise on set indexing with a Panel and a Panel as a value which needs alignment (:issue:`3777`)
   - frozenset objects now raise in the ``Series`` constructor (:issue:`4482`,

--- a/pandas/src/reduce.pyx
+++ b/pandas/src/reduce.pyx
@@ -206,7 +206,7 @@ cdef class SeriesBinGrouper:
 
         counts = np.zeros(self.ngroups, dtype=np.int64)
 
-        if self.ngroups > 1:
+        if self.ngroups > 0:
             counts[0] = self.bins[0]
             for i in range(1, self.ngroups):
                 if i == self.ngroups - 1:

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -438,6 +438,26 @@ class TestResample(unittest.TestCase):
             expected = ts.resample(freq, closed='left', label='left')
             assert_series_equal(result, expected)
 
+    def test_resample_single_group(self):
+        mysum = lambda x: x.sum()
+
+        rng = date_range('2000-1-1', '2000-2-10', freq='D')
+        ts = Series(np.random.randn(len(rng)), index=rng)
+        assert_series_equal(ts.resample('M', how='sum'),
+                            ts.resample('M', how=mysum))
+
+        rng = date_range('2000-1-1', '2000-1-10', freq='D')
+        ts = Series(np.random.randn(len(rng)), index=rng)
+        assert_series_equal(ts.resample('M', how='sum'),
+                            ts.resample('M', how=mysum))
+
+        # GH 3849
+        s = Series([30.1, 31.6], index=[Timestamp('20070915 15:30:00'),
+                                        Timestamp('20070915 15:40:00')])
+        expected = Series([0.75], index=[Timestamp('20070915')])
+        result = s.resample('D', how=lambda x: np.std(x))
+        assert_series_equal(result, expected)
+
     def test_resample_base(self):
         rng = date_range('1/1/2000 00:00:00', '1/1/2000 02:00', freq='s')
         ts = Series(np.random.randn(len(rng)), index=rng)


### PR DESCRIPTION
Using master code, when re-sampling to a frequency that would result in a single group the use of custom aggregation functions do not work as expected. The included changes fix this, and should fix #3849 too.

``` python
In [17]: import pandas as pd

In [18]: import numpy as np

In [19]: mysum = lambda x: x.sum()

In [20]: rng = pd.date_range('2000-1-1', '2000-1-10', freq='D')

In [21]: ts = pd.Series(np.random.randn(len(rng)), index=rng)

In [22]: ts.resample('M', how='sum')
Out[22]: 
2000-01-31    0.985236
Freq: M, dtype: float64

In [23]: ts.resample('M', how=mysum)
Out[23]: 
2000-01-31    0
Freq: M, dtype: float64
```
