### PR TITLE
TST: Use tempfiles in all tests.

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -769,6 +769,7 @@ Bug Fixes
   - The GroupBy methods ``transform`` and ``filter`` can be used on Series
     and DataFrames that have repeated (non-unique) indices. (:issue:`4620`)
   - Fix empty series not printing name in repr (:issue:`4651`)
+  - Make tests create temp files in temp directory by default. (:issue:`5419`)
 
 pandas 0.12.0
 -------------

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5477,12 +5477,13 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         # N=35000
         s1=make_dtnat_arr(chunksize+5)
         s2=make_dtnat_arr(chunksize+5,0)
+        path = '1.csv'
 
-        # s3=make_dtnat_arr(chunksize+5,0)
-        with ensure_clean('1.csv') as path:
+        # s3=make_dtnjat_arr(chunksize+5,0)
+        with ensure_clean('.csv') as pth:
             df=DataFrame(dict(a=s1,b=s2))
-            df.to_csv(path,chunksize=chunksize)
-            recons = DataFrame.from_csv(path).convert_objects('coerce')
+            df.to_csv(pth,chunksize=chunksize)
+            recons = DataFrame.from_csv(pth).convert_objects('coerce')
             assert_frame_equal(df, recons,check_names=False,check_less_precise=True)
 
         for ncols in [4]:
@@ -5491,7 +5492,6 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
                   base-1,base,base+1]:
                 _do_test(mkdf(nrows, ncols,r_idx_type='dt',
                               c_idx_type='s'),path, 'dt','s')
-                pass
 
 
         for ncols in [4]:

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -313,24 +313,25 @@ def ensure_clean(filename=None, return_filelike=False):
     ----------
     filename : str (optional)
         if None, creates a temporary file which is then removed when out of
-        scope.
-    return_filelike: bool (default False)
+        scope. if passed, creates temporary file with filename as ending.
+    return_filelike : bool (default False)
         if True, returns a file-like which is *always* cleaned. Necessary for
-        savefig and other functions which want to append extensions. Ignores
-        filename if True.
+        savefig and other functions which want to append extensions.
     """
+    filename = filename or ''
 
     if return_filelike:
-        f = tempfile.TemporaryFile()
+        f = tempfile.TemporaryFile(suffix=filename)
         try:
             yield f
         finally:
             f.close()
 
     else:
-        # if we are not passed a filename, generate a temporary
-        if filename is None:
-            filename = tempfile.mkstemp()[1]
+        # don't generate tempfile if using a path with directory specified
+        if len(os.path.dirname(filename)):
+            raise ValueError("Can't pass a qualified name to ensure_clean()")
+        filename = tempfile.mkstemp(suffix=filename)[1]
 
         try:
             yield filename
@@ -339,7 +340,7 @@ def ensure_clean(filename=None, return_filelike=False):
                 if os.path.exists(filename):
                     os.remove(filename)
             except Exception as e:
-                print(e)
+                print("Exception on removing file: %s" % e)
 
 
 def get_data_path(f=''):


### PR DESCRIPTION
If you really need to, possible to opt-out with make_tempfile=False.
Something weird with HDF where, even though it's _supposed_ to be
removing the file every time, it causes issues to use a real temp
file... Not sure why (maybe I missed something there).
