### PR TITLE
BUG: Fix DataFrame.from_records w/ normal ndarray.

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -306,8 +306,8 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
   - Fix boolean comparison with a DataFrame on the lhs, and a list/tuple on the rhs (:issue:`4576`)
   - Fix error/dtype conversion with setitem of ``None`` on ``Series/DataFrame`` (:issue:`4667`)
   - Fix decoding based on a passed in non-default encoding in ``pd.read_stata`` (:issue:`4626`)
-  - Fix some inconsistencies with ``Index.rename`` and ``MultiIndex.rename``,
-    etc. (:issue:`4718`, :issue:`4628`)
+  - Fix some inconsistencies with ``Index.rename`` and ``MultiIndex.rename`` (:issue:`4718`, :issue:`4628`)
+  - Fix ``DataFrame.from_records`` with a plain-vanilla ``ndarray``. (:issue:`4727`)
 
 pandas 0.12
 ===========

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4876,7 +4876,9 @@ def _to_arrays(data, columns, coerce_float=False, dtype=None):
         return _list_of_series_to_arrays(data, columns,
                                          coerce_float=coerce_float,
                                          dtype=dtype)
-    elif isinstance(data, (np.ndarray, Series)):
+    elif (isinstance(data, (np.ndarray, Series))
+          and data.dtype.names is not None):
+
         columns = list(data.dtype.names)
         arrays = [data[k] for k in columns]
         return arrays, columns

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3468,12 +3468,15 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         indexed_frame = DataFrame.from_records(arr, index=index)
         self.assert_(np.array_equal(indexed_frame.index, index))
 
+        # without names, it should go to last ditch
+        arr2 = np.zeros((2,3))
+        tm.assert_frame_equal(DataFrame.from_records(arr2), DataFrame(arr2))
+
         # wrong length
         self.assertRaises(Exception, DataFrame.from_records, arr,
                           index=index[:-1])
 
         indexed_frame = DataFrame.from_records(arr, index='f1')
-        self.assertRaises(Exception, DataFrame.from_records, np.zeros((2, 3)))
 
         # what to do?
         records = indexed_frame.to_records()


### PR DESCRIPTION
I haven't looked at the `from_records` code before, which is why I'm spending all this time laying out a relatively minor change. Previously, was causing a TypeError about None not being iterable when arr.dtype.names was None. Now goes to 'last ditch' parsing instead.

This was the original test case (that dates back, in one form or another, to at least 2010), looked like this:

``` python
self.assertRaises(Exception, DataFrame.from_records, np.zeros((2, 3)))
```

Problem is that the actual Exception was a `TypeError: None is not iterable`-style exception, not something internal to the code.  I changed this so now an `ndarray` that isn't structured (i.e., has `arr.dtype.names is None`) is treated separately from the structured ndarrays (so it goes into the general case 'last ditch' verison).

Now it basically produces the same thing as passing the array to the DataFrame constructor:

``` python
arr2 = np.zeros((2,3))
tm.assert_frame_equal(DataFrame.from_records(arr2), DataFrame(arr2))
```
