### PR TITLE
DOC: add links to other pages to contributing.rst

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -4,4 +4,13 @@
 Contributing to pandas
 **********************
 
+See the following links:
+
+- `The developer pages on the website
+  <http://pandas.pydata.org/developers.html>`_
+- `Guidelines on bug reports and pull requests
+  <https://github.com/pydata/pandas/blob/master/CONTRIBUTING.md>`_
+- `Some extra tips on using git
+  <https://github.com/pydata/pandas/wiki/Using-Git>`_
+
 .. include:: ../README.rst


### PR DESCRIPTION
Awaiting for that the different developer pages could be reworked and added to this page, I thought to at least add some links here. So if people go from the docs to this page, they get redirected to the relevant pages.
