### PR TITLE
BUG: df.boxplot fails to use existing axis/subplot (#3578)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -475,6 +475,7 @@ Bug Fixes
   caused possible color/class mismatch (:issue:`6956`)
 - Bug in ``radviz`` and ``andrews_curves`` where multiple values of 'color'
   were being passed to plotting method (:issue:`6956`)
+- Bug in ``DataFrame.boxplot`` where it failed to use the axis passed as the ``ax`` argument (:issue:`3578`)
 
 pandas 0.13.1
 -------------

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1083,6 +1083,25 @@ class TestDataFramePlots(tm.TestCase):
         df['X'] = Series(['A', 'A', 'A', 'A', 'A', 'B', 'B', 'B', 'B', 'B'])
         _check_plot_works(df.boxplot, by='X')
 
+        # When ax is supplied, existing axes should be used:
+        import matplotlib.pyplot as plt
+        fig, ax = plt.subplots()
+        axes = df.boxplot('Col1', by='X', ax=ax)
+        self.assertIs(ax.get_axes(), axes)
+
+        # Multiple columns with an ax argument is not supported
+        fig, ax = plt.subplots()
+        self.assertRaisesRegexp(
+            ValueError, 'existing axis', df.boxplot,
+            column=['Col1', 'Col2'], by='X', ax=ax
+        )
+
+        # When by is None, check that all relevant lines are present in the dict
+        fig, ax = plt.subplots()
+        d = df.boxplot(ax=ax)
+        lines = list(itertools.chain.from_iterable(d.values()))
+        self.assertEqual(len(ax.get_lines()), len(lines))
+
     @slow
     def test_kde(self):
         _skip_if_no_scipy()

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -2760,10 +2760,16 @@ def _grouped_plot_by_column(plotf, data, columns=None, by=None,
         columns = data._get_numeric_data().columns - by
     ngroups = len(columns)
 
-    nrows, ncols = _get_layout(ngroups)
-    fig, axes = _subplots(nrows=nrows, ncols=ncols,
-                          sharex=True, sharey=True,
-                          figsize=figsize, ax=ax)
+    if ax is None:
+        nrows, ncols = _get_layout(ngroups)
+        fig, axes = _subplots(nrows=nrows, ncols=ncols,
+                              sharex=True, sharey=True,
+                              figsize=figsize, ax=ax)
+    else:
+        if ngroups > 1:
+            raise ValueError("Using an existing axis is not supported when plotting multiple columns.")
+        fig = ax.get_figure()
+        axes = ax.get_axes()
 
     if isinstance(axes, plt.Axes):
         ravel_axes = [axes]


### PR DESCRIPTION
Alright, I think I have a fix for issue #3578. In `plotting._grouped_plot_by_column`, there was no check being done for whether `ax` was `None`, which was the main source of the issue. When the boxplot is of multiple columns, I don't think there's anything sensible that can be done with the `ax` argument, so that
now raises a `ValueError`.

I've written some tests, but I'm not sure if they really get to the heart of the problem, so any insight on how to improve them would be appreciated.

Testing code adapted from the original bug report to demonstrate the new behaviour:

``` python
import matplotlib.pyplot as plt
import pandas
from pandas import DataFrame, Series

data = {'day': Series([1, 1, 1, 2, 2, 2, 3, 3, 3]),
        'group2': Series([2, 2, 2, 2, 2, 1, 1, 1, 1]),
        'val': Series([3, 4, 5, 6, 7, 8, 9, 10, 11]),
        'val2': Series([8, 9, 10, 11, 12, 13, 14, 15])}
df = pandas.DataFrame(data)

# Single-column using existing axis: should create a single plot
plt.figure()
plt.subplot(2, 2, 1)
plt.plot([1, 2, 3])
plt.subplot(2, 2, 4)
ax = plt.gca()
fig = ax.get_figure()
axes = df.boxplot('val', 'day', ax=ax)
print("Testing identity of returned axes: (should be True)")
print(id(axes) == id(ax.get_axes()))
plt.show()

# Multiple column, not using existing axis: should create two plots
plt.figure()
plt.subplot(2, 2, 1)
plt.plot([1, 2, 3])
plt.subplot(2, 2, 4)
ax = plt.gca()
axes = df.boxplot(['val', 'val2'], 'day')
print("Testing identity of returned axes: (should be False)")
print(id(axes) == id(ax.get_axes()))
plt.show()


# Multiple column using existing axis: should raise an exception,
# since it's hard to know what to do: we need an axis for each
# column and ax is just a single axis object
plt.figure()
plt.subplot(2, 2, 1)
plt.plot([1, 2, 3])
plt.subplot(2, 2, 4)
ax = plt.gca()
try:
    df.boxplot(['val', 'val2'], 'day', ax=ax)
except ValueError:
    print("Raising exception as expected")
plt.show()
```
