### PR TITLE
BUG/API: allow TimeGrouper with other columns in a groupby (GH3794)

### DIFF
--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -754,6 +754,8 @@ that could be potential groupers.
    df.groupby([pd.Grouper(freq='6M',level='Date'),'Buyer']).sum()
 
 
+.. _groupby.nth:
+
 Taking the first rows of each group
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -833,6 +835,9 @@ To see the order in which each row appears within its group, use the
 Examples
 --------
 
+Regrouping by factor
+~~~~~~~~~~~~~~~~~~~~
+
 Regroup columns of a DataFrame according to their sum, and sum the aggregated ones.
 
 .. ipython:: python
@@ -841,6 +846,9 @@ Regroup columns of a DataFrame according to their sum, and sum the aggregated on
    df
    df.groupby(df.sum(), axis=1).sum()
 
+
+Returning a Series to propogate names
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Group DataFrame columns, compute a set of metrics and return a named Series.
 The Series name is used as the name for the column index.  This is especially

--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -707,6 +707,52 @@ can be used as group keys. If so, the order of the levels will be preserved:
 
    data.groupby(factor).mean()
 
+.. _groupby.specify:
+
+Grouping with a Grouper specification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Your may need to specify a bit more data to properly group. You can
+use the ``pd.Grouper`` to provide this local control.
+
+.. ipython:: python
+
+   import datetime as DT
+
+   df = DataFrame({
+          'Branch' : 'A A A A A A A B'.split(),
+          'Buyer': 'Carl Mark Carl Carl Joe Joe Joe Carl'.split(),
+          'Quantity': [1,3,5,1,8,1,9,3],
+          'Date' : [
+                DT.datetime(2013,1,1,13,0),
+                DT.datetime(2013,1,1,13,5),
+                DT.datetime(2013,10,1,20,0),
+                DT.datetime(2013,10,2,10,0),
+                DT.datetime(2013,10,1,20,0),
+                DT.datetime(2013,10,2,10,0),
+                DT.datetime(2013,12,2,12,0),
+                DT.datetime(2013,12,2,14,0),
+                ]})
+
+   df
+
+Groupby a specific column with the desired frequency. This is like resampling.
+
+.. ipython:: python
+
+   df.groupby([pd.Grouper(freq='1M',key='Date'),'Buyer']).sum()
+
+You have an ambiguous specification in that you have a named index and a column
+that could be potential groupers.
+
+.. ipython:: python
+
+   df = df.set_index('Date')
+   df['Date'] = df.index + pd.offsets.MonthEnd(2)
+   df.groupby([pd.Grouper(freq='6M',key='Date'),'Buyer']).sum()
+
+   df.groupby([pd.Grouper(freq='6M',level='Date'),'Buyer']).sum()
+
 
 Taking the first rows of each group
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -753,7 +799,7 @@ To select from a DataFrame or Series the nth item, use the nth method:
 
    g.nth(-1)
 
-If you want to select the nth not-null method, use the dropna kwarg. For a DataFrame this should be either 'any' or 'all' just like you would pass to dropna, for a Series this just needs to be truthy. 
+If you want to select the nth not-null method, use the dropna kwarg. For a DataFrame this should be either 'any' or 'all' just like you would pass to dropna, for a Series this just needs to be truthy.
 
 .. ipython:: python
 
@@ -808,7 +854,7 @@ column index name will be used as the name of the inserted column:
         'b':  [0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1],
         'c':  [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0],
         'd':  [0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1],
-        }) 
+        })
 
    def compute_metrics(x):
        result = {'b_sum': x['b'].sum(), 'c_mean': x['c'].mean()}

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -125,6 +125,8 @@ API Changes
     ``DataFrame.stack`` operations where the name of the column index is used as
     the name of the inserted column containing the pivoted data.
 
+- Allow specification of a more complex groupby, via ``pd.Groupby`` (:issue:`3794`)
+
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -11,6 +11,7 @@ Highlights include:
 
 - MultIndexing Using Slicers
 - Joining a singly-indexed DataFrame with a multi-indexed DataFrame
+- More flexible groupby specifications
 
 API changes
 ~~~~~~~~~~~
@@ -80,7 +81,7 @@ These are out-of-bounds selections
      g[['B']].head(1)
 
    - groupby ``nth`` now filters by default, with optional dropna argument to ignore
-     NaN (to replicate the previous behaviour.)
+     NaN (to replicate the previous behaviour.), See :ref:`the docs <groupby.nth>`.
 
   .. ipython:: python
 
@@ -90,7 +91,8 @@ These are out-of-bounds selections
 
      g.nth(0, dropna='any')  # similar to old behaviour
 
-- Allow specification of a more complex groupby via ``pd.Groupby``, See :ref:`the docs <groupby.specify>`. (:issue:`3794`)
+- Allow specification of a more complex groupby via ``pd.Groupby``, such as grouping
+  by a Time and a string field simultaneously. See :ref:`the docs <groupby.specify>`. (:issue:`3794`)
 
 - Local variable usage has changed in
   :func:`pandas.eval`/:meth:`DataFrame.eval`/:meth:`DataFrame.query`
@@ -123,6 +125,7 @@ These are out-of-bounds selections
   .. ipython:: python
 
      i[[0,1,2]].astype(np.int_)
+
 - ``set_index`` no longer converts MultiIndexes to an Index of tuples. For example,
   the old behavior returned an Index in this case (:issue:`6459`):
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -90,6 +90,8 @@ These are out-of-bounds selections
 
      g.nth(0, dropna='any')  # similar to old behaviour
 
+- Allow specification of a more complex groupby via ``pd.Groupby``, See :ref:`the docs <groupby.specify>`. (:issue:`3794`)
+
 - Local variable usage has changed in
   :func:`pandas.eval`/:meth:`DataFrame.eval`/:meth:`DataFrame.query`
   (:issue:`5987`). For the :class:`~pandas.DataFrame` methods, two things have

--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -6,6 +6,7 @@ import numpy as np
 from pandas.core.algorithms import factorize, match, unique, value_counts
 from pandas.core.common import isnull, notnull
 from pandas.core.categorical import Categorical
+from pandas.core.groupby import Grouper
 from pandas.core.format import set_eng_float_format
 from pandas.core.index import Index, Int64Index, Float64Index, MultiIndex
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -139,6 +139,111 @@ def _last_compat(x, axis=0):
     else:
         return _last(x)
 
+class Grouper(object):
+    """
+    A Grouper allows the user to specify a groupby instruction
+
+    Parameters
+    ----------
+    key : groupby key, default None
+    level : name, int level number, default None
+    freq : string / freqency object, default None
+    sort : boolean, whether to sort the resulting labels, default True
+
+    Returns
+    -------
+    A specification for a groupby instruction
+
+    Examples
+    --------
+    df.groupby(Group(key='A')) : syntatic sugar for df.groupby('A')
+    df.groupby(Group(key='date',freq='60s')) : specify a resample on the column 'date'
+    df.groupby(Group(level='date',freq='60s',axis=1)) :
+       specify a resample on the level 'date' on the columns axis with a frequency of 60s
+
+    """
+
+    def __new__(cls, *args, **kwargs):
+        if kwargs.get('freq') is not None:
+            from pandas.tseries.resample import TimeGrouper
+            cls = TimeGrouper
+        return super(Grouper, cls).__new__(cls)
+
+    def __init__(self, key=None, level=None, freq=None, axis=None, sort=True):
+        self.key = key
+        self.level = level
+        self.freq = freq
+        self.axis = axis
+        self.sort = sort
+        self.grouper = None
+
+    def get_grouper(self, obj):
+
+        """
+        Parameters
+        ----------
+        obj : the subject object
+
+        Returns
+        -------
+        a tuple of binner, grouper, obj (possibly sorted)
+        """
+
+        # default is to not use a binner
+        return None, self.get_grouper_for_ax(obj), obj
+
+    def get_grouper_for_ax(self, obj):
+        """
+        given an object and the specifcations, return a grouper for this particular specification
+
+        Parameters
+        ----------
+        obj : the subject object
+
+        Returns
+        -------
+        grouper : an index mapping, or a BinGrouper like object
+        """
+
+        if self.key is not None and self.level is not None:
+            raise ValueError("The Grouper cannot specify both a key and a level!")
+
+        # the key must be a valid info item
+        if self.key is not None:
+            key = self.key
+            if key not in obj._info_axis:
+                raise KeyError("The grouper name {0} is not found".format(key))
+            ax = Index(obj[key],name=key)
+
+        else:
+            ax = obj._get_axis(self.axis)
+            if self.level is not None:
+                level = self.level
+
+                # if a level is given it must be a mi level or
+                # equivalent to the axis name
+                if isinstance(ax, MultiIndex):
+
+                    if isinstance(level, compat.string_types):
+                        if obj.index.name != level:
+                            raise ValueError('level name %s is not the name of the '
+                                             'index' % level)
+                    elif level > 0:
+                        raise ValueError('level > 0 only valid with MultiIndex')
+                    ax = Index(ax.get_level_values(level), name=level)
+
+                else:
+                    if not (level == 0 or level == ax.name):
+                        raise ValueError("The grouper level {0} is not valid".format(level))
+
+        return self._get_grouper_for_ax(ax)
+
+    def _get_grouper_for_ax(self, ax):
+        return ax
+
+    @property
+    def groups(self):
+        return self.grouper.groups
 
 class GroupBy(PandasObject):
 
@@ -882,10 +987,9 @@ def _is_indexed_like(obj, axes):
     return False
 
 
-class Grouper(object):
-
+class BaseGrouper(object):
     """
-
+    This is an internal Grouper class, which actually holds the generated groups
     """
 
     def __init__(self, axis, groupings, sort=True, group_keys=True):
@@ -1328,19 +1432,7 @@ def generate_bins_generic(values, binner, closed):
 
     return bins
 
-
-class CustomGrouper(object):
-
-    def get_grouper(self, obj):
-        raise NotImplementedError
-
-    # delegates
-    @property
-    def groups(self):
-        return self.grouper.groups
-
-
-class BinGrouper(Grouper):
+class BinGrouper(BaseGrouper):
 
     def __init__(self, bins, binlabels, filter_empty=False):
         self.bins = com._ensure_int64(bins)
@@ -1495,7 +1587,7 @@ class Grouping(object):
       * groups : dict of {group -> label_list}
     """
 
-    def __init__(self, index, grouper=None, obj=None, axis=0, name=None, level=None,
+    def __init__(self, index, grouper=None, obj=None, name=None, level=None,
                  sort=True):
 
         self.name = name
@@ -1514,6 +1606,10 @@ class Grouping(object):
         # pre-computed
         self._was_factor = False
         self._should_compress = True
+
+        # we have a single grouper which may be a myriad of things, some of which are
+        # dependent on the passing in level
+        #
 
         if level is not None:
             if not isinstance(level, int):
@@ -1556,7 +1652,10 @@ class Grouping(object):
         else:
             if isinstance(self.grouper, (list, tuple)):
                 self.grouper = com._asarray_tuplesafe(self.grouper)
+
+            # a passed Categorical
             elif isinstance(self.grouper, Categorical):
+
                 factor = self.grouper
                 self._was_factor = True
 
@@ -1568,27 +1667,10 @@ class Grouping(object):
                 if self.name is None:
                     self.name = factor.name
 
-            # a passed TimeGrouper like
-            elif isinstance(self.grouper, CustomGrouper):
+            # a passed Grouper like
+            elif isinstance(self.grouper, Grouper):
 
-                # get the obj to work on
-                if self.grouper.name is not None:
-                    name = self.grouper.name
-                    if name not in obj._info_axis:
-                        raise KeyError("The grouper name {0} is not found".format(name))
-                    ax = Index(obj[name],name=name)
-                else:
-                    ax = obj._get_axis(axis)
-                    if self.grouper.level is not None:
-                        level = self.grouper.level
-                        if isinstance(ax, MultiIndex):
-                            level = ax._get_level_name(level)
-                            ax = Index(ax.get_level_values(level), name=level)
-                        else:
-                            if not (level == 0 or level == ax.name):
-                                raise ValueError("The grouper level {0} is not valid".format(level))
-
-                self.grouper = self.grouper._get_grouper_for_ax(ax)
+                self.grouper = self.grouper.get_grouper_for_ax(obj)
                 if self.name is None:
                     self.name = self.grouper.name
 
@@ -1674,10 +1756,10 @@ def _get_grouper(obj, key=None, axis=0, level=None, sort=True):
             level = None
             key = group_axis
 
-    if isinstance(key, CustomGrouper):
+    if isinstance(key, Grouper):
         binner, gpr, obj = key.get_grouper(obj)
         return gpr, [], obj
-    elif isinstance(key, Grouper):
+    elif isinstance(key, BaseGrouper):
         return key, [], obj
 
     if not isinstance(key, (tuple, list)):
@@ -1730,13 +1812,14 @@ def _get_grouper(obj, key=None, axis=0, level=None, sort=True):
             errmsg = "Categorical grouper must have len(grouper) == len(data)"
             raise AssertionError(errmsg)
 
-        ping = Grouping(group_axis, gpr, obj=obj, axis=axis, name=name, level=level, sort=sort)
+        ping = Grouping(group_axis, gpr, obj=obj, name=name, level=level, sort=sort)
         groupings.append(ping)
 
     if len(groupings) == 0:
         raise ValueError('No group keys passed!')
 
-    grouper = Grouper(group_axis, groupings, sort=sort)
+    # create the internals grouper
+    grouper = BaseGrouper(group_axis, groupings, sort=sort)
 
     return grouper, exclusions, obj
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2031,7 +2031,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             raise ValueError("cannot reindex series on non-zero axis!")
         return self.reindex(index=labels, **kwargs)
 
-    def take(self, indices, axis=0, convert=True):
+    def take(self, indices, axis=0, convert=True, is_copy=False):
         """
         Analogous to ndarray.take, return Series corresponding to requested
         indices

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -2933,6 +2933,7 @@ class TestGroupBy(tm.TestCase):
                 DT.datetime(2013,12,31,0,0),
                 DT.datetime(2013,12,31,0,0),
                 ]}).set_index(['Date','Buyer'])
+
         result = df.groupby([pd.Grouper(freq='A'),'Buyer']).sum()
         assert_frame_equal(result,expected)
 
@@ -3021,6 +3022,24 @@ class TestGroupBy(tm.TestCase):
 
         # error as we have both a level and a name!
         self.assertRaises(ValueError, lambda : df.groupby([pd.Grouper(freq='1M',key='Date',level='Date'),'Buyer']).sum())
+
+
+        # single groupers
+        expected = DataFrame({ 'Quantity' : [31],
+                               'Date' : [DT.datetime(2013,10,31,0,0)] }).set_index('Date')
+        result = df.groupby(pd.Grouper(freq='1M')).sum()
+        assert_frame_equal(result, expected)
+
+        result = df.groupby([pd.Grouper(freq='1M')]).sum()
+        assert_frame_equal(result, expected)
+
+        expected = DataFrame({ 'Quantity' : [31],
+                               'Date' : [DT.datetime(2013,11,30,0,0)] }).set_index('Date')
+        result = df.groupby(pd.Grouper(freq='1M',key='Date')).sum()
+        assert_frame_equal(result, expected)
+
+        result = df.groupby([pd.Grouper(freq='1M',key='Date')]).sum()
+        assert_frame_equal(result, expected)
 
     def test_cumcount(self):
         df = DataFrame([['a'], ['a'], ['a'], ['b'], ['a']], columns=['A'])

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -2991,19 +2991,36 @@ class TestGroupBy(tm.TestCase):
 
         # passing the name
         df = df.reset_index()
-        result = df.groupby([pd.TimeGrouper('1M',name='Date'),'Buyer']).sum()
+        result = df.groupby([pd.Grouper(freq='1M',key='Date'),'Buyer']).sum()
         assert_frame_equal(result,expected)
 
-        self.assertRaises(KeyError, lambda : df.groupby([pd.TimeGrouper('1M',name='foo'),'Buyer']).sum())
+        self.assertRaises(KeyError, lambda : df.groupby([pd.Grouper(freq='1M',key='foo'),'Buyer']).sum())
 
         # passing the level
         df = df.set_index('Date')
-        result = df.groupby([pd.TimeGrouper('1M',level='Date'),'Buyer']).sum()
+        result = df.groupby([pd.Grouper(freq='1M',level='Date'),'Buyer']).sum()
         assert_frame_equal(result,expected)
-        result = df.groupby([pd.TimeGrouper('1M',level=0),'Buyer']).sum()
+        result = df.groupby([pd.Grouper(freq='1M',level=0),'Buyer']).sum()
         assert_frame_equal(result,expected)
 
-        self.assertRaises(ValueError, lambda : df.groupby([pd.TimeGrouper('1M',level='foo'),'Buyer']).sum())
+        self.assertRaises(ValueError, lambda : df.groupby([pd.Grouper(freq='1M',level='foo'),'Buyer']).sum())
+
+        # multi names
+        df = df.copy()
+        df['Date'] = df.index + pd.offsets.MonthEnd(2)
+        result = df.groupby([pd.Grouper(freq='1M',key='Date'),'Buyer']).sum()
+        expected = DataFrame({
+            'Buyer': 'Carl Joe Mark'.split(),
+            'Quantity': [10,18,3],
+            'Date' : [
+                DT.datetime(2013,11,30,0,0),
+                DT.datetime(2013,11,30,0,0),
+                DT.datetime(2013,11,30,0,0),
+                ]}).set_index(['Date','Buyer'])
+        assert_frame_equal(result,expected)
+
+        # error as we have both a level and a name!
+        self.assertRaises(ValueError, lambda : df.groupby([pd.Grouper(freq='1M',key='Date',level='Date'),'Buyer']).sum())
 
     def test_cumcount(self):
         df = DataFrame([['a'], ['a'], ['a'], ['b'], ['a']], columns=['A'])

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -2903,6 +2903,108 @@ class TestGroupBy(tm.TestCase):
         self.assertTrue(isinstance(groups,dict))
         self.assertTrue(len(groups) == 3)
 
+    def test_timegrouper_with_reg_groups(self):
+
+        # GH 3794
+        # allow combinateion of timegrouper/reg groups
+
+        import datetime as DT
+
+        df = DataFrame({
+            'Branch' : 'A A A A A A A B'.split(),
+            'Buyer': 'Carl Mark Carl Carl Joe Joe Joe Carl'.split(),
+            'Quantity': [1,3,5,1,8,1,9,3],
+            'Date' : [
+                DT.datetime(2013,1,1,13,0),
+                DT.datetime(2013,1,1,13,5),
+                DT.datetime(2013,10,1,20,0),
+                DT.datetime(2013,10,2,10,0),
+                DT.datetime(2013,10,1,20,0),
+                DT.datetime(2013,10,2,10,0),
+                DT.datetime(2013,12,2,12,0),
+                DT.datetime(2013,12,2,14,0),
+                ]}).set_index('Date')
+
+        expected = DataFrame({
+            'Buyer': 'Carl Joe Mark'.split(),
+            'Quantity': [10,18,3],
+            'Date' : [
+                DT.datetime(2013,12,31,0,0),
+                DT.datetime(2013,12,31,0,0),
+                DT.datetime(2013,12,31,0,0),
+                ]}).set_index(['Date','Buyer'])
+        result = df.groupby([pd.TimeGrouper('A'),'Buyer']).sum()
+        assert_frame_equal(result,expected)
+
+        expected = DataFrame({
+            'Buyer': 'Carl Mark Carl Joe'.split(),
+            'Quantity': [1,3,9,18],
+            'Date' : [
+                DT.datetime(2013,1,1,0,0),
+                DT.datetime(2013,1,1,0,0),
+                DT.datetime(2013,7,1,0,0),
+                DT.datetime(2013,7,1,0,0),
+                ]}).set_index(['Date','Buyer'])
+
+        result = df.groupby([pd.TimeGrouper('6MS'),'Buyer']).sum()
+        assert_frame_equal(result,expected)
+
+        df = DataFrame({
+            'Branch' : 'A A A A A A A B'.split(),
+            'Buyer': 'Carl Mark Carl Carl Joe Joe Joe Carl'.split(),
+            'Quantity': [1,3,5,1,8,1,9,3],
+            'Date' : [
+                DT.datetime(2013,10,1,13,0),
+                DT.datetime(2013,10,1,13,5),
+                DT.datetime(2013,10,1,20,0),
+                DT.datetime(2013,10,2,10,0),
+                DT.datetime(2013,10,1,20,0),
+                DT.datetime(2013,10,2,10,0),
+                DT.datetime(2013,10,2,12,0),
+                DT.datetime(2013,10,2,14,0),
+                ]}).set_index('Date')
+
+        expected = DataFrame({
+            'Buyer': 'Carl Joe Mark Carl Joe'.split(),
+            'Quantity': [6,8,3,4,10],
+            'Date' : [
+                DT.datetime(2013,10,1,0,0),
+                DT.datetime(2013,10,1,0,0),
+                DT.datetime(2013,10,1,0,0),
+                DT.datetime(2013,10,2,0,0),
+                DT.datetime(2013,10,2,0,0),
+                ]}).set_index(['Date','Buyer'])
+
+        result = df.groupby([pd.TimeGrouper('1D'),'Buyer']).sum()
+        assert_frame_equal(result,expected)
+
+        result = df.groupby([pd.TimeGrouper('1M'),'Buyer']).sum()
+        expected = DataFrame({
+            'Buyer': 'Carl Joe Mark'.split(),
+            'Quantity': [10,18,3],
+            'Date' : [
+                DT.datetime(2013,10,31,0,0),
+                DT.datetime(2013,10,31,0,0),
+                DT.datetime(2013,10,31,0,0),
+                ]}).set_index(['Date','Buyer'])
+        assert_frame_equal(result,expected)
+
+        # passing the name
+        df = df.reset_index()
+        result = df.groupby([pd.TimeGrouper('1M',name='Date'),'Buyer']).sum()
+        assert_frame_equal(result,expected)
+
+        self.assertRaises(KeyError, lambda : df.groupby([pd.TimeGrouper('1M',name='foo'),'Buyer']).sum())
+
+        # passing the level
+        df = df.set_index('Date')
+        result = df.groupby([pd.TimeGrouper('1M',level='Date'),'Buyer']).sum()
+        assert_frame_equal(result,expected)
+        result = df.groupby([pd.TimeGrouper('1M',level=0),'Buyer']).sum()
+        assert_frame_equal(result,expected)
+
+        self.assertRaises(ValueError, lambda : df.groupby([pd.TimeGrouper('1M',level='foo'),'Buyer']).sum())
+
     def test_cumcount(self):
         df = DataFrame([['a'], ['a'], ['a'], ['b'], ['a']], columns=['A'])
         g = df.groupby('A')

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -2933,7 +2933,7 @@ class TestGroupBy(tm.TestCase):
                 DT.datetime(2013,12,31,0,0),
                 DT.datetime(2013,12,31,0,0),
                 ]}).set_index(['Date','Buyer'])
-        result = df.groupby([pd.TimeGrouper('A'),'Buyer']).sum()
+        result = df.groupby([pd.Grouper(freq='A'),'Buyer']).sum()
         assert_frame_equal(result,expected)
 
         expected = DataFrame({
@@ -2946,7 +2946,7 @@ class TestGroupBy(tm.TestCase):
                 DT.datetime(2013,7,1,0,0),
                 ]}).set_index(['Date','Buyer'])
 
-        result = df.groupby([pd.TimeGrouper('6MS'),'Buyer']).sum()
+        result = df.groupby([pd.Grouper(freq='6MS'),'Buyer']).sum()
         assert_frame_equal(result,expected)
 
         df = DataFrame({
@@ -2975,10 +2975,10 @@ class TestGroupBy(tm.TestCase):
                 DT.datetime(2013,10,2,0,0),
                 ]}).set_index(['Date','Buyer'])
 
-        result = df.groupby([pd.TimeGrouper('1D'),'Buyer']).sum()
+        result = df.groupby([pd.Grouper(freq='1D'),'Buyer']).sum()
         assert_frame_equal(result,expected)
 
-        result = df.groupby([pd.TimeGrouper('1M'),'Buyer']).sum()
+        result = df.groupby([pd.Grouper(freq='1M'),'Buyer']).sum()
         expected = DataFrame({
             'Buyer': 'Carl Joe Mark'.split(),
             'Quantity': [10,18,3],

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 import numpy as np
 
-from pandas.core.groupby import BinGrouper, CustomGrouper
+from pandas.core.groupby import BinGrouper, Grouper
 from pandas.tseries.frequencies import to_offset, is_subperiod, is_superperiod
 from pandas.tseries.index import DatetimeIndex, date_range
 from pandas.tseries.offsets import DateOffset, Tick, _delta_to_nanoseconds
@@ -18,7 +18,7 @@ import pandas.lib as lib
 _DEFAULT_METHOD = 'mean'
 
 
-class TimeGrouper(CustomGrouper):
+class TimeGrouper(Grouper):
     """
     Custom groupby class for time-interval grouping
 
@@ -30,8 +30,6 @@ class TimeGrouper(CustomGrouper):
     nperiods : optional, integer
     convention : {'start', 'end', 'e', 's'}
         If axis is PeriodIndex
-    name : referring name, default None
-    level : referering level, default None
 
     Notes
     -----
@@ -41,11 +39,11 @@ class TimeGrouper(CustomGrouper):
     def __init__(self, freq='Min', closed=None, label=None, how='mean',
                  nperiods=None, axis=0,
                  fill_method=None, limit=None, loffset=None, kind=None,
-                 convention=None, base=0, name=None, level=None):
-        self.freq = to_offset(freq)
+                 convention=None, base=0, **kwargs):
+        freq = to_offset(freq)
 
         end_types = set(['M', 'A', 'Q', 'BM', 'BA', 'BQ', 'W'])
-        rule = self.freq.rule_code
+        rule = freq.rule_code
         if (rule in end_types or
                 ('-' in rule and rule[:rule.find('-')] in end_types)):
             if closed is None:
@@ -66,14 +64,13 @@ class TimeGrouper(CustomGrouper):
         self.convention = convention or 'E'
         self.convention = self.convention.lower()
 
-        self.axis = axis
         self.loffset = loffset
         self.how = how
         self.fill_method = fill_method
         self.limit = limit
         self.base = base
-        self.name = name
-        self.level = level
+
+        super(TimeGrouper, self).__init__(freq=freq, axis=axis, **kwargs)
 
     def resample(self, obj):
         ax = obj._get_axis(self.axis)

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -1137,7 +1137,6 @@ class TestTimeGrouper(tm.TestCase):
         _, grouper, _ = tg.get_grouper(df)
 
         # Errors
-
         grouped = df.groupby(grouper, group_keys=False)
         f = lambda df: df['close'] / df['open']
 


### PR DESCRIPTION
closes #3794

```
In [3]: df
Out[3]: 
  Branch Buyer                Date  Quantity
0      A  Carl 2013-01-01 13:00:00         1
1      A  Mark 2013-01-01 13:05:00         3
2      A  Carl 2013-10-01 20:00:00         5
3      A  Carl 2013-10-02 10:00:00         1
4      A   Joe 2013-10-01 20:00:00         8
5      A   Joe 2013-10-02 10:00:00         1
6      A   Joe 2013-12-02 12:00:00         9
7      B  Carl 2013-12-02 14:00:00         3

[8 rows x 4 columns]

In [4]:    df.groupby([pd.Grouper(freq='1M',key='Date'),'Buyer']).sum()
Out[4]: 
                  Quantity
Date       Buyer          
2013-01-31 Carl          1
           Mark          3
2013-10-31 Carl          6
           Joe           9
2013-12-31 Carl          3
           Joe           9

[6 rows x 1 columns]

In [5]:    df = df.set_index('Date')

In [6]:    df['Date'] = df.index + pd.offsets.MonthEnd(2)

In [9]:    df.groupby([pd.Grouper(freq='6M',key='Date'),'Buyer']).sum()
Out[9]: 
                  Quantity
Date       Buyer          
2013-02-28 Carl          1
           Mark          3
2014-02-28 Carl          9
           Joe          18

[4 rows x 1 columns]

In [10]:    df.groupby([pd.Grouper(freq='6M',level='Date'),'Buyer']).sum()
Out[10]: 
                  Quantity
Date       Buyer          
2013-01-31 Carl          1
           Mark          3
2014-01-31 Carl          9
           Joe          18

[4 rows x 1 columns]

```
