### PR TITLE
CLN: Deprecation of assert_

### DIFF
--- a/pandas/io/tests/test_cparser.py
+++ b/pandas/io/tests/test_cparser.py
@@ -236,21 +236,21 @@ aaaaa,5"""
         self.assertEqual(result[0].dtype, 'S5')
 
         ex_values = np.array(['a', 'aa', 'aaa', 'aaaa', 'aaaaa'], dtype='S5')
-        self.assert_((result[0] == ex_values).all())
+        self.assertTrue((result[0] == ex_values).all())
         self.assertEqual(result[1].dtype, 'i4')
 
         reader = _make_reader(dtype='S4')
         result = reader.read()
         self.assertEqual(result[0].dtype, 'S4')
         ex_values = np.array(['a', 'aa', 'aaa', 'aaaa', 'aaaa'], dtype='S4')
-        self.assert_((result[0] == ex_values).all())
+        self.assertTrue((result[0] == ex_values).all())
         self.assertEqual(result[1].dtype, 'S4')
 
         reader = _make_reader(dtype='S4', as_recarray=True)
         result = reader.read()
         self.assertEqual(result['0'].dtype, 'S4')
         ex_values = np.array(['a', 'aa', 'aaa', 'aaaa', 'aaaa'], dtype='S4')
-        self.assert_((result['0'] == ex_values).all())
+        self.assertTrue((result['0'] == ex_values).all())
         self.assertEqual(result['1'].dtype, 'S4')
 
     def test_pass_dtype(self):

--- a/pandas/io/tests/test_data.py
+++ b/pandas/io/tests/test_data.py
@@ -217,7 +217,7 @@ class TestYahoo(tm.TestCase):
     def test_get_date_ret_index(self):
         pan = web.get_data_yahoo(['GE', 'INTC', 'IBM'], '1977', '1987',
                                  ret_index=True)
-        self.assert_(hasattr(pan, 'Ret_Index'))
+        self.assertTrue(hasattr(pan, 'Ret_Index'))
         if hasattr(pan, 'Ret_Index') and hasattr(pan.Ret_Index, 'INTC'):
             tstamp = pan.Ret_Index.INTC.first_valid_index()
             result = pan.Ret_Index.ix[tstamp]['INTC']
@@ -358,7 +358,7 @@ class TestOptionsWarnings(tm.TestCase):
 class TestDataReader(tm.TestCase):
     def test_is_s3_url(self):
         from pandas.io.common import _is_s3_url
-        self.assert_(_is_s3_url("s3://pandas/somethingelse.com"))
+        self.assertTrue(_is_s3_url("s3://pandas/somethingelse.com"))
 
     @network
     def test_read_yahoo(self):

--- a/pandas/io/tests/test_date_converters.py
+++ b/pandas/io/tests/test_date_converters.py
@@ -39,7 +39,7 @@ class TestConverters(tm.TestCase):
 
     def test_parse_date_time(self):
         result = conv.parse_date_time(self.dates, self.times)
-        self.assert_((result == self.expected).all())
+        self.assertTrue((result == self.expected).all())
 
         data = """\
 date, time, a, b
@@ -66,7 +66,7 @@ date, time, a, b
     def test_parse_date_fields(self):
         result = conv.parse_date_fields(self.years, self.months, self.days)
         expected = np.array([datetime(2007, 1, 3), datetime(2008, 2, 4)])
-        self.assert_((result == expected).all())
+        self.assertTrue((result == expected).all())
 
         data = "year, month, day, a\n 2001 , 01 , 10 , 10.\n 2001 , 02 , 1 , 11."
         datecols = {'ymd': [0, 1, 2]}
@@ -79,7 +79,7 @@ date, time, a, b
     def test_datetime_six_col(self):
         result = conv.parse_all_fields(self.years, self.months, self.days,
                                        self.hours, self.minutes, self.seconds)
-        self.assert_((result == self.expected).all())
+        self.assertTrue((result == self.expected).all())
 
         data = """\
 year, month, day, hour, minute, second, a, b

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -1223,8 +1223,8 @@ class ExcelWriterEngineTests(tm.TestCase):
 
         def check_called(func):
             func()
-            self.assert_(len(called_save) >= 1)
-            self.assert_(len(called_write_cells) >= 1)
+            self.assertTrue(len(called_save) >= 1)
+            self.assertTrue(len(called_write_cells) >= 1)
             del called_save[:]
             del called_write_cells[:]
 

--- a/pandas/io/tests/test_ga.py
+++ b/pandas/io/tests/test_ga.py
@@ -27,7 +27,7 @@ class TestGoogle(tm.TestCase):
             fh.write('test')
 
         reset_default_token_store()
-        self.assert_(not os.path.exists(auth.DEFAULT_TOKEN_FILE))
+        self.assertFalse(os.path.exists(auth.DEFAULT_TOKEN_FILE))
 
     @slow
     @network

--- a/pandas/io/tests/test_html.py
+++ b/pandas/io/tests/test_html.py
@@ -383,7 +383,7 @@ class TestReadHtml(tm.TestCase):
         url = 'http://code.google.com/p/pythonxy/wiki/StandardPlugins'
         dfs = self.read_html(url, match='Python',
                                  attrs={'class': 'wikitable'})
-        self.assert_(len(dfs) > 1)
+        self.assertTrue(len(dfs) > 1)
 
     @network
     def test_pythonxy_plugins_table(self):

--- a/pandas/io/tests/test_json/test_pandas.py
+++ b/pandas/io/tests/test_json/test_pandas.py
@@ -152,7 +152,7 @@ class TestPandasContainer(tm.TestCase):
             if orient == "records":
                 # index is not captured in this orientation
                 assert_almost_equal(df.values, unser.values)
-                self.assert_(df.columns.equals(unser.columns))
+                self.assertTrue(df.columns.equals(unser.columns))
             elif orient == "values":
                 # index and cols are not captured in this orientation
                 assert_almost_equal(df.values, unser.values)

--- a/pandas/io/tests/test_json/test_ujson.py
+++ b/pandas/io/tests/test_json/test_ujson.py
@@ -120,7 +120,7 @@ class UltraJSONTests(TestCase):
         num = -1e-45
         self.assertEqual(num, ujson.decode(ujson.encode(num)))
         num = -1e-145
-        self.assert_(np.allclose(num, ujson.decode(ujson.encode(num))))
+        self.assertTrue(np.allclose(num, ujson.decode(ujson.encode(num))))
 
     def test_encodeDictWithUnicodeKeys(self):
         input = {u("key1"): u("value1"), u("key1"):
@@ -1315,39 +1315,39 @@ class PandasJSONTests(TestCase):
 
         # column indexed
         outp = Index(ujson.decode(ujson.encode(i)))
-        self.assert_(i.equals(outp))
+        self.assertTrue(i.equals(outp))
 
         outp = Index(ujson.decode(ujson.encode(i), numpy=True))
-        self.assert_(i.equals(outp))
+        self.assertTrue(i.equals(outp))
 
         dec = _clean_dict(ujson.decode(ujson.encode(i, orient="split")))
         outp = Index(**dec)
-        self.assert_(i.equals(outp))
+        self.assertTrue(i.equals(outp))
         self.assertTrue(i.name == outp.name)
 
         dec = _clean_dict(ujson.decode(ujson.encode(i, orient="split"),
                           numpy=True))
         outp = Index(**dec)
-        self.assert_(i.equals(outp))
+        self.assertTrue(i.equals(outp))
         self.assertTrue(i.name == outp.name)
 
         outp = Index(ujson.decode(ujson.encode(i, orient="values")))
-        self.assert_(i.equals(outp))
+        self.assertTrue(i.equals(outp))
 
         outp = Index(ujson.decode(ujson.encode(i, orient="values"), numpy=True))
-        self.assert_(i.equals(outp))
+        self.assertTrue(i.equals(outp))
 
         outp = Index(ujson.decode(ujson.encode(i, orient="records")))
-        self.assert_(i.equals(outp))
+        self.assertTrue(i.equals(outp))
 
         outp = Index(ujson.decode(ujson.encode(i, orient="records"), numpy=True))
-        self.assert_(i.equals(outp))
+        self.assertTrue(i.equals(outp))
 
         outp = Index(ujson.decode(ujson.encode(i, orient="index")))
-        self.assert_(i.equals(outp))
+        self.assertTrue(i.equals(outp))
 
         outp = Index(ujson.decode(ujson.encode(i, orient="index"), numpy=True))
-        self.assert_(i.equals(outp))
+        self.assertTrue(i.equals(outp))
 
     def test_datetimeindex(self):
         from pandas.tseries.index import date_range
@@ -1357,7 +1357,7 @@ class PandasJSONTests(TestCase):
         encoded = ujson.encode(rng, date_unit='ns')
         decoded = DatetimeIndex(np.array(ujson.decode(encoded)))
 
-        self.assert_(rng.equals(decoded))
+        self.assertTrue(rng.equals(decoded))
 
         ts = Series(np.random.randn(len(rng)), index=rng)
         decoded = Series(ujson.decode(ujson.encode(ts, date_unit='ns')))

--- a/pandas/io/tests/test_packers.py
+++ b/pandas/io/tests/test_packers.py
@@ -103,7 +103,7 @@ class TestNumpy(TestPackers):
     def test_numpy_scalar_complex(self):
         x = np.complex64(np.random.rand() + 1j * np.random.rand())
         x_rec = self.encode_decode(x)
-        self.assert_(np.allclose(x, x_rec))
+        self.assertTrue(np.allclose(x, x_rec))
 
     def test_scalar_float(self):
         x = np.random.rand()
@@ -113,7 +113,7 @@ class TestNumpy(TestPackers):
     def test_scalar_complex(self):
         x = np.random.rand() + 1j * np.random.rand()
         x_rec = self.encode_decode(x)
-        self.assert_(np.allclose(x, x_rec))
+        self.assertTrue(np.allclose(x, x_rec))
 
     def test_list_numpy_float(self):
         x = [np.float32(np.random.rand()) for i in range(5)]
@@ -128,7 +128,7 @@ class TestNumpy(TestPackers):
             [np.complex128(np.random.rand() + 1j * np.random.rand())
              for i in range(5)]
         x_rec = self.encode_decode(x)
-        self.assert_(np.allclose(x, x_rec))
+        self.assertTrue(np.allclose(x, x_rec))
 
     def test_list_float(self):
         x = [np.random.rand() for i in range(5)]
@@ -139,7 +139,7 @@ class TestNumpy(TestPackers):
         x = [np.random.rand() for i in range(5)] + \
             [(np.random.rand() + 1j * np.random.rand()) for i in range(5)]
         x_rec = self.encode_decode(x)
-        self.assert_(np.allclose(x, x_rec))
+        self.assertTrue(np.allclose(x, x_rec))
 
     def test_dict_float(self):
         x = {'foo': 1.0, 'bar': 2.0}
@@ -244,23 +244,23 @@ class TestIndex(TestPackers):
 
         for s, i in self.d.items():
             i_rec = self.encode_decode(i)
-            self.assert_(i.equals(i_rec))
+            self.assertTrue(i.equals(i_rec))
 
         # datetime with no freq (GH5506)
         i = Index([Timestamp('20130101'),Timestamp('20130103')])
         i_rec = self.encode_decode(i)
-        self.assert_(i.equals(i_rec))
+        self.assertTrue(i.equals(i_rec))
 
         # datetime with timezone
         i = Index([Timestamp('20130101 9:00:00'),Timestamp('20130103 11:00:00')]).tz_localize('US/Eastern')
         i_rec = self.encode_decode(i)
-        self.assert_(i.equals(i_rec))
+        self.assertTrue(i.equals(i_rec))
 
     def test_multi_index(self):
 
         for s, i in self.mi.items():
             i_rec = self.encode_decode(i)
-            self.assert_(i.equals(i_rec))
+            self.assertTrue(i.equals(i_rec))
 
     def test_unicode(self):
         i = tm.makeUnicodeIndex(100)
@@ -269,7 +269,7 @@ class TestIndex(TestPackers):
         self.assertRaises(UnicodeEncodeError, self.encode_decode, i)
 
         #i_rec = self.encode_decode(i)
-        #self.assert_(i.equals(i_rec))
+        #self.assertTrue(i.equals(i_rec))
 
 
 class TestSeries(TestPackers):

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -528,7 +528,7 @@ A,B,C
         try:
             df = self.read_table(
                 StringIO(data), sep=',', header=1, comment='#')
-            self.assert_(False)
+            self.assertTrue(False)
         except Exception as inst:
             self.assertIn('Expected 3 fields in line 4, saw 5', str(inst))
 
@@ -551,7 +551,7 @@ footer
                 df = self.read_table(
                     StringIO(data), sep=',', header=1, comment='#',
                     skip_footer=1)
-                self.assert_(False)
+                self.assertTrue(False)
         except Exception as inst:
             self.assertIn('Expected 3 fields in line 4, saw 5', str(inst))
 
@@ -569,7 +569,7 @@ skip
                                  header=1, comment='#', iterator=True, chunksize=1,
                                  skiprows=[2])
             df = it.read(5)
-            self.assert_(False)
+            self.assertTrue(False)
         except Exception as inst:
             self.assertIn('Expected 3 fields in line 6, saw 5', str(inst))
 
@@ -588,7 +588,7 @@ skip
                                  skiprows=[2])
             df = it.read(1)
             it.read(2)
-            self.assert_(False)
+            self.assertTrue(False)
         except Exception as inst:
             self.assertIn('Expected 3 fields in line 6, saw 5', str(inst))
 
@@ -607,7 +607,7 @@ skip
                                  skiprows=[2])
             df = it.read(1)
             it.read()
-            self.assert_(False)
+            self.assertTrue(False)
         except Exception as inst:
             self.assertIn('Expected 3 fields in line 6, saw 5', str(inst))
 
@@ -1134,7 +1134,7 @@ bar,4,5,6
 baz,7,8,9
 """
         data = self.read_csv(StringIO(data))
-        self.assert_(data.index.equals(Index(['foo', 'bar', 'baz'])))
+        self.assertTrue(data.index.equals(Index(['foo', 'bar', 'baz'])))
 
     def test_read_nrows(self):
         df = self.read_csv(StringIO(self.data1), nrows=3)
@@ -1912,7 +1912,7 @@ A,B,C
         result = self.read_csv(fh, converters={'score': convert_score,
                                                'days': convert_days},
                                na_values=['', None])
-        self.assert_(pd.isnull(result['days'][1]))
+        self.assertTrue(pd.isnull(result['days'][1]))
 
         fh = StringIO(csv)
         result2 = self.read_csv(fh, converters={'score': convert_score,
@@ -2177,7 +2177,7 @@ bar|4|5|6
 baz|7|8|9
 """
         data = self.read_csv(StringIO(text), index_col=0, sep=None)
-        self.assert_(data.index.equals(Index(['foo', 'bar', 'baz'])))
+        self.assertTrue(data.index.equals(Index(['foo', 'bar', 'baz'])))
 
         data2 = self.read_csv(StringIO(text), index_col=0, delimiter='|')
         tm.assert_frame_equal(data, data2)
@@ -2378,7 +2378,7 @@ c   1   2   3   4
 
         for c in df.columns:
             res = df.loc[:,c]
-            self.assert_(len(res))
+            self.assertTrue(len(res))
 
     def test_fwf_compression(self):
         try:
@@ -2577,7 +2577,7 @@ A,B,C
         try:
             df = self.read_table(
                 StringIO(data), sep=',', header=1, comment='#')
-            self.assert_(False)
+            self.assertTrue(False)
         except Exception as inst:
             self.assertIn('Expected 3 fields in line 4, saw 5', str(inst))
 
@@ -2594,7 +2594,7 @@ footer
             df = self.read_table(
                 StringIO(data), sep=',', header=1, comment='#',
                 skip_footer=1)
-            self.assert_(False)
+            self.assertTrue(False)
         except Exception as inst:
             self.assertIn('Expected 3 fields in line 4, saw 5', str(inst))
 
@@ -2612,7 +2612,7 @@ skip
                                  header=1, comment='#', iterator=True, chunksize=1,
                                  skiprows=[2])
             df = it.read(5)
-            self.assert_(False)
+            self.assertTrue(False)
         except Exception as inst:
             self.assertIn('Expected 3 fields in line 6, saw 5', str(inst))
 
@@ -2631,7 +2631,7 @@ skip
                                  skiprows=[2])
             df = it.read(1)
             it.read(2)
-            self.assert_(False)
+            self.assertTrue(False)
         except Exception as inst:
             self.assertIn('Expected 3 fields in line 6, saw 5', str(inst))
 
@@ -2650,7 +2650,7 @@ skip
                                  skiprows=[2])
             df = it.read(1)
             it.read()
-            self.assert_(False)
+            self.assertTrue(False)
         except Exception as inst:
             self.assertIn('Expected 3 fields in line 6, saw 5', str(inst))
 

--- a/pandas/io/tests/test_pickle.py
+++ b/pandas/io/tests/test_pickle.py
@@ -33,7 +33,7 @@ class TestPickle(tm.TestCase):
 
     def compare_element(self, typ, result, expected):
         if isinstance(expected,Index):
-            self.assert_(expected.equals(result))
+            self.assertTrue(expected.equals(result))
             return
 
         if typ.startswith('sp_'):

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -297,16 +297,16 @@ class TestHDFStore(tm.TestCase):
             pandas.set_option('io.hdf.default_format','fixed')
             _maybe_remove(store,'df')
             store.put('df',df)
-            self.assert_(not store.get_storer('df').is_table)
+            self.assertFalse(store.get_storer('df').is_table)
             self.assertRaises(ValueError, store.append, 'df2',df)
 
             pandas.set_option('io.hdf.default_format','table')
             _maybe_remove(store,'df')
             store.put('df',df)
-            self.assert_(store.get_storer('df').is_table)
+            self.assertTrue(store.get_storer('df').is_table)
             _maybe_remove(store,'df2')
             store.append('df2',df)
-            self.assert_(store.get_storer('df').is_table)
+            self.assertTrue(store.get_storer('df').is_table)
 
             pandas.set_option('io.hdf.default_format',None)
 
@@ -317,16 +317,16 @@ class TestHDFStore(tm.TestCase):
             pandas.set_option('io.hdf.default_format','fixed')
             df.to_hdf(path,'df')
             with get_store(path) as store:
-                self.assert_(not store.get_storer('df').is_table)
+                self.assertFalse(store.get_storer('df').is_table)
             self.assertRaises(ValueError, df.to_hdf, path,'df2', append=True)
 
             pandas.set_option('io.hdf.default_format','table')
             df.to_hdf(path,'df3')
             with get_store(path) as store:
-                self.assert_(store.get_storer('df3').is_table)
+                self.assertTrue(store.get_storer('df3').is_table)
             df.to_hdf(path,'df4',append=True)
             with get_store(path) as store:
-                self.assert_(store.get_storer('df4').is_table)
+                self.assertTrue(store.get_storer('df4').is_table)
 
             pandas.set_option('io.hdf.default_format',None)
 
@@ -489,41 +489,41 @@ class TestHDFStore(tm.TestCase):
             # invalid mode change
             self.assertRaises(PossibleDataLossError, store.open, 'w')
             store.close()
-            self.assert_(not store.is_open)
+            self.assertFalse(store.is_open)
 
             # truncation ok here
             store.open('w')
-            self.assert_(store.is_open)
+            self.assertTrue(store.is_open)
             self.assertEquals(len(store), 0)
             store.close()
-            self.assert_(not store.is_open)
+            self.assertFalse(store.is_open)
 
             store = HDFStore(path,mode='a')
             store['a'] = tm.makeTimeSeries()
 
             # reopen as read
             store.open('r')
-            self.assert_(store.is_open)
+            self.assertTrue(store.is_open)
             self.assertEquals(len(store), 1)
             self.assertEqual(store._mode, 'r')
             store.close()
-            self.assert_(not store.is_open)
+            self.assertFalse(store.is_open)
 
             # reopen as append
             store.open('a')
-            self.assert_(store.is_open)
+            self.assertTrue(store.is_open)
             self.assertEquals(len(store), 1)
             self.assertEqual(store._mode, 'a')
             store.close()
-            self.assert_(not store.is_open)
+            self.assertFalse(store.is_open)
 
             # reopen as append (again)
             store.open('a')
-            self.assert_(store.is_open)
+            self.assertTrue(store.is_open)
             self.assertEquals(len(store), 1)
             self.assertEqual(store._mode, 'a')
             store.close()
-            self.assert_(not store.is_open)
+            self.assertFalse(store.is_open)
 
     def test_open_args(self):
 
@@ -2745,7 +2745,7 @@ class TestHDFStore(tm.TestCase):
             df['foo'] = np.random.randn(len(df))
             store['df'] = df
             recons = store['df']
-            self.assert_(recons._data.is_consolidated())
+            self.assertTrue(recons._data.is_consolidated())
 
         # empty
         self._check_roundtrip(df[:0], tm.assert_frame_equal)
@@ -2782,7 +2782,7 @@ class TestHDFStore(tm.TestCase):
         with ensure_clean_store(self.path) as store:
             store['frame'] = frame
             recons = store['frame']
-            self.assert_(recons.index.equals(rng))
+            self.assertTrue(recons.index.equals(rng))
             self.assertEquals(rng.tz, recons.index.tz)
 
     def test_fixed_offset_tz(self):
@@ -2792,7 +2792,7 @@ class TestHDFStore(tm.TestCase):
         with ensure_clean_store(self.path) as store:
             store['frame'] = frame
             recons = store['frame']
-            self.assert_(recons.index.equals(rng))
+            self.assertTrue(recons.index.equals(rng))
             self.assertEquals(rng.tz, recons.index.tz)
 
     def test_store_hierarchical(self):
@@ -3923,10 +3923,10 @@ class TestHDFStore(tm.TestCase):
             # single
             store = HDFStore(path)
             self.assertNotIn('CLOSED', str(store))
-            self.assert_(store.is_open)
+            self.assertTrue(store.is_open)
             store.close()
             self.assertIn('CLOSED', str(store))
-            self.assert_(not store.is_open)
+            self.assertFalse(store.is_open)
 
         with ensure_clean_path(self.path) as path:
 
@@ -3947,20 +3947,20 @@ class TestHDFStore(tm.TestCase):
 
                 self.assertNotIn('CLOSED', str(store1))
                 self.assertNotIn('CLOSED', str(store2))
-                self.assert_(store1.is_open)
-                self.assert_(store2.is_open)
+                self.assertTrue(store1.is_open)
+                self.assertTrue(store2.is_open)
 
                 store1.close()
                 self.assertIn('CLOSED', str(store1))
-                self.assert_(not store1.is_open)
+                self.assertFalse(store1.is_open)
                 self.assertNotIn('CLOSED', str(store2))
-                self.assert_(store2.is_open)
+                self.assertTrue(store2.is_open)
 
                 store2.close()
                 self.assertIn('CLOSED', str(store1))
                 self.assertIn('CLOSED', str(store2))
-                self.assert_(not store1.is_open)
-                self.assert_(not store2.is_open)
+                self.assertFalse(store1.is_open)
+                self.assertFalse(store2.is_open)
 
                 # nested close
                 store = HDFStore(path,mode='w')
@@ -3970,11 +3970,11 @@ class TestHDFStore(tm.TestCase):
                 store2.append('df2',df)
                 store2.close()
                 self.assertIn('CLOSED', str(store2))
-                self.assert_(not store2.is_open)
+                self.assertFalse(store2.is_open)
 
                 store.close()
                 self.assertIn('CLOSED', str(store))
-                self.assert_(not store.is_open)
+                self.assertFalse(store.is_open)
 
                 # double closing
                 store = HDFStore(path,mode='w')
@@ -3983,11 +3983,11 @@ class TestHDFStore(tm.TestCase):
                 store2 = HDFStore(path)
                 store.close()
                 self.assertIn('CLOSED', str(store))
-                self.assert_(not store.is_open)
+                self.assertFalse(store.is_open)
 
                 store2.close()
                 self.assertIn('CLOSED', str(store2))
-                self.assert_(not store2.is_open)
+                self.assertFalse(store2.is_open)
 
         # ops on a closed store
         with ensure_clean_path(self.path) as path:

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -563,7 +563,7 @@ class _TestSQLApi(PandasSQLTest):
     def test_get_schema(self):
         create_sql = sql.get_schema(self.test_frame1, 'test', 'sqlite',
                                     con=self.conn)
-        self.assert_('CREATE' in create_sql)
+        self.assertTrue('CREATE' in create_sql)
 
 
 class TestSQLApi(_TestSQLApi):
@@ -684,7 +684,7 @@ class TestSQLLegacyApi(_TestSQLApi):
     def test_get_schema2(self):
         # without providing a connection object (available for backwards comp)
         create_sql = sql.get_schema(self.test_frame1, 'test', 'sqlite')
-        self.assert_('CREATE' in create_sql)
+        self.assertTrue('CREATE' in create_sql)
 
     def test_tquery(self):
         with tm.assert_produces_warning(FutureWarning):
@@ -1323,12 +1323,12 @@ class TestXSQLite(tm.TestCase):
         for l in lines:
             tokens = l.split(' ')
             if len(tokens) == 2 and tokens[0] == 'A':
-                self.assert_(tokens[1] == 'DATETIME')
+                self.assertTrue(tokens[1] == 'DATETIME')
 
         frame = tm.makeTimeDataFrame()
         create_sql = sql.get_schema(frame, 'test', 'sqlite', keys=['A', 'B'],)
         lines = create_sql.splitlines()
-        self.assert_('PRIMARY KEY (A,B)' in create_sql)
+        self.assertTrue('PRIMARY KEY (A,B)' in create_sql)
         cur = self.db.cursor()
         cur.execute(create_sql)
 
@@ -1601,13 +1601,13 @@ class TestXMySQL(tm.TestCase):
         for l in lines:
             tokens = l.split(' ')
             if len(tokens) == 2 and tokens[0] == 'A':
-                self.assert_(tokens[1] == 'DATETIME')
+                self.assertTrue(tokens[1] == 'DATETIME')
 
         frame = tm.makeTimeDataFrame()
         drop_sql = "DROP TABLE IF EXISTS test"
         create_sql = sql.get_schema(frame, 'test', 'mysql', keys=['A', 'B'],)
         lines = create_sql.splitlines()
-        self.assert_('PRIMARY KEY (A,B)' in create_sql)
+        self.assertTrue('PRIMARY KEY (A,B)' in create_sql)
         cur = self.db.cursor()
         cur.execute(drop_sql)
         cur.execute(create_sql)

--- a/pandas/sparse/tests/test_array.py
+++ b/pandas/sparse/tests/test_array.py
@@ -57,16 +57,16 @@ class TestSparseArray(tm.TestCase):
     def test_constructor_copy(self):
         cp = SparseArray(self.arr, copy=True)
         cp.sp_values[:3] = 0
-        self.assert_(not (self.arr.sp_values[:3] == 0).any())
+        self.assertFalse((self.arr.sp_values[:3] == 0).any())
 
         not_copy = SparseArray(self.arr)
         not_copy.sp_values[:3] = 0
-        self.assert_((self.arr.sp_values[:3] == 0).all())
+        self.assertTrue((self.arr.sp_values[:3] == 0).all())
 
     def test_astype(self):
         res = self.arr.astype('f8')
         res.sp_values[:3] = 27
-        self.assert_(not (self.arr.sp_values[:3] == 27).any())
+        self.assertFalse((self.arr.sp_values[:3] == 27).any())
 
         assertRaisesRegexp(TypeError, "floating point", self.arr.astype, 'i8')
 

--- a/pandas/sparse/tests/test_libsparse.py
+++ b/pandas/sparse/tests/test_libsparse.py
@@ -238,8 +238,8 @@ class TestBlockIndex(tm.TestCase):
     def test_equals(self):
         index = BlockIndex(10, [0, 4], [2, 5])
 
-        self.assert_(index.equals(index))
-        self.assert_(not index.equals(BlockIndex(10, [0, 4], [2, 6])))
+        self.assertTrue(index.equals(index))
+        self.assertFalse(index.equals(BlockIndex(10, [0, 4], [2, 6])))
 
     def test_check_integrity(self):
         locs = []
@@ -276,8 +276,8 @@ class TestIntIndex(tm.TestCase):
 
     def test_equals(self):
         index = IntIndex(10, [0, 1, 2, 3, 4])
-        self.assert_(index.equals(index))
-        self.assert_(not index.equals(IntIndex(10, [0, 1, 2, 3])))
+        self.assertTrue(index.equals(index))
+        self.assertFalse(index.equals(IntIndex(10, [0, 1, 2, 3])))
 
     def test_to_block_index(self):
         def _check_case(xloc, xlen, yloc, ylen, eloc, elen):
@@ -288,8 +288,8 @@ class TestIntIndex(tm.TestCase):
             xbindex = xindex.to_int_index().to_block_index()
             ybindex = yindex.to_int_index().to_block_index()
             tm.assert_isinstance(xbindex, BlockIndex)
-            self.assert_(xbindex.equals(xindex))
-            self.assert_(ybindex.equals(yindex))
+            self.assertTrue(xbindex.equals(xindex))
+            self.assertTrue(ybindex.equals(yindex))
         check_cases(_check_case)
 
     def test_to_int_index(self):
@@ -313,7 +313,7 @@ class TestSparseOperators(tm.TestCase):
             result_block_vals, rb_index = sparse_op(x, xindex, y, yindex)
             result_int_vals, ri_index = sparse_op(x, xdindex, y, ydindex)
 
-            self.assert_(rb_index.to_int_index().equals(ri_index))
+            self.assertTrue(rb_index.to_int_index().equals(ri_index))
             assert_equal(result_block_vals, result_int_vals)
 
             # check versus Series...
@@ -344,7 +344,7 @@ class TestSparseOperators(tm.TestCase):
             result_int_vals, ri_index = sparse_op(x, xdindex, xfill,
                                                   y, ydindex, yfill)
 
-            self.assert_(rb_index.to_int_index().equals(ri_index))
+            self.assertTrue(rb_index.to_int_index().equals(ri_index))
             assert_equal(result_block_vals, result_int_vals)
 
             # check versus Series...

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -220,9 +220,9 @@ class TestSparseSeries(tm.TestCase,
 
     def test_constructor(self):
         # test setup guys
-        self.assert_(np.isnan(self.bseries.fill_value))
+        self.assertTrue(np.isnan(self.bseries.fill_value))
         tm.assert_isinstance(self.bseries.sp_index, BlockIndex)
-        self.assert_(np.isnan(self.iseries.fill_value))
+        self.assertTrue(np.isnan(self.iseries.fill_value))
         tm.assert_isinstance(self.iseries.sp_index, IntIndex)
 
         self.assertEquals(self.zbseries.fill_value, 0)
@@ -264,8 +264,8 @@ class TestSparseSeries(tm.TestCase,
         data = 5
         sp = SparseSeries(data, np.arange(100))
         sp = sp.reindex(np.arange(200))
-        self.assert_((sp.ix[:99] == data).all())
-        self.assert_(isnull(sp.ix[100:]).all())
+        self.assertTrue((sp.ix[:99] == data).all())
+        self.assertTrue(isnull(sp.ix[100:]).all())
 
         data = np.nan
         sp = SparseSeries(data, np.arange(100))
@@ -304,7 +304,7 @@ class TestSparseSeries(tm.TestCase,
         # no deep copy
         view = self.bseries.copy(deep=False)
         view.sp_values[:5] = 5
-        self.assert_((self.bseries.sp_values[:5] == 5).all())
+        self.assertTrue((self.bseries.sp_values[:5] == 5).all())
 
     def test_astype(self):
         self.assertRaises(Exception, self.bseries.astype, np.int64)
@@ -534,7 +534,7 @@ class TestSparseSeries(tm.TestCase,
         # with copy=False
         reindexed = self.bseries.reindex(self.bseries.index, copy=True)
         reindexed.sp_values[:] = 1.
-        self.assert_((self.bseries.sp_values != 1.).all())
+        self.assertTrue((self.bseries.sp_values != 1.).all())
 
         reindexed = self.bseries.reindex(self.bseries.index, copy=False)
         reindexed.sp_values[:] = 1.
@@ -647,7 +647,7 @@ class TestSparseSeries(tm.TestCase,
         expected = expected[expected != 0]
 
         assert_almost_equal(sp_valid.values, expected.values)
-        self.assert_(sp_valid.index.equals(expected.index))
+        self.assertTrue(sp_valid.index.equals(expected.index))
         self.assertEquals(len(sp_valid.sp_values), 2)
 
         result = self.bseries.dropna()
@@ -687,12 +687,12 @@ class TestSparseSeries(tm.TestCase,
         cop.fill_value = 0
         result = self.bseries / cop
 
-        self.assert_(np.isnan(result.fill_value))
+        self.assertTrue(np.isnan(result.fill_value))
 
         cop2 = self.zbseries.copy()
         cop2.fill_value = 1
         result = cop2 / cop
-        self.assert_(np.isnan(result.fill_value))
+        self.assertTrue(np.isnan(result.fill_value))
 
     def test_shift(self):
         series = SparseSeries([nan, 1., 2., 3., nan, nan],
@@ -793,7 +793,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
         cp = self.frame.copy()
         tm.assert_isinstance(cp, SparseDataFrame)
         assert_sp_frame_equal(cp, self.frame)
-        self.assert_(cp.index.is_(self.frame.index))
+        self.assertTrue(cp.index.is_(self.frame.index))
 
     def test_constructor(self):
         for col, series in compat.iteritems(self.frame):
@@ -930,7 +930,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
                         'B': [1, 2, nan, nan, nan]})
         sdf = df.to_sparse()
         tm.assert_isinstance(sdf, SparseDataFrame)
-        self.assert_(np.isnan(sdf.default_fill_value))
+        self.assertTrue(np.isnan(sdf.default_fill_value))
         tm.assert_isinstance(sdf['A'].sp_index, BlockIndex)
         tm.assert_frame_equal(sdf.to_dense(), df)
 
@@ -1048,7 +1048,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
 
     def test_op_corners(self):
         empty = self.empty + self.empty
-        self.assert_(empty.empty)
+        self.assertTrue(empty.empty)
 
         foo = self.frame + self.empty
         tm.assert_isinstance(foo.index, DatetimeIndex)
@@ -1173,7 +1173,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
             # scalar value
             frame['J'] = 5
             self.assertEquals(len(frame['J'].sp_values), N)
-            self.assert_((frame['J'].sp_values == 5).all())
+            self.assertTrue((frame['J'].sp_values == 5).all())
 
             frame['K'] = frame.default_fill_value
             self.assertEquals(len(frame['K'].sp_values), 0)
@@ -1362,7 +1362,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
             self.assertEquals(len(reindexed.columns), 3)
             assert_almost_equal(reindexed['Z'].fill_value,
                                 frame.default_fill_value)
-            self.assert_(np.isnan(reindexed['Z'].sp_values).all())
+            self.assertTrue(np.isnan(reindexed['Z'].sp_values).all())
 
         _check_frame(self.frame)
         _check_frame(self.iframe)
@@ -1633,7 +1633,7 @@ class TestSparsePanel(tm.TestCase,
             dlp = panel.to_dense().to_frame()
 
             self.assert_numpy_array_equal(slp.values, dlp.values)
-            self.assert_(slp.index.equals(dlp.index))
+            self.assertTrue(slp.index.equals(dlp.index))
 
         _compare_with_dense(self.panel)
         _compare_with_dense(self.panel.reindex(items=['ItemA']))

--- a/pandas/stats/tests/test_math.py
+++ b/pandas/stats/tests/test_math.py
@@ -53,13 +53,13 @@ class TestMath(tm.TestCase):
         b = Series(np.random.randn(N), self.frame.index)
         result = pmath.solve(self.frame, b)
         expected = ols(y=b, x=self.frame, intercept=False).beta
-        self.assert_(np.allclose(result, expected))
+        self.assertTrue(np.allclose(result, expected))
 
     def test_inv_illformed(self):
         singular = DataFrame(np.array([[1, 1], [2, 2]]))
         rs = pmath.inv(singular)
         expected = np.array([[0.1, 0.2], [0.1, 0.2]])
-        self.assert_(np.allclose(rs, expected))
+        self.assertTrue(np.allclose(rs, expected))
 
 if __name__ == '__main__':
     import nose

--- a/pandas/stats/tests/test_moments.py
+++ b/pandas/stats/tests/test_moments.py
@@ -114,7 +114,7 @@ class TestMoments(tm.TestCase):
         vals = np.empty(10, dtype=float)
         vals.fill(np.nan)
         rs = mom.rolling_window(vals, 5, 'boxcar', center=True)
-        self.assert_(np.isnan(rs).all())
+        self.assertTrue(np.isnan(rs).all())
 
         # empty
         vals = np.array([])
@@ -124,7 +124,7 @@ class TestMoments(tm.TestCase):
         # shorter than window
         vals = np.random.randn(5)
         rs = mom.rolling_window(vals, 10, 'boxcar')
-        self.assert_(np.isnan(rs).all())
+        self.assertTrue(np.isnan(rs).all())
         self.assertEqual(len(rs), 5)
 
     def test_cmov_window_frame(self):
@@ -255,7 +255,7 @@ class TestMoments(tm.TestCase):
 
         # it works!
         result = mom.rolling_apply(arr, 10, np.sum)
-        self.assert_(isnull(result).all())
+        self.assertTrue(isnull(result).all())
 
         result = mom.rolling_apply(arr, 10, np.sum, min_periods=1)
         assert_almost_equal(result, result)
@@ -275,7 +275,7 @@ class TestMoments(tm.TestCase):
 
         result = mom.rolling_std(np.array([np.nan, np.nan, 3., 4., 5.]),
                                  3, min_periods=2)
-        self.assert_(np.isnan(result[2]))
+        self.assertTrue(np.isnan(result[2]))
 
     def test_rolling_std_neg_sqrt(self):
         # unit test from Bottleneck
@@ -288,10 +288,10 @@ class TestMoments(tm.TestCase):
                       0.00028718669878572767,
                       0.00028718669878572767])
         b = mom.rolling_std(a, window=3)
-        self.assert_(np.isfinite(b[2:]).all())
+        self.assertTrue(np.isfinite(b[2:]).all())
 
         b = mom.ewmstd(a, span=3)
-        self.assert_(np.isfinite(b[2:]).all())
+        self.assertTrue(np.isfinite(b[2:]).all())
 
     def test_rolling_var(self):
         self._check_moment_func(mom.rolling_var,
@@ -391,16 +391,16 @@ class TestMoments(tm.TestCase):
 
             # min_periods is working correctly
             result = func(arr, 20, min_periods=15)
-            self.assert_(np.isnan(result[23]))
-            self.assert_(not np.isnan(result[24]))
+            self.assertTrue(np.isnan(result[23]))
+            self.assertFalse(np.isnan(result[24]))
 
-            self.assert_(not np.isnan(result[-6]))
-            self.assert_(np.isnan(result[-5]))
+            self.assertFalse(np.isnan(result[-6]))
+            self.assertTrue(np.isnan(result[-5]))
 
             arr2 = randn(20)
             result = func(arr2, 10, min_periods=5)
-            self.assert_(isnull(result[3]))
-            self.assert_(notnull(result[4]))
+            self.assertTrue(isnull(result[3]))
+            self.assertTrue(notnull(result[4]))
 
             # min_periods=0
             result0 = func(arr, 20, min_periods=0)
@@ -420,14 +420,14 @@ class TestMoments(tm.TestCase):
 
             assert_almost_equal(result[1], expected[10])
             if fill_value is None:
-                self.assert_(np.isnan(result[-9:]).all())
+                self.assertTrue(np.isnan(result[-9:]).all())
             else:
-                self.assert_((result[-9:] == 0).all())
+                self.assertTrue((result[-9:] == 0).all())
             if has_min_periods:
-                self.assert_(np.isnan(expected[23]))
-                self.assert_(np.isnan(result[14]))
-                self.assert_(np.isnan(expected[-5]))
-                self.assert_(np.isnan(result[-14]))
+                self.assertTrue(np.isnan(expected[23]))
+                self.assertTrue(np.isnan(result[14]))
+                self.assertTrue(np.isnan(expected[-5]))
+                self.assertTrue(np.isnan(result[-14]))
 
         if test_stable:
             result = func(self.arr + 1e9, window)
@@ -501,7 +501,7 @@ class TestMoments(tm.TestCase):
         arr = np.zeros(1000)
         arr[5] = 1
         result = mom.ewma(arr, span=100, adjust=False).sum()
-        self.assert_(np.abs(result - 1) < 1e-2)
+        self.assertTrue(np.abs(result - 1) < 1e-2)
 
     def test_ewma_nan_handling(self):
         s = Series([1.] + [np.nan] * 5 + [1.])
@@ -678,8 +678,8 @@ class TestMoments(tm.TestCase):
 
         result = func(A, B, 20, min_periods=5)
 
-        self.assert_(np.isnan(result.values[:15]).all())
-        self.assert_(not np.isnan(result.values[15:]).any())
+        self.assertTrue(np.isnan(result.values[:15]).all())
+        self.assertFalse(np.isnan(result.values[15:]).any())
 
         self.assertRaises(Exception, func, A, randn(50), 20, min_periods=5)
 
@@ -827,13 +827,13 @@ class TestMoments(tm.TestCase):
 
             # min_periods is working correctly
             result = func(arr, min_periods=15)
-            self.assert_(np.isnan(result[13]))
-            self.assert_(not np.isnan(result[14]))
+            self.assertTrue(np.isnan(result[13]))
+            self.assertFalse(np.isnan(result[14]))
 
             arr2 = randn(20)
             result = func(arr2, min_periods=5)
-            self.assert_(isnull(result[3]))
-            self.assert_(notnull(result[4]))
+            self.assertTrue(isnull(result[3]))
+            self.assertTrue(notnull(result[4]))
 
             # min_periods=0
             result0 = func(arr, min_periods=0)

--- a/pandas/stats/tests/test_ols.py
+++ b/pandas/stats/tests/test_ols.py
@@ -301,7 +301,7 @@ class TestOLSMisc(tm.TestCase):
         model1 = ols(y=y, x=x, window=20)
         model2 = ols(y=y, x=x_with, window=20, intercept=False)
         assert_frame_equal(model1.beta, model2.beta)
-        self.assert_((model1.r2 != model2.r2).all())
+        self.assertTrue((model1.r2 != model2.r2).all())
 
     def test_summary_many_terms(self):
         x = DataFrame(np.random.randn(100, 20))
@@ -361,7 +361,7 @@ class TestOLSMisc(tm.TestCase):
         model = ols(y=endog, x=exog)
 
         pred = model.y_predict
-        self.assert_(pred.index.equals(exog.index))
+        self.assertTrue(pred.index.equals(exog.index))
 
     def test_longpanel_series_combo(self):
         wp = tm.makePanel()
@@ -369,7 +369,7 @@ class TestOLSMisc(tm.TestCase):
 
         y = lp.pop('ItemA')
         model = ols(y=y, x=lp, entity_effects=True, window=20)
-        self.assert_(notnull(model.beta.values).all())
+        self.assertTrue(notnull(model.beta.values).all())
         tm.assert_isinstance(model, PanelOLS)
         model.summary
 

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -57,27 +57,27 @@ class TestCategorical(tm.TestCase):
     def test_comparisons(self):
         result = self.factor[self.factor == 'a']
         expected = self.factor[np.asarray(self.factor) == 'a']
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         result = self.factor[self.factor != 'a']
         expected = self.factor[np.asarray(self.factor) != 'a']
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         result = self.factor[self.factor < 'c']
         expected = self.factor[np.asarray(self.factor) < 'c']
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         result = self.factor[self.factor > 'a']
         expected = self.factor[np.asarray(self.factor) > 'a']
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         result = self.factor[self.factor >= 'b']
         expected = self.factor[np.asarray(self.factor) >= 'b']
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         result = self.factor[self.factor <= 'b']
         expected = self.factor[np.asarray(self.factor) <= 'b']
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         n = len(self.factor)
 
@@ -105,7 +105,7 @@ class TestCategorical(tm.TestCase):
     def test_levels_none(self):
         factor = Categorical(['a', 'b', 'b', 'a',
                               'a', 'c', 'c', 'c'])
-        self.assert_(factor.equals(self.factor))
+        self.assertTrue(factor.equals(self.factor))
 
     def test_describe(self):
         # string type
@@ -189,9 +189,9 @@ class TestCategorical(tm.TestCase):
 
         exp_arr = np.array([0, 0, 1, 1, 2, 2])
         exp_idx = PeriodIndex(['2014-01', '2014-02', '2014-03'], freq='M')
-        
+
         self.assert_numpy_array_equal(cat1.labels, exp_arr)
-        self.assert_(cat1.levels.equals(exp_idx))
+        self.assertTrue(cat1.levels.equals(exp_idx))
 
 
         idx2 = PeriodIndex(['2014-03', '2014-03', '2014-02', '2014-01',
@@ -201,7 +201,7 @@ class TestCategorical(tm.TestCase):
         exp_arr = np.array([2, 2, 1, 0, 2, 0])
 
         self.assert_numpy_array_equal(cat2.labels, exp_arr)
-        self.assert_(cat2.levels.equals(exp_idx))
+        self.assertTrue(cat2.levels.equals(exp_idx))
 
         idx3 = PeriodIndex(['2013-12', '2013-11', '2013-10', '2013-09',
                             '2013-08', '2013-07', '2013-05'], freq='M')
@@ -212,7 +212,7 @@ class TestCategorical(tm.TestCase):
                                '2013-10', '2013-11', '2013-12'], freq='M')
 
         self.assert_numpy_array_equal(cat3.labels, exp_arr)
-        self.assert_(cat3.levels.equals(exp_idx))
+        self.assertTrue(cat3.levels.equals(exp_idx))
 
 
 if __name__ == '__main__':

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -421,7 +421,7 @@ class TestDataFrameFormatting(tm.TestCase):
                                     self.assertTrue(has_doubly_truncated_repr(df))
                                 else:
                                     self.assertFalse(has_doubly_truncated_repr(df))
-                            
+
     def test_to_string_truncate_multilevel(self):
         arrays = [['bar', 'bar', 'baz', 'baz', 'foo', 'foo', 'qux', 'qux'],
                   ['one', 'two', 'one', 'two', 'one', 'two', 'one', 'two']]
@@ -1190,7 +1190,7 @@ class TestDataFrameFormatting(tm.TestCase):
 
             with option_context('display.width', 120):
                 wider_repr = repr(df)
-                self.assert_(len(wider_repr) < len(wide_repr))
+                self.assertTrue(len(wider_repr) < len(wide_repr))
 
         reset_option('display.expand_frame_repr')
 
@@ -1216,7 +1216,7 @@ class TestDataFrameFormatting(tm.TestCase):
 
             with option_context('display.width', 150):
                 wider_repr = repr(df)
-                self.assert_(len(wider_repr) < len(wide_repr))
+                self.assertTrue(len(wider_repr) < len(wide_repr))
 
             for line in wide_repr.splitlines()[1::13]:
                 self.assertIn('DataFrame Index', line)
@@ -1240,7 +1240,7 @@ class TestDataFrameFormatting(tm.TestCase):
 
             with option_context('display.width', 150):
                 wider_repr = repr(df)
-                self.assert_(len(wider_repr) < len(wide_repr))
+                self.assertTrue(len(wider_repr) < len(wide_repr))
 
             for line in wide_repr.splitlines()[1::13]:
                 self.assertIn('Level 0 Level 1', line)
@@ -1266,7 +1266,7 @@ class TestDataFrameFormatting(tm.TestCase):
 
         with option_context('display.width', 150):
             wider_repr = repr(df)
-            self.assert_(len(wider_repr) < len(wide_repr))
+            self.assertTrue(len(wider_repr) < len(wide_repr))
 
         reset_option('display.expand_frame_repr')
 
@@ -1283,7 +1283,7 @@ class TestDataFrameFormatting(tm.TestCase):
 
             with option_context('display.width', 150):
                 wider_repr = repr(df)
-                self.assert_(len(wider_repr) < len(wide_repr))
+                self.assertTrue(len(wider_repr) < len(wide_repr))
 
         reset_option('display.expand_frame_repr')
 
@@ -1521,7 +1521,7 @@ class TestDataFrameFormatting(tm.TestCase):
 
     def test_to_string_int_formatting(self):
         df = DataFrame({'x': [-15, 20, 25, -35]})
-        self.assert_(issubclass(df['x'].dtype.type, np.integer))
+        self.assertTrue(issubclass(df['x'].dtype.type, np.integer))
 
         output = df.to_string()
         expected = ('    x\n'
@@ -2047,9 +2047,9 @@ c  10  11  12  13  14\
             if line.startswith('dtype:'):
                 continue
             if _three_digit_exp():
-                self.assert_(('+010' in line) or skip)
+                self.assertTrue(('+010' in line) or skip)
             else:
-                self.assert_(('+10' in line) or skip)
+                self.assertTrue(('+10' in line) or skip)
             skip = False
 
     def test_dict_entries(self):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -113,7 +113,7 @@ class CheckIndexing(object):
 
         for _, series in compat.iteritems(sl):
             self.assertEqual(20, len(series.index))
-            self.assert_(tm.equalContents(series.index, sl.index))
+            self.assertTrue(tm.equalContents(series.index, sl.index))
 
         for key, _ in compat.iteritems(self.frame._series):
             self.assertIsNotNone(self.frame[key])
@@ -372,10 +372,10 @@ class CheckIndexing(object):
         assert_frame_equal(result, self.frame[['D', 'C']])
 
         self.frame.ix[:, [-1]] = 0
-        self.assert_((self.frame['D'] == 0).all())
+        self.assertTrue((self.frame['D'] == 0).all())
 
         df = DataFrame(np.random.randn(8, 4))
-        self.assert_(isnull(df.ix[:, [-1]].values).all())
+        self.assertTrue(isnull(df.ix[:, [-1]].values).all())
 
         # #1942
         a = DataFrame(randn(20, 2), index=[chr(x + 65) for x in range(20)])
@@ -392,7 +392,7 @@ class CheckIndexing(object):
         df = DataFrame({'foobar': 1}, index=lrange(10))
 
         df.foobar = 5
-        self.assert_((df.foobar == 5).all())
+        self.assertTrue((df.foobar == 5).all())
 
     def test_setitem(self):
         # not sure what else to do here
@@ -413,7 +413,7 @@ class CheckIndexing(object):
         # set ndarray
         arr = randn(len(self.frame))
         self.frame['col9'] = arr
-        self.assert_((self.frame['col9'] == arr).all())
+        self.assertTrue((self.frame['col9'] == arr).all())
 
         self.frame['col7'] = 5
         assert((self.frame['col7'] == 5).all())
@@ -427,7 +427,7 @@ class CheckIndexing(object):
         smaller = self.frame[:2]
         smaller['col10'] = ['1', '2']
         self.assertEqual(smaller['col10'].dtype, np.object_)
-        self.assert_((smaller['col10'] == ['1', '2']).all())
+        self.assertTrue((smaller['col10'] == ['1', '2']).all())
 
         # with a dtype
         for dtype in ['int32','int64','float32','float64']:
@@ -453,7 +453,7 @@ class CheckIndexing(object):
         self.frame['E'] = s
 
         self.frame['E'][5:10] = nan
-        self.assert_(notnull(s[5:10]).all())
+        self.assertTrue(notnull(s[5:10]).all())
 
     def test_setitem_boolean(self):
         df = self.frame.copy()
@@ -517,7 +517,7 @@ class CheckIndexing(object):
 
         # cast if pass array of course
         self.frame['B'] = np.arange(len(self.frame))
-        self.assert_(issubclass(self.frame['B'].dtype.type, np.integer))
+        self.assertTrue(issubclass(self.frame['B'].dtype.type, np.integer))
 
         self.frame['foo'] = 'bar'
         self.frame['foo'] = 0
@@ -706,7 +706,7 @@ class CheckIndexing(object):
         # this is OK
         result = df.ix[:8:2]
         df.ix[:8:2] = np.nan
-        self.assert_(isnull(df.ix[:8:2]).values.all())
+        self.assertTrue(isnull(df.ix[:8:2]).values.all())
 
     def test_getitem_setitem_integer_slice_keyerrors(self):
         df = DataFrame(np.random.randn(10, 5), index=lrange(0, 20, 2))
@@ -714,12 +714,12 @@ class CheckIndexing(object):
         # this is OK
         cp = df.copy()
         cp.ix[4:10] = 0
-        self.assert_((cp.ix[4:10] == 0).values.all())
+        self.assertTrue((cp.ix[4:10] == 0).values.all())
 
         # so is this
         cp = df.copy()
         cp.ix[3:11] = 0
-        self.assert_((cp.ix[3:11] == 0).values.all())
+        self.assertTrue((cp.ix[3:11] == 0).values.all())
 
         result = df.ix[4:10]
         result2 = df.ix[3:11]
@@ -838,7 +838,7 @@ class CheckIndexing(object):
         # get view with single block
         sliced = self.frame.ix[:, -3:]
         sliced['C'] = 4.
-        self.assert_((self.frame['C'] == 4).all())
+        self.assertTrue((self.frame['C'] == 4).all())
 
     def test_fancy_setitem_int_labels(self):
         # integer index defers to label-based indexing
@@ -905,10 +905,10 @@ class CheckIndexing(object):
     def test_setitem_fancy_mixed_2d(self):
         self.mixed_frame.ix[:5, ['C', 'B', 'A']] = 5
         result = self.mixed_frame.ix[:5, ['C', 'B', 'A']]
-        self.assert_((result.values == 5).all())
+        self.assertTrue((result.values == 5).all())
 
         self.mixed_frame.ix[5] = np.nan
-        self.assert_(isnull(self.mixed_frame.ix[5]).all())
+        self.assertTrue(isnull(self.mixed_frame.ix[5]).all())
 
         self.mixed_frame.ix[5] = self.mixed_frame.ix[6]
         assert_series_equal(self.mixed_frame.ix[5], self.mixed_frame.ix[6])
@@ -916,7 +916,7 @@ class CheckIndexing(object):
         # #1432
         df = DataFrame({1: [1., 2., 3.],
                         2: [3, 4, 5]})
-        self.assert_(df._is_mixed_type)
+        self.assertTrue(df._is_mixed_type)
 
         df.ix[1] = [5, 10]
 
@@ -1263,7 +1263,7 @@ class CheckIndexing(object):
 
         df.ix[1:2] = 0
         result = df[1:2]
-        self.assert_((result==0).all().all())
+        self.assertTrue((result==0).all().all())
 
         # #2727
         index = Index([1.0, 2.5, 3.5, 4.5, 5.0])
@@ -1351,15 +1351,15 @@ class CheckIndexing(object):
         # set an allowable datetime64 type
         from pandas import tslib
         df.ix['b', 'timestamp'] = tslib.iNaT
-        self.assert_(com.isnull(df.ix['b', 'timestamp']))
+        self.assertTrue(com.isnull(df.ix['b', 'timestamp']))
 
         # allow this syntax
         df.ix['c', 'timestamp'] = nan
-        self.assert_(com.isnull(df.ix['c', 'timestamp']))
+        self.assertTrue(com.isnull(df.ix['c', 'timestamp']))
 
         # allow this syntax
         df.ix['d', :] = nan
-        self.assert_(com.isnull(df.ix['c', :]).all() == False)
+        self.assertTrue(com.isnull(df.ix['c', :]).all() == False)
 
         # as of GH 3216 this will now work!
         # try to set with a list like item
@@ -1562,8 +1562,8 @@ class CheckIndexing(object):
 
         res = self.frame.copy()
         res3 = res.set_value('foobar', 'baz', 5)
-        self.assert_(com.is_float_dtype(res3['baz']))
-        self.assert_(isnull(res3['baz'].drop(['foobar'])).all())
+        self.assertTrue(com.is_float_dtype(res3['baz']))
+        self.assertTrue(isnull(res3['baz'].drop(['foobar'])).all())
         self.assertRaises(ValueError, res3.set_value, 'foobar', 'baz', 'sam')
 
     def test_set_value_with_index_dtype_change(self):
@@ -1605,7 +1605,7 @@ class CheckIndexing(object):
                                 (int, np.integer)))
 
         result = self.frame.ix[self.frame.index[5], 'E']
-        self.assert_(com.is_integer(result))
+        self.assertTrue(com.is_integer(result))
 
     def test_irow(self):
         df = DataFrame(np.random.randn(10, 4), index=lrange(0, 20, 2))
@@ -1652,7 +1652,7 @@ class CheckIndexing(object):
 
         # verify slice is view
         result[8] = 0.
-        self.assert_((df[8] == 0).all())
+        self.assertTrue((df[8] == 0).all())
 
         # list of integers
         result = df.icol([1, 2, 4, 6])
@@ -1803,15 +1803,15 @@ class SafeForSparse(object):
         f2 = self.frame.reindex(columns=['C', 'D'])
 
         joined = f.join(f2)
-        self.assert_(f.index.equals(joined.index))
+        self.assertTrue(f.index.equals(joined.index))
         self.assertEqual(len(joined.columns), 4)
 
         joined = f.join(f2, how='left')
-        self.assert_(joined.index.equals(f.index))
+        self.assertTrue(joined.index.equals(f.index))
         self.assertEqual(len(joined.columns), 4)
 
         joined = f.join(f2, how='right')
-        self.assert_(joined.index.equals(f2.index))
+        self.assertTrue(joined.index.equals(f2.index))
         self.assertEqual(len(joined.columns), 4)
 
         # inner
@@ -1820,7 +1820,7 @@ class SafeForSparse(object):
         f2 = self.frame.reindex(columns=['C', 'D'])
 
         joined = f.join(f2, how='inner')
-        self.assert_(joined.index.equals(f.index.intersection(f2.index)))
+        self.assertTrue(joined.index.equals(f.index.intersection(f2.index)))
         self.assertEqual(len(joined.columns), 4)
 
         # outer
@@ -1829,7 +1829,7 @@ class SafeForSparse(object):
         f2 = self.frame.reindex(columns=['C', 'D'])
 
         joined = f.join(f2, how='outer')
-        self.assert_(tm.equalContents(self.frame.index, joined.index))
+        self.assertTrue(tm.equalContents(self.frame.index, joined.index))
         self.assertEqual(len(joined.columns), 4)
 
         assertRaisesRegexp(ValueError, 'join method', f.join, f2, how='foo')
@@ -2292,7 +2292,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         df2 = DataFrame(rec, index=index)
         self.assert_numpy_array_equal(df2.columns, rec.dtype.names)
-        self.assert_(df2.index.equals(index))
+        self.assertTrue(df2.index.equals(index))
 
         rng = np.arange(len(rec))[::-1]
         df3 = DataFrame(rec, index=rng, columns=['C', 'B'])
@@ -2343,7 +2343,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         self.assertEqual(len(frame), len(self.ts2))
         self.assertNotIn('col1', frame)
-        self.assert_(isnull(frame['col3']).all())
+        self.assertTrue(isnull(frame['col3']).all())
 
         # Corner cases
         self.assertEqual(len(DataFrame({})), 0)
@@ -2371,7 +2371,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # with dict of empty list and Series
         frame = DataFrame({'A': [], 'B': []}, columns=['A', 'B'])
-        self.assert_(frame.index.equals(Index([])))
+        self.assertTrue(frame.index.equals(Index([])))
 
     def test_constructor_multi_index(self):
         # GH 4078
@@ -2379,12 +2379,12 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         tuples = [(2, 3), (3, 3), (3, 3)]
         mi = MultiIndex.from_tuples(tuples)
         df = DataFrame(index=mi,columns=mi)
-        self.assert_(pd.isnull(df).values.ravel().all())
+        self.assertTrue(pd.isnull(df).values.ravel().all())
 
         tuples = [(3, 3), (2, 3), (3, 3)]
         mi = MultiIndex.from_tuples(tuples)
         df = DataFrame(index=mi,columns=mi)
-        self.assert_(pd.isnull(df).values.ravel().all())
+        self.assertTrue(pd.isnull(df).values.ravel().all())
 
     def test_constructor_error_msgs(self):
         msg = "Mixing dicts with non-Series may lead to ambiguous ordering."
@@ -2818,7 +2818,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # GH #484
         l = [[1, 'a'], [2, 'b']]
         df = DataFrame(data=l, columns=["num", "str"])
-        self.assert_(com.is_integer_dtype(df['num']))
+        self.assertTrue(com.is_integer_dtype(df['num']))
         self.assertEqual(df['str'].dtype, np.object_)
 
         # GH 4851
@@ -2984,7 +2984,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         data['B'] = Series([4, 3, 2, 1], index=['bar', 'qux', 'baz', 'foo'])
 
         result = DataFrame(data)
-        self.assert_(result.index.is_monotonic)
+        self.assertTrue(result.index.is_monotonic)
 
         # ordering ambiguous, raise exception
         with assertRaisesRegexp(ValueError, 'ambiguous ordering'):
@@ -3019,7 +3019,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         a = Series([1, 2, 3], index=['a', 'b', 'c'], name='x')
         df = DataFrame(a)
         self.assertEqual(df.columns[0], 'x')
-        self.assert_(df.index.equals(a.index))
+        self.assertTrue(df.index.equals(a.index))
 
         # ndarray like
         arr = np.random.randn(10)
@@ -3068,7 +3068,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df2 = DataFrame(s2, index=other_index)
         exp2 = DataFrame(s2.reindex(other_index))
         self.assertEqual(df2.columns[0], 0)
-        self.assert_(df2.index.equals(other_index))
+        self.assertTrue(df2.index.equals(other_index))
         assert_frame_equal(df2, exp2)
 
     def test_constructor_manager_resize(self):
@@ -3253,7 +3253,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df = DataFrame([[1,2.5],[3,4.5]], index=[1,2], columns=['x','x'])
         result = df.values
         expected = np.array([[1,2.5],[3,4.5]])
-        self.assert_((result == expected).all().all())
+        self.assertTrue((result == expected).all().all())
 
         # rename, GH 4403
         df4 = DataFrame({'TClose': [22.02],
@@ -3645,7 +3645,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.assertEqual(result[1], diffs.ix[0,'B'])
 
         result = diffs.min(axis=1)
-        self.assert_((result == diffs.ix[0,'B']).all() == True)
+        self.assertTrue((result == diffs.ix[0,'B']).all() == True)
 
         # max
         result = diffs.max()
@@ -3653,7 +3653,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.assertEqual(result[1], diffs.ix[2,'B'])
 
         result = diffs.max(axis=1)
-        self.assert_((result == diffs['A']).all() == True)
+        self.assertTrue((result == diffs['A']).all() == True)
 
         # abs
         result = diffs.abs()
@@ -3923,7 +3923,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                   (None, 2, 5, 3)]
 
         df = DataFrame.from_records(tuples, columns=['a', 'b', 'c', 'd'])
-        self.assert_(np.isnan(df['c'][0]))
+        self.assertTrue(np.isnan(df['c'][0]))
 
     def test_from_records_iterator(self):
         arr = np.array([(1.0, 1.0, 2, 2), (3.0, 3.0, 4, 4), (5., 5., 6, 6), (7., 7., 8, 8)],
@@ -3991,7 +3991,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         df = DataFrame.from_records(tuples, columns=['a'], coerce_float=True)
         self.assertEqual(df['a'].dtype, np.float64)
-        self.assert_(np.isnan(df['a'].values[-1]))
+        self.assertTrue(np.isnan(df['a'].values[-1]))
 
     def test_from_records_duplicates(self):
         result = DataFrame.from_records([(1, 2, 3), (4, 5, 6)],
@@ -4489,16 +4489,16 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # new item
         df['x'] = df['a'].astype('float32')
         result = Series(dict(float64 = 5, float32 = 1))
-        self.assert_((df.get_dtype_counts() == result).all())
+        self.assertTrue((df.get_dtype_counts() == result).all())
 
         # replacing current (in different block)
         df['a'] = df['a'].astype('float32')
         result = Series(dict(float64 = 4, float32 = 2))
-        self.assert_((df.get_dtype_counts() == result).all())
+        self.assertTrue((df.get_dtype_counts() == result).all())
 
         df['y'] = df['a'].astype('int32')
         result = Series(dict(float64 = 4, float32 = 2, int32 = 1))
-        self.assert_((df.get_dtype_counts() == result).all())
+        self.assertTrue((df.get_dtype_counts() == result).all())
 
         with assertRaisesRegexp(ValueError, 'already exists'):
             df.insert(1, 'a', df['b'])
@@ -4537,7 +4537,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.assertEqual(len(df.index), 2)
 
     def test_iter(self):
-        self.assert_(tm.equalContents(list(self.frame), self.frame.columns))
+        self.assertTrue(tm.equalContents(list(self.frame), self.frame.columns))
 
     def test_iterrows(self):
         for i, (k, v) in enumerate(self.frame.iterrows()):
@@ -4581,7 +4581,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                 if not np.isnan(val):
                     self.assertEqual(val, origVal)
                 else:
-                    self.assert_(np.isnan(origVal))
+                    self.assertTrue(np.isnan(origVal))
 
         for col, series in compat.iteritems(seriesSum):
             for idx, val in compat.iteritems(series):
@@ -4589,7 +4589,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                 if not np.isnan(val):
                     self.assertEqual(val, origVal)
                 else:
-                    self.assert_(np.isnan(origVal))
+                    self.assertTrue(np.isnan(origVal))
 
         added = self.frame2 + self.frame2
         expected = self.frame2 * 2
@@ -5088,7 +5088,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             assert_frame_equal(rs, xp)
 
         # DataFrame
-        self.assert_(df.eq(df).values.all())
+        self.assertTrue(df.eq(df).values.all())
         self.assertFalse(df.ne(df).values.any())
         for op in ['eq', 'ne', 'gt', 'lt', 'ge', 'le']:
             f = getattr(df, op)
@@ -5151,7 +5151,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         rs = df.eq(df)
         self.assertFalse(rs.ix[0, 0])
         rs = df.ne(df)
-        self.assert_(rs.ix[0, 0])
+        self.assertTrue(rs.ix[0, 0])
         rs = df.gt(df)
         self.assertFalse(rs.ix[0, 0])
         rs = df.lt(df)
@@ -5171,7 +5171,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         rs = df.gt(df2)
         self.assertFalse(rs.values.any())
         rs = df.ne(df2)
-        self.assert_(rs.values.all())
+        self.assertTrue(rs.values.all())
 
         arr3 = np.array([2j, np.nan, None])
         df3 = DataFrame({'a': arr3})
@@ -5240,26 +5240,26 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                              self.frame['A'] * 2,
                              compare_keys=False)
 
-        self.assert_(np.isnan(added['C'].reindex(frame_copy.index)[:5]).all())
+        self.assertTrue(np.isnan(added['C'].reindex(frame_copy.index)[:5]).all())
 
         # assert(False)
 
-        self.assert_(np.isnan(added['D']).all())
+        self.assertTrue(np.isnan(added['D']).all())
 
         self_added = self.frame + self.frame
-        self.assert_(self_added.index.equals(self.frame.index))
+        self.assertTrue(self_added.index.equals(self.frame.index))
 
         added_rev = frame_copy + self.frame
-        self.assert_(np.isnan(added['D']).all())
+        self.assertTrue(np.isnan(added['D']).all())
 
         # corner cases
 
         # empty
         plus_empty = self.frame + self.empty
-        self.assert_(np.isnan(plus_empty.values).all())
+        self.assertTrue(np.isnan(plus_empty.values).all())
 
         empty_plus = self.empty + self.frame
-        self.assert_(np.isnan(empty_plus.values).all())
+        self.assertTrue(np.isnan(empty_plus.values).all())
 
         empty_empty = self.empty + self.empty
         self.assertTrue(empty_empty.empty)
@@ -5303,7 +5303,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         for key, s in compat.iteritems(self.frame):
             assert_series_equal(larger_added[key], s + series[key])
         self.assertIn('E', larger_added)
-        self.assert_(np.isnan(larger_added['E']).all())
+        self.assertTrue(np.isnan(larger_added['E']).all())
 
         # vs mix (upcast) as needed
         added = self.mixed_float + series
@@ -5335,7 +5335,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             smaller_frame = self.tsframe[:-5]
             smaller_added = smaller_frame + ts
 
-            self.assert_(smaller_added.index.equals(self.tsframe.index))
+            self.assertTrue(smaller_added.index.equals(self.tsframe.index))
 
             smaller_ts = ts[:-5]
             smaller_added2 = self.tsframe + smaller_ts
@@ -5960,7 +5960,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             df = _make_frame(True)
             df.to_csv(path,tupleize_cols=False,index=False)
             result = read_csv(path,header=[0,1],tupleize_cols=False)
-            self.assert_(all([ x is None for x in result.columns.names ]))
+            self.assertTrue(all([ x is None for x in result.columns.names ]))
             result.columns.names = df.columns.names
             assert_frame_equal(df,result)
 
@@ -6015,7 +6015,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             exp = tsframe[:0]
             exp.index = []
 
-            self.assert_(recons.columns.equals(exp.columns))
+            self.assertTrue(recons.columns.equals(exp.columns))
             self.assertEqual(len(recons), 0)
 
     def test_to_csv_float32_nanrep(self):
@@ -6294,7 +6294,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         io = StringIO()
         df.info(buf=io, max_cols=101)
         rs = io.getvalue()
-        self.assert_(len(rs.splitlines()) > 100)
+        self.assertTrue(len(rs.splitlines()) > 100)
         xp = rs
 
         set_option('display.max_info_columns', 101)
@@ -6621,7 +6621,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             for j, value in enumerate(row):
                 col = frameCols[j]
                 if np.isnan(value):
-                    self.assert_(np.isnan(frame[col][i]))
+                    self.assertTrue(np.isnan(frame[col][i]))
                 else:
                     self.assertEqual(value, frame[col][i])
 
@@ -6659,7 +6659,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
     def test_values(self):
         self.frame.values[:, 0] = 5.
-        self.assert_((self.frame.values[:, 0] == 5).all())
+        self.assertTrue((self.frame.values[:, 0] == 5).all())
 
     def test_deepcopy(self):
         cp = deepcopy(self.frame)
@@ -6726,8 +6726,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             df = DataFrame({'A': [1, 1.5, 1, np.nan, np.nan, np.nan],
                             'B': [np.nan, np.nan, np.nan, 1, 1.5, 1]})
             rs = df.corr(meth)
-            self.assert_(isnull(rs.ix['A', 'B']))
-            self.assert_(isnull(rs.ix['B', 'A']))
+            self.assertTrue(isnull(rs.ix['A', 'B']))
+            self.assertTrue(isnull(rs.ix['B', 'A']))
             self.assertEqual(rs.ix['A', 'A'], 1)
             self.assertEqual(rs.ix['B', 'B'], 1)
 
@@ -6740,7 +6740,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             df = DataFrame({'A': [1, 1, 1, np.nan, np.nan, np.nan],
                             'B': [np.nan, np.nan, np.nan, 1, 1, 1]})
             rs = df.corr(meth)
-            self.assert_(isnull(rs.values).all())
+            self.assertTrue(isnull(rs.values).all())
 
     def test_corr_int(self):
         # dtypes other than float64 #1761
@@ -6758,7 +6758,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_frame_equal(expected, result)
 
         result = self.frame.cov(min_periods=len(self.frame) + 1)
-        self.assert_(isnull(result.values).all())
+        self.assertTrue(isnull(result.values).all())
 
         # with NAs
         frame = self.frame.copy()
@@ -6855,7 +6855,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         c2 = np.corrcoef(df1['a'],df2['a'])[0][1]
 
         assert_almost_equal(c1, c2)
-        self.assert_(c1 < 1)
+        self.assertTrue(c1 < 1)
 
     def test_drop_names(self):
         df = DataFrame([[1, 2, 3],[3, 4, 5],[5, 6, 7]], index=['a', 'b', 'c'],
@@ -6911,10 +6911,10 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         samesize_frame = frame.dropna(subset=['bar'])
         assert_series_equal(frame['foo'], original)
-        self.assert_((frame['bar'] == 5).all())
+        self.assertTrue((frame['bar'] == 5).all())
         inp_frame2.dropna(subset=['bar'], inplace=True)
-        self.assert_(samesize_frame.index.equals(self.frame.index))
-        self.assert_(inp_frame2.index.equals(self.frame.index))
+        self.assertTrue(samesize_frame.index.equals(self.frame.index))
+        self.assertTrue(inp_frame2.index.equals(self.frame.index))
 
     def test_dropna(self):
         df = DataFrame(np.random.randn(6, 4))
@@ -7270,11 +7270,11 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.tsframe['A'][-5:] = nan
 
         zero_filled = self.tsframe.fillna(0)
-        self.assert_((zero_filled['A'][:5] == 0).all())
+        self.assertTrue((zero_filled['A'][:5] == 0).all())
 
         padded = self.tsframe.fillna(method='pad')
-        self.assert_(np.isnan(padded['A'][:5]).all())
-        self.assert_((padded['A'][-5:] == padded['A'][-5]).all())
+        self.assertTrue(np.isnan(padded['A'][:5]).all())
+        self.assertTrue((padded['A'][-5:] == padded['A'][-5]).all())
 
         # mixed type
         self.mixed_frame['foo'][5:20] = nan
@@ -8182,7 +8182,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # bools
         df = DataFrame({'bools': [True, False, True]})
         result = df.replace(False, True)
-        self.assert_(result.values.all())
+        self.assertTrue(result.values.all())
 
         # complex blocks
         df = DataFrame({'complex': [1j, 2j, 3j]})
@@ -8407,7 +8407,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         xs = self.frame.xs(idx)
         for item, value in compat.iteritems(xs):
             if np.isnan(value):
-                self.assert_(np.isnan(self.frame[item][idx]))
+                self.assertTrue(np.isnan(self.frame[item][idx]))
             else:
                 self.assertEqual(value, self.frame[item][idx])
 
@@ -8433,7 +8433,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # view is returned if possible
         series = self.frame.xs('A', axis=1)
         series[:] = 5
-        self.assert_((expected == 5).all())
+        self.assertTrue((expected == 5).all())
 
     def test_xs_corner(self):
         # pathological mixed-type reordering case
@@ -8533,14 +8533,14 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             for idx, val in compat.iteritems(newFrame[col]):
                 if idx in self.frame.index:
                     if np.isnan(val):
-                        self.assert_(np.isnan(self.frame[col][idx]))
+                        self.assertTrue(np.isnan(self.frame[col][idx]))
                     else:
                         self.assertEqual(val, self.frame[col][idx])
                 else:
-                    self.assert_(np.isnan(val))
+                    self.assertTrue(np.isnan(val))
 
         for col, series in compat.iteritems(newFrame):
-            self.assert_(tm.equalContents(series.index, newFrame.index))
+            self.assertTrue(tm.equalContents(series.index, newFrame.index))
         emptyFrame = self.frame.reindex(Index([]))
         self.assertEqual(len(emptyFrame.index), 0)
 
@@ -8551,14 +8551,14 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             for idx, val in compat.iteritems(nonContigFrame[col]):
                 if idx in self.frame.index:
                     if np.isnan(val):
-                        self.assert_(np.isnan(self.frame[col][idx]))
+                        self.assertTrue(np.isnan(self.frame[col][idx]))
                     else:
                         self.assertEqual(val, self.frame[col][idx])
                 else:
-                    self.assert_(np.isnan(val))
+                    self.assertTrue(np.isnan(val))
 
         for col, series in compat.iteritems(nonContigFrame):
-            self.assert_(tm.equalContents(series.index,
+            self.assertTrue(tm.equalContents(series.index,
                                           nonContigFrame.index))
 
         # corner cases
@@ -8569,7 +8569,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # length zero
         newFrame = self.frame.reindex([])
-        self.assert_(newFrame.empty)
+        self.assertTrue(newFrame.empty)
         self.assertEqual(len(newFrame.columns), len(self.frame.columns))
 
         # length zero with columns reindexed with non-empty index
@@ -8580,7 +8580,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # pass non-Index
         newFrame = self.frame.reindex(list(self.ts1.index))
-        self.assert_(newFrame.index.equals(self.ts1.index))
+        self.assertTrue(newFrame.index.equals(self.ts1.index))
 
         # copy with no axes
         result = self.frame.reindex()
@@ -8625,12 +8625,12 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         newFrame = self.frame.reindex(columns=['A', 'B', 'E'])
 
         assert_series_equal(newFrame['B'], self.frame['B'])
-        self.assert_(np.isnan(newFrame['E']).all())
+        self.assertTrue(np.isnan(newFrame['E']).all())
         self.assertNotIn('C', newFrame)
 
         # length zero
         newFrame = self.frame.reindex(columns=[])
-        self.assert_(newFrame.empty)
+        self.assertTrue(newFrame.empty)
 
     def test_reindex_axes(self):
 
@@ -8651,7 +8651,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # axis=0
         result = df.reindex(lrange(15))
-        self.assert_(np.isnan(result.values[-5:]).all())
+        self.assertTrue(np.isnan(result.values[-5:]).all())
 
         result = df.reindex(lrange(15), fill_value=0)
         expected = df.reindex(lrange(15)).fillna(0)
@@ -8713,25 +8713,25 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # axis = 0
         other = self.frame.ix[:-5, :3]
         af, bf = self.frame.align(other, axis=0, fill_value=-1)
-        self.assert_(bf.columns.equals(other.columns))
+        self.assertTrue(bf.columns.equals(other.columns))
         # test fill value
         join_idx = self.frame.index.join(other.index)
         diff_a = self.frame.index.diff(join_idx)
         diff_b = other.index.diff(join_idx)
         diff_a_vals = af.reindex(diff_a).values
         diff_b_vals = bf.reindex(diff_b).values
-        self.assert_((diff_a_vals == -1).all())
+        self.assertTrue((diff_a_vals == -1).all())
 
         af, bf = self.frame.align(other, join='right', axis=0)
-        self.assert_(bf.columns.equals(other.columns))
-        self.assert_(bf.index.equals(other.index))
-        self.assert_(af.index.equals(other.index))
+        self.assertTrue(bf.columns.equals(other.columns))
+        self.assertTrue(bf.index.equals(other.index))
+        self.assertTrue(af.index.equals(other.index))
 
         # axis = 1
         other = self.frame.ix[:-5, :3].copy()
         af, bf = self.frame.align(other, axis=1)
-        self.assert_(bf.columns.equals(self.frame.columns))
-        self.assert_(bf.index.equals(other.index))
+        self.assertTrue(bf.columns.equals(self.frame.columns))
+        self.assertTrue(bf.index.equals(other.index))
 
         # test fill value
         join_idx = self.frame.index.join(other.index)
@@ -8739,38 +8739,38 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         diff_b = other.index.diff(join_idx)
         diff_a_vals = af.reindex(diff_a).values
         diff_b_vals = bf.reindex(diff_b).values
-        self.assert_((diff_a_vals == -1).all())
+        self.assertTrue((diff_a_vals == -1).all())
 
         af, bf = self.frame.align(other, join='inner', axis=1)
-        self.assert_(bf.columns.equals(other.columns))
+        self.assertTrue(bf.columns.equals(other.columns))
 
         af, bf = self.frame.align(other, join='inner', axis=1, method='pad')
-        self.assert_(bf.columns.equals(other.columns))
+        self.assertTrue(bf.columns.equals(other.columns))
 
         # test other non-float types
         af, bf = self.intframe.align(other, join='inner', axis=1, method='pad')
-        self.assert_(bf.columns.equals(other.columns))
+        self.assertTrue(bf.columns.equals(other.columns))
 
         af, bf = self.mixed_frame.align(self.mixed_frame,
                                         join='inner', axis=1, method='pad')
-        self.assert_(bf.columns.equals(self.mixed_frame.columns))
+        self.assertTrue(bf.columns.equals(self.mixed_frame.columns))
 
         af, bf = self.frame.align(other.ix[:, 0], join='inner', axis=1,
                                   method=None, fill_value=None)
-        self.assert_(bf.index.equals(Index([])))
+        self.assertTrue(bf.index.equals(Index([])))
 
         af, bf = self.frame.align(other.ix[:, 0], join='inner', axis=1,
                                   method=None, fill_value=0)
-        self.assert_(bf.index.equals(Index([])))
+        self.assertTrue(bf.index.equals(Index([])))
 
         # mixed floats/ints
         af, bf = self.mixed_float.align(other.ix[:, 0], join='inner', axis=1,
                                         method=None, fill_value=0)
-        self.assert_(bf.index.equals(Index([])))
+        self.assertTrue(bf.index.equals(Index([])))
 
         af, bf = self.mixed_int.align(other.ix[:, 0], join='inner', axis=1,
                                         method=None, fill_value=0)
-        self.assert_(bf.index.equals(Index([])))
+        self.assertTrue(bf.index.equals(Index([])))
 
         # try to align dataframe to series along bad axis
         self.assertRaises(ValueError, self.frame.align, af.ix[0, :3],
@@ -8884,7 +8884,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
             # dtypes
             if check_dtypes:
-                self.assert_((rs.dtypes == df.dtypes).all() == True)
+                self.assertTrue((rs.dtypes == df.dtypes).all() == True)
 
         # check getting
         for df in [ default_frame, self.mixed_frame, self.mixed_float, self.mixed_int ]:
@@ -8930,7 +8930,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             # can't check dtype when other is an ndarray
 
             if check_dtypes and not isinstance(other,np.ndarray):
-                self.assert_((rs.dtypes == df.dtypes).all() == True)
+                self.assertTrue((rs.dtypes == df.dtypes).all() == True)
 
         for df in [ self.mixed_frame, self.mixed_float, self.mixed_int ]:
 
@@ -9094,7 +9094,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         for idx, series in compat.iteritems(dft):
             for col, value in compat.iteritems(series):
                 if np.isnan(value):
-                    self.assert_(np.isnan(frame[col][idx]))
+                    self.assertTrue(np.isnan(frame[col][idx]))
                 else:
                     self.assertEqual(value, frame[col][idx])
 
@@ -9110,7 +9110,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         dft = self.frame.T
         dft.values[:, 5:10] = 5
 
-        self.assert_((self.frame.values[5:10] == 5).all())
+        self.assertTrue((self.frame.values[5:10] == 5).all())
 
     #----------------------------------------------------------------------
     # Renaming
@@ -9179,7 +9179,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
     def test_rename_nocopy(self):
         renamed = self.frame.rename(columns={'C': 'foo'}, copy=False)
         renamed['foo'] = 1.
-        self.assert_((self.frame['C'] == 1.).all())
+        self.assertTrue((self.frame['C'] == 1.).all())
 
     def test_rename_inplace(self):
         self.frame.rename(columns={'C': 'foo'})
@@ -9275,13 +9275,13 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
     def test_shift(self):
         # naive shift
         shiftedFrame = self.tsframe.shift(5)
-        self.assert_(shiftedFrame.index.equals(self.tsframe.index))
+        self.assertTrue(shiftedFrame.index.equals(self.tsframe.index))
 
         shiftedSeries = self.tsframe['A'].shift(5)
         assert_series_equal(shiftedFrame['A'], shiftedSeries)
 
         shiftedFrame = self.tsframe.shift(-5)
-        self.assert_(shiftedFrame.index.equals(self.tsframe.index))
+        self.assertTrue(shiftedFrame.index.equals(self.tsframe.index))
 
         shiftedSeries = self.tsframe['A'].shift(-5)
         assert_series_equal(shiftedFrame['A'], shiftedSeries)
@@ -9309,7 +9309,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         ps = tm.makePeriodFrame()
         shifted = ps.shift(1)
         unshifted = shifted.shift(-1)
-        self.assert_(shifted.index.equals(ps.index))
+        self.assertTrue(shifted.index.equals(ps.index))
 
         tm.assert_dict_equal(unshifted.ix[:, 0].valid(), ps.ix[:, 0],
                              compare_keys=False)
@@ -9403,10 +9403,10 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
     def test_apply_empty(self):
         # empty
         applied = self.empty.apply(np.sqrt)
-        self.assert_(applied.empty)
+        self.assertTrue(applied.empty)
 
         applied = self.empty.apply(np.mean)
-        self.assert_(applied.empty)
+        self.assertTrue(applied.empty)
 
         no_rows = self.frame[:0]
         result = no_rows.apply(lambda x: x.mean())
@@ -9454,12 +9454,12 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         agged = self.frame.apply(np.mean)
 
         for col, ts in compat.iteritems(broadcasted):
-            self.assert_((ts == agged[col]).all())
+            self.assertTrue((ts == agged[col]).all())
 
         broadcasted = self.frame.apply(np.mean, axis=1, broadcast=True)
         agged = self.frame.apply(np.mean, axis=1)
         for idx in broadcasted.index:
-            self.assert_((broadcasted.xs(idx) == agged[idx]).all())
+            self.assertTrue((broadcasted.xs(idx) == agged[idx]).all())
 
     def test_apply_raw(self):
         result0 = self.frame.apply(np.mean, raw=True)
@@ -10199,7 +10199,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         combined = head.combine_first(tail)
         reordered_frame = self.frame.reindex(combined.index)
         assert_frame_equal(combined, reordered_frame)
-        self.assert_(tm.equalContents(combined.columns, self.frame.columns))
+        self.assertTrue(tm.equalContents(combined.columns, self.frame.columns))
         assert_series_equal(combined['A'], reordered_frame['A'])
 
         # same index
@@ -10213,7 +10213,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         combined = fcopy.combine_first(fcopy2)
 
-        self.assert_((combined['A'] == 1).all())
+        self.assertTrue((combined['A'] == 1).all())
         assert_series_equal(combined['B'], fcopy['B'])
         assert_series_equal(combined['C'], fcopy2['C'])
         assert_series_equal(combined['D'], fcopy['D'])
@@ -10223,12 +10223,12 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         head['A'] = 1
 
         combined = head.combine_first(tail)
-        self.assert_((combined['A'][:10] == 1).all())
+        self.assertTrue((combined['A'][:10] == 1).all())
 
         # reverse overlap
         tail['A'][:10] = 0
         combined = tail.combine_first(head)
-        self.assert_((combined['A'][:10] == 0).all())
+        self.assertTrue((combined['A'][:10] == 0).all())
 
         # no overlap
         f = self.frame[:10]
@@ -10485,8 +10485,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         combined = df1.combine(df2, np.add)
         combined2 = df2.combine(df1, np.add)
-        self.assert_(combined['D'].isnull().all())
-        self.assert_(combined2['D'].isnull().all())
+        self.assertTrue(combined['D'].isnull().all())
+        self.assertTrue(combined2['D'].isnull().all())
 
         chunk = combined.ix[:-5, ['A', 'B', 'C']]
         chunk2 = combined2.ix[:-5, ['A', 'B', 'C']]
@@ -10519,9 +10519,9 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             lb_mask = df.values <= lb
             ub_mask = df.values >= ub
             mask = ~lb_mask & ~ub_mask
-            self.assert_((clipped_df.values[lb_mask] == lb).all() == True)
-            self.assert_((clipped_df.values[ub_mask] == ub).all() == True)
-            self.assert_((clipped_df.values[mask] == df.values[mask]).all() == True)
+            self.assertTrue((clipped_df.values[lb_mask] == lb).all() == True)
+            self.assertTrue((clipped_df.values[ub_mask] == ub).all() == True)
+            self.assertTrue((clipped_df.values[mask] == df.values[mask]).all() == True)
 
     def test_get_X_columns(self):
         # numeric and object columns
@@ -10537,7 +10537,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
     def test_is_mixed_type(self):
         self.assertFalse(self.frame._is_mixed_type)
-        self.assert_(self.mixed_frame._is_mixed_type)
+        self.assertTrue(self.mixed_frame._is_mixed_type)
 
     def test_get_numeric_data(self):
         intname = np.dtype(np.int_).name
@@ -10823,7 +10823,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             df['a'] = lrange(len(df))
             result = getattr(df, name)()
             self.assertIsInstance(result, Series)
-            self.assert_(len(result))
+            self.assertTrue(len(result))
 
         if has_skipna:
             def skipna_wrapper(x):
@@ -10883,8 +10883,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             all_na = self.frame * np.NaN
             r0 = getattr(all_na, name)(axis=0)
             r1 = getattr(all_na, name)(axis=1)
-            self.assert_(np.isnan(r0).all())
-            self.assert_(np.isnan(r1).all())
+            self.assertTrue(np.isnan(r0).all())
+            self.assertTrue(np.isnan(r1).all())
 
     def test_mode(self):
         df = pd.DataFrame({"A": [12, 12, 11, 12, 19, 11],
@@ -10964,13 +10964,13 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # unit test when have object data
         the_mean = self.mixed_frame.mean(axis=0)
         the_sum = self.mixed_frame.sum(axis=0, numeric_only=True)
-        self.assert_(the_sum.index.equals(the_mean.index))
-        self.assert_(len(the_mean.index) < len(self.mixed_frame.columns))
+        self.assertTrue(the_sum.index.equals(the_mean.index))
+        self.assertTrue(len(the_mean.index) < len(self.mixed_frame.columns))
 
         # xs sum mixed type, just want to know it works...
         the_mean = self.mixed_frame.mean(axis=1)
         the_sum = self.mixed_frame.sum(axis=1, numeric_only=True)
-        self.assert_(the_sum.index.equals(the_mean.index))
+        self.assertTrue(the_sum.index.equals(the_mean.index))
 
         # take mean of boolean column
         self.frame['bool'] = self.frame['A'] > 0
@@ -11296,11 +11296,11 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         reindexed = frame.reindex(np.arange(10))
         self.assertEqual(reindexed.values.dtype, np.object_)
-        self.assert_(isnull(reindexed[0][1]))
+        self.assertTrue(isnull(reindexed[0][1]))
 
         reindexed = frame.reindex(columns=lrange(3))
         self.assertEqual(reindexed.values.dtype, np.object_)
-        self.assert_(isnull(reindexed[1]).all())
+        self.assertTrue(isnull(reindexed[1]).all())
 
     def test_reindex_objects(self):
         reindexed = self.mixed_frame.reindex(columns=['foo', 'A', 'B'])
@@ -11313,7 +11313,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         index = Index(['a', 'b', 'c'])
         dm = self.empty.reindex(index=[1, 2, 3])
         reindexed = dm.reindex(columns=index)
-        self.assert_(reindexed.columns.equals(index))
+        self.assertTrue(reindexed.columns.equals(index))
 
         # ints are weird
 
@@ -11394,7 +11394,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.mixed_frame['A'][-10:] = nan
 
         filled = self.mixed_frame.fillna(value=0)
-        self.assert_((filled['foo'][5:20] == 0).all())
+        self.assertTrue((filled['foo'][5:20] == 0).all())
         del self.mixed_frame['foo']
 
         empty_float = self.frame.reindex(columns=[])
@@ -11786,14 +11786,14 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
     def test_constructor_frame_copy(self):
         cop = DataFrame(self.frame, copy=True)
         cop['A'] = 5
-        self.assert_((cop['A'] == 5).all())
+        self.assertTrue((cop['A'] == 5).all())
         self.assertFalse((self.frame['A'] == 5).all())
 
     def test_constructor_ndarray_copy(self):
         df = DataFrame(self.frame.values)
 
         self.frame.values[5] = 5
-        self.assert_((df.values[5] == 5).all())
+        self.assertTrue((df.values[5] == 5).all())
 
         df = DataFrame(self.frame.values, copy=True)
         self.frame.values[6] = 6
@@ -11940,16 +11940,16 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.frame['E'] = 7.
         self.assertFalse(self.frame._data.is_consolidated())
         _ = self.frame.as_matrix()
-        self.assert_(self.frame._data.is_consolidated())
+        self.assertTrue(self.frame._data.is_consolidated())
 
     def test_modify_values(self):
         self.frame.values[5] = 5
-        self.assert_((self.frame.values[5] == 5).all())
+        self.assertTrue((self.frame.values[5] == 5).all())
 
         # unconsolidated
         self.frame['E'] = 7.
         self.frame.values[6] = 6
-        self.assert_((self.frame.values[6] == 6).all())
+        self.assertTrue((self.frame.values[6] == 6).all())
 
     def test_boolean_set_uncons(self):
         self.frame['E'] = 7.
@@ -11970,7 +11970,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                        index=lrange(4), columns=lrange(5))
 
         dm.xs(2)[:] = 10
-        self.assert_((dm.xs(2) == 10).all())
+        self.assertTrue((dm.xs(2) == 10).all())
 
     def test_boolean_indexing(self):
         idx = lrange(3)
@@ -12203,7 +12203,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         repr(Y)
         result = Y.sum()
         exp = Y['g'].sum()
-        self.assert_(isnull(Y['g']['c']))
+        self.assertTrue(isnull(Y['g']['c']))
 
     def test_index_namedtuple(self):
         from collections import namedtuple
@@ -12368,8 +12368,8 @@ starting,ending,measure
                 self.assertFalse(r0.any())
                 self.assertFalse(r1.any())
             else:
-                self.assert_(r0.all())
-                self.assert_(r1.all())
+                self.assertTrue(r0.all())
+                self.assertTrue(r1.all())
 
     def test_strange_column_corruption_issue(self):
         df = DataFrame(index=[0, 1])

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -684,13 +684,13 @@ class TestSeries(tm.TestCase, Generic):
         result = pd.Series().describe()
 
         self.assertEqual(result['count'], 0)
-        self.assert_(result.drop('count').isnull().all())
+        self.assertTrue(result.drop('count').isnull().all())
 
         nanSeries = Series([np.nan])
         nanSeries.name = 'NaN'
         result = nanSeries.describe()
         self.assertEqual(result['count'], 0)
-        self.assert_(result.drop('count').isnull().all())
+        self.assertTrue(result.drop('count').isnull().all())
 
     def test_describe_none(self):
         noneSeries = Series([None])
@@ -978,7 +978,7 @@ class TestDataFrame(tm.TestCase, Generic):
         desc = df[df[0] < 0].describe()  # works
         assert_series_equal(desc.xs('count'),
                             Series([0, 0], dtype=float, name='count'))
-        self.assert_(isnull(desc.ix[1:]).all().all())
+        self.assertTrue(isnull(desc.ix[1:]).all().all())
 
     def test_describe_objects(self):
         df = DataFrame({"C1": ['a', 'a', 'c'], "C2": ['d', 'd', 'f']})
@@ -1145,7 +1145,7 @@ class TestNDFrame(tm.TestCase):
     def test_equals(self):
         s1 = pd.Series([1, 2, 3], index=[0, 2, 1])
         s2 = s1.copy()
-        self.assert_(s1.equals(s2))
+        self.assertTrue(s1.equals(s2))
 
         s1[1] = 99
         self.assertFalse(s1.equals(s2))
@@ -1153,7 +1153,7 @@ class TestNDFrame(tm.TestCase):
         # NaNs compare as equal
         s1 = pd.Series([1, np.nan, 3, np.nan], index=[0, 2, 1, 3])
         s2 = s1.copy()
-        self.assert_(s1.equals(s2))
+        self.assertTrue(s1.equals(s2))
 
         s2[0] = 9.9
         self.assertFalse(s1.equals(s2))
@@ -1161,7 +1161,7 @@ class TestNDFrame(tm.TestCase):
         idx = MultiIndex.from_tuples([(0, 'a'), (1, 'b'), (2, 'c')])
         s1 = Series([1, 2, np.nan], index=idx)
         s2 = s1.copy()
-        self.assert_(s1.equals(s2))
+        self.assertTrue(s1.equals(s2))
 
         # Add object dtype column with nans
         index = np.random.random(10)
@@ -1173,12 +1173,12 @@ class TestNDFrame(tm.TestCase):
         df1['bool'] = (np.arange(10) % 3 == 0)
         df1.ix[::2] = nan
         df2 = df1.copy()
-        self.assert_(df1['text'].equals(df2['text']))
-        self.assert_(df1['start'].equals(df2['start']))
-        self.assert_(df1['end'].equals(df2['end']))
-        self.assert_(df1['diff'].equals(df2['diff']))
-        self.assert_(df1['bool'].equals(df2['bool']))
-        self.assert_(df1.equals(df2))
+        self.assertTrue(df1['text'].equals(df2['text']))
+        self.assertTrue(df1['start'].equals(df2['start']))
+        self.assertTrue(df1['end'].equals(df2['end']))
+        self.assertTrue(df1['diff'].equals(df2['diff']))
+        self.assertTrue(df1['bool'].equals(df2['bool']))
+        self.assertTrue(df1.equals(df2))
         self.assertFalse(df1.equals(object))
 
         # different dtype
@@ -1200,12 +1200,12 @@ class TestNDFrame(tm.TestCase):
         index = pd.date_range('2000-1-1', periods=10, freq='T')
         df1 = df1.set_index(index)
         df2 = df1.copy()
-        self.assert_(df1.equals(df2))
+        self.assertTrue(df1.equals(df2))
 
         # MultiIndex
         df3 = df1.set_index(['text'], append=True)
         df2 = df1.set_index(['text'], append=True)
-        self.assert_(df3.equals(df2))
+        self.assertTrue(df3.equals(df2))
 
         df2 = df1.set_index(['floats'], append=True)
         self.assertFalse(df3.equals(df2))
@@ -1213,7 +1213,7 @@ class TestNDFrame(tm.TestCase):
         # NaN in index
         df3 = df1.set_index(['floats'], append=True)
         df2 = df1.set_index(['floats'], append=True)
-        self.assert_(df3.equals(df2))
+        self.assertTrue(df3.equals(df2))
 
     def test_describe_raises(self):
         with tm.assertRaises(NotImplementedError):

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -295,7 +295,7 @@ class TestPlotBase(tm.TestCase):
             self.assertEqual(len(visible_axes), axes_num)
             for ax in visible_axes:
                 # check something drawn on visible axes
-                self.assert_(len(ax.get_children()) > 0)
+                self.assertTrue(len(ax.get_children()) > 0)
 
         if layout is not None:
             if isinstance(axes, list):
@@ -1870,7 +1870,7 @@ class TestDataFramePlots(TestPlotBase):
                        columns=['test'])
         ax = df.plot()
         xticks = ax.lines[0].get_xdata()
-        self.assert_(xticks[0] < xticks[1])
+        self.assertTrue(xticks[0] < xticks[1])
         ydata = ax.lines[0].get_ydata()
         assert_array_equal(ydata, np.array([1.0, 2.0, 3.0]))
 
@@ -2137,9 +2137,9 @@ class TestDataFramePlots(TestPlotBase):
         _check_plot_works(df.plot, table=df)
 
         ax = df.plot()
-        self.assert_(len(ax.tables) == 0)
+        self.assertTrue(len(ax.tables) == 0)
         plotting.table(ax, df.T)
-        self.assert_(len(ax.tables) == 1)
+        self.assertTrue(len(ax.tables) == 1)
 
     def test_errorbar_scatter(self):
         df = DataFrame(np.random.randn(5, 2), index=range(5), columns=['x', 'y'])

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -194,9 +194,9 @@ class TestGroupBy(tm.TestCase):
         grouped['B'].nth(0)
 
         self.df.loc[self.df['A'] == 'foo', 'B'] = np.nan
-        self.assert_(com.isnull(grouped['B'].first()['foo']))
-        self.assert_(com.isnull(grouped['B'].last()['foo']))
-        self.assert_(com.isnull(grouped['B'].nth(0)[0]))  # not sure what this is testing
+        self.assertTrue(com.isnull(grouped['B'].first()['foo']))
+        self.assertTrue(com.isnull(grouped['B'].last()['foo']))
+        self.assertTrue(com.isnull(grouped['B'].nth(0)[0]))  # not sure what this is testing
 
         # v0.14.0 whatsnew
         df = DataFrame([[1, np.nan], [1, 4], [5, 6]], columns=['A', 'B'])
@@ -658,14 +658,14 @@ class TestGroupBy(tm.TestCase):
         self.assertIs(groups, grouped.groups)  # caching works
 
         for k, v in compat.iteritems(grouped.groups):
-            self.assert_((self.df.ix[v]['A'] == k).all())
+            self.assertTrue((self.df.ix[v]['A'] == k).all())
 
         grouped = self.df.groupby(['A', 'B'])
         groups = grouped.groups
         self.assertIs(groups, grouped.groups)  # caching works
         for k, v in compat.iteritems(grouped.groups):
-            self.assert_((self.df.ix[v]['A'] == k[0]).all())
-            self.assert_((self.df.ix[v]['B'] == k[1]).all())
+            self.assertTrue((self.df.ix[v]['A'] == k[0]).all())
+            self.assertTrue((self.df.ix[v]['B'] == k[1]).all())
 
     def test_aggregate_str_func(self):
 
@@ -764,13 +764,13 @@ class TestGroupBy(tm.TestCase):
         grouped = self.ts.groupby(lambda x: x.month)
         result = grouped.transform(np.mean)
 
-        self.assert_(result.index.equals(self.ts.index))
+        self.assertTrue(result.index.equals(self.ts.index))
         for _, gp in grouped:
             assert_fp_equal(result.reindex(gp.index), gp.mean())
 
         grouped = self.tsframe.groupby(lambda x: x.month)
         result = grouped.transform(np.mean)
-        self.assert_(result.index.equals(self.tsframe.index))
+        self.assertTrue(result.index.equals(self.tsframe.index))
         for _, gp in grouped:
             agged = gp.mean()
             res = result.reindex(gp.index)
@@ -781,8 +781,8 @@ class TestGroupBy(tm.TestCase):
         grouped = self.tsframe.groupby({'A': 0, 'B': 0, 'C': 1, 'D': 1},
                                        axis=1)
         result = grouped.transform(np.mean)
-        self.assert_(result.index.equals(self.tsframe.index))
-        self.assert_(result.columns.equals(self.tsframe.columns))
+        self.assertTrue(result.index.equals(self.tsframe.index))
+        self.assertTrue(result.columns.equals(self.tsframe.columns))
         for _, gp in grouped:
             agged = gp.mean(1)
             res = result.reindex(columns=gp.columns)
@@ -857,7 +857,7 @@ class TestGroupBy(tm.TestCase):
             expected = Series([4, 2], index=['bar', 'foo'])
 
             assert_series_equal(agged, expected, check_dtype=False)
-            #self.assert_(issubclass(agged.dtype.type, np.integer))
+            #self.assertTrue(issubclass(agged.dtype.type, np.integer))
 
             # explicity return a float from my function
             def f(x):
@@ -867,7 +867,7 @@ class TestGroupBy(tm.TestCase):
             expected = Series([4, 2], index=['bar', 'foo'])
 
             assert_series_equal(agged, expected, check_dtype=False)
-            self.assert_(issubclass(agged.dtype.type, np.dtype(dtype).type))
+            self.assertTrue(issubclass(agged.dtype.type, np.dtype(dtype).type))
 
     def test_groupby_transform_with_int(self):
 
@@ -1502,7 +1502,7 @@ class TestGroupBy(tm.TestCase):
                                 lambda x: x.day], axis=1)
 
         agged = grouped.agg(lambda x: x.sum(1))
-        self.assert_(agged.index.equals(df.columns))
+        self.assertTrue(agged.index.equals(df.columns))
         assert_almost_equal(df.T.values, agged.values)
 
         agged = grouped.agg(lambda x: x.sum(1))
@@ -1841,7 +1841,7 @@ class TestGroupBy(tm.TestCase):
         result = grouped.apply(f)
 
         tm.assert_isinstance(result, DataFrame)
-        self.assert_(result.index.equals(ts.index))
+        self.assertTrue(result.index.equals(ts.index))
 
     def test_apply_series_yield_constant(self):
         result = self.df.groupby(['A', 'B'])['C'].apply(len)
@@ -1851,7 +1851,7 @@ class TestGroupBy(tm.TestCase):
         grouped = self.df.groupby(['A', 'B'])
         result = grouped.apply(len)
         expected = grouped.count()['C']
-        self.assert_(result.index.equals(expected.index))
+        self.assertTrue(result.index.equals(expected.index))
         self.assert_numpy_array_equal(result.values, expected.values)
 
     def test_apply_frame_concat_series(self):
@@ -1955,26 +1955,26 @@ class TestGroupBy(tm.TestCase):
                        columns=columns)
 
         result = df.groupby(level=0).mean()
-        self.assert_(result.columns.equals(columns))
+        self.assertTrue(result.columns.equals(columns))
 
         result = df.groupby(level=0, axis=1).mean()
-        self.assert_(result.index.equals(df.index))
+        self.assertTrue(result.index.equals(df.index))
 
         result = df.groupby(level=0).agg(np.mean)
-        self.assert_(result.columns.equals(columns))
+        self.assertTrue(result.columns.equals(columns))
 
         result = df.groupby(level=0).apply(lambda x: x.mean())
-        self.assert_(result.columns.equals(columns))
+        self.assertTrue(result.columns.equals(columns))
 
         result = df.groupby(level=0, axis=1).agg(lambda x: x.mean(1))
-        self.assert_(result.columns.equals(Index(['A', 'B'])))
-        self.assert_(result.index.equals(df.index))
+        self.assertTrue(result.columns.equals(Index(['A', 'B'])))
+        self.assertTrue(result.index.equals(df.index))
 
         # add a nuisance column
         sorted_columns, _ = columns.sortlevel(0)
         df['A', 'foo'] = 'bar'
         result = df.groupby(level=0).mean()
-        self.assert_(result.columns.equals(df.columns[:-1]))
+        self.assertTrue(result.columns.equals(df.columns[:-1]))
 
     def test_pass_args_kwargs(self):
         from numpy import percentile
@@ -2343,7 +2343,7 @@ class TestGroupBy(tm.TestCase):
         inds = np.tile(lrange(10), 10)
 
         result = obj.groupby(inds).agg(Series.median)
-        self.assert_(result.isnull().all())
+        self.assertTrue(result.isnull().all())
 
     def test_series_grouper_noncontig_index(self):
         index = Index([tm.rands(10) for _ in range(100)])
@@ -2545,10 +2545,10 @@ class TestGroupBy(tm.TestCase):
         right = rg.sum()['values']
 
         exp_index, _ = left.index.sortlevel(0)
-        self.assert_(left.index.equals(exp_index))
+        self.assertTrue(left.index.equals(exp_index))
 
         exp_index, _ = right.index.sortlevel(0)
-        self.assert_(right.index.equals(exp_index))
+        self.assertTrue(right.index.equals(exp_index))
 
         tups = list(map(tuple, df[['A', 'B', 'C', 'D',
                               'E', 'F', 'G', 'H']].values))
@@ -2905,8 +2905,8 @@ class TestGroupBy(tm.TestCase):
         dates = ['2011-07-19 07:00:00', '2011-07-19 08:00:00', '2011-07-19 09:00:00',
                  '2011-07-19 07:00:00', '2011-07-19 08:00:00', '2011-07-19 09:00:00']
         df = DataFrame({'label': ['a', 'a', 'a', 'b', 'b', 'b'],
-                        'datetime': dates, 
-                        'value1': np.arange(6,dtype='int64'), 
+                        'datetime': dates,
+                        'value1': np.arange(6,dtype='int64'),
                         'value2': [1, 2] * 3})
         df['datetime'] = df['datetime'].apply(lambda d: Timestamp(d, tz='US/Pacific'))
 
@@ -2924,8 +2924,8 @@ class TestGroupBy(tm.TestCase):
 
         # by level
         didx = pd.DatetimeIndex(dates, tz='Asia/Tokyo')
-        df = DataFrame({'value1': np.arange(6,dtype='int64'), 
-                        'value2': [1, 2, 3, 1, 2, 3]}, 
+        df = DataFrame({'value1': np.arange(6,dtype='int64'),
+                        'value2': [1, 2, 3, 1, 2, 3]},
                        index=didx)
 
         exp_idx = pd.DatetimeIndex(['2011-07-19 07:00:00', '2011-07-19 08:00:00',
@@ -3028,15 +3028,15 @@ class TestGroupBy(tm.TestCase):
         df = DataFrame([(1, 1351036800000000000), (2, 1351036800000000000)])
         df[1] = df[1].view('M8[ns]')
 
-        self.assert_(issubclass(df[1].dtype.type, np.datetime64))
+        self.assertTrue(issubclass(df[1].dtype.type, np.datetime64))
 
         result = df.groupby(level=0).first()
         got_dt = result[1].dtype
-        self.assert_(issubclass(got_dt.type, np.datetime64))
+        self.assertTrue(issubclass(got_dt.type, np.datetime64))
 
         result = df[1].groupby(level=0).first()
         got_dt = result.dtype
-        self.assert_(issubclass(got_dt.type, np.datetime64))
+        self.assertTrue(issubclass(got_dt.type, np.datetime64))
 
     def test_groupby_max_datetime64(self):
         # GH 5869

--- a/pandas/tests/test_hashtable.py
+++ b/pandas/tests/test_hashtable.py
@@ -15,15 +15,15 @@ class TestFactorizer(unittest.TestCase):
             ids = rizer.factorize(key, sort=True, na_sentinel=na_sentinel)
             expected = np.array([0, 1, 0, na_sentinel], dtype='int32')
             self.assertEqual(len(set(key)), len(set(expected)))
-            self.assert_(np.array_equal(pd.isnull(key), expected == na_sentinel))
+            self.assertTrue(np.array_equal(pd.isnull(key), expected == na_sentinel))
 
         # nan still maps to na_sentinel when sort=False
         key = np.array([0, np.nan, 1], dtype='O')
-        na_sentinel = -1        
+        na_sentinel = -1
         ids = rizer.factorize(key, sort=False, na_sentinel=na_sentinel)
         expected = np.array([ 2, -1,  0], dtype='int32')
         self.assertEqual(len(set(key)), len(set(expected)))
-        self.assert_(np.array_equal(pd.isnull(key), expected == na_sentinel))        
+        self.assertTrue(np.array_equal(pd.isnull(key), expected == na_sentinel))
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -2261,20 +2261,20 @@ class TestMultiIndex(tm.TestCase):
     def test_identical(self):
         mi = self.index.copy()
         mi2 = self.index.copy()
-        self.assert_(mi.identical(mi2))
+        self.assertTrue(mi.identical(mi2))
 
         mi = mi.set_names(['new1', 'new2'])
-        self.assert_(mi.equals(mi2))
+        self.assertTrue(mi.equals(mi2))
         self.assertFalse(mi.identical(mi2))
 
         mi2 = mi2.set_names(['new1', 'new2'])
-        self.assert_(mi.identical(mi2))
+        self.assertTrue(mi.identical(mi2))
 
         mi3 = Index(mi.tolist(), names=mi.names)
         mi4 = Index(mi.tolist(), names=mi.names, tupleize_cols=False)
-        self.assert_(mi.identical(mi3))
+        self.assertTrue(mi.identical(mi3))
         self.assertFalse(mi.identical(mi4))
-        self.assert_(mi.equals(mi4))
+        self.assertTrue(mi.equals(mi4))
 
     def test_is_(self):
         mi = MultiIndex.from_tuples(lzip(range(10), range(10)))
@@ -2311,7 +2311,7 @@ class TestMultiIndex(tm.TestCase):
         tups = sorted(self.index._tuple_index)
         expected = MultiIndex.from_tuples(tups)
 
-        self.assert_(the_union.equals(expected))
+        self.assertTrue(the_union.equals(expected))
 
         # corner case, pass self or empty thing:
         the_union = self.index.union(self.index)
@@ -2323,7 +2323,7 @@ class TestMultiIndex(tm.TestCase):
         # won't work in python 3
         # tuples = self.index._tuple_index
         # result = self.index[:4] | tuples[4:]
-        # self.assert_(result.equals(tuples))
+        # self.assertTrue(result.equals(tuples))
 
     # not valid for python 3
     # def test_union_with_regular_index(self):
@@ -2334,7 +2334,7 @@ class TestMultiIndex(tm.TestCase):
     #     self.assertIn('B', result)
 
     #     result2 = self.index.union(other)
-    #     self.assert_(result.equals(result2))
+    #     self.assertTrue(result.equals(result2))
 
     def test_intersection(self):
         piece1 = self.index[:5][::-1]
@@ -2343,7 +2343,7 @@ class TestMultiIndex(tm.TestCase):
         the_int = piece1 & piece2
         tups = sorted(self.index[3:5]._tuple_index)
         expected = MultiIndex.from_tuples(tups)
-        self.assert_(the_int.equals(expected))
+        self.assertTrue(the_int.equals(expected))
 
         # corner case, pass self
         the_int = self.index.intersection(self.index)
@@ -2352,12 +2352,12 @@ class TestMultiIndex(tm.TestCase):
         # empty intersection: disjoint
         empty = self.index[:2] & self.index[2:]
         expected = self.index[:0]
-        self.assert_(empty.equals(expected))
+        self.assertTrue(empty.equals(expected))
 
         # can't do in python 3
         # tuples = self.index._tuple_index
         # result = self.index & tuples
-        # self.assert_(result.equals(tuples))
+        # self.assertTrue(result.equals(tuples))
 
     def test_diff(self):
         first = self.index
@@ -2367,25 +2367,25 @@ class TestMultiIndex(tm.TestCase):
                                           names=self.index.names)
 
         tm.assert_isinstance(result, MultiIndex)
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
         self.assertEqual(result.names, self.index.names)
 
         # empty difference: reflexive
         result = self.index - self.index
         expected = self.index[:0]
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
         self.assertEqual(result.names, self.index.names)
 
         # empty difference: superset
         result = self.index[-3:] - self.index
         expected = self.index[:0]
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
         self.assertEqual(result.names, self.index.names)
 
         # empty difference: degenerate
         result = self.index[:0] - self.index
         expected = self.index[:0]
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
         self.assertEqual(result.names, self.index.names)
 
         # names not the same
@@ -2404,7 +2404,7 @@ class TestMultiIndex(tm.TestCase):
 
         # name from empty array
         result = first.diff([])
-        self.assert_(first.equals(result))
+        self.assertTrue(first.equals(result))
         self.assertEqual(first.names, result.names)
 
         # name from non-empty array
@@ -2439,23 +2439,23 @@ class TestMultiIndex(tm.TestCase):
 
         sorted_idx, _ = index.sortlevel(0)
         expected = MultiIndex.from_tuples(sorted(tuples))
-        self.assert_(sorted_idx.equals(expected))
+        self.assertTrue(sorted_idx.equals(expected))
 
         sorted_idx, _ = index.sortlevel(0, ascending=False)
-        self.assert_(sorted_idx.equals(expected[::-1]))
+        self.assertTrue(sorted_idx.equals(expected[::-1]))
 
         sorted_idx, _ = index.sortlevel(1)
         by1 = sorted(tuples, key=lambda x: (x[1], x[0]))
         expected = MultiIndex.from_tuples(by1)
-        self.assert_(sorted_idx.equals(expected))
+        self.assertTrue(sorted_idx.equals(expected))
 
         sorted_idx, _ = index.sortlevel(1, ascending=False)
-        self.assert_(sorted_idx.equals(expected[::-1]))
+        self.assertTrue(sorted_idx.equals(expected[::-1]))
 
     def test_sortlevel_not_sort_remaining(self):
         mi = MultiIndex.from_tuples([[1, 1, 3], [1, 1, 1]], names=list('ABC'))
         sorted_idx, _ = mi.sortlevel('A', sort_remaining=False)
-        self.assert_(sorted_idx.equals(mi))
+        self.assertTrue(sorted_idx.equals(mi))
 
     def test_sortlevel_deterministic(self):
         tuples = [('bar', 'one'), ('foo', 'two'), ('qux', 'two'),
@@ -2465,18 +2465,18 @@ class TestMultiIndex(tm.TestCase):
 
         sorted_idx, _ = index.sortlevel(0)
         expected = MultiIndex.from_tuples(sorted(tuples))
-        self.assert_(sorted_idx.equals(expected))
+        self.assertTrue(sorted_idx.equals(expected))
 
         sorted_idx, _ = index.sortlevel(0, ascending=False)
-        self.assert_(sorted_idx.equals(expected[::-1]))
+        self.assertTrue(sorted_idx.equals(expected[::-1]))
 
         sorted_idx, _ = index.sortlevel(1)
         by1 = sorted(tuples, key=lambda x: (x[1], x[0]))
         expected = MultiIndex.from_tuples(by1)
-        self.assert_(sorted_idx.equals(expected))
+        self.assertTrue(sorted_idx.equals(expected))
 
         sorted_idx, _ = index.sortlevel(1, ascending=False)
-        self.assert_(sorted_idx.equals(expected[::-1]))
+        self.assertTrue(sorted_idx.equals(expected[::-1]))
 
     def test_dims(self):
         pass
@@ -2488,12 +2488,12 @@ class TestMultiIndex(tm.TestCase):
         dropped2 = self.index.drop(index)
 
         expected = self.index[[0, 2, 3, 5]]
-        self.assert_(dropped.equals(expected))
-        self.assert_(dropped2.equals(expected))
+        self.assertTrue(dropped.equals(expected))
+        self.assertTrue(dropped2.equals(expected))
 
         dropped = self.index.drop(['bar'])
         expected = self.index[[0, 1, 3, 4, 5]]
-        self.assert_(dropped.equals(expected))
+        self.assertTrue(dropped.equals(expected))
 
         index = MultiIndex.from_tuples([('bar', 'two')])
         self.assertRaises(KeyError, self.index.drop, [('bar', 'two')])
@@ -2502,7 +2502,7 @@ class TestMultiIndex(tm.TestCase):
         # mixed partial / full drop
         dropped = self.index.drop(['foo', ('qux', 'one')])
         expected = self.index[[2, 3, 5]]
-        self.assert_(dropped.equals(expected))
+        self.assertTrue(dropped.equals(expected))
 
     def test_droplevel_with_names(self):
         index = self.index[self.index.get_loc('foo')]
@@ -2521,7 +2521,7 @@ class TestMultiIndex(tm.TestCase):
 
         dropped = index.droplevel('two')
         expected = index.droplevel(1)
-        self.assert_(dropped.equals(expected))
+        self.assertTrue(dropped.equals(expected))
 
     def test_droplevel_multiple(self):
         index = MultiIndex(levels=[Index(lrange(4)),
@@ -2534,12 +2534,12 @@ class TestMultiIndex(tm.TestCase):
 
         dropped = index[:2].droplevel(['three', 'one'])
         expected = index[:2].droplevel(2).droplevel(0)
-        self.assert_(dropped.equals(expected))
+        self.assertTrue(dropped.equals(expected))
 
     def test_insert(self):
         # key contained in all levels
         new_index = self.index.insert(0, ('bar', 'two'))
-        self.assert_(new_index.equal_levels(self.index))
+        self.assertTrue(new_index.equal_levels(self.index))
         self.assertEqual(new_index[0], ('bar', 'two'))
 
         # key not contained in all levels
@@ -2565,8 +2565,8 @@ class TestMultiIndex(tm.TestCase):
                                                 return_indexers=True)
 
             exp_level = other.join(self.index.levels[1], how=how)
-            self.assert_(join_index.levels[0].equals(self.index.levels[0]))
-            self.assert_(join_index.levels[1].equals(exp_level))
+            self.assertTrue(join_index.levels[0].equals(self.index.levels[0]))
+            self.assertTrue(join_index.levels[1].equals(exp_level))
 
             # pare down levels
             mask = np.array(
@@ -2579,7 +2579,7 @@ class TestMultiIndex(tm.TestCase):
                     self.index.join(other, how=how, level='second',
                                     return_indexers=True)
 
-                self.assert_(join_index.equals(join_index2))
+                self.assertTrue(join_index.equals(join_index2))
                 self.assert_numpy_array_equal(lidx, lidx2)
                 self.assert_numpy_array_equal(ridx, ridx2)
                 self.assert_numpy_array_equal(join_index2.values, exp_values)
@@ -2628,11 +2628,11 @@ class TestMultiIndex(tm.TestCase):
         exp_index = self.index.join(idx, level='second', how='right')
         exp_index2 = self.index.join(idx, level='second', how='left')
 
-        self.assert_(target.equals(exp_index))
+        self.assertTrue(target.equals(exp_index))
         exp_indexer = np.array([0, 2, 4])
         self.assert_numpy_array_equal(indexer, exp_indexer)
 
-        self.assert_(target2.equals(exp_index2))
+        self.assertTrue(target2.equals(exp_index2))
         exp_indexer2 = np.array([0, -1, 0, -1, 0, -1])
         self.assert_numpy_array_equal(indexer2, exp_indexer2)
 
@@ -2645,12 +2645,12 @@ class TestMultiIndex(tm.TestCase):
 
     def test_has_duplicates(self):
         self.assertFalse(self.index.has_duplicates)
-        self.assert_(self.index.append(self.index).has_duplicates)
+        self.assertTrue(self.index.append(self.index).has_duplicates)
 
         index = MultiIndex(levels=[[0, 1], [0, 1, 2]],
                            labels=[[0, 0, 0, 0, 1, 1, 1],
                                    [0, 1, 2, 0, 0, 1, 2]])
-        self.assert_(index.has_duplicates)
+        self.assertTrue(index.has_duplicates)
 
     def test_tolist(self):
         result = self.index.tolist()

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -810,8 +810,8 @@ class TestIndexing(tm.TestCase):
 
         # want this to work
         result = df.loc[:,"A":"B"].iloc[0:2,:]
-        self.assert_((result.columns == ['A','B']).all() == True)
-        self.assert_((result.index == ['A','B']).all() == True)
+        self.assertTrue((result.columns == ['A','B']).all() == True)
+        self.assertTrue((result.index == ['A','B']).all() == True)
 
         # mixed type
         result = DataFrame({ 'a' : [Timestamp('20130101')], 'b' : [1] }).iloc[0]
@@ -1696,7 +1696,7 @@ class TestIndexing(tm.TestCase):
         cols = ['b','a']
         result = df[['b','a']].columns
         expected = Index(['b','a','a'])
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         # across dtypes
         df = DataFrame([[1,2,1.,2.,3.,'foo','bar']], columns=list('aaaaaaa'))
@@ -2329,7 +2329,7 @@ class TestIndexing(tm.TestCase):
         df['A'] = df['A'].astype(np.float64)
         result = df.get_dtype_counts().sort_index()
         expected = Series({ 'float64' : 2, 'object' : 1 }).sort_index()
-        self.assert_(df.index.equals(index))
+        self.assertTrue(df.index.equals(index))
 
     def test_dups_loc(self):
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -192,7 +192,7 @@ class TestMultiLevel(tm.TestCase):
         df = DataFrame({'value': [0, 1]}, index=index)
 
         lines = repr(df).split('\n')
-        self.assert_(lines[2].startswith('a 0 foo'))
+        self.assertTrue(lines[2].startswith('a 0 foo'))
 
     def test_getitem_simple(self):
         df = self.frame.T
@@ -239,12 +239,12 @@ class TestMultiLevel(tm.TestCase):
         s = self.ymd['A']
 
         s[2000, 3] = np.nan
-        self.assert_(isnull(s.values[42:65]).all())
-        self.assert_(notnull(s.values[:42]).all())
-        self.assert_(notnull(s.values[65:]).all())
+        self.assertTrue(isnull(s.values[42:65]).all())
+        self.assertTrue(notnull(s.values[:42]).all())
+        self.assertTrue(notnull(s.values[65:]).all())
 
         s[2000, 3, 10] = np.nan
-        self.assert_(isnull(s[49]))
+        self.assertTrue(isnull(s[49]))
 
     def test_series_slice_partial(self):
         pass
@@ -283,8 +283,8 @@ class TestMultiLevel(tm.TestCase):
         cp = self.frame.copy()
         cp.ix[:4] = 0
 
-        self.assert_((cp.values[:4] == 0).all())
-        self.assert_((cp.values[4:] != 0).all())
+        self.assertTrue((cp.values[:4] == 0).all())
+        self.assertTrue((cp.values[4:] != 0).all())
 
     def test_frame_getitem_setitem_multislice(self):
         levels = [['t1', 't2'], ['a', 'b', 'c']]
@@ -559,7 +559,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         assert_frame_equal(res, exp)
 
         frame.ix[1:2] = 7
-        self.assert_((frame.ix[1:2] == 7).values.all())
+        self.assertTrue((frame.ix[1:2] == 7).values.all())
 
         series = Series(np.random.randn(len(index)), index=index)
 
@@ -568,7 +568,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         assert_series_equal(res, exp)
 
         series.ix[1:2] = 7
-        self.assert_((series.ix[1:2] == 7).values.all())
+        self.assertTrue((series.ix[1:2] == 7).values.all())
 
     def test_getitem_int(self):
         levels = [[0, 1], [0, 1, 2]]
@@ -688,7 +688,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 
         # it works!
         result = df.sortlevel(0)
-        self.assert_((result.dtypes.values == df.dtypes.values).all() == True)
+        self.assertTrue((result.dtypes.values == df.dtypes.values).all() == True)
         self.assertTrue(result.index.lexsort_depth == 3)
 
     def test_delevel_infer_dtype(self):
@@ -699,8 +699,8 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         df = DataFrame(np.random.randn(8, 3), columns=['A', 'B', 'C'],
                        index=index)
         deleveled = df.reset_index()
-        self.assert_(com.is_integer_dtype(deleveled['prm1']))
-        self.assert_(com.is_float_dtype(deleveled['prm2']))
+        self.assertTrue(com.is_integer_dtype(deleveled['prm1']))
+        self.assertTrue(com.is_float_dtype(deleveled['prm2']))
 
     def test_reset_index_with_drop(self):
         deleveled = self.ymd.reset_index(drop=True)
@@ -1148,7 +1148,7 @@ Thur,Lunch,Yes,51.51,17"""
 
         grouped = df1.groupby(axis=1, level=0)
         result = grouped.sum()
-        self.assert_((result.columns == ['f2', 'f3']).all())
+        self.assertTrue((result.columns == ['f2', 'f3']).all())
 
     def test_join(self):
         a = self.frame.ix[:5, ['A']]
@@ -1170,7 +1170,7 @@ Thur,Lunch,Yes,51.51,17"""
 
         back = swapped.swaplevel(0, 1)
         back2 = swapped.swaplevel('second', 'first')
-        self.assert_(back.index.equals(self.frame.index))
+        self.assertTrue(back.index.equals(self.frame.index))
         assert_series_equal(back, back2)
 
         ft = self.frame.T
@@ -1210,7 +1210,7 @@ Thur,Lunch,Yes,51.51,17"""
         df = self.ymd[:5].T
         df[2000, 1, 10] = df[2000, 1, 7]
         tm.assert_isinstance(df.columns, MultiIndex)
-        self.assert_((df[2000, 1, 10] == df[2000, 1, 7]).all())
+        self.assertTrue((df[2000, 1, 10] == df[2000, 1, 7]).all())
 
     def test_alignment(self):
         x = Series(data=[1, 2, 3],
@@ -1236,7 +1236,7 @@ Thur,Lunch,Yes,51.51,17"""
         index = MultiIndex(levels=levels,
                            labels=[[0, 0, 0, 1, 1, 1],
                                    [0, 1, 2, 0, 1, 2]])
-        self.assert_(index.is_lexsorted())
+        self.assertTrue(index.is_lexsorted())
 
         index = MultiIndex(levels=levels,
                            labels=[[0, 0, 0, 1, 1, 1],
@@ -1255,7 +1255,7 @@ Thur,Lunch,Yes,51.51,17"""
         # this works because we are modifying the underlying array
         # really a no-no
         df['foo'].values[:] = 0
-        self.assert_((df['foo'].values == 0).all())
+        self.assertTrue((df['foo'].values == 0).all())
 
         # but not if it's mixed-type
         df['foo', 'four'] = 'foo'
@@ -1271,7 +1271,7 @@ Thur,Lunch,Yes,51.51,17"""
             df = f()
         except:
             pass
-        self.assert_((df['foo', 'one'] == 0).all())
+        self.assertTrue((df['foo', 'one'] == 0).all())
 
     def test_frame_getitem_not_sorted(self):
         df = self.frame.T
@@ -1376,8 +1376,8 @@ Thur,Lunch,Yes,51.51,17"""
             # for good measure, groupby detail
             level_index = frame._get_axis(axis).levels[level]
 
-            self.assert_(leftside._get_axis(axis).equals(level_index))
-            self.assert_(rightside._get_axis(axis).equals(level_index))
+            self.assertTrue(leftside._get_axis(axis).equals(level_index))
+            self.assertTrue(rightside._get_axis(axis).equals(level_index))
 
             assert_frame_equal(leftside, rightside)
 
@@ -1549,7 +1549,7 @@ Thur,Lunch,Yes,51.51,17"""
         # need to put in some work here
 
         # self.ymd.ix[2000, 0] = 0
-        # self.assert_((self.ymd.ix[2000]['A'] == 0).all())
+        # self.assertTrue((self.ymd.ix[2000]['A'] == 0).all())
 
         # Pretty sure the second (and maybe even the first) is already wrong.
         self.assertRaises(Exception, self.ymd.ix.__getitem__, (2000, 6))
@@ -1832,7 +1832,7 @@ Thur,Lunch,Yes,51.51,17"""
         df = DataFrame([[1, 2], [3, 4], [5, 6]], index=mix)
         s = Series({(1, 1): 1, (1, 2): 2})
         df['new'] = s
-        self.assert_(df['new'].isnull().all())
+        self.assertTrue(df['new'].isnull().all())
 
     def test_join_segfault(self):
         # 1532
@@ -1848,11 +1848,11 @@ Thur,Lunch,Yes,51.51,17"""
         subset = self.frame.index[[1, 4, 5]]
 
         self.frame.ix[subset] = 99
-        self.assert_((self.frame.ix[subset].values == 99).all())
+        self.assertTrue((self.frame.ix[subset].values == 99).all())
 
         col = self.frame['B']
         col[subset] = 97
-        self.assert_((self.frame.ix[subset, 'B'] == 97).all())
+        self.assertTrue((self.frame.ix[subset, 'B'] == 97).all())
 
     def test_frame_dict_constructor_empty_series(self):
         s1 = Series([1, 2, 3, 4], index=MultiIndex.from_tuples([(1, 2), (1, 3),
@@ -1888,7 +1888,7 @@ Thur,Lunch,Yes,51.51,17"""
 
         df.ix[ix, "C"] = '_'
 
-        self.assert_((df.xs((1, 1))['C'] == '_').all())
+        self.assertTrue((df.xs((1, 1))['C'] == '_').all())
 
     def test_indexing_over_hashtable_size_cutoff(self):
         n = 10000
@@ -1986,8 +1986,8 @@ Thur,Lunch,Yes,51.51,17"""
 
         expected1 = pd.DatetimeIndex(['2013-04-01 9:00', '2013-04-02 9:00', '2013-04-03 9:00'], tz='Asia/Tokyo')
 
-        self.assert_(idx.levels[0].equals(expected1))
-        self.assert_(idx.levels[1].equals(idx2))
+        self.assertTrue(idx.levels[0].equals(expected1))
+        self.assertTrue(idx.levels[1].equals(idx2))
 
     def test_set_index_datetime(self):
         # GH 3950
@@ -2003,12 +2003,12 @@ Thur,Lunch,Yes,51.51,17"""
         expected = expected.tz_localize('UTC').tz_convert('US/Pacific')
 
         df = df.set_index('label', append=True)
-        self.assert_(df.index.levels[0].equals(expected))
-        self.assert_(df.index.levels[1].equals(pd.Index(['a', 'b'])))
+        self.assertTrue(df.index.levels[0].equals(expected))
+        self.assertTrue(df.index.levels[1].equals(pd.Index(['a', 'b'])))
 
         df = df.swaplevel(0, 1)
-        self.assert_(df.index.levels[0].equals(pd.Index(['a', 'b'])))
-        self.assert_(df.index.levels[1].equals(expected))
+        self.assertTrue(df.index.levels[0].equals(pd.Index(['a', 'b'])))
+        self.assertTrue(df.index.levels[1].equals(expected))
 
 
         df = DataFrame(np.random.random(6))
@@ -2028,14 +2028,14 @@ Thur,Lunch,Yes,51.51,17"""
                                      '2011-07-19 09:00:00'], tz='US/Eastern')
         expected2 = pd.DatetimeIndex(['2012-04-01 09:00', '2012-04-02 09:00'], tz='US/Eastern')
 
-        self.assert_(df.index.levels[0].equals(expected1))
-        self.assert_(df.index.levels[1].equals(expected2))
-        self.assert_(df.index.levels[2].equals(idx3))
+        self.assertTrue(df.index.levels[0].equals(expected1))
+        self.assertTrue(df.index.levels[1].equals(expected2))
+        self.assertTrue(df.index.levels[2].equals(idx3))
 
         # GH 7092
-        self.assert_(df.index.get_level_values(0).equals(idx1))
-        self.assert_(df.index.get_level_values(1).equals(idx2))
-        self.assert_(df.index.get_level_values(2).equals(idx3))
+        self.assertTrue(df.index.get_level_values(0).equals(idx1))
+        self.assertTrue(df.index.get_level_values(1).equals(idx2))
+        self.assertTrue(df.index.get_level_values(2).equals(idx3))
 
     def test_set_index_period(self):
         # GH 6631
@@ -2053,13 +2053,13 @@ Thur,Lunch,Yes,51.51,17"""
         expected1 = pd.period_range('2011-01-01', periods=3, freq='M')
         expected2 = pd.period_range('2013-01-01 09:00', periods=2, freq='H')
 
-        self.assert_(df.index.levels[0].equals(expected1))
-        self.assert_(df.index.levels[1].equals(expected2))
-        self.assert_(df.index.levels[2].equals(idx3))
+        self.assertTrue(df.index.levels[0].equals(expected1))
+        self.assertTrue(df.index.levels[1].equals(expected2))
+        self.assertTrue(df.index.levels[2].equals(idx3))
 
-        self.assert_(df.index.get_level_values(0).equals(idx1))
-        self.assert_(df.index.get_level_values(1).equals(idx2))
-        self.assert_(df.index.get_level_values(2).equals(idx3))
+        self.assertTrue(df.index.get_level_values(0).equals(idx1))
+        self.assertTrue(df.index.get_level_values(1).equals(idx2))
+        self.assertTrue(df.index.get_level_values(2).equals(idx3))
 
 
 if __name__ == '__main__':

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -540,7 +540,7 @@ class CheckIndexing(object):
         # get a view by default
         itemA_view = self.panel.xs('ItemA', axis=0)
         itemA_view.values[:] = np.nan
-        self.assert_(np.isnan(self.panel['ItemA'].values).all())
+        self.assertTrue(np.isnan(self.panel['ItemA'].values).all())
 
         # mixed-type yields a copy
         self.panel['strings'] = 'foo'
@@ -717,7 +717,7 @@ class CheckIndexing(object):
         cp = self.panel.copy()
         obj = cp.ix[indexer]
         obj.values[:] = 0
-        self.assert_((obj.values == 0).all())
+        self.assertTrue((obj.values == 0).all())
         comp(cp.ix[indexer].reindex_like(obj), obj)
 
     def test_logical_with_nas(self):
@@ -797,7 +797,7 @@ class CheckIndexing(object):
         self.assertEqual(res.get_value('ItemE', 'foo', 'bar'), 1.5)
 
         res3 = self.panel.set_value('ItemE', 'foobar', 'baz', 5)
-        self.assert_(com.is_float_dtype(res3['ItemE'].values))
+        self.assertTrue(com.is_float_dtype(res3['ItemE'].values))
         with tm.assertRaisesRegexp(TypeError,
                                    "There must be an argument for each axis"
                                    " plus the value provided"):
@@ -926,13 +926,13 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
             Panel(np.random.randn(10, 2))
 
     def test_consolidate(self):
-        self.assert_(self.panel._data.is_consolidated())
+        self.assertTrue(self.panel._data.is_consolidated())
 
         self.panel['foo'] = 1.
         self.assertFalse(self.panel._data.is_consolidated())
 
         panel = self.panel.consolidate()
-        self.assert_(panel._data.is_consolidated())
+        self.assertTrue(panel._data.is_consolidated())
 
     def test_ctor_dict(self):
         itema = self.panel['ItemA']
@@ -947,12 +947,12 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         wp = Panel.from_dict(d)
         wp2 = Panel.from_dict(d2)  # nested Dict
         wp3 = Panel.from_dict(d3)
-        self.assert_(wp.major_axis.equals(self.panel.major_axis))
+        self.assertTrue(wp.major_axis.equals(self.panel.major_axis))
         assert_panel_equal(wp, wp2)
 
         # intersect
         wp = Panel.from_dict(d, intersect=True)
-        self.assert_(wp.major_axis.equals(itemb.index[5:]))
+        self.assertTrue(wp.major_axis.equals(itemb.index[5:]))
 
         # use constructor
         assert_panel_equal(Panel(d), Panel.from_dict(d))
@@ -981,7 +981,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         data = dict((k, v.values) for k, v in compat.iteritems(self.panel))
         result = Panel(data)
         exp_major = Index(np.arange(len(self.panel.major_axis)))
-        self.assert_(result.major_axis.equals(exp_major))
+        self.assertTrue(result.major_axis.equals(exp_major))
 
         result = Panel(data, items=self.panel.items,
                        major_axis=self.panel.major_axis,
@@ -1310,7 +1310,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
 
     def test_fillna(self):
         filled = self.panel.fillna(0)
-        self.assert_(np.isfinite(filled.values).all())
+        self.assertTrue(np.isfinite(filled.values).all())
 
         filled = self.panel.fillna(method='backfill')
         assert_frame_equal(filled['ItemA'],
@@ -1424,7 +1424,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         assert_panel_equal(result, expected)
 
         panel.values[0, 1, 1] = np.nan
-        self.assert_(notnull(result.values[1, 0, 1]))
+        self.assertTrue(notnull(result.values[1, 0, 1]))
 
     def test_to_frame(self):
         # filtered
@@ -1554,7 +1554,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
                               [0, 1, 2, 3, 4, 5, 2, 3, 4, 5]])
 
         panel = df.to_panel()
-        self.assert_(isnull(panel[0].ix[1, [0, 1]]).all())
+        self.assertTrue(isnull(panel[0].ix[1, [0, 1]]).all())
 
     def test_to_panel_duplicates(self):
         # #2441
@@ -1767,8 +1767,8 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         f2 = wp.ix['a']
         assert_panel_equal(f1, f2)
 
-        self.assert_((f1.items == [1, 2]).all())
-        self.assert_((f2.items == [1, 2]).all())
+        self.assertTrue((f1.items == [1, 2]).all())
+        self.assertTrue((f2.items == [1, 2]).all())
 
         ind = MultiIndex.from_tuples([('a', 1), ('a', 2), ('b', 1)],
                                      names=['first', 'second'])
@@ -1779,10 +1779,10 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         wp = Panel(self.panel._data)
         wp.items = ind
         f1 = wp['a']
-        self.assert_((f1.items == [1, 2]).all())
+        self.assertTrue((f1.items == [1, 2]).all())
 
         f1 = wp[('b', 1)]
-        self.assert_((f1.columns == ['A', 'B', 'C', 'D']).all())
+        self.assertTrue((f1.columns == ['A', 'B', 'C', 'D']).all())
 
     def test_repr_empty(self):
         empty = Panel()
@@ -1797,16 +1797,16 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
 
         renamed = self.panel.rename_axis(mapper, axis=0)
         exp = Index(['foo', 'bar', 'baz'])
-        self.assert_(renamed.items.equals(exp))
+        self.assertTrue(renamed.items.equals(exp))
 
         renamed = self.panel.rename_axis(str.lower, axis=2)
         exp = Index(['a', 'b', 'c', 'd'])
-        self.assert_(renamed.minor_axis.equals(exp))
+        self.assertTrue(renamed.minor_axis.equals(exp))
 
         # don't copy
         renamed_nocopy = self.panel.rename_axis(mapper, axis=0, copy=False)
         renamed_nocopy['foo'] = 3.
-        self.assert_((self.panel['ItemA'].values == 3).all())
+        self.assertTrue((self.panel['ItemA'].values == 3).all())
 
     def test_get_attr(self):
         assert_frame_equal(self.panel['ItemA'], self.panel.ItemA)
@@ -2168,10 +2168,10 @@ class TestLongPanel(tm.TestCase):
             return (arr[1:] > arr[:-1]).any()
 
         sorted_minor = self.panel.sortlevel(level=1)
-        self.assert_(is_sorted(sorted_minor.index.labels[1]))
+        self.assertTrue(is_sorted(sorted_minor.index.labels[1]))
 
         sorted_major = sorted_minor.sortlevel(level=0)
-        self.assert_(is_sorted(sorted_major.index.labels[0]))
+        self.assertTrue(is_sorted(sorted_major.index.labels[0]))
 
     def test_to_string(self):
         buf = StringIO()

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -455,7 +455,7 @@ class CheckIndexing(object):
         # view if possible
         l1_view = self.panel4d.xs('l1', axis=0)
         l1_view.values[:] = np.nan
-        self.assert_(np.isnan(self.panel4d['l1'].values).all())
+        self.assertTrue(np.isnan(self.panel4d['l1'].values).all())
 
         # mixed-type
         self.panel4d['strings'] = 'foo'
@@ -535,7 +535,7 @@ class CheckIndexing(object):
         self.assertEqual(res.get_value('l4', 'ItemE', 'foo', 'bar'), 1.5)
 
         res3 = self.panel4d.set_value('l4', 'ItemE', 'foobar', 'baz', 5)
-        self.assert_(com.is_float_dtype(res3['l4'].values))
+        self.assertTrue(com.is_float_dtype(res3['l4'].values))
 
 
 class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
@@ -609,13 +609,13 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
         self.assertEqual(panel.values.dtype, np.object_)
 
     def test_consolidate(self):
-        self.assert_(self.panel4d._data.is_consolidated())
+        self.assertTrue(self.panel4d._data.is_consolidated())
 
         self.panel4d['foo'] = 1.
         self.assertFalse(self.panel4d._data.is_consolidated())
 
         panel4d = self.panel4d.consolidate()
-        self.assert_(panel4d._data.is_consolidated())
+        self.assertTrue(panel4d._data.is_consolidated())
 
     def test_ctor_dict(self):
         l1 = self.panel4d['l1']
@@ -629,14 +629,14 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
         panel4d = Panel4D(d)
         # wp2 = Panel.from_dict(d2) # nested Dict
         # wp3 = Panel.from_dict(d3)
-        # self.assert_(wp.major_axis.equals(self.panel.major_axis))
+        # self.assertTrue(wp.major_axis.equals(self.panel.major_axis))
         assert_panel_equal(panel4d['A'], self.panel4d['l1'])
         assert_frame_equal(panel4d.ix['B', 'ItemB', :, :],
                            self.panel4d.ix['l2', ['ItemB'], :, :]['ItemB'])
 
         # intersect
         # wp = Panel.from_dict(d, intersect=True)
-        # self.assert_(wp.major_axis.equals(itemb.index[5:]))
+        # self.assertTrue(wp.major_axis.equals(itemb.index[5:]))
 
         # use constructor
         # assert_panel_equal(Panel(d), Panel.from_dict(d))
@@ -655,7 +655,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
         data = dict((k, v.values) for k, v in compat.iteritems(self.panel4d))
         result = Panel4D(data)
         exp_major = Index(np.arange(len(self.panel4d.major_axis)))
-        self.assert_(result.major_axis.equals(exp_major))
+        self.assertTrue(result.major_axis.equals(exp_major))
 
         result = Panel4D(data,
                          labels=self.panel4d.labels,
@@ -841,7 +841,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
     def test_fillna(self):
         self.assertFalse(np.isfinite(self.panel4d.values).all())
         filled = self.panel4d.fillna(0)
-        self.assert_(np.isfinite(filled.values).all())
+        self.assertTrue(np.isfinite(filled.values).all())
 
         self.assertRaises(NotImplementedError, self.panel4d.fillna, method='pad')
 
@@ -975,8 +975,8 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
     #    f2 = wp.ix['a']
     #    assert_panel_equal(f1, f2)
 
-    #    self.assert_((f1.items == [1, 2]).all())
-    #    self.assert_((f2.items == [1, 2]).all())
+    #    self.assertTrue((f1.items == [1, 2]).all())
+    #    self.assertTrue((f2.items == [1, 2]).all())
 
     #    ind = MultiIndex.from_tuples([('a', 1), ('a', 2), ('b', 1)],
     #                                 names=['first', 'second'])
@@ -988,10 +988,10 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
     #    wp = Panel(self.panel._data)
     #    wp.items = ind
     #    f1 = wp['a']
-    #    self.assert_((f1.items == [1, 2]).all())
+    #    self.assertTrue((f1.items == [1, 2]).all())
 
     #    f1 = wp[('b',1)]
-    #    self.assert_((f1.columns == ['A', 'B', 'C', 'D']).all())
+    #    self.assertTrue((f1.columns == ['A', 'B', 'C', 'D']).all())
 
     def test_repr_empty(self):
         empty = Panel4D()
@@ -1006,16 +1006,16 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
 
         renamed = self.panel4d.rename_axis(mapper, axis=0)
         exp = Index(['foo', 'bar', 'baz'])
-        self.assert_(renamed.labels.equals(exp))
+        self.assertTrue(renamed.labels.equals(exp))
 
         renamed = self.panel4d.rename_axis(str.lower, axis=3)
         exp = Index(['a', 'b', 'c', 'd'])
-        self.assert_(renamed.minor_axis.equals(exp))
+        self.assertTrue(renamed.minor_axis.equals(exp))
 
         # don't copy
         renamed_nocopy = self.panel4d.rename_axis(mapper, axis=0, copy=False)
         renamed_nocopy['foo'] = 3.
-        self.assert_((self.panel4d['l1'].values == 3).all())
+        self.assertTrue((self.panel4d['l1'].values == 3).all())
 
     def test_get_attr(self):
         assert_panel_equal(self.panel4d['l1'], self.panel4d.l1)

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -49,7 +49,7 @@ class TestStringMethods(tm.TestCase):
 
             for el in s:
                 # each element of the series is either a basestring/str or nan
-                self.assert_(isinstance(el, compat.string_types) or isnull(el))
+                self.assertTrue(isinstance(el, compat.string_types) or isnull(el))
 
         # desired behavior is to iterate until everything would be nan on the
         # next iter so make sure the last element of the iterator was 'l' in
@@ -116,7 +116,7 @@ class TestStringMethods(tm.TestCase):
 
         # single array
         result = strings.str_cat(one)
-        self.assert_(isnull(result))
+        self.assertTrue(isnull(result))
 
         result = strings.str_cat(one, na_rep='NA')
         exp = 'aabbcNA'

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -219,8 +219,8 @@ class TestMerge(tm.TestCase):
                          columns=['three'])
         joined = df_a.join(df_b, on='one')
         joined = joined.join(df_c, on='one')
-        self.assert_(np.isnan(joined['two']['c']))
-        self.assert_(np.isnan(joined['three']['c']))
+        self.assertTrue(np.isnan(joined['two']['c']))
+        self.assertTrue(np.isnan(joined['three']['c']))
 
         # merge column not p resent
         self.assertRaises(Exception, target.join, source, on='E')
@@ -270,11 +270,11 @@ class TestMerge(tm.TestCase):
         merged = self.target.join(self.source.reindex([]), on='C')
         for col in self.source:
             self.assertIn(col, merged)
-            self.assert_(merged[col].isnull().all())
+            self.assertTrue(merged[col].isnull().all())
 
         merged2 = self.target.join(self.source.reindex([]), on='C',
                                    how='inner')
-        self.assert_(merged2.columns.equals(merged.columns))
+        self.assertTrue(merged2.columns.equals(merged.columns))
         self.assertEqual(len(merged2), 0)
 
     def test_join_on_inner(self):
@@ -287,7 +287,7 @@ class TestMerge(tm.TestCase):
         expected = expected[expected['value'].notnull()]
         self.assert_numpy_array_equal(joined['key'], expected['key'])
         self.assert_numpy_array_equal(joined['value'], expected['value'])
-        self.assert_(joined.index.equals(expected.index))
+        self.assertTrue(joined.index.equals(expected.index))
 
     def test_join_on_singlekey_list(self):
         df = DataFrame({'key': ['a', 'a', 'b', 'b', 'c']})
@@ -438,7 +438,7 @@ class TestMerge(tm.TestCase):
         expected = expected.drop(['first', 'second'], axis=1)
         expected.index = joined.index
 
-        self.assert_(joined.index.is_monotonic)
+        self.assertTrue(joined.index.is_monotonic)
         assert_frame_equal(joined, expected)
 
         # _assert_same_contents(expected, expected2.ix[:, expected.columns])
@@ -592,10 +592,10 @@ class TestMerge(tm.TestCase):
                        right_index=True, copy=True)
 
         merged['a'] = 6
-        self.assert_((left['a'] == 0).all())
+        self.assertTrue((left['a'] == 0).all())
 
         merged['d'] = 'peekaboo'
-        self.assert_((right['d'] == 'bar').all())
+        self.assertTrue((right['d'] == 'bar').all())
 
     def test_merge_nocopy(self):
         left = DataFrame({'a': 0, 'b': 1}, index=lrange(10))
@@ -605,10 +605,10 @@ class TestMerge(tm.TestCase):
                        right_index=True, copy=False)
 
         merged['a'] = 6
-        self.assert_((left['a'] == 6).all())
+        self.assertTrue((left['a'] == 6).all())
 
         merged['d'] = 'peekaboo'
-        self.assert_((right['d'] == 'peekaboo').all())
+        self.assertTrue((right['d'] == 'peekaboo').all())
 
     def test_join_sort(self):
         left = DataFrame({'key': ['foo', 'bar', 'baz', 'foo'],
@@ -643,7 +643,7 @@ class TestMerge(tm.TestCase):
                              columns=['value', 'key', 'rvalue'])
         assert_frame_equal(joined, expected, check_dtype=False)
 
-        self.assert_(joined._data.is_consolidated())
+        self.assertTrue(joined._data.is_consolidated())
 
     def test_handle_join_key_pass_array(self):
         left = DataFrame({'key': [1, 1, 2, 2, 3],
@@ -655,8 +655,8 @@ class TestMerge(tm.TestCase):
         merged2 = merge(right, left, left_on=key, right_on='key', how='outer')
 
         assert_series_equal(merged['key'], merged2['key'])
-        self.assert_(merged['key'].notnull().all())
-        self.assert_(merged2['key'].notnull().all())
+        self.assertTrue(merged['key'].notnull().all())
+        self.assertTrue(merged2['key'].notnull().all())
 
         left = DataFrame({'value': lrange(5)}, columns=['value'])
         right = DataFrame({'rvalue': lrange(6)})
@@ -761,7 +761,7 @@ class TestMerge(tm.TestCase):
         exp = merge(df, new, on='var3', sort=False)
         assert_frame_equal(result, exp)
 
-        self.assert_((df.var3.unique() == result.var3.unique()).all())
+        self.assertTrue((df.var3.unique() == result.var3.unique()).all())
 
     def test_merge_nan_right(self):
         df1 = DataFrame({"i1" : [0, 1], "i2" : [0, 1]})
@@ -1310,8 +1310,8 @@ class TestConcatenate(tm.TestCase):
         b = df[5:].ix[:, ['strings', 'ints', 'floats']]
 
         appended = a.append(b)
-        self.assert_(isnull(appended['strings'][0:4]).all())
-        self.assert_(isnull(appended['bools'][5:]).all())
+        self.assertTrue(isnull(appended['strings'][0:4]).all())
+        self.assertTrue(isnull(appended['bools'][5:]).all())
 
     def test_append_many(self):
         chunks = [self.frame[:5], self.frame[5:10],
@@ -1323,8 +1323,8 @@ class TestConcatenate(tm.TestCase):
         chunks[-1]['foo'] = 'bar'
         result = chunks[0].append(chunks[1:])
         tm.assert_frame_equal(result.ix[:, self.frame.columns], self.frame)
-        self.assert_((result['foo'][15:] == 'bar').all())
-        self.assert_(result['foo'][:15].isnull().all())
+        self.assertTrue((result['foo'][15:] == 'bar').all())
+        self.assertTrue(result['foo'][:15].isnull().all())
 
     def test_append_preserve_index_name(self):
         # #980
@@ -1978,8 +1978,8 @@ class TestConcatenate(tm.TestCase):
         df = DataFrame({'time': rng})
 
         result = concat([df, df])
-        self.assert_((result.iloc[:10]['time'] == rng).all())
-        self.assert_((result.iloc[10:]['time'] == rng).all())
+        self.assertTrue((result.iloc[:10]['time'] == rng).all())
+        self.assertTrue((result.iloc[10:]['time'] == rng).all())
 
     def test_concat_timedelta64_block(self):
 
@@ -1994,8 +1994,8 @@ class TestConcatenate(tm.TestCase):
         df = DataFrame({'time': rng})
 
         result = concat([df, df])
-        self.assert_((result.iloc[:10]['time'] == rng).all())
-        self.assert_((result.iloc[10:]['time'] == rng).all())
+        self.assertTrue((result.iloc[:10]['time'] == rng).all())
+        self.assertTrue((result.iloc[10:]['time'] == rng).all())
 
     def test_concat_keys_with_none(self):
         # #1649
@@ -2133,7 +2133,7 @@ class TestOrderedMerge(tm.TestCase):
         assert_frame_equal(result, result2.ix[:, result.columns])
 
         result = ordered_merge(left, self.right, on='key', left_by='group')
-        self.assert_(result['group'].notnull().all())
+        self.assertTrue(result['group'].notnull().all())
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -57,7 +57,7 @@ class TestPivotTable(tm.TestCase):
         index = ['A', 'B']
         columns = 'C'
         with tm.assert_produces_warning(FutureWarning):
-            table = pivot_table(self.data, values='D', rows=index, 
+            table = pivot_table(self.data, values='D', rows=index,
                                 cols=columns)
 
         with tm.assert_produces_warning(False):
@@ -191,7 +191,7 @@ class TestPivotTable(tm.TestCase):
                                 datetime.datetime(2014, 1, 1, 9, 0),
                                 datetime.datetime(2014, 1, 2, 9, 0),
                                 datetime.datetime(2014, 1, 2, 9, 0)],
-                        'data1': np.arange(4,dtype='int64'), 
+                        'data1': np.arange(4,dtype='int64'),
                         'data2': np.arange(4,dtype='int64')})
 
         df['dt1'] = df['dt1'].apply(lambda d: pd.Timestamp(d, tz='US/Pacific'))
@@ -336,7 +336,7 @@ class TestPivotTable(tm.TestCase):
                                  columns=['Index', 'Symbol', 'Year'],
                                  aggfunc='mean')
 
-        self.assert_(pivoted.columns.is_monotonic)
+        self.assertTrue(pivoted.columns.is_monotonic)
 
     def test_pivot_complex_aggfunc(self):
         f = {'D': ['std'], 'E': ['sum']}
@@ -378,7 +378,7 @@ class TestPivotTable(tm.TestCase):
                       datetime.datetime(2013, 12, 2), datetime.datetime(2013, 12, 2),]}).set_index('Date')
 
         expected = DataFrame(np.array([10, 18, 3],dtype='int64').reshape(1, 3),
-                             index=[datetime.datetime(2013, 12, 31)], 
+                             index=[datetime.datetime(2013, 12, 31)],
                              columns='Carl Joe Mark'.split())
         expected.index.name = 'Date'
         expected.columns.name = 'Buyer'
@@ -387,12 +387,12 @@ class TestPivotTable(tm.TestCase):
                              values='Quantity', aggfunc=np.sum)
         tm.assert_frame_equal(result,expected)
 
-        result = pivot_table(df, index='Buyer', columns=Grouper(freq='A'), 
+        result = pivot_table(df, index='Buyer', columns=Grouper(freq='A'),
                              values='Quantity', aggfunc=np.sum)
         tm.assert_frame_equal(result,expected.T)
 
         expected = DataFrame(np.array([1, np.nan, 3, 9, 18, np.nan]).reshape(2, 3),
-                             index=[datetime.datetime(2013, 1, 1), datetime.datetime(2013, 7, 1)], 
+                             index=[datetime.datetime(2013, 1, 1), datetime.datetime(2013, 7, 1)],
                              columns='Carl Joe Mark'.split())
         expected.index.name = 'Date'
         expected.columns.name = 'Buyer'
@@ -404,7 +404,7 @@ class TestPivotTable(tm.TestCase):
         result = pivot_table(df, index='Buyer', columns=Grouper(freq='6MS'),
                              values='Quantity', aggfunc=np.sum)
         tm.assert_frame_equal(result, expected.T)
- 
+
         # passing the name
         df = df.reset_index()
         result = pivot_table(df, index=Grouper(freq='6MS', key='Date'), columns='Buyer',
@@ -455,11 +455,11 @@ class TestPivotTable(tm.TestCase):
         expected = DataFrame(np.array([np.nan, 3, np.nan, np.nan, 6, np.nan, 1, 9,
                                        np.nan, 9, np.nan, np.nan, np.nan, np.nan, 3, np.nan]).reshape(4, 4),
                              index=[datetime.datetime(2013, 9, 30), datetime.datetime(2013, 10, 31),
-                                    datetime.datetime(2013, 11, 30), datetime.datetime(2013, 12, 31)], 
+                                    datetime.datetime(2013, 11, 30), datetime.datetime(2013, 12, 31)],
                              columns=[datetime.datetime(2013, 9, 30), datetime.datetime(2013, 10, 31),
                                     datetime.datetime(2013, 11, 30), datetime.datetime(2013, 12, 31)])
         expected.index.name = 'Date'
-        expected.columns.name = 'PayDay'        
+        expected.columns.name = 'PayDay'
 
         tm.assert_frame_equal(result, expected)
 
@@ -478,7 +478,7 @@ class TestPivotTable(tm.TestCase):
         expected = DataFrame(np.array([3, np.nan, 6, np.nan, 1, np.nan,
                                        9, np.nan, 9, np.nan, np.nan, 3]).reshape(6, 2),
                              index=idx, columns=['A', 'B'])
-        expected.columns.name = 'Branch'   
+        expected.columns.name = 'Branch'
 
         result = pivot_table(df, index=[Grouper(freq='M', key='Date'),
                              Grouper(freq='M', key='PayDay')], columns=['Branch'],
@@ -486,7 +486,7 @@ class TestPivotTable(tm.TestCase):
         tm.assert_frame_equal(result, expected)
 
         result = pivot_table(df, index=['Branch'], columns=[Grouper(freq='M', key='Date'),
-                             Grouper(freq='M', key='PayDay')], 
+                             Grouper(freq='M', key='PayDay')],
                              values='Quantity', aggfunc=np.sum)
         tm.assert_frame_equal(result, expected.T)
 

--- a/pandas/tools/tests/test_tile.py
+++ b/pandas/tools/tests/test_tile.py
@@ -150,7 +150,7 @@ class TestCut(tm.TestCase):
 
         factor = qcut(arr, [0, .25, .5, .75, 1.])
         expected = qcut(arr, 4)
-        self.assert_(factor.equals(expected))
+        self.assertTrue(factor.equals(expected))
 
     def test_qcut_all_bins_same(self):
         assertRaisesRegexp(ValueError, "edges.*unique", qcut, [0,0,0,0,0,0,0,0,0,0], 3)
@@ -174,7 +174,7 @@ class TestCut(tm.TestCase):
         exp = cut(arr, bins)
         exp.levels = labels
 
-        self.assert_(result.equals(exp))
+        self.assertTrue(result.equals(exp))
 
     def test_qcut_include_lowest(self):
         values = np.arange(10)
@@ -182,14 +182,14 @@ class TestCut(tm.TestCase):
         cats = qcut(values, 4)
 
         ex_levels = ['[0, 2.25]', '(2.25, 4.5]', '(4.5, 6.75]', '(6.75, 9]']
-        self.assert_((cats.levels == ex_levels).all())
+        self.assertTrue((cats.levels == ex_levels).all())
 
     def test_qcut_nas(self):
         arr = np.random.randn(100)
         arr[:20] = np.nan
 
         result = qcut(arr, 4)
-        self.assert_(com.isnull(result[:20]).all())
+        self.assertTrue(com.isnull(result[:20]).all())
 
     def test_label_formatting(self):
         self.assertEquals(tmod._trim_zeros('1.000'), '1')

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -125,13 +125,13 @@ class TestDateRange(tm.TestCase):
         d = self.rng[10]
 
         comp = self.rng > d
-        self.assert_(comp[11])
-        self.assert_(not comp[9])
+        self.assertTrue(comp[11])
+        self.assertFalse(comp[9])
 
     def test_copy(self):
         cp = self.rng.copy()
         repr(cp)
-        self.assert_(cp.equals(self.rng))
+        self.assertTrue(cp.equals(self.rng))
 
     def test_repr(self):
         # only really care that it works
@@ -249,13 +249,13 @@ class TestDateRange(tm.TestCase):
         rng1 = rng[10:]
         rng2 = rng[:25]
         the_union = rng1.union(rng2)
-        self.assert_(the_union.equals(rng))
+        self.assertTrue(the_union.equals(rng))
 
         rng1 = rng[10:]
         rng2 = rng[15:35]
         the_union = rng1.union(rng2)
         expected = rng[10:]
-        self.assert_(the_union.equals(expected))
+        self.assertTrue(the_union.equals(expected))
 
     def test_intersection(self):
         rng = date_range('1/1/2000', periods=50, freq=datetools.Minute())
@@ -263,24 +263,24 @@ class TestDateRange(tm.TestCase):
         rng2 = rng[:25]
         the_int = rng1.intersection(rng2)
         expected = rng[10:25]
-        self.assert_(the_int.equals(expected))
+        self.assertTrue(the_int.equals(expected))
         tm.assert_isinstance(the_int, DatetimeIndex)
         self.assertEqual(the_int.offset, rng.offset)
 
         the_int = rng1.intersection(rng2.view(DatetimeIndex))
-        self.assert_(the_int.equals(expected))
+        self.assertTrue(the_int.equals(expected))
 
         # non-overlapping
         the_int = rng[:10].intersection(rng[10:])
         expected = DatetimeIndex([])
-        self.assert_(the_int.equals(expected))
+        self.assertTrue(the_int.equals(expected))
 
     def test_intersection_bug(self):
         # GH #771
         a = bdate_range('11/30/2011', '12/31/2011')
         b = bdate_range('12/10/2011', '12/20/2011')
         result = a.intersection(b)
-        self.assert_(result.equals(b))
+        self.assertTrue(result.equals(b))
 
     def test_summary(self):
         self.rng.summary()
@@ -318,19 +318,19 @@ class TestDateRange(tm.TestCase):
     def test_identical(self):
         t1 = self.rng.copy()
         t2 = self.rng.copy()
-        self.assert_(t1.identical(t2))
+        self.assertTrue(t1.identical(t2))
 
         # name
         t1 = t1.rename('foo')
-        self.assert_(t1.equals(t2))
-        self.assert_(not t1.identical(t2))
+        self.assertTrue(t1.equals(t2))
+        self.assertFalse(t1.identical(t2))
         t2 = t2.rename('foo')
-        self.assert_(t1.identical(t2))
+        self.assertTrue(t1.identical(t2))
 
         # freq
         t2v = Index(t2.values)
-        self.assert_(t1.equals(t2v))
-        self.assert_(not t1.identical(t2v))
+        self.assertTrue(t1.equals(t2v))
+        self.assertFalse(t1.identical(t2v))
 
     def test_daterange_bug_456(self):
         # GH #456
@@ -405,8 +405,8 @@ class TestDateRange(tm.TestCase):
             expected_left = closed[:-1]
             expected_right = closed[1:]
 
-            self.assert_(expected_left.equals(left))
-            self.assert_(expected_right.equals(right))
+            self.assertTrue(expected_left.equals(left))
+            self.assertTrue(expected_right.equals(right))
 
 
 class TestCustomDateRange(tm.TestCase):
@@ -445,13 +445,13 @@ class TestCustomDateRange(tm.TestCase):
         d = self.rng[10]
 
         comp = self.rng > d
-        self.assert_(comp[11])
-        self.assert_(not comp[9])
+        self.assertTrue(comp[11])
+        self.assertFalse(comp[9])
 
     def test_copy(self):
         cp = self.rng.copy()
         repr(cp)
-        self.assert_(cp.equals(self.rng))
+        self.assertTrue(cp.equals(self.rng))
 
     def test_repr(self):
         # only really care that it works
@@ -569,7 +569,7 @@ class TestCustomDateRange(tm.TestCase):
         a = cdate_range('11/30/2011', '12/31/2011')
         b = cdate_range('12/10/2011', '12/20/2011')
         result = a.intersection(b)
-        self.assert_(result.equals(b))
+        self.assertTrue(result.equals(b))
 
     def test_summary(self):
         self.rng.summary()
@@ -616,26 +616,26 @@ class TestCustomDateRange(tm.TestCase):
     def test_cdaterange(self):
         rng = cdate_range('2013-05-01', periods=3)
         xp = DatetimeIndex(['2013-05-01', '2013-05-02', '2013-05-03'])
-        self.assert_(xp.equals(rng))
+        self.assertTrue(xp.equals(rng))
 
     def test_cdaterange_weekmask(self):
         rng = cdate_range('2013-05-01', periods=3,
                           weekmask='Sun Mon Tue Wed Thu')
         xp = DatetimeIndex(['2013-05-01', '2013-05-02', '2013-05-05'])
-        self.assert_(xp.equals(rng))
+        self.assertTrue(xp.equals(rng))
 
     def test_cdaterange_holidays(self):
         rng = cdate_range('2013-05-01', periods=3,
                           holidays=['2013-05-01'])
         xp = DatetimeIndex(['2013-05-02', '2013-05-03', '2013-05-06'])
-        self.assert_(xp.equals(rng))
+        self.assertTrue(xp.equals(rng))
 
     def test_cdaterange_weekmask_and_holidays(self):
         rng = cdate_range('2013-05-01', periods=3,
                           weekmask='Sun Mon Tue Wed Thu',
                           holidays=['2013-05-01'])
         xp = DatetimeIndex(['2013-05-02', '2013-05-05', '2013-05-06'])
-        self.assert_(xp.equals(rng))
+        self.assertTrue(xp.equals(rng))
 
 
 if __name__ == '__main__':

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -150,11 +150,11 @@ class TestOps(Base):
             self.assertIsInstance(result, Timestamp)
 
             # make sure that we are returning NaT
-            self.assert_(NaT + offset is NaT)
-            self.assert_(offset + NaT is NaT)
+            self.assertTrue(NaT + offset is NaT)
+            self.assertTrue(offset + NaT is NaT)
 
-            self.assert_(NaT - offset is NaT)
-            self.assert_((-offset).apply(NaT) is NaT)
+            self.assertTrue(NaT - offset is NaT)
+            self.assertTrue((-offset).apply(NaT) is NaT)
 
 
 class TestDateOffset(Base):
@@ -891,10 +891,10 @@ class TestWeek(Base):
         assertRaisesRegexp(ValueError, "Day must be", Week, weekday=-1)
 
     def test_isAnchored(self):
-        self.assert_(Week(weekday=0).isAnchored())
-        self.assert_(not Week().isAnchored())
-        self.assert_(not Week(2, weekday=2).isAnchored())
-        self.assert_(not Week(2).isAnchored())
+        self.assertTrue(Week(weekday=0).isAnchored())
+        self.assertFalse(Week().isAnchored())
+        self.assertFalse(Week(2, weekday=2).isAnchored())
+        self.assertFalse(Week(2).isAnchored())
 
     def test_offset(self):
         tests = []
@@ -1343,9 +1343,9 @@ class TestBQuarterBegin(Base):
         self.assertEqual(repr(BQuarterBegin(startingMonth=1)), "<BusinessQuarterBegin: startingMonth=1>")
 
     def test_isAnchored(self):
-        self.assert_(BQuarterBegin(startingMonth=1).isAnchored())
-        self.assert_(BQuarterBegin().isAnchored())
-        self.assert_(not BQuarterBegin(2, startingMonth=1).isAnchored())
+        self.assertTrue(BQuarterBegin(startingMonth=1).isAnchored())
+        self.assertTrue(BQuarterBegin().isAnchored())
+        self.assertFalse(BQuarterBegin(2, startingMonth=1).isAnchored())
 
     def test_offset(self):
         tests = []
@@ -1434,9 +1434,9 @@ class TestBQuarterEnd(Base):
         self.assertEqual(repr(BQuarterEnd(startingMonth=1)), "<BusinessQuarterEnd: startingMonth=1>")
 
     def test_isAnchored(self):
-        self.assert_(BQuarterEnd(startingMonth=1).isAnchored())
-        self.assert_(BQuarterEnd().isAnchored())
-        self.assert_(not BQuarterEnd(2, startingMonth=1).isAnchored())
+        self.assertTrue(BQuarterEnd(startingMonth=1).isAnchored())
+        self.assertTrue(BQuarterEnd().isAnchored())
+        self.assertFalse(BQuarterEnd(2, startingMonth=1).isAnchored())
 
     def test_offset(self):
         tests = []
@@ -1740,9 +1740,9 @@ class TestFY5253NearestEndMonth(Base):
 class TestFY5253LastOfMonthQuarter(Base):
 
     def test_isAnchored(self):
-        self.assert_(makeFY5253LastOfMonthQuarter(startingMonth=1, weekday=WeekDay.SAT, qtr_with_extra_week=4).isAnchored())
-        self.assert_(makeFY5253LastOfMonthQuarter(weekday=WeekDay.SAT, startingMonth=3, qtr_with_extra_week=4).isAnchored())
-        self.assert_(not makeFY5253LastOfMonthQuarter(2, startingMonth=1, weekday=WeekDay.SAT, qtr_with_extra_week=4).isAnchored())
+        self.assertTrue(makeFY5253LastOfMonthQuarter(startingMonth=1, weekday=WeekDay.SAT, qtr_with_extra_week=4).isAnchored())
+        self.assertTrue(makeFY5253LastOfMonthQuarter(weekday=WeekDay.SAT, startingMonth=3, qtr_with_extra_week=4).isAnchored())
+        self.assertFalse(makeFY5253LastOfMonthQuarter(2, startingMonth=1, weekday=WeekDay.SAT, qtr_with_extra_week=4).isAnchored())
 
     def test_equality(self):
         self.assertEqual(makeFY5253LastOfMonthQuarter(startingMonth=1, weekday=WeekDay.SAT, qtr_with_extra_week=4), makeFY5253LastOfMonthQuarter(startingMonth=1, weekday=WeekDay.SAT, qtr_with_extra_week=4))
@@ -1963,9 +1963,9 @@ class TestQuarterBegin(Base):
         self.assertEqual(repr(QuarterBegin(startingMonth=1)),"<QuarterBegin: startingMonth=1>")
 
     def test_isAnchored(self):
-        self.assert_(QuarterBegin(startingMonth=1).isAnchored())
-        self.assert_(QuarterBegin().isAnchored())
-        self.assert_(not QuarterBegin(2, startingMonth=1).isAnchored())
+        self.assertTrue(QuarterBegin(startingMonth=1).isAnchored())
+        self.assertTrue(QuarterBegin().isAnchored())
+        self.assertFalse(QuarterBegin(2, startingMonth=1).isAnchored())
 
     def test_offset(self):
         tests = []
@@ -2039,9 +2039,9 @@ class TestQuarterEnd(Base):
         self.assertEqual(repr(QuarterEnd(startingMonth=1)), "<QuarterEnd: startingMonth=1>")
 
     def test_isAnchored(self):
-        self.assert_(QuarterEnd(startingMonth=1).isAnchored())
-        self.assert_(QuarterEnd().isAnchored())
-        self.assert_(not QuarterEnd(2, startingMonth=1).isAnchored())
+        self.assertTrue(QuarterEnd(startingMonth=1).isAnchored())
+        self.assertTrue(QuarterEnd().isAnchored())
+        self.assertFalse(QuarterEnd(2, startingMonth=1).isAnchored())
 
     def test_offset(self):
         tests = []

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -1102,7 +1102,7 @@ class TestPeriodIndex(tm.TestCase):
         p = Period('4/2/2012', freq='B')
         index = PeriodIndex(start=p, periods=10)
         expected = PeriodIndex(start='4/2/2012', periods=10, freq='B')
-        self.assert_(index.equals(expected))
+        self.assertTrue(index.equals(expected))
 
     def test_constructor_field_arrays(self):
         # GH #1264
@@ -1112,14 +1112,14 @@ class TestPeriodIndex(tm.TestCase):
 
         index = PeriodIndex(year=years, quarter=quarters, freq='Q-DEC')
         expected = period_range('1990Q3', '2009Q2', freq='Q-DEC')
-        self.assert_(index.equals(expected))
+        self.assertTrue(index.equals(expected))
 
         self.assertRaises(
             ValueError, PeriodIndex, year=years, quarter=quarters,
             freq='2Q-DEC')
 
         index = PeriodIndex(year=years, quarter=quarters)
-        self.assert_(index.equals(expected))
+        self.assertTrue(index.equals(expected))
 
         years = [2007, 2007, 2007]
         months = [1, 2]
@@ -1134,7 +1134,7 @@ class TestPeriodIndex(tm.TestCase):
         months = [1, 2, 3]
         idx = PeriodIndex(year=years, month=months, freq='M')
         exp = period_range('2007-01', periods=3, freq='M')
-        self.assert_(idx.equals(exp))
+        self.assertTrue(idx.equals(exp))
 
     def test_constructor_U(self):
         # U was used as undefined period
@@ -1165,7 +1165,7 @@ class TestPeriodIndex(tm.TestCase):
 
         result = period_range('2007-01', periods=10.5, freq='M')
         exp = period_range('2007-01', periods=10, freq='M')
-        self.assert_(result.equals(exp))
+        self.assertTrue(result.equals(exp))
 
     def test_constructor_fromarraylike(self):
         idx = period_range('2007-01', periods=20, freq='M')
@@ -1176,17 +1176,17 @@ class TestPeriodIndex(tm.TestCase):
                           data=Period('2007', freq='A'))
 
         result = PeriodIndex(iter(idx))
-        self.assert_(result.equals(idx))
+        self.assertTrue(result.equals(idx))
 
         result = PeriodIndex(idx)
-        self.assert_(result.equals(idx))
+        self.assertTrue(result.equals(idx))
 
         result = PeriodIndex(idx, freq='M')
-        self.assert_(result.equals(idx))
+        self.assertTrue(result.equals(idx))
 
         result = PeriodIndex(idx, freq='D')
         exp = idx.asfreq('D', 'e')
-        self.assert_(result.equals(exp))
+        self.assertTrue(result.equals(exp))
 
     def test_constructor_datetime64arr(self):
         vals = np.arange(100000, 100000 + 10000, 100, dtype=np.int64)
@@ -1197,10 +1197,10 @@ class TestPeriodIndex(tm.TestCase):
     def test_constructor_simple_new(self):
         idx = period_range('2007-01', name='p', periods=20, freq='M')
         result = idx._simple_new(idx, 'p', freq=idx.freq)
-        self.assert_(result.equals(idx))
+        self.assertTrue(result.equals(idx))
 
         result = idx._simple_new(idx.astype('i8'), 'p', freq=idx.freq)
-        self.assert_(result.equals(idx))
+        self.assertTrue(result.equals(idx))
 
     def test_is_(self):
         create_index = lambda: PeriodIndex(freq='A', start='1/1/2001',
@@ -1241,7 +1241,7 @@ class TestPeriodIndex(tm.TestCase):
         self.assertRaises(KeyError, ts.__getitem__, '2006')
 
         result = ts['2008']
-        self.assert_((result.index.year == 2008).all())
+        self.assertTrue((result.index.year == 2008).all())
 
         result = ts['2008':'2009']
         self.assertEquals(len(result), 24)
@@ -1280,7 +1280,7 @@ class TestPeriodIndex(tm.TestCase):
 
         result = rng - 5
         exp = rng + (-5)
-        self.assert_(result.equals(exp))
+        self.assertTrue(result.equals(exp))
 
     def test_periods_number_check(self):
         self.assertRaises(
@@ -1292,7 +1292,7 @@ class TestPeriodIndex(tm.TestCase):
         [tm.assert_isinstance(x, Period) for x in rs]
 
         recon = PeriodIndex(rs)
-        self.assert_(index.equals(recon))
+        self.assertTrue(index.equals(recon))
 
     def test_to_timestamp(self):
         index = PeriodIndex(freq='A', start='1/1/2001', end='12/1/2009')
@@ -1300,12 +1300,12 @@ class TestPeriodIndex(tm.TestCase):
 
         exp_index = date_range('1/1/2001', end='12/31/2009', freq='A-DEC')
         result = series.to_timestamp(how='end')
-        self.assert_(result.index.equals(exp_index))
+        self.assertTrue(result.index.equals(exp_index))
         self.assertEquals(result.name, 'foo')
 
         exp_index = date_range('1/1/2001', end='1/1/2009', freq='AS-JAN')
         result = series.to_timestamp(how='start')
-        self.assert_(result.index.equals(exp_index))
+        self.assertTrue(result.index.equals(exp_index))
 
         def _get_with_delta(delta, freq='A-DEC'):
             return date_range(to_datetime('1/1/2001') + delta,
@@ -1314,17 +1314,17 @@ class TestPeriodIndex(tm.TestCase):
         delta = timedelta(hours=23)
         result = series.to_timestamp('H', 'end')
         exp_index = _get_with_delta(delta)
-        self.assert_(result.index.equals(exp_index))
+        self.assertTrue(result.index.equals(exp_index))
 
         delta = timedelta(hours=23, minutes=59)
         result = series.to_timestamp('T', 'end')
         exp_index = _get_with_delta(delta)
-        self.assert_(result.index.equals(exp_index))
+        self.assertTrue(result.index.equals(exp_index))
 
         result = series.to_timestamp('S', 'end')
         delta = timedelta(hours=23, minutes=59, seconds=59)
         exp_index = _get_with_delta(delta)
-        self.assert_(result.index.equals(exp_index))
+        self.assertTrue(result.index.equals(exp_index))
 
         self.assertRaises(ValueError, index.to_timestamp, '5t')
 
@@ -1334,7 +1334,7 @@ class TestPeriodIndex(tm.TestCase):
         exp_index = date_range('1/1/2001 00:59:59', end='1/2/2001 00:59:59',
                                freq='H')
         result = series.to_timestamp(how='end')
-        self.assert_(result.index.equals(exp_index))
+        self.assertTrue(result.index.equals(exp_index))
         self.assertEquals(result.name, 'foo')
 
     def test_to_timestamp_quarterly_bug(self):
@@ -1345,7 +1345,7 @@ class TestPeriodIndex(tm.TestCase):
 
         stamps = pindex.to_timestamp('D', 'end')
         expected = DatetimeIndex([x.to_timestamp('D', 'end') for x in pindex])
-        self.assert_(stamps.equals(expected))
+        self.assertTrue(stamps.equals(expected))
 
     def test_to_timestamp_preserve_name(self):
         index = PeriodIndex(freq='A', start='1/1/2001', end='12/1/2009',
@@ -1392,11 +1392,11 @@ class TestPeriodIndex(tm.TestCase):
 
         df['Index'] = rng
         rs = Index(df['Index'])
-        self.assert_(rs.equals(rng))
+        self.assertTrue(rs.equals(rng))
 
         rs = df.reset_index().set_index('index')
         tm.assert_isinstance(rs.index, PeriodIndex)
-        self.assert_(rs.index.equals(rng))
+        self.assertTrue(rs.index.equals(rng))
 
     def test_period_set_index_reindex(self):
         # GH 6631
@@ -1405,9 +1405,9 @@ class TestPeriodIndex(tm.TestCase):
         idx2 = period_range('2013', periods=6, freq='A')
 
         df = df.set_index(idx1)
-        self.assert_(df.index.equals(idx1))
+        self.assertTrue(df.index.equals(idx1))
         df = df.reindex(idx2)
-        self.assert_(df.index.equals(idx2))
+        self.assertTrue(df.index.equals(idx2))
 
     def test_nested_dict_frame_constructor(self):
         rng = period_range('1/1/2000', periods=5)
@@ -1437,12 +1437,12 @@ class TestPeriodIndex(tm.TestCase):
 
         exp_index = date_range('1/1/2001', end='12/31/2009', freq='A-DEC')
         result = df.to_timestamp('D', 'end')
-        self.assert_(result.index.equals(exp_index))
+        self.assertTrue(result.index.equals(exp_index))
         assert_almost_equal(result.values, df.values)
 
         exp_index = date_range('1/1/2001', end='1/1/2009', freq='AS-JAN')
         result = df.to_timestamp('D', 'start')
-        self.assert_(result.index.equals(exp_index))
+        self.assertTrue(result.index.equals(exp_index))
 
         def _get_with_delta(delta, freq='A-DEC'):
             return date_range(to_datetime('1/1/2001') + delta,
@@ -1451,44 +1451,44 @@ class TestPeriodIndex(tm.TestCase):
         delta = timedelta(hours=23)
         result = df.to_timestamp('H', 'end')
         exp_index = _get_with_delta(delta)
-        self.assert_(result.index.equals(exp_index))
+        self.assertTrue(result.index.equals(exp_index))
 
         delta = timedelta(hours=23, minutes=59)
         result = df.to_timestamp('T', 'end')
         exp_index = _get_with_delta(delta)
-        self.assert_(result.index.equals(exp_index))
+        self.assertTrue(result.index.equals(exp_index))
 
         result = df.to_timestamp('S', 'end')
         delta = timedelta(hours=23, minutes=59, seconds=59)
         exp_index = _get_with_delta(delta)
-        self.assert_(result.index.equals(exp_index))
+        self.assertTrue(result.index.equals(exp_index))
 
         # columns
         df = df.T
 
         exp_index = date_range('1/1/2001', end='12/31/2009', freq='A-DEC')
         result = df.to_timestamp('D', 'end', axis=1)
-        self.assert_(result.columns.equals(exp_index))
+        self.assertTrue(result.columns.equals(exp_index))
         assert_almost_equal(result.values, df.values)
 
         exp_index = date_range('1/1/2001', end='1/1/2009', freq='AS-JAN')
         result = df.to_timestamp('D', 'start', axis=1)
-        self.assert_(result.columns.equals(exp_index))
+        self.assertTrue(result.columns.equals(exp_index))
 
         delta = timedelta(hours=23)
         result = df.to_timestamp('H', 'end', axis=1)
         exp_index = _get_with_delta(delta)
-        self.assert_(result.columns.equals(exp_index))
+        self.assertTrue(result.columns.equals(exp_index))
 
         delta = timedelta(hours=23, minutes=59)
         result = df.to_timestamp('T', 'end', axis=1)
         exp_index = _get_with_delta(delta)
-        self.assert_(result.columns.equals(exp_index))
+        self.assertTrue(result.columns.equals(exp_index))
 
         result = df.to_timestamp('S', 'end', axis=1)
         delta = timedelta(hours=23, minutes=59, seconds=59)
         exp_index = _get_with_delta(delta)
-        self.assert_(result.columns.equals(exp_index))
+        self.assertTrue(result.columns.equals(exp_index))
 
         # invalid axis
         assertRaisesRegexp(ValueError, 'axis', df.to_timestamp, axis=2)
@@ -1503,7 +1503,7 @@ class TestPeriodIndex(tm.TestCase):
         expected = ts[1:3]
         assert_series_equal(result, expected)
         result[:] = 1
-        self.assert_((ts[1:3] == 1).all())
+        self.assertTrue((ts[1:3] == 1).all())
 
         # not monotonic
         idx = PeriodIndex([2000, 2007, 2007, 2009, 2007], freq='A-JUN')
@@ -1564,13 +1564,13 @@ class TestPeriodIndex(tm.TestCase):
         end_intv = Period('2006-12-31', '1w')
         i2 = PeriodIndex(end=end_intv, periods=10)
         assert_equal(len(i1), len(i2))
-        self.assert_((i1 == i2).all())
+        self.assertTrue((i1 == i2).all())
         assert_equal(i1.freq, i2.freq)
 
         end_intv = Period('2006-12-31', ('w', 1))
         i2 = PeriodIndex(end=end_intv, periods=10)
         assert_equal(len(i1), len(i2))
-        self.assert_((i1 == i2).all())
+        self.assertTrue((i1 == i2).all())
         assert_equal(i1.freq, i2.freq)
 
         try:
@@ -1608,7 +1608,7 @@ class TestPeriodIndex(tm.TestCase):
         pi1 = PeriodIndex(freq='A', start='1/1/2001', end='12/1/2009')
         pi2 = PeriodIndex(freq='A', start='1/1/2002', end='12/1/2010')
 
-        self.assert_(pi1.shift(0).equals(pi1))
+        self.assertTrue(pi1.shift(0).equals(pi1))
 
         assert_equal(len(pi1), len(pi2))
         assert_equal(pi1.shift(1).values, pi2.values)
@@ -1747,7 +1747,7 @@ class TestPeriodIndex(tm.TestCase):
         end_intv = Period('2006-12-31', '1w')
         i2 = PeriodIndex(end=end_intv, periods=10)
         assert_equal(len(i1), len(i2))
-        self.assert_((i1 == i2).all())
+        self.assertTrue((i1 == i2).all())
         assert_equal(i1.freq, i2.freq)
         assert_equal(i1, eval(compat.text_type(i1)))
         assert_equal(i2, eval(compat.text_type(i2)))
@@ -1755,7 +1755,7 @@ class TestPeriodIndex(tm.TestCase):
         end_intv = Period('2006-12-31', ('w', 1))
         i2 = PeriodIndex(end=end_intv, periods=10)
         assert_equal(len(i1), len(i2))
-        self.assert_((i1 == i2).all())
+        self.assertTrue((i1 == i2).all())
         assert_equal(i1.freq, i2.freq)
         assert_equal(i1, eval(compat.text_type(i1)))
         assert_equal(i2, eval(compat.text_type(i2)))
@@ -1810,12 +1810,12 @@ class TestPeriodIndex(tm.TestCase):
         df_result = df.asfreq('D', how='end')
         exp_index = index.asfreq('D', how='end')
         self.assertEqual(len(result), len(ts))
-        self.assert_(result.index.equals(exp_index))
-        self.assert_(df_result.index.equals(exp_index))
+        self.assertTrue(result.index.equals(exp_index))
+        self.assertTrue(df_result.index.equals(exp_index))
 
         result = ts.asfreq('D', how='start')
         self.assertEqual(len(result), len(ts))
-        self.assert_(result.index.equals(index.asfreq('D', how='start')))
+        self.assertTrue(result.index.equals(index.asfreq('D', how='start')))
 
     def test_badinput(self):
         self.assertRaises(datetools.DateParseError, Period, '1/1/-2000', 'A')
@@ -1985,11 +1985,11 @@ class TestPeriodIndex(tm.TestCase):
     def test_period_dt64_round_trip(self):
         dti = date_range('1/1/2000', '1/7/2002', freq='B')
         pi = dti.to_period()
-        self.assert_(pi.to_timestamp().equals(dti))
+        self.assertTrue(pi.to_timestamp().equals(dti))
 
         dti = date_range('1/1/2000', '1/7/2002', freq='B')
         pi = dti.to_period(freq='H')
-        self.assert_(pi.to_timestamp().equals(dti))
+        self.assertTrue(pi.to_timestamp().equals(dti))
 
     def test_to_period_quarterly(self):
         # make sure we can make the round trip
@@ -1998,7 +1998,7 @@ class TestPeriodIndex(tm.TestCase):
             rng = period_range('1989Q3', '1991Q3', freq=freq)
             stamps = rng.to_timestamp()
             result = stamps.to_period(freq)
-            self.assert_(rng.equals(result))
+            self.assertTrue(rng.equals(result))
 
     def test_to_period_quarterlyish(self):
         offsets = ['BQ', 'QS', 'BQS']
@@ -2129,11 +2129,11 @@ class TestPeriodIndex(tm.TestCase):
         index = period_range('1/1/2000', '1/20/2000', freq='D')
 
         result = index[:-5].union(index[10:])
-        self.assert_(result.equals(index))
+        self.assertTrue(result.equals(index))
 
         # not in order
         result = _permute(index[:-5]).union(_permute(index[10:]))
-        self.assert_(result.equals(index))
+        self.assertTrue(result.equals(index))
 
         # raise if different frequencies
         index = period_range('1/1/2000', '1/20/2000', freq='D')
@@ -2146,13 +2146,13 @@ class TestPeriodIndex(tm.TestCase):
         index = period_range('1/1/2000', '1/20/2000', freq='D')
 
         result = index[:-5].intersection(index[10:])
-        self.assert_(result.equals(index[10:-5]))
+        self.assertTrue(result.equals(index[10:-5]))
 
         # not in order
         left = _permute(index[:-5])
         right = _permute(index[10:])
         result = left.intersection(right).order()
-        self.assert_(result.equals(index[10:-5]))
+        self.assertTrue(result.equals(index[10:-5]))
 
         # raise if different frequencies
         index = period_range('1/1/2000', '1/20/2000', freq='D')
@@ -2207,27 +2207,27 @@ class TestPeriodIndex(tm.TestCase):
 
     def test_is_full(self):
         index = PeriodIndex([2005, 2007, 2009], freq='A')
-        self.assert_(not index.is_full)
+        self.assertFalse(index.is_full)
 
         index = PeriodIndex([2005, 2006, 2007], freq='A')
-        self.assert_(index.is_full)
+        self.assertTrue(index.is_full)
 
         index = PeriodIndex([2005, 2005, 2007], freq='A')
-        self.assert_(not index.is_full)
+        self.assertFalse(index.is_full)
 
         index = PeriodIndex([2005, 2005, 2006], freq='A')
-        self.assert_(index.is_full)
+        self.assertTrue(index.is_full)
 
         index = PeriodIndex([2006, 2005, 2005], freq='A')
         self.assertRaises(ValueError, getattr, index, 'is_full')
 
-        self.assert_(index[:0].is_full)
+        self.assertTrue(index[:0].is_full)
 
     def test_map(self):
         index = PeriodIndex([2005, 2007, 2009], freq='A')
         result = index.map(lambda x: x + 1)
         expected = index + 1
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         result = index.map(lambda x: x.ordinal)
         exp = [x.ordinal for x in index]
@@ -2250,7 +2250,7 @@ class TestPeriodIndex(tm.TestCase):
             tm.assert_isinstance(res, np.ndarray)
 
             # preserve element types
-            self.assert_(all(isinstance(resi, t) for resi in res))
+            self.assertTrue(all(isinstance(resi, t) for resi in res))
 
             # dtype should be object
             self.assertEqual(res.dtype, np.dtype('object').type)
@@ -2328,11 +2328,11 @@ class TestPeriodIndex(tm.TestCase):
 
         arr, idx = idx1.factorize()
         self.assert_numpy_array_equal(arr, exp_arr)
-        self.assert_(idx.equals(exp_idx))
+        self.assertTrue(idx.equals(exp_idx))
 
         arr, idx = idx1.factorize(sort=True)
         self.assert_numpy_array_equal(arr, exp_arr)
-        self.assert_(idx.equals(exp_idx))
+        self.assertTrue(idx.equals(exp_idx))
 
         idx2 = pd.PeriodIndex(['2014-03', '2014-03', '2014-02', '2014-01',
                                '2014-03', '2014-01'], freq='M')
@@ -2340,19 +2340,19 @@ class TestPeriodIndex(tm.TestCase):
         exp_arr = np.array([2, 2, 1, 0, 2, 0])
         arr, idx = idx2.factorize(sort=True)
         self.assert_numpy_array_equal(arr, exp_arr)
-        self.assert_(idx.equals(exp_idx))
+        self.assertTrue(idx.equals(exp_idx))
 
         exp_arr = np.array([0, 0, 1, 2, 0, 2])
         exp_idx = PeriodIndex(['2014-03', '2014-02', '2014-01'], freq='M')
         arr, idx = idx2.factorize()
         self.assert_numpy_array_equal(arr, exp_arr)
-        self.assert_(idx.equals(exp_idx))
+        self.assertTrue(idx.equals(exp_idx))
 
     def test_recreate_from_data(self):
         for o in ['M', 'Q', 'A', 'D', 'B', 'T', 'S', 'L', 'U', 'N', 'H']:
             org = PeriodIndex(start='2001/04/01', freq=o, periods=1)
             idx = PeriodIndex(org.values, freq=o)
-            self.assert_(idx.equals(org))
+            self.assertTrue(idx.equals(org))
 
 def _permute(obj):
     return obj.take(np.random.permutation(len(obj)))
@@ -2452,7 +2452,7 @@ class TestComparisons(tm.TestCase):
         self.assertNotEqual(self.january1, self.february)
 
     def test_greater(self):
-        self.assert_(self.february > self.january1)
+        self.assertTrue(self.february > self.january1)
 
     def test_greater_Raises_Value(self):
         self.assertRaises(ValueError, self.january1.__gt__, self.day)
@@ -2461,14 +2461,14 @@ class TestComparisons(tm.TestCase):
         self.assertRaises(TypeError, self.january1.__gt__, 1)
 
     def test_greaterEqual(self):
-        self.assert_(self.january1 >= self.january2)
+        self.assertTrue(self.january1 >= self.january2)
 
     def test_greaterEqual_Raises_Value(self):
         self.assertRaises(ValueError, self.january1.__ge__, self.day)
         self.assertRaises(TypeError, self.january1.__ge__, 1)
 
     def test_smallerEqual(self):
-        self.assert_(self.january1 <= self.january2)
+        self.assertTrue(self.january1 <= self.january2)
 
     def test_smallerEqual_Raises_Value(self):
         self.assertRaises(ValueError, self.january1.__le__, self.day)
@@ -2477,7 +2477,7 @@ class TestComparisons(tm.TestCase):
         self.assertRaises(TypeError, self.january1.__le__, 1)
 
     def test_smaller(self):
-        self.assert_(self.january1 < self.february)
+        self.assertTrue(self.january1 < self.february)
 
     def test_smaller_Raises_Value(self):
         self.assertRaises(ValueError, self.january1.__lt__, self.day)

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -248,7 +248,7 @@ class TestTSPlot(tm.TestCase):
         diffs = Series(ax.get_lines()[0].get_xydata()[:, 0]).diff()
 
         sec = 1. / 24 / 60 / 60
-        self.assert_((np.fabs(diffs[1:] - [sec, sec * 2, sec]) < 1e-8).all())
+        self.assertTrue((np.fabs(diffs[1:] - [sec, sec * 2, sec]) < 1e-8).all())
 
         plt.clf()
         fig.add_subplot(111)
@@ -256,7 +256,7 @@ class TestTSPlot(tm.TestCase):
         df2.index = df.index.asobject
         ax = df2.plot()
         diffs = Series(ax.get_lines()[0].get_xydata()[:, 0]).diff()
-        self.assert_((np.fabs(diffs[1:] - sec) < 1e-8).all())
+        self.assertTrue((np.fabs(diffs[1:] - sec) < 1e-8).all())
 
     def test_irregular_datetime64_repr_bug(self):
         import matplotlib.pyplot as plt
@@ -475,7 +475,7 @@ class TestTSPlot(tm.TestCase):
         data = l.get_xydata()
         tm.assert_isinstance(data, np.ma.core.MaskedArray)
         mask = data.mask
-        self.assert_(mask[5:25, 1].all())
+        self.assertTrue(mask[5:25, 1].all())
         plt.close(ax.get_figure())
 
         # irregular
@@ -489,7 +489,7 @@ class TestTSPlot(tm.TestCase):
         data = l.get_xydata()
         tm.assert_isinstance(data, np.ma.core.MaskedArray)
         mask = data.mask
-        self.assert_(mask[2:5, 1].all())
+        self.assertTrue(mask[2:5, 1].all())
         plt.close(ax.get_figure())
 
         # non-ts
@@ -503,7 +503,7 @@ class TestTSPlot(tm.TestCase):
         data = l.get_xydata()
         tm.assert_isinstance(data, np.ma.core.MaskedArray)
         mask = data.mask
-        self.assert_(mask[2:5, 1].all())
+        self.assertTrue(mask[2:5, 1].all())
 
     @slow
     def test_gap_upsample(self):
@@ -521,7 +521,7 @@ class TestTSPlot(tm.TestCase):
         data = l.get_xydata()
         tm.assert_isinstance(data, np.ma.core.MaskedArray)
         mask = data.mask
-        self.assert_(mask[5:25, 1].all())
+        self.assertTrue(mask[5:25, 1].all())
 
     @slow
     def test_secondary_y(self):
@@ -545,7 +545,7 @@ class TestTSPlot(tm.TestCase):
 
         ax = ser2.plot()
         ax2 = ser.plot(secondary_y=True).right_ax
-        self.assert_(ax.get_yaxis().get_visible())
+        self.assertTrue(ax.get_yaxis().get_visible())
 
     @slow
     def test_secondary_y_ts(self):
@@ -569,7 +569,7 @@ class TestTSPlot(tm.TestCase):
 
         ax = ser2.plot()
         ax2 = ser.plot(secondary_y=True)
-        self.assert_(ax.get_yaxis().get_visible())
+        self.assertTrue(ax.get_yaxis().get_visible())
 
     @slow
     def test_secondary_kde(self):
@@ -616,8 +616,8 @@ class TestTSPlot(tm.TestCase):
         lines = ax2.get_lines()
         idx1 = lines[0].get_xdata()
         idx2 = lines[1].get_xdata()
-        self.assert_(idx1.equals(s1.index.to_period('B')))
-        self.assert_(idx2.equals(s2.index.to_period('B')))
+        self.assertTrue(idx1.equals(s1.index.to_period('B')))
+        self.assertTrue(idx2.equals(s2.index.to_period('B')))
         left, right = ax2.get_xlim()
         pidx = s1.index.to_period()
         self.assertEqual(left, pidx[0].ordinal)
@@ -703,7 +703,7 @@ class TestTSPlot(tm.TestCase):
         high.plot()
         ax = low.plot()
         for l in ax.get_lines():
-            self.assert_(PeriodIndex(data=l.get_xdata()).freq.startswith('W'))
+            self.assertTrue(PeriodIndex(data=l.get_xdata()).freq.startswith('W'))
 
     @slow
     def test_from_weekly_resampling(self):
@@ -714,7 +714,7 @@ class TestTSPlot(tm.TestCase):
         low.plot()
         ax = high.plot()
         for l in ax.get_lines():
-            self.assert_(PeriodIndex(data=l.get_xdata()).freq.startswith('W'))
+            self.assertTrue(PeriodIndex(data=l.get_xdata()).freq.startswith('W'))
 
     @slow
     def test_irreg_dtypes(self):

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -64,7 +64,7 @@ class TestResample(tm.TestCase):
             g._cython_agg_general(f)
 
         self.assertEquals(g.ngroups, 2593)
-        self.assert_(notnull(g.mean()).all())
+        self.assertTrue(notnull(g.mean()).all())
 
         # construct expected val
         arr = [1] + [5] * 2592
@@ -116,45 +116,45 @@ class TestResample(tm.TestCase):
         result = s.resample('w-sun', how='last')
 
         self.assertEquals(len(result), 3)
-        self.assert_((result.index.dayofweek == [6, 6, 6]).all())
+        self.assertTrue((result.index.dayofweek == [6, 6, 6]).all())
         self.assertEquals(result.irow(0), s['1/2/2005'])
         self.assertEquals(result.irow(1), s['1/9/2005'])
         self.assertEquals(result.irow(2), s.irow(-1))
 
         result = s.resample('W-MON', how='last')
         self.assertEquals(len(result), 2)
-        self.assert_((result.index.dayofweek == [0, 0]).all())
+        self.assertTrue((result.index.dayofweek == [0, 0]).all())
         self.assertEquals(result.irow(0), s['1/3/2005'])
         self.assertEquals(result.irow(1), s['1/10/2005'])
 
         result = s.resample('W-TUE', how='last')
         self.assertEquals(len(result), 2)
-        self.assert_((result.index.dayofweek == [1, 1]).all())
+        self.assertTrue((result.index.dayofweek == [1, 1]).all())
         self.assertEquals(result.irow(0), s['1/4/2005'])
         self.assertEquals(result.irow(1), s['1/10/2005'])
 
         result = s.resample('W-WED', how='last')
         self.assertEquals(len(result), 2)
-        self.assert_((result.index.dayofweek == [2, 2]).all())
+        self.assertTrue((result.index.dayofweek == [2, 2]).all())
         self.assertEquals(result.irow(0), s['1/5/2005'])
         self.assertEquals(result.irow(1), s['1/10/2005'])
 
         result = s.resample('W-THU', how='last')
         self.assertEquals(len(result), 2)
-        self.assert_((result.index.dayofweek == [3, 3]).all())
+        self.assertTrue((result.index.dayofweek == [3, 3]).all())
         self.assertEquals(result.irow(0), s['1/6/2005'])
         self.assertEquals(result.irow(1), s['1/10/2005'])
 
         result = s.resample('W-FRI', how='last')
         self.assertEquals(len(result), 2)
-        self.assert_((result.index.dayofweek == [4, 4]).all())
+        self.assertTrue((result.index.dayofweek == [4, 4]).all())
         self.assertEquals(result.irow(0), s['1/7/2005'])
         self.assertEquals(result.irow(1), s['1/10/2005'])
 
         # to biz day
         result = s.resample('B', how='last')
         self.assertEquals(len(result), 7)
-        self.assert_((result.index.dayofweek == [4, 0, 1, 2, 3, 4, 0]).all())
+        self.assertTrue((result.index.dayofweek == [4, 0, 1, 2, 3, 4, 0]).all())
         self.assertEquals(result.irow(0), s['1/2/2005'])
         self.assertEquals(result.irow(1), s['1/3/2005'])
         self.assertEquals(result.irow(5), s['1/9/2005'])
@@ -369,13 +369,13 @@ class TestResample(tm.TestCase):
         resampled = ts.resample('5min', how='ohlc', closed='right',
                                 label='right')
 
-        self.assert_((resampled.ix['1/1/2000 00:00'] == ts[0]).all())
+        self.assertTrue((resampled.ix['1/1/2000 00:00'] == ts[0]).all())
 
         exp = _ohlc(ts[1:31])
-        self.assert_((resampled.ix['1/1/2000 00:05'] == exp).all())
+        self.assertTrue((resampled.ix['1/1/2000 00:05'] == exp).all())
 
         exp = _ohlc(ts['1/1/2000 5:55:01':])
-        self.assert_((resampled.ix['1/1/2000 6:00:00'] == exp).all())
+        self.assertTrue((resampled.ix['1/1/2000 6:00:00'] == exp).all())
 
     def test_downsample_non_unique(self):
         rng = date_range('1/1/2000', '2/29/2000')
@@ -492,7 +492,7 @@ class TestResample(tm.TestCase):
         resampled = ts.resample('5min', base=2)
         exp_rng = date_range('12/31/1999 23:57:00', '1/1/2000 01:57',
                              freq='5min')
-        self.assert_(resampled.index.equals(exp_rng))
+        self.assertTrue(resampled.index.equals(exp_rng))
 
     def test_resample_daily_anchored(self):
         rng = date_range('1/1/2000 0:00:00', periods=10000, freq='T')
@@ -511,7 +511,7 @@ class TestResample(tm.TestCase):
 
         result = ts.resample('M', kind='period')
         exp_index = period_range('Jan-2000', 'Dec-2000', freq='M')
-        self.assert_(result.index.equals(exp_index))
+        self.assertTrue(result.index.equals(exp_index))
 
     def test_resample_empty(self):
         ts = _simple_ts('1/1/2000', '2/1/2000')[:0]
@@ -593,7 +593,7 @@ class TestResample(tm.TestCase):
 
         result = ts.resample('5t', closed='right', label='left')
         ex_index = date_range('1999-12-31 23:55', periods=4, freq='5t')
-        self.assert_(result.index.equals(ex_index))
+        self.assertTrue(result.index.equals(ex_index))
 
         len0pts = _simple_pts('2007-01', '2010-05', freq='M')[:0]
         # it works
@@ -955,7 +955,7 @@ class TestResamplePeriodIndex(tm.TestCase):
 
         result = ts.resample('W-THU')
 
-        self.assert_(result.isnull().all())
+        self.assertTrue(result.isnull().all())
 
         result = ts.resample('W-THU', fill_method='ffill')[:-1]
         expected = ts.asfreq('W-THU', method='ffill')
@@ -1027,7 +1027,7 @@ class TestResamplePeriodIndex(tm.TestCase):
 
         ex_index = date_range(start='1/1/2012 9:30', freq='10min', periods=3)
 
-        self.assert_(result.index.equals(ex_index))
+        self.assertTrue(result.index.equals(ex_index))
         assert_series_equal(result, exp)
 
     def test_quarterly_resampling(self):

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -140,7 +140,7 @@ class TestTimedeltas(tm.TestCase):
         self.assertEqual(result.astype('int64'), tslib.iNaT)
 
         result = to_timedelta(['', ''])
-        self.assert_(isnull(result).all())
+        self.assertTrue(isnull(result).all())
 
         # pass thru
         result = to_timedelta(np.array([np.timedelta64(1,'s')]))

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -72,14 +72,14 @@ class TestTimeSeriesDuplicates(tm.TestCase):
         tm.assert_isinstance(self.dups.index, DatetimeIndex)
 
     def test_is_unique_monotonic(self):
-        self.assert_(not self.dups.index.is_unique)
+        self.assertFalse(self.dups.index.is_unique)
 
     def test_index_unique(self):
         uniques = self.dups.index.unique()
         expected = DatetimeIndex([datetime(2000, 1, 2), datetime(2000, 1, 3),
                                   datetime(2000, 1, 4), datetime(2000, 1, 5)])
         self.assertEqual(uniques.dtype, 'M8[ns]')  # sanity
-        self.assert_(uniques.equals(expected))
+        self.assertTrue(uniques.equals(expected))
         self.assertEqual(self.dups.index.nunique(), 4)
 
         # #2563
@@ -91,17 +91,17 @@ class TestTimeSeriesDuplicates(tm.TestCase):
         expected = DatetimeIndex(expected, tz='US/Eastern')
         self.assertTrue(result.tz is not None)
         self.assertEquals(result.name, 'foo')
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         # NaT
         arr = [ 1370745748 + t for t in range(20) ] + [iNaT]
         idx = DatetimeIndex(arr * 3)
-        self.assert_(idx.unique().equals(DatetimeIndex(arr)))
+        self.assertTrue(idx.unique().equals(DatetimeIndex(arr)))
         self.assertEqual(idx.nunique(), 21)
 
         arr = [ Timestamp('2013-06-09 02:42:28') + timedelta(seconds=t) for t in range(20) ] + [NaT]
         idx = DatetimeIndex(arr * 3)
-        self.assert_(idx.unique().equals(DatetimeIndex(arr)))
+        self.assertTrue(idx.unique().equals(DatetimeIndex(arr)))
         self.assertEqual(idx.nunique(), 21)
 
     def test_index_dupes_contains(self):
@@ -190,7 +190,7 @@ class TestTimeSeriesDuplicates(tm.TestCase):
 
             # it works!
             df.ix[timestamp]
-            self.assert_(len(df.ix[[timestamp]]) > 0)
+            self.assertTrue(len(df.ix[[timestamp]]) > 0)
         finally:
             _index._SIZE_CUTOFF = old_cutoff
 
@@ -294,7 +294,7 @@ class TestTimeSeriesDuplicates(tm.TestCase):
         for f in freqs:
             org = DatetimeIndex(start='2001/02/01 09:00', freq=f, periods=1)
             idx = DatetimeIndex(org, freq=f)
-            self.assert_(idx.equals(org))
+            self.assertTrue(idx.equals(org))
 
         # unbale to create tz-aware 'A' and 'C' freq
         if _np_version_under1p7:
@@ -305,7 +305,7 @@ class TestTimeSeriesDuplicates(tm.TestCase):
         for f in freqs:
             org = DatetimeIndex(start='2001/02/01 09:00', freq=f, tz='US/Pacific', periods=1)
             idx = DatetimeIndex(org, freq=f, tz='US/Pacific')
-            self.assert_(idx.equals(org))
+            self.assertTrue(idx.equals(org))
 
 
 def assert_range_equal(left, right):
@@ -607,7 +607,7 @@ class TestTimeSeries(tm.TestCase):
         dates = np.asarray(rng)
 
         df = DataFrame({'A': np.random.randn(len(rng)), 'B': dates})
-        self.assert_(np.issubdtype(df['B'].dtype, np.dtype('M8[ns]')))
+        self.assertTrue(np.issubdtype(df['B'].dtype, np.dtype('M8[ns]')))
 
     def test_frame_add_datetime64_column(self):
         rng = date_range('1/1/2000 00:00:00', '1/1/2000 1:59:50',
@@ -615,7 +615,7 @@ class TestTimeSeries(tm.TestCase):
         df = DataFrame(index=np.arange(len(rng)))
 
         df['A'] = rng
-        self.assert_(np.issubdtype(df['A'].dtype, np.dtype('M8[ns]')))
+        self.assertTrue(np.issubdtype(df['A'].dtype, np.dtype('M8[ns]')))
 
     def test_frame_datetime64_pre1900_repr(self):
         df = DataFrame({'year': date_range('1/1/1700', periods=50,
@@ -640,7 +640,7 @@ class TestTimeSeries(tm.TestCase):
             ex_vals = to_datetime(vals.astype('O'))
 
             self.assertEqual(df[unit].dtype, ns_dtype)
-            self.assert_((df[unit].values == ex_vals).all())
+            self.assertTrue((df[unit].values == ex_vals).all())
 
         # Test insertion into existing datetime64 column
         df = DataFrame({'ints': np.arange(n)}, index=np.arange(n))
@@ -655,7 +655,7 @@ class TestTimeSeries(tm.TestCase):
             tmp['dates'] = vals
             ex_vals = to_datetime(vals.astype('O'))
 
-            self.assert_((tmp['dates'].values == ex_vals).all())
+            self.assertTrue((tmp['dates'].values == ex_vals).all())
 
     def test_to_datetime_unit(self):
 
@@ -691,14 +691,14 @@ class TestTimeSeries(tm.TestCase):
         dates = np.asarray(rng)
 
         series = Series(dates)
-        self.assert_(np.issubdtype(series.dtype, np.dtype('M8[ns]')))
+        self.assertTrue(np.issubdtype(series.dtype, np.dtype('M8[ns]')))
 
     def test_index_cast_datetime64_other_units(self):
         arr = np.arange(0, 100, 10, dtype=np.int64).view('M8[D]')
 
         idx = Index(arr)
 
-        self.assert_((idx.values == tslib.cast_to_nanoseconds(arr)).all())
+        self.assertTrue((idx.values == tslib.cast_to_nanoseconds(arr)).all())
 
     def test_index_astype_datetime64(self):
         idx = Index([datetime(2012, 1, 1)], dtype=object)
@@ -709,29 +709,29 @@ class TestTimeSeries(tm.TestCase):
         casted = idx.astype(np.dtype('M8[D]'))
         expected = DatetimeIndex(idx.values)
         tm.assert_isinstance(casted, DatetimeIndex)
-        self.assert_(casted.equals(expected))
+        self.assertTrue(casted.equals(expected))
 
     def test_reindex_series_add_nat(self):
         rng = date_range('1/1/2000 00:00:00', periods=10, freq='10s')
         series = Series(rng)
 
         result = series.reindex(lrange(15))
-        self.assert_(np.issubdtype(result.dtype, np.dtype('M8[ns]')))
+        self.assertTrue(np.issubdtype(result.dtype, np.dtype('M8[ns]')))
 
         mask = result.isnull()
-        self.assert_(mask[-5:].all())
-        self.assert_(not mask[:-5].any())
+        self.assertTrue(mask[-5:].all())
+        self.assertFalse(mask[:-5].any())
 
     def test_reindex_frame_add_nat(self):
         rng = date_range('1/1/2000 00:00:00', periods=10, freq='10s')
         df = DataFrame({'A': np.random.randn(len(rng)), 'B': rng})
 
         result = df.reindex(lrange(15))
-        self.assert_(np.issubdtype(result['B'].dtype, np.dtype('M8[ns]')))
+        self.assertTrue(np.issubdtype(result['B'].dtype, np.dtype('M8[ns]')))
 
         mask = com.isnull(result)['B']
-        self.assert_(mask[-5:].all())
-        self.assert_(not mask[:-5].any())
+        self.assertTrue(mask[-5:].all())
+        self.assertFalse(mask[:-5].any())
 
     def test_series_repr_nat(self):
         series = Series([0, 1000, 2000, iNaT], dtype='M8[ns]')
@@ -846,7 +846,7 @@ class TestTimeSeries(tm.TestCase):
     def test_to_datetime_default(self):
         rs = to_datetime('2001')
         xp = datetime(2001, 1, 1)
-        self.assert_(rs, xp)
+        self.assertTrue(rs, xp)
 
         #### dayfirst is essentially broken
         #### to_datetime('01-13-2012', dayfirst=True)
@@ -907,7 +907,7 @@ class TestTimeSeries(tm.TestCase):
         self.assertIs(result, NaT)
 
         result = to_datetime(['', ''])
-        self.assert_(isnull(result).all())
+        self.assertTrue(isnull(result).all())
 
         # ints
         result = Timestamp(0)
@@ -957,7 +957,7 @@ class TestTimeSeries(tm.TestCase):
 
         result = DatetimeIndex(ints)
 
-        self.assert_(rng.equals(result))
+        self.assertTrue(rng.equals(result))
 
     def test_to_datetime_dt64s(self):
         in_bound_dts = [
@@ -1033,13 +1033,13 @@ class TestTimeSeries(tm.TestCase):
 
         result = idx.to_datetime()
         expected = DatetimeIndex(datetools.to_datetime(idx.values))
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         today = datetime.today()
         idx = Index([today], dtype=object)
         result = idx.to_datetime()
         expected = DatetimeIndex([today])
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
     def test_to_datetime_freq(self):
         xp = bdate_range('2000-1-1', periods=10, tz='UTC')
@@ -1169,7 +1169,7 @@ class TestTimeSeries(tm.TestCase):
 
         result = rng + offsets.Hour(2)
         expected = date_range('1/1/2000 02:00', '2/1/2000 02:00')
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
     def test_format_pre_1900_dates(self):
         rng = date_range('1/1/1850', '1/1/1950', freq='A-DEC')
@@ -1188,9 +1188,9 @@ class TestTimeSeries(tm.TestCase):
         rng = date_range('1/1/2000', '1/5/2000', freq='5min')
         ts = Series(np.random.randn(len(rng)), index=rng)
         rs = ts.at_time(rng[1])
-        self.assert_((rs.index.hour == rng[1].hour).all())
-        self.assert_((rs.index.minute == rng[1].minute).all())
-        self.assert_((rs.index.second == rng[1].second).all())
+        self.assertTrue((rs.index.hour == rng[1].hour).all())
+        self.assertTrue((rs.index.minute == rng[1].minute).all())
+        self.assertTrue((rs.index.second == rng[1].second).all())
 
         result = ts.at_time('9:30')
         expected = ts.at_time(time(9, 30))
@@ -1230,9 +1230,9 @@ class TestTimeSeries(tm.TestCase):
         rng = date_range('1/1/2000', '1/5/2000', freq='5min')
         ts = DataFrame(np.random.randn(len(rng), 2), index=rng)
         rs = ts.at_time(rng[1])
-        self.assert_((rs.index.hour == rng[1].hour).all())
-        self.assert_((rs.index.minute == rng[1].minute).all())
-        self.assert_((rs.index.second == rng[1].second).all())
+        self.assertTrue((rs.index.hour == rng[1].hour).all())
+        self.assertTrue((rs.index.minute == rng[1].minute).all())
+        self.assertTrue((rs.index.second == rng[1].second).all())
 
         result = ts.at_time('9:30')
         expected = ts.at_time(time(9, 30))
@@ -1275,14 +1275,14 @@ class TestTimeSeries(tm.TestCase):
             for rs in filtered.index:
                 t = rs.time()
                 if inc_start:
-                    self.assert_(t >= stime)
+                    self.assertTrue(t >= stime)
                 else:
-                    self.assert_(t > stime)
+                    self.assertTrue(t > stime)
 
                 if inc_end:
-                    self.assert_(t <= etime)
+                    self.assertTrue(t <= etime)
                 else:
-                    self.assert_(t < etime)
+                    self.assertTrue(t < etime)
 
         result = ts.between_time('00:00', '01:00')
         expected = ts.between_time(stime, etime)
@@ -1307,14 +1307,14 @@ class TestTimeSeries(tm.TestCase):
             for rs in filtered.index:
                 t = rs.time()
                 if inc_start:
-                    self.assert_((t >= stime) or (t <= etime))
+                    self.assertTrue((t >= stime) or (t <= etime))
                 else:
-                    self.assert_((t > stime) or (t <= etime))
+                    self.assertTrue((t > stime) or (t <= etime))
 
                 if inc_end:
-                    self.assert_((t <= etime) or (t >= stime))
+                    self.assertTrue((t <= etime) or (t >= stime))
                 else:
-                    self.assert_((t < etime) or (t >= stime))
+                    self.assertTrue((t < etime) or (t >= stime))
 
     def test_between_time_frame(self):
         rng = date_range('1/1/2000', '1/5/2000', freq='5min')
@@ -1335,14 +1335,14 @@ class TestTimeSeries(tm.TestCase):
             for rs in filtered.index:
                 t = rs.time()
                 if inc_start:
-                    self.assert_(t >= stime)
+                    self.assertTrue(t >= stime)
                 else:
-                    self.assert_(t > stime)
+                    self.assertTrue(t > stime)
 
                 if inc_end:
-                    self.assert_(t <= etime)
+                    self.assertTrue(t <= etime)
                 else:
-                    self.assert_(t < etime)
+                    self.assertTrue(t < etime)
 
         result = ts.between_time('00:00', '01:00')
         expected = ts.between_time(stime, etime)
@@ -1367,14 +1367,14 @@ class TestTimeSeries(tm.TestCase):
             for rs in filtered.index:
                 t = rs.time()
                 if inc_start:
-                    self.assert_((t >= stime) or (t <= etime))
+                    self.assertTrue((t >= stime) or (t <= etime))
                 else:
-                    self.assert_((t > stime) or (t <= etime))
+                    self.assertTrue((t > stime) or (t <= etime))
 
                 if inc_end:
-                    self.assert_((t <= etime) or (t >= stime))
+                    self.assertTrue((t <= etime) or (t >= stime))
                 else:
-                    self.assert_((t < etime) or (t >= stime))
+                    self.assertTrue((t < etime) or (t >= stime))
 
     def test_dti_constructor_preserve_dti_freq(self):
         rng = date_range('1/1/2000', '1/2/2000', freq='5min')
@@ -1387,15 +1387,15 @@ class TestTimeSeries(tm.TestCase):
 
         result = rng.normalize()
         expected = date_range('1/1/2000', periods=10, freq='D')
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         rng_ns = pd.DatetimeIndex(np.array([1380585623454345752, 1380585612343234312]).astype("datetime64[ns]"))
         rng_ns_normalized = rng_ns.normalize()
         expected = pd.DatetimeIndex(np.array([1380585600000000000, 1380585600000000000]).astype("datetime64[ns]"))
-        self.assert_(rng_ns_normalized.equals(expected))
+        self.assertTrue(rng_ns_normalized.equals(expected))
 
-        self.assert_(result.is_normalized)
-        self.assert_(not rng.is_normalized)
+        self.assertTrue(result.is_normalized)
+        self.assertFalse(rng.is_normalized)
 
     def test_to_period(self):
         from pandas.tseries.period import period_range
@@ -1408,7 +1408,7 @@ class TestTimeSeries(tm.TestCase):
         assert_series_equal(pts, exp)
 
         pts = ts.to_period('M')
-        self.assert_(pts.index.equals(exp.index.asfreq('M')))
+        self.assertTrue(pts.index.equals(exp.index.asfreq('M')))
 
     def create_dt64_based_index(self):
         data = [Timestamp('2007-01-01 10:11:12.123456Z'),
@@ -1445,7 +1445,7 @@ class TestTimeSeries(tm.TestCase):
         expected = ts[0].to_period()
 
         self.assertEqual(result, expected)
-        self.assert_(ts.to_period().equals(xp))
+        self.assertTrue(ts.to_period().equals(xp))
 
         ts = date_range('1/1/2000', '4/1/2000', tz=UTC)
 
@@ -1453,7 +1453,7 @@ class TestTimeSeries(tm.TestCase):
         expected = ts[0].to_period()
 
         self.assertEqual(result, expected)
-        self.assert_(ts.to_period().equals(xp))
+        self.assertTrue(ts.to_period().equals(xp))
 
         ts = date_range('1/1/2000', '4/1/2000', tz=tzlocal())
 
@@ -1461,7 +1461,7 @@ class TestTimeSeries(tm.TestCase):
         expected = ts[0].to_period()
 
         self.assertEqual(result, expected)
-        self.assert_(ts.to_period().equals(xp))
+        self.assertTrue(ts.to_period().equals(xp))
 
     def test_frame_to_period(self):
         K = 5
@@ -1478,7 +1478,7 @@ class TestTimeSeries(tm.TestCase):
         assert_frame_equal(pts, exp)
 
         pts = df.to_period('M')
-        self.assert_(pts.index.equals(exp.index.asfreq('M')))
+        self.assertTrue(pts.index.equals(exp.index.asfreq('M')))
 
         df = df.T
         pts = df.to_period(axis=1)
@@ -1487,7 +1487,7 @@ class TestTimeSeries(tm.TestCase):
         assert_frame_equal(pts, exp)
 
         pts = df.to_period('M', axis=1)
-        self.assert_(pts.columns.equals(exp.columns.asfreq('M')))
+        self.assertTrue(pts.columns.equals(exp.columns.asfreq('M')))
 
         self.assertRaises(ValueError, df.to_period, axis=2)
 
@@ -1571,11 +1571,11 @@ class TestTimeSeries(tm.TestCase):
 
         result = rng + 5
         expected = rng.shift(5)
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         result = rng - 5
         expected = rng.shift(-5)
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
     def test_astype_object(self):
         # NumPy 1.6.1 weak ns support
@@ -1600,15 +1600,15 @@ class TestTimeSeries(tm.TestCase):
         result = ts.append(ts)
         result_df = df.append(df)
         ex_index = DatetimeIndex(np.tile(rng.values, 2))
-        self.assert_(result.index.equals(ex_index))
-        self.assert_(result_df.index.equals(ex_index))
+        self.assertTrue(result.index.equals(ex_index))
+        self.assertTrue(result_df.index.equals(ex_index))
 
         appended = rng.append(rng)
-        self.assert_(appended.equals(ex_index))
+        self.assertTrue(appended.equals(ex_index))
 
         appended = rng.append([rng, rng])
         ex_index = DatetimeIndex(np.tile(rng.values, 3))
-        self.assert_(appended.equals(ex_index))
+        self.assertTrue(appended.equals(ex_index))
 
         # different index names
         rng1 = rng.copy()
@@ -1635,11 +1635,11 @@ class TestTimeSeries(tm.TestCase):
 
         result = ts.append(ts2)
         result_df = df.append(df2)
-        self.assert_(result.index.equals(rng3))
-        self.assert_(result_df.index.equals(rng3))
+        self.assertTrue(result.index.equals(rng3))
+        self.assertTrue(result_df.index.equals(rng3))
 
         appended = rng.append(rng2)
-        self.assert_(appended.equals(rng3))
+        self.assertTrue(appended.equals(rng3))
 
     def test_set_dataframe_column_ns_dtype(self):
         x = DataFrame([datetime.now(), datetime.now()])
@@ -1675,13 +1675,13 @@ class TestTimeSeries(tm.TestCase):
         index = DatetimeIndex(arr)
 
         arr[50:100] = -1
-        self.assert_((index.asi8[50:100] == -1).all())
+        self.assertTrue((index.asi8[50:100] == -1).all())
 
         arr = np.arange(1000, dtype=np.int64)
         index = DatetimeIndex(arr, copy=True)
 
         arr[50:100] = -1
-        self.assert_((index.asi8[50:100] != -1).all())
+        self.assertTrue((index.asi8[50:100] != -1).all())
 
     def test_series_interpolate_method_values(self):
         # #1646
@@ -1729,7 +1729,7 @@ class TestTimeSeries(tm.TestCase):
 
         # it works!
         d = DataFrame({'A': 'foo', 'B': ts}, index=dr)
-        self.assert_(d['B'].isnull().all())
+        self.assertTrue(d['B'].isnull().all())
 
     def test_frame_timeseries_to_records(self):
         index = date_range('1/1/2000', periods=10)
@@ -1746,11 +1746,11 @@ class TestTimeSeries(tm.TestCase):
 
         tst = DataFrame({'symbol': 'AAA', 'date': dates})
         result = tst.duplicated(['date', 'symbol'])
-        self.assert_((-result).all())
+        self.assertTrue((-result).all())
 
         tst = DataFrame({'date': dates})
         result = tst.duplicated()
-        self.assert_((-result).all())
+        self.assertTrue((-result).all())
 
     def test_timestamp_compare_with_early_datetime(self):
         # e.g. datetime.min
@@ -1762,10 +1762,10 @@ class TestTimeSeries(tm.TestCase):
         self.assertNotEqual(stamp, datetime.min)
         self.assertNotEqual(stamp, datetime(1600, 1, 1))
         self.assertNotEqual(stamp, datetime(2700, 1, 1))
-        self.assert_(stamp > datetime(1600, 1, 1))
-        self.assert_(stamp >= datetime(1600, 1, 1))
-        self.assert_(stamp < datetime(2700, 1, 1))
-        self.assert_(stamp <= datetime(2700, 1, 1))
+        self.assertTrue(stamp > datetime(1600, 1, 1))
+        self.assertTrue(stamp >= datetime(1600, 1, 1))
+        self.assertTrue(stamp < datetime(2700, 1, 1))
+        self.assertTrue(stamp <= datetime(2700, 1, 1))
 
     def test_to_html_timestamp(self):
         rng = date_range('2000-01-01', periods=10)
@@ -1913,7 +1913,7 @@ class TestDatetimeIndex(tm.TestCase):
     def test_constructor_coverage(self):
         rng = date_range('1/1/2000', periods=10.5)
         exp = date_range('1/1/2000', periods=10)
-        self.assert_(rng.equals(exp))
+        self.assertTrue(rng.equals(exp))
 
         self.assertRaises(ValueError, DatetimeIndex, start='1/1/2000',
                           periods='foo', freq='D')
@@ -1928,16 +1928,16 @@ class TestDatetimeIndex(tm.TestCase):
         result = DatetimeIndex(gen)
         expected = DatetimeIndex([datetime(2000, 1, 1) + timedelta(i)
                                   for i in range(10)])
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         # NumPy string array
         strings = np.array(['2000-01-01', '2000-01-02', '2000-01-03'])
         result = DatetimeIndex(strings)
         expected = DatetimeIndex(strings.astype('O'))
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         from_ints = DatetimeIndex(expected.asi8)
-        self.assert_(from_ints.equals(expected))
+        self.assertTrue(from_ints.equals(expected))
 
         # non-conforming
         self.assertRaises(ValueError, DatetimeIndex,
@@ -1979,7 +1979,7 @@ class TestDatetimeIndex(tm.TestCase):
 
         result = rng + rng2
         expected = rng.union(rng2)
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
     def test_misc_coverage(self):
         rng = date_range('1/1/2000', periods=5)
@@ -1987,19 +1987,19 @@ class TestDatetimeIndex(tm.TestCase):
         tm.assert_isinstance(list(result.values())[0][0], Timestamp)
 
         idx = DatetimeIndex(['2000-01-03', '2000-01-01', '2000-01-02'])
-        self.assert_(idx.equals(list(idx)))
+        self.assertTrue(idx.equals(list(idx)))
 
         non_datetime = Index(list('abc'))
-        self.assert_(not idx.equals(list(non_datetime)))
+        self.assertFalse(idx.equals(list(non_datetime)))
 
     def test_union_coverage(self):
         idx = DatetimeIndex(['2000-01-03', '2000-01-01', '2000-01-02'])
         ordered = DatetimeIndex(idx.order(), freq='infer')
         result = ordered.union(idx)
-        self.assert_(result.equals(ordered))
+        self.assertTrue(result.equals(ordered))
 
         result = ordered[:0].union(ordered)
-        self.assert_(result.equals(ordered))
+        self.assertTrue(result.equals(ordered))
         self.assertEqual(result.freq, ordered.freq)
 
     def test_union_bug_1730(self):
@@ -2008,7 +2008,7 @@ class TestDatetimeIndex(tm.TestCase):
 
         result = rng_a.union(rng_b)
         exp = DatetimeIndex(sorted(set(list(rng_a)) | set(list(rng_b))))
-        self.assert_(result.equals(exp))
+        self.assertTrue(result.equals(exp))
 
     def test_union_bug_1745(self):
         left = DatetimeIndex(['2012-05-11 15:19:49.695000'])
@@ -2018,7 +2018,7 @@ class TestDatetimeIndex(tm.TestCase):
 
         result = left.union(right)
         exp = DatetimeIndex(sorted(set(list(left)) | set(list(right))))
-        self.assert_(result.equals(exp))
+        self.assertTrue(result.equals(exp))
 
     def test_union_bug_4564(self):
         from pandas import DateOffset
@@ -2027,7 +2027,7 @@ class TestDatetimeIndex(tm.TestCase):
 
         result = left.union(right)
         exp = DatetimeIndex(sorted(set(list(left)) | set(list(right))))
-        self.assert_(result.equals(exp))
+        self.assertTrue(result.equals(exp))
 
     def test_intersection_bug_1708(self):
         from pandas import DateOffset
@@ -2043,7 +2043,7 @@ class TestDatetimeIndex(tm.TestCase):
 
     #     result = rng + delta
     #     expected = rng + timedelta(2)
-    #     self.assert_(result.equals(expected))
+    #     self.assertTrue(result.equals(expected))
 
     def test_get_duplicates(self):
         idx = DatetimeIndex(['2000-01-01', '2000-01-02', '2000-01-02',
@@ -2051,7 +2051,7 @@ class TestDatetimeIndex(tm.TestCase):
 
         result = idx.get_duplicates()
         ex = DatetimeIndex(['2000-01-02', '2000-01-03'])
-        self.assert_(result.equals(ex))
+        self.assertTrue(result.equals(ex))
 
     def test_argmin_argmax(self):
         idx = DatetimeIndex(['2000-01-04', '2000-01-01', '2000-01-02'])
@@ -2062,17 +2062,17 @@ class TestDatetimeIndex(tm.TestCase):
         idx = DatetimeIndex(['2000-01-04', '2000-01-01', '2000-01-02'])
 
         ordered = idx.order()
-        self.assert_(ordered.is_monotonic)
+        self.assertTrue(ordered.is_monotonic)
 
         ordered = idx.order(ascending=False)
-        self.assert_(ordered[::-1].is_monotonic)
+        self.assertTrue(ordered[::-1].is_monotonic)
 
         ordered, dexer = idx.order(return_indexer=True)
-        self.assert_(ordered.is_monotonic)
+        self.assertTrue(ordered.is_monotonic)
         self.assert_numpy_array_equal(dexer, [1, 2, 0])
 
         ordered, dexer = idx.order(return_indexer=True, ascending=False)
-        self.assert_(ordered[::-1].is_monotonic)
+        self.assertTrue(ordered[::-1].is_monotonic)
         self.assert_numpy_array_equal(dexer, [0, 2, 1])
 
     def test_insert(self):
@@ -2081,7 +2081,7 @@ class TestDatetimeIndex(tm.TestCase):
         result = idx.insert(2, datetime(2000, 1, 5))
         exp = DatetimeIndex(['2000-01-04', '2000-01-01', '2000-01-05',
                              '2000-01-02'])
-        self.assert_(result.equals(exp))
+        self.assertTrue(result.equals(exp))
 
         # insertion of non-datetime should coerce to object index
         result = idx.insert(1, 'inserted')
@@ -2117,15 +2117,15 @@ class TestDatetimeIndex(tm.TestCase):
         c = DataFrame({'A': 'foo', 'B': dr}, index=dr)
 
         result = a.append(c)
-        self.assert_((result['B'] == dr).all())
+        self.assertTrue((result['B'] == dr).all())
 
     def test_isin(self):
         index = tm.makeDateIndex(4)
         result = index.isin(index)
-        self.assert_(result.all())
+        self.assertTrue(result.all())
 
         result = index.isin(list(index))
-        self.assert_(result.all())
+        self.assertTrue(result.all())
 
         assert_almost_equal(index.isin([index[2], 5]),
                             [False, False, True, False])
@@ -2147,13 +2147,13 @@ class TestDatetimeIndex(tm.TestCase):
         rng = pd.date_range('1/1/2000', freq='12min', periods=10)
         result = pd.Index(rng).time
         expected = [t.time() for t in rng]
-        self.assert_((result == expected).all())
+        self.assertTrue((result == expected).all())
 
     def test_date(self):
         rng = pd.date_range('1/1/2000', freq='12H', periods=10)
         result = pd.Index(rng).date
         expected = [t.date() for t in rng]
-        self.assert_((result == expected).all())
+        self.assertTrue((result == expected).all())
 
     def test_does_not_convert_mixed_integer(self):
         df = tm.makeCustomDataframe(10, 10, data_gen_f=lambda *args, **kwargs:
@@ -2217,14 +2217,14 @@ class TestDatetimeIndex(tm.TestCase):
 
         exp_arr = np.array([0, 0, 1, 1, 2, 2])
         exp_idx = DatetimeIndex(['2014-01', '2014-02', '2014-03'])
-        
+
         arr, idx = idx1.factorize()
         self.assert_numpy_array_equal(arr, exp_arr)
-        self.assert_(idx.equals(exp_idx))
+        self.assertTrue(idx.equals(exp_idx))
 
         arr, idx = idx1.factorize(sort=True)
         self.assert_numpy_array_equal(arr, exp_arr)
-        self.assert_(idx.equals(exp_idx))
+        self.assertTrue(idx.equals(exp_idx))
 
         # tz must be preserved
         idx1 = idx1.tz_localize('Asia/Tokyo')
@@ -2232,29 +2232,29 @@ class TestDatetimeIndex(tm.TestCase):
 
         arr, idx = idx1.factorize()
         self.assert_numpy_array_equal(arr, exp_arr)
-        self.assert_(idx.equals(exp_idx))
+        self.assertTrue(idx.equals(exp_idx))
 
         idx2 = pd.DatetimeIndex(['2014-03', '2014-03', '2014-02', '2014-01',
                                '2014-03', '2014-01'])
 
-        exp_arr = np.array([2, 2, 1, 0, 2, 0])        
+        exp_arr = np.array([2, 2, 1, 0, 2, 0])
         exp_idx = DatetimeIndex(['2014-01', '2014-02', '2014-03'])
         arr, idx = idx2.factorize(sort=True)
         self.assert_numpy_array_equal(arr, exp_arr)
-        self.assert_(idx.equals(exp_idx))
+        self.assertTrue(idx.equals(exp_idx))
 
         exp_arr = np.array([0, 0, 1, 2, 0, 2])
         exp_idx = DatetimeIndex(['2014-03', '2014-02', '2014-01'])
         arr, idx = idx2.factorize()
         self.assert_numpy_array_equal(arr, exp_arr)
-        self.assert_(idx.equals(exp_idx))
+        self.assertTrue(idx.equals(exp_idx))
 
         # freq must be preserved
         idx3 = date_range('2000-01', periods=4, freq='M', tz='Asia/Tokyo')
         exp_arr = np.array([0, 1, 2, 3])
         arr, idx = idx3.factorize()
         self.assert_numpy_array_equal(arr, exp_arr)
-        self.assert_(idx.equals(idx3))
+        self.assertTrue(idx.equals(idx3))
 
 
 class TestDatetime64(tm.TestCase):
@@ -2417,7 +2417,7 @@ class TestDatetime64(tm.TestCase):
         s['1/2/2009'] = -2
         self.assertEquals(s[48], -2)
         s['1/2/2009':'2009-06-05'] = -3
-        self.assert_((s[48:54] == -3).all())
+        self.assertTrue((s[48:54] == -3).all())
 
     def test_datetimeindex_constructor(self):
         arr = ['1/1/2005', '1/2/2005', 'Jn 3, 2005', '2005-01-04']
@@ -2447,10 +2447,10 @@ class TestDatetime64(tm.TestCase):
         idx7 = DatetimeIndex(['12/05/2007', '25/01/2008'], dayfirst=True)
         idx8 = DatetimeIndex(['2007/05/12', '2008/01/25'], dayfirst=False,
                              yearfirst=True)
-        self.assert_(idx7.equals(idx8))
+        self.assertTrue(idx7.equals(idx8))
 
         for other in [idx2, idx3, idx4, idx5, idx6]:
-            self.assert_((idx1.values == other.values).all())
+            self.assertTrue((idx1.values == other.values).all())
 
         sdate = datetime(1999, 12, 25)
         edate = datetime(2000, 1, 1)
@@ -2493,13 +2493,13 @@ class TestDatetime64(tm.TestCase):
         idx3 = to_datetime(arr, dayfirst=True)
         idx4 = to_datetime(np.array(arr), dayfirst=True)
         idx5 = DatetimeIndex(Index(arr), dayfirst=True)
-        idx6 = DatetimeIndex(Series(arr), dayfirst=True)        
-        self.assert_(expected.equals(idx1))
-        self.assert_(expected.equals(idx2))
-        self.assert_(expected.equals(idx3))
-        self.assert_(expected.equals(idx4))
-        self.assert_(expected.equals(idx5))
-        self.assert_(expected.equals(idx6))
+        idx6 = DatetimeIndex(Series(arr), dayfirst=True)
+        self.assertTrue(expected.equals(idx1))
+        self.assertTrue(expected.equals(idx2))
+        self.assertTrue(expected.equals(idx3))
+        self.assertTrue(expected.equals(idx4))
+        self.assertTrue(expected.equals(idx5))
+        self.assertTrue(expected.equals(idx6))
 
     def test_dti_snap(self):
         dti = DatetimeIndex(['1/1/2002', '1/2/2002', '1/3/2002', '1/4/2002',
@@ -2508,13 +2508,13 @@ class TestDatetime64(tm.TestCase):
         res = dti.snap(freq='W-MON')
         exp = date_range('12/31/2001', '1/7/2002', freq='w-mon')
         exp = exp.repeat([3, 4])
-        self.assert_((res == exp).all())
+        self.assertTrue((res == exp).all())
 
         res = dti.snap(freq='B')
 
         exp = date_range('1/1/2002', '1/7/2002', freq='b')
         exp = exp.repeat([1, 1, 1, 2, 2])
-        self.assert_((res == exp).all())
+        self.assertTrue((res == exp).all())
 
     def test_dti_reset_index_round_trip(self):
         dti = DatetimeIndex(start='1/1/2001', end='6/1/2001', freq='D')
@@ -2539,9 +2539,9 @@ class TestDatetime64(tm.TestCase):
         idx2 = date_range('2013', periods=6, freq='A', tz='Asia/Tokyo')
 
         df = df.set_index(idx1)
-        self.assert_(df.index.equals(idx1))
+        self.assertTrue(df.index.equals(idx1))
         df = df.reindex(idx2)
-        self.assert_(df.index.equals(idx2))
+        self.assertTrue(df.index.equals(idx2))
 
     def test_datetimeindex_union_join_empty(self):
         dti = DatetimeIndex(start='1/1/2001', end='2/1/2001', freq='D')
@@ -2617,10 +2617,10 @@ class TestSeriesDatetime64(tm.TestCase):
         series = Series([0, 1000, 2000, iNaT], dtype='M8[ns]')
 
         val = series[3]
-        self.assert_(com.isnull(val))
+        self.assertTrue(com.isnull(val))
 
         series[2] = val
-        self.assert_(com.isnull(series[2]))
+        self.assertTrue(com.isnull(series[2]))
 
     def test_set_none_nan(self):
         self.series[3] = None
@@ -2644,13 +2644,13 @@ class TestSeriesDatetime64(tm.TestCase):
                         'b': np.random.randn(len(self.series))})
 
         result = df.values.squeeze()
-        self.assert_((result[:, 0] == expected.values).all())
+        self.assertTrue((result[:, 0] == expected.values).all())
 
         df = DataFrame({'a': self.series,
                         'b': ['foo'] * len(self.series)})
 
         result = df.values.squeeze()
-        self.assert_((result[:, 0] == expected.values).all())
+        self.assertTrue((result[:, 0] == expected.values).all())
 
     def test_union(self):
         rng1 = date_range('1/1/1999', '1/1/2012', freq='MS')
@@ -2669,7 +2669,7 @@ class TestSeriesDatetime64(tm.TestCase):
         rng2 = DatetimeIndex(rng2.values)
 
         result = rng.intersection(rng2)
-        self.assert_(result.equals(rng))
+        self.assertTrue(result.equals(rng))
 
         # empty same freq GH2129
         rng = date_range('6/1/2000', '6/15/2000', freq='T')
@@ -2793,9 +2793,9 @@ class TestTimestamp(tm.TestCase):
         self.assertEqual(val, val)
         self.assertFalse(val != val)
         self.assertFalse(val < val)
-        self.assert_(val <= val)
+        self.assertTrue(val <= val)
         self.assertFalse(val > val)
-        self.assert_(val >= val)
+        self.assertTrue(val >= val)
 
         other = datetime(2012, 5, 18)
         self.assertEqual(val, other)
@@ -3104,13 +3104,13 @@ class TestSlicing(tm.TestCase):
         index = date_range('1/1/2000', periods=50, freq='B')
         shifted = index + timedelta(1)
         back = shifted + timedelta(-1)
-        self.assert_(tm.equalContents(index, back))
+        self.assertTrue(tm.equalContents(index, back))
         self.assertEqual(shifted.freq, index.freq)
         self.assertEqual(shifted.freq, back.freq)
 
         result = index - timedelta(1)
         expected = index + timedelta(-1)
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         # GH4134, buggy with timedeltas
         rng = date_range('2013', '2014')
@@ -3119,8 +3119,8 @@ class TestSlicing(tm.TestCase):
         result2 = DatetimeIndex(s - np.timedelta64(100000000))
         result3 = rng - np.timedelta64(100000000)
         result4 = DatetimeIndex(s - pd.offsets.Hour(1))
-        self.assert_(result1.equals(result4))
-        self.assert_(result2.equals(result3))
+        self.assertTrue(result1.equals(result4))
+        self.assertTrue(result2.equals(result3))
 
     def test_shift(self):
         ts = Series(np.random.randn(5),
@@ -3128,12 +3128,12 @@ class TestSlicing(tm.TestCase):
 
         result = ts.shift(1, freq='5T')
         exp_index = ts.index.shift(1, freq='5T')
-        self.assert_(result.index.equals(exp_index))
+        self.assertTrue(result.index.equals(exp_index))
 
         # GH #1063, multiple of same base
         result = ts.shift(1, freq='4H')
         exp_index = ts.index + datetools.Hour(4)
-        self.assert_(result.index.equals(exp_index))
+        self.assertTrue(result.index.equals(exp_index))
 
         idx = DatetimeIndex(['2000-01-01', '2000-01-02', '2000-01-04'])
         self.assertRaises(ValueError, idx.shift, 1)
@@ -3260,7 +3260,7 @@ class TimeConversionFormats(tm.TestCase):
                 elif isinstance(expected, Timestamp):
                     self.assertEqual(result, expected)
                 else:
-                    self.assert_(result.equals(expected))
+                    self.assertTrue(result.equals(expected))
 
     def test_to_datetime_format_YYYYMMDD(self):
         s = Series([19801222,19801222] + [19810105]*5)

--- a/pandas/tseries/tests/test_timeseries_legacy.py
+++ b/pandas/tseries/tests/test_timeseries_legacy.py
@@ -85,8 +85,8 @@ class LegacySupport(object):
 
         self.assertEquals(type(unpickled.index), DatetimeIndex)
         self.assertEquals(len(unpickled), 10)
-        self.assert_((unpickled.columns == Int64Index(np.arange(5))).all())
-        self.assert_((unpickled.index == dtindex).all())
+        self.assertTrue((unpickled.columns == Int64Index(np.arange(5))).all())
+        self.assertTrue((unpickled.index == dtindex).all())
         self.assertEquals(unpickled.index.offset, BDay(1, normalize=True))
 
     def test_unpickle_legacy_series(self):
@@ -99,7 +99,7 @@ class LegacySupport(object):
 
         self.assertEquals(type(unpickled.index), DatetimeIndex)
         self.assertEquals(len(unpickled), 10)
-        self.assert_((unpickled.index == dtindex).all())
+        self.assertTrue((unpickled.index == dtindex).all())
         self.assertEquals(unpickled.index.offset, BDay(1, normalize=True))
 
     def test_unpickle_legacy_len0_daterange(self):
@@ -110,7 +110,7 @@ class LegacySupport(object):
 
         ex_index = DatetimeIndex([], freq='B')
 
-        self.assert_(result.index.equals(ex_index))
+        self.assertTrue(result.index.equals(ex_index))
         tm.assert_isinstance(result.index.freq, offsets.BDay)
         self.assertEqual(len(result), 0)
 
@@ -141,7 +141,7 @@ class LegacySupport(object):
                                    return_indexers=True)
 
             tm.assert_isinstance(ra, DatetimeIndex)
-            self.assert_(ra.equals(ea))
+            self.assertTrue(ra.equals(ea))
 
             assert_almost_equal(rb, eb)
             assert_almost_equal(rc, ec)
@@ -157,7 +157,7 @@ class LegacySupport(object):
         idx2 = to_datetime(['2012-11-06 15:11:09.006507',
                             '2012-11-06 15:11:09.006507'])
         rs = idx1.join(idx2, how='outer')
-        self.assert_(rs.is_monotonic)
+        self.assertTrue(rs.is_monotonic)
 
     def test_unpickle_daterange(self):
         pth, _ = os.path.split(os.path.abspath(__file__))
@@ -175,24 +175,24 @@ class LegacySupport(object):
         result = index[:5].union(obj_index[5:])
         expected = index
         tm.assert_isinstance(result, DatetimeIndex)
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         result = index[:10].intersection(obj_index[5:])
         expected = index[5:10]
         tm.assert_isinstance(result, DatetimeIndex)
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         result = index[:10] - obj_index[5:]
         expected = index[:5]
         tm.assert_isinstance(result, DatetimeIndex)
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
     def test_index_conversion(self):
         index = self.frame.index
         obj_index = index.asobject
 
         conv = DatetimeIndex(obj_index)
-        self.assert_(conv.equals(index))
+        self.assertTrue(conv.equals(index))
 
         self.assertRaises(ValueError, DatetimeIndex, ['a', 'b', 'c', 'd'])
 
@@ -213,11 +213,11 @@ class LegacySupport(object):
 
         result = index.union(right)
         expected = Index(np.concatenate([index.asobject, right]))
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         result = index.intersection(right)
         expected = Index([])
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
     def test_legacy_time_rules(self):
         rules = [('WEEKDAY', 'B'),
@@ -237,7 +237,7 @@ class LegacySupport(object):
         for old_freq, new_freq in rules:
             old_rng = date_range(start, end, freq=old_freq)
             new_rng = date_range(start, end, freq=new_freq)
-            self.assert_(old_rng.equals(new_rng))
+            self.assertTrue(old_rng.equals(new_rng))
 
             # test get_legacy_offset_name
             offset = datetools.get_offset(new_freq)

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -203,11 +203,11 @@ class TestTimeZoneSupport(tm.TestCase):
         self.assertEqual(off, rng.tz)
 
         rng2 = date_range(start, periods=len(rng), tz=off)
-        self.assert_(rng.equals(rng2))
+        self.assertTrue(rng.equals(rng2))
 
         rng3 = date_range(
             '3/11/2012 05:00:00+07:00', '6/11/2012 05:00:00+07:00')
-        self.assert_((rng.values == rng3.values).all())
+        self.assertTrue((rng.values == rng3.values).all())
 
     def test_create_with_fixedoffset_noname(self):
         off = fixed_off_no_name
@@ -227,7 +227,7 @@ class TestTimeZoneSupport(tm.TestCase):
         rng3 = date_range('3/11/2012 03:00', periods=15, freq='H')
         rng3 = rng3.tz_localize('US/Eastern')
 
-        self.assert_(rng.equals(rng3))
+        self.assertTrue(rng.equals(rng3))
 
         # DST transition time
         val = rng[0]
@@ -236,14 +236,14 @@ class TestTimeZoneSupport(tm.TestCase):
         self.assertEquals(val.hour, 3)
         self.assertEquals(exp.hour, 3)
         self.assertEquals(val, exp)  # same UTC value
-        self.assert_(rng[:2].equals(rng2))
+        self.assertTrue(rng[:2].equals(rng2))
 
         # Right before the DST transition
         rng = date_range(
             '3/11/2012 00:00', periods=2, freq='H', tz='US/Eastern')
         rng2 = DatetimeIndex(['3/11/2012 00:00', '3/11/2012 01:00'],
                              tz='US/Eastern')
-        self.assert_(rng.equals(rng2))
+        self.assertTrue(rng.equals(rng2))
         exp = Timestamp('3/11/2012 00:00', tz='US/Eastern')
         self.assertEquals(exp.hour, 0)
         self.assertEquals(rng[0], exp)
@@ -294,7 +294,7 @@ class TestTimeZoneSupport(tm.TestCase):
     def test_field_access_localize(self):
         strdates = ['1/1/2012', '3/1/2012', '4/1/2012']
         rng = DatetimeIndex(strdates, tz='US/Eastern')
-        self.assert_((rng.hour == 0).all())
+        self.assertTrue((rng.hour == 0).all())
 
         # a more unusual time zone, #1946
         dr = date_range('2011-10-02 00:00', freq='h', periods=10,
@@ -413,7 +413,7 @@ class TestTimeZoneSupport(tm.TestCase):
         expected = date_range('1/1/2000', periods=10,
                               tz=pytz.timezone('US/Eastern'))
 
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
     def test_take_dont_lose_meta(self):
         _skip_if_no_pytz()
@@ -599,16 +599,16 @@ class TestTimeZoneSupport(tm.TestCase):
         dr = date_range('03/06/2012 00:00', periods=200, freq='W-FRI',
                         tz='US/Eastern')
 
-        self.assert_((dr.hour == 0).all())
+        self.assertTrue((dr.hour == 0).all())
 
         dr = date_range('2012-11-02', periods=10, tz='US/Eastern')
-        self.assert_((dr.hour == 0).all())
+        self.assertTrue((dr.hour == 0).all())
 
     def test_convert_datetime_list(self):
         dr = date_range('2012-06-02', periods=10, tz='US/Eastern')
 
         dr2 = DatetimeIndex(list(dr), name='foo')
-        self.assert_(dr.equals(dr2))
+        self.assertTrue(dr.equals(dr2))
         self.assertEqual(dr.tz, dr2.tz)
         self.assertEqual(dr2.name, 'foo')
 
@@ -669,7 +669,7 @@ class TestTimeZoneSupport(tm.TestCase):
         idx4 = DatetimeIndex(np.array(arr), tz='US/Eastern')
 
         for other in [idx2, idx3, idx4]:
-            self.assert_(idx1.equals(other))
+            self.assertTrue(idx1.equals(other))
 
     def test_datetimeindex_tz_nat(self):
         idx = to_datetime([Timestamp("2013-1-1", tz='US/Eastern'), NaT])
@@ -689,7 +689,7 @@ class TestTimeZones(tm.TestCase):
         right = date_range('1/1/2011', periods=100, freq='H',
                            tz='US/Eastern')
 
-        self.assert_(not left.equals(right))
+        self.assertFalse(left.equals(right))
 
     def test_tz_localize_naive(self):
         rng = date_range('1/1/2011', periods=100, freq='H')
@@ -697,7 +697,7 @@ class TestTimeZones(tm.TestCase):
         conv = rng.tz_localize('US/Pacific')
         exp = date_range('1/1/2011', periods=100, freq='H', tz='US/Pacific')
 
-        self.assert_(conv.equals(exp))
+        self.assertTrue(conv.equals(exp))
 
     def test_series_frame_tz_localize(self):
 
@@ -914,15 +914,15 @@ class TestTimeZones(tm.TestCase):
             self.assertEquals(b, c)
             self.assertEquals(a, c)
 
-        self.assert_((utc_range == eastern_range).all())
-        self.assert_((utc_range == berlin_range).all())
-        self.assert_((berlin_range == eastern_range).all())
+        self.assertTrue((utc_range == eastern_range).all())
+        self.assertTrue((utc_range == berlin_range).all())
+        self.assertTrue((berlin_range == eastern_range).all())
 
     def test_datetimeindex_tz(self):
         rng = date_range('03/12/2012 00:00', periods=10, freq='W-FRI',
                          tz='US/Eastern')
         rng2 = DatetimeIndex(data=rng, tz='US/Eastern')
-        self.assert_(rng.equals(rng2))
+        self.assertTrue(rng.equals(rng2))
 
     def test_normalize_tz(self):
         rng = date_range('1/1/2000 9:30', periods=10, freq='D',
@@ -931,10 +931,10 @@ class TestTimeZones(tm.TestCase):
         result = rng.normalize()
         expected = date_range('1/1/2000', periods=10, freq='D',
                               tz='US/Eastern')
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
-        self.assert_(result.is_normalized)
-        self.assert_(not rng.is_normalized)
+        self.assertTrue(result.is_normalized)
+        self.assertFalse(rng.is_normalized)
 
         rng = date_range('1/1/2000 9:30', periods=10, freq='D',
                          tz='UTC')
@@ -942,10 +942,10 @@ class TestTimeZones(tm.TestCase):
         result = rng.normalize()
         expected = date_range('1/1/2000', periods=10, freq='D',
                               tz='UTC')
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
-        self.assert_(result.is_normalized)
-        self.assert_(not rng.is_normalized)
+        self.assertTrue(result.is_normalized)
+        self.assertFalse(rng.is_normalized)
 
         from dateutil.tz import tzlocal
         rng = date_range('1/1/2000 9:30', periods=10, freq='D',
@@ -953,10 +953,10 @@ class TestTimeZones(tm.TestCase):
         result = rng.normalize()
         expected = date_range('1/1/2000', periods=10, freq='D',
                               tz=tzlocal())
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
-        self.assert_(result.is_normalized)
-        self.assert_(not rng.is_normalized)
+        self.assertTrue(result.is_normalized)
+        self.assertFalse(rng.is_normalized)
 
     def test_tzaware_offset(self):
         dates = date_range('2012-11-01', periods=3, tz='US/Pacific')
@@ -970,47 +970,47 @@ class TestTimeZones(tm.TestCase):
                                       '2010-11-01 07:00'], freq='H', tz=tz)
 
             offset = dates + offsets.Hour(5)
-            self.assert_(offset.equals(expected))
+            self.assertTrue(offset.equals(expected))
             if not _np_version_under1p7:
                 offset = dates + np.timedelta64(5, 'h')
-                self.assert_(offset.equals(expected))
+                self.assertTrue(offset.equals(expected))
             offset = dates + timedelta(hours=5)
-            self.assert_(offset.equals(expected))
+            self.assertTrue(offset.equals(expected))
 
     def test_nat(self):
         # GH 5546
         dates = [NaT]
         idx = DatetimeIndex(dates)
         idx = idx.tz_localize('US/Pacific')
-        self.assert_(idx.equals(DatetimeIndex(dates, tz='US/Pacific')))
+        self.assertTrue(idx.equals(DatetimeIndex(dates, tz='US/Pacific')))
         idx = idx.tz_convert('US/Eastern')
-        self.assert_(idx.equals(DatetimeIndex(dates, tz='US/Eastern')))
+        self.assertTrue(idx.equals(DatetimeIndex(dates, tz='US/Eastern')))
         idx = idx.tz_convert('UTC')
-        self.assert_(idx.equals(DatetimeIndex(dates, tz='UTC')))
+        self.assertTrue(idx.equals(DatetimeIndex(dates, tz='UTC')))
 
         dates = ['2010-12-01 00:00', '2010-12-02 00:00', NaT]
         idx = DatetimeIndex(dates)
         idx = idx.tz_localize('US/Pacific')
-        self.assert_(idx.equals(DatetimeIndex(dates, tz='US/Pacific')))
+        self.assertTrue(idx.equals(DatetimeIndex(dates, tz='US/Pacific')))
         idx = idx.tz_convert('US/Eastern')
         expected = ['2010-12-01 03:00', '2010-12-02 03:00', NaT]
-        self.assert_(idx.equals(DatetimeIndex(expected, tz='US/Eastern')))
+        self.assertTrue(idx.equals(DatetimeIndex(expected, tz='US/Eastern')))
 
         idx = idx + offsets.Hour(5)
         expected = ['2010-12-01 08:00', '2010-12-02 08:00', NaT]
-        self.assert_(idx.equals(DatetimeIndex(expected, tz='US/Eastern')))
+        self.assertTrue(idx.equals(DatetimeIndex(expected, tz='US/Eastern')))
         idx = idx.tz_convert('US/Pacific')
         expected = ['2010-12-01 05:00', '2010-12-02 05:00', NaT]
-        self.assert_(idx.equals(DatetimeIndex(expected, tz='US/Pacific')))
+        self.assertTrue(idx.equals(DatetimeIndex(expected, tz='US/Pacific')))
 
         if not _np_version_under1p7:
             idx = idx + np.timedelta64(3, 'h')
             expected = ['2010-12-01 08:00', '2010-12-02 08:00', NaT]
-            self.assert_(idx.equals(DatetimeIndex(expected, tz='US/Pacific')))
+            self.assertTrue(idx.equals(DatetimeIndex(expected, tz='US/Pacific')))
 
             idx = idx.tz_convert('US/Eastern')
             expected = ['2010-12-01 11:00', '2010-12-02 11:00', NaT]
-            self.assert_(idx.equals(DatetimeIndex(expected, tz='US/Eastern')))
+            self.assertTrue(idx.equals(DatetimeIndex(expected, tz='US/Eastern')))
 
 
 if __name__ == '__main__':

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -285,19 +285,19 @@ class TestTimestampNsOperations(tm.TestCase):
                 right + left
 
             # NaT - Timestamp-like (or inverse) returns NaT
-            self.assert_((left - right) is tslib.NaT)
-            self.assert_((right - left) is tslib.NaT)
+            self.assertTrue((left - right) is tslib.NaT)
+            self.assertTrue((right - left) is tslib.NaT)
 
-        # timedelta-like 
+        # timedelta-like
         # offsets are tested in test_offsets.py
         for (left, right) in [(nat, delta)]:
             # NaT + timedelta-like returns NaT
-            self.assert_((left + right) is tslib.NaT)
+            self.assertTrue((left + right) is tslib.NaT)
             # timedelta-like + NaT should raise TypeError
             with tm.assertRaises(TypeError):
                 right + left
 
-            self.assert_((left - right) is tslib.NaT)
+            self.assertTrue((left - right) is tslib.NaT)
             with tm.assertRaises(TypeError):
                 right - left
 


### PR DESCRIPTION
#7131: Convert more instances of self.assert_(not b) to self.assertFalse(b) and self.assert_(b) to self.assertTrue(b)
