### PR TITLE
BUG: tz info lost by set_index and reindex

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -495,6 +495,8 @@ Bug Fixes
 - Bug in ``boxplot`` and ``hist`` draws unnecessary axes (:issue:`6769`)
 - Regression in ``groupby.nth()`` for out-of-bounds indexers (:issue:`6621`)
 - Bug in ``quantile`` with datetime values (:issue:`6965`)
+- Bug in ``Dataframe.set_index``, ``reindex`` and ``pivot`` don't preserve ``DatetimeIndex`` and ``PeriodIndex`` attributes (:issue:`3950`, :issue:`5878`, :issue:`6631`)
+- Bug in ``MultiIndex.get_level_values`` doesn't preserve ``DatetimeIndex`` and ``PeriodIndex`` attributes (:issue:`7092`)
 
 pandas 0.13.1
 -------------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2220,7 +2220,7 @@ class DataFrame(NDFrame):
                 for i in range(self.index.nlevels):
                     arrays.append(self.index.get_level_values(i))
             else:
-                arrays.append(np.asarray(self.index))
+                arrays.append(self.index)
 
         to_remove = []
         for col in keys:
@@ -2232,9 +2232,12 @@ class DataFrame(NDFrame):
 
                 level = col.get_level_values(col.nlevels - 1)
                 names.extend(col.names)
-            elif isinstance(col, (Series, Index)):
+            elif isinstance(col, Series):
                 level = col.values
                 names.append(col.name)
+            elif isinstance(col, Index):
+                level = col
+                names.append(col.name)                
             elif isinstance(col, (list, np.ndarray)):
                 level = col
                 names.append(None)

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -82,11 +82,10 @@ class _Unstacker(object):
         labels = index.labels
 
         def _make_index(lev, lab):
-            if isinstance(lev, PeriodIndex):
-                i = lev.copy()
-            else:
-                i = lev.__class__(_make_index_array_level(lev.values, lab))
-                i.name = lev.name
+            values = _make_index_array_level(lev.values, lab)
+            i = lev._simple_new(values, lev.name, 
+                                freq=getattr(lev, 'freq', None),
+                                tz=getattr(lev, 'tz', None))
             return i
 
         self.new_index_levels = [_make_index(lev, lab)

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -180,6 +180,19 @@ class TestIndex(tm.TestCase):
         assert_array_equal(rs, xp)
         tm.assert_isinstance(rs, PeriodIndex)
 
+    def test_constructor_simple_new(self):
+        idx = Index([1, 2, 3, 4, 5], name='int')
+        result = idx._simple_new(idx, 'int')
+        self.assert_(result.equals(idx))
+
+        idx = Index([1.1, np.nan, 2.2, 3.0], name='float')
+        result = idx._simple_new(idx, 'float')
+        self.assert_(result.equals(idx))
+
+        idx = Index(['A', 'B', 'C', np.nan], name='obj')
+        result = idx._simple_new(idx, 'obj')
+        self.assert_(result.equals(idx))
+
     def test_copy(self):
         i = Index([], name='Foo')
         i_copy = i.copy()

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -669,6 +669,13 @@ class PeriodIndex(Int64Index):
 
         return data, freq
 
+    @classmethod
+    def _simple_new(cls, values, name, freq=None, **kwargs):
+        result = values.view(cls)
+        result.name = name
+        result.freq = freq
+        return result
+
     def __contains__(self, key):
         if not isinstance(key, Period) or key.freq != self.freq:
             if isinstance(key, compat.string_types):

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -1194,6 +1194,14 @@ class TestPeriodIndex(tm.TestCase):
 
         self.assertRaises(ValueError, PeriodIndex, vals, freq='D')
 
+    def test_constructor_simple_new(self):
+        idx = period_range('2007-01', name='p', periods=20, freq='M')
+        result = idx._simple_new(idx, 'p', freq=idx.freq)
+        self.assert_(result.equals(idx))
+
+        result = idx._simple_new(idx.astype('i8'), 'p', freq=idx.freq)
+        self.assert_(result.equals(idx))
+
     def test_is_(self):
         create_index = lambda: PeriodIndex(freq='A', start='1/1/2001',
                                            end='12/1/2009')
@@ -1389,6 +1397,17 @@ class TestPeriodIndex(tm.TestCase):
         rs = df.reset_index().set_index('index')
         tm.assert_isinstance(rs.index, PeriodIndex)
         self.assert_(rs.index.equals(rng))
+
+    def test_period_set_index_reindex(self):
+        # GH 6631
+        df = DataFrame(np.random.random(6))
+        idx1 = period_range('2011/01/01', periods=6, freq='M')
+        idx2 = period_range('2013', periods=6, freq='A')
+
+        df = df.set_index(idx1)
+        self.assert_(df.index.equals(idx1))
+        df = df.reindex(idx2)
+        self.assert_(df.index.equals(idx2))
 
     def test_nested_dict_frame_constructor(self):
         rng = period_range('1/1/2000', periods=5)

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -2510,6 +2510,17 @@ class TestDatetime64(tm.TestCase):
         self.assertEquals(df.index[0], stamp)
         self.assertEquals(df.reset_index()['Date'][0], stamp)
 
+    def test_dti_set_index_reindex(self):
+        # GH 6631
+        df = DataFrame(np.random.random(6))
+        idx1 = date_range('2011/01/01', periods=6, freq='M', tz='US/Eastern')
+        idx2 = date_range('2013', periods=6, freq='A', tz='Asia/Tokyo')
+
+        df = df.set_index(idx1)
+        self.assert_(df.index.equals(idx1))
+        df = df.reindex(idx2)
+        self.assert_(df.index.equals(idx2))
+
     def test_datetimeindex_union_join_empty(self):
         dti = DatetimeIndex(start='1/1/2001', end='2/1/2001', freq='D')
         empty = Index([])


### PR DESCRIPTION
Closes #6631. Closes #5878. Regarding #3950, original problem can be fixed by this, but `groupby` problem isn't.

Also, this includes the fix for `MultiIndex.get_level_values` doesn't retain `tz` and `freq`, as the method is used in `set_index`.

```
# current master
>>> import pandas as pd
>>> didx = pd.DatetimeIndex(start='2013/01/01', freq='H', periods=4, tz='Asia/Tokyo')
>>> pidx = pd.PeriodIndex(start='2013/01/01', freq='H', periods=4)

>>> midx = pd.MultiIndex.from_arrays([didx, pidx])
>>> midx.get_level_values(0)
<class 'pandas.tseries.index.DatetimeIndex'>
[2012-12-31 15:00:00, ..., 2012-12-31 18:00:00]
Length: 4, Freq: None, Timezone: None

>>> midx.get_level_values(1)
Int64Index([376944, 376945, 376946, 376947], dtype='int64')
```

```
# after fix
>>> midx.get_level_values(0)
<class 'pandas.tseries.index.DatetimeIndex'>
[2013-01-01 00:00:00+09:00, ..., 2013-01-01 03:00:00+09:00]
Length: 4, Freq: H, Timezone: Asia/Tokyo

>>> midx.get_level_values(1)
PeriodIndex([u'2013-01-01 00:00', u'2013-01-01 01:00', u'2013-01-01 02:00', u'2013-01-01 03:00'], freq='H')
```
