### PR TITLE
BUG: Series.map fails when keys are tuples of different lengths (#7333)

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -116,3 +116,4 @@ Bug Fixes
 - Bug in ``CustomBusinessDay.apply`` raiases ``NameError`` when ``np.datetime64`` object is passed (:issue:`7196`)
 - Bug in ``MultiIndex.append``, ``concat`` and ``pivot_table`` don't preserve timezone (:issue:`6606`)
 - Bug all ``StringMethods`` now work on empty Series (:issue:`7242`)
+- Bug in ``Series.map`` when mapping a dict with tuple keys of different lengths (:issue:`7333`)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1940,7 +1940,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         if isinstance(arg, (dict, Series)):
             if isinstance(arg, dict):
-                arg = self._constructor(arg)
+                arg = self._constructor(arg, index=arg.keys())
 
             indexer = arg.index.get_indexer(values)
             new_values = com.take_1d(arg.values, indexer)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -4860,6 +4860,25 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         exp = s * 2
         assert_series_equal(result, exp)
 
+    def test_map_dict_with_tuple_keys(self):
+        '''
+        Due to new MultiIndex-ing behaviour in v0.14.0,
+        dicts with tuple keys passed to map were being
+        converted to a multi-index, preventing tuple values
+        from being mapped properly.
+        '''
+        df = pd.DataFrame({'a': [(1,), (2,), (3, 4), (5, 6)]})
+        label_mappings = {
+            (1,): 'A',
+            (2,): 'B',
+            (3, 4): 'A',
+            (5, 6): 'B'
+        }
+        df['labels'] = df['a'].map(label_mappings)
+        df['expected_labels'] = pd.Series(['A', 'B', 'A', 'B'], index=df.index)
+        # All labels should be filled now
+        tm.assert_series_equal(df['labels'], df['expected_labels'])
+
     def test_apply(self):
         assert_series_equal(self.ts.apply(np.sqrt), np.sqrt(self.ts))
 


### PR DESCRIPTION
closes #7333 seems to be due to the new behaviour of `Series`, which will automatically create a MultiIndex out of the dict's keys when creating a series to map the values. The MultiIndex doesn't match the values for the shorter tuples, so they fail to map.

The fix is fairly simple, just pass the dict keys explicitly as the index.

I've added a test case for this specific issue, but could add some more if others can see related issues that would arise from this. I'll try to finalize the PR (squashing into a single commit, rebasing if necessary) tomorrow if it looks good.
