### PR TITLE
CLN: Remove internal classes from MultiIndex pickle.

### DIFF
--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -2458,8 +2458,9 @@ class MultiIndex(Index):
     def __reduce__(self):
         """Necessary for making this object picklable"""
         object_state = list(np.ndarray.__reduce__(self))
-        subclass_state = (list(self.levels), list(
-            self.labels), self.sortorder, list(self.names))
+        subclass_state = ([lev.view(np.ndarray) for lev in self.levels],
+                          [label.view(np.ndarray) for label in self.labels],
+                          self.sortorder, list(self.names))
         object_state[2] = (object_state[2], subclass_state)
         return tuple(object_state)
 


### PR DESCRIPTION
FrozenNDArray had made it into the MI pickle. No reason to do that and just
complicates pickle compat going forward. Now they just output ndarray
instead (which also avoids the unnecessary nested pickle previously
occurring).

Fixes #5076.
