### PR TITLE
CLN/BUG: Better validation of levels/labels/names

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -109,7 +109,8 @@ Improvements to existing features
     (:issue:`4039`)
   - Add ``rename`` and ``set_names`` methods to ``Index`` as well as
     ``set_names``, ``set_levels``, ``set_labels`` to ``MultiIndex``.
-    (:issue:`4039`)
+    (:issue:`4039`) with improved validation for all (:issue:`4039`,
+    :issue:`4794`)
   - A Series of dtype ``timedelta64[ns]`` can now be divided/multiplied
     by an integer series (:issue`4521`)
   - A Series of dtype ``timedelta64[ns]`` can now be divided by another

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -52,7 +52,7 @@ API changes
       # but setting names is not deprecated.
       index = index.set_names(["bob", "cranberry"])
 
-      # and all methods take an inplace kwarg
+      # and all methods take an inplace kwarg - but returns None
       index.set_names(["bob", "cranberry"], inplace=True)
 
 - Infer and downcast dtype if ``downcast='infer'`` is passed to ``fillna/ffill/bfill`` (:issue:`4604`)

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -347,8 +347,8 @@ class TestMultiLevel(unittest.TestCase):
         # it broadcasts
         df['B', '1'] = [1, 2, 3]
         df['A'] = df['B', '1']
-        assert_almost_equal(df['A', '1'], df['B', '1'])
-        assert_almost_equal(df['A', '2'], df['B', '1'])
+        assert_series_equal(df['A', '1'], df['B', '1'])
+        assert_series_equal(df['A', '2'], df['B', '1'])
 
     def test_getitem_tuple_plus_slice(self):
         # GH #671

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -332,11 +332,11 @@ def equalContents(arr1, arr2):
     return frozenset(arr1) == frozenset(arr2)
 
 
-def assert_isinstance(obj, class_type_or_tuple):
+def assert_isinstance(obj, class_type_or_tuple, msg=''):
     """asserts that obj is an instance of class_type_or_tuple"""
     assert isinstance(obj, class_type_or_tuple), (
-        "Expected object to be of type %r, found %r instead" % (
-            type(obj), class_type_or_tuple))
+        "%sExpected object to be of type %r, found %r instead" % (
+            msg, class_type_or_tuple, type(obj)))
 
 
 def assert_equal(a, b, msg=""):
@@ -355,6 +355,8 @@ def assert_equal(a, b, msg=""):
 
 
 def assert_index_equal(left, right):
+    assert_isinstance(left, Index, '[index] ')
+    assert_isinstance(right, Index, '[index] ')
     if not left.equals(right):
         raise AssertionError("[index] left [{0} {1}], right [{2} {3}]".format(left.dtype,
                                                                               left,
@@ -373,6 +375,8 @@ def isiterable(obj):
     return hasattr(obj, '__iter__')
 
 
+# NOTE: don't pass an NDFrame or index to this function - may not handle it
+# well.
 def assert_almost_equal(a, b, check_less_precise=False):
     if isinstance(a, dict) or isinstance(b, dict):
         return assert_dict_equal(a, b)
@@ -385,9 +389,6 @@ def assert_almost_equal(a, b, check_less_precise=False):
         np.testing.assert_(isiterable(b))
         na, nb = len(a), len(b)
         assert na == nb, "%s != %s" % (na, nb)
-        # TODO: Figure out why I thought this needed instance cheacks...
-        # if (isinstance(a, np.ndarray) and isinstance(b, np.ndarray) and
-        #     np.array_equal(a, b)):
         if np.array_equal(a, b):
             return True
         else:


### PR DESCRIPTION
Improved validation of levels, labels and names (plus fleshed out test
cases). Fixes #4794.

Changed an assert_almost_equal to assert_series_equal to better reflect
actual return value.

Also makes set_levels, set_labels and set_names match behavior of rename to _not_ return self if inplace.
