### PR TITLE
ENH: Add axis and level keywords to where, so that the other argument can now be an alignable pandas object.

### DIFF
--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -625,6 +625,18 @@ This can be done intuitively like so:
    df2[df2 < 0] = 0
    df2
 
+By default, ``where`` returns a modified copy of the data. There is an
+optional parameter ``inplace`` so that the original data can be modified
+without creating a copy:
+
+.. ipython:: python
+
+   df_orig = df.copy()
+   df_orig.where(df > 0, -df, inplace=True);
+   df_orig
+
+**alignment**
+
 Furthermore, ``where`` aligns the input boolean condition (ndarray or DataFrame),
 such that partial selection with setting is possible. This is analagous to
 partial setting via ``.ix`` (but on the contents rather than the axis labels)
@@ -635,24 +647,30 @@ partial setting via ``.ix`` (but on the contents rather than the axis labels)
    df2[ df2[1:4] > 0 ] = 3
    df2
 
-By default, ``where`` returns a modified copy of the data. There is an
-optional parameter ``inplace`` so that the original data can be modified
-without creating a copy:
+.. versionadded:: 0.13
+
+Where can also accept ``axis`` and ``level`` parameters to align the input when
+performing the ``where``.
 
 .. ipython:: python
 
-   df_orig = df.copy()
+   df2 = df.copy()
+   df2.where(df2>0,df2['A'],axis='index')
 
-   df_orig.where(df > 0, -df, inplace=True);
+This is equivalent (but faster than) the following.
 
-   df_orig
+.. ipython:: python
+
+   df2 = df.copy()
+   df.apply(lambda x, y: x.where(x>0,y), y=df['A'])
+
+**mask**
 
 ``mask`` is the inverse boolean operation of ``where``.
 
 .. ipython:: python
 
    s.mask(s >= 0)
-
    df.mask(df >= 0)
 
 Take Methods

--- a/doc/source/missing_data.rst
+++ b/doc/source/missing_data.rst
@@ -205,6 +205,33 @@ To remind you, these are the available filling methods:
 With time series data, using pad/ffill is extremely common so that the "last
 known value" is available at every time point.
 
+Filling with a PandasObject
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 0.12
+
+You can also fill using a direct assignment with an alignable object. The
+use case of this is to fill a DataFrame with the mean of that column.
+
+.. ipython:: python
+
+        df = DataFrame(np.random.randn(10,3))
+        df.iloc[3:5,0] = np.nan
+        df.iloc[4:6,1] = np.nan
+        df.iloc[5:8,2] = np.nan
+        df
+
+        df.fillna(df.mean())
+
+.. versionadded:: 0.13
+
+Same result as above, but is aligning the 'fill' value which is
+a Series in this case.
+
+.. ipython:: python
+
+        df.where(pd.notnull(df),df.mean(),axis='columns')
+
 .. _missing_data.dropna:
 
 Dropping axis labels with missing data: dropna

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -102,6 +102,8 @@ Improvements to existing features
     tests/test_frame, tests/test_multilevel (:issue:`4732`).
   - Performance improvement of timesesies plotting with PeriodIndex and added
     test to vbench (:issue:`4705` and :issue:`4722`)
+  - Add ``axis`` and ``level`` keywords to ``where``, so that the ``other`` argument
+    can now be an alignable pandas object.
 
 API Changes
 ~~~~~~~~~~~

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2725,7 +2725,7 @@ class Series(generic.NDFrame):
         else:
             return self._constructor(mapped, index=self.index, name=self.name)
 
-    def align(self, other, join='outer', level=None, copy=True,
+    def align(self, other, join='outer', axis=None, level=None, copy=True,
               fill_value=None, method=None, limit=None):
         """
         Align two Series object with the specified join method
@@ -2734,6 +2734,7 @@ class Series(generic.NDFrame):
         ----------
         other : Series
         join : {'outer', 'inner', 'left', 'right'}, default 'outer'
+        axis : None, alignment axis (is 0 for Series)
         level : int or name
             Broadcast across a level, matching Index values on the
             passed MultiIndex level

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -7931,6 +7931,35 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         expected = DataFrame({'series': Series([0,1,2,3,4,5,6,7,np.nan,np.nan]) })
         assert_frame_equal(df, expected)
 
+    def test_where_align(self):
+
+        def create():
+            df = DataFrame(np.random.randn(10,3))
+            df.iloc[3:5,0] = np.nan
+            df.iloc[4:6,1] = np.nan
+            df.iloc[5:8,2] = np.nan
+            return df
+
+        # series
+        df = create()
+        expected = df.fillna(df.mean())
+        result = df.where(pd.notnull(df),df.mean(),axis='columns')
+        assert_frame_equal(result, expected)
+
+        df.where(pd.notnull(df),df.mean(),inplace=True,axis='columns')
+        assert_frame_equal(df, expected)
+
+        df = create().fillna(0)
+        expected = df.apply(lambda x, y: x.where(x>0,y), y=df[0])
+        result = df.where(df>0,df[0],axis='index')
+        assert_frame_equal(result, expected)
+
+        # frame
+        df = create()
+        expected = df.fillna(1)
+        result = df.where(pd.notnull(df),DataFrame(1,index=df.index,columns=df.columns))
+        assert_frame_equal(result, expected)
+
     def test_mask(self):
         df = DataFrame(np.random.randn(5, 3))
         cond = df > 0


### PR DESCRIPTION
So traditionally a fillna that does the means of the columns is an apply operation

```
In [1]: df = DataFrame(np.random.randn(10,3))

In [2]: df.iloc[3:5,0] = np.nan

In [3]: df.iloc[4:6,1] = np.nan

In [4]: df.iloc[5:8,2] = np.nan

In [5]: df
Out[5]: 
          0         1         2
0  0.096030  0.197451  1.645981
1 -0.443437  0.359204 -0.382563
2  0.613981  1.418754 -0.589935
3  0.000000  0.449953 -0.308414
4  0.000000  0.000000 -0.471054
5 -2.350309  0.000000  0.000000
6 -0.218522  0.498207  0.000000
7  0.478238  0.399154  0.000000
8  0.895854  0.230992  0.025799
9  0.085675  2.189373 -0.946990
```

The following currently fails in 0.12 as where is finicky about how it broadcasts

```
In [4]: df.where(df>0,df[0],axis='index')
ValueError: other must be the same shape as self when an ndarray
```

Adding `axis` and `level` arguments to `where` (which uses align under the hood), now enables the `other` object to be a Series/DataFrame (as well as a scalar) without a whole bunch of alignment/broadcasting. This also should be quite a bit faster.

```
IIn [6]: df.where(df>0,df[0],axis='index')
Out[6]: 
          0         1         2
0  0.096030  0.197451  1.645981
1 -0.443437  0.359204 -0.443437
2  0.613981  1.418754  0.613981
3  0.000000  0.449953  0.000000
4  0.000000  0.000000  0.000000
5 -2.350309 -2.350309 -2.350309
6 -0.218522  0.498207 -0.218522
7  0.478238  0.399154  0.478238
8  0.895854  0.230992  0.025799
9  0.085675  2.189373  0.085675
```

This works in 0.12.

```
In [7]: df.apply(lambda x, y: x.where(x>0,y), y=df[0])
Out[7]: 
          0         1         2
0  0.096030  0.197451  1.645981
1 -0.443437  0.359204 -0.443437
2  0.613981  1.418754  0.613981
3  0.000000  0.449953  0.000000
4  0.000000  0.000000  0.000000
5 -2.350309 -2.350309 -2.350309
6 -0.218522  0.498207 -0.218522
7  0.478238  0.399154  0.478238
8  0.895854  0.230992  0.025799
9  0.085675  2.189373  0.085675
```
