### PR TITLE
ER/API: unicode indices not supported on table formats in py2 (GH5386)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -277,6 +277,7 @@ API Changes
     - ``numexpr`` 2.2.2 fixes incompatiblity in PyTables 2.4 (:issue:`4908`)
     - ``flush`` now accepts an ``fsync`` parameter, which defaults to ``False``
       (:issue:`5364`)
+    - ``unicode`` indices not supported on ``table`` formats (:issue:`5386`)
   - ``JSON``
 
     - added ``date_unit`` parameter to specify resolution of timestamps.

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -336,7 +336,8 @@ def ensure_clean(filename=None, return_filelike=False):
             yield filename
         finally:
             try:
-                os.remove(filename)
+                if os.path.exists(filename):
+                    os.remove(filename)
             except Exception as e:
                 print(e)
 


### PR DESCRIPTION
closes #5386
