### PR TITLE
BUG: use the "join" string in Appender decorator

### DIFF
--- a/pandas/util/decorators.py
+++ b/pandas/util/decorators.py
@@ -102,7 +102,7 @@ class Appender(object):
         func.__doc__ = func.__doc__ if func.__doc__ else ''
         self.addendum = self.addendum if self.addendum else ''
         docitems = [func.__doc__, self.addendum]
-        func.__doc__ = ''.join(docitems)
+        func.__doc__ = self.join.join(docitems)
         return func
 
 


### PR DESCRIPTION
The docstring for Appender decorator says that "join" parameter is used to join the docstring and addendum.  This commit brings the code in line with the documentation.
