### PR TITLE
_sanitize_column now reports proper duplicate error

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1962,6 +1962,8 @@ class DataFrame(NDFrame):
                 # GH 4107
                 try:
                     value = value.reindex(self.index).values
+                except ValueError as e:
+                    raise e
                 except:
                     raise TypeError('incompatible index of inserted column '
                                     'with frame index')


### PR DESCRIPTION
closes #7432
A very simple fix for GH7432. `internals.py` (line 3240) actually raises the correct exception (`ValueError: cannot reindex from a duplicate axis`) but the except: doesn't allow it to be raised. Here I've just allowed the exception itself to be raised since it's more useful to the user than the weird `TypeError` message.
