### PR TITLE
BUG: remove unique requirement rom MultiIndex.get_locs (GH7106)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -295,7 +295,7 @@ Improvements to existing features
   the func (:issue:`6289`)
 - ``plot(legend='reverse')`` will now reverse the order of legend labels for most plot kinds.
   (:issue:`6014`)
-- Allow multi-index slicers (:issue:`6134`, :issue:`4036`, :issue:`3057`, :issue:`2598`, :issue:`5641`)
+- Allow multi-index slicers (:issue:`6134`, :issue:`4036`, :issue:`3057`, :issue:`2598`, :issue:`5641`, :issue:`7106`)
 - improve performance of slice indexing on Series with string keys (:issue:`6341`, :issue:`6372`)
 - implement joining a single-level indexed DataFrame on a matching column of a multi-indexed DataFrame (:issue:`3662`)
 - Performance improvement in indexing into a multi-indexed Series (:issue:`5567`)

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -290,7 +290,7 @@ You can use ``slice(None)`` to select all the contents of *that* level. You do n
 As usual, **both sides** of the slicers are included as this is label indexing.
 
 See :ref:`the docs<indexing.mi_slicers>`
-See also issues (:issue:`6134`, :issue:`4036`, :issue:`3057`, :issue:`2598`, :issue:`5641`)
+See also issues (:issue:`6134`, :issue:`4036`, :issue:`3057`, :issue:`2598`, :issue:`5641`, :issue:`7106`)
 
 .. warning::
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -2595,7 +2595,7 @@ class MultiIndex(Index):
         unique = self.levels[num]  # .values
         labels = self.labels[num]
         filled = com.take_1d(unique.values, labels, fill_value=unique._na_value)
-        values = unique._simple_new(filled, self.names[num], 
+        values = unique._simple_new(filled, self.names[num],
                                     freq=getattr(unique, 'freq', None),
                                     tz=getattr(unique, 'tz', None))
         return values
@@ -3556,8 +3556,6 @@ class MultiIndex(Index):
         if not self.is_lexsorted_for_tuple(tup):
             raise KeyError('MultiIndex Slicing requires the index to be fully lexsorted'
                            ' tuple len ({0}), lexsort depth ({1})'.format(len(tup), self.lexsort_depth))
-        if not self.is_unique:
-            raise ValueError('MultiIndex Slicing requires a unique index')
 
         def _convert_indexer(r):
             if isinstance(r, slice):


### PR DESCRIPTION
enables slicing of non-unique multi-indexes with slicers, closes #7106
