### PR TITLE
BUG: Fix mergesort unstable when ascending=False (GH6399)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -107,6 +107,7 @@ Improvements to existing features
 Bug Fixes
 ~~~~~~~~~
 
+- Bug in ``pd.DataFrame.sort_index`` where mergesort wasn't stable when ``ascending=False`` (:issue:`6399`)
 - Bug in ``pd.tseries.frequencies.to_offset`` when argument has leading zeroes (:issue:`6391`)
 - Bug in version string gen. for dev versions with shallow clones / install from tarball (:issue:`6127`)
 - Inconsistent tz parsing Timestamp/to_datetime for current year (:issue:`5958`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2612,11 +2612,14 @@ class DataFrame(NDFrame):
                 if k.ndim == 2:
                     raise ValueError('Cannot sort by duplicate column %s'
                                      % str(by))
-                indexer = k.argsort(kind=kind)
                 if isinstance(ascending, (tuple, list)):
                     ascending = ascending[0]
+
                 if not ascending:
-                    indexer = indexer[::-1]
+                    k = k[::-1]
+                indexer = k.argsort(kind=kind)
+                if not ascending:
+                    indexer = indexer.max() - indexer[::-1]
         elif isinstance(labels, MultiIndex):
             indexer = _lexsort_indexer(labels.labels, orders=ascending)
             indexer = com._ensure_platform_int(indexer)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -9770,6 +9770,13 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         cp = s.copy()
         cp.sort() # it works!
 
+    def test_stable_descending_sort(self):
+        df = DataFrame([[2, 'first'], [2, 'second'], [1, 'a'], [1, 'b']],
+                       columns=['sort_col', 'order'])
+        sorted = df.sort_index(by='sort_col', kind='mergesort',
+                               ascending=False)
+        assert_frame_equal(df, sorted)
+
     def test_combine_first(self):
         # disjoint
         head, tail = self.frame[:5], self.frame[5:]


### PR DESCRIPTION
closes #6399. I hope I followed all of the correct procedures.

I ran the full test suite (test.sh), and there were no errors.
