### PR TITLE
BLD: fix failing vbench cases

### DIFF
--- a/vb_suite/eval.py
+++ b/vb_suite/eval.py
@@ -78,7 +78,6 @@ eval_frame_and_one_thread = \
               name='eval_frame_and_one_thread',
               start_date=datetime(2013, 7, 26))
 
-setup = common_setup
 eval_frame_and_python = \
     Benchmark("pd.eval('(df > 0) & (df2 > 0) & (df3 > 0) & (df4 > 0)', engine='python')",
               common_setup, name='eval_frame_and_python',
@@ -102,7 +101,6 @@ eval_frame_chained_cmp_one_thread = \
               name='eval_frame_chained_cmp_one_thread',
               start_date=datetime(2013, 7, 26))
 
-# setup = common_setup
 eval_frame_chained_cmp_python = \
     Benchmark("pd.eval('df < df2 < df3 < df4', engine='python')",
               common_setup, name='eval_frame_chained_cmp_python',
@@ -129,7 +127,7 @@ series_setup = setup + """
 df = DataFrame({'dates': s.values})
 """
 
-query_datetime_series = Benchmark("df.query('dates < ts')",
+query_datetime_series = Benchmark("df.query('dates < @ts')",
                                   series_setup,
                                   start_date=datetime(2013, 9, 27))
 
@@ -137,7 +135,7 @@ index_setup = setup + """
 df = DataFrame({'a': np.random.randn(N)}, index=index)
 """
 
-query_datetime_index = Benchmark("df.query('index < ts')",
+query_datetime_index = Benchmark("df.query('index < @ts')",
                                  index_setup, start_date=datetime(2013, 9, 27))
 
 setup = setup + """
@@ -147,6 +145,6 @@ min_val = df['a'].min()
 max_val = df['a'].max()
 """
 
-query_with_boolean_selection = Benchmark("df.query('(a >= min_val) & (a <= max_val)')",
-                                         index_setup, start_date=datetime(2013, 9, 27))
+query_with_boolean_selection = Benchmark("df.query('(a >= @min_val) & (a <= @max_val)')",
+                                         setup, start_date=datetime(2013, 9, 27))
 

--- a/vb_suite/groupby.py
+++ b/vb_suite/groupby.py
@@ -267,22 +267,22 @@ groupby_frame_apply_overhead = Benchmark("df.groupby('key').apply(f)", setup,
                                          start_date=datetime(2011, 10, 1))
 
 groupby_frame_apply = Benchmark("df.groupby(['key', 'key2']).apply(f)", setup,
-                                 start_date=datetime(2011, 10, 1))
+                                start_date=datetime(2011, 10, 1))
 
 
 #----------------------------------------------------------------------
 # DataFrame nth
 
 setup = common_setup + """
-df = pd.DataFrame(np.random.randint(1, 100, (10000, 2)))
+df = DataFrame(np.random.randint(1, 100, (10000, 2)))
 """
 
 # Not really a fair test as behaviour has changed!
 groupby_frame_nth = Benchmark("df.groupby(0).nth(0)", setup,
-                                start_date=datetime(2014, 3, 1))
+                              start_date=datetime(2014, 3, 1))
 
 groupby_series_nth = Benchmark("df[1].groupby(df[0]).nth(0)", setup,
-                                 start_date=datetime(2014, 3, 1))
+                               start_date=datetime(2014, 3, 1))
 
 
 #----------------------------------------------------------------------

--- a/vb_suite/index_object.py
+++ b/vb_suite/index_object.py
@@ -11,7 +11,7 @@ common_setup = """from pandas_vb_common import *
 # intersection, union
 
 setup = common_setup + """
-rng = DatetimeIndex('1/1/2000', periods=10000, offset=datetools.Minute())
+rng = DatetimeIndex(start='1/1/2000', periods=10000, freq=datetools.Minute())
 if rng.dtype == object:
     rng = rng.view(Index)
 else:

--- a/vb_suite/join_merge.py
+++ b/vb_suite/join_merge.py
@@ -223,15 +223,15 @@ stmt = "ordered_merge(left, right, on='key', left_by='group')"
 # GH 6329
 
 setup = common_setup + """
-date_index = pd.date_range('01-Jan-2013', '23-Jan-2013', freq='T')
+date_index = date_range('01-Jan-2013', '23-Jan-2013', freq='T')
 daily_dates = date_index.to_period('D').to_timestamp('S','S')
 fracofday = date_index.view(np.ndarray) - daily_dates.view(np.ndarray)
 fracofday = fracofday.astype('timedelta64[ns]').astype(np.float64)/864e11
-fracofday = pd.TimeSeries(fracofday, daily_dates)
-index = pd.date_range(date_index.min().to_period('A').to_timestamp('D','S'),
+fracofday = TimeSeries(fracofday, daily_dates)
+index = date_range(date_index.min().to_period('A').to_timestamp('D','S'),
                       date_index.max().to_period('A').to_timestamp('D','E'),
                       freq='D')
-temp = pd.TimeSeries(1.0, index)
+temp = TimeSeries(1.0, index)
 """
 
 join_non_unique_equal = Benchmark('fracofday * temp[fracofday.index]', setup,

--- a/vb_suite/packers.py
+++ b/vb_suite/packers.py
@@ -106,7 +106,7 @@ packers_write_hdf_table = Benchmark("df2.to_hdf(f,'df',table=True)", setup, clea
 
 setup_int_index = """
 import numpy as np
-df.index = np.arange(50000)
+df.index = np.arange(N)
 """
 
 setup = common_setup + """

--- a/vb_suite/panel_ctor.py
+++ b/vb_suite/panel_ctor.py
@@ -11,7 +11,8 @@ START_DATE = datetime(2011, 6, 1)
 
 setup_same_index = common_setup + """
 # create 100 dataframes with the same index
-dr = np.asarray(DatetimeIndex(datetime(1990,1,1), datetime(2012,1,1)))
+dr = np.asarray(DatetimeIndex(start=datetime(1990,1,1), end=datetime(2012,1,1),
+                              freq=datetools.Day(1)))
 data_frames = {}
 for x in xrange(100):
    df = DataFrame({"a": [0]*len(dr), "b": [1]*len(dr),
@@ -27,7 +28,8 @@ panel_from_dict_same_index = \
 setup_equiv_indexes = common_setup + """
 data_frames = {}
 for x in xrange(100):
-   dr = np.asarray(DatetimeIndex(datetime(1990,1,1), datetime(2012,1,1)))
+   dr = np.asarray(DatetimeIndex(start=datetime(1990,1,1), end=datetime(2012,1,1),
+                                 freq=datetools.Day(1)))
    df = DataFrame({"a": [0]*len(dr), "b": [1]*len(dr),
                    "c": [2]*len(dr)}, index=dr)
    data_frames[x] = df
@@ -44,7 +46,7 @@ start = datetime(1990,1,1)
 end = datetime(2012,1,1)
 for x in xrange(100):
    end += timedelta(days=1)
-   dr = np.asarray(DateRange(start, end))
+   dr = np.asarray(date_range(start, end))
    df = DataFrame({"a": [0]*len(dr), "b": [1]*len(dr),
                    "c": [2]*len(dr)}, index=dr)
    data_frames[x] = df
@@ -62,7 +64,7 @@ end = datetime(2012,1,1)
 for x in xrange(100):
    if x == 50:
        end += timedelta(days=1)
-   dr = np.asarray(DateRange(start, end))
+   dr = np.asarray(date_range(start, end))
    df = DataFrame({"a": [0]*len(dr), "b": [1]*len(dr),
                    "c": [2]*len(dr)}, index=dr)
    data_frames[x] = df

--- a/vb_suite/panel_methods.py
+++ b/vb_suite/panel_methods.py
@@ -15,7 +15,7 @@ panel = Panel(np.random.randn(100, len(index), 1000))
 panel_shift = Benchmark('panel.shift(1)', setup,
                                start_date=datetime(2012, 1, 12))
 
-panel_shift_minor = Benchmark('panel.shift(1, axis=minor)', setup,
+panel_shift_minor = Benchmark('panel.shift(1, axis="minor")', setup,
                                start_date=datetime(2012, 1, 12))
 
 panel_pct_change_major = Benchmark('panel.pct_change(1, axis="major")', setup,

--- a/vb_suite/reindex.py
+++ b/vb_suite/reindex.py
@@ -18,7 +18,7 @@ frame_reindex_columns = Benchmark(statement, setup)
 #----------------------------------------------------------------------
 
 setup = common_setup + """
-rng = DatetimeIndex('1/1/1970', periods=10000, offset=datetools.Minute())
+rng = DatetimeIndex(start='1/1/1970', periods=10000, freq=datetools.Minute())
 df = DataFrame(np.random.rand(10000, 10), index=rng,
                columns=range(10))
 df['foo'] = 'bar'
@@ -51,7 +51,7 @@ reindex_multi = Benchmark(statement, setup,
 # Pad / backfill
 
 setup = common_setup + """
-rng = DateRange('1/1/2000', periods=100000, offset=datetools.Minute())
+rng = date_range('1/1/2000', periods=100000, freq=datetools.Minute())
 
 ts = Series(np.random.randn(len(rng)), index=rng)
 ts2 = ts[::2]

--- a/vb_suite/stat_ops.py
+++ b/vb_suite/stat_ops.py
@@ -87,7 +87,7 @@ stats_rank_average = Benchmark('s.rank()', setup,
 
 stats_rank_pct_average = Benchmark('s.rank(pct=True)', setup,
                                    start_date=datetime(2014, 01, 16))
-stats_rank_pct_average_old = Benchmark('s.rank() / s.size()', setup,
+stats_rank_pct_average_old = Benchmark('s.rank() / len(s)', setup,
                                        start_date=datetime(2014, 01, 16))
 setup = common_setup + """
 values = np.random.randint(0, 100000, size=200000)

--- a/vb_suite/strings.py
+++ b/vb_suite/strings.py
@@ -46,13 +46,13 @@ strings_rstrip = Benchmark("many.str.rstrip('matchthis')", setup)
 strings_get = Benchmark("many.str.get(0)", setup)
 
 setup = setup + """
-make_series(string.uppercase, strlen=10, size=10000).str.join('|')
+s = make_series(string.uppercase, strlen=10, size=10000).str.join('|')
 """
 strings_get_dummies = Benchmark("s.str.get_dummies('|')", setup)
 
 setup = common_setup + """
 import pandas.util.testing as testing
-ser = pd.Series(testing.makeUnicodeIndex())
+ser = Series(testing.makeUnicodeIndex())
 """
 
 strings_encode_decode = Benchmark("ser.str.encode('utf-8').str.decode('utf-8')", setup)


### PR DESCRIPTION
There were about 30 vbench tests that failed due to multiple recent deprecations and copy-pasting.

This PR fixes all but 8 of those that correspond to constructing frame with "exotic" time offsets (`WeekOfYear`, `LastWeekOfYear`, `FY5253` and `FY5253Quarter`) that apparently require some kwargs for construction.

This also fixes the "different name/same test" situation with `eval_frame_and` benchmarks where for some reason single-thread and multi-thread cases share setup code.
