### PR TITLE
BUG: Allow duplicate indices when performing operations that align (GH5185)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -586,6 +586,7 @@ Bug Fixes
     context manager.
   - Fixed segfault on ``isnull(MultiIndex)`` (now raises an error instead)
     (:issue:`5123`, :issue:`5125`)
+  - Allow duplicate indices when performing operations that align (:issue:`5185`)
 
 pandas 0.12.0
 -------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2455,10 +2455,12 @@ class NDFrame(PandasObject):
 
         left = self._reindex_with_indexers({0: [join_index,   ilidx],
                                             1: [join_columns, clidx]},
-                                           copy=copy, fill_value=fill_value)
+                                           copy=copy, fill_value=fill_value,
+                                           allow_dups=True)
         right = other._reindex_with_indexers({0: [join_index,   iridx],
                                               1: [join_columns, cridx]},
-                                             copy=copy, fill_value=fill_value)
+                                             copy=copy, fill_value=fill_value,
+                                             allow_dups=True)
 
         if method is not None:
             left = left.fillna(axis=fill_axis, method=method, limit=limit)

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -572,7 +572,8 @@ class SparseDataFrame(DataFrame):
         return SparseDataFrame(sdict, index=self.index, columns=columns,
                                default_fill_value=self._default_fill_value)
 
-    def _reindex_with_indexers(self, reindexers, method=None, fill_value=None, limit=None, copy=False):
+    def _reindex_with_indexers(self, reindexers, method=None, fill_value=None, limit=None,
+                               copy=False, allow_dups=False):
 
         if method is not None or limit is not None:
             raise NotImplementedError("cannot reindex with a method or limit with sparse")

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3209,6 +3209,14 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         df = DataFrame(np.arange(12).reshape(3,4), columns=dups,dtype='float64')
         self.assertRaises(ValueError, lambda : df[df.A > 6])
 
+        # dup aligining operations should work
+        # GH 5185
+        df1 = DataFrame([1, 2, 3, 4, 5], index=[1, 2, 1, 2, 3])
+        df2 = DataFrame([1, 2, 3], index=[1, 2, 3])
+        expected = DataFrame([0,2,0,2,2],index=[1,1,2,2,3])
+        result = df1.sub(df2)
+        assert_frame_equal(result,expected)
+
     def test_insert_benchmark(self):
         # from the vb_suite/frame_methods/frame_insert_columns
         N = 10


### PR DESCRIPTION
closes #5185

```
In [1]: df1 = DataFrame([1, 2, 3, 4, 5], index=[1, 2, 1, 2, 3])

In [2]: df2 = DataFrame([1, 2, 3], index=[1, 2, 3])

In [3]: df1-df2
Out[3]: 
   0
1  0
1  2
2  0
2  2
3  2

In [4]: df1.sub(df2)
Out[4]: 
   0
1  0
1  2
2  0
2  2
3  2
```
