### PR TITLE
BUG: TimeGrouper sortedness / API fix (GH4161,GH3881)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -97,6 +97,9 @@ Bug Fixes
   ``to_replace`` argument (:issue:`6332`)
 - Raise when trying to align on different levels of a multi-index assignment (:issue:`3738`)
 - Bug in setting complex dtypes via boolean indexing (:issue:`6345`)
+- Bug in TimeGrouper/resample when presented with a non-monotonic DatetimeIndex would return invalid results. (:issue:`4161`)
+- Bug in index name propogation in TimeGrouper/resample (:issue:`4161`)
+- TimeGrouper has a more compatible API to the rest of the groupers (e.g. ``groups`` was missing) (:issue:`3881`)
 
 pandas 0.13.1
 -------------

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -1100,7 +1100,7 @@ class TestTimeGrouper(tm.TestCase):
         df = DataFrame({'open': 1, 'close': 2}, index=ind)
         tg = TimeGrouper('M')
 
-        grouper = tg.get_grouper(df)
+        _, grouper, _ = tg.get_grouper(df)
 
         # Errors
 
@@ -1118,7 +1118,7 @@ class TestTimeGrouper(tm.TestCase):
                       minor_axis=['A', 'B', 'C', 'D'])
 
         tg = TimeGrouper('M', axis=1)
-        grouper = tg.get_grouper(wp)
+        _, grouper, _ = tg.get_grouper(wp)
         bingrouped = wp.groupby(grouper)
         binagg = bingrouped.mean()
 


### PR DESCRIPTION
BUG: Bug in TimeGrouper/resample when presented with a non-monotonic DatetimeIndex would return invalid results,
BUG: Bug in index name propogation in TimeGrouper/resample
closes #4161

API: TimeGrouper has a more compatible API to the rest of the groupers (e.g. `groups` was missing) 
closes #3881
