### PR TITLE
BUG/API: Fix operating with timedelta64/pd.offsets on rhs of a datelike series/index

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -53,8 +53,11 @@ pandas 0.13
   - Add ``rename`` and ``set_names`` methods to ``Index`` as well as
     ``set_names``, ``set_levels``, ``set_labels`` to ``MultiIndex``.
     (:issue:`4039`)
-  - A Series of dtype ``Timedelta64[ns]`` can now be divided/multiplied
+  - A Series of dtype ``timedelta64[ns]`` can now be divided/multiplied
     by an integer series (:issue`4521`)
+  - A Series of dtype ``timedelta64[ns]`` can now be divided by another
+    ``timedelta64[ns]`` object to yield a ``float64`` dtyped Series. This
+    is frequency conversion.
 
 **API Changes**
 

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -53,6 +53,8 @@ pandas 0.13
   - Add ``rename`` and ``set_names`` methods to ``Index`` as well as
     ``set_names``, ``set_levels``, ``set_labels`` to ``MultiIndex``.
     (:issue:`4039`)
+  - A Series of dtype ``Timedelta64[ns]`` can now be divided/multiplied
+    by an integer series (:issue`4521`)
 
 **API Changes**
 

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -168,6 +168,8 @@ pandas 0.13
   - Fixed (:issue:`3334`) in pivot_table. Margins did not compute if values is the index.
   - Fix bug in having a rhs of ``np.timedelta64`` or ``np.offsets.DateOffset`` when operating
     with datetimes (:issue:`4532`)
+  - Fix arithmetic with series/datetimeindex and ``np.timedelta64`` not working the same (:issue:`4134`)
+    and buggy timedelta in numpy 1.6 (:issue:`4135`)
 
 pandas 0.12
 ===========

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -166,6 +166,8 @@ pandas 0.13
   - Fixed issue where individual ``names``, ``levels`` and ``labels`` could be
     set on ``MultiIndex`` without validation (:issue:`3714`, :issue:`4039`)
   - Fixed (:issue:`3334`) in pivot_table. Margins did not compute if values is the index.
+  - Fix bug in having a rhs of ``np.timedelta64`` or ``np.offsets.DateOffset`` when operating
+    with datetimes (:issue:`4532`)
 
 pandas 0.12
 ===========

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -100,6 +100,40 @@ Enhancements
   - Added a more informative error message when plot arguments contain
     overlapping color and style arguments (:issue:`4402`)
 
+  - ``timedelta64[ns]`` operations
+
+    - A Series of dtype ``timedelta64[ns]`` can now be divided by another
+      ``timedelta64[ns]`` object to yield a ``float64`` dtyped Series. This
+      is frequency conversion. See :ref:`here<timeseries.timedeltas_convert>` for the docs.
+
+      .. ipython:: python
+
+         from datetime import timedelta
+         td = Series(date_range('20130101',periods=4))-Series(date_range('20121201',periods=4))
+         td[2] += np.timedelta64(timedelta(minutes=5,seconds=3))
+         td[3] = np.nan
+         td
+
+         # to days
+         td / np.timedelta64(1,'D')
+
+         # to seconds
+         td / np.timedelta64(1,'s')
+
+    - Dividing or multiplying a ``timedelta64[ns]`` Series by an integer or integer Series
+
+      .. ipython:: python
+
+         td * -1
+         td * Series([1,2,3,4])
+
+    - Absolute ``DateOffset`` objects can act equivalenty to ``timedeltas``
+
+      .. ipython:: python
+
+         from pandas import offsets
+         td + offsets.Minute(5) + offsets.Milli(5)
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1999,6 +1999,51 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
                 [Timestamp('20130101 9:01:00.005'), Timestamp('20130101 9:02:00.005')])
             assert_series_equal(result, expected)
 
+        # GH 4521
+        # divide/multiply by integers
+        startdate = Series(date_range('2013-01-01', '2013-01-03'))
+        enddate = Series(date_range('2013-03-01', '2013-03-03'))
+
+        s1 = enddate - startdate
+        s1[2] = np.nan
+        s2 = Series([2, 3, 4])
+        expected = Series(s1.values.astype(np.int64) / s2, dtype='m8[ns]')
+        expected[2] = np.nan
+        result = s1 / s2
+        assert_series_equal(result,expected)
+
+        s2 = Series([20, 30, 40])
+        expected = Series(s1.values.astype(np.int64) / s2, dtype='m8[ns]')
+        expected[2] = np.nan
+        result = s1 / s2
+        assert_series_equal(result,expected)
+
+        result = s1 / 2
+        expected = Series(s1.values.astype(np.int64) / 2, dtype='m8[ns]')
+        expected[2] = np.nan
+        assert_series_equal(result,expected)
+
+        s2 = Series([20, 30, 40])
+        expected = Series(s1.values.astype(np.int64) * s2, dtype='m8[ns]')
+        expected[2] = np.nan
+        result = s1 * s2
+        assert_series_equal(result,expected)
+
+        result = s1 * 2
+        expected = Series(s1.values.astype(np.int64) * 2, dtype='m8[ns]')
+        expected[2] = np.nan
+        assert_series_equal(result,expected)
+
+        self.assertRaises(TypeError, s1.__div__, s2.astype(float))
+        self.assertRaises(TypeError, s1.__mul__, s2.astype(float))
+        self.assertRaises(TypeError, s1.__div__, 2.)
+        self.assertRaises(TypeError, s1.__mul__, 2.)
+
+        self.assertRaises(TypeError, s1.__add__, 1)
+        self.assertRaises(TypeError, s1.__sub__, 1)
+        self.assertRaises(TypeError, s1.__add__, s2.values)
+        self.assertRaises(TypeError, s1.__sub__, s2.values)
+
     def test_timedelta64_equal_timedelta_supported_ops(self):
         ser = Series([Timestamp('20130301'), Timestamp('20130228 23:00:00'),
                       Timestamp('20130228 22:00:00'),

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1949,6 +1949,27 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         self.assert_(result.dtype=='m8[ns]')
         assert_series_equal(result,expected)
 
+        # GH 4532
+        # operate with pd.offsets
+        s = Series([Timestamp('20130101 9:01'),Timestamp('20130101 9:02')])
+
+        import pdb; pdb.set_trace()
+        result = s + pd.offsets.Second(5)
+        expected = Series([Timestamp('20130101 9:01:05'),Timestamp('20130101 9:02:05')])
+
+        result = s + pd.offsets.Milli(5)
+        expected = Series([Timestamp('20130101 9:01:00.005'),Timestamp('20130101 9:02:00.005')])
+        assert_series_equal(result,expected)
+
+        # operate with np.timedelta64 correctly
+        result = s + np.timedelta64(1,'s')
+        expected = Series([Timestamp('20130101 9:01:01'),Timestamp('20130101 9:02:01')])
+        assert_series_equal(result,expected)
+
+        result = s + np.timedelta64(5,'ms')
+        expected = Series([Timestamp('20130101 9:01:00.005'),Timestamp('20130101 9:02:00.005')])
+        assert_series_equal(result,expected)
+
     def test_operators_datetimelike(self):
 
         ### timedelta64 ###

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -6,7 +6,8 @@ from datetime import timedelta
 
 import numpy as np
 
-from pandas.core.common import isnull, _NS_DTYPE, _INT64_DTYPE
+from pandas.core.common import (isnull, _NS_DTYPE, _INT64_DTYPE,
+                                is_list_like,_possibly_cast_to_timedelta)
 from pandas.core.index import Index, Int64Index
 import pandas.compat as compat
 from pandas.compat import u
@@ -541,7 +542,7 @@ class DatetimeIndex(Int64Index):
         elif isinstance(other, (DateOffset, timedelta)):
             return self._add_delta(other)
         elif isinstance(other, np.timedelta64):
-            raise NotImplementedError
+            return self._add_delta(other)
         elif com.is_integer(other):
             return self.shift(other)
         else:  # pragma: no cover
@@ -553,7 +554,7 @@ class DatetimeIndex(Int64Index):
         elif isinstance(other, (DateOffset, timedelta)):
             return self._add_delta(-other)
         elif isinstance(other, np.timedelta64):
-            raise NotImplementedError
+            return self._add_delta(-other)
         elif com.is_integer(other):
             return self.shift(-other)
         else:  # pragma: no cover
@@ -568,6 +569,9 @@ class DatetimeIndex(Int64Index):
             utc = _utc()
             if self.tz is not None and self.tz is not utc:
                 result = result.tz_convert(self.tz)
+        elif isinstance(delta, np.timedelta64):
+            new_values = self.to_series() + delta
+            result = DatetimeIndex(new_values, tz=self.tz, freq='infer')
         else:
             new_values = self.astype('O') + delta
             result = DatetimeIndex(new_values, tz=self.tz, freq='infer')

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -2296,6 +2296,16 @@ class TestLegacySupport(unittest.TestCase):
         expected = index + timedelta(-1)
         self.assert_(result.equals(expected))
 
+        # GH4134, buggy with timedeltas
+        rng = date_range('2013', '2014')
+        s = Series(rng)
+        result1 = rng - pd.offsets.Hour(1)
+        result2 = DatetimeIndex(s - np.timedelta64(100000000))
+        result3 = rng - np.timedelta64(100000000)
+        result4 = DatetimeIndex(s - pd.offsets.Hour(1))
+        self.assert_(result1.equals(result4))
+        self.assert_(result2.equals(result3))
+
     def test_shift(self):
         ts = Series(np.random.randn(5),
                     index=date_range('1/1/2000', periods=5, freq='H'))

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -45,6 +45,8 @@ PyDateTime_IMPORT
 
 cdef int64_t NPY_NAT = util.get_nat()
 
+# < numpy 1.7 compat for NaT
+compat_NaT = np.array([NPY_NAT]).astype('m8[ns]').item()
 
 try:
     basestring


### PR DESCRIPTION
closes #4532
closes #4134
closes #4135 
closes #4521

Timedeltas can be converted to other ‘frequencies’ by dividing by another timedelta.

```
In [210]: td = Series(date_range('20130101',periods=4))-Series(date_range('20121201',periods=4))

In [211]: td[2] += np.timedelta64(timedelta(minutes=5,seconds=3))

In [212]: td[3] = np.nan

In [213]: td

0   31 days, 00:00:00
1   31 days, 00:00:00
2   31 days, 00:05:03
3                 NaT
dtype: timedelta64[ns]
```

to days

```
In [214]: td / np.timedelta64(1,'D')

0    31.000000
1    31.000000
2    31.003507
3          NaN
dtype: float64
```

to seconds

```
In [215]: td / np.timedelta64(1,'s')

0    2678400
1    2678400
2    2678703
3        NaN
dtype: float64
```

Dividing or multiplying a timedelta64[ns] Series by an integer or integer Series yields a float64 dtyped Series.

```
In [216]: td * -1

0   -31 days, 00:00:00
1   -31 days, 00:00:00
2   -31 days, 00:05:03
3                  NaT
dtype: timedelta64[ns]

In [217]: td * Series([1,2,3,4])

0   31 days, 00:00:00
1   62 days, 00:00:00
2   93 days, 00:15:09
3                 NaT
dtype: timedelta64[ns]
```
