### PR TITLE
BUG: DatetimeIndex uses the wrong union if the operands overlap

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -462,6 +462,7 @@ Bug Fixes
   - Fixed ``copy()`` to shallow copy axes/indices as well and thereby keep
     separate metadata. (:issue:`4202`, :issue:`4830`)
   - Fixed skiprows option in Python parser for read_csv (:issue:`4382`)
+  - Fixed wrong check for overlapping in ``DatetimeIndex.union`` (:issue:`4564`)
 
 pandas 0.12.0
 -------------

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -986,11 +986,11 @@ class DatetimeIndex(Int64Index):
         else:
             left, right = other, self
 
-        left_end = left[-1]
         right_start = right[0]
+        left_end = left[-1]
 
         # Only need to "adjoin", not overlap
-        return (left_end + offset) >= right_start
+        return (right_start == left_end + offset) or right_start in left
 
     def _fast_union(self, other):
         if len(other) == 0:

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1859,6 +1859,15 @@ class TestDatetimeIndex(unittest.TestCase):
         exp = DatetimeIndex(sorted(set(list(left)) | set(list(right))))
         self.assert_(result.equals(exp))
 
+    def test_union_bug_4564(self):
+        from pandas import DateOffset
+        left = date_range("2013-01-01", "2013-02-01")
+        right = left + DateOffset(minutes=15)
+
+        result = left.union(right)
+        exp = DatetimeIndex(sorted(set(list(left)) | set(list(right))))
+        self.assert_(result.equals(exp))
+
     def test_intersection_bug_1708(self):
         from pandas import DateOffset
         index_1 = date_range('1/1/2012', periods=4, freq='12H')


### PR DESCRIPTION
This pretty much boils down to this line: https://github.com/pydata/pandas/blob/master/pandas/tseries/index.py#L987

You can easily reproduce the error using the following code:

```
r = pd.date_range("2013-01-01", "2013-02-01")
r2 = r + pd.DateOffset(minutes=15)
r | r2 # Results in the index r having "2013-01-31 00:15" appended
```

This happens because the check on the given line does not take into account, that two indices with the same offset do not necessarily have to be aligned. If they are the `_fast_union`-method can be used, if not it should fall back to the `Index` implementation.
