### PR TITLE
Fix bug where ``nanops._has_infs`` doesn't work with many dtypes (issue #7357)

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -219,6 +219,8 @@ Bug Fixes
   1-dimensional ``nan`` arrays (:issue:`7354`)
 - Bug where ``nanops.nanmedian`` doesn't work when ``axis==None``
   (:issue:`7352`)
+- Bug where ``nanops._has_infs`` doesn't work with many dtypes
+  (:issue:`7357`)
 
 
 

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -597,25 +597,27 @@ class TestnanopsDataFrame(tm.TestCase):
                 break
 
     def test__has_infs(self):
-        pairs = [('arr_complex_1d', False),
-                 ('arr_int_1d', False),
-                 ('arr_bool_1d', False),
-                 ('arr_str_1d', False),
-                 ('arr_utf_1d', False),
-                 ('arr_complex_1d', False),
-                 ('arr_complex_nan_1d', False),
+        pairs = [('arr_complex', False),
+                 ('arr_int', False),
+                 ('arr_bool', False),
+                 ('arr_str', False),
+                 ('arr_utf', False),
+                 ('arr_complex', False),
+                 ('arr_complex_nan', False),
 
-                 ('arr_nan_nanj_1d', False)]
-        pairs_float = [('arr_float_1d', False),
-                       ('arr_nan_1d', False),
-                       ('arr_float_nan_1d', False),
-                       ('arr_nan_nan_1d', False),
+                 ('arr_nan_nanj', False),
+                 ('arr_nan_infj', True),
+                 ('arr_complex_nan_infj', True)]
+        pairs_float = [('arr_float', False),
+                       ('arr_nan', False),
+                       ('arr_float_nan', False),
+                       ('arr_nan_nan', False),
 
-                       ('arr_float_inf_1d', True),
-                       ('arr_inf_1d', True),
-                       ('arr_nan_inf_1d', True),
-                       ('arr_float_nan_inf_1d', True),
-                       ('arr_nan_nan_inf_1d', True)]
+                       ('arr_float_inf', True),
+                       ('arr_inf', True),
+                       ('arr_nan_inf', True),
+                       ('arr_float_nan_inf', True),
+                       ('arr_nan_nan_inf', True)]
 
         for arr, correct in pairs:
             val = getattr(self, arr)
@@ -630,6 +632,7 @@ class TestnanopsDataFrame(tm.TestCase):
             try:
                 self.check_bool(nanops._has_infs, val, correct)
                 self.check_bool(nanops._has_infs, val.astype('f4'), correct)
+                self.check_bool(nanops._has_infs, val.astype('f2'), correct)
             except BaseException as exc:
                 exc.args += (arr,)
                 raise


### PR DESCRIPTION
Fixes issue #7357, where where `nanops._has_infs` doesn't work with many dtypes
