### PR TITLE
BUG: dont ignore use_index kw in bar plot

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -179,6 +179,7 @@ Bug Fixes
     specificed column spec (:issue:`6169`)
   - Bug in ``nanops.var`` with ``ddof=1`` and 1 elements would sometimes return ``inf``
     rather than ``nan`` on some platforms (:issue:`6136`)
+  - Bug in Series and DataFrame bar plots ignoring the ``use_index`` keyword (:issue:`6209`)
 
 pandas 0.13.0
 -------------

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -162,6 +162,14 @@ class TestSeriesPlots(tm.TestCase):
         ax = Series([200, 500]).plot(log=True, kind='bar')
         assert_array_equal(ax.yaxis.get_ticklocs(), expected)
 
+    @slow
+    def test_bar_ignore_index(self):
+        df = Series([1, 2, 3, 4], index=['a', 'b', 'c', 'd'])
+        ax = df.plot(kind='bar', use_index=False)
+        expected = ['0', '1', '2', '3']
+        result = [x.get_text() for x in ax.get_xticklabels()]
+        self.assertEqual(result, expected)
+
     def test_rotation(self):
         df = DataFrame(randn(5, 5))
         ax = df.plot(rot=30)

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1572,8 +1572,11 @@ class BarPlot(MPLPlot):
 
     def _post_plot_logic(self):
         for ax in self.axes:
-            str_index = [com.pprint_thing(key) for key in self.data.index]
-
+            if self.use_index:
+                str_index = [com.pprint_thing(key) for key in self.data.index]
+            else:
+                str_index = [com.pprint_thing(key) for key in
+                             range(self.data.shape[0])]
             name = self._get_index_name()
             if self.kind == 'bar':
                 ax.set_xlim([self.ax_pos[0] - 0.25, self.ax_pos[-1] + 1])


### PR DESCRIPTION
Closes https://github.com/pydata/pandas/issues/6209

Here's the fixed output for the same example from the issue: `df.plot(kind='bar', use_index=False)`:

![line_false_fixed](https://f.cloud.github.com/assets/1312546/2053850/603f044e-8aad-11e3-86e3-3f3bf38a5683.png)

I thew it in `.13.1`, can push to `.14` if need be.
