### PR TITLE
BUG: Fixed issue #5156: segfault on read_csv

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -183,6 +183,7 @@ Improvements to existing features
   - ``Series`` now supports a ``to_frame`` method to convert it to a single-column DataFrame (:issue:`5164`)
   - DatetimeIndex (and date_range) can now be constructed in a left- or
     right-open fashion using the ``closed`` parameter (:issue:`4579`)
+  - Python csv parser now supports usecols (:issue:`4335`)
 
 API Changes
 ~~~~~~~~~~~
@@ -625,6 +626,8 @@ Bug Fixes
   - Fixed bug in Excel writers where frames with duplicate column names weren't
     written correctly. (:issue:`5235`)
   - Fixed issue with ``drop`` and a non-unique index on Series (:issue:`5248`)
+  - Fixed seg fault in C parser caused by passing more names than columns in
+    the file. (:issue:`5156`)
 
 pandas 0.12.0
 -------------

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -1955,6 +1955,15 @@ a,b,c
         result = self.read_csv(StringIO(data), header=None, sep='\s+')
         self.assertTrue(result[0].dtype == np.float64)
 
+    def test_catch_too_many_names(self):
+        # Issue 5156
+        data = """\
+1,2,3
+4,,6
+7,8,9
+10,11,12\n"""
+        tm.assertRaises(Exception, read_csv, StringIO(data), header=0, names=['a', 'b', 'c', 'd'])
+
 
 class TestPythonParser(ParserTests, unittest.TestCase):
     def test_negative_skipfooter_raises(self):

--- a/pandas/src/parser/tokenizer.c
+++ b/pandas/src/parser/tokenizer.c
@@ -709,7 +709,6 @@ int tokenize_delimited(parser_t *self, size_t line_limit)
             if (c == '\n') {
                 END_FIELD();
                 END_LINE();
-                /* self->state = START_RECORD; */
             } else if (c == '\r') {
                 END_FIELD();
                 self->state = EAT_CRNL;

--- a/pandas/src/parser/tokenizer.h
+++ b/pandas/src/parser/tokenizer.h
@@ -161,7 +161,7 @@ typedef struct parser_t {
 
     int *line_start;      // position in words for start of line
     int *line_fields;     // Number of fields in each line
-    int lines;            // Number of (good) lines observedb
+    int lines;            // Number of (good) lines observed
     int file_lines;       // Number of file lines observed (including bad or skipped)
     int lines_cap;        // Vector capacity
 


### PR DESCRIPTION
closes #5156 

Our c parser was not checking array bounds. 

Example:

```
In [1]: from StringIO import StringIO; import pandas as pd

In [2]: data = """\     
1,2,3                      
4,,6
7,8,9                      
10,11,12\n"""

In [3]: df = pd.read_csv(StringIO(data), header=0, names=['a', 'b', 'c', 'd'], engine='c')
CParserError: Too many columns specified: expected 4 and found 3
```

Previously, this would segfault.
