### PR TITLE
TST: close sparc test failures

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -40,14 +40,17 @@ class AmbiguousIndexError(PandasError, KeyError):
 
 
 _POSSIBLY_CAST_DTYPES = set([np.dtype(t)
-                             for t in ['M8[ns]', 'm8[ns]', 'O', 'int8',
+                             for t in ['M8[ns]', '>M8[ns]', '<M8[ns]',
+                                       'm8[ns]', '>m8[ns]', '<m8[ns]',
+                                       'O', 'int8',
                                        'uint8', 'int16', 'uint16', 'int32',
                                        'uint32', 'int64', 'uint64']])
 
 _NS_DTYPE = np.dtype('M8[ns]')
 _TD_DTYPE = np.dtype('m8[ns]')
 _INT64_DTYPE = np.dtype(np.int64)
-_DATELIKE_DTYPES = set([np.dtype(t) for t in ['M8[ns]', 'm8[ns]']])
+_DATELIKE_DTYPES = set([np.dtype(t) for t in ['M8[ns]', '<M8[ns]', '>M8[ns]',
+                                              'm8[ns]', '<m8[ns]', '>m8[ns]']])
 
 
 # define abstract base classes to enable isinstance type checking on our
@@ -1572,11 +1575,17 @@ def _possibly_cast_to_datetime(value, dtype, coerce=False):
 
             # force the dtype if needed
             if is_datetime64 and dtype != _NS_DTYPE:
-                raise TypeError(
-                    "cannot convert datetimelike to dtype [%s]" % dtype)
+                if dtype.name == 'datetime64[ns]':
+                    dtype = _NS_DTYPE
+                else:
+                    raise TypeError(
+                        "cannot convert datetimelike to dtype [%s]" % dtype)
             elif is_timedelta64 and dtype != _TD_DTYPE:
-                raise TypeError(
-                    "cannot convert timedeltalike to dtype [%s]" % dtype)
+                if dtype.name == 'timedelta64[ns]':
+                    dtype = _TD_DTYPE
+                else:
+                    raise TypeError(
+                        "cannot convert timedeltalike to dtype [%s]" % dtype)
 
             if np.isscalar(value):
                 if value == tslib.iNaT or isnull(value):

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1245,8 +1245,10 @@ class TimeDeltaBlock(IntBlock):
     def _try_coerce_result(self, result):
         """ reverse of try_coerce_args / try_operate """
         if isinstance(result, np.ndarray):
+            mask = isnull(result)
             if result.dtype.kind in ['i', 'f', 'O']:
                 result = result.astype('m8[ns]')
+            result[mask] = tslib.iNaT
         elif isinstance(result, np.integer):
             result = np.timedelta64(result)
         return result

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -14,6 +14,10 @@ import pandas.util.testing as tm
 from pandas.util.misc import is_little_endian
 from pandas import compat
 
+def skip_if_not_little_endian():
+    if not is_little_endian():
+        raise nose.SkipTest("known failure of test on non-little endian")
+
 class TestStata(tm.TestCase):
 
     def setUp(self):
@@ -145,9 +149,7 @@ class TestStata(tm.TestCase):
         tm.assert_frame_equal(parsed_13, expected)
 
     def test_read_write_dta5(self):
-        if not is_little_endian():
-            raise nose.SkipTest("known failure of test_write_dta5 on "
-                                "non-little endian")
+        skip_if_not_little_endian()
 
         original = DataFrame([(np.nan, np.nan, np.nan, np.nan, np.nan)],
                              columns=['float_miss', 'double_miss', 'byte_miss',
@@ -161,9 +163,7 @@ class TestStata(tm.TestCase):
                                   original)
 
     def test_write_dta6(self):
-        if not is_little_endian():
-            raise nose.SkipTest("known failure of test_write_dta6 on "
-                                "non-little endian")
+        skip_if_not_little_endian()
 
         original = self.read_csv(self.csv3)
         original.index.name = 'index'
@@ -193,9 +193,7 @@ class TestStata(tm.TestCase):
         tm.assert_frame_equal(parsed, expected)
 
     def test_read_write_dta10(self):
-        if not is_little_endian():
-            raise nose.SkipTest("known failure of test_write_dta10 on "
-                                "non-little endian")
+        skip_if_not_little_endian()
 
         original = DataFrame(data=[["string", "object", 1, 1.1,
                                     np.datetime64('2003-12-25')]],
@@ -232,6 +230,8 @@ class TestStata(tm.TestCase):
             self.assert_(isinstance(result, unicode))
 
     def test_read_write_dta11(self):
+        skip_if_not_little_endian()
+
         original = DataFrame([(1, 2, 3, 4)],
                              columns=['good', compat.u('b\u00E4d'), '8number', 'astringwithmorethan32characters______'])
         formatted = DataFrame([(1, 2, 3, 4)],
@@ -248,6 +248,8 @@ class TestStata(tm.TestCase):
             tm.assert_frame_equal(written_and_read_again.set_index('index'), formatted)
 
     def test_read_write_dta12(self):
+        skip_if_not_little_endian()
+
         original = DataFrame([(1, 2, 3, 4)],
                              columns=['astringwithmorethan32characters_1', 'astringwithmorethan32characters_2', '+', '-'])
         formatted = DataFrame([(1, 2, 3, 4)],


### PR DESCRIPTION
TST: closes #5778, failing tests on non-little endian for stata (spac)
TST: closes #5779, big endian compensation for datelike dtypes
