### PR TITLE
Fix for GH 6885 - get_dummies chokes on unicode values

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -270,7 +270,6 @@ Improvements to existing features
 Bug Fixes
 ~~~~~~~~~
 
-- Bug causing UnicodeEncodeError when get_dummies called with unicode values and a prefix (:issue:`6885`)
 - Bug in Series ValueError when index doesn't match data (:issue:`6532`)
 - Prevent segfault due to MultiIndex not being supported in HDFStore table
   format (:issue:`1848`)
@@ -382,6 +381,7 @@ Bug Fixes
 - Bug in arithmetic operations affecting to NaT (:issue:`6873`)
 - Bug in ``Series.str.extract`` where the resulting ``Series`` from a single
   group match wasn't renamed to the group name
+- Bug causing UnicodeEncodeError when get_dummies called with unicode values and a prefix (:issue:`6885`)
 
 pandas 0.13.1
 -------------

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -270,6 +270,7 @@ Improvements to existing features
 Bug Fixes
 ~~~~~~~~~
 
+- Bug causing UnicodeEncodeError when get_dummies called with unicode values and a prefix (:issue:`6885`)
 - Bug in Series ValueError when index doesn't match data (:issue:`6532`)
 - Prevent segfault due to MultiIndex not being supported in HDFStore table
   format (:issue:`1848`)

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -1017,7 +1017,7 @@ def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False):
         dummy_mat[cat.labels == -1] = 0
 
     if prefix is not None:
-        dummy_cols = ['%s%s%s' % (prefix, prefix_sep, str(v))
+        dummy_cols = ['%s%s%s' % (prefix, prefix_sep, v)
                       for v in levels]
     else:
         dummy_cols = levels

--- a/pandas/tests/test_reshape.py
+++ b/pandas/tests/test_reshape.py
@@ -199,7 +199,7 @@ class TestGetDummies(tm.TestCase):
         exp_just_na = DataFrame(Series(1.0,index=[0]),columns=[nan])
         assert_array_equal(res_just_na.values, exp_just_na.values)
 
-    def test_unicode(self):  # See GH 6634 - get_dummies chokes on unicode values
+    def test_unicode(self):  # See GH 6885 - get_dummies chokes on unicode values
         import unicodedata
         e = 'e'
         eacute = unicodedata.lookup('LATIN SMALL LETTER E WITH ACUTE')

--- a/pandas/tests/test_reshape.py
+++ b/pandas/tests/test_reshape.py
@@ -18,7 +18,7 @@ from numpy.testing import assert_array_equal
 from pandas.core.reshape import (melt, convert_dummies, lreshape, get_dummies,
                                  wide_to_long)
 import pandas.util.testing as tm
-from pandas.compat import StringIO, cPickle, range
+from pandas.compat import StringIO, cPickle, range, u
 
 _multiprocess_can_split_ = True
 
@@ -198,6 +198,17 @@ class TestGetDummies(tm.TestCase):
         res_just_na = get_dummies([nan], dummy_na=True)
         exp_just_na = DataFrame(Series(1.0,index=[0]),columns=[nan])
         assert_array_equal(res_just_na.values, exp_just_na.values)
+
+    def test_unicode(self):  # See GH 6634 - get_dummies chokes on unicode values
+        import unicodedata
+        e = 'e'
+        eacute = unicodedata.lookup('LATIN SMALL LETTER E WITH ACUTE')
+        s = [e, eacute, eacute]
+        res = get_dummies(s, prefix='letter')
+        print(res)
+        exp = DataFrame({'letter_e': {0: 1.0, 1: 0.0, 2: 0.0},
+                        u('letter_%s') % eacute: {0: 0.0, 1: 1.0, 2: 1.0}})
+        assert_frame_equal(res, exp)
 
 class TestConvertDummies(tm.TestCase):
     def test_convert_dummies(self):

--- a/pandas/tests/test_reshape.py
+++ b/pandas/tests/test_reshape.py
@@ -205,7 +205,6 @@ class TestGetDummies(tm.TestCase):
         eacute = unicodedata.lookup('LATIN SMALL LETTER E WITH ACUTE')
         s = [e, eacute, eacute]
         res = get_dummies(s, prefix='letter')
-        print(res)
         exp = DataFrame({'letter_e': {0: 1.0, 1: 0.0, 2: 0.0},
                         u('letter_%s') % eacute: {0: 0.0, 1: 1.0, 2: 1.0}})
         assert_frame_equal(res, exp)


### PR DESCRIPTION
closes #6885

Please be gentle - this is the first time I've tried to contribute either to someone else's python project or another project on github, so if my python or git foo is lacking, I apologise in advance!
