### PR TITLE
DOC: link to pandas-cookbook instructions

### DIFF
--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -22,7 +22,9 @@ are examples with real-world data, and all the bugs and weirdness that
 that entails.
 
 Here are links to the v0.1 release. For an up-to-date table of contents, see the `pandas-cookbook GitHub
-repository <http://github.com/jvns/pandas-cookbook>`_.
+repository <http://github.com/jvns/pandas-cookbook>`_. To run the examples in this tutorial, you'll need to 
+clone the GitHub repository and get IPython Notebook running. 
+See `How to use this cookbook <https://github.com/jvns/pandas-cookbook#how-to-use-this-cookbook>`_.
 
 -  `A quick tour of the IPython Notebook: <http://nbviewer.ipython.org/github/jvns/pandas-c|%2055ookbook/blob/v0.1/cookbook/A%20quick%20tour%20of%20IPython%20Notebook.ipynb>`_
    Shows off IPython's awesome tab completion and magic functions.


### PR DESCRIPTION
Some people were confused about how to use this cookbook, so adding a link to the setup instructions.

see: https://github.com/jvns/pandas-cookbook/issues/7
this SO question: https://stackoverflow.com/questions/21868105/problems-with-pandas-tutorial-missing-file-bikes-csv-and-special-characters-in
