### PR TITLE
BUG: to_timedelta of a scalar returns a scalar, closes #5410.

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -770,6 +770,7 @@ Bug Fixes
     and DataFrames that have repeated (non-unique) indices. (:issue:`4620`)
   - Fix empty series not printing name in repr (:issue:`4651`)
   - Make tests create temp files in temp directory by default. (:issue:`5419`)
+  - ``pd.to_timedelta`` of a scalar returns a scalar (:issue:`5410`)
 
 pandas 0.12.0
 -------------

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -2314,6 +2314,25 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         # roundtrip
         assert_series_equal(result + td2,td1)
 
+        # Now again, using pd.to_timedelta, which should build
+        # a Series or a scalar, depending on input.
+        if not _np_version_under1p7:
+            td1 = Series(pd.to_timedelta(['00:05:03'] * 3))
+            td2 = pd.to_timedelta('00:05:04')
+            result = td1 - td2
+            expected = Series([timedelta(seconds=0)] * 3) -Series(
+                [timedelta(seconds=1)] * 3)
+            self.assert_(result.dtype == 'm8[ns]')
+            assert_series_equal(result, expected)
+
+            result2 = td2 - td1
+            expected = (Series([timedelta(seconds=1)] * 3) -
+                        Series([timedelta(seconds=0)] * 3))
+            assert_series_equal(result2, expected)
+
+            # roundtrip
+            assert_series_equal(result + td2,td1)
+
     def test_timedelta64_operations_with_integers(self):
 
         # GH 4521

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -180,17 +180,20 @@ class TestTimedeltas(unittest.TestCase):
         s = Series([Timestamp('20130101') + timedelta(seconds=i*i) for i in range(10) ])
         td = s.diff()
 
-        result = td.mean()
+        result = td.mean()[0]
+        # TODO This should have returned a scalar to begin with. Hack for now.
         expected = to_timedelta(timedelta(seconds=9))
-        tm.assert_series_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
         result = td.quantile(.1)
+        # This properly returned a scalar.
         expected = to_timedelta('00:00:02.6')
-        tm.assert_series_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
-        result = td.median()
+        result = td.median()[0]
+        # TODO This should have returned a scalar to begin with. Hack for now.
         expected = to_timedelta('00:00:08')
-        tm.assert_series_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/pandas/tseries/timedeltas.py
+++ b/pandas/tseries/timedeltas.py
@@ -58,7 +58,8 @@ def to_timedelta(arg, box=True, unit='ns'):
     elif is_list_like(arg):
         return _convert_listlike(arg, box=box)
 
-    return _convert_listlike([ arg ], box=box)
+    # ...so it must be a scalar value. Return scalar.
+    return _coerce_scalar_to_timedelta_type(arg, unit=unit)
 
 _short_search = re.compile(
     "^\s*(?P<neg>-?)\s*(?P<value>\d*\.?\d*)\s*(?P<unit>d|s|ms|us|ns)?\s*$",re.IGNORECASE)


### PR DESCRIPTION
closes #5410
