### PR TITLE
DOC: clarified to_excel and read_excel (GH6260)

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1883,6 +1883,15 @@ Files with a ``.xls`` extension will be written using ``xlwt`` and those with a
 ``.xlsx`` extension will be written using ``xlsxwriter`` (if available) or
 ``openpyxl``.
 
+The DataFrame will be written in a way that tries to mimic the REPL output. One
+difference from 0.12.0 is that the ``index_label`` will be placed in the second
+row instead of the first. You can get the previous behaviour by setting the
+``merge_cells`` option in ``to_excel()`` to ``False``:
+
+.. code-block:: python
+
+   df.to_excel('path_to_file.xlsx', index_label='label', merge_cells=False)
+
 The Panel class also has a ``to_excel`` instance method,
 which writes each DataFrame in the Panel to a separate sheet.
 

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -86,7 +86,11 @@ def read_excel(io, sheetname, **kwds):
     convert_float : boolean, default True
         convert integral floats to int (i.e., 1.0 --> 1). If False, all numeric
         data will be read in as floats: Excel stores all numbers as floats
-        internally.
+        internally
+    has_index_names : boolean, default False
+        True if the cols defined in index_col have an index name and are
+        not in the header. Index name will be placed on a separate line below
+        the header.
 
     Returns
     -------


### PR DESCRIPTION
as discussed in issue #6260
- io.rst: added a paragraph explaining the difference in behaviour from 0.12
- excel.py: added docstring for has_index_names

thanks to jmcnamara

ps: sorry about the pollution with multiple commits, I'm still learning how to rebase/squash
