### PR TITLE
BUG: Fixes error in DataReader when getting "F-F_Momentum_Factor" data

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -174,6 +174,7 @@ Bug Fixes
 - Regression in ``MultiIndex.from_product`` with a ``DatetimeIndex`` as input (:issue:`6439`)
 - Bug in ``str.extract`` when passed a non-default index (:issue:`6348`)
 - Bug in ``str.split`` when passed ``pat=None`` and ``n=1`` (:issue:`6466`)
+- Bug in ``io.data.DataReader`` when passed ``"F-F_Momentum_Factor"`` and ``data_source="famafrench"`` (:issue:`6470`)
 
 pandas 0.13.1
 -------------

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -174,7 +174,7 @@ Bug Fixes
 - Regression in ``MultiIndex.from_product`` with a ``DatetimeIndex`` as input (:issue:`6439`)
 - Bug in ``str.extract`` when passed a non-default index (:issue:`6348`)
 - Bug in ``str.split`` when passed ``pat=None`` and ``n=1`` (:issue:`6466`)
-- Bug in ``io.data.DataReader`` when passed ``"F-F_Momentum_Factor"`` and ``data_source="famafrench"`` (:issue:`6470`)
+- Bug in ``io.data.DataReader`` when passed ``"F-F_Momentum_Factor"`` and ``data_source="famafrench"`` (:issue:`6460`)
 
 pandas 0.13.1
 -------------

--- a/pandas/io/data.py
+++ b/pandas/io/data.py
@@ -494,7 +494,7 @@ def get_data_famafrench(name):
         tmpf.write(raw)
 
         with ZipFile(tmpf, 'r') as zf:
-            data = zf.open(name + '.txt').readlines()
+            data = zf.open(zf.namelist()[0]).readlines()
 
     line_lengths = np.array(lmap(len, data))
     file_edges = np.where(line_lengths == 2)[0]

--- a/pandas/io/tests/test_data.py
+++ b/pandas/io/tests/test_data.py
@@ -387,7 +387,7 @@ class TestDataReader(tm.TestCase):
     def test_read_famafrench(self):
         for name in ("F-F_Research_Data_Factors",
                      "F-F_Research_Data_Factors_weekly", "6_Portfolios_2x3",
-                     "F-F_ST_Reversal_Factor"):
+                     "F-F_ST_Reversal_Factor","F-F_Momentum_Factor"):
             ff = DataReader(name, "famafrench")
             assert ff
             assert isinstance(ff, dict)


### PR DESCRIPTION
Hopefully I didn't screw-up using git and github. This PR fixes the minor issue outlined in `GH6460`. I didn't write any new tests but I added the "F-F_Momentum_Factor" data request to the existing tests of the famafrench data reader.

closes #6460
