### PR TITLE
BUG: hist raises TypeError when df contains non numeric column

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -65,3 +65,5 @@ There are no experimental changes in 0.14.1
 Bug Fixes
 ~~~~~~~~~
 
+- BUG in ``DataFrame.hist`` raises ``TypeError`` when it contains non numeric column (:issue:`7277`)
+

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1464,14 +1464,12 @@ class TestDataFramePlots(TestPlotBase):
 
     @slow
     def test_hist(self):
-        df = DataFrame(randn(100, 4))
-        _check_plot_works(df.hist)
-        _check_plot_works(df.hist, grid=False)
+        _check_plot_works(self.hist_df.hist)
 
         # make sure layout is handled
         df = DataFrame(randn(100, 3))
-        _check_plot_works(df.hist)
-        axes = df.hist(grid=False)
+        axes = _check_plot_works(df.hist, grid=False)
+        self._check_axes_shape(axes, axes_num=3, layout=(2, 2))
         self.assertFalse(axes[1, 1].get_visible())
 
         df = DataFrame(randn(100, 1))
@@ -1479,7 +1477,8 @@ class TestDataFramePlots(TestPlotBase):
 
         # make sure layout is handled
         df = DataFrame(randn(100, 6))
-        _check_plot_works(df.hist)
+        axes = _check_plot_works(df.hist, layout=(4, 2))
+        self._check_axes_shape(axes, axes_num=6, layout=(4, 2))
 
         # make sure sharex, sharey is handled
         _check_plot_works(df.hist, sharex=True, sharey=True)

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -4086,7 +4086,8 @@ class TestGroupBy(tm.TestCase):
         n = 10
         weight = Series(np.random.normal(166, 20, size=n))
         height = Series(np.random.normal(60, 10, size=n))
-        gender = tm.choice(['male', 'female'], size=n)
+        with tm.RNGContext(42):
+            gender = tm.choice(['male', 'female'], size=n)
 
         weight.groupby(gender).plot()
         tm.close()
@@ -4118,7 +4119,8 @@ class TestGroupBy(tm.TestCase):
         n = 10
         weight = Series(np.random.normal(166, 20, size=n))
         height = Series(np.random.normal(60, 10, size=n))
-        gender = tm.choice(['male', 'female'], size=n)
+        with tm.RNGContext(42):
+            gender = tm.choice(['male', 'female'], size=n)
         df = DataFrame({'height': height, 'weight': weight, 'gender': gender})
         gb = df.groupby('gender')
 
@@ -4136,11 +4138,6 @@ class TestGroupBy(tm.TestCase):
         res = df.groupby('gender').hist()
         tm.close()
 
-        df2 = df.copy()
-        df2['gender2'] = df['gender']
-        with tm.assertRaisesRegexp(TypeError, '.*str.+float'):
-            df2.groupby('gender').hist()
-
     @slow
     def test_frame_groupby_hist(self):
         _skip_if_mpl_not_installed()
@@ -4152,7 +4149,8 @@ class TestGroupBy(tm.TestCase):
         n = 10
         weight = Series(np.random.normal(166, 20, size=n))
         height = Series(np.random.normal(60, 10, size=n))
-        gender_int = tm.choice([0, 1], size=n)
+        with tm.RNGContext(42):
+            gender_int = tm.choice([0, 1], size=n)
         df_int = DataFrame({'height': height, 'weight': weight,
                             'gender': gender_int})
         gb = df_int.groupby('gender')

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -2536,6 +2536,7 @@ def hist_frame(data, column=None, by=None, grid=True, xlabelsize=None,
         if not isinstance(column, (list, np.ndarray)):
             column = [column]
         data = data[column]
+    data = data._get_numeric_data()
     naxes = len(data.columns)
 
     nrows, ncols = _get_layout(naxes, layout=layout)


### PR DESCRIPTION
`DataFrame.hist` without `by` keyword raises `TypeError` when it contains non-numeric column.

```
import pandas as pd
import numpy as np
import matplotlib.pyplot as plt
import pandas.util.testing as tm

n=100
gender = tm.choice(['Male', 'Female'], size=n)
classroom = tm.choice(['A', 'B', 'C'], size=n)
single = tm.choice(['S'], size=n)

df = pd.DataFrame({'gender': gender,
                   'classroom': classroom,
                   'height': np.random.normal(66, 4, size=n),
                   'weight': np.random.normal(161, 32, size=n),
                   'category': np.random.randint(4, size=n)})

df.hist(by='gender')
# This works, even though 'classroom' (str) column in still contained

df.hist()
# TypeError: cannot concatenate 'str' and 'float' objects
```
