### PR TITLE
PERF faster head, tail and size groupby methods

### DIFF
--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -245,6 +245,7 @@ except ImportError:
 
 
 class _OrderedDict(dict):
+
     """Dictionary that remembers insertion order"""
     # An inherited dict maps keys to values.
     # The inherited dict provides __getitem__, __len__, __contains__, and get.
@@ -505,6 +506,7 @@ except ImportError:
 
 
 class _Counter(dict):
+
     """Dict subclass for counting hashable objects.  Sometimes called a bag
     or multiset.  Elements are stored as dictionary keys and their counts
     are stored as dictionary values.

--- a/pandas/computation/engines.py
+++ b/pandas/computation/engines.py
@@ -10,6 +10,7 @@ from pandas.computation.ops import UndefinedVariableError
 
 
 class AbstractEngine(object):
+
     """Object serving as a base class for all engines."""
 
     __metaclass__ = abc.ABCMeta
@@ -73,6 +74,7 @@ class AbstractEngine(object):
 
 
 class NumExprEngine(AbstractEngine):
+
     """NumExpr engine class"""
     has_neg_frac = True
 
@@ -105,6 +107,7 @@ class NumExprEngine(AbstractEngine):
 
 
 class PythonEngine(AbstractEngine):
+
     """Evaluate an expression in Python space.
 
     Mostly for testing purposes.

--- a/pandas/computation/expr.py
+++ b/pandas/computation/expr.py
@@ -70,6 +70,7 @@ def _raw_hex_id(obj, pad_size=2):
 
 
 class Scope(StringMixin):
+
     """Object to hold scope, with a few bells to deal with some custom syntax
     added by pandas.
 
@@ -324,6 +325,7 @@ def _node_not_implemented(node_name, cls):
     """Return a function that raises a NotImplementedError with a passed node
     name.
     """
+
     def f(self, *args, **kwargs):
         raise NotImplementedError("{0!r} nodes are not "
                                   "implemented".format(node_name))
@@ -356,6 +358,7 @@ def _op_maker(op_class, op_symbol):
     -------
     f : callable
     """
+
     def f(self, node, *args, **kwargs):
         """Return a partial function with an Op subclass with an operator
         already passed.
@@ -389,6 +392,7 @@ def add_ops(op_classes):
 @disallow(_unsupported_nodes)
 @add_ops(_op_classes)
 class BaseExprVisitor(ast.NodeVisitor):
+
     """Custom ast walker. Parsers of other engines should subclass this class
     if necessary.
 
@@ -710,6 +714,7 @@ _numexpr_supported_calls = frozenset(_reductions + _mathops)
           (_boolop_nodes | frozenset(['BoolOp', 'Attribute', 'In', 'NotIn',
                                       'Tuple'])))
 class PandasExprVisitor(BaseExprVisitor):
+
     def __init__(self, env, engine, parser,
                  preparser=lambda x: _replace_locals(_replace_booleans(x))):
         super(PandasExprVisitor, self).__init__(env, engine, parser, preparser)
@@ -717,12 +722,14 @@ class PandasExprVisitor(BaseExprVisitor):
 
 @disallow(_unsupported_nodes | _python_not_supported | frozenset(['Not']))
 class PythonExprVisitor(BaseExprVisitor):
+
     def __init__(self, env, engine, parser, preparser=lambda x: x):
         super(PythonExprVisitor, self).__init__(env, engine, parser,
                                                 preparser=preparser)
 
 
 class Expr(StringMixin):
+
     """Object encapsulating an expression.
 
     Parameters
@@ -734,6 +741,7 @@ class Expr(StringMixin):
     truediv : bool, optional, default True
     level : int, optional, default 2
     """
+
     def __init__(self, expr, engine='numexpr', parser='pandas', env=None,
                  truediv=True, level=2):
         self.expr = expr

--- a/pandas/computation/ops.py
+++ b/pandas/computation/ops.py
@@ -27,7 +27,9 @@ _TAG_RE = re.compile('^{0}'.format(_LOCAL_TAG))
 
 
 class UndefinedVariableError(NameError):
+
     """NameError subclass for local variables."""
+
     def __init__(self, *args):
         msg = 'name {0!r} is not defined'
         subbed = _TAG_RE.sub('', args[0])
@@ -51,6 +53,7 @@ def _possibly_update_key(d, value, old_key, new_key=None):
 
 
 class Term(StringMixin):
+
     def __new__(cls, name, env, side=None, encoding=None):
         klass = Constant if not isinstance(name, string_types) else cls
         supr_new = super(Term, klass).__new__
@@ -195,6 +198,7 @@ class Term(StringMixin):
 
 
 class Constant(Term):
+
     def __init__(self, value, env, side=None, encoding=None):
         super(Constant, self).__init__(value, env, side=side,
                                        encoding=encoding)
@@ -211,8 +215,10 @@ _bool_op_map = {'not': '~', 'and': '&', 'or': '|'}
 
 
 class Op(StringMixin):
+
     """Hold an operator of unknown arity
     """
+
     def __init__(self, op, operands, *args, **kwargs):
         self.op = _bool_op_map.get(op, op)
         self.operands = operands
@@ -328,6 +334,7 @@ def is_term(obj):
 
 
 class BinOp(Op):
+
     """Hold a binary operator and its operands
 
     Parameters
@@ -336,6 +343,7 @@ class BinOp(Op):
     left : Term or Op
     right : Term or Op
     """
+
     def __init__(self, op, lhs, rhs, **kwargs):
         super(BinOp, self).__init__(op, (lhs, rhs))
         self.lhs = lhs
@@ -452,6 +460,7 @@ class BinOp(Op):
 
 
 class Div(BinOp):
+
     """Div operator to special case casting.
 
     Parameters
@@ -462,6 +471,7 @@ class Div(BinOp):
         Whether or not to use true division. With Python 3 this happens
         regardless of the value of ``truediv``.
     """
+
     def __init__(self, lhs, rhs, truediv=True, *args, **kwargs):
         super(Div, self).__init__('/', lhs, rhs, *args, **kwargs)
 
@@ -475,6 +485,7 @@ _unary_ops_dict = dict(zip(_unary_ops_syms, _unary_ops_funcs))
 
 
 class UnaryOp(Op):
+
     """Hold a unary operator and its operands
 
     Parameters
@@ -489,6 +500,7 @@ class UnaryOp(Op):
     ValueError
         * If no function associated with the passed operator token is found.
     """
+
     def __init__(self, op, operand):
         super(UnaryOp, self).__init__(op, (operand,))
         self.operand = operand

--- a/pandas/computation/pytables.py
+++ b/pandas/computation/pytables.py
@@ -30,6 +30,7 @@ class Scope(expr.Scope):
 
 
 class Term(ops.Term):
+
     def __new__(cls, name, env, side=None, encoding=None):
         klass = Constant if not isinstance(name, string_types) else cls
         supr_new = StringMixin.__new__
@@ -57,6 +58,7 @@ class Term(ops.Term):
 
 
 class Constant(Term):
+
     def __init__(self, value, env, side=None, encoding=None):
         super(Constant, self).__init__(value, env, side=side,
                                        encoding=encoding)
@@ -292,9 +294,9 @@ class ConditionBinOp(BinOp):
 
     def invert(self):
         """ invert the condition """
-        #if self.condition is not None:
+        # if self.condition is not None:
         #    self.condition = "~(%s)" % self.condition
-        #return self
+        # return self
         raise NotImplementedError("cannot use an invert condition when "
                                   "passing to numexpr")
 

--- a/pandas/computation/tests/test_eval.py
+++ b/pandas/computation/tests/test_eval.py
@@ -35,6 +35,7 @@ from pandas.compat import PY3, u
 _series_frame_incompatible = _bool_ops_syms
 _scalar_skip = 'in', 'not in'
 
+
 def skip_if_no_ne(engine='numexpr'):
     if not _USE_NUMEXPR and engine == 'numexpr':
         raise nose.SkipTest("numexpr engine not installed or disabled")
@@ -104,6 +105,7 @@ _good_arith_ops = com.difference(_arith_ops_syms, _special_case_arith_ops_syms)
 
 
 class TestEvalNumexprPandas(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
         skip_if_no_ne()
@@ -201,7 +203,8 @@ class TestEvalNumexprPandas(unittest.TestCase):
     @slow
     def test_chained_cmp_op(self):
         mids = self.lhses
-        cmp_ops = '<', '>'# tuple(set(self.cmp_ops) - set(['==', '!=', '<=', '>=']))
+        # tuple(set(self.cmp_ops) - set(['==', '!=', '<=', '>=']))
+        cmp_ops = '<', '>'
         for lhs, cmp1, mid, cmp2, rhs in product(self.lhses, cmp_ops,
                                                  mids, cmp_ops, self.rhses):
             self.check_chained_cmp_op(lhs, cmp1, mid, cmp2, rhs)
@@ -231,7 +234,7 @@ class TestEvalNumexprPandas(unittest.TestCase):
                               engine=self.engine, parser=self.parser)
         elif (np.isscalar(lhs) and np.isnan(lhs) and
                 not np.isscalar(rhs) and (cmp1 in skip_these or cmp2 in
-                    skip_these)):
+                                          skip_these)):
             with tm.assertRaises(TypeError):
                 _eval_single_bin(lhs, binop, rhs, self.engine)
         else:
@@ -243,19 +246,20 @@ class TestEvalNumexprPandas(unittest.TestCase):
                 # TODO: the code below should be added back when left and right
                 # hand side bool ops are fixed.
 
-                #try:
-                    #self.assertRaises(Exception, pd.eval, ex,
+                # try:
+                    # self.assertRaises(Exception, pd.eval, ex,
                                     #local_dict={'lhs': lhs, 'rhs': rhs},
-                                    #engine=self.engine, parser=self.parser)
-                #except AssertionError:
+                                    # engine=self.engine, parser=self.parser)
+                # except AssertionError:
                     #import ipdb; ipdb.set_trace()
-                    #raise
+                    # raise
             elif (np.isscalar(lhs_new) and np.isnan(lhs_new) and
                     not np.isscalar(rhs_new) and binop in skip_these):
                 with tm.assertRaises(TypeError):
                     _eval_single_bin(lhs_new, binop, rhs_new, self.engine)
             else:
-                expected = _eval_single_bin(lhs_new, binop, rhs_new, self.engine)
+                expected = _eval_single_bin(
+                    lhs_new, binop, rhs_new, self.engine)
                 result = pd.eval(ex, engine=self.engine, parser=self.parser)
                 assert_array_equal(result, expected)
 
@@ -306,7 +310,7 @@ class TestEvalNumexprPandas(unittest.TestCase):
 
             for ex in (ex1, ex2, ex3):
                 result = pd.eval(ex, engine=self.engine,
-                                    parser=self.parser)
+                                 parser=self.parser)
                 assert_array_equal(result, expected)
 
     @skip_incompatible_operand
@@ -314,8 +318,8 @@ class TestEvalNumexprPandas(unittest.TestCase):
         ex = 'lhs {0} rhs'.format(cmp1)
         if cmp1 in ('in', 'not in') and not com.is_list_like(rhs):
             self.assertRaises(TypeError, pd.eval, ex, engine=self.engine,
-                            parser=self.parser, local_dict={'lhs': lhs,
-                                                            'rhs': rhs})
+                              parser=self.parser, local_dict={'lhs': lhs,
+                                                              'rhs': rhs})
         else:
             expected = _eval_single_bin(lhs, cmp1, rhs, self.engine)
             result = pd.eval(ex, engine=self.engine, parser=self.parser)
@@ -396,7 +400,7 @@ class TestEvalNumexprPandas(unittest.TestCase):
         result = pd.eval(ex, engine=self.engine, parser=self.parser)
 
         if (np.isscalar(lhs) and np.isscalar(rhs) and
-            _is_py3_complex_incompat(result, expected)):
+                _is_py3_complex_incompat(result, expected)):
             self.assertRaises(AssertionError, assert_array_equal, result,
                               expected)
         else:
@@ -462,9 +466,9 @@ class TestEvalNumexprPandas(unittest.TestCase):
     def test_frame_invert(self):
         expr = self.ex('~')
 
-        ## ~ ##
+        # ~ ##
         # frame
-        ## float always raises
+        # float always raises
         lhs = DataFrame(randn(5, 2))
         if self.engine == 'numexpr':
             with tm.assertRaises(NotImplementedError):
@@ -473,7 +477,7 @@ class TestEvalNumexprPandas(unittest.TestCase):
             with tm.assertRaises(TypeError):
                 result = pd.eval(expr, engine=self.engine, parser=self.parser)
 
-        ## int raises on numexpr
+        # int raises on numexpr
         lhs = DataFrame(randint(5, size=(5, 2)))
         if self.engine == 'numexpr':
             with tm.assertRaises(NotImplementedError):
@@ -483,13 +487,13 @@ class TestEvalNumexprPandas(unittest.TestCase):
             result = pd.eval(expr, engine=self.engine, parser=self.parser)
             assert_frame_equal(expect, result)
 
-        ## bool always works
+        # bool always works
         lhs = DataFrame(rand(5, 2) > 0.5)
         expect = ~lhs
         result = pd.eval(expr, engine=self.engine, parser=self.parser)
         assert_frame_equal(expect, result)
 
-        ## object raises
+        # object raises
         lhs = DataFrame({'b': ['a', 1, 2.0], 'c': rand(3) > 0.5})
         if self.engine == 'numexpr':
             with tm.assertRaises(ValueError):
@@ -499,11 +503,11 @@ class TestEvalNumexprPandas(unittest.TestCase):
                 result = pd.eval(expr, engine=self.engine, parser=self.parser)
 
     def test_series_invert(self):
-        #### ~ ####
+        # ~ ####
         expr = self.ex('~')
 
         # series
-        ## float raises
+        # float raises
         lhs = Series(randn(5))
         if self.engine == 'numexpr':
             with tm.assertRaises(NotImplementedError):
@@ -512,7 +516,7 @@ class TestEvalNumexprPandas(unittest.TestCase):
             with tm.assertRaises(TypeError):
                 result = pd.eval(expr, engine=self.engine, parser=self.parser)
 
-        ## int raises on numexpr
+        # int raises on numexpr
         lhs = Series(randint(5, size=5))
         if self.engine == 'numexpr':
             with tm.assertRaises(NotImplementedError):
@@ -522,7 +526,7 @@ class TestEvalNumexprPandas(unittest.TestCase):
             result = pd.eval(expr, engine=self.engine, parser=self.parser)
             assert_series_equal(expect, result)
 
-        ## bool
+        # bool
         lhs = Series(rand(5) > 0.5)
         expect = ~lhs
         result = pd.eval(expr, engine=self.engine, parser=self.parser)
@@ -661,19 +665,30 @@ class TestEvalNumexprPandas(unittest.TestCase):
         with tm.assertRaises(TypeError):
             pd.eval('~1.0', engine=self.engine, parser=self.parser)
 
-        self.assertEqual(pd.eval('-1.0', parser=self.parser, engine=self.engine), -1.0)
-        self.assertEqual(pd.eval('+1.0', parser=self.parser, engine=self.engine), +1.0)
+        self.assertEqual(
+            pd.eval('-1.0', parser=self.parser, engine=self.engine), -1.0)
+        self.assertEqual(
+            pd.eval('+1.0', parser=self.parser, engine=self.engine), +1.0)
 
-        self.assertEqual(pd.eval('~1', parser=self.parser, engine=self.engine), ~1)
-        self.assertEqual(pd.eval('-1', parser=self.parser, engine=self.engine), -1)
-        self.assertEqual(pd.eval('+1', parser=self.parser, engine=self.engine), +1)
+        self.assertEqual(
+            pd.eval('~1', parser=self.parser, engine=self.engine), ~1)
+        self.assertEqual(
+            pd.eval('-1', parser=self.parser, engine=self.engine), -1)
+        self.assertEqual(
+            pd.eval('+1', parser=self.parser, engine=self.engine), +1)
 
-        self.assertEqual(pd.eval('~True', parser=self.parser, engine=self.engine), ~True)
-        self.assertEqual(pd.eval('~False', parser=self.parser, engine=self.engine), ~False)
-        self.assertEqual(pd.eval('-True', parser=self.parser, engine=self.engine), -True)
-        self.assertEqual(pd.eval('-False', parser=self.parser, engine=self.engine), -False)
-        self.assertEqual(pd.eval('+True', parser=self.parser, engine=self.engine), +True)
-        self.assertEqual(pd.eval('+False', parser=self.parser, engine=self.engine), +False)
+        self.assertEqual(
+            pd.eval('~True', parser=self.parser, engine=self.engine), ~True)
+        self.assertEqual(
+            pd.eval('~False', parser=self.parser, engine=self.engine), ~False)
+        self.assertEqual(
+            pd.eval('-True', parser=self.parser, engine=self.engine), -True)
+        self.assertEqual(
+            pd.eval('-False', parser=self.parser, engine=self.engine), -False)
+        self.assertEqual(
+            pd.eval('+True', parser=self.parser, engine=self.engine), +True)
+        self.assertEqual(
+            pd.eval('+False', parser=self.parser, engine=self.engine), +False)
 
     def test_disallow_scalar_bool_ops(self):
         exprs = '1 or 2', '1 and 2'
@@ -689,6 +704,7 @@ class TestEvalNumexprPandas(unittest.TestCase):
 
 
 class TestEvalNumexprPython(TestEvalNumexprPandas):
+
     @classmethod
     def setUpClass(cls):
         skip_if_no_ne()
@@ -714,6 +730,7 @@ class TestEvalNumexprPython(TestEvalNumexprPandas):
 
 
 class TestEvalPythonPython(TestEvalNumexprPython):
+
     @classmethod
     def setUpClass(cls):
         cls.engine = 'python'
@@ -741,6 +758,7 @@ class TestEvalPythonPython(TestEvalNumexprPython):
 
 
 class TestEvalPythonPandas(TestEvalPythonPython):
+
     @classmethod
     def setUpClass(cls):
         cls.engine = 'python'
@@ -782,9 +800,9 @@ class TestAlignment(object):
                        self.index_types)
         for lr_idx_type, rr_idx_type, c_idx_type in args:
             df = mkdf(10, 10, data_gen_f=f, r_idx_type=lr_idx_type,
-                    c_idx_type=c_idx_type)
+                      c_idx_type=c_idx_type)
             df2 = mkdf(20, 10, data_gen_f=f, r_idx_type=rr_idx_type,
-                    c_idx_type=c_idx_type)
+                       c_idx_type=c_idx_type)
             res = pd.eval('df + df2', engine=engine, parser=parser)
             assert_frame_equal(res, df + df2)
 
@@ -797,7 +815,7 @@ class TestAlignment(object):
         args = product(self.lhs_index_types, repeat=2)
         for r_idx_type, c_idx_type in args:
             df = mkdf(10, 10, data_gen_f=f, r_idx_type=r_idx_type,
-                    c_idx_type=c_idx_type)
+                      c_idx_type=c_idx_type)
             res = pd.eval('df < 2', engine=engine, parser=parser)
             assert_frame_equal(res, df < 2)
 
@@ -829,9 +847,10 @@ class TestAlignment(object):
 
     def check_basic_frame_series_alignment(self, engine, parser):
         skip_if_no_ne(engine)
+
         def testit(r_idx_type, c_idx_type, index_name):
             df = mkdf(10, 10, data_gen_f=f, r_idx_type=r_idx_type,
-                    c_idx_type=c_idx_type)
+                      c_idx_type=c_idx_type)
             index = getattr(df, index_name)
             s = Series(np.random.randn(5), index[:5])
 
@@ -856,9 +875,10 @@ class TestAlignment(object):
 
     def check_basic_series_frame_alignment(self, engine, parser):
         skip_if_no_ne(engine)
+
         def testit(r_idx_type, c_idx_type, index_name):
             df = mkdf(10, 7, data_gen_f=f, r_idx_type=r_idx_type,
-                    c_idx_type=c_idx_type)
+                      c_idx_type=c_idx_type)
             index = getattr(df, index_name)
             s = Series(np.random.randn(5), index[:5])
 
@@ -873,12 +893,12 @@ class TestAlignment(object):
             assert_frame_equal(res, expected)
 
         # only test dt with dt, otherwise weird joins result
-        args = product(['i','u','s'],['i','u','s'],('index', 'columns'))
+        args = product(['i', 'u', 's'], ['i', 'u', 's'], ('index', 'columns'))
         for r_idx_type, c_idx_type, index_name in args:
             testit(r_idx_type, c_idx_type, index_name)
 
         # dt with dt
-        args = product(['dt'],['dt'],('index', 'columns'))
+        args = product(['dt'], ['dt'], ('index', 'columns'))
         for r_idx_type, c_idx_type, index_name in args:
             testit(r_idx_type, c_idx_type, index_name)
 
@@ -892,7 +912,7 @@ class TestAlignment(object):
                        ('index', 'columns'))
         for r_idx_type, c_idx_type, op, index_name in args:
             df = mkdf(10, 10, data_gen_f=f, r_idx_type=r_idx_type,
-                    c_idx_type=c_idx_type)
+                      c_idx_type=c_idx_type)
             index = getattr(df, index_name)
             s = Series(np.random.randn(5), index[:5])
 
@@ -1005,6 +1025,7 @@ class TestAlignment(object):
 # slightly more complex ops
 
 class TestOperationsNumExprPandas(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
         skip_if_no_ne()
@@ -1175,21 +1196,22 @@ class TestOperationsNumExprPandas(unittest.TestCase):
 
         # invalid assignees
         self.assertRaises(SyntaxError, df.eval, 'd,c = a + b')
-        self.assertRaises(SyntaxError, df.eval, 'Timestamp("20131001") = a + b')
+        self.assertRaises(
+            SyntaxError, df.eval, 'Timestamp("20131001") = a + b')
 
         # single assignment - existing variable
         expected = orig_df.copy()
         expected['a'] = expected['a'] + expected['b']
         df = orig_df.copy()
         df.eval('a = a + b')
-        assert_frame_equal(df,expected)
+        assert_frame_equal(df, expected)
 
         # single assignment - new variable
         expected = orig_df.copy()
         expected['c'] = expected['a'] + expected['b']
         df = orig_df.copy()
         df.eval('c = a + b')
-        assert_frame_equal(df,expected)
+        assert_frame_equal(df, expected)
 
         # with a local name overlap
         def f():
@@ -1201,9 +1223,10 @@ class TestOperationsNumExprPandas(unittest.TestCase):
         df = f()
         expected = orig_df.copy()
         expected['a'] = 1 + expected['b']
-        assert_frame_equal(df,expected)
+        assert_frame_equal(df, expected)
 
         df = orig_df.copy()
+
         def f():
             a = 1
             df.eval('a=a+b')
@@ -1216,10 +1239,10 @@ class TestOperationsNumExprPandas(unittest.TestCase):
 
         # explicit targets
         df = orig_df.copy()
-        self.eval('c = df.a + df.b', local_dict={'df' : df}, target=df)
+        self.eval('c = df.a + df.b', local_dict={'df': df}, target=df)
         expected = orig_df.copy()
         expected['c'] = expected['a'] + expected['b']
-        assert_frame_equal(df,expected)
+        assert_frame_equal(df, expected)
 
     def test_basic_period_index_boolean_expression(self):
         df = mkdf(2, 2, data_gen_f=f, c_idx_type='p', r_idx_type='i')
@@ -1311,6 +1334,7 @@ class TestOperationsNumExprPandas(unittest.TestCase):
 
 
 class TestOperationsNumExprPython(TestOperationsNumExprPandas):
+
     @classmethod
     def setUpClass(cls):
         if not _USE_NUMEXPR:
@@ -1377,6 +1401,7 @@ class TestOperationsNumExprPython(TestOperationsNumExprPandas):
 
 
 class TestOperationsPythonPython(TestOperationsNumExprPython):
+
     @classmethod
     def setUpClass(cls):
         cls.engine = cls.parser = 'python'
@@ -1386,6 +1411,7 @@ class TestOperationsPythonPython(TestOperationsNumExprPython):
 
 
 class TestOperationsPythonPandas(TestOperationsNumExprPandas):
+
     @classmethod
     def setUpClass(cls):
         cls.engine = 'python'
@@ -1397,6 +1423,7 @@ _var_s = randn(10)
 
 
 class TestScope(object):
+
     def check_global_scope(self, e, engine, parser):
         skip_if_no_ne(engine)
         assert_array_equal(_var_s * 2, pd.eval(e, engine=engine,
@@ -1477,6 +1504,7 @@ def test_is_expr_names():
 
 _parsers = {'python': PythonExprVisitor, 'pytables': pytables.ExprVisitor,
             'pandas': PandasExprVisitor}
+
 
 def check_disallowed_nodes(engine, parser):
     skip_if_no_ne(engine)

--- a/pandas/core/array.py
+++ b/pandas/core/array.py
@@ -35,7 +35,7 @@ for _f in _lift_random:
 
 NA = np.nan
 
-#### a series-like ndarray ####
+# a series-like ndarray ####
 
 
 class SNDArray(Array):

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -7,6 +7,7 @@ from pandas.core import common as com
 
 
 class StringMixin(object):
+
     """implements string methods so long as object defines a `__unicode__`
     method.
 
@@ -55,6 +56,7 @@ class StringMixin(object):
 
 
 class PandasObject(StringMixin):
+
     """baseclass for various pandas objects"""
 
     @property
@@ -96,6 +98,7 @@ class PandasObject(StringMixin):
 
 
 class FrozenList(PandasObject, list):
+
     """
     Container that doesn't allow setting item *but*
     because it's technically non-hashable, will be used

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -33,6 +33,7 @@ def _cat_compare_op(op):
 
 
 class Categorical(PandasObject):
+
     """
     Represents a categorical variable in classic R / S-plus fashion
 
@@ -74,6 +75,7 @@ class Categorical(PandasObject):
     array(['a', 'b', 'c', 'a', 'b', 'c'], dtype=object)
     Levels (3): Index(['a', 'b', 'c'], dtype=object)
     """
+
     def __init__(self, labels, levels=None, name=None):
         if levels is None:
             if name is None:
@@ -148,14 +150,14 @@ class Categorical(PandasObject):
                                                   footer=False)
 
         result = '%s\n...\n%s' % (head, tail)
-        #TODO: tidy_repr for footer since there may be a ton of levels?
+        # TODO: tidy_repr for footer since there may be a ton of levels?
         result = '%s\n%s' % (result, self._repr_footer())
 
         return compat.text_type(result)
 
     def _repr_footer(self):
         levheader = 'Levels (%d): ' % len(self.levels)
-        #TODO: should max_line_width respect a setting?
+        # TODO: should max_line_width respect a setting?
         levstring = np.array_repr(self.levels, max_line_width=60)
         indent = ' ' * (levstring.find('[') + len(levheader) + 1)
         lines = levstring.split('\n')
@@ -222,11 +224,11 @@ class Categorical(PandasObject):
         """
         Returns a dataframe with frequency and counts by level.
         """
-        #Hack?
+        # Hack?
         from pandas.core.frame import DataFrame
         grouped = DataFrame(self.labels).groupby(0)
         counts = grouped.count().values.squeeze()
-        freqs = counts/float(counts.sum())
+        freqs = counts / float(counts.sum())
         return DataFrame.from_dict({
             'counts': counts,
             'freqs': freqs,

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -73,6 +73,7 @@ ABCSparseArray = create_pandas_abc_type("ABCSparseArray", "_subtyp",
 
 
 class _ABCGeneric(type):
+
     def __instancecheck__(cls, inst):
         return hasattr(inst, "_data")
 
@@ -962,7 +963,8 @@ def _maybe_upcast_putmask(result, mask, other, dtype=None, change=None):
 
                 # if we are trying to do something unsafe
                 # like put a bigger dtype in a smaller one, use the smaller one
-                if change.dtype.itemsize < r.dtype.itemsize: # pragma: no cover
+                # pragma: no cover
+                if change.dtype.itemsize < r.dtype.itemsize:
                     raise AssertionError(
                         "cannot change dtype of input to smaller size")
                 change.dtype = r.dtype
@@ -2469,8 +2471,8 @@ def _pprint_dict(seq, _nest_lvl=0, **kwds):
     nitems = get_option("max_seq_items") or len(seq)
 
     for k, v in list(seq.items())[:nitems]:
-        pairs.append(pfmt % (pprint_thing(k, _nest_lvl+1, **kwds),
-                             pprint_thing(v, _nest_lvl+1, **kwds)))
+        pairs.append(pfmt % (pprint_thing(k, _nest_lvl + 1, **kwds),
+                             pprint_thing(v, _nest_lvl + 1, **kwds)))
 
     if nitems < len(seq):
         return fmt % (", ".join(pairs) + ", ...")

--- a/pandas/core/config.py
+++ b/pandas/core/config.py
@@ -66,11 +66,12 @@ _reserved_keys = ['all']  # keys which have a special meaning
 
 
 class OptionError(AttributeError, KeyError):
+
     """Exception for pandas.options, backwards compatible with KeyError
     checks"""
 
 
-##########################################
+#
 # User API
 
 def _get_single_key(pat, silent):
@@ -187,8 +188,10 @@ def get_default_val(pat):
 
 
 class DictWrapper(object):
+
     """ provide attribute-style access to a nested dict
     """
+
     def __init__(self, d, prefix=""):
         object.__setattr__(self, "d", d)
         object.__setattr__(self, "prefix", prefix)
@@ -354,11 +357,12 @@ reset_option = CallableDynamicDoc(_reset_option, _reset_option_tmpl)
 describe_option = CallableDynamicDoc(_describe_option, _describe_option_tmpl)
 options = DictWrapper(_global_config)
 
-######################################################
+#
 # Functions for use by pandas developers, in addition to User - api
 
 
 class option_context(object):
+
     def __init__(self, *args):
         if not (len(args) % 2 == 0 and len(args) >= 2):
             raise AssertionError(
@@ -499,7 +503,7 @@ def deprecate_option(key, msg=None, rkey=None, removal_ver=None):
     _deprecated_options[key] = DeprecatedOption(key, msg, rkey, removal_ver)
 
 
-################################
+#
 # functions internal to the module
 
 def _select_options(pat):
@@ -662,7 +666,7 @@ def pp_options_list(keys, width=80, _print=False):
         return s
 
 
-##############
+#
 # helpers
 
 from contextlib import contextmanager

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -17,7 +17,7 @@ from pandas.core.config import (is_int, is_bool, is_text, is_float,
 from pandas.core.format import detect_console_encoding
 
 
-###########################################
+#
 # options from the "display" namespace
 
 pc_precision_doc = """

--- a/pandas/core/daterange.py
+++ b/pandas/core/daterange.py
@@ -9,6 +9,7 @@ import pandas.core.datetools as datetools
 # DateRange class
 
 class DateRange(Index):
+
     """Deprecated
     """
 

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -64,6 +64,7 @@ docstring_to_string = """
 
 
 class CategoricalFormatter(object):
+
     def __init__(self, categorical, buf=None, length=True,
                  na_rep='NaN', name=False, footer=True):
         self.categorical = categorical
@@ -246,6 +247,7 @@ class TableFormatter(object):
 
 
 class DataFrameFormatter(TableFormatter):
+
     """
     Render a DataFrame
 
@@ -886,7 +888,7 @@ class CSVFormatter(object):
 
         self.date_format = date_format
 
-        #GH3457
+        # GH3457
         if not self.obj.columns.is_unique and engine == 'python':
             raise NotImplementedError("columns.is_unique == False not "
                                       "supported with engine='python'")
@@ -1155,7 +1157,7 @@ class CSVFormatter(object):
                     col_line.append(columns.names[i])
 
                     if isinstance(index_label, list) and len(index_label) > 1:
-                        col_line.extend([''] * (len(index_label)-1))
+                        col_line.extend([''] * (len(index_label) - 1))
 
                 col_line.extend(columns.get_level_values(i))
 
@@ -1176,7 +1178,7 @@ class CSVFormatter(object):
 
         # write in chunksize bites
         chunksize = self.chunksize
-        chunks = int(nrows / chunksize)+1
+        chunks = int(nrows / chunksize) + 1
 
         for i in range(chunks):
             start_i = i * chunksize
@@ -1237,6 +1239,7 @@ header_style = {"font": {"bold": True},
 
 
 class ExcelFormatter(object):
+
     """
     Class for formatting a DataFrame to a list of ExcelCells,
 
@@ -1591,6 +1594,7 @@ class GenericArrayFormatter(object):
 
 
 class FloatArrayFormatter(GenericArrayFormatter):
+
     """
 
     """
@@ -1860,6 +1864,7 @@ def get_console_size():
 
 
 class EngFormatter(object):
+
     """
     Formats float values according to engineering format.
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -766,9 +766,9 @@ class DataFrame(NDFrame):
 
             values = [first_row]
 
-            #if unknown length iterable (generator)
+            # if unknown length iterable (generator)
             if nrows is None:
-                #consume whole generator
+                # consume whole generator
                 values += list(data)
             else:
                 i = 1
@@ -1592,7 +1592,7 @@ class DataFrame(NDFrame):
                 # a numpy error (as numpy should really raise)
                 values = self._data.iget(i)
                 if not len(values):
-                    values = np.array([np.nan]*len(self.index), dtype=object)
+                    values = np.array([np.nan] * len(self.index), dtype=object)
                 return self._constructor_sliced.from_array(
                     values, index=self.index,
                     name=label, fastpath=True)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -120,6 +120,7 @@ def _last_compat(x, axis=0):
 
 
 class GroupBy(PandasObject):
+
     """
     Class for grouping and aggregating relational data. See aggregate,
     transform, and apply functions on this object.
@@ -185,6 +186,7 @@ class GroupBy(PandasObject):
     len(grouped) : int
         Number of groups
     """
+
     def __init__(self, obj, keys=None, axis=0, level=None,
                  grouper=None, exclusions=None, selection=None, as_index=True,
                  sort=True, group_keys=True, squeeze=False):
@@ -653,9 +655,11 @@ def _is_indexed_like(obj, axes):
 
 
 class Grouper(object):
+
     """
 
     """
+
     def __init__(self, axis, groupings, sort=True, group_keys=True):
         self.axis = axis
         self.groupings = groupings
@@ -1209,6 +1213,7 @@ class BinGrouper(Grouper):
 
 
 class Grouping(object):
+
     """
     Holds the grouping information for a single key
 
@@ -1229,6 +1234,7 @@ class Grouping(object):
       * group_index : unique groups
       * groups : dict of {group -> label_list}
     """
+
     def __init__(self, index, grouper=None, name=None, level=None,
                  sort=True):
 
@@ -1594,7 +1600,7 @@ class SeriesGroupBy(GroupBy):
             return index
 
         if isinstance(values[0], dict):
-            # # GH #823
+            # GH #823
             index = _get_index()
             return DataFrame(values, index=index).stack()
 
@@ -2522,6 +2528,7 @@ class SeriesSplitter(DataSplitter):
 
 
 class FrameSplitter(DataSplitter):
+
     def __init__(self, data, labels, ngroups, axis=0):
         super(FrameSplitter, self).__init__(data, labels, ngroups, axis=axis)
 
@@ -2546,6 +2553,7 @@ class FrameSplitter(DataSplitter):
 
 
 class NDFrameSplitter(DataSplitter):
+
     def __init__(self, data, labels, ngroups, axis=0):
         super(NDFrameSplitter, self).__init__(data, labels, ngroups, axis=axis)
 
@@ -2679,9 +2687,11 @@ def _lexsort_indexer(keys, orders=None):
 
 
 class _KeyMapper(object):
+
     """
     Ease my suffering. Map compressed group id -> key tuple
     """
+
     def __init__(self, comp_ids, ngroups, labels, levels):
         self.levels = levels
         self.labels = labels

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1726,6 +1726,7 @@ class Int64Index(Index):
 
 
 class Float64Index(Index):
+
     """
     Immutable ndarray implementing an ordered, sliceable set. The basic object
     storing axis labels for all pandas objects. Float64Index is a special case

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -22,7 +22,7 @@ def get_indexers_list():
         ('loc',  _LocIndexer),
         ('at',   _AtIndexer),
         ('iat',  _iAtIndexer),
-        ]
+    ]
 
 # "null slice"
 _NS = slice(None, None)
@@ -116,13 +116,13 @@ class _NDFrameIndexer(object):
 
     def _convert_scalar_indexer(self, key, axis):
         # if we are accessing via lowered dim, use the last dim
-        ax = self.obj._get_axis(min(axis, self.ndim-1))
+        ax = self.obj._get_axis(min(axis, self.ndim - 1))
         # a scalar
         return ax._convert_scalar_indexer(key, typ=self.name)
 
     def _convert_slice_indexer(self, key, axis):
         # if we are accessing via lowered dim, use the last dim
-        ax = self.obj._get_axis(min(axis, self.ndim-1))
+        ax = self.obj._get_axis(min(axis, self.ndim - 1))
         return ax._convert_slice_indexer(key, typ=self.name)
 
     def _has_valid_setitem_indexer(self, indexer):
@@ -494,7 +494,7 @@ class _NDFrameIndexer(object):
                     # broadcast along other dims
                     ser = ser.values.copy()
                     for (axis, l) in broadcast:
-                        shape = [-1] * (len(broadcast)+1)
+                        shape = [-1] * (len(broadcast) + 1)
                         shape[axis] = l
                         ser = np.tile(ser, l).reshape(shape)
 
@@ -820,7 +820,7 @@ class _NDFrameIndexer(object):
 
                     # reindex with the specified axis
                     ndim = self.obj.ndim
-                    if axis+1 > ndim:
+                    if axis + 1 > ndim:
                         raise AssertionError("invalid indexing error with "
                                              "non-unique index")
 
@@ -980,6 +980,7 @@ class _NDFrameIndexer(object):
 
 
 class _IXIndexer(_NDFrameIndexer):
+
     """ A primarily location based indexer, with integer fallback """
 
     def _has_valid_type(self, key, axis):
@@ -1039,6 +1040,7 @@ class _LocationIndexer(_NDFrameIndexer):
 
 
 class _LocIndexer(_LocationIndexer):
+
     """ purely label based location based indexing """
     _valid_types = ("labels (MUST BE IN THE INDEX), slices of labels (BOTH "
                     "endpoints included! Can be slices of integers if the "
@@ -1136,6 +1138,7 @@ class _LocIndexer(_LocationIndexer):
 
 
 class _iLocIndexer(_LocationIndexer):
+
     """ purely integer based location based indexing """
     _valid_types = ("integer, integer slice (START point is INCLUDED, END "
                     "point is EXCLUDED), listlike of integers, boolean array")
@@ -1228,6 +1231,7 @@ class _iLocIndexer(_LocationIndexer):
 
 
 class _ScalarAccessIndexer(_NDFrameIndexer):
+
     """ access scalars quickly """
 
     def _convert_key(self, key):
@@ -1257,11 +1261,13 @@ class _ScalarAccessIndexer(_NDFrameIndexer):
 
 
 class _AtIndexer(_ScalarAccessIndexer):
+
     """ label based scalar accessor """
     pass
 
 
 class _iAtIndexer(_ScalarAccessIndexer):
+
     """ integer based scalar accessor """
 
     def _has_valid_setitem_indexer(self, indexer):
@@ -1301,7 +1307,7 @@ def _length_of_indexer(indexer, target=None):
             step = 1
         elif step < 0:
             step = abs(step)
-        return (stop-start) / step
+        return (stop - start) / step
     elif isinstance(indexer, (ABCSeries, np.ndarray, list)):
         return len(indexer)
     elif not is_list_like(indexer):
@@ -1346,6 +1352,7 @@ def _is_index_slice(obj):
 
 
 class _SeriesIndexer(_IXIndexer):
+
     """
     Class to support fancy indexing, potentially using labels
 
@@ -1504,11 +1511,11 @@ def _check_slice_bounds(slobj, values):
     l = len(values)
     start = slobj.start
     if start is not None:
-        if start < -l or start > l-1:
+        if start < -l or start > l - 1:
             raise IndexError("out-of-bounds on slice (start)")
     stop = slobj.stop
     if stop is not None:
-        if stop < -l-1 or stop > l:
+        if stop < -l - 1 or stop > l:
             raise IndexError("out-of-bounds on slice (end)")
 
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -533,7 +533,7 @@ class Block(PandasObject):
         values[mask] = na_rep
         return values.tolist()
 
-    #### block actions ####
+    # block actions ####
     def copy(self, deep=True, ref_items=None):
         values = self.values
         if deep:
@@ -667,7 +667,7 @@ class Block(PandasObject):
             new = self._try_cast(new)
 
             # pseudo-broadcast
-            if isinstance(new, np.ndarray) and new.ndim == self.ndim-1:
+            if isinstance(new, np.ndarray) and new.ndim == self.ndim - 1:
                 new = np.repeat(new, self.shape[-1]).reshape(self.shape)
 
             np.putmask(new_values, mask, new)
@@ -1026,7 +1026,7 @@ class Block(PandasObject):
 
                 # pseodo broadcast (its a 2d vs 1d say and where needs it in a
                 # specific direction)
-                if (other.ndim >= 1 and values.ndim-1 == other.ndim and
+                if (other.ndim >= 1 and values.ndim - 1 == other.ndim and
                         values.shape[0] != other.shape[0]):
                     other = _block_shape(other).T
                 else:
@@ -1201,7 +1201,7 @@ class TimeDeltaBlock(IntBlock):
             pass
         elif com.is_integer(value):
             # coerce to seconds of timedelta
-            value = np.timedelta64(int(value*1e9))
+            value = np.timedelta64(int(value * 1e9))
         elif isinstance(value, timedelta):
             value = np.timedelta64(value)
 
@@ -3035,8 +3035,8 @@ class BlockManager(PandasObject):
 
             # need to shift elements to the right
             if self._ref_locs[loc] is not None:
-                for i in reversed(lrange(loc+1, len(self._ref_locs))):
-                    self._ref_locs[i] = self._ref_locs[i-1]
+                for i in reversed(lrange(loc + 1, len(self._ref_locs))):
+                    self._ref_locs[i] = self._ref_locs[i - 1]
 
             self._ref_locs[loc] = (new_block, 0)
 

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -23,6 +23,7 @@ except ImportError:  # pragma: no cover
 
 
 class disallow(object):
+
     def __init__(self, *dtypes):
         super(disallow, self).__init__()
         self.dtypes = tuple(np.dtype(dtype).type for dtype in dtypes)
@@ -44,6 +45,7 @@ class disallow(object):
 
 
 class bottleneck_switch(object):
+
     def __init__(self, zero_value=None, **kwargs):
         self.zero_value = zero_value
         self.kwargs = kwargs

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -230,6 +230,7 @@ def add_flex_arithmetic_methods(cls, flex_arith_method, radd_func=None,
 
 
 class _TimeOp(object):
+
     """
     Wrapper around Series datetime/time/timedelta arithmetic operations.
     Generally, you should use classmethod ``maybe_convert_for_time_op`` as an

--- a/pandas/core/panelnd.py
+++ b/pandas/core/panelnd.py
@@ -44,7 +44,7 @@ def create_nd_panel_factory(klass_name, orders, slices, slicer, aliases=None,
 
     klass._constructor_sliced = slicer
 
-    #### define the methods ####
+    # define the methods ####
     def __init__(self, *args, **kwargs):
         if not (kwargs.get('data') or len(args)):
             raise Exception(

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -22,6 +22,7 @@ from pandas.core.index import Index, MultiIndex
 
 
 class _Unstacker(object):
+
     """
     Helper class to unstack data / pivot with multi-level index
 
@@ -57,6 +58,7 @@ class _Unstacker(object):
     -------
     unstacked : DataFrame
     """
+
     def __init__(self, values, index, level=-1, value_columns=None):
         if values.ndim == 1:
             values = values[:, np.newaxis]

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -405,7 +405,7 @@ def str_extract(arr, pat, flags=0):
             else:
                 return None
     else:
-        empty_row = Series(regex.groups*[None])
+        empty_row = Series(regex.groups * [None])
 
         def f(x):
             if not isinstance(x, compat.string_types):
@@ -743,6 +743,7 @@ def copy(source):
 
 
 class StringMethods(object):
+
     """
     Vectorized string functions for Series. NAs stay NA unless handled
     otherwise by a particular method. Patterned after Python's string methods,
@@ -753,6 +754,7 @@ class StringMethods(object):
     >>> s.str.split('_')
     >>> s.str.replace('_', '')
     """
+
     def __init__(self, series):
         self.series = series
 


### PR DESCRIPTION
This is some low hanging fruit, significantly faster than master.

To give some numbers, before the change is below the new:

```
In [1]: df = pd.DataFrame(np.random.randint(0, 100, 1000), columns=['A'], index=[0] * 1000); g = df.groupby('A')

In [2]: %timeit g.head(2)
1000 loops, best of 3: 429 µs per loop
#100 loops, best of 3: 9.67 ms per loop

In [3]: %timeit g.tail(2)
1000 loops, best of 3: 398 µs per loop
#100 loops, best of 3: 9.68 ms per loop

In [4]: %timeit g.size()
10000 loops, best of 3: 119 µs per loop
#1000 loops, best of 3: 649 µs per loop

In [11]: df = pd.DataFrame(np.random.randint(0, 10, 1000), columns=['A'], index=[0] * 1000); g = df.groupby('A')

In [12]: %timeit g.head(2)
10000 loops, best of 3: 189 µs per loop
#100 loops, best of 3: 2.1 ms per loop

In [13]: %timeit g.tail(2)
10000 loops, best of 3: 160 µs per loop
#100 loops, best of 3: 2.11 ms per loop

In [14]: %timeit g.size()
10000 loops, best of 3: 41.9 µs per loop
#1000 loops, best of 3: 598 µs per loop
```

...It's a bit messy to keep track of the as_index stuff (which you get when you apply), see below - am I missing some way to grab out the final index ??
