### PR TITLE
ENH: Better read_json error when handling bad keys

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -120,6 +120,8 @@ Improvements to existing features
     thanks @jnothman
   - ``__getitem__`` with ``tuple`` key (e.g., ``[:, 2]``) on ``Series``
     without ``MultiIndex`` raises ``ValueError`` (:issue:`4759`, :issue:`4837`)
+  - ``read_json`` now raises a (more informative) ``ValueError`` when the dict
+    contains a bad key and ``orient='split'`` (:issue:`4730`, :issue:`4838`)
 
 API Changes
 ~~~~~~~~~~~

--- a/pandas/io/tests/test_json/test_pandas.py
+++ b/pandas/io/tests/test_json/test_pandas.py
@@ -252,8 +252,8 @@ class TestPandasContainer(unittest.TestCase):
         json = StringIO('{"badkey":["A","B"],'
                         '"index":["2","3"],'
                         '"data":[[1.0,"1"],[2.0,"2"],[null,"3"]]}')
-        self.assertRaises(TypeError, read_json, json,
-                          orient="split")
+        with tm.assertRaisesRegexp(ValueError, r"unexpected key\(s\): badkey"):
+            read_json(json, orient="split")
 
     def test_frame_from_json_nones(self):
         df = DataFrame([[1, 2], [4, 5, 6]])


### PR DESCRIPTION
(in json data with orient=split)

Fixes #4730.
