### PR TITLE
BUG: Error in to_stata when DataFrame contains non-string column names

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -233,6 +233,7 @@ Bug Fixes
 - Bug in popping from a Series (:issue:`6600`)
 - Bug in ``iloc`` indexing when positional indexer matched Int64Index of corresponding axis no reordering happened (:issue:`6612`)
 - Bug in ``fillna`` with ``limit`` and ``value`` specified
+- Bug in ``DataFrame.to_stata`` when columns have non-string names (:issue:`4558`)
 
 pandas 0.13.1
 -------------


### PR DESCRIPTION
closes #4558

to_stata does not work correctly when used with non-string names.  Since
Stata requires string names, the proposed fix attempts to rename columns using
the string representation of the column name used.  A warning is raised if
the column name is changed.
