### PR TITLE
BUG: groupby with a Float like index misbehaving when the index is non-monotonic (related GH5375)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -345,7 +345,7 @@ API Changes
     indexing and slicing work exactly the same.  Indexing on other index types
     are preserved (and positional fallback for ``[],ix``), with the exception,
     that floating point slicing on indexes on non ``Float64Index`` will raise a
-    ``TypeError``, e.g. ``Series(range(5))[3.5:4.5]`` (:issue:`263`)
+    ``TypeError``, e.g. ``Series(range(5))[3.5:4.5]`` (:issue:`263`,:issue:`5375`)
   - Make Categorical repr nicer (:issue:`4368`)
   - Remove deprecated ``Factor`` (:issue:`3650`)
   - Remove deprecated ``set_printoptions/reset_printoptions`` (:issue:``3046``)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2435,7 +2435,7 @@ class DataSplitter(object):
         return self.data.take(self.sort_idx, axis=self.axis, convert=False)
 
     def _chop(self, sdata, slice_obj):
-        return sdata[slice_obj]
+        return sdata.iloc[slice_obj]
 
     def apply(self, f):
         raise NotImplementedError
@@ -2470,7 +2470,7 @@ class FrameSplitter(DataSplitter):
 
     def _chop(self, sdata, slice_obj):
         if self.axis == 0:
-            return sdata[slice_obj]
+            return sdata.iloc[slice_obj]
         else:
             return sdata._slice(slice_obj, axis=1)  # ix[:, slice_obj]
 

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -202,6 +202,20 @@ class TestGroupBy(unittest.TestCase):
         f = s.groupby(level=0).first()
         self.assert_(f.dtype == 'int64')
 
+    def test_grouper_index_types(self):
+        # related GH5375
+        # groupby misbehaving when using a Floatlike index
+        df = DataFrame(np.arange(10).reshape(5,2),columns=list('AB'))
+        for index in [ tm.makeFloatIndex, tm.makeStringIndex,
+                       tm.makeUnicodeIndex, tm.makeIntIndex,
+                       tm.makeDateIndex, tm.makePeriodIndex ]:
+
+            df.index = index(len(df))
+            df.groupby(list('abcde')).apply(lambda x: x)
+
+            df.index = list(reversed(df.index.tolist()))
+            df.groupby(list('abcde')).apply(lambda x: x)
+
     def test_grouper_iter(self):
         self.assertEqual(sorted(self.df.groupby('A').grouper), ['bar', 'foo'])
 


### PR DESCRIPTION
related #5375
