### PR TITLE
ENH: Support for PyExcelerate as an Excel writer engine.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,8 @@ before_install:
 install:
   - echo "Waldo2"
   - ci/install.sh
-  - pip install git+git://github.com/jmcnamara/PyExcelerate@pandas
+  # Temp testing measure while waiting for PyPi release.
+  - pip install git+git://github.com:kz26/PyExcelerate.git
 
 before_script:
   - mysql -e 'create database pandas_nosetest;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ before_install:
 install:
   - echo "Waldo2"
   - ci/install.sh
+  - pip install git+git://github.com/jmcnamara/PyExcelerate@pandas
 
 before_script:
   - mysql -e 'create database pandas_nosetest;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - echo "Waldo2"
   - ci/install.sh
   # Temp testing measure while waiting for PyPi release.
-  - pip install git+git://github.com:kz26/PyExcelerate.git
+  - pip install git+git://github.com/kz26/PyExcelerate.git
 
 before_script:
   - mysql -e 'create database pandas_nosetest;'

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -101,8 +101,8 @@ Optional Dependencies
   * `openpyxl <http://packages.python.org/openpyxl/>`__, `xlrd/xlwt <http://www.python-excel.org/>`__
      * openpyxl version 1.6.1 or higher
      * Needed for Excel I/O
-  * `XlsxWriter <https://pypi.python.org/pypi/XlsxWriter>`__
-     * Alternative Excel writer.
+  * `XlsxWriter <http://pypi.python.org/pypi/XlsxWriter>`__, `PyExcelerate <http://pypi.python.org/pypi/PyExcelerate>`__
+     * Alternative Excel writers.
   * `boto <https://pypi.python.org/pypi/boto>`__: necessary for Amazon S3
     access.
   * One of `PyQt4

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -136,6 +136,8 @@ Improvements to existing features
   - Added XlsxWriter as an optional ``ExcelWriter``  engine. This is about 5x
     faster than the default openpyxl xlsx writer and is equivalent in speed
     to the xlwt xls writer module. (:issue:`4542`)
+  - Added PyExcelerate as an optional ``ExcelWriter``  engine. This is about
+    14x faster than the default openpyxl xlsx writer.
   - allow DataFrame constructor to accept more list-like objects, e.g. list of
     ``collections.Sequence`` and ``array.Array`` objects (:issue:`3783`,
     :issue:`4297`, :issue:`4851`), thanks @lgautier

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -779,6 +779,9 @@ class _PyExcelerate(ExcelWriter):
         for cell in cells:
             val = _conv_value(cell.val)
 
+            if isinstance(cell.val, datetime.date):
+                val = datetime.datetime.fromordinal(val.toordinal())
+
             if cell.mergestart is not None and cell.mergeend is not None:
 #                 wks.merge_range(startrow + cell.row,
 #                                 startrow + cell.mergestart,

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -745,3 +745,51 @@ class _XlsxWriter(ExcelWriter):
         return xl_format
 
 register_writer(_XlsxWriter)
+
+
+class _PyExcelerate(ExcelWriter):
+    engine = 'pyexcelerate'
+    supported_extensions = ('.xlsx',)
+
+    def __init__(self, path, **engine_kwargs):
+        # Use the pyexcelerate module as the Excel writer.
+        import pyexcelerate
+
+        super(_PyExcelerate, self).__init__(path, **engine_kwargs)
+
+        self.book = pyexcelerate.Workbook(path, **engine_kwargs)
+
+    def save(self):
+        """
+        Save workbook to disk.
+        """
+        return self.book.save(self.path)
+
+    def write_cells(self, cells, sheet_name=None, startrow=0, startcol=0):
+        # Write the frame cells using pyexcelerate.
+
+        sheet_name = self._get_sheet_name(sheet_name)
+
+        if sheet_name in self.sheets:
+            wks = self.sheets[sheet_name]
+        else:
+            wks = self.book.new_sheet(sheet_name)
+            self.sheets[sheet_name] = wks
+
+        for cell in cells:
+            val = _conv_value(cell.val)
+
+            if cell.mergestart is not None and cell.mergeend is not None:
+#                 wks.merge_range(startrow + cell.row,
+#                                 startrow + cell.mergestart,
+#                                 startcol + cell.col,
+#                                 startcol + cell.mergeend,
+#                                 val, style)
+                pass
+            else:
+                # wks[startrow + cell.row][startcol + cell.col] = val
+                wks[1 + startrow + cell.row][1 + startcol + cell.col] = val
+
+
+register_writer(_PyExcelerate)
+

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -790,8 +790,9 @@ class _PyExcelerate(ExcelWriter):
 #                                 val, style)
                 pass
             else:
-                # wks[startrow + cell.row][startcol + cell.col] = val
-                wks[1 + startrow + cell.row][1 + startcol + cell.col] = val
+                wks.set_cell_value(1 + startrow + cell.row,
+                                   1 + startcol + cell.col,
+                                   val)
 
 
 register_writer(_PyExcelerate)

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -1004,22 +1004,6 @@ class PyExcelerateTests(ExcelWriterBase, unittest.TestCase):
             frame.index.names = ['test']
             self.assertAlmostEqual(frame.index.names, recons.index.names)
 
-    # TODO: Skip these tests until the pyexcelerator date issue is fixed.
-    def test_excel_roundtrip_datetime(self):
-        raise nose.SkipTest('pyexcelerator dates not supported')
-
-    def test_sheets(self):
-        raise nose.SkipTest('pyexcelerator dates not supported')
-
-    def test_to_excel_multiindex_dates(self):
-        raise nose.SkipTest('pyexcelerator dates not supported')
-
-    def test_to_excel_periodindex(self):
-        raise nose.SkipTest('pyexcelerator dates not supported')
-
-    def test_tsframe(self):
-        raise nose.SkipTest('pyexcelerator dates not supported')
-
 
 class ExcelWriterEngineTests(unittest.TestCase):
     def test_ExcelWriter_dispatch(self):
@@ -1034,11 +1018,11 @@ class ExcelWriterEngineTests(unittest.TestCase):
         writer = ExcelWriter('apple.xls')
         tm.assert_isinstance(writer, _XlwtWriter)
 
-
     def test_register_writer(self):
         # some awkward mocking to test out dispatch and such actually works
         called_save = []
         called_write_cells = []
+
         class DummyClass(ExcelWriter):
             called_save = False
             called_write_cells = False
@@ -1066,7 +1050,6 @@ class ExcelWriterEngineTests(unittest.TestCase):
         func = lambda: df.to_excel('something.test')
         check_called(func)
         check_called(lambda: panel.to_excel('something.test'))
-        from pandas import set_option, get_option
         val = get_option('io.excel.xlsx.writer')
         set_option('io.excel.xlsx.writer', 'dummy')
         check_called(lambda: df.to_excel('something.xlsx'))

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1595,6 +1595,28 @@ class TestPanel(unittest.TestCase, PanelTests, CheckIndexing,
                 recdf = reader.parse(str(item), index_col=0)
                 assert_frame_equal(df, recdf)
 
+    def test_to_excel_pyexcelerate(self):
+        # TODO: Skip this test until the pyexcelerator date issue is fixed.
+        raise nose.SkipTest('pyexcelerator dates not supported')
+        try:
+            import xlrd
+            import pyexcelerate
+            from pandas.io.excel import ExcelFile
+        except ImportError:
+            raise nose.SkipTest("Requires xlrd and pyexcelerate. Skipping.")
+
+        path = '__tmp__.xlsx'
+        with ensure_clean(path) as path:
+            self.panel.to_excel(path, engine='pyexcelerate')
+            try:
+                reader = ExcelFile(path)
+            except ImportError as e:
+                raise nose.SkipTest("cannot write excel file: %s" % e)
+
+            for item, df in compat.iteritems(self.panel):
+                recdf = reader.parse(str(item), index_col=0)
+                assert_frame_equal(df, recdf)
+
     def test_dropna(self):
         p = Panel(np.random.randn(4, 5, 6), major_axis=list('abcde'))
         p.ix[:, ['b', 'd'], 0] = np.nan

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1596,8 +1596,6 @@ class TestPanel(unittest.TestCase, PanelTests, CheckIndexing,
                 assert_frame_equal(df, recdf)
 
     def test_to_excel_pyexcelerate(self):
-        # TODO: Skip this test until the pyexcelerator date issue is fixed.
-        raise nose.SkipTest('pyexcelerator dates not supported')
         try:
             import xlrd
             import pyexcelerate


### PR DESCRIPTION
This is an initial patch to add PyExcelerate as an Excel writer engine.

**It isn't suitable for merge** yet since there is issue with date handling in PyExcelerate that I am working to resolve with the authors. I just want this to appear on the pandas timeline for now so I can refer to it in other PRs.
1. The requirements files are missing since the PR will require a PyExcelerate update and release. Also, the `print_versions.py` entry.
2. There is also a failing test due to versioning.
3. There is currently no merged cell support.

I'll fix all these before the final PR request. 

John
