### PR TITLE
BUG: fix reading multi-index data in python parser

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -457,6 +457,7 @@ Bug Fixes
 - accept ``TextFileReader`` in ``concat``, which was affecting a common user idiom (:issue:`6583`)
 - Bug in C parser with leading whitespace (:issue:`3374`)
 - Bug in C parser with ``delim_whitespace=True`` and ``\r``-delimited lines
+- Bug in python parser with explicit multi-index in row following column header (:issue:`6893`)
 - Bug in ``Series.rank`` and ``DataFrame.rank`` that caused small floats (<1e-13) to all receive the same rank (:issue:`6886`)
 - Bug in ``DataFrame.apply`` with functions that used \*args`` or \*\*kwargs and returned
   an empty result (:issue:`6952`)

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1383,7 +1383,7 @@ class PythonParser(ParserBase):
         # multiple date column thing turning into a real spaghetti factory
         if not self._has_complex_date_col:
             (index_names,
-             self.orig_names, columns_) = self._get_index_name(self.columns)
+             self.orig_names, self.columns) = self._get_index_name(self.columns)
             self._name_processed = True
             if self.index_names is None:
                 self.index_names = index_names
@@ -1811,8 +1811,9 @@ class PythonParser(ParserBase):
                         columns.insert(0, c)
 
                     # Update list of original names to include all indices.
-                    self.num_original_columns = len(next_line)
-                    return line, columns, orig_names
+                    orig_names = list(columns)
+                    self.num_original_columns = len(columns)
+                    return line, orig_names, columns
 
         if implicit_first_cols > 0:
             # Case 1
@@ -1824,7 +1825,7 @@ class PythonParser(ParserBase):
 
         else:
             # Case 2
-            (index_name, columns,
+            (index_name, columns_,
              self.index_col) = _clean_index_names(columns, self.index_col)
 
         return index_name, orig_names, columns

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -1569,7 +1569,7 @@ c,4,5,01/03/2009
 
     def test_read_table_buglet_4x_multiindex(self):
         # GH 6607
-        # Parsing multiindex columns currently causes an error in the C parser.
+        # Parsing multi-level index currently causes an error in the C parser.
         # Temporarily copied to TestPythonParser.
         # Here test that CParserError is raised:
 
@@ -2692,7 +2692,7 @@ also also skip this
     def test_read_table_buglet_4x_multiindex(self):
         # GH 6607
         # This is a copy which should eventually be merged into ParserTests
-        # when the issue with multiindex columns is fixed in the C parser.
+        # when the issue with multi-level index is fixed in the C parser.
 
         text = """                      A       B       C       D        E
 one two three   four
@@ -2703,6 +2703,13 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         # it works!
         df = self.read_table(StringIO(text), sep='\s+')
         self.assertEquals(df.index.names, ('one', 'two', 'three', 'four'))
+
+        # GH 6893
+        data = '      A B C\na b c\n1 3 7 0 3 6\n3 1 4 1 5 9'
+        expected = DataFrame.from_records([(1,3,7,0,3,6), (3,1,4,1,5,9)],
+                columns=list('abcABC'), index=list('abc'))
+        actual = self.read_table(StringIO(data), sep='\s+')
+        tm.assert_frame_equal(actual, expected)
 
 class TestFwfColspaceSniffing(tm.TestCase):
     def test_full_file(self):


### PR DESCRIPTION
partial fix for #6893

The python parser has a problem reading data with a multi-index specified in the row following the header, for example

``` python
In [3]: text = """                      A       B       C       D        E
one two three   four
a   b   10.0032 5    -0.5109 -2.3358 -0.4645  0.05076  0.3640
a   q   20      4     0.4473  1.4152  0.2834  1.00661  0.1744
x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""

In [4]: pd.read_table(StringIO(text), sep='\s+', engine='python')
Out[4]: 
                           E
one two three   four        
a   b   10.0032 5     0.3640
    q   20.0000 4     0.1744
x   q   30.0000 3     2.5838

[3 rows x 1 columns]
```

(the C parser doesn't make it this far, see #6893)

This PR fixes the bug in the python parser:

``` python
In [4]: pd.read_table(StringIO(text), sep='\s+', engine='python')
Out[4]: 
                           A       B       C        D       E
one two three   four                                         
a   b   10.0032 5    -0.5109 -2.3358 -0.4645  0.05076  0.3640
    q   20.0000 4     0.4473  1.4152  0.2834  1.00661  0.1744
x   q   30.0000 3    -0.6662 -0.5243 -0.3580  0.89145  2.5838

[3 rows x 5 columns]
```
