### PR TITLE
DOC: styling clean-up of docstrings (part 2: series and generic.py)

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -809,8 +809,9 @@ class NDFrame(PandasObject):
               - columns : dict like {column -> {index -> value}}
               - values : just the values array
 
-        date_format : type of date conversion, epoch or iso
-            epoch = epoch milliseconds, iso = ISO8601, default is epoch
+        date_format : {'epoch', 'iso'}
+            Type of date conversion. `epoch` = epoch milliseconds,
+            `iso`` = ISO8601, default is epoch.
         double_precision : The number of decimal places to use when encoding
             floating point values, default 10.
         force_ascii : force encoded string to be ASCII, default True.
@@ -845,7 +846,8 @@ class NDFrame(PandasObject):
         Parameters
         ----------
         path_or_buf : the path (string) or buffer to put the store
-        key : string, an indentifier for the group in the store
+        key : string
+            indentifier for the group in the store
         mode : optional, {'a', 'w', 'r', 'r+'}, default 'a'
 
           ``'r'``
@@ -2079,8 +2081,8 @@ class NDFrame(PandasObject):
             column (for a DataFrame). (values not in the dict/Series will not be
             filled). This value cannot be a list.
         axis : {0, 1}, default 0
-            0: fill column-by-column
-            1: fill row-by-row
+            * 0: fill column-by-column
+            * 1: fill row-by-row
         inplace : boolean, default False
             If True, fill in place. Note: this will modify any
             other views on this object, (e.g. a no-copy slice for a column in a
@@ -2440,9 +2442,9 @@ class NDFrame(PandasObject):
                   'polynomial', 'spline' 'piecewise_polynomial', 'pchip'}
 
             * 'linear': ignore the index and treat the values as equally
-               spaced. default
+              spaced. default
             * 'time': interpolation works on daily and higher resolution
-                data to interpolate given length of interval
+              data to interpolate given length of interval
             * 'index': use the actual numerical values of the index
             * 'nearest', 'zero', 'slinear', 'quadratic', 'cubic',
               'barycentric', 'polynomial' is passed to
@@ -2450,10 +2452,10 @@ class NDFrame(PandasObject):
               'polynomial' and 'spline' requre that you also specify and order
               (int) e.g. df.interpolate(method='polynomial', order=4)
             * 'krogh', 'piecewise_polynomial', 'spline', and 'pchip' are all
-               wrappers around the scipy interpolation methods of similar
-               names. See the scipy documentation for more on their behavior:
-               http://docs.scipy.org/doc/scipy/reference/interpolate.html#univariate-interpolation
-               http://docs.scipy.org/doc/scipy/reference/tutorial/interpolate.html
+              wrappers around the scipy interpolation methods of similar
+              names. See the scipy documentation for more on their behavior:
+              http://docs.scipy.org/doc/scipy/reference/interpolate.html#univariate-interpolation
+              http://docs.scipy.org/doc/scipy/reference/tutorial/interpolate.html
 
         axis : {0, 1}, default 0
             * 0: fill column-by-column
@@ -2745,20 +2747,23 @@ class NDFrame(PandasObject):
 
         Parameters
         ----------
-        rule : the offset string or object representing target conversion
-        how : string, method for down- or re-sampling, default to 'mean' for
-              downsampling
+        rule : string
+            the offset string or object representing target conversion
+        how : string
+            method for down- or re-sampling, default to 'mean' for
+            downsampling
         axis : int, optional, default 0
-        fill_method : string, fill_method for upsampling, default None
+        fill_method : string, default None
+            fill_method for upsampling
         closed : {'right', 'left'}
             Which side of bin interval is closed
         label : {'right', 'left'}
             Which bin edge label to label bucket with
         convention : {'start', 'end', 's', 'e'}
-        kind: "period"/"timestamp"
-        loffset: timedelta
+        kind : "period"/"timestamp"
+        loffset : timedelta
             Adjust the resampled time labels
-        limit: int, default None
+        limit : int, default None
             Maximum size gap to when reindexing with fill_method
         base : int, default 0
             For frequencies that evenly subdivide 1 day, the "origin" of the

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -95,6 +95,7 @@ class Series(generic.NDFrame):
 
     """
     One-dimensional ndarray with axis labels (including time series).
+
     Labels need not be unique but must be any hashable type. The object
     supports both integer- and label-based indexing and provides a host of
     methods for performing operations involving the index. Statistical
@@ -117,7 +118,8 @@ class Series(generic.NDFrame):
         dict.
     dtype : numpy.dtype or None
         If None, dtype will be inferred
-    copy : boolean, default False, copy input data
+    copy : boolean, default False
+        Copy input data
     """
     _metadata = ['name']
 
@@ -807,7 +809,8 @@ class Series(generic.NDFrame):
 
     def reset_index(self, level=None, drop=False, name=None, inplace=False):
         """
-        Analogous to the DataFrame.reset_index function, see docstring there.
+        Analogous to the :meth:`pandas.DataFrame.reset_index` function, see
+        docstring there.
 
         Parameters
         ----------
@@ -1133,7 +1136,7 @@ class Series(generic.NDFrame):
 
         Parameters
         ----------
-        normalize: boolean, default False
+        normalize : boolean, default False
             If True then the Series returned will contain the relative
             frequencies of the unique values.
         sort : boolean, default True
@@ -1161,7 +1164,7 @@ class Series(generic.NDFrame):
         Parameters
         ----------
         sort : bool, default True
-            if True, will lexicographically sort values, if False skips
+            If True, will lexicographically sort values, if False skips
             sorting. Result ordering when ``sort=False`` is not defined.
 
         Returns
@@ -1398,9 +1401,9 @@ class Series(generic.NDFrame):
         ----------
         other : Series
         method : {'pearson', 'kendall', 'spearman'}
-            pearson : standard correlation coefficient
-            kendall : Kendall Tau correlation coefficient
-            spearman : Spearman rank correlation
+            * pearson : standard correlation coefficient
+            * kendall : Kendall Tau correlation coefficient
+            * spearman : Spearman rank correlation
         min_periods : int, optional
             Minimum number of observations needed to have a valid result
 
@@ -1663,7 +1666,7 @@ class Series(generic.NDFrame):
 
         See Also
         --------
-        pandas.Series.order
+        Series.order
         """
 
         # GH 5856/5863
@@ -1750,10 +1753,10 @@ class Series(generic.NDFrame):
         Parameters
         ----------
         method : {'average', 'min', 'max', 'first'}
-            average: average rank of group
-            min: lowest rank in group
-            max: highest rank in group
-            first: ranks assigned in order they appear in the array
+            * average: average rank of group
+            * min: lowest rank in group
+            * max: highest rank in group
+            * first: ranks assigned in order they appear in the array
         na_option : {'keep'}
             keep: leave NA values where they are
         ascending : boolean, default True
@@ -2260,7 +2263,7 @@ class Series(generic.NDFrame):
         Returns
         -------
         valid : Series
-        inplace : bool (default False)
+        inplace : boolean, default False
             Do operation in place.
         """
         axis = self._get_axis_number(axis or 0)


### PR DESCRIPTION
Rediscovered an old branch: some clean-up of docstrings in series/generic.py.
