### PR TITLE
Quick shift fixes

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3238,9 +3238,9 @@ class NDFrame(PandasObject):
         if periods == 0:
             return self
 
-        axis = self._get_axis_number(axis)
+        block_axis = self._get_block_manager_axis(axis)
         if freq is None and not len(kwds):
-            new_data = self._data.shift(periods=periods, axis=axis)
+            new_data = self._data.shift(periods=periods, axis=block_axis)
         else:
             return self.tshift(periods, freq, **kwds)
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -966,7 +966,12 @@ class Block(PandasObject):
         # convert integer to float if necessary. need to do a lot more than
         # that, handle boolean etc also
         new_values, fill_value = com._maybe_upcast(self.values)
-        new_values = np.roll(new_values.T,periods,axis=axis)
+        # make sure array sent to np.roll is c_contiguous
+        f_ordered = new_values.flags.f_contiguous
+        if f_ordered:
+            new_values = new_values.T
+            axis = new_values.ndim - axis - 1
+        new_values = np.roll(new_values, periods, axis=axis)
         axis_indexer = [ slice(None) ] * self.ndim
         if periods > 0:
             axis_indexer[axis] = slice(None,periods)
@@ -974,7 +979,11 @@ class Block(PandasObject):
             axis_indexer[axis] = slice(periods,None)
         new_values[tuple(axis_indexer)] = fill_value
 
-        return [make_block(new_values.T, self.items, self.ref_items,
+        # restore original order
+        if f_ordered:
+            new_values = new_values.T
+
+        return [make_block(new_values, self.items, self.ref_items,
                            ndim=self.ndim, fastpath=True)]
 
     def eval(self, func, other, raise_on_error=True, try_cast=False):

--- a/vb_suite/frame_methods.py
+++ b/vb_suite/frame_methods.py
@@ -386,7 +386,7 @@ def test_equal(name):
 def test_unequal(name):
     df, df2 = pairs[name]
     return df.equals(df2)
-    
+
 float_df = DataFrame(np.random.randn(1000, 1000))
 object_df = DataFrame([['foo']*1000]*1000)
 nonunique_cols = object_df.copy()
@@ -434,11 +434,21 @@ frame_interpolate_some_good_infer = Benchmark('df.interpolate(downcast="infer")'
 # frame shift speedup issue-5609
 
 setup = common_setup + """
-df = pd.DataFrame(np.random.rand(10000,500))
+df = DataFrame(np.random.rand(10000,500))
+# note: df._data.blocks are f_contigous
 """
 frame_shift_axis0 = Benchmark('df.shift(1,axis=0)', setup,
-                    name = 'frame_shift_axis_0',
                     start_date=datetime(2014,1,1))
 frame_shift_axis1 = Benchmark('df.shift(1,axis=1)', setup,
-                    name = 'frame_shift_axis_1',
+                    start_date=datetime(2014,1,1))
+
+#
+setup = common_setup + """
+df = DataFrame(np.random.rand(10000,500))
+df = df.consolidate()
+# note: df._data.blocks are c_contigous
+"""
+frame_shift_c_order_axis0 = Benchmark('df.shift(1,axis=0)', setup,
+                    start_date=datetime(2014,1,1))
+frame_shift_c_order_axis1 = Benchmark('df.shift(1,axis=1)', setup,
                     start_date=datetime(2014,1,1))


### PR DESCRIPTION
Adjustments to the quick fix PR. 

https://gist.github.com/dalejung/9731798#file-vb_suite-log

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
frame_shift_c_order_axis1                    |  14.4524 |  52.8037 |   0.2737 |
frame_shift_c_order_axis0                    |  16.9516 |  46.5320 |   0.3643 |
frame_shift_axis0                            |  15.2656 |  16.3440 |   0.9340 |
frame_shift_axis1                            |  22.2600 |  22.0567 |   1.0092 |
```

Note, that the speed up was really in sending a C order array to `np.take`. You'll notice that master is slow for `frame_shift_c_order_` which are tests where the `block.values` is c_contiguous. Thus current master always transposes. 

The original example had it's speed up because it `np.roll`ed `df.values` which is C ordered (fast) while the `.blocks` were were (slow).
