### PR TITLE
BUG: Regression in .get(None) from 0.12 (GH5652)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -139,6 +139,7 @@ Bug Fixes
   - Possible segfault when chained indexing with an object array under numpy 1.7.1 (:issue:`6016`)
   - Bug in setting using fancy indexing a single element with a non-scalar (e.g. a list),
     (:issue:`6043`)
+  - Regression in ``.get(None)`` indexing from 0.12 (:issue:`5652`)
 
 pandas 0.13.0
 -------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -981,7 +981,7 @@ class NDFrame(PandasObject):
         """
         try:
             return self[key]
-        except KeyError:
+        except (KeyError, ValueError):
             return default
 
     def __getitem__(self, item):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -147,6 +147,11 @@ class CheckIndexing(object):
         self.assert_(self.frame.get('foo') is None)
         assert_series_equal(self.frame.get('foo', self.frame['B']),
                             self.frame['B'])
+        # None
+        # GH 5652
+        for df in [DataFrame(), DataFrame(columns=list('AB')), DataFrame(columns=list('AB'),index=range(3)) ]:
+            result = df.get(None)
+            self.assert_(result is None)
 
     def test_getitem_iterator(self):
         idx = iter(['A', 'B', 'C'])

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -724,6 +724,12 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         d = self.ts.index[0] - datetools.bday
         self.assertRaises(KeyError, self.ts.__getitem__, d)
 
+        # None
+        # GH 5652
+        for s in [Series(), Series(index=list('abc'))]:
+            result = s.get(None)
+            self.assert_(result is None)
+
     def test_iget(self):
         s = Series(np.random.randn(10), index=lrange(0, 20, 2))
         for i in range(len(s)):


### PR DESCRIPTION
closes #5652
