### PR TITLE
BUG: duplicate indexing with setitem with iloc (GH6766)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -450,6 +450,7 @@ Bug Fixes
 - Bug in enabling ``subplots=True`` in ``DataFrame.plot`` only has single column raises ``TypeError``, and ``Series.plot`` raises ``AttributeError`` (:issue:`6951`)
 - Bug in ``DataFrame.plot`` draws unnecessary axes when enabling ``subplots`` and ``kind=scatter`` (:issue:`6951`)
 - Bug in ``read_csv`` from a filesystem with non-utf-8 encoding (:issue:`6807`)
+- Bug in ``iloc`` when setting / aligning (:issue:``6766`)
 
 pandas 0.13.1
 -------------

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -385,6 +385,7 @@ class _NDFrameIndexer(object):
                     s._data = s._data.setitem(indexer=pi, value=v)
                     s._maybe_update_cacher(clear=True)
 
+                # reset the sliced object if unique
                 self.obj[item] = s
 
             def can_do_equal_len():

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -630,6 +630,36 @@ class TestIndexing(tm.TestCase):
         df.loc[indexer]*=2.0
         assert_frame_equal(df.loc[indexer],2.0*df_orig.loc[indexer])
 
+    def test_iloc_setitem_dups(self):
+
+        # GH 6766
+        # iloc with a mask aligning from another iloc
+        df1 = DataFrame([{'A':None, 'B':1},{'A':2, 'B':2}])
+        df2 = DataFrame([{'A':3, 'B':3},{'A':4, 'B':4}])
+        df = concat([df1, df2], axis=1)
+
+        expected = df.fillna(3)
+        expected['A'] = expected['A'].astype('float64')
+        inds = np.isnan(df.iloc[:, 0])
+        mask = inds[inds].index
+        df.iloc[mask,0] = df.iloc[mask,2]
+        assert_frame_equal(df, expected)
+
+        # del a dup column across blocks
+        expected = DataFrame({ 0 : [1,2], 1 : [3,4] })
+        expected.columns=['B','B']
+        del df['A']
+        assert_frame_equal(df, expected)
+
+        # assign back to self
+        df.iloc[[0,1],[0,1]] = df.iloc[[0,1],[0,1]]
+        assert_frame_equal(df, expected)
+
+        # reversed x 2
+        df.iloc[[1,0],[0,1]] = df.iloc[[1,0],[0,1]].reset_index(drop=True)
+        df.iloc[[1,0],[0,1]] = df.iloc[[1,0],[0,1]].reset_index(drop=True)
+        assert_frame_equal(df, expected)
+
     def test_chained_getitem_with_lists(self):
 
         # GH6394


### PR DESCRIPTION
closes #6766 
