### PR TITLE
ENH: avoid unnecessary ga mgmt calls if given profile_id upfront

### DIFF
--- a/ci/print_versions.py
+++ b/ci/print_versions.py
@@ -129,4 +129,22 @@ try:
 except:
     print("html5lib: Not installed")
 
+try:
+    import apiclient
+    print("apiclient: %s" % apiclient.__version__)
+except:
+    print("apiclient: Not installed")
+
+try:
+    import oauth2client
+    print("oauth2client: %s" % oauth2client.__version__)
+except:
+    print("oauth2client: Not installed")
+
+try:
+    import httplib2
+    print("httplib2: %s" % httplib2.__version__)
+except:
+    print("httplib2: Not installed")
+
 print("\n")

--- a/ci/requirements-2.6.txt
+++ b/ci/requirements-2.6.txt
@@ -4,3 +4,5 @@ python-dateutil==1.5
 pytz==2013b
 http://www.crummy.com/software/BeautifulSoup/bs4/download/4.2/beautifulsoup4-4.2.0.tar.gz
 html5lib==1.0b2
+google-api-python-client==1.2
+httplib2==0.8

--- a/ci/requirements-2.7.txt
+++ b/ci/requirements-2.7.txt
@@ -16,3 +16,6 @@ scikits.timeseries==0.91.3
 MySQL-python==1.2.4
 scipy==0.10.0
 beautifulsoup4==4.2.1
+google-api-python-client==1.2
+httplib2==0.8
+python-gflags==2.0

--- a/ci/requirements-2.7_LOCALE.txt
+++ b/ci/requirements-2.7_LOCALE.txt
@@ -14,3 +14,4 @@ html5lib==1.0b2
 lxml==3.2.1
 scipy==0.10.0
 beautifulsoup4==4.2.1
+google-api-python-client==1.2

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -148,6 +148,10 @@ Optional Dependencies
          to get the necessary dependencies for installation of `lxml`_. This
          will prevent further headaches down the line.
 
+  * `google-api-python-client `<https://developers.google.com/
+      api-client-library/python/start/installation>`__
+      * Needed for :mod:`pandas.io.ga`
+
 
 .. _html5lib: https://github.com/html5lib/html5lib-python
 .. _BeautifulSoup4: http://www.crummy.com/software/BeautifulSoup

--- a/pandas/io/tests/test_ga.py
+++ b/pandas/io/tests/test_ga.py
@@ -13,8 +13,8 @@ try:
     from pandas.io.ga import GAnalytics, read_ga
     from pandas.io.auth import AuthenticationConfigError, reset_token_store
     from pandas.io import auth
-except ImportError:
-    raise nose.SkipTest
+except (Exception) as detail:
+    raise nose.SkipTest(detail)
 
 class TestGoogle(unittest.TestCase):
 


### PR DESCRIPTION
`profile_id` is ultimately what's needed to make a call to the reporting api.  If it is specified in the parameter list it seems wasteful to call the management api 3 times.
