### PR TITLE
BUG: fix metacharacter replacement bug in DataFrame.replace()

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -301,7 +301,8 @@ Bug Fixes
 - Bug in downcasting inference with empty arrays (:issue:`6733`)
 - Bug in ``obj.blocks`` on sparse containers dropping all but the last items of same for dtype (:issue:`6748`)
 - Bug in unpickling ``NaT (NaTType)`` (:issue:`4606`)
-- Bug in setting a tz-aware index directly via ``.index`` (:issue:`6785`)
+- Bug in ``DataFrame.replace()`` where regex metacharacters were being treated
+  as regexs even when ``regex=False`` (:issue:`6777`).
 
 pandas 0.13.1
 -------------

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1555,7 +1555,7 @@ class ObjectBlock(Block):
     def _replace_single(self, to_replace, value, inplace=False, filter=None,
                         regex=False):
         # to_replace is regex compilable
-        to_rep_re = com.is_re_compilable(to_replace)
+        to_rep_re = regex and com.is_re_compilable(to_replace)
 
         # regex is regex compilable
         regex_re = com.is_re_compilable(regex)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -7857,6 +7857,15 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_frame_equal(res, expec)
         self.assertEqual(res.a.dtype, np.object_)
 
+    def test_replace_regex_metachar(self):
+        metachars = '[]', '()', '\d', '\w', '\s'
+
+        for metachar in metachars:
+            df = DataFrame({'a': [metachar, 'else']})
+            result = df.replace({'a': {metachar: 'paren'}})
+            expected = DataFrame({'a': ['paren', 'else']})
+            tm.assert_frame_equal(result, expected)
+
     def test_replace(self):
         self.tsframe['A'][:5] = nan
         self.tsframe['A'][-5:] = nan


### PR DESCRIPTION
closes #6777
