### PR TITLE
ENH/DOC: Cleanup docstrings on NDFrame

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -26,7 +26,7 @@ from pandas.core.common import (isnull, notnull, PandasError, _try_sort,
                                 _default_index, _maybe_upcast, _is_sequence,
                                 _infer_dtype_from_scalar, _values_from_object,
                                 _coerce_to_dtypes, _DATELIKE_DTYPES, is_list_like)
-from pandas.core.generic import NDFrame
+from pandas.core.generic import NDFrame, _shared_docs
 from pandas.core.index import Index, MultiIndex, _ensure_index
 from pandas.core.indexing import (_maybe_droplevels,
                                   _convert_to_index_sliceable,
@@ -62,6 +62,9 @@ from pandas.core.config import get_option
 #----------------------------------------------------------------------
 # Docstring templates
 
+_shared_doc_kwargs = dict(axes='index, columns',
+                           klass='DataFrame',
+                           axes_single_arg="{0,1,'index','columns'}")
 
 _numeric_only_doc = """numeric_only : boolean, default None
     Include only float, int, boolean data. If None, will attempt to use
@@ -1380,6 +1383,7 @@ class DataFrame(NDFrame):
         return self.apply(lambda x: x.ftype, reduce=False)
 
     def transpose(self):
+        """Transpose index and columns"""
         return super(DataFrame, self).transpose(1, 0)
 
     T = property(transpose)
@@ -2156,6 +2160,24 @@ class DataFrame(NDFrame):
         else:
             return self._reindex_with_indexers({0: [new_index,   row_indexer],
                                                 1: [new_columns, col_indexer]}, copy=copy, fill_value=fill_value)
+
+    @Appender(_shared_docs['reindex'] % _shared_doc_kwargs)
+    def reindex(self, index=None, columns=None, **kwargs):
+        return super(DataFrame, self).reindex(index=index, columns=columns,
+                                              **kwargs)
+
+    @Appender(_shared_docs['reindex_axis'] % _shared_doc_kwargs)
+    def reindex_axis(self, labels, axis=0, method=None, level=None, copy=True,
+                     limit=None, fill_value=np.nan):
+        return super(DataFrame, self).reindex_axis(labels=labels, axis=axis,
+                                                   method=method, level=level,
+                                                   copy=copy, limit=limit,
+                                                   fill_value=fill_value)
+
+    @Appender(_shared_docs['rename'] % _shared_doc_kwargs)
+    def rename(self, index=None, columns=None, **kwargs):
+        return super(DataFrame, self).rename(index=index, columns=columns,
+                                             **kwargs)
 
     def reindex_like(self, other, method=None, copy=True, limit=None,
                      fill_value=NA):

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -18,13 +18,22 @@ from pandas.core.internals import (BlockManager,
                                    create_block_manager_from_arrays,
                                    create_block_manager_from_blocks)
 from pandas.core.frame import DataFrame
-from pandas.core.generic import NDFrame
+from pandas.core.generic import NDFrame, _shared_docs
 from pandas import compat
 from pandas.util.decorators import deprecate, Appender, Substitution
 import pandas.core.common as com
 import pandas.core.ops as ops
 import pandas.core.nanops as nanops
 import pandas.computation.expressions as expressions
+
+
+_shared_doc_kwargs = dict(
+    axes='items, major_axis, minor_axis',
+    klass="Panel",
+    axes_single_arg="{0,1,2,'items','major_axis','minor_axis'}")
+_shared_doc_kwargs['args_transpose'] = ("three positional arguments: each one"
+                                        "of\n        %s" %
+                                        _shared_doc_kwargs['axes_single_arg'])
 
 
 def _ensure_like_indices(time, panels):
@@ -870,6 +879,31 @@ class Panel(NDFrame):
             result = result.T
 
         return self._construct_return_type(result, axes)
+
+    @Appender(_shared_docs['reindex'] % _shared_doc_kwargs)
+    def reindex(self, items=None, major_axis=None, minor_axis=None, **kwargs):
+        major_axis = major_axis if major_axis is not None else kwargs.pop('major', None)
+        minor_axis = minor_axis if minor_axis is not None else kwargs.pop('minor', None)
+        return super(Panel, self).reindex(items=items, major_axis=major_axis,
+                                          minor_axis=minor_axis, **kwargs)
+
+    @Appender(_shared_docs['rename'] % _shared_doc_kwargs)
+    def rename(self, items=None, major_axis=None, minor_axis=None, **kwargs):
+        major_axis = major_axis if major_axis is not None else kwargs.pop('major', None)
+        minor_axis = minor_axis if minor_axis is not None else kwargs.pop('minor', None)
+        return super(Panel, self).rename(items=items, major_axis=major_axis,
+                                         minor_axis=minor_axis, **kwargs)
+
+    @Appender(_shared_docs['reindex_axis'] % _shared_doc_kwargs)
+    def reindex_axis(self, labels, axis=0, method=None, level=None, copy=True,
+                     limit=None, fill_value=np.nan):
+        return super(Panel, self).reindex_axis(labels=labels, axis=axis,
+                                               method=method, level=level,
+                                               copy=copy, limit=limit,
+                                               fill_value=fill_value)
+    @Appender(_shared_docs['transpose'] % _shared_doc_kwargs)
+    def transpose(self, *args, **kwargs):
+        return super(Panel, self).transpose(*args, **kwargs)
 
     def count(self, axis='major'):
         """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -53,6 +53,11 @@ from pandas.core.config import get_option
 
 __all__ = ['Series']
 
+_shared_doc_kwargs = dict(
+    axes='index',
+    klass='Series',
+    axes_single_arg="{0,'index'}"
+)
 
 def _coerce_method(converter):
     """ install the scalar coercion methods """
@@ -1976,6 +1981,14 @@ class Series(generic.NDFrame):
     def _needs_reindex_multi(self, axes, method, level):
         """ check if we do need a multi reindex; this is for compat with higher dims """
         return False
+
+    @Appender(generic._shared_docs['reindex'] % _shared_doc_kwargs)
+    def rename(self, index=None, **kwargs):
+        return super(Series, self).rename(index=index, **kwargs)
+
+    @Appender(generic._shared_docs['reindex'] % _shared_doc_kwargs)
+    def reindex(self, index=None, **kwargs):
+        return super(Series, self).reindex(index=index, **kwargs)
 
     def reindex_axis(self, labels, axis=0, **kwargs):
         """ for compatibility with higher dims """


### PR DESCRIPTION
Resolves much of #4717. Basically cleans up docstrings in a few places
plus, for the few functions that need them, uses a shared dict of
function definitions to share them. This has the side-benefit of letting
the function docstrings reside right next to the functions themselves,
maintaining readability.
