### PR TITLE
API: pd.infer_freq interacts correctly with a Series

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -80,6 +80,8 @@ API Changes
   - ``week,dayofweek,dayofyear,quarter``
   - ``microsecond,nanosecond,qyear``
   - ``min(),max()``
+  - ``pd.infer_freq()``
+- ``pd.infer_freq()`` will now raise a ``TypeError`` if given an invalid ``Series/Index`` type (:issue:`6407`)
 
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -42,6 +42,7 @@ API changes
   - ``week,dayofweek,dayofyear,quarter``
   - ``microsecond,nanosecond,qyear``
   - ``min(),max()``
+  - ``pd.infer_freq()``
 
   .. ipython:: python
 


### PR DESCRIPTION
ENH: pd.infer_freq() will accept a Series as input
API: pd.infer_freq() will now raise a TypeError if given an invalid Series/Index type (GH6407)

closes #6407
