### PR TITLE
BUG: Make sure series-series boolean comparions are label based (GH4947)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -374,6 +374,8 @@ Bug Fixes
     - appending a 0-len table will work correctly (:issue:`4273`)
     - ``to_hdf`` was raising when passing both arguments ``append`` and ``table`` (:issue:`4584`)
     - reading from a store with duplicate columns across dtypes would raise (:issue:`4767`)
+    - Fixed a bug where ``ValueError`` wasn't correctly raised when column names
+      weren't strings (:issue:`4956`)
   - Fixed bug in tslib.tz_convert(vals, tz1, tz2): it could raise IndexError exception while
     trying to access trans[pos + 1] (:issue:`4496`)
   - The ``by`` argument now works correctly with the ``layout`` argument
@@ -500,8 +502,6 @@ Bug Fixes
   - Fixed a bug with setting invalid or out-of-range values in indexing
     enlargement scenarios (:issue:`4940`)
   - Tests for fillna on empty Series (:issue:`4346`), thanks @immerrr
-  - Fixed a bug where ``ValueError`` wasn't correctly raised when column names
-    weren't strings (:issue:`4956`)
   - Fixed ``copy()`` to shallow copy axes/indices as well and thereby keep
     separate metadata. (:issue:`4202`, :issue:`4830`)
   - Fixed skiprows option in Python parser for read_csv (:issue:`4382`)
@@ -521,6 +521,7 @@ Bug Fixes
   - Fix a bug where reshaping a ``Series`` to its own shape raised ``TypeError`` (:issue:`4554`)
     and other reshaping issues.
   - Bug in setting with ``ix/loc`` and a mixed int/string index (:issue:`4544`)
+  - Make sure series-series boolean comparions are label based (:issue:`4947`)
 
 pandas 0.12.0
 -------------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -21,7 +21,8 @@ from pandas.core.common import (isnull, notnull, _is_bool_indexer,
                                 _values_from_object,
                                 _possibly_cast_to_datetime, _possibly_castable,
                                 _possibly_convert_platform,
-                                ABCSparseArray, _maybe_match_name)
+                                ABCSparseArray, _maybe_match_name, _ensure_object)
+
 from pandas.core.index import (Index, MultiIndex, InvalidIndexError,
                                _ensure_index, _handle_legacy_indexes)
 from pandas.core.indexing import (
@@ -1170,7 +1171,7 @@ class Series(generic.NDFrame):
         -------
         duplicated : Series
         """
-        keys = com._ensure_object(self.values)
+        keys = _ensure_object(self.values)
         duplicated = lib.duplicated(keys, take_last=take_last)
         return self._constructor(duplicated, index=self.index, name=self.name)
 

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -672,6 +672,9 @@ def scalar_binop(ndarray[object] values, object val, object op):
         object x
 
     result = np.empty(n, dtype=object)
+    if util._checknull(val):
+        result.fill(val)
+        return result
 
     for i in range(n):
         x = values[i]

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4526,7 +4526,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         # GH4947
         # bool comparisons should return bool
         result = d['a'] | d['b']
-        expected = Series([True, True])
+        expected = Series([False, True])
         assert_series_equal(result, expected)
 
         # GH4604, automatic casting here

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4523,8 +4523,10 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
     def test_logical_with_nas(self):
         d = DataFrame({'a': [np.nan, False], 'b': [True, True]})
 
+        # GH4947
+        # bool comparisons should return bool
         result = d['a'] | d['b']
-        expected = Series([np.nan, True])
+        expected = Series([True, True])
         assert_series_equal(result, expected)
 
         # GH4604, automatic casting here
@@ -4533,10 +4535,6 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         assert_series_equal(result, expected)
 
         result = d['a'].fillna(False,downcast=False) | d['b']
-        expected = Series([True, True],dtype=object)
-        assert_series_equal(result, expected)
-
-        result = (d['a'].fillna(False,downcast=False) | d['b']).convert_objects()
         expected = Series([True, True])
         assert_series_equal(result, expected)
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -2757,6 +2757,64 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         b = Series([2, 3, 4])
         self.assertRaises(ValueError, a.__eq__, b)
 
+    def test_comparison_label_based(self):
+
+        # GH 4947
+        # comparisons should be label based
+
+        a = Series([True, False, True], list('bca'))
+        b = Series([False, True, False], list('abc'))
+
+        expected = Series([True, False, False], list('bca'))
+        result = a & b
+        assert_series_equal(result,expected)
+
+        expected = Series([True, False, True], list('bca'))
+        result = a | b
+        assert_series_equal(result,expected)
+
+        expected = Series([False, False, True], list('bca'))
+        result = a ^ b
+        assert_series_equal(result,expected)
+
+        # rhs is bigger
+        a = Series([True, False, True], list('bca'))
+        b = Series([False, True, False, True], list('abcd'))
+
+        expected = Series([True, False, False], list('bca'))
+        result = a & b
+        assert_series_equal(result,expected)
+
+        expected = Series([True, False, True], list('bca'))
+        result = a | b
+        assert_series_equal(result,expected)
+
+        # filling
+
+        # vs empty
+        result = a & Series([])
+        expected = Series([False, False, False], list('bca'))
+        assert_series_equal(result,expected)
+
+        result = a | Series([])
+        expected = Series([True, True, True], list('bca'))
+        assert_series_equal(result,expected)
+
+        # vs non-matching
+        result = a & Series([1],['z'])
+        expected = Series([False, False, False], list('bca'))
+        assert_series_equal(result,expected)
+
+        result = a | Series([1],['z'])
+        expected = Series([True, True, True], list('bca'))
+        assert_series_equal(result,expected)
+
+        # identity
+        # we would like s[s|e] == s to hold for any e, whether empty or not
+        for e in [Series([]),Series([1],['z']),Series(['z']),Series(np.nan,b.index),Series(np.nan,a.index)]:
+            result = a[a | e]
+            assert_series_equal(result,a)
+
     def test_between(self):
         s = Series(bdate_range('1/1/2000', periods=20).asobject)
         s[::2] = np.nan


### PR DESCRIPTION
closes #4947

You ask for a boolean comparsion, that is what you get

```
In [1]: a = Series([True, False, True], list('bca'))

In [2]: b = Series([False, True, False], list('abc'))

In [19]: a
Out[19]: 
b     True
c    False
a     True
dtype: bool

In [20]: b
Out[20]: 
a    False
b     True
c    False
dtype: bool

In [21]: a & b
Out[21]: 
b     True
c    False
a    False
dtype: bool

In [22]: a | b
Out[22]: 
b     True
c    False
a     True
dtype: bool

In [23]: a ^ b
Out[23]: 
b    False
c    False
a     True
dtype: bool

In [24]: a & Series([])
Out[24]: 
b    False
c    False
a    False
dtype: bool

In [25]: a | Series([])
Out[25]: 
b     True
c    False
a     True
dtype: bool
```

these ok?

```
In [9]: Series([np.nan,np.nan])&Series([np.nan,np.nan])
Out[9]: 
0    False
1    False
dtype: bool

In [10]: Series([np.nan,np.nan])|Series([np.nan,np.nan])
Out[10]: 
0    False
1    False
dtype: bool
```

scalars

```

In [30]: a | True
Out[30]: 
b    True
c    True
a    True
dtype: bool

In [31]: a | False
Out[31]: 
b     True
c    False
a     True
dtype: bool

In [32]: a & True
Out[32]: 
b     True
c    False
a     True
dtype: bool

In [33]: a & False
Out[33]: 
b    False
c    False
a    False
dtype: bool
```

Invalid scalars

```
In [28]: a | 'foo'
TypeError: cannot compare a dtyped [bool] array with a scalar of type [bool]

In [29]: a | np.nan
TypeError: cannot compare a dtyped [bool] array with a scalar of type [float]
```
