### PR TITLE
BUG: support for GA new segment format (GH5398)

### DIFF
--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -553,6 +553,7 @@ Enhancements
   output datetime objects should be formatted. Datetimes encountered in the
   index, columns, and values will all have this formatting applied. (:issue:`4313`)
 - ``DataFrame.plot`` will scatter plot x versus y by passing ``kind='scatter'`` (:issue:`2215`)
+- Added support for Google Analytics v3 API segment IDs that also supports v2 IDs. (:issue:`5271`)
 
 .. _whatsnew_0130.experimental:
 
@@ -726,7 +727,6 @@ Experimental
      As of 10/10/13, there is a bug in Google's API preventing result sets
      from being larger than 100,000 rows. A patch is scheduled for the week of
      10/14/13.
-
 .. _whatsnew_0130.refactoring:
 
 Internal Refactoring

--- a/pandas/io/ga.py
+++ b/pandas/io/ga.py
@@ -360,7 +360,7 @@ def format_query(ids, metrics, start_date, end_date=None, dimensions=None,
     [_maybe_add_arg(qry, n, d) for n, d in zip(names, lst)]
 
     if isinstance(segment, compat.string_types):
-        if re.match("^[a-zA-Z0-9]+\-*[a-zA-Z0-9]*$", segment):
+        if re.match("^[a-zA-Z0-9\-\_]+$", segment):
             _maybe_add_arg(qry, 'segment', segment, 'gaid:')
         else:
             _maybe_add_arg(qry, 'segment', segment, 'dynamic::ga')

--- a/pandas/io/tests/test_ga.py
+++ b/pandas/io/tests/test_ga.py
@@ -115,9 +115,15 @@ class TestGoogle(unittest.TestCase):
         assert query['segment'] == 'gaid::' + str(advanced_segment_id), "A string value with just letters and numbers should be formatted as an advanced segment."
     
     def test_v3_advanced_segment_weird_format(self):
-        advanced_segment_id = 'aZwqR234-s1'
+        advanced_segment_id = '_aZwqR234-s1'
         query = ga.format_query('google_profile_id', ['visits'], '2013-09-01', segment=advanced_segment_id)
         assert query['segment'] == 'gaid::' + str(advanced_segment_id), "A string value with just letters, numbers, and hyphens should be formatted as an advanced segment."
+
+    def test_v3_advanced_segment_with_underscore_format(self):
+        advanced_segment_id = 'aZwqR234_s1'
+        query = ga.format_query('google_profile_id', ['visits'], '2013-09-01', segment=advanced_segment_id)
+        assert query['segment'] == 'gaid::' + str(advanced_segment_id), "A string value with just letters, numbers, and underscores should be formatted as an advanced segment."
+
 
     @slow
     @with_connectivity_check("http://www.google.com")


### PR DESCRIPTION
Adds support for underscores to Google's new segment format. The issue referenced is here:
closes https://github.com/pydata/pandas/issues/5398
