### PR TITLE
BUG: fix incorrect TypeError raise

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -453,6 +453,8 @@ Bug Fixes
   - Fixed a bug with setting invalid or out-of-range values in indexing
     enlargement scenarios (:issue:`4940`)
   - Tests for fillna on empty Series (:issue:`4346`), thanks @immerrr
+  - Fixed a bug where ``ValueError`` wasn't correctly raised when column names
+    weren't strings (:issue:`4956`)
 
 pandas 0.12.0
 -------------

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3033,7 +3033,9 @@ class Table(Fixed):
                     new_blocks.append(b)
                 except:
                     raise ValueError(
-                        "cannot match existing table structure for [%s] on appending data" % ','.join(items))
+                        "cannot match existing table structure for [%s] on "
+                        "appending data" % ','.join(com.pprint_thing(item) for
+                                                    item in items))
             blocks = new_blocks
 
         # add my values

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -3696,6 +3696,21 @@ class TestHDFStore(unittest.TestCase):
 
     #    self.assertRaises(Exception, store.put, 'foo', df, format='table')
 
+    def test_append_with_diff_col_name_types_raises_value_error(self):
+        df = DataFrame(np.random.randn(10, 1))
+        df2 = DataFrame({'a': np.random.randn(10)})
+        df3 = DataFrame({(1, 2): np.random.randn(10)})
+        df4 = DataFrame({('1', 2): np.random.randn(10)})
+        df5 = DataFrame({('1', 2, object): np.random.randn(10)})
+
+        with ensure_clean('__%s__.h5' % tm.rands(20)) as store:
+            name = 'df_%s' % tm.rands(10)
+            store.append(name, df)
+
+            for d in (df2, df3, df4, df5):
+                with tm.assertRaises(ValueError):
+                    store.append(name, d)
+
 
 def _test_sort(obj):
     if isinstance(obj, DataFrame):


### PR DESCRIPTION
TypeError was being raised when a ValueError was raised because the 
ValueError's message wasn't being converted to a string.

closes #4956
