### PR TITLE
BUG/TST: fix downcasting of float-like object array

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1038,7 +1038,8 @@ def _possibly_downcast_to_dtype(result, dtype):
             # try to upcast here
             elif inferred_type == 'floating':
                 dtype = 'int64'
-                trans = lambda x: x.round()
+                if issubclass(result.dtype.type, np.number):
+                    trans = lambda x: x.round()
 
             else:
                 dtype = 'object'

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -135,6 +135,20 @@ def test_downcast_conv():
     expected = np.array([8, 8, 8, 8, 9])
     assert (np.array_equal(result, expected))
 
+    # conversions
+
+    expected = np.array([1,2])
+    for dtype in [np.float64,object,np.int64]:
+        arr = np.array([1.0,2.0],dtype=dtype)
+        result = com._possibly_downcast_to_dtype(arr,'infer')
+        tm.assert_almost_equal(result, expected)
+
+    expected = np.array([1.0,2.0,np.nan])
+    for dtype in [np.float64,object]:
+        arr = np.array([1.0,2.0,np.nan],dtype=dtype)
+        result = com._possibly_downcast_to_dtype(arr,'infer')
+        tm.assert_almost_equal(result, expected)
+
 def test_datetimeindex_from_empty_datetime64_array():
     for unit in [ 'ms', 'us', 'ns' ]:
         idx = DatetimeIndex(np.array([], dtype='datetime64[%s]' % unit))


### PR DESCRIPTION
related #5394

This now works

```
In [1]: arr = np.array([1.0,2.0],dtype=object)

In [3]: pandas.core.common._possibly_downcast_to_dtype(arr,'infer')
Out[3]: array([1, 2])

```
