### PR TITLE
BUG/CLN: Clear _tuples on setting MI levels/labels

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -597,6 +597,9 @@ Bug Fixes
   - Bug in ``to_datetime`` with a format and ``coerce=True`` not raising (:issue:`5195`)
   - Bug in ``loc`` setting with multiple indexers and a rhs of a Series that needs
     broadcasting (:issue:`5206`)
+  - Fixed bug where inplace setting of levels or labels on ``MultiIndex`` would
+    not clear cached ``values`` property and therefore return wrong ``values``.
+    (:issue:`5215`)
 
 pandas 0.12.0
 -------------

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1903,8 +1903,9 @@ class MultiIndex(Index):
                             for lev in levels)
         names = self.names
         self._levels = levels
-        if len(names):
+        if any(names):
             self._set_names(names)
+        self._tuples = None
 
     def set_levels(self, levels, inplace=False):
         """
@@ -1947,6 +1948,7 @@ class MultiIndex(Index):
             raise ValueError("Length of labels must match length of levels")
         self._labels = FrozenList(_ensure_frozen(labs, copy=copy)._shallow_copy()
                                   for labs in labels)
+        self._tuples = None
 
     def set_labels(self, labels, inplace=False):
         """

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -382,14 +382,15 @@ def assert_almost_equal(a, b, check_less_precise=False):
         return assert_dict_equal(a, b)
 
     if isinstance(a, compat.string_types):
-        assert a == b, "%s != %s" % (a, b)
+        assert a == b, "%r != %r" % (a, b)
         return True
 
     if isiterable(a):
         np.testing.assert_(isiterable(b))
         na, nb = len(a), len(b)
         assert na == nb, "%s != %s" % (na, nb)
-        if np.array_equal(a, b):
+        if isinstance(a, np.ndarray) and isinstance(b, np.ndarray) and\
+           np.array_equal(a, b):
             return True
         else:
             for i in range(na):


### PR DESCRIPTION
Previously, setting levels and labels didn't reset `_tuple`, which meant
that it would return wrong values. (and this was ocurring in v0.12 and
earlier too).
