### PR TITLE
ENH: Excel writer takes locale setting for date and datetime into account

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -53,6 +53,9 @@ pandas 0.13.1
 New features
 ~~~~~~~~~~~~
 
+  - Added ``date_format`` and ``datetime_format`` attribute to ExcelWriter.
+    (:issue:`4133`)
+
 API Changes
 ~~~~~~~~~~~
 

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -780,12 +780,16 @@ class _XlsxWriter(ExcelWriter):
         style_dict: style dictionary to convert
         num_format_str: optional number format string
         """
-        if style_dict is None:
-            return None
 
         # Create a XlsxWriter format object.
         xl_format = self.book.add_format()
+        
+        if num_format_str is not None:
+            xl_format.set_num_format(num_format_str)
 
+        if style_dict is None:
+            return xl_format
+        
         # Map the cell font to XlsxWriter font properties.
         if style_dict.get('font'):
             font = style_dict['font']
@@ -805,9 +809,6 @@ class _XlsxWriter(ExcelWriter):
         # Map the cell borders to XlsxWriter border properties.
         if style_dict.get('borders'):
             xl_format.set_border()
-
-        if num_format_str is not None:
-            xl_format.set_num_format(num_format_str)
 
         return xl_format
 

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -355,6 +355,11 @@ class ExcelWriter(object):
         Engine to use for writing. If None, defaults to
         ``io.excel.<extension>.writer``.  NOTE: can only be passed as a keyword
         argument.
+    date_format : string, default None
+        Format string for dates written into Excel files (e.g. 'YYYY-MM-DD')
+    datetime_format : string, default None
+        Format string for datetime objects written into Excel files
+        (e.g. 'YYYY-MM-DD HH:MM:SS')
     """
     # Defining an ExcelWriter implementation (see abstract methods for more...)
 
@@ -429,14 +434,24 @@ class ExcelWriter(object):
         """
         pass
 
-    def __init__(self, path, engine=None, **engine_kwargs):
-        # validate that this engine can handle the extnesion
+    def __init__(self, path, engine=None,
+                 date_format=None, datetime_format=None, **engine_kwargs):
+        # validate that this engine can handle the extension
         ext = os.path.splitext(path)[-1]
         self.check_extension(ext)
 
         self.path = path
         self.sheets = {}
         self.cur_sheet = None
+
+        if date_format is None:
+            self.date_format = 'YYYY-MM-DD'
+        else:
+            self.date_format = date_format
+        if datetime_format is None:
+            self.datetime_format = 'YYYY-MM-DD HH:MM:SS'
+        else:
+            self.datetime_format = datetime_format
 
     def _get_sheet_name(self, sheet_name):
         if sheet_name is None:
@@ -518,9 +533,9 @@ class _OpenpyxlWriter(ExcelWriter):
                                             style.__getattribute__(field))
 
             if isinstance(cell.val, datetime.datetime):
-                xcell.style.number_format.format_code = "YYYY-MM-DD HH:MM:SS"
+                xcell.style.number_format.format_code = self.datetime_format
             elif isinstance(cell.val, datetime.date):
-                xcell.style.number_format.format_code = "YYYY-MM-DD"
+                xcell.style.number_format.format_code = self.date_format
 
             if cell.mergestart is not None and cell.mergeend is not None:
                 cletterstart = get_column_letter(startcol + cell.col + 1)
@@ -585,8 +600,8 @@ class _XlwtWriter(ExcelWriter):
         super(_XlwtWriter, self).__init__(path, **engine_kwargs)
 
         self.book = xlwt.Workbook()
-        self.fm_datetime = xlwt.easyxf(num_format_str='YYYY-MM-DD HH:MM:SS')
-        self.fm_date = xlwt.easyxf(num_format_str='YYYY-MM-DD')
+        self.fm_datetime = xlwt.easyxf(num_format_str=self.datetime_format)
+        self.fm_date = xlwt.easyxf(num_format_str=self.date_format)
 
     def save(self):
         """
@@ -612,9 +627,9 @@ class _XlwtWriter(ExcelWriter):
 
             num_format_str = None
             if isinstance(cell.val, datetime.datetime):
-                num_format_str = "YYYY-MM-DD HH:MM:SS"
+                num_format_str = self.datetime_format
             if isinstance(cell.val, datetime.date):
-                num_format_str = "YYYY-MM-DD"
+                num_format_str = self.date_format
 
             stylekey = json.dumps(cell.style)
             if num_format_str:
@@ -699,11 +714,14 @@ class _XlsxWriter(ExcelWriter):
     engine = 'xlsxwriter'
     supported_extensions = ('.xlsx',)
 
-    def __init__(self, path, engine=None, **engine_kwargs):
+    def __init__(self, path, engine=None,
+                 date_format=None, datetime_format=None, **engine_kwargs):
         # Use the xlsxwriter module as the Excel writer.
         import xlsxwriter
 
-        super(_XlsxWriter, self).__init__(path, engine=engine, **engine_kwargs)
+        super(_XlsxWriter, self).__init__(path, engine=engine,
+            date_format=date_format, datetime_format=datetime_format,
+            **engine_kwargs)
 
         self.book = xlsxwriter.Workbook(path, **engine_kwargs)
 
@@ -729,9 +747,9 @@ class _XlsxWriter(ExcelWriter):
         for cell in cells:
             num_format_str = None
             if isinstance(cell.val, datetime.datetime):
-                num_format_str = "YYYY-MM-DD HH:MM:SS"
+                num_format_str = self.datetime_format
             if isinstance(cell.val, datetime.date):
-                num_format_str = "YYYY-MM-DD"
+                num_format_str = self.date_format
 
             stylekey = json.dumps(cell.style)
             if num_format_str:

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -1,7 +1,7 @@
 # pylint: disable=E1101
 
 from pandas.compat import u, range, map
-from datetime import datetime
+from datetime import datetime, date
 import os
 
 import nose
@@ -660,6 +660,44 @@ class ExcelWriterBase(SharedItems):
             reader = ExcelFile(path)
             recons = reader.parse('test1')
             tm.assert_frame_equal(self.tsframe, recons)
+
+    # GH4133 - excel output format strings
+    def test_excel_date_datetime_format(self):
+        df = DataFrame([[date(2014, 1, 31),
+                         date(1999, 9, 24)],
+                        [datetime(1998, 5, 26, 23, 33, 4),
+                         datetime(2014, 2, 28, 13, 5, 13)]],
+                       index=['DATE', 'DATETIME'], columns=['X', 'Y'])
+        df_expected = DataFrame([[datetime(2014, 1, 31),
+                                  datetime(1999, 9, 24)],
+                                 [datetime(1998, 5, 26, 23, 33, 4),
+                                  datetime(2014, 2, 28, 13, 5, 13)]],
+                                index=['DATE', 'DATETIME'], columns=['X', 'Y'])
+
+        with ensure_clean(self.ext) as filename1:
+            with ensure_clean(self.ext) as filename2:
+                writer1 = ExcelWriter(filename1)
+                writer2 = ExcelWriter(filename2, 
+                  date_format='DD.MM.YYYY',
+                  datetime_format='DD.MM.YYYY HH-MM-SS')
+
+                df.to_excel(writer1, 'test1')
+                df.to_excel(writer2, 'test1')
+                
+                writer1.close()
+                writer2.close()
+
+                reader1 = ExcelFile(filename1)
+                reader2 = ExcelFile(filename2)
+                
+                rs1 = reader1.parse('test1', index_col=None)
+                rs2 = reader2.parse('test1', index_col=None)
+               
+                tm.assert_frame_equal(rs1, rs2)
+
+                # since the reader returns a datetime object for dates, we need
+                # to use df_expected to check the result         
+                tm.assert_frame_equal(rs2, df_expected)
 
     def test_to_excel_periodindex(self):
         _skip_if_no_xlrd()


### PR DESCRIPTION
closes #4133

Based on the locale setting the date and datetime values are formatted in
excel exports. Moreover the this behaviour can be overruled by keyword
arguments. Old behavior can be enforced by
ExcelWriter(file, date_format='YYYY-MM-DD', datetime_format='YYYY-MM-DD HH:MM:SS')
