### PR TITLE
Fix Xl(sx|wt)Writer always using date_format even if a datetime is supplied.

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -478,6 +478,7 @@ Bug Fixes
 - Bug in ``Float64Index.isin()`` where containing ``nan`` s would make indices
   claim that they contained all the things (:issue:`7066`).
 - Bug in ``DataFrame.boxplot`` where it failed to use the axis passed as the ``ax`` argument (:issue:`3578`)
+- Bug in the ``XlsxWriter`` and ``XlwtWriter`` implementations that resulted in datetime columns being formatted without the time (:issue:`7075`)
 
 pandas 0.13.1
 -------------

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -661,7 +661,7 @@ class _XlwtWriter(ExcelWriter):
             num_format_str = None
             if isinstance(cell.val, datetime.datetime):
                 num_format_str = self.datetime_format
-            if isinstance(cell.val, datetime.date):
+            elif isinstance(cell.val, datetime.date):
                 num_format_str = self.date_format
 
             stylekey = json.dumps(cell.style)
@@ -782,7 +782,7 @@ class _XlsxWriter(ExcelWriter):
             num_format_str = None
             if isinstance(cell.val, datetime.datetime):
                 num_format_str = self.datetime_format
-            if isinstance(cell.val, datetime.date):
+            elif isinstance(cell.val, datetime.date):
                 num_format_str = self.date_format
 
             stylekey = json.dumps(cell.style)


### PR DESCRIPTION
In the `XlsxWriter` and `XlwtWriter` implementations there is a minor bug resulting in the `datetime_format` being discarded (i.e. https://github.com/pydata/pandas/blob/master/pandas/io/excel.py#L662):

```
if isinstance(cell.val, datetime.datetime):
    num_format_str = self.datetime_format
if isinstance(cell.val, datetime.date):
    num_format_str = self.date_format
```

Since `datetime.datetime` derives from `datetime.date` the second `if`-clause in the  will always trigger, leading to the `num_format_str` being overwritten by the `date_format`.
