### PR TITLE
DOC: add DataFrame et al class docstring to api docs

### DIFF
--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -1,0 +1,33 @@
+{% extends "!autosummary/class.rst" %}
+
+{% block methods %}
+{% if methods %}
+
+.. 
+   HACK -- the point here is that we don't want this to appear in the output, but the autosummary should still generate the pages.
+   .. autosummary::
+      :toctree:
+      {% for item in all_methods %}
+      {%- if not item.startswith('_') or item in ['__call__'] %}
+      {{ name }}.{{ item }}
+      {%- endif -%}
+      {%- endfor %}
+
+{% endif %}
+{% endblock %}
+
+{% block attributes %}
+{% if attributes %}
+
+..
+   HACK -- the point here is that we don't want this to appear in the output, but the autosummary should still generate the pages.
+   .. autosummary::
+      :toctree:
+      {% for item in all_attributes %}
+      {%- if not item.startswith('_') %}
+      {{ name }}.{{ item }}
+      {%- endif -%}
+      {%- endfor %}
+
+{% endif %}
+{% endblock %}

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -206,6 +206,13 @@ Exponentially-weighted moving window functions
 Series
 ------
 
+Constructor
+~~~~~~~~~~~
+.. autosummary::
+   :toctree: generated/
+
+   Series
+
 Attributes and underlying data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 **Axes**
@@ -219,13 +226,11 @@ Attributes and underlying data
    Series.isnull
    Series.notnull
 
-Conversion / Constructors
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
+Conversion
+~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
 
-   Series.__init__
    Series.astype
    Series.copy
    Series.isnull
@@ -418,6 +423,13 @@ Serialization / IO / Conversion
 DataFrame
 ---------
 
+Constructor
+~~~~~~~~~~~
+.. autosummary::
+   :toctree: generated/
+
+   DataFrame
+
 Attributes and underlying data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 **Axes**
@@ -436,12 +448,11 @@ Attributes and underlying data
    DataFrame.ndim
    DataFrame.shape
 
-Conversion / Constructors
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Conversion
+~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
 
-   DataFrame.__init__
    DataFrame.astype
    DataFrame.convert_objects
    DataFrame.copy
@@ -665,6 +676,13 @@ Serialization / IO / Conversion
 Panel
 ------
 
+Constructor
+~~~~~~~~~~~
+.. autosummary::
+   :toctree: generated/
+
+   Panel
+
 Attributes and underlying data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 **Axes**
@@ -681,12 +699,11 @@ Attributes and underlying data
    Panel.ndim
    Panel.shape
 
-Conversion / Constructors
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Conversion
+~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
 
-   Panel.__init__
    Panel.astype
    Panel.copy
    Panel.isnull
@@ -853,6 +870,11 @@ Index
 **Many of these methods or variants thereof are available on the objects that contain an index (Series/Dataframe)
 and those should most likely be used before calling these methods directly.**
 
+.. autosummary::
+   :toctree: generated/
+
+   Index
+
 Modifying and Computations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
@@ -933,6 +955,11 @@ Properties
 
 DatetimeIndex
 -------------
+
+.. autosummary::
+   :toctree: generated/
+
+   DatetimeIndex
 
 Time/Date Components
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -51,7 +51,7 @@ extensions = ['sphinx.ext.autodoc',
               ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates', '_templates/autosummary']
+templates_path = ['_templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'


### PR DESCRIPTION
closes #4790

I copied the approach of numpy: extending the autosummary class template to automatically generate all method stub files:
- https://github.com/numpy/numpy/blob/master/doc/source/_templates/autosummary/class.rst
- example output: http://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.html

I added `DataFrame`, `Series`, `Panel`, `Index` and `DatetimeIndex`. Others? (eg `Timestamp`) Or too much?

The only issue at the moment is that normally also a list of attributes should be included, which is not the case (only a list of methods)
