### PR TITLE
TST: Changed the error raised by no tables in data.Options

### DIFF
--- a/pandas/io/data.py
+++ b/pandas/io/data.py
@@ -664,7 +664,9 @@ class Options(object):
                                       "element".format(url))
             tables = root.xpath('.//table')
             ntables = len(tables)
-            if table_loc - 1 > ntables:
+            if ntables == 0:
+                raise RemoteDataError("No tables found at {0!r}".format(url))
+            elif table_loc - 1 > ntables:
                 raise IndexError("Table location {0} invalid, {1} tables"
                                  " found".format(table_loc, ntables))
 


### PR DESCRIPTION
Tests were failing if the scraper got the webpage but there weren't any tables in it. Added condition to raise RemoteDataError if no tables were found.  Still IndexError if it can't find the correct table.

fixes #7335
