### PR TITLE
DOC/PY3: Python 3 docs example compat for range, StringIO and datetime

### DIFF
--- a/doc/source/comparison_with_r.rst
+++ b/doc/source/comparison_with_r.rst
@@ -99,7 +99,7 @@ this:
 .. ipython:: python
 
    s = pd.Series(np.arange(5),dtype=np.float32)
-   Series(pd.match(s,[2,4],np.nan))
+   pd.Series(pd.match(s,[2,4],np.nan))
 
 For more details and examples see :ref:`the reshaping documentation
 <indexing.basics.indexing_isin>`.

--- a/doc/source/comparison_with_r.rst
+++ b/doc/source/comparison_with_r.rst
@@ -279,7 +279,7 @@ In Python, since ``a`` is a list, you can simply use list comprehension.
 
 .. ipython:: python
 
-   a = np.array(range(1,24)+[np.NAN]).reshape(2,3,4)
+   a = np.array(list(range(1,24))+[np.NAN]).reshape(2,3,4)
    DataFrame([tuple(list(x)+[val]) for x, val in np.ndenumerate(a)])
 
 |meltlist|_
@@ -298,7 +298,7 @@ In Python, this list would be a list of tuples, so
 
 .. ipython:: python
 
-   a = list(enumerate(range(1,5)+[np.NAN]))
+   a = list(enumerate(list(range(1,5))+[np.NAN]))
    DataFrame(a)
 
 For more details and examples see :ref:`the Into to Data Structures

--- a/doc/source/enhancingperf.rst
+++ b/doc/source/enhancingperf.rst
@@ -384,7 +384,7 @@ First let's create 4 decent-sized arrays to play with:
    from numpy.random import randn
    import numpy as np
    nrows, ncols = 20000, 100
-   df1, df2, df3, df4 = [DataFrame(randn(nrows, ncols)) for _ in xrange(4)]
+   df1, df2, df3, df4 = [DataFrame(randn(nrows, ncols)) for _ in range(4)]
 
 
 Now let's compare adding them together using plain ol' Python versus

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -7,7 +7,7 @@
 
    import os
    import csv
-   from StringIO import StringIO
+   from pandas.compat import StringIO, BytesIO
    import pandas as pd
    ExcelWriter = pd.ExcelWriter
 
@@ -57,6 +57,11 @@ The corresponding ``writer`` functions are object methods that are accessed like
     * :ref:`to_stata<io.stata_writer>`
     * :ref:`to_clipboard<io.clipboard>`
     * :ref:`to_pickle<io.pickle>`
+
+.. note::
+   For examples that use the ``StringIO`` class, make sure you import it
+   according to your Python version, i.e. ``from StringIO import StringIO`` for
+   Python 2 and ``from io import StringIO`` for Python 3.
 
 .. _io.read_csv_table:
 
@@ -278,7 +283,6 @@ used as the column names:
 
 .. ipython:: python
 
-    from StringIO import StringIO
     data = 'a,b,c\n1,2,3\n4,5,6\n7,8,9'
     print(data)
     pd.read_csv(StringIO(data))
@@ -327,7 +331,7 @@ result in byte strings being decoded to unicode in the result:
 .. ipython:: python
 
    data = b'word,length\nTr\xc3\xa4umen,7\nGr\xc3\xbc\xc3\x9fe,5'.decode('utf8').encode('latin-1')
-   df = pd.read_csv(StringIO(data), encoding='latin-1')
+   df = pd.read_csv(BytesIO(data), encoding='latin-1')
    df
    df['word'][1]
 
@@ -1561,8 +1565,6 @@ You can even pass in an instance of ``StringIO`` if you so desire
 
 .. ipython:: python
 
-   from cStringIO import StringIO
-
    with open(file_path, 'r') as f:
        sio = StringIO(f.read())
 
@@ -2627,7 +2629,7 @@ chunks.
    store.append('dfeq', dfeq, data_columns=['number'])
 
    def chunks(l, n):
-        return [l[i:i+n] for i in xrange(0, len(l), n)]
+        return [l[i:i+n] for i in range(0, len(l), n)]
 
    evens = [2,4,6,8,10]
    coordinates = store.select_as_coordinates('dfeq','number=evens')

--- a/doc/source/remote_data.rst
+++ b/doc/source/remote_data.rst
@@ -7,7 +7,6 @@
 
    import os
    import csv
-   from StringIO import StringIO
    import pandas as pd
 
    import numpy as np
@@ -49,7 +48,7 @@ Yahoo! Finance
     import pandas.io.data as web
     import datetime
     start = datetime.datetime(2010, 1, 1)
-    end = datetime.datetime(2013, 01, 27)
+    end = datetime.datetime(2013, 1, 27)
     f=web.DataReader("F", 'yahoo', start, end)
     f.ix['2010-01-04']
 
@@ -63,7 +62,7 @@ Google Finance
     import pandas.io.data as web
     import datetime
     start = datetime.datetime(2010, 1, 1)
-    end = datetime.datetime(2013, 01, 27)
+    end = datetime.datetime(2013, 1, 27)
     f=web.DataReader("F", 'google', start, end)
     f.ix['2010-01-04']
 
@@ -77,7 +76,7 @@ FRED
     import pandas.io.data as web
     import datetime
     start = datetime.datetime(2010, 1, 1)
-    end = datetime.datetime(2013, 01, 27)
+    end = datetime.datetime(2013, 1, 27)
     gdp=web.DataReader("GDP", "fred", start, end)
     gdp.ix['2013-01-01']
 

--- a/doc/source/reshaping.rst
+++ b/doc/source/reshaping.rst
@@ -436,6 +436,11 @@ To encode 1-d values as an enumerated type use ``factorize``:
 Note that ``factorize`` is similar to ``numpy.unique``, but differs in its
 handling of NaN:
 
+.. note::
+   The following ``numpy.unique`` will fail under Python 3 with a ``TypeError``
+   because of an ordering bug. See also
+   `Here <https://github.com/numpy/numpy/issues/641>`__
+
 .. ipython:: python
 
    pd.factorize(x, sort=True)

--- a/doc/source/v0.10.0.txt
+++ b/doc/source/v0.10.0.txt
@@ -3,7 +3,7 @@
 .. ipython:: python
    :suppress:
 
-   from StringIO import StringIO
+   from pandas.compat import StringIO
 
 v0.10.0 (December 17, 2012)
 ---------------------------

--- a/doc/source/v0.13.0.txt
+++ b/doc/source/v0.13.0.txt
@@ -698,7 +698,7 @@ Experimental
 
      nrows, ncols = 20000, 100
      df1, df2, df3, df4 = [DataFrame(randn(nrows, ncols))
-                           for _ in xrange(4)]
+                           for _ in range(4)]
 
   .. ipython:: python
 

--- a/doc/source/v0.13.1.txt
+++ b/doc/source/v0.13.1.txt
@@ -141,7 +141,7 @@ API changes
   .. ipython:: python
 
      def applied_func(col):
-        print "Apply function being called with:", col
+        print("Apply function being called with: ", col)
         return col.sum()
 
      empty = DataFrame(columns=['a', 'b'])

--- a/doc/source/v0.9.0.txt
+++ b/doc/source/v0.9.0.txt
@@ -1,5 +1,10 @@
 .. _whatsnew_0900:
 
+.. ipython:: python
+   :suppress:
+
+   from pandas.compat import StringIO
+
 v0.9.0 (October 7, 2012)
 ------------------------
 
@@ -35,8 +40,6 @@ API changes
     attribute access:
 
 .. ipython:: python
-
-   from StringIO import StringIO
 
    data = '0,0,1\n1,1,0\n0,1,0'
    df = read_csv(StringIO(data), header=None)

--- a/doc/source/v0.9.1.txt
+++ b/doc/source/v0.9.1.txt
@@ -1,5 +1,10 @@
 .. _whatsnew_0901:
 
+.. ipython:: python
+   :suppress:
+
+   from pandas.compat import StringIO
+
 v0.9.1 (November 14, 2012)
 --------------------------
 
@@ -132,7 +137,6 @@ API changes
 
         data = 'A,B,C\n00001,001,5\n00002,002,6'
 
-        from cStringIO import StringIO
         read_csv(StringIO(data), converters={'A' : lambda x: x.strip()})
 
 


### PR DESCRIPTION
related is #6212

Fixes examples in documentation to be compatible with Python 3. Also tested it locally under Python 2.
- Turned occurrences of `(x)range()` to `range()` for iteration and to `list(range())` for  list concat.
- Fixed leading zero argument(s) as in e.g. `datetime(2013, 01, 27)`.
- Removed explicit `StringIO` and `cStringIO` imports in examples (uses suppressed pandas.compat imports) and added a note on py2/3 library reorganization.
- Fixed `StringIO` for binary data to the more explicit `BytesIO`.
- Fixed `NameError` for missing `pd.` in `pd.Series`.
- Added note for failing `numpy.unique` example, see also #6229.  

I am not sure about the `BytesIO` though. Maybe good to put a note saying this is Python 3 way to do it and users on 2.x should use the old `StringIO` instead. In general, should we favor Python 3 doc versions in such cases and add notes for Python 2.x users? What do you think?
