### PR TITLE
ENH: Refactor code to add is_view method for Series.

### DIFF
--- a/doc/source/v0.13.1.txt
+++ b/doc/source/v0.13.1.txt
@@ -29,6 +29,8 @@ Deprecations
 Enhancements
 ~~~~~~~~~~~~
 
+Added an ``is_view`` method to Series.
+
 Experimental
 ~~~~~~~~~~~~
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1645,6 +1645,20 @@ class Series(generic.NDFrame):
     #----------------------------------------------------------------------
     # Reindexing, sorting
 
+    def is_view(self):
+        """
+        Return True if series is a view of some other array, False otherwise.
+        """
+        true_base = self.values
+        while true_base.base is not None:
+            true_base = true_base.base
+
+        if (true_base is not None and
+                (true_base.ndim != 1 or true_base.shape != self.shape)):
+            return True
+        return False
+
+
     def sort(self, axis=0, kind='quicksort', order=None, ascending=True):
         """
         Sort values and index labels by value, in place. For compatibility with
@@ -1667,12 +1681,7 @@ class Series(generic.NDFrame):
         sortedSeries = self.order(na_last=True, kind=kind,
                                   ascending=ascending)
 
-        true_base = self.values
-        while true_base.base is not None:
-            true_base = true_base.base
-
-        if (true_base is not None and
-                (true_base.ndim != 1 or true_base.shape != self.shape)):
+        if self.is_view():
             raise TypeError('This Series is a view of some other array, to '
                             'sort in-place you must create a copy')
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -5548,6 +5548,13 @@ class TestSeriesNonUnique(tm.TestCase):
         # it works! #1807
         Series(Series(["a", "c", "b"]).unique()).sort()
 
+def test_is_view():
+    df = tm.makeDataFrame()
+    view = df['A'].is_view()
+    tm.assert_equal(view, True)
+    ser = tm.makeStringSeries()
+    view = ser.is_view()
+    tm.assert_equal(view, False)
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
So you can check if a series is a view instead of waiting to get an error on sort or copying by default.
