### PR TITLE
BUG: Bug in setting a tz-aware index directly via .index (GH6785)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -301,6 +301,7 @@ Bug Fixes
 - Bug in downcasting inference with empty arrays (:issue:`6733`)
 - Bug in ``obj.blocks`` on sparse containers dropping all but the last items of same for dtype (:issue:`6748`)
 - Bug in unpickling ``NaT (NaTType)`` (:issue:`4606`)
+- Bug in setting a tz-aware index directly via ``.index`` (:issue:`6785`)
 
 pandas 0.13.1
 -------------

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -154,7 +154,7 @@ class Index(IndexOpsMixin, FrozenNDArray):
                 if (inferred.startswith('datetime') or
                         tslib.is_timestamp_array(subarr)):
                     from pandas.tseries.index import DatetimeIndex
-                    return DatetimeIndex(data, copy=copy, name=name, **kwargs)
+                    return DatetimeIndex(subarr, copy=copy, name=name, **kwargs)
                 elif inferred == 'period':
                     return PeriodIndex(subarr, name=name, **kwargs)
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2125,6 +2125,15 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         result = df['D']
         assert_series_equal(result, expected)
 
+        # GH 6785
+        # set the index manually
+        import pytz
+        df = DataFrame([{'ts':datetime(2014, 4, 1, tzinfo=pytz.utc), 'foo':1}])
+        expected = df.set_index('ts')
+        df.index = df['ts']
+        df.pop('ts')
+        assert_frame_equal(df, expected)
+
     def test_set_index_multiindexcolumns(self):
         columns = MultiIndex.from_tuples([('foo', 1), ('foo', 2), ('bar', 1)])
         df = DataFrame(np.random.randn(3, 3), columns=columns)


### PR DESCRIPTION
closes #6785
