### PR TITLE
DISP: show column dtype in DataFrame.info() output

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1426,10 +1426,12 @@ class DataFrame(NDFrame):
             if len(cols) != len(counts):  # pragma: no cover
                 raise AssertionError('Columns must equal counts (%d != %d)' %
                                      (len(cols), len(counts)))
+            dtypes = self.dtypes
             for col, count in compat.iteritems(counts):
+                dtype = dtypes[col]
                 col = com.pprint_thing(col)
                 lines.append(_put_str(col, space) +
-                             '%d  non-null values' % count)
+                             '%d non-null %s' % (count, dtype))
         else:
             lines.append(self.columns.summary(name='Columns'))
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -6018,6 +6018,21 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                           columns=['a', 'a', 'b', 'b'])
         frame.info(buf=io)
 
+    def test_info_shows_column_dtypes(self):
+        dtypes = ['int64', 'float64', 'datetime64[ns]', 'timedelta64[ns]',
+                  'complex128', 'object', 'bool']
+        data = {}
+        n = 10
+        for i, dtype in enumerate(dtypes):
+            data[i] = np.random.randint(2, size=n).astype(dtype)
+        df = DataFrame(data)
+        buf = StringIO()
+        df.info(buf=buf)
+        res = buf.getvalue()
+        for i, dtype in enumerate(dtypes):
+            name = '%d    %d non-null %s' % (i, n, dtype)
+            assert name in res
+
     def test_dtypes(self):
         self.mixed_frame['bool'] = self.mixed_frame['A'] > 0
         result = self.mixed_frame.dtypes

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -2741,6 +2741,12 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         self.assertRaises(TypeError, s.fillna, [1, 2])
         self.assertRaises(TypeError, s.fillna, (1, 2))
 
+    def test_raise_on_info(self):
+        s = Series(np.random.randn(10))
+        with tm.assertRaises(AttributeError):
+            s.info()
+
+
 # TimeSeries-specific
 
     def test_fillna(self):


### PR DESCRIPTION
closes #3429.

Old:

```
In [39]: DataFrame(randn(10,2)).info()
<class 'pandas.core.frame.DataFrame'>
Int64Index: 10 entries, 0 to 9
Data columns (total 2 columns):
0    10  non-null values
1    10  non-null values
dtypes: float64(2)
```

New:

```
In [39]: DataFrame(randn(10,2)).info()
<class 'pandas.core.frame.DataFrame'>
Int64Index: 10 entries, 0 to 9
Data columns (total 2 columns):
0    10 non-null float64
1    10 non-null object
dtypes: float64(1), object(1)
```
