### PR TITLE
REGR: Bug in Series.reindex when specifying a method with some nan values was inconsistent (GH6418)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -163,6 +163,7 @@ Bug Fixes
 - ``Float64Index`` with nans not comparing correctly
 - ``eval``/``query`` expressions with strings containing the ``@`` character
   will now work (:issue:`6366`).
+- Bug in ``Series.reindex`` when specifying a ``method`` with some nan values was inconsistent (noted on a resample) (:issue:`6418`)
 
 pandas 0.13.1
 -------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1589,23 +1589,9 @@ class NDFrame(PandasObject):
 
             axis = self._get_axis_number(a)
             ax = self._get_axis(a)
-            try:
-                new_index, indexer = ax.reindex(
-                    labels, level=level, limit=limit, method=method,
-                    takeable=takeable)
-            except (ValueError):
-
-                # catch trying to reindex a non-monotonic index with a
-                # specialized indexer e.g. pad, so fallback to the regular
-                # indexer this will show up on reindexing a not-naturally
-                # ordering series,
-                # e.g.
-                # Series(
-                #     [1,2,3,4], index=['a','b','c','d']
-                # ).reindex(['c','b','g'], method='pad')
-                new_index, indexer = ax.reindex(
-                    labels, level=level, limit=limit, method=None,
-                    takeable=takeable)
+            new_index, indexer = ax.reindex(
+                labels, level=level, limit=limit, method=method,
+                takeable=takeable)
 
             obj = obj._reindex_with_indexers(
                 {axis: [new_index, indexer]}, method=method,

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -265,7 +265,7 @@ class Block(PandasObject):
             new_ref_items, indexer = self.items.reindex(new_ref_items,
                                                         limit=limit)
 
-        needs_fill = method is not None and limit is None
+        needs_fill = method is not None
         if fill_value is None:
             fill_value = self.fill_value
 
@@ -275,10 +275,13 @@ class Block(PandasObject):
 
         else:
 
-            # single block reindex
+            # single block reindex, filling is already happending
             if self.ndim == 1:
                 new_values = com.take_1d(self.values, indexer,
                                          fill_value=fill_value)
+                block = make_block(new_values, new_items, new_ref_items,
+                                   ndim=self.ndim, fastpath=True)
+                return block
             else:
 
                 masked_idx = indexer[indexer != -1]
@@ -3705,8 +3708,6 @@ class SingleBlockManager(BlockManager):
 
     def reindex_axis0_with_method(self, new_axis, indexer=None, method=None,
                                   fill_value=None, limit=None, copy=True):
-        if method is None:
-            indexer = None
         return self.reindex(new_axis, indexer=indexer, method=method,
                             fill_value=fill_value, limit=limit, copy=copy)
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -4999,9 +4999,8 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         result = s.reindex(new_index).ffill(downcast='infer')
         assert_series_equal(result, expected)
 
-        # this preserves dtype
-        result = s.reindex(new_index, method='ffill')
-        assert_series_equal(result, expected)
+        # invalid because we can't forward fill on this type of index
+        self.assertRaises(ValueError, lambda : s.reindex(new_index, method='ffill'))
 
         # inferrence of new dtype
         s = Series([True,False,False,True],index=list('abcd'))


### PR DESCRIPTION
closes #6418
