### PR TITLE
BUG: Fix incorrect urlparse in _is_s3_url

### DIFF
--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -61,7 +61,7 @@ def _is_url(url):
 def _is_s3_url(url):
     """Check for an s3 url"""
     try:
-        return urlparse.urlparse(url).scheme == 's3'
+        return parse_url(url).scheme == 's3'
     except:
         return False
 

--- a/pandas/io/tests/test_data.py
+++ b/pandas/io/tests/test_data.py
@@ -332,6 +332,10 @@ class TestOptionsWarnings(unittest.TestCase):
 
 
 class TestDataReader(unittest.TestCase):
+    def test_is_s3_url(self):
+        from pandas.io.common import _is_s3_url
+        self.assert_(_is_s3_url("s3://pandas/somethingelse.com"))
+
     @network
     def test_read_yahoo(self):
         gs = DataReader("GS", "yahoo")


### PR DESCRIPTION
Guess this got reverted/messed up during rebasing, but needs to be
changed - urlparse is no longer imported in io/common (in favor of py2/3
compatible methods).

I added a dumb test case so it at least gets called going forward.
