### PR TITLE
CLN: Add _reset_cache method to PandasObject

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -257,6 +257,8 @@ API Changes
       ('mostly immutable')
     - ``levels``, ``labels`` and ``names`` are validated upon setting and are
       either copied or shallow-copied.
+    - inplace setting of ``levels`` or ``labels`` now correctly invalidates the
+      cached properties. (:issue:`5238`).
     - ``__deepcopy__`` now returns a shallow copy (currently: a view) of the
       data - allowing metadata changes.
     - ``MultiIndex.astype()`` now only allows ``np.object_``-like dtypes and

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -48,16 +48,6 @@ class StringMixin(object):
         """
         return str(self)
 
-    def _local_dir(self):
-        """ provide addtional __dir__ for this object """
-        return []
-
-    def __dir__(self):
-        """
-        Provide method name lookup and completion
-        Only provide 'public' methods
-        """
-        return list(sorted(list(set(dir(type(self)) + self._local_dir()))))
 
 class PandasObject(StringMixin):
     """baseclass for various pandas objects"""
@@ -76,6 +66,29 @@ class PandasObject(StringMixin):
         """
         # Should be overwritten by base classes
         return object.__repr__(self)
+
+    def _local_dir(self):
+        """ provide addtional __dir__ for this object """
+        return []
+
+    def __dir__(self):
+        """
+        Provide method name lookup and completion
+        Only provide 'public' methods
+        """
+        return list(sorted(list(set(dir(type(self)) + self._local_dir()))))
+
+    def _reset_cache(self, key=None):
+        """
+        Reset cached properties. If ``key`` is passed, only clears that key.
+        """
+        if getattr(self, '_cache', None) is None:
+            return
+        if key is None:
+            self._cache.clear()
+        else:
+            self._cache.pop(key, None)
+
 
 class FrozenList(PandasObject, list):
     """

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1929,7 +1929,9 @@ class MultiIndex(Index):
         self._levels = levels
         if any(names):
             self._set_names(names)
+
         self._tuples = None
+        self._reset_cache()
 
         if verify_integrity:
             self._verify_integrity()
@@ -1981,6 +1983,7 @@ class MultiIndex(Index):
         self._labels = FrozenList(_ensure_frozen(labs, copy=copy)._shallow_copy()
                                   for labs in labels)
         self._tuples = None
+        self._reset_cache()
 
         if verify_integrity:
             self._verify_integrity()

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -2462,6 +2462,16 @@ class TestMultiIndex(unittest.TestCase):
         with tm.assertRaises(NotImplementedError):
             pd.isnull(self.index)
 
+    def test_level_setting_resets_attributes(self):
+        ind = MultiIndex.from_arrays([
+            ['A', 'A', 'B', 'B', 'B'],
+            [1, 2, 1, 2, 3]])
+        assert ind.is_monotonic
+        ind.set_levels([['A', 'B', 'A', 'A', 'B'], [2, 1, 3, -2, 5]],
+                       inplace=True)
+        # if this fails, probably didn't reset the cache correctly.
+        assert not ind.is_monotonic
+
 
 def test_get_combined_index():
     from pandas.core.index import _get_combined_index


### PR DESCRIPTION
I think this is the right way to do it. MI needs this for _engine and
friends. I think there are other objects that use `cache_readonly` that
might want to reset too.

I also moved the local dir methods off of StringMixin to PandasObject
(where they ought to have been).

Fixes #5236 and fixes #5225.
