### PR TITLE
ENH/API:  GH2578, allow ix and friends to partially set when the key is not contained in the object

### DIFF
--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -440,6 +440,40 @@ the object it modified, which in the case of enlargement, will be a **new object
    df.at[dates[5], 'E'] = 7
    df.iat[3, 0] = 7
 
+.. _indexing.basics.partial_setting:
+
+Setting With Enlargement
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``.loc/.iloc/[]`` operations can perform enlargement when setting a non-existant key for that axis.
+
+In the ``Series`` case this is effectively an appending operation
+
+.. ipython:: python
+
+   se = Series([1,2,3])
+   se
+   se[5] = 5.
+   se
+
+A ``DataFrame`` can be enlarged on either axis via ``.loc``
+
+.. ipython:: python
+
+   dfi = DataFrame(np.arange(6).reshape(3,2),
+                   columns=['A','B'])
+   dfi
+   dfi.loc[:,'C'] = dfi.loc[:,'A']
+   dfi
+
+This is like an ``append`` operation on the ``DataFrame``.
+
+.. ipython:: python
+
+   dfi.loc[3] = 5
+   dfi
+
+
 Boolean indexing
 ~~~~~~~~~~~~~~~~
 

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -412,40 +412,14 @@ Pandas will detect this and raise ``IndexError``, rather than return an empty st
     >>> df.iloc[:,3:6]
     IndexError: out-of-bounds on slice (end)
 
-.. _indexing.basics.get_value:
-
-Fast scalar value getting and setting
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Since indexing with ``[]`` must handle a lot of cases (single-label access,
-slicing, boolean indexing, etc.), it has a bit of overhead in order to figure
-out what you're asking for. If you only want to access a scalar value, the
-fastest way is to use the ``at`` and ``iat`` methods, which are implemented on
-all of the data structures.
-
-Similary to ``loc``, ``at`` provides **label** based scalar lookups, while, ``iat`` provides **integer** based lookups analagously to ``iloc``
-
-.. ipython:: python
-
-   s.iat[5]
-   df.at[dates[5], 'A']
-   df.iat[3, 0]
-
-You can also set using these same indexers. These have the additional
-capability of enlarging an object. This method *always* returns a reference to
-the object it modified, which in the case of enlargement, will be a **new object**:
-
-.. ipython:: python
-
-   df.at[dates[5], 'E'] = 7
-   df.iat[3, 0] = 7
-
 .. _indexing.basics.partial_setting:
 
 Setting With Enlargement
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``.loc/.iloc/[]`` operations can perform enlargement when setting a non-existant key for that axis.
+.. versionadded:: 0.13
+
+The ``.loc/.ix/[]`` operations can perform enlargement when setting a non-existant key for that axis.
 
 In the ``Series`` case this is effectively an appending operation
 
@@ -473,6 +447,38 @@ This is like an ``append`` operation on the ``DataFrame``.
    dfi.loc[3] = 5
    dfi
 
+.. _indexing.basics.get_value:
+
+Fast scalar value getting and setting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since indexing with ``[]`` must handle a lot of cases (single-label access,
+slicing, boolean indexing, etc.), it has a bit of overhead in order to figure
+out what you're asking for. If you only want to access a scalar value, the
+fastest way is to use the ``at`` and ``iat`` methods, which are implemented on
+all of the data structures.
+
+Similary to ``loc``, ``at`` provides **label** based scalar lookups, while, ``iat`` provides **integer** based lookups analagously to ``iloc``
+
+.. ipython:: python
+
+   s.iat[5]
+   df.at[dates[5], 'A']
+   df.iat[3, 0]
+
+You can also set using these same indexers.
+
+.. ipython:: python
+
+   df.at[dates[5], 'E'] = 7
+   df.iat[3, 0] = 7
+
+``at`` may enlarge the object in-place as above if the indexer is missing.
+
+.. ipython:: python
+
+   df.at[6, 0] = 7
+   df
 
 Boolean indexing
 ~~~~~~~~~~~~~~~~

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -92,6 +92,9 @@ pandas 0.13
     an alias of iteritems used to get around ``2to3``'s changes).
     (:issue:`4384`, :issue:`4375`, :issue:`4372`)
   - ``Series.get`` with negative indexers now returns the same as ``[]`` (:issue:`4390`)
+  - allow ``ix/loc`` for Series/DataFrame/Panel to set on any axis even when the single-key is not currently contained in
+    the index for that axis (:issue:`2578`)
+  - ``at`` now will enlarge the object inplace (and return the same) (:issue:`2578`)
 
   - ``HDFStore``
 
@@ -123,8 +126,6 @@ pandas 0.13
 
     - added ``date_unit`` parameter to specify resolution of timestamps. Options
       are seconds, milliseconds, microseconds and nanoseconds. (:issue:`4362`, :issue:`4498`).
-    - allow ``ix/loc/iloc`` for Series/DataFrame/Panel to set on any axis even when the single-key is not currently contained in
-      the index for that axis (:issue:`2578`)
 
   - ``Index`` and ``MultiIndex`` changes (:issue:`4039`):
 

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -123,6 +123,8 @@ pandas 0.13
 
     - added ``date_unit`` parameter to specify resolution of timestamps. Options
       are seconds, milliseconds, microseconds and nanoseconds. (:issue:`4362`, :issue:`4498`).
+    - allow ``ix/loc/iloc`` for Series/DataFrame/Panel to set on any axis even when the single-key is not currently contained in
+      the index for that axis (:issue:`2578`)
 
   - ``Index`` and ``MultiIndex`` changes (:issue:`4039`):
 
@@ -296,7 +298,7 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
   - ``tslib.get_period_field()`` and ``tslib.get_period_field_arr()`` now raise
     if code argument out of range (:issue:`4519`, :issue:`4520`)
   - Fix boolean indexing on an empty series loses index names (:issue:`4235`),
-  infer_dtype works with empty arrays.
+    infer_dtype works with empty arrays.
   - Fix reindexing with multiple axes; if an axes match was not replacing the current axes, leading
     to a possible lazay frequency inference issue (:issue:`3317`)
   - Fixed issue where ``DataFrame.apply`` was reraising exceptions incorrectly

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -134,6 +134,54 @@ API changes
         df1 and df2
         s1 and s2
 
+Indexing API Changes
+~~~~~~~~~~~~~~~~~~~~
+
+    Prior to 0.13, it was impossible to use an indexer (``.loc/.iloc/.ix``) to set a value that
+    was not contained in the index of a particular axis. (:issue:`2578`). See more at :ref:`here<indexing.basics.partial_setting>`
+
+    In the ``Series`` case this is effectively an appending operation
+
+    .. ipython:: python
+
+       s = Series([1,2,3])
+       s
+       s[5] = 5.
+       s
+
+    .. ipython:: python
+
+       dfi = DataFrame(np.arange(6).reshape(3,2),
+                       columns=['A','B'])
+       dfi
+
+    This would previously ``KeyError``
+
+    .. ipython:: python
+
+       dfi.loc[:,'C'] = dfi.loc[:,'A']
+       dfi
+
+    This is like an ``append`` operation.
+
+    .. ipython:: python
+
+       dfi.loc[3] = 5
+       dfi
+
+    A Panel setting operation on an arbitrary axis aligns the input to the Panel
+
+    .. ipython:: python
+
+       p = pd.Panel(np.arange(16).reshape(2,4,2),
+                   items=['Item1','Item2'],
+                   major_axis=pd.date_range('2001/1/12',periods=4),
+                   minor_axis=['A','B'],dtype='float64')
+       p
+       p.loc[:,:,'C'] = Series([30,32],index=p.items)
+       p
+       p.loc[:,:,'C']
+
 Enhancements
 ~~~~~~~~~~~~
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1731,18 +1731,12 @@ class DataFrame(NDFrame):
             engine.set_value(series.values, index, value)
             return self
         except KeyError:
-            new_index, new_columns = self._expand_axes((index, col))
-            result = self.reindex(index=new_index, columns=new_columns,
-                                  copy=False)
-            likely_dtype, value = _infer_dtype_from_scalar(value)
 
-            made_bigger = not np.array_equal(new_columns, self.columns)
+            # set using a non-recursive method & reset the cache
+            self.loc[index,col] = value
+            self._item_cache.pop(col,None)
 
-            # how to make this logic simpler?
-            if made_bigger:
-                com._possibly_cast_item(result, col, likely_dtype)
-
-            return result.set_value(index, col, value)
+            return self
 
     def irow(self, i, copy=False):
         return self._ixs(i, axis=0)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1,7 +1,7 @@
 # pylint: disable=W0223
 
 from datetime import datetime
-from pandas.core.common import _asarray_tuplesafe
+from pandas.core.common import _asarray_tuplesafe, is_list_like
 from pandas.core.index import Index, MultiIndex, _ensure_index
 from pandas.compat import range, zip
 import pandas.compat as compat
@@ -86,27 +86,66 @@ class _NDFrameIndexer(object):
             if len(key) > self.ndim:
                 raise IndexingError('only tuples of length <= %d supported',
                                     self.ndim)
-            indexer = self._convert_tuple(key)
+            indexer = self._convert_tuple(key, is_setter=True)
         else:
-            indexer = self._convert_to_indexer(key)
+            indexer = self._convert_to_indexer(key, is_setter=True)
 
         self._setitem_with_indexer(indexer, value)
 
     def _has_valid_tuple(self, key):
         pass
 
-    def _convert_tuple(self, key):
+    def _convert_tuple(self, key, is_setter=False):
         keyidx = []
         for i, k in enumerate(key):
-            idx = self._convert_to_indexer(k, axis=i)
+            idx = self._convert_to_indexer(k, axis=i, is_setter=is_setter)
             keyidx.append(idx)
         return tuple(keyidx)
 
     def _setitem_with_indexer(self, indexer, value):
 
         # also has the side effect of consolidating in-place
-        # mmm, spaghetti
+        from pandas import Panel, DataFrame, Series
 
+        # maybe partial set
+        if isinstance(indexer,tuple):
+            nindexer = []
+            for i, idx in enumerate(indexer):
+                if isinstance(idx, dict):
+
+                    # reindex the axis to the new value
+                    # and set inplace
+                    key,_ = _convert_missing_indexer(idx)
+                    labels = self.obj._get_axis(i) + Index([key])
+                    self.obj._data = self.obj.reindex_axis(labels,i)._data
+
+                    nindexer.append(labels.get_loc(key))
+                else:
+                    nindexer.append(idx)
+
+            indexer = tuple(nindexer)
+        else:
+
+            indexer, missing = _convert_missing_indexer(indexer)
+
+            if missing:
+
+                # reindex the axis to the new value
+                # and set inplace
+                if self.ndim == 1:
+                    self.obj._data = self.obj.append(Series(value,index=[indexer]))._data
+                    return
+
+                elif self.ndim == 2:
+                    labels = self.obj._get_axis(0) + Index([indexer])
+                    self.obj._data = self.obj.reindex_axis(labels,0)._data
+                    return getattr(self.obj,self.name).__setitem__(indexer,value)
+
+                # set using setitem (Panel and > dims)
+                elif self.ndim >= 3:
+                    return self.obj.__setitem__(indexer,value)
+
+        # align and set the values
         if self.obj._is_mixed_type:
             if not isinstance(indexer, tuple):
                 indexer = self._tuplify(indexer)
@@ -192,13 +231,72 @@ class _NDFrameIndexer(object):
     def _align_series(self, indexer, ser):
         # indexer to assign Series can be tuple or scalar
         if isinstance(indexer, tuple):
+
+            aligners = [ not _is_null_slice(idx) for idx in indexer ]
+            single_aligner = sum(aligners) == 1
+            is_frame = self.obj.ndim == 2
+            is_panel = self.obj.ndim >= 3
+
+            # are we a single alignable value on a non-primary
+            # dim (e.g. panel: 1,2, or frame: 0) ?
+            # hence need to align to a single axis dimension
+            # rather that find all valid dims
+
+            # frame
+            if is_frame:
+                single_aligner = single_aligner and aligners[0]
+
+            # panel
+            elif is_panel:
+                single_aligner = single_aligner and (aligners[1] or aligners[2])
+
+            obj = self.obj
             for i, idx in enumerate(indexer):
-                ax = self.obj.axes[i]
+                ax = obj.axes[i]
+
+                # multiple aligners (or null slices)
                 if com._is_sequence(idx) or isinstance(idx, slice):
+                    if single_aligner and _is_null_slice(idx):
+                        continue
                     new_ix = ax[idx]
+                    if not is_list_like(new_ix):
+                        new_ix = Index([new_ix])
                     if ser.index.equals(new_ix):
                         return ser.values.copy()
                     return ser.reindex(new_ix).values
+
+                # 2 dims
+                elif single_aligner and is_frame:
+
+                    # reindex along index
+                    ax = self.obj.axes[1]
+                    if ser.index.equals(ax):
+                        return ser.values.copy()
+                    return ser.reindex(ax).values
+
+                # >2 dims
+                elif single_aligner:
+
+                    broadcast = []
+                    for n, labels in enumerate(self.obj._get_plane_axes(i)):
+
+                        # reindex along the matching dimensions
+                        if len(labels & ser.index):
+                            ser = ser.reindex(labels)
+                        else:
+                            broadcast.append((n,len(labels)))
+
+                    # broadcast along other dims
+                    ser = ser.values.copy()
+                    for (axis,l) in broadcast:
+                        shape = [ -1 ] * (len(broadcast)+1)
+                        shape[axis] = l
+                        ser = np.tile(ser,l).reshape(shape)
+
+                    if self.obj.ndim == 3:
+                        ser = ser.T
+
+                    return ser
 
         elif np.isscalar(indexer):
             ax = self.obj._get_axis(1)
@@ -521,7 +619,7 @@ class _NDFrameIndexer(object):
 
                 return result
 
-    def _convert_to_indexer(self, obj, axis=0):
+    def _convert_to_indexer(self, obj, axis=0, is_setter=False):
         """
         Convert indexing key into something we can use to do actual fancy
         indexing on an ndarray
@@ -639,7 +737,14 @@ class _NDFrameIndexer(object):
                 return indexer
 
         else:
-            return labels.get_loc(obj)
+            try:
+                return labels.get_loc(obj)
+            except (KeyError):
+
+                # allow a not found key only if we are a setter
+                if np.isscalar(obj) and is_setter:
+                    return { 'key' : obj }
+                raise
 
     def _tuplify(self, loc):
         tup = [slice(None, None) for _ in range(self.ndim)]
@@ -877,7 +982,7 @@ class _iLocIndexer(_LocationIndexer):
 
             return self._get_loc(key,axis=axis)
 
-    def _convert_to_indexer(self, obj, axis=0):
+    def _convert_to_indexer(self, obj, axis=0, is_setter=False):
         """ much simpler as we only have to deal with our valid types """
         if self._has_valid_type(obj,axis):
             return obj
@@ -1028,6 +1133,12 @@ class _SeriesIndexer(_NDFrameIndexer):
         return self.obj._get_values(indexer)
 
     def _setitem_with_indexer(self, indexer, value):
+
+        # need to delegate to the super setter
+        if isinstance(indexer, dict):
+            return super(_SeriesIndexer, self)._setitem_with_indexer(indexer, value)
+
+        # fast access
         self.obj._set_values(indexer, value)
 
 def _check_bool_indexer(ax, key):
@@ -1052,6 +1163,21 @@ def _check_bool_indexer(ax, key):
 
     return result
 
+
+def _convert_missing_indexer(indexer):
+    """ reverse convert a missing indexer, which is a dict
+        return the scalar indexer and a boolean indicating if we converted """
+
+    if isinstance(indexer, dict):
+
+        # a missing key (but not a tuple indexer)
+        indexer = indexer['key']
+
+        if isinstance(indexer, bool):
+            raise KeyError("cannot use a single bool to index into setitem")
+        return indexer, True
+
+    return indexer, False
 
 def _maybe_convert_indices(indices, n):
     """ if we have negative indicies, translate to postive here

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2647,7 +2647,7 @@ class BlockManager(PandasObject):
             if method is not None or limit is not None:
                 return self.reindex_axis0_with_method(new_axis, indexer=indexer,
                                                       method=method, fill_value=fill_value, limit=limit, copy=copy)
-            return self.reindex_items(new_axis, copy=copy, fill_value=fill_value)
+            return self.reindex_items(new_axis, indexer=indexer, copy=copy, fill_value=fill_value)
 
         new_axis, indexer = cur_axis.reindex(
             new_axis, method, copy_if_needed=True)
@@ -2709,7 +2709,7 @@ class BlockManager(PandasObject):
 
         return self.__class__(new_blocks, new_axes)
 
-    def reindex_items(self, new_items, copy=True, fill_value=None):
+    def reindex_items(self, new_items, indexer=None, copy=True, fill_value=None):
         """
 
         """
@@ -2719,8 +2719,8 @@ class BlockManager(PandasObject):
             data = data.consolidate()
             return data.reindex_items(new_items, copy=copy, fill_value=fill_value)
 
-        # TODO: this part could be faster (!)
-        new_items, indexer = self.items.reindex(new_items, copy_if_needed=True)
+        if indexer is None:
+            new_items, indexer = self.items.reindex(new_items, copy_if_needed=True)
         new_axes = [new_items] + self.axes[1:]
 
         # could have so me pathological (MultiIndex) issues here

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -9,7 +9,7 @@ from pandas.core.base import PandasObject
 
 from pandas.core.common import (_possibly_downcast_to_dtype, isnull, notnull,
                                 _NS_DTYPE, _TD_DTYPE, ABCSeries, ABCSparseSeries,
-                                is_list_like)
+                                is_list_like, _infer_dtype_from_scalar)
 from pandas.core.index import (Index, MultiIndex, _ensure_index,
                                _handle_legacy_indexes)
 from pandas.core.indexing import _check_slice_bounds, _maybe_convert_indices
@@ -460,6 +460,24 @@ class Block(PandasObject):
         if self.is_integer or self.is_bool or self.is_datetime:
             pass
         elif self.is_float and result.dtype == self.dtype:
+
+            # protect against a bool/object showing up here
+            if isinstance(dtype,compat.string_types) and dtype == 'infer':
+                return result
+            if not isinstance(dtype,type):
+                dtype = dtype.type
+            if issubclass(dtype,(np.bool_,np.object_)):
+                if issubclass(dtype,np.bool_):
+                    if isnull(result).all():
+                        return result.astype(np.bool_)
+                    else:
+                        result = result.astype(np.object_)
+                        result[result==1] = True
+                        result[result==0] = False
+                        return result
+                else:
+                    return result.astype(np.object_)
+
             return result
 
         # may need to change the dtype here
@@ -536,8 +554,12 @@ class Block(PandasObject):
             values[indexer] = value
 
             # coerce and try to infer the dtypes of the result
+            if np.isscalar(value):
+                dtype,_ = _infer_dtype_from_scalar(value)
+            else:
+                dtype = 'infer'
             values = self._try_coerce_result(values)
-            values = self._try_cast_result(values, 'infer')
+            values = self._try_cast_result(values, dtype)
             return [make_block(transf(values), self.items, self.ref_items, ndim=self.ndim, fastpath=True)]
         except:
             pass
@@ -902,7 +924,7 @@ class FloatBlock(NumericBlock):
         if is_list_like(element):
             element = np.array(element)
             return issubclass(element.dtype.type, (np.floating, np.integer))
-        return isinstance(element, (float, int))
+        return isinstance(element, (float, int, np.float_, np.int_)) and not isinstance(bool,np.bool_)
 
     def _try_cast(self, element):
         try:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1204,13 +1204,10 @@ class Series(generic.NDFrame):
             self.index._engine.set_value(self.values, label, value)
             return self
         except KeyError:
-            if len(self.index) == 0:
-                new_index = Index([label])
-            else:
-                new_index = self.index.insert(len(self), label)
 
-            new_values = np.concatenate([self.values, [value]])
-            return self._constructor(new_values, index=new_index, name=self.name)
+            # set using a non-recursive method
+            self.loc[label] = value
+            return self
 
     def reset_index(self, level=None, drop=False, name=None, inplace=False):
         """

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -1075,6 +1075,7 @@ class TestSparseDataFrame(TestCase, test_frame.SafeForSparse):
                           type(iframe.icol(0).sp_index))
 
     def test_set_value(self):
+
         res = self.frame.set_value('foobar', 'B', 1.5)
         self.assert_(res is not self.frame)
         self.assert_(res.index[-1] == 'foobar')

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -866,9 +866,11 @@ class CheckIndexing(object):
         self.assertRaises(KeyError,
                           self.frame.ix.__setitem__,
                           (slice(None, None), ['E']), 1)
-        self.assertRaises(KeyError,
-                          self.frame.ix.__setitem__,
-                          (slice(None, None), 'E'), 1)
+
+        # partial setting now allows this GH2578
+        #self.assertRaises(KeyError,
+        #                  self.frame.ix.__setitem__,
+        #                  (slice(None, None), 'E'), 1)
 
     def test_setitem_fancy_mixed_2d(self):
         self.mixed_frame.ix[:5, ['C', 'B', 'A']] = 5

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1483,33 +1483,54 @@ class CheckIndexing(object):
                 assert_almost_equal(self.frame[col][idx], 1)
 
     def test_set_value_resize(self):
+
         res = self.frame.set_value('foobar', 'B', 0)
-        self.assert_(res is not self.frame)
+        self.assert_(res is self.frame)
         self.assert_(res.index[-1] == 'foobar')
         self.assertEqual(res.get_value('foobar', 'B'), 0)
 
-        res2 = res.set_value('foobar', 'qux', 0)
-        self.assert_(res2 is not res)
-        self.assert_(np.array_equal(res2.columns,
-                                    list(self.frame.columns) + ['qux']))
-        self.assertEqual(res2.get_value('foobar', 'qux'), 0)
+        self.frame.loc['foobar','qux'] = 0
+        self.assertEqual(self.frame.get_value('foobar', 'qux'), 0)
 
+        res = self.frame.copy()
         res3 = res.set_value('foobar', 'baz', 'sam')
         self.assert_(res3['baz'].dtype == np.object_)
 
+        res = self.frame.copy()
         res3 = res.set_value('foobar', 'baz', True)
         self.assert_(res3['baz'].dtype == np.object_)
 
+        res = self.frame.copy()
         res3 = res.set_value('foobar', 'baz', 5)
         self.assert_(com.is_float_dtype(res3['baz']))
         self.assert_(isnull(res3['baz'].drop(['foobar'])).values.all())
         self.assertRaises(ValueError, res3.set_value, 'foobar', 'baz', 'sam')
 
     def test_set_value_with_index_dtype_change(self):
-        df = DataFrame(randn(3, 3), index=lrange(3), columns=list('ABC'))
-        res = df.set_value('C', 2, 1.0)
-        self.assert_(list(res.index) == list(df.index) + ['C'])
-        self.assert_(list(res.columns) == list(df.columns) + [2])
+        df_orig = DataFrame(randn(3, 3), index=lrange(3), columns=list('ABC'))
+
+        # this is actually ambiguous as the 2 is interpreted as a positional
+        # so column is not created
+        df = df_orig.copy()
+        df.set_value('C', 2, 1.0)
+        self.assert_(list(df.index) == list(df_orig.index) + ['C'])
+        #self.assert_(list(df.columns) == list(df_orig.columns) + [2])
+
+        df = df_orig.copy()
+        df.loc['C', 2] = 1.0
+        self.assert_(list(df.index) == list(df_orig.index) + ['C'])
+        #self.assert_(list(df.columns) == list(df_orig.columns) + [2])
+
+        # create both new
+        df = df_orig.copy()
+        df.set_value('C', 'D', 1.0)
+        self.assert_(list(df.index) == list(df_orig.index) + ['C'])
+        self.assert_(list(df.columns) == list(df_orig.columns) + ['D'])
+
+        df = df_orig.copy()
+        df.loc['C', 'D'] = 1.0
+        self.assert_(list(df.index) == list(df_orig.index) + ['C'])
+        self.assert_(list(df.columns) == list(df_orig.columns) + ['D'])
 
     def test_get_set_value_no_partial_indexing(self):
         # partial w/ MultiIndex raise exception

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -1233,9 +1233,50 @@ class TestIndexing(unittest.TestCase):
 
         # GH2578, allow ix and friends to partially set
 
+        ### series ###
+        s_orig = Series([1,2,3])
+
+        s = s_orig.copy()
+        s[5] = 5
+        expected = Series([1,2,3,5],index=[0,1,2,5])
+        assert_series_equal(s,expected)
+
+        s = s_orig.copy()
+        s.loc[5] = 5
+        expected = Series([1,2,3,5],index=[0,1,2,5])
+        assert_series_equal(s,expected)
+
+        s = s_orig.copy()
+        s[5] = 5.
+        expected = Series([1,2,3,5.],index=[0,1,2,5])
+        assert_series_equal(s,expected)
+
+        s = s_orig.copy()
+        s.loc[5] = 5.
+        expected = Series([1,2,3,5.],index=[0,1,2,5])
+        assert_series_equal(s,expected)
+
+        # iloc/iat raise
+        s = s_orig.copy()
+        def f():
+            s.iloc[3] = 5.
+        self.assertRaises(IndexError, f)
+        def f():
+            s.iat[3] = 5.
+        self.assertRaises(IndexError, f)
+
         ### frame ###
 
         df_orig = DataFrame(np.arange(6).reshape(3,2),columns=['A','B'])
+
+        # iloc/iat raise
+        df = df_orig.copy()
+        def f():
+            df.iloc[4,2] = 5.
+        self.assertRaises(IndexError, f)
+        def f():
+            df.iat[4,2] = 5.
+        self.assertRaises(IndexError, f)
 
         # row setting where it exists
         expected = DataFrame(dict({ 'A' : [0,4,4], 'B' : [1,5,5] }))

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1400,8 +1400,10 @@ Thur,Lunch,Yes,51.51,17"""
         self.assertRaises(KeyError, self.frame.ix.__getitem__,
                           (('bar', 'three'), 'B'))
 
-        self.assertRaises(KeyError, self.frame.ix.__setitem__,
-                          (('bar', 'three'), 'B'), 0)
+
+        # in theory should be inserting in a sorted space????
+        self.frame.ix[('bar','three'),'B'] = 0
+        self.assert_(self.frame.sortlevel().ix[('bar','three'),'B'] == 0)
 
     #----------------------------------------------------------------------
     # AMBIGUOUS CASES!

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -851,8 +851,17 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
 
     def test_setitem_ambiguous_keyerror(self):
         s = Series(lrange(10), index=lrange(0, 20, 2))
-        self.assertRaises(KeyError, s.__setitem__, 1, 5)
-        self.assertRaises(KeyError, s.ix.__setitem__, 1, 5)
+
+        # equivalent of an append
+        s2 = s.copy()
+        s2[1] = 5
+        expected = s.append(Series([5],index=[1]))
+        assert_series_equal(s2,expected)
+
+        s2 = s.copy()
+        s2.ix[1] = 5
+        expected = s.append(Series([5],index=[1]))
+        assert_series_equal(s2,expected)
 
     def test_setitem_float_labels(self):
         # note labels are floats
@@ -954,8 +963,10 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         self.assert_((series[::2] == 0).all())
 
         # set item that's not contained
-        self.assertRaises(Exception, self.series.__setitem__,
-                          'foobar', 1)
+        s = self.series.copy()
+        s['foobar'] = 1
+        expected = self.series.append(Series([1],index=['foobar']))
+        assert_series_equal(s,expected)
 
     def test_setitem_dtypes(self):
 
@@ -4719,33 +4730,26 @@ class TestSeriesNonUnique(unittest.TestCase):
         self.assertRaises(IndexError, s.__setitem__, 5, 0)
 
         self.assertRaises(KeyError, s.__getitem__, 'c')
-        self.assertRaises(KeyError, s.__setitem__, 'c', 0)
 
         s = s.sort_index()
 
         self.assertRaises(IndexError, s.__getitem__, 5)
         self.assertRaises(IndexError, s.__setitem__, 5, 0)
 
-        self.assertRaises(KeyError, s.__getitem__, 'c')
-        self.assertRaises(KeyError, s.__setitem__, 'c', 0)
 
     def test_int_indexing(self):
         s = Series(np.random.randn(6), index=[0, 0, 1, 1, 2, 2])
 
         self.assertRaises(KeyError, s.__getitem__, 5)
-        self.assertRaises(KeyError, s.__setitem__, 5, 0)
 
         self.assertRaises(KeyError, s.__getitem__, 'c')
-        self.assertRaises(KeyError, s.__setitem__, 'c', 0)
 
         # not monotonic
         s = Series(np.random.randn(6), index=[2, 2, 0, 0, 1, 1])
 
         self.assertRaises(KeyError, s.__getitem__, 5)
-        self.assertRaises(KeyError, s.__setitem__, 5, 0)
 
         self.assertRaises(KeyError, s.__getitem__, 'c')
-        self.assertRaises(KeyError, s.__setitem__, 'c', 0)
 
     def test_datetime_indexing(self):
         from pandas import date_range

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1000,10 +1000,17 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         self.assert_(res is self.ts)
         self.assertEqual(self.ts[idx], 0)
 
-        res = self.series.set_value('foobar', 0)
-        self.assert_(res is not self.series)
+        # equiv
+        s = self.series.copy()
+        res = s.set_value('foobar', 0)
+        self.assert_(res is s)
         self.assert_(res.index[-1] == 'foobar')
         self.assertEqual(res['foobar'], 0)
+
+        s = self.series.copy()
+        s.loc['foobar'] = 0
+        self.assert_(s.index[-1] == 'foobar')
+        self.assertEqual(s['foobar'], 0)
 
     def test_setslice(self):
         sl = self.ts[5:20]
@@ -4761,13 +4768,16 @@ class TestSeriesNonUnique(unittest.TestCase):
         stamp = Timestamp('1/8/2000')
 
         self.assertRaises(KeyError, s.__getitem__, stamp)
-        self.assertRaises(KeyError, s.__setitem__, stamp, 0)
+        s[stamp] = 0
+        self.assert_(s[stamp] == 0)
 
         # not monotonic
+        s = Series(len(index), index=index)
         s = s[::-1]
 
         self.assertRaises(KeyError, s.__getitem__, stamp)
-        self.assertRaises(KeyError, s.__setitem__, stamp, 0)
+        s[stamp] = 0
+        self.assert_(s[stamp] == 0)
 
     def test_reset_index(self):
         df = tm.makeDataFrame()[:5]

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -109,7 +109,10 @@ class TestTimeSeriesDuplicates(unittest.TestCase):
             assert_series_equal(cp, expected)
 
         self.assertRaises(KeyError, ts.__getitem__, datetime(2000, 1, 6))
-        self.assertRaises(KeyError, ts.__setitem__, datetime(2000, 1, 6), 0)
+
+        # new index
+        ts[datetime(2000,1,6)] = 0
+        self.assert_(ts[datetime(2000,1,6)] == 0)
 
     def test_range_slice(self):
         idx = DatetimeIndex(['1/1/2000', '1/2/2000', '1/2/2000', '1/3/2000',


### PR DESCRIPTION
closes #2578

On a series, this is kind of like an inplace append operation (note the dtype change - on purpose)

```
In [6]: s = Series([1,2,3])

In [7]: s[4] = 5.
In [3]: s
Out[3]: 
0    1
1    2
2    3
4    5
dtype: float64
```

This is now allowed: (previously would `KeyError`), you first have to create the column `C`, then set it

```
In [1]: df = DataFrame(np.arange(6).reshape(3,2),columns=['A','B'])

In [3]: df
Out[3]: 
   A  B
0  0  1
1  2  3
2  4  5

In [4]: df.ix[:,'C'] = df.ix[:,'A']

In [5]: df
Out[5]: 
   A  B  C
0  0  1  0
1  2  3  2
2  4  5  4
```

This would previously raise an `IndexError`

```
In [4]: df.loc[3] = 5

In [5]: df
Out[5]: 
   A  B  C
0  0  1  0
1  2  3  2
2  4  5  4
3  5  5  5
```

and on Panel:

```
In [6]: p = Panel(np.arange(16).reshape(2,4,2),
   items=['Item1','Item2'],
   major_axis=pd.date_range('2001/1/12',periods=4),
   minor_axis=['A','B'],dtype='float64')

In [7]: p
Out[7]: 
<class 'pandas.core.panel.Panel'>
Dimensions: 2 (items) x 4 (major_axis) x 2 (minor_axis)
Items axis: Item1 to Item2
Major_axis axis: 2001-01-12 00:00:00 to 2001-01-15 00:00:00
Minor_axis axis: A to B

In [10]: p.loc[:,:,'C'] = Series([30,32],index=p_orig.items)

In [11]: p
Out[11]: 
<class 'pandas.core.panel.Panel'>
Dimensions: 2 (items) x 4 (major_axis) x 3 (minor_axis)
Items axis: Item1 to Item2
Major_axis axis: 2001-01-12 00:00:00 to 2001-01-15 00:00:00
Minor_axis axis: A to C

In [13]: p.loc[:,:,'C']
Out[13]: 
            Item1  Item2
2001-01-12     30     32
2001-01-13     30     32
2001-01-14     30     32
2001-01-15     30     32
```
