### PR TITLE
DOC: correction of docstring dtypes/ftypes

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1748,24 +1748,27 @@ class NDFrame(PandasObject):
         return self.as_matrix()
 
     def get_dtype_counts(self):
-        """ return the counts of dtypes in this object """
+        """ Return the counts of dtypes in this object """
         from pandas import Series
         return Series(self._data.get_dtype_counts())
 
     def get_ftype_counts(self):
-        """ return the counts of ftypes in this object """
+        """ Return the counts of ftypes in this object """
         from pandas import Series
         return Series(self._data.get_ftype_counts())
 
     @property
     def dtypes(self):
-        """ return the counts of dtypes in this object """
+        """ Return the dtypes in this object """
         from pandas import Series
         return Series(self._data.get_dtypes(),index=self._info_axis)
 
     @property
     def ftypes(self):
-        """ return the counts of ftypes in this object """
+        """
+        Return the ftypes (indication of sparse/dense and dtype)
+        in this object.
+        """
         from pandas import Series
         return Series(self._data.get_ftypes(),index=self._info_axis)
 


### PR DESCRIPTION
@jreback 

See #5970, you copied the docstring of `get_dtype_counts`. Only thing I was wondering: `columns` is maybe not generic enough?
