### PR TITLE
Custom Business Month

### DIFF
--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -432,6 +432,8 @@ frequency increment. Specific offset logic like "month", "business day", or
     MonthBegin, "calendar month begin"
     BMonthEnd, "business month end"
     BMonthBegin, "business month begin"
+    CBMonthEnd, "custom business month end"
+    CBMonthBegin, "custom business month begin"
     QuarterEnd, "calendar quarter end"
     QuarterBegin, "calendar quarter begin"
     BQuarterEnd, "business quarter end"
@@ -558,6 +560,20 @@ As of v0.14 holiday calendars can be used to provide the list of holidays.  See 
     # Tuesday after MLK Day (Monday is skipped because it's a holiday)
     dt + bday_us
 
+Monthly offsets that respect a certain holiday calendar can be defined
+in the usual way.
+
+.. ipython:: python
+
+    from pandas.tseries.offsets import CustomBusinessMonthBegin
+    bmth_us = CustomBusinessMonthBegin(calendar=USFederalHolidayCalendar())
+    # Skip new years
+    dt = datetime(2013, 12, 17)
+    dt + bmth_us
+   
+    # Define date index with custom offset
+    from pandas import DatetimeIndex
+    DatetimeIndex(start='20100101',end='20120101',freq=bmth_us)
 
 .. note::
 
@@ -601,8 +617,10 @@ frequencies. We will refer to these aliases as *offset aliases*
     "W", "weekly frequency"
     "M", "month end frequency"
     "BM", "business month end frequency"
+    "CBM", "custom business month end frequency"
     "MS", "month start frequency"
     "BMS", "business month start frequency"
+    "CBMS", "custom business month start frequency"
     "Q", "quarter end frequency"
     "BQ", "business quarter endfrequency"
     "QS", "quarter start frequency"

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -477,6 +477,7 @@ Enhancements
 - Implemented ``Panel.pct_change`` (:issue:`6904`)
 - Added ``how`` option to rolling-moment functions to dictate how to handle resampling; :func:``rolling_max`` defaults to max,
   :func:``rolling_min`` defaults to min, and all others default to mean (:issue:`6297`)
+- ``CustomBuisnessMonthBegin`` and ``CustomBusinessMonthEnd`` are now available (:issue:`6866`) 
 
 Performance
 ~~~~~~~~~~~

--- a/pandas/core/datetools.py
+++ b/pandas/core/datetools.py
@@ -10,14 +10,20 @@ businessDay = bday
 try:
     cday = CDay()
     customBusinessDay = CustomBusinessDay()
+    customBusinessMonthEnd = CBMonthEnd()
+    customBusinessMonthBegin = CBMonthBegin()
 except NotImplementedError:
     cday = None
     customBusinessDay = None
+    customBusinessMonthEnd = None
+    customBusinessMonthBegin = None
 monthEnd = MonthEnd()
 yearEnd = YearEnd()
 yearBegin = YearBegin()
 bmonthEnd = BMonthEnd()
-businessMonthEnd = bmonthEnd
+bmonthBegin = BMonthBegin()
+cbmonthEnd = customBusinessMonthEnd
+cbmonthBegin = customBusinessMonthBegin
 bquarterEnd = BQuarterEnd()
 quarterEnd = QuarterEnd()
 byearEnd = BYearEnd()

--- a/vb_suite/timeseries.py
+++ b/vb_suite/timeseries.py
@@ -288,6 +288,7 @@ import pandas as pd
 
 date = dt.datetime(2011,1,1)
 cday = pd.offsets.CustomBusinessDay()
+cme = pd.offsets.CustomBusinessMonthEnd()
 """
 timeseries_custom_bday_incr = \
     Benchmark("date + cday",setup)
@@ -295,3 +296,10 @@ timeseries_custom_bday_incr = \
 # Increment by n
 timeseries_custom_bday_incr_n = \
     Benchmark("date + 10 * cday",setup)
+
+# Increment custom business month
+timeseries_custom_bmonthend_incr = \
+    Benchmark("date + cme",setup)
+
+timeseries_custom_bmonthend_incr_n = \
+    Benchmark("date + 10 * cme",setup)


### PR DESCRIPTION
This extends the `offsets.py` module with a `CBMonthEnd` based on `CustomBusinessDay`. Tests are found in `test_offsets.py`. 

A few small points still open: 
- Implement CBMonthBegin
- Improve speed. Main speed drag is `DateOffset.onOffset`. 

Also some of the tests are not passing, but the errors seem unrelated. 
e.g.

```
======================================================================
ERROR: test_pickle (pandas.tseries.tests.test_timeseries.TestTimeSeries)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/benjamin/workspace/pandas/pandas/tseries/tests/test_timeseries.py", line 1827, in test_pickle
    p = pick.loads(pick.dumps(NaT))
  File "/usr/lib/python2.7/pickle.py", line 1382, in loads
    return Unpickler(file).load()
  File "/usr/lib/python2.7/pickle.py", line 858, in load
    dispatch[key](self)
  File "/usr/lib/python2.7/pickle.py", line 1133, in load_reduce
    value = func(*args)
TypeError: __new__() takes exactly one argument (2 given)
```
