### PR TITLE
ENH: add to_frame method to Series

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -438,6 +438,7 @@ Serialization / IO / Conversion
    Series.to_pickle
    Series.to_csv
    Series.to_dict
+   Series.to_frame
    Series.to_sparse
    Series.to_string
    Series.to_clipboard

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -492,6 +492,8 @@ Enhancements
   - DatetimeIndex is now in the API documentation, see :ref:`here<api.datetimeindex>`
   - :meth:`~pandas.io.json.json_normalize` is a new method to allow you to create a flat table
     from semi-structured JSON data. :ref:`See the docs<io.json_normalize>` (:issue:`1067`)
+  - ``Series`` now supports ``to_frame`` method to convert it to a single-column DataFrame
+    (:issue:`5164`)
 
 .. _whatsnew_0130.experimental:
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -827,12 +827,7 @@ class Series(generic.NDFrame):
             raise TypeError('Cannot reset_index inplace on a Series '
                             'to create a DataFrame')
         else:
-            from pandas.core.frame import DataFrame
-            if name is None:
-                df = DataFrame(self)
-            else:
-                df = DataFrame({name: self})
-
+            df = self.to_frame(name)
             return df.reset_index(level=level, drop=drop)
 
     def __unicode__(self):
@@ -1027,6 +1022,27 @@ class Series(generic.NDFrame):
         value_dict : dict
         """
         return dict(compat.iteritems(self))
+
+    def to_frame(self, name=None):
+        """
+        Convert Series to DataFrame
+
+        Parameters
+        ----------
+        name : object, default None
+            The passed name should substitute for the series name (if it has one).
+
+        Returns
+        -------
+        data_frame : DataFrame
+        """
+        from pandas.core.frame import DataFrame
+        if name is None:
+            df = DataFrame(self)
+        else:
+            df = DataFrame({name: self})
+
+        return df
 
     def to_sparse(self, kind='block', fill_value=None):
         """

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -30,6 +30,7 @@ from pandas.compat import StringIO, lrange, range, zip, u, OrderedDict, long
 from pandas import compat
 from pandas.util.testing import (assert_series_equal,
                                  assert_almost_equal,
+                                 assert_frame_equal,
                                  ensure_clean)
 import pandas.util.testing as tm
 
@@ -3605,6 +3606,21 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         s = Series(self.ts.index)
         rs = s.tolist()
         self.assertEqual(self.ts.index[0], rs[0])
+
+    def test_to_frame(self):
+        self.ts.name = None
+        rs = self.ts.to_frame()
+        xp = pd.DataFrame(self.ts.values, index=self.ts.index)
+        assert_frame_equal(rs, xp)
+
+        self.ts.name = 'testname'
+        rs = self.ts.to_frame()
+        xp = pd.DataFrame(dict(testname=self.ts.values), index=self.ts.index)
+        assert_frame_equal(rs, xp)
+
+        rs = self.ts.to_frame(name='testdifferent')
+        xp = pd.DataFrame(dict(testdifferent=self.ts.values), index=self.ts.index)
+        assert_frame_equal(rs, xp)
 
     def test_to_dict(self):
         self.assert_(np.array_equal(Series(self.ts.to_dict()), self.ts))


### PR DESCRIPTION
Adding a method to Series to promote it to a DataFrame.  I've wished this existed so that when a method returns a series, and you could easily promote it to a DataFrame so that it's easier to add columns to it.  
