### PR TITLE
BUG: Revisit DatetimeIndex.insert doesnt preserve name and tz

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -166,6 +166,8 @@ Bug Fixes
 
 
 
+- BUG in ``DatetimeIndex.insert`` doesn't preserve ``name`` and ``tz`` (:issue:`7299`)
+- BUG in ``DatetimeIndex.asobject`` doesn't preserve ``name`` (:issue:`7299`)
 
 
 
@@ -218,3 +220,4 @@ Bug Fixes
   :issue:`7409`).
 - Bug where bool objects were converted to ``nan`` in ``convert_objects``
   (:issue:`7416`).
+


### PR DESCRIPTION
Closes #7378. The previous error was unrelated to `insert` logic.

It seems to be caused by DST related to `tslib` or `pytz`, and became obvious by the previous test case.
