### PR TITLE
ENH: Allow aggregate numeric operations on timedelta64.

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1271,14 +1271,23 @@ def _possibly_downcast_to_dtype(result, dtype):
         dtype = np.dtype(dtype)
 
     try:
-
         # don't allow upcasts here (except if empty)
+        print dtype.kind, result.dtype.kind
         if dtype.kind == result.dtype.kind:
             if result.dtype.itemsize <= dtype.itemsize and np.prod(result.shape):
                 return result
 
         if issubclass(dtype.type, np.floating):
             return result.astype(dtype)
+
+        # a datetimelike
+        elif ((dtype.kind == 'M' and result.dtype.kind == 'i') or
+              dtype.kind == 'm'):
+            try:
+                result = result.astype(dtype)
+            except:
+                pass
+
         elif dtype == np.bool_ or issubclass(dtype.type, np.integer):
 
             # if we don't have any elements, just astype it
@@ -1308,13 +1317,6 @@ def _possibly_downcast_to_dtype(result, dtype):
                     # hit here
                     if (new_result == result).all():
                         return new_result
-
-        # a datetimelike
-        elif dtype.kind in ['M','m'] and result.dtype.kind in ['i']:
-            try:
-                result = result.astype(dtype)
-            except:
-                pass
 
     except:
         pass

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1087,6 +1087,7 @@ class GroupBy(PandasObject):
                 obj = com.ensure_float(obj)
                 is_numeric = True
                 out_dtype = 'f%d' % obj.dtype.itemsize
+                values = obj.values
             else:
                 is_numeric = issubclass(obj.dtype.type, (np.datetime64,
                                                             np.timedelta64))

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1084,7 +1084,8 @@ class GroupBy(PandasObject):
         output = {}
         for name, obj in self._iterate_slices():
             is_numeric = is_numeric_dtype(obj.dtype)
-            if numeric_only and not is_numeric:
+            is_timdelta64 = is_timedelta64_dtype(obj.dtype)
+            if numeric_only and not (is_numeric or is_timdelta64):
                 continue
 
             try:
@@ -2567,8 +2568,12 @@ class NDFrameGroupBy(GroupBy):
             data = data.get_numeric_data(copy=False)
 
         for block in data.blocks:
-
             values = block._try_operate(block.values)
+            is_numeric = is_numeric_dtype(values.dtype)
+            is_timedelta64 = is_timedelta64_dtype(values.dtype)
+
+            if numeric_only and not (is_numeric or is_timedelta64):
+                continue
 
             if block.is_numeric:
                 values = _algos.ensure_float64(values)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2581,20 +2581,6 @@ class NDFrameGroupBy(GroupBy):
         for block in data.blocks:
             values = block._try_operate(block.values)
 
-            if is_numeric_dtype(values.dtype):
-                values = com.ensure_float(values)
-                is_numeric = True
-            else:
-                is_numeric = issubclass(values.dtype.type, (np.datetime64,
-                                                            np.timedelta64))
-                if is_numeric:
-                    values = values.view('int64')
-                else:
-                    values = values.astype(object)
-
-            if numeric_only and not is_numeric:
-                continue
-
             # TODO DAN
             if block.is_numeric:
                 values = _algos.ensure_float64(values)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1090,8 +1090,7 @@ class GroupBy(PandasObject):
                 values = obj.values
             else:
                 is_numeric = issubclass(obj.dtype.type, (np.datetime64,
-                                                            np.timedelta64))
-                out_dtype = 'float64'
+                                                         np.timedelta64))
                 if is_numeric:
                     values = obj.view('int64')
                 else:

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -4365,6 +4365,19 @@ class TestGroupBy(tm.TestCase):
         expected = ser.take([1, 3, 4])
         assert_series_equal(actual, expected)
 
+    def test_groupby_methods_on_timedelta64(self):
+        df = self.df.copy().iloc[:4]
+        df['E'] = pd.to_timedelta(['00:00:01', '00:00:02', '00:00:03', '00:00:04'])
+        # DataFrameGroupBy
+        actual = df.groupby('A').mean()['E']
+        expected = pd.to_timedelta(Series(['00:00:03', '00:00:02'], index=['bar', 'foo'], name='E'))
+        assert_series_equal(actual, expected)
+
+        ser = df['E']
+        # SeriesGroupBy
+        actual = ser.groupby(df['A']).mean()
+        assert_series_equal(actual, expected)
+
     def test_groupby_selection_with_methods(self):
         # some methods which require DatetimeIndex
         rng = pd.date_range('2014', periods=len(self.df))

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -7,7 +7,7 @@ from numpy.testing.decorators import slow
 from datetime import datetime
 from numpy import nan
 
-from pandas import date_range,bdate_range, Timestamp, _np_version_under1p7
+from pandas import date_range,bdate_range, Timestamp
 from pandas.core.index import Index, MultiIndex, Int64Index
 from pandas.core.api import Categorical, DataFrame
 from pandas.core.groupby import (SpecificationError, DataError,
@@ -40,11 +40,6 @@ def _skip_if_mpl_not_installed():
         import matplotlib.pyplot as plt
     except ImportError:
         raise nose.SkipTest("matplotlib not installed")
-
-
-def _skip_if_np_version_under1p7():
-    if _np_version_under1p7:
-        raise nose.SkipTest("numpy version 1.7 has throughly broken timedelta")
 
 
 def commonSetUp(self):
@@ -610,27 +605,26 @@ class TestGroupBy(tm.TestCase):
         assert_series_equal(result,e)
 
         # ...and with timedeltas
-        if not _np_version_under1p7:
-            df1 = df.copy()
-            df1['D'] = pd.to_timedelta(['00:00:01', '00:00:02', '00:00:03',
-                                        '00:00:04', '00:00:05', '00:00:06',
-                                        '00:00:07'])
-            result = df1.groupby('A').apply(f)[['D']]
-            e = df1.groupby('A').first()[['D']]
-            e.loc['Pony'] = np.nan
-            print(type(result))
-            print(type(e))
-            assert_frame_equal(result, e)
+        df1 = df.copy()
+        df1['D'] = pd.to_timedelta(['00:00:01', '00:00:02', '00:00:03',
+                                    '00:00:04', '00:00:05', '00:00:06',
+                                    '00:00:07'])
+        result = df1.groupby('A').apply(f)[['D']]
+        e = df1.groupby('A').first()[['D']]
+        e.loc['Pony'] = np.nan
+        print(type(result))
+        print(type(e))
+        assert_frame_equal(result, e)
 
-            def f(grp):
-                if grp.name == 'Pony':
-                    return None
-                return grp.iloc[0].loc['D']
-            result = df1.groupby('A').apply(f)['D']
-            e = df1.groupby('A').first()['D'].copy()
-            e.loc['Pony'] = np.nan
-            e.name = None
-            assert_series_equal(result, e)
+        def f(grp):
+            if grp.name == 'Pony':
+                return None
+            return grp.iloc[0].loc['D']
+        result = df1.groupby('A').apply(f)['D']
+        e = df1.groupby('A').first()['D'].copy()
+        e.loc['Pony'] = np.nan
+        e.name = None
+        assert_series_equal(result, e)
 
     def test_agg_api(self):
 
@@ -4395,7 +4389,6 @@ class TestGroupBy(tm.TestCase):
         assert_series_equal(actual, expected)
 
     def test_groupby_methods_on_timedelta64(self):
-        _skip_if_np_version_under1p7()
         df = self.df.copy().iloc[:4]
         df['E'] = pd.to_timedelta(['00:00:01', '00:00:02', '00:00:03', '00:00:04'])
         # DataFrameGroupBy

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -41,6 +41,12 @@ def _skip_if_mpl_not_installed():
     except ImportError:
         raise nose.SkipTest("matplotlib not installed")
 
+
+def _skip_if_np_version_under1p7():
+    if _np_version_under1p7:
+        raise nose.SkipTest("numpy version 1.7 has throughly broken timedelta")
+
+
 def commonSetUp(self):
     self.dateRange = bdate_range('1/1/2005', periods=250)
     self.stringIndex = Index([rands(8).upper() for x in range(250)])
@@ -607,21 +613,24 @@ class TestGroupBy(tm.TestCase):
         if not _np_version_under1p7:
             df1 = df.copy()
             df1['D'] = pd.to_timedelta(['00:00:01', '00:00:02', '00:00:03',
-                                       '00:00:04', '00:00:05', '00:00:06', '00:00:07'])
+                                        '00:00:04', '00:00:05', '00:00:06',
+                                        '00:00:07'])
             result = df1.groupby('A').apply(f)[['D']]
             e = df1.groupby('A').first()[['D']]
             e.loc['Pony'] = np.nan
+            print(type(result))
+            print(type(e))
             assert_frame_equal(result, e)
 
             def f(grp):
                 if grp.name == 'Pony':
                     return None
                 return grp.iloc[0].loc['D']
-            result = df1.groupby('A').apply(f)
+            result = df1.groupby('A').apply(f)['D']
             e = df1.groupby('A').first()['D'].copy()
             e.loc['Pony'] = np.nan
             e.name = None
-            assert_series_equal(result,e)
+            assert_series_equal(result, e)
 
     def test_agg_api(self):
 
@@ -4386,6 +4395,7 @@ class TestGroupBy(tm.TestCase):
         assert_series_equal(actual, expected)
 
     def test_groupby_methods_on_timedelta64(self):
+        _skip_if_np_version_under1p7()
         df = self.df.copy().iloc[:4]
         df['E'] = pd.to_timedelta(['00:00:01', '00:00:02', '00:00:03', '00:00:04'])
         # DataFrameGroupBy

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -7,7 +7,7 @@ from numpy.testing.decorators import slow
 from datetime import datetime
 from numpy import nan
 
-from pandas import date_range,bdate_range, Timestamp
+from pandas import date_range,bdate_range, Timestamp, _np_version_under1p7
 from pandas.core.index import Index, MultiIndex, Int64Index
 from pandas.core.api import Categorical, DataFrame
 from pandas.core.groupby import (SpecificationError, DataError,
@@ -602,6 +602,26 @@ class TestGroupBy(tm.TestCase):
         e.loc['Pony'] = np.nan
         e.name = None
         assert_series_equal(result,e)
+
+        # ...and with timedeltas
+        if not _np_version_under1p7:
+            df1 = df.copy()
+            df1['D'] = pd.to_timedelta(['00:00:01', '00:00:02', '00:00:03',
+                                       '00:00:04', '00:00:05', '00:00:06', '00:00:07'])
+            result = df1.groupby('A').apply(f)[['D']]
+            e = df1.groupby('A').first()[['D']]
+            e.loc['Pony'] = np.nan
+            assert_frame_equal(result, e)
+
+            def f(grp):
+                if grp.name == 'Pony':
+                    return None
+                return grp.iloc[0].loc['D']
+            result = df1.groupby('A').apply(f)
+            e = df1.groupby('A').first()['D'].copy()
+            e.loc['Pony'] = np.nan
+            e.name = None
+            assert_series_equal(result,e)
 
     def test_agg_api(self):
 


### PR DESCRIPTION
closes #5724

Currently, `timedelta64` columns can't be used in aggregate group operations. They are quietly dropped or, if no other columns are present, an exception is raised:

```
In [2]: df
Out[2]: 
     A        E
0  foo 00:00:01
1  bar 00:00:02
2  foo 00:00:03
3  bar 00:00:04


In [3]: df.groupby('A').mean()
Out[3]: 
(...)
DataError: No numeric types to aggregate
```

But any operation that works on numerical data is also well defined on timedeltas. This PR relaxes the restriction on those methods designated "numeric only" to accept numeric dtypes _and_ `timedelta64`. I include a unit test with one simple case each for `DataFrameGroupBy` and `SeriesGroupBy`.

```
In [2]: df.groupby('A').mean()
Out[2]: 

           E
A           
bar 00:00:03
foo 00:00:02
```
