### PR TITLE
BUG: Work-around a numpy regression affecting pandas.eval() with numexpr

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -820,6 +820,7 @@ Bug Fixes
   - Bug fix in apply when using custom function and objects are not mutated (:issue:`5545`)
   - Bug in selecting from a non-unique index with ``loc`` (:issue:`5553`)
   - Bug in groupby returning non-consistent types when user function returns a ``None``, (:issue:`5592`)
+  - Work around regression in numpy 1.7.0 which erroneously raises IndexError from ``ndarray.item`` (:issue:`5666`)
 
 pandas 0.12.0
 -------------

--- a/pandas/computation/align.py
+++ b/pandas/computation/align.py
@@ -249,6 +249,9 @@ def _reconstruct_object(typ, obj, axes, dtype):
 
     try:
         ret = ret_value.item()
-    except ValueError:
+    except (ValueError, IndexError):
+        # XXX: we catch IndexError to absorb a
+        # regression in numpy 1.7.0
+        # fixed by numpy/numpy@04b89c63
         ret = ret_value
     return ret


### PR DESCRIPTION
numpy 1.7.0 erroneously raises IndexError instead of ValueError
from ndarray.item() when the array is not of length 1. This can be
seen as a failure of

```
computation.tests.test_eval.TestScope.test_global_scope
```

for the cases that engine='numexpr'.

Absorb the splatter from this regression by explicitly catching the
erroneous IndexError.

closes #5535.
