### PR TITLE
BUG/ENH: Add fallback warnings and correctly handle leading whitespace in C parser

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -92,7 +92,8 @@ They can take a number of arguments:
   - ``dialect``: string or :class:`python:csv.Dialect` instance to expose more
     ways to specify the file format
   - ``dtype``: A data type name or a dict of column name to data type. If not
-    specified, data types will be inferred.
+    specified, data types will be inferred. (Unsupported with
+    ``engine='python'``)
   - ``header``: row number(s) to use as the column names, and the start of the
     data.  Defaults to 0 if no ``names`` passed, otherwise ``None``. Explicitly
     pass ``header=0`` to be able to replace existing names. The header can be
@@ -154,6 +155,7 @@ They can take a number of arguments:
     pieces. Will cause an ``TextFileReader`` object to be returned. More on this
     below in the section on :ref:`iterating and chunking <io.chunking>`
   - ``skip_footer``: number of lines to skip at bottom of file (default 0)
+    (Unsupported with ``engine='c'``)
   - ``converters``: a dictionary of functions for converting values in certain
     columns, where keys are either integers or column labels
   - ``encoding``: a string representing the encoding to use for decoding
@@ -274,6 +276,11 @@ individual columns:
     df['a'][0]
     df = pd.read_csv(StringIO(data), dtype={'b': object, 'c': np.float64})
     df.dtypes
+
+.. note::
+    The ``dtype`` option is currently only supported by the C engine.
+    Specifying ``dtype`` with ``engine`` other than 'c' raises a
+    ``ValueError``.
 
 .. _io.headers:
 
@@ -1028,6 +1035,22 @@ Specifying ``iterator=True`` will also return the ``TextFileReader`` object:
 
    os.remove('tmp.sv')
    os.remove('tmp2.sv')
+
+Specifying the parser engine
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Under the hood pandas uses a fast and efficient parser implemented in C as well
+as a python implementation which is currently more feature-complete. Where
+possible pandas uses the C parser (specified as ``engine='c'``), but may fall
+back to python if C-unsupported options are specified. Currently, C-unsupported
+options include:
+
+- ``sep`` other than a single character (e.g. regex separators)
+- ``skip_footer``
+- ``sep=None`` with ``delim_whitespace=False``
+
+Specifying any of the above options will produce a ``ParserWarning`` unless the
+python engine is selected explicitly using ``engine='python'``.
 
 .. _io.store_in_csv:
 

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -176,6 +176,8 @@ API Changes
 - ``.quantile`` on a ``datetime[ns]`` series now returns ``Timestamp`` instead
   of ``np.datetime64`` objects (:issue:`6810`)
 - change ``AssertionError`` to ``TypeError`` for invalid types passed to ``concat`` (:issue:`6583`)
+- Add :class:`~pandas.io.parsers.ParserWarning` class for fallback and option
+  validation warnings in :func:`read_csv`/:func:`read_table` (:issue:`6607`)
 
 Deprecations
 ~~~~~~~~~~~~
@@ -280,6 +282,9 @@ Improvements to existing features
 - Added ``how`` option to rolling-moment functions to dictate how to handle resampling; :func:``rolling_max`` defaults to max,
   :func:``rolling_min`` defaults to min, and all others default to mean (:issue:`6297`)
 - ``pd.stats.moments.rolling_var`` now uses Welford's method for increased numerical stability (:issue:`6817`)
+- Translate ``sep='\s+'`` to ``delim_whitespace=True`` in
+  :func:`read_csv`/:func:`read_table` if no other C-unsupported options
+  specified (:issue:`6607`)
 
 .. _release.bug_fixes-0.14.0:
 
@@ -402,6 +407,17 @@ Bug Fixes
 - Bug in `DataFrame.plot` and `Series.plot` legend behave inconsistently when plotting to the same axes repeatedly (:issue:`6678`)
 - Internal tests for patching ``__finalize__`` / bug in merge not finalizing (:issue:`6923`, :issue:`6927`)
 - accept ``TextFileReader`` in ``concat``, which was affecting a common user idiom (:issue:`6583`)
+- Raise :class:`ValueError` when ``sep`` specified with
+  ``delim_whitespace=True`` in :func:`read_csv`/:func:`read_table`
+  (:issue:`6607`)
+- Raise :class:`ValueError` when `engine='c'` specified with unsupported
+  options (:issue:`6607`)
+- Raise :class:`ValueError` when fallback to python parser causes options to be
+  ignored (:issue:`6607`)
+- Produce :class:`~pandas.io.parsers.ParserWarning` on fallback to python
+  parser when no options are ignored (:issue:`6607`)
+- Bug in C parser with leading whitespace (:issue:`3374`)
+- Bug in C parser with ``delim_whitespace=True`` and ``\r``-delimited lines
 
 pandas 0.13.1
 -------------

--- a/pandas/io/tests/test_cparser.py
+++ b/pandas/io/tests/test_cparser.py
@@ -323,6 +323,9 @@ a,b,c
         data = 'A  B  C\r  2  3\r4  5  6'
         _test(data, delim_whitespace=True)
 
+        data = 'A B C\r2 3\r4 5 6'
+        _test(data, delim_whitespace=True)
+
     def test_empty_field_eof(self):
         data = 'a,b,c\n1,2,3\n4,,'
 

--- a/pandas/src/parser/tokenizer.c
+++ b/pandas/src/parser/tokenizer.c
@@ -1162,7 +1162,6 @@ int tokenize_whitespace(parser_t *self, size_t line_limit)
                 self->state = EAT_CRNL;
                 break;
             } else if (IS_WHITESPACE(c)) {
-                END_FIELD();
                 self->state = EAT_WHITESPACE;
                 break;
             } else {
@@ -1319,10 +1318,14 @@ int tokenize_whitespace(parser_t *self, size_t line_limit)
                 /* self->state = START_RECORD; */
             } else if (IS_WHITESPACE(c)){
                 // Handle \r-delimited files
-                END_LINE_AND_FIELD_STATE(EAT_WHITESPACE);
+                END_LINE_STATE(EAT_WHITESPACE);
             } else {
-                PUSH_CHAR(c);
-                END_LINE_STATE(IN_FIELD);
+                /* XXX
+                 * first character of a new record--need to back up and reread
+                 * to handle properly...
+                 */
+                i--; buf--; /* back up one character (HACK!) */
+                END_LINE_STATE(START_RECORD);
             }
             break;
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -13501,7 +13501,7 @@ class TestDataFrameQueryStrings(object):
         6   "page 3 load"   2/1/2014 1:02:01
         6   "page 3 exit"   2/1/2014 1:02:31
         """
-        df = pd.read_csv(StringIO(raw), sep=r'\s{2,}',
+        df = pd.read_csv(StringIO(raw), sep=r'\s{2,}', engine='python',
                          parse_dates=['timestamp'])
         expected = df[df.event == '"page 1 load"']
         res = df.query("""'"page 1 load"' in event""", parser=parser,

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -462,7 +462,7 @@ a   b   10.0032 5    -0.5109 -2.3358 -0.4645  0.05076  0.3640
 a   q   20      4     0.4473  1.4152  0.2834  1.00661  0.1744
 x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 
-        df = read_table(StringIO(text), sep='\s+')
+        df = read_table(StringIO(text), sep='\s+', engine='python')
 
         result = df.xs(('a', 4), level=['one', 'four'])
         expected = df.xs('a').xs(4, level='four')
@@ -495,7 +495,7 @@ a   b   10.0032 5    -0.5109 -2.3358 -0.4645  0.05076  0.3640
 a   q   20      4     0.4473  1.4152  0.2834  1.00661  0.1744
 x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 
-        df = read_table(StringIO(text), sep='\s+')
+        df = read_table(StringIO(text), sep='\s+', engine='python')
 
         result = df.xs('a', level=0)
         expected = df.xs('a')


### PR DESCRIPTION
closes #6607
closes #3374

Currently, specifying options that are incompatible with the C parser in `read_csv` and `read_table` causes a silent fallback to the python engine. This can be confusing if the user has also passed options that are only supported by the C engine, which are then silently ignored. (See #6607)

For example, the commonly used option `sep='\s+'` causes a fallback to python which could be avoided by automatically translating this to the equivalent `delim_whitespace=True`, which is supported by the C engine.

There are some issues with the C parser that need to be fixed in order not to break tests with `sep='\s+'` which previously fell back to python:

The C parser does not correctly handle leading whitespace with `delim_whitespace=True` (#3374).

There is a related bug when parsing files with \r-delimited lines and missing values:

``` python
In [5]: data = 'a b c\r2 3\r4 5 6'

In [6]: pd.read_table(StringIO(data), delim_whitespace=True)
Out[6]: 
    a  b  c
0   2  3  4
1 NaN  5  6

[2 rows x 3 columns]
```
# Summary of changes
- **Raise `ValueError` when user specifies `engine='c'` with C-unsupported options:**

``` python
In [1]: import pandas as pd

In [2]: from pandas.compat import StringIO

In [3]: data = ' a\tb c\n 1\t2 3\n 4\t5 6'

In [4]: pd.read_table(StringIO(data), engine='c', sep='\s')
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
. . .
ValueError: the 'c' engine does not support regex separators
```
- **Raise `ValueError` when fallback to python parser causes python-unsupported options to be ignored:**

``` python
In [5]: pd.read_table(StringIO(data), sep='\s', dtype={'a': float})
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
. . .
ValueError: Falling back to the 'python' engine because the 'c' engine does not support regex separators, but this causes 'dtype' to be ignored as it is not supported by the 'python' engine. (Note the 'converters' option provides similar functionality.)
```
- **Warn (new class ParserWarning) when C-unsupported options cause a fallback to python:**

``` python
In [6]: pd.read_table(StringIO(data), skip_footer=1)
pandas/io/parsers.py:615: ParserWarning: Falling back to the 'python' engine because the 'c' engine does not support skip_footer; you can avoid this warning by specifying engine='python'.
  ParserWarning)
Out[6]: 
    a  b c
0   1  2 3

[1 rows x 2 columns]
```
- **Raise ValueError when the user specifies both `sep` and `delim_whitespace=True`:**

``` python
In [7]: pd.read_table(StringIO(data), sep='\s', delim_whitespace=True)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
. . .
ValueError: Specified a delimiter with both sep and delim_whitespace=True; you can only specify one.
```
- **Translate `sep='\s+'` to `delim_whitespace=True` when there are no other C-unsupported options:**

``` python
In [8]: pd.read_table(StringIO(data), sep='\s+', engine='c')
Out[8]: 
   a  b  c
0  1  2  3
1  4  5  6

[2 rows x 3 columns]
```
- **Fix handling of leading whitespace in the C parser (#3374) (add test)**

``` python
# Old behavior
In [3]: pd.__version__
Out[3]: '0.13.1-663-g21565a3'

In [4]: pd.read_table(StringIO(data), delim_whitespace=True)
Out[4]: 
   Unnamed: 0  a  b   c
0           1  2  3 NaN
1           4  5  6 NaN

[2 rows x 4 columns]
```

``` python
# New behavior
In [9]: pd.read_table(StringIO(data), delim_whitespace=True)
Out[9]: 
   a  b  c
0  1  2  3
1  4  5  6

[2 rows x 3 columns]
```
- **Fix bug in handling of \r-delimited files (add test)**
  (Old behavior shown above)

``` python
# New behavior
In [10]: data = 'a b c\r2 3\r4 5 6'

In [11]: pd.read_table(StringIO(data), delim_whitespace=True)
Out[11]: 
   a  b   c
0  2  3 NaN
1  4  5   6

[2 rows x 3 columns]
```
- **Copy tests in `ParserTests` that fall back to python to `TestPythonParser`; leave copies of these tests in `ParserTests` with the assertion that they raise a `ValueError` when run under other engines**
- **Add description of `engine` option to docstrings of `read_table` and `read_csv`**
