### PR TITLE
BUG: fix fancy indexing with empty list

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -207,6 +207,7 @@ Bug Fixes
 - Bug in ``pd.read_stata`` which would use the wrong data types and missing values (:issue:`6327`)
 - Bug in ``DataFrame.to_stata`` that lead to data loss in certain cases, and could exported using the
   wrong data types and missing values (:issue:`6335`)
+- Bug in indexing: empty list lookup caused ``IndexError`` exceptions (:issue:`6536`, :issue:`6551`)
 
 
 pandas 0.13.1

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1555,6 +1555,10 @@ def _maybe_convert_indices(indices, n):
     """
     if isinstance(indices, list):
         indices = np.array(indices)
+        if len(indices) == 0:
+            # If list is empty, np.array will return float and cause indexing
+            # errors.
+            return np.empty(0, dtype=np.int_)
 
     mask = indices < 0
     if mask.any():

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -3175,6 +3175,26 @@ class TestIndexing(tm.TestCase):
         df = pd.DataFrame(randn(5, 2), index=["row%s" % i for i in range(5)], columns=["col%s" % i for i in range(2)])
         self.assertRaises(ValueError, df.ix.__setitem__, (0 , 2), 100)
 
+    def test_iloc_empty_list_indexer_is_ok(self):
+        from pandas.util.testing import makeCustomDataframe as mkdf
+        df = mkdf(5, 2)
+        assert_frame_equal(df.iloc[:,[]], df.iloc[:, :0])  # vertical empty
+        assert_frame_equal(df.iloc[[],:], df.iloc[:0, :])  # horizontal empty
+
+    # FIXME: fix loc & xs
+    def test_loc_empty_list_indexer_is_ok(self):
+        raise nose.SkipTest('loc discards columns names')
+        from pandas.util.testing import makeCustomDataframe as mkdf
+        df = mkdf(5, 2)
+        assert_frame_equal(df.loc[:,[]], df.iloc[:, :0])  # vertical empty
+        assert_frame_equal(df.loc[[],:], df.iloc[:0, :])  # horizontal empty
+
+    def test_ix_empty_list_indexer_is_ok(self):
+        raise nose.SkipTest('ix discards columns names')
+        from pandas.util.testing import makeCustomDataframe as mkdf
+        df = mkdf(5, 2)
+        assert_frame_equal(df.ix[:,[]], df.iloc[:, :0])  # vertical empty
+        assert_frame_equal(df.ix[[],:], df.iloc[:0, :])  # horizontal empty
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
This should fix #6536.

There's a side issue though with loc/ix indexers that somehow discard column names for empty indexers.
