### PR TITLE
ENH: Excel output in non-ascii encodings

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1383,7 +1383,7 @@ class DataFrame(NDFrame):
             ``io.excel.xlsx.writer``, ``io.excel.xls.writer``, and
             ``io.excel.xlsm.writer``.
         encoding: string, default None
-	    encoding of the resulting excel file.
+            encoding of the resulting excel file.
 
 
         Notes
@@ -1399,8 +1399,8 @@ class DataFrame(NDFrame):
         from pandas.io.excel import ExcelWriter
         need_save = False
         if encoding == None:
-	  encoding = 'ascii'
-	  
+            encoding = 'ascii'
+
         if isinstance(excel_writer, compat.string_types):
             excel_writer = ExcelWriter(excel_writer, engine=engine, encoding=encoding)
             need_save = True

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1383,7 +1383,8 @@ class DataFrame(NDFrame):
             ``io.excel.xlsx.writer``, ``io.excel.xls.writer``, and
             ``io.excel.xlsm.writer``.
         encoding: string, default None
-            encoding of the resulting excel file.
+            encoding of the resulting excel file. Only necessary for xlwt,
+            other writers support unicode natively.
 
 
         Notes
@@ -1400,9 +1401,9 @@ class DataFrame(NDFrame):
         need_save = False
         if encoding == None:
             encoding = 'ascii'
-
+            
         if isinstance(excel_writer, compat.string_types):
-            excel_writer = ExcelWriter(excel_writer, engine=engine, encoding=encoding)
+            excel_writer = ExcelWriter(excel_writer, engine=engine)
             need_save = True
 
         formatter = fmt.ExcelFormatter(self,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1351,7 +1351,7 @@ class DataFrame(NDFrame):
 
     def to_excel(self, excel_writer, sheet_name='Sheet1', na_rep='',
                  float_format=None, cols=None, header=True, index=True,
-                 index_label=None, startrow=0, startcol=0, engine=None):
+                 index_label=None, startrow=0, startcol=0, engine=None, encoding=None):
         """
         Write DataFrame to a excel sheet
 
@@ -1359,7 +1359,7 @@ class DataFrame(NDFrame):
         ----------
         excel_writer : string or ExcelWriter object
             File path or existing ExcelWriter
-        sheet_name : string, default 'Sheet1'
+        sheet_name : string, default 'Sheet1' 
             Name of sheet which will contain DataFrame
         na_rep : string, default ''
             Missing data representation
@@ -1382,6 +1382,8 @@ class DataFrame(NDFrame):
             write engine to use - you can also set this via the options
             ``io.excel.xlsx.writer``, ``io.excel.xls.writer``, and
             ``io.excel.xlsm.writer``.
+        encoding: string, default None
+	    encoding of the resulting excel file.
 
 
         Notes
@@ -1396,8 +1398,11 @@ class DataFrame(NDFrame):
         """
         from pandas.io.excel import ExcelWriter
         need_save = False
+        if encoding == None:
+	  encoding = 'ascii'
+	  
         if isinstance(excel_writer, compat.string_types):
-            excel_writer = ExcelWriter(excel_writer, engine=engine)
+            excel_writer = ExcelWriter(excel_writer, engine=engine, encoding=encoding)
             need_save = True
 
         formatter = fmt.ExcelFormatter(self,

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -543,8 +543,12 @@ class _XlwtWriter(ExcelWriter):
         import xlwt
 
         super(_XlwtWriter, self).__init__(path, **engine_kwargs)
-
-        self.book = xlwt.Workbook()
+	
+	if 'encoding' in engine_kwargs:
+	  self.book = xlwt.Workbook(encoding = engine_kwargs['encoding'])
+	else:
+	  self.book = xlwt.Workbook()
+        
         self.fm_datetime = xlwt.easyxf(num_format_str='YYYY-MM-DD HH:MM:SS')
         self.fm_date = xlwt.easyxf(num_format_str='YYYY-MM-DD')
 

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -338,6 +338,7 @@ class ExcelWriterMeta(abc.ABCMeta):
         engine = kwargs.pop('engine', None)
         # if it's not an ExcelWriter baseclass, dont' do anything (you've
         # probably made an explicit choice here)
+        
         if not isinstance(getattr(cls, 'engine', None), compat.string_types):
             if engine is None:
                 ext = os.path.splitext(path)[-1][1:]
@@ -346,6 +347,9 @@ class ExcelWriterMeta(abc.ABCMeta):
                 except KeyError:
                     error = ValueError("No engine for filetype: '%s'" % ext)
                     raise error
+            if engine!='xlwt':
+                if 'encoding' in kwargs:
+                    kwargs.pop('encoding')
             cls = get_writer(engine)
         writer = cls.__new__(cls, path, **kwargs)
         writer.__init__(path, **kwargs)

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -347,7 +347,7 @@ class ExcelWriterMeta(abc.ABCMeta):
                 except KeyError:
                     error = ValueError("No engine for filetype: '%s'" % ext)
                     raise error
-            if engine!='xlwt':
+            if engine != 'xlwt':
                 if 'encoding' in kwargs:
                     kwargs.pop('encoding')
             cls = get_writer(engine)

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -338,7 +338,6 @@ class ExcelWriterMeta(abc.ABCMeta):
         engine = kwargs.pop('engine', None)
         # if it's not an ExcelWriter baseclass, dont' do anything (you've
         # probably made an explicit choice here)
-        
         if not isinstance(getattr(cls, 'engine', None), compat.string_types):
             if engine is None:
                 ext = os.path.splitext(path)[-1][1:]

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -346,9 +346,6 @@ class ExcelWriterMeta(abc.ABCMeta):
                 except KeyError:
                     error = ValueError("No engine for filetype: '%s'" % ext)
                     raise error
-            if engine != 'xlwt':
-                if 'encoding' in kwargs:
-                    kwargs.pop('encoding')
             cls = get_writer(engine)
         writer = cls.__new__(cls, path, **kwargs)
         writer.__init__(path, **kwargs)
@@ -541,16 +538,15 @@ class _XlwtWriter(ExcelWriter):
     engine = 'xlwt'
     supported_extensions = ('.xls',)
 
-    def __init__(self, path, **engine_kwargs):
+    def __init__(self, path, encoding=None,**engine_kwargs):
         # Use the xlwt module as the Excel writer.
         import xlwt
 
         super(_XlwtWriter, self).__init__(path, **engine_kwargs)
 
-        if 'encoding' in engine_kwargs:
-            self.book = xlwt.Workbook(encoding = engine_kwargs['encoding'])
-        else:
-            self.book = xlwt.Workbook()
+        if encoding is None:
+            encoding = 'ascii'
+        self.book = xlwt.Workbook(encoding=encoding)
         
         self.fm_datetime = xlwt.easyxf(num_format_str='YYYY-MM-DD HH:MM:SS')
         self.fm_date = xlwt.easyxf(num_format_str='YYYY-MM-DD')

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -543,11 +543,11 @@ class _XlwtWriter(ExcelWriter):
         import xlwt
 
         super(_XlwtWriter, self).__init__(path, **engine_kwargs)
-	
-	if 'encoding' in engine_kwargs:
-	  self.book = xlwt.Workbook(encoding = engine_kwargs['encoding'])
-	else:
-	  self.book = xlwt.Workbook()
+
+        if 'encoding' in engine_kwargs:
+            self.book = xlwt.Workbook(encoding = engine_kwargs['encoding'])
+        else:
+            self.book = xlwt.Workbook()
         
         self.fm_datetime = xlwt.easyxf(num_format_str='YYYY-MM-DD HH:MM:SS')
         self.fm_date = xlwt.easyxf(num_format_str='YYYY-MM-DD')

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -677,9 +677,9 @@ class ExcelWriterBase(SharedItems):
         _skip_if_no_xlrd()
         ext = self.ext
         filename = '__tmp_to_excel_float_format__.' + ext
-        df = DataFrame([[u'\u0192', u'\u0193', u'\u0194'],
-                        [u'\u0195', u'\u0196', u'\u0197']],
-                        index=[u'A\u0192', 'B'], columns=[u'X\u0193', 'Y', 'Z'])
+        df = DataFrame([[u('\u0192'), u('\u0193'), u('\u0194')],
+                        [u('\u0195'), u('\u0196'), u('\u0197')]],
+                        index=[u('A\u0192'), 'B'], columns=[u('X\u0193'), 'Y', 'Z'])
 
         with ensure_clean(filename) as filename:
             df.to_excel(filename, sheet_name = 'TestSheet', encoding='utf8')

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -673,6 +673,20 @@ class ExcelWriterBase(SharedItems):
                             index=['A', 'B'], columns=['X', 'Y', 'Z'])
             tm.assert_frame_equal(rs, xp)
 
+    def test_to_excel_output_encoding(self):
+        _skip_if_no_xlrd()
+        ext = self.ext
+        filename = '__tmp_to_excel_float_format__.' + ext
+        df = DataFrame([[u'\u0192', u'\u0193', u'\u0194'],
+                        [u'\u0195', u'\u0196', u'\u0197']],
+                        index=[u'A\u0192', 'B'], columns=[u'X\u0193', 'Y', 'Z'])
+
+        with ensure_clean(filename) as filename:
+            df.to_excel(filename, sheet_name = 'TestSheet', encoding='utf8')
+	    result = read_excel(filename, 'TestSheet', encoding = 'utf8')
+            tm.assert_frame_equal(result,df)
+
+
     def test_to_excel_unicode_filename(self):
         _skip_if_no_xlrd()
         ext = self.ext

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -683,7 +683,7 @@ class ExcelWriterBase(SharedItems):
 
         with ensure_clean(filename) as filename:
             df.to_excel(filename, sheet_name = 'TestSheet', encoding='utf8')
-	    result = read_excel(filename, 'TestSheet', encoding = 'utf8')
+            result = read_excel(filename, 'TestSheet', encoding = 'utf8')
             tm.assert_frame_equal(result,df)
 
 


### PR DESCRIPTION
ENH/TST: Support for non-ascii encodings in DataFrame.to_excel

Closes #3710.

Notice: Despite (for my modest knowledge of python) it should be easier to just put encoding='ascii' in the declaration of to_excel in line 1352 of frame.py, I've declared it with encoding=None as jreback suggested, and then making it default to ascii later with the if clause.
