### PR TITLE
adding left and right view to DataFrame, equivalent to head() and tail()

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1733,6 +1733,24 @@ class DataFrame(NDFrame):
             raise ValueError('Must pass DataFrame with boolean values only')
         return self.where(key)
 
+    def left(self, n=5):
+        """
+        Return first n columns
+        """
+        l = self.shape[1]
+        if l == 0 or n == 0:
+            return self
+        return self.iloc[:, :n]
+
+    def right(self, n=5):
+        """
+        Return last n columns
+        """
+        l = self.shape[1]
+        if l == 0 or n == 0:
+            return self
+        return self.iloc[:, -n:]
+
     def query(self, expr, **kwargs):
         """Query the columns of a frame with a boolean expression.
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1781,7 +1781,7 @@ class NDFrame(PandasObject):
         Returns first n rows
         """
         l = len(self)
-        if l == 0 or n==0:
+        if l == 0 or n == 0:
             return self
         return self.iloc[:n]
 
@@ -1793,6 +1793,24 @@ class NDFrame(PandasObject):
         if l == 0 or n == 0:
             return self
         return self.iloc[-n:]
+
+    def left(self, n=5):
+        """
+        Return first n columns
+        """
+        l = self.shape[1]
+        if l == 0 or n == 0:
+            return self
+        return self.iloc[:, :n]
+
+    def right(self, n=5):
+        """
+        Return last n columns
+        """
+        l = self.shape[1]
+        if l == 0 or n == 0:
+            return self
+        return self.iloc[:, -n:]
 
     #----------------------------------------------------------------------
     # Attribute access

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1794,24 +1794,6 @@ class NDFrame(PandasObject):
             return self
         return self.iloc[-n:]
 
-    def left(self, n=5):
-        """
-        Return first n columns
-        """
-        l = self.shape[1]
-        if l == 0 or n == 0:
-            return self
-        return self.iloc[:, :n]
-
-    def right(self, n=5):
-        """
-        Return last n columns
-        """
-        l = self.shape[1]
-        if l == 0 or n == 0:
-            return self
-        return self.iloc[:, -n:]
-
     #----------------------------------------------------------------------
     # Attribute access
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4470,6 +4470,29 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_frame_equal(empty_df.tail(), empty_df)
         assert_frame_equal(empty_df.head(), empty_df)
 
+    def test_left_right(self):
+        assert_frame_equal(self.frame.left(), self.frame.iloc[:, :5])
+        assert_frame_equal(self.frame.right(), self.frame.iloc[:, -5:])
+        assert_frame_equal(self.frame.left(0), self.frame)
+        assert_frame_equal(self.frame.right(0), self.frame)
+        assert_frame_equal(self.frame.left(-1), self.frame.iloc[:, :-1])
+        assert_frame_equal(self.frame.right(-1), self.frame.iloc[:, 1:])
+        assert_frame_equal(self.frame.left(1), self.frame.iloc[:, :1])
+        assert_frame_equal(self.frame.right(1), self.frame.iloc[:, -1:])
+        # with a float index
+        df = self.frame.copy()
+        df.index = np.arange(len(self.frame)) + 0.1
+        assert_frame_equal(df.left(), df.iloc[:, :5])
+        assert_frame_equal(df.right(), df.iloc[:, -5:])
+        assert_frame_equal(df.left(0), df)
+        assert_frame_equal(df.right(0), df)
+        assert_frame_equal(df.left(-1), df.iloc[:, :-1])
+        assert_frame_equal(df.right(-1), df.iloc[:, 1:])
+        #test empty dataframe
+        empty_df = DataFrame()
+        assert_frame_equal(empty_df.right(), empty_df)
+        assert_frame_equal(empty_df.left(), empty_df)
+
     def test_insert(self):
         df = DataFrame(np.random.randn(5, 3), index=np.arange(5),
                        columns=['c', 'b', 'a'])


### PR DESCRIPTION
I am working with a lot of columns recently and just thought of these little helpers, basically the same as head() and tail(), but for columns.
Additionally, I fixed a small pep8 issue in head()
