### PR TITLE
BUG: parsing multi-column headers in read_csv (GH6051)

### DIFF
--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -2568,6 +2568,52 @@ class TestCParserLowMemory(ParserTests, tm.TestCase):
         kwds['buffer_lines'] = 2
         return read_table(*args, **kwds)
 
+    def test_list_of_one_header(self):
+        data = """A,B,C
+1,2,3
+4,5,6
+7,8,9
+"""
+        df = self.read_csv(StringIO(data), header=[0])
+
+        values = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        expected = DataFrame(values, columns=['A', 'B', 'C'])
+
+        tm.assert_frame_equal(df, expected)
+
+    def test_list_of_multiple_headers(self):
+        data = """A,B,C
+a,b,c
+1,2,3
+4,5,6
+7,8,9
+"""
+        df = self.read_csv(StringIO(data), header=[0,1])
+
+        values = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        expected_columns = pd.MultiIndex.from_arrays([['A', 'B', 'C'], ['a', 'b', 'c']])
+        expected = DataFrame(values, columns=expected_columns)
+
+        tm.assert_frame_equal(df, expected)
+
+    def test_list_of_multiple_headers_with_duplicated_column_pairs(self):
+        data = """A,A,A,A,A,B,B
+a,b,b,b,c,c,c
+1,2,3,4,5,6,7
+1,2,3,4,5,6,7
+1,2,3,4,5,6,7
+"""
+        df = self.read_csv(StringIO(data), header=[0,1])
+
+        values = [[1, 2, 3, 4, 5, 6, 7], [1, 2, 3, 4, 5, 6, 7], [1, 2, 3, 4, 5, 6, 7]]
+        expected_columns = pd.MultiIndex.from_arrays([
+            ['A', 'A', 'A',   'A',  'A', 'B', 'B'], 
+            ['a', 'b', 'b.1', 'b.2', 'c', 'c', 'c.1']])
+        expected = DataFrame(values, columns=expected_columns)
+
+        tm.assert_frame_equal(df, expected)
+
+
     def test_compact_ints(self):
         data = ('0,1,0,0\n'
                 '1,1,0,0\n'

--- a/pandas/parser.pyx
+++ b/pandas/parser.pyx
@@ -30,6 +30,7 @@ import numpy as np
 cimport util
 
 import pandas.lib as lib
+from pandas.compat import lzip
 
 import time
 import os
@@ -671,7 +672,7 @@ cdef class TextReader:
             if self.has_mi_columns:
 
                 # zip the header, so that we can easily find the duplicated pair
-                header = zip(*header)
+                header = lzip(*header)
 
                 counts = {}
                 for i, column in enumerate(header):
@@ -691,7 +692,7 @@ cdef class TextReader:
                     counts[column] = count + 1
 
                 # unzip the header
-                header = [list(x) for x in zip(*header)]
+                header = lzip(*header)
 
             if self.names is not None:
                 header = [ self.names ]

--- a/pandas/parser.pyx
+++ b/pandas/parser.pyx
@@ -593,6 +593,7 @@ cdef class TextReader:
             char *errors = "strict"
 
         header = []
+        is_duplicated = False
 
         if self.parser.header_start >= 0:
 
@@ -640,6 +641,9 @@ cdef class TextReader:
                     count = counts.get(name, 0)
                     if count > 0 and self.mangle_dupe_cols and not self.has_mi_columns:
                         this_header.append('%s.%d' % (name, count))
+
+                        # for warning later
+                        is_duplicated = True
                     else:
                         this_header.append(name)
                     counts[name] = count + 1
@@ -688,6 +692,9 @@ cdef class TextReader:
                         tmp_column = list(column)
                         tmp_column[-2] = '%s.%d' % (tmp_column[-2], count)
                         header[i] = tuple(tmp_column)
+
+                        # for warning later
+                        is_duplicated = True
 
                     counts[column] = count + 1
 
@@ -750,6 +757,9 @@ cdef class TextReader:
             # oh boy, #2442, #2981
             elif self.allow_leading_cols and passed_count < field_count:
                 self.leading_cols = field_count - passed_count
+
+        if self.mangle_dupe_cols and is_duplicated:
+            warnings.warn('Duplicated columns have been mangled', DtypeWarning)
 
         return header, field_count
 


### PR DESCRIPTION
closes #6051 

Bug: `mangle_dupe_cols` cannot work while the header is a list. 

Originally, `has_mi_columns` will be set as 1 while the header is a list. And the `mangle_dupe_cols` things would not work when `has_mi_columns` == 1. 

This pull request is to 
1. for the list with single element, for example [0], the `has_mi_columns` will be set as 0, and the header will do the original `mangle_dupe_cols` things as the header is a single integer.
2. for the list with more than one element, append the sequence number in the last element of the duplicated multi-column

For example

```
Male,Male,Male,Male,Male,Female,Female
A,B,B,B,C,D,D
1,2,3,4,5,6,7
1,2,3,4,5,6,7
1,2,3,4,5,6,7
1,2,3,4,5,6,7
1,2,3,4,5,6,7
1,2,3,4,5,6,7
```

would be converted to 

```
In [2]: pd.read_csv('woo.csv', header=[0,1])
Out[2]: 
   Male                  Female     
      A  B  B.1  B.2  C       D  D.1
0     1  2    3    4  5       6    7
1     1  2    3    4  5       6    7
2     1  2    3    4  5       6    7
3     1  2    3    4  5       6    7
4     1  2    3    4  5       6    7
5     1  2    3    4  5       6    7

[6 rows x 7 columns]
```
