### PR TITLE
BUG: Consistency with dtypes in setting an empty DataFrame (GH6171)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -174,6 +174,7 @@ Bug Fixes
     being thrown away (:issue:`6148`).
   - Bug in ``HDFStore`` on appending a dataframe with multi-indexed columns to
     an existing table (:issue:`6167`)
+  - Consistency with dtypes in setting an empty DataFrame (:issue:`6171`)
 
 pandas 0.13.0
 -------------

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1421,7 +1421,18 @@ class ObjectBlock(Block):
                     return
             except:
                 pass
-        self.values[loc] = value
+        try:
+            self.values[loc] = value
+        except (ValueError):
+
+            # broadcasting error
+            # see GH6171
+            new_shape = list(value.shape)
+            new_shape[0] = len(self.items)
+            self.values = np.empty(tuple(new_shape),dtype=self.dtype)
+            self.values.fill(np.nan)
+            self.values[loc] = value
+
 
     def _maybe_downcast(self, blocks, downcast=None):
 

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -1987,6 +1987,23 @@ class TestIndexing(tm.TestCase):
         expected = DataFrame(0,index=[0],columns=['a'])
         assert_frame_equal(df, expected)
 
+        # GH 6171
+        # consistency on empty frames
+        df = DataFrame(columns=['x', 'y'])
+        df['x'] = [1, 2]
+        expected = DataFrame(dict(x = [1,2], y = [np.nan,np.nan]))
+        assert_frame_equal(df, expected, check_dtype=False)
+
+        df = DataFrame(columns=['x', 'y'])
+        df['x'] = ['1', '2']
+        expected = DataFrame(dict(x = ['1','2'], y = [np.nan,np.nan]),dtype=object)
+        assert_frame_equal(df, expected)
+
+        df = DataFrame(columns=['x', 'y'])
+        df.loc[0, 'x'] = 1
+        expected = DataFrame(dict(x = [1], y = [np.nan]))
+        assert_frame_equal(df, expected, check_dtype=False)
+
     def test_cache_updating(self):
         # GH 4939, make sure to update the cache on setitem
 


### PR DESCRIPTION
closes #6171
