### PR TITLE
ENH: Have inferred_freq set offset. Have freq always try to infer.

### DIFF
--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -330,6 +330,7 @@ Enhancements
   and data_label which allow the time stamp and dataset label to be set when creating a
   file. (:issue:`6545`)
 - ``pandas.io.gbq`` now handles reading unicode strings properly. (:issue:`5940`)
+- If it is possible to infer the frequency, viewing the ``inferred_freq`` property of a DatetimeIndex now sets the offset and freq property as a side effect.
 
 Performance
 ~~~~~~~~~~~

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -330,7 +330,7 @@ Enhancements
   and data_label which allow the time stamp and dataset label to be set when creating a
   file. (:issue:`6545`)
 - ``pandas.io.gbq`` now handles reading unicode strings properly. (:issue:`5940`)
-- If it is possible to infer the frequency, viewing the ``inferred_freq`` property of a DatetimeIndex now sets the offset and freq property as a side effect.
+- For a DatetimeIndex ``freq`` always tries to infer a frequency. If it is possible to infer the frequency, viewing the ``inferred_freq`` property of a DatetimeIndex will now also set the offset and freq property as a side effect.
 
 Performance
 ~~~~~~~~~~~

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1421,6 +1421,9 @@ class DatetimeIndex(Int64Index):
     @property
     def freq(self):
         """ return the frequency object if its set, otherwise None """
+        offset = self.offset
+        if offset is None:
+            _ = self.inferred_freq
         return self.offset
 
     @cache_readonly

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1426,7 +1426,9 @@ class DatetimeIndex(Int64Index):
     @cache_readonly
     def inferred_freq(self):
         try:
-            return infer_freq(self)
+            freq = infer_freq(self)
+            self.offset = to_offset(freq)
+            return freq
         except ValueError:
             return None
 


### PR DESCRIPTION
I'm on the fence about this. Having a property with side effects doesn't quite sit right to me. But I think it kinda makes sense here. If it didn't set `freq`, then it really doesn't make sense for `freq` to exist. I'd just use `inferred_freq` all of the time.

Now calling `freq` always tries to infer the frequency. Why not? Seems sensible to me. `inferred_freq` is kind of redundant now, but I left it anyway. I was never really sure of the rationale for its existence.
