### PR TITLE
PERF: Series.transform speedups (GH6496)

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -137,7 +137,7 @@ Performance
 
 
 - Improvements in dtype inference for numeric operations involving yielding performance gains for dtypes: ``int64``, ``timedelta64``, ``datetime64`` (:issue:`7223`)
-
+- Improvements in Series.transform for signifcant performance gains (:issue`6496`)
 
 
 

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -126,8 +126,10 @@ class TestGroupBy(tm.TestCase):
             assert_series_equal(agged, grouped.mean())
             assert_series_equal(grouped.agg(np.sum), grouped.sum())
 
+            expected = grouped.apply(lambda x: x * x.sum())
             transformed = grouped.transform(lambda x: x * x.sum())
             self.assertEqual(transformed[7], 12)
+            assert_series_equal(transformed, expected)
 
             value_grouped = data.groupby(data)
             assert_series_equal(value_grouped.aggregate(np.mean), agged)

--- a/vb_suite/groupby.py
+++ b/vb_suite/groupby.py
@@ -376,3 +376,21 @@ f_fillna = lambda x: x.fillna(method='pad')
 """
 
 groupby_transform = Benchmark("data.groupby(level='security_id').transform(f_fillna)", setup)
+
+setup = common_setup + """
+np.random.seed(0)
+
+N = 120000
+N_TRANSITIONS = 1400
+
+# generate groups
+transition_points = np.random.permutation(np.arange(N))[:N_TRANSITIONS]
+transition_points.sort()
+transitions = np.zeros((N,), dtype=np.bool)
+transitions[transition_points] = True
+g = transitions.cumsum()
+
+df = DataFrame({ 'signal' : np.random.rand(N)})
+"""
+
+groupby_transform2 = Benchmark("df['signal'].groupby(g).transform(np.mean)", setup)


### PR DESCRIPTION
closes #6496

turns out indexing into an array rather than building it up as a list
using `concat` is faster (but have to be careful of type changes).

```
# this PR
In [11]: %timeit df['signal'].groupby(g).transform(np.mean)
10 loops, best of 3: 158 ms per loop

# master
In [11]: %timeit df['signal'].groupby(g).transform(np.mean)
1 loops, best of 3: 601 ms per loop
```

```
In [1]: np.random.seed(0)

In [2]: N = 120000

In [3]: N_TRANSITIONS = 1400

In [5]: transition_points = np.random.permutation(np.arange(N))[:N_TRANSITIONS]

In [6]: transition_points.sort()

In [7]: transitions = np.zeros((N,), dtype=np.bool)

In [8]: transitions[transition_points] = True

In [9]: g = transitions.cumsum()

In [10]: df = DataFrame({ 'signal' : np.random.rand(N)})
```
