### PR TITLE
BUG: Revisit Index.delete preserves freq

### DIFF
--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1774,9 +1774,7 @@ class Index(IndexOpsMixin, FrozenNDArray):
         -------
         new_index : Index
         """
-        return self._simple_new(np.delete(self, loc), self.name,
-                                freq=getattr(self, 'freq', None),
-                                tz=getattr(self, 'tz', None))
+        return np.delete(self, loc)
 
     def insert(self, loc, item):
         """

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1608,6 +1608,34 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
                 return self.asobject.insert(loc, item)
             raise TypeError("cannot insert DatetimeIndex with incompatible label")
 
+    def delete(self, loc):
+        """
+        Make new DatetimeIndex with passed location deleted
+        Returns
+
+        loc: int, slice or array of ints
+            Indicate which sub-arrays to remove.
+
+        -------
+        new_index : DatetimeIndex
+        """
+        new_dates = np.delete(self.asi8, loc)
+
+        freq = None
+        if lib.is_integer(loc):
+            if loc in (0, -len(self), -1, len(self) - 1):
+                freq = self.freq
+        else:
+            if com.is_list_like(loc):
+                loc = lib.maybe_indices_to_slice(com._ensure_int64(np.array(loc)))
+            if isinstance(loc, slice) and loc.step in (1, None):
+                if (loc.start in (0, None) or loc.stop in (len(self), None)):
+                    freq = self.freq
+
+        if self.tz is not None:
+            new_dates = tslib.date_normalize(new_dates, self.tz)
+        return DatetimeIndex(new_dates, name=self.name, freq=freq, tz=self.tz)
+
     def _view_like(self, ndarray):
         result = ndarray.view(type(self))
         result.offset = self.offset

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -2293,33 +2293,82 @@ class TestDatetimeIndex(tm.TestCase):
         self.assertEqual(result.freqstr, 'M')
 
     def test_delete(self):
-        idx = date_range(start='2000-01-01', periods=4, freq='M', name='idx')
+        idx = date_range(start='2000-01-01', periods=5, freq='M', name='idx')
 
-        expected = date_range(start='2000-02-01', periods=3, freq='M', name='idx')
-        result = idx.delete(0)
-        self.assertTrue(result.equals(expected))
-        self.assertEqual(result.name, expected.name)
-        self.assertEqual(result.freqstr, 'M')
+        # prserve freq
+        expected_0 = date_range(start='2000-02-01', periods=4, freq='M', name='idx')
+        expected_4 = date_range(start='2000-01-01', periods=4, freq='M', name='idx')
 
-        expected = date_range(start='2000-01-01', periods=3, freq='M', name='idx')
-        result = idx.delete(-1)
-        self.assertTrue(result.equals(expected))
-        self.assertEqual(result.name, expected.name)
-        self.assertEqual(result.freqstr, 'M')
+        # reset freq to None
+        expected_1 = DatetimeIndex(['2000-01-31', '2000-03-31', '2000-04-30',
+                                    '2000-05-31'], freq=None, name='idx')
+
+        cases ={0: expected_0, -5: expected_0,
+                -1: expected_4, 4: expected_4,
+                1: expected_1}
+        for n, expected in compat.iteritems(cases):
+            result = idx.delete(n)
+            self.assertTrue(result.equals(expected))
+            self.assertEqual(result.name, expected.name)
+            self.assertEqual(result.freq, expected.freq)
 
         with tm.assertRaises((IndexError, ValueError)):
             # either depeidnig on numpy version
             result = idx.delete(5)
 
-        idx = date_range(start='2000-01-01', periods=4,
-                         freq='M', name='idx', tz='US/Pacific')
+        idx = date_range(start='2000-01-01', periods=5,
+                         freq='D', name='idx', tz='US/Pacific')
 
-        expected = date_range(start='2000-02-01', periods=3,
-                              freq='M', name='idx', tz='US/Pacific')
+        expected = date_range(start='2000-01-02', periods=4,
+                              freq='D', name='idx', tz='US/Pacific')
         result = idx.delete(0)
         self.assertTrue(result.equals(expected))
         self.assertEqual(result.name, expected.name)
-        self.assertEqual(result.freqstr, 'M')
+        self.assertEqual(result.freqstr, 'D')
+        self.assertEqual(result.tz, expected.tz)
+
+    def test_delete_slice(self):
+        idx = date_range(start='2000-01-01', periods=10, freq='D', name='idx')
+
+        # prserve freq
+        expected_0_2 = date_range(start='2000-01-04', periods=7, freq='D', name='idx')
+        expected_7_9 = date_range(start='2000-01-01', periods=7, freq='D', name='idx')
+
+        # reset freq to None
+        expected_3_5 = DatetimeIndex(['2000-01-01', '2000-01-02', '2000-01-03',
+                                    '2000-01-07', '2000-01-08', '2000-01-09',
+                                    '2000-01-10'], freq=None, name='idx')
+
+        cases ={(0, 1, 2): expected_0_2,
+                (7, 8, 9): expected_7_9,
+                (3, 4, 5): expected_3_5}
+        for n, expected in compat.iteritems(cases):
+            result = idx.delete(n)
+            self.assertTrue(result.equals(expected))
+            self.assertEqual(result.name, expected.name)
+            self.assertEqual(result.freq, expected.freq)
+
+            result = idx.delete(slice(n[0], n[-1] + 1))
+            self.assertTrue(result.equals(expected))
+            self.assertEqual(result.name, expected.name)
+            self.assertEqual(result.freq, expected.freq)
+
+        ts = pd.Series(1, index=pd.date_range('2000-01-01', periods=10,
+                                              freq='D', name='idx'))
+        # preserve freq
+        result = ts.drop(ts.index[:5]).index
+        expected = pd.date_range('2000-01-06', periods=5, freq='D', name='idx')
+        self.assertTrue(result.equals(expected))
+        self.assertEqual(result.name, expected.name)
+        self.assertEqual(result.freq, expected.freq)
+
+        # reset freq to None
+        result = ts.drop(ts.index[[1, 3, 5, 7, 9]]).index
+        expected = DatetimeIndex(['2000-01-01', '2000-01-03', '2000-01-05',
+                                    '2000-01-07', '2000-01-09'], freq=None, name='idx')
+        self.assertTrue(result.equals(expected))
+        self.assertEqual(result.name, expected.name)
+        self.assertEqual(result.freq, expected.freq)
 
     def test_map_bug_1677(self):
         index = DatetimeIndex(['2012-04-25 09:30:00.393000'])


### PR DESCRIPTION
Fix the issue that freq is preserved inappropriately, caused by #7302. Fix preserves freq if edge element is being deleted (same as #7299). 
CC: @rosnfeld
