### PR TITLE
PERF: pd.Index.is_all_dates doesn't require full-scan inference

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -74,6 +74,7 @@ Improvements to existing features
   the func (:issue:`6289`)
 - ``plot(legend='reverse')`` will now reverse the order of legend labels for most plot kinds.
   (:issue:`6014`)
+- improve performance of slice indexing on Series with string keys (:issue:`6341`)
 
 .. _release.bug_fixes-0.14.0:
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -46,7 +46,7 @@ Enhancements
   and parse accordingly. (:issue:`6223`)
 - ``plot(legend='reverse')`` will now reverse the order of legend labels for
   most plot kinds. (:issue:`6014`)
-
+- improve performance of slice indexing on Series with string keys (:issue:`6341`)
 
 Performance
 ~~~~~~~~~~~

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -9,7 +9,7 @@ import pandas.tslib as tslib
 import pandas.lib as lib
 import pandas.algos as _algos
 import pandas.index as _index
-from pandas.lib import Timestamp
+from pandas.lib import Timestamp, is_datetime_array
 from pandas.core.base import FrozenList, FrozenNDArray
 
 from pandas.util.decorators import cache_readonly, deprecate
@@ -577,7 +577,7 @@ class Index(FrozenNDArray):
 
     @cache_readonly
     def is_all_dates(self):
-        return self.inferred_type == 'datetime'
+        return is_datetime_array(self.values)
 
     def __iter__(self):
         return iter(self.values)

--- a/vb_suite/indexing.py
+++ b/vb_suite/indexing.py
@@ -7,7 +7,7 @@ common_setup = """from pandas_vb_common import *
 """
 
 #----------------------------------------------------------------------
-# Series.__getitem__, get_value
+# Series.__getitem__, get_value, __getitem__(slice)
 
 setup = common_setup + """
 tm.N = 1000
@@ -28,6 +28,15 @@ statement = "s.get_value(idx)"
 bm_df_getitem3 = Benchmark(statement, setup,
                            name='series_get_value',
                            start_date=datetime(2011, 11, 12))
+
+
+setup = common_setup + """
+index = tm.makeStringIndex(1000000)
+s = Series(np.random.rand(1000000), index=index)
+"""
+series_getitem_slice = Benchmark("s[:800000]", setup,
+                                 name="series_getitem_slice")
+
 
 #----------------------------------------------------------------------
 # DataFrame __getitem__


### PR DESCRIPTION
While working on #6328 I've stumbled upon this piece that deserves optimization.

Current implementation `Index.is_all_dates` invokes `lib.infer_dtype` which does a full-scan dtype inference which is not not always necessary. If I read cython sources correctly, new code is equivalent to the old one and the performance increase comes from short-circuiting the check on the first non-datetime element.

This change cuts roughly 50% of runtime of the following snippet:

``` python
import numpy as np
import pandas as pd

NUM_ELEMENTS = 1e7
s = pd.Series(np.arange(NUM_ELEMENTS),
              index=['a%s' % i for i in np.arange(NUM_ELEMENTS)])

print("pd.version", pd.__version__)
%timeit s[:int(NUM_ELEMENTS/2)]
```

On recent master:

```
$ ipython test_index_is_all_dates.ipy 
pd.version 0.13.1-108-g87b4308
10 loops, best of 3: 55.5 ms per loop
```

On this branch:

```
$ ipython test_index_is_all_dates.ipy 
pd.version 0.13.1-109-g3b43e2b
10 loops, best of 3: 28 ms per loop
```
