### PR TITLE
  ENH: add method='dense' to rank

### DIFF
--- a/pandas/algos.pyx
+++ b/pandas/algos.pyx
@@ -68,12 +68,14 @@ cdef:
     int TIEBREAK_MAX = 2
     int TIEBREAK_FIRST = 3
     int TIEBREAK_FIRST_DESCENDING = 4
+    int TIEBREAK_DENSE = 5
 
 tiebreakers = {
     'average' : TIEBREAK_AVERAGE,
     'min' : TIEBREAK_MIN,
     'max' : TIEBREAK_MAX,
-    'first' : TIEBREAK_FIRST
+    'first' : TIEBREAK_FIRST,
+    'dense': TIEBREAK_DENSE,
 }
 
 
@@ -137,13 +139,14 @@ def rank_1d_float64(object in_arr, ties_method='average', ascending=True,
     """
 
     cdef:
-        Py_ssize_t i, j, n, dups = 0
+        Py_ssize_t i, j, n, dups, total_tie_count = 0
         ndarray[float64_t] sorted_data, ranks, values
         ndarray[int64_t] argsorted
         float64_t val, nan_value
         float64_t sum_ranks = 0
         int tiebreak = 0
         bint keep_na = 0
+
     tiebreak = tiebreakers[ties_method]
 
     values = np.asarray(in_arr).copy()
@@ -174,7 +177,7 @@ def rank_1d_float64(object in_arr, ties_method='average', ascending=True,
 
     sorted_data = values.take(_as)
     argsorted = _as.astype('i8')
-
+    
     for i in range(n):
         sum_ranks += i + 1
         dups += 1
@@ -198,6 +201,10 @@ def rank_1d_float64(object in_arr, ties_method='average', ascending=True,
             elif tiebreak == TIEBREAK_FIRST_DESCENDING:
                 for j in range(i - dups + 1, i + 1):
                     ranks[argsorted[j]] = 2 * i - j - dups + 2
+            elif tiebreak == TIEBREAK_DENSE:
+                for j in range(i - dups + 1, i + 1):
+                    ranks[argsorted[j]] = i - dups + 2 - total_tie_count
+                total_tie_count += dups - 1
             sum_ranks = dups = 0
     return ranks
 
@@ -209,7 +216,7 @@ def rank_1d_int64(object in_arr, ties_method='average', ascending=True,
     """
 
     cdef:
-        Py_ssize_t i, j, n, dups = 0
+        Py_ssize_t i, j, n, dups, total_tie_count = 0
         ndarray[int64_t] sorted_data, values
         ndarray[float64_t] ranks
         ndarray[int64_t] argsorted
@@ -258,6 +265,10 @@ def rank_1d_int64(object in_arr, ties_method='average', ascending=True,
             elif tiebreak == TIEBREAK_FIRST_DESCENDING:
                 for j in range(i - dups + 1, i + 1):
                     ranks[argsorted[j]] = 2 * i - j - dups + 2
+            elif tiebreak == TIEBREAK_DENSE:
+                for j in range(i - dups + 1, i + 1):
+                    ranks[argsorted[j]] = i - dups + 2 - total_tie_count
+                total_tie_count += dups - 1
             sum_ranks = dups = 0
     return ranks
 
@@ -269,7 +280,7 @@ def rank_2d_float64(object in_arr, axis=0, ties_method='average',
     """
 
     cdef:
-        Py_ssize_t i, j, z, k, n, dups = 0
+        Py_ssize_t i, j, z, k, n, dups, total_tie_count = 0
         ndarray[float64_t, ndim=2] ranks, values
         ndarray[int64_t, ndim=2] argsorted
         float64_t val, nan_value
@@ -337,6 +348,10 @@ def rank_2d_float64(object in_arr, axis=0, ties_method='average',
                 elif tiebreak == TIEBREAK_FIRST_DESCENDING:
                     for z in range(j - dups + 1, j + 1):
                         ranks[i, argsorted[i, z]] = 2 * j - z - dups + 2
+                elif tiebreak == TIEBREAK_DENSE:
+                    for j in range(i - dups + 1, i + 1):
+                        ranks[argsorted[j]] = i - dups + 2 - total_tie_count
+                total_tie_count += dups - 1
                 sum_ranks = dups = 0
 
     if axis == 0:
@@ -352,7 +367,7 @@ def rank_2d_int64(object in_arr, axis=0, ties_method='average',
     """
 
     cdef:
-        Py_ssize_t i, j, z, k, n, dups = 0
+        Py_ssize_t i, j, z, k, n, dups, total_tie_count = 0
         ndarray[float64_t, ndim=2] ranks
         ndarray[int64_t, ndim=2] argsorted
         ndarray[int64_t, ndim=2, cast=True] values
@@ -405,6 +420,10 @@ def rank_2d_int64(object in_arr, axis=0, ties_method='average',
                 elif tiebreak == TIEBREAK_FIRST_DESCENDING:
                     for z in range(j - dups + 1, j + 1):
                         ranks[i, argsorted[i, z]] = 2 * j - z - dups + 2
+                elif tiebreak == TIEBREAK_DENSE:
+                    for j in range(i - dups + 1, i + 1):
+                        ranks[argsorted[j]] = i - dups + 2 - total_tie_count
+                    total_tie_count += dups - 1
                 sum_ranks = dups = 0
 
     if axis == 0:
@@ -420,7 +439,7 @@ def rank_1d_generic(object in_arr, bint retry=1, ties_method='average',
     """
 
     cdef:
-        Py_ssize_t i, j, n, dups = 0
+        Py_ssize_t i, j, n, dups, total_tie_count = 0
         ndarray[float64_t] ranks
         ndarray sorted_data, values
         ndarray[int64_t] argsorted
@@ -490,6 +509,10 @@ def rank_1d_generic(object in_arr, bint retry=1, ties_method='average',
                     ranks[argsorted[j]] = i + 1
             elif tiebreak == TIEBREAK_FIRST:
                 raise ValueError('first not supported for non-numeric data')
+            elif tiebreak == TIEBREAK_DENSE:
+                for j in range(i - dups + 1, i + 1):
+                    ranks[argsorted[j]] = i - dups + 2 - total_tie_count
+                total_tie_count += dups - 1
             sum_ranks = dups = 0
     return ranks
 
@@ -529,7 +552,7 @@ def rank_2d_generic(object in_arr, axis=0, ties_method='average',
     """
 
     cdef:
-        Py_ssize_t i, j, z, k, n, infs, dups = 0
+        Py_ssize_t i, j, z, k, n, infs, dups, total_tie_count = 0
         ndarray[float64_t, ndim=2] ranks
         ndarray[object, ndim=2] values
         ndarray[int64_t, ndim=2] argsorted
@@ -606,6 +629,10 @@ def rank_2d_generic(object in_arr, axis=0, ties_method='average',
                 elif tiebreak == TIEBREAK_FIRST:
                     raise ValueError('first not supported for '
                                      'non-numeric data')
+                elif tiebreak == TIEBREAK_DENSE:
+                    for j in range(i - dups + 1, i + 1):
+                        ranks[argsorted[j]] = i - dups + 2 - total_tie_count
+                    total_tie_count += dups - 1
                 sum_ranks = dups = 0
 
     if axis == 0:
@@ -1406,7 +1433,7 @@ def roll_max2(ndarray[float64_t] a, int window, int minp):
     cdef Py_ssize_t n0 = dim[0]
     cdef np.npy_intp *dims = [n0]
     cdef np.ndarray[np.float64_t, ndim=1] y = PyArray_EMPTY(1, dims,
-		NPY_float64, 0)
+        NPY_float64, 0)
 
     if window < 1:
         raise ValueError('Invalid window size %d'
@@ -1507,7 +1534,7 @@ def roll_min2(np.ndarray[np.float64_t, ndim=1] a, int window, int minp):
     cdef Py_ssize_t n0 = dim[0]
     cdef np.npy_intp *dims = [n0]
     cdef np.ndarray[np.float64_t, ndim=1] y = PyArray_EMPTY(1, dims,
-		NPY_float64, 0)
+        NPY_float64, 0)
 
     if window < 1:
         raise ValueError('Invalid window size %d'

--- a/pandas/algos.pyx
+++ b/pandas/algos.pyx
@@ -139,7 +139,7 @@ def rank_1d_float64(object in_arr, ties_method='average', ascending=True,
     """
 
     cdef:
-        Py_ssize_t i, j, n, dups, total_tie_count = 0
+        Py_ssize_t i, j, n, dups = 0, total_tie_count = 0
         ndarray[float64_t] sorted_data, ranks, values
         ndarray[int64_t] argsorted
         float64_t val, nan_value
@@ -216,7 +216,7 @@ def rank_1d_int64(object in_arr, ties_method='average', ascending=True,
     """
 
     cdef:
-        Py_ssize_t i, j, n, dups, total_tie_count = 0
+        Py_ssize_t i, j, n, dups=0, total_tie_count=0
         ndarray[int64_t] sorted_data, values
         ndarray[float64_t] ranks
         ndarray[int64_t] argsorted
@@ -280,7 +280,7 @@ def rank_2d_float64(object in_arr, axis=0, ties_method='average',
     """
 
     cdef:
-        Py_ssize_t i, j, z, k, n, dups, total_tie_count = 0
+        Py_ssize_t i, j, z, k, n, dups = 0, total_tie_count = 0
         ndarray[float64_t, ndim=2] ranks, values
         ndarray[int64_t, ndim=2] argsorted
         float64_t val, nan_value
@@ -325,6 +325,7 @@ def rank_2d_float64(object in_arr, axis=0, ties_method='average',
 
     for i in range(n):
         dups = sum_ranks = 0
+        total_tie_count = 0
         for j in range(k):
             sum_ranks += j + 1
             dups += 1
@@ -349,9 +350,9 @@ def rank_2d_float64(object in_arr, axis=0, ties_method='average',
                     for z in range(j - dups + 1, j + 1):
                         ranks[i, argsorted[i, z]] = 2 * j - z - dups + 2
                 elif tiebreak == TIEBREAK_DENSE:
-                    for j in range(i - dups + 1, i + 1):
-                        ranks[argsorted[j]] = i - dups + 2 - total_tie_count
-                total_tie_count += dups - 1
+                    for z in range(j - dups + 1, j + 1):
+                        ranks[i, argsorted[i, z]] = j - dups + 2 - total_tie_count
+                    total_tie_count += dups - 1
                 sum_ranks = dups = 0
 
     if axis == 0:
@@ -367,13 +368,14 @@ def rank_2d_int64(object in_arr, axis=0, ties_method='average',
     """
 
     cdef:
-        Py_ssize_t i, j, z, k, n, dups, total_tie_count = 0
+        Py_ssize_t i, j, z, k, n, dups = 0, total_tie_count = 0
         ndarray[float64_t, ndim=2] ranks
         ndarray[int64_t, ndim=2] argsorted
         ndarray[int64_t, ndim=2, cast=True] values
         int64_t val
         float64_t sum_ranks = 0
         int tiebreak = 0
+
     tiebreak = tiebreakers[ties_method]
 
     if axis == 0:
@@ -400,6 +402,7 @@ def rank_2d_int64(object in_arr, axis=0, ties_method='average',
 
     for i in range(n):
         dups = sum_ranks = 0
+        total_tie_count = 0
         for j in range(k):
             sum_ranks += j + 1
             dups += 1
@@ -421,8 +424,8 @@ def rank_2d_int64(object in_arr, axis=0, ties_method='average',
                     for z in range(j - dups + 1, j + 1):
                         ranks[i, argsorted[i, z]] = 2 * j - z - dups + 2
                 elif tiebreak == TIEBREAK_DENSE:
-                    for j in range(i - dups + 1, i + 1):
-                        ranks[argsorted[j]] = i - dups + 2 - total_tie_count
+                    for z in range(j - dups + 1, j + 1):
+                        ranks[i, argsorted[i, z]] = j - dups + 2 - total_tie_count
                     total_tie_count += dups - 1
                 sum_ranks = dups = 0
 
@@ -439,7 +442,7 @@ def rank_1d_generic(object in_arr, bint retry=1, ties_method='average',
     """
 
     cdef:
-        Py_ssize_t i, j, n, dups, total_tie_count = 0
+        Py_ssize_t i, j, n, dups = 0, total_tie_count = 0
         ndarray[float64_t] ranks
         ndarray sorted_data, values
         ndarray[int64_t] argsorted
@@ -552,7 +555,7 @@ def rank_2d_generic(object in_arr, axis=0, ties_method='average',
     """
 
     cdef:
-        Py_ssize_t i, j, z, k, n, infs, dups, total_tie_count = 0
+        Py_ssize_t i, j, z, k, n, infs, dups=0,total_tie_count=0
         ndarray[float64_t, ndim=2] ranks
         ndarray[object, ndim=2] values
         ndarray[int64_t, ndim=2] argsorted
@@ -608,6 +611,7 @@ def rank_2d_generic(object in_arr, axis=0, ties_method='average',
 
     for i in range(n):
         dups = sum_ranks = infs = 0
+        total_tie_count = 0
         for j in range(k):
             val = values[i, j]
             if val is nan_value and keep_na:
@@ -630,8 +634,8 @@ def rank_2d_generic(object in_arr, axis=0, ties_method='average',
                     raise ValueError('first not supported for '
                                      'non-numeric data')
                 elif tiebreak == TIEBREAK_DENSE:
-                    for j in range(i - dups + 1, i + 1):
-                        ranks[argsorted[j]] = i - dups + 2 - total_tie_count
+                    for z in range(j - dups + 1, j + 1):
+                        ranks[i, argsorted[i, z]] = j - dups + 2 - total_tie_count
                     total_tie_count += dups - 1
                 sum_ranks = dups = 0
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4163,11 +4163,12 @@ class DataFrame(NDFrame):
             Ranks over columns (0) or rows (1)
         numeric_only : boolean, default None
             Include only float, int, boolean data
-        method : {'average', 'min', 'max', 'first'}
+        method : {'average', 'min', 'max', 'first', 'dense'}
             * average: average rank of group
             * min: lowest rank in group
             * max: highest rank in group
             * first: ranks assigned in order they appear in the array
+            * dense: like 'min', but rank always increases by 1 between groups 
         na_option : {'keep', 'top', 'bottom'}
             * keep: leave NA values where they are
             * top: smallest rank if ascending

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2825,14 +2825,14 @@ class DataFrame(NDFrame):
                                       fill_value)
 
         new_data = left._data.eval(
-            func=func, other=right, axes=[left.columns, self.index])
+            func, right, axes=[left.columns, self.index])
         return self._constructor(new_data)
 
     def _combine_const(self, other, func, raise_on_error=True):
         if self.empty:
             return self
 
-        new_data = self._data.eval(func=func, other=other, raise_on_error=raise_on_error)
+        new_data = self._data.eval(func, other, raise_on_error=raise_on_error)
         return self._constructor(new_data)
 
     def _compare_frame_evaluate(self, other, func, str_rep):
@@ -3228,7 +3228,7 @@ class DataFrame(NDFrame):
         -------
         diffed : DataFrame
         """
-        new_data = self._data.diff(n=periods)
+        new_data = self._data.diff(periods)
         return self._constructor(new_data)
 
     #----------------------------------------------------------------------
@@ -4168,7 +4168,7 @@ class DataFrame(NDFrame):
             * min: lowest rank in group
             * max: highest rank in group
             * first: ranks assigned in order they appear in the array
-            * dense: like 'min', but rank always increases by 1 between groups 
+            * dense: like 'min', but rank always increases by 1 between groups
         na_option : {'keep', 'top', 'bottom'}
             * keep: leave NA values where they are
             * top: smallest rank if ascending

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -212,7 +212,7 @@ class Series(generic.NDFrame):
             # create/copy the manager
             if isinstance(data, SingleBlockManager):
                 if dtype is not None:
-                    data = data.astype(dtype=dtype, raise_on_error=False)
+                    data = data.astype(dtype, raise_on_error=False)
                 elif copy:
                     data = data.copy()
             else:
@@ -281,23 +281,23 @@ class Series(generic.NDFrame):
 
     # ndarray compatibility
     def item(self):
-        return self._data.values.item()
+        return self.values.item()
 
     @property
     def data(self):
-        return self._data.values.data
+        return self.values.data
 
     @property
     def strides(self):
-        return self._data.values.strides
+        return self.values.strides
 
     @property
     def size(self):
-        return self._data.values.size
+        return self.values.size
 
     @property
     def flags(self):
-        return self._data.values.flags
+        return self.values.flags
 
     @property
     def dtype(self):
@@ -694,7 +694,7 @@ class Series(generic.NDFrame):
     def _set_values(self, key, value):
         if isinstance(key, Series):
             key = key.values
-        self._data = self._data.setitem(indexer=key, value=value)
+        self._data = self._data.setitem(key, value)
 
     # help out SparseSeries
     _get_val_at = ndarray.__getitem__
@@ -1643,7 +1643,7 @@ class Series(generic.NDFrame):
         other = other.reindex_like(self)
         mask = notnull(other)
 
-        self._data = self._data.putmask(mask=mask, new=other, inplace=True)
+        self._data = self._data.putmask(mask, other, inplace=True)
         self._maybe_update_cacher()
 
     #----------------------------------------------------------------------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1752,11 +1752,12 @@ class Series(generic.NDFrame):
 
         Parameters
         ----------
-        method : {'average', 'min', 'max', 'first'}
+        method : {'average', 'min', 'max', 'first', 'dense'}
             * average: average rank of group
             * min: lowest rank in group
             * max: highest rank in group
             * first: ranks assigned in order they appear in the array
+            * dense: like 'min', but rank always increases by 1 between groups 
         na_option : {'keep'}
             keep: leave NA values where they are
         ascending : boolean, default True

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -3950,52 +3950,6 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         exp = iseries.astype(float).rank()
         assert_series_equal(iranks, exp)
 
-    def test_rank_methods(self):
-
-        ser = Series([0,0,1,2,3])
-
-        ranked_average = ser.rank(method='average')
-        expect_average = Series([ 1.5,  1.5,  3. ,  4. ,  5. ])
-        assert_series_equal(ranked_average, expect_average)
-
-        ranked_min = ser.rank(method='min')
-        expect_min = Series([ 1.,  1.,  3.,  4.,  5.])
-        assert_series_equal(ranked_min, expect_min)
-
-        ranked_max = ser.rank(method='max')
-        expect_max = Series([ 2.,  2.,  3.,  4.,  5.])
-        assert_series_equal(ranked_max, expect_max)
-
-        ranked_first = ser.rank(method='first')
-        expect_first = Series([ 1.,  2.,  3.,  4.,  5.])
-        assert_series_equal(ranked_first, expect_first)
-
-        ranked_dense = ser.rank(method='dense')
-        expect_dense = Series([ 1.,  1.,  2.,  3.,  4.])
-        assert_series_equal(ranked_dense, expect_dense)
-
-        ser = Series([2., 6., 3., 9., 2.])
-
-        ranked_average = ser.rank(method='average')
-        expect_average = Series([ 1.5,  4. ,  3. ,  5. ,  1.5])
-        assert_series_equal(ranked_average, expect_average)
-
-        ranked_min = ser.rank(method='min')
-        expect_min = Series([ 1.,  4.,  3.,  5.,  1.])
-        assert_series_equal(ranked_min, expect_min)
-
-        ranked_max = ser.rank(method='max')
-        expect_max = Series([ 2.,  4.,  3.,  5.,  2.])
-        assert_series_equal(ranked_max, expect_max)
-
-        ranked_first = ser.rank(method='first')
-        expect_first = Series([ 1.,  4.,  3.,  5.,  2.])
-        assert_series_equal(ranked_first, expect_first)
-
-        ranked_dense = ser.rank(method='dense')
-        expect_dense = Series([ 1.,  3.,  2.,  4.,  1.])
-        assert_series_equal(ranked_dense, expect_dense)
-        
     def test_from_csv(self):
 
         with ensure_clean() as path:
@@ -5337,6 +5291,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         result = ser.replace(Timestamp('20130103'), Timestamp('20120101'))
         assert_series_equal(result, expected)
 
+
     def test_replace_with_single_list(self):
         ser = Series([0, 1, 2, 3, 4])
         result = ser.replace([1,2,3])
@@ -5351,7 +5306,6 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         with tm.assertRaises(ValueError):
             s.replace([1,2,3],inplace=True,method='crash_cymbal')
         assert_series_equal(s, ser)
-
 
     def test_replace_mixed_types(self):
         s = Series(np.arange(5),dtype='int64')
@@ -5394,30 +5348,6 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         r = dr.astype(object).replace([dr[0],dr[1],dr[2]], [1.0,2,'a'])
         assert_series_equal(r, Series([1.0,2,'a'] +
                                       dr[3:].tolist(),dtype=object))
-
-    def test_replace_bool_with_string_no_op(self):
-        s = Series([True, False, True])
-        result = s.replace('fun', 'in-the-sun')
-        tm.assert_series_equal(s, result)
-
-    def test_replace_bool_with_string(self):
-        # nonexistent elements
-        s = Series([True, False, True])
-        result = s.replace(True, '2u')
-        expected = Series(['2u', False, '2u'])
-        tm.assert_series_equal(expected, result)
-
-    def test_replace_bool_with_bool(self):
-        s = Series([True, False, True])
-        result = s.replace(True, False)
-        expected = Series([False] * len(s))
-        tm.assert_series_equal(expected, result)
-
-    def test_replace_with_dict_with_bool_keys(self):
-        s = Series([True, False, True])
-        result = s.replace({'asdf': 'asdb', True: 'yes'})
-        expected = Series(['yes', False, 'yes'])
-        tm.assert_series_equal(expected, result)
 
     def test_asfreq(self):
         ts = Series([0., 1., 2.], index=[datetime(2009, 10, 30),

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -3950,6 +3950,52 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         exp = iseries.astype(float).rank()
         assert_series_equal(iranks, exp)
 
+    def test_rank_methods(self):
+
+        ser = Series([0,0,1,2,3])
+
+        ranked_average = ser.rank(method='average')
+        expect_average = Series([ 1.5,  1.5,  3. ,  4. ,  5. ])
+        assert_series_equal(ranked_average, expect_average)
+
+        ranked_min = ser.rank(method='min')
+        expect_min = Series([ 1.,  1.,  3.,  4.,  5.])
+        assert_series_equal(ranked_min, expect_min)
+
+        ranked_max = ser.rank(method='max')
+        expect_max = Series([ 2.,  2.,  3.,  4.,  5.])
+        assert_series_equal(ranked_max, expect_max)
+
+        ranked_first = ser.rank(method='first')
+        expect_first = Series([ 1.,  2.,  3.,  4.,  5.])
+        assert_series_equal(ranked_first, expect_first)
+
+        ranked_dense = ser.rank(method='dense')
+        expect_dense = Series([ 1.,  1.,  2.,  3.,  4.])
+        assert_series_equal(ranked_dense, expect_dense)
+
+        ser = Series([2., 6., 3., 9., 2.])
+
+        ranked_average = ser.rank(method='average')
+        expect_average = Series([ 1.5,  4. ,  3. ,  5. ,  1.5])
+        assert_series_equal(ranked_average, expect_average)
+
+        ranked_min = ser.rank(method='min')
+        expect_min = Series([ 1.,  4.,  3.,  5.,  1.])
+        assert_series_equal(ranked_min, expect_min)
+
+        ranked_max = ser.rank(method='max')
+        expect_max = Series([ 2.,  4.,  3.,  5.,  2.])
+        assert_series_equal(ranked_max, expect_max)
+
+        ranked_first = ser.rank(method='first')
+        expect_first = Series([ 1.,  4.,  3.,  5.,  2.])
+        assert_series_equal(ranked_first, expect_first)
+
+        ranked_dense = ser.rank(method='dense')
+        expect_dense = Series([ 1.,  3.,  2.,  4.,  1.])
+        assert_series_equal(ranked_dense, expect_dense)
+        
     def test_from_csv(self):
 
         with ensure_clean() as path:

--- a/pandas/tests/test_stats.py
+++ b/pandas/tests/test_stats.py
@@ -23,7 +23,8 @@ class TestRank(tm.TestCase):
                              3.5, 1.5, 8.0, nan, 5.5]),
         'min': np.array([1, 5, 7, 3, nan, 3, 1, 8, nan, 5]),
         'max': np.array([2, 6, 7, 4, nan, 4, 2, 8, nan, 6]),
-        'first': np.array([1, 5, 7, 3, nan, 4, 2, 8, nan, 6])
+        'first': np.array([1, 5, 7, 3, nan, 4, 2, 8, nan, 6]),
+        'dense': np.array([1, 3, 4, 2, nan, 2, 1, 5, nan, 3])
     }
 
     def test_rank_tie_methods(self):


### PR DESCRIPTION
This adds a `method='dense'` option to `rank` which does the same thing as the one in `scipy.stats.rankdata`: the first ranked group gets 1, the second 2, etc.  Basically it ports the approach used in `scipy.stats._rankdata_fused` to the pandas rankdata implementation.

It also adds a few tests that the various methods do what they're supposed to, which I couldn't find a test for before.

closes #6333
