### PR TITLE
make nanops._maybe_null_out work with complex numbers ( issue #7353 )

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -213,7 +213,8 @@ Bug Fixes
 - Bug where bool objects were converted to ``nan`` in ``convert_objects``
   (:issue:`7416`).
 - Bug in ``quantile`` ignoring the axis keyword argument (:issue`7306`)
-
+- Bug where ``nanops._maybe_null_out`` doesn't work with complex numbers
+  (:issue:`7353`)
 
 
 

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -547,7 +547,10 @@ def _maybe_null_out(result, axis, mask):
     if axis is not None:
         null_mask = (mask.shape[axis] - mask.sum(axis)) == 0
         if null_mask.any():
-            result = result.astype('f8')
+            if np.iscomplexobj(result):
+                result = result.astype('c16')
+            else:
+                result = result.astype('f8')
             result[null_mask] = np.nan
     else:
         null_mask = mask.size - mask.sum()

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -239,7 +239,6 @@ class TestnanopsDataFrame(tm.TestCase):
 
     def test_nansum(self):
         self.check_funs(nanops.nansum, np.sum,
-                        allow_complex=False,
                         allow_str=False, allow_date=False)
 
     def _nanmean_wrap(self, value, *args, **kwargs):
@@ -291,13 +290,11 @@ class TestnanopsDataFrame(tm.TestCase):
     def test_nanmin(self):
         func = partial(self._minmax_wrap, func=np.min)
         self.check_funs(nanops.nanmin, func,
-                        allow_complex=False,
                         allow_str=False, allow_obj=False)
 
     def test_nanmax(self):
         func = partial(self._minmax_wrap, func=np.max)
         self.check_funs(nanops.nanmax, func,
-                        allow_complex=False,
                         allow_str=False, allow_obj=False)
 
     def _argminmax_wrap(self, value, axis=None, func=None):
@@ -355,7 +352,6 @@ class TestnanopsDataFrame(tm.TestCase):
 
     def test_nanprod(self):
         self.check_funs(nanops.nanprod, np.prod,
-                        allow_complex=False,
                         allow_str=False, allow_date=False)
 
     def check_nancorr_nancov_2d(self, checkfun, targ0, targ1, **kwargs):


### PR DESCRIPTION
This fixes #7353 where `nanops._maybe_null_out`, and thus other functions that call on it, don't work with complex numbers.
