### PR TITLE
TST: Always try to close file descriptors of tempfiles

### DIFF
--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -3731,7 +3731,7 @@ class TestHDFStore(tm.TestCase):
 
                 if new_f is None:
                     import tempfile
-                    new_f = tempfile.mkstemp()[1]
+                    fd, new_f = tempfile.mkstemp()
 
                 tstore = store.copy(new_f, keys = keys, propindexes = propindexes, **kwargs)
 
@@ -3757,6 +3757,10 @@ class TestHDFStore(tm.TestCase):
             finally:
                 safe_close(store)
                 safe_close(tstore)
+                try:
+                    os.close(fd)
+                except:
+                    pass
                 safe_remove(new_f)
 
         do_copy()

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -345,17 +345,20 @@ def ensure_clean(filename=None, return_filelike=False):
             yield f
         finally:
             f.close()
-
     else:
-
         # don't generate tempfile if using a path with directory specified
         if len(os.path.dirname(filename)):
             raise ValueError("Can't pass a qualified name to ensure_clean()")
 
         try:
-            filename = tempfile.mkstemp(suffix=filename)[1]
+            fd, filename = tempfile.mkstemp(suffix=filename)
             yield filename
         finally:
+            try:
+                os.close(fd)
+            except Exception as e:
+                print("Couldn't close file descriptor: %d (file: %s)" %
+                    (fd, filename))
             try:
                 if os.path.exists(filename):
                     os.remove(filename)


### PR DESCRIPTION
We weren't closing the file descriptors from `mkstemp`, which caused fun
segmentation faults for me. This should fix the issue.
