### PR TITLE
SQL: fix meta/has_table

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -614,7 +614,7 @@ class PandasSQLAlchemy(PandasSQL):
             meta = MetaData(self.engine)
             meta.reflect(self.engine)
 
-        self.meta = meta
+        self._meta = meta
 
     def execute(self, *args, **kwargs):
         """Simple passthrough to SQLAlchemy engine"""
@@ -650,6 +650,12 @@ class PandasSQLAlchemy(PandasSQL):
         table = PandasSQLTable(
             name, self, frame=frame, index=index, if_exists=if_exists)
         table.insert()
+
+    @property
+    def meta(self):
+        self._meta.clear()
+        self._meta.reflect()
+        return self._meta
 
     @property
     def tables(self):

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -373,6 +373,19 @@ class TestSQLApi(PandasSQLTest):
         row = iris_results[0]
         tm.equalContents(row, [5.1, 3.5, 1.4, 0.2, 'Iris-setosa'])
 
+    def test_has_table(self):
+        sql.to_sql(self.test_frame1, 'test_frame_has_table', self.conn, flavor='sqlite')
+
+        self.assertTrue(
+            sql.has_table('test_frame_has_table', self.conn, flavor='sqlite'),
+            "Table not found with has_table but exists")
+
+        self.drop_table('test_frame_has_table')
+
+        self.assertFalse(
+            sql.has_table('test_frame_has_table', self.conn, flavor='sqlite'),
+            "Table found with has_table but does not exist")
+
     def test_date_parsing(self):
         """ Test date parsing in read_sql """
         # No Parsing
@@ -474,6 +487,22 @@ class _TestSQLAlchemy(PandasSQLTest):
 
         self.assertFalse(
             temp_conn.has_table('temp_frame'), 'Table not deleted from DB')
+
+    def test_has_table(self):
+        temp_frame = DataFrame(
+            {'one': [1., 2., 3., 4.], 'two': [4., 3., 2., 1.]})
+
+        self.pandasSQL.to_sql(temp_frame, 'test_frame_has_table')
+
+        self.assertTrue(
+            self.pandasSQL.has_table('test_frame_has_table'),
+            "Table not found with has_table but exists")
+
+        self.drop_table('test_frame_has_table')
+
+        self.assertFalse(
+            self.pandasSQL.has_table('test_frame_has_table'),
+            "Table found with has_table but does not exist")
 
     def test_roundtrip(self):
         self._roundtrip()


### PR DESCRIPTION
Further work for cleaning up the sql code (#6292).
- the `meta` attribute is not updated automatically, with the consequence that eg when you delete a table from sql directly, the `has_table` function does not work anymore:
  - I added a test for that
  - I converted the `meta` attribute to one which is always updated when called. @mangecoeur looks OK?
- now the tests are skipped when no connection could be made. @jreback, I just did a `raise nose.SkipTest` inside the setup function of the test class. -> moved and merged this in #6651 
