### PR TITLE
BUG: Fix input bytes conversion in Py3 to return str

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -393,6 +393,9 @@ Bug Fixes
   - Fixed bug with reading compressed files with ``read_fwf`` in Python 3.
     (:issue:`3963`)
   - Fixed an issue with a duplicate index and assignment with a dtype change (:issue:`4686`)
+  - Fixed bug with reading compressed files in as ``bytes`` rather than ``str``
+    in Python 3. Simplifies bytes-producing file-handling in Python 3
+    (:issue:`3963`, :issue:`4785`).
 
 pandas 0.12.0
 -------------

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -36,6 +36,7 @@ import sys
 import types
 
 PY3 = (sys.version_info[0] >= 3)
+PY3_2 = sys.version_info[:2] == (3, 2)
 
 try:
     import __builtin__ as builtins


### PR DESCRIPTION
Fixes #3963, #4785

Fixed bug with reading compressed files in as `bytes` (`gzip` and `bz2` both now return `bytes` rather
than `str` in Python 3) rather than `str` in Python 3, as well as the lack of conversion of `BytesIO`. Now, `_get_handle` and `_wrap_compressed` both wrap in an `io.TextIOWrapper`, so that the parsers work internally only with `str` in Python 3. In Python 3.2, has to read the entire file in first (because `gzip` and `bz2` files both lack a `read1()` method in 3.2)

Also adds support for passing fileobjects with compression == 'bz2'.
