### PR TITLE
ENH: Add option to highlight NaN cells

### DIFF
--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -181,6 +181,15 @@ pc_mpl_style_doc = """
     Setting this to None/False restores the values to their initial value.
 """
 
+
+pc_highlight_nan_doc = """
+: bool
+
+    When True, NaN elements in the HTML represenation of Series or
+    DataFrames are displayed with a yellow background.
+
+"""
+
 style_backup = dict()
 def mpl_style_cb(key):
     import sys
@@ -245,6 +254,8 @@ with cf.config_prefix('display'):
                        validator=is_instance_factory([type(None), int]))
     # redirected to width, make defval identical
     cf.register_option('line_width', get_default_val('display.width'), pc_line_width_doc)
+    cf.register_option('highlight_nan', False, pc_highlight_nan_doc,
+                       validator=is_bool)
 
 cf.deprecate_option('display.line_width',
                     msg=pc_line_width_deprecation_warning,

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -456,11 +456,12 @@ class DataFrameFormatter(TableFormatter):
                             na_rep=self.na_rep,
                             space=self.col_space)
 
-    def to_html(self, classes=None):
+    def to_html(self, classes=None, highlight_nan=False):
         """
         Render a DataFrame to a html table.
         """
-        html_renderer = HTMLFormatter(self, classes=classes)
+        html_renderer = HTMLFormatter(self, classes=classes,
+            highlight_nan=highlight_nan)
         if hasattr(self.buf, 'write'):
             html_renderer.write_result(self.buf)
         elif isinstance(self.buf, compat.string_types):
@@ -558,9 +559,10 @@ class HTMLFormatter(TableFormatter):
 
     indent_delta = 2
 
-    def __init__(self, formatter, classes=None):
+    def __init__(self, formatter, classes=None, highlight_nan=False):
         self.fmt = formatter
         self.classes = classes
+        self.highlight_nan = highlight_nan
 
         self.frame = self.fmt.frame
         self.columns = formatter.columns
@@ -581,6 +583,9 @@ class HTMLFormatter(TableFormatter):
         return self._write_cell(s, kind='th', indent=indent, tags=tags)
 
     def write_td(self, s, indent=0, tags=None):
+        tags = (tags or "")
+        tags += ' style="background-color:yellow"' if \
+            self.highlight_nan and s == self.fmt.na_rep else ""
         return self._write_cell(s, kind='td', indent=indent, tags=tags)
 
     def _write_cell(self, s, kind='td', indent=0, tags=None):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -485,9 +485,10 @@ class DataFrame(NDFrame):
                     ignore_width=ipnbh)
 
             if fits_horizontal and fits_vertical:
+                hn = get_option("display.highlight_nan")
                 return ('<div style="max-height:1000px;'
                         'max-width:1500px;overflow:auto;">\n' +
-                        self.to_html() + '\n</div>')
+                        self.to_html(highlight_nan=hn) + '\n</div>')
             else:
                 buf = StringIO(u(""))
                 max_info_rows = get_option('display.max_info_rows')
@@ -1289,7 +1290,7 @@ class DataFrame(NDFrame):
                 header=True, index=True, na_rep='NaN', formatters=None,
                 float_format=None, sparsify=None, index_names=True,
                 justify=None, force_unicode=None, bold_rows=True,
-                classes=None, escape=True):
+                classes=None, escape=True, highlight_nan=False):
         """
         to_html-specific options
 
@@ -1299,6 +1300,8 @@ class DataFrame(NDFrame):
             CSS class(es) to apply to the resulting html table
         escape : boolean, default True
             Convert the characters <, >, and & to HTML-safe sequences.
+        highlight_nan:  boolean, default False
+            Display NaN cells with yellow background
 
         Render a DataFrame as an HTML table.
         """
@@ -1322,7 +1325,7 @@ class DataFrame(NDFrame):
                                            header=header, index=index,
                                            bold_rows=bold_rows,
                                            escape=escape)
-        formatter.to_html(classes=classes)
+        formatter.to_html(classes=classes, highlight_nan=highlight_nan)
 
         if buf is None:
             return formatter.buf.getvalue()

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -1246,6 +1246,13 @@ c  10  11  12  13  14\
         ashtml = x.to_html(bold_rows=False)
         assert('<strong>' not in ashtml[ashtml.find('</thead>')])
 
+
+    def test_to_html_with_highlight_nan(self):
+        x = DataFrame({'c1': [1, 2], 'c2': [3, nan]})
+        ashtml = x.to_html(highlight_nan=True)
+        assert('style="background-color:yellow"' in ashtml)
+
+
     def test_to_html_columns_arg(self):
         result = self.frame.to_html(columns=['A'])
         self.assert_('<th>B</th>' not in result)


### PR DESCRIPTION
Useful for quickly inspecting data in an ipynb
- Add display.highlight_nan option (default True)
- Add argument to DataFrame.to_html
  and HTMLFormatter.__init__
- Add test
