### PR TITLE
ENH: Add mode method to Series and DataFrame

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -348,6 +348,7 @@ Computations / Descriptive Stats
    Series.mean
    Series.median
    Series.min
+   Series.mode
    Series.nunique
    Series.pct_change
    Series.prod
@@ -632,6 +633,7 @@ Computations / Descriptive Stats
    DataFrame.mean
    DataFrame.median
    DataFrame.min
+   DataFrame.mode
    DataFrame.pct_change
    DataFrame.prod
    DataFrame.quantile

--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -378,6 +378,7 @@ optional ``level`` parameter which applies only if the object has a
     ``median``, Arithmetic median of values
     ``min``, Minimum
     ``max``, Maximum
+    ``mode``, Mode
     ``abs``, Absolute Value
     ``prod``, Product of values
     ``std``, Unbiased standard deviation
@@ -473,8 +474,8 @@ value, ``idxmin`` and ``idxmax`` return the first matching index:
 
 .. _basics.discretization:
 
-Value counts (histogramming)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Value counts (histogramming) / Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``value_counts`` Series method and top-level function computes a histogram
 of a 1D array of values. It can also be used as a function on regular arrays:
@@ -486,6 +487,17 @@ of a 1D array of values. It can also be used as a function on regular arrays:
    s = Series(data)
    s.value_counts()
    value_counts(data)
+
+Similarly, you can get the most frequently occuring value(s) (the mode) of the values in a Series or DataFrame:
+
+.. ipython:: python
+
+    data = [1, 1, 3, 3, 3, 5, 5, 7, 7, 7]
+    s = Series(data)
+    s.mode()
+    df = pd.DataFrame({"A": np.random.randint(0, 7, size=50),
+                       "B": np.random.randint(-10, 15, size=50)})
+    df.mode()
 
 
 Discretization and quantiling
@@ -514,6 +526,7 @@ normally distributed data into equal-size quartiles like so:
    value_counts(factor)
 
 We can also pass infinite values to define the bins:
+
 .. ipython:: python
 
    arr = np.random.randn(20)

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -65,6 +65,8 @@ New features
     string via the ``date_format`` keyword (:issue:`4313`)
   - Added ``LastWeekOfMonth`` DateOffset (:issue:`4637`)
   - Added ``FY5253``, and ``FY5253Quarter`` DateOffsets (:issue:`4511`)
+  - Added ``mode()`` method to ``Series`` and ``DataFrame`` to get the
+    statistical mode(s) of a column/series. (:issue:`5367`)
 
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -81,6 +81,8 @@ API changes
   ``SparsePanel``, etc.), now support the entire set of arithmetic operators
   and arithmetic flex methods (add, sub, mul, etc.). ``SparsePanel`` does not
   support ``pow`` or ``mod`` with non-scalars. (:issue:`3765`)
+- ``Series`` and ``DataFrame`` now have a ``mode()`` method to calculate the
+  statistical mode(s) by axis/Series. (:issue:`5367`)
 
 
 Prior Version Deprecations/Changes

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -221,6 +221,34 @@ def value_counts(values, sort=True, ascending=False, normalize=False, bins=None)
     return result
 
 
+def mode(values):
+    from pandas.core.series import Series
+
+    if isinstance(values, Series):
+        constructor = values._constructor
+        values = values.values
+    else:
+        values = np.asanyarray(values)
+        constructor = Series
+
+    dtype = values.dtype
+    if com.is_integer_dtype(values.dtype):
+        values = com._ensure_int64(values)
+        result = constructor(htable.mode_int64(values), dtype=dtype)
+
+    elif issubclass(values.dtype.type, (np.datetime64,np.timedelta64)):
+        dtype = values.dtype
+        values = values.view(np.int64)
+        result = constructor(htable.mode_int64(values), dtype=dtype)
+
+    else:
+        mask = com.isnull(values)
+        values = com._ensure_object(values)
+        result = constructor(htable.mode_object(values, mask), dtype=dtype)
+
+    return result
+
+
 def rank(values, axis=0, method='average', na_option='keep',
          ascending=True):
     """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4083,6 +4083,24 @@ class DataFrame(NDFrame):
         else:
             raise ValueError('Axis must be 0 or 1 (got %r)' % axis_num)
 
+    def mode(self, axis=0, numeric_only=False):
+        """
+        Gets the mode of each element along the axis selected. Empty if nothing
+        has 2+ occurrences. Adds a row for each mode per label, fills in gaps
+        with nan.
+
+        Parameters
+        ----------
+        axis : {0, 1, 'index', 'columns'} (default 0)
+            0/'index' : get mode of each column
+            1/'columns' : get mode of each row
+        numeric_only : bool, default False
+            if True, only apply to numeric columns
+        """
+        data = self if not numeric_only else self._get_numeric_data()
+        f = lambda s: s.mode()
+        return data.apply(f, axis=axis)
+
     def quantile(self, q=0.5, axis=0, numeric_only=True):
         """
         Return values at the given quantile over requested axis, a la

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4096,6 +4096,10 @@ class DataFrame(NDFrame):
             1/'columns' : get mode of each row
         numeric_only : bool, default False
             if True, only apply to numeric columns
+
+        Returns
+        -------
+        modes : DataFrame (sorted)
         """
         data = self if not numeric_only else self._get_numeric_data()
         f = lambda s: s.mode()

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1133,9 +1133,15 @@ class Series(generic.NDFrame):
         Empty if nothing occurs at least 2 times.  Always returns Series even
         if only one value.
 
+        Parameters
+        ----------
+        sort : bool, default True
+            if True, will lexicographically sort values, if False skips
+            sorting. Result ordering when ``sort=False`` is not defined.
+
         Returns
         -------
-        modes : Series
+        modes : Series (sorted)
         """
         # TODO: Add option for bins like value_counts()
         from pandas.core.algorithms import mode

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1127,6 +1127,20 @@ class Series(generic.NDFrame):
         return value_counts(self.values, sort=sort, ascending=ascending,
                             normalize=normalize, bins=bins)
 
+    def mode(self):
+        """Returns the mode(s) of the dataset.
+
+        Empty if nothing occurs at least 2 times.  Always returns Series even
+        if only one value.
+
+        Returns
+        -------
+        modes : Series
+        """
+        # TODO: Add option for bins like value_counts()
+        from pandas.core.algorithms import mode
+        return mode(self)
+
     def unique(self):
         """
         Return array of unique values in the Series. Significantly faster than

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -10052,28 +10052,38 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
 
     def test_mode(self):
         df = pd.DataFrame({"A": [12, 12, 11, 12, 19, 11],
-                           "B": [10, 10, 10, 5, 3, 4],
+                           "B": [10, 10, 10, np.nan, 3, 4],
                            "C": [8, 8, 8, 9, 9, 9],
-                           "D": range(6)})
+                           "D": range(6),
+                           "E": [8, 8, 1, 1, 3, 3]})
         assert_frame_equal(df[["A"]].mode(),
                            pd.DataFrame({"A": [12]}))
         assert_frame_equal(df[["D"]].mode(),
                            pd.DataFrame(pd.Series([], dtype="int64"),
                                         columns=["D"]))
+        assert_frame_equal(df[["E"]].mode(),
+                           pd.DataFrame(pd.Series([1, 3, 8], dtype="int64"),
+                                        columns=["E"]))
         assert_frame_equal(df[["A", "B"]].mode(),
-                           pd.DataFrame({"A": [12], "B": [10]}))
+                           pd.DataFrame({"A": [12], "B": [10.]}))
         assert_frame_equal(df.mode(),
-                           pd.DataFrame({"A": [12, np.nan],
-                                         "B": [10, np.nan],
-                                         "C": [8, 9],
-                                         "D": [np.nan, np.nan]}))
+                           pd.DataFrame({"A": [12, np.nan, np.nan],
+                                         "B": [10, np.nan, np.nan],
+                                         "C": [8, 9, np.nan],
+                                         "D": [np.nan, np.nan, np.nan],
+                                         "E": [1, 3, 8]}))
 
-        # should preserve order
+        # outputs in sorted order
         df["C"] = list(reversed(df["C"]))
-        assert_frame_equal(df[["A", "B", "C"]].mode(),
+        print(df["C"])
+        print(df["C"].mode())
+        a, b = (df[["A", "B", "C"]].mode(),
                            pd.DataFrame({"A": [12, np.nan],
                                          "B": [10, np.nan],
-                                         "C": [9, 8]}))
+                                         "C": [8, 9]}))
+        print(a)
+        print(b)
+        assert_frame_equal(a, b)
         # should work with heterogeneous types
         df = pd.DataFrame({"A": range(6),
                            "B": pd.date_range('2011', periods=6),

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -19,10 +19,8 @@ from pandas import (Index, Series, DataFrame, isnull, notnull,
 from pandas.core.index import MultiIndex
 from pandas.tseries.index import Timestamp, DatetimeIndex
 import pandas.core.config as cf
-import pandas.core.series as smod
 import pandas.lib as lib
 
-import pandas.core.common as com
 import pandas.core.datetools as datetools
 import pandas.core.nanops as nanops
 
@@ -1720,6 +1718,35 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         # test with integers, test failure
         int_ts = Series(np.ones(10, dtype=int), index=lrange(10))
         self.assertAlmostEqual(np.median(int_ts), int_ts.median())
+
+    def test_mode(self):
+        s = Series([12, 12, 11, 10, 19, 11])
+        exp = Series([11, 12])
+        assert_series_equal(s.mode(), exp)
+
+        assert_series_equal(Series([1, 2, 3]).mode(), Series([], dtype=int))
+
+        lst = [5] * 20 + [1] * 10 + [6] * 25
+        np.random.shuffle(lst)
+        s = Series(lst)
+        assert_series_equal(s.mode(), Series([6]))
+
+        s = Series([5] * 10)
+        assert_series_equal(s.mode(), Series([5]))
+
+        s = Series(lst)
+        s[0] = np.nan
+        assert_series_equal(s.mode(), Series([6], dtype=float))
+
+        s = Series(list('adfasbasfwewefwefweeeeasdfasnbam'))
+        assert_series_equal(s.mode(), Series(['e']))
+
+        s = Series(['2011-01-03', '2013-01-02', '1900-05-03'], dtype='M8[ns]')
+        assert_series_equal(s.mode(), Series([], dtype="M8[ns]"))
+        s = Series(['2011-01-03', '2013-01-02', '1900-05-03', '2011-01-03',
+                    '2013-01-02'], dtype='M8[ns]')
+        assert_series_equal(s.mode(), Series(['2011-01-03', '2013-01-02'],
+                                             dtype='M8[ns]'))
 
     def test_prod(self):
         self._check_stat_op('prod', np.prod)


### PR DESCRIPTION
Closes #5367 - generally as fast or faster than value_counts (which makes sense because it has to construct Series), so should be relatively good performance-wise. Also, doesn't get stuck on value_counts' pathological case (huge array with # uniques close to/at the size of the array).

Not using result of hashtable.value_count() under the hood and instead iterating over klib table directly gives a _huge_ speedup. I just moved the value_count table creation method to a separate function (zero perf hit). For performance breakouts check out this gist:

https://gist.github.com/jtratner/7225878

DataFrame version delegates to Series' version at each level.
