### PR TITLE
ENH: select_dypes impl

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -524,6 +524,7 @@ Attributes and underlying data
    DataFrame.ftypes
    DataFrame.get_dtype_counts
    DataFrame.get_ftype_counts
+   DataFrame.select_dtypes
    DataFrame.values
    DataFrame.axes
    DataFrame.ndim

--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -1552,3 +1552,84 @@ While float dtypes are unchanged.
    casted = dfa[df2>0]
    casted
    casted.dtypes
+
+Selecting columns based on ``dtype``
+------------------------------------
+
+.. _basics.selectdtypes:
+
+.. versionadded:: 0.14.1
+
+The :meth:`~pandas.DataFrame.select_dtypes` method implements subsetting of columns
+based on their ``dtype``.
+
+First, let's create a :class:`~pandas.DataFrame` with a slew of different
+dtypes:
+
+.. ipython:: python
+
+   df = DataFrame({'string': list('abc'),
+                   'int64': list(range(1, 4)),
+                   'uint8': np.arange(3, 6).astype('u1'),
+                   'float64': np.arange(4.0, 7.0),
+                   'bool1': [True, False, True],
+                   'bool2': [False, True, False],
+                   'dates': pd.date_range('now', periods=3).values})
+   df['tdeltas'] = df.dates.diff()
+   df['uint64'] = np.arange(3, 6).astype('u8')
+   df['other_dates'] = pd.date_range('20130101', periods=3).values
+   df
+
+
+``select_dtypes`` has two parameters ``include`` and ``exclude`` that allow you to
+say "give me the columns WITH these dtypes" (``include``) and/or "give the
+columns WITHOUT these dtypes" (``exclude``).
+
+For example, to select ``bool`` columns
+
+.. ipython:: python
+
+   df.select_dtypes(include=[bool])
+
+You can also pass the name of a dtype in the `numpy dtype hierarchy
+<http://docs.scipy.org/doc/numpy/reference/arrays.scalars.html>`__:
+
+.. ipython:: python
+
+   df.select_dtypes(include=['bool'])
+
+:meth:`~pandas.DataFrame.select_dtypes` also works with generic dtypes as well.
+
+For example, to select all numeric and boolean columns while excluding unsigned
+integers
+
+.. ipython:: python
+
+   df.select_dtypes(include=['number', 'bool'], exclude=['unsignedinteger'])
+
+To select string columns you must use the ``object`` dtype:
+
+.. ipython:: python
+
+   df.select_dtypes(include=['object'])
+
+To see all the child dtypes of a generic ``dtype`` like ``numpy.number`` you
+can define a function that returns a tree of child dtypes:
+
+.. ipython:: python
+
+   def subdtypes(dtype):
+       subs = dtype.__subclasses__()
+       if not subs:
+           return dtype
+       return [dtype, [subdtypes(dt) for dt in subs]]
+
+All numpy dtypes are subclasses of ``numpy.generic``:
+
+.. ipython:: python
+
+    subdtypes(np.generic)
+
+.. note::
+
+   The ``include`` and ``exclude`` parameters must be non-string sequences.

--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -91,6 +91,8 @@ Enhancements
 
 
 
+- Add :meth:`~pandas.DataFrame.select_dtypes` method to allow selection of
+  columns based on dtype (:issue:`7316`). See :ref:`the docs <basics.selectdtypes>`.
 
 
 


### PR DESCRIPTION
closes #7316

examples:

```
In [8]: paste
   df = DataFrame({'a': list('abc'),
                   'b': list(range(1, 4)),
                   'c': np.arange(3, 6).astype('u1'),
                   'd': np.arange(4.0, 7.0),
                   'e': [True, False, True],
                   'f': [False, True, False],
                   'g': pd.date_range('now', periods=3).values})
   df['h'] = df.g.diff()
   df['i'] = np.arange(3, 6).astype('u8')
   df['j'] = pd.date_range('20130101', periods=3).values
   df
## -- End pasted text --
Out[8]:
   a  b  c  d      e      f                   g      h  i          j
0  a  1  3  4   True  False 2014-06-22 23:40:53    NaT  3 2013-01-01
1  b  2  4  5  False   True 2014-06-23 23:40:53 1 days  4 2013-01-02
2  c  3  5  6   True  False 2014-06-24 23:40:53 1 days  5 2013-01-03

In [9]: paste
   df.select_type(include=[bool])
## -- End pasted text --
Out[9]:
       e      f
0   True  False
1  False   True
2   True  False

In [10]: paste
   df.select_type(include=['number', 'bool'], exclude=['unsignedinteger'])
## -- End pasted text --
Out[10]:
   b  d      e      f      h
0  1  4   True  False    NaT
1  2  5  False   True 1 days
2  3  6   True  False 1 days

In [11]: np.timedelta64.mro()  # this is an integer type
Out[11]:
[numpy.timedelta64,
 numpy.signedinteger,
 numpy.integer,
 numpy.number,
 numpy.generic,
 object]

In [13]: paste
   df.select_type(include=['object'])
## -- End pasted text --
Out[13]:
   a
0  a
1  b
2  c
```
