### PR TITLE
ENH: Ability to tz localize when index is implicility in tz

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -868,3 +868,149 @@ Serialization / IO / Conversion
    Panel.to_frame
    Panel.to_clipboard
 
+.. currentmodule:: pandas.core.index
+
+.. _api.index
+
+Index
+-----
+
+**Many of these methods or variants thereof are available on the objects that contain an index (Series/Dataframe)
+and those should most likely be used before calling these methods directly.**
+
+   * **values**
+Modifying and Computations
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autosummary::
+   :toctree: generated/
+
+   Index.copy
+   Index.delete
+   Index.diff
+   Index.drop
+   Index.equals
+   Index.identical
+   Index.insert
+   Index.order
+   Index.reindex
+   Index.repeat
+   Index.set_names
+   Index.unique
+
+Conversion
+~~~~~~~~~~
+.. autosummary::
+   :toctree: generated/
+
+   Index.astype
+   Index.tolist
+   Index.to_datetime
+   Index.to_series
+
+Sorting
+~~~~~~~
+.. autosummary::
+   :toctree: generated/
+
+   Index.argsort
+   Index.order
+   Index.sort
+
+Time-specific operations
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. autosummary::
+   :toctree: generated/
+
+   Index.shift
+
+Combining / joining / merging
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autosummary::
+   :toctree: generated/
+
+   Index.append
+   Index.intersection
+   Index.join
+   Index.union
+
+Selecting
+~~~~~~~~~
+.. autosummary::
+   :toctree: generated/
+
+   Index.get_indexer
+   Index.get_indexer_non_unique
+   Index.get_level_values
+   Index.get_loc
+   Index.get_value
+   Index.isin
+   Index.slice_indexer
+   Index.slice_locs
+
+Properties
+~~~~~~~~~~
+.. autosummary::
+   :toctree: generated/
+
+   Index.is_monotonic
+   Index.is_numeric
+
+.. currentmodule:: pandas.tseries.index
+
+.. _api.datetimeindex:
+
+DatetimeIndex
+-------------
+
+Time/Date Components
+~~~~~~~~~~~~~~~~~~~~
+  * **year**
+  * **month**
+  * **day**
+  * **hour**
+  * **minute**
+  * **second**
+  * **microsecond**
+  * **nanosecond**
+
+  * **weekofyear**
+  * **week**: Same as weekofyear
+  * **dayofweek**: (0=Monday, 6=Sunday)
+  * **weekday**: (0=Monday, 6=Sunday)
+  * **dayofyear** 
+  * **quarter**
+
+  * **date**: Returns date component of Timestamps
+  * **time**: Returns time component of Timestamps
+
+
+Selecting
+~~~~~~~~~
+.. autosummary::
+   :toctree: generated/
+
+   DatetimeIndex.indexer_at_time
+   DatetimeIndex.indexer_between_time
+   
+
+Time-specific operations
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. autosummary::
+   :toctree: generated/
+
+   DatetimeIndex.normalize
+   DatetimeIndex.snap
+   DatetimeIndex.tz_convert
+   DatetimeIndex.tz_localize
+
+
+Conversion
+~~~~~~~~~~
+.. autosummary::
+   :toctree: generated/
+
+   DatetimeIndex.to_datetime
+   DatetimeIndex.to_period
+   DatetimeIndex.to_pydatetime
+
+

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -160,6 +160,9 @@ Improvements to existing features
     :issue:`4998`)
   - ``to_dict`` now takes ``records`` as a possible outtype.  Returns an array
     of column-keyed dictionaries. (:issue:`4936`)
+  - ``tz_localize`` can infer a fall daylight savings transition based on the 
+    structure of unlocalized data (:issue:`4230`)
+  - DatetimeIndex is now in the API documentation
 
 API Changes
 ~~~~~~~~~~~

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -1108,6 +1108,20 @@ TimeSeries, aligning the data on the UTC timestamps:
 
 .. _timeseries.timedeltas:
 
+In some cases, localize cannot determine the DST and non-DST hours when there are
+duplicates.  This often happens when reading files that simply duplicate the hours.
+The infer_dst argument in tz_localize will attempt
+to determine the right offset.
+
+.. ipython:: python
+
+   rng_hourly = DatetimeIndex(['11/06/2011 00:00', '11/06/2011 01:00', 
+                               '11/06/2011 01:00', '11/06/2011 02:00', 
+                               '11/06/2011 03:00'])
+   rng_hourly.tz_localize('US/Eastern')
+   rng_hourly_eastern = rng_hourly.tz_localize('US/Eastern', infer_dst=True)
+   rng_hourly_eastern.values
+
 Time Deltas
 -----------
 

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -8,7 +8,7 @@ enhancements along with a large number of bug fixes.
 
 .. warning::
 
-   In 0.13.0 ``Series`` has internaly been refactored to no longer sub-class ``ndarray``
+   In 0.13.0 ``Series`` has internally been refactored to no longer sub-class ``ndarray``
    but instead subclass ``NDFrame``, similarly to the rest of the pandas containers. This should be
    a transparent change with only very limited API implications. See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
 
@@ -480,6 +480,10 @@ Enhancements
          dfi[mask.any(1)]
 
       :ref:`See the docs<indexing.basics.indexing_isin>` for more.
+
+  - ``tz_localize`` can infer a fall daylight savings transition based on the structure
+    of the unlocalized data (:issue:`4230`), see :ref:`here<timeseries.timezone>`
+  - DatetimeIndex is now in the API documentation, see :ref:`here<api.datetimeindex>`
 
 .. _whatsnew_0130.experimental:
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2752,7 +2752,7 @@ class NDFrame(PandasObject):
 
         return new_obj
 
-    def tz_localize(self, tz, axis=0, copy=True):
+    def tz_localize(self, tz, axis=0, copy=True, infer_dst=False):
         """
         Localize tz-naive TimeSeries to target time zone
 
@@ -2761,6 +2761,8 @@ class NDFrame(PandasObject):
         tz : string or pytz.timezone object
         copy : boolean, default True
             Also make a copy of the underlying data
+        infer_dst : boolean, default False
+            Attempt to infer fall dst-transition times based on order
 
         Returns
         -------
@@ -2778,7 +2780,7 @@ class NDFrame(PandasObject):
             new_data = new_data.copy()
 
         new_obj = self._constructor(new_data)
-        new_ax = ax.tz_localize(tz)
+        new_ax = ax.tz_localize(tz, infer_dst=infer_dst)
 
         if axis == 0:
             new_obj._set_axis(1, new_ax)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2331,7 +2331,7 @@ class Series(generic.NDFrame):
 
         return self._constructor(new_values, index=new_index, name=self.name)
 
-    def tz_localize(self, tz, copy=True):
+    def tz_localize(self, tz, copy=True, infer_dst=False):
         """
         Localize tz-naive TimeSeries to target time zone
         Entries will retain their "naive" value but will be annotated as
@@ -2345,6 +2345,8 @@ class Series(generic.NDFrame):
         tz : string or pytz.timezone object
         copy : boolean, default True
             Also make a copy of the underlying data
+        infer_dst : boolean, default False
+            Attempt to infer fall dst-transition hours based on order
 
         Returns
         -------
@@ -2358,7 +2360,7 @@ class Series(generic.NDFrame):
 
             new_index = DatetimeIndex([], tz=tz)
         else:
-            new_index = self.index.tz_localize(tz)
+            new_index = self.index.tz_localize(tz, infer_dst=infer_dst)
 
         new_values = self.values
         if copy:

--- a/vb_suite/timeseries.py
+++ b/vb_suite/timeseries.py
@@ -225,3 +225,21 @@ index = rng.repeat(10)
 
 datetimeindex_unique = Benchmark('index.unique()', setup,
                                  start_date=datetime(2012, 7, 1))
+
+# tz_localize with infer argument.  This is an attempt to emulate the results
+# of read_csv with duplicated data.  Not passing infer_dst will fail
+setup = common_setup + """
+dst_rng = date_range('10/29/2000 1:00:00', 
+                     '10/29/2000 1:59:59', freq='S')
+index = date_range('10/29/2000', '10/29/2000 00:59:59', freq='S')
+index = index.append(dst_rng)
+index = index.append(dst_rng)
+index = index.append(date_range('10/29/2000 2:00:00', 
+                                '10/29/2000 3:00:00', freq='S'))
+"""
+
+datetimeindex_infer_dst = \
+Benchmark('index.tz_localize("US/Eastern", infer_dst=True)',
+          setup, start_date=datetime(2013, 9, 30))
+
+


### PR DESCRIPTION
Fix to issue #4230 which allows to localize an index which is
implicitly in a tz (e.g., reading from a file) by passing imply_dst to
tz_localize.
