### PR TITLE
BUG: suble iloc indexing bug with single block and multi-axis indexing (surfaced in GH6059)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -140,6 +140,7 @@ Bug Fixes
   - Bug in setting using fancy indexing a single element with a non-scalar (e.g. a list),
     (:issue:`6043`)
   - Regression in ``.get(None)`` indexing from 0.12 (:issue:`5652`)
+  - Subtle ``iloc`` indexing bug, surfaced in (:issue:`6059`)
 
 pandas 0.13.0
 -------------

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -720,6 +720,49 @@ class TestIndexing(tm.TestCase):
         # trying to use a label
         self.assertRaises(ValueError, df.iloc.__getitem__, tuple(['j','D']))
 
+
+    def test_iloc_getitem_doc_issue(self):
+
+        # multi axis slicing issue with single block
+        # surfaced in GH 6059
+
+        arr = np.random.randn(6,4)
+        index = date_range('20130101',periods=6)
+        columns = list('ABCD')
+        df = DataFrame(arr,index=index,columns=columns)
+
+        # defines ref_locs
+        df.describe()
+
+        result = df.iloc[3:5,0:2]
+        str(result)
+        result.dtypes
+
+        expected = DataFrame(arr[3:5,0:2],index=index[3:5],columns=columns[0:2])
+        assert_frame_equal(result,expected)
+
+        # for dups
+        df.columns = list('aaaa')
+        result = df.iloc[3:5,0:2]
+        str(result)
+        result.dtypes
+
+        expected = DataFrame(arr[3:5,0:2],index=index[3:5],columns=list('aa'))
+        assert_frame_equal(result,expected)
+
+        # related
+        arr = np.random.randn(6,4)
+        index = list(range(0,12,2))
+        columns = list(range(0,8,2))
+        df = DataFrame(arr,index=index,columns=columns)
+
+        df._data.blocks[0].ref_locs
+        result = df.iloc[1:5,2:4]
+        str(result)
+        result.dtypes
+        expected = DataFrame(arr[1:5,2:4],index=index[1:5],columns=columns[2:4])
+        assert_frame_equal(result,expected)
+
     def test_setitem_ndarray_1d(self):
         # GH5508
 


### PR DESCRIPTION
surfaced in #6059

very subtle iloc bug that requires both axis slicing then trying dtypes
