### PR TITLE
BUG: Bug in idxmin/max with object dtypes (GH5914)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -86,6 +86,7 @@ Bug Fixes
   - Testing bug in reading json/msgpack from a non-filepath on windows under py3 (:issue:`5874`)
   - Bug when assigning to .ix[tuple(...)] (:issue:`5896`)
   - Bug in fully reindexing a Panel (:issue:`5905`)
+  - Bug in idxmin/max with object dtypes (:issue:`5914`)
 
 pandas 0.13.0
 -------------

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -171,6 +171,9 @@ def _get_values(values, skipna, fill_value=None, fill_value_typ=None,
 def _isfinite(values):
     if issubclass(values.dtype.type, (np.timedelta64, np.datetime64)):
         return isnull(values)
+    elif isinstance(values.dtype, object):
+        return -np.isfinite(values.astype('float64'))
+
     return -np.isfinite(values)
 
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -3258,6 +3258,20 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         result = s.idxmax()
         self.assert_(result == 4)
 
+        # Float64Index
+        # GH 5914
+        s = pd.Series([1,2,3],[1.1,2.1,3.1])
+        result = s.idxmax()
+        self.assert_(result == 3.1)
+        result = s.idxmin()
+        self.assert_(result == 1.1)
+
+        s = pd.Series(s.index, s.index)
+        result = s.idxmax()
+        self.assert_(result == 3.1)
+        result = s.idxmin()
+        self.assert_(result == 1.1)
+
     def test_ndarray_compat(self):
 
         # test numpy compat with Series as sub-class of NDFrame


### PR DESCRIPTION
closes #5914
