### PR TITLE
ERR: Add check for iterators when creating DataFrame, fixes #5357

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -178,6 +178,8 @@ API Changes
 - change ``AssertionError`` to ``TypeError`` for invalid types passed to ``concat`` (:issue:`6583`)
 - Add :class:`~pandas.io.parsers.ParserWarning` class for fallback and option
   validation warnings in :func:`read_csv`/:func:`read_table` (:issue:`6607`)
+- Raise a ``TypeError`` when ``DataFrame`` is passed an iterator as the
+  ``data`` argument (:issue:`5357`)
 
 Deprecations
 ~~~~~~~~~~~~

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -253,6 +253,8 @@ class DataFrame(NDFrame):
             else:
                 mgr = self._init_ndarray(data, index, columns, dtype=dtype,
                                          copy=copy)
+        elif isinstance(data, collections.Iterator):
+            raise TypeError("data argument can't be an iterator")
         else:
             try:
                 arr = np.array(data, dtype=dtype, copy=copy)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3135,6 +3135,10 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         expected = DataFrame([[np.nan, 1], [1, 0]])
         assert_frame_equal(df, expected)
 
+    def test_constructor_iterator_failure(self):
+        with assertRaisesRegexp(TypeError, 'iterator'):
+            df = DataFrame(iter([1, 2, 3]))
+
     def test_constructor_column_duplicates(self):
         # it works! #2079
         df = DataFrame([[8, 5]], columns=['a', 'a'])


### PR DESCRIPTION
This is a fix for #5357, and adds a more helpful error message when trying to use an iterator as the `data` argument for a `DataFrame`. I've added the type check for iterators in the final else clause where all the valid options have already been exhausted, so it shouldn't interfere with any valid cases like passing a list of iterators.
