### PR TITLE
ENH: Json support for datetime.time

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -97,6 +97,7 @@ Improvements to existing features
     overlapping color and style arguments (:issue:`4402`)
   - Significant table writing performance improvements in ``HDFStore``
   - JSON date serialisation now performed in low-level C code.
+  - JSON support for encoding datetime.time
   - Add ``drop_level`` argument to xs (:issue:`4180`)
   - Can now resample a DataFrame with ohlc (:issue:`2320`)
   - ``Index.copy()`` and ``MultiIndex.copy()`` now accept keyword arguments to

--- a/pandas/io/tests/test_json/test_ujson.py
+++ b/pandas/io/tests/test_json/test_ujson.py
@@ -22,6 +22,7 @@ import numpy as np
 from numpy.testing import (assert_array_equal,
                            assert_array_almost_equal_nulp,
                            assert_approx_equal)
+import pytz
 from pandas import DataFrame, Series, Index, NaT, DatetimeIndex
 import pandas.util.testing as tm
 
@@ -355,6 +356,17 @@ class UltraJSONTests(TestCase):
         expected = calendar.timegm(tup)
         self.assertEquals(int(expected), json.loads(output))
         self.assertEquals(int(expected), ujson.decode(output))
+
+    def test_encodeTimeConversion(self):
+        tests = [
+            datetime.time(),
+            datetime.time(1, 2, 3),
+            datetime.time(10, 12, 15, 343243),
+            datetime.time(10, 12, 15, 343243, pytz.utc)]
+        for test in tests:
+            output = ujson.encode(test)
+            expected = '"%s"' % test.isoformat()
+            self.assertEquals(expected, output)
 
     def test_nat(self):
         input = NaT


### PR DESCRIPTION
Adds `datetime.time` support to JSON serialiser. Note:
- times are encoded to strings and will be decoded to strings.
- `date_unit` and `date_format` params have no affect on `time` serialisation, they are always iso formatted.

Fixes #4873
