### PR TITLE
ENH: check for __array__ instead of ndarray subclasses when creating an Index

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -2038,7 +2038,8 @@ def intersection(*seqs):
 def _asarray_tuplesafe(values, dtype=None):
     from pandas.core.index import Index
 
-    if not isinstance(values, (list, tuple, np.ndarray)):
+    if not (isinstance(values, (list, tuple))
+            or hasattr(values, '__array__')):
         values = list(values)
     elif isinstance(values, Index):
         return values.values

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -173,6 +173,18 @@ class TestIndex(tm.TestCase):
         result = pd.infer_freq(df['date'])
         self.assertEqual(result,'MS')
 
+    def test_constructor_ndarray_like(self):
+        # GH 5460#issuecomment-44474502
+        # it should be possible to convert any object that satisfies the numpy
+        # ndarray interface directly into an Index
+        class ArrayLike(object):
+            def __array__(self, dtype=None):
+                return np.arange(5)
+
+        expected = pd.Index(np.arange(5))
+        result = pd.Index(ArrayLike())
+        self.assertTrue(result.equals(expected))
+
     def test_index_ctor_infer_periodindex(self):
         from pandas import period_range, PeriodIndex
         xp = period_range('2012-1-1', freq='M', periods=3)


### PR DESCRIPTION
This allows custom ndarray-like objects which aren't actual ndarrays
to be smoothly cast to a pandas.Index:
https://github.com/pydata/pandas/issues/5460#issuecomment-44474502
