### PR TITLE
BUG: DatetimeIndex.normalize now accounts for nanoseconds (#5461).

### DIFF
--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1420,6 +1420,11 @@ class TestTimeSeries(unittest.TestCase):
         result = rng.normalize()
         expected = date_range('1/1/2000', periods=10, freq='D')
         self.assert_(result.equals(expected))
+        
+        rng_ns = pd.DatetimeIndex(np.array([1380585623454345752, 1380585612343234312]).astype("datetime64[ns]"))
+        rng_ns_normalized = rng_ns.normalize()
+        expected = pd.DatetimeIndex(np.array([1380585600000000000, 1380585600000000000]).astype("datetime64[ns]"))
+        self.assert_(rng_ns_normalized.equals(expected))
 
         self.assert_(result.is_normalized)
         self.assert_(not rng.is_normalized)

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -2180,6 +2180,7 @@ cdef inline int64_t _normalized_stamp(pandas_datetimestruct *dts):
     dts.min = 0
     dts.sec = 0
     dts.us = 0
+    dts.ps = 0
     return pandas_datetimestruct_to_datetime(PANDAS_FR_ns, dts)
 
 


### PR DESCRIPTION
closes #5461

datetime64(ns) uses the dts->ps which was not being set to zero in the
normalize function.
