### PR TITLE
Add pandas cookbook to tutorials (for #5837)

### DIFF
--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -16,3 +16,43 @@ More complex recipes are in the :ref:`Cookbook<cookbook>`
 Tutorials
 ---------
 
+
+Pandas Cookbook
+---------------
+
+The goal of this cookbook (by `Julia Evans <http://jvns.ca>`_) is to
+give you some concrete examples for getting started with pandas. These
+are examples with real-world data, and all the bugs and weirdness that
+that entails.
+
+Here are links to the v0.1 release. For an up-to-date table of contents, see the `pandas-cookbook GitHub
+repository <http://github.com/jvns/pandas-cookbook>`_.
+
+*  | `A quick tour of the IPython
+     Notebook <http://nbviewer.ipython.org/github/jvns/pandas-c|%2055ookbook/blob/v0.1/cookbook/A%20quick%20tour%20of%20IPython%20Notebook.ipynb>`_
+   |  Shows off IPython's awesome tab completion and magic functions.
+*  | `Chapter 1: <http://nbviewer.ipython.org/github/jvns/pandas-cookbook/blob/v0.1/cookbook/Chapter%201%20-%20Reading%20from%20a%20CSV.ipynb>`_
+      Reading your data into pandas is pretty much the easiest thing. Even
+     when the encoding is wrong!
+*  | `Chapter 2: <http://nbviewer.ipython.org/github/jvns/pandas-cookbook/blob/v0.1/cookbook/Chapter%202%20-%20Selecting%20data%20&%20finding%20the%20most%20common%20complaint%20type.ipynb>`_
+     It's not totally obvious how to select data from a pandas dataframe.
+     Here we explain the basics (how to take slices and get columns)
+*  | `Chapter 3: <http://nbviewer.ipython.org/github/jvns/pandas-cookbook/blob/v0.1/cookbook/Chapter%203%20-%20Which%20borough%20has%20the%20most%20noise%20complaints%3F%20%28or%2C%20more%20selecting%20data%29.ipynb>`_
+    Here we get into serious slicing and dicing and learn how to filter
+     dataframes in complicated ways, really fast.
+*  | `Chapter 4: <http://nbviewer.ipython.org/github/jvns/pandas-cookbook/blob/v0.1/cookbook/Chapter%204%20-%20Find%20out%20on%20which%20weekday%20people%20bike%20the%20most%20with%20groupby%20and%20aggregate.ipynb>`_
+      Groupby/aggregate is seriously my favorite thing about pandas
+     and I use it all the time. You should probably read this.
+*  | `Chapter 5:  <http://nbviewer.ipython.org/github/jvns/pandas-cookbook/blob/v0.1/cookbook/Chapter%205%20-%20Combining%20dataframes%20and%20scraping%20Canadian%20weather%20data.ipynb>`_
+     Here you get to find out if it's cold in Montreal in the winter
+     (spoiler: yes). Web scraping with pandas is fun! Here we combine dataframes.
+*  | `Chapter 6:  <http://nbviewer.ipython.org/github/jvns/pandas-cookbook/blob/v0.1/cookbook/Chapter%206%20-%20String%20operations%21%20Which%20month%20was%20the%20snowiest%3F.ipynb>`_
+      Strings with pandas are great. It has all these vectorized string
+     operations and they're the best. We will turn a bunch of strings
+     containing "Snow" into vectors of numbers in a trice.
+*  | `Chapter 7: <http://nbviewer.ipython.org/github/jvns/pandas-cookbook/blob/v0.1/cookbook/Chapter%207%20-%20Cleaning%20up%20messy%20data.ipynb>`_
+      Cleaning up messy data is never a joy, but with pandas it's easier.
+*  | `Chapter 8:  <http://nbviewer.ipython.org/github/jvns/pandas-cookbook/blob/v0.1/cookbook/Chapter%208%20-%20How%20to%20deal%20with%20timestamps.ipynb>`_
+      Parsing Unix timestamps is confusing at first but it turns out
+      to be really easy.
+


### PR DESCRIPTION
@jreback asked me to add something like this in https://github.com/jvns/pandas-cookbook/issues/1

I haven't been able to test that this displays correctly as I can't figure out how to build the Sphinx docs.

If someone can tell me how to build the docs, I can test it.

```
bork@kiwi ~/c/p/pandas> pwd
/home/bork/clones/pandas/pandas
bork@kiwi ~/c/p/pandas> python ../doc/make.py html
Error: Cannot find source directory.
Building HTML failed
```

```
bork@kiwi ~/c/p/doc> pwd
/home/bork/clones/pandas/doc
bork@kiwi ~/c/p/doc> python make.py html
Running Sphinx v1.1.3
cannot import name hashtable
Exception occurred while building, starting debugger:
Traceback (most recent call last):
  File "/opt/anaconda/lib/python2.7/site-packages/sphinx/cmdline.py", line 188, in main
    warningiserror, tags)
  File "/opt/anaconda/lib/python2.7/site-packages/sphinx/application.py", line 102, in __init__
    confoverrides or {}, self.tags)
  File "/opt/anaconda/lib/python2.7/site-packages/sphinx/config.py", line 216, in __init__
    exec code in config
  File "/home/bork/clones/pandas/doc/source/conf.py", line 74, in <module>
    import pandas
  File "/home/bork/clones/pandas/pandas/__init__.py", line 6, in <module>
    from . import hashtable, tslib, lib
ImportError: cannot import name hashtable
> /home/bork/clones/pandas/pandas/__init__.py(6)<module>()
-> from . import hashtable, tslib, lib
```
