### PR TITLE
PERF/ENH: Use xlsxwriter by default (and then fall back on openpyxl).

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1825,8 +1825,10 @@ written.  For example:
 
    df.to_excel('path_to_file.xlsx', sheet_name='Sheet1')
 
-Files with a ``.xls`` extension will be written using ``xlwt`` and those with
-a ``.xlsx`` extension will be written using ``openpyxl``.
+Files with a ``.xls`` extension will be written using ``xlwt`` and those with a
+``.xlsx`` extension will be written using ``xlsxwriter`` (if available) or
+``openpyxl``.
+
 The Panel class also has a ``to_excel`` instance method,
 which writes each DataFrame in the Panel to a separate sheet.
 
@@ -1858,14 +1860,19 @@ Excel writer engines
 1. the ``engine`` keyword argument
 2. the filename extension (via the default specified in config options)
 
-By default, ``pandas`` uses  `openpyxl <http://packages.python.org/openpyxl/>`__
-for ``.xlsx`` and ``.xlsm`` files and `xlwt <http://www.python-excel.org/>`__
-for ``.xls`` files.  If you have multiple engines installed, you can set the
-default engine through :ref:`setting the config options <basics.working_with_options>`
-``io.excel.xlsx.writer`` and ``io.excel.xls.writer``.
+By default, ``pandas`` uses the `XlsxWriter`_  for ``.xlsx`` and `openpyxl`_
+for ``.xlsm`` files and `xlwt`_ for ``.xls`` files.  If you have multiple
+engines installed, you can set the default engine through :ref:`setting the
+config options <basics.working_with_options>` ``io.excel.xlsx.writer`` and
+``io.excel.xls.writer``. pandas will fall back on `openpyxl`_ for ``.xlsx``
+files if `Xlsxwriter`_ is not available.
 
-For example if the `XlsxWriter <http://xlsxwriter.readthedocs.org>`__
-module is installed you can use it as a xlsx writer engine as follows:
+.. _XlsxWriter: http://xlsxwriter.readthedocs.org
+.. _openpyxl: http://packages.python.org/openpyxl/
+.. _xlwt: http://www.python-excel.org
+
+To specify which writer you want to use, you can pass an engine keyword
+argument to ``to_excel`` and to ``ExcelWriter``.
 
 .. code-block:: python
 

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -290,8 +290,7 @@ writer_engine_doc = """
 with cf.config_prefix('io.excel'):
     # going forward, will be additional writers
     for ext, options in [('xls', ['xlwt']),
-                         ('xlsm', ['openpyxl']),
-                         ('xlsx', ['openpyxl'])]:
+                         ('xlsm', ['openpyxl'])]:
         default = options.pop(0)
         if options:
             options = " " + ", ".join(options)
@@ -300,3 +299,17 @@ with cf.config_prefix('io.excel'):
         doc = writer_engine_doc.format(ext=ext, default=default,
                                        others=options)
         cf.register_option(ext + '.writer', default, doc, validator=str)
+    def _register_xlsx(engine, other):
+        cf.register_option('xlsx.writer', engine,
+                           writer_engine_doc.format(ext='xlsx',
+                                                    default=engine,
+                                                    others=", '%s'" % other),
+                          validator=str)
+
+    try:
+        # better memory footprint
+        import xlsxwriter
+        _register_xlsx('xlsxwriter', 'openpyxl')
+    except ImportError:
+        # fallback
+        _register_xlsx('openpyxl', 'xlsxwriter')

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -14,7 +14,7 @@ from pandas import DataFrame, Index, MultiIndex
 from pandas.io.parsers import read_csv
 from pandas.io.excel import (
     ExcelFile, ExcelWriter, read_excel, _XlwtWriter, _OpenpyxlWriter,
-    register_writer
+    register_writer, _XlsxWriter
 )
 from pandas.util.testing import ensure_clean
 from pandas.core.config import set_option, get_option
@@ -1026,9 +1026,14 @@ class ExcelWriterEngineTests(unittest.TestCase):
         with tm.assertRaisesRegexp(ValueError, 'No engine'):
             ExcelWriter('nothing')
 
-        _skip_if_no_openpyxl()
+        try:
+            import xlsxwriter
+            writer_klass = _XlsxWriter
+        except ImportError:
+            _skip_if_no_openpyxl()
+            writer_klass = _OpenpyxlWriter
         writer = ExcelWriter('apple.xlsx')
-        tm.assert_isinstance(writer, _OpenpyxlWriter)
+        tm.assert_isinstance(writer, writer_klass)
 
         _skip_if_no_xlwt()
         writer = ExcelWriter('apple.xls')


### PR DESCRIPTION
Since xlsxwriter has a smaller install base (because it's newer),
reasonable to assume that if you have it installed, you want xlsxwriter.
Plus, it has better performance characteristics in general (esp. in
terms of memory usage)
