### PR TITLE
ENH: NaTType can be unpickled properly

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -152,6 +152,7 @@ API Changes
 
 - all offset operations now return ``Timestamp`` types (rather than datetime), Business/Week frequencies were incorrect (:issue:`4069`)
 
+
 Deprecations
 ~~~~~~~~~~~~
 
@@ -296,6 +297,7 @@ Bug Fixes
 - Bug in consistency of groupby aggregation when passing a custom function (:issue:`6715`)
 - Bug in resample when ``how=None`` resample freq is the same as the axis frequency (:issue:`5955`)
 - Bug in downcasting inference with empty arrays (:issue:`6733`)
+- Bug in unpickling ``NaT (NaTType)`` (:issue:`4606`)
 
 pandas 0.13.1
 -------------

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1802,6 +1802,21 @@ class TestTimeSeries(tm.TestCase):
         expected = pd.Series(1, index=expected_index)
         assert_series_equal(result, expected)
 
+    def test_pickle(self):
+        #GH4606
+        from pandas.compat import cPickle
+        import pickle
+
+        for pick in [pickle, cPickle]:
+            p = pick.loads(pick.dumps(NaT))
+            self.assertTrue(p is NaT)
+
+            idx = pd.to_datetime(['2013-01-01', NaT, '2014-01-06'])
+            idx_p = pick.loads(pick.dumps(idx))
+            self.assertTrue(idx_p[0] == idx[0])
+            self.assertTrue(idx_p[1] is NaT)
+            self.assertTrue(idx_p[2] == idx[2])
+
 
 def _simple_ts(start, end, freq='D'):
     rng = date_range(start, end, freq=freq)

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -444,6 +444,9 @@ class NaTType(_NaT):
     def toordinal(self):
         return -1
 
+    def __reduce__(self):
+        return (__nat_unpickle, (None, ))
+
 fields = ['year', 'quarter', 'month', 'day', 'hour',
           'minute', 'second', 'microsecond', 'nanosecond',
           'week', 'dayofyear']
@@ -451,6 +454,9 @@ for field in fields:
     prop = property(fget=lambda self: -1)
     setattr(NaTType, field, prop)
 
+def __nat_unpickle(*args):
+    # return constant defined in the module
+    return NaT
 
 NaT = NaTType()
 


### PR DESCRIPTION
Closes #4606. 

I'm not sure this also be a solution for #5388, but seems to be a workaround.
