### PR TITLE
API: change default for show_dimensions to 'truncate', related (GH7108, GH6547)

### DIFF
--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -249,7 +249,7 @@ with cf.config_prefix('display'):
     cf.register_option('encoding', detect_console_encoding(), pc_encoding_doc,
                        validator=is_text)
     cf.register_option('expand_frame_repr', True, pc_expand_repr_doc)
-    cf.register_option('show_dimensions', True, pc_show_dimensions_doc,
+    cf.register_option('show_dimensions', 'truncate', pc_show_dimensions_doc,
                        validator=is_one_of_factory([True, False, 'truncate']))
     cf.register_option('chop_threshold', None, pc_chop_threshold_doc)
     cf.register_option('max_seq_items', 100, pc_max_seq_items)

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -141,16 +141,16 @@ class TestDataFrameFormatting(tm.TestCase):
     def test_repr_chop_threshold(self):
         df = DataFrame([[0.1, 0.5],[0.5, -0.1]])
         pd.reset_option("display.chop_threshold") # default None
-        self.assertEqual(repr(df), '     0    1\n0  0.1  0.5\n1  0.5 -0.1\n\n[2 rows x 2 columns]')
+        self.assertEqual(repr(df), '     0    1\n0  0.1  0.5\n1  0.5 -0.1')
 
         with option_context("display.chop_threshold", 0.2 ):
-            self.assertEqual(repr(df), '     0    1\n0  0.0  0.5\n1  0.5  0.0\n\n[2 rows x 2 columns]')
+            self.assertEqual(repr(df), '     0    1\n0  0.0  0.5\n1  0.5  0.0')
 
         with option_context("display.chop_threshold", 0.6 ):
-            self.assertEqual(repr(df), '   0  1\n0  0  0\n1  0  0\n\n[2 rows x 2 columns]')
+            self.assertEqual(repr(df), '   0  1\n0  0  0\n1  0  0')
 
         with option_context("display.chop_threshold", None ):
-            self.assertEqual(repr(df),  '     0    1\n0  0.1  0.5\n1  0.5 -0.1\n\n[2 rows x 2 columns]')
+            self.assertEqual(repr(df),  '     0    1\n0  0.1  0.5\n1  0.5 -0.1')
 
     def test_repr_obeys_max_seq_limit(self):
         import pandas.core.common as com
@@ -197,7 +197,8 @@ class TestDataFrameFormatting(tm.TestCase):
         with option_context('mode.sim_interactive', True):
             with option_context('display.max_columns', 10,
                                 'display.width',20,
-                                'display.max_rows', 20):
+                                'display.max_rows', 20,
+                                'display.show_dimensions', True):
                 with option_context('display.expand_frame_repr', True):
                     self.assertFalse(has_truncated_repr(df_small))
                     self.assertFalse(has_expanded_repr(df_small))
@@ -789,7 +790,7 @@ class TestDataFrameFormatting(tm.TestCase):
         self.assertTrue(not "\t" in pp_t("a\tb", escape_chars=("\t",)))
 
     def test_wide_repr(self):
-        with option_context('mode.sim_interactive', True):
+        with option_context('mode.sim_interactive', True, 'display.show_dimensions', True):
             col = lambda l, k: [tm.rands(k) for _ in range(l)]
             max_cols = get_option('display.max_columns')
             df = DataFrame([col(max_cols - 1, 25) for _ in range(10)])
@@ -812,7 +813,7 @@ class TestDataFrameFormatting(tm.TestCase):
             df = DataFrame(randn(5, 3), columns=['a' * 90, 'b' * 90, 'c' * 90])
             rep_str = repr(df)
 
-            self.assertEqual(len(rep_str.splitlines()), 22)
+            self.assertEqual(len(rep_str.splitlines()), 20)
 
     def test_wide_repr_named(self):
         with option_context('mode.sim_interactive', True):
@@ -1458,6 +1459,7 @@ c  10  11  12  13  14\
         self.reset_display_options()
 
         df = DataFrame([[1, 2], [3, 4]])
+        fmt.set_option('display.show_dimensions', True)
         self.assertTrue('2 rows' in df._repr_html_())
         fmt.set_option('display.show_dimensions', False)
         self.assertFalse('2 rows' in df._repr_html_())

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4354,12 +4354,14 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
     def test_repr_dimensions(self):
         df = DataFrame([[1, 2,], [3, 4]])
-        self.assertTrue("2 rows x 2 columns" in repr(df))
+        with pd.option_context('display.show_dimensions', True):
+            self.assertTrue("2 rows x 2 columns" in repr(df))
 
-        fmt.set_option('display.show_dimensions', False)
-        self.assertFalse("2 rows x 2 columns" in repr(df))
+        with pd.option_context('display.show_dimensions', False):
+            self.assertFalse("2 rows x 2 columns" in repr(df))
 
-        self.reset_display_options()
+        with pd.option_context('display.show_dimensions', 'truncate'):
+            self.assertFalse("2 rows x 2 columns" in repr(df))
 
     @slow
     def test_repr_big(self):


### PR DESCRIPTION
xref: #7108
xref: #6547
