### PR TITLE
BUG: bug in nanops.var with ddof=1 and 1 elements would sometimes return inf rather than nan (GH6136)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -177,6 +177,8 @@ Bug Fixes
   - Consistency with dtypes in setting an empty DataFrame (:issue:`6171`)
   - Bug in  selecting on a multi-index ``HDFStore`` even in the prescence of under
     specificed column spec (:issue:`6169`)
+  - Bug in ``nanops.var`` with ``ddof=1`` and 1 elements would sometimes return ``inf``
+    rather than ``nan`` on some platforms (:issue:`6136`)
 
 pandas 0.13.0
 -------------

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -302,14 +302,25 @@ def nanvar(values, axis=None, skipna=True, ddof=1):
     else:
         count = float(values.size - mask.sum())
 
+    d = count-ddof
     if skipna:
         values = values.copy()
         np.putmask(values, mask, 0)
 
+    # always return NaN, never inf
+    if np.isscalar(count):
+        if count <= ddof:
+            count = np.nan
+            d = np.nan
+    else:
+        mask = count <= ddof
+        if mask.any():
+            np.putmask(d, mask, np.nan)
+            np.putmask(count, mask, np.nan)
+
     X = _ensure_numeric(values.sum(axis))
     XX = _ensure_numeric((values ** 2).sum(axis))
-    return np.fabs((XX - X ** 2 / count) / (count - ddof))
-
+    return np.fabs((XX - X ** 2 / count) / d)
 
 @bottleneck_switch()
 def nanmin(values, axis=None, skipna=True):

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1832,6 +1832,14 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         expected = np.var(self.ts.values, ddof=4)
         assert_almost_equal(result, expected)
 
+        # 1 - element series with ddof=1
+        s = self.ts.iloc[[0]]
+        result = s.var(ddof=1)
+        self.assert_(isnull(result))
+
+        result = s.std(ddof=1)
+        self.assert_(isnull(result))
+
     def test_skew(self):
         _skip_if_no_scipy()
 


### PR DESCRIPTION
closes #6136
