### PR TITLE
CLN: refactor Series.reindex to core/generic

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -115,6 +115,8 @@ pandas 0.13
     - ``MultiIndex.astype()`` now only allows ``np.object_``-like dtypes and
       now returns a ``MultiIndex`` rather than an ``Index``. (:issue:`4039`)
 
+  - Infer and downcast dtype if ``downcast='infer'`` is passed to ``fillna/ffill/bfill`` (:issue:`4604`)
+
 **Internal Refactoring**
 
 In 0.13.0 there is a major refactor primarily to subclass ``Series`` from ``NDFrame``,
@@ -183,10 +185,8 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
 
 - Indexing with dtype conversions fixed (:issue:`4463`, :issue:`4204`)
 
-- Refactor Series.reindex to core/generic.py (:issue:`4604`), allow ``method=`` in reindexing
+- Refactor Series.reindex to core/generic.py (:issue:`4604`, :issue:`4618`), allow ``method=`` in reindexing
   on a Series to work
-
-- Infer and downcast dtype if appropriate on ``ffill/bfill`` (:issue:`4604`)
 
 **Experimental Features**
 
@@ -259,6 +259,8 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
   - Fix bug in ``pd.read_clipboard`` on windows with PY3 (:issue:`4561`); not decoding properly
   - ``tslib.get_period_field()`` and ``tslib.get_period_field_arr()`` now raise
     if code argument out of range (:issue:`4519`, :issue:`4520`)
+  - Fix reindexing with multiple axes; if an axes match was not replacing the current axes, leading
+    to a possible lazay frequency inference issue (:issue:`3317`)
 
 pandas 0.12
 ===========

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -144,8 +144,6 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
   - support attribute access for setting
   - filter supports same api as original ``DataFrame`` filter
 
-- Reindex called with no arguments will now return a copy of the input object
-
 - Series now inherits from ``NDFrame`` rather than directly from ``ndarray``.
   There are several minor changes that affect the API.
 
@@ -185,6 +183,11 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
 
 - Indexing with dtype conversions fixed (:issue:`4463`, :issue:`4204`)
 
+- Refactor Series.reindex to core/generic.py (:issue:`4604`), allow ``method=`` in reindexing
+  on a Series to work
+
+- Infer and downcast dtype if appropriate on ``ffill/bfill`` (:issue:`4604`)
+
 **Experimental Features**
 
 **Bug Fixes**
@@ -210,7 +213,7 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
   - In ``to_json``, raise if a passed ``orient`` would cause loss of data because
     of a duplicate index (:issue:`4359`)
   - In ``to_json``, fix date handling so milliseconds are the default timestamp
-    as the docstring says (:issue:`4362`). 
+    as the docstring says (:issue:`4362`).
   - JSON NaT handling fixed, NaTs are now serialised to `null` (:issue:`4498`)
   - Fixed passing ``keep_default_na=False`` when ``na_values=None`` (:issue:`4318`)
   - Fixed bug with ``values`` raising an error on a DataFrame with duplicate columns and mixed

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -237,6 +237,11 @@ and behaviors. Series formerly subclassed directly from ``ndarray``. (:issue:`40
 
 - Indexing with dtype conversions fixed (:issue:`4463`, :issue:`4204`)
 
+- Refactor Series.reindex to core/generic.py (:issue:`4604`), allow ``method=`` in reindexing
+  on a Series to work
+
+- Infer and downcast dtype if appropriate on ``ffill/bfill`` (:issue:`4604`)
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -96,6 +96,8 @@ API changes
         # and all methods take an inplace kwarg
         index.set_names(["bob", "cranberry"], inplace=True)
 
+  - Infer and downcast dtype if ``downcast='infer'`` is passed to ``fillna/ffill/bfill`` (:issue:`4604`)
+
 Enhancements
 ~~~~~~~~~~~~
 
@@ -237,10 +239,8 @@ and behaviors. Series formerly subclassed directly from ``ndarray``. (:issue:`40
 
 - Indexing with dtype conversions fixed (:issue:`4463`, :issue:`4204`)
 
-- Refactor Series.reindex to core/generic.py (:issue:`4604`), allow ``method=`` in reindexing
+- Refactor Series.reindex to core/generic.py (:issue:`4604`, :issue:`4618`), allow ``method=`` in reindexing
   on a Series to work
-
-- Infer and downcast dtype if appropriate on ``ffill/bfill`` (:issue:`4604`)
 
 Bug Fixes
 ~~~~~~~~~

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -961,16 +961,43 @@ def _possibly_downcast_to_dtype(result, dtype):
     """ try to cast to the specified dtype (e.g. convert back to bool/int
         or could be an astype of float64->float32 """
 
-    if np.isscalar(result):
+    if np.isscalar(result) or not len(result):
         return result
+
+    if isinstance(dtype, compat.string_types):
+        if dtype == 'infer':
+            inferred_type = lib.infer_dtype(_ensure_object(result.ravel()))
+            if inferred_type == 'boolean':
+                dtype = 'bool'
+            elif inferred_type == 'integer':
+                dtype = 'int64'
+            elif inferred_type == 'datetime64':
+                dtype = 'datetime64[ns]'
+            elif inferred_type == 'timedelta64':
+                dtype = 'timedelta64[ns]'
+
+            # try to upcast here
+            elif inferred_type == 'floating':
+                dtype = 'int64'
+
+            else:
+                dtype = 'object'
+
+    if isinstance(dtype, compat.string_types):
+        dtype = np.dtype(dtype)
 
     try:
         if issubclass(dtype.type, np.floating):
             return result.astype(dtype)
         elif dtype == np.bool_ or issubclass(dtype.type, np.integer):
-            if issubclass(result.dtype.type, np.number) and notnull(result).all():
+            if issubclass(result.dtype.type, (np.object_,np.number)) and notnull(result).all():
                 new_result = result.astype(dtype)
                 if (new_result == result).all():
+
+                    # a comparable, e.g. a Decimal may slip in here
+                    if not isinstance(result.ravel()[0], (np.integer,np.floating,np.bool,int,float,bool)):
+                        return result
+
                     return new_result
     except:
         pass
@@ -1052,6 +1079,9 @@ def pad_1d(values, limit=None, mask=None):
         _method = getattr(algos, 'pad_inplace_%s' % dtype, None)
     elif is_datetime64_dtype(values):
         _method = _pad_1d_datetime
+    elif is_integer_dtype(values):
+        values = _ensure_float64(values)
+        _method = algos.pad_inplace_float64
     elif values.dtype == np.object_:
         _method = algos.pad_inplace_object
 
@@ -1062,7 +1092,7 @@ def pad_1d(values, limit=None, mask=None):
         mask = isnull(values)
     mask = mask.view(np.uint8)
     _method(values, mask, limit=limit)
-
+    return values
 
 def backfill_1d(values, limit=None, mask=None):
 
@@ -1072,6 +1102,9 @@ def backfill_1d(values, limit=None, mask=None):
         _method = getattr(algos, 'backfill_inplace_%s' % dtype, None)
     elif is_datetime64_dtype(values):
         _method = _backfill_1d_datetime
+    elif is_integer_dtype(values):
+        values = _ensure_float64(values)
+        _method = algos.backfill_inplace_float64
     elif values.dtype == np.object_:
         _method = algos.backfill_inplace_object
 
@@ -1083,7 +1116,7 @@ def backfill_1d(values, limit=None, mask=None):
     mask = mask.view(np.uint8)
 
     _method(values, mask, limit=limit)
-
+    return values
 
 def pad_2d(values, limit=None, mask=None):
 
@@ -1093,6 +1126,9 @@ def pad_2d(values, limit=None, mask=None):
         _method = getattr(algos, 'pad_2d_inplace_%s' % dtype, None)
     elif is_datetime64_dtype(values):
         _method = _pad_2d_datetime
+    elif is_integer_dtype(values):
+        values = _ensure_float64(values)
+        _method = algos.pad_2d_inplace_float64
     elif values.dtype == np.object_:
         _method = algos.pad_2d_inplace_object
 
@@ -1108,7 +1144,7 @@ def pad_2d(values, limit=None, mask=None):
     else:
         # for test coverage
         pass
-
+    return values
 
 def backfill_2d(values, limit=None, mask=None):
 
@@ -1118,6 +1154,9 @@ def backfill_2d(values, limit=None, mask=None):
         _method = getattr(algos, 'backfill_2d_inplace_%s' % dtype, None)
     elif is_datetime64_dtype(values):
         _method = _backfill_2d_datetime
+    elif is_integer_dtype(values):
+        values = _ensure_float64(values)
+        _method = algos.backfill_2d_inplace_float64
     elif values.dtype == np.object_:
         _method = algos.backfill_2d_inplace_object
 
@@ -1133,7 +1172,7 @@ def backfill_2d(values, limit=None, mask=None):
     else:
         # for test coverage
         pass
-
+    return values
 
 def interpolate_2d(values, method='pad', axis=0, limit=None, missing=None):
     """ perform an actual interpolation of values, values will be make 2-d if needed
@@ -1153,10 +1192,11 @@ def interpolate_2d(values, method='pad', axis=0, limit=None, missing=None):
     else:  # todo create faster fill func without masking
         mask = mask_missing(transf(values), missing)
 
+    method = _clean_fill_method(method)
     if method == 'pad':
-        pad_2d(transf(values), limit=limit, mask=mask)
+        values = transf(pad_2d(transf(values), limit=limit, mask=mask))
     else:
-        backfill_2d(transf(values), limit=limit, mask=mask)
+        values = transf(backfill_2d(transf(values), limit=limit, mask=mask))
 
     # reshape back
     if ndim == 1:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2280,12 +2280,9 @@ class DataFrame(NDFrame):
                                            fill_value=fill_value)
             return self._constructor(new_values, index=new_index,
                                      columns=new_columns)
-        elif row_indexer is not None:
-            return self._reindex_with_indexers({0: [new_index,   row_indexer]}, copy=copy, fill_value=fill_value)
-        elif col_indexer is not None:
-            return self._reindex_with_indexers({1: [new_columns, col_indexer]}, copy=copy, fill_value=fill_value)
         else:
-            return self.copy() if copy else self
+            return self._reindex_with_indexers({0: [new_index,   row_indexer],
+                                                1: [new_columns, col_indexer]}, copy=copy, fill_value=fill_value)
 
     def reindex_like(self, other, method=None, copy=True, limit=None,
                      fill_value=NA):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1003,11 +1003,15 @@ class NDFrame(PandasObject):
             except:
                 pass
 
-        # perform the reindex on the axes
-        if copy and not com._count_not_none(*axes.values()):
-            return self.copy()
+        # if all axes that are requested to reindex are equal, then only copy if indicated
+        # must have index names equal here as well as values
+        if all([ self._get_axis(axis).identical(ax) for axis, ax in axes.items() if ax is not None ]):
+            if copy:
+                return self.copy()
+            return self
 
-        return self._reindex_axes(axes, level, limit, method, fill_value, copy, takeable=takeable)
+        # perform the reindex on the axes
+        return self._reindex_axes(axes, level, limit, method, fill_value, copy, takeable=takeable)._propogate_attributes(self)
 
     def _reindex_axes(self, axes, level, limit, method, fill_value, copy, takeable=False):
         """ perform the reinxed for all the axes """
@@ -1025,7 +1029,8 @@ class NDFrame(PandasObject):
             new_index, indexer = self._get_axis(a).reindex(
                 labels, level=level, limit=limit, takeable=takeable)
             obj = obj._reindex_with_indexers(
-                {axis: [labels, indexer]}, method, fill_value, copy)
+                {axis: [new_index, indexer]}, method=method, fill_value=fill_value,
+                limit=limit, copy=copy)
 
         return obj
 
@@ -1079,9 +1084,10 @@ class NDFrame(PandasObject):
         axis_values = self._get_axis(axis_name)
         new_index, indexer = axis_values.reindex(labels, method, level,
                                                  limit=limit, copy_if_needed=True)
-        return self._reindex_with_indexers({axis: [new_index, indexer]}, method, fill_value, copy)
+        return self._reindex_with_indexers({axis: [new_index, indexer]}, method=method, fill_value=fill_value,
+                                           limit=limit, copy=copy)._propogate_attributes(self)
 
-    def _reindex_with_indexers(self, reindexers, method=None, fill_value=np.nan, copy=False):
+    def _reindex_with_indexers(self, reindexers, method=None, fill_value=np.nan, limit=None, copy=False):
 
         # reindex doing multiple operations on different axes if indiciated
         new_data = self._data
@@ -1089,11 +1095,15 @@ class NDFrame(PandasObject):
             index, indexer = reindexers[axis]
             baxis = self._get_block_manager_axis(axis)
 
+            if index is None:
+                continue
+            index = _ensure_index(index)
+
             # reindex the axis
             if method is not None:
                 new_data = new_data.reindex_axis(
                     index, method=method, axis=baxis,
-                    fill_value=fill_value, copy=copy)
+                    fill_value=fill_value, limit=limit, copy=copy)
 
             elif indexer is not None:
                 # TODO: speed up on homogeneous DataFrame objects
@@ -1435,14 +1445,20 @@ class NDFrame(PandasObject):
             if self._is_mixed_type and axis == 1:
                 if inplace:
                     raise NotImplementedError()
-                return self.T.fillna(method=method, limit=limit).T
+                result = self.T.fillna(method=method, limit=limit).T
+
+                # need to downcast here because of all of the transposes
+                result._data = result._data.downcast()
+
+                return result
 
             method = com._clean_fill_method(method)
             new_data = self._data.interpolate(method=method,
                                               axis=axis,
                                               limit=limit,
                                               inplace=inplace,
-                                              coerce=True)
+                                              coerce=True,
+                                              downcast=downcast)
         else:
             if method is not None:
                 raise ValueError('cannot specify both a fill method and value')
@@ -1474,11 +1490,11 @@ class NDFrame(PandasObject):
 
     def ffill(self, axis=0, inplace=False, limit=None):
         return self.fillna(method='ffill', axis=axis, inplace=inplace,
-                           limit=limit)
+                           limit=limit, downcast='infer')
 
     def bfill(self, axis=0, inplace=False, limit=None):
         return self.fillna(method='bfill', axis=axis, inplace=inplace,
-                           limit=limit)
+                           limit=limit, downcast='infer')
 
     def replace(self, to_replace=None, value=None, inplace=False, limit=None,
                 regex=False, method=None, axis=None):

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -551,7 +551,7 @@ class Index(FrozenNDArray):
         Similar to equals, but check that other comparable attributes are also equal
         """
         return self.equals(other) and all(
-            [ getattr(self,c,None) == getattr(other,c,None) for c in self._comparables ])
+            ( getattr(self,c,None) == getattr(other,c,None) for c in self._comparables ))
 
     def asof(self, label):
         """
@@ -1555,6 +1555,7 @@ class MultiIndex(Index):
     _names = FrozenList()
     _levels = FrozenList()
     _labels = FrozenList()
+    _comparables = ['names']
 
     def __new__(cls, levels=None, labels=None, sortorder=None, names=None,
                 copy=False):

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -83,6 +83,7 @@ class Index(FrozenNDArray):
 
     name = None
     asi8 = None
+    _comparables = ['name']
 
     _engine_type = _index.ObjectEngine
 
@@ -544,6 +545,13 @@ class Index(FrozenNDArray):
             return other.equals(self)
 
         return np.array_equal(self, other)
+
+    def identical(self, other):
+        """
+        Similar to equals, but check that other comparable attributes are also equal
+        """
+        return self.equals(other) and all(
+            [ getattr(self,c,None) == getattr(other,c,None) for c in self._comparables ])
 
     def asof(self, label):
         """

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -774,7 +774,7 @@ c,4,5
 """
         rs = self.read_csv(
             StringIO(data), index_col='date', parse_dates='date')
-        idx = date_range('1/1/2009', periods=3).asobject
+        idx = date_range('1/1/2009', periods=3)
         idx.name = 'date'
         xp = DataFrame({'A': ['a', 'b', 'c'],
                         'B': [1, 3, 4],

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -471,7 +471,6 @@ class SparseDataFrame(DataFrame):
 
         for col, series in compat.iteritems(this):
             new_data[col] = func(series.values, other.values)
-            #new_data[col] = func(series.as_sparse_array(fill_value=np.nan), other.as_sparse_array(fill_value=np.nan))
 
         # fill_value is a function of our operator
         if isnull(other.fill_value) or isnull(self.default_fill_value):
@@ -576,8 +575,8 @@ class SparseDataFrame(DataFrame):
 
     def _reindex_with_indexers(self, reindexers, method=None, fill_value=np.nan, limit=None, copy=False):
 
-        if limit is not None:
-            raise NotImplementedError("cannot take limit with a sparse tyep")
+        if method is not None or limit is not None:
+            raise NotImplementedError("cannot reindex with a method or limit with sparse")
 
         index,   row_indexer = reindexers.get(0, (None, None))
         columns, col_indexer = reindexers.get(1, (None, None))

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -471,6 +471,7 @@ class SparseDataFrame(DataFrame):
 
         for col, series in compat.iteritems(this):
             new_data[col] = func(series.values, other.values)
+            #new_data[col] = func(series.as_sparse_array(fill_value=np.nan), other.as_sparse_array(fill_value=np.nan))
 
         # fill_value is a function of our operator
         if isnull(other.fill_value) or isnull(self.default_fill_value):
@@ -573,7 +574,10 @@ class SparseDataFrame(DataFrame):
         return SparseDataFrame(sdict, index=self.index, columns=columns,
                                default_fill_value=self._default_fill_value)
 
-    def _reindex_with_indexers(self, reindexers, method=None, copy=False, fill_value=np.nan):
+    def _reindex_with_indexers(self, reindexers, method=None, fill_value=np.nan, limit=None, copy=False):
+
+        if limit is not None:
+            raise NotImplementedError("cannot take limit with a sparse tyep")
 
         index,   row_indexer = reindexers.get(0, (None, None))
         columns, col_indexer = reindexers.get(1, (None, None))

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -565,19 +565,6 @@ class SparseSeries(Series):
                                  sparse_index=new_index,
                                  fill_value=self.fill_value)
 
-    def _reindex_indexer(self, new_index, indexer, copy):
-        if indexer is not None:
-            new_values = com.take_1d(self.values.values, indexer)
-        else:
-            if copy:
-                result = self.copy()
-            else:
-                result = self
-            return result
-
-        # be subclass-friendly
-        return self._constructor(new_values, new_index, name=self.name)
-
     def take(self, indices, axis=0, convert=True):
         """
         Sparse-compatible version of ndarray.take

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4218,8 +4218,17 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         expected = Series([np.nan, True])
         assert_series_equal(result, expected)
 
+        # GH4604, automatic casting here
         result = d['a'].fillna(False) | d['b']
-        expected = Series([True, True], dtype=object)
+        expected = Series([True, True])
+        assert_series_equal(result, expected)
+
+        result = d['a'].fillna(False,downcast=False) | d['b']
+        expected = Series([True, True],dtype=object)
+        assert_series_equal(result, expected)
+
+        result = (d['a'].fillna(False,downcast=False) | d['b']).convert_objects()
+        expected = Series([True, True])
         assert_series_equal(result, expected)
 
     def test_neg(self):
@@ -7410,6 +7419,20 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         # length zero
         newFrame = self.frame.reindex(columns=[])
         self.assert_(newFrame.empty)
+
+    def test_reindex_axes(self):
+
+        # GH 3317, reindexing by both axes loses freq of the index
+        from datetime import datetime
+        df = DataFrame(np.ones((3, 3)), index=[datetime(2012, 1, 1), datetime(2012, 1, 2), datetime(2012, 1, 3)], columns=['a', 'b', 'c'])
+        time_freq = date_range('2012-01-01', '2012-01-03', freq='d')
+        some_cols = ['a', 'b']
+
+        index_freq = df.reindex(index=time_freq).index.freq
+        both_freq = df.reindex(index=time_freq, columns=some_cols).index.freq
+        seq_freq = df.reindex(index=time_freq).reindex(columns=some_cols).index.freq
+        self.assert_(index_freq == both_freq)
+        self.assert_(index_freq == seq_freq)
 
     def test_reindex_fill_value(self):
         df = DataFrame(np.random.randn(10, 4))

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -151,6 +151,21 @@ class TestIndex(unittest.TestCase):
         # Must also be an Index
         self.assertFalse(Index(['a', 'b', 'c']).equals(['a', 'b', 'c']))
 
+    def test_identical(self):
+
+        # index
+        i1 = Index(['a', 'b', 'c'])
+        i2 = Index(['a', 'b', 'c'])
+
+        self.assert_(i1.identical(i2))
+
+        i1 = i1.rename('foo')
+        self.assert_(i1.equals(i2))
+        self.assert_(not i1.identical(i2))
+
+        i2 = i2.rename('foo')
+        self.assert_(i1.identical(i2))
+
     def test_asof(self):
         d = self.dateIndex[0]
         self.assert_(self.dateIndex.asof(d) is d)
@@ -659,6 +674,20 @@ class TestInt64Index(unittest.TestCase):
         same_values = Index(self.index, dtype=object)
         self.assert_(self.index.equals(same_values))
         self.assert_(same_values.equals(self.index))
+
+    def test_identical(self):
+
+        i = self.index.copy()
+        same_values = Index(i, dtype=object)
+        self.assert_(i.identical(same_values))
+
+        i = self.index.copy()
+        i = i.rename('foo')
+        same_values = Index(i, dtype=object)
+        self.assert_(same_values.identical(self.index))
+
+        self.assertFalse(i.identical(self.index))
+        self.assert_(Index(same_values, name='foo').identical(i))
 
     def test_get_indexer(self):
         target = Int64Index(np.arange(10))
@@ -1603,6 +1632,18 @@ class TestMultiIndex(unittest.TestCase):
         index = MultiIndex(levels=[major_axis, minor_axis],
                            labels=[major_labels, minor_labels])
         self.assert_(not self.index.equals(index))
+
+    def test_identical(self):
+        mi = self.index.copy()
+        mi2 = self.index.copy()
+        self.assert_(mi.identical(mi2))
+
+        mi = mi.set_names(['new1','new2'])
+        self.assert_(mi.equals(mi2))
+        self.assert_(not mi.identical(mi2))
+
+        mi2 = mi2.set_names(['new1','new2'])
+        self.assert_(mi.identical(mi2))
 
     def test_union(self):
         piece1 = self.index[:5][::-1]

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1051,7 +1051,7 @@ class TestPanel(unittest.TestCase, PanelTests, CheckIndexing,
         # don't necessarily copy
         result = self.panel.reindex(major=self.panel.major_axis, copy=False)
         assert_panel_equal(result,self.panel)
-        self.assert_((result is self.panel) == False)
+        self.assert_((result is self.panel) == True)
 
     def test_reindex_like(self):
         # reindex_like

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -786,7 +786,7 @@ class TestPanel4d(unittest.TestCase, CheckIndexing, SafeForSparse,
         result = self.panel4d.reindex(
             major=self.panel4d.major_axis, copy=False)
         assert_panel4d_equal(result,self.panel4d)
-        self.assert_((result is self.panel4d) == False)
+        self.assert_((result is self.panel4d) == True)
 
     def test_not_hashable(self):
         p4D_empty = Panel4D()

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -4074,6 +4074,9 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
 
         # this changes dtype because the ffill happens after
         result = s.reindex(new_index).ffill()
+        assert_series_equal(result, expected.astype('float64'))
+
+        result = s.reindex(new_index).ffill(downcast='infer')
         assert_series_equal(result, expected)
 
         # this preserves dtype
@@ -4085,6 +4088,12 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         new_index='agc'
         result = s.reindex(list(new_index)).ffill()
         expected = Series([True,True,False],index=list(new_index))
+        assert_series_equal(result, expected)
+
+        # GH4618 shifted series downcasting
+        s = Series(False,index=lrange(0,5))
+        result = s.shift(1).fillna(method='bfill')
+        expected = Series(False,index=lrange(0,5))
         assert_series_equal(result, expected)
 
     def test_reindex_backfill(self):

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -129,7 +129,7 @@ def pivot_table(data, values=None, rows=None, cols=None, aggfunc='mean',
             table = table.sort_index(axis=1)
 
     if fill_value is not None:
-        table = table.fillna(value=fill_value, downcast=True)
+        table = table.fillna(value=fill_value, downcast='infer')
 
     if margins:
         table = _add_margins(table, data, values, rows=rows,

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -316,6 +316,7 @@ class TestMerge(unittest.TestCase):
         df2['float'] = 1.
 
         for kind in JOIN_TYPES:
+
             joined = df1.join(df2, how=kind)
             expected = _join_by_hand(df1, df2, how=kind)
             assert_frame_equal(joined, expected)

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -155,6 +155,8 @@ class DatetimeIndex(Int64Index):
 
         freq_infer = False
         if not isinstance(freq, DateOffset):
+
+            # if a passed freq is None, don't infer automatically
             if freq != 'infer':
                 freq = to_offset(freq)
             else:

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -139,6 +139,7 @@ class DatetimeIndex(Int64Index):
     _engine_type = _index.DatetimeEngine
 
     offset = None
+    _comparables = ['name','freqstr','tz']
 
     def __new__(cls, data=None,
                 freq=None, start=None, end=None, periods=None,

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -61,6 +61,7 @@ class Period(PandasObject):
     second : int, default 0
     """
     __slots__ = ['freq', 'ordinal']
+    _comparables = ['name','freqstr']
 
     def __init__(self, value=None, freq=None, ordinal=None,
                  year=None, month=1, quarter=None, day=1,

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -316,6 +316,23 @@ class TestDateRange(unittest.TestCase):
     def test_equals(self):
         self.assertFalse(self.rng.equals(list(self.rng)))
 
+    def test_identical(self):
+        t1 = self.rng.copy()
+        t2 = self.rng.copy()
+        self.assert_(t1.identical(t2))
+
+        # name
+        t1 = t1.rename('foo')
+        self.assert_(t1.equals(t2))
+        self.assert_(not t1.identical(t2))
+        t2 = t2.rename('foo')
+        self.assert_(t1.identical(t2))
+
+        # freq
+        t2v = Index(t2.values)
+        self.assert_(t1.equals(t2v))
+        self.assert_(not t1.identical(t2v))
+
     def test_daterange_bug_456(self):
         # GH #456
         rng1 = bdate_range('12/5/2011', '12/5/2011')

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -566,19 +566,19 @@ class TestResample(unittest.TestCase):
     def test_how_lambda_functions(self):
 
         ts = _simple_ts('1/1/2000', '4/1/2000')
-                
+
         result = ts.resample('M', how=lambda x: x.mean())
         exp = ts.resample('M', how='mean')
         tm.assert_series_equal(result, exp)
-        
+
         self.assertRaises(Exception, ts.resample, 'M',
                           how=[lambda x: x.mean(), lambda x: x.std(ddof=1)])
-                
+
         result = ts.resample('M', how={'foo': lambda x: x.mean(),
                                        'bar': lambda x: x.std(ddof=1)})
         foo_exp = ts.resample('M', how='mean')
         bar_exp = ts.resample('M', how='std')
-        
+
         tm.assert_series_equal(result['foo'], foo_exp)
         tm.assert_series_equal(result['bar'], bar_exp)
 
@@ -771,7 +771,7 @@ class TestResamplePeriodIndex(unittest.TestCase):
                                   ts.index[-1].asfreq('D', 'end'),
                                   freq='Q-%s' % month)
 
-            expected = stamps.reindex(qdates.to_timestamp('D', 'e'),
+            expected = stamps.reindex(qdates.to_timestamp('D', 's'),
                                       method='ffill')
             expected.index = qdates
 

--- a/vb_suite/reindex.py
+++ b/vb_suite/reindex.py
@@ -51,7 +51,7 @@ reindex_multi = Benchmark(statement, setup,
 # Pad / backfill
 
 setup = common_setup + """
-rng = DateRange('1/1/2000', periods=10000, offset=datetools.Minute())
+rng = DateRange('1/1/2000', periods=100000, offset=datetools.Minute())
 
 ts = Series(np.random.randn(len(rng)), index=rng)
 ts2 = ts[::2]


### PR DESCRIPTION
closes #4604, #3317, #4618

Incorrect results

```
In [1]: s = pd.Series([1,2,3,4,5], index=['a', 'b', 'c', 'd', 'e'])
In [2]: s.reindex(['a', 'g', 'c', 'f'], method='ffill')
Out[2]: 
a     1
g     5
c   NaN
f     5
dtype: float64
```

Fixed (and happens to automatically cast as well back to the original dtype)
(this was broken in 0.12)

```
In [2]: s.reindex(['a', 'g', 'c', 'f'], method='ffill')
Out[2]: 
a    1
g    1
c    3
f    3
dtype: int64
```

This does NOT automatically downcast here as this is a major
performance bottleneck if we did (this is the same result as in 0.12)

```
In [3]: >>> s.reindex(['a', 'g', 'c', 'f']).ffill()
Out[3]: 
a    1
g    1
c    3
f    3
dtype: float64
```

You can force downcasting by passing 'infer' if you want
(this option was not available in 0.12 for Series)

```
In [4]: >>> s.reindex(['a', 'g', 'c', 'f']).ffill(downcast='infer')
Out[4]: 
a    1
g    1
c    3
f    3
dtype: int64
```

TST: GH4604, reindexing with a method of 'ffill' gives incorrect results

BUG/CLN: (GH4604) Refactor Series.reindex to core/generic.py allow method= in reindexing
  on a Series to work

API/CLN: GH4604 Infer and downcast dtype if appropriate on ffill/bfill
  this is for consistency when doing: df.reindex().ffill() and df.reindex(method='ffill')

CLN: allow backfill/pad/interpolate to operate on integers (by float conversion)
     provide downcasting back to original dtype where needed core.internals.interpolate

ENH: provide core.index.identical method to compare values and attributes similar to .equals

API: changed back to pre-GH3482 where a reindex with no args will by default copy
