### PR TITLE
BUG/API: info repr should honor display.max_info_columns

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -515,6 +515,7 @@ Bug Fixes
 - Bug in the HTML repr of a truncated Series or DataFrame not showing the class name with the `large_repr` set to 'info'
   (:issue:`7105`)
 - Bug in ``DatetimeIndex`` specifying ``freq`` raises ``ValueError`` when passed value is too short (:issue:`7098`)
+- Fixed a bug with the `info` repr not honoring the `display.max_info_columns` setting (:issue:`6939`)
 
 pandas 0.13.1
 -------------

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -210,6 +210,7 @@ API changes
      # this now raises for arith ops like ``+``, ``*``, etc.
      NotImplementedError: operator '*' not implemented for bool dtypes
 
+
 .. _whatsnew_0140.display:
 
 Display Changes
@@ -239,6 +240,11 @@ Display Changes
   length of the series (:issue:`7101`)
 - Fixed a bug in the HTML repr of a truncated Series or DataFrame not showing the class name with the
   `large_repr` set to 'info' (:issue:`7105`)
+- The `verbose` keyword in ``DataFrame.info()``, which controls whether to shorten the ``info``
+  representation, is now ``None`` by default. This will follow the global setting in
+  ``display.max_info_columns``. The global setting can be overriden with ``verbose=True`` or
+  ``verbose=False``.
+- Fixed a bug with the `info` repr not honoring the `display.max_info_columns` setting (:issue:`6939`)
 
 .. _whatsnew_0140.groupby:
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -6326,6 +6326,41 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             name = '%d    %d non-null %s' % (i, n, dtype)
             assert name in res
 
+    def test_info_max_cols(self):
+        df = DataFrame(np.random.randn(10, 5))
+        for len_, verbose in [(4, None), (4, False), (9, True)]:
+        # For verbose always      ^ setting  ^ summarize ^ full output
+            with pd.option_context('max_info_columns', 4):
+                buf = StringIO()
+                df.info(buf=buf, verbose=verbose)
+                res = buf.getvalue()
+                self.assertEqual(len(res.split('\n')), len_)
+
+        for len_, verbose in [(9, None), (4, False), (9, True)]:
+
+            # max_cols no exceeded
+            with pd.option_context('max_info_columns', 5):
+                buf = StringIO()
+                df.info(buf=buf, verbose=verbose)
+                res = buf.getvalue()
+                self.assertEqual(len(res.split('\n')), len_)
+
+        for len_, max_cols in [(9, 5), (4, 4)]:
+            # setting truncates
+            with pd.option_context('max_info_columns', 4):
+                buf = StringIO()
+                df.info(buf=buf, max_cols=max_cols)
+                res = buf.getvalue()
+                self.assertEqual(len(res.split('\n')), len_)
+
+            # setting wouldn't truncate
+            with pd.option_context('max_info_columns', 5):
+                buf = StringIO()
+                df.info(buf=buf, max_cols=max_cols)
+                res = buf.getvalue()
+                self.assertEqual(len(res.split('\n')), len_)
+
+
     def test_dtypes(self):
         self.mixed_frame['bool'] = self.mixed_frame['A'] > 0
         result = self.mixed_frame.dtypes


### PR DESCRIPTION
Closes https://github.com/pydata/pandas/issues/6939

I think this is what we agreed on. The tests are split up. In `test_format` we do more of the following global settings tests. The rest are in `test_frame` which directly call `df.info()` and I'm basically testing that the kwargs there override the global settings.
