### PR TITLE
BUG: scatter_matrix problem, ranges of diagonal and off-diagonal plots are different

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -126,6 +126,8 @@ Bug Fixes
     of pandas in QTConsole, now fixed. If you're using an older version and
     need to supress the warnings, see (:issue:`5922`).
   - Bug in merging ``timedelta`` dtypes (:issue:`5695`)
+  - Bug in plotting.scatter_matrix function. Wrong alignment among diagonal 
+    and off-diagonal plots, see (:issue:`5497`).
 
 pandas 0.13.0
 -------------

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -755,7 +755,7 @@ class TestDataFramePlots(tm.TestCase):
         _check_plot_works(scat, diagonal='kde')
         _check_plot_works(scat, diagonal='density')
         _check_plot_works(scat, diagonal='hist')
-        _check_plot_works(scat, xy_range_extension=.1)
+        _check_plot_works(scat, range_padding=.1)
 
         def scat2(x, y, by=None, ax=None, figsize=None):
             return plt.scatter_plot(df, x, y, by, ax, figsize=None)

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -755,6 +755,7 @@ class TestDataFramePlots(tm.TestCase):
         _check_plot_works(scat, diagonal='kde')
         _check_plot_works(scat, diagonal='density')
         _check_plot_works(scat, diagonal='hist')
+        _check_plot_works(scat, xy_range_extension=.1)
 
         def scat2(x, y, by=None, ax=None, figsize=None):
             return plt.scatter_plot(df, x, y, by, ax, figsize=None)

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -201,29 +201,35 @@ plot_params = _Options()
 
 
 def scatter_matrix(frame, alpha=0.5, figsize=None, ax=None, grid=False,
-                   diagonal='hist', marker='.', density_kwds=None,
-                   hist_kwds=None,
-                   xy_range_extension = .05, **kwds):
+                   diagonal='hist', marker='.', xy_range_extension = .05,
+                   density_kwds=None, hist_kwds=None, **kwds):
     """
     Draw a matrix of scatter plots.
 
     Parameters
     ----------
     frame : DataFrame
-    alpha : amount of transparency applied
-    figsize : a tuple (width, height) in inches
-    ax : Matplotlib axis object
-    grid : setting this to True will show the grid
-    diagonal : pick between 'kde' and 'hist' for
+    alpha : float, optional
+        amount of transparency applied
+    figsize : (float,float), optional
+        a tuple (width, height) in inches
+    ax : Matplotlib axis object, optional
+    grid : bool, optional
+        setting this to True will show the grid
+    diagonal : {'hist', 'kde'}
+        pick between 'kde' and 'hist' for
         either Kernel Density Estimation or Histogram
         plot in the diagonal
-    marker : Matplotlib marker type, default '.'
+    marker : str, optional
+        Matplotlib marker type, default '.'
+    xy_range_extension : float, optional
+        relative extension of axis range in x and y
+        with respect to (x_max - x_min) or (y_max - y_min),
+        default .05
     hist_kwds : other plotting keyword arguments
         To be passed to hist function
     density_kwds : other plotting keyword arguments
-        To be passed to kernel density estimate plot
-    xy_range_extension : percentage of extension of axis range
-        in x and y with respect to x_max - x_min or y_max - y_min    
+        To be passed to kernel density estimate plot    
     kwds : other plotting keyword arguments
         To be passed to scatter function
 
@@ -254,11 +260,11 @@ def scatter_matrix(frame, alpha=0.5, figsize=None, ax=None, grid=False,
     kwds.setdefault('c', plt.rcParams['patch.facecolor'])
 
     boundaries_list = []
-    for i, a in zip(lrange(n), df.columns):
+    for a in df.columns:
         values = df[a].values[mask[a].values]
-        rmin_ , rmax_ = min(values),max(values)
-        rdelta_ext = (rmax_ - rmin_)*xy_range_extension
-        boundaries_list.append((rmin_ - rdelta_ext , rmax_+ rdelta_ext))
+        rmin_, rmax_ = np.min(values), np.max(values)
+        rdelta_ext = (rmax_ - rmin_) * xy_range_extension / 2.
+        boundaries_list.append((rmin_ - rdelta_ext, rmax_+ rdelta_ext))
 
     for i, a in zip(lrange(n), df.columns):
         for j, b in zip(lrange(n), df.columns):
@@ -270,7 +276,7 @@ def scatter_matrix(frame, alpha=0.5, figsize=None, ax=None, grid=False,
                 # Deal with the diagonal by drawing a histogram there.
                 if diagonal == 'hist':
                     ax.hist(values, **hist_kwds)
-                    
+
                 elif diagonal in ('kde', 'density'):
                     from scipy.stats import gaussian_kde
                     y = values
@@ -278,9 +284,8 @@ def scatter_matrix(frame, alpha=0.5, figsize=None, ax=None, grid=False,
                     ind = np.linspace(y.min(), y.max(), 1000)
                     ax.plot(ind, gkde.evaluate(ind), **density_kwds)
 
-
                 ax.set_xlim(boundaries_list[i])
-                
+
             else:
                 common = (mask[a] & mask[b]).values
 

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -201,8 +201,8 @@ plot_params = _Options()
 
 
 def scatter_matrix(frame, alpha=0.5, figsize=None, ax=None, grid=False,
-                   diagonal='hist', marker='.', xy_range_extension = .05,
-                   density_kwds=None, hist_kwds=None, **kwds):
+                   diagonal='hist', marker='.', density_kwds=None,
+                   hist_kwds=None, range_padding=0.05, **kwds):
     """
     Draw a matrix of scatter plots.
 
@@ -221,15 +221,15 @@ def scatter_matrix(frame, alpha=0.5, figsize=None, ax=None, grid=False,
         either Kernel Density Estimation or Histogram
         plot in the diagonal
     marker : str, optional
-        Matplotlib marker type, default '.'
-    xy_range_extension : float, optional
-        relative extension of axis range in x and y
-        with respect to (x_max - x_min) or (y_max - y_min),
-        default .05
+        Matplotlib marker type, default '.'    
     hist_kwds : other plotting keyword arguments
         To be passed to hist function
     density_kwds : other plotting keyword arguments
-        To be passed to kernel density estimate plot    
+        To be passed to kernel density estimate plot
+    range_padding : float, optional
+        relative extension of axis range in x and y
+        with respect to (x_max - x_min) or (y_max - y_min),
+        default 0.05
     kwds : other plotting keyword arguments
         To be passed to scatter function
 
@@ -263,7 +263,7 @@ def scatter_matrix(frame, alpha=0.5, figsize=None, ax=None, grid=False,
     for a in df.columns:
         values = df[a].values[mask[a].values]
         rmin_, rmax_ = np.min(values), np.max(values)
-        rdelta_ext = (rmax_ - rmin_) * xy_range_extension / 2.
+        rdelta_ext = (rmax_ - rmin_) * range_padding / 2.
         boundaries_list.append((rmin_ - rdelta_ext, rmax_+ rdelta_ext))
 
     for i, a in zip(lrange(n), df.columns):


### PR DESCRIPTION
close #5497

**Short story:**

In [this](https://github.com/pydata/pandas/issues/5497) issue I signaled that the x_lim and y_lim in scatter_matrix plots are different. In particular x/y_lim of diagonal hists and x/y_lim of scatter plots are different.  

For instance, this causes peaks nonalignments in the 1-margin and 2-margin of the plotted multivariate pdf. See pictures in the issue.

This is a possible fix.

**Long Story:**
In a `scatter_matrix` plot we have a diagonal constituted by histograms and `scatter_plots` to show correlation among variables in the subplots away from the diagonal.

Let's consider this scatter matrix in which we have two variables `A` and `misfit`
![pict](https://f.cloud.github.com/assets/2300692/1522061/389753b0-4ba1-11e3-97f0-31caab31fcb7.png)

The ranges of `A` and of `misfit` are shown by the axis thicks along the boundary subplots (i.e. plots in the first row and column (starting form the bottom left corner)).

As we can see there is a clear misalignment of the peak among plot 1,2 and plot 2,2. 
This is due to the fact that the plot range for each plot (`xlim`) is determined automatically by matplotlib, hence there is a possible disagreement among different plots. 

In this pull request, the `xlim`s and `ylim`s are forced to be consistent and are calculated as the real ranges of the variables (max - min) plus a given correction (here 5%).  

i.e., for each plot

```
   rdelta_ext = (rmax_ - rmin_)*xy_range_extension  # xy_range_extension defaults 5%
   ax.set_xlim( (rmin_ - rdelta_ext , rmax_+ rdelta_ext)  )
```

This is an example of a `scatter_matrix` obtained with the correction (please compare e.g subplots 1,2 and 2,2 )

![pe_model_radial_const_force](https://f.cloud.github.com/assets/2300692/1782665/5a1afe04-68b3-11e3-89df-51f3884eff91.png)
