### PR TITLE
FIX sql handling of timedelta64 columns (GH6921)

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -809,8 +809,6 @@ two extra parameters:
     String value 'infer' can be used to instruct the parser to try detecting
     the column specifications from the first 100 rows of the data. Default
     behaviour, if not specified, is to infer.
-    As with regular python slices, you can slice to the end of the line
-    with ``None``, e.g. ``colspecs = [(0, 1), (1, None)]``.
   - ``widths``: A list of field widths which can be used instead of 'colspecs'
     if the intervals are contiguous.
 
@@ -3234,6 +3232,13 @@ the database using :func:`~pandas.DataFrame.to_sql`.
 .. ipython:: python
 
     data.to_sql('data', engine)
+
+.. note::
+
+    Due to the limited support for timedelta's in the different database
+    flavors, columns with type ``timedelta64`` will be written as integer
+    values as nanoseconds to the database and a warning will be raised.
+
 
 Reading Tables
 ~~~~~~~~~~~~~~

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -730,7 +730,10 @@ class PandasSQLTable(PandasObject):
             except:
                 return DateTime
         if com.is_timedelta64_dtype(arr_or_dtype):
-            return Interval
+            warnings.warn("the 'timedelta' type is not supported, and will be "
+                          "written as integer values (ns frequency) to the "
+                          "database.", UserWarning)
+            return Integer
         elif com.is_float_dtype(arr_or_dtype):
             return Float
         elif com.is_integer_dtype(arr_or_dtype):
@@ -973,6 +976,11 @@ class PandasSQLTableLegacy(PandasSQLTable):
         pytype_name = "text"
         if issubclass(pytype, np.floating):
             pytype_name = "float"
+        elif com.is_timedelta64_dtype(pytype):
+            warnings.warn("the 'timedelta' type is not supported, and will be "
+                          "written as integer values (ns frequency) to the "
+                          "database.", UserWarning)
+            pytype_name = "int"
         elif issubclass(pytype, np.integer):
             pytype_name = "int"
         elif issubclass(pytype, np.datetime64) or pytype is datetime:


### PR DESCRIPTION
Closes #6921

Converting to an int was actually also how it was now with sqlite DBAPI fallback (as timedelta64 is subclass of integer), so this solution is also backwards compatible and consistent between sqlalchemy and fallback mode.
