### PR TITLE
repr for PeriodIndex does not handle <=2 elements well (GH5372)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -760,7 +760,8 @@ Bug Fixes
     (thanks for catching this @yarikoptic!)
   - Fixed html tests on win32. (:issue:`4580`)
   - Make sure that ``head/tail`` are ``iloc`` based, (:issue:`5370`)
-
+  - Fixed bug for ``PeriodIndex`` string representation if there are 1 or 2
+    elements. (:issue:`5372`)
 
 pandas 0.12.0
 -------------

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -1082,7 +1082,11 @@ class PeriodIndex(Int64Index):
         output = com.pprint_thing(self.__class__) + '\n'
         output += 'freq: %s\n' % self.freq
         n = len(self)
-        if n:
+        if n == 1:
+            output += '[%s]\n' % (self[0])
+        elif n == 2:
+            output += '[%s, %s]\n' % (self[0], self[-1])
+        elif n:
             output += '[%s, ..., %s]\n' % (self[0], self[-1])
         output += 'length: %d' % n
         return output

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -1672,7 +1672,19 @@ class TestPeriodIndex(TestCase):
     def test_ts_repr(self):
         index = PeriodIndex(freq='A', start='1/1/2001', end='12/31/2010')
         ts = Series(np.random.randn(len(index)), index=index)
-        repr(ts)
+        repr(ts) # ??
+
+        val = period_range('2013Q1', periods=1, freq="Q")
+        expected = "<class 'pandas.tseries.period.PeriodIndex'>\nfreq: Q-DEC\n[2013Q1]\nlength: 1"
+        assert_equal(repr(val), expected)
+
+        val = period_range('2013Q1', periods=2, freq="Q")
+        expected = "<class 'pandas.tseries.period.PeriodIndex'>\nfreq: Q-DEC\n[2013Q1, 2013Q2]\nlength: 2"
+        assert_equal(repr(val), expected)
+
+        val = period_range('2013Q1', periods=3, freq="Q")
+        expected = "<class 'pandas.tseries.period.PeriodIndex'>\nfreq: Q-DEC\n[2013Q1, ..., 2013Q3]\nlength: 3"
+        assert_equal(repr(val), expected)
 
     def test_period_index_unicode(self):
         pi = PeriodIndex(freq='A', start='1/1/2001', end='12/1/2009')


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/5372
