### PR TITLE
BUG: Fix behavior of to_offset with leading zeroes

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -96,6 +96,7 @@ Improvements to existing features
 Bug Fixes
 ~~~~~~~~~
 
+- Bug in ``pd.tseries.frequencies.to_offset`` when argument has leading zeroes (:issue:`6391`)
 - Bug in version string gen. for dev versions with shallow clones / install from tarball (:issue:`6127`)
 - Inconsistent tz parsing Timestamp/to_datetime for current year (:issue:`5958`)
 - Indexing bugs with reordered indexes (:issue:`6252`, :issue:`6254`)

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -283,11 +283,11 @@ def to_offset(freqstr):
         try:
             for stride, name, _ in opattern.findall(freqstr):
                 offset = get_offset(name)
+                if stride_sign is None:
+                    stride_sign = -1 if stride.startswith('-') else 1
                 if not stride:
                     stride = 1
                 stride = int(stride)
-                if stride_sign is None:
-                    stride_sign = np.sign(stride)
                 offset = offset * int(np.fabs(stride) * stride_sign)
                 if delta is None:
                     delta = offset

--- a/pandas/tseries/tests/test_frequencies.py
+++ b/pandas/tseries/tests/test_frequencies.py
@@ -72,6 +72,16 @@ def test_to_offset_negative():
     freqstr = '-5min10s'
     result = to_offset(freqstr)
     assert(result.n == -310)
+    
+
+def test_to_offset_leading_zero():
+    freqstr = '00H 00T 01S'
+    result = to_offset(freqstr)
+    assert(result.n == 1)
+
+    freqstr = '-00H 03T 14S'
+    result = to_offset(freqstr)
+    assert(result.n == -194)
 
 
 def test_anchored_shortcuts():


### PR DESCRIPTION
Currently, `pandas.tseries.frequencies.to_offset` erroneously returns a zero time offset when the first part of its argument has a numerical value of zero, even if later parts have nonzero values.  For instance,

```
In [123]: pandas.tseries.frequencies.to_offset('00H 00T 01S')
Out[123]: <0 * Days>
```

This change checks the sign of the numeric part of the argument before converting to `int` in order to support offsets like `'-00H 00T 01S'`.
