### PR TITLE
make nanops work when ndim==1 and axis==0 ( issue #7354 )

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -215,6 +215,8 @@ Bug Fixes
 - Bug in ``quantile`` ignoring the axis keyword argument (:issue`7306`)
 - Bug where ``nanops._maybe_null_out`` doesn't work with complex numbers
   (:issue:`7353`)
+- Bug where several ``nanops`` functions fail when ``axis==0`` for
+  1-dimensional ``nan`` arrays (:issue:`7354`)
 
 
 

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -260,7 +260,7 @@ def nanmean(values, axis=None, skipna=True):
     the_sum = _ensure_numeric(values.sum(axis, dtype=dtype_max))
     count = _get_counts(mask, axis)
 
-    if axis is not None:
+    if axis is not None and getattr(the_sum, 'ndim', False):
         the_mean = the_sum / count
         ct_mask = count == 0
         if ct_mask.any():
@@ -517,7 +517,7 @@ def nanprod(values, axis=None, skipna=True):
 
 def _maybe_arg_null_out(result, axis, mask, skipna):
     # helper function for nanargmin/nanargmax
-    if axis is None:
+    if axis is None or not getattr(result, 'ndim', False):
         if skipna:
             if mask.all():
                 result = -1
@@ -544,7 +544,7 @@ def _get_counts(mask, axis):
 
 
 def _maybe_null_out(result, axis, mask):
-    if axis is not None:
+    if axis is not None and getattr(result, 'ndim', False):
         null_mask = (mask.shape[axis] - mask.sum(axis)) == 0
         if null_mask.any():
             if np.iscomplexobj(result):

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -145,7 +145,7 @@ class TestnanopsDataFrame(tm.TestCase):
                                  'kwargs: %s' % kwargs)
                     raise
 
-        if testarval.ndim <= 2:
+        if testarval.ndim <= 1:
             return
 
         try:
@@ -245,7 +245,7 @@ class TestnanopsDataFrame(tm.TestCase):
         dtype = value.dtype
         res = nanops.nanmean(value, *args, **kwargs)
         if dtype.kind == 'O':
-            res = np.round(res, decimals=15)
+            res = np.round(res, decimals=13)
         return res
 
     def _mean_wrap(self, value, *args, **kwargs):
@@ -254,7 +254,7 @@ class TestnanopsDataFrame(tm.TestCase):
             value = value.astype('c16')
         res = np.mean(value, *args, **kwargs)
         if dtype.kind == 'O':
-            res = np.round(res, decimals=15)
+            res = np.round(res, decimals=13)
         return res
 
     def test_nanmean(self):


### PR DESCRIPTION
This fixes issue #7354, where some `nanops` functions fail for 1-dimensional arrays for the argument `axis=0`.
