### PR TITLE
Add an 'escape' keyword to DataFrame.to_latex

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -254,6 +254,7 @@ Improvements to existing features
 - Performance improvement for ``DataFrame.from_records`` when reading a
   specified number of rows from an iterable (:issue:`6700`)
 - :ref:`Holidays and holiday calendars<timeseries.holiday>` are now available and can be used with CustomBusinessDay (:issue:`6719`)
+- Add option to turn off escaping in ``DataFrame.to_latex``
 
 .. _release.bug_fixes-0.14.0:
 

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -422,6 +422,7 @@ class DataFrameFormatter(TableFormatter):
         """
         Render a DataFrame to a LaTeX tabular/longtable environment output.
         """
+        self.escape = self.kwds.get('escape', True)
         #TODO: column_format is not settable in df.to_latex
         def get_col_type(dtype):
             if issubclass(dtype.type, np.number):
@@ -471,16 +472,19 @@ class DataFrameFormatter(TableFormatter):
                         buf.write('\endfoot\n\n')
                         buf.write('\\bottomrule\n')
                         buf.write('\\endlastfoot\n')
-                crow = [(x.replace('\\', '\\textbackslash') # escape backslashes first
-                         .replace('_', '\\_')
-                         .replace('%', '\\%')
-                         .replace('$', '\\$')
-                         .replace('#', '\\#')
-                         .replace('{', '\\{')
-                         .replace('}', '\\}')
-                         .replace('~', '\\textasciitilde')
-                         .replace('^', '\\textasciicircum')
-                         .replace('&', '\\&') if x else '{}') for x in row]
+                if self.escape:
+                  crow = [(x.replace('\\', '\\textbackslash') # escape backslashes first
+                           .replace('_', '\\_')
+                           .replace('%', '\\%')
+                           .replace('$', '\\$')
+                           .replace('#', '\\#')
+                           .replace('{', '\\{')
+                           .replace('}', '\\}')
+                           .replace('~', '\\textasciitilde')
+                           .replace('^', '\\textasciicircum')
+                           .replace('&', '\\&') if x else '{}') for x in row]
+                else:
+                  crow = [x if x else '{}' for x in row]
                 buf.write(' & '.join(crow))
                 buf.write(' \\\\\n')
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1348,7 +1348,7 @@ class DataFrame(NDFrame):
     def to_latex(self, buf=None, columns=None, col_space=None, colSpace=None,
                  header=True, index=True, na_rep='NaN', formatters=None,
                  float_format=None, sparsify=None, index_names=True,
-                 bold_rows=True, longtable=False):
+                 bold_rows=True, longtable=False, escape=True):
         """
         Render a DataFrame to a tabular environment table. You can splice
         this into a LaTeX document. Requires \\usepackage(booktabs}.
@@ -1360,6 +1360,9 @@ class DataFrame(NDFrame):
         longtable : boolean, default False
             Use a longtable environment instead of tabular. Requires adding
             a \\usepackage{longtable} to your LaTeX preamble.
+        escape : boolean, default True
+            When set to False prevents from escaping latex special
+            characters in column names.
 
         """
 
@@ -1375,7 +1378,8 @@ class DataFrame(NDFrame):
                                            float_format=float_format,
                                            bold_rows=bold_rows,
                                            sparsify=sparsify,
-                                           index_names=index_names)
+                                           index_names=index_names,
+                                           escape=escape)
         formatter.to_latex(longtable=longtable)
 
         if buf is None:

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -1671,6 +1671,40 @@ c  10  11  12  13  14\
 """
         self.assertEqual(withoutindex_result, withoutindex_expected)
 
+    def test_to_latex_escape(self):
+        a = 'a'
+        b = 'b'
+
+        test_dict = {u('co^l1')  : {a: "a",
+                                    b: "b"},
+                     u('co$e^x$'): {a: "a",
+                                    b: "b"}}
+
+        unescaped_result = pd.DataFrame(test_dict).to_latex(escape=False)
+        escaped_result   = pd.DataFrame(test_dict).to_latex() # default: escape=True
+
+        unescaped_expected = r'''\begin{tabular}{lll}
+\toprule
+{} & co$e^x$ & co^l1 \\
+\midrule
+a &       a &     a \\
+b &       b &     b \\
+\bottomrule
+\end{tabular}
+'''
+
+        escaped_expected = r'''\begin{tabular}{lll}
+\toprule
+{} & co\$e\textasciicircumx\$ & co\textasciicircuml1 \\
+\midrule
+a &       a &     a \\
+b &       b &     b \\
+\bottomrule
+\end{tabular}
+'''
+        self.assertEqual(unescaped_result, unescaped_expected)
+        self.assertEqual(escaped_result, escaped_expected)
+
     def test_to_latex_longtable(self):
         self.frame.to_latex(longtable=True)
 


### PR DESCRIPTION
closes #6472

The new keyword prevents the conversion from escaping column names

Currently, a sequence like $e^x$ gets properly formatted when you display a dataframe in an ipython notebook, but gets escaped when converted to latex.
