### PR TITLE
BUG: return Series as DataFrame.dtypes/ftypes for empty dataframes

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -65,6 +65,7 @@ API Changes
 - ``select_as_multiple`` will always raise a ``KeyError``, when a key or the selector is not found (:issue:`6177`)
 - ``df['col'] = value`` and ``df.loc[:,'col'] = value`` are now completely equivalent;
   previously the ``.loc`` would not necessarily coerce the dtype of the resultant series (:issue:`6149`)
+- ``dtypes`` and ``ftypes`` now return a series with ``dtype=object`` on empty containers (:issue:`5740`)
 
 
 Experimental Features

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1947,7 +1947,8 @@ class NDFrame(PandasObject):
     def dtypes(self):
         """ Return the dtypes in this object """
         from pandas import Series
-        return Series(self._data.get_dtypes(),index=self._info_axis)
+        return Series(self._data.get_dtypes(), index=self._info_axis,
+                      dtype=np.object_)
 
     @property
     def ftypes(self):
@@ -1956,7 +1957,8 @@ class NDFrame(PandasObject):
         in this object.
         """
         from pandas import Series
-        return Series(self._data.get_ftypes(),index=self._info_axis)
+        return Series(self._data.get_ftypes(), index=self._info_axis,
+                      dtype=np.object_)
 
     def as_blocks(self, columns=None):
         """

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -12164,6 +12164,47 @@ starting,ending,measure
         self.assertEqual(result['b'].dtype, np.float64)
         self.assertEqual(result['c'].dtype, np.float64)
 
+    def test_empty_frame_dtypes_ftypes(self):
+        empty_df = pd.DataFrame()
+        assert_series_equal(empty_df.dtypes, pd.Series(dtype=np.object))
+        assert_series_equal(empty_df.ftypes, pd.Series(dtype=np.object))
+
+        nocols_df = pd.DataFrame(index=[1,2,3])
+        assert_series_equal(nocols_df.dtypes, pd.Series(dtype=np.object))
+        assert_series_equal(nocols_df.ftypes, pd.Series(dtype=np.object))
+
+        norows_df = pd.DataFrame(columns=list("abc"))
+        assert_series_equal(norows_df.dtypes, pd.Series(np.object, index=list("abc")))
+        assert_series_equal(norows_df.ftypes, pd.Series('object:dense', index=list("abc")))
+
+        norows_int_df = pd.DataFrame(columns=list("abc")).astype(np.int32)
+        assert_series_equal(norows_int_df.dtypes, pd.Series(np.dtype('int32'), index=list("abc")))
+        assert_series_equal(norows_int_df.ftypes, pd.Series('int32:dense', index=list("abc")))
+
+        odict = OrderedDict
+        df = pd.DataFrame(odict([('a', 1), ('b', True), ('c', 1.0)]), index=[1, 2, 3])
+        assert_series_equal(df.dtypes, pd.Series(odict([('a', np.int64),
+                                                        ('b', np.bool),
+                                                        ('c', np.float64)])))
+        assert_series_equal(df.ftypes, pd.Series(odict([('a', 'int64:dense'),
+                                                        ('b', 'bool:dense'),
+                                                        ('c', 'float64:dense')])))
+
+        # same but for empty slice of df
+        assert_series_equal(df[:0].dtypes, pd.Series(odict([('a', np.int),
+                                                            ('b', np.bool),
+                                                            ('c', np.float)])))
+        assert_series_equal(df[:0].ftypes, pd.Series(odict([('a', 'int64:dense'),
+                                                            ('b', 'bool:dense'),
+                                                            ('c', 'float64:dense')])))
+
+def skip_if_no_ne(engine='numexpr'):
+    if engine == 'numexpr':
+        try:
+            import numexpr as ne
+        except ImportError:
+            raise nose.SkipTest("cannot query engine numexpr when numexpr not "
+                                "installed")
 
 
 def skip_if_no_pandas_parser(parser):


### PR DESCRIPTION
`DataFrame.dtypes` and `DataFrame.ftypes` values were inconsistent for empty dataframes: 

``` python
In [2]: pd.DataFrame().dtypes
Out[2]: 
Empty DataFrame
Columns: []
Index: []

[0 rows x 0 columns]

In [3]: pd.DataFrame().ftypes
Out[3]: 
Empty DataFrame
Columns: []
Index: []

[0 rows x 0 columns]

In [4]: pd.DataFrame(columns=list("abc")).ftypes
Out[4]: 
a   NaN
b   NaN
c   NaN
dtype: float64

In [5]: pd.DataFrame(columns=list("abc")).dtypes
Out[5]: 
a   NaN
b   NaN
c   NaN
dtype: float64

In [6]: pd.__version__
Out[6]: '0.13.0rc1-92-gf6fd509'

```
