### PR TITLE
CLN: Remove redundant call to get_splitter

### DIFF
--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -590,8 +590,6 @@ class Grouper(object):
         for each group
         """
         comp_ids, _, ngroups = self.group_info
-        splitter = get_splitter(data, comp_ids, ngroups, axis=axis,
-                                keep_internal=keep_internal)
         splitter = self._get_splitter(data, axis=axis,
                                       keep_internal=keep_internal)
         keys = self._get_group_keys()

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -589,7 +589,6 @@ class Grouper(object):
         Generator yielding sequence of (name, subsetted object)
         for each group
         """
-        comp_ids, _, ngroups = self.group_info
         splitter = self._get_splitter(data, axis=axis,
                                       keep_internal=keep_internal)
         keys = self._get_group_keys()


### PR DESCRIPTION
`get_splitter` was called directly, then again through an internal method.  Results from the first call are not used for anything and immediately replaced.
