### PR TITLE
improving df.to_csv performance

### DIFF
--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -901,54 +901,69 @@ def write_csv_rows(list data, list data_index, int nlevels, list cols, object wr
         writer.writerows(rows[:((j+1) % N)])
 
 
-from libc.stdio cimport fprintf, FILE, fopen, fclose
+from libc.stdio cimport fprintf, FILE, fopen, fclose, fflush
+cdef class FastWriter:
+
+    cdef FILE* _cfile
+
+    def __cinit__(self, filename):
+        filename_byte_string = filename.encode("UTF-8")
+        cdef char* fname = filename_byte_string
+
+        cdef FILE* _cfile
+        _cfile = fopen(fname, "a")
+        if _cfile == NULL:
+            return
+        self._cfile = _cfile
+
+    cpdef int writerow(self, list row):
+        cdef char* colname
+        for item in row[:-1]:
+            tmp = str(item)
+            colname = tmp
+            fprintf(self._cfile, "%s,", colname)
+        tmp = str(row[-1])
+        colname = tmp
+        fprintf(self._cfile, "%s", colname)
+        fprintf(self._cfile, '\n')
+
+    def __dealloc__(self):
+        fflush(self._cfile)
+        fclose(self._cfile)
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def write_csv_rows_fast(list data, list data_index, list cols, object filename):
-    cdef int N, j, i, ncols
-    # cdef list rows
-    filename_byte_string = filename.encode("UTF-8")
-    cdef char* fname = filename_byte_string
-    cdef float item
+def write_csv_rows_fast(list data, list data_index, int nlevels, list cols, 
+                        FastWriter writer, list type_strings):
+    cdef:
+        int N, j, i, ncols
 
-    cdef FILE* cfile
-    cfile = fopen(fname, "a")
-    if cfile == NULL:
-        return
-
-    # In crude testing, N>100 yields little marginal improvement
-    N=100
-
-    # pre-allocate  rows
     ncols = len(cols)
-    # changing nlevels to 1 here, only making this work for nlevel=1
-    # rows = [[None]*(1+ncols) for x in range(N)]
 
     j = -1
 
-    cdef char* fmt = "%f,"
     for j in range(len(data_index)):
-        # row = rows[j % N]
-        # row[0] = data_index[j]
-        item = data_index[j]
-        fprintf(cfile, fmt, item)
-        for i in range(ncols):
-            # row[1+i] = data[i][j]
-            item = data[i][j]
-            fprintf(cfile, fmt, item)
+        for i in range(ncols-1):
+            tmp = data[i][j]
+            typestring = type_strings[i]
+            if typestring == 'f':
+                fprintf(writer._cfile, "%f,", <float>tmp)
+            elif typestring == 'i':
+                fprintf(writer._cfile, "%i,", <int>tmp)
+            elif typestring == 'O':
+                fprintf(writer._cfile, "%s,", <char*>tmp)
+        # last column wthout comma
+        tmp = data[i+1][j]
+        typestring = type_strings[i+1]
+        if typestring == 'f':
+            fprintf(writer._cfile, "%f", <float>tmp)
+        elif typestring == 'i':
+            fprintf(writer._cfile, "%i", <int>tmp)
+        elif typestring == 'O':
+            fprintf(writer._cfile, "%s", <char*>tmp)
+        fprintf(writer._cfile, "\n")
 
-        fprintf(cfile, '\n')
 
-        if j >= N-1 and j % N == N-1:
-            # writer.writerows(rows)
-            pass
-
-    if  j >= 0 and (j < N-1 or (j % N) != N-1 ):
-        # writer.writerows(rows[:((j+1) % N)])
-        pass
-
-    fclose(cfile)
 #-------------------------------------------------------------------------------
 # Groupby-related functions
 


### PR DESCRIPTION
This is a WIP and discuss PR :construction: for #3186 
Adding small Writer class to have short-lived self.writer in CSVFomatter just for the header line. It is closed after the header was written.
Adding new lib.pyx function write_csv_rows_fast that manages file open/close on its own with self.path_or_buf from CSVFormmatter.
Current speed-up is factor 2.5 compared to before. Possibly the fprintf for each item is inefficient, but I thought as fprintf is buffered (in contrast to write) it can't be too bad. Any suggestions what I'm doing horribly wrong?
