### PR TITLE
R dataset

### DIFF
--- a/doc/source/r_interface.rst
+++ b/doc/source/r_interface.rst
@@ -20,7 +20,7 @@ its release 2.3, while the current interface is
 designed for the 2.2.x series. We recommend to use 2.2.x over other series 
 unless you are prepared to fix parts of the code, yet the rpy2-2.3.0
 introduces improvements such as a better R-Python bridge memory management
-layer so I might be a good idea to bite the bullet and submit patches for
+layer so it might be a good idea to bite the bullet and submit patches for
 the few minor differences that need to be fixed.
 
 

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -138,6 +138,9 @@ Improvements to existing features
     (:issue:`4961`).
   - ``concat`` now gives a more informative error message when passed objects
     that cannot be concatenated (:issue:`4608`).
+  - Improve support for converting R datasets to pandas objects (more
+    informative index for timeseries and numeric, support for factors, dist, and
+    high-dimensional arrays.
 
 API Changes
 ~~~~~~~~~~~

--- a/pandas/rpy/common.py
+++ b/pandas/rpy/common.py
@@ -16,9 +16,6 @@ from rpy2.robjects import r
 import rpy2.robjects as robj
 r['options'](warn=-1)
 
-import logging
-logger = logging.getLogger(__name__)
-
 __all__ = ['convert_robj', 'load_data', 'convert_to_r_dataframe',
            'convert_to_r_matrix']
 
@@ -30,7 +27,6 @@ except Exception:
         importr('reshape')
         melt = r['melt']
     except Exception:
-        logger.warn('Unable to load R reshape2 or reshape library')
         melt = None
 
 def load_data(name, package=None, convert=True):

--- a/pandas/rpy/common.py
+++ b/pandas/rpy/common.py
@@ -126,8 +126,8 @@ def _convert_vector(obj):
         return pd.Series(list(obj), index=r['time'](obj)) 
     elif 'labels' in attributes:
         return pd.Series(list(obj), index=r['labels'](obj)) 
-    elif r['class'](obj) == 'dist':
-        # For 'eurodist'. WARNING: This results in a DataFrame, not a Series or list.
+    elif 'dist' in set(r['class'](obj)):
+        # For 'eurodist'. WARNING: This results in a DataFrame, not a Series or listq.
         matrix = r['as.matrix'](obj)
         return convert_robj(matrix)
     else:

--- a/pandas/rpy/common.py
+++ b/pandas/rpy/common.py
@@ -65,7 +65,7 @@ def _convert_list(obj):
 
 def _convert_array(obj):
     """
-    Convert Array to ndarray
+    Convert Array to DataFrame
     """
     def _list(item):
         try:

--- a/pandas/rpy/common.py
+++ b/pandas/rpy/common.py
@@ -14,6 +14,7 @@ import pandas.util.testing as _test
 from rpy2.robjects.packages import importr
 from rpy2.robjects import r
 import rpy2.robjects as robj
+r['options'](warn=-1)
 
 import logging
 logger = logging.getLogger(__name__)

--- a/pandas/rpy/common.py
+++ b/pandas/rpy/common.py
@@ -118,15 +118,22 @@ def _convert_vector(obj):
         attributes = set(r['attributes'](obj).names)
         if 'names' in attributes:
             index = r['names'](obj)
+            return pd.Series(list(obj), index=index)            
         elif 'tsp' in attributes:
             index = r['time'](obj)
+            return pd.Series(list(obj), index=index)            
         elif 'labels' in attributes:
             index = r['labels'](obj)
+            return pd.Series(list(obj), index=index)            
+        elif r['class'](obj) == 'dist':
+            # For 'eurodist'
+            # Note when obj is a dist, this returns a DataFrame, even though obj
+            # was a vector
+            matrix = r['as.matrix'](obj)
+            return convert_robj(matrix)
         else:
-            # For 'eurodist'  
-            return convert_robj(r['as.matrix'](obj))
-        return pd.Series(list(obj), index=index)
-    except (TypeError, AttributeError):
+            return list(obj)
+    except (TypeError, AttributeError, UnboundLocalError):
         return list(obj)
 NA_INTEGER = -2147483648
 

--- a/pandas/rpy/common.py
+++ b/pandas/rpy/common.py
@@ -114,27 +114,25 @@ def _convert_vector(obj):
         return _convert_int_vector(obj)
     elif isinstance(obj, robj.StrVector):
         return _convert_str_vector(obj)
+    # Check if the vector has extra information attached to it that can be used
+    # as an index
     try:
         attributes = set(r['attributes'](obj).names)
-        if 'names' in attributes:
-            index = r['names'](obj)
-            return pd.Series(list(obj), index=index)            
-        elif 'tsp' in attributes:
-            index = r['time'](obj)
-            return pd.Series(list(obj), index=index)            
-        elif 'labels' in attributes:
-            index = r['labels'](obj)
-            return pd.Series(list(obj), index=index)            
-        elif r['class'](obj) == 'dist':
-            # For 'eurodist'
-            # Note when obj is a dist, this returns a DataFrame, even though obj
-            # was a vector
-            matrix = r['as.matrix'](obj)
-            return convert_robj(matrix)
-        else:
-            return list(obj)
-    except (TypeError, AttributeError, UnboundLocalError):
+    except AttributeError:
         return list(obj)
+    if 'names' in attributes:
+        return pd.Series(list(obj), index=r['names'](obj)) 
+    elif 'tsp' in attributes:
+        return pd.Series(list(obj), index=r['time'](obj)) 
+    elif 'labels' in attributes:
+        return pd.Series(list(obj), index=r['labels'](obj)) 
+    elif r['class'](obj) == 'dist':
+        # For 'eurodist'. WARNING: This results in a DataFrame, not a Series or list.
+        matrix = r['as.matrix'](obj)
+        return convert_robj(matrix)
+    else:
+        return list(obj)
+
 NA_INTEGER = -2147483648
 
 

--- a/pandas/rpy/common.py
+++ b/pandas/rpy/common.py
@@ -59,7 +59,7 @@ def _is_null(obj):
 
 def _convert_list(obj):
     """
-    Convert named Vector to dict, factors to DataFrames
+    Convert named Vector to dict, factors to list
     """
     try:
         values = [convert_robj(x) for x in obj]
@@ -67,12 +67,10 @@ def _convert_list(obj):
         return dict(zip(keys, values))
     except TypeError:
         # For state.division and state.region
-        if melt:
-            return convert_robj(melt(obj))
-        else:
-            raise TypeError(
-                'Unable to convert R object. '
-                'Please install the R reshape or reshape2 package')
+        factors = list(r['factor'](obj))
+        level = list(r['levels'](obj))
+        result = [level[index-1] for index in factors]
+        return result
 
 
 def _convert_array(obj):
@@ -125,8 +123,8 @@ def _convert_vector(obj):
     elif 'tsp' in attributes:
         return pd.Series(list(obj), index=r['time'](obj)) 
     elif 'labels' in attributes:
-        return pd.Series(list(obj), index=r['labels'](obj)) 
-    elif 'dist' in set(r['class'](obj)):
+        return pd.Series(list(obj), index=r['labels'](obj))
+    if _rclass(obj) == 'dist':
         # For 'eurodist'. WARNING: This results in a DataFrame, not a Series or listq.
         matrix = r['as.matrix'](obj)
         return convert_robj(matrix)

--- a/pandas/rpy/common.py
+++ b/pandas/rpy/common.py
@@ -15,9 +15,22 @@ from rpy2.robjects.packages import importr
 from rpy2.robjects import r
 import rpy2.robjects as robj
 
+import logging
+logger = logging.getLogger(__name__)
+
 __all__ = ['convert_robj', 'load_data', 'convert_to_r_dataframe',
            'convert_to_r_matrix']
 
+try:
+    importr('reshape2')
+    melt = r['melt']
+except Exception:
+    try:
+        importr('reshape')
+        melt = r['melt']
+    except Exception:
+        logger.warn('Unable to load R reshape2 or reshape library')
+        melt = None
 
 def load_data(name, package=None, convert=True):
     if package:
@@ -46,38 +59,54 @@ def _is_null(obj):
 
 def _convert_list(obj):
     """
-    Convert named Vector to dict
+    Convert named Vector to dict, factors to DataFrames
     """
-    values = [convert_robj(x) for x in obj]
-    return dict(zip(obj.names, values))
+    try:
+        values = [convert_robj(x) for x in obj]
+        keys = r['names'](obj)
+        return dict(zip(keys, values))
+    except TypeError:
+        # For state.division and state.region
+        if melt:
+            return convert_robj(melt(obj))
+        else:
+            raise TypeError(
+                'Unable to convert R object. '
+                'Please install the R reshape or reshape2 package')
 
 
 def _convert_array(obj):
     """
     Convert Array to ndarray
     """
-    # this royally sucks. "Matrices" (arrays) with dimension > 3 in R aren't
-    # really matrices-- things come out Fortran order in the first two
-    # dimensions. Maybe I'm wrong?
-
-    dim = list(obj.dim)
-    values = np.array(list(obj))
-
-    if len(dim) == 3:
-        arr = values.reshape(dim[-1:] + dim[:-1]).swapaxes(1, 2)
-
-    if obj.names is not None:
-        name_list = [list(x) for x in obj.names]
-        if len(dim) == 2:
-            return pd.DataFrame(arr, index=name_list[0], columns=name_list[1])
-        elif len(dim) == 3:
-            return pd.Panel(arr, items=name_list[2],
-                            major_axis=name_list[0],
-                            minor_axis=name_list[1])
-        else:
-            print('Cannot handle dim=%d' % len(dim))
+    if melt:
+        # For iris3, HairEyeColor, UCBAdmissions, Titanic
+        return convert_robj(melt(obj))
     else:
-        return arr
+        # this royally sucks. "Matrices" (arrays) with dimension > 3 in R aren't
+        # really matrices-- things come out Fortran order in the first two
+        # dimensions. Maybe I'm wrong?
+
+        dim = list(obj.dim)
+        values = np.array(list(obj))
+
+        if len(dim) == 3:
+            arr = values.reshape(dim[-1:] + dim[:-1]).swapaxes(1, 2)
+
+        if obj.names is not None:
+            name_list = [list(x) for x in obj.names]
+            if len(dim) == 2:
+                # arr is not defined. There would be an error if we ever got here
+                return pd.DataFrame(arr, index=name_list[0], columns=name_list[1])
+            elif len(dim) == 3:
+                return pd.Panel(arr, items=name_list[2],
+                                major_axis=name_list[0],
+                                minor_axis=name_list[1])
+            else:
+                print('Cannot handle dim=%d' % len(dim))
+        else:
+            # arr might not be defined unless len(dim) == 3
+            return arr
 
 
 def _convert_vector(obj):
@@ -85,9 +114,20 @@ def _convert_vector(obj):
         return _convert_int_vector(obj)
     elif isinstance(obj, robj.StrVector):
         return _convert_str_vector(obj)
-
-    return list(obj)
-
+    try:
+        attributes = set(r['attributes'](obj).names)
+        if 'names' in attributes:
+            index = r['names'](obj)
+        elif 'tsp' in attributes:
+            index = r['time'](obj)
+        elif 'labels' in attributes:
+            index = r['labels'](obj)
+        else:
+            # For 'eurodist'  
+            return convert_robj(r['as.matrix'](obj))
+        return pd.Series(list(obj), index=index)
+    except (TypeError, AttributeError):
+        return list(obj)
 NA_INTEGER = -2147483648
 
 
@@ -141,8 +181,7 @@ def _convert_Matrix(mat):
     rows = mat.rownames
 
     columns = None if _is_null(columns) else list(columns)
-    index = None if _is_null(rows) else list(rows)
-
+    index = r['time'](mat) if _is_null(rows) else list(rows)
     return pd.DataFrame(np.array(mat), index=_check_int(index),
                         columns=columns)
 
@@ -197,7 +236,7 @@ def convert_robj(obj, use_pandas=True):
         if isinstance(obj, rpy_type):
             return converter(obj)
 
-    raise Exception('Do not know what to do with %s object' % type(obj))
+    raise TypeError('Do not know what to do with %s object' % type(obj))
 
 
 def convert_to_r_posixct(obj):
@@ -330,115 +369,8 @@ def convert_to_r_matrix(df, strings_as_factors=False):
     return r_matrix
 
 
-def test_convert_list():
-    obj = r('list(a=1, b=2, c=3)')
-
-    converted = convert_robj(obj)
-    expected = {'a': [1], 'b': [2], 'c': [3]}
-
-    _test.assert_dict_equal(converted, expected)
 
 
-def test_convert_nested_list():
-    obj = r('list(a=list(foo=1, bar=2))')
-
-    converted = convert_robj(obj)
-    expected = {'a': {'foo': [1], 'bar': [2]}}
-
-    _test.assert_dict_equal(converted, expected)
-
-
-def test_convert_frame():
-    # built-in dataset
-    df = r['faithful']
-
-    converted = convert_robj(df)
-
-    assert np.array_equal(converted.columns, ['eruptions', 'waiting'])
-    assert np.array_equal(converted.index, np.arange(1, 273))
-
-
-def _test_matrix():
-    r('mat <- matrix(rnorm(9), ncol=3)')
-    r('colnames(mat) <- c("one", "two", "three")')
-    r('rownames(mat) <- c("a", "b", "c")')
-
-    return r['mat']
-
-
-def test_convert_matrix():
-    mat = _test_matrix()
-
-    converted = convert_robj(mat)
-
-    assert np.array_equal(converted.index, ['a', 'b', 'c'])
-    assert np.array_equal(converted.columns, ['one', 'two', 'three'])
-
-
-def test_convert_r_dataframe():
-
-    is_na = robj.baseenv.get("is.na")
-
-    seriesd = _test.getSeriesData()
-    frame = pd.DataFrame(seriesd, columns=['D', 'C', 'B', 'A'])
-
-    # Null data
-    frame["E"] = [np.nan for item in frame["A"]]
-    # Some mixed type data
-    frame["F"] = ["text" if item % 2 == 0 else np.nan for item in range(30)]
-
-    r_dataframe = convert_to_r_dataframe(frame)
-
-    assert np.array_equal(convert_robj(r_dataframe.rownames), frame.index)
-    assert np.array_equal(convert_robj(r_dataframe.colnames), frame.columns)
-    assert all(is_na(item) for item in r_dataframe.rx2("E"))
-
-    for column in frame[["A", "B", "C", "D"]]:
-        coldata = r_dataframe.rx2(column)
-        original_data = frame[column]
-        assert np.array_equal(convert_robj(coldata), original_data)
-
-    for column in frame[["D", "E"]]:
-        for original, converted in zip(frame[column],
-                                       r_dataframe.rx2(column)):
-
-            if pd.isnull(original):
-                assert is_na(converted)
-            else:
-                assert original == converted
-
-
-def test_convert_r_matrix():
-
-    is_na = robj.baseenv.get("is.na")
-
-    seriesd = _test.getSeriesData()
-    frame = pd.DataFrame(seriesd, columns=['D', 'C', 'B', 'A'])
-    # Null data
-    frame["E"] = [np.nan for item in frame["A"]]
-
-    r_dataframe = convert_to_r_matrix(frame)
-
-    assert np.array_equal(convert_robj(r_dataframe.rownames), frame.index)
-    assert np.array_equal(convert_robj(r_dataframe.colnames), frame.columns)
-    assert all(is_na(item) for item in r_dataframe.rx(True, "E"))
-
-    for column in frame[["A", "B", "C", "D"]]:
-        coldata = r_dataframe.rx(True, column)
-        original_data = frame[column]
-        assert np.array_equal(convert_robj(coldata),
-                              original_data)
-
-    # Pandas bug 1282
-    frame["F"] = ["text" if item % 2 == 0 else np.nan for item in range(30)]
-
-    # FIXME: Ugly, this whole module needs to be ported to nose/unittest
-    try:
-        wrong_matrix = convert_to_r_matrix(frame)
-    except TypeError:
-        pass
-    except Exception:
-        raise
 
 
 if __name__ == '__main__':

--- a/pandas/tests/test_rpy.py
+++ b/pandas/tests/test_rpy.py
@@ -28,7 +28,6 @@ class TestCommon(unittest.TestCase):
 
         tm.assert_dict_equal(converted, expected)
 
-
     def test_convert_frame(self):
         # built-in dataset
         df = r['faithful']
@@ -38,14 +37,12 @@ class TestCommon(unittest.TestCase):
         assert np.array_equal(converted.columns, ['eruptions', 'waiting'])
         assert np.array_equal(converted.index, np.arange(1, 273))
 
-
     def _test_matrix(self):
         r('mat <- matrix(rnorm(9), ncol=3)')
         r('colnames(mat) <- c("one", "two", "three")')
         r('rownames(mat) <- c("a", "b", "c")')
 
         return r['mat']
-
 
     def test_convert_matrix(self):
         mat = self._test_matrix()
@@ -54,7 +51,6 @@ class TestCommon(unittest.TestCase):
 
         assert np.array_equal(converted.index, ['a', 'b', 'c'])
         assert np.array_equal(converted.columns, ['one', 'two', 'three'])
-
 
     def test_convert_r_dataframe(self):
 
@@ -66,12 +62,15 @@ class TestCommon(unittest.TestCase):
         # Null data
         frame["E"] = [np.nan for item in frame["A"]]
         # Some mixed type data
-        frame["F"] = ["text" if item % 2 == 0 else np.nan for item in range(30)]
+        frame["F"] = ["text" if item %
+                      2 == 0 else np.nan for item in range(30)]
 
         r_dataframe = com.convert_to_r_dataframe(frame)
 
-        assert np.array_equal(com.convert_robj(r_dataframe.rownames), frame.index)
-        assert np.array_equal(com.convert_robj(r_dataframe.colnames), frame.columns)
+        assert np.array_equal(
+            com.convert_robj(r_dataframe.rownames), frame.index)
+        assert np.array_equal(
+            com.convert_robj(r_dataframe.colnames), frame.columns)
         assert all(is_na(item) for item in r_dataframe.rx2("E"))
 
         for column in frame[["A", "B", "C", "D"]]:
@@ -88,7 +87,6 @@ class TestCommon(unittest.TestCase):
                 else:
                     assert original == converted
 
-
     def test_convert_r_matrix(self):
 
         is_na = robj.baseenv.get("is.na")
@@ -100,8 +98,10 @@ class TestCommon(unittest.TestCase):
 
         r_dataframe = com.convert_to_r_matrix(frame)
 
-        assert np.array_equal(com.convert_robj(r_dataframe.rownames), frame.index)
-        assert np.array_equal(com.convert_robj(r_dataframe.colnames), frame.columns)
+        assert np.array_equal(
+            com.convert_robj(r_dataframe.rownames), frame.index)
+        assert np.array_equal(
+            com.convert_robj(r_dataframe.colnames), frame.columns)
         assert all(is_na(item) for item in r_dataframe.rx(True, "E"))
 
         for column in frame[["A", "B", "C", "D"]]:
@@ -111,7 +111,8 @@ class TestCommon(unittest.TestCase):
                                   original_data)
 
         # Pandas bug 1282
-        frame["F"] = ["text" if item % 2 == 0 else np.nan for item in range(30)]
+        frame["F"] = ["text" if item %
+                      2 == 0 else np.nan for item in range(30)]
 
         try:
             wrong_matrix = com.convert_to_r_matrix(frame)
@@ -119,7 +120,10 @@ class TestCommon(unittest.TestCase):
             pass
         except Exception:
             raise
-    
+
+    def test_eurodist(self):
+        df = com.load_data('eurodist')
+        print(df)
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
                    # '--with-coverage', '--cover-package=pandas.core'],

--- a/pandas/tests/test_rpy.py
+++ b/pandas/tests/test_rpy.py
@@ -77,8 +77,6 @@ class TestCommon(unittest.TestCase):
         for column in frame[["A", "B", "C", "D"]]:
             coldata = r_dataframe.rx2(column)
             original_data = frame[column]
-            print(com.convert_robj(coldata))
-            print(original_data)
             assert np.array_equal(com.convert_robj(coldata), original_data)
 
         for column in frame[["D", "E"]]:

--- a/pandas/tests/test_rpy.py
+++ b/pandas/tests/test_rpy.py
@@ -1,0 +1,128 @@
+"""
+Testing that functions from rpy work as expected
+"""
+
+import pandas as pd
+import numpy as np
+import unittest
+import nose
+import pandas.util.testing as tm
+import pandas.rpy.common as com
+from rpy2.robjects import r
+import rpy2.robjects as robj
+
+class TestCommon(unittest.TestCase):
+    def test_convert_list(self):
+        obj = r('list(a=1, b=2, c=3)')
+
+        converted = com.convert_robj(obj)
+        expected = {'a': [1], 'b': [2], 'c': [3]}
+
+        tm.assert_dict_equal(converted, expected)
+
+    def test_convert_nested_list(self):
+        obj = r('list(a=list(foo=1, bar=2))')
+
+        converted = com.convert_robj(obj)
+        expected = {'a': {'foo': [1], 'bar': [2]}}
+
+        tm.assert_dict_equal(converted, expected)
+
+
+    def test_convert_frame(self):
+        # built-in dataset
+        df = r['faithful']
+
+        converted = com.convert_robj(df)
+
+        assert np.array_equal(converted.columns, ['eruptions', 'waiting'])
+        assert np.array_equal(converted.index, np.arange(1, 273))
+
+
+    def _test_matrix(self):
+        r('mat <- matrix(rnorm(9), ncol=3)')
+        r('colnames(mat) <- c("one", "two", "three")')
+        r('rownames(mat) <- c("a", "b", "c")')
+
+        return r['mat']
+
+
+    def test_convert_matrix(self):
+        mat = self._test_matrix()
+
+        converted = com.convert_robj(mat)
+
+        assert np.array_equal(converted.index, ['a', 'b', 'c'])
+        assert np.array_equal(converted.columns, ['one', 'two', 'three'])
+
+
+    def test_convert_r_dataframe(self):
+
+        is_na = robj.baseenv.get("is.na")
+
+        seriesd = tm.getSeriesData()
+        frame = pd.DataFrame(seriesd, columns=['D', 'C', 'B', 'A'])
+
+        # Null data
+        frame["E"] = [np.nan for item in frame["A"]]
+        # Some mixed type data
+        frame["F"] = ["text" if item % 2 == 0 else np.nan for item in range(30)]
+
+        r_dataframe = com.convert_to_r_dataframe(frame)
+
+        assert np.array_equal(com.convert_robj(r_dataframe.rownames), frame.index)
+        assert np.array_equal(com.convert_robj(r_dataframe.colnames), frame.columns)
+        assert all(is_na(item) for item in r_dataframe.rx2("E"))
+
+        for column in frame[["A", "B", "C", "D"]]:
+            coldata = r_dataframe.rx2(column)
+            original_data = frame[column]
+            print(com.convert_robj(coldata))
+            print(original_data)
+            assert np.array_equal(com.convert_robj(coldata), original_data)
+
+        for column in frame[["D", "E"]]:
+            for original, converted in zip(frame[column],
+                                           r_dataframe.rx2(column)):
+
+                if pd.isnull(original):
+                    assert is_na(converted)
+                else:
+                    assert original == converted
+
+
+    def test_convert_r_matrix(self):
+
+        is_na = robj.baseenv.get("is.na")
+
+        seriesd = tm.getSeriesData()
+        frame = pd.DataFrame(seriesd, columns=['D', 'C', 'B', 'A'])
+        # Null data
+        frame["E"] = [np.nan for item in frame["A"]]
+
+        r_dataframe = com.convert_to_r_matrix(frame)
+
+        assert np.array_equal(com.convert_robj(r_dataframe.rownames), frame.index)
+        assert np.array_equal(com.convert_robj(r_dataframe.colnames), frame.columns)
+        assert all(is_na(item) for item in r_dataframe.rx(True, "E"))
+
+        for column in frame[["A", "B", "C", "D"]]:
+            coldata = r_dataframe.rx(True, column)
+            original_data = frame[column]
+            assert np.array_equal(com.convert_robj(coldata),
+                                  original_data)
+
+        # Pandas bug 1282
+        frame["F"] = ["text" if item % 2 == 0 else np.nan for item in range(30)]
+
+        try:
+            wrong_matrix = com.convert_to_r_matrix(frame)
+        except TypeError:
+            pass
+        except Exception:
+            raise
+    
+if __name__ == '__main__':
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   # '--with-coverage', '--cover-package=pandas.core'],
+                   exit=False)

--- a/pandas/tests/test_rpy.py
+++ b/pandas/tests/test_rpy.py
@@ -121,9 +121,59 @@ class TestCommon(unittest.TestCase):
         except Exception:
             raise
 
-    def test_eurodist(self):
-        df = com.load_data('eurodist')
-        print(df)
+    def test_dist(self):
+        for name in ('eurodist',):
+            df = com.load_data(name)
+            dist = r[name]
+            labels = r['labels'](dist)
+            assert np.array_equal(df.index, labels)
+            assert np.array_equal(df.columns, labels)
+
+
+    def test_timeseries(self):
+        """
+        Test that the series has an informative index.
+        Unfortunately the code currently does not build a DateTimeIndex
+        """
+        for name in (
+            'austres', 'co2', 'fdeaths', 'freeny.y', 'JohnsonJohnson',
+            'ldeaths', 'mdeaths', 'nottem', 'presidents', 'sunspot.month', 'sunspots',
+            'UKDriverDeaths', 'UKgas', 'USAccDeaths',
+            'airmiles', 'discoveries', 'EuStockMarkets', 
+            'LakeHuron', 'lh', 'lynx', 'nhtemp', 'Nile', 
+            'Seatbelts', 'sunspot.year', 'treering', 'uspop'):
+            series = com.load_data(name)
+            ts = r[name]
+            assert np.array_equal(series.index, r['time'](ts))
+
+    def test_numeric(self):
+        for name in ('euro', 'islands', 'precip'):
+            series = com.load_data(name)
+            numeric = r[name]
+            names = numeric.names
+            assert np.array_equal(series.index, names)            
+
+    def test_table(self):
+        # This test requires the r package 'reshape2' or 'reshape' to be installed
+        for name in ('HairEyeColor', 'Titanic', 'occupationalStatus'):
+            df = com.load_data(name)
+            table = r['melt'](r[name])
+            names = list(table.names)
+            assert np.array_equal(df.columns, names)
+
+    def test_array(self):
+        df = com.load_data('iris3')
+        assert not np.array_equal(df.index, range(len(df.index)))
+        
+    def test_factor(self):
+        for name in ('state.division', 'state.region'):
+            vector = r[name]
+            factors = list(r['factor'](vector))
+            level = list(r['levels'](vector))
+            factors = [level[index-1] for index in factors]
+            result = com.load_data(name)
+            assert np.equal(result, factors)
+        
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
                    # '--with-coverage', '--cover-package=pandas.core'],

--- a/pandas/tests/test_rpy.py
+++ b/pandas/tests/test_rpy.py
@@ -155,16 +155,43 @@ class TestCommon(unittest.TestCase):
 
     def test_table(self):
         # This test requires the r package 'reshape2' or 'reshape' to be installed
-        for name in ('HairEyeColor', 'Titanic'):
+        iris3 = pd.DataFrame({'X0': {0: '0', 1: '1', 2: '2', 3: '3', 4: '4'},
+                 'X1': {0: 'Sepal L.',
+                        1: 'Sepal L.',
+                        2: 'Sepal L.',
+                        3: 'Sepal L.',
+                        4: 'Sepal L.'},
+                 'X2': {0: 'Setosa',
+                        1: 'Setosa',
+                        2: 'Setosa',
+                        3: 'Setosa',
+                        4: 'Setosa'},
+                 'value': {0: '5.1', 1: '4.9', 2: '4.7', 3: '4.6', 4: '5.0'}})
+        hec = pd.DataFrame(
+            {'Eye': {0: 'Brown', 1: 'Brown', 2: 'Brown', 3: 'Brown', 4: 'Blue'},
+             'Hair': {0: 'Black', 1: 'Brown', 2: 'Red', 3: 'Blond', 4: 'Black'},
+             'Sex': {0: 'Male', 1: 'Male', 2: 'Male', 3: 'Male', 4: 'Male'},
+             'value': {0: '32.0', 1: '53.0', 2: '10.0', 3: '3.0', 4: '11.0'}})
+        titanic = pd.DataFrame(
+            {'Age': {0: 'Child', 1: 'Child', 2: 'Child', 3: 'Child', 4: 'Child'},
+             'Class': {0: '1st', 1: '2nd', 2: '3rd', 3: 'Crew', 4: '1st'},
+             'Sex': {0: 'Male', 1: 'Male', 2: 'Male', 3: 'Male', 4: 'Female'},
+             'Survived': {0: 'No', 1: 'No', 2: 'No', 3: 'No', 4: 'No'},
+             'value': {0: '0.0', 1: '0.0', 2: '35.0', 3: '0.0', 4: '0.0'}})
+        for name, expected in zip(('HairEyeColor', 'Titanic', 'iris3'),
+                                (hec, titanic, iris3)):
             df = com.load_data(name)
-            table = r['melt'](r[name])
-            names = list(table.names)
-            assert np.array_equal(df.columns, names)
-
-    def test_array(self):
-        df = com.load_data('iris3')
-        assert not np.array_equal(df.index, range(len(df.index)))
-        
+            table = r[name]
+            names = r['dimnames'](table)
+            try:
+                columns = list(r['names'](names))[::-1]
+            except TypeError:
+                columns = ['X{:d}'.format(i) for i in range(len(names))][::-1]
+            columns.append('value')
+            assert np.array_equal(df.columns, columns)
+            result = df.head()
+            cond = ((result.sort(axis=1) == expected.sort(axis=1))).values
+            assert np.all(cond)
     def test_factor(self):
         for name in ('state.division', 'state.region'):
             vector = r[name]

--- a/pandas/tests/test_rpy.py
+++ b/pandas/tests/test_rpy.py
@@ -155,7 +155,7 @@ class TestCommon(unittest.TestCase):
 
     def test_table(self):
         # This test requires the r package 'reshape2' or 'reshape' to be installed
-        for name in ('HairEyeColor', 'Titanic', 'occupationalStatus'):
+        for name in ('HairEyeColor', 'Titanic'):
             df = com.load_data(name)
             table = r['melt'](r[name])
             names = list(table.names)

--- a/pandas/tests/test_rpy.py
+++ b/pandas/tests/test_rpy.py
@@ -7,9 +7,14 @@ import numpy as np
 import unittest
 import nose
 import pandas.util.testing as tm
-import pandas.rpy.common as com
-from rpy2.robjects import r
-import rpy2.robjects as robj
+
+try:
+    import pandas.rpy.common as com
+    from rpy2.robjects import r
+    import rpy2.robjects as robj
+except ImportError:
+    raise nose.SkipTest
+
 
 class TestCommon(unittest.TestCase):
     def test_convert_list(self):


### PR DESCRIPTION
Motivation for this pull request came from this problem: http://stackoverflow.com/q/19039356/190597.

The problems:
- `pandas.rpy.common.load_data`  currently fails to load high-dimensional arrays such as the "Titanic" dataset. `load_data` prints an error to stdout and returns None.
- Applying `load_data` to "iris3", "state.division" or "state.region" R datasets currently raise a TypeError.
- Timeseries R data is currently converted to lists that lack a time series index.
- Factor data is  converted to a list of index numbers without any levels information.

This pull request:
- Provides code which allows `load_data` to convert the "Titanic" dataset (and similar high-dimensional arrays) to "melted" DataFrames. The code _does not_ use R's melt function, since that would introduce a new dependency.
- load_data now returns a DataFrame for arrays like "iris3".
- load_data converts R factors like "state.division" and "state.region" to lists which use the levels as values.
- load_data converts ts (timeseries) R data, like "airmiles" to Series with an index showing the times. Note however I wasn't able to convert the index to a DatetimeIndex since the same code is used to convert numeric R data (like "euro") which does not have a time-related index.
- moves already existant tests from rpy/common.py to tests/test_rpy.py
- adds new unit tests which highlight the problems mentioned above, and tests for what I think is more desireable behavior as described above.
