### PR TITLE
EHN/FIX: Add na_last parameter to DataFrame.sort. Fixes GH3917

### DIFF
--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -1286,14 +1286,14 @@ The ``by`` argument can take a list of column names, e.g.:
 
 Series has the method ``order`` (analogous to `R's order function
 <http://stat.ethz.ch/R-manual/R-patched/library/base/html/order.html>`__) which
-sorts by value, with special treatment of NA values via the ``na_last``
+sorts by value, with special treatment of NA values via the ``na_position``
 argument:
 
 .. ipython:: python
 
    s[2] = np.nan
    s.order()
-   s.order(na_last=False)
+   s.order(na_position='first')
 
 Some other sorting notes / nuances:
 

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -147,6 +147,8 @@ API Changes
 - Define and document the order of column vs index names in query/eval
     (:issue:`6676`)
 
+- ``DataFrame.sort`` now places NaNs at the beginning or end of the sort according to the ``na_position`` parameter. (:issue:`3917`)
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -316,9 +316,9 @@ def array_equivalent(left, right):
     # NaNs occur only in object arrays, float or complex arrays.
     if issubclass(left.dtype.type, np.object_):
         return ((left == right) | (pd.isnull(left) & pd.isnull(right))).all()
-    if not issubclass(left.dtype.type, (np.floating, np.complexfloating)):
-        return np.array_equal(left, right)
-    return ((left == right) | (np.isnan(left) & np.isnan(right))).all()
+    if issubclass(left.dtype.type, (np.floating, np.complexfloating)):
+        return ((left == right) | (np.isnan(left) & np.isnan(right))).all()
+    return np.array_equal(left, right)
 
 def _iterable_not_string(x):
     return (isinstance(x, collections.Iterable) and

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -13,7 +13,7 @@ from pandas.lib import Timestamp, is_datetime_array
 from pandas.core.base import FrozenList, FrozenNDArray, IndexOpsMixin
 
 from pandas.util.decorators import cache_readonly, deprecate
-from pandas.core.common import isnull
+from pandas.core.common import isnull, array_equivalent
 import pandas.core.common as com
 from pandas.core.common import _values_from_object, is_float, is_integer, ABCSeries
 from pandas.core.config import get_option
@@ -800,7 +800,7 @@ class Index(IndexOpsMixin, FrozenNDArray):
         if type(other) != Index:
             return other.equals(self)
 
-        return np.array_equal(self, other)
+        return array_equivalent(self, other)
 
     def identical(self, other):
         """Similar to equals, but check that other comparable attributes are
@@ -1872,7 +1872,7 @@ class Int64Index(Index):
         #     return False
 
         try:
-            return np.array_equal(self, other)
+            return array_equivalent(self, other)
         except TypeError:
             # e.g. fails in numpy 1.6 with DatetimeIndex #1681
             return False
@@ -3533,7 +3533,7 @@ class MultiIndex(Index):
             return True
 
         if not isinstance(other, MultiIndex):
-            return np.array_equal(self.values, _ensure_index(other))
+            return array_equivalent(self.values, _ensure_index(other))
 
         if self.nlevels != other.nlevels:
             return False
@@ -3546,7 +3546,7 @@ class MultiIndex(Index):
                                   allow_fill=False)
             ovalues = com.take_nd(other.levels[i].values, other.labels[i],
                                   allow_fill=False)
-            if not np.array_equal(svalues, ovalues):
+            if not array_equivalent(svalues, ovalues):
                 return False
 
         return True

--- a/pandas/hashtable.pyx
+++ b/pandas/hashtable.pyx
@@ -835,20 +835,23 @@ cdef class Factorizer:
         return self.count
 
     def factorize(self, ndarray[object] values, sort=False, na_sentinel=-1):
+        """
+        Factorize values with nans replaced by na_sentinel
+        >>> factorize(np.array([1,2,np.nan], dtype='O'), na_sentinel=20)
+        array([ 0,  1, 20])
+        """
         labels = self.table.get_labels(values, self.uniques,
                                        self.count, na_sentinel)
-
+        mask = (labels == na_sentinel)
         # sort on
         if sort:
             if labels.dtype != np.int_:
                 labels = labels.astype(np.int_)
-
             sorter = self.uniques.to_array().argsort()
             reverse_indexer = np.empty(len(sorter), dtype=np.int_)
             reverse_indexer.put(sorter, np.arange(len(sorter)))
-
-            labels = reverse_indexer.take(labels)
-
+            labels = reverse_indexer.take(labels, mode='clip')
+            labels[mask] = na_sentinel
         self.count = len(self.uniques)
         return labels
 

--- a/pandas/tests/test_hashtable.py
+++ b/pandas/tests/test_hashtable.py
@@ -1,0 +1,30 @@
+import numpy as np
+import unittest
+import nose
+import pandas.hashtable as _hash
+import pandas as pd
+
+class TestFactorizer(unittest.TestCase):
+    def test_factorize_nan(self):
+        # nan should map to na_sentinel, not reverse_indexer[na_sentinel]
+        # rizer.factorize should not raise an exception if na_sentinel indexes
+        # outside of reverse_indexer
+        key = np.array([1, 2, 1, np.nan], dtype='O')
+        rizer = _hash.Factorizer(len(key))
+        for na_sentinel in (-1, 20):
+            ids = rizer.factorize(key, sort=True, na_sentinel=na_sentinel)
+            expected = np.array([0, 1, 0, na_sentinel], dtype='int32')
+            self.assertEqual(len(set(key)), len(set(expected)))
+            self.assert_(np.array_equal(pd.isnull(key), expected == na_sentinel))
+
+        # nan still maps to na_sentinel when sort=False
+        key = np.array([0, np.nan, 1], dtype='O')
+        na_sentinel = -1        
+        ids = rizer.factorize(key, sort=False, na_sentinel=na_sentinel)
+        expected = np.array([ 2, -1,  0], dtype='int32')
+        self.assertEqual(len(set(key)), len(set(expected)))
+        self.assert_(np.array_equal(pd.isnull(key), expected == na_sentinel))        
+
+if __name__ == '__main__':
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   exit=False)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -4007,7 +4007,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         self.assert_(np.isnan(result[-5:]).all())
         self.assert_numpy_array_equal(result[:-5], np.sort(vals[5:]))
 
-        result = ts.order(na_last=False)
+        result = ts.order(na_position='first')
         self.assert_(np.isnan(result[:5]).all())
         self.assert_numpy_array_equal(result[5:], np.sort(vals[5:]))
 
@@ -4020,7 +4020,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         ordered = ts.order(ascending=False)
         expected = np.sort(ts.valid().values)[::-1]
         assert_almost_equal(expected, ordered.valid().values)
-        ordered = ts.order(ascending=False, na_last=False)
+        ordered = ts.order(ascending=False, na_position='first')
         assert_almost_equal(expected, ordered.valid().values)
 
     def test_rank(self):


### PR DESCRIPTION
closes  #3917

This is an attempt to fix the Nested Sort with NaN bug (https://github.com/pydata/pandas/issues/3917).

I've added tests to `test_frame.py` and `test_hashtable.py` to demonstrate the problem.

`hashtable.Factorizer.factorize` has been modified to map `nan` to `na_sentinel`. Before it was mapping `nan` to a label which was already being used. This, I believe is the origin of the bug. 

My first idea was to mimick/reuse code from `Series.order`, since this method already handles `nan`s nicely, and allows the user to choose if nans should be placed at the beginning or the end of the sort via the `na_last` parameter. Although I found a solution using code from `Series.order`, I eventually abandoned this when I realized this patches the problem at too high a level and that it could be handled more generally with a modification of `factorize`. I retained the idea that `df.sort` should have a `na_last` parameter, however.

To that end, `groupby._lexsort_indexer` has been modified to handle all possible combinations of `na_last` and `orders` settings. There are four tests (assertions) in `test_frame.py` to exercise the possibilities, one of which demonstrates that `df.sort(['A','B'])` now behaves correctly for the DataFrame shown in GH3917.
