### PR TITLE
BUG: pass bins arg in hist_frame

### DIFF
--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -127,6 +127,12 @@ class TestSeriesPlots(tm.TestCase):
             self.ts.hist(by=self.ts.index, figure=fig)
 
     @slow
+    def test_hist_bins(self):
+        df = DataFrame(np.random.randn(10, 2))
+        ax = df.hist(bins=2)[0][0]
+        self.assertEqual(len(ax.patches), 2)
+
+    @slow
     def test_hist_layout(self):
         n = 10
         gender = tm.choice(['Male', 'Female'], size=n)

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -2342,7 +2342,7 @@ def hist_frame(data, column=None, by=None, grid=True, xlabelsize=None,
         ax = axes[i / cols, i % cols]
         ax.xaxis.set_visible(True)
         ax.yaxis.set_visible(True)
-        ax.hist(data[col].dropna().values, **kwds)
+        ax.hist(data[col].dropna().values, bins=bins, **kwds)
         ax.set_title(col)
         ax.grid(grid)
 


### PR DESCRIPTION
Came up in the comments at https://github.com/pydata/pandas/pull/6850#issuecomment-41119013

Missed passing the `bins` kwarg to a call to matplotlib's hist.
