### PR TITLE
BUG: TimeGrouper doesnt exclude the column specified by key

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -65,3 +65,4 @@ There are no experimental changes in 0.14.1
 Bug Fixes
 ~~~~~~~~~
 
+- Bug in ``TimeGrouper`` doesn't exclude column specified by ``key`` (:issue:`7227`)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1927,7 +1927,10 @@ def _get_grouper(obj, key=None, axis=0, level=None, sort=True):
     # a passed in Grouper, directly convert
     if isinstance(key, Grouper):
         binner, grouper, obj = key._get_grouper(obj)
-        return grouper, [], obj
+        if key.key is None:
+            return grouper, [], obj
+        else:
+            return grouper, set([key.key]), obj
 
     # already have a BaseGrouper, just return it
     elif isinstance(key, BaseGrouper):


### PR DESCRIPTION
This solves latter exclude column issue described in #7227.
