### PR TITLE
ENH: json default_handler param

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -233,6 +233,8 @@ API Changes
 
     - added ``date_unit`` parameter to specify resolution of timestamps. Options
       are seconds, milliseconds, microseconds and nanoseconds. (:issue:`4362`, :issue:`4498`).
+    - added ``default_handler`` parameter to allow a callable to be passed which will be
+      responsible for handling otherwise unserialisable objects.
 
   - ``Index`` and ``MultiIndex`` changes (:issue:`4039`):
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -707,7 +707,8 @@ class NDFrame(PandasObject):
     # I/O Methods
 
     def to_json(self, path_or_buf=None, orient=None, date_format='epoch',
-                double_precision=10, force_ascii=True, date_unit='ms'):
+                double_precision=10, force_ascii=True, date_unit='ms',
+                default_handler=None):
         """
         Convert the object to a JSON string.
 
@@ -728,18 +729,21 @@ class NDFrame(PandasObject):
             * DataFrame
 
               - default is 'columns'
-              - allowed values are: {'split','records','index','columns','values'}
+              - allowed values are:
+                {'split','records','index','columns','values'}
 
             * The format of the JSON string
 
-              - split : dict like {index -> [index], columns -> [columns], data -> [values]}
-              - records : list like [{column -> value}, ... , {column -> value}]
+              - split : dict like
+                {index -> [index], columns -> [columns], data -> [values]}
+              - records : list like
+                [{column -> value}, ... , {column -> value}]
               - index : dict like {index -> {column -> value}}
               - columns : dict like {column -> {index -> value}}
               - values : just the values array
 
-        date_format : type of date conversion (epoch = epoch milliseconds, iso = ISO8601)
-            default is epoch
+        date_format : type of date conversion, epoch or iso
+            epoch = epoch milliseconds, iso = ISO8601, default is epoch
         double_precision : The number of decimal places to use when encoding
             floating point values, default 10.
         force_ascii : force encoded string to be ASCII, default True.
@@ -747,6 +751,10 @@ class NDFrame(PandasObject):
             The time unit to encode to, governs timestamp and ISO8601
             precision.  One of 's', 'ms', 'us', 'ns' for second, millisecond,
             microsecond, and nanosecond respectively.
+        default_handler : callable, default None
+            Handler to call if object cannot otherwise be converted to a
+            suitable format for JSON. Should receive a single argument which is
+            the object to convert and return a serialisable object.
 
         Returns
         -------
@@ -761,7 +769,8 @@ class NDFrame(PandasObject):
             date_format=date_format,
             double_precision=double_precision,
             force_ascii=force_ascii,
-            date_unit=date_unit)
+            date_unit=date_unit,
+            default_handler=default_handler)
 
     def to_hdf(self, path_or_buf, key, **kwargs):
         """ activate the HDFStore

--- a/pandas/io/tests/test_json/test_pandas.py
+++ b/pandas/io/tests/test_json/test_pandas.py
@@ -575,3 +575,16 @@ class TestPandasContainer(unittest.TestCase):
 
         url = 'http://search.twitter.com/search.json?q=pandas%20python'
         result = read_json(url)
+
+    def test_default_handler(self):
+        from datetime import timedelta
+        frame = DataFrame([timedelta(23), timedelta(seconds=5)])
+        self.assertRaises(OverflowError, frame.to_json)
+        expected = DataFrame([str(timedelta(23)), str(timedelta(seconds=5))])
+        assert_frame_equal(
+            expected, pd.read_json(frame.to_json(default_handler=str)))
+
+        def my_handler_raises(obj):
+            raise TypeError
+        self.assertRaises(
+            TypeError, frame.to_json, default_handler=my_handler_raises)

--- a/pandas/io/tests/test_json/test_ujson.py
+++ b/pandas/io/tests/test_json/test_ujson.py
@@ -836,6 +836,51 @@ class UltraJSONTests(TestCase):
         dec = ujson.decode(output)
         self.assertEquals(dec, d)
 
+    def test_defaultHandler(self):
+
+        class _TestObject(object):
+
+            def __init__(self, val):
+                self.val = val
+
+            @property
+            def recursive_attr(self):
+                return _TestObject("recursive_attr")
+
+            def __str__(self):
+                return str(self.val)
+
+        self.assertRaises(OverflowError, ujson.encode, _TestObject("foo"))
+        self.assertEquals('"foo"', ujson.encode(_TestObject("foo"),
+                                                default_handler=str))
+
+        def my_handler(obj):
+            return "foobar"
+        self.assertEquals('"foobar"', ujson.encode(_TestObject("foo"),
+                                                   default_handler=my_handler))
+
+        def my_handler_raises(obj):
+            raise TypeError("I raise for anything")
+        with tm.assertRaisesRegexp(TypeError, "I raise for anything"):
+            ujson.encode(_TestObject("foo"), default_handler=my_handler_raises)
+
+        def my_int_handler(obj):
+            return 42
+        self.assertEquals(
+            42, ujson.decode(ujson.encode(_TestObject("foo"),
+                                          default_handler=my_int_handler)))
+
+        def my_obj_handler(obj):
+            return datetime.datetime(2013, 2, 3)
+        self.assertEquals(
+            ujson.decode(ujson.encode(datetime.datetime(2013, 2, 3))),
+            ujson.decode(ujson.encode(_TestObject("foo"),
+                                      default_handler=my_obj_handler)))
+
+        l = [_TestObject("foo"), _TestObject("bar")]
+        self.assertEquals(json.loads(json.dumps(l, default=str)),
+                          ujson.decode(ujson.encode(l, default_handler=str)))
+
 
 class NumpyJSONTests(TestCase):
 


### PR DESCRIPTION
This adds a `default_handler` param to `to_json`, which if passed must be a callable which takes one argument (the object to convert) and returns a serialisable object. The `default_handler` will only be used if an object cannot otherwise be serialised.

Note right now the JSON serialiser has direct handling for:
- Python basic types `bool`, `int`, `long`, `float`.
- Python containers `dict`, `list`, `tuple` and `set`.
- Python byte and unicode strings.
- Python decimal.
- Python `datetime` and `date`.
- Python `None`.
- Numpy arrays.
- Numpy scalars 
- `NaN` and `NaT`
- Pandas `Index`, `Series`, `DataFrame` and `Timestamp`
- any subclasses of the above.

If an object is not recognised the fallback behaviour with this PR would be:
1. if a `toDict` method is defined by the unrecognised object that 
   will be called and its returned `dict` will be JSON serialised.
2. if a `default_handler` has been passed to `to_json` that will
   be called to convert the object.
3. otherwise an attempt is made to convert the object to a `dict` by
   iterating over its attributes. 
