### PR TITLE
ENH: All args and kwargs to generic expanding/rolling apply.

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -65,6 +65,7 @@ Improvements to existing features
 
 - pd.read_clipboard will, if 'sep' is unspecified, try to detect data copied from a spreadsheet
   and parse accordingly. (:issue:`6223`)
+- pd.expanding_apply and pd.rolling_apply now take args and kwargs that are passed on to the func.
 
 .. _release.bug_fixes-0.14.0:
 

--- a/pandas/algos.pyx
+++ b/pandas/algos.pyx
@@ -1627,7 +1627,7 @@ def roll_quantile(ndarray[float64_t, cast=True] input, int win,
     return output
 
 def roll_generic(ndarray[float64_t, cast=True] input, int win,
-                 int minp, object func):
+                 int minp, object func, object args, object kwargs):
     cdef ndarray[double_t] output, counts, bufarr
     cdef Py_ssize_t i, n
     cdef float64_t *buf
@@ -1652,7 +1652,8 @@ def roll_generic(ndarray[float64_t, cast=True] input, int win,
     n = len(input)
     for i from 0 <= i < int_min(win, n):
         if counts[i] >= minp:
-            output[i] = func(input[int_max(i - win + 1, 0) : i + 1])
+            output[i] = func(input[int_max(i - win + 1, 0) : i + 1], *args,
+                             **kwargs)
         else:
             output[i] = NaN
 
@@ -1660,7 +1661,7 @@ def roll_generic(ndarray[float64_t, cast=True] input, int win,
         buf = buf + 1
         bufarr.data = <char*> buf
         if counts[i] >= minp:
-            output[i] = func(bufarr)
+            output[i] = func(bufarr, *args, **kwargs)
         else:
             output[i] = NaN
 

--- a/pandas/stats/moments.py
+++ b/pandas/stats/moments.py
@@ -514,7 +514,7 @@ def _rolling_func(func, desc, check_minp=_use_window):
     @wraps(func)
     def f(arg, window, min_periods=None, freq=None, center=False,
           time_rule=None, **kwargs):
-        def call_cython(arg, window, minp, **kwds):
+        def call_cython(arg, window, minp, args=(), kwargs={}, **kwds):
             minp = check_minp(minp, window)
             return func(arg, window, minp, **kwds)
         return _rolling_moment(arg, window, call_cython, min_periods,
@@ -562,7 +562,7 @@ def rolling_quantile(arg, window, quantile, min_periods=None, freq=None,
     y : type of input argument
     """
 
-    def call_cython(arg, window, minp):
+    def call_cython(arg, window, minp, args=(), kwargs={}):
         minp = _use_window(minp, window)
         return algos.roll_quantile(arg, window, minp, quantile)
     return _rolling_moment(arg, window, call_cython, min_periods,
@@ -713,7 +713,7 @@ def _expanding_func(func, desc, check_minp=_use_window):
           **kwargs):
         window = len(arg)
 
-        def call_cython(arg, window, minp, **kwds):
+        def call_cython(arg, window, minp, args=(), kwargs={}, **kwds):
             minp = check_minp(minp, window)
             return func(arg, window, minp, **kwds)
         return _rolling_moment(arg, window, call_cython, min_periods,

--- a/pandas/stats/tests/test_moments.py
+++ b/pandas/stats/tests/test_moments.py
@@ -694,6 +694,21 @@ class TestMoments(tm.TestCase):
                                        freq=freq)
         self._check_expanding(expanding_mean, np.mean)
 
+    def test_expanding_apply_args_kwargs(self):
+        def mean_w_arg(x, const):
+            return np.mean(x) + const
+
+        df = DataFrame(np.random.rand(20, 3))
+
+        expected = mom.expanding_apply(df, np.mean) + 20.
+
+        assert_frame_equal(mom.expanding_apply(df, mean_w_arg, args=(20,)),
+                            expected)
+        assert_frame_equal(mom.expanding_apply(df, mean_w_arg,
+                                               kwargs={'const' : 20}),
+                            expected)
+
+
     def test_expanding_corr(self):
         A = self.series.dropna()
         B = (A + randn(len(A)))[:-5]


### PR DESCRIPTION
Been bugging me lately. Simple enough fix I think. Example usage

```
def mean(x, const):
    return np.mean(x) + const

df = pd.DataFrame(np.random.rand(20, 3))
pd.expanding_apply(df, mean, args=(20,)

pd.expanding_apply(df, mean, kwargs=dict(const=20))
```
