### PR TITLE
BUG: tzinfo lost when concatenating multiindex arrays

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -70,3 +70,4 @@ Bug Fixes
 - Bug in ``DataFrame`` and ``Series`` bar and barh plot raises ``TypeError`` when ``bottom``
   and ``left`` keyword is specified (:issue:`7226`)
 - BUG in ``DataFrame.hist`` raises ``TypeError`` when it contains non numeric column (:issue:`7277`)
+- Bug in ``MultiIndex.append``, ``concat`` and ``pivot_table`` don't preserve timezone (:issue:`6606`)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -2948,6 +2948,14 @@ class MultiIndex(Index):
         if not isinstance(other, (list, tuple)):
             other = [other]
 
+        if all((isinstance(o, MultiIndex) and o.nlevels >= self.nlevels) for o in other):
+            arrays = []
+            for i in range(self.nlevels):
+                label = self.get_level_values(i)
+                appended = [o.get_level_values(i) for o in other]
+                arrays.append(label.append(appended))
+            return MultiIndex.from_arrays(arrays, names=self.names)
+
         to_concat = (self.values,) + tuple(k.values for k in other)
         new_tuples = np.concatenate(to_concat)
 

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -490,6 +490,41 @@ class TestPivotTable(tm.TestCase):
                              values='Quantity', aggfunc=np.sum)
         tm.assert_frame_equal(result, expected.T)
 
+    def test_pivot_datetime_tz(self):
+        dates1 = ['2011-07-19 07:00:00', '2011-07-19 08:00:00', '2011-07-19 09:00:00',
+                  '2011-07-19 07:00:00', '2011-07-19 08:00:00', '2011-07-19 09:00:00']
+        dates2 = ['2013-01-01 15:00:00', '2013-01-01 15:00:00', '2013-01-01 15:00:00',
+                  '2013-02-01 15:00:00', '2013-02-01 15:00:00', '2013-02-01 15:00:00']
+        df = DataFrame({'label': ['a', 'a', 'a', 'b', 'b', 'b'],
+                        'dt1': dates1, 'dt2': dates2,
+                        'value1': range(6), 'value2': [1, 2] * 3})
+        df['dt1'] = df['dt1'].apply(lambda d: pd.Timestamp(d, tz='US/Pacific'))
+        df['dt2'] = df['dt2'].apply(lambda d: pd.Timestamp(d, tz='Asia/Tokyo'))
+
+        exp_idx = pd.DatetimeIndex(['2011-07-19 07:00:00', '2011-07-19 08:00:00',
+                                    '2011-07-19 09:00:00'], tz='US/Pacific', name='dt1')
+        exp_col1 = Index(['value1', 'value1'])
+        exp_col2 = Index(['a', 'b'], name='label')
+        exp_col = MultiIndex.from_arrays([exp_col1, exp_col2])
+        expected = DataFrame([[0, 3], [1, 4], [2, 5]],
+                             index=exp_idx, columns=exp_col)
+        result = pivot_table(df, index=['dt1'], columns=['label'], values=['value1'])
+        tm.assert_frame_equal(result, expected)
+
+
+        exp_col1 = Index(['sum', 'sum', 'sum', 'sum', 'mean', 'mean', 'mean', 'mean'])
+        exp_col2 = Index(['value1', 'value1', 'value2', 'value2'] * 2)
+        exp_col3 = pd.DatetimeIndex(['2013-01-01 15:00:00', '2013-02-01 15:00:00'] * 4,
+                                    tz='Asia/Tokyo', name='dt2')
+        exp_col = MultiIndex.from_arrays([exp_col1, exp_col2, exp_col3])
+        expected = DataFrame(np.array([[0, 3, 1, 2, 0, 3, 1, 2], [1, 4, 2, 1, 1, 4, 2, 1],
+                              [2, 5, 1, 2, 2, 5, 1, 2]]), index=exp_idx, columns=exp_col)
+
+        result = pivot_table(df, index=['dt1'], columns=['dt2'], values=['value1', 'value2'],
+                             aggfunc=[np.sum, np.mean])
+        tm.assert_frame_equal(result, expected)
+
+
 class TestCrosstab(tm.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Closes #6606. 

The problem is caused by `MultiIndex.append`. Based on current master, `MultiIndex.append` works as below. The fix covers case1 and case2 which the result will be `MultiIndex`. 

The fix is applied to `concat`, and also `pivot_table` work as expected.

```
import pandas as pd

idx1 = pd.Index([1.1, 1.2, 1.3])
idx2 = pd.date_range('2011-01-01', freq='D', periods=3, tz='Asia/Tokyo')
idx3 = pd.Index(['A', 'B', 'C'])

midx_lv2 = pd.MultiIndex.from_arrays([idx1, idx2])
midx_lv3 = pd.MultiIndex.from_arrays([idx1, idx2, idx3])

#1 results in MultiIndex, which nlevels is 2
midx_lv2.append(midx_lv2)

#2 results in MultiIndex, which nlevels is 2, not 3. 3rd line will be disappeared.
midx_lv2.append(midx_lv3)

#3 results in tupled Index.
midx_lv2.append(idx1)

#4 results in tupled Index.
result = midx_lv3.append(midx_lv2)
```
