### PR TITLE
BUG/ER:  (GH2702) Bug with Series indexing not raising an error when the right-hand-side has an incorrect length

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -319,6 +319,7 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
     etc. (:issue:`4718`, :issue:`4628`)
   - Bug in using ``iloc/loc`` with a cross-sectional and duplicate indicies (:issue:`4726`)
   - Bug with using ``QUOTE_NONE`` with ``to_csv`` causing ``Exception``. (:issue:`4328`)
+  - Bug with Series indexing not raising an error when the right-hand-side has an incorrect length (:issue:`2702`)
 
 pandas 0.12
 ===========

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1096,10 +1096,9 @@ class Series(generic.NDFrame):
         self._set_values(indexer, value)
 
     def _set_values(self, key, value):
-        values = self.values
         if isinstance(key, Series):
             key = key.values
-        values[key] = _index.convert_scalar(values, value)
+        self._data = self._data.setitem(key,value)
 
     # help out SparseSeries
     _get_val_at = ndarray.__getitem__


### PR DESCRIPTION
closes #2702

Base use cases (note that a completely changed series will morph to the new dtype if necessary)

```
In [1]: s = Series(list('abc'))
In [2]: s[0:3] = list(range(3))

In [3]: s
Out[3]: 
0    0
1    1
2    2
dtype: int64

In [4]: s = Series(list('abc'))

In [5]: s[0:2] = list(range(2))

In [6]: s
Out[6]: 
0    0
1    1
2    c
dtype: object
```

This is a bit odd, but allowed

```
In [4]: s[0] = list(range(10))

In [5]: s
Out[5]: 
0    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
1                                 b
2                                 c
dtype: object
```

These all will raise error messages now

```
In [1]: s = Series(list('abc'))

In [2]: s[0:3] = list(range(27))
ValueError: cannot set using a slice indexer with a different length than the value

In [3]: s[[0,1,2]] = list(range(27))
ValueError: cannot set using a list-like indexer with a different length than the value

In [4]: s[[0,1,2]] = list(range(2))
ValueError: cannot set using a list-like indexer with a different length than the value

```

With a step and a slice indexer (not sure was tested before)

When the length of the slicer matches exactly it works

```
In [5]: s = Series(list('abcdef'))

In [6]: s[0:4:2] = list(range(2))

In [7]: s
Out[7]: 
0    0
1    b
2    1
3    d
4    e
5    f
dtype: object
```

Raises when it doesn't

```
In [8]: s[0:4:2] = list(range(27))
ValueError: cannot set using a slice indexer with a different length than the value

```
