### PR TITLE
CLN: clean up parser options

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -564,6 +564,8 @@ Bug Fixes
   - Fixed a bug where ``groupby.plot()`` and friends were duplicating figures
     multiple times (:issue:`5102`).
   - Provide automatic conversion of ``object`` dtypes on fillna, related (:issue:`5103`)
+  - Fixed a bug where default options were being overwritten in the option
+    parser cleaning (:issue:`5121`).
 
 
 pandas 0.12.0

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2,11 +2,10 @@
 Module contains tools for processing files into DataFrames or other objects
 """
 from __future__ import print_function
-from pandas.compat import range, lrange, StringIO, lzip, zip, string_types
+from pandas.compat import range, lrange, StringIO, lzip, zip, string_types, map
 from pandas import compat
 import re
 import csv
-from warnings import warn
 
 import numpy as np
 
@@ -266,7 +265,6 @@ _c_parser_defaults = {
     'buffer_lines': None,
     'error_bad_lines': True,
     'warn_bad_lines': True,
-    'factorize': True,
     'dtype': None,
     'decimal': b'.'
 }
@@ -340,8 +338,7 @@ def _make_parser_function(name, sep=','):
                  encoding=None,
                  squeeze=False,
                  mangle_dupe_cols=True,
-                 tupleize_cols=False,
-                 factorize=True):
+                 tupleize_cols=False):
 
         # Alias sep -> delimiter.
         if delimiter is None:
@@ -400,8 +397,7 @@ def _make_parser_function(name, sep=','):
                     low_memory=low_memory,
                     buffer_lines=buffer_lines,
                     mangle_dupe_cols=mangle_dupe_cols,
-                    tupleize_cols=tupleize_cols,
-                    factorize=factorize)
+                    tupleize_cols=tupleize_cols)
 
         return _read(filepath_or_buffer, kwds)
 
@@ -680,7 +676,7 @@ class ParserBase(object):
                 is_sequence = isinstance(self.index_col, (list, tuple,
                                                           np.ndarray))
                 if not (is_sequence and
-                        all(com.is_integer(i) for i in self.index_col) or
+                        all(map(com.is_integer, self.index_col)) or
                         com.is_integer(self.index_col)):
                     raise ValueError("index_col must only contain row numbers "
                                      "when specifying a multi-index header")

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -341,7 +341,7 @@ def _make_parser_function(name, sep=','):
                  squeeze=False,
                  mangle_dupe_cols=True,
                  tupleize_cols=False,
-                 ):
+                 factorize=True):
 
         # Alias sep -> delimiter.
         if delimiter is None:
@@ -401,7 +401,7 @@ def _make_parser_function(name, sep=','):
                     buffer_lines=buffer_lines,
                     mangle_dupe_cols=mangle_dupe_cols,
                     tupleize_cols=tupleize_cols,
-            )
+                    factorize=factorize)
 
         return _read(filepath_or_buffer, kwds)
 
@@ -490,27 +490,24 @@ class TextFileReader(object):
         kwds = self.orig_options
 
         options = {}
-        for argname, default in compat.iteritems(_parser_defaults):
-            if argname in kwds:
-                value = kwds[argname]
-            else:
-                value = default
 
-            options[argname] = value
+        for argname, default in compat.iteritems(_parser_defaults):
+            options[argname] = kwds.get(argname, default)
 
         for argname, default in compat.iteritems(_c_parser_defaults):
             if argname in kwds:
                 value = kwds[argname]
+
                 if engine != 'c' and value != default:
-                    raise ValueError('%s is not supported with %s parser' %
-                                     (argname, engine))
+                    raise ValueError('The %r option is not supported with the'
+                                     ' %r engine' % (argname, engine))
+            else:
+                value = default
             options[argname] = value
 
         if engine == 'python-fwf':
             for argname, default in compat.iteritems(_fwf_defaults):
-                if argname in kwds:
-                    value = kwds[argname]
-                options[argname] = value
+                options[argname] = kwds.get(argname, default)
 
         return options
 
@@ -518,7 +515,9 @@ class TextFileReader(object):
         result = options.copy()
 
         sep = options['delimiter']
-        if (sep is None and not options['delim_whitespace']):
+        delim_whitespace = options['delim_whitespace']
+
+        if sep is None and not delim_whitespace:
             if engine == 'c':
                 print('Using Python parser to sniff delimiter')
                 engine = 'python'
@@ -667,21 +666,24 @@ class ParserBase(object):
         self.header = kwds.get('header')
         if isinstance(self.header,(list,tuple,np.ndarray)):
             if kwds.get('as_recarray'):
-                raise Exception("cannot specify as_recarray when "
-                                "specifying a multi-index header")
+                raise ValueError("cannot specify as_recarray when "
+                                 "specifying a multi-index header")
             if kwds.get('usecols'):
-                raise Exception("cannot specify usecols when "
-                                "specifying a multi-index header")
+                raise ValueError("cannot specify usecols when "
+                                 "specifying a multi-index header")
             if kwds.get('names'):
-                raise Exception("cannot specify names when "
-                                "specifying a multi-index header")
+                raise ValueError("cannot specify names when "
+                                 "specifying a multi-index header")
 
             # validate index_col that only contains integers
             if self.index_col is not None:
-                if not (isinstance(self.index_col,(list,tuple,np.ndarray)) and all(
-                        [ com.is_integer(i) for i in self.index_col ]) or com.is_integer(self.index_col)):
-                    raise Exception("index_col must only contain row numbers "
-                                    "when specifying a multi-index header")
+                is_sequence = isinstance(self.index_col, (list, tuple,
+                                                          np.ndarray))
+                if not (is_sequence and
+                        all(com.is_integer(i) for i in self.index_col) or
+                        com.is_integer(self.index_col)):
+                    raise ValueError("index_col must only contain row numbers "
+                                     "when specifying a multi-index header")
 
         self._name_processed = False
 

--- a/pandas/parser.pyx
+++ b/pandas/parser.pyx
@@ -237,7 +237,7 @@ cdef class TextReader:
     cdef:
         parser_t *parser
         object file_handle, na_fvalues
-        bint factorize, na_filter, verbose, has_usecols, has_mi_columns
+        bint na_filter, verbose, has_usecols, has_mi_columns
         int parser_start
         list clocks
         char *c_encoding
@@ -276,7 +276,6 @@ cdef class TextReader:
 
                   converters=None,
 
-                  factorize=True,
                   as_recarray=False,
 
                   skipinitialspace=False,
@@ -337,8 +336,6 @@ cdef class TextReader:
             if len(delimiter) > 1:
                 raise ValueError('only length-1 separators excluded right now')
             self.parser.delimiter = ord(delimiter)
-
-        self.factorize = factorize
 
         #----------------------------------------
         # parser options


### PR DESCRIPTION
Also add a test to make sure that the C parser options validation is actually 
covered

example travis fail:

https://travis-ci.org/pydata/pandas/jobs/12171563

explanation (for the record):

if you print out `options` before this commit you'll see that they are all overwritten with a single value. Whatever this value is will depend on how the `_parser_defaults` dictionary happens to be ordered (which is random because of hashing). 

This caused a bug because the value of `value` is retained from the loop over `_parser_defaults`, and `default` is _not_ reassigned in the two loops that follow the loop over `_parser_defaults`, so all the values end up being the same as the last argument that was iterated over from `_parser_defaults`.

magic explained :tada: 
