### PR TITLE
CLN: Change assert_(a is [not] b) to specialized forms

### DIFF
--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -1661,7 +1661,7 @@ a,b,c,d
         stamp = result.index[0]
         self.assertEqual(stamp.minute, 39)
         try:
-            self.assert_(result.index.tz is pytz.utc)
+            self.assertIs(result.index.tz, pytz.utc)
         except AssertionError:  # hello Yaroslav
             arr = result.index.to_pydatetime()
             result = tools.to_datetime(arr, utc=True)[0]

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -514,7 +514,7 @@ class TestHDFStore(tm.TestCase):
             if LooseVersion(tables.__version__) >= '3.0.0':
 
                 # the file should not have actually been written
-                self.assert_(os.path.exists(path) is False)
+                self.assertFalse(os.path.exists(path))
 
     def test_flush(self):
 

--- a/pandas/sparse/tests/test_libsparse.py
+++ b/pandas/sparse/tests/test_libsparse.py
@@ -269,7 +269,7 @@ class TestBlockIndex(tm.TestCase):
 
     def test_to_block_index(self):
         index = BlockIndex(10, [0, 5], [4, 5])
-        self.assert_(index.to_block_index() is index)
+        self.assertIs(index.to_block_index(), index)
 
 
 class TestIntIndex(tm.TestCase):
@@ -294,7 +294,7 @@ class TestIntIndex(tm.TestCase):
 
     def test_to_int_index(self):
         index = IntIndex(10, [2, 3, 4, 5, 6])
-        self.assert_(index.to_int_index() is index)
+        self.assertIs(index.to_int_index(), index)
 
 
 class TestSparseOperators(tm.TestCase):

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -280,8 +280,8 @@ class TestSparseSeries(tm.TestCase,
 
     def test_copy_astype(self):
         cop = self.bseries.astype(np.float64)
-        self.assert_(cop is not self.bseries)
-        self.assert_(cop.sp_index is self.bseries.sp_index)
+        self.assertIsNot(cop, self.bseries)
+        self.assertIs(cop.sp_index, self.bseries.sp_index)
         self.assertEqual(cop.dtype, np.float64)
 
         cop2 = self.iseries.copy()
@@ -524,7 +524,7 @@ class TestSparseSeries(tm.TestCase,
         # special cases
         same_index = self.bseries.reindex(self.bseries.index)
         assert_sp_series_equal(self.bseries, same_index)
-        self.assert_(same_index is not self.bseries)
+        self.assertIsNot(same_index, self.bseries)
 
         # corner cases
         sp = SparseSeries([], index=[])
@@ -547,7 +547,7 @@ class TestSparseSeries(tm.TestCase,
             first_series = SparseSeries(values, sparse_index=index1,
                                         fill_value=fill_value)
             reindexed = first_series.sparse_reindex(index2)
-            self.assert_(reindexed.sp_index is index2)
+            self.assertIs(reindexed.sp_index, index2)
 
             int_indices1 = index1.to_int_index().indices
             int_indices2 = index2.to_int_index().indices
@@ -699,7 +699,7 @@ class TestSparseSeries(tm.TestCase,
                               index=np.arange(6))
 
         shifted = series.shift(0)
-        self.assert_(shifted is not series)
+        self.assertIsNot(shifted, series)
         assert_sp_series_equal(shifted, series)
 
         f = lambda s: s.shift(1)
@@ -1093,12 +1093,12 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
         res.index = res.index.astype(object)
 
         res = self.frame.set_value('foobar', 'B', 1.5)
-        self.assert_(res is not self.frame)
+        self.assertIsNot(res, self.frame)
         self.assertEqual(res.index[-1], 'foobar')
         self.assertEqual(res.get_value('foobar', 'B'), 1.5)
 
         res2 = res.set_value('foobar', 'qux', 1.5)
-        self.assert_(res2 is not res)
+        self.assertIsNot(res2, res)
         self.assert_numpy_array_equal(res2.columns,
                                       list(self.frame.columns) + ['qux'])
         self.assertEqual(res2.get_value('foobar', 'qux'), 1.5)
@@ -1247,7 +1247,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
         assert_frame_equal(broadcasted.to_dense(),
                            self.frame.to_dense().apply(np.sum, broadcast=True))
 
-        self.assert_(self.empty.apply(np.sqrt) is self.empty)
+        self.assertIs(self.empty.apply(np.sqrt), self.empty)
 
         from pandas.core import nanops
         applied = self.frame.apply(np.sum)
@@ -1656,7 +1656,7 @@ class TestSparsePanel(tm.TestCase,
     def test_set_value(self):
         def _check_loc(item, major, minor, val=1.5):
             res = self.panel.set_value(item, major, minor, val)
-            self.assert_(res is not self.panel)
+            self.assertIsNot(res, self.panel)
             self.assertEquals(res.get_value(item, major, minor), val)
 
         _check_loc('ItemA', self.panel.major_axis[4], self.panel.minor_axis[3])
@@ -1669,7 +1669,7 @@ class TestSparsePanel(tm.TestCase,
         assert_almost_equal(self.panel.items, ['ItemA', 'ItemC', 'ItemD'])
         crackle = self.panel['ItemC']
         pop = self.panel.pop('ItemC')
-        self.assert_(pop is crackle)
+        self.assertIs(pop, crackle)
         assert_almost_equal(self.panel.items, ['ItemA', 'ItemD'])
 
         self.assertRaises(KeyError, self.panel.__delitem__, 'ItemC')

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -637,7 +637,7 @@ class CheckIndexing(object):
         df.ix[2:, 'z'] = 42
 
         expected = Series([np.nan, np.nan, 42, 42], index=df.index)
-        self.assert_(df['z'] is not foo)
+        self.assertIsNot(df['z'], foo)
         assert_series_equal(df['z'], expected)
 
     def test_setitem_None(self):
@@ -1046,7 +1046,7 @@ class CheckIndexing(object):
         ix = f.ix
 
         # return self if no slicing...for now
-        self.assert_(ix[:, :] is f)
+        self.assertIs(ix[:, :], f)
 
         # low dimensional slice
         xs1 = ix[2, ['C', 'B', 'A']]
@@ -1532,7 +1532,7 @@ class CheckIndexing(object):
     def test_set_value_resize(self):
 
         res = self.frame.set_value('foobar', 'B', 0)
-        self.assert_(res is self.frame)
+        self.assertIs(res, self.frame)
         self.assertEqual(res.index[-1], 'foobar')
         self.assertEqual(res.get_value('foobar', 'B'), 0)
 
@@ -1943,8 +1943,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.assertEquals(f._get_axis_name('rows'), 'index')
         self.assertEquals(f._get_axis_name('columns'), 'columns')
 
-        self.assert_(f._get_axis(0) is f.index)
-        self.assert_(f._get_axis(1) is f.columns)
+        self.assertIs(f._get_axis(0), f.index)
+        self.assertIs(f._get_axis(1), f.columns)
 
         assertRaisesRegexp(ValueError, 'No axis named', f._get_axis_number, 2)
         assertRaisesRegexp(ValueError, 'No axis.*foo', f._get_axis_name, 'foo')
@@ -1957,7 +1957,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # cache it
         _ = self.mixed_frame['foo']
         self.mixed_frame.index = idx
-        self.assert_(self.mixed_frame['foo'].index is idx)
+        self.assertIs(self.mixed_frame['foo'].index, idx)
         with assertRaisesRegexp(ValueError, 'Length mismatch'):
             self.mixed_frame.index = idx[::2]
 
@@ -2122,7 +2122,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
     def test_keys(self):
         getkeys = self.frame.keys
-        self.assert_(getkeys() is self.frame.columns)
+        self.assertIs(getkeys(), self.frame.columns)
 
     def test_column_contains_typeerror(self):
         try:
@@ -2305,13 +2305,13 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # empty dict plus index
         idx = Index([0, 1, 2])
         frame = DataFrame({}, index=idx)
-        self.assert_(frame.index is idx)
+        self.assertIs(frame.index, idx)
 
         # empty with index and columns
         idx = Index([0, 1, 2])
         frame = DataFrame({}, index=idx, columns=idx)
-        self.assert_(frame.index is idx)
-        self.assert_(frame.columns is idx)
+        self.assertIs(frame.index, idx)
+        self.assertIs(frame.columns, idx)
         self.assertEqual(len(frame._series), 3)
 
         # with dict of empty list and Series
@@ -3717,8 +3717,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
     def test_array_interface(self):
         result = np.sqrt(self.frame)
         tm.assert_isinstance(result, type(self.frame))
-        self.assert_(result.index is self.frame.index)
-        self.assert_(result.columns is self.frame.columns)
+        self.assertIs(result.index, self.frame.index)
+        self.assertIs(result.columns, self.frame.columns)
 
         assert_frame_equal(result, self.frame.apply(np.sqrt))
 
@@ -4191,10 +4191,10 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
     def test_get_agg_axis(self):
         cols = self.frame._get_agg_axis(0)
-        self.assert_(cols is self.frame.columns)
+        self.assertIs(cols, self.frame.columns)
 
         idx = self.frame._get_agg_axis(1)
-        self.assert_(idx is self.frame.index)
+        self.assertIs(idx, self.frame.index)
 
         self.assertRaises(ValueError, self.frame._get_agg_axis, 2)
 
@@ -4731,7 +4731,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # from #1074
         d = DataFrame({'a': [np.nan, False]})
         self.assertEqual(d['a'].dtype, np.object_)
-        self.assert_(d['a'][1] is False)
+        self.assertFalse(d['a'][1])
 
     def test_constructor_with_nas(self):
         # GH 5016
@@ -5243,7 +5243,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         _check_mixed_float(result, dtype = dict(C = None))
 
         result = self.empty * 2
-        self.assert_(result.index is self.empty.index)
+        self.assertIs(result.index, self.empty.index)
         self.assertEqual(len(result.columns), 0)
 
     def test_comparisons(self):
@@ -6373,7 +6373,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # test does not blow up on length-0 DataFrame
         zero_length = self.tsframe.reindex([])
         result = zero_length.asfreq('BM')
-        self.assert_(result is not zero_length)
+        self.assertIsNot(result, zero_length)
 
     def test_asfreq_datetimeindex(self):
         df = DataFrame({'A': [1, 2, 3]},
@@ -6494,7 +6494,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # copy objects
         copy = self.mixed_frame.copy()
-        self.assert_(copy._data is not self.mixed_frame._data)
+        self.assertIsNot(copy._data, self.mixed_frame._data)
 
     def _check_method(self, method='pearson', check_minp=False):
         if not check_minp:
@@ -7134,7 +7134,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df[3][-4:] = np.nan
 
         expected = df.fillna(value=0)
-        self.assert_(expected is not df)
+        self.assertIsNot(expected, df)
 
         df.fillna(value=0, inplace=True)
         assert_frame_equal(df, expected)
@@ -7142,7 +7142,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df[1][:4] = np.nan
         df[3][-4:] = np.nan
         expected = df.fillna(method='ffill')
-        self.assert_(expected is not df)
+        self.assertIsNot(expected, df)
 
         df.fillna(method='ffill', inplace=True)
         assert_frame_equal(df, expected)
@@ -8283,7 +8283,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # Same index, copies values but not index if copy=False
         newFrame = self.frame.reindex(self.frame.index, copy=False)
-        self.assert_(newFrame.index is self.frame.index)
+        self.assertIs(newFrame.index, self.frame.index)
 
         # length zero
         newFrame = self.frame.reindex([])
@@ -8424,10 +8424,10 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
     def test_align(self):
 
         af, bf = self.frame.align(self.frame)
-        self.assert_(af._data is not self.frame._data)
+        self.assertIsNot(af._data, self.frame._data)
 
         af, bf = self.frame.align(self.frame, copy=False)
-        self.assert_(af._data is self.frame._data)
+        self.assertIs(af._data, self.frame._data)
 
         # axis = 0
         other = self.frame.ix[:-5, :3]
@@ -9106,7 +9106,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         d = self.frame.index[0]
         applied = self.frame.apply(np.mean, axis=1)
         self.assertEqual(applied[d], np.mean(self.frame.xs(d)))
-        self.assert_(applied.index is self.frame.index)  # want this
+        self.assertIs(applied.index, self.frame.index)  # want this
 
         # invalid axis
         df = DataFrame(
@@ -9232,7 +9232,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                 if is_reduction:
                     agg_axis = df._get_agg_axis(axis)
                     tm.assert_isinstance(res, Series)
-                    self.assert_(res.index is agg_axis)
+                    self.assertIs(res.index, agg_axis)
                 else:
                     tm.assert_isinstance(res, DataFrame)
 
@@ -11445,7 +11445,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # Ensure copy, do I want this?
         recons = consolidated.consolidate()
-        self.assert_(recons is not consolidated)
+        self.assertIsNot(recons, consolidated)
         assert_frame_equal(recons, consolidated)
 
         self.frame['F'] = 8.

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -393,10 +393,10 @@ class TestSeries(tm.TestCase, Generic):
 
         # allow single item via bool method
         s = Series([True])
-        self.assert_(s.bool() is True)
+        self.assertTrue(s.bool())
 
         s = Series([False])
-        self.assert_(s.bool() is False)
+        self.assertFalse(s.bool())
 
         # single item nan to raise
         for s in [ Series([np.nan]), Series([pd.NaT]), Series([True]), Series([False]) ]:
@@ -633,10 +633,10 @@ class TestDataFrame(tm.TestCase, Generic):
 
         # allow single item via bool method
         df = DataFrame([[True]])
-        self.assert_(df.bool() is True)
+        self.assertTrue(df.bool())
 
         df = DataFrame([[False]])
-        self.assert_(df.bool() is False)
+        self.assertFalse(df.bool())
 
         df = DataFrame([[False, False]])
         self.assertRaises(ValueError, lambda : df.bool())

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -546,14 +546,14 @@ class TestGroupBy(tm.TestCase):
     def test_groups(self):
         grouped = self.df.groupby(['A'])
         groups = grouped.groups
-        self.assert_(groups is grouped.groups)  # caching works
+        self.assertIs(groups, grouped.groups)  # caching works
 
         for k, v in compat.iteritems(grouped.groups):
             self.assert_((self.df.ix[v]['A'] == k).all())
 
         grouped = self.df.groupby(['A', 'B'])
         groups = grouped.groups
-        self.assert_(groups is grouped.groups)  # caching works
+        self.assertIs(groups, grouped.groups)  # caching works
         for k, v in compat.iteritems(grouped.groups):
             self.assert_((self.df.ix[v]['A'] == k[0]).all())
             self.assert_((self.df.ix[v]['B'] == k[1]).all())

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -100,7 +100,7 @@ class TestIndex(tm.TestCase):
 
         for func in (copy, deepcopy):
             idx_copy = func(self.strIndex)
-            self.assert_(idx_copy is not self.strIndex)
+            self.assertIsNot(idx_copy, self.strIndex)
             self.assert_(idx_copy.equals(self.strIndex))
 
         new_copy = self.strIndex.copy(deep=True, name="banana")
@@ -255,7 +255,7 @@ class TestIndex(tm.TestCase):
 
     def test_asof(self):
         d = self.dateIndex[0]
-        self.assert_(self.dateIndex.asof(d) is d)
+        self.assertIs(self.dateIndex.asof(d), d)
         self.assert_(np.isnan(self.dateIndex.asof(d - timedelta(1))))
 
         d = self.dateIndex[-1]
@@ -332,7 +332,7 @@ class TestIndex(tm.TestCase):
 
     def test_shift(self):
         shifted = self.dateIndex.shift(0, timedelta(1))
-        self.assert_(shifted is self.dateIndex)
+        self.assertIs(shifted, self.dateIndex)
 
         shifted = self.dateIndex.shift(5, timedelta(1))
         self.assert_numpy_array_equal(shifted, self.dateIndex + timedelta(5))
@@ -352,7 +352,7 @@ class TestIndex(tm.TestCase):
 
         # Corner cases
         inter = first.intersection(first)
-        self.assert_(inter is first)
+        self.assertIs(inter, first)
 
         # non-iterable input
         assertRaisesRegexp(TypeError, "iterable", first.intersection, 0.5)
@@ -366,13 +366,13 @@ class TestIndex(tm.TestCase):
 
         # Corner cases
         union = first.union(first)
-        self.assert_(union is first)
+        self.assertIs(union, first)
 
         union = first.union([])
-        self.assert_(union is first)
+        self.assertIs(union, first)
 
         union = Index([]).union(first)
-        self.assert_(union is first)
+        self.assertIs(union, first)
 
         # non-iterable input
         assertRaisesRegexp(TypeError, "iterable", first.union, 0.5)
@@ -757,7 +757,7 @@ class TestIndex(tm.TestCase):
             for kind in kinds:
                 res = getattr(self, '{0}Index'.format(index_kind))
                 joined = res.join(res, how=kind)
-                self.assert_(res is joined)
+                self.assertIs(res, joined)
 
 
 class TestFloat64Index(tm.TestCase):
@@ -1174,7 +1174,7 @@ class TestInt64Index(tm.TestCase):
         kinds = 'outer', 'inner', 'left', 'right'
         for kind in kinds:
             joined = self.index.join(self.index, how=kind)
-            self.assert_(self.index is joined)
+            self.assertIs(self.index, joined)
 
     def test_intersection(self):
         other = Index([1, 2, 3, 4, 5])
@@ -1561,11 +1561,11 @@ class TestMultiIndex(tm.TestCase):
 
         # labels doesn't matter which way copied
         assert_almost_equal(copy.labels, original.labels)
-        self.assert_(copy.labels is not original.labels)
+        self.assertIsNot(copy.labels, original.labels)
 
         # names doesn't matter which way copied
         self.assertEqual(copy.names, original.names)
-        self.assert_(copy.names is not original.names)
+        self.assertIsNot(copy.names, original.names)
 
         # sort order should be copied
         self.assertEqual(copy.sortorder, original.sortorder)
@@ -2203,10 +2203,10 @@ class TestMultiIndex(tm.TestCase):
 
         # corner case, pass self or empty thing:
         the_union = self.index.union(self.index)
-        self.assert_(the_union is self.index)
+        self.assertIs(the_union, self.index)
 
         the_union = self.index.union(self.index[:0])
-        self.assert_(the_union is self.index)
+        self.assertIs(the_union, self.index)
 
         # won't work in python 3
         # tuples = self.index._tuple_index
@@ -2235,7 +2235,7 @@ class TestMultiIndex(tm.TestCase):
 
         # corner case, pass self
         the_int = self.index.intersection(self.index)
-        self.assert_(the_int is self.index)
+        self.assertIs(the_int, self.index)
 
         # empty intersection: disjoint
         empty = self.index[:2] & self.index[2:]
@@ -2490,7 +2490,7 @@ class TestMultiIndex(tm.TestCase):
         for kind in kinds:
             res = self.index
             joined = res.join(res, how=kind)
-            self.assert_(res is joined)
+            self.assertIs(res, joined)
 
     def test_reindex(self):
         result, indexer = self.index.reindex(list(self.index[:4]))

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -2681,7 +2681,7 @@ class TestIndexing(tm.TestCase):
         df.loc[:,'letters'] = df['letters'].apply(str.lower)
 
         # should be ok even though its a copy!
-        self.assert_(df.is_copy is  None)
+        self.assertIsNone(df.is_copy)
         df['letters'] = df['letters'].apply(str.lower)
         self.assertIsNone(df.is_copy)
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -157,17 +157,17 @@ class TestMultiLevel(tm.TestCase):
     def test_reindex_preserve_levels(self):
         new_index = self.ymd.index[::10]
         chunk = self.ymd.reindex(new_index)
-        self.assert_(chunk.index is new_index)
+        self.assertIs(chunk.index, new_index)
 
         chunk = self.ymd.ix[new_index]
-        self.assert_(chunk.index is new_index)
+        self.assertIs(chunk.index, new_index)
 
         ymdT = self.ymd.T
         chunk = ymdT.reindex(columns=new_index)
-        self.assert_(chunk.columns is new_index)
+        self.assertIs(chunk.columns, new_index)
 
         chunk = ymdT.ix[:, new_index]
-        self.assert_(chunk.columns is new_index)
+        self.assertIs(chunk.columns, new_index)
 
     def test_sort_index_preserve_levels(self):
         result = self.frame.sort_index()

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -193,17 +193,17 @@ class SafeForSparse(object):
 
         if hasattr(self.panel, '_item_cache'):
             self.assertNotIn('ItemA', self.panel._item_cache)
-        self.assert_(self.panel.items is new_items)
+        self.assertIs(self.panel.items, new_items)
 
         item = self.panel[0]
         self.panel.major_axis = new_major
-        self.assert_(self.panel[0].index is new_major)
-        self.assert_(self.panel.major_axis is new_major)
+        self.assertIs(self.panel[0].index, new_major)
+        self.assertIs(self.panel.major_axis, new_major)
 
         item = self.panel[0]
         self.panel.minor_axis = new_minor
-        self.assert_(self.panel[0].columns is new_minor)
-        self.assert_(self.panel.minor_axis is new_minor)
+        self.assertIs(self.panel[0].columns, new_minor)
+        self.assertIs(self.panel.minor_axis, new_minor)
 
     def test_get_axis_number(self):
         self.assertEqual(self.panel._get_axis_number('items'), 0)
@@ -796,7 +796,7 @@ class CheckIndexing(object):
         # resize
         res = self.panel.set_value('ItemE', 'foo', 'bar', 1.5)
         tm.assert_isinstance(res, Panel)
-        self.assert_(res is not self.panel)
+        self.assertIsNot(res, self.panel)
         self.assertEqual(res.get_value('ItemE', 'foo', 'bar'), 1.5)
 
         res3 = self.panel.set_value('ItemE', 'foobar', 'baz', 5)
@@ -831,10 +831,10 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
     def test_constructor(self):
         # with BlockManager
         wp = Panel(self.panel._data)
-        self.assert_(wp._data is self.panel._data)
+        self.assertIs(wp._data, self.panel._data)
 
         wp = Panel(self.panel._data, copy=True)
-        self.assert_(wp._data is not self.panel._data)
+        self.assertIsNot(wp._data, self.panel._data)
         assert_panel_equal(wp, self.panel)
 
         # strings handled prop
@@ -846,11 +846,11 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
 
         # no copy
         wp = Panel(vals)
-        self.assert_(wp.values is vals)
+        self.assertIs(wp.values, vals)
 
         # copy
         wp = Panel(vals, copy=True)
-        self.assert_(wp.values is not vals)
+        self.assertIsNot(wp.values, vals)
 
     def test_constructor_cast(self):
         zero_filled = self.panel.fillna(0)
@@ -1211,9 +1211,9 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
                                     minor=self.panel.minor_axis,
                                     copy = False)
 
-        self.assert_(result.items is self.panel.items)
-        self.assert_(result.major_axis is self.panel.major_axis)
-        self.assert_(result.minor_axis is self.panel.minor_axis)
+        self.assertIs(result.items, self.panel.items)
+        self.assertIs(result.major_axis, self.panel.major_axis)
+        self.assertIs(result.minor_axis, self.panel.minor_axis)
 
         result = self.panel.reindex(items=self.panel.items,
                                     major=self.panel.major_axis,
@@ -1337,13 +1337,13 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
 
     def test_swapaxes(self):
         result = self.panel.swapaxes('items', 'minor')
-        self.assert_(result.items is self.panel.minor_axis)
+        self.assertIs(result.items, self.panel.minor_axis)
 
         result = self.panel.swapaxes('items', 'major')
-        self.assert_(result.items is self.panel.major_axis)
+        self.assertIs(result.items, self.panel.major_axis)
 
         result = self.panel.swapaxes('major', 'minor')
-        self.assert_(result.major_axis is self.panel.minor_axis)
+        self.assertIs(result.major_axis, self.panel.minor_axis)
 
         panel = self.panel.copy()
         result = panel.swapaxes('major', 'minor')
@@ -1353,7 +1353,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
 
         # this should also work
         result = self.panel.swapaxes(0, 1)
-        self.assert_(result.items is self.panel.major_axis)
+        self.assertIs(result.items, self.panel.major_axis)
 
         # this works, but return a copy
         result = self.panel.swapaxes('items', 'items')

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -172,15 +172,15 @@ class SafeForSparse(object):
 
         if hasattr(self.panel4d, '_item_cache'):
             self.assertNotIn('l1', self.panel4d._item_cache)
-        self.assert_(self.panel4d.labels is new_labels)
+        self.assertIs(self.panel4d.labels, new_labels)
 
         self.panel4d.major_axis = new_major
-        self.assert_(self.panel4d[0].major_axis is new_major)
-        self.assert_(self.panel4d.major_axis is new_major)
+        self.assertIs(self.panel4d[0].major_axis, new_major)
+        self.assertIs(self.panel4d.major_axis, new_major)
 
         self.panel4d.minor_axis = new_minor
-        self.assert_(self.panel4d[0].minor_axis is new_minor)
-        self.assert_(self.panel4d.minor_axis is new_minor)
+        self.assertIs(self.panel4d[0].minor_axis, new_minor)
+        self.assertIs(self.panel4d.minor_axis, new_minor)
 
     def test_get_axis_number(self):
         self.assertEqual(self.panel4d._get_axis_number('labels'), 0)
@@ -535,7 +535,7 @@ class CheckIndexing(object):
         # resize
         res = self.panel4d.set_value('l4', 'ItemE', 'foo', 'bar', 1.5)
         tm.assert_isinstance(res, Panel4D)
-        self.assert_(res is not self.panel4d)
+        self.assertIsNot(res, self.panel4d)
         self.assertEqual(res.get_value('l4', 'ItemE', 'foo', 'bar'), 1.5)
 
         res3 = self.panel4d.set_value('l4', 'ItemE', 'foobar', 'baz', 5)
@@ -558,10 +558,10 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
     def test_constructor(self):
         # with BlockManager
         panel4d = Panel4D(self.panel4d._data)
-        self.assert_(panel4d._data is self.panel4d._data)
+        self.assertIs(panel4d._data, self.panel4d._data)
 
         panel4d = Panel4D(self.panel4d._data, copy=True)
-        self.assert_(panel4d._data is not self.panel4d._data)
+        self.assertIsNot(panel4d._data, self.panel4d._data)
         assert_panel4d_equal(panel4d, self.panel4d)
 
         # strings handled prop
@@ -573,11 +573,11 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
 
         # no copy
         panel4d = Panel4D(vals)
-        self.assert_(panel4d.values is vals)
+        self.assertIs(panel4d.values, vals)
 
         # copy
         panel4d = Panel4D(vals, copy=True)
-        self.assert_(panel4d.values is not vals)
+        self.assertIsNot(panel4d.values, vals)
 
     def test_constructor_cast(self):
         zero_filled = self.panel4d.fillna(0)
@@ -851,23 +851,23 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
 
     def test_swapaxes(self):
         result = self.panel4d.swapaxes('labels', 'items')
-        self.assert_(result.items is self.panel4d.labels)
+        self.assertIs(result.items, self.panel4d.labels)
 
         result = self.panel4d.swapaxes('labels', 'minor')
-        self.assert_(result.labels is self.panel4d.minor_axis)
+        self.assertIs(result.labels, self.panel4d.minor_axis)
 
         result = self.panel4d.swapaxes('items', 'minor')
-        self.assert_(result.items is self.panel4d.minor_axis)
+        self.assertIs(result.items, self.panel4d.minor_axis)
 
         result = self.panel4d.swapaxes('items', 'major')
-        self.assert_(result.items is self.panel4d.major_axis)
+        self.assertIs(result.items, self.panel4d.major_axis)
 
         result = self.panel4d.swapaxes('major', 'minor')
-        self.assert_(result.major_axis is self.panel4d.minor_axis)
+        self.assertIs(result.major_axis, self.panel4d.minor_axis)
 
         # this should also work
         result = self.panel4d.swapaxes(0, 1)
-        self.assert_(result.labels is self.panel4d.items)
+        self.assertIs(result.labels, self.panel4d.items)
 
         # this works, but return a copy
         result = self.panel4d.swapaxes('items', 'items')

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1756,7 +1756,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # HACK: By doing this in two stages, we avoid 2to3 wrapping the call
         # to .keys() in a list()
         getkeys = self.ts.keys
-        self.assert_(getkeys() is self.ts.index)
+        self.assertIs(getkeys(), self.ts.index)
 
     def test_values(self):
         self.assert_numpy_array_equal(self.ts, self.ts.values)
@@ -4916,12 +4916,12 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
     def test_align_sameindex(self):
         a, b = self.ts.align(self.ts, copy=False)
-        self.assert_(a.index is self.ts.index)
-        self.assert_(b.index is self.ts.index)
+        self.assertIs(a.index, self.ts.index)
+        self.assertIs(b.index, self.ts.index)
 
         # a, b = self.ts.align(self.ts, copy=True)
-        # self.assert_(a.index is not self.ts.index)
-        # self.assert_(b.index is not self.ts.index)
+        # self.assertIsNot(a.index, self.ts.index)
+        # self.assertIsNot(b.index, self.ts.index)
 
     def test_reindex(self):
         identity = self.series.reindex(self.series.index)
@@ -5465,7 +5465,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         result = ts[:0].asfreq('M')
         self.assertEqual(len(result), 0)
-        self.assert_(result is not ts)
+        self.assertIsNot(result, ts)
 
     def test_weekday(self):
         # Just run the function

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -1245,11 +1245,11 @@ class TestConcatenate(tm.TestCase):
 
         appended = self.frame.append(empty)
         assert_frame_equal(self.frame, appended)
-        self.assert_(appended is not self.frame)
+        self.assertIsNot(appended, self.frame)
 
         appended = empty.append(self.frame)
         assert_frame_equal(self.frame, appended)
-        self.assert_(appended is not self.frame)
+        self.assertIsNot(appended, self.frame)
 
         # overlap
         self.assertRaises(ValueError, self.frame.append, self.frame,

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -1920,7 +1920,7 @@ class TestPeriodIndex(tm.TestCase):
 
         for kind in ['inner', 'outer', 'left', 'right']:
             res = index.join(index, how=kind)
-            self.assert_(index is res)
+            self.assertIs(index, res)
 
     def test_join_does_not_recur(self):
         df = tm.makeCustomDataframe(3, 2, data_gen_f=lambda *args:

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -392,7 +392,7 @@ class TestTimeSeries(tm.TestCase):
         data = dict((k, 1) for k in rng)
 
         result = Series(data, index=rng)
-        self.assert_(result.index is rng)
+        self.assertIs(result.index, rng)
 
     def test_series_pad_backfill_limit(self):
         index = np.arange(10)
@@ -866,7 +866,7 @@ class TestTimeSeries(tm.TestCase):
 
         # empty string
         result = to_datetime('')
-        self.assert_(result is NaT)
+        self.assertIs(result, NaT)
 
         result = to_datetime(['', ''])
         self.assert_(isnull(result).all())
@@ -943,7 +943,7 @@ class TestTimeSeries(tm.TestCase):
         for dt in oob_dts:
             self.assertRaises(ValueError, pd.to_datetime, dt, errors='raise')
             self.assertRaises(ValueError, tslib.Timestamp, dt)
-            self.assert_(pd.to_datetime(dt, coerce=True) is NaT)
+            self.assertIs(pd.to_datetime(dt, coerce=True), NaT)
 
     def test_to_datetime_array_of_dt64s(self):
         dts = [
@@ -2131,7 +2131,7 @@ class TestDatetimeIndex(tm.TestCase):
         kinds = 'outer', 'inner', 'left', 'right'
         for kind in kinds:
             joined = index.join(index, how=kind)
-            self.assert_(index is joined)
+            self.assertIs(index, joined)
 
     def assert_index_parameters(self, index):
         assert index.freq == '40960N'
@@ -2351,7 +2351,7 @@ class TestDatetime64(tm.TestCase):
 
         result = dti.union(empty)
         tm.assert_isinstance(result, DatetimeIndex)
-        self.assert_(result is result)
+        self.assertIs(result, result)
 
         result = dti.join(empty)
         tm.assert_isinstance(result, DatetimeIndex)
@@ -2426,16 +2426,16 @@ class TestSeriesDatetime64(tm.TestCase):
 
     def test_set_none_nan(self):
         self.series[3] = None
-        self.assert_(self.series[3] is NaT)
+        self.assertIs(self.series[3], NaT)
 
         self.series[3:5] = None
-        self.assert_(self.series[4] is NaT)
+        self.assertIs(self.series[4], NaT)
 
         self.series[5] = np.nan
-        self.assert_(self.series[5] is NaT)
+        self.assertIs(self.series[5], NaT)
 
         self.series[5:7] = np.nan
-        self.assert_(self.series[6] is NaT)
+        self.assertIs(self.series[6], NaT)
 
     def test_intercept_astype_object(self):
 
@@ -2575,16 +2575,16 @@ class TestTimestamp(tm.TestCase):
 
         # nan
         result = Timestamp(np.nan)
-        self.assert_(result is NaT)
+        self.assertIs(result, NaT)
 
         result = Timestamp(None)
-        self.assert_(result is NaT)
+        self.assertIs(result, NaT)
 
         result = Timestamp(iNaT)
-        self.assert_(result is NaT)
+        self.assertIs(result, NaT)
 
         result = Timestamp(NaT)
-        self.assert_(result is NaT)
+        self.assertIs(result, NaT)
 
     def test_comparison(self):
         # 5-18-2012 00:00:00.000

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -189,7 +189,7 @@ class TestTimeZoneSupport(tm.TestCase):
         self.assertEquals(stamp, rng[1])
 
         utc_stamp = Timestamp('3/11/2012 05:00', tz='utc')
-        self.assert_(utc_stamp.tzinfo is pytz.utc)
+        self.assertIs(utc_stamp.tzinfo, pytz.utc)
         self.assertEquals(utc_stamp.hour, 5)
 
         stamp = Timestamp('3/11/2012 05:00').tz_localize('utc')
@@ -309,7 +309,7 @@ class TestTimeZoneSupport(tm.TestCase):
         # just want it to work
         start = datetime(2011, 3, 12, tzinfo=pytz.utc)
         dr = bdate_range(start, periods=50, freq=datetools.Hour())
-        self.assert_(dr.tz is pytz.utc)
+        self.assertIs(dr.tz, pytz.utc)
 
         # DateRange with naive datetimes
         dr = bdate_range('1/1/2005', '1/1/2009', tz=pytz.utc)
@@ -317,8 +317,8 @@ class TestTimeZoneSupport(tm.TestCase):
 
         # normalized
         central = dr.tz_convert(tz)
-        self.assert_(central.tz is tz)
-        self.assert_(central[0].tz is tz)
+        self.assertIs(central.tz, tz)
+        self.assertIs(central[0].tz, tz)
 
         # datetimes with tzinfo set
         dr = bdate_range(datetime(2005, 1, 1, tzinfo=pytz.utc),
@@ -503,14 +503,14 @@ class TestTimeZoneSupport(tm.TestCase):
         converted = to_datetime(dates_aware, utc=True)
         ex_vals = [Timestamp(x).value for x in dates_aware]
         self.assert_numpy_array_equal(converted.asi8, ex_vals)
-        self.assert_(converted.tz is pytz.utc)
+        self.assertIs(converted.tz, pytz.utc)
 
     def test_to_datetime_utc(self):
         from dateutil.parser import parse
         arr = np.array([parse('2012-06-13T01:39:00Z')], dtype=object)
 
         result = to_datetime(arr, utc=True)
-        self.assert_(result.tz is pytz.utc)
+        self.assertIs(result.tz, pytz.utc)
 
     def test_to_datetime_tzlocal(self):
         from dateutil.parser import parse
@@ -521,12 +521,12 @@ class TestTimeZoneSupport(tm.TestCase):
         arr = np.array([dt], dtype=object)
 
         result = to_datetime(arr, utc=True)
-        self.assert_(result.tz is pytz.utc)
+        self.assertIs(result.tz, pytz.utc)
 
         rng = date_range('2012-11-03 03:00', '2012-11-05 03:00', tz=tzlocal())
         arr = rng.to_pydatetime()
         result = to_datetime(arr, utc=True)
-        self.assert_(result.tz is pytz.utc)
+        self.assertIs(result.tz, pytz.utc)
 
     def test_frame_no_datetime64_dtype(self):
 
@@ -858,18 +858,18 @@ class TestTimeZones(tm.TestCase):
         ts_moscow = ts.tz_convert('Europe/Moscow')
 
         result = ts + ts_moscow
-        self.assert_(result.index.tz is pytz.utc)
+        self.assertIs(result.index.tz, pytz.utc)
 
         result = ts_moscow + ts
-        self.assert_(result.index.tz is pytz.utc)
+        self.assertIs(result.index.tz, pytz.utc)
 
         df = DataFrame({'a': ts})
         df_moscow = df.tz_convert('Europe/Moscow')
         result = df + df_moscow
-        self.assert_(result.index.tz is pytz.utc)
+        self.assertIs(result.index.tz, pytz.utc)
 
         result = df_moscow + df
-        self.assert_(result.index.tz is pytz.utc)
+        self.assertIs(result.index.tz, pytz.utc)
 
     def test_arith_utc_convert(self):
         rng = date_range('1/1/2011', periods=100, freq='H', tz='utc')


### PR DESCRIPTION
Work on #6175. Changes instances of assert_(a is [not] b) to specialized assertIs[Not](a, b).
