### PR TITLE
CLN/ENH: Make names getattr'able in core/ops +PEP8.

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -304,6 +304,7 @@ API Changes
     ``SparsePanel``, etc.), now support the entire set of arithmetic operators
     and arithmetic flex methods (add, sub, mul, etc.). ``SparsePanel`` does not
     support ``pow`` or ``mod`` with non-scalars. (:issue:`3765`)
+  - Arithemtic func factories are now passed real names (suitable for using with super) (:issue:`5240`)
   - Provide numpy compatibility with 1.7 for a calling convention like ``np.prod(pandas_object)`` as numpy
     call with additional keyword args (:issue:`4435`)
   - Provide __dir__ method (and local context) for tab completion / remove ipython completers code

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -19,8 +19,12 @@ from pandas.core.common import(bind_method, is_list_like, notnull, isnull,
 # Functions that add arithmetic methods to objects, given arithmetic factory
 # methods
 
+
 def _create_methods(arith_method, radd_func, comp_method, bool_method,
                     use_numexpr, special=False, default_axis='columns'):
+    # creates actual methods based upon arithmetic, comp and bool method
+    # constructors.
+
     # NOTE: Only frame cares about default_axis, specifically: special methods
     # have default axis None, whereas flex methods have default axis 'columns'
     # if we're not using numexpr, then don't pass a str_rep
@@ -37,42 +41,62 @@ def _create_methods(arith_method, radd_func, comp_method, bool_method,
     else:
         names = lambda x: x
     radd_func = radd_func or operator.add
-    # Inframe, all special methods have default_axis=None, flex methods have default_axis set to the default (columns)
+    # Inframe, all special methods have default_axis=None, flex methods have
+    # default_axis set to the default (columns)
     new_methods = dict(
-        add=arith_method(operator.add, names('add'), op('+'), default_axis=default_axis),
-        radd=arith_method(radd_func, names('radd'), op('+'), default_axis=default_axis),
-        sub=arith_method(operator.sub, names('sub'), op('-'), default_axis=default_axis),
-        mul=arith_method(operator.mul, names('mul'), op('*'), default_axis=default_axis),
+        add=arith_method(operator.add, names('add'), op('+'),
+                         default_axis=default_axis),
+        radd=arith_method(radd_func, names('radd'), op('+'),
+                          default_axis=default_axis),
+        sub=arith_method(operator.sub, names('sub'), op('-'),
+                         default_axis=default_axis),
+        mul=arith_method(operator.mul, names('mul'), op('*'),
+                         default_axis=default_axis),
         truediv=arith_method(operator.truediv, names('truediv'), op('/'),
-                             truediv=True, fill_zeros=np.inf, default_axis=default_axis),
+                             truediv=True, fill_zeros=np.inf,
+                             default_axis=default_axis),
         floordiv=arith_method(operator.floordiv, names('floordiv'), op('//'),
                               default_axis=default_axis, fill_zeros=np.inf),
         # Causes a floating point exception in the tests when numexpr
         # enabled, so for now no speedup
         mod=arith_method(operator.mod, names('mod'), default_axis=default_axis,
                          fill_zeros=np.nan),
-        pow=arith_method(operator.pow, names('pow'), op('**'), default_axis=default_axis),
+        pow=arith_method(operator.pow, names('pow'), op('**'),
+                         default_axis=default_axis),
         # not entirely sure why this is necessary, but previously was included
         # so it's here to maintain compatibility
-        rmul=arith_method(operator.mul, names('rmul'), default_axis=default_axis),
-        rsub=arith_method(lambda x, y: y - x, names('rsub'), default_axis=default_axis),
-        rtruediv=arith_method(lambda x, y: operator.truediv(y, x), names('rtruediv'),
-                              truediv=True, fill_zeros=np.inf, default_axis=default_axis),
-        rfloordiv=arith_method(lambda x, y: operator.floordiv(y, x), names('rfloordiv'),
-                               default_axis=default_axis, fill_zeros=np.inf),
-        rpow=arith_method(lambda x, y: y ** x, names('rpow'), default_axis=default_axis),
-        rmod=arith_method(lambda x, y: y % x, names('rmod'), default_axis=default_axis),
+        rmul=arith_method(operator.mul, names('rmul'),
+                          default_axis=default_axis),
+        rsub=arith_method(lambda x, y: y - x, names('rsub'),
+                          default_axis=default_axis),
+        rtruediv=arith_method(lambda x, y: operator.truediv(y, x),
+                              names('rtruediv'), truediv=True,
+                              fill_zeros=np.inf, default_axis=default_axis),
+        rfloordiv=arith_method(lambda x, y: operator.floordiv(y, x),
+                               names('rfloordiv'), default_axis=default_axis,
+                               fill_zeros=np.inf),
+        rpow=arith_method(lambda x, y: y ** x, names('rpow'),
+                          default_axis=default_axis),
+        rmod=arith_method(lambda x, y: y % x, names('rmod'),
+                          default_axis=default_axis),
     )
     if not compat.PY3:
         new_methods["div"] = arith_method(operator.div, names('div'), op('/'),
-                                          truediv=False, fill_zeros=np.inf, default_axis=default_axis)
-        new_methods["rdiv"] = arith_method(lambda x, y: operator.div(y, x), names('rdiv'),
-                                           truediv=False, fill_zeros=np.inf, default_axis=default_axis)
+                                          truediv=False, fill_zeros=np.inf,
+                                          default_axis=default_axis)
+        new_methods["rdiv"] = arith_method(lambda x, y: operator.div(y, x),
+                                           names('rdiv'), truediv=False,
+                                           fill_zeros=np.inf,
+                                           default_axis=default_axis)
     else:
-        new_methods["div"] = arith_method(operator.truediv, names('div'), op('/'),
-                                          truediv=True, fill_zeros=np.inf, default_axis=default_axis)
-        new_methods["rdiv"] = arith_method(lambda x, y: operator.truediv(y, x), names('rdiv'),
-                                           truediv=False, fill_zeros=np.inf, default_axis=default_axis)
+        new_methods["div"] = arith_method(operator.truediv, names('div'),
+                                          op('/'), truediv=True,
+                                          fill_zeros=np.inf,
+                                          default_axis=default_axis)
+        new_methods["rdiv"] = arith_method(lambda x, y: operator.truediv(y, x),
+                                           names('rdiv'), truediv=False,
+                                           fill_zeros=np.inf,
+                                           default_axis=default_axis)
         # Comp methods never had a default axis set
     if comp_method:
         new_methods.update(dict(
@@ -85,13 +109,14 @@ def _create_methods(arith_method, radd_func, comp_method, bool_method,
         ))
     if bool_method:
         new_methods.update(dict(
-        and_=bool_method(operator.and_, names('and_ [&]'), op('&')),
-        or_=bool_method(operator.or_, names('or_ [|]'), op('|')),
-        # For some reason ``^`` wasn't used in original.
-        xor=bool_method(operator.xor, names('xor [^]')),
-        rand_=bool_method(lambda x, y: operator.and_(y, x), names('rand_[&]')),
-        ror_=bool_method(lambda x, y: operator.or_(y, x), names('ror_ [|]')),
-        rxor=bool_method(lambda x, y: operator.xor(y, x), names('rxor [^]'))
+            and_=bool_method(operator.and_, names('and_'), op('&')),
+            or_=bool_method(operator.or_, names('or_'), op('|')),
+            # For some reason ``^`` wasn't used in original.
+            xor=bool_method(operator.xor, names('xor')),
+            rand_=bool_method(lambda x, y: operator.and_(y, x),
+                              names('rand_')),
+            ror_=bool_method(lambda x, y: operator.or_(y, x), names('ror_')),
+            rxor=bool_method(lambda x, y: operator.xor(y, x), names('rxor'))
         ))
 
     new_methods = dict((names(k), v) for k, v in new_methods.items())
@@ -116,6 +141,7 @@ def add_methods(cls, new_methods, force, select, exclude):
         if force or name not in cls.__dict__:
             bind_method(cls, name, method)
 
+
 #----------------------------------------------------------------------
 # Arithmetic
 def add_special_arithmetic_methods(cls, arith_method=None, radd_func=None,
@@ -123,7 +149,8 @@ def add_special_arithmetic_methods(cls, arith_method=None, radd_func=None,
                                    use_numexpr=True, force=False, select=None,
                                    exclude=None):
     """
-    Adds the full suite of special arithmetic methods (``__add__``, ``__sub__``, etc.) to the class.
+    Adds the full suite of special arithmetic methods (``__add__``,
+    ``__sub__``, etc.) to the class.
 
     Parameters
     ----------
@@ -137,16 +164,18 @@ def add_special_arithmetic_methods(cls, arith_method=None, radd_func=None,
     use_numexpr : bool, default True
         whether to accelerate with numexpr, defaults to True
     force : bool, default False
-        if False, checks whether function is defined **on ``cls.__dict__``** before defining
-        if True, always defines functions on class base
+        if False, checks whether function is defined **on ``cls.__dict__``**
+        before defining if True, always defines functions on class base
     select : iterable of strings (optional)
         if passed, only sets functions with names in select
     exclude : iterable of strings (optional)
         if passed, will not set functions with names in exclude
     """
     radd_func = radd_func or operator.add
-    # in frame, special methods have default_axis = None, comp methods use 'columns'
-    new_methods = _create_methods(arith_method, radd_func, comp_method, bool_method, use_numexpr, default_axis=None,
+    # in frame, special methods have default_axis = None, comp methods use
+    # 'columns'
+    new_methods = _create_methods(arith_method, radd_func, comp_method,
+                                  bool_method, use_numexpr, default_axis=None,
                                   special=True)
 
     # inplace operators (I feel like these should get passed an `inplace=True`
@@ -161,7 +190,8 @@ def add_special_arithmetic_methods(cls, arith_method=None, radd_func=None,
     if not compat.PY3:
         new_methods["__idiv__"] = new_methods["__div__"]
 
-    add_methods(cls, new_methods=new_methods, force=force, select=select, exclude=exclude)
+    add_methods(cls, new_methods=new_methods, force=force, select=select,
+                exclude=exclude)
 
 
 def add_flex_arithmetic_methods(cls, flex_arith_method, radd_func=None,
@@ -169,7 +199,8 @@ def add_flex_arithmetic_methods(cls, flex_arith_method, radd_func=None,
                                 use_numexpr=True, force=False, select=None,
                                 exclude=None):
     """
-    Adds the full suite of flex arithmetic methods (``pow``, ``mul``, ``add``) to the class.
+    Adds the full suite of flex arithmetic methods (``pow``, ``mul``, ``add``)
+    to the class.
 
     Parameters
     ----------
@@ -177,14 +208,15 @@ def add_flex_arithmetic_methods(cls, flex_arith_method, radd_func=None,
         factory for special arithmetic methods, with op string:
         f(op, name, str_rep, default_axis=None, fill_zeros=None, **eval_kwargs)
     radd_func :  function (optional)
-        Possible replacement for ``lambda x, y: operator.add(y, x)`` for compatibility
+        Possible replacement for ``lambda x, y: operator.add(y, x)`` for
+        compatibility
     flex_comp_method : function, optional,
         factory for rich comparison - signature: f(op, name, str_rep)
     use_numexpr : bool, default True
         whether to accelerate with numexpr, defaults to True
     force : bool, default False
-        if False, checks whether function is defined **on ``cls.__dict__``** before defining
-        if True, always defines functions on class base
+        if False, checks whether function is defined **on ``cls.__dict__``**
+        before defining if True, always defines functions on class base
     select : iterable of strings (optional)
         if passed, only sets functions with names in select
     exclude : iterable of strings (optional)
@@ -205,28 +237,10 @@ def add_flex_arithmetic_methods(cls, flex_arith_method, radd_func=None,
         if k in new_methods:
             new_methods.pop(k)
 
-    add_methods(cls, new_methods=new_methods, force=force, select=select, exclude=exclude)
-
-def cleanup_name(name):
-    """cleanup special names
-    >>> cleanup_name("__rsub__")
-    sub
-    >>> cleanup_name("rand_")
-    and_
-    """
-    if name[:2] == "__":
-        name = name[2:-2]
-    if name[0] == "r":
-        name = name[1:]
-    # readd last _ for operator names.
-    if name == "or":
-        name = "or_"
-    elif name == "and":
-        name = "and_"
-    return name
+    add_methods(cls, new_methods=new_methods, force=force, select=select,
+                exclude=exclude)
 
 
-# direct copy of original Series _TimeOp
 class _TimeOp(object):
     """
     Wrapper around Series datetime/time/timedelta arithmetic operations.
@@ -244,13 +258,13 @@ class _TimeOp(object):
         rvalues = self._convert_to_array(right, name=name)
 
         self.is_timedelta_lhs = com.is_timedelta64_dtype(left)
-        self.is_datetime_lhs  = com.is_datetime64_dtype(left)
-        self.is_integer_lhs = left.dtype.kind in ['i','u']
-        self.is_datetime_rhs  = com.is_datetime64_dtype(rvalues)
+        self.is_datetime_lhs = com.is_datetime64_dtype(left)
+        self.is_integer_lhs = left.dtype.kind in ['i', 'u']
+        self.is_datetime_rhs = com.is_datetime64_dtype(rvalues)
         self.is_timedelta_rhs = (com.is_timedelta64_dtype(rvalues)
                                  or (not self.is_datetime_rhs
                                      and pd._np_version_under1p7))
-        self.is_integer_rhs = rvalues.dtype.kind in ('i','u')
+        self.is_integer_rhs = rvalues.dtype.kind in ('i', 'u')
 
         self._validate()
 
@@ -262,36 +276,42 @@ class _TimeOp(object):
         if (self.is_timedelta_lhs and self.is_integer_rhs) or\
            (self.is_integer_lhs and self.is_timedelta_rhs):
 
-            if self.name not in ('__truediv__','__div__','__mul__'):
-                raise TypeError("can only operate on a timedelta and an integer for "
-                                "division, but the operator [%s] was passed" % self.name)
+            if self.name not in ('__truediv__', '__div__', '__mul__'):
+                raise TypeError("can only operate on a timedelta and an "
+                                "integer for division, but the operator [%s]"
+                                "was passed" % self.name)
 
         # 2 datetimes
         elif self.is_datetime_lhs and self.is_datetime_rhs:
             if self.name != '__sub__':
-                raise TypeError("can only operate on a datetimes for subtraction, "
-                                "but the operator [%s] was passed" % self.name)
-
+                raise TypeError("can only operate on a datetimes for"
+                                " subtraction, but the operator [%s] was"
+                                " passed" % self.name)
 
         # 2 timedeltas
         elif self.is_timedelta_lhs and self.is_timedelta_rhs:
 
-            if self.name not in ('__div__', '__truediv__', '__add__', '__sub__'):
+            if self.name not in ('__div__', '__truediv__', '__add__',
+                                 '__sub__'):
                 raise TypeError("can only operate on a timedeltas for "
-                                "addition, subtraction, and division, but the operator [%s] was passed" % self.name)
+                                "addition, subtraction, and division, but the"
+                                " operator [%s] was passed" % self.name)
 
         # datetime and timedelta
         elif self.is_datetime_lhs and self.is_timedelta_rhs:
 
-            if self.name not in ('__add__','__sub__'):
-                raise TypeError("can only operate on a datetime with a rhs of a timedelta for "
-                                "addition and subtraction, but the operator [%s] was passed" % self.name)
+            if self.name not in ('__add__', '__sub__'):
+                raise TypeError("can only operate on a datetime with a rhs of"
+                                " a timedelta for addition and subtraction, "
+                                " but the operator [%s] was passed" %
+                                self.name)
 
         elif self.is_timedelta_lhs and self.is_datetime_rhs:
 
             if self.name != '__add__':
-                raise TypeError("can only operate on a timedelta and a datetime for "
-                                "addition, but the operator [%s] was passed" % self.name)
+                raise TypeError("can only operate on a timedelta and"
+                                " a datetime for addition, but the operator"
+                                " [%s] was passed" % self.name)
         else:
             raise TypeError('cannot operate on a series with out a rhs '
                             'of a series/ndarray of type datetime64[ns] '
@@ -305,9 +325,10 @@ class _TimeOp(object):
         if not is_list_like(values):
             values = np.array([values])
         inferred_type = lib.infer_dtype(values)
-        if inferred_type in ('datetime64','datetime','date','time'):
+        if inferred_type in ('datetime64', 'datetime', 'date', 'time'):
             # a datetlike
-            if not (isinstance(values, (pa.Array, pd.Series)) and com.is_datetime64_dtype(values)):
+            if not (isinstance(values, (pa.Array, pd.Series)) and
+                    com.is_datetime64_dtype(values)):
                 values = tslib.array_to_datetime(values)
             elif isinstance(values, pd.DatetimeIndex):
                 values = values.to_series()
@@ -320,20 +341,22 @@ class _TimeOp(object):
                 values = values.astype('timedelta64[ns]')
             elif isinstance(values, pd.PeriodIndex):
                 values = values.to_timestamp().to_series()
-            elif name not in ('__truediv__','__div__','__mul__'):
+            elif name not in ('__truediv__', '__div__', '__mul__'):
                 raise TypeError("incompatible type for a datetime/timedelta "
                                 "operation [{0}]".format(name))
         elif isinstance(values[0], pd.DateOffset):
             # handle DateOffsets
-            os = pa.array([ getattr(v,'delta',None) for v in values ])
+            os = pa.array([getattr(v, 'delta', None) for v in values])
             mask = isnull(os)
             if mask.any():
                 raise TypeError("cannot use a non-absolute DateOffset in "
                                 "datetime/timedelta operations [{0}]".format(
-                                    ','.join([ com.pprint_thing(v) for v in values[mask] ])))
+                                    ', '.join([com.pprint_thing(v)
+                                               for v in values[mask]])))
             values = _possibly_cast_to_timedelta(os, coerce=coerce)
         else:
-            raise TypeError("incompatible type [{0}] for a datetime/timedelta operation".format(pa.array(values).dtype))
+            raise TypeError("incompatible type [{0}] for a datetime/timedelta"
+                            " operation".format(pa.array(values).dtype))
 
         return values
 
@@ -372,8 +395,8 @@ class _TimeOp(object):
         if mask is not None:
             if mask.any():
                 def f(x):
-                    x = pa.array(x,dtype=self.dtype)
-                    np.putmask(x,mask,self.fill_value)
+                    x = pa.array(x, dtype=self.dtype)
+                    np.putmask(x, mask, self.fill_value)
                     return x
                 self.wrap_results = f
         self.lvalues = lvalues
@@ -391,7 +414,7 @@ class _TimeOp(object):
         """
         # decide if we can do it
         is_timedelta_lhs = com.is_timedelta64_dtype(left)
-        is_datetime_lhs  = com.is_datetime64_dtype(left)
+        is_datetime_lhs = com.is_datetime64_dtype(left)
         if not (is_datetime_lhs or is_timedelta_lhs):
             return None
         # rops are allowed. No need for special checks, just strip off
@@ -401,7 +424,8 @@ class _TimeOp(object):
         return cls(left, right, name)
 
 
-def _arith_method_SERIES(op, name, str_rep=None, fill_zeros=None, default_axis=None, **eval_kwargs):
+def _arith_method_SERIES(op, name, str_rep=None, fill_zeros=None,
+                         default_axis=None, **eval_kwargs):
     """
     Wrapper function for Series arithmetic operations, to avoid
     code duplication.
@@ -412,7 +436,7 @@ def _arith_method_SERIES(op, name, str_rep=None, fill_zeros=None, default_axis=N
                                           raise_on_error=True, **eval_kwargs)
         except TypeError:
             if isinstance(y, (pa.Array, pd.Series)):
-                dtype = np.find_common_type([x.dtype,y.dtype],[])
+                dtype = np.find_common_type([x.dtype, y.dtype], [])
                 result = np.empty(x.size, dtype=dtype)
                 mask = notnull(x) & notnull(y)
                 result[mask] = op(x[mask], y[mask])
@@ -471,8 +495,10 @@ def _arith_method_SERIES(op, name, str_rep=None, fill_zeros=None, default_axis=N
             if hasattr(lvalues, 'values'):
                 lvalues = lvalues.values
             return left._constructor(wrap_results(na_op(lvalues, rvalues)),
-                                     index=left.index, name=left.name, dtype=dtype)
+                                     index=left.index, name=left.name,
+                                     dtype=dtype)
     return wrapper
+
 
 def _comp_method_SERIES(op, name, str_rep=None, masker=False):
     """
@@ -494,7 +520,7 @@ def _comp_method_SERIES(op, name, str_rep=None, masker=False):
         else:
 
             try:
-                result = getattr(x,name)(y)
+                result = getattr(x, name)(y)
                 if result is NotImplemented:
                     raise TypeError("invalid type comparison")
             except (AttributeError):
@@ -535,7 +561,8 @@ def _comp_method_SERIES(op, name, str_rep=None, masker=False):
             # always return a full value series here
             res = _values_from_object(res)
 
-            res = pd.Series(res, index=self.index, name=self.name, dtype='bool')
+            res = pd.Series(res, index=self.index, name=self.name,
+                            dtype='bool')
 
             # mask out the invalids
             if mask.any():
@@ -574,7 +601,8 @@ def _bool_method_SERIES(op, name, str_rep=None):
                     result = lib.scalar_binop(x, y, op)
                 except:
                     raise TypeError("cannot compare a dtyped [{0}] array with "
-                                    "a scalar of type [{1}]".format(x.dtype,type(y).__name__))
+                                    "a scalar of type [{1}]".format(
+                                        x.dtype, type(y).__name__))
 
         return result
 
@@ -584,17 +612,18 @@ def _bool_method_SERIES(op, name, str_rep=None):
 
             other = other.reindex_like(self).fillna(False).astype(bool)
             return self._constructor(na_op(self.values, other.values),
-                                     index=self.index, name=name).fillna(False).astype(bool)
+                                     index=self.index,
+                                     name=name).fillna(False).astype(bool)
         elif isinstance(other, pd.DataFrame):
             return NotImplemented
         else:
             # scalars
-            return self._constructor(na_op(self.values, other),
-                                     index=self.index).fillna(False).astype(bool).__finalize__(self)
+            res = self._constructor(na_op(self.values, other),
+                                    index=self.index).fillna(False)
+            return res.astype(bool).__finalize__(self)
     return wrapper
 
 
-# original Series _radd_compat method
 def _radd_compat(left, right):
     radd = lambda x, y: y + x
     # GH #353, NumPy 1.5.1 workaround
@@ -685,7 +714,8 @@ result : DataFrame
 """
 
 
-def _arith_method_FRAME(op, name, str_rep=None, default_axis='columns', fill_zeros=None, **eval_kwargs):
+def _arith_method_FRAME(op, name, str_rep=None, default_axis='columns',
+                        fill_zeros=None, **eval_kwargs):
     def na_op(x, y):
         try:
             result = expressions.evaluate(
@@ -693,7 +723,7 @@ def _arith_method_FRAME(op, name, str_rep=None, default_axis='columns', fill_zer
         except TypeError:
             xrav = x.ravel()
             if isinstance(y, (np.ndarray, pd.Series)):
-                dtype = np.find_common_type([x.dtype,y.dtype],[])
+                dtype = np.find_common_type([x.dtype, y.dtype], [])
                 result = np.empty(x.size, dtype=dtype)
                 yrav = y.ravel()
                 mask = notnull(xrav) & notnull(yrav)
@@ -718,6 +748,7 @@ def _arith_method_FRAME(op, name, str_rep=None, default_axis='columns', fill_zer
             return self._combine_series(other, na_op, fill_value, axis, level)
         elif isinstance(other, (list, tuple)):
             if axis is not None and self._get_axis_name(axis) == 'index':
+                # TODO: Get all of these to use _constructor_sliced
                 # casted = self._constructor_sliced(other, index=self.index)
                 casted = pd.Series(other, index=self.index)
             else:
@@ -727,22 +758,24 @@ def _arith_method_FRAME(op, name, str_rep=None, default_axis='columns', fill_zer
         elif isinstance(other, np.ndarray):
             if other.ndim == 1:
                 if axis is not None and self._get_axis_name(axis) == 'index':
-                    # casted = self._constructor_sliced(other, index=self.index)
+                    # casted = self._constructor_sliced(other,
+                    #                                   index=self.index)
                     casted = pd.Series(other, index=self.index)
                 else:
-                    # casted = self._constructor_sliced(other, index=self.columns)
+                    # casted = self._constructor_sliced(other,
+                    #                                   index=self.columns)
                     casted = pd.Series(other, index=self.columns)
                 return self._combine_series(casted, na_op, fill_value,
                                             axis, level)
             elif other.ndim == 2:
                 # casted = self._constructor(other, index=self.index,
-                                           # columns=self.columns)
+                #                            columns=self.columns)
                 casted = pd.DataFrame(other, index=self.index,
-                                 columns=self.columns)
+                                      columns=self.columns)
                 return self._combine_frame(casted, na_op, fill_value, level)
             else:
                 raise ValueError("Incompatible argument shape: %s" %
-                                 (other.shape,))
+                                 (other.shape, ))
         else:
             return self._combine_const(other, na_op)
 
@@ -805,13 +838,13 @@ def _flex_comp_method_FRAME(op, name, str_rep=None, default_axis='columns',
 
             elif other.ndim == 2:
                 casted = pd.DataFrame(other, index=self.index,
-                                   columns=self.columns)
+                                      columns=self.columns)
 
                 return self._flex_compare_frame(casted, na_op, str_rep, level)
 
             else:
                 raise ValueError("Incompatible argument shape: %s" %
-                                 (other.shape,))
+                                 (other.shape, ))
 
         else:
             return self._combine_const(other, na_op)
@@ -832,7 +865,8 @@ def _comp_method_FRAME(func, name, str_rep, masker=False):
 
             # straight boolean comparisions we want to allow all columns
             # (regardless of dtype to pass thru) See #4537 for discussion.
-            return self._combine_const(other, func, raise_on_error=False).fillna(True).astype(bool)
+            res = self._combine_const(other, func, raise_on_error=False)
+            return res.fillna(True).astype(bool)
 
     f.__name__ = name
 
@@ -868,12 +902,13 @@ def _arith_method_PANEL(op, name, str_rep=None, fill_zeros=None,
 
         result = com._fill_zeros(result, y, fill_zeros)
         return result
-    # work only for scalars
 
+    # work only for scalars
     def f(self, other):
         if not np.isscalar(other):
             raise ValueError('Simple arithmetic with %s can only be '
-                             'done with scalar values' % self._constructor.__name__)
+                             'done with scalar values' %
+                             self._constructor.__name__)
 
         return self._combine(other, op)
     f.__name__ = name


### PR DESCRIPTION
Now the name passed to a method can be used to get that method from the 
NDFrame (previously you had things like `or_ [|]`. better to just have them
all be named exactly what they are s.t. subclasses can do
`getattr(super(self, MyClass), name)(*args, **kwargs)`.
