### PR TITLE
BUG: DataFrame.apply when using mixed datelike reductions (GH6125)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -161,6 +161,8 @@ Bug Fixes
     are a slice (e.g. next to each other) (:issue:`6120`)
   - Bug in propogating _ref_locs during construction of a DataFrame with dups
     index/columns (:issue:`6121`)
+  - Bug in ``DataFrame.apply`` when using mixed datelike reductions (:issue:`6125`)
+
 
 pandas 0.13.0
 -------------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3341,10 +3341,16 @@ class DataFrame(NDFrame):
 
     def _apply_standard(self, func, axis, ignore_failures=False, reduce=True):
 
+        # skip if we are mixed datelike and trying reduce across axes
+        # GH6125
+        if reduce and axis==1 and self._is_mixed_type and self._is_datelike_mixed_type:
+            reduce=False
+
         # try to reduce first (by default)
         # this only matters if the reduction in values is of different dtype
         # e.g. if we want to apply to a SparseFrame, then can't directly reduce
         if reduce:
+
             try:
 
                 # the is the fast-path

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -9215,6 +9215,28 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             self.assertEqual(e.args[1], 'occurred at index 4')
             self.assertEqual(e.args[0], "'float' object has no attribute 'startswith'")
 
+    def test_apply_bug(self):
+
+        # GH 6125
+        import datetime
+        positions = pd.DataFrame([[1, 'ABC0', 50], [1, 'YUM0', 20],
+                                  [1, 'DEF0', 20], [2, 'ABC1', 50],
+                                  [2, 'YUM1', 20], [2, 'DEF1', 20]],
+                                 columns=['a', 'market', 'position'])
+        def f(r):
+            return r['market']
+        expected = positions.apply(f, axis=1)
+
+        positions = DataFrame([[datetime.datetime(2013, 1, 1), 'ABC0', 50],
+                               [datetime.datetime(2013, 1, 2), 'YUM0', 20],
+                               [datetime.datetime(2013, 1, 3), 'DEF0', 20],
+                               [datetime.datetime(2013, 1, 4), 'ABC1', 50],
+                               [datetime.datetime(2013, 1, 5), 'YUM1', 20],
+                               [datetime.datetime(2013, 1, 6), 'DEF1', 20]],
+                                                columns=['a', 'market', 'position'])
+        result = positions.apply(f, axis=1)
+        assert_series_equal(result,expected)
+
     def test_swapaxes(self):
         df = DataFrame(np.random.randn(10, 5))
         assert_frame_equal(df.T, df.swapaxes(0, 1))


### PR DESCRIPTION
closes #6125
