### PR TITLE
TST: Testing bug in reading json/msgpack from a non-filepath on windows under py3 (GH5874)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -83,6 +83,7 @@ Bug Fixes
   - Bug in groupby dtype conversion with datetimelike (:issue:`5869`)
   - Regresssion in handling of empty Series as indexers to Series  (:issue:`5877`)
   - Bug in internal caching, related to (:issue:`5727`)
+  - Testing bug in reading json/msgpack from a non-filepath on windows under py3 (:issue:`5874`)
 
 pandas 0.13.0
 -------------

--- a/pandas/io/json.py
+++ b/pandas/io/json.py
@@ -173,7 +173,15 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=True,
 
     filepath_or_buffer, _ = get_filepath_or_buffer(path_or_buf)
     if isinstance(filepath_or_buffer, compat.string_types):
-        if os.path.exists(filepath_or_buffer):
+        try:
+            exists = os.path.exists(filepath_or_buffer)
+
+        # if the filepath is too long will raise here
+        # 5874
+        except (TypeError,ValueError):
+            exists = False
+
+        if exists:
             with open(filepath_or_buffer, 'r') as fh:
                 json = fh.read()
         else:

--- a/pandas/io/packers.py
+++ b/pandas/io/packers.py
@@ -147,11 +147,11 @@ def read_msgpack(path_or_buf, iterator=False, **kwargs):
     if isinstance(path_or_buf, compat.string_types):
 
         try:
-            path_exists = os.path.exists(path_or_buf)
-        except (TypeError):
-            path_exists = False
+            exists = os.path.exists(path_or_buf)
+        except (TypeError,ValueError):
+            exists = False
 
-        if path_exists:
+        if exists:
             with open(path_or_buf, 'rb') as fh:
                 return read(fh)
 


### PR DESCRIPTION
closes #5874
