### PR TITLE
PERF: add np.max and np.min to _cython_table (GH5927)

### DIFF
--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2994,7 +2994,9 @@ _cython_table = {
     np.prod: 'prod',
     np.std: 'std',
     np.var: 'var',
-    np.median: 'median'
+    np.median: 'median',
+    np.max: 'max',
+    np.min: 'min'
 }
 
 

--- a/vb_suite/timeseries.py
+++ b/vb_suite/timeseries.py
@@ -243,3 +243,29 @@ Benchmark('index.tz_localize("US/Eastern", infer_dst=True)',
           setup, start_date=datetime(2013, 9, 30))
 
 
+#----------------------------------------------------------------------
+# Resampling: fast-path various functions
+
+setup = common_setup + """
+rng = date_range('20130101',periods=100000,freq='50L')
+df = DataFrame(np.random.randn(100000,2),index=rng)
+"""
+
+dataframe_resample_mean_string = \
+    Benchmark("df.resample('1s', how='mean')", setup)
+
+dataframe_resample_mean_numpy = \
+    Benchmark("df.resample('1s', how=np.mean)", setup)
+
+dataframe_resample_min_string = \
+    Benchmark("df.resample('1s', how='min')", setup)
+
+dataframe_resample_min_numpy = \
+    Benchmark("df.resample('1s', how=np.min)", setup)
+
+dataframe_resample_max_string = \
+    Benchmark("df.resample('1s', how='max')", setup)
+
+dataframe_resample_max_numpy = \
+    Benchmark("df.resample('1s', how=np.max)", setup)
+


### PR DESCRIPTION
closes #5927

Fixes numpy max/min slow path on resample and adds tests to vbench.
