### PR TITLE
ENH: evaluate datetime ops in python with eval

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -335,6 +335,9 @@ Experimental Features
 - A :meth:`~pandas.DataFrame.query` method has been added that allows
   you to select elements of a ``DataFrame`` using a natural query syntax nearly
   identical to Python syntax.
+- ``pd.eval`` and friends now evaluate operations involving ``datetime64``
+  objects in Python space because ``numexpr`` cannot handle ``NaT`` values
+  (:issue:`4897`).
 
 .. _release.bug_fixes-0.13.0:
 

--- a/pandas/computation/align.py
+++ b/pandas/computation/align.py
@@ -111,15 +111,19 @@ def _align_core(terms):
     typ = biggest._constructor
     axes = biggest.axes
     naxes = len(axes)
+    gt_than_one_axis = naxes > 1
 
     for value in (terms[i].value for i in term_index):
+        is_series = isinstance(value, pd.Series)
+        is_series_and_gt_one_axis = is_series and gt_than_one_axis
+
         for axis, items in enumerate(value.axes):
-            if isinstance(value, pd.Series) and naxes > 1:
+            if is_series_and_gt_one_axis:
                 ax, itm = naxes - 1, value.index
             else:
                 ax, itm = axis, items
-            # TODO: use is_ method when jtratner's PR is merged
-            if axes[ax] is not itm:
+
+            if not axes[ax].is_(itm):
                 axes[ax] = axes[ax].join(itm, how='outer')
 
     for i, ndim in compat.iteritems(ndims):

--- a/pandas/computation/align.py
+++ b/pandas/computation/align.py
@@ -112,13 +112,15 @@ def _align_core(terms):
     axes = biggest.axes
     naxes = len(axes)
 
-    for term in (terms[i] for i in term_index):
-        for axis, items in enumerate(term.value.axes):
-            if isinstance(term.value, pd.Series) and naxes > 1:
-                ax, itm = naxes - 1, term.value.index
+    for value in (terms[i].value for i in term_index):
+        for axis, items in enumerate(value.axes):
+            if isinstance(value, pd.Series) and naxes > 1:
+                ax, itm = naxes - 1, value.index
             else:
                 ax, itm = axis, items
-            axes[ax] = axes[ax].join(itm, how='outer')
+            # TODO: use is_ method when jtratner's PR is merged
+            if axes[ax] is not itm:
+                axes[ax] = axes[ax].join(itm, how='outer')
 
     for i, ndim in compat.iteritems(ndims):
         for axis, items in zip(range(ndim), axes):
@@ -136,7 +138,7 @@ def _align_core(terms):
                     warnings.warn("Alignment difference on axis {0} is larger"
                                   " than an order of magnitude on term {1!r}, "
                                   "by more than {2:.4g}; performance may suffer"
-                                  "".format(axis, term.name, ordm),
+                                  "".format(axis, terms[i].name, ordm),
                                   category=pd.io.common.PerformanceWarning)
 
                 if transpose:

--- a/pandas/computation/expr.py
+++ b/pandas/computation/expr.py
@@ -379,8 +379,6 @@ def add_ops(op_classes):
     return f
 
 
-_date_kinds = frozenset(['datetime64', 'timestamp', 'datetime'])
-
 @disallow(_unsupported_nodes)
 @add_ops(_op_classes)
 class BaseExprVisitor(ast.NodeVisitor):
@@ -496,7 +494,7 @@ class BaseExprVisitor(ast.NodeVisitor):
         res = op(lhs, rhs)
 
         if (res.op in _cmp_ops_syms and
-            lhs.kind in _date_kinds or rhs.kind in _date_kinds and
+            lhs.is_datetime or rhs.is_datetime and
             self.engine != 'pytables'):
             # all date ops must be done in python bc numexpr doesn't work well
             # with NaT

--- a/pandas/computation/ops.py
+++ b/pandas/computation/ops.py
@@ -5,6 +5,7 @@ import re
 import operator as op
 from functools import partial
 from itertools import product, islice, chain
+from datetime import datetime
 
 import numpy as np
 
@@ -161,21 +162,16 @@ class Term(StringMixin):
                                           self.type))
 
     @property
-    def kind(self):
-        t = self.type
+    def is_datetime(self):
         try:
-            res = t.__name__
+            t = self.type.type
         except AttributeError:
-            res = t.type.__name__
-        return res.lower()
+            t = self.type
+
+        return issubclass(t, (datetime, np.datetime64))
 
     @property
     def value(self):
-        kind = self.kind
-        if kind == 'timestamp':
-            return self._value.asm8
-        elif kind == 'datetime':
-            return np.datetime64(self._value)
         return self._value
 
     @value.setter
@@ -246,14 +242,13 @@ class Op(StringMixin):
         return all(operand.isscalar for operand in self.operands)
 
     @property
-    def kind(self):
-        t = self.return_type
-
+    def is_datetime(self):
         try:
-            res = t.__name__
+            t = self.return_type.type
         except AttributeError:
-            res = t.type.__name__
-        return res.lower()
+            t = self.return_type
+
+        return issubclass(t, (datetime, np.datetime64))
 
 
 def _in(x, y):
@@ -431,24 +426,20 @@ class BinOp(Op):
 
         lhs, rhs = self.lhs, self.rhs
 
-        if (is_term(lhs) and lhs.kind.startswith('datetime') and is_term(rhs)
-                and rhs.isscalar):
+        if is_term(lhs) and lhs.is_datetime and is_term(rhs) and rhs.isscalar:
             v = rhs.value
             if isinstance(v, (int, float)):
                 v = stringify(v)
-            v = _ensure_decoded(v)
-            v = pd.Timestamp(v)
+            v = pd.Timestamp(_ensure_decoded(v))
             if v.tz is not None:
                 v = v.tz_convert('UTC')
             self.rhs.update(v)
 
-        if (is_term(rhs) and rhs.kind.startswith('datetime') and
-                is_term(lhs) and lhs.isscalar):
+        if is_term(rhs) and rhs.is_datetime and is_term(lhs) and lhs.isscalar:
             v = lhs.value
             if isinstance(v, (int, float)):
                 v = stringify(v)
-            v = _ensure_decoded(v)
-            v = pd.Timestamp(v)
+            v = pd.Timestamp(_ensure_decoded(v))
             if v.tz is not None:
                 v = v.tz_convert('UTC')
             self.lhs.update(v)

--- a/pandas/computation/ops.py
+++ b/pandas/computation/ops.py
@@ -162,23 +162,20 @@ class Term(StringMixin):
 
     @property
     def kind(self):
+        t = self.type
         try:
-            return self.type.__name__
+            res = t.__name__
         except AttributeError:
-            return self.type.type.__name__
+            res = t.type.__name__
+        return res.lower()
 
     @property
     def value(self):
-        kind = self.kind.lower()
-        if kind == 'datetime64':
-            try:
-                return self._value.asi8
-            except AttributeError:
-                return self._value.view('i8')
+        kind = self.kind
+        if kind == 'timestamp':
+            return self._value.asm8
         elif kind == 'datetime':
-            return pd.Timestamp(self._value)
-        elif kind == 'timestamp':
-            return self._value.asm8.view('i8')
+            return np.datetime64(self._value)
         return self._value
 
     @value.setter
@@ -247,6 +244,16 @@ class Op(StringMixin):
     @property
     def isscalar(self):
         return all(operand.isscalar for operand in self.operands)
+
+    @property
+    def kind(self):
+        t = self.return_type
+
+        try:
+            res = t.__name__
+        except AttributeError:
+            res = t.type.__name__
+        return res.lower()
 
 
 def _in(x, y):

--- a/pandas/computation/tests/test_eval.py
+++ b/pandas/computation/tests/test_eval.py
@@ -1003,7 +1003,7 @@ class TestAlignment(object):
                 expected = ("Alignment difference on axis {0} is larger"
                             " than an order of magnitude on term {1!r}, "
                             "by more than {2:.4g}; performance may suffer"
-                            "".format(1, 's', np.log10(s.size - df.shape[1])))
+                            "".format(1, 'df', np.log10(s.size - df.shape[1])))
                 assert_equal(msg, expected)
 
     def test_performance_warning_for_poor_alignment(self):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1898,6 +1898,7 @@ class DataFrame(NDFrame):
         # index or columns
         axis_index = getattr(self, axis)
         d = dict()
+        prefix = axis[0]
 
         for i, name in enumerate(axis_index.names):
             if name is not None:
@@ -1906,15 +1907,19 @@ class DataFrame(NDFrame):
                 # prefix with 'i' or 'c' depending on the input axis
                 # e.g., you must do ilevel_0 for the 0th level of an unnamed
                 # multiiindex
-                level_string = '{prefix}level_{i}'.format(prefix=axis[0], i=i)
-                key = level_string
+                key = '{prefix}level_{i}'.format(prefix=prefix, i=i)
                 level = i
 
             d[key] = Series(axis_index.get_level_values(level).values,
-                            index=axis_index, name=level)
+                            index=axis_index, name=name)
 
         # put the index/columns itself in the dict
-        d[axis] = axis_index
+        if isinstance(axis_index, MultiIndex):
+            dindex = axis_index
+        else:
+            dindex = axis_index.to_series()
+
+        d[axis] = dindex
         return d
 
     def query(self, expr, **kwargs):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1910,8 +1910,10 @@ class DataFrame(NDFrame):
                 key = '{prefix}level_{i}'.format(prefix=prefix, i=i)
                 level = i
 
-            d[key] = Series(axis_index.get_level_values(level).values,
-                            index=axis_index, name=level)
+            level_values = axis_index.get_level_values(level)
+            s = level_values.to_series()
+            s.index = axis_index
+            d[key] = s
 
         # put the index/columns itself in the dict
         if isinstance(axis_index, MultiIndex):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1911,7 +1911,7 @@ class DataFrame(NDFrame):
                 level = i
 
             d[key] = Series(axis_index.get_level_values(level).values,
-                            index=axis_index, name=name)
+                            index=axis_index, name=level)
 
         # put the index/columns itself in the dict
         if isinstance(axis_index, MultiIndex):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -11429,8 +11429,7 @@ class TestDataFrameQueryWithMultiIndex(object):
 
     def check_query_multiindex_get_index_resolvers(self, parser, engine):
         df = mkdf(10, 3, r_idx_nlevels=2, r_idx_names=['spam', 'eggs'])
-        resolvers = df._get_index_resolvers('index')
-        resolvers.update(df._get_index_resolvers('columns'))
+        resolvers = df._get_resolvers()
 
         def to_series(mi, level):
             level_values = mi.get_level_values(level)
@@ -11452,6 +11451,28 @@ class TestDataFrameQueryWithMultiIndex(object):
                 tm.assert_series_equal(v, expected[k])
             else:
                 raise AssertionError("object must be a Series or Index")
+
+    def test_raise_on_panel_with_multiindex(self):
+        for parser, engine in product(PARSERS, ENGINES):
+            yield self.check_raise_on_panel_with_multiindex, parser, engine
+
+    def check_raise_on_panel_with_multiindex(self, parser, engine):
+        skip_if_no_ne()
+        p = tm.makePanel(7)
+        p.items = tm.makeCustomIndex(len(p.items), nlevels=2)
+        with tm.assertRaises(NotImplementedError):
+            pd.eval('p + 1', parser=parser, engine=engine)
+
+    def test_raise_on_panel4d_with_multiindex(self):
+        for parser, engine in product(PARSERS, ENGINES):
+            yield self.check_raise_on_panel4d_with_multiindex, parser, engine
+
+    def check_raise_on_panel4d_with_multiindex(self, parser, engine):
+        skip_if_no_ne()
+        p4d = tm.makePanel4D(7)
+        p4d.items = tm.makeCustomIndex(len(p4d.items), nlevels=2)
+        with tm.assertRaises(NotImplementedError):
+            pd.eval('p4d + 1', parser=parser, engine=engine)
 
 
 class TestDataFrameQueryNumExprPandas(unittest.TestCase):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -11498,6 +11498,19 @@ class TestDataFrameQueryNumExprPandas(unittest.TestCase):
         expec = df[(df.index.to_series() < '20130101') & ('20130101' < df.dates3)]
         assert_frame_equal(res, expec)
 
+    def test_date_query_with_non_date(self):
+        engine, parser = self.engine, self.parser
+
+        n = 10
+        df = DataFrame({'dates': date_range('1/1/2012', periods=n),
+             'nondate': np.arange(n)})
+
+        ops = '==', '!=', '<', '>', '<=', '>='
+
+        for op in ops:
+            with tm.assertRaises(TypeError):
+                df.query('dates %s nondate' % op, parser=parser, engine=engine)
+
     def test_query_scope(self):
         engine, parser = self.engine, self.parser
         from pandas.computation.common import NameResolutionError

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -11432,22 +11432,27 @@ class TestDataFrameQueryWithMultiIndex(object):
         resolvers = df._get_index_resolvers('index')
         resolvers.update(df._get_index_resolvers('columns'))
 
+        def to_series(mi, level):
+            level_values = mi.get_level_values(level)
+            s = level_values.to_series()
+            s.index = mi
+            return s
+
+        col_series = df.columns.to_series()
         expected = {'index': df.index,
-                    'columns': Series(df.columns, index=df.columns,
-                                      name=df.columns.name),
-                    'spam': Series(df.index.get_level_values('spam'),
-                                   name='spam', index=df.index),
-                    'eggs': Series(df.index.get_level_values('eggs'),
-                                   name='eggs', index=df.index),
-                    'C0': Series(df.columns, index=df.columns,
-                                 name=df.columns.name)}
+                    'columns': col_series,
+                    'spam': to_series(df.index, 'spam'),
+                    'eggs': to_series(df.index, 'eggs'),
+                    'C0': col_series}
         for k, v in resolvers.items():
             if isinstance(v, Index):
                 assert v.is_(expected[k])
             elif isinstance(v, Series):
+                print(k)
                 tm.assert_series_equal(v, expected[k])
             else:
                 raise AssertionError("object must be a Series or Index")
+
 
 class TestDataFrameQueryNumExprPandas(unittest.TestCase):
     @classmethod

--- a/vb_suite/binary_ops.py
+++ b/vb_suite/binary_ops.py
@@ -106,7 +106,7 @@ frame_multi_and_no_ne = \
 setup = common_setup + """
 N = 1000000
 halfway = N // 2 - 1
-s  = Series(date_range('20010101', periods=N, freq='D'))
+s = Series(date_range('20010101', periods=N, freq='D'))
 ts = s[halfway]
 """
 

--- a/vb_suite/binary_ops.py
+++ b/vb_suite/binary_ops.py
@@ -106,7 +106,7 @@ frame_multi_and_no_ne = \
 setup = common_setup + """
 N = 1000000
 halfway = N // 2 - 1
-s = Series(date_range('20010101', periods=N, freq='D'))
+s = Series(date_range('20010101', periods=N, freq='T'))
 ts = s[halfway]
 """
 

--- a/vb_suite/eval.py
+++ b/vb_suite/eval.py
@@ -47,12 +47,12 @@ eval_frame_add_python_one_thread = \
 eval_frame_mult_all_threads = \
     Benchmark("pd.eval('df * df2 * df3 * df4')", common_setup,
               name='eval_frame_mult_all_threads',
-              start_date=datetime(2012, 7, 21))
+              start_date=datetime(2013, 7, 21))
 
 eval_frame_mult_one_thread = \
     Benchmark("pd.eval('df * df2 * df3 * df4')", setup,
               name='eval_frame_mult_one_thread',
-              start_date=datetime(2012, 7, 26))
+              start_date=datetime(2013, 7, 26))
 
 eval_frame_mult_python = \
     Benchmark("pdl.eval('df * df2 * df3 * df4', engine='python')",
@@ -62,7 +62,7 @@ eval_frame_mult_python = \
 eval_frame_mult_python_one_thread = \
     Benchmark("pd.eval('df * df2 * df3 * df4', engine='python')", setup,
               name='eval_frame_mult_python_one_thread',
-              start_date=datetime(2012, 7, 26))
+              start_date=datetime(2013, 7, 26))
 
 #----------------------------------------------------------------------
 # multi and
@@ -71,12 +71,12 @@ eval_frame_and_all_threads = \
     Benchmark("pd.eval('(df > 0) & (df2 > 0) & (df3 > 0) & (df4 > 0)')",
               common_setup,
               name='eval_frame_and_all_threads',
-              start_date=datetime(2012, 7, 21))
+              start_date=datetime(2013, 7, 21))
 
 eval_frame_and_one_thread = \
     Benchmark("pd.eval('(df > 0) & (df2 > 0) & (df3 > 0) & (df4 > 0)')", setup,
               name='eval_frame_and_one_thread',
-              start_date=datetime(2012, 7, 26))
+              start_date=datetime(2013, 7, 26))
 
 setup = common_setup
 eval_frame_and_python = \
@@ -88,19 +88,19 @@ eval_frame_and_one_thread = \
     Benchmark("pd.eval('(df > 0) & (df2 > 0) & (df3 > 0) & (df4 > 0)', engine='python')",
               setup,
               name='eval_frame_and_python_one_thread',
-              start_date=datetime(2012, 7, 26))
+              start_date=datetime(2013, 7, 26))
 
 #--------------------------------------------------------------------
 # chained comp
 eval_frame_chained_cmp_all_threads = \
     Benchmark("pd.eval('df < df2 < df3 < df4')", common_setup,
               name='eval_frame_chained_cmp_all_threads',
-              start_date=datetime(2012, 7, 21))
+              start_date=datetime(2013, 7, 21))
 
 eval_frame_chained_cmp_one_thread = \
     Benchmark("pd.eval('df < df2 < df3 < df4')", setup,
               name='eval_frame_chained_cmp_one_thread',
-              start_date=datetime(2012, 7, 26))
+              start_date=datetime(2013, 7, 26))
 
 setup = common_setup
 eval_frame_chained_cmp_python = \
@@ -111,4 +111,31 @@ eval_frame_chained_cmp_python = \
 eval_frame_chained_cmp_one_thread = \
     Benchmark("pd.eval('df < df2 < df3 < df4', engine='python')", setup,
               name='eval_frame_chained_cmp_python_one_thread',
-              start_date=datetime(2012, 7, 26))
+              start_date=datetime(2013, 7, 26))
+
+
+common_setup = """from pandas_vb_common import *
+"""
+
+setup = common_setup + """
+N = 1000000
+halfway = N // 2 - 1
+index = date_range('20010101', periods=N, freq='T')
+s = Series(index)
+ts = s.iloc[halfway]
+"""
+
+series_setup = setup + """
+df = DataFrame({'dates': s.values})
+"""
+
+query_datetime_series = Benchmark("df.query('dates < ts')",
+                                  series_setup,
+                                  start_date=datetime(2013, 9, 27))
+
+index_setup = setup + """
+df = DataFrame({'a': np.random.randn(N)}, index=index)
+"""
+
+query_datetime_index = Benchmark("df.query('index < ts')",
+                                 index_setup, start_date=datetime(2013, 9, 27))


### PR DESCRIPTION
closes #4897

Also adds `DatetimeIndex` comparisons in query expressions and a corresponding vbench for a simple `Timestamp` vs either `Series` or `DatetimeIndex`.
