### PR TITLE
DOC: suppress warnings with okwarning in whatsnew

### DIFF
--- a/doc/source/v0.10.1.txt
+++ b/doc/source/v0.10.1.txt
@@ -66,6 +66,7 @@ perform queries on a table, by passing a list to ``data_columns``
 Retrieving unique values in an indexable or data column.
 
 .. ipython:: python
+   :okwarning:
 
    import warnings
    with warnings.catch_warnings():

--- a/doc/source/v0.12.0.txt
+++ b/doc/source/v0.12.0.txt
@@ -186,6 +186,7 @@ I/O Enhancements
     You can use ``pd.read_html()`` to read the output from ``DataFrame.to_html()`` like so
 
     .. ipython :: python
+       :okwarning:
 
         df = DataFrame({'a': range(3), 'b': list('abc')})
         print(df)
@@ -252,6 +253,7 @@ I/O Enhancements
     store when iteration is finished. This is only for *tables*
 
     .. ipython:: python
+       :okwarning:
 
          path = 'store_iterator.h5'
          DataFrame(randn(10,2)).to_hdf(path,'df',table=True)

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -149,6 +149,7 @@ API changes
   The following warning / exception will show if this is attempted.
 
   .. ipython:: python
+     :okwarning:
 
      dfc.loc[0]['A'] = 1111
 


### PR DESCRIPTION
Using the new functionality of @y-p from #6082, suppressing some warnings in the older whatsnew sections.

Some of them are deprecation warnings, so from older functinality. We could also change the code example, but since it's from whatsnew I think it's more logical to leave it as it is (when they start to generate errors, then of course we have to do something else)
