### PR TITLE
DEPR: Deprecate cols in several functions

### DIFF
--- a/doc/source/comparison_with_r.rst
+++ b/doc/source/comparison_with_r.rst
@@ -171,7 +171,7 @@ In ``pandas`` we may use :meth:`~pandas.pivot_table` method to handle this:
       'player': random.sample(list(string.ascii_lowercase),25),
       'batting avg': np.random.uniform(.200, .400, 25)
       })
-   baseball.pivot_table(values='batting avg', cols='team', aggfunc=np.max)
+   baseball.pivot_table(values='batting avg', columns='team', aggfunc=np.max)
 
 For more details and examples see :ref:`the reshaping documentation
 <reshaping.pivot>`.
@@ -402,8 +402,8 @@ In Python the best way is to make use of :meth:`~pandas.pivot_table`:
         'week': [1,2]*6
    })
    mdf = pd.melt(df, id_vars=['month', 'week'])
-   pd.pivot_table(mdf, values='value', rows=['variable','week'],
-                    cols=['month'], aggfunc=np.mean)
+   pd.pivot_table(mdf, values='value', index=['variable','week'],
+                    columns=['month'], aggfunc=np.mean)
 
 Similarly for ``dcast`` which uses a data.frame called ``df`` in R to
 aggregate information based on ``Animal`` and ``FeedType``:
@@ -433,7 +433,7 @@ using :meth:`~pandas.pivot_table`:
        'Amount': [10, 7, 4, 2, 5, 6, 2],
    })
 
-   df.pivot_table(values='Amount', rows='Animal', cols='FeedType', aggfunc='sum')
+   df.pivot_table(values='Amount', index='Animal', columns='FeedType', aggfunc='sum')
 
 The second approach is to use the :meth:`~pandas.DataFrame.groupby` method:
 

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -129,11 +129,6 @@ API Changes
     ``DataFrame.stack`` operations where the name of the column index is used as
     the name of the inserted column containing the pivoted data.
 
-- The :func:`pivot_table`/:meth:`DataFrame.pivot_table` and :func:`crosstab` functions
-  now take arguments ``index`` and ``columns`` instead of ``rows`` and ``cols``.  A
-  ``FutureWarning`` is raised  to alert that the old ``rows`` and ``cols`` arguments
-  will not be supported in a future release (:issue:`5505`)
-
 - Allow specification of a more complex groupby, via ``pd.Grouper`` (:issue:`3794`)
 
 - A tuple passed to ``DataFame.sort_index`` will be interpreted as the levels of
@@ -148,6 +143,21 @@ API Changes
 
 Deprecations
 ~~~~~~~~~~~~
+
+- The :func:`pivot_table`/:meth:`DataFrame.pivot_table` and :func:`crosstab` functions
+  now take arguments ``index`` and ``columns`` instead of ``rows`` and ``cols``.  A
+  ``FutureWarning`` is raised  to alert that the old ``rows`` and ``cols`` arguments
+  will not be supported in a future release (:issue:`5505`)
+
+- The :meth:`DataFrame.drop_duplicates` and :meth:`DataFrame.duplicated` methods
+  now take argument ``subset`` instead of ``cols`` to better align with
+  :meth:`DataFrame.dropna`.  A ``FutureWarning`` is raised  to alert that the old
+  ``cols`` arguments will not be supported in a future release (:issue:`6680`)
+
+- The :meth:`DataFrame.to_csv` and :meth:`DataFrame.to_excel` functions
+  now takes argument ``columns`` instead of ``cols``.  A
+  ``FutureWarning`` is raised  to alert that the old ``cols`` arguments
+  will not be supported in a future release (:issue:`6645`)
 
 Prior Version Deprecations/Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/reshaping.rst
+++ b/doc/source/reshaping.rst
@@ -283,9 +283,9 @@ We can produce pivot tables from this data very easily:
 
 .. ipython:: python
 
-   pivot_table(df, values='D', rows=['A', 'B'], cols=['C'])
-   pivot_table(df, values='D', rows=['B'], cols=['A', 'C'], aggfunc=np.sum)
-   pivot_table(df, values=['D','E'], rows=['B'], cols=['A', 'C'], aggfunc=np.sum)
+   pivot_table(df, values='D', index=['A', 'B'], columns=['C'])
+   pivot_table(df, values='D', index=['B'], columns=['A', 'C'], aggfunc=np.sum)
+   pivot_table(df, values=['D','E'], index=['B'], columns=['A', 'C'], aggfunc=np.sum)
 
 The result object is a DataFrame having potentially hierarchical indexes on the
 rows and columns. If the ``values`` column name is not given, the pivot table
@@ -294,14 +294,14 @@ hierarchy in the columns:
 
 .. ipython:: python
 
-   pivot_table(df, rows=['A', 'B'], cols=['C'])
+   pivot_table(df, index=['A', 'B'], columns=['C'])
 
 You can render a nice output of the table omitting the missing values by
 calling ``to_string`` if you wish:
 
 .. ipython:: python
 
-   table = pivot_table(df, rows=['A', 'B'], cols=['C'])
+   table = pivot_table(df, index=['A', 'B'], columns=['C'])
    print(table.to_string(na_rep=''))
 
 Note that ``pivot_table`` is also available as an instance method on DataFrame.
@@ -315,8 +315,8 @@ unless an array of values and an aggregation function are passed.
 
 It takes a number of arguments
 
-- ``rows``: array-like, values to group by in the rows
-- ``cols``: array-like, values to group by in the columns
+- ``index``: array-like, values to group by in the rows
+- ``columns``: array-like, values to group by in the columns
 - ``values``: array-like, optional, array of values to aggregate according to
   the factors
 - ``aggfunc``: function, optional, If no values array is passed, computes a
@@ -350,7 +350,7 @@ rows and columns:
 
 .. ipython:: python
 
-   df.pivot_table(rows=['A', 'B'], cols='C', margins=True, aggfunc=np.std)
+   df.pivot_table(index=['A', 'B'], columns='C', margins=True, aggfunc=np.std)
 
 .. _reshaping.tile:
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -173,11 +173,6 @@ These are out-of-bounds selections
     # New output, 4-level MultiIndex
     df_multi.set_index([df_multi.index, df_multi.index])
 
-- The :func:`pivot_table`/:meth:`DataFrame.pivot_table` and :func:`crosstab` functions
-  now take arguments ``index`` and ``columns`` instead of ``rows`` and ``cols``.  A
-  ``FutureWarning`` is raised  to alert that the old ``rows`` and ``cols`` arguments
-  will not be supported in a future release (:issue:`5505`)
-
 - Following keywords are now acceptable for :meth:`DataFrame.plot(kind='bar')` and :meth:`DataFrame.plot(kind='barh')`.
   - `width`: Specify the bar width. In previous versions, static value 0.5 was passed to matplotlib and it cannot be overwritten.
   - `position`: Specify relative alignments for bar plot layout. From 0 (left/bottom-end) to 1(right/top-end). Default is 0.5 (center). (:issue:`6604`)
@@ -313,8 +308,20 @@ Therse are prior version deprecations that are taking effect as of 0.14.0.
 
 Deprecations
 ~~~~~~~~~~~~
+- The :func:`pivot_table`/:meth:`DataFrame.pivot_table` and :func:`crosstab` functions
+  now take arguments ``index`` and ``columns`` instead of ``rows`` and ``cols``.  A
+  ``FutureWarning`` is raised  to alert that the old ``rows`` and ``cols`` arguments
+  will not be supported in a future release (:issue:`5505`)
 
-There are no deprecations of prior behavior in 0.14.0
+- The :meth:`DataFrame.drop_duplicates` and :meth:`DataFrame.duplicated` methods
+  now take argument ``subset`` instead of ``cols`` to better align with
+  :meth:`DataFrame.dropna`.  A ``FutureWarning`` is raised  to alert that the old
+  ``cols`` arguments will not be supported in a future release (:issue:`6680`)
+
+- The :meth:`DataFrame.to_csv` and :meth:`DataFrame.to_excel` functions
+  now takes argument ``columns`` instead of ``cols``.  A
+  ``FutureWarning`` is raised  to alert that the old ``cols`` arguments
+  will not be supported in a future release (:issue:`6645`)
 
 Enhancements
 ~~~~~~~~~~~~

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -396,6 +396,14 @@ class ExcelWriterBase(SharedItems):
 
             self.assertRaises(xlrd.XLRDError, xl.parse, '0')
 
+    def test_excel_deprecated_options(self):
+        with ensure_clean(self.ext) as path:
+            with tm.assert_produces_warning(FutureWarning):
+                self.frame.to_excel(path, 'test1', cols=['A', 'B'])
+    
+            with tm.assert_produces_warning(False):
+                self.frame.to_excel(path, 'test1', columns=['A', 'B'])
+
     def test_excelwriter_contextmanager(self):
         _skip_if_no_xlrd()
 
@@ -417,7 +425,7 @@ class ExcelWriterBase(SharedItems):
             self.frame['A'][:5] = nan
 
             self.frame.to_excel(path, 'test1')
-            self.frame.to_excel(path, 'test1', cols=['A', 'B'])
+            self.frame.to_excel(path, 'test1', columns=['A', 'B'])
             self.frame.to_excel(path, 'test1', header=False)
             self.frame.to_excel(path, 'test1', index=False)
 
@@ -479,7 +487,7 @@ class ExcelWriterBase(SharedItems):
         with ensure_clean(self.ext) as path:
             self.frame['A'][:5] = nan
             self.frame.to_excel(path, 'test1')
-            self.frame.to_excel(path, 'test1', cols=['A', 'B'])
+            self.frame.to_excel(path, 'test1', columns=['A', 'B'])
             self.frame.to_excel(path, 'test1', header=False)
             self.frame.to_excel(path, 'test1', index=False)
 
@@ -537,7 +545,7 @@ class ExcelWriterBase(SharedItems):
             self.frame['A'][:5] = nan
 
             self.frame.to_excel(path, 'test1')
-            self.frame.to_excel(path, 'test1', cols=['A', 'B'])
+            self.frame.to_excel(path, 'test1', columns=['A', 'B'])
             self.frame.to_excel(path, 'test1', header=False)
             self.frame.to_excel(path, 'test1', index=False)
 
@@ -562,7 +570,7 @@ class ExcelWriterBase(SharedItems):
             self.frame['A'][:5] = nan
 
             self.frame.to_excel(path, 'test1')
-            self.frame.to_excel(path, 'test1', cols=['A', 'B'])
+            self.frame.to_excel(path, 'test1', columns=['A', 'B'])
             self.frame.to_excel(path, 'test1', header=False)
             self.frame.to_excel(path, 'test1', index=False)
 
@@ -583,7 +591,7 @@ class ExcelWriterBase(SharedItems):
             self.frame['A'][:5] = nan
 
             self.frame.to_excel(path, 'test1')
-            self.frame.to_excel(path, 'test1', cols=['A', 'B'])
+            self.frame.to_excel(path, 'test1', columns=['A', 'B'])
             self.frame.to_excel(path, 'test1', header=False)
             self.frame.to_excel(path, 'test1', index=False)
 
@@ -630,7 +638,7 @@ class ExcelWriterBase(SharedItems):
 
             self.frame.to_excel(path,
                                 'test1',
-                                cols=['A', 'B', 'C', 'D'],
+                                columns=['A', 'B', 'C', 'D'],
                                 index=False, merge_cells=self.merge_cells)
             # take 'A' and 'B' as indexes (same row as cols 'C', 'D')
             df = self.frame.copy()
@@ -733,7 +741,7 @@ class ExcelWriterBase(SharedItems):
 
         with ensure_clean(self.ext) as path:
             frame.to_excel(path, 'test1', header=False)
-            frame.to_excel(path, 'test1', cols=['A', 'B'])
+            frame.to_excel(path, 'test1', columns=['A', 'B'])
 
             # round trip
             frame.to_excel(path, 'test1', merge_cells=self.merge_cells)
@@ -1020,7 +1028,7 @@ class ExcelWriterBase(SharedItems):
         with ensure_clean(self.ext) as path:
             write_frame = DataFrame({'A': [1, 1, 1],
                                      'B': [2, 2, 2]})
-            write_frame.to_excel(path, 'test1', cols=['B', 'A'])
+            write_frame.to_excel(path, 'test1', columns=['B', 'A'])
 
             read_frame = read_excel(path, 'test1', header=0)
 

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -725,7 +725,7 @@ class TestDataFrameFormatting(tm.TestCase):
                            'données1': np.random.randn(5),
                            'données2': np.random.randn(5)})
         # it works
-        df.pivot_table(rows=[u('clé1')], cols=[u('clé2')])._repr_html_()
+        df.pivot_table(index=[u('clé1')], columns=[u('clé2')])._repr_html_()
 
     def test_nonunicode_nonascii_alignment(self):
         df = DataFrame([["aa\xc3\xa4\xc3\xa4", 1], ["bbbb", 2]])

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -7,13 +7,15 @@ from pandas.core.index import MultiIndex
 from pandas.tools.merge import concat
 from pandas.tools.util import cartesian_product
 from pandas.compat import range, lrange, zip
+from pandas.util.decorators import deprecate_kwarg
 from pandas import compat
 import pandas.core.common as com
 import numpy as np
 
-
+@deprecate_kwarg(old_arg_name='cols', new_arg_name='columns')
+@deprecate_kwarg(old_arg_name='rows', new_arg_name='index')
 def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
-                fill_value=None, margins=False, dropna=True, **kwarg):
+                fill_value=None, margins=False, dropna=True):
     """
     Create a spreadsheet-style pivot table as a DataFrame. The levels in the
     pivot table will be stored in MultiIndex objects (hierarchical indexes) on
@@ -67,28 +69,6 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
     -------
     table : DataFrame
     """
-    # Parse old-style keyword arguments
-    rows = kwarg.pop('rows', None)
-    if rows is not None:
-        warnings.warn("rows is deprecated, use index", FutureWarning)
-        if index is None:
-            index = rows
-        else:
-            msg = "Can only specify either 'rows' or 'index'"
-            raise TypeError(msg)
-
-    cols = kwarg.pop('cols', None)
-    if cols is not None:
-        warnings.warn("cols is deprecated, use columns", FutureWarning)
-        if columns is None:
-            columns = cols
-        else:
-            msg = "Can only specify either 'cols' or 'columns'"
-            raise TypeError(msg)
-    
-    if kwarg:
-        raise TypeError("Unexpected argument(s): %s" % kwarg.keys())
-    
     index = _convert_by(index)
     columns = _convert_by(columns)
 
@@ -324,9 +304,10 @@ def _convert_by(by):
         by = list(by)
     return by
 
-
+@deprecate_kwarg(old_arg_name='cols', new_arg_name='columns')
+@deprecate_kwarg(old_arg_name='rows', new_arg_name='index')
 def crosstab(index, columns, values=None, rownames=None, colnames=None,
-             aggfunc=None, margins=False, dropna=True, **kwarg):
+             aggfunc=None, margins=False, dropna=True):
     """
     Compute a simple cross-tabulation of two (or more) factors. By default
     computes a frequency table of the factors unless an array of values and an
@@ -381,27 +362,6 @@ def crosstab(index, columns, values=None, rownames=None, colnames=None,
     -------
     crosstab : DataFrame
     """
-    # Parse old-style keyword arguments
-    rows = kwarg.pop('rows', None)
-    if rows is not None:
-        warnings.warn("rows is deprecated, use index", FutureWarning)
-        if index is None:
-            index = rows
-        else:
-            msg = "Can only specify either 'rows' or 'index'"
-            raise TypeError(msg)
-
-    cols = kwarg.pop('cols', None)
-    if cols is not None:
-        warnings.warn("cols is deprecated, use columns", FutureWarning)
-        if columns is None:
-            columns = cols
-        else:
-            msg = "Can only specify either 'cols' or 'columns'"
-            raise TypeError(msg)
-
-    if kwarg:
-        raise TypeError("Unexpected argument(s): %s" % kwarg.keys())
 
     index = com._maybe_make_list(index)
     columns = com._maybe_make_list(columns)

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -430,7 +430,7 @@ class TestCrosstab(tm.TestCase):
 
         df = DataFrame({'foo': a, 'bar': b, 'baz': c, 'values': values})
 
-        expected = df.pivot_table('values', index=['foo', 'bar'], cols='baz',
+        expected = df.pivot_table('values', index=['foo', 'bar'], columns='baz',
                                   aggfunc=np.sum)
         tm.assert_frame_equal(table, expected)
 


### PR DESCRIPTION
closes #6680 -- Deprecate `cols` in `drop_duplicates()` and `duplicated()` (rename to `subset`)
closes #6645 -- Deprecate `cols` in `to_csv()` and `to_excel()` (rename to `columns`)
releated to #6686 
Related #5505 -- Deprecate `cols` and `rows` in `pivot_table()` and `crosstab()` (rename to `columns` and `index`)

Related #6581 -- Reminder to come back in 0.16, remove deprecation warnings, and use new arguments
