### PR TITLE
BUG: Series.reshape to own shape raises TypeError

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -498,6 +498,8 @@ Bug Fixes
   - ``Timestamp`` objects can now appear in the left hand side of a comparison
     operation with a ``Series`` or ``DataFrame`` object (:issue:`4982`).
   - Fix a bug when indexing with ``np.nan`` via ``iloc/loc`` (:issue:`5016`)
+  - Fix a bug where reshaping a ``Series`` to its own shape raised ``TypeError`` (:issue:`4554`)
+    and other reshaping issues.
 
 pandas 0.12.0
 -------------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1152,18 +1152,21 @@ class Series(generic.NDFrame):
         new_values = self.values.repeat(reps)
         return self._constructor(new_values, index=new_index, name=self.name)
 
-    def reshape(self, newshape, order='C'):
+    def reshape(self, *args, **kwargs):
         """
         See numpy.ndarray.reshape
         """
-        if order not in ['C', 'F']:
-            raise TypeError(
-                "must specify a tuple / singular length to reshape")
-
-        if isinstance(newshape, tuple) and len(newshape) > 1:
-            return self.values.reshape(newshape, order=order)
+        if len(args) == 1 and hasattr(args[0], '__iter__'):
+            shape = args[0]
         else:
-            return ndarray.reshape(self, newshape, order)
+            shape = args
+
+        if tuple(shape) == self.shape:
+            # XXX ignoring the "order" keyword.
+            return self
+
+        return self.values.reshape(shape, **kwargs)
+
 
     def get(self, label, default=None):
         """

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1046,12 +1046,16 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
                           [5, slice(None, None)], 2)
 
     def test_reshape_non_2d(self):
+        # GH 4554
         x = Series(np.random.random(201), name='x')
-        self.assertRaises(TypeError, x.reshape, (len(x),))
+        self.assertTrue(x.reshape(x.shape,) is x)
 
         # GH 2719
         a = Series([1, 2, 3, 4])
-        self.assertRaises(TypeError, a.reshape, 2, 2)
+        result = a.reshape(2, 2)
+        expected = a.values.reshape(2, 2)
+        np.testing.assert_array_equal(result, expected)
+        self.assertTrue(type(result) is type(expected))
 
     def test_reshape_2d_return_array(self):
         x = Series(np.random.random(201), name='x')


### PR DESCRIPTION
closes #4554

I just fixed the call to ndarray.reshape with order as a positional argument, which is wrong. Please note that I had to remove a test.
