### PR TITLE
CLN: Change assert_([not] isinstance(a,b)) to specialized forms

### DIFF
--- a/pandas/io/tests/test_packers.py
+++ b/pandas/io/tests/test_packers.py
@@ -359,7 +359,7 @@ class TestNDFrame(TestPackers):
         l = [self.frame['float'], self.frame['float']
              .A, self.frame['float'].B, None]
         l_rec = self.encode_decode(l)
-        self.assert_(isinstance(l_rec, tuple))
+        self.assertIsInstance(l_rec, tuple)
         check_arbitrary(l, l_rec)
 
     def test_iterator(self):

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -415,7 +415,7 @@ KORD,19990127, 22:00:00, 21:56:00, -0.5900, 1.7100, 5.1000, 0.0000, 290.0000
 KORD,19990127, 23:00:00, 22:56:00, -0.5900, 1.7100, 4.6000, 0.0000, 280.0000"""
 
         df = self.read_csv(StringIO(data), parse_dates={'nominal': [1, 2]})
-        self.assert_(not isinstance(df.nominal[0], compat.string_types))
+        self.assertNotIsInstance(df.nominal[0], compat.string_types)
 
     ts_data = """\
 ID,date,nominalTime,actualTime,A,B,C,D,E
@@ -1006,8 +1006,7 @@ baz,7,8,9
                               parse_dates=True)
         self.assert_numpy_array_equal(df.columns, ['A', 'B', 'C', 'D'])
         self.assertEqual(df.index.name, 'index')
-        self.assert_(isinstance(df.index[0], (datetime, np.datetime64,
-                                              Timestamp)))
+        self.assertIsInstance(df.index[0], (datetime, np.datetime64, Timestamp))
         self.assertEqual(df.values.dtype, np.float64)
         tm.assert_frame_equal(df, df2)
 
@@ -1016,8 +1015,7 @@ baz,7,8,9
         df2 = self.read_table(self.csv2, sep=',', index_col=0,
                               parse_dates=True)
         self.assert_numpy_array_equal(df.columns, ['A', 'B', 'C', 'D', 'E'])
-        self.assert_(isinstance(df.index[0], (datetime, np.datetime64,
-                                              Timestamp)))
+        self.assertIsInstance(df.index[0], (datetime, np.datetime64, Timestamp))
         self.assertEqual(df.ix[:, ['A', 'B', 'C', 'D']].values.dtype, np.float64)
         tm.assert_frame_equal(df, df2)
 
@@ -1441,13 +1439,13 @@ bar,two,12,13,14,15
 20090103,three,c,4,5
 """
         df = self.read_csv(StringIO(data), index_col=[0, 1], parse_dates=True)
-        self.assert_(isinstance(df.index.levels[0][0],
-                     (datetime, np.datetime64, Timestamp)))
+        self.assertIsInstance(df.index.levels[0][0],
+                              (datetime, np.datetime64, Timestamp))
 
         # specify columns out of order!
         df2 = self.read_csv(StringIO(data), index_col=[1, 0], parse_dates=True)
-        self.assert_(isinstance(df2.index.levels[1][0],
-                     (datetime, np.datetime64, Timestamp)))
+        self.assertIsInstance(df2.index.levels[1][0],
+                              (datetime, np.datetime64, Timestamp))
 
     def test_skip_footer(self):
         data = """A,B,C

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -3554,7 +3554,7 @@ class TestHDFStore(tm.TestCase):
             # valid
             result = store.select_column('df', 'index')
             tm.assert_almost_equal(result.values, Series(df.index).values)
-            self.assert_(isinstance(result,Series))
+            self.assertIsInstance(result,Series)
 
             # not a data indexable column
             self.assertRaises(
@@ -3622,7 +3622,7 @@ class TestHDFStore(tm.TestCase):
             result = store.select('df', where=c)
             expected = df.ix[3:4, :]
             tm.assert_frame_equal(result, expected)
-            self.assert_(isinstance(c, Index))
+            self.assertIsInstance(c, Index)
 
             # multiple tables
             _maybe_remove(store, 'df1')

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -277,11 +277,11 @@ class TestStata(tm.TestCase):
         if compat.PY3:
             expected = raw.kreis1849[0]
             self.assertEqual(result, expected)
-            self.assert_(isinstance(result, compat.string_types))
+            self.assertIsInstance(result, compat.string_types)
         else:
             expected = raw.kreis1849.str.decode("latin-1")[0]
             self.assertEqual(result, expected)
-            self.assert_(isinstance(result, unicode))
+            self.assertIsInstance(result, unicode)
 
     def test_read_write_dta11(self):
         # skip_if_not_little_endian()

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -405,7 +405,7 @@ class TestSparseSeries(tm.TestCase,
             def _compare(idx):
                 dense_result = dense.take(idx).values
                 sparse_result = sp.take(idx)
-                self.assert_(isinstance(sparse_result, SparseSeries))
+                self.assertIsInstance(sparse_result, SparseSeries)
                 assert_almost_equal(dense_result, sparse_result.values.values)
 
             _compare([1., 2., 3., 4., 5., 0.])
@@ -652,7 +652,7 @@ class TestSparseSeries(tm.TestCase,
 
         result = self.bseries.dropna()
         expected = self.bseries.to_dense().dropna()
-        self.assert_(not isinstance(result, SparseSeries))
+        self.assertNotIsInstance(result, SparseSeries)
         tm.assert_series_equal(result, expected)
 
     def test_homogenize(self):

--- a/pandas/tests/test_compat.py
+++ b/pandas/tests/test_compat.py
@@ -11,7 +11,7 @@ import unittest
 import nose
 import pandas.util.testing as tm
 
-class TestBuiltinIterators(unittest.TestCase):
+class TestBuiltinIterators(tm.TestCase):
     def check_result(self, actual, expected, lengths):
         for (iter_res, list_res), exp, length in zip(actual, expected, lengths):
             self.assertNotIsInstance(iter_res, list)

--- a/pandas/tests/test_compat.py
+++ b/pandas/tests/test_compat.py
@@ -14,7 +14,7 @@ import pandas.util.testing as tm
 class TestBuiltinIterators(unittest.TestCase):
     def check_result(self, actual, expected, lengths):
         for (iter_res, list_res), exp, length in zip(actual, expected, lengths):
-            self.assert_(not isinstance(iter_res, list))
+            self.assertNotIsInstance(iter_res, list)
             tm.assert_isinstance(list_res, list)
             iter_res = list(iter_res)
             self.assertEqual(len(list_res), length)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -10427,11 +10427,11 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             df = DataFrame({'b': date_range('1/1/2001', periods=2)})
             _f = getattr(df, name)
             result = _f()
-            self.assert_(isinstance(result, Series))
+            self.assertIsInstance(result, Series)
 
             df['a'] = lrange(len(df))
             result = getattr(df, name)()
-            self.assert_(isinstance(result, Series))
+            self.assertIsInstance(result, Series)
             self.assert_(len(result))
 
         if has_skipna:

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -469,13 +469,13 @@ class TestDataFramePlots(tm.TestCase):
         df = tm.makeTimeDataFrame()
         ax = df.plot(x_compat=True)
         lines = ax.get_lines()
-        self.assert_(not isinstance(lines[0].get_xdata(), PeriodIndex))
+        self.assertNotIsInstance(lines[0].get_xdata(), PeriodIndex)
 
         tm.close()
         pd.plot_params['xaxis.compat'] = True
         ax = df.plot()
         lines = ax.get_lines()
-        self.assert_(not isinstance(lines[0].get_xdata(), PeriodIndex))
+        self.assertNotIsInstance(lines[0].get_xdata(), PeriodIndex)
 
         tm.close()
         pd.plot_params['x_compat'] = False
@@ -488,7 +488,7 @@ class TestDataFramePlots(tm.TestCase):
         with pd.plot_params.use('x_compat', True):
             ax = df.plot()
             lines = ax.get_lines()
-            self.assert_(not isinstance(lines[0].get_xdata(), PeriodIndex))
+            self.assertNotIsInstance(lines[0].get_xdata(), PeriodIndex)
 
         tm.close()
         ax = df.plot()

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -295,7 +295,7 @@ class TestIndex(tm.TestCase):
             index_result = op(index, element)
 
             tm.assert_isinstance(index_result, np.ndarray)
-            self.assert_(not isinstance(index_result, Index))
+            self.assertNotIsInstance(index_result, Index)
             self.assert_numpy_array_equal(arr_result, index_result)
 
         _check(operator.eq)
@@ -762,7 +762,7 @@ class TestIndex(tm.TestCase):
 
         self.assert_(res.all())
         self.assertEqual(res.dtype, 'bool')
-        self.assert_(not isinstance(res, Index))
+        self.assertNotIsInstance(res, Index)
 
     def test_get_level_values(self):
         result = self.strIndex.get_level_values(0)
@@ -808,12 +808,13 @@ class TestFloat64Index(tm.TestCase):
             tm.assert_index_equal(eval(repr(ind)), ind)
 
     def check_is_index(self, i):
-        self.assert_(isinstance(i, Index) and not isinstance(i, Float64Index))
+        self.assertIsInstance(i, Index)
+        self.assertNotIsInstance(i, Float64Index)
 
     def check_coerce(self, a, b, is_float_index=True):
         self.assert_(a.equals(b))
         if is_float_index:
-            self.assert_(isinstance(b, Float64Index))
+            self.assertIsInstance(b, Float64Index)
         else:
             self.check_is_index(b)
 
@@ -821,22 +822,22 @@ class TestFloat64Index(tm.TestCase):
 
         # explicit construction
         index = Float64Index([1,2,3,4,5])
-        self.assert_(isinstance(index, Float64Index))
+        self.assertIsInstance(index, Float64Index)
         self.assert_((index.values == np.array([1,2,3,4,5],dtype='float64')).all())
         index = Float64Index(np.array([1,2,3,4,5]))
-        self.assert_(isinstance(index, Float64Index))
+        self.assertIsInstance(index, Float64Index)
         index = Float64Index([1.,2,3,4,5])
-        self.assert_(isinstance(index, Float64Index))
+        self.assertIsInstance(index, Float64Index)
         index = Float64Index(np.array([1.,2,3,4,5]))
-        self.assert_(isinstance(index, Float64Index))
+        self.assertIsInstance(index, Float64Index)
         self.assertEqual(index.dtype, object)
 
         index = Float64Index(np.array([1.,2,3,4,5]),dtype=np.float32)
-        self.assert_(isinstance(index, Float64Index))
+        self.assertIsInstance(index, Float64Index)
         self.assertEqual(index.dtype, object)
 
         index = Float64Index(np.array([1,2,3,4,5]),dtype=np.float32)
-        self.assert_(isinstance(index, Float64Index))
+        self.assertIsInstance(index, Float64Index)
         self.assertEqual(index.dtype, object)
 
         # nan handling
@@ -1548,7 +1549,7 @@ class TestMultiIndex(tm.TestCase):
                                   labels=[[0, 1, 2, 3]],
                                   names=['first'])
         tm.assert_isinstance(single_level, Index)
-        self.assert_(not isinstance(single_level, MultiIndex))
+        self.assertNotIsInstance(single_level, MultiIndex)
         self.assertEqual(single_level.name, 'first')
 
         single_level = MultiIndex(levels=[['foo', 'bar', 'baz', 'qux']],

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -378,7 +378,7 @@ class TestBlockManager(tm.TestCase):
     def test_sparse_mixed(self):
         mgr = create_blockmanager([get_sparse_ex1(),get_sparse_ex2(),get_float_ex()])
         self.assertEqual(len(mgr.blocks), 3)
-        self.assert_(isinstance(mgr,BlockManager))
+        self.assertIsInstance(mgr, BlockManager)
 
         # what to test here?
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -75,7 +75,7 @@ class TestMultiLevel(tm.TestCase):
                           index=[np.array(['a', 'a', 'b', 'b']),
                                  np.array(['x', 'y', 'x', 'y'])])
         tm.assert_isinstance(multi.index, MultiIndex)
-        self.assert_(not isinstance(multi.columns, MultiIndex))
+        self.assertNotIsInstance(multi.columns, MultiIndex)
 
         multi = DataFrame(np.random.randn(4, 4),
                           columns=[['a', 'a', 'b', 'b'],

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -343,7 +343,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # Pass in scalar is disabled
         scalar = Series(0.5)
-        self.assert_(not isinstance(scalar, float))
+        self.assertNotIsInstance(scalar, float)
 
         # coercion
         self.assertEqual(float(Series([1.])), 1.0)
@@ -1175,10 +1175,10 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
     def test_reshape_2d_return_array(self):
         x = Series(np.random.random(201), name='x')
         result = x.reshape((-1, 1))
-        self.assert_(not isinstance(result, Series))
+        self.assertNotIsInstance(result, Series)
 
         result2 = np.reshape(x, (-1, 1))
-        self.assert_(not isinstance(result, Series))
+        self.assertNotIsInstance(result, Series)
 
         result = x[:, None]
         expected = x.reshape((-1, 1))
@@ -2091,7 +2091,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
     def test_prod_numpy16_bug(self):
         s = Series([1., 1., 1.], index=lrange(3))
         result = s.prod()
-        self.assert_(not isinstance(result, Series))
+        self.assertNotIsInstance(result, Series)
 
     def test_quantile(self):
         from pandas.compat.scipy import scoreatpercentile
@@ -5722,7 +5722,7 @@ class TestSeriesNonUnique(tm.TestCase):
         idx = tm.makeDateIndex(10000)
         ser = Series(np.random.randn(len(idx)), idx.astype(object))
         self.assertTrue(ser.is_time_series)
-        self.assert_(isinstance(ser.index, DatetimeIndex))
+        self.assertIsInstance(ser.index, DatetimeIndex)
 
     def test_replace(self):
         N = 100

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -107,7 +107,7 @@ class TestBase(tm.TestCase):
             offset = self._offset(10000)
 
             result = Timestamp('20080101') + offset
-            self.assert_(isinstance(result, datetime))
+            self.assertIsInstance(result, datetime)
         except (OutOfBoundsDatetime):
             raise
         except (ValueError, KeyError):

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -2042,7 +2042,7 @@ class TestDatetimeIndex(tm.TestCase):
         result = idx.insert(1, 'inserted')
         expected = Index([datetime(2000, 1, 4), 'inserted', datetime(2000, 1, 1),
                           datetime(2000, 1, 2)])
-        self.assert_(not isinstance(result, DatetimeIndex))
+        self.assertNotIsInstance(result, DatetimeIndex)
         tm.assert_index_equal(result, expected)
 
         idx = date_range('1/1/2000', periods=3, freq='M')
@@ -3321,7 +3321,7 @@ class TestDateTimeIndexToJulianDate(tm.TestCase):
         r2 = date_range(start=Timestamp('1710-10-01'),
                         periods=5,
                         freq='D').to_julian_date()
-        self.assert_(isinstance(r2, Float64Index))
+        self.assertIsInstance(r2, Float64Index)
         tm.assert_index_equal(r1, r2)
 
     def test_2000(self):
@@ -3333,7 +3333,7 @@ class TestDateTimeIndexToJulianDate(tm.TestCase):
         r2 = date_range(start=Timestamp('2000-02-27'),
                         periods=5,
                         freq='D').to_julian_date()
-        self.assert_(isinstance(r2, Float64Index))
+        self.assertIsInstance(r2, Float64Index)
         tm.assert_index_equal(r1, r2)
 
     def test_hour(self):
@@ -3345,7 +3345,7 @@ class TestDateTimeIndexToJulianDate(tm.TestCase):
         r2 = date_range(start=Timestamp('2000-02-27'),
                         periods=5,
                         freq='H').to_julian_date()
-        self.assert_(isinstance(r2, Float64Index))
+        self.assertIsInstance(r2, Float64Index)
         tm.assert_index_equal(r1, r2)
 
     def test_minute(self):
@@ -3357,7 +3357,7 @@ class TestDateTimeIndexToJulianDate(tm.TestCase):
         r2 = date_range(start=Timestamp('2000-02-27'),
                         periods=5,
                         freq='T').to_julian_date()
-        self.assert_(isinstance(r2, Float64Index))
+        self.assertIsInstance(r2, Float64Index)
         tm.assert_index_equal(r1, r2)
 
     def test_second(self):
@@ -3369,7 +3369,7 @@ class TestDateTimeIndexToJulianDate(tm.TestCase):
         r2 = date_range(start=Timestamp('2000-02-27'),
                         periods=5,
                         freq='S').to_julian_date()
-        self.assert_(isinstance(r2, Float64Index))
+        self.assertIsInstance(r2, Float64Index)
         tm.assert_index_equal(r1, r2)
 
 if __name__ == '__main__':

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -99,6 +99,21 @@ class TestCase(unittest.TestCase):
         a, b = first, second
         assert a not in b, "%s: %r is in %r" % (msg.format(a,b), a, b)
 
+    def assertIsInstance(self, obj, cls, msg=''):
+        """Test that obj is an instance of cls
+        (which can be a class or a tuple of classes,
+        as supported by isinstance())."""
+        assert isinstance(obj, cls), (
+            "%sExpected object to be of type %r, found %r instead" % (
+                msg, cls, type(obj)))
+
+    def assertNotIsInstance(self, obj, cls, msg=''):
+        """Test that obj is not an instance of cls
+        (which can be a class or a tuple of classes,
+        as supported by isinstance())."""
+        assert not isinstance(obj, cls), (
+            "%sExpected object to be of type %r, found %r instead" % (
+                msg, cls, type(obj)))
 
 # NOTE: don't pass an NDFrame or index to this function - may not handle it
 # well.


### PR DESCRIPTION
Work on #6175. Changes instances of assert_([not] isinstance(a,b)) to specialized assert[Not]IsInstance(a, b).
