### PR TITLE
REF/BUG/ENH/API: refactor read_html to use TextParser

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -167,6 +167,8 @@ Improvements to existing features
   - Improve support for converting R datasets to pandas objects (more
     informative index for timeseries and numeric, support for factors, dist, and
     high-dimensional arrays).
+  - :func:`~pandas.read_html` now supports the ``parse_dates``,
+    ``tupleize_cols`` and ``thousands`` parameters (:issue:`4770`).
 
 API Changes
 ~~~~~~~~~~~
@@ -373,6 +375,8 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
    ``core/generic.py`` (:issue:`4435`).
  - Refactor cum objects to core/generic.py (:issue:`4435`), note that these have a more numpy-like
    function signature.
+ - :func:`~pandas.read_html` now uses ``TextParser`` to parse HTML data from
+   bs4/lxml (:issue:`4770`).
 
 .. _release.bug_fixes-0.13.0:
 
@@ -538,6 +542,15 @@ Bug Fixes
   - Make sure series-series boolean comparions are label based (:issue:`4947`)
   - Bug in multi-level indexing with a Timestamp partial indexer (:issue:`4294`)
   - Tests/fix for multi-index construction of an all-nan frame (:isue:`4078`)
+  - Fixed a bug where :func:`~pandas.read_html` wasn't correctly inferring
+    values of tables with commas (:issue:`5029`)
+  - Fixed a bug where :func:`~pandas.read_html` wasn't providing a stable
+    ordering of returned tables (:issue:`4770`, :issue:`5029`).
+  - Fixed a bug where :func:`~pandas.read_html` was incorrectly parsing when
+    passed ``index_col=0`` (:issue:`5066`).
+  - Fixed a bug where :func:`~pandas.read_html` was incorrectly infering the
+    type of headers (:issue:`5048`).
+
 
 pandas 0.12.0
 -------------

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -16,7 +16,7 @@ import numpy as np
 from pandas.io.common import _is_url, urlopen, parse_url
 from pandas.io.parsers import TextParser
 from pandas.compat import (lrange, lmap, u, string_types, iteritems, text_type,
-                           raise_with_traceback, OrderedDict)
+                           raise_with_traceback)
 from pandas.core import common as com
 from pandas import Series
 
@@ -485,8 +485,8 @@ class _LxmlFrameParser(_HtmlFrameParser):
         pattern = match.pattern
 
         # 1. check all descendants for the given pattern and only search tables
-        # 2. go up the tree until we find a table or if we are a table use that
-        query = '//table/*[re:test(text(), %r)]/ancestor-or-self::table'
+        # 2. go up the tree until we find a table
+        query = '//table//*[re:test(text(), %r)]/ancestor::table'
         xpath_expr = u(query) % pattern
 
         # if any table attributes were given build an xpath expression to
@@ -786,9 +786,8 @@ def read_html(io, match='.+', flavor=None, header=None, index_col=None,
 
     tupleize_cols : bool, optional
         If ``False`` try to parse multiple header rows into a
-        :class:`~pandas.MultiIndex`. See :func:`~pandas.read_csv` for more
-        details. Defaults to ``False`` for backwards compatibility. This is in
-        contrast to other IO functions which default to ``True``.
+        :class:`~pandas.MultiIndex`, otherwise return raw tuples. Defaults to
+        ``False``.
 
     thousands : str, optional
         Separator to use to parse thousands. Defaults to ``','``.

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1468,23 +1468,22 @@ class PythonParser(ParserBase):
                 col = self.orig_names[col]
             clean_conv[col] = f
 
-        return self._convert_to_ndarrays(data, self.na_values, self.na_fvalues,
-                                         self.verbose, clean_conv)
+        return self._convert_to_ndarrays(data, self.na_values, self.na_fvalues, self.verbose,
+                                         clean_conv)
 
     def _infer_columns(self):
-        #import ipdb; ipdb.set_trace()
         names = self.names
 
         if self.header is not None:
             header = self.header
 
             # we have a mi columns, so read and extra line
-            if isinstance(header, (list, tuple, np.ndarray)):
+            if isinstance(header,(list,tuple,np.ndarray)):
                 have_mi_columns = True
-                header = list(header) + [header[-1] + 1]
+                header = list(header) + [header[-1]+1]
             else:
                 have_mi_columns = False
-                header = [header]
+                header = [ header ]
 
             columns = []
             for level, hr in enumerate(header):
@@ -1499,7 +1498,7 @@ class PythonParser(ParserBase):
 
                 this_columns = []
                 for i, c in enumerate(line):
-                    if not c:
+                    if c == '':
                         if have_mi_columns:
                             this_columns.append('Unnamed: %d_level_%d' % (i,level))
                         else:

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1468,22 +1468,23 @@ class PythonParser(ParserBase):
                 col = self.orig_names[col]
             clean_conv[col] = f
 
-        return self._convert_to_ndarrays(data, self.na_values, self.na_fvalues, self.verbose,
-                                         clean_conv)
+        return self._convert_to_ndarrays(data, self.na_values, self.na_fvalues,
+                                         self.verbose, clean_conv)
 
     def _infer_columns(self):
+        #import ipdb; ipdb.set_trace()
         names = self.names
 
         if self.header is not None:
             header = self.header
 
             # we have a mi columns, so read and extra line
-            if isinstance(header,(list,tuple,np.ndarray)):
+            if isinstance(header, (list, tuple, np.ndarray)):
                 have_mi_columns = True
-                header = list(header) + [header[-1]+1]
+                header = list(header) + [header[-1] + 1]
             else:
                 have_mi_columns = False
-                header = [ header ]
+                header = [header]
 
             columns = []
             for level, hr in enumerate(header):
@@ -1498,7 +1499,7 @@ class PythonParser(ParserBase):
 
                 this_columns = []
                 for i, c in enumerate(line):
-                    if c == '':
+                    if not c:
                         if have_mi_columns:
                             this_columns.append('Unnamed: %d_level_%d' % (i,level))
                         else:

--- a/pandas/io/tests/data/macau.html
+++ b/pandas/io/tests/data/macau.html
@@ -1,0 +1,3691 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!-- saved from url=(0037)http://www.camacau.com/statistic_list -->
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+
+<link rel="stylesheet" type="text/css" href="./macau_files/style.css" media="screen">
+<script type="text/javascript" src="./macau_files/jquery.js"></script>
+
+
+
+
+
+<script type="text/javascript">
+
+function slideSwitch() {
+    
+    var $active = $('#banner1 a.active');
+    
+    var totalTmp=document.getElementById("bannerTotal").innerHTML;
+    
+    var randomTmp=Math.floor(Math.random()*totalTmp+1);
+
+    var $next = $('#image'+randomTmp).length?$('#image'+randomTmp):$('#banner1 a:first');
+    
+    if($next.attr("id")==$active.attr("id")){
+
+      $next =  $active.next().length ? $active.next():$('#banner1 a:first');
+    }
+    
+    $active.removeClass("active");
+	
+	$next.addClass("active").show();
+
+    $active.hide();
+
+}
+
+jQuery(function() {
+    
+    var totalTmp=document.getElementById("bannerTotal").innerHTML;
+    if(totalTmp>1){
+       setInterval( "slideSwitch()", 5000 );
+    }
+    
+});
+
+</script>
+<script type="text/javascript">
+function close_notice(){
+jQuery("#tbNotice").hide();
+}
+</script>
+
+<title>Traffic Statistics - Passengers</title>
+
+<!--  GOOGLE STATISTICS
+<script type="text/javascript">
+
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-24989877-2']);
+  _gaq.push(['_trackPageview']);
+
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+
+</script>
+-->
+<style type="text/css"></style><style type="text/css"></style><script id="fireplug-jssdk" src="./macau_files/all.js"></script><style type="text/css">.fireplug-credit-widget-overlay{z-index:9999999999999999999;background-color:rgba(91,91,91,0.6)}.fireplug-credit-widget-overlay div,.fireplug-credit-widget-overlay span,.fireplug-credit-widget-overlay applet,.fireplug-credit-widget-overlay object,.fireplug-credit-widget-overlay iframe,.fireplug-credit-widget-overlay h1,.fireplug-credit-widget-overlay h2,.fireplug-credit-widget-overlay h3,.fireplug-credit-widget-overlay h4,.fireplug-credit-widget-overlay h5,.fireplug-credit-widget-overlay h6,.fireplug-credit-widget-overlay p,.fireplug-credit-widget-overlay blockquote,.fireplug-credit-widget-overlay pre,.fireplug-credit-widget-overlay a,.fireplug-credit-widget-overlay abbr,.fireplug-credit-widget-overlay acronym,.fireplug-credit-widget-overlay address,.fireplug-credit-widget-overlay big,.fireplug-credit-widget-overlay cite,.fireplug-credit-widget-overlay code,.fireplug-credit-widget-overlay del,.fireplug-credit-widget-overlay dfn,.fireplug-credit-widget-overlay em,.fireplug-credit-widget-overlay img,.fireplug-credit-widget-overlay ins,.fireplug-credit-widget-overlay kbd,.fireplug-credit-widget-overlay q,.fireplug-credit-widget-overlay s,.fireplug-credit-widget-overlay samp,.fireplug-credit-widget-overlay small,.fireplug-credit-widget-overlay strike,.fireplug-credit-widget-overlay strong,.fireplug-credit-widget-overlay sub,.fireplug-credit-widget-overlay sup,.fireplug-credit-widget-overlay tt,.fireplug-credit-widget-overlay var,.fireplug-credit-widget-overlay b,.fireplug-credit-widget-overlay u,.fireplug-credit-widget-overlay i,.fireplug-credit-widget-overlay center,.fireplug-credit-widget-overlay dl,.fireplug-credit-widget-overlay dt,.fireplug-credit-widget-overlay dd,.fireplug-credit-widget-overlay ol,.fireplug-credit-widget-overlay ul,.fireplug-credit-widget-overlay li,.fireplug-credit-widget-overlay fieldset,.fireplug-credit-widget-overlay form,.fireplug-credit-widget-overlay label,.fireplug-credit-widget-overlay legend,.fireplug-credit-widget-overlay table,.fireplug-credit-widget-overlay caption,.fireplug-credit-widget-overlay tbody,.fireplug-credit-widget-overlay tfoot,.fireplug-credit-widget-overlay thead,.fireplug-credit-widget-overlay tr,.fireplug-credit-widget-overlay th,.fireplug-credit-widget-overlay td,.fireplug-credit-widget-overlay article,.fireplug-credit-widget-overlay aside,.fireplug-credit-widget-overlay canvas,.fireplug-credit-widget-overlay details,.fireplug-credit-widget-overlay embed,.fireplug-credit-widget-overlay figure,.fireplug-credit-widget-overlay figcaption,.fireplug-credit-widget-overlay footer,.fireplug-credit-widget-overlay header,.fireplug-credit-widget-overlay hgroup,.fireplug-credit-widget-overlay menu,.fireplug-credit-widget-overlay nav,.fireplug-credit-widget-overlay output,.fireplug-credit-widget-overlay ruby,.fireplug-credit-widget-overlay section,.fireplug-credit-widget-overlay summary,.fireplug-credit-widget-overlay time,.fireplug-credit-widget-overlay mark,.fireplug-credit-widget-overlay audio,.fireplug-credit-widget-overlay video{margin:0;padding:0;border:0;font:inherit;font-size:100%;vertical-align:baseline}.fireplug-credit-widget-overlay table{border-collapse:collapse;border-spacing:0}.fireplug-credit-widget-overlay caption,.fireplug-credit-widget-overlay th,.fireplug-credit-widget-overlay td{text-align:left;font-weight:normal;vertical-align:middle}.fireplug-credit-widget-overlay q,.fireplug-credit-widget-overlay blockquote{quotes:none}.fireplug-credit-widget-overlay q:before,.fireplug-credit-widget-overlay q:after,.fireplug-credit-widget-overlay blockquote:before,.fireplug-credit-widget-overlay blockquote:after{content:"";content:none}.fireplug-credit-widget-overlay a img{border:none}.fireplug-credit-widget-overlay .fireplug-credit-widget-overlay-item{z-index:9999999999999999999;-webkit-box-shadow:#333 0px 0px 10px;-moz-box-shadow:#333 0px 0px 10px;box-shadow:#333 0px 0px 10px}.fireplug-credit-widget-overlay-body{height:100% !important;overflow:hidden !important}.fp-getcredit iframe{border:none;overflow:hidden;height:20px;width:145px}
+</style></head>
+<body>
+<div id="full">
+<div id="container">
+
+
+<div id="top">
+		<div id="lang">
+		  
+		  <a href="http://www.camacau.com/changeLang?lang=zh_TW&url=/statistic_list">繁體中文</a> | 
+		  <a href="http://www.camacau.com/changeLang?lang=zh_CN&url=/statistic_list">簡體中文</a> 
+		  <!--<a href="changeLang?lang=pt_PT&url=/statistic_list" >Portuguese</a>
+		  -->
+		  </div>
+</div>
+
+<div id="header">
+  <div id="sitelogo"><a href="http://www.camacau.com/index" style="color : #FFF;"><img src="./macau_files/cam h04.jpg"></a></div>
+  <div id="navcontainer">
+		  <div id="menu">
+		  <div id="search">
+		  <form id="searchForm" name="searchForm" action="http://www.camacau.com/search" method="POST">
+			<input id="keyword" name="keyword" type="text">
+			<a href="javascript:document.searchForm.submit();">Search</a> | 
+			<a href="mailto:mkd@macau-airport.com">Contact Us</a>  | 
+			<a href="http://www.camacau.com/sitemap">SiteMap</a> |
+			
+		  	<a href="http://www.camacau.com/rssBuilder.action"><img src="./macau_files/rssIcon.png" alt="RSS">RSS</a>
+			</form></div>
+		</div>
+</div>
+</div>
+<div id="menu2">
+			<div>
+			
+		          	 
+		    <object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="95" height="20" id="FlashID4" title="Main Page">
+				<param name="movie" value="flash/button_index_EN.swf">
+				<param name="quality" value="high">
+				<param name="scale" value="exactfit">
+				<param name="wmode" value="opaque">
+				<param name="swfversion" value="6.0.65.0">
+				<!-- 此 param 標籤會提示使用 Flash Player 6.0 r65 和更新版本的使用者下載最新版本的 Flash Player。如果您不想讓使用者看到這項提示，請將其刪除。 -->
+				<param name="expressinstall" value="flash/expressInstall.swf">
+				<!-- 下一個物件標籤僅供非 IE 瀏覽器使用。因此，請使用 IECC 將其自 IE 隱藏。 -->
+				<!--[if !IE]>-->
+				<object type="application/x-shockwave-flash" data="http://www.camacau.com/flash/button_index_EN.swf" width="92" height="20">
+				  <!--<![endif]-->
+				  <param name="quality" value="high">
+				  <param name="scale" value="exactfit">
+				  <param name="wmode" value="opaque">
+				  <param name="swfversion" value="6.0.65.0">
+				  <param name="expressinstall" value="flash/expressInstall.swf">
+				  <!-- 瀏覽器會為使用 Flash Player 6.0 和更早版本的使用者顯示下列替代內容。 -->
+				  <div>
+					<h4>這個頁面上的內容需要較新版本的 Adobe Flash Player。</h4>
+					<p><a href="http://www.adobe.com/go/getflashplayer"><img src="./macau_files/get_flash_player.gif" alt="取得 Adobe Flash Player" width="112" height="33"></a></p>
+				  </div>
+				  <!--[if !IE]>-->
+				</object>
+				<!--<![endif]-->
+			  </object>		  
+		          	 
+			<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="95" height="20" id="FlashID4" title="Our Business">
+				<param name="movie" value="flash/button_our business_EN.swf">
+				<param name="quality" value="high">
+				<param name="scale" value="exactfit">
+				<param name="wmode" value="opaque">
+				<param name="swfversion" value="6.0.65.0">
+				<!-- 此 param 標籤會提示使用 Flash Player 6.0 r65 和更新版本的使用者下載最新版本的 Flash Player。如果您不想讓使用者看到這項提示，請將其刪除。 -->
+				<param name="expressinstall" value="flash/expressInstall.swf">
+				<!-- 下一個物件標籤僅供非 IE 瀏覽器使用。因此，請使用 IECC 將其自 IE 隱藏。 -->
+				<!--[if !IE]>-->
+				<object type="application/x-shockwave-flash" data="http://www.camacau.com/flash/button_our%20business_EN.swf" width="92" height="20">
+				  <!--<![endif]-->
+				  <param name="quality" value="high">
+				  <param name="scale" value="exactfit">
+				  <param name="wmode" value="opaque">
+				  <param name="swfversion" value="6.0.65.0">
+				  <param name="expressinstall" value="flash/expressInstall.swf">
+				  <!-- 瀏覽器會為使用 Flash Player 6.0 和更早版本的使用者顯示下列替代內容。 -->
+				  <div>
+					<h4>這個頁面上的內容需要較新版本的 Adobe Flash Player。</h4>
+					<p><a href="http://www.adobe.com/go/getflashplayer"><img src="./macau_files/get_flash_player.gif" alt="取得 Adobe Flash Player" width="112" height="33"></a></p>
+				  </div>
+				  <!--[if !IE]>-->
+				</object>
+				<!--<![endif]-->
+			  </object>
+			  
+			  <object id="FlashID" classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="95" height="20" title="About Us">
+				<param name="movie" value="flash/button_about us_EN.swf">
+				<param name="quality" value="high">
+				<param name="scale" value="exactfit">
+				<param name="wmode" value="opaque">
+				<param name="swfversion" value="6.0.65.0">
+				  <!-- 此 param 標籤會提示使用 Flash Player 6.0 r65 和更新版本的使用者下載最新版本的 Flash Player。如果您不想讓使用者看到這項提示，請將其刪除。 -->
+				<param name="expressinstall" value="flash/expressInstall.swf">
+				  <!-- 下一個物件標籤僅供非 IE 瀏覽器使用。因此，請使用 IECC 將其自 IE 隱藏。 -->
+				  <!--[if !IE]>-->
+				  <object type="application/x-shockwave-flash" data="http://www.camacau.com/flash/button_about%20us_EN.swf" width="92" height="20">
+					<!--<![endif]-->
+					<param name="quality" value="high">
+					<param name="scale" value="exactfit">
+					<param name="wmode" value="opaque">
+					<param name="swfversion" value="6.0.65.0">
+					<param name="expressinstall" value="flash/expressInstall.swf">
+					<!-- 瀏覽器會為使用 Flash Player 6.0 和更早版本的使用者顯示下列替代內容。 -->
+					<div>
+					  <h4>這個頁面上的內容需要較新版本的 Adobe Flash Player。</h4>
+					  <p><a href="http://www.adobe.com/go/getflashplayer"><img src="./macau_files/get_flash_player.gif" alt="取得 Adobe Flash Player" width="112" height="33"></a></p>
+					</div>
+					<!--[if !IE]>-->
+				</object>
+				  <!--<![endif]-->
+			  </object>
+			  
+			  <object id="FlashID3" classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="95" height="20" title="Media Centre">
+				<param name="movie" value="flash/button_media centre_EN.swf">
+				<param name="quality" value="high">
+				<param name="scale" value="exactfit">
+				<param name="wmode" value="opaque">
+				<param name="swfversion" value="6.0.65.0">
+				<!-- 此 param 標籤會提示使用 Flash Player 6.0 r65 和更新版本的使用者下載最新版本的 Flash Player。如果您不想讓使用者看到這項提示，請將其刪除。 -->
+				<param name="expressinstall" value="flash/expressInstall.swf">
+				<!-- 下一個物件標籤僅供非 IE 瀏覽器使用。因此，請使用 IECC 將其自 IE 隱藏。 -->
+				<!--[if !IE]>-->
+				<object type="application/x-shockwave-flash" data="http://www.camacau.com/flash/button_media%20centre_EN.swf" width="92" height="20">
+				  <!--<![endif]-->
+				  <param name="quality" value="high">
+				  <param name="wmode" value="opaque">
+				  <param name="scale" value="exactfit">
+				  <param name="swfversion" value="6.0.65.0">
+				  <param name="expressinstall" value="flash/expressInstall.swf">
+				  <!-- 瀏覽器會為使用 Flash Player 6.0 和更早版本的使用者顯示下列替代內容。 -->
+				  <div>
+					<h4>這個頁面上的內容需要較新版本的 Adobe Flash Player。</h4>
+					<p><a href="http://www.adobe.com/go/getflashplayer"><img src="./macau_files/get_flash_player.gif" alt="取得 Adobe Flash Player" width="112" height="33"></a></p>
+				  </div>
+				  <!--[if !IE]>-->
+				</object>
+				<!--<![endif]-->
+			  </object>
+			  
+			  <object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="95" height="20" id="FlashID5" title="Related Links">
+				<param name="movie" value="flash/button_related links_EN.swf">
+				<param name="quality" value="high">
+				<param name="scale" value="exactfit">
+				<param name="wmode" value="opaque">
+				<param name="swfversion" value="6.0.65.0">
+				<!-- 此 param 標籤會提示使用 Flash Player 6.0 r65 和更新版本的使用者下載最新版本的 Flash Player。如果您不想讓使用者看到這項提示，請將其刪除。 -->
+				<param name="expressinstall" value="flash/expressInstall.swf">
+				<!-- 下一個物件標籤僅供非 IE 瀏覽器使用。因此，請使用 IECC 將其自 IE 隱藏。 -->
+				<!--[if !IE]>-->
+				<object type="application/x-shockwave-flash" data="http://www.camacau.com/flash/button_related%20links_EN.swf" width="92" height="20">
+				  <!--<![endif]-->
+				  <param name="quality" value="high">
+				  <param name="scale" value="exactfit">
+				  <param name="wmode" value="opaque">
+				  <param name="swfversion" value="6.0.65.0">
+				  <param name="expressinstall" value="flash/expressInstall.swf">
+				  <!-- 瀏覽器會為使用 Flash Player 6.0 和更早版本的使用者顯示下列替代內容。 -->
+				  <div>
+					<h4>這個頁面上的內容需要較新版本的 Adobe Flash Player。</h4>
+					<p><a href="http://www.adobe.com/go/getflashplayer"><img src="./macau_files/get_flash_player.gif" alt="取得 Adobe Flash Player" width="112" height="33"></a></p>
+				  </div>
+				  <!--[if !IE]>-->
+				</object>
+				<!--<![endif]-->
+			  </object>
+			  
+			  <object id="FlashID2" classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="95" height="20" title="Interactive">
+				<param name="movie" value="flash/button_interactive_EN.swf">
+				<param name="quality" value="high">
+				<param name="scale" value="exactfit">
+				<param name="wmode" value="opaque">
+				<param name="swfversion" value="6.0.65.0">
+				<!-- 此 param 標籤會提示使用 Flash Player 6.0 r65 和更新版本的使用者下載最新版本的 Flash Player。如果您不想讓使用者看到這項提示，請將其刪除。 -->
+				<param name="expressinstall" value="flash/expressInstall.swf">
+				<!-- 下一個物件標籤僅供非 IE 瀏覽器使用。因此，請使用 IECC 將其自 IE 隱藏。 -->
+				<!--[if !IE]>-->
+				<object type="application/x-shockwave-flash" data="http://www.camacau.com/flash/button_interactive_EN.swf" width="92" height="20">
+				  <!--<![endif]-->
+				  <param name="quality" value="high">
+				  <param name="scale" value="exactfit">
+				  <param name="wmode" value="opaque">
+				  <param name="swfversion" value="6.0.65.0">
+				  <param name="expressinstall" value="flash/expressInstall.swf">
+				  <!-- 瀏覽器會為使用 Flash Player 6.0 和更早版本的使用者顯示下列替代內容。 -->
+				  <div>
+					<h4>這個頁面上的內容需要較新版本的 Adobe Flash Player。</h4>
+					<p><a href="http://www.adobe.com/go/getflashplayer"><img src="./macau_files/get_flash_player.gif" alt="取得 Adobe Flash Player" width="112" height="33"></a></p>
+				  </div>
+				  <!--[if !IE]>-->
+				</object>
+				<!--<![endif]-->
+			  </object>
+			  
+			  <!--<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="95" height="20" id="FlashID4" title="Group of Public">
+				<param name="movie" value="flash/button_pressRelease_EN.swf" />
+				<param name="quality" value="high" />
+				<param name="scale" value="exactfit">
+				<param name="wmode" value="opaque" />
+				<param name="swfversion" value="6.0.65.0" />
+				 此 param 標籤會提示使用 Flash Player 6.0 r65 和更新版本的使用者下載最新版本的 Flash Player。如果您不想讓使用者看到這項提示，請將其刪除。 
+				<param name="expressinstall" value="flash/expressInstall.swf" />
+				 下一個物件標籤僅供非 IE 瀏覽器使用。因此，請使用 IECC 將其自 IE 隱藏。 
+				[if !IE]>
+				<object type="application/x-shockwave-flash" data="flash/button_pressRelease_EN.swf" width="92" height="20">
+				  <![endif]
+				  <param name="quality" value="high" />
+				  <param name="scale" value="exactfit">
+				  <param name="wmode" value="opaque" />
+				  <param name="swfversion" value="6.0.65.0" />
+				  <param name="expressinstall" value="flash/expressInstall.swf" />
+				   瀏覽器會為使用 Flash Player 6.0 和更早版本的使用者顯示下列替代內容。 
+				  <div>
+					<h4>這個頁面上的內容需要較新版本的 Adobe Flash Player。</h4>
+					<p><a href="http://www.adobe.com/go/getflashplayer"><img src="http://www.adobe.com/images/shared/download_buttons/get_flash_player.gif" alt="取得 Adobe Flash Player" width="112" height="33" /></a></p>
+				  </div>
+				  [if !IE]>
+				</object>
+				<![endif]
+			  </object>
+			  
+			  --></div>
+		  </div>
+
+
+
+
+
+
+
+<style>
+#slider ul li 
+{ 
+height: 90px;
+list-style:none;
+width:95%;
+font-size:11pt;
+text-indent:2em;
+text-align:justify;
+text-justify:inter-ideograph;
+color:#663300;
+}
+
+
+#slider
+{
+margin: auto;
+overflow: hidden;
+/* Non Core */
+background: #f6f7f8;
+box-shadow: 4px 4px 15px #aaa;
+-o-box-shadow: 4px 4px 15px #aaa;
+-icab-box-shadow: 4px 4px 15px #aaa;
+-khtml-box-shadow: 4px 4px 15px #aaa;
+-moz-box-shadow: 4px 4px 15px #aaa;
+-webkit-box-shadow: 4px 4px 15px #aaa;
+border: 4px solid #bcc5cb;
+
+border-width: 1px 2px 2px 1px;
+
+-o-border-radius: 10px;
+-icab-border-radius: 10px;
+-khtml-border-radius: 10px;
+-moz-border-radius: 10px;
+-webkit-border-radius: 10px;
+border-radius: 10px;
+
+}
+
+#close_tbNotice img
+{
+width:20px;
+height:20px;
+align:right;
+cursor:pointer;
+}
+</style>
+
+<div id="banner">
+	<!--<div id="leftGradient"></div>-->
+	
+			<table id="tbNotice" style="display:none;width:800px;z-index:999;position:absolute;left:20%;" align="center">
+				<tbody><tr height="40px"><td></td></tr> 
+				<tr><td>
+					
+					<div id="slider">
+				<div id="close_tbNotice"><img src="./macau_files/delete.png" onclick="close_notice()"></div>
+				<ul>
+					<li>
+						
+		                
+		                
+						
+					</li>
+				</ul>
+				
+			</div>
+			<div id="show_notice" style="display:none;">
+			
+			</div>
+			
+				</td>
+	
+				</tr>
+				<tr><td align="right"></td></tr>
+			</tbody></table>
+			 
+		
+	<div class="gradient">
+		
+	</div>
+	<div class="banner1" id="banner1">
+	
+	
+			
+			
+             <a href="http://www.macau-airport.com/" target="_blank" style="display: none;" id="image1" class="">
+		     <img src="./macau_files/41.jpeg" alt="Slideshow Image 1">
+	         </a>
+		    
+            
+	
+			
+            
+             <a href="http://www.macau-airport.com/" target="_blank" style="display: none;" id="image2" class="">
+		     <img src="./macau_files/45.jpeg" alt="Slideshow Image 2">
+	         </a>
+		    
+		
+	
+			
+            
+             <a href="http://www.macau-airport.com/" target="_blank" style="display: none;" id="image3" class="">
+		     <img src="./macau_files/46.jpeg" alt="Slideshow Image 3">
+	         </a>
+		    
+		
+	
+			
+            
+             <a href="http://www.macau-airport.com/" target="_blank" style="display: inline;" id="image4" class="active">
+		     <img src="./macau_files/47.jpeg" alt="Slideshow Image 4">
+	         </a>
+		    
+		
+	
+			
+            
+             <a href="http://www.macau-airport.com/" target="_blank" style="display: none;" id="image5" class="">
+		     <img src="./macau_files/48.jpeg" alt="Slideshow Image 5">
+	         </a>
+		    
+		
+	
+			
+            
+             <a href="http://www.macau-airport.com/" target="_blank" style="display: none;" id="image6" class="">
+		     <img src="./macau_files/49.jpeg" alt="Slideshow Image 6">
+	         </a>
+		    
+		
+	
+			
+            
+             <a href="http://www.4cpscac.com/" target="_blank" style="display: none;" id="image7" class="">
+		     <img src="./macau_files/50.jpg" alt="Slideshow Image 7">
+	         </a>
+		    
+		
+	
+	
+	</div>
+	<div id="bannerTotal" style="display:none;">7</div>
+</div>
+
+<div id="content">
+        <div id="leftnav">
+        
+                <div id="navmenu">
+				
+        		
+
+
+
+<link href="./macau_files/ddaccordion.css" rel="stylesheet" type="text/css">
+<script type="text/javascript" src="./macau_files/ddaccordion.js"></script>
+
+
+
+<script type="text/javascript">
+	ddaccordion.init({
+	headerclass: "leftmenu_silverheader", //Shared CSS class name of headers group
+	contentclass: "leftmenu_submenu", //Shared CSS class name of contents group
+	revealtype: "clickgo", //Reveal content when user clicks or onmouseover the header? Valid value: "click", "clickgo", or "mouseover"
+	mouseoverdelay: 100, //if revealtype="mouseover", set delay in milliseconds before header expands onMouseover
+	collapseprev: true, //Collapse previous content (so only one open at any time)? true/false
+	defaultexpanded: [0], //index of content(s) open by default [index1, index2, etc] [] denotes no content
+	onemustopen: false, //Specify whether at least one header should be open always (so never all headers closed)
+	animatedefault: true, //Should contents open by default be animated into view?
+	persiststate: true, //persist state of opened contents within browser session?
+	toggleclass: ["", "selected"], //Two CSS classes to be applied to the header when it's collapsed and expanded, respectively ["class1", "class2"]
+	togglehtml: ["", "", ""], //Additional HTML added to the header when it's collapsed and expanded, respectively  ["position", "html1", "html2"] (see docs)
+	animatespeed: "normal", //speed of animation: integer in milliseconds (ie: 200), or keywords "fast", "normal", or "slow"
+	oninit:function(headers, expandedindices){ //custom code to run when headers have initalized
+		//do nothing
+	},
+	onopenclose:function(header, index, state, isuseractivated){ //custom code to run whenever a header is opened or closed
+		//do nothing
+	
+	}
+});
+</script><style type="text/css">
+.leftmenu_submenu{display: none}
+a.hiddenajaxlink{display: none}
+</style>
+
+	
+				<table>
+				<tbody><tr><td><img width="20" height="15" src="./macau_files/double.gif"></td><td><a href="http://www.camacau.com/geographic_information">MIA Geographical Information</a></td></tr>
+				<tr><td><img width="20" height="15" src="./macau_files/double.gif"></td><td><a href="http://www.camacau.com/airport_services">Scope of Service</a></td></tr>
+				<tr><td><img width="20" height="15" src="./macau_files/double.gif"></td><td><a href="http://www.camacau.com/services_agreement">Air Services Agreement</a></td></tr>
+				<tr><td><img width="20" height="15" src="./macau_files/double.gif"></td><td><a href="http://www.camacau.com/airport_charges" class="leftmenu_silverheader selected" headerindex="0h"><span>Airport Charges</span></a></td></tr>
+				<tr><td colspan="2" style="padding-top:0px;padding-bottom:0px;padding-right:0px;">
+				<table class="leftmenu_submenu" contentindex="0c" style="display: block;">
+				<tbody><tr><td>&nbsp;</td><td><table class="submenu"><tbody><tr><td><img width="20" height="15" src="./macau_files/sub_icon.gif"></td><td><a href="http://www.camacau.com/airport_charges1">Passenger Service Fees</a></td></tr></tbody></table></td></tr>
+				<tr><td>&nbsp;</td><td><table class="submenu"><tbody><tr><td><img width="20" height="15" src="./macau_files/sub_icon.gif"></td><td><a href="http://www.camacau.com/airport_charges2">Aircraft Parking fees</a></td></tr></tbody></table></td></tr>
+				<tr><td>&nbsp;</td><td><table class="submenu"><tbody><tr><td><img width="20" height="15" src="./macau_files/sub_icon.gif"></td><td><a href="http://www.camacau.com/airport_charges3">Airport Security Fee</a></td></tr></tbody></table></td></tr>
+				<tr><td>&nbsp;</td><td><table class="submenu"><tbody><tr><td><img width="20" height="15" src="./macau_files/sub_icon.gif"></td><td><a href="http://www.camacau.com/airport_charges4">Utilization fees</a></td></tr></tbody></table></td></tr>
+				<tr><td>&nbsp;</td><td><table class="submenu"><tbody><tr><td><img width="20" height="15" src="./macau_files/sub_icon.gif"></td><td><a href="http://www.camacau.com/airport_charges5">Refuelling Charge</a></td></tr></tbody></table></td></tr>
+				<tr><td>&nbsp;</td><td><table class="submenu"><tbody><tr><td><img width="20" height="15" src="./macau_files/sub_icon.gif"></td><td><a href="http://www.camacau.com/calculation">Calculation of Landing fee Rate</a></td></tr></tbody></table></td></tr>
+				</tbody></table>
+				</td>
+				</tr>
+				<tr><td><img width="20" height="15" src="./macau_files/double.gif"></td><td><a href="http://www.camacau.com/application_facilities">Application of Credit Facilities</a></td></tr>
+				<tr><td><img width="20" height="15" src="./macau_files/double.gif"></td><td><a href="javascript:void(0)" class="leftmenu_silverheader " headerindex="1h"><span>Passenger Flight Incentive Program</span></a></td></tr>
+				<tr><td colspan="2" style="padding-top:0px;padding-bottom:0px;padding-right:0px;">
+				<table class="leftmenu_submenu" contentindex="1c" style="display: none;">
+				<tbody><tr><td>&nbsp;</td><td><table class="submenu"><tbody><tr><td><img width="20" height="15" src="./macau_files/sub_icon.gif"></td><td><a href="http://www.camacau.com/incentive_program1">Incentive policy for new routes and additional flights</a></td></tr></tbody></table></td></tr>
+				<tr><td>&nbsp;</td><td><table class="submenu"><tbody><tr><td><img width="20" height="15" src="./macau_files/sub_icon.gif"></td><td><a href="http://www.camacau.com/incentive_program1_1">Passenger flights</a></td></tr></tbody></table></td></tr>
+				<tr><td>&nbsp;</td><td><table class="submenu"><tbody><tr><td><img width="20" height="15" src="./macau_files/sub_icon.gif"></td><td><a href="http://www.camacau.com/incentive_program1_2">Charter flights</a></td></tr></tbody></table></td></tr>
+				<tr><td>&nbsp;</td><td><table class="submenu"><tbody><tr><td><img width="20" height="15" src="./macau_files/sub_icon.gif"></td><td><a href="http://www.camacau.com/docs/MIA_Route_Development_IncentiveApp_Form.pdf" target="_blank">Route Development Incentive Application Form</a></td></tr></tbody></table></td></tr>
+				<tr><td>&nbsp;</td><td><table class="submenu"><tbody><tr><td><img width="20" height="15" src="./macau_files/sub_icon.gif"></td><td><a href="http://www.camacau.com/online_application">Online Application</a></td></tr></tbody></table></td></tr>
+				</tbody></table>
+				</td>
+				</tr>
+				
+				<tr><td><img width="20" height="15" src="./macau_files/double.gif"></td><td><a href="http://www.camacau.com/slot_application">Slot Application</a></td></tr>
+				
+				<tr><td><img width="20" height="15" src="./macau_files/double.gif"></td><td><a href="http://www.camacau.com/freighter_forwards">Macau Freight Forwarders</a></td></tr>
+				<tr><td><img width="20" height="15" src="./macau_files/double.gif"></td><td><a href="http://www.camacau.com/ctplatform">Cargo Tracking Platform</a></td></tr>
+				<tr><td><img width="20" height="15" src="./macau_files/double.gif"></td><td><a href="http://www.camacau.com/for_rent">For Rent</a></td></tr>
+				<tr><td><img width="20" height="15" src="./macau_files/double.gif"></td><td><a href="http://www.camacau.com/capacity">Airport Capacity</a></td></tr>
+				
+				<tr><td><img width="20" height="15" src="./macau_files/double.gif"></td><td style="color: #606060;text-decoration: none;"><a href="javascript:void(0)" class="leftmenu_silverheader " headerindex="2h">Airport Characteristics &amp; Traffic Statistics</a></td></tr>
+				<tr><td colspan="2" style="padding-top:0px;padding-bottom:0px;padding-right:0px;">
+				<table class="leftmenu_submenu" contentindex="2c" style="display: none;">
+				<!--<tr><td>&nbsp;</td><td><table class="submenu"><tr><td><img width="20" height="15" src="images/sub_icon.gif"/></td><td><a href="airport_characteristics">Airport Characteristics</a></td></tr></table></td></tr>
+				-->
+				<tbody><tr><td>&nbsp;</td><td><table class="submenu"><tbody><tr><td><img width="20" height="15" src="./macau_files/sub_icon.gif"></td><td><a href="./macau_files/macau.html">Traffic Statistics - Passengers</a></td></tr></tbody></table></td></tr>
+				<tr><td>&nbsp;</td><td><table class="submenu"><tbody><tr><td><img width="20" height="15" src="./macau_files/sub_icon.gif"></td><td><a href="http://www.camacau.com/statistics_cargo">Traffic Statistics - Cargo</a></td></tr></tbody></table></td></tr>
+				</tbody></table>
+				</td>
+				</tr>
+				<tr><td><img width="20" height="15" src="./macau_files/double.gif"></td><td><a href="http://www.camacau.com/operational_routes">Operational Routes</a></td></tr>
+
+				<!--<tr><td><img width="20" height="15" src="images/double.gif"/></td><td><a href="route_development">Member Registration</a></td></tr>
+				
+				--><!--<tr><td><img width="20" height="15" src="images/double.gif"/></td><td><a href="cargo_arrival">Cargo Flight Information</a></td></tr>-->
+				
+				<!--<tr><td><img width="20" height="15" src="images/double.gif"/></td><td><a href="/mvnforum/mvnforum/index">Forum</a></td></tr>-->
+				
+				</tbody></table>
+
+
+        		</div>
+		</div>
+
+<div id="under">
+			<div id="contextTitle">
+          			<h2 class="con">Traffic Statistics - Passengers</h2>
+          
+          </div>
+			<div class="contextTitleAfter"></div>
+	<div>
+    	  
+          
+    	  <div id="context">
+          <!--/*begin context*/-->
+          <div class="Container">
+                     <div id="Scroller-1">
+                           <div class="Scroller-Container">
+          		<div id="statisticspassengers" style="width:550px;">
+          		
+
+   <span id="title">Traffic Statistics</span>
+
+  
+   
+   
+   
+   <br><br><br>
+   <span id="title">Passengers Figure(2008-2013) </span><br><br>
+   <table class="style1">
+   <tbody>
+   <tr height="17">
+   <th align="right">&nbsp; </th>
+   
+   <th align="center">2013</th>
+   
+   <th align="center">2012</th>
+   
+   <th align="center">2011</th>
+   
+   <th align="center">2010</th>
+   
+   <th align="center">2009</th>
+   
+   <th align="center">2008</th>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">January</th>
+   
+   <td align="center">
+    
+    374,917
+   </td>
+   
+   <td align="center">
+    
+    362,379
+   </td>
+   
+   <td align="center">
+    
+    301,503
+   </td>
+   
+   <td align="center">
+    
+    358,902
+   </td>
+   
+   <td align="center">
+    
+    342,323
+   </td>
+   
+   <td align="center">
+    
+    420,574
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">February</th>
+   
+   <td align="center">
+   
+    393,152
+   </td>
+   
+   <td align="center">
+   
+    312,405
+   </td>
+   
+   <td align="center">
+   
+    301,259
+   </td>
+   
+   <td align="center">
+   
+    351,654
+   </td>
+   
+   <td align="center">
+   
+    297,755
+   </td>
+   
+   <td align="center">
+   
+    442,809
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">March</th>
+   
+   <td align="center">
+   
+    408,755
+   </td>
+   
+   <td align="center">
+   
+    334,000
+   </td>
+   
+   <td align="center">
+   
+    318,908
+   </td>
+   
+   <td align="center">
+   
+    360,365
+   </td>
+   
+   <td align="center">
+   
+    387,879
+   </td>
+   
+   <td align="center">
+   
+    468,540
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">April</th>
+   
+   <td align="center">
+   
+    408,860
+   </td>
+   
+   <td align="center">
+   
+    358,198
+   </td>
+   
+   <td align="center">
+   
+    339,060
+   </td>
+   
+   <td align="center">
+   
+    352,976
+   </td>
+   
+   <td align="center">
+   
+    400,553
+   </td>
+   
+   <td align="center">
+   
+    492,930
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">May</th>
+   
+   <td align="center">
+   
+    374,397
+   </td>
+   
+   <td align="center">
+   
+    329,218
+   </td>
+   
+   <td align="center">
+   
+    321,060
+   </td>
+   
+   <td align="center">
+   
+    330,407
+   </td>
+   
+   <td align="center">
+   
+    335,967
+   </td>
+   
+   <td align="center">
+   
+    465,045
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">June</th>
+   
+   <td align="center">
+   
+    401,995
+   </td>
+   
+   <td align="center">
+   
+    356,679
+   </td>
+   
+   <td align="center">
+   
+    343,006
+   </td>
+   
+   <td align="center">
+   
+    326,724
+   </td>
+   
+   <td align="center">
+   
+    296,748
+   </td>
+   
+   <td align="center">
+   
+    426,764
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">July</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   <td align="center">
+   
+    423,081
+   </td>
+   
+   <td align="center">
+   
+    378,993
+   </td>
+   
+   <td align="center">
+   
+    356,580
+   </td>
+   
+   <td align="center">
+   
+    351,110
+   </td>
+   
+   <td align="center">
+   
+    439,425
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">August</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   <td align="center">
+   
+    453,391
+   </td>
+   
+   <td align="center">
+   
+    395,883
+   </td>
+   
+   <td align="center">
+   
+    364,011
+   </td>
+   
+   <td align="center">
+   
+    404,076
+   </td>
+   
+   <td align="center">
+   
+    425,814
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">September</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   <td align="center">
+   
+    384,887
+   </td>
+   
+   <td align="center">
+   
+    325,124
+   </td>
+   
+   <td align="center">
+   
+    308,940
+   </td>
+   
+   <td align="center">
+   
+    317,226
+   </td>
+   
+   <td align="center">
+   
+    379,898
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">October</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   <td align="center">
+   
+    383,889
+   </td>
+   
+   <td align="center">
+   
+    333,102
+   </td>
+   
+   <td align="center">
+   
+    317,040
+   </td>
+   
+   <td align="center">
+   
+    355,935
+   </td>
+   
+   <td align="center">
+   
+    415,339
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">November</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   <td align="center">
+   
+    379,065
+   </td>
+   
+   <td align="center">
+   
+    327,803
+   </td>
+   
+   <td align="center">
+   
+    303,186
+   </td>
+   
+   <td align="center">
+   
+    372,104
+   </td>
+   
+   <td align="center">
+   
+    366,411
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">December</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   <td align="center">
+   
+    413,873
+   </td>
+   
+   <td align="center">
+   
+    359,313
+   </td>
+   
+   <td align="center">
+   
+    348,051
+   </td>
+   
+   <td align="center">
+   
+    388,573
+   </td>
+   
+   <td align="center">
+   
+    354,253
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">Total</th>
+   
+   <td align="center">
+   
+    2,362,076
+   </td>
+   
+   <td align="center">
+   
+    4,491,065
+   </td>
+   
+   <td align="center">
+   
+    4,045,014
+   </td>
+   
+   <td align="center">
+   
+    4,078,836
+   </td>
+   
+   <td align="center">
+   
+    4,250,249
+   </td>
+   
+   <td align="center">
+   
+    5,097,802
+   </td>
+   
+   </tr>
+   </tbody>
+   </table>
+   
+   <br><br><br>
+   <span id="title">Passengers Figure(2002-2007) </span><br><br>
+   <table class="style1">
+   <tbody>
+   <tr height="17">
+   <th align="right">&nbsp; </th>
+   
+   <th align="center">2007</th>
+   
+   <th align="center">2006</th>
+   
+   <th align="center">2005</th>
+   
+   <th align="center">2004</th>
+   
+   <th align="center">2003</th>
+   
+   <th align="center">2002</th>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">January</th>
+   
+   <td align="center">
+    
+    381,887
+   </td>
+   
+   <td align="center">
+    
+    323,282
+   </td>
+   
+   <td align="center">
+    
+    289,701
+   </td>
+   
+   <td align="center">
+    
+    288,507
+   </td>
+   
+   <td align="center">
+    
+    290,140
+   </td>
+   
+   <td align="center">
+    
+    268,783
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">February</th>
+   
+   <td align="center">
+   
+    426,014
+   </td>
+   
+   <td align="center">
+   
+    360,820
+   </td>
+   
+   <td align="center">
+   
+    348,723
+   </td>
+   
+   <td align="center">
+   
+    207,710
+   </td>
+   
+   <td align="center">
+   
+    323,264
+   </td>
+   
+   <td align="center">
+   
+    323,654
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">March</th>
+   
+   <td align="center">
+   
+    443,805
+   </td>
+   
+   <td align="center">
+   
+    389,125
+   </td>
+   
+   <td align="center">
+   
+    321,953
+   </td>
+   
+   <td align="center">
+   
+    273,910
+   </td>
+   
+   <td align="center">
+   
+    295,052
+   </td>
+   
+   <td align="center">
+   
+    360,668
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">April</th>
+   
+   <td align="center">
+   
+    500,917
+   </td>
+   
+   <td align="center">
+   
+    431,550
+   </td>
+   
+   <td align="center">
+   
+    367,976
+   </td>
+   
+   <td align="center">
+   
+    324,931
+   </td>
+   
+   <td align="center">
+   
+    144,082
+   </td>
+   
+   <td align="center">
+   
+    380,648
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">May</th>
+   
+   <td align="center">
+   
+    468,637
+   </td>
+   
+   <td align="center">
+   
+    399,743
+   </td>
+   
+   <td align="center">
+   
+    359,298
+   </td>
+   
+   <td align="center">
+   
+    250,601
+   </td>
+   
+   <td align="center">
+   
+    47,333
+   </td>
+   
+   <td align="center">
+   
+    359,547
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">June</th>
+   
+   <td align="center">
+   
+    463,676
+   </td>
+   
+   <td align="center">
+   
+    393,713
+   </td>
+   
+   <td align="center">
+   
+    360,147
+   </td>
+   
+   <td align="center">
+   
+    296,000
+   </td>
+   
+   <td align="center">
+   
+    94,294
+   </td>
+   
+   <td align="center">
+   
+    326,508
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">July</th>
+   
+   <td align="center">
+   
+    490,404
+   </td>
+   
+   <td align="center">
+   
+    465,497
+   </td>
+   
+   <td align="center">
+   
+    413,131
+   </td>
+   
+   <td align="center">
+   
+    365,454
+   </td>
+   
+   <td align="center">
+   
+    272,784
+   </td>
+   
+   <td align="center">
+   
+    388,061
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">August</th>
+   
+   <td align="center">
+   
+    490,830
+   </td>
+   
+   <td align="center">
+   
+    478,474
+   </td>
+   
+   <td align="center">
+   
+    409,281
+   </td>
+   
+   <td align="center">
+   
+    372,802
+   </td>
+   
+   <td align="center">
+   
+    333,840
+   </td>
+   
+   <td align="center">
+   
+    384,719
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">September</th>
+   
+   <td align="center">
+   
+    446,594
+   </td>
+   
+   <td align="center">
+   
+    412,444
+   </td>
+   
+   <td align="center">
+   
+    354,751
+   </td>
+   
+   <td align="center">
+   
+    321,456
+   </td>
+   
+   <td align="center">
+   
+    295,447
+   </td>
+   
+   <td align="center">
+   
+    334,029
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">October</th>
+   
+   <td align="center">
+   
+    465,757
+   </td>
+   
+   <td align="center">
+   
+    461,215
+   </td>
+   
+   <td align="center">
+   
+    390,435
+   </td>
+   
+   <td align="center">
+   
+    358,362
+   </td>
+   
+   <td align="center">
+   
+    291,193
+   </td>
+   
+   <td align="center">
+   
+    372,706
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">November</th>
+   
+   <td align="center">
+   
+    455,132
+   </td>
+   
+   <td align="center">
+   
+    425,116
+   </td>
+   
+   <td align="center">
+   
+    323,347
+   </td>
+   
+   <td align="center">
+   
+    327,593
+   </td>
+   
+   <td align="center">
+   
+    268,282
+   </td>
+   
+   <td align="center">
+   
+    350,324
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">December</th>
+   
+   <td align="center">
+   
+    465,225
+   </td>
+   
+   <td align="center">
+   
+    435,114
+   </td>
+   
+   <td align="center">
+   
+    308,999
+   </td>
+   
+   <td align="center">
+   
+    326,933
+   </td>
+   
+   <td align="center">
+   
+    249,855
+   </td>
+   
+   <td align="center">
+   
+    322,056
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">Total</th>
+   
+   <td align="center">
+   
+    5,498,878
+   </td>
+   
+   <td align="center">
+   
+    4,976,093
+   </td>
+   
+   <td align="center">
+   
+    4,247,742
+   </td>
+   
+   <td align="center">
+   
+    3,714,259
+   </td>
+   
+   <td align="center">
+   
+    2,905,566
+   </td>
+   
+   <td align="center">
+   
+    4,171,703
+   </td>
+   
+   </tr>
+   </tbody>
+   </table>
+   
+   <br><br><br>
+   <span id="title">Passengers Figure(1996-2001) </span><br><br>
+   <table class="style1">
+   <tbody>
+   <tr height="17">
+   <th align="right">&nbsp; </th>
+   
+   <th align="center">2001</th>
+   
+   <th align="center">2000</th>
+   
+   <th align="center">1999</th>
+   
+   <th align="center">1998</th>
+   
+   <th align="center">1997</th>
+   
+   <th align="center">1996</th>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">January</th>
+   
+   <td align="center">
+    
+    265,603
+   </td>
+   
+   <td align="center">
+    
+    184,381
+   </td>
+   
+   <td align="center">
+    
+    161,264
+   </td>
+   
+   <td align="center">
+    
+    161,432
+   </td>
+   
+   <td align="center">
+    
+    117,984
+   </td>
+   
+   <td align="center">
+    
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">February</th>
+   
+   <td align="center">
+   
+    249,259
+   </td>
+   
+   <td align="center">
+   
+    264,066
+   </td>
+   
+   <td align="center">
+   
+    209,569
+   </td>
+   
+   <td align="center">
+   
+    168,777
+   </td>
+   
+   <td align="center">
+   
+    150,772
+   </td>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">March</th>
+   
+   <td align="center">
+   
+    312,319
+   </td>
+   
+   <td align="center">
+   
+    226,483
+   </td>
+   
+   <td align="center">
+   
+    186,965
+   </td>
+   
+   <td align="center">
+   
+    172,060
+   </td>
+   
+   <td align="center">
+   
+    149,795
+   </td>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">April</th>
+   
+   <td align="center">
+   
+    351,793
+   </td>
+   
+   <td align="center">
+   
+    296,541
+   </td>
+   
+   <td align="center">
+   
+    237,449
+   </td>
+   
+   <td align="center">
+   
+    180,241
+   </td>
+   
+   <td align="center">
+   
+    179,049
+   </td>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">May</th>
+   
+   <td align="center">
+   
+    338,692
+   </td>
+   
+   <td align="center">
+   
+    288,949
+   </td>
+   
+   <td align="center">
+   
+    230,691
+   </td>
+   
+   <td align="center">
+   
+    172,391
+   </td>
+   
+   <td align="center">
+   
+    189,925
+   </td>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">June</th>
+   
+   <td align="center">
+   
+    332,630
+   </td>
+   
+   <td align="center">
+   
+    271,181
+   </td>
+   
+   <td align="center">
+   
+    231,328
+   </td>
+   
+   <td align="center">
+   
+    157,519
+   </td>
+   
+   <td align="center">
+   
+    175,402
+   </td>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">July</th>
+   
+   <td align="center">
+   
+    344,658
+   </td>
+   
+   <td align="center">
+   
+    304,276
+   </td>
+   
+   <td align="center">
+   
+    243,534
+   </td>
+   
+   <td align="center">
+   
+    205,595
+   </td>
+   
+   <td align="center">
+   
+    173,103
+   </td>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">August</th>
+   
+   <td align="center">
+   
+    360,899
+   </td>
+   
+   <td align="center">
+   
+    300,418
+   </td>
+   
+   <td align="center">
+   
+    257,616
+   </td>
+   
+   <td align="center">
+   
+    241,140
+   </td>
+   
+   <td align="center">
+   
+    178,118
+   </td>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">September</th>
+   
+   <td align="center">
+   
+    291,817
+   </td>
+   
+   <td align="center">
+   
+    280,803
+   </td>
+   
+   <td align="center">
+   
+    210,885
+   </td>
+   
+   <td align="center">
+   
+    183,954
+   </td>
+   
+   <td align="center">
+   
+    163,385
+   </td>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">October</th>
+   
+   <td align="center">
+   
+    327,232
+   </td>
+   
+   <td align="center">
+   
+    298,873
+   </td>
+   
+   <td align="center">
+   
+    231,251
+   </td>
+   
+   <td align="center">
+   
+    205,726
+   </td>
+   
+   <td align="center">
+   
+    176,879
+   </td>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">November</th>
+   
+   <td align="center">
+   
+    315,538
+   </td>
+   
+   <td align="center">
+   
+    265,528
+   </td>
+   
+   <td align="center">
+   
+    228,637
+   </td>
+   
+   <td align="center">
+   
+    181,677
+   </td>
+   
+   <td align="center">
+   
+    146,804
+   </td>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">December</th>
+   
+   <td align="center">
+   
+    314,866
+   </td>
+   
+   <td align="center">
+   
+    257,929
+   </td>
+   
+   <td align="center">
+   
+    210,922
+   </td>
+   
+   <td align="center">
+   
+    183,975
+   </td>
+   
+   <td align="center">
+   
+    151,362
+   </td>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">Total</th>
+   
+   <td align="center">
+   
+    3,805,306
+   </td>
+   
+   <td align="center">
+   
+    3,239,428
+   </td>
+   
+   <td align="center">
+   
+    2,640,111
+   </td>
+   
+   <td align="center">
+   
+    2,214,487
+   </td>
+   
+   <td align="center">
+   
+    1,952,578
+   </td>
+   
+   <td align="center">
+   
+    0
+   </td>
+   
+   </tr>
+   </tbody>
+   </table>
+   
+   <br><br><br>
+   <span id="title">Passengers Figure(1995-1995) </span><br><br>
+   <table class="style1">
+   <tbody>
+   <tr height="17">
+   <th align="right">&nbsp; </th>
+   
+   <th align="center">1995</th>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">January</th>
+   
+   <td align="center">
+    
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">February</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">March</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">April</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">May</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">June</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">July</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">August</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">September</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">October</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">November</th>
+   
+   <td align="center">
+   
+    6,601
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">December</th>
+   
+   <td align="center">
+   
+    37,041
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">Total</th>
+   
+   <td align="center">
+   
+    43,642
+   </td>
+   
+   </tr>
+   </tbody>
+   </table>
+   
+
+   <br><br><br>
+   <div align="right"><img src="./macau_files/pass_stat.jpg" alt="passenger statistic picture" width="565" height="318"></div>
+   <br><br><br>
+   
+   
+   <!--statistics-movement  --> 
+   
+   <br><br><br>
+   <span id="title">Movement Statistics(2008-2013) </span><br><br>
+   <table class="style1">
+   <tbody>
+   <tr height="17">
+   <th align="right">&nbsp; </th>
+   
+   <th align="center">2013</th>
+   
+   <th align="center">2012</th>
+   
+   <th align="center">2011</th>
+   
+   <th align="center">2010</th>
+   
+   <th align="center">2009</th>
+   
+   <th align="center">2008</th>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">January</th>
+   
+   <td align="center">
+   
+    3,925
+   </td>
+   
+   <td align="center">
+   
+    3,463
+   </td>
+   
+   <td align="center">
+   
+    3,289
+   </td>
+   
+   <td align="center">
+   
+    3,184
+   </td>
+   
+   <td align="center">
+   
+    3,488
+   </td>
+   
+   <td align="center">
+   
+    4,568
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">February</th>
+   
+   <td align="center">
+   
+    3,632
+   </td>
+   
+   <td align="center">
+   
+    2,983
+   </td>
+   
+   <td align="center">
+   
+    2,902
+   </td>
+   
+   <td align="center">
+   
+    3,053
+   </td>
+   
+   <td align="center">
+   
+    3,347
+   </td>
+   
+   <td align="center">
+   
+    4,527
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">March</th>
+   
+   <td align="center">
+   
+    3,909
+   </td>
+   
+   <td align="center">
+   
+    3,166
+   </td>
+   
+   <td align="center">
+   
+    3,217
+   </td>
+   
+   <td align="center">
+   
+    3,175
+   </td>
+   
+   <td align="center">
+   
+    3,636
+   </td>
+   
+   <td align="center">
+   
+    4,594
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">April</th>
+   
+   <td align="center">
+   
+    3,903
+   </td>
+   
+   <td align="center">
+   
+    3,258
+   </td>
+   
+   <td align="center">
+   
+    3,146
+   </td>
+   
+   <td align="center">
+   
+    3,023
+   </td>
+   
+   <td align="center">
+   
+    3,709
+   </td>
+   
+   <td align="center">
+   
+    4,574
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">May</th>
+   
+   <td align="center">
+   
+    4,075
+   </td>
+   
+   <td align="center">
+   
+    3,234
+   </td>
+   
+   <td align="center">
+   
+    3,266
+   </td>
+   
+   <td align="center">
+   
+    3,033
+   </td>
+   
+   <td align="center">
+   
+    3,603
+   </td>
+   
+   <td align="center">
+   
+    4,511
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">June</th>
+   
+   <td align="center">
+   
+    4,038
+   </td>
+   
+   <td align="center">
+   
+    3,272
+   </td>
+   
+   <td align="center">
+   
+    3,316
+   </td>
+   
+   <td align="center">
+   
+    2,909
+   </td>
+   
+   <td align="center">
+   
+    3,057
+   </td>
+   
+   <td align="center">
+   
+    4,081
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">July</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   <td align="center">
+   
+    3,661
+   </td>
+   
+   <td align="center">
+   
+    3,359
+   </td>
+   
+   <td align="center">
+   
+    3,062
+   </td>
+   
+   <td align="center">
+   
+    3,354
+   </td>
+   
+   <td align="center">
+   
+    4,215
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">August</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   <td align="center">
+   
+    3,942
+   </td>
+   
+   <td align="center">
+   
+    3,417
+   </td>
+   
+   <td align="center">
+   
+    3,077
+   </td>
+   
+   <td align="center">
+   
+    3,395
+   </td>
+   
+   <td align="center">
+   
+    4,139
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">September</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   <td align="center">
+   
+    3,703
+   </td>
+   
+   <td align="center">
+   
+    3,169
+   </td>
+   
+   <td align="center">
+   
+    3,095
+   </td>
+   
+   <td align="center">
+   
+    3,100
+   </td>
+   
+   <td align="center">
+   
+    3,752
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">October</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   <td align="center">
+   
+    3,727
+   </td>
+   
+   <td align="center">
+   
+    3,469
+   </td>
+   
+   <td align="center">
+   
+    3,179
+   </td>
+   
+   <td align="center">
+   
+    3,375
+   </td>
+   
+   <td align="center">
+   
+    3,874
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">November</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   <td align="center">
+   
+    3,722
+   </td>
+   
+   <td align="center">
+   
+    3,145
+   </td>
+   
+   <td align="center">
+   
+    3,159
+   </td>
+   
+   <td align="center">
+   
+    3,213
+   </td>
+   
+   <td align="center">
+   
+    3,567
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">December</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   <td align="center">
+   
+    3,866
+   </td>
+   
+   <td align="center">
+   
+    3,251
+   </td>
+   
+   <td align="center">
+   
+    3,199
+   </td>
+   
+   <td align="center">
+   
+    3,324
+   </td>
+   
+   <td align="center">
+   
+    3,362
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">Total</th>
+   
+   <td align="center">
+   
+    23,482
+   </td>
+   
+   <td align="center">
+   
+    41,997
+   </td>
+   
+   <td align="center">
+   
+    38,946
+   </td>
+   
+   <td align="center">
+   
+    37,148
+   </td>
+   
+   <td align="center">
+   
+    40,601
+   </td>
+   
+   <td align="center">
+   
+    49,764
+   </td>
+   
+   </tr>
+   </tbody>
+   </table>
+   
+   <br><br><br>
+   <span id="title">Movement Statistics(2002-2007) </span><br><br>
+   <table class="style1">
+   <tbody>
+   <tr height="17">
+   <th align="right">&nbsp; </th>
+   
+   <th align="center">2007</th>
+   
+   <th align="center">2006</th>
+   
+   <th align="center">2005</th>
+   
+   <th align="center">2004</th>
+   
+   <th align="center">2003</th>
+   
+   <th align="center">2002</th>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">January</th>
+   
+   <td align="center">
+   
+    4,384
+   </td>
+   
+   <td align="center">
+   
+    3,933
+   </td>
+   
+   <td align="center">
+   
+    3,528
+   </td>
+   
+   <td align="center">
+   
+    3,051
+   </td>
+   
+   <td align="center">
+   
+    3,257
+   </td>
+   
+   <td align="center">
+   
+    2,711
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">February</th>
+   
+   <td align="center">
+   
+    4,131
+   </td>
+   
+   <td align="center">
+   
+    3,667
+   </td>
+   
+   <td align="center">
+   
+    3,331
+   </td>
+   
+   <td align="center">
+   
+    2,372
+   </td>
+   
+   <td align="center">
+   
+    3,003
+   </td>
+   
+   <td align="center">
+   
+    2,747
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">March</th>
+   
+   <td align="center">
+   
+    4,349
+   </td>
+   
+   <td align="center">
+   
+    4,345
+   </td>
+   
+   <td align="center">
+   
+    3,549
+   </td>
+   
+   <td align="center">
+   
+    3,049
+   </td>
+   
+   <td align="center">
+   
+    3,109
+   </td>
+   
+   <td align="center">
+   
+    2,985
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">April</th>
+   
+   <td align="center">
+   
+    4,460
+   </td>
+   
+   <td align="center">
+   
+    4,490
+   </td>
+   
+   <td align="center">
+   
+    3,832
+   </td>
+   
+   <td align="center">
+   
+    3,359
+   </td>
+   
+   <td align="center">
+   
+    2,033
+   </td>
+   
+   <td align="center">
+   
+    2,928
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">May</th>
+   
+   <td align="center">
+   
+    4,629
+   </td>
+   
+   <td align="center">
+   
+    4,245
+   </td>
+   
+   <td align="center">
+   
+    3,663
+   </td>
+   
+   <td align="center">
+   
+    3,251
+   </td>
+   
+   <td align="center">
+   
+    1,229
+   </td>
+   
+   <td align="center">
+   
+    3,109
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">June</th>
+   
+   <td align="center">
+   
+    4,365
+   </td>
+   
+   <td align="center">
+   
+    4,124
+   </td>
+   
+   <td align="center">
+   
+    3,752
+   </td>
+   
+   <td align="center">
+   
+    3,414
+   </td>
+   
+   <td align="center">
+   
+    1,217
+   </td>
+   
+   <td align="center">
+   
+    3,049
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">July</th>
+   
+   <td align="center">
+   
+    4,612
+   </td>
+   
+   <td align="center">
+   
+    4,386
+   </td>
+   
+   <td align="center">
+   
+    3,876
+   </td>
+   
+   <td align="center">
+   
+    3,664
+   </td>
+   
+   <td align="center">
+   
+    2,423
+   </td>
+   
+   <td align="center">
+   
+    3,078
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">August</th>
+   
+   <td align="center">
+   
+    4,446
+   </td>
+   
+   <td align="center">
+   
+    4,373
+   </td>
+   
+   <td align="center">
+   
+    3,987
+   </td>
+   
+   <td align="center">
+   
+    3,631
+   </td>
+   
+   <td align="center">
+   
+    3,040
+   </td>
+   
+   <td align="center">
+   
+    3,166
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">September</th>
+   
+   <td align="center">
+   
+    4,414
+   </td>
+   
+   <td align="center">
+   
+    4,311
+   </td>
+   
+   <td align="center">
+   
+    3,782
+   </td>
+   
+   <td align="center">
+   
+    3,514
+   </td>
+   
+   <td align="center">
+   
+    2,809
+   </td>
+   
+   <td align="center">
+   
+    3,239
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">October</th>
+   
+   <td align="center">
+   
+    4,445
+   </td>
+   
+   <td align="center">
+   
+    4,455
+   </td>
+   
+   <td align="center">
+   
+    3,898
+   </td>
+   
+   <td align="center">
+   
+    3,744
+   </td>
+   
+   <td align="center">
+   
+    3,052
+   </td>
+   
+   <td align="center">
+   
+    3,562
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">November</th>
+   
+   <td align="center">
+   
+    4,563
+   </td>
+   
+   <td align="center">
+   
+    4,285
+   </td>
+   
+   <td align="center">
+   
+    3,951
+   </td>
+   
+   <td align="center">
+   
+    3,694
+   </td>
+   
+   <td align="center">
+   
+    3,125
+   </td>
+   
+   <td align="center">
+   
+    3,546
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">December</th>
+   
+   <td align="center">
+   
+    4,588
+   </td>
+   
+   <td align="center">
+   
+    4,435
+   </td>
+   
+   <td align="center">
+   
+    3,855
+   </td>
+   
+   <td align="center">
+   
+    3,763
+   </td>
+   
+   <td align="center">
+   
+    2,996
+   </td>
+   
+   <td align="center">
+   
+    3,444
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">Total</th>
+   
+   <td align="center">
+   
+    53,386
+   </td>
+   
+   <td align="center">
+   
+    51,049
+   </td>
+   
+   <td align="center">
+   
+    45,004
+   </td>
+   
+   <td align="center">
+   
+    40,506
+   </td>
+   
+   <td align="center">
+   
+    31,293
+   </td>
+   
+   <td align="center">
+   
+    37,564
+   </td>
+   
+   </tr>
+   </tbody>
+   </table>
+   
+   <br><br><br>
+   <span id="title">Movement Statistics(1996-2001) </span><br><br>
+   <table class="style1">
+   <tbody>
+   <tr height="17">
+   <th align="right">&nbsp; </th>
+   
+   <th align="center">2001</th>
+   
+   <th align="center">2000</th>
+   
+   <th align="center">1999</th>
+   
+   <th align="center">1998</th>
+   
+   <th align="center">1997</th>
+   
+   <th align="center">1996</th>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">January</th>
+   
+   <td align="center">
+   
+    2,694
+   </td>
+   
+   <td align="center">
+   
+    2,201
+   </td>
+   
+   <td align="center">
+   
+    1,835
+   </td>
+   
+   <td align="center">
+   
+    2,177
+   </td>
+   
+   <td align="center">
+   
+    1,353
+   </td>
+   
+   <td align="center">
+   
+    744
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">February</th>
+   
+   <td align="center">
+   
+    2,364
+   </td>
+   
+   <td align="center">
+   
+    2,357
+   </td>
+   
+   <td align="center">
+   
+    1,826
+   </td>
+   
+   <td align="center">
+   
+    1,740
+   </td>
+   
+   <td align="center">
+   
+    1,339
+   </td>
+   
+   <td align="center">
+   
+    692
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">March</th>
+   
+   <td align="center">
+   
+    2,543
+   </td>
+   
+   <td align="center">
+   
+    2,206
+   </td>
+   
+   <td align="center">
+   
+    1,895
+   </td>
+   
+   <td align="center">
+   
+    1,911
+   </td>
+   
+   <td align="center">
+   
+    1,533
+   </td>
+   
+   <td align="center">
+   
+    872
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">April</th>
+   
+   <td align="center">
+   
+    2,531
+   </td>
+   
+   <td align="center">
+   
+    2,311
+   </td>
+   
+   <td align="center">
+   
+    2,076
+   </td>
+   
+   <td align="center">
+   
+    1,886
+   </td>
+   
+   <td align="center">
+   
+    1,587
+   </td>
+   
+   <td align="center">
+   
+    1,026
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">May</th>
+   
+   <td align="center">
+   
+    2,579
+   </td>
+   
+   <td align="center">
+   
+    2,383
+   </td>
+   
+   <td align="center">
+   
+    1,914
+   </td>
+   
+   <td align="center">
+   
+    2,102
+   </td>
+   
+   <td align="center">
+   
+    1,720
+   </td>
+   
+   <td align="center">
+   
+    1,115
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">June</th>
+   
+   <td align="center">
+   
+    2,681
+   </td>
+   
+   <td align="center">
+   
+    2,370
+   </td>
+   
+   <td align="center">
+   
+    1,890
+   </td>
+   
+   <td align="center">
+   
+    2,038
+   </td>
+   
+   <td align="center">
+   
+    1,716
+   </td>
+   
+   <td align="center">
+   
+    1,037
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">July</th>
+   
+   <td align="center">
+   
+    2,903
+   </td>
+   
+   <td align="center">
+   
+    2,609
+   </td>
+   
+   <td align="center">
+   
+    1,916
+   </td>
+   
+   <td align="center">
+   
+    2,078
+   </td>
+   
+   <td align="center">
+   
+    1,693
+   </td>
+   
+   <td align="center">
+   
+    1,209
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">August</th>
+   
+   <td align="center">
+   
+    3,037
+   </td>
+   
+   <td align="center">
+   
+    2,487
+   </td>
+   
+   <td align="center">
+   
+    1,968
+   </td>
+   
+   <td align="center">
+   
+    2,061
+   </td>
+   
+   <td align="center">
+   
+    1,676
+   </td>
+   
+   <td align="center">
+   
+    1,241
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">September</th>
+   
+   <td align="center">
+   
+    2,767
+   </td>
+   
+   <td align="center">
+   
+    2,329
+   </td>
+   
+   <td align="center">
+   
+    1,955
+   </td>
+   
+   <td align="center">
+   
+    1,970
+   </td>
+   
+   <td align="center">
+   
+    1,681
+   </td>
+   
+   <td align="center">
+   
+    1,263
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">October</th>
+   
+   <td align="center">
+   
+    2,922
+   </td>
+   
+   <td align="center">
+   
+    2,417
+   </td>
+   
+   <td align="center">
+   
+    2,267
+   </td>
+   
+   <td align="center">
+   
+    1,969
+   </td>
+   
+   <td align="center">
+   
+    1,809
+   </td>
+   
+   <td align="center">
+   
+    1,368
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">November</th>
+   
+   <td align="center">
+   
+    2,670
+   </td>
+   
+   <td align="center">
+   
+    2,273
+   </td>
+   
+   <td align="center">
+   
+    2,132
+   </td>
+   
+   <td align="center">
+   
+    2,102
+   </td>
+   
+   <td align="center">
+   
+    1,786
+   </td>
+   
+   <td align="center">
+   
+    1,433
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">December</th>
+   
+   <td align="center">
+   
+    2,815
+   </td>
+   
+   <td align="center">
+   
+    2,749
+   </td>
+   
+   <td align="center">
+   
+    2,187
+   </td>
+   
+   <td align="center">
+   
+    1,981
+   </td>
+   
+   <td align="center">
+   
+    1,944
+   </td>
+   
+   <td align="center">
+   
+    1,386
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">Total</th>
+   
+   <td align="center">
+   
+    32,506
+   </td>
+   
+   <td align="center">
+   
+    28,692
+   </td>
+   
+   <td align="center">
+   
+    23,861
+   </td>
+   
+   <td align="center">
+   
+    24,015
+   </td>
+   
+   <td align="center">
+   
+    19,837
+   </td>
+   
+   <td align="center">
+   
+    13,386
+   </td>
+   
+   </tr>
+   </tbody>
+   </table>
+   
+   <br><br><br>
+   <span id="title">Movement Statistics(1995-1995) </span><br><br>
+   <table class="style1">
+   <tbody>
+   <tr height="17">
+   <th align="right">&nbsp; </th>
+   
+   <th align="center">1995</th>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">January</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">February</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">March</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">April</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">May</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">June</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">July</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">August</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">September</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">October</th>
+   
+   <td align="center">
+   
+    
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">November</th>
+   
+   <td align="center">
+   
+    126
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">December</th>
+   
+   <td align="center">
+   
+    536
+   </td>
+   
+   </tr>
+   <tr height="17">
+   <th align="right">Total</th>
+   
+   <td align="center">
+   
+    662
+   </td>
+   
+   </tr>
+   </tbody>
+   </table>
+   
+
+   <br><br><br>
+   <div align="right"><img src="./macau_files/mov_stat.jpg" alt="passenger statistic picture" width="565" height="318"></div>
+
+          		
+  </div>
+            
+          </div>
+                     </div>
+            </div>
+         
+          
+          <!--/*end context*/-->
+          </div>
+    </div>
+  
+	<div id="buttombar"><img height="100" src="./macau_files/buttombar.gif"></div>
+	<div id="logo">
+
+
+		
+		<div>
+		
+          <a href="http://www.macau-airport.com/envirop/zh/default.php" style="display: inline;"><img height="80" src="./macau_files/38.jpg"></a>
+		
+		</div>
+
+		
+		<div>
+		
+          <a href="http://www.macau-airport.com/envirop/en/default.php" style="display: inline;"><img height="80" src="./macau_files/36.jpg"></a>
+		
+		</div>
+
+</div>
+</div>
+
+
+
+</div>
+
+
+<div id="footer">
+<hr>
+  <div id="footer-left">
+  <a href="http://www.camacau.com/index">Main Page</a> | 
+  <a href="http://www.camacau.com/geographic_information">Our Business</a> | 
+  <a href="http://www.camacau.com/about_us">About Us</a> | 
+  <a href="http://www.camacau.com/pressReleases_list">Media Centre</a> | 
+  <a href="http://www.camacau.com/rlinks2">Related Links</a> | 
+  <a href="http://www.camacau.com/download_list">Interactive</a>
+  </div>
+  <div id="footer-right">Macau International Airport Co. Ltd. | Copyright 2013 | All rights reserved</div>
+</div>
+</div>
+</div>
+
+<div id="___fireplug_chrome_extension___" style="display: none;"></div><iframe id="rdbIndicator" width="100%" height="270" border="0" src="./macau_files/indicator.html" style="display: none; border: 0; position: fixed; left: 0; top: 0; z-index: 2147483647"></iframe><link rel="stylesheet" type="text/css" media="screen" href="chrome-extension://fcdjadjbdihbaodagojiomdljhjhjfho/css/atd.css"></body></html>

--- a/pandas/io/tests/data/nyse_wsj.html
+++ b/pandas/io/tests/data/nyse_wsj.html
@@ -1,0 +1,1207 @@
+<table border="0" cellpadding="0" cellspacing="0" class="autocompleteContainer">
+    <tbody>
+    <tr>
+        <td>
+            <div class="symbolCompleteContainer">
+                <div><input autocomplete="off" maxlength="80" name="KEYWORDS" type="text" value=""/></div>
+            </div>
+            <div class="hat_button">
+                <span class="hat_button_text">SEARCH</span>
+            </div> 
+            <div style="clear: both;"><div class="subSymbolCompleteResults"></div></div>
+        </td>
+    </tr>
+    </tbody>
+</table>
+<table bgcolor="" border="0" cellpadding="0" cellspacing="0" width="100%"><tbody><tr>
+        <td height="0"><img alt="" border="0" height="0" src="null/img/b.gif" width="1"/></td>
+</tr></tbody></table>
+<table border="0" cellpadding="0" cellspacing="0" class="mdcTable" width="100%">
+    <tbody><tr>
+        <td class="colhead" style="text-align:left"> </td>
+        <td class="colhead" style="text-align:left">Issue<span class="textb10gray" style="margin-left: 8px;">(Roll over for charts and headlines)</span>
+        </td>
+        <td class="colhead">Volume</td>
+        <td class="colhead">Price</td>
+        <td class="colhead" style="width:35px;">Chg</td>
+        <td class="colhead">% Chg</td>
+    </tr>
+    <tr>
+        <td class="num">1</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=JCP" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'JCP')">J.C. Penney (JCP)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">250,697,455</td>
+        <td class="nnum">$9.05</td>
+        <td class="nnum">-1.37</td>
+        <td class="nnum" style="border-right:0px">-13.15</td>
+    </tr>
+    <tr>
+        <td class="num">2</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=BAC" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'BAC')">Bank of America (BAC)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">77,162,103</td>
+        <td class="nnum">13.90</td>
+        <td class="nnum">-0.18</td>
+        <td class="nnum" style="border-right:0px">-1.28</td>
+    </tr>
+    <tr>
+        <td class="num">3</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=RAD" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'RAD')">Rite Aid (RAD)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">52,140,382</td>
+        <td class="nnum">4.70</td>
+        <td class="nnum">-0.08</td>
+        <td class="nnum" style="border-right:0px">-1.67</td>
+    </tr>
+    <tr>
+        <td class="num">4</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=F" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'F')">Ford Motor (F)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">33,745,287</td>
+        <td class="nnum">17.05</td>
+        <td class="nnum">-0.22</td>
+        <td class="nnum" style="border-right:0px">-1.27</td>
+    </tr>
+    <tr>
+        <td class="num">5</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=PFE" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'PFE')">Pfizer (PFE)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">27,801,853</td>
+        <td class="pnum">28.88</td>
+        <td class="pnum">0.36</td>
+        <td class="pnum" style="border-right:0px">1.26</td>
+    </tr>
+    <tr>
+        <td class="num">6</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=HTZ" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'HTZ')">Hertz Global Hldgs (HTZ)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">25,821,264</td>
+        <td class="pnum">22.32</td>
+        <td class="pnum">0.69</td>
+        <td class="pnum" style="border-right:0px">3.19</td>
+    </tr>
+    <tr>
+        <td class="num">7</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=GE" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'GE')">General Electric (GE)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">25,142,064</td>
+        <td class="nnum">24.05</td>
+        <td class="nnum">-0.20</td>
+        <td class="nnum" style="border-right:0px">-0.82</td>
+    </tr>
+    <tr>
+        <td class="num">8</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=ELN" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'ELN')">Elan ADS (ELN)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">24,725,209</td>
+        <td class="pnum">15.59</td>
+        <td class="pnum">0.08</td>
+        <td class="pnum" style="border-right:0px">0.52</td>
+    </tr>
+    <tr>
+        <td class="num">9</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=JPM" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'JPM')">JPMorgan Chase (JPM)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">22,402,756</td>
+        <td class="pnum">52.24</td>
+        <td class="pnum">0.35</td>
+        <td class="pnum" style="border-right:0px">0.67</td>
+    </tr>
+    <tr>
+        <td class="num">10</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=RF" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'RF')">Regions Financial (RF)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">20,790,532</td>
+        <td class="pnum">9.30</td>
+        <td class="pnum">0.12</td>
+        <td class="pnum" style="border-right:0px">1.31</td>
+    </tr>
+    <tr>
+        <td class="num">11</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=VMEM" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'VMEM')">Violin Memory (VMEM)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">20,669,846</td>
+        <td class="nnum">7.02</td>
+        <td class="nnum">-1.98</td>
+        <td class="nnum" style="border-right:0px">-22.00</td>
+    </tr>
+    <tr>
+        <td class="num">12</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=C" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'C')">Citigroup (C)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">19,979,932</td>
+        <td class="nnum">48.89</td>
+        <td class="nnum">-0.04</td>
+        <td class="nnum" style="border-right:0px">-0.08</td>
+    </tr>
+    <tr>
+        <td class="num">13</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=NOK" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'NOK')">Nokia ADS (NOK)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">19,585,075</td>
+        <td class="pnum">6.66</td>
+        <td class="pnum">0.02</td>
+        <td class="pnum" style="border-right:0px">0.30</td>
+    </tr>
+    <tr>
+        <td class="num">14</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=WFC" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'WFC')">Wells Fargo (WFC)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">19,478,590</td>
+        <td class="nnum">41.59</td>
+        <td class="nnum">-0.02</td>
+        <td class="nnum" style="border-right:0px">-0.05</td>
+    </tr>
+    <tr>
+        <td class="num">15</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=VALE" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'VALE')">Vale ADS (VALE)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">18,781,987</td>
+        <td class="nnum">15.60</td>
+        <td class="nnum">-0.52</td>
+        <td class="nnum" style="border-right:0px">-3.23</td>
+    </tr>
+    <tr>
+        <td class="num">16</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=DAL" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'DAL')">Delta Air Lines (DAL)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">16,013,956</td>
+        <td class="nnum">23.57</td>
+        <td class="nnum">-0.44</td>
+        <td class="nnum" style="border-right:0px">-1.83</td>
+    </tr>
+    <tr>
+        <td class="num">17</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=EMC" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'EMC')">EMC (EMC)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">15,771,252</td>
+        <td class="nnum">26.07</td>
+        <td class="nnum">-0.11</td>
+        <td class="nnum" style="border-right:0px">-0.42</td>
+    </tr>
+    <tr>
+        <td class="num">18</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=NKE" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'NKE')">Nike Cl B (NKE)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">15,514,717</td>
+        <td class="pnum">73.64</td>
+        <td class="pnum">3.30</td>
+        <td class="pnum" style="border-right:0px">4.69</td>
+    </tr>
+    <tr>
+        <td class="num">19</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=AA" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'AA')">Alcoa (AA)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">14,061,073</td>
+        <td class="nnum">8.20</td>
+        <td class="nnum">-0.07</td>
+        <td class="nnum" style="border-right:0px">-0.85</td>
+    </tr>
+    <tr>
+        <td class="num">20</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=GM" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'GM')">General Motors (GM)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">13,984,004</td>
+        <td class="nnum">36.37</td>
+        <td class="nnum">-0.58</td>
+        <td class="nnum" style="border-right:0px">-1.57</td>
+    </tr>
+    <tr>
+        <td class="num">21</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=ORCL" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'ORCL')">Oracle (ORCL)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">13,856,671</td>
+        <td class="nnum">33.78</td>
+        <td class="nnum">-0.03</td>
+        <td class="nnum" style="border-right:0px">-0.09</td>
+    </tr>
+    <tr>
+        <td class="num">22</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=T" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'T')">AT&amp;T (T)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">13,736,948</td>
+        <td class="nnum">33.98</td>
+        <td class="nnum">-0.25</td>
+        <td class="nnum" style="border-right:0px">-0.73</td>
+    </tr>
+    <tr>
+        <td class="num">23</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=TSL" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'TSL')">Trina Solar ADS (TSL)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">13,284,202</td>
+        <td class="pnum">14.83</td>
+        <td class="pnum">1.99</td>
+        <td class="pnum" style="border-right:0px">15.50</td>
+    </tr>
+    <tr>
+        <td class="num">24</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=YGE" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'YGE')">Yingli Green Energy Holding ADS (YGE)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">12,978,378</td>
+        <td class="pnum">6.73</td>
+        <td class="pnum">0.63</td>
+        <td class="pnum" style="border-right:0px">10.33</td>
+    </tr>
+    <tr>
+        <td class="num">25</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=PBR" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'PBR')">Petroleo Brasileiro ADS (PBR)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">12,833,660</td>
+        <td class="nnum">15.40</td>
+        <td class="nnum">-0.21</td>
+        <td class="nnum" style="border-right:0px">-1.35</td>
+    </tr>
+    <tr>
+        <td class="num">26</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=UAL" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'UAL')">United Continental Holdings (UAL)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">12,603,225</td>
+        <td class="nnum">30.91</td>
+        <td class="nnum">-3.16</td>
+        <td class="nnum" style="border-right:0px">-9.28</td>
+    </tr>
+    <tr>
+        <td class="num">27</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=KO" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'KO')">Coca-Cola (KO)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">12,343,452</td>
+        <td class="nnum">38.40</td>
+        <td class="nnum">-0.34</td>
+        <td class="nnum" style="border-right:0px">-0.88</td>
+    </tr>
+    <tr>
+        <td class="num">28</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=ACI" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'ACI')">Arch Coal (ACI)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">12,261,138</td>
+        <td class="nnum">4.25</td>
+        <td class="nnum">-0.28</td>
+        <td class="nnum" style="border-right:0px">-6.18</td>
+    </tr>
+    <tr>
+        <td class="num">29</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=MS" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'MS')">Morgan Stanley (MS)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">11,956,345</td>
+        <td class="nnum">27.08</td>
+        <td class="nnum">-0.07</td>
+        <td class="nnum" style="border-right:0px">-0.26</td>
+    </tr>
+    <tr>
+        <td class="num">30</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=P" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'P')">Pandora Media (P)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">11,829,963</td>
+        <td class="pnum">25.52</td>
+        <td class="pnum">0.13</td>
+        <td class="pnum" style="border-right:0px">0.51</td>
+    </tr>
+    <tr>
+        <td class="num">31</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=ABX" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'ABX')">Barrick Gold (ABX)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">11,775,585</td>
+        <td class="num">18.53</td>
+        <td class="num">0.00</td>
+        <td class="num" style="border-right:0px">0.00</td>
+    </tr>
+    <tr>
+        <td class="num">32</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=ABT" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'ABT')">Abbott Laboratories (ABT)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">11,755,718</td>
+        <td class="nnum">33.14</td>
+        <td class="nnum">-0.52</td>
+        <td class="nnum" style="border-right:0px">-1.54</td>
+    </tr>
+    <tr>
+        <td class="num">33</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=BSBR" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'BSBR')">Banco Santander Brasil ADS (BSBR)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">11,587,310</td>
+        <td class="pnum">7.01</td>
+        <td class="pnum">0.46</td>
+        <td class="pnum" style="border-right:0px">7.02</td>
+    </tr>
+    <tr>
+        <td class="num">34</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=AMD" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'AMD')">Advanced Micro Devices (AMD)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">11,337,609</td>
+        <td class="nnum">3.86</td>
+        <td class="nnum">-0.03</td>
+        <td class="nnum" style="border-right:0px">-0.77</td>
+    </tr>
+    <tr>
+        <td class="num">35</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=NLY" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'NLY')">Annaly Capital Management (NLY)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">11,004,440</td>
+        <td class="nnum">11.63</td>
+        <td class="nnum">-0.07</td>
+        <td class="nnum" style="border-right:0px">-0.60</td>
+    </tr>
+    <tr>
+        <td class="num">36</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=ANR" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'ANR')">Alpha Natural Resources (ANR)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">10,941,074</td>
+        <td class="nnum">6.08</td>
+        <td class="nnum">-0.19</td>
+        <td class="nnum" style="border-right:0px">-3.03</td>
+    </tr>
+    <tr>
+        <td class="num">37</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=XOM" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'XOM')">Exxon Mobil (XOM)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">10,668,115</td>
+        <td class="nnum">86.90</td>
+        <td class="nnum">-0.17</td>
+        <td class="nnum" style="border-right:0px">-0.20</td>
+    </tr>
+    <tr>
+        <td class="num">38</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=ITUB" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'ITUB')">Itau Unibanco Holding ADS (ITUB)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">10,638,803</td>
+        <td class="pnum">14.30</td>
+        <td class="pnum">0.23</td>
+        <td class="pnum" style="border-right:0px">1.63</td>
+    </tr>
+    <tr>
+        <td class="num">39</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=MRK" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'MRK')">Merck&amp;Co (MRK)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">10,388,152</td>
+        <td class="pnum">47.79</td>
+        <td class="pnum">0.11</td>
+        <td class="pnum" style="border-right:0px">0.23</td>
+    </tr>
+    <tr>
+        <td class="num">40</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=ALU" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'ALU')">Alcatel-Lucent ADS (ALU)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">10,181,833</td>
+        <td class="pnum">3.65</td>
+        <td class="pnum">0.01</td>
+        <td class="pnum" style="border-right:0px">0.27</td>
+    </tr>
+    <tr>
+        <td class="num">41</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=VZ" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'VZ')">Verizon Communications (VZ)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">10,139,321</td>
+        <td class="nnum">47.00</td>
+        <td class="nnum">-0.67</td>
+        <td class="nnum" style="border-right:0px">-1.41</td>
+    </tr>
+    <tr>
+        <td class="num">42</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=MHR" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'MHR')">Magnum Hunter Resources (MHR)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">10,004,303</td>
+        <td class="pnum">6.33</td>
+        <td class="pnum">0.46</td>
+        <td class="pnum" style="border-right:0px">7.84</td>
+    </tr>
+    <tr>
+        <td class="num">43</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=HPQ" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'HPQ')">Hewlett-Packard (HPQ)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">9,948,935</td>
+        <td class="nnum">21.17</td>
+        <td class="nnum">-0.13</td>
+        <td class="nnum" style="border-right:0px">-0.61</td>
+    </tr>
+    <tr>
+        <td class="num">44</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=PHM" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'PHM')">PulteGroup (PHM)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">9,899,141</td>
+        <td class="nnum">16.57</td>
+        <td class="nnum">-0.41</td>
+        <td class="nnum" style="border-right:0px">-2.41</td>
+    </tr>
+    <tr>
+        <td class="num">45</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=SOL" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'SOL')">ReneSola ADS (SOL)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">9,667,438</td>
+        <td class="pnum">4.84</td>
+        <td class="pnum">0.39</td>
+        <td class="pnum" style="border-right:0px">8.76</td>
+    </tr>
+    <tr>
+        <td class="num">46</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=GLW" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'GLW')">Corning (GLW)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">9,547,265</td>
+        <td class="nnum">14.73</td>
+        <td class="nnum">-0.21</td>
+        <td class="nnum" style="border-right:0px">-1.41</td>
+    </tr>
+    <tr>
+        <td class="num">47</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=COLE" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'COLE')">Cole Real Estate Investments (COLE)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">9,544,021</td>
+        <td class="pnum">12.21</td>
+        <td class="pnum">0.01</td>
+        <td class="pnum" style="border-right:0px">0.08</td>
+    </tr>
+    <tr>
+        <td class="num">48</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=DOW" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'DOW')">Dow Chemical (DOW)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">9,150,479</td>
+        <td class="nnum">39.02</td>
+        <td class="nnum">-0.97</td>
+        <td class="nnum" style="border-right:0px">-2.43</td>
+    </tr>
+    <tr>
+        <td class="num">49</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=IGT" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'IGT')">International Game Technology (IGT)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">9,129,123</td>
+        <td class="nnum">19.23</td>
+        <td class="nnum">-1.44</td>
+        <td class="nnum" style="border-right:0px">-6.97</td>
+    </tr>
+    <tr>
+        <td class="num">50</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=ACN" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'ACN')">Accenture Cl A (ACN)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">8,773,260</td>
+        <td class="nnum">74.09</td>
+        <td class="nnum">-1.78</td>
+        <td class="nnum" style="border-right:0px">-2.35</td>
+    </tr>
+    <tr>
+        <td class="num">51</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=KEY" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'KEY')">KeyCorp (KEY)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">8,599,333</td>
+        <td class="pnum">11.36</td>
+        <td class="pnum">0.02</td>
+        <td class="pnum" style="border-right:0px">0.18</td>
+    </tr>
+    <tr>
+        <td class="num">52</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=BMY" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'BMY')">Bristol-Myers Squibb (BMY)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">8,440,709</td>
+        <td class="nnum">46.20</td>
+        <td class="nnum">-0.73</td>
+        <td class="nnum" style="border-right:0px">-1.56</td>
+    </tr>
+    <tr>
+        <td class="num">53</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=SID" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'SID')">Companhia Siderurgica Nacional ADS (SID)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">8,437,636</td>
+        <td class="nnum">4.36</td>
+        <td class="nnum">-0.05</td>
+        <td class="nnum" style="border-right:0px">-1.13</td>
+    </tr>
+    <tr>
+        <td class="num">54</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=HRB" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'HRB')">H&amp;R Block (HRB)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">8,240,984</td>
+        <td class="pnum">26.36</td>
+        <td class="pnum">0.31</td>
+        <td class="pnum" style="border-right:0px">1.19</td>
+    </tr>
+    <tr>
+        <td class="num">55</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=MTG" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'MTG')">MGIC Investment (MTG)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">8,135,037</td>
+        <td class="nnum">7.26</td>
+        <td class="nnum">-0.10</td>
+        <td class="nnum" style="border-right:0px">-1.36</td>
+    </tr>
+    <tr>
+        <td class="num">56</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=RNG" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'RNG')">RingCentral Cl A (RNG)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">8,117,469</td>
+        <td class="pnum">18.20</td>
+        <td class="pnum">5.20</td>
+        <td class="pnum" style="border-right:0px">40.00</td>
+    </tr>
+    <tr>
+        <td class="num">57</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=X" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'X')">United States Steel (X)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">8,107,899</td>
+        <td class="nnum">20.44</td>
+        <td class="nnum">-0.66</td>
+        <td class="nnum" style="border-right:0px">-3.13</td>
+    </tr>
+    <tr>
+        <td class="num">58</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=CLF" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'CLF')">Cliffs Natural Resources (CLF)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">8,041,572</td>
+        <td class="nnum">21.00</td>
+        <td class="nnum">-0.83</td>
+        <td class="nnum" style="border-right:0px">-3.80</td>
+    </tr>
+    <tr>
+        <td class="num">59</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=NEM" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'NEM')">Newmont Mining (NEM)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">8,014,250</td>
+        <td class="nnum">27.98</td>
+        <td class="nnum">-0.19</td>
+        <td class="nnum" style="border-right:0px">-0.67</td>
+    </tr>
+    <tr>
+        <td class="num">60</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=MO" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'MO')">Altria Group (MO)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">7,786,048</td>
+        <td class="nnum">34.71</td>
+        <td class="nnum">-0.29</td>
+        <td class="nnum" style="border-right:0px">-0.83</td>
+    </tr>
+    <tr>
+        <td class="num">61</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=SD" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'SD')">SandRidge Energy (SD)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">7,782,745</td>
+        <td class="nnum">5.93</td>
+        <td class="nnum">-0.06</td>
+        <td class="nnum" style="border-right:0px">-1.00</td>
+    </tr>
+    <tr>
+        <td class="num">62</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=MCP" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'MCP')">Molycorp (MCP)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">7,735,831</td>
+        <td class="nnum">6.73</td>
+        <td class="nnum">-0.45</td>
+        <td class="nnum" style="border-right:0px">-6.27</td>
+    </tr>
+    <tr>
+        <td class="num">63</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=HAL" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'HAL')">Halliburton (HAL)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">7,728,735</td>
+        <td class="nnum">48.39</td>
+        <td class="nnum">-0.32</td>
+        <td class="nnum" style="border-right:0px">-0.66</td>
+    </tr>
+    <tr>
+        <td class="num">64</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=TSM" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'TSM')">Taiwan Semiconductor Manufacturing ADS (TSM)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">7,661,397</td>
+        <td class="nnum">17.07</td>
+        <td class="nnum">-0.25</td>
+        <td class="nnum" style="border-right:0px">-1.44</td>
+    </tr>
+    <tr>
+        <td class="num">65</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=FCX" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'FCX')">Freeport-McMoRan Copper&amp;Gold (FCX)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">7,622,803</td>
+        <td class="nnum">33.42</td>
+        <td class="nnum">-0.45</td>
+        <td class="nnum" style="border-right:0px">-1.33</td>
+    </tr>
+    <tr>
+        <td class="num">66</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=KOG" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'KOG')">Kodiak Oil&amp;Gas (KOG)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">7,543,806</td>
+        <td class="pnum">11.94</td>
+        <td class="pnum">0.16</td>
+        <td class="pnum" style="border-right:0px">1.36</td>
+    </tr>
+    <tr>
+        <td class="num">67</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=XRX" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'XRX')">Xerox (XRX)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">7,440,689</td>
+        <td class="nnum">10.37</td>
+        <td class="nnum">-0.01</td>
+        <td class="nnum" style="border-right:0px">-0.10</td>
+    </tr>
+    <tr>
+        <td class="num">68</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=S" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'S')">Sprint (S)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">7,291,351</td>
+        <td class="nnum">6.16</td>
+        <td class="nnum">-0.14</td>
+        <td class="nnum" style="border-right:0px">-2.22</td>
+    </tr>
+    <tr>
+        <td class="num">69</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=TWO" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'TWO')">Two Harbors Investment (TWO)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">7,153,803</td>
+        <td class="pnum">9.79</td>
+        <td class="pnum">0.05</td>
+        <td class="pnum" style="border-right:0px">0.51</td>
+    </tr>
+    <tr>
+        <td class="num">70</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=WLT" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'WLT')">Walter Energy (WLT)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">7,152,192</td>
+        <td class="nnum">14.19</td>
+        <td class="nnum">-0.36</td>
+        <td class="nnum" style="border-right:0px">-2.47</td>
+    </tr>
+    <tr>
+        <td class="num">71</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=IP" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'IP')">International Paper (IP)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">7,123,722</td>
+        <td class="nnum">45.44</td>
+        <td class="nnum">-1.85</td>
+        <td class="nnum" style="border-right:0px">-3.91</td>
+    </tr>
+    <tr>
+        <td class="num">72</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=PPL" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'PPL')">PPL (PPL)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">7,026,292</td>
+        <td class="nnum">30.34</td>
+        <td class="nnum">-0.13</td>
+        <td class="nnum" style="border-right:0px">-0.43</td>
+    </tr>
+    <tr>
+        <td class="num">73</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=GG" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'GG')">Goldcorp (GG)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">6,857,447</td>
+        <td class="pnum">25.76</td>
+        <td class="pnum">0.08</td>
+        <td class="pnum" style="border-right:0px">0.31</td>
+    </tr>
+    <tr>
+        <td class="num">74</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=TWX" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'TWX')">Time Warner (TWX)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">6,807,237</td>
+        <td class="pnum">66.20</td>
+        <td class="pnum">1.33</td>
+        <td class="pnum" style="border-right:0px">2.05</td>
+    </tr>
+    <tr>
+        <td class="num">75</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=SNV" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'SNV')">Synovus Financial (SNV)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">6,764,805</td>
+        <td class="pnum">3.29</td>
+        <td class="pnum">0.02</td>
+        <td class="pnum" style="border-right:0px">0.61</td>
+    </tr>
+    <tr>
+        <td class="num">76</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=AKS" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'AKS')">AK Steel Holding (AKS)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">6,662,599</td>
+        <td class="nnum">3.83</td>
+        <td class="nnum">-0.11</td>
+        <td class="nnum" style="border-right:0px">-2.79</td>
+    </tr>
+    <tr>
+        <td class="num">77</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=BSX" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'BSX')">Boston Scientific (BSX)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">6,629,084</td>
+        <td class="nnum">11.52</td>
+        <td class="nnum">-0.15</td>
+        <td class="nnum" style="border-right:0px">-1.29</td>
+    </tr>
+    <tr>
+        <td class="num">78</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=EGO" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'EGO')">Eldorado Gold (EGO)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">6,596,902</td>
+        <td class="nnum">6.65</td>
+        <td class="nnum">-0.03</td>
+        <td class="nnum" style="border-right:0px">-0.45</td>
+    </tr>
+    <tr>
+        <td class="num">79</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=NR" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'NR')">Newpark Resources (NR)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">6,552,453</td>
+        <td class="pnum">12.56</td>
+        <td class="pnum">0.09</td>
+        <td class="pnum" style="border-right:0px">0.72</td>
+    </tr>
+    <tr>
+        <td class="num">80</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=ABBV" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'ABBV')">AbbVie (ABBV)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">6,525,524</td>
+        <td class="nnum">44.33</td>
+        <td class="nnum">-0.67</td>
+        <td class="nnum" style="border-right:0px">-1.49</td>
+    </tr>
+    <tr>
+        <td class="num">81</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=MBI" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'MBI')">MBIA (MBI)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">6,416,587</td>
+        <td class="nnum">10.38</td>
+        <td class="nnum">-0.43</td>
+        <td class="nnum" style="border-right:0px">-3.98</td>
+    </tr>
+    <tr>
+        <td class="num">82</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=SAI" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'SAI')">SAIC (SAI)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">6,404,587</td>
+        <td class="pnum">16.03</td>
+        <td class="pnum">0.13</td>
+        <td class="pnum" style="border-right:0px">0.82</td>
+    </tr>
+    <tr>
+        <td class="num">83</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=PG" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'PG')">Procter&amp;Gamble (PG)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">6,389,143</td>
+        <td class="nnum">77.21</td>
+        <td class="nnum">-0.84</td>
+        <td class="nnum" style="border-right:0px">-1.08</td>
+    </tr>
+    <tr>
+        <td class="num">84</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=IAG" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'IAG')">IAMGOLD (IAG)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">6,293,001</td>
+        <td class="nnum">4.77</td>
+        <td class="nnum">-0.06</td>
+        <td class="nnum" style="border-right:0px">-1.24</td>
+    </tr>
+    <tr>
+        <td class="num">85</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=SWY" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'SWY')">Safeway (SWY)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">6,268,184</td>
+        <td class="nnum">32.25</td>
+        <td class="nnum">-0.29</td>
+        <td class="nnum" style="border-right:0px">-0.89</td>
+    </tr>
+    <tr>
+        <td class="num">86</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=KGC" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'KGC')">Kinross Gold (KGC)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">6,112,658</td>
+        <td class="nnum">4.99</td>
+        <td class="nnum">-0.03</td>
+        <td class="nnum" style="border-right:0px">-0.60</td>
+    </tr>
+    <tr>
+        <td class="num">87</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=MGM" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'MGM')">MGM Resorts International (MGM)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">5,986,143</td>
+        <td class="nnum">20.22</td>
+        <td class="nnum">-0.05</td>
+        <td class="nnum" style="border-right:0px">-0.25</td>
+    </tr>
+    <tr>
+        <td class="num">88</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=CX" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'CX')">Cemex ADS (CX)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">5,907,040</td>
+        <td class="nnum">11.27</td>
+        <td class="nnum">-0.06</td>
+        <td class="nnum" style="border-right:0px">-0.53</td>
+    </tr>
+    <tr>
+        <td class="num">89</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=AIG" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'AIG')">American International Group (AIG)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">5,900,133</td>
+        <td class="nnum">49.15</td>
+        <td class="nnum">-0.30</td>
+        <td class="nnum" style="border-right:0px">-0.61</td>
+    </tr>
+    <tr>
+        <td class="num">90</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=CHK" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'CHK')">Chesapeake Energy (CHK)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">5,848,016</td>
+        <td class="nnum">26.21</td>
+        <td class="nnum">-0.20</td>
+        <td class="nnum" style="border-right:0px">-0.76</td>
+    </tr>
+    <tr>
+        <td class="num">91</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=RSH" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'RSH')">RadioShack (RSH)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">5,837,833</td>
+        <td class="nnum">3.44</td>
+        <td class="nnum">-0.43</td>
+        <td class="nnum" style="border-right:0px">-11.11</td>
+    </tr>
+    <tr>
+        <td class="num">92</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=USB" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'USB')">U.S. Bancorp (USB)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">5,814,373</td>
+        <td class="nnum">36.50</td>
+        <td class="nnum">-0.04</td>
+        <td class="nnum" style="border-right:0px">-0.11</td>
+    </tr>
+    <tr>
+        <td class="num">93</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=LLY" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'LLY')">Eli Lilly (LLY)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">5,776,991</td>
+        <td class="nnum">50.50</td>
+        <td class="nnum">-0.54</td>
+        <td class="nnum" style="border-right:0px">-1.06</td>
+    </tr>
+    <tr>
+        <td class="num">94</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=MET" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'MET')">MetLife (MET)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">5,774,996</td>
+        <td class="nnum">47.21</td>
+        <td class="nnum">-0.37</td>
+        <td class="nnum" style="border-right:0px">-0.78</td>
+    </tr>
+    <tr>
+        <td class="num">95</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=AUY" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'AUY')">Yamana Gold (AUY)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">5,742,426</td>
+        <td class="pnum">10.37</td>
+        <td class="pnum">0.03</td>
+        <td class="pnum" style="border-right:0px">0.29</td>
+    </tr>
+    <tr>
+        <td class="num">96</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=CBS" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'CBS')">CBS Cl B (CBS)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">5,718,858</td>
+        <td class="nnum">55.50</td>
+        <td class="nnum">-0.06</td>
+        <td class="nnum" style="border-right:0px">-0.11</td>
+    </tr>
+    <tr>
+        <td class="num">97</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=CSX" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'CSX')">CSX (CSX)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">5,710,066</td>
+        <td class="nnum">25.85</td>
+        <td class="nnum">-0.13</td>
+        <td class="nnum" style="border-right:0px">-0.50</td>
+    </tr>
+    <tr>
+        <td class="num">98</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=CCL" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'CCL')">Carnival (CCL)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">5,661,325</td>
+        <td class="nnum">32.88</td>
+        <td class="nnum">-0.05</td>
+        <td class="nnum" style="border-right:0px">-0.15</td>
+    </tr>
+    <tr>
+        <td class="num">99</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=MOS" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'MOS')">Mosaic (MOS)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">5,595,592</td>
+        <td class="nnum">43.43</td>
+        <td class="nnum">-0.76</td>
+        <td class="nnum" style="border-right:0px">-1.72</td>
+    </tr>
+    <tr>
+        <td class="num">100</td>
+        <td class="text" style="max-width:307px">
+            <a class="linkb" href="/public/quotes/main.html?symbol=WAG" onmouseout="com.dowjones.rolloverQuotes.hidelater();" onmouseover="com.dowjones.rolloverQuotes.show(this,'WAG')">Walgreen (WAG)
+            </a>
+        </td>
+        <td align="right" class="num" style="font-weight:bold;">5,568,310</td>
+        <td class="nnum">54.51</td>
+        <td class="nnum">-0.22</td>
+        <td class="nnum" style="border-right:0px">-0.40</td>
+    </tr>
+</tbody></table>
+<table bgcolor="" border="0" cellpadding="0" cellspacing="0" width="100%">
+    <tbody><tr><td height="20px"><img alt="" border="0" height="20px" src="/img/b.gif" width="1"/></td></tr>
+</tbody></table>
+<table align="center" bgcolor="#ffffff" border="0" cellpadding="0" cellspacing="0" style="border:1px solid #cfc7b7;margin-bottom:5px;" width="575px">
+    <tbody><tr>
+        <td bgcolor="#e9e7e0" class="b12" colspan="3" style="padding:3px 0px 3px 0px;"><span class="p10" style="color:#000; float:right">An Advertising Feature  </span>  PARTNER CENTER</td>
+    </tr>
+
+    <tr>
+        <td align="center" class="p10" style="padding:10px 0px 5px 0px;border-right:1px solid #cfc7b7;" valign="top">
+
+
+
+            <script type="text/javascript">
+<!--
+            var tempHTML = '';
+            var adURL = 'http://ad.doubleclick.net/adi/'+((GetCookie('etsFlag'))?'ets.wsj.com':'brokerbuttons.wsj.com')+'/markets_front;!category=;msrc=' + msrc + ';' + segQS + ';' + mc + ';tile=1;sz=170x67;ord=26093260932609326093;';
+            if ( isSafari ) {
+                tempHTML += '<iframe id="mdc_tradingcenter1" src="'+adURL+'" width="170" height="67" marginwidth="0" marginheight="0" hspace="0" vspace="0" frameborder="0" scrolling="no" bordercolor="#000000" style="width:170">';
+            } else {
+                tempHTML += '<iframe id="mdc_tradingcenter1" src="/static_html_files/blank.htm" width="170" height="67" marginwidth="0" marginheight="0" hspace="0" vspace="0" frameborder="0" scrolling="no" bordercolor="#000000" style="width:170px;">';
+                ListOfIframes.mdc_tradingcenter1= adURL;
+            }
+            tempHTML += '<a href="http://ad.doubleclick.net/jump/'+((GetCookie('etsFlag'))?'ets.wsj.com':'brokerbuttons.wsj.com')+'/markets_front;!category=;msrc=' + msrc + ';' + segQS + ';' + mc + ';tile=1;sz=170x67;ord=26093260932609326093;" target="_new">';
+            tempHTML += '<img src="http://ad.doubleclick.net/ad/'+((GetCookie('etsFlag'))?'ets.wsj.com':'brokerbuttons.wsj.com')+'/markets_front;!category=;msrc=' + msrc + ';' + segQS + ';' + mc + ';tile=1;sz=170x67;ord=26093260932609326093;" border="0" width="170" height="67" vspace="0" alt="Advertisement" /></a><br /></iframe>';
+            document.write(tempHTML);
+            // -->
+            </script>
+        </td>
+
+        <td align="center" class="p10" style="padding:10px 0px 5px 0px;border-right:1px solid #cfc7b7;" valign="top">
+
+
+
+            <script type="text/javascript">
+<!--
+            var tempHTML = '';
+            var adURL = 'http://ad.doubleclick.net/adi/'+((GetCookie('etsFlag'))?'ets.wsj.com':'brokerbuttons.wsj.com')+'/markets_front;!category=;msrc=' + msrc + ';' + segQS + ';' + mc + ';tile=2;sz=170x67;ord=26093260932609326093;';
+            if ( isSafari ) {
+                tempHTML += '<iframe id="mdc_tradingcenter2" src="'+adURL+'" width="170" height="67" marginwidth="0" marginheight="0" hspace="0" vspace="0" frameborder="0" scrolling="no" bordercolor="#000000" style="width:170">';
+            } else {
+                tempHTML += '<iframe id="mdc_tradingcenter2" src="/static_html_files/blank.htm" width="170" height="67" marginwidth="0" marginheight="0" hspace="0" vspace="0" frameborder="0" scrolling="no" bordercolor="#000000" style="width:170px;">';
+                ListOfIframes.mdc_tradingcenter2= adURL;
+            }
+            tempHTML += '<a href="http://ad.doubleclick.net/jump/'+((GetCookie('etsFlag'))?'ets.wsj.com':'brokerbuttons.wsj.com')+'/markets_front;!category=;msrc=' + msrc + ';' + segQS + ';' + mc + ';tile=2;sz=170x67;ord=26093260932609326093;" target="_new">';
+            tempHTML += '<img src="http://ad.doubleclick.net/ad/'+((GetCookie('etsFlag'))?'ets.wsj.com':'brokerbuttons.wsj.com')+'/markets_front;!category=;msrc=' + msrc + ';' + segQS + ';' + mc + ';tile=2;sz=170x67;ord=26093260932609326093;" border="0" width="170" height="67" vspace="0" alt="Advertisement" /></a><br /></iframe>';
+            document.write(tempHTML);
+            // -->
+            </script>
+        </td>
+
+        <td align="center" class="p10" style="padding:10px 0px 5px 0px;" valign="top">
+
+
+
+            <script type="text/javascript">
+<!--
+            var tempHTML = '';
+            var adURL = 'http://ad.doubleclick.net/adi/'+((GetCookie('etsFlag'))?'ets.wsj.com':'brokerbuttons.wsj.com')+'/markets_front;!category=;msrc=' + msrc + ';' + segQS + ';' + mc + ';tile=3;sz=170x67;ord=26093260932609326093;';
+            if ( isSafari ) {
+                tempHTML += '<iframe id="mdc_tradingcenter3" src="'+adURL+'" width="170" height="67" marginwidth="0" marginheight="0" hspace="0" vspace="0" frameborder="0" scrolling="no" bordercolor="#000000" style="width:170">';
+            } else {
+                tempHTML += '<iframe id="mdc_tradingcenter3" src="/static_html_files/blank.htm" width="170" height="67" marginwidth="0" marginheight="0" hspace="0" vspace="0" frameborder="0" scrolling="no" bordercolor="#000000" style="width:170px;">';
+                ListOfIframes.mdc_tradingcenter3= adURL;
+            }
+            tempHTML += '<a href="http://ad.doubleclick.net/jump/'+((GetCookie('etsFlag'))?'ets.wsj.com':'brokerbuttons.wsj.com')+'/markets_front;!category=;msrc=' + msrc + ';' + segQS + ';' + mc + ';tile=3;sz=170x67;ord=26093260932609326093;" target="_new">';
+            tempHTML += '<img src="http://ad.doubleclick.net/ad/'+((GetCookie('etsFlag'))?'ets.wsj.com':'brokerbuttons.wsj.com')+'/markets_front;!category=;msrc=' + msrc + ';' + segQS + ';' + mc + ';tile=3;sz=170x67;ord=26093260932609326093;" border="0" width="170" height="67" vspace="0" alt="Advertisement" /></a><br /></iframe>';
+            document.write(tempHTML);
+            // -->
+            </script>
+        </td>
+
+    </tr>
+
+</tbody></table>
+<table bgcolor="" border="0" cellpadding="0" cellspacing="0" width="100%">
+    <tbody><tr><td height="20px"><img alt="" border="0" height="20px" src="/img/b.gif" width="1"/></td></tr>
+</tbody></table>

--- a/pandas/io/tests/data/valid_markup.html
+++ b/pandas/io/tests/data/valid_markup.html
@@ -35,35 +35,26 @@
                     <td>7</td>
                     <td>0</td>
                 </tr>
-                <tr>
-                    <th>4</th>
-                    <td>4</td>
-                    <td>3</td>
+            </tbody>
+        </table>
+        <table border="1" class="dataframe">
+            <thead>
+                <tr style="text-align: right;">
+                    <th></th>
+                    <th>a</th>
+                    <th>b</th>
                 </tr>
+            </thead>
+            <tbody>
                 <tr>
-                    <th>5</th>
-                    <td>5</td>
-                    <td>4</td>
-                </tr>
-                <tr>
-                    <th>6</th>
-                    <td>4</td>
-                    <td>5</td>
-                </tr>
-                <tr>
-                    <th>7</th>
-                    <td>1</td>
-                    <td>4</td>
-                </tr>
-                <tr>
-                    <th>8</th>
+                    <th>0</th>
                     <td>6</td>
                     <td>7</td>
                 </tr>
                 <tr>
-                    <th>9</th>
-                    <td>8</td>
-                    <td>5</td>
+                    <th>1</th>
+                    <td>4</td>
+                    <td>0</td>
                 </tr>
             </tbody>
         </table>

--- a/pandas/io/tests/test_html.py
+++ b/pandas/io/tests/test_html.py
@@ -85,7 +85,7 @@ def test_bs4_version_fails():
 
 
 class TestReadHtml(unittest.TestCase):
-    def run_read_html(self, *args, **kwargs):
+    def read_html(self, *args, **kwargs):
         kwargs['flavor'] = kwargs.get('flavor', self.flavor)
         return read_html(*args, **kwargs)
 
@@ -108,16 +108,16 @@ class TestReadHtml(unittest.TestCase):
         df = mkdf(4, 3, data_gen_f=lambda *args: rand(), c_idx_names=False,
                   r_idx_names=False).applymap('{0:.3f}'.format).astype(float)
         out = df.to_html()
-        res = self.run_read_html(out, attrs={'class': 'dataframe'},
+        res = self.read_html(out, attrs={'class': 'dataframe'},
                                  index_col=0)[0]
         tm.assert_frame_equal(res, df)
 
     @network
     def test_banklist_url(self):
         url = 'http://www.fdic.gov/bank/individual/failed/banklist.html'
-        df1 = self.run_read_html(url, 'First Federal Bank of Florida',
+        df1 = self.read_html(url, 'First Federal Bank of Florida',
                                  attrs={"id": 'table'})
-        df2 = self.run_read_html(url, 'Metcalf Bank', attrs={'id': 'table'})
+        df2 = self.read_html(url, 'Metcalf Bank', attrs={'id': 'table'})
 
         assert_framelist_equal(df1, df2)
 
@@ -125,26 +125,26 @@ class TestReadHtml(unittest.TestCase):
     def test_spam_url(self):
         url = ('http://ndb.nal.usda.gov/ndb/foods/show/1732?fg=&man=&'
                'lfacet=&format=&count=&max=25&offset=&sort=&qlookup=spam')
-        df1 = self.run_read_html(url, '.*Water.*')
-        df2 = self.run_read_html(url, 'Unit')
+        df1 = self.read_html(url, '.*Water.*')
+        df2 = self.read_html(url, 'Unit')
 
         assert_framelist_equal(df1, df2)
 
     @slow
     def test_banklist(self):
-        df1 = self.run_read_html(self.banklist_data, '.*Florida.*',
+        df1 = self.read_html(self.banklist_data, '.*Florida.*',
                                  attrs={'id': 'table'})
-        df2 = self.run_read_html(self.banklist_data, 'Metcalf Bank',
+        df2 = self.read_html(self.banklist_data, 'Metcalf Bank',
                                  attrs={'id': 'table'})
 
         assert_framelist_equal(df1, df2)
 
     def test_spam_no_types(self):
         with tm.assert_produces_warning():
-            df1 = self.run_read_html(self.spam_data, '.*Water.*',
+            df1 = self.read_html(self.spam_data, '.*Water.*',
                                      infer_types=False)
         with tm.assert_produces_warning():
-            df2 = self.run_read_html(self.spam_data, 'Unit', infer_types=False)
+            df2 = self.read_html(self.spam_data, 'Unit', infer_types=False)
 
         assert_framelist_equal(df1, df2)
 
@@ -152,116 +152,116 @@ class TestReadHtml(unittest.TestCase):
         self.assertEqual(df1[0].columns[0], 'Nutrient')
 
     def test_spam_with_types(self):
-        df1 = self.run_read_html(self.spam_data, '.*Water.*')
-        df2 = self.run_read_html(self.spam_data, 'Unit')
+        df1 = self.read_html(self.spam_data, '.*Water.*')
+        df2 = self.read_html(self.spam_data, 'Unit')
         assert_framelist_equal(df1, df2)
 
         self.assertEqual(df1[0].ix[0, 0], 'Proximates')
         self.assertEqual(df1[0].columns[0], 'Nutrient')
 
     def test_spam_no_match(self):
-        dfs = self.run_read_html(self.spam_data)
+        dfs = self.read_html(self.spam_data)
         for df in dfs:
             tm.assert_isinstance(df, DataFrame)
 
     def test_banklist_no_match(self):
-        dfs = self.run_read_html(self.banklist_data, attrs={'id': 'table'})
+        dfs = self.read_html(self.banklist_data, attrs={'id': 'table'})
         for df in dfs:
             tm.assert_isinstance(df, DataFrame)
 
     def test_spam_header(self):
-        df = self.run_read_html(self.spam_data, '.*Water.*', header=1)[0]
+        df = self.read_html(self.spam_data, '.*Water.*', header=1)[0]
         self.assertEqual(df.columns[0], 'Proximates')
         self.assertFalse(df.empty)
 
     def test_skiprows_int(self):
-        df1 = self.run_read_html(self.spam_data, '.*Water.*', skiprows=1)
-        df2 = self.run_read_html(self.spam_data, 'Unit', skiprows=1)
+        df1 = self.read_html(self.spam_data, '.*Water.*', skiprows=1)
+        df2 = self.read_html(self.spam_data, 'Unit', skiprows=1)
 
         assert_framelist_equal(df1, df2)
 
     def test_skiprows_xrange(self):
-        df1 = self.run_read_html(self.spam_data, '.*Water.*',
+        df1 = self.read_html(self.spam_data, '.*Water.*',
                                  skiprows=range(2))[0]
-        df2 = self.run_read_html(self.spam_data, 'Unit', skiprows=range(2))[0]
+        df2 = self.read_html(self.spam_data, 'Unit', skiprows=range(2))[0]
         tm.assert_frame_equal(df1, df2)
 
     def test_skiprows_list(self):
-        df1 = self.run_read_html(self.spam_data, '.*Water.*', skiprows=[1, 2])
-        df2 = self.run_read_html(self.spam_data, 'Unit', skiprows=[2, 1])
+        df1 = self.read_html(self.spam_data, '.*Water.*', skiprows=[1, 2])
+        df2 = self.read_html(self.spam_data, 'Unit', skiprows=[2, 1])
 
         assert_framelist_equal(df1, df2)
 
     def test_skiprows_set(self):
-        df1 = self.run_read_html(self.spam_data, '.*Water.*',
+        df1 = self.read_html(self.spam_data, '.*Water.*',
                                  skiprows=set([1, 2]))
-        df2 = self.run_read_html(self.spam_data, 'Unit', skiprows=set([2, 1]))
+        df2 = self.read_html(self.spam_data, 'Unit', skiprows=set([2, 1]))
 
         assert_framelist_equal(df1, df2)
 
     def test_skiprows_slice(self):
-        df1 = self.run_read_html(self.spam_data, '.*Water.*', skiprows=1)
-        df2 = self.run_read_html(self.spam_data, 'Unit', skiprows=1)
+        df1 = self.read_html(self.spam_data, '.*Water.*', skiprows=1)
+        df2 = self.read_html(self.spam_data, 'Unit', skiprows=1)
 
         assert_framelist_equal(df1, df2)
 
     def test_skiprows_slice_short(self):
-        df1 = self.run_read_html(self.spam_data, '.*Water.*',
+        df1 = self.read_html(self.spam_data, '.*Water.*',
                                  skiprows=slice(2))
-        df2 = self.run_read_html(self.spam_data, 'Unit', skiprows=slice(2))
+        df2 = self.read_html(self.spam_data, 'Unit', skiprows=slice(2))
 
         assert_framelist_equal(df1, df2)
 
     def test_skiprows_slice_long(self):
-        df1 = self.run_read_html(self.spam_data, '.*Water.*',
+        df1 = self.read_html(self.spam_data, '.*Water.*',
                                  skiprows=slice(2, 5))
-        df2 = self.run_read_html(self.spam_data, 'Unit',
+        df2 = self.read_html(self.spam_data, 'Unit',
                                  skiprows=slice(4, 1, -1))
 
         assert_framelist_equal(df1, df2)
 
     def test_skiprows_ndarray(self):
-        df1 = self.run_read_html(self.spam_data, '.*Water.*',
+        df1 = self.read_html(self.spam_data, '.*Water.*',
                                  skiprows=np.arange(2))
-        df2 = self.run_read_html(self.spam_data, 'Unit', skiprows=np.arange(2))
+        df2 = self.read_html(self.spam_data, 'Unit', skiprows=np.arange(2))
 
         assert_framelist_equal(df1, df2)
 
     def test_skiprows_invalid(self):
-        self.assertRaises(TypeError, self.run_read_html, self.spam_data,
+        self.assertRaises(TypeError, self.read_html, self.spam_data,
                           '.*Water.*', skiprows='asdf')
 
     def test_index(self):
-        df1 = self.run_read_html(self.spam_data, '.*Water.*', index_col=0)
-        df2 = self.run_read_html(self.spam_data, 'Unit', index_col=0)
+        df1 = self.read_html(self.spam_data, '.*Water.*', index_col=0)
+        df2 = self.read_html(self.spam_data, 'Unit', index_col=0)
         assert_framelist_equal(df1, df2)
 
     def test_header_and_index_no_types(self):
         with tm.assert_produces_warning():
-            df1 = self.run_read_html(self.spam_data, '.*Water.*', header=1,
+            df1 = self.read_html(self.spam_data, '.*Water.*', header=1,
                                      index_col=0, infer_types=False)
         with tm.assert_produces_warning():
-            df2 = self.run_read_html(self.spam_data, 'Unit', header=1,
+            df2 = self.read_html(self.spam_data, 'Unit', header=1,
                                     index_col=0, infer_types=False)
         assert_framelist_equal(df1, df2)
 
     def test_header_and_index_with_types(self):
-        df1 = self.run_read_html(self.spam_data, '.*Water.*', header=1,
+        df1 = self.read_html(self.spam_data, '.*Water.*', header=1,
                                  index_col=0)
-        df2 = self.run_read_html(self.spam_data, 'Unit', header=1, index_col=0)
+        df2 = self.read_html(self.spam_data, 'Unit', header=1, index_col=0)
         assert_framelist_equal(df1, df2)
 
     def test_infer_types(self):
         with tm.assert_produces_warning():
-            df1 = self.run_read_html(self.spam_data, '.*Water.*', index_col=0,
+            df1 = self.read_html(self.spam_data, '.*Water.*', index_col=0,
                                      infer_types=False)
         with tm.assert_produces_warning():
-            df2 = self.run_read_html(self.spam_data, 'Unit', index_col=0,
+            df2 = self.read_html(self.spam_data, 'Unit', index_col=0,
                                     infer_types=False)
         assert_framelist_equal(df1, df2)
 
         with tm.assert_produces_warning():
-            df2 = self.run_read_html(self.spam_data, 'Unit', index_col=0,
+            df2 = self.read_html(self.spam_data, 'Unit', index_col=0,
                                     infer_types=True)
 
         self.assertRaises(AssertionError, assert_framelist_equal, df1, df2)
@@ -273,42 +273,42 @@ class TestReadHtml(unittest.TestCase):
         with open(self.spam_data) as f:
             data2 = StringIO(f.read())
 
-        df1 = self.run_read_html(data1, '.*Water.*')
-        df2 = self.run_read_html(data2, 'Unit')
+        df1 = self.read_html(data1, '.*Water.*')
+        df2 = self.read_html(data2, 'Unit')
         assert_framelist_equal(df1, df2)
 
     def test_string(self):
         with open(self.spam_data) as f:
             data = f.read()
 
-        df1 = self.run_read_html(data, '.*Water.*')
-        df2 = self.run_read_html(data, 'Unit')
+        df1 = self.read_html(data, '.*Water.*')
+        df2 = self.read_html(data, 'Unit')
 
         assert_framelist_equal(df1, df2)
 
     def test_file_like(self):
         with open(self.spam_data) as f:
-            df1 = self.run_read_html(f, '.*Water.*')
+            df1 = self.read_html(f, '.*Water.*')
 
         with open(self.spam_data) as f:
-            df2 = self.run_read_html(f, 'Unit')
+            df2 = self.read_html(f, 'Unit')
 
         assert_framelist_equal(df1, df2)
 
     @network
     def test_bad_url_protocol(self):
-        self.assertRaises(URLError, self.run_read_html,
+        self.assertRaises(URLError, self.read_html,
                           'git://github.com', '.*Water.*')
 
     @network
     def test_invalid_url(self):
-        self.assertRaises(URLError, self.run_read_html,
+        self.assertRaises(URLError, self.read_html,
                           'http://www.a23950sdfa908sd.com')
 
     @slow
     def test_file_url(self):
         url = self.banklist_data
-        dfs = self.run_read_html('file://' + url, 'First',
+        dfs = self.read_html('file://' + url, 'First',
                                  attrs={'id': 'table'})
         tm.assert_isinstance(dfs, list)
         for df in dfs:
@@ -317,12 +317,12 @@ class TestReadHtml(unittest.TestCase):
     @slow
     def test_invalid_table_attrs(self):
         url = self.banklist_data
-        self.assertRaises(AssertionError, self.run_read_html, url,
+        self.assertRaises(AssertionError, self.read_html, url,
                           'First Federal Bank of Florida',
                           attrs={'id': 'tasdfable'})
 
     def _bank_data(self, *args, **kwargs):
-        return self.run_read_html(self.banklist_data, 'Metcalf',
+        return self.read_html(self.banklist_data, 'Metcalf',
                                   attrs={'id': 'table'}, *args, **kwargs)
 
     @slow
@@ -357,7 +357,7 @@ class TestReadHtml(unittest.TestCase):
     @slow
     def test_regex_idempotency(self):
         url = self.banklist_data
-        dfs = self.run_read_html('file://' + url,
+        dfs = self.read_html('file://' + url,
                                  match=re.compile(re.compile('Florida')),
                                  attrs={'id': 'table'})
         tm.assert_isinstance(dfs, list)
@@ -366,38 +366,75 @@ class TestReadHtml(unittest.TestCase):
 
     def test_negative_skiprows_spam(self):
         url = self.spam_data
-        self.assertRaises(AssertionError, self.run_read_html, url, 'Water',
+        self.assertRaises(AssertionError, self.read_html, url, 'Water',
                           skiprows=-1)
 
     def test_negative_skiprows_banklist(self):
         url = self.banklist_data
-        self.assertRaises(AssertionError, self.run_read_html, url, 'Florida',
+        self.assertRaises(AssertionError, self.read_html, url, 'Florida',
                           skiprows=-1)
 
     @network
     def test_multiple_matches(self):
         url = 'http://code.google.com/p/pythonxy/wiki/StandardPlugins'
-        dfs = self.run_read_html(url, match='Python',
+        dfs = self.read_html(url, match='Python',
                                  attrs={'class': 'wikitable'})
         self.assert_(len(dfs) > 1)
 
     @network
     def test_pythonxy_plugins_table(self):
         url = 'http://code.google.com/p/pythonxy/wiki/StandardPlugins'
-        dfs = self.run_read_html(url, match='Python',
+        dfs = self.read_html(url, match='Python',
                                  attrs={'class': 'wikitable'})
         zz = [df.iloc[0, 0] for df in dfs]
         self.assertEqual(sorted(zz), sorted(['Python', 'SciTE']))
 
-    @network
+    @slow
     def test_thousands_macau_stats(self):
         macau_data = os.path.join(DATA_PATH, 'macau.html')
-        dfs = self.run_read_html(macau_data, index_col=0,
+        dfs = self.read_html(macau_data, index_col=0,
                                  attrs={'class': 'style1'})
 
         # no columns should have all nans
         res = any((df.count() == 0).any() for df in dfs)
         self.assertEqual(res, False)
+
+    def test_countries_municipalities(self):
+        # GH5048
+        data1 = StringIO(u'''<table>
+            <thead>
+                <tr>
+                    <th>Country</th>
+                    <th>Municipality</th>
+                    <th>Year</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Ukraine</td>
+                    <th>Odessa</th>
+                    <td>1944</td>
+                </tr>
+            </tbody>
+        </table>''')
+        data2 = StringIO(u'''
+        <table>
+            <tbody>
+                <tr>
+                    <th>Country</th>
+                    <th>Municipality</th>
+                    <th>Year</th>
+                </tr>
+                <tr>
+                    <td>Ukraine</td>
+                    <th>Odessa</th>
+                    <td>1944</td>
+                </tr>
+            </tbody>
+        </table>''')
+        res1 = self.read_html(data1)
+        res2 = self.read_html(data2, header=0)
+        assert_framelist_equal(res1, res2)
 
     @slow
     def test_banklist_header(self):
@@ -409,7 +446,7 @@ class TestReadHtml(unittest.TestCase):
             except AttributeError:
                 return x
 
-        df = self.run_read_html(self.banklist_data, 'Metcalf',
+        df = self.read_html(self.banklist_data, 'Metcalf',
                                 attrs={'id': 'table'})[0]
         ground_truth = read_csv(os.path.join(DATA_PATH, 'banklist.csv'),
                                 converters={'Updated Date': Timestamp,
@@ -443,7 +480,7 @@ class TestReadHtml(unittest.TestCase):
             raw_text = f.read()
 
         self.assert_(gc in raw_text)
-        df = self.run_read_html(self.banklist_data, 'Gold Canyon',
+        df = self.read_html(self.banklist_data, 'Gold Canyon',
                                 attrs={'id': 'table'})[0]
         self.assert_(gc in df.to_string())
 
@@ -505,9 +542,9 @@ class TestReadHtml(unittest.TestCase):
                         </tr>
                     </tbody>
                  </table>"""
-        expected = self.run_read_html(out, attrs={'class': 'dataframe'},
+        expected = self.read_html(out, attrs={'class': 'dataframe'},
                                       index_col=0)[0]
-        res = self.run_read_html(out, attrs={'class': 'dataframe'},
+        res = self.read_html(out, attrs={'class': 'dataframe'},
                                  index_col=0)[0]
         tm.assert_frame_equal(expected, res)
 
@@ -516,7 +553,7 @@ class TestReadHtmlLxml(unittest.TestCase):
     def setUp(self):
         self.try_skip()
 
-    def run_read_html(self, *args, **kwargs):
+    def read_html(self, *args, **kwargs):
         self.flavor = ['lxml']
         self.try_skip()
         kwargs['flavor'] = kwargs.get('flavor', self.flavor)
@@ -528,18 +565,18 @@ class TestReadHtmlLxml(unittest.TestCase):
     def test_spam_data_fail(self):
         from lxml.etree import XMLSyntaxError
         spam_data = os.path.join(DATA_PATH, 'spam.html')
-        self.assertRaises(XMLSyntaxError, self.run_read_html, spam_data,
+        self.assertRaises(XMLSyntaxError, self.read_html, spam_data,
                           flavor=['lxml'])
 
     def test_banklist_data_fail(self):
         from lxml.etree import XMLSyntaxError
         banklist_data = os.path.join(DATA_PATH, 'banklist.html')
-        self.assertRaises(XMLSyntaxError, self.run_read_html, banklist_data,
+        self.assertRaises(XMLSyntaxError, self.read_html, banklist_data,
                           flavor=['lxml'])
 
     def test_works_on_valid_markup(self):
         filename = os.path.join(DATA_PATH, 'valid_markup.html')
-        dfs = self.run_read_html(filename, index_col=0, flavor=['lxml'])
+        dfs = self.read_html(filename, index_col=0, flavor=['lxml'])
         tm.assert_isinstance(dfs, list)
         tm.assert_isinstance(dfs[0], DataFrame)
 
@@ -547,7 +584,7 @@ class TestReadHtmlLxml(unittest.TestCase):
     def test_fallback_success(self):
         _skip_if_none_of(('bs4', 'html5lib'))
         banklist_data = os.path.join(DATA_PATH, 'banklist.html')
-        self.run_read_html(banklist_data, '.*Water.*', flavor=['lxml',
+        self.read_html(banklist_data, '.*Water.*', flavor=['lxml',
                                                                'html5lib'])
 
 

--- a/pandas/io/tests/test_html.py
+++ b/pandas/io/tests/test_html.py
@@ -3,13 +3,13 @@ from __future__ import print_function
 import os
 import re
 import warnings
+import unittest
 
 try:
     from importlib import import_module
 except ImportError:
     import_module = __import__
 
-from unittest import TestCase
 from distutils.version import LooseVersion
 
 import nose
@@ -84,7 +84,7 @@ def test_bs4_version_fails():
                          flavor='bs4')
 
 
-class TestReadHtmlBase(TestCase):
+class TestReadHtml(unittest.TestCase):
     def run_read_html(self, *args, **kwargs):
         kwargs['flavor'] = kwargs.get('flavor', self.flavor)
         return read_html(*args, **kwargs)
@@ -110,8 +110,6 @@ class TestReadHtmlBase(TestCase):
         out = df.to_html()
         res = self.run_read_html(out, attrs={'class': 'dataframe'},
                                  index_col=0)[0]
-        print(df.dtypes)
-        print(res.dtypes)
         tm.assert_frame_equal(res, df)
 
     @network
@@ -142,9 +140,11 @@ class TestReadHtmlBase(TestCase):
         assert_framelist_equal(df1, df2)
 
     def test_spam_no_types(self):
-        df1 = self.run_read_html(self.spam_data, '.*Water.*',
-                                 infer_types=False)
-        df2 = self.run_read_html(self.spam_data, 'Unit', infer_types=False)
+        with tm.assert_produces_warning():
+            df1 = self.run_read_html(self.spam_data, '.*Water.*',
+                                     infer_types=False)
+        with tm.assert_produces_warning():
+            df2 = self.run_read_html(self.spam_data, 'Unit', infer_types=False)
 
         assert_framelist_equal(df1, df2)
 
@@ -162,12 +162,12 @@ class TestReadHtmlBase(TestCase):
     def test_spam_no_match(self):
         dfs = self.run_read_html(self.spam_data)
         for df in dfs:
-            self.assert_(isinstance(df, DataFrame))
+            tm.assert_isinstance(df, DataFrame)
 
     def test_banklist_no_match(self):
         dfs = self.run_read_html(self.banklist_data, attrs={'id': 'table'})
         for df in dfs:
-            self.assert_(isinstance(df, DataFrame))
+            tm.assert_isinstance(df, DataFrame)
 
     def test_spam_header(self):
         df = self.run_read_html(self.spam_data, '.*Water.*', header=1)[0]
@@ -237,10 +237,12 @@ class TestReadHtmlBase(TestCase):
         assert_framelist_equal(df1, df2)
 
     def test_header_and_index_no_types(self):
-        df1 = self.run_read_html(self.spam_data, '.*Water.*', header=1,
-                                 index_col=0, infer_types=False)
-        df2 = self.run_read_html(self.spam_data, 'Unit', header=1,
-                                 index_col=0, infer_types=False)
+        with tm.assert_produces_warning():
+            df1 = self.run_read_html(self.spam_data, '.*Water.*', header=1,
+                                     index_col=0, infer_types=False)
+        with tm.assert_produces_warning():
+            df2 = self.run_read_html(self.spam_data, 'Unit', header=1,
+                                    index_col=0, infer_types=False)
         assert_framelist_equal(df1, df2)
 
     def test_header_and_index_with_types(self):
@@ -250,14 +252,17 @@ class TestReadHtmlBase(TestCase):
         assert_framelist_equal(df1, df2)
 
     def test_infer_types(self):
-        df1 = self.run_read_html(self.spam_data, '.*Water.*', index_col=0,
-                                 infer_types=False)
-        df2 = self.run_read_html(self.spam_data, 'Unit', index_col=0,
-                                 infer_types=False)
+        with tm.assert_produces_warning():
+            df1 = self.run_read_html(self.spam_data, '.*Water.*', index_col=0,
+                                     infer_types=False)
+        with tm.assert_produces_warning():
+            df2 = self.run_read_html(self.spam_data, 'Unit', index_col=0,
+                                    infer_types=False)
         assert_framelist_equal(df1, df2)
 
-        df2 = self.run_read_html(self.spam_data, 'Unit', index_col=0,
-                                 infer_types=True)
+        with tm.assert_produces_warning():
+            df2 = self.run_read_html(self.spam_data, 'Unit', index_col=0,
+                                    infer_types=True)
 
         self.assertRaises(AssertionError, assert_framelist_equal, df1, df2)
 
@@ -268,25 +273,25 @@ class TestReadHtmlBase(TestCase):
         with open(self.spam_data) as f:
             data2 = StringIO(f.read())
 
-        df1 = self.run_read_html(data1, '.*Water.*', infer_types=False)
-        df2 = self.run_read_html(data2, 'Unit', infer_types=False)
+        df1 = self.run_read_html(data1, '.*Water.*')
+        df2 = self.run_read_html(data2, 'Unit')
         assert_framelist_equal(df1, df2)
 
     def test_string(self):
         with open(self.spam_data) as f:
             data = f.read()
 
-        df1 = self.run_read_html(data, '.*Water.*', infer_types=False)
-        df2 = self.run_read_html(data, 'Unit', infer_types=False)
+        df1 = self.run_read_html(data, '.*Water.*')
+        df2 = self.run_read_html(data, 'Unit')
 
         assert_framelist_equal(df1, df2)
 
     def test_file_like(self):
         with open(self.spam_data) as f:
-            df1 = self.run_read_html(f, '.*Water.*', infer_types=False)
+            df1 = self.run_read_html(f, '.*Water.*')
 
         with open(self.spam_data) as f:
-            df2 = self.run_read_html(f, 'Unit', infer_types=False)
+            df2 = self.run_read_html(f, 'Unit')
 
         assert_framelist_equal(df1, df2)
 
@@ -305,9 +310,9 @@ class TestReadHtmlBase(TestCase):
         url = self.banklist_data
         dfs = self.run_read_html('file://' + url, 'First',
                                  attrs={'id': 'table'})
-        self.assert_(isinstance(dfs, list))
+        tm.assert_isinstance(dfs, list)
         for df in dfs:
-            self.assert_(isinstance(df, DataFrame))
+            tm.assert_isinstance(df, DataFrame)
 
     @slow
     def test_invalid_table_attrs(self):
@@ -323,30 +328,31 @@ class TestReadHtmlBase(TestCase):
     @slow
     def test_multiindex_header(self):
         df = self._bank_data(header=[0, 1])[0]
-        self.assert_(isinstance(df.columns, MultiIndex))
+        tm.assert_isinstance(df.columns, MultiIndex)
 
     @slow
     def test_multiindex_index(self):
         df = self._bank_data(index_col=[0, 1])[0]
-        self.assert_(isinstance(df.index, MultiIndex))
+        tm.assert_isinstance(df.index, MultiIndex)
 
     @slow
     def test_multiindex_header_index(self):
         df = self._bank_data(header=[0, 1], index_col=[0, 1])[0]
-        self.assert_(isinstance(df.columns, MultiIndex))
-        self.assert_(isinstance(df.index, MultiIndex))
+        tm.assert_isinstance(df.columns, MultiIndex)
+        tm.assert_isinstance(df.index, MultiIndex)
 
     @slow
     def test_multiindex_header_skiprows(self):
-        import ipdb; ipdb.set_trace()
+        # wtf does skiprows=1 fail here?!?
         df = self._bank_data(header=[0, 1], skiprows=1)[0]
-        self.assert_(isinstance(df.columns, MultiIndex))
+        tm.assert_isinstance(df.columns, MultiIndex)
 
     @slow
     def test_multiindex_header_index_skiprows(self):
+        # wtf does skiprows=1 fail here?!?
         df = self._bank_data(header=[0, 1], index_col=[0, 1], skiprows=1)[0]
-        self.assert_(isinstance(df.index, MultiIndex))
-        self.assert_(isinstance(df.columns, MultiIndex))
+        tm.assert_isinstance(df.index, MultiIndex)
+        tm.assert_isinstance(df.columns, MultiIndex)
 
     @slow
     def test_regex_idempotency(self):
@@ -354,9 +360,9 @@ class TestReadHtmlBase(TestCase):
         dfs = self.run_read_html('file://' + url,
                                  match=re.compile(re.compile('Florida')),
                                  attrs={'id': 'table'})
-        self.assert_(isinstance(dfs, list))
+        tm.assert_isinstance(dfs, list)
         for df in dfs:
-            self.assert_(isinstance(df, DataFrame))
+            tm.assert_isinstance(df, DataFrame)
 
     def test_negative_skiprows_spam(self):
         url = self.spam_data
@@ -382,6 +388,16 @@ class TestReadHtmlBase(TestCase):
                                  attrs={'class': 'wikitable'})
         zz = [df.iloc[0, 0] for df in dfs]
         self.assertEqual(sorted(zz), sorted(['Python', 'SciTE']))
+
+    @network
+    def test_thousands_macau_stats(self):
+        macau_data = os.path.join(DATA_PATH, 'macau.html')
+        dfs = self.run_read_html(macau_data, index_col=0,
+                                 attrs={'class': 'style1'})
+
+        # no columns should have all nans
+        res = any((df.count() == 0).any() for df in dfs)
+        self.assertEqual(res, False)
 
     @slow
     def test_banklist_header(self):
@@ -428,11 +444,78 @@ class TestReadHtmlBase(TestCase):
 
         self.assert_(gc in raw_text)
         df = self.run_read_html(self.banklist_data, 'Gold Canyon',
-                                attrs={'id': 'table'}, infer_types=False)[0]
+                                attrs={'id': 'table'})[0]
         self.assert_(gc in df.to_string())
 
+    def test_different_number_of_rows(self):
+        expected = """<table border="1" class="dataframe">
+                        <thead>
+                            <tr style="text-align: right;">
+                            <th></th>
+                            <th>C_l0_g0</th>
+                            <th>C_l0_g1</th>
+                            <th>C_l0_g2</th>
+                            <th>C_l0_g3</th>
+                            <th>C_l0_g4</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                            <th>R_l0_g0</th>
+                            <td> 0.763</td>
+                            <td> 0.233</td>
+                            <td> nan</td>
+                            <td> nan</td>
+                            <td> nan</td>
+                            </tr>
+                            <tr>
+                            <th>R_l0_g1</th>
+                            <td> 0.244</td>
+                            <td> 0.285</td>
+                            <td> 0.392</td>
+                            <td> 0.137</td>
+                            <td> 0.222</td>
+                            </tr>
+                        </tbody>
+                    </table>"""
+        out = """<table border="1" class="dataframe">
+                    <thead>
+                        <tr style="text-align: right;">
+                        <th></th>
+                        <th>C_l0_g0</th>
+                        <th>C_l0_g1</th>
+                        <th>C_l0_g2</th>
+                        <th>C_l0_g3</th>
+                        <th>C_l0_g4</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                        <th>R_l0_g0</th>
+                        <td> 0.763</td>
+                        <td> 0.233</td>
+                        </tr>
+                        <tr>
+                        <th>R_l0_g1</th>
+                        <td> 0.244</td>
+                        <td> 0.285</td>
+                        <td> 0.392</td>
+                        <td> 0.137</td>
+                        <td> 0.222</td>
+                        </tr>
+                    </tbody>
+                 </table>"""
+        expected = self.run_read_html(out, attrs={'class': 'dataframe'},
+                                      index_col=0)[0]
+        res = self.run_read_html(out, attrs={'class': 'dataframe'},
+                                 index_col=0)[0]
+        tm.assert_frame_equal(expected, res)
 
-class TestReadHtmlLxml(TestCase):
+
+class TestReadHtmlLxml(unittest.TestCase):
+    def setUp(self):
+        self.try_skip()
+
     def run_read_html(self, *args, **kwargs):
         self.flavor = ['lxml']
         self.try_skip()
@@ -457,11 +540,8 @@ class TestReadHtmlLxml(TestCase):
     def test_works_on_valid_markup(self):
         filename = os.path.join(DATA_PATH, 'valid_markup.html')
         dfs = self.run_read_html(filename, index_col=0, flavor=['lxml'])
-        self.assert_(isinstance(dfs, list))
-        self.assert_(isinstance(dfs[0], DataFrame))
-
-    def setUp(self):
-        self.try_skip()
+        tm.assert_isinstance(dfs, list)
+        tm.assert_isinstance(dfs[0], DataFrame)
 
     @slow
     def test_fallback_success(self):


### PR DESCRIPTION
closes #4697 (refactor issue) (REF/ENH)
closes #4700 (header inconsistency issue) (API)
closes #5029 (comma issue, added this data set, ordering issue) (BUG)
closes #5048 (header type conversion issue) (BUG)
closes #5066 (index_col issue) (BUG)
- [x] figure out `skiprows`, `header`, and `index_col` interaction (a somewhat longstanding `MultiIndex` sorting issue, I just took the long way to get there :))
- ~~spam url not working anymore~~ (US gov "shutdown" is responsible for this, it correctly skips)
- ~~table ordering doc blurb/HTML gotchas~~ (was an actual "bug", now fixed in this PR)
- ~~add tests for rows with a different length~~ (this is already done by the existing tests)
