### PR TITLE
BUG: dt+BDay(n) wrong if n>5, n%5==0 and dt not on offset (GH5890)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -87,6 +87,7 @@ Bug Fixes
   - Bug when assigning to .ix[tuple(...)] (:issue:`5896`)
   - Bug in fully reindexing a Panel (:issue:`5905`)
   - Bug in idxmin/max with object dtypes (:issue:`5914`)
+  - Bug in ``BusinessDay`` when adding n days to a date not on offset when n>5 and n%5==0 (:issue:`5890`)
 
 pandas 0.13.0
 -------------

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -397,7 +397,9 @@ class BusinessDay(CacheableOffset, SingleConstructorOffset):
                 if n < 0 and result.weekday() > 4:
                     n += 1
                 n -= 5 * k
-
+                if n == 0 and result.weekday() > 4:
+                    n -= 1
+            
             while n != 0:
                 k = n // abs(n)
                 result = result + timedelta(k)

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -317,6 +317,11 @@ class TestBusinessDay(TestBase):
         rs = st + off
         xp = datetime(2011, 12, 26)
         self.assertEqual(rs, xp)
+        
+        off = BDay() * 10
+        rs = datetime(2014, 1, 5) + off # see #5890
+        xp = datetime(2014, 1, 17)
+        self.assertEqual(rs, xp)
 
     def test_apply_corner(self):
         self.assertRaises(TypeError, BDay().apply, BMonthEnd())


### PR DESCRIPTION
closes #5890
