### PR TITLE
BUG: Pagination in pandas.io.gbq

### DIFF
--- a/ci/requirements-2.6.txt
+++ b/ci/requirements-2.6.txt
@@ -4,4 +4,4 @@ python-dateutil==1.5
 pytz==2013b
 http://www.crummy.com/software/BeautifulSoup/bs4/download/4.2/beautifulsoup4-4.2.0.tar.gz
 html5lib==1.0b2
-bigquery==2.0.15
+bigquery==2.0.17

--- a/ci/requirements-2.7.txt
+++ b/ci/requirements-2.7.txt
@@ -18,4 +18,4 @@ MySQL-python==1.2.4
 scipy==0.10.0
 beautifulsoup4==4.2.1
 statsmodels==0.5.0
-bigquery==2.0.15
+bigquery==2.0.17

--- a/ci/requirements-2.7_LOCALE.txt
+++ b/ci/requirements-2.7_LOCALE.txt
@@ -16,4 +16,4 @@ lxml==3.2.1
 scipy==0.10.0
 beautifulsoup4==4.2.1
 statsmodels==0.5.0
-bigquery==2.0.15
+bigquery==2.0.17

--- a/pandas/io/tests/test_gbq.py
+++ b/pandas/io/tests/test_gbq.py
@@ -40,20 +40,21 @@ class FakeClient:
 # Fake Google BigQuery API Client
 class FakeApiClient:
     def __init__(self):
-        self._tabledata = FakeTableData()
+        self._fakejobs = FakeJobs()
         
 
-    def tabledata(self):
-        return self._tabledata
+    def jobs(self):
+        return self._fakejobs
 
-class FakeTableData:
+class FakeJobs:
     def __init__(self): 
-        self._list = FakeList()
+        self._fakequeryresults = FakeResults()
 
-    def list(self,maxResults = None, pageToken = None, **table_dict):
-        return self._list   
+    def getQueryResults(self, job_id=None, project_id=None,
+                        max_results=None, timeout_ms=None, **kwargs):
+        return self._fakequeryresults   
 
-class FakeList:
+class FakeResults:
     def execute(self):
         return {'rows': [  {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'brave'}, {'v': '3'}]},
                             {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'attended'}, {'v': '1'}]},
@@ -68,7 +69,8 @@ class FakeList:
                         ],
                 'kind': 'bigquery#tableDataList',
                 'etag': '"4PTsVxg68bQkQs1RJ1Ndewqkgg4/hoRHzb4qfhJAIa2mEewC-jhs9Bg"',
-                'totalRows': '10'}
+                'totalRows': '10',
+                'jobComplete' : True}
 
 ####################################################################################
 
@@ -225,16 +227,16 @@ class test_gbq(unittest.TestCase):
         correct_frame_small = DataFrame(correct_frame_small)[col_order]
         tm.assert_index_equal(result_frame.columns, correct_frame_small.columns)
 
-    # @with_connectivity_check
-    # def test_download_dataset_larger_than_100k_rows(self):
-    #     # Test for known BigQuery bug in datasets larger than 100k rows
-    #     # http://stackoverflow.com/questions/19145587/bq-py-not-paging-results
-    #     if not os.path.exists(self.bq_token):
-    #         raise nose.SkipTest('Skipped because authentication information is not available.')
+    @with_connectivity_check
+    def test_download_dataset_larger_than_100k_rows(self):
+        # Test for known BigQuery bug in datasets larger than 100k rows
+        # http://stackoverflow.com/questions/19145587/bq-py-not-paging-results
+        if not os.path.exists(self.bq_token):
+            raise nose.SkipTest('Skipped because authentication information is not available.')
 
-    #     client = gbq._authenticate()
-    #     a = gbq.read_gbq("SELECT id, FROM [publicdata:samples.wikipedia] LIMIT 100005")
-    #     self.assertTrue(len(a) == 100005)
+        client = gbq._authenticate()
+        a = gbq.read_gbq("SELECT id, FROM [publicdata:samples.wikipedia] LIMIT 100005")
+        self.assertTrue(len(a) == 100005)
 
     @with_connectivity_check
     def test_download_all_data_types(self):


### PR DESCRIPTION
In light of some last minute API changes in Google BigQuery, I have updated our code to function properly. In particular, this fixes a known bug that limited result sets to 10,000. Hopefully we'll have an entirely new version soon that will make better use of Google's reference code and thus be more future proof. Note that bigquery v2.0.17 is new as of today... 2.0.16 tested fine, but they fixed a few important backend things so we went ahead and made the change mandatory in light of the pandas release candidate.

See:
closes https://github.com/pydata/pandas/issues/5255
