### PR TITLE
BUG: Allow DatetimeIndex for scipy interpolate

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -114,6 +114,7 @@ Bug Fixes
     incorrectly (:issue:`5947`)
   - Fixed ``to_datetime`` for array with both Tz-aware datetimes and ``NaT``s  (:issue:`5961`)
   - Bug in rolling skew/kurtosis when passed a Series with bad data (:issue:`5749`)
+  - Bug in scipy ``interpolate`` methods with a datetime index (:issue: `5975`)
 
 pandas 0.13.0
 -------------

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1401,6 +1401,7 @@ def _interpolate_scipy_wrapper(x, y, new_x, method, fill_value=None,
     """
     try:
         from scipy import interpolate
+        from pandas import DatetimeIndex
     except ImportError:
         raise ImportError('{0} interpolation requires Scipy'.format(method))
 
@@ -1412,6 +1413,10 @@ def _interpolate_scipy_wrapper(x, y, new_x, method, fill_value=None,
         'krogh': interpolate.krogh_interpolate,
         'piecewise_polynomial': interpolate.piecewise_polynomial_interpolate,
     }
+
+    if hasattr(x, 'asi8'):
+        # GH 5975, scipy.interp1d can't hande datetime64s
+        x, new_x = x.values.view('i8'), new_x.view('i8')
 
     try:
         alt_methods['pchip'] = interpolate.pchip_interpolate

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -587,6 +587,13 @@ class TestSeries(tm.TestCase, Generic):
         with tm.assertRaises(ValueError):
             s.interpolate(method='krogh')
 
+    def test_interp_datetime64(self):
+        _skip_if_no_scipy()
+        df = Series([1, np.nan, 3], index=date_range('1/1/2000', periods=3))
+        result = df.interpolate(method='nearest')
+        expected = Series([1, 1, 3], index=date_range('1/1/2000', periods=3))
+        assert_series_equal(result, expected)
+
 class TestDataFrame(tm.TestCase, Generic):
     _typ = DataFrame
     _comparator = lambda self, x, y: assert_frame_equal(x,y)


### PR DESCRIPTION
Closes #5975

Is there a better way to check for a DatetimeIndex than with an `isinstance()`?
