### PR TITLE
PERF: optimize __getitem__ in DataFrame for columns lookup

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -59,6 +59,8 @@ pandas 0.13
   - A Series of dtype ``timedelta64[ns]`` can now be divided by another
     ``timedelta64[ns]`` object to yield a ``float64`` dtyped Series. This
     is frequency conversion.
+  - Performance improvements with ``__getitem__`` on ``DataFrames`` with
+    when the key is a column
 
 **API Changes**
 
@@ -183,7 +185,7 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
 - Refactor ``Series.reindex`` to core/generic.py (:issue:`4604`, :issue:`4618`), allow ``method=`` in reindexing
   on a Series to work
 - ``Series.copy`` no longer accepts the ``order`` parameter and is now consistent with ``NDFrame`` copy
-- Refactor ``rename`` methods to core/generic.py; fixes ``Series.rename`` for (:issue`4605`), and adds ``rename``
+- Refactor ``rename`` methods to core/generic.py; fixes ``Series.rename`` for (:issue:`4605`), and adds ``rename``
   with the same signature for ``Panel``
 
 **Experimental Features**

--- a/vb_suite/frame_methods.py
+++ b/vb_suite/frame_methods.py
@@ -84,6 +84,8 @@ frame_boolean_row_select = Benchmark('df[bool_arr]', setup,
 
 setup = common_setup + """
 df = DataFrame(randn(10000, 1000))
+df2 = DataFrame(randn(3000,1),columns=['A'])
+df3 = DataFrame(randn(3000,1))
 
 def f():
     if hasattr(df, '_item_cache'):
@@ -94,6 +96,15 @@ def f():
 def g():
     for name, col in df.iteritems():
         pass
+
+def h():
+    for i in xrange(10000):
+        df2['A']
+
+def j():
+    for i in xrange(10000):
+        df3[0]
+
 """
 
 # as far back as the earliest test currently in the suite
@@ -102,6 +113,12 @@ frame_iteritems = Benchmark('f()', setup,
 
 frame_iteritems_cached = Benchmark('g()', setup,
                                    start_date=datetime(2010, 6, 1))
+
+frame_getitem_single_column = Benchmark('h()', setup,
+                                        start_date=datetime(2010, 6, 1))
+
+frame_getitem_single_column2 = Benchmark('j()', setup,
+                                         start_date=datetime(2010, 6, 1))
 
 #----------------------------------------------------------------------
 # to_string


### PR DESCRIPTION
```
In [1]: df2 = DataFrame(randn(3000,1),columns=['A'])
In [2]: df3 = DataFrame(randn(3000,1))
In [3]: def h():
   ...:         for i in xrange(10000):
   ...:                 df2['A']
   ...:         
In [4]: def j():
   ...:         for i in xrange(10000):
   ...:                 df3[0]
   ...:         
```

0.12

```
In [5]: %timeit h()
%time10 loops, best of 3: 39.8 ms per loop

In [6]: %timeit j()
10 loops, best of 3: 31.8 ms per loop
```

with PR

```
In [8]: %timeit h()
10 loops, best of 3: 25.5 ms per loop

In [9]: %timeit j()
10 loops, best of 3: 27.4 ms per loop
```

and the vbench

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
frame_getitem_single_column                  |  25.5514 |  43.3776 |   0.5890 |
frame_getitem_single_column2                 |  27.3627 |  32.4320 |   0.8437 |
```
