### PR TITLE
API: change nomeclature in HDFStore to use format=fixed(f) | table(t)

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1831,7 +1831,11 @@ Table Format
 format. Conceptually a ``table`` is shaped very much like a DataFrame,
 with rows and columns. A ``table`` may be appended to in the same or
 other sessions.  In addition, delete & query type operations are
-supported. This format is specified by ``format='table'`` or ``format='t'`` to ``append`` or ``put`` or ``to_hdf``
+supported. This format is specified by ``format='table'`` or ``format='t'``
+to ``append`` or ``put`` or ``to_hdf``
+
+This format can be set as an option as well ``pd.set_option('io.hdf.default_format','table')`` to
+enable ``put/append/to_hdf`` to by default store in the ``table`` format.
 
 .. ipython:: python
    :suppress:

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1794,27 +1794,31 @@ similar to how ``read_csv`` and ``to_csv`` work. (new in 0.11.0)
 
    os.remove('store_tl.h5')
 
-.. _io.hdf5-storer:
+.. _io.hdf5-fixed:
 
-Storer Format
-~~~~~~~~~~~~~
+Fixed Format
+~~~~~~~~~~~~
+
+.. note::
+
+   This was prior to 0.13.0 the ``Storer`` format.
 
 The examples above show storing using ``put``, which write the HDF5 to ``PyTables`` in a fixed array format, called
-the ``storer`` format. These types of stores are are **not** appendable once written (though you can simply
+the ``fixed`` format. These types of stores are are **not** appendable once written (though you can simply
 remove them and rewrite). Nor are they **queryable**; they must be
 retrieved in their entirety. These offer very fast writing and slightly faster reading than ``table`` stores.
-This format is specified by default when using ``put`` or by ``fmt='s'``
+This format is specified by default when using ``put`` or ``to_hdf`` or by ``format='fixed'`` or ``format='f'``
 
 .. warning::
 
-   A ``storer`` format will raise a ``TypeError`` if you try to retrieve using a ``where`` .
+   A ``fixed`` format will raise a ``TypeError`` if you try to retrieve using a ``where`` .
 
    .. code-block:: python
 
-       DataFrame(randn(10,2)).to_hdf('test_storer.h5','df')
+       DataFrame(randn(10,2)).to_hdf('test_fixed.h5','df')
 
-       pd.read_hdf('test_storer.h5','df',where='index>5')
-       TypeError: cannot pass a where specification when reading a non-table
+       pd.read_hdf('test_fixed.h5','df',where='index>5')
+       TypeError: cannot pass a where specification when reading a fixed format.
                   this store must be selected in its entirety
 
 
@@ -1827,7 +1831,7 @@ Table Format
 format. Conceptually a ``table`` is shaped very much like a DataFrame,
 with rows and columns. A ``table`` may be appended to in the same or
 other sessions.  In addition, delete & query type operations are
-supported. This format is specified by ``fmt='t'`` to ``append`` or ``put``.
+supported. This format is specified by ``format='table'`` or ``format='t'`` to ``append`` or ``put`` or ``to_hdf``
 
 .. ipython:: python
    :suppress:
@@ -1854,7 +1858,7 @@ supported. This format is specified by ``fmt='t'`` to ``append`` or ``put``.
 
 .. note::
 
-   You can also create a ``table`` by passing ``fmt='t'`` to a ``put`` operation.
+   You can also create a ``table`` by passing ``format='table'`` or ``format='t'`` to a ``put`` operation.
 
 .. _io.hdf5-keys:
 
@@ -2363,7 +2367,7 @@ Starting in 0.11, passing a ``min_itemsize`` dict will cause all passed columns 
 External Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~
 
-``HDFStore`` write storer objects in specific formats suitable for
+``HDFStore`` write ``table`` format objects in specific formats suitable for
 producing loss-less roundtrips to pandas objects. For external
 compatibility, ``HDFStore`` can read native ``PyTables`` format
 tables. It is possible to write an ``HDFStore`` object that can easily

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -108,10 +108,11 @@ pandas 0.13
     - removed the ``warn`` argument from ``open``. Instead a ``PossibleDataLossError`` exception will
       be raised if you try to use ``mode='w'`` with an OPEN file handle (:issue:`4367`)
     - allow a passed locations array or mask as a ``where`` condition (:issue:`4467`)
-    - the ``fmt`` keyword now replaces the ``table`` keyword; allowed values are ``s|t``
     - add the keyword ``dropna=True`` to ``append`` to change whether ALL nan rows are not written
       to the store (default is ``True``, ALL nan rows are NOT written), also settable
       via the option ``io.hdf.dropna_table`` (:issue:`4625`)
+    - the ``format`` keyword now replaces the ``table`` keyword; allowed values are ``fixed(f)|table(t)``
+      the ``Storer`` format has been renamed to ``Fixed``
   - ``JSON``
 
     - added ``date_unit`` parameter to specify resolution of timestamps. Options

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -79,17 +79,17 @@ API changes
     - allow a passed locations array or mask as a ``where`` condition (:issue:`4467`).
       See :ref:`here<io.hdf5-where_mask>` for an example.
 
-    - the ``fmt`` keyword now replaces the ``table`` keyword; allowed values are ``s|t``
-      the same defaults as prior < 0.13.0 remain, e.g. ``put`` implies 's' (Storer) format
-      and ``append`` imples 't' (Table) format
+    - the ``format`` keyword now replaces the ``table`` keyword; allowed values are ``fixed(f)`` or ``table(t)``
+      the same defaults as prior < 0.13.0 remain, e.g. ``put`` implies 'fixed` or 'f' (Fixed) format
+      and ``append`` imples 'table' or 't' (Table) format
 
       .. ipython:: python
 
          path = 'test.h5'
          df = DataFrame(randn(10,2))
-         df.to_hdf(path,'df_table',fmt='t')
+         df.to_hdf(path,'df_table',format='table')
          df.to_hdf(path,'df_table2',append=True)
-         df.to_hdf(path,'df_storer')
+         df.to_hdf(path,'df_fixed')
          with get_store(path) as store:
             print store
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -678,6 +678,15 @@ class NDFrame(PandasObject):
               and if the file does not exist it is created.
           ``'r+'``
               It is similar to ``'a'``, but the file must already exist.
+        format   : 'fixed(f)|table(t)', default is 'fixed'
+            fixed(f) : Fixed format
+                       Fast writing/reading. Not-appendable, nor searchable
+            table(t) : Table format
+                       Write as a PyTables Table structure which may perform worse but
+                       allow more flexible operations like searching / selecting subsets
+                       of the data
+        append   : boolean, default False
+            For Table formats, append the input data to the existing
         complevel : int, 1-9, default 0
             If a complib is specified compression will be applied
             where possible

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -150,38 +150,38 @@ class TestHDFStore(unittest.TestCase):
     def test_api(self):
 
         # GH4584
-        # API issue when to_hdf doesn't acdept append AND table args
+        # API issue when to_hdf doesn't acdept append AND format args
         with tm.ensure_clean(self.path) as path:
 
             df = tm.makeDataFrame()
-            df.iloc[:10].to_hdf(path,'df',append=True,table=True)
-            df.iloc[10:].to_hdf(path,'df',append=True,table=True)
+            df.iloc[:10].to_hdf(path,'df',append=True,format='table')
+            df.iloc[10:].to_hdf(path,'df',append=True,format='table')
             assert_frame_equal(read_hdf(path,'df'),df)
 
             # append to False
-            df.iloc[:10].to_hdf(path,'df',append=False,table=True)
-            df.iloc[10:].to_hdf(path,'df',append=True,table=True)
+            df.iloc[:10].to_hdf(path,'df',append=False,format='table')
+            df.iloc[10:].to_hdf(path,'df',append=True,format='table')
             assert_frame_equal(read_hdf(path,'df'),df)
 
         with tm.ensure_clean(self.path) as path:
 
             df = tm.makeDataFrame()
             df.iloc[:10].to_hdf(path,'df',append=True)
-            df.iloc[10:].to_hdf(path,'df',append=True,table='t')
+            df.iloc[10:].to_hdf(path,'df',append=True,format='table')
             assert_frame_equal(read_hdf(path,'df'),df)
 
             # append to False
-            df.iloc[:10].to_hdf(path,'df',append=False,table='t')
+            df.iloc[:10].to_hdf(path,'df',append=False,format='table')
             df.iloc[10:].to_hdf(path,'df',append=True)
             assert_frame_equal(read_hdf(path,'df'),df)
 
         with tm.ensure_clean(self.path) as path:
 
             df = tm.makeDataFrame()
-            df.to_hdf(path,'df',append=False,table=False)
+            df.to_hdf(path,'df',append=False,format='fixed')
             assert_frame_equal(read_hdf(path,'df'),df)
 
-            df.to_hdf(path,'df',append=False,fmt='s')
+            df.to_hdf(path,'df',append=False,format='f')
             assert_frame_equal(read_hdf(path,'df'),df)
 
             df.to_hdf(path,'df',append=False)
@@ -193,34 +193,34 @@ class TestHDFStore(unittest.TestCase):
         with ensure_clean(self.path) as store:
 
             df = tm.makeDataFrame()
-            store.append('df',df.iloc[:10],append=True,table=True)
-            store.append('df',df.iloc[10:],append=True,table=True)
+            store.append('df',df.iloc[:10],append=True,format='table')
+            store.append('df',df.iloc[10:],append=True,format='table')
             assert_frame_equal(read_hdf(path,'df'),df)
 
             # append to False
-            store.append('df',df.iloc[:10],append=False,table=True)
-            store.append('df',df.iloc[10:],append=True,table=True)
+            store.append('df',df.iloc[:10],append=False,format='table')
+            store.append('df',df.iloc[10:],append=True,format='table')
             assert_frame_equal(read_hdf(path,'df'),df)
 
             # formats
-            store.append('df',df.iloc[:10],append=False,fmt='t')
-            store.append('df',df.iloc[10:],append=True,fmt='t')
+            store.append('df',df.iloc[:10],append=False,format='table')
+            store.append('df',df.iloc[10:],append=True,format='table')
             assert_frame_equal(read_hdf(path,'df'),df)
 
             _maybe_remove(store,'df')
-            store.append('df',df.iloc[:10],append=False,fmt='t')
-            store.append('df',df.iloc[10:],append=True,fmt=None)
+            store.append('df',df.iloc[:10],append=False,format='table')
+            store.append('df',df.iloc[10:],append=True,format=None)
             assert_frame_equal(read_hdf(path,'df'),df)
 
         with tm.ensure_clean(self.path) as path:
 
             # invalid
             df = tm.makeDataFrame()
-            self.assertRaises(ValueError, df.to_hdf, path,'df',append=True,fmt='s')
+            self.assertRaises(ValueError, df.to_hdf, path,'df',append=True,format='f')
+            self.assertRaises(ValueError, df.to_hdf, path,'df',append=True,format='fixed')
 
-            self.assertRaises(TypeError, df.to_hdf, path,'df',append=True,fmt='foo')
-            self.assertRaises(TypeError, df.to_hdf, path,'df',append=False,fmt='bar')
-            self.assertRaises(TypeError, df.to_hdf, path,'df',format='s')
+            self.assertRaises(TypeError, df.to_hdf, path,'df',append=True,format='foo')
+            self.assertRaises(TypeError, df.to_hdf, path,'df',append=False,format='bar')
 
     def test_keys(self):
 
@@ -466,7 +466,7 @@ class TestHDFStore(unittest.TestCase):
             store['foo/bar/bah'] = df[:10]
             store['foo'] = df[:10]
             store['/foo'] = df[:10]
-            store.put('c', df[:10], table=True)
+            store.put('c', df[:10], format='table')
 
             # not OK, not a table
             self.assertRaises(
@@ -481,7 +481,7 @@ class TestHDFStore(unittest.TestCase):
             self.assertRaises(ValueError, store.put, 'c', df[10:], append=True)
 
             # overwrite table
-            store.put('c', df[:10], table=True, append=False)
+            store.put('c', df[:10], format='table', append=False)
             tm.assert_frame_equal(df[:10], store['c'])
 
     def test_put_string_index(self):
@@ -514,12 +514,12 @@ class TestHDFStore(unittest.TestCase):
         with ensure_clean(self.path) as store:
             df = tm.makeTimeDataFrame()
 
-            store.put('c', df, table=True, complib='zlib')
+            store.put('c', df, format='table', complib='zlib')
             tm.assert_frame_equal(store['c'], df)
 
-            # can't compress if table=False
+            # can't compress if format='fixed'
             self.assertRaises(ValueError, store.put, 'b', df,
-                              table=False, complib='zlib')
+                              format='fixed', complib='zlib')
 
     def test_put_compression_blosc(self):
         tm.skip_if_no_package('tables', '2.2', app='blosc support')
@@ -527,11 +527,11 @@ class TestHDFStore(unittest.TestCase):
 
         with ensure_clean(self.path) as store:
 
-            # can't compress if table=False
+            # can't compress if format='fixed'
             self.assertRaises(ValueError, store.put, 'b', df,
-                              table=False, complib='blosc')
+                              format='fixed', complib='blosc')
 
-            store.put('c', df, table=True, complib='blosc')
+            store.put('c', df, format='table', complib='blosc')
             tm.assert_frame_equal(store['c'], df)
 
     def test_put_integer(self):
@@ -577,7 +577,7 @@ class TestHDFStore(unittest.TestCase):
             tm.assert_frame_equal(store['df1'], df)
 
             _maybe_remove(store, 'df2')
-            store.put('df2', df[:10], table=True)
+            store.put('df2', df[:10], format='table')
             store.append('df2', df[10:])
             tm.assert_frame_equal(store['df2'], df)
 
@@ -1376,7 +1376,7 @@ class TestHDFStore(unittest.TestCase):
         wp2 = wp.ix[['ItemC', 'ItemB', 'ItemA'], 10:, :]
 
         with ensure_clean(self.path) as store:
-            store.put('panel', wp1, table=True)
+            store.put('panel', wp1, format='table')
             self.assertRaises(ValueError, store.put, 'panel', wp2,
                               append=True)
 
@@ -1400,7 +1400,7 @@ class TestHDFStore(unittest.TestCase):
             tm.assert_frame_equal(result,expected)
 
         with tm.ensure_clean('test.hdf') as path:
-            df.to_hdf(path,'df',table=True)
+            df.to_hdf(path,'df',format='table')
             result = read_hdf(path,'df',columns=['A','B'])
             expected = df.reindex(columns=['A','B'])
             tm.assert_frame_equal(result,expected)
@@ -1541,9 +1541,9 @@ class TestHDFStore(unittest.TestCase):
                         index=date_range('1/1/2000', periods=3))
 
         with ensure_clean(self.path) as store:
-            store.put('frame', df1, table=True)
+            store.put('frame', df1, format='table')
             self.assertRaises(TypeError, store.put, 'frame', df2,
-                              table=True, append=True)
+                              format='table', append=True)
 
     def test_table_values_dtypes_roundtrip(self):
 
@@ -1777,7 +1777,7 @@ class TestHDFStore(unittest.TestCase):
             # try to remove non-table (with crit)
             # non-table ok (where = None)
             wp = tm.makePanel()
-            store.put('wp', wp, fmt='t')
+            store.put('wp', wp, format='t')
             store.remove('wp', [('minor_axis', ['A', 'D'])])
             rs = store.select('wp')
             expected = wp.reindex(minor_axis=['B', 'C'])
@@ -1785,7 +1785,7 @@ class TestHDFStore(unittest.TestCase):
 
             # empty where
             _maybe_remove(store, 'wp')
-            store.put('wp', wp, fmt='t')
+            store.put('wp', wp, format='table')
 
             # deleted number (entire table)
             n = store.remove('wp', [])
@@ -1793,12 +1793,12 @@ class TestHDFStore(unittest.TestCase):
 
             # non - empty where
             _maybe_remove(store, 'wp')
-            store.put('wp', wp, fmt='t')
+            store.put('wp', wp, format='table')
             self.assertRaises(ValueError, store.remove,
                               'wp', ['foo'])
 
             # selectin non-table with a where
-            # store.put('wp2', wp, fmt='s')
+            # store.put('wp2', wp, format='f')
             # self.assertRaises(ValueError, store.remove,
             #                  'wp2', [('column', ['A', 'D'])])
 
@@ -1811,7 +1811,7 @@ class TestHDFStore(unittest.TestCase):
             # group row removal
             date4 = wp.major_axis.take([0, 1, 2, 4, 5, 6, 8, 9, 10])
             crit4 = Term('major_axis', date4)
-            store.put('wp3', wp, fmt='t')
+            store.put('wp3', wp, format='table')
             n = store.remove('wp3', where=[crit4])
             assert(n == 36)
             result = store.select('wp3')
@@ -1819,7 +1819,7 @@ class TestHDFStore(unittest.TestCase):
             assert_panel_equal(result, expected)
 
             # upper half
-            store.put('wp', wp, fmt='t')
+            store.put('wp', wp, format='table')
             date = wp.major_axis[len(wp.major_axis) // 2]
 
             crit1 = Term('major_axis', '>', date)
@@ -1836,7 +1836,7 @@ class TestHDFStore(unittest.TestCase):
             assert_panel_equal(result, expected)
 
             # individual row elements
-            store.put('wp2', wp, fmt='t')
+            store.put('wp2', wp, format='table')
 
             date1 = wp.major_axis[1:3]
             crit1 = Term('major_axis', date1)
@@ -1862,7 +1862,7 @@ class TestHDFStore(unittest.TestCase):
             assert_panel_equal(result, expected)
 
             # corners
-            store.put('wp4', wp, fmt='t')
+            store.put('wp4', wp, format='table')
             n = store.remove(
                 'wp4', where=[Term('major_axis', '>', wp.major_axis[-1])])
             result = store.select('wp4')
@@ -1874,8 +1874,8 @@ class TestHDFStore(unittest.TestCase):
 
             wp = tm.makePanel()
             p4d = tm.makePanel4D()
-            store.put('wp', wp, fmt='t')
-            store.put('p4d', p4d, fmt='t')
+            store.put('wp', wp, format='table')
+            store.put('p4d', p4d, format='table')
 
             # some invalid terms
             terms = [
@@ -2230,8 +2230,8 @@ class TestHDFStore(unittest.TestCase):
     def test_wide_table_dups(self):
         wp = tm.makePanel()
         with ensure_clean(self.path) as store:
-            store.put('panel', wp, fmt='t')
-            store.put('panel', wp, fmt='t', append=True)
+            store.put('panel', wp, format='table')
+            store.put('panel', wp, format='table', append=True)
 
             with tm.assert_produces_warning(expected_warning=DuplicateWarning):
                 recons = store['panel']
@@ -2297,7 +2297,7 @@ class TestHDFStore(unittest.TestCase):
 
             # put/select ok
             _maybe_remove(store, 'wp')
-            store.put('wp', wp, fmt='t')
+            store.put('wp', wp, format='table')
             store.select('wp')
 
             # non-table ok (where = None)
@@ -2483,7 +2483,7 @@ class TestHDFStore(unittest.TestCase):
         with tm.ensure_clean(self.path) as path:
 
             df = tm.makeTimeDataFrame(500)
-            df.to_hdf(path,'df',fmt='t')
+            df.to_hdf(path,'df',format='table')
 
             results = []
             for x in read_hdf(path,'df',chunksize=100):
@@ -2534,7 +2534,7 @@ class TestHDFStore(unittest.TestCase):
 
         with ensure_clean(self.path) as store:
             _maybe_remove(store,'data')
-            store.put('data', df, fmt='t')
+            store.put('data', df, format='table')
 
             result = store.get('data')
             tm.assert_frame_equal(df,result)
@@ -2592,7 +2592,7 @@ class TestHDFStore(unittest.TestCase):
         wp = tm.makePanel()
 
         with ensure_clean(self.path) as store:
-            store.put('wp', wp, fmt='t')
+            store.put('wp', wp, format='table')
             date = wp.major_axis[len(wp.major_axis) // 2]
 
             crit1 = ('major_axis', '>=', date)
@@ -2612,7 +2612,7 @@ class TestHDFStore(unittest.TestCase):
         df = tm.makeTimeDataFrame()
 
         with ensure_clean(self.path) as store:
-            store.put('frame', df,fmt='t')
+            store.put('frame', df,format='table')
             date = df.index[len(df) // 2]
 
             crit1 = ('index', '>=', date)
@@ -2920,7 +2920,7 @@ class TestHDFStore(unittest.TestCase):
         df.columns = ['%.3d' % c for c in df.columns]
 
         with ensure_clean(self.path) as store:
-            store.put('frame', df, fmt='t')
+            store.put('frame', df, format='table')
 
             crit = Term('columns', df.columns[:75])
             result = store.select('frame', [crit])
@@ -2958,7 +2958,7 @@ class TestHDFStore(unittest.TestCase):
             options['complib'] = _default_compressor
 
         with ensure_clean(self.path, 'w', **options) as store:
-            store.put('obj', obj, fmt='t')
+            store.put('obj', obj, format='table')
             retrieved = store['obj']
             # sorted_obj = _test_sort(obj)
             comparator(retrieved, obj)
@@ -2969,7 +2969,7 @@ class TestHDFStore(unittest.TestCase):
         with tm.ensure_clean(self.path) as path:
 
             df = tm.makeDataFrame()
-            df.to_hdf(path,'df',mode='w',fmt='t')
+            df.to_hdf(path,'df',mode='w',format='table')
 
             # single
             store = HDFStore(path)
@@ -3031,7 +3031,7 @@ class TestHDFStore(unittest.TestCase):
         with tm.ensure_clean(self.path) as path:
 
             df = tm.makeDataFrame()
-            df.to_hdf(path,'df',mode='w',fmt='t')
+            df.to_hdf(path,'df',mode='w',format='table')
 
             store = HDFStore(path)
             store.close()
@@ -3274,7 +3274,7 @@ class TestHDFStore(unittest.TestCase):
     #                   index=[np.arange(5).repeat(2),
     #                          np.tile(np.arange(2), 5)])
 
-    #    self.assertRaises(Exception, store.put, 'foo', df, fmt='t')
+    #    self.assertRaises(Exception, store.put, 'foo', df, format='table')
 
 
 def _test_sort(obj):

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -222,6 +222,49 @@ class TestHDFStore(unittest.TestCase):
             self.assertRaises(TypeError, df.to_hdf, path,'df',append=True,format='foo')
             self.assertRaises(TypeError, df.to_hdf, path,'df',append=False,format='bar')
 
+
+    def test_api_default_format(self):
+
+        # default_format option
+        with ensure_clean(self.path) as store:
+            df = tm.makeDataFrame()
+
+            pandas.set_option('io.hdf.default_format','fixed')
+            _maybe_remove(store,'df')
+            store.put('df',df)
+            self.assert_(not store.get_storer('df').is_table)
+            self.assertRaises(ValueError, store.append, 'df2',df)
+
+            pandas.set_option('io.hdf.default_format','table')
+            _maybe_remove(store,'df')
+            store.put('df',df)
+            self.assert_(store.get_storer('df').is_table)
+            _maybe_remove(store,'df2')
+            store.append('df2',df)
+            self.assert_(store.get_storer('df').is_table)
+
+            pandas.set_option('io.hdf.default_format',None)
+
+        with tm.ensure_clean(self.path) as path:
+
+            df = tm.makeDataFrame()
+
+            pandas.set_option('io.hdf.default_format','fixed')
+            df.to_hdf(path,'df')
+            with get_store(path) as store:
+                self.assert_(not store.get_storer('df').is_table)
+            self.assertRaises(ValueError, df.to_hdf, path,'df2', append=True)
+
+            pandas.set_option('io.hdf.default_format','table')
+            df.to_hdf(path,'df3')
+            with get_store(path) as store:
+                self.assert_(store.get_storer('df3').is_table)
+            df.to_hdf(path,'df4',append=True)
+            with get_store(path) as store:
+                self.assert_(store.get_storer('df4').is_table)
+
+            pandas.set_option('io.hdf.default_format',None)
+
     def test_keys(self):
 
         with ensure_clean(self.path) as store:


### PR DESCRIPTION
see #4645

Storer has been renamed to Fixed (and all docs changed)

added option: `io.hdf.default_format` to allow the overriding of the default format

format is now specified as: `format=` with a value of (`fixed(f)` or `table(t)`)

should be a bit more intuitve
