### PR TITLE
ENH group attribute access for HDFStore

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -889,6 +889,8 @@ class NDFrame(PandasObject):
             in the store wherever possible
         fletcher32 : bool, default False
             If applying compression use the fletcher32 checksum
+        attrs : dict, default None
+            Also store each value inside an attribute of the group
 
         """
 


### PR DESCRIPTION
Summary:
- `store.set_attrs(key, **attrs)` to set attributes of a group
- `store.get_attrs(key, attrs, default)` returns namedtuple with values from a groups attributes or single attribute directly if attrs is specified as a single string
- `to_hdf`, `put` and `append` have optional `attrs=dict(...)` argument to update attributes when storing an object

Examples:

```
from pandas.io.pytables import get_attrs
df.to_hdf('h5', 'df', attrs=dict(a=1, b=2))
a,b = get_attrs('h5', 'df', ['a', 'b'])
df = read_hdf('h5', 'df')
```

```
st.put('df', df)
st.set_attrs('df', a=1, b=2)
a,b,c = st.get_attrs('df', 'a b c', default=None)
a = st.get_attrs('df', 'a')
b, = st.get_attrs('df', ['b'])
```

```
st.append_to_mutple({'grp/a': ['A1', 'A2'], 'grp/b': ['B1', 'B2']}, 'grp/a')
st.set_attrs('grp', a=1, b=2)
attrs = st.get_attrs('group', ['a', 'b'])
```
