### PR TITLE
BUG: use astype for scipy datetime interpolation

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1414,9 +1414,9 @@ def _interpolate_scipy_wrapper(x, y, new_x, method, fill_value=None,
         'piecewise_polynomial': interpolate.piecewise_polynomial_interpolate,
     }
 
-    if hasattr(x, 'asi8'):
+    if getattr(x, 'is_all_dates', False):
         # GH 5975, scipy.interp1d can't hande datetime64s
-        x, new_x = x.values.view('i8'), new_x.view('i8')
+        x, new_x = x.values.astype('i8'), new_x.astype('i8')
 
     try:
         alt_methods['pchip'] = interpolate.pchip_interpolate


### PR DESCRIPTION
Closes #5975 (again), with the issue raised at https://github.com/pydata/pandas/pull/5977#issuecomment-32691271.

I'm using `astype` instead of `view` now, as Jeff suggested. I also didn't realize that `asi8` was a method on all `Index`es, and not just `DatetimeIndex`es. So instead of checking for that attr, I just check if it's a DatetimeIndex.

@y-p this should fix the doc example. It built for me anyway, but I've had trouble building the docs off my working branch.
