### PR TITLE
SQL: add index_label keyword to to_sql

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -908,7 +908,8 @@ class NDFrame(PandasObject):
         from pandas.io import packers
         return packers.to_msgpack(path_or_buf, self, **kwargs)
 
-    def to_sql(self, name, con, flavor='sqlite', if_exists='fail', index=True):
+    def to_sql(self, name, con, flavor='sqlite', if_exists='fail', index=True,
+               index_label=None):
         """
         Write records stored in a DataFrame to a SQL database.
 
@@ -928,12 +929,17 @@ class NDFrame(PandasObject):
             - replace: If table exists, drop it, recreate it, and insert data.
             - append: If table exists, insert data. Create if does not exist.
         index : boolean, default True
-            Write DataFrame index as a column
+            Write DataFrame index as a column.
+        index_label : string or sequence, default None
+            Column label for index column(s). If None is given (default) and
+            `index` is True, then the index names are used.
+            A sequence should be given if the DataFrame uses MultiIndex.
 
         """
         from pandas.io import sql
         sql.to_sql(
-            self, name, con, flavor=flavor, if_exists=if_exists, index=index)
+            self, name, con, flavor=flavor, if_exists=if_exists, index=index,
+            index_label=index_label)
 
     def to_pickle(self, path):
         """


### PR DESCRIPTION
Further work on #6292. While looking at possible multi-index support, I thought of first adding this:
- added ability to specify the used column name for the index column in `to_sql` (analoguous to `to_csv`). Good idea?
- I only did it for the new sqlalchemy function, not the legacy one. Only problem is that it starts from the same function call, so all keyword arguments have also to be added to the legacy `to_sql` (https://github.com/jorisvandenbossche/pandas/compare/sql-multiindex?expand=1#diff-b41f9fd042c423682f8e4c4d808dbe64R891) without using it. Is there a better approach? Should I warn that this is ignored if the user specifies this?
- added tests for it

to do:
- [x] should also change this in generic.py
- [ ] check for name conflicts (warn and suggest to use index_label?)

@mangecoeur
