### PR TITLE
ENH add base arg to value_counts

### DIFF
--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -436,6 +436,12 @@ Enhancements
 
 - ``quotechar``, ``doublequote``, and ``escapechar`` can now be specified when
   using ``DataFrame.to_csv`` (:issue:`5414`, :issue:`4528`)
+- ``value_counts`` accepts a base argument:
+
+  ..ipython::python
+
+     Series(list('aaabbc')).value_counts(base=list('acd'))
+
 - Added a ``to_julian_date`` function to ``TimeStamp`` and ``DatetimeIndex``
   to convert to the Julian Date used primarily in astronomy. (:issue:`4041`)
 - ``DataFrame.to_stata`` will now check data for compatibility with Stata data types

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1090,6 +1090,37 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         return notnull(_values_from_object(self)).sum()
 
+    def value_counts(self, normalize=False, sort=True, ascending=False,
+                     bins=None, base=None):
+        """
+        Returns Series containing counts of unique values. The resulting Series
+        will be in descending order so that the first element is the most
+        frequently-occurring element. Excludes NA values
+
+        Parameters
+        ----------
+        normalize : boolean, default False
+            If True then the Series returned will contain the relative
+            frequencies of the unique values.
+        sort : boolean, default True
+            Sort by values
+        ascending : boolean, default False
+            Sort in ascending order
+        bins : integer, optional
+            Rather than count values, group them into half-open bins,
+            a convenience for pd.cut, only works with numeric data
+        base : list-like, optional
+            Unique values to count against
+
+        Returns
+        -------
+        counts : Series
+        """
+        from pandas.core.algorithms import value_counts
+        return value_counts(self.values, sort=sort, ascending=ascending,
+                            normalize=normalize, bins=bins, base=base)
+
+
     def mode(self):
         """Returns the mode(s) of the dataset.
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -187,6 +187,21 @@ class TestValueCounts(tm.TestCase):
 
         self.assertRaises(TypeError, lambda s: algos.value_counts(s, bins=1), ['1', 1])
 
+    def test_value_counts_base(self):
+        x = [1, 3, 3, 3, 2, 2, 7]
+        y = [3, 2, 5]
+        res = algos.value_counts(x, base=y, sort=False)
+        exp = Series([3, 2, 0], y)
+        tm.assert_series_equal(res, exp)
+        
+        res = algos.value_counts(x, base=y, sort=True)
+        tm.assert_series_equal(res, exp.reindex([3, 2, 5]))
+
+        res = algos.value_counts(x, base=y, sort=False, normalize=True)
+        exp = Series([0.42857142857142855, 0.2857142857142857, 0.0], [3, 2, 5])
+        # Note: this *doesnt* sum to 1 (intentionally)
+        tm.assert_series_equal(res, exp)
+
 
 def test_quantile():
     s = Series(np.random.randn(100))

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -3830,7 +3830,99 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         self.assertRaises(ValueError, a.dot, b.T)
 
     def test_value_counts_nunique(self):
+        s = Series(['a', 'b', 'b', 'b', 'b', 'a', 'c', 'd', 'd', 'a'])
+        hist = s.value_counts()
+        expected = Series([4, 3, 2, 1], index=['b', 'a', 'd', 'c'])
+        assert_series_equal(hist, expected)
+
+        # don't sort, have to sort after the fact as not sorting is platform-dep
+        hist = s.value_counts(sort=False)
+        hist.sort()
+        expected = Series([3, 1, 4, 2], index=list('acbd'))
+        expected.sort()
+        assert_series_equal(hist, expected)
+
+        # sort ascending
+        hist = s.value_counts(ascending=True)
+        expected = Series([1, 2, 3, 4], index=list('cdab'))
+        assert_series_equal(hist, expected)
+
+        # relative histogram.
+        hist = s.value_counts(normalize=True)
+        expected = Series([.4, .3, .2, .1], index=['b', 'a', 'd', 'c'])
+        assert_series_equal(hist, expected)
+
+        self.assertEquals(s.nunique(), 4)
+
+        # bins
+        self.assertRaises(TypeError, lambda bins: s.value_counts(bins=bins), 1)
+
+        s1 = Series([1, 1, 2, 3])
+        res1 = s1.value_counts(bins=1)
+        exp1 = Series({0.998: 4})
+        assert_series_equal(res1, exp1)
+        res1n = s1.value_counts(bins=1, normalize=True)
+        exp1n = Series({0.998: 1.0})
+        assert_series_equal(res1n, exp1n)
+
+        res4 = s1.value_counts(bins=4)
+        exp4 = Series({0.998: 2, 1.5: 1, 2.0: 0, 2.5: 1}, index=[0.998, 2.5, 1.5, 2.0])
+        assert_series_equal(res4, exp4)
+        res4n = s1.value_counts(bins=4, normalize=True)
+        exp4n = Series({0.998: 0.5, 1.5: 0.25, 2.0: 0.0, 2.5: 0.25}, index=[0.998, 2.5, 1.5, 2.0])
+        assert_series_equal(res4n, exp4n)
+
+        # base
+        x = Series([1, 3, 3, 3, 2, 2, 7])
+        y = Series([3, 2, 5])
+        res = x.value_counts(base=y, sort=False)
+        exp = Series([3, 2, 0], y)
+        assert_series_equal(res, exp)
         
+        res = x.value_counts(base=y, sort=True)
+        assert_series_equal(res, exp.reindex([3, 2, 5]))
+
+        res = x.value_counts(base=y, sort=True, normalize=True)
+        exp = Series([0.42857142857142855, 0.2857142857142857, 0.0], [3, 2, 5])
+        # Note: this *doesn't* sum to 1 (intentionally)
+        assert_series_equal(res, exp)
+
+        # handle NA's properly
+        s[5:7] = np.nan
+        hist = s.value_counts()
+        expected = s.dropna().value_counts()
+        assert_series_equal(hist, expected)
+
+        s = Series({})
+        hist = s.value_counts()
+        expected = Series([], dtype=np.int64)
+        assert_series_equal(hist, expected)
+
+        # GH 3002, datetime64[ns]
+        import pandas as pd
+        f = StringIO(
+            "xxyyzz20100101PIE\nxxyyzz20100101GUM\nxxyyww20090101EGG\nfoofoo20080909PIE")
+        df = pd.read_fwf(f, widths=[6, 8, 3], names=[
+                         "person_id", "dt", "food"], parse_dates=["dt"])
+        s = df.dt.copy()
+        result = s.value_counts()
+        self.assertEqual(result.index.dtype, 'datetime64[ns]')
+
+        # with NaT
+        s = s.append(Series({4: pd.NaT}))
+        result = s.value_counts()
+        self.assertEqual(result.index.dtype, 'datetime64[ns]')
+
+        # timedelta64[ns]
+        from datetime import timedelta
+        td = df.dt - df.dt + timedelta(1)
+        td2 = timedelta(1) + (df.dt - df.dt)
+        result = td.value_counts()
+        result2 = td2.value_counts()
+        #self.assertEqual(result.index.dtype, 'timedelta64[ns]')
+        self.assertEqual(result.index.dtype, 'int64')
+        self.assertEqual(result2.index.dtype, 'int64')
+
         # basics.rst doc example
         series = Series(np.random.randn(500))
         series[20:500] = np.nan


### PR DESCRIPTION
Often I find myself wanting to throw away values which aren't in a given set when doing `value_counts`...

This basically just does this but inside value_counts (before possibly sorting):

```
pd.value_counts(x).reindex(base, fill_value=0)  # same as Series method
```

_I previously thought this was trickier to implement, so feel a bit stupid, but anyway could be useful....?_
