### PR TITLE
API: Improved inference of datetime/timedelta with mixed null objects. (GH7431)

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -46,10 +46,8 @@ API changes
    day = offsets.Day(normalize=True)
    day.apply(Timestamp('2014-01-01 09:00'))
 
-
-
-
-
+- Improved inference of datetime/timedelta with mixed null objects. Regression from 0.13.1 in interpretation of an object Index
+  with all null elements (:issue:`7431`)
 
 - Openpyxl now raises a ValueError on construction of the openpyxl writer
   instead of warning on pandas import (:issue:`7284`).

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1802,9 +1802,11 @@ def _possibly_infer_to_datetimelike(value):
     v = value
     if not is_list_like(v):
         v = [v]
-    v = np.array(v)
+    if not isinstance(v, np.ndarray):
+        v = np.array(v)
     shape = v.shape
-    v = v.ravel()
+    if not v.ndim == 1:
+        v = v.ravel()
 
     if len(v):
 

--- a/pandas/io/tests/test_json/test_pandas.py
+++ b/pandas/io/tests/test_json/test_pandas.py
@@ -4,8 +4,8 @@ from pandas import compat
 import os
 
 import numpy as np
-
-from pandas import Series, DataFrame, DatetimeIndex, Timestamp
+import nose
+from pandas import Series, DataFrame, DatetimeIndex, Timestamp, _np_version_under1p7
 import pandas as pd
 read_json = pd.read_json
 
@@ -600,11 +600,29 @@ class TestPandasContainer(tm.TestCase):
         for c in ['created_at', 'closed_at', 'updated_at']:
             self.assertEqual(result[c].dtype, 'datetime64[ns]')
 
+    def test_timedelta(self):
+        if _np_version_under1p7:
+            raise nose.SkipTest("numpy < 1.7")
+
+        from datetime import timedelta
+        converter = lambda x: pd.to_timedelta(x,unit='ms')
+
+        s = Series([timedelta(23), timedelta(seconds=5)])
+        self.assertEqual(s.dtype,'timedelta64[ns]')
+        assert_series_equal(s, pd.read_json(s.to_json(),typ='series').apply(converter))
+
+        frame = DataFrame([timedelta(23), timedelta(seconds=5)])
+        self.assertEqual(frame[0].dtype,'timedelta64[ns]')
+        assert_frame_equal(
+            frame, pd.read_json(frame.to_json()).apply(converter))
+
     def test_default_handler(self):
         from datetime import timedelta
-        frame = DataFrame([timedelta(23), timedelta(seconds=5)])
+
+        frame = DataFrame([timedelta(23), timedelta(seconds=5), 42])
         self.assertRaises(OverflowError, frame.to_json)
-        expected = DataFrame([str(timedelta(23)), str(timedelta(seconds=5))])
+
+        expected = DataFrame([str(timedelta(23)), str(timedelta(seconds=5)), 42])
         assert_frame_equal(
             expected, pd.read_json(frame.to_json(default_handler=str)))
 

--- a/pandas/tests/test_tseries.py
+++ b/pandas/tests/test_tseries.py
@@ -658,6 +658,13 @@ class TestTypeInference(tm.TestCase):
         except ImportError:
             pass
 
+    def test_object(self):
+
+        # GH 7431
+        # cannot infer more than this as only a single element
+        arr = np.array([None],dtype='O')
+        result = lib.infer_dtype(arr)
+        self.assertEqual(result, 'mixed')
 
 class TestMoments(tm.TestCase):
     pass

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -58,7 +58,7 @@ def _skip_if_has_locale():
     lang, _ = locale.getlocale()
     if lang is not None:
         raise nose.SkipTest("Specific locale is set {0}".format(lang))
-    
+
 def _skip_if_windows_python_3():
     if sys.version_info > (3,) and sys.platform == 'win32':
         raise nose.SkipTest("not used on python 3/win32")

--- a/pandas/tseries/timedeltas.py
+++ b/pandas/tseries/timedeltas.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas.tslib as tslib
 from pandas import compat, _np_version_under1p7
 from pandas.core.common import (ABCSeries, is_integer, is_integer_dtype, is_timedelta64_dtype,
-                                _values_from_object, is_list_like, isnull)
+                                _values_from_object, is_list_like, isnull, _ensure_object)
 
 repr_timedelta = tslib.repr_timedelta64
 repr_timedelta64 = tslib.repr_timedelta64
@@ -46,7 +46,7 @@ def to_timedelta(arg, box=True, unit='ns'):
             value = arg.astype('timedelta64[{0}]'.format(unit)).astype('timedelta64[ns]')
         else:
             try:
-                value = tslib.array_to_timedelta64(_ensure_object(arg),unit=unit)
+                value = tslib.array_to_timedelta64(_ensure_object(arg), unit=unit)
             except:
                 value = np.array([ _coerce_scalar_to_timedelta_type(r, unit=unit) for r in arg ])
 


### PR DESCRIPTION
- regression from 0.13.1 in interpretation of an object Index
- additional tests to validate datetimelike inferences

closes #7431
