### PR TITLE
TST Fix AttributeError: 'iterator' object has no attribute 'next' on Python 3

### DIFF
--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -481,7 +481,7 @@ class TestSeriesPlots(TestPlotBase):
                                autopct='%.2f', fontsize=7)
         pcts = ['{0:.2f}'.format(s * 100) for s in series.values / float(series.sum())]
         iters = [iter(series.index), iter(pcts)]
-        expected_texts = list(it.next() for it in itertools.cycle(iters))
+        expected_texts = list(next(it) for it in itertools.cycle(iters))
         self._check_text_labels(ax.texts, expected_texts)
         for t in ax.texts:
             self.assertEqual(t.get_fontsize(), 7)


### PR DESCRIPTION
```
======================================================================
ERROR: test_pie_series (pandas.tests.test_graphics.TestSeriesPlots)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\pandas\tests\test_graphics.py", line 484, in test_pie_series
    expected_texts = list(it.next() for it in itertools.cycle(iters))
  File "X:\Python34\lib\site-packages\pandas\tests\test_graphics.py", line 484, in <genexpr>
    expected_texts = list(it.next() for it in itertools.cycle(iters))
AttributeError: 'iterator' object has no attribute 'next'

----------------------------------------------------------------------
```
