### PR TITLE
Make to_csv return a string if no path or buffer is provided.

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -71,6 +71,8 @@ API Changes
 - ``df['col'] = value`` and ``df.loc[:,'col'] = value`` are now completely equivalent;
   previously the ``.loc`` would not necessarily coerce the dtype of the resultant series (:issue:`6149`)
 - ``dtypes`` and ``ftypes`` now return a series with ``dtype=object`` on empty containers (:issue:`5740`)
+- ``df.to_csv`` will now return a string of the CSV data if neither a target path nor a buffer is provided
+  (:issue:`6061`)
 - The ``interpolate`` ``downcast`` keyword default has been changed from ``infer`` to
   ``None``. This is to preseve the original dtype unless explicitly requested otherwise (:issue:`6290`).
 - allow a Series to utilize index methods depending on its index type, e.g. ``Series.year`` is now defined

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -943,7 +943,7 @@ def _get_level_lengths(levels, sentinel=''):
 
 class CSVFormatter(object):
 
-    def __init__(self, obj, path_or_buf, sep=",", na_rep='', float_format=None,
+    def __init__(self, obj, path_or_buf=None, sep=",", na_rep='', float_format=None,
                  cols=None, header=True, index=True, index_label=None,
                  mode='w', nanRep=None, encoding=None, quoting=None,
                  line_terminator='\n', chunksize=None, engine=None,
@@ -952,6 +952,9 @@ class CSVFormatter(object):
 
         self.engine = engine  # remove for 0.13
         self.obj = obj
+
+        if path_or_buf is None:
+            path_or_buf = StringIO()
 
         self.path_or_buf = path_or_buf
         self.sep = sep
@@ -1144,7 +1147,7 @@ class CSVFormatter(object):
 
     def save(self):
         # create the writer & save
-        if hasattr(self.path_or_buf, 'read'):
+        if hasattr(self.path_or_buf, 'write'):
             f = self.path_or_buf
             close = False
         else:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1067,7 +1067,7 @@ class DataFrame(NDFrame):
 
     to_wide = deprecate('to_wide', to_panel)
 
-    def to_csv(self, path_or_buf, sep=",", na_rep='', float_format=None,
+    def to_csv(self, path_or_buf=None, sep=",", na_rep='', float_format=None,
                cols=None, header=True, index=True, index_label=None,
                mode='w', nanRep=None, encoding=None, quoting=None,
                quotechar='"', line_terminator='\n', chunksize=None,
@@ -1077,8 +1077,9 @@ class DataFrame(NDFrame):
 
         Parameters
         ----------
-        path_or_buf : string or file handle / StringIO
-            File path
+        path_or_buf : string or file handle, default None
+            File path or object, if None is provided the result is returned as
+            a string.
         sep : character, default ","
             Field delimiter for the output file.
         na_rep : string, default ''
@@ -1143,6 +1144,9 @@ class DataFrame(NDFrame):
                                      doublequote=doublequote,
                                      escapechar=escapechar)
         formatter.save()
+
+        if path_or_buf is None:
+            return formatter.path_or_buf.getvalue()
 
     def to_excel(self, excel_writer, sheet_name='Sheet1', na_rep='',
                  float_format=None, cols=None, header=True, index=True,

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -1787,6 +1787,12 @@ $1$,$2$
             with open(path, 'r') as f:
                 self.assertEqual(f.read(), expected)
 
+    def test_csv_to_string(self):
+        df = DataFrame({'col' : [1,2]})
+        expected = ',col\n0,1\n1,2\n'
+        self.assertEqual(df.to_csv(), expected)
+        
+
 class TestSeriesFormatting(tm.TestCase):
     _multiprocess_can_split_ = True
 


### PR DESCRIPTION
Fixes #6061.
