### PR TITLE
CLN: Work on converting assert_'s to specialized forms, in pandas/tests

### DIFF
--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -92,7 +92,7 @@ class TestIndex(tm.TestCase):
 
     def test_new_axis(self):
         new_index = self.dateIndex[None, :]
-        self.assert_(new_index.ndim == 2)
+        self.assertEqual(new_index.ndim, 2)
         tm.assert_isinstance(new_index, np.ndarray)
 
     def test_copy_and_deepcopy(self):
@@ -133,7 +133,7 @@ class TestIndex(tm.TestCase):
         arr = np.array(self.strIndex)
         index = Index(arr, copy=True, name='name')
         tm.assert_isinstance(index, Index)
-        self.assert_(index.name == 'name')
+        self.assertEqual(index.name, 'name')
         assert_array_equal(arr, index)
         arr[0] = "SOMEBIGLONGSTRING"
         self.assertNotEqual(index[0], "SOMEBIGLONGSTRING")
@@ -156,12 +156,12 @@ class TestIndex(tm.TestCase):
     def test_copy(self):
         i = Index([], name='Foo')
         i_copy = i.copy()
-        self.assert_(i_copy.name == 'Foo')
+        self.assertEqual(i_copy.name, 'Foo')
 
     def test_view(self):
         i = Index([], name='Foo')
         i_view = i.view()
-        self.assert_(i_view.name == 'Foo')
+        self.assertEqual(i_view.name, 'Foo')
 
     def test_astype(self):
         casted = self.intIndex.astype('i8')
@@ -234,7 +234,7 @@ class TestIndex(tm.TestCase):
         self.assert_(np.isnan(self.dateIndex.asof(d - timedelta(1))))
 
         d = self.dateIndex[-1]
-        self.assert_(self.dateIndex.asof(d + timedelta(1)) == d)
+        self.assertEqual(self.dateIndex.asof(d + timedelta(1)), d)
 
         d = self.dateIndex[0].to_datetime()
         tm.assert_isinstance(self.dateIndex.asof(d), Timestamp)
@@ -356,7 +356,7 @@ class TestIndex(tm.TestCase):
         first.name = 'A'
         second.name = 'A'
         union = first.union(second)
-        self.assert_(union.name == 'A')
+        self.assertEqual(union.name, 'A')
 
         second.name = 'B'
         union = first.union(second)
@@ -393,7 +393,7 @@ class TestIndex(tm.TestCase):
         right = Index([1, 2, 3], name='foo')
 
         result = left.append(right)
-        self.assert_(result.name == 'foo')
+        self.assertEqual(result.name, 'foo')
 
         left = Index([], name='foo')
         right = Index([1, 2, 3], name='bar')
@@ -440,7 +440,7 @@ class TestIndex(tm.TestCase):
 
         # with everythin
         result = first.diff(first)
-        self.assert_(len(result) == 0)
+        self.assertEqual(len(result), 0)
         self.assertEqual(result.name, first.name)
 
         # non-iterable input
@@ -511,14 +511,14 @@ class TestIndex(tm.TestCase):
         dates = Index([dt + inc for dt in self.dateIndex], name='something')
 
         formatted = dates.format(name=True)
-        self.assert_(formatted[0] == 'something')
+        self.assertEqual(formatted[0], 'something')
 
     def test_format_datetime_with_time(self):
         t = Index([datetime(2012, 2, 7), datetime(2012, 2, 7, 23)])
 
         result = t.format()
         expected = ['2012-02-07 00:00:00', '2012-02-07 23:00:00']
-        self.assert_(len(result) == 2)
+        self.assertEqual(len(result), 2)
         self.assertEquals(result, expected)
 
     def test_format_none(self):
@@ -579,16 +579,16 @@ class TestIndex(tm.TestCase):
     def test_slice_locs_dup(self):
         idx = Index(['a', 'a', 'b', 'c', 'd', 'd'])
         rs = idx.slice_locs('a', 'd')
-        self.assert_(rs == (0, 6))
+        self.assertEqual(rs, (0, 6))
 
         rs = idx.slice_locs(end='d')
-        self.assert_(rs == (0, 6))
+        self.assertEqual(rs, (0, 6))
 
         rs = idx.slice_locs('a', 'c')
-        self.assert_(rs == (0, 4))
+        self.assertEqual(rs, (0, 4))
 
         rs = idx.slice_locs('b', 'd')
-        self.assert_(rs == (2, 6))
+        self.assertEqual(rs, (2, 6))
 
     def test_drop(self):
         n = len(self.strIndex)
@@ -624,13 +624,13 @@ class TestIndex(tm.TestCase):
         int_idx = idx1.intersection(idx2)
         # needs to be 1d like idx1 and idx2
         expected = idx1[:4]  # pandas.Index(sorted(set(idx1) & set(idx2)))
-        self.assert_(int_idx.ndim == 1)
+        self.assertEqual(int_idx.ndim, 1)
         self.assert_(int_idx.equals(expected))
 
         # union broken
         union_idx = idx1.union(idx2)
         expected = pandas.Index(sorted(set(idx1) | set(idx2)))
-        self.assert_(union_idx.ndim == 1)
+        self.assertEqual(union_idx.ndim, 1)
         self.assert_(union_idx.equals(expected))
 
     def test_is_monotonic_incomparable(self):
@@ -658,8 +658,8 @@ class TestIndex(tm.TestCase):
         # empty, return dtype bool
         idx = Index([])
         result = idx.isin(values)
-        self.assert_(len(result) == 0)
-        self.assert_(result.dtype == np.bool_)
+        self.assertEqual(len(result), 0)
+        self.assertEqual(result.dtype, np.bool_)
 
     def test_boolean_cmp(self):
         values = [1, 2, 3, 4]
@@ -668,7 +668,7 @@ class TestIndex(tm.TestCase):
         res = (idx == values)
 
         self.assert_(res.all())
-        self.assert_(res.dtype == 'bool')
+        self.assertEqual(res.dtype, 'bool')
         self.assert_(not isinstance(res, Index))
 
     def test_get_level_values(self):
@@ -728,15 +728,15 @@ class TestFloat64Index(tm.TestCase):
         self.assert_(isinstance(index, Float64Index))
         index = Float64Index(np.array([1.,2,3,4,5]))
         self.assert_(isinstance(index, Float64Index))
-        self.assert_(index.dtype == object)
+        self.assertEqual(index.dtype, object)
 
         index = Float64Index(np.array([1.,2,3,4,5]),dtype=np.float32)
         self.assert_(isinstance(index, Float64Index))
-        self.assert_(index.dtype == object)
+        self.assertEqual(index.dtype, object)
 
         index = Float64Index(np.array([1,2,3,4,5]),dtype=np.float32)
         self.assert_(isinstance(index, Float64Index))
-        self.assert_(index.dtype == object)
+        self.assertEqual(index.dtype, object)
 
         # nan handling
         result = Float64Index([np.nan, np.nan])
@@ -818,7 +818,7 @@ class TestInt64Index(tm.TestCase):
     def test_constructor_corner(self):
         arr = np.array([1, 2, 3, 4], dtype=object)
         index = Int64Index(arr)
-        self.assert_(index.values.dtype == np.int64)
+        self.assertEqual(index.values.dtype, np.int64)
         self.assert_(index.equals(arr))
 
         # preventing casting
@@ -839,12 +839,12 @@ class TestInt64Index(tm.TestCase):
     def test_copy(self):
         i = Int64Index([], name='Foo')
         i_copy = i.copy()
-        self.assert_(i_copy.name == 'Foo')
+        self.assertEqual(i_copy.name, 'Foo')
 
     def test_view(self):
         i = Int64Index([], name='Foo')
         i_view = i.view()
-        self.assert_(i_view.name == 'Foo')
+        self.assertEqual(i_view.name, 'Foo')
 
     def test_coerce_list(self):
         # coerce things
@@ -856,7 +856,7 @@ class TestInt64Index(tm.TestCase):
         tm.assert_isinstance(arr, Index)
 
     def test_dtype(self):
-        self.assert_(self.index.dtype == np.int64)
+        self.assertEqual(self.index.dtype, np.int64)
 
     def test_is_monotonic(self):
         self.assert_(self.index.is_monotonic)
@@ -1123,7 +1123,7 @@ class TestInt64Index(tm.TestCase):
         i2 = Index(['aa'], dtype=object)
         res = i2.intersection(i1)
 
-        self.assert_(len(res) == 0)
+        self.assertEqual(len(res), 0)
 
     def test_union_noncomparable(self):
         from datetime import datetime, timedelta
@@ -1152,7 +1152,7 @@ class TestInt64Index(tm.TestCase):
 
     def test_prevent_casting(self):
         result = self.index.astype('O')
-        self.assert_(result.dtype == np.object_)
+        self.assertEqual(result.dtype, np.object_)
 
     def test_take_preserve_name(self):
         index = Int64Index([1, 2, 3, 4], name='foo')
@@ -1223,7 +1223,7 @@ class TestMultiIndex(tm.TestCase):
 
     def test_set_names_and_rename(self):
         # so long as these are synonyms, we don't need to test set_names
-        self.assert_(self.index.rename == self.index.set_names)
+        self.assertEqual(self.index.rename, self.index.set_names)
         new_names = [name + "SUFFIX" for name in self.index_names]
         ind = self.index.set_names(new_names)
         self.assertEqual(self.index.names, self.index_names)
@@ -1433,7 +1433,7 @@ class TestMultiIndex(tm.TestCase):
                                   names=['first'])
         tm.assert_isinstance(single_level, Index)
         self.assert_(not isinstance(single_level, MultiIndex))
-        self.assert_(single_level.name == 'first')
+        self.assertEqual(single_level.name, 'first')
 
         single_level = MultiIndex(levels=[['foo', 'bar', 'baz', 'qux']],
                                   labels=[[0, 1, 2, 3]])
@@ -1644,7 +1644,7 @@ class TestMultiIndex(tm.TestCase):
         result = list(self.index)
         expected = [('foo', 'one'), ('foo', 'two'), ('bar', 'one'),
                     ('baz', 'two'), ('qux', 'one'), ('qux', 'two')]
-        self.assert_(result == expected)
+        self.assertEqual(result, expected)
 
     def test_pickle(self):
         pickled = pickle.dumps(self.index)
@@ -1735,8 +1735,8 @@ class TestMultiIndex(tm.TestCase):
         self.assertEquals(sorted_idx.get_loc('foo'), slice(0, 2))
 
     def test_get_loc(self):
-        self.assert_(self.index.get_loc(('foo', 'two')) == 1)
-        self.assert_(self.index.get_loc(('baz', 'two')) == 3)
+        self.assertEqual(self.index.get_loc(('foo', 'two')), 1)
+        self.assertEqual(self.index.get_loc(('baz', 'two')), 3)
         self.assertRaises(KeyError, self.index.get_loc, ('bar', 'two'))
         self.assertRaises(KeyError, self.index.get_loc, 'quux')
 
@@ -1748,13 +1748,13 @@ class TestMultiIndex(tm.TestCase):
                                    np.array([0, 1, 0, 0, 0, 1, 0, 1]),
                                    np.array([1, 0, 1, 1, 0, 0, 1, 0])])
         self.assertRaises(KeyError, index.get_loc, (1, 1))
-        self.assert_(index.get_loc((2, 0)) == slice(3, 5))
+        self.assertEqual(index.get_loc((2, 0)), slice(3, 5))
 
     def test_get_loc_duplicates(self):
         index = Index([2, 2, 2, 2])
         result = index.get_loc(2)
         expected = slice(0, 4)
-        assert(result == expected)
+        self.assertEqual(result, expected)
         # self.assertRaises(Exception, index.get_loc, 2)
 
         index = Index(['c', 'a', 'a', 'b', 'b'])
@@ -2213,7 +2213,7 @@ class TestMultiIndex(tm.TestCase):
 
         # empty, but non-equal
         result = self.index - self.index.sortlevel(1)[0]
-        self.assert_(len(result) == 0)
+        self.assertEqual(len(result), 0)
 
         # raise Exception called with non-MultiIndex
         result = first.diff(first._tuple_index)
@@ -2352,7 +2352,7 @@ class TestMultiIndex(tm.TestCase):
         # key contained in all levels
         new_index = self.index.insert(0, ('bar', 'two'))
         self.assert_(new_index.equal_levels(self.index))
-        self.assert_(new_index[0] == ('bar', 'two'))
+        self.assertEqual(new_index[0], ('bar', 'two'))
 
         # key not contained in all levels
         new_index = self.index.insert(0, ('abc', 'three'))
@@ -2360,7 +2360,7 @@ class TestMultiIndex(tm.TestCase):
                                     list(self.index.levels[0]) + ['abc']))
         self.assert_(np.array_equal(new_index.levels[1],
                                     list(self.index.levels[1]) + ['three']))
-        self.assert_(new_index[0] == ('abc', 'three'))
+        self.assertEqual(new_index[0], ('abc', 'three'))
 
         # key wrong length
         assertRaisesRegexp(ValueError, "Item must have length equal to number"

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -180,7 +180,7 @@ class TestIndexing(tm.TestCase):
 
                 try:
                     if np.isscalar(rs) and np.isscalar(xp):
-                        self.assert_(rs == xp)
+                        self.assertEqual(rs, xp)
                     elif xp.ndim == 1:
                         assert_series_equal(rs,xp)
                     elif xp.ndim == 2:
@@ -326,7 +326,7 @@ class TestIndexing(tm.TestCase):
 
         result = s.at[dates[5]]
         xp     = s.values[5]
-        self.assert_(result == xp)
+        self.assertEqual(result, xp)
 
     def test_iat_invalid_args(self):
         pass
@@ -427,7 +427,7 @@ class TestIndexing(tm.TestCase):
 
         rs = df.iloc[2,2]
         xp = df.values[2,2]
-        self.assert_(rs == xp)
+        self.assertEqual(rs, xp)
 
         # for multiple items
         # GH 5528
@@ -455,7 +455,7 @@ class TestIndexing(tm.TestCase):
 
         df.iloc[1,1] = 1
         result = df.iloc[1,1]
-        self.assert_(result == 1)
+        self.assertEqual(result, 1)
 
         df.iloc[:,2:3] = 0
         expected = df.iloc[:,2:3]
@@ -627,7 +627,7 @@ class TestIndexing(tm.TestCase):
         result = DataFrame({ 'a' : [Timestamp('20130101')], 'b' : [1] }).iloc[0]
         expected = Series([ Timestamp('20130101'), 1],index=['a','b'])
         assert_series_equal(result,expected)
-        self.assert_(result.dtype == object)
+        self.assertEqual(result.dtype, object)
 
     def test_loc_setitem_frame(self):
         df = self.frame_labels
@@ -636,10 +636,10 @@ class TestIndexing(tm.TestCase):
 
         df.loc['a','A'] = 1
         result = df.loc['a','A']
-        self.assert_(result == 1)
+        self.assertEqual(result, 1)
 
         result = df.iloc[0,0]
-        self.assert_(result == 1)
+        self.assertEqual(result, 1)
 
         df.loc[:,'B':'D'] = 0
         expected = df.loc[:,'B':'D']
@@ -676,7 +676,7 @@ class TestIndexing(tm.TestCase):
 
         result = df.iloc[2,2]
         exp = df.ix[4,4]
-        self.assert_(result == exp)
+        self.assertEqual(result, exp)
 
         # slice
         result = df.iloc[4:8]
@@ -723,7 +723,7 @@ class TestIndexing(tm.TestCase):
 
         result = df.iloc[1,1]
         exp = df.ix['b','B']
-        self.assert_(result == exp)
+        self.assertEqual(result, exp)
 
         result = df.iloc[:,2:3]
         expected = df.ix[:,['C']]
@@ -732,7 +732,7 @@ class TestIndexing(tm.TestCase):
         # negative indexing
         result = df.iloc[-1,-1]
         exp = df.ix['j','D']
-        self.assert_(result == exp)
+        self.assertEqual(result, exp)
 
         # out-of-bounds exception
         self.assertRaises(IndexError, df.iloc.__getitem__, tuple([10,5]))
@@ -817,7 +817,7 @@ class TestIndexing(tm.TestCase):
 
         df.iloc[1,1] = 1
         result = df.iloc[1,1]
-        self.assert_(result == 1)
+        self.assertEqual(result, 1)
 
         df.iloc[:,2:3] = 0
         expected = df.iloc[:,2:3]
@@ -829,7 +829,7 @@ class TestIndexing(tm.TestCase):
 
         s.iloc[1] = 1
         result = s.iloc[1]
-        self.assert_(result == 1)
+        self.assertEqual(result, 1)
 
         s.iloc[:4] = 0
         expected = s.iloc[:4]
@@ -859,12 +859,12 @@ class TestIndexing(tm.TestCase):
         # corner column
         rs = mi_int.iloc[2,2]
         xp = mi_int.ix[:,2].ix[2]
-        self.assert_(rs == xp)
+        self.assertEqual(rs, xp)
 
         # this is basically regular indexing
         rs = mi_labels.iloc[2,2]
         xp = mi_labels.ix['j'].ix[:,'j'].ix[0,0]
-        self.assert_(rs == xp)
+        self.assertEqual(rs, xp)
 
     def test_loc_multiindex(self):
 
@@ -1006,7 +1006,7 @@ class TestIndexing(tm.TestCase):
         # GH3216
         df = DataFrame([{"a": 1}, {"a": 3, "b": 2}])
         df['c'] = np.nan
-        self.assert_(df['c'].dtype == np.float64)
+        self.assertEqual(df['c'].dtype, np.float64)
 
         df.ix[0,'c'] = 'foo'
         expected = DataFrame([{"a": 1, "c" : 'foo'}, {"a": 3, "b": 2, "c" : np.nan}])
@@ -1114,7 +1114,7 @@ class TestIndexing(tm.TestCase):
         idx=df['test']=='_'
         temp=df.ix[idx,'a'].apply(lambda x: '-----' if x=='aaa' else x)
         df.ix[idx,'test']=temp
-        self.assert_(df.iloc[0,2] == '-----')
+        self.assertEqual(df.iloc[0,2], '-----')
 
         #if I look at df, then element [0,2] equals '_'. If instead I type df.ix[idx,'test'], I get '-----', finally by typing df.iloc[0,2] I get '_'.
 
@@ -1151,13 +1151,13 @@ class TestIndexing(tm.TestCase):
         # GH 3617
         p = Panel(randn(4, 4, 4))
 
-        self.assert_(p.iloc[:3, :3, :3].shape == (3,3,3))
-        self.assert_(p.iloc[1, :3, :3].shape == (3,3))
-        self.assert_(p.iloc[:3, 1, :3].shape == (3,3))
-        self.assert_(p.iloc[:3, :3, 1].shape == (3,3))
-        self.assert_(p.iloc[1, 1, :3].shape == (3,))
-        self.assert_(p.iloc[1, :3, 1].shape == (3,))
-        self.assert_(p.iloc[:3, 1, 1].shape == (3,))
+        self.assertEqual(p.iloc[:3, :3, :3].shape, (3,3,3))
+        self.assertEqual(p.iloc[1, :3, :3].shape, (3,3))
+        self.assertEqual(p.iloc[:3, 1, :3].shape, (3,3))
+        self.assertEqual(p.iloc[:3, :3, 1].shape, (3,3))
+        self.assertEqual(p.iloc[1, 1, :3].shape, (3,))
+        self.assertEqual(p.iloc[1, :3, 1].shape, (3,))
+        self.assertEqual(p.iloc[:3, 1, 1].shape, (3,))
 
     def test_panel_getitem(self):
         # GH4016, date selection returns a frame when a partial string selection
@@ -1305,7 +1305,7 @@ class TestIndexing(tm.TestCase):
             indexer = i*2
             v = 1000 + i*200
             expected.ix[indexer, 'y'] = v
-            self.assert_(expected.ix[indexer, 'y'] == v)
+            self.assertEqual(expected.ix[indexer, 'y'], v)
 
         df.ix[df.x % 2 == 0, 'y'] = df.ix[df.x % 2 == 0, 'y'] * 100
         assert_frame_equal(df,expected)
@@ -1337,16 +1337,16 @@ class TestIndexing(tm.TestCase):
                        columns=['a', 'b', 8, 'c'],
                        index=['e', 7, 'f', 'g'])
 
-        self.assert_(df.ix['e', 8] == 2)
-        self.assert_(df.loc['e', 8] == 2)
+        self.assertEqual(df.ix['e', 8], 2)
+        self.assertEqual(df.loc['e', 8], 2)
 
         df.ix['e', 8] = 42
-        self.assert_(df.ix['e', 8] == 42)
-        self.assert_(df.loc['e', 8] == 42)
+        self.assertEqual(df.ix['e', 8], 42)
+        self.assertEqual(df.loc['e', 8], 42)
 
         df.loc['e', 8] = 45
-        self.assert_(df.ix['e', 8] == 45)
-        self.assert_(df.loc['e', 8] == 45)
+        self.assertEqual(df.ix['e', 8], 45)
+        self.assertEqual(df.loc['e', 8], 45)
 
     def test_setitem_list(self):
 
@@ -1490,13 +1490,13 @@ class TestIndexing(tm.TestCase):
         df = DataFrame([[1, 1], [1, 1]])
         df.index.name = 'index_name'
         result = df.iloc[[0, 1]].index.name
-        self.assert_(result == 'index_name')
+        self.assertEqual(result, 'index_name')
 
         result = df.ix[[0, 1]].index.name
-        self.assert_(result == 'index_name')
+        self.assertEqual(result, 'index_name')
 
         result = df.loc[[0, 1]].index.name
-        self.assert_(result == 'index_name')
+        self.assertEqual(result, 'index_name')
 
     def test_iloc_non_unique_indexing(self):
 
@@ -2035,7 +2035,7 @@ class TestIndexing(tm.TestCase):
         # correct setting
         df.loc[(0,0),'z'] = 2
         result = df.loc[(0,0),'z']
-        self.assert_(result == 2)
+        self.assertEqual(result, 2)
 
     def test_slice_consolidate_invalidate_item_cache(self):
         # #3970
@@ -2069,8 +2069,8 @@ class TestIndexing(tm.TestCase):
             # set it
             df.ix[7,'c'] = 1
 
-            self.assert_(df.ix[0,'c'] == 0.0)
-            self.assert_(df.ix[7,'c'] == 1.0)
+            self.assertEqual(df.ix[0,'c'], 0.0)
+            self.assertEqual(df.ix[7,'c'], 1.0)
 
     def test_setitem_chained_setfault(self):
 
@@ -2289,10 +2289,10 @@ class TestIndexing(tm.TestCase):
 
         index = Index([1.5, 2, 3, 4.5, 5])
         s = Series(range(5),index=index)
-        self.assert_(s[3] == 2)
-        self.assert_(s.ix[3] == 2)
-        self.assert_(s.loc[3] == 2)
-        self.assert_(s.iloc[3] == 3)
+        self.assertEqual(s[3], 2)
+        self.assertEqual(s.ix[3], 2)
+        self.assertEqual(s.loc[3], 2)
+        self.assertEqual(s.iloc[3], 3)
 
     def test_floating_index(self):
 
@@ -2311,16 +2311,16 @@ class TestIndexing(tm.TestCase):
         result1 = s[5.0]
         result2 = s.loc[5.0]
         result3 = s.ix[5.0]
-        self.assert_(result1 == result2)
-        self.assert_(result1 == result3)
+        self.assertEqual(result1, result2)
+        self.assertEqual(result1, result3)
 
         result1 = s[5]
         result2 = s.loc[5]
         result3 = s.ix[5]
-        self.assert_(result1 == result2)
-        self.assert_(result1 == result3)
+        self.assertEqual(result1, result2)
+        self.assertEqual(result1, result3)
 
-        self.assert_(s[5.0] == s[5])
+        self.assertEqual(s[5.0], s[5])
 
         # value not found (and no fallbacking at all)
 
@@ -2450,11 +2450,11 @@ class TestIndexing(tm.TestCase):
             # this is fallback, so it works
             result5 = s.ix[5]
             result6 = s.ix[5.0]
-            self.assert_(result1 == result2)
-            self.assert_(result1 == result3)
-            self.assert_(result1 == result4)
-            self.assert_(result1 == result5)
-            self.assert_(result1 == result6)
+            self.assertEqual(result1, result2)
+            self.assertEqual(result1, result3)
+            self.assertEqual(result1, result4)
+            self.assertEqual(result1, result5)
+            self.assertEqual(result1, result6)
 
         # all index types except float/int
         for index in [ tm.makeStringIndex, tm.makeUnicodeIndex,
@@ -2470,11 +2470,11 @@ class TestIndexing(tm.TestCase):
         result4 = s[5]
         result5 = s.loc[5]
         result6 = s.ix[5]
-        self.assert_(result1 == result2)
-        self.assert_(result1 == result3)
-        self.assert_(result1 == result4)
-        self.assert_(result1 == result5)
-        self.assert_(result1 == result6)
+        self.assertEqual(result1, result2)
+        self.assertEqual(result1, result3)
+        self.assertEqual(result1, result4)
+        self.assertEqual(result1, result5)
+        self.assertEqual(result1, result6)
 
     def test_slice_indexer(self):
 

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -100,7 +100,7 @@ class TestBlock(tm.TestCase):
 
     def test_constructor(self):
         int32block = get_int_ex(['a'],dtype = np.int32)
-        self.assert_(int32block.dtype == np.int32)
+        self.assertEqual(int32block.dtype, np.int32)
 
     def test_pickle(self):
         import pickle
@@ -119,9 +119,9 @@ class TestBlock(tm.TestCase):
         assert_almost_equal(self.fblock.ref_locs, [0, 2, 4])
 
     def test_attrs(self):
-        self.assert_(self.fblock.shape == self.fblock.values.shape)
-        self.assert_(self.fblock.dtype == self.fblock.values.dtype)
-        self.assert_(len(self.fblock) == len(self.fblock.values))
+        self.assertEqual(self.fblock.shape, self.fblock.values.shape)
+        self.assertEqual(self.fblock.dtype, self.fblock.values.dtype)
+        self.assertEqual(len(self.fblock), len(self.fblock.values))
 
     def test_merge(self):
         avals = randn(2, 10)
@@ -346,17 +346,17 @@ class TestBlockManager(tm.TestCase):
         self.mgr.set('baz', np.zeros(N, dtype=bool))
 
         self.mgr.set('baz', np.repeat('foo', N))
-        self.assert_(self.mgr.get('baz').dtype == np.object_)
+        self.assertEqual(self.mgr.get('baz').dtype, np.object_)
 
         mgr2 = self.mgr.consolidate()
         mgr2.set('baz', np.repeat('foo', N))
-        self.assert_(mgr2.get('baz').dtype == np.object_)
+        self.assertEqual(mgr2.get('baz').dtype, np.object_)
 
         mgr2.set('quux', randn(N).astype(int))
-        self.assert_(mgr2.get('quux').dtype == np.int_)
+        self.assertEqual(mgr2.get('quux').dtype, np.int_)
 
         mgr2.set('quux', randn(N))
-        self.assert_(mgr2.get('quux').dtype == np.float_)
+        self.assertEqual(mgr2.get('quux').dtype, np.float_)
 
     def test_copy(self):
         shallow = self.mgr.copy(deep=False)
@@ -368,17 +368,17 @@ class TestBlockManager(tm.TestCase):
                 if cp_blk.values is blk.values:
                     found = True
                     break
-            self.assert_(found == True)
+            self.assertTrue(found)
 
     def test_sparse(self):
         mgr = create_blockmanager([get_sparse_ex1(),get_sparse_ex2()])
 
         # what to test here?
-        self.assert_(mgr.as_matrix().dtype == np.float64)
+        self.assertEqual(mgr.as_matrix().dtype, np.float64)
 
     def test_sparse_mixed(self):
         mgr = create_blockmanager([get_sparse_ex1(),get_sparse_ex2(),get_float_ex()])
-        self.assert_(len(mgr.blocks) == 3)
+        self.assertEqual(len(mgr.blocks), 3)
         self.assert_(isinstance(mgr,BlockManager))
 
         # what to test here?
@@ -386,25 +386,25 @@ class TestBlockManager(tm.TestCase):
     def test_as_matrix_float(self):
 
         mgr = create_blockmanager([get_float_ex(['c'],np.float32), get_float_ex(['d'],np.float16), get_float_ex(['e'],np.float64)])
-        self.assert_(mgr.as_matrix().dtype == np.float64)
+        self.assertEqual(mgr.as_matrix().dtype, np.float64)
 
         mgr = create_blockmanager([get_float_ex(['c'],np.float32), get_float_ex(['d'],np.float16)])
-        self.assert_(mgr.as_matrix().dtype == np.float32)
+        self.assertEqual(mgr.as_matrix().dtype, np.float32)
 
     def test_as_matrix_int_bool(self):
 
         mgr = create_blockmanager([get_bool_ex(['a']), get_bool_ex(['b'])])
-        self.assert_(mgr.as_matrix().dtype == np.bool_)
+        self.assertEqual(mgr.as_matrix().dtype, np.bool_)
 
         mgr = create_blockmanager([get_int_ex(['a'],np.int64), get_int_ex(['b'],np.int64), get_int_ex(['c'],np.int32), get_int_ex(['d'],np.int16), get_int_ex(['e'],np.uint8) ])
-        self.assert_(mgr.as_matrix().dtype == np.int64)
+        self.assertEqual(mgr.as_matrix().dtype, np.int64)
 
         mgr = create_blockmanager([get_int_ex(['c'],np.int32), get_int_ex(['d'],np.int16), get_int_ex(['e'],np.uint8) ])
-        self.assert_(mgr.as_matrix().dtype == np.int32)
+        self.assertEqual(mgr.as_matrix().dtype, np.int32)
 
     def test_as_matrix_datetime(self):
         mgr = create_blockmanager([get_dt_ex(['h']), get_dt_ex(['g'])])
-        self.assert_(mgr.as_matrix().dtype == 'M8[ns]')
+        self.assertEqual(mgr.as_matrix().dtype, 'M8[ns]')
 
     def test_astype(self):
 
@@ -413,13 +413,13 @@ class TestBlockManager(tm.TestCase):
 
         for t in ['float16','float32','float64','int32','int64']:
             tmgr = mgr.astype(t)
-            self.assert_(tmgr.as_matrix().dtype == np.dtype(t))
+            self.assertEqual(tmgr.as_matrix().dtype, np.dtype(t))
 
         # mixed
         mgr = create_blockmanager([get_obj_ex(['a','b']),get_bool_ex(['c']),get_dt_ex(['d']),get_float_ex(['e'],np.float32), get_float_ex(['f'],np.float16), get_float_ex(['g'],np.float64)])
         for t in ['float16','float32','float64','int32','int64']:
             tmgr = mgr.astype(t, raise_on_error = False).get_numeric_data()
-            self.assert_(tmgr.as_matrix().dtype == np.dtype(t))
+            self.assertEqual(tmgr.as_matrix().dtype, np.dtype(t))
 
     def test_convert(self):
 
@@ -427,7 +427,7 @@ class TestBlockManager(tm.TestCase):
             """ compare the blocks, numeric compare ==, object don't """
             old_blocks = set(old_mgr.blocks)
             new_blocks = set(new_mgr.blocks)
-            self.assert_(len(old_blocks) == len(new_blocks))
+            self.assertEqual(len(old_blocks), len(new_blocks))
 
             # compare non-numeric
             for b in old_blocks:
@@ -436,7 +436,7 @@ class TestBlockManager(tm.TestCase):
                     if (b.values == nb.values).all():
                         found = True
                         break
-                self.assert_(found == True)
+                self.assertTrue(found)
 
             for b in new_blocks:
                 found = False
@@ -444,7 +444,7 @@ class TestBlockManager(tm.TestCase):
                     if (b.values == ob.values).all():
                         found = True
                         break
-                self.assert_(found == True)
+                self.assertTrue(found)
 
         # noops
         mgr = create_blockmanager([get_int_ex(['f']), get_float_ex(['g'])])
@@ -462,7 +462,7 @@ class TestBlockManager(tm.TestCase):
                 if isinstance(b,block_type):
                     for i in list(b.items):
                         items.add(i)
-            self.assert_(items == set(citems))
+            self.assertEqual(items, set(citems))
 
         # convert
         mat = np.empty((N, 3), dtype=object)

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -867,7 +867,7 @@ Thur,Lunch,Yes,51.51,17"""
 
         stacked = df.stack()
         assert_series_equal(stacked['foo'], df['foo'].stack())
-        self.assert_(stacked['bar'].dtype == np.float_)
+        self.assertEqual(stacked['bar'].dtype, np.float_)
 
     def test_unstack_bug(self):
         df = DataFrame({'state': ['naive', 'naive', 'naive',
@@ -1138,7 +1138,7 @@ Thur,Lunch,Yes,51.51,17"""
                            labels=[[0, 0, 1, 0, 1, 1],
                                    [0, 1, 0, 2, 2, 1]])
         self.assert_(not index.is_lexsorted())
-        self.assert_(index.lexsort_depth == 0)
+        self.assertEqual(index.lexsort_depth, 0)
 
     def test_frame_getitem_view(self):
         df = self.frame.T.copy()
@@ -1381,9 +1381,9 @@ Thur,Lunch,Yes,51.51,17"""
         self.ymd['F'] = 2
 
         unstacked = self.ymd.unstack('month')
-        self.assert_(unstacked['A', 1].dtype == np.float64)
-        self.assert_(unstacked['E', 1].dtype == np.object_)
-        self.assert_(unstacked['F', 1].dtype == np.float64)
+        self.assertEqual(unstacked['A', 1].dtype, np.float64)
+        self.assertEqual(unstacked['E', 1].dtype, np.object_)
+        self.assertEqual(unstacked['F', 1].dtype, np.float64)
 
     def test_unstack_group_index_overflow(self):
         labels = np.tile(np.arange(500), 2)
@@ -1425,7 +1425,7 @@ Thur,Lunch,Yes,51.51,17"""
 
         # in theory should be inserting in a sorted space????
         self.frame.ix[('bar','three'),'B'] = 0
-        self.assert_(self.frame.sortlevel().ix[('bar','three'),'B'] == 0)
+        self.assertEqual(self.frame.sortlevel().ix[('bar','three'),'B'], 0)
 
     #----------------------------------------------------------------------
     # AMBIGUOUS CASES!
@@ -1694,7 +1694,7 @@ Thur,Lunch,Yes,51.51,17"""
         df = DataFrame(np.random.randn(6, 3), index=index)
 
         result = df.drop([(0, 2)])
-        self.assert_(result.index.names == ('one', 'two'))
+        self.assertEqual(result.index.names, ('one', 'two'))
 
     def test_unicode_repr_issues(self):
         levels = [Index([u('a/\u03c3'), u('b/\u03c3'), u('c/\u03c3')]),

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -458,16 +458,16 @@ class CheckIndexing(object):
         # scalar
         self.panel['ItemG'] = 1
         self.panel['ItemE'] = True
-        self.assert_(self.panel['ItemG'].values.dtype == np.int64)
-        self.assert_(self.panel['ItemE'].values.dtype == np.bool_)
+        self.assertEqual(self.panel['ItemG'].values.dtype, np.int64)
+        self.assertEqual(self.panel['ItemE'].values.dtype, np.bool_)
 
         # object dtype
         self.panel['ItemQ'] = 'foo'
-        self.assert_(self.panel['ItemQ'].values.dtype == np.object_)
+        self.assertEqual(self.panel['ItemQ'].values.dtype, np.object_)
 
         # boolean dtype
         self.panel['ItemP'] = self.panel['ItemA'] > 0
-        self.assert_(self.panel['ItemP'].values.dtype == np.bool_)
+        self.assertEqual(self.panel['ItemP'].values.dtype, np.bool_)
 
         self.assertRaises(TypeError, self.panel.__setitem__, 'foo',
                           self.panel.ix[['ItemP']])
@@ -510,8 +510,8 @@ class CheckIndexing(object):
     def test_major_xs_mixed(self):
         self.panel['ItemD'] = 'foo'
         xs = self.panel.major_xs(self.panel.major_axis[0])
-        self.assert_(xs['ItemA'].dtype == np.float64)
-        self.assert_(xs['ItemD'].dtype == np.object_)
+        self.assertEqual(xs['ItemA'].dtype, np.float64)
+        self.assertEqual(xs['ItemD'].dtype, np.object_)
 
     def test_minor_xs(self):
         ref = self.panel['ItemA']
@@ -528,8 +528,8 @@ class CheckIndexing(object):
         self.panel['ItemD'] = 'foo'
 
         xs = self.panel.minor_xs('D')
-        self.assert_(xs['ItemA'].dtype == np.float64)
-        self.assert_(xs['ItemD'].dtype == np.object_)
+        self.assertEqual(xs['ItemA'].dtype, np.float64)
+        self.assertEqual(xs['ItemD'].dtype, np.object_)
 
     def test_xs(self):
         itemA = self.panel.xs('ItemA', axis=0)
@@ -840,7 +840,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         # strings handled prop
         wp = Panel([[['foo', 'foo', 'foo', ],
                      ['foo', 'foo', 'foo']]])
-        self.assert_(wp.values.dtype == np.object_)
+        self.assertEqual(wp.values.dtype, np.object_)
 
         vals = self.panel.values
 
@@ -875,22 +875,22 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
 
     def test_constructor_empty_panel(self):
         empty = Panel()
-        self.assert_(len(empty.items) == 0)
-        self.assert_(len(empty.major_axis) == 0)
-        self.assert_(len(empty.minor_axis) == 0)
+        self.assertEqual(len(empty.items), 0)
+        self.assertEqual(len(empty.major_axis), 0)
+        self.assertEqual(len(empty.minor_axis), 0)
 
     def test_constructor_observe_dtype(self):
         # GH #411
         panel = Panel(items=lrange(3), major_axis=lrange(3),
                       minor_axis=lrange(3), dtype='O')
-        self.assert_(panel.values.dtype == np.object_)
+        self.assertEqual(panel.values.dtype, np.object_)
 
     def test_constructor_dtypes(self):
         # GH #797
 
         def _check_dtype(panel, dtype):
             for i in panel.items:
-                self.assert_(panel[i].values.dtype.name == dtype)
+                self.assertEqual(panel[i].values.dtype.name, dtype)
 
         # only nan holding types allowed here
         for dtype in ['float64','float32','object']:
@@ -1029,8 +1029,8 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
 
         panel = Panel.from_dict(data, orient='minor')
 
-        self.assert_(panel['foo'].values.dtype == np.object_)
-        self.assert_(panel['A'].values.dtype == np.float64)
+        self.assertEqual(panel['foo'].values.dtype, np.object_)
+        self.assertEqual(panel['A'].values.dtype, np.float64)
 
     def test_constructor_error_msgs(self):
 
@@ -1186,7 +1186,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         # this ok
         result = self.panel.reindex()
         assert_panel_equal(result,self.panel)
-        self.assert_((result is self.panel) == False)
+        self.assertFalse(result is self.panel)
 
         # with filling
         smaller_major = self.panel.major_axis[::5]
@@ -1201,7 +1201,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         # don't necessarily copy
         result = self.panel.reindex(major=self.panel.major_axis, copy=False)
         assert_panel_equal(result,self.panel)
-        self.assert_((result is self.panel) == True)
+        self.assertTrue(result is self.panel)
 
     def test_reindex_multi(self):
 

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -355,16 +355,16 @@ class CheckIndexing(object):
         # scalar
         self.panel4d['lG'] = 1
         self.panel4d['lE'] = True
-        self.assert_(self.panel4d['lG'].values.dtype == np.int64)
-        self.assert_(self.panel4d['lE'].values.dtype == np.bool_)
+        self.assertEqual(self.panel4d['lG'].values.dtype, np.int64)
+        self.assertEqual(self.panel4d['lE'].values.dtype, np.bool_)
 
         # object dtype
         self.panel4d['lQ'] = 'foo'
-        self.assert_(self.panel4d['lQ'].values.dtype == np.object_)
+        self.assertEqual(self.panel4d['lQ'].values.dtype, np.object_)
 
         # boolean dtype
         self.panel4d['lP'] = self.panel4d['l1'] > 0
-        self.assert_(self.panel4d['lP'].values.dtype == np.bool_)
+        self.assertEqual(self.panel4d['lP'].values.dtype, np.bool_)
 
     def test_comparisons(self):
         p1 = tm.makePanel4D()
@@ -426,8 +426,8 @@ class CheckIndexing(object):
     def test_major_xs_mixed(self):
         self.panel4d['l4'] = 'foo'
         xs = self.panel4d.major_xs(self.panel4d.major_axis[0])
-        self.assert_(xs['l1']['A'].dtype == np.float64)
-        self.assert_(xs['l4']['A'].dtype == np.object_)
+        self.assertEqual(xs['l1']['A'].dtype, np.float64)
+        self.assertEqual(xs['l4']['A'].dtype, np.object_)
 
     def test_minor_xs(self):
         ref = self.panel4d['l1']['ItemA']
@@ -444,8 +444,8 @@ class CheckIndexing(object):
         self.panel4d['l4'] = 'foo'
 
         xs = self.panel4d.minor_xs('D')
-        self.assert_(xs['l1'].T['ItemA'].dtype == np.float64)
-        self.assert_(xs['l4'].T['ItemA'].dtype == np.object_)
+        self.assertEqual(xs['l1'].T['ItemA'].dtype, np.float64)
+        self.assertEqual(xs['l4'].T['ItemA'].dtype, np.object_)
 
     def test_xs(self):
         l1 = self.panel4d.xs('l1', axis=0)
@@ -567,7 +567,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
         # strings handled prop
         # panel4d = Panel4D([[['foo', 'foo', 'foo',],
         #                 ['foo', 'foo', 'foo']]])
-        # self.assert_(wp.values.dtype == np.object_)
+        # self.assertEqual(wp.values.dtype, np.object_)
 
         vals = self.panel4d.values
 
@@ -602,15 +602,15 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
 
     def test_constructor_empty_panel(self):
         empty = Panel()
-        self.assert_(len(empty.items) == 0)
-        self.assert_(len(empty.major_axis) == 0)
-        self.assert_(len(empty.minor_axis) == 0)
+        self.assertEqual(len(empty.items), 0)
+        self.assertEqual(len(empty.major_axis), 0)
+        self.assertEqual(len(empty.minor_axis), 0)
 
     def test_constructor_observe_dtype(self):
         # GH #411
         panel = Panel(items=lrange(3), major_axis=lrange(3),
                       minor_axis=lrange(3), dtype='O')
-        self.assert_(panel.values.dtype == np.object_)
+        self.assertEqual(panel.values.dtype, np.object_)
 
     def test_consolidate(self):
         self.assert_(self.panel4d._data.is_consolidated())
@@ -714,8 +714,8 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
 
     #    panel = Panel.from_dict(data, orient='minor')
 
-    #    self.assert_(panel['foo'].values.dtype == np.object_)
-    #    self.assert_(panel['A'].values.dtype == np.float64)
+    #    self.assertEqual(panel['foo'].values.dtype, np.object_)
+    #    self.assertEqual(panel['A'].values.dtype, np.float64)
 
     def test_values(self):
         self.assertRaises(Exception, Panel, np.random.randn(5, 5, 5),
@@ -764,7 +764,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
         # don't necessarily copy
         result = self.panel4d.reindex()
         assert_panel4d_equal(result,self.panel4d)
-        self.assert_((result is self.panel4d) == False)
+        self.assertFalse(result is self.panel4d)
 
         # with filling
         smaller_major = self.panel4d.major_axis[::5]
@@ -780,7 +780,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
         result = self.panel4d.reindex(
             major=self.panel4d.major_axis, copy=False)
         assert_panel4d_equal(result,self.panel4d)
-        self.assert_((result is self.panel4d) == True)
+        self.assertTrue(result is self.panel4d)
 
     def test_not_hashable(self):
         p4D_empty = Panel4D()

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -275,14 +275,14 @@ class TestNanops(tm.TestCase):
 
     def test_sum_zero(self):
         arr = np.array([])
-        self.assert_(nanops.nansum(arr) == 0)
+        self.assertEqual(nanops.nansum(arr), 0)
 
         arr = np.empty((10, 0))
         self.assert_((nanops.nansum(arr, axis=1) == 0).all())
 
         # GH #844
         s = Series([], index=[])
-        self.assert_(s.sum() == 0)
+        self.assertEqual(s.sum(), 0)
 
         df = DataFrame(np.empty((10, 0)))
         self.assert_((df.sum(1) == 0).all())
@@ -324,25 +324,25 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         self.assert_(not isinstance(scalar, float))
 
         # coercion
-        self.assert_(float(Series([1.])) == 1.0)
-        self.assert_(int(Series([1.])) == 1)
-        self.assert_(long(Series([1.])) == 1)
+        self.assertEqual(float(Series([1.])), 1.0)
+        self.assertEqual(int(Series([1.])), 1)
+        self.assertEqual(long(Series([1.])), 1)
 
     def test_astype(self):
         s = Series(np.random.randn(5),name='foo')
 
         for dtype in ['float32','float64','int64','int32']:
             astyped = s.astype(dtype)
-            self.assert_(astyped.dtype == dtype)
-            self.assert_(astyped.name == s.name)
+            self.assertEqual(astyped.dtype, dtype)
+            self.assertEqual(astyped.name, s.name)
 
     def test_constructor(self):
         # Recognize TimeSeries
-        self.assert_(self.ts.is_time_series == True)
+        self.assertTrue(self.ts.is_time_series)
 
         # Pass in Series
         derived = Series(self.ts)
-        self.assert_(derived.is_time_series == True)
+        self.assertTrue(derived.is_time_series)
 
         self.assert_(tm.equalContents(derived.index, self.ts.index))
         # Ensure new index is not created
@@ -350,7 +350,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # Mixed type Series
         mixed = Series(['hello', np.NaN], index=[0, 1])
-        self.assert_(mixed.dtype == np.object_)
+        self.assertEqual(mixed.dtype, np.object_)
         self.assert_(mixed[1] is np.NaN)
 
         self.assert_(not self.empty.is_time_series)
@@ -504,10 +504,10 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
     def test_constructor_pass_none(self):
         s = Series(None, index=lrange(5))
-        self.assert_(s.dtype == np.float64)
+        self.assertEqual(s.dtype, np.float64)
 
         s = Series(None, index=lrange(5), dtype=object)
-        self.assert_(s.dtype == np.object_)
+        self.assertEqual(s.dtype, np.object_)
 
     def test_constructor_cast(self):
         self.assertRaises(ValueError, Series, ['a', 'b', 'c'], dtype=float)
@@ -525,23 +525,23 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         import pandas.tslib as tslib
 
         s = Series(tslib.iNaT, dtype='M8[ns]', index=lrange(5))
-        self.assert_(isnull(s).all() == True)
+        self.assertTrue(isnull(s).all())
 
         # in theory this should be all nulls, but since
         # we are not specifying a dtype is ambiguous
         s = Series(tslib.iNaT, index=lrange(5))
-        self.assert_(isnull(s).all() == False)
+        self.assertFalse(isnull(s).all())
 
         s = Series(nan, dtype='M8[ns]', index=lrange(5))
-        self.assert_(isnull(s).all() == True)
+        self.assertTrue(isnull(s).all())
 
         s = Series([datetime(2001, 1, 2, 0, 0), tslib.iNaT], dtype='M8[ns]')
-        self.assert_(isnull(s[1]) == True)
-        self.assert_(s.dtype == 'M8[ns]')
+        self.assertTrue(isnull(s[1]))
+        self.assertEqual(s.dtype, 'M8[ns]')
 
         s = Series([datetime(2001, 1, 2, 0, 0), nan], dtype='M8[ns]')
-        self.assert_(isnull(s[1]) == True)
-        self.assert_(s.dtype == 'M8[ns]')
+        self.assertTrue(isnull(s[1]))
+        self.assertEqual(s.dtype, 'M8[ns]')
 
         # GH3416
         dates = [
@@ -551,10 +551,10 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
             ]
 
         s = Series(dates)
-        self.assert_(s.dtype == 'M8[ns]')
+        self.assertEqual(s.dtype, 'M8[ns]')
 
         s.ix[0] = np.nan
-        self.assert_(s.dtype == 'M8[ns]')
+        self.assertEqual(s.dtype, 'M8[ns]')
 
         # invalid astypes
         for t in ['s', 'D', 'us', 'ms']:
@@ -568,15 +568,15 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # invalid dates can be help as object
         result = Series([datetime(2,1,1)])
-        self.assert_(result[0] == datetime(2,1,1,0,0))
+        self.assertEqual(result[0], datetime(2,1,1,0,0))
 
         result = Series([datetime(3000,1,1)])
-        self.assert_(result[0] == datetime(3000,1,1,0,0))
+        self.assertEqual(result[0], datetime(3000,1,1,0,0))
 
         # don't mix types
         result = Series([ Timestamp('20130101'), 1],index=['a','b'])
-        self.assert_(result['a'] == Timestamp('20130101'))
-        self.assert_(result['b'] == 1)
+        self.assertEqual(result['a'], Timestamp('20130101'))
+        self.assertEqual(result['b'], 1)
 
     def test_constructor_dict(self):
         d = {'a': 0., 'b': 1., 'c': 2.}
@@ -641,15 +641,15 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         data = {'a': 0, 'b': '1', 'c': '2', 'd': datetime.now()}
         series = Series(data)
-        self.assert_(series.dtype == np.object_)
+        self.assertEqual(series.dtype, np.object_)
 
         data = {'a': 0, 'b': '1', 'c': '2', 'd': '3'}
         series = Series(data)
-        self.assert_(series.dtype == np.object_)
+        self.assertEqual(series.dtype, np.object_)
 
         data = {'a': '0', 'b': '1'}
         series = Series(data, dtype=float)
-        self.assert_(series.dtype == np.float64)
+        self.assertEqual(series.dtype, np.float64)
 
     def test_setindex(self):
         # wrong type
@@ -678,16 +678,16 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
     def test_fromValue(self):
 
         nans = Series(np.NaN, index=self.ts.index)
-        self.assert_(nans.dtype == np.float_)
+        self.assertEqual(nans.dtype, np.float_)
         self.assertEqual(len(nans), len(self.ts))
 
         strings = Series('foo', index=self.ts.index)
-        self.assert_(strings.dtype == np.object_)
+        self.assertEqual(strings.dtype, np.object_)
         self.assertEqual(len(strings), len(self.ts))
 
         d = datetime.now()
         dates = Series(d, index=self.ts.index)
-        self.assert_(dates.dtype == 'M8[ns]')
+        self.assertEqual(dates.dtype, 'M8[ns]')
         self.assertEqual(len(dates), len(self.ts))
 
     def test_contains(self):
@@ -916,7 +916,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
     def test_getitem_unordered_dup(self):
         obj = Series(lrange(5), index=['c', 'a', 'a', 'b', 'b'])
         self.assert_(np.isscalar(obj['c']))
-        self.assert_(obj['c'] == 0)
+        self.assertEqual(obj['c'], 0)
 
     def test_getitem_dups_with_missing(self):
 
@@ -990,14 +990,14 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
     def test_slice_floats2(self):
         s = Series(np.random.rand(10), index=np.arange(10, 20, dtype=float))
 
-        self.assert_(len(s.ix[12.0:]) == 8)
-        self.assert_(len(s.ix[12.5:]) == 7)
+        self.assertEqual(len(s.ix[12.0:]), 8)
+        self.assertEqual(len(s.ix[12.5:]), 7)
 
         i = np.arange(10, 20, dtype=float)
         i[2] = 12.2
         s.index = i
-        self.assert_(len(s.ix[12.0:]) == 8)
-        self.assert_(len(s.ix[12.5:]) == 7)
+        self.assertEqual(len(s.ix[12.0:]), 8)
+        self.assertEqual(len(s.ix[12.5:]), 7)
 
     def test_slice_float64(self):
 
@@ -1082,12 +1082,12 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         s = self.series.copy()
         res = s.set_value('foobar', 0)
         self.assert_(res is s)
-        self.assert_(res.index[-1] == 'foobar')
+        self.assertEqual(res.index[-1], 'foobar')
         self.assertEqual(res['foobar'], 0)
 
         s = self.series.copy()
         s.loc['foobar'] = 0
-        self.assert_(s.index[-1] == 'foobar')
+        self.assertEqual(s.index[-1], 'foobar')
         self.assertEqual(s['foobar'], 0)
 
     def test_setslice(self):
@@ -1868,10 +1868,10 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # GH 2967 (introduced bug in 0.11-dev I think)
         s = Series([Timestamp('201301%02d' % (i + 1)) for i in range(5)])
-        self.assert_(s.dtype == 'datetime64[ns]')
+        self.assertEqual(s.dtype, 'datetime64[ns]')
         shifted = s.shift(-1)
-        self.assert_(shifted.dtype == 'datetime64[ns]')
-        self.assert_(isnull(shifted[4]) == True)
+        self.assertEqual(shifted.dtype, 'datetime64[ns]')
+        self.assertTrue(isnull(shifted[4]))
 
         result = s.argsort()
         expected = Series(lrange(5), dtype='int64')
@@ -2090,13 +2090,13 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
     def test_describe_empty(self):
         result = self.empty.describe()
 
-        self.assert_(result['count'] == 0)
+        self.assertEqual(result['count'], 0)
         self.assert_(result.drop('count').isnull().all())
 
         nanSeries = Series([np.nan])
         nanSeries.name = 'NaN'
         result = nanSeries.describe()
-        self.assert_(result['count'] == 0)
+        self.assertEqual(result['count'], 0)
         self.assert_(result.drop('count').isnull().all())
 
     def test_describe_none(self):
@@ -2265,43 +2265,43 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # basic
         td = Series([timedelta(days=i) for i in range(3)])
-        self.assert_(td.dtype == 'timedelta64[ns]')
+        self.assertEqual(td.dtype, 'timedelta64[ns]')
 
         td = Series([timedelta(days=1)])
-        self.assert_(td.dtype == 'timedelta64[ns]')
+        self.assertEqual(td.dtype, 'timedelta64[ns]')
 
         if not _np_version_under1p7:
             td = Series([timedelta(days=1),timedelta(days=2),np.timedelta64(1,'s')])
-            self.assert_(td.dtype == 'timedelta64[ns]')
+            self.assertEqual(td.dtype, 'timedelta64[ns]')
 
         # mixed with NaT
         from pandas import tslib
         td = Series([timedelta(days=1),tslib.NaT ], dtype='m8[ns]' )
-        self.assert_(td.dtype == 'timedelta64[ns]')
+        self.assertEqual(td.dtype, 'timedelta64[ns]')
 
         td = Series([timedelta(days=1),np.nan ], dtype='m8[ns]' )
-        self.assert_(td.dtype == 'timedelta64[ns]')
+        self.assertEqual(td.dtype, 'timedelta64[ns]')
 
         td = Series([np.timedelta64(300000000), pd.NaT],dtype='m8[ns]')
-        self.assert_(td.dtype == 'timedelta64[ns]')
+        self.assertEqual(td.dtype, 'timedelta64[ns]')
 
         # improved inference
         # GH5689
         td = Series([np.timedelta64(300000000), pd.NaT])
-        self.assert_(td.dtype == 'timedelta64[ns]')
+        self.assertEqual(td.dtype, 'timedelta64[ns]')
 
         td = Series([np.timedelta64(300000000), tslib.iNaT])
-        self.assert_(td.dtype == 'timedelta64[ns]')
+        self.assertEqual(td.dtype, 'timedelta64[ns]')
 
         td = Series([np.timedelta64(300000000), np.nan])
-        self.assert_(td.dtype == 'timedelta64[ns]')
+        self.assertEqual(td.dtype, 'timedelta64[ns]')
 
         td = Series([pd.NaT, np.timedelta64(300000000)])
-        self.assert_(td.dtype == 'timedelta64[ns]')
+        self.assertEqual(td.dtype, 'timedelta64[ns]')
 
         if not _np_version_under1p7:
             td = Series([np.timedelta64(1,'s')])
-            self.assert_(td.dtype == 'timedelta64[ns]')
+            self.assertEqual(td.dtype, 'timedelta64[ns]')
 
         # these are frequency conversion astypes
         #for t in ['s', 'D', 'us', 'ms']:
@@ -2320,7 +2320,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # leave as object here
         td = Series([timedelta(days=i) for i in range(3)] + ['foo'])
-        self.assert_(td.dtype == 'object')
+        self.assertEqual(td.dtype, 'object')
 
     def test_operators_timedelta64(self):
 
@@ -2339,25 +2339,25 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         xp = Series(1e9 * 3600 * 24, rs.index).astype(
             'int64').astype('timedelta64[ns]')
         assert_series_equal(rs, xp)
-        self.assert_(rs.dtype == 'timedelta64[ns]')
+        self.assertEqual(rs.dtype, 'timedelta64[ns]')
 
         df = DataFrame(dict(A=v1))
         td = Series([timedelta(days=i) for i in range(3)])
-        self.assert_(td.dtype == 'timedelta64[ns]')
+        self.assertEqual(td.dtype, 'timedelta64[ns]')
 
         # series on the rhs
         result = df['A'] - df['A'].shift()
-        self.assert_(result.dtype == 'timedelta64[ns]')
+        self.assertEqual(result.dtype, 'timedelta64[ns]')
 
         result = df['A'] + td
-        self.assert_(result.dtype == 'M8[ns]')
+        self.assertEqual(result.dtype, 'M8[ns]')
 
         # scalar Timestamp on rhs
         maxa = df['A'].max()
         tm.assert_isinstance(maxa, Timestamp)
 
         resultb = df['A'] - df['A'].max()
-        self.assert_(resultb.dtype == 'timedelta64[ns]')
+        self.assertEqual(resultb.dtype, 'timedelta64[ns]')
 
         # timestamp on lhs
         result = resultb + df['A']
@@ -2369,11 +2369,11 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         result = df['A'] - datetime(2001, 1, 1)
         expected = Series([timedelta(days=4017 + i) for i in range(3)])
         assert_series_equal(result, expected)
-        self.assert_(result.dtype == 'm8[ns]')
+        self.assertEqual(result.dtype, 'm8[ns]')
 
         d = datetime(2001, 1, 1, 3, 4)
         resulta = df['A'] - d
-        self.assert_(resulta.dtype == 'm8[ns]')
+        self.assertEqual(resulta.dtype, 'm8[ns]')
 
         # roundtrip
         resultb = resulta + d
@@ -2384,19 +2384,19 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         resulta = df['A'] + td
         resultb = resulta - td
         assert_series_equal(resultb, df['A'])
-        self.assert_(resultb.dtype == 'M8[ns]')
+        self.assertEqual(resultb.dtype, 'M8[ns]')
 
         # roundtrip
         td = timedelta(minutes=5, seconds=3)
         resulta = df['A'] + td
         resultb = resulta - td
         assert_series_equal(df['A'], resultb)
-        self.assert_(resultb.dtype == 'M8[ns]')
+        self.assertEqual(resultb.dtype, 'M8[ns]')
 
         # inplace
         value = rs[2] + np.timedelta64(timedelta(minutes=5,seconds=1))
         rs[2] += np.timedelta64(timedelta(minutes=5,seconds=1))
-        self.assert_(rs[2] == value)
+        self.assertEqual(rs[2], value)
 
     def test_timedeltas_with_DateOffset(self):
 
@@ -2464,7 +2464,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         result = td1 - td2
         expected = Series([timedelta(seconds=0)] * 3) -Series(
             [timedelta(seconds=1)] * 3)
-        self.assert_(result.dtype == 'm8[ns]')
+        self.assertEqual(result.dtype, 'm8[ns]')
         assert_series_equal(result, expected)
 
         result2 = td2 - td1
@@ -2483,7 +2483,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
             result = td1 - td2
             expected = Series([timedelta(seconds=0)] * 3) -Series(
                 [timedelta(seconds=1)] * 3)
-            self.assert_(result.dtype == 'm8[ns]')
+            self.assertEqual(result.dtype, 'm8[ns]')
             assert_series_equal(result, expected)
 
             result2 = td2 - td1
@@ -2680,20 +2680,20 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
                     Timestamp('20120101')
 
         result = td.idxmin()
-        self.assert_(result == 0)
+        self.assertEqual(result, 0)
 
         result = td.idxmax()
-        self.assert_(result == 2)
+        self.assertEqual(result, 2)
 
         # GH 2982
         # with NaT
         td[0] = np.nan
 
         result = td.idxmin()
-        self.assert_(result == 1)
+        self.assertEqual(result, 1)
 
         result = td.idxmax()
-        self.assert_(result == 2)
+        self.assertEqual(result, 2)
 
         # abs
         s1 = Series(date_range('20120101', periods=3))
@@ -2906,10 +2906,10 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         b = datetime(1993, 6, 22, 13, 30)
         a = Series([a])
         result = _possibly_cast_to_timedelta(np.abs(a - b))
-        self.assert_(result.dtype == 'timedelta64[ns]')
+        self.assertEqual(result.dtype, 'timedelta64[ns]')
 
         result = _possibly_cast_to_timedelta(np.abs(b - a))
-        self.assert_(result.dtype == 'timedelta64[ns]')
+        self.assertEqual(result.dtype, 'timedelta64[ns]')
 
     def test_datetime64_with_index(self):
 
@@ -2943,27 +2943,27 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # nan ops on timedeltas
         td1 = td.copy()
         td1[0] = np.nan
-        self.assert_(isnull(td1[0]) == True)
-        self.assert_(td1[0].view('i8') == tslib.iNaT)
+        self.assertTrue(isnull(td1[0]))
+        self.assertEqual(td1[0].view('i8'), tslib.iNaT)
         td1[0] = td[0]
-        self.assert_(isnull(td1[0]) == False)
+        self.assertFalse(isnull(td1[0]))
 
         td1[1] = tslib.iNaT
-        self.assert_(isnull(td1[1]) == True)
-        self.assert_(td1[1].view('i8') == tslib.iNaT)
+        self.assertTrue(isnull(td1[1]))
+        self.assertEqual(td1[1].view('i8'), tslib.iNaT)
         td1[1] = td[1]
-        self.assert_(isnull(td1[1]) == False)
+        self.assertFalse(isnull(td1[1]))
 
         td1[2] = tslib.NaT
-        self.assert_(isnull(td1[2]) == True)
-        self.assert_(td1[2].view('i8') == tslib.iNaT)
+        self.assertTrue(isnull(td1[2]))
+        self.assertEqual(td1[2].view('i8'), tslib.iNaT)
         td1[2] = td[2]
-        self.assert_(isnull(td1[2]) == False)
+        self.assertFalse(isnull(td1[2]))
 
         # boolean setting
         # this doesn't work, not sure numpy even supports it
         #result = td[(td>np.timedelta64(timedelta(days=3))) & (td<np.timedelta64(timedelta(days=7)))] = np.nan
-        #self.assert_(isnull(result).sum() == 7)
+        #self.assertEqual(isnull(result).sum(), 7)
 
     # NumPy limitiation =(
 
@@ -3268,11 +3268,11 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         from pandas import date_range
         s = Series(date_range('20130102', periods=6))
         result = s.idxmin()
-        self.assert_(result == 0)
+        self.assertEqual(result, 0)
 
         s[0] = np.nan
         result = s.idxmin()
-        self.assert_(result == 1)
+        self.assertEqual(result, 1)
 
     def test_idxmax(self):
         # test idxmax
@@ -3298,25 +3298,25 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         from pandas import date_range
         s = Series(date_range('20130102', periods=6))
         result = s.idxmax()
-        self.assert_(result == 5)
+        self.assertEqual(result, 5)
 
         s[5] = np.nan
         result = s.idxmax()
-        self.assert_(result == 4)
+        self.assertEqual(result, 4)
 
         # Float64Index
         # GH 5914
         s = pd.Series([1,2,3],[1.1,2.1,3.1])
         result = s.idxmax()
-        self.assert_(result == 3.1)
+        self.assertEqual(result, 3.1)
         result = s.idxmin()
-        self.assert_(result == 1.1)
+        self.assertEqual(result, 1.1)
 
         s = pd.Series(s.index, s.index)
         result = s.idxmax()
-        self.assert_(result == 3.1)
+        self.assertEqual(result, 3.1)
         result = s.idxmin()
-        self.assert_(result == 1.1)
+        self.assertEqual(result, 1.1)
 
     def test_ndarray_compat(self):
 
@@ -3333,8 +3333,8 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # .item()
         s = Series([1])
         result = s.item()
-        self.assert_(result == 1)
-        self.assert_(s.item() == s.iloc[0])
+        self.assertEqual(result, 1)
+        self.assertEqual(s.item(), s.iloc[0])
 
         # using an ndarray like function
         s = Series(np.random.randn(10))
@@ -3380,7 +3380,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         df["bb"].iloc[0] = .13
         df_tmp = df.iloc[ck]
         df["bb"].iloc[0] = .15
-        self.assert_(df['bb'].iloc[0] == 0.15)
+        self.assertEqual(df['bb'].iloc[0], 0.15)
 
         # GH 3217
         df = DataFrame(dict(a = [1,3], b = [np.nan, 2]))
@@ -3399,7 +3399,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         self.assert_(np.isnan(result).all())
 
         result = empty + Series([], index=Index([]))
-        self.assert_(len(result) == 0)
+        self.assertEqual(len(result), 0)
 
         # TODO: this returned NotImplemented earlier, what to do?
         # deltas = Series([timedelta(1)] * 5, index=np.arange(5))
@@ -3668,10 +3668,10 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
     def test_dtype(self):
 
-        self.assert_(self.ts.dtype == np.dtype('float64'))
-        self.assert_(self.ts.dtypes == np.dtype('float64'))
-        self.assert_(self.ts.ftype == 'float64:dense')
-        self.assert_(self.ts.ftypes == 'float64:dense')
+        self.assertEqual(self.ts.dtype, np.dtype('float64'))
+        self.assertEqual(self.ts.dtypes, np.dtype('float64'))
+        self.assertEqual(self.ts.ftype, 'float64:dense')
+        self.assertEqual(self.ts.ftypes, 'float64:dense')
         assert_series_equal(self.ts.get_dtype_counts(),Series(1,['float64']))
         assert_series_equal(self.ts.get_ftype_counts(),Series(1,['float64:dense']))
 
@@ -3764,12 +3764,12 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
                          "person_id", "dt", "food"], parse_dates=["dt"])
         s = df.dt.copy()
         result = s.value_counts()
-        self.assert_(result.index.dtype == 'datetime64[ns]')
+        self.assertEqual(result.index.dtype, 'datetime64[ns]')
 
         # with NaT
         s = s.append(Series({4: pd.NaT}))
         result = s.value_counts()
-        self.assert_(result.index.dtype == 'datetime64[ns]')
+        self.assertEqual(result.index.dtype, 'datetime64[ns]')
 
         # timedelta64[ns]
         from datetime import timedelta
@@ -3777,16 +3777,16 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         td2 = timedelta(1) + (df.dt - df.dt)
         result = td.value_counts()
         result2 = td2.value_counts()
-        #self.assert_(result.index.dtype == 'timedelta64[ns]')
-        self.assert_(result.index.dtype == 'int64')
-        self.assert_(result2.index.dtype == 'int64')
+        #self.assertEqual(result.index.dtype, 'timedelta64[ns]')
+        self.assertEqual(result.index.dtype, 'int64')
+        self.assertEqual(result2.index.dtype, 'int64')
 
         # basics.rst doc example
         series = Series(np.random.randn(500))
         series[20:500] = np.nan
         series[10:20]  = 5000
         result = series.nunique()
-        self.assert_(result == 11)
+        self.assertEqual(result, 11)
 
     def test_unique(self):
 
@@ -3794,18 +3794,18 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         s = Series([1.2345] * 100)
         s[::2] = np.nan
         result = s.unique()
-        self.assert_(len(result) == 2)
+        self.assertEqual(len(result), 2)
 
         s = Series([1.2345] * 100, dtype='f4')
         s[::2] = np.nan
         result = s.unique()
-        self.assert_(len(result) == 2)
+        self.assertEqual(len(result), 2)
 
         # NAs in object arrays #714
         s = Series(['foo'] * 100, dtype='O')
         s[::2] = np.nan
         result = s.unique()
-        self.assert_(len(result) == 2)
+        self.assertEqual(len(result), 2)
 
         # integers
         s = Series(np.random.randint(0, 100, size=100))
@@ -3833,9 +3833,9 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
     def test_dropna_empty(self):
         s = Series([])
-        self.assert_(len(s.dropna()) == 0)
+        self.assertEqual(len(s.dropna()), 0)
         s.dropna(inplace=True)
-        self.assert_(len(s) == 0)
+        self.assertEqual(len(s), 0)
 
         # invalid axis
         self.assertRaises(ValueError, s.dropna, axis=1)
@@ -4291,7 +4291,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         result = ts["1990-01-01 04:00:00"]
         expected = ts[4]
-        self.assert_(result == expected)
+        self.assertEqual(result, expected)
 
         result = ts.copy()
         result["1990-01-01 04:00:00"] = 0
@@ -4316,7 +4316,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # repeat all the above with naive datetimes
         result = ts[datetime(1990, 1, 1, 4)]
         expected = ts[4]
-        self.assert_(result == expected)
+        self.assertEqual(result, expected)
 
         result = ts.copy()
         result[datetime(1990, 1, 1, 4)] = 0
@@ -4340,7 +4340,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         result = ts[ts.index[4]]
         expected = ts[4]
-        self.assert_(result == expected)
+        self.assertEqual(result, expected)
 
         result = ts[ts.index[4:8]]
         expected = ts[4:8]
@@ -4401,7 +4401,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         result = ts["1990-01-01 04"]
         expected = ts[4]
-        self.assert_(result == expected)
+        self.assertEqual(result, expected)
 
         result = ts.copy()
         result["1990-01-01 04"] = 0
@@ -4426,7 +4426,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # GH 2782
         result = ts[ts.index[4]]
         expected = ts[4]
-        self.assert_(result == expected)
+        self.assertEqual(result, expected)
 
         result = ts[ts.index[4:8]]
         expected = ts[4:8]
@@ -4529,17 +4529,17 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         s = Series(tslib.iNaT, dtype='M8[ns]', index=lrange(5))
         s = s.astype('O')
-        self.assert_(s.dtype == np.object_)
+        self.assertEqual(s.dtype, np.object_)
 
         s = Series([datetime(2001, 1, 2, 0, 0)])
         s = s.astype('O')
-        self.assert_(s.dtype == np.object_)
+        self.assertEqual(s.dtype, np.object_)
 
         s = Series([datetime(2001, 1, 2, 0, 0) for i in range(3)])
         s[1] = np.nan
-        self.assert_(s.dtype == 'M8[ns]')
+        self.assertEqual(s.dtype, 'M8[ns]')
         s = s.astype('O')
-        self.assert_(s.dtype == np.object_)
+        self.assertEqual(s.dtype, np.object_)
 
     def test_astype_str(self):
         # GH4405
@@ -4579,11 +4579,11 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         left = Series({'a': 1., 'b': 2., 'c': 3., 'd': 4})
         right = Series({1: 11, 2: 22, 3: 33})
 
-        self.assert_(left.dtype == np.float_)
+        self.assertEqual(left.dtype, np.float_)
         self.assert_(issubclass(right.dtype.type, np.integer))
 
         merged = left.map(right)
-        self.assert_(merged.dtype == np.float_)
+        self.assertEqual(merged.dtype, np.float_)
         self.assert_(isnull(merged['d']))
         self.assert_(not isnull(merged['c']))
 
@@ -4596,7 +4596,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         from decimal import Decimal
 
         result = self.series.map(lambda x: Decimal(str(x)))
-        self.assert_(result.dtype == np.object_)
+        self.assertEqual(result.dtype, np.object_)
         tm.assert_isinstance(result[0], Decimal)
 
     def test_map_na_exclusion(self):
@@ -4647,7 +4647,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         f = lambda x: x if x > 0 else np.nan
         result = s.apply(f, convert_dtype=False)
-        self.assert_(result.dtype == object)
+        self.assertEqual(result.dtype, object)
 
     def test_convert_objects(self):
 
@@ -4727,7 +4727,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         #r = s.copy()
         #r[0] = np.nan
         #result = r.convert_objects(convert_dates=True,convert_numeric=False)
-        #self.assert_(result.dtype == 'M8[ns]')
+        #self.assertEqual(result.dtype, 'M8[ns]')
 
         # dateutil parses some single letters into today's value as a date
         for x in 'abcdefghijklmnopqrstuvwxyz':
@@ -4742,7 +4742,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         s = Series(['foo,bar'])
 
         result = s.apply(str.split, args=(',',))
-        self.assert_(result[0] == ['foo', 'bar'])
+        self.assertEqual(result[0], ['foo', 'bar'])
 
     def test_align(self):
         def _check_align(a, b, how='left', fill=None):
@@ -4881,7 +4881,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # return a copy the same index here
         result = self.ts.reindex()
-        self.assert_((result is self.ts) == False)
+        self.assertFalse((result is self.ts))
 
     def test_reindex_corner(self):
         # (don't forget to fix this) I think it's fixed
@@ -4950,11 +4950,11 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         reindexed_int = int_ts.reindex(self.ts.index)
 
         # if NaNs introduced
-        self.assert_(reindexed_int.dtype == np.float_)
+        self.assertEqual(reindexed_int.dtype, np.float_)
 
         # NO NaNs introduced
         reindexed_int = int_ts.reindex(int_ts.index[::2])
-        self.assert_(reindexed_int.dtype == np.int_)
+        self.assertEqual(reindexed_int.dtype, np.int_)
 
     def test_reindex_bool(self):
 
@@ -4966,11 +4966,11 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         reindexed_bool = bool_ts.reindex(self.ts.index)
 
         # if NaNs introduced
-        self.assert_(reindexed_bool.dtype == np.object_)
+        self.assertEqual(reindexed_bool.dtype, np.object_)
 
         # NO NaNs introduced
         reindexed_bool = bool_ts.reindex(bool_ts.index[::2])
-        self.assert_(reindexed_bool.dtype == np.bool_)
+        self.assertEqual(reindexed_bool.dtype, np.bool_)
 
     def test_reindex_bool_pad(self):
         # fail
@@ -5367,7 +5367,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         self.assert_(np.array_equal(monthly_ts, ts))
 
         result = ts[:0].asfreq('M')
-        self.assert_(len(result) == 0)
+        self.assertEqual(len(result), 0)
         self.assert_(result is not ts)
 
     def test_weekday(self):
@@ -5543,7 +5543,7 @@ class TestSeriesNonUnique(tm.TestCase):
 
         self.assertRaises(KeyError, s.__getitem__, stamp)
         s[stamp] = 0
-        self.assert_(s[stamp] == 0)
+        self.assertEqual(s[stamp], 0)
 
         # not monotonic
         s = Series(len(index), index=index)
@@ -5551,7 +5551,7 @@ class TestSeriesNonUnique(tm.TestCase):
 
         self.assertRaises(KeyError, s.__getitem__, stamp)
         s[stamp] = 0
-        self.assert_(s[stamp] == 0)
+        self.assertEqual(s[stamp], 0)
 
     def test_reset_index(self):
         df = tm.makeDataFrame()[:5]
@@ -5578,7 +5578,7 @@ class TestSeriesNonUnique(tm.TestCase):
                                    [0, 1, 0, 1, 0, 1]])
         s = Series(np.random.randn(6), index=index)
         rs = s.reset_index(level=1)
-        self.assert_(len(rs.columns) == 2)
+        self.assertEqual(len(rs.columns), 2)
 
         rs = s.reset_index(level=[0, 2], drop=True)
         self.assert_(rs.index.equals(Index(index.get_level_values(1))))
@@ -5595,7 +5595,7 @@ class TestSeriesNonUnique(tm.TestCase):
     def test_timeseries_coercion(self):
         idx = tm.makeDateIndex(10000)
         ser = Series(np.random.randn(len(idx)), idx.astype(object))
-        self.assert_(ser.is_time_series == True)
+        self.assertTrue(ser.is_time_series)
         self.assert_(isinstance(ser.index, DatetimeIndex))
 
     def test_replace(self):

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -186,7 +186,7 @@ class TestStringMethods(tm.TestCase):
         values = ['foo', 'xyz', 'fooommm__foo', 'mmm_']
         result = strings.str_contains(values, pat)
         expected = [False, False, True, True]
-        self.assert_(result.dtype == np.bool_)
+        self.assertEqual(result.dtype, np.bool_)
         tm.assert_almost_equal(result, expected)
 
         # mixed
@@ -214,7 +214,7 @@ class TestStringMethods(tm.TestCase):
         values = ['foo', 'xyz', 'fooommm__foo', 'mmm_']
         result = strings.str_contains(values, pat)
         expected = [False, False, True, True]
-        self.assert_(result.dtype == np.bool_)
+        self.assertEqual(result.dtype, np.bool_)
         tm.assert_almost_equal(result, expected)
 
         # na

--- a/pandas/tests/test_tseries.py
+++ b/pandas/tests/test_tseries.py
@@ -627,13 +627,13 @@ class TestTypeInference(tm.TestCase):
         import datetime
         dates = [datetime.datetime(2012, 1, x) for x in range(1, 20)]
         index = Index(dates)
-        self.assert_(index.inferred_type == 'datetime64')
+        self.assertEqual(index.inferred_type, 'datetime64')
 
     def test_date(self):
         import datetime
         dates = [datetime.date(2012, 1, x) for x in range(1, 20)]
         index = Index(dates)
-        self.assert_(index.inferred_type == 'date')
+        self.assertEqual(index.inferred_type, 'date')
 
     def test_to_object_array_tuples(self):
         r = (5, 6)


### PR DESCRIPTION
Work on #6175, in pandas/tests. Tests still pass locally. A work-in-progress, but--with #6261--removes many/most cases of assert_(x == y) in this directory

Replacements:
- assert_(x == y) ==> assertEqual(x, y)
- assert_(x == True) ==> assertTrue(x)
- assert_(x == False) ==> assertFalse(x)
