### PR TITLE
BUG: Index.delete doesnt preserve name and other attrs

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -70,3 +70,4 @@ Bug Fixes
 - Bug in ``DataFrame`` and ``Series`` bar and barh plot raises ``TypeError`` when ``bottom``
   and ``left`` keyword is specified (:issue:`7226`)
 - BUG in ``DataFrame.hist`` raises ``TypeError`` when it contains non numeric column (:issue:`7277`)
+- BUG in ``Index.delete`` does not preserve ``name`` and ``freq`` attributes (:issue:`7302`)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1770,7 +1770,9 @@ class Index(IndexOpsMixin, FrozenNDArray):
         -------
         new_index : Index
         """
-        return np.delete(self, loc)
+        return self._simple_new(np.delete(self, loc), self.name,
+                                freq=getattr(self, 'freq', None),
+                                tz=getattr(self, 'tz', None))
 
     def insert(self, loc, item):
         """

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -265,6 +265,23 @@ class TestIndex(tm.TestCase):
         self.assertTrue(Index(['a']).equals(
             null_index.insert(0, 'a')))
 
+    def test_delete(self):
+        idx = Index(['a', 'b', 'c', 'd'], name='idx')
+
+        expected = Index(['b', 'c', 'd'], name='idx')
+        result = idx.delete(0)
+        self.assertTrue(result.equals(expected))
+        self.assertEqual(result.name, expected.name)
+
+        expected = Index(['a', 'b', 'c'], name='idx')
+        result = idx.delete(-1)
+        self.assertTrue(result.equals(expected))
+        self.assertEqual(result.name, expected.name)
+
+        with tm.assertRaises((IndexError, ValueError)):
+            # either depeidnig on numpy version
+            result = idx.delete(5)
+
     def test_identical(self):
 
         # index

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1608,17 +1608,6 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
                 return self.asobject.insert(loc, item)
             raise TypeError("cannot insert DatetimeIndex with incompatible label")
 
-    def delete(self, loc):
-        """
-        Make new DatetimeIndex with passed location deleted
-
-        Returns
-        -------
-        new_index : DatetimeIndex
-        """
-        arr = np.delete(self.values, loc)
-        return DatetimeIndex(arr, tz=self.tz)
-
     def _view_like(self, ndarray):
         result = ndarray.view(type(self))
         result.offset = self.offset

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -4,8 +4,6 @@ import sys
 import os
 import operator
 
-from distutils.version import LooseVersion
-
 import nose
 
 import numpy as np
@@ -2092,6 +2090,35 @@ class TestDatetimeIndex(tm.TestCase):
 
         idx = date_range('1/1/2000', periods=3, freq='M')
         result = idx.insert(3, datetime(2000, 4, 30))
+        self.assertEqual(result.freqstr, 'M')
+
+    def test_delete(self):
+        idx = date_range(start='2000-01-01', periods=4, freq='M', name='idx')
+
+        expected = date_range(start='2000-02-01', periods=3, freq='M', name='idx')
+        result = idx.delete(0)
+        self.assertTrue(result.equals(expected))
+        self.assertEqual(result.name, expected.name)
+        self.assertEqual(result.freqstr, 'M')
+
+        expected = date_range(start='2000-01-01', periods=3, freq='M', name='idx')
+        result = idx.delete(-1)
+        self.assertTrue(result.equals(expected))
+        self.assertEqual(result.name, expected.name)
+        self.assertEqual(result.freqstr, 'M')
+
+        with tm.assertRaises((IndexError, ValueError)):
+            # either depeidnig on numpy version
+            result = idx.delete(5)
+
+        idx = date_range(start='2000-01-01', periods=4,
+                         freq='M', name='idx', tz='US/Pacific')
+
+        expected = date_range(start='2000-02-01', periods=3,
+                              freq='M', name='idx', tz='US/Pacific')
+        result = idx.delete(0)
+        self.assertTrue(result.equals(expected))
+        self.assertEqual(result.name, expected.name)
         self.assertEqual(result.freqstr, 'M')
 
     def test_map_bug_1677(self):


### PR DESCRIPTION
Made `Index.delete` to preserve `name`, `tz` and `freq` attributes.
