### PR TITLE
Modified test_pow function in computation/tests/test_eval.py to use asse...

### DIFF
--- a/pandas/computation/tests/test_eval.py
+++ b/pandas/computation/tests/test_eval.py
@@ -405,13 +405,13 @@ class TestEvalNumexprPandas(tm.TestCase):
             self.assertRaises(AssertionError, assert_array_equal, result,
                               expected)
         else:
-            assert_array_equal(result, expected)
+            assert_allclose(result, expected)
 
             ex = '(lhs {0} rhs) {0} rhs'.format(arith1)
             result = pd.eval(ex, engine=self.engine, parser=self.parser)
             expected = self.get_expected_pow_result(
                 self.get_expected_pow_result(lhs, rhs), rhs)
-            assert_array_equal(result, expected)
+            assert_allclose(result, expected)
 
     @skip_incompatible_operand
     def check_single_invert_op(self, lhs, cmp1, rhs):


### PR DESCRIPTION
...rt_allclose rather than assert_all_equal to avoid machine precision failures in TestEvalNumexprPandas/Numpy.  Fixes issue #5981.
