### PR TITLE
BUG: Regression from 0.13 in the treatment of numpy datetime64 non-ns dtypes in Series creation (GH6429)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -195,6 +195,7 @@ Bug Fixes
   fail (:issue:`6445`).
 - Bug in multi-axis indexing using ``.loc`` on non-unique indices (:issue:`6504`)
 - Bug that caused _ref_locs corruption when slice indexing across columns axis of a DataFrame (:issue:`6525`)
+- Regression from 0.13 in the treatmenet of numpy ``datetime64`` non-ns dtypes in Series creation (:issue:`6529`)
 
 pandas 0.13.1
 -------------

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -124,7 +124,7 @@ def isnull(obj):
 
     See also
     --------
-    pandas.notnull: boolean inverse of pandas.isnull    
+    pandas.notnull: boolean inverse of pandas.isnull
     """
     return _isnull(obj)
 
@@ -272,7 +272,7 @@ def notnull(obj):
     isnulled : array-like of bool or bool
         Array or bool indicating whether an object is *not* null or if an array
         is given which of the element is *not* null.
-    
+
     See also
     --------
     pandas.isnull : boolean inverse of pandas.notnull
@@ -1727,10 +1727,7 @@ def _possibly_cast_to_datetime(value, dtype, coerce=False):
             dtype = value.dtype
 
             if dtype.kind == 'M' and dtype != _NS_DTYPE:
-                try:
-                    value = tslib.array_to_datetime(value)
-                except:
-                    raise
+                value = value.astype(_NS_DTYPE)
 
             elif dtype.kind == 'm' and dtype != _TD_DTYPE:
                 from pandas.tseries.timedeltas import \


### PR DESCRIPTION
closes #6529
