### PR TITLE
BUG: multi-index output formatting is buggy (GH7174)

### DIFF
--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -953,8 +953,8 @@ class TestDataFrameFormatting(tm.TestCase):
       <td> NaN</td>
     </tr>
     <tr>
-      <td>...</td>
-      <td>...</td>
+      <th>...</th>
+      <th>...</th>
       <td>...</td>
       <td>...</td>
       <td>...</td>


### PR DESCRIPTION
Closes #7174

Adjusts the truncation in the notebook for multiindex dfs. Both rows and columns are affected. 

http://nbviewer.ipython.org/gist/bjonen/492fea9559fd73edf579
