### PR TITLE
BUG: unstack fails in PeriodIndex

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -487,6 +487,7 @@ Bug Fixes
   views; mark ``is_copy`` on ``xs` only if its an actual copy (and not a view) (:issue:`7084`)
 - Bug in DatetimeIndex creation from string ndarray with ``dayfirst=True`` (:issue:`5917`)
 - Bug in ``MultiIndex.from_arrays`` created from ``DatetimeIndex`` doesn't preserve ``freq`` and ``tz`` (:issue:`7090`)
+- Bug in ``unstack`` raises ``ValueError`` when ``MultiIndex`` contains ``PeriodIndex`` (:issue:`4342`)
 
 pandas 0.13.1
 -------------

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -18,6 +18,7 @@ import pandas.core.common as com
 import pandas.algos as algos
 
 from pandas.core.index import Index, MultiIndex
+from pandas.tseries.period import PeriodIndex
 
 
 class _Unstacker(object):
@@ -81,8 +82,11 @@ class _Unstacker(object):
         labels = index.labels
 
         def _make_index(lev, lab):
-            i = lev.__class__(_make_index_array_level(lev.values, lab))
-            i.name = lev.name
+            if isinstance(lev, PeriodIndex):
+                i = lev.copy()
+            else:
+                i = lev.__class__(_make_index_array_level(lev.values, lab))
+                i.name = lev.name
             return i
 
         self.new_index_levels = [_make_index(lev, lab)

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -13,6 +13,7 @@ from pandas.core.frame import DataFrame
 from pandas.tseries.period import PeriodIndex
 from pandas.util.testing import assert_almost_equal
 import pandas.core.common as com
+from pandas.tseries.period import PeriodIndex
 
 import pandas.util.testing as tm
 
@@ -183,7 +184,7 @@ class TestCategorical(tm.TestCase):
 
     def test_periodindex(self):
         idx1 = PeriodIndex(['2014-01', '2014-01', '2014-02', '2014-02',
-                               '2014-03', '2014-03'], freq='M')
+                            '2014-03', '2014-03'], freq='M')
         cat1 = Categorical.from_array(idx1)
 
         exp_arr = np.array([0, 0, 1, 1, 2, 2])
@@ -192,8 +193,9 @@ class TestCategorical(tm.TestCase):
         self.assert_numpy_array_equal(cat1.labels, exp_arr)
         self.assert_(cat1.levels.equals(exp_idx))
 
+
         idx2 = PeriodIndex(['2014-03', '2014-03', '2014-02', '2014-01',
-                               '2014-03', '2014-01'], freq='M')
+                            '2014-03', '2014-01'], freq='M')
         cat2 = Categorical.from_array(idx2)
 
         exp_arr = np.array([2, 2, 1, 0, 2, 0])

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -2177,7 +2177,7 @@ class TestPeriodIndex(tm.TestCase):
 
     def test_factorize(self):
         idx1 = PeriodIndex(['2014-01', '2014-01', '2014-02', '2014-02',
-                       '2014-03', '2014-03'], freq='M')
+                            '2014-03', '2014-03'], freq='M')
 
         exp_arr = np.array([0, 0, 1, 1, 2, 2])
         exp_idx = PeriodIndex(['2014-01', '2014-02', '2014-03'], freq='M')


### PR DESCRIPTION
Closes #4342.

Also changed `Categorical` and `PeriodIndex.factorize` to make index sorted like other indexes do.
