### PR TITLE
ENH: cythonize groupby.count

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -313,6 +313,8 @@ Improvements to existing features
   in item handling (:issue:`6745`, :issue:`6988`).
 - Improve performance in certain reindexing operations by optimizing ``take_2d`` (:issue:`6749`)
 - Arrays of strings can be wrapped to a specified width (``str.wrap``) (:issue:`6999`)
+- ``GroupBy.count()`` is now implemented in Cython and is much faster for large
+  numbers of groups (:issue:`7016`).
 
 .. _release.bug_fixes-0.14.0:
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -568,6 +568,8 @@ Performance
 - Performance improvements in timedelta conversions for integer dtypes (:issue:`6754`)
 - Improved performance of compatible pickles (:issue:`6899`)
 - Improve performance in certain reindexing operations by optimizing ``take_2d`` (:issue:`6749`)
+- ``GroupBy.count()`` is now implemented in Cython and is much faster for large
+  numbers of groups (:issue:`7016`).
 
 Experimental
 ~~~~~~~~~~~~

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1405,10 +1405,10 @@ class BaseGrouper(object):
 
         if self._filter_empty_groups:
             if result.ndim == 2:
-                if is_numeric:
+                try:
                     result = lib.row_bool_subset(
                         result, (counts > 0).view(np.uint8))
-                else:
+                except ValueError:
                     result = lib.row_bool_subset_object(
                         result, (counts > 0).view(np.uint8))
             else:
@@ -1442,6 +1442,7 @@ class BaseGrouper(object):
                 chunk = chunk.squeeze()
                 agg_func(result[:, :, i], counts, chunk, comp_ids)
         else:
+            #import ipdb; ipdb.set_trace()  # XXX BREAKPOINT
             agg_func(result, counts, values, comp_ids)
 
         return trans_func(result)

--- a/pandas/src/generate_code.py
+++ b/pandas/src/generate_code.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 # don't introduce a pandas/pandas.compat import
 # or we get a bootstrapping problem
 from StringIO import StringIO
-import os
 
 header = """
 cimport numpy as np
@@ -1150,6 +1149,86 @@ def group_var_bin_%(name)s(ndarray[%(dest_type2)s, ndim=2] out,
                              (ct * ct - ct))
 """
 
+group_count_template = """@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_count_%(name)s(ndarray[%(dest_type2)s, ndim=2] out,
+                         ndarray[int64_t] counts,
+                         ndarray[%(c_type)s, ndim=2] values,
+                         ndarray[int64_t] labels):
+    '''
+    Only aggregates on axis=0
+    '''
+    cdef:
+        Py_ssize_t i, j, N, K, lab
+        %(dest_type2)s val
+        ndarray[%(dest_type2)s, ndim=2] nobs = np.zeros_like(out)
+
+
+    if not len(values) == len(labels):
+       raise AssertionError("len(index) != len(labels)")
+
+    N, K = (<object> values).shape
+
+    for i in range(N):
+        lab = labels[i]
+        if lab < 0:
+            continue
+
+        counts[lab] += 1
+        for j in range(K):
+            val = values[i, j]
+
+            # not nan
+            nobs[lab, j] += val == val
+
+    for i in range(len(counts)):
+        for j in range(K):
+            out[i, j] = nobs[i, j]
+
+
+"""
+
+group_count_bin_template = """@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_count_bin_%(name)s(ndarray[%(dest_type2)s, ndim=2] out,
+                             ndarray[int64_t] counts,
+                             ndarray[%(c_type)s, ndim=2] values,
+                             ndarray[int64_t] bins):
+    '''
+    Only aggregates on axis=0
+    '''
+    cdef:
+        Py_ssize_t i, j, N, K, ngroups, b
+        %(dest_type2)s val, count
+        ndarray[%(dest_type2)s, ndim=2] nobs
+
+    nobs = np.zeros_like(out)
+
+    if bins[len(bins) - 1] == len(values):
+        ngroups = len(bins)
+    else:
+        ngroups = len(bins) + 1
+
+    N, K = (<object> values).shape
+
+    b = 0
+    for i in range(N):
+        while b < ngroups - 1 and i >= bins[b]:
+            b += 1
+
+        counts[b] += 1
+        for j in range(K):
+            val = values[i, j]
+
+            # not nan
+            nobs[b, j] += val == val
+
+    for i in range(ngroups):
+        for j in range(K):
+            out[i, j] = nobs[i, j]
+
+
+"""
 # add passing bin edges, instead of labels
 
 
@@ -2251,6 +2330,8 @@ groupbys = [group_last_template,
             group_max_bin_template,
             group_ohlc_template]
 
+groupby_count = [group_count_template, group_count_bin_template]
+
 templates_1d = [map_indices_template,
                 pad_template,
                 backfill_template,
@@ -2272,6 +2353,7 @@ take_templates = [take_1d_template,
                   take_2d_axis1_template,
                   take_2d_multi_template]
 
+
 def generate_take_cython_file(path='generated.pyx'):
     with open(path, 'w') as f:
         print(header, file=f)
@@ -2288,7 +2370,10 @@ def generate_take_cython_file(path='generated.pyx'):
             print(generate_put_template(template), file=f)
 
         for template in groupbys:
-            print(generate_put_template(template, use_ints = False), file=f)
+            print(generate_put_template(template, use_ints=False), file=f)
+
+        for template in groupby_count:
+            print(generate_put_template(template), file=f)
 
         # for template in templates_1d_datetime:
         #     print >> f, generate_from_template_datetime(template)
@@ -2298,6 +2383,7 @@ def generate_take_cython_file(path='generated.pyx'):
 
         for template in nobool_1d_templates:
             print(generate_from_template(template, exclude=['bool']), file=f)
+
 
 if __name__ == '__main__':
     generate_take_cython_file()

--- a/pandas/src/generated.pyx
+++ b/pandas/src/generated.pyx
@@ -27,7 +27,9 @@ from khash cimport *
 ctypedef unsigned char UChar
 
 cimport util
-from util cimport is_array, _checknull, _checknan
+from util cimport is_array, _checknull, _checknan, get_nat
+
+cdef int64_t iNaT = get_nat()
 
 # import datetime C API
 PyDateTime_IMPORT
@@ -6631,15 +6633,14 @@ def group_count_float64(ndarray[float64_t, ndim=2] out,
     Only aggregates on axis=0
     '''
     cdef:
-        Py_ssize_t i, j, N, K, lab
+        Py_ssize_t i, j, lab
+        Py_ssize_t N = values.shape[0], K = values.shape[1]
         float64_t val
-        ndarray[float64_t, ndim=2] nobs = np.zeros_like(out)
+        ndarray[int64_t, ndim=2] nobs = np.zeros((out.shape[0], out.shape[1]),
+                                                 dtype=np.int64)
 
-
-    if not len(values) == len(labels):
+    if len(values) != len(labels):
        raise AssertionError("len(index) != len(labels)")
-
-    N, K = (<object> values).shape
 
     for i in range(N):
         lab = labels[i]
@@ -6651,7 +6652,7 @@ def group_count_float64(ndarray[float64_t, ndim=2] out,
             val = values[i, j]
 
             # not nan
-            nobs[lab, j] += val == val
+            nobs[lab, j] += val == val and val != iNaT
 
     for i in range(len(counts)):
         for j in range(K):
@@ -6668,15 +6669,14 @@ def group_count_float32(ndarray[float32_t, ndim=2] out,
     Only aggregates on axis=0
     '''
     cdef:
-        Py_ssize_t i, j, N, K, lab
+        Py_ssize_t i, j, lab
+        Py_ssize_t N = values.shape[0], K = values.shape[1]
         float32_t val
-        ndarray[float32_t, ndim=2] nobs = np.zeros_like(out)
+        ndarray[int64_t, ndim=2] nobs = np.zeros((out.shape[0], out.shape[1]),
+                                                 dtype=np.int64)
 
-
-    if not len(values) == len(labels):
+    if len(values) != len(labels):
        raise AssertionError("len(index) != len(labels)")
-
-    N, K = (<object> values).shape
 
     for i in range(N):
         lab = labels[i]
@@ -6688,7 +6688,7 @@ def group_count_float32(ndarray[float32_t, ndim=2] out,
             val = values[i, j]
 
             # not nan
-            nobs[lab, j] += val == val
+            nobs[lab, j] += val == val and val != iNaT
 
     for i in range(len(counts)):
         for j in range(K):
@@ -6705,15 +6705,14 @@ def group_count_int8(ndarray[float32_t, ndim=2] out,
     Only aggregates on axis=0
     '''
     cdef:
-        Py_ssize_t i, j, N, K, lab
-        float32_t val
-        ndarray[float32_t, ndim=2] nobs = np.zeros_like(out)
+        Py_ssize_t i, j, lab
+        Py_ssize_t N = values.shape[0], K = values.shape[1]
+        int8_t val
+        ndarray[int64_t, ndim=2] nobs = np.zeros((out.shape[0], out.shape[1]),
+                                                 dtype=np.int64)
 
-
-    if not len(values) == len(labels):
+    if len(values) != len(labels):
        raise AssertionError("len(index) != len(labels)")
-
-    N, K = (<object> values).shape
 
     for i in range(N):
         lab = labels[i]
@@ -6725,7 +6724,7 @@ def group_count_int8(ndarray[float32_t, ndim=2] out,
             val = values[i, j]
 
             # not nan
-            nobs[lab, j] += val == val
+            nobs[lab, j] += val == val and val != iNaT
 
     for i in range(len(counts)):
         for j in range(K):
@@ -6742,15 +6741,14 @@ def group_count_int16(ndarray[float32_t, ndim=2] out,
     Only aggregates on axis=0
     '''
     cdef:
-        Py_ssize_t i, j, N, K, lab
-        float32_t val
-        ndarray[float32_t, ndim=2] nobs = np.zeros_like(out)
+        Py_ssize_t i, j, lab
+        Py_ssize_t N = values.shape[0], K = values.shape[1]
+        int16_t val
+        ndarray[int64_t, ndim=2] nobs = np.zeros((out.shape[0], out.shape[1]),
+                                                 dtype=np.int64)
 
-
-    if not len(values) == len(labels):
+    if len(values) != len(labels):
        raise AssertionError("len(index) != len(labels)")
-
-    N, K = (<object> values).shape
 
     for i in range(N):
         lab = labels[i]
@@ -6762,7 +6760,7 @@ def group_count_int16(ndarray[float32_t, ndim=2] out,
             val = values[i, j]
 
             # not nan
-            nobs[lab, j] += val == val
+            nobs[lab, j] += val == val and val != iNaT
 
     for i in range(len(counts)):
         for j in range(K):
@@ -6779,15 +6777,14 @@ def group_count_int32(ndarray[float64_t, ndim=2] out,
     Only aggregates on axis=0
     '''
     cdef:
-        Py_ssize_t i, j, N, K, lab
-        float64_t val
-        ndarray[float64_t, ndim=2] nobs = np.zeros_like(out)
+        Py_ssize_t i, j, lab
+        Py_ssize_t N = values.shape[0], K = values.shape[1]
+        int32_t val
+        ndarray[int64_t, ndim=2] nobs = np.zeros((out.shape[0], out.shape[1]),
+                                                 dtype=np.int64)
 
-
-    if not len(values) == len(labels):
+    if len(values) != len(labels):
        raise AssertionError("len(index) != len(labels)")
-
-    N, K = (<object> values).shape
 
     for i in range(N):
         lab = labels[i]
@@ -6799,7 +6796,7 @@ def group_count_int32(ndarray[float64_t, ndim=2] out,
             val = values[i, j]
 
             # not nan
-            nobs[lab, j] += val == val
+            nobs[lab, j] += val == val and val != iNaT
 
     for i in range(len(counts)):
         for j in range(K):
@@ -6816,15 +6813,14 @@ def group_count_int64(ndarray[float64_t, ndim=2] out,
     Only aggregates on axis=0
     '''
     cdef:
-        Py_ssize_t i, j, N, K, lab
-        float64_t val
-        ndarray[float64_t, ndim=2] nobs = np.zeros_like(out)
+        Py_ssize_t i, j, lab
+        Py_ssize_t N = values.shape[0], K = values.shape[1]
+        int64_t val
+        ndarray[int64_t, ndim=2] nobs = np.zeros((out.shape[0], out.shape[1]),
+                                                 dtype=np.int64)
 
-
-    if not len(values) == len(labels):
+    if len(values) != len(labels):
        raise AssertionError("len(index) != len(labels)")
-
-    N, K = (<object> values).shape
 
     for i in range(N):
         lab = labels[i]
@@ -6836,7 +6832,43 @@ def group_count_int64(ndarray[float64_t, ndim=2] out,
             val = values[i, j]
 
             # not nan
-            nobs[lab, j] += val == val
+            nobs[lab, j] += val == val and val != iNaT
+
+    for i in range(len(counts)):
+        for j in range(K):
+            out[i, j] = nobs[i, j]
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_count_object(ndarray[float64_t, ndim=2] out,
+                         ndarray[int64_t] counts,
+                         ndarray[object, ndim=2] values,
+                         ndarray[int64_t] labels):
+    '''
+    Only aggregates on axis=0
+    '''
+    cdef:
+        Py_ssize_t i, j, lab
+        Py_ssize_t N = values.shape[0], K = values.shape[1]
+        object val
+        ndarray[int64_t, ndim=2] nobs = np.zeros((out.shape[0], out.shape[1]),
+                                                 dtype=np.int64)
+
+    if len(values) != len(labels):
+       raise AssertionError("len(index) != len(labels)")
+
+    for i in range(N):
+        lab = labels[i]
+        if lab < 0:
+            continue
+
+        counts[lab] += 1
+        for j in range(K):
+            val = values[i, j]
+
+            # not nan
+            nobs[lab, j] += val == val and val != iNaT
 
     for i in range(len(counts)):
         for j in range(K):
@@ -6854,20 +6886,14 @@ def group_count_bin_float64(ndarray[float64_t, ndim=2] out,
     Only aggregates on axis=0
     '''
     cdef:
-        Py_ssize_t i, j, N, K, ngroups, b
-        float64_t val, count
-        ndarray[float64_t, ndim=2] nobs
+        Py_ssize_t i, j, ngroups
+        Py_ssize_t N = values.shape[0], K = values.shape[1], b = 0
+        float64_t val
+        ndarray[int64_t, ndim=2] nobs = np.zeros((out.shape[0], out.shape[1]),
+                                                 dtype=np.int64)
 
-    nobs = np.zeros_like(out)
+    ngroups = len(bins) + (bins[len(bins) - 1] != N)
 
-    if bins[len(bins) - 1] == len(values):
-        ngroups = len(bins)
-    else:
-        ngroups = len(bins) + 1
-
-    N, K = (<object> values).shape
-
-    b = 0
     for i in range(N):
         while b < ngroups - 1 and i >= bins[b]:
             b += 1
@@ -6877,7 +6903,7 @@ def group_count_bin_float64(ndarray[float64_t, ndim=2] out,
             val = values[i, j]
 
             # not nan
-            nobs[b, j] += val == val
+            nobs[b, j] += val == val and val != iNaT
 
     for i in range(ngroups):
         for j in range(K):
@@ -6894,20 +6920,14 @@ def group_count_bin_float32(ndarray[float32_t, ndim=2] out,
     Only aggregates on axis=0
     '''
     cdef:
-        Py_ssize_t i, j, N, K, ngroups, b
-        float32_t val, count
-        ndarray[float32_t, ndim=2] nobs
+        Py_ssize_t i, j, ngroups
+        Py_ssize_t N = values.shape[0], K = values.shape[1], b = 0
+        float32_t val
+        ndarray[int64_t, ndim=2] nobs = np.zeros((out.shape[0], out.shape[1]),
+                                                 dtype=np.int64)
 
-    nobs = np.zeros_like(out)
+    ngroups = len(bins) + (bins[len(bins) - 1] != N)
 
-    if bins[len(bins) - 1] == len(values):
-        ngroups = len(bins)
-    else:
-        ngroups = len(bins) + 1
-
-    N, K = (<object> values).shape
-
-    b = 0
     for i in range(N):
         while b < ngroups - 1 and i >= bins[b]:
             b += 1
@@ -6917,7 +6937,7 @@ def group_count_bin_float32(ndarray[float32_t, ndim=2] out,
             val = values[i, j]
 
             # not nan
-            nobs[b, j] += val == val
+            nobs[b, j] += val == val and val != iNaT
 
     for i in range(ngroups):
         for j in range(K):
@@ -6934,20 +6954,14 @@ def group_count_bin_int8(ndarray[float32_t, ndim=2] out,
     Only aggregates on axis=0
     '''
     cdef:
-        Py_ssize_t i, j, N, K, ngroups, b
-        float32_t val, count
-        ndarray[float32_t, ndim=2] nobs
+        Py_ssize_t i, j, ngroups
+        Py_ssize_t N = values.shape[0], K = values.shape[1], b = 0
+        int8_t val
+        ndarray[int64_t, ndim=2] nobs = np.zeros((out.shape[0], out.shape[1]),
+                                                 dtype=np.int64)
 
-    nobs = np.zeros_like(out)
+    ngroups = len(bins) + (bins[len(bins) - 1] != N)
 
-    if bins[len(bins) - 1] == len(values):
-        ngroups = len(bins)
-    else:
-        ngroups = len(bins) + 1
-
-    N, K = (<object> values).shape
-
-    b = 0
     for i in range(N):
         while b < ngroups - 1 and i >= bins[b]:
             b += 1
@@ -6957,7 +6971,7 @@ def group_count_bin_int8(ndarray[float32_t, ndim=2] out,
             val = values[i, j]
 
             # not nan
-            nobs[b, j] += val == val
+            nobs[b, j] += val == val and val != iNaT
 
     for i in range(ngroups):
         for j in range(K):
@@ -6974,20 +6988,14 @@ def group_count_bin_int16(ndarray[float32_t, ndim=2] out,
     Only aggregates on axis=0
     '''
     cdef:
-        Py_ssize_t i, j, N, K, ngroups, b
-        float32_t val, count
-        ndarray[float32_t, ndim=2] nobs
+        Py_ssize_t i, j, ngroups
+        Py_ssize_t N = values.shape[0], K = values.shape[1], b = 0
+        int16_t val
+        ndarray[int64_t, ndim=2] nobs = np.zeros((out.shape[0], out.shape[1]),
+                                                 dtype=np.int64)
 
-    nobs = np.zeros_like(out)
+    ngroups = len(bins) + (bins[len(bins) - 1] != N)
 
-    if bins[len(bins) - 1] == len(values):
-        ngroups = len(bins)
-    else:
-        ngroups = len(bins) + 1
-
-    N, K = (<object> values).shape
-
-    b = 0
     for i in range(N):
         while b < ngroups - 1 and i >= bins[b]:
             b += 1
@@ -6997,7 +7005,7 @@ def group_count_bin_int16(ndarray[float32_t, ndim=2] out,
             val = values[i, j]
 
             # not nan
-            nobs[b, j] += val == val
+            nobs[b, j] += val == val and val != iNaT
 
     for i in range(ngroups):
         for j in range(K):
@@ -7014,20 +7022,14 @@ def group_count_bin_int32(ndarray[float64_t, ndim=2] out,
     Only aggregates on axis=0
     '''
     cdef:
-        Py_ssize_t i, j, N, K, ngroups, b
-        float64_t val, count
-        ndarray[float64_t, ndim=2] nobs
+        Py_ssize_t i, j, ngroups
+        Py_ssize_t N = values.shape[0], K = values.shape[1], b = 0
+        int32_t val
+        ndarray[int64_t, ndim=2] nobs = np.zeros((out.shape[0], out.shape[1]),
+                                                 dtype=np.int64)
 
-    nobs = np.zeros_like(out)
+    ngroups = len(bins) + (bins[len(bins) - 1] != N)
 
-    if bins[len(bins) - 1] == len(values):
-        ngroups = len(bins)
-    else:
-        ngroups = len(bins) + 1
-
-    N, K = (<object> values).shape
-
-    b = 0
     for i in range(N):
         while b < ngroups - 1 and i >= bins[b]:
             b += 1
@@ -7037,7 +7039,7 @@ def group_count_bin_int32(ndarray[float64_t, ndim=2] out,
             val = values[i, j]
 
             # not nan
-            nobs[b, j] += val == val
+            nobs[b, j] += val == val and val != iNaT
 
     for i in range(ngroups):
         for j in range(K):
@@ -7054,20 +7056,14 @@ def group_count_bin_int64(ndarray[float64_t, ndim=2] out,
     Only aggregates on axis=0
     '''
     cdef:
-        Py_ssize_t i, j, N, K, ngroups, b
-        float64_t val, count
-        ndarray[float64_t, ndim=2] nobs
+        Py_ssize_t i, j, ngroups
+        Py_ssize_t N = values.shape[0], K = values.shape[1], b = 0
+        int64_t val
+        ndarray[int64_t, ndim=2] nobs = np.zeros((out.shape[0], out.shape[1]),
+                                                 dtype=np.int64)
 
-    nobs = np.zeros_like(out)
+    ngroups = len(bins) + (bins[len(bins) - 1] != N)
 
-    if bins[len(bins) - 1] == len(values):
-        ngroups = len(bins)
-    else:
-        ngroups = len(bins) + 1
-
-    N, K = (<object> values).shape
-
-    b = 0
     for i in range(N):
         while b < ngroups - 1 and i >= bins[b]:
             b += 1
@@ -7077,7 +7073,41 @@ def group_count_bin_int64(ndarray[float64_t, ndim=2] out,
             val = values[i, j]
 
             # not nan
-            nobs[b, j] += val == val
+            nobs[b, j] += val == val and val != iNaT
+
+    for i in range(ngroups):
+        for j in range(K):
+            out[i, j] = nobs[i, j]
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_count_bin_object(ndarray[float64_t, ndim=2] out,
+                             ndarray[int64_t] counts,
+                             ndarray[object, ndim=2] values,
+                             ndarray[int64_t] bins):
+    '''
+    Only aggregates on axis=0
+    '''
+    cdef:
+        Py_ssize_t i, j, ngroups
+        Py_ssize_t N = values.shape[0], K = values.shape[1], b = 0
+        object val
+        ndarray[int64_t, ndim=2] nobs = np.zeros((out.shape[0], out.shape[1]),
+                                                 dtype=np.int64)
+
+    ngroups = len(bins) + (bins[len(bins) - 1] != N)
+
+    for i in range(N):
+        while b < ngroups - 1 and i >= bins[b]:
+            b += 1
+
+        counts[b] += 1
+        for j in range(K):
+            val = values[i, j]
+
+            # not nan
+            nobs[b, j] += val == val and val != iNaT
 
     for i in range(ngroups):
         for j in range(K):

--- a/pandas/src/generated.pyx
+++ b/pandas/src/generated.pyx
@@ -6621,6 +6621,470 @@ def group_ohlc_float32(ndarray[float32_t, ndim=2] out,
             out[b, 2] = vlow
             out[b, 3] = vclose
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_count_float64(ndarray[float64_t, ndim=2] out,
+                         ndarray[int64_t] counts,
+                         ndarray[float64_t, ndim=2] values,
+                         ndarray[int64_t] labels):
+    '''
+    Only aggregates on axis=0
+    '''
+    cdef:
+        Py_ssize_t i, j, N, K, lab
+        float64_t val
+        ndarray[float64_t, ndim=2] nobs = np.zeros_like(out)
+
+
+    if not len(values) == len(labels):
+       raise AssertionError("len(index) != len(labels)")
+
+    N, K = (<object> values).shape
+
+    for i in range(N):
+        lab = labels[i]
+        if lab < 0:
+            continue
+
+        counts[lab] += 1
+        for j in range(K):
+            val = values[i, j]
+
+            # not nan
+            nobs[lab, j] += val == val
+
+    for i in range(len(counts)):
+        for j in range(K):
+            out[i, j] = nobs[i, j]
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_count_float32(ndarray[float32_t, ndim=2] out,
+                         ndarray[int64_t] counts,
+                         ndarray[float32_t, ndim=2] values,
+                         ndarray[int64_t] labels):
+    '''
+    Only aggregates on axis=0
+    '''
+    cdef:
+        Py_ssize_t i, j, N, K, lab
+        float32_t val
+        ndarray[float32_t, ndim=2] nobs = np.zeros_like(out)
+
+
+    if not len(values) == len(labels):
+       raise AssertionError("len(index) != len(labels)")
+
+    N, K = (<object> values).shape
+
+    for i in range(N):
+        lab = labels[i]
+        if lab < 0:
+            continue
+
+        counts[lab] += 1
+        for j in range(K):
+            val = values[i, j]
+
+            # not nan
+            nobs[lab, j] += val == val
+
+    for i in range(len(counts)):
+        for j in range(K):
+            out[i, j] = nobs[i, j]
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_count_int8(ndarray[float32_t, ndim=2] out,
+                         ndarray[int64_t] counts,
+                         ndarray[int8_t, ndim=2] values,
+                         ndarray[int64_t] labels):
+    '''
+    Only aggregates on axis=0
+    '''
+    cdef:
+        Py_ssize_t i, j, N, K, lab
+        float32_t val
+        ndarray[float32_t, ndim=2] nobs = np.zeros_like(out)
+
+
+    if not len(values) == len(labels):
+       raise AssertionError("len(index) != len(labels)")
+
+    N, K = (<object> values).shape
+
+    for i in range(N):
+        lab = labels[i]
+        if lab < 0:
+            continue
+
+        counts[lab] += 1
+        for j in range(K):
+            val = values[i, j]
+
+            # not nan
+            nobs[lab, j] += val == val
+
+    for i in range(len(counts)):
+        for j in range(K):
+            out[i, j] = nobs[i, j]
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_count_int16(ndarray[float32_t, ndim=2] out,
+                         ndarray[int64_t] counts,
+                         ndarray[int16_t, ndim=2] values,
+                         ndarray[int64_t] labels):
+    '''
+    Only aggregates on axis=0
+    '''
+    cdef:
+        Py_ssize_t i, j, N, K, lab
+        float32_t val
+        ndarray[float32_t, ndim=2] nobs = np.zeros_like(out)
+
+
+    if not len(values) == len(labels):
+       raise AssertionError("len(index) != len(labels)")
+
+    N, K = (<object> values).shape
+
+    for i in range(N):
+        lab = labels[i]
+        if lab < 0:
+            continue
+
+        counts[lab] += 1
+        for j in range(K):
+            val = values[i, j]
+
+            # not nan
+            nobs[lab, j] += val == val
+
+    for i in range(len(counts)):
+        for j in range(K):
+            out[i, j] = nobs[i, j]
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_count_int32(ndarray[float64_t, ndim=2] out,
+                         ndarray[int64_t] counts,
+                         ndarray[int32_t, ndim=2] values,
+                         ndarray[int64_t] labels):
+    '''
+    Only aggregates on axis=0
+    '''
+    cdef:
+        Py_ssize_t i, j, N, K, lab
+        float64_t val
+        ndarray[float64_t, ndim=2] nobs = np.zeros_like(out)
+
+
+    if not len(values) == len(labels):
+       raise AssertionError("len(index) != len(labels)")
+
+    N, K = (<object> values).shape
+
+    for i in range(N):
+        lab = labels[i]
+        if lab < 0:
+            continue
+
+        counts[lab] += 1
+        for j in range(K):
+            val = values[i, j]
+
+            # not nan
+            nobs[lab, j] += val == val
+
+    for i in range(len(counts)):
+        for j in range(K):
+            out[i, j] = nobs[i, j]
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_count_int64(ndarray[float64_t, ndim=2] out,
+                         ndarray[int64_t] counts,
+                         ndarray[int64_t, ndim=2] values,
+                         ndarray[int64_t] labels):
+    '''
+    Only aggregates on axis=0
+    '''
+    cdef:
+        Py_ssize_t i, j, N, K, lab
+        float64_t val
+        ndarray[float64_t, ndim=2] nobs = np.zeros_like(out)
+
+
+    if not len(values) == len(labels):
+       raise AssertionError("len(index) != len(labels)")
+
+    N, K = (<object> values).shape
+
+    for i in range(N):
+        lab = labels[i]
+        if lab < 0:
+            continue
+
+        counts[lab] += 1
+        for j in range(K):
+            val = values[i, j]
+
+            # not nan
+            nobs[lab, j] += val == val
+
+    for i in range(len(counts)):
+        for j in range(K):
+            out[i, j] = nobs[i, j]
+
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_count_bin_float64(ndarray[float64_t, ndim=2] out,
+                             ndarray[int64_t] counts,
+                             ndarray[float64_t, ndim=2] values,
+                             ndarray[int64_t] bins):
+    '''
+    Only aggregates on axis=0
+    '''
+    cdef:
+        Py_ssize_t i, j, N, K, ngroups, b
+        float64_t val, count
+        ndarray[float64_t, ndim=2] nobs
+
+    nobs = np.zeros_like(out)
+
+    if bins[len(bins) - 1] == len(values):
+        ngroups = len(bins)
+    else:
+        ngroups = len(bins) + 1
+
+    N, K = (<object> values).shape
+
+    b = 0
+    for i in range(N):
+        while b < ngroups - 1 and i >= bins[b]:
+            b += 1
+
+        counts[b] += 1
+        for j in range(K):
+            val = values[i, j]
+
+            # not nan
+            nobs[b, j] += val == val
+
+    for i in range(ngroups):
+        for j in range(K):
+            out[i, j] = nobs[i, j]
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_count_bin_float32(ndarray[float32_t, ndim=2] out,
+                             ndarray[int64_t] counts,
+                             ndarray[float32_t, ndim=2] values,
+                             ndarray[int64_t] bins):
+    '''
+    Only aggregates on axis=0
+    '''
+    cdef:
+        Py_ssize_t i, j, N, K, ngroups, b
+        float32_t val, count
+        ndarray[float32_t, ndim=2] nobs
+
+    nobs = np.zeros_like(out)
+
+    if bins[len(bins) - 1] == len(values):
+        ngroups = len(bins)
+    else:
+        ngroups = len(bins) + 1
+
+    N, K = (<object> values).shape
+
+    b = 0
+    for i in range(N):
+        while b < ngroups - 1 and i >= bins[b]:
+            b += 1
+
+        counts[b] += 1
+        for j in range(K):
+            val = values[i, j]
+
+            # not nan
+            nobs[b, j] += val == val
+
+    for i in range(ngroups):
+        for j in range(K):
+            out[i, j] = nobs[i, j]
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_count_bin_int8(ndarray[float32_t, ndim=2] out,
+                             ndarray[int64_t] counts,
+                             ndarray[int8_t, ndim=2] values,
+                             ndarray[int64_t] bins):
+    '''
+    Only aggregates on axis=0
+    '''
+    cdef:
+        Py_ssize_t i, j, N, K, ngroups, b
+        float32_t val, count
+        ndarray[float32_t, ndim=2] nobs
+
+    nobs = np.zeros_like(out)
+
+    if bins[len(bins) - 1] == len(values):
+        ngroups = len(bins)
+    else:
+        ngroups = len(bins) + 1
+
+    N, K = (<object> values).shape
+
+    b = 0
+    for i in range(N):
+        while b < ngroups - 1 and i >= bins[b]:
+            b += 1
+
+        counts[b] += 1
+        for j in range(K):
+            val = values[i, j]
+
+            # not nan
+            nobs[b, j] += val == val
+
+    for i in range(ngroups):
+        for j in range(K):
+            out[i, j] = nobs[i, j]
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_count_bin_int16(ndarray[float32_t, ndim=2] out,
+                             ndarray[int64_t] counts,
+                             ndarray[int16_t, ndim=2] values,
+                             ndarray[int64_t] bins):
+    '''
+    Only aggregates on axis=0
+    '''
+    cdef:
+        Py_ssize_t i, j, N, K, ngroups, b
+        float32_t val, count
+        ndarray[float32_t, ndim=2] nobs
+
+    nobs = np.zeros_like(out)
+
+    if bins[len(bins) - 1] == len(values):
+        ngroups = len(bins)
+    else:
+        ngroups = len(bins) + 1
+
+    N, K = (<object> values).shape
+
+    b = 0
+    for i in range(N):
+        while b < ngroups - 1 and i >= bins[b]:
+            b += 1
+
+        counts[b] += 1
+        for j in range(K):
+            val = values[i, j]
+
+            # not nan
+            nobs[b, j] += val == val
+
+    for i in range(ngroups):
+        for j in range(K):
+            out[i, j] = nobs[i, j]
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_count_bin_int32(ndarray[float64_t, ndim=2] out,
+                             ndarray[int64_t] counts,
+                             ndarray[int32_t, ndim=2] values,
+                             ndarray[int64_t] bins):
+    '''
+    Only aggregates on axis=0
+    '''
+    cdef:
+        Py_ssize_t i, j, N, K, ngroups, b
+        float64_t val, count
+        ndarray[float64_t, ndim=2] nobs
+
+    nobs = np.zeros_like(out)
+
+    if bins[len(bins) - 1] == len(values):
+        ngroups = len(bins)
+    else:
+        ngroups = len(bins) + 1
+
+    N, K = (<object> values).shape
+
+    b = 0
+    for i in range(N):
+        while b < ngroups - 1 and i >= bins[b]:
+            b += 1
+
+        counts[b] += 1
+        for j in range(K):
+            val = values[i, j]
+
+            # not nan
+            nobs[b, j] += val == val
+
+    for i in range(ngroups):
+        for j in range(K):
+            out[i, j] = nobs[i, j]
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_count_bin_int64(ndarray[float64_t, ndim=2] out,
+                             ndarray[int64_t] counts,
+                             ndarray[int64_t, ndim=2] values,
+                             ndarray[int64_t] bins):
+    '''
+    Only aggregates on axis=0
+    '''
+    cdef:
+        Py_ssize_t i, j, N, K, ngroups, b
+        float64_t val, count
+        ndarray[float64_t, ndim=2] nobs
+
+    nobs = np.zeros_like(out)
+
+    if bins[len(bins) - 1] == len(values):
+        ngroups = len(bins)
+    else:
+        ngroups = len(bins) + 1
+
+    N, K = (<object> values).shape
+
+    b = 0
+    for i in range(N):
+        while b < ngroups - 1 and i >= bins[b]:
+            b += 1
+
+        counts[b] += 1
+        for j in range(K):
+            val = values[i, j]
+
+            # not nan
+            nobs[b, j] += val == val
+
+    for i in range(ngroups):
+        for j in range(K):
+            out[i, j] = nobs[i, j]
+
+
+
 @cython.wraparound(False)
 @cython.boundscheck(False)
 def left_join_indexer_unique_float64(ndarray[float64_t] left,

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -462,6 +462,12 @@ class NaTType(_NaT):
     def __hash__(self):
         return iNaT
 
+    def __int__(self):
+        return NPY_NAT
+
+    def __long__(self):
+        return NPY_NAT
+
     def weekday(self):
         return -1
 

--- a/vb_suite/groupby.py
+++ b/vb_suite/groupby.py
@@ -146,7 +146,8 @@ df = DataFrame({'key1': np.random.randint(0, 500, size=n),
 """
 
 groupby_multi_count = Benchmark("df.groupby(['key1', 'key2']).count()",
-                                setup, start_date=datetime(2014, 5, 5))
+                                setup, name='groupby_multi_count',
+                                start_date=datetime(2014, 5, 5))
 #----------------------------------------------------------------------
 # Series.value_counts
 
@@ -180,11 +181,11 @@ ind1 = np.random.randint(0, 3, size=100000)
 ind2 = np.random.randint(0, 2, size=100000)
 
 df = DataFrame({'key1': fac1.take(ind1),
-                'key2': fac2.take(ind2),
-                'key3': fac2.take(ind2),
-                'value1' : np.random.randn(100000),
-                'value2' : np.random.randn(100000),
-                'value3' : np.random.randn(100000)})
+'key2': fac2.take(ind2),
+'key3': fac2.take(ind2),
+'value1' : np.random.randn(100000),
+'value2' : np.random.randn(100000),
+'value3' : np.random.randn(100000)})
 """
 
 stmt = "df.pivot_table(rows='key1', cols=['key2', 'key3'])"
@@ -221,13 +222,13 @@ groupby_first = Benchmark('data.groupby(labels).first()', setup,
                           start_date=datetime(2012, 5, 1))
 
 groupby_first_float32 = Benchmark('data2.groupby(labels).first()', setup,
-                          start_date=datetime(2013, 1, 1))
+                                  start_date=datetime(2013, 1, 1))
 
 groupby_last = Benchmark('data.groupby(labels).last()', setup,
                          start_date=datetime(2012, 5, 1))
 
 groupby_last_float32 = Benchmark('data2.groupby(labels).last()', setup,
-                         start_date=datetime(2013, 1, 1))
+                                 start_date=datetime(2013, 1, 1))
 
 
 #----------------------------------------------------------------------
@@ -285,9 +286,9 @@ N = 10000
 labels = np.random.randint(0, 2000, size=N)
 labels2 = np.random.randint(0, 3, size=N)
 df = DataFrame({'key': labels,
-                'key2': labels2,
-                'value1': randn(N),
-                'value2': ['foo', 'bar', 'baz', 'qux'] * (N / 4)})
+'key2': labels2,
+'value1': randn(N),
+'value2': ['foo', 'bar', 'baz', 'qux'] * (N / 4)})
 def f(g):
     return 1
 """

--- a/vb_suite/groupby.py
+++ b/vb_suite/groupby.py
@@ -122,15 +122,31 @@ groupby_multi_size = Benchmark("df.groupby(['key1', 'key2']).size()",
 # count() speed
 
 setup = common_setup + """
-df = DataFrame({'key1': np.random.randint(0, 500, size=100000),
-                'key2': np.random.randint(0, 100, size=100000),
-                'value1' : np.random.randn(100000),
-                'value2' : np.random.randn(100000),
-                'value3' : np.random.randn(100000)})
+n = 10000
+offsets = np.random.randint(n, size=n).astype('timedelta64[ns]')
+
+dates = np.datetime64('now') + offsets
+dates[np.random.rand(n) > 0.5] = np.datetime64('nat')
+
+offsets[np.random.rand(n) > 0.5] = np.timedelta64('nat')
+
+value2 = np.random.randn(n)
+value2[np.random.rand(n) > 0.5] = np.nan
+
+obj = pd.util.testing.choice(['a', 'b'], size=n).astype(object)
+obj[np.random.randn(n) > 0.5] = np.nan
+
+df = DataFrame({'key1': np.random.randint(0, 500, size=n),
+                'key2': np.random.randint(0, 100, size=n),
+                'dates': dates,
+                'value2' : value2,
+                'value3' : np.random.randn(n),
+                'obj': obj,
+                'offsets': offsets})
 """
 
 groupby_multi_count = Benchmark("df.groupby(['key1', 'key2']).count()",
-                                setup, start_date=datetime(2014, 5, 1))
+                                setup, start_date=datetime(2014, 5, 5))
 #----------------------------------------------------------------------
 # Series.value_counts
 

--- a/vb_suite/groupby.py
+++ b/vb_suite/groupby.py
@@ -119,6 +119,19 @@ groupby_multi_size = Benchmark("df.groupby(['key1', 'key2']).size()",
                                setup, start_date=datetime(2011, 10, 1))
 
 #----------------------------------------------------------------------
+# count() speed
+
+setup = common_setup + """
+df = DataFrame({'key1': np.random.randint(0, 500, size=100000),
+                'key2': np.random.randint(0, 100, size=100000),
+                'value1' : np.random.randn(100000),
+                'value2' : np.random.randn(100000),
+                'value3' : np.random.randn(100000)})
+"""
+
+groupby_multi_count = Benchmark("df.groupby(['key1', 'key2']).count()",
+                                setup, start_date=datetime(2014, 5, 1))
+#----------------------------------------------------------------------
 # Series.value_counts
 
 setup = common_setup + """


### PR DESCRIPTION
closes #7003
- [x] vbench
- ~~axis parameter~~ (this only works in non-cython land)
- [x] tests for `object` dtype if there are none
- [x] datetime64/timedelta64 count

vbench results:

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
groupby_multi_count                          |   7.3980 | 6814.2579 |   0.0011 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
```
