### PR TITLE
StataWriter: Replace missing values in string columns by an empty string

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -302,6 +302,8 @@ Bug Fixes
 - Bug in ``obj.blocks`` on sparse containers dropping all but the last items of same for dtype (:issue:`6748`)
 - Bug in unpickling ``NaT (NaTType)`` (:issue:`4606`)
 - Bug in setting a tz-aware index directly via ``.index`` (:issue:`6785`)
+- StataWriter replaces missing values in string columns by empty string (:issue:`6802`)
+
 
 pandas 0.13.1
 -------------

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1319,6 +1319,8 @@ class StataWriter(StataParser):
             for i, var in enumerate(row):
                 typ = ord(typlist[i])
                 if typ <= 244:  # we've got a string
+                    if var is None or var == np.nan:
+                        var = _pad_bytes('', typ)
                     if len(var) < typ:
                         var = _pad_bytes(var, typ)
                     self._write(var)

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -508,6 +508,16 @@ class TestStata(tm.TestCase):
             tm.assert_frame_equal(written_and_read_again.set_index('index'),
                                   expected)
 
+    def test_write_missing_strings(self):
+        original = DataFrame([["1"], [None]], columns=["foo"])
+        expected = DataFrame([["1"], [""]], columns=["foo"])
+        expected.index.name = 'index'
+        with tm.ensure_clean() as path:
+            original.to_stata(path)
+            written_and_read_again = self.read_dta(path)
+            tm.assert_frame_equal(written_and_read_again.set_index('index'),
+                                  expected)
+
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
Otherwise writing fails with errors about len() applied to a float or NoneType.
