### PR TITLE
BUG: preserve dtypes in interpolate

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2435,7 +2435,7 @@ class NDFrame(PandasObject):
             return self._constructor(new_data).__finalize__(self)
 
     def interpolate(self, method='linear', axis=0, limit=None, inplace=False,
-                    downcast='infer', **kwargs):
+                    downcast=None, **kwargs):
         """
         Interpolate values according to different methods.
 
@@ -2468,7 +2468,7 @@ class NDFrame(PandasObject):
             Maximum number of consecutive NaNs to fill.
         inplace : bool, default False
             Update the NDFrame in place if possible.
-        downcast : optional, 'infer' or None, defaults to 'infer'
+        downcast : optional, 'infer' or None, defaults to None
             Downcast dtypes if possible.
 
         Returns
@@ -2492,7 +2492,6 @@ class NDFrame(PandasObject):
         dtype: float64
 
         """
-
         if self.ndim > 2:
             raise NotImplementedError("Interpolate has not been implemented "
                                       "on Panel and Panel 4D objects.")
@@ -2534,7 +2533,6 @@ class NDFrame(PandasObject):
                                           inplace=inplace,
                                           downcast=downcast,
                                           **kwargs)
-
         if inplace:
             if axis == 1:
                 self._update_inplace(new_data)

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -826,6 +826,12 @@ class Block(PandasObject):
             m = None
 
         if m is not None:
+            # Skip interpolating this block if no NaNs.
+            if (~isnull(self.values)).all():
+                if inplace:
+                    return self
+                else:
+                    return self.copy()
             return self._interpolate(method=m,
                                      index=index,
                                      values=values,

--- a/vb_suite/frame_methods.py
+++ b/vb_suite/frame_methods.py
@@ -403,3 +403,29 @@ frame_float_unequal = Benchmark('test_unequal("float_df")', setup)
 frame_object_unequal = Benchmark('test_unequal("object_df")', setup)
 frame_nonunique_unequal = Benchmark('test_unequal("nonunique_cols")', setup)
 
+#-----------------------------------------------------------------------------
+# interpolate
+# this is the worst case, where every column has NaNs.
+setup = common_setup + """
+df = DataFrame(randn(10000, 100))
+df.values[::2] = np.nan
+"""
+
+frame_interpolate = Benchmark('df.interpolate()', setup,
+                               start_date=datetime(2014, 2, 7))
+
+setup = common_setup + """
+df = DataFrame({'A': np.arange(0, 10000),
+                'B': np.random.randint(0, 100, 10000),
+                'C': randn(10000),
+                'D': randn(10000)})
+df.loc[1::5, 'A'] = np.nan
+df.loc[1::5, 'C'] = np.nan
+"""
+
+frame_interpolate_some_good = Benchmark('df.interpolate()', setup,
+                                        start_date=datetime(2014, 2, 7))
+frame_interpolate_some_good_infer = Benchmark('df.interpolate(downcast="infer")',
+                                              setup,
+                                              start_date=datetime(2014, 2, 7))
+


### PR DESCRIPTION
Closes https://github.com/pydata/pandas/issues/6290

@jreback is there a good way to update **part** of a BlockManager inplace? I have a new BlockManager from `interpolate` and the original BlockManager (or DataFrame) which contains some "all good" columns that didn't get interpolate on, and some bad columns that did get interpolated on.

For the non inplace version I'm calling `self._constructor` on the BlockManager returned from interpolating and concating that to the all good columns.
