### PR TITLE
BUG/API: autocorrelation_plot should accept kwargs

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -61,6 +61,7 @@ API Changes
   - Raise/Warn ``SettingWithCopyError`` (according to the option ``chained_assignment`` in more cases,
     when detecting chained assignment, related (:issue:`5938`)
   - DataFrame.head(0) returns self instead of empty frame (:issue:`5846`)
+  - ``autocorrelation_plot`` now accepts ``**kwargs``. (:issue:`5623`)
 
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -299,6 +299,10 @@ class TestSeriesPlots(tm.TestCase):
         _check_plot_works(autocorrelation_plot, self.ts)
         _check_plot_works(autocorrelation_plot, self.ts.values)
 
+        ax = autocorrelation_plot(self.ts, label='Test')
+        t = ax.get_legend().get_texts()[0].get_text()
+        self.assertEqual(t, 'Test')
+
     @slow
     def test_lag_plot(self):
         from pandas.tools.plotting import lag_plot

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -672,13 +672,15 @@ def lag_plot(series, lag=1, ax=None, **kwds):
     return ax
 
 
-def autocorrelation_plot(series, ax=None):
+def autocorrelation_plot(series, ax=None, **kwds):
     """Autocorrelation plot for time series.
 
     Parameters:
     -----------
     series: Time series
     ax: Matplotlib axis object, optional
+    kwds : keywords
+        Options to pass to matplotlib plotting method
 
     Returns:
     -----------
@@ -705,7 +707,9 @@ def autocorrelation_plot(series, ax=None):
     ax.axhline(y=-z99 / np.sqrt(n), linestyle='--', color='grey')
     ax.set_xlabel("Lag")
     ax.set_ylabel("Autocorrelation")
-    ax.plot(x, y)
+    ax.plot(x, y, **kwds)
+    if 'label' in kwds:
+        ax.legend()
     ax.grid()
     return ax
 


### PR DESCRIPTION
Unless there's a specific reason not to for this plot?  All the others seem to accept them.

``` python
autocorrelation_plot(data, label='ACF')
```

![label_autocorr](https://f.cloud.github.com/assets/1312546/1649385/4cad26d2-59fb-11e3-9d3e-2ccc7c44856e.png)
