### PR TITLE
BUG: tail raises on empty DataFrame

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -90,6 +90,8 @@ Bug Fixes
   - Bug in ``BusinessDay`` when adding n days to a date not on offset when n>5 and n%5==0 (:issue:`5890`)
   - Bug in assigning to chained series with a series via ix (:issue:`5928`)
   - Bug in creating an empty DataFrame, copying, then assigning (:issue:`5932`)
+  - Bug in DataFrame.tail with empty frame (:issue:`5846`)
+  - DataFrame.head(0) returns self instead of empty frame (:issue:`5846`)
 
 pandas 0.13.0
 -------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1570,8 +1570,12 @@ class NDFrame(PandasObject):
         Returns first n rows
         """
         l = len(self)
-        if abs(n) > l:
-            n = l if n > 0 else -l
+        if l == 0 or n==0:
+            return self
+        if n > l:
+            n = l
+        elif n < -l:
+            n = -l
         return self.iloc[:n]
 
     def tail(self, n=5):
@@ -1579,8 +1583,12 @@ class NDFrame(PandasObject):
         Returns last n rows
         """
         l = len(self)
-        if abs(n) > l:
-            n = l if n > 0 else -l
+        if l == 0 or n == 0:
+            return self
+        if n > l:
+            n = l
+        elif n < -l:
+            n = -l
         return self.iloc[-n:]
 
     #----------------------------------------------------------------------

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4259,12 +4259,25 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
     def test_head_tail(self):
         assert_frame_equal(self.frame.head(), self.frame[:5])
         assert_frame_equal(self.frame.tail(), self.frame[-5:])
-
+        assert_frame_equal(self.frame.head(0), self.frame)
+        assert_frame_equal(self.frame.tail(0), self.frame)
+        assert_frame_equal(self.frame.head(-1), self.frame[:-1])
+        assert_frame_equal(self.frame.tail(-1), self.frame[1:])
+        assert_frame_equal(self.frame.head(1), self.frame[:1])
+        assert_frame_equal(self.frame.tail(1), self.frame[-1:])
         # with a float index
         df = self.frame.copy()
         df.index = np.arange(len(self.frame)) + 0.1
         assert_frame_equal(df.head(), df.iloc[:5])
         assert_frame_equal(df.tail(), df.iloc[-5:])
+        assert_frame_equal(df.head(0), df)
+        assert_frame_equal(df.tail(0), df)
+        assert_frame_equal(df.head(-1), df.iloc[:-1])
+        assert_frame_equal(df.tail(-1), df.iloc[1:])
+        #test empty dataframe
+        empty_df = DataFrame()
+        assert_frame_equal(empty_df.tail(), empty_df)
+        assert_frame_equal(empty_df.head(), empty_df)
 
     def test_insert(self):
         df = DataFrame(np.random.randn(5, 3), index=np.arange(5),

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -338,7 +338,7 @@ class Generic(object):
             self._compare(o.tail(), o.iloc[-5:])
 
             # 0-len
-            self._compare(o.head(0), o.iloc[:0])
+            self._compare(o.head(0), o.iloc[:])
             self._compare(o.tail(0), o.iloc[0:])
 
             # bounded


### PR DESCRIPTION
closes #5846

calling tail on an empty frame threw an exception.   In addition, df.tail(0) returns self without indexing.  
