### PR TITLE
BUG: empty series not printing name in repr (#4651)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -768,7 +768,7 @@ Bug Fixes
     elements. (:issue:`5372`)
   - The GroupBy methods ``transform`` and ``filter`` can be used on Series
     and DataFrames that have repeated (non-unique) indices. (:issue:`4620`)
-
+  - Fix empty series not printing name in repr (:issue:`4651`)
 
 pandas 0.12.0
 -------------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -844,8 +844,11 @@ class Series(generic.NDFrame):
                                     length=len(self) > 50,
                                     name=True,
                                     dtype=True)
+        elif self.name is None:
+            result = u('Series([], dtype: %s)') % (self.dtype)
         else:
-            result = u('Series([], dtype: %s)') % self.dtype
+            result = u('Series([], name: %s, dtype: %s)') % (self.name,
+                                                             self.dtype)
         return result
 
     def _tidy_repr(self, max_vals=20):

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1580,6 +1580,13 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         self.assertFalse("\r" in repr(ser))
         self.assertFalse("a\n" in repr(ser))
 
+        # with empty series (#4651)
+        s = Series([], dtype=np.int64, name='foo')
+        self.assertEqual(repr(s), 'Series([], name: foo, dtype: int64)')
+
+        s = Series([], dtype=np.int64, name=None)
+        self.assertEqual(repr(s), 'Series([], dtype: int64)')
+
     def test_tidy_repr(self):
         a = Series([u("\u05d0")] * 1000)
         a.name = 'title1'


### PR DESCRIPTION
Implemented as suggested in #4651
