### PR TITLE
CLN #6589 remove print statements when sep=None is passed to read_csv

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -535,7 +535,6 @@ class TextFileReader(object):
 
         if sep is None and not delim_whitespace:
             if engine == 'c':
-                print('Using Python parser to sniff delimiter')
                 engine = 'python'
         elif sep is not None and len(sep) > 1:
             # wait until regex engine integrated


### PR DESCRIPTION
Simply removed unneceesary print.

fix https://github.com/pydata/pandas/issues/6589
