### PR TITLE
PERF: fix JSON performance regression from 0.12 (GH5765)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -119,6 +119,7 @@ Bug Fixes
   - Regresssion in handling of empty Series as indexers to Series  (:issue:`5877`)
   - Bug in internal caching, related to (:issue:`5727`)
   - Testing bug in reading json/msgpack from a non-filepath on windows under py3 (:issue:`5874`)
+  - Fix performance regression in JSON IO (:issue:`5765`)
   - Bug when assigning to .ix[tuple(...)] (:issue:`5896`)
   - Bug in fully reindexing a Panel (:issue:`5905`)
   - Bug in idxmin/max with object dtypes (:issue:`5914`)

--- a/pandas/src/ujson/lib/ultrajsondec.c
+++ b/pandas/src/ujson/lib/ultrajsondec.c
@@ -894,15 +894,23 @@ JSOBJ JSON_DecodeObject(JSONObjectDecoder *dec, const char *buffer, size_t cbBuf
 
   ds.dec = dec;
 
-  locale = strdup(setlocale(LC_NUMERIC, NULL));
-  if (!locale)
+  locale = setlocale(LC_NUMERIC, NULL);
+  if (strcmp(locale, "C"))
   {
-    return SetError(&ds, -1, "Could not reserve memory block");
+    locale = strdup(locale);
+    if (!locale)
+    {
+      return SetError(&ds, -1, "Could not reserve memory block");
+    }
+    setlocale(LC_NUMERIC, "C");
+    ret = decode_any (&ds);
+    setlocale(LC_NUMERIC, locale);
+    free(locale);
   }
-  setlocale(LC_NUMERIC, "C");
-  ret = decode_any (&ds);
-  setlocale(LC_NUMERIC, locale);
-  free(locale);
+  else 
+  {
+    ret = decode_any (&ds);
+  }
 
   if (ds.escHeap)
   {

--- a/pandas/src/ujson/lib/ultrajsonenc.c
+++ b/pandas/src/ujson/lib/ultrajsonenc.c
@@ -917,16 +917,24 @@ char *JSON_EncodeObject(JSOBJ obj, JSONObjectEncoder *enc, char *_buffer, size_t
   enc->end = enc->start + _cbBuffer;
   enc->offset = enc->start;
 
-  locale = strdup(setlocale(LC_NUMERIC, NULL));
-  if (!locale)
+  locale = setlocale(LC_NUMERIC, NULL);
+  if (strcmp(locale, "C"))
   {
-    SetError(NULL, enc, "Could not reserve memory block");
-    return NULL;
+    locale = strdup(locale);
+    if (!locale)
+    {
+      SetError(NULL, enc, "Could not reserve memory block");
+      return NULL;
+    }
+    setlocale(LC_NUMERIC, "C");
+    encode (obj, enc, NULL, 0);
+    setlocale(LC_NUMERIC, locale);
+    free(locale);
   }
-  setlocale(LC_NUMERIC, "C");
-  encode (obj, enc, NULL, 0);
-  setlocale(LC_NUMERIC, locale);
-  free(locale);
+  else 
+  {
+    encode (obj, enc, NULL, 0);
+  }
 
   Buffer_Reserve(enc, 1);
   if (enc->errorMsg)

--- a/vb_suite/packers.py
+++ b/vb_suite/packers.py
@@ -92,3 +92,23 @@ setup = common_setup + """
 
 packers_write_hdf_table = Benchmark("df.to_hdf(f,'df',table=True)", setup, cleanup="remove(f)", start_date=start_date)
 
+#----------------------------------------------------------------------
+# json
+
+setup_int_index = """
+import numpy as np
+df.index = np.arange(50000)
+"""
+
+setup = common_setup + """
+df.to_json(f,orient='split')
+"""
+packers_read_json_date_index = Benchmark("pd.read_json(f, orient='split')", setup, start_date=start_date)
+setup = setup + setup_int_index
+packers_read_json = Benchmark("pd.read_json(f, orient='split')", setup, start_date=start_date)
+
+setup = common_setup + """
+"""
+packers_write_json_date_index = Benchmark("df.to_json(f,orient='split')", setup, cleanup="remove(f)", start_date=start_date)
+setup = setup + setup_int_index
+packers_write_json = Benchmark("df.to_json(f,orient='split')", setup, cleanup="remove(f)", start_date=start_date)


### PR DESCRIPTION
This fixes the main JSON performance regression  in v0.13 (closes #5765). The main bottleneck was the use of intermediate NumPy scalars (from PR #4498). I introduced code to avoid the use of NumPy scalars. Also:
- checks current locale so locale fudging is only done if necessary
- added numpy 1.6 preprocessor switches as it still requires the use of scalars due to its weird datetime handling
- reorgranised some of the if/else checks in `objToJSON.c` based on likelihood.
- added some JSON benchmarks to vbench to try and avoid future regressions.

0.12

``` python
In [1]: import pandas as pd, numpy as np

In [2]: df = pd.DataFrame(np.random.rand(100000,10))

In [3]: %timeit df.to_json(orient='split')
10 loops, best of 3: 119 ms per loop

In [4]: pd.__version__, np.__version__
Out[4]: ('0.12.0', '1.8.0')
```

This PR

``` python
In [1]: import pandas as pd, numpy as np

In [2]: df = pd.DataFrame(np.random.rand(100000,10))

In [3]: %timeit df.to_json(orient='split')
10 loops, best of 3: 119 ms per loop

In [4]: pd.__version__, np.__version__
Out[4]: ('0.13.0-406-ga18e5e6', '1.8.0')
```

While this solves the main performance issue, using vbench this PR still appears to be a bit slower than v0.12 (~ 2 - 5%) but it's unclear where the slowdown is coming from.

@jreback do you still have a windows box / vm that you could test on?
