### PR TITLE
BUG: MPLPlot cannot make loglog keyword worked

### DIFF
--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -410,6 +410,22 @@ class TestDataFramePlots(tm.TestCase):
         # TODO add MultiIndex test
 
     @slow
+    def test_logscales(self):
+        df = DataFrame({'a': np.arange(100)},
+                       index=np.arange(100))
+        ax = df.plot(logy=True)
+        self.assertEqual(ax.xaxis.get_scale(), 'linear')
+        self.assertEqual(ax.yaxis.get_scale(), 'log')
+
+        ax = df.plot(logx=True)
+        self.assertEqual(ax.xaxis.get_scale(), 'log')
+        self.assertEqual(ax.yaxis.get_scale(), 'linear')
+
+        ax = df.plot(loglog=True)
+        self.assertEqual(ax.xaxis.get_scale(), 'log')
+        self.assertEqual(ax.yaxis.get_scale(), 'log')
+
+    @slow
     def test_xcompat(self):
         import pandas as pd
         import matplotlib.pyplot as plt
@@ -1229,6 +1245,7 @@ class TestDataFramePlots(tm.TestCase):
         # check line plots
         _check_plot_works(df.plot, yerr=df_err, logy=True)
         _check_plot_works(df.plot, yerr=df_err, logx=True, logy=True)
+        _check_plot_works(df.plot, yerr=df_err, loglog=True)
 
         kinds = ['line', 'bar', 'barh']
         for kind in kinds:

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -976,9 +976,9 @@ class MPLPlot(object):
 
             axes = [ax]
 
-        if self.logx:
+        if self.logx or self.loglog:
             [a.set_xscale('log') for a in axes]
-        if self.logy:
+        if self.logy or self.loglog:
             [a.set_yscale('log') for a in axes]
 
         self.fig = fig
@@ -1879,9 +1879,11 @@ def plot_frame(frame=None, x=None, y=None, subplots=False, sharex=True,
         scatter: scatter plot
         hexbin: hexbin plot
     logx : boolean, default False
-        For line plots, use log scaling on x axis
+        Use log scaling on x axis
     logy : boolean, default False
-        For line plots, use log scaling on y axis
+        Use log scaling on y axis
+    loglog : boolean, default False
+        Use log scaling on both x and y axes
     xticks : sequence
         Values to use for the xticks
     yticks : sequence
@@ -2031,9 +2033,11 @@ def plot_series(series, label=None, kind='line', use_index=True, rot=None,
     grid : matplotlib grid
     legend: matplotlib legend
     logx : boolean, default False
-        For line plots, use log scaling on x axis
+        Use log scaling on x axis
     logy : boolean, default False
-        For line plots, use log scaling on y axis
+        Use log scaling on y axis
+    loglog : boolean, default False
+        Use log scaling on both x and y axes
     secondary_y : boolean or sequence of ints, default False
         If True then y-axis will be on the right
     figsize : a tuple (width, height) in inches


### PR DESCRIPTION
Changes made in #5638 make `loglog` keyword not worked, and it fixes the problem.
