### PR TITLE
API: update nth to use the _set_selection_from_grouper makes first==nth(0) and last==nth(-1)

### DIFF
--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -397,7 +397,7 @@ index are the group names and whose values are the sizes of each group.
    named *columns*.
 
    Aggregating functions are ones that reduce the dimension of the returned objects,
-   for example: ``mean, sum, size, count, std, var, describe, first, last, min, max``. This is
+   for example: ``mean, sum, size, count, std, var, describe, first, last, nth, min, max``. This is
    what happens when you do for example ``DataFrame.sum()`` and get back a ``Series``.
 
 .. _groupby.aggregate.multifunc:
@@ -613,7 +613,7 @@ For dataframes with multiple columns, filters should explicitly specify a column
    a reduced shape of the original (and potentitally eliminating groups), but with the index unchanged.
    Passing ``as_index=False`` will not affect these transformation methods.
 
-   For example: ``head, tail nth``.
+   For example: ``head, tail``.
 
    .. ipython:: python
 

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -190,7 +190,7 @@ API Changes
   validation warnings in :func:`read_csv`/:func:`read_table` (:issue:`6607`)
 - Raise a ``TypeError`` when ``DataFrame`` is passed an iterator as the
   ``data`` argument (:issue:`5357`)
-- groupby will now not return the grouped column for non-cython functions (:issue:`5610`, :issue:`5614`),
+- groupby will now not return the grouped column for non-cython functions (:issue:`5610`, :issue:`5614`, :issue:`6732`),
   as its already the index
 - ``DataFrame.plot`` and ``Series.plot`` now supports area plot with specifying ``kind='area'`` (:issue:`6656`)
 - Line plot can be stacked by ``stacked=True``. (:issue:`6656`)

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -22,6 +22,8 @@ users upgrade to this version.
 
 - :ref:`API Changes <whatsnew_0140.api>`
 
+- :ref:`Groupby API Changes <whatsnew_0140.groupby>`
+
 - :ref:`Performance Improvements <whatsnew_0140.performance>`
 
 - :ref:`Prior Deprecations <whatsnew_0140.prior_deprecations>`
@@ -94,57 +96,6 @@ API changes
      s.index.year
 
 - Add ``is_month_start``, ``is_month_end``, ``is_quarter_start``, ``is_quarter_end``, ``is_year_start``, ``is_year_end`` accessors for ``DateTimeIndex`` / ``Timestamp`` which return a boolean array of whether the timestamp(s) are at the start/end of the month/quarter/year defined by the frequency of the ``DateTimeIndex`` / ``Timestamp`` (:issue:`4565`, :issue:`6998`)
-
-- More consistent behaviour for some groupby methods:
-
-  groupby ``head`` and ``tail`` now act more like ``filter`` rather than an aggregation:
-
-  .. ipython:: python
-
-     df = pd.DataFrame([[1, 2], [1, 4], [5, 6]], columns=['A', 'B'])
-     g = df.groupby('A')
-     g.head(1)  # filters DataFrame
-
-     g.apply(lambda x: x.head(1))  # used to simply fall-through
-
-  groupby head and tail respect column selection:
-
-  .. ipython:: python
-
-     g[['B']].head(1)
-
-  groupby ``nth`` now filters by default, with optional dropna argument to ignore
-  NaN (to replicate the previous behaviour.), See :ref:`the docs <groupby.nth>`.
-
-  .. ipython:: python
-
-     df = DataFrame([[1, np.nan], [1, 4], [5, 6]], columns=['A', 'B'])
-     g = df.groupby('A')
-     g.nth(0)  # can also use negative ints
-
-     g.nth(0, dropna='any')  # similar to old behaviour
-
-  groupby will now not return the grouped column for non-cython functions (:issue:`5610`, :issue:`5614`, :issue:`6732`),
-  as its already the index
-
-  .. ipython:: python
-
-     df = DataFrame([[1, np.nan], [1, 4], [5, 6], [5, 8]], columns=['A', 'B'])
-     g = df.groupby('A')
-     g.count()
-     g.describe()
-
-  passing ``as_index`` will leave the grouped column in-place (this is not change in 0.14.0)
-
-  .. ipython:: python
-
-     df = DataFrame([[1, np.nan], [1, 4], [5, 6], [5, 8]], columns=['A', 'B'])
-     g = df.groupby('A',as_index=False)
-     g.count()
-     g.describe()
-
-- Allow specification of a more complex groupby via ``pd.Grouper``, such as grouping
-  by a Time and a string field simultaneously. See :ref:`the docs <groupby.specify>`. (:issue:`3794`)
 
 - Local variable usage has changed in
   :func:`pandas.eval`/:meth:`DataFrame.eval`/:meth:`DataFrame.query`
@@ -246,6 +197,62 @@ API changes
 - accept ``TextFileReader`` in ``concat``, which was affecting a common user idiom (:issue:`6583`), this was a regression
   from 0.13.1
 - Added ``factorize`` functions to ``Index`` and ``Series`` to get indexer and unique values (:issue:`7090`)
+
+.. _whatsnew_0140.groupby:
+
+Groupby API Changes
+~~~~~~~~~~~~~~~~~~~
+
+More consistent behaviour for some groupby methods:
+
+- groupby ``head`` and ``tail`` now act more like ``filter`` rather than an aggregation:
+
+  .. ipython:: python
+
+     df = pd.DataFrame([[1, 2], [1, 4], [5, 6]], columns=['A', 'B'])
+     g = df.groupby('A')
+     g.head(1)  # filters DataFrame
+
+     g.apply(lambda x: x.head(1))  # used to simply fall-through
+
+- groupby head and tail respect column selection:
+
+  .. ipython:: python
+
+     g[['B']].head(1)
+
+- groupby ``nth`` now filters by default, with optional dropna argument to ignore
+  NaN (to replicate the previous behaviour.), See :ref:`the docs <groupby.nth>`.
+
+  .. ipython:: python
+
+     df = DataFrame([[1, np.nan], [1, 4], [5, 6]], columns=['A', 'B'])
+     g = df.groupby('A')
+     g.nth(0)  # can also use negative ints
+
+     g.nth(0, dropna='any')  # similar to old behaviour
+
+- groupby will now not return the grouped column for non-cython functions (:issue:`5610`, :issue:`5614`, :issue:`6732`),
+  as its already the index
+
+  .. ipython:: python
+
+     df = DataFrame([[1, np.nan], [1, 4], [5, 6], [5, 8]], columns=['A', 'B'])
+     g = df.groupby('A')
+     g.count()
+     g.describe()
+
+- passing ``as_index`` will leave the grouped column in-place (this is not change in 0.14.0)
+
+  .. ipython:: python
+
+     df = DataFrame([[1, np.nan], [1, 4], [5, 6], [5, 8]], columns=['A', 'B'])
+     g = df.groupby('A',as_index=False)
+     g.count()
+     g.describe()
+
+- Allow specification of a more complex groupby via ``pd.Grouper``, such as grouping
+  by a Time and a string field simultaneously. See :ref:`the docs <groupby.specify>`. (:issue:`3794`)
 
 .. _whatsnew_0140.sql:
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -124,7 +124,7 @@ API changes
 
      g.nth(0, dropna='any')  # similar to old behaviour
 
-  groupby will now not return the grouped column for non-cython functions (:issue:`5610`, :issue:`5614`),
+  groupby will now not return the grouped column for non-cython functions (:issue:`5610`, :issue:`5614`, :issue:`6732`),
   as its already the index
 
   .. ipython:: python


### PR DESCRIPTION
closes  #6732

`nth` sets the index appropriately and the same as first/last.

this becomes less like head/tail in that `as_index` determines when you have an index

here's the revised behavior:

```
In [1]: df = DataFrame([[1, np.nan], [1, 4], [5, 6]], columns=['A', 'B'])

In [3]: df
Out[3]: 
   A   B
0  1 NaN
1  1   4
2  5   6

[3 rows x 2 columns]

In [2]: g = df.groupby('A')

In [9]: gni = df.groupby('A',as_index=False)
```

```
In [5]: g.first()
Out[5]: 
   B
A   
1  4
5  6

[2 rows x 1 columns]

# this was a regression from 0.13.1 (in that before this PR, this was returning like ``as_index=False``)
In [6]: g.nth(0)
Out[6]: 
    B
A    
1 NaN
5   6

[2 rows x 1 columns]

In [7]: g.nth(0,dropna='all')
Out[7]: 
   B
A   
1  4
5  6

[2 rows x 1 columns]
```

```
In [10]: gni.nth(0)
Out[10]: 
   A   B
0  1 NaN
2  5   6

[2 rows x 2 columns]

In [11]: gni.nth(0,dropna='all')
Out[11]: 
   A  B
0  1  4
1  5  6

[2 rows x 2 columns]
```
