### PR TITLE
VIS: let scatter plots obey mpl color scheme (#3338)

### DIFF
--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -229,6 +229,7 @@ def scatter_matrix(frame, alpha=0.5, figsize=None, ax=None, grid=False,
     >>> df = DataFrame(np.random.randn(1000, 4), columns=['A','B','C','D'])
     >>> scatter_matrix(df, alpha=0.2)
     """
+    import matplotlib.pyplot as plt
     from matplotlib.artist import setp
 
     df = frame._get_numeric_data()
@@ -245,6 +246,9 @@ def scatter_matrix(frame, alpha=0.5, figsize=None, ax=None, grid=False,
 
     hist_kwds = hist_kwds or {}
     density_kwds = density_kwds or {}
+
+    # workaround because `c='b'` is hardcoded in matplotlibs scatter method
+    kwds.setdefault('c', plt.rcParams['patch.facecolor'])
 
     for i, a in zip(lrange(n), df.columns):
         for j, b in zip(lrange(n), df.columns):
@@ -653,6 +657,10 @@ def lag_plot(series, lag=1, ax=None, **kwds):
     ax: Matplotlib axis object
     """
     import matplotlib.pyplot as plt
+    
+    # workaround because `c='b'` is hardcoded in matplotlibs scatter method
+    kwds.setdefault('c', plt.rcParams['patch.facecolor'])
+    
     data = series.values
     y1 = data[:-lag]
     y2 = data[lag:]
@@ -1888,6 +1896,9 @@ def scatter_plot(data, x, y, by=None, ax=None, figsize=None, grid=False, **kwarg
     fig : matplotlib.Figure
     """
     import matplotlib.pyplot as plt
+
+    # workaround because `c='b'` is hardcoded in matplotlibs scatter method
+    kwargs.setdefault('c', plt.rcParams['patch.facecolor'])
 
     def plot_group(group, ax):
         xvals = group[x].values


### PR DESCRIPTION
Closes #3338.

Fixes the remaining plot functions that don't follow the matplotlib style (functions based on scatter plots).

Rationale:
- set the color keyword `c` to default one defined in matplotlibs rcParams if `c` was not specified by the user (because `c='b'` is harcoded in matplotlib `scatter` method).
- the `color` keyword is not checked because, if specified by the user, it already is given preference by matplotlib over `c` if both are given.

There is a new PR on scatter based plotting methods (#3473), but I suppose that it can be handled in that PR to ensure this new plotting method also follows this approach?
