### PR TITLE
BUG: bug in to_datetime when passed a np.nan or integer datelike and a format string (GH5863)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -79,6 +79,7 @@ Bug Fixes
   - Bug in selection with missing values via ``.ix`` from a duplicate indexed DataFrame failing (:issue:`5835`)
   - Fix issue of boolean comparison on empty DataFrames (:issue:`5808`)
   - Bug in isnull handling ``NaT`` in an object array (:issue:`5443`)
+  - Bug in ``to_datetime`` when passed a ``np.nan`` or integer datelike and a format string (:issue:`5863`)
 
 pandas 0.13.0
 -------------

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -804,6 +804,31 @@ class TestTimeSeries(tm.TestCase):
         xp = datetime(2001, 1, 1)
         self.assert_(rs, xp)
 
+
+    def test_to_datetime_mixed(self):
+
+        # 5863
+        # passing a string format with embedded np.nan
+
+        ts = Series([np.nan, '2013-04-08 00:00:00.000', '9999-12-31 00:00:00.000'])
+        expected = Series([NaT,Timestamp('20130408'),NaT])
+
+        result = to_datetime(ts, format='%Y-%m-%d %H:%M:%S.%f')
+        assert_series_equal(result, ts)
+
+        # raises if specified
+        self.assertRaises(pd.tslib.OutOfBoundsDatetime, to_datetime, ts, format='%Y-%m-%d %H:%M:%S.%f', errors='raise')
+
+        result = to_datetime(ts, format='%Y-%m-%d %H:%M:%S.%f',coerce=True)
+        expected = Series([NaT,Timestamp('20130408'),NaT])
+        assert_series_equal(result,expected)
+
+        # passing integers
+        ts = Series([np.nan, 20130408, '20130409'])
+        result = to_datetime(ts, format='%Y%m%d')
+        expected = Series([NaT,Timestamp('20130408'),Timestamp('20130409')])
+        assert_series_equal(result,expected)
+
     def test_dayfirst(self):
 
         # GH 3341

--- a/pandas/tseries/tools.py
+++ b/pandas/tseries/tools.py
@@ -112,7 +112,12 @@ def to_datetime(arg, errors='ignore', dayfirst=False, utc=None, box=True,
 
                 # fallback
                 if result is None:
-                    result = tslib.array_strptime(arg, format, coerce=coerce)
+                    try:
+                        result = tslib.array_strptime(arg, format, coerce=coerce)
+                    except (tslib.OutOfBoundsDatetime):
+                        if errors == 'raise':
+                            raise
+                        result = arg
             else:
                 result = tslib.array_to_datetime(arg, raise_=errors == 'raise',
                                                  utc=utc, dayfirst=dayfirst,


### PR DESCRIPTION
closes #5863
