### PR TITLE
CLN: Specialize assert_(np.array_equal(...))

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -82,6 +82,7 @@ Improvements to existing features
 - improve performance of slice indexing on Series with string keys (:issue:`6341`)
 - implement joining a single-level indexed DataFrame on a matching column of a multi-indexed DataFrame (:issue:`3662`)
 - Performance improvement in indexing into a multi-indexed Series (:issue:`5567`)
+- Testing statements updated to use specialized asserts (:issue: `6175`)
 
 .. _release.bug_fixes-0.14.0:
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -17,7 +17,7 @@ class TestMatch(tm.TestCase):
 
         result = algos.match(to_match, values)
         expected = np.array([0, 2, 1, 1, 0, 2, -1, 0])
-        self.assert_numpy_array_equals(result, expected)
+        self.assert_numpy_array_equal(result, expected)
 
         result = Series(algos.match(to_match, values, np.nan))
         expected = Series(np.array([0, 2, 1, 1, 0, 2, np.nan, 0]))
@@ -26,7 +26,7 @@ class TestMatch(tm.TestCase):
         s = pd.Series(np.arange(5),dtype=np.float32)
         result = algos.match(s, [2,4])
         expected = np.array([-1, -1, 0, -1, 1])
-        self.assert_numpy_array_equals(result, expected)
+        self.assert_numpy_array_equal(result, expected)
 
         result = Series(algos.match(s, [2,4], np.nan))
         expected = Series(np.array([np.nan, np.nan, 0, np.nan, 1]))
@@ -38,7 +38,7 @@ class TestMatch(tm.TestCase):
 
         result = algos.match(to_match, values)
         expected = np.array([1, 0, -1, 0, 1, 2, -1])
-        self.assert_numpy_array_equals(result, expected)
+        self.assert_numpy_array_equal(result, expected)
 
         result = Series(algos.match(to_match, values, np.nan))
         expected = Series(np.array([1, 0, np.nan, 0, 1, 2, np.nan]))
@@ -51,29 +51,29 @@ class TestFactorize(tm.TestCase):
 
         labels, uniques = algos.factorize(['a', 'b', 'b', 'a',
                                            'a', 'c', 'c', 'c'])
-        # self.assert_numpy_array_equals(labels, np.array([ 0, 1, 1, 0, 0, 2, 2, 2],dtype=np.int64))
-        self.assert_numpy_array_equals(uniques, np.array(['a','b','c'], dtype=object))
+        # self.assert_numpy_array_equal(labels, np.array([ 0, 1, 1, 0, 0, 2, 2, 2],dtype=np.int64))
+        self.assert_numpy_array_equal(uniques, np.array(['a','b','c'], dtype=object))
 
         labels, uniques = algos.factorize(['a', 'b', 'b', 'a',
                                            'a', 'c', 'c', 'c'], sort=True)
-        self.assert_numpy_array_equals(labels, np.array([ 0, 1, 1, 0, 0, 2, 2, 2],dtype=np.int64))
-        self.assert_numpy_array_equals(uniques, np.array(['a','b','c'], dtype=object))
+        self.assert_numpy_array_equal(labels, np.array([ 0, 1, 1, 0, 0, 2, 2, 2],dtype=np.int64))
+        self.assert_numpy_array_equal(uniques, np.array(['a','b','c'], dtype=object))
 
         labels, uniques = algos.factorize(list(reversed(range(5))))
-        self.assert_numpy_array_equals(labels, np.array([0, 1, 2, 3, 4], dtype=np.int64))
-        self.assert_numpy_array_equals(uniques, np.array([ 4, 3, 2, 1, 0],dtype=np.int64))
+        self.assert_numpy_array_equal(labels, np.array([0, 1, 2, 3, 4], dtype=np.int64))
+        self.assert_numpy_array_equal(uniques, np.array([ 4, 3, 2, 1, 0],dtype=np.int64))
 
         labels, uniques = algos.factorize(list(reversed(range(5))), sort=True)
-        self.assert_numpy_array_equals(labels, np.array([ 4, 3, 2, 1, 0],dtype=np.int64))
-        self.assert_numpy_array_equals(uniques, np.array([0, 1, 2, 3, 4], dtype=np.int64))
+        self.assert_numpy_array_equal(labels, np.array([ 4, 3, 2, 1, 0],dtype=np.int64))
+        self.assert_numpy_array_equal(uniques, np.array([0, 1, 2, 3, 4], dtype=np.int64))
 
         labels, uniques = algos.factorize(list(reversed(np.arange(5.))))
-        self.assert_numpy_array_equals(labels, np.array([0., 1., 2., 3., 4.], dtype=np.float64))
-        self.assert_numpy_array_equals(uniques, np.array([ 4, 3, 2, 1, 0],dtype=np.int64))
+        self.assert_numpy_array_equal(labels, np.array([0., 1., 2., 3., 4.], dtype=np.float64))
+        self.assert_numpy_array_equal(uniques, np.array([ 4, 3, 2, 1, 0],dtype=np.int64))
 
         labels, uniques = algos.factorize(list(reversed(np.arange(5.))), sort=True)
-        self.assert_numpy_array_equals(labels, np.array([ 4, 3, 2, 1, 0],dtype=np.int64))
-        self.assert_numpy_array_equals(uniques, np.array([0., 1., 2., 3., 4.], dtype=np.float64))
+        self.assert_numpy_array_equal(labels, np.array([ 4, 3, 2, 1, 0],dtype=np.int64))
+        self.assert_numpy_array_equal(uniques, np.array([0., 1., 2., 3., 4.], dtype=np.float64))
 
     def test_mixed(self):
 
@@ -81,12 +81,12 @@ class TestFactorize(tm.TestCase):
         x = Series(['A', 'A', np.nan, 'B', 3.14, np.inf])
         labels, uniques = algos.factorize(x)
 
-        self.assert_numpy_array_equals(labels, np.array([ 0,  0, -1,  1,  2,  3],dtype=np.int64))
-        self.assert_numpy_array_equals(uniques, np.array(['A', 'B', 3.14, np.inf], dtype=object))
+        self.assert_numpy_array_equal(labels, np.array([ 0,  0, -1,  1,  2,  3],dtype=np.int64))
+        self.assert_numpy_array_equal(uniques, np.array(['A', 'B', 3.14, np.inf], dtype=object))
 
         labels, uniques = algos.factorize(x, sort=True)
-        self.assert_numpy_array_equals(labels, np.array([ 2,  2, -1,  3,  0,  1],dtype=np.int64))
-        self.assert_numpy_array_equals(uniques, np.array([3.14, np.inf, 'A', 'B'], dtype=object))
+        self.assert_numpy_array_equal(labels, np.array([ 2,  2, -1,  3,  0,  1],dtype=np.int64))
+        self.assert_numpy_array_equal(uniques, np.array([3.14, np.inf, 'A', 'B'], dtype=object))
 
     def test_datelike(self):
 
@@ -95,12 +95,12 @@ class TestFactorize(tm.TestCase):
         v2 = pd.Timestamp('20130101')
         x = Series([v1,v1,v1,v2,v2,v1])
         labels, uniques = algos.factorize(x)
-        self.assert_numpy_array_equals(labels, np.array([ 0,0,0,1,1,0],dtype=np.int64))
-        self.assert_numpy_array_equals(uniques, np.array([v1.value,v2.value],dtype='M8[ns]'))
+        self.assert_numpy_array_equal(labels, np.array([ 0,0,0,1,1,0],dtype=np.int64))
+        self.assert_numpy_array_equal(uniques, np.array([v1.value,v2.value],dtype='M8[ns]'))
 
         labels, uniques = algos.factorize(x, sort=True)
-        self.assert_numpy_array_equals(labels, np.array([ 1,1,1,0,0,1],dtype=np.int64))
-        self.assert_numpy_array_equals(uniques, np.array([v2.value,v1.value],dtype='M8[ns]'))
+        self.assert_numpy_array_equal(labels, np.array([ 1,1,1,0,0,1],dtype=np.int64))
+        self.assert_numpy_array_equal(uniques, np.array([v2.value,v1.value],dtype='M8[ns]'))
 
         # period
         v1 = pd.Period('201302',freq='M')
@@ -109,12 +109,12 @@ class TestFactorize(tm.TestCase):
 
         # periods are not 'sorted' as they are converted back into an index
         labels, uniques = algos.factorize(x)
-        self.assert_numpy_array_equals(labels, np.array([ 0,0,0,1,1,0],dtype=np.int64))
-        self.assert_numpy_array_equals(uniques, np.array([v1, v2],dtype=object))
+        self.assert_numpy_array_equal(labels, np.array([ 0,0,0,1,1,0],dtype=np.int64))
+        self.assert_numpy_array_equal(uniques, np.array([v1, v2],dtype=object))
 
         labels, uniques = algos.factorize(x,sort=True)
-        self.assert_numpy_array_equals(labels, np.array([ 0,0,0,1,1,0],dtype=np.int64))
-        self.assert_numpy_array_equals(uniques, np.array([v1, v2],dtype=object))
+        self.assert_numpy_array_equal(labels, np.array([ 0,0,0,1,1,0],dtype=np.int64))
+        self.assert_numpy_array_equal(uniques, np.array([v1, v2],dtype=object))
 
 class TestUnique(tm.TestCase):
     _multiprocess_can_split_ = True

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -102,7 +102,7 @@ class TestFrozenNDArray(CheckImmutable, CheckStringMixin, tm.TestCase):
         assert_isinstance(self.container.view(), FrozenNDArray)
         self.assert_(not isinstance(self.container.view(np.ndarray), FrozenNDArray))
         self.assert_(self.container.view() is not self.container)
-        self.assert_(np.array_equal(self.container, original))
+        self.assert_numpy_array_equal(self.container, original)
         # shallow copy should be the same too
         assert_isinstance(self.container._shallow_copy(), FrozenNDArray)
         # setting should not be allowed
@@ -114,10 +114,10 @@ class TestFrozenNDArray(CheckImmutable, CheckStringMixin, tm.TestCase):
         original = self.container.view(np.ndarray).copy()
         n = original[0] + 15
         vals = self.container.values()
-        self.assert_(np.array_equal(original, vals))
+        self.assert_numpy_array_equal(original, vals)
         self.assert_(original is not vals)
         vals[0] = n
-        self.assert_(np.array_equal(self.container, original))
+        self.assert_numpy_array_equal(self.container, original)
         self.assertEqual(vals[0], n)
 
 

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -82,11 +82,11 @@ class TestCategorical(tm.TestCase):
         other = self.factor[np.random.permutation(n)]
         result = self.factor == other
         expected = np.asarray(self.factor) == np.asarray(other)
-        self.assert_(np.array_equal(result, expected))
+        self.assert_numpy_array_equal(result, expected)
 
         result = self.factor == 'd'
         expected = np.repeat(False, len(self.factor))
-        self.assert_(np.array_equal(result, expected))
+        self.assert_numpy_array_equal(result, expected)
 
     def test_na_flags_int_levels(self):
         # #1457
@@ -98,7 +98,7 @@ class TestCategorical(tm.TestCase):
         cat = Categorical(labels, levels)
         repr(cat)
 
-        self.assert_(np.array_equal(com.isnull(cat), labels == -1))
+        self.assert_numpy_array_equal(com.isnull(cat), labels == -1)
 
     def test_levels_none(self):
         factor = Categorical(['a', 'b', 'b', 'a',

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -241,7 +241,7 @@ class CheckIndexing(object):
         subindex = self.tsframe.index[indexer]
         subframe = self.tsframe[indexer]
 
-        self.assert_(np.array_equal(subindex, subframe.index))
+        self.assert_numpy_array_equal(subindex, subframe.index)
         with assertRaisesRegexp(ValueError, 'Item wrong length'):
             self.tsframe[indexer[:-1]]
 
@@ -1872,11 +1872,11 @@ class SafeForSparse(object):
     def test_add_prefix_suffix(self):
         with_prefix = self.frame.add_prefix('foo#')
         expected = ['foo#%s' % c for c in self.frame.columns]
-        self.assert_(np.array_equal(with_prefix.columns, expected))
+        self.assert_numpy_array_equal(with_prefix.columns, expected)
 
         with_suffix = self.frame.add_suffix('#foo')
         expected = ['%s#foo' % c for c in self.frame.columns]
-        self.assert_(np.array_equal(with_suffix.columns, expected))
+        self.assert_numpy_array_equal(with_suffix.columns, expected)
 
 
 class TestDataFrame(tm.TestCase, CheckIndexing,
@@ -2236,10 +2236,10 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         index = self.frame.index
 
         df = DataFrame(rec)
-        self.assert_(np.array_equal(df.columns, rec.dtype.names))
+        self.assert_numpy_array_equal(df.columns, rec.dtype.names)
 
         df2 = DataFrame(rec, index=index)
-        self.assert_(np.array_equal(df2.columns, rec.dtype.names))
+        self.assert_numpy_array_equal(df2.columns, rec.dtype.names)
         self.assert_(df2.index.equals(index))
 
         rng = np.arange(len(rec))[::-1]
@@ -2303,7 +2303,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # Length-one dict micro-optimization
         frame = DataFrame({'A': {'1': 1, '2': 2}})
-        self.assert_(np.array_equal(frame.index, ['1', '2']))
+        self.assert_numpy_array_equal(frame.index, ['1', '2'])
 
         # empty dict plus index
         idx = Index([0, 1, 2])
@@ -2495,14 +2495,14 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # automatic labeling
         frame = DataFrame(mat)
-        self.assert_(np.array_equal(frame.index, lrange(2)))
-        self.assert_(np.array_equal(frame.columns, lrange(3)))
+        self.assert_numpy_array_equal(frame.index, lrange(2))
+        self.assert_numpy_array_equal(frame.columns, lrange(3))
 
         frame = DataFrame(mat, index=[1, 2])
-        self.assert_(np.array_equal(frame.columns, lrange(3)))
+        self.assert_numpy_array_equal(frame.columns, lrange(3))
 
         frame = DataFrame(mat, columns=['A', 'B', 'C'])
-        self.assert_(np.array_equal(frame.index, lrange(2)))
+        self.assert_numpy_array_equal(frame.index, lrange(2))
 
         # 0-length axis
         frame = DataFrame(empty((0, 3)))
@@ -2995,8 +2995,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         result = DataFrame(self.frame._data, index=index,
                            columns=columns)
-        self.assert_(np.array_equal(result.index, index))
-        self.assert_(np.array_equal(result.columns, columns))
+        self.assert_numpy_array_equal(result.index, index)
+        self.assert_numpy_array_equal(result.columns, columns)
 
     def test_constructor_from_items(self):
         items = [(c, self.frame[c]) for c in self.frame.columns]
@@ -3781,7 +3781,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         index = np.arange(len(arr))[::-1]
         indexed_frame = DataFrame.from_records(arr, index=index)
-        self.assert_(np.array_equal(indexed_frame.index, index))
+        self.assert_numpy_array_equal(indexed_frame.index, index)
 
         # without names, it should go to last ditch
         arr2 = np.zeros((2,3))
@@ -4064,7 +4064,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # tuples is in the order of the columns
         result = DataFrame.from_records(tuples)
-        self.assert_(np.array_equal(result.columns, lrange(8)))
+        self.assert_numpy_array_equal(result.columns, lrange(8))
 
         # test exclude parameter & we are casting the results here (as we don't have dtype info to recover)
         columns_to_test = [ columns.index('C'), columns.index('E1') ]
@@ -4078,7 +4078,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # empty case
         result = DataFrame.from_records([], columns=['foo', 'bar', 'baz'])
         self.assertEqual(len(result), 0)
-        self.assert_(np.array_equal(result.columns, ['foo', 'bar', 'baz']))
+        self.assert_numpy_array_equal(result.columns, ['foo', 'bar', 'baz'])
 
         result = DataFrame.from_records([])
         self.assertEqual(len(result), 0)
@@ -4360,11 +4360,11 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                        columns=['c', 'b', 'a'])
 
         df.insert(0, 'foo', df['a'])
-        self.assert_(np.array_equal(df.columns, ['foo', 'c', 'b', 'a']))
+        self.assert_numpy_array_equal(df.columns, ['foo', 'c', 'b', 'a'])
         assert_almost_equal(df['a'], df['foo'])
 
         df.insert(2, 'bar', df['c'])
-        self.assert_(np.array_equal(df.columns, ['foo', 'c', 'bar', 'b', 'a']))
+        self.assert_numpy_array_equal(df.columns, ['foo', 'c', 'bar', 'b', 'a'])
         assert_almost_equal(df['c'], df['bar'])
 
         # diff dtype
@@ -5207,12 +5207,12 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
     def test_combineFunc(self):
         result = self.frame * 2
-        self.assert_(np.array_equal(result.values, self.frame.values * 2))
+        self.assert_numpy_array_equal(result.values, self.frame.values * 2)
 
         # vs mix
         result = self.mixed_float * 2
         for c, s in compat.iteritems(result):
-            self.assert_(np.array_equal(s.values, self.mixed_float[c].values * 2))
+            self.assert_numpy_array_equal(s.values, self.mixed_float[c].values * 2)
         _check_mixed_float(result, dtype = dict(C = None))
 
         result = self.empty * 2
@@ -5228,18 +5228,18 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         def test_comp(func):
             result = func(df1, df2)
-            self.assert_(np.array_equal(result.values,
-                                        func(df1.values, df2.values)))
+            self.assert_numpy_array_equal(result.values,
+                                          func(df1.values, df2.values))
             with assertRaisesRegexp(ValueError, 'Wrong number of dimensions'):
                 func(df1, ndim_5)
 
             result2 = func(self.simple, row)
-            self.assert_(np.array_equal(result2.values,
-                                        func(self.simple.values, row.values)))
+            self.assert_numpy_array_equal(result2.values,
+                                          func(self.simple.values, row.values))
 
             result3 = func(self.frame, 0)
-            self.assert_(np.array_equal(result3.values,
-                                        func(self.frame.values, 0)))
+            self.assert_numpy_array_equal(result3.values,
+                                          func(self.frame.values, 0))
 
 
             with assertRaisesRegexp(ValueError, 'Can only compare '
@@ -6698,8 +6698,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         smaller_frame = frame.dropna()
         assert_series_equal(frame['foo'], original)
         inp_frame1.dropna(inplace=True)
-        self.assert_(np.array_equal(smaller_frame['foo'], mat[5:]))
-        self.assert_(np.array_equal(inp_frame1['foo'], mat[5:]))
+        self.assert_numpy_array_equal(smaller_frame['foo'], mat[5:])
+        self.assert_numpy_array_equal(inp_frame1['foo'], mat[5:])
 
         samesize_frame = frame.dropna(subset=['bar'])
         assert_series_equal(frame['foo'], original)
@@ -8195,7 +8195,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         result = df.pivot(index=1, columns=0, values=2)
         repr(result)
-        self.assert_(np.array_equal(result.columns, ['A', 'B']))
+        self.assert_numpy_array_equal(result.columns, ['A', 'B'])
 
     def test_reindex(self):
         newFrame = self.frame.reindex(self.ts1.index)
@@ -8810,27 +8810,27 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # gets sorted alphabetical
         df = DataFrame(data)
         renamed = df.rename(index={'foo': 'bar', 'bar': 'foo'})
-        self.assert_(np.array_equal(renamed.index, ['foo', 'bar']))
+        self.assert_numpy_array_equal(renamed.index, ['foo', 'bar'])
 
         renamed = df.rename(index=str.upper)
-        self.assert_(np.array_equal(renamed.index, ['BAR', 'FOO']))
+        self.assert_numpy_array_equal(renamed.index, ['BAR', 'FOO'])
 
         # have to pass something
         self.assertRaises(TypeError, self.frame.rename)
 
         # partial columns
         renamed = self.frame.rename(columns={'C': 'foo', 'D': 'bar'})
-        self.assert_(np.array_equal(renamed.columns, ['A', 'B', 'foo', 'bar']))
+        self.assert_numpy_array_equal(renamed.columns, ['A', 'B', 'foo', 'bar'])
 
         # other axis
         renamed = self.frame.T.rename(index={'C': 'foo', 'D': 'bar'})
-        self.assert_(np.array_equal(renamed.index, ['A', 'B', 'foo', 'bar']))
+        self.assert_numpy_array_equal(renamed.index, ['A', 'B', 'foo', 'bar'])
 
         # index with name
         index = Index(['foo', 'bar'], name='name')
         renamer = DataFrame(data, index=index)
         renamed = renamer.rename(index={'foo': 'bar', 'bar': 'foo'})
-        self.assert_(np.array_equal(renamed.index, ['bar', 'foo']))
+        self.assert_numpy_array_equal(renamed.index, ['bar', 'foo'])
         self.assertEquals(renamed.index.name, renamer.index.name)
 
         # MultiIndex
@@ -8843,8 +8843,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                                  columns={'fizz1': 'fizz3', 'buzz2': 'buzz3'})
         new_index = MultiIndex.from_tuples([('foo3', 'bar1'), ('foo2', 'bar3')])
         new_columns = MultiIndex.from_tuples([('fizz3', 'buzz1'), ('fizz2', 'buzz3')])
-        self.assert_(np.array_equal(renamed.index, new_index))
-        self.assert_(np.array_equal(renamed.columns, new_columns))
+        self.assert_numpy_array_equal(renamed.index, new_index)
+        self.assert_numpy_array_equal(renamed.columns, new_columns)
         self.assertEquals(renamed.index.names, renamer.index.names)
         self.assertEquals(renamed.columns.names, renamer.columns.names)
 
@@ -10055,8 +10055,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                         'd': [None, None, None],
                         'e': [3.14, 0.577, 2.773]})
 
-        self.assert_(np.array_equal(df._get_numeric_data().columns,
-                                    ['a', 'b', 'e']))
+        self.assert_numpy_array_equal(df._get_numeric_data().columns,
+                                      ['a', 'b', 'e'])
 
     def test_is_mixed_type(self):
         self.assert_(not self.frame._is_mixed_type)
@@ -10100,7 +10100,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         })
 
         # Boolean data and integer data is included in .describe() output, string data isn't
-        self.assert_(np.array_equal(df.describe().columns, ['bool_data', 'int_data']))
+        self.assert_numpy_array_equal(df.describe().columns, ['bool_data', 'int_data'])
 
         bool_describe = df.describe()['bool_data']
 
@@ -10995,28 +10995,28 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         stacked.index.names = [None, None]
         deleveled2 = stacked.reset_index()
-        self.assert_(np.array_equal(deleveled['first'],
-                                    deleveled2['level_0']))
-        self.assert_(np.array_equal(deleveled['second'],
-                                    deleveled2['level_1']))
+        self.assert_numpy_array_equal(deleveled['first'],
+                                      deleveled2['level_0'])
+        self.assert_numpy_array_equal(deleveled['second'],
+                                      deleveled2['level_1'])
 
         # default name assigned
         rdf = self.frame.reset_index()
-        self.assert_(np.array_equal(rdf['index'], self.frame.index.values))
+        self.assert_numpy_array_equal(rdf['index'], self.frame.index.values)
 
         # default name assigned, corner case
         df = self.frame.copy()
         df['index'] = 'foo'
         rdf = df.reset_index()
-        self.assert_(np.array_equal(rdf['level_0'], self.frame.index.values))
+        self.assert_numpy_array_equal(rdf['level_0'], self.frame.index.values)
 
         # but this is ok
         self.frame.index.name = 'index'
         deleveled = self.frame.reset_index()
-        self.assert_(np.array_equal(deleveled['index'],
-                                    self.frame.index.values))
-        self.assert_(np.array_equal(deleveled.index,
-                                    np.arange(len(deleveled))))
+        self.assert_numpy_array_equal(deleveled['index'],
+                                      self.frame.index.values)
+        self.assert_numpy_array_equal(deleveled.index,
+                                      np.arange(len(deleveled)))
 
         # preserve column names
         self.frame.columns.name = 'columns'

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -127,7 +127,7 @@ class TestIndex(tm.TestCase):
         arr = np.array(self.strIndex)
         index = arr.view(Index)
         tm.assert_contains_all(arr, index)
-        self.assert_(np.array_equal(self.strIndex, index))
+        self.assert_numpy_array_equal(self.strIndex, index)
 
         # copy
         arr = np.array(self.strIndex)
@@ -281,7 +281,7 @@ class TestIndex(tm.TestCase):
     def test_argsort(self):
         result = self.strIndex.argsort()
         expected = np.array(self.strIndex).argsort()
-        self.assert_(np.array_equal(result, expected))
+        self.assert_numpy_array_equal(result, expected)
 
     def test_comparators(self):
         index = self.dateIndex
@@ -296,7 +296,7 @@ class TestIndex(tm.TestCase):
 
             tm.assert_isinstance(index_result, np.ndarray)
             self.assert_(not isinstance(index_result, Index))
-            self.assert_(np.array_equal(arr_result, index_result))
+            self.assert_numpy_array_equal(arr_result, index_result)
 
         _check(operator.eq)
         _check(operator.ne)
@@ -335,10 +335,10 @@ class TestIndex(tm.TestCase):
         self.assert_(shifted is self.dateIndex)
 
         shifted = self.dateIndex.shift(5, timedelta(1))
-        self.assert_(np.array_equal(shifted, self.dateIndex + timedelta(5)))
+        self.assert_numpy_array_equal(shifted, self.dateIndex + timedelta(5))
 
         shifted = self.dateIndex.shift(1, 'B')
-        self.assert_(np.array_equal(shifted, self.dateIndex + offsets.BDay()))
+        self.assert_numpy_array_equal(shifted, self.dateIndex + offsets.BDay())
 
         shifted.name = 'shifted'
         self.assertEqual(shifted.name, shifted.shift(1, 'D').name)
@@ -477,7 +477,7 @@ class TestIndex(tm.TestCase):
             unpickled = pickle.loads(pickled)
 
             tm.assert_isinstance(unpickled, Index)
-            self.assert_(np.array_equal(unpickled, index))
+            self.assert_numpy_array_equal(unpickled, index)
             self.assertEquals(unpickled.name, index.name)
 
             # tm.assert_dict_equal(unpickled.indexMap, index.indexMap)
@@ -678,7 +678,7 @@ class TestIndex(tm.TestCase):
         idx = Index(['qux', 'baz', 'foo', 'bar'])
         result = idx.isin(values)
         expected = np.array([False, False, True, True])
-        self.assert_(np.array_equal(result, expected))
+        self.assert_numpy_array_equal(result, expected)
 
         # empty, return dtype bool
         idx = Index([])
@@ -822,11 +822,11 @@ class TestInt64Index(tm.TestCase):
         # pass list, coerce fine
         index = Int64Index([-5, 0, 1, 2])
         expected = np.array([-5, 0, 1, 2], dtype=np.int64)
-        self.assert_(np.array_equal(index, expected))
+        self.assert_numpy_array_equal(index, expected)
 
         # from iterable
         index = Int64Index(iter([-5, 0, 1, 2]))
-        self.assert_(np.array_equal(index, expected))
+        self.assert_numpy_array_equal(index, expected)
 
         # scalar raise Exception
         self.assertRaises(TypeError, Int64Index, 5)
@@ -834,7 +834,7 @@ class TestInt64Index(tm.TestCase):
         # copy
         arr = self.index.values
         new_index = Int64Index(arr, copy=True)
-        self.assert_(np.array_equal(new_index, self.index))
+        self.assert_numpy_array_equal(new_index, self.index)
         val = arr[0] + 3000
         # this should not change index
         arr[0] = val
@@ -912,19 +912,19 @@ class TestInt64Index(tm.TestCase):
         target = Int64Index(np.arange(10))
         indexer = self.index.get_indexer(target)
         expected = np.array([0, -1, 1, -1, 2, -1, 3, -1, 4, -1])
-        self.assert_(np.array_equal(indexer, expected))
+        self.assert_numpy_array_equal(indexer, expected)
 
     def test_get_indexer_pad(self):
         target = Int64Index(np.arange(10))
         indexer = self.index.get_indexer(target, method='pad')
         expected = np.array([0, 0, 1, 1, 2, 2, 3, 3, 4, 4])
-        self.assert_(np.array_equal(indexer, expected))
+        self.assert_numpy_array_equal(indexer, expected)
 
     def test_get_indexer_backfill(self):
         target = Int64Index(np.arange(10))
         indexer = self.index.get_indexer(target, method='backfill')
         expected = np.array([0, 1, 1, 2, 2, 3, 3, 4, 4, 5])
-        self.assert_(np.array_equal(indexer, expected))
+        self.assert_numpy_array_equal(indexer, expected)
 
     def test_join_outer(self):
         other = Int64Index([7, 12, 25, 1, 2, 5])
@@ -945,8 +945,8 @@ class TestInt64Index(tm.TestCase):
 
         tm.assert_isinstance(res, Int64Index)
         self.assert_(res.equals(eres))
-        self.assert_(np.array_equal(lidx, elidx))
-        self.assert_(np.array_equal(ridx, eridx))
+        self.assert_numpy_array_equal(lidx, elidx)
+        self.assert_numpy_array_equal(ridx, eridx)
 
         # monotonic
         res, lidx, ridx = self.index.join(other_mono, how='outer',
@@ -958,8 +958,8 @@ class TestInt64Index(tm.TestCase):
                          dtype=np.int64)
         tm.assert_isinstance(res, Int64Index)
         self.assert_(res.equals(eres))
-        self.assert_(np.array_equal(lidx, elidx))
-        self.assert_(np.array_equal(ridx, eridx))
+        self.assert_numpy_array_equal(lidx, elidx)
+        self.assert_numpy_array_equal(ridx, eridx)
 
     def test_join_inner(self):
         other = Int64Index([7, 12, 25, 1, 2, 5])
@@ -981,8 +981,8 @@ class TestInt64Index(tm.TestCase):
 
         tm.assert_isinstance(res, Int64Index)
         self.assert_(res.equals(eres))
-        self.assert_(np.array_equal(lidx, elidx))
-        self.assert_(np.array_equal(ridx, eridx))
+        self.assert_numpy_array_equal(lidx, elidx)
+        self.assert_numpy_array_equal(ridx, eridx)
 
         # monotonic
         res, lidx, ridx = self.index.join(other_mono, how='inner',
@@ -994,8 +994,8 @@ class TestInt64Index(tm.TestCase):
         eridx = np.array([1, 4])
         tm.assert_isinstance(res, Int64Index)
         self.assert_(res.equals(eres))
-        self.assert_(np.array_equal(lidx, elidx))
-        self.assert_(np.array_equal(ridx, eridx))
+        self.assert_numpy_array_equal(lidx, elidx)
+        self.assert_numpy_array_equal(ridx, eridx)
 
     def test_join_left(self):
         other = Int64Index([7, 12, 25, 1, 2, 5])
@@ -1011,7 +1011,7 @@ class TestInt64Index(tm.TestCase):
         tm.assert_isinstance(res, Int64Index)
         self.assert_(res.equals(eres))
         self.assert_(lidx is None)
-        self.assert_(np.array_equal(ridx, eridx))
+        self.assert_numpy_array_equal(ridx, eridx)
 
         # monotonic
         res, lidx, ridx = self.index.join(other_mono, how='left',
@@ -1021,7 +1021,7 @@ class TestInt64Index(tm.TestCase):
         tm.assert_isinstance(res, Int64Index)
         self.assert_(res.equals(eres))
         self.assert_(lidx is None)
-        self.assert_(np.array_equal(ridx, eridx))
+        self.assert_numpy_array_equal(ridx, eridx)
 
         # non-unique
         """
@@ -1032,8 +1032,8 @@ class TestInt64Index(tm.TestCase):
         eridx = np.array([0, 2, 3, -1, -1])
         elidx = np.array([0, 1, 2, 3, 4])
         self.assert_(res.equals(eres))
-        self.assert_(np.array_equal(lidx, elidx))
-        self.assert_(np.array_equal(ridx, eridx))
+        self.assert_numpy_array_equal(lidx, elidx)
+        self.assert_numpy_array_equal(ridx, eridx)
         """
 
     def test_join_right(self):
@@ -1049,7 +1049,7 @@ class TestInt64Index(tm.TestCase):
 
         tm.assert_isinstance(other, Int64Index)
         self.assert_(res.equals(eres))
-        self.assert_(np.array_equal(lidx, elidx))
+        self.assert_numpy_array_equal(lidx, elidx)
         self.assert_(ridx is None)
 
         # monotonic
@@ -1060,7 +1060,7 @@ class TestInt64Index(tm.TestCase):
                          dtype=np.int64)
         tm.assert_isinstance(other, Int64Index)
         self.assert_(res.equals(eres))
-        self.assert_(np.array_equal(lidx, elidx))
+        self.assert_numpy_array_equal(lidx, elidx)
         self.assert_(ridx is None)
 
         # non-unique
@@ -1072,8 +1072,8 @@ class TestInt64Index(tm.TestCase):
         elidx = np.array([0, 2, 3, -1, -1])
         eridx = np.array([0, 1, 2, 3, 4])
         self.assert_(res.equals(eres))
-        self.assert_(np.array_equal(lidx, elidx))
-        self.assert_(np.array_equal(ridx, eridx))
+        self.assert_numpy_array_equal(lidx, elidx)
+        self.assert_numpy_array_equal(ridx, eridx)
 
         idx = Index([1,1,2,5])
         idx2 = Index([1,2,5,9,7])
@@ -1119,10 +1119,10 @@ class TestInt64Index(tm.TestCase):
         self.assert_(joined.equals(exp_joined))
 
         exp_lidx = np.array([2, 2, 3, 3, 0, 0, 1, 1], dtype=np.int64)
-        self.assert_(np.array_equal(lidx, exp_lidx))
+        self.assert_numpy_array_equal(lidx, exp_lidx)
 
         exp_ridx = np.array([2, 3, 2, 3, 0, 1, 0, 1], dtype=np.int64)
-        self.assert_(np.array_equal(ridx, exp_ridx))
+        self.assert_numpy_array_equal(ridx, exp_ridx)
 
     def test_join_self(self):
         kinds = 'outer', 'inner', 'left', 'right'
@@ -1134,12 +1134,12 @@ class TestInt64Index(tm.TestCase):
         other = Index([1, 2, 3, 4, 5])
         result = self.index.intersection(other)
         expected = np.sort(np.intersect1d(self.index.values, other.values))
-        self.assert_(np.array_equal(result, expected))
+        self.assert_numpy_array_equal(result, expected)
 
         result = other.intersection(self.index)
         expected = np.sort(np.asarray(np.intersect1d(self.index.values,
                                                      other.values)))
-        self.assert_(np.array_equal(result, expected))
+        self.assert_numpy_array_equal(result, expected)
 
     def test_intersect_str_dates(self):
         dt_dates = [datetime(2012, 2, 9), datetime(2012, 2, 22)]
@@ -1157,11 +1157,11 @@ class TestInt64Index(tm.TestCase):
         other = Index([now + timedelta(i) for i in range(4)], dtype=object)
         result = self.index.union(other)
         expected = np.concatenate((self.index, other))
-        self.assert_(np.array_equal(result, expected))
+        self.assert_numpy_array_equal(result, expected)
 
         result = other.union(self.index)
         expected = np.concatenate((other, self.index))
-        self.assert_(np.array_equal(result, expected))
+        self.assert_numpy_array_equal(result, expected)
 
     def test_cant_or_shouldnt_cast(self):
         # can't
@@ -1615,13 +1615,13 @@ class TestMultiIndex(tm.TestCase):
     def test_get_level_values(self):
         result = self.index.get_level_values(0)
         expected = ['foo', 'foo', 'bar', 'baz', 'qux', 'qux']
-        self.assert_(np.array_equal(result, expected))
+        self.assert_numpy_array_equal(result, expected)
 
         self.assertEquals(result.name, 'first')
 
         result = self.index.get_level_values('first')
         expected = self.index.get_level_values(0)
-        self.assert_(np.array_equal(result, expected))
+        self.assert_numpy_array_equal(result, expected)
 
     def test_get_level_values_na(self):
         arrays = [['a', 'b', 'b'], [1, np.nan, 2]]
@@ -2269,7 +2269,7 @@ class TestMultiIndex(tm.TestCase):
     def test_argsort(self):
         result = self.index.argsort()
         expected = self.index._tuple_index.argsort()
-        self.assert_(np.array_equal(result, expected))
+        self.assert_numpy_array_equal(result, expected)
 
     def test_sortlevel(self):
         import random
@@ -2381,10 +2381,10 @@ class TestMultiIndex(tm.TestCase):
 
         # key not contained in all levels
         new_index = self.index.insert(0, ('abc', 'three'))
-        self.assert_(np.array_equal(new_index.levels[0],
-                                    list(self.index.levels[0]) + ['abc']))
-        self.assert_(np.array_equal(new_index.levels[1],
-                                    list(self.index.levels[1]) + ['three']))
+        self.assert_numpy_array_equal(new_index.levels[0],
+                                      list(self.index.levels[0]) + ['abc'])
+        self.assert_numpy_array_equal(new_index.levels[1],
+                                      list(self.index.levels[1]) + ['three'])
         self.assertEqual(new_index[0], ('abc', 'three'))
 
         # key wrong length
@@ -2409,7 +2409,7 @@ class TestMultiIndex(tm.TestCase):
             mask = np.array(
                 [x[1] in exp_level for x in self.index], dtype=bool)
             exp_values = self.index.values[mask]
-            self.assert_(np.array_equal(join_index.values, exp_values))
+            self.assert_numpy_array_equal(join_index.values, exp_values)
 
             if how in ('outer', 'inner'):
                 join_index2, ridx2, lidx2 = \
@@ -2417,9 +2417,9 @@ class TestMultiIndex(tm.TestCase):
                                     return_indexers=True)
 
                 self.assert_(join_index.equals(join_index2))
-                self.assert_(np.array_equal(lidx, lidx2))
-                self.assert_(np.array_equal(ridx, ridx2))
-                self.assert_(np.array_equal(join_index2.values, exp_values))
+                self.assert_numpy_array_equal(lidx, lidx2)
+                self.assert_numpy_array_equal(ridx, ridx2)
+                self.assert_numpy_array_equal(join_index2.values, exp_values)
 
         def _check_all(other):
             _check_how(other, 'outer')
@@ -2467,11 +2467,11 @@ class TestMultiIndex(tm.TestCase):
 
         self.assert_(target.equals(exp_index))
         exp_indexer = np.array([0, 2, 4])
-        self.assert_(np.array_equal(indexer, exp_indexer))
+        self.assert_numpy_array_equal(indexer, exp_indexer)
 
         self.assert_(target2.equals(exp_index2))
         exp_indexer2 = np.array([0, -1, 0, -1, 0, -1])
-        self.assert_(np.array_equal(indexer2, exp_indexer2))
+        self.assert_numpy_array_equal(indexer2, exp_indexer2)
 
         assertRaisesRegexp(TypeError, "Fill method not supported",
                            self.index.reindex, self.index, method='pad',

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -147,7 +147,7 @@ class TestBlock(tm.TestCase):
 
     def test_items(self):
         cols = self.fblock.items
-        self.assert_(np.array_equal(cols, ['a', 'c', 'e']))
+        self.assert_numpy_array_equal(cols, ['a', 'c', 'e'])
 
         cols2 = self.fblock.items
         self.assert_(cols is cols2)
@@ -155,8 +155,7 @@ class TestBlock(tm.TestCase):
     def test_assign_ref_items(self):
         new_cols = Index(['foo', 'bar', 'baz', 'quux', 'hi'])
         self.fblock.set_ref_items(new_cols)
-        self.assert_(np.array_equal(self.fblock.items,
-                                    ['foo', 'baz', 'hi']))
+        self.assert_numpy_array_equal(self.fblock.items, ['foo', 'baz', 'hi'])
 
     def test_reindex_index(self):
         pass

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -375,8 +375,8 @@ class CheckIndexing(object):
 
         def test_comp(func):
             result = func(p1, p2)
-            self.assert_(np.array_equal(result.values,
-                                        func(p1.values, p2.values)))
+            self.assert_numpy_array_equal(result.values,
+                                          func(p1.values, p2.values))
 
             # versus non-indexed same objs
             self.assertRaises(Exception, func, p1, tp)
@@ -385,8 +385,8 @@ class CheckIndexing(object):
             self.assertRaises(Exception, func, p1, p)
 
             result3 = func(self.panel4d, 0)
-            self.assert_(np.array_equal(result3.values,
-                                        func(self.panel4d.values, 0)))
+            self.assert_numpy_array_equal(result3.values,
+                                          func(self.panel4d.values, 0))
 
         test_comp(operator.eq)
         test_comp(operator.ne)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -798,7 +798,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         result = s[list(mask)]
         expected = s[mask]
         assert_series_equal(result, expected)
-        self.assert_(np.array_equal(result.index, s.index[mask]))
+        self.assert_numpy_array_equal(result.index, s.index[mask])
 
     def test_getitem_boolean_empty(self):
         s = Series([], dtype=np.int64)
@@ -1737,7 +1737,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         self.assert_(getkeys() is self.ts.index)
 
     def test_values(self):
-        self.assert_(np.array_equal(self.ts, self.ts.values))
+        self.assert_numpy_array_equal(self.ts, self.ts.values)
 
     def test_iteritems(self):
         for idx, val in compat.iteritems(self.series):
@@ -1889,8 +1889,8 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         mexpected = np.argsort(s.values, kind='mergesort')
         qexpected = np.argsort(s.values, kind='quicksort')
 
-        self.assert_(np.array_equal(mindexer, mexpected))
-        self.assert_(np.array_equal(qindexer, qexpected))
+        self.assert_numpy_array_equal(mindexer, mexpected)
+        self.assert_numpy_array_equal(qindexer, qexpected)
         self.assert_(not np.array_equal(qindexer, mindexer))
 
     def test_reorder_levels(self):
@@ -1938,24 +1938,24 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         self._check_accum_op('cumprod')
 
     def test_cummin(self):
-        self.assert_(np.array_equal(self.ts.cummin(),
-                                    np.minimum.accumulate(np.array(self.ts))))
+        self.assert_numpy_array_equal(self.ts.cummin(),
+                                      np.minimum.accumulate(np.array(self.ts)))
         ts = self.ts.copy()
         ts[::2] = np.NaN
         result = ts.cummin()[1::2]
         expected = np.minimum.accumulate(ts.valid())
 
-        self.assert_(np.array_equal(result, expected))
+        self.assert_numpy_array_equal(result, expected)
 
     def test_cummax(self):
-        self.assert_(np.array_equal(self.ts.cummax(),
-                                    np.maximum.accumulate(np.array(self.ts))))
+        self.assert_numpy_array_equal(self.ts.cummax(),
+                                      np.maximum.accumulate(np.array(self.ts)))
         ts = self.ts.copy()
         ts[::2] = np.NaN
         result = ts.cummax()[1::2]
         expected = np.maximum.accumulate(ts.valid())
 
-        self.assert_(np.array_equal(result, expected))
+        self.assert_numpy_array_equal(result, expected)
 
     def test_npdiff(self):
         raise nose.SkipTest("skipping due to Series no longer being an "
@@ -2022,7 +2022,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
     def _check_accum_op(self, name):
         func = getattr(np, name)
-        self.assert_(np.array_equal(func(self.ts), func(np.array(self.ts))))
+        self.assert_numpy_array_equal(func(self.ts), func(np.array(self.ts)))
 
         # with missing values
         ts = self.ts.copy()
@@ -2031,7 +2031,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         result = func(ts)[1::2]
         expected = func(np.array(ts.valid()))
 
-        self.assert_(np.array_equal(result, expected))
+        self.assert_numpy_array_equal(result, expected)
 
     def test_round(self):
         # numpy.round doesn't preserve metadata, probably a numpy bug,
@@ -2824,16 +2824,16 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
     def test_fillna(self):
         ts = Series([0., 1., 2., 3., 4.], index=tm.makeDateIndex(5))
 
-        self.assert_(np.array_equal(ts, ts.fillna(method='ffill')))
+        self.assert_numpy_array_equal(ts, ts.fillna(method='ffill'))
 
         ts[2] = np.NaN
 
         self.assert_(
             np.array_equal(ts.fillna(method='ffill'), [0., 1., 1., 3., 4.]))
-        self.assert_(np.array_equal(ts.fillna(method='backfill'),
-                                    [0., 1., 3., 3., 4.]))
+        self.assert_numpy_array_equal(ts.fillna(method='backfill'),
+                                      [0., 1., 3., 3., 4.])
 
-        self.assert_(np.array_equal(ts.fillna(value=5), [0., 1., 5., 3., 4.]))
+        self.assert_numpy_array_equal(ts.fillna(value=5), [0., 1., 5., 3., 4.])
 
         self.assertRaises(ValueError, ts.fillna)
         self.assertRaises(ValueError, self.ts.fillna, value=0, method='ffill')
@@ -3417,7 +3417,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         int_ts = self.ts.astype(int)[:-5]
         added = self.ts + int_ts
         expected = self.ts.values[:-5] + int_ts.values
-        self.assert_(np.array_equal(added[:-5], expected))
+        self.assert_numpy_array_equal(added[:-5], expected)
 
     def test_operators_reverse_object(self):
         # GH 56
@@ -3529,14 +3529,14 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # nothing used from the input
         combined = series.combine_first(series_copy)
 
-        self.assert_(np.array_equal(combined, series))
+        self.assert_numpy_array_equal(combined, series)
 
         # Holes filled from input
         combined = series_copy.combine_first(series)
         self.assert_(np.isfinite(combined).all())
 
-        self.assert_(np.array_equal(combined[::2], series[::2]))
-        self.assert_(np.array_equal(combined[1::2], series_copy[1::2]))
+        self.assert_numpy_array_equal(combined[::2], series[::2])
+        self.assert_numpy_array_equal(combined[1::2], series_copy[1::2])
 
         # mixed types
         index = tm.makeStringIndex(20)
@@ -3817,25 +3817,25 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         s = Series(np.random.randint(0, 100, size=100))
         result = np.sort(s.unique())
         expected = np.unique(s.values)
-        self.assert_(np.array_equal(result, expected))
+        self.assert_numpy_array_equal(result, expected)
 
         s = Series(np.random.randint(0, 100, size=100).astype(np.int32))
         result = np.sort(s.unique())
         expected = np.unique(s.values)
-        self.assert_(np.array_equal(result, expected))
+        self.assert_numpy_array_equal(result, expected)
 
         # test string arrays for coverage
         strings = np.tile(np.array([tm.rands(10) for _ in range(10)]), 10)
         result = np.sort(nanops.unique1d(strings))
         expected = np.unique(strings)
-        self.assert_(np.array_equal(result, expected))
+        self.assert_numpy_array_equal(result, expected)
 
         # decision about None
 
         s = Series([1, 2, 3, None, None, None], dtype=object)
         result = s.unique()
         expected = np.array([1, 2, 3, None], dtype=object)
-        self.assert_(np.array_equal(result, expected))
+        self.assert_numpy_array_equal(result, expected)
 
     def test_dropna_empty(self):
         s = Series([])
@@ -3882,13 +3882,13 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         ts = self.ts.copy()
         ts.sort()
 
-        self.assert_(np.array_equal(ts, self.ts.order()))
-        self.assert_(np.array_equal(ts.index, self.ts.order().index))
+        self.assert_numpy_array_equal(ts, self.ts.order())
+        self.assert_numpy_array_equal(ts.index, self.ts.order().index)
 
         ts.sort(ascending=False)
-        self.assert_(np.array_equal(ts, self.ts.order(ascending=False)))
-        self.assert_(np.array_equal(ts.index,
-                                    self.ts.order(ascending=False).index))
+        self.assert_numpy_array_equal(ts, self.ts.order(ascending=False))
+        self.assert_numpy_array_equal(ts.index,
+                                      self.ts.order(ascending=False).index)
 
     def test_sort_index(self):
         import random
@@ -3912,11 +3912,11 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         result = ts.order()
         self.assert_(np.isnan(result[-5:]).all())
-        self.assert_(np.array_equal(result[:-5], np.sort(vals[5:])))
+        self.assert_numpy_array_equal(result[:-5], np.sort(vals[5:]))
 
         result = ts.order(na_last=False)
         self.assert_(np.isnan(result[:5]).all())
-        self.assert_(np.array_equal(result[5:], np.sort(vals[5:])))
+        self.assert_numpy_array_equal(result[5:], np.sort(vals[5:]))
 
         # something object-type
         ser = Series(['A', 'B'], [1, 2])
@@ -4031,7 +4031,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         assert_frame_equal(rs, xp)
 
     def test_to_dict(self):
-        self.assert_(np.array_equal(Series(self.ts.to_dict()), self.ts))
+        self.assert_numpy_array_equal(Series(self.ts.to_dict()), self.ts)
 
     def test_to_csv_float_format(self):
 
@@ -4528,7 +4528,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         arr = Series(['1', '2', '3', '4'], dtype=object)
         result = arr.astype(int)
-        self.assert_(np.array_equal(result, np.arange(1, 5)))
+        self.assert_numpy_array_equal(result, np.arange(1, 5))
 
     def test_astype_datetimes(self):
         import pandas.tslib as tslib
@@ -4579,7 +4579,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # function
         result = self.ts.map(lambda x: x * 2)
-        self.assert_(np.array_equal(result, self.ts * 2))
+        self.assert_numpy_array_equal(result, self.ts * 2)
 
     def test_map_int(self):
         left = Series({'a': 1., 'b': 2., 'c': 3., 'd': 4})
@@ -5053,7 +5053,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # partial dict
         s = Series(np.arange(4), index=['a', 'b', 'c', 'd'])
         renamed = s.rename({'b': 'foo', 'd': 'bar'})
-        self.assert_(np.array_equal(renamed.index, ['a', 'foo', 'c', 'bar']))
+        self.assert_numpy_array_equal(renamed.index, ['a', 'foo', 'c', 'bar'])
 
         # index with name
         renamer = Series(
@@ -5389,15 +5389,15 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         daily_ts = ts.asfreq('B')
         monthly_ts = daily_ts.asfreq('BM')
-        self.assert_(np.array_equal(monthly_ts, ts))
+        self.assert_numpy_array_equal(monthly_ts, ts)
 
         daily_ts = ts.asfreq('B', method='pad')
         monthly_ts = daily_ts.asfreq('BM')
-        self.assert_(np.array_equal(monthly_ts, ts))
+        self.assert_numpy_array_equal(monthly_ts, ts)
 
         daily_ts = ts.asfreq(datetools.bday)
         monthly_ts = daily_ts.asfreq(datetools.bmonthEnd)
-        self.assert_(np.array_equal(monthly_ts, ts))
+        self.assert_numpy_array_equal(monthly_ts, ts)
 
         result = ts[:0].asfreq('M')
         self.assertEqual(len(result), 0)

--- a/pandas/tests/test_tseries.py
+++ b/pandas/tests/test_tseries.py
@@ -34,7 +34,7 @@ class TestTseriesUtil(tm.TestCase):
         filler = algos.backfill_int64(old, new)
 
         expect_filler = [0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, -1]
-        self.assert_(np.array_equal(filler, expect_filler))
+        self.assert_numpy_array_equal(filler, expect_filler)
 
         # corner case
         old = Index([1, 4])
@@ -42,7 +42,7 @@ class TestTseriesUtil(tm.TestCase):
         filler = algos.backfill_int64(old, new)
 
         expect_filler = [-1, -1, -1, -1, -1]
-        self.assert_(np.array_equal(filler, expect_filler))
+        self.assert_numpy_array_equal(filler, expect_filler)
 
     def test_pad(self):
         old = Index([1, 5, 10])
@@ -51,14 +51,14 @@ class TestTseriesUtil(tm.TestCase):
         filler = algos.pad_int64(old, new)
 
         expect_filler = [-1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2]
-        self.assert_(np.array_equal(filler, expect_filler))
+        self.assert_numpy_array_equal(filler, expect_filler)
 
         # corner case
         old = Index([5, 10])
         new = Index(lrange(5))
         filler = algos.pad_int64(old, new)
         expect_filler = [-1, -1, -1, -1, -1]
-        self.assert_(np.array_equal(filler, expect_filler))
+        self.assert_numpy_array_equal(filler, expect_filler)
 
 
 def test_left_join_indexer_unique():

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -66,7 +66,7 @@ class TestCase(unittest.TestCase):
         #print("tearing down up: {0}".format(cls))
         pass
     
-    def assert_numpy_array_equals(self, np_array, assert_equal):
+    def assert_numpy_array_equal(self, np_array, assert_equal):
         if np.array_equal(np_array, assert_equal):
 	        return
         raise AssertionError('{0} is not equal to {1}.'.format(np_array, assert_equal))


### PR DESCRIPTION
Work on #6175. Work in progress. One more commit needed to finish; splitting to keep reasonably sized.
- Changes assert_numpy_array_equals to assert_numpy_array_equal, for consistency with other methods. (API change of recently-added function)
- Changes instances of assert_(np.array_equal(A,B)) to assert_numpy_array_equal(A,B)
- Update release.rst to reflect work on #6175
