### PR TITLE
ENH: (GH4629) Support for using a DatetimeIndex/PeriodsIndex directly in a datelike calculation

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -61,6 +61,8 @@ pandas 0.13
     is frequency conversion.
   - Performance improvements with ``__getitem__`` on ``DataFrames`` with
     when the key is a column
+  - Support for using a ``DatetimeIndex/PeriodsIndex`` directly in a datelike calculation
+    e.g. s-s.index (:issue:`4629`)
 
 **API Changes**
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -2319,6 +2319,30 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         result = com._possibly_cast_to_timedelta(np.abs(a - b))
         self.assert_(result.dtype == 'timedelta64[ns]')
 
+    def test_datetime64_with_index(self):
+
+        # arithmetic integer ops with an index
+        s = Series(np.random.randn(5))
+        expected = s-s.index.to_series()
+        result = s-s.index
+        assert_series_equal(result,expected)
+
+        # GH 4629
+        # arithmetic datetime64 ops with an index
+        s = Series(date_range('20130101',periods=5),index=date_range('20130101',periods=5))
+        expected = s-s.index.to_series()
+        result = s-s.index
+        assert_series_equal(result,expected)
+
+        result = s-s.index.to_period()
+        assert_series_equal(result,expected)
+
+        df = DataFrame(np.random.randn(5,2),index=date_range('20130101',periods=5))
+        df['date'] = Timestamp('20130102')
+        df['expected'] = df['date']-df.index.to_series()
+        df['result'] = df['date']-df.index
+        assert_series_equal(df['result'],df['expected'])
+
     def test_timedelta64_nan(self):
 
         from pandas import tslib


### PR DESCRIPTION
closes #4629

```
In [1]: s = Series(date_range('20130101',periods=5),index=date_range('20130102',periods=5))

In [2]: s
Out[2]: 
2013-01-02   2013-01-01 00:00:00
2013-01-03   2013-01-02 00:00:00
2013-01-04   2013-01-03 00:00:00
2013-01-05   2013-01-04 00:00:00
2013-01-06   2013-01-05 00:00:00
Freq: D, dtype: datetime64[ns]

In [3]: s-s.index
Out[3]: 
2013-01-02   -1 days, 00:00:00
2013-01-03   -1 days, 00:00:00
2013-01-04   -1 days, 00:00:00
2013-01-05   -1 days, 00:00:00
2013-01-06   -1 days, 00:00:00
Freq: D, dtype: timedelta64[ns]
```
