### PR TITLE
CLN: Change assert_(a in b) and assert_(a not in b) to specialized forms

### DIFF
--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -100,7 +100,7 @@ class TestFrozenNDArray(CheckImmutable, CheckStringMixin, tm.TestCase):
     def test_shallow_copying(self):
         original = self.container.copy()
         assert_isinstance(self.container.view(), FrozenNDArray)
-        self.assert_(not isinstance(self.container.view(np.ndarray), FrozenNDArray))
+        self.assertFalse(isinstance(self.container.view(np.ndarray), FrozenNDArray))
         self.assertIsNot(self.container.view(), self.container)
         self.assert_numpy_array_equal(self.container, original)
         # shallow copy should be the same too

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -127,15 +127,15 @@ class TestDataFrameFormatting(tm.TestCase):
 
             for line, value in lzip(r.split('\n'), df['B']):
                 if _strlen(value) + 1 > max_len:
-                    self.assert_('...' in line)
+                    self.assertIn('...', line)
                 else:
-                    self.assert_('...' not in line)
+                    self.assertNotIn('...', line)
 
         with option_context("display.max_colwidth", 999999):
-            self.assert_('...' not in repr(df))
+            self.assertNotIn('...', repr(df))
 
         with option_context("display.max_colwidth", max_len + 2):
-            self.assert_('...' not in repr(df))
+            self.assertNotIn('...', repr(df))
 
     def test_repr_chop_threshold(self):
         df = DataFrame([[0.1, 0.5],[0.5, -0.1]])
@@ -831,7 +831,7 @@ class TestDataFrameFormatting(tm.TestCase):
                 self.assert_(len(wider_repr) < len(wide_repr))
 
             for line in wide_repr.splitlines()[1::13]:
-                self.assert_('DataFrame Index' in line)
+                self.assertIn('DataFrame Index', line)
 
         reset_option('display.expand_frame_repr')
 
@@ -855,7 +855,7 @@ class TestDataFrameFormatting(tm.TestCase):
                 self.assert_(len(wider_repr) < len(wide_repr))
 
             for line in wide_repr.splitlines()[1::13]:
-                self.assert_('Level 0 Level 1' in line)
+                self.assertIn('Level 0 Level 1', line)
 
         reset_option('display.expand_frame_repr')
 
@@ -1251,7 +1251,7 @@ c  10  11  12  13  14\
 
     def test_to_html_columns_arg(self):
         result = self.frame.to_html(columns=['A'])
-        self.assert_('<th>B</th>' not in result)
+        self.assertNotIn('<th>B</th>', result)
 
     def test_to_html_multiindex(self):
         columns = pandas.MultiIndex.from_tuples(list(zip(np.arange(2).repeat(2),
@@ -1417,13 +1417,13 @@ c  10  11  12  13  14\
                               index=index)
         result = df.to_html(index=False)
         for i in index:
-            self.assert_(i not in result)
+            self.assertNotIn(i, result)
 
         tuples = [('foo', 'car'), ('foo', 'bike'), ('bar', 'car')]
         df.index = pandas.MultiIndex.from_tuples(tuples)
         result = df.to_html(index=False)
         for i in ['foo', 'bar', 'car', 'bike']:
-            self.assert_(i not in result)
+            self.assertNotIn(i, result)
 
     def test_repr_html(self):
         self.frame._repr_html_()
@@ -1578,7 +1578,7 @@ c  10  11  12  13  14\
 
         fmt.set_option('display.max_rows', 5, 'display.max_columns', 2)
         repstr = self.frame._repr_html_()
-        self.assert_('class' in repstr)  # info fallback
+        self.assertIn('class', repstr)  # info fallback
 
         fmt.reset_option('^display.')
 
@@ -1888,9 +1888,9 @@ class TestSeriesFormatting(tm.TestCase):
             if line.startswith('dtype:'):
                 continue
             if _three_digit_exp():
-                self.assert_('+010' in line)
+                self.assertIn('+010', line)
             else:
-                self.assert_('+10' in line)
+                self.assertIn('+10', line)
 
     def test_datetimeindex(self):
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -119,7 +119,7 @@ class CheckIndexing(object):
         for key, _ in compat.iteritems(self.frame._series):
             self.assert_(self.frame[key] is not None)
 
-        self.assert_('random' not in self.frame)
+        self.assertNotIn('random', self.frame)
         with assertRaisesRegexp(KeyError, 'no item named random'):
             self.frame['random']
 
@@ -399,7 +399,7 @@ class CheckIndexing(object):
         # not sure what else to do here
         series = self.frame['A'][::2]
         self.frame['col5'] = series
-        self.assert_('col5' in self.frame)
+        self.assertIn('col5', self.frame)
         tm.assert_dict_equal(series, self.frame['col5'],
                              compare_keys=False)
 
@@ -551,7 +551,7 @@ class CheckIndexing(object):
                        index=np.arange(3))
         del df['B']
         df['B'] = [1., 2., 3.]
-        self.assert_('B' in df)
+        self.assertIn('B', df)
         self.assertEqual(len(df.columns), 2)
 
         df['A'] = 'beginning'
@@ -2060,7 +2060,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                         'E': np.random.randn(5)})
         with assertRaisesRegexp(ValueError, 'Index has duplicate keys'):
             df.set_index('A', verify_integrity=True, inplace=True)
-        self.assert_('A' in df)
+        self.assertIn('A', df)
 
     def test_set_index_bug(self):
         # GH1590
@@ -2287,7 +2287,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                           columns=['col2', 'col3', 'col4'])
 
         self.assertEqual(len(frame), len(self.ts2))
-        self.assert_('col1' not in frame)
+        self.assertNotIn('col1', frame)
         self.assert_(isnull(frame['col3']).all())
 
         # Corner cases
@@ -3810,7 +3810,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         records = indexed_frame.to_records(index=False)
         self.assertEqual(len(records.dtype.names), 2)
-        self.assert_('index' not in records.dtype.names)
+        self.assertNotIn('index', records.dtype.names)
 
     def test_from_records_nones(self):
         tuples = [(1, 2, None, 3),
@@ -4007,16 +4007,16 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df = DataFrame(np.random.randn(3, 3))
         df.index.name = 'X'
         rs = df.to_records()
-        self.assert_('X' in rs.dtype.fields)
+        self.assertIn('X', rs.dtype.fields)
 
         df = DataFrame(np.random.randn(3, 3))
         rs = df.to_records()
-        self.assert_('index' in rs.dtype.fields)
+        self.assertIn('index', rs.dtype.fields)
 
         df.index = MultiIndex.from_tuples([('a', 'x'), ('a', 'y'), ('b', 'z')])
         df.index.names = ['A', None]
         rs = df.to_records()
-        self.assert_('level_0' in rs.dtype.fields)
+        self.assertIn('level_0', rs.dtype.fields)
 
     def test_join_str_datetime(self):
         str_dates = ['20120209', '20120222']
@@ -4340,7 +4340,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                                       ' the File through the code..')})
 
         result = repr(df)
-        self.assert_('StringCol' in result)
+        self.assertIn('StringCol', result)
 
     def test_head_tail(self):
         assert_frame_equal(self.frame.head(), self.frame[:5])
@@ -4404,17 +4404,17 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
     def test_delitem(self):
         del self.frame['A']
-        self.assert_('A' not in self.frame)
+        self.assertNotIn('A', self.frame)
 
     def test_pop(self):
         self.frame.columns.name = 'baz'
 
         A = self.frame.pop('A')
-        self.assert_('A' not in self.frame)
+        self.assertNotIn('A', self.frame)
 
         self.frame['foo'] = 'bar'
         foo = self.frame.pop('foo')
-        self.assert_('foo' not in self.frame)
+        self.assertNotIn('foo', self.frame)
         # TODO self.assertEqual(self.frame.columns.name, 'baz')
 
     def test_pop_non_unique_cols(self):
@@ -5162,7 +5162,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         for key, s in compat.iteritems(self.frame):
             assert_series_equal(larger_added[key], s + series[key])
-        self.assert_('E' in larger_added)
+        self.assertIn('E', larger_added)
         self.assert_(np.isnan(larger_added['E']).all())
 
         # vs mix (upcast) as needed
@@ -6473,7 +6473,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
     def test_copy(self):
         cop = self.frame.copy()
         cop['E'] = cop['A']
-        self.assert_('E' not in self.frame)
+        self.assertNotIn('E', self.frame)
 
         # copy objects
         copy = self.mixed_frame.copy()
@@ -6614,10 +6614,10 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         dropped = a.corrwith(b, axis=0, drop=True)
         assert_almost_equal(dropped['A'], a['A'].corr(b['A']))
-        self.assert_('B' not in dropped)
+        self.assertNotIn('B', dropped)
 
         dropped = a.corrwith(b, axis=1, drop=True)
-        self.assert_(a.index[-1] not in dropped.index)
+        self.assertNotIn(a.index[-1], dropped.index)
 
         # non time-series data
         index = ['a', 'b', 'c', 'd', 'e']
@@ -8327,7 +8327,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         assert_series_equal(newFrame['B'], self.frame['B'])
         self.assert_(np.isnan(newFrame['E']).all())
-        self.assert_('C' not in newFrame)
+        self.assertNotIn('C', newFrame)
 
         # length zero
         newFrame = self.frame.reindex(columns=[])
@@ -8885,15 +8885,15 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
     def test_rename_inplace(self):
         self.frame.rename(columns={'C': 'foo'})
-        self.assert_('C' in self.frame)
-        self.assert_('foo' not in self.frame)
+        self.assertIn('C', self.frame)
+        self.assertNotIn('foo', self.frame)
 
         c_id = id(self.frame['C'])
         frame = self.frame.copy()
         frame.rename(columns={'C': 'foo'}, inplace=True)
 
-        self.assert_('C' not in frame)
-        self.assert_('foo' in frame)
+        self.assertNotIn('C', frame)
+        self.assertIn('foo', frame)
         self.assertNotEqual(id(frame['foo']), c_id)
 
     def test_rename_bug(self):
@@ -9424,11 +9424,11 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # items
         filtered = self.frame.filter(['A', 'B', 'E'])
         self.assertEqual(len(filtered.columns), 2)
-        self.assert_('E' not in filtered)
+        self.assertNotIn('E', filtered)
 
         filtered = self.frame.filter(['A', 'B', 'E'], axis='columns')
         self.assertEqual(len(filtered.columns), 2)
-        self.assert_('E' not in filtered)
+        self.assertNotIn('E', filtered)
 
         # other axis
         idx = self.frame.index[0:4]
@@ -9442,7 +9442,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         filtered = fcopy.filter(like='A')
         self.assertEqual(len(filtered.columns), 2)
-        self.assert_('AA' in filtered)
+        self.assertIn('AA', filtered)
 
         # like with ints in column names
         df = DataFrame(0., index=[0, 1, 2], columns=[0, 1, '_A', '_B'])
@@ -9455,7 +9455,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # objects
         filtered = self.mixed_frame.filter(like='foo')
-        self.assert_('foo' in filtered)
+        self.assertIn('foo', filtered)
 
         # unicode columns, won't ascii-encode
         df = self.frame.rename(columns={'B': u('\u2202')})
@@ -9469,7 +9469,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # regex
         filtered = fcopy.filter(regex='[A]+')
         self.assertEqual(len(filtered.columns), 2)
-        self.assert_('AA' in filtered)
+        self.assertIn('AA', filtered)
 
         # doesn't have to be at beginning
         df = DataFrame({'aBBa': [1, 2],
@@ -10821,10 +10821,10 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
     def test_reindex_objects(self):
         reindexed = self.mixed_frame.reindex(columns=['foo', 'A', 'B'])
-        self.assert_('foo' in reindexed)
+        self.assertIn('foo', reindexed)
 
         reindexed = self.mixed_frame.reindex(columns=['A', 'B'])
-        self.assert_('foo' not in reindexed)
+        self.assertNotIn('foo', reindexed)
 
     def test_reindex_corner(self):
         index = Index(['a', 'b', 'c'])
@@ -10903,8 +10903,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
     def test_rename_objects(self):
         renamed = self.mixed_frame.rename(columns=str.upper)
-        self.assert_('FOO' in renamed)
-        self.assert_('foo' not in renamed)
+        self.assertIn('FOO', renamed)
+        self.assertNotIn('foo', renamed)
 
     def test_fill_corner(self):
         self.mixed_frame['foo'][5:20] = nan

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -2047,14 +2047,14 @@ class TestGroupBy(tm.TestCase):
         result = self.df.groupby(self.df['A']).mean()
         result2 = self.df.groupby(self.df['A'], as_index=False).mean()
         self.assertEquals(result.index.name, 'A')
-        self.assert_('A' in result2)
+        self.assertIn('A', result2)
 
         result = self.df.groupby([self.df['A'], self.df['B']]).mean()
         result2 = self.df.groupby([self.df['A'], self.df['B']],
                                   as_index=False).mean()
         self.assertEquals(result.index.names, ('A', 'B'))
-        self.assert_('A' in result2)
-        self.assert_('B' in result2)
+        self.assertIn('A', result2)
+        self.assertIn('B', result2)
 
     def test_groupby_nonstring_columns(self):
         df = DataFrame([np.arange(10) for x in range(10)])

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -431,16 +431,16 @@ class TestIndex(tm.TestCase):
         index = Index(['a', 'b', 'c'])
         index2 = index + 'foo'
 
-        self.assert_('a' not in index2)
-        self.assert_('afoo' in index2)
+        self.assertNotIn('a', index2)
+        self.assertIn('afoo', index2)
 
     def test_iadd_string(self):
         index = pd.Index(['a', 'b', 'c'])
         # doesn't fail test unless there is a check before `+=`
-        self.assert_('a' in index)
+        self.assertIn('a', index)
 
         index += '_x'
-        self.assert_('a_x' in index)
+        self.assertIn('a_x', index)
 
     def test_diff(self):
         first = self.strIndex[5:20]
@@ -505,8 +505,8 @@ class TestIndex(tm.TestCase):
         ind = Index(['{other}%s', "~:{range}:0"], name='A')
         result = ind.summary()
         # shouldn't be formatted accidentally.
-        self.assert_('~:{range}:0' in result)
-        self.assert_('{other}%s' in result)
+        self.assertIn('~:{range}:0', result)
+        self.assertIn('{other}%s', result)
 
     def test_format(self):
         self._check_method_works(Index.format)
@@ -1727,9 +1727,9 @@ class TestMultiIndex(tm.TestCase):
         self.assert_((result.values == self.index.values).all())
 
     def test_contains(self):
-        self.assert_(('foo', 'two') in self.index)
-        self.assert_(('bar', 'two') not in self.index)
-        self.assert_(None not in self.index)
+        self.assertIn(('foo', 'two'), self.index)
+        self.assertNotIn(('bar', 'two'), self.index)
+        self.assertNotIn(None, self.index)
 
     def test_is_all_dates(self):
         self.assert_(not self.index.is_all_dates)
@@ -1938,12 +1938,12 @@ class TestMultiIndex(tm.TestCase):
                            labels=[major_labels, minor_labels])
 
         result = index.truncate(before=1)
-        self.assert_('foo' not in result.levels[0])
-        self.assert_(1 in result.levels[0])
+        self.assertNotIn('foo', result.levels[0])
+        self.assertIn(1, result.levels[0])
 
         result = index.truncate(after=1)
-        self.assert_(2 not in result.levels[0])
-        self.assert_(1 in result.levels[0])
+        self.assertNotIn(2, result.levels[0])
+        self.assertIn(1, result.levels[0])
 
         result = index.truncate(before=1, after=2)
         self.assertEqual(len(result.levels[0]), 2)
@@ -2172,8 +2172,8 @@ class TestMultiIndex(tm.TestCase):
     #     other = Index(['A', 'B', 'C'])
 
     #     result = other.union(self.index)
-    #     self.assert_(('foo', 'one') in result)
-    #     self.assert_('B' in result)
+    #     self.assertIn(('foo', 'one'), result)
+    #     self.assertIn('B', result)
 
     #     result2 = self.index.union(other)
     #     self.assert_(result.equals(result2))

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -2474,14 +2474,14 @@ class TestIndexing(tm.TestCase):
         df = tm.makeDataFrame()
         df['A'] # cache series
         df.ix["Hello Friend"] = df.ix[0]
-        self.assert_("Hello Friend" in df['A'].index)
-        self.assert_("Hello Friend" in df['B'].index)
+        self.assertIn("Hello Friend", df['A'].index)
+        self.assertIn("Hello Friend", df['B'].index)
 
         panel = tm.makePanel()
         panel.ix[0] # get first item into cache
         panel.ix[:, :, 'A+1'] = panel.ix[:, :, 'A'] + 1
-        self.assert_("A+1" in panel.ix[0].columns)
-        self.assert_("A+1" in panel.ix[1].columns)
+        self.assertIn("A+1", panel.ix[0].columns)
+        self.assertIn("A+1", panel.ix[1].columns)
 
         # 5216
         # make sure that we don't try to set a dead cache

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -260,15 +260,15 @@ class TestBlockManager(tm.TestCase):
         self.assertEquals(len(self.mgr), len(self.mgr.items))
 
     def test_is_mixed_dtype(self):
-        self.assert_(self.mgr.is_mixed_type)
+        self.assertTrue(self.mgr.is_mixed_type)
 
         mgr = create_blockmanager([get_bool_ex(['a']), get_bool_ex(['b'])])
-        self.assert_(not mgr.is_mixed_type)
+        self.assertFalse(mgr.is_mixed_type)
 
     def test_is_indexed_like(self):
-        self.assert_(self.mgr._is_indexed_like(self.mgr))
+        self.assertTrue(self.mgr._is_indexed_like(self.mgr))
         mgr2 = self.mgr.reindex_axis(np.arange(N - 1), axis=1)
-        self.assert_(not self.mgr._is_indexed_like(mgr2))
+        self.assertFalse(self.mgr._is_indexed_like(mgr2))
 
     def test_block_id_vector_item_dtypes(self):
         expected = [0, 1, 0, 1, 0, 2, 3, 4]
@@ -512,7 +512,7 @@ class TestBlockManager(tm.TestCase):
 
         cons = self.mgr.consolidate()
         self.assertEquals(cons.nblocks, 1)
-        self.assert_(cons.blocks[0].items.equals(cons.items))
+        self.assertTrue(cons.blocks[0].items.equals(cons.items))
 
     def test_reindex_index(self):
         pass
@@ -591,7 +591,7 @@ class TestBlockManager(tm.TestCase):
         block1.ref_items = block2.ref_items = index
         bm1 = BlockManager([block1, block2], [index, np.arange(block1.shape[1])])
         bm2 = BlockManager([block2, block1], [index, np.arange(block1.shape[1])])
-        self.assert_(bm1.equals(bm2))
+        self.assertTrue(bm1.equals(bm2))
 
         # non-unique items
         index = Index(list('aaabbb'))
@@ -602,7 +602,7 @@ class TestBlockManager(tm.TestCase):
         block1.ref_items = block2.ref_items = index
         bm1 = BlockManager([block1, block2], [index, np.arange(block1.shape[1])])
         bm2 = BlockManager([block2, block1], [index, np.arange(block1.shape[1])])
-        self.assert_(bm1.equals(bm2))
+        self.assertTrue(bm1.equals(bm2))
 
 if __name__ == '__main__':
     import nose

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -192,7 +192,7 @@ class SafeForSparse(object):
         self.panel.items = new_items
 
         if hasattr(self.panel, '_item_cache'):
-            self.assert_('ItemA' not in self.panel._item_cache)
+            self.assertNotIn('ItemA', self.panel._item_cache)
         self.assert_(self.panel.items is new_items)
 
         item = self.panel[0]
@@ -409,10 +409,10 @@ class CheckIndexing(object):
         expected = self.panel['ItemA']
         result = self.panel.pop('ItemA')
         assert_frame_equal(expected, result)
-        self.assert_('ItemA' not in self.panel.items)
+        self.assertNotIn('ItemA', self.panel.items)
 
         del self.panel['ItemB']
-        self.assert_('ItemB' not in self.panel.items)
+        self.assertNotIn('ItemB', self.panel.items)
         self.assertRaises(Exception, self.panel.__delitem__, 'ItemB')
 
         values = np.empty((3, 3, 3))

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -171,7 +171,7 @@ class SafeForSparse(object):
         self.panel4d.labels = new_labels
 
         if hasattr(self.panel4d, '_item_cache'):
-            self.assert_('l1' not in self.panel4d._item_cache)
+            self.assertNotIn('l1', self.panel4d._item_cache)
         self.assert_(self.panel4d.labels is new_labels)
 
         self.panel4d.major_axis = new_major
@@ -294,10 +294,10 @@ class CheckIndexing(object):
         expected = self.panel4d['l2']
         result = self.panel4d.pop('l2')
         assert_panel_equal(expected, result)
-        self.assert_('l2' not in self.panel4d.labels)
+        self.assertNotIn('l2', self.panel4d.labels)
 
         del self.panel4d['l3']
-        self.assert_('l3' not in self.panel4d.labels)
+        self.assertNotIn('l3', self.panel4d.labels)
         self.assertRaises(Exception, self.panel4d.__delitem__, 'l3')
 
         values = np.empty((4, 4, 4, 4))

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -74,7 +74,7 @@ class CheckNameIntegration(object):
         cp = self.ts.copy()
         cp.index.name = 'foo'
         print(self.ts.index.name)
-        self.assert_(self.ts.index.name is None)
+        self.assertIsNone(self.ts.index.name)
 
     def test_append_preserve_name(self):
         result = self.ts[:5].append(self.ts[5:])
@@ -93,7 +93,7 @@ class CheckNameIntegration(object):
         cp = self.ts.copy()
         cp.name = 'something else'
         result = self.ts + cp
-        self.assert_(result.name is None)
+        self.assertIsNone(result.name)
 
     def test_combine_first_name(self):
         result = self.ts.combine_first(self.ts[:5])
@@ -209,18 +209,18 @@ class CheckNameIntegration(object):
         # test small series
         s = Series([0, 1, 2])
         s.name = "test"
-        self.assert_("Name: test" in repr(s))
+        self.assertIn("Name: test", repr(s))
         s.name = None
-        self.assert_(not "Name:" in repr(s))
+        self.assertNotIn("Name:", repr(s))
         # test big series (diff code path)
         s = Series(lrange(0, 1000))
         s.name = "test"
-        self.assert_("Name: test" in repr(s))
+        self.assertIn("Name: test", repr(s))
         s.name = None
-        self.assert_(not "Name:" in repr(s))
+        self.assertNotIn("Name:", repr(s))
 
         s = Series(index=date_range('20010101', '20020101'), name='test')
-        self.assert_("Name: test" in repr(s))
+        self.assertIn("Name: test", repr(s))
 
     def test_pickle_preserve_name(self):
         unpickled = self._pickle_roundtrip_name(self.ts)
@@ -351,10 +351,10 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # Mixed type Series
         mixed = Series(['hello', np.NaN], index=[0, 1])
         self.assertEqual(mixed.dtype, np.object_)
-        self.assert_(mixed[1] is np.NaN)
+        self.assertIs(mixed[1], np.NaN)
 
-        self.assert_(not self.empty.is_time_series)
-        self.assert_(not Series({}).is_time_series)
+        self.assertFalse(self.empty.is_time_series)
+        self.assertFalse(Series({}).is_time_series)
 
         self.assertRaises(Exception, Series, np.random.randn(3, 3),
                           index=np.arange(3))
@@ -637,7 +637,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         data = {'a': 0, 'b': 1, 'c': 2, 'd': 3}
 
         series = Series(data)
-        self.assert_(tm.is_sorted(series.index))
+        self.assertTrue(tm.is_sorted(series.index))
 
         data = {'a': 0, 'b': '1', 'c': '2', 'd': datetime.now()}
         series = Series(data)
@@ -728,7 +728,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # GH 5652
         for s in [Series(), Series(index=list('abc'))]:
             result = s.get(None)
-            self.assert_(result is None)
+            self.assertIsNone(result)
 
     def test_iget(self):
         s = Series(np.random.randn(10), index=lrange(0, 20, 2))
@@ -956,8 +956,8 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         numSliceEnd = self.series[-10:]
         objSlice = self.objSeries[10:20]
 
-        self.assert_(self.series.index[9] not in numSlice.index)
-        self.assert_(self.objSeries.index[9] not in objSlice.index)
+        self.assertNotIn(self.series.index[9], numSlice.index)
+        self.assertNotIn(self.objSeries.index[9], objSlice.index)
 
         self.assertEqual(len(numSlice), len(numSlice.index))
         self.assertEqual(self.series[numSlice.index[0]],
@@ -1075,13 +1075,13 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
     def test_set_value(self):
         idx = self.ts.index[10]
         res = self.ts.set_value(idx, 0)
-        self.assert_(res is self.ts)
+        self.assertIs(res, self.ts)
         self.assertEqual(self.ts[idx], 0)
 
         # equiv
         s = self.series.copy()
         res = s.set_value('foobar', 0)
-        self.assert_(res is s)
+        self.assertIs(res, s)
         self.assertEqual(res.index[-1], 'foobar')
         self.assertEqual(res['foobar'], 0)
 
@@ -1628,12 +1628,12 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # 0 as name
         ser = Series(np.random.randn(100), name=0)
         rep_str = repr(ser)
-        self.assert_("Name: 0" in rep_str)
+        self.assertIn("Name: 0", rep_str)
 
         # tidy repr
         ser = Series(np.random.randn(1001), name=0)
         rep_str = repr(ser)
-        self.assert_("Name: 0" in rep_str)
+        self.assertIn("Name: 0", rep_str)
 
         ser = Series(["a\n\r\tb"], name=["a\n\r\td"], index=["a\n\r\tf"])
         self.assertFalse("\t" in repr(ser))
@@ -2890,7 +2890,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         try:
             self.ts.fillna(method='ffil')
         except ValueError as inst:
-            self.assert_('ffil' in str(inst))
+            self.assertIn('ffil', str(inst))
 
     def test_ffill(self):
         ts = Series([0., 1., 2., 3., 4.], index=tm.makeDateIndex(5))
@@ -5635,10 +5635,10 @@ class TestSeriesNonUnique(tm.TestCase):
 
         ser.name = 'value'
         df = ser.reset_index()
-        self.assert_('value' in df)
+        self.assertIn('value', df)
 
         df = ser.reset_index(name='value2')
-        self.assert_('value2' in df)
+        self.assertIn('value2', df)
 
         # check inplace
         s = ser.reset_index(drop=True)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -71,28 +71,32 @@ class TestCase(unittest.TestCase):
 	        return
         raise AssertionError('{0} is not equal to {1}.'.format(np_array, assert_equal))
 
-    def assertIs(self, a, b, msg=''):
-        """Checks that 'a' is 'b'"""
+    def assertIs(self, first, second, msg=''):
+        """Checks that 'first' is 'second'"""
+        a, b = first, second
         assert a is b, "%s: %r is not %r" % (msg.format(a,b), a, b)
 
-    def assertIsNot(self, a, b, msg=''):
-        """Checks that 'a' is not 'b'"""
+    def assertIsNot(self, first, second, msg=''):
+        """Checks that 'first' is not 'second'"""
+        a, b = first, second
         assert a is not b, "%s: %r is %r" % (msg.format(a,b), a, b)
 
-    def assertIsNone(self, a, msg=''):
-        """Checks that 'a' is None"""
-        self.assertIs(a, None, msg)
+    def assertIsNone(self, expr, msg=''):
+        """Checks that 'expr' is None"""
+        self.assertIs(expr, None, msg)
 
-    def assertIsNotNone(self, a, msg=''):
-        """Checks that 'a' is not None"""
-        self.assertIsNot(a, None, msg)
+    def assertIsNotNone(self, expr, msg=''):
+        """Checks that 'expr' is not None"""
+        self.assertIsNot(expr, None, msg)
 
-    def assertIn(self, a, b, msg=''):
-        """Checks that 'a' is in 'b'"""
+    def assertIn(self, first, second, msg=''):
+        """Checks that 'first' is in 'second'"""
+        a, b = first, second
         assert a in b, "%s: %r is not in %r" % (msg.format(a,b), a, b)
 
-    def assertNotIn(self, a, b, msg=''):
-        """Checks that 'a' is not in 'b'"""
+    def assertNotIn(self, first, second, msg=''):
+        """Checks that 'first' is not in 'second'"""
+        a, b = first, second
         assert a not in b, "%s: %r is in %r" % (msg.format(a,b), a, b)
 
 


### PR DESCRIPTION
Work on #6175. Changes instances of assert_(a [not] in b) to specialized assert[Not]In(a,b).
