### PR TITLE
ENH: Add new specialized asserts for tests

### DIFF
--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -101,7 +101,7 @@ class TestFrozenNDArray(CheckImmutable, CheckStringMixin, tm.TestCase):
         original = self.container.copy()
         assert_isinstance(self.container.view(), FrozenNDArray)
         self.assert_(not isinstance(self.container.view(np.ndarray), FrozenNDArray))
-        self.assert_(self.container.view() is not self.container)
+        self.assertIsNot(self.container.view(), self.container)
         self.assert_numpy_array_equal(self.container, original)
         # shallow copy should be the same too
         assert_isinstance(self.container._shallow_copy(), FrozenNDArray)
@@ -115,7 +115,7 @@ class TestFrozenNDArray(CheckImmutable, CheckStringMixin, tm.TestCase):
         n = original[0] + 15
         vals = self.container.values()
         self.assert_numpy_array_equal(original, vals)
-        self.assert_(original is not vals)
+        self.assertIsNot(original, vals)
         vals[0] = n
         self.assert_numpy_array_equal(self.container, original)
         self.assertEqual(vals[0], n)

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -1352,7 +1352,7 @@ class TestMultiIndex(tm.TestCase):
         mi2 = MultiIndex(levels=levels2, labels=labels)
         vals = mi1.values.copy()
         vals2 = mi2.values.copy()
-        self.assert_(mi1._tuples is not None)
+        self.assertIsNotNone(mi1._tuples)
 
         # make sure level setting works
         new_vals = mi1.set_levels(levels2).values

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -142,7 +142,7 @@ class TestBlock(tm.TestCase):
 
     def test_copy(self):
         cop = self.fblock.copy()
-        self.assert_(cop is not self.fblock)
+        self.assertIsNot(cop, self.fblock)
         assert_block_equal(self.fblock, cop)
 
     def test_items(self):
@@ -150,7 +150,7 @@ class TestBlock(tm.TestCase):
         self.assert_numpy_array_equal(cols, ['a', 'c', 'e'])
 
         cols2 = self.fblock.items
-        self.assert_(cols is cols2)
+        self.assertIs(cols, cols2)
 
     def test_assign_ref_items(self):
         new_cols = Index(['foo', 'bar', 'baz', 'quux', 'hi'])
@@ -305,8 +305,8 @@ class TestBlockManager(tm.TestCase):
         self.assertRaises(AssertionError, mgr._set_ref_locs, do_refs=True)
 
     def test_contains(self):
-        self.assert_('a' in self.mgr)
-        self.assert_('baz' not in self.mgr)
+        self.assertIn('a', self.mgr)
+        self.assertNotIn('baz', self.mgr)
 
     def test_pickle(self):
         import pickle
@@ -318,7 +318,7 @@ class TestBlockManager(tm.TestCase):
         assert_frame_equal(DataFrame(self.mgr), DataFrame(mgr2))
 
         # share ref_items
-        self.assert_(mgr2.blocks[0].ref_items is mgr2.blocks[1].ref_items)
+        self.assertIs(mgr2.blocks[0].ref_items, mgr2.blocks[1].ref_items)
 
         # GH2431
         self.assertTrue(hasattr(mgr2, "_is_consolidated"))

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -69,8 +69,8 @@ class CheckNameIntegration(object):
         # making a copy
 
         self.ts.index.name = None
-        self.assert_(self.ts.index.name is None)
-        self.assert_(self.ts is self.ts)
+        self.assertIsNone(self.ts.index.name)
+        self.assertIs(self.ts, self.ts)
         cp = self.ts.copy()
         cp.index.name = 'foo'
         print(self.ts.index.name)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -71,6 +71,31 @@ class TestCase(unittest.TestCase):
 	        return
         raise AssertionError('{0} is not equal to {1}.'.format(np_array, assert_equal))
 
+    def assertIs(self, a, b, msg=''):
+        """Checks that 'a' is 'b'"""
+        assert a is b, "%s: %r is not %r" % (msg.format(a,b), a, b)
+
+    def assertIsNot(self, a, b, msg=''):
+        """Checks that 'a' is not 'b'"""
+        assert a is not b, "%s: %r is %r" % (msg.format(a,b), a, b)
+
+    def assertIsNone(self, a, msg=''):
+        """Checks that 'a' is None"""
+        self.assertIs(a, None, msg)
+
+    def assertIsNotNone(self, a, msg=''):
+        """Checks that 'a' is not None"""
+        self.assertIsNot(a, None, msg)
+
+    def assertIn(self, a, b, msg=''):
+        """Checks that 'a' is in 'b'"""
+        assert a in b, "%s: %r is not in %r" % (msg.format(a,b), a, b)
+
+    def assertNotIn(self, a, b, msg=''):
+        """Checks that 'a' is not in 'b'"""
+        assert a not in b, "%s: %r is in %r" % (msg.format(a,b), a, b)
+
+
 # NOTE: don't pass an NDFrame or index to this function - may not handle it
 # well.
 assert_almost_equal = _testing.assert_almost_equal


### PR DESCRIPTION
Work on #6175. Add versions of asserts (assertIs, assertIsNone, assertIn, plus complements) that were added in 2.7
