### PR TITLE
DOC: fix conflicting ewma documentation

### DIFF
--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -450,7 +450,7 @@ average as
 
 .. math::
 
-    y_t = \alpha y_{t-1} + (1 - \alpha) x_t
+    y_t = (1 - \alpha) y_{t-1} + \alpha x_t
 
 One must have :math:`0 < \alpha \leq 1`, but rather than pass :math:`\alpha`
 directly, it's easier to think about either the **span** or **center of mass
@@ -461,8 +461,18 @@ directly, it's easier to think about either the **span** or **center of mass
    \alpha =
     \begin{cases}
 	\frac{2}{s + 1}, s = \text{span}\\
-	\frac{1}{c + 1}, c = \text{center of mass}
+	\frac{1}{1 + c}, c = \text{center of mass}
     \end{cases}
+
+.. note::
+  
+  the equation above is sometimes written in the form
+
+  .. math::
+
+    y_t = \alpha' y_{t-1} + (1 - \alpha') x_t
+
+  where :math:`\alpha' = 1 - \alpha`.
 
 You can pass one or the other to these functions but not both. **Span**
 corresponds to what is commonly called a "20-day EW moving average" for

--- a/pandas/stats/moments.py
+++ b/pandas/stats/moments.py
@@ -56,9 +56,9 @@ Parameters
 ----------
 %s
 com : float. optional
-    Center of mass: \alpha = com / (1 + com),
+    Center of mass: :math:`\alpha = 1 / (1 + com)`,
 span : float, optional
-    Specify decay in terms of span, \alpha = 2 / (span + 1)
+    Specify decay in terms of span, :math:`\alpha = 2 / (span + 1)`
 min_periods : int, default 0
     Number of observations in sample to require (only affects
     beginning)
@@ -75,8 +75,8 @@ Notes
 Either center of mass or span must be specified
 
 EWMA is sometimes specified using a "span" parameter s, we have have that the
-decay parameter \alpha is related to the span as
-:math:`\alpha = 1 - 2 / (s + 1) = c / (1 + c)`
+decay parameter :math:`\alpha` is related to the span as
+:math:`\alpha = 2 / (s + 1) = 1 / (1 + c)`
 
 where c is the center of mass. Given a span, the associated center of mass is
 :math:`c = (s - 1) / 2`


### PR DESCRIPTION
The information in the docs, in the parameter description and in the body of the docstring is conflicting. This should hopefully make them consistent amongst themselves (and with the code).
