### PR TITLE
add class=„pandas-empty“ to NaN-cells’ HTML

### DIFF
--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -711,6 +711,8 @@ class HTMLFormatter(TableFormatter):
         return self._write_cell(s, kind='th', indent=indent, tags=tags)
 
     def write_td(self, s, indent=0, tags=None):
+        if s == self.fmt.na_rep:
+            tags = (tags or "") + ' class="pandas-empty"'
         return self._write_cell(s, kind='td', indent=indent, tags=tags)
 
     def _write_cell(self, s, kind='td', indent=0, tags=None):


### PR DESCRIPTION
This PR is related to #5330, but is much simpler.  There is no new API, this just allows styling empty cells using CSS, e.g. using

``` css
  td.pandas-empty { color: #eee }
```

to de-emphasize, or

``` css
  td.pandas-empty { background-color: yellow }
```

to let empty cells stand out.
