### PR TITLE
ENH: Make 'rows' an axis alias for 'index'

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4358,8 +4358,8 @@ class DataFrame(NDFrame):
         return self.mul(other, fill_value=1.)
 
 
-DataFrame._setup_axes(
-    ['index', 'columns'], info_axis=1, stat_axis=0, axes_are_reversed=True)
+DataFrame._setup_axes(['index', 'columns'], info_axis=1, stat_axis=0,
+                      axes_are_reversed=True, aliases={'rows': 0})
 DataFrame._add_numeric_operations()
 
 _EMPTY_SERIES = Series([])

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2381,7 +2381,8 @@ class Series(generic.NDFrame):
         new_index = self.index.to_period(freq=freq)
         return self._constructor(new_values, index=new_index).__finalize__(self)
 
-Series._setup_axes(['index'], info_axis=0, stat_axis=0)
+Series._setup_axes(['index'], info_axis=0, stat_axis=0,
+                   aliases={'rows': 0})
 Series._add_numeric_operations()
 _INDEX_TYPES = ndarray, Index, list, tuple
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1930,11 +1930,13 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         self.assertEquals(f._get_axis_number(0), 0)
         self.assertEquals(f._get_axis_number(1), 1)
         self.assertEquals(f._get_axis_number('index'), 0)
+        self.assertEquals(f._get_axis_number('rows'), 0)
         self.assertEquals(f._get_axis_number('columns'), 1)
 
         self.assertEquals(f._get_axis_name(0), 'index')
         self.assertEquals(f._get_axis_name(1), 'columns')
         self.assertEquals(f._get_axis_name('index'), 'index')
+        self.assertEquals(f._get_axis_name('rows'), 'index')
         self.assertEquals(f._get_axis_name('columns'), 'columns')
 
         self.assert_(f._get_axis(0) is f.index)
@@ -8399,6 +8401,8 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         df = create().fillna(0)
         expected = df.apply(lambda x, y: x.where(x>0,y), y=df[0])
         result = df.where(df>0,df[0],axis='index')
+        assert_frame_equal(result, expected)
+        result = df.where(df>0,df[0],axis='rows')
         assert_frame_equal(result, expected)
 
         # frame

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -3566,6 +3566,13 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         # invalid axis
         self.assertRaises(ValueError, s.dropna, axis=1)
 
+    def test_axis_alias(self):
+        s = Series([1, 2, np.nan])
+        assert_series_equal(s.dropna(axis='rows'), s.dropna(axis='index'))
+        self.assertEqual(s.dropna().sum('rows'), 3)
+        self.assertEqual(s._get_axis_number('rows'), 0)
+        self.assertEqual(s._get_axis_name('rows'), 'index')
+
     def test_drop_duplicates(self):
         s = Series([1, 2, 3, 3])
 


### PR DESCRIPTION
Think this covers it - think I have an appropriate number of cases too.
I don't actually want to put this in the docs, as it's just for
convenience. Thoughts on that?
