### PR TITLE
API: default for mangle_dup_cols is now False for read_csv. Fair warning in 0.12 (GH3612)

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -151,7 +151,7 @@ They can take a number of arguments:
   - ``error_bad_lines``: if False then any lines causing an error will be skipped :ref:`bad lines <io.bad_lines>`
   - ``usecols``: a subset of columns to return, results in much faster parsing
     time and lower memory usage.
-  - ``mangle_dupe_cols``: boolean, default True, then duplicate columns will be specified
+  - ``mangle_dupe_cols``: boolean, default False, then duplicate columns will be specified
     as 'X.0'...'X.N', rather than 'X'...'X'
   - ``tupleize_cols``: boolean, default False, if False, convert a list of tuples
     to a multi-index of columns, otherwise, leave the column index as a list of tuples

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -246,6 +246,7 @@ API Changes
   - Begin removing methods that don't make sense on ``GroupBy`` objects
     (:issue:`4887`).
   - Remove deprecated ``read_clipboard/to_clipboard/ExcelFile/ExcelWriter`` from ``pandas.io.parsers`` (:issue:`3717`)
+  - default for ``mangele_dup_cols`` is now ``False`` for ``read_csv``. Fair warning in 0.12 (:issue:`3612`)
 
 Internal Refactoring
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -68,9 +68,17 @@ API changes
         df1 and df2
         s1 and s2
 
+Prior Version Deprecations/Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These were announced changes in 0.12 or prior that are taking effect as of 0.13.0
+
   - Remove deprecated ``Factor`` (:issue:`3650`)
   - Remove deprecated ``set_printoptions/reset_printoptions`` (:issue:``3046``)
   - Remove deprecated ``_verbose_info`` (:issue:`3215`)
+  - Remove deprecated ``read_clipboard/to_clipboard/ExcelFile/ExcelWriter`` from ``pandas.io.parsers`` (:issue:`3717`)
+  - default for ``tupleize_cols`` is now ``False`` for both ``to_csv`` and ``read_csv``. Fair warning in 0.12 (:issue:`3604`)
+  - default for ``mangele_dup_cols`` is now ``False`` for ``read_csv``. Fair warning in 0.12 (:issue:`3612`)
 
 Indexing API Changes
 ~~~~~~~~~~~~~~~~~~~~

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -128,7 +128,7 @@ na_filter: boolean, default True
 usecols : array-like
     Return a subset of the columns.
     Results in much faster parsing time and lower memory usage.
-mangle_dupe_cols: boolean, default True
+mangle_dupe_cols: boolean, default False
     Duplicate columns will be specified as 'X.0'...'X.N', rather than 'X'...'X'
 tupleize_cols: boolean, default False
     Leave a list of tuples on columns as is (default is to convert to
@@ -245,7 +245,7 @@ _parser_defaults = {
     'encoding': None,
     'squeeze': False,
     'compression': None,
-    'mangle_dupe_cols': True,
+    'mangle_dupe_cols': False,
     'tupleize_cols':False,
 }
 
@@ -334,7 +334,7 @@ def _make_parser_function(name, sep=','):
                  verbose=False,
                  encoding=None,
                  squeeze=False,
-                 mangle_dupe_cols=True,
+                 mangle_dupe_cols=False,
                  tupleize_cols=False,
                  ):
 
@@ -1260,7 +1260,7 @@ class PythonParser(ParserBase):
         self.skipinitialspace = kwds['skipinitialspace']
         self.lineterminator = kwds['lineterminator']
         self.quoting = kwds['quoting']
-        self.mangle_dupe_cols = kwds.get('mangle_dupe_cols',True)
+        self.mangle_dupe_cols = kwds.get('mangle_dupe_cols',False)
 
         self.has_index_names = False
         if 'has_index_names' in kwds:

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -804,10 +804,6 @@ d,,f
     6,7,8,9,10
     11,12,13,14,15
     """
-            # check default beahviour
-            df = self.read_table(StringIO(data), sep=',',engine=engine)
-            self.assertEqual(list(df.columns), ['A', 'A.1', 'B', 'B.1', 'B.2'])
-
             df = self.read_table(StringIO(data), sep=',',engine=engine,mangle_dupe_cols=False)
             self.assertEqual(list(df.columns), ['A', 'A', 'B', 'B', 'B'])
 

--- a/pandas/parser.pyx
+++ b/pandas/parser.pyx
@@ -309,7 +309,7 @@ cdef class TextReader:
                   skiprows=None,
                   skip_footer=0,
                   verbose=False,
-                  mangle_dupe_cols=True,
+                  mangle_dupe_cols=False,
                   tupleize_cols=False):
 
         self.parser = parser_new()


### PR DESCRIPTION
closes #3512
