### PR TITLE
API: remove the copy kw from .xs to prevent an expectation of a view (which may not be possible)

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -78,7 +78,7 @@ SQL
 
 .. autosummary::
    :toctree: generated/
-    
+
    read_sql_table
    read_sql_query
    read_sql

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -176,6 +176,10 @@ API Changes
 - ``.quantile`` on a ``datetime[ns]`` series now returns ``Timestamp`` instead
   of ``np.datetime64`` objects (:issue:`6810`)
 
+- Remove the ``copy`` keyword from ``DataFrame.xs``,``Panel.major_xs``,``Panel.minor_xs``. A view will be
+  returned if possible, otherwise a copy will be made. Previously the user could think that ``copy=False`` would
+  ALWAYS return a view. (:issue:`6894`)
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -214,6 +214,10 @@ API changes
   (and numpy defaults)
 - add ``inplace`` keyword to ``Series.order/sort`` to make them inverses (:issue:`6859`)
 
+- Remove the ``copy`` keyword from ``DataFrame.xs``,``Panel.major_xs``,``Panel.minor_xs``. A view will be
+  returned if possible, otherwise a copy will be made. Previously the user could think that ``copy=False`` would
+  ALWAYS return a view. (:issue:`6894`)
+
 .. _whatsnew_0140.sql:
 
 SQL

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1564,7 +1564,7 @@ class DataFrame(NDFrame):
     def icol(self, i):
         return self._ixs(i, axis=1)
 
-    def _ixs(self, i, axis=0, copy=False):
+    def _ixs(self, i, axis=0):
         """
         i : int, slice, or sequence of integers
         axis : int
@@ -1588,7 +1588,10 @@ class DataFrame(NDFrame):
                     result = self.take(i, axis=axis)
                     copy=True
                 else:
-                    new_values, copy = self._data.fast_xs(i, copy=copy)
+                    new_values = self._data.fast_xs(i)
+
+                    # if we are a copy, mark as such
+                    copy = isinstance(new_values,np.ndarray) and new_values.base is None
                     result = Series(new_values, index=self.columns,
                                     name=self.index[i], dtype=new_values.dtype)
                 result._set_is_copy(self, copy=copy)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -76,17 +76,14 @@ class _NDFrameIndexer(object):
             # but will fail when the index is not present
             # see GH5667
             try:
-                return self.obj._xs(label, axis=axis, copy=False)
+                return self.obj._xs(label, axis=axis)
             except:
                 return self.obj[label]
         elif (isinstance(label, tuple) and
                 isinstance(label[axis], slice)):
             raise IndexingError('no slices here, handle elsewhere')
 
-        try:
-            return self.obj._xs(label, axis=axis, copy=False)
-        except Exception:
-            return self.obj._xs(label, axis=axis, copy=True)
+        return self.obj._xs(label, axis=axis)
 
     def _get_loc(self, key, axis=0):
         return self.obj._ixs(key, axis=axis)

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -688,7 +688,7 @@ class Panel(NDFrame):
 
         return self._constructor(result_values, items, major, minor)
 
-    def major_xs(self, key, copy=True):
+    def major_xs(self, key, copy=None):
         """
         Return slice of panel along major axis
 
@@ -696,17 +696,29 @@ class Panel(NDFrame):
         ----------
         key : object
             Major axis label
-        copy : boolean, default True
-            Copy data
+        copy : boolean [deprecated]
+            Whether to make a copy of the data
 
         Returns
         -------
         y : DataFrame
             index -> minor axis, columns -> items
-        """
-        return self.xs(key, axis=self._AXIS_LEN - 2, copy=copy)
 
-    def minor_xs(self, key, copy=True):
+        Notes
+        -----
+        major_xs is only for getting, not setting values.
+
+        MultiIndex Slicers is a generic way to get/set values on any level or levels
+        it is a superset of major_xs functionality, see :ref:`MultiIndex Slicers <indexing.mi_slicers>`
+
+        """
+        if copy is not None:
+            warnings.warn("copy keyword is deprecated, "
+                          "default is to return a copy or a view if possible")
+
+        return self.xs(key, axis=self._AXIS_LEN - 2)
+
+    def minor_xs(self, key, copy=None):
         """
         Return slice of panel along minor axis
 
@@ -714,17 +726,29 @@ class Panel(NDFrame):
         ----------
         key : object
             Minor axis label
-        copy : boolean, default True
-            Copy data
+        copy : boolean [deprecated]
+            Whether to make a copy of the data
 
         Returns
         -------
         y : DataFrame
             index -> major axis, columns -> items
-        """
-        return self.xs(key, axis=self._AXIS_LEN - 1, copy=copy)
 
-    def xs(self, key, axis=1, copy=True):
+        Notes
+        -----
+        minor_xs is only for getting, not setting values.
+
+        MultiIndex Slicers is a generic way to get/set values on any level or levels
+        it is a superset of minor_xs functionality, see :ref:`MultiIndex Slicers <indexing.mi_slicers>`
+
+        """
+        if copy is not None:
+            warnings.warn("copy keyword is deprecated, "
+                          "default is to return a copy or a view if possible")
+
+        return self.xs(key, axis=self._AXIS_LEN - 1)
+
+    def xs(self, key, axis=1, copy=None):
         """
         Return slice of panel along selected axis
 
@@ -733,24 +757,36 @@ class Panel(NDFrame):
         key : object
             Label
         axis : {'items', 'major', 'minor}, default 1/'major'
-        copy : boolean, default True
-            Copy data
+        copy : boolean [deprecated]
+            Whether to make a copy of the data
 
         Returns
         -------
         y : ndim(self)-1
+
+        Notes
+        -----
+        xs is only for getting, not setting values.
+
+        MultiIndex Slicers is a generic way to get/set values on any level or levels
+        it is a superset of xs functionality, see :ref:`MultiIndex Slicers <indexing.mi_slicers>`
+
         """
+        if copy is not None:
+            warnings.warn("copy keyword is deprecated, "
+                          "default is to return a copy or a view if possible")
+
         axis = self._get_axis_number(axis)
         if axis == 0:
-            data = self[key]
-            if copy:
-                data = data.copy()
-            return data
+            return self[key]
 
         self._consolidate_inplace()
         axis_number = self._get_axis_number(axis)
-        new_data = self._data.xs(key, axis=axis_number, copy=copy)
-        return self._construct_return_type(new_data)
+        new_data = self._data.xs(key, axis=axis_number, copy=False)
+        result = self._construct_return_type(new_data)
+        copy = new_data.is_mixed_type
+        result._set_is_copy(self, copy=copy)
+        return result
 
     _xs = xs
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -8371,12 +8371,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         expected = self.frame['A']
         assert_series_equal(series, expected)
 
-        # no view by default
-        series[:] = 5
-        self.assert_((expected != 5).all())
-
-        # view
-        series = self.frame.xs('A', axis=1, copy=False)
+        # view is returned if possible
+        series = self.frame.xs('A', axis=1)
         series[:] = 5
         self.assert_((expected == 5).all())
 
@@ -11888,25 +11884,16 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_almost_equal(expected, self.frame.values)
 
     def test_xs_view(self):
+        """
+        in 0.14 this will return a view if possible
+        a copy otherwise, but this is numpy dependent
+        """
+
         dm = DataFrame(np.arange(20.).reshape(4, 5),
                        index=lrange(4), columns=lrange(5))
 
-        dm.xs(2, copy=False)[:] = 5
-        self.assert_((dm.xs(2) == 5).all())
-
         dm.xs(2)[:] = 10
-        self.assert_((dm.xs(2) == 5).all())
-
-        # prior to chained assignment (GH5390)
-        # this would raise, but now just returns a copy (and sets is_copy)
-        # TODO (?): deal with mixed-type fiasco?
-        # with assertRaisesRegexp(TypeError, 'cannot get view of mixed-type'):
-        #    self.mixed_frame.xs(self.mixed_frame.index[2], copy=False)
-
-        # unconsolidated
-        dm['foo'] = 6.
-        dm.xs(3, copy=False)[:] = 10
-        self.assert_((dm.xs(3) == 10).all())
+        self.assert_((dm.xs(2) == 10).all())
 
     def test_boolean_indexing(self):
         idx = lrange(3)

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -444,9 +444,15 @@ class TestMultiLevel(tm.TestCase):
         expected = df[1:2]
         expected.index = expected.index.droplevel(2)
         assert_frame_equal(result, expected)
-        # can't produce a view of a multiindex with a level without copying
-        with assertRaisesRegexp(ValueError, 'Cannot retrieve view'):
-            self.frame.xs('two', level='second', copy=False)
+
+        # this is a copy in 0.14
+        result = self.frame.xs('two', level='second')
+
+        # setting this will give a SettingWithCopyError
+        # as we are trying to write a view
+        def f(x):
+            x[:] = 10
+        self.assertRaises(com.SettingWithCopyError, f, result)
 
     def test_xs_level_multiple(self):
         from pandas import read_table
@@ -461,8 +467,15 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         result = df.xs(('a', 4), level=['one', 'four'])
         expected = df.xs('a').xs(4, level='four')
         assert_frame_equal(result, expected)
-        with assertRaisesRegexp(ValueError, 'Cannot retrieve view'):
-            df.xs(('a', 4), level=['one', 'four'], copy=False)
+
+        # this is a copy in 0.14
+        result = df.xs(('a', 4), level=['one', 'four'])
+
+        # setting this will give a SettingWithCopyError
+        # as we are trying to write a view
+        def f(x):
+            x[:] = 10
+        self.assertRaises(com.SettingWithCopyError, f, result)
 
         # GH2107
         dates = lrange(20111201, 20111205)

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -536,19 +536,15 @@ class CheckIndexing(object):
         expected = self.panel['ItemA']
         assert_frame_equal(itemA, expected)
 
-        # not view by default
-        itemA.values[:] = np.nan
-        self.assert_(not np.isnan(self.panel['ItemA'].values).all())
-
-        # but can get view
-        itemA_view = self.panel.xs('ItemA', axis=0, copy=False)
+        # get a view by default
+        itemA_view = self.panel.xs('ItemA', axis=0)
         itemA_view.values[:] = np.nan
         self.assert_(np.isnan(self.panel['ItemA'].values).all())
 
-        # mixed-type
+        # mixed-type yields a copy
         self.panel['strings'] = 'foo'
-        self.assertRaises(Exception, self.panel.xs, 'D', axis=2,
-                          copy=False)
+        result = self.panel.xs('D', axis=2)
+        self.assertIsNotNone(result.is_copy)
 
     def test_getitem_fancy_labels(self):
         p = self.panel

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -452,19 +452,15 @@ class CheckIndexing(object):
         expected = self.panel4d['l1']
         assert_panel_equal(l1, expected)
 
-        # not view by default
-        l1.values[:] = np.nan
-        self.assert_(not np.isnan(self.panel4d['l1'].values).all())
-
-        # but can get view
-        l1_view = self.panel4d.xs('l1', axis=0, copy=False)
+        # view if possible
+        l1_view = self.panel4d.xs('l1', axis=0)
         l1_view.values[:] = np.nan
         self.assert_(np.isnan(self.panel4d['l1'].values).all())
 
         # mixed-type
         self.panel4d['strings'] = 'foo'
-        self.assertRaises(Exception, self.panel4d.xs, 'D', axis=2,
-                          copy=False)
+        result = self.panel4d.xs('D', axis=3)
+        self.assertIsNotNone(result.is_copy)
 
     def test_getitem_fancy_labels(self):
         panel4d = self.panel4d


### PR DESCRIPTION
closes #6894

Deprecate passing keyword `copy` to:
- `DataFrame/Series/Panel/.xs`
- `Panel.minor_xs`
- `Panel.major_xs`

`.xs` returns a view (as does `.loc`) **IF POSSIBLE**

MultiIndexing with Slicers eliminates the need for this (and `.xs` for the too, but for
some cases its 'simpler').
