### PR TITLE
BUG: Bug in DataFrame construction with recarray and non-ns datetime dtype (GH6140)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -164,6 +164,7 @@ Bug Fixes
     index/columns (:issue:`6121`)
   - Bug in ``DataFrame.apply`` when using mixed datelike reductions (:issue:`6125`)
   - Bug in ``DataFrame.append`` when appending a row with different columns (:issue:`6129`)
+  - Bug in DataFrame construction with recarray and non-ns datetime dtype (:issue:`6140`)
 
 pandas 0.13.0
 -------------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2536,7 +2536,10 @@ def _sanitize_array(data, index, dtype=None, copy=False,
                 else:
                     subarr = _try_cast(data, True)
         else:
-            subarr = _try_cast(data, True)
+            # don't coerce Index types
+            # e.g. indexes can have different conversions (so don't fast path them)
+            # GH 6140
+            subarr = _try_cast(data, not isinstance(data, Index))
 
         if copy:
             subarr = data.copy()


### PR DESCRIPTION
closes #6140
