### PR TITLE
BUG: adding np.timedelta64 to DatetimeIndex with tz outputs incorrect

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -315,7 +315,6 @@ Bug Fixes
   as regexs even when ``regex=False`` (:issue:`6777`).
 - Bug in timedelta ops on 32-bit platforms (:issue:`6808`)
 - Bug in setting a tz-aware index directly via ``.index`` (:issue:`6785`)
-<<<<<<< HEAD
 - Bug in expressions.py where numexpr would try to evaluate arithmetic ops
   (:issue:`6762`).
 - Bug in Makefile where it didn't remove Cython generated C files with ``make
@@ -324,6 +323,7 @@ Bug Fixes
 - Bug in ``DataFrame._reduce`` where non bool-like (0/1) integers were being
   coverted into bools. (:issue:`6806`)
 - Regression from 0.13 with ``fillna`` and a Series on datetime-like (:issue:`6344`)
+- Bug in adding np.timedelta64 to DatetimeIndex with tz outputs incorrect result (:issue:`6818`)
 
 pandas 0.13.1
 -------------

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -624,17 +624,15 @@ class DatetimeIndex(Int64Index):
         if isinstance(delta, (Tick, timedelta)):
             inc = offsets._delta_to_nanoseconds(delta)
             new_values = (self.asi8 + inc).view(_NS_DTYPE)
-            tz = 'UTC' if self.tz is not None else None
-            result = DatetimeIndex(new_values, tz=tz, freq='infer')
-            utc = _utc()
-            if self.tz is not None and self.tz is not utc:
-                result = result.tz_convert(self.tz)
         elif isinstance(delta, np.timedelta64):
             new_values = self.to_series() + delta
-            result = DatetimeIndex(new_values, tz=self.tz, freq='infer')
         else:
             new_values = self.astype('O') + delta
-            result = DatetimeIndex(new_values, tz=self.tz, freq='infer')
+        tz = 'UTC' if self.tz is not None else None
+        result = DatetimeIndex(new_values, tz=tz, freq='infer')
+        utc = _utc()
+        if self.tz is not None and self.tz is not utc:
+            result = result.tz_convert(self.tz)
         return result
 
     def __contains__(self, key):


### PR DESCRIPTION
```
>>> idx = pd.date_range(start='2010-11-02 01:00:00', periods=3, tz='US/Pacific', freq='1H')

>>> idx + offsets.Hour(3)
[2010-11-02 04:00:00-07:00, ..., 2010-11-02 06:00:00-07:00]
Length: 3, Freq: H, Timezone: US/Pacific

>>> idx + datetime.timedelta(hours=3)
[2010-11-02 04:00:00-07:00, ..., 2010-11-02 06:00:00-07:00]
Length: 3, Freq: H, Timezone: US/Pacific

>>> idx + np.timedelta64(3, 'h')          # incorrect
[2010-11-02 11:00:00-07:00, ..., 2010-11-02 13:00:00-07:00]
Length: 3, Freq: H, Timezone: US/Pacific
```
