### PR TITLE
PERF: fix performance for series slices (even more)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -79,7 +79,7 @@ Improvements to existing features
 - ``plot(legend='reverse')`` will now reverse the order of legend labels for most plot kinds.
   (:issue:`6014`)
 - Allow multi-index slicers (:issue:`6134`, :issue:`4036`, :issue:`3057`, :issue:`2598`, :issue:`5641`)
-- improve performance of slice indexing on Series with string keys (:issue:`6341`)
+- improve performance of slice indexing on Series with string keys (:issue:`6341`, :issue:`6372`)
 - implement joining a single-level indexed DataFrame on a matching column of a multi-indexed DataFrame (:issue:`3662`)
 - Performance improvement in indexing into a multi-indexed Series (:issue:`5567`)
 - Testing statements updated to use specialized asserts (:issue: `6175`)

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -153,7 +153,7 @@ Enhancements
   and parse accordingly. (:issue:`6223`)
 - ``plot(legend='reverse')`` will now reverse the order of legend labels for
   most plot kinds. (:issue:`6014`)
-- improve performance of slice indexing on Series with string keys (:issue:`6341`)
+- improve performance of slice indexing on Series with string keys (:issue:`6341`, :issue:`6372`)
 - Hexagonal bin plots from ``DataFrame.plot`` with ``kind='hexbin'`` (:issue:`5478`)
 - Joining a singly-indexed DataFrame with a multi-indexed DataFrame (:issue:`3662`)
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -463,8 +463,7 @@ class Series(generic.NDFrame):
         if raise_on_error:
             _check_slice_bounds(slobj, self.values)
         slobj = self.index._convert_slice_indexer(slobj, typ=typ or 'getitem')
-        return self._constructor(self.values[slobj],
-                                 index=self.index[slobj]).__finalize__(self)
+        return self._get_values(slobj)
 
     def __getitem__(self, key):
         try:
@@ -678,23 +677,6 @@ class Series(generic.NDFrame):
 
     # help out SparseSeries
     _get_val_at = ndarray.__getitem__
-
-    def __getslice__(self, i, j):
-        if i < 0:
-            i = 0
-        if j < 0:
-            j = 0
-        slobj = slice(i, j)
-        return self._slice(slobj)
-
-    def __setslice__(self, i, j, value):
-        """Set slice equal to given value(s)"""
-        if i < 0:
-            i = 0
-        if j < 0:
-            j = 0
-        slobj = slice(i, j)
-        return self.__setitem__(slobj, value)
 
     def repeat(self, reps):
         """

--- a/vb_suite/indexing.py
+++ b/vb_suite/indexing.py
@@ -34,8 +34,17 @@ setup = common_setup + """
 index = tm.makeStringIndex(1000000)
 s = Series(np.random.rand(1000000), index=index)
 """
-series_getitem_slice = Benchmark("s[:800000]", setup,
-                                 name="series_getitem_slice")
+series_getitem_pos_slice = Benchmark("s[:800000]", setup,
+                                     name="series_getitem_pos_slice")
+
+
+setup = common_setup + """
+index = tm.makeStringIndex(1000000)
+s = Series(np.random.rand(1000000), index=index)
+lbl = s.index[800000]
+"""
+series_getitem_label_slice = Benchmark("s[:lbl]", setup,
+                                       name="series_getitem_label_slice")
 
 
 #----------------------------------------------------------------------


### PR DESCRIPTION
This is a continuation of #6341 and is related to #6370. The latter unfortunately concerns public API and may be not easy to fix gracefully.

So, regardless of the decision to be made in other ticket, this patch will optimize series slicing right away and remove some redundant code (no need to override `__getslice__` because `Series` doesn't inherit `ndarray` anymore).
