### PR TITLE
ENH: including offset/freq in Timestamp repr (#4553)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -150,6 +150,7 @@ Improvements to existing features
   (e.g. MonthEnd,BusinessMonthEnd), (:issue:`6479`)
 - perf improvements in single-dtyped indexing (:issue:`6484`)
 - ``StataWriter`` and ``DataFrame.to_stata`` accept time stamp and data labels (:issue:`6545`)
+- offset/freq info now in Timestamp __repr__ (:issue:`4553`)
 
 .. _release.bug_fixes-0.14.0:
 

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -13,6 +13,41 @@ from pandas import _np_version_under1p7
 import pandas.util.testing as tm
 
 class TestTimestamp(tm.TestCase):
+    def test_repr(self):
+        date = '2014-03-07'
+        tz = 'US/Eastern'
+        freq = 'M'
+
+        date_only = Timestamp(date)
+        self.assertIn(date, repr(date_only))
+        self.assertNotIn(tz, repr(date_only))
+        self.assertNotIn(freq, repr(date_only))
+        self.assertEqual(date_only, eval(repr(date_only)))
+
+        date_tz = Timestamp(date, tz=tz)
+        self.assertIn(date, repr(date_tz))
+        self.assertIn(tz, repr(date_tz))
+        self.assertNotIn(freq, repr(date_tz))
+        self.assertEqual(date_tz, eval(repr(date_tz)))
+
+        date_freq = Timestamp(date, offset=freq)
+        self.assertIn(date, repr(date_freq))
+        self.assertNotIn(tz, repr(date_freq))
+        self.assertIn(freq, repr(date_freq))
+        self.assertEqual(date_freq, eval(repr(date_freq)))
+
+        date_tz_freq = Timestamp(date, tz=tz, offset=freq)
+        self.assertIn(date, repr(date_tz_freq))
+        self.assertIn(tz, repr(date_tz_freq))
+        self.assertIn(freq, repr(date_tz_freq))
+        self.assertEqual(date_tz_freq, eval(repr(date_tz_freq)))
+
+        # this can cause the tz field to be populated, but it's redundant to information in the datestring
+        date_with_utc_offset = Timestamp('2014-03-13 00:00:00-0400', tz=None)
+        self.assertIn('2014-03-13 00:00:00-0400', repr(date_with_utc_offset))
+        self.assertNotIn('tzoffset', repr(date_with_utc_offset))
+        self.assertEqual(date_with_utc_offset, eval(repr(date_with_utc_offset)))
+
     def test_bounds_with_different_units(self):
         out_of_bounds_dates = (
             '1677-09-21',


### PR DESCRIPTION
fixes #4553 

Hopefully the `test_repr()` implementation I included was sufficient. I see some `test_repr()` instances in the code that are more minimal - literally just making sure that repr(obj) doesn't blow up. And some which are pretty detailed, which makes me worry they might be a bit fragile. I went more middle-of-the-road.

``` python
In [1]: from pandas import Timestamp

In [2]: date = '2014-03-07'

In [3]: tz = 'US/Eastern'

In [4]: freq = 'M'

In [5]: repr(Timestamp(date))  # date_only_repr
Out[5]: "Timestamp('2014-03-07 00:00:00')"

In [6]: repr(Timestamp(date, tz=tz))  # date_tz_repr
Out[6]: "Timestamp('2014-03-07 00:00:00-0500', tz='US/Eastern')"

In [7]: repr(Timestamp(date, offset=freq))  # date_freq_repr
Out[7]: "Timestamp('2014-03-07 00:00:00', offset='M')"

In [8]: repr(Timestamp(date, tz=tz, offset=freq))  # date_tz_freq_repr
Out[8]: "Timestamp('2014-03-07 00:00:00-0500', tz='US/Eastern', offset='M')"

In [9]: repr(Timestamp('2014-03-13 00:00:00-0400', tz=None))  # date_with_utc_offset_repr
Out[9]: "Timestamp('2014-03-13 00:00:00-0400')"
```
