### PR TITLE
BUG: replace with a scalar works like a list of to_replace for compat with 0.12 (GH5319)

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -41,6 +41,10 @@ def is_dictlike(x):
 
 
 def _single_replace(self, to_replace, method, inplace, limit):
+    if self.ndim != 1:
+        raise TypeError('cannot replace {0} with method {1} on a {2}'.format(to_replace,
+                                                                             method,type(self).__name__))
+
     orig_dtype = self.dtype
     result = self if inplace else self.copy()
     fill_f = com._get_fill_func(method)
@@ -2033,6 +2037,11 @@ class NDFrame(PandasObject):
         self._consolidate_inplace()
 
         if value is None:
+            # passing a single value that is scalar like
+            # when value is None (GH5319), for compat
+            if not is_dictlike(to_replace) and not is_dictlike(regex):
+                to_replace = [ to_replace ]
+
             if isinstance(to_replace, (tuple, list)):
                 return _single_replace(self, to_replace, method, inplace,
                                        limit)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -6975,6 +6975,7 @@ class TestDataFrame(unittest.TestCase, CheckIndexing,
         assert_frame_equal(tsframe, self.tsframe.fillna(0))
 
         self.assertRaises(TypeError, self.tsframe.replace, nan, inplace=True)
+        self.assertRaises(TypeError, self.tsframe.replace, nan)
 
         # mixed type
         self.mixed_frame['foo'][5:20] = nan

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -5140,6 +5140,18 @@ class TestSeries(unittest.TestCase, CheckNameIntegration):
         result = ser.replace([0, 1, 2, 3, 4], [4, 3, 2, 1, 0])
         assert_series_equal(result, Series([4, 3, 2, 1, 0]))
 
+        # API change from 0.12?
+        # GH 5319
+        ser = Series([0, np.nan, 2, 3, 4])
+        expected = ser.ffill()
+        result = ser.replace([np.nan])
+        assert_series_equal(result, expected)
+
+        ser = Series([0, np.nan, 2, 3, 4])
+        expected = ser.ffill()
+        result = ser.replace(np.nan)
+        assert_series_equal(result, expected)
+
     def test_replace_with_single_list(self):
         ser = Series([0, 1, 2, 3, 4])
         result = ser.replace([1,2,3])


### PR DESCRIPTION
closes #5319

Essentitally this is `ffill`

```
In [1]: Series([1,np.nan,2]).replace([np.nan])
Out[1]: 
0    1
1    1
2    2
dtype: float64

In [2]: Series([1,np.nan,2]).replace(np.nan)
Out[2]: 
0    1
1    1
2    2
dtype: float64
```

A bit confusing on a Frame, so raise an error

```
In [3]: DataFrame(randn(5,2)).replace(np.nan)
TypeError: cannot replace [nan] with method pad on a DataFrame
```

This was the exception before this PR on a Frame

```
TypeError: If "to_replace" and "value" are both None and "to_replace" is not a list, then regex must be a mapping
```
