### PR TITLE
BUG: Bug in groupby dtype conversion with datetimelike (GH5869)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -80,6 +80,7 @@ Bug Fixes
   - Fix issue of boolean comparison on empty DataFrames (:issue:`5808`)
   - Bug in isnull handling ``NaT`` in an object array (:issue:`5443`)
   - Bug in ``to_datetime`` when passed a ``np.nan`` or integer datelike and a format string (:issue:`5863`)
+  - Bug in groupby dtype conversion with datetimelike (:issue:`5869`)
 
 pandas 0.13.0
 -------------

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1102,6 +1102,14 @@ def _possibly_downcast_to_dtype(result, dtype):
                     # hit here
                     if (new_result == result).all():
                         return new_result
+
+        # a datetimelike
+        elif dtype.kind in ['M','m'] and result.dtype.kind in ['i']:
+            try:
+                result = result.astype(dtype)
+            except:
+                pass
+
     except:
         pass
 

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -2672,6 +2672,14 @@ class TestGroupBy(tm.TestCase):
         got_dt = result.dtype
         self.assert_(issubclass(got_dt.type, np.datetime64))
 
+    def test_groupby_max_datetime64(self):
+        # GH 5869
+        # datetimelike dtype conversion from int
+        df = DataFrame(dict(A = Timestamp('20130101'), B = np.arange(5)))
+        expected = df.groupby('A')['A'].apply(lambda x: x.max())
+        result = df.groupby('A')['A'].max()
+        assert_series_equal(result,expected)
+
     def test_groupby_categorical_unequal_len(self):
         import pandas as pd
         #GH3011


### PR DESCRIPTION
closes #5869
