### PR TITLE
BUG: series replace should allow a single list

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -152,6 +152,8 @@ pandas 0.13
     passed a string (:issue:`4763`). Pass a ``list`` of one element (containing
     the string) instead.
   - Remove undocumented/unused ``kind`` keyword argument from ``read_excel``, and ``ExcelFile``. (:issue:`4713`, :issue:`4712`)
+  - The ``method`` argument of ``NDFrame.replace()`` is valid again, so that a
+    a list can be passed to ``to_replace`` (:issue:`4743`).
 
 **Internal Refactoring**
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1047,6 +1047,7 @@ _backfill_2d_datetime = _interp_wrapper(algos.backfill_2d_inplace_int64,
                                         np.int64)
 
 
+
 def pad_1d(values, limit=None, mask=None):
 
     dtype = values.dtype.name
@@ -1187,6 +1188,14 @@ def _consensus_name_attr(objs):
         if obj.name != name:
             return None
     return name
+
+
+_fill_methods = {'pad': pad_1d, 'backfill': backfill_1d}
+
+def _get_fill_func(method):
+    method = _clean_fill_method(method)
+    return _fill_methods[method]
+
 
 #----------------------------------------------------------------------
 # Lots of little utilities


### PR DESCRIPTION
Also reverts the `method` parameter of `NDFrame.replace()` deprecation

closes #4743
