### PR TITLE
PERF: fix infer_dtype to properly infer a Series (GH5801)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -64,6 +64,8 @@ Experimental Features
 Improvements to existing features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+  - perf improvements in Series datetime/timedelta binary operations (:issue:`5801`)
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/pandas/src/inference.pyx
+++ b/pandas/src/inference.pyx
@@ -35,6 +35,8 @@ def infer_dtype(object _values):
 
     if isinstance(_values, np.ndarray):
         values = _values
+    elif hasattr(_values,'values'):
+        values = _values.values
     else:
         if not isinstance(_values, list):
             _values = list(_values)

--- a/vb_suite/binary_ops.py
+++ b/vb_suite/binary_ops.py
@@ -103,6 +103,9 @@ frame_multi_and_no_ne = \
     Benchmark("df[(df>0) & (df2>0)]", setup, name='frame_multi_and_no_ne',cleanup="expr.set_use_numexpr(True)",
               start_date=datetime(2013, 2, 26))
 
+#----------------------------------------------------------------------
+# timeseries
+
 setup = common_setup + """
 N = 1000000
 halfway = N // 2 - 1
@@ -114,3 +117,13 @@ timestamp_series_compare = Benchmark("ts >= s", setup,
                                      start_date=datetime(2013, 9, 27))
 series_timestamp_compare = Benchmark("s <= ts", setup,
                                      start_date=datetime(2012, 2, 21))
+
+setup = common_setup + """
+N = 1000000
+s = Series(date_range('20010101', periods=N, freq='s'))
+"""
+
+timestamp_ops_diff1 = Benchmark("s.diff()", setup,
+                                start_date=datetime(2013, 1, 1))
+timestamp_ops_diff2 = Benchmark("s-s.shift()", setup,
+                                start_date=datetime(2013, 1, 1))


### PR DESCRIPTION
closes #5801

```
------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
timestamp_ops_diff2                          |  21.7124 | 2472.3583 |   0.0088 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234
```

really though this was in their before....oh well
