### PR TITLE
BUG: Panel.to_frame() with MultiIndex major axis

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -104,6 +104,8 @@ Bug Fixes
   - Fixed string-representation of ``NaT`` to be "NaT" (:issue:`5708`)
   - Fixed string-representation for Timestamp to show nanoseconds if present (:issue:`5912`)
   - ``pd.match`` not returning passed sentinel
+  - ``Panel.to_frame()`` no longer fails when ``major_axis`` is a
+    ``MultiIndex`` (:issue:`5402`).
 
 pandas 0.13.0
 -------------

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -2396,6 +2396,44 @@ class MultiIndex(Index):
         else:
             return result_levels
 
+    def to_hierarchical(self, n_repeat, n_shuffle=1):
+        """
+        Return a MultiIndex reshaped to conform to the
+        shapes given by n_repeat and n_shuffle.
+
+        Useful to replicate and rearrange a MultiIndex for combination
+        with another Index with n_repeat items.
+
+        Parameters
+        ----------
+        n_repeat : int
+            Number of times to repeat the labels on self
+        n_shuffle : int
+            Controls the reordering of the labels. If the result is going
+            to be an inner level in a MultiIndex, n_shuffle will need to be
+            greater than one. The size of each label must divisible by
+            n_shuffle.
+
+        Returns
+        -------
+        MultiIndex
+
+        Examples
+        --------
+        >>> idx = MultiIndex.from_tuples([(1, u'one'), (1, u'two'),
+                                          (2, u'one'), (2, u'two')])
+        >>> idx.to_hierarchical(3)
+        MultiIndex(levels=[[1, 2], [u'one', u'two']],
+                   labels=[[0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
+                           [0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1]])
+        """
+        levels = self.levels
+        labels = [np.repeat(x, n_repeat) for x in self.labels]
+        # Assumes that each label is divisible by n_shuffle
+        labels = [x.reshape(n_shuffle, -1).ravel(1) for x in labels]
+        names = self.names
+        return MultiIndex(levels=levels, labels=labels, names=names)
+
     @property
     def is_all_dates(self):
         return False

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -1990,6 +1990,36 @@ class TestMultiIndex(tm.TestCase):
 
         warnings.filters = warn_filters
 
+    def test_to_hierarchical(self):
+        index = MultiIndex.from_tuples([(1, 'one'), (1, 'two'),
+                                        (2, 'one'), (2, 'two')])
+        result = index.to_hierarchical(3)
+        expected = MultiIndex(levels=[[1, 2], ['one', 'two']],
+                              labels=[[0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
+                                      [0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1]])
+        tm.assert_index_equal(result, expected)
+        self.assertEqual(result.names, index.names)
+
+        # K > 1
+        result = index.to_hierarchical(3, 2)
+        expected = MultiIndex(levels=[[1, 2], ['one', 'two']],
+                              labels=[[0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1],
+                                      [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1]])
+        tm.assert_index_equal(result, expected)
+        self.assertEqual(result.names, index.names)
+
+        # non-sorted
+        index = MultiIndex.from_tuples([(2, 'c'), (1, 'b'),
+                                        (2, 'a'), (2, 'b')],
+                                       names=['N1', 'N2'])
+
+        result = index.to_hierarchical(2)
+        expected = MultiIndex.from_tuples([(2, 'c'), (2, 'c'), (1, 'b'), (1, 'b'),
+                                           (2, 'a'), (2, 'a'), (2, 'b'), (2, 'b')],
+                                          names=['N1', 'N2'])
+        tm.assert_index_equal(result, expected)
+        self.assertEqual(result.names, index.names)
+
     def test_bounds(self):
         self.index._bounds
 


### PR DESCRIPTION
Closes #5402  WIP for now.

So this is a hack to get things "working".

I mainly just wanted to ask if there was a better way to get the levels and labels to the MultiIndex constructor.
Don't spend long thinking about it (this is my PR after all), but if you know of a quick way off the top of your head, I'd be interested.
I essentially need to
1. flatten the MultiIndex from major axis (levels and labels)
2. combine that flattened index with the minor axis (levels and labels)

Step 2 could be complicated by `minor_axis` being a MultiIndex also, I should be able to refactor this pretty easily to handle that.  I think my was is making several copies of each index, and I'm not sure that they're all necessary.
