### PR TITLE
TST: changes AssertionErrors in core/generic/_construct_axes_from_arguments to Type/Value Errors

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -233,7 +233,7 @@ class NDFrame(PandasObject):
             if alias is not None:
                 if a in kwargs:
                     if alias in kwargs:
-                        raise Exception(
+                        raise TypeError(
                             "arguments are multually exclusive for [%s,%s]" % (a, alias))
                     continue
                 if alias in kwargs:
@@ -246,8 +246,8 @@ class NDFrame(PandasObject):
                     kwargs[a] = args.pop(0)
                 except (IndexError):
                     if require_all:
-                        raise AssertionError(
-                            "not enough arguments specified!")
+                        raise TypeError(
+                            "not enough/duplicate arguments specified!")
 
         axes = dict([(a, kwargs.get(a)) for a in self._AXIS_ORDERS])
         return axes, kwargs

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1248,14 +1248,12 @@ class TestPanel(unittest.TestCase, PanelTests, CheckIndexing,
         expected = self.panel.swapaxes('items', 'minor')
         assert_panel_equal(result, expected)
 
-        ## test bad aliases
-        # test ambiguous aliases
-        self.assertRaises(AssertionError, self.panel.transpose, 'minor',
-                          maj='major', majo='items')
+        # duplicate axes
+        with tm.assertRaisesRegexp(TypeError, 'not enough/duplicate arguments'):
+            self.panel.transpose('minor', maj='major', minor='items')
 
-        # test invalid kwargs
-        self.assertRaises(AssertionError, self.panel.transpose, 'minor',
-                          maj='major', minor='items')
+        with tm.assertRaisesRegexp(ValueError, 'repeated axis in transpose'):
+            self.panel.transpose('minor', 'major', major='minor', minor='items')
 
         result = self.panel.transpose(2, 1, 0)
         assert_panel_equal(result, expected)


### PR DESCRIPTION
closes #5051
