### PR TITLE
REGR/API: accept TextFileReader in concat (GH6583)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -175,6 +175,7 @@ API Changes
 - Replace ``pandas.compat.scipy.scoreatpercentile`` with ``numpy.percentile`` (:issue:`6810`)
 - ``.quantile`` on a ``datetime[ns]`` series now returns ``Timestamp`` instead
   of ``np.datetime64`` objects (:issue:`6810`)
+- change ``AssertionError`` to ``TypeError`` for invalid types passed to ``concat`` (:issue:`6583`)
 
 Deprecations
 ~~~~~~~~~~~~
@@ -400,6 +401,7 @@ Bug Fixes
   `header` kwarg (:issue:`6186`)
 - Bug in `DataFrame.plot` and `Series.plot` legend behave inconsistently when plotting to the same axes repeatedly (:issue:`6678`)
 - Internal tests for patching ``__finalize__`` / bug in merge not finalizing (:issue:`6923`, :issue:`6927`)
+- accept ``TextFileReader`` in ``concat``, which was affecting a common user idiom (:issue:`6583`)
 
 pandas 0.13.1
 -------------

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -209,6 +209,8 @@ API changes
 - default sorting algorithm for ``Series.order`` is not ``quicksort``, to conform with ``Series.sort``
   (and numpy defaults)
 - add ``inplace`` keyword to ``Series.order/sort`` to make them inverses (:issue:`6859`)
+- accept ``TextFileReader`` in ``concat``, which was affecting a common user idiom (:issue:`6583`), this was a regression
+  from 0.13.1
 
 .. _whatsnew_0140.sql:
 

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -20,6 +20,7 @@ from pandas.util.decorators import cache_readonly, Appender, Substitution
 from pandas.core.common import (PandasError, ABCSeries,
                                 is_timedelta64_dtype, is_datetime64_dtype,
                                 is_integer_dtype, isnull)
+from pandas.io.parsers import TextFileReader
 
 import pandas.core.common as com
 
@@ -938,10 +939,10 @@ class _Concatenator(object):
     def __init__(self, objs, axis=0, join='outer', join_axes=None,
                  keys=None, levels=None, names=None,
                  ignore_index=False, verify_integrity=False):
-        if not isinstance(objs, (list,tuple,types.GeneratorType,dict)):
-            raise AssertionError('first argument must be a list-like of pandas '
-                                 'objects, you passed an object of type '
-                                 '"{0}"'.format(type(objs).__name__))
+        if not isinstance(objs, (list,tuple,types.GeneratorType,dict,TextFileReader)):
+            raise TypeError('first argument must be a list-like of pandas '
+                            'objects, you passed an object of type '
+                            '"{0}"'.format(type(objs).__name__))
 
         if join == 'outer':
             self.intersect = False

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -16,7 +16,7 @@ from pandas.util.testing import (assert_frame_equal, assert_series_equal,
                                  assert_almost_equal, rands,
                                  makeCustomDataframe as mkdf,
                                  assertRaisesRegexp)
-from pandas import isnull, DataFrame, Index, MultiIndex, Panel, Series, date_range, read_table
+from pandas import isnull, DataFrame, Index, MultiIndex, Panel, Series, date_range, read_table, read_csv
 import pandas.algos as algos
 import pandas.util.testing as tm
 
@@ -2048,10 +2048,26 @@ class TestConcatenate(tm.TestCase):
     def test_concat_invalid_first_argument(self):
         df1 = mkdf(10, 2)
         df2 = mkdf(10, 2)
-        self.assertRaises(AssertionError, concat, df1, df2)
+        self.assertRaises(TypeError, concat, df1, df2)
 
         # generator ok though
         concat(DataFrame(np.random.rand(5,5)) for _ in range(3))
+
+        # text reader ok
+        # GH6583
+        data = """index,A,B,C,D
+foo,2,3,4,5
+bar,7,8,9,10
+baz,12,13,14,15
+qux,12,13,14,15
+foo2,12,13,14,15
+bar2,12,13,14,15
+"""
+
+        reader = read_csv(StringIO(data), chunksize=1)
+        result = concat(reader, ignore_index=True)
+        expected = read_csv(StringIO(data))
+        assert_frame_equal(result,expected)
 
 class TestOrderedMerge(tm.TestCase):
 


### PR DESCRIPTION
closes #6583
- API: change AssertionError to TypeError for invalid types passed to concat 
- REGR: TextFileReader in concat, which was affecting a common user idiom 
