### PR TITLE
BUG: Groupby filter maintains ordering, closes #4621

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -600,6 +600,8 @@ Bug Fixes
   - Fixed bug where inplace setting of levels or labels on ``MultiIndex`` would
     not clear cached ``values`` property and therefore return wrong ``values``.
     (:issue:`5215`)
+  - Fixed bug where filtering a grouped DataFrame or Series did not maintain
+    the original ordering (:issue:`4621`).
 
 pandas 0.12.0
 -------------

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1641,7 +1641,7 @@ class SeriesGroupBy(GroupBy):
         if len(indexers) == 0:
             filtered = self.obj.take([]) # because np.concatenate would fail
         else:
-            filtered = self.obj.take(np.concatenate(indexers))
+            filtered = self.obj.take(np.sort(np.concatenate(indexers)))
         if dropna:
             return filtered
         else:
@@ -2166,7 +2166,7 @@ class NDFrameGroupBy(GroupBy):
         if len(indexers) == 0:
             filtered = self.obj.take([]) # because np.concatenate would fail
         else:
-            filtered = self.obj.take(np.concatenate(indexers))
+            filtered = self.obj.take(np.sort(np.concatenate(indexers)))
         if dropna:
             return filtered
         else:


### PR DESCRIPTION
Simply adds `np.sort`.

Includes tests for SeriesGroupBy and DataFrameGroupBy, using indexes that are sequentially increasing, sequentially decreasing, and shuffled. Also, this PR removes all ad hoc sorting involved in the original filter tests -- now no longer needed. Much better!
