### PR TITLE
ENH: HDFStore.flush() to optionally perform fsync (GH5364)

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -2745,12 +2745,9 @@ Notes & Caveats
      need to serialize these operations in a single thread in a single
      process. You will corrupt your data otherwise. See the issue
      (:`2397`) for more information.
-   - If serializing all write operations via a single thread in a single
-     process is not an option, another alternative is to use an external
-     distributed lock manager to ensure there is only a single writer at a
-     time and all readers close the file during writes and re-open it after any
-     writes. In this case you should use ``store.flush(fsync=True)`` prior to
-     releasing any write locks. See the issue (:`5364`) for more information.
+   - If you use locks to manage write access between multiple processes, you
+     may want to use :py:func:`~os.fsync` before releasing write locks. For
+     convenience you can use ``store.flush(fsync=True)`` to do this for you.
    - ``PyTables`` only supports fixed-width string columns in
      ``tables``. The sizes of a string based indexing column
      (e.g. *columns* or *minor_axis*) are determined as the maximum size

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -2745,6 +2745,12 @@ Notes & Caveats
      need to serialize these operations in a single thread in a single
      process. You will corrupt your data otherwise. See the issue
      (:`2397`) for more information.
+   - If serializing all write operations via a single thread in a single
+     process is not an option, another alternative is to use an external
+     distributed lock manager to ensure there is only a single writer at a
+     time and all readers close the file during writes and re-open it after any
+     writes. In this case you should use ``store.flush(fsync=True)`` prior to
+     releasing any write locks. See the issue (:`5364`) for more information.
    - ``PyTables`` only supports fixed-width string columns in
      ``tables``. The sizes of a string based indexing column
      (e.g. *columns* or *minor_axis*) are determined as the maximum size

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -275,6 +275,8 @@ API Changes
     - store `datetime.date` objects as ordinals rather then timetuples to avoid
       timezone issues (:issue:`2852`), thanks @tavistmorph and @numpand
     - ``numexpr`` 2.2.2 fixes incompatiblity in PyTables 2.4 (:issue:`4908`)
+    - ``flush`` now accepts an ``fsync`` parameter, which defaults to ``False``
+      (:issue:`5364`)
   - ``JSON``
 
     - added ``date_unit`` parameter to specify resolution of timestamps.

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -530,21 +530,17 @@ class HDFStore(StringMixin):
         """
         Force all buffered modifications to be written to disk.
 
-        By default this method requests PyTables to flush, and PyTables in turn
-        requests the HDF5 library to flush any changes to the operating system.
-        There is no guarantee the operating system will actually commit writes
-        to disk.
-
-        To request the operating system to write the file to disk, pass
-        ``fsync=True``. The method will then block until the operating system
-        reports completion, although be aware there might be other caching
-        layers (eg disk controllers, disks themselves etc) which further delay
-        durability.
-
         Parameters
         ----------
-        fsync : boolean, invoke fsync for the file handle, default False
+        fsync : bool (default False)
+          call ``os.fsync()`` on the file handle to force writing to disk.
 
+        Notes
+        -----
+        Without ``fsync=True``, flushing may not guarantee that the OS writes
+        to disk. With fsync, the operation will block until the OS claims the
+        file has been written; however, other caching layers may still
+        interfere.
         """
         if self._handle is not None:
             self._handle.flush()

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -465,11 +465,6 @@ class TestHDFStore(unittest.TestCase):
         with ensure_clean(self.path) as store:
             store['a'] = tm.makeTimeSeries()
             store.flush()
-
-    def test_flush_fsync(self):
-
-        with ensure_clean(self.path) as store:
-            store['a'] = tm.makeTimeSeries()
             store.flush(fsync=True)
 
     def test_get(self):

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -466,6 +466,12 @@ class TestHDFStore(unittest.TestCase):
             store['a'] = tm.makeTimeSeries()
             store.flush()
 
+    def test_flush_fsync(self):
+
+        with ensure_clean(self.path) as store:
+            store['a'] = tm.makeTimeSeries()
+            store.flush(fsync=True)
+
     def test_get(self):
 
         with ensure_clean(self.path) as store:


### PR DESCRIPTION
Pull request for #5364.

The `fsync=False` parameter was added to `flush` given this offers utility for non-distribution use cases, such as a user just wanting to ensure their data is regularly flushed to disk.

I could not see any mocking library in use in the Pandas tests, so I skipped adding one just to verify `os.fsync` actually gets called.
