### PR TITLE
CLN: Deprecation of assert_

### DIFF
--- a/pandas/io/tests/test_packers.py
+++ b/pandas/io/tests/test_packers.py
@@ -179,7 +179,7 @@ class TestNumpy(TestPackers):
         x = (np.random.rand(5) + 1j * np.random.rand(5)).astype(np.complex128)
         x_rec = self.encode_decode(x)
         self.assertTrue(all(map(lambda x, y: x == y, x, x_rec)) and
-                     x.dtype == x_rec.dtype)
+                        x.dtype == x_rec.dtype)
 
     def test_list_mixed(self):
         x = [1.0, np.float32(3.5), np.complex128(4.25), u('foo')]

--- a/pandas/io/tests/test_packers.py
+++ b/pandas/io/tests/test_packers.py
@@ -149,8 +149,8 @@ class TestNumpy(TestPackers):
     def test_dict_complex(self):
         x = {'foo': 1.0 + 1.0j, 'bar': 2.0 + 2.0j}
         x_rec = self.encode_decode(x)
-        self.assert_(all(map(lambda x, y: x == y, x.values(), x_rec.values())) and
-                     all(map(lambda x, y: type(x) == type(y), x.values(), x_rec.values())))
+        self.assertTrue(all(map(lambda x, y: x == y, x.values(), x_rec.values())) and
+                        all(map(lambda x, y: type(x) == type(y), x.values(), x_rec.values())))
 
     def test_dict_numpy_float(self):
         x = {'foo': np.float32(1.0), 'bar': np.float32(2.0)}
@@ -161,8 +161,8 @@ class TestNumpy(TestPackers):
         x = {'foo': np.complex128(
             1.0 + 1.0j), 'bar': np.complex128(2.0 + 2.0j)}
         x_rec = self.encode_decode(x)
-        self.assert_(all(map(lambda x, y: x == y, x.values(), x_rec.values())) and
-                     all(map(lambda x, y: type(x) == type(y), x.values(), x_rec.values())))
+        self.assertTrue(all(map(lambda x, y: x == y, x.values(), x_rec.values())) and
+                        all(map(lambda x, y: type(x) == type(y), x.values(), x_rec.values())))
 
 
     def test_numpy_array_float(self):
@@ -178,7 +178,7 @@ class TestNumpy(TestPackers):
     def test_numpy_array_complex(self):
         x = (np.random.rand(5) + 1j * np.random.rand(5)).astype(np.complex128)
         x_rec = self.encode_decode(x)
-        self.assert_(all(map(lambda x, y: x == y, x, x_rec)) and
+        self.assertTrue(all(map(lambda x, y: x == y, x, x_rec)) and
                      x.dtype == x_rec.dtype)
 
     def test_list_mixed(self):

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -339,8 +339,8 @@ class TestHDFStore(tm.TestCase):
             store['d'] = tm.makePanel()
             store['foo/bar'] = tm.makePanel()
             self.assertEqual(len(store), 5)
-            self.assert_(set(
-                    store.keys()) == set(['/a', '/b', '/c', '/d', '/foo/bar']))
+            self.assertTrue(set(
+                store.keys()) == set(['/a', '/b', '/c', '/d', '/foo/bar']))
 
     def test_repr(self):
 
@@ -1077,8 +1077,8 @@ class TestHDFStore(tm.TestCase):
 
             def check_indexers(key, indexers):
                 for i, idx in enumerate(indexers):
-                    self.assert_(getattr(getattr(
-                                store.root, key).table.description, idx)._v_pos == i)
+                    self.assertTrue(getattr(getattr(
+                        store.root, key).table.description, idx)._v_pos == i)
 
             # append then change (will take existing schema)
             indexers = ['items', 'major_axis', 'minor_axis']

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -1382,8 +1382,8 @@ class TestDataFrameFormatting(tm.TestCase):
                             header=None, sep=' ')
         tm.assert_series_equal(recons['B'], biggie['B'])
         self.assertEqual(recons['A'].count(), biggie['A'].count())
-        self.assert_((np.abs(recons['A'].dropna() -
-                             biggie['A'].dropna()) < 0.1).all())
+        self.assertTrue((np.abs(recons['A'].dropna() -
+                                biggie['A'].dropna()) < 0.1).all())
 
         # expected = ['B', 'A']
         # self.assertEqual(header, expected)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1601,8 +1601,8 @@ class CheckIndexing(object):
 
     def test_single_element_ix_dont_upcast(self):
         self.frame['E'] = 1
-        self.assert_(issubclass(self.frame['E'].dtype.type,
-                                (int, np.integer)))
+        self.assertTrue(issubclass(self.frame['E'].dtype.type,
+                                   (int, np.integer)))
 
         result = self.frame.ix[self.frame.index[5], 'E']
         self.assertTrue(com.is_integer(result))

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1085,8 +1085,8 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
 
         # ufunc
         applied = self.panel.apply(np.sqrt)
-        self.assert_(assert_almost_equal(applied.values,
-                                         np.sqrt(self.panel.values)))
+        self.assertTrue(assert_almost_equal(applied.values,
+                                            np.sqrt(self.panel.values)))
 
         # ufunc same shape
         result = self.panel.apply(lambda x: x*2, axis='items')

--- a/pandas/tseries/tests/test_frequencies.py
+++ b/pandas/tseries/tests/test_frequencies.py
@@ -217,15 +217,15 @@ class TestFrequencyInference(tm.TestCase):
             self.assertEqual(infer_freq(index), gen.freqstr)
         else:
             inf_freq = infer_freq(index)
-            self.assert_((inf_freq == 'Q-DEC' and
-                          gen.freqstr in ('Q', 'Q-DEC', 'Q-SEP', 'Q-JUN',
-                                          'Q-MAR'))
-                         or
-                         (inf_freq == 'Q-NOV' and
-                          gen.freqstr in ('Q-NOV', 'Q-AUG', 'Q-MAY', 'Q-FEB'))
-                         or
-                         (inf_freq == 'Q-OCT' and
-                          gen.freqstr in ('Q-OCT', 'Q-JUL', 'Q-APR', 'Q-JAN')))
+            self.assertTrue((inf_freq == 'Q-DEC' and
+                             gen.freqstr in ('Q', 'Q-DEC', 'Q-SEP', 'Q-JUN',
+                                             'Q-MAR'))
+                            or
+                            (inf_freq == 'Q-NOV' and
+                             gen.freqstr in ('Q-NOV', 'Q-AUG', 'Q-MAY', 'Q-FEB'))
+                            or
+                            (inf_freq == 'Q-OCT' and
+                             gen.freqstr in ('Q-OCT', 'Q-JUL', 'Q-APR', 'Q-JAN')))
 
         gen = date_range(start, periods=5, freq=freq)
         index = _dti(gen.values)
@@ -233,15 +233,15 @@ class TestFrequencyInference(tm.TestCase):
             self.assertEqual(infer_freq(index), gen.freqstr)
         else:
             inf_freq = infer_freq(index)
-            self.assert_((inf_freq == 'Q-DEC' and
-                          gen.freqstr in ('Q', 'Q-DEC', 'Q-SEP', 'Q-JUN',
-                                          'Q-MAR'))
-                         or
-                         (inf_freq == 'Q-NOV' and
-                          gen.freqstr in ('Q-NOV', 'Q-AUG', 'Q-MAY', 'Q-FEB'))
-                         or
-                         (inf_freq == 'Q-OCT' and
-                          gen.freqstr in ('Q-OCT', 'Q-JUL', 'Q-APR', 'Q-JAN')))
+            self.assertTrue((inf_freq == 'Q-DEC' and
+                             gen.freqstr in ('Q', 'Q-DEC', 'Q-SEP', 'Q-JUN',
+                                             'Q-MAR'))
+                            or
+                            (inf_freq == 'Q-NOV' and
+                             gen.freqstr in ('Q-NOV', 'Q-AUG', 'Q-MAY', 'Q-FEB'))
+                            or
+                            (inf_freq == 'Q-OCT' and
+                             gen.freqstr in ('Q-OCT', 'Q-JUL', 'Q-APR', 'Q-JAN')))
 
     def test_infer_freq(self):
         rng = period_range('1959Q2', '2009Q3', freq='Q')

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -840,7 +840,7 @@ class TestTimeZones(tm.TestCase):
         ts1 = Series(np.random.randn(len(rng1)), index=rng1)
         ts2 = Series(np.random.randn(len(rng2)), index=rng2)
         ts_result = ts1.append(ts2)
-        self.assert_(ts_result.index.equals(
+        self.assertTrue(ts_result.index.equals(
             ts1.index.asobject.append(ts2.index.asobject)))
 
         # mixed
@@ -850,7 +850,7 @@ class TestTimeZones(tm.TestCase):
         ts1 = Series(np.random.randn(len(rng1)), index=rng1)
         ts2 = Series(np.random.randn(len(rng2)), index=rng2)
         ts_result = ts1.append(ts2)
-        self.assert_(ts_result.index.equals(
+        self.assertTrue(ts_result.index.equals(
             ts1.index.asobject.append(ts2.index)))
 
     def test_equal_join_ensure_utc(self):

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -177,7 +177,7 @@ class TestArrayToDatetime(tm.TestCase):
                 coerce=False,
                 raise_=True,
             )
-            self.assert_(
+            self.assertTrue(
                 np.array_equal(
                     tslib.array_to_datetime(
                         np.array([invalid_date], dtype='object'), coerce=True


### PR DESCRIPTION
#7131: Run s/self.assert_(/self.assertTrue( on remaining instances I can find. These were the multi-line expressions, and I tried to retain the formatting of the expressions
