### PR TITLE
BUG: single group series should preserve group name

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -80,3 +80,5 @@ Bug Fixes
 - Bug in ``Float64Index`` which didn't allow duplicates (:issue:`7149`).
 - Bug in ``DataFrame.replace()`` where truthy values were being replaced
   (:issue:`7140`).
+- Bug in ``StringMethods.extract()`` where a single match group Series
+  would use the matcher's name instead of the group name (:issue:`7313`).

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -906,8 +906,9 @@ class StringMethods(object):
         if not hasattr(result, 'ndim'):
             return result
         elif result.ndim == 1:
+            name = getattr(result, 'name', None)
             return Series(result, index=self.series.index,
-                          name=self.series.name)
+                          name=name or self.series.name)
         else:
             assert result.ndim < 3
             return DataFrame(result, index=self.series.index)

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -578,6 +578,13 @@ class TestStringMethods(tm.TestCase):
                        tm.makeDateIndex, tm.makePeriodIndex ]:
             check_index(index())
 
+    def test_extract_single_series_name_is_preserved(self):
+        s = Series(['a3', 'b3', 'c2'], name='bob')
+        r = s.str.extract(r'(?P<sue>[a-z])')
+        e = Series(['a', 'b', 'c'], name='sue')
+        tm.assert_series_equal(r, e)
+        self.assertEqual(r.name, e.name)
+
     def test_get_dummies(self):
         s = Series(['a|b', 'a|c', np.nan])
         result = s.str.get_dummies('|')


### PR DESCRIPTION
Extract currently doesn't preserve group names when a series is returned. This
PR fixes that.
