### PR TITLE
Add idxmax/idxmin to groupby dispatch whitelist (#5786)

### DIFF
--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -65,6 +65,7 @@ _common_apply_whitelist = frozenset([
     'mad',
     'any', 'all',
     'irow', 'take',
+    'idxmax', 'idxmin',
     'shift', 'tshift',
     'ffill', 'bfill',
     'pct_change', 'skew',

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -3264,6 +3264,7 @@ class TestGroupBy(tm.TestCase):
             'mad',
             'any', 'all',
             'irow', 'take',
+            'idxmax', 'idxmin',
             'shift', 'tshift',
             'ffill', 'bfill',
             'pct_change', 'skew',
@@ -3284,6 +3285,7 @@ class TestGroupBy(tm.TestCase):
             'mad',
             'any', 'all',
             'irow', 'take',
+            'idxmax', 'idxmin',
             'shift', 'tshift',
             'ffill', 'bfill',
             'pct_change', 'skew',
@@ -3413,7 +3415,7 @@ class TestGroupBy(tm.TestCase):
             'resample', 'cummin', 'fillna', 'cumsum', 'cumcount',
             'all', 'shift', 'skew', 'bfill', 'irow', 'ffill',
             'take', 'tshift', 'pct_change', 'any', 'mad', 'corr', 'corrwith',
-            'cov', 'dtypes', 'diff',
+            'cov', 'dtypes', 'diff', 'idxmax', 'idxmin'
         ])
         self.assertEqual(results, expected)
 


### PR DESCRIPTION
Closes #5786.
