### PR TITLE
BUG: don't allow an empty dataframe to have scalar assignment succeed (GH5744)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -247,7 +247,7 @@ API Changes
     (:issue:`4390`)
   - allow ``ix/loc`` for Series/DataFrame/Panel to set on any axis even when
     the single-key is not currently contained in the index for that axis
-    (:issue:`2578`, :issue:`5226`, :issue:`5632`, :issue:`5720`)
+    (:issue:`2578`, :issue:`5226`, :issue:`5632`, :issue:`5720`, :issue:`5744`)
   - Default export for ``to_clipboard`` is now csv with a sep of `\t` for
     compat (:issue:`3368`)
   - ``at`` now will enlarge the object inplace (and return the same)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1916,6 +1916,11 @@ class DataFrame(NDFrame):
                                      'Series')
                 self._data.set_axis(1, value.index.copy(), check_axis=False)
 
+            else:
+                raise ValueError('Cannot set a frame with no defined index '
+                                 'and a value that cannot be converted to a '
+                                 'Series')
+
     def _set_item(self, key, value):
         """
         Add series to DataFrame in specified column.

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -1753,13 +1753,26 @@ class TestIndexing(tm.TestCase):
         str(df)
         assert_frame_equal(df,expected)
 
-        # GH5720
+        # GH5720, GH5744
         # don't create rows when empty
         df = DataFrame({"A": [1, 2, 3], "B": [1.2, 4.2, 5.2]})
         y = df[df.A > 5]
-        y['New'] = np.nan
-        expected = DataFrame(columns=['A','B','New'])
-        assert_frame_equal(y, expected)
+        def f():
+            y['New'] = np.nan
+        self.assertRaises(ValueError, f)
+
+        df = DataFrame(columns=['a', 'b', 'c c'])
+        def f():
+            df['d'] = 3
+        self.assertRaises(ValueError, f)
+        assert_series_equal(df['c c'],Series(name='c c',dtype=object))
+
+        # reindex columns is ok
+        df = DataFrame({"A": [1, 2, 3], "B": [1.2, 4.2, 5.2]})
+        y = df[df.A > 5]
+        result = y.reindex(columns=['A','B','C'])
+        expected = DataFrame(columns=['A','B','C'])
+        assert_frame_equal(result,expected)
 
     def test_cache_updating(self):
         # GH 4939, make sure to update the cache on setitem


### PR DESCRIPTION
closes #5744
related #5720

I think this is the correct behavior

```
In [1]: df = pd.DataFrame(columns=['a', 'b', 'c c'])

In [2]: df['d'] = 3
ValueError: Cannot set a frame with no defined index and a value that cannot be converted to a Series

In [3]: df['c c']
Out[3]: Series([], name: c c, dtype: object)
```
