### PR TITLE
BUG: bug in getitem with a duplicate index when using where (GH4879)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -429,9 +429,11 @@ Bug Fixes
     ``ascending`` was being interpreted as ``True`` (:issue:`4839`,
     :issue:`4846`)
   - Fixed ``Panel.tshift`` not working. Added `freq` support to ``Panel.shift`` (:issue:`4853`)
-  - Fix an issue in TextFileReader w/ Python engine (i.e. PythonParser) 
+  - Fix an issue in TextFileReader w/ Python engine (i.e. PythonParser)
     with thousands != "," (:issue:`4596`)
-    
+  - Bug in getitem with a duplicate index when using where (:issue:`4879`)
+
+
 pandas 0.12.0
 -------------
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1840,8 +1840,12 @@ class DataFrame(NDFrame):
         if self.columns.is_unique:
             return self._get_item_cache(key)
 
-        # duplicate columns
-        return self._constructor(self._data.get(key))
+        # duplicate columns & possible reduce dimensionaility
+        result = self._constructor(self._data.get(key))
+        if result.columns.is_unique:
+            result = result[key]
+
+        return result
 
     def _getitem_slice(self, key):
         return self._slice(key, axis=0)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3150,6 +3150,36 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         expected = DataFrame([[1],[1],[1]],columns=['bar'])
         check(df,expected)
 
+    def test_column_dups_indexing(self):
+
+        def check(result, expected=None):
+            if expected is not None:
+                assert_frame_equal(result,expected)
+            result.dtypes
+            str(result)
+
+        # boolean indexing
+        # GH 4879
+        dups = ['A', 'A', 'C', 'D']
+        df = DataFrame(np.arange(12).reshape(3,4), columns=['A', 'B', 'C', 'D'],dtype='float64')
+        expected = df[df.C > 6]
+        expected.columns = dups
+        df = DataFrame(np.arange(12).reshape(3,4), columns=dups,dtype='float64')
+        result = df[df.C > 6]
+        check(result,expected)
+
+        # where
+        df = DataFrame(np.arange(12).reshape(3,4), columns=['A', 'B', 'C', 'D'],dtype='float64')
+        expected = df[df > 6]
+        expected.columns = dups
+        df = DataFrame(np.arange(12).reshape(3,4), columns=dups,dtype='float64')
+        result = df[df > 6]
+        check(result,expected)
+
+        # boolean with the duplicate raises
+        df = DataFrame(np.arange(12).reshape(3,4), columns=dups,dtype='float64')
+        self.assertRaises(ValueError, lambda : df[df.A > 6])
+
     def test_insert_benchmark(self):
         # from the vb_suite/frame_methods/frame_insert_columns
         N = 10

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -1233,9 +1233,10 @@ class TestIndexing(unittest.TestCase):
 
         # GH 4146, not returning a block manager when selecting a unique index
         # from a duplicate index
-        expected = DataFrame([['a',1,1]],index=['A1'],columns=['h1','h3','h5'],).T
+        # as of 4879, this returns a Series (which is similar to what happens with a non-unique)
+        expected = Series(['a',1,1],index=['h1','h3','h5'])
         result = df2['A']['A1']
-        assert_frame_equal(result,expected)
+        assert_series_equal(result,expected)
 
         # selecting a non_unique from the 2nd level
         expected = DataFrame([['d',4,4],['e',5,5]],index=Index(['B2','B2'],name='sub'),columns=['h1','h3','h5'],).T


### PR DESCRIPTION
raising previously as this was not handled properly
closes #4879

```
In [1]: df = DataFrame(np.arange(12).reshape(3,4), columns=['A', 'B', 'C', 'D'],dtype='float64')

In [2]: df
Out[2]: 
   A  B   C   D
0  0  1   2   3
1  4  5   6   7
2  8  9  10  11

In [3]: df[df.C>6]
Out[3]: 
   A  B   C   D
2  8  9  10  11

In [4]: df = DataFrame(np.arange(12).reshape(3,4), columns=['A', 'A', 'C', 'D'],dtype='float64')

In [5]: df
Out[5]: 
   A  A   C   D
0  0  1   2   3
1  4  5   6   7
2  8  9  10  11

In [6]: df[df.C>6]
Out[6]: 
   A  A   C   D
2  8  9  10  11
```
