### PR TITLE
TST: enable MySQL tests

### DIFF
--- a/ci/requirements-2.7.txt
+++ b/ci/requirements-2.7.txt
@@ -18,4 +18,5 @@ beautifulsoup4==4.2.1
 statsmodels==0.5.0
 bigquery==2.0.17
 sqlalchemy==0.8.1
+pymysql==0.6.1
 psycopg2==2.5.2

--- a/ci/requirements-3.3.txt
+++ b/ci/requirements-3.3.txt
@@ -16,4 +16,5 @@ scipy==0.12.0
 beautifulsoup4==4.2.1
 statsmodels==0.4.3
 sqlalchemy==0.9.1
+pymysql==0.6.1
 psycopg2==2.5.2

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -668,7 +668,7 @@ class PandasSQLAlchemy(PandasSQL):
                    parse_dates=None, columns=None):
 
         table = PandasSQLTable(table_name, self, index=index_col)
-        return table.read(coerce_float=parse_dates,
+        return table.read(coerce_float=coerce_float,
                           parse_dates=parse_dates, columns=columns)
 
     def drop_table(self, table_name):

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -495,7 +495,7 @@ class _TestSQLAlchemy(PandasSQLTest):
         self.assertRaises(
             ValueError, sql.read_table, "this_doesnt_exist", con=self.conn)
 
-    def test_default_type_convertion(self):
+    def test_default_type_conversion(self):
         df = sql.read_table("types_test_data", self.conn)
 
         self.assertTrue(issubclass(df.FloatCol.dtype.type, np.floating),
@@ -589,7 +589,7 @@ class TestSQLAlchemy(_TestSQLAlchemy):
 
         self._load_test1_data()
 
-    def test_default_type_convertion(self):
+    def test_default_type_conversion(self):
         df = sql.read_table("types_test_data", self.conn)
 
         self.assertTrue(issubclass(df.FloatCol.dtype.type, np.floating),
@@ -754,6 +754,24 @@ class TestMySQLAlchemy(_TestSQLAlchemy):
             c = self.conn.execute('SHOW TABLES')
             for table in c.fetchall():
                 self.conn.execute('DROP TABLE %s' % table[0])
+
+        def test_default_type_conversion(self):
+            df = sql.read_table("types_test_data", self.conn)
+    
+            self.assertTrue(issubclass(df.FloatCol.dtype.type, np.floating),
+                            "FloatCol loaded with incorrect type")
+            self.assertTrue(issubclass(df.IntCol.dtype.type, np.integer),
+                            "IntCol loaded with incorrect type")
+            # MySQL has no real BOOL type (it's an alias for TINYINT) 
+            self.assertTrue(issubclass(df.BoolCol.dtype.type, np.integer),
+                            "BoolCol loaded with incorrect type")
+    
+            # Int column with NA values stays as float
+            self.assertTrue(issubclass(df.IntColWithNull.dtype.type, np.floating),
+                            "IntColWithNull loaded with incorrect type")
+            # Bool column with NA = int column with NA values => becomes float
+            self.assertTrue(issubclass(df.BoolColWithNull.dtype.type, np.floating), 
+                            "BoolColWithNull loaded with incorrect type")
 
 
 class TestPostgreSQLAlchemy(_TestSQLAlchemy):


### PR DESCRIPTION
PR to fix and enable the MySQL tests for the new sql functionality.
- floats (decimal.Decimal) were not converted due to a small bug in the `coerce_float` arg. This is now OK.
- MySQL has no real BOOL type (it is just an alias for tiny int). So I changed the tests for that (so a bool column is converted to int64 (or float if there are NA's)

We should maybe add somewhere in the sql docs an overview of the limitations of the type conversion.
