### PR TITLE
BUG: Bug in concatenation with duplicate columns across dtypes, GH4975

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -432,7 +432,7 @@ Bug Fixes
   - Bug in multi-indexing with a partial string selection as one part of a MultIndex (:issue:`4758`)
   - Bug with reindexing on the index with a non-unique index will now raise ``ValueError`` (:issue:`4746`)
   - Bug in setting with ``loc/ix`` a single indexer with a multi-index axis and a numpy array, related to (:issue:`3777`)
-  - Bug in concatenation with duplicate columns across dtypes not merging with axis=0 (:issue:`4771`)
+  - Bug in concatenation with duplicate columns across dtypes not merging with axis=0 (:issue:`4771`, :issue:`4975`)
   - Bug in ``iloc`` with a slice index failing (:issue:`4771`)
   - Incorrect error message with no colspecs or width in ``read_fwf``. (:issue:`4774`)
   - Fix bugs in indexing in a Series with a duplicate index (:issue:`4548`, :issue:`4550`)


### PR DESCRIPTION
partially fixed in #4771

closes #4975

```
In [1]: w = DataFrame(np.random.randn(4,2), columns=["x", "y"])

In [2]: x = DataFrame(np.random.randn(4,2), columns=["x", "y"])

In [3]: y = DataFrame(np.random.randn(4,2), columns=["x", "y"])

In [4]: z = DataFrame(np.random.randn(4,2), columns=["x", "y"])

In [5]: dta = x.merge(y, left_index=True, right_index=True).merge(z, left_index=True, right_index=True, how="outer")

In [6]: dta = dta.merge(w, left_index=True, right_index=True)

In [7]: dta
Out[7]: 
        x_x       y_x       x_y       y_y       x_x       y_x       x_y       y_y
0  0.393625 -0.340291  0.035043 -0.195235 -0.892856 -0.357269  0.820424  0.142803
1 -1.600176  0.737261 -0.571140  1.352393  0.201634  1.403633  0.590919 -1.003057
2 -1.046113  2.148139  2.406527 -1.460300  0.881712  0.949246 -0.061758 -0.386265
3 -0.472761 -0.055612 -0.449152 -0.209876  1.076689  0.294275 -0.684433  0.925683
```

Via direct concat

```
In [11]: concat([x,y,z,w],axis=1)
Out[11]: 
          x         y         x         y         x         y         x         y
0  0.393625 -0.340291  0.035043 -0.195235 -0.892856 -0.357269  0.820424  0.142803
1 -1.600176  0.737261 -0.571140  1.352393  0.201634  1.403633  0.590919 -1.003057
2 -1.046113  2.148139  2.406527 -1.460300  0.881712  0.949246 -0.061758 -0.386265
3 -0.472761 -0.055612 -0.449152 -0.209876  1.076689  0.294275 -0.684433  0.925683

In [8]: expected = concat([x,y,z,w],axis=1)

In [9]: expected.columns=['x_x','y_x','x_y','y_y','x_x','y_x','x_y','y_y']

In [10]: expected
Out[10]: 
        x_x       y_x       x_y       y_y       x_x       y_x       x_y       y_y
0  0.393625 -0.340291  0.035043 -0.195235 -0.892856 -0.357269  0.820424  0.142803
1 -1.600176  0.737261 -0.571140  1.352393  0.201634  1.403633  0.590919 -1.003057
2 -1.046113  2.148139  2.406527 -1.460300  0.881712  0.949246 -0.061758 -0.386265
3 -0.472761 -0.055612 -0.449152 -0.209876  1.076689  0.294275 -0.684433  0.925683

```
