### PR TITLE
CLN: Deprecation of assert_

### DIFF
--- a/pandas/io/tests/test_json/test_ujson.py
+++ b/pandas/io/tests/test_json/test_ujson.py
@@ -629,11 +629,11 @@ class UltraJSONTests(TestCase):
 
     def test_decodeNumericIntPos(self):
         input = "31337"
-        self.assertEquals (31337, ujson.decode(input))
+        self.assertEqual(31337, ujson.decode(input))
 
     def test_decodeNumericIntNeg(self):
         input = "-31337"
-        self.assertEquals (-31337, ujson.decode(input))
+        self.assertEqual(-31337, ujson.decode(input))
 
     def test_encodeUnicode4BytesUTF8Fail(self):
         _skip_if_python_ver(3)


### PR DESCRIPTION
#7131: Fix two instances of assertEquals that naive grepping did not find
