### PR TITLE
DOC: remove usage of code-block directive in docstrings + fix some warnings

### DIFF
--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -19,7 +19,7 @@ We'd like to make it easier for users to find these project, if you know of othe
 substantial projects that you feel should be on this list, please let us know.
 
 `Statsmodels <http://statsmodels.sourceforge.net>`__
------------
+----------------------------------------------------
 
 Statsmodels is the prominent python "statistics and econometrics library" and it has
 a long-standing special relationship with pandas. Statsmodels provides powerful statistics,
@@ -27,14 +27,14 @@ econometrics, analysis and modeling functionality that is out of pandas' scope.
 Statsmodels leverages pandas objects as the underlying data container for computation.
 
 `Vincent <https://github.com/wrobstory/vincent>`__
--------
+--------------------------------------------------
 
 The `Vincent <https://github.com/wrobstory/vincent>`__ project leverages `Vega <https://github.com/trifacta/vega>`__
 (that in turn, leverages `d3 <http://d3js.org/>`__) to create plots . It has great support
 for pandas data objects.
 
 `yhat/ggplot <https://github.com/yhat/ggplot>`__
------------
+------------------------------------------------
 
 Hadley Wickham's `ggplot2 <http://ggplot2.org/>`__ is a foundational exploratory visualization package for the R language.
 Based on `"The Grammer of Graphics" <http://www.cs.uic.edu/~wilkinson/TheGrammarOfGraphics/GOG.html>`__ it
@@ -46,7 +46,7 @@ progressing quickly in that direction.
 
 
 `Seaborn <https://github.com/mwaskom/seaborn>`__
--------
+------------------------------------------------
 
 Although pandas has quite a bit of "just plot it" functionality built-in, visualization and
 in particular statistical graphics is a vast field with a long tradition and lots of ground
@@ -56,7 +56,7 @@ more advanced types of plots then those offered by pandas.
 
 
 `Geopandas <https://github.com/kjordahl/geopandas>`__
----------
+------------------------------------------------------
 
 Geopandas extends pandas data objects to include geographic information which support
 geometric operations. If your work entails maps and geographical coordinates, and

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2094,21 +2094,8 @@ class Series(generic.NDFrame):
         ----------
         values : list-like
             The sequence of values to test. Passing in a single string will
-            raise a ``TypeError``:
-
-                .. code-block:: python
-
-                   from pandas import Series
-                   s = Series(list('abc'))
-                   s.isin('a')
-
-            Instead, turn a single string into a ``list`` of one element:
-
-                .. code-block:: python
-
-                   from pandas import Series
-                   s = Series(list('abc'))
-                   s.isin(['a'])
+            raise a ``TypeError``. Instead, turn a single string into a 
+            ``list`` of one element.
 
         Returns
         -------
@@ -2122,6 +2109,26 @@ class Series(generic.NDFrame):
         See Also
         --------
         pandas.DataFrame.isin
+
+        Examples
+        --------
+
+        >>> s = pd.Series(list('abc'))
+        >>> s.isin(['a', 'c', 'e'])
+        0     True
+        1    False
+        2     True
+        dtype: bool
+
+        Passing a single string as ``s.isin('a')`` will raise an error. Use
+        a list of one element instead:
+
+        >>> s.isin(['a'])
+        0     True
+        1    False
+        2    False
+        dtype: bool
+
         """
         if not com.is_list_like(values):
             raise TypeError("only list-like objects are allowed to be passed"

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -759,20 +759,16 @@ def read_html(io, match='.+', flavor=None, header=None, index_col=None,
         This is a dictionary of attributes that you can pass to use to identify
         the table in the HTML. These are not checked for validity before being
         passed to lxml or Beautiful Soup. However, these attributes must be
-        valid HTML table attributes to work correctly. For example,
-
-        .. code-block:: python
-
-           attrs = {'id': 'table'}
-
+        valid HTML table attributes to work correctly. For example, ::
+        
+            attrs = {'id': 'table'}
+        
         is a valid attribute dictionary because the 'id' HTML tag attribute is
         a valid HTML attribute for *any* HTML tag as per `this document
-        <http://www.w3.org/TR/html-markup/global-attributes.html>`__.
-
-        .. code-block:: python
-
-           attrs = {'asdf': 'table'}
-
+        <http://www.w3.org/TR/html-markup/global-attributes.html>`__. ::
+        
+            attrs = {'asdf': 'table'}
+        
         is *not* a valid attribute dictionary because 'asdf' is not a valid
         HTML attribute even if it is a valid XML attribute.  Valid HTML 4.01
         table attributes can be found `here


### PR DESCRIPTION
Some docs things:
- remove remaining use of `code-block`, closes #3430 (@y-p, I think that were the last ones, so now it can be really closed)
- fix some headers to avoid useless warnings during doc build (if the line under the header is not as long as the header itself, sphinx complains about it although it renders fine)
