### PR TITLE
API/ENH: Detect trying to set inplace on copies in a nicer way, related (GH5597)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1677,6 +1677,7 @@ class DataFrame(NDFrame):
             if self._is_mixed_type:
                 result = self.reindex(columns=new_columns)
                 result.columns = result_columns
+                result.is_copy=True
             else:
                 new_values = self.values[:, loc]
                 result = DataFrame(new_values, index=self.index,
@@ -2307,7 +2308,6 @@ class DataFrame(NDFrame):
 
         if inplace:
             frame = self
-
         else:
             frame = self.copy()
 
@@ -2552,8 +2552,8 @@ class DataFrame(NDFrame):
 
         if inplace:
             inds, = (-duplicated).nonzero()
-            self._data = self._data.take(inds)
-            self._clear_item_cache()
+            new_data = self._data.take(inds)
+            self._update_inplace(new_data)
         else:
             return self[-duplicated]
 
@@ -2717,13 +2717,12 @@ class DataFrame(NDFrame):
 
         if inplace:
             if axis == 1:
-                self._data = self._data.reindex_items(
+                new_data = self._data.reindex_items(
                     self._data.items[indexer],
                     copy=False)
             elif axis == 0:
-                self._data = self._data.take(indexer)
-
-            self._clear_item_cache()
+                new_data = self._data.take(indexer)
+            self._update_inplace(new_data)
         else:
             return self.take(indexer, axis=axis, convert=False, is_copy=False)
 
@@ -2763,13 +2762,12 @@ class DataFrame(NDFrame):
 
         if inplace:
             if axis == 1:
-                self._data = self._data.reindex_items(
+                new_data = self._data.reindex_items(
                     self._data.items[indexer],
                     copy=False)
             elif axis == 0:
-                self._data = self._data.take(indexer)
-
-            self._clear_item_cache()
+                new_data = self._data.take(indexer)
+            self._update_inplace(new_data)
         else:
             return self.take(indexer, axis=axis, convert=False, is_copy=False)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1566,11 +1566,14 @@ class DataFrame(NDFrame):
 
                     # a location index by definition
                     i = _maybe_convert_indices(i, len(self._get_axis(axis)))
-                    return self.reindex(i, takeable=True)._setitem_copy(True)
+                    result = self.reindex(i, takeable=True)
+                    copy=True
                 else:
                     new_values, copy = self._data.fast_2d_xs(i, copy=copy)
-                    return Series(new_values, index=self.columns,
-                                  name=self.index[i])._setitem_copy(copy)
+                    result = Series(new_values, index=self.columns,
+                                    name=self.index[i])
+                result.is_copy=copy
+                return result
 
         # icol
         else:
@@ -1677,11 +1680,10 @@ class DataFrame(NDFrame):
             if self._is_mixed_type:
                 result = self.reindex(columns=new_columns)
                 result.columns = result_columns
-                result.is_copy=True
             else:
                 new_values = self.values[:, loc]
                 result = DataFrame(new_values, index=self.index,
-                                   columns=result_columns)
+                                   columns=result_columns).__finalize__(self)
             if len(result.columns) == 1:
                 top = result.columns[0]
                 if ((type(top) == str and top == '') or
@@ -1690,6 +1692,7 @@ class DataFrame(NDFrame):
                     if isinstance(result, Series):
                         result = Series(result, index=self.index, name=key)
 
+            result.is_copy=True
             return result
         else:
             return self._get_item_cache(key)
@@ -2137,7 +2140,8 @@ class DataFrame(NDFrame):
 
             new_values, copy = self._data.fast_2d_xs(loc, copy=copy)
             result = Series(new_values, index=self.columns,
-                            name=self.index[loc])._setitem_copy(copy)
+                            name=self.index[loc])
+            result.is_copy=True
 
         else:
             result = self[loc]

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1022,11 +1022,6 @@ class NDFrame(PandasObject):
         self._data.set(key, value)
         self._clear_item_cache()
 
-    def _setitem_copy(self, copy):
-        """ set the _is_copy of the iiem """
-        self.is_copy = copy
-        return self
-
     def _check_setitem_copy(self, stacklevel=4, t='setting'):
         """ validate if we are doing a settitem on a chained copy.
 
@@ -1115,7 +1110,7 @@ class NDFrame(PandasObject):
 
         # maybe set copy if we didn't actually change the index
         if is_copy and not result._get_axis(axis).equals(self._get_axis(axis)):
-            result = result._setitem_copy(is_copy)
+            result.is_copy=is_copy
 
         return result
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -59,7 +59,7 @@ def _single_replace(self, to_replace, method, inplace, limit):
                        dtype=self.dtype).__finalize__(self)
 
     if inplace:
-        self._data = result._data
+        self._update_inplace(result._data)
         return
 
     return result
@@ -562,9 +562,7 @@ class NDFrame(PandasObject):
             result._clear_item_cache()
 
         if inplace:
-            self._data = result._data
-            self._clear_item_cache()
-
+            self._update_inplace(result._data)
         else:
             return result.__finalize__(self)
 
@@ -994,12 +992,22 @@ class NDFrame(PandasObject):
             if clear, then clear our cache """
         cacher = getattr(self, '_cacher', None)
         if cacher is not None:
-            try:
-                cacher[1]()._maybe_cache_changed(cacher[0], self)
-            except:
+            ref = cacher[1]()
 
-                # our referant is dead
+            # we are trying to reference a dead referant, hence
+            # a copy
+            if ref is None:
                 del self._cacher
+                self.is_copy = True
+                self._check_setitem_copy(stacklevel=5, t='referant')
+            else:
+                try:
+                    ref._maybe_cache_changed(cacher[0], self)
+                except:
+                    pass
+                if ref.is_copy:
+                    self.is_copy = True
+                    self._check_setitem_copy(stacklevel=5, t='referant')
 
         if clear:
             self._clear_item_cache()
@@ -1019,7 +1027,7 @@ class NDFrame(PandasObject):
         self.is_copy = copy
         return self
 
-    def _check_setitem_copy(self, stacklevel=4):
+    def _check_setitem_copy(self, stacklevel=4, t='setting'):
         """ validate if we are doing a settitem on a chained copy.
 
         If you call this function, be sure to set the stacklevel such that the
@@ -1027,9 +1035,13 @@ class NDFrame(PandasObject):
         if self.is_copy:
             value = config.get_option('mode.chained_assignment')
 
-            t = ("A value is trying to be set on a copy of a slice from a "
-                 "DataFrame.\nTry using .loc[row_index,col_indexer] = value "
-                 "instead")
+            if t == 'referant':
+                t = ("A value is trying to be set on a copy of a slice from a "
+                     "DataFrame")
+            else:
+                t = ("A value is trying to be set on a copy of a slice from a "
+                     "DataFrame.\nTry using .loc[row_index,col_indexer] = value "
+                     "instead")
             if value == 'raise':
                 raise SettingWithCopyError(t)
             elif value == 'warn':
@@ -1218,7 +1230,7 @@ class NDFrame(PandasObject):
         # decision that we may revisit in the future.
         self._reset_cache()
         self._clear_item_cache()
-        self._data = result._data
+        self._data = getattr(result,'_data',result)
         self._maybe_update_cacher()
 
     def add_prefix(self, prefix):
@@ -1910,14 +1922,13 @@ class NDFrame(PandasObject):
                         continue
                     obj = result[k]
                     obj.fillna(v, inplace=True)
-                    obj._maybe_update_cacher()
                 return result
             else:
                 new_data = self._data.fillna(value, inplace=inplace,
                                              downcast=downcast)
 
         if inplace:
-            self._data = new_data
+            self._update_inplace(new_data)
         else:
             return self._constructor(new_data).__finalize__(self)
 
@@ -2165,7 +2176,7 @@ class NDFrame(PandasObject):
         new_data = new_data.convert(copy=not inplace, convert_numeric=False)
 
         if inplace:
-            self._data = new_data
+            self._update_inplace(new_data)
         else:
             return self._constructor(new_data).__finalize__(self)
 
@@ -2272,10 +2283,10 @@ class NDFrame(PandasObject):
 
         if inplace:
             if axis == 1:
-                self._data = new_data
+                self._update_inplace(new_data)
                 self = self.T
             else:
-                self._data = new_data
+                self._update_inplace(new_data)
         else:
             res = self._constructor(new_data).__finalize__(self)
         if axis == 1:
@@ -2856,8 +2867,9 @@ class NDFrame(PandasObject):
         if inplace:
             # we may have different type blocks come out of putmask, so
             # reconstruct the block manager
-            self._data = self._data.putmask(cond, other, align=axis is None,
-                                            inplace=True)
+            new_data = self._data.putmask(cond, other, align=axis is None,
+                                          inplace=True)
+            self._update_inplace(new_data)
 
         else:
             new_data = self._data.where(other, cond, align=axis is None,

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -209,7 +209,7 @@ class _NDFrameIndexer(object):
                     labels = _safe_append_to_index(index, key)
                     self.obj._data = self.obj.reindex_axis(labels, i)._data
                     self.obj._maybe_update_cacher(clear=True)
-                    self.obj._setitem_copy(False)
+                    self.obj.is_copy=False
 
                     if isinstance(labels, MultiIndex):
                         self.obj.sortlevel(inplace=True)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -11607,6 +11607,7 @@ starting,ending,measure
         _check_f(data.copy(), f)
 
         # -----Series-----
+        d = data.copy()['c']
 
         # reset_index
         f = lambda x: x.reset_index(inplace=True, drop=True)
@@ -11614,15 +11615,15 @@ starting,ending,measure
 
         # fillna
         f = lambda x: x.fillna(0, inplace=True)
-        _check_f(data.copy()['c'], f)
+        _check_f(d.copy(), f)
 
         # replace
         f = lambda x: x.replace(1, 0, inplace=True)
-        _check_f(data.copy()['c'], f)
+        _check_f(d.copy(), f)
 
         # rename
         f = lambda x: x.rename({1: 'foo'}, inplace=True)
-        _check_f(data.copy()['c'], f)
+        _check_f(d.copy(), f)
 
     def test_isin(self):
         # GH #4211

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -365,7 +365,7 @@ class TestGroupBy(tm.TestCase):
                 return None
             return grp.iloc[0].loc['C']
         result = df.groupby('A').apply(f)
-        e = df.groupby('A').first()['C']
+        e = df.groupby('A').first()['C'].copy()
         e.loc['Pony'] = np.nan
         e.name = None
         assert_series_equal(result,e)

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -1733,9 +1733,9 @@ class TestIndexing(tm.TestCase):
         df.index = index
 
         # setting via chained assignment
-        df.loc[0]['z'].iloc[0] = 1.
-        result = df.loc[(0,0),'z']
-        self.assert_(result == 1)
+        def f():
+            df.loc[0]['z'].iloc[0] = 1.
+        self.assertRaises(com.SettingWithCopyError, f)
 
         # correct setting
         df.loc[(0,0),'z'] = 2
@@ -1890,6 +1890,20 @@ class TestIndexing(tm.TestCase):
         df = DataFrame({'a' : [1]}).dropna()
         self.assert_(df.is_copy is False)
         df['a'] += 1
+
+        # inplace ops
+        # original from: http://stackoverflow.com/questions/20508968/series-fillna-in-a-multiindex-dataframe-does-not-fill-is-this-a-bug
+        a = [12, 23]
+        b = [123, None]
+        c = [1234, 2345]
+        d = [12345, 23456]
+        tuples = [('eyes', 'left'), ('eyes', 'right'), ('ears', 'left'), ('ears', 'right')]
+        events = {('eyes', 'left'): a, ('eyes', 'right'): b, ('ears', 'left'): c, ('ears', 'right'): d}
+        multiind = MultiIndex.from_tuples(tuples, names=['part', 'side'])
+        zed = DataFrame(events, index=['a', 'b'], columns=multiind)
+        def f():
+            zed['eyes']['right'].fillna(value=555, inplace=True)
+        self.assertRaises(com.SettingWithCopyError, f)
 
         pd.set_option('chained_assignment','warn')
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1141,7 +1141,10 @@ Thur,Lunch,Yes,51.51,17"""
         self.assert_(index.lexsort_depth == 0)
 
     def test_frame_getitem_view(self):
-        df = self.frame.T
+        df = self.frame.T.copy()
+
+        # this works because we are modifying the underlying array
+        # really a no-no
         df['foo'].values[:] = 0
         self.assert_((df['foo'].values == 0).all())
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1148,7 +1148,17 @@ Thur,Lunch,Yes,51.51,17"""
         # but not if it's mixed-type
         df['foo', 'four'] = 'foo'
         df = df.sortlevel(0, axis=1)
-        df['foo']['one'] = 2
+
+        # this will work, but will raise/warn as its chained assignment
+        def f():
+            df['foo']['one'] = 2
+            return df
+        self.assertRaises(com.SettingWithCopyError, f)
+
+        try:
+            df = f()
+        except:
+            pass
         self.assert_((df['foo', 'one'] == 0).all())
 
     def test_frame_getitem_not_sorted(self):


### PR DESCRIPTION
related #5597
pretty common error that I have seen, originally from:

http://stackoverflow.com/questions/20508968/series-fillna-in-a-multiindex-dataframe-does-not-fill-is-this-a-bug

```
In [1]: a = [12, 23]

In [2]: b = [123, None]

In [3]: c = [1234, 2345]

In [4]: d = [12345, 23456]

In [5]: tuples = [('eyes', 'left'), ('eyes', 'right'), ('ears', 'left'), ('ears', 'right')]

In [6]: events = {('eyes', 'left'): a, ('eyes', 'right'): b, ('ears', 'left'): c, ('ears', 'right'): d}

In [7]: multiind = pandas.MultiIndex.from_tuples(tuples, names=['part', 'side'])

In [8]: zed = pandas.DataFrame(events, index=['a', 'b'], columns=multiind)
```

Shows a warning (the message is comewhat generic)

```
In [9]: zed['eyes']['right'].fillna(value=555, inplace=True)
/usr/local/bin/ipython:1: SettingWithCopyWarning: A value is trying to be set on a copy of a slice from a DataFrame
  #!/usr/local/bin/python

In [10]: zed
Out[10]: 
part  eyes         ears       
side  left  right  left  right
a       12    123  1234  12345
b       23    NaN  2345  23456

[2 rows x 4 columns]
```

Correct method

```
In [11]: zed.loc[:,('eyes','right')].fillna(value=555, inplace=True)

In [12]: zed
Out[12]: 
part  eyes         ears       
side  left  right  left  right
a       12    123  1234  12345
b       23    555  2345  23456

[2 rows x 4 columns]
```
