### PR TITLE
BUG: Fix interpolate with inplace=True

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -77,6 +77,7 @@ Bug Fixes
 - Bug in ``.xs`` with a Series multiindex (:issue:`6258`, :issue:`5684`)
 - Bug in conversion of a string types to a DatetimeIndex with a specified frequency (:issue:`6273`, :issue:`6274`)
 - Bug in ``eval`` where type-promotion failed for large expressions (:issue:`6205`)
+- Bug in interpolate with inplace=True (:issue:`6281`)
 
 pandas 0.13.1
 -------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2541,9 +2541,9 @@ class NDFrame(PandasObject):
                 self._update_inplace(new_data)
         else:
             res = self._constructor(new_data).__finalize__(self)
-        if axis == 1:
-            res = res.T
-        return res
+            if axis == 1:
+                res = res.T
+            return res
 
     #----------------------------------------------------------------------
     # Action Methods

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -784,6 +784,12 @@ class TestDataFrame(tm.TestCase, Generic):
         with tm.assertRaises(TypeError):
             df.interpolate(axis=1)
 
+    def test_interp_inplace(self):
+        df = DataFrame({'a': [1., 2., np.nan, 4.]})
+        expected = DataFrame({'a': [1, 2, 3, 4]})
+        df['a'].interpolate(inplace=True)
+        assert_frame_equal(df, expected)
+
     def test_no_order(self):
         _skip_if_no_scipy()
         s = Series([0, 1, np.nan, 3])


### PR DESCRIPTION
Closes https://github.com/pydata/pandas/issues/6281

I didn't have the non inplace return in an else block. And I clearly didn't test this :/
