### PR TITLE
BUG/TST: Allow generators in DataFrame.from_records

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -169,6 +169,7 @@ Improvements to existing features
     high-dimensional arrays).
   - :func:`~pandas.read_html` now supports the ``parse_dates``,
     ``tupleize_cols`` and ``thousands`` parameters (:issue:`4770`).
+  - ``DataFrame.from_records()`` accept generators (:issue:`4910`)
 
 API Changes
 ~~~~~~~~~~~

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -724,12 +724,17 @@ class DataFrame(NDFrame):
 
             values = [first_row]
 
-            i = 1
-            for row in data:
-                values.append(row)
-                i += 1
-                if i >= nrows:
-                    break
+            #if unknown length iterable (generator)
+            if nrows == None:
+                #consume whole generator
+                values += list(data)
+            else:
+                i = 1
+                for row in data:
+                    values.append(row)
+                    i += 1
+                    if i >= nrows:
+                        break
 
             if dtype is not None:
                 data = np.array(values, dtype=dtype)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3739,6 +3739,36 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
                                     nrows=2)
         assert_frame_equal(df, xp.reindex(columns=['x','y']), check_dtype=False)
 
+    def test_from_records_tuples_generator(self):
+        def tuple_generator(length):
+            for i in range(length):
+                letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+                yield (i, letters[i % len(letters)], i/length)
+        
+        columns_names = ['Integer', 'String', 'Float']
+        columns = [[i[j] for i in tuple_generator(10)] for j in range(len(columns_names))]
+        data = {'Integer': columns[0], 'String': columns[1], 'Float': columns[2]}
+        expected = DataFrame(data, columns=columns_names)
+	
+        generator = tuple_generator(10)
+        result = DataFrame.from_records(generator, columns=columns_names)
+        assert_frame_equal(result, expected)
+    
+    def test_from_records_lists_generator(self):
+        def list_generator(length):
+            for i in range(length):
+                letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+                yield [i, letters[i % len(letters)], i/length]
+        
+        columns_names = ['Integer', 'String', 'Float']
+        columns = [[i[j] for i in list_generator(10)] for j in range(len(columns_names))]
+        data = {'Integer': columns[0], 'String': columns[1], 'Float': columns[2]}
+        expected = DataFrame(data, columns=columns_names)
+        
+        generator = list_generator(10)
+        result = DataFrame.from_records(generator, columns=columns_names)
+        assert_frame_equal(result, expected)
+    
     def test_from_records_columns_not_modified(self):
         tuples = [(1, 2, 3),
                   (1, 2, 3),


### PR DESCRIPTION
closes #4910
- nrows implementation doesn't allow unknown size iterator like
  generators, if nrows = none ends with a TypeError.
- To allow generators if nrows=None consume it into a list.
- Add two tests of generators input.
