### PR TITLE
API: validate conversions of datetimeindex with tz, and fixup to_series() to handle (GH6032)

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1176,7 +1176,7 @@ Conversion
    DatetimeIndex.to_datetime
    DatetimeIndex.to_period
    DatetimeIndex.to_pydatetime
-
+   DatetimeIndex.to_series
 
 GroupBy
 -------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2033,6 +2033,8 @@ class DataFrame(NDFrame):
                     value = com._asarray_tuplesafe(value)
             elif isinstance(value, PeriodIndex):
                 value = value.asobject
+            elif isinstance(value, DatetimeIndex):
+                value = value._to_embed(keep_tz=True).copy()
             elif value.ndim == 2:
                 value = value.copy().T
             else:

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -266,13 +266,28 @@ class Index(IndexOpsMixin, FrozenNDArray):
             new_index = new_index.astype(dtype)
         return new_index
 
-    def to_series(self):
+    def to_series(self, keep_tz=False):
         """
-        return a series with both index and values equal to the index keys
+        Create a Series with both index and values equal to the index keys
         useful with map for returning an indexer based on an index
+
+        Parameters
+        ----------
+        keep_tz : optional, defaults False.
+                  applies only to a DatetimeIndex
+
+        Returns
+        -------
+        Series : dtype will be based on the type of the Index values.
         """
+
         import pandas as pd
-        return pd.Series(self.values, index=self, name=self.name)
+        values = self._to_embed(keep_tz)
+        return pd.Series(values, index=self, name=self.name)
+
+    def _to_embed(self, keep_tz=False):
+        """ return an array repr of this object, potentially casting to object """
+        return self.values
 
     def astype(self, dtype):
         return Index(self.values.astype(dtype), name=self.name,

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -162,7 +162,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                 # need to copy to avoid aliasing issues
                 if name is None:
                     name = data.name
-                data = data.values
+
+                data = data._to_embed(keep_tz=True)
                 copy = True
             elif isinstance(data, pa.Array):
                 pass

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -721,6 +721,38 @@ class DatetimeIndex(Int64Index):
             values = self._local_timestamps()
         return tslib.get_time_micros(values)
 
+    def to_series(self, keep_tz=False):
+        """
+        Create a Series with both index and values equal to the index keys
+        useful with map for returning an indexer based on an index
+
+        Parameters
+        ----------
+        keep_tz : optional, defaults False.
+                  return the data keeping the timezone.
+
+                  If keep_tz is True:
+
+                    If the timezone is not set or is UTC, the resulting
+                    Series will have a datetime64[ns] dtype.
+                    Otherwise the Series will have an object dtype.
+
+                  If keep_tz is False:
+
+                    Series will have a datetime64[ns] dtype.
+
+        Returns
+        -------
+        Series
+        """
+        return super(DatetimeIndex, self).to_series(keep_tz=keep_tz)
+
+    def _to_embed(self, keep_tz=False):
+        """ return an array repr of this object, potentially casting to object """
+        if keep_tz and self.tz is not None and str(self.tz) != 'UTC':
+            return self.asobject
+        return self.values
+
     @property
     def asobject(self):
         """


### PR DESCRIPTION
closes #6032
