### PR TITLE
BUG: Fix crash using to_csv with QUOTE_NONE

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -315,6 +315,7 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
   - Fix some inconsistencies with ``Index.rename`` and ``MultiIndex.rename``,
     etc. (:issue:`4718`, :issue:`4628`)
   - Bug in using ``iloc/loc`` with a cross-sectional and duplicate indicies (:issue:`4726`)
+  - Bug with using ``QUOTE_NONE`` with ``to_csv`` causing ``Exception``. (:issue:`4328`)
 
 pandas 0.12
 ===========

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -787,7 +787,7 @@ class CSVFormatter(object):
                  cols=None, header=True, index=True, index_label=None,
                  mode='w', nanRep=None, encoding=None, quoting=None,
                  line_terminator='\n', chunksize=None, engine=None,
-                 tupleize_cols=True):
+                 tupleize_cols=True, quotechar='"'):
 
         self.engine = engine  # remove for 0.13
         self.obj = obj
@@ -806,6 +806,11 @@ class CSVFormatter(object):
         if quoting is None:
             quoting = csv.QUOTE_MINIMAL
         self.quoting = quoting
+
+        if quoting == csv.QUOTE_NONE:
+            # prevents crash in _csv
+            quotechar = None
+        self.quotechar = quotechar
 
         self.line_terminator = line_terminator
 
@@ -950,13 +955,14 @@ class CSVFormatter(object):
             close = True
 
         try:
+            writer_kwargs = dict(lineterminator=self.line_terminator,
+                                 delimiter=self.sep, quoting=self.quoting,
+                                 quotechar=self.quotechar)
             if self.encoding is not None:
-                self.writer = com.UnicodeWriter(f, lineterminator=self.line_terminator,
-                                                delimiter=self.sep, encoding=self.encoding,
-                                                quoting=self.quoting)
+                writer_kwargs['encoding'] = self.encoding
+                self.writer = com.UnicodeWriter(f, **writer_kwargs)
             else:
-                self.writer = csv.writer(f, lineterminator=self.line_terminator,
-                                         delimiter=self.sep, quoting=self.quoting)
+                self.writer = csv.writer(f, **writer_kwargs)
 
             if self.engine == 'python':
             # to be removed in 0.13

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta, time
 import operator
 import re
+import csv
 import unittest
 import nose
 
@@ -5465,8 +5466,6 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
             assert_frame_equal(rs, xp)
 
     def test_to_csv_quoting(self):
-        import csv
-
         df = DataFrame({'A': [1, 2, 3], 'B': ['foo', 'bar', 'baz']})
 
         buf = StringIO()
@@ -5489,8 +5488,6 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self.assertEqual(buf.getvalue(), text)
 
     def test_to_csv_unicodewriter_quoting(self):
-        import csv
-
         df = DataFrame({'A': [1, 2, 3], 'B': ['foo', 'bar', 'baz']})
 
         buf = StringIO()
@@ -5504,6 +5501,17 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
                     '3,"baz"\n')
 
         self.assertEqual(result, expected)
+
+    def test_to_csv_quote_none(self):
+        # GH4328
+        df = DataFrame({'A': ['hello', '{"hello"}']})
+        for encoding in (None, 'utf-8'):
+            buf = StringIO()
+            df.to_csv(buf, quoting=csv.QUOTE_NONE,
+                      encoding=encoding, index=False)
+            result = buf.getvalue()
+            expected = 'A\nhello\n{"hello"}\n'
+            self.assertEqual(result, expected)
 
     def test_to_csv_index_no_leading_comma(self):
         df = DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]},


### PR DESCRIPTION
Fixes #4328.

Now passes `quotechar` to csv's writer. Default is same as csv (`'"'`), but sets to `None` with `quoting=csv.QUOTE_NONE`.
