### PR TITLE
PERF: calling get_indexer twice when a specialized indexer (e.g. pad) could be called instead

### DIFF
--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -490,7 +490,7 @@ Enhancements
      mask
      dfi[mask.any(1)]
 
-    :ref:`See the docs<indexing.basics.indexing_isin>` for more.
+  :ref:`See the docs<indexing.basics.indexing_isin>` for more.
 
 - ``Series`` now supports a ``to_frame`` method to convert it to a single-column DataFrame (:issue:`5164`)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1241,8 +1241,19 @@ class NDFrame(PandasObject):
                 labels = _ensure_index(labels)
 
             axis = self._get_axis_number(a)
-            new_index, indexer = self._get_axis(a).reindex(
-                labels, level=level, limit=limit, takeable=takeable)
+            ax = self._get_axis(a)
+            try:
+                new_index, indexer = ax.reindex(labels, level=level,
+                                                limit=limit, method=method, takeable=takeable)
+            except (ValueError):
+
+                # catch trying to reindex a non-monotonic index with a specialized indexer
+                # e.g. pad, so fallback to the regular indexer
+                # this will show up on reindexing a not-naturally ordering series, e.g.
+                # Series([1,2,3,4],index=['a','b','c','d']).reindex(['c','b','g'],method='pad')
+                new_index, indexer = ax.reindex(labels, level=level,
+                                                limit=limit, method=None, takeable=takeable)
+
             obj = obj._reindex_with_indexers(
                 {axis: [new_index, indexer]}, method=method, fill_value=fill_value,
                 limit=limit, copy=copy)

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -224,6 +224,7 @@ class Block(PandasObject):
         if indexer is None:
             new_ref_items, indexer = self.items.reindex(new_ref_items, limit=limit)
 
+        needs_fill = method is not None and limit is None
         if fill_value is None:
             fill_value = self.fill_value
 
@@ -245,14 +246,13 @@ class Block(PandasObject):
                 new_items = self.items.take(masked_idx)
 
         # fill if needed
-        fill_method = method is not None or limit is not None
-        if fill_method:
+        if needs_fill:
             new_values = com.interpolate_2d(new_values, method=method, limit=limit, fill_value=fill_value)
 
         block = make_block(new_values, new_items, new_ref_items, ndim=self.ndim, fastpath=True)
 
         # down cast if needed
-        if not self.is_float and (fill_method or notnull(fill_value)):
+        if not self.is_float and (needs_fill or notnull(fill_value)):
             block = block.downcast()
 
         return block


### PR DESCRIPTION
better on reindexing

```
Invoked with :
--ncalls: 3
--repeats: 3


-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
frame_reindex_upcast                         |  12.3383 |  12.7693 |   0.9662 |
frame_reindex_both_axes                      |  36.2797 |  36.2826 |   0.9999 |
frame_reindex_both_axes_ix                   |  34.7884 |  34.7476 |   1.0012 |
frame_reindex_axis1                          | 555.0433 | 553.5540 |   1.0027 |
frame_reindex_axis0                          |  87.8770 |  82.8171 |   1.0611 |
reindex_fillna_pad                           |   0.6303 |   0.5744 |   1.0974 |
reindex_frame_level_align                    |   0.6430 |   0.5836 |   1.1017 |
reindex_fillna_backfill                      |   0.6286 |   0.5697 |   1.1035 |
reindex_frame_level_reindex                  |   0.5973 |   0.5407 |   1.1048 |
reindex_fillna_pad_float32                   |   0.5320 |   0.4800 |   1.1083 |
reindex_fillna_backfill_float32              |   0.5307 |   0.4773 |   1.1119 |
dataframe_reindex                            |   0.4213 |   0.3650 |   1.1541 |
frame_reindex_columns                        |   0.3730 |   0.3120 |   1.1954 |
reindex_multiindex                           |   1.4537 |   1.1006 |   1.3208 |
reindex_daterange_pad                        |   1.2333 |   0.6417 |   1.9221 |
reindex_daterange_backfill                   |   1.2383 |   0.6430 |   1.9258 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [661adc5] : PERF: calling get_indexer twice when a specialized indexer (e.g. pad) could be called instead
Base   [8c0a34f] : RLS: set released to True, edit release dates
```
