### PR TITLE
PERF: various performance optimizations

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -134,7 +134,7 @@ def _isnull_new(obj):
     elif isinstance(obj, (ABCSeries, np.ndarray)):
         return _isnull_ndarraylike(obj)
     elif isinstance(obj, ABCGeneric):
-        return obj._constructor(obj._data.apply(lambda x: isnull(x.values)))
+        return obj._constructor(obj._data.isnull(func=isnull))
     elif isinstance(obj, list) or hasattr(obj, '__array__'):
         return _isnull_ndarraylike(np.asarray(obj))
     else:
@@ -160,8 +160,7 @@ def _isnull_old(obj):
     elif isinstance(obj, (ABCSeries, np.ndarray)):
         return _isnull_ndarraylike_old(obj)
     elif isinstance(obj, ABCGeneric):
-        return obj._constructor(obj._data.apply(
-            lambda x: _isnull_old(x.values)))
+        return obj._constructor(obj._data.isnull(func=_isnull_old))
     elif isinstance(obj, list) or hasattr(obj, '__array__'):
         return _isnull_ndarraylike_old(np.asarray(obj))
     else:
@@ -1540,14 +1539,7 @@ def _maybe_box(indexer, values, obj, key):
     # return the value
     return values
 
-
-def _values_from_object(o):
-    """ return my values or the object if we are say an ndarray """
-    f = getattr(o, 'get_values', None)
-    if f is not None:
-        o = f()
-    return o
-
+_values_from_object = lib.values_from_object
 
 def _possibly_convert_objects(values, convert_dates=True,
                               convert_numeric=True,
@@ -2036,20 +2028,16 @@ def _maybe_make_list(obj):
     return obj
 
 
-def is_bool(obj):
-    return isinstance(obj, (bool, np.bool_))
+is_bool = lib.is_bool
 
 
-def is_integer(obj):
-    return isinstance(obj, (numbers.Integral, np.integer))
+is_integer = lib.is_integer
 
 
-def is_float(obj):
-    return isinstance(obj, (float, np.floating))
+is_float = lib.is_float
 
 
-def is_complex(obj):
-    return isinstance(obj, (numbers.Complex, np.complexfloating))
+is_complex = lib.is_complex
 
 
 def is_iterator(obj):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2825,14 +2825,14 @@ class DataFrame(NDFrame):
                                       fill_value)
 
         new_data = left._data.eval(
-            func, right, axes=[left.columns, self.index])
+            func=func, other=right, axes=[left.columns, self.index])
         return self._constructor(new_data)
 
     def _combine_const(self, other, func, raise_on_error=True):
         if self.empty:
             return self
 
-        new_data = self._data.eval(func, other, raise_on_error=raise_on_error)
+        new_data = self._data.eval(func=func, other=other, raise_on_error=raise_on_error)
         return self._constructor(new_data)
 
     def _compare_frame_evaluate(self, other, func, str_rep):
@@ -3228,7 +3228,7 @@ class DataFrame(NDFrame):
         -------
         diffed : DataFrame
         """
-        new_data = self._data.diff(periods)
+        new_data = self._data.diff(n=periods)
         return self._constructor(new_data)
 
     #----------------------------------------------------------------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -128,7 +128,7 @@ class NDFrame(PandasObject):
         elif dtype is not None:
             # avoid copy if we can
             if len(mgr.blocks) > 1 or mgr.blocks[0].values.dtype != dtype:
-                mgr = mgr.astype(dtype)
+                mgr = mgr.astype(dtype=dtype)
         return mgr
 
     #----------------------------------------------------------------------
@@ -2011,7 +2011,7 @@ class NDFrame(PandasObject):
         """
 
         mgr = self._data.astype(
-            dtype, copy=copy, raise_on_error=raise_on_error)
+            dtype=dtype, copy=copy, raise_on_error=raise_on_error)
         return self._constructor(mgr).__finalize__(self)
 
     def copy(self, deep=True):
@@ -2153,7 +2153,7 @@ class NDFrame(PandasObject):
                     from pandas import Series
                     value = Series(value)
 
-                new_data = self._data.fillna(value, inplace=inplace,
+                new_data = self._data.fillna(value=value, inplace=inplace,
                                              downcast=downcast)
 
             elif isinstance(value, (dict, com.ABCSeries)):
@@ -2170,7 +2170,7 @@ class NDFrame(PandasObject):
                     obj.fillna(v, inplace=True)
                 return result
             else:
-                new_data = self._data.fillna(value, inplace=inplace,
+                new_data = self._data.fillna(value=value, inplace=inplace,
                                              downcast=downcast)
 
         if inplace:
@@ -2355,7 +2355,8 @@ class NDFrame(PandasObject):
                     new_data = self._data
                     for c, src in compat.iteritems(to_replace):
                         if c in value and c in self:
-                            new_data = new_data.replace(src, value[c],
+                            new_data = new_data.replace(to_replace=src,
+                                                        value=value[c],
                                                         filter=[c],
                                                         inplace=inplace,
                                                         regex=regex)
@@ -2365,7 +2366,8 @@ class NDFrame(PandasObject):
                     new_data = self._data
                     for k, src in compat.iteritems(to_replace):
                         if k in self:
-                            new_data = new_data.replace(src, value,
+                            new_data = new_data.replace(to_replace=src,
+                                                        value=value,
                                                         filter=[k],
                                                         inplace=inplace,
                                                         regex=regex)
@@ -2380,13 +2382,16 @@ class NDFrame(PandasObject):
                                          'in length. Expecting %d got %d ' %
                                          (len(to_replace), len(value)))
 
-                    new_data = self._data.replace_list(to_replace, value,
+                    new_data = self._data.replace_list(src_list=to_replace,
+                                                       dest_list=value,
                                                        inplace=inplace,
                                                        regex=regex)
 
                 else:  # [NA, ''] -> 0
-                    new_data = self._data.replace(to_replace, value,
-                                                  inplace=inplace, regex=regex)
+                    new_data = self._data.replace(to_replace=to_replace,
+                                                  value=value,
+                                                  inplace=inplace,
+                                                  regex=regex)
             elif to_replace is None:
                 if not (com.is_re_compilable(regex) or
                         com.is_list_like(regex) or
@@ -2406,13 +2411,14 @@ class NDFrame(PandasObject):
 
                     for k, v in compat.iteritems(value):
                         if k in self:
-                            new_data = new_data.replace(to_replace, v,
+                            new_data = new_data.replace(to_replace=to_replace,
+                                                        value=v,
                                                         filter=[k],
                                                         inplace=inplace,
                                                         regex=regex)
 
                 elif not com.is_list_like(value):  # NA -> 0
-                    new_data = self._data.replace(to_replace, value,
+                    new_data = self._data.replace(to_replace=to_replace, value=value,
                                                   inplace=inplace, regex=regex)
                 else:
                     msg = ('Invalid "to_replace" type: '
@@ -3116,12 +3122,12 @@ class NDFrame(PandasObject):
         if inplace:
             # we may have different type blocks come out of putmask, so
             # reconstruct the block manager
-            new_data = self._data.putmask(cond, other, align=axis is None,
+            new_data = self._data.putmask(mask=cond, new=other, align=axis is None,
                                           inplace=True)
             self._update_inplace(new_data)
 
         else:
-            new_data = self._data.where(other, cond, align=axis is None,
+            new_data = self._data.where(other=other, cond=cond, align=axis is None,
                                         raise_on_error=raise_on_error,
                                         try_cast=try_cast)
 
@@ -3168,7 +3174,7 @@ class NDFrame(PandasObject):
         if freq is None and not len(kwds):
             block_axis = self._get_block_manager_axis(axis)
             indexer = com._shift_indexer(len(self), periods)
-            new_data = self._data.shift(indexer, periods, axis=block_axis)
+            new_data = self._data.shift(indexer=indexer, periods=periods, axis=block_axis)
         else:
             return self.tshift(periods, freq, **kwds)
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -321,7 +321,7 @@ class _NDFrameIndexer(object):
                     # as we select a slice indexer on the mi
                     idx = index._convert_slice_indexer(idx)
                     obj = obj.copy()
-                    obj._data = obj._data.setitem(tuple([idx]), value)
+                    obj._data = obj._data.setitem(indexer=tuple([idx]), value=value)
                     self.obj[item] = obj
                     return
 
@@ -341,7 +341,7 @@ class _NDFrameIndexer(object):
 
                 # set the item, possibly having a dtype change
                 s = s.copy()
-                s._data = s._data.setitem(pi, v)
+                s._data = s._data.setitem(indexer=pi, value=v)
                 s._maybe_update_cacher(clear=True)
                 self.obj[item] = s
 
@@ -419,7 +419,7 @@ class _NDFrameIndexer(object):
                 value = self._align_panel(indexer, value)
 
             # actually do the set
-            self.obj._data = self.obj._data.setitem(indexer, value)
+            self.obj._data = self.obj._data.setitem(indexer=indexer, value=value)
             self.obj._maybe_update_cacher(clear=True)
 
     def _align_series(self, indexer, ser):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -212,7 +212,7 @@ class Series(generic.NDFrame):
             # create/copy the manager
             if isinstance(data, SingleBlockManager):
                 if dtype is not None:
-                    data = data.astype(dtype, raise_on_error=False)
+                    data = data.astype(dtype=dtype, raise_on_error=False)
                 elif copy:
                     data = data.copy()
             else:
@@ -281,23 +281,23 @@ class Series(generic.NDFrame):
 
     # ndarray compatibility
     def item(self):
-        return self.values.item()
+        return self._data.values.item()
 
     @property
     def data(self):
-        return self.values.data
+        return self._data.values.data
 
     @property
     def strides(self):
-        return self.values.strides
+        return self._data.values.strides
 
     @property
     def size(self):
-        return self.values.size
+        return self._data.values.size
 
     @property
     def flags(self):
-        return self.values.flags
+        return self._data.values.flags
 
     @property
     def dtype(self):
@@ -694,7 +694,7 @@ class Series(generic.NDFrame):
     def _set_values(self, key, value):
         if isinstance(key, Series):
             key = key.values
-        self._data = self._data.setitem(key, value)
+        self._data = self._data.setitem(indexer=key, value=value)
 
     # help out SparseSeries
     _get_val_at = ndarray.__getitem__
@@ -1643,7 +1643,7 @@ class Series(generic.NDFrame):
         other = other.reindex_like(self)
         mask = notnull(other)
 
-        self._data = self._data.putmask(mask, other, inplace=True)
+        self._data = self._data.putmask(mask=mask, new=other, inplace=True)
         self._maybe_update_cacher()
 
     #----------------------------------------------------------------------

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -59,6 +59,15 @@ PyDateTime_IMPORT
 import_array()
 import_ufunc()
 
+def values_from_object(object o):
+    """ return my values or the object if we are say an ndarray """
+    cdef f
+
+    f = getattr(o, 'get_values', None)
+    if f is not None:
+        o = f()
+    return o
+
 cpdef map_indices_list(list index):
     '''
     Produce a dict mapping the values of the input array to their respective

--- a/pandas/src/inference.pyx
+++ b/pandas/src/inference.pyx
@@ -3,6 +3,23 @@ from tslib import NaT
 from datetime import datetime, timedelta
 iNaT = util.get_nat()
 
+# core.common import for fast inference checks
+def is_float(object obj):
+    return util.is_float_object(obj)
+
+
+def is_integer(object obj):
+    return util.is_integer_object(obj)
+
+
+def is_bool(object obj):
+    return util.is_bool_object(obj)
+
+
+def is_complex(object obj):
+    return util.is_complex_object(obj)
+
+
 _TYPE_MAP = {
     np.int8: 'integer',
     np.int16: 'integer',

--- a/pandas/src/reduce.pyx
+++ b/pandas/src/reduce.pyx
@@ -55,18 +55,18 @@ cdef class Reducer:
             # in cython, so increment first
             Py_INCREF(dummy)
         else:
-            if dummy.dtype != self.arr.dtype:
-                raise ValueError('Dummy array must be same dtype')
-            if len(dummy) != self.chunksize:
-                raise ValueError('Dummy array must be length %d' %
-                                 self.chunksize)
-
             # we passed a series-like
             if hasattr(dummy,'values'):
 
                 self.typ = type(dummy)
                 index = getattr(dummy,'index',None)
                 dummy = dummy.values
+
+            if dummy.dtype != self.arr.dtype:
+                raise ValueError('Dummy array must be same dtype')
+            if len(dummy) != self.chunksize:
+                raise ValueError('Dummy array must be length %d' %
+                                 self.chunksize)
 
         return dummy, index
 
@@ -193,9 +193,9 @@ cdef class SeriesBinGrouper:
             values = np.empty(0, dtype=self.arr.dtype)
             index = None
         else:
-            if dummy.dtype != self.arr.dtype:
-                raise ValueError('Dummy array must be same dtype')
             values = dummy.values
+            if values.dtype != self.arr.dtype:
+                raise ValueError('Dummy array must be same dtype')
             if not values.flags.contiguous:
                 values = values.copy()
             index = dummy.index
@@ -318,9 +318,9 @@ cdef class SeriesGrouper:
             values = np.empty(0, dtype=self.arr.dtype)
             index  = None
         else:
+            values = dummy.values
             if dummy.dtype != self.arr.dtype:
                 raise ValueError('Dummy array must be same dtype')
-            values = dummy.values
             if not values.flags.contiguous:
                 values = values.copy()
             index  = dummy.index

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -198,7 +198,7 @@ def test_nan_to_nat_conversions():
     assert(result == iNaT)
 
     s = df['B'].copy()
-    s._data = s._data.setitem(tuple([slice(8,9)]),np.nan)
+    s._data = s._data.setitem(indexer=tuple([slice(8,9)]),value=np.nan)
     assert(isnull(s[8]))
 
     # numpy < 1.7.0 is wrong

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -604,7 +604,7 @@ class TestBlockManager(tm.TestCase):
         bm1 = BlockManager([block1, block2], [index, np.arange(block1.shape[1])])
         bm2 = BlockManager([block2, block1], [index, np.arange(block1.shape[1])])
         self.assert_(bm1.equals(bm2))
-        
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1200,16 +1200,14 @@ class DatetimeIndex(Int64Index):
         Fast lookup of value from 1-dimensional ndarray. Only use this if you
         know what you're doing
         """
-        timestamp = None
-        #if isinstance(key, Timestamp):
-        #    timestamp = key
-        #el
-        if isinstance(key, datetime):
-            # needed to localize naive datetimes
-            timestamp = Timestamp(key, tz=self.tz)
 
-        if timestamp:
-            return self.get_value_maybe_box(series, timestamp)
+        if isinstance(key, datetime):
+
+            # needed to localize naive datetimes
+            if self.tz is not None:
+                key = Timestamp(key, tz=self.tz)
+
+            return self.get_value_maybe_box(series, key)
 
         try:
             return _maybe_box(self, Index.get_value(self, series, key), series, key)


### PR DESCRIPTION
PERF: enhance tseries getitem indexing
PERF: micro optimzations in inference
API/CLN: core.internals.apply now only takes kwargs; makes code a bit simpler
CLN: wrap core/common/isnull into more direct Block.isnull
PERF: fast path series block operations

closes #6264

original timings

```
In [11]: %timeit com.is_integer(13)
100000 loops, best of 3: 1.29 µs per loop

In [12]: %timeit com.is_integer(np.int32(2))
100000 loops, best of 3: 3.32 µs per loop

In [13]: %timeit com.is_integer(np.int64(2))
100000 loops, best of 3: 1.86 µs per loop

In [14]: %timeit com.is_integer(14L)
100000 loops, best of 3: 1.29 µs per loop

In [15]: %timeit com.is_integer("1")
100000 loops, best of 3: 2.2 µs per loop
```

withi this PR

```
In [2]: %timeit com.is_integer(13)
10000000 loops, best of 3: 72.5 ns per loop

In [3]: %timeit com.is_integer(np.int32(2))
1000000 loops, best of 3: 620 ns per loop

In [4]: %timeit com.is_integer(np.int64(2))
1000000 loops, best of 3: 315 ns per loop

In [5]: %timeit com.is_integer(14L)
10000000 loops, best of 3: 72.4 ns per loop

In [6]: %timeit com.is_integer("1")
10000000 loops, best of 3: 78.8 ns per loop
```
