### PR TITLE
DEPR: Indexers will warn FutureWarning when used with a scalar indexer this is floating-point (GH4892)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -189,6 +189,9 @@ Deprecations
   ``FutureWarning`` is raised  to alert that the old ``cols`` arguments
   will not be supported in a future release (:issue:`6645`)
 
+- Indexers will warn ``FutureWarning`` when used with a scalar indexer and
+  a non-floating point Index (:issue:`4892`)
+
 Prior Version Deprecations/Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -390,6 +390,27 @@ Deprecations
   ``FutureWarning`` is raised  to alert that the old ``cols`` arguments
   will not be supported in a future release (:issue:`6645`)
 
+- Indexers will warn ``FutureWarning`` when used with a scalar indexer and
+  a non-floating point Index (:issue:`4892`)
+
+  .. code-block:: python
+
+     # non-floating point indexes can only be indexed by integers / labels
+     In [1]: Series(1,np.arange(5))[3.0]
+             pandas/core/index.py:469: FutureWarning: scalar indexers for index type Int64Index should be integers and not floating point
+     Out[1]: 1
+
+     In [5]: Series(1,np.arange(5)).iloc[3.0]
+             pandas/core/index.py:469: FutureWarning: scalar indexers for index type Int64Index should be integers and not floating point
+     Out[5]: 1
+
+     # these are Float64Indexes, so integer or floating point is acceptable
+     In [3]: Series(1,np.arange(5.))[3]
+     Out[3]: 1
+
+     In [4]: Series(1,np.arange(5.))[3.0]
+     Out[4]: 1
+
 .. _whatsnew_0140.enhancements:
 
 Enhancements

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1,6 +1,7 @@
 # pylint: disable=E1101,E1103,W0232
 import datetime
 from functools import partial
+import warnings
 from pandas.compat import range, zip, lrange, lzip, u, reduce
 from pandas import compat
 import numpy as np
@@ -468,11 +469,19 @@ class Index(IndexOpsMixin, FrozenNDArray):
             return ikey
 
         if typ == 'iloc':
-            if not (is_integer(key) or is_float(key)):
-                self._convert_indexer_error(key, 'label')
-            return to_int()
+            if is_integer(key):
+                return key
+            elif is_float(key):
+                if not self.is_floating():
+                    warnings.warn("scalar indexers for index type {0} should be integers and not floating point".format(
+                        type(self).__name__),FutureWarning)
+                return to_int()
+            return self._convert_indexer_error(key, 'label')
 
         if is_float(key):
+            if not self.is_floating():
+                warnings.warn("scalar indexers for index type {0} should be integers and not floating point".format(
+                    type(self).__name__),FutureWarning)
             return to_int()
 
         return key

--- a/pandas/index.pyx
+++ b/pandas/index.pyx
@@ -355,6 +355,8 @@ cdef class Int64Engine(IndexEngine):
         hash(val)
         if util.is_bool_object(val):
             raise KeyError(val)
+        elif util.is_float_object(val):
+            raise KeyError(val)
 
     cdef _maybe_get_bool_indexer(self, object val):
         cdef:

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -94,6 +94,7 @@ class TestIndexing(tm.TestCase):
     _typs = set(['ints','labels','mixed','ts','floats','empty'])
 
     def setUp(self):
+
         import warnings
         warnings.filterwarnings(action='ignore', category=FutureWarning)
 
@@ -3219,6 +3220,64 @@ class TestIndexing(tm.TestCase):
         df = mkdf(5, 2)
         assert_frame_equal(df.ix[:,[]], df.iloc[:, :0])  # vertical empty
         assert_frame_equal(df.ix[[],:], df.iloc[:0, :])  # horizontal empty
+
+    def test_deprecate_float_indexers(self):
+
+        # GH 4892
+        # deprecate allowing float indexers that are equal to ints to be used
+        # as indexers in non-float indices
+
+        import warnings
+        warnings.filterwarnings(action='error', category=FutureWarning)
+
+        for index in [ tm.makeStringIndex, tm.makeUnicodeIndex,
+                       tm.makeDateIndex, tm.makePeriodIndex ]:
+
+            i = index(5)
+            s = Series(np.arange(len(i)),index=i)
+            self.assertRaises(FutureWarning, lambda :
+                              s.iloc[3.0])
+            self.assertRaises(FutureWarning, lambda :
+                              s[3.0])
+
+            # this is ok!
+            s[3]
+
+        # ints
+        i = index(5)
+        s = Series(np.arange(len(i)))
+        self.assertRaises(FutureWarning, lambda :
+                          s.iloc[3.0])
+
+        # on some arch's this doesn't provide a warning (and thus raise)
+        # and some it does
+        try:
+            s[3.0]
+        except:
+            pass
+
+        # floats: these are all ok!
+        i = np.arange(5.)
+        s = Series(np.arange(len(i)),index=i)
+        with tm.assert_produces_warning(False):
+            s[3.0]
+
+        with tm.assert_produces_warning(False):
+            s[3]
+
+        with tm.assert_produces_warning(False):
+            s.iloc[3.0]
+
+        with tm.assert_produces_warning(False):
+            s.iloc[3]
+
+        with tm.assert_produces_warning(False):
+            s.loc[3.0]
+
+        with tm.assert_produces_warning(False):
+            s.loc[3]
+
+        warnings.filterwarnings(action='ignore', category=FutureWarning)
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
closes #4892

numpy is doing this i 1.9 IIRC, and Scipy already did it. in 0.13.3

 Indexers will warn `FutureWarning` when used with a scalar indexer and a non-floating point Index

```
# non-floating point indexes can only be indexed by integers / labels
In [1]: Series(1,np.arange(5))[3.0]
        pandas/core/index.py:469: FutureWarning: scalar indexers should not be floating point unless a    floating index
Out[1]: 1

In [5]: Series(1,np.arange(5)).iloc[3.0]
        pandas/core/index.py:463: FutureWarning: scalar indexers should not be floating point unless a floating index
Out[5]: 1

# these are Float64Indexes, so integer or floating point is acceptable
In [3]: Series(1,np.arange(5.))[3]
Out[3]: 1

In [4]: Series(1,np.arange(5.))[3.0]
Out[4]: 1
```
