### PR TITLE
API: Add equals method to NDFrames.

### DIFF
--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -215,6 +215,14 @@ These operations produce a pandas object the same type as the left-hand-side inp
 that if of dtype ``bool``. These ``boolean`` objects can be used in indexing operations,
 see :ref:`here<indexing.boolean>`
 
+As of v0.13.1, Series, DataFrames and Panels have an equals method to compare if
+two such objects are equal.
+
+.. ipython:: python
+
+   df.equals(df)
+   df.equals(df2)
+
 .. _basics.reductions:
 
 Boolean Reductions

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -66,6 +66,7 @@ API Changes
     timedeltas (:issue:`5458`,:issue:`5689`)
   - Add ``-NaN`` and ``-nan`` to the default set of NA values
     (:issue:`5952`).  See :ref:`NA Values <io.na_values>`.
+  - ``NDFrame`` now has an ``equals`` method. (:issue:`5283`) 
 
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/v0.13.1.txt
+++ b/doc/source/v0.13.1.txt
@@ -42,6 +42,21 @@ API changes
 
 - Add ``-NaN`` and ``-nan`` to the default set of NA values (:issue:`5952`).
   See :ref:`NA Values <io.na_values>`.
+- Added the ``NDFrame.equals()`` method to compare if two NDFrames are
+  equal have equal axes, dtypes, and values. Added the
+  ``array_equivalent`` function to compare if two ndarrays are
+  equal. NaNs in identical locations are treated as
+  equal. (:issue:`5283`)
+
+  .. ipython:: python
+
+      df = DataFrame({'col':['foo', 0, np.nan]}).sort()
+      df2 = DataFrame({'col':[np.nan, 0, 'foo']}, index=[2,1,0])
+      df.equals(df)
+
+      import pandas.core.common as com
+      com.array_equivalent(np.array([0, np.nan]), np.array([0, np.nan]))
+      np.array_equal(np.array([0, np.nan]), np.array([0, np.nan]))
 
 Prior Version Deprecations/Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -277,6 +277,42 @@ def notnull(obj):
     return -res
 
 
+def array_equivalent(left, right):
+    """
+    True if two arrays, left and right, have equal non-NaN elements, and NaNs in
+    corresponding locations.  False otherwise. It is assumed that left and right
+    are NumPy arrays of the same dtype. The behavior of this function
+    (particularly with respect to NaNs) is not defined if the dtypes are
+    different.
+
+    Parameters
+    ----------
+    left, right : array_like
+        Input arrays.
+
+    Returns
+    -------
+    b : bool
+        Returns True if the arrays are equivalent.
+
+    Examples
+    --------
+    >>> array_equivalent([1, 2, nan], np.array([1, 2, nan]))
+    True
+    >>> array_equivalent([1, nan, 2], [1, 2, nan])
+    False
+    """
+    if left.shape != right.shape: return False
+    # NaNs occur only in object arrays, float or complex arrays.
+    if left.dtype == np.object_:
+        # If object array, we need to use pd.isnull
+        return ((left == right) | pd.isnull(left) & pd.isnull(right)).all()
+    elif not issubclass(left.dtype.type, (np.floating, np.complexfloating)):
+        # if not a float or complex array, then there are no NaNs
+        return np.array_equal(left, right)
+    # For float or complex arrays, using np.isnan is faster than pd.isnull
+    return  ((left == right) | (np.isnan(left) & np.isnan(right))).all()
+
 def _iterable_not_string(x):
     return (isinstance(x, collections.Iterable) and
             not isinstance(x, compat.string_types))

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -608,6 +608,15 @@ class NDFrame(PandasObject):
         arr = operator.inv(_values_from_object(self))
         return self._wrap_array(arr, self.axes, copy=False)
 
+    def equals(self, other):
+        """
+        Determines if two NDFrame objects contain the same elements. NaNs in the
+        same location are considered equal.
+        """
+        if not isinstance(other, self._constructor):
+            return False
+        return self._data.equals(other._data)
+            
     #----------------------------------------------------------------------
     # Iteration
 

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -5,11 +5,10 @@ import nose
 from nose.tools import assert_equal
 import numpy as np
 from pandas.tslib import iNaT, NaT
-
 from pandas import Series, DataFrame, date_range, DatetimeIndex, Timestamp
 from pandas import compat
 from pandas.compat import range, long, lrange, lmap, u
-from pandas.core.common import notnull, isnull
+from pandas.core.common import notnull, isnull, array_equivalent
 import pandas.core.common as com
 import pandas.util.testing as tm
 import pandas.core.config as cf
@@ -166,6 +165,19 @@ def test_downcast_conv():
         arr = np.array([1.0,2.0,np.nan],dtype=dtype)
         result = com._possibly_downcast_to_dtype(arr,'infer')
         tm.assert_almost_equal(result, expected)
+
+
+def test_array_equivalent():
+    assert array_equivalent(np.array([np.nan, np.nan]), np.array([np.nan, np.nan]))
+    assert array_equivalent(np.array([np.nan, 1, np.nan]), np.array([np.nan, 1, np.nan]))
+    assert array_equivalent(np.array([np.nan, None], dtype='object'),
+                            np.array([np.nan, None], dtype='object'))
+    assert array_equivalent(np.array([np.nan, 1+1j], dtype='complex'),
+                            np.array([np.nan, 1+1j], dtype='complex'))
+    assert not array_equivalent(np.array([np.nan, 1+1j], dtype='complex'),
+                                np.array([np.nan, 1+2j], dtype='complex'))
+    assert not array_equivalent(np.array([np.nan, 1, np.nan]), np.array([np.nan, 2, np.nan]))
+    assert not array_equivalent(np.array(['a', 'b', 'c', 'd']), np.array(['e', 'e']))
 
 def test_datetimeindex_from_empty_datetime64_array():
     for unit in [ 'ms', 'us', 'ns' ]:

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -584,6 +584,27 @@ class TestBlockManager(tm.TestCase):
         except KeyError:
             pass  # this is the expected exception
 
+    def test_equals(self):
+        # unique items
+        index = Index(list('abcdef'))
+        block1 = make_block(np.arange(12).reshape(3,4), list('abc'), index)
+        block2 = make_block(np.arange(12).reshape(3,4)*10, list('def'), index)
+        block1.ref_items = block2.ref_items = index
+        bm1 = BlockManager([block1, block2], [index, np.arange(block1.shape[1])])
+        bm2 = BlockManager([block2, block1], [index, np.arange(block1.shape[1])])
+        self.assert_(bm1.equals(bm2))
+
+        # non-unique items
+        index = Index(list('aaabbb'))
+        block1 = make_block(np.arange(12).reshape(3,4), list('aaa'), index,
+                            placement=[0,1,2])
+        block2 = make_block(np.arange(12).reshape(3,4)*10, list('bbb'), index,
+                            placement=[3,4,5])
+        block1.ref_items = block2.ref_items = index
+        bm1 = BlockManager([block1, block2], [index, np.arange(block1.shape[1])])
+        bm2 = BlockManager([block2, block1], [index, np.arange(block1.shape[1])])
+        self.assert_(bm1.equals(bm2))
+        
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -436,6 +436,7 @@ def isiterable(obj):
 def is_sorted(seq):
     return assert_almost_equal(seq, np.sort(np.array(seq)))
 
+# This could be refactored to use the NDFrame.equals method
 def assert_series_equal(left, right, check_dtype=True,
                         check_index_type=False,
                         check_series_type=False,
@@ -455,7 +456,7 @@ def assert_series_equal(left, right, check_dtype=True,
         assert_attr_equal('dtype', left.index, right.index)
         assert_attr_equal('inferred_type', left.index, right.index)
 
-
+# This could be refactored to use the NDFrame.equals method
 def assert_frame_equal(left, right, check_dtype=True,
                        check_index_type=False,
                        check_column_type=False,

--- a/vb_suite/frame_methods.py
+++ b/vb_suite/frame_methods.py
@@ -370,3 +370,36 @@ df = DataFrame(np.random.randn(1000,1000))
 frame_dtypes = Benchmark('df.dtypes', setup,
                          start_date=datetime(2012,1,1))
 
+#----------------------------------------------------------------------
+# equals
+setup = common_setup + """
+def make_pair(name):
+    df = globals()[name]
+    df2 = df.copy()
+    df2.ix[-1,-1] = np.nan
+    return df, df2
+
+def test_equal(name):
+    df, df2 = pairs[name]
+    return df.equals(df)
+
+def test_unequal(name):
+    df, df2 = pairs[name]
+    return df.equals(df2)
+    
+float_df = DataFrame(np.random.randn(1000, 1000))
+object_df = DataFrame([['foo']*1000]*1000)
+nonunique_cols = object_df.copy()
+nonunique_cols.columns = ['A']*len(nonunique_cols.columns)
+
+pairs = dict([(name,make_pair(name))
+         for name in ('float_df', 'object_df', 'nonunique_cols')])
+"""
+frame_float_equal = Benchmark('test_equal("float_df")', setup)
+frame_object_equal = Benchmark('test_equal("object_df")', setup)
+frame_nonunique_equal = Benchmark('test_equal("nonunique_cols")', setup)
+
+frame_float_unequal = Benchmark('test_unequal("float_df")', setup)
+frame_object_unequal = Benchmark('test_unequal("object_df")', setup)
+frame_nonunique_unequal = Benchmark('test_unequal("nonunique_cols")', setup)
+


### PR DESCRIPTION
Also adds `array_equivalent`, which
is similar to `np.array_equal` except that it handles object arrays and
treats NaNs in corresponding locations as equal.

closes https://github.com/pydata/pandas/issues/5183
