### PR TITLE
ENH: support pie plot in series and dataframe plot

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -277,6 +277,7 @@ latex_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'statsmodels': ('http://statsmodels.sourceforge.net/devel/', None),
+    'matplotlib': ('http://matplotlib.org/', None),
     'python': ('http://docs.python.org/', None)
 }
 import glob

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -58,6 +58,7 @@ New features
   ``DataFrame(dict)`` and ``Series(dict)`` create ``MultiIndex``
   columns and index where applicable (:issue:`4187`)
 - Hexagonal bin plots from ``DataFrame.plot`` with ``kind='hexbin'`` (:issue:`5478`)
+- Pie plots from ``Series.plot`` and ``DataFrame.plot`` with ``kind='pie'`` (:issue:`6976`)
 - Added the ``sym_diff`` method to ``Index`` (:issue:`5543`)
 - Added ``to_julian_date`` to ``TimeStamp`` and ``DatetimeIndex``.  The Julian
   Date is used primarily in astronomy and represents the number of days from

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -364,7 +364,8 @@ Plotting
 ~~~~~~~~
 
 - Hexagonal bin plots from ``DataFrame.plot`` with ``kind='hexbin'`` (:issue:`5478`), See :ref:`the docs<visualization.hexbin>`.
-- ``DataFrame.plot`` and ``Series.plot`` now supports area plot with specifying ``kind='area'`` (:issue:`6656`)
+- ``DataFrame.plot`` and ``Series.plot`` now supports area plot with specifying ``kind='area'`` (:issue:`6656`), See :ref:`the docs<visualization.area>`
+- Pie plots from ``Series.plot`` and ``DataFrame.plot`` with ``kind='pie'`` (:issue:`6976`), See :ref:`the docs<visualization.pie>`.
 - Plotting with Error Bars is now supported in the ``.plot`` method of ``DataFrame`` and ``Series`` objects (:issue:`3796`, :issue:`6834`), See :ref:`the docs<visualization.errorbars>`.
 - ``DataFrame.plot`` and ``Series.plot`` now support a ``table`` keyword for plotting ``matplotlib.Table``, See :ref:`the docs<visualization.table>`.
 - ``plot(legend='reverse')`` will now reverse the order of legend labels for

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -588,6 +588,80 @@ given by column ``z``. The bins are aggregated with numpy's ``max`` function.
 
 See the `matplotlib hexbin documenation <http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.hexbin>`__ for more.
 
+.. _visualization.pie:
+
+Pie plot
+~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 0.14
+
+You can create pie plot with ``DataFrame.plot`` or ``Series.plot`` with ``kind='pie'``.
+If data includes ``NaN``, it will be automatically filled by 0.
+If data contains negative value, ``ValueError`` will be raised.
+
+.. ipython:: python
+   :suppress:
+
+   plt.figure()
+
+.. ipython:: python
+   
+   series = Series(3 * rand(4), index=['a', 'b', 'c', 'd'], name='series')
+
+   @savefig series_pie_plot.png
+   series.plot(kind='pie')
+
+Note that pie plot with ``DataFrame`` requires either to specify target column by ``y``
+argument or ``subplots=True``. When ``y`` is specified, pie plot of selected column 
+will be drawn. If ``subplots=True`` is specified, pie plots for each columns are drawn as subplots.
+Legend will be drawn in each pie plots by default, specify ``legend=False`` to hide it.
+
+.. ipython:: python
+   :suppress:
+
+   plt.figure()
+
+.. ipython:: python
+   
+   df = DataFrame(3 * rand(4, 2), index=['a', 'b', 'c', 'd'], columns=['x', 'y'])
+
+   @savefig df_pie_plot.png
+   df.plot(kind='pie', subplots=True) 
+
+You can use ``labels`` and ``colors`` keywords to specify labels and colors of each wedges
+(Cannot use ``label`` and ``color``, because of matplotlib's specification).
+If you want to hide wedge labels, specify ``labels=None``. 
+If ``fontsize`` is specified, the value will be applied to wedge labels.
+Also, other keywords supported by :func:`matplotlib.pyplot.pie` can be used.
+
+
+.. ipython:: python
+   :suppress:
+
+   plt.figure()
+
+.. ipython:: python
+   
+   @savefig series_pie_plot_options.png
+   series.plot(kind='pie', labels=['AA', 'BB', 'CC', 'DD'], colors=['r', 'g', 'b', 'c'],
+               autopct='%.2f', fontsize=20)
+
+If you pass values which sum total is less than 1.0, matplotlib draws semicircle.
+
+.. ipython:: python
+   :suppress:
+
+   plt.figure()
+
+.. ipython:: python
+   
+   series = Series([0.1] * 4, index=['a', 'b', 'c', 'd'], name='series2')
+
+   @savefig series_pie_plot_semi.png
+   series.plot(kind='pie') 
+
+See the `matplotlib pie documenation <http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.pie>`__ for more.
+
 .. _visualization.andrews_curves:
 
 Andrews Curves


### PR DESCRIPTION
Related to #413, added pie plot for `Series.plot` and `DataFrame.plot` kind.

If data includes `NaN`, it will be automatically filled by 0. If data contains negative value, `ValueError` will be raised.

```
import pandas as pd
import numpy as np
series = pd.Series(3 * np.random.rand(4), index=['a', 'b', 'c', 'd'], name='series')
series.plot(kind='pie')
```

![series_pie_plot](https://cloud.githubusercontent.com/assets/1696302/2810158/526e4f82-cda1-11e3-95b3-422d8e5b18ef.png)
### Plotting with DataFrame

Pie plot with `DataFrame` requires either to specify target column by `y` argument or `subplots=True`. When `y` is specified, pie plot of selected column will be drawn. If `subplots=True` is specified, pie plots for each columns are drawn as subplots. Legend will be drawn in each pie plots by default, specify `legend=False` to hide it.

```
df = pd.DataFrame(3 * np.random.rand(4, 2), index=['a', 'b', 'c', 'd'], columns=['x', 'y'])
df.plot(kind='pie', subplots=True) 
```

![df_pie_plot](https://cloud.githubusercontent.com/assets/1696302/2810159/5691fc76-cda1-11e3-9532-43a7ebafc3e5.png)
### Plotting with Options

You can use `labels` and `colors` keywords to specify labels and colors of each wedges (Cannot use `label` and `color`, because of matplotlib's specification). If you want to hide wedge labels, specify `labels=None`.  If `fontsize` is specified, the value will be applied to wedge labels. Also, other keywords supported by `matplotlib.pyplot.pie` can be used.

```
series.plot(kind='pie', labels=['AA', 'BB', 'CC', 'DD'], colors=['r', 'g', 'b', 'c'],
               autopct='%.2f', fontsize=20)
```

![series_pie_plot_options](https://cloud.githubusercontent.com/assets/1696302/2810160/5b5d8f72-cda1-11e3-87b0-de164b887c75.png)
