### PR TITLE
COMPAT: fix numpy 1.9-dev deprecation warnings in test suite

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -16,6 +16,13 @@ fi
 "$TRAVIS_BUILD_DIR"/ci/build_docs.sh 2>&1 > /tmp/doc.log &
 # doc build log will be shown after tests
 
+# export the testing mode
+if [ -n "$NUMPY_BUILD" ]; then
+
+    export PANDAS_TESTING_MODE="numpy_deprecate"
+
+fi
+
 echo nosetests --exe -w /tmp -A "$NOSE_ARGS" pandas --with-xunit --xunit-file=/tmp/nosetests.xml
 nosetests --exe -w /tmp -A "$NOSE_ARGS" pandas --with-xunit --xunit-file=/tmp/nosetests.xml
 

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -240,6 +240,9 @@ Prior Version Deprecations/Changes
 - Remove ``time_rule`` from several rolling-moment statistical functions, such
   as :func:`rolling_sum` (:issue:`1042`)
 
+- Removed neg (-) boolean operations on numpy arrays in favor of inv (~), as this is going to
+  be deprecated in numpy 1.9 (:issue:`6960`)
+
 Experimental Features
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -368,6 +368,8 @@ There are prior version deprecations that are taking effect as of 0.14.0.
   ( `commit 3136390 <https://github.com/pydata/pandas/commit/3136390>`__ )
 - Remove ``time_rule`` from several rolling-moment statistical functions, such
   as :func:`rolling_sum` (:issue:`1042`)
+- Removed neg (-) boolean operations on numpy arrays in favor of inv (~), as this is going to
+  be deprecated in numpy 1.9 (:issue:`6960`)
 
 .. _whatsnew_0140.deprecations:
 

--- a/pandas/algos.pyx
+++ b/pandas/algos.pyx
@@ -510,7 +510,7 @@ def rank_1d_generic(object in_arr, bint retry=1, ties_method='average',
         if not retry:
             raise
 
-        valid_locs = (-mask).nonzero()[0]
+        valid_locs = (~mask).nonzero()[0]
         ranks.put(valid_locs, rank_1d_generic(values.take(valid_locs), 0,
                                               ties_method=ties_method,
                                               ascending=ascending))

--- a/pandas/computation/ops.py
+++ b/pandas/computation/ops.py
@@ -42,9 +42,7 @@ class Term(StringMixin):
     def __new__(cls, name, env, side=None, encoding=None):
         klass = Constant if not isinstance(name, string_types) else cls
         supr_new = super(Term, klass).__new__
-        if PY3:
-            return supr_new(klass)
-        return supr_new(klass, name, env, side=side, encoding=encoding)
+        return supr_new(klass)
 
     def __init__(self, name, env, side=None, encoding=None):
         self._name = name

--- a/pandas/computation/pytables.py
+++ b/pandas/computation/pytables.py
@@ -33,9 +33,7 @@ class Term(ops.Term):
     def __new__(cls, name, env, side=None, encoding=None):
         klass = Constant if not isinstance(name, string_types) else cls
         supr_new = StringMixin.__new__
-        if PY3:
-            return supr_new(klass)
-        return supr_new(klass, name, env, side=side, encoding=encoding)
+        return supr_new(klass)
 
     def __init__(self, name, env, side=None, encoding=None):
         super(Term, self).__init__(name, env, side=side, encoding=encoding)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -329,7 +329,7 @@ def quantile(x, q, interpolation_method='fraction'):
     x = np.asarray(x)
     mask = com.isnull(x)
 
-    x = x[-mask]
+    x = x[~mask]
 
     values = np.sort(x)
 
@@ -339,7 +339,7 @@ def quantile(x, q, interpolation_method='fraction'):
 
         idx = at * (len(values) - 1)
         if idx % 1 == 0:
-            score = values[idx]
+            score = values[int(idx)]
         else:
             if interpolation_method == 'fraction':
                 score = _interpolate(values[int(idx)], values[int(idx) + 1],

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -248,7 +248,7 @@ def _isnull_ndarraylike_old(obj):
         # this is the NaT pattern
         result = values.view('i8') == tslib.iNaT
     else:
-        result = -np.isfinite(values)
+        result = ~np.isfinite(values)
 
     # box
     if isinstance(obj, ABCSeries):
@@ -280,7 +280,7 @@ def notnull(obj):
     res = isnull(obj)
     if np.isscalar(res):
         return not res
-    return -res
+    return ~res
 
 def _is_null_datelike_scalar(other):
     """ test whether the object is a null datelike, e.g. Nat
@@ -363,7 +363,7 @@ def mask_missing(arr, values_to_mask):
         values_to_mask = np.array(values_to_mask, dtype=object)
 
     na_mask = isnull(values_to_mask)
-    nonna = values_to_mask[-na_mask]
+    nonna = values_to_mask[~na_mask]
 
     mask = None
     for x in nonna:

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -285,7 +285,17 @@ def notnull(obj):
 def _is_null_datelike_scalar(other):
     """ test whether the object is a null datelike, e.g. Nat
     but guard against passing a non-scalar """
-    return (np.isscalar(other) and (isnull(other) or other == tslib.iNaT)) or other is pd.NaT or other is None
+    if other is pd.NaT or other is None:
+        return True
+    elif np.isscalar(other):
+
+        # a timedelta
+        if hasattr(other,'dtype'):
+            return other.view('i8') == tslib.iNaT
+        elif is_integer(other) and other == tslib.iNaT:
+            return True
+        return isnull(other)
+    return False
 
 def array_equivalent(left, right):
     """

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -1861,7 +1861,7 @@ def _get_format_timedelta64(values):
     def impl(x):
         if x is None or lib.checknull(x):
             return 'NaT'
-        elif format_short and x == 0:
+        elif format_short and com.is_integer(x) and x.view('int64') == 0:
             return "0 days" if even_days else "00:00:00"
         else:
             return lib.repr_timedelta64(x, format=format)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3041,7 +3041,7 @@ class DataFrame(NDFrame):
             this = self[col].values
             that = other[col].values
             if filter_func is not None:
-                mask = -filter_func(this) | isnull(that)
+                mask = ~filter_func(this) | isnull(that)
             else:
                 if raise_conflict:
                     mask_this = notnull(that)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -606,7 +606,11 @@ class NDFrame(PandasObject):
                     for a in self._AXIS_ORDERS])
 
     def __neg__(self):
-        arr = operator.neg(_values_from_object(self))
+        values = _values_from_object(self)
+        if values.dtype == np.bool_:
+            arr = operator.inv(values)
+        else:
+            arr = operator.neg(values)
         return self._wrap_array(arr, self.axes, copy=False)
 
     def __invert__(self):
@@ -1459,10 +1463,10 @@ class NDFrame(PandasObject):
             if level is not None:
                 if not isinstance(axis, MultiIndex):
                     raise AssertionError('axis must be a MultiIndex')
-                indexer = -lib.ismember(axis.get_level_values(level),
+                indexer = ~lib.ismember(axis.get_level_values(level),
                                         set(labels))
             else:
-                indexer = -axis.isin(labels)
+                indexer = ~axis.isin(labels)
 
             slicer = [slice(None)] * self.ndim
             slicer[self._get_axis_number(axis_name)] = indexer

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1698,7 +1698,7 @@ class Grouping(object):
 
                     labels = np.empty(len(inds), dtype=inds.dtype)
                     labels[mask] = ok_labels
-                    labels[-mask] = -1
+                    labels[~mask] = -1
 
                 if len(uniques) < len(level_index):
                     level_index = level_index.take(uniques)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -2997,7 +2997,7 @@ class MultiIndex(Index):
         index = self.levels[i]
         values = index.get_indexer(labels)
 
-        mask = -lib.ismember(self.labels[i], set(values))
+        mask = ~lib.ismember(self.labels[i], set(values))
 
         return self[mask]
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -480,10 +480,10 @@ class Index(IndexOpsMixin, FrozenNDArray):
             if is_integer(key):
                 return key
             elif is_float(key):
-                if not self.is_floating():
-                    warnings.warn("scalar indexers for index type {0} should be integers and not floating point".format(
-                        type(self).__name__),FutureWarning)
-                return to_int()
+                key = to_int()
+                warnings.warn("scalar indexers for index type {0} should be integers and not floating point".format(
+                    type(self).__name__),FutureWarning)
+                return key
             return self._convert_indexer_error(key, 'label')
 
         if is_float(key):
@@ -498,17 +498,9 @@ class Index(IndexOpsMixin, FrozenNDArray):
         """ validate and raise if needed on a slice indexers according to the
         passed in function """
 
-        if not f(key.start):
-            self._convert_indexer_error(key.start, 'slice start value')
-        if not f(key.stop):
-            self._convert_indexer_error(key.stop, 'slice stop value')
-        if not f(key.step):
-            self._convert_indexer_error(key.step, 'slice step value')
-
-    def _convert_slice_indexer_iloc(self, key):
-        """ convert a slice indexer for iloc only """
-        self._validate_slicer(key, lambda v: v is None or is_integer(v))
-        return key
+        for c in ['start','stop','step']:
+            if not f(getattr(key,c)):
+                self._convert_indexer_error(key.start, 'slice {0} value'.format(c))
 
     def _convert_slice_indexer_getitem(self, key, is_index_slice=False):
         """ called from the getitem slicers, determine how to treat the key
@@ -520,6 +512,25 @@ class Index(IndexOpsMixin, FrozenNDArray):
     def _convert_slice_indexer(self, key, typ=None):
         """ convert a slice indexer. disallow floats in the start/stop/step """
 
+        # validate iloc
+        if typ == 'iloc':
+
+            # need to coerce to_int if needed
+            def f(c):
+                v = getattr(key,c)
+                if v is None or is_integer(v):
+                    return v
+
+                # warn if its a convertible float
+                if v == int(v):
+                    warnings.warn("slice indexers when using iloc should be integers "
+                                  "and not floating point",FutureWarning)
+                    return int(v)
+
+                self._convert_indexer_error(v, 'slice {0} value'.format(c))
+
+            return slice(*[ f(c) for c in ['start','stop','step']])
+
         # validate slicers
         def validate(v):
             if v is None or is_integer(v):
@@ -530,7 +541,6 @@ class Index(IndexOpsMixin, FrozenNDArray):
                 return False
 
             return True
-
         self._validate_slicer(key, validate)
 
         # figure out if this is a positional indexer
@@ -543,9 +553,7 @@ class Index(IndexOpsMixin, FrozenNDArray):
         is_index_slice = is_int(start) and is_int(stop)
         is_positional = is_index_slice and not self.is_integer()
 
-        if typ == 'iloc':
-            return self._convert_slice_indexer_iloc(key)
-        elif typ == 'getitem':
+        if typ == 'getitem':
             return self._convert_slice_indexer_getitem(
                 key, is_index_slice=is_index_slice)
 
@@ -1980,7 +1988,7 @@ class Float64Index(Index):
         """ convert a slice indexer, by definition these are labels
             unless we are iloc """
         if typ == 'iloc':
-            return self._convert_slice_indexer_iloc(key)
+            return super(Float64Index, self)._convert_slice_indexer(key, typ=typ)
 
         # allow floats here
         self._validate_slicer(
@@ -2385,14 +2393,6 @@ class MultiIndex(Index):
 
     def __len__(self):
         return len(self.labels[0])
-
-    def _convert_slice_indexer(self, key, typ=None):
-        """ convert a slice indexer. disallow floats in the start/stop/step """
-
-        if typ == 'iloc':
-            return self._convert_slice_indexer_iloc(key)
-
-        return super(MultiIndex, self)._convert_slice_indexer(key, typ=typ)
 
     def _get_names(self):
         return FrozenList(level.name for level in self.levels)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -7,7 +7,7 @@ import pandas.compat as compat
 import pandas.core.common as com
 from pandas.core.common import (_is_bool_indexer, is_integer_dtype,
                                 _asarray_tuplesafe, is_list_like, isnull,
-                                ABCSeries, ABCDataFrame, ABCPanel)
+                                ABCSeries, ABCDataFrame, ABCPanel, is_float)
 import pandas.lib as lib
 
 import numpy as np
@@ -1319,6 +1319,7 @@ class _iLocIndexer(_LocationIndexer):
         if not _need_slice(slice_obj):
             return obj
 
+        slice_obj = self._convert_slice_indexer(slice_obj, axis)
         if isinstance(slice_obj, slice):
             return self._slice(slice_obj, axis=axis, typ='iloc')
         else:
@@ -1363,7 +1364,15 @@ class _iLocIndexer(_LocationIndexer):
 
     def _convert_to_indexer(self, obj, axis=0, is_setter=False):
         """ much simpler as we only have to deal with our valid types """
-        if self._has_valid_type(obj, axis):
+
+        # make need to convert a float key
+        if isinstance(obj, slice):
+            return self._convert_slice_indexer(obj, axis)
+
+        elif is_float(obj):
+            return self._convert_scalar_indexer(obj, axis)
+
+        elif self._has_valid_type(obj, axis):
             return obj
 
         raise ValueError("Can only index by location with a [%s]" %

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1049,7 +1049,7 @@ class FloatBlock(FloatOrComplexBlock):
         mask = isnull(values)
         values[mask] = na_rep
         if float_format:
-            imask = (-mask).ravel()
+            imask = (~mask).ravel()
             values.flat[imask] = np.array(
                 [float_format % val for val in values.ravel()[imask]])
         return values.tolist()
@@ -1181,7 +1181,7 @@ class TimeDeltaBlock(IntBlock):
         if na_rep is None:
             na_rep = 'NaT'
         rvalues[mask] = na_rep
-        imask = (-mask).ravel()
+        imask = (~mask).ravel()
         rvalues.flat[imask] = np.array([lib.repr_timedelta64(val)
                                         for val in values.ravel()[imask]],
                                        dtype=object)
@@ -1531,7 +1531,7 @@ class DatetimeBlock(Block):
         if na_rep is None:
             na_rep = 'NaT'
         rvalues[mask] = na_rep
-        imask = (-mask).ravel()
+        imask = (~mask).ravel()
 
         if date_format is None:
             date_formatter = lambda x: Timestamp(x)._repr_base

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -190,9 +190,9 @@ def _isfinite(values):
     if issubclass(values.dtype.type, (np.timedelta64, np.datetime64)):
         return isnull(values)
     elif isinstance(values.dtype, object):
-        return -np.isfinite(values.astype('float64'))
+        return ~np.isfinite(values.astype('float64'))
 
-    return -np.isfinite(values)
+    return ~np.isfinite(values)
 
 
 def _na_ok_dtype(dtype):

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -452,7 +452,7 @@ def _arith_method_SERIES(op, name, str_rep=None, fill_zeros=None,
                 mask = notnull(x)
                 result[mask] = op(x[mask], y)
 
-            result, changed = com._maybe_upcast_putmask(result, -mask, pa.NA)
+            result, changed = com._maybe_upcast_putmask(result, ~mask, pa.NA)
 
         result = com._fill_zeros(result, x, y, name, fill_zeros)
         return result
@@ -746,7 +746,7 @@ def _arith_method_FRAME(op, name, str_rep=None, default_axis='columns',
                 if np.prod(xrav.shape):
                     result[mask] = op(xrav, y)
 
-            result, changed = com._maybe_upcast_putmask(result, -mask, np.nan)
+            result, changed = com._maybe_upcast_putmask(result, ~mask, np.nan)
             result = result.reshape(x.shape)
 
         result = com._fill_zeros(result, x, y, name, fill_zeros)
@@ -817,9 +817,9 @@ def _flex_comp_method_FRAME(op, name, str_rep=None, default_axis='columns',
                 result[mask] = op(np.array(list(xrav[mask])), y)
 
             if op == operator.ne:  # pragma: no cover
-                np.putmask(result, -mask, True)
+                np.putmask(result, ~mask, True)
             else:
-                np.putmask(result, -mask, False)
+                np.putmask(result, ~mask, False)
             result = result.reshape(x.shape)
 
         return result
@@ -911,7 +911,7 @@ def _arith_method_PANEL(op, name, str_rep=None, fill_zeros=None,
             result = pa.empty(len(x), dtype=x.dtype)
             mask = notnull(x)
             result[mask] = op(x[mask], y)
-            result, changed = com._maybe_upcast_putmask(result, -mask, pa.NA)
+            result, changed = com._maybe_upcast_putmask(result, ~mask, pa.NA)
 
         result = com._fill_zeros(result, x, y, name, fill_zeros)
         return result
@@ -947,9 +947,9 @@ def _comp_method_PANEL(op, name, str_rep=None, masker=False):
                 result[mask] = op(np.array(list(xrav[mask])), y)
 
             if op == operator.ne:  # pragma: no cover
-                np.putmask(result, -mask, True)
+                np.putmask(result, ~mask, True)
             else:
-                np.putmask(result, -mask, False)
+                np.putmask(result, ~mask, False)
             result = result.reshape(x.shape)
 
         return result

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -961,7 +961,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     # inversion
     def __neg__(self):
-        arr = operator.neg(self.values)
+        values = self.values
+        if values.dtype == np.bool_:
+            arr = operator.inv(values)
+        else:
+            arr = operator.neg(values)
         return self._constructor(arr, self.index).__finalize__(self)
 
     def __invert__(self):
@@ -1646,7 +1650,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         if mask.any():
             result = Series(
                 -1, index=self.index, name=self.name, dtype='int64')
-            notmask = -mask
+            notmask = ~mask
             result[notmask] = np.argsort(values[notmask], kind=kind)
             return self._constructor(result,
                                      index=self.index).__finalize__(self)
@@ -1767,7 +1771,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         bad = isnull(arr)
 
-        good = -bad
+        good = ~bad
         idx = pa.arange(len(self))
 
         argsorted = _try_kind_sort(arr[good])

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -51,7 +51,7 @@ def str_cat(arr, others=None, sep=None, na_rep=None):
             result = np.empty(n, dtype=object)
             np.putmask(result, na_mask, np.nan)
 
-            notmask = -na_mask
+            notmask = ~na_mask
 
             tuples = zip(*[x[notmask] for x in arrays])
             cats = [sep.join(tup) for tup in tuples]

--- a/pandas/sparse/array.py
+++ b/pandas/sparse/array.py
@@ -509,7 +509,7 @@ def make_sparse(arr, kind='block', fill_value=nan):
     length = len(arr)
 
     if np.isnan(fill_value):
-        mask = -np.isnan(arr)
+        mask = ~np.isnan(arr)
     else:
         mask = arr != fill_value
 

--- a/pandas/src/inference.pyx
+++ b/pandas/src/inference.pyx
@@ -152,7 +152,18 @@ def infer_dtype_list(list values):
 
 
 cdef inline bint is_null_datetimelike(v):
-    return util._checknull(v) or (util.is_integer_object(v) and v == iNaT) or v is NaT
+    # determine if we have a null for a timedelta/datetime (or integer versions)x
+    if util._checknull(v):
+        return True
+    elif util.is_timedelta64_object(v):
+        return v.view('int64') == iNaT
+    elif util.is_datetime64_object(v):
+        return v.view('int64') == iNaT
+    elif util.is_integer_object(v):
+        return v == iNaT
+    elif v is NaT:
+        return True
+    return False
 
 cdef inline bint is_datetime(object o):
     return PyDateTime_Check(o)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4786,7 +4786,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         _check_bin_op(operator.or_)
         _check_bin_op(operator.xor)
 
-        _check_unary_op(operator.neg)
+        # operator.neg is deprecated in numpy >= 1.9
+        _check_unary_op(operator.inv)
 
     def test_logical_typeerror(self):
         if not compat.PY3:
@@ -11110,7 +11111,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         exp = DataFrame({"a":[ 3.5,  1. ,  3.5,  5. ,  6. ,  7. ,  2. ]})
         assert_frame_equal(df.rank(), exp)
 
-        
+
     def test_rank_na_option(self):
         from pandas.compat.scipy import rankdata
 

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -526,7 +526,7 @@ class TestSeries(tm.TestCase, Generic):
 
         expected = s.copy()
         bad = isnull(expected.values)
-        good = -bad
+        good = ~bad
         expected = Series(
             np.interp(vals[bad], vals[good], s.values[good]), index=s.index[bad])
 

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -3229,48 +3229,92 @@ class TestIndexing(tm.TestCase):
                        tm.makeDateIndex, tm.makePeriodIndex ]:
 
             i = index(5)
+
+            for s in  [ Series(np.arange(len(i)),index=i), DataFrame(np.random.randn(len(i),len(i)),index=i,columns=i) ]:
+                self.assertRaises(FutureWarning, lambda :
+                                  s.iloc[3.0])
+
+                # setting
+                def f():
+                    s.iloc[3.0] = 0
+                self.assertRaises(FutureWarning, f)
+
+            # fallsback to position selection ,series only
             s = Series(np.arange(len(i)),index=i)
-            self.assertRaises(FutureWarning, lambda :
-                              s.iloc[3.0])
+            s[3]
             self.assertRaises(FutureWarning, lambda :
                               s[3.0])
 
-            # this is ok!
-            s[3]
-
         # ints
         i = index(5)
-        s = Series(np.arange(len(i)))
-        self.assertRaises(FutureWarning, lambda :
-                          s.iloc[3.0])
+        for s in [ Series(np.arange(len(i))), DataFrame(np.random.randn(len(i),len(i)),index=i,columns=i) ]:
+            self.assertRaises(FutureWarning, lambda :
+                              s.iloc[3.0])
 
-        # on some arch's this doesn't provide a warning (and thus raise)
-        # and some it does
-        try:
-            s[3.0]
-        except:
-            pass
+            # on some arch's this doesn't provide a warning (and thus raise)
+            # and some it does
+            try:
+                s[3.0]
+            except:
+                pass
+
+            # setting
+            def f():
+                s.iloc[3.0] = 0
+            self.assertRaises(FutureWarning, f)
 
         # floats: these are all ok!
         i = np.arange(5.)
-        s = Series(np.arange(len(i)),index=i)
-        with tm.assert_produces_warning(False):
-            s[3.0]
 
-        with tm.assert_produces_warning(False):
-            s[3]
+        for s in [ Series(np.arange(len(i)),index=i), DataFrame(np.random.randn(len(i),len(i)),index=i,columns=i) ]:
+            with tm.assert_produces_warning(False):
+                s[3.0]
 
-        with tm.assert_produces_warning(False):
-            s.iloc[3.0]
+            with tm.assert_produces_warning(False):
+                s[3]
 
-        with tm.assert_produces_warning(False):
-            s.iloc[3]
+            self.assertRaises(FutureWarning, lambda :
+                              s.iloc[3.0])
 
-        with tm.assert_produces_warning(False):
-            s.loc[3.0]
+            with tm.assert_produces_warning(False):
+                s.iloc[3]
 
-        with tm.assert_produces_warning(False):
-            s.loc[3]
+            with tm.assert_produces_warning(False):
+                s.loc[3.0]
+
+            with tm.assert_produces_warning(False):
+                s.loc[3]
+
+            def f():
+                s.iloc[3.0] = 0
+            self.assertRaises(FutureWarning, f)
+
+        # slices
+        for index in [ tm.makeIntIndex, tm.makeFloatIndex,
+                       tm.makeStringIndex, tm.makeUnicodeIndex,
+                       tm.makeDateIndex, tm.makePeriodIndex ]:
+
+            index = index(5)
+            for s in [ Series(range(5),index=index), DataFrame(np.random.randn(5,2),index=index) ]:
+
+                # getitem
+                self.assertRaises(FutureWarning, lambda :
+                                  s.iloc[3.0:4])
+                self.assertRaises(FutureWarning, lambda :
+                                  s.iloc[3.0:4.0])
+                self.assertRaises(FutureWarning, lambda :
+                                  s.iloc[3:4.0])
+
+                # setitem
+                def f():
+                    s.iloc[3.0:4] = 0
+                self.assertRaises(FutureWarning, f)
+                def f():
+                    s.iloc[3:4.0] = 0
+                self.assertRaises(FutureWarning, f)
+                def f():
+                    s.iloc[3.0:4.0] = 0
+                self.assertRaises(FutureWarning, f)
 
         warnings.filterwarnings(action='ignore', category=FutureWarning)
 

--- a/pandas/tests/test_tseries.py
+++ b/pandas/tests/test_tseries.py
@@ -338,7 +338,7 @@ def test_rank():
     from pandas.compat.scipy import rankdata
 
     def _check(arr):
-        mask = -np.isfinite(arr)
+        mask = ~np.isfinite(arr)
         arr = arr.copy()
         result = algos.rank_1d_float64(arr)
         arr[mask] = np.inf

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -1065,7 +1065,7 @@ class PeriodIndex(Int64Index):
         mask = isnull(self.values)
         values[mask] = na_rep
 
-        imask = -mask
+        imask = ~mask
         values[imask] = np.array([u('%s') % dt for dt in values[imask]])
         return values.tolist()
 

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -122,8 +122,8 @@ class TestTimedeltas(tm.TestCase):
     def test_nat_converters(self):
         _skip_if_numpy_not_friendly()
 
-        self.assertEqual(to_timedelta('nat',box=False), tslib.iNaT)
-        self.assertEqual(to_timedelta('nan',box=False), tslib.iNaT)
+        self.assertEqual(to_timedelta('nat',box=False).astype('int64'), tslib.iNaT)
+        self.assertEqual(to_timedelta('nan',box=False).astype('int64'), tslib.iNaT)
 
     def test_to_timedelta(self):
         _skip_if_numpy_not_friendly()
@@ -137,7 +137,7 @@ class TestTimedeltas(tm.TestCase):
 
         # empty string
         result = to_timedelta('',box=False)
-        self.assertEqual(result, tslib.iNaT)
+        self.assertEqual(result.astype('int64'), tslib.iNaT)
 
         result = to_timedelta(['', ''])
         self.assert_(isnull(result).all())
@@ -302,10 +302,10 @@ class TestTimedeltas(tm.TestCase):
         assert_series_equal(actual, expected)
 
         actual = pd.to_timedelta(np.nan)
-        self.assertEqual(actual, timedelta_NaT)
+        self.assertEqual(actual.astype('int64'), timedelta_NaT.astype('int64'))
 
         actual = pd.to_timedelta(pd.NaT)
-        self.assertEqual(actual, timedelta_NaT)
+        self.assertEqual(actual.astype('int64'), timedelta_NaT.astype('int64'))
 
     def test_timedelta_ops_with_missing_values(self):
         _skip_if_numpy_not_friendly()

--- a/pandas/tseries/tests/test_util.py
+++ b/pandas/tseries/tests/test_util.py
@@ -24,7 +24,7 @@ class TestPivotAnnual(tm.TestCase):
         annual = pivot_annual(ts, 'D')
 
         doy = ts.index.dayofyear
-        doy[(-isleapyear(ts.index.year)) & (doy >= 60)] += 1
+        doy[(~isleapyear(ts.index.year)) & (doy >= 60)] += 1
 
         for i in range(1, 367):
             subset = ts[doy == i]
@@ -47,7 +47,7 @@ class TestPivotAnnual(tm.TestCase):
         grouped = ts_hourly.groupby(ts_hourly.index.year)
         hoy = grouped.apply(lambda x: x.reset_index(drop=True))
         hoy = hoy.index.droplevel(0).values
-        hoy[-isleapyear(ts_hourly.index.year) & (hoy >= 1416)] += 24
+        hoy[~isleapyear(ts_hourly.index.year) & (hoy >= 1416)] += 24
         hoy += 1
 
         annual = pivot_annual(ts_hourly)

--- a/pandas/tseries/tools.py
+++ b/pandas/tseries/tools.py
@@ -334,7 +334,7 @@ def _attempt_YYYYMMDD(arg):
     def calc_with_mask(carg,mask):
         result = np.empty(carg.shape, dtype='M8[ns]')
         iresult = result.view('i8')
-        iresult[-mask] = tslib.iNaT
+        iresult[~mask] = tslib.iNaT
         result[mask] = calc(carg[mask].astype(np.float64).astype(np.int64)).astype('M8[ns]')
         return result
 

--- a/pandas/tseries/util.py
+++ b/pandas/tseries/util.py
@@ -52,7 +52,7 @@ def pivot_annual(series, freq=None):
         offset = index.dayofyear - 1
 
         # adjust for leap year
-        offset[(-isleapyear(year)) & (offset >= 59)] += 1
+        offset[(~isleapyear(year)) & (offset >= 59)] += 1
 
         columns = lrange(1, 367)
         # todo: strings like 1/1, 1/25, etc.?
@@ -66,7 +66,7 @@ def pivot_annual(series, freq=None):
         defaulted = grouped.apply(lambda x: x.reset_index(drop=True))
         defaulted.index = defaulted.index.droplevel(0)
         offset = np.asarray(defaulted.index)
-        offset[-isleapyear(year) & (offset >= 1416)] += 24
+        offset[~isleapyear(year) & (offset >= 1416)] += 24
         columns = lrange(1, 8785)
     else:
         raise NotImplementedError(freq)

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -402,17 +402,17 @@ class Timestamp(_Timestamp):
         if month <= 2:
             year -= 1
             month += 12
-        return (day + 
-                np.fix((153*month - 457)/5) + 
-                365*year + 
-                np.floor(year / 4) - 
-                np.floor(year / 100) + 
-                np.floor(year / 400) + 
-                1721118.5 + 
-                (self.hour + 
-                 self.minute/60.0 + 
-                 self.second/3600.0 + 
-                 self.microsecond/3600.0/1e+6 + 
+        return (day +
+                np.fix((153*month - 457)/5) +
+                365*year +
+                np.floor(year / 4) -
+                np.floor(year / 100) +
+                np.floor(year / 400) +
+                1721118.5 +
+                (self.hour +
+                 self.minute/60.0 +
+                 self.second/3600.0 +
+                 self.microsecond/3600.0/1e+6 +
                  self.nanosecond/3600.0/1e+9
                 )/24.0)
 
@@ -1114,7 +1114,7 @@ def array_to_datetime(ndarray[object] values, raise_=False, dayfirst=False,
                         continue
                     raise
             elif util.is_datetime64_object(val):
-                if val == np_NaT:
+                if val is np_NaT or val.view('i8') == iNaT:
                     iresult[i] = iNaT
                 else:
                     try:
@@ -1190,7 +1190,11 @@ def array_to_datetime(ndarray[object] values, raise_=False, dayfirst=False,
         oresult = np.empty(n, dtype=object)
         for i in range(n):
             val = values[i]
-            if util.is_datetime64_object(val):
+
+            # set as nan if is even a datetime NaT
+            if _checknull_with_nat(val) or val is np_NaT:
+                oresult[i] = np.nan
+            elif util.is_datetime64_object(val):
                 oresult[i] = val.item()
             else:
                 oresult[i] = val

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -54,16 +54,19 @@ N = 30
 K = 4
 _RAISE_NETWORK_ERROR_DEFAULT = False
 
+# set testing_mode
+testing_mode = os.environ.get('PANDAS_TESTING_MODE','None')
+if 'numpy_deprecate' in testing_mode:
+    warnings.simplefilter('always', DeprecationWarning)
+
 class TestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
         pd.set_option('chained_assignment','raise')
-        #print("setting up: {0}".format(cls))
 
     @classmethod
     def tearDownClass(cls):
-        #print("tearing down up: {0}".format(cls))
         pass
 
     def assert_numpy_array_equal(self, np_array, assert_equal):


### PR DESCRIPTION
COMPAT: change neg of boolean to inv (deprecation in numpy 1.9)
COMPAT: remove deprecation warnings on **new** (in computation/pytables)
COMPAT: fix array_to_datetime on invalid comparison to NaT

related #6958

add ability to set an environmental variable to actually show the DeprecationWarnings

just

`setenv PANDAS_TESTING_MODE 'numpy_deprecate'`
