### PR TITLE
API: provide compat for Timestamp  now/today/utcnow class methods (GH5339)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -321,6 +321,7 @@ API Changes
     (:issue:`4501`)
   - Support non-unique axes in a Panel via indexing operations (:issue:`4960`)
   - ``.truncate`` will raise a ``ValueError`` if invalid before and afters dates are given (:issue:`5242`)
+  - ``Timestamp`` now supports ``now/today/utcnow`` class methods (:issue:`5339`)
 
 Internal Refactoring
 ~~~~~~~~~~~~~~~~~~~~

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -2516,6 +2516,18 @@ class TestSeriesDatetime64(unittest.TestCase):
 
 class TestTimestamp(unittest.TestCase):
 
+    def test_class_ops(self):
+        _skip_if_no_pytz()
+        import pytz
+
+        def compare(x,y):
+            self.assert_(int(Timestamp(x).value/1e9) == int(Timestamp(y).value/1e9))
+
+        compare(Timestamp.now(),datetime.now())
+        compare(Timestamp.now('UTC'),datetime.now(pytz.timezone('UTC')))
+        compare(Timestamp.utcnow(),datetime.utcnow())
+        compare(Timestamp.today(),datetime.today())
+
     def test_basics_nanos(self):
         val = np.int64(946684800000000000).view('M8[ns]')
         stamp = Timestamp(val.view('i8') + 500)
@@ -3031,10 +3043,10 @@ class TestSlicing(unittest.TestCase):
         df = df.applymap(lambda x: x + BDay())
 
         self.assertTrue(df.x1.dtype == 'M8[ns]')
-        
+
     def test_date_range_fy5252(self):
-        dr = date_range(start="2013-01-01", 
-                           periods=2, 
+        dr = date_range(start="2013-01-01",
+                           periods=2,
                            freq=offsets.FY5253(startingMonth=1,
                                                weekday=3,
                                                variation="nearest"))

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -140,6 +140,22 @@ class Timestamp(_Timestamp):
             note: by definition there cannot be any tz info on the ordinal itself """
         return cls(datetime.fromordinal(ordinal),offset=offset,tz=tz)
 
+    @classmethod
+    def now(cls, tz=None):
+        """ compat now with datetime """
+        if isinstance(tz, basestring):
+            tz = pytz.timezone(tz)
+        return cls(datetime.now(tz))
+
+    @classmethod
+    def today(cls):
+        """ compat today with datetime """
+        return cls(datetime.today())
+
+    @classmethod
+    def utcnow(cls):
+        return cls.now('UTC')
+
     def __new__(cls, object ts_input, object offset=None, tz=None, unit=None):
         cdef _TSObject ts
         cdef _Timestamp ts_base


### PR DESCRIPTION
closes #5339
