### PR TITLE
BUG: CustomBusinessDay apply raises NameError when np.datetime64 is pass...

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -86,3 +86,4 @@ Bug Fixes
   wouldn't test ``True`` when it encountered an ``inf``/``-inf``
   (:issue:`7315`).
 - Bug in inferred_freq results in None for eastern hemisphere timezones (:issue:`7310`)
+- Bug in ``CustomBusinessDay.apply`` raiases ``NameError`` when ``np.datetime64`` object is passed (:issue:`7196`)

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -528,7 +528,6 @@ class CustomBusinessDay(BusinessDay):
 
         # Distinguish input cases to enhance performance
         if isinstance(other, datetime):
-            dtype = type(other)
             date_in = other
             np_dt = np.datetime64(date_in.date())
 
@@ -547,7 +546,6 @@ class CustomBusinessDay(BusinessDay):
             return as_timestamp(result)
 
         elif isinstance(other, np.datetime64):
-            dtype = other.dtype
             date_in = other
             np_day = date_in.astype('datetime64[D]')
             np_time = date_in - np_day
@@ -556,7 +554,7 @@ class CustomBusinessDay(BusinessDay):
                                   busdaycal=self.busdaycalendar)
 
             if not self.normalize:
-                result = np_day_incr + np_time
+                result = np_incr_dt + np_time
             else:
                 result = np_incr_dt
 

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -382,6 +382,7 @@ class TestCustomBusinessDay(Base):
 
     def setUp(self):
         self.d = datetime(2008, 1, 1)
+        self.nd = np.datetime64('2008-01-01 00:00:00Z')
 
         _skip_if_no_cday()
         self.offset = CDay()
@@ -417,6 +418,7 @@ class TestCustomBusinessDay(Base):
 
     def testCall(self):
         self.assertEqual(self.offset2(self.d), datetime(2008, 1, 3))
+        self.assertEqual(self.offset2(self.nd), datetime(2008, 1, 3))
 
     def testRAdd(self):
         self.assertEqual(self.d + self.offset2, self.offset2 + self.d)


### PR DESCRIPTION
`CustomBusinessDay` raises `NameError` when `np.datetime64` is passed. It works if `normalize=True` is specified.

```
d = pd.offsets.CustomBusinessDay().apply(np.datetime64('2011-01-01 09:00:00'))
# NameError: global name 'np_day_incr' is not defined

d = pd.offsets.CustomBusinessDay(normalize=True).apply(np.datetime64('2011-01-01 09:00:00'))
#2011-01-03 00:00:00
```
