### PR TITLE
added halflife to exponentially weighted moving functions

### DIFF
--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -453,15 +453,16 @@ average as
     y_t = (1 - \alpha) y_{t-1} + \alpha x_t
 
 One must have :math:`0 < \alpha \leq 1`, but rather than pass :math:`\alpha`
-directly, it's easier to think about either the **span** or **center of mass
-(com)** of an EW moment:
+directly, it's easier to think about either the **span**, **center of mass
+(com)** or **halflife** of an EW moment:
 
 .. math::
 
    \alpha =
     \begin{cases}
 	\frac{2}{s + 1}, s = \text{span}\\
-	\frac{1}{1 + c}, c = \text{center of mass}
+	\frac{1}{1 + c}, c = \text{center of mass}\\
+	1 - \exp^{\frac{\log 0.5}{h}}, h = \text{half life}
     \end{cases}
 
 .. note::
@@ -474,11 +475,12 @@ directly, it's easier to think about either the **span** or **center of mass
 
   where :math:`\alpha' = 1 - \alpha`.
 
-You can pass one or the other to these functions but not both. **Span**
+You can pass one of the three to these functions but not more. **Span**
 corresponds to what is commonly called a "20-day EW moving average" for
 example. **Center of mass** has a more physical interpretation. For example,
-**span** = 20 corresponds to **com** = 9.5. Here is the list of functions
-available:
+**span** = 20 corresponds to **com** = 9.5. **Halflife** is the period of
+time for the exponential weight to reduce to one half. Here is the list of 
+functions available:
 
 .. csv-table::
     :header: "Function", "Description"

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -138,6 +138,8 @@ Improvements to existing features
     (:issue:`4961`).
   - ``concat`` now gives a more informative error message when passed objects
     that cannot be concatenated (:issue:`4608`).
+  - Add ``halflife`` option to exponentially weighted moving functions (PR
+    :issue:`4998`)
 
 API Changes
 ~~~~~~~~~~~

--- a/pandas/stats/tests/test_moments.py
+++ b/pandas/stats/tests/test_moments.py
@@ -535,6 +535,16 @@ class TestMoments(unittest.TestCase):
         self.assertRaises(Exception, mom.ewma, self.arr, com=9.5, span=20)
         self.assertRaises(Exception, mom.ewma, self.arr)
 
+    def test_ewma_halflife_arg(self):
+        A = mom.ewma(self.arr, com=13.932726172912965)
+        B = mom.ewma(self.arr, halflife=10.0)
+        assert_almost_equal(A, B)
+
+        self.assertRaises(Exception, mom.ewma, self.arr, span=20, halflife=50)
+        self.assertRaises(Exception, mom.ewma, self.arr, com=9.5, halflife=50)
+        self.assertRaises(Exception, mom.ewma, self.arr, com=9.5, span=20, halflife=50)
+        self.assertRaises(Exception, mom.ewma, self.arr)
+
     def test_ew_empty_arrays(self):
         arr = np.array([], dtype=np.float64)
 


### PR DESCRIPTION
Currently for the exponentially weighted moving functions (ewma, ewmstd, ewmvol, ewmvar, ewmcov) there are two ways (span, center of mass) to specify how fast the exponential decay is. It would be nice to support a "half life" option as well.

The half life is basically just the number of periods in which the exponential weight drops to one half, i.e.,

(1 - \alpha)^h = 0.5, h: half life
