### PR TITLE
API: Raise/Warn SettingWithCopyError in more cases

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -58,8 +58,9 @@ API Changes
 
   - ``Series.sort`` will raise a ``ValueError`` (rather than a ``TypeError``) on sorting an
     object that is a view of another (:issue:`5856`, :issue:`5853`)
-
-.. _release.bug_fixes-0.13.1:
+  - Raise/Warn ``SettingWithCopyError`` (according to the option ``chained_assignment`` in more cases,
+    when detecting chained assignment, related (:issue:`5938`)
+  - DataFrame.head(0) returns self instead of empty frame (:issue:`5846`)
 
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~
@@ -72,7 +73,8 @@ Improvements to existing features
   - df.info() view now display dtype info per column (:issue: `5682`)
   - perf improvements in DataFrame ``count/dropna`` for ``axis=1``
   - Series.str.contains now has a `regex=False` keyword which can be faster for plain (non-regex) string patterns. (:issue: `5879`)
-  - DataFrame.head(0) returns self instead of empty frame (:issue:`5846`)
+
+.. _release.bug_fixes-0.13.1:
 
 Bug Fixes
 ~~~~~~~~~

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1856,6 +1856,7 @@ class DataFrame(NDFrame):
                                                    name=items, fastpath=True)
 
     def __setitem__(self, key, value):
+
         # see if we can slice the rows
         indexer = _convert_to_index_sliceable(self, key)
         if indexer is not None:
@@ -1880,6 +1881,7 @@ class DataFrame(NDFrame):
                                  (len(key), len(self.index)))
             key = _check_bool_indexer(self.index, key)
             indexer = key.nonzero()[0]
+            self._check_setitem_copy()
             self.ix._setitem_with_indexer(indexer, value)
         else:
             if isinstance(value, DataFrame):
@@ -1889,6 +1891,7 @@ class DataFrame(NDFrame):
                     self[k1] = value[k2]
             else:
                 indexer = self.ix._convert_to_indexer(key, axis=1)
+                self._check_setitem_copy()
                 self.ix._setitem_with_indexer((slice(None), indexer), value)
 
     def _setitem_frame(self, key, value):

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -2061,6 +2061,14 @@ class TestIndexing(tm.TestCase):
         assert_series_equal(s,df.iloc[:,0].order())
         assert_series_equal(s,df[0].order())
 
+        # operating on a copy
+        df = pd.DataFrame({'a': list(range(4)), 'b': list('ab..'), 'c': ['a', 'b', np.nan, 'd']})
+        mask = pd.isnull(df.c)
+
+        def f():
+            df[['c']][mask] = df[['b']][mask]
+        self.assertRaises(com.SettingWithCopyError, f)
+
         pd.set_option('chained_assignment','warn')
 
     def test_float64index_slicing_bug(self):


### PR DESCRIPTION
when detecting chained assignment, related, #5938
