### PR TITLE
PERF: perf improvements in timedelta conversions from integer dtypes

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -208,6 +208,7 @@ Improvements to existing features
 - Performance improvement when converting ``DatetimeIndex`` to floating ordinals
   using ``DatetimeConverter`` (:issue:`6636`)
 - Performance improvement for  ``DataFrame.shift`` (:issue:`5609`)
+- Performance improvements in timedelta conversions for integer dtypes (:issue:`6754`)
 
 .. _release.bug_fixes-0.14.0:
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -2130,6 +2130,16 @@ def is_timedelta64_dtype(arr_or_dtype):
     return issubclass(tipo, np.timedelta64)
 
 
+def is_timedelta64_ns_dtype(arr_or_dtype):
+    if isinstance(arr_or_dtype, np.dtype):
+        tipo = arr_or_dtype.type
+    elif isinstance(arr_or_dtype, type):
+        tipo = np.dtype(arr_or_dtype).type
+    else:
+        tipo = arr_or_dtype.dtype.type
+    return tipo == _TD_DTYPE
+
+
 def needs_i8_conversion(arr_or_dtype):
     return (is_datetime64_dtype(arr_or_dtype) or
             is_timedelta64_dtype(arr_or_dtype))

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -173,6 +173,36 @@ class TestTimedeltas(tm.TestCase):
         expected = np.timedelta64(timedelta(seconds=1))
         self.assertEqual(result, expected)
 
+        # arrays of various dtypes
+        arr = np.array([1]*5,dtype='int64')
+        result = to_timedelta(arr,unit='s')
+        expected = Series([ np.timedelta64(1,'s') ]*5)
+        tm.assert_series_equal(result, expected)
+
+        arr = np.array([1]*5,dtype='int64')
+        result = to_timedelta(arr,unit='m')
+        expected = Series([ np.timedelta64(1,'m') ]*5)
+        tm.assert_series_equal(result, expected)
+
+        arr = np.array([1]*5,dtype='int64')
+        result = to_timedelta(arr,unit='h')
+        expected = Series([ np.timedelta64(1,'h') ]*5)
+        tm.assert_series_equal(result, expected)
+
+        arr = np.array([1]*5,dtype='timedelta64[s]')
+        result = to_timedelta(arr)
+        expected = Series([ np.timedelta64(1,'s') ]*5)
+        tm.assert_series_equal(result, expected)
+
+        arr = np.array([1]*5,dtype='timedelta64[D]')
+        result = to_timedelta(arr)
+        expected = Series([ np.timedelta64(1,'D') ]*5)
+        tm.assert_series_equal(result, expected)
+
+        # these will error
+        self.assertRaises(ValueError, lambda : to_timedelta(['1h']))
+        self.assertRaises(ValueError, lambda : to_timedelta(['1m']))
+
     def test_to_timedelta_via_apply(self):
         _skip_if_numpy_not_friendly()
 

--- a/vb_suite/suite.py
+++ b/vb_suite/suite.py
@@ -26,6 +26,7 @@ modules = ['attrs_caching',
            'reshape',
            'stat_ops',
            'timeseries',
+           'timedelta',
            'eval']
 
 by_module = {}

--- a/vb_suite/timedelta.py
+++ b/vb_suite/timedelta.py
@@ -1,0 +1,32 @@
+from vbench.api import Benchmark
+from datetime import datetime
+
+common_setup = """from pandas_vb_common import *
+from pandas import to_timedelta
+"""
+
+#----------------------------------------------------------------------
+# conversion
+
+setup = common_setup + """
+arr = np.random.randint(0,1000,size=10000)
+"""
+
+stmt = "to_timedelta(arr,unit='s')"
+timedelta_convert_int = Benchmark(stmt, setup, start_date=datetime(2014, 1, 1))
+
+setup = common_setup + """
+arr = np.random.randint(0,1000,size=10000)
+arr = [ '{0} days'.format(i) for i in arr ]
+"""
+
+stmt = "to_timedelta(arr)"
+timedelta_convert_string = Benchmark(stmt, setup, start_date=datetime(2014, 1, 1))
+
+setup = common_setup + """
+arr = np.random.randint(0,60,size=10000)
+arr = [ '00:00:{0:02d}'.format(i) for i in arr ]
+"""
+
+stmt = "to_timedelta(arr)"
+timedelta_convert_string_seconds = Benchmark(stmt, setup, start_date=datetime(2014, 1, 1))

--- a/vb_suite/timeseries.py
+++ b/vb_suite/timeseries.py
@@ -278,7 +278,7 @@ from pandas.tseries.converter import DatetimeConverter
 """
 
 datetimeindex_converter = \
-    Benchmark('DatetimeConverter.convert(rng, None, None)', 
+    Benchmark('DatetimeConverter.convert(rng, None, None)',
               setup, start_date=datetime(2013, 1, 1))
 
 # Adding custom business day


### PR DESCRIPTION
```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
timedelta_convert                            |   0.2253 |  71.0374 |   0.0032 |
timedelta_convert_string_seconds             | 186.8856 | 184.1813 |   1.0147 |
timedelta_convert_string                     | 185.8193 | 181.2983 |   1.0249 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

```

Using shortcuts for integers arrays
