### PR TITLE
BUG: DataFrame.append when appending a row with different columns (GH6129)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -162,7 +162,7 @@ Bug Fixes
   - Bug in propogating _ref_locs during construction of a DataFrame with dups
     index/columns (:issue:`6121`)
   - Bug in ``DataFrame.apply`` when using mixed datelike reductions (:issue:`6125`)
-
+  - Bug in ``DataFrame.append`` when appending a row with different columns (:issue:`6129`)
 
 pandas 0.13.0
 -------------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3513,9 +3513,12 @@ class DataFrame(NDFrame):
                                 'ignore_index=True')
 
             index = None if other.name is None else [other.name]
-            other = other.reindex(self.columns, copy=False)
+            combined_columns = self.columns.tolist() + ((self.columns | other.index) - self.columns).tolist()
+            other = other.reindex(combined_columns, copy=False)
             other = DataFrame(other.values.reshape((1, len(other))),
-                              index=index, columns=self.columns).convert_objects()
+                              index=index, columns=combined_columns).convert_objects()
+            if not self.columns.equals(combined_columns):
+                self = self.reindex(columns=combined_columns)
         elif isinstance(other, list) and not isinstance(other[0], DataFrame):
             other = DataFrame(other)
             if (self.columns.get_indexer(other.columns) >= 0).all():

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -1163,6 +1163,14 @@ class TestConcatenate(tm.TestCase):
         self.assertRaises(ValueError, self.frame.append, self.frame,
                           verify_integrity=True)
 
+        # new columns
+        # GH 6129
+        df = DataFrame({'a': {'x': 1, 'y': 2}, 'b': {'x': 3, 'y': 4}})
+        row = Series([5, 6, 7], index=['a', 'b', 'c'], name='z')
+        expected = DataFrame({'a': {'x': 1, 'y': 2, 'z': 5}, 'b': {'x': 3, 'y': 4, 'z': 6}, 'c' : {'z' : 7}})
+        result = df.append(row)
+        assert_frame_equal(result, expected)
+
     def test_append_length0_frame(self):
         df = DataFrame(columns=['A', 'B', 'C'])
         df3 = DataFrame(index=[0, 1], columns=['A', 'B'])


### PR DESCRIPTION
closes #6129
