### PR TITLE
BUG: don't lose dtypes when concatenating empty array-likes

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -118,6 +118,7 @@ Bug Fixes
   - Bug in rolling skew/kurtosis when passed a Series with bad data (:issue:`5749`)
   - Bug in scipy ``interpolate`` methods with a datetime index (:issue:`5975`)
   - Bug in NaT comparison if a mixed datetime/np.datetime64 with NaT were passed (:issue:`5968`)
+  - Fixed bug with ``pd.concat`` losing dtype information if all inputs are empty (:issue:`5742`)
 
 pandas 0.13.0
 -------------

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -11909,6 +11909,23 @@ starting,ending,measure
 
                 assert_frame_equal(test, nat_frame)
 
+    def test_concat_empty_dataframe_dtypes(self):
+        df = DataFrame(columns=list("abc"))
+        df['a'] = df['a'].astype(np.bool_)
+        df['b'] = df['b'].astype(np.int32)
+        df['c'] = df['c'].astype(np.float64)
+
+        result = pd.concat([df, df])
+        self.assertEqual(result['a'].dtype, np.bool_)
+        self.assertEqual(result['b'].dtype, np.int32)
+        self.assertEqual(result['c'].dtype, np.float64)
+
+        result = pd.concat([df, df.astype(np.float64)])
+        self.assertEqual(result['a'].dtype, np.object_)
+        self.assertEqual(result['b'].dtype, np.float64)
+        self.assertEqual(result['c'].dtype, np.float64)
+
+
 def skip_if_no_ne(engine='numexpr'):
     if engine == 'numexpr':
         try:

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -5441,6 +5441,15 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # it works!
         result = np.unique(self.ts)
 
+    def test_concat_empty_series_dtypes(self):
+        self.assertEqual(pd.concat([Series(dtype=np.float64)]).dtype, np.float64)
+        self.assertEqual(pd.concat([Series(dtype=np.int8)]).dtype, np.int8)
+        self.assertEqual(pd.concat([Series(dtype=np.bool_)]).dtype, np.bool_)
+
+        self.assertEqual(pd.concat([Series(dtype=np.bool_),
+                                    Series(dtype=np.int32)]).dtype, np.int32)
+
+
 
 class TestSeriesNonUnique(tm.TestCase):
 


### PR DESCRIPTION
I develop an application that does quite a bit of data manipulation. Being aware of `pandas` being functional-but-not-really-heavily-optimized I use it to maintain label consistency and for grouping/merging data, heavy-duty maths is usually done with `numpy` ufuncs. The application contains entities that have no data at the beginning and receive data over their lifetimes. Every once in a while an incoming data chunk will contain no data for a certain entity. Usually it's fine but if the entity was just created the following happens:

``` python
In [1]: pd.__version__ 
Out[1]: '0.13.0rc1-92-gf6fd509'

In [2]: data = pd.Series(dtype=np.float)

In [3]: chunk = pd.Series(dtype=np.float)

In [4]: pd.concat([data, chunk])
Out[4]: Series([], dtype: object)

```

After that ufuncs like `isnan` cease to work on `data.values` since its dtype has changed to `object`. This PR fixes it.
