### PR TITLE
BUG: Fix boolean comparison with a DataFrame on the lhs, and a list/tuple on the rhs GH4576

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -283,6 +283,7 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
     in csv_import (:issue:`4322`)
   - Fix an issue with CacheableOffset not properly being used by many DateOffset; this prevented
     the DateOffset from being cached (:issue:`4609`)
+  - Fix boolean comparison with a DataFrame on the lhs, and a list/tuple on the rhs (:issue:`4576`)
 
 pandas 0.12
 ===========

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4709,6 +4709,75 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
         self.assertRaises(TypeError, df.__eq__, None)
 
+    def test_boolean_comparison(self):
+
+        # GH 4576
+        # boolean comparisons with a tuple/list give unexpected results
+        df = DataFrame(np.arange(6).reshape((3,2)))
+        b = np.array([2, 2])
+        b_r = np.atleast_2d([2,2])
+        b_c = b_r.T
+        l = (2,2,2)
+        tup = tuple(l)
+
+        # gt
+        expected = DataFrame([[False,False],[False,True],[True,True]])
+        result = df>b
+        assert_frame_equal(result,expected)
+
+        result = df.values>b
+        assert_array_equal(result,expected.values)
+
+        result = df>l
+        assert_frame_equal(result,expected)
+
+        result = df>tup
+        assert_frame_equal(result,expected)
+
+        result = df>b_r
+        assert_frame_equal(result,expected)
+
+        result = df.values>b_r
+        assert_array_equal(result,expected.values)
+
+        self.assertRaises(ValueError, df.__gt__, b_c)
+        self.assertRaises(ValueError, df.values.__gt__, b_c)
+
+        # ==
+        expected = DataFrame([[False,False],[True,False],[False,False]])
+        result = df == b
+        assert_frame_equal(result,expected)
+
+        result = df==l
+        assert_frame_equal(result,expected)
+
+        result = df==tup
+        assert_frame_equal(result,expected)
+
+        result = df == b_r
+        assert_frame_equal(result,expected)
+
+        result = df.values == b_r
+        assert_array_equal(result,expected.values)
+
+        self.assertRaises(ValueError, lambda : df == b_c)
+        self.assert_((df.values == b_c) is False)
+
+        # with alignment
+        df = DataFrame(np.arange(6).reshape((3,2)),columns=list('AB'),index=list('abc'))
+        expected.index=df.index
+        expected.columns=df.columns
+
+        result = df==l
+        assert_frame_equal(result,expected)
+
+        result = df==tup
+        assert_frame_equal(result,expected)
+
+        # not shape compatible
+        self.assertRaises(ValueError, lambda : df == (2,2))
+        self.assertRaises(ValueError, lambda : df == [2,2])
+
     def test_to_csv_deprecated_options(self):
 
         pname = '__tmp_to_csv_deprecated_options__'


### PR DESCRIPTION
closes #4576

```
In [1]: df = DataFrame(np.arange(6).reshape((3,2)))

In [2]:  b = np.array([2, 2])

In [3]:  b_r = np.atleast_2d([2,2])

In [4]:  b_c = b_r.T

In [5]: df>b
Out[5]: 
       0      1
0  False  False
1  False   True
2   True   True

In [6]: df.values>b
Out[6]: 
array([[False, False],
       [False,  True],
       [ True,  True]], dtype=bool)

In [7]: df>b_r
Out[7]: 
       0      1
0  False  False
1  False   True
2   True   True

In [8]: df.values>b_r
Out[8]: 
array([[False, False],
       [False,  True],
       [ True,  True]], dtype=bool)

In [9]: df>b_c
ValueError: cannot broadcast shape [(3, 2)] with block values [(2, 1)]

In [10]: df.values>b_c
ValueError: operands could not be broadcast together with shapes (3,2) (2,1) 

In [11]: df == b
Out[11]: 
       0      1
0  False  False
1   True  False
2  False  False

In [12]: df.values == b
Out[12]: 
array([[False, False],
       [ True, False],
       [False, False]], dtype=bool)

In [13]: df==b_r
Out[13]: 
       0      1
0  False  False
1   True  False
2  False  False

In [14]: df.values==b_r
Out[14]: 
array([[False, False],
       [ True, False],
       [False, False]], dtype=bool)
```

Numpy does weird things like this (bottom example), but we will raise
I believe it is actually a NotImplemented Type which is interpreted as False (but still very weird)

```
In [15]: df==b_c
ValueError: cannot broadcast shape [(3, 2)] with block values [(2, 1)]

In [16]: df.values==b_c
Out[16]: False
```

with list/tuple

```
In [2]: df>(2,2)
ValueError: operands could not be broadcast together with shapes (2,3) (2) 

In [3]: df>(2,2,2)
Out[3]: 
       0      1
0  False  False
1  False   True
2   True   True

In [4]: df>[2,2,2]
Out[4]: 
       0      1
0  False  False
1  False   True
2   True   True

In [5]: df==[2,2,2]
Out[5]: 
       0      1
0  False  False
1   True  False
2  False  False
```

This will work with a frame with non integer labels too

```
In [6]: df = DataFrame(np.arange(6).reshape((3,2)),columns=list('AB'),index=list('abc'))

In [7]: df==[2,2,2]
Out[7]: 
       A      B
a  False  False
b   True  False
c  False  False
```
