### PR TITLE
ENH: Better rename/set_names handling for Index

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -306,6 +306,8 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
   - Fix boolean comparison with a DataFrame on the lhs, and a list/tuple on the rhs (:issue:`4576`)
   - Fix error/dtype conversion with setitem of ``None`` on ``Series/DataFrame`` (:issue:`4667`)
   - Fix decoding based on a passed in non-default encoding in ``pd.read_stata`` (:issue:`4626`)
+  - Fix some inconsistencies with ``Index.rename`` and ``MultiIndex.rename``,
+    etc. (:issue:`4718`, :issue:`4628`)
 
 pandas 0.12
 ===========

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -114,7 +114,7 @@ class FrozenList(PandasObject, list):
     def _disabled(self, *args, **kwargs):
         """This method will not function because object is immutable."""
         raise TypeError("'%s' does not support mutable operations." %
-                        self.__class__)
+                        self.__class__.__name__)
 
     def __unicode__(self):
         from pandas.core.common import pprint_thing

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1783,7 +1783,7 @@ def is_re_compilable(obj):
 
 
 def is_list_like(arg):
-    return hasattr(arg, '__iter__') and not isinstance(arg, compat.string_types)
+    return hasattr(arg, '__iter__') and not isinstance(arg, compat.string_and_binary_types)
 
 
 def _is_sequence(x):

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -273,16 +273,33 @@ class Index(FrozenNDArray):
 
         Returns
         -------
-        new index (of same type and class...etc)
+        new index (of same type and class...etc) [if inplace, returns None]
         """
+        if not com.is_list_like(names):
+            raise TypeError("Must pass list-like as `names`.")
         if inplace:
             idx = self
         else:
             idx = self._shallow_copy()
         idx._set_names(names)
-        return idx
+        if not inplace:
+            return idx
 
     def rename(self, name, inplace=False):
+        """
+        Set new names on index. Defaults to returning new index.
+
+        Parameters
+        ----------
+        name : str or list
+            name to set
+        inplace : bool
+            if True, mutates in place
+
+        Returns
+        -------
+        new index (of same type and class...etc) [if inplace, returns None]
+        """
         return self.set_names([name], inplace=inplace)
 
     @property
@@ -1556,6 +1573,7 @@ class MultiIndex(Index):
     _levels = FrozenList()
     _labels = FrozenList()
     _comparables = ['names']
+    rename = Index.set_names
 
     def __new__(cls, levels=None, labels=None, sortorder=None, names=None,
                 copy=False):


### PR DESCRIPTION
Fixes #4628
- MultiIndex now responds correctly to `rename` (synonym for
  `set_names`)
- `set_names` checks that input is list like.
- Cleaner error message for immutable ops.
- Added in previously missing tests for MultiIndex immutable metadata.
- Altered `is_list_like` to check for binary_types as well.

For now, this is the behavior for Index.rename. It's simple and clear and lets existing code just work instead of dealing with typechecks:

``` python
In [2]: ind = Index(range(10))

In [3]: ind = ind.rename((u'A', u'B'))

In [4]: ind.name
Out[4]: (u'A', u'B')

In [5]: ind.names
Out[5]: FrozenList([(u'A', u'B')])
```
