### PR TITLE
DOC: correction of example in unstack docstring

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3280,28 +3280,38 @@ class DataFrame(NDFrame):
 
         Parameters
         ----------
-        level : int, string, or list of these, default last level
+        level : int, string, or list of these, default -1 (last level)
             Level(s) of index to unstack, can pass level name
+
+        See also
+        --------
+        DataFrame.pivot : Pivot a table based on column values.
+        DataFrame.stack : Pivot a level of the column labels (inverse operation 
+            from `unstack`).
 
         Examples
         --------
+        >>> index = pd.MultiIndex.from_tuples([('one', 'a'), ('one', 'b'),
+        ...                                    ('two', 'a'), ('two', 'b')])
+        >>> s = pd.Series(np.arange(1.0, 5.0), index=index)
         >>> s
-        one  a   1.
-        one  b   2.
-        two  a   3.
-        two  b   4.
+        one  a   1
+             b   2
+        two  a   3
+             b   4
+        dtype: float64
 
         >>> s.unstack(level=-1)
              a   b
-        one  1.  2.
-        two  3.  4.
+        one  1  2
+        two  3  4
+
+        >>> s.unstack(level=0)
+           one  two
+        a  1   3
+        b  2   4
 
         >>> df = s.unstack(level=0)
-        >>> df
-           one  two
-        a  1.   2.
-        b  3.   4.
-
         >>> df.unstack()
         one  a  1.
              b  3.


### PR DESCRIPTION
There is an error in the example of the `unstack` docstring (http://pandas.pydata.org/pandas-docs/dev/generated/pandas.DataFrame.unstack.html ):

```
>>> df = s.unstack(level=0)
>>> df
   one  two
a  1.   2.
b  3.   4
```

should be 

```
   one  two
a  1.   3.
b  2.   4
```

So this PR fixes that, but in the same time I did some other adjustments. Mainly:
- added a "see also"
- added in the example the code to create the series, so one can run the example him/herself
