### PR TITLE
TYPO: idxmax is maximum, not minimum

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1179,7 +1179,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Returns
         -------
-        idxmax : Index of minimum of values
+        idxmax : Index of maximum of values
 
         Notes
         -----


### PR DESCRIPTION
Confusing doc typo was momentarily confusing.
