### PR TITLE
ENH/BUG: boxplot now supports layout

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -332,6 +332,7 @@ Improvements to existing features
 - Arrays of strings can be wrapped to a specified width (``str.wrap``) (:issue:`6999`)
 - ``GroupBy.count()`` is now implemented in Cython and is much faster for large
   numbers of groups (:issue:`7016`).
+- ``boxplot`` now supports ``layout`` keyword (:issue:`6769`)
 
 .. _release.bug_fixes-0.14.0:
 
@@ -485,6 +486,7 @@ Bug Fixes
 - Bug in cache coherence with chained indexing and slicing; add ``_is_view`` property to ``NDFrame`` to correctly predict
   views; mark ``is_copy`` on ``xs` only if its an actual copy (and not a view) (:issue:`7084`)
 - Bug in DatetimeIndex creation from string ndarray with ``dayfirst=True`` (:issue:`5917`)
+- Bug in ``boxplot`` and ``hist`` draws unnecessary axes (:issue:`6769`)
 
 pandas 0.13.1
 -------------

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -390,6 +390,8 @@ Plotting
   positional argument ``frame`` instead of ``data``. A ``FutureWarning`` is
   raised  if the old ``data`` argument is used by name. (:issue:`6956`)
 
+- ``boxplot`` now supports ``layout`` keyword (:issue:`6769`)
+
 .. _whatsnew_0140.prior_deprecations:
 
 Prior Version Deprecations/Changes


### PR DESCRIPTION
Closes #6769. Added `layout` kw to `boxplot`. I think tests can be improved if boxplot can return ndarray with the same shape as layout, as the same manner as hist (maybe after #4472).
## Bug fix

It includes the fix to hide unnecessary axes than required in boxplot and hist. For example, `layout=(2, 2)` is specified for 3 subplots. I've listed affected cases as below.

```
import pandas as pd
import numpy as np

df = pd.DataFrame({'3g': 'A A A B B B C C C'.split(),
                   '2g': [1, 2, 1, 2, 1, 2, 1, 2, 2],
                   'values': np.random.rand(9), 
                   'values2': np.random.rand(9),
                   'values3': np.random.rand(9)})
# BoxPlot

# specify 3 columns with by keyword -> should be 3 axes in (2, 2) layout
df.boxplot(column=['values', 'values2', 'values3'], by='2g')

# groupby results in 3 groups -> should be 3 axes 
df.groupby('3g').boxplot()

# groupby results in 3 groups, with column kw -> should be 3 axes in (2, 2) layout
df.groupby('3g').boxplot(column=['values', 'values2', 'values3'])

# Histogram

# specify 3 columns without by kw -> should be 3 axes in (2, 2) layout
df.hist(column=['values', 'values2', 'values3'])

# groupby results 3 groups results of by kw -> should be 3 axes in (2, 2) layout
df.hist(column=['values'], by='3g')
# This results KeyError: '3g' in current master, and the error has been fixed.

# groupby results in 3 groups -> should be 3 axes in (2, 2) layout
df.hist(by='3g')

# layout contains more size than groups -> should be 2 axes in specified layout
df.hist(by='2g', layout=(2, 2))
```
