### PR TITLE
BUG: Fix selection with ``ix/loc`` and non_unique selectors (GH4619)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -264,6 +264,7 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
     to a possible lazay frequency inference issue (:issue:`3317`)
   - Fixed issue where ``DataFrame.apply`` was reraising exceptions incorrectly
     (causing the original stack trace to be truncated).
+  - Fix selection with ``ix/loc`` and non_unique selectors (:issue:`4619`)
 
 pandas 0.12
 ===========

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -476,8 +476,12 @@ class _NDFrameIndexer(object):
             else:
                 level = None
 
-            if labels.is_unique and Index(keyarr).is_unique:
+            keyarr_is_unique = Index(keyarr).is_unique
+
+            # existing labels are unique and indexer is unique
+            if labels.is_unique and keyarr_is_unique:
                 return _reindex(keyarr, level=level)
+
             else:
                 indexer, missing = labels.get_indexer_non_unique(keyarr)
                 check = indexer != -1
@@ -496,8 +500,15 @@ class _NDFrameIndexer(object):
                     new_labels = np.empty(tuple([len(indexer)]),dtype=object)
                     new_labels[cur_indexer]     = cur_labels
                     new_labels[missing_indexer] = missing_labels
-                    new_indexer = (Index(cur_indexer) + Index(missing_indexer)).values
-                    new_indexer[missing_indexer] = -1
+
+                    # a unique indexer
+                    if keyarr_is_unique:
+                        new_indexer = (Index(cur_indexer) + Index(missing_indexer)).values
+                        new_indexer[missing_indexer] = -1
+
+                    # we have a non_unique selector, need to use the original indexer here
+                    else:
+                        new_indexer = indexer
 
                     # reindex with the specified axis
                     ndim = self.obj.ndim

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -796,25 +796,43 @@ class TestIndexing(unittest.TestCase):
         assert_frame_equal(df,result)
 
         # GH 3561, dups not in selected order
-        ind = ['A', 'A', 'B', 'C']
-        df = DataFrame({'test':lrange(len(ind))}, index=ind)
+        df = DataFrame({'test': [5,7,9,11]}, index=['A', 'A', 'B', 'C'])
         rows = ['C', 'B']
-        res = df.ix[rows]
-        self.assert_(rows == list(res.index))
+        expected = DataFrame({'test' : [11,9]},index=rows)
+        result = df.ix[rows]
+        assert_frame_equal(result, expected)
 
-        res = df.ix[Index(rows)]
-        self.assert_(Index(rows).equals(res.index))
+        result = df.ix[Index(rows)]
+        assert_frame_equal(result, expected)
 
         rows = ['C','B','E']
-        res = df.ix[rows]
-        self.assert_(rows == list(res.index))
+        expected = DataFrame({'test' : [11,9,np.nan]},index=rows)
+        result = df.ix[rows]
+        assert_frame_equal(result, expected)
 
-        # inconcistent returns for unique/duplicate indices when values are missing
+        # inconsistent returns for unique/duplicate indices when values are missing
         df = DataFrame(randn(4,3),index=list('ABCD'))
         expected = df.ix[['E']]
 
         dfnu = DataFrame(randn(5,3),index=list('AABCD'))
         result = dfnu.ix[['E']]
+        assert_frame_equal(result, expected)
+
+        # GH 4619; duplicate indexer with missing label
+        df = DataFrame({"A": [0, 1, 2]})
+        result = df.ix[[0,8,0]]
+        expected = DataFrame({"A": [0, np.nan, 0]},index=[0,8,0])
+        assert_frame_equal(result,expected)
+
+        df = DataFrame({"A": list('abc')})
+        result = df.ix[[0,8,0]]
+        expected = DataFrame({"A": ['a', np.nan, 'a']},index=[0,8,0])
+        assert_frame_equal(result,expected)
+
+        # non unique with non unique selector
+        df = DataFrame({'test': [5,7,9,11]}, index=['A','A','B','C'])
+        expected = DataFrame({'test' : [5,7,5,7,np.nan]},index=['A','A','A','A','E'])
+        result = df.ix[['A','A','E']]
         assert_frame_equal(result, expected)
 
     def test_indexing_mixed_frame_bug(self):


### PR DESCRIPTION
closes #4619

```
In [7]: df = DataFrame({"A": [0, 1, 2]})

In [8]: df
Out[8]: 
   A
0  0
1  1
2  2

In [9]: df.ix[[0,8,0]]
Out[9]: 
    A
0   0
8 NaN
0   0

In [10]: df = DataFrame({"A": list('abc')})

In [12]: df
Out[12]: 
   A
0  a
1  b
2  c

In [11]: df.ix[[0,8,0]]
Out[11]: 
     A
0    a
8  NaN
0    a

```

and this beauty here!

```
In [13]: df = DataFrame({'test': [5,7,9,11]}, index=['A','A','B','C'])

In [14]: df
Out[14]: 
   test
A     5
A     7
B     9
C    11

In [15]: df.ix[['A','A','E']]
Out[15]: 
   test
A     5
A     7
A     5
A     7
E   NaN

```
