### PR TITLE
ENH: Allow abs to work with PandasObjects

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -560,6 +560,9 @@ class NDFrame(PandasObject):
 
     __bool__ = __nonzero__
 
+    def __abs__(self):
+        return self.abs()
+
     #----------------------------------------------------------------------
     # Array Interface
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3234,9 +3234,11 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
         # abs
         result = diffs.abs()
+        result2 = abs(diffs)
         expected = DataFrame(dict(A = df['A']-df['C'],
                                   B = df['B']-df['A']))
         assert_frame_equal(result,expected)
+        assert_frame_equal(result2, expected)
 
         # mixed frame
         mixed = diffs.copy()

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -355,18 +355,24 @@ class SafeForSparse(object):
 
     def test_abs(self):
         result = self.panel.abs()
+        result2 = abs(self.panel)
         expected = np.abs(self.panel)
         self.assert_panel_equal(result, expected)
+        self.assert_panel_equal(result2, expected)
 
         df = self.panel['ItemA']
         result = df.abs()
+        result2 = abs(df)
         expected = np.abs(df)
         assert_frame_equal(result, expected)
+        assert_frame_equal(result2, expected)
 
         s = df['A']
         result = s.abs()
+        result2 = abs(s)
         expected = np.abs(s)
         assert_series_equal(result, expected)
+        assert_series_equal(result2, expected)
 
 
 class CheckIndexing(object):


### PR DESCRIPTION
Add `__abs__` method so that you can use the toplevel `abs()` with
PandasObjects. I note there aren't that many existing test cases for
abs. At some point we might want to think about that.

Also related #4819 

cc @thisch
