### PR TITLE
BUG: read_html should convert array skiprows into a list

### DIFF
--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -90,8 +90,10 @@ def _get_skiprows(skiprows):
     """
     if isinstance(skiprows, slice):
         return lrange(skiprows.start or 0, skiprows.stop, skiprows.step or 1)
-    elif isinstance(skiprows, numbers.Integral) or com.is_list_like(skiprows):
+    elif isinstance(skiprows, numbers.Integral):
         return skiprows
+    elif com.is_list_like(skiprows):
+        return list(skiprows)
     elif skiprows is None:
         return 0
     raise TypeError('%r is not a valid type for skipping rows' %


### PR DESCRIPTION
not sure why this is only showing up here, but it should be converted to a `list` anyway:

https://travis-ci.org/cpcloud/pandas/jobs/12117482
