### PR TITLE
BUG: Don't return the same thing twice.

### DIFF
--- a/pandas/tseries/tools.py
+++ b/pandas/tseries/tools.py
@@ -297,7 +297,7 @@ def parse_time_string(arg, freq=None, dayfirst=None, yearfirst=None):
     if parsed is None:
         raise DateParseError("Could not parse %s" % arg)
 
-    return parsed, parsed, reso  # datetime, resolution
+    return parsed, reso  # datetime, resolution
 
 
 def dateutil_parse(timestr, default,


### PR DESCRIPTION
Surely this is a typo.

I noticed this because I was going add more robust parsing to datetools.parse [1], and I was surprised to find this function there. Two suggestions / questions. 1) Why not just roll this into the parse function like statsmodels instead of having it fall down on things like "1989Q1"? Extra function seems unneeded to me.

2) Why return the "resolution"? The parse function doesn't do this, and I'd expect them to have the same return signature. Optionally, the parse function should also try to infer a frequency.

[1] https://github.com/statsmodels/statsmodels/blob/master/statsmodels/tsa/base/datetools.py#L117
