### PR TITLE
Panel shift revert

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -151,7 +151,6 @@ API Changes
   to a non-unique item in the ``Index`` (previously raised a ``KeyError``). (:issue:`6738`)
 - all offset operations now return ``Timestamp`` types (rather than datetime), Business/Week frequencies were incorrect (:issue:`4069`)
 - ``Series.iteritems()`` is now lazy (returns an iterator rather than a list). This was the documented behavior prior to 0.14. (:issue:`6760`)
-- ``Panel.shift`` now uses ``NDFrame.shift``. It no longer drops the ``nan`` data and retains its original shape.  (:issue:`4867`)
 - ``to_excel`` now converts ``np.inf`` into a string representation,
   customizable by the ``inf_rep`` keyword argument (Excel has no native inf
   representation) (:issue:`6782`)
@@ -424,6 +423,7 @@ Bug Fixes
 - Bug in ``DataFrame.apply`` with functions that used *args or **kwargs and returned
   an empty result (:issue:`6952`)
 - Bug in sum/mean on 32-bit platforms on overflows (:issue:`6915`)
+- Moved ``Panel.shift`` to ``NDFrame.slice_shift`` and fixed to respect multiple dtypes. (:issue:`6959`)
 
 pandas 0.13.1
 -------------

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -199,7 +199,6 @@ API changes
     covs[df.index[-1]]
 
 - ``Series.iteritems()`` is now lazy (returns an iterator rather than a list). This was the documented behavior prior to 0.14. (:issue:`6760`)
-- ``Panel.shift`` now uses ``NDFrame.shift``. It no longer drops the ``nan`` data and retains its original shape.  (:issue:`4867`)
 
 - Added ``nunique`` and ``value_counts`` functions to ``Index`` for counting unique elements. (:issue:`6734`)
 - ``stack`` and ``unstack`` now raise a ``ValueError`` when the ``level`` keyword refers

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3227,6 +3227,42 @@ class NDFrame(PandasObject):
 
         return self._constructor(new_data).__finalize__(self)
 
+    def slice_shift(self, periods=1, axis=0, **kwds):
+        """
+        Equivalent to `shift` without copying data. The shifted data will
+        not include the dropped periods and the shifted axis will be smaller
+        than the original.
+
+        Parameters
+        ----------
+        periods : int
+            Number of periods to move, can be positive or negative
+
+        Notes
+        -----
+        While the `slice_shift` is faster than `shift`, you may pay for it
+        later during alignment.
+
+        Returns
+        -------
+        shifted : same type as caller
+        """
+        if periods == 0:
+            return self
+
+        if periods > 0:
+            vslicer = slice(None, -periods)
+            islicer = slice(periods, None)
+        else:
+            vslicer = slice(-periods, None)
+            islicer = slice(None, periods)
+
+        new_obj = self._slice(vslicer, axis=axis)
+        shifted_axis = self._get_axis(axis)[islicer]
+        new_obj.set_axis(axis, shifted_axis)
+
+        return new_obj.__finalize__(self)
+
     def tshift(self, periods=1, freq=None, axis=0, **kwds):
         """
         Shift the time index, using the index's frequency if available

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -1154,7 +1154,8 @@ class Panel(NDFrame):
     @deprecate_kwarg(old_arg_name='lags', new_arg_name='periods')
     def shift(self, periods=1, freq=None, axis='major'):
         """
-        Shift major or minor axis by specified number of leads/lags.
+        Shift major or minor axis by specified number of leads/lags. Drops
+        periods right now compared with DataFrame.shift
 
         Parameters
         ----------
@@ -1171,7 +1172,7 @@ class Panel(NDFrame):
         if axis == 'items':
             raise ValueError('Invalid axis')
 
-        return super(Panel, self).shift(periods, freq=freq, axis=axis)
+        return super(Panel, self).slice_shift(periods, axis=axis)
 
     def tshift(self, periods=1, freq=None, axis='major', **kwds):
         return super(Panel, self).tshift(periods, freq, axis, **kwds)

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -21,7 +21,8 @@ from pandas.util.testing import (assert_panel_equal,
                                  assert_almost_equal,
                                  ensure_clean,
                                  assertRaisesRegexp,
-                                 makeCustomDataframe as mkdf
+                                 makeCustomDataframe as mkdf,
+                                 makeMixedDataFrame
     )
 import pandas.core.panel as panelm
 import pandas.util.testing as tm
@@ -1652,9 +1653,16 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
 
         # negative numbers, #2164
         result = self.panel.shift(-1)
-        expected = Panel(dict((i, f.shift(-1))
+        expected = Panel(dict((i, f.shift(-1)[:-1])
                               for i, f in compat.iteritems(self.panel)))
         assert_panel_equal(result, expected)
+
+        # mixed dtypes #6959
+        data = [('item '+ch, makeMixedDataFrame()) for ch in list('abcde')]
+        data = dict(data)
+        mixed_panel = Panel.from_dict(data, orient='minor')
+        shifted = mixed_panel.shift(1)
+        assert_series_equal(mixed_panel.dtypes, shifted.dtypes)
 
     def test_tshift(self):
         # PeriodIndex


### PR DESCRIPTION
Reverts #6605 closes #6959 #6826
## vs 13.1

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
panel_shift                                  |   0.0773 |   0.0990 |   0.7809 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [3d0099a] : BUG: Change Panel.shift to use slice_shift #6605 #6826
Base   [d10a658] : RLS: set released to True. v0.13.1
```
## vs master

Note that the `pct_change is slower due to the deferred alignment. 

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
panel_shift                                  |   0.1650 | 522.0180 |   0.0003 |
panel_pct_change_major                       | 7615.9450 | 6213.1660 |   1.2258 |
panel_pct_change_minor                       | 7864.9763 | 5877.1353 |   1.3382 |
panel_pct_change_items                       | 8646.0753 | 5884.1163 |   1.4694 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [3ec426f] : BUG: Change Panel.shift to use slice_shift #6605 #6826
Base   [0d2966f] : COMPAT:  32-bit platform compat for Panel.count
```
