### PR TITLE
API: allow Series/Panel dropna to accept other args for compat with DataFrame (GH5233/GH5250)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -409,6 +409,8 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
    (:issue:`5189`, related :issue:`5004`)
  - ``MultiIndex`` constructor now validates that passed levels and labels are
    compatible. (:issue:`5213`, :issue:`5214`)
+ - Unity ``dropna`` for Series/DataFrame signature (:issue:`5250`),
+   tests from :issue:`5234`, courtesy of @rockg
 
 .. _release.bug_fixes-0.13.0:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2459,8 +2459,6 @@ class DataFrame(NDFrame):
             return result
 
         axis = self._get_axis_number(axis)
-        if axis not in (0, 1):  # pragma: no cover
-            raise AssertionError('axis must be 0 or 1')
         agg_axis = 1 - axis
 
         agg_obj = self

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -615,7 +615,7 @@ class Panel(NDFrame):
         return Panel(new_values, items=new_items, major_axis=new_major,
                      minor_axis=new_minor)
 
-    def dropna(self, axis=0, how='any'):
+    def dropna(self, axis=0, how='any', **kwargs):
         """
         Drop 2D from panel, holding passed axis constant
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2178,7 +2178,7 @@ class Series(generic.NDFrame):
                   index_label=index_label, mode=mode, nanRep=nanRep,
                   encoding=encoding, date_format=date_format)
 
-    def dropna(self):
+    def dropna(self, axis=0, **kwargs):
         """
         Return Series without null values
 
@@ -2186,6 +2186,7 @@ class Series(generic.NDFrame):
         -------
         valid : Series
         """
+        axis = self._get_axis_number(axis or 0)
         return remove_na(self)
 
     valid = lambda self: self.dropna()

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -569,11 +569,12 @@ class SparseSeries(Series):
             return self._constructor(new_array, index=self.index, sparse_index=new_array.sp_index).__finalize__(self)
         return Series(new_array, index=self.index).__finalize__(self)
 
-    def dropna(self):
+    def dropna(self, axis=0, **kwargs):
         """
         Analogous to Series.dropna. If fill_value=NaN, returns a dense Series
         """
         # TODO: make more efficient
+        axis = self._get_axis_number(axis or 0)
         dense_valid = self.to_dense().valid()
         if isnull(self.fill_value):
             return dense_valid

--- a/pandas/stats/tests/test_ols.py
+++ b/pandas/stats/tests/test_ols.py
@@ -379,6 +379,9 @@ class TestOLSMisc(unittest.TestCase):
         expected = ols(y=y, x={'x': x})
         assert_series_equal(model.beta, expected.beta)
 
+        # GH 5233/5250
+        assert_series_equal(model.y_predict, model.predict(x=x))
+
     def test_various_attributes(self):
         # just make sure everything "works". test correctness elsewhere
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -3550,6 +3550,9 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         s = Series([])
         self.assert_(len(s.dropna()) == 0)
 
+        # invalid axis
+        self.assertRaises(ValueError, s.dropna, axis=1)
+
     def test_drop_duplicates(self):
         s = Series([1, 2, 3, 3])
 


### PR DESCRIPTION
closes #5233
closes #5234
closes #5250
