### PR TITLE
BUG: fix NDFrame.as_blocks() for sparse containers

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -296,6 +296,7 @@ Bug Fixes
 - Bug in consistency of groupby aggregation when passing a custom function (:issue:`6715`)
 - Bug in resample when ``how=None`` resample freq is the same as the axis frequency (:issue:`5955`)
 - Bug in downcasting inference with empty arrays (:issue:`6733`)
+- Bug in ``obj.blocks`` on sparse containers dropping all but the last items of same for dtype (:issue:`6748`)
 
 pandas 0.13.1
 -------------

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -1515,6 +1515,14 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
 
         self.assertEqual(len(r2.sp_values), len(r1.sp_values))
 
+    def test_as_blocks(self):
+        df = SparseDataFrame({'A': [1.1, 3.3], 'B': [nan, -3.9]},
+                             dtype='float64')
+
+        df_blocks = df.blocks
+        self.assertEqual(list(df_blocks.keys()), ['float64'])
+        assert_frame_equal(df_blocks['float64'], df)
+
 
 def _dense_series_compare(s, f):
     result = f(s)


### PR DESCRIPTION
SparseBlocks don't consolidate, so previous implementation silently dropped all but the last blocks for given dtype:

``` python
In [1]: pd.__version__
Out[1]: '0.13.1-527-g73506cb'

In [2]: pd.SparseDataFrame({'a': [1,2,3, np.nan, np.nan], 'b': [1,2,3, np.nan, np.nan]})
Out[2]: 
    a   b
0   1   1
1   2   2
2   3   3
3 NaN NaN
4 NaN NaN

[5 rows x 2 columns]

In [3]: _2.blocks
Out[3]: 
{'float64':     b
0   1
1   2
2   3
3 NaN
4 NaN

[5 rows x 1 columns]}
```

when the last output should be:

``` python
In [3]: _2.blocks
Out[3]: 
{'float64':     a   b
0   1   1
1   2   2
2   3   3
3 NaN NaN
4 NaN NaN

[5 rows x 2 columns]}


```

This also drops the `columns` kwarg of as_blocks since it doubles reindex functionality.
