### PR TITLE
TST: fix cumcount test on 32-bit env

### DIFF
--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -2574,7 +2574,7 @@ class TestGroupBy(unittest.TestCase):
         ge = DataFrame().groupby()
         se = Series().groupby()
 
-        e = Series(dtype='int')  # edge case, as this is usually considered float
+        e = Series(dtype='int64')  # edge case, as this is usually considered float
 
         assert_series_equal(e, ge.cumcount())
         assert_series_equal(e, se.cumcount())


### PR DESCRIPTION
Fix `test_groupby.test_cumcount_empty()` on 32-bit platforms by specifying expected dtype of 'int64'.

```
======================================================================
FAIL: test_cumcount_empty (pandas.tests.test_groupby.TestGroupBy)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/gmd/github_shadow/pandas/pandas/tests/test_groupby.py", line 2579, in test_cumcount_empty
    assert_series_equal(e, ge.cumcount())
  File "/home/gmd/github_shadow/pandas/pandas/util/testing.py", line 423, in assert_series_equal
    assert_attr_equal('dtype', left, right)
  File "/home/gmd/github_shadow/pandas/pandas/util/testing.py", line 407, in assert_attr_equal
    assert_equal(left_attr,right_attr,"attr is not equal [{0}]" .format(attr))
  File "/home/gmd/github_shadow/pandas/pandas/util/testing.py", line 390, in assert_equal
    assert a == b, "%s: %r != %r" % (msg.format(a,b), a, b)
AssertionError: attr is not equal [dtype]: dtype('int32') != dtype('int64')
```
