### PR TITLE
BUG: fix isnull for 0d object arrays

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -529,6 +529,7 @@ Bug Fixes
 - Fixed a bug with the `info` repr not honoring the `display.max_info_columns` setting (:issue:`6939`)
 - Bug ``PeriodIndex`` string slicing with out of bounds values (:issue:`5407`)
 - Fixed a memory error in the hashtable implementation/factorizer on resizing of large tables (:issue:`7157`)
+- Bug in ``isnull`` when applied to 0-dimensional object arrays (:issue:`7176`)
 
 pandas 0.13.1
 -------------

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -213,7 +213,7 @@ def _isnull_ndarraylike(obj):
         else:
             result = np.empty(shape, dtype=bool)
             vec = lib.isnullobj(values.ravel())
-            result[:] = vec.reshape(shape)
+            result[...] = vec.reshape(shape)
 
     elif dtype in _DATELIKE_DTYPES:
         # this is the NaT pattern

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -135,6 +135,18 @@ def test_isnull_datetime():
     assert(mask[0])
     assert(not mask[1:].any())
 
+
+class TestIsNull(tm.TestCase):
+    def test_0d_array(self):
+        self.assertTrue(isnull(np.array(np.nan)))
+        self.assertFalse(isnull(np.array(0.0)))
+        self.assertFalse(isnull(np.array(0)))
+        # test object dtype
+        self.assertTrue(isnull(np.array(np.nan, dtype=object)))
+        self.assertFalse(isnull(np.array(0.0, dtype=object)))
+        self.assertFalse(isnull(np.array(0, dtype=object)))
+
+
 def test_downcast_conv():
     # test downcasting
 


### PR DESCRIPTION
If this looks good, it would be nice to get it in 0.14, too.
