### PR TITLE
ENH: rename function now has errors keyword

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -154,6 +154,8 @@ API Changes
 - ``Series.iteritems()`` is now lazy (returns an iterator rather than a list). This was the documented behavior prior to 0.14. (:issue:`6760`)
 - ``Panel.shift`` now uses ``NDFrame.shift``. It no longer drops the ``nan`` data and retains its original shape.  (:issue:`4867`)
 
+- ``rename`` function can now accept ``errors`` keyword to suppress error raised by a passed function, or raise ValueError when any of label in a passed dict is not found in the target axis.
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -199,6 +199,8 @@ API changes
 - ``Series.iteritems()`` is now lazy (returns an iterator rather than a list). This was the documented behavior prior to 0.14. (:issue:`6760`)
 - ``Panel.shift`` now uses ``NDFrame.shift``. It no longer drops the ``nan`` data and retains its original shape.  (:issue:`4867`)
 
+- ``rename`` function can now accept ``errors`` keyword to suppress error raised by a passed function, or raise ValueError when any of label in a passed dict is not found in the target axis. From this version, passing a dict with labels which isn't included in the axis results in FutureWarning, and will raise ValueError in future version.
+
 
 MultiIndexing Using Slicers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -9031,14 +9031,52 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         index = MultiIndex.from_tuples(tuples_index, names=['foo', 'bar'])
         columns = MultiIndex.from_tuples(tuples_columns, names=['fizz', 'buzz'])
         renamer = DataFrame([(0,0),(1,1)], index=index, columns=columns)
+
+        with tm.assert_produces_warning():
+            # should raise ValueError in future version
+            renamed = renamer.rename(index={'foo1': 'foo3', 'bar2': 'bar3'},
+                                     columns={'fizz1': 'fizz3', 'buzz2': 'buzz3'})
+            new_index = MultiIndex.from_tuples([('foo3', 'bar1'), ('foo2', 'bar3')])
+            new_columns = MultiIndex.from_tuples([('fizz3', 'buzz1'), ('fizz2', 'buzz3')])
+            self.assert_numpy_array_equal(renamed.index, new_index)
+            self.assert_numpy_array_equal(renamed.columns, new_columns)
+            self.assertEquals(renamed.index.names, renamer.index.names)
+            self.assertEquals(renamed.columns.names, renamer.columns.names)
+
+        self.assertRaises(ValueError, renamer.rename, index={'foo1': 'foo3', 'bar2': 'bar3'},
+                                     columns={'fizz1': 'fizz3', 'buzz2': 'buzz3'}, errors='raise')
+
         renamed = renamer.rename(index={'foo1': 'foo3', 'bar2': 'bar3'},
-                                 columns={'fizz1': 'fizz3', 'buzz2': 'buzz3'})
+                                 columns={'fizz1': 'fizz3', 'buzz2': 'buzz3'}, errors='ignore')
         new_index = MultiIndex.from_tuples([('foo3', 'bar1'), ('foo2', 'bar3')])
         new_columns = MultiIndex.from_tuples([('fizz3', 'buzz1'), ('fizz2', 'buzz3')])
         self.assert_numpy_array_equal(renamed.index, new_index)
         self.assert_numpy_array_equal(renamed.columns, new_columns)
         self.assertEquals(renamed.index.names, renamer.index.names)
         self.assertEquals(renamed.columns.names, renamer.columns.names)
+
+        # error handling
+        data = {1: {'A': 0, 'B': 1}, '2': {'C':1, 'D': 2}}
+        df = DataFrame(data)
+
+        # errors = default
+        with tm.assert_produces_warning():
+            # should raise ValueError in future version
+            renamed = df.rename(columns={'1': 'One', '2': 'Two'})
+            self.assertEqual(renamed.columns.tolist(), [1, 'Two'])
+        self.assertRaises(TypeError, df.rename, columns=lambda x: x + 1)
+
+        # errors = raise
+        self.assertRaises(ValueError, df.rename,
+                          columns={'1': 'One', '2': 'Two'}, errors='raise')
+        self.assertRaises(TypeError, df.rename, columns=lambda x: x + 1, errors='raise')
+
+        # errors = ignore
+        renamed = df.rename(columns={'1': 'One', '2': 'Two'}, errors='ignore')
+        self.assertEqual(renamed.columns.tolist(), [1, 'Two'])
+
+        renamed = df.rename(columns=lambda x: x + 1, errors='ignore')
+        self.assertEqual(renamed.columns.tolist(), [2, '2'])
 
     def test_rename_nocopy(self):
         renamed = self.frame.rename(columns={'C': 'foo'}, copy=False)


### PR DESCRIPTION
Same background as #6736.

Currently,
- When a function is passed, any error caused by the function results in `rename` error.
- When a dict is passed, label which is not included in the axis will be silently skipped. Even though `drop` raises `ValueError` in such a case.

```
>>> df = pd.DataFrame({1: [1, 2], 'B': pd.to_datetime(['2010-01-01', np.nan])})
>>> renamed_func = df.rename(columns=lambda x: x + 1)
TypeError: cannot concatenate 'str' and 'int' objects

>>> renamed_dict = df.rename(columns={'B':'C', 'D':'E'})
Index([1, u'C'], dtype='object')
```

I think it is nice if `rename` also has `errors` keyword to:
- Suppress error raised by the function and `rename` only non-problematic labels (`errors='ignore'`), or raise error whatever derived from the function (`errors='raise'`).
- Suppress error if label is not found in the target axis, and `rename` only non-problematic labels (`errors='ignore'`), or raise error if any of label is not included in the target axis (`errors='raise'`).

I feel the default should be `errors='raise'` in the future version based on the other functions behavior. This doesn't affect to the current behavior when a function is passed, but affects to when a dict is passed. 

In this version, `rename` raise `FutureWarning` for future precaution if it is called with non-existing label. And it is possible to force `rename` to raise `ValueError` in such a case by specifying `errors='raise'`.

```
>>> renamed_func = df.rename(columns=lambda x: x + 1, errors='ignore')
Index([2, u'B'], dtype='object')
>>> renamed_dict = df.rename(columns={'B':'C', 'D':'E', 'F':'G'}, errors='ignore')
Index([1, u'C'], dtype='object')

>>> renamed_func = df.rename(columns=lambda x: x + 1, errors='raise')
TypeError: cannot concatenate 'str' and 'int' objects
>>> renamed_dict = df.rename(columns={'B':'C', 'D':'E', 'F':'G'}, errors='raise')
ValueError: labels ['D' 'F'] not contained in axis
```
