### PR TITLE
API: add reads_json, reads_msgpack, reads_csv, reads_pickle as convience functions which accept a string

### DIFF
--- a/pandas/io/api.py
+++ b/pandas/io/api.py
@@ -2,14 +2,14 @@
 Data IO api
 """
 
-from pandas.io.parsers import read_csv, read_table, read_fwf
+from pandas.io.parsers import read_csv, reads_csv, read_table, read_fwf
 from pandas.io.clipboard import read_clipboard
 from pandas.io.excel import ExcelFile, ExcelWriter, read_excel
 from pandas.io.pytables import HDFStore, Term, get_store, read_hdf
-from pandas.io.json import read_json
+from pandas.io.json import read_json, reads_json
 from pandas.io.html import read_html
 from pandas.io.sql import read_sql
 from pandas.io.stata import read_stata
-from pandas.io.pickle import read_pickle, to_pickle
-from pandas.io.packers import read_msgpack, to_msgpack
+from pandas.io.pickle import read_pickle, reads_pickle, to_pickle
+from pandas.io.packers import read_msgpack, reads_msgpack, to_msgpack
 from pandas.io.gbq import read_gbq

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -15,7 +15,7 @@ import datetime
 import pandas.core.common as com
 from pandas.core.config import get_option
 from pandas.io.date_converters import generic_parser
-from pandas.io.common import get_filepath_or_buffer
+from pandas.io.common import get_filepath_or_buffer, _create_string_file_reader
 
 from pandas.util.decorators import Appender
 
@@ -417,6 +417,7 @@ def _make_parser_function(name, sep=','):
 
 read_csv = _make_parser_function('read_csv', sep=',')
 read_csv = Appender(_read_csv_doc)(read_csv)
+reads_csv = _create_string_file_reader(read_csv)
 
 read_table = _make_parser_function('read_table', sep='\t')
 read_table = Appender(_read_table_doc)(read_table)

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -1,5 +1,5 @@
 from pandas.compat import cPickle as pkl, pickle_compat as pc, PY3
-
+from pandas.io.common import _create_string_file_reader
 
 def to_pickle(obj, path):
     """
@@ -51,3 +51,5 @@ def read_pickle(path):
         if PY3:
             return try_read(path, encoding='latin1')
         raise
+
+reads_pickle= _create_string_file_reader(read_pickle)

--- a/pandas/io/tests/test_packers.py
+++ b/pandas/io/tests/test_packers.py
@@ -16,13 +16,13 @@ from pandas.tests.test_series import assert_series_equal
 from pandas.tests.test_frame import assert_frame_equal
 from pandas.tests.test_panel import assert_panel_equal
 
-import pandas
+import pandas as pd
 from pandas.sparse.tests.test_sparse import assert_sp_series_equal, assert_sp_frame_equal
 from pandas import Timestamp, tslib
 
 nan = np.nan
 
-from pandas.io.packers import to_msgpack, read_msgpack
+from pandas.io.packers import to_msgpack, read_msgpack, reads_msgpack
 
 _multiprocess_can_split_ = False
 
@@ -62,19 +62,19 @@ class TestAPI(TestPackers):
 
         df = DataFrame(np.random.randn(10,2))
         s = df.to_msgpack(None)
-        result = read_msgpack(s)
+        result = reads_msgpack(s)
         tm.assert_frame_equal(result,df)
 
         s = df.to_msgpack()
-        result = read_msgpack(s)
+        result = reads_msgpack(s)
         tm.assert_frame_equal(result,df)
 
         s = df.to_msgpack()
-        result = read_msgpack(compat.BytesIO(s))
+        result = reads_msgpack(compat.BytesIO(s))
         tm.assert_frame_equal(result,df)
 
         s = to_msgpack(None,df)
-        result = read_msgpack(s)
+        result = reads_msgpack(s)
         tm.assert_frame_equal(result, df)
 
         with ensure_clean(self.path) as p:
@@ -90,7 +90,7 @@ class TestAPI(TestPackers):
 
         dfs = [ DataFrame(np.random.randn(10,2)) for i in range(5) ]
         s = to_msgpack(None,*dfs)
-        for i, result in enumerate(read_msgpack(s,iterator=True)):
+        for i, result in enumerate(reads_msgpack(s,iterator=True)):
             tm.assert_frame_equal(result,dfs[i])
 
 class TestNumpy(TestPackers):


### PR DESCRIPTION
related #5655
related #5874
closes #5924

todo:

```
[ ] update io.rst docs / whatsnew
[ ] more tests (esp pickle/csv) for passing string to ``read_csv`` or file-handle to ``reads_csv``
```
