### PR TITLE
BUG/VIS: correctly test for yaxis ticklocs across different versions of MPL

### DIFF
--- a/ci/requirements-2.7_LOCALE.txt
+++ b/ci/requirements-2.7_LOCALE.txt
@@ -8,7 +8,7 @@ cython==0.19.1
 bottleneck==0.6.0
 numexpr==2.1
 tables==2.3.1
-matplotlib==1.2.1
+matplotlib==1.3.0
 patsy==0.1.0
 html5lib==1.0b2
 lxml==3.2.1

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -396,6 +396,8 @@ Bug Fixes
   - Fixed bug with reading compressed files in as ``bytes`` rather than ``str``
     in Python 3. Simplifies bytes-producing file-handling in Python 3
     (:issue:`3963`, :issue:`4785`).
+  - Fixed an issue related to ticklocs/ticklabels with log scale bar plots
+    across different versions of matplotlib (:issue:`4789`)
 
 pandas 0.12.0
 -------------


### PR DESCRIPTION
closes #4789
