### PR TITLE
BUG: fix read_sql delegation for queries without select statement (GH7324)

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -117,3 +117,6 @@ Bug Fixes
 - Bug in ``MultiIndex.append``, ``concat`` and ``pivot_table`` don't preserve timezone (:issue:`6606`)
 - Bug in ``.loc`` with a list of indexers on a single-multi index level (that is not nested) (:issue:`7349`)
 - Bug in ``Series.map`` when mapping a dict with tuple keys of different lengths (:issue:`7333`)
+- Bug all ``StringMethods`` now work on empty Series (:issue:`7242`)
+- Fix delegation of `read_sql` to `read_sql_query` when query does not contain
+ 'select' (:issue:`7324`).

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -374,26 +374,19 @@ def read_sql(sql, con, index_col=None, coerce_float=True, params=None,
     """
     pandas_sql = pandasSQL_builder(con)
 
-    if 'select' in sql.lower():
-        try:
-            if pandas_sql.has_table(sql):
-                return pandas_sql.read_table(
-                    sql, index_col=index_col, coerce_float=coerce_float,
-                    parse_dates=parse_dates, columns=columns)
-        except:
-            pass
-
+    if isinstance(pandas_sql, PandasSQLLegacy):
         return pandas_sql.read_sql(
             sql, index_col=index_col, params=params,
             coerce_float=coerce_float, parse_dates=parse_dates)
-    else:
-        if isinstance(pandas_sql, PandasSQLLegacy):
-            raise ValueError("Reading a table with read_sql is not supported "
-                             "for a DBAPI2 connection. Use an SQLAlchemy "
-                             "engine or specify an sql query")
+
+    if pandas_sql.has_table(sql):
         return pandas_sql.read_table(
             sql, index_col=index_col, coerce_float=coerce_float,
             parse_dates=parse_dates, columns=columns)
+    else:
+        return pandas_sql.read_sql(
+            sql, index_col=index_col, params=params,
+            coerce_float=coerce_float, parse_dates=parse_dates)
 
 
 def to_sql(frame, name, con, flavor='sqlite', if_exists='fail', index=True,


### PR DESCRIPTION
Closes #7324.

The `if 'select' in ...'` check was introduced for mysql legacy compatibility, but introduced problem if the query did not contain a select statement (eg a stored procedure). This should solve this, and passes the test suite (locally).
