### PR TITLE
ENH/API: Keep original traceback in DataFrame.apply

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -262,6 +262,8 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
     if code argument out of range (:issue:`4519`, :issue:`4520`)
   - Fix reindexing with multiple axes; if an axes match was not replacing the current axes, leading
     to a possible lazay frequency inference issue (:issue:`3317`)
+  - Fixed issue where ``DataFrame.apply`` was reraising exceptions incorrectly
+    (causing the original stack trace to be truncated).
 
 pandas 0.12
 ===========

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3632,7 +3632,7 @@ class DataFrame(NDFrame):
                 except (NameError, UnboundLocalError):  # pragma: no cover
                     # no k defined yet
                     pass
-                raise e
+                raise
 
         if len(results) > 0 and _is_sequence(results[0]):
             if not isinstance(results[0], Series):


### PR DESCRIPTION
When "raise <exception instance>" is used inside a try/except block, the
original stacktrace (containing the code path that raised the original
exception).  This makes debugging difficult since all we know is that an error
occured when `frame._apply_standard` attempted to call the provided function.
Preserve the original stacktrace by using "raise" instead of "raise <exception
instance>".  This facilitates debugginb by allowing us to see where (in the
provided callable) the exception occured.
