### PR TITLE
TEST: add basic postgresql tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ install:
 
 before_script:
   - mysql -e 'create database pandas_nosetest;'
+  - psql -c 'create database pandas_nosetest;' -U postgres
 
 script:
   - echo "script"

--- a/ci/requirements-2.7.txt
+++ b/ci/requirements-2.7.txt
@@ -19,3 +19,4 @@ beautifulsoup4==4.2.1
 statsmodels==0.5.0
 bigquery==2.0.17
 sqlalchemy==0.8.1
+psycopg2==2.5.2

--- a/ci/requirements-3.3.txt
+++ b/ci/requirements-3.3.txt
@@ -15,3 +15,4 @@ scipy==0.12.0
 beautifulsoup4==4.2.1
 statsmodels==0.4.3
 sqlalchemy==0.9.1
+psycopg2==2.5.2


### PR DESCRIPTION
@mangecoeur I just copied and adapted the mysql tests and provided some `SQL_STRINGS` that follow the postgresql dialect. Is this what you had in mind how other sql dialects would be added to the tests?  

@jreback I now added it to requirements-2.7.txt. Should I add it to all test environments? Or if only one, is this the correct one?

@mangecoeur Is it possible that there is a `pymysql` missing in the requirement files to run the MySQL tests (they are all skipped on travis)?

At the moment, there are two tests failing with postgresql (see https://travis-ci.org/jorisvandenbossche/pandas/jobs/18576746). 
