### PR TITLE
BUG: Treat a list/ndarray identically for iloc indexing with list-like (GH5006)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -297,7 +297,6 @@ API Changes
     (:issue:`4501`)
   - Support non-unique axes in a Panel via indexing operations (:issue:`4960`)
 
-
 Internal Refactoring
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -566,7 +565,7 @@ Bug Fixes
   - Provide automatic conversion of ``object`` dtypes on fillna, related (:issue:`5103`)
   - Fixed a bug where default options were being overwritten in the option
     parser cleaning (:issue:`5121`).
-
+  - Treat a list/ndarray identically for ``iloc`` indexing with list-like (:issue:`5006`)
 
 pandas 0.12.0
 -------------

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1092,7 +1092,9 @@ class _iLocIndexer(_LocationIndexer):
         else:
 
             if _is_list_like(key):
-                pass
+
+                # force an actual list
+                key = list(key)
             else:
                 key = self._convert_scalar_indexer(key, axis)
 

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -333,7 +333,14 @@ class TestIndexing(unittest.TestCase):
 
         # list of ints
         self.check_result('list int', 'iloc', [0,1,2], 'ix', { 0 : [0,2,4], 1 : [0,3,6], 2: [0,4,8] }, typs = ['ints'])
+        self.check_result('list int', 'iloc', [2], 'ix', { 0 : [4], 1 : [6], 2: [8] }, typs = ['ints'])
         self.check_result('list int', 'iloc', [0,1,2], 'indexer', [0,1,2], typs = ['labels','mixed','ts','floats','empty'], fails = IndexError)
+
+        # array of ints
+        # (GH5006), make sure that a single indexer is returning the correct type
+        self.check_result('array int', 'iloc', np.array([0,1,2]), 'ix', { 0 : [0,2,4], 1 : [0,3,6], 2: [0,4,8] }, typs = ['ints'])
+        self.check_result('array int', 'iloc', np.array([2]), 'ix', { 0 : [4], 1 : [6], 2: [8] }, typs = ['ints'])
+        self.check_result('array int', 'iloc', np.array([0,1,2]), 'indexer', [0,1,2], typs = ['labels','mixed','ts','floats','empty'], fails = IndexError)
 
     def test_iloc_getitem_dups(self):
 


### PR DESCRIPTION
closes #5006
