### PR TITLE
BF: reading stata files - unpack read value describing stored byte order

### DIFF
--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -561,7 +561,7 @@ class StataReader(StataParser):
                 raise ValueError("Version of given Stata file is not 104, "
                                  "105, 108, 113 (Stata 8/9), 114 (Stata "
                                  "10/11), 115 (Stata 12) or 117 (Stata 13)")
-            self.byteorder = self.path_or_buf.read(1) == 0x1 and '>' or '<'
+            self.byteorder = struct.unpack('b', self.path_or_buf.read(1))[0] == 0x1 and '>' or '<'
             self.filetype = struct.unpack('b', self.path_or_buf.read(1))[0]
             self.path_or_buf.read(1)  # unused
 

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -19,9 +19,6 @@ import pandas.util.testing as tm
 from pandas.util.misc import is_little_endian
 from pandas import compat
 
-if not is_little_endian():
-    raise nose.SkipTest("known failure of test_stata on non-little endian")
-
 class TestStata(tm.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Otherwise comparison would always result in "low endian" .  Seems to resolve all the gory stata files reading tests on sparc at least 
closes #5781 
