### PR TITLE
ENH: Import testing into main namespace.

### DIFF
--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -51,3 +51,4 @@ from pandas.tools.plotting import scatter_matrix, plot_params
 from pandas.tools.tile import cut, qcut
 from pandas.core.reshape import melt
 from pandas.util.print_versions import show_versions
+import pandas.util.testing


### PR DESCRIPTION
Unfortunately I won't be able to use this in production until 2020 when we require 0.14, but this would make some things a bit easier for projects that use pandas as a library.
