### PR TITLE
ENH: Better handling of MultiIndex with Excel

### DIFF
--- a/ci/requirements-2.7.txt
+++ b/ci/requirements-2.7.txt
@@ -8,7 +8,7 @@ numexpr==2.1
 tables==2.3.1
 matplotlib==1.1.1
 openpyxl==1.6.2
-xlsxwriter==0.4.3
+xlsxwriter==0.4.6
 xlrd==0.9.2
 patsy==0.1.0
 html5lib==1.0b2

--- a/ci/requirements-2.7_LOCALE.txt
+++ b/ci/requirements-2.7_LOCALE.txt
@@ -2,7 +2,7 @@ python-dateutil
 pytz==2013b
 xlwt==0.7.5
 openpyxl==1.6.2
-xlsxwriter==0.4.3
+xlsxwriter==0.4.6
 xlrd==0.9.2
 numpy==1.6.1
 cython==0.19.1

--- a/ci/requirements-3.2.txt
+++ b/ci/requirements-3.2.txt
@@ -1,7 +1,7 @@
 python-dateutil==2.1
 pytz==2013b
 openpyxl==1.6.2
-xlsxwriter==0.4.3
+xlsxwriter==0.4.6
 xlrd==0.9.2
 numpy==1.7.1
 cython==0.19.1

--- a/ci/requirements-3.3.txt
+++ b/ci/requirements-3.3.txt
@@ -1,7 +1,7 @@
 python-dateutil==2.2
 pytz==2013b
 openpyxl==1.6.2
-xlsxwriter==0.4.3
+xlsxwriter==0.4.6
 xlrd==0.9.2
 html5lib==1.0b2
 numpy==1.8.0

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -209,6 +209,11 @@ Improvements to existing features
     by color as expected.
   - ``read_excel()`` now tries to convert integral floats (like ``1.0``) to int
     by default. (:issue:`5394`)
+  - Excel writers now have a default option ``merge_cells`` in ``to_excel()``
+    to merge cells in MultiIndex and Hierarchical Rows. Note: using this
+    option it is no longer possible to round trip Excel files with merged
+    MultiIndex and Hierarchical Rows. Set the ``merge_cells`` to ``False`` to
+    restore the previous behaviour.  (:issue:`5254`)
 
 API Changes
 ~~~~~~~~~~~

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1130,7 +1130,8 @@ class DataFrame(NDFrame):
 
     def to_excel(self, excel_writer, sheet_name='Sheet1', na_rep='',
                  float_format=None, cols=None, header=True, index=True,
-                 index_label=None, startrow=0, startcol=0, engine=None):
+                 index_label=None, startrow=0, startcol=0, engine=None,
+                 merge_cells=True):
         """
         Write DataFrame to a excel sheet
 
@@ -1161,13 +1162,15 @@ class DataFrame(NDFrame):
             write engine to use - you can also set this via the options
             ``io.excel.xlsx.writer``, ``io.excel.xls.writer``, and
             ``io.excel.xlsm.writer``.
-
+        merge_cells : boolean, default True
+            Write MultiIndex and Hierarchical Rows as merged cells.
 
         Notes
         -----
         If passing an existing ExcelWriter object, then the sheet will be added
         to the existing workbook.  This can be used to save different
         DataFrames to one workbook
+
         >>> writer = ExcelWriter('output.xlsx')
         >>> df1.to_excel(writer,'Sheet1')
         >>> df2.to_excel(writer,'Sheet2')
@@ -1185,7 +1188,8 @@ class DataFrame(NDFrame):
                                        header=header,
                                        float_format=float_format,
                                        index=index,
-                                       index_label=index_label)
+                                       index_label=index_label,
+                                       merge_cells=merge_cells)
         formatted_cells = formatter.get_formatted_cells()
         excel_writer.write_cells(formatted_cells, sheet_name,
                                  startrow=startrow, startcol=startcol)


### PR DESCRIPTION
Allow optional formatting of MultiIndex and Hierarchical Rows
as merged cells. closes #5254.

Some notes on this PR:
- The required xlsxwriter version was up-revved in `ci/requirements*.txt`to pick up a fix in that module that makes working with charts from pandas easier.
- Added a comment to `release.rst`.
- Modified `format.py` to format MultiIndex and Hierarchical Rows as merged cells in Excel. The old code path/option is still available. The new formatting must be explicitly invoked via the `merge_cells` option in `to_excel`:

``` python
df.to_excel('file.xlsx', merge_cells=True)
```
- The `merge_cells` option can be renamed if required. During development I also used `multi_index` and `merge_range`.
- Updated the API and docs in `frame.py` to reflect the new option.
- Fixed openpyxl merge handling in `excel.py`.
- Modified the `test_excel.py` test cases so that they could be used to test the existing `dot notation` or the new `merge_cells` options for MultiIndex and Hierarchical Rows handling.
- Did some minor PEP8 formatting to the `test_excel.py`.
