### PR TITLE
TST: numpy 1.9 -dev exception changes indatetime64 indexing (GH7116)

### DIFF
--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -30,6 +30,7 @@ _np_version = np.version.short_version
 _np_version_under1p6 = LooseVersion(_np_version) < '1.6'
 _np_version_under1p7 = LooseVersion(_np_version) < '1.7'
 _np_version_under1p8 = LooseVersion(_np_version) < '1.8'
+_np_version_under1p9 = LooseVersion(_np_version) < '1.9'
 
 from pandas.version import version as __version__
 from pandas.info import __doc__

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -23,7 +23,7 @@ import numpy as np
 from numpy.random import randn
 from pandas.compat import range, lrange, lmap, zip
 
-from pandas import Series, TimeSeries, DataFrame
+from pandas import Series, TimeSeries, DataFrame, _np_version_under1p9
 from pandas.util.testing import(assert_series_equal, assert_almost_equal,
                                 assertRaisesRegexp)
 import pandas.util.testing as tm
@@ -1862,8 +1862,17 @@ class TestPeriodIndex(tm.TestCase):
             values = ['2014', '2013/02', '2013/01/02',
                       '2013/02/01 9H', '2013/02/01 09:00']
             for v in values:
-                with tm.assertRaises(ValueError):
-                    idx[v]
+
+                if _np_version_under1p9:
+                    with tm.assertRaises(ValueError):
+                        idx[v]
+                else:
+                    # GH7116
+                    # these show deprecations as we are trying
+                    # to slice with non-integer indexers
+                    #with tm.assertRaises(IndexError):
+                    #    idx[v]
+                    continue
 
             s = Series(np.random.rand(len(idx)), index=idx)
             assert_series_equal(s['2013/01'], s[0:31])
@@ -1910,8 +1919,16 @@ class TestPeriodIndex(tm.TestCase):
             values = ['2014', '2013/02', '2013/01/02',
                       '2013/02/01 9H', '2013/02/01 09:00']
             for v in values:
-                with tm.assertRaises(ValueError):
-                    idx[v]
+                if _np_version_under1p9:
+                    with tm.assertRaises(ValueError):
+                        idx[v]
+                else:
+                    # GH7116
+                    # these show deprecations as we are trying
+                    # to slice with non-integer indexers
+                    #with tm.assertRaises(IndexError):
+                    #    idx[v]
+                    continue
 
             s = Series(np.random.rand(len(idx)), index=idx)
 
@@ -2291,7 +2308,7 @@ class TestPeriodIndex(tm.TestCase):
 
         exp_arr = np.array([0, 0, 1, 1, 2, 2])
         exp_idx = PeriodIndex(['2014-01', '2014-02', '2014-03'], freq='M')
-        
+
         arr, idx = idx1.factorize()
         self.assert_numpy_array_equal(arr, exp_arr)
         self.assert_(idx.equals(exp_idx))
@@ -2303,7 +2320,7 @@ class TestPeriodIndex(tm.TestCase):
         idx2 = pd.PeriodIndex(['2014-03', '2014-03', '2014-02', '2014-01',
                                '2014-03', '2014-01'], freq='M')
 
-        exp_arr = np.array([2, 2, 1, 0, 2, 0])        
+        exp_arr = np.array([2, 2, 1, 0, 2, 0])
         arr, idx = idx2.factorize(sort=True)
         self.assert_numpy_array_equal(arr, exp_arr)
         self.assert_(idx.equals(exp_idx))


### PR DESCRIPTION
closes #7116 
