### PR TITLE
DOC: add dynamically generated doc-strings for generic functions

### DIFF
--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -180,8 +180,13 @@ if PY3:
 
     def u(s):
         return s
+
     def u_safe(s):
         return s
+
+    def function_object(f):
+        return f
+
 else:
     string_types = basestring,
     integer_types = (int, long)
@@ -197,6 +202,9 @@ else:
             return unicode(s, "unicode_escape")
         except:
             return s
+
+    def function_object(f):
+        return f.im_func
 
 
 string_and_binary_types = string_types + (binary_type,)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4716,7 +4716,7 @@ class DataFrame(NDFrame):
 
 DataFrame._setup_axes(
     ['index', 'columns'], info_axis=1, stat_axis=0, axes_are_reversed=True)
-
+DataFrame._setup_generic_methods()
 
 _EMPTY_SERIES = Series([])
 

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -1016,7 +1016,7 @@ class Panel(NDFrame):
     def tshift(self, periods=1, freq=None, axis='major', **kwds):
         return super(Panel, self).tshift(periods, freq, axis, **kwds)
 
-    def truncate(self, before=None, after=None, axis='major'):
+    def truncate(self, before=None, after=None, axis='major', copy=False):
         """Function truncates a sorted Panel before and/or after some
         particular values on the requested axis
 
@@ -1370,6 +1370,7 @@ Panel._setup_axes(axes=['items', 'major_axis', 'minor_axis'],
                   slicers={'major_axis': 'index',
                            'minor_axis': 'columns'})
 Panel._add_aggregate_operations()
+Panel._setup_generic_methods()
 
 WidePanel = Panel
 LongPanel = DataFrame

--- a/pandas/core/panelnd.py
+++ b/pandas/core/panelnd.py
@@ -108,5 +108,6 @@ def create_nd_panel_factory(klass_name, orders, slices, slicer, aliases=None, st
 
     # add the aggregate operations
     klass._add_aggregate_operations()
+    klass._setup_generic_methods(allow_matching=True)
 
     return klass

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3124,6 +3124,7 @@ class Series(generic.NDFrame):
         return self._constructor(new_values, index=new_index, name=self.name)
 
 Series._setup_axes(['index'], info_axis=0)
+Series._setup_generic_methods()
 _INDEX_TYPES = ndarray, Index, list, tuple
 
 # reinstall the SeriesIndexer

--- a/pandas/util/decorators.py
+++ b/pandas/util/decorators.py
@@ -3,7 +3,6 @@ from pandas.lib import cache_readonly
 import sys
 import warnings
 
-
 def deprecate(name, alternative, alt_name=None):
     alt_name = alt_name or alternative.__name__
 
@@ -105,6 +104,24 @@ class Appender(object):
         func.__doc__ = ''.join(docitems)
         return func
 
+
+class Generic(object):
+    """
+    A function decorator that will hold specific functions for the named classes
+    of the target function.
+    """
+    functions = {}
+
+    def __init__(self, subs=None):
+        if subs is None:
+            subs = dict()
+        self.subs = subs
+        self.func = None
+
+    def __call__(self, func):
+        self.func = func
+        self.functions[func.__name__] = self
+        return func
 
 def indent(text, indents=1):
     if not text or not isinstance(text, str):


### PR DESCRIPTION
closes #4717

```
In [2]: pd.DataFrame.reindex?
Type:       instancemethod
String Form:<unbound method DataFrame.reindex>
File:       /mnt/home/jreback/pandas/pandas/core/generic.py
Definition: pd.DataFrame.reindex(self, *args, **kwargs)
Docstring:
Conform DataFrame to new index with optional filling logic, placing
NA/NaN in locations having no value in the previous index. A new object
is produced unless the new index is equivalent to the current one and
copy=False

Parameters
----------
index : array-like, optional
    New labels / index to conform to. Preferably an Index object to
    avoid duplicating data
columns : array-like, optional
    New labels / index to conform to. Preferably an Index object to
    avoid duplicating data
method : {'backfill', 'bfill', 'pad', 'ffill', None}, default None
    Method to use for filling holes in reindexed DataFrame
    pad / ffill: propagate last valid observation forward to next valid
    backfill / bfill: use NEXT valid observation to fill gap
copy : boolean, default True
    Return a new object, even if the passed indexes are the same
level : int or name
    Broadcast across a level, matching Index values on the
    passed MultiIndex level
fill_value : scalar, default np.NaN
    Value to use for missing values. Defaults to NaN, but can be any
    "compatible" value
limit : int, default None
    Maximum size gap to forward or backward fill
takeable : boolean, default False
    treat the passed as positional values

Examples
--------
>>> df.reindex(index=[date1, date2, date3], columns=['A', 'B', 'C'])

Returns
-------
reindexed : DataFrame
```
