### PR TITLE
BUG: fix Index's __iadd__ methods

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -214,6 +214,7 @@ API Changes
       data - allowing metadata changes.
     - ``MultiIndex.astype()`` now only allows ``np.object_``-like dtypes and
       now returns a ``MultiIndex`` rather than an ``Index``. (:issue:`4039`)
+    - Aliased ``__iadd__`` to ``__add__``. (:issue:`4996`)
    - Added ``is_`` method to ``Index`` that allows fast equality comparison of
      views (similar to ``np.may_share_memory`` but no false positives, and
      changes on ``levels`` and ``labels`` setting on ``MultiIndex``).

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -832,6 +832,7 @@ class Index(FrozenNDArray):
         else:
             return Index(self.view(np.ndarray) + other)
 
+    __iadd__ = __add__
     __eq__ = _indexOp('__eq__')
     __ne__ = _indexOp('__ne__')
     __lt__ = _indexOp('__lt__')

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -382,6 +382,14 @@ class TestIndex(unittest.TestCase):
         self.assert_('a' not in index2)
         self.assert_('afoo' in index2)
 
+    def test_iadd_string(self):
+        index = pd.Index(['a', 'b', 'c'])
+        # doesn't fail test unless there is a check before `+=`
+        self.assert_('a' in index)
+
+        index += '_x'
+        self.assert_('a_x' in index)
+
     def test_diff(self):
         first = self.strIndex[5:20]
         second = self.strIndex[:10]


### PR DESCRIPTION
closes #4996

Aliases **iadd** = **add**.

Not doing anything else for now until time to consider.
