### PR TITLE
ENH: fix eval scoping issues

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -83,8 +83,25 @@ API Changes
   - ``pd.infer_freq()``
 - ``pd.infer_freq()`` will now raise a ``TypeError`` if given an invalid ``Series/Index`` type (:issue:`6407`)
 
+- Local variable usage has changed in
+  :func:`pandas.eval`/:meth:`DataFrame.eval`/:meth:`DataFrame.query`
+  (:issue:`5987`). For the :class:`~pandas.DataFrame` methods, two things have
+  changed
+
+   - Column names are now given precedence over locals
+   - Local variables must be referred to explicitly. This means that even if
+     you have a local variable that is *not* a column you must still refer to
+     it with the ``'@'`` prefix.
+   - You can have an expression like ``df.query('@a < a')`` with no complaints
+     from ``pandas`` about ambiguity of the name ``a``.
+
+- The top-level :func:`pandas.eval` function does not allow you use the
+  ``'@'`` prefix and provides you with an error message telling you so.
+- ``NameResolutionError`` was removed because it isn't necessary anymore.
+
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~
+
 
 Improvements to existing features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -144,6 +161,8 @@ Bug Fixes
 - Bug in DataFrame.dropna with duplicate indices (:issue:`6355`)
 - Regression in chained getitem indexing with embedded list-like from 0.12 (:issue:`6394`)
 - ``Float64Index`` with nans not comparing correctly
+- ``eval``/``query`` expressions with strings containing the ``@`` character
+  will now work (:issue:`6366`).
 
 pandas 0.13.1
 -------------

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -51,6 +51,22 @@ API changes
      s.year
      s.index.year
 
+- Local variable usage has changed in
+  :func:`pandas.eval`/:meth:`DataFrame.eval`/:meth:`DataFrame.query`
+  (:issue:`5987`). For the :class:`~pandas.DataFrame` methods, two things have
+  changed
+
+   - Column names are now given precedence over locals
+   - Local variables must be referred to explicitly. This means that even if
+     you have a local variable that is *not* a column you must still refer to
+     it with the ``'@'`` prefix.
+   - You can have an expression like ``df.query('@a < a')`` with no complaints
+     from ``pandas`` about ambiguity of the name ``a``.
+
+- The top-level :func:`pandas.eval` function does not allow you use the
+  ``'@'`` prefix and provides you with an error message telling you so.
+- ``NameResolutionError`` was removed because it isn't necessary anymore.
+
 MultiIndexing Using Slicers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -54,6 +54,8 @@ except ImportError:
     import pickle as cPickle
     import http.client as httplib
 
+from chainmap import DeepChainMap
+
 
 if PY3:
     def isidentifier(s):

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -54,7 +54,7 @@ except ImportError:
     import pickle as cPickle
     import http.client as httplib
 
-from chainmap import DeepChainMap
+from pandas.compat.chainmap import DeepChainMap
 
 
 if PY3:

--- a/pandas/compat/chainmap.py
+++ b/pandas/compat/chainmap.py
@@ -1,0 +1,20 @@
+try:
+    from collections import ChainMap
+except ImportError:
+    from chainmap_impl import ChainMap
+
+
+class DeepChainMap(ChainMap):
+    def __setitem__(self, key, value):
+        for mapping in self.maps:
+            if key in mapping:
+                mapping[key] = value
+                return
+        self.maps[0][key] = value
+
+    def __delitem__(self, key):
+        for mapping in self.maps:
+            if key in mapping:
+                del mapping[key]
+                return
+        raise KeyError(key)

--- a/pandas/compat/chainmap.py
+++ b/pandas/compat/chainmap.py
@@ -1,7 +1,7 @@
 try:
     from collections import ChainMap
 except ImportError:
-    from chainmap_impl import ChainMap
+    from pandas.compat.chainmap_impl import ChainMap
 
 
 class DeepChainMap(ChainMap):
@@ -18,3 +18,9 @@ class DeepChainMap(ChainMap):
                 del mapping[key]
                 return
         raise KeyError(key)
+
+    # override because the m parameter is introduced in Python 3.4
+    def new_child(self, m=None):
+        if m is None:
+            m = {}
+        return self.__class__(m, *self.maps)

--- a/pandas/compat/chainmap_impl.py
+++ b/pandas/compat/chainmap_impl.py
@@ -1,0 +1,132 @@
+from collections import MutableMapping
+from thread import get_ident
+
+
+def recursive_repr(fillvalue='...'):
+    'Decorator to make a repr function return fillvalue for a recursive call'
+
+    def decorating_function(user_function):
+        repr_running = set()
+
+        def wrapper(self):
+            key = id(self), get_ident()
+            if key in repr_running:
+                return fillvalue
+            repr_running.add(key)
+            try:
+                result = user_function(self)
+            finally:
+                repr_running.discard(key)
+            return result
+
+        # Can't use functools.wraps() here because of bootstrap issues
+        wrapper.__module__ = getattr(user_function, '__module__')
+        wrapper.__doc__ = getattr(user_function, '__doc__')
+        wrapper.__name__ = getattr(user_function, '__name__')
+        return wrapper
+
+    return decorating_function
+
+
+class ChainMap(MutableMapping):
+    ''' A ChainMap groups multiple dicts (or other mappings) together
+    to create a single, updateable view.
+
+    The underlying mappings are stored in a list.  That list is public and can
+    accessed or updated using the *maps* attribute.  There is no other state.
+
+    Lookups search the underlying mappings successively until a key is found.
+    In contrast, writes, updates, and deletions only operate on the first
+    mapping.
+
+    '''
+
+    def __init__(self, *maps):
+        '''Initialize a ChainMap by setting *maps* to the given mappings.
+        If no mappings are provided, a single empty dictionary is used.
+
+        '''
+        self.maps = list(maps) or [{}]          # always at least one map
+
+    def __missing__(self, key):
+        raise KeyError(key)
+
+    def __getitem__(self, key):
+        for mapping in self.maps:
+            try:
+                return mapping[key]             # can't use 'key in mapping' with defaultdict
+            except KeyError:
+                pass
+        return self.__missing__(key)            # support subclasses that define __missing__
+
+    def get(self, key, default=None):
+        return self[key] if key in self else default
+
+    def __len__(self):
+        return len(set().union(*self.maps))     # reuses stored hash values if possible
+
+    def __iter__(self):
+        return iter(set().union(*self.maps))
+
+    def __contains__(self, key):
+        return any(key in m for m in self.maps)
+
+    def __bool__(self):
+        return any(self.maps)
+
+    @recursive_repr()
+    def __repr__(self):
+        return '{0.__class__.__name__}({1})'.format(
+            self, ', '.join(repr(m) for m in self.maps))
+
+    @classmethod
+    def fromkeys(cls, iterable, *args):
+        'Create a ChainMap with a single dict created from the iterable.'
+        return cls(dict.fromkeys(iterable, *args))
+
+    def copy(self):
+        'New ChainMap or subclass with a new copy of maps[0] and refs to maps[1:]'
+        return self.__class__(self.maps[0].copy(), *self.maps[1:])
+
+    __copy__ = copy
+
+    def new_child(self, m=None):                # like Django's Context.push()
+        '''
+        New ChainMap with a new map followed by all previous maps. If no
+        map is provided, an empty dict is used.
+        '''
+        if m is None:
+            m = {}
+        return self.__class__(m, *self.maps)
+
+    @property
+    def parents(self):                          # like Django's Context.pop()
+        'New ChainMap from maps[1:].'
+        return self.__class__(*self.maps[1:])
+
+    def __setitem__(self, key, value):
+        self.maps[0][key] = value
+
+    def __delitem__(self, key):
+        try:
+            del self.maps[0][key]
+        except KeyError:
+            raise KeyError('Key not found in the first mapping: {!r}'.format(key))
+
+    def popitem(self):
+        'Remove and return an item pair from maps[0]. Raise KeyError is maps[0] is empty.'
+        try:
+            return self.maps[0].popitem()
+        except KeyError:
+            raise KeyError('No keys found in the first mapping.')
+
+    def pop(self, key, *args):
+        'Remove *key* from maps[0] and return its value. Raise KeyError if *key* not in maps[0].'
+        try:
+            return self.maps[0].pop(key, *args)
+        except KeyError:
+            raise KeyError('Key not found in the first mapping: {!r}'.format(key))
+
+    def clear(self):
+        'Clear maps[0], leaving maps[1:] intact.'
+        self.maps[0].clear()

--- a/pandas/compat/chainmap_impl.py
+++ b/pandas/compat/chainmap_impl.py
@@ -1,5 +1,9 @@
 from collections import MutableMapping
-from thread import get_ident
+
+try:
+    from thread import get_ident
+except ImportError:
+    from _thread import get_ident
 
 
 def recursive_repr(fillvalue='...'):

--- a/pandas/computation/eval.py
+++ b/pandas/computation/eval.py
@@ -3,9 +3,11 @@
 """Top level ``eval`` module.
 """
 
-
+import sys
 from pandas.core import common as com
-from pandas.computation.expr import Expr, _parsers, _ensure_scope
+from pandas.computation.expr import Expr, _parsers
+from pandas.computation.scope import _ensure_scope
+from pandas.compat import DeepChainMap, builtins
 from pandas.computation.engines import _engines
 from distutils.version import LooseVersion
 
@@ -117,7 +119,7 @@ def _convert_expression(expr):
 
 
 def eval(expr, parser='pandas', engine='numexpr', truediv=True,
-         local_dict=None, global_dict=None, resolvers=None, level=2,
+         local_dict=None, global_dict=None, resolvers=(), level=0,
          target=None):
     """Evaluate a Python expression as a string using various backends.
 
@@ -200,8 +202,10 @@ def eval(expr, parser='pandas', engine='numexpr', truediv=True,
     _check_resolvers(resolvers)
 
     # get our (possibly passed-in) scope
-    env = _ensure_scope(global_dict=global_dict, local_dict=local_dict,
-                        resolvers=resolvers, level=level, target=target)
+    level += 1
+    env = _ensure_scope(level, global_dict=global_dict,
+                        local_dict=local_dict, resolvers=resolvers,
+                        target=target)
 
     parsed_expr = Expr(expr, engine=engine, parser=parser, env=env,
                        truediv=truediv)

--- a/pandas/computation/eval.py
+++ b/pandas/computation/eval.py
@@ -3,7 +3,6 @@
 """Top level ``eval`` module.
 """
 
-import sys
 import tokenize
 from pandas.core import common as com
 from pandas.computation.expr import Expr, _parsers, tokenize_string
@@ -127,7 +126,7 @@ def _check_for_locals(expr, stack_level, parser):
         msg = "The '@' prefix is only supported by the pandas parser"
     elif at_top_of_stack:
         msg = ("The '@' prefix is not allowed in "
-               "top-level eval calls, please refer to "
+               "top-level eval calls, \nplease refer to "
                "your variables by name without the '@' "
                "prefix")
 

--- a/pandas/computation/expr.py
+++ b/pandas/computation/expr.py
@@ -23,13 +23,16 @@ from pandas.computation.ops import UndefinedVariableError
 from pandas.computation.scope import Scope, _ensure_scope
 
 
+def tokenize_string(s):
+    return tokenize.generate_tokens(StringIO(s).readline)
+
+
 def _rewrite_assign(source):
     """Rewrite the assignment operator for PyTables expression that want to use
     ``=`` as a substitute for ``==``.
     """
     res = []
-    g = tokenize.generate_tokens(StringIO(source).readline)
-    for toknum, tokval, _, _, _ in g:
+    for toknum, tokval, _, _, _ in tokenize_string(source):
         res.append((toknum, '==' if tokval == '=' else tokval))
     return tokenize.untokenize(res)
 
@@ -39,8 +42,7 @@ def _replace_booleans(source):
     precedence is changed to boolean precedence.
     """
     res = []
-    g = tokenize.generate_tokens(StringIO(source).readline)
-    for toknum, tokval, _, _, _ in g:
+    for toknum, tokval, _, _, _ in tokenize_string(source):
         if toknum == tokenize.OP:
             if tokval == '&':
                 res.append((tokenize.NAME, 'and'))
@@ -54,7 +56,7 @@ def _replace_booleans(source):
 
 
 def _replace_locals(source, local_symbol='@'):
-    """Replace local variables with a syntacticall valid name."""
+    """Replace local variables with a syntactically valid name."""
     return source.replace(local_symbol, _LOCAL_TAG)
 
 

--- a/pandas/computation/expr.py
+++ b/pandas/computation/expr.py
@@ -631,7 +631,7 @@ class BaseExprVisitor(ast.NodeVisitor):
 
         try:
             assigner = self.visit(node.targets[0], **kwargs)
-        except UndefinedVariableError:
+        except (UndefinedVariableError, KeyError):
             assigner = node.targets[0].id
 
         self.assigner = getattr(assigner, 'name', assigner)
@@ -639,6 +639,7 @@ class BaseExprVisitor(ast.NodeVisitor):
             raise SyntaxError('left hand side of an assignment must be a '
                               'single resolvable name')
 
+        import ipdb; ipdb.set_trace()
         return self.visit(node.value, **kwargs)
 
     def visit_Attribute(self, node, **kwargs):

--- a/pandas/computation/pytables.py
+++ b/pandas/computation/pytables.py
@@ -7,25 +7,24 @@ from functools import partial
 from datetime import datetime, timedelta
 import numpy as np
 import pandas as pd
-from pandas.compat import u, string_types, PY3
+from pandas.compat import u, string_types, PY3, DeepChainMap
 from pandas.core.base import StringMixin
 import pandas.core.common as com
 from pandas.computation import expr, ops
 from pandas.computation.ops import is_term
+from pandas.computation.scope import _ensure_scope
 from pandas.computation.expr import BaseExprVisitor
 from pandas.computation.common import _ensure_decoded
 from pandas.tseries.timedeltas import _coerce_scalar_to_timedelta_type
 
 
 class Scope(expr.Scope):
-    __slots__ = 'globals', 'locals', 'queryables'
+    __slots__ = 'queryables',
 
-    def __init__(self, gbls=None, lcls=None, queryables=None, level=1):
-        super(
-            Scope,
-            self).__init__(gbls=gbls,
-                           lcls=lcls,
-                           level=level)
+    def __init__(self, level, global_dict=None, local_dict=None,
+                 queryables=None):
+        super(Scope, self).__init__(level + 1, global_dict=global_dict,
+                                    local_dict=local_dict)
         self.queryables = queryables or dict()
 
 
@@ -48,9 +47,8 @@ class Term(ops.Term):
                 raise NameError('name {0!r} is not defined'.format(self.name))
             return self.name
 
-        # resolve the rhs (and allow to be None)
-        return self.env.locals.get(self.name,
-                                   self.env.globals.get(self.name, self.name))
+        # resolve the rhs (and allow it to be None)
+        return self.env.resolve(self.name, is_local=False)
 
     @property
     def value(self):
@@ -478,7 +476,7 @@ class Expr(expr.Expr):
     """
 
     def __init__(self, where, op=None, value=None, queryables=None,
-                 encoding=None, scope_level=None):
+                 encoding=None, scope_level=0):
 
         # try to be back compat
         where = self.parse_back_compat(where, op, value)
@@ -488,25 +486,25 @@ class Expr(expr.Expr):
         self.filter = None
         self.terms = None
         self._visitor = None
-        # capture the environement if needed
-        lcls = dict()
-        if isinstance(where, Expr):
 
-            lcls.update(where.env.locals)
+        # capture the environment if needed
+        local_dict = dict()
+
+        if isinstance(where, Expr):
+            local_dict.update(where.env.scope)
             where = where.expr
 
         elif isinstance(where, (list, tuple)):
             for idx, w in enumerate(where):
                 if isinstance(w, Expr):
-                    lcls.update(w.env.locals)
+                    local_dict.update(w.env.scope)
                 else:
                     w = self.parse_back_compat(w)
                     where[idx] = w
             where = ' & ' .join(["(%s)" % w for w in where])
 
         self.expr = where
-        self.env = Scope(lcls=lcls)
-        self.env.update(scope_level)
+        self.env = Scope(scope_level + 1, local_dict=local_dict)
 
         if queryables is not None and isinstance(self.expr, string_types):
             self.env.queryables.update(queryables)
@@ -535,7 +533,7 @@ class Expr(expr.Expr):
             warnings.warn("passing a tuple into Expr is deprecated, "
                           "pass the where as a single string",
                           DeprecationWarning)
-                
+
         if op is not None:
             if not isinstance(w, string_types):
                 raise TypeError(

--- a/pandas/computation/pytables.py
+++ b/pandas/computation/pytables.py
@@ -11,7 +11,7 @@ from pandas.compat import u, string_types, PY3, DeepChainMap
 from pandas.core.base import StringMixin
 import pandas.core.common as com
 from pandas.computation import expr, ops
-from pandas.computation.ops import is_term
+from pandas.computation.ops import is_term, UndefinedVariableError
 from pandas.computation.scope import _ensure_scope
 from pandas.computation.expr import BaseExprVisitor
 from pandas.computation.common import _ensure_decoded
@@ -48,7 +48,10 @@ class Term(ops.Term):
             return self.name
 
         # resolve the rhs (and allow it to be None)
-        return self.env.resolve(self.name, is_local=False)
+        try:
+            return self.env.resolve(self.name, is_local=False)
+        except UndefinedVariableError:
+            return self.name
 
     @property
     def value(self):

--- a/pandas/computation/pytables.py
+++ b/pandas/computation/pytables.py
@@ -491,16 +491,16 @@ class Expr(expr.Expr):
         self._visitor = None
 
         # capture the environment if needed
-        local_dict = dict()
+        local_dict = DeepChainMap()
 
         if isinstance(where, Expr):
-            local_dict.update(where.env.scope)
+            local_dict = where.env.scope
             where = where.expr
 
         elif isinstance(where, (list, tuple)):
             for idx, w in enumerate(where):
                 if isinstance(w, Expr):
-                    local_dict.update(w.env.scope)
+                    local_dict = w.env.scope
                 else:
                     w = self.parse_back_compat(w)
                     where[idx] = w

--- a/pandas/computation/scope.py
+++ b/pandas/computation/scope.py
@@ -10,7 +10,7 @@ import itertools
 import pprint
 
 import pandas as pd
-from pandas.compat import DeepChainMap, map
+from pandas.compat import DeepChainMap, map, StringIO
 from pandas.core import common as com
 from pandas.core.base import StringMixin
 from pandas.computation.ops import UndefinedVariableError, _LOCAL_TAG
@@ -117,11 +117,11 @@ class Scope(StringMixin):
             # shallow copy here because we don't want to replace what's in
             # scope when we align terms (alignment accesses the underlying
             # numpy array of pandas objects)
+            self.scope = self.scope.new_child((global_dict or
+                                               frame.f_globals).copy())
             if not isinstance(local_dict, Scope):
                 self.scope = self.scope.new_child((local_dict or
                                                    frame.f_locals).copy())
-            self.scope = self.scope.new_child((global_dict or
-                                               frame.f_globals).copy())
         finally:
             del frame
 
@@ -132,8 +132,8 @@ class Scope(StringMixin):
         self.temps = {}
 
     def __unicode__(self):
-        scope_keys = _get_pretty_string(self.scope.keys())
-        res_keys = _get_pretty_string(self.resolvers.keys())
+        scope_keys = _get_pretty_string(list(self.scope.keys()))
+        res_keys = _get_pretty_string(list(self.resolvers.keys()))
         return '%s(scope=%s, resolvers=%s)' % (type(self).__name__, scope_keys,
                                                res_keys)
 

--- a/pandas/computation/scope.py
+++ b/pandas/computation/scope.py
@@ -1,0 +1,240 @@
+"""Module for scope operations
+"""
+
+import sys
+import operator
+import struct
+import inspect
+import datetime
+import itertools
+import pprint
+
+import pandas as pd
+from pandas.compat import DeepChainMap, map
+from pandas.core import common as com
+from pandas.core.base import StringMixin
+from pandas.computation.ops import UndefinedVariableError
+
+
+def _ensure_scope(level, global_dict=None, local_dict=None, resolvers=(),
+                  target=None, **kwargs):
+    """Ensure that we are grabbing the correct scope."""
+    return Scope(level + 1, gbls=global_dict, lcls=local_dict,
+                 resolvers=resolvers, target=target)
+
+
+def _replacer(x, pad_size):
+    """Replace a number with its padded hexadecimal representation. Used to tag
+    temporary variables with their calling scope's id.
+    """
+    # get the hex repr of the binary char and remove 0x and pad by pad_size
+    # zeros
+    try:
+        hexin = ord(x)
+    except TypeError:
+        # bytes literals masquerade as ints when iterating in py3
+        hexin = x
+
+    return hex(hexin).replace('0x', '').rjust(pad_size, '0')
+
+
+def _raw_hex_id(obj, pad_size=2):
+    """Return the padded hexadecimal id of ``obj``."""
+    # interpret as a pointer since that's what really what id returns
+    packed = struct.pack('@P', id(obj))
+    return ''.join(_replacer(x, pad_size) for x in packed)
+
+
+
+_DEFAULT_GLOBALS = {
+    'Timestamp': pd.lib.Timestamp,
+    'datetime': datetime.datetime,
+    'True': True,
+    'False': False,
+    'list': list,
+    'tuple': tuple
+}
+
+
+def _is_resolver(x):
+    return isinstance(x, Resolver)
+
+
+def _get_pretty_string(obj):
+    sio = StringIO()
+    pprint.pprint(obj, stream=sio)
+    return sio.getvalue()
+
+
+class Scope(StringMixin):
+
+    """Object to hold scope, with a few bells to deal with some custom syntax
+    added by pandas.
+
+    Parameters
+    ----------
+    gbls : dict or None, optional, default None
+    lcls : dict or Scope or None, optional, default None
+    level : int, optional, default 1
+    resolvers : list-like or None, optional, default None
+
+    Attributes
+    ----------
+    globals : dict
+    locals : dict
+    level : int
+    resolvers : tuple
+    resolver_keys : frozenset
+    """
+    __slots__ = 'level', 'scope', 'target', 'ntemps'
+
+    def __init__(self, level, gbls=None, lcls=None, resolvers=(), target=None):
+        self.level = level + 1
+
+        # shallow copy because we don't want to keep filling this up with what
+        # was there before if there are multiple calls to Scope/_ensure_scope
+        self.scope = DeepChainMap(_DEFAULT_GLOBALS.copy())
+        self.target = target
+        self.ntemps = 0  # number of temporary variables in this scope
+
+        if isinstance(lcls, Scope):
+            self.scope.update(lcls.scope)
+            if lcls.target is not None:
+                self.target = lcls.target
+            self.update(lcls.level)
+
+        frame = sys._getframe(self.level)
+
+        try:
+            # shallow copy here because we don't want to replace what's in
+            # scope when we align terms (alignment accesses the underlying
+            # numpy array of pandas objects)
+            if not isinstance(lcls, Scope):
+                self.scope = self.scope.new_child((lcls or frame.f_locals).copy())
+            self.scope = self.scope.new_child((gbls or frame.f_globals).copy())
+        finally:
+            del frame
+
+        # assumes that resolvers are going from outermost scope to inner
+        if isinstance(lcls, Scope):
+            resolvers += tuple(lcls.resolvers.maps)
+        self.resolvers = DeepChainMap(*resolvers)
+
+    def __unicode__(self):
+        scope_keys = _get_pretty_string(self.scope.keys())
+        res_keys = _get_pretty_string(self.resolvers.keys())
+        return 'Scope(scope=%s, resolvers=%s)' % (scope_keys, res_keys)
+
+    @property
+    def has_resolvers(self):
+        return bool(self.nresolvers)
+
+    @property
+    def nresolvers(self):
+        return len(self.resolvers)
+
+    def resolve(self, key, is_local):
+        """Resolve a variable name in a possibly local context
+
+        Parameters
+        ----------
+        key : text_type
+            A variable name
+        is_local : bool
+            Flag indicating whether the variable is local or not (prefixed with
+            the '@' symbol)
+
+        Returns
+        -------
+        value : object
+            The value of a particular variable
+        """
+        try:
+            # only look for locals in outer scope
+            if is_local:
+                return self.scope[key]
+
+            # not a local variable so check in resolvers if we have them
+            if self.has_resolvers:
+                return self.resolvers[key]
+
+            # if we're here that means that we have no locals and we also have
+            # no resolvers
+            assert not is_local and not self.has_resolvers
+            return self.scope[key]
+        except KeyError:
+            raise UndefinedVariableError(key)
+
+    def swapkey(self, old_key, new_key, new_value=None):
+        if self.has_resolvers:
+            maps = self.resolvers.maps + self.scope.maps
+        else:
+            maps = self.scope.maps
+
+        for mapping in maps:
+            if old_key in mapping:
+                if new_value is None:
+                    mapping[new_key] = mapping.pop(old_key)
+                else:
+                    mapping[new_key] = new_value
+                return
+        raise KeyError(old_key)
+
+    def _get_vars(self, stack, scopes):
+        variables = itertools.product(scopes, stack)
+        for scope, (frame, _, _, _, _, _) in variables:
+            try:
+                d = getattr(frame, 'f_' + scope)
+                self.scope = self.scope.new_child(d)
+            finally:
+                # won't remove it, but DECREF it
+                # in Py3 this probably isn't necessary since frame won't be
+                # scope after the loop
+                del frame
+
+    def update(self, level):
+        """Update the current scope by going back `level` levels.
+
+        Parameters
+        ----------
+        level : int or None, optional, default None
+        """
+        sl = level + 1
+
+        # add sl frames to the scope starting with the
+        # most distant and overwriting with more current
+        # makes sure that we can capture variable scope
+        stack = inspect.stack()
+
+        try:
+            self._get_vars(stack[:sl], scopes=['locals'])
+        finally:
+            del stack[:], stack
+
+    def add_tmp(self, value):
+        """Add a temporary variable to the scope.
+
+        Parameters
+        ----------
+        value : object
+            An arbitrary object to be assigned to a temporary variable.
+
+        Returns
+        -------
+        name : basestring
+            The name of the temporary variable created.
+        """
+        name = 'tmp_var_{0}_{1}_{2}'.format(type(value).__name__, self.ntemps,
+                                            _raw_hex_id(self))
+
+        # add to inner most scope
+        assert name not in self.scope.maps[0]
+        self.scope.maps[0][name] = value
+
+        # only increment if the variable gets put in the scope
+        self.ntemps += 1
+        return name
+
+    def remove_tmp(self, name):
+        del self.scope[name]
+        self.ntemps -= 1

--- a/pandas/computation/tests/test_eval.py
+++ b/pandas/computation/tests/test_eval.py
@@ -1556,6 +1556,25 @@ def test_invalid_numexpr_version():
         yield check_invalid_numexpr_version, engine, parser
 
 
+def check_invalid_local_variable_reference(engine, parser):
+    tm.skip_if_no_ne(engine)
+
+    a, b = 1, 2
+    exprs = 'a + @b', '@a + b', '@a + @b'
+    for expr in exprs:
+        if parser != 'pandas':
+            with tm.assertRaisesRegexp(SyntaxError, "The '@' prefix is only"):
+                pd.eval(exprs, engine=engine, parser=parser)
+        else:
+            with tm.assertRaisesRegexp(SyntaxError, "The '@' prefix is not"):
+                pd.eval(exprs, engine=engine, parser=parser)
+
+
+def test_invalid_local_variable_reference():
+    for engine, parser in ENGINES_PARSERS:
+        yield check_invalid_local_variable_reference, engine, parser
+
+
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
                    exit=False)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1738,26 +1738,30 @@ class DataFrame(NDFrame):
     def query(self, expr, **kwargs):
         """Query the columns of a frame with a boolean expression.
 
+        .. versionadded:: 0.13
+
         Parameters
         ----------
         expr : string
-            The query string to evaluate. The result of the evaluation of this
-            expression is first passed to :attr:`~pandas.DataFrame.loc` and if
-            that fails because of a multidimensional key (e.g., a DataFrame)
-            then the result will be passed to
-            :meth:`~pandas.DataFrame.__getitem__`.
+            The query string to evaluate.  You can refer to variables
+            in the environment by prefixing them with an '@' character like
+            ``@a + b``.
         kwargs : dict
-            See the documentation for :func:`~pandas.eval` for complete details
-            on the keyword arguments accepted by
-            :meth:`~pandas.DataFrame.query`.
+            See the documentation for :func:`pandas.eval` for complete details
+            on the keyword arguments accepted by :meth:`DataFrame.query`.
 
         Returns
         -------
-        q : DataFrame or Series
+        q : DataFrame
 
         Notes
         -----
-        This method uses the top-level :func:`~pandas.eval` function to
+        The result of the evaluation of this expression is first passed to
+        :attr:`DataFrame.loc` and if that fails because of a
+        multidimensional key (e.g., a DataFrame) then the result will be passed
+        to :meth:`DataFrame.__getitem__`.
+
+        This method uses the top-level :func:`pandas.eval` function to
         evaluate the passed query.
 
         The :meth:`~pandas.DataFrame.query` method uses a slightly
@@ -1773,12 +1777,12 @@ class DataFrame(NDFrame):
         recommended as it is inefficient compared to using ``numexpr`` as the
         engine.
 
-        The :attr:`~pandas.DataFrame.index` and
-        :attr:`~pandas.DataFrame.columns` attributes of the
-        :class:`~pandas.DataFrame` instance is placed in the namespace by
-        default, which allows you to treat both the index and columns of the
+        The :attr:`DataFrame.index` and
+        :attr:`DataFrame.columns` attributes of the
+        :class:`~pandas.DataFrame` instance are placed in the query namespace
+        by default, which allows you to treat both the index and columns of the
         frame as a column in the frame.
-        The identifier ``index`` is used for this variable, and you can also
+        The identifier ``index`` is used for the frame index; you can also
         use the name of the index to identify it in a query.
 
         For further details and examples see the ``query`` documentation in
@@ -1797,12 +1801,6 @@ class DataFrame(NDFrame):
         >>> df.query('a > b')
         >>> df[df.a > df.b]  # same result as the previous expression
         """
-        # need to go up at least 4 stack frames
-        # 4 expr.Scope
-        # 3 expr._ensure_scope
-        # 2 self.eval
-        # 1 self.query
-        # 0 self.query caller (implicit)
         kwargs['level'] = kwargs.pop('level', 0) + 1
         res = self.eval(expr, **kwargs)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -350,7 +350,7 @@ class NDFrame(PandasObject):
         d[axis] = dindex
         return d
 
-    def _get_resolvers(self):
+    def _get_index_resolvers(self):
         d = {}
         for axis_name in self._AXIS_ORDERS:
             d.update(self._get_axis_resolvers(axis_name))

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -81,7 +81,7 @@ def _ensure_term(where, scope_level):
         where = [w if not maybe_expression(w) else Term(w, scope_level=level)
                  for w in where if w is not None]
     elif maybe_expression(where):
-        where = Term(where, level)
+        where = Term(where, scope_level=level)
     return where
 
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -30,7 +30,7 @@ from pandas.tseries.timedeltas import _coerce_scalar_to_timedelta_type
 import pandas.core.common as com
 from pandas.tools.merge import concat
 from pandas import compat
-from pandas.compat import u_safe as u, PY3, range, lrange, string_types
+from pandas.compat import u_safe as u, PY3, range, lrange, string_types, filter
 from pandas.io.common import PerformanceWarning
 from pandas.core.config import get_option
 from pandas.computation.pytables import Expr, maybe_expression
@@ -78,8 +78,13 @@ def _ensure_term(where, scope_level):
     # list
     level = scope_level + 1
     if isinstance(where, (list, tuple)):
-        where = [w if not maybe_expression(w) else Term(w, scope_level=level)
-                 for w in where if w is not None]
+        wlist = []
+        for w in filter(lambda x: x is not None, where):
+            if not maybe_expression(w):
+                wlist.append(w)
+            else:
+                wlist.append(Term(w, scope_level=level))
+        where = wlist
     elif maybe_expression(where):
         where = Term(where, scope_level=level)
     return where

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -59,6 +59,7 @@ def create_tempfile(path):
     """ create an unopened named temporary file """
     return os.path.join(tempfile.gettempdir(),path)
 
+
 @contextmanager
 def ensure_clean_store(path, mode='a', complevel=None, complib=None,
               fletcher32=False):
@@ -77,6 +78,7 @@ def ensure_clean_store(path, mode='a', complevel=None, complib=None,
         if mode == 'w' or mode == 'a':
             safe_remove(path)
 
+
 @contextmanager
 def ensure_clean_path(path):
     """
@@ -94,6 +96,7 @@ def ensure_clean_path(path):
     finally:
         for f in filenames:
             safe_remove(f)
+
 
 # set these parameters so we don't have file sharing
 tables.parameters.MAX_NUMEXPR_THREADS = 1
@@ -255,7 +258,6 @@ class TestHDFStore(tm.TestCase):
 
             self.assertRaises(TypeError, df.to_hdf, path,'df',append=True,format='foo')
             self.assertRaises(TypeError, df.to_hdf, path,'df',append=False,format='bar')
-
 
     def test_api_default_format(self):
 
@@ -2257,7 +2259,6 @@ class TestHDFStore(tm.TestCase):
             expected = wp.reindex(major_axis=wp.major_axis-wp.major_axis[np.arange(0,20,3)])
             assert_panel_equal(result, expected)
 
-
     def test_remove_crit(self):
 
         with ensure_clean_store(self.path) as store:
@@ -2517,7 +2518,7 @@ class TestHDFStore(tm.TestCase):
                 result = store.select('wp', [('minor_axis','=',['A','B'])])
             expected = wp.loc[:,:,['A','B']]
             assert_panel_equal(result, expected)
-            
+
     def test_same_name_scoping(self):
 
         with ensure_clean_store(self.path) as store:
@@ -3323,6 +3324,8 @@ class TestHDFStore(tm.TestCase):
             date = df.index[len(df) // 2]
 
             crit1 = Term('index>=date')
+            self.assertEqual(crit1.env.scope['date'], date)
+
             crit2 = ("columns=['A', 'D']")
             crit3 = ('columns=A')
 
@@ -3776,7 +3779,6 @@ class TestHDFStore(tm.TestCase):
             self.assertRaises(ValueError, store.select_as_multiple,
                               ['df1','df3'], where=['A>0', 'B>0'], selector='df1')
 
-
     def test_nan_selection_bug_4858(self):
 
         # GH 4858; nan selection bug, only works for pytables >= 3.1
@@ -4226,6 +4228,7 @@ class TestHDFStore(tm.TestCase):
             store.append('test', df, format='table', data_columns=True)
             result = store.select('test', 'a = "test & test"')
         tm.assert_frame_equal(expected, result)
+
 
 def _test_sort(obj):
     if isinstance(obj, DataFrame):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -12116,7 +12116,6 @@ starting,ending,measure
         expected.iloc[1, 1] = True
         assert_frame_equal(result, expected)
 
-
     def test_isin_against_series(self):
         df = pd.DataFrame({'A': [1, 2, 3, 4], 'B': [2, np.nan, 4, 4]},
                           index=['a', 'b', 'c', 'd'])
@@ -12248,6 +12247,7 @@ starting,ending,measure
         assert_series_equal(df[:0].ftypes, pd.Series(odict([('a', 'int64:dense'),
                                                             ('b', 'bool:dense'),
                                                             ('c', 'float64:dense')])))
+
 
 def skip_if_no_ne(engine='numexpr'):
     if engine == 'numexpr':
@@ -12705,16 +12705,16 @@ class TestDataFrameQueryNumExprPandas(tm.TestCase):
         result = df.query('(@df > 0) & (@df2 > 0)', engine=engine, parser=parser)
         assert_frame_equal(result, expected)
 
-        result = pd.eval('@df[@df > 0 and @df2 > 0]', engine=engine,
+        result = pd.eval('df[df > 0 and df2 > 0]', engine=engine,
                          parser=parser)
         assert_frame_equal(result, expected)
 
-        result = pd.eval('@df[@df > 0 and @df2 > 0 and @df[@df > 0] > 0]',
+        result = pd.eval('df[df > 0 and df2 > 0 and df[df > 0] > 0]',
                          engine=engine, parser=parser)
         expected = df[(df > 0) & (df2 > 0) & (df[df > 0] > 0)]
         assert_frame_equal(result, expected)
 
-        result = pd.eval('@df[(@df>0) & (@df2>0)]', engine=engine, parser=parser)
+        result = pd.eval('df[(df>0) & (df2>0)]', engine=engine, parser=parser)
         expected = df.query('(@df>0) & (@df2>0)', engine=engine, parser=parser)
         assert_frame_equal(result, expected)
 
@@ -12874,6 +12874,7 @@ class TestDataFrameQueryPythonPandas(TestDataFrameQueryNumExprPandas):
         result = df.query('sin > 5', engine=engine, parser=parser)
         tm.assert_frame_equal(expected, result)
 
+
 class TestDataFrameQueryPythonPython(TestDataFrameQueryNumExprPython):
 
     @classmethod
@@ -12893,6 +12894,7 @@ class TestDataFrameQueryPythonPython(TestDataFrameQueryNumExprPython):
         expected = df[df.index > 5]
         result = df.query('sin > 5', engine=engine, parser=parser)
         tm.assert_frame_equal(expected, result)
+
 
 PARSERS = 'python', 'pandas'
 ENGINES = 'python', 'numexpr'

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -12752,6 +12752,22 @@ class TestDataFrameQueryNumExprPandas(tm.TestCase):
         expec = df[ind]
         assert_frame_equal(res, expec)
 
+    def test_local_variable_with_in(self):
+        engine, parser = self.engine, self.parser
+        skip_if_no_pandas_parser(parser)
+        a = Series(np.random.randint(3, size=15), name='a')
+        b = Series(np.random.randint(10, size=15), name='b')
+        df = DataFrame({'a': a, 'b': b})
+
+        expected = df.loc[(df.b - 1).isin(a)]
+        result = df.query('b - 1 in a', engine=engine, parser=parser)
+        tm.assert_frame_equal(expected, result)
+
+        b = Series(np.random.randint(10, size=15), name='b')
+        expected = df.loc[(b - 1).isin(a)]
+        result = df.query('@b - 1 in a', engine=engine, parser=parser)
+        tm.assert_frame_equal(expected, result)
+
 
 class TestDataFrameQueryNumExprPython(TestDataFrameQueryNumExprPandas):
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -12325,6 +12325,7 @@ class TestDataFrameQueryWithMultiIndex(object):
         df = DataFrame(randn(10, 2), index=index)
         ind = Series(df.index.get_level_values(0).values, index=index)
 
+        #import ipdb; ipdb.set_trace()
         res1 = df.query('ilevel_0 == "red"', parser=parser, engine=engine)
         res2 = df.query('"red" == ilevel_0', parser=parser, engine=engine)
         exp = df[ind == 'red']
@@ -12448,7 +12449,7 @@ class TestDataFrameQueryWithMultiIndex(object):
 
     def check_query_multiindex_get_index_resolvers(self, parser, engine):
         df = mkdf(10, 3, r_idx_nlevels=2, r_idx_names=['spam', 'eggs'])
-        resolvers = df._get_resolvers()
+        resolvers = df._get_index_resolvers()
 
         def to_series(mi, level):
             level_values = mi.get_level_values(level)
@@ -12508,7 +12509,19 @@ class TestDataFrameQueryNumExprPandas(tm.TestCase):
         super(TestDataFrameQueryNumExprPandas, cls).tearDownClass()
         del cls.engine, cls.parser
 
-    def test_date_query_method(self):
+    def test_date_query_with_attribute_access(self):
+        engine, parser = self.engine, self.parser
+        skip_if_no_pandas_parser(parser)
+        df = DataFrame(randn(5, 3))
+        df['dates1'] = date_range('1/1/2012', periods=5)
+        df['dates2'] = date_range('1/1/2013', periods=5)
+        df['dates3'] = date_range('1/1/2014', periods=5)
+        res = df.query('@df.dates1 < 20130101 < @df.dates3', engine=engine,
+                       parser=parser)
+        expec = df[(df.dates1 < '20130101') & ('20130101' < df.dates3)]
+        assert_frame_equal(res, expec)
+
+    def test_date_query_no_attribute_access(self):
         engine, parser = self.engine, self.parser
         df = DataFrame(randn(5, 3))
         df['dates1'] = date_range('1/1/2012', periods=5)
@@ -12517,7 +12530,7 @@ class TestDataFrameQueryNumExprPandas(tm.TestCase):
         res = df.query('dates1 < 20130101 < dates3', engine=engine,
                        parser=parser)
         expec = df[(df.dates1 < '20130101') & ('20130101' < df.dates3)]
-        assert_frame_equal(res, expec)
+        tm.assert_frame_equal(res, expec)
 
     def test_date_query_with_NaT(self):
         engine, parser = self.engine, self.parser
@@ -12576,7 +12589,7 @@ class TestDataFrameQueryNumExprPandas(tm.TestCase):
 
         n = 10
         df = DataFrame({'dates': date_range('1/1/2012', periods=n),
-             'nondate': np.arange(n)})
+                        'nondate': np.arange(n)})
 
         ops = '==', '!=', '<', '>', '<=', '>='
 
@@ -12584,32 +12597,61 @@ class TestDataFrameQueryNumExprPandas(tm.TestCase):
             with tm.assertRaises(TypeError):
                 df.query('dates %s nondate' % op, parser=parser, engine=engine)
 
-    def test_query_scope(self):
+    def test_query_syntax_error(self):
         engine, parser = self.engine, self.parser
-        from pandas.computation.common import NameResolutionError
-
         df = DataFrame({"i": lrange(10), "+": lrange(3, 13),
                         "r": lrange(4, 14)})
-        i, s = 5, 6
-        self.assertRaises(NameResolutionError, df.query, 'i < 5',
-                          engine=engine, parser=parser, local_dict={'i': i})
-        self.assertRaises(SyntaxError, df.query, 'i - +', engine=engine,
-                          parser=parser)
-        self.assertRaises(NameResolutionError, df.query, 'i == s',
-                          engine=engine, parser=parser, local_dict={'i': i,
-                                                                    's': s})
+        with tm.assertRaises(SyntaxError):
+            df.query('i - +', engine=engine, parser=parser)
 
-    def test_query_scope_index(self):
+    def test_query_scope(self):
+        from pandas.computation.ops import UndefinedVariableError
         engine, parser = self.engine, self.parser
-        from pandas.computation.common import NameResolutionError
-        df = DataFrame(np.random.randint(10, size=(10, 3)),
-                       index=Index(range(10), name='blob'),
-                       columns=['a', 'b', 'c'])
+        skip_if_no_pandas_parser(parser)
+
+        df = DataFrame(np.random.randn(20, 2), columns=list('ab'))
+
+        a, b = 1, 2
+        res = df.query('a > b', engine=engine, parser=parser)
+        expected = df[df.a > df.b]
+        tm.assert_frame_equal(res, expected)
+
+        res = df.query('@a > b', engine=engine, parser=parser)
+        expected = df[a > df.b]
+        tm.assert_frame_equal(res, expected)
+
+        # no local variable c
+        with tm.assertRaises(UndefinedVariableError):
+            df.query('@a > b > @c', engine=engine, parser=parser)
+
+        # no column named 'c'
+        with tm.assertRaises(UndefinedVariableError):
+            df.query('@a > b > c', engine=engine, parser=parser)
+
+    def test_query_doesnt_pickup_local(self):
+        from pandas.computation.ops import UndefinedVariableError
+
+        engine, parser = self.engine, self.parser
+        n = m = 10
+        df = DataFrame(np.random.randint(m, size=(n, 3)), columns=list('abc'))
+
         from numpy import sin
+
+        # we don't pick up the local 'sin'
+        with tm.assertRaises(UndefinedVariableError):
+            df.query('sin > 5', engine=engine, parser=parser)
+
+    def test_query_builtin(self):
+        from pandas.computation.engines import NumExprClobberingError
+        engine, parser = self.engine, self.parser
+
+        n = m = 10
+        df = DataFrame(np.random.randint(m, size=(n, 3)), columns=list('abc'))
+
         df.index.name = 'sin'
-        self.assertRaises(NameResolutionError, df.query, 'sin > 5',
-                          engine=engine, parser=parser, local_dict={'sin':
-                                                                    sin})
+        with tm.assertRaisesRegexp(NumExprClobberingError,
+                                  'Variables in expression.+'):
+            df.query('sin > 5', engine=engine, parser=parser)
 
     def test_query(self):
         engine, parser = self.engine, self.parser
@@ -12620,16 +12662,6 @@ class TestDataFrameQueryNumExprPandas(tm.TestCase):
         assert_frame_equal(df.query('a + b > b * c', engine=engine,
                                     parser=parser),
                            df[df.a + df.b > df.b * df.c])
-
-        local_dict = dict(df.iteritems())
-        local_dict.update({'df': df})
-        self.assertRaises(NameError, df.query, 'a < d & b < f',
-                          local_dict=local_dict, engine=engine, parser=parser)
-
-        # make sure that it's not just because we didn't pass the locals in
-        self.assertRaises(AssertionError, self.assertRaises, NameError,
-                          df.query, 'a < b', local_dict={'df': df},
-                          engine=engine, parser=parser)
 
     def test_query_index_with_name(self):
         engine, parser = self.engine, self.parser
@@ -12663,35 +12695,40 @@ class TestDataFrameQueryNumExprPandas(tm.TestCase):
     def test_nested_scope(self):
         engine = self.engine
         parser = self.parser
-        # smoke test
-        x = 1
-        result = pd.eval('x + 1', engine=engine, parser=parser)
-        self.assertEqual(result, 2)
 
-        df  = DataFrame(np.random.randn(5, 3))
+        skip_if_no_pandas_parser(parser)
+
+        df = DataFrame(np.random.randn(5, 3))
         df2 = DataFrame(np.random.randn(5, 3))
-        expected = df[(df>0) & (df2>0)]
+        expected = df[(df > 0) & (df2 > 0)]
 
-        result = df.query('(df>0) & (df2>0)', engine=engine, parser=parser)
+        result = df.query('(@df > 0) & (@df2 > 0)', engine=engine, parser=parser)
         assert_frame_equal(result, expected)
 
-        result = pd.eval('df[(df > 0) and (df2 > 0)]', engine=engine,
+        result = pd.eval('@df[@df > 0 and @df2 > 0]', engine=engine,
                          parser=parser)
         assert_frame_equal(result, expected)
 
-        result = pd.eval('df[(df > 0) and (df2 > 0) and df[df > 0] > 0]',
+        result = pd.eval('@df[@df > 0 and @df2 > 0 and @df[@df > 0] > 0]',
                          engine=engine, parser=parser)
         expected = df[(df > 0) & (df2 > 0) & (df[df > 0] > 0)]
         assert_frame_equal(result, expected)
 
-        result = pd.eval('df[(df>0) & (df2>0)]', engine=engine, parser=parser)
-        expected = df.query('(df>0) & (df2>0)', engine=engine, parser=parser)
+        result = pd.eval('@df[(@df>0) & (@df2>0)]', engine=engine, parser=parser)
+        expected = df.query('(@df>0) & (@df2>0)', engine=engine, parser=parser)
         assert_frame_equal(result, expected)
+
+    def test_nested_raises_on_local_self_reference(self):
+        from pandas.computation.ops import UndefinedVariableError
+
+        df = DataFrame(np.random.randn(5, 3))
+
+        # can't reference ourself b/c we're a local so @ is necessary
+        with tm.assertRaises(UndefinedVariableError):
+            df.query('df > 0', engine=self.engine, parser=self.parser)
 
     def test_local_syntax(self):
         skip_if_no_pandas_parser(self.parser)
-
-        from pandas.computation.common import NameResolutionError
 
         engine, parser = self.engine, self.parser
         df = DataFrame(randn(100, 10), columns=list('abcdefghij'))
@@ -12700,13 +12737,6 @@ class TestDataFrameQueryNumExprPandas(tm.TestCase):
         result = df.query('a < @b', engine=engine, parser=parser)
         assert_frame_equal(result, expect)
 
-        # scope issue with self.assertRaises so just catch it and let it pass
-        try:
-            df.query('a < @b', engine=engine, parser=parser)
-        except NameResolutionError:
-            pass
-
-        del b
         expect = df[df.a < df.b]
         result = df.query('a < b', engine=engine, parser=parser)
         assert_frame_equal(result, expect)
@@ -12733,17 +12763,16 @@ class TestDataFrameQueryNumExprPython(TestDataFrameQueryNumExprPandas):
         tm.skip_if_no_ne(cls.engine)
         cls.frame = _frame.copy()
 
-    def test_date_query_method(self):
+    def test_date_query_no_attribute_access(self):
         engine, parser = self.engine, self.parser
         df = DataFrame(randn(5, 3))
         df['dates1'] = date_range('1/1/2012', periods=5)
         df['dates2'] = date_range('1/1/2013', periods=5)
         df['dates3'] = date_range('1/1/2014', periods=5)
-        res = df.query('(df.dates1 < 20130101) & (20130101 < df.dates3)',
+        res = df.query('(dates1 < 20130101) & (20130101 < dates3)',
                        engine=engine, parser=parser)
         expec = df[(df.dates1 < '20130101') & ('20130101' < df.dates3)]
-        assert_frame_equal(res, expec)
-
+        tm.assert_frame_equal(res, expec)
     def test_date_query_with_NaT(self):
         engine, parser = self.engine, self.parser
         n = 10
@@ -12792,10 +12821,10 @@ class TestDataFrameQueryNumExprPython(TestDataFrameQueryNumExprPandas):
         df.loc[np.random.rand(n) > 0.5, 'dates1'] = pd.NaT
         df.set_index('dates1', inplace=True, drop=True)
         with tm.assertRaises(NotImplementedError):
-            res = df.query('index < 20130101 < dates3', engine=engine,
-                           parser=parser)
+            df.query('index < 20130101 < dates3', engine=engine, parser=parser)
 
     def test_nested_scope(self):
+        from pandas.computation.ops import UndefinedVariableError
         engine = self.engine
         parser = self.parser
         # smoke test
@@ -12805,23 +12834,23 @@ class TestDataFrameQueryNumExprPython(TestDataFrameQueryNumExprPandas):
 
         df  = DataFrame(np.random.randn(5, 3))
         df2 = DataFrame(np.random.randn(5, 3))
-        expected = df[(df>0) & (df2>0)]
 
-        result = df.query('(df>0) & (df2>0)', engine=engine, parser=parser)
-        assert_frame_equal(result, expected)
+        # don't have the pandas parser
+        with tm.assertRaises(SyntaxError):
+            df.query('(@df>0) & (@df2>0)', engine=engine, parser=parser)
 
+        with tm.assertRaises(UndefinedVariableError):
+            df.query('(df>0) & (df2>0)', engine=engine, parser=parser)
+
+        expected = df[(df > 0) & (df2 > 0)]
         result = pd.eval('df[(df > 0) & (df2 > 0)]', engine=engine,
                          parser=parser)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(expected, result)
 
+        expected = df[(df > 0) & (df2 > 0) & (df[df > 0] > 0)]
         result = pd.eval('df[(df > 0) & (df2 > 0) & (df[df > 0] > 0)]',
                          engine=engine, parser=parser)
-        expected = df[(df > 0) & (df2 > 0) & (df[df > 0] > 0)]
-        assert_frame_equal(result, expected)
-
-        result = pd.eval('df[(df>0) & (df2>0)]', engine=engine, parser=parser)
-        expected = df.query('(df>0) & (df2>0)', engine=engine, parser=parser)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(expected, result)
 
 
 class TestDataFrameQueryPythonPandas(TestDataFrameQueryNumExprPandas):
@@ -12833,6 +12862,17 @@ class TestDataFrameQueryPythonPandas(TestDataFrameQueryNumExprPandas):
         cls.parser = 'pandas'
         cls.frame = _frame.copy()
 
+    def test_query_builtin(self):
+        from pandas.computation.engines import NumExprClobberingError
+        engine, parser = self.engine, self.parser
+
+        n = m = 10
+        df = DataFrame(np.random.randint(m, size=(n, 3)), columns=list('abc'))
+
+        df.index.name = 'sin'
+        expected = df[df.index > 5]
+        result = df.query('sin > 5', engine=engine, parser=parser)
+        tm.assert_frame_equal(expected, result)
 
 class TestDataFrameQueryPythonPython(TestDataFrameQueryNumExprPython):
 
@@ -12842,6 +12882,17 @@ class TestDataFrameQueryPythonPython(TestDataFrameQueryNumExprPython):
         cls.engine = cls.parser = 'python'
         cls.frame = _frame.copy()
 
+    def test_query_builtin(self):
+        from pandas.computation.engines import NumExprClobberingError
+        engine, parser = self.engine, self.parser
+
+        n = m = 10
+        df = DataFrame(np.random.randint(m, size=(n, 3)), columns=list('abc'))
+
+        df.index.name = 'sin'
+        expected = df[df.index > 5]
+        result = df.query('sin > 5', engine=engine, parser=parser)
+        tm.assert_frame_equal(expected, result)
 
 PARSERS = 'python', 'pandas'
 ENGINES = 'python', 'numexpr'
@@ -12910,8 +12961,8 @@ class TestDataFrameQueryStrings(object):
 
             for lhs, op, rhs in zip(lhs, ops, rhs):
                 ex = '{lhs} {op} {rhs}'.format(lhs=lhs, op=op, rhs=rhs)
-                assertRaises(NotImplementedError, df.query, ex, engine=engine,
-                             parser=parser, local_dict={'strings': df.strings})
+                with tm.assertRaises(NotImplementedError):
+                    df.query(ex, engine=engine, parser=parser)
         else:
             res = df.query('strings == ["a", "b"]', engine=engine,
                            parser=parser)


### PR DESCRIPTION
closes #5987
closes #5087

Relevant user-facing changes:

```
In [9]: df = DataFrame(randn(5, 2), columns=list('ab'))

In [10]: a, b = 1, 2

In [11]: # column names take precedence

In [12]: df.query('a < b')
Out[12]:
          a         b
0 -0.805549 -0.090572
1 -1.782325 -1.594079
2 -0.984364  0.934457
3 -1.963798  1.122112

[4 rows x 2 columns]

In [13]: # we must use @ whenever we want a local variable

In [14]: df.query('@a < b')
Out[14]:
          a         b
3 -1.963798  1.122112

[1 rows x 2 columns]

In [15]: # we cannot use @ in eval calls

In [16]: pd.eval('@a + b')
  File "<string>", line unknown
SyntaxError: The '@' prefix is not allowed in top-level eval calls, please refer to your variables by name without the '@' prefix

In [17]: pd.eval('@a + b', parser='python')
  File "<string>", line unknown
SyntaxError: The '@' prefix is only supported by the pandas parser
```
- [x] update query/eval docstrings/indexing/perfenhancing
- [x] make sure docs build
- [x] release notes
- [x] pytables
- [x] make the `repr` of `Scope` objects work or revert to previous version
- [x] more tests for new local variable scoping API
- [x] disallow (and provide a useful error message for) locals in expressions like `pd.eval('@a + b')`
- [x] Raise when your variables have the same name as the [builtin math functions that `numexpr` supports](https://code.google.com/p/numexpr/wiki/UsersGuide#Supported_functions), since you cannot override them in `numexpr.evaluate`, even when explicitly passing them. For example

``` python
import numexpr as ne
sin = randn(10)
d = {'sin': sin}
result = ne.evaluate('sin > 1', local_dict=d, global_dict=d)
result == array(True)
```

For reference, after this PR local variables are given lower precedence than column names. For example

``` python
a, b = 1, 2
df = DataFrame(randn(10, 2), columns=list('ab'))
res = df.query('a > b')
```

will no longer raise an exception about overlapping variable names. If you want the local `a` (as opposed to the column `a`) you must do

``` python
df.query('@a > b')
```
