### PR TITLE
BUG: Regresssion in handling of empty Series as indexers to Series  (GH5877)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -81,6 +81,7 @@ Bug Fixes
   - Bug in isnull handling ``NaT`` in an object array (:issue:`5443`)
   - Bug in ``to_datetime`` when passed a ``np.nan`` or integer datelike and a format string (:issue:`5863`)
   - Bug in groupby dtype conversion with datetimelike (:issue:`5869`)
+  - Regresssion in handling of empty Series as indexers to Series  (:issue:`5877`)
 
 pandas 0.13.0
 -------------

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1660,7 +1660,7 @@ def _is_bool_indexer(key):
         if key.dtype == np.object_:
             key = np.asarray(_values_from_object(key))
 
-            if len(key) and not lib.is_bool_array(key):
+            if not lib.is_bool_array(key):
                 if isnull(key).any():
                     raise ValueError('cannot index with vector containing '
                                      'NA / NaN values')


### PR DESCRIPTION
closes #5877

```
In [1]: s = Series(['A', 'B'])

In [2]: s[Series(['C'], dtype=object)]
Out[2]: 
C    NaN
dtype: object

In [3]: s[Series([], dtype=object)]
Out[3]: Series([], dtype: object)
```

This didn't work in 0.12

```
In [4]: s[Series([], dtype=bool)]
Out[4]: Series([], dtype: object)
```

This raises though (in both 0.12 and 0.13)

```
In [5]: s[Series([True], dtype=bool)]
IndexingError: Unalignable boolean Series key provided
``
```
