### PR TITLE
PERF: optimize index.__getitem__ for slice & boolean mask indexers

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -105,6 +105,8 @@ API Changes
 - ``NameResolutionError`` was removed because it isn't necessary anymore.
 - ``concat`` will now concatenate mixed Series and DataFrames using the Series name
   or numbering columns as needed (:issue:`2385`)
+- Slicing and advanced/boolean indexing operations on ``Index`` classes will no
+  longer change type of the resulting index (:issue:`6440`).
 
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -78,6 +78,21 @@ These are out-of-bounds selections
 - ``NameResolutionError`` was removed because it isn't necessary anymore.
 - ``concat`` will now concatenate mixed Series and DataFrames using the Series name
   or numbering columns as needed (:issue:`2385`). See :ref:`the docs <merging.mixed_ndims>`
+- Slicing and advanced/boolean indexing operations on ``Index`` classes will no
+  longer change type of the resulting index (:issue:`6440`)
+
+  .. ipython:: python
+
+     i = pd.Index([1, 2, 3, 'a' , 'b', 'c'])
+     i[[0,1,2]]
+
+  Previously, the above operation would return ``Int64Index``.  If you'd like
+  to do this manually, use :meth:`Index.astype`
+
+  .. ipython:: python
+
+     i[[0,1,2]].astype(np.int_)
+
 
 MultiIndexing Using Slicers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -3737,7 +3737,7 @@ class SingleBlockManager(BlockManager):
         if raise_on_error:
             _check_slice_bounds(slobj, self.index)
         return self.__class__(self._block._slice(slobj),
-                              self.index._getitem_slice(slobj), fastpath=True)
+                              self.index[slobj], fastpath=True)
 
     def set_axis(self, axis, value, maybe_rename=True, check_axis=True):
         cur_axis, value = self._set_axis(axis, value, check_axis)

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -323,6 +323,25 @@ class TestIndex(tm.TestCase):
         for i in sl:
             self.assertEqual(i, sl[sl.get_loc(i)])
 
+    def test_empty_fancy(self):
+        empty_farr = np.array([], dtype=np.float_)
+        empty_iarr = np.array([], dtype=np.int_)
+        empty_barr = np.array([], dtype=np.bool_)
+
+        # pd.DatetimeIndex is excluded, because it overrides getitem and should
+        # be tested separately.
+        for idx in [self.strIndex, self.intIndex, self.floatIndex]:
+            empty_idx = idx.__class__([])
+            values = idx.values
+
+            self.assert_(idx[[]].identical(empty_idx))
+            self.assert_(idx[empty_iarr].identical(empty_idx))
+            self.assert_(idx[empty_barr].identical(empty_idx))
+
+            # np.ndarray only accepts ndarray of int & bool dtypes, so should
+            # Index.
+            self.assertRaises(IndexError, idx.__getitem__, empty_farr)
+
     def test_getitem(self):
         arr = np.array(self.dateIndex)
         exp = self.dateIndex[5]
@@ -761,6 +780,14 @@ class TestIndex(tm.TestCase):
                 res = getattr(self, '{0}Index'.format(index_kind))
                 joined = res.join(res, how=kind)
                 self.assertIs(res, joined)
+
+    def test_indexing_doesnt_change_class(self):
+        idx = Index([1, 2, 3, 'a', 'b', 'c'])
+
+        self.assert_(idx[1:3].identical(
+            pd.Index([2, 3], dtype=np.object_)))
+        self.assert_(idx[[0,1]].identical(
+            pd.Index([1, 2], dtype=np.object_)))
 
 
 class TestFloat64Index(tm.TestCase):

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1406,8 +1406,6 @@ class DatetimeIndex(Int64Index):
 
             return self._simple_new(result, self.name, new_offset, self.tz)
 
-    _getitem_slice = __getitem__
-
     # Try to run function on index first, and then on elements of index
     # Especially important for group-by functionality
     def map(self, f):

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -1056,8 +1056,6 @@ class PeriodIndex(Int64Index):
 
             return PeriodIndex(result, name=self.name, freq=self.freq)
 
-    _getitem_slice = __getitem__
-
     def _format_with_header(self, header, **kwargs):
         return header + self._format_native_types(**kwargs)
 

--- a/vb_suite/index_object.py
+++ b/vb_suite/index_object.py
@@ -46,3 +46,16 @@ index_int64_union = Benchmark('left.union(right)', setup,
 
 index_int64_intersection = Benchmark('left.intersection(right)', setup,
                                      start_date=datetime(2011, 1, 1))
+
+#----------------------------------------------------------------------
+# string index slicing
+setup = common_setup + """
+idx = tm.makeStringIndex(1000000)
+
+mask = np.arange(1000000) % 3 == 0
+series_mask = Series(mask)
+"""
+index_str_slice_indexer_basic = Benchmark('idx[:-1]', setup)
+index_str_slice_indexer_even = Benchmark('idx[::2]', setup)
+index_str_boolean_indexer = Benchmark('idx[mask]', setup)
+index_str_boolean_series_indexer = Benchmark('idx[series_mask]', setup)


### PR DESCRIPTION
This patch fixes performance issues discussed in and closes #6370.

There's an API change though: no type inference will now happen upon resulting index, e.g. here's what it would look like on current master:

``` python
In [1]: pd.Index([1,2,3, 'a', 'b', 'c'])
Out[1]: Index([1, 2, 3, u'a', u'b', u'c'], dtype='object')

In [2]: _1[[0,1,2]]
Out[2]: Int64Index([1, 2, 3], dtype='int64')
```

And this is how it looks with the patch:

``` python
In [1]: pd.Index([1,2,3, 'a', 'b', 'c'])
Out[1]: Index([1, 2, 3, u'a', u'b', u'c'], dtype='object')

In [2]: _1[[0,1,2]]
Out[2]: Index([1, 2, 3], dtype='object')
```

On the bright side, I'd say using mixed-type indices seems a quite rare scenario and the performance improvement is worth it.
## Performance Before:

``` python
In [1]: import pandas.util.testing as tm

In [2]: idx = tm.makeStringIndex(1000000)

In [3]: mask = np.arange(1000000) % 3 == 0

In [4]: series_mask = pd.Series(mask); mask
Out[4]: array([ True, False, False, ..., False, False,  True], dtype=bool)

In [5]: timeit idx[:-1]
100000 loops, best of 3: 1.57 µs per loop

In [6]: timeit idx[::2]
100 loops, best of 3: 14.6 ms per loop

In [7]: timeit idx[mask]
100 loops, best of 3: 15.4 ms per loop

In [8]: timeit idx[series_mask]
100 loops, best of 3: 15.4 ms per loop

In [9]: pd.__version__
Out[9]: '0.13.1-278-gaf63b99'
```
## Performance After:

``` python
In [1]: import pandas.util.testing as tm

In [2]: idx = tm.makeStringIndex(1000000)

In [3]: mask = np.arange(1000000) % 3 == 0

In [4]: series_mask = pd.Series(mask)

In [5]: timeit idx[:-1]
1000000 loops, best of 3: 1.56 µs per loop

In [6]: timeit idx[::2]
100000 loops, best of 3: 4.89 µs per loop

In [7]: timeit idx[mask]
100 loops, best of 3: 11.4 ms per loop

In [8]: timeit idx[series_mask]
100 loops, best of 3: 11.4 ms per loop

In [9]: pd.__version__
Out[9]: '0.13.1-279-gbc810f0'

```
