### PR TITLE
pandas.io.gbq Version 2

### DIFF
--- a/ci/requirements-2.6.txt
+++ b/ci/requirements-2.6.txt
@@ -14,6 +14,3 @@ xlwt==0.7.5
 openpyxl==2.0.3
 xlsxwriter==0.4.6
 xlrd==0.9.2
-httplib2==0.8
-python-gflags==2.0
-google-api-python-client==1.2

--- a/ci/requirements-2.6.txt
+++ b/ci/requirements-2.6.txt
@@ -4,7 +4,6 @@ python-dateutil==1.5
 pytz==2013b
 http://www.crummy.com/software/BeautifulSoup/bs4/download/4.2/beautifulsoup4-4.2.0.tar.gz
 html5lib==1.0b2
-bigquery==2.0.17
 numexpr==1.4.2
 sqlalchemy==0.7.1
 pymysql==0.6.0
@@ -15,3 +14,6 @@ xlwt==0.7.5
 openpyxl==2.0.3
 xlsxwriter==0.4.6
 xlrd==0.9.2
+httplib2==0.8
+python-gflags==2.0
+google-api-python-client==1.2

--- a/ci/requirements-2.7.txt
+++ b/ci/requirements-2.7.txt
@@ -19,5 +19,7 @@ lxml==3.2.1
 scipy==0.13.3
 beautifulsoup4==4.2.1
 statsmodels==0.5.0
-bigquery==2.0.17
 boto==2.26.1
+httplib2==0.8
+python-gflags==2.0
+google-api-python-client==1.2

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -112,7 +112,9 @@ Optional Dependencies
     :func:`~pandas.io.clipboard.read_clipboard`. Most package managers on Linux
     distributions will have xclip and/or xsel immediately available for
     installation.
-  * `Google bq Command Line Tool <https://developers.google.com/bigquery/bq-command-line-tool/>`__
+  * Google's `python-gflags` and `google-api-python-client`
+    * Needed for :mod:`~pandas.io.gbq`
+  * `httplib2`
     * Needed for :mod:`~pandas.io.gbq`
   * One of the following combinations of libraries is needed to use the
     top-level :func:`~pandas.io.html.read_html` function:

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -3373,83 +3373,79 @@ Google BigQuery (Experimental)
 The :mod:`pandas.io.gbq` module provides a wrapper for Google's BigQuery
 analytics web service to simplify retrieving results from BigQuery tables
 using SQL-like queries. Result sets are parsed into a pandas
-DataFrame with a shape derived from the source table. Additionally,
-DataFrames can be uploaded into BigQuery datasets as tables
-if the source datatypes are compatible with BigQuery ones.
+DataFrame with a shape and data types derived from the source table. 
+Additionally, DataFrames can be appended to existing BigQuery tables if 
+the destination table is the same shape as the DataFrame.
 
 For specifics on the service itself, see `here <https://developers.google.com/bigquery/>`__
 
-As an example, suppose you want to load all data from an existing table
-: `test_dataset.test_table`
-into BigQuery and pull it into a DataFrame.
+As an example, suppose you want to load all data from an existing BigQuery 
+table : `test_dataset.test_table` into a DataFrame using the :func:`~pandas.io.read_gbq` 
+function.
 
 .. code-block:: python
-
-   from pandas.io import gbq
-
    # Insert your BigQuery Project ID Here
-   # Can be found in the web console, or
-   # using the command line tool `bq ls`
+   # Can be found in the Google web console
    projectid = "xxxxxxxx"
 
-   data_frame = gbq.read_gbq('SELECT * FROM test_dataset.test_table', project_id = projectid)
+   data_frame = pd.read_gbq('SELECT * FROM test_dataset.test_table', project_id = projectid)
 
-The user will then be authenticated by the `bq` command line client -
-this usually involves the default browser opening to a login page,
-though the process can be done entirely from command line if necessary.
-Datasets and additional parameters can be either configured with `bq`,
-passed in as options to `read_gbq`, or set using Google's gflags (this
-is not officially supported by this module, though care was taken
-to ensure that they should be followed regardless of how you call the
-method).
+You will then be authenticated to the specified BigQuery account
+via Google's Oauth2 mechanism. In general, this is as simple as following the
+prompts in a browser window which will be opened for you. Should the browser not
+be available, or fail to launch, a code will be provided to complete the process
+manually.  Additional information on the authentication mechanism can be found
+`here <https://developers.google.com/accounts/docs/OAuth2#clientside/>`__
 
-Additionally, you can define which column to use as an index as well as a preferred column order as follows:
+You can define which column from BigQuery to use as an index in the
+destination DataFrame as well as a preferred column order as follows:
 
 .. code-block:: python
 
-   data_frame = gbq.read_gbq('SELECT * FROM test_dataset.test_table',
+   data_frame = pd.read_gbq('SELECT * FROM test_dataset.test_table',
                              index_col='index_column_name',
-                             col_order='[col1, col2, col3,...]', project_id = projectid)
+                             col_order=['col1', 'col2', 'col3'], project_id = projectid)
 
-Finally, if you would like to create a BigQuery table, `my_dataset.my_table`, from the rows of DataFrame, `df`:
+Finally, you can append data to a BigQuery table from a pandas DataFrame
+using the :func:`~pandas.io.to_gbq` function. This function uses the
+Google streaming API which requires that your destination table exists in
+BigQuery. Given the BigQuery table already exists, your DataFrame should
+match the destination table in column order, structure, and data types. 
+DataFrame indexes are not supported. By default, rows are streamed to 
+BigQuery in chunks of 10,000 rows, but you can pass other chuck values 
+via the ``chunksize`` argument. You can also see the progess of your 
+post via the ``verbose`` flag which defaults to ``True``. The http 
+response code of Google BigQuery can be successful (200) even if the 
+append failed. For this reason, if there is a failure to append to the 
+table, the complete error response from BigQuery is returned which 
+can be quite long given it provides a status for each row. You may want
+to start with smaller chuncks to test that the size and types of your
+dataframe match your destination table to make debugging simpler.
 
 .. code-block:: python
 
    df = pandas.DataFrame({'string_col_name' : ['hello'],
          'integer_col_name' : [1],
          'boolean_col_name' : [True]})
-   schema = ['STRING', 'INTEGER', 'BOOLEAN']
-   data_frame = gbq.to_gbq(df, 'my_dataset.my_table',
-                           if_exists='fail', schema = schema, project_id = projectid)
+   df.to_gbq('my_dataset.my_table', project_id = projectid)
 
-To add more rows to this, simply:
+The BigQuery SQL query language has some oddities, see `here <https://developers.google.com/bigquery/query-reference>`__
 
-.. code-block:: python
+While BigQuery uses SQL-like syntax, it has some important differences
+from traditional databases both in functionality, API limitations (size and
+qunatity of queries or uploads), and how Google charges for use of the service. 
+You should refer to Google documentation often as the service seems to
+be changing and evolving. BiqQuery is best for analyzing large sets of 
+data quickly, but it is not a direct replacement for a transactional database.
 
-   df2 = pandas.DataFrame({'string_col_name' : ['hello2'],
-         'integer_col_name' : [2],
-         'boolean_col_name' : [False]})
-   data_frame = gbq.to_gbq(df2, 'my_dataset.my_table', if_exists='append', project_id = projectid)
-
-.. note::
-
-   A default project id can be set using the command line:
-   `bq init`.
-
-   There is a hard cap on BigQuery result sets, at 128MB compressed. Also, the BigQuery SQL query language has some oddities,
-   see `here <https://developers.google.com/bigquery/query-reference>`__
-
-   You can access the management console to determine project id's by:
-   <https://code.google.com/apis/console/b/0/?noredirect>
+You can access the management console to determine project id's by:
+<https://code.google.com/apis/console/b/0/?noredirect>
 
 .. warning::
 
-   To use this module, you will need a BigQuery account. See
-   <https://cloud.google.com/products/big-query> for details.
-
-   As of 1/28/14, a known bug is present that could possibly cause data duplication in the resultant dataframe. A fix is imminent,
-   but any client changes will not make it into 0.13.1. See:
-   http://stackoverflow.com/questions/20984592/bigquery-results-not-including-page-token/21009144?noredirect=1#comment32090677_21009144
+   To use this module, you will need a valid BigQuery account. See
+   <https://cloud.google.com/products/big-query> for details on the
+   service.
 
 .. _io.stata:
 

--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -154,14 +154,11 @@ Performance
 Experimental
 ~~~~~~~~~~~~
 
-``pandas.io.data.Options`` has gained a ``get_all_data method``, and now consistently returns a multi-indexed ``DataFrame`` (:issue:`5602`). See :ref:`the docs<remote_data.yahoo_options>`
-
-  .. ipython:: python
-
-     from pandas.io.data import Options
-     aapl = Options('aapl', 'yahoo')
-     data = aapl.get_all_data()
-     data.iloc[0:5, 0:5]
+- ``io.gbq.read_gbq`` and ``io.gbq.to_gbq`` were refactored to remove the
+  dependency on the Google ``bq.py`` command line client. This submodule 
+  now uses ``httplib2`` and the Google ``apiclient`` and ``oauth2client`` API client 
+  libraries which should be more stable and, therefore, reliable than 
+  ``bq.py`` (:issue:`6937`).  
 
 .. _whatsnew_0141.bug_fixes:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -669,47 +669,43 @@ class DataFrame(NDFrame):
         else:  # pragma: no cover
             raise ValueError("outtype %s not understood" % outtype)
 
-    def to_gbq(self, destination_table, schema=None, col_order=None,
-               if_exists='fail', **kwargs):
+    def to_gbq(self, destination_table, project_id=None, chunksize=10000,
+               verbose=True, reauth=False):
         """Write a DataFrame to a Google BigQuery table.
 
-        If the table exists, the DataFrame will be appended. If not, a new
-        table will be created, in which case the schema will have to be
-        specified. By default, rows will be written in the order they appear
-        in the DataFrame, though the user may specify an alternative order.
+        THIS IS AN EXPERIMENTAL LIBRARY
+
+        If the table exists, the dataframe will be written to the table using
+        the defined table schema and column types. For simplicity, this method
+        uses the Google BigQuery streaming API. The to_gbq method chunks data
+        into a default chunk size of 10,000. Failures return the complete error
+        response which can be quite long depending on the size of the insert. 
+        There are several important limitations of the Google streaming API 
+        which are detailed at:
+        https://developers.google.com/bigquery/streaming-data-into-bigquery.
 
         Parameters
-        ---------------
+        ----------
+        dataframe : DataFrame
+            DataFrame to be written
         destination_table : string
-             name of table to be written, in the form 'dataset.tablename'
-        schema : sequence (optional)
-             list of column types in order for data to be inserted, e.g.
-             ['INTEGER', 'TIMESTAMP', 'BOOLEAN']
-        col_order : sequence (optional)
-             order which columns are to be inserted, e.g. ['primary_key',
-             'birthday', 'username']
-        if_exists : {'fail', 'replace', 'append'} (optional)
-            - fail: If table exists, do nothing.
-            - replace: If table exists, drop it, recreate it, and insert data.
-            - append: If table exists, insert data. Create if does not exist.
-        kwargs are passed to the Client constructor
+            Name of table to be written, in the form 'dataset.tablename'
+        project_id : str
+            Google BigQuery Account project ID.
+        chunksize : int (default 10000)
+            Number of rows to be inserted in each chunk from the dataframe.
+        verbose : boolean (default True)
+            Show percentage complete
+        reauth : boolean (default False)
+            Force Google BigQuery to reauthenticate the user. This is useful
+            if multiple accounts are used.
 
-        Raises
-        ------
-        SchemaMissing :
-            Raised if the 'if_exists' parameter is set to 'replace', but no
-            schema is specified
-        TableExists :
-            Raised if the specified 'destination_table' exists but the
-            'if_exists' parameter is set to 'fail' (the default)
-        InvalidSchema :
-            Raised if the 'schema' parameter does not match the provided
-            DataFrame
         """
 
         from pandas.io import gbq
-        return gbq.to_gbq(self, destination_table, schema=None, col_order=None,
-                          if_exists='fail', **kwargs)
+        return gbq.to_gbq(self, destination_table, project_id=project_id,
+                          chunksize=chunksize, verbose=verbose,
+                          reauth=reauth)
 
     @classmethod
     def from_records(cls, data, index=None, exclude=None, columns=None,

--- a/pandas/io/tests/test_gbq.py
+++ b/pandas/io/tests/test_gbq.py
@@ -1,474 +1,290 @@
 import ast
+import datetime
+import json
 import nose
 import os
+import pytz
 import shutil
 import subprocess
+import sys
+import platform
+from time import sleep
 
 import numpy as np
 
+from pandas import NaT
+from pandas.compat import u
+from pandas.core.frame import DataFrame
 import pandas.io.gbq as gbq
 import pandas.util.testing as tm
 
-from pandas.core.frame import DataFrame
-from pandas.util.testing import with_connectivity_check
-from pandas.compat import u
-from pandas import NaT
+PROJECT_ID = None
 
+VERSION = platform.python_version()
 
-try:
-    import bq
-    import bigquery_client
-    import gflags as flags
-except ImportError:
-    raise nose.SkipTest
+def missing_bq():
+    try:
+        subprocess.call('bq')
+        return False
+    except OSError:
+        return True
 
-####################################################################################
-# Fake Google BigQuery Client
+def test_requirements():
+    try:
+        gbq._test_imports()
+    except (ImportError, NotImplementedError) as import_exception:
+        raise nose.SkipTest(import_exception)
 
-class FakeClient:
-    def __init__(self):
-        self.apiclient = FakeApiClient()
-    def GetTableSchema(self,table_dict):
-        retval =  {'fields': [
-                    {'type': 'STRING', 'name': 'corpus', 'mode': 'NULLABLE'},
-                    {'type': 'INTEGER', 'name': 'corpus_date', 'mode': 'NULLABLE'},
-                    {'type': 'STRING', 'name': 'word', 'mode': 'NULLABLE'},
-                    {'type': 'INTEGER', 'name': 'word_count', 'mode': 'NULLABLE'}
-                  ]}
-        return retval
-
-# Fake Google BigQuery API Client
-class FakeApiClient:
-    def __init__(self):
-        self._fakejobs = FakeJobs()
-
-
-    def jobs(self):
-        return self._fakejobs
-
-class FakeJobs:
-    def __init__(self):
-        self._fakequeryresults = FakeResults()
-
-    def getQueryResults(self, job_id=None, project_id=None,
-                        max_results=None, timeout_ms=None, **kwargs):
-        return self._fakequeryresults
-
-class FakeResults:
-    def execute(self):
-        return {'rows': [  {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'brave'}, {'v': '3'}]},
-                            {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'attended'}, {'v': '1'}]},
-                            {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'treason'}, {'v': '1'}]},
-                            {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'islanders'}, {'v': '1'}]},
-                            {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'heed'}, {'v': '3'}]},
-                            {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'alehouse'}, {'v': '1'}]},
-                            {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'corrigible'}, {'v': '1'}]},
-                            {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'brawl'}, {'v': '2'}]},
-                            {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': "'"}, {'v': '17'}]},
-                            {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'troubled'}, {'v': '1'}]}
-                        ],
-                'kind': 'bigquery#tableDataList',
-                'etag': '"4PTsVxg68bQkQs1RJ1Ndewqkgg4/hoRHzb4qfhJAIa2mEewC-jhs9Bg"',
-                'totalRows': '10',
-                'jobComplete' : True}
-
-####################################################################################
-
-class TestGbq(tm.TestCase):
+class TestGBQConnectorIntegration(tm.TestCase):
     def setUp(self):
-        with open(self.fake_job_path, 'r') as fin:
-            self.fake_job = ast.literal_eval(fin.read())
+        test_requirements()
 
-        self.test_data_small = [{'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'brave'}, {'v': '3'}]},
-                {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'attended'}, {'v': '1'}]},
-                {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'treason'}, {'v': '1'}]},
-                {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'islanders'}, {'v': '1'}]},
-                {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'heed'}, {'v': '3'}]},
-                {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'alehouse'}, {'v': '1'}]},
-                {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'corrigible'}, {'v': '1'}]},
-                {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'brawl'}, {'v': '2'}]},
-                {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': "'"}, {'v': '17'}]},
-                {'f': [{'v': 'othello'}, {'v': '1603'}, {'v': 'troubled'},
-                {'v': '1'}]}]
+        if not PROJECT_ID:
+            raise nose.SkipTest("Cannot run integration tests without a project id")
+        
+        self.sut = gbq.GbqConnector(PROJECT_ID)
 
-        self.correct_data_small = np.array(
-            [('othello', 1603, 'brave', 3),
-             ('othello', 1603, 'attended', 1),
-             ('othello', 1603, 'treason', 1),
-             ('othello', 1603, 'islanders', 1),
-             ('othello', 1603, 'heed', 3),
-             ('othello', 1603, 'alehouse', 1),
-             ('othello', 1603, 'corrigible', 1),
-             ('othello', 1603, 'brawl', 2),
-             ('othello', 1603, "'", 17),
-             ('othello', 1603, 'troubled', 1)
-            ],
-            dtype=[('corpus', 'S16'),
-                   ('corpus_date', '<i8'),
-                   ('word', 'S16'),
-                   ('word_count', '<i8')]
-        )
+    def test_should_be_able_to_make_a_connector(self):
+        self.assertTrue(self.sut is not None, 'Could not create a GbqConnector')
 
-        self.correct_test_datatype = DataFrame(
-            {'VALID_STRING' : ['PI'],
-             'EMPTY_STRING' :  [""],
-             'NULL_STRING' : [None],
-             'VALID_INTEGER' : [3],
-             'NULL_INTEGER' : [np.nan],
-             'VALID_FLOAT' : [3.141592653589793],
-             'NULL_FLOAT' : [np.nan],
-             'UNIX_EPOCH' : [np.datetime64('1970-01-01T00:00:00.000000Z')],
-             'VALID_TIMESTAMP' : [np.datetime64('2004-09-15T05:00:00.000000Z')],
-             'NULL_TIMESTAMP' :[NaT],
-             'TRUE_BOOLEAN' : [True],
-             'FALSE_BOOLEAN' : [False],
-             'NULL_BOOLEAN' : [None]
-            }
-        )[['VALID_STRING',
-          'EMPTY_STRING',
-          'NULL_STRING',
-          'VALID_INTEGER',
-          'NULL_INTEGER',
-          'VALID_FLOAT',
-          'NULL_FLOAT',
-          'UNIX_EPOCH',
-          'VALID_TIMESTAMP',
-          'NULL_TIMESTAMP',
-          'TRUE_BOOLEAN',
-          'FALSE_BOOLEAN',
-          'NULL_BOOLEAN']]
+    def test_should_be_able_to_get_valid_credentials(self):
+        credentials = self.sut.get_credentials()
+        self.assertFalse(credentials.invalid, 'Returned credentials invalid')
 
-    @classmethod
-    def setUpClass(cls):
-        # Integration tests require a valid bigquery token
-        # be present in the user's home directory. This
-        # can be generated with 'bq init' in the command line
-        super(TestGbq, cls).setUpClass()
-        cls.dirpath = tm.get_data_path()
-        home = os.path.expanduser("~")
-        cls.bq_token = os.path.join(home, '.bigquery.v2.token')
-        cls.fake_job_path = os.path.join(cls.dirpath, 'gbq_fake_job.txt')
+    def test_should_be_able_to_get_a_bigquery_service(self):
+        credentials = self.sut.get_credentials()
+        bigquery_service = self.sut.get_service(credentials)
+        self.assertTrue(bigquery_service is not None, 'No service returned')
 
-        # If we're using a valid token, make a test dataset
-        # Note, dataset functionality is beyond the scope
-        # of the module under test, so we rely on the command
-        # line utility for this.
-        if os.path.exists(cls.bq_token):
-            subprocess.call(['bq','mk', '-d', 'pandas_testing_dataset'])
+    def test_should_be_able_to_get_schema_from_query(self):
+        schema, pages = self.sut.run_query('SELECT 1')
+        self.assertTrue(schema is not None)
 
-    @classmethod
-    def tearDownClass(cls):
-        super(TestGbq, cls).tearDownClass()
+    def test_should_be_able_to_get_results_from_query(self):
+        schema, pages = self.sut.run_query('SELECT 1')
+        self.assertTrue(pages is not None)
 
-        # If we're using a valid token, remove the test dataset
-        # created.
-        if os.path.exists(cls.bq_token):
-            subprocess.call(['bq', 'rm', '-r', '-f', '-d', 'pandas_testing_dataset'])
+class TestReadGBQUnitTests(tm.TestCase):
+    def setUp(self):
+        test_requirements()
 
-    @with_connectivity_check
-    def test_valid_authentication(self):
-        # If the user has a token file, they should recieve a client from gbq._authenticate
-        if not os.path.exists(self.bq_token):
-            raise nose.SkipTest('Skipped because authentication information is not available.')
+    def test_should_return_bigquery_integers_as_python_floats(self):
+        result = gbq._parse_entry(1, 'INTEGER')
+        tm.assert_equal(result, float(1))
 
-        self.assertTrue(gbq._authenticate is not None, 'Authentication To GBQ Failed')
+    def test_should_return_bigquery_floats_as_python_floats(self):
+        result = gbq._parse_entry(1, 'FLOAT')
+        tm.assert_equal(result, float(1))
 
-    @with_connectivity_check
-    def test_malformed_query(self):
-        # If the user has a connection file, performing an invalid query should raise an error
-        if not os.path.exists(self.bq_token):
-            raise nose.SkipTest('Skipped because authentication information is not available.')
-        else:
-            self.assertRaises(bigquery_client.BigqueryInvalidQueryError,
-                              gbq.read_gbq, "SELCET * FORM [publicdata:samples.shakespeare]")
+    def test_should_return_bigquery_timestamps_as_numpy_datetime(self):
+        result = gbq._parse_entry('0e9', 'TIMESTAMP')
+        tm.assert_equal(result, np.datetime64('1970-01-01T00:00:00Z'))
 
-    def test_type_conversion(self):
-        # All BigQuery Types should be cast into appropriate numpy types
-        sample_input = [('1.095292800E9', 'TIMESTAMP'),
-                 ('false', 'BOOLEAN'),
-                 ('2', 'INTEGER'),
-                 ('3.14159', 'FLOAT'),
-                 ('Hello World', 'STRING')]
-        actual_output = [gbq._parse_entry(result[0],result[1]) for result in sample_input]
-        sample_output = [np.datetime64('2004-09-16T00:00:00.000000Z'),
-                  np.bool(False),
-                  np.int('2'),
-                  np.float('3.14159'),
-                  u('Hello World')]
-        self.assertEqual(actual_output, sample_output, 'A format conversion failed')
+    def test_should_return_bigquery_booleans_as_python_booleans(self):
+        result = gbq._parse_entry('false', 'BOOLEAN')
+        tm.assert_equal(result, False)
 
-    @with_connectivity_check
-    def test_unicode_string_conversion(self):
-        # Strings from BigQuery Should be converted to UTF-8 properly
+    def test_should_return_bigquery_strings_as_python_strings(self):
+        result = gbq._parse_entry('STRING', 'STRING')
+        tm.assert_equal(result, 'STRING')
 
-        if not os.path.exists(self.bq_token):
-            raise nose.SkipTest('Skipped because authentication information is not available.')
+    def test_to_gbq_should_fail_if_invalid_table_name_passed(self):
+        with tm.assertRaises(gbq.NotFoundException):
+            gbq.to_gbq(DataFrame(), 'invalid_table_name', project_id="1234")
 
+    def test_to_gbq_with_no_project_id_given_should_fail(self):
+        with tm.assertRaises(TypeError):
+            gbq.to_gbq(DataFrame(), 'dataset.tablename')
+
+    def test_read_gbq_with_no_project_id_given_should_fail(self):
+        with tm.assertRaises(TypeError):
+            gbq.read_gbq('SELECT "1" as NUMBER_1')
+
+    def test_that_parse_data_works_properly(self):
+        test_schema = {'fields': [{'mode': 'NULLABLE',
+                  'name': 'VALID_STRING',
+                  'type': 'STRING'}]}
+        test_page = [{'f': [{'v': 'PI'}]}]
+
+        test_output = gbq._parse_data(test_schema, test_page)
+        correct_output = DataFrame({'VALID_STRING' : ['PI']})
+        tm.assert_frame_equal(test_output, correct_output)
+
+class TestReadGBQIntegration(tm.TestCase):
+    def setUp(self):
+        test_requirements()
+
+        if not PROJECT_ID:
+            raise nose.SkipTest("Cannot run integration tests without a project id")
+
+    def test_should_properly_handle_valid_strings(self):
+        query = 'SELECT "PI" as VALID_STRING'
+        df = gbq.read_gbq(query, project_id=PROJECT_ID)
+        tm.assert_frame_equal(df, DataFrame({'VALID_STRING' : ['PI']}))
+
+    def test_should_properly_handle_empty_strings(self):
+        query = 'SELECT "" as EMPTY_STRING'
+        df = gbq.read_gbq(query, project_id=PROJECT_ID)
+        tm.assert_frame_equal(df, DataFrame({'EMPTY_STRING' : [""]}))
+
+    def test_should_properly_handle_null_strings(self):
+        query = 'SELECT STRING(NULL) as NULL_STRING'
+        df = gbq.read_gbq(query, project_id=PROJECT_ID)
+        tm.assert_frame_equal(df, DataFrame({'NULL_STRING' : [None]}))
+
+    def test_should_properly_handle_valid_integers(self):
+        query = 'SELECT INTEGER(3) as VALID_INTEGER'
+        df = gbq.read_gbq(query, project_id=PROJECT_ID)
+        tm.assert_frame_equal(df, DataFrame({'VALID_INTEGER' : [3]}))
+
+    def test_should_properly_handle_null_integers(self):
+        query = 'SELECT INTEGER(NULL) as NULL_INTEGER'
+        df = gbq.read_gbq(query, project_id=PROJECT_ID)
+        tm.assert_frame_equal(df, DataFrame({'NULL_INTEGER' : [np.nan]}))
+
+    def test_should_properly_handle_valid_floats(self):
+        query = 'SELECT PI() as VALID_FLOAT'
+        df = gbq.read_gbq(query, project_id=PROJECT_ID)
+        tm.assert_frame_equal(df, DataFrame({'VALID_FLOAT' : [3.141592653589793]}))
+
+    def test_should_properly_handle_null_floats(self):
+        query = 'SELECT FLOAT(NULL) as NULL_FLOAT'
+        df = gbq.read_gbq(query, project_id=PROJECT_ID)
+        tm.assert_frame_equal(df, DataFrame({'NULL_FLOAT' : [np.nan]}))
+
+    def test_should_properly_handle_timestamp_unix_epoch(self):
+        query = 'SELECT TIMESTAMP("1970-01-01 00:00:00") as UNIX_EPOCH'
+        df = gbq.read_gbq(query, project_id=PROJECT_ID)
+        tm.assert_frame_equal(df, DataFrame({'UNIX_EPOCH' : [np.datetime64('1970-01-01T00:00:00.000000Z')]}))
+
+    def test_should_properly_handle_arbitrary_timestamp(self):
+        query = 'SELECT TIMESTAMP("2004-09-15 05:00:00") as VALID_TIMESTAMP'
+        df = gbq.read_gbq(query, project_id=PROJECT_ID)
+        tm.assert_frame_equal(df, DataFrame({'VALID_TIMESTAMP' : [np.datetime64('2004-09-15T05:00:00.000000Z')]}))
+
+    def test_should_properly_handle_null_timestamp(self):
+        query = 'SELECT TIMESTAMP(NULL) as NULL_TIMESTAMP'
+        df = gbq.read_gbq(query, project_id=PROJECT_ID)
+        tm.assert_frame_equal(df, DataFrame({'NULL_TIMESTAMP' :[NaT]}))
+
+    def test_should_properly_handle_true_boolean(self):
+        query = 'SELECT BOOLEAN(TRUE) as TRUE_BOOLEAN'
+        df = gbq.read_gbq(query, project_id=PROJECT_ID)
+        tm.assert_frame_equal(df, DataFrame({'TRUE_BOOLEAN' : [True]}))
+
+    def test_should_properly_handle_false_boolean(self):
+        query = 'SELECT BOOLEAN(FALSE) as FALSE_BOOLEAN'
+        df = gbq.read_gbq(query, project_id=PROJECT_ID)
+        tm.assert_frame_equal(df, DataFrame({'FALSE_BOOLEAN' : [False]}))
+
+    def test_should_properly_handle_null_boolean(self):
+        query = 'SELECT BOOLEAN(NULL) as NULL_BOOLEAN'
+        df = gbq.read_gbq(query, project_id=PROJECT_ID)
+        tm.assert_frame_equal(df, DataFrame({'NULL_BOOLEAN' : [None]}))
+
+    def test_unicode_string_conversion_and_normalization(self):
         correct_test_datatype = DataFrame(
             {'UNICODE_STRING' : [u("\xe9\xfc")]}
         )
 
-        query = """SELECT '\xc3\xa9\xc3\xbc' as UNICODE_STRING"""
+        query = 'SELECT "\xc3\xa9\xc3\xbc" as UNICODE_STRING'
 
-        client = gbq._authenticate()
-        a = gbq.read_gbq(query)
-        tm.assert_frame_equal(a, correct_test_datatype)
-
-
-
-    def test_data_small(self):
-        # Parsing a fixed page of data should return the proper fixed np.array()
-        result_frame = gbq._parse_page(self.test_data_small,
-                                        ['corpus','corpus_date','word','word_count'],
-                                        ['STRING','INTEGER','STRING','INTEGER'],
-                                        [object,np.dtype(int),object,np.dtype(int)]
-                                      )
-        tm.assert_frame_equal(DataFrame(result_frame), DataFrame(self.correct_data_small),
-                        'An element in the result DataFrame didn\'t match the sample set')
+        df = gbq.read_gbq(query, project_id=PROJECT_ID)
+        tm.assert_frame_equal(df, correct_test_datatype)
 
     def test_index_column(self):
-        # A user should be able to specify an index column for return
-        result_frame = gbq._parse_data(FakeClient(), self.fake_job, index_col='word')
-        correct_frame = DataFrame(self.correct_data_small)
-        correct_frame.set_index('word', inplace=True)
-        self.assertTrue(result_frame.index.name == correct_frame.index.name)
+        query = "SELECT 'a' as STRING_1, 'b' as STRING_2"
+        result_frame = gbq.read_gbq(query, project_id=PROJECT_ID, index_col="STRING_1")
+        correct_frame = DataFrame({'STRING_1' : ['a'], 'STRING_2' : ['b']}).set_index("STRING_1")
+        tm.assert_equal(result_frame.index.name, correct_frame.index.name)
 
     def test_column_order(self):
-        # A User should be able to specify the order in which columns are returned in the dataframe
-        col_order = ['corpus_date', 'word_count', 'corpus', 'word']
-        result_frame = gbq._parse_data(FakeClient(), self.fake_job, col_order=col_order)
-        tm.assert_index_equal(result_frame.columns, DataFrame(self.correct_data_small)[col_order].columns)
+        query = "SELECT 'a' as STRING_1, 'b' as STRING_2, 'c' as STRING_3"
+        col_order = ['STRING_3', 'STRING_1', 'STRING_2']
+        result_frame = gbq.read_gbq(query, project_id=PROJECT_ID, col_order=col_order)
+        correct_frame = DataFrame({'STRING_1' : ['a'], 'STRING_2' : ['b'], 'STRING_3' : ['c']})[col_order]
+        tm.assert_frame_equal(result_frame, correct_frame)
 
     def test_column_order_plus_index(self):
-        # A User should be able to specify an index and the order of THE REMAINING columns.. they should be notified
-        # if they screw up
-        col_order = ['corpus_date', 'word', 'corpus']
-        result_frame = gbq._parse_data(FakeClient(), self.fake_job, index_col='word_count', col_order=col_order)
-        correct_frame_small = DataFrame(self.correct_data_small)
-        correct_frame_small.set_index('word_count',inplace=True)
-        correct_frame_small = DataFrame(correct_frame_small)[col_order]
-        tm.assert_index_equal(result_frame.columns, correct_frame_small.columns)
+        query = "SELECT 'a' as STRING_1, 'b' as STRING_2, 'c' as STRING_3"
+        col_order = ['STRING_3', 'STRING_2']
+        result_frame = gbq.read_gbq(query, project_id=PROJECT_ID, index_col='STRING_1', col_order=col_order)
+        correct_frame = DataFrame({'STRING_1' : ['a'], 'STRING_2' : ['b'], 'STRING_3' : ['c']})
+        correct_frame.set_index('STRING_1', inplace=True)
+        correct_frame = correct_frame[col_order]
+        tm.assert_frame_equal(result_frame, correct_frame)
 
-    @with_connectivity_check
-    def test_download_dataset_larger_than_100k_rows(self):
+    def test_malformed_query(self):
+        with tm.assertRaises(gbq.InvalidQueryException):
+            gbq.read_gbq("SELCET * FORM [publicdata:samples.shakespeare]", project_id=PROJECT_ID)
+
+    def test_bad_project_id(self):
+        with tm.assertRaises(gbq.NotFoundException):
+            gbq.read_gbq("SELECT 1", project_id='001')
+
+    def test_bad_table_name(self):
+        with tm.assertRaises(gbq.NotFoundException):
+            gbq.read_gbq("SELECT * FROM [publicdata:samples.nope]", project_id=PROJECT_ID)
+
+    def test_download_dataset_larger_than_200k_rows(self):
         # Test for known BigQuery bug in datasets larger than 100k rows
         # http://stackoverflow.com/questions/19145587/bq-py-not-paging-results
-        if not os.path.exists(self.bq_token):
-            raise nose.SkipTest('Skipped because authentication information is not available.')
+        df = gbq.read_gbq("SELECT id FROM [publicdata:samples.wikipedia] GROUP EACH BY id ORDER BY id ASC LIMIT 200005", project_id=PROJECT_ID)
+        self.assertEqual(len(df.drop_duplicates()), 200005)
 
-        client = gbq._authenticate()
-        a = gbq.read_gbq("SELECT id, FROM [publicdata:samples.wikipedia] LIMIT 100005")
-        self.assertTrue(len(a) == 100005)
+class TestToGBQIntegration(tm.TestCase):
+    # This class requires bq.py to be installed for setup/teardown. 
+    # It will also need to be preconfigured with a default dataset,
+    # so, be sure to `bq init` in terminal before running.
 
-    @with_connectivity_check
-    def test_download_all_data_types(self):
-        # Test that all available data types from BigQuery (as of now)
-        # are handled properly
-        if not os.path.exists(self.bq_token):
-            raise nose.SkipTest('Skipped because authentication information is not available.')
+    def setUp(self):
+        test_requirements()
 
-        query = """SELECT "PI" as VALID_STRING,
-                   "" as EMPTY_STRING,
-                   STRING(NULL) as NULL_STRING,
-                   INTEGER(3) as VALID_INTEGER,
-                   INTEGER(NULL) as NULL_INTEGER,
-                   PI() as VALID_FLOAT,
-                   FLOAT(NULL) as NULL_FLOAT,
-                   TIMESTAMP("1970-01-01 00:00:00") as UNIX_EPOCH,
-                   TIMESTAMP("2004-09-15 05:00:00") as VALID_TIMESTAMP,
-                   TIMESTAMP(NULL) as NULL_TIMESTAMP,
-                   BOOLEAN(TRUE) as TRUE_BOOLEAN,
-                   BOOLEAN(FALSE) as FALSE_BOOLEAN,
-                   BOOLEAN(NULL) as NULL_BOOLEAN"""
+        if not PROJECT_ID:
+            raise nose.SkipTest("Cannot run integration tests without a project id")
+        if missing_bq():
+            raise nose.SkipTest("Cannot run to_gbq tests without bq command line client")
 
-        client = gbq._authenticate()
-        a = gbq.read_gbq(query, col_order = ['VALID_STRING',
-                                             'EMPTY_STRING',
-                                             'NULL_STRING',
-                                             'VALID_INTEGER',
-                                             'NULL_INTEGER',
-                                             'VALID_FLOAT',
-                                             'NULL_FLOAT',
-                                             'UNIX_EPOCH',
-                                             'VALID_TIMESTAMP',
-                                             'NULL_TIMESTAMP',
-                                             'TRUE_BOOLEAN',
-                                             'FALSE_BOOLEAN',
-                                             'NULL_BOOLEAN'])
+    @classmethod
+    def setUpClass(cls):
+        if PROJECT_ID and not missing_bq():
+            subprocess.call(['bq','mk','pydata_pandas_bq_testing'])
+            subprocess.call(['bq','mk','pydata_pandas_bq_testing.new_test','bools:BOOLEAN,flts:FLOAT,ints:INTEGER,strs:STRING,times:TIMESTAMP'])
 
-        tm.assert_frame_equal(a, self.correct_test_datatype)
+    def test_upload_data(self):
+        test_size = 1000001
+        #create df to test for all BQ datatypes except RECORD
+        bools = np.random.randint(2, size=(1,test_size)).astype(bool)
+        flts = np.random.randn(1,test_size)
+        ints = np.random.randint(1,10, size=(1,test_size))
+        strs = np.random.randint(1,10, size=(1,test_size)).astype(str)
+        times = [datetime.datetime.now(pytz.timezone('US/Arizona')) for t in xrange(test_size)]
+        df = DataFrame({'bools':bools[0], 'flts':flts[0], 'ints':ints[0], 'strs':strs[0], 'times':times[0]}, index=range(test_size))
+        gbq.to_gbq(df,"pydata_pandas_bq_testing.new_test", project_id=PROJECT_ID, chunksize=10000)
+        sleep(60) # <- Curses Google!!!
 
-    @with_connectivity_check
-    def test_table_exists(self):
-        # Given a table name in the format {dataset}.{tablename}, if a table exists,
-        # the GetTableReference should accurately indicate this.
-        # This could possibly change in future implementations of bq,
-        # but it is the simplest way to provide users with appropriate
-        # error messages regarding schemas.
-        if not os.path.exists(self.bq_token):
-            raise nose.SkipTest('Skipped because authentication information is not available.')
+        result = gbq.read_gbq("SELECT COUNT(*) as NUM_ROWS FROM pydata_pandas_bq_testing.new_test", project_id=PROJECT_ID)
+        self.assertEqual(result['NUM_ROWS'][0], test_size)
 
-        client = gbq._authenticate()
-        table_reference = client.GetTableReference("publicdata:samples.shakespeare")
-        self.assertTrue(client.TableExists(table_reference))
+    def test_google_upload_errors_should_raise_exception(self):
+        test_timestamp = datetime.datetime.now(pytz.timezone('US/Arizona'))
+        bad_df = DataFrame( {'bools': [False, False],
+                             'flts': [0.0,1.0],
+                             'ints': [0,'1'],
+                             'strs': ['a', 1],
+                             'times': [test_timestamp, test_timestamp]
+                             }, index=range(2))
+        with tm.assertRaises(gbq.UnknownGBQException):
+            gbq.to_gbq(bad_df, 'pydata_pandas_bq_testing.new_test', project_id = PROJECT_ID)
 
-    @with_connectivity_check
-    def test_table__not_exists(self):
-        # Test the inverse of `test_table_exists`
-        if not os.path.exists(self.bq_token):
-            raise nose.SkipTest('Skipped because authentication information is not available.')
 
-        client = gbq._authenticate()
-        table_reference = client.GetTableReference("publicdata:samples.does_not_exist")
-        self.assertFalse(client.TableExists(table_reference))
-
-    @with_connectivity_check
-    def test_upload_new_table_schema_error(self):
-        # Attempting to upload to a non-existent table without a schema should fail
-        if not os.path.exists(self.bq_token):
-            raise nose.SkipTest('Skipped because authentication information is not available.')
-
-        df = DataFrame(self.correct_data_small)
-        with self.assertRaises(gbq.SchemaMissing):
-            gbq.to_gbq(df, 'pandas_testing_dataset.test_database', schema=None, col_order=None, if_exists='fail')
-
-    @with_connectivity_check
-    def test_upload_replace_schema_error(self):
-        # Attempting to replace an existing table without specifying a schema should fail
-        if not os.path.exists(self.bq_token):
-            raise nose.SkipTest('Skipped because authentication information is not available.')
-
-        df = DataFrame(self.correct_data_small)
-        with self.assertRaises(gbq.SchemaMissing):
-            gbq.to_gbq(df, 'pandas_testing_dataset.test_database', schema=None, col_order=None, if_exists='replace')
-
-    @with_connectivity_check
-    def test_upload_public_data_error(self):
-        # Attempting to upload to a public, read-only, dataset should fail
-        if not os.path.exists(self.bq_token):
-            raise nose.SkipTest('Skipped because authentication information is not available.')
-
-        array = [['TESTING_GBQ', 999999999, 'hi', 0, True, 9999999999, '00.000.00.000', 1, 'hola',
-                 99999999, False, False, 1, 'Jedi', 11210]]
-        df = DataFrame(array)
-        with self.assertRaises(bigquery_client.BigqueryServiceError):
-            gbq.to_gbq(df, 'publicdata:samples.wikipedia', schema=None, col_order=None, if_exists='append')
-
-    @with_connectivity_check
-    def test_upload_new_table(self):
-        # Attempting to upload to a new table with valid data and a valid schema should succeed
-        if not os.path.exists(self.bq_token):
-            raise nose.SkipTest('Skipped because authentication information is not available.')
-
-        schema = ['STRING', 'INTEGER', 'STRING', 'INTEGER', 'BOOLEAN',
-                  'INTEGER', 'STRING', 'INTEGER',
-                  'STRING', 'INTEGER', 'BOOLEAN', 'BOOLEAN',
-                  'INTEGER', 'STRING', 'INTEGER']
-
-        array = [['TESTING_GBQ', 999999999, 'hi', 0, True, 9999999999, '00.000.00.000', 1, 'hola',
-                 99999999, False, False, 1, 'Jedi', 11210]]
-        df = DataFrame(array, columns=['title','id','language','wp_namespace','is_redirect','revision_id',
-                                       'contributor_ip','contributor_id','contributor_username','timestamp',
-                                       'is_minor','is_bot','reversion_id','comment','num_characters'])
-        gbq.to_gbq(df, 'pandas_testing_dataset.test_data2', schema=schema, col_order=None, if_exists='append')
-        a = gbq.read_gbq("SELECT * FROM pandas_testing_dataset.test_data2")
-        self.assertTrue((a == df).all().all())
-
-    @with_connectivity_check
-    def test_upload_bad_data_table(self):
-        # Attempting to upload data that does not match schema should fail
-        if not os.path.exists(self.bq_token):
-            raise nose.SkipTest('Skipped because authentication information is not available.')
-
-        schema = ['STRING', 'INTEGER', 'STRING', 'INTEGER', 'BOOLEAN',
-                  'INTEGER', 'STRING', 'INTEGER',
-                  'STRING', 'INTEGER', 'BOOLEAN', 'BOOLEAN',
-                  'INTEGER', 'STRING', 'INTEGER']
-
-        array = [['TESTING_GBQ\',', False, 'hi', 0, True, 'STRING IN INTEGER', '00.000.00.000', 1, 'hola',
-                 99999999, -100, 1000, 1, 'Jedi', 11210]]
-        df = DataFrame(array, columns=['title','id','language','wp_namespace','is_redirect','revision_id',
-                                       'contributor_ip','contributor_id','contributor_username','timestamp',
-                                       'is_minor','is_bot','reversion_id','comment','num_characters'])
-        with self.assertRaises(bigquery_client.BigqueryServiceError):
-            gbq.to_gbq(df, 'pandas_testing_dataset.test_data1', schema=schema, col_order=None, if_exists='append')
-
-    @with_connectivity_check
-    def test_invalid_column_name_schema(self):
-        # Specifying a schema that contains an invalid column name should fail
-        if not os.path.exists(self.bq_token):
-            raise nose.SkipTest('Skipped because authentication information is not available.')
-
-        schema = ['INCORRECT']
-        df = DataFrame([[1]],columns=['fake'])
-        with self.assertRaises(gbq.InvalidSchema):
-            gbq.to_gbq(df, 'pandas_testing_dataset.test_data', schema=schema, col_order=None, if_exists='append')
-
-    @with_connectivity_check
-    def test_invalid_number_of_columns_schema(self):
-        # Specifying a schema that does not have same shape as dataframe should fail
-        if not os.path.exists(self.bq_token):
-            raise nose.SkipTest('Skipped because authentication information is not available.')
-
-        schema = ['INTEGER']
-        df = DataFrame([[1, 'STRING']],columns=['fake','fake'])
-        with self.assertRaises(gbq.InvalidSchema):
-            gbq.to_gbq(df, 'pandas_testing_dataset.test_data4', schema=schema, col_order=None, if_exists='append')
-
-    @with_connectivity_check
-    def test_upload_fail_if_exists(self):
-        # Attempting to upload to a new table with valid data and a valid schema should succeed
-        if not os.path.exists(self.bq_token):
-            raise nose.SkipTest('Skipped because authentication information is not available.')
-
-        schema = ['STRING', 'INTEGER', 'STRING', 'INTEGER', 'BOOLEAN',
-                  'INTEGER', 'STRING', 'INTEGER',
-                  'STRING', 'INTEGER', 'BOOLEAN', 'BOOLEAN',
-                  'INTEGER', 'STRING', 'INTEGER']
-
-        array = [['TESTING_GBQ', 999999999, 'hi', 0, True, 9999999999, '00.000.00.000', 1, 'hola',
-                 99999999, False, False, 1, 'Jedi', 11210]]
-        df = DataFrame(array, columns=['title','id','language','wp_namespace','is_redirect','revision_id',
-                                       'contributor_ip','contributor_id','contributor_username','timestamp',
-                                       'is_minor','is_bot','reversion_id','comment','num_characters'])
-        gbq.to_gbq(df, 'pandas_testing_dataset.test_data3', schema=schema, col_order=None, if_exists='fail')
-
-        with self.assertRaises(gbq.TableExistsFail):
-            gbq.to_gbq(df, 'pandas_testing_dataset.test_data3', schema=schema, col_order=None, if_exists='fail')
-
-    @with_connectivity_check
-    def test_upload_replace(self):
-        # Attempting to overwrite an existing table with valid data and a valid schema should succeed
-        if not os.path.exists(self.bq_token):
-            raise nose.SkipTest('Skipped because authentication information is not available.')
-
-        schema = ['STRING', 'INTEGER', 'STRING', 'INTEGER', 'BOOLEAN',
-                  'INTEGER', 'STRING', 'INTEGER',
-                  'STRING', 'INTEGER', 'BOOLEAN', 'BOOLEAN',
-                  'INTEGER', 'STRING', 'INTEGER']
-
-        # Setup an existing table
-        array1 = [['', 1, '', 1, False, 1, '00.111.00.111', 1, 'hola',
-                 1, True, True, 1, 'Sith', 1]]
-        df1 = DataFrame(array1, columns=['title','id','language','wp_namespace','is_redirect','revision_id',
-                                       'contributor_ip','contributor_id','contributor_username','timestamp',
-                                       'is_minor','is_bot','reversion_id','comment','num_characters'])
-        gbq.to_gbq(df1, 'pandas_testing_dataset.test_data5', schema=schema, col_order=None, if_exists='fail')
-
-        array2 = [['TESTING_GBQ', 999999999, 'hi', 0, True, 9999999999, '00.000.00.000', 1, 'hola',
-                 99999999, False, False, 1, 'Jedi', 11210]]
-
-        # Overwrite the existing table with different data
-        df2 = DataFrame(array2, columns=['title','id','language','wp_namespace','is_redirect','revision_id',
-                                       'contributor_ip','contributor_id','contributor_username','timestamp',
-                                       'is_minor','is_bot','reversion_id','comment','num_characters'])
-        gbq.to_gbq(df2, 'pandas_testing_dataset.test_data5', schema=schema, col_order=None, if_exists='replace')
-
-        # Read the table and confirm the new data is all that is there
-        a = gbq.read_gbq("SELECT * FROM pandas_testing_dataset.test_data5")
-        self.assertTrue((a == df2).all().all())
-
+    @classmethod
+    def tearDownClass(cls):
+        if PROJECT_ID and not missing_bq():
+            subprocess.call(['bq','rm','-f','pydata_pandas_bq_testing.new_test'])
+            subprocess.call(['bq','rm','-f','pydata_pandas_bq_testing'])
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
                    exit=False)
+

--- a/pandas/util/print_versions.py
+++ b/pandas/util/print_versions.py
@@ -82,7 +82,7 @@ def show_versions(as_json=False):
         ("lxml", lambda mod: mod.etree.__version__),
         ("bs4", lambda mod: mod.__version__),
         ("html5lib", lambda mod: mod.__version__),
-        ("bq", lambda mod: mod._VersionNumber()),
+        ("httplib2", lambda mod: mod.__version__),
         ("apiclient", lambda mod: mod.__version__),
         ("rpy2", lambda mod: mod.__version__),
         ("sqlalchemy", lambda mod: mod.__version__),


### PR DESCRIPTION
closes #5840 (as new interface makes it obsolete)
closes #6096 

@jreback : We still have some documentation to work on, but we would like your initial thoughts on what we have so far. The key change for this version is the removal of bq.py as a dependency (except as a setup method for a test case). Instead, we rely entirely on the BigQuery python API. We also simplified to_gbq() significantly. Though it cost a few features, the code is much more manageable and less error prone (thanks Google!). Test cases are much more granular and run significantly faster. To use the test cases fully, a BigQuery project_id is still required, though there are some unittests offline. 
