### PR TITLE
CLN: Fix return type for initObjToJSON()

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -640,6 +640,8 @@ Bug Fixes
   - Bug when trying to display an embedded PandasObject (:issue:`5324`)
   - Allows operating of Timestamps to return a datetime if the result is out-of-bounds
     related (:issue:`5312`)
+  - Fix return value/type signature of ``initObjToJSON()`` to be compatible
+    with numpy's ``import_array()`` (:issue:`5334`, :issue:`5326`)
 
 pandas 0.12.0
 -------------

--- a/pandas/src/ujson/python/objToJSON.c
+++ b/pandas/src/ujson/python/objToJSON.c
@@ -145,10 +145,11 @@ enum PANDAS_FORMAT
 //#define PRINTMARK() fprintf(stderr, "%s: MARK(%d)\n", __FILE__, __LINE__)
 #define PRINTMARK()
 
-#if (PY_VERSION_HEX < 0x03000000)
-void initObjToJSON(void)
+// import_array() compat
+#if (PY_VERSION_HEX >= 0x03000000)
+void *initObjToJSON(void)
 #else
-int initObjToJSON(void)
+void initObjToJSON(void)
 #endif
 {
   PyObject *mod_pandas;
@@ -176,8 +177,9 @@ int initObjToJSON(void)
     Py_DECREF(mod_tslib);
   }
 
-  /* Initialise numpy API */
+  /* Initialise numpy API and use 2/3 compatible return */
   import_array();
+  return NUMPY_IMPORT_ARRAY_RETVAL;
 }
 
 static void *PyIntToINT32(JSOBJ _obj, JSONTypeContext *tc, void *outValue, size_t *_outLen)


### PR DESCRIPTION
Make it so that it always returns the same thing as numpy, so that it
matches the right signature whether in or not in the error condition.

Closes #5326.
