### PR TITLE
PERF: slow conversion of single series to data frame

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4575,7 +4575,7 @@ def extract_index(data):
 
 
 def _prep_ndarray(values, copy=True):
-    if not isinstance(values, np.ndarray):
+    if not isinstance(values, (np.ndarray,Series)):
         if len(values) == 0:
             return np.empty((0, 0), dtype=object)
 

--- a/vb_suite/frame_ctor.py
+++ b/vb_suite/frame_ctor.py
@@ -25,18 +25,23 @@ dict_list = [dict(zip(columns, row)) for row in frame.values]
 frame_ctor_nested_dict = Benchmark("DataFrame(data)", setup)
 
 # From JSON-like stuff
-
 frame_ctor_list_of_dict = Benchmark("DataFrame(dict_list)", setup,
                                     start_date=datetime(2011, 12, 20))
 
 series_ctor_from_dict = Benchmark("Series(some_dict)", setup)
 
 # nested dict, integer indexes, regression described in #621
-
 setup = common_setup + """
 data = dict((i,dict((j,float(j)) for j in xrange(100))) for i in xrange(2000))
 """
 frame_ctor_nested_dict_int64 = Benchmark("DataFrame(data)", setup)
+
+# from a mi-series
+setup = common_setup + """
+mi = MultiIndex.from_tuples([(x,y) for x in range(100) for y in range(100)])
+s = Series(randn(10000), index=mi)
+"""
+frame_from_series = Benchmark("DataFrame(s)", setup)
 
 #----------------------------------------------------------------------
 # get_numeric_data


### PR DESCRIPTION
```

-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
frame_from_series                            |   0.1043 |  17.8473 |   0.0058 |
```

an oversight in handling a case like:

`DataFrame(a_series)`
