### PR TITLE
DOC: Add common error message to byte-ordering gotcha.

### DIFF
--- a/doc/source/gotchas.rst
+++ b/doc/source/gotchas.rst
@@ -533,7 +533,15 @@ parse HTML tables in the top-level pandas io function ``read_html``.
 Byte-Ordering Issues
 --------------------
 Occasionally you may have to deal with data that were created on a machine with
-a different byte order than the one on which you are running Python. To deal
+a different byte order than the one on which you are running Python. A common symptom of this issue is an error like
+
+.. code-block:: python
+
+    Traceback
+        ...
+    ValueError: Big-endian buffer not supported on little-endian compiler
+
+To deal
 with this issue you should convert the underlying NumPy array to the native
 system byte order *before* passing it to Series/DataFrame/Panel constructors
 using something similar to the following:


### PR DESCRIPTION
A friend of mine got tripped up by [this gotcha](http://pandas.pydata.org/pandas-docs/stable/gotchas.html#byte-ordering-issues). We document it well, but Googling the error message doesn't turn up our documentation, so it took him a lot of digging to get there.

This commit adds an example error message that byte-ordering issues raise, in hopes of making this easier to Google.
