### PR TITLE
BUG: Bug in setting using fancy indexing a single element with a non-scalar (e.g. a list) (GH6043)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -135,6 +135,8 @@ Bug Fixes
   - Bug in Series construction of mixed type with datelike and an integer (which should result in
     object type and not automatic conversion) (:issue:`6028`)
   - Possible segfault when chained indexing with an object array under numpy 1.7.1 (:issue:`6016`)
+  - Bug in setting using fancy indexing a single element with a non-scalar (e.g. a list),
+    (:issue:`6043`)
 
 pandas 0.13.0
 -------------

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -605,10 +605,18 @@ class Block(PandasObject):
                                      "different length than the value")
 
         try:
+            # setting a single element for each dim and with a rhs that could be say a list
+            # GH 6043
+            if arr_value.ndim == 1 and (
+                np.isscalar(indexer) or (isinstance(indexer, tuple) and all([ np.isscalar(idx) for idx in indexer ]))):
+                values[indexer] = value
+
             # if we are an exact match (ex-broadcasting),
             # then use the resultant dtype
-            if len(arr_value.shape) and arr_value.shape[0] == values.shape[0] and np.prod(arr_value.shape) == np.prod(values.shape):
+            elif len(arr_value.shape) and arr_value.shape[0] == values.shape[0] and np.prod(arr_value.shape) == np.prod(values.shape):
                 values = arr_value.reshape(values.shape)
+
+            # set
             else:
                 values[indexer] = value
 

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -1286,6 +1286,48 @@ class TestIndexing(tm.TestCase):
         self.assert_(df.ix['e', 8] == 45)
         self.assert_(df.loc['e', 8] == 45)
 
+    def test_setitem_list(self):
+
+        # GH 6043
+        # ix with a list
+        df = DataFrame(index=[0,1], columns=[0])
+        df.ix[1,0] = [1,2,3]
+        df.ix[1,0] = [1,2]
+
+        result = DataFrame(index=[0,1], columns=[0])
+        result.ix[1,0] = [1,2]
+
+        assert_frame_equal(result,df)
+
+        # ix with an object
+        class TO(object):
+            def __init__(self, value):
+                self.value = value
+            def __str__(self):
+                return "[{0}]".format(self.value)
+            __repr__ = __str__
+            def __eq__(self, other):
+                return self.value == other.value
+            def view(self):
+                return self
+
+        df = DataFrame(index=[0,1], columns=[0])
+        df.ix[1,0] = TO(1)
+        df.ix[1,0] = TO(2)
+
+        result = DataFrame(index=[0,1], columns=[0])
+        result.ix[1,0] = TO(2)
+
+        assert_frame_equal(result,df)
+
+        # remains object dtype even after setting it back
+        df = DataFrame(index=[0,1], columns=[0])
+        df.ix[1,0] = TO(1)
+        df.ix[1,0] = np.nan
+        result = DataFrame(index=[0,1], columns=[0])
+
+        assert_frame_equal(result, df)
+
     def test_iloc_mask(self):
 
         # GH 3631, iloc with a mask (of a series) should raise


### PR DESCRIPTION
closes #6043
