### PR TITLE
CLN: removed need for Coordinates in HDFStore tables / added doc section

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -2118,6 +2118,22 @@ These do not currently accept the ``where`` selector (coming soon)
    store.select_column('df_dc', 'index')
    store.select_column('df_dc', 'string')
 
+.. _io.hdf5-selecting_coordinates:
+
+**Selecting coordinates**
+
+Sometimes you want to get the coordinates (a.k.a the index locations) of your query. This returns an
+``Int64Index`` of the resulting locations. These coordinates can also be passed to subsequent
+``where`` operations.
+
+.. ipython:: python
+
+   df_coord = DataFrame(np.random.randn(1000,2),index=date_range('20000101',periods=1000))
+   store.append('df_coord',df_coord)
+   c = store.select_as_coordinates('df_coord','index>20020101')
+   c.summary()
+   store.select('df_coord',where=c)
+
 .. _io.hdf5-where_mask:
 
 **Selecting using a where mask**

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -155,6 +155,7 @@ API Changes
       the ``Storer`` format has been renamed to ``Fixed``
     - a column multi-index will be recreated properly (:issue:`4710`); raise on trying to use a multi-index
       with data_columns on the same axis
+    - ``select_as_coordinates`` will now return an ``Int64Index`` of the resultant selection set
   - ``JSON``
 
     - added ``date_unit`` parameter to specify resolution of timestamps. Options

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -76,6 +76,8 @@ API changes
       duplicate rows from a table (:issue:`4367`)
     - removed the ``warn`` argument from ``open``. Instead a ``PossibleDataLossError`` exception will
       be raised if you try to use ``mode='w'`` with an OPEN file handle (:issue:`4367`)
+    - ``select_as_coordinates`` will now return an ``Int64Index`` of the resultant selection set
+      See :ref:`here<io.hdf5-selecting_coordinates>` for an example.
     - allow a passed locations array or mask as a ``where`` condition (:issue:`4467`).
       See :ref:`here<io.hdf5-where_mask>` for an example.
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -565,7 +565,7 @@ class HDFStore(StringMixin):
 
     def select_as_coordinates(self, key, where=None, start=None, stop=None, **kwargs):
         """
-        return the selection as a Coordinates.
+        return the selection as an Index
 
         Parameters
         ----------
@@ -3071,7 +3071,7 @@ class Table(Fixed):
         # create the selection
         self.selection = Selection(
             self, where=where, start=start, stop=stop, **kwargs)
-        return Coordinates(self.selection.select_coords(), group=self.group, where=where)
+        return Index(self.selection.select_coords())
 
     def read_column(self, column, where=None, **kwargs):
         """ return a single column from the table, generally only indexables are interesting """
@@ -4106,28 +4106,6 @@ class TermValue(object):
         return self.converted
 
 
-class Coordinates(object):
-
-    """ holds a returned coordinates list, useful to select the same rows from different tables
-
-    coordinates : holds the array of coordinates
-    group       : the source group
-    where       : the source where
-    """
-
-    def __init__(self, values, group, where, **kwargs):
-        self.values = values
-        self.group = group
-        self.where = where
-
-    def __len__(self):
-        return len(self.values)
-
-    def __getitem__(self, key):
-        """ return a new coordinates object, sliced by the key """
-        return Coordinates(self.values[key], self.group, self.where)
-
-
 class Selection(object):
 
     """
@@ -4151,11 +4129,7 @@ class Selection(object):
         self.terms = None
         self.coordinates = None
 
-        # a coordinate
-        if isinstance(where, Coordinates):
-            self.coordinates = where.values
-
-        elif com.is_list_like(where):
+        if com.is_list_like(where):
 
             # see if we have a passed coordinate like
             try:

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -2879,6 +2879,7 @@ class TestHDFStore(unittest.TestCase):
             result = store.select('df', where=c)
             expected = df.ix[3:4, :]
             tm.assert_frame_equal(result, expected)
+            self.assert_(isinstance(c, Index))
 
             # multiple tables
             _maybe_remove(store, 'df1')


### PR DESCRIPTION
CLN: removed need for Coordinates, instead return an Index of the coordinates

DOC: added section on select_as_coordinates
