### PR TITLE
add test for indexing with integer arrays

### DIFF
--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -15,7 +15,8 @@ import pandas.core.common as com
 from pandas.core.api import (DataFrame, Index, Series, Panel, notnull, isnull,
                              MultiIndex, DatetimeIndex, Float64Index, Timestamp)
 from pandas.util.testing import (assert_almost_equal, assert_series_equal,
-                                 assert_frame_equal, assert_panel_equal)
+                                 assert_frame_equal, assert_panel_equal,
+                                 assert_isinstance)
 from pandas import compat, concat
 
 import pandas.util.testing as tm
@@ -1840,6 +1841,16 @@ class TestIndexing(unittest.TestCase):
         #self.assertRaises(TypeError, lambda : s.iloc[2.0:5])
         #self.assertRaises(TypeError, lambda : s.iloc[2.0:5.0])
         #self.assertRaises(TypeError, lambda : s.iloc[2:5.0])
+
+    def test_array_indexing(self):
+        """test that array indexing returns a sequence by calling len()"""
+        column = Series(np.arange(10))
+        indices = np.arange(5, 10)
+        assert_isinstance(column.iloc[indices], Series)
+        indices = np.array([5], dtype = int)
+        assert_isinstance(column.iloc[indices], Series)
+        indices = np.array([], dtype = int)
+        assert_isinstance(column.iloc[indices], Series)
 
 
 if __name__ == '__main__':

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -167,7 +167,7 @@ def assert_isinstance(obj, class_type_or_tuple):
     """asserts that obj is an instance of class_type_or_tuple"""
     assert isinstance(obj, class_type_or_tuple), (
         "Expected object to be of type %r, found %r instead" % (
-            type(obj), class_type_or_tuple))
+            class_type_or_tuple, type(obj)))
 
 def assert_equal(a, b, msg=""):
     """asserts that a equals b, like nose's assert_equal, but allows custom message to start.


### PR DESCRIPTION
I had a try at solving issue #5006, but it does not look as trivial to me as @jreback suggested. ;-)

I added a test for indexing with int-typed arrays containing single indices, which currently fails.  I spent some time reading test_indexing, because my hunch is that it could be better integrated with the existing tests (e.g. using check_result), but anyhow - any test is better than none, I guess.

The failing test goes through `_iLocIndexer._getitem_axis()` -> `_NDFrameIndexer._get_loc()` -> `Series._ixs()` -> `index.get_value_at()` -> `util.get_value_at()`, but I don't see the point where that should've been different right now.

Sorry, but I lack time for solving this at the moment.
