### PR TITLE
Remove number of deprecated parameters/functions/classes [fix #6641]

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -180,6 +180,28 @@ Prior Version Deprecations/Changes
 
 - Remove ``column`` keyword from ``DataFrame.sort`` (:issue:`4370`)
 
+- Remove ``precision`` keyword from :func:`set_eng_float_format` (:issue:`6641`)
+
+- Remove ``force_unicode`` keyword from :meth:`DataFrame.to_string`,
+  :meth:`DataFrame.to_latex`, and :meth:`DataFrame.to_html`; these function
+  encode in unicode by default (:issue:`6641`)
+
+- Remove ``nanRep`` keyword from :meth:`DataFrame.to_csv` and
+  :meth:`DataFrame.to_string` (:issue:`6641`)
+
+- Remove ``unique`` keyword from :meth:`HDFStore.select_column` (:issue:`6641`)
+
+- Remove ``inferTimeRule`` keyword from :func:`Timestamp.offset` (:issue:`6641`)
+
+- Remove ``name`` keyword from :func:`get_data_yahoo` and
+  :func:`get_data_google` (:issue:`6641`)
+
+- Remove ``offset`` keyword from :class:`DatetimeIndex` constructor
+  (:issue:`6641`)
+
+- Remove ``time_rule`` from several rolling-moment statistical functions, such
+  as :func:`rolling_sum` (:issue:`6641`)
+
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -328,6 +328,29 @@ Therse are prior version deprecations that are taking effect as of 0.14.0.
 
 - Remove ``column`` keyword from ``DataFrame.sort`` (:issue:`4370`)
 
+- Remove ``precision`` keyword from :func:`set_eng_float_format` (:issue:`6641`)
+
+- Remove ``force_unicode`` keyword from :meth:`DataFrame.to_string`,
+  :meth:`DataFrame.to_latex`, and :meth:`DataFrame.to_html`; these function
+  encode in unicode by default (:issue:`6641`)
+
+- Remove ``nanRep`` keyword from :meth:`DataFrame.to_csv` and
+  :meth:`DataFrame.to_string` (:issue:`6641`)
+
+- Remove ``unique`` keyword from :meth:`HDFStore.select_column` (:issue:`6641`)
+
+- Remove ``inferTimeRule`` keyword from :func:`Timestamp.offset` (:issue:`6641`)
+
+- Remove ``name`` keyword from :func:`get_data_yahoo` and
+  :func:`get_data_google` (:issue:`6641`)
+
+- Remove ``offset`` keyword from :class:`DatetimeIndex` constructor
+  (:issue:`6641`)
+
+- Remove ``time_rule`` from several rolling-moment statistical functions, such
+  as :func:`rolling_sum` (:issue:`6641`)
+  
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -358,15 +358,10 @@ class DataFrameFormatter(TableFormatter):
 
         return strcols
 
-    def to_string(self, force_unicode=None):
+    def to_string(self):
         """
         Render a DataFrame to a console-friendly tabular output.
         """
-        import warnings
-        if force_unicode is not None:  # pragma: no cover
-            warnings.warn(
-                "force_unicode is deprecated, it will have no effect",
-                FutureWarning)
 
         frame = self.frame
 
@@ -423,8 +418,7 @@ class DataFrameFormatter(TableFormatter):
             st = ed
         return '\n\n'.join(str_lst)
 
-    def to_latex(self, force_unicode=None, column_format=None,
-                 longtable=False):
+    def to_latex(self, column_format=None, longtable=False):
         """
         Render a DataFrame to a LaTeX tabular/longtable environment output.
         """
@@ -434,12 +428,6 @@ class DataFrameFormatter(TableFormatter):
                 return 'r'
             else:
                 return 'l'
-
-        import warnings
-        if force_unicode is not None:  # pragma: no cover
-            warnings.warn(
-                "force_unicode is deprecated, it will have no effect",
-                FutureWarning)
 
         frame = self.frame
 
@@ -2139,7 +2127,7 @@ class EngFormatter(object):
         return formatted  # .strip()
 
 
-def set_eng_float_format(precision=None, accuracy=3, use_eng_prefix=False):
+def set_eng_float_format(accuracy=3, use_eng_prefix=False):
     """
     Alter default behavior on how float is formatted in DataFrame.
     Format float in engineering format. By accuracy, we mean the number of
@@ -2147,11 +2135,6 @@ def set_eng_float_format(precision=None, accuracy=3, use_eng_prefix=False):
 
     See also EngFormatter.
     """
-    if precision is not None:  # pragma: no cover
-        import warnings
-        warnings.warn("'precision' parameter in set_eng_float_format is "
-                      "being renamed to 'accuracy'", FutureWarning)
-        accuracy = precision
 
     set_option("display.float_format", EngFormatter(accuracy, use_eng_prefix))
     set_option("display.column_space", max(12, accuracy + 9))

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1071,7 +1071,7 @@ class DataFrame(NDFrame):
     @deprecate_kwarg(old_arg_name='cols', new_arg_name='columns')
     def to_csv(self, path_or_buf=None, sep=",", na_rep='', float_format=None,
                columns=None, header=True, index=True, index_label=None,
-               mode='w', nanRep=None, encoding=None, quoting=None,
+               mode='w', encoding=None, quoting=None,
                quotechar='"', line_terminator='\n', chunksize=None,
                tupleize_cols=False, date_format=None, doublequote=True,
                escapechar=None, **kwds):
@@ -1128,10 +1128,6 @@ class DataFrame(NDFrame):
             Format string for datetime objects
         cols : kwarg only alias of columns [deprecated]
         """
-        if nanRep is not None:  # pragma: no cover
-            warnings.warn("nanRep is deprecated, use na_rep",
-                          FutureWarning)
-            na_rep = nanRep
 
         formatter = fmt.CSVFormatter(self, path_or_buf,
                                      line_terminator=line_terminator,
@@ -1275,21 +1271,12 @@ class DataFrame(NDFrame):
     @Appender(fmt.docstring_to_string, indents=1)
     def to_string(self, buf=None, columns=None, col_space=None, colSpace=None,
                   header=True, index=True, na_rep='NaN', formatters=None,
-                  float_format=None, sparsify=None, nanRep=None,
-                  index_names=True, justify=None, force_unicode=None,
-                  line_width=None, max_rows=None, max_cols=None,
+                  float_format=None, sparsify=None, index_names=True,
+                  justify=None, line_width=None, max_rows=None, max_cols=None,
                   show_dimensions=False):
         """
         Render a DataFrame to a console-friendly tabular output.
         """
-        if force_unicode is not None:  # pragma: no cover
-            warnings.warn("force_unicode is deprecated, it will have no "
-                          "effect", FutureWarning)
-
-        if nanRep is not None:  # pragma: no cover
-            warnings.warn("nanRep is deprecated, use na_rep",
-                          FutureWarning)
-            na_rep = nanRep
 
         if colSpace is not None:  # pragma: no cover
             warnings.warn("colSpace is deprecated, use col_space",
@@ -1318,9 +1305,8 @@ class DataFrame(NDFrame):
     def to_html(self, buf=None, columns=None, col_space=None, colSpace=None,
                 header=True, index=True, na_rep='NaN', formatters=None,
                 float_format=None, sparsify=None, index_names=True,
-                justify=None, force_unicode=None, bold_rows=True,
-                classes=None, escape=True, max_rows=None, max_cols=None,
-                show_dimensions=False):
+                justify=None, bold_rows=True, classes=None, escape=True,
+                max_rows=None, max_cols=None, show_dimensions=False):
         """
         Render a DataFrame as an HTML table.
 
@@ -1340,10 +1326,6 @@ class DataFrame(NDFrame):
             all.
 
         """
-
-        if force_unicode is not None:  # pragma: no cover
-            warnings.warn("force_unicode is deprecated, it will have no "
-                          "effect", FutureWarning)
 
         if colSpace is not None:  # pragma: no cover
             warnings.warn("colSpace is deprecated, use col_space",
@@ -1372,7 +1354,7 @@ class DataFrame(NDFrame):
     def to_latex(self, buf=None, columns=None, col_space=None, colSpace=None,
                  header=True, index=True, na_rep='NaN', formatters=None,
                  float_format=None, sparsify=None, index_names=True,
-                 bold_rows=True, force_unicode=None, longtable=False):
+                 bold_rows=True, longtable=False):
         """
         Render a DataFrame to a tabular environment table. You can splice
         this into a LaTeX document. Requires \\usepackage(booktabs}.
@@ -1386,10 +1368,6 @@ class DataFrame(NDFrame):
             a \\usepackage{longtable} to your LaTeX preamble.
 
         """
-
-        if force_unicode is not None:  # pragma: no cover
-            warnings.warn("force_unicode is deprecated, it will have no "
-                          "effect", FutureWarning)
 
         if colSpace is not None:  # pragma: no cover
             warnings.warn("colSpace is deprecated, use col_space",

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -881,7 +881,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                                                str(self.dtype.name))
 
     def to_string(self, buf=None, na_rep='NaN', float_format=None,
-                  nanRep=None, length=False, dtype=False, name=False):
+                  length=False, dtype=False, name=False):
         """
         Render a string representation of the Series
 
@@ -905,10 +905,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         -------
         formatted : string (if not buffer passed)
         """
-
-        if nanRep is not None:  # pragma: no cover
-            warnings.warn("nanRep is deprecated, use na_rep", FutureWarning)
-            na_rep = nanRep
 
         the_repr = self._get_repr(float_format=float_format, na_rep=na_rep,
                                   length=length, dtype=dtype, name=name)

--- a/pandas/io/data.py
+++ b/pandas/io/data.py
@@ -338,11 +338,7 @@ _source_functions = {'google': _get_hist_google, 'yahoo': _get_hist_yahoo}
 
 
 def _get_data_from(symbols, start, end, retry_count, pause, adjust_price,
-                   ret_index, chunksize, source, name):
-    if name is not None:
-        warnings.warn("Arg 'name' is deprecated, please use 'symbols' "
-                      "instead.", FutureWarning)
-        symbols = name
+                   ret_index, chunksize, source):
 
     src_fn = _source_functions[source]
 
@@ -367,7 +363,7 @@ def _get_data_from(symbols, start, end, retry_count, pause, adjust_price,
 
 def get_data_yahoo(symbols=None, start=None, end=None, retry_count=3,
                    pause=0.001, adjust_price=False, ret_index=False,
-                   chunksize=25, name=None):
+                   chunksize=25):
     """
     Returns DataFrame/Panel of historical stock prices from symbols, over date
     range, start to end. To avoid being penalized by Yahoo! Finance servers,
@@ -402,12 +398,12 @@ def get_data_yahoo(symbols=None, start=None, end=None, retry_count=3,
     hist_data : DataFrame (str) or Panel (array-like object, DataFrame)
     """
     return _get_data_from(symbols, start, end, retry_count, pause,
-                          adjust_price, ret_index, chunksize, 'yahoo', name)
+                          adjust_price, ret_index, chunksize, 'yahoo')
 
 
 def get_data_google(symbols=None, start=None, end=None, retry_count=3,
                     pause=0.001, adjust_price=False, ret_index=False,
-                    chunksize=25, name=None):
+                    chunksize=25):
     """
     Returns DataFrame/Panel of historical stock prices from symbols, over date
     range, start to end. To avoid being penalized by Google Finance servers,
@@ -436,7 +432,7 @@ def get_data_google(symbols=None, start=None, end=None, retry_count=3,
     hist_data : DataFrame (str) or Panel (array-like object, DataFrame)
     """
     return _get_data_from(symbols, start, end, retry_count, pause,
-                          adjust_price, ret_index, chunksize, 'google', name)
+                          adjust_price, ret_index, chunksize, 'google')
 
 
 _FRED_URL = "http://research.stlouisfed.org/fred2/series/"

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -685,13 +685,6 @@ class HDFStore(StringMixin):
         return self.get_storer(key).read_coordinates(where=where, start=start,
                                                      stop=stop, **kwargs)
 
-    def unique(self, key, column, **kwargs):
-        warnings.warn("unique(key,column) is deprecated\n"
-                      "use select_column(key,column).unique() instead",
-                      FutureWarning)
-        return self.get_storer(key).read_column(column=column,
-                                                **kwargs).unique()
-
     def select_column(self, key, column, **kwargs):
         """
         return a single column from the table. This is generally only useful to

--- a/pandas/stats/tests/test_moments.py
+++ b/pandas/stats/tests/test_moments.py
@@ -485,27 +485,6 @@ class TestMoments(tm.TestCase):
             assert_series_equal(series_xp, series_rs)
             assert_frame_equal(frame_xp, frame_rs)
 
-    def test_legacy_time_rule_arg(self):
-        # suppress deprecation warnings
-        sys.stderr = StringIO()
-
-        rng = bdate_range('1/1/2000', periods=20)
-        ts = Series(np.random.randn(20), index=rng)
-        ts = ts.take(np.random.permutation(len(ts))[:12]).sort_index()
-
-        try:
-            result = mom.rolling_mean(ts, 1, min_periods=1, freq='B')
-            expected = mom.rolling_mean(ts, 1, min_periods=1,
-                                        time_rule='WEEKDAY')
-            tm.assert_series_equal(result, expected)
-
-            result = mom.ewma(ts, span=5, freq='B')
-            expected = mom.ewma(ts, span=5, time_rule='WEEKDAY')
-            tm.assert_series_equal(result, expected)
-
-        finally:
-            sys.stderr = sys.__stderr__
-
     def test_ewma(self):
         self._check_ew(mom.ewma)
 

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -239,21 +239,6 @@ for _i, _weekday in enumerate(['MON', 'TUE', 'WED', 'THU', 'FRI']):
 _legacy_reverse_map = dict((v, k) for k, v in
                            reversed(sorted(compat.iteritems(_rule_aliases))))
 
-
-def inferTimeRule(index):
-    from pandas.tseries.index import DatetimeIndex
-    import warnings
-    warnings.warn("This method is deprecated, use infer_freq or inferred_freq"
-                  " attribute of DatetimeIndex", FutureWarning)
-
-    freq = DatetimeIndex(index).inferred_freq
-    if freq is None:
-        raise Exception('Unable to infer time rule')
-
-    offset = to_offset(freq)
-    return get_legacy_offset_name(offset)
-
-
 def to_offset(freqstr):
     """
     Return DateOffset object from string representation

--- a/pandas/tseries/tests/test_timeseries_legacy.py
+++ b/pandas/tseries/tests/test_timeseries_legacy.py
@@ -262,28 +262,6 @@ class TestLegacyCompat(unittest.TestCase):
         # suppress deprecation warnings
         sys.stderr = StringIO()
 
-    def test_inferTimeRule(self):
-        from pandas.tseries.frequencies import inferTimeRule
-
-        index1 = [datetime(2010, 1, 29, 0, 0),
-                  datetime(2010, 2, 26, 0, 0),
-                  datetime(2010, 3, 31, 0, 0)]
-
-        index2 = [datetime(2010, 3, 26, 0, 0),
-                  datetime(2010, 3, 29, 0, 0),
-                  datetime(2010, 3, 30, 0, 0)]
-
-        index3 = [datetime(2010, 3, 26, 0, 0),
-                  datetime(2010, 3, 27, 0, 0),
-                  datetime(2010, 3, 29, 0, 0)]
-
-        # LEGACY
-        assert inferTimeRule(index1) == 'EOM'
-        assert inferTimeRule(index2) == 'WEEKDAY'
-
-        self.assertRaises(Exception, inferTimeRule, index1[:2])
-        self.assertRaises(Exception, inferTimeRule, index3)
-
     def test_time_rule(self):
         result = DateRange('1/1/2000', '1/30/2000', time_rule='WEEKDAY')
         result2 = DateRange('1/1/2000', '1/30/2000', timeRule='WEEKDAY')


### PR DESCRIPTION
Fixes #6641

Line numbers as of commit 70de129:
#### Deprecated since 0.11 or before

The following are fixed in this PR:
- [x]  Deprecate precision in favor of accuracy (#395)  --  v0.7.0  
     .\pandas\core\format.py:{2143}
- [x]   Deprecate force_unicode (#2224, #2225)  --  v0.10.0  
      .\pandas\core\format.py:{442, 369}  
      .\pandas\core\frame.py:{1387, 1342, 1283} 
- [x]  Deprecate nanRep in favor of na_rep (#275)  -- v0.5.0  
    .\pandas\core\frame.py:{1285, 1133}  
    .\pandas\core\series.py:{910}
- [x]  Deprecate unique in HDFStore (#3256)  -- v0.11.0  
   .\pandas\io\pytables.py:{691}
- [x]  Deprecate time_rule favor freq (#1042)  -- v0.8.0  
    .\pandas\stats\moments.py:{554}
- [x]  Deprecate inferTimeRule in favor of infer_freq (#391)  -- v0.8.0  
   .\pandas\tseries\frequencies.py:{247}
- [x] Deprecate DateRange in favor of DatetimeIndex (no issue number, commit 6fe2db57)  -- v0.8.0  
    .\pandas\core\daterange.py:{24}  (will be done in #6816)
- [x]  Deprecate 'name' in favor of 'symbols' (no issue, commit b921d1a2)  -- v0.11.0  
   .\pandas\io\data.py:{344}
- [x]  Deprecate offset in favor of freq (no issue, commit 31363905c20)  -- v0.8.0  
   .\pandas\tseries\index.py:{180}
##### Deprecated since 0.12 or after

Issue #6581 documents the following for future removal.  **These are not included in this PR**
- [ ]  ~~Deprecate na_last in favor of na_position (#5231, #3917)~~  
   .\pandas\core\series.py:{1770}  
- [ ] ~~Deprecate rolling_corr_pairwise and expanding_corr_pairwise (#4950)~~  
    .\pandas\stats\moments.py:{301,957}
- [ ]  ~~Deprecate broadcasting TimeSeries along DataFrame index (#2304)~~  
   .\pandas\core\frame.py:{2837}  
- [ ] ~~Deprecate load and save in favor of pickle and to_pickle (#3787)~~  
    .\pandas\core\common56.py:{2740, 2756}  
    .\pandas\core\generic.py:{960, 967} 
- [ ]  ~~Deprecate timeRule and offset in favor of freq (#4853, #4864)~~  
     .\pandas\core\datetools.py:{55}  
- [ ]  ~~Deprecate colSpace in favor of col_space (no issue, commit 4a5a677c)~~  
    .\pandas\core\frame.py:{1292,1346,1392}  
- [ ] ~~Deprecate year/month parameters in finance option signatures (#3822, #3817)~~  
   .\pandas\io\data.py:{588,811,848}
- [ ]  ~~Remove kind from read_excel (#4713)~~  
     .\pandas\io\excel.py:{103}
- [ ]  ~~Deprecate infer_types to have no effect (#4770)~~  
    .\pandas\io\html.py:{830}
- [ ]  ~~Deprecate table keyword in HDFStore (#4645)~~  
   .\pandas\io\pytables.py:{1124}
