### PR TITLE
BUG: bool(NaT) was True

### DIFF
--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -358,6 +358,10 @@ class NaTType(_NaT):
     def __hash__(self):
         return iNaT
 
+    def __bool__(self):
+        return False
+    __nonzero__ = __bool__
+
     def weekday(self):
         return -1
 


### PR DESCRIPTION
bool(NaT) evaluates to True. I am not sure if this is by design or if it is a bug, but I think it makes more sense to evaluate it to False.
