### PR TITLE
API/CLN: consolidate truncate into NDFrame (panel had a separate method)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -311,6 +311,7 @@ API Changes
   - Provide __dir__ method (and local context) for tab completion / remove ipython completers code
     (:issue:`4501`)
   - Support non-unique axes in a Panel via indexing operations (:issue:`4960`)
+  - ``.truncate`` will raise a ``ValueError`` if invalid before and afters dates are given (:issue:`5242`)
 
 Internal Refactoring
 ~~~~~~~~~~~~~~~~~~~~

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -998,30 +998,6 @@ class Panel(NDFrame):
     def tshift(self, periods=1, freq=None, axis='major', **kwds):
         return super(Panel, self).tshift(periods, freq, axis, **kwds)
 
-    def truncate(self, before=None, after=None, axis='major'):
-        """Function truncates a sorted Panel before and/or after some
-        particular values on the requested axis
-
-        Parameters
-        ----------
-        before : date
-            Left boundary
-        after : date
-            Right boundary
-        axis : {'major', 'minor', 'items'}
-
-        Returns
-        -------
-        Panel
-        """
-        axis = self._get_axis_name(axis)
-        index = self._get_axis(axis)
-
-        beg_slice, end_slice = index.slice_locs(before, after)
-        new_index = index[beg_slice:end_slice]
-
-        return self.reindex(**{axis: new_index})
-
     def join(self, other, how='left', lsuffix='', rsuffix=''):
         """
         Join items with other Panel either on major and minor axes column

--- a/pandas/sparse/panel.py
+++ b/pandas/sparse/panel.py
@@ -187,6 +187,15 @@ class SparsePanel(Panel):
 
         return self.xs(key, axis=axis)
 
+    def _slice(self, slobj, axis=0, raise_on_error=False, typ=None):
+        """
+        for compat as we don't support Block Manager here
+        """
+        axis = self._get_axis_name(axis)
+        index = self._get_axis(axis)
+
+        return self.reindex(**{axis: index[slobj]})
+
     def _get_item_cache(self, key):
         return self._frames[key]
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -7731,6 +7731,10 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         truncated = ts.truncate(after=end_missing)
         assert_frame_equal(truncated, expected)
 
+        self.assertRaises(ValueError, ts.truncate,
+                          before=ts.index[-1] - 1,
+                          after=ts.index[0] +1)
+
     def test_truncate_copy(self):
         index = self.tsframe.index
         truncated = self.tsframe.truncate(index[5], index[10])

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -3899,7 +3899,7 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         truncated = ts.truncate(before=self.ts.index[-1] + offset)
         assert(len(truncated) == 0)
 
-        self.assertRaises(Exception, ts.truncate,
+        self.assertRaises(ValueError, ts.truncate,
                           before=self.ts.index[-1] + offset,
                           after=self.ts.index[0] - offset)
 


### PR DESCRIPTION
API: truncate error if before > after is now a ValueError (rather than AssertionError)
(related #5242)
