### PR TITLE
ENH: Add inplace option to drop and dropna

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -200,6 +200,11 @@ Improvements to existing features
     argument. (:issue:`5354`)
   - Added short docstrings to a few methods that were missing them + fixed the
     docstrings for Panel flex methods. (:issue:`5336`)
+  - ``NDFrame.drop()``, ``NDFrame.dropna()``, and ``.drop_duplicates()`` all
+    accept ``inplace`` as a kewyord argument; however, this only means that the
+    wrapper is updated inplace, a copy is still made internally.
+    (:issue:`1960`, :issue:`5247`, and related :issue:`2325` [still not
+    closed])
 
 API Changes
 ~~~~~~~~~~~
@@ -474,6 +479,9 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
  - Unity ``dropna`` for Series/DataFrame signature (:issue:`5250`),
    tests from :issue:`5234`, courtesy of @rockg
  - Rewrite assert_almost_equal() in cython for performance (:issue:`4398`)
+ - Added an internal ``_update_inplace`` method to facilitate updating
+   ``NDFrame`` wrappers on inplace ops (only is for convenience of caller,
+   doesn't actually prevent copies). (:issue:`5247`)
 
 .. _release.bug_fixes-0.13.0:
 

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -615,7 +615,7 @@ class Panel(NDFrame):
         return Panel(new_values, items=new_items, major_axis=new_major,
                      minor_axis=new_minor)
 
-    def dropna(self, axis=0, how='any', **kwargs):
+    def dropna(self, axis=0, how='any', inplace=False, **kwargs):
         """
         Drop 2D from panel, holding passed axis constant
 
@@ -627,6 +627,8 @@ class Panel(NDFrame):
         how : {'all', 'any'}, default 'any'
             'any': one or more values are NA in the DataFrame along the
             axis. For 'all' they all must be.
+        inplace : bool, default False
+            If True, do operation inplace and return None.
 
         Returns
         -------
@@ -648,7 +650,11 @@ class Panel(NDFrame):
             cond = mask == per_slice
 
         new_ax = self._get_axis(axis)[cond]
-        return self.reindex_axis(new_ax, axis=axis)
+        result = self.reindex_axis(new_ax, axis=axis)
+        if inplace:
+            self._update_inplace(result)
+        else:
+            return result
 
     def _combine(self, other, func, axis=0):
         if isinstance(other, Panel):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1155,7 +1155,7 @@ class Series(generic.NDFrame):
         """
         return len(self.value_counts())
 
-    def drop_duplicates(self, take_last=False):
+    def drop_duplicates(self, take_last=False, inplace=False):
         """
         Return Series with duplicate values removed
 
@@ -1163,13 +1163,20 @@ class Series(generic.NDFrame):
         ----------
         take_last : boolean, default False
             Take the last observed index in a group. Default first
+        inplace : boolean, default False
+            If True, performs operation inplace and returns None.
 
         Returns
         -------
         deduplicated : Series
         """
         duplicated = self.duplicated(take_last=take_last)
-        return self[-duplicated]
+        result = self[-duplicated]
+        if inplace:
+            return self._update_inplace(result)
+        else:
+            return result
+
 
     def duplicated(self, take_last=False):
         """
@@ -2190,18 +2197,25 @@ class Series(generic.NDFrame):
                   index_label=index_label, mode=mode, nanRep=nanRep,
                   encoding=encoding, date_format=date_format)
 
-    def dropna(self, axis=0, **kwargs):
+    def dropna(self, axis=0, inplace=False, **kwargs):
         """
         Return Series without null values
 
         Returns
         -------
         valid : Series
+        inplace : bool (default False)
+            Do operation in place.
         """
         axis = self._get_axis_number(axis or 0)
-        return remove_na(self)
+        result = remove_na(self)
+        if inplace:
+            self._update_inplace(result)
+        else:
+            return result
 
-    valid = lambda self: self.dropna()
+    valid = lambda self, inplace=False, **kwargs: self.dropna(inplace=inplace,
+                                                              **kwargs)
 
     def first_valid_index(self):
         """

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -569,13 +569,16 @@ class SparseSeries(Series):
             return self._constructor(new_array, index=self.index, sparse_index=new_array.sp_index).__finalize__(self)
         return Series(new_array, index=self.index).__finalize__(self)
 
-    def dropna(self, axis=0, **kwargs):
+    def dropna(self, axis=0, inplace=False, **kwargs):
         """
         Analogous to Series.dropna. If fill_value=NaN, returns a dense Series
         """
         # TODO: make more efficient
         axis = self._get_axis_number(axis or 0)
         dense_valid = self.to_dense().valid()
+        if inplace:
+            raise NotImplementedError("Cannot perform inplace dropna"
+                                      " operations on a SparseSeries")
         if isnull(self.fill_value):
             return dense_valid
         else:

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1600,6 +1600,9 @@ class TestPanel(unittest.TestCase, PanelTests, CheckIndexing,
         result = p.dropna(axis=1)
         exp = p.ix[:, ['a', 'c', 'e'], :]
         assert_panel_equal(result, exp)
+        inp = p.copy()
+        inp.dropna(axis=1, inplace=True)
+        assert_panel_equal(inp, exp)
 
         result = p.dropna(axis=1, how='all')
         assert_panel_equal(result, p)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -3582,6 +3582,8 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
     def test_dropna_empty(self):
         s = Series([])
         self.assert_(len(s.dropna()) == 0)
+        s.dropna(inplace=True)
+        self.assert_(len(s) == 0)
 
         # invalid axis
         self.assertRaises(ValueError, s.dropna, axis=1)
@@ -3607,10 +3609,16 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         result = s.drop_duplicates()
         expected = s[[True, True, True, False]]
         assert_series_equal(result, expected)
+        sc = s.copy()
+        sc.drop_duplicates(inplace=True)
+        assert_series_equal(sc, expected)
 
         result = s.drop_duplicates(take_last=True)
         expected = s[[True, True, False, True]]
         assert_series_equal(result, expected)
+        sc = s.copy()
+        sc.drop_duplicates(take_last=True, inplace=True)
+        assert_series_equal(sc, expected)
 
     def test_sort(self):
         ts = self.ts.copy()
@@ -5196,6 +5204,10 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         self.ts[:5] = np.nan
         result = self.ts.dropna()
         self.assertEquals(result.name, self.ts.name)
+        name = self.ts.name
+        ts = self.ts.copy()
+        ts.dropna(inplace=True)
+        self.assertEquals(ts.name, name)
 
     def test_numpy_unique(self):
         # it works!


### PR DESCRIPTION
And appropriately invalidates caches as necessary BUT _still_ makes a copy.  @jreback and I decided that it shouldn't call `__finalize__` a second time in `_update_inplace` (so if metadata is supposed to change, it's not going to be updated, but subclass can always override it). Closes #1960, related #2325 (doesn't actually fix because still makes a copy).

Adds `_update_inplace` method that takes a result and invalidates the internal cache then reindexes.

---

@jreback - would you mind taking a look? It's almost there, I think I'm
missing one cache reference or something... (or I'm just using reindex
wrong).
