### PR TITLE
CLN: Converting assert_'s to specialized forms, in pandas/*/tests

### DIFF
--- a/pandas/io/tests/test_cparser.py
+++ b/pandas/io/tests/test_cparser.py
@@ -70,7 +70,7 @@ class TestCParser(tm.TestCase):
         data = 'a\nb\na\nb\na'
         reader = TextReader(StringIO(data), header=None)
         result = reader.read()
-        self.assert_(len(set(map(id, result[0]))) == 2)
+        self.assertEqual(len(set(map(id, result[0]))), 2)
 
     def test_skipinitialspace(self):
         data = ('a,   b\n'
@@ -91,7 +91,7 @@ class TestCParser(tm.TestCase):
         reader = TextReader(StringIO(data), header=None)
         result = reader.read()
 
-        self.assert_(result[0].dtype == np.bool_)
+        self.assertEqual(result[0].dtype, np.bool_)
 
     def test_delimit_whitespace(self):
         data = 'a  b\na\t\t "b"\n"a"\t \t b'
@@ -233,25 +233,25 @@ aaaaa,5"""
         reader = _make_reader(dtype='S5,i4')
         result = reader.read()
 
-        self.assert_(result[0].dtype == 'S5')
+        self.assertEqual(result[0].dtype, 'S5')
 
         ex_values = np.array(['a', 'aa', 'aaa', 'aaaa', 'aaaaa'], dtype='S5')
         self.assert_((result[0] == ex_values).all())
-        self.assert_(result[1].dtype == 'i4')
+        self.assertEqual(result[1].dtype, 'i4')
 
         reader = _make_reader(dtype='S4')
         result = reader.read()
-        self.assert_(result[0].dtype == 'S4')
+        self.assertEqual(result[0].dtype, 'S4')
         ex_values = np.array(['a', 'aa', 'aaa', 'aaaa', 'aaaa'], dtype='S4')
         self.assert_((result[0] == ex_values).all())
-        self.assert_(result[1].dtype == 'S4')
+        self.assertEqual(result[1].dtype, 'S4')
 
         reader = _make_reader(dtype='S4', as_recarray=True)
         result = reader.read()
-        self.assert_(result['0'].dtype == 'S4')
+        self.assertEqual(result['0'].dtype, 'S4')
         ex_values = np.array(['a', 'aa', 'aaa', 'aaaa', 'aaaa'], dtype='S4')
         self.assert_((result['0'] == ex_values).all())
-        self.assert_(result['1'].dtype == 'S4')
+        self.assertEqual(result['1'].dtype, 'S4')
 
     def test_pass_dtype(self):
         data = """\
@@ -266,19 +266,19 @@ one,two
 
         reader = _make_reader(dtype={'one': 'u1', 1: 'S1'})
         result = reader.read()
-        self.assert_(result[0].dtype == 'u1')
-        self.assert_(result[1].dtype == 'S1')
+        self.assertEqual(result[0].dtype, 'u1')
+        self.assertEqual(result[1].dtype, 'S1')
 
         reader = _make_reader(dtype={'one': np.uint8, 1: object})
         result = reader.read()
-        self.assert_(result[0].dtype == 'u1')
-        self.assert_(result[1].dtype == 'O')
+        self.assertEqual(result[0].dtype, 'u1')
+        self.assertEqual(result[1].dtype, 'O')
 
         reader = _make_reader(dtype={'one': np.dtype('u1'),
                                      1: np.dtype('O')})
         result = reader.read()
-        self.assert_(result[0].dtype == 'u1')
-        self.assert_(result[1].dtype == 'O')
+        self.assertEqual(result[0].dtype, 'u1')
+        self.assertEqual(result[1].dtype, 'O')
 
     def test_usecols(self):
         data = """\

--- a/pandas/io/tests/test_date_converters.py
+++ b/pandas/io/tests/test_date_converters.py
@@ -50,7 +50,7 @@ date, time, a, b
         df = read_table(StringIO(data), sep=',', header=0,
                         parse_dates=datecols, date_parser=conv.parse_date_time)
         self.assert_('date_time' in df)
-        self.assert_(df.date_time.ix[0] == datetime(2001, 1, 5, 10, 0, 0))
+        self.assertEqual(df.date_time.ix[0], datetime(2001, 1, 5, 10, 0, 0))
 
         data = ("KORD,19990127, 19:00:00, 18:56:00, 0.8100\n"
                 "KORD,19990127, 20:00:00, 19:56:00, 0.0100\n"
@@ -74,7 +74,7 @@ date, time, a, b
                         parse_dates=datecols,
                         date_parser=conv.parse_date_fields)
         self.assert_('ymd' in df)
-        self.assert_(df.ymd.ix[0] == datetime(2001, 1, 10))
+        self.assertEqual(df.ymd.ix[0], datetime(2001, 1, 10))
 
     def test_datetime_six_col(self):
         result = conv.parse_all_fields(self.years, self.months, self.days,
@@ -91,7 +91,7 @@ year, month, day, hour, minute, second, a, b
                         parse_dates=datecols,
                         date_parser=conv.parse_all_fields)
         self.assert_('ymdHMS' in df)
-        self.assert_(df.ymdHMS.ix[0] == datetime(2001, 1, 5, 10, 0, 0))
+        self.assertEqual(df.ymdHMS.ix[0], datetime(2001, 1, 5, 10, 0, 0))
 
     def test_datetime_fractional_seconds(self):
         data = """\
@@ -104,10 +104,10 @@ year, month, day, hour, minute, second, a, b
                         parse_dates=datecols,
                         date_parser=conv.parse_all_fields)
         self.assert_('ymdHMS' in df)
-        self.assert_(df.ymdHMS.ix[0] == datetime(2001, 1, 5, 10, 0, 0,
-                                                 microsecond=123456))
-        self.assert_(df.ymdHMS.ix[1] == datetime(2001, 1, 5, 10, 0, 0,
-                                                 microsecond=500000))
+        self.assertEqual(df.ymdHMS.ix[0], datetime(2001, 1, 5, 10, 0, 0,
+                                                   microsecond=123456))
+        self.assertEqual(df.ymdHMS.ix[1], datetime(2001, 1, 5, 10, 0, 0,
+                                                   microsecond=500000))
 
     def test_generic(self):
         data = "year, month, day, a\n 2001, 01, 10, 10.\n 2001, 02, 1, 11."
@@ -117,7 +117,7 @@ year, month, day, hour, minute, second, a, b
                         parse_dates=datecols,
                         date_parser=dateconverter)
         self.assert_('ym' in df)
-        self.assert_(df.ym.ix[0] == date(2001, 1, 1))
+        self.assertEqual(df.ym.ix[0], date(2001, 1, 1))
 
 
 if __name__ == '__main__':

--- a/pandas/io/tests/test_packers.py
+++ b/pandas/io/tests/test_packers.py
@@ -194,7 +194,7 @@ class TestBasic(TestPackers):
             '20130101'), Timestamp('20130101', tz='US/Eastern'),
                 Timestamp('201301010501')]:
             i_rec = self.encode_decode(i)
-            self.assert_(i == i_rec)
+            self.assertEqual(i, i_rec)
 
     def test_datetimes(self):
 
@@ -207,7 +207,7 @@ class TestBasic(TestPackers):
             2013, 1, 1), datetime.datetime(2013, 1, 1, 5, 1),
                 datetime.date(2013, 1, 1), np.datetime64(datetime.datetime(2013, 1, 5, 2, 15))]:
             i_rec = self.encode_decode(i)
-            self.assert_(i == i_rec)
+            self.assertEqual(i, i_rec)
 
     def test_timedeltas(self):
 
@@ -215,7 +215,7 @@ class TestBasic(TestPackers):
                   datetime.timedelta(days=1, seconds=10),
                   np.timedelta64(1000000)]:
             i_rec = self.encode_decode(i)
-            self.assert_(i == i_rec)
+            self.assertEqual(i, i_rec)
 
 
 class TestIndex(TestPackers):

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -309,7 +309,7 @@ KORD,19990127, 23:00:00, 22:56:00, -0.5900, 1.7100, 4.6000, 0.0000, 280.0000
         self.assert_('X3' not in df)
 
         d = datetime(1999, 1, 27, 19, 0)
-        self.assert_(df.ix[0, 'nominal'] == d)
+        self.assertEqual(df.ix[0, 'nominal'], d)
 
         df = self.read_csv(StringIO(data), header=None,
                            date_parser=func,
@@ -342,7 +342,7 @@ KORD,19990127, 23:00:00, 22:56:00, -0.5900, 1.7100, 4.6000, 0.0000, 280.0000
         self.assert_('X3' not in df)
 
         d = datetime(1999, 1, 27, 19, 0)
-        self.assert_(df.ix[0, 'X1_X2'] == d)
+        self.assertEqual(df.ix[0, 'X1_X2'], d)
 
         df = read_csv(StringIO(data), header=None,
                       parse_dates=[[1, 2], [1, 3]], keep_date_col=True)
@@ -363,7 +363,7 @@ KORD,19990127 22:00:00, 21:56:00, -0.5900, 1.7100, 5.1000, 0.0000, 290.0000
         df = self.read_csv(StringIO(data), sep=',', header=None,
                            parse_dates=[1], index_col=1)
         d = datetime(1999, 1, 27, 19, 0)
-        self.assert_(df.index[0] == d)
+        self.assertEqual(df.index[0], d)
 
     def test_multiple_date_cols_int_cast(self):
         data = ("KORD,19990127, 19:00:00, 18:56:00, 0.8100\n"
@@ -473,11 +473,11 @@ KORD6,19990127, 23:00:00, 22:56:00, -0.5900, 1.7100, 4.6000, 0.0000, 280.0000"""
                        index=Index(['hello', 'world', 'foo'], name='message'))
         rs = self.read_csv(StringIO(data), names=names, index_col=['message'])
         tm.assert_frame_equal(xp, rs)
-        self.assert_(xp.index.name == rs.index.name)
+        self.assertEqual(xp.index.name, rs.index.name)
 
         rs = self.read_csv(StringIO(data), names=names, index_col='message')
         tm.assert_frame_equal(xp, rs)
-        self.assert_(xp.index.name == rs.index.name)
+        self.assertEqual(xp.index.name, rs.index.name)
 
     def test_converter_index_col_bug(self):
         # 1835
@@ -488,7 +488,7 @@ KORD6,19990127, 23:00:00, 22:56:00, -0.5900, 1.7100, 4.6000, 0.0000, 280.0000"""
 
         xp = DataFrame({'B': [2, 4]}, index=Index([1, 3], name='A'))
         tm.assert_frame_equal(rs, xp)
-        self.assert_(rs.index.name == xp.index.name)
+        self.assertEqual(rs.index.name, xp.index.name)
 
     def test_date_parser_int_bug(self):
         # #3071
@@ -640,7 +640,7 @@ Klosterdruckerei\tKlosterdruckerei <Kempten> (1609-1805)\tHochfurstliche Buchhan
 
         good_line_small = bad_line_small + '"'
         df = self.read_table(StringIO(good_line_small), sep='\t')
-        self.assert_(len(df) == 3)
+        self.assertEqual(len(df), 3)
 
     def test_non_string_na_values(self):
         # GH3611, na_values that are not a string are an issue
@@ -1005,10 +1005,10 @@ baz,7,8,9
         df2 = self.read_table(self.csv1, sep=',', index_col=0,
                               parse_dates=True)
         self.assert_(np.array_equal(df.columns, ['A', 'B', 'C', 'D']))
-        self.assert_(df.index.name == 'index')
+        self.assertEqual(df.index.name, 'index')
         self.assert_(isinstance(df.index[0], (datetime, np.datetime64,
                                               Timestamp)))
-        self.assert_(df.values.dtype == np.float64)
+        self.assertEqual(df.values.dtype, np.float64)
         tm.assert_frame_equal(df, df2)
 
     def test_read_csv_no_index_name(self):
@@ -1018,7 +1018,7 @@ baz,7,8,9
         self.assert_(np.array_equal(df.columns, ['A', 'B', 'C', 'D', 'E']))
         self.assert_(isinstance(df.index[0], (datetime, np.datetime64,
                                               Timestamp)))
-        self.assert_(df.ix[:, ['A', 'B', 'C', 'D']].values.dtype == np.float64)
+        self.assertEqual(df.ix[:, ['A', 'B', 'C', 'D']].values.dtype, np.float64)
         tm.assert_frame_equal(df, df2)
 
     def test_read_table_unicode(self):
@@ -1070,7 +1070,7 @@ False,2
 True,3
 """
         data = self.read_csv(StringIO(data))
-        self.assert_(data['A'].dtype == np.bool_)
+        self.assertEqual(data['A'].dtype, np.bool_)
 
         data = """A,B
 YES,1
@@ -1082,7 +1082,7 @@ Yes,3
         data = self.read_csv(StringIO(data),
                              true_values=['yes', 'Yes', 'YES'],
                              false_values=['no', 'NO', 'No'])
-        self.assert_(data['A'].dtype == np.bool_)
+        self.assertEqual(data['A'].dtype, np.bool_)
 
         data = """A,B
 TRUE,1
@@ -1090,7 +1090,7 @@ FALSE,2
 TRUE,3
 """
         data = self.read_csv(StringIO(data))
-        self.assert_(data['A'].dtype == np.bool_)
+        self.assertEqual(data['A'].dtype, np.bool_)
 
         data = """A,B
 foo,bar
@@ -1107,8 +1107,8 @@ bar,foo"""
 3.0,3
 """
         data = self.read_csv(StringIO(data))
-        self.assert_(data['A'].dtype == np.float64)
-        self.assert_(data['B'].dtype == np.int64)
+        self.assertEqual(data['A'].dtype, np.float64)
+        self.assertEqual(data['B'].dtype, np.int64)
 
     def test_infer_index_col(self):
         data = """A,B,C
@@ -1218,7 +1218,7 @@ baz,7,8,9
         reader = self.read_csv(StringIO(data), chunksize=1)
         result = list(reader)
         expected = DataFrame(dict(A = [1,4,7], B = [2,5,8], C = [3,6,9]), index=['foo','bar','baz'])
-        self.assert_(len(result) == 3)
+        self.assertEqual(len(result), 3)
         tm.assert_frame_equal(pd.concat(result), expected)
 
     def test_header_not_first_line(self):
@@ -1513,7 +1513,7 @@ c,4,5,01/03/2009
         f = lambda x: x.strip()
         converter = {0: f}
         df = self.read_csv(StringIO(data), header=None, converters=converter)
-        self.assert_(df[0].dtype == object)
+        self.assertEqual(df[0].dtype, object)
 
     def test_converters_euro_decimal_format(self):
         data = """Id;Number1;Number2;Text1;Text2;Number3
@@ -1523,9 +1523,9 @@ c,4,5,01/03/2009
         f = lambda x: float(x.replace(",", "."))
         converter = {'Number1': f, 'Number2': f, 'Number3': f}
         df2 = self.read_csv(StringIO(data), sep=';', converters=converter)
-        self.assert_(df2['Number1'].dtype == float)
-        self.assert_(df2['Number2'].dtype == float)
-        self.assert_(df2['Number3'].dtype == float)
+        self.assertEqual(df2['Number1'].dtype, float)
+        self.assertEqual(df2['Number2'].dtype, float)
+        self.assertEqual(df2['Number3'].dtype, float)
 
     def test_converter_return_string_bug(self):
         # GH #583
@@ -1536,7 +1536,7 @@ c,4,5,01/03/2009
         f = lambda x: float(x.replace(",", "."))
         converter = {'Number1': f, 'Number2': f, 'Number3': f}
         df2 = self.read_csv(StringIO(data), sep=';', converters=converter)
-        self.assert_(df2['Number1'].dtype == float)
+        self.assertEqual(df2['Number1'].dtype, float)
 
     def test_read_table_buglet_4x_multiindex(self):
         text = """                      A       B       C       D        E
@@ -1659,15 +1659,15 @@ a,b,c,d
         # it works
         result = read_csv(data, index_col=0, parse_dates=True)
         stamp = result.index[0]
-        self.assert_(stamp.minute == 39)
+        self.assertEqual(stamp.minute, 39)
         try:
             self.assert_(result.index.tz is pytz.utc)
         except AssertionError:  # hello Yaroslav
             arr = result.index.to_pydatetime()
             result = tools.to_datetime(arr, utc=True)[0]
-            self.assert_(stamp.minute == result.minute)
-            self.assert_(stamp.hour == result.hour)
-            self.assert_(stamp.day == result.day)
+            self.assertEqual(stamp.minute, result.minute)
+            self.assertEqual(stamp.hour, result.hour)
+            self.assertEqual(stamp.day, result.day)
 
     def test_multiple_date_cols_index(self):
         data = """\
@@ -2364,7 +2364,7 @@ two,1,2,3"""
         try:
             # it works!
             df = self.read_csv(StringIO(text), verbose=True)
-            self.assert_(buf.getvalue() == 'Filled 3 NA values in column a\n')
+            self.assertEqual(buf.getvalue(), 'Filled 3 NA values in column a\n')
         finally:
             sys.stdout = sys.__stdout__
 
@@ -2384,7 +2384,7 @@ eight,1,2,3"""
         try:
             # it works!
             df = self.read_csv(StringIO(text), verbose=True, index_col=0)
-            self.assert_(buf.getvalue() == 'Filled 1 NA values in column a\n')
+            self.assertEqual(buf.getvalue(), 'Filled 1 NA values in column a\n')
         finally:
             sys.stdout = sys.__stdout__
 
@@ -2597,8 +2597,8 @@ one,two
 
         result = self.read_csv(StringIO(data), dtype={'one': 'u1', 1: 'S1'},
                                as_recarray=True)
-        self.assert_(result['one'].dtype == 'u1')
-        self.assert_(result['two'].dtype == 'S1')
+        self.assertEqual(result['one'].dtype, 'u1')
+        self.assertEqual(result['two'].dtype, 'S1')
 
     def test_usecols_dtypes(self):
         data = """\
@@ -2765,9 +2765,9 @@ No,No,No"""
 3;878,158;108013,434;GHI;rez;2,735694704"""
 
         df2 = self.read_csv(StringIO(data), sep=';', decimal=',')
-        self.assert_(df2['Number1'].dtype == float)
-        self.assert_(df2['Number2'].dtype == float)
-        self.assert_(df2['Number3'].dtype == float)
+        self.assertEqual(df2['Number1'].dtype, float)
+        self.assertEqual(df2['Number2'].dtype, float)
+        self.assertEqual(df2['Number3'].dtype, float)
 
     def test_custom_lineterminator(self):
         data = 'a,b,c~1,2,3~4,5,6'

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -385,9 +385,9 @@ class TestHDFStore(tm.TestCase):
             _maybe_remove(store, 'df1')
             store.append('df1', df[:10])
             store.append('df1', df[10:])
-            self.assert_(store.root.a._v_attrs.pandas_version == '0.10.1')
-            self.assert_(store.root.b._v_attrs.pandas_version == '0.10.1')
-            self.assert_(store.root.df1._v_attrs.pandas_version == '0.10.1')
+            self.assertEqual(store.root.a._v_attrs.pandas_version, '0.10.1')
+            self.assertEqual(store.root.b._v_attrs.pandas_version, '0.10.1')
+            self.assertEqual(store.root.df1._v_attrs.pandas_version, '0.10.1')
 
             # write a file and wipe its versioning
             _maybe_remove(store, 'df2')
@@ -412,7 +412,7 @@ class TestHDFStore(tm.TestCase):
 
                 else:
                     store = HDFStore(path,mode=mode)
-                    self.assert_(store._handle.mode == mode)
+                    self.assertEqual(store._handle.mode, mode)
                     store.close()
 
             with ensure_clean_path(self.path) as path:
@@ -425,7 +425,7 @@ class TestHDFStore(tm.TestCase):
                     self.assertRaises(IOError, f)
                 else:
                     with get_store(path,mode=mode) as store:
-                        self.assert_(store._handle.mode == mode)
+                        self.assertEqual(store._handle.mode, mode)
 
             with ensure_clean_path(self.path) as path:
 
@@ -474,7 +474,7 @@ class TestHDFStore(tm.TestCase):
             store.open('r')
             self.assert_(store.is_open)
             self.assertEquals(len(store), 1)
-            self.assert_(store._mode == 'r')
+            self.assertEqual(store._mode, 'r')
             store.close()
             self.assert_(not store.is_open)
 
@@ -482,7 +482,7 @@ class TestHDFStore(tm.TestCase):
             store.open('a')
             self.assert_(store.is_open)
             self.assertEquals(len(store), 1)
-            self.assert_(store._mode == 'a')
+            self.assertEqual(store._mode, 'a')
             store.close()
             self.assert_(not store.is_open)
 
@@ -490,7 +490,7 @@ class TestHDFStore(tm.TestCase):
             store.open('a')
             self.assert_(store.is_open)
             self.assertEquals(len(store), 1)
-            self.assert_(store._mode == 'a')
+            self.assertEqual(store._mode, 'a')
             store.close()
             self.assert_(not store.is_open)
 
@@ -788,7 +788,7 @@ class TestHDFStore(tm.TestCase):
             store.append('ns', ns)
             result = store['ns']
             tm.assert_series_equal(result, ns)
-            self.assert_(result.name == ns.name)
+            self.assertEqual(result.name, ns.name)
 
             # select on the values
             expected = ns[ns>60]
@@ -1113,7 +1113,7 @@ class TestHDFStore(tm.TestCase):
                 dict([(x, "%s_extra" % x) for x in wp.minor_axis]), axis=2)
 
             def check_col(key,name,size):
-                self.assert_(getattr(store.get_storer(key).table.description,name).itemsize == size)
+                self.assertEqual(getattr(store.get_storer(key).table.description,name).itemsize, size)
 
             store.append('s1', wp, min_itemsize=20)
             store.append('s1', wp2)
@@ -1179,7 +1179,7 @@ class TestHDFStore(tm.TestCase):
         with ensure_clean_store(self.path) as store:
 
             def check_col(key,name,size):
-                self.assert_(getattr(store.get_storer(key).table.description,name).itemsize == size)
+                self.assertEqual(getattr(store.get_storer(key).table.description,name).itemsize, size)
 
             df = DataFrame(dict(A = 'foo', B = 'bar'),index=range(10))
 
@@ -1187,20 +1187,20 @@ class TestHDFStore(tm.TestCase):
             _maybe_remove(store, 'df')
             store.append('df', df, min_itemsize={'A' : 200 })
             check_col('df', 'A', 200)
-            self.assert_(store.get_storer('df').data_columns == ['A'])
+            self.assertEqual(store.get_storer('df').data_columns, ['A'])
 
             # a min_itemsize that creates a data_column2
             _maybe_remove(store, 'df')
             store.append('df', df, data_columns = ['B'], min_itemsize={'A' : 200 })
             check_col('df', 'A', 200)
-            self.assert_(store.get_storer('df').data_columns == ['B','A'])
+            self.assertEqual(store.get_storer('df').data_columns, ['B','A'])
 
             # a min_itemsize that creates a data_column2
             _maybe_remove(store, 'df')
             store.append('df', df, data_columns = ['B'], min_itemsize={'values' : 200 })
             check_col('df', 'B', 200)
             check_col('df', 'values_block_0', 200)
-            self.assert_(store.get_storer('df').data_columns == ['B'])
+            self.assertEqual(store.get_storer('df').data_columns, ['B'])
 
             # infer the .typ on subsequent appends
             _maybe_remove(store, 'df')
@@ -1252,7 +1252,7 @@ class TestHDFStore(tm.TestCase):
 
             # using min_itemsize and a data column
             def check_col(key,name,size):
-                self.assert_(getattr(store.get_storer(key).table.description,name).itemsize == size)
+                self.assertEqual(getattr(store.get_storer(key).table.description,name).itemsize, size)
 
         with ensure_clean_store(self.path) as store:
             _maybe_remove(store, 'df')
@@ -1803,7 +1803,7 @@ class TestHDFStore(tm.TestCase):
             # list in column
             df = tm.makeDataFrame()
             df['invalid'] = [['a']] * len(df)
-            self.assert_(df.dtypes['invalid'] == np.object_)
+            self.assertEqual(df.dtypes['invalid'], np.object_)
             self.assertRaises(TypeError, store.append,'df',df)
 
             # multiple invalid columns
@@ -1817,7 +1817,7 @@ class TestHDFStore(tm.TestCase):
             s = s.astype(object)
             s[0:5] = np.nan
             df['invalid'] = s
-            self.assert_(df.dtypes['invalid'] == np.object_)
+            self.assertEqual(df.dtypes['invalid'], np.object_)
             self.assertRaises(TypeError, store.append,'df', df)
 
             # directy ndarray
@@ -3034,14 +3034,14 @@ class TestHDFStore(tm.TestCase):
             result = store.select('df', [Term('B=selector')])
             expected = df[ df.B.isin(selector) ]
             tm.assert_frame_equal(expected, result)
-            self.assert_(len(result) == 100)
+            self.assertEqual(len(result), 100)
 
             # big selector along the index
             selector = Index(df.ts[0:100].values)
             result  = store.select('df', [Term('ts=selector')])
             expected = df[ df.ts.isin(selector.values) ]
             tm.assert_frame_equal(expected, result)
-            self.assert_(len(result) == 100)
+            self.assertEqual(len(result), 100)
 
     def test_select_iterator(self):
 
@@ -3062,7 +3062,7 @@ class TestHDFStore(tm.TestCase):
             results = []
             for s in store.select('df',chunksize=100):
                 results.append(s)
-            self.assert_(len(results) == 5)
+            self.assertEqual(len(results), 5)
             result = concat(results)
             tm.assert_frame_equal(expected, result)
 
@@ -3088,7 +3088,7 @@ class TestHDFStore(tm.TestCase):
             for x in read_hdf(path,'df',chunksize=100):
                 results.append(x)
 
-            self.assert_(len(results) == 5)
+            self.assertEqual(len(results), 5)
             result = concat(results)
             tm.assert_frame_equal(result, df)
             tm.assert_frame_equal(result, read_hdf(path,'df'))
@@ -3175,7 +3175,7 @@ class TestHDFStore(tm.TestCase):
                 df  = DataFrame(dict(A = Series(lrange(3), index=idx)))
                 df.to_hdf(path,'data',mode='w',append=True)
 
-            self.assert_(read_hdf(path,'data').index.name == 'foo')
+            self.assertEqual(read_hdf(path,'data').index.name, 'foo')
 
             with tm.assert_produces_warning(expected_warning=AttributeConflictWarning):
 
@@ -3906,7 +3906,7 @@ class TestHDFStore(tm.TestCase):
                 # check keys
                 if keys is None:
                     keys = store.keys()
-                self.assert_(set(keys) == set(tstore.keys()))
+                self.assertEqual(set(keys), set(tstore.keys()))
 
                 # check indicies & nrows
                 for k in tstore.keys():
@@ -3914,13 +3914,13 @@ class TestHDFStore(tm.TestCase):
                         new_t = tstore.get_storer(k)
                         orig_t = store.get_storer(k)
 
-                        self.assert_(orig_t.nrows == new_t.nrows)
+                        self.assertEqual(orig_t.nrows, new_t.nrows)
 
                         # check propindixes
                         if propindexes:
                             for a in orig_t.axes:
                                 if a.is_indexed:
-                                    self.assert_(new_t[a.name].is_indexed == True)
+                                    self.assertTrue(new_t[a.name].is_indexed)
 
             finally:
                 safe_close(store)

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -230,11 +230,11 @@ class TestStata(tm.TestCase):
 
         if compat.PY3:
             expected = raw.kreis1849[0]
-            self.assert_(result == expected)
+            self.assertEqual(result, expected)
             self.assert_(isinstance(result, compat.string_types))
         else:
             expected = raw.kreis1849.str.decode("latin-1")[0]
-            self.assert_(result == expected)
+            self.assertEqual(result, expected)
             self.assert_(isinstance(result, unicode))
 
     def test_read_write_dta11(self):

--- a/pandas/sparse/tests/test_list.py
+++ b/pandas/sparse/tests/test_list.py
@@ -68,12 +68,12 @@ class TestSparseList(unittest.TestCase):
         splist.append(arr[6:])
 
         consol = splist.consolidate(inplace=False)
-        self.assert_(consol.nchunks == 1)
-        self.assert_(splist.nchunks == 3)
+        self.assertEqual(consol.nchunks, 1)
+        self.assertEqual(splist.nchunks, 3)
         assert_sp_array_equal(consol.to_array(), exp_sparr)
 
         splist.consolidate()
-        self.assert_(splist.nchunks == 1)
+        self.assertEqual(splist.nchunks, 1)
         assert_sp_array_equal(splist.to_array(), exp_sparr)
 
     def test_copy(self):

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -252,13 +252,13 @@ class TestSparseSeries(tm.TestCase,
         values = np.ones(self.bseries.npoints)
         sp = SparseSeries(values, sparse_index=self.bseries.sp_index)
         sp.sp_values[:5] = 97
-        self.assert_(values[0] == 97)
+        self.assertEqual(values[0], 97)
 
         # but can make it copy!
         sp = SparseSeries(values, sparse_index=self.bseries.sp_index,
                           copy=True)
         sp.sp_values[:5] = 100
-        self.assert_(values[0] == 97)
+        self.assertEqual(values[0], 97)
 
     def test_constructor_scalar(self):
         data = 5
@@ -282,7 +282,7 @@ class TestSparseSeries(tm.TestCase,
         cop = self.bseries.astype(np.float64)
         self.assert_(cop is not self.bseries)
         self.assert_(cop.sp_index is self.bseries.sp_index)
-        self.assert_(cop.dtype == np.float64)
+        self.assertEqual(cop.dtype, np.float64)
 
         cop2 = self.iseries.copy()
 
@@ -291,8 +291,8 @@ class TestSparseSeries(tm.TestCase,
 
         # test that data is copied
         cop[:5] = 97
-        self.assert_(cop.sp_values[0] == 97)
-        self.assert_(self.bseries.sp_values[0] != 97)
+        self.assertEqual(cop.sp_values[0], 97)
+        self.assertNotEqual(self.bseries.sp_values[0], 97)
 
         # correct fill value
         zbcop = self.zbseries.copy()
@@ -376,7 +376,7 @@ class TestSparseSeries(tm.TestCase,
         self.assertEqual(self.btseries[idx], 0)
 
         self.iseries.set_value('foobar', 0)
-        self.assert_(self.iseries.index[-1] == 'foobar')
+        self.assertEqual(self.iseries.index[-1], 'foobar')
         self.assertEqual(self.iseries['foobar'], 0)
 
     def test_getitem_slice(self):
@@ -423,7 +423,7 @@ class TestSparseSeries(tm.TestCase,
 
     def test_setitem(self):
         self.bseries[5] = 7.
-        self.assert_(self.bseries[5] == 7.)
+        self.assertEqual(self.bseries[5], 7.)
 
     def test_setslice(self):
         self.bseries[5:10] = 7.
@@ -779,15 +779,15 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
 
     def test_as_matrix(self):
         empty = self.empty.as_matrix()
-        self.assert_(empty.shape == (0, 0))
+        self.assertEqual(empty.shape, (0, 0))
 
         no_cols = SparseDataFrame(index=np.arange(10))
         mat = no_cols.as_matrix()
-        self.assert_(mat.shape == (10, 0))
+        self.assertEqual(mat.shape, (10, 0))
 
         no_index = SparseDataFrame(columns=np.arange(10))
         mat = no_index.as_matrix()
-        self.assert_(mat.shape == (0, 10))
+        self.assertEqual(mat.shape, (0, 10))
 
     def test_copy(self):
         cp = self.frame.copy()
@@ -859,8 +859,8 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
 
     def test_constructor_empty(self):
         sp = SparseDataFrame()
-        self.assert_(len(sp.index) == 0)
-        self.assert_(len(sp.columns) == 0)
+        self.assertEqual(len(sp.index), 0)
+        self.assertEqual(len(sp.columns), 0)
 
     def test_constructor_dataframe(self):
         dense = self.frame.to_dense()
@@ -1087,14 +1087,14 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
         # ok as the index gets conver to object
         frame = self.frame.copy()
         res = frame.set_value('foobar', 'B', 1.5)
-        self.assert_(res.index.dtype == 'object')
+        self.assertEqual(res.index.dtype, 'object')
 
         res = self.frame
         res.index = res.index.astype(object)
 
         res = self.frame.set_value('foobar', 'B', 1.5)
         self.assert_(res is not self.frame)
-        self.assert_(res.index[-1] == 'foobar')
+        self.assertEqual(res.index[-1], 'foobar')
         self.assertEqual(res.get_value('foobar', 'B'), 1.5)
 
         res2 = res.set_value('foobar', 'qux', 1.5)
@@ -1239,7 +1239,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
         assert_almost_equal(applied.values, np.sqrt(self.frame.values))
 
         applied = self.fill_frame.apply(np.sqrt)
-        self.assert_(applied['A'].fill_value == np.sqrt(2))
+        self.assertEqual(applied['A'].fill_value, np.sqrt(2))
 
         # agg / broadcast
         broadcasted = self.frame.apply(np.sum, broadcast=True)

--- a/pandas/stats/tests/test_moments.py
+++ b/pandas/stats/tests/test_moments.py
@@ -119,13 +119,13 @@ class TestMoments(tm.TestCase):
         # empty
         vals = np.array([])
         rs = mom.rolling_window(vals, 5, 'boxcar', center=True)
-        self.assert_(len(rs) == 0)
+        self.assertEqual(len(rs), 0)
 
         # shorter than window
         vals = np.random.randn(5)
         rs = mom.rolling_window(vals, 10, 'boxcar')
         self.assert_(np.isnan(rs).all())
-        self.assert_(len(rs) == 5)
+        self.assertEqual(len(rs), 5)
 
     def test_cmov_window_frame(self):
         _skip_if_no_scipy()
@@ -570,7 +570,7 @@ class TestMoments(tm.TestCase):
 
         # pass in ints
         result2 = func(np.arange(50), span=10)
-        self.assert_(result2.dtype == np.float_)
+        self.assertEqual(result2.dtype, np.float_)
 
     def _check_ew_structures(self, func):
         series_result = func(self.series, com=10)

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -2392,7 +2392,7 @@ class TestGroupBy(tm.TestCase):
 
         grouped = x.groupby('test')
         result = grouped.agg({'fl': 'sum', 2: 'size'})
-        self.assert_(result['fl'].dtype == np.float64)
+        self.assertEqual(result['fl'].dtype, np.float64)
 
     def test_handle_dict_return_value(self):
         def f(group):

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -317,8 +317,8 @@ class TestMerge(tm.TestCase):
         df1 = DataFrame({'A': 1., 'B': 2, 'C': 'foo', 'D': True},
                         index=np.arange(10),
                         columns=['A', 'B', 'C', 'D'])
-        self.assert_(df1['B'].dtype == np.int64)
-        self.assert_(df1['D'].dtype == np.bool_)
+        self.assertEqual(df1['B'].dtype, np.int64)
+        self.assertEqual(df1['D'].dtype, np.bool_)
 
         df2 = DataFrame({'A': 1., 'B': 2, 'C': 'foo', 'D': True},
                         index=np.arange(0, 10, 2),
@@ -459,9 +459,9 @@ class TestMerge(tm.TestCase):
         a = DataFrame(randn(10, 2), columns=['a', 'b'], dtype = np.float64)
         b = DataFrame(randn(10, 1), columns=['c'], dtype = np.float32)
         joined = a.join(b)
-        self.assert_(joined.dtypes['a'] == 'float64')
-        self.assert_(joined.dtypes['b'] == 'float64')
-        self.assert_(joined.dtypes['c'] == 'float32')
+        self.assertEqual(joined.dtypes['a'], 'float64')
+        self.assertEqual(joined.dtypes['b'], 'float64')
+        self.assertEqual(joined.dtypes['c'], 'float32')
 
         a = np.random.randint(0, 5, 100).astype('int64')
         b = np.random.random(100).astype('float64')
@@ -470,10 +470,10 @@ class TestMerge(tm.TestCase):
         xpdf = DataFrame({'a': a, 'b': b, 'c': c })
         s = DataFrame(np.random.random(5).astype('float32'), columns=['md'])
         rs = df.merge(s, left_on='a', right_index=True)
-        self.assert_(rs.dtypes['a'] == 'int64')
-        self.assert_(rs.dtypes['b'] == 'float64')
-        self.assert_(rs.dtypes['c'] == 'float32')
-        self.assert_(rs.dtypes['md'] == 'float32')
+        self.assertEqual(rs.dtypes['a'], 'int64')
+        self.assertEqual(rs.dtypes['b'], 'float64')
+        self.assertEqual(rs.dtypes['c'], 'float32')
+        self.assertEqual(rs.dtypes['md'], 'float32')
 
         xp = xpdf.merge(s, left_on='a', right_index=True)
         assert_frame_equal(rs, xp)
@@ -1230,7 +1230,7 @@ class TestConcatenate(tm.TestCase):
         df2 = df2.set_index(['A'])
 
         result = df1.append(df2)
-        self.assert_(result.index.name == 'A')
+        self.assertEqual(result.index.name, 'A')
 
     def test_join_many(self):
         df = DataFrame(np.random.randn(10, 6), columns=list('abcdef'))
@@ -1275,8 +1275,8 @@ class TestConcatenate(tm.TestCase):
                                        dtype=bool)})
 
         appended = df1.append(df2, ignore_index=True)
-        self.assert_(appended['A'].dtype == 'f8')
-        self.assert_(appended['B'].dtype == 'O')
+        self.assertEqual(appended['A'].dtype, 'f8')
+        self.assertEqual(appended['B'].dtype, 'O')
 
     def test_concat_with_group_keys(self):
         df = DataFrame(np.random.randn(4, 3))

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -114,7 +114,7 @@ class TestPivotTable(tm.TestCase):
 
         # can convert dtypes
         f = DataFrame({'a' : ['cat', 'bat', 'cat', 'bat'], 'v' : [1,2,3,4], 'i' : ['a','b','a','b']})
-        self.assert_(f.dtypes['v'] == 'int64')
+        self.assertEqual(f.dtypes['v'], 'int64')
 
         z = pivot_table(f, values='v', rows=['a'], cols=['i'], fill_value=0, aggfunc=np.sum)
         result = z.get_dtype_counts()
@@ -123,7 +123,7 @@ class TestPivotTable(tm.TestCase):
 
         # cannot convert dtypes
         f = DataFrame({'a' : ['cat', 'bat', 'cat', 'bat'], 'v' : [1.5,2.5,3.5,4.5], 'i' : ['a','b','a','b']})
-        self.assert_(f.dtypes['v'] == 'float64')
+        self.assertEqual(f.dtypes['v'], 'float64')
 
         z = pivot_table(f, values='v', rows=['a'], cols=['i'], fill_value=0, aggfunc=np.mean)
         result = z.get_dtype_counts()

--- a/pandas/tools/tests/test_tile.py
+++ b/pandas/tools/tests/test_tile.py
@@ -143,7 +143,7 @@ class TestCut(tm.TestCase):
         arr = np.random.randn(1000)
 
         factor = qcut(arr, 10, labels=False)
-        self.assert_(len(np.unique(factor)) == 10)
+        self.assertEqual(len(np.unique(factor)), 10)
 
     def test_qcut_specify_quantiles(self):
         arr = np.random.randn(100)

--- a/pandas/tools/tests/test_tools.py
+++ b/pandas/tools/tests/test_tools.py
@@ -14,10 +14,10 @@ class TestTools(tm.TestCase):
 
         res = value_range(df)
 
-        self.assert_(res['Minimum'] == -5)
-        self.assert_(res['Maximum'] == 5)
+        self.assertEqual(res['Minimum'], -5)
+        self.assertEqual(res['Maximum'], 5)
 
         df.ix[0, 1] = np.NaN
 
-        self.assert_(res['Minimum'] == -5)
-        self.assert_(res['Maximum'] == 5)
+        self.assertEqual(res['Minimum'], -5)
+        self.assertEqual(res['Maximum'], 5)

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -265,7 +265,7 @@ class TestDateRange(tm.TestCase):
         expected = rng[10:25]
         self.assert_(the_int.equals(expected))
         tm.assert_isinstance(the_int, DatetimeIndex)
-        self.assert_(the_int.offset == rng.offset)
+        self.assertEqual(the_int.offset, rng.offset)
 
         the_int = rng1.intersection(rng2.view(DatetimeIndex))
         self.assert_(the_int.equals(expected))
@@ -363,7 +363,7 @@ class TestDateRange(tm.TestCase):
         end = datetime(2011, 1, 3, tzinfo=tz('US/Eastern'))
 
         dr = date_range(start=start, periods=3)
-        self.assert_(dr.tz == tz('US/Eastern'))
+        self.assertEqual(dr.tz, tz('US/Eastern'))
         self.assertEqual(dr[0], start)
         self.assertEqual(dr[2], end)
 

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1613,7 +1613,7 @@ class TestTimeSeries(tm.TestCase):
 
     def test_set_dataframe_column_ns_dtype(self):
         x = DataFrame([datetime.now(), datetime.now()])
-        self.assert_(x[0].dtype == np.dtype('M8[ns]'))
+        self.assertEqual(x[0].dtype, np.dtype('M8[ns]'))
 
     def test_groupby_count_dateparseerror(self):
         dr = date_range(start='1/1/2012', freq='5min', periods=10)

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -77,7 +77,7 @@ class TestTimeZoneSupport(tm.TestCase):
         # Values are unmodified
         self.assert_(np.array_equal(rng.asi8, rng_eastern.asi8))
 
-        self.assert_(rng_eastern.tz == pytz.timezone('US/Eastern'))
+        self.assertEqual(rng_eastern.tz, pytz.timezone('US/Eastern'))
 
 
     def test_localize_utc_conversion(self):
@@ -253,7 +253,7 @@ class TestTimeZoneSupport(tm.TestCase):
 
         rng = date_range('3/11/2012 00:00', periods=10, freq='H',
                          tz='US/Eastern')
-        self.assert_(rng[2].hour == 3)
+        self.assertEqual(rng[2].hour, 3)
 
     def test_utc_box_timestamp_and_localize(self):
         rng = date_range('3/11/2012', '3/12/2012', freq='H', tz='utc')
@@ -288,7 +288,7 @@ class TestTimeZoneSupport(tm.TestCase):
 
         fromdates = DatetimeIndex(strdates, tz='US/Eastern')
 
-        self.assert_(conv.tz == fromdates.tz)
+        self.assertEqual(conv.tz, fromdates.tz)
         self.assert_(np.array_equal(conv.values, fromdates.values))
 
     def test_field_access_localize(self):
@@ -417,8 +417,8 @@ class TestTimeZoneSupport(tm.TestCase):
         rng = date_range('1/1/2000', periods=20, tz='US/Eastern')
 
         result = rng.take(lrange(5))
-        self.assert_(result.tz == rng.tz)
-        self.assert_(result.freq == rng.freq)
+        self.assertEqual(result.tz, rng.tz)
+        self.assertEqual(result.freq, rng.freq)
 
     def test_index_with_timezone_repr(self):
         rng = date_range('4/13/2010', '5/6/2010')
@@ -457,13 +457,13 @@ class TestTimeZoneSupport(tm.TestCase):
         result = ts_local.at_time(time(10, 0))
         expected = ts.at_time(time(10, 0)).tz_localize('US/Eastern')
         assert_series_equal(result, expected)
-        self.assert_(result.index.tz.zone == 'US/Eastern')
+        self.assertEqual(result.index.tz.zone, 'US/Eastern')
 
         t1, t2 = time(10, 0), time(11, 0)
         result = ts_local.between_time(t1, t2)
         expected = ts.between_time(t1, t2).tz_localize('US/Eastern')
         assert_series_equal(result, expected)
-        self.assert_(result.index.tz.zone == 'US/Eastern')
+        self.assertEqual(result.index.tz.zone, 'US/Eastern')
 
     def test_string_index_alias_tz_aware(self):
         rng = date_range('1/1/2000', periods=10, tz='US/Eastern')
@@ -477,7 +477,7 @@ class TestTimeZoneSupport(tm.TestCase):
                  datetime(2000, 1, 2, tzinfo=fixed_off),
                  datetime(2000, 1, 3, tzinfo=fixed_off)]
         result = to_datetime(dates)
-        self.assert_(result.tz == fixed_off)
+        self.assertEqual(result.tz, fixed_off)
 
     def test_fixedtz_topydatetime(self):
         dates = np.array([datetime(2000, 1, 1, tzinfo=fixed_off),
@@ -498,7 +498,7 @@ class TestTimeZoneSupport(tm.TestCase):
 
         dates_aware = [tz.localize(x) for x in dates]
         result = to_datetime(dates_aware)
-        self.assert_(result.tz.zone == 'US/Eastern')
+        self.assertEqual(result.tz.zone, 'US/Eastern')
 
         converted = to_datetime(dates_aware, utc=True)
         ex_vals = [Timestamp(x).value for x in dates_aware]
@@ -533,7 +533,7 @@ class TestTimeZoneSupport(tm.TestCase):
         dr = date_range('2011/1/1', '2012/1/1', freq='W-FRI')
         dr_tz = dr.tz_localize('US/Eastern')
         e = DataFrame({'A': 'foo', 'B': dr_tz}, index=dr)
-        self.assert_(e['B'].dtype == 'M8[ns]')
+        self.assertEqual(e['B'].dtype, 'M8[ns]')
 
         # GH 2810 (with timezones)
         datetimes_naive   = [ ts.to_pydatetime() for ts in dr ]
@@ -566,7 +566,7 @@ class TestTimeZoneSupport(tm.TestCase):
         dr_tz = dr.tz_localize('US/Eastern')
 
         result = dr_tz.shift(1, '10T')
-        self.assert_(result.tz == dr_tz.tz)
+        self.assertEqual(result.tz, dr_tz.tz)
 
     def test_tz_aware_asfreq(self):
         dr = date_range(
@@ -587,7 +587,7 @@ class TestTimeZoneSupport(tm.TestCase):
         d = [datetime(2012, 8, 19, tzinfo=pytz.timezone('US/Eastern'))]
 
         index = DatetimeIndex(d)
-        self.assert_(index.tz.zone == 'US/Eastern')
+        self.assertEqual(index.tz.zone, 'US/Eastern')
 
     def test_date_range_span_dst_transition(self):
         # #1778
@@ -606,8 +606,8 @@ class TestTimeZoneSupport(tm.TestCase):
 
         dr2 = DatetimeIndex(list(dr), name='foo')
         self.assert_(dr.equals(dr2))
-        self.assert_(dr.tz == dr2.tz)
-        self.assert_(dr2.name == 'foo')
+        self.assertEqual(dr.tz, dr2.tz)
+        self.assertEqual(dr2.name, 'foo')
 
     def test_frame_from_records_utc(self):
         rec = {'datum': 1.5,
@@ -703,17 +703,17 @@ class TestTimeZones(tm.TestCase):
         ts = Series(1, index=rng)
 
         result = ts.tz_localize('utc')
-        self.assert_(result.index.tz.zone == 'UTC')
+        self.assertEqual(result.index.tz.zone, 'UTC')
 
         df = DataFrame({'a': 1}, index=rng)
         result = df.tz_localize('utc')
         expected = DataFrame({'a': 1}, rng.tz_localize('UTC'))
-        self.assert_(result.index.tz.zone == 'UTC')
+        self.assertEqual(result.index.tz.zone, 'UTC')
         assert_frame_equal(result, expected)
 
         df = df.T
         result = df.tz_localize('utc', axis=1)
-        self.assert_(result.columns.tz.zone == 'UTC')
+        self.assertEqual(result.columns.tz.zone, 'UTC')
         assert_frame_equal(result, expected.T)
 
         # Can't localize if already tz-aware
@@ -727,17 +727,17 @@ class TestTimeZones(tm.TestCase):
         ts = Series(1, index=rng)
 
         result = ts.tz_convert('Europe/Berlin')
-        self.assert_(result.index.tz.zone == 'Europe/Berlin')
+        self.assertEqual(result.index.tz.zone, 'Europe/Berlin')
 
         df = DataFrame({'a': 1}, index=rng)
         result = df.tz_convert('Europe/Berlin')
         expected = DataFrame({'a': 1}, rng.tz_convert('Europe/Berlin'))
-        self.assert_(result.index.tz.zone == 'Europe/Berlin')
+        self.assertEqual(result.index.tz.zone, 'Europe/Berlin')
         assert_frame_equal(result, expected)
 
         df = df.T
         result = df.tz_convert('Europe/Berlin', axis=1)
-        self.assert_(result.columns.tz.zone == 'Europe/Berlin')
+        self.assertEqual(result.columns.tz.zone, 'Europe/Berlin')
         assert_frame_equal(result, expected.T)
 
         # can't convert tz-naive
@@ -754,11 +754,11 @@ class TestTimeZones(tm.TestCase):
         for how in ['inner', 'outer', 'left', 'right']:
             result = left.join(left[:-5], how=how)
             tm.assert_isinstance(result, DatetimeIndex)
-            self.assert_(result.tz == left.tz)
+            self.assertEqual(result.tz, left.tz)
 
             result = left.join(right[:-5], how=how)
             tm.assert_isinstance(result, DatetimeIndex)
-            self.assert_(result.tz.zone == 'UTC')
+            self.assertEqual(result.tz.zone, 'UTC')
 
     def test_join_aware(self):
         rng = date_range('1/1/2011', periods=10, freq='H')
@@ -888,7 +888,7 @@ class TestTimeZones(tm.TestCase):
         uts2 = ts2.tz_convert('utc')
         expected = uts1 + uts2
 
-        self.assert_(result.index.tz == pytz.UTC)
+        self.assertEqual(result.index.tz, pytz.UTC)
         assert_series_equal(result, expected)
 
     def test_intersection(self):
@@ -897,9 +897,9 @@ class TestTimeZones(tm.TestCase):
         left = rng[10:90][::-1]
         right = rng[20:80][::-1]
 
-        self.assert_(left.tz == rng.tz)
+        self.assertEqual(left.tz, rng.tz)
         result = left.intersection(right)
-        self.assert_(result.tz == left.tz)
+        self.assertEqual(result.tz, left.tz)
 
     def test_timestamp_equality_different_timezones(self):
         utc_range = date_range('1/1/2000', periods=20, tz='UTC')


### PR DESCRIPTION
Work on #6175, in pandas/*/tests. Tests still pass locally. Finishes most (all?) of the remaining vanilla assert_(x == y) conversions
