### PR TITLE
CLN/BUG: Fix stacklevel on setting with copy warning.

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1015,8 +1015,11 @@ class NDFrame(PandasObject):
         self._is_copy = copy
         return self
 
-    def _check_setitem_copy(self):
-        """ validate if we are doing a settitem on a chained copy """
+    def _check_setitem_copy(self, stacklevel=4):
+        """ validate if we are doing a settitem on a chained copy.
+
+        If you call this function, be sure to set the stacklevel such that the
+        user will see the error *at the level of setting*"""
         if self._is_copy:
             value = config.get_option('mode.chained_assignment')
 
@@ -1026,7 +1029,7 @@ class NDFrame(PandasObject):
             if value == 'raise':
                 raise SettingWithCopyError(t)
             elif value == 'warn':
-                warnings.warn(t, SettingWithCopyWarning)
+                warnings.warn(t, SettingWithCopyWarning, stacklevel=stacklevel)
 
     def __delitem__(self, key):
         """


### PR DESCRIPTION
May not be perfect, but gets us most of the way there. Resolves [@TomAugspurger's comment](https://github.com/pydata/pandas/pull/5390#issuecomment-29166038) on #5390.

Put the following in a file called `test.py`.

``` python
from pandas import DataFrame
def myfunction():
    df = DataFrame({"A": [1, 2, 3, 4, 5], "B": [3.125, 4.12, 3.1, 6.2, 7.]})
    row = df.loc[0]
    row["A"] = 0

def anotherfunction():
    myfunction()

def third_function():
    anotherfunction()

third_function()
```

Running it will generate this warning:

```
test.py:5: SettingWithCopyWarning: A value is trying to be set on a copy
of a slice from a DataFrame.
Try using .loc[row_index,col_indexer] = value instead
  row["A"] = 0
```

I don't think it's worth testing (especially because there's not necessarily a simple way to do it).
