### PR TITLE
API: make allclose comparison on dtype downcasting (GH5174)

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1053,7 +1053,7 @@ def _possibly_downcast_to_dtype(result, dtype):
             # do a test on the first element, if it fails then we are done
             r = result.ravel()
             arr = np.array([ r[0] ])
-            if (arr != arr.astype(dtype)).item():
+            if not np.allclose(arr,arr.astype(dtype)):
                 return result
 
             # a comparable, e.g. a Decimal may slip in here
@@ -1062,8 +1062,14 @@ def _possibly_downcast_to_dtype(result, dtype):
 
             if issubclass(result.dtype.type, (np.object_,np.number)) and notnull(result).all():
                 new_result = result.astype(dtype)
-                if (new_result == result).all():
-                    return new_result
+                try:
+                    if np.allclose(new_result,result):
+                        return new_result
+                except:
+
+                    # comparison of an object dtype with a number type could hit here
+                    if (new_result == result).all():
+                        return new_result
     except:
         pass
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -376,10 +376,10 @@ class Block(PandasObject):
                 dtype = dtypes.get(item, self._downcast_dtype)
 
             if dtype is None:
-                nv = _block_shape(values[i])
+                nv = _block_shape(values[i],ndim=self.ndim)
             else:
                 nv = _possibly_downcast_to_dtype(values[i], dtype)
-                nv = _block_shape(nv)
+                nv = _block_shape(nv,ndim=self.ndim)
 
             blocks.append(make_block(nv, Index([item]), self.ref_items, ndim=self.ndim, fastpath=True))
 


### PR DESCRIPTION
TST: update interpolate tests to account for correct dtype inferernce

closes #5174
