### PR TITLE
BUG: (GH4708) A zero length series written to HDF cannot be read back.

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -209,6 +209,7 @@ API Changes
 
   - ``HDFStore``
 
+    - A zero length series written to HDF cannot be read back. (:issue:`4708`)
     - ``append_to_multiple`` automatically synchronizes writing rows to multiple
       tables and adds a ``dropna`` kwarg (:issue:`4698`)
     - handle a passed ``Series`` in table format (:issue:`4330`)

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -2358,6 +2358,11 @@ class TestHDFStore(unittest.TestCase):
         self._check_roundtrip(df1, tm.assert_frame_equal)
         self._check_roundtrip(df2, tm.assert_frame_equal)
 
+    def test_empty_series(self):
+        for dtype in [np.int64, np.float64, np.object, 'm8[ns]', 'M8[ns]']:
+            s = Series(dtype=dtype)
+            self._check_roundtrip(s, tm.assert_series_equal)
+
     def test_can_serialize_dates(self):
 
         rng = [x.date() for x in bdate_range('1/1/2000', '1/30/2000')]


### PR DESCRIPTION
closes #4708 by spotting when the sentinel single value has been written. This was not being done for the index which resulted in a values/index length miss-match. 
