### PR TITLE
API/CLN: make rename and copy consistent across NDFrame

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -730,6 +730,7 @@ Reindexing / Selection / Label manipulation
    Panel.reindex
    Panel.reindex_axis
    Panel.reindex_like
+   Panel.rename
    Panel.select
    Panel.take
    Panel.truncate

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -172,21 +172,19 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
 
 - added ``ftypes`` method to Series/DataFame, similar to ``dtypes``, but indicates
   if the underlying is sparse/dense (as well as the dtype)
-
 - All ``NDFrame`` objects now have a ``_prop_attributes``, which can be used to indcated various
   values to propogate to a new object from an existing (e.g. name in ``Series`` will follow
   more automatically now)
-
 - Internal type checking is now done via a suite of generated classes, allowing ``isinstance(value, klass)``
   without having to directly import the klass, courtesy of @jtratner
-
 - Bug in Series update where the parent frame is not updating its cache based on
   changes (:issue:`4080`) or types (:issue:`3217`), fillna (:issue:`3386`)
-
 - Indexing with dtype conversions fixed (:issue:`4463`, :issue:`4204`)
-
-- Refactor Series.reindex to core/generic.py (:issue:`4604`, :issue:`4618`), allow ``method=`` in reindexing
+- Refactor ``Series.reindex`` to core/generic.py (:issue:`4604`, :issue:`4618`), allow ``method=`` in reindexing
   on a Series to work
+- ``Series.copy`` no longer accepts the ``order`` parameter and is now consistent with ``NDFrame`` copy
+- Refactor ``rename`` methods to core/generic.py; fixes ``Series.rename`` for (:issue`4605`), and adds ``rename``
+  with the same signature for ``Panel``
 
 **Experimental Features**
 

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -226,21 +226,19 @@ and behaviors. Series formerly subclassed directly from ``ndarray``. (:issue:`40
 
 - added ``ftypes`` method to Series/DataFame, similar to ``dtypes``, but indicates
   if the underlying is sparse/dense (as well as the dtype)
-
 - All ``NDFrame`` objects now have a ``_prop_attributes``, which can be used to indcated various
   values to propogate to a new object from an existing (e.g. name in ``Series`` will follow
   more automatically now)
-
 - Internal type checking is now done via a suite of generated classes, allowing ``isinstance(value, klass)``
   without having to directly import the klass, courtesy of @jtratner
-
 - Bug in Series update where the parent frame is not updating its cache based on
   changes (:issue:`4080`) or types (:issue:`3217`), fillna (:issue:`3386`)
-
 - Indexing with dtype conversions fixed (:issue:`4463`, :issue:`4204`)
-
-- Refactor Series.reindex to core/generic.py (:issue:`4604`, :issue:`4618`), allow ``method=`` in reindexing
+- Refactor ``Series.reindex`` to core/generic.py (:issue:`4604`, :issue:`4618`), allow ``method=`` in reindexing
   on a Series to work
+- ``Series.copy`` no longer accepts the ``order`` parameter and is now consistent with ``NDFrame`` copy
+- Refactor ``rename`` methods to core/generic.py; fixes ``Series.rename`` for (:issue`4605`), and adds ``rename``
+  with the same signature for ``Panel``
 
 Bug Fixes
 ~~~~~~~~~

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2898,64 +2898,6 @@ class DataFrame(NDFrame):
         return result
 
     #----------------------------------------------------------------------
-    # Rename
-
-    def rename(self, index=None, columns=None, copy=True, inplace=False):
-        """
-        Alter index and / or columns using input function or
-        functions. Function / dict values must be unique (1-to-1). Labels not
-        contained in a dict / Series will be left as-is.
-
-        Parameters
-        ----------
-        index : dict-like or function, optional
-            Transformation to apply to index values
-        columns : dict-like or function, optional
-            Transformation to apply to column values
-        copy : boolean, default True
-            Also copy underlying data
-        inplace : boolean, default False
-            Whether to return a new DataFrame. If True then value of copy is
-            ignored.
-
-        See also
-        --------
-        Series.rename
-
-        Returns
-        -------
-        renamed : DataFrame (new object)
-        """
-        from pandas.core.series import _get_rename_function
-
-        if index is None and columns is None:
-            raise Exception('must pass either index or columns')
-
-        index_f = _get_rename_function(index)
-        columns_f = _get_rename_function(columns)
-
-        self._consolidate_inplace()
-
-        result = self if inplace else self.copy(deep=copy)
-
-        if index is not None:
-            result._rename_index_inplace(index_f)
-
-        if columns is not None:
-            result._rename_columns_inplace(columns_f)
-
-        if not inplace:
-            return result
-
-    def _rename_index_inplace(self, mapper):
-        self._data = self._data.rename_axis(mapper, axis=1)
-        self._clear_item_cache()
-
-    def _rename_columns_inplace(self, mapper):
-        self._data = self._data.rename_items(mapper, copydata=False)
-        self._clear_item_cache()
-
-    #----------------------------------------------------------------------
     # Arithmetic / combination related
 
     def _combine_frame(self, other, func, fill_value=None, level=None):

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2758,8 +2758,8 @@ class BlockManager(PandasObject):
                     return '%s%s' % (x, rsuffix)
                 return x
 
-            this = self.rename_items(lrenamer, copydata=copydata)
-            other = other.rename_items(rrenamer, copydata=copydata)
+            this = self.rename_items(lrenamer, copy=copydata)
+            other = other.rename_items(rrenamer, copy=copydata)
         else:
             this = self
 
@@ -2777,6 +2777,13 @@ class BlockManager(PandasObject):
                 return False
         return True
 
+    def rename(self, mapper, axis, copy=False):
+        """ generic rename """
+
+        if axis == 0:
+            return self.rename_items(mapper, copy=copy)
+        return self.rename_axis(mapper, axis=axis)
+
     def rename_axis(self, mapper, axis=1):
 
         index = self.axes[axis]
@@ -2793,7 +2800,7 @@ class BlockManager(PandasObject):
         new_axes[axis] = new_axis
         return self.__class__(self.blocks, new_axes)
 
-    def rename_items(self, mapper, copydata=True):
+    def rename_items(self, mapper, copy=True):
         if isinstance(self.items, MultiIndex):
             items = [tuple(mapper(y) for y in x) for x in self.items]
             new_items = MultiIndex.from_tuples(items, names=self.items.names)
@@ -2803,7 +2810,7 @@ class BlockManager(PandasObject):
 
         new_blocks = []
         for block in self.blocks:
-            newb = block.copy(deep=copydata)
+            newb = block.copy(deep=copy)
             newb.set_ref_items(new_items, maybe_rename=True)
             new_blocks.append(newb)
         new_axes = list(self.axes)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1437,32 +1437,6 @@ class Series(generic.NDFrame):
         """
         return self._data.values
 
-    def copy(self, order='C', deep=False):
-        """
-        Return new Series with copy of underlying values
-
-        Parameters
-        ----------
-        deep : boolean, default False
-            deep copy index along with data
-        order : boolean, default 'C'
-            order for underlying numpy array
-
-        Returns
-        -------
-        cp : Series
-        """
-        if deep:
-            from copy import deepcopy
-            index = self.index.copy(deep=deep)
-            name = deepcopy(self.name)
-        else:
-            index = self.index
-            name = self.name
-
-        return Series(self.values.copy(order), index=index,
-                      name=name)
-
     def get_values(self):
         """ same as values (but handles sparseness conversions); is a view """
         return self._data.values
@@ -3090,48 +3064,6 @@ class Series(generic.NDFrame):
 
         return self._constructor(result, index=self.index, name=self.name)
 
-    def rename(self, mapper, inplace=False):
-        """
-        Alter Series index using dict or function
-
-        Parameters
-        ----------
-        mapper : dict-like or function
-            Transformation to apply to each index
-
-        Notes
-        -----
-        Function / dict values must be unique (1-to-1)
-
-        Examples
-        --------
-        >>> x
-        foo 1
-        bar 2
-        baz 3
-
-        >>> x.rename(str.upper)
-        FOO 1
-        BAR 2
-        BAZ 3
-
-        >>> x.rename({'foo' : 'a', 'bar' : 'b', 'baz' : 'c'})
-        a 1
-        b 2
-        c 3
-
-        Returns
-        -------
-        renamed : Series (new object)
-        """
-        mapper_f = _get_rename_function(mapper)
-        result = self if inplace else self.copy()
-        result.index = Index([mapper_f(x)
-                             for x in self.index], name=self.index.name)
-
-        if not inplace:
-            return result
-
     @property
     def weekday(self):
         return self._constructor([d.weekday() for d in self.index], index=self.index)
@@ -3378,20 +3310,6 @@ def _sanitize_array(data, index, dtype=None, copy=False,
         subarr = pa.array(data, dtype=object, copy=copy)
 
     return subarr
-
-
-def _get_rename_function(mapper):
-    if isinstance(mapper, (dict, Series)):
-        def f(x):
-            if x in mapper:
-                return mapper[x]
-            else:
-                return x
-    else:
-        f = mapper
-
-    return f
-
 
 def _resolve_offset(freq, kwds):
     if 'timeRule' in kwds or 'offset' in kwds:

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -1,0 +1,95 @@
+# pylint: disable-msg=E1101,W0612
+
+from datetime import datetime, timedelta
+import operator
+import unittest
+import nose
+
+import numpy as np
+import pandas as pd
+
+from pandas import (Index, Series, DataFrame, Panel,
+                    isnull, notnull,date_range)
+from pandas.core.index import Index, MultiIndex
+from pandas.tseries.index import Timestamp, DatetimeIndex
+
+import pandas.core.common as com
+
+from pandas.compat import StringIO, lrange, range, zip, u, OrderedDict, long
+from pandas import compat
+from pandas.util.testing import (assert_series_equal,
+                                 assert_frame_equal,
+                                 assert_panel_equal,
+                                 assert_almost_equal,
+                                 ensure_clean)
+import pandas.util.testing as tm
+
+#------------------------------------------------------------------------------
+# Generic types test cases
+
+
+class Generic(object):
+
+    _multiprocess_can_split_ = True
+
+    def setUp(self):
+        import warnings
+        warnings.filterwarnings(action='ignore', category=FutureWarning)
+
+    def _axes(self):
+        """ return the axes for my object typ """
+        return self._typ._AXIS_ORDERS
+
+    def _construct(self, shape=None, **kwargs):
+        """ construct an object for the given shape """
+
+        if isinstance(shape,int):
+            shape = tuple([shape] * self._typ._AXIS_LEN)
+        return self._typ(np.random.randn(*shape),**kwargs)
+
+    def _compare(self, result, expected):
+        self._comparator(result,expected)
+
+    def test_rename(self):
+
+        # single axis
+        for axis in self._axes():
+            kwargs = { axis : list('ABCD') }
+            o = self._construct(4,**kwargs)
+
+            # no values passed
+            #self.assertRaises(Exception, o.rename(str.lower))
+
+            # rename a single axis
+            result = o.rename(**{ axis : str.lower })
+            expected = o.copy()
+            setattr(expected,axis,list('abcd'))
+            self._compare(result, expected)
+
+        # multiple axes at once
+
+class TestSeries(unittest.TestCase, Generic):
+    _typ = Series
+    _comparator = lambda self, x, y: assert_series_equal(x,y)
+
+    def test_rename_mi(self):
+        s = Series([11,21,31],
+                   index=MultiIndex.from_tuples([("A",x) for x in ["a","B","c"]]))
+        result = s.rename(str.lower)
+
+class TestDataFrame(unittest.TestCase, Generic):
+    _typ = DataFrame
+    _comparator = lambda self, x, y: assert_frame_equal(x,y)
+
+    def test_rename_mi(self):
+        df = DataFrame([11,21,31],
+                       index=MultiIndex.from_tuples([("A",x) for x in ["a","B","c"]]))
+        result = df.rename(str.lower)
+
+class TestPanel(unittest.TestCase, Generic):
+    _typ = Panel
+    _comparator = lambda self, x, y: assert_panel_equal(x,y)
+
+if __name__ == '__main__':
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   exit=False)


### PR DESCRIPTION
verifies #2721, #4039
closes #4605

TST: add tests/test_generic.py

API/CLN: Refactor rename methods to core/generic.py; fixes Series.rename for (GH4605), and adds rename
   with the same signature for `Panel`

API/CLN: Refactor Series.copy to core/generic.py; removes the order argument from Series.copy (inconsistent)
