### PR TITLE
Fix issue #4496: tslib.tz_convert(vals, tz1, tz2) may raise an IndexErro...

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -197,6 +197,8 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
     - raising an invalid ``TypeError`` rather than ``ValueError`` when appending
       with a different block ordering (:issue:`4096`)
     - ``read_hdf`` was not respecting as passed ``mode`` (:issue:`4504`)
+  - Fixed bug in tslib.tz_convert(vals, tz1, tz2): it could raise IndexError exception while 
+    trying to access trans[pos + 1] (:issue:`4496`)
   - The ``by`` argument now works correctly with the ``layout`` argument
     (:issue:`4102`, :issue:`4014`) in ``*.hist`` plotting methods
   - Fixed bug in ``PeriodIndex.map`` where using ``str`` would return the str

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -10587,6 +10587,25 @@ starting,ending,measure
         assert_array_equal(df.starting.values, ser_starting.index.values)
         assert_array_equal(df.ending.values, ser_ending.index.values)
 
+    def test_tslib_tz_convert_trans_pos_plus_1__bug(self):
+        """
+        Regression test for tslib.tz_convert(vals, tz1, tz2).
+        See https://github.com/pydata/pandas/issues/4496 for details.
+        """
+        idx = pd.date_range(datetime(2011, 3, 26, 23), datetime(2011, 3, 27, 1), freq='1min')
+        idx = idx.tz_localize('UTC')
+        idx = idx.tz_convert('Europe/Moscow')
+
+        test_vector = pd.Series([3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                                 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                                 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 
+                                 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 
+                                 4, 4, 4, 4, 4, 4, 4, 4, 5], dtype=int)
+
+        hours = idx.hour
+
+        np.testing.assert_equal(hours, test_vector.values)
+
     def _check_bool_op(self, name, alternative, frame=None, has_skipna=True,
                        has_bool_only=False):
         if frame is None:

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -1432,9 +1432,11 @@ def tz_convert(ndarray[int64_t] vals, object tz1, object tz2):
     pos -= 1
 
     offset = deltas[pos]
+    cdef Py_ssize_t trans_len = len(trans)
+
     for i in range(n):
         v = utc_dates[i]
-        if v >= trans[pos + 1]:
+        if (pos + 1) < trans_len and v >= trans[pos + 1]:
             pos += 1
             offset = deltas[pos]
         result[i] = v + offset


### PR DESCRIPTION
Bug-fix for Issue #4496 Bug: tslib.tz_convert(vals, tz1, tz2) may raise an IndexError exception.
