### PR TITLE
CLN: Change assert_(a is [not] None) to specialized forms

### DIFF
--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -1480,7 +1480,7 @@ also also skip this
 2 2 2 e f
 """
         df = self.read_table(StringIO(data), sep=' ')
-        self.assert_(df.index.name is None)
+        self.assertIsNone(df.index.name)
 
     def test_converters(self):
         data = """A,B,C,D
@@ -2177,7 +2177,7 @@ c   1   2   3   4
         df = self.read_table(StringIO(data), sep='\s+')
         expected = self.read_csv(StringIO(re.sub('[ ]+', ',', data)),
                                  index_col=0)
-        self.assert_(expected.index.name is None)
+        self.assertIsNone(expected.index.name)
         tm.assert_frame_equal(df, expected)
 
     def test_1000_fwf(self):

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -777,12 +777,12 @@ class TestHDFStore(tm.TestCase):
             store.append('ss', ss)
             result = store['ss']
             tm.assert_series_equal(result, ss)
-            self.assert_(result.name is None)
+            self.assertIsNone(result.name)
 
             store.append('ts', ts)
             result = store['ts']
             tm.assert_series_equal(result, ts)
-            self.assert_(result.name is None)
+            self.assertIsNone(result.name)
 
             ns.name = 'foo'
             store.append('ns', ns)
@@ -3213,7 +3213,7 @@ class TestHDFStore(tm.TestCase):
                                                 index=date_range('2002-1-1',periods=3,freq='D'))))
                 store.append('data',df2)
 
-            self.assert_(store.get_storer('data').info['index']['freq'] is None)
+            self.assertIsNone(store.get_storer('data').info['index']['freq'])
 
             # this is ok
             _maybe_remove(store,'df2')
@@ -3248,7 +3248,7 @@ class TestHDFStore(tm.TestCase):
                 df2 = DataFrame(dict(A = Series(lrange(3), index=idx2)))
                 df2.to_hdf(path,'data',append=True)
 
-            self.assert_(read_hdf(path,'data').index.name is None)
+            self.assertIsNone(read_hdf(path,'data').index.name)
 
     def test_panel_select(self):
 

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -360,7 +360,7 @@ class TestSparseSeries(tm.TestCase,
 
     def test_get_get_value(self):
         assert_almost_equal(self.bseries.get(10), self.bseries[10])
-        self.assert_(self.bseries.get(len(self.bseries) + 1) is None)
+        self.assertIsNone(self.bseries.get(len(self.bseries) + 1))
 
         dt = self.btseries.index[10]
         result = self.btseries.get(dt)

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -979,7 +979,7 @@ class TestDataFrameFormatting(tm.TestCase):
 
         buf = StringIO()
         retval = biggie.to_string(buf=buf)
-        self.assert_(retval is None)
+        self.assertIsNone(retval)
         self.assertEqual(buf.getvalue(), s)
 
         tm.assert_isinstance(s, compat.string_types)
@@ -1208,7 +1208,7 @@ c  10  11  12  13  14\
 
         buf = StringIO()
         retval = biggie.to_html(buf=buf)
-        self.assert_(retval is None)
+        self.assertIsNone(retval)
         self.assertEqual(buf.getvalue(), s)
 
         tm.assert_isinstance(s, compat.string_types)
@@ -1574,7 +1574,7 @@ c  10  11  12  13  14\
                    {'parent_appname': 'ipython-qtconsole'}}}
 
         repstr = self.frame._repr_html_()
-        self.assert_(repstr is not None)
+        self.assertIsNotNone(repstr)
 
         fmt.set_option('display.max_rows', 5, 'display.max_columns', 2)
         repstr = self.frame._repr_html_()
@@ -1807,7 +1807,7 @@ class TestSeriesFormatting(tm.TestCase):
         s = self.ts.to_string()
 
         retval = self.ts.to_string(buf=buf)
-        self.assert_(retval is None)
+        self.assertIsNone(retval)
         self.assertEqual(buf.getvalue().strip(), s)
 
         # pass float_format

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -117,7 +117,7 @@ class CheckIndexing(object):
             self.assert_(tm.equalContents(series.index, sl.index))
 
         for key, _ in compat.iteritems(self.frame._series):
-            self.assert_(self.frame[key] is not None)
+            self.assertIsNotNone(self.frame[key])
 
         self.assertNotIn('random', self.frame)
         with assertRaisesRegexp(KeyError, 'no item named random'):
@@ -144,14 +144,14 @@ class CheckIndexing(object):
         b = self.frame.get('B')
         assert_series_equal(b, self.frame['B'])
 
-        self.assert_(self.frame.get('foo') is None)
+        self.assertIsNone(self.frame.get('foo'))
         assert_series_equal(self.frame.get('foo', self.frame['B']),
                             self.frame['B'])
         # None
         # GH 5652
         for df in [DataFrame(), DataFrame(columns=list('AB')), DataFrame(columns=list('AB'),index=range(3)) ]:
             result = df.get(None)
-            self.assert_(result is None)
+            self.assertIsNone(result)
 
     def test_getitem_iterator(self):
         idx = iter(['A', 'B', 'C'])
@@ -614,15 +614,15 @@ class CheckIndexing(object):
 
         dm[0] = np.ones(3)
         self.assertEqual(len(dm.columns), 3)
-        # self.assert_(dm.objects is None)
+        # self.assertIsNone(dm.objects)
 
         dm[1] = coercable_series
         self.assertEqual(len(dm.columns), 3)
-        # self.assert_(dm.objects is None)
+        # self.assertIsNone(dm.objects)
 
         dm[2] = uncoercable_series
         self.assertEqual(len(dm.columns), 3)
-        # self.assert_(dm.objects is not None)
+        # self.assertIsNotNone(dm.objects)
         self.assertEqual(dm[2].dtype, np.object_)
 
     def test_setitem_clear_caches(self):
@@ -1761,7 +1761,7 @@ class SafeForSparse(object):
             ind.name = None
             cp = self.frame.copy()
             getattr(cp, attr).name = 'foo'
-            self.assert_(getattr(self.frame, attr).name is None)
+            self.assertIsNone(getattr(self.frame, attr).name)
 
     def test_getitem_pop_assign_name(self):
         s = self.frame['A']
@@ -2174,7 +2174,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
     def test_constructor_dtype_list_data(self):
         df = DataFrame([[1, '2'],
                         [None, 'a']], dtype=object)
-        self.assert_(df.ix[1, 0] is None)
+        self.assertIsNone(df.ix[1, 0])
         self.assertEqual(df.ix[0, 1], '2')
 
     def test_constructor_list_frames(self):
@@ -3606,7 +3606,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df1 = DataFrame(randn(0, 3))
         df2 = DataFrame(randn(0, 3))
         df1.index.name = 'foo'
-        self.assert_(df2.index.name is None)
+        self.assertIsNone(df2.index.name)
 
     def test_astype(self):
         casted = self.frame.astype(int)

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -227,7 +227,7 @@ class Generic(object):
         for m in x._metadata:
             v = getattr(x,m,None)
             if y is None:
-                self.assert_(v is None)
+                self.assertIsNone(v)
             else:
                 self.assertEqual(v, getattr(y,m,None))
 

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -524,7 +524,7 @@ class TestDataFramePlots(tm.TestCase):
         axes = df.plot(subplots=True, sharex=True, legend=True)
 
         for ax in axes:
-            self.assert_(ax.get_legend() is not None)
+            self.assertIsNotNone(ax.get_legend())
 
         axes = df.plot(subplots=True, sharex=True)
         for ax in axes[:-2]:
@@ -649,7 +649,7 @@ class TestDataFramePlots(tm.TestCase):
         _check_plot_works(df.plot, kind='kde')
         _check_plot_works(df.plot, kind='kde', subplots=True)
         ax = df.plot(kind='kde')
-        self.assert_(ax.get_legend() is not None)
+        self.assertIsNotNone(ax.get_legend())
         axes = df.plot(kind='kde', logy=True, subplots=True)
         for ax in axes:
             self.assertEqual(ax.get_yscale(), 'log')

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -2397,7 +2397,7 @@ class TestGroupBy(tm.TestCase):
         s.name = None
 
         result = s.groupby(self.frame['A']).agg(np.sum)
-        self.assert_(result.name is None)
+        self.assertIsNone(result.name)
 
     def test_wrap_agg_out(self):
         grouped = self.three_group.groupby(['A', 'B'])
@@ -2575,7 +2575,7 @@ class TestGroupBy(tm.TestCase):
         # GH #1291
 
         result = self.df.groupby(self.df['A'].values).sum()
-        self.assert_(result.index.name is None)
+        self.assertIsNone(result.index.name)
 
         result = self.df.groupby([self.df['A'].values,
                                   self.df['B'].values]).sum()

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -71,7 +71,7 @@ class TestIndex(tm.TestCase):
             self.assertEqual(ind.name, original_name)
             res = ind.rename(new_name, inplace=True)
             # should return None
-            self.assert_(res is None)
+            self.assertIsNone(res)
             self.assertEqual(ind.name, new_name)
             self.assertEqual(ind.names, [new_name])
             with assertRaisesRegexp(TypeError, "list-like"):
@@ -385,7 +385,7 @@ class TestIndex(tm.TestCase):
 
         second.name = 'B'
         union = first.union(second)
-        self.assert_(union.name is None)
+        self.assertIsNone(union.name)
 
     def test_add(self):
         firstCat = self.strIndex + self.dateIndex
@@ -424,7 +424,7 @@ class TestIndex(tm.TestCase):
         right = Index([1, 2, 3], name='bar')
 
         result = left.append(right)
-        self.assert_(result.name is None)
+        self.assertIsNone(result.name)
 
     def test_add_string(self):
         # from bug report
@@ -478,12 +478,12 @@ class TestIndex(tm.TestCase):
         result = idx1.sym_diff(idx2)
         expected = Index([1, 5])
         self.assert_(tm.equalContents(result, expected))
-        self.assert_(result.name is None)
+        self.assertIsNone(result.name)
 
         # __xor__ syntax
         expected = idx1 ^ idx2
         self.assert_(tm.equalContents(result, expected))
-        self.assert_(result.name is None)
+        self.assertIsNone(result.name)
 
         # multiIndex
         idx1 = MultiIndex.from_tuples(self.tuples)
@@ -597,7 +597,7 @@ class TestIndex(tm.TestCase):
 
         idx = Index(values)
         idx.format()
-        self.assert_(idx[3] is None)
+        self.assertIsNone(idx[3])
 
     def test_take(self):
         indexer = [4, 3, 0, 2]
@@ -1056,7 +1056,7 @@ class TestInt64Index(tm.TestCase):
 
         tm.assert_isinstance(res, Int64Index)
         self.assert_(res.equals(eres))
-        self.assert_(lidx is None)
+        self.assertIsNone(lidx)
         self.assert_numpy_array_equal(ridx, eridx)
 
         # monotonic
@@ -1066,7 +1066,7 @@ class TestInt64Index(tm.TestCase):
                          dtype=np.int64)
         tm.assert_isinstance(res, Int64Index)
         self.assert_(res.equals(eres))
-        self.assert_(lidx is None)
+        self.assertIsNone(lidx)
         self.assert_numpy_array_equal(ridx, eridx)
 
         # non-unique
@@ -1096,7 +1096,7 @@ class TestInt64Index(tm.TestCase):
         tm.assert_isinstance(other, Int64Index)
         self.assert_(res.equals(eres))
         self.assert_numpy_array_equal(lidx, elidx)
-        self.assert_(ridx is None)
+        self.assertIsNone(ridx)
 
         # monotonic
         res, lidx, ridx = self.index.join(other_mono, how='right',
@@ -1107,7 +1107,7 @@ class TestInt64Index(tm.TestCase):
         tm.assert_isinstance(other, Int64Index)
         self.assert_(res.equals(eres))
         self.assert_numpy_array_equal(lidx, elidx)
-        self.assert_(ridx is None)
+        self.assertIsNone(ridx)
 
         # non-unique
         """
@@ -1303,7 +1303,7 @@ class TestMultiIndex(tm.TestCase):
             ind.set_names(new_names + new_names)
         new_names2 = [name + "SUFFIX2" for name in new_names]
         res = ind.set_names(new_names2, inplace=True)
-        self.assert_(res is None)
+        self.assertIsNone(res)
         self.assertEqual(ind.names, new_names2)
 
     def test_set_levels_and_set_labels(self):
@@ -1333,7 +1333,7 @@ class TestMultiIndex(tm.TestCase):
         # level changing [w/ mutation]
         ind2 = self.index.copy()
         inplace_return = ind2.set_levels(new_levels, inplace=True)
-        self.assert_(inplace_return is None)
+        self.assertIsNone(inplace_return)
         assert_matching(ind2.levels, new_levels)
 
         # label changing [w/o mutation]
@@ -1344,7 +1344,7 @@ class TestMultiIndex(tm.TestCase):
         # label changing [w/ mutation]
         ind2 = self.index.copy()
         inplace_return = ind2.set_labels(new_labels, inplace=True)
-        self.assert_(inplace_return is None)
+        self.assertIsNone(inplace_return)
         assert_matching(ind2.labels, new_labels)
 
     def test_set_levels_labels_names_bad_input(self):
@@ -1450,10 +1450,10 @@ class TestMultiIndex(tm.TestCase):
             columns=['one', 'two', 'three', 'four'],
             index=idx)
         df = df.sortlevel()
-        self.assert_(df.is_copy is None)
+        self.assertIsNone(df.is_copy)
         self.assertEqual(df.index.names, ('Name', 'Number'))
         df = df.set_value(('grethe', '4'), 'one', 99.34)
-        self.assert_(df.is_copy is None)
+        self.assertIsNone(df.is_copy)
         self.assertEqual(df.index.names, ('Name', 'Number'))
 
     def test_names(self):
@@ -1508,7 +1508,7 @@ class TestMultiIndex(tm.TestCase):
 
         single_level = MultiIndex(levels=[['foo', 'bar', 'baz', 'qux']],
                                   labels=[[0, 1, 2, 3]])
-        self.assert_(single_level.name is None)
+        self.assertIsNone(single_level.name)
 
     def test_constructor_no_levels(self):
         assertRaisesRegexp(ValueError, "non-zero number of levels/labels",
@@ -1850,7 +1850,7 @@ class TestMultiIndex(tm.TestCase):
         loc, new_index = index.get_loc_level((0, 1, 0))
         expected = 1
         self.assertEqual(loc, expected)
-        self.assert_(new_index is None)
+        self.assertIsNone(new_index)
 
         self.assertRaises(KeyError, index.get_loc_level, (2, 2))
 
@@ -2499,7 +2499,7 @@ class TestMultiIndex(tm.TestCase):
 
         result, indexer = self.index.reindex(list(self.index))
         tm.assert_isinstance(result, MultiIndex)
-        self.assert_(indexer is None)
+        self.assertIsNone(indexer)
         self.check_level_names(result, self.index.names)
 
     def test_reindex_level(self):

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -2578,7 +2578,7 @@ class TestIndexing(tm.TestCase):
         # work with the chain
         expected = DataFrame([[-5,1],[-6,3]],columns=list('AB'))
         df = DataFrame(np.arange(4).reshape(2,2),columns=list('AB'),dtype='int64')
-        self.assert_(df.is_copy is None)
+        self.assertIsNone(df.is_copy)
 
         df['A'][0] = -5
         df['A'][1] = -6
@@ -2586,11 +2586,11 @@ class TestIndexing(tm.TestCase):
 
         expected = DataFrame([[-5,2],[np.nan,3.]],columns=list('AB'))
         df = DataFrame({ 'A' : Series(range(2),dtype='int64'), 'B' : np.array(np.arange(2,4),dtype=np.float64)})
-        self.assert_(df.is_copy is None)
+        self.assertIsNone(df.is_copy)
         df['A'][0] = -5
         df['A'][1] = np.nan
         assert_frame_equal(df, expected)
-        self.assert_(df['A'].is_copy is None)
+        self.assertIsNone(df['A'].is_copy)
 
         # using a copy (the chain), fails
         df = DataFrame({ 'A' : Series(range(2),dtype='int64'), 'B' : np.array(np.arange(2,4),dtype=np.float64)})
@@ -2602,7 +2602,7 @@ class TestIndexing(tm.TestCase):
         df = DataFrame({'a' : ['one', 'one', 'two',
                                'three', 'two', 'one', 'six'],
                         'c' : Series(range(7),dtype='int64') })
-        self.assert_(df.is_copy is None)
+        self.assertIsNone(df.is_copy)
         expected = DataFrame({'a' : ['one', 'one', 'two',
                                      'three', 'two', 'one', 'six'],
                               'c' : [42,42,2,3,4,42,6]})
@@ -2631,7 +2631,7 @@ class TestIndexing(tm.TestCase):
         # make sure that is_copy is picked up reconstruction
         # GH5475
         df = DataFrame({"A": [1,2]})
-        self.assert_(df.is_copy is None)
+        self.assertIsNone(df.is_copy)
         with tm.ensure_clean('__tmp__pickle') as path:
             df.to_pickle(path)
             df2 = pd.read_pickle(path)
@@ -2656,34 +2656,34 @@ class TestIndexing(tm.TestCase):
 
         # always a copy
         x = df.iloc[[0,1,2]]
-        self.assert_(x.is_copy is not None)
+        self.assertIsNotNone(x.is_copy)
         x = df.iloc[[0,1,2,4]]
-        self.assert_(x.is_copy is not None)
+        self.assertIsNotNone(x.is_copy)
 
         # explicity copy
         indexer = df.letters.apply(lambda x : len(x) > 10)
         df = df.ix[indexer].copy()
-        self.assert_(df.is_copy is None)
+        self.assertIsNone(df.is_copy)
         df['letters'] = df['letters'].apply(str.lower)
 
         # implicity take
         df = random_text(100000)
         indexer = df.letters.apply(lambda x : len(x) > 10)
         df = df.ix[indexer]
-        self.assert_(df.is_copy is not None)
+        self.assertIsNotNone(df.is_copy)
         df['letters'] = df['letters'].apply(str.lower)
 
         # implicity take 2
         df = random_text(100000)
         indexer = df.letters.apply(lambda x : len(x) > 10)
         df = df.ix[indexer]
-        self.assert_(df.is_copy is not None)
+        self.assertIsNotNone(df.is_copy)
         df.loc[:,'letters'] = df['letters'].apply(str.lower)
 
         # should be ok even though its a copy!
         self.assert_(df.is_copy is  None)
         df['letters'] = df['letters'].apply(str.lower)
-        self.assert_(df.is_copy is None)
+        self.assertIsNone(df.is_copy)
 
         df = random_text(100000)
         indexer = df.letters.apply(lambda x : len(x) > 10)
@@ -2691,7 +2691,7 @@ class TestIndexing(tm.TestCase):
 
         # an identical take, so no copy
         df = DataFrame({'a' : [1]}).dropna()
-        self.assert_(df.is_copy is None)
+        self.assertIsNone(df.is_copy)
         df['a'] += 1
 
         # inplace ops

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -64,7 +64,7 @@ class SafeForLongAndSparse(object):
             getattr(self.panel, attr).name = None
             cp = self.panel.copy()
             getattr(cp, attr).name = 'foo'
-            self.assert_(getattr(self.panel, attr).name is None)
+            self.assertIsNone(getattr(self.panel, attr).name)
 
     def test_iter(self):
         tm.equalContents(list(self.panel), self.panel.items)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -4008,8 +4008,8 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
             self.series.to_csv(path)
             series = Series.from_csv(path)
-            self.assert_(series.name is None)
-            self.assert_(series.index.name is None)
+            self.assertIsNone(series.name)
+            self.assertIsNone(series.index.name)
             assert_series_equal(self.series, series)
 
             outfile = open(path, 'w')
@@ -5521,12 +5521,12 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         self.assertEqual(index, ts.index[-6])
 
         ts[:] = np.nan
-        self.assert_(ts.last_valid_index() is None)
-        self.assert_(ts.first_valid_index() is None)
+        self.assertIsNone(ts.last_valid_index())
+        self.assertIsNone(ts.first_valid_index())
 
         ser = Series([], index=[])
-        self.assert_(ser.last_valid_index() is None)
-        self.assert_(ser.first_valid_index() is None)
+        self.assertIsNone(ser.last_valid_index())
+        self.assertIsNone(ser.first_valid_index())
 
     def test_mpl_compat_hack(self):
         result = self.ts[:, np.newaxis]

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -32,7 +32,7 @@ class TestStringMethods(tm.TestCase):
     def test_api(self):
 
         # GH 6106
-        self.assert_(Series.str is None)
+        self.assertIsNone(Series.str)
 
     def test_iter(self):
         # GH3638

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -148,7 +148,7 @@ class TestDateRange(tm.TestCase):
         fancy_indexed = self.rng[[4, 3, 2, 1, 0]]
         self.assertEquals(len(fancy_indexed), 5)
         tm.assert_isinstance(fancy_indexed, DatetimeIndex)
-        self.assert_(fancy_indexed.freq is None)
+        self.assertIsNone(fancy_indexed.freq)
 
         # 32-bit vs. 64-bit platforms
         self.assertEquals(self.rng[4], self.rng[np.int_(4)])
@@ -179,7 +179,7 @@ class TestDateRange(tm.TestCase):
         pickled = pickle.dumps(self.rng)
         unpickled = pickle.loads(pickled)
 
-        self.assert_(unpickled.offset is not None)
+        self.assertIsNotNone(unpickled.offset)
 
     def test_union(self):
         # overlapping
@@ -228,7 +228,7 @@ class TestDateRange(tm.TestCase):
 
         the_join = left.join(right, how='outer')
         tm.assert_isinstance(the_join, DatetimeIndex)
-        self.assert_(the_join.freq is None)
+        self.assertIsNone(the_join.freq)
 
         # non-overlapping, no gap
         left = self.rng[:5]
@@ -242,7 +242,7 @@ class TestDateRange(tm.TestCase):
 
         the_join = self.rng.join(rng, how='outer')
         tm.assert_isinstance(the_join, DatetimeIndex)
-        self.assert_(the_join.freq is None)
+        self.assertIsNone(the_join.freq)
 
     def test_union_not_cacheable(self):
         rng = date_range('1/1/2000', periods=50, freq=datetools.Minute())
@@ -468,7 +468,7 @@ class TestCustomDateRange(tm.TestCase):
         fancy_indexed = self.rng[[4, 3, 2, 1, 0]]
         self.assertEquals(len(fancy_indexed), 5)
         tm.assert_isinstance(fancy_indexed, DatetimeIndex)
-        self.assert_(fancy_indexed.freq is None)
+        self.assertIsNone(fancy_indexed.freq)
 
         # 32-bit vs. 64-bit platforms
         self.assertEquals(self.rng[4], self.rng[np.int_(4)])
@@ -499,7 +499,7 @@ class TestCustomDateRange(tm.TestCase):
         pickled = pickle.dumps(self.rng)
         unpickled = pickle.loads(pickled)
 
-        self.assert_(unpickled.offset is not None)
+        self.assertIsNotNone(unpickled.offset)
 
     def test_union(self):
         # overlapping
@@ -548,7 +548,7 @@ class TestCustomDateRange(tm.TestCase):
 
         the_join = left.join(right, how='outer')
         tm.assert_isinstance(the_join, DatetimeIndex)
-        self.assert_(the_join.freq is None)
+        self.assertIsNone(the_join.freq)
 
         # non-overlapping, no gap
         left = self.rng[:5]
@@ -562,7 +562,7 @@ class TestCustomDateRange(tm.TestCase):
 
         the_join = self.rng.join(rng, how='outer')
         tm.assert_isinstance(the_join, DatetimeIndex)
-        self.assert_(the_join.freq is None)
+        self.assertIsNone(the_join.freq)
 
     def test_intersection_bug(self):
         # GH #771

--- a/pandas/tseries/tests/test_frequencies.py
+++ b/pandas/tseries/tests/test_frequencies.py
@@ -145,11 +145,11 @@ class TestFrequencyInference(tm.TestCase):
 
         index = _dti([b + base_delta * 7] +
                      [b + base_delta * j for j in range(3)])
-        self.assert_(infer_freq(index) is None)
+        self.assertIsNone(infer_freq(index))
 
         index = _dti([b + base_delta * j for j in range(3)] +
                      [b + base_delta * 7])
-        self.assert_(infer_freq(index) is None)
+        self.assertIsNone(infer_freq(index))
 
     def test_weekly(self):
         days = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
@@ -249,7 +249,7 @@ class TestFrequencyInference(tm.TestCase):
     def test_not_monotonic(self):
         rng = _dti(['1/31/2000', '1/31/2001', '1/31/2002'])
         rng = rng[::-1]
-        self.assert_(rng.inferred_freq is None)
+        self.assertIsNone(rng.inferred_freq)
 
     def test_non_datetimeindex(self):
         rng = _dti(['1/31/2000', '1/31/2001', '1/31/2002'])

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -124,7 +124,7 @@ class TestTSPlot(tm.TestCase):
 
     def test_get_datevalue(self):
         from pandas.tseries.converter import get_datevalue
-        self.assert_(get_datevalue(None, 'D') is None)
+        self.assertIsNone(get_datevalue(None, 'D'))
         self.assertEqual(get_datevalue(1987, 'A'), 1987)
         self.assertEqual(get_datevalue(Period(1987, 'A'), 'M'),
                          Period('1987-12', 'M').ordinal)
@@ -245,7 +245,7 @@ class TestTSPlot(tm.TestCase):
         plt.clf()
         ax = fig.add_subplot(211)
         ret = ser.plot()
-        self.assert_(ret is not None)
+        self.assertIsNotNone(ret)
 
         for rs, xp in zip(ax.get_lines()[0].get_xdata(), ser.index):
             self.assertEqual(rs, xp)
@@ -793,7 +793,7 @@ class TestTSPlot(tm.TestCase):
         self.assertEqual(leg.get_texts()[1].get_text(), 'B (right)')
         self.assertEqual(leg.get_texts()[2].get_text(), 'C')
         self.assertEqual(leg.get_texts()[3].get_text(), 'D')
-        self.assert_(ax.right_ax.get_legend() is None)
+        self.assertIsNone(ax.right_ax.get_legend())
         colors = set()
         for line in leg.get_lines():
             colors.add(line.get_color())
@@ -829,7 +829,7 @@ class TestTSPlot(tm.TestCase):
         ax = df.plot(secondary_y=['C', 'D'])
         leg = ax.get_legend()
         self.assertEqual(len(leg.get_lines()), 4)
-        self.assert_(ax.right_ax.get_legend() is None)
+        self.assertIsNone(ax.right_ax.get_legend())
         colors = set()
         for line in leg.get_lines():
             colors.add(line.get_color())
@@ -844,7 +844,7 @@ class TestTSPlot(tm.TestCase):
         ax = df.plot(secondary_y=['A', 'B'])
         leg = ax.get_legend()
         self.assertEqual(len(leg.get_lines()), 4)
-        self.assert_(ax.right_ax.get_legend() is None)
+        self.assertIsNone(ax.right_ax.get_legend())
         colors = set()
         for line in leg.get_lines():
             colors.add(line.get_color())
@@ -857,7 +857,7 @@ class TestTSPlot(tm.TestCase):
         ax = df.plot(secondary_y=['C', 'D'])
         leg = ax.get_legend()
         self.assertEqual(len(leg.get_lines()), 4)
-        self.assert_(ax.right_ax.get_legend() is None)
+        self.assertIsNone(ax.right_ax.get_legend())
         colors = set()
         for line in leg.get_lines():
             colors.add(line.get_color())

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -298,7 +298,7 @@ class TestTimeSeries(tm.TestCase):
         self.assertEquals(v3, Timestamp('6/30/2005'))
 
         # don't carry freq through irregular slicing
-        self.assert_(dti2.freq is None)
+        self.assertIsNone(dti2.freq)
 
     def test_pass_datetimeindex_to_index(self):
         # Bugs in #1396
@@ -318,12 +318,12 @@ class TestTimeSeries(tm.TestCase):
 
         masked = rng[mask]
         expected = rng[10:20]
-        self.assert_(expected.freq is not None)
+        self.assertIsNotNone(expected.freq)
         assert_range_equal(masked, expected)
 
         mask[22] = True
         masked = rng[mask]
-        self.assert_(masked.freq is None)
+        self.assertIsNone(masked.freq)
 
     def test_getitem_median_slice_bug(self):
         index = date_range('20090415', '20090519', freq='2B')
@@ -1151,7 +1151,7 @@ class TestTimeSeries(tm.TestCase):
         rng = date_range('1/1/2000', '1/1/2001')
 
         result = rng.repeat(5)
-        self.assert_(result.freq is None)
+        self.assertIsNone(result.freq)
         self.assertEqual(len(result), 5 * len(rng))
 
     def test_at_time(self):
@@ -1586,7 +1586,7 @@ class TestTimeSeries(tm.TestCase):
         rng1.name = 'foo'
         rng2.name = 'bar'
         self.assertEqual(rng1.append(rng1).name, 'foo')
-        self.assert_(rng1.append(rng2).name is None)
+        self.assertIsNone(rng1.append(rng2).name)
 
     def test_append_concat_tz(self):
         #GH 2938
@@ -2950,7 +2950,7 @@ class TestSlicing(tm.TestCase):
         self.assertEqual(result.freq, rng.freq)
 
         result = rng[:50].union(rng[60:100])
-        self.assert_(result.freq is None)
+        self.assertIsNone(result.freq)
 
         result = rng[:50].intersection(rng[25:75])
         self.assertEqual(result.freqstr, 'D')


### PR DESCRIPTION
Work on #6175. Changes instances of assert_(a is [not] None) to specialized assertIs[Not]None(a).
