### PR TITLE
BUG: Escape `<` and `>` in info _repr_html_

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -499,6 +499,8 @@ Bug Fixes
 - Bug in ``MultiIndex.get_level_values`` doesn't preserve ``DatetimeIndex`` and ``PeriodIndex`` attributes (:issue:`7092`)
 - Bug in ``Groupby`` doesn't preserve ``tz`` (:issue:`3950`)
 - Bug in ``PeriodIndex`` partial string slicing (:issue:`6716`)
+- Bug in the HTML repr of a truncated Series or DataFrame not showing the class name with the `large_repr` set to 'info'
+  (:issue:`7105`)
 
 pandas 0.13.1
 -------------

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -202,6 +202,9 @@ API changes
 Display Changes
 ~~~~~~~~~~~~~~~
 
+- Fixed a bug in the HTML repr of a truncated Series or DataFrame not showing the class name with the
+  `large_repr` set to 'info' (:issue:`7105`)
+
 .. _whatsnew_0140.groupby:
 
 Groupby API Changes

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -485,7 +485,10 @@ class DataFrame(NDFrame):
         if self._info_repr():
             buf = StringIO(u(""))
             self.info(buf=buf)
-            return '<pre>' + buf.getvalue() + '</pre>'
+            # need to escape the <class>, should be the first line.
+            val = buf.getvalue().replace('<', r'&lt;', 1).replace('>',
+                                                                  r'&gt;', 1)
+            return '<pre>' + val + '</pre>'
 
         if get_option("display.notebook_repr_html"):
             max_rows = get_option("display.max_rows")

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -34,7 +34,9 @@ def curpath():
 
 def has_info_repr(df):
     r = repr(df)
-    return r.split('\n')[0].startswith("<class")
+    c1 = r.split('\n')[0].startswith("<class")
+    c2 = r.split('\n')[0].startswith(r"&lt;class")  # _repr_html_
+    return c1 or c2
 
 def has_horizontally_truncated_repr(df):
     r = repr(df)
@@ -1555,16 +1557,16 @@ c  10  11  12  13  14\
         # Long
         h, w = max_rows+1, max_cols-1
         df = pandas.DataFrame(dict((k,np.arange(1,1+h)) for k in np.arange(w)))
-        assert '<class' not in df._repr_html_()
+        assert r'&lt;class' not in df._repr_html_()
         with option_context('display.large_repr', 'info'):
-            assert '<class' in df._repr_html_()
+            assert r'&lt;class' in df._repr_html_()
 
         # Wide
         h, w = max_rows-1, max_cols+1
         df = pandas.DataFrame(dict((k,np.arange(1,1+h)) for k in np.arange(w)))
         assert '<class' not in df._repr_html_()
         with option_context('display.large_repr', 'info'):
-            assert '<class' in df._repr_html_()
+            assert '&lt;class' in df._repr_html_()
 
     def test_fake_qtconsole_repr_html(self):
         def get_ipython():


### PR DESCRIPTION
Closes https://github.com/pydata/pandas/issues/7105

Before: http://nbviewer.ipython.org/gist/TomAugspurger/4c83a646ffb93d5ee978
After: http://nbviewer.ipython.org/gist/TomAugspurger/81bf15086864ca090bb6

After conosle:

```
In [28]: df
 Out[5]: 
<class 'pandas.core.frame.DataFrame'>
Int64Index: 2 entries, 0 to 1
Data columns (total 2 columns):
0    2 non-null float64
1    2 non-null float64
dtypes: float64(2)
```

FYI, I don't know HTML, but I think this is mostly right.
