### PR TITLE
BUG: TimeGrouper outputs different result by column order

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -294,6 +294,7 @@ Bug Fixes
 - Bug in TimeGrouper/resample when presented with a non-monotonic DatetimeIndex would return invalid results. (:issue:`4161`)
 - Bug in index name propogation in TimeGrouper/resample (:issue:`4161`)
 - TimeGrouper has a more compatible API to the rest of the groupers (e.g. ``groups`` was missing) (:issue:`3881`)
+- Bug in multiple grouping with a TimeGrouper depending on target column order (:issue:`6764`)
 - Bug in ``pd.eval`` when parsing strings with possible tokens like ``'&'``
   (:issue:`6351`)
 - Bug correctly handle placements of ``-inf`` in Panels when dividing by integer 0 (:issue:`6178`)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -263,11 +263,11 @@ class Grouper(object):
                     if not (level == 0 or level == ax.name):
                         raise ValueError("The grouper level {0} is not valid".format(level))
 
-            # possibly sort
-            if (self.sort or sort) and not ax.is_monotonic:
-                indexer = self.indexer = ax.argsort(kind='quicksort')
-                ax = ax.take(indexer)
-                obj = obj.take(indexer, axis=self.axis, convert=False, is_copy=False)
+        # possibly sort
+        if (self.sort or sort) and not ax.is_monotonic:
+            indexer = self.indexer = ax.argsort(kind='quicksort')
+            ax = ax.take(indexer)
+            obj = obj.take(indexer, axis=self.axis, convert=False, is_copy=False)
 
         self.obj = obj
         self.grouper = ax

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -138,7 +138,8 @@ class TimeGrouper(Grouper):
         # since we may have had to sort
         # may need to reorder groups here
         if self.indexer is not None:
-            grouper = grouper.take(self.indexer)
+            indexer = self.indexer.argsort(kind='quicksort')
+            grouper = grouper.take(indexer)
         return grouper
 
     def _get_time_bins(self, ax):
@@ -161,7 +162,7 @@ class TimeGrouper(Grouper):
 
         # a little hack
         trimmed = False
-        if (len(binner) > 2 and binner[-2] == ax[-1] and
+        if (len(binner) > 2 and binner[-2] == ax.max() and
                 self.closed == 'right'):
 
             binner = binner[:-1]
@@ -204,7 +205,7 @@ class TimeGrouper(Grouper):
                 bin_edges = bin_edges + day_nanos - 1
 
             # intraday values on last day
-            if bin_edges[-2] > ax_values[-1]:
+            if bin_edges[-2] > ax_values.max():
                 bin_edges = bin_edges[:-1]
                 binner = binner[:-1]
 
@@ -320,8 +321,8 @@ class TimeGrouper(Grouper):
             # Get the fill indexer
             indexer = memb.get_indexer(new_index, method=self.fill_method,
                                        limit=self.limit)
-
             return _take_new_index(obj, indexer, new_index, axis=self.axis)
+
         else:
             raise ValueError('Frequency %s cannot be resampled to %s'
                              % (axlabels.freq, self.freq))
@@ -352,7 +353,7 @@ def _get_range_edges(axis, offset, closed='left', base=0):
             return _adjust_dates_anchored(axis[0], axis[-1], offset,
                                           closed=closed, base=base)
 
-    first, last = axis[0], axis[-1]
+    first, last = axis.min(), axis.max()
     if not isinstance(offset, Tick):  # and first.time() != last.time():
         # hack!
         first = tools.normalize_date(first)


### PR DESCRIPTION
closes #6764

`TimeGrouper` may output incorrect results depending on the target column order. The problem seems to be caused by 2 parts.
- `TimeGrouper._get_time_bins` and related methods expects sorted values input.
- `BinGrouper.get_iterator` expects sorted data input. 

```
>>> df = pd.DataFrame({'Branch' : 'A A A A A A A B'.split(),
                   'Buyer': 'Carl Mark Carl Carl Joe Joe Joe Carl'.split(),
                   'Quantity': [1,3,5,1,8,1,9,3],
                   'Date' : [
                    datetime(2013,1,1,13,0), datetime(2013,1,1,13,5),
                    datetime(2013,10,1,20,0), datetime(2013,10,2,10,0),
                    datetime(2013,10,1,20,0), datetime(2013,10,2,10,0),
                    datetime(2013,12,2,12,0), datetime(2013,12,2,14,0),]})

# correct
>>> df.groupby([pd.Grouper(freq='1M',key='Date'),'Buyer']).sum()
                  Quantity
Date       Buyer          
2013-01-31 Carl          1
           Mark          3
2013-10-31 Carl          6
           Joe           9
2013-12-31 Carl          3
           Joe           9

[6 rows x 1 columns]

>>> df_sorted = df.sort('Quantity')          # change "Date" column unsorted
# incorrect
>>> df_sorted.groupby([pd.Grouper(freq='1M',key='Date'),'Buyer']).sum()
                  Quantity
Date       Buyer          
2013-01-31 Carl          1
2013-10-31 Carl          1
           Joe           1
           Mark          3
2013-12-31 Carl          8
           Joe          17

[6 rows x 1 columns]

>>> df_sorted.groupby([pd.Grouper(freq='1M',key='Date', sort=True),'Buyer']).sum()
# same incorrect result
```

```
# correct
>>> df.groupby([pd.Grouper(freq='6M',key='Date'),'Buyer']).sum()
                  Quantity
Date       Buyer          
2013-01-31 Carl          1
           Mark          3
2014-01-31 Carl          9
           Joe          18

[4 rows x 1 columns]

# incorrect
>>> df_sorted.groupby([pd.Grouper(freq='6M',key='Date'),'Buyer']).sum()
                  Quantity
Date       Buyer          
2013-01-31 Carl          1
2014-01-31 Carl          9
           Joe          18
           Mark          3

[4 rows x 1 columns]
```
