### PR TITLE
append to existing table with mulitindex fix

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -172,6 +172,8 @@ Bug Fixes
     string comparisons (:issue:`6155`).
   - Fixed a bug in ``query`` where the index of a single-element ``Series`` was
     being thrown away (:issue:`6148`).
+  - Bug in ``HDFStore`` on appending a dataframe with multi-indexed columns to
+    an existing table (:issue:`6167`)
 
 pandas 0.13.0
 -------------

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3068,9 +3068,9 @@ class Table(Fixed):
 
         axis, axis_labels = self.non_index_axes[0]
         info = self.info.get(axis, dict())
-        if info.get('type') == 'MultiIndex' and data_columns is not None:
+        if info.get('type') == 'MultiIndex' and data_columns:
             raise ValueError("cannot use a multi-index on axis [{0}] with "
-                             "data_columns".format(axis))
+                             "data_columns {1}".format(axis, data_columns))
 
         # evaluate the passed data_columns, True == use all columns
         # take only valide axis labels

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -1613,6 +1613,13 @@ class TestHDFStore(tm.TestCase):
             self.assertRaises(ValueError, store.put, 'df2',df,format='table',data_columns=['A'])
             self.assertRaises(ValueError, store.put, 'df3',df,format='table',data_columns=True)
 
+        # appending multi-column on existing table (see GH 6167)
+        with ensure_clean_store(self.path) as store:
+            store.append('df2', df)
+            store.append('df2', df)
+
+            tm.assert_frame_equal(store['df2'], concat((df,df)))
+
         # non_index_axes name
         df = DataFrame(np.arange(12).reshape(3,4), columns=Index(list('ABCD'),name='foo'))
 


### PR DESCRIPTION
Appending to an existing table with a multiindex failed as data_columns is set to [] but compared with None
