### PR TITLE
BUG: bug when trying to display an embedded PandasObject (GH5324)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -637,6 +637,7 @@ Bug Fixes
   - C and Python Parser can now handle the more common multi-index column format
     which doesn't have a row for index names (:issue:`4702`)
   - Bug when trying to use an out-of-bounds date as an object dtype (:issue:`5312`)
+  - Bug when trying to display an embedded PandasObject (:issue:`5324`)
 
 pandas 0.12.0
 -------------

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import sys
 
+from pandas.core.base import PandasObject
 from pandas.core.common import adjoin, isnull, notnull
 from pandas.core.index import Index, MultiIndex, _ensure_index
 from pandas import compat
@@ -1486,6 +1487,8 @@ class GenericArrayFormatter(object):
                 if x is None:
                     return 'None'
                 return self.na_rep
+            elif isinstance(x, PandasObject):
+                return '%s' % x
             else:
                 # object dtype
                 return '%s' % formatter(x)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2356,6 +2356,21 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         with assertRaisesRegexp(ValueError, 'If using all scalar values, you must must pass an index'):
             DataFrame({'a': False, 'b': True})
 
+    def test_constructor_with_embedded_frames(self):
+
+        # embedded data frames
+        df1 = DataFrame({'a':[1, 2, 3], 'b':[3, 4, 5]})
+        df2 = DataFrame([df1, df1+10])
+
+        df2.dtypes
+        str(df2)
+
+        result = df2.loc[0,0]
+        assert_frame_equal(result,df1)
+
+        result = df2.loc[1,0]
+        assert_frame_equal(result,df1+10)
+
     def test_insert_error_msmgs(self):
 
         # GH 4107, more descriptive error message


### PR DESCRIPTION
closes #5324

There was a bug where this wasn't display at all, so this PR fixes

Do we care about formatting _embedded_ pandas objects? (as we don't recommend this anyhow)

```
In [15]: df1 = DataFrame({'a':[1, 2, 3], 'b':[3, 4, 5]})

In [19]: df2.dtypes
Out[19]: 
0    object
dtype: object

In [16]: df1
Out[16]: 
   a  b
0  1  3
1  2  4
2  3  5

In [17]: df2 = DataFrame([df1,df1+10])

In [18]: df2
Out[18]: 
                                         0
0             a  b
0  1  3
1  2  4
2  3  5
1      a   b
0  11  13
1  12  14
2  13  15
```
