### PR TITLE
PERF: vbench for time-series index assignment in frame (GH5320)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1914,7 +1914,11 @@ class DataFrame(NDFrame):
     def _sanitize_column(self, key, value):
         # Need to make sure new columns (which go into the BlockManager as new
         # blocks) are always copied
-        if _is_sequence(value):
+
+        # dont' need further processing on an equal index
+        if isinstance(value, Index) and (not len(self.index) or value.equals(self.index)):
+                value = value.values.copy()
+        elif isinstance(value, Series) or _is_sequence(value):
             is_frame = isinstance(value, DataFrame)
             if isinstance(value, Series) or is_frame:
                 if value.index.equals(self.index) or not len(self.index):

--- a/vb_suite/frame_methods.py
+++ b/vb_suite/frame_methods.py
@@ -121,6 +121,21 @@ frame_getitem_single_column2 = Benchmark('j()', setup,
                                          start_date=datetime(2010, 6, 1))
 
 #----------------------------------------------------------------------
+# assignment
+
+setup = common_setup + """
+idx = date_range('1/1/2000', periods=100000, freq='D')
+df = DataFrame(randn(100000, 1),columns=['A'],index=idx)
+def f(x):
+    x = x.copy()
+    x['date'] = x.index
+"""
+
+frame_assign_timeseries_index = Benchmark('f(df)', setup,
+                                          start_date=datetime(2013, 10, 1))
+
+
+#----------------------------------------------------------------------
 # to_string
 
 setup = common_setup + """

--- a/vb_suite/timeseries.py
+++ b/vb_suite/timeseries.py
@@ -229,12 +229,12 @@ datetimeindex_unique = Benchmark('index.unique()', setup,
 # tz_localize with infer argument.  This is an attempt to emulate the results
 # of read_csv with duplicated data.  Not passing infer_dst will fail
 setup = common_setup + """
-dst_rng = date_range('10/29/2000 1:00:00', 
+dst_rng = date_range('10/29/2000 1:00:00',
                      '10/29/2000 1:59:59', freq='S')
 index = date_range('10/29/2000', '10/29/2000 00:59:59', freq='S')
 index = index.append(dst_rng)
 index = index.append(dst_rng)
-index = index.append(date_range('10/29/2000 2:00:00', 
+index = index.append(date_range('10/29/2000 2:00:00',
                                 '10/29/2000 3:00:00', freq='S'))
 """
 


### PR DESCRIPTION
PERF: direct index assignment in a frame was doing lots of work

closes #5320

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
frame_assign_timeseries_index                |   0.7157 | 398.8634 |   0.0018 |
```
