### PR TITLE
TST: test_frame/test_sum not comparing correctly on smaller sized dtypes (GH6982)

### DIFF
--- a/pandas/src/testing.pyx
+++ b/pandas/src/testing.pyx
@@ -121,7 +121,7 @@ cpdef assert_almost_equal(a, b, bint check_less_precise=False):
             dtype_a = np.dtype(type(a))
             dtype_b = np.dtype(type(b))
             if dtype_a.kind == 'f' and dtype_b == 'f':
-                if dtype_a.itemsize <= 4 and dtype_b.itemsize <= 4:
+                if dtype_a.itemsize <= 4 or dtype_b.itemsize <= 4:
                     decimal = 3
 
         if np.isinf(a):


### PR DESCRIPTION
closes #6982
