### PR TITLE
BUG: Fix to_datetime() uncaught error with unparseable inputs #4928

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -575,6 +575,7 @@ Bug Fixes
     function (:issue:`5150`).
   - Fix a bug with ``NDFrame.replace()`` which made replacement appear as
     though it was (incorrectly) using regular expressions (:issue:`5143`).
+  - Fix better error message for to_datetime (:issue:`4928`)
 
 pandas 0.12.0
 -------------

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -931,6 +931,16 @@ class TestTimeSeries(unittest.TestCase):
         ### expected = to_datetime('2012')
         ### self.assert_(result == expected)
 
+    def test_to_datetime_unprocessable_input(self):
+        # GH 4928
+        self.assert_(
+            np.array_equal(
+                to_datetime([1, '1']),
+                np.array([1, '1'], dtype='O')
+            )
+        )
+        self.assertRaises(TypeError, to_datetime, [1, '1'], errors='raise')
+
     def test_to_datetime_other_datetime64_units(self):
         # 5/25/2012
         scalar = np.int64(1337904000000000).view('M8[us]')

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -1055,7 +1055,7 @@ def array_to_datetime(ndarray[object] values, raise_=False, dayfirst=False,
             val = values[i]
             if util._checknull(val):
                 oresult[i] = val
-            else:
+            elif util.is_string_object(val):
                 if len(val) == 0:
                     # TODO: ??
                     oresult[i] = 'NaT'
@@ -1069,6 +1069,10 @@ def array_to_datetime(ndarray[object] values, raise_=False, dayfirst=False,
                         raise
                     return values
                     # oresult[i] = val
+            else:
+                if raise_:
+                    raise
+                return values
 
         return oresult
 


### PR DESCRIPTION
closes #4928
