### PR TITLE
Display the correct error message when calling a binary moment without appropriate parameters.

### DIFF
--- a/pandas/stats/moments.py
+++ b/pandas/stats/moments.py
@@ -195,7 +195,7 @@ def rolling_corr(arg1, arg2, window, min_periods=None, freq=None,
 
 def _flex_binary_moment(arg1, arg2, f):
     if not (isinstance(arg1,(np.ndarray, Series, DataFrame)) and
-            isinstance(arg1,(np.ndarray, Series, DataFrame))):
+            isinstance(arg2,(np.ndarray, Series, DataFrame))):
         raise ValueError("arguments to moment function must be of type ndarray/DataFrame")
 
     if isinstance(arg1, (np.ndarray,Series)) and isinstance(arg2, (np.ndarray,Series)):


### PR DESCRIPTION
This pr fixes a typo in the type checking of  binary moments. It makes the error messages below consistent:

> > > import pandas
> > > a = pandas.DataFrame([1,2,3,4,5,6])
> > > pandas.rolling_cov(list(), a, 3)
> > > ValueError: arguments to moment function must be of type ndarray/DataFrame
> > > 
> > > pandas.rolling_cov(a, list(), 3)
> > > TypeError: unsupported type: <type 'list'>
