### PR TITLE
ENH (GH6568) Add option info_verbose

### DIFF
--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -1667,21 +1667,34 @@ columns of DataFrame objects are shown by default. If ``max_columns`` is set to
 string representation into the current terminal width, and defaulting to the
 summary view otherwise.
 
-Two options allow for controlling which elements of a DataFrame are
-printed. Depending on the size of the DataFrame it might be more
-convenient to print a summary representation only.
+The visualization of a dataframe can be controled directly with two
+options - `large_repr` and `info_verbose`. Depending on the size of
+the DataFrame it might be more convenient to print a summary
+representation only.
 
 .. ipython:: python
 
     df_lrge = DataFrame(columns=['a','b','c'],
               index=DatetimeIndex(start='19900101',end='20000101',freq='BM'))
-    # The default display for a DataFrame is 'truncate'
-    options.display.large_repr
-    # This prints all elements of the df up to max_rows/max_columns.
-    df_lrge
-    # To get a more concise representation of the df
-    options.display.large_repr = 'info'
-    df_lrge
-    # Further reduce summary view to one line for all columns
-    options.display.info_verbose = False
-    df_lrge
+
+The default display for a DataFrame is 'truncate'. This prints all
+elements of the df up to max_rows/max_columns.
+
+.. ipython:: python
+
+    with option_context("display.large_repr",'truncate'):
+        print df_lrge
+
+To get a more concise representation of the df
+
+.. ipython:: python
+
+    with option_context("display.large_repr",'info'):
+        print df_lrge
+
+Further reduce summary view to one line for all columns
+
+.. ipython:: python
+
+    with option_context("display.large_repr",'info',"display.info_verbose",False):
+	print df_lrge

--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -1666,3 +1666,22 @@ columns of DataFrame objects are shown by default. If ``max_columns`` is set to
 0 (the default, in fact), the library will attempt to fit the DataFrame's
 string representation into the current terminal width, and defaulting to the
 summary view otherwise.
+
+Two options allow for controlling which elements of a DataFrame are
+printed. Depending on the size of the DataFrame it might be more
+convenient to print a summary representation only.
+
+.. ipython:: python
+
+    df_lrge = DataFrame(columns=['a','b','c'],
+              index=DatetimeIndex(start='19900101',end='20000101',freq='BM'))
+    # The default display for a DataFrame is 'truncate'
+    options.display.large_repr
+    # This prints all elements of the df up to max_rows/max_columns.
+    df_lrge
+    # To get a more concise representation of the df
+    options.display.large_repr = 'info'
+    df_lrge
+    # Further reduce summary view to one line for all columns
+    options.display.info_verbose = False
+    df_lrge

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -45,6 +45,11 @@ As of 0.13, these are the relevant options, all under the `display` namespace,
 - large_repr (default 'truncate'): when a :class:`~pandas.DataFrame`
   exceeds max_columns or max_rows, it can be displayed either as a
   truncated table or, with this set to 'info', as a short summary view.
+- info_verbose (default True): When large_repr is set to 'info', the
+  index of a :class:`~pandas.DataFrame` will be displayed as a short
+  summary, while columns are still listed individually. When
+  'info_verbose' is set to False, the columns will be displayed in a
+  short summary view also.
 - max_columns (default 20): max dataframe columns to display.
 - max_rows (default 60): max dataframe rows display.
 - show_dimensions (default True): controls the display of the row/col counts footer.

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -183,8 +183,17 @@ pc_large_repr_doc = """
     df.info() (the behaviour in earlier versions of pandas).
 """
 
+pc_info_verbose_doc = """
+: boolean
+
+    Relevant when `large_repr` set to `info`. Dictates whether a df
+    will be displayed as df.info(verbose=True) or
+    df.info(verbose=False). When `False`, columns are displayed in a
+    summary line, instead of listing all columns. 
+"""
+
 pc_mpl_style_doc = """
-: bool
+: boolean
 
     Setting this to 'default' will modify the rcParams used by matplotlib
     to give plots a more pleasing visual style by default.
@@ -230,6 +239,8 @@ with cf.config_prefix('display'):
                        validator=is_instance_factory([type(None), int]))
     cf.register_option('large_repr', 'truncate', pc_large_repr_doc,
                        validator=is_one_of_factory(['truncate', 'info']))
+    cf.register_option('info_verbose', True, pc_info_verbose_doc, 
+                       validator=is_bool)
     cf.register_option('max_info_columns', 100, pc_max_info_cols_doc,
                        validator=is_int)
     cf.register_option('colheader_justify', 'right', colheader_justify_doc,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -447,8 +447,12 @@ class DataFrame(NDFrame):
         py2/py3.
         """
         buf = StringIO(u(""))
-        if self._info_repr():
-            self.info(buf=buf)
+        info_verbose = get_option("display.info_verbose")
+        if self._info_repr() and info_verbose:
+            self.info(buf=buf,verbose=True)
+            return buf.getvalue()
+        elif self._info_repr() and not info_verbose:
+            self.info(buf=buf,verbose=False)
             return buf.getvalue()
 
         max_rows = get_option("display.max_rows")
@@ -480,9 +484,14 @@ class DataFrame(NDFrame):
             # 'HTML output is disabled in QtConsole'
             return None
 
-        if self._info_repr():
+        info_verbose = get_option("display.info_verbose")
+        if self._info_repr() and info_verbose:
             buf = StringIO(u(""))
-            self.info(buf=buf)
+            self.info(buf=buf,verbose=True)
+            return '<pre>' + buf.getvalue() + '</pre>'
+        elif self._info_repr() and not info_verbose:
+            buf = StringIO(u(""))
+            self.info(buf=buf,verbose=False)
             return '<pre>' + buf.getvalue() + '</pre>'
 
         if get_option("display.notebook_repr_html"):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -447,12 +447,8 @@ class DataFrame(NDFrame):
         py2/py3.
         """
         buf = StringIO(u(""))
-        info_verbose = get_option("display.info_verbose")
-        if self._info_repr() and info_verbose:
-            self.info(buf=buf,verbose=True)
-            return buf.getvalue()
-        elif self._info_repr() and not info_verbose:
-            self.info(buf=buf,verbose=False)
+        if self._info_repr():
+            self.info(buf=buf)
             return buf.getvalue()
 
         max_rows = get_option("display.max_rows")
@@ -484,14 +480,9 @@ class DataFrame(NDFrame):
             # 'HTML output is disabled in QtConsole'
             return None
 
-        info_verbose = get_option("display.info_verbose")
-        if self._info_repr() and info_verbose:
+        if self._info_repr():
             buf = StringIO(u(""))
-            self.info(buf=buf,verbose=True)
-            return '<pre>' + buf.getvalue() + '</pre>'
-        elif self._info_repr() and not info_verbose:
-            buf = StringIO(u(""))
-            self.info(buf=buf,verbose=False)
+            self.info(buf=buf)
             return '<pre>' + buf.getvalue() + '</pre>'
 
         if get_option("display.notebook_repr_html"):
@@ -1390,19 +1381,22 @@ class DataFrame(NDFrame):
         if buf is None:
             return formatter.buf.getvalue()
 
-    def info(self, verbose=True, buf=None, max_cols=None):
+    def info(self, verbose=None, buf=None, max_cols=None):
         """
         Concise summary of a DataFrame.
 
         Parameters
         ----------
-        verbose : boolean, default True
+        verbose : boolean, default None
             If False, don't print column count summary
         buf : writable buffer, defaults to sys.stdout
         max_cols : int, default None
             Determines whether full summary or short summary is printed
         """
         from pandas.core.format import _put_lines
+
+        if verbose is None:
+            verbose = get_option("display.info_verbose")
 
         if buf is None:  # pragma: no cover
             buf = sys.stdout


### PR DESCRIPTION
This adds a info_verbose to the options. There's a small section in faq and basic introduction. Entry in v0.14 is still missing. 

Closes #6568
