### PR TITLE
API/CLN: setitem in Series now consistent with DataFrame

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -265,6 +265,8 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
   - Fixed issue where ``DataFrame.apply`` was reraising exceptions incorrectly
     (causing the original stack trace to be truncated).
   - Fix selection with ``ix/loc`` and non_unique selectors (:issue:`4619`)
+  - Fix assignment with iloc/loc involving a dtype change in an existing column (:issue:`4312`)
+    have internal setitem_with_indexer in core/indexing to use Block.setitem
 
 pandas 0.12
 ===========

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1557,7 +1557,9 @@ class SeriesGroupBy(GroupBy):
 
             # need to do a safe put here, as the dtype may be different
             # this needs to be an ndarray
-            result,_ = com._maybe_upcast_indexer(result, indexer, res)
+            result = Series(result)
+            result.loc[indexer] = res
+            result = result.values
 
         # downcast if we can (and need)
         result = _possibly_downcast_to_dtype(result, dtype)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -124,11 +124,13 @@ class _NDFrameIndexer(object):
             item_labels = self.obj._get_axis(info_axis)
 
             def setter(item, v):
-                data = self.obj[item]
-                values = data.values
-                if np.prod(values.shape):
-                    result, changed = com._maybe_upcast_indexer(values,plane_indexer,v,dtype=getattr(data,'dtype',None))
-                    self.obj[item] = result
+                s = self.obj[item]
+                pi = plane_indexer[0] if len(plane_indexer) == 1 else plane_indexer
+
+                # set the item, possibly having a dtype change
+                s = s.copy()
+                s._data = s._data.setitem(pi,v)
+                self.obj[item] = s
 
             labels = item_labels[info_idx]
 

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -127,14 +127,14 @@ def test_nan_to_nat_conversions():
     result = df.loc[4,'B'].value
     assert(result == iNaT)
 
-    values = df['B'].values
-    result, changed = com._maybe_upcast_indexer(values,tuple([slice(8,9)]),np.nan)
-    assert(isnull(result[8]))
+    s = df['B'].copy()
+    s._data = s._data.setitem(tuple([slice(8,9)]),np.nan)
+    assert(isnull(s[8]))
 
     # numpy < 1.7.0 is wrong
     from distutils.version import LooseVersion
     if LooseVersion(np.__version__) >= '1.7.0':
-        assert(result[8] == np.datetime64('NaT'))
+        assert(s[8].value == np.datetime64('NaT').astype(np.int64))
 
 def test_any_none():
     assert(com._any_none(1, 2, 3, None))

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -7669,10 +7669,9 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         # upcasting case (GH # 2794)
         df = DataFrame(dict([ (c,Series([1]*3,dtype=c)) for c in ['int64','int32','float32','float64'] ]))
         df.ix[1,:] = 0
-
         result = df.where(df>=0).get_dtype_counts()
 
-        #### when we don't preserver boolean casts ####
+        #### when we don't preserve boolean casts ####
         #expected = Series({ 'float32' : 1, 'float64' : 3 })
 
         expected = Series({ 'float32' : 1, 'float64' : 1, 'int32' : 1, 'int64' : 1 })

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -964,11 +964,12 @@ class TestIndexing(unittest.TestCase):
         # GH 3668, mixed frame with series value
         df = DataFrame({'x':lrange(10), 'y':lrange(10,20),'z' : 'bar'})
         expected = df.copy()
-        expected.ix[0, 'y'] = 1000
-        expected.ix[2, 'y'] = 1200
-        expected.ix[4, 'y'] = 1400
-        expected.ix[6, 'y'] = 1600
-        expected.ix[8, 'y'] = 1800
+
+        for i in range(5):
+            indexer = i*2
+            v = 1000 + i*200
+            expected.ix[indexer, 'y'] = v
+            self.assert_(expected.ix[indexer, 'y'] == v)
 
         df.ix[df.x % 2 == 0, 'y'] = df.ix[df.x % 2 == 0, 'y'] * 100
         assert_frame_equal(df,expected)
@@ -1196,6 +1197,22 @@ class TestIndexing(unittest.TestCase):
         result = df.loc[mask]
         expected = gen_expected(df,mask)
         assert_frame_equal(result,expected)
+
+    def test_astype_assignment_with_iloc(self):
+
+        # GH4312
+        df_orig = DataFrame([['1','2','3','.4',5,6.,'foo']],columns=list('ABCDEFG'))
+
+        df = df_orig.copy()
+        df.iloc[:,0:3] = df.iloc[:,0:3].astype(int)
+        result = df.get_dtype_counts().sort_index()
+        expected = Series({ 'int64' : 4, 'float64' : 1, 'object' : 2 }).sort_index()
+        assert_series_equal(result,expected)
+
+        df = df_orig.copy()
+        df.iloc[:,0:3] = df.iloc[:,0:3].convert_objects(convert_numeric=True)
+        result = df.get_dtype_counts().sort_index()
+        expected = Series({ 'int64' : 4, 'float64' : 1, 'object' : 2 }).sort_index()
 
 if __name__ == '__main__':
     import nose

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -942,6 +942,7 @@ class TestIndexing(unittest.TestCase):
         # frame on rhs
         df2.ix[mask, cols]= dft.ix[mask, cols]
         assert_frame_equal(df2,expected)
+
         df2.ix[mask, cols]= dft.ix[mask, cols]
         assert_frame_equal(df2,expected)
 


### PR DESCRIPTION
closes #4312

setitem in a frame that can change dtype
setitem_with_indexer now uses the Block.setitem machinery
