### PR TITLE
BUG: ujson labels are encoded twice

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -212,6 +212,7 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
   - In ``to_json``, fix date handling so milliseconds are the default timestamp
     as the docstring says (:issue:`4362`). 
   - JSON NaT handling fixed, NaTs are now serialised to `null` (:issue:`4498`)
+  - Fixed JSON handling of escapable characters in JSON object keys (:issue:`4593`)
   - Fixed passing ``keep_default_na=False`` when ``na_values=None`` (:issue:`4318`)
   - Fixed bug with ``values`` raising an error on a DataFrame with duplicate columns and mixed
     dtypes, surfaced in (:issue:`4377`)

--- a/pandas/io/tests/test_json/test_pandas.py
+++ b/pandas/io/tests/test_json/test_pandas.py
@@ -14,7 +14,7 @@ read_json = pd.read_json
 
 from pandas.util.testing import (assert_almost_equal, assert_frame_equal,
                                  assert_series_equal, network,
-                                 ensure_clean)
+                                 ensure_clean, assert_index_equal)
 import pandas.util.testing as tm
 from numpy.testing.decorators import slow
 
@@ -52,6 +52,21 @@ class TestPandasContainer(unittest.TestCase):
         self.intframe = _intframe.copy()
         self.tsframe = _tsframe.copy()
         self.mixed_frame = _mixed_frame.copy()
+
+    def test_frame_double_encoded_labels(self):
+        df = DataFrame([['a', 'b'], ['c', 'd']],
+                       index=['index " 1', 'index / 2'],
+                       columns=['a \\ b', 'y / z'])
+
+        assert_frame_equal(
+            df, read_json(df.to_json(orient='split'), orient='split'))
+        assert_frame_equal(
+            df, read_json(df.to_json(orient='columns'), orient='columns'))
+        assert_frame_equal(
+            df, read_json(df.to_json(orient='index'), orient='index'))
+        df_unser = read_json(df.to_json(orient='records'), orient='records')
+        assert_index_equal(df.columns, df_unser.columns)
+        np.testing.assert_equal(df.values, df_unser.values)
 
     def test_frame_non_unique_index(self):
         df = DataFrame([['a', 'b'], ['c', 'd']], index=[1, 1],


### PR DESCRIPTION
With its current handling ujson ends up encoding labels twice, which can cause problems if they contain escapable characters:

``` python
In [16]: df = DataFrame([['a', 'b'], ['c', 'd']], index=['index " 1', 'index / 2'], columns=['a \\ b', 'y / z'])

In [17]: df
Out[17]: 
          a \ b y / z
index " 1     a     b
index / 2     c     d

In [18]: json = df.to_json()

In [19]: json
Out[19]: '{"a \\\\\\\\ b":{"index \\\\\\" 1":"a","index \\\\\\/ 2":"c"},"y \\\\\\/ z":{"index \\\\\\" 1":"b","index \\\\\\/ 2":"d"}}'

In [20]: pd.read_json(json)
Out[20]: 
           a \\ b y \/ z
index \" 1      a      b
index \/ 2      c      d
```

This PR fixes this behaviour so labels are only encoded a single time.
