### PR TITLE
DOC: fix build error in to_latex and release notes

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -386,6 +386,7 @@ API Changes
     division.
 
   .. code-block:: python
+
     In [3]: arr = np.array([1, 2, 3, 4])
 
     In [4]: arr2 = np.array([5, 3, 2, 1])

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -60,6 +60,7 @@ API changes
   division.
 
   .. code-block:: python
+
       In [3]: arr = np.array([1, 2, 3, 4])
 
       In [4]: arr2 = np.array([5, 3, 2, 1])

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1295,7 +1295,9 @@ class DataFrame(NDFrame):
                 justify=None, force_unicode=None, bold_rows=True,
                 classes=None, escape=True):
         """
-        to_html-specific options
+        Render a DataFrame as an HTML table.
+
+        `to_html`-specific options:
 
         bold_rows : boolean, default True
             Make the row labels bold in the output
@@ -1303,8 +1305,6 @@ class DataFrame(NDFrame):
             CSS class(es) to apply to the resulting html table
         escape : boolean, default True
             Convert the characters <, >, and & to HTML-safe sequences.
-
-        Render a DataFrame as an HTML table.
         """
 
         if force_unicode is not None:  # pragma: no cover
@@ -1337,12 +1337,13 @@ class DataFrame(NDFrame):
                  float_format=None, sparsify=None, index_names=True,
                  bold_rows=True, force_unicode=None):
         """
-        to_latex-specific options
-        bold_rows : boolean, default True
-            Make the row labels bold in the output
-
         Render a DataFrame to a tabular environment table.
         You can splice this into a LaTeX document.
+
+        `to_latex`-specific options:
+
+        bold_rows : boolean, default True
+            Make the row labels bold in the output
         """
 
         if force_unicode is not None:  # pragma: no cover


### PR DESCRIPTION
This partly fixes #5331 (the `to_latex` part, not the 'Malformed table' one).

And in the same time, fixes a build error in the newly added docs on `truediv` in the release notes.
