### PR TITLE
BUG: allow tuples in recursive call to replace

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -573,6 +573,8 @@ Bug Fixes
   - Fix bound checking for Timestamp() with datetime64 input (:issue:`4065`)
   - Fix a bug where ``TestReadHtml`` wasn't calling the correct ``read_html()``
     function (:issue:`5150`).
+  - Fix a bug with ``NDFrame.replace()`` which made replacement appear as
+    though it was (incorrectly) using regular expressions (:issue:`5143`).
 
 pandas 0.12.0
 -------------

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -7,12 +7,7 @@ import collections
 import numbers
 import codecs
 import csv
-import sys
 import types
-
-from datetime import timedelta
-
-from distutils.version import LooseVersion
 
 from numpy.lib.format import read_array, write_array
 import numpy as np
@@ -21,9 +16,7 @@ import pandas.algos as algos
 import pandas.lib as lib
 import pandas.tslib as tslib
 from pandas import compat
-from pandas.compat import (StringIO, BytesIO, range, long, u, zip, map,
-                           string_types)
-from datetime import timedelta
+from pandas.compat import StringIO, BytesIO, range, long, u, zip, map
 
 from pandas.core.config import get_option
 from pandas.core import array as pa
@@ -35,6 +28,7 @@ class PandasError(Exception):
 
 class AmbiguousIndexError(PandasError, KeyError):
     pass
+
 
 _POSSIBLY_CAST_DTYPES = set([np.dtype(t)
                             for t in ['M8[ns]', 'm8[ns]', 'O', 'int8',
@@ -100,6 +94,7 @@ def bind_method(cls, name, func):
         setattr(cls, name, types.MethodType(func, None, cls))
     else:
         setattr(cls, name, func)
+
 
 def isnull(obj):
     """Detect missing values (NaN in numeric arrays, None/NaN in object arrays)
@@ -772,6 +767,7 @@ def diff(arr, n, axis=0):
 
     return out_arr
 
+
 def _coerce_to_dtypes(result, dtypes):
     """ given a dtypes and a result set, coerce the result elements to the dtypes """
     if len(result) != len(dtypes):
@@ -799,6 +795,7 @@ def _coerce_to_dtypes(result, dtypes):
         return r
 
     return np.array([ conv(r,dtype) for r, dtype in zip(result,dtypes) ])
+
 
 def _infer_dtype_from_scalar(val):
     """ interpret the dtype from a scalar, upcast floats and ints
@@ -986,6 +983,7 @@ def _maybe_upcast_putmask(result, mask, other, dtype=None, change=None):
 
     return result, False
 
+
 def _maybe_upcast(values, fill_value=np.nan, dtype=None, copy=False):
     """ provide explicty type promotion and coercion
 
@@ -1166,6 +1164,7 @@ def pad_1d(values, limit=None, mask=None):
     _method(values, mask, limit=limit)
     return values
 
+
 def backfill_1d(values, limit=None, mask=None):
 
     dtype = values.dtype.name
@@ -1189,6 +1188,7 @@ def backfill_1d(values, limit=None, mask=None):
 
     _method(values, mask, limit=limit)
     return values
+
 
 def pad_2d(values, limit=None, mask=None):
 
@@ -1218,6 +1218,7 @@ def pad_2d(values, limit=None, mask=None):
         pass
     return values
 
+
 def backfill_2d(values, limit=None, mask=None):
 
     dtype = values.dtype.name
@@ -1245,6 +1246,7 @@ def backfill_2d(values, limit=None, mask=None):
         # for test coverage
         pass
     return values
+
 
 def interpolate_2d(values, method='pad', axis=0, limit=None, fill_value=None):
     """ perform an actual interpolation of values, values will be make 2-d if needed
@@ -1370,6 +1372,7 @@ def _possibly_convert_platform(values):
         values = lib.maybe_convert_objects(values)
 
     return values
+
 
 def _possibly_cast_to_datetime(value, dtype, coerce=False):
     """ try to cast the array/value to a datetimelike dtype, converting float nan to iNaT """
@@ -1787,6 +1790,7 @@ def is_datetime64_dtype(arr_or_dtype):
         tipo = arr_or_dtype.dtype.type
     return issubclass(tipo, np.datetime64)
 
+
 def is_datetime64_ns_dtype(arr_or_dtype):
     if isinstance(arr_or_dtype, np.dtype):
         tipo = arr_or_dtype
@@ -1795,6 +1799,7 @@ def is_datetime64_ns_dtype(arr_or_dtype):
     else:
         tipo = arr_or_dtype.dtype
     return tipo == _NS_DTYPE
+
 
 def is_timedelta64_dtype(arr_or_dtype):
     if isinstance(arr_or_dtype, np.dtype):
@@ -1850,6 +1855,7 @@ def _is_sequence(x):
         return not isinstance(x, compat.string_and_binary_types)
     except (TypeError, AttributeError):
         return False
+
 
 _ensure_float64 = algos.ensure_float64
 _ensure_float32 = algos.ensure_float32
@@ -1986,6 +1992,7 @@ def _get_handle(path, mode, encoding=None, compression=None):
             f = open(path, mode)
 
     return f
+
 
 if compat.PY3:  # pragma: no cover
     def UnicodeReader(f, dialect=csv.excel, encoding="utf-8", **kwds):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -12,7 +12,6 @@ labeling information
 # pylint: disable=E1101,E1103
 # pylint: disable=W0212,W0231,W0703,W0622
 
-import operator
 import sys
 import collections
 import warnings
@@ -25,7 +24,7 @@ import numpy.ma as ma
 from pandas.core.common import (isnull, notnull, PandasError, _try_sort,
                                 _default_index, _maybe_upcast, _is_sequence,
                                 _infer_dtype_from_scalar, _values_from_object,
-                                _coerce_to_dtypes, _DATELIKE_DTYPES, is_list_like)
+                                _DATELIKE_DTYPES, is_list_like)
 from pandas.core.generic import NDFrame, _shared_docs
 from pandas.core.index import Index, MultiIndex, _ensure_index
 from pandas.core.indexing import (_maybe_droplevels,
@@ -48,7 +47,6 @@ from pandas.tseries.period import PeriodIndex
 from pandas.tseries.index import DatetimeIndex
 
 import pandas.core.algorithms as algos
-import pandas.core.datetools as datetools
 import pandas.core.common as com
 import pandas.core.format as fmt
 import pandas.core.nanops as nanops
@@ -4292,6 +4290,7 @@ class DataFrame(NDFrame):
         """
         return self.mul(other, fill_value=1.)
 
+
 DataFrame._setup_axes(
     ['index', 'columns'], info_axis=1, stat_axis=0, axes_are_reversed=True)
 DataFrame._add_numeric_operations()
@@ -4552,6 +4551,7 @@ def _masked_rec_array_to_mgr(data, index, columns, dtype, copy):
         mgr = mgr.copy()
     return mgr
 
+
 def _reorder_arrays(arrays, arr_columns, columns):
     # reorder according to the columns
     if columns is not None and len(columns) and arr_columns is not None and len(arr_columns):
@@ -4561,6 +4561,7 @@ def _reorder_arrays(arrays, arr_columns, columns):
             [arr_columns[i] for i in indexer])
         arrays = [arrays[i] for i in indexer]
     return arrays, arr_columns
+
 
 def _list_to_arrays(data, columns, coerce_float=False, dtype=None):
     if len(data) > 0 and isinstance(data[0], tuple):

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -992,6 +992,7 @@ class NumericBlock(Block):
     is_numeric = True
     _can_hold_na = True
 
+
 class FloatBlock(NumericBlock):
     is_float = True
     _downcast_dtype = 'int64'
@@ -1064,6 +1065,7 @@ class IntBlock(NumericBlock):
     def should_store(self, value):
         return com.is_integer_dtype(value) and value.dtype == self.dtype
 
+
 class TimeDeltaBlock(IntBlock):
     is_timedelta = True
     _can_hold_na = True
@@ -1129,6 +1131,7 @@ class TimeDeltaBlock(IntBlock):
         rvalues.flat[imask] = np.array([lib.repr_timedelta64(val)
                                         for val in values.ravel()[imask]], dtype=object)
         return rvalues.tolist()
+
 
 class BoolBlock(NumericBlock):
     is_bool = True
@@ -1676,6 +1679,7 @@ class SparseBlock(Block):
 
     def _try_cast_result(self, result, dtype=None):
         return result
+
 
 def make_block(values, items, ref_items, klass=None, ndim=None, dtype=None, fastpath=False, placement=None):
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -17,10 +17,10 @@ from pandas.compat import(
     map, zip, range, long, lrange, lmap, lzip,
     OrderedDict, cPickle as pickle, u, StringIO
 )
-from pandas import compat, _np_version_under1p7
+from pandas import compat
 
 from numpy import random, nan
-from numpy.random import randn, rand
+from numpy.random import randn
 import numpy as np
 import numpy.ma as ma
 from numpy.testing import assert_array_equal
@@ -47,9 +47,6 @@ from pandas.util.testing import (assert_almost_equal,
                                  ensure_clean)
 from pandas.core.indexing import IndexingError
 from pandas.core.common import PandasError
-from pandas.compat import OrderedDict
-from pandas.computation.expr import Expr
-import pandas.computation as comp
 
 import pandas.util.testing as tm
 import pandas.lib as lib
@@ -2367,7 +2364,6 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         with assertRaisesRegexp(TypeError, msg):
             df['gr'] = df.groupby(['b', 'c']).count()
 
-
     def test_constructor_subclass_dict(self):
         # Test for passing dict subclass to constructor
         data = {'col1': tm.TestSubDict((x, 10.0 * x) for x in range(10)),
@@ -2497,7 +2493,6 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
         frame = DataFrame(['foo', 'bar'], index=[0, 1], columns=['A'])
         self.assertEqual(len(frame), 2)
-
 
     def test_constructor_maskedarray(self):
         self._check_basic_constructor(ma.masked_all)
@@ -3051,7 +3046,6 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self.assertRaises(ValueError, DataFrame.from_items,
                           [('a', [8]), ('a', [5]), ('b', [6])],
                           columns=['b', 'a', 'a'])
-
 
     def test_column_dups_operations(self):
 
@@ -6845,7 +6839,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self.tsframe['A'][-5:] = nan
 
         tsframe = self.tsframe.copy()
-        res = tsframe.replace(nan, 0, inplace=True)
+        tsframe.replace(nan, 0, inplace=True)
         assert_frame_equal(tsframe, self.tsframe.fillna(0))
 
         self.assertRaises(TypeError, self.tsframe.replace, nan, inplace=True)
@@ -7617,6 +7611,46 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
     def test_replace_limit(self):
         pass
+
+    def test_replace_dict_no_regex(self):
+        answer = Series({0: 'Strongly Agree', 1: 'Agree', 2: 'Neutral', 3:
+                         'Disagree', 4: 'Strongly Disagree'})
+        weights = {'Agree': 4, 'Disagree': 2, 'Neutral': 3, 'Strongly Agree':
+                   5, 'Strongly Disagree': 1}
+        expected = Series({0: 5, 1: 4, 2: 3, 3: 2, 4: 1})
+        result = answer.replace(weights)
+        tm.assert_series_equal(result, expected)
+
+    def test_replace_series_no_regex(self):
+        answer = Series({0: 'Strongly Agree', 1: 'Agree', 2: 'Neutral', 3:
+                         'Disagree', 4: 'Strongly Disagree'})
+        weights = Series({'Agree': 4, 'Disagree': 2, 'Neutral': 3,
+                          'Strongly Agree': 5, 'Strongly Disagree': 1})
+        expected = Series({0: 5, 1: 4, 2: 3, 3: 2, 4: 1})
+        result = answer.replace(weights)
+        tm.assert_series_equal(result, expected)
+
+    def test_replace_dict_tuple_list_ordering_remains_the_same(self):
+        df = DataFrame(dict(A=[nan, 1]))
+        res1 = df.replace(to_replace={nan: 0, 1: -1e8})
+        res2 = df.replace(to_replace=(1, nan), value=[-1e8, 0])
+        res3 = df.replace(to_replace=[1, nan], value=[-1e8, 0])
+
+        expected = DataFrame({'A': [0, -1e8]})
+        tm.assert_frame_equal(res1, res2)
+        tm.assert_frame_equal(res2, res3)
+        tm.assert_frame_equal(res3, expected)
+
+    def test_replace_doesnt_replace_with_no_regex(self):
+        from pandas.compat import StringIO
+        raw = """fol T_opp T_Dir T_Enh
+        0    1     0     0    vo
+        1    2    vr     0     0
+        2    2     0     0     0
+        3    3     0    bt     0"""
+        df = read_csv(StringIO(raw), sep=r'\s+')
+        res = df.replace({'\D': 1})
+        tm.assert_frame_equal(df, res)
 
     def test_combine_multiple_frames_dtypes(self):
         from pandas import concat
@@ -8712,7 +8746,6 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
                                                   ignore_failures=True)
         expected = self.mixed_frame._get_numeric_data().apply(np.mean)
         assert_series_equal(result, expected)
-
 
     def test_apply_mixed_dtype_corner(self):
         df = DataFrame({'A': ['foo'],


### PR DESCRIPTION
This avoids the seeming passage of regular expressions

closes #5143.
