### PR TITLE
Initial implementation of holiday and holiday calendar.

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -201,6 +201,7 @@ Improvements to existing features
 - Performance improvement when converting ``DatetimeIndex`` to floating ordinals
   using ``DatetimeConverter`` (:issue:`6636`)
 - Performance improvement for  ``DataFrame.shift`` (:issue: `5609`)
+- :ref:`Holidays and holiday calendars<timeseries.holiday>` are now available and can be used with CustomBusinessDay (:issue:`6719`)
 
 .. _release.bug_fixes-0.14.0:
 

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -732,9 +732,12 @@ Holidays and calendars provide a simple way to define holiday rules to be used
 with ``CustomBusinessDay`` or in other analysis that requires a predefined
 set of holidays.  The ``AbstractHolidayCalendar`` class provides all the necessary 
 methods to return a list of holidays and only ``rules`` need to be defined
-in a specific holiday calendar class.  ``USFederalHolidayCalendar`` is the only
-calendar that exists and primarily serves as an example for developing
-other holiday calendars.
+in a specific holiday calendar class.  Further, ``start_date`` and ``end_date``
+class attributes determine over what date range holidays are generated.  These
+should be overwritten on the ``AbstractHolidayCalendar`` class to have the range
+apply to all calendar subclasses.  ``USFederalHolidayCalendar`` is the 
+only calendar that exists and primarily serves as an example for developing 
+other calendars.
 
 For holidays that occur on fixed dates (e.g., US Memorial Day or July 4th) an 
 observance rule determines when that holiday is observed if it falls on a weekend
@@ -764,8 +767,13 @@ An example of how holidays and holiday calendars are defined:
                 offset=DateOffset(weekday=MO(2))), #same as 2*Week(weekday=2)
             ]
     cal = ExampleCalendar()
-    cal.holidays(datetime(2012, 1, 1), datetime(2012, 12, 31)) #holiday list
     datetime(2012, 5, 25) + CustomBusinessDay(calendar=cal)
+    cal.holidays(datetime(2012, 1, 1), datetime(2012, 12, 31))#holiday list
+    AbstractHolidayCalendar.start_date #default start date of range
+    AbstractHolidayCalendar.end_date #default end date of range
+    AbstractHolidayCalendar.start_date = datetime(2012, 1, 1)#or Timestamp
+    AbstractHolidayCalendar.end_date = datetime(2012, 12, 31)#or Timestamp
+    cal.holidays()
 
 Every calendar class is accessible by name using the ``get_calendar`` function
 which returns a holiday class instance.  Any imported calendar class will

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -730,8 +730,8 @@ Holidays / Holiday Calendars
 
 Holidays and calendars provide a simple way to define holiday rules to be used
 with ``CustomBusinessDay`` or in other analysis that requires a predefined
-set of holidays.  The ``AbstractHolidayCalendar`` class provides all the necessary methods
-to return a list of holidays and only the ``_rule_table`` needs to be defined
+set of holidays.  The ``AbstractHolidayCalendar`` class provides all the necessary 
+methods to return a list of holidays and only ``rules`` need to be defined
 in a specific holiday calendar class.
 
 Moreover, there are several observance functions that define how a fixed-date 
@@ -746,15 +746,30 @@ can easily be specified.
     from pandas.tseries.holiday import Holiday, USMemorialDay,\
         AbstractHolidayCalendar, Nearest, MO
     class ExampleCalendar(AbstractHolidayCalendar):
-        _rule_table = [
+        rules = [
             USMemorialDay,
             Holiday('July 4th', month=7, day=4, observance=Nearest),
             Holiday('Columbus Day', month=10, day=1, 
-                offset=DateOffset(weekday=MO(2))),
+                offset=DateOffset(weekday=MO(2))), #This could be 2*Week(weekday=2)
             ]
     cal = ExampleCalendar()
     cal.holidays(datetime(2012, 1, 1), datetime(2012, 12, 31)) #holiday list
     datetime(2012, 5, 25) + CustomBusinessDay(calendar=cal) #holiday arithmetic
+
+Every calendar class is accessible by name using the ``get_calendar`` function
+which returns a holiday class instance.  Any imported calendar class will
+automatically be available by this function.  Also, ``HolidayCalendarFactory``
+provides an easy interface to create calendars that are combinations of calendars
+or calendars with additional rules.
+
+.. ipython:: python
+
+    from pandas.tseries.holiday import get_calendar, HolidayCalendarFactory,\
+        USLaborDay
+    cal = get_calendar('ExampleCalendar')
+    cal.rules
+    new_cal = HolidayCalendarFactory('NewExampleCalendar', cal, USLaborDay)
+    new_cal.rules
 
 There are several defined US holidays in ``pandas.tseries.holiday`` along with
 several common holidays calendars.

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -546,6 +546,17 @@ calendars which account for local holidays and local weekend conventions.
     print(dts)
     print(Series(dts.weekday, dts).map(Series('Mon Tue Wed Thu Fri Sat Sun'.split())))
 
+As of v0.14 holiday calendars can be used to provide the list of holidays.  See the
+:ref:`holiday calendar<timeseries.holiday>` section for more information.
+
+.. ipython:: python
+
+    from pandas.tseries.holiday import USFederalHolidayCalendar
+    bday_us = CustomBusinessDay(calendar=USFederalHolidayCalendar())
+    dt = datetime(2014, 1, 17) #Friday before MLK Day
+    print(dt + bday_us) #Tuesday after MLK Day
+     
+
 .. note::
 
     The frequency string 'C' is used to indicate that a CustomBusinessDay
@@ -711,6 +722,42 @@ As you can see, legacy quarterly and annual frequencies are business quarter
 and business year ends. Please also note the legacy time rule for milliseconds
 ``ms`` versus the new offset alias for month start ``MS``. This means that
 offset alias parsing is case sensitive.
+
+.. _timeseries.holiday:
+
+Holidays / Holiday Calendars
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Holidays and calendars provide a simple way to define holiday rules to be used
+with ``CustomBusinessDay`` or in other analysis that requires a predefined
+set of holidays.  The ``AbstractHolidayCalendar`` class provides all the necessary methods
+to return a list of holidays and only the ``_rule_table`` needs to be defined
+in a specific holiday calendar class.
+
+Moreover, there are several observance functions that define how a fixed-date 
+holiday is observed.  For example, if Christmas falls on a weekend
+is may be observed on Friday if it falls on Saturday and Monday if it falls on 
+Sunday (``tseries.offsets.holiday.Nearest``) or only if it falls on Sunday
+is will be observed on Monday (``tseries.offsets.holiday.Sunday``).  Other rules
+can easily be specified.
+
+.. ipython:: python
+
+    from pandas.tseries.holiday import Holiday, USMemorialDay,\
+        AbstractHolidayCalendar, Nearest, MO
+    class ExampleCalendar(AbstractHolidayCalendar):
+        _rule_table = [
+            USMemorialDay,
+            Holiday('July 4th', month=7, day=4, observance=Nearest),
+            Holiday('Columbus Day', month=10, day=1, 
+                offset=DateOffset(weekday=MO(2))),
+            ]
+    cal = ExampleCalendar()
+    cal.holidays(datetime(2012, 1, 1), datetime(2012, 12, 31)) #holiday list
+    datetime(2012, 5, 25) + CustomBusinessDay(calendar=cal) #holiday arithmetic
+
+There are several defined US holidays in ``pandas.tseries.holiday`` along with
+several common holidays calendars.
 
 .. _timeseries.advanced_datetime:
 

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -732,7 +732,6 @@ Holidays and calendars provide a simple way to define holiday rules to be used
 with ``CustomBusinessDay`` or in other analysis that requires a predefined
 set of holidays.  The ``AbstractHolidayCalendar`` class provides all the necessary 
 methods to return a list of holidays and only ``rules`` need to be defined
-<<<<<<< HEAD
 in a specific holiday calendar class.  ``USFederalHolidayCalendar`` is the only
 calendar that exists and primarily serves as an example for developing
 other holiday calendars.
@@ -752,21 +751,10 @@ or some other non-observed day.  Defined observance rules are:
     "next_monday", "move Saturday and Sunday to following Monday"
 
 An example of how holidays and holiday calendars are defined:
-=======
-in a specific holiday calendar class.
-
-Moreover, there are several observance functions that define how a fixed-date 
-holiday is observed.  For example, if Christmas falls on a weekend
-is may be observed on Friday if it falls on Saturday and Monday if it falls on 
-Sunday (``tseries.offsets.holiday.Nearest``) or only if it falls on Sunday
-is will be observed on Monday (``tseries.offsets.holiday.Sunday``).  Other rules
-can easily be specified.
->>>>>>> FETCH_HEAD
 
 .. ipython:: python
 
     from pandas.tseries.holiday import Holiday, USMemorialDay,\
-<<<<<<< HEAD
         AbstractHolidayCalendar, nearest_workday, MO
     class ExampleCalendar(AbstractHolidayCalendar):
         rules = [
@@ -778,19 +766,6 @@ can easily be specified.
     cal = ExampleCalendar()
     cal.holidays(datetime(2012, 1, 1), datetime(2012, 12, 31)) #holiday list
     datetime(2012, 5, 25) + CustomBusinessDay(calendar=cal)
-=======
-        AbstractHolidayCalendar, Nearest, MO
-    class ExampleCalendar(AbstractHolidayCalendar):
-        rules = [
-            USMemorialDay,
-            Holiday('July 4th', month=7, day=4, observance=Nearest),
-            Holiday('Columbus Day', month=10, day=1, 
-                offset=DateOffset(weekday=MO(2))), #This could be 2*Week(weekday=2)
-            ]
-    cal = ExampleCalendar()
-    cal.holidays(datetime(2012, 1, 1), datetime(2012, 12, 31)) #holiday list
-    datetime(2012, 5, 25) + CustomBusinessDay(calendar=cal) #holiday arithmetic
->>>>>>> FETCH_HEAD
 
 Every calendar class is accessible by name using the ``get_calendar`` function
 which returns a holiday class instance.  Any imported calendar class will
@@ -807,12 +782,6 @@ or calendars with additional rules.
     new_cal = HolidayCalendarFactory('NewExampleCalendar', cal, USLaborDay)
     new_cal.rules
 
-<<<<<<< HEAD
-=======
-There are several defined US holidays in ``pandas.tseries.holiday`` along with
-several common holidays calendars.
-
->>>>>>> FETCH_HEAD
 .. _timeseries.advanced_datetime:
 
 Time series-related instance methods

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -546,6 +546,17 @@ calendars which account for local holidays and local weekend conventions.
     print(dts)
     print(Series(dts.weekday, dts).map(Series('Mon Tue Wed Thu Fri Sat Sun'.split())))
 
+As of v0.14 holiday calendars can be used to provide the list of holidays.  See the
+:ref:`holiday calendar<timeseries.holiday>` section for more information.
+
+.. ipython:: python
+
+    from pandas.tseries.holiday import USFederalHolidayCalendar
+    bday_us = CustomBusinessDay(calendar=USFederalHolidayCalendar())
+    dt = datetime(2014, 1, 17) #Friday before MLK Day
+    print(dt + bday_us) #Tuesday after MLK Day
+     
+
 .. note::
 
     The frequency string 'C' is used to indicate that a CustomBusinessDay
@@ -711,6 +722,65 @@ As you can see, legacy quarterly and annual frequencies are business quarter
 and business year ends. Please also note the legacy time rule for milliseconds
 ``ms`` versus the new offset alias for month start ``MS``. This means that
 offset alias parsing is case sensitive.
+
+.. _timeseries.holiday:
+
+Holidays / Holiday Calendars
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Holidays and calendars provide a simple way to define holiday rules to be used
+with ``CustomBusinessDay`` or in other analysis that requires a predefined
+set of holidays.  The ``AbstractHolidayCalendar`` class provides all the necessary 
+methods to return a list of holidays and only ``rules`` need to be defined
+in a specific holiday calendar class.  ``USFederalHolidayCalendar`` is the only
+calendar that exists and primarily serves as an example for developing
+other holiday calendars.
+
+For holidays that occur on fixed dates (e.g., US Memorial Day or July 4th) an 
+observance rule determines when that holiday is observed if it falls on a weekend
+or some other non-observed day.  Defined observance rules are:
+
+.. csv-table::
+    :header: "Rule", "Description"
+    :widths: 15, 70
+
+    "nearest_workday", "move Saturday to Friday and Sunday to Monday"
+    "sunday_to_monday", "move Sunday to following Monday"
+    "next_monday_or_tuesday", "move Saturday to Monday and Sunday/Monday to Tuesday"
+    "previous_friday", move Saturday and Sunday to previous Friday"
+    "next_monday", "move Saturday and Sunday to following Monday"
+
+An example of how holidays and holiday calendars are defined:
+
+.. ipython:: python
+
+    from pandas.tseries.holiday import Holiday, USMemorialDay,\
+        AbstractHolidayCalendar, nearest_workday, MO
+    class ExampleCalendar(AbstractHolidayCalendar):
+        rules = [
+            USMemorialDay,
+            Holiday('July 4th', month=7, day=4, observance=nearest_workday),
+            Holiday('Columbus Day', month=10, day=1, 
+                offset=DateOffset(weekday=MO(2))), #same as 2*Week(weekday=2)
+            ]
+    cal = ExampleCalendar()
+    cal.holidays(datetime(2012, 1, 1), datetime(2012, 12, 31)) #holiday list
+    datetime(2012, 5, 25) + CustomBusinessDay(calendar=cal)
+
+Every calendar class is accessible by name using the ``get_calendar`` function
+which returns a holiday class instance.  Any imported calendar class will
+automatically be available by this function.  Also, ``HolidayCalendarFactory``
+provides an easy interface to create calendars that are combinations of calendars
+or calendars with additional rules.
+
+.. ipython:: python
+
+    from pandas.tseries.holiday import get_calendar, HolidayCalendarFactory,\
+        USLaborDay
+    cal = get_calendar('ExampleCalendar')
+    cal.rules
+    new_cal = HolidayCalendarFactory('NewExampleCalendar', cal, USLaborDay)
+    new_cal.rules
 
 .. _timeseries.advanced_datetime:
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -308,7 +308,7 @@ Asymmetrical error bars are also supported, however raw error values must be pro
 Prior Version Deprecations/Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Therse are prior version deprecations that are taking effect as of 0.14.0.
+There are prior version deprecations that are taking effect as of 0.14.0.
 
 - Remove ``column`` keyword from ``DataFrame.sort`` (:issue:`4370`)
 
@@ -376,6 +376,7 @@ Enhancements
   file. (:issue:`6545`)
 - ``pandas.io.gbq`` now handles reading unicode strings properly. (:issue:`5940`)
 - Improve performance of ``CustomBusinessDay`` (:issue:`6584`)
+- :ref:`Holidays and holiday calendars<timeseries.holiday>` are now available and can be used with CustomBusinessDay.
 
 Performance
 ~~~~~~~~~~~

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -376,7 +376,7 @@ Enhancements
   file. (:issue:`6545`)
 - ``pandas.io.gbq`` now handles reading unicode strings properly. (:issue:`5940`)
 - Improve performance of ``CustomBusinessDay`` (:issue:`6584`)
-- :ref:`Holidays and holiday calendars<timeseries.holiday>` are now available and can be used with CustomBusinessDay.
+- :ref:`Holidays and holiday calendars<timeseries.holiday>` are now available and can be used with CustomBusinessDay (:issue:`6719`)
 
 Performance
 ~~~~~~~~~~~

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -1,43 +1,60 @@
-from pandas import DateOffset, date_range, DatetimeIndex, Series
-from datetime import datetime
-from pandas.tseries.offsets import Easter
+from pandas import DateOffset, date_range, Series
+from datetime import datetime, timedelta
 from dateutil.relativedelta import MO, TU, WE, TH, FR, SA, SU
 
-def Sunday(dt):
+def next_monday(dt):
     '''
-    If the holiday falls on Sunday, make Monday a holiday (nothing
-    happens for Saturday.
+    If holiday falls on Saturday, use following Monday instead;
+    if holiday falls on Sunday, use Monday instead
     '''
-    if dt.isoweekday() == 7:
-        return dt + DateOffset(+1)
-    else:
-        return dt
-    
-def Nearest(dt):
-    '''
-    If the holiday falls on a weekend, make it a 3-day weekend by making
-    Saturday a Friday holiday and Sunday a Monday holiday.
-    '''
-    if dt.isoweekday() == 6:
-        return dt + DateOffset(-1)
-    elif dt.isoweekday() == 7:
-        return dt + DateOffset(+1)
-    else:
-        return dt
+    if dt.weekday() == 5: 
+        return dt + timedelta(2)
+    elif dt.weekday() == 6: 
+        return dt + timedelta(1)
+    return dt
 
-#TODO: Need to add an observance function when a holiday
-# falls on a Tuesday and get a 4-day weekend
-# def Nearest4(dt):
-#     '''
-#     If the holiday falls on Tuesday,
-#     make Monday a holiday as well, otherwise
-#     follow the rules for Nearest (a
-#     3-day weekend).
-#     '''
-#     if dt.isoweekday() == 2:
-#         return dt - DateOffset()
-#     else:
-#         return Nearest(dt)
+def next_monday_or_tuesday(dt):
+    '''
+    For second holiday of two adjacent ones!
+    If holiday falls on Saturday, use following Monday instead;
+    if holiday falls on Sunday or Monday, use following Tuesday instead
+    (because Monday is already taken by adjacent holiday on the day before)
+    '''
+    dow = dt.weekday()
+    if dow == 5 or dow == 6: 
+        return dt + timedelta(2)
+    elif dow == 0: 
+        return dt + timedelta(1)
+    return dt
+
+def previous_friday(dt):
+    '''
+    If holiday falls on Saturday or Sunday, use previous Friday instead.
+    '''
+    if dt.weekday() == 5: 
+        return dt - timedelta(1)
+    elif dt.weekday() == 6: 
+        return dt - timedelta(2)
+    return dt
+
+def sunday_to_monday(dt):
+    '''
+    If holiday falls on Sunday, use day thereafter (Monday) instead.
+    '''
+    if dt.weekday() == 6: 
+        return dt + timedelta(1)
+    return dt
+
+def nearest_workday(dt):
+    '''
+    If holiday falls on Saturday, use day before (Friday) instead;
+    if holiday falls on Sunday, use day thereafter (Monday) instead.
+    '''
+    if dt.weekday() == 5: 
+        return dt - timedelta(1)
+    elif dt.weekday() == 6:
+        return dt + timedelta(1)
+    return dt
 
 class Holiday(object):
     '''
@@ -56,12 +73,31 @@ class Holiday(object):
         self.observance = observance
     
     def __repr__(self):
-        #FIXME: This should handle observance rules as well
-        return 'Holiday %s (%s, %s, %s)' % (self.name, self.month, self.day, 
-                                            self.offset)
-    
-    def dates(self, start_date, end_date):
+        info = ''
+        if self.year is not None:
+            info += 'year=%s, ' % self.year
+        info += 'month=%s, day=%s, ' % (self.month, self.day)
         
+        if self.offset is not None:
+            info += 'offset=%s' % self.offset
+            
+        if self.observance is not None:
+            info += 'observance=%s' % self.observance
+        
+        return 'Holiday: %s (%s)' % (self.name, info)
+    
+    def dates(self, start_date, end_date, return_name=False):
+        '''
+        Calculate holidays between start date and end date
+        
+        Parameters
+        ----------
+        start_date : starting date, datetime-like, optional
+        end_date : ending date, datetime-like, optional
+        return_name : bool, optional, default=False
+            If True, return a series that has dates and holiday names.
+            False will only return dates.
+        '''
         if self.year is not None:
             return datetime(self.year, self.month, self.day)
         
@@ -74,13 +110,11 @@ class Holiday(object):
         year_offset = DateOffset(years=1)   
         baseDate = datetime(start_date.year, self.month, self.day)
         dates = date_range(baseDate, end_date, freq=year_offset)
+        holiday_dates = self._apply_rule(dates)
+        if return_name:
+            return Series(self.name, index=holiday_dates)
         
-        return self._apply_rule(dates)
-    
-    def dates_with_name(self, start_date, end_date):
-        
-        dates = self.dates(start_date, end_date)
-        return Series(self.name, index=dates)
+        return holiday_dates
 
     def _apply_rule(self, dates):   
         '''
@@ -109,31 +143,67 @@ class Holiday(object):
             
         return dates
 
+#----------------------------------------------------------------------
+# Calendar class registration
+
+holiday_calendars = {}
+def register(cls):
+    try:
+        name = cls.name
+    except:
+        name = cls.__name__
+    holiday_calendars[name] = cls
+    
+def get_calendar(name):
+    '''
+    Return an instance of a calendar based on its name.
+    
+    Parameters
+    ----------
+    name : str
+        Calendar name to return an instance of
+    '''
+    return holiday_calendars[name]()
+
+#----------------------------------------------------------------------
+# Holiday classes
+class HolidayCalendarMetaClass(type):
+    def __new__(cls, clsname, bases, attrs):
+        calendar_class = super(HolidayCalendarMetaClass, cls).__new__(cls, clsname, bases, attrs)
+        register(calendar_class)
+        return calendar_class
+
 class AbstractHolidayCalendar(object):
     '''
     Abstract interface to create holidays following certain rules.
     '''
-    _rule_table = []
+    __metaclass__ = HolidayCalendarMetaClass
+    rules = []
+    _holiday_start_date = datetime(1970, 1, 1)
+    _holiday_end_date   = datetime(2030, 12, 31)
+    _holiday_cache = None
     
-    def __init__(self, rules=None):
+    def __init__(self, name=None, rules=None):
         '''
         Initializes holiday object with a given set a rules.  Normally
         classes just have the rules defined within them.
         
         Parameters
         ----------
+        name : str 
+            Name of the holiday calendar, defaults to class name
         rules : array of Holiday objects
             A set of rules used to create the holidays.
         '''
         super(AbstractHolidayCalendar, self).__init__()
-        if rules is not None:
-            self._rule_table = rules
+        if name is None:
+            name = self.__class__.__name__
+        self.name = name
         
-    @property
-    def holiday_rules(self):
-        return self._rule_table
+        if rules is not None:
+            self.rules = rules
 
-    def holidays(self, start=None, end=None, return_names=False):
+    def holidays(self, start=_holiday_start_date, end=_holiday_end_date, return_name=False):
         '''
         Returns a curve with holidays between start_date and end_date
         
@@ -149,40 +219,89 @@ class AbstractHolidayCalendar(object):
         -------
             DatetimeIndex of holidays
         '''
-        #FIXME: Where should the default limits exist?
-        if start is None:
-            start = datetime(1970, 1, 1)
-            
-        if end is None:
-            end = datetime(2030, 12, 31)
-            
-        if self.holiday_rules is None:
+        if self.rules is None:
             raise Exception('Holiday Calendar %s does not have any '\
-                            'rules specified' % self.calendarName)
-        
-        if return_names:
-            holidays = None
-        else:
-            holidays    = []
-        for rule in self.holiday_rules:
-            if return_names:
-                rule_holidays = rule.dates_with_name(start, end)
+                            'rules specified' % self.name)
+
+        holidays = None
+        # If we don't have a cache or the dates are outside the prior cache, we get them again
+        if self._cache is None or start < self._cache[0] or end > self._cache[1]: 
+            for rule in self.rules:
+                rule_holidays = rule.dates(start, end, return_name=True)
                 if holidays is None:
                     holidays = rule_holidays
                 else:
                     holidays = holidays.append(rule_holidays)
-            else:
-                holidays += rule.dates(start, end)
-
-        if return_names:
-            return holidays.sort_index()
+                    
+            self._cache = (start, end, holidays.sort_index())
+        
+        holidays = self._cache[2]
+        holidays = holidays[start:end]
+        
+        if return_name:
+            return holidays
         else:
-            return DatetimeIndex(holidays).order(False)
+            return holidays.index
+    
+    @property
+    def _cache(self):
+        return self.__class__._holiday_cache
+    
+    @_cache.setter
+    def _cache(self, values):
+        self.__class__._holiday_cache = values
+
+    @staticmethod
+    def merge_class(base, other):
+        '''
+        Merge holiday calendars together.  The base calendar
+        will take precedence to other. The merge will be done
+        based on each holiday's name.
+        
+        Parameters
+        ----------
+        base : AbstractHolidayCalendar instance of array of Holiday objects
+        other : AbstractHolidayCalendar instance or array of Holiday objects
+        '''
+        if isinstance(other, AbstractHolidayCalendar):
+            other = other.rules
+        if not isinstance(other, list):
+            other = [other]
+        other_holidays = {holiday.name: holiday for holiday in other}
+            
+        if isinstance(base, AbstractHolidayCalendar):
+            base = base.rules
+        if not isinstance(base, list):
+            base = [base]
+        base_holidays = {holiday.name: holiday for holiday in base}
+        
+        other_holidays.update(base_holidays)
+        return other_holidays.values()
+
+    def merge(self, other, inplace=False):
+        '''
+        Merge holiday calendars together.  The caller's class
+        rules take precedence.  The merge will be done
+        based on each holiday's name.
+        
+        Parameters
+        ----------
+        other : holiday calendar
+        inplace : bool (default=False)
+            If True set rule_table to holidays, else return array of Holidays
+        '''
+        holidays    =   self.merge_class(self, other)
+        if inplace:
+            self.rules = holidays
+        else:
+            return holidays
 
 USMemorialDay     = Holiday('MemorialDay', month=5, day=24, 
                             offset=DateOffset(weekday=MO(1)))
 USLaborDay        = Holiday('Labor Day', month=9, day=1, 
                             offset=DateOffset(weekday=MO(1)))
+USColumbusDay     = Holiday('Columbus Day', month=10, day=1,
+                            offset=DateOffset(weekday=MO(2)))
 USThanksgivingDay = Holiday('Thanksgiving', month=11, day=1, 
                             offset=DateOffset(weekday=TH(4)))
 USMartinLutherKingJr = Holiday('Dr. Martin Luther King Jr.', month=1, day=1, 
@@ -191,27 +310,24 @@ USPresidentsDay      = Holiday('President''s Day', month=2, day=1,
                                offset=DateOffset(weekday=MO(3)))
 
 class USFederalHolidayCalendar(AbstractHolidayCalendar):
-    
-    _rule_table = [ 
-        Holiday('New Years Day', month=1,  day=1,  observance=Nearest), 
+    '''
+    US Federal Government Holiday Calendar based on rules specified
+    by: https://www.opm.gov/policy-data-oversight/snow-dismissal-procedures/federal-holidays/
+    '''
+    rules = [ 
+        Holiday('New Years Day', month=1,  day=1,  observance=nearest_workday), 
         USMartinLutherKingJr,
         USPresidentsDay,
         USMemorialDay,
-        Holiday('July 4th', month=7,  day=4,  observance=Nearest),
-        USLaborDay, 
-        Holiday('Columbus Day', month=10, day=1,  offset=DateOffset(weekday=MO(2))),
-        Holiday('Veterans Day', month=11, day=11, observance=Nearest),
-        USThanksgivingDay,
-        Holiday('Christmas', month=12, day=25, observance=Nearest)
-        ]
-
-class NERCHolidayCalendar(AbstractHolidayCalendar):
-    
-    _rule_table = [
-        Holiday('New Years Day', month=1, day=1, observance=Sunday),
-        USMemorialDay,
-        Holiday('July 4th', month=7,  day=4, observance=Sunday),
+        Holiday('July 4th', month=7,  day=4,  observance=nearest_workday),
         USLaborDay,
+        USColumbusDay,
+        Holiday('Veterans Day', month=11, day=11, observance=nearest_workday),
         USThanksgivingDay,
-        Holiday('Christmas', month=12, day=25, observance=Sunday)
+        Holiday('Christmas', month=12, day=25, observance=nearest_workday)
         ]
+    
+def HolidayCalendarFactory(name, base, other, base_class=AbstractHolidayCalendar):
+    rules = AbstractHolidayCalendar.merge_class(base, other)
+    calendar_class = type(name, (base_class,), {"rules": rules, "name": name})
+    return calendar_class

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -296,51 +296,6 @@ class AbstractHolidayCalendar(object):
         else:
             return holidays
 
-    @staticmethod
-    def merge_class(base, other):
-        '''
-        Merge holiday calendars together.  The base calendar
-        will take precedence to other. The merge will be done
-        based on each holiday's name.
-        
-        Parameters
-        ----------
-        base : AbstractHolidayCalendar instance of array of Holiday objects
-        other : AbstractHolidayCalendar instance or array of Holiday objects
-        '''
-        if isinstance(other, AbstractHolidayCalendar):
-            other = other.rules
-        if not isinstance(other, list):
-            other = [other]
-        other_holidays = {holiday.name: holiday for holiday in other}
-            
-        if isinstance(base, AbstractHolidayCalendar):
-            base = base.rules
-        if not isinstance(base, list):
-            base = [base]
-        base_holidays = {holiday.name: holiday for holiday in base}
-        
-        other_holidays.update(base_holidays)
-        return other_holidays.values()
-
-    def merge(self, other, inplace=False):
-        '''
-        Merge holiday calendars together.  The caller's class
-        rules take precedence.  The merge will be done
-        based on each holiday's name.
-        
-        Parameters
-        ----------
-        other : holiday calendar
-        inplace : bool (default=False)
-            If True set rule_table to holidays, else return array of Holidays
-        '''
-        holidays    =   self.merge_class(self, other)
-        if inplace:
-            self.rules = holidays
-        else:
-            return holidays
-
 USMemorialDay     = Holiday('MemorialDay', month=5, day=24, 
                             offset=DateOffset(weekday=MO(1)))
 USLaborDay        = Holiday('Labor Day', month=9, day=1, 

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -1,0 +1,217 @@
+from pandas import DateOffset, date_range, DatetimeIndex, Series
+from datetime import datetime
+from pandas.tseries.offsets import Easter
+from dateutil.relativedelta import MO, TU, WE, TH, FR, SA, SU
+
+def Sunday(dt):
+    '''
+    If the holiday falls on Sunday, make Monday a holiday (nothing
+    happens for Saturday.
+    '''
+    if dt.isoweekday() == 7:
+        return dt + DateOffset(+1)
+    else:
+        return dt
+    
+def Nearest(dt):
+    '''
+    If the holiday falls on a weekend, make it a 3-day weekend by making
+    Saturday a Friday holiday and Sunday a Monday holiday.
+    '''
+    if dt.isoweekday() == 6:
+        return dt + DateOffset(-1)
+    elif dt.isoweekday() == 7:
+        return dt + DateOffset(+1)
+    else:
+        return dt
+
+#TODO: Need to add an observance function when a holiday
+# falls on a Tuesday and get a 4-day weekend
+# def Nearest4(dt):
+#     '''
+#     If the holiday falls on Tuesday,
+#     make Monday a holiday as well, otherwise
+#     follow the rules for Nearest (a
+#     3-day weekend).
+#     '''
+#     if dt.isoweekday() == 2:
+#         return dt - DateOffset()
+#     else:
+#         return Nearest(dt)
+
+class Holiday(object):
+    '''
+    Class that defines a holiday with start/end dates and rules
+    for observance.
+    '''
+    def __init__(self, name, year=None, month=None, day=None, offset=None,
+                 observance=None, start_date=None, end_date=None):
+        self.name   =   name
+        self.year   =   year
+        self.month  =   month
+        self.day    =   day
+        self.offset =   offset
+        self.start_date = start_date
+        self.end_date   = end_date
+        self.observance = observance
+    
+    def __repr__(self):
+        #FIXME: This should handle observance rules as well
+        return 'Holiday %s (%s, %s, %s)' % (self.name, self.month, self.day, 
+                                            self.offset)
+    
+    def dates(self, start_date, end_date):
+        
+        if self.year is not None:
+            return datetime(self.year, self.month, self.day)
+        
+        if self.start_date is not None:
+            start_date = self.start_date
+            
+        if self.end_date is not None:
+            end_date = self.end_date
+        
+        year_offset = DateOffset(years=1)   
+        baseDate = datetime(start_date.year, self.month, self.day)
+        dates = date_range(baseDate, end_date, freq=year_offset)
+        
+        return self._apply_rule(dates)
+    
+    def dates_with_name(self, start_date, end_date):
+        
+        dates = self.dates(start_date, end_date)
+        return Series(self.name, index=dates)
+
+    def _apply_rule(self, dates):   
+        '''
+        Apply the given offset/observance to an 
+        iterable of dates.
+        
+        Parameters
+        ----------
+        dates : array-like
+            Dates to apply the given offset/observance rule
+        
+        Returns
+        -------
+        Dates with rules applied
+        '''
+        if self.observance is not None:
+            return map(lambda d: self.observance(d), dates)
+
+        if not isinstance(self.offset, list):
+            offsets =   [self.offset]
+        else:
+            offsets =   self.offset
+            
+        for offset in offsets:
+            dates = map(lambda d: d + offset, dates)
+            
+        return dates
+
+class AbstractHolidayCalendar(object):
+    '''
+    Abstract interface to create holidays following certain rules.
+    '''
+    _rule_table = []
+    
+    def __init__(self, rules=None):
+        '''
+        Initializes holiday object with a given set a rules.  Normally
+        classes just have the rules defined within them.
+        
+        Parameters
+        ----------
+        rules : array of Holiday objects
+            A set of rules used to create the holidays.
+        '''
+        super(AbstractHolidayCalendar, self).__init__()
+        if rules is not None:
+            self._rule_table = rules
+        
+    @property
+    def holiday_rules(self):
+        return self._rule_table
+
+    def holidays(self, start=None, end=None, return_names=False):
+        '''
+        Returns a curve with holidays between start_date and end_date
+        
+        Parameters
+        ----------
+        start : starting date, datetime-like, optional
+        end : ending date, datetime-like, optional
+        return_names : bool, optional
+            If True, return a series that has dates and holiday names.
+            False will only return a DatetimeIndex of dates.
+
+        Returns
+        -------
+            DatetimeIndex of holidays
+        '''
+        #FIXME: Where should the default limits exist?
+        if start is None:
+            start = datetime(1970, 1, 1)
+            
+        if end is None:
+            end = datetime(2030, 12, 31)
+            
+        if self.holiday_rules is None:
+            raise Exception('Holiday Calendar %s does not have any '\
+                            'rules specified' % self.calendarName)
+        
+        if return_names:
+            holidays = None
+        else:
+            holidays    = []
+        for rule in self.holiday_rules:
+            if return_names:
+                rule_holidays = rule.dates_with_name(start, end)
+                if holidays is None:
+                    holidays = rule_holidays
+                else:
+                    holidays = holidays.append(rule_holidays)
+            else:
+                holidays += rule.dates(start, end)
+
+        if return_names:
+            return holidays.sort_index()
+        else:
+            return DatetimeIndex(holidays).order(False)
+
+USMemorialDay     = Holiday('MemorialDay', month=5, day=24, 
+                            offset=DateOffset(weekday=MO(1)))
+USLaborDay        = Holiday('Labor Day', month=9, day=1, 
+                            offset=DateOffset(weekday=MO(1)))
+USThanksgivingDay = Holiday('Thanksgiving', month=11, day=1, 
+                            offset=DateOffset(weekday=TH(4)))
+USMartinLutherKingJr = Holiday('Dr. Martin Luther King Jr.', month=1, day=1, 
+                               offset=DateOffset(weekday=MO(3)))
+USPresidentsDay      = Holiday('President''s Day', month=2, day=1, 
+                               offset=DateOffset(weekday=MO(3)))
+
+class USFederalHolidayCalendar(AbstractHolidayCalendar):
+    
+    _rule_table = [ 
+        Holiday('New Years Day', month=1,  day=1,  observance=Nearest), 
+        USMartinLutherKingJr,
+        USPresidentsDay,
+        USMemorialDay,
+        Holiday('July 4th', month=7,  day=4,  observance=Nearest),
+        USLaborDay, 
+        Holiday('Columbus Day', month=10, day=1,  offset=DateOffset(weekday=MO(2))),
+        Holiday('Veterans Day', month=11, day=11, observance=Nearest),
+        USThanksgivingDay,
+        Holiday('Christmas', month=12, day=25, observance=Nearest)
+        ]
+
+class NERCHolidayCalendar(AbstractHolidayCalendar):
+    
+    _rule_table = [
+        Holiday('New Years Day', month=1, day=1, observance=Sunday),
+        USMemorialDay,
+        Holiday('July 4th', month=7,  day=4, observance=Sunday),
+        USLaborDay,
+        USThanksgivingDay,
+        Holiday('Christmas', month=12, day=25, observance=Sunday)
+        ]

--- a/pandas/tseries/tests/test_holiday.py
+++ b/pandas/tseries/tests/test_holiday.py
@@ -1,0 +1,64 @@
+
+from datetime import datetime
+import pandas.util.testing as tm
+from pandas.tseries.holiday import (
+    USFederalHolidayCalendar, USMemorialDay, USThanksgivingDay)
+
+class TestCalendar(tm.TestCase):
+    
+    def test_calendar(self):
+
+        calendar = USFederalHolidayCalendar()
+        holidays = calendar.holidays(datetime(2012, 1, 1), datetime(2012, 12, 31))
+        
+        holidayList = [
+                       datetime(2012, 1, 2),
+                       datetime(2012, 1, 16),
+                       datetime(2012, 2, 20),
+                       datetime(2012, 5, 28),
+                       datetime(2012, 7, 4),
+                       datetime(2012, 9, 3),
+                       datetime(2012, 10, 8),
+                       datetime(2012, 11, 12),
+                       datetime(2012, 11, 22),
+                       datetime(2012, 12, 25)]
+        
+        self.assertEqual(list(holidays.to_pydatetime()), holidayList)
+        
+class TestHoliday(tm.TestCase):
+    
+    def setUp(self):
+        self.start_date = datetime(2011, 1, 1)
+        self.end_date   = datetime(2020, 12, 31)
+    
+    def test_usmemorialday(self):
+        holidays = USMemorialDay.dates(self.start_date, self.end_date)
+        holidayList = [
+                       datetime(2011, 5, 30),
+                       datetime(2012, 5, 28),
+                       datetime(2013, 5, 27),
+                       datetime(2014, 5, 26),
+                       datetime(2015, 5, 25),
+                       datetime(2016, 5, 30),
+                       datetime(2017, 5, 29),
+                       datetime(2018, 5, 28),
+                       datetime(2019, 5, 27),
+                       datetime(2020, 5, 25),
+                       ]
+        self.assertEqual(holidays, holidayList)
+        
+    def test_usthanksgivingday(self):
+        holidays = USThanksgivingDay.dates(self.start_date, self.end_date)
+        holidayList = [
+                       datetime(2011, 11, 24),
+                       datetime(2012, 11, 22),
+                       datetime(2013, 11, 28),
+                       datetime(2014, 11, 27),
+                       datetime(2015, 11, 26),
+                       datetime(2016, 11, 24),
+                       datetime(2017, 11, 23),
+                       datetime(2018, 11, 22),
+                       datetime(2019, 11, 28),
+                       datetime(2020, 11, 26),
+                       ]
+        self.assertEqual(holidays, holidayList)

--- a/pandas/tseries/tests/test_holiday.py
+++ b/pandas/tseries/tests/test_holiday.py
@@ -45,7 +45,7 @@ class TestHoliday(tm.TestCase):
                        datetime(2019, 5, 27),
                        datetime(2020, 5, 25),
                        ]
-        self.assertEqual(holidays, holidayList)
+        self.assertEqual(list(holidays), holidayList)
         
     def test_usthanksgivingday(self):
         holidays = USThanksgivingDay.dates(self.start_date, self.end_date)
@@ -61,4 +61,4 @@ class TestHoliday(tm.TestCase):
                        datetime(2019, 11, 28),
                        datetime(2020, 11, 26),
                        ]
-        self.assertEqual(holidays, holidayList)
+        self.assertEqual(list(holidays), holidayList)

--- a/pandas/tseries/tests/test_holiday.py
+++ b/pandas/tseries/tests/test_holiday.py
@@ -2,14 +2,17 @@
 from datetime import datetime
 import pandas.util.testing as tm
 from pandas.tseries.holiday import (
-    USFederalHolidayCalendar, USMemorialDay, USThanksgivingDay)
+    USFederalHolidayCalendar, USMemorialDay, USThanksgivingDay,
+    nearest_workday, next_monday_or_tuesday, next_monday,
+    previous_friday, sunday_to_monday)
 
 class TestCalendar(tm.TestCase):
     
     def test_calendar(self):
 
         calendar = USFederalHolidayCalendar()
-        holidays = calendar.holidays(datetime(2012, 1, 1), datetime(2012, 12, 31))
+        holidays = calendar.holidays(datetime(2012, 1, 1), 
+                                     datetime(2012, 12, 31))
         
         holidayList = [
                        datetime(2012, 1, 2),
@@ -23,7 +26,8 @@ class TestCalendar(tm.TestCase):
                        datetime(2012, 11, 22),
                        datetime(2012, 12, 25)]
         
-        self.assertEqual(list(holidays.to_pydatetime()), holidayList)
+        self.assertEqual(list(holidays.to_pydatetime()), 
+                         holidayList)
         
 class TestHoliday(tm.TestCase):
     
@@ -32,7 +36,8 @@ class TestHoliday(tm.TestCase):
         self.end_date   = datetime(2020, 12, 31)
     
     def test_usmemorialday(self):
-        holidays = USMemorialDay.dates(self.start_date, self.end_date)
+        holidays = USMemorialDay.dates(self.start_date, 
+                                       self.end_date)
         holidayList = [
                        datetime(2011, 5, 30),
                        datetime(2012, 5, 28),
@@ -45,10 +50,11 @@ class TestHoliday(tm.TestCase):
                        datetime(2019, 5, 27),
                        datetime(2020, 5, 25),
                        ]
-        self.assertEqual(holidays, holidayList)
+        self.assertEqual(list(holidays), holidayList)
         
     def test_usthanksgivingday(self):
-        holidays = USThanksgivingDay.dates(self.start_date, self.end_date)
+        holidays = USThanksgivingDay.dates(self.start_date, 
+                                           self.end_date)
         holidayList = [
                        datetime(2011, 11, 24),
                        datetime(2012, 11, 22),
@@ -61,4 +67,36 @@ class TestHoliday(tm.TestCase):
                        datetime(2019, 11, 28),
                        datetime(2020, 11, 26),
                        ]
-        self.assertEqual(holidays, holidayList)
+        self.assertEqual(list(holidays), holidayList)
+        
+class TestObservanceRules(tm.TestCase):
+    
+    def setUp(self):
+        self.we =   datetime(2014, 4, 9)
+        self.th =   datetime(2014, 4, 10)
+        self.fr =   datetime(2014, 4, 11)
+        self.sa =   datetime(2014, 4, 12)
+        self.su =   datetime(2014, 4, 13)
+        self.mo =   datetime(2014, 4, 14)
+        self.tu =   datetime(2014, 4, 15)
+    
+    def test_next_monday(self):
+        self.assertEqual(next_monday(self.sa), self.mo)
+        self.assertEqual(next_monday(self.su), self.mo)
+
+    def test_next_monday_or_tuesday(self):
+        self.assertEqual(next_monday_or_tuesday(self.sa), self.mo)
+        self.assertEqual(next_monday_or_tuesday(self.su), self.tu)
+        self.assertEqual(next_monday_or_tuesday(self.mo), self.tu)
+
+    def test_previous_friday(self):
+        self.assertEqual(previous_friday(self.sa), self.fr)
+        self.assertEqual(previous_friday(self.su), self.fr)
+
+    def test_sunday_to_monday(self):
+        self.assertEqual(sunday_to_monday(self.su), self.mo)
+
+    def test_nearest_workday(self):
+        self.assertEqual(nearest_workday(self.sa), self.fr)
+        self.assertEqual(nearest_workday(self.su), self.mo)
+        self.assertEqual(nearest_workday(self.mo), self.mo)

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -11,7 +11,7 @@ from pandas.core.datetools import (
     bday, BDay, cday, CDay, BQuarterEnd, BMonthEnd, BYearEnd, MonthEnd,
     MonthBegin, BYearBegin, QuarterBegin, BQuarterBegin, BMonthBegin,
     DateOffset, Week, YearBegin, YearEnd, Hour, Minute, Second, Day, Micro,
-    Milli, Nano,
+    Milli, Nano, Easter, 
     WeekOfMonth, format, ole2datetime, QuarterEnd, to_datetime, normalize_date,
     get_offset, get_offset_name, get_standard_freq)
 
@@ -26,6 +26,7 @@ from pandas.util.testing import assertRaisesRegexp
 import pandas.util.testing as tm
 from pandas.tseries.offsets import BusinessMonthEnd, CacheableOffset, \
     LastWeekOfMonth, FY5253, FY5253Quarter, WeekDay
+from pandas.tseries.holiday import USFederalHolidayCalendar
 
 from pandas import _np_version_under1p7
 
@@ -546,6 +547,10 @@ class TestCustomBusinessDay(TestBase):
         xp_egypt = datetime(2013, 5, 5)
         self.assertEqual(xp_egypt, dt + 2 * bday_egypt)
 
+    def test_calendar(self):
+        calendar = USFederalHolidayCalendar()
+        dt = datetime(2014, 1, 17)
+        assertEq(CDay(calendar=calendar), dt, datetime(2014, 1, 21))
 
 def assertOnOffset(offset, date, expected):
     actual = offset.onOffset(date)
@@ -2167,6 +2172,8 @@ def assertEq(offset, base, expected):
                              "\nAt Date: %s" %
                             (expected, actual, offset, base))
 
+def test_Easter():
+    assertEq(Easter(), datetime(2010, 1, 1), datetime(2010, 4, 4))
 
 def test_Hour():
     assertEq(Hour(), datetime(2010, 1, 1), datetime(2010, 1, 1, 1))


### PR DESCRIPTION
Implementation of holidays based on DateOffset objects and calendars that are collections of those holidays.  These calendars can be passed into CustomBusinessDay.  Also, add an Easter offset for use in holiday calendars.

Currently the default dates are hard-coded in the calendar class but this should move somewhere else and be calculated differently.  I'm open to suggestions here.  Also, the 4-day weekend observance needs to be incorporated (for example, if July 4th is on a Tuesday, perhaps Monday is also a holiday).  This would require a little bit of tweaking, but not much.

```
from pandas.tseries.holiday import Holiday, USMemorialDay,\
        AbstractHolidayCalendar, Nearest, MO, USFederalHolidayCalendar
from pandas.tseries.offsets import DateOffset, CustomBusinessDay
from datetime import datetime
class ExampleCalendar(AbstractHolidayCalendar):
    _rule_table = [
        USMemorialDay,
        Holiday('July 4th', month=7, day=4, observance=Nearest),
        Holiday('Columbus Day', month=10, day=1, 
            offset=DateOffset(weekday=MO(2))),
        ]
cal = ExampleCalendar()
cal.holidays()
print(datetime(2012, 5, 25) + CustomBusinessDay(calendar=cal))
print(datetime(2012, 5, 25) + CustomBusinessDay(calendar=USFederalHolidayCalendar()))
```
