### PR TITLE
BUG: changed io.wb.get_countries URL

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -102,6 +102,7 @@ Improvements to existing features
 
 Bug Fixes
 ~~~~~~~~~
+  - Bug in ``io.wb.get_countries`` not including all countries (:issue:`6008`)
   - Bug in Series replace with timestamp dict (:issue:`5797`)
   - read_csv/read_table now respects the `prefix` kwarg (:issue:`5732`).
   - Bug in selection with missing values via ``.ix`` from a duplicate indexed DataFrame failing (:issue:`5835`)

--- a/doc/sphinxext/ipython_directive.py
+++ b/doc/sphinxext/ipython_directive.py
@@ -447,15 +447,11 @@ class EmbeddedSphinxShell(object):
         # context information
         filename = self.state.document.current_source
         lineno = self.state.document.current_line
-        try:
-            lineno -= 1
-        except:
-            pass
 
         # output any exceptions raised during execution to stdout
         # unless :okexcept: has been specified.
         if not is_okexcept and "Traceback" in output:
-            s =  "\nException in %s at line %s:\n" % (filename, lineno)
+            s =  "\nException in %s at block ending on line %s\n" % (filename, lineno)
             sys.stdout.write('\n\n>>>'+'-'*73)
             sys.stdout.write(s)
             sys.stdout.write(output)
@@ -464,15 +460,16 @@ class EmbeddedSphinxShell(object):
         # output any warning raised during execution to stdout
         # unless :okwarning: has been specified.
         if not is_okwarning:
+            import textwrap
             for w in ws:
-                s =  "\nWarning raised in %s at line %s:\n" % (filename, lineno)
+                s =  "\nWarning in %s at block ending on line %s\n" % (filename, lineno)
                 sys.stdout.write('\n\n>>>'+'-'*73)
                 sys.stdout.write(s)
                 sys.stdout.write('-'*76+'\n')
                 s=warnings.formatwarning(w.message, w.category,
                                          w.filename, w.lineno, w.line)
-                sys.stdout.write(s)
-                sys.stdout.write('\n<<<' + '-'*73+'\n\n')
+                sys.stdout.write('\n'.join(textwrap.wrap(s,80)))
+                sys.stdout.write('\n<<<' + '-'*73+'\n')
 
         self.cout.truncate(0)
         return (ret, input_lines, output, is_doctest, decorator, image_file,

--- a/pandas/io/tests/test_wb.py
+++ b/pandas/io/tests/test_wb.py
@@ -15,7 +15,6 @@ class TestWB(tm.TestCase):
     @slow
     @network
     def test_wdi_search(self):
-        #raise nose.SkipTest
 
         expected = {u('id'): {2634: u('GDPPCKD'),
                               4649: u('NY.GDP.PCAP.KD'),
@@ -35,7 +34,6 @@ class TestWB(tm.TestCase):
     @slow
     @network
     def test_wdi_download(self):
-        #raise nose.SkipTest
 
         expected = {'GDPPCKN': {(u('United States'), u('2003')): u('40800.0735367688'), (u('Canada'), u('2004')): u('37857.1261134552'), (u('United States'), u('2005')): u('42714.8594790102'), (u('Canada'), u('2003')): u('37081.4575704003'), (u('United States'), u('2004')): u('41826.1728310667'), (u('Mexico'), u('2003')): u('72720.0691255285'), (u('Mexico'), u('2004')): u('74751.6003347038'), (u('Mexico'), u('2005')): u('76200.2154469437'), (u('Canada'), u('2005')): u('38617.4563629611')}, 'GDPPCKD': {(u('United States'), u('2003')): u('40800.0735367688'), (u('Canada'), u('2004')): u('34397.055116118'), (u('United States'), u('2005')): u('42714.8594790102'), (u('Canada'), u('2003')): u('33692.2812368928'), (u('United States'), u('2004')): u('41826.1728310667'), (u('Mexico'), u('2003')): u('7608.43848670658'), (u('Mexico'), u('2004')): u('7820.99026814334'), (u('Mexico'), u('2005')): u('7972.55364129367'), (u('Canada'), u('2005')): u('35087.8925933298')}}
         expected = pandas.DataFrame(expected)
@@ -47,7 +45,6 @@ class TestWB(tm.TestCase):
     @slow
     @network
     def test_wdi_get_countries(self):
-        #raise nose.SkipTest
 
         result = get_countries()
         assert_equal(result[-1:].name, 'Zimbabwe')

--- a/pandas/io/tests/test_wb.py
+++ b/pandas/io/tests/test_wb.py
@@ -15,7 +15,7 @@ class TestWB(tm.TestCase):
     @slow
     @network
     def test_wdi_search(self):
-        raise nose.SkipTest
+        #raise nose.SkipTest
 
         expected = {u('id'): {2634: u('GDPPCKD'),
                               4649: u('NY.GDP.PCAP.KD'),
@@ -35,7 +35,7 @@ class TestWB(tm.TestCase):
     @slow
     @network
     def test_wdi_download(self):
-        raise nose.SkipTest
+        #raise nose.SkipTest
 
         expected = {'GDPPCKN': {(u('United States'), u('2003')): u('40800.0735367688'), (u('Canada'), u('2004')): u('37857.1261134552'), (u('United States'), u('2005')): u('42714.8594790102'), (u('Canada'), u('2003')): u('37081.4575704003'), (u('United States'), u('2004')): u('41826.1728310667'), (u('Mexico'), u('2003')): u('72720.0691255285'), (u('Mexico'), u('2004')): u('74751.6003347038'), (u('Mexico'), u('2005')): u('76200.2154469437'), (u('Canada'), u('2005')): u('38617.4563629611')}, 'GDPPCKD': {(u('United States'), u('2003')): u('40800.0735367688'), (u('Canada'), u('2004')): u('34397.055116118'), (u('United States'), u('2005')): u('42714.8594790102'), (u('Canada'), u('2003')): u('33692.2812368928'), (u('United States'), u('2004')): u('41826.1728310667'), (u('Mexico'), u('2003')): u('7608.43848670658'), (u('Mexico'), u('2004')): u('7820.99026814334'), (u('Mexico'), u('2005')): u('7972.55364129367'), (u('Canada'), u('2005')): u('35087.8925933298')}}
         expected = pandas.DataFrame(expected)
@@ -47,7 +47,7 @@ class TestWB(tm.TestCase):
     @slow
     @network
     def test_wdi_get_countries(self):
-        raise nose.SkipTest
+        #raise nose.SkipTest
 
         result = get_countries()
         assert_equal(result[-1:].name, 'Zimbabwe')

--- a/pandas/io/tests/test_wb.py
+++ b/pandas/io/tests/test_wb.py
@@ -1,12 +1,14 @@
 import nose
+from nose.tools import assert_equal
 
 import pandas
 from pandas.compat import u
 from pandas.util.testing import network
 from pandas.util.testing import assert_frame_equal
 from numpy.testing.decorators import slow
-from pandas.io.wb import search, download
+from pandas.io.wb import search, download, get_countries
 import pandas.util.testing as tm
+
 
 class TestWB(tm.TestCase):
 
@@ -30,7 +32,6 @@ class TestWB(tm.TestCase):
         expected.index = result.index
         assert_frame_equal(result, expected)
 
-
     @slow
     @network
     def test_wdi_download(self):
@@ -42,6 +43,14 @@ class TestWB(tm.TestCase):
                                                                          'GDPPCKN', 'junk'], start=2003, end=2005)
         expected.index = result.index
         assert_frame_equal(result, pandas.DataFrame(expected))
+
+    @slow
+    @network
+    def test_wdi_get_countries(self):
+        raise nose.SkipTest
+
+        result = get_countries()
+        assert_equal(result[-1:].name, 'Zimbabwe')
 
 
 if __name__ == '__main__':

--- a/pandas/io/wb.py
+++ b/pandas/io/wb.py
@@ -106,7 +106,7 @@ def _get_data(indicator="NY.GNS.ICTR.GN.ZS", country='US',
 def get_countries():
     '''Query information about countries
     '''
-    url = 'http://api.worldbank.org/countries/all?format=json'
+    url = 'http://api.worldbank.org/countries/?per_page=1000&format=json'
     with urlopen(url) as response:
         data = response.read()
     data = json.loads(data)[1]


### PR DESCRIPTION
Only 50 countries show up for the get_countries() call in io.wb, rather than the 256 that actually exist. Looks like a typo in the [World Bank Documentation](http://data.worldbank.org/node/18). The workaround is to request 1000 countries. Running this change by @vincentarelbundock.
