### PR TITLE
MAINT: Numpy deprecated boolean unary '-' operator

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -280,7 +280,7 @@ def notnull(obj):
     res = isnull(obj)
     if np.isscalar(res):
         return not res
-    return -res
+    return ~res
 
 def _is_null_datelike_scalar(other):
     """ test whether the object is a null datelike, e.g. Nat


### PR DESCRIPTION
I'm sure there are more of these, but I just caught this one when I was raising on all warnings.
