### PR TITLE
BUG: Bug in binary operations with a rhs of a Series not aligning (GH6681)

### DIFF
--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -140,10 +140,9 @@ either match on the *index* or *columns* via the **axis** keyword:
 
 .. ipython:: python
 
-   d = {'one' : Series(randn(3), index=['a', 'b', 'c']),
-        'two' : Series(randn(4), index=['a', 'b', 'c', 'd']),
-        'three' : Series(randn(3), index=['b', 'c', 'd'])}
-   df = df_orig = DataFrame(d)
+   df = DataFrame({'one' : Series(randn(3), index=['a', 'b', 'c']),
+                   'two' : Series(randn(4), index=['a', 'b', 'c', 'd']),
+                   'three' : Series(randn(3), index=['b', 'c', 'd'])})
    df
    row = df.ix[1]
    column = df['two']
@@ -153,6 +152,20 @@ either match on the *index* or *columns* via the **axis** keyword:
 
    df.sub(column, axis='index')
    df.sub(column, axis=0)
+
+.. ipython:: python
+   :suppress:
+
+   df_orig = df
+
+Furthermore you can align a level of a multi-indexed DataFrame with a Series.
+
+.. ipython:: python
+
+   dfmi = df.copy()
+   dfmi.index = MultiIndex.from_tuples([(1,'a'),(1,'b'),(1,'c'),(2,'a')],
+                                       names=['first','second'])
+   dfmi.sub(column, axis=0, level='second')
 
 With Panel, describing the matching behavior is a bit more difficult, so
 the arithmetic methods instead (and perhaps confusingly?) give you the option

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1843,11 +1843,11 @@ the sheet names using the ``sheet_names`` attribute.
 .. versionadded:: 0.13
 
 There are now two ways to read in sheets from an Excel file. You can provide
-either the index of a sheet or its name to by passing different values for 
-``sheet_name``. 
+either the index of a sheet or its name to by passing different values for
+``sheet_name``.
 
 - Pass a string to refer to the name of a particular sheet in the workbook.
-- Pass an integer to refer to the index of a sheet. Indices follow Python 
+- Pass an integer to refer to the index of a sheet. Indices follow Python
   convention, beginning at 0.
 - The default value is ``sheet_name=0``. This reads the first sheet.
 

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -268,6 +268,7 @@ Bug Fixes
 - Bug in ``fillna`` with ``limit`` and ``value`` specified
 - Bug in ``DataFrame.to_stata`` when columns have non-string names (:issue:`4558`)
 - Bug in compat with ``np.compress``, surfaced in (:issue:`6658`)
+- Bug in binary operations with a rhs of a Series not aligning (:issue:`6681`)
 
 pandas 0.13.1
 -------------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2801,12 +2801,12 @@ class DataFrame(NDFrame):
         if axis is not None:
             axis = self._get_axis_name(axis)
             if axis == 'index':
-                return self._combine_match_index(other, func, fill_value)
+                return self._combine_match_index(other, func, level=level, fill_value=fill_value)
             else:
-                return self._combine_match_columns(other, func, fill_value)
-        return self._combine_series_infer(other, func, fill_value)
+                return self._combine_match_columns(other, func, level=level, fill_value=fill_value)
+        return self._combine_series_infer(other, func, level=level, fill_value=fill_value)
 
-    def _combine_series_infer(self, other, func, fill_value=None):
+    def _combine_series_infer(self, other, func, level=None, fill_value=None):
         if len(other) == 0:
             return self * NA
 
@@ -2822,12 +2822,12 @@ class DataFrame(NDFrame):
                            "DataFrame.<op> to explicitly broadcast arithmetic "
                            "operations along the index"),
                           FutureWarning)
-            return self._combine_match_index(other, func, fill_value)
+            return self._combine_match_index(other, func, level=level, fill_value=fill_value)
         else:
-            return self._combine_match_columns(other, func, fill_value)
+            return self._combine_match_columns(other, func, level=level, fill_value=fill_value)
 
-    def _combine_match_index(self, other, func, fill_value=None):
-        left, right = self.align(other, join='outer', axis=0, copy=False)
+    def _combine_match_index(self, other, func, level=None, fill_value=None):
+        left, right = self.align(other, join='outer', axis=0, level=level, copy=False)
         if fill_value is not None:
             raise NotImplementedError("fill_value %r not supported." %
                                       fill_value)
@@ -2835,8 +2835,8 @@ class DataFrame(NDFrame):
                                  index=left.index,
                                  columns=self.columns, copy=False)
 
-    def _combine_match_columns(self, other, func, fill_value=None):
-        left, right = self.align(other, join='outer', axis=1, copy=False)
+    def _combine_match_columns(self, other, func, level=None, fill_value=None):
+        left, right = self.align(other, join='outer', axis=1, level=level, copy=False)
         if fill_value is not None:
             raise NotImplementedError("fill_value %r not supported" %
                                       fill_value)

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -456,10 +456,12 @@ class SparseDataFrame(DataFrame):
                                  default_fill_value=new_fill_value,
                                  fill_value=new_fill_value).__finalize__(self)
 
-    def _combine_match_index(self, other, func, fill_value=None):
+    def _combine_match_index(self, other, func, level=None, fill_value=None):
         new_data = {}
 
         if fill_value is not None:
+            raise NotImplementedError
+        if level is not None:
             raise NotImplementedError
 
         new_index = self.index.union(other.index)
@@ -486,13 +488,15 @@ class SparseDataFrame(DataFrame):
                                  default_fill_value=fill_value,
                                  fill_value=self.default_fill_value).__finalize__(self)
 
-    def _combine_match_columns(self, other, func, fill_value):
+    def _combine_match_columns(self, other, func, level=None, fill_value=None):
         # patched version of DataFrame._combine_match_columns to account for
         # NumPy circumventing __rsub__ with float64 types, e.g.: 3.0 - series,
         # where 3.0 is numpy.float64 and series is a SparseSeries. Still
         # possible for this to happen, which is bothersome
 
         if fill_value is not None:
+            raise NotImplementedError
+        if level is not None:
             raise NotImplementedError
 
         new_data = {}


### PR DESCRIPTION
closes #6681

```
In [11]:         index=MultiIndex.from_product([list('abc'),
                                       ['one','two','three'],
                                       [1,2,3]],
                                      names=['first','second','third'])

In [12]:         df = DataFrame(np.arange(27*3).reshape(27,3),
                       index=index,
                       columns=['value1','value2','value3']).sortlevel()

In [13]: df
Out[13]: 
                    value1  value2  value3
first second third                        
a     one    1           0       1       2
             2           3       4       5
             3           6       7       8
      three  1          18      19      20
             2          21      22      23
             3          24      25      26
      two    1           9      10      11
             2          12      13      14
             3          15      16      17
b     one    1          27      28      29
             2          30      31      32
             3          33      34      35
      three  1          45      46      47
             2          48      49      50
             3          51      52      53
      two    1          36      37      38
             2          39      40      41
             3          42      43      44
c     one    1          54      55      56
             2          57      58      59
             3          60      61      62
      three  1          72      73      74
             2          75      76      77
             3          78      79      80
      two    1          63      64      65
             2          66      67      68
             3          69      70      71

[27 rows x 3 columns]

In [15]: x = Series([ 1.0, 10.0], ['two','three'])

In [16]: x
Out[16]: 
two       1
three    10
dtype: float64
```

Passing a level now aligns by that level

```
In [14]: df.mul(x,level='second',axis=0)
Out[14]: 
                    value1  value2  value3
first second third                        
a     one    1         NaN     NaN     NaN
             2         NaN     NaN     NaN
             3         NaN     NaN     NaN
      three  1         180     190     200
             2         210     220     230
             3         240     250     260
      two    1           9      10      11
             2          12      13      14
             3          15      16      17
b     one    1         NaN     NaN     NaN
             2         NaN     NaN     NaN
             3         NaN     NaN     NaN
      three  1         450     460     470
             2         480     490     500
             3         510     520     530
      two    1          36      37      38
             2          39      40      41
             3          42      43      44
c     one    1         NaN     NaN     NaN
             2         NaN     NaN     NaN
             3         NaN     NaN     NaN
      three  1         720     730     740
             2         750     760     770
             3         780     790     800
      two    1          63      64      65
             2          66      67      68
             3          69      70      71

[27 rows x 3 columns]
```
