### PR TITLE
BUG: Excel writer doesn't handle "cols" option correctly

### DIFF
--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -1393,8 +1393,12 @@ class ExcelFormatter(object):
             for idx, idxval in enumerate(index_values):
                 yield ExcelCell(self.rowcounter + idx, 0, idxval, header_style)
 
+        # Get a frame that will account for any duplicates in the column names.
+        col_mapped_frame = self.df.loc[:, self.columns]
+
+        # Write the body of the frame data series by series.
         for colidx in range(len(self.columns)):
-            series = self.df.iloc[:, colidx]
+            series = col_mapped_frame.iloc[:, colidx]
             for i, val in enumerate(series):
                 yield ExcelCell(self.rowcounter + i, colidx + coloffset, val)
 
@@ -1461,8 +1465,12 @@ class ExcelFormatter(object):
                                         header_style)
                     gcolidx += 1
 
+        # Get a frame that will account for any duplicates in the column names.
+        col_mapped_frame = self.df.loc[:, self.columns]
+
+        # Write the body of the frame data series by series.
         for colidx in range(len(self.columns)):
-            series = self.df.iloc[:, colidx]
+            series = col_mapped_frame.iloc[:, colidx]
             for i, val in enumerate(series):
                 yield ExcelCell(self.rowcounter + i, gcolidx + colidx, val)
 

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -922,10 +922,24 @@ class ExcelWriterBase(SharedItems):
             write_frame.columns = colnames
             write_frame.to_excel(path, 'test1')
 
-            read_frame = read_excel(path, 'test1').astype(np.int64)
+            read_frame = read_excel(path, 'test1')
             read_frame.columns = colnames
 
             tm.assert_frame_equal(write_frame, read_frame)
+
+    def test_swapped_columns(self):
+        # Test for issue #5427.
+        _skip_if_no_xlrd()
+
+        with ensure_clean(self.ext) as path:
+            write_frame = DataFrame({'A': [1, 1, 1],
+                                     'B': [2, 2, 2]})
+            write_frame.to_excel(path, 'test1', cols=['B', 'A'])
+
+            read_frame = read_excel(path, 'test1', header=0)
+
+            tm.assert_series_equal(write_frame['A'], read_frame['A'])
+            tm.assert_series_equal(write_frame['B'], read_frame['B'])
 
 
 class OpenpyxlTests(ExcelWriterBase, unittest.TestCase):


### PR DESCRIPTION
closes #5427

Notes on this PR:
- This fix addresses an issue introduced in #5235 (Issue with Excel writers when column names are duplicated).
- Basically it needs to handle 2 different use cases:
  - The user uses duplicate column names
  - The user specifies a different order via the `cols` option

``` python
# Case 1
df = pd.DataFrame([[1, 2, 3], [1, 2, 3], [1, 2, 3]])

df.columns = ['A', 'B', 'B']
```

``` python
# Case 2
df = pd.DataFrame({'A': ['a', 'a', 'a'],
                   'B': ['b', 'b', 'b']})

df.to_excel('frame.xlsx', sheet_name='Sheet1', cols=['B', 'A'])

```

The proposed solution is to iterate through self.columns in the default or user supplied order. If a duplicate column name is encountered (i.e. if `df['B']` returns more than one series) then we select the first series and keep track of that index. If the duplicate column name is encountered again then we select the next available series from `df['B']` up to the last series available. If the duplicate name is encountered again then we return the last series again.

The patch is slightly kludgy. I didn't know how to check if `df[col]` contained more than one series so I used `len(self.df[col_name].columns)` in a `try:catch`. Hopefully there is something cleaner.

The change is repeated twice in the code.

There is a new test for this issue and an existing test for the previous issue.

I don't think this needs a release note since it is a fix for an issue that was never released.
