### PR TITLE
TST: provide tests for memory_cycles

### DIFF
--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -2561,6 +2561,50 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         # Did not modify original Series
         self.assertFalse(np.isnan(self.ts[0]))
 
+    def test_memory_cycles(self):
+        """
+        test that we are completely cleaning up memory and
+        not leaving uncollectable cycles
+        """
+
+        def f():
+            s = Series(np.random.randn(1000))
+            s[100]
+            return s
+        tm.assert_memory_is_clean(f)
+
+        def f():
+            s = Series(np.random.randn(1000))
+            return s.reindex(range(10))
+        tm.assert_memory_is_clean(f)
+
+        def f():
+            s = Series(np.random.randn(1000))
+            s = s.reindex(range(10))
+            s[5]
+            return s
+        tm.assert_memory_is_clean(f)
+
+        # reindex seems to not be destroying the engine mapping
+        # http://stackoverflow.com/questions/18070520/pandas-memory-usage-when-reindexing
+        idx =["%07d" % x for x in range(int(2e3))]
+        a = Series(np.arange(2e3, dtype=np.double), index=idx)
+        new_index = ["0000003", "0000020", "000002a"]
+
+        self.assert_(a.index._engine.mapping is None)
+        a.reindex(new_index)
+        self.assert_(a.index._engine.mapping is not None)
+
+        a = Series(np.arange(2e3, dtype=np.double), index=idx)
+        self.assert_(a.index._engine.mapping is None)
+        a.asof(new_index)
+        self.assert_(a.index._engine.mapping is None)
+
+        a = Series(np.arange(2e3, dtype=np.double), index=idx)
+        self.assert_(a.index._engine.mapping is None)
+        a[new_index[0]]
+        self.assert_(a.index._engine.mapping is not None)
+
     def test_count(self):
         self.assertEqual(self.ts.count(), len(self.ts))
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1145,3 +1145,22 @@ def assert_produces_warning(expected_warning=Warning, filter_level="always"):
                                  % expected_warning.__name__)
         assert not extra_warnings, ("Caused unexpected warning(s): %r."
                                     % extra_warnings)
+
+def assert_memory_is_clean(f):
+    """
+    assert that the function (which should return a reference to an object)
+    does not create memory cycles and cleans up after itself on deletion
+    """
+
+    import gc
+    gc.collect()
+    gc.garbage[:] = []
+    created = f()
+    gc.collect()
+    assert (gc.collect() == 0), "memory cycles are created"
+    assert (len(gc.garbage) == 0), "garbage is not empty after collection"
+    del created
+    gc.collect()
+    assert (gc.collect() == 0), "garbage is not collected post deletion"
+    assert (len(gc.garbage) == 0), "garbage is not empty post deletion"
+


### PR DESCRIPTION
related to #4491

provides an assert_memory_is_clean to test a function for leaking memory

provides a test that the current series does not leak memory
and properly cleans up

tests that an index generally populates the engine mapping (but not always
e.g. asof)
