### PR TITLE
BUG: Arithmetic, timezone and offsets operations affecting to NaT

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -370,6 +370,8 @@ Bug Fixes
 - Better error message when passing a frequency of 'MS' in ``Period`` construction (GH5332)
 - Bug in `Series.__unicode__` when `max_rows` is `None` and the Series has more than 1000 rows. (:issue:`6863`)
 - Bug in ``groupby.get_group`` where a datetlike wasn't always accepted (:issue:`5267`)
+- Bug in ``DatetimeIndex.tz_localize`` and ``DatetimeIndex.tz_convert`` affects to NaT (:issue:`5546`)
+- Bug in arithmetic operations affecting to NaT (:issue:`6873`)
 
 pandas 0.13.1
 -------------

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -611,7 +611,10 @@ class DatetimeIndex(Int64Index):
     def _add_delta(self, delta):
         if isinstance(delta, (Tick, timedelta)):
             inc = offsets._delta_to_nanoseconds(delta)
+            mask = self.asi8 == tslib.iNaT
             new_values = (self.asi8 + inc).view(_NS_DTYPE)
+            new_values[mask] = tslib.iNaT
+            new_values = new_values.view(_NS_DTYPE)
         elif isinstance(delta, np.timedelta64):
             new_values = self.to_series() + delta
         else:

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -975,6 +975,41 @@ class TestTimeZones(tm.TestCase):
             offset = dates + timedelta(hours=5)
             self.assert_(offset.equals(expected))
             
+    def test_nat(self):
+        # GH 5546
+        dates = [NaT]
+        idx = DatetimeIndex(dates)
+        idx = idx.tz_localize('US/Pacific')
+        self.assert_(idx.equals(DatetimeIndex(dates, tz='US/Pacific')))
+        idx = idx.tz_convert('US/Eastern')
+        self.assert_(idx.equals(DatetimeIndex(dates, tz='US/Eastern')))
+        idx = idx.tz_convert('UTC')
+        self.assert_(idx.equals(DatetimeIndex(dates, tz='UTC')))
+
+        dates = ['2010-12-01 00:00', '2010-12-02 00:00', NaT]
+        idx = DatetimeIndex(dates)
+        idx = idx.tz_localize('US/Pacific')
+        self.assert_(idx.equals(DatetimeIndex(dates, tz='US/Pacific')))
+        idx = idx.tz_convert('US/Eastern')
+        expected = ['2010-12-01 03:00', '2010-12-02 03:00', NaT]
+        self.assert_(idx.equals(DatetimeIndex(expected, tz='US/Eastern')))
+
+        idx = idx + offsets.Hour(5)
+        expected = ['2010-12-01 08:00', '2010-12-02 08:00', NaT]
+        self.assert_(idx.equals(DatetimeIndex(expected, tz='US/Eastern')))
+        idx = idx.tz_convert('US/Pacific')
+        expected = ['2010-12-01 05:00', '2010-12-02 05:00', NaT]
+        self.assert_(idx.equals(DatetimeIndex(expected, tz='US/Pacific')))
+
+        if not _np_version_under1p7:
+            idx = idx + np.timedelta64(3, 'h')
+            expected = ['2010-12-01 08:00', '2010-12-02 08:00', NaT]
+            self.assert_(idx.equals(DatetimeIndex(expected, tz='US/Pacific')))
+
+            idx = idx.tz_convert('US/Eastern')
+            expected = ['2010-12-01 11:00', '2010-12-02 11:00', NaT]
+            self.assert_(idx.equals(DatetimeIndex(expected, tz='US/Eastern')))
+
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
NaT affected by some datetime related ops unexpectedly.
# Arithmetic

Applying arithmetic ops to `NaT` is not handled properly. Based on numpy results, I understand that results should be all `NaT` as long as valid data is passed.

```
# current results
>>> pd.NaT + pd.offsets.Hour(1)
2262-04-11 01:12:43.145224192
>>> pd.NaT - pd.offsets.Hour(1))
OverflowError: Python int too large to convert to C long
>>> pd.NaT - pd.Timestamp('2011-01-01')
-734779 days, 0:00:00

# numpy
>>> np.datetime64('nat') + np.timedelta64(1, 'h')
NaT
>>> np.datetime64('nat') - np.timedelta64(1, 'h')
NaT
>>> np.datetime64('nat') - np.datetime64('2011-01-01')
NaT
```
# Timezone

Closes #5546. 

```
# current results
>>> idx = pd.DatetimeIndex(['2011-01-01 00:00', '2011-01-02 00:00', pd.NaT])
>>> idx.tz_localize('Asia/Tokyo')
<class 'pandas.tseries.index.DatetimeIndex'>
[2011-01-01 00:00:00+09:00, ..., 2262-04-10 00:12:43.145224192+09:00]
Length: 3, Freq: None, Timezone: Asia/Tokyo

>>> idx = pd.DatetimeIndex(['2011-01-01 00:00', '2011-01-02 00:00', pd.NaT], tz='US/Eastern')
>>> idx.tz_convert('Asia/Tokyo')
<class 'pandas.tseries.index.DatetimeIndex'>
[2011-01-01 14:00:00+09:00, ..., 2262-04-11 14:12:43.145224192+09:00]
```

_Note_ I fixed `DatetimeIndex`, and I leave `NatType` still doesn't have `tz_localize` and `tz_convert` methods `Timestamp` has. Is it should be added?
# Offsets

These have `apply` method which accepts `Timestamp`, but it cannot handle `Nat`.

```
# current result
>>> pd.offsets.Hour(1).apply(pd.NaT)
2262-04-11 01:12:43.145224192
```
