### PR TITLE
API/PERF: restore auto-boxing on isnull/notnull for Series (w/o copy) preserves perf gains

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -202,6 +202,11 @@ def _isnull_ndarraylike(obj):
     else:
         result = np.isnan(values)
 
+    # box
+    if isinstance(obj, ABCSeries):
+        from pandas import Series
+        result = Series(result, index=obj.index, name=obj.name, copy=False)
+
     return result
 
 
@@ -225,6 +230,11 @@ def _isnull_ndarraylike_old(obj):
         result = values.view('i8') == tslib.iNaT
     else:
         result = -np.isfinite(values)
+
+    # box
+    if isinstance(obj, ABCSeries):
+        from pandas import Series
+        result = Series(result, index=obj.index, name=obj.name, copy=False)
 
     return result
 

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -66,7 +66,7 @@ def test_notnull():
     with cf.option_context("mode.use_inf_as_null", False):
         for s in [tm.makeFloatSeries(),tm.makeStringSeries(),
                   tm.makeObjectSeries(),tm.makeTimeSeries(),tm.makePeriodSeries()]:
-            assert(isinstance(isnull(s), np.ndarray))
+            assert(isinstance(isnull(s), Series))
 
 def test_isnull():
     assert not isnull(1.)
@@ -77,7 +77,7 @@ def test_isnull():
 
     for s in [tm.makeFloatSeries(),tm.makeStringSeries(),
               tm.makeObjectSeries(),tm.makeTimeSeries(),tm.makePeriodSeries()]:
-        assert(isinstance(isnull(s), np.ndarray))
+            assert(isinstance(isnull(s), Series))
 
     # call on DataFrame
     df = DataFrame(np.random.randn(10, 5))


### PR DESCRIPTION
restore API before #5154

boxing via null/isnull is same as 0.12
(aside from now `isnull/notnull` are now available on `NDFrame` objs as well)
