### PR TITLE
sphinxext py3 compatibility

### DIFF
--- a/doc/sphinxext/numpydoc/docscrape.py
+++ b/doc/sphinxext/numpydoc/docscrape.py
@@ -499,10 +499,14 @@ class ClassDoc(NumpyDocString):
             for field, items in [('Methods', self.methods),
                                  ('Attributes', self.properties)]:
                 if not self[field]:
-                    self[field] = [
-                        (name, '',
-                         splitlines_x(pydoc.getdoc(getattr(self._cls, name))))
-                        for name in sorted(items)]
+                    doc_list = []
+                    for name in sorted(items):
+                         try:
+                            doc_item = pydoc.getdoc(getattr(self._cls, name))
+                            doc_list.append((name, '', splitlines_x(doc_item)))
+                         except AttributeError:
+                            pass # method doesn't exist
+                    self[field] = doc_list
 
     @property
     def methods(self):


### PR DESCRIPTION
Temporary sphinxext py3 compatibility fix as discussed in #5479 before #5221 is resolved. So far test_docscrape.py passes on both Python 2.7 and 3.3 (which should be the typical developer interpreters).
