### PR TITLE
ENH: series rank has a percentage rank option

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -66,6 +66,7 @@ API Changes
 - ``df['col'] = value`` and ``df.loc[:,'col'] = value`` are now completely equivalent;
   previously the ``.loc`` would not necessarily coerce the dtype of the resultant series (:issue:`6149`)
 
+
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -83,6 +84,8 @@ Improvements to existing features
 - implement joining a single-level indexed DataFrame on a matching column of a multi-indexed DataFrame (:issue:`3662`)
 - Performance improvement in indexing into a multi-indexed Series (:issue:`5567`)
 - Testing statements updated to use specialized asserts (:issue: `6175`)
+- ``Series.rank()`` now has a percentage rank option (:issue: `5971`)
+
 
 .. _release.bug_fixes-0.14.0:
 

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -285,14 +285,14 @@ def mode(values):
 
 
 def rank(values, axis=0, method='average', na_option='keep',
-         ascending=True):
+         ascending=True, pct=False):
     """
 
     """
     if values.ndim == 1:
         f, values = _get_data_algo(values, _rank1d_functions)
         ranks = f(values, ties_method=method, ascending=ascending,
-                  na_option=na_option)
+                  na_option=na_option, pct=pct)
     elif values.ndim == 2:
         f, values = _get_data_algo(values, _rank2d_functions)
         ranks = f(values, axis=axis, ties_method=method,

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1707,7 +1707,8 @@ class Series(generic.NDFrame):
                 np.argsort(values, kind=kind), index=self.index,
                 dtype='int64').__finalize__(self)
 
-    def rank(self, method='average', na_option='keep', ascending=True):
+    def rank(self, method='average', na_option='keep', ascending=True,
+             pct=False):
         """
         Compute data ranks (1 through n). Equal values are assigned a rank that
         is the average of the ranks of those values
@@ -1723,14 +1724,16 @@ class Series(generic.NDFrame):
             keep: leave NA values where they are
         ascending : boolean, default True
             False for ranks by high (1) to low (N)
-
+        pct : boolean, defeault False
+            Computes percentage rank of data
+            
         Returns
         -------
         ranks : Series
         """
         from pandas.core.algorithms import rank
         ranks = rank(self.values, method=method, na_option=na_option,
-                     ascending=ascending)
+                     ascending=ascending, pct=pct)
         return self._constructor(ranks, index=self.index).__finalize__(self)
 
     def order(self, na_last=True, ascending=True, kind='mergesort'):

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -2348,7 +2348,15 @@ class TestGroupBy(tm.TestCase):
             expected.append(piece.value.rank())
         expected = concat(expected, axis=0)
         expected = expected.reindex(result.index)
+        assert_series_equal(result, expected)
 
+        result = df.groupby(['key1', 'key2']).value.rank(pct=True)
+
+        expected = []
+        for key, piece in df.groupby(['key1', 'key2']):
+            expected.append(piece.value.rank(pct=True))
+        expected = concat(expected, axis=0)
+        expected = expected.reindex(result.index)
         assert_series_equal(result, expected)
 
     def test_dont_clobber_name_column(self):

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -3955,6 +3955,48 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         iranks = iseries.rank()
         exp = iseries.astype(float).rank()
         assert_series_equal(iranks, exp)
+        iseries = Series(np.arange(5)) + 1.0
+        exp = iseries / 5.0
+        iranks = iseries.rank(pct=True)
+
+        assert_series_equal(iranks, exp)
+
+        iseries = Series(np.repeat(1, 100))
+        exp = Series(np.repeat(0.505, 100))
+        iranks = iseries.rank(pct=True)
+        assert_series_equal(iranks, exp)
+
+        iseries[1] = np.nan
+        exp = Series(np.repeat(50.0 / 99.0, 100))
+        exp[1] =  np.nan
+        iranks = iseries.rank(pct=True)
+        assert_series_equal(iranks, exp)
+
+        iseries = Series(np.arange(5)) + 1.0
+        iseries[4] = np.nan
+        exp = iseries / 4.0
+        iranks = iseries.rank(pct=True)
+        assert_series_equal(iranks, exp)
+
+        iseries = Series(np.repeat(np.nan, 100))
+        exp = iseries.copy()
+        iranks = iseries.rank(pct=True)
+        assert_series_equal(iranks, exp)
+
+        iseries = Series(np.arange(5)) + 1
+        iseries[4] = np.nan
+        exp = iseries / 4.0
+        iranks = iseries.rank(pct=True)
+        assert_series_equal(iranks, exp)
+        rng = date_range('1/1/1990', periods=5)
+
+        iseries = Series(np.arange(5), rng) + 1
+        iseries.ix[4] = np.nan
+        exp = iseries / 4.0
+        iranks = iseries.rank(pct=True)
+        assert_series_equal(iranks, exp)
+
+
 
     def test_from_csv(self):
 

--- a/vb_suite/groupby.py
+++ b/vb_suite/groupby.py
@@ -47,6 +47,11 @@ groupby_series_simple_cython = \
     Benchmark('simple_series.groupby(key1).sum()', setup,
               start_date=datetime(2011, 3, 1))
 
+
+stmt4 = "df.groupby('key1').rank(pct=True)"
+groupby_series_simple_cython = Benchmark(stmt4, setup,
+                                    start_date=datetime(2014, 1, 16))
+
 #----------------------------------------------------------------------
 # 2d grouping, aggregate many columns
 

--- a/vb_suite/stat_ops.py
+++ b/vb_suite/stat_ops.py
@@ -85,6 +85,10 @@ s = Series(values)
 stats_rank_average = Benchmark('s.rank()', setup,
                                start_date=datetime(2011, 12, 12))
 
+stats_rank_pct_average = Benchmark('s.rank(pct=True)', setup,
+                                   start_date=datetime(2014, 01, 16))
+stats_rank_pct_average_old = Benchmark('s.rank() / s.size()', setup,
+                                       start_date=datetime(2014, 01, 16))
 setup = common_setup + """
 values = np.random.randint(0, 100000, size=200000)
 s = Series(values)


### PR DESCRIPTION
closes #5971
This pull allows people to compute percentage ranks in cython for a series. I found myself computing this all the time and it will make this calculation much faster.  
