### PR TITLE
BUG: Bug in multi-index slicing with datetimelike ranges (strings and Timestamps) (GH7429)

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -127,15 +127,6 @@ Enhancements
 
 Performance
 ~~~~~~~~~~~
-
-
-
-
-
-
-
-
-
 - Improvements in dtype inference for numeric operations involving yielding performance gains for dtypes: ``int64``, ``timedelta64``, ``datetime64`` (:issue:`7223`)
 
 
@@ -166,13 +157,13 @@ Bug Fixes
 
 
 
-- BUG in ``DatetimeIndex.insert`` doesn't preserve ``name`` and ``tz`` (:issue:`7299`)
-- BUG in ``DatetimeIndex.asobject`` doesn't preserve ``name`` (:issue:`7299`)
+- Bug in ``DatetimeIndex.insert`` doesn't preserve ``name`` and ``tz`` (:issue:`7299`)
+- Bug in ``DatetimeIndex.asobject`` doesn't preserve ``name`` (:issue:`7299`)
 
 
 
 
-
+- Bug in multi-index slicing with datetimelike ranges (strings and Timestamps), (:issue:`7429`)
 
 
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1635,16 +1635,12 @@ def _maybe_convert_ix(*args):
 
 def _is_nested_tuple(tup, labels):
     # check for a compatiable nested tuple and multiindexes among the axes
-
     if not isinstance(tup, tuple):
         return False
 
     # are we nested tuple of: tuple,list,slice
     for i, k in enumerate(tup):
 
-        #if i > len(axes):
-        #    raise IndexingError("invalid indxing tuple passed, has too many indexers for this object")
-        #ax = axes[i]
         if isinstance(k, (tuple, list, slice)):
             return isinstance(labels, MultiIndex)
 

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -1565,6 +1565,35 @@ class TestIndexing(tm.TestCase):
         self.assertFalse(result.index.is_unique)
         assert_frame_equal(result, expected)
 
+    def test_multiindex_slicers_datetimelike(self):
+
+        # GH 7429
+        # buggy/inconsistent behavior when slicing with datetime-like
+        import datetime
+        dates = [datetime.datetime(2012,1,1,12,12,12) + datetime.timedelta(days=i) for i in range(6)]
+        freq = [1,2]
+        index = MultiIndex.from_product([dates,freq], names=['date','frequency'])
+
+        df = DataFrame(np.arange(6*2*4,dtype='int64').reshape(-1,4),index=index,columns=list('ABCD'))
+
+        # multi-axis slicing
+        idx = pd.IndexSlice
+        expected = df.iloc[[0,2,4],[0,1]]
+        result = df.loc[(slice(Timestamp('2012-01-01 12:12:12'),Timestamp('2012-01-03 12:12:12')),slice(1,1)), slice('A','B')]
+        assert_frame_equal(result,expected)
+
+        result = df.loc[(idx[Timestamp('2012-01-01 12:12:12'):Timestamp('2012-01-03 12:12:12')],idx[1:1]), slice('A','B')]
+        assert_frame_equal(result,expected)
+
+        result = df.loc[(slice(Timestamp('2012-01-01 12:12:12'),Timestamp('2012-01-03 12:12:12')),1), slice('A','B')]
+        assert_frame_equal(result,expected)
+
+        # with strings
+        result = df.loc[(slice('2012-01-01 12:12:12','2012-01-03 12:12:12'),slice(1,1)), slice('A','B')]
+        assert_frame_equal(result,expected)
+
+        result = df.loc[(idx['2012-01-01 12:12:12':'2012-01-03 12:12:12'],1), idx['A','B']]
+        assert_frame_equal(result,expected)
 
     def test_per_axis_per_level_doc_examples(self):
 


### PR DESCRIPTION
closes #7429
