### PR TITLE
ENH: Quantiles accepts an array

### DIFF
--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -482,6 +482,8 @@ Enhancements
 - Added ``how`` option to rolling-moment functions to dictate how to handle resampling; :func:``rolling_max`` defaults to max,
   :func:``rolling_min`` defaults to min, and all others default to mean (:issue:`6297`)
 - ``CustomBuisnessMonthBegin`` and ``CustomBusinessMonthEnd`` are now available (:issue:`6866`)
+- :meth:`Series.quantile` and :meth:`DataFrame.quantile` now accept an array of 
+  quantiles.
 
 Performance
 ~~~~~~~~~~~

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -10945,6 +10945,25 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         xp = df.median()
         assert_series_equal(rs, xp)
 
+    def test_quantile_multi(self):
+        df = DataFrame([[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                       columns=['a', 'b', 'c'])
+        result = df.quantile([.25, .5])
+        expected = DataFrame([[1.5, 1.5, 1.5], [2., 2., 2.]],
+                             index=[.25, .5], columns=['a', 'b', 'c'])
+        assert_frame_equal(result, expected)
+
+        # axis = 1
+        result = df.quantile([.25, .5], axis=1)
+        expected = DataFrame([[1.5, 1.5, 1.5], [2., 2., 2.]],
+                             index=[.25, .5], columns=[0, 1, 2])
+
+        # empty
+        result = DataFrame({'x': [], 'y': []}).quantile([0.1, .9], axis=0)
+        expected = DataFrame({'x': [np.nan, np.nan], 'y': [np.nan, np.nan]},
+                             index=[.1, .9])
+        assert_frame_equal(result, expected)
+
     def test_cumsum(self):
         self.tsframe.ix[5:10, 0] = nan
         self.tsframe.ix[10:15, 1] = nan
@@ -12728,7 +12747,6 @@ class TestDataFrameQueryWithMultiIndex(object):
         df = DataFrame(randn(10, 2), index=index)
         ind = Series(df.index.get_level_values(0).values, index=index)
 
-        #import ipdb; ipdb.set_trace()
         res1 = df.query('ilevel_0 == "red"', parser=parser, engine=engine)
         res2 = df.query('"red" == ilevel_0', parser=parser, engine=engine)
         exp = df[ind == 'red']

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -2203,6 +2203,22 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
             q = tds.quantile(.25)
             self.assertEqual(q, pd.to_timedelta('24:00:00'))
 
+    def test_quantile_multi(self):
+        from numpy import percentile
+
+        qs = [.1, .9]
+        result = self.ts.quantile(qs)
+        expected = pd.Series([percentile(self.ts.valid(), 10),
+                              percentile(self.ts.valid(), 90)],
+                             index=qs)
+        assert_series_equal(result, expected)
+
+        dts = self.ts.index.to_series()
+        result = dts.quantile((.2, .2))
+        assert_series_equal(result, Series([Timestamp('2000-01-10 19:12:00'),
+                                            Timestamp('2000-01-10 19:12:00')],
+                                           index=[.2, .2]))
+
     def test_describe(self):
         _ = self.series.describe()
         _ = self.ts.describe()


### PR DESCRIPTION
Doesn't quite finish #4196, but it should be easy not that `quantile` takes arrays.

I did this on top of #6953, so that should go in first.
