### PR TITLE
DOC: some stylistic improvements to docstring rendering in documentation

### DIFF
--- a/doc/source/themes/nature_with_gtoc/static/nature.css_t
+++ b/doc/source/themes/nature_with_gtoc/static/nature.css_t
@@ -178,6 +178,10 @@ div.body h4 { font-size: 110%; background-color: #D8DEE3; }
 div.body h5 { font-size: 100%; background-color: #D8DEE3; }
 div.body h6 { font-size: 100%; background-color: #D8DEE3; }
 
+p.rubric {
+    border-bottom: 1px solid rgb(201, 201, 201);
+}
+
 a.headerlink {
     color: #c60f0f;
     font-size: 0.8em;
@@ -231,10 +235,10 @@ p.admonition-title:after {
 
 pre {
     padding: 10px;
-    background-color: White;
+    background-color: rgb(250,250,250);
     color: #222;
     line-height: 1.2em;
-    border: 1px solid #C6C9CB;
+    border: 1px solid rgb(201,201,201);
     font-size: 1.1em;
     margin: 1.5em 0 1.5em 0;
     -webkit-box-shadow: 1px 1px 1px #d8d8d8;
@@ -257,4 +261,50 @@ div.viewcode-block:target {
     background-color: #f4debf;
     border-top: 1px solid #ac9;
     border-bottom: 1px solid #ac9;
+}
+
+
+/**
+ * Styling for field lists
+ */
+
+ /* grey highlighting of 'parameter' and 'returns' field */
+table.field-list {
+    border-collapse: separate;
+    border-spacing: 10px;
+    margin-left: 1px;
+    /* border-left: 5px solid rgb(238, 238, 238) !important; */
+}
+
+table.field-list th.field-name {
+    /* display: inline-block; */
+    padding: 1px 8px 1px 5px;
+    white-space: nowrap;
+    background-color: rgb(238, 238, 238);
+}
+
+/* italic font for parameter types */
+table.field-list td.field-body > p {
+    font-style: italic;
+}
+
+table.field-list td.field-body > p > strong {
+    font-style: normal;
+}
+
+/* reduced space around parameter description */
+td.field-body blockquote {
+    border-left: none;
+    margin: 0em 0em 0.3em;
+    padding-left: 30px;
+}
+
+
+/**
+ * See also
+ */
+
+div.seealso dd {
+    margin-top: 0;
+    margin-bottom: 0;
 }


### PR DESCRIPTION
This is a PR with some stylistic improvements to the docstring rendering in the documentation. The incentive was that I found the reference (docstring) documentation not always clearly organised.

Things I changed (mainly copied from the new numpy/scipy docs):
- reduced space around parameter description
- italic font for parameter types
- assure that colon after "Parameters" is on same line and some grey background in Parameter field to highlight the 
- "See also" box: put link and description on same line
- light background color in code examples 
- line under Notes and Examples section headers

You can see the result here: http://jorisvandenbossche.github.io/example-pandas-docs/html-docstring-rendering/generated/pandas.DataFrame.apply.html#pandas.DataFrame.apply
and compare with the original: http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.apply.html#pandas.DataFrame.apply

Each of the points is of course debatable and I can change some of them back. Maybe the grey background of the code cells (this also applies to the tutorial docs) and the grey highlighting of the "parameter" and "returns" field (this can alse be the full block as in eg http://docs.scipy.org/doc/numpy/reference/generated/numpy.reshape.html#numpy.reshape) is maybe the most debatable.

Style is of course always subjective :-) So what do you think?
