### PR TITLE
DOC: DatetimeIndex accepts name param

### DIFF
--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -119,6 +119,8 @@ class DatetimeIndex(Int64Index):
     closed : string or None, default None
         Make the interval closed with respect to the given frequency to
         the 'left', 'right', or both sides (None)
+    name : object
+        Name to be stored in the index
     """
     _join_precedence = 10
 

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1966,6 +1966,11 @@ class TestDatetimeIndex(tm.TestCase):
                           end='2011-01-01', freq='B')
         self.assertRaises(ValueError, DatetimeIndex, periods=10, freq='D')
 
+    def test_constructor_name(self):
+        idx = DatetimeIndex(start='2000-01-01', periods=1, freq='A',
+                            name='TEST')
+        self.assertEquals(idx.name, 'TEST')
+
     def test_comparisons_coverage(self):
         rng = date_range('1/1/2000', periods=10)
 


### PR DESCRIPTION
Just a docstring change to reflect `DatetimeIndex` taking a name parameter. I added a test since it wasn't explicitly tested anywhere.

``` python
In [1]: from pandas import DatetimeIndex

In [2]: idx = DatetimeIndex(start='2000-01-01', periods=1, freq='A', name='TEST')

In [3]: idx.name
Out[3]: 'TEST'
```
