### PR TITLE
BUG: setting on a frame without an index silently was failing, related (GH5226)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -210,8 +210,8 @@ API Changes
     an alias of iteritems used to get around ``2to3``'s changes).
     (:issue:`4384`, :issue:`4375`, :issue:`4372`)
   - ``Series.get`` with negative indexers now returns the same as ``[]`` (:issue:`4390`)
-  - allow ``ix/loc`` for Series/DataFrame/Panel to set on any axis even when the single-key is not currently contained in
-    the index for that axis (:issue:`2578`, :issue:`5226`)
+  - allow ``ix/loc`` for Series/DataFrame/Panel to set on any axis even when the single-key
+    is not currently contained in the index for that axis (:issue:`2578`, :issue:`5226`)
   - Default export for ``to_clipboard`` is now csv with a sep of `\t` for
     compat (:issue:`3368`)
   - ``at`` now will enlarge the object inplace (and return the same) (:issue:`2578`)

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1632,7 +1632,6 @@ def _default_index(n):
 def ensure_float(arr):
     if issubclass(arr.dtype.type, (np.integer, np.bool_)):
         arr = arr.astype(float)
-
     return arr
 
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1573,7 +1573,13 @@ class DataFrame(NDFrame):
                 if isinstance(label, Index):
                     return self.take(i, axis=1, convert=True)
 
+                # if the values returned are not the same length
+                # as the index (iow a not found value), iget returns
+                # a 0-len ndarray. This is effectively catching
+                # a numpy error (as numpy should really raise)
                 values = self._data.iget(i)
+                if not len(values):
+                    values = np.array([np.nan]*len(self.index),dtype=object)
                 return self._constructor_sliced.from_array(
                     values, index=self.index,
                     name=label, fastpath=True)

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -300,12 +300,18 @@ def nanmin(values, axis=None, skipna=True):
             apply_ax = axis if axis is not None else 0
             result = np.apply_along_axis(builtins.min, apply_ax, values)
         else:
-            result = builtins.min(values)
+            try:
+                result = builtins.min(values)
+            except:
+                result = np.nan
     else:
         if ((axis is not None and values.shape[axis] == 0)
                 or values.size == 0):
-            result = com.ensure_float(values.sum(axis))
-            result.fill(np.nan)
+            try:
+                result = com.ensure_float(values.sum(axis))
+                result.fill(np.nan)
+            except:
+                result = np.nan
         else:
             result = values.min(axis)
 
@@ -324,12 +330,18 @@ def nanmax(values, axis=None, skipna=True):
             apply_ax = axis if axis is not None else 0
             result = np.apply_along_axis(builtins.max, apply_ax, values)
         else:
-            result = builtins.max(values)
+            try:
+                result = builtins.max(values)
+            except:
+                result = np.nan
     else:
         if ((axis is not None and values.shape[axis] == 0)
                 or values.size == 0):
-            result = com.ensure_float(values.sum(axis))
-            result.fill(np.nan)
+            try:
+                result = com.ensure_float(values.sum(axis))
+                result.fill(np.nan)
+            except:
+                result = np.nan
         else:
             result = values.max(axis)
 

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -1592,6 +1592,26 @@ class TestIndexing(unittest.TestCase):
         df.loc[3] = [6,7]
         assert_frame_equal(df,DataFrame([[6,7]],index=[3],columns=['A','B']))
 
+        # no label overlap
+        df = DataFrame(columns=['A','B'])
+        df.loc[0] = Series(1,index=range(4))
+        assert_frame_equal(df,DataFrame(columns=['A','B'],index=[0]))
+
+        # no index to start
+        expected = DataFrame({ 0 : Series(1,index=range(4)) },columns=['A','B',0])
+
+        df = DataFrame(columns=['A','B'])
+        df[0] = Series(1,index=range(4))
+        df.dtypes
+        str(df)
+        assert_frame_equal(df,expected)
+
+        df = DataFrame(columns=['A','B'])
+        df.loc[:,0] = Series(1,index=range(4))
+        df.dtypes
+        str(df)
+        assert_frame_equal(df,expected)
+
     def test_cache_updating(self):
         # GH 4939, make sure to update the cache on setitem
 


### PR DESCRIPTION
related to #5226

the following would previously silently fail:

```
In [3]: df = DataFrame(columns=['A','B'])

In [4]: df[0] = Series(1,index=range(4))

In [5]: df
Out[5]: 
     A    B  0
0  NaN  NaN  1
1  NaN  NaN  1
2  NaN  NaN  1
3  NaN  NaN  1
```
