### PR TITLE
BUG/CLN: clarified timedelta inferences

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -62,6 +62,8 @@ API Changes
     when detecting chained assignment, related (:issue:`5938`)
   - DataFrame.head(0) returns self instead of empty frame (:issue:`5846`)
   - ``autocorrelation_plot`` now accepts ``**kwargs``. (:issue:`5623`)
+  - ``convert_objects`` now accepts a ``convert_timedeltas='coerce'`` argument to allow forced dtype conversion of
+    timedeltas (:issue:`5458`,:issue:`5689`)
 
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~
@@ -78,12 +80,13 @@ Improvements to existing features
   - support ``dtypes`` property on ``Series/Panel/Panel4D``
   - extend ``Panel.apply`` to allow arbitrary functions (rather than only ufuncs) (:issue:`1148`)
     allow multiple axes to be used to operate on slabs of a ``Panel``
-  - The ``ArrayFormatter``s for ``datetime`` and ``timedelta64`` now intelligently
+  - The ``ArrayFormatter`` for ``datetime`` and ``timedelta64`` now intelligently
     limit precision based on the values in the array (:issue:`3401`)
   - pd.show_versions() is now available for convenience when reporting issues.
   - perf improvements to Series.str.extract (:issue:`5944`)
   - perf improvments in ``dtypes/ftypes`` methods (:issue:`5968`)
   - perf improvments in indexing with object dtypes (:issue:`5968`)
+  - improved dtype inference for ``timedelta`` like passed to constructors (:issue:`5458`,:issue:`5689`)
 
 .. _release.bug_fixes-0.13.1:
 
@@ -122,6 +125,7 @@ Bug Fixes
   - Recent changes in IPython cause warnings to be emitted when using previous versions
     of pandas in QTConsole, now fixed. If you're using an older version and
     need to supress the warnings, see (:issue:`5922`).
+  - Bug in merging ``timedelta`` dtypes (:issue:`5695`)
 
 pandas 0.13.0
 -------------

--- a/doc/source/v0.13.1.txt
+++ b/doc/source/v0.13.1.txt
@@ -3,7 +3,7 @@
 v0.13.1 (???)
 -------------
 
-This is a major release from 0.13.0 and includes a number of API changes, several new features and
+This is a minor release from 0.13.0 and includes a number of API changes, several new features and
 enhancements along with a large number of bug fixes.
 
 Highlights include:
@@ -28,6 +28,27 @@ Deprecations
 
 Enhancements
 ~~~~~~~~~~~~
+
+- The ``ArrayFormatter`` for ``datetime`` and ``timedelta64`` now intelligently
+  limit precision based on the values in the array (:issue:`3401`)
+
+  Previously output might look like:
+
+  .. code-block:: python
+
+        age                 today               diff
+      0 2001-01-01 00:00:00 2013-04-19 00:00:00 4491 days, 00:00:00
+      1 2004-06-01 00:00:00 2013-04-19 00:00:00 3244 days, 00:00:00
+
+  Now the output looks like:
+
+   .. ipython:: python
+
+      df = DataFrame([ Timestamp('20010101'),
+                       Timestamp('20040601') ], columns=['age'])
+      df['today'] = Timestamp('20130419')
+      df['diff'] = df['today']-df['age']
+      df
 
 - ``Panel.apply`` will work on non-ufuncs. See :ref:`the docs<basics.apply_panel>`.
 
@@ -83,27 +104,6 @@ Enhancements
      result
      result.loc[:,:,'ItemA']
 
-- The ``ArrayFormatter``s for ``datetime`` and ``timedelta64`` now intelligently
-  limit precision based on the values in the array (:issue:`3401`)
-  
-  Previously output might look like:
-
-  .. code-block:: python
-   
-        age                 today               diff
-      0 2001-01-01 00:00:00 2013-04-19 00:00:00 4491 days, 00:00:00
-      1 2004-06-01 00:00:00 2013-04-19 00:00:00 3244 days, 00:00:00
-      
-  Now the output looks like:
-
-   .. ipython:: python
-   
-      df = DataFrame([ Timestamp('20010101'),
-                       Timestamp('20040601') ], columns=['age'])
-      df['today'] = Timestamp('20130419')
-      df['diff'] = df['today']-df['age']
-      df
-   
 Experimental
 ~~~~~~~~~~~~
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1514,7 +1514,8 @@ def _values_from_object(o):
 
 
 def _possibly_convert_objects(values, convert_dates=True,
-                              convert_numeric=True):
+                              convert_numeric=True,
+                              convert_timedeltas=True):
     """ if we have an object dtype, try to coerce dates and/or numbers """
 
     # if we have passed in a list or scalar
@@ -1538,6 +1539,22 @@ def _possibly_convert_objects(values, convert_dates=True,
         else:
             values = lib.maybe_convert_objects(
                 values, convert_datetime=convert_dates)
+
+    # convert timedeltas
+    if convert_timedeltas and values.dtype == np.object_:
+
+        if convert_timedeltas == 'coerce':
+            from pandas.tseries.timedeltas import \
+                 _possibly_cast_to_timedelta
+            values = _possibly_cast_to_timedelta(values)
+
+            # if we are all nans then leave me alone
+            if not isnull(new_values).all():
+                values = new_values
+
+        else:
+            values = lib.maybe_convert_objects(
+                values, convert_timedelta=convert_timedeltas)
 
     # convert to numeric
     if values.dtype == np.object_:

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1546,7 +1546,7 @@ def _possibly_convert_objects(values, convert_dates=True,
         if convert_timedeltas == 'coerce':
             from pandas.tseries.timedeltas import \
                  _possibly_cast_to_timedelta
-            values = _possibly_cast_to_timedelta(values)
+            values = _possibly_cast_to_timedelta(values, coerce=True)
 
             # if we are all nans then leave me alone
             if not isnull(new_values).all():
@@ -1641,7 +1641,7 @@ def _possibly_cast_to_datetime(value, dtype, coerce=False):
                         elif is_timedelta64:
                             from pandas.tseries.timedeltas import \
                                 _possibly_cast_to_timedelta
-                            value = _possibly_cast_to_timedelta(value)
+                            value = _possibly_cast_to_timedelta(value, coerce=True)
                     except:
                         pass
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1641,7 +1641,7 @@ def _possibly_cast_to_datetime(value, dtype, coerce=False):
                         elif is_timedelta64:
                             from pandas.tseries.timedeltas import \
                                 _possibly_cast_to_timedelta
-                            value = _possibly_cast_to_timedelta(value, coerce=True)
+                            value = _possibly_cast_to_timedelta(value, coerce='compat')
                     except:
                         pass
 
@@ -1672,7 +1672,7 @@ def _possibly_cast_to_datetime(value, dtype, coerce=False):
                 elif inferred_type in ['timedelta', 'timedelta64']:
                     from pandas.tseries.timedeltas import \
                         _possibly_cast_to_timedelta
-                    value = _possibly_cast_to_timedelta(value)
+                    value = _possibly_cast_to_timedelta(value, coerce='compat')
 
     return value
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3626,7 +3626,7 @@ class DataFrame(NDFrame):
             index = None if other.name is None else [other.name]
             other = other.reindex(self.columns, copy=False)
             other = DataFrame(other.values.reshape((1, len(other))),
-                              index=index, columns=self.columns)
+                              index=index, columns=self.columns).convert_objects()
         elif isinstance(other, list) and not isinstance(other[0], DataFrame):
             other = DataFrame(other)
             if (self.columns.get_indexer(other.columns) >= 0).all():

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1844,16 +1844,18 @@ class NDFrame(PandasObject):
         return self._constructor(data).__finalize__(self)
 
     def convert_objects(self, convert_dates=True, convert_numeric=False,
-                        copy=True):
+                        convert_timedeltas=True, copy=True):
         """
         Attempt to infer better dtype for object columns
 
         Parameters
         ----------
-        convert_dates : if True, attempt to soft convert_dates, if 'coerce',
+        convert_dates : if True, attempt to soft convert dates, if 'coerce',
             force conversion (and non-convertibles get NaT)
         convert_numeric : if True attempt to coerce to numbers (including
             strings), non-convertibles get NaN
+        convert_timedeltas : if True, attempt to soft convert timedeltas, if 'coerce',
+            force conversion (and non-convertibles get NaT)
         copy : Boolean, if True, return copy, default is True
 
         Returns
@@ -1863,6 +1865,7 @@ class NDFrame(PandasObject):
         return self._constructor(
             self._data.convert(convert_dates=convert_dates,
                                convert_numeric=convert_numeric,
+                               convert_timedeltas=convert_timedeltas,
                                copy=copy)).__finalize__(self)
 
     #----------------------------------------------------------------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3177,23 +3177,22 @@ class NDFrame(PandasObject):
         -------
         abs: type of caller
         """
-        obj = np.abs(self)
 
         # suprimo numpy 1.6 hacking
+        # for timedeltas
         if _np_version_under1p7:
+
+            def _convert_timedeltas(x):
+                if x.dtype.kind == 'm':
+                    return np.abs(x.view('i8')).astype(x.dtype)
+                return np.abs(x)
+
             if self.ndim == 1:
-                if obj.dtype == 'm8[us]':
-                    obj = obj.astype('m8[ns]')
+                return _convert_timedeltas(self)
             elif self.ndim == 2:
-                def f(x):
-                    if x.dtype == 'm8[us]':
-                        x = x.astype('m8[ns]')
-                    return x
+                return  self.apply(_convert_timedeltas)
 
-                if 'm8[us]' in obj.dtypes.values:
-                    obj = obj.apply(f)
-
-        return obj
+        return np.abs(self)
 
     def pct_change(self, periods=1, fill_method='pad', limit=None, freq=None,
                    **kwds):

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1315,8 +1315,8 @@ class ObjectBlock(Block):
         """
         return lib.is_bool_array(self.values.ravel())
 
-    def convert(self, convert_dates=True, convert_numeric=True, copy=True,
-                by_item=True):
+    def convert(self, convert_dates=True, convert_numeric=True, convert_timedeltas=True,
+                copy=True, by_item=True):
         """ attempt to coerce any object types to better types
             return a copy of the block (if copy = True)
             by definition we ARE an ObjectBlock!!!!!
@@ -1334,7 +1334,8 @@ class ObjectBlock(Block):
 
                 values = com._possibly_convert_objects(
                     values.ravel(), convert_dates=convert_dates,
-                    convert_numeric=convert_numeric
+                    convert_numeric=convert_numeric,
+                    convert_timedeltas=convert_timedeltas,
                 ).reshape(values.shape)
                 values = _block_shape(values, ndim=self.ndim)
                 items = self.items.take([i])

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -31,7 +31,7 @@ from datetime import datetime as pydatetime
 # this is our tseries.pxd
 from datetime cimport *
 
-from tslib cimport convert_to_tsobject
+from tslib cimport convert_to_tsobject, convert_to_timedelta64
 import tslib
 from tslib import NaT, Timestamp, repr_timedelta64
 

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -14,7 +14,7 @@ from cpython cimport (PyDict_New, PyDict_GetItem, PyDict_SetItem,
                       Py_INCREF, PyTuple_SET_ITEM,
                       PyList_Check, PyFloat_Check,
                       PyString_Check,
-		      PyBytes_Check,
+                      PyBytes_Check,
                       PyTuple_SetItem,
                       PyTuple_New,
                       PyObject_SetAttrString)

--- a/pandas/src/datetime.pxd
+++ b/pandas/src/datetime.pxd
@@ -37,6 +37,7 @@ cdef extern from "datetime.h":
     bint PyDateTime_Check(object o)
     bint PyDate_Check(object o)
     bint PyTime_Check(object o)
+    bint PyDelta_Check(object o)
     object PyDateTime_FromDateAndTime(int year, int month, int day, int hour,
                                       int minute, int second, int us)
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -2263,6 +2263,16 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
                     for i in range(3)] + [np.nan ], dtype='m8[ns]' )
         self.assert_(td.dtype == 'timedelta64[ns]')
 
+        td = Series([np.timedelta64(300000000), pd.NaT],dtype='m8[ns]')
+        self.assert_(td.dtype == 'timedelta64[ns]')
+
+        # improved inference
+        td = Series([np.timedelta64(300000000), pd.NaT])
+        self.assert_(td.dtype == 'timedelta64[ns]')
+
+        td = Series([pd.NaT, np.timedelta64(300000000)])
+        self.assert_(td.dtype == 'timedelta64[ns]')
+
         # these are frequency conversion astypes
         #for t in ['s', 'D', 'us', 'ms']:
         #    self.assertRaises(TypeError, td.astype, 'm8[%s]' % t)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -2253,8 +2253,9 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         td = Series([timedelta(days=1)])
         self.assert_(td.dtype == 'timedelta64[ns]')
 
-        td = Series([timedelta(days=1),timedelta(days=2),np.timedelta64(1,'s')])
-        self.assert_(td.dtype == 'timedelta64[ns]')
+        if not _np_version_under1p7:
+            td = Series([timedelta(days=1),timedelta(days=2),np.timedelta64(1,'s')])
+            self.assert_(td.dtype == 'timedelta64[ns]')
 
         # mixed with NaT
         from pandas import tslib
@@ -2281,8 +2282,9 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         td = Series([pd.NaT, np.timedelta64(300000000)])
         self.assert_(td.dtype == 'timedelta64[ns]')
 
-        td = Series([np.timedelta64(1,'s')])
-        self.assert_(td.dtype == 'timedelta64[ns]')
+        if not _np_version_under1p7:
+            td = Series([np.timedelta64(1,'s')])
+            self.assert_(td.dtype == 'timedelta64[ns]')
 
         # these are frequency conversion astypes
         #for t in ['s', 'D', 'us', 'ms']:
@@ -2878,6 +2880,9 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         assert_series_equal(ts.bfill(), ts.fillna(method='bfill'))
 
     def test_sub_of_datetime_from_TimeSeries(self):
+        if _np_version_under1p7:
+            raise nose.SkipTest("timedelta broken in np 1.6.1")
+
         from pandas.tseries.timedeltas import _possibly_cast_to_timedelta
         from datetime import datetime
         a = Timestamp(datetime(1993, 0o1, 0o7, 13, 30, 00))

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -14,7 +14,7 @@ from pandas.core.series import Series
 from pandas.core.index import (Index, MultiIndex, _get_combined_index,
                                _ensure_index, _get_consensus_names,
                                _all_indexes_same)
-from pandas.core.internals import (IntBlock, BoolBlock, BlockManager,
+from pandas.core.internals import (TimeDeltaBlock, IntBlock, BoolBlock, BlockManager,
                                    make_block, _consolidate)
 from pandas.util.decorators import cache_readonly, Appender, Substitution
 from pandas.core.common import (PandasError, ABCSeries,
@@ -816,7 +816,7 @@ class _JoinUnit(object):
 
 def _may_need_upcasting(blocks):
     for block in blocks:
-        if isinstance(block, (IntBlock, BoolBlock)):
+        if isinstance(block, (IntBlock, BoolBlock)) and not isinstance(block, TimeDeltaBlock):
             return True
     return False
 
@@ -827,7 +827,10 @@ def _upcast_blocks(blocks):
     """
     new_blocks = []
     for block in blocks:
-        if isinstance(block, IntBlock):
+        if isinstance(block, TimeDeltaBlock):
+            # these are int blocks underlying, but are ok
+            newb = block
+        elif isinstance(block, IntBlock):
             newb = make_block(block.values.astype(float), block.items,
                               block.ref_items, placement=block._ref_locs)
         elif isinstance(block, BoolBlock):

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -9,7 +9,7 @@ import numpy as np
 import random
 
 from pandas.compat import range, lrange, lzip, zip
-from pandas import compat
+from pandas import compat, _np_version_under1p7
 from pandas.tseries.index import DatetimeIndex
 from pandas.tools.merge import merge, concat, ordered_merge, MergeError
 from pandas.util.testing import (assert_frame_equal, assert_series_equal,
@@ -791,8 +791,16 @@ class TestMerge(tm.TestCase):
         result = df1.append(df2,ignore_index=True)
         assert_frame_equal(result, expected)
 
-        # timedelta64
+    def test_join_append_timedeltas(self):
+
+        import datetime as dt
+        from pandas import NaT
+
+        # timedelta64 issues with join/merge
         # GH 5695
+        if _np_version_under1p7:
+            raise nose.SkipTest("numpy < 1.7")
+
         d = {'d': dt.datetime(2013, 11, 5, 5, 56), 't': dt.timedelta(0, 22500)}
         df = DataFrame(columns=list('dt'))
         df = df.append(d, ignore_index=True)
@@ -1787,6 +1795,11 @@ class TestConcatenate(tm.TestCase):
         self.assert_((result.iloc[10:]['time'] == rng).all())
 
     def test_concat_timedelta64_block(self):
+
+        # not friendly for < 1.7
+        if _np_version_under1p7:
+            raise nose.SkipTest("numpy < 1.7")
+
         from pandas import to_timedelta
 
         rng = to_timedelta(np.arange(10),unit='s')

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -791,6 +791,26 @@ class TestMerge(tm.TestCase):
         result = df1.append(df2,ignore_index=True)
         assert_frame_equal(result, expected)
 
+        # timedelta64
+        # GH 5695
+        d = {'d': dt.datetime(2013, 11, 5, 5, 56), 't': dt.timedelta(0, 22500)}
+        df = DataFrame(columns=list('dt'))
+        df = df.append(d, ignore_index=True)
+        result = df.append(d, ignore_index=True)
+        expected = DataFrame({'d': [dt.datetime(2013, 11, 5, 5, 56),
+                                    dt.datetime(2013, 11, 5, 5, 56) ],
+                              't': [ dt.timedelta(0, 22500),
+                                     dt.timedelta(0, 22500) ]})
+        assert_frame_equal(result, expected)
+
+        td = np.timedelta64(300000000)
+        lhs = DataFrame(Series([td,td],index=["A","B"]))
+        rhs = DataFrame(Series([td],index=["A"]))
+
+        from pandas import NaT
+        result = lhs.join(rhs,rsuffix='r', how="left")
+        expected = DataFrame({ '0' : Series([td,td],index=list('AB')), '0r' : Series([td,NaT],index=list('AB')) })
+        assert_frame_equal(result, expected)
 
     def test_overlapping_columns_error_message(self):
         # #2649
@@ -1763,7 +1783,19 @@ class TestConcatenate(tm.TestCase):
         df = DataFrame({'time': rng})
 
         result = concat([df, df])
-        self.assert_((result[:10]['time'] == rng).all())
+        self.assert_((result.iloc[:10]['time'] == rng).all())
+        self.assert_((result.iloc[10:]['time'] == rng).all())
+
+    def test_concat_timedelta64_block(self):
+        from pandas import to_timedelta
+
+        rng = to_timedelta(np.arange(10),unit='s')
+
+        df = DataFrame({'time': rng})
+
+        result = concat([df, df])
+        self.assert_((result.iloc[:10]['time'] == rng).all())
+        self.assert_((result.iloc[10:]['time'] == rng).all())
 
     def test_concat_keys_with_none(self):
         # #1649

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -165,11 +165,13 @@ class TestTimedeltas(tm.TestCase):
         # single element conversion
         v = timedelta(seconds=1)
         result = to_timedelta(v,box=False)
-        expected = to_timedelta([v])
+        expected = np.timedelta64(timedelta(seconds=1))
+        self.assert_(result == expected)
 
         v = np.timedelta64(timedelta(seconds=1))
         result = to_timedelta(v,box=False)
-        expected = to_timedelta([v])
+        expected = np.timedelta64(timedelta(seconds=1))
+        self.assert_(result == expected)
 
     def test_timedelta_ops(self):
         _skip_if_numpy_not_friendly()

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -173,6 +173,16 @@ class TestTimedeltas(tm.TestCase):
         expected = np.timedelta64(timedelta(seconds=1))
         self.assert_(result == expected)
 
+    def test_to_timedelta_via_apply(self):
+
+        # GH 5458
+        expected = Series([np.timedelta64(1,'s')])
+        result = Series(['00:00:01']).apply(to_timedelta)
+        tm.assert_series_equal(result, expected)
+
+        result = Series([to_timedelta('00:00:01')])
+        tm.assert_series_equal(result, expected)
+
     def test_timedelta_ops(self):
         _skip_if_numpy_not_friendly()
 

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -174,6 +174,7 @@ class TestTimedeltas(tm.TestCase):
         self.assert_(result == expected)
 
     def test_to_timedelta_via_apply(self):
+        _skip_if_numpy_not_friendly()
 
         # GH 5458
         expected = Series([np.timedelta64(1,'s')])

--- a/pandas/tseries/timedeltas.py
+++ b/pandas/tseries/timedeltas.py
@@ -163,7 +163,7 @@ def _possibly_cast_to_timedelta(value, coerce=True):
                     td *= 1000
                 return td
 
-            if td == tslib.compat_NaT:
+            if isnull(td) or td == tslib.compat_NaT or td == tslib.iNaT:
                 return tslib.iNaT
 
             # convert td value to a nanosecond value

--- a/pandas/tslib.pxd
+++ b/pandas/tslib.pxd
@@ -1,3 +1,4 @@
 from numpy cimport ndarray, int64_t
 
 cdef convert_to_tsobject(object, object, object)
+cdef convert_to_timedelta64(object, object)

--- a/pandas/tslib.pxd
+++ b/pandas/tslib.pxd
@@ -1,4 +1,4 @@
 from numpy cimport ndarray, int64_t
 
 cdef convert_to_tsobject(object, object, object)
-cdef convert_to_timedelta64(object, object)
+cdef convert_to_timedelta64(object, object, object)

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -1155,52 +1155,26 @@ def array_to_datetime(ndarray[object] values, raise_=False, dayfirst=False,
 
         return oresult
 
-def array_to_timedelta64(ndarray[object] values, coerce=True):
+def array_to_timedelta64(ndarray[object] values, coerce=False):
     """ convert an ndarray to an array of ints that are timedeltas
         force conversion if coerce = True,
-        else return an object array """
+        else will raise if cannot convert """
     cdef:
         Py_ssize_t i, n
-        object val
-        ndarray[int64_t] result
+        ndarray[int64_t] iresult
 
     n = values.shape[0]
-    result = np.empty(n, dtype='i8')
+    result = np.empty(n, dtype='m8[ns]')
+    iresult = result.view('i8')
+
     for i in range(n):
-        val = values[i]
+        result[i] = convert_to_timedelta64(values[i], 'ns', coerce)
+    return iresult
 
-        # in py3 this is already an int, don't convert
-        if is_integer_object(val):
-            result[i] = val
+def convert_to_timedelta(object ts, object unit='ns', coerce=False):
+    return convert_to_timedelta64(ts, unit, coerce)
 
-        elif isinstance(val,timedelta) or isinstance(val,np.timedelta64):
-
-             if isinstance(val, np.timedelta64):
-                 if val.dtype != 'm8[ns]':
-                      val = val.astype('m8[ns]')
-                 val = val.item()
-             else:
-                 val = _delta_to_nanoseconds(np.timedelta64(val).item())
-
-             result[i] = val
-
-        elif _checknull_with_nat(val):
-             result[i] = iNaT
-
-        else:
-
-             # just return, don't convert
-             if not coerce:
-                 return values.copy()
-
-             result[i] = iNaT
-
-    return result
-
-def convert_to_timedelta(object ts, object unit='ns'):
-    return convert_to_timedelta64(ts, unit)
-
-cdef convert_to_timedelta64(object ts, object unit):
+cdef convert_to_timedelta64(object ts, object unit, object coerce):
     """
     Convert an incoming object to a timedelta64 if possible
 
@@ -1209,6 +1183,8 @@ cdef convert_to_timedelta64(object ts, object unit):
         - timedelta64
         - np.int64 (with unit providing a possible modifier)
         - None/NaT
+
+    if coerce, set a non-valid value to NaT
 
     Return a ns based int64
 
@@ -1237,7 +1213,9 @@ cdef convert_to_timedelta64(object ts, object unit):
 
     if _np_version_under1p7:
         if not isinstance(ts, timedelta):
-            raise AssertionError("Invalid type for timedelta scalar: %s" % type(ts))
+            if coerce:
+                return np.timedelta64(iNaT)
+            raise ValueError("Invalid type for timedelta scalar: %s" % type(ts))
         if not PY2:
             # convert to microseconds in timedelta64
             ts = np.timedelta64(int(ts.total_seconds()*1e9 + ts.microseconds*1000))
@@ -1247,7 +1225,9 @@ cdef convert_to_timedelta64(object ts, object unit):
     if isinstance(ts, timedelta):
         ts = np.timedelta64(ts)
     elif not isinstance(ts, np.timedelta64):
-        raise AssertionError("Invalid type for timedelta scalar: %s" % type(ts))
+        if coerce:
+            return np.timedelta64(iNaT)
+        raise ValueError("Invalid type for timedelta scalar: %s" % type(ts))
     return ts.astype('timedelta64[ns]')
 
 def repr_timedelta64(object value, format=None):

--- a/test.py
+++ b/test.py
@@ -1,0 +1,12 @@
+import numpy as np
+import pandas
+from pandas import Series,DataFrame
+
+print pandas.__version__
+
+s = Series(np.arange(1028.))
+
+df = DataFrame({ i:s for i in range(1028) })
+
+import pdb; pdb.set_trace()
+df.apply(lambda x: np.corrcoef(x,s)[0,1])


### PR DESCRIPTION
closes #5458
closes #5695
closes #5689

cleaned up / clarified timedelta inferences, bottom line is the following works, previously these would
return not-useful object dtypes

```

In [4]: Series([np.timedelta64(1,'s'),timedelta(days=1),pd.NaT])
Out[4]: 
0   0 days, 00:00:01
1   1 days, 00:00:00
2                NaT
dtype: timedelta64[ns]

```
