### PR TITLE
support axis=None for nanmedian ( issue #7352 )

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -217,6 +217,8 @@ Bug Fixes
   (:issue:`7353`)
 - Bug in several ``nanops`` functions when ``axis==0`` for
   1-dimensional ``nan`` arrays (:issue:`7354`)
+- Bug where ``nanops.nanmedian`` doesn't work when ``axis==None``
+  (:issue:`7352`)
 
 
 

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -286,6 +286,9 @@ def nanmedian(values, axis=None, skipna=True):
     if values.dtype != np.float64:
         values = values.astype('f8')
 
+    if axis is None:
+        values = values.ravel()
+
     notempty = values.size
 
     # an array from a frame


### PR DESCRIPTION
This fixes #7352, where `nanmedian` does not work when `axis==None`.
