### PR TITLE
ENH/API: Accept DataFrame for isin

### DIFF
--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -476,7 +476,7 @@ Enhancements
      t = Timestamp('20130101 09:01:02')
      t + pd.datetools.Nano(123)
 
-- A new method, ``isin`` for DataFrames, plays nicely with boolean indexing. See :ref:`the docs<indexing.basics.indexing_isin>` for more.
+- A new method, ``isin`` for DataFrames, which plays nicely with boolean indexing. The argument to ``isin``, what we're comparing the DataFrame to, can be a DataFrame, Series, dict, or array of values. See :ref:`the docs<indexing.basics.indexing_isin>` for more.
 
   To get the rows where any of the conditions are met:
 
@@ -484,7 +484,8 @@ Enhancements
 
      dfi = DataFrame({'A': [1, 2, 3, 4], 'B': ['a', 'b', 'f', 'n']})
      dfi
-     mask = dfi.isin({'A': [1, 2], 'B': ['e', 'f']})
+     other = DataFrame({'A': [1, 3, 3, 7], 'B': ['e', 'f', 'f', 'e']})
+     mask = dfi.isin(other)
      mask
      dfi[mask.any(1)]
 


### PR DESCRIPTION
API: Series should respect index labels. This would be incompatible, but there hasn't been any official release since `isin` was merged.

Will close #4421.  Still a WIP for now. Needs more testing.

Thoughts on adding an argument to ignore the index? i.e.

``` python
In [150]: df = pd.DataFrame({'A': [1, 2, 3, 4], 'B': [2, np.nan, 4, 4]}, index=['a','b','c','d'])

In [151]: s = pd.Series([1, 3, 11, 12], index=['a','b','c','d'])

In [152]: df.isin(s)
Out[152]: 
       A      B
a   True  False
b  False  False
c  False  False
d  False  False

In [152]: df.isin(s, ignore_index=True)
Out[152]: 
       A      B
a   True  False
b  False  False
c   True  False
d  False  False
```

I would say there's no need for an `ignore_index` since you could just do `df.isin(s.values)`.
