### PR TITLE
CLN: drop internals._invert_reordering in favour of lib.get_reverse_indexer

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -295,6 +295,8 @@ Improvements to existing features
 - ``read_excel`` can now read milliseconds in Excel dates and times with xlrd >= 0.9.3. (:issue:`5945`)
 - ``pivot_table`` can now accept ``Grouper`` by ``index`` and ``columns`` keywords (:issue:`6913`)
 - Improved performance of compatible pickles (:issue:`6899`)
+- Refactor Block classes removing `Block.items` attributes to avoid duplication
+  in item handling (:issue:`6745`, :issue:`6988`).
 
 .. _release.bug_fixes-0.14.0:
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -27,6 +27,12 @@ users upgrade to this version.
 
 - :ref:`Bug Fixes <release.bug_fixes-0.14.0>`
 
+.. warning::
+
+   In 0.14.0 all ``NDFrame`` based containers have underwent significant internal refactoring.  Before that each block of
+   homogeneous data had its own labels and extra care was necessary to keep those in sync with parent container's labels.
+   As stated, the refactoring is internal and no publicly visible changes should happen.
+
 .. _whatsnew_0140.api:
 
 API changes

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -495,6 +495,17 @@ def fast_zip(list ndarrays):
     return result
 
 def get_reverse_indexer(ndarray[int64_t] indexer, Py_ssize_t length):
+    """
+    Reverse indexing operation.
+
+    Given `indexer`, make `indexer_inv` of it, such that::
+
+        indexer_inv[indexer[x]] = x
+
+    .. note:: If indexer is not unique, only first occurrence is accounted.
+
+    """
+
     cdef:
         Py_ssize_t i, n = len(indexer)
         ndarray[int64_t] rev_indexer


### PR DESCRIPTION
I've implemented the former while refactoring BlockManager (#6745) because I didn't find the latter in lib module. This PR will remove the duplication (and also add missing changelog entry).
