### PR TITLE
BUG: Bug in repeated indexing of object with resultant non-unique index (GH5678)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -821,6 +821,7 @@ Bug Fixes
   - Bug in selecting from a non-unique index with ``loc`` (:issue:`5553`)
   - Bug in groupby returning non-consistent types when user function returns a ``None``, (:issue:`5592`)
   - Work around regression in numpy 1.7.0 which erroneously raises IndexError from ``ndarray.item`` (:issue:`5666`)
+  - Bug in repeated indexing of object with resultant non-unique index (:issue:`5678`)
 
 pandas 0.12.0
 -------------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -481,7 +481,10 @@ class Series(generic.NDFrame):
 
     def __getitem__(self, key):
         try:
-            return self.index.get_value(self, key)
+            result = self.index.get_value(self, key)
+            if isinstance(result, np.ndarray):
+                return self._constructor(result,index=[key]*len(result)).__finalize__(self)
+            return result
         except InvalidIndexError:
             pass
         except (KeyError, ValueError):

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -316,6 +316,14 @@ class TestIndexing(tm.TestCase):
     def test_iat_invalid_args(self):
         pass
 
+    def test_repeated_getitem_dups(self):
+        # GH 5678
+        # repeated gettitems on a dup index returing a ndarray
+        df = DataFrame(np.random.random_sample((20,5)), index=['ABCDE'[x%5] for x in range(20)])
+        expected = df.loc['A',0]
+        result = df.loc[:,0].loc['A']
+        assert_series_equal(result,expected)
+
     def test_iloc_getitem_int(self):
 
         # integer


### PR DESCRIPTION
closes #5678
