### PR TITLE
ENH: Implement core/strings/wrap method

### DIFF
--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -1223,6 +1223,7 @@ Methods like ``match``, ``contains``, ``startswith``, and ``endswith`` take
     ``repeat``,Duplicate values (``s.str.repeat(3)`` equivalent to ``x * 3``)
     ``pad``,"Add whitespace to left, right, or both sides of strings"
     ``center``,Equivalent to ``pad(side='both')``
+    ``wrap``,Split long strings into lines with length less than a given width
     ``slice``,Slice each string in the Series
     ``slice_replace``,Replace slice in each string with passed value
     ``count``,Count occurrences of pattern

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -185,6 +185,7 @@ Improvements to existing features
 - Performance improvement when converting ``DatetimeIndex`` to floating ordinals
   using ``DatetimeConverter`` (:issue:`6636`)
 - Performance improvement for  ``DataFrame.shift`` (:issue: `5609`)
+- Arrays of strings can be wrapped to a specified width (``str.wrap``) (:issue:`6999`)
 
 .. _release.bug_fixes-0.14.0:
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -362,6 +362,7 @@ Enhancements
   file. (:issue:`6545`)
 - ``pandas.io.gbq`` now handles reading unicode strings properly. (:issue:`5940`)
 - Improve performance of ``CustomBusinessDay`` (:issue:`6584`)
+- str.wrap implemented (:issue:`6999`)
 
 Performance
 ~~~~~~~~~~~

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -711,15 +711,15 @@ def str_rstrip(arr, to_strip=None):
     return _na_map(lambda x: x.rstrip(to_strip), arr)
 
 
-def str_wrap(arr, **kwargs):
+def str_wrap(arr, width, **kwargs):
     """
     Wrap long strings to be formatted in paragraphs
 
     Parameters
     ----------
     Same keyword parameters as textwrap.TextWrapper
-    width : int, optional
-        Maximum line-width (default: 70)
+    width : int
+        Maximum line-width
     expand_tabs: bool, optional
         If true, tab characters will be expanded to spaces (default: False)
     replace_whitespace: bool, optional
@@ -759,7 +759,7 @@ def str_wrap(arr, **kwargs):
     >>> str_wrap(Series(['line to be wrapped', 'another line to be wrapped']), width=12)
     Series(['line to be\nwrapped', 'another\nline to be\nwrapped'])
     """
-    textwrap_args = {'width': 69, 'expand_tabs': False, 'replace_whitespace': True,
+    textwrap_args = {'width': width, 'expand_tabs': False, 'replace_whitespace': True,
                      'drop_whitespace': True, 'break_long_words': False,
                      'break_on_hyphens': False}
 
@@ -993,8 +993,8 @@ class StringMethods(object):
         return self._wrap_result(result)
 
     @copy(str_wrap)
-    def wrap(self, **kwargs):
-        result = str_wrap(self.series, **kwargs)
+    def wrap(self, width, **kwargs):
+        result = str_wrap(self.series, width, **kwargs)
         return self._wrap_result(result)
 
     @copy(str_get_dummies)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -720,19 +720,19 @@ def str_wrap(arr, width, **kwargs):
     Same keyword parameters as textwrap.TextWrapper
     width : int
         Maximum line-width
-    expand_tabs: bool, optional
+    expand_tabs : bool, optional
         If true, tab characters will be expanded to spaces (default: False)
-    replace_whitespace: bool, optional
+    replace_whitespace : bool, optional
         If true, each whitespace character (as defined by string.whitespace) remaining
         after tab expansion will be replaced by a single space (default: True)
-    drop_whitespace: bool, optional
+    drop_whitespace : bool, optional
         If true, whitespace that, after wrapping, happens to end up at the beginning
         or end of a line is dropped (default: True)
-    break_long_words: bool, optional
+    break_long_words : bool, optional
         If true, then words longer than width will be broken in order to ensure that
         no lines are longer than width. If it is false, long words will not be broken,
         and some lines may be longer than width. (default: True)
-    break_on_hyphens: bool, optional
+    break_on_hyphens : bool, optional
         If true, wrapping will occur preferably on whitespace and right after hyphens
         in compound words, as it is customary in English. If false, only whitespaces
         will be considered as potentially good places for line breaks, but you need

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -748,8 +748,10 @@ def str_wrap(arr, **kwargs):
     Internally, this method uses a textwrap.TextWrapper instance configured to match R's stringr
     library str_wrap function. Unless overwritten using kwargs, the instance has expand_tabs=False,
     replace_whitespace=True, drop_whitespace=True, break_long_words=False, and
-    break_on_hyphens=False. Since R's stringr str_wrap treats the line width as an exclusive
-    value, the instance is configured with width=user-supplied width - 1.
+    break_on_hyphens=False. R's stringr function treats width as exclusive (less than width) while
+    Python's textwrap module treats width as inclusive (less than or equal to width). str_wrap follows
+    Python's textwrap module and uses the inclusive definition. When adapting R code, add 1 to
+    the width.
 
     Examples
     --------
@@ -762,9 +764,6 @@ def str_wrap(arr, **kwargs):
                      'break_on_hyphens': False}
 
     textwrap_args.update(kwargs)
-
-    if 'width' in kwargs:
-        textwrap_args['width'] -= 1  # change width to 'exclusive' width
 
     tw = textwrap.TextWrapper(**textwrap_args)
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -720,6 +720,24 @@ def str_wrap(arr, **kwargs):
     Same keyword parameters as textwrap.TextWrapper
     width : int, optional
         Maximum line-width (default: 70)
+    expand_tabs: bool, optional
+        If true, tab characters will be expanded to spaces (default: False)
+    replace_whitespace: bool, optional
+        If true, each whitespace character (as defined by string.whitespace) remaining
+        after tab expansion will be replaced by a single space (default: True)
+    drop_whitespace: bool, optional
+        If true, whitespace that, after wrapping, happens to end up at the beginning
+        or end of a line is dropped (default: True)
+    break_long_words: bool, optional
+        If true, then words longer than width will be broken in order to ensure that
+        no lines are longer than width. If it is false, long words will not be broken,
+        and some lines may be longer than width. (default: True)
+    break_on_hyphens: bool, optional
+        If true, wrapping will occur preferably on whitespace and right after hyphens
+        in compound words, as it is customary in English. If false, only whitespaces
+        will be considered as potentially good places for line breaks, but you need
+        to set break_long_words to false if you want truly insecable words.
+        (default: False)
 
     Returns
     -------
@@ -732,8 +750,14 @@ def str_wrap(arr, **kwargs):
     replace_whitespace=True, drop_whitespace=True, break_long_words=False, and
     break_on_hyphens=False. Since R's stringr str_wrap treats the line width as an exclusive
     value, the instance is configured with width=user-supplied width - 1.
+
+    Examples
+    --------
+
+    >>> str_wrap(Series([u'line to be wrapped', u'another line to be wrapped']), width=12)
+    Series([u'line to be\nwrapped', u'another\nline to be\nwrapped'])
     """
-    textwrap_args = {'width': 79, 'expand_tabs': False, 'replace_whitespace': True,
+    textwrap_args = {'width': 69, 'expand_tabs': False, 'replace_whitespace': True,
                     'drop_whitespace': True, 'break_long_words': False,
                     'break_on_hyphens': False}
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -754,12 +754,12 @@ def str_wrap(arr, **kwargs):
     Examples
     --------
 
-    >>> str_wrap(Series([u'line to be wrapped', u'another line to be wrapped']), width=12)
-    Series([u'line to be\nwrapped', u'another\nline to be\nwrapped'])
+    >>> str_wrap(Series(['line to be wrapped', 'another line to be wrapped']), width=12)
+    Series(['line to be\nwrapped', 'another\nline to be\nwrapped'])
     """
     textwrap_args = {'width': 69, 'expand_tabs': False, 'replace_whitespace': True,
-                    'drop_whitespace': True, 'break_long_words': False,
-                    'break_on_hyphens': False}
+                     'drop_whitespace': True, 'break_long_words': False,
+                     'break_on_hyphens': False}
 
     textwrap_args.update(kwargs)
 
@@ -768,7 +768,7 @@ def str_wrap(arr, **kwargs):
 
     tw = textwrap.TextWrapper(**textwrap_args)
 
-    return _na_map(lambda s: u'\n'.join(tw.wrap(s)), arr)
+    return _na_map(lambda s: '\n'.join(tw.wrap(s)), arr)
 
 
 def str_get(arr, i):

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -756,8 +756,10 @@ def str_wrap(arr, width, **kwargs):
     Examples
     --------
 
-    >>> str_wrap(Series(['line to be wrapped', 'another line to be wrapped']), width=12)
-    Series(['line to be\nwrapped', 'another\nline to be\nwrapped'])
+    >>> s = pd.Series(['line to be wrapped', 'another line to be wrapped'])
+    >>> s.str.wrap(12)
+    0             line to be\nwrapped
+    1    another line\nto be\nwrapped
     """
     textwrap_args = {'width': width, 'expand_tabs': False, 'replace_whitespace': True,
                      'drop_whitespace': True, 'break_long_words': False,

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -948,6 +948,11 @@ class StringMethods(object):
         result = str_rstrip(self.series, to_strip)
         return self._wrap_result(result)
 
+    @copy(str_wrap)
+    def wrap(self, width=80):
+        result = str_wrap(self.series, width=width)
+        return self._wrap_result(result)
+
     @copy(str_get_dummies)
     def get_dummies(self, sep='|'):
         result = str_get_dummies(self.series, sep)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -723,7 +723,30 @@ def str_wrap(arr, width=80):
     -------
     wrapped : array
     """
-    raise NotImplementedError
+    def wrap_str(s):
+        """Returns a string with lines wrapped (newlines inserted) at max(len(word), width)"""
+        words = unicode(s).split()
+        if not words:
+            return u''
+        else:
+            lines = []
+            line = u''
+
+            for word in words:
+                if not line:  # line is empty
+                    line = word
+                else:
+                    if len(line) + 1 + len(word) < width:  # word plus space will not exceed limit
+                        line = line + u' ' + word
+                    else:  # limit exceeded
+                        lines.append(line)  # store previous line
+                        line = word  # set new line to the word
+
+            if line:  # remaining from loop
+                lines.append(line)
+            return u'\n'.join(lines)
+
+    return _na_map(wrap_str, arr)
 
 
 def str_get(arr, i):

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -717,11 +717,11 @@ def str_wrap(arr, width, **kwargs):
 
     Parameters
     ----------
-    Same keyword parameters as textwrap.TextWrapper
+    Same keyword parameters and defaults as :class:`textwrap.TextWrapper`
     width : int
         Maximum line-width
     expand_tabs : bool, optional
-        If true, tab characters will be expanded to spaces (default: False)
+        If true, tab characters will be expanded to spaces (default: True)
     replace_whitespace : bool, optional
         If true, each whitespace character (as defined by string.whitespace) remaining
         after tab expansion will be replaced by a single space (default: True)
@@ -737,7 +737,7 @@ def str_wrap(arr, width, **kwargs):
         in compound words, as it is customary in English. If false, only whitespaces
         will be considered as potentially good places for line breaks, but you need
         to set break_long_words to false if you want truly insecable words.
-        (default: False)
+        (default: True)
 
     Returns
     -------
@@ -745,13 +745,15 @@ def str_wrap(arr, width, **kwargs):
 
     Notes
     -----
-    Internally, this method uses a textwrap.TextWrapper instance configured to match R's stringr
-    library str_wrap function. Unless overwritten using kwargs, the instance has expand_tabs=False,
-    replace_whitespace=True, drop_whitespace=True, break_long_words=False, and
-    break_on_hyphens=False. R's stringr function treats width as exclusive (less than width) while
-    Python's textwrap module treats width as inclusive (less than or equal to width). str_wrap follows
-    Python's textwrap module and uses the inclusive definition. When adapting R code, add 1 to
-    the width.
+    Internally, this method uses a :class:`textwrap.TextWrapper` instance with default
+    settings. To achieve behavior matching R's stringr library str_wrap function, use
+    the arguments:
+
+        expand_tabs = False
+        replace_whitespace = True
+        drop_whitespace = True
+        break_long_words = False
+        break_on_hyphens = False
 
     Examples
     --------
@@ -761,13 +763,9 @@ def str_wrap(arr, width, **kwargs):
     0             line to be\nwrapped
     1    another line\nto be\nwrapped
     """
-    textwrap_args = {'width': width, 'expand_tabs': False, 'replace_whitespace': True,
-                     'drop_whitespace': True, 'break_long_words': False,
-                     'break_on_hyphens': False}
+    kwargs['width'] = width
 
-    textwrap_args.update(kwargs)
-
-    tw = textwrap.TextWrapper(**textwrap_args)
+    tw = textwrap.TextWrapper(**kwargs)
 
     return _na_map(lambda s: '\n'.join(tw.wrap(s)), arr)
 

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -952,19 +952,19 @@ class TestStringMethods(tm.TestCase):
                          u('ab ab ab ab '), u('ab ab ab ab a'),
                          u('\t')])
 
-        # expected values match R's stringr library
-        xp = Series([u('hello world'), u('hello\nworld!'),
+        # expected values
+        xp = Series([u('hello world'), u('hello world!'),
                      u('hello\nworld!!'), u('abcdefabcde'),
-                     u('abcdefabcdef'), u('abcdefabcdefa'),
+                     u('abcdefabcdef'), u('abcdefabcdef\na'),
                      u('ab ab ab ab'), u('ab ab ab ab\na'),
                      u('')])
 
-        rs = values.str.wrap(11)
+        rs = values.str.wrap(12, break_long_words=True)
         assert_series_equal(rs, xp)
 
         # test with pre and post whitespace (non-unicode), NaN, and non-ascii Unicode
         values = Series(['  pre  ', np.nan, u('\xac\u20ac\U00008000 abadcafe')])
-        xp = Series(['  pre', NA, u('\xac\u20ac\U00008000\nabadcafe')])
+        xp = Series(['  pre', NA, u('\xac\u20ac\U00008000 ab\nadcafe')])
         rs = values.str.wrap(6)
         assert_series_equal(rs, xp)
 

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -959,13 +959,13 @@ class TestStringMethods(tm.TestCase):
                      u('ab ab ab ab'), u('ab ab ab ab\na'),
                      u('')])
 
-        rs = values.str.wrap(width=11)
+        rs = values.str.wrap(11)
         assert_series_equal(rs, xp)
 
         # test with pre and post whitespace (non-unicode), NaN, and non-ascii Unicode
         values = Series(['  pre  ', np.nan, u('\xac\u20ac\U00008000 abadcafe')])
         xp = Series(['  pre', NA, u('\xac\u20ac\U00008000\nabadcafe')])
-        rs = values.str.wrap(width=6)
+        rs = values.str.wrap(6)
         assert_series_equal(rs, xp)
 
     def test_get(self):

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -959,7 +959,7 @@ class TestStringMethods(tm.TestCase):
                      u('ab ab ab ab'), u('ab ab ab ab\na'),
                      u('')])
 
-        rs = values.str.wrap(values)
+        rs = values.str.wrap(width=12)
         assert_series_equal(rs, xp)
 
     def test_get(self):

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -959,7 +959,7 @@ class TestStringMethods(tm.TestCase):
                      u('ab ab ab ab'), u('ab ab ab ab\na'),
                      u('')])
 
-        rs = values.str.wrap(width=12)
+        rs = values.str.wrap(width=11)
         assert_series_equal(rs, xp)
 
         # test with pre and post whitespace (non-unicode) and NaN

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -942,7 +942,25 @@ class TestStringMethods(tm.TestCase):
         assert_series_equal(rs, xp)
 
     def test_wrap(self):
-        pass
+        # test values are: two words less than width, two words equal to width,
+        # two words greater than width, one word less than width, one word
+        # equal to width, one word greater than width, multiple tokens with trailing
+        # whitespace equal to width
+        values = Series([u('hello world'), u('hello world!'),
+                         u('hello world!!'), u('abcdefabcde'),
+                         u('abcdefabcdef'), u('abcdefabcdefa'),
+                         u('ab ab ab ab '), u('ab ab ab ab a'),
+                         u('\t')])
+
+        # expected values match R's stringr library
+        xp = Series([u('hello world'), u('hello\nworld!'),
+                     u('hello\nworld!!'), u('abcdefabcde'),
+                     u('abcdefabcdef'), u('abcdefabcdefa'),
+                     u('ab ab ab ab'), u('ab ab ab ab\na'),
+                     u('')])
+
+        rs = values.str.wrap(values)
+        assert_series_equal(rs, xp)
 
     def test_get(self):
         values = Series(['a_b_c', 'c_d_e', np.nan, 'f_g_h'])

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -962,9 +962,9 @@ class TestStringMethods(tm.TestCase):
         rs = values.str.wrap(width=11)
         assert_series_equal(rs, xp)
 
-        # test with pre and post whitespace (non-unicode) and NaN
-        values = Series(['  pre  ', np.nan])
-        xp = Series(['  pre', NA])
+        # test with pre and post whitespace (non-unicode), NaN, and non-ascii Unicode
+        values = Series(['  pre  ', np.nan, u('\xac\u20ac\U00008000 abadcafe')])
+        xp = Series(['  pre', NA, u('\xac\u20ac\U00008000\nabadcafe')])
         rs = values.str.wrap(width=6)
         assert_series_equal(rs, xp)
 

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -962,6 +962,12 @@ class TestStringMethods(tm.TestCase):
         rs = values.str.wrap(width=12)
         assert_series_equal(rs, xp)
 
+        # test with pre and post whitespace (non-unicode) and NaN
+        values = Series(['  pre  ', np.nan])
+        xp = Series(['  pre', NA])
+        rs = values.str.wrap(width=6)
+        assert_series_equal(rs, xp)
+
     def test_get(self):
         values = Series(['a_b_c', 'c_d_e', np.nan, 'f_g_h'])
 


### PR DESCRIPTION
This patch implements the str.wrap function within core/strings.

Example:

```
    >>> s = pd.Series(['line to be wrapped', 'another line to be wrapped'])
    >>> s.str.wrap(12)
    0             line to be\nwrapped
    1    another line\nto be\nwrapped
```

This is a cleaned branch; the original is at #6705.
