### PR TITLE
API: clarify DataFrame.apply reduction on empty frames

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -62,6 +62,9 @@ API Changes
     when detecting chained assignment, related (:issue:`5938`)
   - DataFrame.head(0) returns self instead of empty frame (:issue:`5846`)
   - ``autocorrelation_plot`` now accepts ``**kwargs``. (:issue:`5623`)
+  - ``DataFrame.apply`` will use the ``reduce`` argument to determine whether a
+    ``Series`` or a ``DataFrame`` should be returned when the ``DataFrame`` is
+    empty (:issue:`6007`).
 
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/v0.13.1.txt
+++ b/doc/source/v0.13.1.txt
@@ -18,6 +18,37 @@ There are several new or updated docs sections including:
 API changes
 ~~~~~~~~~~~
 
+- ``DataFrame.apply`` will use the ``reduce`` argument to determine whether a
+  ``Series`` or a ``DataFrame`` should be returned when the ``DataFrame`` is
+  empty (:issue:`6007`).
+
+  Previously, calling ``DataFrame.apply`` an empty ``DataFrame`` would return
+  either a ``DataFrame`` if there were no columns, or the function being
+  applied would be called with an empty ``Series`` to guess whether a
+  ``Series`` or ``DataFrame`` should be returned:
+
+  .. ipython:: python
+
+     def applied_func(col):
+        print "Apply function being called with:", col
+        return col.sum()
+
+     import pandas as pd
+     empty = pd.DataFrame(columns=['a', 'b'])
+     empty.apply(applied_func)
+
+  Now, when ``apply`` is called on an empty ``DataFrame``: if the ``reduce``
+  argument is ``True`` a ``Series`` will returned, if it is ``False`` a
+  ``DataFrame`` will be returned, and if it is ``None`` (the default) the
+  function being applied will be called with an empty series to try and guess
+  the return type.
+
+  .. ipython:: python
+
+     empty.apply(applied_func, reduce=True)
+     empty.apply(applied_func, reduce=False)
+
+
 Prior Version Deprecations/Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3363,7 +3363,7 @@ class DataFrame(NDFrame):
     # Function application
 
     def apply(self, func, axis=0, broadcast=False, raw=False, reduce=True,
-              args=(), **kwds):
+              args=(), is_reduction=None, **kwds):
         """
         Applies function along input axis of DataFrame.
 
@@ -3391,6 +3391,14 @@ class DataFrame(NDFrame):
         args : tuple
             Positional arguments to pass to function in addition to the
             array/series
+        is_reduction : boolean or None, default None
+            If the DataFrame is empty, apply needs to determine whether the
+            return value should be a Series or a DataFrame. If is_reduction is
+            None, func will be called with an empty Series and the return value
+            will be guessed based on the result (or, if an exception is raised,
+            a DataFrame will be returned). If is_reduction is True a Series
+            will always be returned, and if False a DataFrame will always be
+            returned.
         Additional keyword arguments will be passed as keywords to the function
 
         Examples
@@ -3423,12 +3431,12 @@ class DataFrame(NDFrame):
         else:
             if not broadcast:
                 if not all(self.shape):
-                    # How to determine this better?
-                    is_reduction = False
-                    try:
-                        is_reduction = not isinstance(f(_EMPTY_SERIES), Series)
-                    except Exception:
-                        pass
+                    if is_reduction is None:
+                        is_reduction = False
+                        try:
+                            is_reduction = not isinstance(f(_EMPTY_SERIES), Series)
+                        except Exception:
+                            pass
 
                     if is_reduction:
                         return Series(NA, index=self._get_agg_axis(axis))

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3369,7 +3369,8 @@ class DataFrame(NDFrame):
 
         Objects passed to functions are Series objects having index
         either the DataFrame's index (axis=0) or the columns (axis=1).
-        Return type depends on whether passed function aggregates
+        Return type depends on whether passed function aggregates, or the
+        reduce argument if the DataFrame is empty.
 
         Parameters
         ----------

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -8978,11 +8978,11 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         rs = xp.apply(lambda x: x['a'], axis=1)
         assert_frame_equal(xp, rs)
 
-        # is_reduction
+        # reduce with an empty DataFrame
         x = []
-        result = self.empty.apply(x.append, axis=1, is_reduction=False)
+        result = self.empty.apply(x.append, axis=1, reduce=False)
         assert_frame_equal(result, self.empty)
-        result = self.empty.apply(x.append, axis=1, is_reduction=True)
+        result = self.empty.apply(x.append, axis=1, reduce=True)
         assert_series_equal(result, Series([]))
         # Ensure that x.append hasn't been called
         self.assertEqual(x, [])

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -8978,6 +8978,15 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         rs = xp.apply(lambda x: x['a'], axis=1)
         assert_frame_equal(xp, rs)
 
+        # is_reduction
+        x = []
+        result = self.empty.apply(x.append, axis=1, is_reduction=False)
+        assert_frame_equal(result, self.empty)
+        result = self.empty.apply(x.append, axis=1, is_reduction=True)
+        assert_series_equal(result, Series([]))
+        # Ensure that x.append hasn't been called
+        self.assertEqual(x, [])
+
     def test_apply_standard_nonunique(self):
         df = DataFrame(
             [[1, 2, 3], [4, 5, 6], [7, 8, 9]], index=['a', 'a', 'c'])

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -8984,6 +8984,13 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_frame_equal(result, self.empty)
         result = self.empty.apply(x.append, axis=1, reduce=True)
         assert_series_equal(result, Series([]))
+
+        empty_with_cols = DataFrame(columns=['a', 'b', 'c'])
+        result = empty_with_cols.apply(x.append, axis=1, reduce=False)
+        assert_frame_equal(result, empty_with_cols)
+        result = empty_with_cols.apply(x.append, axis=1, reduce=True)
+        assert_series_equal(result, Series([]))
+
         # Ensure that x.append hasn't been called
         self.assertEqual(x, [])
 


### PR DESCRIPTION
Add `is_reduction` argument to `DataFrame.apply` to avoid undefined behavior when `.apply` is called on an empty DataFrame when function being applied is only defined for valid inputs.

Currently, if the DataFrame is empty, a guess is made at the correct return value (either a `DataFrame` or a `Series`) by calling the function being applied with an empty Series as an argument:

``` python
if not all(self.shape):
    # How to determine this better?
    is_reduction = False
    try:
        is_reduction = not isinstance(f(_EMPTY_SERIES), Series)
    except Exception:
        pass

    if is_reduction:
        return Series(NA, index=self._get_agg_axis(axis))
    else:
        return self.copy()
```

For reduction functions which produce undefined results on unexpected input (ex, a function which doesn't expect an empty argument), this means that the the result of `apply` is also undefined.

This pull request adds an explicit `is_reduction` argument so that it's possible to explicitly control this otherwise undefined behavior.

**Update**: there has been the suggestion that the existing `reduce` argument should be used. Is this reasonable? The PR would be updated as follows:
- Remove the `is_reduction` argument
- Change the default value of `reduce` from `True` to `None` (to preserve the current behavior of checking the return value of the function being applied)
- In the case of an empty DataFrame, treat `reduce` in the same way that I'm currently treating `is_reduction`
- Otherwise treat `reduce` as normal

Ref:
- http://stackoverflow.com/q/21225608/71522
- http://stackoverflow.com/q/21225552/71522
