### PR TITLE
fix replacement key for deprecated option `display.height`

### DIFF
--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -252,7 +252,7 @@ cf.deprecate_option('display.line_width',
 
 cf.deprecate_option('display.height',
                     msg=pc_height_deprecation_warning,
-                    rkey='display.height')
+                    rkey='display.max_rows')
 
 tc_sim_interactive_doc = """
 : boolean


### PR DESCRIPTION
replacement key for deprecated option `display.height` was set to `display.height` itself. I believe it should be `display.max_rows` instead.

This avoid a weird message in `describe_option()` :

```
display.height: [default: 60] [currently: 60]
: int
        Deprecated.
    (Deprecated, use `display.height` instead.)
```

(I spotted it while reading the online doc http://pandas.pydata.org/pandas-docs/dev/basics.html?highlight=display.height#working-with-package-options )
