### PR TITLE
TST/API/BUG: resolve scoping issues in pytables query where rhs is a compound selection or scoped variable

### DIFF
--- a/pandas/computation/pytables.py
+++ b/pandas/computation/pytables.py
@@ -401,8 +401,15 @@ class ExprVisitor(BaseExprVisitor):
         return self.visit(cmpr)
 
     def visit_Subscript(self, node, **kwargs):
+        # only allow simple suscripts
+
         value = self.visit(node.value)
         slobj = self.visit(node.slice)
+        try:
+            value = value.value
+        except:
+            pass
+
         try:
             return self.const_type(value[slobj], self.env)
         except TypeError:
@@ -416,9 +423,16 @@ class ExprVisitor(BaseExprVisitor):
         ctx = node.ctx.__class__
         if ctx == ast.Load:
             # resolve the value
-            resolved = self.visit(value).value
+            resolved = self.visit(value)
+
+            # try to get the value to see if we are another expression
             try:
-                return getattr(resolved, attr)
+                resolved = resolved.value
+            except (AttributeError):
+                pass
+
+            try:
+                return self.term_type(getattr(resolved, attr), self.env)
             except AttributeError:
 
                 # something like datetime.datetime where scope is overriden

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -294,6 +294,10 @@ def read_hdf(path_or_buf, key, **kwargs):
 
         """
 
+    # grab the scope
+    if 'where' in kwargs:
+        kwargs['where'] = _ensure_term(kwargs['where'])
+
     f = lambda store, auto_close: store.select(
         key, auto_close=auto_close, **kwargs)
 


### PR DESCRIPTION
e.g. 'l1=selection.index' and 'l1=l', where l = selection.index were failing

example reproduced here:
http://stackoverflow.com/questions/20111542/selecting-rows-from-an-hdfstore-given-list-of-indexes

```
In [5]: parms = DataFrame({ 'A' : [1,1,2,2,3] })

In [6]: parms
Out[6]: 
   A
0  1
1  1
2  2
3  2
4  3

In [7]: parms.to_hdf('parms.hdf','df',mode='w',format='table',data_columns=['A'])

In [8]: selection = pd.read_hdf('parms.hdf','df',where='A=[2,3]')

In [9]: selection
Out[9]: 
   A
2  2
3  2
4  3

In [10]: hist = DataFrame(np.random.randn(25,1),columns=['data'],
   ....: index=MultiIndex.from_tuples([ (i,j) for i in range(5) for j in range(5) ],
   ....: names=['l1','l2']))

In [11]: hist
Out[11]: 
           data
l1 l2          
0  0   1.232358
   1  -2.677047
   2  -0.168854
   3   0.538848
   4  -0.678224
1  0   0.092575
   1   1.297578
   2  -1.489906
   3  -1.380054
   4   0.701762
2  0   1.397368
   1   0.198522
   2   1.034036
   3   0.650406
   4   1.823683
3  0   0.045635
   1  -0.213975
   2  -1.221950
   3  -0.145615
   4  -1.187883
4  0  -0.782221
   1  -0.626280
   2  -0.331885
   3  -0.975978
   4   2.006322
```

this works in 0.12

```
In [15]: pd.read_hdf('hist.hdf','df',where=pd.Term('l1','=',selection.index.tolist()))
Out[15]: 
           data
l1 l2          
2  0   1.397368
   1   0.198522
   2   1.034036
   3   0.650406
   4   1.823683
3  0   0.045635
   1  -0.213975
   2  -1.221950
   3  -0.145615
   4  -1.187883
4  0  -0.782221
   1  -0.626280
   2  -0.331885
   3  -0.975978
   4   2.006322
```

This works in 0.13 as well

```
In [16]: pd.read_hdf('hist.hdf','df',where='l1=selection.index')
Out[16]: 
           data
l1 l2          
2  0   1.397368
   1   0.198522
   2   1.034036
   3   0.650406
   4   1.823683
3  0   0.045635
   1  -0.213975
   2  -1.221950
   3  -0.145615
   4  -1.187883
4  0  -0.782221
   1  -0.626280
   2  -0.331885
   3  -0.975978
   4   2.006322
```
