### PR TITLE
PERF: perf improvments in dtypes/ftypes methods (GH5968)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -80,6 +80,7 @@ Improvements to existing features
   - The ``ArrayFormatter``s for ``datetime`` and ``timedelta64`` now intelligently
     limit precision based on the values in the array (:issue:`3401`)
   - perf improvements to Series.str.extract (:issue:`5944`)
+  - perf improvments in ``dtypes/ftypes`` methods (:issue:`5968`)
 
 .. _release.bug_fixes-0.13.1:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1441,14 +1441,6 @@ class DataFrame(NDFrame):
         lines.append('dtypes: %s' % ', '.join(dtypes))
         _put_lines(buf, lines)
 
-    @property
-    def dtypes(self):
-        return self.apply(lambda x: x.dtype, reduce=False)
-
-    @property
-    def ftypes(self):
-        return self.apply(lambda x: x.ftype, reduce=False)
-
     def transpose(self):
         """Transpose index and columns"""
         return super(DataFrame, self).transpose(1, 0)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1748,14 +1748,26 @@ class NDFrame(PandasObject):
         return self.as_matrix()
 
     def get_dtype_counts(self):
-        """ return the counts of dtypes in this frame """
+        """ return the counts of dtypes in this object """
         from pandas import Series
         return Series(self._data.get_dtype_counts())
 
     def get_ftype_counts(self):
-        """ return the counts of ftypes in this frame """
+        """ return the counts of ftypes in this object """
         from pandas import Series
         return Series(self._data.get_ftype_counts())
+
+    @property
+    def dtypes(self):
+        """ return the counts of dtypes in this object """
+        from pandas import Series
+        return Series(self._data.get_dtypes(),index=self._info_axis)
+
+    @property
+    def ftypes(self):
+        """ return the counts of ftypes in this object """
+        from pandas import Series
+        return Series(self._data.get_ftypes(),index=self._info_axis)
 
     def as_blocks(self, columns=None):
         """

--- a/vb_suite/frame_methods.py
+++ b/vb_suite/frame_methods.py
@@ -326,3 +326,12 @@ df = DataFrame({ i:s for i in range(1028) })
 frame_apply_user_func = Benchmark('df.apply(lambda x: np.corrcoef(x,s)[0,1])', setup,
                            start_date=datetime(2012,1,1))
 
+#----------------------------------------------------------------------
+# dtypes
+
+setup = common_setup + """
+df = DataFrame(np.random.randn(1000,1000))
+"""
+frame_dtypes = Benchmark('df.dtypes', setup,
+                         start_date=datetime(2012,1,1))
+


### PR DESCRIPTION
closes #5968

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
frame_dtypes                                 |   0.2654 |  51.2140 |   0.0052 |
frame_wide_repr                              |  17.1947 | 525.7313 |   0.0327 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [6a7bfc1] : PERF: perf improvments in dtypes/ftypes methods (GH5968)
Base   [2081fcc] : Merge pull request #5951 from y-p/PR_latest_ipython_rep_fixes

CLN: repr_html raises NotImplementedError rather then ValueError in qtconsole
```
