### PR TITLE
DOC/BLD: Update version support in docs and setup.py.

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -16,11 +16,10 @@ compiler (MinGW or Visual Studio) installed. `How-to install MinGW on Windows
 Python version support
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Officially Python 2.6 to 2.7 and Python 3.1+, although Python 3 support is less
-well tested. Python 2.4 support is being phased out since the userbase has
-shrunk significantly. Continuing Python 2.4 support will require either monetary
-development support or someone contributing to the project to maintain
-compatibility.
+Officially Python 2.6 to 2.7 and Python 3.2+. Python 2.4 and Python 2.5 are no
+longer supported since the userbase has shrunk significantly. Continuing Python
+2.4 and 2.5 support will require either monetary development support or someone
+contributing to the project to restore compatibility.
 
 
 Binary installers

--- a/setup.py
+++ b/setup.py
@@ -180,6 +180,10 @@ CLASSIFIERS = [
     'Programming Language :: Python',
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 2.6',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3.2',
+    'Programming Language :: Python :: 3.3',
     'Programming Language :: Cython',
     'Topic :: Scientific/Engineering',
 ]


### PR DESCRIPTION
Fixes #4412.

Changes install.rst to explicitly reference that pandas supports 2.6,
2.7, and 3.2+. (and removes line that Python 3 support is less
well-tested). Also adds 2.6, 2.7, 3.2, and 3.3 in classifiers in
setup.py
