### PR TITLE
CLN: add diff to series/dataframe groupby dispatch whitelist

### DIFF
--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -68,7 +68,7 @@ _common_apply_whitelist = frozenset([
     'shift', 'tshift',
     'ffill', 'bfill',
     'pct_change', 'skew',
-    'corr', 'cov',
+    'corr', 'cov', 'diff',
 ]) | _plotting_methods
 
 _series_apply_whitelist = \

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -3270,6 +3270,7 @@ class TestGroupBy(tm.TestCase):
             'plot', 'boxplot', 'hist',
             'median', 'dtypes',
             'corrwith', 'corr', 'cov',
+            'diff',
         ])
         s_whitelist = frozenset([
             'last', 'first',
@@ -3290,6 +3291,7 @@ class TestGroupBy(tm.TestCase):
             'median', 'dtype',
             'corr', 'cov',
             'value_counts',
+            'diff',
         ])
 
         for obj, whitelist in zip((df, s),
@@ -3411,7 +3413,7 @@ class TestGroupBy(tm.TestCase):
             'resample', 'cummin', 'fillna', 'cumsum', 'cumcount',
             'all', 'shift', 'skew', 'bfill', 'irow', 'ffill',
             'take', 'tshift', 'pct_change', 'any', 'mad', 'corr', 'corrwith',
-            'cov', 'dtypes',
+            'cov', 'dtypes', 'diff',
         ])
         self.assertEqual(results, expected)
 


### PR DESCRIPTION
Building on #5480, this PR adds `diff` to the groupby dispatch whitelist.
