### PR TITLE
API/DEPR: Deprecate order kwarg in factorize

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -206,6 +206,8 @@ Deprecations
   ``periods`` with a default value of 1. A ``FutureWarning`` is raised if the
   old argument ``lags`` is used by name. (:issue:`6910`)
 
+- The ``order`` keyword argument of :func:`factorize` will be removed. (:issue:`6926`).
+
 Prior Version Deprecations/Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -420,6 +420,7 @@ Deprecations
   The old positional argument ``lags`` has been changed to a keyword argument
   ``periods`` with a default value of 1. A ``FutureWarning`` is raised if the
   old argument ``lags`` is used by name. (:issue:`6910`)
+- The ``order`` keyword argument of :func:`factorize` will be removed. (:issue:`6926`).
 
 .. _whatsnew_0140.enhancements:
 

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -11,6 +11,7 @@ import pandas.algos as algos
 import pandas.hashtable as htable
 import pandas.compat as compat
 from pandas.compat import filter, string_types
+from pandas.util.decorators import deprecate_kwarg
 
 def match(to_match, values, na_sentinel=-1):
     """
@@ -104,7 +105,7 @@ def factorize(values, sort=False, order=None, na_sentinel=-1):
         Sequence
     sort : boolean, default False
         Sort by values
-    order :
+    order : deprecated
     na_sentinel: int, default -1
         Value to mark "not found"
 
@@ -115,6 +116,10 @@ def factorize(values, sort=False, order=None, na_sentinel=-1):
 
     note: an array of Periods will ignore sort as it returns an always sorted PeriodIndex
     """
+    if order is not None:
+        warn("order is deprecated."
+             "See https://github.com/pydata/pandas/issues/6926", FutureWarning)
+
     from pandas.tseries.period import PeriodIndex
     vals = np.asarray(values)
     is_datetime = com.is_datetime64_dtype(vals)

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -47,6 +47,12 @@ class TestMatch(tm.TestCase):
 class TestFactorize(tm.TestCase):
     _multiprocess_can_split_ = True
 
+    def test_warn(self):
+
+        s = Series([1, 2, 3])
+        with tm.assert_produces_warning(FutureWarning):
+            algos.factorize(s, order='A')
+
     def test_basic(self):
 
         labels, uniques = algos.factorize(['a', 'b', 'b', 'a',


### PR DESCRIPTION
Closes https://github.com/pydata/pandas/issues/6926

`order` wasn't being used at all.

I couldn't use the deprecate_kwarg decorator since the kwarg is being removed, not changed.
