### PR TITLE
BUG: Seed RNG in test_partially_invalid_plot_data

### DIFF
--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1106,13 +1106,13 @@ class TestDataFramePlots(tm.TestCase):
 
     @slow
     def test_partially_invalid_plot_data(self):
-        np.random.seed(42)
-        kinds = 'line', 'bar', 'barh', 'kde', 'density'
-        df = DataFrame(randn(10, 2), dtype=object)
-        df[np.random.rand(df.shape[0]) > 0.5] = 'a'
-        for kind in kinds:
-            with tm.assertRaises(TypeError):
-                df.plot(kind=kind)
+        with tm.RNGContext(42):
+            kinds = 'line', 'bar', 'barh', 'kde', 'density'
+            df = DataFrame(randn(10, 2), dtype=object)
+            df[np.random.rand(df.shape[0]) > 0.5] = 'a'
+            for kind in kinds:
+                with tm.assertRaises(TypeError):
+                    df.plot(kind=kind)
 
     def test_invalid_kind(self):
         df = DataFrame(randn(10, 2))

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1106,6 +1106,7 @@ class TestDataFramePlots(tm.TestCase):
 
     @slow
     def test_partially_invalid_plot_data(self):
+        np.random.seed(42)
         kinds = 'line', 'bar', 'barh', 'kde', 'density'
         df = DataFrame(randn(10, 2), dtype=object)
         df[np.random.rand(df.shape[0]) > 0.5] = 'a'

--- a/pandas/tests/test_testing.py
+++ b/pandas/tests/test_testing.py
@@ -8,7 +8,8 @@ import numpy as np
 import sys
 from pandas import Series
 from pandas.util.testing import (
-    assert_almost_equal, assertRaisesRegexp, raise_with_traceback, assert_series_equal
+    assert_almost_equal, assertRaisesRegexp, raise_with_traceback, assert_series_equal,
+    RNGContext
 )
 
 # let's get meta.
@@ -153,3 +154,14 @@ class TestAssertSeriesEqual(unittest.TestCase):
         # ATM meta data is not checked in assert_series_equal
         # self._assert_not_equal(Series(range(3)),Series(range(3),name='foo'),check_names=True)
 
+
+class TestRNGContext(unittest.TestCase):
+
+    def test_RNGContext(self):
+        expected0 = 1.764052345967664
+        expected1 = 1.6243453636632417
+
+        with RNGContext(0):
+            with RNGContext(1):
+                self.assertEqual(np.random.randn(), expected1)
+            self.assertEqual(np.random.randn(), expected0)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1528,3 +1528,33 @@ def skip_if_no_ne(engine='numexpr'):
 def disabled(t):
     t.disabled = True
     return t
+
+
+class RNGContext(object):
+    """
+    Context manager to set the numpy random number generator speed. Returns
+    to the original value upon exiting the context manager.
+
+    Parameters
+    ----------
+    seed : int
+        Seed for numpy.random.seed
+
+    Examples
+    --------
+
+    with RNGContext(42):
+        np.random.randn()
+    """
+
+    def __init__(self, seed):
+        self.seed = seed
+
+    def __enter__(self):
+
+        self.start_state = np.random.get_state()
+        np.random.seed(self.seed)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+
+        np.random.set_state(self.start_state)


### PR DESCRIPTION
Came up upon merging another PR. See comment https://github.com/pydata/pandas/pull/6644#issuecomment-38057195

The test relies on drawing at least 1 draw out of 10 uniform draw to be larger than 0.5; even if this didn't cause the failure originally, it should still be fixed. I set a seed that's known to produce the desired values.
