### PR TITLE
BUG/CLN: fix iloc when positional indexer matched Int64Index key

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -231,6 +231,8 @@ Bug Fixes
 - Bug in fillna with method = 'bfill/ffill' and ``datetime64[ns]`` dtype (:issue:`6587`)
 - Bug in sql writing with mixed dtypes possibly leading to data loss (:issue:`6509`)
 - Bug in popping from a Series (:issue:`6600`)
+- Bug in ``iloc`` indexing when positional indexer matched Int64Index of corresponding axis no reordering happened (:issue:`6612`)
+
 
 pandas 0.13.1
 -------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1546,8 +1546,6 @@ class NDFrame(PandasObject):
             "compatible" value
         limit : int, default None
             Maximum size gap to forward or backward fill
-        takeable : boolean, default False
-            treat the passed as positional values
 
         Examples
         --------
@@ -1570,7 +1568,6 @@ class NDFrame(PandasObject):
         copy = kwargs.get('copy', True)
         limit = kwargs.get('limit')
         fill_value = kwargs.get('fill_value', np.nan)
-        takeable = kwargs.get('takeable', False)
 
         self._consolidate_inplace()
 
@@ -1591,11 +1588,9 @@ class NDFrame(PandasObject):
 
         # perform the reindex on the axes
         return self._reindex_axes(axes, level, limit,
-                                  method, fill_value, copy,
-                                  takeable=takeable).__finalize__(self)
+                                  method, fill_value, copy).__finalize__(self)
 
-    def _reindex_axes(self, axes, level, limit, method, fill_value, copy,
-                      takeable=False):
+    def _reindex_axes(self, axes, level, limit, method, fill_value, copy):
         """ perform the reinxed for all the axes """
         obj = self
         for a in self._AXIS_ORDERS:
@@ -1610,13 +1605,12 @@ class NDFrame(PandasObject):
             axis = self._get_axis_number(a)
             ax = self._get_axis(a)
             new_index, indexer = ax.reindex(
-                labels, level=level, limit=limit, method=method,
-                takeable=takeable)
+                labels, level=level, limit=limit, method=method)
 
             obj = obj._reindex_with_indexers(
                 {axis: [new_index, indexer]}, method=method,
                 fill_value=fill_value, limit=limit, copy=copy,
-                allow_dups=takeable)
+                allow_dups=False)
 
         return obj
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1308,7 +1308,7 @@ class Index(IndexOpsMixin, FrozenNDArray):
         return aliases.get(method, method)
 
     def reindex(self, target, method=None, level=None, limit=None,
-                copy_if_needed=False, takeable=False):
+                copy_if_needed=False):
         """
         For Index, simply returns the new index and the results of
         get_indexer. Provided here to enable an interface that is amenable for
@@ -1336,13 +1336,6 @@ class Index(IndexOpsMixin, FrozenNDArray):
                         target = self.copy()
 
             else:
-
-                if takeable:
-                    if method is not None or limit is not None:
-                        raise ValueError("cannot do a takeable reindex with "
-                                         "with a method or limit")
-                    return self[target], target
-
                 if self.is_unique:
                     indexer = self.get_indexer(target, method=method,
                                                limit=limit)
@@ -3113,7 +3106,7 @@ class MultiIndex(Index):
         return com._ensure_platform_int(indexer)
 
     def reindex(self, target, method=None, level=None, limit=None,
-                copy_if_needed=False, takeable=False):
+                copy_if_needed=False):
         """
         Performs any necessary conversion on the input index and calls
         get_indexer. This method is here so MultiIndex and an Index of
@@ -3123,10 +3116,6 @@ class MultiIndex(Index):
         -------
         (new_index, indexer, mask) : (MultiIndex, ndarray, ndarray)
         """
-
-        # a direct takeable
-        if takeable:
-            return self.take(target), target
 
         if level is not None:
             if method is not None:
@@ -3142,14 +3131,8 @@ class MultiIndex(Index):
                     indexer = self.get_indexer(target, method=method,
                                                limit=limit)
                 else:
-                    if takeable:
-                        if method is not None or limit is not None:
-                            raise ValueError("cannot do a takeable reindex "
-                                             "with a method or limit")
-                        return self[target], target
-
                     raise Exception(
-                        "cannot handle a non-takeable non-unique multi-index!")
+                        "cannot handle a non-unique multi-index!")
 
         if not isinstance(target, MultiIndex):
             if indexer is None:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -460,8 +460,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             else:
                 label = self.index[i]
                 if isinstance(label, Index):
-                    i = _maybe_convert_indices(i, len(self))
-                    return self.reindex(i, takeable=True)
+                    return self.take(i, axis=axis, convert=True)
                 else:
                     return _index.get_value_at(self, i)
 


### PR DESCRIPTION
closes #6612

As discussed in #6612, `reindex(..., takeable=True)` as released in 0.13.0 didn't do anything that's not achieved by `.take`, `.iloc` and `.copy` attrs/methods, but also contained a bug which propagated to `iloc` when the latter was changed to use _reindex/takeable_ internally.

The proposed solution is to remove _reindex/takeable_ functionality altogether. According to @jreback, it was never supposed to be a part of public API, so probably no deprecation procedure is necessary.
