### PR TITLE
improved daytimes conversion performance in period.c

### DIFF
--- a/pandas/src/helper.h
+++ b/pandas/src/helper.h
@@ -1,0 +1,16 @@
+#ifndef C_HELPER_H
+#define C_HELPER_H
+
+#ifndef PANDAS_INLINE
+  #if defined(__GNUC__)
+    #define PANDAS_INLINE __inline__
+  #elif defined(_MSC_VER)
+    #define PANDAS_INLINE __inline
+  #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+    #define PANDAS_INLINE inline
+  #else
+    #define PANDAS_INLINE
+  #endif
+#endif
+
+#endif

--- a/pandas/src/numpy_helper.h
+++ b/pandas/src/numpy_helper.h
@@ -1,18 +1,7 @@
 #include "Python.h"
 #include "numpy/arrayobject.h"
 #include "numpy/arrayscalars.h"
-
-#ifndef PANDAS_INLINE
-  #if defined(__GNUC__)
-    #define PANDAS_INLINE __inline__
-  #elif defined(_MSC_VER)
-    #define PANDAS_INLINE __inline
-  #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-    #define PANDAS_INLINE inline
-  #else
-    #define PANDAS_INLINE
-  #endif
-#endif
+#include "helper.h"
 
 #define PANDAS_FLOAT 0
 #define PANDAS_INT 1

--- a/pandas/src/period.h
+++ b/pandas/src/period.h
@@ -8,6 +8,7 @@
 #define C_PERIOD_H
 
 #include <Python.h>
+#include "helper.h"
 #include "numpy/ndarraytypes.h"
 #include "headers/stdint.h"
 #include "limits.h"
@@ -106,8 +107,7 @@ typedef struct asfreq_info {
     int from_q_year_end; // month the year ends on in the "from" frequency
     int to_q_year_end;   // month the year ends on in the "to" frequency
 
-    int sourceFreq;
-    int targetFreq; 
+    npy_int64 intraday_conversion_factor;
 } asfreq_info;
 
 
@@ -162,4 +162,5 @@ double getAbsTime(int freq, npy_int64 dailyDate, npy_int64 originalDate);
 char *c_strftime(struct date_info *dinfo, char *fmt);
 int get_yq(npy_int64 ordinal, int freq, int *quarter, int *year);
 
+void initialize_daytime_conversion_factor_matrix();
 #endif

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -2340,6 +2340,7 @@ cdef extern from "period.h":
 
     ctypedef int64_t (*freq_conv_func)(int64_t, char, asfreq_info*)
 
+    void initialize_daytime_conversion_factor_matrix()
     int64_t asfreq(int64_t dtordinal, int freq1, int freq2, char relation) except INT32_MIN
     freq_conv_func get_asfreq_func(int fromFreq, int toFreq)
     void get_asfreq_info(int fromFreq, int toFreq, asfreq_info *af_info)
@@ -2367,6 +2368,8 @@ cdef extern from "period.h":
     int psecond(int64_t ordinal, int freq) except INT32_MIN
     char *c_strftime(date_info *dinfo, char *fmt)
     int get_yq(int64_t ordinal, int freq, int *quarter, int *year)
+
+initialize_daytime_conversion_factor_matrix()
 
 # Period logic
 #----------------------------------------------------------------------


### PR DESCRIPTION
Especially when using repeated conversion with period_asfreq_arr of tslib the code introduced with #3060 was about two to three times slower than before.

This PR improves the performance issues by moving global calculations out of the loop.
