### PR TITLE
API/REGRESS: partial revert of f8b6208675b5b10d73a74f50478fa5e37b43fc02 (GH5720,GH5744)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1916,10 +1916,11 @@ class DataFrame(NDFrame):
                                      'Series')
                 self._data.set_axis(1, value.index.copy(), check_axis=False)
 
+            # we are a scalar
+            # noop
             else:
-                raise ValueError('Cannot set a frame with no defined index '
-                                 'and a value that cannot be converted to a '
-                                 'Series')
+
+                pass
 
     def _set_item(self, key, value):
         """

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -1778,14 +1778,12 @@ class TestIndexing(tm.TestCase):
         # don't create rows when empty
         df = DataFrame({"A": [1, 2, 3], "B": [1.2, 4.2, 5.2]})
         y = df[df.A > 5]
-        def f():
-            y['New'] = np.nan
-        self.assertRaises(ValueError, f)
+        y['New'] = np.nan
+        assert_frame_equal(y,DataFrame(columns=['A','B','New']))
 
         df = DataFrame(columns=['a', 'b', 'c c'])
-        def f():
-            df['d'] = 3
-        self.assertRaises(ValueError, f)
+        df['d'] = 3
+        assert_frame_equal(df,DataFrame(columns=['a','b','c c','d']))
         assert_series_equal(df['c c'],Series(name='c c',dtype=object))
 
         # reindex columns is ok


### PR DESCRIPTION
```
 allow assignment of a column in a frame with a scalar with no index (so adds to the columns),
 instead of raising; this preservers 0.12 behavior
```

related #5720, #5744

going back to 0.12 behavior
effectively can add a column by assigning a scalar to a frame that doesn't have an index
need a more compelling reason to raise here

```
In [4]: df = DataFrame({"A": [1, 2, 3], "B": [1.2, 4.2, 5.2]})

In [5]: y = df[df.A > 5]

In [6]: y
Out[6]: 
Empty DataFrame
Columns: [A, B]
Index: []

[0 rows x 2 columns]

In [7]: y['New'] = np.nan

In [8]: y
Out[8]: 
Empty DataFrame
Columns: [A, B, New]
Index: []

[0 rows x 3 columns]

```
