### PR TITLE
BUG: DatetimeIndex with freq raises ValueError when passed value is short

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -499,6 +499,7 @@ Bug Fixes
 - Bug in ``MultiIndex.get_level_values`` doesn't preserve ``DatetimeIndex`` and ``PeriodIndex`` attributes (:issue:`7092`)
 - Bug in ``Groupby`` doesn't preserve ``tz`` (:issue:`3950`)
 - Bug in ``PeriodIndex`` partial string slicing (:issue:`6716`)
+- Bug in ``DatetimeIndex`` specifying ``freq`` raises ``ValueError`` when passed value is too short
 
 pandas 0.13.1
 -------------

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -299,8 +299,10 @@ class DatetimeIndex(Int64Index):
             if freq is not None and not freq_infer:
                 inferred = subarr.inferred_freq
                 if inferred != freq.freqstr:
-                    raise ValueError('Dates do not conform to passed '
-                                     'frequency')
+                    on_freq = cls._generate(subarr[0], None, len(subarr), None, freq, tz=tz)
+                    if not np.array_equal(subarr.asi8, on_freq.asi8):
+                        raise ValueError('Inferred frequency {0} from passed dates does not'
+                                         'conform to passed frequency {1}'.format(inferred, freq.freqstr))
 
         if freq_infer:
             inferred = subarr.inferred_freq

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -2314,6 +2314,11 @@ class TestPeriodIndex(tm.TestCase):
         self.assert_numpy_array_equal(arr, exp_arr)
         self.assert_(idx.equals(exp_idx))
 
+    def test_recreate_from_data(self):
+        for o in ['M', 'Q', 'A', 'D', 'B', 'T', 'S', 'L', 'U', 'N', 'H']:
+            org = PeriodIndex(start='2001/04/01', freq=o, periods=1)
+            idx = PeriodIndex(org.values, freq=o)
+            self.assert_(idx.equals(org))
 
 def _permute(obj):
     return obj.take(np.random.permutation(len(obj)))

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -285,6 +285,28 @@ class TestTimeSeriesDuplicates(tm.TestCase):
         # this is a single date, so will raise
         self.assertRaises(KeyError, df.__getitem__, df.index[2],)
 
+    def test_recreate_from_data(self):
+        if _np_version_under1p7:
+            freqs = ['M', 'Q', 'A', 'D', 'B', 'T', 'S', 'L', 'U', 'H']
+        else:
+            freqs = ['M', 'Q', 'A', 'D', 'B', 'T', 'S', 'L', 'U', 'H', 'N', 'C']
+
+        for f in freqs:
+            org = DatetimeIndex(start='2001/02/01 09:00', freq=f, periods=1)
+            idx = DatetimeIndex(org, freq=f)
+            self.assert_(idx.equals(org))
+
+        # unbale to create tz-aware 'A' and 'C' freq
+        if _np_version_under1p7:
+            freqs = ['M', 'Q', 'D', 'B', 'T', 'S', 'L', 'U', 'H']
+        else:
+            freqs = ['M', 'Q', 'D', 'B', 'T', 'S', 'L', 'U', 'H', 'N']
+
+        for f in freqs:
+            org = DatetimeIndex(start='2001/02/01 09:00', freq=f, tz='US/Pacific', periods=1)
+            idx = DatetimeIndex(org, freq=f, tz='US/Pacific')
+            self.assert_(idx.equals(org))
+
 
 def assert_range_equal(left, right):
     assert(left.equals(right))


### PR DESCRIPTION
When `DatetimeIndex` is created by passing `freq` and `check_integrity=True`, passed `freq` and `inferred_freq` must be identical. But this comparison can fail if length of passed data doesn't have enough length to infer freq. 

Added additional logic to determine whether passed values are on the passed `freq`.
