### PR TITLE
API: rename _prop_attributes to __finalize__ (in NDFrame)

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -2554,7 +2554,8 @@ def save(obj, path):  # TODO remove in 0.13
 
 
 def _maybe_match_name(a, b):
-    name = None
-    if a.name == b.name:
-        name = a.name
-    return name
+    a_name = getattr(a,'name',None)
+    b_name = getattr(b,'name',None)
+    if a_name == b_name:
+        return a_name
+    return None

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -515,7 +515,7 @@ def _comp_method_SERIES(op, name, str_rep=None, masker=False):
             if len(self) != len(other):
                 raise ValueError('Lengths must match to compare')
             return self._constructor(na_op(self.values, np.asarray(other)),
-                                     index=self.index, name=self.name)
+                                     index=self.index).__finalize__(self)
         else:
 
             mask = isnull(self)
@@ -590,7 +590,7 @@ def _bool_method_SERIES(op, name, str_rep=None):
         else:
             # scalars
             return self._constructor(na_op(self.values, other),
-                                     index=self.index, name=self.name).fillna(False).astype(bool)
+                                     index=self.index).fillna(False).astype(bool).__finalize__(self)
     return wrapper
 
 
@@ -643,8 +643,8 @@ def _flex_method_SERIES(op, name, str_rep=None, default_axis=None,
             return self._binop(self._constructor(other, self.index), op,
                                level=level, fill_value=fill_value)
         else:
-            return self._constructor(op(self.values, other), self.index,
-                                     name=self.name)
+            return self._constructor(op(self.values, other),
+                                     self.index).__finalize__(self)
 
     f.__name__ = name
     return f

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -289,7 +289,7 @@ class SparseSeries(Series):
                                  index=self.index,
                                  sparse_index=self.sp_index,
                                  fill_value=self.fill_value,
-                                 copy=False)
+                                 copy=False).__finalize__(self)
 
     def __array_finalize__(self, obj):
         """
@@ -368,7 +368,7 @@ class SparseSeries(Series):
         key = _values_from_object(key)
         dataSlice = self.values[key]
         new_index = Index(self.index.view(ndarray)[key])
-        return self._constructor(dataSlice, index=new_index, name=self.name)
+        return self._constructor(dataSlice, index=new_index).__finalize__(self)
 
     def _set_with_engine(self, key, value):
         return self.set_value(key, value)
@@ -383,9 +383,9 @@ class SparseSeries(Series):
         abs: type of caller
         """
         res_sp_values = np.abs(self.sp_values)
-        return SparseSeries(res_sp_values, index=self.index,
-                            sparse_index=self.sp_index,
-                            fill_value=self.fill_value)
+        return self._constructor(res_sp_values, index=self.index,
+                                 sparse_index=self.sp_index,
+                                 fill_value=self.fill_value)
 
     def get(self, label, default=None):
         """
@@ -501,7 +501,7 @@ class SparseSeries(Series):
 
         return self._constructor(new_data,
                                  sparse_index=self.sp_index,
-                                 fill_value=self.fill_value, name=self.name)
+                                 fill_value=self.fill_value).__finalize__(self)
 
     def reindex(self, index=None, method=None, copy=True, limit=None):
         """
@@ -520,7 +520,8 @@ class SparseSeries(Series):
                 return self.copy()
             else:
                 return self
-        return self._constructor(self._data.reindex(new_index, method=method, limit=limit, copy=copy), index=new_index, name=self.name)
+        return self._constructor(self._data.reindex(new_index, method=method, limit=limit, copy=copy),
+                                 index=new_index).__finalize__(self)
 
     def sparse_reindex(self, new_index):
         """
@@ -541,7 +542,7 @@ class SparseSeries(Series):
         new_data = SingleBlockManager(block, block.ref_items)
         return self._constructor(new_data, index=self.index,
                                  sparse_index=new_index,
-                                 fill_value=self.fill_value)
+                                 fill_value=self.fill_value).__finalize__(self)
 
     def take(self, indices, axis=0, convert=True):
         """
@@ -553,7 +554,7 @@ class SparseSeries(Series):
         """
         new_values = SparseArray.take(self.values, indices)
         new_index = self.index.take(indices)
-        return self._constructor(new_values, index=new_index)
+        return self._constructor(new_values, index=new_index).__finalize__(self)
 
     def cumsum(self, axis=0, dtype=None, out=None):
         """
@@ -565,8 +566,8 @@ class SparseSeries(Series):
         """
         new_array = SparseArray.cumsum(self.values)
         if isinstance(new_array, SparseArray):
-            return self._constructor(new_array, index=self.index, sparse_index=new_array.sp_index, name=self.name)
-        return Series(new_array, index=self.index, name=self.name)
+            return self._constructor(new_array, index=self.index, sparse_index=new_array.sp_index).__finalize__(self)
+        return Series(new_array, index=self.index).__finalize__(self)
 
     def dropna(self):
         """
@@ -602,7 +603,7 @@ class SparseSeries(Series):
             return self._constructor(self.sp_values,
                                      sparse_index=self.sp_index,
                                      index=self.index.shift(periods, offset),
-                                     fill_value=self.fill_value)
+                                     fill_value=self.fill_value).__finalize__(self)
 
         int_index = self.sp_index.to_int_index()
         new_indices = int_index.indices + periods
@@ -617,7 +618,7 @@ class SparseSeries(Series):
         return self._constructor(self.sp_values[start:end].copy(),
                                  index=self.index,
                                  sparse_index=new_sp_index,
-                                 fill_value=self.fill_value)
+                                 fill_value=self.fill_value).__finalize__(self)
 
     def combine_first(self, other):
         """

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -83,6 +83,7 @@ class CheckNameIntegration(object):
         self.assertEquals(result.name, self.ts.name)
 
     def test_binop_maybe_preserve_name(self):
+
         # names match, preserve
         result = self.ts * self.ts
         self.assertEquals(result.name, self.ts.name)


### PR DESCRIPTION
- rename _propogate_attributes to _metadata (in NDFrame)
- change methods which directly pass metadata to use **finalize**

These provide a simple mechanism for meta data propagation, which
can be overriden in subclasses if desired. Currently these only do non-ambiguous 
propagation.

makes #60, #2485 easier
