### PR TITLE
ENH: allow in-line expression assignment with df.eval

### DIFF
--- a/doc/source/enhancingperf.rst
+++ b/doc/source/enhancingperf.rst
@@ -441,18 +441,27 @@ The ``DataFrame.eval`` method (Experimental)
 In addition to the top level :func:`~pandas.eval` function you can also
 evaluate an expression in the "context" of a ``DataFrame``.
 
-
 .. ipython:: python
 
    df = DataFrame(randn(5, 2), columns=['a', 'b'])
    df.eval('a + b')
-
 
 Any expression that is a valid :func:`~pandas.eval` expression is also a valid
 ``DataFrame.eval`` expression, with the added benefit that *you don't have to
 prefix the name of the* ``DataFrame`` *to the column you're interested in
 evaluating*.
 
+In addition, you can perform in-line assignment of columns within an expression.
+This can allow for *formulaic evaluation*. Only a signle assignement is permitted.
+It can be a new column name or an existing column name. It must be a string-like.
+
+.. ipython:: python
+
+   df = DataFrame(dict(a = range(5), b = range(5,10)))
+   df.eval('c=a+b')
+   df.eval('d=a+b+c')
+   df.eval('a=1')
+   df
 
 Local Variables
 ~~~~~~~~~~~~~~~

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -72,7 +72,8 @@ Experimental Features
     ``numexpr`` behind the scenes. This results in large speedups for complicated
     expressions involving large DataFrames/Series.
   - :class:`~pandas.DataFrame` has a new :meth:`~pandas.DataFrame.eval` that
-    evaluates an expression in the context of the ``DataFrame``.
+    evaluates an expression in the context of the ``DataFrame``; allows
+    inline expression assignment
   - A :meth:`~pandas.DataFrame.query` method has been added that allows
     you to select elements of a ``DataFrame`` using a natural query syntax nearly
     identical to Python syntax.

--- a/pandas/computation/eval.py
+++ b/pandas/computation/eval.py
@@ -203,4 +203,10 @@ def eval(expr, parser='pandas', engine='numexpr', truediv=True,
     eng = _engines[engine]
     eng_inst = eng(parsed_expr)
     ret = eng_inst.evaluate()
+
+    # assign if needed
+    if parsed_expr.assignee is not None and parsed_expr.assigner is not None:
+        parsed_expr.assignee[parsed_expr.assigner] = ret
+        return None
+
     return ret

--- a/pandas/computation/eval.py
+++ b/pandas/computation/eval.py
@@ -113,7 +113,8 @@ def _convert_expression(expr):
 
 
 def eval(expr, parser='pandas', engine='numexpr', truediv=True,
-         local_dict=None, global_dict=None, resolvers=None, level=2):
+         local_dict=None, global_dict=None, resolvers=None, level=2,
+         target=None):
     """Evaluate a Python expression as a string using various backends.
 
     The following arithmetic operations are supported: ``+``, ``-``, ``*``,
@@ -169,6 +170,8 @@ def eval(expr, parser='pandas', engine='numexpr', truediv=True,
     level : int, optional
         The number of prior stack frames to traverse and add to the current
         scope. Most users will **not** need to change this parameter.
+    target : a target object for assignment, optional, default is None
+        essentially this is a passed in resolver
 
     Returns
     -------
@@ -194,7 +197,7 @@ def eval(expr, parser='pandas', engine='numexpr', truediv=True,
 
     # get our (possibly passed-in) scope
     env = _ensure_scope(global_dict=global_dict, local_dict=local_dict,
-                        resolvers=resolvers, level=level)
+                        resolvers=resolvers, level=level, target=target)
 
     parsed_expr = Expr(expr, engine=engine, parser=parser, env=env,
                        truediv=truediv)
@@ -205,8 +208,8 @@ def eval(expr, parser='pandas', engine='numexpr', truediv=True,
     ret = eng_inst.evaluate()
 
     # assign if needed
-    if parsed_expr.assignee is not None and parsed_expr.assigner is not None:
-        parsed_expr.assignee[parsed_expr.assigner] = ret
+    if env.target is not None and parsed_expr.assigner is not None:
+        env.target[parsed_expr.assigner] = ret
         return None
 
     return ret

--- a/pandas/computation/pytables.py
+++ b/pandas/computation/pytables.py
@@ -389,6 +389,11 @@ class ExprVisitor(BaseExprVisitor):
     def visit_Index(self, node, **kwargs):
         return self.visit(node.value).value
 
+    def visit_Assign(self, node, **kwargs):
+        cmpr = ast.Compare(ops=[ast.Eq()], left=node.targets[0],
+                           comparators=[node.value])
+        return self.visit(cmpr)
+
     def visit_Subscript(self, node, **kwargs):
         value = self.visit(node.value)
         slobj = self.visit(node.slice)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1797,12 +1797,14 @@ class DataFrame(NDFrame):
         >>> from pandas import DataFrame
         >>> df = DataFrame(randn(10, 2), columns=list('ab'))
         >>> df.eval('a + b')
+        >>> df.eval('c=a + b')
         """
         resolvers = kwargs.pop('resolvers', None)
         if resolvers is None:
             index_resolvers = self._get_resolvers()
             resolvers = [self, index_resolvers]
         kwargs['local_dict'] = _ensure_scope(resolvers=resolvers, **kwargs)
+        kwargs['target'] = self
         return _eval(expr, **kwargs)
 
     def _slice(self, slobj, axis=0, raise_on_error=False, typ=None):


### PR DESCRIPTION
This was a relatively easy extension of eval to allow in-line creation/assignment.

Allows one to basically use formulas to do things (pandas conquers excel!!!!)
- [x] docs
- [x] tests non-frame

```
In [11]: df = DataFrame(dict(a = range(5), b = range(5,10)))

In [12]: df
Out[12]: 
   a  b
0  0  5
1  1  6
2  2  7
3  3  8
4  4  9

In [13]: df.eval('c=a+b')

In [14]: df.eval('d=a+b+c')

In [15]: df.eval('a=1')

In [16]: df
Out[16]: 
   a  b   c   d
0  1  5   5  10
1  1  6   7  14
2  1  7   9  18
3  1  8  11  22
4  1  9  13  26
```

You can do this (this could maybe have a bit better syntax though)

```
In [31]: df = DataFrame(dict(a = range(5), b = range(5,10)))

In [32]: formulas = Series(['c=a+b','d=a*b'],index=['a','b'])

In [33]: df.apply(lambda x: df.eval(formulas[x.name]))
Out[33]: 
a    None
b    None
dtype: object

In [34]: df
Out[34]: 
   a  b   c   d
0  0  5   5   0
1  1  6   7   6
2  2  7   9  14
3  3  8  11  24
4  4  9  13  36
```
