### PR TITLE
CLN: Finish changing assert_(...) to specialized forms

### DIFF
--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -873,8 +873,7 @@ c,4,5
 """
         df = self.read_csv(StringIO(data), parse_dates=True)
         expected = self.read_csv(StringIO(data), index_col=0, parse_dates=True)
-        self.assert_(
-            isinstance(df.index[0], (datetime, np.datetime64, Timestamp)))
+        self.assertIsInstance(df.index[0], (datetime, np.datetime64, Timestamp))
         tm.assert_frame_equal(df, expected)
 
     def test_parse_dates_string(self):

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -964,7 +964,7 @@ class TestDataFramePlots(tm.TestCase):
 
         ax = df.plot(kind='hexbin', x='A', y='B', gridsize=10)
         # TODO: need better way to test. This just does existence.
-        self.assert_(len(ax.collections) == 1)
+        self.assertEqual(len(ax.collections), 1)
 
     @slow
     def test_hexbin_with_c(self):
@@ -973,11 +973,11 @@ class TestDataFramePlots(tm.TestCase):
                         "C": np.arange(20) + np.random.uniform(size=20)})
 
         ax = df.plot(kind='hexbin', x='A', y='B', C='C')
-        self.assert_(len(ax.collections) == 1)
+        self.assertEqual(len(ax.collections), 1)
 
         ax = df.plot(kind='hexbin', x='A', y='B', C='C',
                           reduce_C_function=np.std)
-        self.assert_(len(ax.collections) == 1)
+        self.assertEqual(len(ax.collections), 1)
 
     @slow
     def test_hexbin_cmap(self):

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -679,8 +679,8 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 
         deleveled = self.series.reset_index()
         tm.assert_isinstance(deleveled, DataFrame)
-        self.assert_(
-            len(deleveled.columns) == len(self.series.index.levels) + 1)
+        self.assertEqual(len(deleveled.columns),
+                         len(self.series.index.levels) + 1)
 
         deleveled = self.series.reset_index(drop=True)
         tm.assert_isinstance(deleveled, Series)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -2879,8 +2879,8 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         ts[2] = np.NaN
 
-        self.assert_(
-            np.array_equal(ts.fillna(method='ffill'), [0., 1., 1., 3., 4.]))
+        self.assert_numpy_array_equal(ts.fillna(method='ffill'),
+                                      [0., 1., 1., 3., 4.])
         self.assert_numpy_array_equal(ts.fillna(method='backfill'),
                                       [0., 1., 3., 3., 4.])
 

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -894,11 +894,9 @@ class TestTimeSeries(tm.TestCase):
 
     def test_to_datetime_unprocessable_input(self):
         # GH 4928
-        self.assert_(
-            np.array_equal(
-                to_datetime([1, '1']),
-                np.array([1, '1'], dtype='O')
-            )
+        self.assert_numpy_array_equal(
+            to_datetime([1, '1']),
+            np.array([1, '1'], dtype='O')
         )
         self.assertRaises(TypeError, to_datetime, [1, '1'], errors='raise')
 
@@ -953,11 +951,9 @@ class TestTimeSeries(tm.TestCase):
 
         # Assuming all datetimes are in bounds, to_datetime() returns
         # an array that is equal to Timestamp() parsing
-        self.assert_(
-            np.array_equal(
-                pd.to_datetime(dts, box=False),
-                np.array([Timestamp(x).asm8 for x in dts])
-            )
+        self.assert_numpy_array_equal(
+            pd.to_datetime(dts, box=False),
+            np.array([Timestamp(x).asm8 for x in dts])
         )
 
         # A list of datetimes where the last one is out of bounds
@@ -971,30 +967,26 @@ class TestTimeSeries(tm.TestCase):
             errors='raise'
         )
 
-        self.assert_(
-            np.array_equal(
-                pd.to_datetime(dts_with_oob, box=False, coerce=True),
-                np.array(
+        self.assert_numpy_array_equal(
+            pd.to_datetime(dts_with_oob, box=False, coerce=True),
+            np.array(
                     [
                         Timestamp(dts_with_oob[0]).asm8,
                         Timestamp(dts_with_oob[1]).asm8,
                         iNaT,
                     ],
                     dtype='M8'
-                )
             )
         )
 
         # With coerce=False and errors='ignore', out of bounds datetime64s
         # are converted to their .item(), which depending on the version of
         # numpy is either a python datetime.datetime or datetime.date
-        self.assert_(
-            np.array_equal(
-                pd.to_datetime(dts_with_oob, box=False, coerce=False),
-                np.array(
+        self.assert_numpy_array_equal(
+            pd.to_datetime(dts_with_oob, box=False, coerce=False),
+            np.array(
                     [dt.item() for dt in dts_with_oob],
                     dtype='O'
-                )
             )
         )
 

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -91,30 +91,26 @@ class TestDatetimeParsingWrappers(tm.TestCase):
 class TestArrayToDatetime(tm.TestCase):
     def test_parsing_valid_dates(self):
         arr = np.array(['01-01-2013', '01-02-2013'], dtype=object)
-        self.assert_(
-            np.array_equal(
-                tslib.array_to_datetime(arr),
-                np.array(
+        self.assert_numpy_array_equal(
+            tslib.array_to_datetime(arr),
+            np.array(
                     [
                         '2013-01-01T00:00:00.000000000-0000',
                         '2013-01-02T00:00:00.000000000-0000'
                     ],
                     dtype='M8[ns]'
-                )
             )
         )
 
         arr = np.array(['Mon Sep 16 2013', 'Tue Sep 17 2013'], dtype=object)
-        self.assert_(
-            np.array_equal(
-                tslib.array_to_datetime(arr),
-                np.array(
+        self.assert_numpy_array_equal(
+            tslib.array_to_datetime(arr),
+            np.array(
                     [
                         '2013-09-16T00:00:00.000000000-0000',
                         '2013-09-17T00:00:00.000000000-0000'
                     ],
                     dtype='M8[ns]'
-                )
             )
         )
 
@@ -155,16 +151,14 @@ class TestArrayToDatetime(tm.TestCase):
             )
 
         arr = np.array(['1/1/1000', '1/1/2000'], dtype=object)
-        self.assert_(
-            np.array_equal(
-                tslib.array_to_datetime(arr, coerce=True),
-                np.array(
+        self.assert_numpy_array_equal(
+            tslib.array_to_datetime(arr, coerce=True),
+            np.array(
                     [
                         tslib.iNaT,
                         '2000-01-01T00:00:00.000000000-0000'
                     ],
                     dtype='M8[ns]'
-                )
             )
         )
 
@@ -176,17 +170,15 @@ class TestArrayToDatetime(tm.TestCase):
         self.assert_numpy_array_equal(tslib.array_to_datetime(arr), arr)
 
         # With coercing, the invalid dates becomes iNaT
-        self.assert_(
-            np.array_equal(
-                tslib.array_to_datetime(arr, coerce=True),
-                np.array(
+        self.assert_numpy_array_equal(
+            tslib.array_to_datetime(arr, coerce=True),
+            np.array(
                     [
                         '2013-01-01T00:00:00.000000000-0000',
                         tslib.iNaT,
                         tslib.iNaT
                     ],
                     dtype='M8[ns]'
-                )
             )
         )
 
@@ -205,13 +197,11 @@ class TestArrayToDatetime(tm.TestCase):
         )
 
         for dt_string in dt_strings:
-            self.assert_(
-                np.array_equal(
-                    tslib.array_to_datetime(
-                        np.array([dt_string], dtype=object)
-                    ),
-                    expected_output
-                )
+            self.assert_numpy_array_equal(
+                tslib.array_to_datetime(
+                    np.array([dt_string], dtype=object)
+                ),
+                expected_output
             )
 
 class TestTimestampNsOperations(tm.TestCase):


### PR DESCRIPTION
Finishes #6175, to the extent that everything remaining can be mapped to assertTrue or assertFalse, unless larger refactorings are desired.
