### PR TITLE
BUG: IndexError on read_csv/read_table when using usecols/names parameters and omitting last column

### DIFF
--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -2037,16 +2037,16 @@ a,b,c
 4,5,6
 7,8,9
 10,11,12"""
-        result = self.read_csv(StringIO(data), names=['b', 'c'],
-                               header=None, usecols=[1, 2])
+        result = self.read_csv(StringIO(data), names=['a', 'b'],
+                               header=None, usecols=[0, 1])
 
         expected = self.read_csv(StringIO(data), names=['a', 'b', 'c'],
                                  header=None)
-        expected = expected[['b', 'c']]
+        expected = expected[['a', 'b']]
         tm.assert_frame_equal(result, expected)
 
         result2 = self.read_csv(StringIO(data), names=['a', 'b', 'c'],
-                                header=None, usecols=['b', 'c'])
+                                header=None, usecols=['a', 'b'])
         tm.assert_frame_equal(result2, result)
 
         # length conflict, passed names and usecols disagree
@@ -2071,7 +2071,6 @@ a,b,c
 7,8,9
 10,11,12\n"""
         tm.assertRaises(Exception, read_csv, StringIO(data), header=0, names=['a', 'b', 'c', 'd'])
-
 
 class TestPythonParser(ParserTests, tm.TestCase):
     def test_negative_skipfooter_raises(self):

--- a/pandas/parser.pyx
+++ b/pandas/parser.pyx
@@ -1135,8 +1135,11 @@ cdef class TextReader:
 
     cdef _get_column_name(self, Py_ssize_t i, Py_ssize_t nused):
         if self.has_usecols and self.names is not None:
-            if len(self.names) == len(self.usecols):
+            if len(self.names) == len(self.usecols) and nused < len(self.names):
                 return self.names[nused]
+            # addresses Issue #5766
+            elif nused >= len(self.names):
+                return None
             else:
                 return self.names[i - self.leading_cols]
         else:


### PR DESCRIPTION
This addresses an issue in read_csv/read_table where there is no header and both usecols and names are assigned but the last column is not included. This caused an IndexError after reaching the last column specified in usecols. Existing test cases for `usecols` were modified to expose and address this specific issue.
#5766
