### PR TITLE
Make doc compiling under windows workable

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -122,6 +122,12 @@ def html():
         io_doc = io_doc.replace(_good,_bad)
         with io.open("source/io.rst", 'w', encoding='ascii') as f:
             f.write(io_doc)
+        # these files are often left over due to "[Error 32] file in use"
+        try:
+            os.remove('tmp.sv')
+            os.remove('store.h5')
+        except:
+            pass
 
 def latex():
     check_build()

--- a/doc/make.py
+++ b/doc/make.py
@@ -99,11 +99,29 @@ def clean():
 
 
 def html():
+    # Sphinx fails on embedded unicode on Windows, so replace the offending 
+    # strings before the build and restore them afterwards
+    import os, io
+    _bad = r"   data = 'word,length\nTr\xe4umen,7\nGr\xfc\xdfe,5'"
+    _good = """   # Due to problems with sphinx and embedded unicode under windows, 
+   # the umlauts were replaced during doc generation!
+   data = 'word,length\\nTraumen,7\\nGruse,5'"""
+    if os.name == 'nt':
+        with io.open("source/io.rst", 'r', encoding='ascii') as f:
+            io_doc = f.read()
+        io_doc = io_doc.replace(_bad, _good)
+        with io.open("source/io.rst", 'w', encoding='ascii') as f:
+            f.write(io_doc)
     check_build()
     if os.system('sphinx-build -P -b html -d build/doctrees '
                  'source build/html'):
         raise SystemExit("Building HTML failed.")
-
+    if os.name == 'nt':
+        with io.open("source/io.rst", 'r', encoding='ascii') as f:
+            io_doc = f.read()
+        io_doc = io_doc.replace(_good,_bad)
+        with io.open("source/io.rst", 'w', encoding='ascii') as f:
+            f.write(io_doc)
 
 def latex():
     check_build()


### PR DESCRIPTION
The doc generation failed under windows due to problems with sphinx
and encoded umlauts in code (see links in
https://github.com/pydata/pandas/issues/5142).

The workaround is to replace the offending text with one which does not fail
(but which makes the example a bit pointless), build the docs and restore the
old text.

Closes: #5142
