### PR TITLE
BUG: bar plot can now handle bottom and left kw properly

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -65,3 +65,4 @@ There are no experimental changes in 0.14.1
 Bug Fixes
 ~~~~~~~~~
 
+- Bug in ``DataFrame`` and ``Series`` bar and barh plot raises ``TypeError`` when ``bottom`` and ``left`` keyword is specified (:issue:`7226`)

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1135,6 +1135,35 @@ class TestDataFramePlots(TestPlotBase):
         self._check_bar_alignment(df, kind='barh', subplots=True, width=0.9, position=0.2)
 
     @slow
+    def test_bar_bottom_left(self):
+        df = DataFrame(rand(5, 5))
+        ax = df.plot(kind='bar', stacked=False, bottom=1)
+        result = [p.get_y() for p in ax.patches]
+        self.assertEqual(result, [1] * 25)
+
+        ax = df.plot(kind='bar', stacked=True, bottom=[-1, -2, -3, -4, -5])
+        result = [p.get_y() for p in ax.patches[:5]]
+        self.assertEqual(result, [-1, -2, -3, -4, -5])
+
+        ax = df.plot(kind='barh', stacked=False, left=np.array([1, 1, 1, 1, 1]))
+        result = [p.get_x() for p in ax.patches]
+        self.assertEqual(result, [1] * 25)
+
+        ax = df.plot(kind='barh', stacked=True, left=[1, 2, 3, 4, 5])
+        result = [p.get_x() for p in ax.patches[:5]]
+        self.assertEqual(result, [1, 2, 3, 4, 5])
+
+        axes = df.plot(kind='bar', subplots=True, bottom=-1)
+        for ax in axes:
+            result = [p.get_y() for p in ax.patches]
+            self.assertEqual(result, [-1] * 5)
+
+        axes = df.plot(kind='barh', subplots=True, left=np.array([1, 1, 1, 1, 1]))
+        for ax in axes:
+            result = [p.get_x() for p in ax.patches]
+            self.assertEqual(result, [1] * 5)
+
+    @slow
     def test_plot_scatter(self):
         df = DataFrame(randn(6, 4),
                        index=list(string.ascii_letters[:6]),

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1789,6 +1789,9 @@ class BarPlot(MPLPlot):
         kwargs['align'] = kwargs.pop('align', 'center')
         self.tick_pos = np.arange(len(data))
 
+        self.bottom = kwargs.pop('bottom', None)
+        self.left = kwargs.pop('left', None)
+
         self.log = kwargs.pop('log',False)
         MPLPlot.__init__(self, data, **kwargs)
 
@@ -1808,13 +1811,21 @@ class BarPlot(MPLPlot):
         if self.rot is None:
             self.rot = self._default_rot[self.kind]
 
-    @property
-    def bar_f(self):
+        if com.is_list_like(self.bottom):
+            self.bottom = np.array(self.bottom)
+        if com.is_list_like(self.left):
+            self.left = np.array(self.left)
+
+    def _get_plot_function(self):
         if self.kind == 'bar':
             def f(ax, x, y, w, start=None, **kwds):
+                if self.bottom is not None:
+                    start = start + self.bottom
                 return ax.bar(x, y, w, bottom=start,log=self.log, **kwds)
         elif self.kind == 'barh':
             def f(ax, x, y, w, start=None, log=self.log, **kwds):
+                if self.left is not None:
+                    start = start + self.left
                 return ax.barh(x, y, w, left=start, **kwds)
         else:
             raise NotImplementedError
@@ -1830,10 +1841,8 @@ class BarPlot(MPLPlot):
         colors = self._get_colors()
         ncolors = len(colors)
 
-        bar_f = self.bar_f
-
+        bar_f = self._get_plot_function()
         pos_prior = neg_prior = np.zeros(len(self.data))
-
         K = self.nseries
 
         for i, (label, y) in enumerate(self._iter_data()):


### PR DESCRIPTION
Actually not a bug, but allows `bar` and `barh` plot to accept `bottom` and `left` kw respectively to specify the starting point.

Currently, passing `bottom` or `left` keyword results in `TypeError`

```
import pandas as pd
import numpy as np
df = pd.DataFrame(np.random.randn(5, 5))
df.plot(kind='bar', bottom=1, ax=axes[0])
# TypeError: bar() got multiple values for keyword argument 'bottom'
```
### After fix

```
import matplotlib.pyplot as plt
fig, axes = plt.subplots(1, 2)

df = pd.DataFrame(np.random.randn(5, 5))
df.plot(kind='bar', bottom=1, ax=axes[0])

df2 = pd.DataFrame(np.random.rand(5, 5))
df2.plot(kind='barh', left=[1, 2, 3, 4, 5], stacked=True, ax=axes[1])
```

![figure_1](https://cloud.githubusercontent.com/assets/1696302/3074746/24f8bebe-e351-11e3-9506-ac7de60db7fd.png)
