### PR TITLE
BUG: boxplot returns incorrect dict

### DIFF
--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -2363,12 +2363,17 @@ def boxplot(data, column=None, by=None, ax=None, fontsize=None,
         if return_type is None:
             ret = axes
         if return_type == 'axes':
-            ret = dict((k, ax) for k, ax in zip(d.keys(), axes))
+            ret = compat.OrderedDict()
+            axes = _flatten(axes)[:len(d)]
+            for k, ax in zip(d.keys(), axes):
+                ret[k] = ax
         elif return_type == 'dict':
             ret = d
         elif return_type == 'both':
-            ret = dict((k, BP(ax=ax, lines=line)) for
-                       (k, line), ax in zip(d.items(), axes))
+            ret = compat.OrderedDict()
+            axes = _flatten(axes)[:len(d)]
+            for (k, line), ax in zip(d.items(), axes):
+                ret[k] = BP(ax=ax, lines=line)
     else:
         if layout is not None:
             raise ValueError("The 'layout' keyword is not supported when "
@@ -2723,7 +2728,7 @@ def boxplot_frame_groupby(grouped, subplots=True, column=None, fontsize=None,
                             sharex=False, sharey=True)
         axes = _flatten(axes)
 
-        ret = {}
+        ret = compat.OrderedDict()
         for (key, group), ax in zip(grouped, axes):
             d = group.boxplot(ax=ax, column=column, fontsize=fontsize,
                               rot=rot, grid=grid, **kwds)
@@ -2804,7 +2809,6 @@ def _grouped_plot_by_column(plotf, data, columns=None, by=None,
     ravel_axes = _flatten(axes)
 
     out_dict = compat.OrderedDict()
-
     for i, col in enumerate(columns):
         ax = ravel_axes[i]
         gp_col = grouped[col]


### PR DESCRIPTION
#7096 returns incorrect `dict` when number of columns and subplots are different.

```
import pandas as pd
import numpy as np
import matplotlib.pyplot as plt
import pandas.util.testing as tm


n=100
gender = tm.choice(['Male', 'Female'], size=n)
classroom = tm.choice(['A', 'B', 'C'], size=n)

df = pd.DataFrame({'gender': gender,
                          'classroom': classroom,
                          'height': np.random.normal(66, 4, size=n),
                          'weight': np.random.normal(161, 32, size=n),
                          'category': np.random.randint(4, size=n)})

df.boxplot(by='classroom', return_type='axes')
# {'category': array([<matplotlib.axes.AxesSubplot object at 0x104700e90>,
#        <matplotlib.axes.AxesSubplot object at 0x10671ca90>], dtype=object),
#  'height': array([<matplotlib.axes.AxesSubplot object at 0x106744dd0>,
#        <matplotlib.axes.AxesSubplot object at 0x106766b50>], dtype=object)}

# This must be a dict with 3 keys ('category', 'height' and 'weight') which value is AxesSubplot (not numpy.array).
```

Also, `boxplot` sometimes return `OrderedDict` and sometimes `dict` inconsistently.

```
df.boxplot(by='classroom', return_type='dict')
# OrderedDict([('category', {'medians': [<matplotlib.lines.Line2D object at 0x106fe8c10>,
# ...
```

The fix makes `boxplot` to always return `OrderedDict` which has correct mapping of keys and values
