### PR TITLE
BUG: Bug in setting with loc/ix a single indexer on a multi-index axis and a listlike (related to GH3777)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -327,6 +327,7 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
   - Bug with Series indexing not raising an error when the right-hand-side has an incorrect length (:issue:`2702`)
   - Bug in multi-indexing with a partial string selection as one part of a MultIndex (:issue:`4758`)
   - Bug with reindexing on the index with a non-unique index will now raise ``ValueError`` (:issue:`4746`)
+  - Bug in setting with ``loc/ix`` a single indexer with a multi-index axis and a numpy array, related to (:issue:`3777`)
 
 pandas 0.12
 ===========

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -12,7 +12,8 @@ from pandas.core.common import (_possibly_downcast_to_dtype, isnull, notnull,
                                 is_list_like, _infer_dtype_from_scalar)
 from pandas.core.index import (Index, MultiIndex, _ensure_index,
                                _handle_legacy_indexes)
-from pandas.core.indexing import _check_slice_bounds, _maybe_convert_indices
+from pandas.core.indexing import (_check_slice_bounds, _maybe_convert_indices,
+                                  _length_of_indexer)
 import pandas.core.common as com
 from pandas.sparse.array import _maybe_to_sparse, SparseArray
 import pandas.lib as lib
@@ -563,22 +564,7 @@ class Block(PandasObject):
         elif isinstance(indexer, slice):
 
             if is_list_like(value) and l:
-                start = indexer.start
-                stop = indexer.stop
-                step = indexer.step
-                if start is None:
-                    start = 0
-                elif start < 0:
-                    start += l
-                if stop is None or stop > l:
-                    stop = len(values)
-                elif stop < 0:
-                    stop += l
-                if step is None:
-                    step = 1
-                elif step < 0:
-                    step = abs(step)
-                if (stop-start) / step != len(value):
+                if len(value) != _length_of_indexer(indexer, values):
                     raise ValueError("cannot set using a slice indexer with a different length than the value")
 
         try:


### PR DESCRIPTION
related to #3777

This shows enlarging (and setting inplace)

```
In [8]: df = DataFrame(np.random.randint(5,10,size=9).reshape(3, 3),
   ...:    ...:                        columns=list('abc'),
   ...:    ...:                        index=[[4,4,8],[8,10,12]])

In [9]: 

In [9]: df
Out[9]: 
      a  b  c
4 8   8  8  8
  10  9  7  6
8 12  8  7  9

In [10]: df.loc[4,'d'] = [0,1.]

In [11]: df
Out[11]: 
      a  b  c   d
4 8   8  8  8   0
  10  9  7  6   1
8 12  8  7  9 NaN

In [12]: df.loc[4,'d'] = [3,4]

In [13]: df
Out[13]: 
      a  b  c   d
4 8   8  8  8   3
  10  9  7  6   4
8 12  8  7  9 NaN
```

Invalid assignments

```
In [10]: df.loc[4,'d'] = [3]
ValueError: cannot set using a multi-index selection indexer with a different length than the value

In [11]: df.loc[4,'d'] = [3,4,5]
ValueError: cannot set using a multi-index selection indexer with a different length than the value
```
