### PR TITLE
PERF: msgpack encoding changes to use to/from string for speed boosts

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1871,8 +1871,12 @@ def _asarray_tuplesafe(values, dtype=None):
         else:
             # Making a 1D array that safely contains tuples is a bit tricky
             # in numpy, leading to the following
-            result = np.empty(len(values), dtype=object)
-            result[:] = values
+            try:
+                result = np.empty(len(values), dtype=object)
+                result[:] = values
+            except (ValueError):
+                # we have a list-of-list
+                result[:] = [ tuple(x) for x in values ]
 
     return result
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -851,8 +851,8 @@ class NDFrame(PandasObject):
 
         Parameters
         ----------
-        path : string File path
-        args : an object or objects to serialize
+        path : string File path, buffer-like, or None
+           if None, return generated string
         append : boolean whether to append to an existing msgpack
                 (default is False)
         compress : type of compressor (zlib or blosc), default to None (no compression)

--- a/pandas/io/tests/test_packers.py
+++ b/pandas/io/tests/test_packers.py
@@ -61,30 +61,28 @@ class TestNumpy(Test):
     def test_numpy_scalar_float(self):
         x = np.float32(np.random.rand())
         x_rec = self.encode_decode(x)
-        self.assert_(np.allclose(x, x_rec) and type(x) == type(x_rec))
+        tm.assert_almost_equal(x,x_rec)
 
     def test_numpy_scalar_complex(self):
         x = np.complex64(np.random.rand() + 1j * np.random.rand())
         x_rec = self.encode_decode(x)
-        self.assert_(np.allclose(x, x_rec) and type(x) == type(x_rec))
+        tm.assert_almost_equal(x,x_rec)
 
     def test_scalar_float(self):
         x = np.random.rand()
         x_rec = self.encode_decode(x)
-        self.assert_(np.allclose(x, x_rec) and type(x) == type(x_rec))
+        tm.assert_almost_equal(x,x_rec)
 
     def test_scalar_complex(self):
         x = np.random.rand() + 1j * np.random.rand()
         x_rec = self.encode_decode(x)
-        self.assert_(np.allclose(x, x_rec) and type(x) == type(x_rec))
+        tm.assert_almost_equal(x,x_rec)
 
     def test_list_numpy_float(self):
         raise nose.SkipTest('buggy test')
         x = [np.float32(np.random.rand()) for i in range(5)]
         x_rec = self.encode_decode(x)
-        self.assert_(all(map(lambda x, y:
-                             x == y, x, x_rec)) and
-                     all(map(lambda x, y: type(x) == type(y), x, x_rec)))
+        tm.assert_almost_equal(x,x_rec)
 
     def test_list_numpy_float_complex(self):
         if not hasattr(np, 'complex128'):
@@ -96,65 +94,59 @@ class TestNumpy(Test):
             [np.complex128(np.random.rand() + 1j * np.random.rand())
              for i in range(5)]
         x_rec = self.encode_decode(x)
-        self.assert_(all(map(lambda x, y: x == y, x, x_rec)) and
-                     all(map(lambda x, y: type(x) == type(y), x, x_rec)))
+        tm.assert_almost_equal(x,x_rec)
 
     def test_list_float(self):
         x = [np.random.rand() for i in range(5)]
         x_rec = self.encode_decode(x)
-        self.assert_(all(map(lambda x, y: x == y, x, x_rec)) and
-                     all(map(lambda x, y: type(x) == type(y), x, x_rec)))
+        tm.assert_almost_equal(x,x_rec)
 
     def test_list_float_complex(self):
         x = [np.random.rand() for i in range(5)] + \
             [(np.random.rand() + 1j * np.random.rand()) for i in range(5)]
         x_rec = self.encode_decode(x)
-        self.assert_(all(map(lambda x, y: x == y, x, x_rec)) and
-                     all(map(lambda x, y: type(x) == type(y), x, x_rec)))
+        tm.assert_almost_equal(x,x_rec)
 
     def test_dict_float(self):
         x = {'foo': 1.0, 'bar': 2.0}
         x_rec = self.encode_decode(x)
-        self.assert_(all(map(lambda x, y: x == y, x.values(), x_rec.values())) and
-                     all(map(lambda x, y: type(x) == type(y), x.values(), x_rec.values())))
+        tm.assert_almost_equal(x,x_rec)
 
     def test_dict_complex(self):
         x = {'foo': 1.0 + 1.0j, 'bar': 2.0 + 2.0j}
         x_rec = self.encode_decode(x)
-        self.assert_(all(map(lambda x, y: x == y, x.values(), x_rec.values())) and
-                     all(map(lambda x, y: type(x) == type(y), x.values(), x_rec.values())))
+        tm.assert_almost_equal(x,x_rec)
 
     def test_dict_numpy_float(self):
         x = {'foo': np.float32(1.0), 'bar': np.float32(2.0)}
         x_rec = self.encode_decode(x)
-        self.assert_(all(map(lambda x, y: x == y, x.values(), x_rec.values())) and
-                     all(map(lambda x, y: type(x) == type(y), x.values(), x_rec.values())))
+        tm.assert_almost_equal(x,x_rec)
 
     def test_dict_numpy_complex(self):
         x = {'foo': np.complex128(
             1.0 + 1.0j), 'bar': np.complex128(2.0 + 2.0j)}
         x_rec = self.encode_decode(x)
-        self.assert_(all(map(lambda x, y: x == y, x.values(), x_rec.values())) and
-                     all(map(lambda x, y: type(x) == type(y), x.values(), x_rec.values())))
+        tm.assert_almost_equal(x,x_rec)
 
     def test_numpy_array_float(self):
-        x = np.random.rand(5).astype(np.float32)
-        x_rec = self.encode_decode(x)
-        self.assert_(all(map(lambda x, y: x == y, x, x_rec)) and
-                     x.dtype == x_rec.dtype)
+
+        # run multiple times
+        for n in range(10):
+            x = np.random.rand(10)
+            for dtype in ['float32','float64']:
+                x = x.astype(dtype)
+                x_rec = self.encode_decode(x)
+                tm.assert_almost_equal(x,x_rec)
 
     def test_numpy_array_complex(self):
         x = (np.random.rand(5) + 1j * np.random.rand(5)).astype(np.complex128)
         x_rec = self.encode_decode(x)
-        self.assert_(all(map(lambda x, y: x == y, x, x_rec)) and
-                     x.dtype == x_rec.dtype)
+        tm.assert_almost_equal(x,x_rec)
 
     def test_list_mixed(self):
         x = [1.0, np.float32(3.5), np.complex128(4.25), u('foo')]
         x_rec = self.encode_decode(x)
-        self.assert_(all(map(lambda x, y: x == y, x, x_rec)) and
-                     all(map(lambda x, y: type(x) == type(y), x, x_rec)))
-
+        tm.assert_almost_equal(x,x_rec)
 
 class TestBasic(Test):
 
@@ -219,8 +211,12 @@ class TestIndex(Test):
 
     def test_unicode(self):
         i = tm.makeUnicodeIndex(100)
-        i_rec = self.encode_decode(i)
-        self.assert_(i.equals(i_rec))
+
+        # this currently fails
+        self.assertRaises(UnicodeEncodeError, self.encode_decode, i)
+
+        #i_rec = self.encode_decode(i)
+        #self.assert_(i.equals(i_rec))
 
 
 class TestSeries(Test):
@@ -255,9 +251,11 @@ class TestSeries(Test):
 
     def test_basic(self):
 
-        for s, i in self.d.items():
-            i_rec = self.encode_decode(i)
-            assert_series_equal(i, i_rec)
+        # run multiple times here
+        for n in range(10):
+            for s, i in self.d.items():
+                i_rec = self.encode_decode(i)
+                assert_series_equal(i, i_rec)
 
 
 class TestNDFrame(Test):
@@ -326,8 +324,10 @@ class TestSparse(Test):
 
     def _check_roundtrip(self, obj, comparator, **kwargs):
 
-        i_rec = self.encode_decode(obj)
-        comparator(obj, i_rec, **kwargs)
+        # currently these are not implemetned
+        #i_rec = self.encode_decode(obj)
+        #comparator(obj, i_rec, **kwargs)
+        self.assertRaises(NotImplementedError, self.encode_decode, obj)
 
     def test_sparse_series(self):
 

--- a/pandas/io/tests/test_packers.py
+++ b/pandas/io/tests/test_packers.py
@@ -55,6 +55,38 @@ class Test(unittest.TestCase):
             to_msgpack(p, x, **kwargs)
             return read_msgpack(p, **kwargs)
 
+class TestAPI(Test):
+
+    def test_string_io(self):
+
+        df = DataFrame(np.random.randn(10,2))
+        s = df.to_msgpack(None)
+        result = read_msgpack(s.getvalue())
+        tm.assert_frame_equal(result,df)
+
+        s = to_msgpack(None,df)
+        result = read_msgpack(s.getvalue())
+        tm.assert_frame_equal(result, df)
+
+        with ensure_clean(self.path) as p:
+
+            s = df.to_msgpack(None)
+            fh = open(p,'wb')
+            fh.write(s.getvalue())
+            fh.close()
+            result = read_msgpack(p)
+            tm.assert_frame_equal(result, df)
+
+    def test_iterator_with_string_io(self):
+
+        dfs = [ DataFrame(np.random.randn(10,2)) for i in range(5) ]
+        s = to_msgpack(None,*dfs)
+        for i, result in enumerate(read_msgpack(s.getvalue(),iterator=True)):
+            tm.assert_frame_equal(result,dfs[i])
+
+        s = to_msgpack(None,*dfs)
+        for i, result in enumerate(read_msgpack(s,iterator=True)):
+            tm.assert_frame_equal(result,dfs[i])
 
 class TestNumpy(Test):
 


### PR DESCRIPTION
API: disable sparse structure encodings and unicode indexes

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
packers_read_pack                            |   3.5113 |  17.8316 |   0.1969 |
packers_read_pickle                          |   0.6769 |   0.6770 |   0.9999 |
packers_write_pack                           |   1.8814 |   3.5230 |   0.5340 |
packers_write_pickle                         |   1.5387 |   1.4664 |   1.0493 |

packers_write_hdf_store                      |  12.1900 |  12.2033 |   0.9989 |
packers_read_csv                             |  52.3347 |  52.2310 |   1.0020 |
packers_write_csv                            | 536.2056 | 526.5187 |   1.0184 |
packers_write_hdf_table                      |  33.3436 |  32.4137 |   1.0287 |
packers_read_hdf_store                       |   8.3120 |   8.0493 |   1.0326 |
packers_read_hdf_table                       |  13.9607 |  12.9707 |   1.0763 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [381e86b] : PERF: msgpack encoding changnes to use to/from string for speed boosts
API: disable sparse structure encodings and unicode indexes
Base   [46008ec] : DOC: add cookbook entry
```

```
In [1]: from pandas.io.packers import pack

In [2]: import cPickle as pkl

In [3]: df = pd.DataFrame(np.random.rand(1000, 100))

In [6]: %timeit buf = pack(df)
1000 loops, best of 3: 492 ﾵs per loop

In [7]: %timeit buf = pkl.dumps(df,pkl.HIGHEST_PROTOCOL)
1000 loops, best of 3: 681 ﾵs per loop

In [8]: df = pd.DataFrame(np.random.rand(100000, 100))

In [11]:  %timeit buf = pack(df)
1 loops, best of 3: 184 ms per loop

In [12]: %timeit buf = pkl.dumps(df,pkl.HIGHEST_PROTOCOL)
10 loops, best of 3: 111 ms per loop
```

now pretty competitive with pickle

note on bigger frames, writing an in-memory hdf file is quite fast

```
In [3]: def f(x):
   ...:     store = pd.HDFStore('test.h5',mode='w',driver='H5FD_CORE',driver_core_backing_store=0)
   ...:     store['df'] = x
   ...:     store.close()
   ...:     

In [11]: df = pd.DataFrame(np.random.rand(100000, 100))

In [13]: %timeit -n 5 buf = pack(df)
5 loops, best of 3: 202 ms per loop

In [14]: %timeit -n 5 buf = pkl.dumps(df,pkl.HIGHEST_PROTOCOL)
5 loops, best of 3: 115 ms per loop

In [15]: %timeit -n 5 f(df)
5 loops, best of 3: 53.9 ms per loop
```
