### PR TITLE
BUG: enabling subplots works unexpectedly

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -432,6 +432,8 @@ Bug Fixes
 - Bug in ``DataFrame.apply`` with functions that used *args or **kwargs and returned
   an empty result (:issue:`6952`)
 - Bug in sum/mean on 32-bit platforms on overflows (:issue:`6915`)
+- Bug in enabling ``subplots=True`` in ``DataFrame.plot`` only has single column raises ``TypeError``, and ``Series.plot`` raises ``AttributeError`` (:issue:`6951`)
+- Bug in ``DataFrame.plot`` draws unnecessary axes when enabling ``subplots`` and ``kind=scatter`` (:issue:`6951`)
 
 pandas 0.13.1
 -------------

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -62,6 +62,9 @@ class TestSeriesPlots(tm.TestCase):
         _check_plot_works(self.series[:10].plot, kind='barh')
         _check_plot_works(Series(randn(10)).plot, kind='bar', color='black')
 
+        # GH 6951
+        _check_plot_works(self.ts.plot, subplots=True)
+
     @slow
     def test_plot_figsize_and_title(self):
         # figsize and title
@@ -367,6 +370,11 @@ class TestDataFramePlots(tm.TestCase):
                        index=index)
         _check_plot_works(df.plot, title=u('\u03A3'))
 
+        # GH 6951
+        # Test with single column
+        df = DataFrame({'x': np.random.rand(10)})
+        _check_plot_works(df.plot, kind='bar', subplots=True)
+
     def test_nonnumeric_exclude(self):
         import matplotlib.pyplot as plt
         df = DataFrame({'A': ["x", "y", "z"], 'B': [1, 2, 3]})
@@ -664,6 +672,10 @@ class TestDataFramePlots(tm.TestCase):
             df.plot(x='x', kind='scatter')
         with tm.assertRaises(ValueError):
             df.plot(y='y', kind='scatter')
+
+        # GH 6951
+        axes = df.plot(x='x', y='y', kind='scatter', subplots=True)
+        self.assertEqual(len(axes[0].figure.axes), 1)
 
     @slow
     def test_plot_bar(self):
@@ -1270,6 +1282,11 @@ class TestDataFramePlots(tm.TestCase):
         ax = df.plot(kind='hexbin', x='A', y='B', gridsize=10)
         # TODO: need better way to test. This just does existence.
         self.assertEqual(len(ax.collections), 1)
+
+        # GH 6951
+        axes = df.plot(x='A', y='B', kind='hexbin', subplots=True)
+        # hexbin should have 2 axes, 1 for plotting and another is colorbar
+        self.assertEqual(len(axes[0].figure.axes), 2)
 
     @slow
     def test_hexbin_with_c(self):

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -966,18 +966,13 @@ class MPLPlot(object):
     def _setup_subplots(self):
         if self.subplots:
             nrows, ncols = self._get_layout()
-            if self.ax is None:
-                fig, axes = _subplots(nrows=nrows, ncols=ncols,
-                                      sharex=self.sharex, sharey=self.sharey,
-                                      figsize=self.figsize,
-                                      secondary_y=self.secondary_y,
-                                      data=self.data)
-            else:
-                fig, axes = _subplots(nrows=nrows, ncols=ncols,
-                                      sharex=self.sharex, sharey=self.sharey,
-                                      figsize=self.figsize, ax=self.ax,
-                                      secondary_y=self.secondary_y,
-                                      data=self.data)
+            fig, axes = _subplots(nrows=nrows, ncols=ncols,
+                                  sharex=self.sharex, sharey=self.sharey,
+                                  figsize=self.figsize, ax=self.ax,
+                                  secondary_y=self.secondary_y,
+                                  data=self.data)
+            if not com.is_list_like(axes):
+                axes = np.array([axes])
         else:
             if self.ax is None:
                 fig = self.plt.figure(figsize=self.figsize)
@@ -1000,7 +995,11 @@ class MPLPlot(object):
         self.axes = axes
 
     def _get_layout(self):
-        return (len(self.data.columns), 1)
+        from pandas.core.frame import DataFrame
+        if isinstance(self.data, DataFrame):
+            return (len(self.data.columns), 1)
+        else:
+            return (1, 1)
 
     def _compute_plot_data(self):
         numeric_data = self.data.convert_objects()._get_numeric_data()
@@ -1403,6 +1402,8 @@ class ScatterPlot(MPLPlot):
         self.x = x
         self.y = y
 
+    def _get_layout(self):
+        return (1, 1)
 
     def _make_plot(self):
         x, y, data = self.x, self.y, self.data
@@ -1441,6 +1442,9 @@ class HexBinPlot(MPLPlot):
         self.x = x
         self.y = y
         self.C = C
+
+    def _get_layout(self):
+        return (1, 1)
 
     def _make_plot(self):
         import matplotlib.pyplot as plt


### PR DESCRIPTION
Found 2 minor issues related to plotting with `subplots=True`.
1. If `DataFrame` only has single column, plot raises `TypeError`. It is because `_subplots` returns `Axes` instance, not array.
2. If `kind=scatter` or `kind=hexbin` is specified with `subplots=True`, additional blank axes is drawn.
