### PR TITLE
BUG: _tidy_repr should not be called when max_rows is None

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -364,6 +364,7 @@ Bug Fixes
 - Bug in ``DataFrame.replace()`` where changing a dtype through replacement
   would only replace the first occurrence of a value (:issue:`6689`)
 - Better error message when passing a frequency of 'MS' in ``Period`` construction (GH5332)
+- Bug in `Series.__unicode__` when `max_rows` is `None` and the Series has more than 1000 rows. (:issue:`6863`)
 
 pandas 0.13.1
 -------------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -828,7 +828,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         width, height = get_terminal_size()
         max_rows = (height if get_option("display.max_rows") == 0
                     else get_option("display.max_rows"))
-        if len(self.index) > (max_rows or 1000):
+        if max_rows and len(self.index) > max_rows:
             result = self._tidy_repr(min(30, max_rows - 4))
         elif len(self.index) > 0:
             result = self._get_repr(print_header=True,

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1770,6 +1770,11 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         df = Series(data, index=index1)
         self.assertTrue(type(df.__repr__() == str))  # both py2 / 3
 
+    def test_repr_max_rows(self):
+        # GH 6863
+        with pd.option_context('max_rows', None):
+            str(Series(range(1001))) # should not raise exception
+
     def test_unicode_string_with_unicode(self):
         df = Series([u("\u05d0")], name=u("\u05d1"))
         if compat.PY3:


### PR DESCRIPTION
This issue was raised in http://stackoverflow.com/q/22824104/190597:

```
import pandas as pd
pd.options.display.max_rows = None
result = pd.Series(range(1001))
print(result)
```

raises `TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'`.

The problem occurs in series.py  (line 832) when `max_rows` is `None`:

```
    if len(self.index) > (max_rows or 1000):
        result = self._tidy_repr(min(30, max_rows - 4))
```

Since the doc string for `get_options` says

```
display.max_rows: [default: 60] [currently: 60]
        ...
        'None' value means unlimited.
```

I think `_tidy_repr` should not be called when `max_rows` is None.

This PR seems simple enough but my main concern is that  this PR stomps on GH1467 which explicitly changed `> max_rows` to `> (max_rows or 1000)` and I don't know what the purpose of this was.
