### PR TITLE
ENH/VIS: Area plot is now supported by kind='area'. 

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -190,6 +190,8 @@ API Changes
   ``data`` argument (:issue:`5357`)
 - groupby will now not return the grouped column for non-cython functions (:issue:`5610`),
   as its already the index
+- ``DataFrame.plot`` and ``Series.plot`` now supports area plot with specifying ``kind='area'`` (:issue:`6656`)
+- Line plot can be stacked by ``stacked=True``. (:issue:`6656`)
 
 Deprecations
 ~~~~~~~~~~~~

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -364,10 +364,12 @@ Plotting
 ~~~~~~~~
 
 - Hexagonal bin plots from ``DataFrame.plot`` with ``kind='hexbin'`` (:issue:`5478`), See :ref:`the docs<visualization.hexbin>`.
+- ``DataFrame.plot`` and ``Series.plot`` now supports area plot with specifying ``kind='area'`` (:issue:`6656`)
 - Plotting with Error Bars is now supported in the ``.plot`` method of ``DataFrame`` and ``Series`` objects (:issue:`3796`), See :ref:`the docs<visualization.errorbars>`.
 - ``DataFrame.plot`` and ``Series.plot`` now support a ``table`` keyword for plotting ``matplotlib.Table``, See :ref:`the docs<visualization.table>`.
 - ``plot(legend='reverse')`` will now reverse the order of legend labels for
   most plot kinds. (:issue:`6014`)
+- Line plot and area plot can be stacked by ``stacked=True`` (:issue:`6656`) 
 
 - Following keywords are now acceptable for :meth:`DataFrame.plot(kind='bar')` and :meth:`DataFrame.plot(kind='barh')`.
 

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -461,6 +461,40 @@ Finally, there is a helper function ``pandas.tools.plotting.table`` to create a 
 
 **Note**: You can get table instances on the axes using ``axes.tables`` property for further decorations. See the `matplotlib table documenation <http://matplotlib.org/api/axes_api.html#matplotlib.axes.Axes.table>`__ for more.
 
+.. _visualization.area_plot:
+
+Area plot
+~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 0.14
+
+You can create area plots with ``Series.plot`` and ``DataFrame.plot`` by passing ``kind='area'``. Area plots are stacked by default. To produce stacked area plot, each column must be either all positive or all negative values.
+
+When input data contains `NaN`, it will be automatically filled by 0. If you want to drop or fill by different values, use :func:`dataframe.dropna` or :func:`dataframe.fillna` before calling `plot`.
+
+.. ipython:: python
+   :suppress:
+
+   plt.figure();
+
+.. ipython:: python
+   
+   df = DataFrame(rand(10, 4), columns=['a', 'b', 'c', 'd'])
+
+   @savefig area_plot_stacked.png
+   df.plot(kind='area');
+
+To produce an unstacked plot, pass ``stacked=False``. Alpha value is set to 0.5 unless otherwise specified:
+
+.. ipython:: python
+   :suppress:
+
+   plt.figure();
+
+.. ipython:: python
+   
+   @savefig area_plot_unstacked.png
+   df.plot(kind='area', stacked=False);
 
 .. _visualization.scatter_matrix:
 


### PR DESCRIPTION
Area plot is added to plotting method. The AreaPlot class is created as a subclass of LinePlot, thus it works also in time series. 

By default, area plot is being stacked. When area plot is not stacked (`stacked=False`), alpha value is set to 0.5 to show overlapped area if not configured specifically. As a side benefit, line plot also can be stacked by specifying `stacked=True` (disabled by default). Different from stacked bar plot, I don't know good visualization for positive/negative mixed data. Thus, input must be all positive or all negative when `stacked=True`. I'll try to implement it if there is a good way. Also, area plot doesn't support logy and loglog plot because filling area starts from 0.

Note: Area plot's legend is implemented based on the answer described in:
http://stackoverflow.com/questions/14534130/legend-not-showing-up-in-matplotlib-stacked-area-plot

_Example:_
![figure_1](https://f.cloud.github.com/assets/1696302/2436288/dee8f4e6-add8-11e3-9297-a7403935844d.png)
