### PR TITLE
ENH: pivot_table can now accept Grouper

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -286,6 +286,7 @@ Improvements to existing features
   :func:`read_csv`/:func:`read_table` if no other C-unsupported options
   specified (:issue:`6607`)
 - ``read_excel`` can now read milliseconds in Excel dates and times with xlrd >= 0.9.3. (:issue:`5945`)
+- ``pivot_table`` can now accept ``Grouper`` by ``index`` and ``columns`` keywords (:issue:`6913`)
 
 .. _release.bug_fixes-0.14.0:
 

--- a/doc/source/reshaping.rst
+++ b/doc/source/reshaping.rst
@@ -264,19 +264,24 @@ It takes a number of arguments
 
 - ``data``: A DataFrame object
 - ``values``: a column or a list of columns to aggregate
-- ``rows``: list of columns to group by on the table rows
-- ``cols``: list of columns to group by on the table columns
+- ``index``: a column, Grouper, array which has the same length as data, or list of them.
+  Keys to group by on the pivot table index. If an array is passed, it is being used as the same manner as column values.
+- ``columns``: a column, Grouper, array which has the same length as data, or list of them. 
+  Keys to group by on the pivot table column. If an array is passed, it is being used as the same manner as column values.
 - ``aggfunc``: function to use for aggregation, defaulting to ``numpy.mean``
 
 Consider a data set like this:
 
 .. ipython:: python
 
+   import datetime
    df = DataFrame({'A' : ['one', 'one', 'two', 'three'] * 6,
                    'B' : ['A', 'B', 'C'] * 8,
                    'C' : ['foo', 'foo', 'foo', 'bar', 'bar', 'bar'] * 4,
                    'D' : np.random.randn(24),
-                   'E' : np.random.randn(24)})
+                   'E' : np.random.randn(24),
+                   'F' : [datetime.datetime(2013, i, 1) for i in range(1, 13)] +
+                         [datetime.datetime(2013, i, 15) for i in range(1, 13)]})
    df
 
 We can produce pivot tables from this data very easily:
@@ -295,6 +300,12 @@ hierarchy in the columns:
 .. ipython:: python
 
    pivot_table(df, index=['A', 'B'], columns=['C'])
+
+Also, you can use ``Grouper`` for ``index`` and ``columns`` keywords. For detail of ``Grouper``, see :ref:`Grouping with a Grouper specification <groupby.specify>`.
+
+.. ipython:: python
+
+   pivot_table(df, values='D', index=Grouper(freq='M', key='F'), columns='C')
 
 You can render a nice output of the table omitting the missing values by
 calling ``to_string`` if you wish:

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -484,6 +484,26 @@ Enhancements
 - ``CustomBuisnessMonthBegin`` and ``CustomBusinessMonthEnd`` are now available (:issue:`6866`)
 - :meth:`Series.quantile` and :meth:`DataFrame.quantile` now accept an array of 
   quantiles.
+- ``pivot_table`` can now accept ``Grouper`` by ``index`` and ``columns`` keywords (:issue:`6913`)
+
+  .. ipython:: python
+
+    import datetime 
+    df = DataFrame({
+      'Branch' : 'A A A A A B'.split(),
+      'Buyer': 'Carl Mark Carl Carl Joe Joe'.split(),
+      'Quantity': [1, 3, 5, 1, 8, 1],
+      'Date' : [datetime.datetime(2013,11,1,13,0), datetime.datetime(2013,9,1,13,5),
+                datetime.datetime(2013,10,1,20,0), datetime.datetime(2013,10,2,10,0),
+                datetime.datetime(2013,11,1,20,0), datetime.datetime(2013,10,2,10,0)],
+      'PayDay' : [datetime.datetime(2013,10,4,0,0), datetime.datetime(2013,10,15,13,5),
+                  datetime.datetime(2013,9,5,20,0), datetime.datetime(2013,11,2,10,0),
+                  datetime.datetime(2013,10,7,20,0), datetime.datetime(2013,9,5,10,0)]})
+    df
+
+    pivot_table(df, index=Grouper(freq='M', key='Date'),
+                columns=Grouper(freq='M', key='PayDay'),
+                values='Quantity', aggfunc=np.sum)
 
 Performance
 ~~~~~~~~~~~

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -4,6 +4,7 @@ import warnings
 
 from pandas import Series, DataFrame
 from pandas.core.index import MultiIndex
+from pandas.core.groupby import Grouper
 from pandas.tools.merge import concat
 from pandas.tools.util import cartesian_product
 from pandas.compat import range, lrange, zip
@@ -25,10 +26,12 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
     ----------
     data : DataFrame
     values : column to aggregate, optional
-    index : list of column names or arrays to group on
-        Keys to group on the x-axis of the pivot table
-    columns : list of column names or arrays to group on
-        Keys to group on the y-axis of the pivot table
+    index : a column, Grouper, array which has the same length as data, or list of them.
+        Keys to group by on the pivot table index.
+        If an array is passed, it is being used as the same manner as column values.
+    columns : a column, Grouper, array which has the same length as data, or list of them.
+        Keys to group by on the pivot table column.
+        If an array is passed, it is being used as the same manner as column values.
     aggfunc : function, default numpy.mean, or list of functions
         If list of functions passed, the resulting pivot table will have
         hierarchical columns whose top level are the function names (inferred
@@ -98,6 +101,8 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
     if values_passed:
         to_filter = []
         for x in keys + values:
+            if isinstance(x, Grouper):
+                x = x.key
             try:
                 if x in data:
                     to_filter.append(x)
@@ -297,7 +302,7 @@ def _generate_marginal_results_without_values(table, data, rows, cols, aggfunc):
 def _convert_by(by):
     if by is None:
         by = []
-    elif (np.isscalar(by) or isinstance(by, (np.ndarray, Series))
+    elif (np.isscalar(by) or isinstance(by, (np.ndarray, Series, Grouper))
           or hasattr(by, '__call__')):
         by = [by]
     else:


### PR DESCRIPTION
`pivot_table` can accept `Grouper` by `index` and `columns` kw.

```
>>> df = pd.DataFrame({
    'Branch' : 'A A A A A A A B'.split(),
    'Buyer': 'Carl Mark Carl Carl Joe Joe Joe Carl'.split(),
    'Quantity': [1,3,5,1,8,1,9,3],
    'Date' : [datetime(2013,11,1,13,0), datetime(2013,9,1,13,5),
              datetime(2013,10,1,20,0), datetime(2013,10,2,10,0),
              datetime(2013,11,1,20,0), datetime(2013,10,2,10,0),
              datetime(2013,10,2,12,0), datetime(2013,12,5,14,0)],
    'PayDay' : [datetime(2013,10,4,0,0), datetime(2013,10,15,13,5),
                datetime(2013,9,5,20,0), datetime(2013,11,2,10,0),
                datetime(2013,10,7,20,0), datetime(2013,9,5,10,0),
                datetime(2013,12,30,12,0), datetime(2013,11,20,14,0),]})

>>> pd.pivot_table(df, index=pd.Grouper(freq='M', key='Date'),
                     columns=pd.Grouper(freq='M', key='PayDay'),
                     values='Quantity', aggfunc=np.sum)
PayDay      2013-09-30  2013-10-31  2013-11-30  2013-12-31
Date                                                      
2013-09-30         NaN           3         NaN         NaN
2013-10-31           6         NaN           1           9
2013-11-30         NaN           9         NaN         NaN
2013-12-31         NaN         NaN           3         NaN
```
