### PR TITLE
ENH: Add usecols option to python parser.

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -85,11 +85,11 @@ They can take a number of arguments:
     ways to specify the file format
   - ``dtype``: A data type name or a dict of column name to data type. If not
     specified, data types will be inferred.
-  - ``header``: row number to use as the column names, and the start of the
+  - ``header``: row number(s) to use as the column names, and the start of the
     data.  Defaults to 0 if no ``names`` passed, otherwise ``None``. Explicitly
     pass ``header=0`` to be able to replace existing names. The header can be
     a list of integers that specify row locations for a multi-index on the columns
-    E.g. [0,1,3]. Interveaning rows that are not specified will be skipped.
+    E.g. [0,1,3]. Intervening rows that are not specified will be skipped.
     (E.g. 2 in this example are skipped)
   - ``skiprows``: A collection of numbers for rows in the file to skip. Can
     also be an integer to skip the first ``n`` rows
@@ -2938,7 +2938,7 @@ into BigQuery and pull it into a DataFrame.
 .. code-block:: python
 
    from pandas.io import gbq
-   
+
    # Insert your BigQuery Project ID Here
    # Can be found in the web console, or
    # using the command line tool `bq ls`
@@ -2998,7 +2998,7 @@ To add more rows to this, simply:
 
    To use this module, you will need a BigQuery account. See
    <https://cloud.google.com/products/big-query> for details.
- 
+
    As of 10/10/13, there is a bug in Google's API preventing result sets
    from being larger than 100,000 rows. A patch is scheduled for the week of
    10/14/13.

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -505,10 +505,12 @@ Enhancements
 - :meth:`~pandas.io.json.json_normalize` is a new method to allow you to create a flat table
   from semi-structured JSON data. See :ref:`the docs<io.json_normalize>` (:issue:`1067`)
 
-
 - Added PySide support for the qtpandas DataFrameModel and DataFrameWidget.
 
+- Python csv parser now supports usecols (:issue:`4335`)
+
 - DataFrame has a new ``interpolate`` method, similar to Series (:issue:`4434`, :issue:`1892`)
+
 
   .. ipython:: python
 
@@ -654,7 +656,7 @@ Experimental
   against extremely large datasets. :ref:`See the docs <io.bigquery>`
 
   .. code-block:: python
-  
+
      from pandas.io import gbq
 
      # A query to select the average monthly temperatures in the
@@ -665,8 +667,8 @@ Experimental
      query = """SELECT station_number as STATION,
      month as MONTH, AVG(mean_temp) as MEAN_TEMP
      FROM publicdata:samples.gsod
-     WHERE YEAR = 2000 
-     GROUP BY STATION, MONTH 
+     WHERE YEAR = 2000
+     GROUP BY STATION, MONTH
      ORDER BY STATION, MONTH ASC"""
 
      # Fetch the result set for this query
@@ -675,7 +677,7 @@ Experimental
      # To find this, see your dashboard:
      # https://code.google.com/apis/console/b/0/?noredirect
      projectid = xxxxxxxxx;
-     
+
      df = gbq.read_gbq(query, project_id = projectid)
 
      # Use pandas to process and reshape the dataset
@@ -686,9 +688,9 @@ Experimental
 
   The resulting dataframe is::
 
-     > df3 
+     > df3
                  Min Tem  Mean Temp    Max Temp
-      MONTH                                  
+      MONTH
       1     -53.336667  39.827892   89.770968
       2     -49.837500  43.685219   93.437932
       3     -77.926087  48.708355   96.099998


### PR DESCRIPTION
Closes #4335

This ticket felt a little bit like whack-a-mole. 

The key is that names can have two meanings: if it matches length of usecols then it is the name to apply to the (numeric) usecols. If it matches the length of the original columns, it is the set of column names and string values in usecols refer to it. 
