### PR TITLE
BUG: Series replace values using timestamps in a dict GH5797

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -71,7 +71,7 @@ Improvements to existing features
 
 Bug Fixes
 ~~~~~~~~~
-
+  - Bug in Series replace with timestamp dict (:issue:`5797`)
 
 pandas 0.13.0
 -------------
@@ -861,7 +861,7 @@ Bug Fixes
   - Bug in fillna with Series and a passed series/dict (:issue:`5703`)
   - Bug in groupby transform with a datetime-like grouper (:issue:`5712`)
   - Bug in multi-index selection in PY3 when using certain keys (:issue:`5725`)
-  - Row-wise concat of differeing dtypes failing in certain cases (:issue:`5754`)
+  - Row-wise concat of differing dtypes failing in certain cases (:issue:`5754`)
 
 pandas 0.12.0
 -------------

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2322,7 +2322,7 @@ class BlockManager(PandasObject):
         def comp(s):
             if isnull(s):
                 return isnull(values)
-            return values == s
+            return values == getattr(s, 'asm8', s)
         masks = [comp(s) for i, s in enumerate(src_lst)]
 
         result_blocks = []

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -5189,6 +5189,16 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         expected = ser.ffill()
         result = ser.replace(np.nan)
         assert_series_equal(result, expected)
+        #GH 5797
+        ser = Series(date_range('20130101', periods=5))
+        expected = ser.copy()
+        expected.loc[2] = Timestamp('20120101')
+        result = ser.replace({Timestamp('20130103'):
+                              Timestamp('20120101')})
+        assert_series_equal(result, expected)
+        result = ser.replace(Timestamp('20130103'), Timestamp('20120101'))
+        assert_series_equal(result, expected)
+
 
     def test_replace_with_single_list(self):
         ser = Series([0, 1, 2, 3, 4])


### PR DESCRIPTION
This fixes issue #5797.
