### PR TITLE
BUG: Fix DatetimeIndex.insert() with strings.

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -73,6 +73,7 @@ Bug Fixes
 ~~~~~~~~~
   - Bug in Series replace with timestamp dict (:issue:`5797`)
   - read_csv/read_table now respects the `prefix` kwarg (:issue:`5732`).
+  - Bug with insert of strings into DatetimeIndex (:issue:`5818`, :issue:`5819`)
 
 pandas 0.13.0
 -------------

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1455,7 +1455,6 @@ def _safe_append_to_index(index, key):
 
         # raise here as this is basically an unsafe operation and we want
         # it to be obvious that you are doing something wrong
-
         raise ValueError("unsafe appending to index of type {0} with a key "
                          "{1}".format(index.__class__.__name__, key))
 

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -1084,8 +1084,10 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
 
     def test_set_value(self):
 
-        # this is invalid because it is not a valid type for this index
-        self.assertRaises(ValueError, self.frame.set_value, 'foobar', 'B', 1.5)
+        # ok as the index gets conver to object
+        frame = self.frame.copy()
+        res = frame.set_value('foobar', 'B', 1.5)
+        self.assert_(res.index.dtype == 'object')
 
         res = self.frame
         res.index = res.index.astype(object)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -10897,6 +10897,19 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                                 ['a', 'mean', 'median', 'mean']])
         assert_frame_equal(rs, xp)
 
+    def test_reset_index_with_datetimeindex_cols(self):
+        # GH5818
+        #
+        df = pd.DataFrame([[1, 2], [3, 4]],
+                          columns=pd.date_range('1/1/2013', '1/2/2013'),
+                          index=['A', 'B'])
+
+        result = df.reset_index()
+        expected = pd.DataFrame([['A', 1, 2], ['B', 3, 4]],
+                          columns=['index', datetime(2013, 1, 1),
+                                   datetime(2013, 1, 2)])
+        assert_frame_equal(result, expected)
+
     #----------------------------------------------------------------------
     # Tests to cope with refactored internals
     def test_as_matrix_numeric_cols(self):

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -1665,14 +1665,12 @@ class TestIndexing(tm.TestCase):
 
         df = tm.makeTimeDataFrame()
 
+        # don't allow not string inserts
         def f():
             df.loc[100.0, :] = df.ix[0]
         self.assertRaises(ValueError, f)
         def f():
             df.loc[100,:] = df.ix[0]
-        self.assertRaises(ValueError, f)
-        def f():
-            df.loc['a',:] = df.ix[0]
         self.assertRaises(ValueError, f)
 
         def f():
@@ -1681,6 +1679,9 @@ class TestIndexing(tm.TestCase):
         def f():
             df.ix[100,:] = df.ix[0]
         self.assertRaises(ValueError, f)
+
+        # allow object conversion here
+        df.loc['a',:] = df.ix[0]
 
     def test_partial_set_empty(self):
 

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1548,9 +1548,11 @@ class DatetimeIndex(Int64Index):
                                     self[loc:].asi8))
             return DatetimeIndex(new_index, freq='infer')
         except (AttributeError, TypeError):
-            # fall back to object index
-            return self.asobject.insert(loc, item)
 
+            # fall back to object index
+            if isinstance(item,compat.string_types):
+                return self.asobject.insert(loc, item)
+            raise TypeError("cannot insert DatetimeIndex with incompatible label")
 
     def delete(self, loc):
         """
@@ -1591,7 +1593,7 @@ class DatetimeIndex(Int64Index):
     def tz_localize(self, tz, infer_dst=False):
         """
         Localize tz-naive DatetimeIndex to given time zone (using pytz)
-       
+
         Parameters
         ----------
         tz : string or pytz.timezone

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -2099,6 +2099,13 @@ class TestDatetimeIndex(tm.TestCase):
                              '2000-01-02'])
         self.assert_(result.equals(exp))
 
+        # insertion of non-datetime should coerce to object index
+        result = idx.insert(1, 'inserted')
+        expected = Index([datetime(2000, 1, 4), 'inserted', datetime(2000, 1, 1),
+                          datetime(2000, 1, 2)])
+        self.assert_(not isinstance(result, DatetimeIndex))
+        tm.assert_index_equal(result, expected)
+
         idx = date_range('1/1/2000', periods=3, freq='M')
         result = idx.insert(3, datetime(2000, 4, 30))
         self.assert_(result.freqstr == 'M')


### PR DESCRIPTION
Falls back to object Index instead. (previously wasn't checking for them), but _only_ strings are allowed.

Fixes #5818.
