### PR TITLE
BUG/TST: read_html should follow pandas conventions when creating empty data

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -184,6 +184,11 @@ Bug Fixes
 - Bug in ``sum`` of a ``timedelta64[ns]`` series (:issue:`6462`)
 - Bug in ``resample`` with a timezone and certain offsets (:issue:`6397`)
 - Bug in ``iat/iloc`` with duplicate indices on a Series (:issue:`6493`)
+- Bug in ``read_html`` where nan's were incorrectly being used to indicate
+  missing values in text. Should use the empty string for consistency with the
+  rest of pandas (:issue:`5129`).
+- Bug in ``read_html`` tests where redirected invalid URLs would make one test
+  fail (:issue:`6445`).
 
 pandas 0.13.1
 -------------

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -579,8 +579,9 @@ def _expand_elements(body):
     lens_max = lens.max()
     not_max = lens[lens != lens_max]
 
+    empty = ['']
     for ind, length in iteritems(not_max):
-        body[ind] += [np.nan] * (lens_max - length)
+        body[ind] += empty * (lens_max - length)
 
 
 def _data_to_frame(data, header, index_col, skiprows, infer_types,
@@ -760,15 +761,15 @@ def read_html(io, match='.+', flavor=None, header=None, index_col=None,
         the table in the HTML. These are not checked for validity before being
         passed to lxml or Beautiful Soup. However, these attributes must be
         valid HTML table attributes to work correctly. For example, ::
-        
+
             attrs = {'id': 'table'}
-        
+
         is a valid attribute dictionary because the 'id' HTML tag attribute is
         a valid HTML attribute for *any* HTML tag as per `this document
         <http://www.w3.org/TR/html-markup/global-attributes.html>`__. ::
-        
+
             attrs = {'asdf': 'table'}
-        
+
         is *not* a valid attribute dictionary because 'asdf' is not a valid
         HTML attribute even if it is a valid XML attribute.  Valid HTML 4.01
         table attributes can be found `here

--- a/pandas/io/tests/data/computer_sales_page.html
+++ b/pandas/io/tests/data/computer_sales_page.html
@@ -1,0 +1,619 @@
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+<tbody><tr><!-- TABLE COLUMN WIDTHS SET -->
+<td width="" style="font-family:times;"></td>
+<td width="12pt" style="font-family:times;"></td>
+<td width="7pt" align="RIGHT" style="font-family:times;"></td>
+<td width="45pt" style="font-family:times;"></td>
+<td width="12pt" style="font-family:times;"></td>
+<td width="7pt" align="RIGHT" style="font-family:times;"></td>
+<td width="45pt" style="font-family:times;"></td>
+<td width="12pt" style="font-family:times;"></td>
+<td width="7pt" align="RIGHT" style="font-family:times;"></td>
+<td width="45pt" style="font-family:times;"></td>
+<td width="12pt" style="font-family:times;"></td>
+<td width="7pt" align="RIGHT" style="font-family:times;"></td>
+<td width="45pt" style="font-family:times;"></td>
+<td width="12pt" style="font-family:times;"></td>
+<!-- TABLE COLUMN WIDTHS END --></tr>
+
+<tr valign="BOTTOM">
+<th align="LEFT" style="font-family:times;"><font size="2">&nbsp;</font><br></th>
+<th style="font-family:times;"><font size="1">&nbsp;</font></th>
+<th colspan="5" align="CENTER" style="font-family:times;border-bottom:solid #000000 1.0pt;"><font size="1"><b>Three months ended<br>
+April&nbsp;30 </b></font></th>
+<th style="font-family:times;"><font size="1">&nbsp;</font></th>
+<th colspan="5" align="CENTER" style="font-family:times;border-bottom:solid #000000 1.0pt;"><font size="1"><b>Six months ended<br>
+April&nbsp;30 </b></font></th>
+<th style="font-family:times;"><font size="1">&nbsp;</font></th>
+</tr>
+<tr valign="BOTTOM">
+<th align="LEFT" style="font-family:times;"><font size="1">&nbsp;</font><br></th>
+<th style="font-family:times;"><font size="1">&nbsp;</font></th>
+<th colspan="2" align="CENTER" style="font-family:times;border-bottom:solid #000000 1.0pt;"><font size="1"><b>2013 </b></font></th>
+<th style="font-family:times;"><font size="1">&nbsp;</font></th>
+<th colspan="2" align="CENTER" style="font-family:times;border-bottom:solid #000000 1.0pt;"><font size="1"><b>2012 </b></font></th>
+<th style="font-family:times;"><font size="1">&nbsp;</font></th>
+<th colspan="2" align="CENTER" style="font-family:times;border-bottom:solid #000000 1.0pt;"><font size="1"><b>2013 </b></font></th>
+<th style="font-family:times;"><font size="1">&nbsp;</font></th>
+<th colspan="2" align="CENTER" style="font-family:times;border-bottom:solid #000000 1.0pt;"><font size="1"><b>2012 </b></font></th>
+<th style="font-family:times;"><font size="1">&nbsp;</font></th>
+</tr>
+<tr valign="BOTTOM">
+<th align="LEFT" style="font-family:times;"><font size="1">&nbsp;</font><br></th>
+<th style="font-family:times;"><font size="1">&nbsp;</font></th>
+<th colspan="11" align="CENTER" style="font-family:times;"><font size="1"><b>In millions</b></font><br></th>
+<th style="font-family:times;"><font size="1">&nbsp;</font></th>
+</tr>
+<tr bgcolor="#CCEEFF" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:10pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Net revenue:</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr bgcolor="White" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:30pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Notebooks</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">$</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">3,718</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">$</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">4,900</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">$</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">7,846</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">$</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">9,842</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr bgcolor="#CCEEFF" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:30pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Desktops</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">3,103</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">3,827</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">6,424</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">7,033</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr bgcolor="White" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:30pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Workstations</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">521</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">537</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">1,056</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">1,072</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr bgcolor="#CCEEFF" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:30pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Other</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">242</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">206</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">462</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">415</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr style="font-size:1.5pt;" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+</tr>
+<tr bgcolor="White" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:20pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Personal Systems</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">7,584</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">9,470</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">15,788</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">18,362</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr style="font-size:1.5pt;" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+</tr>
+<tr bgcolor="#CCEEFF" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:20pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Supplies</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">4,122</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">4,060</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">8,015</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">8,139</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr bgcolor="White" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:20pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Commercial Hardware</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">1,398</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">1,479</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">2,752</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">2,968</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr bgcolor="#CCEEFF" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:20pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Consumer Hardware</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">561</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">593</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">1,240</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">1,283</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr style="font-size:1.5pt;" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+</tr>
+<tr bgcolor="White" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:20pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Printing</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">6,081</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">6,132</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">12,007</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">12,390</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr style="font-size:1.5pt;" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+</tr>
+<tr bgcolor="#CCEEFF" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:10pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Printing and Personal Systems Group</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">13,665</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">15,602</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">27,795</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">30,752</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr style="font-size:1.5pt;" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+</tr>
+<tr bgcolor="White" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:20pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Industry Standard Servers</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">2,806</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">3,186</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">5,800</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">6,258</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr bgcolor="#CCEEFF" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:20pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Technology Services</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">2,272</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">2,335</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">4,515</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">4,599</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr bgcolor="White" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:20pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Storage</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">857</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">990</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">1,690</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">1,945</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr bgcolor="#CCEEFF" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:20pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Networking</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">618</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">614</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">1,226</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">1,200</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr bgcolor="White" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:20pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Business Critical Systems</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">266</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">421</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">572</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">826</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr style="font-size:1.5pt;" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+</tr>
+<tr bgcolor="#CCEEFF" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:10pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Enterprise Group</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">6,819</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">7,546</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">13,803</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">14,828</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr style="font-size:1.5pt;" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+</tr>
+<tr bgcolor="White" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:20pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Infrastructure Technology Outsourcing</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">3,721</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">3,954</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">7,457</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">7,934</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr bgcolor="#CCEEFF" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:20pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Application and Business Services</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">2,278</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">2,535</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">4,461</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">4,926</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr style="font-size:1.5pt;" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+</tr>
+<tr bgcolor="White" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:10pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Enterprise Services</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">5,999</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">6,489</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">11,918</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">12,860</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr style="font-size:1.5pt;" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+</tr>
+<tr bgcolor="#CCEEFF" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:10pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Software</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">941</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">970</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">1,867</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">1,916</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr bgcolor="White" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:10pt;text-indent:-10pt;"><font size="2"> </font><font size="2">HP Financial Services</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">881</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">968</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">1,838</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">1,918</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr bgcolor="#CCEEFF" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:10pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Corporate Investments</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">10</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">7</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">14</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">37</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr style="font-size:1.5pt;" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+</tr>
+<tr bgcolor="White" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:30pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Total segments</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">28,315</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">31,582</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">57,235</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">62,311</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr style="font-size:1.5pt;" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+</tr>
+<tr bgcolor="#CCEEFF" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:10pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Eliminations of intersegment net revenue and other</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">(733</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">)</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">(889</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">)</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">(1,294</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">)</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">(1,582</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">)</font></td>
+</tr>
+<tr style="font-size:1.5pt;" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:solid #000000 1.0pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+</tr>
+<tr bgcolor="White" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;"><p style="font-family:times;margin-left:30pt;text-indent:-10pt;"><font size="2"> </font><font size="2">Total HP consolidated net revenue</font></p></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">$</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">27,582</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">$</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">30,693</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">$</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">55,941</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">$</font></td>
+<td align="RIGHT" valign="BOTTOM" style="font-family:times;"><font size="2">60,729</font></td>
+<td valign="BOTTOM" style="font-family:times;"><font size="2">&nbsp;</font></td>
+</tr>
+<tr style="font-size:1.5pt;" valign="TOP">
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:double #000000 2.25pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:double #000000 2.25pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:double #000000 2.25pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+<td colspan="2" align="RIGHT" valign="BOTTOM" style="font-family:times;border-bottom:double #000000 2.25pt;">&nbsp;</td>
+<td valign="BOTTOM" style="font-family:times;">&nbsp;</td>
+</tr>
+</tbody></table>

--- a/pandas/io/tests/test_html.py
+++ b/pandas/io/tests/test_html.py
@@ -22,6 +22,7 @@ from pandas import (DataFrame, MultiIndex, read_csv, Timestamp, Index,
 from pandas.compat import map, zip, StringIO, string_types
 from pandas.io.common import URLError, urlopen, file_path_to_url
 from pandas.io.html import read_html
+from pandas.parser import CParserError
 
 import pandas.util.testing as tm
 from pandas.util.testing import makeCustomDataframe as mkdf, network
@@ -143,7 +144,7 @@ class TestReadHtml(tm.TestCase):
     def test_spam_no_types(self):
         with tm.assert_produces_warning(FutureWarning):
             df1 = self.read_html(self.spam_data, '.*Water.*',
-                                     infer_types=False)
+                                 infer_types=False)
         with tm.assert_produces_warning(FutureWarning):
             df2 = self.read_html(self.spam_data, 'Unit', infer_types=False)
 
@@ -305,8 +306,11 @@ class TestReadHtml(tm.TestCase):
 
     @network
     def test_invalid_url(self):
-        with tm.assertRaises(URLError):
-            self.read_html('http://www.a23950sdfa908sd.com', match='.*Water.*')
+        try:
+            with tm.assertRaises(URLError):
+                self.read_html('http://www.a23950sdfa908sd.com', match='.*Water.*')
+        except ValueError as e:
+            tm.assert_equal(str(e), 'No tables found')
 
     @slow
     def test_file_url(self):
@@ -581,6 +585,14 @@ class TestReadHtml(tm.TestCase):
         newdf = DataFrame({'datetime': raw_dates})
         tm.assert_frame_equal(newdf, res[0])
 
+    def test_computer_sales_page(self):
+        data = os.path.join(DATA_PATH, 'computer_sales_page.html')
+        with tm.assertRaisesRegexp(CParserError, r"Passed header=\[0,1\] are "
+                                   "too many rows for this multi_index "
+                                   "of columns"):
+            with tm.assert_produces_warning(FutureWarning):
+                self.read_html(data, infer_types=False, header=[0, 1])
+
 
 class TestReadHtmlLxml(tm.TestCase):
     @classmethod
@@ -630,6 +642,12 @@ class TestReadHtmlLxml(tm.TestCase):
                              index_col=1)
         newdf = DataFrame({'datetime': raw_dates})
         tm.assert_frame_equal(newdf, res[0])
+
+    def test_computer_sales_page(self):
+        import pandas as pd
+        data = os.path.join(DATA_PATH, 'computer_sales_page.html')
+        with tm.assert_produces_warning(FutureWarning):
+            self.read_html(data, infer_types=False, header=[0, 1])
 
 
 def test_invalid_flavor():


### PR DESCRIPTION
closes #5129
closes #6445

This a very specific bug fix. Only using `lxml` exposes this bug, whereas using
`bs4` raises an exception. `lxml` drops data which allows it to parse the multiindex
header differently and succeed.
