### PR TITLE
SQL: bunch of fixes based on the old tests

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -130,7 +130,7 @@ def tquery(sql, con, cur=None, params=None, flavor='sqlite'):
     """
     warnings.warn(
         "tquery is depreciated, and will be removed in future versions",
-        DeprecationWarning)
+        FutureWarning)
 
     pandas_sql = pandasSQL_builder(con, flavor=flavor)
     args = _convert_params(sql, params)
@@ -163,7 +163,7 @@ def uquery(sql, con, cur=None, params=None, engine=None, flavor='sqlite'):
     """
     warnings.warn(
         "uquery is depreciated, and will be removed in future versions",
-        DeprecationWarning)
+        FutureWarning)
     pandas_sql = pandasSQL_builder(con, flavor=flavor)
     args = _convert_params(sql, params)
     return pandas_sql.uquery(*args)
@@ -212,7 +212,7 @@ def read_sql_table(table_name, con, meta=None, index_col=None,
     --------
     read_sql_query : Read SQL query into a DataFrame.
     read_sql
-    
+
 
     """
     pandas_sql = PandasSQLAlchemy(con, meta=meta)
@@ -322,8 +322,8 @@ def read_sql(sql, con, index_col=None, flavor='sqlite', coerce_float=True,
     Notes
     -----
     This function is a convenience wrapper around ``read_sql_table`` and
-    ``read_sql_query`` (and for backward compatibility) and will delegate 
-    to the specific function depending on the provided input (database 
+    ``read_sql_query`` (and for backward compatibility) and will delegate
+    to the specific function depending on the provided input (database
     table name or sql query).
 
     See also
@@ -423,13 +423,12 @@ def pandasSQL_builder(con, flavor=None, meta=None):
         if isinstance(con, sqlalchemy.engine.Engine):
             return PandasSQLAlchemy(con, meta=meta)
         else:
-            warnings.warn(
-                """Not an SQLAlchemy engine,
-                  attempting to use as legacy DBAPI connection""")
+            warnings.warn("Not an SQLAlchemy engine, "
+                          "attempting to use as legacy DBAPI connection")
             if flavor is None:
                 raise ValueError(
-                    """PandasSQL must be created with an SQLAlchemy engine
-                    or a DBAPI2 connection and SQL flavour""")
+                    "PandasSQL must be created with an SQLAlchemy engine "
+                    "or a DBAPI2 connection and SQL flavor")
             else:
                 return PandasSQLLegacy(con, flavor)
 
@@ -1006,7 +1005,7 @@ class PandasSQLLegacy(PandasSQL):
             fail: If table exists, do nothing.
             replace: If table exists, drop it, recreate it, and insert data.
             append: If table exists, insert data. Create if does not exist.
-        
+
         """
         table = PandasSQLTableLegacy(
             name, self, frame=frame, index=index, if_exists=if_exists,
@@ -1041,20 +1040,20 @@ def get_schema(frame, name, con, flavor='sqlite'):
     name: name of SQL table
     con: an open SQL database connection object
     engine: an SQLAlchemy engine - replaces connection and flavor
-    flavor: {'sqlite', 'mysql', 'postgres'}, default 'sqlite'
+    flavor: {'sqlite', 'mysql'}, default 'sqlite'
 
     """
-    warnings.warn(
-        "get_schema is depreciated", DeprecationWarning)
+    warnings.warn("get_schema is depreciated", FutureWarning)
+
     pandas_sql = pandasSQL_builder(con=con, flavor=flavor)
     return pandas_sql._create_sql_schema(frame, name)
+
 
 
 def read_frame(*args, **kwargs):
     """DEPRECIATED - use read_sql
     """
-    warnings.warn(
-        "read_frame is depreciated, use read_sql", DeprecationWarning)
+    warnings.warn("read_frame is depreciated, use read_sql", FutureWarning)
     return read_sql(*args, **kwargs)
 
 
@@ -1092,7 +1091,7 @@ def write_frame(frame, name, con, flavor='sqlite', if_exists='fail', **kwargs):
     pandas.DataFrame.to_sql
 
     """
-    warnings.warn("write_frame is depreciated, use to_sql", DeprecationWarning)
+    warnings.warn("write_frame is depreciated, use to_sql", FutureWarning)
 
     # for backwards compatibility, set index=False when not specified
     index = kwargs.pop('index', False)

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -336,8 +336,9 @@ class _TestSQLApi(PandasSQLTest):
         self._check_iris_loaded_frame(iris_frame)
 
     def test_legacy_read_frame(self):
-        iris_frame = sql.read_frame(
-            "SELECT * FROM iris", self.conn, flavor='sqlite')
+        with tm.assert_produces_warning(FutureWarning):
+            iris_frame = sql.read_frame(
+                "SELECT * FROM iris", self.conn, flavor='sqlite')
         self._check_iris_loaded_frame(iris_frame)
 
     def test_to_sql(self):
@@ -402,8 +403,10 @@ class _TestSQLApi(PandasSQLTest):
     def test_legacy_write_frame(self):
         # Assume that functionality is already tested above so just do
         # quick check that it basically works
-        sql.write_frame(self.test_frame1, 'test_frame_legacy', self.conn,
-                        flavor='sqlite')
+        with tm.assert_produces_warning(FutureWarning):
+            sql.write_frame(self.test_frame1, 'test_frame_legacy', self.conn,
+                            flavor='sqlite')
+
         self.assertTrue(
             sql.has_table('test_frame_legacy', self.conn, flavor='sqlite'),
             'Table not written to DB')
@@ -431,10 +434,17 @@ class _TestSQLApi(PandasSQLTest):
         tm.equalContents(row, [5.1, 3.5, 1.4, 0.2, 'Iris-setosa'])
 
     def test_tquery(self):
-        iris_results = sql.tquery(
-            "SELECT * FROM iris", con=self.conn, flavor='sqlite')
+        with tm.assert_produces_warning(FutureWarning):
+            iris_results = sql.tquery(
+                "SELECT * FROM iris", con=self.conn, flavor='sqlite')
         row = iris_results[0]
         tm.equalContents(row, [5.1, 3.5, 1.4, 0.2, 'Iris-setosa'])
+
+    def test_uquery(self):
+        with tm.assert_produces_warning(FutureWarning):
+            rows = sql.uquery(
+                "SELECT * FROM iris LIMIT 1", con=self.conn, flavor='sqlite')
+        self.assertEqual(rows, -1)
 
     def test_date_parsing(self):
         # Test date parsing in read_sq

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -296,11 +296,6 @@ class PandasSQLTest(unittest.TestCase):
         row = iris_results.fetchone()
         tm.equalContents(row, [5.1, 3.5, 1.4, 0.2, 'Iris-setosa'])
 
-    def _tquery(self):
-        iris_results = self.pandasSQL.tquery("SELECT * FROM iris")
-        row = iris_results[0]
-        tm.equalContents(row, [5.1, 3.5, 1.4, 0.2, 'Iris-setosa'])
-
 
 #------------------------------------------------------------------------------
 #--- Testing the public API
@@ -432,19 +427,6 @@ class _TestSQLApi(PandasSQLTest):
             "SELECT * FROM iris", con=self.conn, flavor='sqlite')
         row = iris_results.fetchone()
         tm.equalContents(row, [5.1, 3.5, 1.4, 0.2, 'Iris-setosa'])
-
-    def test_tquery(self):
-        with tm.assert_produces_warning(FutureWarning):
-            iris_results = sql.tquery(
-                "SELECT * FROM iris", con=self.conn, flavor='sqlite')
-        row = iris_results[0]
-        tm.equalContents(row, [5.1, 3.5, 1.4, 0.2, 'Iris-setosa'])
-
-    def test_uquery(self):
-        with tm.assert_produces_warning(FutureWarning):
-            rows = sql.uquery(
-                "SELECT * FROM iris LIMIT 1", con=self.conn, flavor='sqlite')
-        self.assertEqual(rows, -1)
 
     def test_date_parsing(self):
         # Test date parsing in read_sq
@@ -693,6 +675,17 @@ class TestSQLLegacyApi(_TestSQLApi):
         # without providing a connection object (available for backwards comp)
         create_sql = sql.get_schema(self.test_frame1, 'test', 'sqlite')
         self.assert_('CREATE' in create_sql)
+
+    def test_tquery(self):
+        with tm.assert_produces_warning(FutureWarning):
+            iris_results = sql.tquery("SELECT * FROM iris", con=self.conn)
+        row = iris_results[0]
+        tm.equalContents(row, [5.1, 3.5, 1.4, 0.2, 'Iris-setosa'])
+
+    def test_uquery(self):
+        with tm.assert_produces_warning(FutureWarning):
+            rows = sql.uquery("SELECT * FROM iris LIMIT 1", con=self.conn)
+        self.assertEqual(rows, -1)
 
 
 #------------------------------------------------------------------------------
@@ -1062,9 +1055,6 @@ class TestSQLiteLegacy(PandasSQLTest):
 
     def test_execute_sql(self):
         self._execute_sql()
-
-    def test_tquery(self):
-        self._tquery()
 
 
 class TestMySQLLegacy(TestSQLiteLegacy):

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -20,13 +20,18 @@ import unittest
 import sqlite3
 import csv
 import os
+import sys
 
 import nose
+import warnings
 import numpy as np
 
-from pandas import DataFrame, Series, MultiIndex
-from pandas.compat import range
-#from pandas.core.datetools import format as date_format
+from datetime import datetime
+
+from pandas import DataFrame, Series, Index, MultiIndex, isnull
+import pandas.compat as compat
+from pandas.compat import StringIO, range, lrange
+from pandas.core.datetools import format as date_format
 
 import pandas.io.sql as sql
 import pandas.util.testing as tm
@@ -1103,6 +1108,604 @@ class TestMySQLLegacy(TestSQLiteLegacy):
             c.execute('DROP TABLE %s' % table[0])
         self.conn.commit()
         self.conn.close()
+
+
+#------------------------------------------------------------------------------
+#--- Old tests from 0.13.1 (before refactor using sqlalchemy)
+
+
+_formatters = {
+    datetime: lambda dt: "'%s'" % date_format(dt),
+    str: lambda x: "'%s'" % x,
+    np.str_: lambda x: "'%s'" % x,
+    compat.text_type: lambda x: "'%s'" % x,
+    compat.binary_type: lambda x: "'%s'" % x,
+    float: lambda x: "%.8f" % x,
+    int: lambda x: "%s" % x,
+    type(None): lambda x: "NULL",
+    np.float64: lambda x: "%.10f" % x,
+    bool: lambda x: "'%s'" % x,
+}
+
+def format_query(sql, *args):
+    """
+
+    """
+    processed_args = []
+    for arg in args:
+        if isinstance(arg, float) and isnull(arg):
+            arg = None
+
+        formatter = _formatters[type(arg)]
+        processed_args.append(formatter(arg))
+
+    return sql % tuple(processed_args)
+
+def _skip_if_no_pymysql():
+    try:
+        import pymysql
+    except ImportError:
+        raise nose.SkipTest('pymysql not installed, skipping')
+
+
+class TestXSQLite(tm.TestCase):
+
+    def setUp(self):
+        self.db = sqlite3.connect(':memory:')
+
+    def test_basic(self):
+        frame = tm.makeTimeDataFrame()
+        self._check_roundtrip(frame)
+
+    def test_write_row_by_row(self):
+
+        #FIXME: for now skip test
+        raise nose.SkipTest('execute not supporting cursor object')
+
+        frame = tm.makeTimeDataFrame()
+        frame.ix[0, 0] = np.nan
+        create_sql = sql.get_schema(frame, 'test', 'sqlite')
+        cur = self.db.cursor()
+        cur.execute(create_sql)
+
+        cur = self.db.cursor()
+
+        ins = "INSERT INTO test VALUES (%s, %s, %s, %s)"
+        for idx, row in frame.iterrows():
+            fmt_sql = format_query(ins, *row)
+            sql.tquery(fmt_sql, cur=cur)
+
+        self.db.commit()
+
+        result = sql.read_frame("select * from test", con=self.db)
+        result.index = frame.index
+        tm.assert_frame_equal(result, frame)
+
+    def test_execute(self):
+        frame = tm.makeTimeDataFrame()
+        create_sql = sql.get_schema(frame, 'test', 'sqlite')
+        cur = self.db.cursor()
+        cur.execute(create_sql)
+        ins = "INSERT INTO test VALUES (?, ?, ?, ?)"
+
+        row = frame.ix[0]
+        sql.execute(ins, self.db, params=tuple(row))
+        self.db.commit()
+
+        result = sql.read_frame("select * from test", self.db)
+        result.index = frame.index[:1]
+        tm.assert_frame_equal(result, frame[:1])
+
+    def test_schema(self):
+        frame = tm.makeTimeDataFrame()
+        create_sql = sql.get_schema(frame, 'test', 'sqlite')
+        lines = create_sql.splitlines()
+        for l in lines:
+            tokens = l.split(' ')
+            if len(tokens) == 2 and tokens[0] == 'A':
+                self.assert_(tokens[1] == 'DATETIME')
+
+        frame = tm.makeTimeDataFrame()
+        create_sql = sql.get_schema(frame, 'test', 'sqlite', keys=['A', 'B'],)
+        lines = create_sql.splitlines()
+        self.assert_('PRIMARY KEY (A,B)' in create_sql)
+        cur = self.db.cursor()
+        cur.execute(create_sql)
+
+    def test_execute_fail(self):
+        create_sql = """
+        CREATE TABLE test
+        (
+        a TEXT,
+        b TEXT,
+        c REAL,
+        PRIMARY KEY (a, b)
+        );
+        """
+        cur = self.db.cursor()
+        cur.execute(create_sql)
+
+        sql.execute('INSERT INTO test VALUES("foo", "bar", 1.234)', self.db)
+        sql.execute('INSERT INTO test VALUES("foo", "baz", 2.567)', self.db)
+
+        try:
+            sys.stdout = StringIO()
+            self.assertRaises(Exception, sql.execute,
+                              'INSERT INTO test VALUES("foo", "bar", 7)',
+                              self.db)
+        finally:
+            sys.stdout = sys.__stdout__
+
+    def test_execute_closed_connection(self):
+        create_sql = """
+        CREATE TABLE test
+        (
+        a TEXT,
+        b TEXT,
+        c REAL,
+        PRIMARY KEY (a, b)
+        );
+        """
+        cur = self.db.cursor()
+        cur.execute(create_sql)
+
+        sql.execute('INSERT INTO test VALUES("foo", "bar", 1.234)', self.db)
+        self.db.close()
+        try:
+            sys.stdout = StringIO()
+            self.assertRaises(Exception, sql.tquery, "select * from test",
+                              con=self.db)
+        finally:
+            sys.stdout = sys.__stdout__
+
+    def test_na_roundtrip(self):
+        pass
+
+    def _check_roundtrip(self, frame):
+        sql.write_frame(frame, name='test_table', con=self.db)
+        result = sql.read_frame("select * from test_table", self.db)
+
+        # HACK! Change this once indexes are handled properly.
+        result.index = frame.index
+
+        expected = frame
+        tm.assert_frame_equal(result, expected)
+
+        frame['txt'] = ['a'] * len(frame)
+        frame2 = frame.copy()
+        frame2['Idx'] = Index(lrange(len(frame2))) + 10
+        sql.write_frame(frame2, name='test_table2', con=self.db)
+        result = sql.read_frame("select * from test_table2", self.db,
+                                index_col='Idx')
+        expected = frame.copy()
+        expected.index = Index(lrange(len(frame2))) + 10
+        expected.index.name = 'Idx'
+        print(expected.index.names)
+        print(result.index.names)
+        tm.assert_frame_equal(expected, result)
+
+    def test_tquery(self):
+        frame = tm.makeTimeDataFrame()
+        sql.write_frame(frame, name='test_table', con=self.db)
+        result = sql.tquery("select A from test_table", self.db)
+        expected = frame.A
+        result = Series(result, frame.index)
+        tm.assert_series_equal(result, expected)
+
+        try:
+            sys.stdout = StringIO()
+            self.assertRaises(sql.DatabaseError, sql.tquery,
+                              'select * from blah', con=self.db)
+
+            self.assertRaises(sql.DatabaseError, sql.tquery,
+                              'select * from blah', con=self.db, retry=True)
+        finally:
+            sys.stdout = sys.__stdout__
+
+    def test_uquery(self):
+        frame = tm.makeTimeDataFrame()
+        sql.write_frame(frame, name='test_table', con=self.db)
+        stmt = 'INSERT INTO test_table VALUES(2.314, -123.1, 1.234, 2.3)'
+        self.assertEqual(sql.uquery(stmt, con=self.db), 1)
+
+        try:
+            sys.stdout = StringIO()
+
+            self.assertRaises(sql.DatabaseError, sql.tquery,
+                              'insert into blah values (1)', con=self.db)
+
+            self.assertRaises(sql.DatabaseError, sql.tquery,
+                              'insert into blah values (1)', con=self.db,
+                              retry=True)
+        finally:
+            sys.stdout = sys.__stdout__
+
+    def test_keyword_as_column_names(self):
+        '''
+        '''
+        df = DataFrame({'From':np.ones(5)})
+        sql.write_frame(df, con = self.db, name = 'testkeywords')
+
+    def test_onecolumn_of_integer(self):
+        # GH 3628
+        # a column_of_integers dataframe should transfer well to sql
+
+        mono_df=DataFrame([1 , 2], columns=['c0'])
+        sql.write_frame(mono_df, con = self.db, name = 'mono_df')
+        # computing the sum via sql
+        con_x=self.db
+        the_sum=sum([my_c0[0] for  my_c0 in con_x.execute("select * from mono_df")])
+        # it should not fail, and gives 3 ( Issue #3628 )
+        self.assertEqual(the_sum , 3)
+
+        result = sql.read_frame("select * from mono_df",con_x)
+        tm.assert_frame_equal(result,mono_df)
+
+    def test_if_exists(self):
+        df_if_exists_1 = DataFrame({'col1': [1, 2], 'col2': ['A', 'B']})
+        df_if_exists_2 = DataFrame({'col1': [3, 4, 5], 'col2': ['C', 'D', 'E']})
+        table_name = 'table_if_exists'
+        sql_select = "SELECT * FROM %s" % table_name
+
+        def clean_up(test_table_to_drop):
+            """
+            Drops tables created from individual tests
+            so no dependencies arise from sequential tests
+            """
+            if sql.table_exists(test_table_to_drop, self.db, flavor='sqlite'):
+                cur = self.db.cursor()
+                cur.execute("DROP TABLE %s" % test_table_to_drop)
+                cur.close()
+
+        # test if invalid value for if_exists raises appropriate error
+        self.assertRaises(ValueError,
+                          sql.write_frame,
+                          frame=df_if_exists_1,
+                          con=self.db,
+                          name=table_name,
+                          flavor='sqlite',
+                          if_exists='notvalidvalue')
+        clean_up(table_name)
+
+        # test if_exists='fail'
+        sql.write_frame(frame=df_if_exists_1, con=self.db, name=table_name,
+                        flavor='sqlite', if_exists='fail')
+        self.assertRaises(ValueError,
+                          sql.write_frame,
+                          frame=df_if_exists_1,
+                          con=self.db,
+                          name=table_name,
+                          flavor='sqlite',
+                          if_exists='fail')
+
+        # test if_exists='replace'
+        sql.write_frame(frame=df_if_exists_1, con=self.db, name=table_name,
+                        flavor='sqlite', if_exists='replace')
+        self.assertEqual(sql.tquery(sql_select, con=self.db),
+                         [(1, 'A'), (2, 'B')])
+        sql.write_frame(frame=df_if_exists_2, con=self.db, name=table_name,
+                        flavor='sqlite', if_exists='replace')
+        self.assertEqual(sql.tquery(sql_select, con=self.db),
+                         [(3, 'C'), (4, 'D'), (5, 'E')])
+        clean_up(table_name)
+
+        # test if_exists='append'
+        sql.write_frame(frame=df_if_exists_1, con=self.db, name=table_name,
+                        flavor='sqlite', if_exists='fail')
+        self.assertEqual(sql.tquery(sql_select, con=self.db),
+                         [(1, 'A'), (2, 'B')])
+        sql.write_frame(frame=df_if_exists_2, con=self.db, name=table_name,
+                        flavor='sqlite', if_exists='append')
+        self.assertEqual(sql.tquery(sql_select, con=self.db),
+                         [(1, 'A'), (2, 'B'), (3, 'C'), (4, 'D'), (5, 'E')])
+        clean_up(table_name)
+
+
+class TestXMySQL(tm.TestCase):
+
+    def setUp(self):
+        _skip_if_no_pymysql()
+        import pymysql
+        try:
+            # Try Travis defaults.
+            # No real user should allow root access with a blank password.
+            self.db = pymysql.connect(host='localhost', user='root', passwd='',
+                                    db='pandas_nosetest')
+        except:
+            pass
+        else:
+            return
+        try:
+            self.db = pymysql.connect(read_default_group='pandas')
+        except pymysql.ProgrammingError as e:
+            raise nose.SkipTest(
+                "Create a group of connection parameters under the heading "
+                "[pandas] in your system's mysql default file, "
+                "typically located at ~/.my.cnf or /etc/.my.cnf. ")
+        except pymysql.Error as e:
+            raise nose.SkipTest(
+                "Cannot connect to database. "
+                "Create a group of connection parameters under the heading "
+                "[pandas] in your system's mysql default file, "
+                "typically located at ~/.my.cnf or /etc/.my.cnf. ")
+
+    def test_basic(self):
+        _skip_if_no_pymysql()
+        frame = tm.makeTimeDataFrame()
+        self._check_roundtrip(frame)
+
+    def test_write_row_by_row(self):
+
+        #FIXME: for now skip test
+        raise nose.SkipTest('execute not supporting cursor object')
+
+        _skip_if_no_pymysql()
+        frame = tm.makeTimeDataFrame()
+        frame.ix[0, 0] = np.nan
+        drop_sql = "DROP TABLE IF EXISTS test"
+        create_sql = sql.get_schema(frame, 'test', 'mysql')
+        cur = self.db.cursor()
+        cur.execute(drop_sql)
+        cur.execute(create_sql)
+        ins = "INSERT INTO test VALUES (%s, %s, %s, %s)"
+        for idx, row in frame.iterrows():
+            fmt_sql = format_query(ins, *row)
+            sql.tquery(fmt_sql, cur=cur)
+
+        self.db.commit()
+
+        result = sql.read_frame("select * from test", con=self.db)
+        result.index = frame.index
+        tm.assert_frame_equal(result, frame)
+
+    def test_execute(self):
+        _skip_if_no_pymysql()
+        frame = tm.makeTimeDataFrame()
+        drop_sql = "DROP TABLE IF EXISTS test"
+        create_sql = sql.get_schema(frame, 'test', 'mysql')
+        cur = self.db.cursor()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "Unknown table.*")
+            cur.execute(drop_sql)
+        cur.execute(create_sql)
+        ins = "INSERT INTO test VALUES (%s, %s, %s, %s)"
+
+        row = frame.ix[0].values.tolist()
+        sql.execute(ins, self.db, params=tuple(row))
+        self.db.commit()
+
+        result = sql.read_frame("select * from test", self.db)
+        result.index = frame.index[:1]
+        tm.assert_frame_equal(result, frame[:1])
+
+    def test_schema(self):
+        _skip_if_no_pymysql()
+        frame = tm.makeTimeDataFrame()
+        create_sql = sql.get_schema(frame, 'test', 'mysql')
+        lines = create_sql.splitlines()
+        for l in lines:
+            tokens = l.split(' ')
+            if len(tokens) == 2 and tokens[0] == 'A':
+                self.assert_(tokens[1] == 'DATETIME')
+
+        frame = tm.makeTimeDataFrame()
+        drop_sql = "DROP TABLE IF EXISTS test"
+        create_sql = sql.get_schema(frame, 'test', 'mysql', keys=['A', 'B'],)
+        lines = create_sql.splitlines()
+        self.assert_('PRIMARY KEY (A,B)' in create_sql)
+        cur = self.db.cursor()
+        cur.execute(drop_sql)
+        cur.execute(create_sql)
+
+    def test_execute_fail(self):
+        _skip_if_no_pymysql()
+        drop_sql = "DROP TABLE IF EXISTS test"
+        create_sql = """
+        CREATE TABLE test
+        (
+        a TEXT,
+        b TEXT,
+        c REAL,
+        PRIMARY KEY (a(5), b(5))
+        );
+        """
+        cur = self.db.cursor()
+        cur.execute(drop_sql)
+        cur.execute(create_sql)
+
+        sql.execute('INSERT INTO test VALUES("foo", "bar", 1.234)', self.db)
+        sql.execute('INSERT INTO test VALUES("foo", "baz", 2.567)', self.db)
+
+        try:
+            sys.stdout = StringIO()
+            self.assertRaises(Exception, sql.execute,
+                              'INSERT INTO test VALUES("foo", "bar", 7)',
+                              self.db)
+        finally:
+            sys.stdout = sys.__stdout__
+
+    def test_execute_closed_connection(self):
+        _skip_if_no_pymysql()
+        drop_sql = "DROP TABLE IF EXISTS test"
+        create_sql = """
+        CREATE TABLE test
+        (
+        a TEXT,
+        b TEXT,
+        c REAL,
+        PRIMARY KEY (a(5), b(5))
+        );
+        """
+        cur = self.db.cursor()
+        cur.execute(drop_sql)
+        cur.execute(create_sql)
+
+        sql.execute('INSERT INTO test VALUES("foo", "bar", 1.234)', self.db)
+        self.db.close()
+        try:
+            sys.stdout = StringIO()
+            self.assertRaises(Exception, sql.tquery, "select * from test",
+                              con=self.db)
+        finally:
+            sys.stdout = sys.__stdout__
+
+    def test_na_roundtrip(self):
+        _skip_if_no_pymysql()
+        pass
+
+    def _check_roundtrip(self, frame):
+        _skip_if_no_pymysql()
+        drop_sql = "DROP TABLE IF EXISTS test_table"
+        cur = self.db.cursor()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "Unknown table.*")
+            cur.execute(drop_sql)
+        sql.write_frame(frame, name='test_table', con=self.db, flavor='mysql')
+        result = sql.read_frame("select * from test_table", self.db)
+
+        # HACK! Change this once indexes are handled properly.
+        result.index = frame.index
+        result.index.name = frame.index.name
+
+        expected = frame
+        tm.assert_frame_equal(result, expected)
+
+        frame['txt'] = ['a'] * len(frame)
+        frame2 = frame.copy()
+        index = Index(lrange(len(frame2))) + 10
+        frame2['Idx'] = index
+        drop_sql = "DROP TABLE IF EXISTS test_table2"
+        cur = self.db.cursor()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "Unknown table.*")
+            cur.execute(drop_sql)
+        sql.write_frame(frame2, name='test_table2', con=self.db, flavor='mysql')
+        result = sql.read_frame("select * from test_table2", self.db,
+                                index_col='Idx')
+        expected = frame.copy()
+
+        # HACK! Change this once indexes are handled properly.
+        expected.index = index
+        expected.index.names = result.index.names
+        tm.assert_frame_equal(expected, result)
+
+    def test_tquery(self):
+        try:
+            import pymysql
+        except ImportError:
+            raise nose.SkipTest("no pymysql")
+        frame = tm.makeTimeDataFrame()
+        drop_sql = "DROP TABLE IF EXISTS test_table"
+        cur = self.db.cursor()
+        cur.execute(drop_sql)
+        sql.write_frame(frame, name='test_table', con=self.db, flavor='mysql')
+        result = sql.tquery("select A from test_table", self.db)
+        expected = frame.A
+        result = Series(result, frame.index)
+        tm.assert_series_equal(result, expected)
+
+        try:
+            sys.stdout = StringIO()
+            self.assertRaises(sql.DatabaseError, sql.tquery,
+                              'select * from blah', con=self.db)
+
+            self.assertRaises(sql.DatabaseError, sql.tquery,
+                              'select * from blah', con=self.db, retry=True)
+        finally:
+            sys.stdout = sys.__stdout__
+
+    def test_uquery(self):
+        try:
+            import pymysql
+        except ImportError:
+            raise nose.SkipTest("no pymysql")
+        frame = tm.makeTimeDataFrame()
+        drop_sql = "DROP TABLE IF EXISTS test_table"
+        cur = self.db.cursor()
+        cur.execute(drop_sql)
+        sql.write_frame(frame, name='test_table', con=self.db, flavor='mysql')
+        stmt = 'INSERT INTO test_table VALUES(2.314, -123.1, 1.234, 2.3)'
+        self.assertEqual(sql.uquery(stmt, con=self.db), 1)
+
+        try:
+            sys.stdout = StringIO()
+
+            self.assertRaises(sql.DatabaseError, sql.tquery,
+                              'insert into blah values (1)', con=self.db)
+
+            self.assertRaises(sql.DatabaseError, sql.tquery,
+                              'insert into blah values (1)', con=self.db,
+                              retry=True)
+        finally:
+            sys.stdout = sys.__stdout__
+
+    def test_keyword_as_column_names(self):
+        '''
+        '''
+        _skip_if_no_pymysql()
+        df = DataFrame({'From':np.ones(5)})
+        sql.write_frame(df, con = self.db, name = 'testkeywords',
+                        if_exists='replace', flavor='mysql')
+
+    def test_if_exists(self):
+        _skip_if_no_pymysql()
+        df_if_exists_1 = DataFrame({'col1': [1, 2], 'col2': ['A', 'B']})
+        df_if_exists_2 = DataFrame({'col1': [3, 4, 5], 'col2': ['C', 'D', 'E']})
+        table_name = 'table_if_exists'
+        sql_select = "SELECT * FROM %s" % table_name
+
+        def clean_up(test_table_to_drop):
+            """
+            Drops tables created from individual tests
+            so no dependencies arise from sequential tests
+            """
+            if sql.table_exists(test_table_to_drop, self.db, flavor='mysql'):
+                cur = self.db.cursor()
+                cur.execute("DROP TABLE %s" % test_table_to_drop)
+                cur.close()
+
+        # test if invalid value for if_exists raises appropriate error
+        self.assertRaises(ValueError,
+                          sql.write_frame,
+                          frame=df_if_exists_1,
+                          con=self.db,
+                          name=table_name,
+                          flavor='mysql',
+                          if_exists='notvalidvalue')
+        clean_up(table_name)
+
+        # test if_exists='fail'
+        sql.write_frame(frame=df_if_exists_1, con=self.db, name=table_name,
+                        flavor='mysql', if_exists='fail')
+        self.assertRaises(ValueError,
+                          sql.write_frame,
+                          frame=df_if_exists_1,
+                          con=self.db,
+                          name=table_name,
+                          flavor='mysql',
+                          if_exists='fail')
+
+        # test if_exists='replace'
+        sql.write_frame(frame=df_if_exists_1, con=self.db, name=table_name,
+                        flavor='mysql', if_exists='replace')
+        self.assertEqual(sql.tquery(sql_select, con=self.db),
+                         [(1, 'A'), (2, 'B')])
+        sql.write_frame(frame=df_if_exists_2, con=self.db, name=table_name,
+                        flavor='mysql', if_exists='replace')
+        self.assertEqual(sql.tquery(sql_select, con=self.db),
+                         [(3, 'C'), (4, 'D'), (5, 'E')])
+        clean_up(table_name)
+
+        # test if_exists='append'
+        sql.write_frame(frame=df_if_exists_1, con=self.db, name=table_name,
+                        flavor='mysql', if_exists='fail')
+        self.assertEqual(sql.tquery(sql_select, con=self.db),
+                         [(1, 'A'), (2, 'B')])
+        sql.write_frame(frame=df_if_exists_2, con=self.db, name=table_name,
+                        flavor='mysql', if_exists='append')
+        self.assertEqual(sql.tquery(sql_select, con=self.db),
+                         [(1, 'A'), (2, 'B'), (3, 'C'), (4, 'D'), (5, 'E')])
+        clean_up(table_name)
 
 
 if __name__ == '__main__':

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -1159,9 +1159,6 @@ class TestXSQLite(tm.TestCase):
 
     def test_write_row_by_row(self):
 
-        #FIXME: for now skip test
-        raise nose.SkipTest('execute not supporting cursor object')
-
         frame = tm.makeTimeDataFrame()
         frame.ix[0, 0] = np.nan
         create_sql = sql.get_schema(frame, 'test', 'sqlite')
@@ -1435,9 +1432,6 @@ class TestXMySQL(tm.TestCase):
         self._check_roundtrip(frame)
 
     def test_write_row_by_row(self):
-
-        #FIXME: for now skip test
-        raise nose.SkipTest('execute not supporting cursor object')
 
         _skip_if_no_pymysql()
         frame = tm.makeTimeDataFrame()

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -565,6 +565,11 @@ class _TestSQLApi(PandasSQLTest):
         sql.to_sql(df, "test_frame_integer_col_names", self.conn,
                    if_exists='replace')
 
+    def test_get_schema(self):
+        create_sql = sql.get_schema(self.test_frame1, 'test', 'sqlite',
+                                    con=self.conn)
+        self.assert_('CREATE' in create_sql)
+
 
 class TestSQLApi(_TestSQLApi):
     """
@@ -683,6 +688,11 @@ class TestSQLLegacyApi(_TestSQLApi):
         with tm.assert_produces_warning():
             sql.to_sql(df, "test_frame3_legacy", self.conn,
                        flavor="sqlite", index=False)
+
+    def test_get_schema2(self):
+        # without providing a connection object (available for backwards comp)
+        create_sql = sql.get_schema(self.test_frame1, 'test', 'sqlite')
+        self.assert_('CREATE' in create_sql)
 
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Some first fixes based on running the old sql tests (from 0.13.1 tag)
- fixed `get_schema` (and adapted is signature back to how it was for 0.13.1). For this I added back the old function, as this functionality was not possible with the refactored class based approach (for those you always have to provide a connection object or engine, this was not necessary for `get_schema`)
- `table_exists` seems to be renamed to `has_table`? I don't know why (and we should also decide if we expose this as a public function), but added it back for now as an alias.

All tests from the old test suite are now running with the new code (for sqlite, not yet tested for mysql), except for the following issues:
- `tquery` had a  `retry` and `cur` arguments (which were at least used in the tests), but not that simple to put back with the new implementation
- OperationalError is changed to DatabaseError

@jreback I also changed the DeprecationWarnings to FutureWarnings (I am right this is the canonical way to raise deprecation warnings in pandas?) and catched them in the tests. I don't know if this solves #6984 for the sql warnings?
