### PR TITLE
BUG: NaN values not converted to Stata missing values (GH6684)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -269,6 +269,7 @@ Bug Fixes
 - Bug in ``DataFrame.to_stata`` when columns have non-string names (:issue:`4558`)
 - Bug in compat with ``np.compress``, surfaced in (:issue:`6658`)
 - Bug in binary operations with a rhs of a Series not aligning (:issue:`6681`)
+- Bug in ``DataFrame.to_stata`` which incorrectly handles nan values and ignores 'with_index' keyword argument (:issue:`6685`)
 
 pandas 0.13.1
 -------------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1258,7 +1258,8 @@ class DataFrame(NDFrame):
         from pandas.io.stata import StataWriter
         writer = StataWriter(fname, self, convert_dates=convert_dates,
                              encoding=encoding, byteorder=byteorder,
-                             time_stamp=time_stamp, data_label=data_label)
+                             time_stamp=time_stamp, data_label=data_label,
+                             write_index=write_index)
         writer.write_file()
 
     @Appender(fmt.docstring_to_string, indents=1)


### PR DESCRIPTION
closes #6684

Stata does not correctly handle NaNs, and so these must be replaced with Stata
missing values (. by default).  The fix checks floating point columns for nan
and replaces these with the Stata numeric code for (.).

The write_index option was also being ignored by omission. This has been fixed and
numerous tests which were not correct have been fixed.
