### PR TITLE
ENH/VIS: Dataframe bar plot can now handle align keyword properly

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -135,10 +135,16 @@ API Changes
   the index, rather than requiring a list of tuple (:issue:`4370`)
 
 - Fix a bug where invalid eval/query operations would blow the stack (:issue:`5198`)
+
 - Following keywords are now acceptable for :meth:`DataFrame.plot(kind='bar')` and :meth:`DataFrame.plot(kind='barh')`.
-  - `width`: Specify the bar width. In previous versions, static value 0.5 was passed to matplotlib and it cannot be overwritten.
+
+  - `width`: Specify the bar width. In previous versions, static value 0.5 was passed to matplotlib and it cannot be overwritten. (:issue:`6604`)
+  
+  - `align`: Specify the bar alignment. Default is `center` (different from matplotlib). In previous versions, pandas passes `align='edge'` to matplotlib and adjust the location to `center` by itself, and it results `align` keyword is not applied as expected. (:issue:`4525`)
+  
   - `position`: Specify relative alignments for bar plot layout. From 0 (left/bottom-end) to 1(right/top-end). Default is 0.5 (center). (:issue:`6604`)
-  - Define and document the order of column vs index names in query/eval
+  
+- Define and document the order of column vs index names in query/eval
     (:issue:`6676`)
 
 Deprecations

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -174,8 +174,14 @@ These are out-of-bounds selections
     df_multi.set_index([df_multi.index, df_multi.index])
 
 - Following keywords are now acceptable for :meth:`DataFrame.plot(kind='bar')` and :meth:`DataFrame.plot(kind='barh')`.
-  - `width`: Specify the bar width. In previous versions, static value 0.5 was passed to matplotlib and it cannot be overwritten.
+
+  - `width`: Specify the bar width. In previous versions, static value 0.5 was passed to matplotlib and it cannot be overwritten. (:issue:`6604`)
+
+  - `align`: Specify the bar alignment. Default is `center` (different from matplotlib). In previous versions, pandas passes `align='edge'` to matplotlib and adjust the location to `center` by itself, and it results `align` keyword is not applied as expected. (:issue:`4525`)
+
   - `position`: Specify relative alignments for bar plot layout. From 0 (left/bottom-end) to 1(right/top-end). Default is 0.5 (center). (:issue:`6604`)
+
+   Because of the default `align` value changes, coordinates of bar plots are now located on integer values (0.0, 1.0, 2.0 ...). This is intended to make bar plot be located on the same coodinates as line plot. However, bar plot may differs unexpectedly when you manually adjust the bar location or drawing area, such as using `set_xlim`, `set_ylim`, etc. In this cases, please modify your script to meet with new coordinates. 
 
 
 MultiIndexing Using Slicers


### PR DESCRIPTION
Closes #4525.

I modified the `BarPlot` internal alignment to meet line coordinates. Previously, `BarPlot` doesn't pass `align` keyword to matplotlib (thus matplotlib uses `align='edge'`), but it adjusts bar locations to looks like `align='center'`.

Now `BarPlot` pass `align=center` to matplotlib by default and ticks are being locates on integer value starts from 0 (0.0, 1.0 ...). Drawing bar and line on the same axes looks like below.

_Output using current master:_
![align_incorrect](https://f.cloud.github.com/assets/1696302/2492234/0df22b26-b21c-11e3-8a96-95cffa20a7c6.png)

_Output after fix_
![align_correct](https://f.cloud.github.com/assets/1696302/2492238/5f5bc26a-b21c-11e3-9b70-76892cea9eca.png)
