### PR TITLE
Groupby as index

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -217,6 +217,7 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
     of a duplicate index (:issue:`4359`)
   - In ``to_json``, fix date handling so milliseconds are the default timestamp
     as the docstring says (:issue:`4362`).
+  - ``as_index`` is no longer ignored when doing groupby apply (:issue:`4648`), (:issue:`3417`)
   - JSON NaT handling fixed, NaTs are now serialised to `null` (:issue:`4498`)
   - Fixed JSON handling of escapable characters in JSON object keys (:issue:`4593`)
   - Fixed passing ``keep_default_na=False`` when ``na_values=None`` (:issue:`4318`)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -516,7 +516,7 @@ class GroupBy(PandasObject):
                 result = result.reindex(ax)
             else:
                 result = result.reindex_axis(ax, axis=self.axis)
-        elif self.group_keys:
+        elif self.group_keys and self.as_index:
             group_keys = keys
             group_levels = self.grouper.levels
             group_names = self.grouper.names

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -1202,6 +1202,10 @@ class TestGroupBy(unittest.TestCase):
         res_not_as = g_not_as.apply(lambda x: x.head(2)).index
         assert_index_equal(res_not_as, exp_not_as)
 
+        ind = Index(list('abcde'))
+        df = DataFrame([[1, 2], [2, 3], [1, 4], [1, 5], [2, 6]], index=ind)
+        res = df.groupby(0, as_index=False).apply(lambda x: x).index
+        assert_index_equal(res, ind)
 
     def test_groupby_multiple_key(self):
         df = tm.makeTimeDataFrame()

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -12,7 +12,8 @@ from pandas.core.api import Categorical, DataFrame
 from pandas.core.groupby import GroupByError, SpecificationError, DataError
 from pandas.core.series import Series
 from pandas.util.testing import (assert_panel_equal, assert_frame_equal,
-                                 assert_series_equal, assert_almost_equal)
+                                 assert_series_equal, assert_almost_equal,
+                                 assert_index_equal)
 from pandas.compat import(
     range, long, lrange, StringIO, lmap, lzip, map, zip, builtins, OrderedDict
 )
@@ -1177,6 +1178,30 @@ class TestGroupBy(unittest.TestCase):
 
         self.assertRaises(ValueError, self.df.groupby,
                           lambda x: x.lower(), as_index=False, axis=1)
+
+    def test_groupby_as_index_apply(self):
+        # GH #4648 and #3417
+        df = DataFrame({'item_id': ['b', 'b', 'a', 'c', 'a', 'b'],
+                        'user_id': [1,2,1,1,3,1],
+                        'time': range(6)})
+
+        g_as = df.groupby('user_id', as_index=True)
+        g_not_as = df.groupby('user_id', as_index=False)
+
+        res_as = g_as.head(2).index
+        exp_as = MultiIndex.from_tuples([(1, 0), (1, 2), (2, 1), (3, 4)])
+        assert_index_equal(res_as, exp_as)
+
+        res_not_as = g_not_as.head(2).index
+        exp_not_as = Index([0, 2, 1, 4])
+        assert_index_equal(res_not_as, exp_not_as)
+
+        res_as = g_as.apply(lambda x: x.head(2)).index
+        assert_index_equal(res_not_as, exp_not_as)
+
+        res_not_as = g_not_as.apply(lambda x: x.head(2)).index
+        assert_index_equal(res_not_as, exp_not_as)
+
 
     def test_groupby_multiple_key(self):
         df = tm.makeTimeDataFrame()


### PR DESCRIPTION
closes #4648
closes #3417
closes #4649 (pr)

```
In [1]: df = pd.DataFrame([[1, 2], [2, 3], [1, 4], [1, 5], [2, 6]], index=list('abcde'))

In [2]: g = df.groupby(0, as_index=False)

In [3]: g.apply(lambda x: x)
Out[3]: 
   0  1
a  1  2
b  2  3
c  1  4
d  1  5
e  2  6

In [4]: g.head(2)
Out[4]: 
   0  1
a  1  2
c  1  4
b  2  3
e  2  6
```
