### PR TITLE
remove semicolon from CREATE TABLE legacy template

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -786,7 +786,7 @@ class PandasSQLTableLegacy(PandasSQLTable):
                                x for x in zip(safe_columns, column_types))
         template = """CREATE TABLE %(name)s (
                       %(columns)s
-                      );"""
+                      )"""
         create_statement = template % {'name': self.name, 'columns': columns}
         return create_statement
 


### PR DESCRIPTION
It's not necessary and causes some DB engines to choke (e.g., Impala)
