### PR TITLE
BUG: Possible segfault when chained indexing with an object array under numpy 1.7.1 (GH6016)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -134,6 +134,7 @@ Bug Fixes
   - Bug in Series.xs with a multi-index (:issue:`6018`)
   - Bug in Series construction of mixed type with datelike and an integer (which should result in
     object type and not automatic conversion) (:issue:`6028`)
+  - Possible segfault when chained indexing with an object array under numpy 1.7.1 (:issue:`6016`)
 
 pandas 0.13.0
 -------------

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -29,6 +29,7 @@ from distutils.version import LooseVersion
 _np_version = np.version.short_version
 _np_version_under1p6 = LooseVersion(_np_version) < '1.6'
 _np_version_under1p7 = LooseVersion(_np_version) < '1.7'
+_np_version_under1p8 = LooseVersion(_np_version) < '1.8'
 
 from pandas.version import version as __version__
 from pandas.info import __doc__

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1005,9 +1005,14 @@ class NDFrame(PandasObject):
         raise NotImplementedError
 
     def _maybe_cache_changed(self, item, value):
-        """ the object has called back to us saying
-        maybe it has changed """
-        self._data.set(item, value)
+        """
+        the object has called back to us saying
+        maybe it has changed
+
+        numpy < 1.8 has an issue with object arrays and aliasing
+        GH6026
+        """
+        self._data.set(item, value, check=pd._np_version_under1p8)
 
     @property
     def _is_cached(self):

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -1950,6 +1950,29 @@ class TestIndexing(tm.TestCase):
             self.assert_(df.ix[0,'c'] == 0.0)
             self.assert_(df.ix[7,'c'] == 1.0)
 
+    def test_setitem_chained_setfault(self):
+
+        # GH6026
+        # setfaults under numpy 1.7.1 (ok on 1.8)
+        data = ['right', 'left', 'left', 'left', 'right', 'left', 'timeout']
+        mdata = ['right', 'left', 'left', 'left', 'right', 'left', 'none']
+
+        df = DataFrame({'response': np.array(data)})
+        mask = df.response == 'timeout'
+        df.response[mask] = 'none'
+        assert_frame_equal(df, DataFrame({'response': mdata }))
+
+        recarray = np.rec.fromarrays([data], names=['response'])
+        df = DataFrame(recarray)
+        mask = df.response == 'timeout'
+        df.response[mask] = 'none'
+        assert_frame_equal(df, DataFrame({'response': mdata }))
+
+        df = DataFrame({'response': data, 'response1' : data })
+        mask = df.response == 'timeout'
+        df.response[mask] = 'none'
+        assert_frame_equal(df, DataFrame({'response': mdata, 'response1' : data }))
+
     def test_detect_chained_assignment(self):
 
         pd.set_option('chained_assignment','raise')


### PR DESCRIPTION
closes #6026
