### PR TITLE
Revert print_skipped.py changes for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,3 +48,4 @@ script:
 
 after_script:
   - ci/print_versions.py
+  - ci/print_skipped.py /tmp/nosetests.xml

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -55,9 +55,6 @@ if [ -n "$LOCALE_OVERRIDE" ]; then
     time sudo locale-gen "$LOCALE_OVERRIDE"
 fi
 
-# show-skipped is working at this particular commit
-show_skipped_commit=fa4ff84e53c09247753a155b428c1bf2c69cb6c3
-time pip install git+git://github.com/cpcloud/nose-show-skipped.git@$show_skipped_commit
 time pip install $PIP_ARGS -r ci/requirements-${wheel_box}.txt
 
 # we need these for numpy

--- a/ci/print_skipped.py
+++ b/ci/print_skipped.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+import sys
+import math
+import xml.etree.ElementTree as et
+
+
+def parse_results(filename):
+    tree = et.parse(filename)
+    root = tree.getroot()
+    skipped = []
+
+    current_class = old_class = ''
+    i = 1
+    assert i - 1 == len(skipped)
+    for el in root.findall('testcase'):
+        cn = el.attrib['classname']
+        for sk in el.findall('skipped'):
+            old_class = current_class
+            current_class = cn
+            name = '{classname}.{name}'.format(classname=current_class,
+                                               name=el.attrib['name'])
+            msg = sk.attrib['message']
+            out = ''
+            if old_class != current_class:
+                ndigits = int(math.log(i, 10) + 1)
+                out += ('-' * (len(name + msg) + 4 + ndigits) + '\n') # 4 for : + space + # + space
+            out += '#{i} {name}: {msg}'.format(i=i, name=name, msg=msg)
+            skipped.append(out)
+            i += 1
+            assert i - 1 == len(skipped)
+    assert i - 1 == len(skipped)
+    assert len(skipped) == int(root.attrib['skip'])
+    return '\n'.join(skipped)
+
+
+def main(args):
+    print('SKIPPED TESTS:')
+    print(parse_results(args.filename))
+    return 0
+
+
+def parse_args():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('filename', help='XUnit file to parse')
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    sys.exit(main(parse_args()))

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -9,5 +9,5 @@ if [ -n "$LOCALE_OVERRIDE" ]; then
     python -c "$pycmd"
 fi
 
-echo nosetests --exe -w /tmp -A "$NOSE_ARGS" pandas --show-skipped
-nosetests --exe -w /tmp -A "$NOSE_ARGS" pandas --show-skipped
+echo nosetests --exe -w /tmp -A "$NOSE_ARGS" pandas --with-xunit --xunit-file=/tmp/nosetests.xml
+nosetests --exe -w /tmp -A "$NOSE_ARGS" pandas --with-xunit --xunit-file=/tmp/nosetests.xml


### PR DESCRIPTION
goes back to @cpcloud's original plugin that echo'd separately. Just
until @cpcloud has time to implement this for nose-skipped.

Just makes it much easier to read through Travis builds (especially for
new users) if the print_skipped stuff is hidden at first glance.
