### PR TITLE
DOC: fix minor doc build warnings

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -248,7 +248,7 @@ API Changes
   - allow ``ix/loc`` for Series/DataFrame/Panel to set on any axis even when
     the single-key is not currently contained in the index for that axis
     (:issue:`2578`, :issue:`5226`, :issue:`5632`, :issue:`5720`,
-     :issue:`5744`, :issue:`5756`)
+    :issue:`5744`, :issue:`5756`)
   - Default export for ``to_clipboard`` is now csv with a sep of `\t` for
     compat (:issue:`3368`)
   - ``at`` now will enlarge the object inplace (and return the same)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1852,7 +1852,7 @@ class NDFrame(PandasObject):
         limit : int, default None
             Maximum size gap to forward or backward fill
         downcast : dict, default is None
-             a dict of item->dtype of what to downcast if possible,
+            a dict of item->dtype of what to downcast if possible,
             or the string 'infer' which will try to downcast to an appropriate
             equal type (e.g. float64 to int64 if possible)
 


### PR DESCRIPTION
Two minor space-errors which caused a doc build warning.
