### PR TITLE
DOC: Note -> Notes (numpydoc docstring section)

### DIFF
--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1990,8 +1990,8 @@ class NDFrameGroupBy(GroupBy):
         f : function
             Function to apply to each subframe
 
-        Note
-        ----
+        Notes
+        -----
         Each subframe is endowed the attribute 'name' in case you need to know
         which group you are working on.
 
@@ -2102,8 +2102,8 @@ class NDFrameGroupBy(GroupBy):
         dropna : Drop groups that do not pass the filter. True by default;
             if False, groups that evaluate False are filled with NaNs.
 
-        Note
-        ----
+        Notes
+        -----
         Each subframe is endowed the attribute 'name' in case you need to know
         which group you are working on.
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -71,8 +71,8 @@ class Index(FrozenNDArray):
     name : object
         Name to be stored in the index
 
-    Note
-    ----
+    Notes
+    -----
     An Index instance can **only** contain hashable objects
     """
     # To hand over control to subclasses
@@ -1634,8 +1634,8 @@ class Int64Index(Index):
     name : object
         Name to be stored in the index
 
-    Note
-    ----
+    Notes
+    -----
     An Index instance can **only** contain hashable objects
     """
 
@@ -1731,8 +1731,8 @@ class Float64Index(Index):
     name : object
         Name to be stored in the index
 
-    Note
-    ----
+    Notes
+    -----
     An Index instance can **only** contain hashable objects
     """
 

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -357,8 +357,8 @@ def pivot_simple(index, columns, values):
     values : ndarray
         Values to use for populating new frame's values
 
-    Note
-    ----
+    Notes
+    -----
     Obviously, all 3 of the input arguments must have the same length
 
     Returns

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -345,8 +345,8 @@ def str_extract(arr, pat, flags=0):
     extracted groups : Series (one group) or DataFrame (multiple groups)
 
 
-    Note
-    ----
+    Notes
+    -----
     Compare to the string method match, which returns re.match objects.
     """
     regex = re.compile(pat, flags=flags)

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -1354,8 +1354,8 @@ def generate_range(start=None, end=None, periods=None,
     time_rule : (legacy) name of DateOffset object to be used, optional
         Corresponds with names expected by tseries.frequencies.get_offset
 
-    Note
-    ----
+    Notes
+    -----
     * This method is faster for generating weekdays than dateutil.rrule
     * At least two of (start, end, periods) must be specified.
     * If both start and end are specified, the returned dates will


### PR DESCRIPTION
While adding functions/methods to the docs in #5160, I noticed an error in the build output mentioning an unknown 'Note' section. This has to be  'Notes' for numpydoc.

So I searched for all occurences and adjusted them.
