### PR TITLE
BUG: fix DataFarame column slice indexer

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -194,6 +194,7 @@ Bug Fixes
 - Bug in ``read_html`` tests where redirected invalid URLs would make one test
   fail (:issue:`6445`).
 - Bug in multi-axis indexing using ``.loc`` on non-unique indices (:issue:`6504`)
+- Bug that caused _ref_locs corruption when slice indexing across columns axis of a DataFrame (:issue:`6525`)
 
 pandas 0.13.1
 -------------

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -133,6 +133,12 @@ class Block(PandasObject):
         tindexer[indexer] = False
         tindexer = tindexer.astype(int).cumsum()[indexer]
         ref_locs = ref_locs[indexer]
+
+        # Make sure the result is a copy, or otherwise self._ref_locs will be
+        # updated.
+        if ref_locs.base is not None:
+            ref_locs = ref_locs.copy()
+
         ref_locs -= tindexer
         return ref_locs
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -12267,6 +12267,19 @@ starting,ending,measure
                                                             ('b', 'bool:dense'),
                                                             ('c', 'float64:dense')])))
 
+    def test_dtypes_are_correct_after_column_slice(self):
+        # GH6525
+        df = pd.DataFrame(index=range(5), columns=list("abc"), dtype=np.float_)
+        odict = OrderedDict
+        assert_series_equal(df.dtypes,
+                            pd.Series(odict([('a', np.float_), ('b', np.float_),
+                                             ('c', np.float_),])))
+        assert_series_equal(df.iloc[:,2:].dtypes,
+                            pd.Series(odict([('c', np.float_)])))
+        assert_series_equal(df.dtypes,
+                            pd.Series(odict([('a', np.float_), ('b', np.float_),
+                                             ('c', np.float_),])))
+
 
 def skip_if_no_ne(engine='numexpr'):
     if engine == 'numexpr':


### PR DESCRIPTION
The code pulled in in #6123 didn't account for slice indexers which return views, not copies in `take_ref_locs` function. As a result, slice across columns corrupted `_ref_locs` of the parent block (provided `_ref_locs` existed). This PR should fix that.

``` python
In [1]: df = pd.DataFrame(np.random.rand(5,3))

In [2]: df.dtypes
Out[2]: 
0    float64
1    float64
2    float64
dtype: object

In [3]: df.iloc[:,2:]
Out[3]: 
          2
0  0.524160
1  0.072608
2  0.289047
3  0.494401
4  0.235275

[5 rows x 1 columns]

In [4]: _3.dtypes
Out[4]: 
2    float64
dtype: object

In [5]: df.dtypes
Out[5]: 
0    float64
1    float64
2       None
dtype: object

In [6]: pd.__version__
Out[6]: '0.13.1-346-g30d3cba'
```
