### PR TITLE
adding a NotImplementedError for simultaneous use of nrows and chunksize...

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -86,7 +86,8 @@ Enhancements
 
 
 - Add ``dropna`` argument to ``value_counts`` and ``nunique`` (:issue:`5569`).
-
+- Add ``NotImplementedError`` for simultaneous use of ``chunksize`` and ``nrows``
+  for read_csv() (:issue:`6774`).
 
 
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -227,7 +227,10 @@ def _read(filepath_or_buffer, kwds):
     # Create the parser.
     parser = TextFileReader(filepath_or_buffer, **kwds)
 
-    if nrows is not None:
+    if (nrows is not None) and (chunksize is not None):
+        raise NotImplementedError("'nrows' and 'chunksize' can not be used"
+                                  " together yet.")
+    elif nrows is not None:
         return parser.read(nrows)
     elif chunksize or iterator:
         return parser

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -1973,13 +1973,6 @@ A,B,C
                                header=0)
         tm.assert_frame_equal(result, expected)
 
-    def test_integer_overflow_bug(self):
-        # #2601
-        data = "65248E10 11\n55555E55 22\n"
-
-        result = self.read_csv(StringIO(data), header=None, sep=' ')
-        self.assertTrue(result[0].dtype == np.float64)
-
     def test_int64_min_issues(self):
         # #2599
         data = 'A,B\n0,0\n0,'
@@ -2141,6 +2134,10 @@ a,b,c
         expected = DataFrame({'a':[1,4,7], 'b':[2,5,8], 'c': [3,6,9]})
         tm.assert_frame_equal(result, expected)
 
+    def test_nrows_and_chunksize_raises_notimplemented(self):
+        data = 'a b c'
+        self.assertRaises(NotImplementedError, self.read_csv, StringIO(data),
+                     nrows=10, chunksize=5)
 
 
 class TestPythonParser(ParserTests, tm.TestCase):


### PR DESCRIPTION
..., as the user intention most likely is to get a TextFileReader, when using the chunksize option.
Fixes #6774
