### PR TITLE
BUG/ENH: provide better .loc based semantics for float based indicies, continuing not to fallback (related GH236)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -226,6 +226,10 @@ API Changes
     add top-level ``to_timedelta`` function
   - ``NDFrame`` now is compatible with Python's toplevel ``abs()`` function (:issue:`4821`).
   - raise a ``TypeError`` on invalid comparison ops on Series/DataFrame (e.g. integer/datetime) (:issue:`4968`)
+  - Added a new index type, ``Float64Index``. This will be automatically created when passing floating values in index creation.
+    This enables a pure label-based slicing paradigm that makes ``[],ix,loc`` for scalar indexing and slicing work exactly the same.
+    Indexing on other index types are preserved (and positional fallback for ``[],ix``), with the exception, that floating point slicing
+    on indexes on non ``Float64Index`` will raise a ``TypeError``, e.g. ``Series(range(5))[3.5:4.5]`` (:issue:`263`)
 
 Internal Refactoring
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -116,6 +116,72 @@ Indexing API Changes
        p
        p.loc[:,:,'C']
 
+Float64Index API Change
+~~~~~~~~~~~~~~~~~~~~~~~
+
+  - Added a new index type, ``Float64Index``. This will be automatically created when passing floating values in index creation.
+    This enables a pure label-based slicing paradigm that makes ``[],ix,loc`` for scalar indexing and slicing work exactly the
+    same. See :ref:`the docs<indexing.float64index>`, (:issue:`263`)
+
+    Construction is by default for floating type values.
+
+    .. ipython:: python
+
+       index = Index([1.5, 2, 3, 4.5, 5])
+       index
+       s = Series(range(5),index=index)
+       s
+
+    Scalar selection for ``[],.ix,.loc`` will always be label based. An integer will match an equal float index (e.g. ``3`` is equivalent to ``3.0``)
+
+    .. ipython:: python
+
+       s[3]
+       s.ix[3]
+       s.loc[3]
+
+    The only positional indexing is via ``iloc``
+
+    .. ipython:: python
+
+       s.iloc[3]
+
+    A scalar index that is not found will raise ``KeyError``
+
+    Slicing is ALWAYS on the values of the index, for ``[],ix,loc`` and ALWAYS positional with ``iloc``
+
+    .. ipython:: python
+
+       s[2:4]
+       s.ix[2:4]
+       s.loc[2:4]
+       s.iloc[2:4]
+
+    In float indexes, slicing using floats are allowed
+
+    .. ipython:: python
+
+       s[2.1:4.6]
+       s.loc[2.1:4.6]
+
+  - Indexing on other index types are preserved (and positional fallback for ``[],ix``), with the exception, that floating point slicing
+    on indexes on non ``Float64Index`` will now raise a ``TypeError``.
+
+    .. code-block:: python
+
+       In [1]: Series(range(5))[3.5]
+       TypeError: the label [3.5] is not a proper indexer for this index type (Int64Index)
+
+       In [1]: Series(range(5))[3.5:4.5]
+       TypeError: the slice start [3.5] is not a proper indexer for this index type (Int64Index)
+
+    Using a scalar float indexer will be deprecated in a future version, but is allowed for now.
+
+    .. code-block:: python
+
+       In [3]: Series(range(5))[3.0]
+       Out[3]: 3
+
 HDFStore API Changes
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/v0.4.x.txt
+++ b/doc/source/v0.4.x.txt
@@ -15,8 +15,7 @@ New Features
   with choice of join method (ENH56_)
 - :ref:`Added <indexing.get_level_values>` method ``get_level_values`` to
   ``MultiIndex`` (:issue:`188`)
-- :ref:`Set <indexing.mixed_type_setting>` values in mixed-type
-  ``DataFrame`` objects via ``.ix`` indexing attribute (:issue:`135`)
+- Set values in mixed-type ``DataFrame`` objects via ``.ix`` indexing attribute (:issue:`135`)
 - Added new ``DataFrame`` :ref:`methods <basics.dtypes>`
   ``get_dtype_counts`` and property ``dtypes`` (ENHdc_)
 - Added :ref:`ignore_index <merging.ignore_index>` option to

--- a/pandas/computation/tests/test_eval.py
+++ b/pandas/computation/tests/test_eval.py
@@ -778,7 +778,7 @@ ENGINES_PARSERS = list(product(_engines, expr._parsers))
 class TestAlignment(object):
 
     index_types = 'i', 'u', 'dt'
-    lhs_index_types = index_types + ('f', 's')  # 'p'
+    lhs_index_types = index_types + ('s',)  # 'p'
 
     def check_align_nested_unary_op(self, engine, parser):
         skip_if_no_ne(engine)

--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -8,7 +8,7 @@ from pandas.core.common import isnull, notnull
 from pandas.core.categorical import Categorical, Factor
 from pandas.core.format import (set_printoptions, reset_printoptions,
                                 set_eng_float_format)
-from pandas.core.index import Index, Int64Index, MultiIndex
+from pandas.core.index import Index, Int64Index, Float64Index, MultiIndex
 
 from pandas.core.series import Series, TimeSeries
 from pandas.core.frame import DataFrame

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2050,7 +2050,7 @@ class DataFrame(NDFrame):
         kwargs['local_dict'] = _ensure_scope(resolvers=resolvers, **kwargs)
         return _eval(expr, **kwargs)
 
-    def _slice(self, slobj, axis=0, raise_on_error=False):
+    def _slice(self, slobj, axis=0, raise_on_error=False, typ=None):
         axis = self._get_block_manager_axis(axis)
         new_data = self._data.get_slice(
             slobj, axis=axis, raise_on_error=raise_on_error)

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -579,7 +579,7 @@ class Panel(NDFrame):
         d = self._construct_axes_dict_for_slice(self._AXIS_ORDERS[1:])
         return self._constructor_sliced(values, **d)
 
-    def _slice(self, slobj, axis=0, raise_on_error=False):
+    def _slice(self, slobj, axis=0, raise_on_error=False, typ=None):
         new_data = self._data.get_slice(slobj,
                                         axis=axis,
                                         raise_on_error=raise_on_error)

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -374,7 +374,7 @@ class SparseDataFrame(DataFrame):
         return dense.to_sparse(kind=self._default_kind,
                                fill_value=self._default_fill_value)
 
-    def _slice(self, slobj, axis=0, raise_on_error=False):
+    def _slice(self, slobj, axis=0, raise_on_error=False, typ=None):
         if axis == 0:
             if raise_on_error:
                 _check_slice_bounds(slobj, self.index)

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -1110,10 +1110,10 @@ class TestDataFrameFormatting(unittest.TestCase):
         result = df.to_string()
         expected = ('     0\n'
                     '1.5  0\n'
-                    '2    1\n'
-                    '3    2\n'
-                    '4    3\n'
-                    '5    4')
+                    '2.0  1\n'
+                    '3.0  2\n'
+                    '4.0  3\n'
+                    '5.0  4')
         self.assertEqual(result, expected)
 
     def test_to_string_ascii_error(self):

--- a/pandas/tests/test_reshape.py
+++ b/pandas/tests/test_reshape.py
@@ -14,6 +14,7 @@ from numpy import nan
 import numpy as np
 
 from pandas.util.testing import assert_frame_equal
+from numpy.testing import assert_array_equal
 
 from pandas.core.reshape import melt, convert_dummies, lreshape, get_dummies
 import pandas.util.testing as tm
@@ -195,11 +196,8 @@ class TestGetDummies(unittest.TestCase):
         assert_frame_equal(res_na, exp_na)
 
         res_just_na = get_dummies([nan], dummy_na=True)
-        exp_just_na = DataFrame({nan: {0: 1.0}})
-        # hack (NaN handling in assert_index_equal)
-        exp_just_na.columns = res_just_na.columns
-        assert_frame_equal(res_just_na, exp_just_na)
-
+        exp_just_na = DataFrame(Series(1.0,index=[0]),columns=[nan])
+        assert_array_equal(res_just_na.values, exp_just_na.values)
 
 class TestConvertDummies(unittest.TestCase):
     def test_convert_dummies(self):

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -909,12 +909,11 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         result = s[::-1]  # it works!
 
     def test_slice_float_get_set(self):
-        result = self.ts[4.0:10.0]
-        expected = self.ts[4:10]
-        assert_series_equal(result, expected)
 
-        self.ts[4.0:10.0] = 0
-        self.assert_((self.ts[4:10] == 0).all())
+        self.assertRaises(TypeError, lambda : self.ts[4.0:10.0])
+        def f():
+            self.ts[4.0:10.0] = 0
+        self.assertRaises(TypeError, f)
 
         self.assertRaises(TypeError, self.ts.__getitem__, slice(4.5, 10.0))
         self.assertRaises(TypeError, self.ts.__setitem__, slice(4.5, 10.0), 0)
@@ -932,6 +931,7 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         self.assert_(len(s.ix[12.5:]) == 7)
 
     def test_slice_float64(self):
+
         values = np.arange(10., 50., 2)
         index = Index(values)
 
@@ -940,19 +940,19 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         s = Series(np.random.randn(20), index=index)
 
         result = s[start:end]
-        expected = s.ix[5:16]
+        expected = s.iloc[5:16]
         assert_series_equal(result, expected)
 
-        result = s.ix[start:end]
+        result = s.loc[start:end]
         assert_series_equal(result, expected)
 
         df = DataFrame(np.random.randn(20, 3), index=index)
 
         result = df[start:end]
-        expected = df.ix[5:16]
+        expected = df.iloc[5:16]
         tm.assert_frame_equal(result, expected)
 
-        result = df.ix[start:end]
+        result = df.loc[start:end]
         tm.assert_frame_equal(result, expected)
 
     def test_setitem(self):
@@ -3253,6 +3253,13 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         result = td.value_counts()
         #self.assert_(result.index.dtype == 'timedelta64[ns]')
         self.assert_(result.index.dtype == 'int64')
+
+        # basics.rst doc example
+        series = Series(np.random.randn(500))
+        series[20:500] = np.nan
+        series[10:20]  = 5000
+        result = series.nunique()
+        self.assert_(result == 11)
 
     def test_unique(self):
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -393,23 +393,36 @@ def getCols(k):
     return string.ascii_uppercase[:k]
 
 
-def makeStringIndex(k):
+# make index
+def makeStringIndex(k=10):
     return Index([rands(10) for _ in range(k)])
 
 
-def makeUnicodeIndex(k):
+def makeUnicodeIndex(k=10):
     return Index([randu(10) for _ in range(k)])
 
 
-def makeIntIndex(k):
+def makeIntIndex(k=10):
     return Index(lrange(k))
 
 
-def makeFloatIndex(k):
+def makeFloatIndex(k=10):
     values = sorted(np.random.random_sample(k)) - np.random.random_sample(1)
     return Index(values * (10 ** np.random.randint(0, 9)))
 
+def makeDateIndex(k=10):
+    dt = datetime(2000, 1, 1)
+    dr = bdate_range(dt, periods=k)
+    return DatetimeIndex(dr)
 
+
+def makePeriodIndex(k=10):
+    dt = datetime(2000, 1, 1)
+    dr = PeriodIndex(start=dt, periods=k, freq='B')
+    return dr
+
+
+# make series
 def makeFloatSeries():
     index = makeStringIndex(N)
     return Series(randn(N), index=index)
@@ -430,41 +443,6 @@ def makeObjectSeries():
 def getSeriesData():
     index = makeStringIndex(N)
     return dict((c, Series(randn(N), index=index)) for c in getCols(K))
-
-
-def makeDataFrame():
-    data = getSeriesData()
-    return DataFrame(data)
-
-
-def getArangeMat():
-    return np.arange(N * K).reshape((N, K))
-
-
-def getMixedTypeDict():
-    index = Index(['a', 'b', 'c', 'd', 'e'])
-
-    data = {
-        'A': [0., 1., 2., 3., 4.],
-        'B': [0., 1., 0., 1., 0.],
-        'C': ['foo1', 'foo2', 'foo3', 'foo4', 'foo5'],
-        'D': bdate_range('1/1/2009', periods=5)
-    }
-
-    return index, data
-
-
-def makeDateIndex(k):
-    dt = datetime(2000, 1, 1)
-    dr = bdate_range(dt, periods=k)
-    return DatetimeIndex(dr)
-
-
-def makePeriodIndex(k):
-    dt = datetime(2000, 1, 1)
-    dr = PeriodIndex(start=dt, periods=k, freq='B')
-    return dr
-
 
 def makeTimeSeries(nper=None):
     if nper is None:
@@ -489,6 +467,28 @@ def makeTimeDataFrame(nper=None):
 
 def getPeriodData(nper=None):
     return dict((c, makePeriodSeries(nper)) for c in getCols(K))
+
+# make frame
+def makeDataFrame():
+    data = getSeriesData()
+    return DataFrame(data)
+
+
+def getArangeMat():
+    return np.arange(N * K).reshape((N, K))
+
+
+def getMixedTypeDict():
+    index = Index(['a', 'b', 'c', 'd', 'e'])
+
+    data = {
+        'A': [0., 1., 2., 3., 4.],
+        'B': [0., 1., 0., 1., 0.],
+        'C': ['foo1', 'foo2', 'foo3', 'foo4', 'foo5'],
+        'D': bdate_range('1/1/2009', periods=5)
+    }
+
+    return index, data
 
 
 def makePeriodFrame(nper=None):


### PR DESCRIPTION
closes #236 
- CLN: refactor all scalar/slicing code from core/indexing.py to core/index.py on a per-index basis
- BUG: provide better `.loc` semantics on floating indicies
- API: provide a implementation of `Float64Index`
- BUG: raise on indexing with float keys on a non-float index

provide better `loc` semantics on `Float64Index`

```
In [1]: s = Series(np.arange(5), index=np.arange(5) * 2.5)

In [9]: s.index
Out[9]: Float64Index([0.0, 2.5, 5.0, 7.5, 10.0], dtype=object)

In [2]: s
Out[2]: 
0.0     0
2.5     1
5.0     2
7.5     3
10.0    4
dtype: int64

In [3]: # label based slicing

In [4]: s[1.0:3.0]
Out[4]: 
2.5    1
dtype: int64

In [5]: s.ix[1.0:3.0]
Out[5]: 
2.5    1
dtype: int64

In [6]: s.loc[1.0:3.0]
Out[6]: 
2.5    1
dtype: int64

In [7]: # exact indexing when found

In [8]: s[5.0]
Out[8]: 2

In [9]: s.loc[5.0]
Out[9]: 2

In [10]: s.ix[5.0]
Out[10]: 2

In [11]: # non-fallback location based should raise this error (__getitem__,ix fallback here)

In [12]: s.loc[4.0]
KeyError: 'the label [4.0] is not in the [index]'

In [13]: s[4.0] == s[4]
Out[13]: True

In [14]: s[4] == s[4]
Out[14]: True

# [],ix,s.ix[2:5]
loc is clear about slicing on the values ONLY

In [11]: s[2:5]
Out[11]: 
2.5    1
5.0    2
dtype: int64

In [12]: s.ix[2:5]
Out[12]: 
2.5    1
5.0    2
dtype: int64

In [2]: s.loc[2:5]
Out[2]: 
2.5    1
5.0    2
dtype: int64

In [15]: s.loc[2.0:5.0]
Out[15]: 
2.5    1
5.0    2
dtype: int64

In [16]: s.loc[2.0:5]
Out[16]: 
2.5    1
5.0    2
dtype: int64

In [17]: s.loc[2.1:5]
Out[17]: 
2.5    1
5.0    2
dtype: int64
```

Float Slicing now raises when indexing by a non-integer slicer

```
 In [1]: s = Series(np.arange(5))

In [2]: s
Out[2]: 
0    0
1    1
2    2
3    3
4    4
dtype: int64

In [3]: s[3.5]
KeyError: 

In [4]: s.loc[3.5]
KeyError: 'the label [3.5] is not in the [index]'

In [5]: s.ix[3.5]
KeyError: 'the label [3.5] is not in the [index]'

In [6]: s.iloc[3.5]
TypeError: the positional label [3.5] is not a proper indexer for this index type (Float64Index)
```
