### PR TITLE
HTML (and text) reprs for large dataframes.

### DIFF
--- a/doc/source/dsintro.rst
+++ b/doc/source/dsintro.rst
@@ -573,8 +573,9 @@ indexing semantics are quite different in places from a matrix.
 Console display
 ~~~~~~~~~~~~~~~
 
-For very large DataFrame objects, only a summary will be printed to the console
-(here I am reading a CSV version of the **baseball** dataset from the **plyr**
+Very large DataFrames will be truncated to display them in the console.
+You can also get a summary using :meth:`~pandas.DataFrame.info`.
+(Here I am reading a CSV version of the **baseball** dataset from the **plyr**
 R package):
 
 .. ipython:: python
@@ -587,6 +588,7 @@ R package):
 
    baseball = read_csv('data/baseball.csv')
    print(baseball)
+   baseball.info()
 
 .. ipython:: python
    :suppress:
@@ -622,19 +624,8 @@ option:
 
    reset_option('line_width')
 
-You can also disable this feature via the ``expand_frame_repr`` option:
-
-.. ipython:: python
-
-   set_option('expand_frame_repr', False)
-
-   DataFrame(randn(3, 12))
-
-.. ipython:: python
-   :suppress:
-
-   reset_option('expand_frame_repr')
-
+You can also disable this feature via the ``expand_frame_repr`` option.
+This will print the table in one block.
 
 DataFrame column attribute access and IPython completion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -36,21 +36,25 @@ horizontal scrolling, auto-detection of width/height.
 To appropriately address all these environments, the display behavior is controlled
 by several options, which you're encouraged to tweak to suit your setup.
 
-As of 0.12, these are the relevant options, all under the `display` namespace,
-(e.g. display.width,  etc'):
+As of 0.13, these are the relevant options, all under the `display` namespace,
+(e.g. ``display.width``,  etc.):
 
 - notebook_repr_html: if True, IPython frontends with HTML support will display
   dataframes as HTML tables when possible.
-- expand_repr (default True):  when the frame width cannot fit within the screen,
-  the output will be broken into multiple pages to accomedate. This applies to
-  textual (as opposed to HTML) display only.
-- max_columns: max dataframe columns to display. a wider frame will trigger
-  a summary view, unless `expand_repr` is True and HTML output is disabled.
-- max_rows: max dataframe rows display. a longer frame will trigger a summary view.
-- width: width of display screen in characters, used to determine the width of lines
-  when expand_repr is active,  Setting this to None will trigger auto-detection of terminal
-  width, this only works for proper terminals, not IPython frontends such as ipnb.
-  width is ignored in IPython notebook, since the browser provides horizontal scrolling.
+- large_repr (default 'truncate'): when a :class:`~pandas.DataFrame`
+  exceeds max_columns or max_rows, it can be displayed either as a
+  truncated table or, with this set to 'info', as a short summary view.
+- max_columns (default 20): max dataframe columns to display.
+- max_rows (default 60): max dataframe rows display.
+
+Two additional options only apply to displaying DataFrames in terminals,
+not to the HTML view:
+
+- expand_repr (default True):  when the frame width cannot fit within
+  the screen, the output will be broken into multiple pages.
+- width: width of display screen in characters, used to determine the
+  width of lines when expand_repr is active. Setting this to None will
+  trigger auto-detection of terminal width.
 
 IPython users can use the IPython startup file to import pandas and set these
 options automatically when starting up.

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -375,6 +375,22 @@ HDFStore API Changes
   via the option ``io.hdf.dropna_table`` (:issue:`4625`)
 - pass thru store creation arguments; can be used to support in-memory stores
 
+DataFrame repr Changes
+~~~~~~~~~~~~~~~~~~~~~~
+
+The HTML and plain text representations of :class:`DataFrame` now show
+a truncated view of the table once it exceeds a certain size, rather
+than switching to the short info view (:issue:`4886`, :issue:`5550`).
+This makes the representation more consistent as small DataFrames get
+larger.
+
+.. image:: _static/df_repr_truncated.png
+   :alt: Truncated HTML representation of a DataFrame
+
+To get the info view, call :meth:`DataFrame.info`. If you prefer the
+info view as the repr for large DataFrames, you can set this by running
+``set_option('display.large_repr', 'info')``.
+
 Enhancements
 ~~~~~~~~~~~~
 
@@ -607,12 +623,6 @@ Enhancements
   output datetime objects should be formatted. Datetimes encountered in the
   index, columns, and values will all have this formatting applied. (:issue:`4313`)
 - ``DataFrame.plot`` will scatter plot x versus y by passing ``kind='scatter'`` (:issue:`2215`)
-- The HTML and plain text representations of :class:`DataFrame` now show
-  a truncated view of the table once it exceeds a certain size, rather
-  than switching to the short info view (:issue:`4886`, :issue:`5550`).
-  This makes the representation more consistent as small DataFrames get
-  larger. To get the info view, call :meth:`DataFrame.info`, or restore
-  the old behaviour with ``set_option('display.large_repr', 'info')``.
 
 .. _whatsnew_0130.experimental:
 

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -607,6 +607,12 @@ Enhancements
   output datetime objects should be formatted. Datetimes encountered in the
   index, columns, and values will all have this formatting applied. (:issue:`4313`)
 - ``DataFrame.plot`` will scatter plot x versus y by passing ``kind='scatter'`` (:issue:`2215`)
+- The HTML and plain text representations of :class:`DataFrame` now show
+  a truncated view of the table once it exceeds a certain size, rather
+  than switching to the short info view (:issue:`4886`, :issue:`5550`).
+  This makes the representation more consistent as small DataFrames get
+  larger. To get the info view, call :meth:`DataFrame.info`, or restore
+  the old behaviour with ``set_option('display.large_repr', 'info')``.
 
 .. _whatsnew_0130.experimental:
 

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -166,13 +166,19 @@ pc_max_seq_items = """
 
 pc_max_info_rows_doc = """
 : int or None
-    max_info_rows is the maximum number of rows for which a frame will
-    perform a null check on its columns when repr'ing To a console.
-    The default is 1,000,000 rows. So, if a DataFrame has more
-    1,000,000 rows there will be no null check performed on the
-    columns and thus the representation will take much less time to
-    display in an interactive session. A value of None means always
-    perform a null check when repr'ing.
+    Deprecated.
+"""
+
+pc_max_info_rows_deprecation_warning = """\
+max_info_rows has been deprecated, as reprs no longer use the info view.
+"""
+
+pc_large_repr_doc = """
+: 'truncate'/'info'
+
+    For DataFrames exceeding max_rows/max_cols, the repr (and HTML repr) can
+    show a truncated table (the default from 0.13), or switch to the view from
+    df.info() (the behaviour in earlier versions of pandas).
 """
 
 pc_mpl_style_doc = """
@@ -220,6 +226,8 @@ with cf.config_prefix('display'):
     cf.register_option('max_colwidth', 50, max_colwidth_doc, validator=is_int)
     cf.register_option('max_columns', 20, pc_max_cols_doc,
                        validator=is_instance_factory([type(None), int]))
+    cf.register_option('large_repr', 'truncate', pc_large_repr_doc,
+                       validator=is_one_of_factory(['truncate', 'info']))
     cf.register_option('max_info_columns', 100, pc_max_info_cols_doc,
                        validator=is_int)
     cf.register_option('colheader_justify', 'right', colheader_justify_doc,
@@ -257,6 +265,9 @@ cf.deprecate_option('display.line_width',
 cf.deprecate_option('display.height',
                     msg=pc_height_deprecation_warning,
                     rkey='display.max_rows')
+
+cf.deprecate_option('display.max_info_rows',
+                    msg=pc_max_info_rows_deprecation_warning)
 
 tc_sim_interactive_doc = """
 : boolean

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -1,3 +1,4 @@
+#coding: utf-8
 from __future__ import print_function
 # pylint: disable=W0141
 
@@ -264,7 +265,7 @@ class DataFrameFormatter(TableFormatter):
                  header=True, index=True, na_rep='NaN', formatters=None,
                  justify=None, float_format=None, sparsify=None,
                  index_names=True, line_width=None, max_rows=None, max_cols=None,
-                 **kwds):
+                 show_dimensions=False, **kwds):
         self.frame = frame
         self.buf = buf if buf is not None else StringIO()
         self.show_index_names = index_names
@@ -283,6 +284,7 @@ class DataFrameFormatter(TableFormatter):
         self.line_width = line_width
         self.max_rows = max_rows
         self.max_cols = max_cols
+        self.show_dimensions = show_dimensions
 
         if justify is None:
             self.justify = get_option("display.colheader_justify")
@@ -311,6 +313,7 @@ class DataFrameFormatter(TableFormatter):
         cols_to_show = self.columns[:self.max_cols]
         truncate_h = self.max_cols and (len(self.columns) > self.max_cols)
         truncate_v = self.max_rows and (len(self.frame) > self.max_rows)
+        self.truncated_v = truncate_v
         if truncate_h:
             cols_to_show = self.columns[:self.max_cols]
         else:
@@ -376,6 +379,10 @@ class DataFrameFormatter(TableFormatter):
                 text = self._join_multiline(*strcols)
 
         self.buf.writelines(text)
+
+        if self.show_dimensions:
+            self.buf.write("\n\n[%d rows x %d columns]" \
+                            % (len(frame), len(frame.columns)) )
 
     def _join_multiline(self, *strcols):
         lwidth = self.line_width
@@ -671,6 +678,8 @@ class HTMLFormatter(TableFormatter):
                                       'not %s') % type(self.classes))
             _classes.extend(self.classes)
 
+
+
         self.write('<table border="1" class="%s">' % ' '.join(_classes),
                    indent)
 
@@ -687,6 +696,10 @@ class HTMLFormatter(TableFormatter):
             indent = self._write_body(indent)
 
         self.write('</table>', indent)
+        if self.fmt.show_dimensions:
+            by = chr(215) if compat.PY3 else unichr(215) # ×
+            self.write(u('<p>%d rows %s %d columns</p>') %
+                         (len(frame), by, len(frame.columns)) )
         _put_lines(buf, self.elements)
 
     def _write_header(self, indent):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -454,7 +454,7 @@ class DataFrame(NDFrame):
         else:
             width = None
         self.to_string(buf=buf, max_rows=max_rows, max_cols=max_cols,
-                       line_width=width)
+                       line_width=width, show_dimensions=True)
 
         return buf.getvalue()
 
@@ -485,7 +485,8 @@ class DataFrame(NDFrame):
 
             return ('<div style="max-height:1000px;'
                     'max-width:1500px;overflow:auto;">\n' +
-                    self.to_html(max_rows=max_rows, max_cols=max_cols) \
+                    self.to_html(max_rows=max_rows, max_cols=max_cols,
+                                 show_dimensions=True) \
                     + '\n</div>')
         else:
             return None
@@ -1254,7 +1255,8 @@ class DataFrame(NDFrame):
                   header=True, index=True, na_rep='NaN', formatters=None,
                   float_format=None, sparsify=None, nanRep=None,
                   index_names=True, justify=None, force_unicode=None,
-                  line_width=None, max_rows=None, max_cols=None):
+                  line_width=None, max_rows=None, max_cols=None,
+                  show_dimensions=False):
         """
         Render a DataFrame to a console-friendly tabular output.
         """
@@ -1281,7 +1283,8 @@ class DataFrame(NDFrame):
                                            index_names=index_names,
                                            header=header, index=index,
                                            line_width=line_width,
-                                           max_rows=max_rows, max_cols=max_cols)
+                                           max_rows=max_rows, max_cols=max_cols,
+                                           show_dimensions=show_dimensions)
         formatter.to_string()
 
         if buf is None:
@@ -1293,7 +1296,8 @@ class DataFrame(NDFrame):
                 header=True, index=True, na_rep='NaN', formatters=None,
                 float_format=None, sparsify=None, index_names=True,
                 justify=None, force_unicode=None, bold_rows=True,
-                classes=None, escape=True, max_rows=None, max_cols=None):
+                classes=None, escape=True, max_rows=None, max_cols=None,
+                show_dimensions=False):
         """
         Render a DataFrame as an HTML table.
 
@@ -1332,7 +1336,8 @@ class DataFrame(NDFrame):
                                            header=header, index=index,
                                            bold_rows=bold_rows,
                                            escape=escape,
-                                           max_rows=max_rows, max_cols=max_cols)
+                                           max_rows=max_rows, max_cols=max_cols,
+                                           show_dimensions=show_dimensions)
         formatter.to_html(classes=classes)
 
         if buf is None:

--- a/pandas/io/clipboard.py
+++ b/pandas/io/clipboard.py
@@ -1,5 +1,5 @@
 """ io on the clipboard """
-from pandas import compat, get_option
+from pandas import compat, get_option, DataFrame
 from pandas.compat import StringIO
 
 def read_clipboard(**kwargs):  # pragma: no cover
@@ -64,5 +64,10 @@ def to_clipboard(obj, excel=None, sep=None, **kwargs):  # pragma: no cover
         except:
             pass
 
-    clipboard_set(str(obj))
+    if isinstance(obj, DataFrame):
+        # str(df) has various unhelpful defaults, like truncation
+        objstr = obj.to_string()
+    else:
+        objstr = str(obj)
+    clipboard_set(objstr)
 

--- a/pandas/io/tests/test_clipboard.py
+++ b/pandas/io/tests/test_clipboard.py
@@ -7,6 +7,7 @@ import nose
 
 from pandas import DataFrame
 from pandas import read_clipboard
+from pandas import get_option
 from pandas.util import testing as tm
 from pandas.util.testing import makeCustomDataframe as mkdf
 
@@ -33,6 +34,11 @@ class TestClipboard(unittest.TestCase):
         cls.data['mixed'] = DataFrame({'a': np.arange(1.0, 6.0) + 0.01,
                                        'b': np.arange(1, 6),
                                        'c': list('abcde')})
+        # Test GH-5346
+        max_rows = get_option('display.max_rows')
+        cls.data['longdf'] = mkdf(max_rows+1, 3, data_gen_f=lambda *args: randint(2),
+                                  c_idx_type='s', r_idx_type='i',
+                                  c_idx_names=[None], r_idx_names=[None])  
         cls.data_types = list(cls.data.keys())
 
     @classmethod

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 from pandas.compat import range, zip, lrange, StringIO, PY3, lzip, u
 import pandas.compat as compat
+import itertools
 import os
 import sys
 import unittest
@@ -33,6 +34,20 @@ def curpath():
 def has_info_repr(df):
     r = repr(df)
     return r.split('\n')[0].startswith("<class")
+
+def has_horizontally_truncated_repr(df):
+    r = repr(df)
+    return any(l.strip().endswith('...') for l in r.splitlines())
+
+def has_vertically_truncated_repr(df):
+    r = repr(df)
+    return '..' in r.splitlines()[-1]
+
+def has_truncated_repr(df):
+    return has_horizontally_truncated_repr(df) or has_vertically_truncated_repr(df)
+
+def has_doubly_truncated_repr(df):
+    return has_horizontally_truncated_repr(df) and has_vertically_truncated_repr(df)
 
 def has_expanded_repr(df):
     r = repr(df)
@@ -172,19 +187,19 @@ class TestDataFrameFormatting(unittest.TestCase):
                                 'display.width',20,
                                 'display.max_rows', 20):
                 with option_context('display.expand_frame_repr', True):
-                    self.assertFalse(has_info_repr(df_small))
+                    self.assertFalse(has_truncated_repr(df_small))
                     self.assertFalse(has_expanded_repr(df_small))
-                    self.assertFalse(has_info_repr(df_wide))
+                    self.assertFalse(has_truncated_repr(df_wide))
                     self.assertTrue(has_expanded_repr(df_wide))
-                    self.assertTrue(has_info_repr(df_tall))
-                    self.assertFalse(has_expanded_repr(df_tall))
+                    self.assertTrue(has_vertically_truncated_repr(df_tall))
+                    self.assertTrue(has_expanded_repr(df_tall))
 
                 with option_context('display.expand_frame_repr', False):
-                    self.assertFalse(has_info_repr(df_small))
+                    self.assertFalse(has_truncated_repr(df_small))
                     self.assertFalse(has_expanded_repr(df_small))
-                    self.assertTrue(has_info_repr(df_wide))
+                    self.assertFalse(has_horizontally_truncated_repr(df_wide))
                     self.assertFalse(has_expanded_repr(df_wide))
-                    self.assertTrue(has_info_repr(df_tall))
+                    self.assertTrue(has_vertically_truncated_repr(df_tall))
                     self.assertFalse(has_expanded_repr(df_tall))
 
     def test_repr_non_interactive(self):
@@ -196,7 +211,7 @@ class TestDataFrameFormatting(unittest.TestCase):
                             'display.width', 0,
                             'display.height', 0,
                             'display.max_rows',5000):
-            self.assertFalse(has_info_repr(df))
+            self.assertFalse(has_truncated_repr(df))
             self.assertFalse(has_expanded_repr(df))
 
     def test_repr_max_columns_max_rows(self):
@@ -218,20 +233,20 @@ class TestDataFrameFormatting(unittest.TestCase):
                     self.assertFalse(has_expanded_repr(mkframe(4)))
                     self.assertFalse(has_expanded_repr(mkframe(5)))
                     self.assertFalse(has_expanded_repr(df6))
-                    self.assertTrue(has_info_repr(df6))
+                    self.assertTrue(has_doubly_truncated_repr(df6))
 
                 with option_context('display.max_rows', 20,
                                     'display.max_columns', 10):
                     # Out off max_columns boundary, but no extending
                     # since not exceeding width
                     self.assertFalse(has_expanded_repr(df6))
-                    self.assertFalse(has_info_repr(df6))
+                    self.assertFalse(has_truncated_repr(df6))
 
                 with option_context('display.max_rows', 9,
                                     'display.max_columns', 10):
                     # out vertical bounds can not result in exanded repr
                     self.assertFalse(has_expanded_repr(df10))
-                    self.assertTrue(has_info_repr(df10))
+                    self.assertTrue(has_vertically_truncated_repr(df10))
 
             # width=None in terminal, auto detection
             with option_context('display.max_columns', 100,
@@ -722,45 +737,6 @@ class TestDataFrameFormatting(unittest.TestCase):
         repr(df)
         repr(df.T)
         fmt.set_option('display.max_rows', 200)
-
-    def test_large_frame_repr(self):
-        def wrap_rows_options(f):
-            def _f(*args, **kwargs):
-                old_max_rows = pd.get_option('display.max_rows')
-                old_max_info_rows = pd.get_option('display.max_info_rows')
-                o = f(*args, **kwargs)
-                pd.set_option('display.max_rows', old_max_rows)
-                pd.set_option('display.max_info_rows', old_max_info_rows)
-                return o
-            return _f
-
-        @wrap_rows_options
-        def test_setting(value, nrows=3, ncols=2):
-            if value is None:
-                expected_difference = 0
-            elif isinstance(value, int):
-                expected_difference = ncols
-            else:
-                raise ValueError("'value' must be int or None")
-
-            with option_context('mode.sim_interactive', True):
-                pd.set_option('display.max_rows', nrows - 1)
-                pd.set_option('display.max_info_rows', value)
-
-                smallx = DataFrame(np.random.rand(nrows, ncols))
-                repr_small = repr(smallx)
-
-                bigx = DataFrame(np.random.rand(nrows + 1, ncols))
-                repr_big = repr(bigx)
-
-                diff = len(repr_small.splitlines()) - len(repr_big.splitlines())
-
-                # the difference in line count is the number of columns
-                self.assertEqual(diff, expected_difference)
-
-        test_setting(None)
-        test_setting(3)
-        self.assertRaises(ValueError, test_setting, 'string')
 
     def test_pprint_thing(self):
         import nose
@@ -1432,6 +1408,112 @@ c  10  11  12  13  14\
         self.frame._repr_html_()
 
         fmt.reset_option('^display.')
+
+    def test_repr_html_wide(self):
+        row = lambda l, k: [tm.rands(k) for _ in range(l)]
+        max_cols = get_option('display.max_columns')
+        df = DataFrame([row(max_cols-1, 25) for _ in range(10)])
+        reg_repr = df._repr_html_()
+        assert "..." not in reg_repr
+
+        wide_df = DataFrame([row(max_cols+1, 25) for _ in range(10)])
+        wide_repr = wide_df._repr_html_()
+        assert "..." in wide_repr
+
+    def test_repr_html_wide_multiindex_cols(self):
+        row = lambda l, k: [tm.rands(k) for _ in range(l)]
+        max_cols = get_option('display.max_columns')
+
+        tuples = list(itertools.product(np.arange(max_cols//2), ['foo', 'bar']))
+        mcols = pandas.MultiIndex.from_tuples(tuples, names=['first', 'second'])
+        df = DataFrame([row(len(mcols), 25) for _ in range(10)], columns=mcols)
+        reg_repr = df._repr_html_()
+        assert '...' not in reg_repr
+
+
+        tuples = list(itertools.product(np.arange(1+(max_cols//2)), ['foo', 'bar']))
+        mcols = pandas.MultiIndex.from_tuples(tuples, names=['first', 'second'])
+        df = DataFrame([row(len(mcols), 25) for _ in range(10)], columns=mcols)
+        wide_repr = df._repr_html_()
+        assert '...' in wide_repr
+
+    def test_repr_html_long(self):
+        max_rows = get_option('display.max_rows')
+        h = max_rows - 1
+        df = pandas.DataFrame({'A':np.arange(1,1+h), 'B':np.arange(41, 41+h)})
+        reg_repr = df._repr_html_()
+        assert '...' not in reg_repr
+        assert str(40 + h) in reg_repr
+
+        h = max_rows + 1
+        df = pandas.DataFrame({'A':np.arange(1,1+h), 'B':np.arange(41, 41+h)})
+        long_repr = df._repr_html_()
+        assert '...' in long_repr
+        assert str(40 + h) not in long_repr
+
+    def test_repr_html_long_multiindex(self):
+        max_rows = get_option('display.max_rows')
+        max_L1 = max_rows//2
+
+        tuples = list(itertools.product(np.arange(max_L1), ['foo', 'bar']))
+        idx = pandas.MultiIndex.from_tuples(tuples, names=['first', 'second'])
+        df = DataFrame(np.random.randn(max_L1*2, 2), index=idx,
+                       columns=['A', 'B'])
+        reg_repr = df._repr_html_()
+        assert '...' not in reg_repr
+
+        tuples = list(itertools.product(np.arange(max_L1+1), ['foo', 'bar']))
+        idx = pandas.MultiIndex.from_tuples(tuples, names=['first', 'second'])
+        df = DataFrame(np.random.randn((max_L1+1)*2, 2), index=idx,
+                       columns=['A', 'B'])
+        long_repr = df._repr_html_()
+        assert '...' in long_repr
+
+    def test_repr_html_long_and_wide(self):
+        max_cols = get_option('display.max_columns')
+        max_rows = get_option('display.max_rows')
+
+        h, w = max_rows-1, max_cols-1
+        df = pandas.DataFrame(dict((k,np.arange(1,1+h)) for k in np.arange(w)))
+        assert '...'  not in df._repr_html_()
+
+        h, w = max_rows+1, max_cols+1
+        df = pandas.DataFrame(dict((k,np.arange(1,1+h)) for k in np.arange(w)))
+        assert '...'  in df._repr_html_()
+
+    def test_info_repr(self):
+        max_rows = get_option('display.max_rows')
+        max_cols = get_option('display.max_columns')
+        # Long
+        h, w = max_rows+1, max_cols-1
+        df = pandas.DataFrame(dict((k,np.arange(1,1+h)) for k in np.arange(w)))
+        assert has_vertically_truncated_repr(df)
+        with option_context('display.large_repr', 'info'):
+            assert has_info_repr(df)
+
+        # Wide
+        h, w = max_rows-1, max_cols+1
+        df = pandas.DataFrame(dict((k,np.arange(1,1+h)) for k in np.arange(w)))
+        assert has_vertically_truncated_repr(df)
+        with option_context('display.large_repr', 'info'):
+            assert has_info_repr(df)
+
+    def test_info_repr_html(self):
+        max_rows = get_option('display.max_rows')
+        max_cols = get_option('display.max_columns')
+        # Long
+        h, w = max_rows+1, max_cols-1
+        df = pandas.DataFrame(dict((k,np.arange(1,1+h)) for k in np.arange(w)))
+        assert '<class' not in df._repr_html_()
+        with option_context('display.large_repr', 'info'):
+            assert '<class' in df._repr_html_()
+
+        # Wide
+        h, w = max_rows-1, max_cols+1
+        df = pandas.DataFrame(dict((k,np.arange(1,1+h)) for k in np.arange(w)))
+        assert '<class' not in df._repr_html_()
+        with option_context('display.large_repr', 'info'):
+            assert '<class' in df._repr_html_()
 
     def test_fake_qtconsole_repr_html(self):
         def get_ipython():


### PR DESCRIPTION
As discussed in #4886, the HTML representation of DataFrames currently starts off as a table, but switches to the condensed info view if the table exceeds a certain size (by default, more than 60 rows or 20 columns). I've seen this confusing users, who think that they suddenly have a completely different kind of object, and don't understand why.

With these changes, the HTML repr always displays the table, but truncates it when it exceeds a certain size. It reuses the same options, `display.max_rows` and `display.max_columns`.

Before:

![pandas_long_repr_before](https://f.cloud.github.com/assets/327925/1575857/ae103a8c-5153-11e3-8a2c-f770cc76bdc2.png)
![pandas_wide_repr_before](https://f.cloud.github.com/assets/327925/1575858/ae40b22a-5153-11e3-8c1e-3d9a632a5136.png)

After:

![pandas_long_repr_after](https://f.cloud.github.com/assets/327925/1575860/b35a2caa-5153-11e3-9887-69302703f545.png)
![pandas_wide_repr_after](https://f.cloud.github.com/assets/327925/1575861/b35c7bc2-5153-11e3-872c-6a85523f93db.png)
