### PR TITLE
ENH: Add 'is_' method to Index for identity checks

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -198,6 +198,10 @@ API Changes
       data - allowing metadata changes.
     - ``MultiIndex.astype()`` now only allows ``np.object_``-like dtypes and
       now returns a ``MultiIndex`` rather than an ``Index``. (:issue:`4039`)
+   - Added ``is_`` method to ``Index`` that allows fast equality comparison of
+     views (similar to ``np.may_share_memory`` but no false positives, and
+     changes on ``levels`` and ``labels`` setting on ``MultiIndex``).
+     (:issue:`4859`, :issue:`4909`)
 
   - Infer and downcast dtype if ``downcast='infer'`` is passed to ``fillna/ffill/bfill`` (:issue:`4604`)
   - ``__nonzero__`` for all NDFrame objects, will now raise a ``ValueError``, this reverts back to (:issue:`1073`, :issue:`4633`)

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from pandas.core.common import (isnull, _NS_DTYPE, _INT64_DTYPE,
                                 is_list_like,_values_from_object, _maybe_box)
-from pandas.core.index import Index, Int64Index
+from pandas.core.index import Index, Int64Index, _Identity
 import pandas.compat as compat
 from pandas.compat import u
 from pandas.tseries.frequencies import (
@@ -1029,6 +1029,7 @@ class DatetimeIndex(Int64Index):
         self.offset = getattr(obj, 'offset', None)
         self.tz = getattr(obj, 'tz', None)
         self.name = getattr(obj, 'name', None)
+        self._reset_identity()
 
     def intersection(self, other):
         """
@@ -1446,7 +1447,7 @@ class DatetimeIndex(Int64Index):
         """
         Determines if two Index objects contain the same elements.
         """
-        if self is other:
+        if self.is_(other):
             return True
 
         if (not hasattr(other, 'inferred_type') or

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -812,7 +812,7 @@ class PeriodIndex(Int64Index):
         """
         Determines if two Index objects contain the same elements.
         """
-        if self is other:
+        if self.is_(other):
             return True
 
         return np.array_equal(self.asi8, other.asi8)
@@ -1076,6 +1076,7 @@ class PeriodIndex(Int64Index):
 
         self.freq = getattr(obj, 'freq', None)
         self.name = getattr(obj, 'name', None)
+        self._reset_identity()
 
     def __repr__(self):
         output = com.pprint_thing(self.__class__) + '\n'

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -1054,9 +1054,6 @@ class TestFreqConversion(TestCase):
 
 
 class TestPeriodIndex(TestCase):
-    def __init__(self, *args, **kwds):
-        TestCase.__init__(self, *args, **kwds)
-
     def setUp(self):
         pass
 
@@ -1167,6 +1164,25 @@ class TestPeriodIndex(TestCase):
         vals = vals.view(np.dtype('M8[us]'))
 
         self.assertRaises(ValueError, PeriodIndex, vals, freq='D')
+
+    def test_is_(self):
+        create_index = lambda: PeriodIndex(freq='A', start='1/1/2001',
+                                           end='12/1/2009')
+        index = create_index()
+        self.assertTrue(index.is_(index))
+        self.assertFalse(index.is_(create_index()))
+        self.assertTrue(index.is_(index.view()))
+        self.assertTrue(index.is_(index.view().view().view().view().view()))
+        self.assertTrue(index.view().is_(index))
+        ind2 = index.view()
+        index.name = "Apple"
+        self.assertTrue(ind2.is_(index))
+        self.assertFalse(index.is_(index[:]))
+        self.assertFalse(index.is_(index.asfreq('M')))
+        self.assertFalse(index.is_(index.asfreq('A')))
+        self.assertFalse(index.is_(index - 2))
+        self.assertFalse(index.is_(index - 0))
+
 
     def test_comp_period(self):
         idx = period_range('2007-01', periods=20, freq='M')

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -274,6 +274,12 @@ def assert_range_equal(left, right):
 class TestTimeSeries(unittest.TestCase):
     _multiprocess_can_split_ = True
 
+    def test_is_(self):
+        dti = DatetimeIndex(start='1/1/2005', end='12/1/2005', freq='M')
+        self.assertTrue(dti.is_(dti))
+        self.assertTrue(dti.is_(dti.view()))
+        self.assertFalse(dti.is_(dti.copy()))
+
     def test_dti_slicing(self):
         dti = DatetimeIndex(start='1/1/2005', end='12/1/2005', freq='M')
         dti2 = dti[[1, 3, 5]]
@@ -655,7 +661,7 @@ class TestTimeSeries(unittest.TestCase):
         idx = Index([datetime(2012, 1, 1)], dtype=object)
 
         if np.__version__ >= '1.7':
-            raise nose.SkipTest
+            raise nose.SkipTest("Test requires numpy < 1.7")
 
         casted = idx.astype(np.dtype('M8[D]'))
         expected = DatetimeIndex(idx.values)


### PR DESCRIPTION
Closes #4859.

Adds a method that can quickly tell whether something is a view or not
(in the way that actually matters). Also changes checks in `equals()` to
use `is_` rather than `is`.
