### PR TITLE
CLN: Deprecation of assertEquals

### DIFF
--- a/pandas/io/tests/test_cparser.py
+++ b/pandas/io/tests/test_cparser.py
@@ -190,7 +190,7 @@ class TestCParser(tm.TestCase):
                             as_recarray=True)
         header = reader.header
         expected = [['a', 'b', 'c']]
-        self.assertEquals(header, expected)
+        self.assertEqual(header, expected)
 
         recs = reader.read()
         expected = {'a': [1, 4], 'b': [2, 5], 'c': [3, 6]}
@@ -295,7 +295,7 @@ a,b,c
         result = reader.read()
 
         exp = _make_reader().read()
-        self.assertEquals(len(result), 2)
+        self.assertEqual(len(result), 2)
         self.assertTrue((result[1] == exp[1]).all())
         self.assertTrue((result[2] == exp[2]).all())
 

--- a/pandas/io/tests/test_data.py
+++ b/pandas/io/tests/test_data.py
@@ -62,7 +62,7 @@ class TestGoogle(tm.TestCase):
         for locale in self.locales:
             with tm.set_locale(locale):
                 panel = web.DataReader("F", 'google', start, end)
-            self.assertEquals(panel.Close[-1], 13.68)
+            self.assertEqual(panel.Close[-1], 13.68)
 
         self.assertRaises(Exception, web.DataReader, "NON EXISTENT TICKER",
                           'google', start, end)
@@ -88,7 +88,7 @@ class TestGoogle(tm.TestCase):
             ts = pan.Close.GOOG.index[pan.Close.AAPL > pan.Close.GOOG]
             if (hasattr(pan, 'Close') and hasattr(pan.Close, 'GOOG') and
                 hasattr(pan.Close, 'AAPL')):
-                self.assertEquals(ts[0].dayofyear, 96)
+                self.assertEqual(ts[0].dayofyear, 96)
             else:
                 self.assertRaises(AttributeError, lambda: pan.Close)
 
@@ -124,7 +124,7 @@ class TestYahoo(tm.TestCase):
         start = datetime(2010, 1, 1)
         end = datetime(2013, 1, 27)
 
-        self.assertEquals( web.DataReader("F", 'yahoo', start,
+        self.assertEqual( web.DataReader("F", 'yahoo', start,
                                           end)['Close'][-1], 13.68)
 
     @network
@@ -396,7 +396,7 @@ class TestFred(tm.TestCase):
         end = datetime(2013, 1, 27)
 
         received = web.DataReader("GDP", "fred", start, end)['GDP'].tail(1)[0]
-        self.assertEquals(int(received), 16535)
+        self.assertEqual(int(received), 16535)
 
         self.assertRaises(Exception, web.DataReader, "NON EXISTENT SERIES",
                           'fred', start, end)

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -823,7 +823,7 @@ class ExcelWriterBase(SharedItems):
                                   has_index_names=self.merge_cells)
 
             tm.assert_frame_equal(tsframe, recons)
-            self.assertEquals(recons.index.names, ('time', 'foo'))
+            self.assertEqual(recons.index.names, ('time', 'foo'))
 
     def test_to_excel_multiindex_no_write_index(self):
         _skip_if_no_xlrd()
@@ -936,21 +936,21 @@ class ExcelWriterBase(SharedItems):
 
     #     wbk = xlrd.open_workbook(filename,
     #                              formatting_info=True)
-    #     self.assertEquals(["test1"], wbk.sheet_names())
+    #     self.assertEqual(["test1"], wbk.sheet_names())
     #     ws = wbk.sheet_by_name('test1')
-    #     self.assertEquals([(0, 1, 5, 7), (0, 1, 3, 5), (0, 1, 1, 3)],
+    #     self.assertEqual([(0, 1, 5, 7), (0, 1, 3, 5), (0, 1, 1, 3)],
     #                       ws.merged_cells)
     #     for i in range(0, 2):
     #         for j in range(0, 7):
     #             xfx = ws.cell_xf_index(0, 0)
     #             cell_xf = wbk.xf_list[xfx]
     #             font = wbk.font_list
-    #             self.assertEquals(1, font[cell_xf.font_index].bold)
-    #             self.assertEquals(1, cell_xf.border.top_line_style)
-    #             self.assertEquals(1, cell_xf.border.right_line_style)
-    #             self.assertEquals(1, cell_xf.border.bottom_line_style)
-    #             self.assertEquals(1, cell_xf.border.left_line_style)
-    #             self.assertEquals(2, cell_xf.alignment.hor_align)
+    #             self.assertEqual(1, font[cell_xf.font_index].bold)
+    #             self.assertEqual(1, cell_xf.border.top_line_style)
+    #             self.assertEqual(1, cell_xf.border.right_line_style)
+    #             self.assertEqual(1, cell_xf.border.bottom_line_style)
+    #             self.assertEqual(1, cell_xf.border.left_line_style)
+    #             self.assertEqual(2, cell_xf.alignment.hor_align)
     #     os.remove(filename)
     # def test_to_excel_header_styling_xlsx(self):
     #     import StringIO
@@ -982,7 +982,7 @@ class ExcelWriterBase(SharedItems):
     #     filename = '__tmp_to_excel_header_styling_xlsx__.xlsx'
     #     pdf.to_excel(filename, 'test1')
     #     wbk = openpyxl.load_workbook(filename)
-    #     self.assertEquals(["test1"], wbk.get_sheet_names())
+    #     self.assertEqual(["test1"], wbk.get_sheet_names())
     #     ws = wbk.get_sheet_by_name('test1')
     #     xlsaddrs = ["%s2" % chr(i) for i in range(ord('A'), ord('H'))]
     #     xlsaddrs += ["A%s" % i for i in range(1, 6)]
@@ -990,15 +990,15 @@ class ExcelWriterBase(SharedItems):
     #     for xlsaddr in xlsaddrs:
     #         cell = ws.cell(xlsaddr)
     #         self.assertTrue(cell.style.font.bold)
-    #         self.assertEquals(openpyxl.style.Border.BORDER_THIN,
+    #         self.assertEqual(openpyxl.style.Border.BORDER_THIN,
     #                           cell.style.borders.top.border_style)
-    #         self.assertEquals(openpyxl.style.Border.BORDER_THIN,
+    #         self.assertEqual(openpyxl.style.Border.BORDER_THIN,
     #                           cell.style.borders.right.border_style)
-    #         self.assertEquals(openpyxl.style.Border.BORDER_THIN,
+    #         self.assertEqual(openpyxl.style.Border.BORDER_THIN,
     #                           cell.style.borders.bottom.border_style)
-    #         self.assertEquals(openpyxl.style.Border.BORDER_THIN,
+    #         self.assertEqual(openpyxl.style.Border.BORDER_THIN,
     #                           cell.style.borders.left.border_style)
-    #         self.assertEquals(openpyxl.style.Alignment.HORIZONTAL_CENTER,
+    #         self.assertEqual(openpyxl.style.Alignment.HORIZONTAL_CENTER,
     #                           cell.style.alignment.horizontal)
     #     mergedcells_addrs = ["C1", "E1", "G1"]
     #     for maddr in mergedcells_addrs:
@@ -1109,17 +1109,17 @@ class OpenpyxlTests(ExcelWriterBase, tm.TestCase):
 
         xlsx_style = _OpenpyxlWriter._convert_to_style(hstyle)
         self.assertTrue(xlsx_style.font.bold)
-        self.assertEquals(openpyxl.style.Border.BORDER_THIN,
+        self.assertEqual(openpyxl.style.Border.BORDER_THIN,
                           xlsx_style.borders.top.border_style)
-        self.assertEquals(openpyxl.style.Border.BORDER_THIN,
+        self.assertEqual(openpyxl.style.Border.BORDER_THIN,
                           xlsx_style.borders.right.border_style)
-        self.assertEquals(openpyxl.style.Border.BORDER_THIN,
+        self.assertEqual(openpyxl.style.Border.BORDER_THIN,
                           xlsx_style.borders.bottom.border_style)
-        self.assertEquals(openpyxl.style.Border.BORDER_THIN,
+        self.assertEqual(openpyxl.style.Border.BORDER_THIN,
                           xlsx_style.borders.left.border_style)
-        self.assertEquals(openpyxl.style.Alignment.HORIZONTAL_CENTER,
+        self.assertEqual(openpyxl.style.Alignment.HORIZONTAL_CENTER,
                           xlsx_style.alignment.horizontal)
-        self.assertEquals(openpyxl.style.Alignment.VERTICAL_TOP,
+        self.assertEqual(openpyxl.style.Alignment.VERTICAL_TOP,
                           xlsx_style.alignment.vertical)
 
 
@@ -1142,12 +1142,12 @@ class XlwtTests(ExcelWriterBase, tm.TestCase):
 
         xls_style = _XlwtWriter._convert_to_style(hstyle)
         self.assertTrue(xls_style.font.bold)
-        self.assertEquals(xlwt.Borders.THIN, xls_style.borders.top)
-        self.assertEquals(xlwt.Borders.THIN, xls_style.borders.right)
-        self.assertEquals(xlwt.Borders.THIN, xls_style.borders.bottom)
-        self.assertEquals(xlwt.Borders.THIN, xls_style.borders.left)
-        self.assertEquals(xlwt.Alignment.HORZ_CENTER, xls_style.alignment.horz)
-        self.assertEquals(xlwt.Alignment.VERT_TOP, xls_style.alignment.vert)
+        self.assertEqual(xlwt.Borders.THIN, xls_style.borders.top)
+        self.assertEqual(xlwt.Borders.THIN, xls_style.borders.right)
+        self.assertEqual(xlwt.Borders.THIN, xls_style.borders.bottom)
+        self.assertEqual(xlwt.Borders.THIN, xls_style.borders.left)
+        self.assertEqual(xlwt.Alignment.HORZ_CENTER, xls_style.alignment.horz)
+        self.assertEqual(xlwt.Alignment.VERT_TOP, xls_style.alignment.vert)
 
 
 class XlsxWriterTests(ExcelWriterBase, tm.TestCase):

--- a/pandas/io/tests/test_json/test_ujson.py
+++ b/pandas/io/tests/test_json/test_ujson.py
@@ -44,7 +44,7 @@ class UltraJSONTests(TestCase):
         sut = decimal.Decimal("1337.1337")
         encoded = ujson.encode(sut, double_precision=15)
         decoded = ujson.decode(encoded)
-        self.assertEquals(decoded, 1337.1337)
+        self.assertEqual(decoded, 1337.1337)
 
     def test_encodeStringConversion(self):
         input = "A string \\ / \b \f \n \r \t </script> &"
@@ -53,9 +53,9 @@ class UltraJSONTests(TestCase):
 
         def helper(expected_output, **encode_kwargs):
             output = ujson.encode(input, **encode_kwargs)
-            self.assertEquals(input, json.loads(output))
-            self.assertEquals(output, expected_output)
-            self.assertEquals(input, ujson.decode(output))
+            self.assertEqual(input, json.loads(output))
+            self.assertEqual(output, expected_output)
+            self.assertEqual(input, ujson.decode(output))
 
         # Default behavior assumes encode_html_chars=False.
         helper(not_html_encoded, ensure_ascii=True)
@@ -140,51 +140,51 @@ class UltraJSONTests(TestCase):
     def test_encodeDoubleConversion(self):
         input = math.pi
         output = ujson.encode(input)
-        self.assertEquals(round(input, 5), round(json.loads(output), 5))
-        self.assertEquals(round(input, 5), round(ujson.decode(output), 5))
+        self.assertEqual(round(input, 5), round(json.loads(output), 5))
+        self.assertEqual(round(input, 5), round(ujson.decode(output), 5))
 
     def test_encodeWithDecimal(self):
         input = 1.0
         output = ujson.encode(input)
-        self.assertEquals(output, "1.0")
+        self.assertEqual(output, "1.0")
 
     def test_encodeDoubleNegConversion(self):
         input = -math.pi
         output = ujson.encode(input)
 
-        self.assertEquals(round(input, 5), round(json.loads(output), 5))
-        self.assertEquals(round(input, 5), round(ujson.decode(output), 5))
+        self.assertEqual(round(input, 5), round(json.loads(output), 5))
+        self.assertEqual(round(input, 5), round(ujson.decode(output), 5))
 
     def test_encodeArrayOfNestedArrays(self):
         input = [[[[]]]] * 20
         output = ujson.encode(input)
-        self.assertEquals(input, json.loads(output))
-        #self.assertEquals(output, json.dumps(input))
-        self.assertEquals(input, ujson.decode(output))
+        self.assertEqual(input, json.loads(output))
+        #self.assertEqual(output, json.dumps(input))
+        self.assertEqual(input, ujson.decode(output))
         input = np.array(input)
         assert_array_equal(input, ujson.decode(output, numpy=True, dtype=input.dtype))
 
     def test_encodeArrayOfDoubles(self):
         input = [ 31337.31337, 31337.31337, 31337.31337, 31337.31337] * 10
         output = ujson.encode(input)
-        self.assertEquals(input, json.loads(output))
-        #self.assertEquals(output, json.dumps(input))
-        self.assertEquals(input, ujson.decode(output))
+        self.assertEqual(input, json.loads(output))
+        #self.assertEqual(output, json.dumps(input))
+        self.assertEqual(input, ujson.decode(output))
         assert_array_equal(np.array(input), ujson.decode(output, numpy=True))
 
     def test_doublePrecisionTest(self):
         input = 30.012345678901234
         output = ujson.encode(input, double_precision = 15)
-        self.assertEquals(input, json.loads(output))
-        self.assertEquals(input, ujson.decode(output))
+        self.assertEqual(input, json.loads(output))
+        self.assertEqual(input, ujson.decode(output))
 
         output = ujson.encode(input, double_precision = 9)
-        self.assertEquals(round(input, 9), json.loads(output))
-        self.assertEquals(round(input, 9), ujson.decode(output))
+        self.assertEqual(round(input, 9), json.loads(output))
+        self.assertEqual(round(input, 9), ujson.decode(output))
 
         output = ujson.encode(input, double_precision = 3)
-        self.assertEquals(round(input, 3), json.loads(output))
-        self.assertEquals(round(input, 3), ujson.decode(output))
+        self.assertEqual(round(input, 3), json.loads(output))
+        self.assertEqual(round(input, 3), ujson.decode(output))
 
     def test_invalidDoublePrecision(self):
         input = 30.12345678901234567890
@@ -200,9 +200,9 @@ class UltraJSONTests(TestCase):
     def test_encodeStringConversion(self):
         input = "A string \\ / \b \f \n \r \t"
         output = ujson.encode(input)
-        self.assertEquals(input, json.loads(output))
-        self.assertEquals(output, '"A string \\\\ \\/ \\b \\f \\n \\r \\t"')
-        self.assertEquals(input, ujson.decode(output))
+        self.assertEqual(input, json.loads(output))
+        self.assertEqual(output, '"A string \\\\ \\/ \\b \\f \\n \\r \\t"')
+        self.assertEqual(input, ujson.decode(output))
         pass
 
     def test_decodeUnicodeConversion(self):
@@ -212,22 +212,22 @@ class UltraJSONTests(TestCase):
         input = "Räksmörgås اسامة بن محمد بن عوض بن لادن"
         enc = ujson.encode(input)
         dec = ujson.decode(enc)
-        self.assertEquals(enc, json_unicode(input))
-        self.assertEquals(dec, json.loads(enc))
+        self.assertEqual(enc, json_unicode(input))
+        self.assertEqual(dec, json.loads(enc))
 
     def test_encodeControlEscaping(self):
         input = "\x19"
         enc = ujson.encode(input)
         dec = ujson.decode(enc)
-        self.assertEquals(input, dec)
-        self.assertEquals(enc, json_unicode(input))
+        self.assertEqual(input, dec)
+        self.assertEqual(enc, json_unicode(input))
 
     def test_encodeUnicodeConversion2(self):
         input = "\xe6\x97\xa5\xd1\x88"
         enc = ujson.encode(input)
         dec = ujson.decode(enc)
-        self.assertEquals(enc, json_unicode(input))
-        self.assertEquals(dec, json.loads(enc))
+        self.assertEqual(enc, json_unicode(input))
+        self.assertEqual(dec, json.loads(enc))
 
     def test_encodeUnicodeSurrogatePair(self):
         _skip_if_python_ver(2, 5)
@@ -236,8 +236,8 @@ class UltraJSONTests(TestCase):
         enc = ujson.encode(input)
         dec = ujson.decode(enc)
 
-        self.assertEquals(enc, json_unicode(input))
-        self.assertEquals(dec, json.loads(enc))
+        self.assertEqual(enc, json_unicode(input))
+        self.assertEqual(dec, json.loads(enc))
 
     def test_encodeUnicode4BytesUTF8(self):
         _skip_if_python_ver(2, 5)
@@ -246,8 +246,8 @@ class UltraJSONTests(TestCase):
         enc = ujson.encode(input)
         dec = ujson.decode(enc)
 
-        self.assertEquals(enc, json_unicode(input))
-        self.assertEquals(dec, json.loads(enc))
+        self.assertEqual(enc, json_unicode(input))
+        self.assertEqual(dec, json.loads(enc))
 
     def test_encodeUnicode4BytesUTF8Highest(self):
         _skip_if_python_ver(2, 5)
@@ -257,33 +257,33 @@ class UltraJSONTests(TestCase):
 
         dec = ujson.decode(enc)
 
-        self.assertEquals(enc, json_unicode(input))
-        self.assertEquals(dec, json.loads(enc))
+        self.assertEqual(enc, json_unicode(input))
+        self.assertEqual(dec, json.loads(enc))
 
     def test_encodeArrayInArray(self):
         input = [[[[]]]]
         output = ujson.encode(input)
 
-        self.assertEquals(input, json.loads(output))
-        self.assertEquals(output, json.dumps(input))
-        self.assertEquals(input, ujson.decode(output))
+        self.assertEqual(input, json.loads(output))
+        self.assertEqual(output, json.dumps(input))
+        self.assertEqual(input, ujson.decode(output))
         assert_array_equal(np.array(input), ujson.decode(output, numpy=True))
         pass
 
     def test_encodeIntConversion(self):
         input = 31337
         output = ujson.encode(input)
-        self.assertEquals(input, json.loads(output))
-        self.assertEquals(output, json.dumps(input))
-        self.assertEquals(input, ujson.decode(output))
+        self.assertEqual(input, json.loads(output))
+        self.assertEqual(output, json.dumps(input))
+        self.assertEqual(input, ujson.decode(output))
         pass
 
     def test_encodeIntNegConversion(self):
         input = -31337
         output = ujson.encode(input)
-        self.assertEquals(input, json.loads(output))
-        self.assertEquals(output, json.dumps(input))
-        self.assertEquals(input, ujson.decode(output))
+        self.assertEqual(input, json.loads(output))
+        self.assertEqual(output, json.dumps(input))
+        self.assertEqual(input, ujson.decode(output))
         pass
 
     def test_encodeLongNegConversion(self):
@@ -293,57 +293,57 @@ class UltraJSONTests(TestCase):
         outputjson = json.loads(output)
         outputujson = ujson.decode(output)
 
-        self.assertEquals(input, json.loads(output))
-        self.assertEquals(output, json.dumps(input))
-        self.assertEquals(input, ujson.decode(output))
+        self.assertEqual(input, json.loads(output))
+        self.assertEqual(output, json.dumps(input))
+        self.assertEqual(input, ujson.decode(output))
         pass
 
     def test_encodeListConversion(self):
         input = [ 1, 2, 3, 4 ]
         output = ujson.encode(input)
-        self.assertEquals(input, json.loads(output))
-        self.assertEquals(input, ujson.decode(output))
+        self.assertEqual(input, json.loads(output))
+        self.assertEqual(input, ujson.decode(output))
         assert_array_equal(np.array(input), ujson.decode(output, numpy=True))
         pass
 
     def test_encodeDictConversion(self):
         input = { "k1": 1, "k2":  2, "k3": 3, "k4": 4 }
         output = ujson.encode(input)
-        self.assertEquals(input, json.loads(output))
-        self.assertEquals(input, ujson.decode(output))
-        self.assertEquals(input, ujson.decode(output))
+        self.assertEqual(input, json.loads(output))
+        self.assertEqual(input, ujson.decode(output))
+        self.assertEqual(input, ujson.decode(output))
         pass
 
     def test_encodeNoneConversion(self):
         input = None
         output = ujson.encode(input)
-        self.assertEquals(input, json.loads(output))
-        self.assertEquals(output, json.dumps(input))
-        self.assertEquals(input, ujson.decode(output))
+        self.assertEqual(input, json.loads(output))
+        self.assertEqual(output, json.dumps(input))
+        self.assertEqual(input, ujson.decode(output))
         pass
 
     def test_encodeTrueConversion(self):
         input = True
         output = ujson.encode(input)
-        self.assertEquals(input, json.loads(output))
-        self.assertEquals(output, json.dumps(input))
-        self.assertEquals(input, ujson.decode(output))
+        self.assertEqual(input, json.loads(output))
+        self.assertEqual(output, json.dumps(input))
+        self.assertEqual(input, ujson.decode(output))
         pass
 
     def test_encodeFalseConversion(self):
         input = False
         output = ujson.encode(input)
-        self.assertEquals(input, json.loads(output))
-        self.assertEquals(output, json.dumps(input))
-        self.assertEquals(input, ujson.decode(output))
+        self.assertEqual(input, json.loads(output))
+        self.assertEqual(output, json.dumps(input))
+        self.assertEqual(input, ujson.decode(output))
 
     def test_encodeDatetimeConversion(self):
         ts = time.time()
         input = datetime.datetime.fromtimestamp(ts)
         output = ujson.encode(input, date_unit='s')
         expected = calendar.timegm(input.utctimetuple())
-        self.assertEquals(int(expected), json.loads(output))
-        self.assertEquals(int(expected), ujson.decode(output))
+        self.assertEqual(int(expected), json.loads(output))
+        self.assertEqual(int(expected), ujson.decode(output))
 
     def test_encodeDateConversion(self):
         ts = time.time()
@@ -353,8 +353,8 @@ class UltraJSONTests(TestCase):
         tup = (input.year, input.month, input.day, 0, 0, 0)
 
         expected = calendar.timegm(tup)
-        self.assertEquals(int(expected), json.loads(output))
-        self.assertEquals(int(expected), ujson.decode(output))
+        self.assertEqual(int(expected), json.loads(output))
+        self.assertEqual(int(expected), ujson.decode(output))
 
     def test_encodeTimeConversion(self):
         tests = [
@@ -365,7 +365,7 @@ class UltraJSONTests(TestCase):
         for test in tests:
             output = ujson.encode(test)
             expected = '"%s"' % test.isoformat()
-            self.assertEquals(expected, output)
+            self.assertEqual(expected, output)
 
     def test_nat(self):
         input = NaT
@@ -405,14 +405,14 @@ class UltraJSONTests(TestCase):
         input = "\xe6\x97\xa5\xd1\x88"
         enc = ujson.encode(input, ensure_ascii=False)
         dec = ujson.decode(enc)
-        self.assertEquals(enc, json_unicode(input, ensure_ascii=False))
-        self.assertEquals(dec, json.loads(enc))
+        self.assertEqual(enc, json_unicode(input, ensure_ascii=False))
+        self.assertEqual(dec, json.loads(enc))
 
     def test_decodeFromUnicode(self):
         input = u("{\"obj\": 31337}")
         dec1 = ujson.decode(input)
         dec2 = ujson.decode(str(input))
-        self.assertEquals(dec1, dec2)
+        self.assertEqual(dec1, dec2)
 
     def test_encodeRecursionMax(self):
         # 8 is the max recursion depth
@@ -647,29 +647,29 @@ class UltraJSONTests(TestCase):
     def test_encodeNullCharacter(self):
         input = "31337 \x00 1337"
         output = ujson.encode(input)
-        self.assertEquals(input, json.loads(output))
-        self.assertEquals(output, json.dumps(input))
-        self.assertEquals(input, ujson.decode(output))
+        self.assertEqual(input, json.loads(output))
+        self.assertEqual(output, json.dumps(input))
+        self.assertEqual(input, ujson.decode(output))
 
         input = "\x00"
         output = ujson.encode(input)
-        self.assertEquals(input, json.loads(output))
-        self.assertEquals(output, json.dumps(input))
-        self.assertEquals(input, ujson.decode(output))
+        self.assertEqual(input, json.loads(output))
+        self.assertEqual(output, json.dumps(input))
+        self.assertEqual(input, ujson.decode(output))
 
-        self.assertEquals('"  \\u0000\\r\\n "', ujson.dumps(u("  \u0000\r\n ")))
+        self.assertEqual('"  \\u0000\\r\\n "', ujson.dumps(u("  \u0000\r\n ")))
         pass
 
     def test_decodeNullCharacter(self):
         input = "\"31337 \\u0000 31337\""
-        self.assertEquals(ujson.decode(input), json.loads(input))
+        self.assertEqual(ujson.decode(input), json.loads(input))
 
     def test_encodeListLongConversion(self):
         input = [9223372036854775807, 9223372036854775807, 9223372036854775807,
                  9223372036854775807, 9223372036854775807, 9223372036854775807 ]
         output = ujson.encode(input)
-        self.assertEquals(input, json.loads(output))
-        self.assertEquals(input, ujson.decode(output))
+        self.assertEqual(input, json.loads(output))
+        self.assertEqual(input, ujson.decode(output))
         assert_array_equal(np.array(input), ujson.decode(output, numpy=True,
                                                          dtype=np.int64))
         pass
@@ -677,15 +677,15 @@ class UltraJSONTests(TestCase):
     def test_encodeLongConversion(self):
         input = 9223372036854775807
         output = ujson.encode(input)
-        self.assertEquals(input, json.loads(output))
-        self.assertEquals(output, json.dumps(input))
-        self.assertEquals(input, ujson.decode(output))
+        self.assertEqual(input, json.loads(output))
+        self.assertEqual(output, json.dumps(input))
+        self.assertEqual(input, ujson.decode(output))
         pass
 
     def test_numericIntExp(self):
         input = "1337E40"
         output = ujson.decode(input)
-        self.assertEquals(output, json.loads(input))
+        self.assertEqual(output, json.loads(input))
 
     def test_numericIntFrcExp(self):
         input = "1.337E40"
@@ -725,7 +725,7 @@ class UltraJSONTests(TestCase):
     def test_dumpToFile(self):
         f = StringIO()
         ujson.dump([1, 2, 3], f)
-        self.assertEquals("[1,2,3]", f.getvalue())
+        self.assertEqual("[1,2,3]", f.getvalue())
 
     def test_dumpToFileLikeObject(self):
         class filelike:
@@ -735,7 +735,7 @@ class UltraJSONTests(TestCase):
                 self.bytes += bytes
         f = filelike()
         ujson.dump([1, 2, 3], f)
-        self.assertEquals("[1,2,3]", f.bytes)
+        self.assertEqual("[1,2,3]", f.bytes)
 
     def test_dumpFileArgsError(self):
         try:
@@ -747,7 +747,7 @@ class UltraJSONTests(TestCase):
 
     def test_loadFile(self):
         f = StringIO("[1,2,3,4]")
-        self.assertEquals([1, 2, 3, 4], ujson.load(f))
+        self.assertEqual([1, 2, 3, 4], ujson.load(f))
         f = StringIO("[1,2,3,4]")
         assert_array_equal(np.array([1, 2, 3, 4]), ujson.load(f, numpy=True))
 
@@ -760,7 +760,7 @@ class UltraJSONTests(TestCase):
                     self.end = True
                     return "[1,2,3,4]"
         f = filelike()
-        self.assertEquals([1, 2, 3, 4], ujson.load(f))
+        self.assertEqual([1, 2, 3, 4], ujson.load(f))
         f = filelike()
         assert_array_equal(np.array([1, 2, 3, 4]), ujson.load(f, numpy=True))
 
@@ -842,7 +842,7 @@ class UltraJSONTests(TestCase):
         o = DictTest()
         output = ujson.encode(o)
         dec = ujson.decode(output)
-        self.assertEquals(dec, d)
+        self.assertEqual(dec, d)
 
     def test_defaultHandler(self):
 
@@ -859,12 +859,12 @@ class UltraJSONTests(TestCase):
                 return str(self.val)
 
         self.assertRaises(OverflowError, ujson.encode, _TestObject("foo"))
-        self.assertEquals('"foo"', ujson.encode(_TestObject("foo"),
+        self.assertEqual('"foo"', ujson.encode(_TestObject("foo"),
                                                 default_handler=str))
 
         def my_handler(obj):
             return "foobar"
-        self.assertEquals('"foobar"', ujson.encode(_TestObject("foo"),
+        self.assertEqual('"foobar"', ujson.encode(_TestObject("foo"),
                                                    default_handler=my_handler))
 
         def my_handler_raises(obj):
@@ -874,19 +874,19 @@ class UltraJSONTests(TestCase):
 
         def my_int_handler(obj):
             return 42
-        self.assertEquals(
+        self.assertEqual(
             42, ujson.decode(ujson.encode(_TestObject("foo"),
                                           default_handler=my_int_handler)))
 
         def my_obj_handler(obj):
             return datetime.datetime(2013, 2, 3)
-        self.assertEquals(
+        self.assertEqual(
             ujson.decode(ujson.encode(datetime.datetime(2013, 2, 3))),
             ujson.decode(ujson.encode(_TestObject("foo"),
                                       default_handler=my_obj_handler)))
 
         l = [_TestObject("foo"), _TestObject("bar")]
-        self.assertEquals(json.loads(json.dumps(l, default=str)),
+        self.assertEqual(json.loads(json.dumps(l, default=str)),
                           ujson.decode(ujson.encode(l, default_handler=str)))
 
 
@@ -1513,7 +1513,7 @@ class PandasJSONTests(TestCase):
 
     def test_encodeEmptySet(self):
         s = set()
-        self.assertEquals("[]", ujson.encode(s))
+        self.assertEqual("[]", ujson.encode(s))
 
     def test_encodeSet(self):
         s = set([1,2,3,4,5,6,7,8,9])

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -1582,7 +1582,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 
             # it works!
             df = self.read_table(StringIO(text), sep='\s+')
-            self.assertEquals(df.index.names, ('one', 'two', 'three', 'four'))
+            self.assertEqual(df.index.names, ('one', 'two', 'three', 'four'))
 
     def test_read_csv_parse_simple_list(self):
         text = """foo
@@ -1853,12 +1853,12 @@ A,B,C
 
         # it works! and is the right length
         result = self.read_table(path, encoding='utf-16')
-        self.assertEquals(len(result), 50)
+        self.assertEqual(len(result), 50)
 
         if not compat.PY3:
             buf = BytesIO(open(path, 'rb').read())
             result = self.read_table(buf, encoding='utf-16')
-            self.assertEquals(len(result), 50)
+            self.assertEqual(len(result), 50)
 
     def test_converters_corner_with_nas(self):
         # skip aberration observed on Win64 Python 3.2.2
@@ -1929,7 +1929,7 @@ A,B,C
         got = result[1][1632]
         expected = u('\xc1 k\xf6ldum klaka (Cold Fever) (1994)')
 
-        self.assertEquals(got, expected)
+        self.assertEqual(got, expected)
 
     def test_trailing_delimiters(self):
         # #2442. grumble grumble
@@ -2072,7 +2072,7 @@ a,b,c
         result2 = self.read_csv(StringIO(data), usecols=('b', 'c'))
         exp = self.read_csv(StringIO(data))
 
-        self.assertEquals(len(result.columns), 2)
+        self.assertEqual(len(result.columns), 2)
         self.assertTrue((result['b'] == exp['b']).all())
         self.assertTrue((result['c'] == exp['c']).all())
 
@@ -2729,7 +2729,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 
         # it works!
         df = self.read_table(StringIO(text), sep='\s+')
-        self.assertEquals(df.index.names, ('one', 'two', 'three', 'four'))
+        self.assertEqual(df.index.names, ('one', 'two', 'three', 'four'))
 
         # GH 6893
         data = '      A B C\na b c\n1 3 7 0 3 6\n3 1 4 1 5 9'
@@ -3117,7 +3117,7 @@ No,No,No"""
         self.assertTrue((result.dtypes == object).all())
 
         result = read_csv(StringIO(data), dtype=object, na_filter=False)
-        self.assertEquals(result['B'][2], '')
+        self.assertEqual(result['B'][2], '')
 
     def test_int64_overflow(self):
         data = """ID
@@ -3174,7 +3174,7 @@ No,No,No"""
 2012-05-12,USD,SBUX,SELL,500"""
 
         result = self.read_csv(StringIO(data))
-        self.assertEquals(result['Date'][1], '2012-05-12')
+        self.assertEqual(result['Date'][1], '2012-05-12')
         self.assertTrue(result['UnitPrice'].isnull().all())
 
     def test_parse_ragged_csv(self):

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -159,8 +159,8 @@ class TestHDFStore(tm.TestCase):
                 tbl['a'] = tm.makeDataFrame()
 
             with get_store(self.path) as tbl:
-                self.assertEquals(len(tbl), 1)
-                self.assertEquals(type(tbl['a']), DataFrame)
+                self.assertEqual(len(tbl), 1)
+                self.assertEqual(type(tbl['a']), DataFrame)
         finally:
             safe_remove(self.path)
 
@@ -338,7 +338,7 @@ class TestHDFStore(tm.TestCase):
             store['c'] = tm.makeDataFrame()
             store['d'] = tm.makePanel()
             store['foo/bar'] = tm.makePanel()
-            self.assertEquals(len(store), 5)
+            self.assertEqual(len(store), 5)
             self.assert_(set(
                     store.keys()) == set(['/a', '/b', '/c', '/d', '/foo/bar']))
 
@@ -494,7 +494,7 @@ class TestHDFStore(tm.TestCase):
             # truncation ok here
             store.open('w')
             self.assertTrue(store.is_open)
-            self.assertEquals(len(store), 0)
+            self.assertEqual(len(store), 0)
             store.close()
             self.assertFalse(store.is_open)
 
@@ -504,7 +504,7 @@ class TestHDFStore(tm.TestCase):
             # reopen as read
             store.open('r')
             self.assertTrue(store.is_open)
-            self.assertEquals(len(store), 1)
+            self.assertEqual(len(store), 1)
             self.assertEqual(store._mode, 'r')
             store.close()
             self.assertFalse(store.is_open)
@@ -512,7 +512,7 @@ class TestHDFStore(tm.TestCase):
             # reopen as append
             store.open('a')
             self.assertTrue(store.is_open)
-            self.assertEquals(len(store), 1)
+            self.assertEqual(len(store), 1)
             self.assertEqual(store._mode, 'a')
             store.close()
             self.assertFalse(store.is_open)
@@ -520,7 +520,7 @@ class TestHDFStore(tm.TestCase):
             # reopen as append (again)
             store.open('a')
             self.assertTrue(store.is_open)
-            self.assertEquals(len(store), 1)
+            self.assertEqual(len(store), 1)
             self.assertEqual(store._mode, 'a')
             store.close()
             self.assertFalse(store.is_open)
@@ -2162,11 +2162,11 @@ class TestHDFStore(tm.TestCase):
             store['a'] = ts
             store['b'] = df
             _maybe_remove(store, 'a')
-            self.assertEquals(len(store), 1)
+            self.assertEqual(len(store), 1)
             tm.assert_frame_equal(df, store['b'])
 
             _maybe_remove(store, 'b')
-            self.assertEquals(len(store), 0)
+            self.assertEqual(len(store), 0)
 
             # nonexistence
             self.assertRaises(KeyError, store.remove, 'a_nonexistent_store')
@@ -2176,19 +2176,19 @@ class TestHDFStore(tm.TestCase):
             store['b/foo'] = df
             _maybe_remove(store, 'foo')
             _maybe_remove(store, 'b/foo')
-            self.assertEquals(len(store), 1)
+            self.assertEqual(len(store), 1)
 
             store['a'] = ts
             store['b/foo'] = df
             _maybe_remove(store, 'b')
-            self.assertEquals(len(store), 1)
+            self.assertEqual(len(store), 1)
 
             # __delitem__
             store['a'] = ts
             store['b'] = df
             del store['a']
             del store['b']
-            self.assertEquals(len(store), 0)
+            self.assertEqual(len(store), 0)
 
     def test_remove_where(self):
 
@@ -2783,7 +2783,7 @@ class TestHDFStore(tm.TestCase):
             store['frame'] = frame
             recons = store['frame']
             self.assertTrue(recons.index.equals(rng))
-            self.assertEquals(rng.tz, recons.index.tz)
+            self.assertEqual(rng.tz, recons.index.tz)
 
     def test_fixed_offset_tz(self):
         rng = date_range('1/1/2000 00:00:00-07:00', '1/30/2000 00:00:00-07:00')
@@ -2793,7 +2793,7 @@ class TestHDFStore(tm.TestCase):
             store['frame'] = frame
             recons = store['frame']
             self.assertTrue(recons.index.equals(rng))
-            self.assertEquals(rng.tz, recons.index.tz)
+            self.assertEqual(rng.tz, recons.index.tz)
 
     def test_store_hierarchical(self):
         index = MultiIndex(levels=[['foo', 'bar', 'baz', 'qux'],
@@ -4183,7 +4183,7 @@ class TestHDFStore(tm.TestCase):
             dt = datetime.datetime(2012, 1, 2, 3, 4, 5, 123456)
             series = Series([0], [dt])
             store['a'] = series
-            self.assertEquals(store['a'].index[0], dt)
+            self.assertEqual(store['a'].index[0], dt)
 
     def test_tseries_indices_series(self):
 
@@ -4194,8 +4194,8 @@ class TestHDFStore(tm.TestCase):
             result = store['a']
 
             assert_series_equal(result, ser)
-            self.assertEquals(type(result.index), type(ser.index))
-            self.assertEquals(result.index.freq, ser.index.freq)
+            self.assertEqual(type(result.index), type(ser.index))
+            self.assertEqual(result.index.freq, ser.index.freq)
 
             idx = tm.makePeriodIndex(10)
             ser = Series(np.random.randn(len(idx)), idx)
@@ -4203,8 +4203,8 @@ class TestHDFStore(tm.TestCase):
             result = store['a']
 
             assert_series_equal(result, ser)
-            self.assertEquals(type(result.index), type(ser.index))
-            self.assertEquals(result.index.freq, ser.index.freq)
+            self.assertEqual(type(result.index), type(ser.index))
+            self.assertEqual(result.index.freq, ser.index.freq)
 
     def test_tseries_indices_frame(self):
 
@@ -4215,8 +4215,8 @@ class TestHDFStore(tm.TestCase):
             result = store['a']
 
             assert_frame_equal(result, df)
-            self.assertEquals(type(result.index), type(df.index))
-            self.assertEquals(result.index.freq, df.index.freq)
+            self.assertEqual(type(result.index), type(df.index))
+            self.assertEqual(result.index.freq, df.index.freq)
 
             idx = tm.makePeriodIndex(10)
             df = DataFrame(np.random.randn(len(idx), 3), idx)
@@ -4224,8 +4224,8 @@ class TestHDFStore(tm.TestCase):
             result = store['a']
 
             assert_frame_equal(result, df)
-            self.assertEquals(type(result.index), type(df.index))
-            self.assertEquals(result.index.freq, df.index.freq)
+            self.assertEqual(type(result.index), type(df.index))
+            self.assertEqual(result.index.freq, df.index.freq)
 
     def test_unicode_index(self):
 

--- a/pandas/sparse/tests/test_array.py
+++ b/pandas/sparse/tests/test_array.py
@@ -51,7 +51,7 @@ class TestSparseArray(tm.TestCase):
 
     def test_constructor_from_sparse(self):
         res = SparseArray(self.zarr)
-        self.assertEquals(res.fill_value, 0)
+        self.assertEqual(res.fill_value, 0)
         assert_almost_equal(res.sp_values, self.zarr.sp_values)
 
     def test_constructor_copy(self):

--- a/pandas/sparse/tests/test_list.py
+++ b/pandas/sparse/tests/test_list.py
@@ -32,11 +32,11 @@ class TestSparseList(unittest.TestCase):
         arr = self.na_data
         splist = SparseList()
         splist.append(arr[:5])
-        self.assertEquals(len(splist), 5)
+        self.assertEqual(len(splist), 5)
         splist.append(arr[5])
-        self.assertEquals(len(splist), 6)
+        self.assertEqual(len(splist), 6)
         splist.append(arr[6:])
-        self.assertEquals(len(splist), 10)
+        self.assertEqual(len(splist), 10)
 
     def test_append_na(self):
         arr = self.na_data
@@ -86,7 +86,7 @@ class TestSparseList(unittest.TestCase):
 
         cp = splist.copy()
         cp.append(arr[6:])
-        self.assertEquals(splist.nchunks, 2)
+        self.assertEqual(splist.nchunks, 2)
         assert_sp_array_equal(cp.to_array(), exp_sparr)
 
     def test_getitem(self):

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -216,7 +216,7 @@ class TestSparseSeries(tm.TestCase,
     def test_to_dense_preserve_name(self):
         assert(self.bseries.name is not None)
         result = self.bseries.to_dense()
-        self.assertEquals(result.name, self.bseries.name)
+        self.assertEqual(result.name, self.bseries.name)
 
     def test_constructor(self):
         # test setup guys
@@ -225,7 +225,7 @@ class TestSparseSeries(tm.TestCase,
         self.assertTrue(np.isnan(self.iseries.fill_value))
         tm.assert_isinstance(self.iseries.sp_index, IntIndex)
 
-        self.assertEquals(self.zbseries.fill_value, 0)
+        self.assertEqual(self.zbseries.fill_value, 0)
         assert_equal(self.zbseries.values.values,
                      self.bseries.to_dense().fillna(0).values)
 
@@ -310,8 +310,8 @@ class TestSparseSeries(tm.TestCase,
         self.assertRaises(Exception, self.bseries.astype, np.int64)
 
     def test_kind(self):
-        self.assertEquals(self.bseries.kind, 'block')
-        self.assertEquals(self.iseries.kind, 'integer')
+        self.assertEqual(self.bseries.kind, 'block')
+        self.assertEqual(self.iseries.kind, 'integer')
 
     def test_pickle(self):
         def _test_roundtrip(series):
@@ -610,7 +610,7 @@ class TestSparseSeries(tm.TestCase,
             sparse_result = getattr(obj, op)()
             series = obj.to_dense()
             dense_result = getattr(series, op)()
-            self.assertEquals(sparse_result, dense_result)
+            self.assertEqual(sparse_result, dense_result)
 
         to_compare = ['count', 'sum', 'mean', 'std', 'var', 'skew']
 
@@ -648,7 +648,7 @@ class TestSparseSeries(tm.TestCase,
 
         assert_almost_equal(sp_valid.values, expected.values)
         self.assertTrue(sp_valid.index.equals(expected.index))
-        self.assertEquals(len(sp_valid.sp_values), 2)
+        self.assertEqual(len(sp_valid.sp_values), 2)
 
         result = self.bseries.dropna()
         expected = self.bseries.to_dense().dropna()
@@ -720,7 +720,7 @@ class TestSparseSeries(tm.TestCase,
         result = self.bseries.cumsum()
         expected = self.bseries.to_dense().cumsum()
         tm.assert_isinstance(result, SparseSeries)
-        self.assertEquals(result.name, self.bseries.name)
+        self.assertEqual(result.name, self.bseries.name)
         assert_series_equal(result.to_dense(), expected)
 
         result = self.zbseries.cumsum()
@@ -802,7 +802,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
         tm.assert_isinstance(self.iframe['A'].sp_index, IntIndex)
 
         # constructed zframe from matrix above
-        self.assertEquals(self.zframe['A'].fill_value, 0)
+        self.assertEqual(self.zframe['A'].fill_value, 0)
         assert_almost_equal([0, 0, 0, 0, 1, 2, 3, 4, 5, 6],
                             self.zframe['A'].values)
 
@@ -940,12 +940,12 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
         df = DataFrame({'A': [0, 0, 0, 1, 2],
                         'B': [1, 2, 0, 0, 0]}, dtype=float)
         sdf = df.to_sparse(fill_value=0)
-        self.assertEquals(sdf.default_fill_value, 0)
+        self.assertEqual(sdf.default_fill_value, 0)
         tm.assert_frame_equal(sdf.to_dense(), df)
 
     def test_density(self):
         df = SparseSeries([nan, nan, nan, 0, 1, 2, 3, 4, 5, 6])
-        self.assertEquals(df.density, 0.7)
+        self.assertEqual(df.density, 0.7)
 
     def test_sparse_to_dense(self):
         pass
@@ -1079,7 +1079,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
         # preserve sparse index type. #2251
         data = {'A': [0, 1]}
         iframe = SparseDataFrame(data, default_kind='integer')
-        self.assertEquals(type(iframe['A'].sp_index),
+        self.assertEqual(type(iframe['A'].sp_index),
                           type(iframe.icol(0).sp_index))
 
     def test_set_value(self):
@@ -1164,7 +1164,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
             to_sparsify = np.random.randn(N)
             to_sparsify[N // 2:] = frame.default_fill_value
             frame['I'] = to_sparsify
-            self.assertEquals(len(frame['I'].sp_values), N // 2)
+            self.assertEqual(len(frame['I'].sp_values), N // 2)
 
             # insert ndarray wrong size
             self.assertRaises(Exception, frame.__setitem__, 'foo',
@@ -1172,11 +1172,11 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
 
             # scalar value
             frame['J'] = 5
-            self.assertEquals(len(frame['J'].sp_values), N)
+            self.assertEqual(len(frame['J'].sp_values), N)
             self.assertTrue((frame['J'].sp_values == 5).all())
 
             frame['K'] = frame.default_fill_value
-            self.assertEquals(len(frame['K'].sp_values), 0)
+            self.assertEqual(len(frame['K'].sp_values), 0)
 
         self._check_all(_check_frame)
 
@@ -1347,19 +1347,19 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
 
             # length zero
             length_zero = frame.reindex([])
-            self.assertEquals(len(length_zero), 0)
-            self.assertEquals(len(length_zero.columns), len(frame.columns))
-            self.assertEquals(len(length_zero['A']), 0)
+            self.assertEqual(len(length_zero), 0)
+            self.assertEqual(len(length_zero.columns), len(frame.columns))
+            self.assertEqual(len(length_zero['A']), 0)
 
             # frame being reindexed has length zero
             length_n = length_zero.reindex(index)
-            self.assertEquals(len(length_n), len(frame))
-            self.assertEquals(len(length_n.columns), len(frame.columns))
-            self.assertEquals(len(length_n['A']), len(frame))
+            self.assertEqual(len(length_n), len(frame))
+            self.assertEqual(len(length_n.columns), len(frame.columns))
+            self.assertEqual(len(length_n['A']), len(frame))
 
             # reindex columns
             reindexed = frame.reindex(columns=['A', 'B', 'Z'])
-            self.assertEquals(len(reindexed.columns), 3)
+            self.assertEqual(len(reindexed.columns), 3)
             assert_almost_equal(reindexed['Z'].fill_value,
                                 frame.default_fill_value)
             self.assertTrue(np.isnan(reindexed['Z'].sp_values).all())
@@ -1395,7 +1395,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
                               'C': np.arange(10),
                               'D': [0, 1, 2, 3, 4, 5, nan, nan, nan, nan]})
 
-        self.assertEquals(df.density, 0.75)
+        self.assertEqual(df.density, 0.75)
 
     def test_to_dense(self):
         def _check(frame):
@@ -1665,7 +1665,7 @@ class TestSparsePanel(tm.TestCase,
         def _check_loc(item, major, minor, val=1.5):
             res = self.panel.set_value(item, major, minor, val)
             self.assertIsNot(res, self.panel)
-            self.assertEquals(res.get_value(item, major, minor), val)
+            self.assertEqual(res.get_value(item, major, minor), val)
 
         _check_loc('ItemA', self.panel.major_axis[4], self.panel.minor_axis[3])
         _check_loc('ItemF', self.panel.major_axis[4], self.panel.minor_axis[3])

--- a/pandas/stats/tests/test_moments.py
+++ b/pandas/stats/tests/test_moments.py
@@ -444,7 +444,7 @@ class TestMoments(tm.TestCase):
         tm.assert_isinstance(series_result, Series)
 
         frame_result = func(self.frame, 50)
-        self.assertEquals(type(frame_result), DataFrame)
+        self.assertEqual(type(frame_result), DataFrame)
 
         # check time_rule works
         if has_time_rule:
@@ -565,7 +565,7 @@ class TestMoments(tm.TestCase):
         series_result = func(self.series, com=10)
         tm.assert_isinstance(series_result, Series)
         frame_result = func(self.frame, com=10)
-        self.assertEquals(type(frame_result), DataFrame)
+        self.assertEqual(type(frame_result), DataFrame)
 
     # binary moments
     def test_rolling_cov(self):
@@ -847,7 +847,7 @@ class TestMoments(tm.TestCase):
         series_result = func(self.series)
         tm.assert_isinstance(series_result, Series)
         frame_result = func(self.frame)
-        self.assertEquals(type(frame_result), DataFrame)
+        self.assertEqual(type(frame_result), DataFrame)
 
     def _check_expanding(self, func, static_comp, has_min_periods=True,
                          has_time_rule=True,

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -280,7 +280,7 @@ class TestIndexOps(Ops):
             tm.assert_series_equal(s.value_counts(), expected)
 
             self.assert_numpy_array_equal(s.unique(), np.unique(s_values))
-            self.assertEquals(s.nunique(), 4)
+            self.assertEqual(s.nunique(), 4)
             # don't sort, have to sort after the fact as not sorting is platform-dep
             hist = s.value_counts(sort=False)
             hist.sort()
@@ -310,7 +310,7 @@ class TestIndexOps(Ops):
             tm.assert_series_equal(res1n, exp1n)
 
             self.assert_numpy_array_equal(s1.unique(), np.array([1, 2, 3]))
-            self.assertEquals(s1.nunique(), 3)
+            self.assertEqual(s1.nunique(), 3)
 
             res4 = s1.value_counts(bins=4)
             exp4 = Series({0.998: 2, 1.5: 1, 2.0: 0, 2.5: 1}, index=[0.998, 2.5, 1.5, 2.0])
@@ -326,13 +326,13 @@ class TestIndexOps(Ops):
             tm.assert_series_equal(s.value_counts(), expected)
 
             self.assert_numpy_array_equal(s.unique(), np.array(['a', 'b', np.nan, 'd'], dtype='O'))
-            self.assertEquals(s.nunique(), 3)
+            self.assertEqual(s.nunique(), 3)
 
             s = klass({})
             expected = Series([], dtype=np.int64)
             tm.assert_series_equal(s.value_counts(), expected)
             self.assert_numpy_array_equal(s.unique(), np.array([]))
-            self.assertEquals(s.nunique(), 0)
+            self.assertEqual(s.nunique(), 0)
 
             # GH 3002, datetime64[ns]
             txt = "\n".join(['xxyyzz20100101PIE', 'xxyyzz20100101GUM', 'xxyyzz20100101EGG',
@@ -355,7 +355,7 @@ class TestIndexOps(Ops):
             else:
                 self.assert_numpy_array_equal(s.unique(), expected)
 
-            self.assertEquals(s.nunique(), 3)
+            self.assertEqual(s.nunique(), 3)
 
             # with NaT
             s = df['dt'].copy()
@@ -372,7 +372,7 @@ class TestIndexOps(Ops):
             self.assert_numpy_array_equal(unique[:3], expected)
             self.assertTrue(unique[3] is pd.NaT or unique[3].astype('int64') == pd.tslib.iNaT)
 
-            self.assertEquals(s.nunique(), 4)
+            self.assertEqual(s.nunique(), 4)
 
             # timedelta64[ns]
             td = df.dt - df.dt + timedelta(1)
@@ -386,7 +386,7 @@ class TestIndexOps(Ops):
             # get nanoseconds to compare
             expected = np.array([86400000000000])
             self.assert_numpy_array_equal(td.unique(), expected)
-            self.assertEquals(td.nunique(), 1)
+            self.assertEqual(td.nunique(), 1)
 
             td2 = timedelta(1) + (df.dt - df.dt)
             td2 = klass(td2)
@@ -396,7 +396,7 @@ class TestIndexOps(Ops):
             tm.assert_series_equal(result2, expected_s)
 
             self.assert_numpy_array_equal(td.unique(), expected)
-            self.assertEquals(td.nunique(), 1)
+            self.assertEqual(td.nunique(), 1)
 
     def test_factorize(self):
         for o in self.objs:

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -135,7 +135,7 @@ class TestCategorical(tm.TestCase):
         sub = "Index([a, b, c]"
         actual = re.sub(pat, sub, actual)
 
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_big_print(self):
         factor = Categorical([0,1,2,0,1,2]*100, ['a', 'b', 'c'], name='cat')
@@ -152,7 +152,7 @@ class TestCategorical(tm.TestCase):
         sub = "Index([a, b, c]"
         actual = re.sub(pat, sub, actual)
 
-        self.assertEquals(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_empty_print(self):
         factor = Categorical([], ["a","b","c"], name="cat")

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -576,7 +576,7 @@ class TestDataFrameFormatting(tm.TestCase):
     </tr>
   </tbody>
 </table>"""
-            self.assertEquals(result, expected)
+            self.assertEqual(result, expected)
 
             df = DataFrame([[0, 1], [2, 3], [4, 5], [6, 7]],
                            columns=index[::2], index=index)
@@ -631,7 +631,7 @@ class TestDataFrameFormatting(tm.TestCase):
     </tr>
   </tbody>
 </table>"""
-            self.assertEquals(result, expected)
+            self.assertEqual(result, expected)
 
     def test_to_html_multiindex_sparsify(self):
         index = pd.MultiIndex.from_arrays([[0, 0, 1, 1], [0, 1, 0, 1]],
@@ -680,7 +680,7 @@ class TestDataFrameFormatting(tm.TestCase):
     </tr>
   </tbody>
 </table>"""
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
         df = DataFrame([[0, 1], [2, 3], [4, 5], [6, 7]],
                        columns=index[::2], index=index)
@@ -733,7 +733,7 @@ class TestDataFrameFormatting(tm.TestCase):
     </tr>
   </tbody>
 </table>"""
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_to_html_index_formatter(self):
         df = DataFrame([[0, 1], [2, 3], [4, 5], [6, 7]],
@@ -773,7 +773,7 @@ class TestDataFrameFormatting(tm.TestCase):
     </tr>
   </tbody>
 </table>"""
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_to_html_regression_GH6098(self):
         df = DataFrame({u('clé1'): [u('a'), u('a'), u('b'), u('b'), u('a')],
@@ -1152,21 +1152,21 @@ class TestDataFrameFormatting(tm.TestCase):
         if PY3:
             raise nose.SkipTest("doesn't work on Python 3")
 
-        self.assertEquals(pp_t('a') , u('a'))
-        self.assertEquals(pp_t(u('a')) , u('a'))
-        self.assertEquals(pp_t(None) , 'None')
-        self.assertEquals(pp_t(u('\u05d0'), quote_strings=True),
+        self.assertEqual(pp_t('a') , u('a'))
+        self.assertEqual(pp_t(u('a')) , u('a'))
+        self.assertEqual(pp_t(None) , 'None')
+        self.assertEqual(pp_t(u('\u05d0'), quote_strings=True),
                           u("u'\u05d0'"))
-        self.assertEquals(pp_t(u('\u05d0'), quote_strings=False),
+        self.assertEqual(pp_t(u('\u05d0'), quote_strings=False),
                           u('\u05d0'))
-        self.assertEquals(pp_t((u('\u05d0'),
+        self.assertEqual(pp_t((u('\u05d0'),
                                 u('\u05d1')), quote_strings=True),
                           u("(u'\u05d0', u'\u05d1')"))
-        self.assertEquals(pp_t((u('\u05d0'), (u('\u05d1'),
+        self.assertEqual(pp_t((u('\u05d0'), (u('\u05d1'),
                                                   u('\u05d2'))),
                                quote_strings=True),
                           u("(u'\u05d0', (u'\u05d1', u'\u05d2'))"))
-        self.assertEquals(pp_t(('foo', u('\u05d0'), (u('\u05d0'),
+        self.assertEqual(pp_t(('foo', u('\u05d0'), (u('\u05d0'),
                                                          u('\u05d0'))),
                                quote_strings=True),
                           u("(u'foo', u'\u05d0', (u'\u05d0', u'\u05d0'))"))
@@ -2496,29 +2496,29 @@ class TestSeriesFormatting(tm.TestCase):
         s = Series(randn(8), index=index)
 
         with option_context("display.max_rows", 10):
-            self.assertEquals(len(str(s).split('\n')),10)
+            self.assertEqual(len(str(s).split('\n')),10)
         with option_context("display.max_rows", 3):
-            self.assertEquals(len(str(s).split('\n')),5)
+            self.assertEqual(len(str(s).split('\n')),5)
         with option_context("display.max_rows", 2):
-            self.assertEquals(len(str(s).split('\n')),5)
+            self.assertEqual(len(str(s).split('\n')),5)
         with option_context("display.max_rows", 1):
-            self.assertEquals(len(str(s).split('\n')),5)
+            self.assertEqual(len(str(s).split('\n')),5)
         with option_context("display.max_rows", 0):
-            self.assertEquals(len(str(s).split('\n')),10)
+            self.assertEqual(len(str(s).split('\n')),10)
 
         # index
         s = Series(randn(8), None)
 
         with option_context("display.max_rows", 10):
-            self.assertEquals(len(str(s).split('\n')),9)
+            self.assertEqual(len(str(s).split('\n')),9)
         with option_context("display.max_rows", 3):
-            self.assertEquals(len(str(s).split('\n')),4)
+            self.assertEqual(len(str(s).split('\n')),4)
         with option_context("display.max_rows", 2):
-            self.assertEquals(len(str(s).split('\n')),4)
+            self.assertEqual(len(str(s).split('\n')),4)
         with option_context("display.max_rows", 1):
-            self.assertEquals(len(str(s).split('\n')),4)
+            self.assertEqual(len(str(s).split('\n')),4)
         with option_context("display.max_rows", 0):
-            self.assertEquals(len(str(s).split('\n')),9)
+            self.assertEqual(len(str(s).split('\n')),9)
 
 class TestEngFormatter(tm.TestCase):
     _multiprocess_can_split_ = True

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -692,13 +692,13 @@ class CheckIndexing(object):
         df = DataFrame(np.random.rand(3, 2), index=index)
 
         s1 = df.ix[52195.1:52196.5]
-        self.assertEquals(len(s1), 2)
+        self.assertEqual(len(s1), 2)
 
         s1 = df.ix[52195.1:52196.6]
-        self.assertEquals(len(s1), 2)
+        self.assertEqual(len(s1), 2)
 
         s1 = df.ix[52195.1:52198.9]
-        self.assertEquals(len(s1), 3)
+        self.assertEqual(len(s1), 3)
 
     def test_getitem_fancy_slice_integers_step(self):
         df = DataFrame(np.random.randn(10, 5))
@@ -1944,17 +1944,17 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
     def test_get_axis(self):
         f = self.frame
-        self.assertEquals(f._get_axis_number(0), 0)
-        self.assertEquals(f._get_axis_number(1), 1)
-        self.assertEquals(f._get_axis_number('index'), 0)
-        self.assertEquals(f._get_axis_number('rows'), 0)
-        self.assertEquals(f._get_axis_number('columns'), 1)
+        self.assertEqual(f._get_axis_number(0), 0)
+        self.assertEqual(f._get_axis_number(1), 1)
+        self.assertEqual(f._get_axis_number('index'), 0)
+        self.assertEqual(f._get_axis_number('rows'), 0)
+        self.assertEqual(f._get_axis_number('columns'), 1)
 
-        self.assertEquals(f._get_axis_name(0), 'index')
-        self.assertEquals(f._get_axis_name(1), 'columns')
-        self.assertEquals(f._get_axis_name('index'), 'index')
-        self.assertEquals(f._get_axis_name('rows'), 'index')
-        self.assertEquals(f._get_axis_name('columns'), 'columns')
+        self.assertEqual(f._get_axis_name(0), 'index')
+        self.assertEqual(f._get_axis_name(1), 'columns')
+        self.assertEqual(f._get_axis_name('index'), 'index')
+        self.assertEqual(f._get_axis_name('rows'), 'index')
+        self.assertEqual(f._get_axis_name('columns'), 'columns')
 
         self.assertIs(f._get_axis(0), f.index)
         self.assertIs(f._get_axis(1), f.columns)
@@ -9159,7 +9159,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         renamer = DataFrame(data, index=index)
         renamed = renamer.rename(index={'foo': 'bar', 'bar': 'foo'})
         self.assert_numpy_array_equal(renamed.index, ['bar', 'foo'])
-        self.assertEquals(renamed.index.name, renamer.index.name)
+        self.assertEqual(renamed.index.name, renamer.index.name)
 
         # MultiIndex
         tuples_index = [('foo1', 'bar1'), ('foo2', 'bar2')]
@@ -9173,8 +9173,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         new_columns = MultiIndex.from_tuples([('fizz3', 'buzz1'), ('fizz2', 'buzz3')])
         self.assert_numpy_array_equal(renamed.index, new_index)
         self.assert_numpy_array_equal(renamed.columns, new_columns)
-        self.assertEquals(renamed.index.names, renamer.index.names)
-        self.assertEquals(renamed.columns.names, renamer.columns.names)
+        self.assertEqual(renamed.index.names, renamer.index.names)
+        self.assertEqual(renamed.columns.names, renamer.columns.names)
 
     def test_rename_nocopy(self):
         renamed = self.frame.rename(columns={'C': 'foo'}, copy=False)
@@ -10944,8 +10944,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         axis1 = self.empty.sum(1)
         tm.assert_isinstance(axis0, Series)
         tm.assert_isinstance(axis1, Series)
-        self.assertEquals(len(axis0), 0)
-        self.assertEquals(len(axis1), 0)
+        self.assertEqual(len(axis0), 0)
+        self.assertEqual(len(axis1), 0)
 
     def test_sum_object(self):
         values = self.frame.values.astype(int)
@@ -12699,7 +12699,7 @@ starting,ending,measure
         df = pd.util.testing.makeDataFrame()
         df.index.name = 'name'
 
-        self.assertEquals(df.set_index(df.index).index.names, ['name'])
+        self.assertEqual(df.set_index(df.index).index.names, ['name'])
 
         mi = MultiIndex.from_arrays(df[['A', 'B']].T.values, names=['A', 'B'])
         mi2 = MultiIndex.from_arrays(df[['A', 'B', 'A', 'B']].T.values,
@@ -12707,7 +12707,7 @@ starting,ending,measure
 
         df = df.set_index(['A', 'B'])
 
-        self.assertEquals(df.set_index(df.index).index.names, ['A', 'B'])
+        self.assertEqual(df.set_index(df.index).index.names, ['A', 'B'])
 
         # Check that set_index isn't converting a MultiIndex into an Index
         self.assertTrue(isinstance(df.set_index(df.index).index, MultiIndex))

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -459,7 +459,7 @@ class TestSeries(tm.TestCase, Generic):
         Series.__finalize__ = finalize
 
         result = pd.concat([o, o2])
-        self.assertEquals(result.filename,'foo+bar')
+        self.assertEqual(result.filename,'foo+bar')
         self.assertIsNone(result.name)
 
         # reset
@@ -1080,7 +1080,7 @@ class TestDataFrame(tm.TestCase, Generic):
 
         DataFrame.__finalize__ = finalize
         result = df1.merge(df2, left_on=['a'], right_on=['c'], how='inner')
-        self.assertEquals(result.filename,'fname1.csv|fname2.csv')
+        self.assertEqual(result.filename,'fname1.csv|fname2.csv')
 
         # concat
         # GH 6927
@@ -1101,7 +1101,7 @@ class TestDataFrame(tm.TestCase, Generic):
         DataFrame.__finalize__ = finalize
 
         result = pd.concat([df1, df1])
-        self.assertEquals(result.filename,'foo+foo')
+        self.assertEqual(result.filename,'foo+foo')
 
         # reset
         DataFrame._metadata = _metadata

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1940,11 +1940,11 @@ class TestDataFramePlots(TestPlotBase):
 
         # Default to BuGn
         ax = df.plot(kind='hexbin', x='A', y='B')
-        self.assertEquals(ax.collections[0].cmap.name, 'BuGn')
+        self.assertEqual(ax.collections[0].cmap.name, 'BuGn')
 
         cm = 'cubehelix'
         ax = df.plot(kind='hexbin', x='A', y='B', colormap=cm)
-        self.assertEquals(ax.collections[0].cmap.name, cm)
+        self.assertEqual(ax.collections[0].cmap.name, cm)
 
     @slow
     def test_no_color_bar(self):
@@ -1958,7 +1958,7 @@ class TestDataFramePlots(TestPlotBase):
         df = self.hexbin_df
 
         ax = df.plot(kind='hexbin', x='A', y='B', cmap='YlGn')
-        self.assertEquals(ax.collections[0].cmap.name, 'YlGn')
+        self.assertEqual(ax.collections[0].cmap.name, 'YlGn')
 
         with tm.assertRaises(TypeError):
             df.plot(kind='hexbin', x='A', y='B', cmap='YlGn',

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -645,12 +645,12 @@ class TestGroupBy(tm.TestCase):
         grouped = df.groupby([lambda x: x.year,
                               lambda x: x.month,
                               lambda x: x.day])
-        self.assertEquals(len(grouped), len(df))
+        self.assertEqual(len(grouped), len(df))
 
         grouped = df.groupby([lambda x: x.year,
                               lambda x: x.month])
         expected = len(set([(x.year, x.month) for x in df.index]))
-        self.assertEquals(len(grouped), expected)
+        self.assertEqual(len(grouped), expected)
 
     def test_groups(self):
         grouped = self.df.groupby(['A'])
@@ -1197,7 +1197,7 @@ class TestGroupBy(tm.TestCase):
         groups = {}
         for key, gp in grouped:
             groups[key] = gp
-        self.assertEquals(len(groups), 2)
+        self.assertEqual(len(groups), 2)
 
         # axis = 1
         three_levels = self.three_group.groupby(['A', 'B', 'C']).mean()
@@ -1566,7 +1566,7 @@ class TestGroupBy(tm.TestCase):
         agged = grouped.apply(lambda x: x.mean())
         agged_A = grouped['A'].apply(np.mean)
         assert_series_equal(agged['A'], agged_A)
-        self.assertEquals(agged.index.name, 'first')
+        self.assertEqual(agged.index.name, 'first')
 
     def test_apply_concat_preserve_names(self):
         grouped = self.three_group.groupby(['A', 'B'])
@@ -1594,13 +1594,13 @@ class TestGroupBy(tm.TestCase):
             return result
 
         result = grouped.apply(desc)
-        self.assertEquals(result.index.names, ('A', 'B', 'stat'))
+        self.assertEqual(result.index.names, ('A', 'B', 'stat'))
 
         result2 = grouped.apply(desc2)
-        self.assertEquals(result2.index.names, ('A', 'B', 'stat'))
+        self.assertEqual(result2.index.names, ('A', 'B', 'stat'))
 
         result3 = grouped.apply(desc3)
-        self.assertEquals(result3.index.names, ('A', 'B', None))
+        self.assertEqual(result3.index.names, ('A', 'B', None))
 
     def test_nonsense_func(self):
         df = DataFrame([0])
@@ -1724,8 +1724,8 @@ class TestGroupBy(tm.TestCase):
 
         assert_frame_equal(result0, expected0)
         assert_frame_equal(result1, expected1)
-        self.assertEquals(result0.index.name, frame.index.names[0])
-        self.assertEquals(result1.index.name, frame.index.names[1])
+        self.assertEqual(result0.index.name, frame.index.names[0])
+        self.assertEqual(result1.index.name, frame.index.names[1])
 
         # groupby level name
         result0 = frame.groupby(level='first').sum()
@@ -1807,7 +1807,7 @@ class TestGroupBy(tm.TestCase):
                    4, 5, 2, 6], name='foo'))
 
         result = a.groupby(level=0).sum()
-        self.assertEquals(result.index.name, a.index.name)
+        self.assertEqual(result.index.name, a.index.name)
 
     def test_level_preserve_order(self):
         grouped = self.mframe.groupby(level=0)
@@ -1845,7 +1845,7 @@ class TestGroupBy(tm.TestCase):
 
     def test_apply_series_yield_constant(self):
         result = self.df.groupby(['A', 'B'])['C'].apply(len)
-        self.assertEquals(result.index.names[:2], ('A', 'B'))
+        self.assertEqual(result.index.names[:2], ('A', 'B'))
 
     def test_apply_frame_to_series(self):
         grouped = self.df.groupby(['A', 'B'])
@@ -2028,17 +2028,17 @@ class TestGroupBy(tm.TestCase):
         grouped = self.df.groupby(['A', 'B'])
         result = grouped.size()
         for key, group in grouped:
-            self.assertEquals(result[key], len(group))
+            self.assertEqual(result[key], len(group))
 
         grouped = self.df.groupby('A')
         result = grouped.size()
         for key, group in grouped:
-            self.assertEquals(result[key], len(group))
+            self.assertEqual(result[key], len(group))
 
         grouped = self.df.groupby('B')
         result = grouped.size()
         for key, group in grouped:
-            self.assertEquals(result[key], len(group))
+            self.assertEqual(result[key], len(group))
 
     def test_count(self):
 
@@ -2224,7 +2224,7 @@ class TestGroupBy(tm.TestCase):
                     'count': group.count(), 'mean': group.mean()}
 
         result = self.df.groupby(cats).D.apply(get_stats)
-        self.assertEquals(result.index.names[0], 'C')
+        self.assertEqual(result.index.names[0], 'C')
 
     def test_apply_corner_cases(self):
         # #535, can't use sliding iterator
@@ -2283,24 +2283,24 @@ class TestGroupBy(tm.TestCase):
     def test_groupby_series_with_name(self):
         result = self.df.groupby(self.df['A']).mean()
         result2 = self.df.groupby(self.df['A'], as_index=False).mean()
-        self.assertEquals(result.index.name, 'A')
+        self.assertEqual(result.index.name, 'A')
         self.assertIn('A', result2)
 
         result = self.df.groupby([self.df['A'], self.df['B']]).mean()
         result2 = self.df.groupby([self.df['A'], self.df['B']],
                                   as_index=False).mean()
-        self.assertEquals(result.index.names, ('A', 'B'))
+        self.assertEqual(result.index.names, ('A', 'B'))
         self.assertIn('A', result2)
         self.assertIn('B', result2)
 
     def test_seriesgroupby_name_attr(self):
         # GH 6265
         result = self.df.groupby('A')['C']
-        self.assertEquals(result.count().name, 'C')
-        self.assertEquals(result.mean().name, 'C')
+        self.assertEqual(result.count().name, 'C')
+        self.assertEqual(result.mean().name, 'C')
 
         testFunc = lambda x: np.sum(x)*2
-        self.assertEquals(result.agg(testFunc).name, 'C')
+        self.assertEqual(result.agg(testFunc).name, 'C')
 
     def test_groupby_name_propagation(self):
         # GH 6124
@@ -2983,13 +2983,13 @@ class TestGroupBy(tm.TestCase):
 
         expected = df.groupby('to filter').groups
         result = df.groupby([('to filter', '')]).groups
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
         df = DataFrame([[long(1), 'A'], [long(2), 'A']], columns=midx)
 
         expected = df.groupby('to filter').groups
         result = df.groupby([('to filter', '')]).groups
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_cython_median(self):
         df = DataFrame(np.random.randn(1000))

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -366,7 +366,7 @@ class TestIndex(tm.TestCase):
         exp = self.dateIndex[5]
         exp = _to_m8(exp)
 
-        self.assertEquals(exp, arr[5])
+        self.assertEqual(exp, arr[5])
 
     def test_shift(self):
         shifted = self.dateIndex.shift(0, timedelta(1))
@@ -548,11 +548,11 @@ class TestIndex(tm.TestCase):
         expected = Index([1, 5])
         result = idx1.sym_diff(idx2)
         self.assertTrue(tm.equalContents(result, expected))
-        self.assertEquals(result.name, 'idx1')
+        self.assertEqual(result.name, 'idx1')
 
         result = idx1.sym_diff(idx2, result_name='new_name')
         self.assertTrue(tm.equalContents(result, expected))
-        self.assertEquals(result.name, 'new_name')
+        self.assertEqual(result.name, 'new_name')
 
         # other isn't iterable
         with tm.assertRaises(TypeError):
@@ -565,7 +565,7 @@ class TestIndex(tm.TestCase):
 
             tm.assert_isinstance(unpickled, Index)
             self.assert_numpy_array_equal(unpickled, index)
-            self.assertEquals(unpickled.name, index.name)
+            self.assertEqual(unpickled.name, index.name)
 
             # tm.assert_dict_equal(unpickled.indexMap, index.indexMap)
 
@@ -601,19 +601,19 @@ class TestIndex(tm.TestCase):
         index = Index([datetime.now()])
         formatted = index.format()
         expected = [str(index[0])]
-        self.assertEquals(formatted, expected)
+        self.assertEqual(formatted, expected)
 
         # 2845
         index = Index([1, 2.0+3.0j, np.nan])
         formatted = index.format()
         expected = [str(index[0]), str(index[1]), u('NaN')]
-        self.assertEquals(formatted, expected)
+        self.assertEqual(formatted, expected)
 
         # is this really allowed?
         index = Index([1, 2.0+3.0j, None])
         formatted = index.format()
         expected = [str(index[0]), str(index[1]), u('NaN')]
-        self.assertEquals(formatted, expected)
+        self.assertEqual(formatted, expected)
 
         self.strIndex[:0].format()
 
@@ -631,7 +631,7 @@ class TestIndex(tm.TestCase):
         result = t.format()
         expected = ['2012-02-07 00:00:00', '2012-02-07 23:00:00']
         self.assertEqual(len(result), 2)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_format_none(self):
         values = ['a', 'b', 'c', None]
@@ -677,12 +677,12 @@ class TestIndex(tm.TestCase):
         idx = Index([0, 1, 2, 5, 6, 7, 9, 10])
         n = len(idx)
 
-        self.assertEquals(idx.slice_locs(start=2), (2, n))
-        self.assertEquals(idx.slice_locs(start=3), (3, n))
-        self.assertEquals(idx.slice_locs(3, 8), (3, 6))
-        self.assertEquals(idx.slice_locs(5, 10), (3, n))
-        self.assertEquals(idx.slice_locs(end=8), (0, 6))
-        self.assertEquals(idx.slice_locs(end=9), (0, 7))
+        self.assertEqual(idx.slice_locs(start=2), (2, n))
+        self.assertEqual(idx.slice_locs(start=3), (3, n))
+        self.assertEqual(idx.slice_locs(3, 8), (3, 6))
+        self.assertEqual(idx.slice_locs(5, 10), (3, n))
+        self.assertEqual(idx.slice_locs(end=8), (0, 6))
+        self.assertEqual(idx.slice_locs(end=9), (0, 7))
 
         idx2 = idx[::-1]
         self.assertRaises(KeyError, idx2.slice_locs, 8, 2)
@@ -757,7 +757,7 @@ class TestIndex(tm.TestCase):
                             values[67])
 
         self.dateIndex.set_value(values, date, 10)
-        self.assertEquals(values[67], 10)
+        self.assertEqual(values[67], 10)
 
     def test_isin(self):
         values = ['foo', 'bar']
@@ -1736,7 +1736,7 @@ class TestMultiIndex(tm.TestCase):
             arrays.append(np.asarray(lev).take(lab))
 
         result = MultiIndex.from_arrays(arrays)
-        self.assertEquals(list(result), list(self.index))
+        self.assertEqual(list(result), list(self.index))
 
     def test_from_product(self):
         first = ['foo', 'bar', 'buz']
@@ -1750,7 +1750,7 @@ class TestMultiIndex(tm.TestCase):
         expected = MultiIndex.from_tuples(tuples, names=names)
 
         assert_array_equal(result, expected)
-        self.assertEquals(result.names, names)
+        self.assertEqual(result.names, names)
 
     def test_append(self):
         result = self.index[:3].append(self.index[3:])
@@ -1769,7 +1769,7 @@ class TestMultiIndex(tm.TestCase):
         expected = ['foo', 'foo', 'bar', 'baz', 'qux', 'qux']
         self.assert_numpy_array_equal(result, expected)
 
-        self.assertEquals(result.name, 'first')
+        self.assertEqual(result.name, 'first')
 
         result = self.index.get_level_values('first')
         expected = self.index.get_level_values(0)
@@ -1815,7 +1815,7 @@ class TestMultiIndex(tm.TestCase):
                            self.index.reorder_levels, [2, 1, 0])
 
     def test_nlevels(self):
-        self.assertEquals(self.index.nlevels, 2)
+        self.assertEqual(self.index.nlevels, 2)
 
     def test_iter(self):
         result = list(self.index)
@@ -1892,7 +1892,7 @@ class TestMultiIndex(tm.TestCase):
 
     def test_getitem(self):
         # scalar
-        self.assertEquals(self.index[2], ('bar', 'one'))
+        self.assertEqual(self.index[2], ('bar', 'one'))
 
         # slice
         result = self.index[2:5]
@@ -1908,8 +1908,8 @@ class TestMultiIndex(tm.TestCase):
 
     def test_getitem_group_select(self):
         sorted_idx, _ = self.index.sortlevel(0)
-        self.assertEquals(sorted_idx.get_loc('baz'), slice(3, 4))
-        self.assertEquals(sorted_idx.get_loc('foo'), slice(0, 2))
+        self.assertEqual(sorted_idx.get_loc('baz'), slice(3, 4))
+        self.assertEqual(sorted_idx.get_loc('foo'), slice(0, 2))
 
     def test_get_loc(self):
         self.assertEqual(self.index.get_loc(('foo', 'two')), 1)
@@ -2022,16 +2022,16 @@ class TestMultiIndex(tm.TestCase):
         sorted_idx, _ = self.index.sortlevel(0)
 
         result = sorted_idx.slice_locs(('foo', 'two'), ('qux', 'one'))
-        self.assertEquals(result, (1, 5))
+        self.assertEqual(result, (1, 5))
 
         result = sorted_idx.slice_locs(None, ('qux', 'one'))
-        self.assertEquals(result, (0, 5))
+        self.assertEqual(result, (0, 5))
 
         result = sorted_idx.slice_locs(('foo', 'two'), None)
-        self.assertEquals(result, (1, len(sorted_idx)))
+        self.assertEqual(result, (1, len(sorted_idx)))
 
         result = sorted_idx.slice_locs('bar', 'baz')
-        self.assertEquals(result, (2, 4))
+        self.assertEqual(result, (2, 4))
 
     def test_slice_locs_not_contained(self):
         # some searchsorted action
@@ -2042,22 +2042,22 @@ class TestMultiIndex(tm.TestCase):
                            sortorder=0)
 
         result = index.slice_locs((1, 0), (5, 2))
-        self.assertEquals(result, (3, 6))
+        self.assertEqual(result, (3, 6))
 
         result = index.slice_locs(1, 5)
-        self.assertEquals(result, (3, 6))
+        self.assertEqual(result, (3, 6))
 
         result = index.slice_locs((2, 2), (5, 2))
-        self.assertEquals(result, (3, 6))
+        self.assertEqual(result, (3, 6))
 
         result = index.slice_locs(2, 5)
-        self.assertEquals(result, (3, 6))
+        self.assertEqual(result, (3, 6))
 
         result = index.slice_locs((1, 0), (6, 3))
-        self.assertEquals(result, (3, 8))
+        self.assertEqual(result, (3, 8))
 
         result = index.slice_locs(-1, 10)
-        self.assertEquals(result, (0, len(index)))
+        self.assertEqual(result, (0, len(index)))
 
     def test_consistency(self):
         # need to construct an overflow
@@ -2422,7 +2422,7 @@ class TestMultiIndex(tm.TestCase):
                            ' empty list', MultiIndex.from_tuples, [])
 
         idx = MultiIndex.from_tuples(((1, 2), (3, 4)), names=['a', 'b'])
-        self.assertEquals(len(idx), 2)
+        self.assertEqual(len(idx), 2)
 
     def test_argsort(self):
         result = self.index.argsort()

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -1357,9 +1357,9 @@ class TestIndexing(tm.TestCase):
         self.assertRaises(KeyError, f)
 
         # not lexsorted
-        self.assertEquals(df.index.lexsort_depth,2)
+        self.assertEqual(df.index.lexsort_depth,2)
         df = df.sortlevel(level=1,axis=0)
-        self.assertEquals(df.index.lexsort_depth,0)
+        self.assertEqual(df.index.lexsort_depth,0)
         with tm.assertRaisesRegexp(KeyError, 'MultiIndex Slicing requires the index to be fully lexsorted tuple len \(2\), lexsort depth \(0\)'):
             df.loc[(slice(None),df.loc[:,('a','bar')]>5),:]
 

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -292,8 +292,8 @@ class TestBlockManager(tm.TestCase):
 
     def test_attrs(self):
         mgr = create_mgr('a,b,c: f8-1; d,e,f: f8-2')
-        self.assertEquals(mgr.nblocks, 2)
-        self.assertEquals(len(mgr), 6)
+        self.assertEqual(mgr.nblocks, 2)
+        self.assertEqual(len(mgr), 6)
 
     def test_is_mixed_dtype(self):
         self.assertFalse(create_mgr('a,b:f8').is_mixed_type)
@@ -518,11 +518,11 @@ class TestBlockManager(tm.TestCase):
         mgr.set('b', np.array(['2.'] * N, dtype=np.object_))
         mgr.set('foo', np.array(['foo.'] * N, dtype=np.object_))
         new_mgr = mgr.convert(convert_numeric=True)
-        self.assertEquals(new_mgr.get('a').dtype, np.int64)
-        self.assertEquals(new_mgr.get('b').dtype, np.float64)
-        self.assertEquals(new_mgr.get('foo').dtype, np.object_)
-        self.assertEquals(new_mgr.get('f').dtype, np.int64)
-        self.assertEquals(new_mgr.get('g').dtype, np.float64)
+        self.assertEqual(new_mgr.get('a').dtype, np.int64)
+        self.assertEqual(new_mgr.get('b').dtype, np.float64)
+        self.assertEqual(new_mgr.get('foo').dtype, np.object_)
+        self.assertEqual(new_mgr.get('f').dtype, np.int64)
+        self.assertEqual(new_mgr.get('g').dtype, np.float64)
 
         mgr = create_mgr('a,b,foo: object; f: i4; bool: bool; dt: datetime;'
                          'i: i8; g: f8; h: f2')
@@ -530,15 +530,15 @@ class TestBlockManager(tm.TestCase):
         mgr.set('b', np.array(['2.'] * N, dtype=np.object_))
         mgr.set('foo', np.array(['foo.'] * N, dtype=np.object_))
         new_mgr = mgr.convert(convert_numeric=True)
-        self.assertEquals(new_mgr.get('a').dtype, np.int64)
-        self.assertEquals(new_mgr.get('b').dtype, np.float64)
-        self.assertEquals(new_mgr.get('foo').dtype, np.object_)
-        self.assertEquals(new_mgr.get('f').dtype, np.int32)
-        self.assertEquals(new_mgr.get('bool').dtype, np.bool_)
-        self.assertEquals(new_mgr.get('dt').dtype.type, np.datetime64)
-        self.assertEquals(new_mgr.get('i').dtype, np.int64)
-        self.assertEquals(new_mgr.get('g').dtype, np.float64)
-        self.assertEquals(new_mgr.get('h').dtype, np.float16)
+        self.assertEqual(new_mgr.get('a').dtype, np.int64)
+        self.assertEqual(new_mgr.get('b').dtype, np.float64)
+        self.assertEqual(new_mgr.get('foo').dtype, np.object_)
+        self.assertEqual(new_mgr.get('f').dtype, np.int32)
+        self.assertEqual(new_mgr.get('bool').dtype, np.bool_)
+        self.assertEqual(new_mgr.get('dt').dtype.type, np.datetime64)
+        self.assertEqual(new_mgr.get('i').dtype, np.int64)
+        self.assertEqual(new_mgr.get('g').dtype, np.float64)
+        self.assertEqual(new_mgr.get('h').dtype, np.float16)
 
     def test_interleave(self):
         pass
@@ -565,7 +565,7 @@ class TestBlockManager(tm.TestCase):
         self.mgr.set('h', randn(N))
 
         cons = self.mgr.consolidate()
-        self.assertEquals(cons.nblocks, 1)
+        self.assertEqual(cons.nblocks, 1)
         assert_almost_equal(cons.blocks[0].mgr_locs,
                             np.arange(len(cons.items)))
 
@@ -578,7 +578,7 @@ class TestBlockManager(tm.TestCase):
                          'f: bool; g: f8-2')
 
         reindexed = mgr.reindex_axis(['g', 'c', 'a', 'd'], axis=0)
-        self.assertEquals(reindexed.nblocks, 2)
+        self.assertEqual(reindexed.nblocks, 2)
         assert_almost_equal(reindexed.items, ['g', 'c', 'a', 'd'])
         assert_almost_equal(mgr.get('g'), reindexed.get('g'))
         assert_almost_equal(mgr.get('c'), reindexed.get('c'))
@@ -659,7 +659,7 @@ class TestBlockManager(tm.TestCase):
 
     def test_single_mgr_ctor(self):
         mgr = create_single_mgr('f8', num_rows=5)
-        self.assertEquals(mgr.as_matrix().tolist(), [0., 1., 2., 3., 4.])
+        self.assertEqual(mgr.as_matrix().tolist(), [0., 1., 2., 3., 4.])
 
 
 class TestIndexing(object):
@@ -841,12 +841,12 @@ class TestBlockPlacement(tm.TestCase):
     _multiprocess_can_split_ = True
 
     def test_slice_len(self):
-        self.assertEquals(len(BlockPlacement(slice(0, 4))), 4)
-        self.assertEquals(len(BlockPlacement(slice(0, 4, 2))), 2)
-        self.assertEquals(len(BlockPlacement(slice(0, 3, 2))), 2)
+        self.assertEqual(len(BlockPlacement(slice(0, 4))), 4)
+        self.assertEqual(len(BlockPlacement(slice(0, 4, 2))), 2)
+        self.assertEqual(len(BlockPlacement(slice(0, 3, 2))), 2)
 
-        self.assertEquals(len(BlockPlacement(slice(0, 1, 2))), 1)
-        self.assertEquals(len(BlockPlacement(slice(1, 0, -1))), 1)
+        self.assertEqual(len(BlockPlacement(slice(0, 1, 2))), 1)
+        self.assertEqual(len(BlockPlacement(slice(1, 0, -1))), 1)
 
     def test_zero_step_raises(self):
         self.assertRaises(ValueError, BlockPlacement, slice(1, 1, 0))
@@ -888,7 +888,7 @@ class TestBlockPlacement(tm.TestCase):
 
     def test_array_to_slice_conversion(self):
         def assert_as_slice_equals(arr, slc):
-            self.assertEquals(BlockPlacement(arr).as_slice, slc)
+            self.assertEqual(BlockPlacement(arr).as_slice, slc)
 
         assert_as_slice_equals([0], slice(0, 1, 1))
         assert_as_slice_equals([100], slice(100, 101, 1))
@@ -916,12 +916,12 @@ class TestBlockPlacement(tm.TestCase):
         assert_not_slice_like([1, 1, 1])
 
     def test_slice_iter(self):
-        self.assertEquals(list(BlockPlacement(slice(0, 3))), [0, 1, 2])
-        self.assertEquals(list(BlockPlacement(slice(0, 0))), [])
-        self.assertEquals(list(BlockPlacement(slice(3, 0))), [])
+        self.assertEqual(list(BlockPlacement(slice(0, 3))), [0, 1, 2])
+        self.assertEqual(list(BlockPlacement(slice(0, 0))), [])
+        self.assertEqual(list(BlockPlacement(slice(3, 0))), [])
 
-        self.assertEquals(list(BlockPlacement(slice(3, 0, -1))), [3, 2, 1])
-        self.assertEquals(list(BlockPlacement(slice(3, None, -1))),
+        self.assertEqual(list(BlockPlacement(slice(3, 0, -1))), [3, 2, 1])
+        self.assertEqual(list(BlockPlacement(slice(3, None, -1))),
                           [3, 2, 1, 0])
 
     def test_slice_to_array_conversion(self):
@@ -940,15 +940,15 @@ class TestBlockPlacement(tm.TestCase):
 
     def test_blockplacement_add(self):
         bpl = BlockPlacement(slice(0, 5))
-        self.assertEquals(bpl.add(1).as_slice, slice(1, 6, 1))
-        self.assertEquals(bpl.add(np.arange(5)).as_slice,
+        self.assertEqual(bpl.add(1).as_slice, slice(1, 6, 1))
+        self.assertEqual(bpl.add(np.arange(5)).as_slice,
                           slice(0, 10, 2))
-        self.assertEquals(list(bpl.add(np.arange(5, 0, -1))),
+        self.assertEqual(list(bpl.add(np.arange(5, 0, -1))),
                           [5, 5, 5, 5, 5])
 
     def test_blockplacement_add_int(self):
         def assert_add_equals(val, inc, result):
-            self.assertEquals(list(BlockPlacement(val).add(inc)),
+            self.assertEqual(list(BlockPlacement(val).add(inc)),
                               result)
 
         assert_add_equals(slice(0, 0), 0, [])

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -171,7 +171,7 @@ class TestMultiLevel(tm.TestCase):
 
     def test_sort_index_preserve_levels(self):
         result = self.frame.sort_index()
-        self.assertEquals(result.index.names, self.frame.index.names)
+        self.assertEqual(result.index.names, self.frame.index.names)
 
     def test_repr_to_string(self):
         repr(self.frame)
@@ -213,7 +213,7 @@ class TestMultiLevel(tm.TestCase):
 
         result = s[2000, 3, 10]
         expected = s[49]
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
         # fancy
         result = s.ix[[(2000, 3, 10), (2000, 3, 13)]]
@@ -618,13 +618,13 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 
     def test_frame_setitem_ix(self):
         self.frame.ix[('bar', 'two'), 'B'] = 5
-        self.assertEquals(self.frame.ix[('bar', 'two'), 'B'], 5)
+        self.assertEqual(self.frame.ix[('bar', 'two'), 'B'], 5)
 
         # with integer labels
         df = self.frame.copy()
         df.columns = lrange(3)
         df.ix[('bar', 'two'), 1] = 7
-        self.assertEquals(df.ix[('bar', 'two'), 1], 7)
+        self.assertEqual(df.ix[('bar', 'two'), 1], 7)
 
     def test_fancy_slice_partial(self):
         result = self.frame.ix['bar':'baz']
@@ -665,7 +665,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
             self.frame.reset_index()['A'].sortlevel()
 
         # preserve names
-        self.assertEquals(a_sorted.index.names, self.frame.index.names)
+        self.assertEqual(a_sorted.index.names, self.frame.index.names)
 
         # inplace
         rs = self.frame.copy()
@@ -704,7 +704,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 
     def test_reset_index_with_drop(self):
         deleveled = self.ymd.reset_index(drop=True)
-        self.assertEquals(len(deleveled.columns), len(self.ymd.columns))
+        self.assertEqual(len(deleveled.columns), len(self.ymd.columns))
 
         deleveled = self.series.reset_index()
         tm.assert_isinstance(deleveled, DataFrame)
@@ -915,11 +915,11 @@ Thur,Lunch,Yes,51.51,17"""
 
     def test_stack_unstack_preserve_names(self):
         unstacked = self.frame.unstack()
-        self.assertEquals(unstacked.index.name, 'first')
-        self.assertEquals(unstacked.columns.names, ['exp', 'second'])
+        self.assertEqual(unstacked.index.name, 'first')
+        self.assertEqual(unstacked.columns.names, ['exp', 'second'])
 
         restacked = unstacked.stack()
-        self.assertEquals(restacked.index.names, self.frame.index.names)
+        self.assertEqual(restacked.index.names, self.frame.index.names)
 
     def test_unstack_level_name(self):
         result = self.frame.unstack('second')
@@ -940,7 +940,7 @@ Thur,Lunch,Yes,51.51,17"""
         unstacked = self.ymd.unstack(['year', 'month'])
         expected = self.ymd.unstack('year').unstack('month')
         assert_frame_equal(unstacked, expected)
-        self.assertEquals(unstacked.columns.names,
+        self.assertEqual(unstacked.columns.names,
                           expected.columns.names)
 
         # series
@@ -953,7 +953,7 @@ Thur,Lunch,Yes,51.51,17"""
         restacked = restacked.sortlevel(0)
 
         assert_frame_equal(restacked, self.ymd)
-        self.assertEquals(restacked.index.names, self.ymd.index.names)
+        self.assertEqual(restacked.index.names, self.ymd.index.names)
 
         # GH #451
         unstacked = self.ymd.unstack([1, 2])
@@ -1124,7 +1124,7 @@ Thur,Lunch,Yes,51.51,17"""
         df = DataFrame(np.random.randn(4, 2), index=index)
 
         result = df.unstack()
-        self.assertEquals(len(result.columns), 4)
+        self.assertEqual(len(result.columns), 4)
 
         recons = result.stack()
         assert_frame_equal(recons, df)
@@ -1438,7 +1438,7 @@ Thur,Lunch,Yes,51.51,17"""
         expected = self.ymd.groupby([k1, k2]).mean()
 
         assert_frame_equal(result, expected, check_names=False)  # TODO groupby with level_values drops names
-        self.assertEquals(result.index.names, self.ymd.index.names[:2])
+        self.assertEqual(result.index.names, self.ymd.index.names[:2])
 
         result2 = self.ymd.groupby(level=self.ymd.index.names[:2]).mean()
         assert_frame_equal(result, result2)
@@ -1456,13 +1456,13 @@ Thur,Lunch,Yes,51.51,17"""
     def test_ix_preserve_names(self):
         result = self.ymd.ix[2000]
         result2 = self.ymd['A'].ix[2000]
-        self.assertEquals(result.index.names, self.ymd.index.names[1:])
-        self.assertEquals(result2.index.names, self.ymd.index.names[1:])
+        self.assertEqual(result.index.names, self.ymd.index.names[1:])
+        self.assertEqual(result2.index.names, self.ymd.index.names[1:])
 
         result = self.ymd.ix[2000, 2]
         result2 = self.ymd['A'].ix[2000, 2]
-        self.assertEquals(result.index.name, self.ymd.index.names[2])
-        self.assertEquals(result2.index.name, self.ymd.index.names[2])
+        self.assertEqual(result.index.name, self.ymd.index.names[2])
+        self.assertEqual(result2.index.name, self.ymd.index.names[2])
 
     def test_partial_set(self):
         # GH #397
@@ -1482,7 +1482,7 @@ Thur,Lunch,Yes,51.51,17"""
 
         # this works...for now
         df['A'].ix[14] = 5
-        self.assertEquals(df['A'][14], 5)
+        self.assertEqual(df['A'][14], 5)
 
     def test_unstack_preserve_types(self):
         # GH #403
@@ -1636,12 +1636,12 @@ Thur,Lunch,Yes,51.51,17"""
         result = df['a']
         expected = df['a', '', '']
         assert_series_equal(result, expected)
-        self.assertEquals(result.name, 'a')
+        self.assertEqual(result.name, 'a')
 
         result = df['routine1', 'result1']
         expected = df['routine1', 'result1', '']
         assert_series_equal(result, expected)
-        self.assertEquals(result.name, ('routine1', 'result1'))
+        self.assertEqual(result.name, ('routine1', 'result1'))
 
     def test_mixed_depth_insert(self):
         arrays = [['a', 'top', 'top', 'routine1', 'routine1', 'routine2'],
@@ -1724,7 +1724,7 @@ Thur,Lunch,Yes,51.51,17"""
         expected = df2.pop(('a', '', ''))
         assert_series_equal(expected, result)
         assert_frame_equal(df1, df2)
-        self.assertEquals(result.name, 'a')
+        self.assertEqual(result.name, 'a')
 
         expected = df1['top']
         df1 = df1.drop(['top'], axis=1)
@@ -1900,9 +1900,9 @@ Thur,Lunch,Yes,51.51,17"""
                    MultiIndex.from_arrays((["a"] * n, np.arange(n))))
 
         # hai it works!
-        self.assertEquals(s[("a", 5)], 5)
-        self.assertEquals(s[("a", 6)], 6)
-        self.assertEquals(s[("a", 7)], 7)
+        self.assertEqual(s[("a", 5)], 5)
+        self.assertEqual(s[("a", 6)], 6)
+        self.assertEqual(s[("a", 7)], 7)
 
         _index._SIZE_CUTOFF = old_cutoff
 
@@ -1954,7 +1954,7 @@ Thur,Lunch,Yes,51.51,17"""
         s = Series(dt, index=idx)
 
         result = s.groupby(s.index).first()
-        self.assertEquals(len(result), 3)
+        self.assertEqual(len(result), 3)
 
     def test_duplicate_mi(self):
         # GH 4516

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -58,11 +58,11 @@ class CheckNameIntegration(object):
 
     def test_scalarop_preserve_name(self):
         result = self.ts * 2
-        self.assertEquals(result.name, self.ts.name)
+        self.assertEqual(result.name, self.ts.name)
 
     def test_copy_name(self):
         result = self.ts.copy()
-        self.assertEquals(result.name, self.ts.name)
+        self.assertEqual(result.name, self.ts.name)
 
     def test_copy_index_name_checking(self):
         # don't want to be able to modify the index stored elsewhere after
@@ -78,16 +78,16 @@ class CheckNameIntegration(object):
 
     def test_append_preserve_name(self):
         result = self.ts[:5].append(self.ts[5:])
-        self.assertEquals(result.name, self.ts.name)
+        self.assertEqual(result.name, self.ts.name)
 
     def test_binop_maybe_preserve_name(self):
 
         # names match, preserve
         result = self.ts * self.ts
-        self.assertEquals(result.name, self.ts.name)
+        self.assertEqual(result.name, self.ts.name)
 
         result = self.ts * self.ts[:-2]
-        self.assertEquals(result.name, self.ts.name)
+        self.assertEqual(result.name, self.ts.name)
 
         # names don't match, don't preserve
         cp = self.ts.copy()
@@ -97,7 +97,7 @@ class CheckNameIntegration(object):
 
     def test_combine_first_name(self):
         result = self.ts.combine_first(self.ts[:5])
-        self.assertEquals(result.name, self.ts.name)
+        self.assertEqual(result.name, self.ts.name)
 
     def test_combine_first_dt64(self):
         from pandas.tseries.tools import to_datetime
@@ -121,7 +121,7 @@ class CheckNameIntegration(object):
 
         result = s.get(25, 0)
         expected = 0
-        self.assertEquals(result,expected)
+        self.assertEqual(result,expected)
 
         s = Series(np.array([43, 48, 60, 48, 50, 51, 50, 45, 57, 48, 56,
                              45, 51, 39, 55, 43, 54, 52, 51, 54]),
@@ -133,7 +133,7 @@ class CheckNameIntegration(object):
 
         result = s.get(25, 0)
         expected = 43
-        self.assertEquals(result,expected)
+        self.assertEqual(result,expected)
 
     def test_delitem(self):
 
@@ -166,13 +166,13 @@ class CheckNameIntegration(object):
 
     def test_getitem_preserve_name(self):
         result = self.ts[self.ts > 0]
-        self.assertEquals(result.name, self.ts.name)
+        self.assertEqual(result.name, self.ts.name)
 
         result = self.ts[[0, 2, 4]]
-        self.assertEquals(result.name, self.ts.name)
+        self.assertEqual(result.name, self.ts.name)
 
         result = self.ts[5:10]
-        self.assertEquals(result.name, self.ts.name)
+        self.assertEqual(result.name, self.ts.name)
 
     def test_getitem_setitem_ellipsis(self):
         s = Series(np.random.randn(10))
@@ -212,7 +212,7 @@ class CheckNameIntegration(object):
                     "       three     9",
                     "Name: sth, dtype: int64"]
         expected = "\n".join(expected)
-        self.assertEquals(repr(s), expected)
+        self.assertEqual(repr(s), expected)
 
     def test_multilevel_preserve_name(self):
         index = MultiIndex(levels=[['foo', 'bar', 'baz', 'qux'],
@@ -224,8 +224,8 @@ class CheckNameIntegration(object):
 
         result = s['foo']
         result2 = s.ix['foo']
-        self.assertEquals(result.name, s.name)
-        self.assertEquals(result2.name, s.name)
+        self.assertEqual(result.name, s.name)
+        self.assertEqual(result2.name, s.name)
 
     def test_name_printing(self):
         # test small series
@@ -246,7 +246,7 @@ class CheckNameIntegration(object):
 
     def test_pickle_preserve_name(self):
         unpickled = self._pickle_roundtrip_name(self.ts)
-        self.assertEquals(unpickled.name, self.ts.name)
+        self.assertEqual(unpickled.name, self.ts.name)
 
     def _pickle_roundtrip_name(self, obj):
 
@@ -257,15 +257,15 @@ class CheckNameIntegration(object):
 
     def test_argsort_preserve_name(self):
         result = self.ts.argsort()
-        self.assertEquals(result.name, self.ts.name)
+        self.assertEqual(result.name, self.ts.name)
 
     def test_sort_index_name(self):
         result = self.ts.sort_index(ascending=False)
-        self.assertEquals(result.name, self.ts.name)
+        self.assertEqual(result.name, self.ts.name)
 
     def test_to_sparse_pass_name(self):
         result = self.ts.to_sparse()
-        self.assertEquals(result.name, self.ts.name)
+        self.assertEqual(result.name, self.ts.name)
 
 
 class TestNanops(tm.TestCase):
@@ -326,17 +326,17 @@ class TestNanops(tm.TestCase):
             result = s.sum(skipna=False)
             self.assertEqual(int(result),v.sum(dtype='int64'))
             result = s.min(skipna=False)
-            self.assertEquals(int(result),0)
+            self.assertEqual(int(result),0)
             result = s.max(skipna=False)
-            self.assertEquals(int(result),v[-1])
+            self.assertEqual(int(result),v[-1])
 
             # use bottleneck if available
             result = s.sum()
             self.assertEqual(int(result),v.sum(dtype='int64'))
             result = s.min()
-            self.assertEquals(int(result),0)
+            self.assertEqual(int(result),0)
             result = s.max()
-            self.assertEquals(int(result),v[-1])
+            self.assertEqual(int(result),v[-1])
 
         for dtype in ['float32','float64']:
             v = np.arange(5000000,dtype=dtype)
@@ -411,7 +411,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         self.assertTrue(tm.equalContents(derived.index, self.ts.index))
         # Ensure new index is not created
-        self.assertEquals(id(self.ts.index), id(derived.index))
+        self.assertEqual(id(self.ts.index), id(derived.index))
 
         # Mixed type Series
         mixed = Series(['hello', np.NaN], index=[0, 1])
@@ -562,10 +562,10 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
     def test_constructor_sanitize(self):
         s = Series(np.array([1., 1., 8.]), dtype='i8')
-        self.assertEquals(s.dtype, np.dtype('i8'))
+        self.assertEqual(s.dtype, np.dtype('i8'))
 
         s = Series(np.array([1., 1., np.nan]), copy=True, dtype='i8')
-        self.assertEquals(s.dtype, np.dtype('f8'))
+        self.assertEqual(s.dtype, np.dtype('f8'))
 
     def test_constructor_pass_none(self):
         s = Series(None, index=lrange(5))
@@ -584,7 +584,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         s2 = Series(s, dtype=np.int64)
 
         s2[1] = 5
-        self.assertEquals(s[1], 5)
+        self.assertEqual(s[1], 5)
 
     def test_constructor_dtype_datetime64(self):
         import pandas.tslib as tslib
@@ -1338,8 +1338,8 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         assert_series_equal(self.series.ix[mask], self.series[mask])
 
         # ask for index value
-        self.assertEquals(self.ts.ix[d1], self.ts[d1])
-        self.assertEquals(self.ts.ix[d2], self.ts[d2])
+        self.assertEqual(self.ts.ix[d1], self.ts[d1])
+        self.assertEqual(self.ts.ix[d2], self.ts[d2])
 
     def test_ix_getitem_not_monotonic(self):
         d1, d2 = self.ts.index[[5, 15]]
@@ -1429,7 +1429,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
             s[mask] = lrange(2, 7)
             expected = Series(lrange(2, 7) + lrange(5, 10), dtype=dtype)
             assert_series_equal(s, expected)
-            self.assertEquals(s.dtype, expected.dtype)
+            self.assertEqual(s.dtype, expected.dtype)
 
         # these are allowed operations, but are upcasted
         for dtype in [np.int64, np.float64]:
@@ -1439,7 +1439,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
             s[mask] = values
             expected = Series(values + lrange(5, 10), dtype='float64')
             assert_series_equal(s, expected)
-            self.assertEquals(s.dtype, expected.dtype)
+            self.assertEqual(s.dtype, expected.dtype)
 
         # can't do these as we are forced to change the itemsize of the input
         # to something we cannot
@@ -1455,7 +1455,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         s[mask] = lrange(2, 7)
         expected = Series(lrange(2, 7) + lrange(5, 10), dtype='int64')
         assert_series_equal(s, expected)
-        self.assertEquals(s.dtype, expected.dtype)
+        self.assertEqual(s.dtype, expected.dtype)
 
         s = Series(np.arange(10), dtype='int64')
         mask = s > 5
@@ -1663,8 +1663,8 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # set index value
         self.series.ix[d1] = 4
         self.series.ix[d2] = 6
-        self.assertEquals(self.series[d1], 4)
-        self.assertEquals(self.series[d2], 6)
+        self.assertEqual(self.series[d1], 4)
+        self.assertEqual(self.series[d2], 6)
 
     def test_setitem_boolean(self):
         mask = self.series > self.series.median()
@@ -1790,7 +1790,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
             repr(s)
         finally:
             sys.stderr = tmp
-        self.assertEquals(buf.getvalue(), '')
+        self.assertEqual(buf.getvalue(), '')
 
     def test_repr_name_iterable_indexable(self):
         s = Series([1, 2, 3], name=np.int64(3))
@@ -5724,11 +5724,11 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
     def test_dropna_preserve_name(self):
         self.ts[:5] = np.nan
         result = self.ts.dropna()
-        self.assertEquals(result.name, self.ts.name)
+        self.assertEqual(result.name, self.ts.name)
         name = self.ts.name
         ts = self.ts.copy()
         ts.dropna(inplace=True)
-        self.assertEquals(ts.name, name)
+        self.assertEqual(ts.name, name)
 
     def test_numpy_unique(self):
         # it works!

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -120,15 +120,15 @@ class TestStringMethods(tm.TestCase):
 
         result = strings.str_cat(one, na_rep='NA')
         exp = 'aabbcNA'
-        self.assertEquals(result, exp)
+        self.assertEqual(result, exp)
 
         result = strings.str_cat(one, na_rep='-')
         exp = 'aabbc-'
-        self.assertEquals(result, exp)
+        self.assertEqual(result, exp)
 
         result = strings.str_cat(one, sep='_', na_rep='NA')
         exp = 'a_a_b_b_c_NA'
-        self.assertEquals(result, exp)
+        self.assertEqual(result, exp)
 
         # Multiple arrays
         result = strings.str_cat(one, [two], na_rep='NA')
@@ -788,7 +788,7 @@ class TestStringMethods(tm.TestCase):
         s = Series(['Wes McKinney', 'Travis  Oliphant'])
 
         result = s.str.split()
-        self.assertEquals(result[1], ['Travis', 'Oliphant'])
+        self.assertEqual(result[1], ['Travis', 'Oliphant'])
 
     def test_split_maxsplit(self):
         # re.split 0, str.split -1
@@ -1088,19 +1088,19 @@ class TestStringMethods(tm.TestCase):
             warnings.simplefilter('always')
             result = data.str.match(pat, flags=re.IGNORECASE)
             assert issubclass(w[-1].category, UserWarning)
-        self.assertEquals(result[0], ('dave', 'google', 'com'))
+        self.assertEqual(result[0], ('dave', 'google', 'com'))
 
         result = data.str.findall(pat, flags=re.IGNORECASE)
-        self.assertEquals(result[0][0], ('dave', 'google', 'com'))
+        self.assertEqual(result[0][0], ('dave', 'google', 'com'))
 
         result = data.str.count(pat, flags=re.IGNORECASE)
-        self.assertEquals(result[0], 1)
+        self.assertEqual(result[0], 1)
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
             result = data.str.contains(pat, flags=re.IGNORECASE)
             assert issubclass(w[-1].category, UserWarning)
-        self.assertEquals(result[0], True)
+        self.assertEqual(result[0], True)
 
     def test_encode_decode(self):
         base = Series([u('a'), u('b'), u('a\xe4')])

--- a/pandas/tools/tests/test_tile.py
+++ b/pandas/tools/tests/test_tile.py
@@ -87,7 +87,7 @@ class TestCut(tm.TestCase):
         s = Series(np.random.randn(100), name='foo')
 
         factor = cut(s, 4)
-        self.assertEquals(factor.name, 'foo')
+        self.assertEqual(factor.name, 'foo')
 
     def test_label_precision(self):
         arr = np.arange(0, 0.73, 0.01)
@@ -124,10 +124,10 @@ class TestCut(tm.TestCase):
 
         np.testing.assert_array_equal(result.levels, ex_levels)
         np.testing.assert_array_equal(result_ser.levels, ex_levels)
-        self.assertEquals(result[5], '(4, inf]')
-        self.assertEquals(result[0], '(-inf, 2]')
-        self.assertEquals(result_ser[5], '(4, inf]')
-        self.assertEquals(result_ser[0], '(-inf, 2]')
+        self.assertEqual(result[5], '(4, inf]')
+        self.assertEqual(result[0], '(-inf, 2]')
+        self.assertEqual(result_ser[5], '(4, inf]')
+        self.assertEqual(result_ser[0], '(-inf, 2]')
 
     def test_qcut(self):
         arr = np.random.randn(1000)
@@ -192,7 +192,7 @@ class TestCut(tm.TestCase):
         self.assertTrue(com.isnull(result[:20]).all())
 
     def test_label_formatting(self):
-        self.assertEquals(tmod._trim_zeros('1.000'), '1')
+        self.assertEqual(tmod._trim_zeros('1.000'), '1')
 
         # it works
         result = cut(np.arange(11.), 2)
@@ -202,9 +202,9 @@ class TestCut(tm.TestCase):
         # #1979, negative numbers
 
         result = tmod._format_label(-117.9998, precision=3)
-        self.assertEquals(result, '-118')
+        self.assertEqual(result, '-118')
         result = tmod._format_label(117.9998, precision=3)
-        self.assertEquals(result, '118')
+        self.assertEqual(result, '118')
 
     def test_qcut_binning_issues(self):
         # #1978, 1979

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -107,8 +107,8 @@ class TestDateRange(tm.TestCase):
     def test_cached_range_bug(self):
         rng = date_range('2010-09-01 05:00:00', periods=50,
                          freq=datetools.DateOffset(hours=6))
-        self.assertEquals(len(rng), 50)
-        self.assertEquals(rng[0], datetime(2010, 9, 1, 5))
+        self.assertEqual(len(rng), 50)
+        self.assertEqual(rng[0], datetime(2010, 9, 1, 5))
 
     def test_timezone_comparaison_bug(self):
         start = Timestamp('20130220 10:00', tz='US/Eastern')
@@ -140,18 +140,18 @@ class TestDateRange(tm.TestCase):
     def test_getitem(self):
         smaller = self.rng[:5]
         self.assert_numpy_array_equal(smaller, self.rng.view(np.ndarray)[:5])
-        self.assertEquals(smaller.offset, self.rng.offset)
+        self.assertEqual(smaller.offset, self.rng.offset)
 
         sliced = self.rng[::5]
-        self.assertEquals(sliced.offset, datetools.bday * 5)
+        self.assertEqual(sliced.offset, datetools.bday * 5)
 
         fancy_indexed = self.rng[[4, 3, 2, 1, 0]]
-        self.assertEquals(len(fancy_indexed), 5)
+        self.assertEqual(len(fancy_indexed), 5)
         tm.assert_isinstance(fancy_indexed, DatetimeIndex)
         self.assertIsNone(fancy_indexed.freq)
 
         # 32-bit vs. 64-bit platforms
-        self.assertEquals(self.rng[4], self.rng[np.int_(4)])
+        self.assertEqual(self.rng[4], self.rng[np.int_(4)])
 
     def test_getitem_matplotlib_hackaround(self):
         values = self.rng[:, None]
@@ -160,20 +160,20 @@ class TestDateRange(tm.TestCase):
 
     def test_shift(self):
         shifted = self.rng.shift(5)
-        self.assertEquals(shifted[0], self.rng[5])
-        self.assertEquals(shifted.offset, self.rng.offset)
+        self.assertEqual(shifted[0], self.rng[5])
+        self.assertEqual(shifted.offset, self.rng.offset)
 
         shifted = self.rng.shift(-5)
-        self.assertEquals(shifted[5], self.rng[0])
-        self.assertEquals(shifted.offset, self.rng.offset)
+        self.assertEqual(shifted[5], self.rng[0])
+        self.assertEqual(shifted.offset, self.rng.offset)
 
         shifted = self.rng.shift(0)
-        self.assertEquals(shifted[0], self.rng[0])
-        self.assertEquals(shifted.offset, self.rng.offset)
+        self.assertEqual(shifted[0], self.rng[0])
+        self.assertEqual(shifted.offset, self.rng.offset)
 
         rng = date_range(START, END, freq=datetools.bmonthEnd)
         shifted = rng.shift(1, freq=datetools.bday)
-        self.assertEquals(shifted[0], rng[0] + datetools.bday)
+        self.assertEqual(shifted[0], rng[0] + datetools.bday)
 
     def test_pickle_unpickle(self):
         pickled = pickle.dumps(self.rng)
@@ -460,18 +460,18 @@ class TestCustomDateRange(tm.TestCase):
     def test_getitem(self):
         smaller = self.rng[:5]
         self.assert_numpy_array_equal(smaller, self.rng.view(np.ndarray)[:5])
-        self.assertEquals(smaller.offset, self.rng.offset)
+        self.assertEqual(smaller.offset, self.rng.offset)
 
         sliced = self.rng[::5]
-        self.assertEquals(sliced.offset, datetools.cday * 5)
+        self.assertEqual(sliced.offset, datetools.cday * 5)
 
         fancy_indexed = self.rng[[4, 3, 2, 1, 0]]
-        self.assertEquals(len(fancy_indexed), 5)
+        self.assertEqual(len(fancy_indexed), 5)
         tm.assert_isinstance(fancy_indexed, DatetimeIndex)
         self.assertIsNone(fancy_indexed.freq)
 
         # 32-bit vs. 64-bit platforms
-        self.assertEquals(self.rng[4], self.rng[np.int_(4)])
+        self.assertEqual(self.rng[4], self.rng[np.int_(4)])
 
     def test_getitem_matplotlib_hackaround(self):
         values = self.rng[:, None]
@@ -480,20 +480,20 @@ class TestCustomDateRange(tm.TestCase):
 
     def test_shift(self):
         shifted = self.rng.shift(5)
-        self.assertEquals(shifted[0], self.rng[5])
-        self.assertEquals(shifted.offset, self.rng.offset)
+        self.assertEqual(shifted[0], self.rng[5])
+        self.assertEqual(shifted.offset, self.rng.offset)
 
         shifted = self.rng.shift(-5)
-        self.assertEquals(shifted[5], self.rng[0])
-        self.assertEquals(shifted.offset, self.rng.offset)
+        self.assertEqual(shifted[5], self.rng[0])
+        self.assertEqual(shifted.offset, self.rng.offset)
 
         shifted = self.rng.shift(0)
-        self.assertEquals(shifted[0], self.rng[0])
-        self.assertEquals(shifted.offset, self.rng.offset)
+        self.assertEqual(shifted[0], self.rng[0])
+        self.assertEqual(shifted.offset, self.rng.offset)
 
         rng = date_range(START, END, freq=datetools.bmonthEnd)
         shifted = rng.shift(1, freq=datetools.cday)
-        self.assertEquals(shifted[0], rng[0] + datetools.cday)
+        self.assertEqual(shifted[0], rng[0] + datetools.cday)
 
     def test_pickle_unpickle(self):
         pickled = pickle.dumps(self.rng)

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -37,16 +37,16 @@ class TestPeriodProperties(tm.TestCase):
 
     def test_quarterly_negative_ordinals(self):
         p = Period(ordinal=-1, freq='Q-DEC')
-        self.assertEquals(p.year, 1969)
-        self.assertEquals(p.quarter, 4)
+        self.assertEqual(p.year, 1969)
+        self.assertEqual(p.quarter, 4)
 
         p = Period(ordinal=-2, freq='Q-DEC')
-        self.assertEquals(p.year, 1969)
-        self.assertEquals(p.quarter, 3)
+        self.assertEqual(p.year, 1969)
+        self.assertEqual(p.quarter, 3)
 
         p = Period(ordinal=-2, freq='M')
-        self.assertEquals(p.year, 1969)
-        self.assertEquals(p.month, 11)
+        self.assertEqual(p.year, 1969)
+        self.assertEqual(p.month, 11)
 
     def test_period_cons_quarterly(self):
         # bugs in scikits.timeseries
@@ -56,7 +56,7 @@ class TestPeriodProperties(tm.TestCase):
             self.assertIn('1989Q3', str(exp))
             stamp = exp.to_timestamp('D', how='end')
             p = Period(stamp, freq=freq)
-            self.assertEquals(p, exp)
+            self.assertEqual(p, exp)
 
     def test_period_cons_annual(self):
         # bugs in scikits.timeseries
@@ -65,7 +65,7 @@ class TestPeriodProperties(tm.TestCase):
             exp = Period('1989', freq=freq)
             stamp = exp.to_timestamp('D', how='end') + timedelta(days=30)
             p = Period(stamp, freq=freq)
-            self.assertEquals(p, exp + 1)
+            self.assertEqual(p, exp + 1)
 
     def test_period_cons_weekly(self):
         for num in range(10, 17):
@@ -75,7 +75,7 @@ class TestPeriodProperties(tm.TestCase):
 
                 result = Period(daystr, freq=freq)
                 expected = Period(daystr, freq='D').asfreq(freq)
-                self.assertEquals(result, expected)
+                self.assertEqual(result, expected)
 
     def test_timestamp_tz_arg(self):
         import pytz
@@ -87,90 +87,90 @@ class TestPeriodProperties(tm.TestCase):
         i1 = Period('1/1/2005', freq='M')
         i2 = Period('Jan 2005')
 
-        self.assertEquals(i1, i2)
+        self.assertEqual(i1, i2)
 
         i1 = Period('2005', freq='A')
         i2 = Period('2005')
         i3 = Period('2005', freq='a')
 
-        self.assertEquals(i1, i2)
-        self.assertEquals(i1, i3)
+        self.assertEqual(i1, i2)
+        self.assertEqual(i1, i3)
 
         i4 = Period('2005', freq='M')
         i5 = Period('2005', freq='m')
 
         self.assertRaises(ValueError, i1.__ne__, i4)
-        self.assertEquals(i4, i5)
+        self.assertEqual(i4, i5)
 
         i1 = Period.now('Q')
         i2 = Period(datetime.now(), freq='Q')
         i3 = Period.now('q')
 
-        self.assertEquals(i1, i2)
-        self.assertEquals(i1, i3)
+        self.assertEqual(i1, i2)
+        self.assertEqual(i1, i3)
 
         # Biz day construction, roll forward if non-weekday
         i1 = Period('3/10/12', freq='B')
         i2 = Period('3/10/12', freq='D')
-        self.assertEquals(i1, i2.asfreq('B'))
+        self.assertEqual(i1, i2.asfreq('B'))
         i2 = Period('3/11/12', freq='D')
-        self.assertEquals(i1, i2.asfreq('B'))
+        self.assertEqual(i1, i2.asfreq('B'))
         i2 = Period('3/12/12', freq='D')
-        self.assertEquals(i1, i2.asfreq('B'))
+        self.assertEqual(i1, i2.asfreq('B'))
 
         i3 = Period('3/10/12', freq='b')
-        self.assertEquals(i1, i3)
+        self.assertEqual(i1, i3)
 
         i1 = Period(year=2005, quarter=1, freq='Q')
         i2 = Period('1/1/2005', freq='Q')
-        self.assertEquals(i1, i2)
+        self.assertEqual(i1, i2)
 
         i1 = Period(year=2005, quarter=3, freq='Q')
         i2 = Period('9/1/2005', freq='Q')
-        self.assertEquals(i1, i2)
+        self.assertEqual(i1, i2)
 
         i1 = Period(year=2005, month=3, day=1, freq='D')
         i2 = Period('3/1/2005', freq='D')
-        self.assertEquals(i1, i2)
+        self.assertEqual(i1, i2)
 
         i3 = Period(year=2005, month=3, day=1, freq='d')
-        self.assertEquals(i1, i3)
+        self.assertEqual(i1, i3)
 
         i1 = Period(year=2012, month=3, day=10, freq='B')
         i2 = Period('3/12/12', freq='B')
-        self.assertEquals(i1, i2)
+        self.assertEqual(i1, i2)
 
         i1 = Period('2005Q1')
         i2 = Period(year=2005, quarter=1, freq='Q')
         i3 = Period('2005q1')
-        self.assertEquals(i1, i2)
-        self.assertEquals(i1, i3)
+        self.assertEqual(i1, i2)
+        self.assertEqual(i1, i3)
 
         i1 = Period('05Q1')
-        self.assertEquals(i1, i2)
+        self.assertEqual(i1, i2)
         lower = Period('05q1')
-        self.assertEquals(i1, lower)
+        self.assertEqual(i1, lower)
 
         i1 = Period('1Q2005')
-        self.assertEquals(i1, i2)
+        self.assertEqual(i1, i2)
         lower = Period('1q2005')
-        self.assertEquals(i1, lower)
+        self.assertEqual(i1, lower)
 
         i1 = Period('1Q05')
-        self.assertEquals(i1, i2)
+        self.assertEqual(i1, i2)
         lower = Period('1q05')
-        self.assertEquals(i1, lower)
+        self.assertEqual(i1, lower)
 
         i1 = Period('4Q1984')
-        self.assertEquals(i1.year, 1984)
+        self.assertEqual(i1.year, 1984)
         lower = Period('4q1984')
-        self.assertEquals(i1, lower)
+        self.assertEqual(i1, lower)
 
         i1 = Period('1982', freq='min')
         i2 = Period('1982', freq='MIN')
-        self.assertEquals(i1, i2)
+        self.assertEqual(i1, i2)
         i2 = Period('1982', freq=('Min', 1))
-        self.assertEquals(i1, i2)
+        self.assertEqual(i1, i2)
 
         expected = Period('2007-01', freq='M')
         i1 = Period('200701', freq='M')
@@ -211,12 +211,12 @@ class TestPeriodProperties(tm.TestCase):
     def test_millisecond_repr(self):
         p = Period('2000-01-01 12:15:02.123')
 
-        self.assertEquals("Period('2000-01-01 12:15:02.123', 'L')", repr(p))
+        self.assertEqual("Period('2000-01-01 12:15:02.123', 'L')", repr(p))
 
     def test_microsecond_repr(self):
         p = Period('2000-01-01 12:15:02.123567')
 
-        self.assertEquals("Period('2000-01-01 12:15:02.123567', 'U')", repr(p))
+        self.assertEqual("Period('2000-01-01 12:15:02.123567', 'U')", repr(p))
 
     def test_strftime(self):
         p = Period('2000-1-1 12:34:12', freq='S')
@@ -237,12 +237,12 @@ class TestPeriodProperties(tm.TestCase):
         start_ts = p.to_timestamp(how='S')
         aliases = ['s', 'StarT', 'BEGIn']
         for a in aliases:
-            self.assertEquals(start_ts, p.to_timestamp('D', how=a))
+            self.assertEqual(start_ts, p.to_timestamp('D', how=a))
 
         end_ts = p.to_timestamp(how='E')
         aliases = ['e', 'end', 'FINIsH']
         for a in aliases:
-            self.assertEquals(end_ts, p.to_timestamp('D', how=a))
+            self.assertEqual(end_ts, p.to_timestamp('D', how=a))
 
         from_lst = ['A', 'Q', 'M', 'W', 'B',
                     'D', 'H', 'Min', 'S']
@@ -253,11 +253,11 @@ class TestPeriodProperties(tm.TestCase):
         for i, fcode in enumerate(from_lst):
             p = Period('1982', freq=fcode)
             result = p.to_timestamp().to_period(fcode)
-            self.assertEquals(result, p)
+            self.assertEqual(result, p)
 
-            self.assertEquals(p.start_time, p.to_timestamp(how='S'))
+            self.assertEqual(p.start_time, p.to_timestamp(how='S'))
 
-            self.assertEquals(p.end_time, _ex(p))
+            self.assertEqual(p.end_time, _ex(p))
 
         # Frequency other than daily
 
@@ -265,23 +265,23 @@ class TestPeriodProperties(tm.TestCase):
 
         result = p.to_timestamp('H', how='end')
         expected = datetime(1985, 12, 31, 23)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
         result = p.to_timestamp('T', how='end')
         expected = datetime(1985, 12, 31, 23, 59)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
         result = p.to_timestamp(how='end')
         expected = datetime(1985, 12, 31)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
         expected = datetime(1985, 1, 1)
         result = p.to_timestamp('H', how='start')
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         result = p.to_timestamp('T', how='start')
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         result = p.to_timestamp('S', how='start')
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
         assertRaisesRegexp(ValueError, 'Only mult == 1',  p.to_timestamp, '5t')
 
@@ -290,10 +290,10 @@ class TestPeriodProperties(tm.TestCase):
         xp = datetime(2012, 1, 1)
         for f in freq_lst:
             p = Period('2012', freq=f)
-            self.assertEquals(p.start_time, xp)
-        self.assertEquals(Period('2012', freq='B').start_time,
+            self.assertEqual(p.start_time, xp)
+        self.assertEqual(Period('2012', freq='B').start_time,
                           datetime(2012, 1, 2))
-        self.assertEquals(Period('2012', freq='W').start_time,
+        self.assertEqual(Period('2012', freq='W').start_time,
                           datetime(2011, 12, 26))
 
     def test_end_time(self):
@@ -303,29 +303,29 @@ class TestPeriodProperties(tm.TestCase):
             return Timestamp(Timestamp(datetime(*args)).value - 1)
 
         xp = _ex(2013, 1, 1)
-        self.assertEquals(xp, p.end_time)
+        self.assertEqual(xp, p.end_time)
 
         p = Period('2012', freq='Q')
         xp = _ex(2012, 4, 1)
-        self.assertEquals(xp, p.end_time)
+        self.assertEqual(xp, p.end_time)
 
         p = Period('2012', freq='M')
         xp = _ex(2012, 2, 1)
-        self.assertEquals(xp, p.end_time)
+        self.assertEqual(xp, p.end_time)
 
         xp = _ex(2012, 1, 2)
         p = Period('2012', freq='D')
-        self.assertEquals(p.end_time, xp)
+        self.assertEqual(p.end_time, xp)
 
         xp = _ex(2012, 1, 1, 1)
         p = Period('2012', freq='H')
-        self.assertEquals(p.end_time, xp)
+        self.assertEqual(p.end_time, xp)
 
         xp = _ex(2012, 1, 3)
-        self.assertEquals(Period('2012', freq='B').end_time, xp)
+        self.assertEqual(Period('2012', freq='B').end_time, xp)
 
         xp = _ex(2012, 1, 2)
-        self.assertEquals(Period('2012', freq='W').end_time, xp)
+        self.assertEqual(Period('2012', freq='W').end_time, xp)
 
     def test_anchor_week_end_time(self):
         def _ex(*args):
@@ -333,7 +333,7 @@ class TestPeriodProperties(tm.TestCase):
 
         p = Period('2013-1-1', 'W-SAT')
         xp = _ex(2013, 1, 6)
-        self.assertEquals(p.end_time, xp)
+        self.assertEqual(p.end_time, xp)
 
     def test_properties_annually(self):
         # Test properties on Periods with annually frequency.
@@ -443,7 +443,7 @@ class TestPeriodProperties(tm.TestCase):
 
         val = pmod.pnow('D')
         exp = Period(dt, freq='D')
-        self.assertEquals(val, exp)
+        self.assertEqual(val, exp)
 
     def test_constructor_corner(self):
         self.assertRaises(ValueError, Period, year=2007, month=1,
@@ -461,7 +461,7 @@ class TestPeriodProperties(tm.TestCase):
 
         result = Period(p, freq='A')
         exp = Period('2007', freq='A')
-        self.assertEquals(result, exp)
+        self.assertEqual(result, exp)
 
     def test_constructor_infer_freq(self):
         p = Period('2007-01-01')
@@ -1244,19 +1244,19 @@ class TestPeriodIndex(tm.TestCase):
         self.assertTrue((result.index.year == 2008).all())
 
         result = ts['2008':'2009']
-        self.assertEquals(len(result), 24)
+        self.assertEqual(len(result), 24)
 
         result = ts['2008-1':'2009-12']
-        self.assertEquals(len(result), 24)
+        self.assertEqual(len(result), 24)
 
         result = ts['2008Q1':'2009Q4']
-        self.assertEquals(len(result), 24)
+        self.assertEqual(len(result), 24)
 
         result = ts[:'2009']
-        self.assertEquals(len(result), 36)
+        self.assertEqual(len(result), 36)
 
         result = ts['2009':]
-        self.assertEquals(len(result), 50 - 24)
+        self.assertEqual(len(result), 50 - 24)
 
         exp = result
         result = ts[24:]
@@ -1301,7 +1301,7 @@ class TestPeriodIndex(tm.TestCase):
         exp_index = date_range('1/1/2001', end='12/31/2009', freq='A-DEC')
         result = series.to_timestamp(how='end')
         self.assertTrue(result.index.equals(exp_index))
-        self.assertEquals(result.name, 'foo')
+        self.assertEqual(result.name, 'foo')
 
         exp_index = date_range('1/1/2001', end='1/1/2009', freq='AS-JAN')
         result = series.to_timestamp(how='start')
@@ -1335,7 +1335,7 @@ class TestPeriodIndex(tm.TestCase):
                                freq='H')
         result = series.to_timestamp(how='end')
         self.assertTrue(result.index.equals(exp_index))
-        self.assertEquals(result.name, 'foo')
+        self.assertEqual(result.name, 'foo')
 
     def test_to_timestamp_quarterly_bug(self):
         years = np.arange(1960, 2000).repeat(4)
@@ -1350,10 +1350,10 @@ class TestPeriodIndex(tm.TestCase):
     def test_to_timestamp_preserve_name(self):
         index = PeriodIndex(freq='A', start='1/1/2001', end='12/1/2009',
                             name='foo')
-        self.assertEquals(index.name, 'foo')
+        self.assertEqual(index.name, 'foo')
 
         conv = index.to_timestamp('D')
-        self.assertEquals(conv.name, 'foo')
+        self.assertEqual(conv.name, 'foo')
 
     def test_to_timestamp_repr_is_code(self):
         zs=[Timestamp('99-04-17 00:00:00',tz='UTC'),
@@ -1361,7 +1361,7 @@ class TestPeriodIndex(tm.TestCase):
         Timestamp('2001-04-17 00:00:00',tz='America/Los_Angeles'),
         Timestamp('2001-04-17 00:00:00',tz=None)]
         for z in zs:
-            self.assertEquals( eval(repr(z)), z)
+            self.assertEqual( eval(repr(z)), z)
 
     def test_as_frame_columns(self):
         rng = period_range('1/1/2000', periods=5)
@@ -1647,55 +1647,55 @@ class TestPeriodIndex(tm.TestCase):
         pi6 = PeriodIndex(freq='Min', start='1/1/2001', end='1/1/2001 00:00')
         pi7 = PeriodIndex(freq='S', start='1/1/2001', end='1/1/2001 00:00:00')
 
-        self.assertEquals(pi1.asfreq('Q', 'S'), pi2)
-        self.assertEquals(pi1.asfreq('Q', 's'), pi2)
-        self.assertEquals(pi1.asfreq('M', 'start'), pi3)
-        self.assertEquals(pi1.asfreq('D', 'StarT'), pi4)
-        self.assertEquals(pi1.asfreq('H', 'beGIN'), pi5)
-        self.assertEquals(pi1.asfreq('Min', 'S'), pi6)
-        self.assertEquals(pi1.asfreq('S', 'S'), pi7)
+        self.assertEqual(pi1.asfreq('Q', 'S'), pi2)
+        self.assertEqual(pi1.asfreq('Q', 's'), pi2)
+        self.assertEqual(pi1.asfreq('M', 'start'), pi3)
+        self.assertEqual(pi1.asfreq('D', 'StarT'), pi4)
+        self.assertEqual(pi1.asfreq('H', 'beGIN'), pi5)
+        self.assertEqual(pi1.asfreq('Min', 'S'), pi6)
+        self.assertEqual(pi1.asfreq('S', 'S'), pi7)
 
-        self.assertEquals(pi2.asfreq('A', 'S'), pi1)
-        self.assertEquals(pi2.asfreq('M', 'S'), pi3)
-        self.assertEquals(pi2.asfreq('D', 'S'), pi4)
-        self.assertEquals(pi2.asfreq('H', 'S'), pi5)
-        self.assertEquals(pi2.asfreq('Min', 'S'), pi6)
-        self.assertEquals(pi2.asfreq('S', 'S'), pi7)
+        self.assertEqual(pi2.asfreq('A', 'S'), pi1)
+        self.assertEqual(pi2.asfreq('M', 'S'), pi3)
+        self.assertEqual(pi2.asfreq('D', 'S'), pi4)
+        self.assertEqual(pi2.asfreq('H', 'S'), pi5)
+        self.assertEqual(pi2.asfreq('Min', 'S'), pi6)
+        self.assertEqual(pi2.asfreq('S', 'S'), pi7)
 
-        self.assertEquals(pi3.asfreq('A', 'S'), pi1)
-        self.assertEquals(pi3.asfreq('Q', 'S'), pi2)
-        self.assertEquals(pi3.asfreq('D', 'S'), pi4)
-        self.assertEquals(pi3.asfreq('H', 'S'), pi5)
-        self.assertEquals(pi3.asfreq('Min', 'S'), pi6)
-        self.assertEquals(pi3.asfreq('S', 'S'), pi7)
+        self.assertEqual(pi3.asfreq('A', 'S'), pi1)
+        self.assertEqual(pi3.asfreq('Q', 'S'), pi2)
+        self.assertEqual(pi3.asfreq('D', 'S'), pi4)
+        self.assertEqual(pi3.asfreq('H', 'S'), pi5)
+        self.assertEqual(pi3.asfreq('Min', 'S'), pi6)
+        self.assertEqual(pi3.asfreq('S', 'S'), pi7)
 
-        self.assertEquals(pi4.asfreq('A', 'S'), pi1)
-        self.assertEquals(pi4.asfreq('Q', 'S'), pi2)
-        self.assertEquals(pi4.asfreq('M', 'S'), pi3)
-        self.assertEquals(pi4.asfreq('H', 'S'), pi5)
-        self.assertEquals(pi4.asfreq('Min', 'S'), pi6)
-        self.assertEquals(pi4.asfreq('S', 'S'), pi7)
+        self.assertEqual(pi4.asfreq('A', 'S'), pi1)
+        self.assertEqual(pi4.asfreq('Q', 'S'), pi2)
+        self.assertEqual(pi4.asfreq('M', 'S'), pi3)
+        self.assertEqual(pi4.asfreq('H', 'S'), pi5)
+        self.assertEqual(pi4.asfreq('Min', 'S'), pi6)
+        self.assertEqual(pi4.asfreq('S', 'S'), pi7)
 
-        self.assertEquals(pi5.asfreq('A', 'S'), pi1)
-        self.assertEquals(pi5.asfreq('Q', 'S'), pi2)
-        self.assertEquals(pi5.asfreq('M', 'S'), pi3)
-        self.assertEquals(pi5.asfreq('D', 'S'), pi4)
-        self.assertEquals(pi5.asfreq('Min', 'S'), pi6)
-        self.assertEquals(pi5.asfreq('S', 'S'), pi7)
+        self.assertEqual(pi5.asfreq('A', 'S'), pi1)
+        self.assertEqual(pi5.asfreq('Q', 'S'), pi2)
+        self.assertEqual(pi5.asfreq('M', 'S'), pi3)
+        self.assertEqual(pi5.asfreq('D', 'S'), pi4)
+        self.assertEqual(pi5.asfreq('Min', 'S'), pi6)
+        self.assertEqual(pi5.asfreq('S', 'S'), pi7)
 
-        self.assertEquals(pi6.asfreq('A', 'S'), pi1)
-        self.assertEquals(pi6.asfreq('Q', 'S'), pi2)
-        self.assertEquals(pi6.asfreq('M', 'S'), pi3)
-        self.assertEquals(pi6.asfreq('D', 'S'), pi4)
-        self.assertEquals(pi6.asfreq('H', 'S'), pi5)
-        self.assertEquals(pi6.asfreq('S', 'S'), pi7)
+        self.assertEqual(pi6.asfreq('A', 'S'), pi1)
+        self.assertEqual(pi6.asfreq('Q', 'S'), pi2)
+        self.assertEqual(pi6.asfreq('M', 'S'), pi3)
+        self.assertEqual(pi6.asfreq('D', 'S'), pi4)
+        self.assertEqual(pi6.asfreq('H', 'S'), pi5)
+        self.assertEqual(pi6.asfreq('S', 'S'), pi7)
 
-        self.assertEquals(pi7.asfreq('A', 'S'), pi1)
-        self.assertEquals(pi7.asfreq('Q', 'S'), pi2)
-        self.assertEquals(pi7.asfreq('M', 'S'), pi3)
-        self.assertEquals(pi7.asfreq('D', 'S'), pi4)
-        self.assertEquals(pi7.asfreq('H', 'S'), pi5)
-        self.assertEquals(pi7.asfreq('Min', 'S'), pi6)
+        self.assertEqual(pi7.asfreq('A', 'S'), pi1)
+        self.assertEqual(pi7.asfreq('Q', 'S'), pi2)
+        self.assertEqual(pi7.asfreq('M', 'S'), pi3)
+        self.assertEqual(pi7.asfreq('D', 'S'), pi4)
+        self.assertEqual(pi7.asfreq('H', 'S'), pi5)
+        self.assertEqual(pi7.asfreq('Min', 'S'), pi6)
 
         self.assertRaises(ValueError, pi7.asfreq, 'T', 'foo')
         self.assertRaises(ValueError, pi1.asfreq, '5t')
@@ -1835,11 +1835,11 @@ class TestPeriodIndex(tm.TestCase):
         pi1 = dti.to_period()
         pi2 = dti.to_period(freq='D')
 
-        self.assertEquals(pi1[0], Period('Jan 2005', freq='M'))
-        self.assertEquals(pi2[0], Period('1/31/2005', freq='D'))
+        self.assertEqual(pi1[0], Period('Jan 2005', freq='M'))
+        self.assertEqual(pi2[0], Period('1/31/2005', freq='D'))
 
-        self.assertEquals(pi1[-1], Period('Nov 2005', freq='M'))
-        self.assertEquals(pi2[-1], Period('11/30/2005', freq='D'))
+        self.assertEqual(pi1[-1], Period('Nov 2005', freq='M'))
+        self.assertEqual(pi2[-1], Period('11/30/2005', freq='D'))
 
     def test_pindex_slice_index(self):
         pi = PeriodIndex(start='1/1/10', end='12/31/12', freq='M')
@@ -2031,24 +2031,24 @@ class TestPeriodIndex(tm.TestCase):
 
     # def test_pindex_multiples(self):
     #     pi = PeriodIndex(start='1/1/10', end='12/31/12', freq='2M')
-    #     self.assertEquals(pi[0], Period('1/1/10', '2M'))
-    #     self.assertEquals(pi[1], Period('3/1/10', '2M'))
+    #     self.assertEqual(pi[0], Period('1/1/10', '2M'))
+    #     self.assertEqual(pi[1], Period('3/1/10', '2M'))
 
-    #     self.assertEquals(pi[0].asfreq('6M'), pi[2].asfreq('6M'))
-    #     self.assertEquals(pi[0].asfreq('A'), pi[2].asfreq('A'))
+    #     self.assertEqual(pi[0].asfreq('6M'), pi[2].asfreq('6M'))
+    #     self.assertEqual(pi[0].asfreq('A'), pi[2].asfreq('A'))
 
-    #     self.assertEquals(pi[0].asfreq('M', how='S'),
+    #     self.assertEqual(pi[0].asfreq('M', how='S'),
     #                       Period('Jan 2010', '1M'))
-    #     self.assertEquals(pi[0].asfreq('M', how='E'),
+    #     self.assertEqual(pi[0].asfreq('M', how='E'),
     #                       Period('Feb 2010', '1M'))
-    #     self.assertEquals(pi[1].asfreq('M', how='S'),
+    #     self.assertEqual(pi[1].asfreq('M', how='S'),
     #                       Period('Mar 2010', '1M'))
 
     #     i = Period('1/1/2010 12:05:18', '5S')
-    #     self.assertEquals(i, Period('1/1/2010 12:05:15', '5S'))
+    #     self.assertEqual(i, Period('1/1/2010 12:05:15', '5S'))
 
     #     i = Period('1/1/2010 12:05:18', '5S')
-    #     self.assertEquals(i.asfreq('1S', how='E'),
+    #     self.assertEqual(i.asfreq('1S', how='E'),
     #                       Period('1/1/2010 12:05:19', '1S'))
 
     def test_iteration(self):
@@ -2280,7 +2280,7 @@ class TestPeriodIndex(tm.TestCase):
         index = period_range('1/1/2012', periods=4, freq='D')
 
         result = index.to_datetime()
-        self.assertEquals(result[0], Timestamp('1/1/2012'))
+        self.assertEqual(result[0], Timestamp('1/1/2012'))
 
     def test_get_loc_msg(self):
         idx = period_range('2000-1-1', freq='A', periods=10)
@@ -2306,7 +2306,7 @@ class TestPeriodIndex(tm.TestCase):
         # drops index
         result = pd.concat([s1, s2])
         tm.assert_isinstance(result.index, PeriodIndex)
-        self.assertEquals(result.index[0], s1.index[0])
+        self.assertEqual(result.index[0], s1.index[0])
 
     def test_pickle_freq(self):
         # GH2891
@@ -2423,7 +2423,7 @@ class TestPeriodRepresentation(tm.TestCase):
         for freq in freqs:
             period = Period(ordinal=-1, freq=freq)
             repr(period)
-            self.assertEquals(period.year, 1969)
+            self.assertEqual(period.year, 1969)
 
         period = Period(ordinal=-1, freq='B')
         repr(period)

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -63,7 +63,7 @@ class TestResample(tm.TestCase):
         for f in funcs:
             g._cython_agg_general(f)
 
-        self.assertEquals(g.ngroups, 2593)
+        self.assertEqual(g.ngroups, 2593)
         self.assertTrue(notnull(g.mean()).all())
 
         # construct expected val
@@ -79,8 +79,8 @@ class TestResample(tm.TestCase):
         df = DataFrame(np.random.rand(len(dti), 10), index=dti, dtype='float64')
         r = df.groupby(b).agg(np.sum)
 
-        self.assertEquals(len(r.columns), 10)
-        self.assertEquals(len(r.index), 2593)
+        self.assertEqual(len(r.columns), 10)
+        self.assertEqual(len(r.index), 2593)
 
     def test_resample_basic(self):
         rng = date_range('1/1/2000 00:00:00', '1/1/2000 00:13:00', freq='min',
@@ -115,49 +115,49 @@ class TestResample(tm.TestCase):
         # to weekly
         result = s.resample('w-sun', how='last')
 
-        self.assertEquals(len(result), 3)
+        self.assertEqual(len(result), 3)
         self.assertTrue((result.index.dayofweek == [6, 6, 6]).all())
-        self.assertEquals(result.irow(0), s['1/2/2005'])
-        self.assertEquals(result.irow(1), s['1/9/2005'])
-        self.assertEquals(result.irow(2), s.irow(-1))
+        self.assertEqual(result.irow(0), s['1/2/2005'])
+        self.assertEqual(result.irow(1), s['1/9/2005'])
+        self.assertEqual(result.irow(2), s.irow(-1))
 
         result = s.resample('W-MON', how='last')
-        self.assertEquals(len(result), 2)
+        self.assertEqual(len(result), 2)
         self.assertTrue((result.index.dayofweek == [0, 0]).all())
-        self.assertEquals(result.irow(0), s['1/3/2005'])
-        self.assertEquals(result.irow(1), s['1/10/2005'])
+        self.assertEqual(result.irow(0), s['1/3/2005'])
+        self.assertEqual(result.irow(1), s['1/10/2005'])
 
         result = s.resample('W-TUE', how='last')
-        self.assertEquals(len(result), 2)
+        self.assertEqual(len(result), 2)
         self.assertTrue((result.index.dayofweek == [1, 1]).all())
-        self.assertEquals(result.irow(0), s['1/4/2005'])
-        self.assertEquals(result.irow(1), s['1/10/2005'])
+        self.assertEqual(result.irow(0), s['1/4/2005'])
+        self.assertEqual(result.irow(1), s['1/10/2005'])
 
         result = s.resample('W-WED', how='last')
-        self.assertEquals(len(result), 2)
+        self.assertEqual(len(result), 2)
         self.assertTrue((result.index.dayofweek == [2, 2]).all())
-        self.assertEquals(result.irow(0), s['1/5/2005'])
-        self.assertEquals(result.irow(1), s['1/10/2005'])
+        self.assertEqual(result.irow(0), s['1/5/2005'])
+        self.assertEqual(result.irow(1), s['1/10/2005'])
 
         result = s.resample('W-THU', how='last')
-        self.assertEquals(len(result), 2)
+        self.assertEqual(len(result), 2)
         self.assertTrue((result.index.dayofweek == [3, 3]).all())
-        self.assertEquals(result.irow(0), s['1/6/2005'])
-        self.assertEquals(result.irow(1), s['1/10/2005'])
+        self.assertEqual(result.irow(0), s['1/6/2005'])
+        self.assertEqual(result.irow(1), s['1/10/2005'])
 
         result = s.resample('W-FRI', how='last')
-        self.assertEquals(len(result), 2)
+        self.assertEqual(len(result), 2)
         self.assertTrue((result.index.dayofweek == [4, 4]).all())
-        self.assertEquals(result.irow(0), s['1/7/2005'])
-        self.assertEquals(result.irow(1), s['1/10/2005'])
+        self.assertEqual(result.irow(0), s['1/7/2005'])
+        self.assertEqual(result.irow(1), s['1/10/2005'])
 
         # to biz day
         result = s.resample('B', how='last')
-        self.assertEquals(len(result), 7)
+        self.assertEqual(len(result), 7)
         self.assertTrue((result.index.dayofweek == [4, 0, 1, 2, 3, 4, 0]).all())
-        self.assertEquals(result.irow(0), s['1/2/2005'])
-        self.assertEquals(result.irow(1), s['1/3/2005'])
-        self.assertEquals(result.irow(5), s['1/9/2005'])
+        self.assertEqual(result.irow(0), s['1/2/2005'])
+        self.assertEqual(result.irow(1), s['1/3/2005'])
+        self.assertEqual(result.irow(5), s['1/9/2005'])
         self.assertEqual(result.index.name, 'index')
 
     def test_resample_upsampling_picked_but_not_correct(self):
@@ -167,7 +167,7 @@ class TestResample(tm.TestCase):
         series = Series(1, index=dates)
 
         result = series.resample('D')
-        self.assertEquals(result.index[0], dates[0])
+        self.assertEqual(result.index[0], dates[0])
 
         # GH 5955
         # incorrect deciding to upsample when the axis frequency matches the resample frequency
@@ -250,9 +250,9 @@ class TestResample(tm.TestCase):
 
         # to minutely, by padding
         result = s.resample('Min', fill_method='pad')
-        self.assertEquals(len(result), 12961)
-        self.assertEquals(result[0], s[0])
-        self.assertEquals(result[-1], s[-1])
+        self.assertEqual(len(result), 12961)
+        self.assertEqual(result[0], s[0])
+        self.assertEqual(result[-1], s[-1])
 
         self.assertEqual(result.index.name, 'index')
 
@@ -271,20 +271,20 @@ class TestResample(tm.TestCase):
         expect = s.groupby(grouper).agg(lambda x: x[-1])
         result = s.resample('5Min', how='ohlc')
 
-        self.assertEquals(len(result), len(expect))
-        self.assertEquals(len(result.columns), 4)
+        self.assertEqual(len(result), len(expect))
+        self.assertEqual(len(result.columns), 4)
 
         xs = result.irow(-2)
-        self.assertEquals(xs['open'], s[-6])
-        self.assertEquals(xs['high'], s[-6:-1].max())
-        self.assertEquals(xs['low'], s[-6:-1].min())
-        self.assertEquals(xs['close'], s[-2])
+        self.assertEqual(xs['open'], s[-6])
+        self.assertEqual(xs['high'], s[-6:-1].max())
+        self.assertEqual(xs['low'], s[-6:-1].min())
+        self.assertEqual(xs['close'], s[-2])
 
         xs = result.irow(0)
-        self.assertEquals(xs['open'], s[0])
-        self.assertEquals(xs['high'], s[:5].max())
-        self.assertEquals(xs['low'], s[:5].min())
-        self.assertEquals(xs['close'], s[4])
+        self.assertEqual(xs['open'], s[0])
+        self.assertEqual(xs['high'], s[:5].max())
+        self.assertEqual(xs['low'], s[:5].min())
+        self.assertEqual(xs['close'], s[4])
 
     def test_resample_ohlc_dataframe(self):
         df = (pd.DataFrame({'PRICE': {Timestamp('2011-01-06 10:59:05', tz=None): 24990,
@@ -329,7 +329,7 @@ class TestResample(tm.TestCase):
         s = Series(np.random.rand(len(dti)), dti)
         bs = s.resample('B', closed='right', label='right')
         result = bs.resample('8H')
-        self.assertEquals(len(result), 22)
+        self.assertEqual(len(result), 22)
         tm.assert_isinstance(result.index.freq, offsets.DateOffset)
         self.assertEqual(result.index.freq, offsets.Hour(8))
 
@@ -385,7 +385,7 @@ class TestResample(tm.TestCase):
         result = ts.resample('M', how='mean')
 
         expected = ts.groupby(lambda x: x.month).mean()
-        self.assertEquals(len(result), 2)
+        self.assertEqual(len(result), 2)
         assert_almost_equal(result[0], expected[1])
         assert_almost_equal(result[1], expected[2])
 

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -268,10 +268,10 @@ class TestTimedeltas(tm.TestCase):
                        np.timedelta64(10000000000,'ns'),
                        pd.offsets.Second(10)]:
             result = base + offset
-            self.assertEquals(result, expected_add)
+            self.assertEqual(result, expected_add)
 
             result = base - offset
-            self.assertEquals(result, expected_sub)
+            self.assertEqual(result, expected_sub)
 
         base = pd.to_datetime('20130102 09:01:12.123456')
         expected_add = pd.to_datetime('20130103 09:01:22.123456')
@@ -283,10 +283,10 @@ class TestTimedeltas(tm.TestCase):
                        np.timedelta64(1,'D')+np.timedelta64(10,'s'),
                        pd.offsets.Day()+pd.offsets.Second(10)]:
             result = base + offset
-            self.assertEquals(result, expected_add)
+            self.assertEqual(result, expected_add)
 
             result = base - offset
-            self.assertEquals(result, expected_sub)
+            self.assertEqual(result, expected_sub)
 
     def test_to_timedelta_on_missing_values(self):
         _skip_if_numpy_not_friendly()

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -90,7 +90,7 @@ class TestTimeSeriesDuplicates(tm.TestCase):
         result = dups_local.unique()
         expected = DatetimeIndex(expected, tz='US/Eastern')
         self.assertTrue(result.tz is not None)
-        self.assertEquals(result.name, 'foo')
+        self.assertEqual(result.name, 'foo')
         self.assertTrue(result.equals(expected))
 
         # NaT
@@ -331,9 +331,9 @@ class TestTimeSeries(tm.TestCase):
         v2 = dti2[1]
         v3 = dti2[2]
 
-        self.assertEquals(v1, Timestamp('2/28/2005'))
-        self.assertEquals(v2, Timestamp('4/30/2005'))
-        self.assertEquals(v3, Timestamp('6/30/2005'))
+        self.assertEqual(v1, Timestamp('2/28/2005'))
+        self.assertEqual(v2, Timestamp('4/30/2005'))
+        self.assertEqual(v3, Timestamp('6/30/2005'))
 
         # don't carry freq through irregular slicing
         self.assertIsNone(dti2.freq)
@@ -399,8 +399,8 @@ class TestTimeSeries(tm.TestCase):
 
         stamp = rng[0]
         dtval = stamp.to_pydatetime()
-        self.assertEquals(stamp, dtval)
-        self.assertEquals(stamp.tzinfo, dtval.tzinfo)
+        self.assertEqual(stamp, dtval)
+        self.assertEqual(stamp.tzinfo, dtval.tzinfo)
 
     def test_index_convert_to_datetime_array(self):
         _skip_if_no_pytz()
@@ -410,8 +410,8 @@ class TestTimeSeries(tm.TestCase):
             tm.assert_isinstance(converted, np.ndarray)
             for x, stamp in zip(converted, rng):
                 tm.assert_isinstance(x, datetime)
-                self.assertEquals(x, stamp.to_pydatetime())
-                self.assertEquals(x.tzinfo, stamp.tzinfo)
+                self.assertEqual(x, stamp.to_pydatetime())
+                self.assertEqual(x.tzinfo, stamp.tzinfo)
 
         rng = date_range('20090415', '20090519')
         rng_eastern = date_range('20090415', '20090519', tz='US/Eastern')
@@ -742,7 +742,7 @@ class TestTimeSeries(tm.TestCase):
                     '2   1970-01-01 00:00:00.000002\n'
                     '3                          NaT\n'
                     'dtype: datetime64[ns]')
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_fillna_nat(self):
         series = Series([0, 1, 2, iNaT], dtype='M8[ns]')
@@ -829,10 +829,10 @@ class TestTimeSeries(tm.TestCase):
                 expected[i] = to_datetime(x)
 
         assert_series_equal(result, expected)
-        self.assertEquals(result.name, 'foo')
+        self.assertEqual(result.name, 'foo')
 
         assert_series_equal(dresult, expected)
-        self.assertEquals(dresult.name, 'foo')
+        self.assertEqual(dresult.name, 'foo')
 
     def test_to_datetime_iso8601(self):
         result = to_datetime(["2012-01-01 00:00:00"])
@@ -857,7 +857,7 @@ class TestTimeSeries(tm.TestCase):
         s = Series(date_range('1/1/2000', periods=10))
 
         result = to_datetime(s)
-        self.assertEquals(result[0], s[0])
+        self.assertEqual(result[0], s[0])
 
     def test_to_datetime_with_apply(self):
         # this is only locale tested with US/None locales
@@ -896,9 +896,9 @@ class TestTimeSeries(tm.TestCase):
                   'week', 'dayofyear']
         for field in fields:
             result = getattr(NaT, field)
-            self.assertEquals(result, -1)
+            self.assertEqual(result, -1)
 
-        self.assertEquals(NaT.weekday(), -1)
+        self.assertEqual(NaT.weekday(), -1)
 
     def test_to_datetime_types(self):
 
@@ -944,10 +944,10 @@ class TestTimeSeries(tm.TestCase):
         as_obj = scalar.astype('O')
 
         index = DatetimeIndex([scalar])
-        self.assertEquals(index[0], scalar.astype('O'))
+        self.assertEqual(index[0], scalar.astype('O'))
 
         value = Timestamp(scalar)
-        self.assertEquals(value, as_obj)
+        self.assertEqual(value, as_obj)
 
     def test_to_datetime_list_of_integers(self):
         rng = date_range('1/1/2000', periods=20)
@@ -1122,7 +1122,7 @@ class TestTimeSeries(tm.TestCase):
 
     def test_date_range_gen_error(self):
         rng = date_range('1/1/2000 00:00', '1/1/2000 00:18', freq='5min')
-        self.assertEquals(len(rng), 4)
+        self.assertEqual(len(rng), 4)
 
     def test_first_subset(self):
         ts = _simple_ts('1/1/2000', '1/1/2010', freq='12h')
@@ -1953,7 +1953,7 @@ class TestDatetimeIndex(tm.TestCase):
     def test_constructor_name(self):
         idx = DatetimeIndex(start='2000-01-01', periods=1, freq='A',
                             name='TEST')
-        self.assertEquals(idx.name, 'TEST')
+        self.assertEqual(idx.name, 'TEST')
 
     def test_comparisons_coverage(self):
         rng = date_range('1/1/2000', periods=10)
@@ -2271,67 +2271,67 @@ class TestDatetime64(tm.TestCase):
         dti = DatetimeIndex(
             freq='D', start=datetime(1998, 1, 1), periods=365)
 
-        self.assertEquals(dti.year[0], 1998)
-        self.assertEquals(dti.month[0], 1)
-        self.assertEquals(dti.day[0], 1)
-        self.assertEquals(dti.hour[0], 0)
-        self.assertEquals(dti.minute[0], 0)
-        self.assertEquals(dti.second[0], 0)
-        self.assertEquals(dti.microsecond[0], 0)
-        self.assertEquals(dti.dayofweek[0], 3)
+        self.assertEqual(dti.year[0], 1998)
+        self.assertEqual(dti.month[0], 1)
+        self.assertEqual(dti.day[0], 1)
+        self.assertEqual(dti.hour[0], 0)
+        self.assertEqual(dti.minute[0], 0)
+        self.assertEqual(dti.second[0], 0)
+        self.assertEqual(dti.microsecond[0], 0)
+        self.assertEqual(dti.dayofweek[0], 3)
 
-        self.assertEquals(dti.dayofyear[0], 1)
-        self.assertEquals(dti.dayofyear[120], 121)
+        self.assertEqual(dti.dayofyear[0], 1)
+        self.assertEqual(dti.dayofyear[120], 121)
 
-        self.assertEquals(dti.weekofyear[0], 1)
-        self.assertEquals(dti.weekofyear[120], 18)
+        self.assertEqual(dti.weekofyear[0], 1)
+        self.assertEqual(dti.weekofyear[120], 18)
 
-        self.assertEquals(dti.quarter[0], 1)
-        self.assertEquals(dti.quarter[120], 2)
+        self.assertEqual(dti.quarter[0], 1)
+        self.assertEqual(dti.quarter[120], 2)
 
-        self.assertEquals(dti.is_month_start[0], True)
-        self.assertEquals(dti.is_month_start[1], False)
-        self.assertEquals(dti.is_month_start[31], True)
-        self.assertEquals(dti.is_quarter_start[0], True)
-        self.assertEquals(dti.is_quarter_start[90], True)
-        self.assertEquals(dti.is_year_start[0], True)
-        self.assertEquals(dti.is_year_start[364], False)
-        self.assertEquals(dti.is_month_end[0], False)
-        self.assertEquals(dti.is_month_end[30], True)
-        self.assertEquals(dti.is_month_end[31], False)
-        self.assertEquals(dti.is_month_end[364], True)
-        self.assertEquals(dti.is_quarter_end[0], False)
-        self.assertEquals(dti.is_quarter_end[30], False)
-        self.assertEquals(dti.is_quarter_end[89], True)
-        self.assertEquals(dti.is_quarter_end[364], True)
-        self.assertEquals(dti.is_year_end[0], False)
-        self.assertEquals(dti.is_year_end[364], True)
+        self.assertEqual(dti.is_month_start[0], True)
+        self.assertEqual(dti.is_month_start[1], False)
+        self.assertEqual(dti.is_month_start[31], True)
+        self.assertEqual(dti.is_quarter_start[0], True)
+        self.assertEqual(dti.is_quarter_start[90], True)
+        self.assertEqual(dti.is_year_start[0], True)
+        self.assertEqual(dti.is_year_start[364], False)
+        self.assertEqual(dti.is_month_end[0], False)
+        self.assertEqual(dti.is_month_end[30], True)
+        self.assertEqual(dti.is_month_end[31], False)
+        self.assertEqual(dti.is_month_end[364], True)
+        self.assertEqual(dti.is_quarter_end[0], False)
+        self.assertEqual(dti.is_quarter_end[30], False)
+        self.assertEqual(dti.is_quarter_end[89], True)
+        self.assertEqual(dti.is_quarter_end[364], True)
+        self.assertEqual(dti.is_year_end[0], False)
+        self.assertEqual(dti.is_year_end[364], True)
 
-        self.assertEquals(len(dti.year), 365)
-        self.assertEquals(len(dti.month), 365)
-        self.assertEquals(len(dti.day), 365)
-        self.assertEquals(len(dti.hour), 365)
-        self.assertEquals(len(dti.minute), 365)
-        self.assertEquals(len(dti.second), 365)
-        self.assertEquals(len(dti.microsecond), 365)
-        self.assertEquals(len(dti.dayofweek), 365)
-        self.assertEquals(len(dti.dayofyear), 365)
-        self.assertEquals(len(dti.weekofyear), 365)
-        self.assertEquals(len(dti.quarter), 365)
-        self.assertEquals(len(dti.is_month_start), 365)
-        self.assertEquals(len(dti.is_month_end), 365)
-        self.assertEquals(len(dti.is_quarter_start), 365)
-        self.assertEquals(len(dti.is_quarter_end), 365)
-        self.assertEquals(len(dti.is_year_start), 365)
-        self.assertEquals(len(dti.is_year_end), 365)
+        self.assertEqual(len(dti.year), 365)
+        self.assertEqual(len(dti.month), 365)
+        self.assertEqual(len(dti.day), 365)
+        self.assertEqual(len(dti.hour), 365)
+        self.assertEqual(len(dti.minute), 365)
+        self.assertEqual(len(dti.second), 365)
+        self.assertEqual(len(dti.microsecond), 365)
+        self.assertEqual(len(dti.dayofweek), 365)
+        self.assertEqual(len(dti.dayofyear), 365)
+        self.assertEqual(len(dti.weekofyear), 365)
+        self.assertEqual(len(dti.quarter), 365)
+        self.assertEqual(len(dti.is_month_start), 365)
+        self.assertEqual(len(dti.is_month_end), 365)
+        self.assertEqual(len(dti.is_quarter_start), 365)
+        self.assertEqual(len(dti.is_quarter_end), 365)
+        self.assertEqual(len(dti.is_year_start), 365)
+        self.assertEqual(len(dti.is_year_end), 365)
 
         dti = DatetimeIndex(
             freq='BQ-FEB', start=datetime(1998, 1, 1), periods=4)
 
-        self.assertEquals(sum(dti.is_quarter_start), 0)
-        self.assertEquals(sum(dti.is_quarter_end), 4)
-        self.assertEquals(sum(dti.is_year_start), 0)
-        self.assertEquals(sum(dti.is_year_end), 1)
+        self.assertEqual(sum(dti.is_quarter_start), 0)
+        self.assertEqual(sum(dti.is_quarter_end), 4)
+        self.assertEqual(sum(dti.is_year_start), 0)
+        self.assertEqual(sum(dti.is_year_end), 1)
 
         # Ensure is_start/end accessors throw ValueError for CustomBusinessDay, CBD requires np >= 1.7
         if not _np_version_under1p7:
@@ -2341,7 +2341,7 @@ class TestDatetime64(tm.TestCase):
 
         dti = DatetimeIndex(['2000-01-01', '2000-01-02', '2000-01-03'])
 
-        self.assertEquals(dti.is_month_start[0], 1)
+        self.assertEqual(dti.is_month_start[0], 1)
 
         tests = [
             (Timestamp('2013-06-01', offset='M').is_month_start, 1),
@@ -2376,7 +2376,7 @@ class TestDatetime64(tm.TestCase):
             (Timestamp('2013-10-31', offset='AS-NOV').is_year_end, 1)]
 
         for ts, value in tests:
-            self.assertEquals(ts, value)
+            self.assertEqual(ts, value)
 
 
     def test_nanosecond_field(self):
@@ -2397,11 +2397,11 @@ class TestDatetime64(tm.TestCase):
 
         s = Series(np.arange(len(dti)), index=dti)
 
-        self.assertEquals(s[48], 48)
-        self.assertEquals(s['1/2/2009'], 48)
-        self.assertEquals(s['2009-1-2'], 48)
-        self.assertEquals(s[datetime(2009, 1, 2)], 48)
-        self.assertEquals(s[lib.Timestamp(datetime(2009, 1, 2))], 48)
+        self.assertEqual(s[48], 48)
+        self.assertEqual(s['1/2/2009'], 48)
+        self.assertEqual(s['2009-1-2'], 48)
+        self.assertEqual(s[datetime(2009, 1, 2)], 48)
+        self.assertEqual(s[lib.Timestamp(datetime(2009, 1, 2))], 48)
         self.assertRaises(KeyError, s.__getitem__, '2009-1-3')
 
         assert_series_equal(s['3/6/2009':'2009-06-05'],
@@ -2413,9 +2413,9 @@ class TestDatetime64(tm.TestCase):
 
         s = Series(np.arange(len(dti)), index=dti)
         s[48] = -1
-        self.assertEquals(s[48], -1)
+        self.assertEqual(s[48], -1)
         s['1/2/2009'] = -2
-        self.assertEquals(s[48], -2)
+        self.assertEqual(s[48], -2)
         s['1/2/2009':'2009-06-05'] = -3
         self.assertTrue((s[48:54] == -3).all())
 
@@ -2455,32 +2455,32 @@ class TestDatetime64(tm.TestCase):
         sdate = datetime(1999, 12, 25)
         edate = datetime(2000, 1, 1)
         idx = DatetimeIndex(start=sdate, freq='1B', periods=20)
-        self.assertEquals(len(idx), 20)
-        self.assertEquals(idx[0], sdate + 0 * dt.bday)
-        self.assertEquals(idx.freq, 'B')
+        self.assertEqual(len(idx), 20)
+        self.assertEqual(idx[0], sdate + 0 * dt.bday)
+        self.assertEqual(idx.freq, 'B')
 
         idx = DatetimeIndex(end=edate, freq=('D', 5), periods=20)
-        self.assertEquals(len(idx), 20)
-        self.assertEquals(idx[-1], edate)
-        self.assertEquals(idx.freq, '5D')
+        self.assertEqual(len(idx), 20)
+        self.assertEqual(idx[-1], edate)
+        self.assertEqual(idx.freq, '5D')
 
         idx1 = DatetimeIndex(start=sdate, end=edate, freq='W-SUN')
         idx2 = DatetimeIndex(start=sdate, end=edate,
                              freq=dt.Week(weekday=6))
-        self.assertEquals(len(idx1), len(idx2))
-        self.assertEquals(idx1.offset, idx2.offset)
+        self.assertEqual(len(idx1), len(idx2))
+        self.assertEqual(idx1.offset, idx2.offset)
 
         idx1 = DatetimeIndex(start=sdate, end=edate, freq='QS')
         idx2 = DatetimeIndex(start=sdate, end=edate,
                              freq=dt.QuarterBegin(startingMonth=1))
-        self.assertEquals(len(idx1), len(idx2))
-        self.assertEquals(idx1.offset, idx2.offset)
+        self.assertEqual(len(idx1), len(idx2))
+        self.assertEqual(idx1.offset, idx2.offset)
 
         idx1 = DatetimeIndex(start=sdate, end=edate, freq='BQ')
         idx2 = DatetimeIndex(start=sdate, end=edate,
                              freq=dt.BQuarterEnd(startingMonth=12))
-        self.assertEquals(len(idx1), len(idx2))
-        self.assertEquals(idx1.offset, idx2.offset)
+        self.assertEqual(len(idx1), len(idx2))
+        self.assertEqual(idx1.offset, idx2.offset)
 
     def test_dayfirst(self):
         # GH 5917
@@ -2529,8 +2529,8 @@ class TestDatetime64(tm.TestCase):
         df = DataFrame([[stamp, 12.1]], columns=['Date', 'Value'])
         df = df.set_index('Date')
 
-        self.assertEquals(df.index[0], stamp)
-        self.assertEquals(df.reset_index()['Date'][0], stamp)
+        self.assertEqual(df.index[0], stamp)
+        self.assertEqual(df.reset_index()['Date'][0], stamp)
 
     def test_dti_set_index_reindex(self):
         # GH 6631
@@ -2684,7 +2684,7 @@ class TestSeriesDatetime64(tm.TestCase):
         rng = date_range('1/1/2000', periods=10, freq='BMS')
 
         ex_first = Timestamp('2000-01-03')
-        self.assertEquals(rng[0], ex_first)
+        self.assertEqual(rng[0], ex_first)
 
     def test_string_index_series_name_converted(self):
         # #1644
@@ -2692,10 +2692,10 @@ class TestSeriesDatetime64(tm.TestCase):
                        index=date_range('1/1/2000', periods=10))
 
         result = df.ix['1/3/2000']
-        self.assertEquals(result.name, df.index[2])
+        self.assertEqual(result.name, df.index[2])
 
         result = df.T['1/3/2000']
-        self.assertEquals(result.name, df.index[2])
+        self.assertEqual(result.name, df.index[2])
 
 
 class TestTimestamp(tm.TestCase):
@@ -2842,23 +2842,23 @@ class TestTimestamp(tm.TestCase):
         self.assertEqual(result.nanosecond, val.nanosecond)
 
     def test_frequency_misc(self):
-        self.assertEquals(fmod.get_freq_group('T'),
+        self.assertEqual(fmod.get_freq_group('T'),
                           fmod.FreqGroup.FR_MIN)
 
         code, stride = fmod.get_freq_code(offsets.Hour())
-        self.assertEquals(code, fmod.FreqGroup.FR_HR)
+        self.assertEqual(code, fmod.FreqGroup.FR_HR)
 
         code, stride = fmod.get_freq_code((5, 'T'))
-        self.assertEquals(code, fmod.FreqGroup.FR_MIN)
-        self.assertEquals(stride, 5)
+        self.assertEqual(code, fmod.FreqGroup.FR_MIN)
+        self.assertEqual(stride, 5)
 
         offset = offsets.Hour()
         result = fmod.to_offset(offset)
-        self.assertEquals(result, offset)
+        self.assertEqual(result, offset)
 
         result = fmod.to_offset((5, 'T'))
         expected = offsets.Minute(5)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
         self.assertRaises(ValueError, fmod.get_freq_code, (5, 'baz'))
 
@@ -2867,12 +2867,12 @@ class TestTimestamp(tm.TestCase):
         self.assertRaises(ValueError, fmod.to_offset, ('', ''))
 
         result = fmod.get_standard_freq(offsets.Hour())
-        self.assertEquals(result, 'H')
+        self.assertEqual(result, 'H')
 
     def test_hash_equivalent(self):
         d = {datetime(2011, 1, 1): 5}
         stamp = Timestamp(datetime(2011, 1, 1))
-        self.assertEquals(d[stamp], 5)
+        self.assertEqual(d[stamp], 5)
 
     def test_timestamp_compare_scalars(self):
         # case where ndim == 0
@@ -2967,18 +2967,18 @@ class TestSlicing(tm.TestCase):
         dti = DatetimeIndex(freq='D', start=datetime(2000, 6, 1), periods=500)
 
         s = Series(np.arange(len(dti)), index=dti)
-        self.assertEquals(len(s['2001Q1']), 90)
+        self.assertEqual(len(s['2001Q1']), 90)
 
         df = DataFrame(np.random.rand(len(dti), 5), index=dti)
-        self.assertEquals(len(df.ix['1Q01']), 90)
+        self.assertEqual(len(df.ix['1Q01']), 90)
 
     def test_slice_month(self):
         dti = DatetimeIndex(freq='D', start=datetime(2005, 1, 1), periods=500)
         s = Series(np.arange(len(dti)), index=dti)
-        self.assertEquals(len(s['2005-11']), 30)
+        self.assertEqual(len(s['2005-11']), 30)
 
         df = DataFrame(np.random.rand(len(dti), 5), index=dti)
-        self.assertEquals(len(df.ix['2005-11']), 30)
+        self.assertEqual(len(df.ix['2005-11']), 30)
 
         assert_series_equal(s['2005-11'], s['11-2005'])
 
@@ -3413,18 +3413,18 @@ class TestGuessDatetimeFormat(tm.TestCase):
         )
 
         for dt_string, dt_format in dt_string_to_format:
-            self.assertEquals(
+            self.assertEqual(
                 tools._guess_datetime_format(dt_string),
                 dt_format
             )
 
     def test_guess_datetime_format_with_dayfirst(self):
         ambiguous_string = '01/01/2011'
-        self.assertEquals(
+        self.assertEqual(
             tools._guess_datetime_format(ambiguous_string, dayfirst=True),
             '%d/%m/%Y'
         )
-        self.assertEquals(
+        self.assertEqual(
             tools._guess_datetime_format(ambiguous_string, dayfirst=False),
             '%m/%d/%Y'
         )
@@ -3441,7 +3441,7 @@ class TestGuessDatetimeFormat(tm.TestCase):
         )
 
         for dt_string, dt_format in dt_string_to_format:
-            self.assertEquals(
+            self.assertEqual(
                 tools._guess_datetime_format(dt_string),
                 dt_format
             )

--- a/pandas/tseries/tests/test_timeseries_legacy.py
+++ b/pandas/tseries/tests/test_timeseries_legacy.py
@@ -83,11 +83,11 @@ class LegacySupport(object):
 
         unpickled = self.frame
 
-        self.assertEquals(type(unpickled.index), DatetimeIndex)
-        self.assertEquals(len(unpickled), 10)
+        self.assertEqual(type(unpickled.index), DatetimeIndex)
+        self.assertEqual(len(unpickled), 10)
         self.assertTrue((unpickled.columns == Int64Index(np.arange(5))).all())
         self.assertTrue((unpickled.index == dtindex).all())
-        self.assertEquals(unpickled.index.offset, BDay(1, normalize=True))
+        self.assertEqual(unpickled.index.offset, BDay(1, normalize=True))
 
     def test_unpickle_legacy_series(self):
         from pandas.core.datetools import BDay
@@ -97,10 +97,10 @@ class LegacySupport(object):
         dtindex = DatetimeIndex(start='1/3/2005', end='1/14/2005',
                                 freq=BDay(1))
 
-        self.assertEquals(type(unpickled.index), DatetimeIndex)
-        self.assertEquals(len(unpickled), 10)
+        self.assertEqual(type(unpickled.index), DatetimeIndex)
+        self.assertEqual(len(unpickled), 10)
         self.assertTrue((unpickled.index == dtindex).all())
-        self.assertEquals(unpickled.index.offset, BDay(1, normalize=True))
+        self.assertEqual(unpickled.index.offset, BDay(1, normalize=True))
 
     def test_unpickle_legacy_len0_daterange(self):
         pth, _ = os.path.split(os.path.abspath(__file__))
@@ -242,7 +242,7 @@ class LegacySupport(object):
             # test get_legacy_offset_name
             offset = datetools.get_offset(new_freq)
             old_name = datetools.get_legacy_offset_name(offset)
-            self.assertEquals(old_name, old_freq)
+            self.assertEqual(old_name, old_freq)
 
     def test_ms_vs_MS(self):
         left = datetools.get_offset('ms')

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -101,8 +101,8 @@ class TestTimeZoneSupport(tm.TestCase):
 
         result = stamp.tz_localize('US/Eastern')
         expected = Timestamp('3/11/2012 04:00', tz='US/Eastern')
-        self.assertEquals(result.hour, expected.hour)
-        self.assertEquals(result, expected)
+        self.assertEqual(result.hour, expected.hour)
+        self.assertEqual(result, expected)
 
     def test_timestamp_constructed_by_date_and_tz(self):
         # Fix Issue 2993, Timestamp cannot be constructed by datetime.date
@@ -111,8 +111,8 @@ class TestTimeZoneSupport(tm.TestCase):
         result = Timestamp(date(2012, 3, 11), tz='US/Eastern')
 
         expected = Timestamp('3/11/2012', tz='US/Eastern')
-        self.assertEquals(result.hour, expected.hour)
-        self.assertEquals(result, expected)
+        self.assertEqual(result.hour, expected.hour)
+        self.assertEqual(result, expected)
 
     def test_timestamp_to_datetime_tzoffset(self):
         # tzoffset
@@ -120,7 +120,7 @@ class TestTimeZoneSupport(tm.TestCase):
         tzinfo = tzoffset(None, 7200)
         expected = Timestamp('3/11/2012 04:00', tz=tzinfo)
         result = Timestamp(expected.to_datetime())
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_timedelta_push_over_dst_boundary(self):
         # #1389
@@ -133,7 +133,7 @@ class TestTimeZoneSupport(tm.TestCase):
         # spring forward, + "7" hours
         expected = Timestamp('3/11/2012 05:00', tz='US/Eastern')
 
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_tz_localize_dti(self):
         from pandas.tseries.offsets import Hour
@@ -176,24 +176,24 @@ class TestTimeZoneSupport(tm.TestCase):
         utc = Timestamp('3/11/2012 22:00', tz='UTC')
         expected = utc.tz_convert('US/Eastern')
         result = utc.astimezone('US/Eastern')
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
         tm.assert_isinstance(result, Timestamp)
 
     def test_create_with_tz(self):
         stamp = Timestamp('3/11/2012 05:00', tz='US/Eastern')
-        self.assertEquals(stamp.hour, 5)
+        self.assertEqual(stamp.hour, 5)
 
         rng = date_range(
             '3/11/2012 04:00', periods=10, freq='H', tz='US/Eastern')
 
-        self.assertEquals(stamp, rng[1])
+        self.assertEqual(stamp, rng[1])
 
         utc_stamp = Timestamp('3/11/2012 05:00', tz='utc')
         self.assertIs(utc_stamp.tzinfo, pytz.utc)
-        self.assertEquals(utc_stamp.hour, 5)
+        self.assertEqual(utc_stamp.hour, 5)
 
         stamp = Timestamp('3/11/2012 05:00').tz_localize('utc')
-        self.assertEquals(utc_stamp.hour, 5)
+        self.assertEqual(utc_stamp.hour, 5)
 
     def test_create_with_fixed_tz(self):
         off = FixedOffset(420, '+07:00')
@@ -233,9 +233,9 @@ class TestTimeZoneSupport(tm.TestCase):
         val = rng[0]
         exp = Timestamp('3/11/2012 03:00', tz='US/Eastern')
 
-        self.assertEquals(val.hour, 3)
-        self.assertEquals(exp.hour, 3)
-        self.assertEquals(val, exp)  # same UTC value
+        self.assertEqual(val.hour, 3)
+        self.assertEqual(exp.hour, 3)
+        self.assertEqual(val, exp)  # same UTC value
         self.assertTrue(rng[:2].equals(rng2))
 
         # Right before the DST transition
@@ -245,11 +245,11 @@ class TestTimeZoneSupport(tm.TestCase):
                              tz='US/Eastern')
         self.assertTrue(rng.equals(rng2))
         exp = Timestamp('3/11/2012 00:00', tz='US/Eastern')
-        self.assertEquals(exp.hour, 0)
-        self.assertEquals(rng[0], exp)
+        self.assertEqual(exp.hour, 0)
+        self.assertEqual(rng[0], exp)
         exp = Timestamp('3/11/2012 01:00', tz='US/Eastern')
-        self.assertEquals(exp.hour, 1)
-        self.assertEquals(rng[1], exp)
+        self.assertEqual(exp.hour, 1)
+        self.assertEqual(rng[1], exp)
 
         rng = date_range('3/11/2012 00:00', periods=10, freq='H',
                          tz='US/Eastern')
@@ -263,8 +263,8 @@ class TestTimeZoneSupport(tm.TestCase):
         expected = tz.normalize(rng[-1])
 
         stamp = rng_eastern[-1]
-        self.assertEquals(stamp, expected)
-        self.assertEquals(stamp.tzinfo, expected.tzinfo)
+        self.assertEqual(stamp, expected)
+        self.assertEqual(stamp.tzinfo, expected.tzinfo)
 
         # right tzinfo
         rng = date_range('3/13/2012', '3/14/2012', freq='H', tz='utc')
@@ -278,7 +278,7 @@ class TestTimeZoneSupport(tm.TestCase):
         conv = idx[0].tz_convert('US/Pacific')
         expected = idx.tz_convert('US/Pacific')[0]
 
-        self.assertEquals(conv, expected)
+        self.assertEqual(conv, expected)
 
     def test_pass_dates_localize_to_utc(self):
         strdates = ['1/1/2012', '3/1/2012', '4/1/2012']
@@ -440,14 +440,14 @@ class TestTimeZoneSupport(tm.TestCase):
         objs = rng.asobject
         for i, x in enumerate(objs):
             exval = rng[i]
-            self.assertEquals(x, exval)
-            self.assertEquals(x.tzinfo, exval.tzinfo)
+            self.assertEqual(x, exval)
+            self.assertEqual(x.tzinfo, exval.tzinfo)
 
         objs = rng.astype(object)
         for i, x in enumerate(objs):
             exval = rng[i]
-            self.assertEquals(x, exval)
-            self.assertEquals(x.tzinfo, exval.tzinfo)
+            self.assertEqual(x, exval)
+            self.assertEqual(x.tzinfo, exval.tzinfo)
 
     def test_localized_at_time_between_time(self):
         from datetime import time
@@ -625,7 +625,7 @@ class TestTimeZoneSupport(tm.TestCase):
         roundtripped = df.reset_index().set_index('index')
         xp = df.index.tz
         rs = roundtripped.index.tz
-        self.assertEquals(xp, rs)
+        self.assertEqual(xp, rs)
 
     def test_dateutil_tzoffset_support(self):
         from dateutil.tz import tzoffset
@@ -635,7 +635,7 @@ class TestTimeZoneSupport(tm.TestCase):
                  datetime(2012, 5, 11, 12, tzinfo=tzinfo)]
         series = Series(data=values, index=index)
 
-        self.assertEquals(series.index.tz, tzinfo)
+        self.assertEqual(series.index.tz, tzinfo)
 
         # it works! #2443
         repr(series.index[0])
@@ -910,9 +910,9 @@ class TestTimeZones(tm.TestCase):
         berlin_range = utc_range.tz_convert('Europe/Berlin')
 
         for a, b, c in zip(utc_range, eastern_range, berlin_range):
-            self.assertEquals(a, b)
-            self.assertEquals(b, c)
-            self.assertEquals(a, c)
+            self.assertEqual(a, b)
+            self.assertEqual(b, c)
+            self.assertEqual(a, c)
 
         self.assertTrue((utc_range == eastern_range).all())
         self.assertTrue((utc_range == berlin_range).all())

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -250,7 +250,7 @@ class TestTimestampNsOperations(tm.TestCase):
         value = self.timestamp.value
         modified_value = modified_timestamp.value
 
-        self.assertEquals(modified_value - value, expected_value)
+        self.assertEqual(modified_value - value, expected_value)
 
     def test_timedelta_ns_arithmetic(self):
         self.assert_ns_timedelta(self.timestamp + np.timedelta64(-123, 'ns'), -123)


### PR DESCRIPTION
#7131: s/self.assertEquals(/self.assertEqual(
