### PR TITLE
API: Return axes from boxplot

### DIFF
--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -909,6 +909,37 @@ To see the order in which each row appears within its group, use the
 
    df.groupby('A').cumcount(ascending=False)  # kwarg only
 
+Plotting
+~~~~~~~~
+
+Groupby also works with some plotting methods.  For example, suppose we
+suspect that some features in a DataFrame my differ by group, in this case,
+the values in column 1 where the group is "B" are 3 higher on average.
+
+.. ipython:: python
+
+   np.random.seed(1234)
+   df = DataFrame(np.random.randn(50, 2))
+   df['g'] = np.random.choice(['A', 'B'], size=50)
+   df.loc[df['g'] == 'B', 1] += 3
+
+We can easily visualize this with a boxplot:
+
+..ipython:: python
+
+   @savefig groupby_boxplot.png
+   bp = df.groupby('g').boxplot()
+
+The result of calling ``boxplot`` is a dictionary whose keys are the values
+of our grouping column ``g`` ("A" and "B"). The values of the resulting dictionary
+can be controlled by the ``return_type`` keyword of ``boxplot``.
+See the :ref:`visualization documentation<visualization.box>` for more.
+
+.. warning::
+
+  For historical reasons, ``df.groupby("g").boxplot()`` is not equivalent
+  to ``df.boxplot(by="g")``. See :ref:`here<visualization.box.return>`.
+
 Examples
 --------
 

--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -925,7 +925,7 @@ the values in column 1 where the group is "B" are 3 higher on average.
 
 We can easily visualize this with a boxplot:
 
-..ipython:: python
+.. ipython:: python
 
    @savefig groupby_boxplot.png
    bp = df.groupby('g').boxplot()
@@ -938,7 +938,8 @@ See the :ref:`visualization documentation<visualization.box>` for more.
 .. warning::
 
   For historical reasons, ``df.groupby("g").boxplot()`` is not equivalent
-  to ``df.boxplot(by="g")``. See :ref:`here<visualization.box.return>`.
+  to ``df.boxplot(by="g")``. See :ref:`here<visualization.box.return>` for
+  an explanation.
 
 Examples
 --------

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -208,6 +208,9 @@ API Changes
   returns a different Index (:issue:`7088`). Previously the index was unintentionally sorted.
 - arithmetic operations with **only** ``bool`` dtypes now raise an error
   (:issue:`7011`, :issue:`6762`, :issue:`7015`)
+- :meth:`DataFrame.boxplot` has a new keyword argument, `return_type`. It accepts ``'dict'``,
+  ``'axes'``, or ``'both'``, in which case a namedtuple with the matplotlib
+  axes and a dict of matplotlib Lines is returned.
 
 Deprecations
 ~~~~~~~~~~~~
@@ -257,6 +260,10 @@ Deprecations
 - The `percentile_width` keyword argument in :meth:`~DataFrame.describe` has been deprecated.
   Use the `percentiles` keyword instead, which takes a list of percentiles to display. The
   default output is unchanged.
+
+- The default return type of :func:`boxplot` will change from a dict to a matpltolib Axes
+  in a future release. You can use the future behavior now by passing ``return_type='dict'``
+  to boxplot.
 
 Prior Version Deprecations/Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -262,7 +262,7 @@ Deprecations
   default output is unchanged.
 
 - The default return type of :func:`boxplot` will change from a dict to a matpltolib Axes
-  in a future release. You can use the future behavior now by passing ``return_type='dict'``
+  in a future release. You can use the future behavior now by passing ``return_type='axes'``
   to boxplot.
 
 Prior Version Deprecations/Changes

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -559,7 +559,7 @@ Deprecations
   default output is unchanged.
 
 - The default return type of :func:`boxplot` will change from a dict to a matpltolib Axes
-  in a future release. You can use the future behavior now by passing ``return_type='dict'``
+  in a future release. You can use the future behavior now by passing ``return_type='axes'``
   to boxplot.
 
 .. _whatsnew_0140.enhancements:

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -210,6 +210,10 @@ API changes
      # this now raises for arith ops like ``+``, ``*``, etc.
      NotImplementedError: operator '*' not implemented for bool dtypes
 
+- :meth:`DataFrame.boxplot` has a new keyword argument, `return_type`. It accepts ``'dict'``,
+  ``'axes'``, or ``'both'``, in which case a namedtuple with the matplotlib
+  axes and a dict of matplotlib Lines is returned.
+
 
 .. _whatsnew_0140.display:
 
@@ -553,6 +557,10 @@ Deprecations
 - The `percentile_width` keyword argument in :meth:`~DataFrame.describe` has been deprecated.
   Use the `percentiles` keyword instead, which takes a list of percentiles to display. The
   default output is unchanged.
+
+- The default return type of :func:`boxplot` will change from a dict to a matpltolib Axes
+  in a future release. You can use the future behavior now by passing ``return_type='dict'``
+  to boxplot.
 
 .. _whatsnew_0140.enhancements:
 

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -304,6 +304,42 @@ columns:
 
     plt.close('all')
 
+.. _visualization.box.return:
+
+The return type of ``boxplot`` depends on two keyword arguments: ``by`` and ``return_type``.
+When ``by`` is ``None``:
+
+* if ``return_type`` is ``'dict'``, a dictionary containing the :class:`matplotlib Lines <matplotlib.lines.Line2D>` is returned. The keys are "boxes", "caps", "fliers", "medians", and "whiskers".
+   This is the deafult.
+* if ``return_type`` is ``'axes'``, a :class:`matplotlib Axes <matplotlib.axes.Axes>` containing the boxplot is returned.
+* if ``return_type`` is ``'both'`` a namedtuple containging the :class:`matplotlib Axes <matplotlib.axes.Axes>`
+   and :class:`matplotlib Lines <matplotlib.lines.Line2D>` is returned
+
+When ``by`` is some column of the DataFrame, a dict of ``return_type`` is returned, where
+the keys are the columns of the DataFrame. The plot has a facet for each column of
+the DataFrame, with a separate box for each value of ``by``.
+
+Finally, when calling boxplot on a :class:`Groupby` object, a dict of ``return_type``
+is returned, where the keys are the same as the Groupby object. The plot has a
+facet for each key, with each facet containing a box for each column of the
+DataFrame.
+
+.. ipython:: python
+
+   np.random.seed(1234)
+   df_box = DataFrame(np.random.randn(50, 2))
+   df_box['g'] = np.random.choice(['A', 'B'], size=50)
+   df_box.loc[df_box['g'] == 'B', 1] += 3
+
+..ipython:: python
+
+   @savefig(boxplot_groupby.png)
+   df_box.boxplot(by='g')
+
+   @savefig groupby_boxplot_vis.png
+   df_box.groupby('g').boxplot()
+
+
 .. _visualization.area_plot:
 
 Area Plot

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -331,14 +331,15 @@ DataFrame.
    df_box['g'] = np.random.choice(['A', 'B'], size=50)
    df_box.loc[df_box['g'] == 'B', 1] += 3
 
-..ipython:: python
+   @savefig boxplot_groupby.png
+   bp = df_box.boxplot(by='g')
 
-   @savefig(boxplot_groupby.png)
-   df_box.boxplot(by='g')
+Compare to:
+
+.. ipython:: python
 
    @savefig groupby_boxplot_vis.png
-   df_box.groupby('g').boxplot()
-
+   bp = df_box.groupby('g').boxplot()
 
 .. _visualization.area_plot:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4856,48 +4856,15 @@ DataFrame.plot = gfx.plot_frame
 DataFrame.hist = gfx.hist_frame
 
 
+@Appender(_shared_docs['boxplot'] % _shared_doc_kwargs)
 def boxplot(self, column=None, by=None, ax=None, fontsize=None,
             rot=0, grid=True, figsize=None, layout=None, return_type=None,
             **kwds):
-    """
-    Make a box plot from DataFrame column/columns optionally grouped
-    (stratified) by one or more columns
-
-    Parameters
-    ----------
-    data : DataFrame
-    column : column names or list of names, or vector
-        Can be any valid input to groupby
-    by : string or sequence
-        Column in the DataFrame to group by
-    ax : matplotlib axis object, default None
-    fontsize : int or string
-    rot : int, default None
-        Rotation for ticks
-    grid : boolean, default None (matlab style default)
-        Axis grid lines
-    layout : tuple (optional)
-        (rows, columns) for the layout of the plot
-    return_type : bool, default False
-        Whether to return a dict whose values are the lines of the boxplot
-    kwds : other plotting keyword arguments to be passed to matplotlib boxplot
-           function
-
-    Returns
-    -------
-    ax : matplotlib.axes.AxesSubplot
-    lines : dict (optional)
-
-    Notes
-    -----
-    Use ``return_dict=True`` when you want to modify the appearance
-    of the lines. In this case a named tuple is returned.
-    """
     import pandas.tools.plotting as plots
     import matplotlib.pyplot as plt
     ax = plots.boxplot(self, column=column, by=by, ax=ax,
                        fontsize=fontsize, grid=grid, rot=rot,
-                       figsize=figsize, layout=layout, return_dict=return_dict,
+                       figsize=figsize, layout=layout, return_type=return_type,
                        **kwds)
     plt.draw_if_interactive()
     return ax

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4857,7 +4857,8 @@ DataFrame.hist = gfx.hist_frame
 
 
 def boxplot(self, column=None, by=None, ax=None, fontsize=None,
-            rot=0, grid=True, **kwds):
+            rot=0, grid=True, figsize=None, layout=None, return_type=None,
+            **kwds):
     """
     Make a box plot from DataFrame column/columns optionally grouped
     (stratified) by one or more columns
@@ -4875,17 +4876,32 @@ def boxplot(self, column=None, by=None, ax=None, fontsize=None,
         Rotation for ticks
     grid : boolean, default None (matlab style default)
         Axis grid lines
+    layout : tuple (optional)
+        (rows, columns) for the layout of the plot
+    return_type : bool, default False
+        Whether to return a dict whose values are the lines of the boxplot
+    kwds : other plotting keyword arguments to be passed to matplotlib boxplot
+           function
 
     Returns
     -------
     ax : matplotlib.axes.AxesSubplot
+    lines : dict (optional)
+
+    Notes
+    -----
+    Use ``return_dict=True`` when you want to modify the appearance
+    of the lines. In this case a named tuple is returned.
     """
     import pandas.tools.plotting as plots
     import matplotlib.pyplot as plt
     ax = plots.boxplot(self, column=column, by=by, ax=ax,
-                       fontsize=fontsize, grid=grid, rot=rot, **kwds)
+                       fontsize=fontsize, grid=grid, rot=rot,
+                       figsize=figsize, layout=layout, return_dict=return_dict,
+                       **kwds)
     plt.draw_if_interactive()
     return ax
+
 DataFrame.boxplot = boxplot
 
 ops.add_flex_arithmetic_methods(DataFrame, **ops.frame_flex_funcs)

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -33,20 +33,25 @@ def _skip_if_no_scipy():
     except ImportError:
         raise nose.SkipTest("no scipy")
 
+
 @tm.mplskip
 class TestPlotBase(tm.TestCase):
 
     def setUp(self):
+
+        import matplotlib as mpl
+        mpl.rcdefaults()
+
         n = 100
         with tm.RNGContext(42):
             gender = tm.choice(['Male', 'Female'], size=n)
             classroom = tm.choice(['A', 'B', 'C'], size=n)
 
             self.hist_df = DataFrame({'gender': gender,
-                            'classroom': classroom,
-                            'height': random.normal(66, 4, size=n),
-                            'weight': random.normal(161, 32, size=n),
-                            'category': random.randint(4, size=n)})
+                                      'classroom': classroom,
+                                      'height': random.normal(66, 4, size=n),
+                                      'weight': random.normal(161, 32, size=n),
+                                      'category': random.randint(4, size=n)})
 
     def tearDown(self):
         tm.close()
@@ -119,7 +124,6 @@ class TestPlotBase(tm.TestCase):
 
         for patch in collections:
             self.assertEqual(patch.get_visible(), visible)
-
 
     def _get_colors_mapped(self, series, colors):
         unique = series.unique()
@@ -338,6 +342,8 @@ class TestSeriesPlots(TestPlotBase):
     def setUp(self):
         TestPlotBase.setUp(self)
         import matplotlib as mpl
+        mpl.rcdefaults()
+
         self.mpl_le_1_2_1 = str(mpl.__version__) <= LooseVersion('1.2.1')
         self.ts = tm.makeTimeSeries()
         self.ts.name = 'ts'
@@ -706,6 +712,8 @@ class TestDataFramePlots(TestPlotBase):
     def setUp(self):
         TestPlotBase.setUp(self)
         import matplotlib as mpl
+        mpl.rcdefaults()
+
         self.mpl_le_1_2_1 = str(mpl.__version__) <= LooseVersion('1.2.1')
 
         self.tdf = tm.makeTimeDataFrame()
@@ -2100,7 +2108,7 @@ class TestDataFramePlots(TestPlotBase):
         df = DataFrame(np.random.randn(5, 2), index=range(5), columns=['x', 'y'])
         df_err = DataFrame(np.random.randn(5, 2) / 5,
                            index=range(5), columns=['x', 'y'])
-            
+
         ax = _check_plot_works(df.plot, kind='scatter', x='x', y='y')
         self._check_has_errorbars(ax, xerr=0, yerr=0)
         ax = _check_plot_works(df.plot, kind='scatter', x='x', y='y', xerr=df_err)

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from pandas.util.decorators import cache_readonly, deprecate_kwarg
 import pandas.core.common as com
+from pandas.core.generic import _shared_docs, _shared_doc_kwargs
 from pandas.core.index import MultiIndex
 from pandas.core.series import Series, remove_na
 from pandas.tseries.index import DatetimeIndex
@@ -19,6 +20,7 @@ from pandas.tseries.frequencies import get_period_alias, get_base_alias
 from pandas.tseries.offsets import DateOffset
 from pandas.compat import range, lrange, lmap, map, zip, string_types
 import pandas.compat as compat
+from pandas.util.decorators import Appender
 
 try:  # mpl optional
     import pandas.tseries.converter as conv
@@ -2258,16 +2260,13 @@ def plot_series(series, label=None, kind='line', use_index=True, rot=None,
     return plot_obj.axes[0]
 
 
-def boxplot(data, column=None, by=None, ax=None, fontsize=None,
-            rot=0, grid=True, figsize=None, layout=None, return_type=None,
-            **kwds):
-    """
+_shared_docs['boxplot'] = """
     Make a box plot from DataFrame column optionally grouped by some columns or
     other inputs
 
     Parameters
     ----------
-    data : DataFrame or Series
+    data : the pandas object holding the data
     column : column name or list of names, or vector
         Can be any valid input to groupby
     by : string or sequence
@@ -2299,7 +2298,7 @@ def boxplot(data, column=None, by=None, ax=None, fontsize=None,
 
     Notes
     -----
-    Use ``return_dict=True`` when you want to tweak the appearance
+    Use ``return_type='dict'`` when you want to tweak the appearance
     of the lines after plotting. In this case a dict containing the Lines
     making up the boxes, caps, fliers, medians, and whiskers is returned.
     """
@@ -2314,6 +2313,7 @@ def boxplot(data, column=None, by=None, ax=None, fontsize=None,
     valid_types = (None, 'axes', 'dict', 'both')
     if return_type not in valid_types:
         raise ValueError("return_type")
+
 
     from pandas import Series, DataFrame
     if isinstance(data, Series):

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -3,6 +3,7 @@
 import datetime
 import warnings
 import re
+from collections import namedtuple
 from contextlib import contextmanager
 from distutils.version import LooseVersion
 
@@ -2258,7 +2259,8 @@ def plot_series(series, label=None, kind='line', use_index=True, rot=None,
 
 
 def boxplot(data, column=None, by=None, ax=None, fontsize=None,
-            rot=0, grid=True, figsize=None, layout=None, **kwds):
+            rot=0, grid=True, figsize=None, layout=None, return_type=None,
+            **kwds):
     """
     Make a box plot from DataFrame column optionally grouped by some columns or
     other inputs
@@ -2270,20 +2272,49 @@ def boxplot(data, column=None, by=None, ax=None, fontsize=None,
         Can be any valid input to groupby
     by : string or sequence
         Column in the DataFrame to group by
-    ax : Matplotlib axis object, optional
+    ax : Matplotlib axes object, optional
     fontsize : int or string
     rot : label rotation angle
     figsize : A tuple (width, height) in inches
     grid : Setting this to True will show the grid
     layout : tuple (optional)
         (rows, columns) for the layout of the plot
+    return_type : {'axes', 'dict', 'both'}, default 'dict'
+        The kind of object to return. 'dict' returns a dictionary
+        whose values are the matplotlib Lines of the boxplot;
+        'axes' returns the matplotlib axes the boxplot is drawn on;
+        'both' returns a namedtuple with the axes and dict.
+
+        When grouping with ``by``, a dict mapping columns to ``return_type``
+        is returned.
+
     kwds : other plotting keyword arguments to be passed to matplotlib boxplot
            function
 
     Returns
     -------
-    ax : matplotlib.axes.AxesSubplot
+    lines : dict
+    ax : matplotlib Axes
+    (ax, lines): namedtuple
+
+    Notes
+    -----
+    Use ``return_dict=True`` when you want to tweak the appearance
+    of the lines after plotting. In this case a dict containing the Lines
+    making up the boxes, caps, fliers, medians, and whiskers is returned.
     """
+
+
+@Appender(_shared_docs['boxplot'] % _shared_doc_kwargs)
+def boxplot(data, column=None, by=None, ax=None, fontsize=None,
+            rot=0, grid=True, figsize=None, layout=None, return_type=None,
+            **kwds):
+
+    # validate return_type:
+    valid_types = (None, 'axes', 'dict', 'both')
+    if return_type not in valid_types:
+        raise ValueError("return_type")
+
     from pandas import Series, DataFrame
     if isinstance(data, Series):
         data = DataFrame({'x': data})
@@ -2310,6 +2341,7 @@ def boxplot(data, column=None, by=None, ax=None, fontsize=None,
         else:
             ax.set_yticklabels(keys, rotation=rot, fontsize=fontsize)
         maybe_color_bp(bp)
+        return bp
 
     colors = _get_colors()
     if column is None:
@@ -2320,13 +2352,23 @@ def boxplot(data, column=None, by=None, ax=None, fontsize=None,
         else:
             columns = [column]
 
+    BP = namedtuple("Boxplot", ['ax', 'lines'])  # namedtuple to hold results
+
     if by is not None:
-        fig, axes = _grouped_plot_by_column(plot_group, data, columns=columns,
-                                            by=by, grid=grid, figsize=figsize,
-                                            ax=ax, layout=layout)
+        fig, axes, d = _grouped_plot_by_column(plot_group, data, columns=columns,
+                                               by=by, grid=grid, figsize=figsize,
+                                               ax=ax, layout=layout)
 
         # Return axes in multiplot case, maybe revisit later # 985
-        ret = axes
+        if return_type is None:
+            ret = axes
+        if return_type == 'axes':
+            ret = dict((k, ax) for k, ax in zip(d.keys(), axes))
+        elif return_type == 'dict':
+            ret = d
+        elif return_type == 'both':
+            ret = dict((k, BP(ax=ax, lines=line)) for
+                       (k, line), ax in zip(d.items(), axes))
     else:
         if layout is not None:
             raise ValueError("The 'layout' keyword is not supported when "
@@ -2354,7 +2396,20 @@ def boxplot(data, column=None, by=None, ax=None, fontsize=None,
             ax.set_yticklabels(keys, rotation=rot, fontsize=fontsize)
         ax.grid(grid)
 
-        ret = bp
+        ret = ax
+
+        if return_type is None:
+            msg = ("\nThe default value for 'return_type' will change to "
+                   "'axes' in a future release.\n To use the future behavior "
+                   "now, set return_type='axes'.\n To keep the previous "
+                   "behavior and silence this warning, set "
+                   "return_type='dict'.")
+            warnings.warn(msg, FutureWarning)
+            return_type = 'dict'
+        if return_type == 'dict':
+            ret = bp
+        elif return_type == 'both':
+            ret = BP(ax=ret, lines=bp)
 
     fig.subplots_adjust(bottom=0.15, top=0.9, left=0.1, right=0.9, wspace=0.2)
     return ret
@@ -2692,7 +2747,7 @@ def boxplot_frame_groupby(grouped, subplots=True, column=None, fontsize=None,
 def _grouped_plot(plotf, data, column=None, by=None, numeric_only=True,
                   figsize=None, sharex=True, sharey=True, layout=None,
                   rot=0, ax=None, **kwargs):
-    from pandas.core.frame import DataFrame
+    from pandas import DataFrame
 
     # allow to specify mpl default with 'default'
     if figsize is None or figsize == 'default':
@@ -2726,6 +2781,8 @@ def _grouped_plot(plotf, data, column=None, by=None, numeric_only=True,
 def _grouped_plot_by_column(plotf, data, columns=None, by=None,
                             numeric_only=True, grid=False,
                             figsize=None, ax=None, layout=None, **kwargs):
+    from pandas.core.frame import DataFrame
+
     grouped = data.groupby(by)
     if columns is None:
         if not isinstance(by, (list, tuple)):
@@ -2746,18 +2803,21 @@ def _grouped_plot_by_column(plotf, data, columns=None, by=None,
 
     ravel_axes = _flatten(axes)
 
+    out_dict = compat.OrderedDict()
+
     for i, col in enumerate(columns):
         ax = ravel_axes[i]
         gp_col = grouped[col]
-        plotf(gp_col, ax, **kwargs)
+        re_plotf = plotf(gp_col, ax, **kwargs)
         ax.set_title(col)
         ax.set_xlabel(com.pprint_thing(by))
         ax.grid(grid)
+        out_dict[col] = re_plotf
 
     byline = by[0] if len(by) == 1 else by
     fig.suptitle('Boxplot grouped by %s' % byline)
 
-    return fig, axes
+    return fig, axes, out_dict
 
 
 def table(ax, data, rowLabels=None, colLabels=None,


### PR DESCRIPTION
Closes: https://github.com/pydata/pandas/issues/4264
Will go in place of https://github.com/pydata/pandas/pull/4472

In https://github.com/pydata/pandas/issues/985 we intentionally decided to have boxplot return a dict with the Lines of the boxplot.

I've added a kwarg `return_dict`. By default, `return_dict` is False. In this case only a `matplotlib.axes` is returned. When `return_dict` is True, we should either
- return the `matplotlib.axes` **and** the dict in a namedtuple
- return just the dict

Both of these are API breaking. Right now I've got both in the named tuple, but I may change that to just return just the dict. If we just return the dict, the only change people will have to make to their code is to add `return_dict` to True in their boxplot calls. Thoughts?

cc @jseabold, @fonnesbeck
