### PR TITLE
ENH/VIS: KDE plot can be cumulative

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -208,6 +208,7 @@ API Changes
   returns a different Index (:issue:`7088`). Previously the index was unintentionally sorted.
 - arithmetic operations with **only** ``bool`` dtypes now raise an error
   (:issue:`7011`, :issue:`6762`, :issue:`7015`)
+- Density plot can be cumulative to plot cumulative density by ``cumulative=True`` (:issue:`7134`)
 
 Deprecations
 ~~~~~~~~~~~~

--- a/doc/source/v0.14.0.txt
+++ b/doc/source/v0.14.0.txt
@@ -462,6 +462,8 @@ Plotting
 
 - ``boxplot`` now supports ``layout`` keyword (:issue:`6769`)
 
+- Density plot can be cumulative to plot cumulative density by ``cumulative=True`` (:issue:`7134`)
+
 .. _whatsnew_0140.prior_deprecations:
 
 Prior Version Deprecations/Changes

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -534,6 +534,13 @@ setting ``kind='kde'``:
    @savefig kde_plot.png
    ser.plot(kind='kde')
 
+You can plot cumulative density by passing ``cumulative=True``.
+
+.. ipython:: python
+
+   @savefig kde_plot_cum.png
+   ser.plot(kind='kde', cumulative=True)
+
 .. _visualization.andrews_curves:
 
 Andrews Curves

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -592,6 +592,13 @@ class TestSeriesPlots(TestPlotBase):
         _check_plot_works(self.ts.plot, kind='density', bw_method=.5, ind=linspace(-100,100,20))
         ax = self.ts.plot(kind='kde', logy=True, bw_method=.5, ind=linspace(-100,100,20))
         self._check_ax_scales(ax, yaxis='log')
+        tm.close()
+
+        ax = self.ts.plot(kind='kde', cumulative=True)
+        line = ax.lines[0].get_ydata()
+        print(line)
+        tm.assert_almost_equal(line[0], 0.0)
+        tm.assert_almost_equal(line[-1], 1.0)
 
     @slow
     def test_kde_color(self):

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1334,15 +1334,16 @@ class MPLPlot(object):
 
 
 class KdePlot(MPLPlot):
-    def __init__(self, data, bw_method=None, ind=None, **kwargs):
+    def __init__(self, data, bw_method=None, ind=None,
+                 cumulative=False, **kwargs):
         MPLPlot.__init__(self, data, **kwargs)
-        self.bw_method=bw_method
-        self.ind=ind
+        self.bw_method = bw_method
+        self.ind = ind
+        self.cumulative = cumulative
 
     def _make_plot(self):
         from scipy.stats import gaussian_kde
         from scipy import __version__ as spv
-        from distutils.version import LooseVersion
         plotf = self.plt.Axes.plot
         colors = self._get_colors()
         for i, (label, y) in enumerate(self._iter_data()):
@@ -1371,6 +1372,11 @@ class KdePlot(MPLPlot):
             ax.set_ylabel("Density")
 
             y = gkde.evaluate(ind)
+
+            if self.cumulative:
+                y = y.cumsum()
+                y = y / y[-1]
+
             kwds = self.kwds.copy()
             kwds['label'] = label
             self._maybe_add_color(colors, kwds, style, i)


### PR DESCRIPTION
I sometimes want cumulative density plot for distribution comparison. Added `cumulative` to KDE plot, like `matplotlib.pyplot.hist`.

```
import pandas as pd
import numpy as np

s = pd.Series(np.random.randn(100))
s.plot(kind='kde', cumulative=True)
```

![figure_1](https://cloud.githubusercontent.com/assets/1696302/2985394/e88ddcd2-dc3b-11e3-9f77-381c5cb981ec.png)
