### PR TITLE
BUG: Regression in the display of a MultiIndexed Series with display.max_rows (GH7101)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -337,6 +337,8 @@ Improvements to existing features
 - ``GroupBy.count()`` is now implemented in Cython and is much faster for large
   numbers of groups (:issue:`7016`).
 - ``boxplot`` now supports ``layout`` keyword (:issue:`6769`)
+- Regression in the display of a MultiIndexed Series with ``display.max_rows`` is less than the
+  length of the series (:issue:`7101`)
 
 .. _release.bug_fixes-0.14.0:
 

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -202,6 +202,9 @@ API changes
 Display Changes
 ~~~~~~~~~~~~~~~
 
+- Regression in the display of a MultiIndexed Series with ``display.max_rows`` is less than the
+  length of the series (:issue:`7101`)
+
 .. _whatsnew_0140.groupby:
 
 Groupby API Changes

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -848,7 +848,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Internal function, should always return unicode string
         """
-        num = max_vals // 2
+        if max_vals > 1:
+            num = max_vals // 2
+        else:
+            num = 1
+            max_vals = 2
         head = self.iloc[:num]._get_repr(print_header=True, length=False,
                                          dtype=False, name=False)
         tail = self.iloc[-(max_vals - num):]._get_repr(print_header=False,

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -13,7 +13,7 @@ from numpy import nan
 from numpy.random import randn
 import numpy as np
 
-from pandas import DataFrame, Series, Index, _np_version_under1p7, Timestamp
+from pandas import DataFrame, Series, Index, _np_version_under1p7, Timestamp, MultiIndex
 
 import pandas.core.format as fmt
 import pandas.util.testing as tm
@@ -2057,6 +2057,42 @@ class TestSeriesFormatting(tm.TestCase):
         result = repr(df.ix[0])
         self.assertTrue('2012-01-01' in result)
 
+    def test_max_multi_index_display(self):
+        # GH 7101
+
+        # doc example (indexing.rst)
+
+        # multi-index
+        arrays = [['bar', 'bar', 'baz', 'baz', 'foo', 'foo', 'qux', 'qux'],
+                  ['one', 'two', 'one', 'two', 'one', 'two', 'one', 'two']]
+        tuples = list(zip(*arrays))
+        index = MultiIndex.from_tuples(tuples, names=['first', 'second'])
+        s = Series(randn(8), index=index)
+
+        with option_context("display.max_rows", 10):
+            self.assertEquals(len(str(s).split('\n')),10)
+        with option_context("display.max_rows", 3):
+            self.assertEquals(len(str(s).split('\n')),5)
+        with option_context("display.max_rows", 2):
+            self.assertEquals(len(str(s).split('\n')),5)
+        with option_context("display.max_rows", 1):
+            self.assertEquals(len(str(s).split('\n')),5)
+        with option_context("display.max_rows", 0):
+            self.assertEquals(len(str(s).split('\n')),10)
+
+        # index
+        s = Series(randn(8), None)
+
+        with option_context("display.max_rows", 10):
+            self.assertEquals(len(str(s).split('\n')),9)
+        with option_context("display.max_rows", 3):
+            self.assertEquals(len(str(s).split('\n')),4)
+        with option_context("display.max_rows", 2):
+            self.assertEquals(len(str(s).split('\n')),4)
+        with option_context("display.max_rows", 1):
+            self.assertEquals(len(str(s).split('\n')),4)
+        with option_context("display.max_rows", 0):
+            self.assertEquals(len(str(s).split('\n')),9)
 
 class TestEngFormatter(tm.TestCase):
     _multiprocess_can_split_ = True


### PR DESCRIPTION
closes #7101
