### PR TITLE
BUG: Fixed _format_labels in tile.py for np.inf.

### DIFF
--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -505,6 +505,12 @@ normally distributed data into equal-size quartiles like so:
    factor
    value_counts(factor)
 
+We can also pass infinite values to define the bins:
+.. ipython:: python
+
+   arr = np.random.randn(20)
+   factor = cut(arr, [-np.inf, 0, np.inf])
+   factor
 
 .. _basics.apply:
 

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -462,6 +462,8 @@ Bug Fixes
   - Fixed ``copy()`` to shallow copy axes/indices as well and thereby keep
     separate metadata. (:issue:`4202`, :issue:`4830`)
   - Fixed skiprows option in Python parser for read_csv (:issue:`4382`)
+  - Fixed bug preventing ``cut`` from working with ``np.inf`` levels without
+    explicitly passing labels (:issue:`3415`)
 
 pandas 0.12.0
 -------------

--- a/pandas/tools/tests/test_tile.py
+++ b/pandas/tools/tests/test_tile.py
@@ -114,6 +114,22 @@ class TestCut(unittest.TestCase):
         ex_result = np.where(com.isnull(arr), np.nan, result)
         tm.assert_almost_equal(result, ex_result)
 
+    def test_inf_handling(self):
+        data = np.arange(6)
+        data_ser = Series(data)
+
+        result = cut(data, [-np.inf, 2, 4, np.inf])
+        result_ser = cut(data_ser, [-np.inf, 2, 4, np.inf])
+        
+        ex_levels = ['(-inf, 2]', '(2, 4]', '(4, inf]']
+        
+        np.testing.assert_array_equal(result.levels, ex_levels)
+        np.testing.assert_array_equal(result_ser.levels, ex_levels)
+        self.assertEquals(result[5], '(4, inf]')
+        self.assertEquals(result[0], '(-inf, 2]')
+        self.assertEquals(result_ser[5], '(4, inf]')
+        self.assertEquals(result_ser[0], '(-inf, 2]')
+
     def test_qcut(self):
         arr = np.random.randn(1000)
 

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -245,7 +245,7 @@ def _format_label(x, precision=3):
                 else:  # pragma: no cover
                     return sgn + '.'.join(('%d' % whole, val))
         else:
-            return sgn + '%d' % whole
+            return sgn + '%0.f' % whole
     else:
         return str(x)
 


### PR DESCRIPTION
Fixes issue https://github.com/pydata/pandas/issues/3415.
