### PR TITLE
BUG: Bug in multi-axis indexing using .loc on non-unique indices (GH6504)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -190,6 +190,7 @@ Bug Fixes
   rest of pandas (:issue:`5129`).
 - Bug in ``read_html`` tests where redirected invalid URLs would make one test
   fail (:issue:`6445`).
+- Bug in multi-axis indexing using ``.loc`` on non-unique indices (:issue:`6504`)
 
 pandas 0.13.1
 -------------

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -710,6 +710,8 @@ class _NDFrameIndexer(object):
                 return False
             elif com._is_bool_indexer(indexer):
                 return False
+            elif not ax.is_unique:
+                return False
 
         return True
 

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -1599,6 +1599,21 @@ class TestIndexing(tm.TestCase):
         result = df.ix[:,['A','B','C']]
         assert_frame_equal(result, expected)
 
+        # GH 6504, multi-axis indexing
+        df = DataFrame(np.random.randn(9,2), index=[1,1,1,2,2,2,3,3,3], columns=['a', 'b'])
+
+        expected = df.iloc[0:6]
+        result = df.loc[[1, 2]]
+        assert_frame_equal(result, expected)
+
+        expected = df
+        result = df.loc[:,['a', 'b']]
+        assert_frame_equal(result, expected)
+
+        expected = df.iloc[0:6,:]
+        result = df.loc[[1, 2], ['a', 'b']]
+        assert_frame_equal(result, expected)
+
     def test_indexing_mixed_frame_bug(self):
 
         # GH3492


### PR DESCRIPTION
closes #6504
