### PR TITLE
ENH/API: Add count parameter to limit generator in Series, DataFrame, and DataFrame.from_records()

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2,6 +2,7 @@
 Data structure for 1-dimensional cross-sectional and time series data
 """
 from __future__ import division
+from itertools import islice
 
 # pylint: disable=E1101,E1103
 # pylint: disable=W0703,W0622,W0613,W0201
@@ -118,11 +119,13 @@ class Series(generic.NDFrame):
     dtype : numpy.dtype or None
         If None, dtype will be inferred
     copy : boolean, default False, copy input data
+    count : int or None, number of values to read from a generator.
+        If None reads the whole generator
     """
     _metadata = ['name']
 
     def __init__(self, data=None, index=None, dtype=None, name=None,
-                 copy=False, fastpath=False):
+                 copy=False, count=None, fastpath=False):
 
         # we are called internally, so short-circuit
         if fastpath:
@@ -192,7 +195,7 @@ class Series(generic.NDFrame):
                     name = data.name
                 data = np.asarray(data)
             elif isinstance(data, types.GeneratorType):
-                data = list(data)
+                data = list(islice(data, count))
             elif isinstance(data, (set, frozenset)):
                 raise TypeError("{0!r} type is unordered"
                                 "".format(data.__class__.__name__))

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2791,6 +2791,15 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         expected = DataFrame({ 0 : range(10), 1 : 'a' })
         assert_frame_equal(result, expected, check_dtype=False)
 
+    def test_constructor_generator_count_limit(self):
+        generator_length = 10
+        expected_length = 5
+
+        #only works when data it'a a generator, not a collection
+        gen = ([ i, 'a'] for i in range(generator_length))
+        result = DataFrame(gen, count=expected_length)
+        self.assertEqual(len(result), expected_length)
+
     def test_constructor_list_of_dicts(self):
         data = [OrderedDict([['a', 1.5], ['b', 3], ['c', 4], ['d', 6]]),
                 OrderedDict([['a', 1.5], ['b', 3], ['d', 6]]),
@@ -3819,6 +3828,14 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         generator = list_generator(10)
         result = DataFrame.from_records(generator, columns=columns_names)
         assert_frame_equal(result, expected)
+
+    def test_from_records_generator_count_limit(self):
+        def generator(length):
+            for i in range(length):
+                yield (i, i/2)
+        expected_length = 5
+        df = DataFrame.from_records(generator(10), count=expected_length)
+        self.assertEqual(len(df), expected_length)
 
     def test_from_records_columns_not_modified(self):
         tuples = [(1, 2, 3),

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -403,6 +403,14 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         exp.index = lrange(10, 20)
         assert_series_equal(result, exp)
 
+    def test_constructor_generator_count_limit(self):
+        generator_length = 10
+        expected_length = 5
+        gen = (i for i in range(generator_length))
+
+        result = Series(gen, count=expected_length)
+        self.assertEqual(len(result), expected_length)
+
     def test_constructor_categorical(self):
         cat = pd.Categorical([0, 1, 2, 0, 1, 2], ['a', 'b', 'c'])
         res = Series(cat)


### PR DESCRIPTION
When reading data from a generator type collection only reads the firsts number (count) of values.
First step to solve #2305, known the length of the data to allocate memory.
- Add count parameter to Series, DataFrame, and  DataFrame.from_records(). 
- In DataFrame.from_records() deprecate the existing parameter nrows. Count it's more general and only refers to quantity of data units. Also exists on numpy API (fromiter). 
- Some refactor in DataFrame.from_records(). 
- Add tests too.
- Lack of release docs for now.
