### PR TITLE
PERF: perf issue with dropna on frame

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -67,6 +67,7 @@ Improvements to existing features
   - perf improvements in Series datetime/timedelta binary operations (:issue:`5801`)
   - `option_context` context manager now available as top-level API (:issue:`5752`)
   - df.info() view now display dtype info per column (:issue: `5682`)
+  - perf improvements in DataFrame ``count/dropna`` for ``axis=1``
 
 Bug Fixes
 ~~~~~~~~~

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3952,7 +3952,7 @@ class DataFrame(NDFrame):
                 counts = notnull(frame.values).sum(1)
                 result = Series(counts, index=frame._get_agg_axis(axis))
             else:
-                result = DataFrame.apply(frame, Series.count, axis=axis)
+                result = notnull(frame).sum(axis=axis)
 
         return result
 

--- a/vb_suite/frame_methods.py
+++ b/vb_suite/frame_methods.py
@@ -289,6 +289,33 @@ df = DataFrame(data)
 frame_isnull  = Benchmark('isnull(df)', setup,
                            start_date=datetime(2012,1,1))
 
+## dropna
+setup = common_setup + """
+data = np.random.randn(10000, 1000)
+df = DataFrame(data)
+df.ix[50:1000,20:50] = np.nan
+df.ix[2000:3000] = np.nan
+df.ix[:,60:70] = np.nan
+"""
+frame_dropna_axis0_any  = Benchmark('df.dropna(how="any",axis=0)', setup,
+                                     start_date=datetime(2012,1,1))
+frame_dropna_axis0_all  = Benchmark('df.dropna(how="all",axis=0)', setup,
+                                     start_date=datetime(2012,1,1))
+
+setup = common_setup + """
+data = np.random.randn(10000, 1000)
+df = DataFrame(data)
+df.ix[50:1000,20:50] = np.nan
+df.ix[2000:3000] = np.nan
+df.ix[:,60:70] = np.nan
+"""
+frame_dropna_axis1_any  = Benchmark('df.dropna(how="any",axis=1)', setup,
+                                    start_date=datetime(2012,1,1))
+
+frame_dropna_axis1_all  = Benchmark('df.dropna(how="all",axis=1)', setup,
+                                    start_date=datetime(2012,1,1))
+
+
 #----------------------------------------------------------------------
 # apply
 
@@ -298,3 +325,4 @@ df = DataFrame({ i:s for i in range(1028) })
 """
 frame_apply_user_func = Benchmark('df.apply(lambda x: np.corrcoef(x,s)[0,1])', setup,
                            start_date=datetime(2012,1,1))
+


### PR DESCRIPTION
took out the apply on `count` and just compute directly

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
frame_dropna_axis1_any                       | 147.5154 | 334.2137 |   0.4414 |
frame_dropna_axis1_all                       | 251.1443 | 437.9021 |   0.5735 |
frame_dropna_axis0_all                       |  80.6900 |  80.8613 |   0.9979 |
frame_dropna_axis0_any                       |  58.6040 |  54.6887 |   1.0716 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [c6e300d] : PERF: perf issue with dropna on frame
Base   [5e176a9] : Merge pull request #5738 from y-p/PR_json_pr_ver

BLD: ci/print_versions.py learned to output json

```
