### PR TITLE
ENH: Support dateutil timezones. GH4688.

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -9,6 +9,8 @@ users upgrade to this version.
 
 - Highlights include:
 
+  - Support for ``dateutil`` timezones.
+
 - :ref:`Other Enhancements <whatsnew_0141.enhancements>`
 
 - :ref:`API Changes <whatsnew_0141.api>`
@@ -52,6 +54,17 @@ Known Issues
 Enhancements
 ~~~~~~~~~~~~
 - Tests for basic reading of public S3 buckets now exist (:issue:`7281`).
+
+- Support for dateutil timezones, which can now be used in the same way as
+  pytz timezones across pandas. (:issue:`4688`)
+
+  .. ipython:: python
+
+   rng_utc_dateutil = date_range('3/6/2012 00:00', periods=10, freq='D',
+                                 tz='dateutil/UTC')
+   rng_utc_dateutil.tz
+
+  See :ref:`the docs <timeseries.timezone>`.
 
 .. _whatsnew_0141.performance:
 

--- a/pandas/index.pyx
+++ b/pandas/index.pyx
@@ -605,11 +605,11 @@ cdef inline _to_i8(object val):
             return get_datetime64_value(val)
         elif PyDateTime_Check(val):
             tzinfo = getattr(val, 'tzinfo', None)
-            val = _pydatetime_to_dts(val, &dts)
+            ival = _pydatetime_to_dts(val, &dts)  # Save the original date value so we can get the utcoffset from it.
             if tzinfo is not None and not _is_utc(tzinfo):
                 offset = tslib._get_utcoffset(tzinfo, val)
-                val -= tslib._delta_to_nanoseconds(offset)
-
+                ival -= tslib._delta_to_nanoseconds(offset)
+            return ival
         return val
 
 cdef inline bint _is_utc(object tz):

--- a/pandas/io/tests/test_json/test_ujson.py
+++ b/pandas/io/tests/test_json/test_ujson.py
@@ -25,6 +25,7 @@ from numpy.testing import (assert_array_equal,
                            assert_array_almost_equal_nulp,
                            assert_approx_equal)
 import pytz
+import dateutil
 from pandas import DataFrame, Series, Index, NaT, DatetimeIndex
 import pandas.util.testing as tm
 
@@ -361,7 +362,9 @@ class UltraJSONTests(TestCase):
             datetime.time(),
             datetime.time(1, 2, 3),
             datetime.time(10, 12, 15, 343243),
-            datetime.time(10, 12, 15, 343243, pytz.utc)]
+            datetime.time(10, 12, 15, 343243, pytz.utc),
+#             datetime.time(10, 12, 15, 343243, dateutil.tz.gettz('UTC')),  # this segfaults! No idea why.
+            ]
         for test in tests:
             output = ujson.encode(test)
             expected = '"%s"' % test.isoformat()

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -92,6 +92,13 @@ def _skip_if_no_pytz():
     except ImportError:
         raise nose.SkipTest("pytz not installed")
 
+def _skip_if_no_dateutil():
+    try:
+        import dateutil
+    except ImportError:
+        raise nose.SkipTest("dateutil not installed")
+
+
 class TestDataFrameFormatting(tm.TestCase):
     _multiprocess_can_split_ = True
 
@@ -2922,7 +2929,7 @@ class TestStringRepTimestamp(tm.TestCase):
         ts_nanos_micros = Timestamp(1200)
         self.assertEqual(str(ts_nanos_micros), "1970-01-01 00:00:00.000001200")
 
-    def test_tz(self):
+    def test_tz_pytz(self):
         _skip_if_no_pytz()
 
         import pytz
@@ -2934,6 +2941,20 @@ class TestStringRepTimestamp(tm.TestCase):
         self.assertEqual(str(dt_datetime), str(Timestamp(dt_datetime)))
 
         dt_datetime_us = datetime(2013, 1, 2, 12, 1, 3, 45, tzinfo=pytz.utc)
+        self.assertEqual(str(dt_datetime_us), str(Timestamp(dt_datetime_us)))
+
+    def test_tz_dateutil(self):
+        _skip_if_no_dateutil()
+        import dateutil
+        utc = dateutil.tz.gettz('UTC')
+
+        dt_date = datetime(2013, 1, 2, tzinfo=utc)
+        self.assertEqual(str(dt_date), str(Timestamp(dt_date)))
+
+        dt_datetime = datetime(2013, 1, 2, 12, 1, 3, tzinfo=utc)
+        self.assertEqual(str(dt_datetime), str(Timestamp(dt_datetime)))
+
+        dt_datetime_us = datetime(2013, 1, 2, 12, 1, 3, 45, tzinfo=utc)
         self.assertEqual(str(dt_datetime_us), str(Timestamp(dt_datetime_us)))
 
 if __name__ == '__main__':

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1617,7 +1617,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
 
     def tz_convert(self, tz):
         """
-        Convert DatetimeIndex from one time zone to another (using pytz)
+        Convert DatetimeIndex from one time zone to another (using pytz/dateutil)
 
         Returns
         -------
@@ -1635,11 +1635,11 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
 
     def tz_localize(self, tz, infer_dst=False):
         """
-        Localize tz-naive DatetimeIndex to given time zone (using pytz)
+        Localize tz-naive DatetimeIndex to given time zone (using pytz/dateutil)
 
         Parameters
         ----------
-        tz : string or pytz.timezone
+        tz : string or pytz.timezone or dateutil.tz.tzfile
             Time zone for time. Corresponding timestamps would be converted to
             time zone of the TimeSeries
         infer_dst : boolean, default False
@@ -1666,7 +1666,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
         Parameters
         ----------
         time : datetime.time or string
-        tz : string or pytz.timezone
+        tz : string or pytz.timezone or dateutil.tz.tzfile
             Time zone for time. Corresponding timestamps would be converted to
             time zone of the TimeSeries
 
@@ -1701,7 +1701,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
         end_time : datetime.time or string
         include_start : boolean, default True
         include_end : boolean, default True
-        tz : string or pytz.timezone, default None
+        tz : string or pytz.timezone or dateutil.tz.tzfile, default None
 
         Returns
         -------

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -24,6 +24,12 @@ def _skip_if_no_pytz():
     except ImportError:
         raise nose.SkipTest("pytz not installed")
 
+def _skip_if_no_dateutil():
+    try:
+        import dateutil
+    except ImportError:
+        raise nose.SkipTest("dateutil not installed")
+
 
 def _skip_if_no_cday():
     if datetools.cday is None:
@@ -291,6 +297,11 @@ class TestDateRange(tm.TestCase):
         import pytz
         bdate_range('1/1/2005', '1/1/2009', tz=pytz.utc).summary()
 
+    def test_summary_dateutil(self):
+        _skip_if_no_dateutil()
+        import dateutil
+        bdate_range('1/1/2005', '1/1/2009', tz=dateutil.tz.gettz('UTC')).summary()
+
     def test_misc(self):
         end = datetime(2009, 5, 13)
         dr = bdate_range(end=end, periods=20)
@@ -354,7 +365,7 @@ class TestDateRange(tm.TestCase):
         exp_values = [start + i * offset for i in range(5)]
         self.assert_numpy_array_equal(result, DatetimeIndex(exp_values))
 
-    def test_range_tz(self):
+    def test_range_tz_pytz(self):
         # GH 2906
         _skip_if_no_pytz()
         from pytz import timezone as tz
@@ -377,9 +388,48 @@ class TestDateRange(tm.TestCase):
         self.assertEqual(dr[0], start)
         self.assertEqual(dr[2], end)
 
-    def test_month_range_union_tz(self):
+    def test_range_tz_dateutil(self):
+        # GH 2906
+        _skip_if_no_dateutil()
+        from dateutil.tz import gettz as tz
+
+        start = datetime(2011, 1, 1, tzinfo=tz('US/Eastern'))
+        end = datetime(2011, 1, 3, tzinfo=tz('US/Eastern'))
+
+        dr = date_range(start=start, periods=3)
+        self.assert_(dr.tz == tz('US/Eastern'))
+        self.assert_(dr[0] == start)
+        self.assert_(dr[2] == end)
+
+        dr = date_range(end=end, periods=3)
+        self.assert_(dr.tz == tz('US/Eastern'))
+        self.assert_(dr[0] == start)
+        self.assert_(dr[2] == end)
+
+        dr = date_range(start=start, end=end)
+        self.assert_(dr.tz == tz('US/Eastern'))
+        self.assert_(dr[0] == start)
+        self.assert_(dr[2] == end)
+
+    def test_month_range_union_tz_pytz(self):
         _skip_if_no_pytz()
         from pytz import timezone
+        tz = timezone('US/Eastern')
+
+        early_start = datetime(2011, 1, 1)
+        early_end = datetime(2011, 3, 1)
+
+        late_start = datetime(2011, 3, 1)
+        late_end = datetime(2011, 5, 1)
+
+        early_dr = date_range(start=early_start, end=early_end, tz=tz, freq=datetools.monthEnd)
+        late_dr = date_range(start=late_start, end=late_end, tz=tz, freq=datetools.monthEnd)
+
+        early_dr.union(late_dr)
+
+    def test_month_range_union_tz_dateutil(self):
+        _skip_if_no_dateutil()
+        from dateutil.tz import gettz as timezone
         tz = timezone('US/Eastern')
 
         early_start = datetime(2011, 1, 1)
@@ -579,6 +629,11 @@ class TestCustomDateRange(tm.TestCase):
         _skip_if_no_pytz()
         import pytz
         cdate_range('1/1/2005', '1/1/2009', tz=pytz.utc).summary()
+
+    def test_summary_dateutil(self):
+        _skip_if_no_dateutil()
+        import dateutil
+        cdate_range('1/1/2005', '1/1/2009', tz=dateutil.tz.gettz('UTC')).summary()
 
     def test_misc(self):
         end = datetime(2009, 5, 13)

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -83,6 +83,16 @@ class TestPeriodProperties(tm.TestCase):
         self.assertEqual(p.tz,
                          pytz.timezone('Europe/Brussels').normalize(p).tzinfo)
 
+    def test_timestamp_tz_arg_dateutil(self):
+        import dateutil
+        p = Period('1/1/2005', freq='M').to_timestamp(tz=dateutil.tz.gettz('Europe/Brussels'))
+        self.assertEqual(p.tz, dateutil.tz.gettz('Europe/Brussels'))
+
+    def test_timestamp_tz_arg_dateutil_from_string(self):
+        import dateutil
+        p = Period('1/1/2005', freq='M').to_timestamp(tz='dateutil/Europe/Brussels')
+        self.assertEqual(p.tz, dateutil.tz.gettz('Europe/Brussels'))
+
     def test_period_constructor(self):
         i1 = Period('1/1/2005', freq='M')
         i2 = Period('Jan 2005')

--- a/pandas/tseries/tools.py
+++ b/pandas/tseries/tools.py
@@ -57,9 +57,7 @@ def _infer_tzinfo(start, end):
 
 
 def _maybe_get_tz(tz, date=None):
-    if isinstance(tz, compat.string_types):
-        import pytz
-        tz = pytz.timezone(tz)
+    tz = tslib.maybe_get_tz(tz)
     if com.is_integer(tz):
         import pytz
         tz = pytz.FixedOffset(tz / 60)
@@ -70,6 +68,7 @@ def _maybe_get_tz(tz, date=None):
             tz = tz.localize(date.replace(tzinfo=None)).tzinfo
 
     return tz
+
 
 def _guess_datetime_format(dt_str, dayfirst=False,
                            dt_str_parse=compat.parse_date,


### PR DESCRIPTION
closes #4688

This PR should provide support for dateutil timezones. It was discussed quite a bit in https://github.com/pydata/pandas/pull/4689.

The discussion there ended two months back with "we should incorporate this if it can be made seamless". I think I've managed that now so it would be great to get some feedback on the changes in this PR. 

Everything that works with pytz timezones should work with dateutil timezones and you shouldn't notice any difference in behaviour when you change between them. There are two exceptions which I'm looking at now: saving data to ujson and pytables.

The changes I've made just allow pandas to treat dateutil timezones exactly the same as pytz timezones (from the user perspective) - just extending conversion logic to deal with both where appropriate. This has made a few methods a bit more complicated but relatively few changes were required.

All of the significant changes are in tslib.pyx. Almost all of the other changes are adding test cases for the dateutil timezones. The test suites pass locally.

Let me know if you have any questions or if there's anything that needs doing before the PR can be accepted.
