### PR TITLE
BUG: grouped hist and scatter use old figsize default

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -175,6 +175,7 @@ Bug Fixes
 - Bug in ``value_counts`` where ``NaT`` did not qualify as missing (``NaN``) (:issue:`7423`)
 
 
+- Bug in grouped ``hist`` and ``scatter`` plots use old ``figsize`` default (:issue:`7394`)
 
 - Bug in ``Panel.apply`` with a multi-index as an axis (:issue:`7469`)
 

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -609,16 +609,16 @@ class TestSeriesPlots(TestPlotBase):
         df = self.hist_df
 
         axes = _check_plot_works(df.height.hist, by=df.gender, layout=(2, 1))
-        self._check_axes_shape(axes, axes_num=2, layout=(2, 1), figsize=(10, 5))
+        self._check_axes_shape(axes, axes_num=2, layout=(2, 1))
 
         axes = _check_plot_works(df.height.hist, by=df.category, layout=(4, 1))
-        self._check_axes_shape(axes, axes_num=4, layout=(4, 1), figsize=(10, 5))
+        self._check_axes_shape(axes, axes_num=4, layout=(4, 1))
 
         axes = _check_plot_works(df.height.hist, by=df.classroom, layout=(2, 2))
-        self._check_axes_shape(axes, axes_num=3, layout=(2, 2), figsize=(10, 5))
+        self._check_axes_shape(axes, axes_num=3, layout=(2, 2))
 
-        axes = _check_plot_works(df.height.hist, by=df.category, layout=(4, 2))
-        self._check_axes_shape(axes, axes_num=4, layout=(4, 2), figsize=(10, 5))
+        axes = _check_plot_works(df.height.hist, by=df.category, layout=(4, 2), figsize=(12, 7))
+        self._check_axes_shape(axes, axes_num=4, layout=(4, 2), figsize=(12, 7))
 
     @slow
     def test_hist_no_overlap(self):
@@ -2255,11 +2255,11 @@ class TestDataFrameGroupByPlots(TestPlotBase):
         df = DataFrame(randn(500, 2), columns=['A', 'B'])
         df['C'] = np.random.randint(0, 4, 500)
         axes = plotting.grouped_hist(df.A, by=df.C)
-        self._check_axes_shape(axes, axes_num=4, layout=(2, 2), figsize=(10, 5))
+        self._check_axes_shape(axes, axes_num=4, layout=(2, 2))
 
         tm.close()
         axes = df.hist(by=df.C)
-        self._check_axes_shape(axes, axes_num=4, layout=(2, 2), figsize=(10, 5))
+        self._check_axes_shape(axes, axes_num=4, layout=(2, 2))
 
         tm.close()
         # make sure kwargs to hist are handled
@@ -2280,6 +2280,9 @@ class TestDataFrameGroupByPlots(TestPlotBase):
         # propagate attr exception from matplotlib.Axes.hist
         with tm.assertRaises(AttributeError):
             plotting.grouped_hist(df.A, by=df.C, foo='bar')
+
+        with tm.assert_produces_warning(FutureWarning):
+            df.hist(by='C', figsize='default')
 
     @slow
     def test_grouped_box_return_type(self):
@@ -2366,29 +2369,28 @@ class TestDataFrameGroupByPlots(TestPlotBase):
                           layout=(1, 3))
 
         axes = _check_plot_works(df.hist, column='height', by=df.gender, layout=(2, 1))
-        self._check_axes_shape(axes, axes_num=2, layout=(2, 1), figsize=(10, 5))
+        self._check_axes_shape(axes, axes_num=2, layout=(2, 1))
 
         axes = _check_plot_works(df.hist, column='height', by=df.category, layout=(4, 1))
-        self._check_axes_shape(axes, axes_num=4, layout=(4, 1), figsize=(10, 5))
+        self._check_axes_shape(axes, axes_num=4, layout=(4, 1))
 
         axes = _check_plot_works(df.hist, column='height', by=df.category,
                                  layout=(4, 2), figsize=(12, 8))
-
         self._check_axes_shape(axes, axes_num=4, layout=(4, 2), figsize=(12, 8))
 
         # GH 6769
         axes = _check_plot_works(df.hist, column='height', by='classroom', layout=(2, 2))
-        self._check_axes_shape(axes, axes_num=3, layout=(2, 2), figsize=(10, 5))
+        self._check_axes_shape(axes, axes_num=3, layout=(2, 2))
 
         # without column
         axes = _check_plot_works(df.hist, by='classroom')
-        self._check_axes_shape(axes, axes_num=3, layout=(2, 2), figsize=(10, 5))
+        self._check_axes_shape(axes, axes_num=3, layout=(2, 2))
 
         axes = _check_plot_works(df.hist, by='gender', layout=(3, 5))
-        self._check_axes_shape(axes, axes_num=2, layout=(3, 5), figsize=(10, 5))
+        self._check_axes_shape(axes, axes_num=2, layout=(3, 5))
 
         axes = _check_plot_works(df.hist, column=['height', 'weight', 'category'])
-        self._check_axes_shape(axes, axes_num=3, layout=(2, 2), figsize=(10, 5))
+        self._check_axes_shape(axes, axes_num=3, layout=(2, 2))
 
     @slow
     def test_axis_share_x(self):

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -2734,9 +2734,11 @@ def _grouped_plot(plotf, data, column=None, by=None, numeric_only=True,
                   rot=0, ax=None, **kwargs):
     from pandas import DataFrame
 
-    # allow to specify mpl default with 'default'
-    if figsize is None or figsize == 'default':
-        figsize = (10, 5)               # our default
+    if figsize == 'default':
+        # allowed to specify mpl default with 'default'
+        warnings.warn("figsize='default' is deprecated. Specify figure"
+                      "size by tuple instead", FutureWarning)
+        figsize = None
 
     grouped = data.groupby(by)
     if column is not None:
@@ -2744,10 +2746,6 @@ def _grouped_plot(plotf, data, column=None, by=None, numeric_only=True,
 
     naxes = len(grouped)
     nrows, ncols = _get_layout(naxes, layout=layout)
-    if figsize is None:
-        # our favorite default beating matplotlib's idea of the
-        # default size
-        figsize = (10, 5)
     fig, axes = _subplots(nrows=nrows, ncols=ncols, naxes=naxes,
                           figsize=figsize, sharex=sharex, sharey=sharey, ax=ax)
 


### PR DESCRIPTION
Grouped `hist` and `scatter` plots use `figsize` default which is different from pandas current and mpl.
