### PR TITLE
BUG: Fix to_datetime to properly deal with tz offsets #3944

### DIFF
--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -189,6 +189,29 @@ class TestArrayToDatetime(tm.TestCase):
             )
         )
 
+    def test_parsing_timezone_offsets(self):
+        # All of these datetime strings with offsets are equivalent
+        # to the same datetime after the timezone offset is added
+        dt_strings = [
+            '01-01-2013 08:00:00+08:00',
+            '2013-01-01T08:00:00.000000000+0800',
+            '2012-12-31T16:00:00.000000000-0800',
+            '12-31-2012 23:00:00-01:00',
+        ]
+
+        expected_output = tslib.array_to_datetime(
+            np.array(['01-01-2013 00:00:00'], dtype=object)
+        )
+
+        for dt_string in dt_strings:
+            self.assert_(
+                np.array_equal(
+                    tslib.array_to_datetime(
+                        np.array([dt_string], dtype=object)
+                    ),
+                    expected_output
+                )
+            )
 
 class TestTimestampNsOperations(tm.TestCase):
     def setUp(self):

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -995,7 +995,7 @@ def array_to_datetime(ndarray[object] values, raise_=False, dayfirst=False,
                       format=None, utc=None, coerce=False, unit=None):
     cdef:
         Py_ssize_t i, n = len(values)
-        object val
+        object val, py_dt
         ndarray[int64_t] iresult
         ndarray[object] oresult
         pandas_datetimestruct dts
@@ -1085,10 +1085,7 @@ def array_to_datetime(ndarray[object] values, raise_=False, dayfirst=False,
                     _check_dts_bounds(&dts)
                 except ValueError:
                     try:
-                        iresult[i] = _pydatetime_to_dts(
-                            parse_datetime_string(val, dayfirst=dayfirst),
-                            &dts
-                        )
+                        py_dt = parse_datetime_string(val, dayfirst=dayfirst)
                     except Exception:
                         if coerce:
                            iresult[i] = iNaT
@@ -1096,7 +1093,8 @@ def array_to_datetime(ndarray[object] values, raise_=False, dayfirst=False,
                         raise TypeError
 
                     try:
-                        _check_dts_bounds(&dts)
+                        _ts = convert_to_tsobject(py_dt, None, None)
+                        iresult[i] = _ts.value
                     except ValueError:
                         if coerce:
                             iresult[i] = iNaT


### PR DESCRIPTION
Currently for certain formats of datetime strings, the tz offset will
just be ignored.
#3944
