### PR TITLE
ENH: Scatter plot now supports errorbar

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -63,7 +63,7 @@ New features
   Date is used primarily in astronomy and represents the number of days from
   noon, January 1, 4713 BC.  Because nanoseconds are used to define the time
   in pandas the actual range of dates that you can use is 1678 AD to 2262 AD. (:issue:`4041`)
-- Added error bar support to the ``.plot`` method of ``DataFrame`` and ``Series`` (:issue:`3796`)
+- Added error bar support to the ``.plot`` method of ``DataFrame`` and ``Series`` (:issue:`3796`, :issue:`6834`)
 - Implemented ``Panel.pct_change`` (:issue:`6904`)
 
 API Changes

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -365,7 +365,7 @@ Plotting
 
 - Hexagonal bin plots from ``DataFrame.plot`` with ``kind='hexbin'`` (:issue:`5478`), See :ref:`the docs<visualization.hexbin>`.
 - ``DataFrame.plot`` and ``Series.plot`` now supports area plot with specifying ``kind='area'`` (:issue:`6656`)
-- Plotting with Error Bars is now supported in the ``.plot`` method of ``DataFrame`` and ``Series`` objects (:issue:`3796`), See :ref:`the docs<visualization.errorbars>`.
+- Plotting with Error Bars is now supported in the ``.plot`` method of ``DataFrame`` and ``Series`` objects (:issue:`3796`, :issue:`6834`), See :ref:`the docs<visualization.errorbars>`.
 - ``DataFrame.plot`` and ``Series.plot`` now support a ``table`` keyword for plotting ``matplotlib.Table``, See :ref:`the docs<visualization.table>`.
 - ``plot(legend='reverse')`` will now reverse the order of legend labels for
   most plot kinds. (:issue:`6014`)

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -394,9 +394,12 @@ x and y errorbars are supported and be supplied using the ``xerr`` and ``yerr`` 
 
 - As a ``DataFrame`` or ``dict`` of errors with column names matching the ``columns`` attribute of the plotting ``DataFrame`` or matching the ``name`` attribute of the ``Series``
 - As a ``str`` indicating which of the columns of plotting ``DataFrame`` contain the error values
-- As raw values (``list``, ``tuple``, or ``np.ndarray``). Must be the same length as the plotting ``DataFrame``/``Series``
+- As list-like raw values (``list``, ``tuple``, or ``np.ndarray``). Must be the same length as the plotting ``DataFrame``/``Series``
+- As float. The error value will be applied to all data.
 
 Asymmetrical error bars are also supported, however raw error values must be provided in this case. For a ``M`` length ``Series``, a ``Mx2`` array should be provided indicating lower and upper (or left and right) errors. For a ``MxN`` ``DataFrame``, asymmetrical errors should be in a ``Mx2xN`` array.
+
+**Note**: Plotting ``xerr`` is not supported in time series.
 
 Here is an example of one way to easily plot group means with standard deviations from the raw data.
 


### PR DESCRIPTION
This is enhancement for #5638. I sometimes want to plot scatter with errorbars, thus I've refactored to support it.

![figure_1](https://cloud.githubusercontent.com/assets/1696302/2632517/21edcfd6-be65-11e3-9cd9-97bad65c8129.png)

Also, this includes following fixes. I've also modified tests to check the number of errorbars actually drawn.
- There are some types which expected to work, but results in `ValueError`.
  - `float` (MPL can accept it)
  - `unicode` (in Python 2.x)
  - Other list-like, such as `iterator`
- A bug related to time series.

```
>>> s = Series(rand(6), index=range(6), name='x')
>>> err_df = DataFrame(rand(6, 3) / 10, index=range(6), columns=['x', 'y', 'z'])
>>> s.plot(yerr=err_df)               # This works, errorbar appears using err_df x column

>>> s.index = tm.makeDateIndex(k=6)
>>> s.plot(yerr=err_df)               # But this doesn't, errorbar doesn't appear
```
