### PR TITLE
BLD: use sqlalchemy 0.7.1 in 2.6 build (GH6340)

### DIFF
--- a/ci/requirements-2.6.txt
+++ b/ci/requirements-2.6.txt
@@ -6,7 +6,9 @@ http://www.crummy.com/software/BeautifulSoup/bs4/download/4.2/beautifulsoup4-4.2
 html5lib==1.0b2
 bigquery==2.0.17
 numexpr==1.4.2
-sqlalchemy==0.8.1
+sqlalchemy==0.7.1
+pymysql==0.6.0
+psycopg2==2.5
 scipy==0.11.0
 statsmodels==0.4.3
 xlwt==0.7.5


### PR DESCRIPTION
closes #6340
