### PR TITLE
DOC: expand JSON docs

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -102,6 +102,8 @@ Improvements to existing features
   - Significant table writing performance improvements in ``HDFStore``
   - JSON date serialisation now performed in low-level C code.
   - JSON support for encoding datetime.time
+  - Expanded JSON docs, more info about orient options and the use of the numpy
+    param when decoding.
   - Add ``drop_level`` argument to xs (:issue:`4180`)
   - Can now resample a DataFrame with ohlc (:issue:`2320`)
   - ``Index.copy()`` and ``MultiIndex.copy()`` now accept keyword arguments to

--- a/pandas/io/json.py
+++ b/pandas/io/json.py
@@ -153,8 +153,9 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=True,
     keep_default_dates : boolean, default True.
         If parsing dates, then parse the default datelike columns
     numpy : boolean, default False
-        Direct decoding to numpy arrays. Note that the JSON ordering MUST be
-        the same for each term if numpy=True.
+        Direct decoding to numpy arrays. Supports numeric data only, but
+        non-numeric column and index labels are supported. Note also that the
+        JSON ordering MUST be the same for each term if numpy=True.
     precise_float : boolean, default False.
         Set to enable usage of higher precision (strtod) function when
         decoding string to double values. Default (False) is to use fast but


### PR DESCRIPTION
closes #4703

Expanded JSON docs to add more detail about the different orient options and the use of the numpy param when decoding.

Feedback welcome.
