### PR TITLE
BUG/CLN: MI now checks level & label compatibility

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -400,6 +400,8 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
    instead they are generated and cached on the fly. The internal
    representation and handling of DateOffsets has also been clarified.
    (:issue:`5189`, related :issue:`5004`)
+ - ``MultiIndex`` constructor now validates that passed levels and labels are
+   compatible. (:issue:`5213`, :issue:`5214`)
 
 .. _release.bug_fixes-0.13.0:
 

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -96,7 +96,8 @@ def panel_index(time, panels, names=['time', 'panel']):
 
     labels = [time_factor.labels, panel_factor.labels]
     levels = [time_factor.levels, panel_factor.levels]
-    return MultiIndex(levels, labels, sortorder=None, names=names)
+    return MultiIndex(levels, labels, sortorder=None, names=names,
+                      verify_integrity=False)
 
 
 
@@ -838,7 +839,7 @@ class Panel(NDFrame):
 
         index = MultiIndex(levels=[self.major_axis, self.minor_axis],
                            labels=[major_labels, minor_labels],
-                           names=[maj_name, min_name])
+                           names=[maj_name, min_name], verify_integrity=False)
 
         return DataFrame(data, index=index, columns=self.items)
 

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -218,7 +218,7 @@ class _Unstacker(object):
             new_labels.append(np.tile(np.arange(stride), width))
 
         return MultiIndex(levels=new_levels, labels=new_labels,
-                          names=new_names)
+                          names=new_names, verify_integrity=False)
 
     def get_new_index(self):
         result_labels = []
@@ -234,7 +234,8 @@ class _Unstacker(object):
         else:
             new_index = MultiIndex(levels=self.new_index_levels,
                                    labels=result_labels,
-                                   names=self.new_index_names)
+                                   names=self.new_index_names,
+                                   verify_integrity=False)
 
         return new_index
 
@@ -286,7 +287,8 @@ def _unstack_multiple(data, clocs):
 
     dummy_index = MultiIndex(levels=rlevels + [obs_ids],
                              labels=rlabels + [comp_ids],
-                             names=rnames + ['__placeholder__'])
+                             names=rnames + ['__placeholder__'],
+                             verify_integrity=False)
 
     if isinstance(data, Series):
         dummy = Series(data.values, index=dummy_index)
@@ -320,7 +322,7 @@ def _unstack_multiple(data, clocs):
             new_labels.append(rec.take(unstcols.labels[-1]))
 
     new_columns = MultiIndex(levels=new_levels, labels=new_labels,
-                             names=new_names)
+                             names=new_names, verify_integrity=False)
 
     if isinstance(unstacked, Series):
         unstacked.index = new_columns
@@ -505,13 +507,14 @@ def stack(frame, level=-1, dropna=True):
         new_names = list(frame.index.names)
         new_names.append(frame.columns.name)
         new_index = MultiIndex(levels=new_levels, labels=new_labels,
-                               names=new_names)
+                               names=new_names, verify_integrity=False)
     else:
         ilabels = np.arange(N).repeat(K)
         clabels = np.tile(np.arange(K), N).ravel()
         new_index = MultiIndex(levels=[frame.index, frame.columns],
                                labels=[ilabels, clabels],
-                               names=[frame.index.name, frame.columns.name])
+                               names=[frame.index.name, frame.columns.name],
+                               verify_integrity=False)
 
     new_values = frame.values.ravel()
     if dropna:
@@ -590,7 +593,7 @@ def _stack_multi_columns(frame, level=-1, dropna=True):
     new_names.append(frame.columns.names[level])
 
     new_index = MultiIndex(levels=new_levels, labels=new_labels,
-                           names=new_names)
+                           names=new_names, verify_integrity=False)
 
     result = DataFrame(new_data, index=new_index, columns=new_columns)
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2209,7 +2209,8 @@ class GenericFixed(Fixed):
             lab = self.read_array(label_key)
             labels.append(lab)
 
-        return MultiIndex(levels=levels, labels=labels, names=names)
+        return MultiIndex(levels=levels, labels=labels, names=names,
+                          verify_integrity=True)
 
     def read_index_node(self, node):
         data = node[:]

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -767,7 +767,8 @@ def stack_sparse_frame(frame):
     major_labels = np.concatenate(inds_to_concat)
     stacked_values = np.concatenate(vals_to_concat)
     index = MultiIndex(levels=[frame.index, frame.columns],
-                       labels=[major_labels, minor_labels])
+                       labels=[major_labels, minor_labels],
+                       verify_integrity=False)
 
     lp = DataFrame(stacked_values.reshape((nobs, 1)), index=index,
                    columns=['foo'])

--- a/pandas/sparse/panel.py
+++ b/pandas/sparse/panel.py
@@ -317,7 +317,8 @@ class SparsePanel(Panel):
         minor_labels = inds // N
 
         index = MultiIndex(levels=[self.major_axis, self.minor_axis],
-                           labels=[major_labels, minor_labels])
+                           labels=[major_labels, minor_labels],
+                           verify_integrity=False)
 
         df = DataFrame(values, index=index, columns=self.items)
         return df.sortlevel(level=0)

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -488,9 +488,6 @@ class TestBlockManager(unittest.TestCase):
         _check(new_mgr,BoolBlock,['bool'])
         _check(new_mgr,DatetimeBlock,['dt'])
 
-    def test_xs(self):
-        pass
-
     def test_interleave(self):
         pass
 

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1366,7 +1366,8 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None):
             # also copies
             names = names + _get_consensus_names(indexes)
 
-        return MultiIndex(levels=levels, labels=label_list, names=names)
+        return MultiIndex(levels=levels, labels=label_list, names=names,
+                          verify_integrity=False)
 
     new_index = indexes[0]
     n = len(new_index)
@@ -1402,7 +1403,8 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None):
     if len(new_names) < len(new_levels):
         new_names.extend(new_index.names)
 
-    return MultiIndex(levels=new_levels, labels=new_labels, names=new_names)
+    return MultiIndex(levels=new_levels, labels=new_labels, names=new_names,
+                      verify_integrity=False)
 
 
 def _should_fill(lname, rname):


### PR DESCRIPTION
Via verify_integrity kwarg. Internals all pass False.I don't think I've missed anything / passed verify_integrity=True where
it ought not to be.

Fixes #5213.

Clearly this adds a (likely small) perf hit - but should only occur
from external MI calls that specifically call the constructor with
levels and labels (for example, doesn't occur with `from_arrays` or
`from_tuples`). For 0.14 I'll have to do it differently, but this should
work for 0.13.
