### PR TITLE
ENH/VIS: Plotting DataFrame/Series with matplotlib.table

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -161,6 +161,17 @@ API Changes
 
 - Added ``nunique`` and ``value_counts`` functions to ``Index`` for counting unique elements. (:issue:`6734`)
 
+- ``DataFrame.plot`` and ``Series.plot`` now support a ``table`` keyword for plotting ``matplotlib.Table``. The ``table`` kewyword can receive the following values. 
+  
+  - ``False``: Do nothing (default).
+
+  - ``True``: Draw a table using the ``DataFrame`` or ``Series`` called ``plot`` method. Data will be transposed to meet matplotlib's default layout.
+  
+  - ``DataFrame`` or ``Series``: Draw matplotlib.table using the passed data. The data will be drawn as displayed in print method (not transposed automatically).
+
+  Also, helper function ``pandas.tools.plotting.table`` is added to create a table from ``DataFrame`` and ``Series``, and add it to an ``matplotlib.Axes``.
+
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -201,6 +201,17 @@ API changes
 
 - Added ``nunique`` and ``value_counts`` functions to ``Index`` for counting unique elements. (:issue:`6734`)
 
+- ``DataFrame.plot`` and ``Series.plot`` now support a ``table`` keyword for plotting ``matplotlib.Table``. The ``table`` kewyword can receive the following values. 
+  
+  - ``False``: Do nothing (default).
+
+  - ``True``: Draw a table using the ``DataFrame`` or ``Series`` called ``plot`` method. Data will be transposed to meet matplotlib's default layout.
+  
+  - ``DataFrame`` or ``Series``: Draw matplotlib.table using the passed data. The data will be drawn as displayed in print method (not transposed automatically).
+
+  Also, helper function ``pandas.tools.plotting.table`` is added to create a table from ``DataFrame`` and ``Series``, and add it to an ``matplotlib.Axes``.
+
+
 MultiIndexing Using Slicers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -415,6 +415,48 @@ Here is an example of one way to easily plot group means with standard deviation
    @savefig errorbar_example.png
    means.plot(yerr=errors, ax=ax, kind='bar')
 
+Plotting With Table
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 0.14
+
+Plotting with matplotlib table is now supported in the ``DataFrame.plot`` and ``Series.plot`` by a ``table`` keyword. The ``table`` keyword can accept ``bool``, ``DataFrame`` or ``Series``. The simple way to draw a table is to specify ``table=True``. Data will be transposed to meet matplotlib's default layout.
+
+.. ipython:: python
+
+   fig, ax = plt.subplots(1, 1)
+   df = DataFrame(rand(5, 3), columns=['a', 'b', 'c'])
+   ax.get_xaxis().set_visible(False)   # Hide Ticks
+
+   @savefig line_plot_table_true.png
+   df.plot(table=True, ax=ax)
+
+Also, you can pass different ``DataFrame`` or ``Series`` for ``table`` keyword. The data will be drawn as displayed in print method (not transposed automatically). If required, it should be transposed manually as below example.
+
+.. ipython:: python
+
+   fig, ax = plt.subplots(1, 1)
+   ax.get_xaxis().set_visible(False)   # Hide Ticks
+   @savefig line_plot_table_data.png
+   df.plot(table=np.round(df.T, 2), ax=ax)
+
+
+Finally, there is a helper function ``pandas.tools.plotting.table`` to create a table from ``DataFrame`` and ``Series``, and add it to an ``matplotlib.Axes``. This function can accept keywords which matplotlib table has.
+
+.. ipython:: python
+
+   from pandas.tools.plotting import table
+   fig, ax = plt.subplots(1, 1)
+
+   table(ax, np.round(df.describe(), 2), 
+         loc='upper right', colWidths=[0.2, 0.2, 0.2])
+
+   @savefig line_plot_table_describe.png
+   df.plot(ax=ax, ylim=(0, 2), legend=None)
+
+**Note**: You can get table instances on the axes using ``axes.tables`` property for further decorations. See the `matplotlib table documenation <http://matplotlib.org/api/axes_api.html#matplotlib.axes.Axes.table>`__ for more.
+
+
 .. _visualization.scatter_matrix:
 
 Scatter plot matrix

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -309,6 +309,11 @@ class TestSeriesPlots(tm.TestCase):
         with tm.assertRaises(TypeError):
             s.plot(yerr=s_err)
 
+    def test_table(self):
+        _check_plot_works(self.series.plot, table=True)
+        _check_plot_works(self.series.plot, table=self.series)
+
+
 @tm.mplskip
 class TestDataFramePlots(tm.TestCase):
     def setUp(self):
@@ -1334,6 +1339,18 @@ class TestDataFramePlots(tm.TestCase):
             df.plot(yerr=err.T)
 
         tm.close()
+
+    def test_table(self):
+        df = DataFrame(np.random.rand(10, 3),
+                       index=list(string.ascii_letters[:10]))
+        _check_plot_works(df.plot, table=True)
+        _check_plot_works(df.plot, table=df)
+
+        ax = df.plot()
+        self.assert_(len(ax.tables) == 0)
+        plotting.table(ax, df.T)
+        self.assert_(len(ax.tables) == 1)
+
 
 @tm.mplskip
 class TestDataFrameGroupByPlots(tm.TestCase):


### PR DESCRIPTION
closes #4803

Related to #4803, I prepared some codes to add a `matplotlib.Table` to `DataFrame` and `Series` plot using `table` keyword. `table` can take followings as an input:
- `False`: Do nothing (default).
- `True`: Draw a table using the data called `plot` method. Data will be transposed to meet the matplotlib's default layout.
- `DataFrame` or `Series`: Draw matplotlib.table using the passed data. The data will be drawn as displayed in print method (not transposed automatically).

Also, helper function `pandas.tools.plotting.table` is added to create a table from `DataFrame` and `Series`, and add it to the `matplotlib.Axes`.

_Example:_

```
fig, axes = plt.subplots(1, 3, figsize=(14, 4))
plt.subplots_adjust(top=0.97, bottom=0.2, left=0.05, right=0.97, hspace=0.2)

df.plot(ax=axes[0], table=True, legend=False)
axes[0].get_xaxis().set_visible(False)

df.plot(ax=axes[1], table=np.round(df.T, 2), legend=False)
axes[1].get_xaxis().set_visible(False)

df.plot(ax=axes[2], legend=False)

import pandas.tools.plotting as plotting
plotting.table(axes[2], np.round(df.describe(), 2),
               loc='upper right', colWidths=[0.2, 0.2, 0.2])

plt.show()
```

_Outputs:_
![figure_table](https://f.cloud.github.com/assets/1696302/2448693/7d4028e6-aea9-11e3-9a2e-f36087638dac.png)
