### PR TITLE
BUG/ER: various panel indexing fixes

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -129,6 +129,8 @@ pandas 0.13
     (:issue:`4486`)
   - Fixed an issue where cumsum and cumprod didn't work with bool dtypes
     (:issue:`4170`, :issue:`4440`)
+  - Fixed Panel slicing issued in ``xs`` that was returning an incorrect dimmed object
+    (:issue:`4016`)
 
 pandas 0.12
 ===========

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -131,6 +131,7 @@ pandas 0.13
     (:issue:`4170`, :issue:`4440`)
   - Fixed Panel slicing issued in ``xs`` that was returning an incorrect dimmed object
     (:issue:`4016`)
+  - Fixed Panel assignment with a transposed frame (:issue:`3830`)
 
 pandas 0.12
 ===========

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -132,6 +132,7 @@ pandas 0.13
   - Fixed Panel slicing issued in ``xs`` that was returning an incorrect dimmed object
     (:issue:`4016`)
   - Fixed Panel assignment with a transposed frame (:issue:`3830`)
+  - Raise on set indexing with a Panel and a Panel as a value which needs alignment (:issue:`3777`)
 
 pandas 0.12
 ===========

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -100,7 +100,7 @@ class _NDFrameIndexer(object):
         return tuple(keyidx)
 
     def _setitem_with_indexer(self, indexer, value):
-        from pandas.core.frame import DataFrame, Series
+        from pandas import Panel, DataFrame, Series
 
         # also has the side effect of consolidating in-place
 
@@ -180,6 +180,9 @@ class _NDFrameIndexer(object):
 
             if isinstance(value, DataFrame):
                 value = self._align_frame(indexer, value)
+
+            if isinstance(value, Panel):
+                value = self._align_panel(indexer, value)
 
             # 2096
             values = self.obj.values
@@ -268,6 +271,11 @@ class _NDFrameIndexer(object):
             return df.reindex(idx, columns=cols).values
 
         raise ValueError('Incompatible indexer with DataFrame')
+
+    def _align_panel(self, indexer, df):
+        is_frame = self.obj.ndim == 2
+        is_panel = self.obj.ndim >= 3
+        raise NotImplementedError("cannot set using an indexer with a Panel yet!")
 
     def _getitem_tuple(self, tup):
         try:

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -877,11 +877,26 @@ class TestIndexing(unittest.TestCase):
         # GH4016, date selection returns a frame when a partial string selection
         ind = date_range(start="2000", freq="D", periods=1000)
         df = DataFrame(np.random.randn(len(ind), 5), index=ind, columns=list('ABCDE'))
-        panel = Panel({'frame_'+c:df for c in list('ABC')})
+        panel = Panel(dict([ ('frame_'+c,df) for c in list('ABC') ]))
 
         test2 = panel.ix[:, "2002":"2002-12-31"]
         test1 = panel.ix[:, "2002"]
         tm.assert_panel_equal(test1,test2)
+
+    def test_panel_assignment(self):
+
+        # GH3777
+        wp = Panel(randn(2, 5, 4), items=['Item1', 'Item2'], major_axis=date_range('1/1/2000', periods=5), minor_axis=['A', 'B', 'C', 'D'])
+        wp2 = Panel(randn(2, 5, 4), items=['Item1', 'Item2'], major_axis=date_range('1/1/2000', periods=5), minor_axis=['A', 'B', 'C', 'D'])
+        expected = wp.loc[['Item1', 'Item2'], :, ['A', 'B']]
+
+        def f():
+            wp.loc[['Item1', 'Item2'], :, ['A', 'B']] = wp2.loc[['Item1', 'Item2'], :, ['A', 'B']]
+        self.assertRaises(NotImplementedError, f)
+
+        #wp.loc[['Item1', 'Item2'], :, ['A', 'B']] = wp2.loc[['Item1', 'Item2'], :, ['A', 'B']]
+        #result = wp.loc[['Item1', 'Item2'], :, ['A', 'B']]
+        #tm.assert_panel_equal(result,expected)
 
     def test_multi_assign(self):
 

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -873,6 +873,16 @@ class TestIndexing(unittest.TestCase):
         self.assert_(p.iloc[1, :3, 1].shape == (3,))
         self.assert_(p.iloc[:3, 1, 1].shape == (3,))
 
+    def test_panel_getitem(self):
+        # GH4016, date selection returns a frame when a partial string selection
+        ind = date_range(start="2000", freq="D", periods=1000)
+        df = DataFrame(np.random.randn(len(ind), 5), index=ind, columns=list('ABCDE'))
+        panel = Panel({'frame_'+c:df for c in list('ABC')})
+
+        test2 = panel.ix[:, "2002":"2002-12-31"]
+        test1 = panel.ix[:, "2002"]
+        tm.assert_panel_equal(test1,test2)
+
     def test_multi_assign(self):
 
         # GH 3626, an assignement of a sub-df to a df

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -655,6 +655,31 @@ class CheckIndexing(object):
         out = p.ix[0, [0, 1, 3, 5], -2:]
         assert_frame_equal(out, df.T.reindex([0, 1, 3, 5], p.minor_axis[-2:]))
 
+        # GH3830, panel assignent by values/frame
+        for dtype in ['float64','int64']:
+
+            panel = Panel(np.arange(40).reshape((2,4,5)), items=['a1','a2'], dtype=dtype)
+            df1 = panel.iloc[0]
+            df2 = panel.iloc[1]
+
+            tm.assert_frame_equal(panel.loc['a1'], df1)
+            tm.assert_frame_equal(panel.loc['a2'], df2)
+
+            # Assignment by Value Passes for 'a2'
+            panel.loc['a2'] = df1.values
+            tm.assert_frame_equal(panel.loc['a1'], df1)
+            tm.assert_frame_equal(panel.loc['a2'], df1)
+
+            # Assignment by DataFrame Ok w/o loc 'a2'
+            panel['a2'] = df2
+            tm.assert_frame_equal(panel.loc['a1'], df1)
+            tm.assert_frame_equal(panel.loc['a2'], df2)
+
+            # Assignment by DataFrame Fails for 'a2'
+            panel.loc['a2'] = df2
+            tm.assert_frame_equal(panel.loc['a1'], df1)
+            tm.assert_frame_equal(panel.loc['a2'], df2)
+
     def _check_view(self, indexer, comp):
         cp = self.panel.copy()
         obj = cp.ix[indexer]


### PR DESCRIPTION
- ER: #3777, raise a `NotImplementedError` for `Panel` -> `Panel` setting with alignment (issue will still be open though)
- BUG: closes #3830, panel assignment using loc with a transpose frame did not work
- BUG: closes #4016 fix panel slicing issue that was returning an object that should not have be a reduction in ndim
