### PR TITLE
BUG: Conflict between thousands sep and date parser.

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -447,6 +447,7 @@ Bug Fixes
   - Fixed a bug in ``convert_objects`` for > 2 ndims (:issue:`4937`)
   - Fixed a bug in DataFrame/Panel cache insertion and subsequent indexing (:issue:`4939`)
   - Fixed string methods for ``FrozenNDArray`` and ``FrozenList`` (:issue:`4929`)
+  - Fixed conflict between thousands separator and date parser in csv_parser (:issue:`4678`)
 
 pandas 0.12.0
 -------------

--- a/pandas/io/date_converters.py
+++ b/pandas/io/date_converters.py
@@ -26,7 +26,7 @@ def parse_all_fields(year_col, month_col, day_col, hour_col, minute_col,
     minute_col = _maybe_cast(minute_col)
     second_col = _maybe_cast(second_col)
     return lib.try_parse_datetime_components(year_col, month_col, day_col,
-                                             hour_col, minute_col, second_col)
+                    hour_col, minute_col, second_col)
 
 
 def generic_parser(parse_func, *cols):

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1020,6 +1020,14 @@ class CParserWrapper(ParserBase):
                 else:
                     _set(val)
 
+        elif isinstance(self.parse_dates, dict):
+            for val in self.parse_dates.values():
+                if isinstance(val, list):
+                    for k in val:
+                        _set(k)
+                else:
+                    _set(val)
+
     def set_error_bad_lines(self, status):
         self._reader.set_error_bad_lines(int(status))
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1277,6 +1277,7 @@ class PythonParser(ParserBase):
             self._make_reader(f)
         else:
             self.data = f
+
         self.columns = self._infer_columns()
 
         # we are processing a multi index column
@@ -1299,6 +1300,38 @@ class PythonParser(ParserBase):
             if self.index_names is None:
                 self.index_names = index_names
         self._first_chunk = True
+
+        if self.parse_dates:
+            self._no_thousands_columns = self._set_no_thousands_columns()
+        else:
+            self._no_thousands_columns = None
+
+    def _set_no_thousands_columns(self):
+        # Create a set of column ids that are not to be stripped of thousands operators.
+        noconvert_columns = set()
+
+        def _set(x):
+            if com.is_integer(x):
+                noconvert_columns.add(x)
+            else:
+                noconvert_columns.add(self.columns.index(x))
+
+        if isinstance(self.parse_dates, list):
+            for val in self.parse_dates:
+                if isinstance(val, list):
+                    for k in val:
+                        _set(k)
+                else:
+                    _set(val)
+
+        elif isinstance(self.parse_dates, dict):
+            for val in self.parse_dates.values():
+                if isinstance(val, list):
+                    for k in val:
+                        _set(k)
+                else:
+                    _set(val)
+        return noconvert_columns
 
     def _make_reader(self, f):
         sep = self.delimiter
@@ -1508,7 +1541,6 @@ class PythonParser(ParserBase):
             line = next(self.data)
 
         line = self._check_comments([line])[0]
-        line = self._check_thousands([line])[0]
 
         self.pos += 1
         self.buf.append(line)
@@ -1540,9 +1572,10 @@ class PythonParser(ParserBase):
         ret = []
         for l in lines:
             rl = []
-            for x in l:
+            for i, x in enumerate(l):
                 if (not isinstance(x, compat.string_types) or
                     self.thousands not in x or
+                    (self._no_thousands_columns and i in self._no_thousands_columns) or
                         nonnum.search(x.strip())):
                     rl.append(x)
                 else:
@@ -1616,7 +1649,6 @@ class PythonParser(ParserBase):
             raise AssertionError()
 
         if col_len != zip_len and self.index_col is not False:
-            row_num = -1
             i = 0
             for (i, l) in enumerate(content):
                 if len(l) != col_len:

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -1952,9 +1952,6 @@ c   1   2   3   4
         df = self.read_table(StringIO(data), sep='|', thousands=',')
         tm.assert_frame_equal(df, expected)
 
-    def test_separator_date_conflict(self):
-        raise nose.SkipTest("Not supported in Python parser.")
-
     def test_comment_fwf(self):
         data = """
   1   2.   4  #hello world

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -233,6 +233,18 @@ index2,b,d,f
         df = self.read_table(StringIO(data_with_odd_sep), sep='|', thousands='.', decimal=',')
         tm.assert_frame_equal(df, expected)
 
+    def test_separator_date_conflict(self):
+        # Regression test for issue #4678: make sure thousands separator and
+        # date parsing do not conflict.
+        data = '06-02-2013;13:00;1-000.215'
+        expected = DataFrame(
+            [[datetime(2013, 6, 2, 13, 0, 0), 1000.215]],
+            columns=['Date', 2]
+        )
+
+        df = self.read_csv(StringIO(data), sep=';', thousands='-', parse_dates={'Date': [0, 1]}, header=None)
+        tm.assert_frame_equal(df, expected)
+
     def test_squeeze(self):
         data = """\
 a,1
@@ -1939,6 +1951,9 @@ c   1   2   3   4
 
         df = self.read_table(StringIO(data), sep='|', thousands=',')
         tm.assert_frame_equal(df, expected)
+
+    def test_separator_date_conflict(self):
+        raise nose.SkipTest("Not supported in Python parser.")
 
     def test_comment_fwf(self):
         data = """

--- a/pandas/src/inference.pyx
+++ b/pandas/src/inference.pyx
@@ -708,20 +708,22 @@ def try_parse_datetime_components(ndarray[object] years,
         Py_ssize_t i, n
         ndarray[object] result
         int secs
+        double float_secs
         double micros
 
     from datetime import datetime
 
     n = len(years)
-    if (len(months) != n and len(days) != n and len(hours) != n and
-        len(minutes) != n and len(seconds) != n):
+    if (len(months) != n or len(days) != n or len(hours) != n or
+        len(minutes) != n or len(seconds) != n):
         raise ValueError('Length of all datetime components must be equal')
     result = np.empty(n, dtype='O')
 
     for i from 0 <= i < n:
-        secs = int(seconds[i])
+        float_secs = float(seconds[i])
+        secs = int(float_secs)
 
-        micros = seconds[i] - secs
+        micros = float_secs - secs
         if micros > 0:
             micros = micros * 1000000
 


### PR DESCRIPTION
closes #4678 
closes #4322 

I've fixed the C parser portion. The issue there was that it did not handle the case where parse_dates is a dict.

Python parser fix yet to come. That test still fails.

Example:
    s = '06-02-2013;13:00;1-000,215;0,215;0,185;0,205;0,00'
    d = pd.read_csv(StringIO(s), header=None, parse_dates={'Date': [0, 1]}, thousands='-', sep=';', decimal=',')

Then d should have a column 'Date' with value "2013-06-02 13:00:00"
