### PR TITLE
API: allow option truncate for display.show_dimensions to only show dimensions if truncated (GH6457)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -346,6 +346,8 @@ Improvements to existing features
 - Regression in the display of a MultiIndexed Series with ``display.max_rows`` is less than the
   length of the series (:issue:`7101`)
 - :meth:`~DataFrame.describe` now accepts an array of percentiles to include in the summary statistics (:issue:`4196`)
+- allow option ``'truncate'`` for ``display.show_dimensions`` to only show the dimensions if the
+  frame is truncated (:issue:`6547`)
 
 .. _release.bug_fixes-0.14.0:
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -204,6 +204,26 @@ API changes
 Display Changes
 ~~~~~~~~~~~~~~~
 
+- allow option ``'truncate'`` for ``display.show_dimensions`` to only show the dimensions if the
+  frame is truncated (:issue:`6547`).
+
+  The default for ``display.show_dimensions`` will now be **truncate**! This is consistent with
+  how Series display length.
+
+  .. ipython:: python
+
+     dfd = pd.DataFrame(np.arange(25).reshape(-1,5), index=[0,1,2,3,4], columns=[0,1,2,3,4])
+
+     # show dimensions only if truncated
+     with pd.option_context('display.max_rows', 2, 'display.max_columns', 2,
+                            'display.show_dimensions', 'truncate'):
+        print(dfd)
+
+     # show dimensions only if truncated
+     with pd.option_context('display.max_rows', 10, 'display.max_columns', 40,
+                            'display.show_dimensions', 'truncate'):
+        print(dfd)
+
 - Regression in the display of a MultiIndexed Series with ``display.max_rows`` is less than the
   length of the series (:issue:`7101`)
 - Fixed a bug in the HTML repr of a truncated Series or DataFrame not showing the class name with the

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -120,8 +120,10 @@ pc_expand_repr_doc = """
 """
 
 pc_show_dimensions_doc = """
-: boolean
+: boolean or 'truncate'
     Whether to print out dimensions at the end of DataFrame repr.
+    If 'truncate' is specified, only print out the dimensions if the
+    frame is truncated (e.g. not display all rows and/or columns)
 """
 
 pc_line_width_doc = """
@@ -247,7 +249,8 @@ with cf.config_prefix('display'):
     cf.register_option('encoding', detect_console_encoding(), pc_encoding_doc,
                        validator=is_text)
     cf.register_option('expand_frame_repr', True, pc_expand_repr_doc)
-    cf.register_option('show_dimensions', True, pc_show_dimensions_doc)
+    cf.register_option('show_dimensions', True, pc_show_dimensions_doc,
+                       validator=is_one_of_factory([True, False, 'truncate']))
     cf.register_option('chop_threshold', None, pc_chop_threshold_doc)
     cf.register_option('max_seq_items', 100, pc_max_seq_items)
     cf.register_option('mpl_style', None, pc_mpl_style_doc,

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -1197,6 +1197,26 @@ c  10  11  12  13  14\
         s = df.to_string(line_width=80)
         self.assertEqual(max(len(l) for l in s.split('\n')), 80)
 
+    def test_show_dimensions(self):
+        df = pd.DataFrame(123, lrange(10, 15), lrange(30))
+
+        with option_context('display.max_rows', 10, 'display.max_columns', 40, 'display.width',
+                            500, 'display.expand_frame_repr', 'info', 'display.show_dimensions', True):
+            self.assertTrue('5 rows' in str(df))
+            self.assertTrue('5 rows' in df._repr_html_())
+        with option_context('display.max_rows', 10, 'display.max_columns', 40, 'display.width',
+                            500, 'display.expand_frame_repr', 'info', 'display.show_dimensions', False):
+            self.assertFalse('5 rows' in str(df))
+            self.assertFalse('5 rows' in df._repr_html_())
+        with option_context('display.max_rows', 2, 'display.max_columns', 2, 'display.width',
+                            500, 'display.expand_frame_repr', 'info', 'display.show_dimensions', 'truncate'):
+            self.assertTrue('5 rows' in str(df))
+            self.assertTrue('5 rows' in df._repr_html_())
+        with option_context('display.max_rows', 10, 'display.max_columns', 40, 'display.width',
+                            500, 'display.expand_frame_repr', 'info', 'display.show_dimensions', 'truncate'):
+            self.assertFalse('5 rows' in str(df))
+            self.assertFalse('5 rows' in df._repr_html_())
+
     def test_to_html(self):
         # big mixed
         biggie = DataFrame({'A': randn(200),


### PR DESCRIPTION
closes #6547

add the option 'trunctate'.
Should this be the new default?????

```
dfd = pd.DataFrame(np.arange(25).reshape(-1,5), index=[0,1,2,3,4], columns=[0,1,2,3,4])

# show dimensions only if truncated
with pd.option_context('display.max_rows', 2, 'display.max_columns', 2,  'display.show_dimensions', 'truncate'):
        print(dfd)
```

```
   0  1    
0  0  1 ...
1  5  6 ...
  .. ..    

[5 rows x 5 columns]
```

```
# show dimensions only if truncated
with pd.option_context('display.max_rows', 10, 'display.max_columns', 40, 'display.show_dimensions', 'truncate'):
        print(dfd)
```

```
    0   1   2   3   4
0   0   1   2   3   4
1   5   6   7   8   9
2  10  11  12  13  14
3  15  16  17  18  19
4  20  21  22  23  24
```
