### PR TITLE
TST: correctly predict locale setability

### DIFF
--- a/pandas/tools/tests/test_util.py
+++ b/pandas/tools/tests/test_util.py
@@ -65,7 +65,7 @@ class TestLocaleUtils(unittest.TestCase):
         enc = codecs.lookup(enc).name
         new_locale = lang, enc
 
-        if not tm._can_set_locale('.'.join(new_locale)):
+        if not tm._can_set_locale(new_locale):
             with tm.assertRaises(locale.Error):
                 with tm.set_locale(new_locale):
                     pass


### PR DESCRIPTION
Don't join the lang and encoding when performing the trial set, because

```
locale.setlocale(locale.LC_ALL, ('it_CH', 'utf-8'))
```

succeeds, but

```
locale.setlocale(locale.LC_ALL, 'it_CH.utf-8')
```

throws locale.Error.

Closes #5537.
