### PR TITLE
Add example section to groupby.rst and one example

### DIFF
--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -729,22 +729,7 @@ Examples
 
 Regroup columns of a DataFrame according to their sum, and sum the aggregated ones.
 
-.. ipython::
+.. ipython:: python
    
-   In [2]: dat = {'a':[1,0,0], 'b':[0,1,0], 'c':[1,0,0], 'd':[2,3,4]}
-   
-   In [3]: df = pd.DataFrame(dat)
-   
-   In [4]: df
-   Out[4]: 
-      a  b  c  d
-   0  1  0  1  2
-   1  0  1  0  3
-   2  0  0  0  4
-   
-   In [5]: df.groupby(df.sum(), axis=1).sum()
-   Out[5]: 
-      1  9
-   0  2  2
-   1  1  3
-   2  0  4
+   df = pd.DataFrame({'a':[1,0,0], 'b':[0,1,0], 'c':[1,0,0], 'd':[2,3,4]})
+   df.groupby(df.sum(), axis=1).sum()

--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -723,3 +723,28 @@ To see the order in which each row appears within its group, use the
    df.groupby('A').cumcount()
 
    df.groupby('A').cumcount(ascending=False)  # kwarg only
+   
+Examples
+~~~~~~~~
+
+Regroup columns of a DataFrame according to their sum, and sum the aggregated ones.
+
+.. ipython::
+   
+   In [2]: dat = {'a':[1,0,0], 'b':[0,1,0], 'c':[1,0,0], 'd':[2,3,4]}
+   
+   In [3]: df = pd.DataFrame(dat)
+   
+   In [4]: df
+   Out[4]: 
+      a  b  c  d
+   0  1  0  1  2
+   1  0  1  0  3
+   2  0  0  0  4
+   
+   In [5]: df.groupby(df.sum(), axis=1).sum()
+   Out[5]: 
+      1  9
+   0  2  2
+   1  1  3
+   2  0  4


### PR DESCRIPTION
following this question on  [StackOverFlow](https://stackoverflow.com/questions/21584434/group-by-value-of-sum-of-columns-with-pandas) and [this issue](https://github.com/pydata/pandas/issues/6288).
I opened an "Examples" section in the doc of `groupby()` and add an example about how a way to regroup columns of a DataFrame according to their sum, and to sum the aggregated ones.

closes #6288
