### PR TITLE
Boolean indexing on an empty series loses index names (rebase of 4236)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -258,6 +258,8 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
   - Fix bug in ``pd.read_clipboard`` on windows with PY3 (:issue:`4561`); not decoding properly
   - ``tslib.get_period_field()`` and ``tslib.get_period_field_arr()`` now raise
     if code argument out of range (:issue:`4519`, :issue:`4520`)
+  - Fix boolean indexing on an empty series loses index names (:issue:`4235`),
+  infer_dtype works with empty arrays.
   - Fix reindexing with multiple axes; if an axes match was not replacing the current axes, leading
     to a possible lazay frequency inference issue (:issue:`3317`)
   - Fixed issue where ``DataFrame.apply`` was reraising exceptions incorrectly

--- a/pandas/src/inference.pyx
+++ b/pandas/src/inference.pyx
@@ -41,16 +41,16 @@ def infer_dtype(object _values):
             _values = list(_values)
         values = list_to_object_array(_values)
 
-    n = len(values)
-    if n == 0:
-        return 'empty'
-
     val_kind = values.dtype.type
     if val_kind in _TYPE_MAP:
         return _TYPE_MAP[val_kind]
 
     if values.dtype != np.object_:
         values = values.astype('O')
+
+    n = len(values)
+    if n == 0:
+        return 'empty'
 
     val = util.get_value_1d(values, 0)
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -740,6 +740,13 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         assert_series_equal(result, expected)
         self.assert_(np.array_equal(result.index, s.index[mask]))
 
+    def test_getitem_boolean_empty(self):
+        s = Series([], dtype=np.int64)
+        s.index.name = 'index_name'
+        s = s[s.isnull()]
+        self.assertEqual(s.index.name, 'index_name')
+        self.assertEqual(s.dtype, np.int64)
+
     def test_getitem_generator(self):
         gen = (x > 0 for x in self.series)
         result = self.series[gen]

--- a/pandas/tests/test_tseries.py
+++ b/pandas/tests/test_tseries.py
@@ -565,9 +565,9 @@ class TestTypeInference(unittest.TestCase):
 
     def test_length_zero(self):
         result = lib.infer_dtype(np.array([], dtype='i4'))
-        self.assertEqual(result, 'empty')
+        self.assertEqual(result, 'integer')
 
-        result = lib.infer_dtype(np.array([], dtype='O'))
+        result = lib.infer_dtype([])
         self.assertEqual(result, 'empty')
 
     def test_integers(self):


### PR DESCRIPTION
Fixes #4235.

This just adds a release note to #4236: Boolean indexing on an empty series loses index names.

Actually that commit really just adds tests for this, since they now already pass in master. It also, fixes behaviour of `infer_dtype` with empty arrays.
