### PR TITLE
PERF: perf regression with mixed-type ops using numexpr (GH5481)

### DIFF
--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3217,6 +3217,15 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
             this_df['A'] = index
             check(this_df, expected_df)
 
+        # operations
+        for op in ['__add__','__mul__','__sub__','__truediv__']:
+            df = DataFrame(dict(A = np.arange(10), B = np.random.rand(10)))
+            expected = getattr(df,op)(df)
+            expected.columns = ['A','A']
+            df.columns = ['A','A']
+            result = getattr(df,op)(df)
+            check(result,expected)
+
     def test_column_dups_indexing(self):
 
         def check(result, expected=None):


### PR DESCRIPTION
closes #5481

BUG: non-unique ops not aligning correctly

these are bascially a trivial op in numpy, so numexpr is slightly slower (but the
the dtype inference issue is fixed). Essentially the recreation of an int64 ndarray had to check if its a datetime-like. In this case just passing in the dtype on the reconstructed series fixes it.

Also handles non-unique columns now (no tests before, and it would fail).

```
In [1]: df = pd.DataFrame({"A": np.arange(1000000), "B": np.arange(1000000, 0, -1), "C": np.random.randn(1000000)})

In [2]: pd.computation.expressions.set_use_numexpr(False)

In [3]: %timeit df*df
100 loops, best of 3: 11 ms per loop

In [4]: pd.computation.expressions.set_use_numexpr(True)

In [5]: %timeit df*df
100 loops, best of 3: 15.7 ms per loop

In [6]: df = df.astype(float)

In [7]: pd.computation.expressions.set_use_numexpr(False)

In [8]: %timeit df*df
100 loops, best of 3: 5.16 ms per loop

In [9]: pd.computation.expressions.set_use_numexpr(True)

In [10]: %timeit df*df
100 loops, best of 3: 5.37 ms per loop

```
