### PR TITLE
CLN: Python 3.4 deprecation of assert_

### DIFF
--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -221,7 +221,7 @@ class TestIndexOps(Ops):
 
             if isinstance(o, DatetimeIndex):
                 # DatetimeIndex.unique returns DatetimeIndex
-                self.assert_(o.unique().equals(klass(values)))
+                self.assertTrue(o.unique().equals(klass(values)))
             else:
                 self.assert_numpy_array_equal(o.unique(), values)
 
@@ -262,9 +262,9 @@ class TestIndexOps(Ops):
                 self.assert_numpy_array_equal(result[1:], values[2:])
 
                 if isinstance(o, DatetimeIndex):
-                    self.assert_(result[0] is pd.NaT)
+                    self.assertTrue(result[0] is pd.NaT)
                 else:
-                    self.assert_(pd.isnull(result[0]))
+                    self.assertTrue(pd.isnull(result[0]))
 
                 if isinstance(o, DatetimeIndex):
                     self.assertEqual(o.nunique(), 9)
@@ -351,7 +351,7 @@ class TestIndexOps(Ops):
                                 dtype='datetime64[ns]')
             if isinstance(s, DatetimeIndex):
                 expected = DatetimeIndex(expected)
-                self.assert_(s.unique().equals(expected))
+                self.assertTrue(s.unique().equals(expected))
             else:
                 self.assert_numpy_array_equal(s.unique(), expected)
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5089,7 +5089,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # DataFrame
         self.assert_(df.eq(df).values.all())
-        self.assert_(not df.ne(df).values.any())
+        self.assertFalse(df.ne(df).values.any())
         for op in ['eq', 'ne', 'gt', 'lt', 'ge', 'le']:
             f = getattr(df, op)
             o = getattr(operator, op)
@@ -5149,17 +5149,17 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # NA
         df.ix[0, 0] = np.nan
         rs = df.eq(df)
-        self.assert_(not rs.ix[0, 0])
+        self.assertFalse(rs.ix[0, 0])
         rs = df.ne(df)
         self.assert_(rs.ix[0, 0])
         rs = df.gt(df)
-        self.assert_(not rs.ix[0, 0])
+        self.assertFalse(rs.ix[0, 0])
         rs = df.lt(df)
-        self.assert_(not rs.ix[0, 0])
+        self.assertFalse(rs.ix[0, 0])
         rs = df.ge(df)
-        self.assert_(not rs.ix[0, 0])
+        self.assertFalse(rs.ix[0, 0])
         rs = df.le(df)
-        self.assert_(not rs.ix[0, 0])
+        self.assertFalse(rs.ix[0, 0])
 
 
 
@@ -5169,14 +5169,14 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df = DataFrame({'a': arr})
         df2 = DataFrame({'a': arr2})
         rs = df.gt(df2)
-        self.assert_(not rs.values.any())
+        self.assertFalse(rs.values.any())
         rs = df.ne(df2)
         self.assert_(rs.values.all())
 
         arr3 = np.array([2j, np.nan, None])
         df3 = DataFrame({'a': arr3})
         rs = df3.gt(2j)
-        self.assert_(not rs.values.any())
+        self.assertFalse(rs.values.any())
 
         # corner, dtype=object
         df1 = DataFrame({'col': ['foo', np.nan, 'bar']})
@@ -8400,7 +8400,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         index = self.tsframe.index
         truncated = self.tsframe.truncate(index[5], index[10])
         truncated.values[:] = 5.
-        self.assert_(not (self.tsframe.values[5:11] == 5).any())
+        self.assertFalse((self.tsframe.values[5:11] == 5).any())
 
     def test_xs(self):
         idx = self.frame.index[5]
@@ -10499,13 +10499,13 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         median = self.frame.median().median()
 
         capped = self.frame.clip_upper(median)
-        self.assert_(not (capped.values > median).any())
+        self.assertFalse((capped.values > median).any())
 
         floored = self.frame.clip_lower(median)
-        self.assert_(not (floored.values < median).any())
+        self.assertFalse((floored.values < median).any())
 
         double = self.frame.clip(upper=median, lower=median)
-        self.assert_(not (double.values != median).any())
+        self.assertFalse((double.values != median).any())
 
     def test_dataframe_clip(self):
 
@@ -10536,7 +10536,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                                       ['a', 'b', 'e'])
 
     def test_is_mixed_type(self):
-        self.assert_(not self.frame._is_mixed_type)
+        self.assertFalse(self.frame._is_mixed_type)
         self.assert_(self.mixed_frame._is_mixed_type)
 
     def test_get_numeric_data(self):
@@ -11787,7 +11787,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         cop = DataFrame(self.frame, copy=True)
         cop['A'] = 5
         self.assert_((cop['A'] == 5).all())
-        self.assert_(not (self.frame['A'] == 5).all())
+        self.assertFalse((self.frame['A'] == 5).all())
 
     def test_constructor_ndarray_copy(self):
         df = DataFrame(self.frame.values)
@@ -11797,7 +11797,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         df = DataFrame(self.frame.values, copy=True)
         self.frame.values[6] = 6
-        self.assert_(not (df.values[6] == 6).all())
+        self.assertFalse((df.values[6] == 6).all())
 
     def test_constructor_series_copy(self):
         series = self.frame._series
@@ -11805,7 +11805,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df = DataFrame({'A': series['A']})
         df['A'][:] = 5
 
-        self.assert_(not (series['A'] == 5).all())
+        self.assertFalse((series['A'] == 5).all())
 
     def test_constructor_compound_dtypes(self):
         # GH 5191
@@ -11938,7 +11938,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
     def test_as_matrix_consolidate(self):
         self.frame['E'] = 7.
-        self.assert_(not self.frame._data.is_consolidated())
+        self.assertFalse(self.frame._data.is_consolidated())
         _ = self.frame.as_matrix()
         self.assert_(self.frame._data.is_consolidated())
 
@@ -12365,8 +12365,8 @@ starting,ending,measure
             r0 = getattr(all_na, name)(axis=0)
             r1 = getattr(all_na, name)(axis=1)
             if name == 'any':
-                self.assert_(not r0.any())
-                self.assert_(not r1.any())
+                self.assertFalse(r0.any())
+                self.assertFalse(r1.any())
             else:
                 self.assert_(r0.all())
                 self.assert_(r1.all())

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -1148,7 +1148,7 @@ class TestNDFrame(tm.TestCase):
         self.assert_(s1.equals(s2))
 
         s1[1] = 99
-        self.assert_(not s1.equals(s2))
+        self.assertFalse(s1.equals(s2))
 
         # NaNs compare as equal
         s1 = pd.Series([1, np.nan, 3, np.nan], index=[0, 2, 1, 3])
@@ -1156,7 +1156,7 @@ class TestNDFrame(tm.TestCase):
         self.assert_(s1.equals(s2))
 
         s2[0] = 9.9
-        self.assert_(not s1.equals(s2))
+        self.assertFalse(s1.equals(s2))
 
         idx = MultiIndex.from_tuples([(0, 'a'), (1, 'b'), (2, 'c')])
         s1 = Series([1, 2, np.nan], index=idx)
@@ -1179,22 +1179,22 @@ class TestNDFrame(tm.TestCase):
         self.assert_(df1['diff'].equals(df2['diff']))
         self.assert_(df1['bool'].equals(df2['bool']))
         self.assert_(df1.equals(df2))
-        self.assert_(not df1.equals(object))
+        self.assertFalse(df1.equals(object))
 
         # different dtype
         different = df1.copy()
         different['floats'] = different['floats'].astype('float32')
-        self.assert_(not df1.equals(different))
+        self.assertFalse(df1.equals(different))
 
         # different index
         different_index = -index
         different = df2.set_index(different_index)
-        self.assert_(not df1.equals(different))
+        self.assertFalse(df1.equals(different))
 
         # different columns
         different = df2.copy()
         different.columns = df2.columns[::-1]
-        self.assert_(not df1.equals(different))
+        self.assertFalse(df1.equals(different))
 
         # DatetimeIndex
         index = pd.date_range('2000-1-1', periods=10, freq='T')
@@ -1208,7 +1208,7 @@ class TestNDFrame(tm.TestCase):
         self.assert_(df3.equals(df2))
 
         df2 = df1.set_index(['floats'], append=True)
-        self.assert_(not df3.equals(df2))
+        self.assertFalse(df3.equals(df2))
 
         # NaN in index
         df3 = df1.set_index(['floats'], append=True)

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -413,7 +413,7 @@ class TestSeriesPlots(TestPlotBase):
         ax = self.ts.plot(kind='area', stacked=False)
         xmin, xmax = ax.get_xlim()
         lines = ax.get_lines()
-        self.assertEqual(xmin, lines[0].get_data(orig=False)[0][0])       
+        self.assertEqual(xmin, lines[0].get_data(orig=False)[0][0])
         self.assertEqual(xmax, lines[0].get_data(orig=False)[0][-1])
 
     def test_line_area_nan_series(self):
@@ -1023,13 +1023,13 @@ class TestDataFramePlots(TestPlotBase):
             xmin, xmax = ax.get_xlim()
             ymin, ymax = ax.get_ylim()
             lines = ax.get_lines()
-            self.assertEqual(xmin, lines[0].get_data()[0][0])        
-            self.assertEqual(xmax, lines[0].get_data()[0][-1]) 
-            self.assertEqual(ymin, 0) 
+            self.assertEqual(xmin, lines[0].get_data()[0][0])
+            self.assertEqual(xmax, lines[0].get_data()[0][-1])
+            self.assertEqual(ymin, 0)
 
             ax = _check_plot_works(neg_df.plot, kind='area', stacked=stacked)
             ymin, ymax = ax.get_ylim()
-            self.assertEqual(ymax, 0) 
+            self.assertEqual(ymax, 0)
 
     @slow
     def test_bar_colors(self):
@@ -1471,7 +1471,7 @@ class TestDataFramePlots(TestPlotBase):
         df = DataFrame(randn(100, 3))
         _check_plot_works(df.hist)
         axes = df.hist(grid=False)
-        self.assert_(not axes[1, 1].get_visible())
+        self.assertFalse(axes[1, 1].get_visible())
 
         df = DataFrame(randn(100, 1))
         _check_plot_works(df.hist)
@@ -1576,7 +1576,7 @@ class TestDataFramePlots(TestPlotBase):
     def test_andrews_curves(self):
         from pandas.tools.plotting import andrews_curves
         from matplotlib import cm
-        
+
         df = self.iris
 
         _check_plot_works(andrews_curves, df, 'Name')
@@ -1601,7 +1601,7 @@ class TestDataFramePlots(TestPlotBase):
         ax = andrews_curves(df, 'Name', color=colors)
         handles, labels = ax.get_legend_handles_labels()
         self._check_colors(handles, linecolors=colors)
-        
+
         with tm.assert_produces_warning(FutureWarning):
             andrews_curves(data=df, class_column='Name')
 
@@ -1609,7 +1609,7 @@ class TestDataFramePlots(TestPlotBase):
     def test_parallel_coordinates(self):
         from pandas.tools.plotting import parallel_coordinates
         from matplotlib import cm
-        
+
         df = self.iris
 
         _check_plot_works(parallel_coordinates, df, 'Name')
@@ -1634,7 +1634,7 @@ class TestDataFramePlots(TestPlotBase):
         ax = parallel_coordinates(df, 'Name', color=colors)
         handles, labels = ax.get_legend_handles_labels()
         self._check_colors(handles, linecolors=colors)
-        
+
         with tm.assert_produces_warning(FutureWarning):
             parallel_coordinates(data=df, class_column='Name')
         with tm.assert_produces_warning(FutureWarning):
@@ -1845,7 +1845,7 @@ class TestDataFramePlots(TestPlotBase):
         poly = [o for o in ax.get_children() if isinstance(o, PolyCollection)]
         self._check_colors(poly, facecolors=rgba_colors)
         tm.close()
-        
+
         ax = df.plot(kind='area', colormap=cm.jet)
         rgba_colors = lmap(cm.jet, np.linspace(0, 1, len(df)))
         self._check_colors(ax.get_lines(), linecolors=rgba_colors)
@@ -1920,7 +1920,7 @@ class TestDataFramePlots(TestPlotBase):
         # hexbin should have 2 axes in the figure, 1 for plotting and another is colorbar
         self.assertEqual(len(axes[0].figure.axes), 2)
         # return value is single axes
-        self._check_axes_shape(axes, axes_num=1, layout=(1, )) 
+        self._check_axes_shape(axes, axes_num=1, layout=(1, ))
 
 
     @slow
@@ -2081,7 +2081,7 @@ class TestDataFramePlots(TestPlotBase):
         df_err = DataFrame(d_err)
         for err in [d_err, df_err]:
             ax = _check_plot_works(df.plot, yerr=err)
-            self._check_has_errorbars(ax, xerr=0, yerr=1)            
+            self._check_has_errorbars(ax, xerr=0, yerr=1)
 
     @slow
     def test_errorbar_timeseries(self):

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -103,7 +103,7 @@ class TestIndex(tm.TestCase):
         for func in (copy, deepcopy):
             idx_copy = func(self.strIndex)
             self.assertIsNot(idx_copy, self.strIndex)
-            self.assert_(idx_copy.equals(self.strIndex))
+            self.assertTrue(idx_copy.equals(self.strIndex))
 
         new_copy = self.strIndex.copy(deep=True, name="banana")
         self.assertEqual(new_copy.name, "banana")
@@ -112,7 +112,7 @@ class TestIndex(tm.TestCase):
 
     def test_duplicates(self):
         idx = Index([0, 0, 0])
-        self.assert_(not idx.is_unique)
+        self.assertFalse(idx.is_unique)
 
     def test_sort(self):
         self.assertRaises(TypeError, self.strIndex.sort)
@@ -183,15 +183,15 @@ class TestIndex(tm.TestCase):
     def test_constructor_simple_new(self):
         idx = Index([1, 2, 3, 4, 5], name='int')
         result = idx._simple_new(idx, 'int')
-        self.assert_(result.equals(idx))
+        self.assertTrue(result.equals(idx))
 
         idx = Index([1.1, np.nan, 2.2, 3.0], name='float')
         result = idx._simple_new(idx, 'float')
-        self.assert_(result.equals(idx))
+        self.assertTrue(result.equals(idx))
 
         idx = Index(['A', 'B', 'C', np.nan], name='obj')
         result = idx._simple_new(idx, 'obj')
-        self.assert_(result.equals(idx))
+        self.assertTrue(result.equals(idx))
 
     def test_copy(self):
         i = Index([], name='Foo')
@@ -219,7 +219,7 @@ class TestIndex(tm.TestCase):
 
     def test_equals(self):
         # same
-        self.assert_(Index(['a', 'b', 'c']).equals(Index(['a', 'b', 'c'])))
+        self.assertTrue(Index(['a', 'b', 'c']).equals(Index(['a', 'b', 'c'])))
 
         # different length
         self.assertFalse(Index(['a', 'b', 'c']).equals(Index(['a', 'b'])))
@@ -236,14 +236,14 @@ class TestIndex(tm.TestCase):
         i1 = Index(['a', 'b', 'c'])
         i2 = Index(['a', 'b', 'c'])
 
-        self.assert_(i1.identical(i2))
+        self.assertTrue(i1.identical(i2))
 
         i1 = i1.rename('foo')
-        self.assert_(i1.equals(i2))
-        self.assert_(not i1.identical(i2))
+        self.assertTrue(i1.equals(i2))
+        self.assertFalse(i1.identical(i2))
 
         i2 = i2.rename('foo')
-        self.assert_(i1.identical(i2))
+        self.assertTrue(i1.identical(i2))
 
         i3 = Index([('a', 'a'), ('a', 'b'), ('b', 'a')])
         i4 = Index([('a', 'a'), ('a', 'b'), ('b', 'a')], tupleize_cols=False)
@@ -275,7 +275,7 @@ class TestIndex(tm.TestCase):
     def test_asof(self):
         d = self.dateIndex[0]
         self.assertIs(self.dateIndex.asof(d), d)
-        self.assert_(np.isnan(self.dateIndex.asof(d - timedelta(1))))
+        self.assertTrue(np.isnan(self.dateIndex.asof(d - timedelta(1))))
 
         d = self.dateIndex[-1]
         self.assertEqual(self.dateIndex.asof(d + timedelta(1)), d)
@@ -353,9 +353,9 @@ class TestIndex(tm.TestCase):
             empty_idx = idx.__class__([])
             values = idx.values
 
-            self.assert_(idx[[]].identical(empty_idx))
-            self.assert_(idx[empty_iarr].identical(empty_idx))
-            self.assert_(idx[empty_barr].identical(empty_idx))
+            self.assertTrue(idx[[]].identical(empty_idx))
+            self.assertTrue(idx[empty_iarr].identical(empty_idx))
+            self.assertTrue(idx[empty_barr].identical(empty_idx))
 
             # np.ndarray only accepts ndarray of int & bool dtypes, so should
             # Index.
@@ -386,7 +386,7 @@ class TestIndex(tm.TestCase):
         second = self.strIndex[:10]
         intersect = first.intersection(second)
 
-        self.assert_(tm.equalContents(intersect, second))
+        self.assertTrue(tm.equalContents(intersect, second))
 
         # Corner cases
         inter = first.intersection(first)
@@ -400,7 +400,7 @@ class TestIndex(tm.TestCase):
         second = self.strIndex[:10]
         everything = self.strIndex[:20]
         union = first.union(second)
-        self.assert_(tm.equalContents(union, everything))
+        self.assertTrue(tm.equalContents(union, everything))
 
         # Corner cases
         union = first.union(first)
@@ -434,8 +434,8 @@ class TestIndex(tm.TestCase):
         else:
             appended = np.append(self.strIndex, self.dateIndex.astype('O'))
 
-        self.assert_(tm.equalContents(firstCat, appended))
-        self.assert_(tm.equalContents(secondCat, self.strIndex))
+        self.assertTrue(tm.equalContents(firstCat, appended))
+        self.assertTrue(tm.equalContents(secondCat, self.strIndex))
         tm.assert_contains_all(self.strIndex, firstCat)
         tm.assert_contains_all(self.strIndex, secondCat)
         tm.assert_contains_all(self.dateIndex, firstCat)
@@ -445,11 +445,11 @@ class TestIndex(tm.TestCase):
 
         foos = [index[:2], index[2:4], index[4:]]
         result = foos[0].append(foos[1:])
-        self.assert_(result.equals(index))
+        self.assertTrue(result.equals(index))
 
         # empty
         result = index.append([])
-        self.assert_(result.equals(index))
+        self.assertTrue(result.equals(index))
 
     def test_append_empty_preserve_name(self):
         left = Index([], name='foo')
@@ -488,7 +488,7 @@ class TestIndex(tm.TestCase):
         # different names
         result = first - second
 
-        self.assert_(tm.equalContents(result, answer))
+        self.assertTrue(tm.equalContents(result, answer))
         self.assertEqual(result.name, None)
 
         # same names
@@ -498,7 +498,7 @@ class TestIndex(tm.TestCase):
 
         # with empty
         result = first.diff([])
-        self.assert_(tm.equalContents(result, first))
+        self.assertTrue(tm.equalContents(result, first))
         self.assertEqual(result.name, first.name)
 
         # with everythin
@@ -515,12 +515,12 @@ class TestIndex(tm.TestCase):
         idx2 = Index([2, 3, 4, 5])
         result = idx1.sym_diff(idx2)
         expected = Index([1, 5])
-        self.assert_(tm.equalContents(result, expected))
+        self.assertTrue(tm.equalContents(result, expected))
         self.assertIsNone(result.name)
 
         # __xor__ syntax
         expected = idx1 ^ idx2
-        self.assert_(tm.equalContents(result, expected))
+        self.assertTrue(tm.equalContents(result, expected))
         self.assertIsNone(result.name)
 
         # multiIndex
@@ -528,7 +528,7 @@ class TestIndex(tm.TestCase):
         idx2 = MultiIndex.from_tuples([('foo', 1), ('bar', 3)])
         result = idx1.sym_diff(idx2)
         expected = MultiIndex.from_tuples([('bar', 2), ('baz', 3), ('bar', 3)])
-        self.assert_(tm.equalContents(result, expected))
+        self.assertTrue(tm.equalContents(result, expected))
 
         # nans:
         # GH #6444, sorting of nans. Make sure the number of nans is right
@@ -547,11 +547,11 @@ class TestIndex(tm.TestCase):
         idx2 = np.array([2, 3, 4, 5])
         expected = Index([1, 5])
         result = idx1.sym_diff(idx2)
-        self.assert_(tm.equalContents(result, expected))
+        self.assertTrue(tm.equalContents(result, expected))
         self.assertEquals(result.name, 'idx1')
 
         result = idx1.sym_diff(idx2, result_name='new_name')
-        self.assert_(tm.equalContents(result, expected))
+        self.assertTrue(tm.equalContents(result, expected))
         self.assertEquals(result.name, 'new_name')
 
         # other isn't iterable
@@ -576,15 +576,15 @@ class TestIndex(tm.TestCase):
         testit(self.dateIndex)
 
     def test_is_numeric(self):
-        self.assert_(not self.dateIndex.is_numeric())
-        self.assert_(not self.strIndex.is_numeric())
-        self.assert_(self.intIndex.is_numeric())
-        self.assert_(self.floatIndex.is_numeric())
+        self.assertFalse(self.dateIndex.is_numeric())
+        self.assertFalse(self.strIndex.is_numeric())
+        self.assertTrue(self.intIndex.is_numeric())
+        self.assertTrue(self.floatIndex.is_numeric())
 
     def test_is_all_dates(self):
-        self.assert_(self.dateIndex.is_all_dates)
-        self.assert_(not self.strIndex.is_all_dates)
-        self.assert_(not self.intIndex.is_all_dates)
+        self.assertTrue(self.dateIndex.is_all_dates)
+        self.assertFalse(self.strIndex.is_all_dates)
+        self.assertFalse(self.intIndex.is_all_dates)
 
     def test_summary(self):
         self._check_method_works(Index.summary)
@@ -644,7 +644,7 @@ class TestIndex(tm.TestCase):
         indexer = [4, 3, 0, 2]
         result = self.dateIndex.take(indexer)
         expected = self.dateIndex[indexer]
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
     def _check_method_works(self, method):
         method(self.empty)
@@ -707,18 +707,18 @@ class TestIndex(tm.TestCase):
 
         dropped = self.strIndex.drop(self.strIndex[lrange(5, 10)])
         expected = self.strIndex[lrange(5) + lrange(10, n)]
-        self.assert_(dropped.equals(expected))
+        self.assertTrue(dropped.equals(expected))
 
         self.assertRaises(ValueError, self.strIndex.drop, ['foo', 'bar'])
 
         dropped = self.strIndex.drop(self.strIndex[0])
         expected = self.strIndex[1:]
-        self.assert_(dropped.equals(expected))
+        self.assertTrue(dropped.equals(expected))
 
         ser = Index([1, 2, 3])
         dropped = ser.drop(1)
         expected = Index([2, 3])
-        self.assert_(dropped.equals(expected))
+        self.assertTrue(dropped.equals(expected))
 
     def test_tuple_union_bug(self):
         import pandas
@@ -737,17 +737,17 @@ class TestIndex(tm.TestCase):
         # needs to be 1d like idx1 and idx2
         expected = idx1[:4]  # pandas.Index(sorted(set(idx1) & set(idx2)))
         self.assertEqual(int_idx.ndim, 1)
-        self.assert_(int_idx.equals(expected))
+        self.assertTrue(int_idx.equals(expected))
 
         # union broken
         union_idx = idx1.union(idx2)
         expected = pandas.Index(sorted(set(idx1) | set(idx2)))
         self.assertEqual(union_idx.ndim, 1)
-        self.assert_(union_idx.equals(expected))
+        self.assertTrue(union_idx.equals(expected))
 
     def test_is_monotonic_incomparable(self):
         index = Index([5, datetime.now(), 7])
-        self.assert_(not index.is_monotonic)
+        self.assertFalse(index.is_monotonic)
 
     def test_get_set_value(self):
         values = np.random.randn(100)
@@ -779,13 +779,13 @@ class TestIndex(tm.TestCase):
         idx = Index(values)
         res = (idx == values)
 
-        self.assert_(res.all())
+        self.assertTrue(res.all())
         self.assertEqual(res.dtype, 'bool')
         self.assertNotIsInstance(res, Index)
 
     def test_get_level_values(self):
         result = self.strIndex.get_level_values(0)
-        self.assert_(result.equals(self.strIndex))
+        self.assertTrue(result.equals(self.strIndex))
 
     def test_slice_keep_name(self):
         idx = Index(['a', 'b'], name='asdf')
@@ -803,9 +803,9 @@ class TestIndex(tm.TestCase):
     def test_indexing_doesnt_change_class(self):
         idx = Index([1, 2, 3, 'a', 'b', 'c'])
 
-        self.assert_(idx[1:3].identical(
+        self.assertTrue(idx[1:3].identical(
             pd.Index([2, 3], dtype=np.object_)))
-        self.assert_(idx[[0,1]].identical(
+        self.assertTrue(idx[[0,1]].identical(
             pd.Index([1, 2], dtype=np.object_)))
 
 
@@ -831,7 +831,7 @@ class TestFloat64Index(tm.TestCase):
         self.assertNotIsInstance(i, Float64Index)
 
     def check_coerce(self, a, b, is_float_index=True):
-        self.assert_(a.equals(b))
+        self.assertTrue(a.equals(b))
         if is_float_index:
             self.assertIsInstance(b, Float64Index)
         else:
@@ -842,7 +842,7 @@ class TestFloat64Index(tm.TestCase):
         # explicit construction
         index = Float64Index([1,2,3,4,5])
         self.assertIsInstance(index, Float64Index)
-        self.assert_((index.values == np.array([1,2,3,4,5],dtype='float64')).all())
+        self.assertTrue((index.values == np.array([1,2,3,4,5],dtype='float64')).all())
         index = Float64Index(np.array([1,2,3,4,5]))
         self.assertIsInstance(index, Float64Index)
         index = Float64Index([1.,2,3,4,5])
@@ -861,11 +861,11 @@ class TestFloat64Index(tm.TestCase):
 
         # nan handling
         result = Float64Index([np.nan, np.nan])
-        self.assert_(pd.isnull(result.values).all())
+        self.assertTrue(pd.isnull(result.values).all())
         result = Float64Index(np.array([np.nan]))
-        self.assert_(pd.isnull(result.values).all())
+        self.assertTrue(pd.isnull(result.values).all())
         result = Index(np.array([np.nan]))
-        self.assert_(pd.isnull(result.values).all())
+        self.assertTrue(pd.isnull(result.values).all())
 
     def test_constructor_invalid(self):
 
@@ -891,15 +891,15 @@ class TestFloat64Index(tm.TestCase):
     def test_astype(self):
 
         result = self.float.astype(object)
-        self.assert_(result.equals(self.float))
-        self.assert_(self.float.equals(result))
+        self.assertTrue(result.equals(self.float))
+        self.assertTrue(self.float.equals(result))
         self.check_is_index(result)
 
         i = self.mixed.copy()
         i.name = 'foo'
         result = i.astype(object)
-        self.assert_(result.equals(i))
-        self.assert_(i.equals(result))
+        self.assertTrue(result.equals(i))
+        self.assertTrue(i.equals(result))
         self.check_is_index(result)
 
     def test_equals(self):
@@ -983,7 +983,7 @@ class TestInt64Index(tm.TestCase):
         arr = np.array([1, 2, 3, 4], dtype=object)
         index = Int64Index(arr)
         self.assertEqual(index.values.dtype, np.int64)
-        self.assert_(index.equals(arr))
+        self.assertTrue(index.equals(arr))
 
         # preventing casting
         arr = np.array([1, '2', 3, '4'], dtype=object)
@@ -1023,15 +1023,15 @@ class TestInt64Index(tm.TestCase):
         self.assertEqual(self.index.dtype, np.int64)
 
     def test_is_monotonic(self):
-        self.assert_(self.index.is_monotonic)
+        self.assertTrue(self.index.is_monotonic)
 
         index = Int64Index([4, 3, 2, 1])
-        self.assert_(not index.is_monotonic)
+        self.assertFalse(index.is_monotonic)
 
     def test_equals(self):
         same_values = Index(self.index, dtype=object)
-        self.assert_(self.index.equals(same_values))
-        self.assert_(same_values.equals(self.index))
+        self.assertTrue(self.index.equals(same_values))
+        self.assertTrue(same_values.equals(self.index))
 
     def test_identical(self):
         i = Index(self.index.copy())
@@ -1080,7 +1080,7 @@ class TestInt64Index(tm.TestCase):
         res, lidx, ridx = self.index.join(other, how='outer',
                                           return_indexers=True)
         noidx_res = self.index.join(other, how='outer')
-        self.assert_(res.equals(noidx_res))
+        self.assertTrue(res.equals(noidx_res))
 
         eres = Int64Index([0, 1, 2, 4, 5, 6, 7, 8, 10, 12, 14, 16, 18, 25])
         elidx = np.array([0, -1, 1, 2, -1, 3, -1, 4, 5, 6, 7, 8, 9, -1],
@@ -1089,7 +1089,7 @@ class TestInt64Index(tm.TestCase):
                          dtype=np.int64)
 
         tm.assert_isinstance(res, Int64Index)
-        self.assert_(res.equals(eres))
+        self.assertTrue(res.equals(eres))
         self.assert_numpy_array_equal(lidx, elidx)
         self.assert_numpy_array_equal(ridx, eridx)
 
@@ -1097,12 +1097,12 @@ class TestInt64Index(tm.TestCase):
         res, lidx, ridx = self.index.join(other_mono, how='outer',
                                           return_indexers=True)
         noidx_res = self.index.join(other_mono, how='outer')
-        self.assert_(res.equals(noidx_res))
+        self.assertTrue(res.equals(noidx_res))
 
         eridx = np.array([-1, 0, 1, -1, 2, -1, 3, -1, -1, 4, -1, -1, -1, 5],
                          dtype=np.int64)
         tm.assert_isinstance(res, Int64Index)
-        self.assert_(res.equals(eres))
+        self.assertTrue(res.equals(eres))
         self.assert_numpy_array_equal(lidx, elidx)
         self.assert_numpy_array_equal(ridx, eridx)
 
@@ -1125,7 +1125,7 @@ class TestInt64Index(tm.TestCase):
         eridx = np.array([4, 1])
 
         tm.assert_isinstance(res, Int64Index)
-        self.assert_(res.equals(eres))
+        self.assertTrue(res.equals(eres))
         self.assert_numpy_array_equal(lidx, elidx)
         self.assert_numpy_array_equal(ridx, eridx)
 
@@ -1134,11 +1134,11 @@ class TestInt64Index(tm.TestCase):
                                           return_indexers=True)
 
         res2 = self.index.intersection(other_mono)
-        self.assert_(res.equals(res2))
+        self.assertTrue(res.equals(res2))
 
         eridx = np.array([1, 4])
         tm.assert_isinstance(res, Int64Index)
-        self.assert_(res.equals(eres))
+        self.assertTrue(res.equals(eres))
         self.assert_numpy_array_equal(lidx, elidx)
         self.assert_numpy_array_equal(ridx, eridx)
 
@@ -1154,7 +1154,7 @@ class TestInt64Index(tm.TestCase):
                          dtype=np.int64)
 
         tm.assert_isinstance(res, Int64Index)
-        self.assert_(res.equals(eres))
+        self.assertTrue(res.equals(eres))
         self.assertIsNone(lidx)
         self.assert_numpy_array_equal(ridx, eridx)
 
@@ -1164,7 +1164,7 @@ class TestInt64Index(tm.TestCase):
         eridx = np.array([-1, 1, -1, -1, -1, -1, 4, -1, -1, -1],
                          dtype=np.int64)
         tm.assert_isinstance(res, Int64Index)
-        self.assert_(res.equals(eres))
+        self.assertTrue(res.equals(eres))
         self.assertIsNone(lidx)
         self.assert_numpy_array_equal(ridx, eridx)
 
@@ -1176,7 +1176,7 @@ class TestInt64Index(tm.TestCase):
         eres = idx2
         eridx = np.array([0, 2, 3, -1, -1])
         elidx = np.array([0, 1, 2, 3, 4])
-        self.assert_(res.equals(eres))
+        self.assertTrue(res.equals(eres))
         self.assert_numpy_array_equal(lidx, elidx)
         self.assert_numpy_array_equal(ridx, eridx)
         """
@@ -1193,7 +1193,7 @@ class TestInt64Index(tm.TestCase):
                          dtype=np.int64)
 
         tm.assert_isinstance(other, Int64Index)
-        self.assert_(res.equals(eres))
+        self.assertTrue(res.equals(eres))
         self.assert_numpy_array_equal(lidx, elidx)
         self.assertIsNone(ridx)
 
@@ -1204,7 +1204,7 @@ class TestInt64Index(tm.TestCase):
         elidx = np.array([-1, 1, -1, -1, 6, -1],
                          dtype=np.int64)
         tm.assert_isinstance(other, Int64Index)
-        self.assert_(res.equals(eres))
+        self.assertTrue(res.equals(eres))
         self.assert_numpy_array_equal(lidx, elidx)
         self.assertIsNone(ridx)
 
@@ -1216,7 +1216,7 @@ class TestInt64Index(tm.TestCase):
         eres = idx2
         elidx = np.array([0, 2, 3, -1, -1])
         eridx = np.array([0, 1, 2, 3, 4])
-        self.assert_(res.equals(eres))
+        self.assertTrue(res.equals(eres))
         self.assert_numpy_array_equal(lidx, elidx)
         self.assert_numpy_array_equal(ridx, eridx)
 
@@ -1234,26 +1234,26 @@ class TestInt64Index(tm.TestCase):
         outer2 = other.join(self.index, how='outer')
         expected = Index([0, 2, 3, 4, 6, 7, 8, 10, 12, 14,
                           16, 18], dtype=object)
-        self.assert_(outer.equals(outer2))
-        self.assert_(outer.equals(expected))
+        self.assertTrue(outer.equals(outer2))
+        self.assertTrue(outer.equals(expected))
 
         inner = self.index.join(other, how='inner')
         inner2 = other.join(self.index, how='inner')
         expected = Index([6, 8, 10], dtype=object)
-        self.assert_(inner.equals(inner2))
-        self.assert_(inner.equals(expected))
+        self.assertTrue(inner.equals(inner2))
+        self.assertTrue(inner.equals(expected))
 
         left = self.index.join(other, how='left')
-        self.assert_(left.equals(self.index))
+        self.assertTrue(left.equals(self.index))
 
         left2 = other.join(self.index, how='left')
-        self.assert_(left2.equals(other))
+        self.assertTrue(left2.equals(other))
 
         right = self.index.join(other, how='right')
-        self.assert_(right.equals(other))
+        self.assertTrue(right.equals(other))
 
         right2 = other.join(self.index, how='right')
-        self.assert_(right2.equals(self.index))
+        self.assertTrue(right2.equals(self.index))
 
     def test_join_non_unique(self):
         left = Index([4, 4, 3, 3])
@@ -1261,7 +1261,7 @@ class TestInt64Index(tm.TestCase):
         joined, lidx, ridx = left.join(left, return_indexers=True)
 
         exp_joined = Index([3, 3, 3, 3, 4, 4, 4, 4])
-        self.assert_(joined.equals(exp_joined))
+        self.assertTrue(joined.equals(exp_joined))
 
         exp_lidx = np.array([2, 2, 3, 3, 0, 0, 1, 1], dtype=np.int64)
         self.assert_numpy_array_equal(lidx, exp_lidx)
@@ -1754,15 +1754,15 @@ class TestMultiIndex(tm.TestCase):
 
     def test_append(self):
         result = self.index[:3].append(self.index[3:])
-        self.assert_(result.equals(self.index))
+        self.assertTrue(result.equals(self.index))
 
         foos = [self.index[:1], self.index[1:3], self.index[3:]]
         result = foos[0].append(foos[1:])
-        self.assert_(result.equals(self.index))
+        self.assertTrue(result.equals(self.index))
 
         # empty
         result = self.index.append([])
-        self.assert_(result.equals(self.index))
+        self.assertTrue(result.equals(self.index))
 
     def test_get_level_values(self):
         result = self.index.get_level_values(0)
@@ -1826,7 +1826,7 @@ class TestMultiIndex(tm.TestCase):
     def test_pickle(self):
         pickled = pickle.dumps(self.index)
         unpickled = pickle.loads(pickled)
-        self.assert_(self.index.equals(unpickled))
+        self.assertTrue(self.index.equals(unpickled))
 
     def test_legacy_pickle(self):
         if compat.PY3:
@@ -1839,10 +1839,10 @@ class TestMultiIndex(tm.TestCase):
         ppath = os.path.join(curpath(), 'data/multiindex_v1.pickle')
         obj = pickle.load(open(ppath, 'r'))
 
-        self.assert_(obj._is_v1)
+        self.assertTrue(obj._is_v1)
 
         obj2 = MultiIndex.from_tuples(obj.values)
-        self.assert_(obj.equals(obj2))
+        self.assertTrue(obj.equals(obj2))
 
         res = obj.get_indexer(obj)
         exp = np.arange(len(obj))
@@ -1862,7 +1862,7 @@ class TestMultiIndex(tm.TestCase):
         obj = pd.read_pickle(filepath)
 
         obj2 = MultiIndex.from_tuples(obj.values)
-        self.assert_(obj.equals(obj2))
+        self.assertTrue(obj.equals(obj2))
 
         res = obj.get_indexer(obj)
         exp = np.arange(len(obj))
@@ -1876,7 +1876,7 @@ class TestMultiIndex(tm.TestCase):
 
     def test_from_tuples_index_values(self):
         result = MultiIndex.from_tuples(self.index)
-        self.assert_((result.values == self.index.values).all())
+        self.assertTrue((result.values == self.index.values).all())
 
     def test_contains(self):
         self.assertIn(('foo', 'two'), self.index)
@@ -1884,11 +1884,11 @@ class TestMultiIndex(tm.TestCase):
         self.assertNotIn(None, self.index)
 
     def test_is_all_dates(self):
-        self.assert_(not self.index.is_all_dates)
+        self.assertFalse(self.index.is_all_dates)
 
     def test_is_numeric(self):
         # MultiIndex is never numeric
-        self.assert_(not self.index.is_numeric())
+        self.assertFalse(self.index.is_numeric())
 
     def test_getitem(self):
         # scalar
@@ -1897,14 +1897,14 @@ class TestMultiIndex(tm.TestCase):
         # slice
         result = self.index[2:5]
         expected = self.index[[2, 3, 4]]
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         # boolean
         result = self.index[[True, False, True, False, True, True]]
         result2 = self.index[np.array([True, False, True, False, True, True])]
         expected = self.index[[0, 2, 4, 5]]
-        self.assert_(result.equals(expected))
-        self.assert_(result2.equals(expected))
+        self.assertTrue(result.equals(expected))
+        self.assertTrue(result2.equals(expected))
 
     def test_getitem_group_select(self):
         sorted_idx, _ = self.index.sortlevel(0)
@@ -1951,7 +1951,7 @@ class TestMultiIndex(tm.TestCase):
         expected = slice(1, 2)
         exp_index = index[expected].droplevel(0).droplevel(0)
         self.assertEqual(loc, expected)
-        self.assert_(new_index.equals(exp_index))
+        self.assertTrue(new_index.equals(exp_index))
 
         loc, new_index = index.get_loc_level((0, 1, 0))
         expected = 1
@@ -1966,7 +1966,7 @@ class TestMultiIndex(tm.TestCase):
         result, new_index = index.get_loc_level((2000, slice(None, None)))
         expected = slice(None, None)
         self.assertEqual(result, expected)
-        self.assert_(new_index.equals(index.droplevel(0)))
+        self.assertTrue(new_index.equals(index.droplevel(0)))
 
     def test_slice_locs(self):
         df = tm.makeTimeDataFrame()
@@ -2077,7 +2077,7 @@ class TestMultiIndex(tm.TestCase):
         index = MultiIndex(levels=[major_axis, minor_axis],
                            labels=[major_labels, minor_labels])
 
-        self.assert_(not index.is_unique)
+        self.assertFalse(index.is_unique)
 
     def test_truncate(self):
         major_axis = Index(lrange(4))
@@ -2136,7 +2136,7 @@ class TestMultiIndex(tm.TestCase):
         assert_almost_equal(r1, rexp1)
 
         r1 = idx1.get_indexer([1, 2, 3])
-        self.assert_((r1 == [-1, -1, -1]).all())
+        self.assertTrue((r1 == [-1, -1, -1]).all())
 
         # create index with duplicates
         idx1 = Index(lrange(10) + lrange(10))
@@ -2215,12 +2215,12 @@ class TestMultiIndex(tm.TestCase):
         self.index._bounds
 
     def test_equals(self):
-        self.assert_(self.index.equals(self.index))
-        self.assert_(self.index.equal_levels(self.index))
+        self.assertTrue(self.index.equals(self.index))
+        self.assertTrue(self.index.equal_levels(self.index))
 
-        self.assert_(not self.index.equals(self.index[:-1]))
+        self.assertFalse(self.index.equals(self.index[:-1]))
 
-        self.assert_(self.index.equals(self.index._tuple_index))
+        self.assertTrue(self.index.equals(self.index._tuple_index))
 
         # different number of levels
         index = MultiIndex(levels=[Index(lrange(4)),
@@ -2232,8 +2232,8 @@ class TestMultiIndex(tm.TestCase):
 
         index2 = MultiIndex(levels=index.levels[:-1],
                             labels=index.labels[:-1])
-        self.assert_(not index.equals(index2))
-        self.assert_(not index.equal_levels(index2))
+        self.assertFalse(index.equals(index2))
+        self.assertFalse(index.equal_levels(index2))
 
         # levels are different
         major_axis = Index(lrange(4))
@@ -2244,8 +2244,8 @@ class TestMultiIndex(tm.TestCase):
 
         index = MultiIndex(levels=[major_axis, minor_axis],
                            labels=[major_labels, minor_labels])
-        self.assert_(not self.index.equals(index))
-        self.assert_(not self.index.equal_levels(index))
+        self.assertFalse(self.index.equals(index))
+        self.assertFalse(self.index.equal_levels(index))
 
         # some of the labels are different
         major_axis = Index(['foo', 'bar', 'baz', 'qux'])
@@ -2256,7 +2256,7 @@ class TestMultiIndex(tm.TestCase):
 
         index = MultiIndex(levels=[major_axis, minor_axis],
                            labels=[major_labels, minor_labels])
-        self.assert_(not self.index.equals(index))
+        self.assertFalse(self.index.equals(index))
 
     def test_identical(self):
         mi = self.index.copy()
@@ -2265,7 +2265,7 @@ class TestMultiIndex(tm.TestCase):
 
         mi = mi.set_names(['new1', 'new2'])
         self.assert_(mi.equals(mi2))
-        self.assert_(not mi.identical(mi2))
+        self.assertFalse(mi.identical(mi2))
 
         mi2 = mi2.set_names(['new1', 'new2'])
         self.assert_(mi.identical(mi2))
@@ -2273,7 +2273,7 @@ class TestMultiIndex(tm.TestCase):
         mi3 = Index(mi.tolist(), names=mi.names)
         mi4 = Index(mi.tolist(), names=mi.names, tupleize_cols=False)
         self.assert_(mi.identical(mi3))
-        self.assert_(not mi.identical(mi4))
+        self.assertFalse(mi.identical(mi4))
         self.assert_(mi.equals(mi4))
 
     def test_is_(self):
@@ -2644,7 +2644,7 @@ class TestMultiIndex(tm.TestCase):
                            idx.reindex, idx, method='bfill', level='first')
 
     def test_has_duplicates(self):
-        self.assert_(not self.index.has_duplicates)
+        self.assertFalse(self.index.has_duplicates)
         self.assert_(self.index.append(self.index).has_duplicates)
 
         index = MultiIndex(levels=[[0, 1], [0, 1, 2]],

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -2261,7 +2261,7 @@ class TestIndexing(tm.TestCase):
                 df.take(mask[1:],convert=False) ])
 
         df = gen_test(900,100)
-        self.assert_(not df.index.is_unique)
+        self.assertFalse(df.index.is_unique)
 
         mask = np.arange(100)
         result = df.loc[mask]
@@ -2269,7 +2269,7 @@ class TestIndexing(tm.TestCase):
         assert_frame_equal(result,expected)
 
         df = gen_test(900000,100000)
-        self.assert_(not df.index.is_unique)
+        self.assertFalse(df.index.is_unique)
 
         mask = np.arange(100000)
         result = df.loc[mask]

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -229,17 +229,17 @@ class TestBlock(tm.TestCase):
         newb = self.fblock.copy()
         newb.delete(0)
         assert_almost_equal(newb.mgr_locs, [2, 4])
-        self.assert_((newb.values[0] == 1).all())
+        self.assertTrue((newb.values[0] == 1).all())
 
         newb = self.fblock.copy()
         newb.delete(1)
         assert_almost_equal(newb.mgr_locs, [0, 4])
-        self.assert_((newb.values[1] == 2).all())
+        self.assertTrue((newb.values[1] == 2).all())
 
         newb = self.fblock.copy()
         newb.delete(2)
         assert_almost_equal(newb.mgr_locs, [0, 2])
-        self.assert_((newb.values[1] == 1).all())
+        self.assertTrue((newb.values[1] == 1).all())
 
         newb = self.fblock.copy()
         self.assertRaises(Exception, newb.delete, 3)
@@ -985,6 +985,3 @@ if __name__ == '__main__':
     import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
                    exit=False)
-
-
-    

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -966,7 +966,7 @@ Thur,Lunch,Yes,51.51,17"""
 
     def test_unstack_period_series(self):
         # GH 4342
-        idx1 = pd.PeriodIndex(['2013-01', '2013-01', '2013-02', '2013-02', 
+        idx1 = pd.PeriodIndex(['2013-01', '2013-01', '2013-02', '2013-02',
                                '2013-03', '2013-03'], freq='M', name='period')
         idx2 = Index(['A', 'B'] * 3, name='str')
         value = [1, 2, 3, 4, 5, 6]
@@ -987,10 +987,10 @@ Thur,Lunch,Yes,51.51,17"""
         assert_frame_equal(result2, expected)
         assert_frame_equal(result3, expected.T)
 
-        idx1 = pd.PeriodIndex(['2013-01', '2013-01', '2013-02', '2013-02', 
+        idx1 = pd.PeriodIndex(['2013-01', '2013-01', '2013-02', '2013-02',
                                '2013-03', '2013-03'], freq='M', name='period1')
 
-        idx2 = pd.PeriodIndex(['2013-12', '2013-11', '2013-10', '2013-09', 
+        idx2 = pd.PeriodIndex(['2013-12', '2013-11', '2013-10', '2013-09',
                                '2013-08', '2013-07'], freq='M', name='period2')
         idx = pd.MultiIndex.from_arrays([idx1, idx2])
         s = Series(value, index=idx)
@@ -1031,7 +1031,7 @@ Thur,Lunch,Yes,51.51,17"""
         e_cols = pd.MultiIndex.from_arrays(['A A A B B B'.split(), e_2])
         expected = DataFrame([[5, 1, 6, 2, 6, 1], [4, 2, 3, 3, 5, 4]],
                              index=e_1, columns=e_cols)
-   
+
         assert_frame_equal(result1, expected)
         assert_frame_equal(result2, expected)
 
@@ -1158,14 +1158,14 @@ Thur,Lunch,Yes,51.51,17"""
         expected = self.frame.copy()
         expected.values[np.isnan(joined.values)] = np.nan
 
-        self.assert_(not np.isnan(joined.values).all())
+        self.assertFalse(np.isnan(joined.values).all())
 
         assert_frame_equal(joined, expected, check_names=False)  # TODO what should join do with names ?
 
     def test_swaplevel(self):
         swapped = self.frame['A'].swaplevel(0, 1)
         swapped2 = self.frame['A'].swaplevel('first', 'second')
-        self.assert_(not swapped.index.equals(self.frame.index))
+        self.assertFalse(swapped.index.equals(self.frame.index))
         assert_series_equal(swapped, swapped2)
 
         back = swapped.swaplevel(0, 1)
@@ -1241,12 +1241,12 @@ Thur,Lunch,Yes,51.51,17"""
         index = MultiIndex(levels=levels,
                            labels=[[0, 0, 0, 1, 1, 1],
                                    [0, 1, 2, 0, 2, 1]])
-        self.assert_(not index.is_lexsorted())
+        self.assertFalse(index.is_lexsorted())
 
         index = MultiIndex(levels=levels,
                            labels=[[0, 0, 1, 0, 1, 1],
                                    [0, 1, 0, 2, 2, 1]])
-        self.assert_(not index.is_lexsorted())
+        self.assertFalse(index.is_lexsorted())
         self.assertEqual(index.lexsort_depth, 0)
 
     def test_frame_getitem_view(self):
@@ -2056,7 +2056,7 @@ Thur,Lunch,Yes,51.51,17"""
         self.assert_(df.index.levels[0].equals(expected1))
         self.assert_(df.index.levels[1].equals(expected2))
         self.assert_(df.index.levels[2].equals(idx3))
-        
+
         self.assert_(df.index.get_level_values(0).equals(idx1))
         self.assert_(df.index.get_level_values(1).equals(idx2))
         self.assert_(df.index.get_level_values(2).equals(idx3))

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -929,7 +929,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         self.assert_(self.panel._data.is_consolidated())
 
         self.panel['foo'] = 1.
-        self.assert_(not self.panel._data.is_consolidated())
+        self.assertFalse(self.panel._data.is_consolidated())
 
         panel = self.panel.consolidate()
         self.assert_(panel._data.is_consolidated())

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -612,7 +612,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
         self.assert_(self.panel4d._data.is_consolidated())
 
         self.panel4d['foo'] = 1.
-        self.assert_(not self.panel4d._data.is_consolidated())
+        self.assertFalse(self.panel4d._data.is_consolidated())
 
         panel4d = self.panel4d.consolidate()
         self.assert_(panel4d._data.is_consolidated())
@@ -839,7 +839,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
         # assert_panel_equal(sorted_panel, self.panel)
 
     def test_fillna(self):
-        self.assert_(not np.isfinite(self.panel4d.values).all())
+        self.assertFalse(np.isfinite(self.panel4d.values).all())
         filled = self.panel4d.fillna(0)
         self.assert_(np.isfinite(filled.values).all())
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -183,7 +183,7 @@ class CheckNameIntegration(object):
         assert_series_equal(result, s)
 
         s[...] = 5
-        self.assert_((result == 5).all())
+        self.assertTrue((result == 5).all())
 
     def test_getitem_negative_out_of_bounds(self):
         s = Series([tm.rands(5) for _ in range(10)],
@@ -300,14 +300,14 @@ class TestNanops(tm.TestCase):
         self.assertEqual(nanops.nansum(arr), 0)
 
         arr = np.empty((10, 0))
-        self.assert_((nanops.nansum(arr, axis=1) == 0).all())
+        self.assertTrue((nanops.nansum(arr, axis=1) == 0).all())
 
         # GH #844
         s = Series([], index=[])
         self.assertEqual(s.sum(), 0)
 
         df = DataFrame(np.empty((10, 0)))
-        self.assert_((df.sum(1) == 0).all())
+        self.assertTrue((df.sum(1) == 0).all())
 
     def test_nansum_buglet(self):
         s = Series([1.0, np.nan], index=[0, 1])
@@ -409,7 +409,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         derived = Series(self.ts)
         self.assertTrue(derived.is_time_series)
 
-        self.assert_(tm.equalContents(derived.index, self.ts.index))
+        self.assertTrue(tm.equalContents(derived.index, self.ts.index))
         # Ensure new index is not created
         self.assertEquals(id(self.ts.index), id(derived.index))
 
@@ -863,7 +863,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # test slice is a view
         result[:] = 0
-        self.assert_((s[1:3] == 0).all())
+        self.assertTrue((s[1:3] == 0).all())
 
         # list of integers
         result = s.iget([0, 2, 3, 4, 5])
@@ -892,10 +892,10 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         s = Series(lrange(10), lrange(10))
         s[-12:] = 0
-        self.assert_((s == 0).all())
+        self.assertTrue((s == 0).all())
 
         s[:-12] = 5
-        self.assert_((s == 0).all())
+        self.assertTrue((s == 0).all())
 
     def test_getitem_int64(self):
         idx = np.int64(5)
@@ -1004,8 +1004,8 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         assert_series_equal(result, expected)
 
         s[:4] = 0
-        self.assert_((s[:4] == 0).all())
-        self.assert_(not (s[4:] == 0).any())
+        self.assertTrue((s[:4] == 0).all())
+        self.assertTrue(not (s[4:] == 0).any())
 
     def test_getitem_out_of_bounds(self):
         # don't segfault, GH #495
@@ -1034,7 +1034,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
     def test_getitem_unordered_dup(self):
         obj = Series(lrange(5), index=['c', 'a', 'a', 'b', 'b'])
-        self.assert_(np.isscalar(obj['c']))
+        self.assertTrue(np.isscalar(obj['c']))
         self.assertEqual(obj['c'], 0)
 
     def test_getitem_dups_with_missing(self):
@@ -1090,13 +1090,13 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         self.assertEqual(numSlice.index[1], self.series.index[11])
 
-        self.assert_(tm.equalContents(numSliceEnd,
-                                      np.array(self.series)[-10:]))
+        self.assertTrue(tm.equalContents(numSliceEnd,
+                                         np.array(self.series)[-10:]))
 
         # test return view
         sl = self.series[10:20]
         sl[:] = 0
-        self.assert_((self.series[10:20] == 0).all())
+        self.assertTrue((self.series[10:20] == 0).all())
 
     def test_slice_can_reorder_not_uniquely_indexed(self):
         s = Series(1, index=['a', 'a', 'b', 'b', 'c'])
@@ -1153,17 +1153,17 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         self.ts[self.ts.index[5]] = np.NaN
         self.ts[[1, 2, 17]] = np.NaN
         self.ts[6] = np.NaN
-        self.assert_(np.isnan(self.ts[6]))
-        self.assert_(np.isnan(self.ts[2]))
+        self.assertTrue(np.isnan(self.ts[6]))
+        self.assertTrue(np.isnan(self.ts[2]))
         self.ts[np.isnan(self.ts)] = 5
-        self.assert_(not np.isnan(self.ts[2]))
+        self.assertFalse(np.isnan(self.ts[2]))
 
         # caught this bug when writing tests
         series = Series(tm.makeIntIndex(20).astype(float),
                         index=tm.makeIntIndex(20))
 
         series[::2] = 0
-        self.assert_((series[::2] == 0).all())
+        self.assertTrue((series[::2] == 0).all())
 
         # set item that's not contained
         s = self.series.copy()
@@ -1218,7 +1218,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
     def test_setslice(self):
         sl = self.ts[5:20]
         self.assertEqual(len(sl), len(sl.index))
-        self.assert_(sl.index.is_unique)
+        self.assertTrue(sl.index.is_unique)
 
     def test_basic_getitem_setitem_corner(self):
         # invalid tuples, e.g. self.ts[:, None] vs. self.ts[:, 2]
@@ -1355,12 +1355,12 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # this is OK
         cp = s.copy()
         cp.ix[4:10] = 0
-        self.assert_((cp.ix[4:10] == 0).all())
+        self.assertTrue((cp.ix[4:10] == 0).all())
 
         # so is this
         cp = s.copy()
         cp.ix[3:11] = 0
-        self.assert_((cp.ix[3:11] == 0).values.all())
+        self.assertTrue((cp.ix[3:11] == 0).values.all())
 
         result = s.ix[4:10]
         result2 = s.ix[3:11]
@@ -1483,7 +1483,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         s = Series(range(10)).astype(float)
         s[8] = None
         result = s[8]
-        self.assert_(isnull(result))
+        self.assertTrue(isnull(result))
 
         s = Series(range(10)).astype(float)
         s[s > 8] = None
@@ -1839,7 +1839,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         repr(ts)
 
         ts = tm.makeTimeSeries(1000)
-        self.assert_(repr(ts).splitlines()[-1].startswith('Freq:'))
+        self.assertTrue(repr(ts).splitlines()[-1].startswith('Freq:'))
 
         ts2 = ts.ix[np.random.randint(0, len(ts) - 1, 400)]
         repr(ts).splitlines()[-1]
@@ -1968,10 +1968,10 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # 1 - element series with ddof=1
         s = self.ts.iloc[[0]]
         result = s.var(ddof=1)
-        self.assert_(isnull(result))
+        self.assertTrue(isnull(result))
 
         result = s.std(ddof=1)
-        self.assert_(isnull(result))
+        self.assertTrue(isnull(result))
 
     def test_skew(self):
         _skip_if_no_scipy()
@@ -1997,7 +1997,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
     def test_argsort(self):
         self._check_accum_op('argsort')
         argsorted = self.ts.argsort()
-        self.assert_(issubclass(argsorted.dtype.type, np.integer))
+        self.assertTrue(issubclass(argsorted.dtype.type, np.integer))
 
         # GH 2967 (introduced bug in 0.11-dev I think)
         s = Series([Timestamp('201301%02d' % (i + 1)) for i in range(5)])
@@ -2024,7 +2024,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         self.assert_numpy_array_equal(mindexer, mexpected)
         self.assert_numpy_array_equal(qindexer, qexpected)
-        self.assert_(not np.array_equal(qindexer, mindexer))
+        self.assertFalse(np.array_equal(qindexer, mindexer))
 
     def test_reorder_levels(self):
         index = MultiIndex(levels=[['bar'], ['one', 'two', 'three'], [0, 1]],
@@ -2115,8 +2115,8 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
                 self.assertRaises(TypeError, f, ds)
 
             # skipna or no
-            self.assert_(notnull(f(self.series)))
-            self.assert_(isnull(f(self.series, skipna=False)))
+            self.assertTrue(notnull(f(self.series)))
+            self.assertTrue(isnull(f(self.series, skipna=False)))
 
             # check the result is correct
             nona = self.series.dropna()
@@ -2124,7 +2124,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
             assert_almost_equal(f(self.series), alternate(nona.values))
 
             allna = self.series * nan
-            self.assert_(np.isnan(f(allna)))
+            self.assertTrue(np.isnan(f(allna)))
 
             # dtype=object with None, it works!
             s = Series([1, 2, 3, None, 5])
@@ -2241,8 +2241,8 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
     def test_all_any(self):
         ts = tm.makeTimeSeries()
         bool_series = ts > 0
-        self.assert_(not bool_series.all())
-        self.assert_(bool_series.any())
+        self.assertFalse(bool_series.all())
+        self.assertTrue(bool_series.any())
 
     def test_op_method(self):
         def check(series, other, check_reverse=False):
@@ -3119,8 +3119,8 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         result = s + s.shift(1)
         result2 = s.shift(1) + s
-        self.assert_(isnull(result[0]))
-        self.assert_(isnull(result2[0]))
+        self.assertTrue(isnull(result[0]))
+        self.assertTrue(isnull(result2[0]))
 
         s = Series(['foo', 'bar', 'baz', np.nan])
         result = 'prefix_' + s
@@ -3390,7 +3390,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # skipna or no
         self.assertEqual(self.series[self.series.idxmin()], self.series.min())
-        self.assert_(isnull(self.series.idxmin(skipna=False)))
+        self.assertTrue(isnull(self.series.idxmin(skipna=False)))
 
         # no NaNs
         nona = self.series.dropna()
@@ -3400,7 +3400,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # all NaNs
         allna = self.series * nan
-        self.assert_(isnull(allna.idxmin()))
+        self.assertTrue(isnull(allna.idxmin()))
 
         # datetime64[ns]
         from pandas import date_range
@@ -3421,7 +3421,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # skipna or no
         self.assertEqual(self.series[self.series.idxmax()], self.series.max())
-        self.assert_(isnull(self.series.idxmax(skipna=False)))
+        self.assertTrue(isnull(self.series.idxmax(skipna=False)))
 
         # no NaNs
         nona = self.series.dropna()
@@ -3431,7 +3431,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # all NaNs
         allna = self.series * nan
-        self.assert_(isnull(allna.idxmax()))
+        self.assertTrue(isnull(allna.idxmax()))
 
         from pandas import date_range
         s = Series(date_range('20130102', periods=6))
@@ -3543,7 +3543,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         empty = Series([], index=Index([]))
 
         result = series + empty
-        self.assert_(np.isnan(result).all())
+        self.assertTrue(np.isnan(result).all())
 
         result = empty + Series([], index=Index([]))
         self.assertEqual(len(result), 0)
@@ -3674,7 +3674,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # Holes filled from input
         combined = series_copy.combine_first(series)
-        self.assert_(np.isfinite(combined).all())
+        self.assertTrue(np.isfinite(combined).all())
 
         self.assert_numpy_array_equal(combined[::2], series[::2])
         self.assert_numpy_array_equal(combined[1::2], series_copy[1::2])
@@ -3720,19 +3720,19 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # partial overlap
         self.assertAlmostEqual(self.ts[:15].corr(self.ts[5:]), 1)
 
-        self.assert_(isnull(self.ts[:15].corr(self.ts[5:], min_periods=12)))
+        self.assertTrue(isnull(self.ts[:15].corr(self.ts[5:], min_periods=12)))
 
         ts1 = self.ts[:15].reindex(self.ts.index)
         ts2 = self.ts[5:].reindex(self.ts.index)
-        self.assert_(isnull(ts1.corr(ts2, min_periods=12)))
+        self.assertTrue(isnull(ts1.corr(ts2, min_periods=12)))
 
         # No overlap
-        self.assert_(np.isnan(self.ts[::2].corr(self.ts[1::2])))
+        self.assertTrue(np.isnan(self.ts[::2].corr(self.ts[1::2])))
 
         # all NA
         cp = self.ts[:10].copy()
         cp[:] = np.nan
-        self.assert_(isnull(cp.corr(cp)))
+        self.assertTrue(isnull(cp.corr(cp)))
 
         A = tm.makeTimeSeries()
         B = tm.makeTimeSeries()
@@ -3784,19 +3784,19 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
             self.ts[:15].cov(self.ts[5:]), self.ts[5:15].std() ** 2)
 
         # No overlap
-        self.assert_(np.isnan(self.ts[::2].cov(self.ts[1::2])))
+        self.assertTrue(np.isnan(self.ts[::2].cov(self.ts[1::2])))
 
         # all NA
         cp = self.ts[:10].copy()
         cp[:] = np.nan
-        self.assert_(isnull(cp.cov(cp)))
+        self.assertTrue(isnull(cp.cov(cp)))
 
         # min_periods
-        self.assert_(isnull(self.ts[:15].cov(self.ts[5:], min_periods=12)))
+        self.assertTrue(isnull(self.ts[:15].cov(self.ts[5:], min_periods=12)))
 
         ts1 = self.ts[:15].reindex(self.ts.index)
         ts2 = self.ts[5:].reindex(self.ts.index)
-        self.assert_(isnull(ts1.cov(ts2, min_periods=12)))
+        self.assertTrue(isnull(ts1.cov(ts2, min_periods=12)))
 
     def test_copy(self):
         ts = self.ts.copy()
@@ -3979,11 +3979,11 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         vals = ts.values
 
         result = ts.order()
-        self.assert_(np.isnan(result[-5:]).all())
+        self.assertTrue(np.isnan(result[-5:]).all())
         self.assert_numpy_array_equal(result[:-5], np.sort(vals[5:]))
 
         result = ts.order(na_position='first')
-        self.assert_(np.isnan(result[:5]).all())
+        self.assertTrue(np.isnan(result[:5]).all())
         self.assert_numpy_array_equal(result[5:], np.sort(vals[5:]))
 
         # something object-type
@@ -4446,18 +4446,18 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         dates = date_range('1/1/1990', periods=N * 3, freq='25s')
 
         result = ts.asof(dates)
-        self.assert_(notnull(result).all())
+        self.assertTrue(notnull(result).all())
         lb = ts.index[14]
         ub = ts.index[30]
 
         result = ts.asof(list(dates))
-        self.assert_(notnull(result).all())
+        self.assertTrue(notnull(result).all())
         lb = ts.index[14]
         ub = ts.index[30]
 
         mask = (result.index >= lb) & (result.index < ub)
         rs = result[mask]
-        self.assert_((rs == ts[lb]).all())
+        self.assertTrue((rs == ts[lb]).all())
 
         val = result[result.index[result.index >= ub][0]]
         self.assertEqual(ts[ub], val)
@@ -4480,7 +4480,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # no as of value
         d = self.ts.index[0] - datetools.bday
-        self.assert_(np.isnan(self.ts.asof(d)))
+        self.assertTrue(np.isnan(self.ts.asof(d)))
 
     def test_getitem_setitem_datetimeindex(self):
         from pandas import date_range
@@ -4650,19 +4650,19 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         dates = date_range('1/1/1990', periods=N * 3, freq='37min')
 
         result = ts.asof(dates)
-        self.assert_(notnull(result).all())
+        self.assertTrue(notnull(result).all())
         lb = ts.index[14]
         ub = ts.index[30]
 
         result = ts.asof(list(dates))
-        self.assert_(notnull(result).all())
+        self.assertTrue(notnull(result).all())
         lb = ts.index[14]
         ub = ts.index[30]
 
         pix = PeriodIndex(result.index.values, freq='H')
         mask = (pix >= lb) & (pix < ub)
         rs = result[mask]
-        self.assert_((rs == ts[lb]).all())
+        self.assertTrue((rs == ts[lb]).all())
 
         ts[5:10] = np.NaN
         ts[15:20] = np.NaN
@@ -4682,7 +4682,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # no as of value
         d = ts.index[0].to_timestamp() - datetools.bday
-        self.assert_(np.isnan(ts.asof(d)))
+        self.assertTrue(np.isnan(ts.asof(d)))
 
     def test_asof_more(self):
         from pandas import date_range
@@ -4783,17 +4783,17 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         right = Series({1: 11, 2: 22, 3: 33})
 
         self.assertEqual(left.dtype, np.float_)
-        self.assert_(issubclass(right.dtype.type, np.integer))
+        self.assertTrue(issubclass(right.dtype.type, np.integer))
 
         merged = left.map(right)
         self.assertEqual(merged.dtype, np.float_)
-        self.assert_(isnull(merged['d']))
-        self.assert_(not isnull(merged['c']))
+        self.assertTrue(isnull(merged['d']))
+        self.assertTrue(not isnull(merged['c']))
 
     def test_map_type_inference(self):
         s = Series(lrange(3))
         s2 = s.map(lambda x: np.where(x == 0, 0, 1))
-        self.assert_(issubclass(s2.dtype.type, np.integer))
+        self.assertTrue(issubclass(s2.dtype.type, np.integer))
 
     def test_map_decimal(self):
         from decimal import Decimal
@@ -4957,9 +4957,9 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
                 diff_a = aa.index.diff(join_index)
                 diff_b = ab.index.diff(join_index)
                 if len(diff_a) > 0:
-                    self.assert_((aa.reindex(diff_a) == fill).all())
+                    self.assertTrue((aa.reindex(diff_a) == fill).all())
                 if len(diff_b) > 0:
-                    self.assert_((ab.reindex(diff_b) == fill).all())
+                    self.assertTrue((ab.reindex(diff_b) == fill).all())
 
             ea = a.reindex(join_index)
             eb = b.reindex(join_index)
@@ -5026,27 +5026,27 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         a = self.ts.copy()
         ra, _ = a.align(b, join='left')
         ra[:5] = 5
-        self.assert_(not (a[:5] == 5).any())
+        self.assertFalse((a[:5] == 5).any())
 
         # do not copy
         a = self.ts.copy()
         ra, _ = a.align(b, join='left', copy=False)
         ra[:5] = 5
-        self.assert_((a[:5] == 5).all())
+        self.assertTrue((a[:5] == 5).all())
 
         # do copy
         a = self.ts.copy()
         b = self.ts[:5].copy()
         _, rb = a.align(b, join='right')
         rb[:3] = 5
-        self.assert_(not (b[:3] == 5).any())
+        self.assertFalse((b[:3] == 5).any())
 
         # do not copy
         a = self.ts.copy()
         b = self.ts[:5].copy()
         _, rb = a.align(b, join='right', copy=False)
         rb[:2] = 5
-        self.assert_((b[:2] == 5).all())
+        self.assertTrue((b[:2] == 5).all())
 
     def test_align_sameindex(self):
         a, b = self.ts.align(self.ts, copy=False)
@@ -5059,8 +5059,8 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
     def test_reindex(self):
         identity = self.series.reindex(self.series.index)
-        self.assert_(np.may_share_memory(self.series.index, identity.index))
-        self.assert_(identity.index.is_(self.series.index))
+        self.assertTrue(np.may_share_memory(self.series.index, identity.index))
+        self.assertTrue(identity.index.is_(self.series.index))
 
         subIndex = self.series.index[10:20]
         subSeries = self.series.reindex(subIndex)
@@ -5075,7 +5075,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
             self.assertEqual(val, self.ts[idx])
         stuffSeries = self.ts.reindex(subIndex)
 
-        self.assert_(np.isnan(stuffSeries).all())
+        self.assertTrue(np.isnan(stuffSeries).all())
 
         # This is extremely important for the Cython code to not screw up
         nonContigIndex = self.ts.index[::2]
@@ -5180,7 +5180,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         ts = self.ts[5:]
         bool_ts = Series(np.zeros(len(ts), dtype=bool), index=ts.index)
         filled_bool = bool_ts.reindex(self.ts.index, method='pad')
-        self.assert_(isnull(filled_bool[:5]).all())
+        self.assertTrue(isnull(filled_bool[:5]).all())
 
     def test_reindex_like(self):
         other = self.ts[::2]
@@ -5210,7 +5210,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # don't upcast
         result = ints.reindex([1, 2, 3], fill_value=0)
         expected = Series([2, 3, 0], index=[1, 2, 3])
-        self.assert_(issubclass(result.dtype.type, np.integer))
+        self.assertTrue(issubclass(result.dtype.type, np.integer))
         assert_series_equal(result, expected)
 
         #------------------------------------------------------------
@@ -5273,8 +5273,8 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
     def test_ne(self):
         ts = Series([3, 4, 5, 6, 7], [3, 4, 5, 6, 7], dtype=float)
         expected = [True, True, False, True, True]
-        self.assert_(tm.equalContents(ts.index != 5, expected))
-        self.assert_(tm.equalContents(~(ts.index == 5), expected))
+        self.assertTrue(tm.equalContents(ts.index != 5, expected))
+        self.assertTrue(tm.equalContents(~(ts.index == 5), expected))
 
     def test_pad_nan(self):
         x = Series([np.nan, 1., np.nan, 3., np.nan],
@@ -5285,7 +5285,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         expected = Series([np.nan, 1.0, 1.0, 3.0, 3.0],
                           ['z', 'a', 'b', 'c', 'd'], dtype=float)
         assert_series_equal(x[1:], expected[1:])
-        self.assert_(np.isnan(x[0]), np.isnan(expected[0]))
+        self.assertTrue(np.isnan(x[0]), np.isnan(expected[0]))
 
     def test_unstack(self):
         from numpy import nan
@@ -5446,18 +5446,18 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # replace list with a single value
         rs = ser.replace([np.nan, 'foo', 'bar'], -1)
 
-        self.assert_((rs[:5] == -1).all())
-        self.assert_((rs[6:10] == -1).all())
-        self.assert_((rs[20:30] == -1).all())
-        self.assert_((isnull(ser[:5])).all())
+        self.assertTrue((rs[:5] == -1).all())
+        self.assertTrue((rs[6:10] == -1).all())
+        self.assertTrue((rs[20:30] == -1).all())
+        self.assertTrue((isnull(ser[:5])).all())
 
         # replace with different values
         rs = ser.replace({np.nan: -1, 'foo': -2, 'bar': -3})
 
-        self.assert_((rs[:5] == -1).all())
-        self.assert_((rs[6:10] == -2).all())
-        self.assert_((rs[20:30] == -3).all())
-        self.assert_((isnull(ser[:5])).all())
+        self.assertTrue((rs[:5] == -1).all())
+        self.assertTrue((rs[6:10] == -2).all())
+        self.assertTrue((rs[20:30] == -3).all())
+        self.assertTrue((isnull(ser[:5])).all())
 
         # replace with different values with 2 lists
         rs2 = ser.replace([np.nan, 'foo', 'bar'], [-1, -2, -3])
@@ -5466,9 +5466,9 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # replace inplace
         ser.replace([np.nan, 'foo', 'bar'], -1, inplace=True)
 
-        self.assert_((ser[:5] == -1).all())
-        self.assert_((ser[6:10] == -1).all())
-        self.assert_((ser[20:30] == -1).all())
+        self.assertTrue((ser[:5] == -1).all())
+        self.assertTrue((ser[6:10] == -1).all())
+        self.assertTrue((ser[20:30] == -1).all())
 
         ser = Series([np.nan, 0, np.inf])
         assert_series_equal(ser.replace(np.nan, 0), ser.fillna(0))
@@ -5828,7 +5828,7 @@ class TestSeriesNonUnique(tm.TestCase):
         self.assertEqual(len(rs.columns), 2)
 
         rs = s.reset_index(level=[0, 2], drop=True)
-        self.assert_(rs.index.equals(Index(index.get_level_values(1))))
+        self.assertTrue(rs.index.equals(Index(index.get_level_values(1))))
         tm.assert_isinstance(rs, Series)
 
     def test_set_index_makes_timeseries(self):
@@ -5856,18 +5856,18 @@ class TestSeriesNonUnique(tm.TestCase):
         # replace list with a single value
         rs = ser.replace([np.nan, 'foo', 'bar'], -1)
 
-        self.assert_((rs[:5] == -1).all())
-        self.assert_((rs[6:10] == -1).all())
-        self.assert_((rs[20:30] == -1).all())
-        self.assert_((isnull(ser[:5])).all())
+        self.assertTrue((rs[:5] == -1).all())
+        self.assertTrue((rs[6:10] == -1).all())
+        self.assertTrue((rs[20:30] == -1).all())
+        self.assertTrue((isnull(ser[:5])).all())
 
         # replace with different values
         rs = ser.replace({np.nan: -1, 'foo': -2, 'bar': -3})
 
-        self.assert_((rs[:5] == -1).all())
-        self.assert_((rs[6:10] == -2).all())
-        self.assert_((rs[20:30] == -3).all())
-        self.assert_((isnull(ser[:5])).all())
+        self.assertTrue((rs[:5] == -1).all())
+        self.assertTrue((rs[6:10] == -2).all())
+        self.assertTrue((rs[20:30] == -3).all())
+        self.assertTrue((isnull(ser[:5])).all())
 
         # replace with different values with 2 lists
         rs2 = ser.replace([np.nan, 'foo', 'bar'], [-1, -2, -3])
@@ -5875,9 +5875,9 @@ class TestSeriesNonUnique(tm.TestCase):
 
         # replace inplace
         ser.replace([np.nan, 'foo', 'bar'], -1, inplace=True)
-        self.assert_((ser[:5] == -1).all())
-        self.assert_((ser[6:10] == -1).all())
-        self.assert_((ser[20:30] == -1).all())
+        self.assertTrue((ser[:5] == -1).all())
+        self.assertTrue((ser[6:10] == -1).all())
+        self.assertTrue((ser[20:30] == -1).all())
 
     def test_repeat(self):
         s = Series(np.random.randn(3), index=['a', 'b', 'c'])


### PR DESCRIPTION
#7131: replace some instances of assert_(not b) with assertFalse(b) and some instances of assert_(b) with assertTrue(b). Work-in-progress
