### PR TITLE
TST: windows dtype 32-bit fixes

### DIFF
--- a/pandas/io/tests/test_clipboard.py
+++ b/pandas/io/tests/test_clipboard.py
@@ -43,7 +43,7 @@ class TestClipboard(unittest.TestCase):
         data = self.data[data_type]
         data.to_clipboard()
         result = read_clipboard()
-        tm.assert_frame_equal(data, result)
+        tm.assert_frame_equal(data, result, check_dtype=False)
 
     def test_round_trip_frame(self):
         for dt in self.data_types:

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -492,7 +492,7 @@ class TestDataFramePlots(unittest.TestCase):
 
     def test_unsorted_index(self):
         df = DataFrame({'y': np.arange(100)},
-                       index=np.arange(99, -1, -1))
+                       index=np.arange(99, -1, -1), dtype=np.int64)
         ax = df.plot()
         l = ax.get_lines()[0]
         rs = l.get_xydata()


### PR DESCRIPTION
Fix test failures related to incoorrect dtype, detail #4866.
