### PR TITLE
SQL: resolve legacy mode + deprecate mysql flavor (GH6900)

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -3159,9 +3159,9 @@ your database.
 
 .. versionadded:: 0.14.0
 
-
-If SQLAlchemy is not installed a legacy fallback is provided for sqlite and mysql.
-These legacy modes require Python database adapters which respect the `Python
+If SQLAlchemy is not installed, a fallback is only provided for sqlite (and
+for mysql for backwards compatibility, but this is deprecated).
+This mode requires a Python database adapter which respect the `Python
 DB-API <http://www.python.org/dev/peps/pep-0249/>`__.
 
 See also some :ref:`cookbook examples <cookbook.sql>` for some advanced strategies.
@@ -3335,9 +3335,14 @@ Engine connection examples
   engine = create_engine('sqlite:////absolute/path/to/foo.db')
 
 
-Legacy
-~~~~~~
-To use the sqlite support without SQLAlchemy, you can create connections like so:
+Sqlite fallback
+~~~~~~~~~~~~~~~
+
+The use of sqlite is supported without using SQLAlchemy.
+This mode requires a Python database adapter which respect the `Python
+DB-API <http://www.python.org/dev/peps/pep-0249/>`__.
+
+You can create connections like so:
 
 .. code-block:: python
 
@@ -3345,14 +3350,13 @@ To use the sqlite support without SQLAlchemy, you can create connections like so
    from pandas.io import sql
    cnx = sqlite3.connect(':memory:')
 
-And then issue the following queries, remembering to also specify the flavor of SQL
-you are using.
+And then issue the following queries:
 
 .. code-block:: python
 
-   data.to_sql('data', cnx,  flavor='sqlite')
+   data.to_sql('data', cnx)
 
-   sql.read_sql("SELECT * FROM data", cnx, flavor='sqlite')
+   sql.read_sql("SELECT * FROM data", cnx)
 
 
 .. _io.bigquery:

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -246,6 +246,9 @@ Deprecations
   positional argument ``frame`` instead of ``data``. A ``FutureWarning`` is
   raised  if the old ``data`` argument is used by name. (:issue:`6956`)
 
+- The support for the 'mysql' flavor when using DBAPI connection objects has been deprecated.
+  MySQL will be further supported with SQLAlchemy engines (:issue:`6900`).
+
 Prior Version Deprecations/Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -475,6 +475,9 @@ Deprecations
   returned if possible, otherwise a copy will be made. Previously the user could think that ``copy=False`` would
   ALWAYS return a view. (:issue:`6894`)
 
+- The support for the 'mysql' flavor when using DBAPI connection objects has been deprecated.
+  MySQL will be further supported with SQLAlchemy engines (:issue:`6900`).
+
 .. _whatsnew_0140.enhancements:
 
 Enhancements


### PR DESCRIPTION
- removed warning for not using sqlalchemy (as sqlite DBAPI connection is fully supported, no warning needed)
- added deprecation warning for 'mysql' flavor
- removed necessity of providing flavor kwarg (no warning if not provided, assumed to be sqlite3)
- removed `flavor` kwarg from execute and read_sql_query (because a) are not database specific functions + b) would only be needed for mysql, but this will is deprecated so no need to introduce it)
- updated the tests to reflect this
- updated docs and docstrings to reflect that sqlite3 is the only but fully supported DBAPI connection (no 'legacy')

Closes #6900.
