### PR TITLE
ENH: Removing unnecessary whitespace when formatting to a HTML table.

### DIFF
--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -735,7 +735,7 @@ class HTMLFormatter(TableFormatter):
 
         fmt_values = {}
         for i in range(len(self.columns)):
-            fmt_values[i] = self.fmt._format_col(i)
+            fmt_values[i] = [item.strip() for item in self.fmt._format_col(i)]
 
         # write values
         if self.fmt.index:

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -1159,7 +1159,7 @@ c  10  11  12  13  14\
         df_s = df.to_string(justify='left')
         expected = ('   x       \n'
                     '0  3234.000\n'
-                    '1     0.253')
+                    '1  0.253   ')
         assert(df_s == expected)
 
     def test_to_string_format_na(self):
@@ -1933,6 +1933,69 @@ class TestFloatArrayFormatter(unittest.TestCase):
     def test_misc(self):
         obj = fmt.FloatArrayFormatter(np.array([], dtype=np.float64))
         result = obj.get_result()
+
+
+class TestDataFrameJustification(unittest.TestCase):
+    def setUp(self):
+        self.df_int = pd.DataFrame(np.arange(3).reshape(1, 3),
+                                   columns=['foo', 'bar', 'baz'],
+                                   dtype=int)
+        self.df_float = pd.DataFrame(np.linspace(0.3, 1.2, 3).reshape(1, 3),
+                                     columns=['a', 'b', 'c'],
+                                     dtype=float)
+        self.df_string = pd.DataFrame([
+            ['test', 'something long', 'something even longer'],
+            ['foo', 'bar', 'baz'],
+            ['small', 'text', 'samples']
+        ], columns=['a', 'b', 'c'])
+
+    def test_left_justification(self):
+        expected = '   foo  bar  baz\n0  0    1    2  '
+        self.assertEqual(expected, self.df_int.to_string(justify='left'),
+                         'Left int justification failed')
+        expected = '   a    b     c  \n0  0.3  0.75  1.2'
+        self.assertEqual(expected, self.df_float.to_string(justify='left'),
+                         'Left float justification failed')
+        expected = '''
+  a      b               c                     
+0  test   something long  something even longer
+1  foo    bar             baz                  
+2  small  text            samples              
+'''.strip('\r\n')
+        self.assertEqual(expected, self.df_string.to_string(justify='left'),
+                         'Left string justification failed')
+
+    def test_right_justification(self):
+        expected = '   foo  bar  baz\n0    0    1    2'
+        self.assertEqual(expected, self.df_int.to_string(justify='right'),
+                         'Right int justification failed')
+        expected = '     a     b    c\n0  0.3  0.75  1.2'
+        self.assertEqual(expected, self.df_float.to_string(justify='right'),
+                         'Right float justification failed')
+        expected = '''
+       a               b                      c
+0   test  something long  something even longer
+1    foo             bar                    baz
+2  small            text                samples
+'''.strip('\r\n')
+        self.assertEqual(expected, self.df_string.to_string(justify='right'),
+                         'Right string justification failed')
+
+    def test_center_justification(self):
+        expected = '   foo  bar  baz\n0   0    1    2 '
+        self.assertEqual(expected, self.df_int.to_string(justify='center'),
+                         'Center int justification failed')
+        expected = '    a     b    c \n0  0.3  0.75  1.2'
+        self.assertEqual(expected, self.df_float.to_string(justify='center'),
+                         'Center float justification failed')
+        expected = '''
+    a           b                  c           
+0  test   something long  something even longer
+1   foo         bar                baz         
+2  small       text              samples       
+'''.strip('\r\n')
+        self.assertEqual(expected, self.df_string.to_string(justify='center'),
+                         'Center string justification failed')
 
 if __name__ == '__main__':
     import nose

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -399,13 +399,13 @@ class TestDataFrameFormatting(unittest.TestCase):
   <tbody>
     <tr>
       <th>str&lt;ing1 &amp;amp;</th>
-      <td> &lt;type 'str'&gt;</td>
-      <td> &lt;type 'str'&gt;</td>
+      <td>&lt;type 'str'&gt;</td>
+      <td>&lt;type 'str'&gt;</td>
     </tr>
     <tr>
       <th>stri&gt;ng2 &amp;amp;</th>
-      <td> &lt;type 'str'&gt;</td>
-      <td> &lt;type 'str'&gt;</td>
+      <td>&lt;type 'str'&gt;</td>
+      <td>&lt;type 'str'&gt;</td>
     </tr>
   </tbody>
 </table>"""
@@ -431,13 +431,13 @@ class TestDataFrameFormatting(unittest.TestCase):
   <tbody>
     <tr>
       <th>str<ing1 &amp;</th>
-      <td> <b>bold</b></td>
-      <td> <b>bold</b></td>
+      <td><b>bold</b></td>
+      <td><b>bold</b></td>
     </tr>
     <tr>
       <th>stri>ng2 &amp;</th>
-      <td> <b>bold</b></td>
-      <td> <b>bold</b></td>
+      <td><b>bold</b></td>
+      <td><b>bold</b></td>
     </tr>
   </tbody>
 </table>"""
@@ -471,26 +471,26 @@ class TestDataFrameFormatting(unittest.TestCase):
     <tr>
       <th>0</th>
       <th>0</th>
-      <td> 0</td>
-      <td> 1</td>
+      <td>0</td>
+      <td>1</td>
     </tr>
     <tr>
       <th>0</th>
       <th>1</th>
-      <td> 2</td>
-      <td> 3</td>
+      <td>2</td>
+      <td>3</td>
     </tr>
     <tr>
       <th>1</th>
       <th>0</th>
-      <td> 4</td>
-      <td> 5</td>
+      <td>4</td>
+      <td>5</td>
     </tr>
     <tr>
       <th>1</th>
       <th>1</th>
-      <td> 6</td>
-      <td> 7</td>
+      <td>6</td>
+      <td>7</td>
     </tr>
   </tbody>
 </table>"""
@@ -526,26 +526,26 @@ class TestDataFrameFormatting(unittest.TestCase):
     <tr>
       <th>0</th>
       <th>0</th>
-      <td> 0</td>
-      <td> 1</td>
+      <td>0</td>
+      <td>1</td>
     </tr>
     <tr>
       <th>0</th>
       <th>1</th>
-      <td> 2</td>
-      <td> 3</td>
+      <td>2</td>
+      <td>3</td>
     </tr>
     <tr>
       <th>1</th>
       <th>0</th>
-      <td> 4</td>
-      <td> 5</td>
+      <td>4</td>
+      <td>5</td>
     </tr>
     <tr>
       <th>1</th>
       <th>1</th>
-      <td> 6</td>
-      <td> 7</td>
+      <td>6</td>
+      <td>7</td>
     </tr>
   </tbody>
 </table>"""
@@ -577,24 +577,24 @@ class TestDataFrameFormatting(unittest.TestCase):
     <tr>
       <th rowspan="2" valign="top">0</th>
       <th>0</th>
-      <td> 0</td>
-      <td> 1</td>
+      <td>0</td>
+      <td>1</td>
     </tr>
     <tr>
       <th>1</th>
-      <td> 2</td>
-      <td> 3</td>
+      <td>2</td>
+      <td>3</td>
     </tr>
     <tr>
       <th rowspan="2" valign="top">1</th>
       <th>0</th>
-      <td> 4</td>
-      <td> 5</td>
+      <td>4</td>
+      <td>5</td>
     </tr>
     <tr>
       <th>1</th>
-      <td> 6</td>
-      <td> 7</td>
+      <td>6</td>
+      <td>7</td>
     </tr>
   </tbody>
 </table>"""
@@ -630,24 +630,24 @@ class TestDataFrameFormatting(unittest.TestCase):
     <tr>
       <th rowspan="2" valign="top">0</th>
       <th>0</th>
-      <td> 0</td>
-      <td> 1</td>
+      <td>0</td>
+      <td>1</td>
     </tr>
     <tr>
       <th>1</th>
-      <td> 2</td>
-      <td> 3</td>
+      <td>2</td>
+      <td>3</td>
     </tr>
     <tr>
       <th rowspan="2" valign="top">1</th>
       <th>0</th>
-      <td> 4</td>
-      <td> 5</td>
+      <td>4</td>
+      <td>5</td>
     </tr>
     <tr>
       <th>1</th>
-      <td> 6</td>
-      <td> 7</td>
+      <td>6</td>
+      <td>7</td>
     </tr>
   </tbody>
 </table>"""
@@ -671,23 +671,23 @@ class TestDataFrameFormatting(unittest.TestCase):
   <tbody>
     <tr>
       <th>a</th>
-      <td> 0</td>
-      <td> 1</td>
+      <td>0</td>
+      <td>1</td>
     </tr>
     <tr>
       <th>b</th>
-      <td> 2</td>
-      <td> 3</td>
+      <td>2</td>
+      <td>3</td>
     </tr>
     <tr>
       <th>c</th>
-      <td> 4</td>
-      <td> 5</td>
+      <td>4</td>
+      <td>5</td>
     </tr>
     <tr>
       <th>d</th>
-      <td> 6</td>
-      <td> 7</td>
+      <td>6</td>
+      <td>7</td>
     </tr>
   </tbody>
 </table>"""
@@ -1274,17 +1274,17 @@ c  10  11  12  13  14\
                     '  <tbody>\n'
                     '    <tr>\n'
                     '      <th>0</th>\n'
-                    '      <td> a</td>\n'
-                    '      <td> b</td>\n'
-                    '      <td> c</td>\n'
-                    '      <td> d</td>\n'
+                    '      <td>a</td>\n'
+                    '      <td>b</td>\n'
+                    '      <td>c</td>\n'
+                    '      <td>d</td>\n'
                     '    </tr>\n'
                     '    <tr>\n'
                     '      <th>1</th>\n'
-                    '      <td> e</td>\n'
-                    '      <td> f</td>\n'
-                    '      <td> g</td>\n'
-                    '      <td> h</td>\n'
+                    '      <td>e</td>\n'
+                    '      <td>f</td>\n'
+                    '      <td>g</td>\n'
+                    '      <td>h</td>\n'
                     '    </tr>\n'
                     '  </tbody>\n'
                     '</table>')
@@ -1316,17 +1316,17 @@ c  10  11  12  13  14\
                     '  <tbody>\n'
                     '    <tr>\n'
                     '      <th>0</th>\n'
-                    '      <td> a</td>\n'
-                    '      <td> b</td>\n'
-                    '      <td> c</td>\n'
-                    '      <td> d</td>\n'
+                    '      <td>a</td>\n'
+                    '      <td>b</td>\n'
+                    '      <td>c</td>\n'
+                    '      <td>d</td>\n'
                     '    </tr>\n'
                     '    <tr>\n'
                     '      <th>1</th>\n'
-                    '      <td> e</td>\n'
-                    '      <td> f</td>\n'
-                    '      <td> g</td>\n'
-                    '      <td> h</td>\n'
+                    '      <td>e</td>\n'
+                    '      <td>f</td>\n'
+                    '      <td>g</td>\n'
+                    '      <td>h</td>\n'
                     '    </tr>\n'
                     '  </tbody>\n'
                     '</table>')
@@ -1351,21 +1351,21 @@ c  10  11  12  13  14\
                     '  <tbody>\n'
                     '    <tr>\n'
                     '      <th>0</th>\n'
-                    '      <td>     6</td>\n'
-                    '      <td>     1</td>\n'
-                    '      <td> 223442</td>\n'
+                    '      <td>6</td>\n'
+                    '      <td>1</td>\n'
+                    '      <td>223442</td>\n'
                     '    </tr>\n'
                     '    <tr>\n'
                     '      <th>1</th>\n'
-                    '      <td> 30000</td>\n'
-                    '      <td>     2</td>\n'
-                    '      <td>      0</td>\n'
+                    '      <td>30000</td>\n'
+                    '      <td>2</td>\n'
+                    '      <td>0</td>\n'
                     '    </tr>\n'
                     '    <tr>\n'
                     '      <th>2</th>\n'
-                    '      <td>     2</td>\n'
-                    '      <td> 70000</td>\n'
-                    '      <td>      1</td>\n'
+                    '      <td>2</td>\n'
+                    '      <td>70000</td>\n'
+                    '      <td>1</td>\n'
                     '    </tr>\n'
                     '  </tbody>\n'
                     '</table>')
@@ -1385,21 +1385,21 @@ c  10  11  12  13  14\
                     '  <tbody>\n'
                     '    <tr>\n'
                     '      <th>0</th>\n'
-                    '      <td>     6</td>\n'
-                    '      <td>     1</td>\n'
-                    '      <td> 223442</td>\n'
+                    '      <td>6</td>\n'
+                    '      <td>1</td>\n'
+                    '      <td>223442</td>\n'
                     '    </tr>\n'
                     '    <tr>\n'
                     '      <th>1</th>\n'
-                    '      <td> 30000</td>\n'
-                    '      <td>     2</td>\n'
-                    '      <td>      0</td>\n'
+                    '      <td>30000</td>\n'
+                    '      <td>2</td>\n'
+                    '      <td>0</td>\n'
                     '    </tr>\n'
                     '    <tr>\n'
                     '      <th>2</th>\n'
-                    '      <td>     2</td>\n'
-                    '      <td> 70000</td>\n'
-                    '      <td>      1</td>\n'
+                    '      <td>2</td>\n'
+                    '      <td>70000</td>\n'
+                    '      <td>1</td>\n'
                     '    </tr>\n'
                     '  </tbody>\n'
                     '</table>')


### PR DESCRIPTION
Closes #4987.

The problem is that all formatters always call `_make_fixed_width`. So, the only solution I found is just to strip the unnecessary whitespace.
