### PR TITLE
ENH: GH3371 support timedelta fillna

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -157,6 +157,8 @@ pandas 0.13
   - Remove undocumented/unused ``kind`` keyword argument from ``read_excel``, and ``ExcelFile``. (:issue:`4713`, :issue:`4712`)
   - The ``method`` argument of ``NDFrame.replace()`` is valid again, so that a
     a list can be passed to ``to_replace`` (:issue:`4743`).
+  - provide automatic dtype conversions on _reduce operations (:issue:`3371`)
+  - exclude non-numerics if mixed types with datelike in _reduce operations (:issue:`3371`)
 
 **Internal Refactoring**
 

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -67,8 +67,9 @@ pandas 0.13
   - A Series of dtype ``timedelta64[ns]`` can now be divided by another
     ``timedelta64[ns]`` object to yield a ``float64`` dtyped Series. This
     is frequency conversion.
-  - Timedeltas support ``fillna`` with an integer interpreted as seconds,
+  - Timedelta64 support ``fillna/ffill/bfill`` with an integer interpreted as seconds,
     or a ``timedelta`` (:issue:`3371`)
+  - Datetime64 support ``ffill/bfill``
   - Performance improvements with ``__getitem__`` on ``DataFrames`` with
     when the key is a column
   - Support for using a ``DatetimeIndex/PeriodsIndex`` directly in a datelike calculation

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -67,6 +67,8 @@ pandas 0.13
   - A Series of dtype ``timedelta64[ns]`` can now be divided by another
     ``timedelta64[ns]`` object to yield a ``float64`` dtyped Series. This
     is frequency conversion.
+  - Timedeltas support ``fillna`` with an integer interpreted as seconds,
+    or a ``timedelta`` (:issue:`3371`)
   - Performance improvements with ``__getitem__`` on ``DataFrames`` with
     when the key is a column
   - Support for using a ``DatetimeIndex/PeriodsIndex`` directly in a datelike calculation

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -1195,6 +1195,15 @@ issues). ``idxmin, idxmax`` are supported as well.
    df.min().idxmax()
    df.min(axis=1).idxmin()
 
+You can fillna on timedeltas. Integers will be interpreted as seconds. You can
+pass a timedelta to get a particular value.
+
+.. ipython:: python
+
+   y.fillna(0)
+   y.fillna(10)
+   y.fillna(timedelta(days=-1,seconds=5))
+
 .. _timeseries.timedeltas_convert:
 
 Time Deltas & Conversions

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -195,6 +195,7 @@ Enhancements
   - NaN handing in get_dummies (:issue:`4446`) with `dummy_na`
 
     .. ipython:: python
+
        # previously, nan was erroneously counted as 2 here
        # now it is not counted at all
        get_dummies([1, 2, np.nan])
@@ -237,10 +238,17 @@ Enhancements
          from pandas import offsets
          td + offsets.Minute(5) + offsets.Milli(5)
 
-    - ``plot(kind='kde')`` now accepts the optional parameters ``bw_method`` and
-      ``ind``, passed to scipy.stats.gaussian_kde() (for scipy >= 0.11.0) to set
-      the bandwidth, and to gkde.evaluate() to specify the indicies at which it
-      is evaluated, respecttively. See scipy docs.
+    - Fillna is now supported for timedeltas
+
+      .. ipython:: python
+
+         td.fillna(0)
+         td.fillna(timedelta(days=1,seconds=5))
+
+  - ``plot(kind='kde')`` now accepts the optional parameters ``bw_method`` and
+    ``ind``, passed to scipy.stats.gaussian_kde() (for scipy >= 0.11.0) to set
+    the bandwidth, and to gkde.evaluate() to specify the indicies at which it
+    is evaluated, respecttively. See scipy docs.
 
 .. _whatsnew_0130.refactoring:
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1043,7 +1043,8 @@ class TimeDeltaBlock(IntBlock):
     def _try_coerce_result(self, result):
         """ reverse of try_coerce_args / try_operate """
         if isinstance(result, np.ndarray):
-            result = result.astype('m8[ns]')
+            if result.dtype.kind in ['i','f','O']:
+                result = result.astype('m8[ns]')
         elif isinstance(result, np.integer):
             result = np.timedelta64(result)
         return result
@@ -1299,6 +1300,8 @@ class DatetimeBlock(Block):
             if result.dtype == 'i8':
                 result = tslib.array_to_datetime(
                     result.astype(object).ravel()).reshape(result.shape)
+            elif result.dtype.kind in ['i','f','O']:
+                result = result.astype('M8[ns]')
         elif isinstance(result, (np.integer, np.datetime64)):
             result = lib.Timestamp(result)
         return result

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1021,6 +1021,7 @@ class IntBlock(NumericBlock):
 class TimeDeltaBlock(IntBlock):
     is_timedelta = True
     _can_hold_na = True
+    is_numeric = False
 
     def _try_fill(self, value):
         """ if we are a NaT, return the actual fill value """

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1,6 +1,6 @@
 import itertools
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
 import copy
 from collections import defaultdict
 
@@ -41,6 +41,7 @@ class Block(PandasObject):
     is_integer = False
     is_complex = False
     is_datetime = False
+    is_timedelta = False
     is_bool = False
     is_object = False
     is_sparse = False
@@ -326,6 +327,8 @@ class Block(PandasObject):
         # unless indicated
         if downcast is None and self.is_float:
             return blocks
+        elif downcast is None and (self.is_timedelta or self.is_datetime):
+            return blocks
 
         result_blocks = []
         for b in blocks:
@@ -484,6 +487,10 @@ class Block(PandasObject):
 
         # may need to change the dtype here
         return _possibly_downcast_to_dtype(result, dtype)
+
+    def _try_operate(self, values):
+        """ return a version to operate on as the input """
+        return values
 
     def _try_coerce_args(self, values, other):
         """ provide coercion to our input arguments """
@@ -703,8 +710,11 @@ class Block(PandasObject):
                 else:
                     return [self.copy()]
 
+        fill_value = self._try_fill(fill_value)
         values = self.values if inplace else self.values.copy()
+        values = self._try_operate(values)
         values = com.interpolate_2d(values, method, axis, limit, fill_value)
+        values = self._try_coerce_result(values)
 
         blocks = [ make_block(values, self.items, self.ref_items, ndim=self.ndim, klass=self.__class__, fastpath=True) ]
         return self._maybe_downcast(blocks, downcast)
@@ -1008,6 +1018,55 @@ class IntBlock(NumericBlock):
     def should_store(self, value):
         return com.is_integer_dtype(value) and value.dtype == self.dtype
 
+class TimeDeltaBlock(IntBlock):
+    is_timedelta = True
+    _can_hold_na = True
+
+    def _try_fill(self, value):
+        """ if we are a NaT, return the actual fill value """
+        if isinstance(value, type(tslib.NaT)) or isnull(value):
+            value = tslib.iNaT
+        elif isinstance(value, np.timedelta64):
+            pass
+        elif com.is_integer(value):
+            # coerce to seconds of timedelta
+            value = np.timedelta64(int(value*1e9))
+        elif isinstance(value, timedelta):
+            value = np.timedelta64(value)
+
+        return value
+
+    def _try_operate(self, values):
+        """ return a version to operate on """
+        return values.view('i8')
+
+    def _try_coerce_result(self, result):
+        """ reverse of try_coerce_args / try_operate """
+        if isinstance(result, np.ndarray):
+            result = result.astype('m8[ns]')
+        elif isinstance(result, np.integer):
+            result = np.timedelta64(result)
+        return result
+
+    def should_store(self, value):
+        return issubclass(value.dtype.type, np.timedelta64)
+
+    def to_native_types(self, slicer=None, na_rep=None, **kwargs):
+        """ convert to our native types format, slicing if desired """
+
+        values = self.values
+        if slicer is not None:
+            values = values[:, slicer]
+        mask = isnull(values)
+
+        rvalues = np.empty(values.shape, dtype=object)
+        if na_rep is None:
+            na_rep = 'NaT'
+        rvalues[mask] = na_rep
+        imask = (-mask).ravel()
+        rvalues.flat[imask] = np.array([lib.repr_timedelta64(val)
+                                        for val in values.ravel()[imask]], dtype=object)
+        return rvalues.tolist()
 
 class BoolBlock(NumericBlock):
     is_bool = True
@@ -1216,6 +1275,10 @@ class DatetimeBlock(Block):
         except:
             return element
 
+    def _try_operate(self, values):
+        """ return a version to operate on """
+        return values.view('i8')
+
     def _try_coerce_args(self, values, other):
         """ provide coercion to our input arguments
             we are going to compare vs i8, so coerce to integer
@@ -1242,11 +1305,12 @@ class DatetimeBlock(Block):
 
     def _try_fill(self, value):
         """ if we are a NaT, return the actual fill value """
-        if isinstance(value, type(tslib.NaT)):
+        if isinstance(value, type(tslib.NaT)) or isnull(value):
             value = tslib.iNaT
         return value
 
     def fillna(self, value, inplace=False, downcast=None):
+        # straight putmask here
         values = self.values if inplace else self.values.copy()
         mask = com.isnull(self.values)
         value = self._try_fill(value)
@@ -1267,12 +1331,9 @@ class DatetimeBlock(Block):
             na_rep = 'NaT'
         rvalues[mask] = na_rep
         imask = (-mask).ravel()
-        if self.dtype == 'datetime64[ns]':
-            rvalues.flat[imask] = np.array(
-                [Timestamp(val)._repr_base for val in values.ravel()[imask]], dtype=object)
-        elif self.dtype == 'timedelta64[ns]':
-            rvalues.flat[imask] = np.array([lib.repr_timedelta64(val)
-                                           for val in values.ravel()[imask]], dtype=object)
+        rvalues.flat[imask] = np.array(
+            [Timestamp(val)._repr_base for val in values.ravel()[imask]], dtype=object)
+
         return rvalues.tolist()
 
     def should_store(self, value):
@@ -1551,6 +1612,8 @@ def make_block(values, items, ref_items, klass=None, ndim=None, dtype=None, fast
             klass = SparseBlock
         elif issubclass(vtype, np.floating):
             klass = FloatBlock
+        elif issubclass(vtype, np.integer) and issubclass(vtype, np.timedelta64):
+            klass = TimeDeltaBlock
         elif issubclass(vtype, np.integer) and not issubclass(vtype, np.datetime64):
             klass = IntBlock
         elif dtype == np.bool_:
@@ -3404,12 +3467,13 @@ def _interleaved_dtype(blocks):
     have_float = len(counts[FloatBlock]) > 0
     have_complex = len(counts[ComplexBlock]) > 0
     have_dt64 = len(counts[DatetimeBlock]) > 0
+    have_td64 = len(counts[TimeDeltaBlock]) > 0
     have_sparse = len(counts[SparseBlock]) > 0
     have_numeric = have_float or have_complex or have_int
 
     if (have_object or
         (have_bool and have_numeric) or
-            (have_numeric and have_dt64)):
+            (have_numeric and (have_dt64 or have_td64))):
         return np.dtype(object)
     elif have_bool:
         return np.dtype(bool)
@@ -3432,6 +3496,8 @@ def _interleaved_dtype(blocks):
 
     elif have_dt64 and not have_float and not have_complex:
         return np.dtype('M8[ns]')
+    elif have_td64 and not have_float and not have_complex:
+        return np.dtype('m8[ns]')
     elif have_complex:
         return np.dtype('c16')
     else:

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -287,8 +287,7 @@ def nanmin(values, axis=None, skipna=True):
     values, mask, dtype = _get_values(values, skipna, fill_value_typ = '+inf')
 
     # numpy 1.6.1 workaround in Python 3.x
-    if (values.dtype == np.object_
-            and sys.version_info[0] >= 3):  # pragma: no cover
+    if (values.dtype == np.object_ and compat.PY3):
         if values.ndim > 1:
             apply_ax = axis if axis is not None else 0
             result = np.apply_along_axis(builtins.min, apply_ax, values)
@@ -311,8 +310,7 @@ def nanmax(values, axis=None, skipna=True):
     values, mask, dtype = _get_values(values, skipna, fill_value_typ ='-inf')
 
     # numpy 1.6.1 workaround in Python 3.x
-    if (values.dtype == np.object_
-            and sys.version_info[0] >= 3):  # pragma: no cover
+    if (values.dtype == np.object_ and compat.PY3):
 
         if values.ndim > 1:
             apply_ax = axis if axis is not None else 0

--- a/pandas/src/inference.pyx
+++ b/pandas/src/inference.pyx
@@ -480,6 +480,9 @@ def maybe_convert_objects(ndarray[object] objects, bint try_float=0,
                 seen_object = 1
                 # objects[i] = val.astype('O')
                 break
+        elif util.is_timedelta64_object(val):
+            seen_object = 1
+            break
         elif util.is_integer_object(val):
             seen_int = 1
             floats[i] = <float64_t> val

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -4277,16 +4277,14 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
 
     def test_reindex_pad(self):
 
-        s = Series(np.arange(10), np.arange(10))
+        s = Series(np.arange(10))
         s2 = s[::2]
 
         reindexed = s2.reindex(s.index, method='pad')
         reindexed2 = s2.reindex(s.index, method='ffill')
         assert_series_equal(reindexed, reindexed2)
 
-        # used platform int above, need to pass int explicitly here per #1219
-        expected = Series([0, 0, 2, 2, 4, 4, 6, 6, 8, 8], dtype=int,
-                          index=np.arange(10))
+        expected = Series([0, 0, 2, 2, 4, 4, 6, 6, 8, 8], index=np.arange(10))
         assert_series_equal(reindexed, expected)
 
         # GH4604
@@ -4696,7 +4694,7 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         assert_series_equal(s, ser)
 
     def test_replace_mixed_types(self):
-        s = Series(np.arange(5))
+        s = Series(np.arange(5),dtype='int64')
 
         def check_replace(to_rep, val, expected):
             sc = s.copy()

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -2445,6 +2445,38 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         expected[0] = np.nan
         assert_series_equal(result,expected)
 
+        # bfill
+        td[2] = np.nan
+        result = td.bfill()
+        expected = td.fillna(0)
+        expected[2] = timedelta(days=1,seconds=9*3600+60+1)
+        assert_series_equal(result,expected)
+
+    def test_datetime64_fillna(self):
+
+        s = Series([Timestamp('20130101'),Timestamp('20130101'),Timestamp('20130102'),Timestamp('20130103 9:01:01')])
+        s[2] = np.nan
+
+        # reg fillna
+        result = s.fillna(Timestamp('20130104'))
+        expected = Series([Timestamp('20130101'),Timestamp('20130101'),Timestamp('20130104'),Timestamp('20130103 9:01:01')])
+        assert_series_equal(result,expected)
+
+        from pandas import tslib
+        result = s.fillna(tslib.NaT)
+        expected = s
+        assert_series_equal(result,expected)
+
+        # ffill
+        result = s.ffill()
+        expected = Series([Timestamp('20130101'),Timestamp('20130101'),Timestamp('20130101'),Timestamp('20130103 9:01:01')])
+        assert_series_equal(result,expected)
+
+        # bfill
+        result = s.bfill()
+        expected = Series([Timestamp('20130101'),Timestamp('20130101'),Timestamp('20130103 9:01:01'),Timestamp('20130103 9:01:01')])
+        assert_series_equal(result,expected)
+
     def test_sub_of_datetime_from_TimeSeries(self):
         from pandas.core import common as com
         from datetime import datetime


### PR DESCRIPTION
closes #3371
- ENH: GH3371 support timedelta fillna
- BUG: add support for datetime64 ffill/bfill
- INT: add TimeDeltaBlock support in internals

```
In [3]: s = Series([Timestamp('20130101'),Timestamp('20130101'),
                  Timestamp('20130102'),Timestamp('20130103 9:01:01')])

In [4]: td = s.diff()

In [5]: td
Out[5]: 
0                NaT
1           00:00:00
2   1 days, 00:00:00
3   1 days, 09:01:01
dtype: timedelta64[ns]

In [6]: td.fillna(0)
Out[6]: 
0           00:00:00
1           00:00:00
2   1 days, 00:00:00
3   1 days, 09:01:01
dtype: timedelta64[ns]

In [7]: from datetime import timedelta

In [8]: td.fillna(timedelta(days=3,seconds=5))
Out[8]: 
0   3 days, 00:00:05
1           00:00:00
2   1 days, 00:00:00
3   1 days, 09:01:01
dtype: timedelta64[ns]
```

ffill

```
In [9]: td[2] = np.nan

In [10]: td
Out[10]: 
0                NaT
1           00:00:00
2                NaT
3   1 days, 09:01:01
dtype: timedelta64[ns]

In [11]: td.ffill()
Out[11]: 
0                NaT
1           00:00:00
2           00:00:00
3   1 days, 09:01:01
dtype: timedelta64[ns]
```
