### PR TITLE
API: raise/warn SettingWithCopy when chained assignment is detected

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -396,6 +396,9 @@ API Changes
     3    4.000000
     dtype: float64
 
+  - raise/warn ``SettingWithCopyError/Warning`` exception/warning when setting of a
+    copy thru chained assignment is detected, settable via option ``mode.chained_assignment``
+
 Internal Refactoring
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -104,6 +104,34 @@ API changes
 - ``Series`` and ``DataFrame`` now have a ``mode()`` method to calculate the
   statistical mode(s) by axis/Series. (:issue:`5367`)
 
+- Chained assignment will now by default warn if the user is assigning to a copy. This can be changed
+  with he option ``mode.chained_assignment``, allowed options are ``raise/warn/None``. See :ref:`the docs<indexing.view_versus_copy>`.
+
+  .. ipython:: python
+
+     dfc = DataFrame({'A':['aaa','bbb','ccc'],'B':[1,2,3]})
+     pd.set_option('chained_assignment','warn')
+
+  The following warning / exception will show if this is attempted.
+
+  .. ipython:: python
+
+     dfc.loc[0]['A'] = 1111
+
+  ::
+
+     Traceback (most recent call last)
+        ...
+     SettingWithCopyWarning:
+        A value is trying to be set on a copy of a slice from a DataFrame.
+        Try using .loc[row_index,col_indexer] = value instead
+
+  Here is the correct method of assignment.
+
+  .. ipython:: python
+
+     dfc.loc[0,'A'] = 11
+     dfc
 
 Prior Version Deprecations/Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -26,6 +26,11 @@ from pandas.core import array as pa
 class PandasError(Exception):
     pass
 
+class SettingWithCopyError(ValueError):
+    pass
+
+class SettingWithCopyWarning(Warning):
+    pass
 
 class AmbiguousIndexError(PandasError, KeyError):
     pass

--- a/pandas/core/config.py
+++ b/pandas/core/config.py
@@ -512,6 +512,13 @@ def _get_root(key):
         cursor = cursor[p]
     return cursor, path[-1]
 
+def _get_option_fast(key):
+    """ internal quick access routine, no error checking """
+    path = key.split('.')
+    cursor = _global_config
+    for p in path:
+        cursor = cursor[p]
+    return cursor
 
 def _is_deprecated(key):
     """ Returns True if the given option has been deprecated """

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -271,7 +271,6 @@ use_inf_as_null_doc = """
 # We don't want to start importing everything at the global context level
 # or we'll hit circular deps.
 
-
 def use_inf_as_null_cb(key):
     from pandas.core.common import _use_inf_as_null
     _use_inf_as_null(key)
@@ -279,6 +278,17 @@ def use_inf_as_null_cb(key):
 with cf.config_prefix('mode'):
     cf.register_option('use_inf_as_null', False, use_inf_as_null_doc,
                        cb=use_inf_as_null_cb)
+
+
+# user warnings
+chained_assignment = """
+: string
+    Raise an exception, warn, or no action if trying to use chained assignment, The default is warn
+"""
+
+with cf.config_prefix('mode'):
+    cf.register_option('chained_assignment', 'warn', chained_assignment,
+                       validator=is_one_of_factory([None, 'warn', 'raise']))
 
 
 # Set up the io.excel specific configuration.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1547,12 +1547,9 @@ class DataFrame(NDFrame):
                     i = _maybe_convert_indices(i, len(self._get_axis(axis)))
                     return self.reindex(i, takeable=True)
                 else:
-                    try:
-                        new_values = self._data.fast_2d_xs(i, copy=copy)
-                    except:
-                        new_values = self._data.fast_2d_xs(i, copy=True)
+                    new_values, copy = self._data.fast_2d_xs(i, copy=copy)
                     return Series(new_values, index=self.columns,
-                                  name=self.index[i])
+                                  name=self.index[i])._setitem_copy(copy)
 
         # icol
         else:
@@ -1892,9 +1889,17 @@ class DataFrame(NDFrame):
         Series/TimeSeries will be conformed to the DataFrame's index to
         ensure homogeneity.
         """
+
+        is_existing = key in self.columns
         self._ensure_valid_index(value)
         value = self._sanitize_column(key, value)
         NDFrame._set_item(self, key, value)
+
+        # check if we are modifying a copy
+        # try to set first as we want an invalid
+        # value exeption to occur first
+        if is_existing:
+            self._check_setitem_copy()
 
     def insert(self, loc, column, value, allow_duplicates=False):
         """
@@ -2093,13 +2098,16 @@ class DataFrame(NDFrame):
                 new_index = self.index[loc]
 
         if np.isscalar(loc):
-            new_values = self._data.fast_2d_xs(loc, copy=copy)
-            return Series(new_values, index=self.columns,
-                          name=self.index[loc])
+
+            new_values, copy = self._data.fast_2d_xs(loc, copy=copy)
+            result = Series(new_values, index=self.columns,
+                            name=self.index[loc])._setitem_copy(copy)
+
         else:
             result = self[loc]
             result.index = new_index
-            return result
+
+        return result
 
     _xs = xs
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2567,22 +2567,20 @@ class BlockManager(PandasObject):
         """
         get a cross sectional for a given location in the
         items ; handle dups
+
+        return the result and a flag if a copy was actually made
         """
         if len(self.blocks) == 1:
             result = self.blocks[0].values[:, loc]
             if copy:
                 result = result.copy()
-            return result
-
-        if not copy:
-            raise TypeError('cannot get view of mixed-type or '
-                            'non-consolidated DataFrame')
+            return result, copy
 
         items = self.items
 
         # non-unique (GH4726)
         if not items.is_unique:
-            return self._interleave(items).ravel()
+            return self._interleave(items).ravel(), True
 
         # unique
         dtype = _interleaved_dtype(self.blocks)
@@ -2593,7 +2591,7 @@ class BlockManager(PandasObject):
                 i = items.get_loc(item)
                 result[i] = blk._try_coerce_result(blk.iget((j, loc)))
 
-        return result
+        return result, True
 
     def consolidate(self):
         """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -22,7 +22,8 @@ from pandas.core.common import (isnull, notnull, _is_bool_indexer,
                                 _values_from_object,
                                 _possibly_cast_to_datetime, _possibly_castable,
                                 _possibly_convert_platform,
-                                ABCSparseArray, _maybe_match_name, _ensure_object)
+                                ABCSparseArray, _maybe_match_name, _ensure_object,
+                                SettingWithCopyError)
 
 from pandas.core.index import (Index, MultiIndex, InvalidIndexError,
                                _ensure_index, _handle_legacy_indexes)
@@ -575,6 +576,8 @@ class Series(generic.NDFrame):
         try:
             self._set_with_engine(key, value)
             return
+        except (SettingWithCopyError):
+            raise
         except (KeyError, ValueError):
             values = self.values
             if (com.is_integer(key)
@@ -623,6 +626,7 @@ class Series(generic.NDFrame):
         values = self.values
         try:
             self.index._engine.set_value(values, key, value)
+            self._check_setitem_copy()
             return
         except KeyError:
             values[self.index.get_loc(key)] = value

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -11059,9 +11059,11 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         dm.xs(2)[:] = 10
         self.assert_((dm.xs(2) == 5).all())
 
+        # prior to chained assignment (GH5390)
+        # this would raise, but now just rrens a copy (and sets _is_copy)
         # TODO (?): deal with mixed-type fiasco?
-        with assertRaisesRegexp(TypeError, 'cannot get view of mixed-type'):
-            self.mixed_frame.xs(self.mixed_frame.index[2], copy=False)
+        # with assertRaisesRegexp(TypeError, 'cannot get view of mixed-type'):
+        #    self.mixed_frame.xs(self.mixed_frame.index[2], copy=False)
 
         # unconsolidated
         dm['foo'] = 6.


### PR DESCRIPTION
```
In [1]: df = DataFrame({"A": [1, 2, 3, 4, 5], "B": [3.125, 4.12, 3.1, 6.2, 7.]})

In [2]: row = df.loc[0]
```

Default is to warn

```
In [3]: row["A"] = 0
pandas/core/generic.py:1001: SettingWithCopyWarning: A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_index,col_indexer] = value instead
  warnings.warn(t,SettingWithCopyWarning)

In [4]: row
Out[4]: 
A    0.000
B    3.125
Name: 0, dtype: float64

In [5]: df
Out[5]: 
   A      B
0  1  3.125
1  2  4.120
2  3  3.100
3  4  6.200
4  5  7.000
```

You can turn it off

```
In [6]: pd.set_option('chained',None)

In [7]: row["A"] = 0

In [8]: row
Out[8]: 
A    0.000
B    3.125
Name: 0, dtype: float64

In [9]: df
Out[9]: 
   A      B
0  1  3.125
1  2  4.120
2  3  3.100
3  4  6.200
4  5  7.000
```

Or set to raise

```
In [10]: row["A"] = 0
SettingWithCopyError: A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_index,col_indexer] = value instead
```
