### PR TITLE
Series.rank() doesn't handle small floats correctly

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -402,6 +402,7 @@ Bug Fixes
 - Bug in `DataFrame.plot` and `Series.plot` legend behave inconsistently when plotting to the same axes repeatedly (:issue:`6678`)
 - Internal tests for patching ``__finalize__`` / bug in merge not finalizing (:issue:`6923`, :issue:`6927`)
 - accept ``TextFileReader`` in ``concat``, which was affecting a common user idiom (:issue:`6583`)
+- Bug in ``Series.rank`` and ``DataFrame.rank`` that caused small floats (<1e-13) to all receive the same rank (:issue:`6886`)
 
 pandas 0.13.1
 -------------

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -11031,6 +11031,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         exp = df.astype(float).rank(1)
         assert_frame_equal(result, exp)
 
+
     def test_rank2(self):
         from datetime import datetime
         df = DataFrame([[1, 3, 2], [1, 2, 3]])
@@ -11084,6 +11085,11 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         expected = self.mixed_frame.rank(1, numeric_only=True)
         assert_frame_equal(result, expected)
 
+        df = DataFrame({"a":[1e-20, -5, 1e-20+1e-40, 10, 1e60, 1e80, 1e-30]})
+        exp = DataFrame({"a":[ 3.5,  1. ,  3.5,  5. ,  6. ,  7. ,  2. ]})
+        assert_frame_equal(df.rank(), exp)
+
+        
     def test_rank_na_option(self):
         from pandas.compat.scipy import rankdata
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -4047,14 +4047,35 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         exp = iseries / 4.0
         iranks = iseries.rank(pct=True)
         assert_series_equal(iranks, exp)
-        rng = date_range('1/1/1990', periods=5)
 
+        rng = date_range('1/1/1990', periods=5)
         iseries = Series(np.arange(5), rng) + 1
         iseries.ix[4] = np.nan
         exp = iseries / 4.0
         iranks = iseries.rank(pct=True)
         assert_series_equal(iranks, exp)
 
+        iseries = Series([1e-50, 1e-100, 1e-20, 1e-2, 1e-20+1e-30, 1e-1])
+        exp = Series([2, 1, 3.5, 5, 3.5, 6])
+        iranks = iseries.rank()
+        assert_series_equal(iranks, exp)
+
+        values = np.array([-50, -1, -1e-20, -1e-25, -1e-50, 0, 1e-40, 1e-20, 1e-10, 2, 40], dtype='float64')
+        random_order = np.random.permutation(len(values))
+        iseries = Series(values[random_order])
+        exp = Series(random_order + 1.0, dtype='float64')
+        iranks = iseries.rank()
+        assert_series_equal(iranks, exp)
+
+    def test_rank_inf(self):
+        raise nose.SkipTest('DataFrame.rank does not currently rank np.inf and -np.inf properly')
+
+        values = np.array([-np.inf, -50, -1, -1e-20, -1e-25, -1e-50, 0, 1e-40, 1e-20, 1e-10, 2, 40, np.inf], dtype='float64')
+        random_order = np.random.permutation(len(values))
+        iseries = Series(values[random_order])
+        exp = Series(random_order + 1.0, dtype='float64')
+        iranks = iseries.rank()
+        assert_series_equal(iranks, exp)
 
 
     def test_from_csv(self):


### PR DESCRIPTION
Okay, this fixes #6868 but does so with a bit of a performance penalty. The current pandas version performs just a tad slower than `scipy.stats.rankdata()`, but after these changes, it's about 2-3x slower. On the plus side, it does (what I think is) the right thing.

I'm no cython expert, so there may well be things that can be done to improve the speed.

Here's some quick benchmarking code (couldn't figure out how to work with the vbench suite):

```
import timeit
setup2 = """import pandas
import scipy.stats
import numpy
numpy.random.seed(154)
s = pandas.Series(numpy.random.normal(size=10000))"""

print "pandas:", timeit.repeat(stmt='s.rank()', setup=setup2, repeat=3, number=10000)
print "scipy:", timeit.repeat(stmt='scipy.stats.rankdata(s)', 
    setup=setup2, repeat=3, number=10000)
```
