### PR TITLE
FIX: extend access to `quotechar` param in `DataFrame.to_csv`

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -55,6 +55,7 @@ New features
 
   - Added ``date_format`` and ``datetime_format`` attribute to ExcelWriter.
     (:issue:`4133`)
+  - ``DataFrame.to_csv`` now accepts ``quotechar`` parameter (:issue:`6034`)
 
 API Changes
 ~~~~~~~~~~~

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1070,7 +1070,7 @@ class DataFrame(NDFrame):
     def to_csv(self, path_or_buf, sep=",", na_rep='', float_format=None,
                cols=None, header=True, index=True, index_label=None,
                mode='w', nanRep=None, encoding=None, quoting=None,
-               line_terminator='\n', chunksize=None,
+               quotechar='"', line_terminator='\n', chunksize=None,
                tupleize_cols=False, date_format=None, **kwds):
         r"""Write DataFrame to a comma-separated values (csv) file
 
@@ -1109,6 +1109,8 @@ class DataFrame(NDFrame):
             file
         quoting : optional constant from csv module
             defaults to csv.QUOTE_MINIMAL
+        quotechar : string (length 1), default '"'
+            character used to quote fields
         chunksize : int or None
             rows to write at a time
         tupleize_cols : boolean, default False
@@ -1129,8 +1131,8 @@ class DataFrame(NDFrame):
                                      float_format=float_format, cols=cols,
                                      header=header, index=index,
                                      index_label=index_label, mode=mode,
-                                     chunksize=chunksize, engine=kwds.get(
-                                         "engine"),
+                                     chunksize=chunksize, quotechar=quotechar, 
+                                     engine=kwds.get("engine"),
                                      tupleize_cols=tupleize_cols,
                                      date_format=date_format)
         formatter.save()

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -1669,10 +1669,10 @@ c  10  11  12  13  14\
 \end{tabular}
 """
         self.assertEqual(withoutindex_result, withoutindex_expected)
-        
+
     def test_to_latex_escape_special_chars(self):
         special_characters = ['&','%','$','#','_',
-                               '{','}','~','^','\\'] 
+                               '{','}','~','^','\\']
         df = DataFrame(data=special_characters)
         observed = df.to_latex()
         expected = r"""\begin{tabular}{ll}
@@ -1693,6 +1693,24 @@ c  10  11  12  13  14\
 \end{tabular}
 """
         self.assertEqual(observed, expected)
+
+    def test_to_csv_quotechar(self):
+        df = DataFrame({'col' : [1,2]})
+        expected = """\
+$$,$col$
+$0$,$1$
+$1$,$2$
+"""
+        from tempfile import NamedTemporaryFile
+        with NamedTemporaryFile() as output:
+            df.to_csv(output.name, quoting=1, quotechar="$") # QUOTE_ALL
+            results = open(output.name).read()
+            self.assertEqual(results, expected)
+
+            df.to_csv(output.name, quoting=1, quotechar="$", engine='python')
+            results = open(output.name).read()
+            self.assertEqual(results, expected)
+
 
 class TestSeriesFormatting(tm.TestCase):
     _multiprocess_can_split_ = True


### PR DESCRIPTION
Existing `pandas.core.format.CSVFormatter` param `quotechar` can now be
specified as keyword arg to `DataFrame.to_csv`
