### PR TITLE
ENH/REF: More options for interpolation and fillna

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -174,6 +174,8 @@ Improvements to existing features
   - :meth:`~pandas.io.json.json_normalize` is a new method to allow you to create a flat table
     from semi-structured JSON data. :ref:`See the docs<io.json_normalize>` (:issue:`1067`)
   - ``DataFrame.from_records()`` will now accept generators (:issue:`4910`)
+  - ``DataFrame.interpolate()`` and ``Series.interpolate()`` have been expanded to include
+    interpolation methods from scipy. (:issue:`4915`)
 
 API Changes
 ~~~~~~~~~~~

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -614,6 +614,34 @@ Experimental
 
 - Added PySide support for the qtpandas DataFrameModel and DataFrameWidget.
 
+- DataFrame has a new ``interpolate`` method, similar to Series:
+
+  .. ipython:: python
+
+      df = DataFrame({'A': [1, 2.1, np.nan, 4.7, 5.6, 6.8],
+                      'B': [.25, np.nan, np.nan, 4, 12.2, 14.4]})
+      df.interpolate()
+
+  Additionally, the ``method`` argument to ``interpolate`` has been expanded
+  to include 'nearest', 'zero', 'slinear', 'quadratic', 'cubic',
+  'barycentric', 'krogh', 'piecewise_polynomial', 'pchip' or "polynomial" or 'spline'
+  and an integer representing the degree or order of the approximation.  The new methods
+  require scipy_. Consult the Scipy reference guide_ and documentation_ for more information
+  about when the various methods are appropriate.  See also the :ref:`pandas interpolation docs<missing_data.interpolate:>`.
+
+  Interpolate now also accepts a ``limit`` keyword argument.
+  This works similar to ``fillna``'s limit:
+
+  .. ipython:: python
+
+    ser = Series([1, 3, np.nan, np.nan, np.nan, 11])
+    ser.interpolate(limit=2)
+
+.. _scipy: http://www.scipy.org
+.. _documentation: http://docs.scipy.org/doc/scipy/reference/interpolate.html#univariate-interpolation
+.. _guide: http://docs.scipy.org/doc/scipy/reference/tutorial/interpolate.html
+
+
 .. _whatsnew_0130.refactoring:
 
 Internal Refactoring

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2251,57 +2251,6 @@ class Series(generic.NDFrame):
         new_values = com.take_1d(values, locs)
         return self._constructor(new_values, index=where, name=self.name)
 
-    def interpolate(self, method='linear'):
-        """
-        Interpolate missing values (after the first valid value)
-
-        Parameters
-        ----------
-        method : {'linear', 'time', 'values'}
-            Interpolation method.
-            'time' interpolation works on daily and higher resolution
-            data to interpolate given length of interval
-            'values' using the actual index numeric values
-
-        Returns
-        -------
-        interpolated : Series
-        """
-        if method == 'time':
-            if not self.is_time_series:
-                raise Exception('time-weighted interpolation only works'
-                                'on TimeSeries')
-            method = 'values'
-            # inds = pa.array([d.toordinal() for d in self.index])
-
-        if method == 'values':
-            inds = self.index.values
-            # hack for DatetimeIndex, #1646
-            if issubclass(inds.dtype.type, np.datetime64):
-                inds = inds.view(pa.int64)
-
-            if inds.dtype == np.object_:
-                inds = lib.maybe_convert_objects(inds)
-        else:
-            inds = pa.arange(len(self))
-
-        values = self.values
-
-        invalid = isnull(values)
-        valid = -invalid
-
-        result = values.copy()
-        if valid.any():
-            firstIndex = valid.argmax()
-            valid = valid[firstIndex:]
-            invalid = invalid[firstIndex:]
-            inds = inds[firstIndex:]
-
-            result[firstIndex:][invalid] = np.interp(
-                inds[invalid], inds[valid], values[firstIndex:][valid])
-
-        return self._constructor(result, index=self.index, name=self.name)
-
     @property
     def weekday(self):
         return self._constructor([d.weekday() for d in self.index], index=self.index)


### PR DESCRIPTION
closes #4434
closes #1892

I've basically just hacked out the Series interpolate and stuffed it under generic under a big `if` statement.  Gonna make that much cleaner.  Moved the interpolation and fillna specific tests in `test_series.py` to `test_generic.py`.

API question for you all.  The interpolation procedures in Scipy take an array of x-values and an array of y-values that form the basis for the interpolation object.  The interpolation object can then be evaluated wherever, but it maps X -> Y; f(x-values) == y-values.  So we have 3 arrays to deal with:
1.  x-values
2.  y-values
3.  new values

Preferences for names?  The other issue is for defaults. Right now I'm thinking
1.  x-values: index if numeric.
2.  y-values: the Series.values if Series. Each numeric column of DataFrame if DataFrame?
3.  new values: Fill NaNs by default. Interpolate at `new values` if an array is given.
