### PR TITLE
ENH: Have pivot and pivot_table take similar arguments

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -124,6 +124,11 @@ API Changes
     DataFrame returned by ``GroupBy.apply`` (:issue:`6124`).  This facilitates
     ``DataFrame.stack`` operations where the name of the column index is used as
     the name of the inserted column containing the pivoted data.
+	
+- The :func:`pivot_table`/:meth:`DataFrame.pivot_table` and :func:`crosstab` functions 
+  now take arguments ``index`` and ``columns`` instead of ``rows`` and ``cols``.  A 
+  ``FutureWarning`` is raised  to alert that the old ``rows`` and ``cols`` arguments
+  will not be supported in a future release (:issue:`5505`)
 
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -165,6 +165,11 @@ These are out-of-bounds selections
     # New output, 4-level MultiIndex
     df_multi.set_index([df_multi.index, df_multi.index])
 
+- The :func:`pivot_table`/:meth:`DataFrame.pivot_table` and :func:`crosstab` functions 
+  now take arguments ``index`` and ``columns`` instead of ``rows`` and ``cols``.  A 
+  ``FutureWarning`` is raised  to alert that the old ``rows`` and ``cols`` arguments
+  will not be supported in a future release (:issue:`5505`)
+
 
 MultiIndexing Using Slicers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Right now, there is 

```
df.pivot(index=foo, columns=bar, values=baz)
```

and

```
df.pivot_table(rows=foo, cols=bar, values=baz)
```

Because of dirtyness in my data I occasionally have to go back and forth between the two forms (and use `df.pivot_table(..., aggfunc='count')` to see who had the bad data).  It would be nice if I didn't have to change the keyword arguments each time and one had an alias of the other.  It would also be easier to remember, especially in the trivial case of `cols` vs `columns`.  Finally, the two are related operations and having an option for consistent keyword parameters makes sense.

I could make a PR to solve this easy enough, if this is an enhancement you are interested in.  I'm not really sure what your stance is on redundant keyword arguments.
