### PR TITLE
BUG: array_equivalent was not passing its own doctest. 

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -287,8 +287,7 @@ def array_equivalent(left, right):
 
     Parameters
     ----------
-    left, right : array_like
-        Input arrays.
+    left, right : ndarrays
 
     Returns
     -------
@@ -297,20 +296,15 @@ def array_equivalent(left, right):
 
     Examples
     --------
-    >>> array_equivalent([1, 2, nan], np.array([1, 2, nan]))
+    >>> array_equivalent(np.array([1, 2, nan]), np.array([1, 2, nan]))
     True
-    >>> array_equivalent([1, nan, 2], [1, 2, nan])
+    >>> array_equivalent(np.array([1, nan, 2]), np.array([1, 2, nan]))
     False
     """
     if left.shape != right.shape: return False
     # NaNs occur only in object arrays, float or complex arrays.
-    if left.dtype == np.object_:
-        # If object array, we need to use pd.isnull
-        return ((left == right) | pd.isnull(left) & pd.isnull(right)).all()
-    elif not issubclass(left.dtype.type, (np.floating, np.complexfloating)):
-        # if not a float or complex array, then there are no NaNs
+    if not issubclass(left.dtype.type, (np.floating, np.complexfloating)):
         return np.array_equal(left, right)
-    # For float or complex arrays, using np.isnan is faster than pd.isnull
     return  ((left == right) | (np.isnan(left) & np.isnan(right))).all()
 
 def _iterable_not_string(x):

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -168,15 +168,18 @@ def test_downcast_conv():
 
 
 def test_array_equivalent():
-    assert array_equivalent(np.array([np.nan, np.nan]), np.array([np.nan, np.nan]))
-    assert array_equivalent(np.array([np.nan, 1, np.nan]), np.array([np.nan, 1, np.nan]))
+    assert array_equivalent(np.array([np.nan, np.nan]),
+                            np.array([np.nan, np.nan]))
+    assert array_equivalent(np.array([np.nan, 1, np.nan]),
+                            np.array([np.nan, 1, np.nan]))
     assert array_equivalent(np.array([np.nan, None], dtype='object'),
                             np.array([np.nan, None], dtype='object'))
     assert array_equivalent(np.array([np.nan, 1+1j], dtype='complex'),
                             np.array([np.nan, 1+1j], dtype='complex'))
     assert not array_equivalent(np.array([np.nan, 1+1j], dtype='complex'),
                                 np.array([np.nan, 1+2j], dtype='complex'))
-    assert not array_equivalent(np.array([np.nan, 1, np.nan]), np.array([np.nan, 2, np.nan]))
+    assert not array_equivalent(np.array([np.nan, 1, np.nan]),
+                                np.array([np.nan, 2, np.nan]))
     assert not array_equivalent(np.array(['a', 'b', 'c', 'd']), np.array(['e', 'e']))
 
 def test_datetimeindex_from_empty_datetime64_array():


### PR DESCRIPTION
The examples in the docstring showed lists being passed to array_equivalent. `array_equivalent` expects `ndarrays` only. (It raises an `AttributeError` when passed a list.)

Also, the use of `pd.isnull` can be removed from `array_equivalent`. My thinking here was muddled. `pd.isnull` is only needed if `array_equivalent` were to accept objects other than ndarrays. `np.array_equal` works as desired for all `ndarrays` except those of float or complex dtype.
