### PR TITLE
BUG: Pass args and kwargs to empty

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -420,6 +420,8 @@ Bug Fixes
 - Bug in C parser with leading whitespace (:issue:`3374`)
 - Bug in C parser with ``delim_whitespace=True`` and ``\r``-delimited lines
 - Bug in ``Series.rank`` and ``DataFrame.rank`` that caused small floats (<1e-13) to all receive the same rank (:issue:`6886`)
+- Bug in ``DataFrame.apply`` with functions that used *args or **kwargs and returned
+  an empty result (:issue:`6952`)
 
 pandas 0.13.1
 -------------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3313,7 +3313,7 @@ class DataFrame(NDFrame):
             f = func
 
         if len(self.columns) == 0 and len(self.index) == 0:
-            return self._apply_empty_result(func, axis, reduce)
+            return self._apply_empty_result(func, axis, reduce, *args, **kwds)
 
         if isinstance(f, np.ufunc):
             results = f(self.values)
@@ -3322,7 +3322,8 @@ class DataFrame(NDFrame):
         else:
             if not broadcast:
                 if not all(self.shape):
-                    return self._apply_empty_result(func, axis, reduce)
+                    return self._apply_empty_result(func, axis, reduce, *args,
+                                                    **kwds)
 
                 if raw and not self._is_mixed_type:
                     return self._apply_raw(f, axis)
@@ -3333,11 +3334,12 @@ class DataFrame(NDFrame):
             else:
                 return self._apply_broadcast(f, axis)
 
-    def _apply_empty_result(self, func, axis, reduce):
+    def _apply_empty_result(self, func, axis, reduce, *args, **kwds):
         if reduce is None:
             reduce = False
             try:
-                reduce = not isinstance(func(_EMPTY_SERIES), Series)
+                reduce = not isinstance(func(_EMPTY_SERIES, *args, **kwds),
+                                        Series)
             except Exception:
                 pass
 


### PR DESCRIPTION
Closes #6952

I wasn't sure what the best way to test this was. I went with calling `_apply_empty_result` directly and checking for a SystemExit to get around the try: except Exception block in `_apply_empty_result`.

I still don't think I've 100% ensured that `_apply_empty_result` will always be _called with_ _args and *_kwargs (if there are any), but if they are passed things will be handled correctly.
