### PR TITLE
BUG: set_names should not change is_ relationship

### DIFF
--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -335,7 +335,6 @@ class Index(FrozenNDArray):
             raise TypeError("Must pass list-like as `names`.")
         if inplace:
             idx = self
-            idx._reset_identity()
         else:
             idx = self._shallow_copy()
         idx._set_names(names)

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -1887,6 +1887,9 @@ class TestMultiIndex(unittest.TestCase):
         self.assertTrue(mi2.is_(mi))
         self.assertTrue(mi.is_(mi2))
         self.assertTrue(mi.is_(mi.set_names(["C", "D"])))
+        mi2 = mi.view()
+        mi2.set_names(["E", "F"], inplace=True)
+        self.assertTrue(mi.is_(mi2))
         # levels are inherent properties, they change identity
         mi3 = mi2.set_levels([lrange(10), lrange(10)])
         self.assertFalse(mi3.is_(mi2))


### PR DESCRIPTION
inplace change shouldn't change identity on set names (my bad)
