### PR TITLE
SQL: move df.to_sql to generic + update with new functionality

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1261,25 +1261,6 @@ class DataFrame(NDFrame):
                              time_stamp=time_stamp, data_label=data_label)
         writer.write_file()
 
-    def to_sql(self, name, con, flavor='sqlite', if_exists='fail', **kwargs):
-        """
-        Write records stored in a DataFrame to a SQL database.
-
-        Parameters
-        ----------
-        name : str
-            Name of SQL table
-        conn : an open SQL database connection object
-        flavor: {'sqlite', 'mysql', 'oracle'}, default 'sqlite'
-        if_exists: {'fail', 'replace', 'append'}, default 'fail'
-            - fail: If table exists, do nothing.
-            - replace: If table exists, drop it, recreate it, and insert data.
-            - append: If table exists, insert data. Create if does not exist.
-        """
-        from pandas.io.sql import write_frame
-        write_frame(
-            self, name, con, flavor=flavor, if_exists=if_exists, **kwargs)
-
     @Appender(fmt.docstring_to_string, indents=1)
     def to_string(self, buf=None, columns=None, col_space=None, colSpace=None,
                   header=True, index=True, na_rep='NaN', formatters=None,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -908,6 +908,33 @@ class NDFrame(PandasObject):
         from pandas.io import packers
         return packers.to_msgpack(path_or_buf, self, **kwargs)
 
+    def to_sql(self, name, con, flavor='sqlite', if_exists='fail', index=True):
+        """
+        Write records stored in a DataFrame to a SQL database.
+
+        Parameters
+        ----------
+        name : string
+            Name of SQL table
+        con : SQLAlchemy engine or DBAPI2 connection (legacy mode)
+            Using SQLAlchemy makes it possible to use any DB supported by that
+            library.
+            If a DBAPI2 object is given, a supported SQL flavor must also be provided
+        flavor : {'sqlite', 'mysql'}, default 'sqlite'
+            The flavor of SQL to use. Ignored when using SQLAlchemy engine.
+            Required when using DBAPI2 connection.
+        if_exists : {'fail', 'replace', 'append'}, default 'fail'
+            - fail: If table exists, do nothing.
+            - replace: If table exists, drop it, recreate it, and insert data.
+            - append: If table exists, insert data. Create if does not exist.
+        index : boolean, default True
+            Write DataFrame index as a column
+
+        """
+        from pandas.io import sql
+        sql.to_sql(
+            self, name, con, flavor=flavor, if_exists=if_exists, index=index)
+
     def to_pickle(self, path):
         """
         Pickle (serialize) object to input file path

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -11,7 +11,7 @@ import numpy as np
 
 import pandas.core.common as com
 from pandas.compat import lzip, map, zip, raise_with_traceback, string_types
-from pandas.core.api import DataFrame
+from pandas.core.api import DataFrame, Series
 from pandas.core.base import PandasObject
 from pandas.tseries.tools import to_datetime
 
@@ -253,6 +253,12 @@ def to_sql(frame, name, con, flavor='sqlite', if_exists='fail', index=True):
         Write DataFrame index as a column
     """
     pandas_sql = pandasSQL_builder(con, flavor=flavor)
+
+    if isinstance(frame, Series):
+        frame = frame.to_frame()
+    elif not isinstance(frame, DataFrame):
+        raise NotImplementedError
+
     pandas_sql.to_sql(frame, name, if_exists=if_exists, index=index)
 
 

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -337,6 +337,18 @@ class TestSQLApi(PandasSQLTest):
         self.assertEqual(
             num_rows, num_entries, "not the same number of rows as entries")
 
+    def test_to_sql_series(self):
+        s = Series(np.arange(5, dtype='int64'), name='series')
+        sql.to_sql(s, "test_series", self.conn, flavor='sqlite', index=False)
+        s2 = sql.read_sql("SELECT * FROM test_series", self.conn, 
+                          flavor='sqlite')
+        tm.assert_frame_equal(s.to_frame(), s2)
+
+    def test_to_sql_panel(self):
+        panel = tm.makePanel()
+        self.assertRaises(NotImplementedError, sql.to_sql, panel,
+                          'test_panel', self.conn, flavor='sqlite')
+
     def test_legacy_write_frame(self):
         """Test legacy write frame name.
         Assume that functionality is already tested above so just do quick check that it basically works"""


### PR DESCRIPTION
Initial commit for this.

Questions:
- To catch Panels (and raiseNotImplementedError), should I do this in sql.to_sql or in NDFrame.to_sql?
- To support Series, I can just call `to_frame` on it. Is this OK?

And should add tests for this.
