### PR TITLE
CLN: change print to print() in docs

### DIFF
--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -860,7 +860,7 @@ Thus, for example:
 .. ipython::
 
    In [0]: for col in df:
-      ...:     print col
+      ...:     print(col)
       ...:
 
 iteritems
@@ -878,8 +878,8 @@ For example:
 .. ipython::
 
    In [0]: for item, frame in wp.iteritems():
-      ...:     print item
-      ...:     print frame
+      ...:     print(item)
+      ...:     print(frame)
       ...:
 
 
@@ -895,7 +895,7 @@ containing the data in each row:
 .. ipython::
 
    In [0]: for row_index, row in df2.iterrows():
-      ...:     print '%s\n%s' % (row_index, row)
+      ...:     print('%s\n%s' % (row_index, row))
       ...:
 
 For instance, a contrived way to transpose the dataframe would be:
@@ -903,11 +903,11 @@ For instance, a contrived way to transpose the dataframe would be:
 .. ipython:: python
 
    df2 = DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
-   print df2
-   print df2.T
+   print(df2)
+   print(df2.T)
 
    df2_t = DataFrame(dict((idx,values) for idx, values in df2.iterrows()))
-   print df2_t
+   print(df2_t)
 
 .. note::
 
@@ -918,8 +918,8 @@ For instance, a contrived way to transpose the dataframe would be:
 
       df_iter = DataFrame([[1, 1.0]], columns=['x', 'y'])
       row = next(df_iter.iterrows())[1]
-      print row['x'].dtype
-      print df_iter['x'].dtype
+      print(row['x'].dtype)
+      print(df_iter['x'].dtype)
 
 itertuples
 ~~~~~~~~~~
@@ -932,7 +932,8 @@ For instance,
 
 .. ipython:: python
 
-   for r in df2.itertuples(): print r
+   for r in df2.itertuples():
+       print(r)
 
 .. _basics.string_methods:
 

--- a/doc/source/dsintro.rst
+++ b/doc/source/dsintro.rst
@@ -586,7 +586,7 @@ R package):
 .. ipython:: python
 
    baseball = read_csv('data/baseball.csv')
-   print baseball
+   print(baseball)
 
 .. ipython:: python
    :suppress:
@@ -599,7 +599,7 @@ DataFrame in tabular form, though it won't always fit the console width:
 
 .. ipython:: python
 
-   print baseball.iloc[-20:, :12].to_string()
+   print(baseball.iloc[-20:, :12].to_string())
 
 New since 0.10.0, wide DataFrames will now be printed across multiple rows by
 default:

--- a/doc/source/gotchas.rst
+++ b/doc/source/gotchas.rst
@@ -372,7 +372,7 @@ of the new set of columns rather than the original ones:
 
 .. ipython:: python
 
-   print open('tmp.csv').read()
+   print(open('tmp.csv').read())
 
    date_spec = {'nominal': [1, 2], 'actual': [1, 3]}
    df = read_csv('tmp.csv', header=None,

--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -282,8 +282,8 @@ natural and functions similarly to ``itertools.groupby``:
    In [4]: grouped = df.groupby('A')
 
    In [5]: for name, group in grouped:
-      ...:        print name
-      ...:        print group
+      ...:        print(name)
+      ...:        print(group)
       ...:
 
 In the case of grouping by multiple keys, the group name will be a tuple:
@@ -291,8 +291,8 @@ In the case of grouping by multiple keys, the group name will be a tuple:
 .. ipython::
 
    In [5]: for name, group in df.groupby(['A', 'B']):
-      ...:        print name
-      ...:        print group
+      ...:        print(name)
+      ...:        print(group)
       ...:
 
 It's standard Python-fu but remember you can unpack the tuple in the for loop

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -1149,7 +1149,7 @@ and stop are **inclusive** in the label-based case:
 .. ipython:: python
 
    date1, date2 = dates[[2, 4]]
-   print date1, date2
+   print(date1, date2)
    df.ix[date1:date2]
    df['A'].ix[date1:date2]
 
@@ -1211,10 +1211,10 @@ scalar values, though setting arbitrary vectors is not yet supported:
 
    df2 = df[:4]
    df2['foo'] = 'bar'
-   print df2
+   print(df2)
    df2.ix[2] = np.nan
-   print df2
-   print df2.dtypes
+   print(df2)
+   print(df2.dtypes)
 
 .. _indexing.view_versus_copy:
 
@@ -1639,13 +1639,13 @@ instance:
    midx = MultiIndex(levels=[['zero', 'one'], ['x','y']],
                      labels=[[1,1,0,0],[1,0,1,0]])
    df = DataFrame(randn(4,2), index=midx)
-   print df
+   print(df)
    df2 = df.mean(level=0)
-   print df2
-   print df2.reindex(df.index, level=0)
+   print(df2)
+   print(df2.reindex(df.index, level=0))
    df_aligned, df2_aligned = df.align(df2, level=0)
-   print df_aligned
-   print df2_aligned
+   print(df_aligned)
+   print(df2_aligned)
 
 
 The need for sortedness with :class:`~pandas.MultiIndex`

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -167,7 +167,7 @@ Consider a typical CSV file containing, in this case, some time series data:
 
 .. ipython:: python
 
-   print open('foo.csv').read()
+   print(open('foo.csv').read())
 
 The default for `read_csv` is to create a DataFrame with simple numbered rows:
 
@@ -209,7 +209,7 @@ Suppose you had data with unenclosed quotes:
 
 .. ipython:: python
 
-   print data
+   print(data)
 
 By default, ``read_csv`` uses the Excel dialect and treats the double quote as
 the quote character, which causes it to fail when it finds a newline before it
@@ -236,7 +236,7 @@ after a delimiter:
 .. ipython:: python
 
    data = 'a, b, c\n1, 2, 3\n4, 5, 6'
-   print data
+   print(data)
    pd.read_csv(StringIO(data), skipinitialspace=True)
 
 The parsers make every attempt to "do the right thing" and not be very
@@ -255,7 +255,7 @@ individual columns:
 .. ipython:: python
 
     data = 'a,b,c\n1,2,3\n4,5,6\n7,8,9'
-    print data
+    print(data)
 
     df = pd.read_csv(StringIO(data), dtype=object)
     df
@@ -275,7 +275,7 @@ used as the column names:
 
     from StringIO import StringIO
     data = 'a,b,c\n1,2,3\n4,5,6\n7,8,9'
-    print data
+    print(data)
     pd.read_csv(StringIO(data))
 
 By specifying the ``names`` argument in conjunction with ``header`` you can
@@ -284,7 +284,7 @@ any):
 
 .. ipython:: python
 
-    print data
+    print(data)
     pd.read_csv(StringIO(data), names=['foo', 'bar', 'baz'], header=0)
     pd.read_csv(StringIO(data), names=['foo', 'bar', 'baz'], header=None)
 
@@ -356,7 +356,7 @@ index column inference and discard the last column, pass ``index_col=False``:
 .. ipython:: python
 
     data = 'a,b,c\n4,apple,bat,\n8,orange,cow,'
-    print data
+    print(data)
     pd.read_csv(StringIO(data))
     pd.read_csv(StringIO(data), index_col=False)
 
@@ -411,7 +411,7 @@ column names:
 
 .. ipython:: python
 
-    print open('tmp.csv').read()
+    print(open('tmp.csv').read())
     df = pd.read_csv('tmp.csv', header=None, parse_dates=[[1, 2], [1, 3]])
     df
 
@@ -499,7 +499,7 @@ DD/MM/YYYY instead. For convenience, a ``dayfirst`` keyword is provided:
 
 .. ipython:: python
 
-   print open('tmp.csv').read()
+   print(open('tmp.csv').read())
 
    pd.read_csv('tmp.csv', parse_dates=[0])
    pd.read_csv('tmp.csv', dayfirst=True, parse_dates=[0])
@@ -527,7 +527,7 @@ By default, numbers with a thousands separator will be parsed as strings
 
 .. ipython:: python
 
-    print open('tmp.csv').read()
+    print(open('tmp.csv').read())
     df = pd.read_csv('tmp.csv', sep='|')
     df
 
@@ -537,7 +537,7 @@ The ``thousands`` keyword allows integers to be parsed correctly
 
 .. ipython:: python
 
-    print open('tmp.csv').read()
+    print(open('tmp.csv').read())
     df = pd.read_csv('tmp.csv', sep='|', thousands=',')
     df
 
@@ -614,7 +614,7 @@ Sometimes comments or meta data may be included in a file:
 
 .. ipython:: python
 
-   print open('tmp.csv').read()
+   print(open('tmp.csv').read())
 
 By default, the parse includes the comments in the output:
 
@@ -654,7 +654,7 @@ as a ``Series``:
 
 .. ipython:: python
 
-   print open('tmp.csv').read()
+   print(open('tmp.csv').read())
 
    output =  pd.read_csv('tmp.csv', squeeze=True)
    output
@@ -679,7 +679,7 @@ options:
 .. ipython:: python
 
     data= 'a,b,c\n1,Yes,2\n3,No,4'
-    print data
+    print(data)
     pd.read_csv(StringIO(data))
     pd.read_csv(StringIO(data), true_values=['Yes'], false_values=['No'])
 
@@ -730,7 +730,7 @@ should pass the ``escapechar`` option:
 .. ipython:: python
 
    data = 'a,b\n"hello, \\"Bob\\", nice to see you",5'
-   print data
+   print(data)
    pd.read_csv(StringIO(data), escapechar='\\')
 
 .. _io.fwf:
@@ -763,7 +763,7 @@ Consider a typical fixed-width data file:
 
 .. ipython:: python
 
-   print open('bar.csv').read()
+   print(open('bar.csv').read())
 
 In order to parse this file into a DataFrame, we simply need to supply the
 column specifications to the `read_fwf` function along with the file name:
@@ -809,7 +809,7 @@ column:
 
 .. ipython:: python
 
-   print open('foo.csv').read()
+   print(open('foo.csv').read())
 
 In this special case, ``read_csv`` assumes that the first column is to be used
 as the index of the DataFrame:
@@ -841,7 +841,7 @@ Suppose you have data indexed by two columns:
 
 .. ipython:: python
 
-   print open('data/mindex_ex.csv').read()
+   print(open('data/mindex_ex.csv').read())
 
 The ``index_col`` argument to ``read_csv`` and ``read_table`` can take a list of
 column numbers to turn multiple columns into a ``MultiIndex`` for the index of the
@@ -868,7 +868,7 @@ of tupleizing columns, specify ``tupleize_cols=True``.
    from pandas.util.testing import makeCustomDataframe as mkdf
    df = mkdf(5,3,r_idx_nlevels=2,c_idx_nlevels=4)
    df.to_csv('mi.csv')
-   print open('mi.csv').read()
+   print(open('mi.csv').read())
    pd.read_csv('mi.csv',header=[0,1,2,3],index_col=[0,1])
 
 Note: If an ``index_col`` is not specified (e.g. you don't have an index, or wrote it
@@ -898,7 +898,7 @@ class of the csv module.
 
 .. ipython:: python
 
-    print open('tmp2.sv').read()
+    print(open('tmp2.sv').read())
     pd.read_csv('tmp2.sv')
 
 .. _io.chunking:
@@ -912,7 +912,7 @@ rather than reading the entire file into memory, such as the following:
 
 .. ipython:: python
 
-   print open('tmp.sv').read()
+   print(open('tmp.sv').read())
    table = pd.read_table('tmp.sv', sep='|')
    table
 
@@ -926,7 +926,7 @@ value will be an iterable object of type ``TextFileReader``:
    reader
 
    for chunk in reader:
-       print chunk
+       print(chunk)
 
 
 Specifying ``iterator=True`` will also return the ``TextFileReader`` object:
@@ -1333,7 +1333,7 @@ Specify an HTML attribute
 
    dfs1 = read_html(url, attrs={'id': 'table'})
    dfs2 = read_html(url, attrs={'class': 'sortable'})
-   print np.array_equal(dfs1[0], dfs2[0])  # Should be True
+   print(np.array_equal(dfs1[0], dfs2[0]))  # Should be True
 
 Use some combination of the above
 
@@ -1400,7 +1400,7 @@ in the method ``to_string`` described above.
 
    df = DataFrame(randn(2, 2))
    df
-   print df.to_html()  # raw html
+   print(df.to_html())  # raw html
 
 .. ipython:: python
    :suppress:
@@ -1416,7 +1416,7 @@ The ``columns`` argument will limit the columns shown
 
 .. ipython:: python
 
-   print df.to_html(columns=[0])
+   print(df.to_html(columns=[0]))
 
 .. ipython:: python
    :suppress:
@@ -1433,7 +1433,7 @@ point values
 
 .. ipython:: python
 
-   print df.to_html(float_format='{0:.10f}'.format)
+   print(df.to_html(float_format='{0:.10f}'.format))
 
 .. ipython:: python
    :suppress:
@@ -1450,7 +1450,7 @@ off
 
 .. ipython:: python
 
-   print df.to_html(bold_rows=False)
+   print(df.to_html(bold_rows=False))
 
 .. ipython:: python
    :suppress:
@@ -1466,7 +1466,7 @@ table CSS classes. Note that these classes are *appended* to the existing
 
 .. ipython:: python
 
-   print df.to_html(classes=['awesome_table_class', 'even_more_awesome_class'])
+   print(df.to_html(classes=['awesome_table_class', 'even_more_awesome_class']))
 
 Finally, the ``escape`` argument allows you to control whether the
 "<", ">" and "&" characters escaped in the resulting HTML (by default it is
@@ -1487,7 +1487,7 @@ Escaped:
 
 .. ipython:: python
 
-   print df.to_html()
+   print(df.to_html())
 
 .. raw:: html
    :file: _static/escape.html
@@ -1496,7 +1496,7 @@ Not escaped:
 
 .. ipython:: python
 
-   print df.to_html(escape=False)
+   print(df.to_html(escape=False))
 
 .. raw:: html
    :file: _static/noescape.html
@@ -1746,7 +1746,7 @@ for some advanced strategies
 .. ipython:: python
 
    store = HDFStore('store.h5')
-   print store
+   print(store)
 
 Objects can be written to the file just like adding key-value pairs to a
 dict:
@@ -2209,7 +2209,7 @@ The default is 50,000 rows returned in a chunk.
 .. ipython:: python
 
    for df in store.select('df', chunksize=3):
-      print df
+      print(df)
 
 .. note::
 
@@ -2221,7 +2221,7 @@ The default is 50,000 rows returned in a chunk.
    .. code-block:: python
 
       for df in read_hdf('store.h5','df', chunsize=3):
-          print df
+          print(df)
 
 Note, that the chunksize keyword applies to the **returned** rows. So if you
 are doing a query, then that set will be subdivided and returned in the

--- a/doc/source/r_interface.rst
+++ b/doc/source/r_interface.rst
@@ -74,8 +74,8 @@ DataFrames into the equivalent R object (that is, **data.frame**):
                   index=["one", "two", "three"])
    r_dataframe = com.convert_to_r_dataframe(df)
 
-   print type(r_dataframe)
-   print r_dataframe
+   print(type(r_dataframe))
+   print(r_dataframe)
 
 
 The DataFrame's index is stored as the ``rownames`` attribute of the
@@ -90,8 +90,8 @@ R matrices bear no information on the data type):
 
    r_matrix = com.convert_to_r_matrix(df)
 
-   print type(r_matrix)
-   print r_matrix
+   print(type(r_matrix))
+   print(r_matrix)
 
 
 Calling R functions with pandas objects

--- a/doc/source/remote_data.rst
+++ b/doc/source/remote_data.rst
@@ -126,7 +126,7 @@ Bank's servers:
 
     In [3]: dat = wb.download(indicator='NY.GDP.PCAP.KD', country=['US', 'CA', 'MX'], start=2005, end=2008)
 
-    In [4]: print dat
+    In [4]: print(dat)
                           NY.GDP.PCAP.KD
     country       year
     Canada        2008  36005.5004978584
@@ -175,7 +175,7 @@ Notice that this second search was much faster than the first one because
     In [13]: ind = ['NY.GDP.PCAP.KD', 'IT.MOB.COV.ZS']
     In [14]: dat = wb.download(indicator=ind, country='all', start=2011, end=2011).dropna()
     In [15]: dat.columns = ['gdp', 'cellphone']
-    In [16]: print dat.tail()
+    In [16]: print(dat.tail())
                             gdp  cellphone
     country   year
     Swaziland 2011  2413.952853       94.9
@@ -193,7 +193,7 @@ populations in rich countries tend to use cellphones at a higher rate:
     In [17]: import numpy as np
     In [18]: import statsmodels.formula.api as smf
     In [19]: mod = smf.ols("cellphone ~ np.log(gdp)", dat).fit()
-    In [20]: print mod.summary()
+    In [20]: print(mod.summary())
                                 OLS Regression Results
     ==============================================================================
     Dep. Variable:              cellphone   R-squared:                       0.297

--- a/doc/source/reshaping.rst
+++ b/doc/source/reshaping.rst
@@ -287,7 +287,7 @@ calling ``to_string`` if you wish:
 .. ipython:: python
 
    table = pivot_table(df, rows=['A', 'B'], cols=['C'])
-   print table.to_string(na_rep='')
+   print(table.to_string(na_rep=''))
 
 Note that ``pivot_table`` is also available as an instance method on DataFrame.
 

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -514,10 +514,10 @@ calendars which account for local holidays and local weekend conventions.
     holidays = ['2012-05-01', datetime(2013, 5, 1), np.datetime64('2014-05-01')]
     bday_egypt = CustomBusinessDay(holidays=holidays, weekmask=weekmask_egypt)
     dt = datetime(2013, 4, 30)
-    print dt + 2 * bday_egypt
+    print(dt + 2 * bday_egypt)
     dts = date_range(dt, periods=5, freq=bday_egypt).to_series()
-    print dts
-    print Series(dts.weekday, dts).map(Series('Mon Tue Wed Thu Fri Sat Sun'.split()))
+    print(dts)
+    print(Series(dts.weekday, dts).map(Series('Mon Tue Wed Thu Fri Sat Sun'.split())))
 
 .. note::
 

--- a/doc/source/v0.10.0.txt
+++ b/doc/source/v0.10.0.txt
@@ -111,7 +111,7 @@ Note:
 .. ipython:: python
 
     data= 'a,b,c\n1,Yes,2\n3,No,4'
-    print data
+    print(data)
     pd.read_csv(StringIO(data), header=None)
     pd.read_csv(StringIO(data), header=None, prefix='X')
 
@@ -121,7 +121,7 @@ Note:
 
 .. ipython:: python
 
-    print data
+    print(data)
     pd.read_csv(StringIO(data))
     pd.read_csv(StringIO(data), true_values=['Yes'], false_values=['No'])
 

--- a/doc/source/v0.12.0.txt
+++ b/doc/source/v0.12.0.txt
@@ -188,10 +188,10 @@ I/O Enhancements
     .. ipython :: python
 
         df = DataFrame({'a': range(3), 'b': list('abc')})
-        print df
+        print(df)
         html = df.to_html()
         alist = pd.read_html(html, infer_types=True, index_col=0)
-        print df == alist[0]
+        print(df == alist[0])
 
     Note that ``alist`` here is a Python ``list`` so ``pd.read_html()`` and
     ``DataFrame.to_html()`` are not inverses.
@@ -237,7 +237,7 @@ I/O Enhancements
          from pandas.util.testing import makeCustomDataframe as mkdf
          df = mkdf(5,3,r_idx_nlevels=2,c_idx_nlevels=4)
          df.to_csv('mi.csv',tupleize_cols=False)
-         print open('mi.csv').read()
+         print(open('mi.csv').read())
          pd.read_csv('mi.csv',header=[0,1,2,3],index_col=[0,1],tupleize_cols=False)
 
       .. ipython:: python
@@ -256,7 +256,7 @@ I/O Enhancements
          path = 'store_iterator.h5'
          DataFrame(randn(10,2)).to_hdf(path,'df',table=True)
          for df in read_hdf(path,'df', chunksize=3):
-            print df
+            print(df)
 
     .. ipython:: python
          :suppress:
@@ -376,9 +376,9 @@ Experimental Features
       holidays = ['2012-05-01', datetime(2013, 5, 1), np.datetime64('2014-05-01')]
       bday_egypt = CustomBusinessDay(holidays=holidays, weekmask=weekmask_egypt)
       dt = datetime(2013, 4, 30)
-      print dt + 2 * bday_egypt
+      print(dt + 2 * bday_egypt)
       dts = date_range(dt, periods=5, freq=bday_egypt).to_series()
-      print Series(dts.weekday, dts).map(Series('Mon Tue Wed Thu Fri Sat Sun'.split()))
+      print(Series(dts.weekday, dts).map(Series('Mon Tue Wed Thu Fri Sat Sun'.split())))
 
 Bug Fixes
 ~~~~~~~~~
@@ -404,7 +404,7 @@ Bug Fixes
         ds = Series(strs)
 
         for s in ds.str:
-            print s
+            print(s)
 
         s
         s.dropna().values.item() == 'w'

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -161,7 +161,7 @@ HDFStore API Changes
        df.to_hdf(path,'df_table2',append=True)
        df.to_hdf(path,'df_fixed')
        with get_store(path) as store:
-          print store
+          print(store)
 
     .. ipython:: python
        :suppress:


### PR DESCRIPTION
closes #4967

`print` statements refactoring
