### PR TITLE
PERF: optimize Index.delete for dtype=object

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -124,8 +124,9 @@ API Changes
 
 - ``concat`` will now concatenate mixed Series and DataFrames using the Series name
   or numbering columns as needed (:issue:`2385`)
-- Slicing and advanced/boolean indexing operations on ``Index`` classes will no
-  longer change type of the resulting index (:issue:`6440`).
+- Slicing and advanced/boolean indexing operations on ``Index`` classes as well
+  as :meth:`Index.delete` and :meth:`Index.drop` methods will no longer change type of the
+  resulting index (:issue:`6440`, :issue:`7040`)
 - ``set_index`` no longer converts MultiIndexes to an Index of tuples (:issue:`6459`).
 - Slicing with negative start, stop & step values handles corner cases better (:issue:`6531`):
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -163,13 +163,15 @@ API changes
 
 - ``concat`` will now concatenate mixed Series and DataFrames using the Series name
   or numbering columns as needed (:issue:`2385`). See :ref:`the docs <merging.mixed_ndims>`
-- Slicing and advanced/boolean indexing operations on ``Index`` classes will no
-  longer change type of the resulting index (:issue:`6440`)
+- Slicing and advanced/boolean indexing operations on ``Index`` classes as well
+  as :meth:`Index.delete` and :meth:`Index.drop` methods will no longer change type of the
+  resulting index (:issue:`6440`, :issue:`7040`)
 
   .. ipython:: python
 
      i = pd.Index([1, 2, 3, 'a' , 'b', 'c'])
      i[[0,1,2]]
+     i.drop(['a', 'b', 'c'])
 
   Previously, the above operation would return ``Int64Index``.  If you'd like
   to do this manually, use :meth:`Index.astype`

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1760,14 +1760,13 @@ class Index(IndexOpsMixin, FrozenNDArray):
 
     def delete(self, loc):
         """
-        Make new Index with passed location deleted
+        Make new Index with passed location(-s) deleted
 
         Returns
         -------
         new_index : Index
         """
-        arr = np.delete(self.values, loc)
-        return Index(arr)
+        return np.delete(self, loc)
 
     def insert(self, loc, item):
         """


### PR DESCRIPTION
This should close #6933.

The downside of this patch is that we'll lose type inference that might change index type in rare occasions when index items have different dtypes. This is the same issue that occurred in #6440, and it was ruled out as infrequent and worth dropping for extra performance.

Note though, that the benchmark results are not exactly what I've expected:

``` python

In [39]: idx = tm.makeStringIndex(100000)

In [40]: timeit idx.delete(-1)
1000 loops, best of 3: 1.46 ms per loop

In [41]: timeit np.delete(idx, -1)
1000 loops, best of 3: 1.05 ms per loop

```

The result is faster, but not as fast as I'd expect. This is probably because of object refcounting overhead, because MultiIndex fares a lot better with its Categorial-like implementation:

``` python
In [42]: midx = pd.MultiIndex.from_product([[0], idx])

# <..snip..>

In [45]: timeit midx.delete(-1)
1000 loops, best of 3: 225 µs per loop

```
