### PR TITLE
CLN: Refactor series datetime arithmetic

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -200,6 +200,8 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
   with the same signature for ``Panel``
 - Series (for index) / Panel (for items) now as attribute access to its elements  (:issue:`1903`)
 - Refactor of ``_get_numeric_data/_get_bool_data`` to core/generic.py, allowing Series/Panel functionaility
+- Refactor of Series arithmetic with time-like objects (datetime/timedelta/time
+  etc.) into a separate, cleaned up wrapper class. (:issue:`4613`)
 
 **Experimental Features**
 


### PR DESCRIPTION
This is a prelude to the larger refactoring of arithmetic into core/ops,
etc. It doesn't change any external behavior (and I'm relatively confident that
the test suite covers all the branches).

The complexity of the time arithmetic code was making it hard to tweak,
so I decided to change it up. It's not that complicated, but wanted to
run it by you all in an easy-to-read diff before I change its files.

Specifically it:
1. Moves Series time arithmetic out of `_arith_method` into a encapsulated `_TimeOp` class.
2. Consolidates the previously repeated type conversions into one.
3. Separates validations from type conversions, which makes the function
easier to follow and write.
4. Changes all obscure character codes to clear ones.
5. Removes the unnecessary `set()` calls in convert_to_array.
