### PR TITLE
ENH: Improve error message for PeriodIndex to infer_freq. Closes #5841.

### DIFF
--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -358,7 +358,7 @@ def get_offset(name):
     else:
         if name in _rule_aliases:
             name = _rule_aliases[name]
-            
+
     if name not in _offset_map:
         try:
             # generate and cache offset
@@ -625,7 +625,7 @@ def _period_str_to_code(freqstr):
             alias = _period_alias_dict[freqstr]
         except KeyError:
             raise ValueError("Unknown freqstr: %s" % freqstr)
-        
+
         return _period_code_map[alias]
 
 
@@ -647,6 +647,10 @@ def infer_freq(index, warn=True):
     from pandas.tseries.index import DatetimeIndex
 
     if not isinstance(index, DatetimeIndex):
+        from pandas.tseries.period import PeriodIndex
+        if isinstance(index, PeriodIndex):
+            raise ValueError("PeriodIndex given. Check the `freq` attribute "
+                             "instead of using infer_freq.")
         index = DatetimeIndex(index)
 
     inferer = _FrequencyInferer(index, warn=warn)
@@ -850,7 +854,7 @@ class _FrequencyInferer(object):
         weekdays = unique(self.index.weekday)
         if len(weekdays) > 1:
             return None
-        
+
         week_of_months = unique((self.index.day - 1) // 7)
         if len(week_of_months) > 1:
             return None

--- a/pandas/tseries/tests/test_frequencies.py
+++ b/pandas/tseries/tests/test_frequencies.py
@@ -13,6 +13,7 @@ from pandas.tseries.frequencies import to_offset, infer_freq
 from pandas.tseries.tools import to_datetime
 import pandas.tseries.frequencies as fmod
 import pandas.tseries.offsets as offsets
+from pandas.tseries.period import PeriodIndex
 
 import pandas.lib as lib
 
@@ -87,6 +88,10 @@ _dti = DatetimeIndex
 
 
 class TestFrequencyInference(tm.TestCase):
+
+    def test_raise_if_period_index(self):
+        index = PeriodIndex(start="1/1/1990", periods=20, freq="M")
+        self.assertRaises(ValueError, infer_freq, index)
 
     def test_raise_if_too_few(self):
         index = _dti(['12/31/1998', '1/3/1999'])


### PR DESCRIPTION
closes #5841. I'm still not sure we shouldn't just return `freq` if a PeriodIndex is given. Seems easy enough.
