### PR TITLE
BUG: xlim on plots with shared axes (GH2960, GH3490)

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -270,6 +270,9 @@ Bug Fixes
 - Bug in non-monotonic ``Index.union`` may preserve ``name`` incorrectly (:issue:`7458`)
 - Bug in ``DatetimeIndex.intersection`` doesn't preserve timezone (:issue:`4690`)
 
+- Bug with last plotted timeseries dictating ``xlim`` (:issue:`2960`)
+- Bug with ``secondary_y`` axis not being considered for timeseries ``xlim`` (:issue:`3490`)
+
 - Bug in ``Float64Index`` assignment with a non scalar indexer (:issue:`7586`)
 - Bug in ``pandas.core.strings.str_contains`` does not properly match in a case insensitive fashion when ``regex=False`` and ``case=False`` (:issue:`7505`)
 

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1563,6 +1563,8 @@ class LinePlot(MPLPlot):
                 kwds = self.kwds.copy()
                 self._maybe_add_color(colors, kwds, style, i)
 
+                lines += _get_all_lines(ax)
+
                 errors = self._get_errorbars(label=label, index=i)
                 kwds = dict(kwds, **errors)
 
@@ -3062,6 +3064,20 @@ def _flatten(axes):
     elif isinstance(axes, np.ndarray):
         axes = axes.ravel()
     return axes
+
+
+def _get_all_lines(ax):
+    lines = ax.get_lines()
+
+    # check for right_ax, which can oddly sometimes point back to ax
+    if hasattr(ax, 'right_ax') and ax.right_ax != ax:
+        lines += ax.right_ax.get_lines()
+
+    # no such risk with left_ax
+    if hasattr(ax, 'left_ax'):
+        lines += ax.left_ax.get_lines()
+
+    return lines
 
 
 def _get_xlim(lines):

--- a/pandas/tseries/plotting.py
+++ b/pandas/tseries/plotting.py
@@ -22,6 +22,8 @@ import pandas.core.common as com
 from pandas.tseries.converter import (PeriodConverter, TimeSeries_DateLocator,
                                       TimeSeries_DateFormatter)
 
+from pandas.tools.plotting import _get_all_lines
+
 #----------------------------------------------------------------------
 # Plotting functions and monkey patches
 
@@ -78,7 +80,7 @@ def tsplot(series, plotf, **kwargs):
 
     # set date formatter, locators and rescale limits
     format_dateaxis(ax, ax.freq)
-    left, right = _get_xlim(ax.get_lines())
+    left, right = _get_xlim(_get_all_lines(ax))
     ax.set_xlim(left, right)
 
     # x and y coord info
@@ -115,7 +117,7 @@ def _get_ax_freq(ax):
     if ax_freq is None:
         if hasattr(ax, 'left_ax'):
             ax_freq = getattr(ax.left_ax, 'freq', None)
-        if hasattr(ax, 'right_ax'):
+        elif hasattr(ax, 'right_ax'):
             ax_freq = getattr(ax.right_ax, 'freq', None)
     return ax_freq
 


### PR DESCRIPTION
Fixes #2960
Fixes #3490. 

Summary of changes:
- for irregular timeseries plots, considers all lines already plotted when calculating xlim
- for plots with secondary_y axis, considers lines on both left and right axes when calculating xlim. There are tests for non-timeseries plots (always worked, but now a test to confirm this), irregular timeseries plots, and regular timeseries plots.

This does not fix #6608, which I now think is a fairly specific/rare case that could always be manually avoided by `x_compat=True`. I will still try and fix that, but it looks a bit uglier and I didn't want to hold back these more important changes.
