### PR TITLE
DOC: add way to document DatetimeIndex field attributes

### DIFF
--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -36,7 +36,7 @@ def _utc():
 # -------- some conversion wrapper functions
 
 
-def _field_accessor(name, field):
+def _field_accessor(name, field, docstring=None):
     def f(self):
         values = self.asi8
         if self.tz is not None:
@@ -45,6 +45,7 @@ def _field_accessor(name, field):
                 values = self._local_timestamps()
         return tslib.get_date_field(values, field)
     f.__name__ = name
+    f.__doc__ = docstring
     return property(f)
 
 
@@ -1398,7 +1399,7 @@ class DatetimeIndex(Int64Index):
         return self.offset.freqstr
 
     year = _field_accessor('year', 'Y')
-    month = _field_accessor('month', 'M')
+    month = _field_accessor('month', 'M', "The month as January=1, December=12")
     day = _field_accessor('day', 'D')
     hour = _field_accessor('hour', 'h')
     minute = _field_accessor('minute', 'm')
@@ -1407,7 +1408,8 @@ class DatetimeIndex(Int64Index):
     nanosecond = _field_accessor('nanosecond', 'ns')
     weekofyear = _field_accessor('weekofyear', 'woy')
     week = weekofyear
-    dayofweek = _field_accessor('dayofweek', 'dow')
+    dayofweek = _field_accessor('dayofweek', 'dow', 
+                                "The day of the week with Monday=0, Sunday=6")
     weekday = dayofweek
     dayofyear = _field_accessor('dayofyear', 'doy')
     quarter = _field_accessor('quarter', 'q')


### PR DESCRIPTION
Ping @rockg. The docstring is now listed in the autosummary table in api.rst.

Related to issue #5813 (but does not closes it, this only documents the DatetimeIndex field in the api.rst, not more general the Timestamp values).

I added the attribute docstring within the `_field_accessor` function. Is this a good approach? 
You can also document attributes with a docstring line beneath the definition (see Sphinx docs: http://sphinx-doc.org/ext/autodoc.html#directive-autoattribute). The problem with this is that, for the moment, this works for the sphinx autodoc (so the generated pages), but not for the autosummary (there is an open PR for this: https://bitbucket.org/birkenfeld/sphinx/pull-request/142/make-autosummary-work-with-module-class/diff).
