### PR TITLE
BUG: Fix FrozenNDArray & FrozenList string methods

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -446,6 +446,7 @@ Bug Fixes
     the ``by`` argument was passed (:issue:`4112`, :issue:`4113`).
   - Fixed a bug in ``convert_objects`` for > 2 ndims (:issue:`4937`)
   - Fixed a bug in DataFrame/Panel cache insertion and subsequent indexing (:issue:`4939`)
+  - Fixed string methods for ``FrozenNDArray`` and ``FrozenList`` (:issue:`4929`)
 
 pandas 0.12.0
 -------------

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -122,9 +122,12 @@ class FrozenList(PandasObject, list):
 
     def __unicode__(self):
         from pandas.core.common import pprint_thing
+        return pprint_thing(self, quote_strings=True,
+                     escape_chars=('\t', '\r', '\n'))
+
+    def __repr__(self):
         return "%s(%s)" % (self.__class__.__name__,
-                           pprint_thing(self, quote_strings=True,
-                                        escape_chars=('\t', '\r', '\n')))
+                           str(self))
 
     __setitem__ = __setslice__ = __delitem__ = __delslice__ = _disabled
     pop = append = extend = remove = sort = insert = _disabled
@@ -154,3 +157,12 @@ class FrozenNDArray(PandasObject, np.ndarray):
         """returns *copy* of underlying array"""
         arr = self.view(np.ndarray).copy()
         return arr
+
+    def __unicode__(self):
+        """
+        Return a string representation for this object.
+
+        Invoked by unicode(df) in py2 only. Yields a Unicode String in both py2/py3.
+        """
+        prepr = com.pprint_thing(self, escape_chars=('\t', '\r', '\n'),quote_strings=True)
+        return '%s(%s, dtype=%s)' % (type(self).__name__, prepr, self.dtype)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -228,15 +228,6 @@ class Index(FrozenNDArray):
             new_index = new_index.astype(dtype)
         return new_index
 
-    def __unicode__(self):
-        """
-        Return a string representation for a particular Index
-
-        Invoked by unicode(df) in py2 only. Yields a Unicode String in both py2/py3.
-        """
-        prepr = com.pprint_thing(self, escape_chars=('\t', '\r', '\n'),quote_strings=True)
-        return '%s(%s, dtype=%s)' % (type(self).__name__, prepr, self.dtype)
-
     def to_series(self):
         """
         return a series with both index and values equal to the index keys

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -1,8 +1,28 @@
 import re
 import unittest
 import numpy as np
+import pandas.compat as compat
+from pandas.compat import u
 from pandas.core.base import FrozenList, FrozenNDArray
 from pandas.util.testing import assertRaisesRegexp, assert_isinstance
+
+
+class CheckStringMixin(object):
+    def test_string_methods_dont_fail(self):
+        repr(self.container)
+        str(self.container)
+        bytes(self.container)
+        if not compat.PY3:
+            unicode(self.container)
+
+    def test_tricky_container(self):
+        if not hasattr(self, 'unicode_container'):
+            raise nose.SkipTest('Need unicode_container to test with this')
+        repr(self.unicode_container)
+        str(self.unicode_container)
+        bytes(self.unicode_container)
+        if not compat.PY3:
+            unicode(self.unicode_container)
 
 
 class CheckImmutable(object):
@@ -43,8 +63,9 @@ class CheckImmutable(object):
         self.assertEqual(result, expected)
 
 
-class TestFrozenList(CheckImmutable, unittest.TestCase):
+class TestFrozenList(CheckImmutable, CheckStringMixin, unittest.TestCase):
     mutable_methods = ('extend', 'pop', 'remove', 'insert')
+    unicode_container = FrozenList([u("\u05d0"), u("\u05d1"), "c"])
 
     def setUp(self):
         self.lst = [1, 2, 3, 4, 5]
@@ -68,8 +89,9 @@ class TestFrozenList(CheckImmutable, unittest.TestCase):
         self.check_result(r, self.lst)
 
 
-class TestFrozenNDArray(CheckImmutable, unittest.TestCase):
+class TestFrozenNDArray(CheckImmutable, CheckStringMixin, unittest.TestCase):
     mutable_methods = ('put', 'itemset', 'fill')
+    unicode_container = FrozenNDArray([u("\u05d0"), u("\u05d1"), "c"])
 
     def setUp(self):
         self.lst = [3, 5, 7, -2]


### PR DESCRIPTION
Plus basic tests (i.e., "Hey! If you pass me unicode I don't fail - yay!")

Previously were showing bad object reprs, now do this:

```
In [4]: mi = MultiIndex.from_arrays([range(10), range(10)])

In [5]: mi
Out[5]:
MultiIndex
[(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9)]

In [6]: mi.levels
Out[6]: FrozenList([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]])

In [7]: mi.levels[0]
Out[7]: Int64Index([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=int64)

In [8]: mi.labels[0]
Out[8]: FrozenNDArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=int64)

In [9]: mi.labels[1]
Out[9]: FrozenNDArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=int64)

In [10]: mi = MultiIndex.from
MultiIndex.from_arrays  MultiIndex.from_tuples

In [10]: mi = MultiIndex.from_arrays([range(5), list('abcde')])

In [11]: mi.levels
Out[11]: FrozenList([[0, 1, 2, 3, 4], [u'a', u'b', u'c', u'd', u'e']])

In [12]: mi.labels[0]
Out[12]: FrozenNDArray([0, 1, 2, 3, 4], dtype=int64)

In [13]: mi.labels[1]
Out[13]: FrozenNDArray([0, 1, 2, 3, 4], dtype=int64)

In [14]: mi.levels[0]
Out[14]: Int64Index([0, 1, 2, 3, 4], dtype=int64)

In [15]: mi.levels[1]
Out[15]: Index([u'a', u'b', u'c', u'd', u'e'], dtype=object)
```
