### PR TITLE
add optional default value to GroupBy.get_group

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -221,6 +221,9 @@ Improvements to existing features
     MultiIndex and Hierarchical Rows. Set the ``merge_cells`` to ``False`` to
     restore the previous behaviour.  (:issue:`5254`)
   - The FRED DataReader now accepts multiple series (:issue`3413`)
+  - ``GroupBy.get_group()`` now accepts an optional ``default``
+    argument which is used to generate a default NDFrame in the event
+    that the provided ``name`` is not found. (:issue:`5452`)
 
 API Changes
 ~~~~~~~~~~~

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -414,6 +414,29 @@ class TestGroupBy(unittest.TestCase):
         expected = wp.reindex(major=[x for x in wp.major_axis if x.month == 1])
         assert_panel_equal(gp, expected)
 
+    def test_get_group_default(self):
+        wp = tm.makePanel()
+        grouped = wp.groupby(lambda x: x.month, axis='major')
+
+        gp = grouped.get_group(-1, default=[])
+        expected = wp.take([], axis='major')
+        assert_panel_equal(gp, expected)
+
+    def test_get_group_default_string(self):
+        wp = tm.makePanel()
+        grouped = wp.groupby(lambda x: x.month, axis='major')
+
+        self.assertRaises(TypeError, grouped.get_group, -1, default='string')
+
+    def test_get_group_default_index(self):
+        data = DataFrame({
+            'name' : ['other', 'a', 'a', 'b', 'd'],
+            'count' : [1,3,4,3,2],
+        })
+        g = data.groupby('name')
+        self.assertEqual(g.get_group('a', default = [])['count'].sum(), 7)
+        self.assertEqual(g.get_group('c', default = [0])['count'].sum(), 1)
+
     def test_agg_apply_corner(self):
         # nothing to group, all NA
         grouped = self.ts.groupby(self.ts * np.nan)


### PR DESCRIPTION
I've used a try except block as opposed to and if else (below) to keep the non-default code path fast.  What I didn't do:

```
if default is None :
    inds = self.indices[name]
else :
    inds = self.indices.get(name, default)
```

Here is an example use case:

```
def foo(df, keys) :
    g = df.groupby('key')
    for key in keys :
        for x in g.get_group(key, default=[]).x :
            yield key, x
```

vs

```
def foo(df, keys) :
    g = df.groupby('key')
    for key in keys :
        if key in g.indices :
            for x in g.get_group(key).x :
                yield key, x
```

Many of the simple cases are actually handled by other higher level functions 
