### PR TITLE
BUG: Bug in sum/mean on 32-bit platforms on overflows (GH6915)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -422,6 +422,7 @@ Bug Fixes
 - Bug in ``Series.rank`` and ``DataFrame.rank`` that caused small floats (<1e-13) to all receive the same rank (:issue:`6886`)
 - Bug in ``DataFrame.apply`` with functions that used *args or **kwargs and returned
   an empty result (:issue:`6952`)
+- Bug in sum/mean on 32-bit platforms on overflows (:issue:`6915`)
 
 pandas 0.13.1
 -------------

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -314,6 +314,49 @@ class TestNanops(tm.TestCase):
         result = np.nansum(s)
         assert_almost_equal(result, 1)
 
+    def test_overflow(self):
+
+        # GH 6915
+        # overflowing on the smaller int dtypes
+        for dtype in ['int32','int64']:
+            v = np.arange(5000000,dtype=dtype)
+            s = Series(v)
+
+            # no bottleneck
+            result = s.sum(skipna=False)
+            self.assertEqual(int(result),v.sum(dtype='int64'))
+            result = s.min(skipna=False)
+            self.assertEquals(int(result),0)
+            result = s.max(skipna=False)
+            self.assertEquals(int(result),v[-1])
+
+            # use bottleneck if available
+            result = s.sum()
+            self.assertEqual(int(result),v.sum(dtype='int64'))
+            result = s.min()
+            self.assertEquals(int(result),0)
+            result = s.max()
+            self.assertEquals(int(result),v[-1])
+
+        for dtype in ['float32','float64']:
+            v = np.arange(5000000,dtype=dtype)
+            s = Series(v)
+
+            # no bottleneck
+            result = s.sum(skipna=False)
+            self.assertTrue(np.allclose(float(result),v.sum(dtype='float64')))
+            result = s.min(skipna=False)
+            self.assertTrue(np.allclose(float(result),0.0))
+            result = s.max(skipna=False)
+            self.assertTrue(np.allclose(float(result),v[-1]))
+
+            # use bottleneck if available
+            result = s.sum()
+            self.assertTrue(np.allclose(float(result),v.sum(dtype='float64')))
+            result = s.min()
+            self.assertTrue(np.allclose(float(result),0.0))
+            result = s.max()
+            self.assertTrue(np.allclose(float(result),v[-1]))
 
 class SafeForSparse(object):
     pass


### PR DESCRIPTION
closes #6915

overflow when doing sum (and mean) using bottleneck/numpy on 32-bit platforms with 32-bit dtypes
