### PR TITLE
FIX: OLS.predict() - cast input to DataFrame from Series before performing operations

### DIFF
--- a/pandas/stats/ols.py
+++ b/pandas/stats/ols.py
@@ -445,12 +445,12 @@ class OLS(StringMixin):
             orig_x = x
         else:
             orig_x = x
+            if isinstance(x, Series):
+                x = DataFrame({'x': x})            
             if fill_value is None and fill_method is None:
                 x = x.dropna(how='any')
             else:
                 x = x.fillna(value=fill_value, method=fill_method, axis=axis)
-            if isinstance(x, Series):
-                x = DataFrame({'x': x})
             if self._intercept:
                 x['intercept'] = 1.
 

--- a/pandas/stats/tests/test_ols.py
+++ b/pandas/stats/tests/test_ols.py
@@ -378,6 +378,9 @@ class TestOLSMisc(unittest.TestCase):
         model = ols(y=y, x=x)
         expected = ols(y=y, x={'x': x})
         assert_series_equal(model.beta, expected.beta)
+        
+        # Test predict using a series
+        assert_series_equal(model.y_predict, model.predict(x=x))
 
     def test_various_attributes(self):
         # just make sure everything "works". test correctness elsewhere


### PR DESCRIPTION
Closes #5233.  Simply cast to a Series to a DataFrame before dropping NAs or filling.
