### PR TITLE
BUG: preserve frequency across Timestamp addition/subtraction (#4547)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -218,6 +218,7 @@ Bug Fixes
 - Bug in ``DataFrame.to_stata`` that lead to data loss in certain cases, and could exported using the
   wrong data types and missing values (:issue:`6335`)
 - Inconsistent types in Timestamp addition/subtraction (:issue:`6543`)
+- Bug in preserving frequency across Timestamp addition/subtraction (:issue:`4547`)
 - Bug in indexing: empty list lookup caused ``IndexError`` exceptions (:issue:`6536`, :issue:`6551`)
 
 

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -330,6 +330,20 @@ class TestTimestampOps(tm.TestCase):
             self.assertEqual(type(timestamp_instance + timedelta64_instance), Timestamp)
             self.assertEqual(type(timestamp_instance - timedelta64_instance), Timestamp)
 
+    def test_addition_subtraction_preserve_frequency(self):
+        timestamp_instance = date_range('2014-03-05', periods=1, freq='D')[0]
+        timedelta_instance = datetime.timedelta(days=1)
+        original_freq = timestamp_instance.freq
+        self.assertEqual((timestamp_instance + 1).freq, original_freq)
+        self.assertEqual((timestamp_instance - 1).freq, original_freq)
+        self.assertEqual((timestamp_instance + timedelta_instance).freq, original_freq)
+        self.assertEqual((timestamp_instance - timedelta_instance).freq, original_freq)
+
+        if not _np_version_under1p7:
+            timedelta64_instance = np.timedelta64(1, 'D')
+            self.assertEqual((timestamp_instance + timedelta64_instance).freq, original_freq)
+            self.assertEqual((timestamp_instance - timedelta64_instance).freq, original_freq)
+
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
                    exit=False)

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -681,17 +681,17 @@ cdef class _Timestamp(datetime):
 
         if is_timedelta64_object(other):
             other_int = other.astype('timedelta64[ns]').astype(int)
-            return Timestamp(self.value + other_int, tz=self.tzinfo)
+            return Timestamp(self.value + other_int, tz=self.tzinfo, offset=self.offset)
 
         if is_integer_object(other):
             if self.offset is None:
                 raise ValueError("Cannot add integral value to Timestamp "
                                  "without offset.")
-            return Timestamp((self.offset * other).apply(self))
+            return Timestamp((self.offset * other).apply(self), offset=self.offset)
 
         if isinstance(other, timedelta) or hasattr(other, 'delta'):
             nanos = _delta_to_nanoseconds(other)
-            return Timestamp(self.value + nanos, tz=self.tzinfo)
+            return Timestamp(self.value + nanos, tz=self.tzinfo, offset=self.offset)
 
         result = datetime.__add__(self, other)
         if isinstance(result, datetime):


### PR DESCRIPTION
closes #4547

My second PR, on basically the same code.

Assuming people agree with my comments on #4547 (that users adding timedeltas that don't match frequencies better know what they are doing), then this would be my submission.

I'm also assuming that something is up with Travis and it is not anything I have done - nosetests passes fine for me though Travis still dies more or less at startup, while it didn't on older code. That problem is true of builds not including any code I have added, e.g. https://travis-ci.org/pydata/pandas/jobs/20167915 . Maybe something in PR #6068, or does this kind of thing happen from time to time?
