### PR TITLE
ENH ohlc resample for DataFrame

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -56,6 +56,7 @@ pandas 0.13
   - Significant table writing performance improvements in ``HDFStore``
   - JSON date serialisation now performed in low-level C code.
   - Add ``drop_level`` argument to xs (:issue:`4180`)
+  - Can now resample a DataFrame with ohlc (:issue:`2320`)
   - ``Index.copy()`` and ``MultiIndex.copy()`` now accept keyword arguments to
     change attributes (i.e., ``names``, ``levels``, ``labels``)
     (:issue:`4039`)


### PR DESCRIPTION
closes #2320

Can use ohlc from DataFrame.

cc @jreback

Example:

```
In [24]: df = pd.DataFrame({'PRICE': {Timestamp('2011-01-06 10:59:05', tz=None): 24990,
  Timestamp('2011-01-06 12:43:33', tz=None): 25499,
  Timestamp('2011-01-06 12:54:09', tz=None): 25499},
 'VOLUME': {Timestamp('2011-01-06 10:59:05', tz=None): 1500000000,
  Timestamp('2011-01-06 12:43:33', tz=None): 5000000000,
  Timestamp('2011-01-06 12:54:09', tz=None): 100000000}})

In [25]: df.resample('H', how='ohlc')
Out[25]: 
                     PRICE                           VOLUME              \
                      open   high    low  close        open        high   
2011-01-06 10:00:00  24990  24990  24990  24990  1500000000  1500000000   
2011-01-06 11:00:00    NaN    NaN    NaN    NaN         NaN         NaN   
2011-01-06 12:00:00  25499  25499  25499  25499  5000000000  5000000000   


                            low       close  
2011-01-06 10:00:00  1500000000  1500000000  
2011-01-06 11:00:00         NaN         NaN  
2011-01-06 12:00:00   100000000   100000000 
```
