### PR TITLE
BUG: GroupBy.get_group doesnt work with TimeGrouper

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -399,6 +399,7 @@ Bug Fixes
 - Better error message when passing a frequency of 'MS' in ``Period`` construction (GH5332)
 - Bug in `Series.__unicode__` when `max_rows` is `None` and the Series has more than 1000 rows. (:issue:`6863`)
 - Bug in ``groupby.get_group`` where a datetlike wasn't always accepted (:issue:`5267`)
+- Bug in ``groupBy.get_group`` created by ``TimeGrouper`` raises ``AttributeError`` (:issue:`6914`)
 - Bug in ``DatetimeIndex.tz_localize`` and ``DatetimeIndex.tz_convert`` affects to NaT (:issue:`5546`)
 - Bug in arithmetic operations affecting to NaT (:issue:`6873`)
 - Bug in ``Series.str.extract`` where the resulting ``Series`` from a single

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2,6 +2,7 @@ import types
 from functools import wraps
 import numpy as np
 import datetime
+import collections
 
 from pandas.compat import(
     zip, builtins, range, long, lrange, lzip,
@@ -1555,6 +1556,17 @@ class BinGrouper(BaseGrouper):
             result_values.append(res)
 
         return result_keys, result_values, mutated
+
+    @cache_readonly
+    def indices(self):
+        indices = collections.defaultdict(list)
+
+        i = 0
+        for label, bin in zip(self.binlabels, self.bins):
+            if i < bin:
+                indices[label] = list(range(i, bin))
+                i = bin
+        return indices
 
     @cache_readonly
     def ngroups(self):

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -3140,6 +3140,55 @@ class TestGroupBy(tm.TestCase):
             result2 = df.groupby([pd.TimeGrouper(freq=freq), 'user_id'])['whole_cost'].sum()
             assert_series_equal(result2, expected)
 
+    def test_timegrouper_get_group(self):
+        # GH 6914
+
+        df_original = DataFrame({
+            'Buyer': 'Carl Joe Joe Carl Joe Carl'.split(),
+            'Quantity': [18,3,5,1,9,3],
+            'Date' : [datetime(2013,9,1,13,0), datetime(2013,9,1,13,5),
+                      datetime(2013,10,1,20,0), datetime(2013,10,3,10,0),
+                      datetime(2013,12,2,12,0), datetime(2013,9,2,14,0),]})
+        df_reordered = df_original.sort(columns='Quantity')
+
+        # single grouping
+        expected_list = [df_original.iloc[[0, 1, 5]], df_original.iloc[[2, 3]],
+                         df_original.iloc[[4]]]
+        dt_list = ['2013-09-30', '2013-10-31', '2013-12-31']
+
+        for df in [df_original, df_reordered]:
+            grouped = df.groupby(pd.Grouper(freq='M', key='Date'))
+            for t, expected in zip(dt_list, expected_list):
+                dt = pd.Timestamp(t)
+                result = grouped.get_group(dt)
+                assert_frame_equal(result, expected)
+
+        # multiple grouping
+        expected_list = [df_original.iloc[[1]], df_original.iloc[[3]],
+                         df_original.iloc[[4]]]
+        g_list = [('Joe', '2013-09-30'), ('Carl', '2013-10-31'), ('Joe', '2013-12-31')]
+
+        for df in [df_original, df_reordered]:
+            grouped = df.groupby(['Buyer', pd.Grouper(freq='M', key='Date')])
+            for (b, t), expected in zip(g_list, expected_list):
+                dt = pd.Timestamp(t)
+                result = grouped.get_group((b, dt))
+                assert_frame_equal(result, expected)
+
+        # with index
+        df_original = df_original.set_index('Date')
+        df_reordered = df_original.sort(columns='Quantity')
+
+        expected_list = [df_original.iloc[[0, 1, 5]], df_original.iloc[[2, 3]],
+                         df_original.iloc[[4]]]
+
+        for df in [df_original, df_reordered]:
+            grouped = df.groupby(pd.Grouper(freq='M'))
+            for t, expected in zip(dt_list, expected_list):
+                dt = pd.Timestamp(t)
+                result = grouped.get_group(dt)
+                assert_frame_equal(result, expected)
+
     def test_cumcount(self):
         df = DataFrame([['a'], ['a'], ['a'], ['b'], ['a']], columns=['A'])
         g = df.groupby('A')


### PR DESCRIPTION
`get_group` raises `AttributeError` when the group is created by `TimeGrouper`.

```
>>> df = pd.DataFrame({'Branch' : 'A A A A A A A B'.split(),
                   'Buyer': 'Carl Mark Carl Carl Joe Joe Joe Carl'.split(),
                   'Quantity': [1,3,5,1,8,1,9,3],
                   'Date' : [
                    datetime(2013,1,1,13,0), datetime(2013,1,1,13,5),
                    datetime(2013,10,1,20,0), datetime(2013,10,2,10,0),
                    datetime(2013,10,1,20,0), datetime(2013,10,2,10,0),
                    datetime(2013,12,2,12,0), datetime(2013,12,2,14,0),]})

>>> grouped = df.groupby(pd.Grouper(freq='1M',key='Date'))
>>> grouped.get_group(pd.Timestamp('2013-12-31'))
AttributeError: 'DataFrameGroupBy' object has no attribute 'indices'
```
