### PR TITLE
BUG: fixing tseries plot cursor display, resolves #5453

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -450,8 +450,9 @@ Bug Fixes
 - Bug in enabling ``subplots=True`` in ``DataFrame.plot`` only has single column raises ``TypeError``, and ``Series.plot`` raises ``AttributeError`` (:issue:`6951`)
 - Bug in ``DataFrame.plot`` draws unnecessary axes when enabling ``subplots`` and ``kind=scatter`` (:issue:`6951`)
 - Bug in ``read_csv`` from a filesystem with non-utf-8 encoding (:issue:`6807`)
-- Bug in ``iloc`` when setting / aligning (:issue:``6766`)
+- Bug in ``iloc`` when setting / aligning (:issue:`6766`)
 - Bug causing UnicodeEncodeError when get_dummies called with unicode values and a prefix (:issue:`6885`)
+- Bug in timeseries-with-frequency plot cursor display (:issue:`5453`)
 
 pandas 0.13.1
 -------------

--- a/pandas/tseries/plotting.py
+++ b/pandas/tseries/plotting.py
@@ -83,8 +83,7 @@ def tsplot(series, plotf, **kwargs):
     ax.set_xlim(left, right)
 
     # x and y coord info
-    tz = series.index.to_datetime().tz
-    ax.format_coord = lambda t, y : "t = {}    y = {:8f}".format(datetime.fromtimestamp(t, tz), y)
+    ax.format_coord = lambda t, y: "t = {}  y = {:8f}".format(Period(ordinal=int(t), freq=ax.freq), y)
 
     return lines
 

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -132,6 +132,21 @@ class TestTSPlot(tm.TestCase):
                          Period('1987-1-1', 'D').ordinal)
 
     @slow
+    def test_ts_plot_format_coord(self):
+        def check_format_of_first_point(ax, expected_string):
+            first_line = ax.get_lines()[0]
+            first_x = first_line.get_xdata()[0].ordinal
+            first_y = first_line.get_ydata()[0]
+            self.assertEqual(expected_string, ax.format_coord(first_x, first_y))
+
+        annual = Series(1, index=date_range('2014-01-01', periods=3, freq='A-DEC'))
+        check_format_of_first_point(annual.plot(), 't = 2014  y = 1.000000')
+
+        # note this is added to the annual plot already in existence, and changes its freq field
+        daily = Series(1, index=date_range('2014-01-01', periods=3, freq='D'))
+        check_format_of_first_point(daily.plot(), 't = 2014-01-01  y = 1.000000')
+
+    @slow
     def test_line_plot_period_series(self):
         for s in self.period_ser:
             _check_plot_works(s.plot, s.index.freq)


### PR DESCRIPTION
Fixes #5453

I am not sure how to test a mouse-over, and the original commit 922c6102eebb7347cea587fffc4795a3ca3e73b2 introducing this functionality did not have tests either, which is sadly probably how this got broken. @willfurnass do you happen to have any ideas for how to test this functionality, maybe from when you first looked at this?

The new code doesn't display timezone information like the old code once did (before it was broken) as Periods don't seem to have timezone info, and all `tseries/plotting.py` plots are Period-based. One could perhaps do some minor acrobatics to convert the tz-naive start time of the Period into a tz-aware Timestamp, I can research that if people feel strongly about it.
