### PR TITLE
BUG: fix Resampling a Series with a timezone using kind='period' (GH5430)

### DIFF
--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -192,7 +192,9 @@ class TimeGrouper(CustomGrouper):
         labels = binner = PeriodIndex(start=axis[0], end=axis[-1],
                                       freq=self.freq)
 
-        end_stamps = (labels + 1).asfreq('D', 's').to_timestamp()
+        end_stamps = (labels + 1).asfreq(self.freq, 's').to_timestamp()
+        if axis.tzinfo:
+            end_stamps = end_stamps.tz_localize(axis.tzinfo)
         bins = axis.searchsorted(end_stamps, side='left')
 
         return binner, bins, labels


### PR DESCRIPTION
There's a failing test case and the patch in subsequent commits.

closes #5430
closes #3609 
