### PR TITLE
API: Allow groupby's by to take column and index names [WIP]

### DIFF
--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1922,9 +1922,10 @@ def _get_grouper(obj, key=None, axis=0, level=None, sort=True):
 
     try:
         if from_idx and from_col:
-            to_exclude = set(obj.index.names) - from_idx
-            obj = obj.reset_index()
+            # check the drop part...
+            obj = obj.reset_index(level=list(from_idx)).reset_index(drop=True)
             group_axis = obj._get_axis(axis)
+
         if isinstance(obj, DataFrame):
             all_in_columns = all(g in obj.columns for g in keys)
         else:
@@ -1946,11 +1947,6 @@ def _get_grouper(obj, key=None, axis=0, level=None, sort=True):
 
     groupings = []
     exclusions = []
-
-    if from_col and from_idx:
-        # don't include those just there becaues of the reset_index
-        if to_exclude:
-            exclusions += list(to_exclude)
 
     for i, (gpr, level) in enumerate(zip(keys, levels)):
         name = None

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1985,7 +1985,9 @@ def _from_index_and_columns(obj, keys):
     """
     keys is already listlike
     """
-    if not all(isinstance(g, compat.string_types) for g in keys):
+    not_all_string = not all(isinstance(g, compat.string_types) for g in keys)
+    not_df = not isinstance(obj, DataFrame)
+    if not_all_string or not_df:
         # TODO: Handle mix of callables and strings.
         return None, None, None
     ks = set(keys)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1995,8 +1995,8 @@ def _from_index_and_columns(obj, keys):
     if from_both:
         from warnings import warn
         msg = ("Found {0} in both the columns and index labels. "
-               "Grouping by the columns".format(from_both))
-        warn(msg)
+               "Grouping by the columns".format(from_both),)
+        warn(msg, FutureWarning)
 
     # don't need to do anything if the only ones from either are in both
     return from_col, from_idx - from_both, from_both

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -4171,17 +4171,24 @@ class TestGroupBy(tm.TestCase):
 
     def test_by_index_cols(self):
         df = DataFrame([[1, 2, 'x', 'a', 'a'],
-                        [1, 3, 'x', 'a', 'b'],
-                        [1, 4, 'x', 'b', 'a'],
-                        [1, 5, 'y', 'b', 'b']],
+                        [2, 3, 'x', 'a', 'b'],
+                        [3, 4, 'x', 'b', 'a'],
+                        [4, 5, 'y', 'b', 'b']],
                        columns=['c1', 'c2', 'g1', 'i1', 'i2'])
         df = df.set_index(['i1', 'i2'])
-        df.index.names = ['i1', 'g1']
+        df.index.set_names(['i1', 'g1'], inplace=True)
         result = df.groupby(by=['g1', 'i1']).mean()
         idx = MultiIndex.from_tuples([('x', 'a'), ('x', 'b'), ('y', 'b')],
                                      names=['g1', 'i1'])
-        expected = DataFrame([[1, 2.5], [1, 4], [1, 5]],
+        expected = DataFrame([[1.5, 2.5], [1, 4], [1, 5]],
                              index=idx, columns=['c1', 'c2'])
+        assert_frame_equal(result, expected)
+
+        with tm.assert_produces_warning(FutureWarning):
+            result = df.groupby('g1').mean()
+        expected = DataFrame([[2, 3], [4, 5]],
+                             index=['x', 'y'], columns=['c1', 'c2'])
+        expected.index.set_names(['g1'], inplace=True)
         assert_frame_equal(result, expected)
 
     def test_from_index_and_columns(self):
@@ -4203,7 +4210,7 @@ class TestGroupBy(tm.TestCase):
 
         df.index.names = ['i1', 'c1']
         keys = ['c1', 'i1']
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(FutureWarning):
             from_col, from_idx, from_both = _from_index_and_columns(df, keys)
         self.assertEqual(from_col, set(['c1']))
         self.assertEqual(from_idx, set(['i1']))

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -4169,6 +4169,21 @@ class TestGroupBy(tm.TestCase):
         expected = list(range(5)) + list(range(105, 110)) + list(range(104, 4, -1))
         assert_equal(result, expected)
 
+    def test_by_index_cols(self):
+        df = DataFrame([[1, 2, 'x', 'a', 'a'],
+                        [1, 3, 'x', 'a', 'b'],
+                        [1, 4, 'x', 'b', 'a'],
+                        [1, 5, 'y', 'b', 'b']],
+                       columns=['c1', 'c2', 'g1', 'i1', 'i2'])
+        df = df.set_index(['i1', 'i2'])
+        df.index.names = ['i1', 'g1']
+        result = df.groupby(by=['g1', 'i1']).mean()
+        idx = MultiIndex.from_tuples([('x', 'a'), ('x', 'b'), ('y', 'b')],
+                                     names=['g1', 'i1'])
+        expected = DataFrame([[1, 2.5], [1, 4], [1, 5]],
+                             index=idx, columns=['c1', 'c2'])
+        assert_frame_equal(result, expected)
+
     def test_from_index_and_columns(self):
         # allowing by to spread across index and col names GH #5677
         df = DataFrame([[1, 2, 3, 4]], columns=['c1', 'c2', 'i1', 'i2'])


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/5677

As a reminder, with a  data frame like:

``` python
from itertools import cycle, islice 

np.random.seed(0)
df = pd.DataFrame(np.random.randn(20, 2))
df.columns = ["foo","bar"]
df['g0'] = list(islice(cycle('ab'), 20))
df['g1'] = ['a'] * 10 + ['b'] * 10
df['g2'] = ['c'] * 5 + ['d'] * 5 + ['c'] * 5 + ['d'] * 5

df = df.set_index(['g1', 'g2'])
```

Before if you wanted to groupby a a column and index level, you'd have to

``` python
g = df.reset_index().groupby(['g0', 'g1'])
```

Now you can just do `df.groupby(['g0', 'g1'])`. In ambiguous cases where a there's a key in `by` that's in both the index names and columns we warn and proceed with grouping by the columns (I haven't tested this part yet).
