### PR TITLE
API: allow the iloc indexer to run off the end and not raise IndexError (GH6296)

### DIFF
--- a/doc/source/10min.rst
+++ b/doc/source/10min.rst
@@ -273,25 +273,6 @@ For getting fast access to a scalar (equiv to the prior method)
 
    df.iat[1,1]
 
-There is one signficant departure from standard python/numpy slicing semantics.
-python/numpy allow slicing past the end of an array without an associated
-error.
-
-.. ipython:: python
-
-    # these are allowed in python/numpy.
-    x = list('abcdef')
-    x[4:10]
-    x[8:10]
-
-Pandas will detect this and raise ``IndexError``, rather than return an empty
-structure.
-
-::
-
-    >>> df.iloc[:,8:10]
-    IndexError: out-of-bounds on slice (end)
-
 Boolean Indexing
 ~~~~~~~~~~~~~~~~
 

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -77,8 +77,9 @@ of multi-axis indexing.
   See more at :ref:`Selection by Label <indexing.label>`
 
 - ``.iloc`` is strictly integer position based (from ``0`` to ``length-1`` of
-  the axis), will raise ``IndexError`` when the requested indicies are out of
-  bounds. Allowed inputs are:
+  the axis), will raise ``IndexError`` if a single index is requested and it
+  is out-of-bounds, otherwise it will conform the bounds to size of the object.
+  Allowed inputs are:
 
   - An integer e.g. ``5``
   - A list or array of integers ``[4, 3, 0]``
@@ -420,12 +421,19 @@ python/numpy allow slicing past the end of an array without an associated error.
     x[4:10]
     x[8:10]
 
-Pandas will detect this and raise ``IndexError``, rather than return an empty structure.
+- as of v0.14.0, ``iloc`` will now accept out-of-bounds indexers, e.g. a value that exceeds the length of the object being
+  indexed. These will be excluded. This will make pandas conform more with pandas/numpy indexing of out-of-bounds
+  values. A single indexer that is out-of-bounds and drops the dimensions of the object will still raise
+  ``IndexError`` (:issue:`6296`). This could result in an empty axis (e.g. an empty DataFrame being returned)
 
-::
+  .. ipython:: python
 
-    >>> df.iloc[:,3:6]
-    IndexError: out-of-bounds on slice (end)
+      df = DataFrame(np.random.randn(5,2),columns=list('AB'))
+      df
+      df.iloc[[4,5,6]]
+      df.iloc[4:6]
+      df.iloc[:,2:3]
+      df.iloc[:,1:3]
 
 .. _indexing.basics.partial_setting:
 

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -56,6 +56,10 @@ New features
 API Changes
 ~~~~~~~~~~~
 
+- ``iloc`` will now accept out-of-bounds indexers, e.g. a value that exceeds the length of the object being
+  indexed. These will be excluded. This will make pandas conform more with pandas/numpy indexing of out-of-bounds
+  values. A single indexer that is out-of-bounds and drops the dimensions of the object will still raise
+  ``IndexError`` (:issue:`6296`)
 
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -15,6 +15,20 @@ Highlights include:
 API changes
 ~~~~~~~~~~~
 
+- ``iloc`` will now accept out-of-bounds indexers, e.g. a value that exceeds the length of the object being
+  indexed. These will be excluded. This will make pandas conform more with pandas/numpy indexing of out-of-bounds
+  values. A single indexer that is out-of-bounds and drops the dimensions of the object will still raise
+  ``IndexError`` (:issue:`6296`). This could result in an empty axis (e.g. an empty DataFrame being returned)
+
+  .. ipython:: python
+
+      df = DataFrame(np.random.randn(5,2),columns=list('AB'))
+      df
+      df.iloc[[4,5,6]]
+      df.iloc[4:6]
+      df.iloc[:,2:3]
+      df.iloc[:,1:3]
+
 Prior Version Deprecations/Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1756,10 +1756,6 @@ class NDFrame(PandasObject):
         l = len(self)
         if l == 0 or n==0:
             return self
-        if n > l:
-            n = l
-        elif n < -l:
-            n = -l
         return self.iloc[:n]
 
     def tail(self, n=5):
@@ -1769,10 +1765,6 @@ class NDFrame(PandasObject):
         l = len(self)
         if l == 0 or n == 0:
             return self
-        if n > l:
-            n = l
-        elif n < -l:
-            n = -l
         return self.iloc[-n:]
 
     #----------------------------------------------------------------------

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -621,9 +621,15 @@ class Index(FrozenNDArray):
             if com._is_bool_indexer(key):
                 key = np.asarray(key)
 
-            result = arr_idx[key]
-            if result.ndim > 1:
-                return result
+            try:
+                result = arr_idx[key]
+                if result.ndim > 1:
+                    return result
+            except (IndexError):
+                if not len(key):
+                    result = []
+                else:
+                    raise
 
             return Index(result, name=self.name)
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -3246,7 +3246,7 @@ class BlockManager(PandasObject):
         pandas-indexer with -1's only.
         """
         # trying to reindex on an axis with duplicates
-        if not allow_dups and not self.axes[axis].is_unique:
+        if not allow_dups and not self.axes[axis].is_unique and len(indexer):
             raise ValueError("cannot reindex from a duplicate axis")
 
         if not self.is_consolidated():

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -873,7 +873,7 @@ class TestNDFrame(tm.TestCase):
 
         s2[0] = 9.9
         self.assert_(not s1.equals(s2))
-        
+
         idx = MultiIndex.from_tuples([(0, 'a'), (1, 'b'), (2, 'c')])
         s1 = Series([1, 2, np.nan], index=idx)
         s2 = s1.copy()
@@ -900,17 +900,17 @@ class TestNDFrame(tm.TestCase):
         # different dtype
         different = df1.copy()
         different['floats'] = different['floats'].astype('float32')
-        self.assert_(not df1.equals(different)) 
+        self.assert_(not df1.equals(different))
 
         # different index
         different_index = -index
         different = df2.set_index(different_index)
-        self.assert_(not df1.equals(different))        
+        self.assert_(not df1.equals(different))
 
         # different columns
         different = df2.copy()
         different.columns = df2.columns[::-1]
-        self.assert_(not df1.equals(different))        
+        self.assert_(not df1.equals(different))
 
         # DatetimeIndex
         index = pd.date_range('2000-1-1', periods=10, freq='T')


### PR DESCRIPTION
closes #6296

Here's the behavior
I left it raising an `IndexError` if a single indexer is given that is out-of-bounds (consistent with the way `ix/loc` would work)

```
In [1]: df = DataFrame(np.random.randn(5,2),columns=list('AB'))

In [2]: df
Out[2]: 
          A         B
0  1.105982  0.309531
1 -0.619102 -0.002967
2 -0.817371  0.270714
3  1.569206  1.595204
4  0.276390 -1.316232

[5 rows x 2 columns]

In [3]: df.iloc[[4,5,6]]
Out[3]: 
         A         B
4  0.27639 -1.316232

[1 rows x 2 columns]

In [4]: df.iloc[4:6]
Out[4]: 
         A         B
4  0.27639 -1.316232

[1 rows x 2 columns]

In [5]: df.iloc[:,2:3]
Out[5]: 
Empty DataFrame
Columns: []
Index: [0, 1, 2, 3, 4]

[5 rows x 0 columns]

In [6]: df.iloc[:,1:3]
Out[6]: 
          B
0  0.309531
1 -0.002967
2  0.270714
3  1.595204
4 -1.316232

[5 rows x 1 columns]

In [7]: df.iloc[10]
IndexError: 

```
