### PR TITLE
BUG: legend behaves inconsistently when plotting to the same axes 

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -384,6 +384,7 @@ Bug Fixes
   group match wasn't renamed to the group name
 - Bug in ``DataFrame.to_csv`` where setting `index` to `False` ignored the
   `header` kwarg (:issue:`6186`)
+- Bug in `DataFrame.plot` and `Series.plot` legend behave inconsistently when plotting to the same axes repeatedly (:issue:`6678`)
 
 pandas 0.13.1
 -------------

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -66,7 +66,7 @@ for controlling the look of the plot:
 .. ipython:: python
 
    @savefig series_plot_basic2.png
-   plt.figure(); ts.plot(style='k--', label='Series'); plt.legend()
+   plt.figure(); ts.plot(style='k--', label='Series');
 
 On DataFrame, ``plot`` is a convenience to plot all of the columns with labels:
 
@@ -76,7 +76,7 @@ On DataFrame, ``plot`` is a convenience to plot all of the columns with labels:
    df = df.cumsum()
 
    @savefig frame_plot_basic.png
-   plt.figure(); df.plot(); plt.legend(loc='best')
+   plt.figure(); df.plot();
 
 You may set the ``legend`` argument to ``False`` to hide the legend, which is
 shown by default.
@@ -91,7 +91,7 @@ Some other options are available, like plotting each Series on a different axis:
 .. ipython:: python
 
    @savefig frame_plot_subplots.png
-   df.plot(subplots=True, figsize=(6, 6)); plt.legend(loc='best')
+   df.plot(subplots=True, figsize=(6, 6));
 
 You may pass ``logy`` to get a log-scale Y axis.
 


### PR DESCRIPTION
There seems to be some inconsistencies related to `DataFrame.plot` and `Series.plot` legend behaviors.

_Problems:_
- When `DataFrame.plot` or `Series.plot` plots data on the same axes repeatedly:
  - If the target axes already has a legend, line plot always appends its legend to existing one ignoring `legend` kw and existing legend will be drawn as line artist regardless of actual artist type. Also, legend cannot be `reverse`ed if the axes already has a legend.
  - Bar/BarH plot deletes the existing legend and overwrites with latest one.
  - KDE plot appends its legend to the existing one, and will apply `reverse` to all artists including the existing one.
- When `subplots` is enabled, line plot draws legends on each axes but bar plot doesn't.
- Scatter plot does not draw legend even if `label` keyword is passed.

_Fix:_
I've prepared a fix based on following concept, except `hexbin` which doesn't use legend.
- Legend should be drawn by the order of the artists drawn.
- Each legend should be drawn according to the passed `legend` value.
  - If df1 plots with `legend=True` and df2 with `legend=False`, only df1's legend should appear.
  - If df2 plots with `legend='reverse'`d, only df2's legend should be reversed.
- When `subplots=True` and `legend=True`, each subplot axes should have its own legend (standardize current line plot behavior). 

_Example Code_

```
df1 = DataFrame(randn(6, 3), index=range(6), columns=['a', 'b', 'c'])
df2 = DataFrame(randn(6, 3), index=range(6), columns=['d', 'e', 'f'])
df3 = DataFrame(randn(6, 3), index=range(6), columns=['x', 'y', 'z'])

fig, axes = plt.subplots(1, 5, figsize=(14, 3))
for i, (legend, df) in enumerate(zip([True, False, 'reverse'], [df1, df2, df3])):
    df.plot(ax=axes[0],  legend=legend, title='line')
    df.plot(kind='bar', ax=axes[1], legend=legend, title='bar')
    df.plot(kind='barh', ax=axes[2],  legend=legend, title='barh')
    df.plot(kind='kde', ax=axes[3],  legend=legend, title='kde')
    df.plot(kind='scatter', ax=axes[4], x=df.columns[0], y=df.columns[1], label=i, 
        legend=legend, title='scatter')
plt.show()
```

_Output using current repository_
- For line, bar, kde plot, expected legend is `a, b, c, z, y x`. Because df2 was plot by `legend=False`, and df3 was plot by `legend='reverse'`.
- For scatter plot, `0, 2` is expected because df2 was plot by `legend=False`.

![figure_legend_current](https://f.cloud.github.com/assets/1696302/2480801/ba3c694a-b0c9-11e3-8f5b-d2ebec0798e3.png)

_Output after fix_
![figure_fixed](https://f.cloud.github.com/assets/1696302/2480773/b1bd8f70-b0c8-11e3-9654-3e3c2b20157b.png)

If there is anything should be considered, please let me know. Thanks.
