### PR TITLE
BUG/TST: transform and filter on non-unique index, closes #4620

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -762,6 +762,9 @@ Bug Fixes
   - Make sure that ``head/tail`` are ``iloc`` based, (:issue:`5370`)
   - Fixed bug for ``PeriodIndex`` string representation if there are 1 or 2
     elements. (:issue:`5372`)
+  - The GroupBy methods ``transform`` and ``filter`` can be used on Series
+    and DataFrames that have repeated (non-unique) indices. (:issue:`4620`)
+
 
 pandas 0.12.0
 -------------


### PR DESCRIPTION
closes #4620

This is a relatively minor change. Previously, `filter` on
`SeriesGroupBy` and `DataFrameGroupby` and `transform` on only
`SeriesGroupBy` referred to the index of each group's object.

This cannot work with repeated indexes, because some repeated
indexes occur between more than one group. Instead, use
`{Series, DataFrame}GroupBy.indices` array, an array of
locations, not labels.

_This was marked for 0.14, but I would really like to start using it._
