### PR TITLE
BUG: Fix ImportError on Python 3.4b2 and 3.4b3

### DIFF
--- a/pandas/src/ujson/python/ujson.c
+++ b/pandas/src/ujson/python/ujson.c
@@ -78,7 +78,7 @@ static struct PyModuleDef moduledef = {
   NULL            /* m_free */
 };
 
-#define PYMODINITFUNC       PyObject *PyInit_json(void)
+#define PYMODINITFUNC       PyMODINIT_FUNC PyInit_json(void)
 #define PYMODULE_CREATE()   PyModule_Create(&moduledef)
 #define MODINITERROR        return NULL
 


### PR DESCRIPTION
See http://bugs.python.org/issue20166

```
ERROR: Failure: ImportError (dynamic module does not define init function (PyInit_json))
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\nose\failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "X:\Python34\lib\site-packages\nose\loader.py", line 402, in loadTestsFromName
    module = resolve_name(addr.module)
  File "X:\Python34\lib\site-packages\nose\util.py", line 311, in resolve_name
    module = __import__('.'.join(parts_copy))
  File "X:\Python34\lib\site-packages\pandas\__init__.py", line 44, in <module>
    from pandas.io.api import *
  File "X:\Python34\lib\site-packages\pandas\io\api.py", line 7, in <module>
    from pandas.io.excel import ExcelFile, ExcelWriter, read_excel
  File "X:\Python34\lib\site-packages\pandas\io\excel.py", line 14, in <module>
    from pandas import json
ImportError: dynamic module does not define init function (PyInit_json)
```
