### PR TITLE
PERF: perf improvements in single-dtyped indexing (GH6484)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -129,6 +129,7 @@ Improvements to existing features
   using ``DataFrame.to_csv`` (:issue:`5414`, :issue:`4528`)
 - perf improvements in DataFrame construction with certain offsets, by removing faulty caching
   (e.g. MonthEnd,BusinessMonthEnd), (:issue:`6479`)
+- perf improvements in single-dtyped indexing (:issue:`6484`)
 
 .. _release.bug_fixes-0.14.0:
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -3402,8 +3402,11 @@ class BlockManager(PandasObject):
             # unique
             if self.axes[0].is_unique and new_items.is_unique:
 
+                # ok to use the global indexer if only 1 block
+                i = indexer if len(self.blocks) == 1 else None
+
                 for block in self.blocks:
-                    blk = block.reindex_items_from(new_items, copy=copy)
+                    blk = block.reindex_items_from(new_items, indexer=i, copy=copy)
                     new_blocks.extend(_valid_blocks(blk))
 
             # non-unique


### PR DESCRIPTION
closes #6484

seems on a full vbench to somewhat speedup some reindexing operations.. but this particular is not vbenched

```
In [13]: pn = pd.Panel(np.random.random((12, 5412, 162)))

In [14]: ix = np.ones(pn.shape[1], dtype=bool)

In [15]: ix[np.random.random(ix.size) > 0.5] = 0

In [16]: %timeit pn.loc[0, ix]  # one field, as fast as dataframe
1000 loops, best of 3: 981 µs per loop

In [17]: %timeit pn.loc[[0, 1], ix]  # two fields, 233x slower
>>> %timeit pn.loc[:, ix]
100 loops, best of 3: 18.6 ms per loop

In [18]: >>> %timeit pn.loc[:, ix]
10 loops, best of 3: 47.5 ms per loop

In [19]: pn_t = pn.swapaxes(0, 1).copy()  # try .loc on the first axis

In [20]: %timeit pn_t.loc[ix]
10 loops, best of 3: 42.8 ms per loop
```
