### PR TITLE
BUG: Easter works incorrectly in negative offsets

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -86,3 +86,4 @@ Bug Fixes
   wouldn't test ``True`` when it encountered an ``inf``/``-inf``
   (:issue:`7315`).
 - Bug in inferred_freq results in None for eastern hemisphere timezones (:issue:`7310`)
+- Bug in ``Easter`` returns incorrect date when offset is negative (:issue:`7195`)

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -1846,12 +1846,16 @@ class Easter(DateOffset):
         currentEaster = datetime(currentEaster.year, currentEaster.month, currentEaster.day)
         
         # NOTE: easter returns a datetime.date so we have to convert to type of other
-        if other >= currentEaster:
-            new = easter(other.year + self.n)
-        elif other < currentEaster:
-            new = easter(other.year + self.n - 1)
+        if self.n >= 0:
+            if other >= currentEaster:
+                new = easter(other.year + self.n)
+            else:
+                new = easter(other.year + self.n - 1)
         else:
-            new = other
+            if other > currentEaster:
+                new = easter(other.year + self.n + 1)
+            else:
+                new = easter(other.year + self.n)
         
         # FIXME: There has to be a better way to do this, but I don't know what it is
         if isinstance(other, Timestamp):

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -2483,9 +2483,11 @@ class TestYearEndDiffMonth(Base):
 def assertEq(offset, base, expected):
     actual = offset + base
     actual_swapped = base + offset
+    actual_apply = offset.apply(base)
     try:
         assert actual == expected
         assert actual_swapped == expected
+        assert actual_apply == expected
     except AssertionError:
         raise AssertionError("\nExpected: %s\nActual: %s\nFor Offset: %s)"
                              "\nAt Date: %s" %
@@ -2493,6 +2495,18 @@ def assertEq(offset, base, expected):
 
 def test_Easter():
     assertEq(Easter(), datetime(2010, 1, 1), datetime(2010, 4, 4))
+    assertEq(Easter(), datetime(2010, 4, 5), datetime(2011, 4, 24))
+    assertEq(Easter(2), datetime(2010, 1, 1), datetime(2011, 4, 24))
+
+    assertEq(Easter(), datetime(2010, 4, 4), datetime(2011, 4, 24))
+    assertEq(Easter(2), datetime(2010, 4, 4), datetime(2012, 4, 8))
+
+    assertEq(-Easter(), datetime(2011, 1, 1), datetime(2010, 4, 4))
+    assertEq(-Easter(), datetime(2010, 4, 5), datetime(2010, 4, 4))
+    assertEq(-Easter(2), datetime(2011, 1, 1), datetime(2009, 4, 12))
+
+    assertEq(-Easter(), datetime(2010, 4, 4), datetime(2009, 4, 12))
+    assertEq(-Easter(2), datetime(2010, 4, 4), datetime(2008, 3, 23))
 
 def test_Hour():
     assertEq(Hour(), datetime(2010, 1, 1), datetime(2010, 1, 1, 1))


### PR DESCRIPTION
When an offset is negative, Easter skips the date just before and returns one before.

```
(- pd.offsets.Easter()).apply(pd.Timestamp('2011-01-01 09:00:00'))
#2009-04-12 00:00:00

(- pd.offsets.Easter()).apply(pd.Timestamp('2012-01-01 09:00:00'))
# returns 2010-04-04 00:00:00

(- pd.offsets.Easter()).apply(pd.Timestamp('2010-04-05 09:00:00'))
#2009-04-12 00:00:00
```
