### PR TITLE
API: Remove deprecated read_clipboard/to_clipboard/ExcelFile/ExcelWriter from pandas.io.parsers (GH3717)

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -31,6 +31,15 @@ Flat File
    read_table
    read_csv
    read_fwf
+
+Clipboard
+~~~~~~~~~
+
+.. currentmodule:: pandas.io.clipboard
+
+.. autosummary::
+   :toctree: generated/
+
    read_clipboard
 
 Excel

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -111,7 +111,7 @@ Optional Dependencies
     <http://www.pygtk.org/>`__, `xsel
     <http://www.vergenet.net/~conrad/software/xsel/>`__, or `xclip
     <http://sourceforge.net/projects/xclip/>`__: necessary to use
-    :func:`~pandas.io.parsers.read_clipboard`. Most package managers on Linux
+    :func:`~pandas.io.clipboard.read_clipboard`. Most package managers on Linux
     distributions will have xclip and/or xsel immediately available for
     installation.
   * One of the following combinations of libraries is needed to use the

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -245,6 +245,7 @@ API Changes
   - Remove deprecated ``_verbose_info`` (:issue:`3215`)
   - Begin removing methods that don't make sense on ``GroupBy`` objects
     (:issue:`4887`).
+  - Remove deprecated ``read_clipboard/to_clipboard/ExcelFile/ExcelWriter`` from ``pandas.io.parsers`` (:issue:`3717`)
 
 Internal Refactoring
 ~~~~~~~~~~~~~~~~~~~~

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2048,27 +2048,3 @@ class FixedWidthFieldParser(PythonParser):
     def _make_reader(self, f):
         self.data = FixedWidthReader(f, self.colspecs, self.delimiter,
                                      encoding=self.encoding)
-
-
-##### deprecations in 0.12 #####
-##### remove in 0.12         #####
-
-from pandas.io import clipboard
-def read_clipboard(**kwargs):
-    warn("read_clipboard is now a top-level accessible via pandas.read_clipboard", FutureWarning)
-    clipboard.read_clipboard(**kwargs)
-
-def to_clipboard(obj):
-    warn("to_clipboard is now an object level method accessible via obj.to_clipboard()", FutureWarning)
-    clipboard.to_clipboard(obj)
-
-from pandas.io import excel
-class ExcelWriter(excel.ExcelWriter):
-    def __init__(self, path):
-        warn("ExcelWriter can now be imported from: pandas.io.excel", FutureWarning)
-        super(ExcelWriter, self).__init__(path)
-
-class ExcelFile(excel.ExcelFile):
-    def __init__(self, path_or_buf, **kwds):
-        warn("ExcelFile can now be imported from: pandas.io.excel", FutureWarning)
-        super(ExcelFile, self).__init__(path_or_buf, **kwds)

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -254,20 +254,20 @@ class ExcelReaderTests(SharedItems, unittest.TestCase):
         f = open(pth, 'rb')
         xl = ExcelFile(f)
         xl.parse('Sheet1', index_col=0, parse_dates=True)
-        
+
     def test_read_xlrd_Book(self):
         _skip_if_no_xlrd()
         _skip_if_no_xlwt()
-        
+
         import xlrd
-        
+
         pth = '__tmp_excel_read_worksheet__.xls'
         df = self.frame
-        
+
         with ensure_clean(pth) as pth:
             df.to_excel(pth, "SheetA")
             book = xlrd.open_workbook(pth)
-            
+
             with ExcelFile(book, engine="xlrd") as xl:
                 result = xl.parse("SheetA")
                 tm.assert_frame_equal(df, result)
@@ -1003,26 +1003,6 @@ class ExcelWriterEngineTests(unittest.TestCase):
         check_called(lambda: df.to_excel('something.xlsx'))
         check_called(lambda: df.to_excel('something.xls', engine='dummy'))
         set_option('io.excel.xlsx.writer', val)
-
-
-class ExcelLegacyTests(SharedItems, unittest.TestCase):
-    def test_deprecated_from_parsers(self):
-
-        # since 0.12 changed the import path
-        import warnings
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings(action='ignore', category=FutureWarning)
-
-            _skip_if_no_xlrd()
-            from pandas.io.parsers import ExcelFile as xf
-            xf(self.xls1)
-
-            _skip_if_no_xlwt()
-            with ensure_clean('test.xls') as path:
-                from pandas.io.parsers import ExcelWriter as xw
-                xw(path)
-
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
closes #3717
