### PR TITLE
BUG: Indexing bugs with reordered indexes (GH6252, GH6254)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -73,6 +73,7 @@ Bug Fixes
 
 - Bug in version string gen. for dev versions with shallow clones / install from tarball (:issue:`6127`)
 - Inconsistent tz parsing Timestamp/to_datetime for current year (:issue:`5958`)
+- Indexing bugs with reordered indexes (:issue:`6252`, :issue:`6254`)
 
 pandas 0.13.1
 -------------

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -633,7 +633,8 @@ class Block(PandasObject):
             # if we are an exact match (ex-broadcasting),
             # then use the resultant dtype
             elif len(arr_value.shape) and arr_value.shape[0] == values.shape[0] and np.prod(arr_value.shape) == np.prod(values.shape):
-                values = arr_value.reshape(values.shape)
+                values[indexer] = value
+                values = values.astype(arr_value.dtype)
 
             # set
             else:

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -646,6 +646,32 @@ class TestIndexing(tm.TestCase):
         result = df.ix[:,1:]
         assert_frame_equal(result, expected)
 
+        # GH 6254
+        # setting issue
+        df = DataFrame(index=[3, 5, 4], columns=['A'])
+        df.loc[[4, 3, 5], 'A'] = [1, 2, 3]
+        expected = DataFrame(dict(A = Series([1,2,3],index=[4, 3, 5]))).reindex(index=[3,5,4])
+        assert_frame_equal(df, expected)
+
+        # GH 6252
+        # setting with an empty frame
+        keys1 = ['@' + str(i) for i in range(5)]
+        val1 = np.arange(5)
+
+        keys2 = ['@' + str(i) for i in range(4)]
+        val2 = np.arange(4)
+
+        index = list(set(keys1).union(keys2))
+        df = DataFrame(index = index)
+        df['A'] = nan
+        df.loc[keys1, 'A'] = val1
+
+        df['B'] = nan
+        df.loc[keys2, 'B'] = val2
+
+        expected = DataFrame(dict(A = Series(val1,index=keys1), B = Series(val2,index=keys2))).reindex(index=index)
+        assert_frame_equal(df, expected)
+
     def test_loc_setitem_frame_multiples(self):
 
         # multiple setting


### PR DESCRIPTION
closes #6252
closes #6254

```
In [1]:  df = DataFrame(index=[3, 5, 4], columns=['A'])

In [2]: df.loc[[4, 3, 5], 'A'] = [1, 2, 3]

In [3]: df
Out[3]: 
   A
3  2
5  3
4  1

[3 rows x 1 columns]
```

```
In [4]: keys1 = ['@' + str(i) for i in range(5)]

In [5]: val1 = np.arange(5)

In [6]: keys2 = ['@' + str(i) for i in range(4)]

In [7]: val2 = np.arange(4)

In [8]: index = list(set(keys1).union(keys2))

In [9]: df = DataFrame(index = index)

In [10]: df['A'] = nan

In [11]: df.loc[keys1, 'A'] = val1

In [12]: df['B'] = nan

In [13]: df.loc[keys2, 'B'] = val2

In [14]: df
Out[14]: 
    A   B
@2  2   2
@3  3   3
@0  0   0
@1  1   1
@4  4 NaN

[5 rows x 2 columns]
```
