### PR TITLE
TST: fix ujson's intermittently failing date unit test

### DIFF
--- a/pandas/io/tests/test_json/test_ujson.py
+++ b/pandas/io/tests/test_json/test_ujson.py
@@ -356,20 +356,19 @@ class UltraJSONTests(TestCase):
         assert ujson.encode(input) == 'null', "Expected null"
 
     def test_datetime_units(self):
-        raise nose.SkipTest("skipping for now, test is buggy, pls fix me")
         from pandas.lib import Timestamp
 
-        val = datetime.datetime.now()
+        val = datetime.datetime(2013, 8, 17, 21, 17, 12, 215504)
         stamp = Timestamp(val)
 
         roundtrip = ujson.decode(ujson.encode(val, date_unit='s'))
-        self.assert_(roundtrip == stamp.value // 1e9)
+        self.assert_(roundtrip == stamp.value // 10**9)
 
         roundtrip = ujson.decode(ujson.encode(val, date_unit='ms'))
-        self.assert_(roundtrip == stamp.value // 1e6)
+        self.assert_(roundtrip == stamp.value // 10**6)
 
         roundtrip = ujson.decode(ujson.encode(val, date_unit='us'))
-        self.assert_(roundtrip == stamp.value / 1e3)
+        self.assert_(roundtrip == stamp.value // 10**3)
 
         roundtrip = ujson.decode(ujson.encode(val, date_unit='ns'))
         self.assert_(roundtrip == stamp.value)


### PR DESCRIPTION
Fixes #4575.

As you surmised @jreback it looks like unnecessary float arithmetic was causing the test failure. I fixed this up and in the interest of consistency removed the dependence on `datetime.now()`

Example

``` python
In [8]: val = 1376774232215504000

In [9]: val / 1000
Out[9]: 1376774232215504

In [10]: val / 1e3
Out[10]: 1376774232215503.8

In [11]: val // 1e3
Out[11]: 1376774232215503.0

In [12]: val / 1000.0
Out[12]: 1376774232215503.8

In [13]: val / 10**3
Out[13]: 1376774232215504
```
