### PR TITLE
Added dropna to docstring for HDFStore.put()

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -809,6 +809,8 @@ class HDFStore(StringMixin):
             This will force Table format, append the input data to the
             existing.
         encoding : default None, provide an encoding for strings
+        dropna   : boolean, default True, do not write an ALL nan row to
+            the store 
         """
         if format is None:
             format = get_option("io.hdf.default_format") or 'fixed'

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -810,7 +810,7 @@ class HDFStore(StringMixin):
             existing.
         encoding : default None, provide an encoding for strings
         dropna   : boolean, default True, do not write an ALL nan row to
-            the store 
+            the store settable by the option 'io.hdf.dropna_table'
         """
         if format is None:
             format = get_option("io.hdf.default_format") or 'fixed'


### PR DESCRIPTION
HDFStore.put() method accepts dropna boolean parameter as it is passed
directly to the internal _write_to_group() method, but it was not
explicitly documented (as it is for append).
Just added 2 lines to the put() method docstring to mention it explicitly.  
