### PR TITLE
CLN/API refactor drop and filter and deprecate select

### DIFF
--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -484,6 +484,7 @@ Enhancements
 - ``DataFrame.to_latex`` now takes a longtable keyword, which if True will return a table in a longtable environment. (:issue:`6617`)
 - ``pd.read_clipboard`` will, if 'sep' is unspecified, try to detect data copied from a spreadsheet
   and parse accordingly. (:issue:`6223`)
+- Unify drop and select API, allow drop to take a regex (:issue:`4818`) and drop with a boolean mask (:issue:`6189`)
 - Joining a singly-indexed DataFrame with a multi-indexed DataFrame (:issue:`3662`)
 
   See :ref:`the docs<merging.join_on_mi>`. Joining multi-index DataFrames on both the left and right is not yet supported ATM.

--- a/pandas/core/panelnd.py
+++ b/pandas/core/panelnd.py
@@ -96,7 +96,7 @@ def create_nd_panel_factory(klass_name, orders, slices, slicer, aliases=None,
     klass._combine_with_constructor = _combine_with_constructor
 
     # set as NonImplemented operations which we don't support
-    for f in ['to_frame', 'to_excel', 'to_sparse', 'groupby', 'join', 'filter',
+    for f in ['to_frame', 'to_excel', 'to_sparse', 'groupby', 'join',
               'dropna', 'shift']:
         def func(self, *args, **kwargs):
             raise NotImplementedError

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3286,7 +3286,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         result = df.drop(['a'],axis=1)
         expected = DataFrame([[1],[1],[1]],columns=['bar'])
         check(result,expected)
-        result = df.drop('a',axis=1)
+        result = df.drop('a', axis=1, regex=False)
         check(result,expected)
 
         # describe
@@ -9717,8 +9717,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.assertEqual(len(filtered.columns), 2)
 
         # pass in None
-        with assertRaisesRegexp(TypeError, 'Must pass'):
-            self.frame.filter(items=None)
+        with assertRaisesRegexp(TypeError, 'must not be None'):
+            self.frame.filter(labels=None)
 
         # objects
         filtered = self.mixed_frame.filter(like='foo')

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1587,11 +1587,11 @@ Thur,Lunch,Yes,51.51,17"""
         index = MultiIndex.from_tuples(tuples)
         df = DataFrame(randn(4, 6), columns=index)
 
-        result = df.drop('a', axis=1)
+        result = df.drop('a', axis=1, level=0)
         expected = df.drop([('a', '', '')], axis=1)
         assert_frame_equal(expected, result)
 
-        result = df.drop(['top'], axis=1)
+        result = df.drop(['top'], axis=1, level=0)
         expected = df.drop([('top', 'OD', 'wx')], axis=1)
         expected = expected.drop([('top', 'OD', 'wy')], axis=1)
         assert_frame_equal(expected, result)
@@ -1601,7 +1601,7 @@ Thur,Lunch,Yes,51.51,17"""
         assert_frame_equal(expected, result)
 
         expected = df.drop([('top', 'OD', 'wy')], axis=1)
-        expected = df.drop('top', axis=1)
+        expected = df.drop('top', axis=1, level=0)
 
         result = df.drop('result1', level=1, axis=1)
         expected = df.drop([('routine1', 'result1', ''),
@@ -1647,7 +1647,7 @@ Thur,Lunch,Yes,51.51,17"""
         self.assertEquals(result.name, 'a')
 
         expected = df1['top']
-        df1 = df1.drop(['top'], axis=1)
+        df1 = df1.drop(['top'], axis=1, level=0)
         result = df2.pop('top')
         assert_frame_equal(expected, result)
         assert_frame_equal(df1, df2)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1634,8 +1634,8 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # single string/tuple-like
         s = Series(range(3),index=list('abc'))
-        self.assertRaises(ValueError, s.drop, 'bc')
-        self.assertRaises(ValueError, s.drop, ('a',))
+        assert_series_equal(s.drop('bc'), s)
+        assert_series_equal(s.drop(('a',)), s.loc[['b', 'c']])
 
         # bad axis
         self.assertRaises(ValueError, s.drop, 'one', axis='columns')


### PR DESCRIPTION
closes #4818
- need to unify api for drop and filter
- should they take args for regex (regex, flags, case)
- should we keep select or filter?

closes #6189
xref #8530 
xref #8594
