### PR TITLE
DOC: add a couple plt.close('all') to avoid warning

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -71,10 +71,10 @@ Improvements to existing features
 
   - perf improvements in Series datetime/timedelta binary operations (:issue:`5801`)
   - `option_context` context manager now available as top-level API (:issue:`5752`)
-  - df.info() view now display dtype info per column (:issue: `5682`)
-  - df.info() now honors option max_info_rows, disable null counts for large frames (:issue: `5974`)
+  - df.info() view now display dtype info per column (:issue:`5682`)
+  - df.info() now honors option max_info_rows, disable null counts for large frames (:issue:`5974`)
   - perf improvements in DataFrame ``count/dropna`` for ``axis=1``
-  - Series.str.contains now has a `regex=False` keyword which can be faster for plain (non-regex) string patterns. (:issue: `5879`)
+  - Series.str.contains now has a `regex=False` keyword which can be faster for plain (non-regex) string patterns. (:issue:`5879`)
   - support ``dtypes`` on ``Panel``
   - extend ``Panel.apply`` to allow arbitrary functions (rather than only ufuncs) (:issue:`1148`)
     allow multiple axes to be used to operate on slabs of a ``Panel``
@@ -114,9 +114,9 @@ Bug Fixes
     ``MultiIndex`` (:issue:`5402`).
   - Bug in ``pd.read_msgpack`` with inferring a ``DateTimeIndex`` frequencey
     incorrectly (:issue:`5947`)
-  - Fixed ``to_datetime`` for array with both Tz-aware datetimes and ``NaT``s  (:issue:`5961`)
+  - Fixed ``to_datetime`` for array with both Tz-aware datetimes and ``NaT``'s  (:issue:`5961`)
   - Bug in rolling skew/kurtosis when passed a Series with bad data (:issue:`5749`)
-  - Bug in scipy ``interpolate`` methods with a datetime index (:issue: `5975`)
+  - Bug in scipy ``interpolate`` methods with a datetime index (:issue:`5975`)
   - Bug in NaT comparison if a mixed datetime/np.datetime64 with NaT were passed (:issue:`5968`)
 
 pandas 0.13.0

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -220,6 +220,11 @@ You can pass an ``ax`` argument to ``Series.plot`` to plot on a particular axis:
    @savefig series_plot_multi.png
    df['D'].plot(ax=axes[1,1]); axes[1,1].set_title('D')
 
+.. ipython:: python
+   :suppress:
+
+    plt.close('all')
+
 
 .. _visualization.other:
 
@@ -360,6 +365,11 @@ columns:
 
    @savefig box_plot_ex3.png
    bp = df.boxplot(column=['Col1','Col2'], by=['X','Y'])
+
+.. ipython:: python
+   :suppress:
+
+    plt.close('all')
 
 .. _visualization.scatter_matrix:
 
@@ -595,3 +605,8 @@ Andrews curves charts:
 
    @savefig andrews_curve_winter.png
    andrews_curves(data, 'Name', colormap='winter')
+
+.. ipython:: python
+   :suppress:
+
+    plt.close('all')


### PR DESCRIPTION
Some small doc fixes:
- added some `plt.close('all')` calls to avoid the matplotlib warning that there are more than 20 figures open.
- some style errors in release.rst. Apparantly sphinx complains about something like ```NaN``s`.because there may not be a character directly after the closing ````
