### PR TITLE
TST7337: Fix test failures on windows.

### DIFF
--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -12,6 +12,8 @@
    randint = np.random.randint
    np.set_printoptions(precision=4, suppress=True)
    options.display.max_rows=15
+   import dateutil
+   import pytz
    from dateutil.relativedelta import relativedelta
    from pandas.tseries.api import *
    from pandas.tseries.offsets import *
@@ -1266,32 +1268,37 @@ common zones, the names are the same as ``pytz``.
 .. ipython:: python
 
    # pytz
-   rng_utc = date_range('3/6/2012 00:00', periods=10, freq='D', tz='UTC')
-   rng_utc.tz
+   rng_pytz = date_range('3/6/2012 00:00', periods=10, freq='D',
+                         tz='Europe/London')
+   rng_pytz.tz
 
    # dateutil
-   rng_utc_dateutil = date_range('3/6/2012 00:00', periods=10, freq='D',
-                                 tz='dateutil/UTC')
-   rng_utc_dateutil.tz
+   rng_dateutil = date_range('3/6/2012 00:00', periods=10, freq='D',
+                             tz='dateutil/Europe/London')
+   rng_dateutil.tz
 
-You can also construct the timezone explicitly first, which gives you more control over which
-time zone is used:
+   # dateutil - utc special case
+   rng_utc = date_range('3/6/2012 00:00', periods=10, freq='D',
+                        tz=dateutil.tz.tzutc())
+   rng_utc.tz
+
+Note that the ``UTC`` timezone is a special case in ``dateutil`` and should be constructed explicitly
+as an instance of ``dateutil.tz.tzutc``. You can also construct other timezones explicitly first,
+which gives you more control over which time zone is used:
 
 .. ipython:: python
 
    # pytz
-   import pytz
-   tz_pytz = pytz.timezone('UTC')
-   rng_utc = date_range('3/6/2012 00:00', periods=10, freq='D', tz=tz_pytz)
-   rng_utc.tz
+   tz_pytz = pytz.timezone('Europe/London')
+   rng_pytz = date_range('3/6/2012 00:00', periods=10, freq='D',
+                         tz=tz_pytz)
+   rng_pytz.tz == tz_pytz
 
    # dateutil
-   import dateutil
-   tz_dateutil = dateutil.tz.gettz('UTC')
-   rng_utc_dateutil = date_range('3/6/2012 00:00', periods=10, freq='D',
-                                 tz=tz_dateutil)
-   rng_utc_dateutil.tz
-
+   tz_dateutil = dateutil.tz.gettz('Europe/London')
+   rng_dateutil = date_range('3/6/2012 00:00', periods=10, freq='D',
+                             tz=tz_dateutil)
+   rng_dateutil.tz == tz_dateutil
 
 Timestamps, like Python's ``datetime.datetime`` object can be either time zone
 naive or time zone aware. Naive time series and DatetimeIndex objects can be
@@ -1313,9 +1320,10 @@ tz-aware data to another time zone:
    ts_utc.tz_convert('US/Eastern')
 
 .. warning::
-    Be very wary of conversions between libraries as ``pytz`` and ``dateutil``
-    may have different definitions of the time zones. This is more of a problem for
-    unusual timezones than for 'standard' zones like ``US/Eastern``.
+
+	Be wary of conversions between libraries. For some zones ``pytz`` and ``dateutil`` have different
+	definitions of the zone. This is more of a problem for unusual timezones than for
+	'standard' zones like ``US/Eastern``.
 
 Under the hood, all timestamps are stored in UTC. Scalar values from a
 ``DatetimeIndex`` with a time zone will have their fields (day, hour, minute)
@@ -1359,8 +1367,6 @@ TimeSeries, aligning the data on the UTC timestamps:
    result
    result.index
 
-.. _timeseries.timedeltas:
-
 In some cases, localize cannot determine the DST and non-DST hours when there are
 duplicates.  This often happens when reading files that simply duplicate the hours.
 The infer_dst argument in tz_localize will attempt
@@ -1375,6 +1381,8 @@ to determine the right offset.
    rng_hourly.tz_localize('US/Eastern')
    rng_hourly_eastern = rng_hourly.tz_localize('US/Eastern', infer_dst=True)
    rng_hourly_eastern.values
+
+.. _timeseries.timedeltas:
 
 Time Deltas
 -----------

--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -104,11 +104,9 @@ Enhancements
 
   .. ipython:: python
 
-   rng_utc_dateutil = date_range('3/6/2012 00:00',
-                                 periods=10,
-                                 freq='D',
-                                 tz='dateutil/UTC')
-   rng_utc_dateutil.tz
+   rng = date_range('3/6/2012 00:00', periods=10, freq='D',
+                    tz='dateutil/Europe/London')
+   rng.tz
 
   See :ref:`the docs <timeseries.timezone>`.
 

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -2946,7 +2946,7 @@ class TestStringRepTimestamp(tm.TestCase):
     def test_tz_dateutil(self):
         _skip_if_no_dateutil()
         import dateutil
-        utc = dateutil.tz.gettz('UTC')
+        utc = dateutil.tz.tzutc()
 
         dt_date = datetime(2013, 1, 2, tzinfo=utc)
         self.assertEqual(str(dt_date), str(Timestamp(dt_date)))

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -4630,7 +4630,8 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
     def test_getitem_setitem_datetime_tz_dateutil(self):
         _skip_if_no_dateutil();
-        from dateutil.tz import gettz as tz
+        from dateutil.tz import gettz, tzutc
+        tz = lambda x: tzutc() if x == 'UTC' else gettz(x)  # handle special case for utc in dateutil
 
         from pandas import date_range
         N = 50

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -85,7 +85,8 @@ class TestPeriodProperties(tm.TestCase):
 
     def test_timestamp_tz_arg_dateutil(self):
         import dateutil
-        p = Period('1/1/2005', freq='M').to_timestamp(tz=dateutil.tz.gettz('Europe/Brussels'))
+        from pandas.tslib import maybe_get_tz
+        p = Period('1/1/2005', freq='M').to_timestamp(tz=maybe_get_tz('dateutil/Europe/Brussels'))
         self.assertEqual(p.tz, dateutil.tz.gettz('Europe/Brussels'))
 
     def test_timestamp_tz_arg_dateutil_from_string(self):

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -770,8 +770,12 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
         _skip_if_no_dateutil()
 
     def tz(self, tz):
-        ''' Construct a timezone object from a string. Overridden in subclass to parameterize tests. '''
-        return dateutil.tz.gettz(tz)
+        '''
+        Construct a dateutil timezone.
+        Use tslib.maybe_get_tz so that we get the filename on the tz right
+        on windows. See #7337.
+        '''
+        return tslib.maybe_get_tz('dateutil/' + tz)
 
     def tzstr(self, tz):
         ''' Construct a timezone string from a string. Overridden in subclass to parameterize tests. '''

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -788,6 +788,19 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
     def localize(self, tz, x):
         return x.replace(tzinfo=tz)
 
+    def test_utc_with_system_utc(self):
+        from pandas.tslib import maybe_get_tz
+
+        # from system utc to real utc
+        ts = Timestamp('2001-01-05 11:56', tz=maybe_get_tz('dateutil/UTC'))
+        # check that the time hasn't changed.
+        self.assertEqual(ts, ts.tz_convert(dateutil.tz.tzutc()))
+
+        # from system utc to real utc
+        ts = Timestamp('2001-01-05 11:56', tz=maybe_get_tz('dateutil/UTC'))
+        # check that the time hasn't changed.
+        self.assertEqual(ts, ts.tz_convert(dateutil.tz.tzutc()))
+
 
 class TestTimeZones(tm.TestCase):
     _multiprocess_can_split_ = True


### PR DESCRIPTION
closes #7337

Use dateutil.tz.tzutc() to construct UTC timezone instead of dateutil.tz.gettz('UTC')
Update docs to reflect this.
Tidy up examples in the timezones section of the docs.
