### PR TITLE
PERF: apply perf enhancements

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -88,6 +88,7 @@ Improvements to existing features
   - perf improvments in indexing with object dtypes (:issue:`5968`)
   - improved dtype inference for ``timedelta`` like passed to constructors (:issue:`5458`,:issue:`5689`)
   - escape special characters when writing to latex (:issue: `5374`)
+  - perf improvements in ``DataFrame.apply`` (:issue:`6013`)
 
 .. _release.bug_fixes-0.13.1:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3324,16 +3324,16 @@ class DataFrame(NDFrame):
         if reduce:
             try:
 
-                if self._is_mixed_type:  # maybe a hack for now
-                    raise AssertionError('Must be mixed type DataFrame')
-                values = self.values
-                dummy = Series(NA, index=self._get_axis(axis),
+                # can only work with numeric data in the fast path
+                numeric = self._get_numeric_data()
+                values = numeric.values
+                dummy = Series(NA, index=numeric._get_axis(axis),
                                dtype=values.dtype)
 
                 labels = self._get_agg_axis(axis)
                 result = lib.reduce(values, func, axis=axis, dummy=dummy,
                                     labels=labels)
-                return Series(result, index=self._get_agg_axis(axis))
+                return Series(result, index=labels)
             except Exception:
                 pass
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -78,7 +78,8 @@ class NDFrame(PandasObject):
     copy : boolean, default False
     """
     _internal_names = ['_data', '_cacher', '_item_cache', '_cache',
-                       'is_copy', '_subtyp', '_index', '_default_kind', '_default_fill_value']
+                       'is_copy', '_subtyp', '_index', '_default_kind',
+                       '_default_fill_value','__array_struct__','__array_interface__']
     _internal_names_set = set(_internal_names)
     _metadata = []
     is_copy = None
@@ -697,6 +698,14 @@ class NDFrame(PandasObject):
     def __array_wrap__(self, result):
         d = self._construct_axes_dict(self._AXIS_ORDERS, copy=False)
         return self._constructor(result, **d).__finalize__(self)
+
+    # ideally we would define this to avoid the getattr checks, but
+    # is slower
+    #@property
+    #def __array_interface__(self):
+    #    """ provide numpy array interface method """
+    #    values = self.values
+    #    return dict(typestr=values.dtype.str,shape=values.shape,data=values)
 
     def to_dense(self):
         "Return dense representation of NDFrame (as opposed to sparse)"

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1837,6 +1837,11 @@ class NDFrame(PandasObject):
         f = lambda: self._data.is_numeric_mixed_type
         return self._protect_consolidate(f)
 
+    @property
+    def _is_datelike_mixed_type(self):
+        f = lambda: self._data.is_datelike_mixed_type
+        return self._protect_consolidate(f)
+
     def _protect_consolidate(self, f):
         blocks_before = len(self._data.blocks)
         result = f()

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -84,6 +84,11 @@ class Block(PandasObject):
         return self.ndim == 1
 
     @property
+    def is_datelike(self):
+        """ return True if I am a non-datelike """
+        return self.is_datetime or self.is_timedelta
+
+    @property
     def fill_value(self):
         return np.nan
 
@@ -2438,6 +2443,12 @@ class BlockManager(PandasObject):
         # Warning, consolidation needs to get checked upstairs
         self._consolidate_inplace()
         return all([block.is_numeric for block in self.blocks])
+
+    @property
+    def is_datelike_mixed_type(self):
+        # Warning, consolidation needs to get checked upstairs
+        self._consolidate_inplace()
+        return any([block.is_datelike for block in self.blocks])
 
     def get_block_map(self, copy=False, typ=None, columns=None,
                       is_numeric=False, is_bool=False):

--- a/pandas/tests/test_tseries.py
+++ b/pandas/tests/test_tseries.py
@@ -661,7 +661,6 @@ class TestReducer(tm.TestCase):
         from pandas.core.series import Series
 
         arr = np.random.randn(100, 4)
-
         result = lib.reduce(arr, np.sum, labels=Index(np.arange(4)))
         expected = arr.sum(0)
         assert_almost_equal(result, expected)

--- a/vb_suite/frame_methods.py
+++ b/vb_suite/frame_methods.py
@@ -324,7 +324,42 @@ s = Series(np.arange(1028.))
 df = DataFrame({ i:s for i in range(1028) })
 """
 frame_apply_user_func = Benchmark('df.apply(lambda x: np.corrcoef(x,s)[0,1])', setup,
+                           name = 'frame_apply_user_func',
                            start_date=datetime(2012,1,1))
+
+setup = common_setup + """
+df = DataFrame(np.random.randn(1000,100))
+"""
+frame_apply_lambda_mean = Benchmark('df.apply(lambda x: x.sum())', setup,
+                                    name = 'frame_apply_lambda_mean',
+                                    start_date=datetime(2012,1,1))
+setup = common_setup + """
+df = DataFrame(np.random.randn(1000,100))
+"""
+frame_apply_np_mean = Benchmark('df.apply(np.mean)', setup,
+                               name = 'frame_apply_np_mean',
+                               start_date=datetime(2012,1,1))
+
+setup = common_setup + """
+df = DataFrame(np.random.randn(1000,100))
+"""
+frame_apply_pass_thru = Benchmark('df.apply(lambda x: x)', setup,
+                                  name = 'frame_apply_pass_thru',
+                                  start_date=datetime(2012,1,1))
+
+setup = common_setup + """
+df = DataFrame(np.random.randn(1000,100))
+"""
+frame_apply_axis_1 = Benchmark('df.apply(lambda x: x+1,axis=1)', setup,
+                               name = 'frame_apply_axis_1',
+                               start_date=datetime(2012,1,1))
+
+setup = common_setup + """
+df = DataFrame(np.random.randn(1000,3),columns=list('ABC'))
+"""
+frame_apply_ref_by_name = Benchmark('df.apply(lambda x: x["A"] + x["B"],axis=1)', setup,
+                                     name = 'frame_apply_ref_by_name',
+                                     start_date=datetime(2012,1,1))
 
 #----------------------------------------------------------------------
 # dtypes


### PR DESCRIPTION
added vbenches and make most apply operations a fair bit faster

closes #6013

I can't put this one in the vbench as its cython based, but previously was about 100ms (on my machine)
0.12 clocks in at 15ms (the remaining difference in time is due to the sub-indexing, e.g. x['a'] which in theory could also be speeded but a bit tricky and not a lot more to win)

```
In [6]: %timeit df.apply(lambda x: integrate_f_typed(x['a'], x['b'], x['N']), axis=1)
10 loops, best of 3: 26.2 ms per loop
```

Here's a related benchmark from #5654 (a version of which is in the vbenches):

```
In [16]: s = pd.Series(np.arange(4096.))

In [17]: df = pd.DataFrame({i:s for i in range(4096)})
```

0.12

```
In [18]: %timeit df.apply((lambda x: np.corrcoef(x, s)[0, 1]), axis=1)
1 loops, best of 3: 1.11 s per loop
```

with this PR

```
In [3]: In [18]: %timeit df.apply((lambda x: np.corrcoef(x, s)[0, 1]), axis=1)

1 loops, best of 3: 1.24 s per loop
```

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
frame_apply_ref_by_name                      |  15.4320 |  32.2250 |   0.4789 | like the cython example above
frame_apply_user_func                        | 166.7013 | 232.7064 |   0.7164 | bench for example right above
frame_apply_axis_1                           | 108.5210 | 109.1857 |   0.9939 |
frame_apply_pass_thru                        |   6.5626 |   6.4860 |   1.0118 |
frame_apply_np_mean                          |   3.9033 |   0.9290 |   4.2018 | this suffers from some construction overhead, not much I can do
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
```
