### PR TITLE
BUG: in HTMLFormatter._write_header(), str() fails on column names in unicode

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -149,6 +149,7 @@ Bug Fixes
   - Regression in ``.get(None)`` indexing from 0.12 (:issue:`5652`)
   - Subtle ``iloc`` indexing bug, surfaced in (:issue:`6059`)
   - Bug with insert of strings into DatetimeIndex (:issue:`5818`)
+  - Bug in ``HTMLFormatter._write_header`` for column names in unicode (:issue:`6098`)
 
 pandas 0.13.0
 -------------

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -767,7 +767,7 @@ class HTMLFormatter(TableFormatter):
                                                          levels)):
                 name = self.columns.names[lnum]
                 row = [''] * (row_levels - 1) + ['' if name is None
-                                                 else str(name)]
+                                                 else name]
 
                 tags = {}
                 j = len(row)


### PR DESCRIPTION
Issue #6098
