### PR TITLE
ENH: Add unique and nunique to GroupBy whitelist

### DIFF
--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -75,7 +75,7 @@ _common_apply_whitelist = frozenset([
 
 _series_apply_whitelist = \
     (_common_apply_whitelist - set(['boxplot'])) | \
-    frozenset(['dtype', 'value_counts'])
+    frozenset(['dtype', 'value_counts', 'unique', 'nunique'])
 
 _dataframe_apply_whitelist = \
     _common_apply_whitelist | frozenset(['dtypes', 'corrwith'])

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -3335,6 +3335,7 @@ class TestGroupBy(tm.TestCase):
             'corr', 'cov',
             'value_counts',
             'diff',
+            'unique', 'nunique',
         ])
 
         for obj, whitelist in zip((df, s),


### PR DESCRIPTION
Series.unique and Series.nunique are useful methods for querying the
unique elements (or number of unique elements) in each group when used
in conjunction with DataFrame.GroupBy.  This commit addresses
closes pydata/pandas#6146.
