### PR TITLE
PRF: Optimize 2d take operations.

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -665,6 +665,17 @@ def take_nd(arr, indexer, axis=0, out=None, fill_value=np.nan,
                     # to crash when trying to cast it to dtype)
                     dtype, fill_value = arr.dtype, arr.dtype.type()
 
+    flip_order = False
+    if arr.ndim == 2:
+        if arr.flags.f_contiguous:
+            flip_order = True
+
+    if flip_order:
+        arr = arr.T
+        axis = arr.ndim - axis - 1
+        if out is not None:
+            out = out.T
+
     # at this point, it's guaranteed that dtype can hold both the arr values
     # and the fill_value
     if out is None:
@@ -682,7 +693,11 @@ def take_nd(arr, indexer, axis=0, out=None, fill_value=np.nan,
 
     func = _get_take_nd_function(arr.ndim, arr.dtype, out.dtype,
                                  axis=axis, mask_info=mask_info)
+
     func(arr, indexer, out, fill_value)
+
+    if flip_order:
+        out = out.T
     return out
 
 

--- a/pandas/src/generate_code.py
+++ b/pandas/src/generate_code.py
@@ -143,34 +143,12 @@ def take_2d_axis1_%(name)s_%(dest)s(ndarray[%(c_type_in)s, ndim=2] values,
 
     fv = fill_value
 
-    IF %(can_copy)s:
-        cdef:
-            %(c_type_out)s *v
-            %(c_type_out)s *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(%(c_type_out)s) and
-            sizeof(%(c_type_out)s) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(%(c_type_out)s) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = %(preval)svalues[i, idx]%(postval)s
 
 """

--- a/pandas/src/generate_code.py
+++ b/pandas/src/generate_code.py
@@ -80,9 +80,9 @@ def take_1d_%(name)s_%(dest)s(ndarray[%(c_type_in)s] values,
 
 take_2d_axis0_template = """@cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_%(name)s_%(dest)s(ndarray[%(c_type_in)s, ndim=2] values,
+def take_2d_axis0_%(name)s_%(dest)s(%(c_type_in)s[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[%(c_type_out)s, ndim=2] out,
+                                    %(c_type_out)s[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -127,9 +127,9 @@ def take_2d_axis0_%(name)s_%(dest)s(ndarray[%(c_type_in)s, ndim=2] values,
 
 take_2d_axis1_template = """@cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_%(name)s_%(dest)s(ndarray[%(c_type_in)s, ndim=2] values,
+def take_2d_axis1_%(name)s_%(dest)s(%(c_type_in)s[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[%(c_type_out)s, ndim=2] out,
+                                    %(c_type_out)s[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx

--- a/pandas/src/generated.pyx
+++ b/pandas/src/generated.pyx
@@ -3453,34 +3453,12 @@ def take_2d_axis1_bool_bool(ndarray[uint8_t, ndim=2] values,
 
     fv = fill_value
 
-    IF True:
-        cdef:
-            uint8_t *v
-            uint8_t *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(uint8_t) and
-            sizeof(uint8_t) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(uint8_t) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = values[i, idx]
 
 @cython.wraparound(False)
@@ -3501,34 +3479,12 @@ def take_2d_axis1_bool_object(ndarray[uint8_t, ndim=2] values,
 
     fv = fill_value
 
-    IF False:
-        cdef:
-            object *v
-            object *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(object) and
-            sizeof(object) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(object) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = True if values[i, idx] > 0 else False
 
 @cython.wraparound(False)
@@ -3549,34 +3505,12 @@ def take_2d_axis1_int8_int8(ndarray[int8_t, ndim=2] values,
 
     fv = fill_value
 
-    IF True:
-        cdef:
-            int8_t *v
-            int8_t *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(int8_t) and
-            sizeof(int8_t) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(int8_t) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = values[i, idx]
 
 @cython.wraparound(False)
@@ -3597,34 +3531,12 @@ def take_2d_axis1_int8_int32(ndarray[int8_t, ndim=2] values,
 
     fv = fill_value
 
-    IF False:
-        cdef:
-            int32_t *v
-            int32_t *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(int32_t) and
-            sizeof(int32_t) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(int32_t) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = values[i, idx]
 
 @cython.wraparound(False)
@@ -3645,34 +3557,12 @@ def take_2d_axis1_int8_int64(ndarray[int8_t, ndim=2] values,
 
     fv = fill_value
 
-    IF False:
-        cdef:
-            int64_t *v
-            int64_t *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(int64_t) and
-            sizeof(int64_t) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(int64_t) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = values[i, idx]
 
 @cython.wraparound(False)
@@ -3693,34 +3583,12 @@ def take_2d_axis1_int8_float64(ndarray[int8_t, ndim=2] values,
 
     fv = fill_value
 
-    IF False:
-        cdef:
-            float64_t *v
-            float64_t *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(float64_t) and
-            sizeof(float64_t) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(float64_t) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = values[i, idx]
 
 @cython.wraparound(False)
@@ -3741,34 +3609,12 @@ def take_2d_axis1_int16_int16(ndarray[int16_t, ndim=2] values,
 
     fv = fill_value
 
-    IF True:
-        cdef:
-            int16_t *v
-            int16_t *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(int16_t) and
-            sizeof(int16_t) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(int16_t) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = values[i, idx]
 
 @cython.wraparound(False)
@@ -3789,34 +3635,12 @@ def take_2d_axis1_int16_int32(ndarray[int16_t, ndim=2] values,
 
     fv = fill_value
 
-    IF False:
-        cdef:
-            int32_t *v
-            int32_t *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(int32_t) and
-            sizeof(int32_t) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(int32_t) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = values[i, idx]
 
 @cython.wraparound(False)
@@ -3837,34 +3661,12 @@ def take_2d_axis1_int16_int64(ndarray[int16_t, ndim=2] values,
 
     fv = fill_value
 
-    IF False:
-        cdef:
-            int64_t *v
-            int64_t *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(int64_t) and
-            sizeof(int64_t) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(int64_t) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = values[i, idx]
 
 @cython.wraparound(False)
@@ -3885,34 +3687,12 @@ def take_2d_axis1_int16_float64(ndarray[int16_t, ndim=2] values,
 
     fv = fill_value
 
-    IF False:
-        cdef:
-            float64_t *v
-            float64_t *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(float64_t) and
-            sizeof(float64_t) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(float64_t) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = values[i, idx]
 
 @cython.wraparound(False)
@@ -3933,34 +3713,12 @@ def take_2d_axis1_int32_int32(ndarray[int32_t, ndim=2] values,
 
     fv = fill_value
 
-    IF True:
-        cdef:
-            int32_t *v
-            int32_t *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(int32_t) and
-            sizeof(int32_t) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(int32_t) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = values[i, idx]
 
 @cython.wraparound(False)
@@ -3981,34 +3739,12 @@ def take_2d_axis1_int32_int64(ndarray[int32_t, ndim=2] values,
 
     fv = fill_value
 
-    IF False:
-        cdef:
-            int64_t *v
-            int64_t *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(int64_t) and
-            sizeof(int64_t) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(int64_t) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = values[i, idx]
 
 @cython.wraparound(False)
@@ -4029,34 +3765,12 @@ def take_2d_axis1_int32_float64(ndarray[int32_t, ndim=2] values,
 
     fv = fill_value
 
-    IF False:
-        cdef:
-            float64_t *v
-            float64_t *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(float64_t) and
-            sizeof(float64_t) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(float64_t) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = values[i, idx]
 
 @cython.wraparound(False)
@@ -4077,34 +3791,12 @@ def take_2d_axis1_int64_int64(ndarray[int64_t, ndim=2] values,
 
     fv = fill_value
 
-    IF True:
-        cdef:
-            int64_t *v
-            int64_t *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(int64_t) and
-            sizeof(int64_t) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(int64_t) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = values[i, idx]
 
 @cython.wraparound(False)
@@ -4125,34 +3817,12 @@ def take_2d_axis1_int64_float64(ndarray[int64_t, ndim=2] values,
 
     fv = fill_value
 
-    IF False:
-        cdef:
-            float64_t *v
-            float64_t *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(float64_t) and
-            sizeof(float64_t) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(float64_t) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = values[i, idx]
 
 @cython.wraparound(False)
@@ -4173,34 +3843,12 @@ def take_2d_axis1_float32_float32(ndarray[float32_t, ndim=2] values,
 
     fv = fill_value
 
-    IF True:
-        cdef:
-            float32_t *v
-            float32_t *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(float32_t) and
-            sizeof(float32_t) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(float32_t) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = values[i, idx]
 
 @cython.wraparound(False)
@@ -4221,34 +3869,12 @@ def take_2d_axis1_float32_float64(ndarray[float32_t, ndim=2] values,
 
     fv = fill_value
 
-    IF False:
-        cdef:
-            float64_t *v
-            float64_t *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(float64_t) and
-            sizeof(float64_t) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(float64_t) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = values[i, idx]
 
 @cython.wraparound(False)
@@ -4269,34 +3895,12 @@ def take_2d_axis1_float64_float64(ndarray[float64_t, ndim=2] values,
 
     fv = fill_value
 
-    IF True:
-        cdef:
-            float64_t *v
-            float64_t *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(float64_t) and
-            sizeof(float64_t) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(float64_t) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = values[i, idx]
 
 @cython.wraparound(False)
@@ -4317,34 +3921,12 @@ def take_2d_axis1_object_object(ndarray[object, ndim=2] values,
 
     fv = fill_value
 
-    IF False:
-        cdef:
-            object *v
-            object *o
-
-        #GH3130
-        if (values.strides[0] == out.strides[0] and
-            values.strides[0] == sizeof(object) and
-            sizeof(object) * n >= 256):
-
-            for j from 0 <= j < k:
-                idx = indexer[j]
-                if idx == -1:
-                    for i from 0 <= i < n:
-                        out[i, j] = fv
-                else:
-                    v = &values[0, idx]
-                    o = &out[0, j]
-                    memmove(o, v, <size_t>(sizeof(object) * n))
-            return
-
-    for j from 0 <= j < k:
-        idx = indexer[j]
-        if idx == -1:
-            for i from 0 <= i < n:
+    for i from 0 <= i < n:
+        for j from 0 <= j < k:
+            idx = indexer[j]
+            if idx == -1:
                 out[i, j] = fv
-        else:
-            for i from 0 <= i < n:
+            else:
                 out[i, j] = values[i, idx]
 
 

--- a/pandas/src/generated.pyx
+++ b/pandas/src/generated.pyx
@@ -2581,9 +2581,9 @@ def take_1d_object_object(ndarray[object] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_bool_bool(ndarray[uint8_t, ndim=2] values,
+def take_2d_axis0_bool_bool(uint8_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[uint8_t, ndim=2] out,
+                                    uint8_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -2626,9 +2626,9 @@ def take_2d_axis0_bool_bool(ndarray[uint8_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_bool_object(ndarray[uint8_t, ndim=2] values,
+def take_2d_axis0_bool_object(uint8_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[object, ndim=2] out,
+                                    object[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -2671,9 +2671,9 @@ def take_2d_axis0_bool_object(ndarray[uint8_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_int8_int8(ndarray[int8_t, ndim=2] values,
+def take_2d_axis0_int8_int8(int8_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[int8_t, ndim=2] out,
+                                    int8_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -2716,9 +2716,9 @@ def take_2d_axis0_int8_int8(ndarray[int8_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_int8_int32(ndarray[int8_t, ndim=2] values,
+def take_2d_axis0_int8_int32(int8_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[int32_t, ndim=2] out,
+                                    int32_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -2761,9 +2761,9 @@ def take_2d_axis0_int8_int32(ndarray[int8_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_int8_int64(ndarray[int8_t, ndim=2] values,
+def take_2d_axis0_int8_int64(int8_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[int64_t, ndim=2] out,
+                                    int64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -2806,9 +2806,9 @@ def take_2d_axis0_int8_int64(ndarray[int8_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_int8_float64(ndarray[int8_t, ndim=2] values,
+def take_2d_axis0_int8_float64(int8_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[float64_t, ndim=2] out,
+                                    float64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -2851,9 +2851,9 @@ def take_2d_axis0_int8_float64(ndarray[int8_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_int16_int16(ndarray[int16_t, ndim=2] values,
+def take_2d_axis0_int16_int16(int16_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[int16_t, ndim=2] out,
+                                    int16_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -2896,9 +2896,9 @@ def take_2d_axis0_int16_int16(ndarray[int16_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_int16_int32(ndarray[int16_t, ndim=2] values,
+def take_2d_axis0_int16_int32(int16_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[int32_t, ndim=2] out,
+                                    int32_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -2941,9 +2941,9 @@ def take_2d_axis0_int16_int32(ndarray[int16_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_int16_int64(ndarray[int16_t, ndim=2] values,
+def take_2d_axis0_int16_int64(int16_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[int64_t, ndim=2] out,
+                                    int64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -2986,9 +2986,9 @@ def take_2d_axis0_int16_int64(ndarray[int16_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_int16_float64(ndarray[int16_t, ndim=2] values,
+def take_2d_axis0_int16_float64(int16_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[float64_t, ndim=2] out,
+                                    float64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3031,9 +3031,9 @@ def take_2d_axis0_int16_float64(ndarray[int16_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_int32_int32(ndarray[int32_t, ndim=2] values,
+def take_2d_axis0_int32_int32(int32_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[int32_t, ndim=2] out,
+                                    int32_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3076,9 +3076,9 @@ def take_2d_axis0_int32_int32(ndarray[int32_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_int32_int64(ndarray[int32_t, ndim=2] values,
+def take_2d_axis0_int32_int64(int32_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[int64_t, ndim=2] out,
+                                    int64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3121,9 +3121,9 @@ def take_2d_axis0_int32_int64(ndarray[int32_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_int32_float64(ndarray[int32_t, ndim=2] values,
+def take_2d_axis0_int32_float64(int32_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[float64_t, ndim=2] out,
+                                    float64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3166,9 +3166,9 @@ def take_2d_axis0_int32_float64(ndarray[int32_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_int64_int64(ndarray[int64_t, ndim=2] values,
+def take_2d_axis0_int64_int64(int64_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[int64_t, ndim=2] out,
+                                    int64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3211,9 +3211,9 @@ def take_2d_axis0_int64_int64(ndarray[int64_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_int64_float64(ndarray[int64_t, ndim=2] values,
+def take_2d_axis0_int64_float64(int64_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[float64_t, ndim=2] out,
+                                    float64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3256,9 +3256,9 @@ def take_2d_axis0_int64_float64(ndarray[int64_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_float32_float32(ndarray[float32_t, ndim=2] values,
+def take_2d_axis0_float32_float32(float32_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[float32_t, ndim=2] out,
+                                    float32_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3301,9 +3301,9 @@ def take_2d_axis0_float32_float32(ndarray[float32_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_float32_float64(ndarray[float32_t, ndim=2] values,
+def take_2d_axis0_float32_float64(float32_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[float64_t, ndim=2] out,
+                                    float64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3346,9 +3346,9 @@ def take_2d_axis0_float32_float64(ndarray[float32_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_float64_float64(ndarray[float64_t, ndim=2] values,
+def take_2d_axis0_float64_float64(float64_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[float64_t, ndim=2] out,
+                                    float64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3391,9 +3391,9 @@ def take_2d_axis0_float64_float64(ndarray[float64_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis0_object_object(ndarray[object, ndim=2] values,
+def take_2d_axis0_object_object(object[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[object, ndim=2] out,
+                                    object[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3437,9 +3437,9 @@ def take_2d_axis0_object_object(ndarray[object, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_bool_bool(ndarray[uint8_t, ndim=2] values,
+def take_2d_axis1_bool_bool(uint8_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[uint8_t, ndim=2] out,
+                                    uint8_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3463,9 +3463,9 @@ def take_2d_axis1_bool_bool(ndarray[uint8_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_bool_object(ndarray[uint8_t, ndim=2] values,
+def take_2d_axis1_bool_object(uint8_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[object, ndim=2] out,
+                                    object[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3489,9 +3489,9 @@ def take_2d_axis1_bool_object(ndarray[uint8_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_int8_int8(ndarray[int8_t, ndim=2] values,
+def take_2d_axis1_int8_int8(int8_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[int8_t, ndim=2] out,
+                                    int8_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3515,9 +3515,9 @@ def take_2d_axis1_int8_int8(ndarray[int8_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_int8_int32(ndarray[int8_t, ndim=2] values,
+def take_2d_axis1_int8_int32(int8_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[int32_t, ndim=2] out,
+                                    int32_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3541,9 +3541,9 @@ def take_2d_axis1_int8_int32(ndarray[int8_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_int8_int64(ndarray[int8_t, ndim=2] values,
+def take_2d_axis1_int8_int64(int8_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[int64_t, ndim=2] out,
+                                    int64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3567,9 +3567,9 @@ def take_2d_axis1_int8_int64(ndarray[int8_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_int8_float64(ndarray[int8_t, ndim=2] values,
+def take_2d_axis1_int8_float64(int8_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[float64_t, ndim=2] out,
+                                    float64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3593,9 +3593,9 @@ def take_2d_axis1_int8_float64(ndarray[int8_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_int16_int16(ndarray[int16_t, ndim=2] values,
+def take_2d_axis1_int16_int16(int16_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[int16_t, ndim=2] out,
+                                    int16_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3619,9 +3619,9 @@ def take_2d_axis1_int16_int16(ndarray[int16_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_int16_int32(ndarray[int16_t, ndim=2] values,
+def take_2d_axis1_int16_int32(int16_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[int32_t, ndim=2] out,
+                                    int32_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3645,9 +3645,9 @@ def take_2d_axis1_int16_int32(ndarray[int16_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_int16_int64(ndarray[int16_t, ndim=2] values,
+def take_2d_axis1_int16_int64(int16_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[int64_t, ndim=2] out,
+                                    int64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3671,9 +3671,9 @@ def take_2d_axis1_int16_int64(ndarray[int16_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_int16_float64(ndarray[int16_t, ndim=2] values,
+def take_2d_axis1_int16_float64(int16_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[float64_t, ndim=2] out,
+                                    float64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3697,9 +3697,9 @@ def take_2d_axis1_int16_float64(ndarray[int16_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_int32_int32(ndarray[int32_t, ndim=2] values,
+def take_2d_axis1_int32_int32(int32_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[int32_t, ndim=2] out,
+                                    int32_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3723,9 +3723,9 @@ def take_2d_axis1_int32_int32(ndarray[int32_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_int32_int64(ndarray[int32_t, ndim=2] values,
+def take_2d_axis1_int32_int64(int32_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[int64_t, ndim=2] out,
+                                    int64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3749,9 +3749,9 @@ def take_2d_axis1_int32_int64(ndarray[int32_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_int32_float64(ndarray[int32_t, ndim=2] values,
+def take_2d_axis1_int32_float64(int32_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[float64_t, ndim=2] out,
+                                    float64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3775,9 +3775,9 @@ def take_2d_axis1_int32_float64(ndarray[int32_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_int64_int64(ndarray[int64_t, ndim=2] values,
+def take_2d_axis1_int64_int64(int64_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[int64_t, ndim=2] out,
+                                    int64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3801,9 +3801,9 @@ def take_2d_axis1_int64_int64(ndarray[int64_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_int64_float64(ndarray[int64_t, ndim=2] values,
+def take_2d_axis1_int64_float64(int64_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[float64_t, ndim=2] out,
+                                    float64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3827,9 +3827,9 @@ def take_2d_axis1_int64_float64(ndarray[int64_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_float32_float32(ndarray[float32_t, ndim=2] values,
+def take_2d_axis1_float32_float32(float32_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[float32_t, ndim=2] out,
+                                    float32_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3853,9 +3853,9 @@ def take_2d_axis1_float32_float32(ndarray[float32_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_float32_float64(ndarray[float32_t, ndim=2] values,
+def take_2d_axis1_float32_float64(float32_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[float64_t, ndim=2] out,
+                                    float64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3879,9 +3879,9 @@ def take_2d_axis1_float32_float64(ndarray[float32_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_float64_float64(ndarray[float64_t, ndim=2] values,
+def take_2d_axis1_float64_float64(float64_t[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[float64_t, ndim=2] out,
+                                    float64_t[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx
@@ -3905,9 +3905,9 @@ def take_2d_axis1_float64_float64(ndarray[float64_t, ndim=2] values,
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def take_2d_axis1_object_object(ndarray[object, ndim=2] values,
+def take_2d_axis1_object_object(object[:, :] values,
                                     ndarray[int64_t] indexer,
-                                    ndarray[object, ndim=2] out,
+                                    object[:, :] out,
                                     fill_value=np.nan):
     cdef:
         Py_ssize_t i, j, k, n, idx


### PR DESCRIPTION
Wanted to get eyes on this. The original axis=1 2d methods were optimized for Fortran. I changed it to be friendly to C order and transposed the array when F ordered. 

These timings are for master. `cdf` is just the consolidated dataframe to switch from C to F.

```
In [3]:
%timeit a = df.take(indexes, axis=0)
10 loops, best of 3: 214 ms per loop

In [4]:
%timeit a = df.take(indexes, axis=1)
1 loops, best of 3: 978 ms per loop

In [8]:
%timeit cdf.take(indexes, axis=0)
1 loops, best of 3: 1.6 s per loop

In [9]:
%timeit cdf.take(indexes, axis=1)
1 loops, best of 3: 216 ms per loop
```

http://nbviewer.ipython.org/gist/dalejung/9914956/pandas%20perf_baseline.ipynb

The PR timings are:

```
In [18]:

%timeit a = df.take(indexes, axis=0)
10 loops, best of 3: 215 ms per loop
In [19]:

%timeit a = df.take(indexes, axis=1)
1 loops, best of 3: 265 ms per loop

In [23]:
%timeit cdf.take(indexes, axis=0)
1 loops, best of 3: 290 ms per loop

In [24]:
%timeit cdf.take(indexes, axis=1)
1 loops, best of 3: 222 ms per loop
```

http://nbviewer.ipython.org/gist/dalejung/9914956/pandas%20perf.ipynb

It's similar behavior to the shift perf update. 

For a numpy baseline i wrote:

``` python
# wrap np.take to reshape to C order
def quick_take(values, indexer, axis=0):
    f_ordered = values.flags.f_contiguous
    if f_ordered:
        values = values.T
        axis = values.ndim - axis - 1
    res = values.take(indexes, axis) 
    if f_ordered:
        res = res.T
    return res    

%timeit quick_take(df.values, indexes, axis=0)
1 loops, best of 3: 234 ms per loop

In [14]:
%timeit quick_take(df.values, indexes, axis=1)
1 loops, best of 3: 271 ms per loop
```

Which are similar timings.
