### PR TITLE
CLN: Remove unused and undocumented kind keyword from read_excel

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -203,6 +203,7 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
 - Refactor of ``_get_numeric_data/_get_bool_data`` to core/generic.py, allowing Series/Panel functionaility
 - Refactor of Series arithmetic with time-like objects (datetime/timedelta/time
   etc.) into a separate, cleaned up wrapper class. (:issue:`4613`)
+- Remove undocumented/unused ``kind`` keyword argument from ``read_excel``, and ``ExcelFile``. (:issue:`4713`, :issue:`4712`)
 
 **Experimental Features**
 

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -13,9 +13,10 @@ from pandas.tseries.period import Period
 from pandas import json
 from pandas.compat import map, zip, reduce, range, lrange
 import pandas.compat as compat
+from warnings import warn
 
 
-def read_excel(path_or_buf, sheetname, kind=None, **kwds):
+def read_excel(path_or_buf, sheetname, **kwds):
     """Read an Excel table into a pandas DataFrame
 
     Parameters
@@ -50,8 +51,11 @@ def read_excel(path_or_buf, sheetname, kind=None, **kwds):
     parsed : DataFrame
         DataFrame from the passed in Excel file
     """
-    return ExcelFile(path_or_buf, kind=kind).parse(sheetname=sheetname,
-                                                   kind=kind, **kwds)
+    if 'kind' in kwds:
+        kwds.pop('kind')
+        warn("kind keyword is no longer supported in read_excel and may be "
+             "removed in a future version", FutureWarning)
+    return ExcelFile(path_or_buf).parse(sheetname=sheetname, **kwds)
 
 
 class ExcelFile(object):
@@ -64,8 +68,7 @@ class ExcelFile(object):
     path : string or file-like object
         Path to xls or xlsx file
     """
-    def __init__(self, path_or_buf, kind=None, **kwds):
-        self.kind = kind
+    def __init__(self, path_or_buf, **kwds):
 
         import xlrd  # throw an ImportError if we need to
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1979,6 +1979,6 @@ class ExcelWriter(excel.ExcelWriter):
         super(ExcelWriter, self).__init__(path)
 
 class ExcelFile(excel.ExcelFile):
-    def __init__(self, path_or_buf, kind=None, **kwds):
+    def __init__(self, path_or_buf, **kwds):
         warn("ExcelFile can now be imported from: pandas.io.excel", FutureWarning)
-        super(ExcelFile, self).__init__(path_or_buf, kind=kind, **kwds)
+        super(ExcelFile, self).__init__(path_or_buf, **kwds)


### PR DESCRIPTION
Pops kwarg and warns if you pass it (rather than passing on).

Fixes #4712
