### PR TITLE
BUG: when trying to use an out-of-bounds date as an object dtype (GH5312)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -636,6 +636,7 @@ Bug Fixes
   - Fix ``Series.isin`` with date/time-like dtypes (:issue:`5021`)
   - C and Python Parser can now handle the more common multi-index column format
     which doesn't have a row for index names (:issue:`4702`)
+  - Bug when trying to use an out-of-bounds date as an object dtype (:issue:`5312`)
 
 pandas 0.12.0
 -------------

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1789,14 +1789,15 @@ def make_block(values, items, ref_items, klass=None, ndim=None, dtype=None, fast
             if np.prod(values.shape):
                 flat = values.ravel()
                 inferred_type = lib.infer_dtype(flat)
-                if inferred_type == 'datetime':
+                if inferred_type in ['datetime','datetime64']:
 
                     # we have an object array that has been inferred as datetime, so
                     # convert it
                     try:
                         values = tslib.array_to_datetime(
                             flat).reshape(values.shape)
-                        klass = DatetimeBlock
+                        if issubclass(values.dtype.type, np.datetime64):
+                            klass = DatetimeBlock
                     except:  # it already object, so leave it
                         pass
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -539,6 +539,13 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         self.assertRaises(
             TypeError, lambda x: Series(dates, dtype='datetime64'))
 
+        # invalid dates can be help as object
+        result = Series([datetime(2,1,1)])
+        self.assert_(result[0] == datetime(2,1,1,0,0))
+
+        result = Series([datetime(3000,1,1)])
+        self.assert_(result[0] == datetime(3000,1,1,0,0))
+
     def test_constructor_dict(self):
         d = {'a': 0., 'b': 1., 'c': 2.}
         result = Series(d, index=['b', 'c', 'd', 'a'])


### PR DESCRIPTION
closes 1st issue in #5312
