### PR TITLE
BUG: pd.isnull with tuple argumnet should return same results as list (#4872)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -215,6 +215,7 @@ API Changes
   - moved timedeltas support to pandas.tseries.timedeltas.py; add timedeltas string parsing,
     add top-level ``to_timedelta`` function
   - ``NDFrame`` now is compatible with Python's toplevel ``abs()`` function (:issue:`4821`).
+  - `pd.isnull` now treats tuple argumnent the same way as list (:issue:`4872`).
 
 Internal Refactoring
 ~~~~~~~~~~~~~~~~~~~~

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -92,8 +92,11 @@ def isnull(obj):
 
 
 def _isnull_new(obj):
-    if lib.isscalar(obj):
+    is_tuple = isinstance(obj, tuple)
+    if not is_tuple and lib.isscalar(obj):
         return lib.checknull(obj)
+    elif is_tuple:
+        return _isnull_ndarraylike(np.asarray(obj))
 
     if isinstance(obj, (ABCSeries, np.ndarray)):
         return _isnull_ndarraylike(obj)
@@ -117,8 +120,11 @@ def _isnull_old(obj):
     -------
     boolean ndarray or boolean
     '''
-    if lib.isscalar(obj):
+    is_tuple = isinstance(obj, tuple)
+    if not is_tuple and lib.isscalar(obj):
         return lib.checknull_old(obj)
+    elif is_tuple:
+        return _isnull_ndarraylike_old(np.asarray(obj))
 
     if isinstance(obj, (ABCSeries, np.ndarray)):
         return _isnull_ndarraylike_old(obj)

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -89,6 +89,27 @@ def test_isnull():
     tm.assert_frame_equal(result, expected)
 
 
+def test_isnull_tuples():
+    result = isnull((1, 2))
+    exp = np.array([False, False])
+    assert(np.array_equal(result, exp))
+
+    result = isnull([(False,)])
+    exp = np.array([[False]])
+    assert(np.array_equal(result, exp))
+
+    result = isnull([(1,), (2,)])
+    exp = np.array([[False], [False]])
+    assert(np.array_equal(result, exp))
+
+    # list of strings / unicode
+    result = isnull(('foo', 'bar'))
+    assert(not result.any())
+
+    result = isnull((u('foo'), u('bar')))
+    assert(not result.any())
+
+
 def test_isnull_lists():
     result = isnull([[False]])
     exp = np.array([[False]])


### PR DESCRIPTION
Fix for issue #4872. Now tuple argument for pd.isnull behaves the same way as list pd.isnull(list(tuple_argument)).
