### PR TITLE
COMPAT/BUG: Ignore numexpr < 2.0

### DIFF
--- a/pandas/computation/__init__.py
+++ b/pandas/computation/__init__.py
@@ -1,0 +1,17 @@
+try:
+    import numexpr as ne
+    _NUMEXPR_INSTALLED = True
+    import distutils.version
+    if distutils.version.LooseVersion(ne.__version__) < '2':
+        _NUMEXPR_INSTALLED = False
+        import warnings
+        warnings.warn("pandas requires at least numexpr version 2.0"
+                      " to accelerate with numexpr. Found numexpr version"
+                      " %s" % ne.__version__)
+    del ne
+    del distutils.version
+except ImportError:  # pragma: no cover
+    _NUMEXPR_INSTALLED = False
+
+#: tracks globally whether numexpr should be used.
+_USE_NUMEXPR = _NUMEXPR_INSTALLED

--- a/pandas/computation/engines.py
+++ b/pandas/computation/engines.py
@@ -80,9 +80,9 @@ class NumExprEngine(AbstractEngine):
 
     def __init__(self, expr):
         import pandas.computation.expressions as expr
-        if not expr._NUMEXPR_INSTALLED:
+        if not expr._USE_NUMEXPR:
             raise ValueError("Can't use numexpr engine without compatbile"
-                             " version of numexpr")
+                             " version of numexpr (or with numexpr disabled)")
         super(NumExprEngine, self).__init__(expr)
 
     def convert(self):

--- a/pandas/computation/engines.py
+++ b/pandas/computation/engines.py
@@ -79,8 +79,8 @@ class NumExprEngine(AbstractEngine):
     has_neg_frac = True
 
     def __init__(self, expr):
-        import pandas.computation.expressions as expr
-        if not expr._USE_NUMEXPR:
+        import pandas.computation.expressions
+        if not pandas.computation.expressions._USE_NUMEXPR:
             raise ValueError("Can't use numexpr engine without compatbile"
                              " version of numexpr (or with numexpr disabled)")
         super(NumExprEngine, self).__init__(expr)

--- a/pandas/computation/engines.py
+++ b/pandas/computation/engines.py
@@ -79,6 +79,10 @@ class NumExprEngine(AbstractEngine):
     has_neg_frac = True
 
     def __init__(self, expr):
+        import pandas.computation.expressions as expr
+        if not expr._NUMEXPR_INSTALLED:
+            raise ValueError("Can't use numexpr engine without compatbile"
+                             " version of numexpr")
         super(NumExprEngine, self).__init__(expr)
 
     def convert(self):

--- a/pandas/computation/engines.py
+++ b/pandas/computation/engines.py
@@ -5,6 +5,7 @@ import abc
 
 from pandas import compat
 from pandas.core import common as com
+import pandas.computation as computation
 from pandas.computation.align import _align, _reconstruct_object
 from pandas.computation.ops import UndefinedVariableError
 
@@ -79,10 +80,9 @@ class NumExprEngine(AbstractEngine):
     has_neg_frac = True
 
     def __init__(self, expr):
-        import pandas.computation.expressions
-        if not pandas.computation.expressions._USE_NUMEXPR:
-            raise ValueError("Can't use numexpr engine without compatbile"
-                             " version of numexpr (or with numexpr disabled)")
+        if not computation._USE_NUMEXPR:
+            raise ImportError("Can't use numexpr engine without compatbile"
+                              " version of numexpr (or with numexpr disabled)")
         super(NumExprEngine, self).__init__(expr)
 
     def convert(self):

--- a/pandas/computation/eval.py
+++ b/pandas/computation/eval.py
@@ -10,6 +10,7 @@ from pandas.core import common as com
 from pandas.compat import string_types
 from pandas.computation.expr import Expr, _parsers, _ensure_scope
 from pandas.computation.engines import _engines
+import pandas.computation as computation
 
 
 def _check_engine(engine):
@@ -33,12 +34,10 @@ def _check_engine(engine):
     # TODO: validate this in a more general way (thinking of future engines
     # that won't necessarily be import-able)
     # Could potentially be done on engine instantiation
-    if engine == 'numexpr':
-        try:
-            import numexpr
-        except ImportError:
-            raise ImportError("'numexpr' not found. Cannot use "
-                              "engine='numexpr' if 'numexpr' is not installed")
+    if engine == 'numexpr' and not computation._USE_NUMEXPR:
+            raise ImportError("'numexpr' not found or disabled. Cannot use "
+                              "engine='numexpr' if 'numexpr' < v2.0 is not "
+                              "installed")
 
 
 def _check_parser(parser):

--- a/pandas/computation/expr.py
+++ b/pandas/computation/expr.py
@@ -16,6 +16,7 @@ from pandas import compat
 from pandas.compat import StringIO, zip, reduce, string_types
 from pandas.core.base import StringMixin
 from pandas.core import common as com
+import pandas.computation as computation
 from pandas.computation.common import NameResolutionError
 from pandas.computation.ops import (_cmp_ops_syms, _bool_ops_syms,
                                     _arith_ops_syms, _unary_ops_syms, is_term)

--- a/pandas/computation/expressions.py
+++ b/pandas/computation/expressions.py
@@ -8,25 +8,15 @@ Offer fast expression evaluation through numexpr
 
 import numpy as np
 from pandas.core.common import _values_from_object
-
+import pandas.computation as computation
 try:
     import numexpr as ne
-    _NUMEXPR_INSTALLED = True
-    import distutils.version
-    if distutils.version.LooseVersion(ne.__version__) < '2':
-        _NUMEXPR_INSTALLED = False
-        import warnings
-        warnings.warn("pandas requires at least numexpr version 2.0"
-                      " to accelerate with numexpr. Found numexpr version"
-                      " %s" % ne.__version__)
-    del ne
-    del distutils.version
-except ImportError:  # pragma: no cover
-    _NUMEXPR_INSTALLED = False
+except ImportError:
+    pass
+
 
 _TEST_MODE = None
 _TEST_RESULT = None
-_USE_NUMEXPR = _NUMEXPR_INSTALLED
 _evaluate = None
 _where = None
 
@@ -42,13 +32,12 @@ _MIN_ELEMENTS = 10000
 
 def set_use_numexpr(v=True):
     # set/unset to use numexpr
-    global _USE_NUMEXPR
-    if _NUMEXPR_INSTALLED:
-        _USE_NUMEXPR = v
+    if computation._NUMEXPR_INSTALLED:
+        computation._USE_NUMEXPR = v
 
     # choose what we are going to do
     global _evaluate, _where
-    if not _USE_NUMEXPR:
+    if not computation._USE_NUMEXPR:
         _evaluate = _evaluate_standard
         _where = _where_standard
     else:
@@ -59,7 +48,7 @@ def set_use_numexpr(v=True):
 def set_numexpr_threads(n=None):
     # if we are using numexpr, set the threads to n
     # otherwise reset
-    if _NUMEXPR_INSTALLED and _USE_NUMEXPR:
+    if computation._NUMEXPR_INSTALLED and computation._USE_NUMEXPR:
         if n is None:
             n = ne.detect_number_of_cores()
         ne.set_num_threads(n)

--- a/pandas/computation/expressions.py
+++ b/pandas/computation/expressions.py
@@ -12,6 +12,15 @@ from pandas.core.common import _values_from_object
 try:
     import numexpr as ne
     _NUMEXPR_INSTALLED = True
+    import distutils.version
+    if distutils.version.LooseVersion(ne.__version__) < '2':
+        _NUMEXPR_INSTALLED = False
+        import warnings
+        warnings.warn("pandas requires at least numexpr version 2.0"
+                      " to accelerate with numexpr. Found numexpr version"
+                      " %s" % ne.__version__)
+    del ne
+    del distutils.version
 except ImportError:  # pragma: no cover
     _NUMEXPR_INSTALLED = False
 

--- a/pandas/computation/tests/test_eval.py
+++ b/pandas/computation/tests/test_eval.py
@@ -16,8 +16,7 @@ from pandas.core import common as com
 from pandas import DataFrame, Series, Panel, date_range
 from pandas.util.testing import makeCustomDataframe as mkdf
 
-from pandas.computation import pytables
-from pandas.computation.expressions import _USE_NUMEXPR
+from pandas.computation import pytables, _USE_NUMEXPR
 from pandas.computation.engines import _engines
 from pandas.computation.expr import PythonExprVisitor, PandasExprVisitor
 from pandas.computation.ops import (_binary_ops_dict, _unary_ops_dict,

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -10,7 +10,8 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from pandas.core.api import DataFrame, Panel
-from pandas.computation import expressions as expr
+import pandas.computation as computation
+import pandas.computation.expressions as expr
 from pandas import compat
 
 from pandas.util.testing import (assert_almost_equal, assert_series_equal,
@@ -48,7 +49,7 @@ def test_arithmetic_works_with_zero_min_elements():
     expr._MIN_ELEMENTS = original_min
 
 
-if not expr._USE_NUMEXPR:
+if not computation._USE_NUMEXPR:
     try:
         import numexpr
     except ImportError:

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -20,15 +20,6 @@ import pandas.util.testing as tm
 from numpy.testing.decorators import slow
 
 
-if not expr._USE_NUMEXPR:
-    try:
-        import numexpr
-    except ImportError:
-        msg = "don't have"
-    else:
-        msg = "not using"
-    raise nose.SkipTest("{0} numexpr".format(msg))
-
 _frame  = DataFrame(randn(10000, 4), columns=list('ABCD'), dtype='float64')
 _frame2 = DataFrame(randn(100, 4),   columns = list('ABCD'), dtype='float64')
 _mixed  = DataFrame({ 'A' : _frame['A'].copy(), 'B' : _frame['B'].astype('float32'), 'C' : _frame['C'].astype('int64'), 'D' : _frame['D'].astype('int32') })
@@ -45,6 +36,26 @@ _integer2_panel = Panel(dict(ItemA=_integer2,
                              ItemB=(_integer2 + 34).astype('int64')))
 _mixed_panel = Panel(dict(ItemA=_mixed, ItemB=(_mixed + 3)))
 _mixed2_panel = Panel(dict(ItemA=_mixed2, ItemB=(_mixed2 + 3)))
+
+
+def test_arithmetic_works_with_zero_min_elements():
+    df = DataFrame(range(10))
+    original_min = expr._MIN_ELEMENTS
+    expr._MIN_ELEMENTS = 0
+    result = df + 1
+    expected = DataFrame(range(1, 11))
+    assert tm.assert_frame_equal(result, expected)
+    expr._MIN_ELEMENTS = original_min
+
+
+if not expr._USE_NUMEXPR:
+    try:
+        import numexpr
+    except ImportError:
+        msg = "don't have"
+    else:
+        msg = "not using"
+    raise nose.SkipTest("{0} numexpr".format(msg))
 
 
 class TestExpressions(tm.TestCase):

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -45,7 +45,7 @@ def test_arithmetic_works_with_zero_min_elements():
     expr._MIN_ELEMENTS = 0
     result = df + 1
     expected = DataFrame(range(1, 11))
-    assert tm.assert_frame_equal(result, expected)
+    tm.assert_frame_equal(result, expected)
     expr._MIN_ELEMENTS = original_min
 
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -49,6 +49,7 @@ from pandas.core.common import PandasError
 
 import pandas.util.testing as tm
 import pandas.lib as lib
+import pandas.computation as computation
 
 from numpy.testing.decorators import slow
 
@@ -11927,9 +11928,8 @@ starting,ending,measure
 
 
 def skip_if_no_ne(engine='numexpr'):
-    import pandas.computation.expressions as expr
-    if engine == 'numexpr' and not expr._NUMEXPR_INSTALLED:
-        raise nose.SkipTest("cannot query engine numexpr when numexpr not "
+    if engine == 'numexpr' and not computation._NUMEXPR_INSTALLED:
+        raise nose.SkipTest("cannot query engine numexpr when numexpr 2.0 not "
                             "installed")
 
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -11927,12 +11927,10 @@ starting,ending,measure
 
 
 def skip_if_no_ne(engine='numexpr'):
-    if engine == 'numexpr':
-        try:
-            import numexpr as ne
-        except ImportError:
-            raise nose.SkipTest("cannot query engine numexpr when numexpr not "
-                                "installed")
+    import pandas.computation.expressions as expr
+    if engine == 'numexpr' and not expr._NUMEXPR_INSTALLED:
+        raise nose.SkipTest("cannot query engine numexpr when numexpr not "
+                            "installed")
 
 
 def skip_if_no_pandas_parser(parser):


### PR DESCRIPTION
in both computation.expressions and computationr.engine. Issues with API
compatibility.

Fixes #5857, #5855, #5845.
