### PR TITLE
Escape special characters in to_latex() output

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -87,6 +87,7 @@ Improvements to existing features
   - perf improvments in ``dtypes/ftypes`` methods (:issue:`5968`)
   - perf improvments in indexing with object dtypes (:issue:`5968`)
   - improved dtype inference for ``timedelta`` like passed to constructors (:issue:`5458`,:issue:`5689`)
+  - escape special characters when writing to latex (:issue: `5374`)
 
 .. _release.bug_fixes-0.13.1:
 

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -468,8 +468,15 @@ class DataFrameFormatter(TableFormatter):
             for i, row in enumerate(zip(*strcols)):
                 if i == nlevels:
                     buf.write('\\midrule\n')  # End of header
-                crow = [(x.replace('_', '\\_')
+                crow = [(x.replace('\\', '\\textbackslash') # escape backslashes first
+                         .replace('_', '\\_')
                          .replace('%', '\\%')
+                         .replace('$', '\\$')
+                         .replace('#', '\\#')
+                         .replace('{', '\\{')
+                         .replace('}', '\\}')
+                         .replace('~', '\\textasciitilde')
+                         .replace('^', '\\textasciicircum')
                          .replace('&', '\\&') if x else '{}') for x in row]
                 buf.write(' & '.join(crow))
                 buf.write(' \\\\\n')

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -1654,6 +1654,30 @@ c  10  11  12  13  14\
 \end{tabular}
 """
         self.assertEqual(withoutindex_result, withoutindex_expected)
+        
+    def test_to_latex_escape_special_chars(self):
+        special_characters = ['&','%','$','#','_',
+                               '{','}','~','^','\\'] 
+        df = DataFrame(data=special_characters)
+        observed = df.to_latex()
+        expected = r"""\begin{tabular}{ll}
+\toprule
+{} &  0 \\
+\midrule
+0 &  \& \\
+1 &  \% \\
+2 &  \$ \\
+3 &  \# \\
+4 &  \_ \\
+5 &  \{ \\
+6 &  \} \\
+7 &  \textasciitilde \\
+8 &  \textasciicircum \\
+9 &  \textbackslash \\
+\bottomrule
+\end{tabular}
+"""
+        self.assertEqual(observed, expected)
 
 class TestSeriesFormatting(tm.TestCase):
     _multiprocess_can_split_ = True


### PR DESCRIPTION
Some characters have special meaning in latex: & % $ # _ { } ~ ^ .  When a dataframe contains a special character (as part of an index label, for example), to_latex() spits out invalid latex. 
