### PR TITLE
ENH/BUG: ignore line comments in CSV files GH2685

### DIFF
--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -1527,17 +1527,29 @@ KORD6,19990127, 23:00:00, 22:56:00, -0.5900, 1.7100, 4.6000, 0.0000, 280.0000"""
 
     def test_comment(self):
         data = """A,B,C
-1,2.,4.#hello world
-5.,NaN,10.0
+#first line comment
+1,2.,4. # first end line comment
+# second line comment
+3,5.,7.#second end line comment
+6.,NaN,10.0
 """
-        expected = [[1., 2., 4.],
-                    [5., np.nan, 10.]]
-        df = self.read_csv(StringIO(data), comment='#')
-        assert_almost_equal(df.values, expected)
+        expected = {
+            'c': [[np.nan, np.nan, np.nan],
+                  [1., 2., 4.],
+                  [np.nan, np.nan, np.nan],
+                  [3., 5., 7.],
+                  [6., np.nan, 10.]],
+            'python': [[1., 2., 4.],
+                       [3., 5., 7.],
+                       [6., np.nan, 10.]]
+            }
+        for engine in ('c', 'python'):
+            df = self.read_csv(StringIO(data), comment='#', engine=engine)
+            assert_almost_equal(df.values, expected[engine])
 
-        df = self.read_table(StringIO(data), sep=',', comment='#',
-                             na_values=['NaN'])
-        assert_almost_equal(df.values, expected)
+            df = self.read_table(StringIO(data), sep=',', comment='#',
+                                 na_values=['NaN'], engine=engine)
+            assert_almost_equal(df.values, expected[engine])
 
     def test_bool_na_values(self):
         data = """A,B,C

--- a/pandas/src/parser/tokenizer.c
+++ b/pandas/src/parser/tokenizer.c
@@ -823,7 +823,6 @@ int tokenize_delimited(parser_t *self, size_t line_limit)
             }
             else if (c == self->delimiter) {
                 // End of field. End of line not reached yet
-
                 END_FIELD();
                 self->state = START_FIELD;
             }
@@ -866,7 +865,7 @@ int tokenize_delimited(parser_t *self, size_t line_limit)
             } else {
                 /* \r line terminator */
 
-                /* UGH. we don't actually want to consume the token. fix this later */
+                /*FIXME UGH. we don't actually want to consume the token. */
                 self->stream_len = slen;
                 if (end_line(self) < 0) {
                     goto parsingerror;
@@ -875,7 +874,7 @@ int tokenize_delimited(parser_t *self, size_t line_limit)
                 slen = self->stream_len;
                 self->state = START_RECORD;
 
-                /* HACK, let's try this one again */
+                /*FIXME let's try this one again */
                 --i; buf--;
                 if (line_limit > 0 && self->lines == start_lines + line_limit) {
                     goto linelimit;


### PR DESCRIPTION
closes #2685

I have added the ability for both the C and Python CSV parsers to ignore commented lines (i.e., lines beginning with a comment character).  Currently the C parser preserves commented lines as empty lines (all NaN), while the Python parser ignores them all together.

In addition, I fixed a small related problem with the CSV format sniffer in the Python parser.

I plan to finish up this work by ignoring empty lines as per #4466.
