### PR TITLE
DOC: Added/fixed some docstrings, esp Panel flex

### DIFF
--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -3,7 +3,7 @@
 {% block methods %}
 {% if methods %}
 
-.. 
+..
    HACK -- the point here is that we don't want this to appear in the output, but the autosummary should still generate the pages.
    .. autosummary::
       :toctree:

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -7,7 +7,7 @@
 
    import os
    import csv
-   from StringIO import StringIO
+   from pandas.compat import StringIO
    import pandas as pd
    ExcelWriter = pd.ExcelWriter
 
@@ -58,32 +58,35 @@ New features
     is evaluated, respecttively. See scipy docs. (:issue:`4298`)
   - Added ``isin`` method to DataFrame (:issue:`4211`)
   - Clipboard functionality now works with PySide (:issue:`4282`)
-  - New ``extract`` string method returns regex matches more conveniently (:issue:`4685`)
+  - New ``extract`` string method returns regex matches more conveniently
+    (:issue:`4685`)
   - Auto-detect field widths in read_fwf when unspecified (:issue:`4488`)
-  - ``to_csv()`` now outputs datetime objects according to a specified format string
-    via the ``date_format`` keyword (:issue:`4313`)
+  - ``to_csv()`` now outputs datetime objects according to a specified format
+    string via the ``date_format`` keyword (:issue:`4313`)
   - Added ``LastWeekOfMonth`` DateOffset (:issue:`4637`)
   - Added ``FY5253``, and ``FY5253Quarter`` DateOffsets (:issue:`4511`)
 
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~
 
-  - The new :func:`~pandas.eval` function implements expression evaluation using
-    ``numexpr`` behind the scenes. This results in large speedups for complicated
-    expressions involving large DataFrames/Series.
+  - The new :func:`~pandas.eval` function implements expression evaluation
+    using ``numexpr`` behind the scenes. This results in large speedups for
+    complicated expressions involving large DataFrames/Series.
   - :class:`~pandas.DataFrame` has a new :meth:`~pandas.DataFrame.eval` that
     evaluates an expression in the context of the ``DataFrame``; allows
     inline expression assignment
   - A :meth:`~pandas.DataFrame.query` method has been added that allows
-    you to select elements of a ``DataFrame`` using a natural query syntax nearly
-    identical to Python syntax.
+    you to select elements of a ``DataFrame`` using a natural query syntax
+    nearly identical to Python syntax.
   - ``pd.eval`` and friends now evaluate operations involving ``datetime64``
     objects in Python space because ``numexpr`` cannot handle ``NaT`` values
     (:issue:`4897`).
-  - Add msgpack support via ``pd.read_msgpack()`` and ``pd.to_msgpack()`` / ``df.to_msgpack()`` for serialization
-    of arbitrary pandas (and python objects) in a lightweight portable binary format (:issue:`686`)
+  - Add msgpack support via ``pd.read_msgpack()`` and ``pd.to_msgpack()`` /
+    ``df.to_msgpack()`` for serialization of arbitrary pandas (and python
+    objects) in a lightweight portable binary format (:issue:`686`)
   - Added PySide support for the qtpandas DataFrameModel and DataFrameWidget.
-  - Added :mod:`pandas.io.gbq` for reading from (and writing to) Google BigQuery into a DataFrame. (:issue:`4140`)
+  - Added :mod:`pandas.io.gbq` for reading from (and writing to) Google
+    BigQuery into a DataFrame. (:issue:`4140`)
 
 Improvements to existing features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -93,7 +96,8 @@ Improvements to existing features
   - ``read_excel`` now supports an integer in its ``sheetname`` argument giving
     the index of the sheet to read in (:issue:`4301`).
   - ``get_dummies`` works with NaN (:issue:`4446`)
-  - Added a test for ``read_clipboard()`` and ``to_clipboard()`` (:issue:`4282`)
+  - Added a test for ``read_clipboard()`` and ``to_clipboard()``
+    (:issue:`4282`)
   - Added bins argument to ``value_counts`` (:issue:`3945`), also sort and
     ascending, now available in Series method as well as top-level function.
   - Text parser now treats anything that reads like inf ("inf", "Inf", "-Inf",
@@ -120,21 +124,21 @@ Improvements to existing features
   - A Series of dtype ``timedelta64[ns]`` can now be divided by another
     ``timedelta64[ns]`` object to yield a ``float64`` dtyped Series. This
     is frequency conversion; astyping is also supported.
-  - Timedelta64 support ``fillna/ffill/bfill`` with an integer interpreted as seconds,
-    or a ``timedelta`` (:issue:`3371`)
+  - Timedelta64 support ``fillna/ffill/bfill`` with an integer interpreted as
+    seconds, or a ``timedelta`` (:issue:`3371`)
   - Box numeric ops on ``timedelta`` Series (:issue:`4984`)
   - Datetime64 support ``ffill/bfill``
   - Performance improvements with ``__getitem__`` on ``DataFrames`` with
     when the key is a column
-  - Support for using a ``DatetimeIndex/PeriodsIndex`` directly in a datelike calculation
-    e.g. s-s.index (:issue:`4629`)
+  - Support for using a ``DatetimeIndex/PeriodsIndex`` directly in a datelike
+    calculation e.g. s-s.index (:issue:`4629`)
   - Better/cleaned up exceptions in core/common, io/excel and core/format
     (:issue:`4721`, :issue:`3954`), as well as cleaned up test cases in
     tests/test_frame, tests/test_multilevel (:issue:`4732`).
   - Performance improvement of timesesies plotting with PeriodIndex and added
     test to vbench (:issue:`4705` and :issue:`4722`)
-  - Add ``axis`` and ``level`` keywords to ``where``, so that the ``other`` argument
-    can now be an alignable pandas object.
+  - Add ``axis`` and ``level`` keywords to ``where``, so that the ``other``
+    argument can now be an alignable pandas object.
   - ``to_datetime`` with a format of '%Y%m%d' now parses much faster
   - It's now easier to hook new Excel writers into pandas (just subclass
     ``ExcelWriter`` and register your engine). You can specify an ``engine`` in
@@ -149,8 +153,8 @@ Improvements to existing features
   - allow DataFrame constructor to accept more list-like objects, e.g. list of
     ``collections.Sequence`` and ``array.Array`` objects (:issue:`3783`,
     :issue:`4297`, :issue:`4851`), thanks @lgautier
-  - DataFrame constructor now accepts a numpy masked record array (:issue:`3478`),
-    thanks @jnothman
+  - DataFrame constructor now accepts a numpy masked record array
+    (:issue:`3478`), thanks @jnothman
   - ``__getitem__`` with ``tuple`` key (e.g., ``[:, 2]``) on ``Series``
     without ``MultiIndex`` raises ``ValueError`` (:issue:`4759`, :issue:`4837`)
   - ``read_json`` now raises a (more informative) ``ValueError`` when the dict
@@ -160,8 +164,8 @@ Improvements to existing features
     (:issue:`3441`, :issue:`4933`)
   - ``pandas`` is now tested with two different versions of ``statsmodels``
     (0.4.3 and 0.5.0) (:issue:`4981`).
-  - Better string representations of ``MultiIndex`` (including ability to roundtrip
-    via ``repr``). (:issue:`3347`, :issue:`4935`)
+  - Better string representations of ``MultiIndex`` (including ability to
+    roundtrip via ``repr``). (:issue:`3347`, :issue:`4935`)
   - Both ExcelFile and read_excel to accept an xlrd.Book for the io
     (formerly path_or_buf) argument; this requires engine to be set.
     (:issue:`4961`).
@@ -175,22 +179,27 @@ Improvements to existing features
     structure of unlocalized data (:issue:`4230`)
   - DatetimeIndex is now in the API documentation
   - Improve support for converting R datasets to pandas objects (more
-    informative index for timeseries and numeric, support for factors, dist, and
-    high-dimensional arrays).
+    informative index for timeseries and numeric, support for factors, dist,
+    and high-dimensional arrays).
   - :func:`~pandas.read_html` now supports the ``parse_dates``,
     ``tupleize_cols`` and ``thousands`` parameters (:issue:`4770`).
-  - :meth:`~pandas.io.json.json_normalize` is a new method to allow you to create a flat table
-    from semi-structured JSON data. :ref:`See the docs<io.json_normalize>` (:issue:`1067`)
+  - :meth:`~pandas.io.json.json_normalize` is a new method to allow you to
+    create a flat table from semi-structured JSON data. :ref:`See the
+    docs<io.json_normalize>` (:issue:`1067`)
   - ``DataFrame.from_records()`` will now accept generators (:issue:`4910`)
-  - ``DataFrame.interpolate()`` and ``Series.interpolate()`` have been expanded to include
-    interpolation methods from scipy. (:issue:`4434`, :issue:`1892`)
-  - ``Series`` now supports a ``to_frame`` method to convert it to a single-column DataFrame (:issue:`5164`)
+  - ``DataFrame.interpolate()`` and ``Series.interpolate()`` have been expanded
+    to include interpolation methods from scipy. (:issue:`4434`, :issue:`1892`)
+  - ``Series`` now supports a ``to_frame`` method to convert it to a
+    single-column DataFrame (:issue:`5164`)
   - DatetimeIndex (and date_range) can now be constructed in a left- or
     right-open fashion using the ``closed`` parameter (:issue:`4579`)
   - Python csv parser now supports usecols (:issue:`4335`)
-  - Added support for Google Analytics v3 API segment IDs that also supports v2 IDs. (:issue:`5271`)
+  - Added support for Google Analytics v3 API segment IDs that also supports v2
+    IDs. (:issue:`5271`)
   - ``NDFrame.drop()`` now accepts names as well as integers for the axis
     argument. (:issue:`5354`)
+  - Added short docstrings to a few methods that were missing them + fixed the
+    docstrings for Panel flex methods. (:issue:`5336`)
 
 API Changes
 ~~~~~~~~~~~
@@ -212,51 +221,63 @@ API Changes
   - deprecated ``iterkv``, which will be removed in a future release (was just
     an alias of iteritems used to get around ``2to3``'s changes).
     (:issue:`4384`, :issue:`4375`, :issue:`4372`)
-  - ``Series.get`` with negative indexers now returns the same as ``[]`` (:issue:`4390`)
-  - allow ``ix/loc`` for Series/DataFrame/Panel to set on any axis even when the single-key
-    is not currently contained in the index for that axis (:issue:`2578`, :issue:`5226`)
+  - ``Series.get`` with negative indexers now returns the same as ``[]``
+    (:issue:`4390`)
+  - allow ``ix/loc`` for Series/DataFrame/Panel to set on any axis even when
+    the single-key is not currently contained in the index for that axis
+    (:issue:`2578`, :issue:`5226`)
   - Default export for ``to_clipboard`` is now csv with a sep of `\t` for
     compat (:issue:`3368`)
-  - ``at`` now will enlarge the object inplace (and return the same) (:issue:`2578`)
-  - ``DataFrame.plot`` will scatter plot x versus y by passing ``kind='scatter'`` (:issue:`2215`)
+  - ``at`` now will enlarge the object inplace (and return the same)
+    (:issue:`2578`)
+  - ``DataFrame.plot`` will scatter plot x versus y by passing
+    ``kind='scatter'`` (:issue:`2215`)
 
   - ``HDFStore``
 
     - ``append_to_multiple`` automatically synchronizes writing rows to multiple
       tables and adds a ``dropna`` kwarg (:issue:`4698`)
     - handle a passed ``Series`` in table format (:issue:`4330`)
-    - added an ``is_open`` property to indicate if the underlying file handle is_open;
-      a closed store will now report 'CLOSED' when viewing the store (rather than raising an error)
-      (:issue:`4409`)
-    - a close of a ``HDFStore`` now will close that instance of the ``HDFStore``
-      but will only close the actual file if the ref count (by ``PyTables``) w.r.t. all of the open handles
-      are 0. Essentially you have a local instance of ``HDFStore`` referenced by a variable. Once you
-      close it, it will report closed. Other references (to the same file) will continue to operate
-      until they themselves are closed. Performing an action on a closed file will raise
-      ``ClosedFileError``
-    - removed the ``_quiet`` attribute, replace by a ``DuplicateWarning`` if retrieving
-      duplicate rows from a table (:issue:`4367`)
-    - removed the ``warn`` argument from ``open``. Instead a ``PossibleDataLossError`` exception will
-      be raised if you try to use ``mode='w'`` with an OPEN file handle (:issue:`4367`)
-    - allow a passed locations array or mask as a ``where`` condition (:issue:`4467`)
-    - add the keyword ``dropna=True`` to ``append`` to change whether ALL nan rows are not written
-      to the store (default is ``True``, ALL nan rows are NOT written), also settable
-      via the option ``io.hdf.dropna_table`` (:issue:`4625`)
-    - the ``format`` keyword now replaces the ``table`` keyword; allowed values are ``fixed(f)|table(t)``
-      the ``Storer`` format has been renamed to ``Fixed``
-    - a column multi-index will be recreated properly (:issue:`4710`); raise on trying to use a multi-index
-      with data_columns on the same axis
-    - ``select_as_coordinates`` will now return an ``Int64Index`` of the resultant selection set
+    - added an ``is_open`` property to indicate if the underlying file handle
+      is_open; a closed store will now report 'CLOSED' when viewing the store
+      (rather than raising an error) (:issue:`4409`)
+    - a close of a ``HDFStore`` now will close that instance of the
+      ``HDFStore`` but will only close the actual file if the ref count (by
+      ``PyTables``) w.r.t. all of the open handles are 0. Essentially you have
+      a local instance of ``HDFStore`` referenced by a variable. Once you close
+      it, it will report closed. Other references (to the same file) will
+      continue to operate until they themselves are closed. Performing an
+      action on a closed file will raise ``ClosedFileError``
+    - removed the ``_quiet`` attribute, replace by a ``DuplicateWarning`` if
+      retrieving duplicate rows from a table (:issue:`4367`)
+    - removed the ``warn`` argument from ``open``. Instead a
+      ``PossibleDataLossError`` exception will be raised if you try to use
+      ``mode='w'`` with an OPEN file handle (:issue:`4367`)
+    - allow a passed locations array or mask as a ``where`` condition
+      (:issue:`4467`)
+    - add the keyword ``dropna=True`` to ``append`` to change whether ALL nan
+      rows are not written to the store (default is ``True``, ALL nan rows are
+      NOT written), also settable via the option ``io.hdf.dropna_table``
+      (:issue:`4625`)
+    - the ``format`` keyword now replaces the ``table`` keyword; allowed values
+      are ``fixed(f)|table(t)`` the ``Storer`` format has been renamed to
+      ``Fixed``
+    - a column multi-index will be recreated properly (:issue:`4710`); raise on
+      trying to use a multi-index with data_columns on the same axis
+    - ``select_as_coordinates`` will now return an ``Int64Index`` of the
+      resultant selection set
     - support ``timedelta64[ns]`` as a serialization type (:issue:`3577`)
-    - store `datetime.date` objects as ordinals rather then timetuples to avoid timezone issues (:issue:`2852`),
-      thanks @tavistmorph and @numpand
+    - store `datetime.date` objects as ordinals rather then timetuples to avoid
+      timezone issues (:issue:`2852`), thanks @tavistmorph and @numpand
     - ``numexpr`` 2.2.2 fixes incompatiblity in PyTables 2.4 (:issue:`4908`)
   - ``JSON``
 
-    - added ``date_unit`` parameter to specify resolution of timestamps. Options
-      are seconds, milliseconds, microseconds and nanoseconds. (:issue:`4362`, :issue:`4498`).
-    - added ``default_handler`` parameter to allow a callable to be passed which will be
-      responsible for handling otherwise unserialisable objects. (:issue:`5138`)
+    - added ``date_unit`` parameter to specify resolution of timestamps.
+      Options are seconds, milliseconds, microseconds and nanoseconds.
+      (:issue:`4362`, :issue:`4498`).
+    - added ``default_handler`` parameter to allow a callable to be passed
+      which will be responsible for handling otherwise unserialisable objects.
+      (:issue:`5138`)
 
   - ``Index`` and ``MultiIndex`` changes (:issue:`4039`):
 
@@ -284,54 +305,71 @@ API Changes
       changes on ``levels`` and ``labels`` setting on ``MultiIndex``).
       (:issue:`4859`, :issue:`4909`)
 
-  - Infer and downcast dtype if ``downcast='infer'`` is passed to ``fillna/ffill/bfill`` (:issue:`4604`)
-  - ``__nonzero__`` for all NDFrame objects, will now raise a ``ValueError``, this reverts back to (:issue:`1073`, :issue:`4633`)
-    behavior. Add ``.bool()`` method to ``NDFrame`` objects to facilitate evaluating of single-element boolean Series
+  - Infer and downcast dtype if ``downcast='infer'`` is passed to
+    ``fillna/ffill/bfill`` (:issue:`4604`)
+  - ``__nonzero__`` for all NDFrame objects, will now raise a ``ValueError``,
+    this reverts back to (:issue:`1073`, :issue:`4633`) behavior. Add
+    ``.bool()`` method to ``NDFrame`` objects to facilitate evaluating of
+    single-element boolean Series
   - ``DataFrame.update()`` no longer raises a ``DataConflictError``, it now
     will raise a ``ValueError`` instead (if necessary) (:issue:`4732`)
   - ``Series.isin()`` and ``DataFrame.isin()``  now raise a ``TypeError`` when
     passed a string (:issue:`4763`). Pass a ``list`` of one element (containing
     the string) instead.
-  - Remove undocumented/unused ``kind`` keyword argument from ``read_excel``, and ``ExcelFile``. (:issue:`4713`, :issue:`4712`)
+  - Remove undocumented/unused ``kind`` keyword argument from ``read_excel``,
+    and ``ExcelFile``. (:issue:`4713`, :issue:`4712`)
   - The ``method`` argument of ``NDFrame.replace()`` is valid again, so that a
     a list can be passed to ``to_replace`` (:issue:`4743`).
   - provide automatic dtype conversions on _reduce operations (:issue:`3371`)
-  - exclude non-numerics if mixed types with datelike in _reduce operations (:issue:`3371`)
-  - default for ``tupleize_cols`` is now ``False`` for both ``to_csv`` and ``read_csv``. Fair warning in 0.12 (:issue:`3604`)
-  - moved timedeltas support to pandas.tseries.timedeltas.py; add timedeltas string parsing,
-    add top-level ``to_timedelta`` function
-  - ``NDFrame`` now is compatible with Python's toplevel ``abs()`` function (:issue:`4821`).
-  - raise a ``TypeError`` on invalid comparison ops on Series/DataFrame (e.g. integer/datetime) (:issue:`4968`)
-  - Added a new index type, ``Float64Index``. This will be automatically created when passing floating values in index creation.
-    This enables a pure label-based slicing paradigm that makes ``[],ix,loc`` for scalar indexing and slicing work exactly the same.
-    Indexing on other index types are preserved (and positional fallback for ``[],ix``), with the exception, that floating point slicing
-    on indexes on non ``Float64Index`` will raise a ``TypeError``, e.g. ``Series(range(5))[3.5:4.5]`` (:issue:`263`)
+  - exclude non-numerics if mixed types with datelike in _reduce operations
+    (:issue:`3371`)
+  - default for ``tupleize_cols`` is now ``False`` for both ``to_csv`` and
+    ``read_csv``. Fair warning in 0.12 (:issue:`3604`)
+  - moved timedeltas support to pandas.tseries.timedeltas.py; add timedeltas
+    string parsing, add top-level ``to_timedelta`` function
+  - ``NDFrame`` now is compatible with Python's toplevel ``abs()`` function
+    (:issue:`4821`).
+  - raise a ``TypeError`` on invalid comparison ops on Series/DataFrame (e.g.
+    integer/datetime) (:issue:`4968`)
+  - Added a new index type, ``Float64Index``. This will be automatically
+    created when passing floating values in index creation.  This enables a
+    pure label-based slicing paradigm that makes ``[],ix,loc`` for scalar
+    indexing and slicing work exactly the same.  Indexing on other index types
+    are preserved (and positional fallback for ``[],ix``), with the exception,
+    that floating point slicing on indexes on non ``Float64Index`` will raise a
+    ``TypeError``, e.g. ``Series(range(5))[3.5:4.5]`` (:issue:`263`)
   - Make Categorical repr nicer (:issue:`4368`)
   - Remove deprecated ``Factor`` (:issue:`3650`)
   - Remove deprecated ``set_printoptions/reset_printoptions`` (:issue:``3046``)
   - Remove deprecated ``_verbose_info`` (:issue:`3215`)
   - Begin removing methods that don't make sense on ``GroupBy`` objects
     (:issue:`4887`).
-  - Remove deprecated ``read_clipboard/to_clipboard/ExcelFile/ExcelWriter`` from ``pandas.io.parsers`` (:issue:`3717`)
+  - Remove deprecated ``read_clipboard/to_clipboard/ExcelFile/ExcelWriter``
+    from ``pandas.io.parsers`` (:issue:`3717`)
   - All non-Index NDFrames (``Series``, ``DataFrame``, ``Panel``, ``Panel4D``,
     ``SparsePanel``, etc.), now support the entire set of arithmetic operators
     and arithmetic flex methods (add, sub, mul, etc.). ``SparsePanel`` does not
     support ``pow`` or ``mod`` with non-scalars. (:issue:`3765`)
-  - Arithemtic func factories are now passed real names (suitable for using with super) (:issue:`5240`)
-  - Provide numpy compatibility with 1.7 for a calling convention like ``np.prod(pandas_object)`` as numpy
-    call with additional keyword args (:issue:`4435`)
-  - Provide __dir__ method (and local context) for tab completion / remove ipython completers code
-    (:issue:`4501`)
+  - Arithemtic func factories are now passed real names (suitable for using
+    with super) (:issue:`5240`)
+  - Provide numpy compatibility with 1.7 for a calling convention like
+    ``np.prod(pandas_object)`` as numpy call with additional keyword args
+    (:issue:`4435`)
+  - Provide __dir__ method (and local context) for tab completion / remove
+    ipython completers code (:issue:`4501`)
   - Support non-unique axes in a Panel via indexing operations (:issue:`4960`)
-  - ``.truncate`` will raise a ``ValueError`` if invalid before and afters dates are given (:issue:`5242`)
-  - ``Timestamp`` now supports ``now/today/utcnow`` class methods (:issue:`5339`)
+  - ``.truncate`` will raise a ``ValueError`` if invalid before and afters
+    dates are given (:issue:`5242`)
+  - ``Timestamp`` now supports ``now/today/utcnow`` class methods
+    (:issue:`5339`)
 
 Internal Refactoring
 ~~~~~~~~~~~~~~~~~~~~
 
-In 0.13.0 there is a major refactor primarily to subclass ``Series`` from ``NDFrame``,
-which is the base class currently for ``DataFrame`` and ``Panel``, to unify methods
-and behaviors. Series formerly subclassed directly from ``ndarray``. (:issue:`4080`, :issue:`3862`, :issue:`816`)
+In 0.13.0 there is a major refactor primarily to subclass ``Series`` from
+``NDFrame``, which is the base class currently for ``DataFrame`` and ``Panel``,
+to unify methods and behaviors. Series formerly subclassed directly from
+``ndarray``. (:issue:`4080`, :issue:`3862`, :issue:`816`)
 See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
 
  - Refactor of series.py/frame.py/panel.py to move common code to generic.py
@@ -339,15 +377,19 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
   - added ``_setup_axes`` to created generic NDFrame structures
   - moved methods
 
-    - ``from_axes,_wrap_array,axes,ix,loc,iloc,shape,empty,swapaxes,transpose,pop``
-    - ``__iter__,keys,__contains__,__len__,__neg__,__invert__``
-    - ``convert_objects,as_blocks,as_matrix,values``
-    - ``__getstate__,__setstate__`` (compat remains in frame/panel)
-    - ``__getattr__,__setattr__``
-    - ``_indexed_same,reindex_like,align,where,mask``
-    - ``fillna,replace`` (``Series`` replace is now consistent with ``DataFrame``)
-    - ``filter`` (also added axis argument to selectively filter on a different axis)
-    - ``reindex,reindex_axis,take``
+    - ``from_axes``, ``_wrap_array``, ``axes``, ``ix``, ``loc``, ``iloc``,
+      ``shape``, ``empty``, ``swapaxes``, ``transpose``, ``pop``
+    - ``__iter__``, ``keys``, ``__contains__``, ``__len__``, ``__neg__``,
+      ``__invert__``
+    - ``convert_objects``, ``as_blocks``, ``as_matrix``, ``values``
+    - ``__getstate__``, ``__setstate__`` (compat remains in frame/panel)
+    - ``__getattr__``, ``__setattr__``
+    - ``_indexed_same``, ``reindex_like``, ``align``, ``where``, ``mask``
+    - ``fillna``, ``replace`` (``Series`` replace is now consistent with
+      ``DataFrame``)
+    - ``filter`` (also added axis argument to selectively filter on a different
+      axis)
+    - ``reindex``, ``reindex_axis``, ``take``
     - ``truncate`` (moved to become part of ``NDFrame``)
     - ``isnull/notnull`` now available on ``NDFrame`` objects
 
@@ -356,58 +398,69 @@ See :ref:`Internal Refactoring<whatsnew_0130.refactoring>`
   - ``swapaxes`` on a ``Panel`` with the same axes specified now return a copy
   - support attribute access for setting
   - ``filter`` supports same api as original ``DataFrame`` filter
-  - ``fillna`` refactored to ``core/generic.py``, while > 3ndim is ``NotImplemented``
+  - ``fillna`` refactored to ``core/generic.py``, while > 3ndim is
+    ``NotImplemented``
 
  - Series now inherits from ``NDFrame`` rather than directly from ``ndarray``.
    There are several minor changes that affect the API.
 
-  - numpy functions that do not support the array interface will now
-    return ``ndarrays`` rather than series, e.g. ``np.diff``, ``np.ones_like``, ``np.where``
+  - numpy functions that do not support the array interface will now return
+    ``ndarrays`` rather than series, e.g. ``np.diff``, ``np.ones_like``,
+    ``np.where``
   - ``Series(0.5)`` would previously return the scalar ``0.5``, this is no
     longer supported
-  - ``TimeSeries`` is now an alias for ``Series``. the property ``is_time_series``
-    can be used to distinguish (if desired)
+  - ``TimeSeries`` is now an alias for ``Series``. the property
+    ``is_time_series`` can be used to distinguish (if desired)
 
  - Refactor of Sparse objects to use BlockManager
 
-  - Created a new block type in internals, ``SparseBlock``, which can hold multi-dtypes
-    and is non-consolidatable. ``SparseSeries`` and ``SparseDataFrame`` now inherit
-    more methods from there hierarchy (Series/DataFrame), and no longer inherit
-    from ``SparseArray`` (which instead is the object of the ``SparseBlock``)
-  - Sparse suite now supports integration with non-sparse data. Non-float sparse
-    data is supportable (partially implemented)
-  - Operations on sparse structures within DataFrames should preserve sparseness,
-    merging type operations will convert to dense (and back to sparse), so might
-    be somewhat inefficient
+  - Created a new block type in internals, ``SparseBlock``, which can hold
+    multi-dtypes and is non-consolidatable. ``SparseSeries`` and
+    ``SparseDataFrame`` now inherit more methods from there hierarchy
+    (Series/DataFrame), and no longer inherit from ``SparseArray`` (which
+    instead is the object of the ``SparseBlock``)
+  - Sparse suite now supports integration with non-sparse data. Non-float
+    sparse data is supportable (partially implemented)
+  - Operations on sparse structures within DataFrames should preserve
+    sparseness, merging type operations will convert to dense (and back to
+    sparse), so might be somewhat inefficient
   - enable setitem on ``SparseSeries`` for boolean/integer/slices
-  - ``SparsePanels`` implementation is unchanged (e.g. not using BlockManager, needs work)
+  - ``SparsePanels`` implementation is unchanged (e.g. not using BlockManager,
+    needs work)
 
- - added ``ftypes`` method to Series/DataFame, similar to ``dtypes``, but indicates
-   if the underlying is sparse/dense (as well as the dtype)
- - All ``NDFrame`` objects now have a ``_prop_attributes``, which can be used to indcated various
-   values to propogate to a new object from an existing (e.g. name in ``Series`` will follow
-   more automatically now)
- - Internal type checking is now done via a suite of generated classes, allowing ``isinstance(value, klass)``
-   without having to directly import the klass, courtesy of @jtratner
- - Bug in Series update where the parent frame is not updating its cache based on
-   changes (:issue:`4080`, :issue:`5216`) or types (:issue:`3217`), fillna (:issue:`3386`)
+ - added ``ftypes`` method to Series/DataFame, similar to ``dtypes``, but
+   indicates if the underlying is sparse/dense (as well as the dtype)
+ - All ``NDFrame`` objects now have a ``_prop_attributes``, which can be used
+   to indcated various values to propogate to a new object from an existing
+   (e.g. name in ``Series`` will follow more automatically now)
+ - Internal type checking is now done via a suite of generated classes,
+   allowing ``isinstance(value, klass)`` without having to directly import the
+   klass, courtesy of @jtratner
+ - Bug in Series update where the parent frame is not updating its cache based
+   on changes (:issue:`4080`, :issue:`5216`) or types (:issue:`3217`), fillna
+   (:issue:`3386`)
  - Indexing with dtype conversions fixed (:issue:`4463`, :issue:`4204`)
- - Refactor ``Series.reindex`` to core/generic.py (:issue:`4604`, :issue:`4618`), allow ``method=`` in reindexing
-   on a Series to work
- - ``Series.copy`` no longer accepts the ``order`` parameter and is now consistent with ``NDFrame`` copy
- - Refactor ``rename`` methods to core/generic.py; fixes ``Series.rename`` for (:issue:`4605`), and adds ``rename``
-   with the same signature for ``Panel``
- - Series (for index) / Panel (for items) now as attribute access to its elements  (:issue:`1903`)
+ - Refactor ``Series.reindex`` to core/generic.py (:issue:`4604`,
+   :issue:`4618`), allow ``method=`` in reindexing on a Series to work
+ - ``Series.copy`` no longer accepts the ``order`` parameter and is now
+   consistent with ``NDFrame`` copy
+ - Refactor ``rename`` methods to core/generic.py; fixes ``Series.rename`` for
+   (:issue:`4605`), and adds ``rename`` with the same signature for ``Panel``
+ - Series (for index) / Panel (for items) now as attribute access to its
+   elements  (:issue:`1903`)
  - Refactor ``clip`` methods to core/generic.py (:issue:`4798`)
- - Refactor of ``_get_numeric_data/_get_bool_data`` to core/generic.py, allowing Series/Panel functionaility
- - Refactor of Series arithmetic with time-like objects (datetime/timedelta/time
-   etc.) into a separate, cleaned up wrapper class. (:issue:`4613`)
+ - Refactor of ``_get_numeric_data/_get_bool_data`` to core/generic.py,
+   allowing Series/Panel functionaility
+ - Refactor of Series arithmetic with time-like objects
+   (datetime/timedelta/time etc.) into a separate, cleaned up wrapper class.
+   (:issue:`4613`)
  - Complex compat for ``Series`` with ``ndarray``. (:issue:`4819`)
- - Removed unnecessary ``rwproperty`` from codebase in favor of builtin property. (:issue:`4843`)
- - Refactor object level numeric methods (mean/sum/min/max...) from object level modules to
-   ``core/generic.py`` (:issue:`4435`).
- - Refactor cum objects to core/generic.py (:issue:`4435`), note that these have a more numpy-like
-   function signature.
+ - Removed unnecessary ``rwproperty`` from codebase in favor of builtin
+   property. (:issue:`4843`)
+ - Refactor object level numeric methods (mean/sum/min/max...) from object
+   level modules to ``core/generic.py`` (:issue:`4435`).
+ - Refactor cum objects to core/generic.py (:issue:`4435`), note that these
+   have a more numpy-like function signature.
  - :func:`~pandas.read_html` now uses ``TextParser`` to parse HTML data from
    bs4/lxml (:issue:`4770`).
  - Removed the ``keep_internal`` keyword parameter in
@@ -430,17 +483,20 @@ Bug Fixes
 
   - ``HDFStore``
 
-    - raising an invalid ``TypeError`` rather than ``ValueError`` when appending
-      with a different block ordering (:issue:`4096`)
+    - raising an invalid ``TypeError`` rather than ``ValueError`` when
+      appending with a different block ordering (:issue:`4096`)
     - ``read_hdf`` was not respecting as passed ``mode`` (:issue:`4504`)
     - appending a 0-len table will work correctly (:issue:`4273`)
-    - ``to_hdf`` was raising when passing both arguments ``append`` and ``table`` (:issue:`4584`)
-    - reading from a store with duplicate columns across dtypes would raise (:issue:`4767`)
-    - Fixed a bug where ``ValueError`` wasn't correctly raised when column names
-      weren't strings (:issue:`4956`)
-    - A zero length series written in Fixed format not deserializing properly. (:issue:`4708`)
-  - Fixed bug in tslib.tz_convert(vals, tz1, tz2): it could raise IndexError exception while
-    trying to access trans[pos + 1] (:issue:`4496`)
+    - ``to_hdf`` was raising when passing both arguments ``append`` and
+      ``table`` (:issue:`4584`)
+    - reading from a store with duplicate columns across dtypes would raise
+      (:issue:`4767`)
+    - Fixed a bug where ``ValueError`` wasn't correctly raised when column
+      names weren't strings (:issue:`4956`)
+    - A zero length series written in Fixed format not deserializing properly.
+      (:issue:`4708`)
+  - Fixed bug in tslib.tz_convert(vals, tz1, tz2): it could raise IndexError
+    exception while trying to access trans[pos + 1] (:issue:`4496`)
   - The ``by`` argument now works correctly with the ``layout`` argument
     (:issue:`4102`, :issue:`4014`) in ``*.hist`` plotting methods
   - Fixed bug in ``PeriodIndex.map`` where using ``str`` would return the str
@@ -454,16 +510,19 @@ Bug Fixes
   - ``read_html`` tests now work with Python 2.6 (:issue:`4351`)
   - Fixed bug where ``network`` testing was throwing ``NameError`` because a
     local variable was undefined (:issue:`4381`)
-  - In ``to_json``, raise if a passed ``orient`` would cause loss of data because
-    of a duplicate index (:issue:`4359`)
+  - In ``to_json``, raise if a passed ``orient`` would cause loss of data
+    because of a duplicate index (:issue:`4359`)
   - In ``to_json``, fix date handling so milliseconds are the default timestamp
     as the docstring says (:issue:`4362`).
-  - ``as_index`` is no longer ignored when doing groupby apply (:issue:`4648`), (:issue:`3417`)
+  - ``as_index`` is no longer ignored when doing groupby apply (:issue:`4648`,
+    :issue:`3417`)
   - JSON NaT handling fixed, NaTs are now serialised to `null` (:issue:`4498`)
-  - Fixed JSON handling of escapable characters in JSON object keys (:issue:`4593`)
-  - Fixed passing ``keep_default_na=False`` when ``na_values=None`` (:issue:`4318`)
-  - Fixed bug with ``values`` raising an error on a DataFrame with duplicate columns and mixed
-    dtypes, surfaced in (:issue:`4377`)
+  - Fixed JSON handling of escapable characters in JSON object keys
+    (:issue:`4593`)
+  - Fixed passing ``keep_default_na=False`` when ``na_values=None``
+    (:issue:`4318`)
+  - Fixed bug with ``values`` raising an error on a DataFrame with duplicate
+    columns and mixed dtypes, surfaced in (:issue:`4377`)
   - Fixed bug with duplicate columns and type conversion in ``read_json`` when
     ``orient='split'`` (:issue:`4377`)
   - Fixed JSON bug where locales with decimal separators other than '.' threw
@@ -472,8 +531,8 @@ Bug Fixes
   - Fixed an issue where ``PeriodIndex`` joining with self was returning a new
     instance rather than the same instance (:issue:`4379`); also adds a test
     for this for the other index types
-  - Fixed a bug with all the dtypes being converted to object when using the CSV cparser
-    with the usecols parameter (:issue:`3192`)
+  - Fixed a bug with all the dtypes being converted to object when using the
+    CSV cparser with the usecols parameter (:issue:`3192`)
   - Fix an issue in merging blocks where the resulting DataFrame had partially
     set _ref_locs (:issue:`4403`)
   - Fixed an issue where hist subplots were being overwritten when they were
@@ -488,80 +547,107 @@ Bug Fixes
     (:issue:`4486`)
   - Fixed an issue where cumsum and cumprod didn't work with bool dtypes
     (:issue:`4170`, :issue:`4440`)
-  - Fixed Panel slicing issued in ``xs`` that was returning an incorrect dimmed object
-    (:issue:`4016`)
-  - Fix resampling bug where custom reduce function not used if only one group (:issue:`3849`, :issue:`4494`)
+  - Fixed Panel slicing issued in ``xs`` that was returning an incorrect dimmed
+    object (:issue:`4016`)
+  - Fix resampling bug where custom reduce function not used if only one group
+    (:issue:`3849`, :issue:`4494`)
   - Fixed Panel assignment with a transposed frame (:issue:`3830`)
-  - Raise on set indexing with a Panel and a Panel as a value which needs alignment (:issue:`3777`)
+  - Raise on set indexing with a Panel and a Panel as a value which needs
+    alignment (:issue:`3777`)
   - frozenset objects now raise in the ``Series`` constructor (:issue:`4482`,
     :issue:`4480`)
-  - Fixed issue with sorting a duplicate multi-index that has multiple dtypes (:issue:`4516`)
+  - Fixed issue with sorting a duplicate multi-index that has multiple dtypes
+    (:issue:`4516`)
   - Fixed bug in ``DataFrame.set_values`` which was causing name attributes to
     be lost when expanding the index. (:issue:`3742`, :issue:`4039`)
   - Fixed issue where individual ``names``, ``levels`` and ``labels`` could be
     set on ``MultiIndex`` without validation (:issue:`3714`, :issue:`4039`)
-  - Fixed (:issue:`3334`) in pivot_table. Margins did not compute if values is the index.
-  - Fix bug in having a rhs of ``np.timedelta64`` or ``np.offsets.DateOffset`` when operating
-    with datetimes (:issue:`4532`)
-  - Fix arithmetic with series/datetimeindex and ``np.timedelta64`` not working the same (:issue:`4134`)
-    and buggy timedelta in numpy 1.6 (:issue:`4135`)
-  - Fix bug in ``pd.read_clipboard`` on windows with PY3 (:issue:`4561`); not decoding properly
+  - Fixed (:issue:`3334`) in pivot_table. Margins did not compute if values is
+    the index.
+  - Fix bug in having a rhs of ``np.timedelta64`` or ``np.offsets.DateOffset``
+    when operating with datetimes (:issue:`4532`)
+  - Fix arithmetic with series/datetimeindex and ``np.timedelta64`` not working
+    the same (:issue:`4134`) and buggy timedelta in numpy 1.6 (:issue:`4135`)
+  - Fix bug in ``pd.read_clipboard`` on windows with PY3 (:issue:`4561`); not
+    decoding properly
   - ``tslib.get_period_field()`` and ``tslib.get_period_field_arr()`` now raise
     if code argument out of range (:issue:`4519`, :issue:`4520`)
   - Fix boolean indexing on an empty series loses index names (:issue:`4235`),
     infer_dtype works with empty arrays.
-  - Fix reindexing with multiple axes; if an axes match was not replacing the current axes, leading
-    to a possible lazay frequency inference issue (:issue:`3317`)
+  - Fix reindexing with multiple axes; if an axes match was not replacing the
+    current axes, leading to a possible lazay frequency inference issue
+    (:issue:`3317`)
   - Fixed issue where ``DataFrame.apply`` was reraising exceptions incorrectly
     (causing the original stack trace to be truncated).
   - Fix selection with ``ix/loc`` and non_unique selectors (:issue:`4619`)
-  - Fix assignment with iloc/loc involving a dtype change in an existing column (:issue:`4312`)
-    have internal setitem_with_indexer in core/indexing to use Block.setitem
-  - Fixed bug where thousands operator was not handled correctly for floating point numbers
-    in csv_import (:issue:`4322`)
-  - Fix an issue with CacheableOffset not properly being used by many DateOffset; this prevented
-    the DateOffset from being cached (:issue:`4609`)
-  - Fix boolean comparison with a DataFrame on the lhs, and a list/tuple on the rhs (:issue:`4576`)
-  - Fix error/dtype conversion with setitem of ``None`` on ``Series/DataFrame`` (:issue:`4667`)
-  - Fix decoding based on a passed in non-default encoding in ``pd.read_stata`` (:issue:`4626`)
-  - Fix ``DataFrame.from_records`` with a plain-vanilla ``ndarray``. (:issue:`4727`)
+  - Fix assignment with iloc/loc involving a dtype change in an existing column
+    (:issue:`4312`) have internal setitem_with_indexer in core/indexing to use
+    Block.setitem
+  - Fixed bug where thousands operator was not handled correctly for floating
+    point numbers in csv_import (:issue:`4322`)
+  - Fix an issue with CacheableOffset not properly being used by many
+    DateOffset; this prevented the DateOffset from being cached (:issue:`4609`)
+  - Fix boolean comparison with a DataFrame on the lhs, and a list/tuple on the
+    rhs (:issue:`4576`)
+  - Fix error/dtype conversion with setitem of ``None`` on ``Series/DataFrame``
+    (:issue:`4667`)
+  - Fix decoding based on a passed in non-default encoding in ``pd.read_stata``
+    (:issue:`4626`)
+  - Fix ``DataFrame.from_records`` with a plain-vanilla ``ndarray``.
+    (:issue:`4727`)
   - Fix some inconsistencies with ``Index.rename`` and ``MultiIndex.rename``,
     etc. (:issue:`4718`, :issue:`4628`)
-  - Bug in using ``iloc/loc`` with a cross-sectional and duplicate indicies (:issue:`4726`)
-  - Bug with using ``QUOTE_NONE`` with ``to_csv`` causing ``Exception``. (:issue:`4328`)
-  - Bug with Series indexing not raising an error when the right-hand-side has an incorrect length (:issue:`2702`)
-  - Bug in multi-indexing with a partial string selection as one part of a MultIndex (:issue:`4758`)
-  - Bug with reindexing on the index with a non-unique index will now raise ``ValueError`` (:issue:`4746`)
-  - Bug in setting with ``loc/ix`` a single indexer with a multi-index axis and a numpy array, related to (:issue:`3777`)
-  - Bug in concatenation with duplicate columns across dtypes not merging with axis=0 (:issue:`4771`, :issue:`4975`)
+  - Bug in using ``iloc/loc`` with a cross-sectional and duplicate indicies
+    (:issue:`4726`)
+  - Bug with using ``QUOTE_NONE`` with ``to_csv`` causing ``Exception``.
+    (:issue:`4328`)
+  - Bug with Series indexing not raising an error when the right-hand-side has
+    an incorrect length (:issue:`2702`)
+  - Bug in multi-indexing with a partial string selection as one part of a
+    MultIndex (:issue:`4758`)
+  - Bug with reindexing on the index with a non-unique index will now raise
+    ``ValueError`` (:issue:`4746`)
+  - Bug in setting with ``loc/ix`` a single indexer with a multi-index axis and
+    a numpy array, related to (:issue:`3777`)
+  - Bug in concatenation with duplicate columns across dtypes not merging with
+    axis=0 (:issue:`4771`, :issue:`4975`)
   - Bug in ``iloc`` with a slice index failing (:issue:`4771`)
-  - Incorrect error message with no colspecs or width in ``read_fwf``. (:issue:`4774`)
-  - Fix bugs in indexing in a Series with a duplicate index (:issue:`4548`, :issue:`4550`)
+  - Incorrect error message with no colspecs or width in ``read_fwf``.
+    (:issue:`4774`)
+  - Fix bugs in indexing in a Series with a duplicate index (:issue:`4548`,
+    :issue:`4550`)
   - Fixed bug with reading compressed files with ``read_fwf`` in Python 3.
     (:issue:`3963`)
-  - Fixed an issue with a duplicate index and assignment with a dtype change (:issue:`4686`)
+  - Fixed an issue with a duplicate index and assignment with a dtype change
+    (:issue:`4686`)
   - Fixed bug with reading compressed files in as ``bytes`` rather than ``str``
     in Python 3. Simplifies bytes-producing file-handling in Python 3
     (:issue:`3963`, :issue:`4785`).
   - Fixed an issue related to ticklocs/ticklabels with log scale bar plots
     across different versions of matplotlib (:issue:`4789`)
-  - Suppressed DeprecationWarning associated with internal calls issued by repr() (:issue:`4391`)
-  - Fixed an issue with a duplicate index and duplicate selector with ``.loc`` (:issue:`4825`)
+  - Suppressed DeprecationWarning associated with internal calls issued by
+    repr() (:issue:`4391`)
+  - Fixed an issue with a duplicate index and duplicate selector with ``.loc``
+    (:issue:`4825`)
   - Fixed an issue with ``DataFrame.sort_index`` where, when sorting by a
     single column and passing a list for ``ascending``, the argument for
     ``ascending`` was being interpreted as ``True`` (:issue:`4839`,
     :issue:`4846`)
-  - Fixed ``Panel.tshift`` not working. Added `freq` support to ``Panel.shift`` (:issue:`4853`)
+  - Fixed ``Panel.tshift`` not working. Added `freq` support to ``Panel.shift``
+    (:issue:`4853`)
   - Fix an issue in TextFileReader w/ Python engine (i.e. PythonParser)
     with thousands != "," (:issue:`4596`)
   - Bug in getitem with a duplicate index when using where (:issue:`4879`)
   - Fix Type inference code coerces float column into datetime (:issue:`4601`)
-  - Fixed ``_ensure_numeric`` does not check for complex numbers (:issue:`4902`)
+  - Fixed ``_ensure_numeric`` does not check for complex numbers
+    (:issue:`4902`)
   - Fixed a bug in ``Series.hist`` where two figures were being created when
     the ``by`` argument was passed (:issue:`4112`, :issue:`4113`).
   - Fixed a bug in ``convert_objects`` for > 2 ndims (:issue:`4937`)
-  - Fixed a bug in DataFrame/Panel cache insertion and subsequent indexing (:issue:`4939`)
-  - Fixed string methods for ``FrozenNDArray`` and ``FrozenList`` (:issue:`4929`)
+  - Fixed a bug in DataFrame/Panel cache insertion and subsequent indexing
+    (:issue:`4939`)
+  - Fixed string methods for ``FrozenNDArray`` and ``FrozenList``
+    (:issue:`4929`)
   - Fixed a bug with setting invalid or out-of-range values in indexing
     enlargement scenarios (:issue:`4940`)
   - Tests for fillna on empty Series (:issue:`4346`), thanks @immerrr
@@ -570,22 +656,28 @@ Bug Fixes
   - Fixed skiprows option in Python parser for read_csv (:issue:`4382`)
   - Fixed bug preventing ``cut`` from working with ``np.inf`` levels without
     explicitly passing labels (:issue:`3415`)
-  - Fixed wrong check for overlapping in ``DatetimeIndex.union`` (:issue:`4564`)
-  - Fixed conflict between thousands separator and date parser in csv_parser (:issue:`4678`)
-  - Fix appending when dtypes are not the same (error showing mixing float/np.datetime64) (:issue:`4993`)
+  - Fixed wrong check for overlapping in ``DatetimeIndex.union``
+    (:issue:`4564`)
+  - Fixed conflict between thousands separator and date parser in csv_parser
+    (:issue:`4678`)
+  - Fix appending when dtypes are not the same (error showing mixing
+    float/np.datetime64) (:issue:`4993`)
   - Fix repr for DateOffset. No longer show duplicate entries in kwds.
     Removed unused offset fields. (:issue:`4638`)
-  - Fixed wrong index name during read_csv if using usecols. Applies to c parser only. (:issue:`4201`)
+  - Fixed wrong index name during read_csv if using usecols. Applies to c
+    parser only. (:issue:`4201`)
   - ``Timestamp`` objects can now appear in the left hand side of a comparison
     operation with a ``Series`` or ``DataFrame`` object (:issue:`4982`).
   - Fix a bug when indexing with ``np.nan`` via ``iloc/loc`` (:issue:`5016`)
-  - Fixed a bug where low memory c parser could create different types in different
-    chunks of the same file. Now coerces to numerical type or raises warning. (:issue:`3866`)
-  - Fix a bug where reshaping a ``Series`` to its own shape raised ``TypeError`` (:issue:`4554`)
-    and other reshaping issues.
+  - Fixed a bug where low memory c parser could create different types in
+    different chunks of the same file. Now coerces to numerical type or raises
+    warning. (:issue:`3866`)
+  - Fix a bug where reshaping a ``Series`` to its own shape raised
+    ``TypeError`` (:issue:`4554`) and other reshaping issues.
   - Bug in setting with ``ix/loc`` and a mixed int/string index (:issue:`4544`)
   - Make sure series-series boolean comparions are label based (:issue:`4947`)
-  - Bug in multi-level indexing with a Timestamp partial indexer (:issue:`4294`)
+  - Bug in multi-level indexing with a Timestamp partial indexer
+    (:issue:`4294`)
   - Tests/fix for multi-index construction of an all-nan frame (:issue:`4078`)
   - Fixed a bug where :func:`~pandas.read_html` wasn't correctly inferring
     values of tables with commas (:issue:`5029`)
@@ -602,10 +694,12 @@ Bug Fixes
     (:issue:`5102`).
   - Fixed a bug where ``groupby.plot()`` and friends were duplicating figures
     multiple times (:issue:`5102`).
-  - Provide automatic conversion of ``object`` dtypes on fillna, related (:issue:`5103`)
+  - Provide automatic conversion of ``object`` dtypes on fillna, related
+    (:issue:`5103`)
   - Fixed a bug where default options were being overwritten in the option
     parser cleaning (:issue:`5121`).
-  - Treat a list/ndarray identically for ``iloc`` indexing with list-like (:issue:`5006`)
+  - Treat a list/ndarray identically for ``iloc`` indexing with list-like
+    (:issue:`5006`)
   - Fix ``MultiIndex.get_level_values()`` with missing values (:issue:`5074`)
   - Fix bound checking for Timestamp() with datetime64 input (:issue:`4065`)
   - Fix a bug where ``TestReadHtml`` wasn't calling the correct ``read_html()``
@@ -618,13 +712,16 @@ Bug Fixes
     context manager.
   - Fixed segfault on ``isnull(MultiIndex)`` (now raises an error instead)
     (:issue:`5123`, :issue:`5125`)
-  - Allow duplicate indices when performing operations that align (:issue:`5185`)
-  - Compound dtypes in a constructor raise ``NotImplementedError`` (:issue:`5191`)
+  - Allow duplicate indices when performing operations that align
+    (:issue:`5185`)
+  - Compound dtypes in a constructor raise ``NotImplementedError``
+    (:issue:`5191`)
   - Bug in comparing duplicate frames (:issue:`4421`) related
   - Bug in describe on duplicate frames
-  - Bug in ``to_datetime`` with a format and ``coerce=True`` not raising (:issue:`5195`)
-  - Bug in ``loc`` setting with multiple indexers and a rhs of a Series that needs
-    broadcasting (:issue:`5206`)
+  - Bug in ``to_datetime`` with a format and ``coerce=True`` not raising
+    (:issue:`5195`)
+  - Bug in ``loc`` setting with multiple indexers and a rhs of a Series that
+    needs broadcasting (:issue:`5206`)
   - Fixed bug where inplace setting of levels or labels on ``MultiIndex`` would
     not clear cached ``values`` property and therefore return wrong ``values``.
     (:issue:`5215`)
@@ -638,9 +735,10 @@ Bug Fixes
   - Fixed seg fault in C parser caused by passing more names than columns in
     the file. (:issue:`5156`)
   - Fix ``Series.isin`` with date/time-like dtypes (:issue:`5021`)
-  - C and Python Parser can now handle the more common multi-index column format
-    which doesn't have a row for index names (:issue:`4702`)
-  - Bug when trying to use an out-of-bounds date as an object dtype (:issue:`5312`)
+  - C and Python Parser can now handle the more common multi-index column
+    format which doesn't have a row for index names (:issue:`4702`)
+  - Bug when trying to use an out-of-bounds date as an object dtype
+    (:issue:`5312`)
   - Bug when trying to display an embedded PandasObject (:issue:`5324`)
   - Allows operating of Timestamps to return a datetime if the result is out-of-bounds
     related (:issue:`5312`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -345,16 +345,19 @@ class NDFrame(PandasObject):
 
     @property
     def shape(self):
+        "tuple of axis dimensions"
         return tuple(len(self._get_axis(a)) for a in self._AXIS_ORDERS)
 
     @property
     def axes(self):
-        """ we do it this way because if we have reversed axes, then
-        the block manager shows then reversed """
+        "index(es) of the NDFrame"
+        # we do it this way because if we have reversed axes, then
+        # the block manager shows then reversed
         return [self._get_axis(a) for a in self._AXIS_ORDERS]
 
     @property
     def ndim(self):
+        "Number of axes / array dimensions"
         return self._data.ndim
 
     def _expand_axes(self, key):
@@ -598,11 +601,18 @@ class NDFrame(PandasObject):
 
     # can we get a better explanation of this?
     def keys(self):
-        """ return the info axis names """
+        """Get the 'info axis' (see Indexing for more)
+
+        This is index for Series, columns for DataFrame and major_axis for
+        Panel."""
         return self._info_axis
 
-    # what does info axis actually mean?
     def iteritems(self):
+        """Iterate over (label, values) on info axis
+
+        This is index for Series, columns for DataFrame, major_axis for Panel,
+        and so on.
+        """
         for h in self._info_axis:
             yield h, self[h]
 
@@ -610,6 +620,7 @@ class NDFrame(PandasObject):
     # Now unnecessary. Sidenote: don't want to deprecate this for a while,
     # otherwise libraries that use 2to3 will have issues.
     def iterkv(self, *args, **kwargs):
+        "iteritems alias used to get around 2to3. Deprecated"
         warnings.warn("iterkv is deprecated and will be removed in a future "
                       "release, use ``iteritems`` instead.", DeprecationWarning)
         return self.iteritems(*args, **kwargs)
@@ -624,6 +635,7 @@ class NDFrame(PandasObject):
 
     @property
     def empty(self):
+        "True if NDFrame is entirely empty [no items]"
         return not all(len(self._get_axis(a)) > 0 for a in self._AXIS_ORDERS)
 
     def __nonzero__(self):
@@ -664,6 +676,7 @@ class NDFrame(PandasObject):
         return self._constructor(result, **d).__finalize__(self)
 
     def to_dense(self):
+        "Return dense representation of NDFrame (as opposed to sparse)"
         # compat
         return self
 
@@ -857,12 +870,14 @@ class NDFrame(PandasObject):
         return to_pickle(self, path)
 
     def save(self, path):  # TODO remove in 0.14
+        "Deprecated. Use to_pickle instead"
         import warnings
         from pandas.io.pickle import to_pickle
         warnings.warn("save is deprecated, use to_pickle", FutureWarning)
         return to_pickle(self, path)
 
     def load(self, path):  # TODO remove in 0.14
+        "Deprecated. Use read_pickle instead."
         import warnings
         from pandas.io.pickle import read_pickle
         warnings.warn("load is deprecated, use pd.read_pickle", FutureWarning)
@@ -1562,6 +1577,7 @@ class NDFrame(PandasObject):
 
     @property
     def values(self):
+        "Numpy representation of NDFrame"
         return self.as_matrix()
 
     @property
@@ -1611,6 +1627,7 @@ class NDFrame(PandasObject):
 
     @property
     def blocks(self):
+        "Internal property, property synonym for as_blocks()"
         return self.as_blocks()
 
     def astype(self, dtype, copy=True, raise_on_error=True):
@@ -1777,10 +1794,12 @@ class NDFrame(PandasObject):
             return self._constructor(new_data).__finalize__(self)
 
     def ffill(self, axis=0, inplace=False, limit=None, downcast=None):
+        "Synonym for NDFrame.fillna(method='ffill')"
         return self.fillna(method='ffill', axis=axis, inplace=inplace,
                            limit=limit, downcast=downcast)
 
     def bfill(self, axis=0, inplace=False, limit=None, downcast=None):
+        "Synonym for NDFrame.fillna(method='bfill')"
         return self.fillna(method='bfill', axis=axis, inplace=inplace,
                            limit=limit, downcast=downcast)
 

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -1238,7 +1238,7 @@ Returns
                 # not sure whether it's worth it at the moment
                 result = com._fill_zeros(result,y,fill_zeros)
                 return result
-            @Substitution(op)
+            @Substitution(name)
             @Appender(_agg_doc)
             def f(self, other, axis=0):
                 return self._combine(other, na_op, axis=axis)


### PR DESCRIPTION
1. Panel flex docstrings had str representation of functions like
   `<builtin-func add..>` (not pretty). Fixed to be name
2. Added some docstrings to miscellaneous properties and clarified
   meaning of info_axis/keys.
3. Wrap 0.13's release.rst at 80 characters per line.

I'm happy to revert (3) above...just was bothering me (most of the doc
breaks at 80)

Key change is here - http://jtratner.github.io/example-pandas-docs/html-minor-doc-fixup-10-25/api.html#id17
