### PR TITLE
DOC: Panel *xs() docstring indicates wrong default for copy

### DIFF
--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -702,7 +702,7 @@ class Panel(NDFrame):
         ----------
         key : object
             Major axis label
-        copy : boolean, default False
+        copy : boolean, default True
             Copy data
 
         Returns
@@ -720,7 +720,7 @@ class Panel(NDFrame):
         ----------
         key : object
             Minor axis label
-        copy : boolean, default False
+        copy : boolean, default True
             Copy data
 
         Returns
@@ -739,6 +739,8 @@ class Panel(NDFrame):
         key : object
             Label
         axis : {'items', 'major', 'minor}, default 1/'major'
+        copy : boolean, default True
+            Copy data
 
         Returns
         -------


### PR DESCRIPTION
Also the copy param in Panel.xs was undocumented. Intentional?

Worth a line in release.rst?
