### PR TITLE
ENH/API: accept list-like percentiles in describe (WIP)

### DIFF
--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -454,6 +454,7 @@ non-null values:
    series[10:20]  = 5
    series.nunique()
 
+.. _basics.describe:
 
 Summarizing data: describe
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -471,7 +472,13 @@ course):
     frame.ix[::2] = np.nan
     frame.describe()
 
-.. _basics.describe:
+You can select specific percentiles to include in the output:
+
+.. ipython:: python
+
+    series.describe(percentiles=[.05, .25, .75, .95])
+
+By default, the median is always included.
 
 For a non-numerical Series object, `describe` will give a simple summary of the
 number of unique values and most frequently occurring values:
@@ -481,6 +488,7 @@ number of unique values and most frequently occurring values:
 
    s = Series(['a', 'a', 'b', 'b', 'a', 'a', np.nan, 'c', 'd', 'a'])
    s.describe()
+
 
 There also is a utility function, ``value_range`` which takes a DataFrame and
 returns a series with the minimum/maximum values in the DataFrame.

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -204,6 +204,8 @@ API Changes
 - Produce :class:`~pandas.io.parsers.ParserWarning` on fallback to python
   parser when no options are ignored (:issue:`6607`)
 - Added ``factorize`` functions to ``Index`` and ``Series`` to get indexer and unique values (:issue:`7090`)
+- :meth:`DataFrame.describe` on a DataFrame with a mix of Timestamp and string like objects
+  returns a different Index (:issue:`7088`). Previously the index was unintentionally sorted.
 
 Deprecations
 ~~~~~~~~~~~~
@@ -249,6 +251,10 @@ Deprecations
 
 - The support for the 'mysql' flavor when using DBAPI connection objects has been deprecated.
   MySQL will be further supported with SQLAlchemy engines (:issue:`6900`).
+
+- The `percentile_width` keyword argument in :meth:`~DataFrame.describe` has been deprecated.
+  Use the `percentiles` keyword instead, which takes a list of percentiles to display. The
+  default output is unchanged.
 
 Prior Version Deprecations/Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -339,6 +345,7 @@ Improvements to existing features
 - ``boxplot`` now supports ``layout`` keyword (:issue:`6769`)
 - Regression in the display of a MultiIndexed Series with ``display.max_rows`` is less than the
   length of the series (:issue:`7101`)
+- :meth:`~DataFrame.describe` now accepts an array of percentiles to include in the summary statistics (:issue:`4196`)
 
 .. _release.bug_fixes-0.14.0:
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -196,6 +196,8 @@ API changes
 - accept ``TextFileReader`` in ``concat``, which was affecting a common user idiom (:issue:`6583`), this was a regression
   from 0.13.1
 - Added ``factorize`` functions to ``Index`` and ``Series`` to get indexer and unique values (:issue:`7090`)
+- ``describe`` on a DataFrame with a mix of Timestamp and string like objects returns a different Index (:issue:`7088`).
+  Previously the index was unintentionally sorted.
 
 .. _whatsnew_0140.display:
 
@@ -509,6 +511,10 @@ Deprecations
 - The support for the 'mysql' flavor when using DBAPI connection objects has been deprecated.
   MySQL will be further supported with SQLAlchemy engines (:issue:`6900`).
 
+- The `percentile_width` keyword argument in :meth:`~DataFrame.describe` has been deprecated.
+  Use the `percentiles` keyword instead, which takes a list of percentiles to display. The
+  default output is unchanged.
+
 .. _whatsnew_0140.enhancements:
 
 Enhancements
@@ -575,6 +581,7 @@ Enhancements
 - ``CustomBuisnessMonthBegin`` and ``CustomBusinessMonthEnd`` are now available (:issue:`6866`)
 - :meth:`Series.quantile` and :meth:`DataFrame.quantile` now accept an array of
   quantiles.
+- :meth:`~DataFrame.describe` now accepts an array of percentiles to include in the summary statistics (:issue:`4196`)
 - ``pivot_table`` can now accept ``Grouper`` by ``index`` and ``columns`` keywords (:issue:`6913`)
 
   .. ipython:: python

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3805,54 +3805,6 @@ class DataFrame(NDFrame):
 
         return correl
 
-    def describe(self, percentile_width=50):
-        """
-        Generate various summary statistics of each column, excluding
-        NaN values. These include: count, mean, std, min, max, and
-        lower%/50%/upper% percentiles
-
-        Parameters
-        ----------
-        percentile_width : float, optional
-            width of the desired uncertainty interval, default is 50,
-            which corresponds to lower=25, upper=75
-
-        Returns
-        -------
-        DataFrame of summary statistics
-        """
-        numdata = self._get_numeric_data()
-
-        if len(numdata.columns) == 0:
-            return DataFrame(dict((k, v.describe())
-                                  for k, v in compat.iteritems(self)),
-                             columns=self.columns)
-
-        lb = .5 * (1. - percentile_width / 100.)
-        ub = 1. - lb
-
-        def pretty_name(x):
-            x *= 100
-            if x == int(x):
-                return '%.0f%%' % x
-            else:
-                return '%.1f%%' % x
-
-        destat_columns = ['count', 'mean', 'std', 'min',
-                          pretty_name(lb), '50%', pretty_name(ub),
-                          'max']
-
-        destat = []
-
-        for i in range(len(numdata.columns)):
-            series = numdata.iloc[:, i]
-            destat.append([series.count(), series.mean(), series.std(),
-                           series.min(), series.quantile(lb), series.median(),
-                           series.quantile(ub), series.max()])
-
-        return self._constructor(lmap(list, zip(*destat)),
-                                 index=destat_columns, columns=numdata.columns)
-
     #----------------------------------------------------------------------
     # ndarray-like stats methods
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1267,67 +1267,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     def ptp(self, axis=None, out=None):
         return _values_from_object(self).ptp(axis, out)
 
-    def describe(self, percentile_width=50):
-        """
-        Generate various summary statistics of Series, excluding NaN
-        values. These include: count, mean, std, min, max, and
-        lower%/50%/upper% percentiles
-
-        Parameters
-        ----------
-        percentile_width : float, optional
-            width of the desired uncertainty interval, default is 50,
-            which corresponds to lower=25, upper=75
-
-        Returns
-        -------
-        desc : Series
-        """
-        from pandas.compat import Counter
-
-        if self.dtype == object:
-            names = ['count', 'unique']
-            objcounts = Counter(self.dropna().values)
-            data = [self.count(), len(objcounts)]
-            if data[1] > 0:
-                names += ['top', 'freq']
-                top, freq = objcounts.most_common(1)[0]
-                data += [top, freq]
-
-        elif issubclass(self.dtype.type, np.datetime64):
-            names = ['count', 'unique']
-            asint = self.dropna().values.view('i8')
-            objcounts = Counter(asint)
-            data = [self.count(), len(objcounts)]
-            if data[1] > 0:
-                top, freq = objcounts.most_common(1)[0]
-                names += ['first', 'last', 'top', 'freq']
-                data += [lib.Timestamp(asint.min()),
-                         lib.Timestamp(asint.max()),
-                         lib.Timestamp(top), freq]
-        else:
-
-            lb = .5 * (1. - percentile_width / 100.)
-            ub = 1. - lb
-
-            def pretty_name(x):
-                x *= 100
-                if x == int(x):
-                    return '%.0f%%' % x
-                else:
-                    return '%.1f%%' % x
-
-            names = ['count']
-            data = [self.count()]
-            names += ['mean', 'std', 'min', pretty_name(lb), '50%',
-                      pretty_name(ub), 'max']
-            data += [self.mean(), self.std(), self.min(),
-                     self.quantile(
-                         lb), self.median(), self.quantile(ub),
-                     self.max()]
-
-        return self._constructor(data, index=names).__finalize__(self)
-
     def corr(self, other, method='pearson',
              min_periods=None):
         """

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -11224,40 +11224,6 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_almost_equal(ranks0.values, exp0)
         assert_almost_equal(ranks1.values, exp1)
 
-    def test_describe(self):
-        desc = self.tsframe.describe()
-        desc = self.mixed_frame.describe()
-        desc = self.frame.describe()
-
-    def test_describe_percentiles(self):
-        desc = self.frame.describe(percentile_width=50)
-        assert '75%' in desc.index
-        assert '25%' in desc.index
-
-        desc = self.frame.describe(percentile_width=95)
-        assert '97.5%' in desc.index
-        assert '2.5%' in desc.index
-
-    def test_describe_no_numeric(self):
-        df = DataFrame({'A': ['foo', 'foo', 'bar'] * 8,
-                        'B': ['a', 'b', 'c', 'd'] * 6})
-        desc = df.describe()
-        expected = DataFrame(dict((k, v.describe())
-                                  for k, v in compat.iteritems(df)),
-                             columns=df.columns)
-        assert_frame_equal(desc, expected)
-
-        df = DataFrame({'time': self.tsframe.index})
-        desc = df.describe()
-        assert(desc.time['first'] == min(self.tsframe.index))
-
-    def test_describe_empty_int_columns(self):
-        df = DataFrame([[0, 1], [1, 2]])
-        desc = df[df[0] < 0].describe()  # works
-        assert_series_equal(desc.xs('count'),
-                            Series([0, 0], dtype=float, name='count'))
-        self.assert_(isnull(desc.ix[1:]).all().all())
-
     def test_axis_aliases(self):
 
         f = self.frame

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -2219,56 +2219,6 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
                                             Timestamp('2000-01-10 19:12:00')],
                                            index=[.2, .2]))
 
-    def test_describe(self):
-        _ = self.series.describe()
-        _ = self.ts.describe()
-
-    def test_describe_percentiles(self):
-        desc = self.series.describe(percentile_width=50)
-        assert '75%' in desc.index
-        assert '25%' in desc.index
-
-        desc = self.series.describe(percentile_width=95)
-        assert '97.5%' in desc.index
-        assert '2.5%' in desc.index
-
-    def test_describe_objects(self):
-        s = Series(['a', 'b', 'b', np.nan, np.nan, np.nan, 'c', 'd', 'a', 'a'])
-        result = s.describe()
-        expected = Series({'count': 7, 'unique': 4,
-                           'top': 'a', 'freq': 3}, index=result.index)
-        assert_series_equal(result, expected)
-
-        dt = list(self.ts.index)
-        dt.append(dt[0])
-        ser = Series(dt)
-        rs = ser.describe()
-        min_date = min(dt)
-        max_date = max(dt)
-        xp = Series({'count': len(dt),
-                     'unique': len(self.ts.index),
-                     'first': min_date, 'last': max_date, 'freq': 2,
-                     'top': min_date}, index=rs.index)
-        assert_series_equal(rs, xp)
-
-    def test_describe_empty(self):
-        result = self.empty.describe()
-
-        self.assertEqual(result['count'], 0)
-        self.assert_(result.drop('count').isnull().all())
-
-        nanSeries = Series([np.nan])
-        nanSeries.name = 'NaN'
-        result = nanSeries.describe()
-        self.assertEqual(result['count'], 0)
-        self.assert_(result.drop('count').isnull().all())
-
-    def test_describe_none(self):
-        noneSeries = Series([None])
-        noneSeries.name = 'None'
-        assert_series_equal(noneSeries.describe(),
-                            Series([0, 0], index=['count', 'unique']))
-
     def test_append(self):
         appendedSeries = self.series.append(self.objSeries)
         for idx, value in compat.iteritems(appendedSeries):


### PR DESCRIPTION
Closes https://github.com/pydata/pandas/issues/4196

This is for frames. I'm going to refactor this into generic since to cover series / frames.

A couple questions:
- API wise, I added a new kwarg `percentiles`. For backwards compat, we keep the `percentile_width` kwarg. I changed the default `percentile_width` from 50 to `None` (but the default output is the same) Cases:
  1. You specify `percentile_width` and `percentiles` -> `ValueError`
  2. You specify neither `percentile_width` nor `percentiles` -> `percentile_width` set to 50 and same as before
  3. You specify one of those, everything goes as expected.
- I'm accepting either decimals (e.g. [0.25, .5, .75]) or percentages (e.g. [25, 50, 75]). Those two are equivalent in output. Should I move this logic to the `.quantile` to be more consistent?
- I'm choosing to not sort the provided percentiles. It's easy for the user to sort, but hard for them to unsort if for some reason they want it in a specific order. I'd rather not add another kwarg.
