### PR TITLE
add fix for opening zero observation dta files

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -123,3 +123,4 @@ Bug Fixes
 - Bug where a string column name assignment to a ``DataFrame`` with a
   ``Float64Index`` raised a ``TypeError`` during a call to ``np.isnan``
   (:issue:`7366`).
+- Bug in ``StataReader.data`` where reading a 0-observation dta failed (:issue:`7369`)

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -852,7 +852,10 @@ class StataReader(StataParser):
         if convert_categoricals:
             self._read_value_labels()
 
-        data = DataFrame(data, columns=self.varlist, index=index)
+        if len(data)==0:
+            data = DataFrame(columns=self.varlist, index=index)
+        else:
+            data = DataFrame(data, columns=self.varlist, index=index)
 
         cols_ = np.where(self.dtyplist)[0]
         for i in cols_:

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -72,6 +72,14 @@ class TestStata(tm.TestCase):
     def read_csv(self, file):
         return read_csv(file, parse_dates=True)
 
+    def test_read_empty_dta(self):
+        empty_ds = DataFrame(columns=['unit'])
+        # GH 7369, make sure can read a 0-obs dta file
+        with tm.ensure_clean() as path:
+            empty_ds.to_stata(path,write_index=False)
+            empty_ds2 = read_stata(path)
+            tm.assert_frame_equal(empty_ds, empty_ds2)
+
     def test_read_dta1(self):
         reader_114 = StataReader(self.dta1_114)
         parsed_114 = reader_114.data()


### PR DESCRIPTION
Opening a Stata dta file with no observations (but having variables) resulted in an error. Example file: https://dl.dropboxusercontent.com/u/6705315/no_obs_v115.dta.

``` python
>>> import pandas as pd
>>> pd.read_stata("no_obs_v115.dta")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Python27\lib\site-packages\pandas\io\stata.py", line 49, in read_stata
    return reader.data(convert_dates, convert_categoricals, index)
  File "C:\Python27\lib\site-packages\pandas\io\stata.py", line 855, in data
    data = DataFrame(data, columns=self.varlist, index=index)
  File "C:\Python27\lib\site-packages\pandas\core\frame.py", line 255, in __init__
    copy=copy)
  File "C:\Python27\lib\site-packages\pandas\core\frame.py", line 367, in _init_ndarray
    return create_block_manager_from_blocks([values.T], [columns, index])
  File "C:\Python27\lib\site-packages\pandas\core\internals.py", line 3185, in create_block_manager_from_blocks
    construction_error(tot_items, blocks[0].shape[1:], axes, e)
  File "C:\Python27\lib\site-packages\pandas\core\internals.py", line 3166, in construction_error
    passed,implied))
ValueError: Shape of passed values is (0, 0), indices imply (1, 0)
>>> pd.show_versions()

INSTALLED VERSIONS
------------------
commit: None
python: 2.7.6.final.0
python-bits: 32
OS: Windows
OS-release: 7
machine: AMD64
processor: AMD64 Family 16 Model 6 Stepping 3, AuthenticAMD
byteorder: little
LC_ALL: None
LANG: None

pandas: 0.14.0
nose: 1.3.3
Cython: 0.20.1
numpy: 1.8.1
scipy: None
statsmodels: None
IPython: None
sphinx: None
patsy: None
scikits.timeseries: None
dateutil: 2.2
pytz: 2014.3
bottleneck: 0.8.0
tables: None
numexpr: None
matplotlib: None
openpyxl: 1.8.6
xlrd: None
xlwt: None
xlsxwriter: None
lxml: None
bs4: None
html5lib: None
bq: None
apiclient: None
rpy2: None
sqlalchemy: None
pymysql: None
psycopg2: None
```

The PR fixes this issue in stata.py, though maybe the issue should be fixed in DataFrame.
