### PR TITLE
BLD/TST: correct pytz version for tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     cython
     numpy >= 1.6.1
     nose
-    pytz
+    pytz >= 2011k
     six
 
 # cd to anything but the default {toxinidir} which


### PR DESCRIPTION
Tox fails to build pandas without a specific version of pytz.
