### PR TITLE
BUG: Fix bound checking for Timestamp() with dt64 #4065

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -555,7 +555,7 @@ Bug Fixes
     type of headers (:issue:`5048`).
   - Fixed a bug where ``DatetimeIndex`` joins with ``PeriodIndex`` caused a
     stack overflow (:issue:`3899`).
-
+  - Fix bound checking for Timestamp() with datetime64 input (:issue:`4065`)
 
 pandas 0.12.0
 -------------

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -348,6 +348,13 @@ def _pickle_array(arr):
 
 def _unpickle_array(bytes):
     arr = read_array(BytesIO(bytes))
+
+    # All datetimes should be stored as M8[ns].  When unpickling with
+    # numpy1.6, it will read these as M8[us].  So this ensures all
+    # datetime64 types are read as MS[ns]
+    if is_datetime64_dtype(arr):
+        arr = arr.view(_NS_DTYPE)
+
     return arr
 
 
@@ -1780,6 +1787,14 @@ def is_datetime64_dtype(arr_or_dtype):
         tipo = arr_or_dtype.dtype.type
     return issubclass(tipo, np.datetime64)
 
+def is_datetime64_ns_dtype(arr_or_dtype):
+    if isinstance(arr_or_dtype, np.dtype):
+        tipo = arr_or_dtype
+    elif isinstance(arr_or_dtype, type):
+        tipo = np.dtype(arr_or_dtype)
+    else:
+        tipo = arr_or_dtype.dtype
+    return tipo == _NS_DTYPE
 
 def is_timedelta64_dtype(arr_or_dtype):
     if isinstance(arr_or_dtype, np.dtype):

--- a/pandas/src/datetime.pxd
+++ b/pandas/src/datetime.pxd
@@ -85,6 +85,9 @@ cdef extern from "datetime/np_datetime.h":
         npy_int64 year
         npy_int32 month, day, hour, min, sec, us, ps, as
 
+    int cmp_pandas_datetimestruct(pandas_datetimestruct *a,
+                                  pandas_datetimestruct *b)
+
     int convert_pydatetime_to_datetimestruct(PyObject *obj,
                                              pandas_datetimestruct *out,
                                              PANDAS_DATETIMEUNIT *out_bestunit,

--- a/pandas/src/datetime/np_datetime.c
+++ b/pandas/src/datetime/np_datetime.c
@@ -274,6 +274,69 @@ set_datetimestruct_days(npy_int64 days, pandas_datetimestruct *dts)
 }
 
 /*
+ * Compares two pandas_datetimestruct objects chronologically
+ */
+int
+cmp_pandas_datetimestruct(pandas_datetimestruct *a, pandas_datetimestruct *b)
+{
+    if (a->year > b->year) {
+        return 1;
+    } else if (a->year < b->year) {
+        return -1;
+    }
+
+    if (a->month > b->month) {
+        return 1;
+    } else if (a->month < b->month) {
+        return -1;
+    }
+
+    if (a->day > b->day) {
+        return 1;
+    } else if (a->day < b->day) {
+        return -1;
+    }
+
+    if (a->hour > b->hour) {
+        return 1;
+    } else if (a->hour < b->hour) {
+        return -1;
+    }
+
+    if (a->min > b->min) {
+        return 1;
+    } else if (a->min < b->min) {
+        return -1;
+    }
+
+    if (a->sec > b->sec) {
+        return 1;
+    } else if (a->sec < b->sec) {
+        return -1;
+    }
+
+    if (a->us > b->us) {
+        return 1;
+    } else if (a->us < b->us) {
+        return -1;
+    }
+
+    if (a->ps > b->ps) {
+        return 1;
+    } else if (a->ps < b->ps) {
+        return -1;
+    }
+
+    if (a->as > b->as) {
+        return 1;
+    } else if (a->as < b->as) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
  *
  * Tests for and converts a Python datetime.datetime or datetime.date
  * object into a NumPy pandas_datetimestruct.

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -204,7 +204,7 @@ class DatetimeIndex(Int64Index):
                 data = _str_to_dt_array(data, offset, dayfirst=dayfirst,
                                         yearfirst=yearfirst)
             else:
-                data = tools.to_datetime(data)
+                data = tools.to_datetime(data, errors='raise')
                 data.offset = offset
                 if isinstance(data, DatetimeIndex):
                     if name is not None:
@@ -243,14 +243,14 @@ class DatetimeIndex(Int64Index):
                 subarr = data.view(_NS_DTYPE)
         else:
             try:
-                subarr = tools.to_datetime(data)
+                subarr = tools.to_datetime(data, box=False)
             except ValueError:
                 # tz aware
-                subarr = tools.to_datetime(data, utc=True)
+                subarr = tools.to_datetime(data, box=False, utc=True)
 
             if not np.issubdtype(subarr.dtype, np.datetime64):
-                raise TypeError('Unable to convert %s to datetime dtype'
-                                % str(data))
+                raise ValueError('Unable to convert %s to datetime dtype'
+                                 % str(data))
 
         if isinstance(subarr, DatetimeIndex):
             if tz is None:
@@ -934,7 +934,7 @@ class DatetimeIndex(Int64Index):
                                         'mixed-integer-float', 'mixed')):
             try:
                 other = DatetimeIndex(other)
-            except TypeError:
+            except (TypeError, ValueError):
                 pass
 
         this, other = self._maybe_utc_convert(other)
@@ -1051,7 +1051,7 @@ class DatetimeIndex(Int64Index):
         if not isinstance(other, DatetimeIndex):
             try:
                 other = DatetimeIndex(other)
-            except TypeError:
+            except (TypeError, ValueError):
                 pass
             result = Index.intersection(self, other)
             if isinstance(result, DatetimeIndex):

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1,5 +1,5 @@
 # pylint: disable-msg=E1101,W0612
-from datetime import datetime, time, timedelta
+from datetime import datetime, time, timedelta, date
 import sys
 import os
 import unittest
@@ -951,6 +951,81 @@ class TestTimeSeries(unittest.TestCase):
         result = DatetimeIndex(ints)
 
         self.assert_(rng.equals(result))
+
+    def test_to_datetime_dt64s(self):
+        in_bound_dts = [
+            np.datetime64('2000-01-01'),
+            np.datetime64('2000-01-02'),
+        ]
+
+        for dt in in_bound_dts:
+            self.assertEqual(
+                pd.to_datetime(dt),
+                Timestamp(dt)
+            )
+
+        oob_dts = [
+            np.datetime64('1000-01-01'),
+            np.datetime64('5000-01-02'),
+        ]
+
+        for dt in oob_dts:
+            self.assertRaises(ValueError, pd.to_datetime, dt, errors='raise')
+            self.assertRaises(ValueError, tslib.Timestamp, dt)
+            self.assert_(pd.to_datetime(dt, coerce=True) is NaT)
+
+    def test_to_datetime_array_of_dt64s(self):
+        dts = [
+            np.datetime64('2000-01-01'),
+            np.datetime64('2000-01-02'),
+        ]
+
+        # Assuming all datetimes are in bounds, to_datetime() returns
+        # an array that is equal to Timestamp() parsing
+        self.assert_(
+            np.array_equal(
+                pd.to_datetime(dts, box=False),
+                np.array([Timestamp(x).asm8 for x in dts])
+            )
+        )
+
+        # A list of datetimes where the last one is out of bounds
+        dts_with_oob = dts + [np.datetime64('9999-01-01')]
+
+        self.assertRaises(
+            ValueError,
+            pd.to_datetime,
+            dts_with_oob,
+            coerce=False,
+            errors='raise'
+        )
+
+        self.assert_(
+            np.array_equal(
+                pd.to_datetime(dts_with_oob, box=False, coerce=True),
+                np.array(
+                    [
+                        Timestamp(dts_with_oob[0]).asm8,
+                        Timestamp(dts_with_oob[1]).asm8,
+                        iNaT,
+                    ],
+                    dtype='M8'
+                )
+            )
+        )
+
+        # With coerce=False and errors='ignore', out of bounds datetime64s
+        # are converted to their .item(), which depending on the version of
+        # numpy is either a python datetime.datetime or datetime.date
+        self.assert_(
+            np.array_equal(
+                pd.to_datetime(dts_with_oob, box=False, coerce=False),
+                np.array(
+                    [dt.item() for dt in dts_with_oob],
+                    dtype='O'
+                )
+            )
+        )
 
     def test_index_to_datetime(self):
         idx = Index(['1/1/2000', '1/2/2000', '1/3/2000'])

--- a/pandas/tseries/tools.py
+++ b/pandas/tseries/tools.py
@@ -89,13 +89,12 @@ def to_datetime(arg, errors='ignore', dayfirst=False, utc=None, box=True,
         if isinstance(arg, (list,tuple)):
             arg = np.array(arg, dtype='O')
 
-        if com.is_datetime64_dtype(arg):
+        if com.is_datetime64_ns_dtype(arg):
             if box and not isinstance(arg, DatetimeIndex):
                 try:
                     return DatetimeIndex(arg, tz='utc' if utc else None)
-                except ValueError as e:
-                    values, tz = tslib.datetime_to_datetime64(arg)
-                    return DatetimeIndex._simple_new(values, None, tz=tz)
+                except ValueError:
+                    pass
 
             return arg
 


### PR DESCRIPTION
closes #4065

To fix the bug, this change adds bounds checking to
_get_datetime64_nanos() for numpy datetimes that aren't already in [ns]
units.

Additionally, it updates _check_dts_bounds() to do the bound check just
based off the pandas_datetimestruct, by comparing to the minimum and
maximum valid pandas_datetimestructs for datetime64[ns].  It is simpler
and more accurate than the previous system.
