### PR TITLE
DOC: fix link to str.get_dummies

### DIFF
--- a/doc/source/reshaping.rst
+++ b/doc/source/reshaping.rst
@@ -418,7 +418,7 @@ This function is often used along with discretization functions like ``cut``:
 
    get_dummies(cut(values, bins))
 
-See also :func:`~pandas.Series.str.get_dummies`.
+See also :func:`Series.str.get_dummies <pandas.core.strings.StringMethods.get_dummies>`.
 
 Factorizing values
 ------------------


### PR DESCRIPTION
Links directly to `Series.str.get_dummies` don't work, as the object actually lives in `StringMethods`.
