### PR TITLE
Fix bug where use of .ix[tuple(...)]=x fails to correctly check out of b...

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -84,6 +84,7 @@ Bug Fixes
   - Regresssion in handling of empty Series as indexers to Series  (:issue:`5877`)
   - Bug in internal caching, related to (:issue:`5727`)
   - Testing bug in reading json/msgpack from a non-filepath on windows under py3 (:issue:`5874`)
+  - Bug when assigning to .ix[tuple(...)] (:issue:`5896`)
 
 pandas 0.13.0
 -------------

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -903,7 +903,8 @@ class _NDFrameIndexer(object):
                     return {'key': obj}
 
                 # a positional
-                if obj >= len(self.obj) and not isinstance(labels, MultiIndex):
+                if (obj >= self.obj.shape[axis] and
+                        not isinstance(labels, MultiIndex)):
                     raise ValueError("cannot set by positional indexing with "
                                      "enlargement")
 

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -2352,6 +2352,14 @@ class TestIndexing(tm.TestCase):
         #self.assertRaises(TypeError, lambda : s.iloc[2.0:5.0])
         #self.assertRaises(TypeError, lambda : s.iloc[2:5.0])
 
+    def test_set_ix_out_of_bounds_axis_0(self):
+        df = pd.DataFrame(randn(2, 5), index=["row%s" % i for i in range(2)], columns=["col%s" % i for i in range(5)])
+        self.assertRaises(ValueError, df.ix.__setitem__, (2, 0), 100)
+
+    def test_set_ix_out_of_bounds_axis_1(self):
+        df = pd.DataFrame(randn(5, 2), index=["row%s" % i for i in range(5)], columns=["col%s" % i for i in range(2)])
+        self.assertRaises(ValueError, df.ix.__setitem__, (0 , 2), 100)
+
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
...ounds index for columns. This is a regression as it used to work in pandas 0.12.0. The code incorrectly checks the column index against the len() of the dataframe to see if it is in bounds not against the number of columns. Have added 2 tests with non-square dataframes to test that the fix works.
