### PR TITLE
REGR: Regression in groupby.nth() for out-of-bounds indexers (GH6621)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -490,6 +490,7 @@ Bug Fixes
 - Bug in ``MultiIndex.from_arrays`` created from ``DatetimeIndex`` doesn't preserve ``freq`` and ``tz`` (:issue:`7090`)
 - Bug in ``unstack`` raises ``ValueError`` when ``MultiIndex`` contains ``PeriodIndex`` (:issue:`4342`)
 - Bug in ``boxplot`` and ``hist`` draws unnecessary axes (:issue:`6769`)
+- Regression in ``groupby.nth()`` for out-of-bounds indexers (:issue:`6621`)
 
 pandas 0.13.1
 -------------

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -891,7 +891,7 @@ class _NDFrameIndexer(object):
                 return self.obj.take(indexer, axis=axis)
 
             # this is not the most robust, but...
-            if (isinstance(labels, MultiIndex) and
+            if (isinstance(labels, MultiIndex) and len(keyarr) and
                     not isinstance(keyarr[0], tuple)):
                 level = 0
             else:

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -241,6 +241,20 @@ class TestGroupBy(tm.TestCase):
         assert_frame_equal(g.nth(7, dropna='any'), exp.iloc[[1, 2]])
         assert_frame_equal(g.nth(2, dropna='any'), exp.iloc[[1, 2]])
 
+        # out of bounds, regression from 0.13.1
+        # GH 6621
+        df = DataFrame({'color': {0: 'green', 1: 'green', 2: 'red', 3: 'red', 4: 'red'},
+                        'food': {0: 'ham', 1: 'eggs', 2: 'eggs', 3: 'ham', 4: 'pork'},
+                        'two': {0: 1.5456590000000001, 1: -0.070345000000000005, 2: -2.4004539999999999, 3: 0.46206000000000003, 4: 0.52350799999999997},
+                        'one': {0: 0.56573799999999996, 1: -0.9742360000000001, 2: 1.033801, 3: -0.78543499999999999, 4: 0.70422799999999997}}).set_index(['color', 'food'])
+
+        result = df.groupby(level=0).nth(2)
+        expected = df.iloc[[-1]]
+        assert_frame_equal(result,expected)
+
+        result = df.groupby(level=0).nth(3)
+        expected = df.loc[[]]
+        assert_frame_equal(result,expected)
 
     def test_grouper_index_types(self):
         # related GH5375

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -3253,6 +3253,7 @@ class TestIndexing(tm.TestCase):
         df = mkdf(5, 2)
         assert_frame_equal(df.iloc[:,[]], df.iloc[:, :0])  # vertical empty
         assert_frame_equal(df.iloc[[],:], df.iloc[:0, :])  # horizontal empty
+        assert_frame_equal(df.iloc[[]], df.iloc[:0, :])  # horizontal empty
 
     # FIXME: fix loc & xs
     def test_loc_empty_list_indexer_is_ok(self):
@@ -3261,6 +3262,7 @@ class TestIndexing(tm.TestCase):
         df = mkdf(5, 2)
         assert_frame_equal(df.loc[:,[]], df.iloc[:, :0])  # vertical empty
         assert_frame_equal(df.loc[[],:], df.iloc[:0, :])  # horizontal empty
+        assert_frame_equal(df.loc[[]], df.iloc[:0, :])  # horizontal empty
 
     def test_ix_empty_list_indexer_is_ok(self):
         raise nose.SkipTest('ix discards columns names')
@@ -3268,6 +3270,7 @@ class TestIndexing(tm.TestCase):
         df = mkdf(5, 2)
         assert_frame_equal(df.ix[:,[]], df.iloc[:, :0])  # vertical empty
         assert_frame_equal(df.ix[[],:], df.iloc[:0, :])  # horizontal empty
+        assert_frame_equal(df.ix[[]], df.iloc[:0, :])  # horizontal empty
 
     def test_deprecate_float_indexers(self):
 


### PR DESCRIPTION
closes #6621 
