### PR TITLE
BUG: Make Index, Int64Index and MI repr evalable

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -175,4 +175,4 @@ class FrozenNDArray(PandasObject, np.ndarray):
         Invoked by unicode(df) in py2 only. Yields a Unicode String in both py2/py3.
         """
         prepr = com.pprint_thing(self, escape_chars=('\t', '\r', '\n'),quote_strings=True)
-        return '%s(%s, dtype=%s)' % (type(self).__name__, prepr, self.dtype)
+        return "%s(%s, dtype='%s')" % (type(self).__name__, prepr, self.dtype)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -2044,7 +2044,7 @@ class MultiIndex(Index):
             attrs.append(('sortorder', default_pprint(self.sortorder)))
 
         space = ' ' * (len(self.__class__.__name__) + 1)
-        prepr = (u("\n%s") % space).join([u("%s=%s") % (k, v)
+        prepr = (u(",\n%s") % space).join([u("%s=%s") % (k, v)
                                           for k, v in attrs])
         res = u("%s(%s)") % (self.__class__.__name__, prepr)
 

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -1456,7 +1456,7 @@ c  10  11  12  13  14\
             <table border="1" class="dataframe sortable draggable">
               <tbody>
                 <tr>
-                  <td>Index([], dtype=object)</td>
+                  <td>Index([], dtype='object')</td>
                   <td>Empty DataFrame</td>
                 </tr>
               </tbody>

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -36,21 +36,23 @@ class TestIndex(unittest.TestCase):
     _multiprocess_can_split_ = True
 
     def setUp(self):
-        self.unicodeIndex = tm.makeUnicodeIndex(100)
-        self.strIndex = tm.makeStringIndex(100)
-        self.dateIndex = tm.makeDateIndex(100)
-        self.intIndex = tm.makeIntIndex(100)
-        self.floatIndex = tm.makeFloatIndex(100)
-        self.empty = Index([])
-        self.tuples = Index(lzip(['foo', 'bar', 'baz'], [1, 2, 3]))
+        self.indices = dict(
+            unicodeIndex = tm.makeUnicodeIndex(100),
+            strIndex = tm.makeStringIndex(100),
+            dateIndex = tm.makeDateIndex(100),
+            intIndex = tm.makeIntIndex(100),
+            floatIndex = tm.makeFloatIndex(100),
+            empty = Index([]),
+            tuples = Index(lzip(['foo', 'bar', 'baz'], [1, 2, 3])),
+        )
+        for name, ind in self.indices.items():
+            setattr(self, name, ind)
 
     def test_wrong_number_names(self):
         def testit(ind):
             ind.names = ["apple", "banana", "carrot"]
 
-        indices = (self.dateIndex, self.unicodeIndex, self.strIndex,
-                   self.intIndex, self.floatIndex, self.empty, self.tuples)
-        for ind in indices:
+        for ind in self.indices.values():
             assertRaisesRegexp(ValueError, "^Length", testit, ind)
 
     def test_set_name_methods(self):
@@ -700,6 +702,10 @@ class TestFloat64Index(unittest.TestCase):
                                    type(self.float).__name__):
             hash(self.float)
 
+    def test_repr_roundtrip(self):
+        for ind in (self.mixed, self.float):
+            tm.assert_index_equal(eval(repr(ind)), ind)
+
     def check_is_index(self, i):
         self.assert_(isinstance(i, Index) and not isinstance(i, Float64Index))
 
@@ -1166,6 +1172,9 @@ class TestInt64Index(unittest.TestCase):
             r = repr(pd.Index(np.arange(1000)))
             self.assertTrue(len(r) < 100)
             self.assertTrue("..." in r)
+
+    def test_repr_roundtrip(self):
+        tm.assert_index_equal(eval(repr(self.index)), self.index)
 
     def test_unicode_string_with_unicode(self):
         idx = Index(lrange(1000))
@@ -2290,6 +2299,9 @@ class TestMultiIndex(unittest.TestCase):
             d = {"a": [u("\u05d0"), 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]}
             index = pd.DataFrame(d).set_index(["a", "b"]).index
             self.assertFalse("\\u" in repr(index))  # we don't want unicode-escaped
+
+    def test_repr_roundtrip(self):
+        tm.assert_index_equal(eval(repr(self.index)), self.index)
 
     def test_unicode_string_with_unicode(self):
         d = {"a": [u("\u05d0"), 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]}


### PR DESCRIPTION
MI repr was missing a comma between its arguments and Index reprs needed
to quote their dtypes.

Only talking about Index, Int64Index and
MultiIndex. Tseries indices (like PeriodIndex and DatetimeIndex) are
more complicated and could be covered separately.
