### PR TITLE
FIX: Bug whereby array_equivalent was not correctly comparing Float64Ind...

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -311,11 +311,14 @@ def array_equivalent(left, right):
     >>> array_equivalent(np.array([1, nan, 2]), np.array([1, 2, nan]))
     False
     """
+    left, right = np.asarray(left), np.asarray(right)
     if left.shape != right.shape: return False
     # NaNs occur only in object arrays, float or complex arrays.
+    if issubclass(left.dtype.type, np.object_):
+        return ((left == right) | (pd.isnull(left) & pd.isnull(right))).all()
     if not issubclass(left.dtype.type, (np.floating, np.complexfloating)):
         return np.array_equal(left, right)
-    return  ((left == right) | (np.isnan(left) & np.isnan(right))).all()
+    return ((left == right) | (np.isnan(left) & np.isnan(right))).all()
 
 def _iterable_not_string(x):
     return (isinstance(x, collections.Iterable) and

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -5,7 +5,7 @@ import nose
 from nose.tools import assert_equal
 import numpy as np
 from pandas.tslib import iNaT, NaT
-from pandas import Series, DataFrame, date_range, DatetimeIndex, Timestamp
+from pandas import Series, DataFrame, date_range, DatetimeIndex, Timestamp, Float64Index
 from pandas import compat
 from pandas.compat import range, long, lrange, lmap, u
 from pandas.core.common import notnull, isnull, array_equivalent
@@ -181,7 +181,11 @@ def test_array_equivalent():
     assert not array_equivalent(np.array([np.nan, 1, np.nan]),
                                 np.array([np.nan, 2, np.nan]))
     assert not array_equivalent(np.array(['a', 'b', 'c', 'd']), np.array(['e', 'e']))
-
+    assert array_equivalent(Float64Index([0, np.nan]), Float64Index([0, np.nan]))
+    assert not array_equivalent(Float64Index([0, np.nan]), Float64Index([1, np.nan]))    
+    assert array_equivalent(DatetimeIndex([0, np.nan]), DatetimeIndex([0, np.nan]))    
+    assert not array_equivalent(DatetimeIndex([0, np.nan]), DatetimeIndex([1, np.nan]))
+    
 def test_datetimeindex_from_empty_datetime64_array():
     for unit in [ 'ms', 'us', 'ns' ]:
         idx = DatetimeIndex(np.array([], dtype='datetime64[%s]' % unit))


### PR DESCRIPTION
Currently, 

```
>>> import pandas.core.common as com
>>> com.array_equivalent(Float64Index([0, np.nan]), Float64Index([0, np.nan]))
False
```

Although the current pandas code base does not use `array_equivalent` to compare Float64Indexes, leaving `array_equivalent` in its current state may be a bug waiting to happen. 

This PR attempts to fix the problem by using `pd.isnull` for all arrays of dtype `object`. In a previous PR I tried this and got terrible perf results. Since then I've discovered that my machine does not have enough memory to run the full perf test suit without page faults. If I rerun `test_perf.sh` for just a few Benchmarks, I can avoid the page faults and get consistent results.

Running `/usr/bin/time -v ./test_perf.sh -b master -t fix-equivalent` yielded two tests with ratio > 1.1. 

``` -------------------------------------------------------------------------------
reindex_fillna_pad                           |   0.5784 |   0.5034 |   1.1490 |
packers_write_pack                           |  15.2360 |   7.1851 |   2.1205 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
```

which I believe were due to page faults. When I reran perf on just these tests using
`/usr/bin/time -v ./test_perf.sh -b master -t fix-equivalent  -r "reindex_fillna_pad|packers_write_pack"`

I got

``` -------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
reindex_fillna_pad_float32                   |   0.4633 |   0.4590 |   1.0093 |
packers_write_pack                           |   7.9544 |   7.8390 |   1.0147 |
reindex_fillna_pad                           |   0.7290 |   0.7180 |   1.0154 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
```
