### PR TITLE
TST/CLN: centralize module check funcs

### DIFF
--- a/pandas/stats/tests/test_moments.py
+++ b/pandas/stats/tests/test_moments.py
@@ -17,11 +17,6 @@ from pandas.compat import range, zip, PY3, StringIO
 
 N, K = 100, 10
 
-def _skip_if_no_scipy():
-    try:
-        import scipy.stats
-    except ImportError:
-        raise nose.SkipTest("no scipy.stats")
 
 class TestMoments(tm.TestCase):
 
@@ -68,7 +63,7 @@ class TestMoments(tm.TestCase):
         self._check_moment_func(mom.rolling_mean, np.mean)
 
     def test_cmov_mean(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         try:
             from scikits.timeseries.lib import cmov_mean
         except ImportError:
@@ -86,7 +81,7 @@ class TestMoments(tm.TestCase):
         assert_series_equal(xp, rs)
 
     def test_cmov_window(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         try:
             from scikits.timeseries.lib import cmov_window
         except ImportError:
@@ -104,7 +99,7 @@ class TestMoments(tm.TestCase):
         assert_series_equal(xp, rs)
 
     def test_cmov_window_corner(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         try:
             from scikits.timeseries.lib import cmov_window
         except ImportError:
@@ -128,7 +123,7 @@ class TestMoments(tm.TestCase):
         self.assertEqual(len(rs), 5)
 
     def test_cmov_window_frame(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         try:
             from scikits.timeseries.lib import cmov_window
         except ImportError:
@@ -141,7 +136,7 @@ class TestMoments(tm.TestCase):
         assert_frame_equal(DataFrame(xp), rs)
 
     def test_cmov_window_na_min_periods(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         try:
             from scikits.timeseries.lib import cmov_window
         except ImportError:
@@ -158,7 +153,7 @@ class TestMoments(tm.TestCase):
         assert_series_equal(xp, rs)
 
     def test_cmov_window_regular(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         try:
             from scikits.timeseries.lib import cmov_window
         except ImportError:
@@ -174,7 +169,7 @@ class TestMoments(tm.TestCase):
             assert_series_equal(Series(xp), rs)
 
     def test_cmov_window_special(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         try:
             from scikits.timeseries.lib import cmov_window
         except ImportError:

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -86,18 +86,6 @@ def skip_if_np_version_under1p7():
 
         raise nose.SkipTest('numpy >= 1.7 required')
 
-def _skip_if_no_pytz():
-    try:
-        import pytz
-    except ImportError:
-        raise nose.SkipTest("pytz not installed")
-
-def _skip_if_no_dateutil():
-    try:
-        import dateutil
-    except ImportError:
-        raise nose.SkipTest("dateutil not installed")
-
 
 class TestDataFrameFormatting(tm.TestCase):
     _multiprocess_can_split_ = True
@@ -2930,7 +2918,7 @@ class TestStringRepTimestamp(tm.TestCase):
         self.assertEqual(str(ts_nanos_micros), "1970-01-01 00:00:00.000001200")
 
     def test_tz_pytz(self):
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
 
         import pytz
 
@@ -2944,7 +2932,7 @@ class TestStringRepTimestamp(tm.TestCase):
         self.assertEqual(str(dt_datetime_us), str(Timestamp(dt_datetime_us)))
 
     def test_tz_dateutil(self):
-        _skip_if_no_dateutil()
+        tm._skip_if_no_dateutil()
         import dateutil
         utc = dateutil.tz.tzutc()
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -52,12 +52,6 @@ import pandas.lib as lib
 
 from numpy.testing.decorators import slow
 
-def _skip_if_no_scipy():
-    try:
-        import scipy.stats
-    except ImportError:
-        raise nose.SkipTest("no scipy.stats module")
-
 #---------------------------------------------------------------------
 # DataFrame test cases
 
@@ -6739,28 +6733,28 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             expected.ix['A', 'B'] = expected.ix['B', 'A'] = nan
 
     def test_corr_pearson(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         self.frame['A'][:5] = nan
         self.frame['B'][5:10] = nan
 
         self._check_method('pearson')
 
     def test_corr_kendall(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         self.frame['A'][:5] = nan
         self.frame['B'][5:10] = nan
 
         self._check_method('kendall')
 
     def test_corr_spearman(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         self.frame['A'][:5] = nan
         self.frame['B'][5:10] = nan
 
         self._check_method('spearman')
 
     def test_corr_non_numeric(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         self.frame['A'][:5] = nan
         self.frame['B'][5:10] = nan
 
@@ -6770,7 +6764,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_frame_equal(result, expected)
 
     def test_corr_nooverlap(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
 
         # nothing in common
         for meth in ['pearson', 'kendall', 'spearman']:
@@ -6783,7 +6777,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             self.assertEqual(rs.ix['B', 'B'], 1)
 
     def test_corr_constant(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
 
         # constant --> all NA
 
@@ -10957,7 +10951,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             nanops._USE_BOTTLENECK = True
 
     def test_skew(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         from scipy.stats import skew
 
         def alt(x):
@@ -10968,7 +10962,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self._check_stat_op('skew', alt)
 
     def test_kurt(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
 
         from scipy.stats import kurtosis
 
@@ -11320,7 +11314,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df.cumprod(1)
 
     def test_rank(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         from scipy.stats import rankdata
 
         self.frame['A'][::2] = np.nan
@@ -11412,7 +11406,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_frame_equal(df.rank(), exp)
 
     def test_rank_na_option(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         from scipy.stats import rankdata
 
         self.frame['A'][::2] = np.nan

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -1,9 +1,7 @@
 # pylint: disable-msg=E1101,W0612
 
 from datetime import datetime, timedelta
-import operator
 import nose
-import copy
 import numpy as np
 from numpy import nan
 import pandas as pd
@@ -11,7 +9,6 @@ import pandas as pd
 from pandas import (Index, Series, DataFrame, Panel,
                     isnull, notnull,date_range, _np_version_under1p7)
 from pandas.core.index import Index, MultiIndex
-from pandas.tseries.index import Timestamp, DatetimeIndex
 
 import pandas.core.common as com
 
@@ -23,13 +20,6 @@ from pandas.util.testing import (assert_series_equal,
                                  assert_almost_equal,
                                  ensure_clean)
 import pandas.util.testing as tm
-
-
-def _skip_if_no_scipy():
-    try:
-        import scipy.interpolate
-    except ImportError:
-        raise nose.SkipTest('scipy.interpolate missing')
 
 
 def _skip_if_no_pchip():
@@ -491,7 +481,7 @@ class TestSeries(tm.TestCase, Generic):
         self.assertRaises(ValueError, non_ts.interpolate, method='time')
 
     def test_interp_regression(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         _skip_if_no_pchip()
 
         ser = Series(np.sort(np.random.uniform(size=100)))
@@ -509,7 +499,7 @@ class TestSeries(tm.TestCase, Generic):
         s = Series([]).interpolate()
         assert_series_equal(s.interpolate(), s)
 
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         s = Series([np.nan, np.nan])
         assert_series_equal(s.interpolate(method='polynomial', order=1), s)
 
@@ -544,7 +534,7 @@ class TestSeries(tm.TestCase, Generic):
         expected = Series([0., 1., 2., 3.])
         assert_series_equal(result, expected)
 
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         result = s.interpolate(method='polynomial', order=1)
         assert_series_equal(result, expected)
 
@@ -561,14 +551,14 @@ class TestSeries(tm.TestCase, Generic):
         assert_series_equal(result, expected)
 
     def test_interp_quad(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         sq = Series([1, 4, np.nan, 16], index=[1, 2, 3, 4])
         result = sq.interpolate(method='quadratic')
         expected = Series([1., 4., 9., 16.], index=[1, 2, 3, 4])
         assert_series_equal(result, expected)
 
     def test_interp_scipy_basic(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         s = Series([1, 3, np.nan, 12, np.nan, 25])
         # slinear
         expected = Series([1., 3., 7.5, 12., 18.5, 25.])
@@ -611,7 +601,7 @@ class TestSeries(tm.TestCase, Generic):
 
     def test_interp_all_good(self):
         # scipy
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         s = Series([1, 2, 3])
         result = s.interpolate(method='polynomial', order=1)
         assert_series_equal(result, s)
@@ -629,18 +619,18 @@ class TestSeries(tm.TestCase, Generic):
         result = s.interpolate()
         assert_series_equal(result, expected)
 
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         with tm.assertRaises(ValueError):
             s.interpolate(method='polynomial', order=1)
 
     def test_interp_nonmono_raise(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         s = Series([1, np.nan, 3], index=[0, 2, 1])
         with tm.assertRaises(ValueError):
             s.interpolate(method='krogh')
 
     def test_interp_datetime64(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         df = Series([1, np.nan, 3], index=date_range('1/1/2000', periods=3))
         result = df.interpolate(method='nearest')
         expected = Series([1., 1., 3.], index=date_range('1/1/2000', periods=3))
@@ -768,7 +758,7 @@ class TestDataFrame(tm.TestCase, Generic):
             df.interpolate(method='values')
 
     def test_interp_various(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         df = DataFrame({'A': [1, 2, np.nan, 4, 5, np.nan, 7],
                         'C': [1, 2, 3, 5, 8, 13, 21]})
         df = df.set_index('C')
@@ -810,7 +800,7 @@ class TestDataFrame(tm.TestCase, Generic):
         assert_frame_equal(result, expected)
 
     def test_interp_alt_scipy(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         df = DataFrame({'A': [1, 2, np.nan, 4, 5, np.nan, 7],
                         'C': [1, 2, 3, 5, 8, 13, 21]})
         result = df.interpolate(method='barycentric')
@@ -850,7 +840,7 @@ class TestDataFrame(tm.TestCase, Generic):
         assert_frame_equal(result, expected)
 
         # scipy route
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         result = df.interpolate(axis=1, method='values')
         assert_frame_equal(result, expected)
 
@@ -871,7 +861,7 @@ class TestDataFrame(tm.TestCase, Generic):
         expected['B'].loc[3] = -3.75
         assert_frame_equal(result, expected)
 
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         result = df.interpolate(method='polynomial', order=1)
         assert_frame_equal(result, expected)
 
@@ -1022,7 +1012,7 @@ class TestDataFrame(tm.TestCase, Generic):
         assert_frame_equal(df[['C2', 'C3']].describe(), df[['C3']].describe())
 
     def test_no_order(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         s = Series([0, 1, np.nan, 3])
         with tm.assertRaises(ValueError):
             s.interpolate(method='polynomial')
@@ -1030,7 +1020,7 @@ class TestDataFrame(tm.TestCase, Generic):
             s.interpolate(method='spline')
 
     def test_spline(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         s = Series([1, 2, np.nan, 4, 5, np.nan, 7])
         result = s.interpolate(method='spline', order=1)
         expected = Series([1., 2., 3., 4., 5., 6., 7.])

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -28,12 +28,6 @@ from numpy.testing.decorators import slow
 import pandas.tools.plotting as plotting
 
 
-def _skip_if_no_scipy():
-    try:
-        import scipy
-    except ImportError:
-        raise nose.SkipTest("no scipy")
-
 def _skip_if_no_scipy_gaussian_kde():
     try:
         import scipy
@@ -655,7 +649,7 @@ class TestSeriesPlots(TestPlotBase):
 
     @slow
     def test_kde(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         _skip_if_no_scipy_gaussian_kde()
         _check_plot_works(self.ts.plot, kind='kde')
         _check_plot_works(self.ts.plot, kind='density')
@@ -664,7 +658,7 @@ class TestSeriesPlots(TestPlotBase):
 
     @slow
     def test_kde_kwargs(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         _skip_if_no_scipy_gaussian_kde()
         from numpy import linspace
         _check_plot_works(self.ts.plot, kind='kde', bw_method=.5, ind=linspace(-100,100,20))
@@ -674,7 +668,7 @@ class TestSeriesPlots(TestPlotBase):
 
     @slow
     def test_kde_color(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         _skip_if_no_scipy_gaussian_kde()
         ax = self.ts.plot(kind='kde', logy=True, color='r')
         self._check_ax_scales(ax, yaxis='log')
@@ -1486,7 +1480,7 @@ class TestDataFramePlots(TestPlotBase):
 
     @slow
     def test_kde(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         _skip_if_no_scipy_gaussian_kde()
         df = DataFrame(randn(100, 4))
         ax = _check_plot_works(df.plot, kind='kde')
@@ -1584,7 +1578,7 @@ class TestDataFramePlots(TestPlotBase):
 
     @slow
     def test_scatter(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
 
         df = DataFrame(randn(100, 2))
         import pandas.tools.plotting as plt

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -28,13 +28,6 @@ import pandas.core.panel as panelm
 import pandas.util.testing as tm
 
 
-def _skip_if_no_scipy():
-    try:
-        import scipy.stats
-    except ImportError:
-        raise nose.SkipTest("no scipy.stats")
-
-
 class PanelTests(object):
     panel = None
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -34,25 +34,6 @@ from pandas.util.testing import (assert_series_equal,
 import pandas.util.testing as tm
 
 
-def _skip_if_no_scipy():
-    try:
-        import scipy.stats
-    except ImportError:
-        raise nose.SkipTest("scipy not installed")
-
-
-def _skip_if_no_pytz():
-    try:
-        import pytz
-    except ImportError:
-        raise nose.SkipTest("pytz not installed")
-
-def _skip_if_no_dateutil():
-    try:
-        import dateutil
-    except ImportError:
-        raise nose.SkipTest("dateutil not installed")
-
 #------------------------------------------------------------------------------
 # Series test cases
 
@@ -2010,14 +1991,14 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         self.assert_(isnull(result))
 
     def test_skew(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
 
         from scipy.stats import skew
         alt = lambda x: skew(x, bias=False)
         self._check_stat_op('skew', alt)
 
     def test_kurt(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
 
         from scipy.stats import kurtosis
         alt = lambda x: kurtosis(x, bias=False)
@@ -3786,7 +3767,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # df['c'].update(Series(['foo'],index=[0])) #####
 
     def test_corr(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
 
         import scipy.stats as stats
 
@@ -3817,7 +3798,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         self.assertAlmostEqual(result, expected)
 
     def test_corr_rank(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
 
         import scipy
         import scipy.stats as stats
@@ -4138,7 +4119,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         assert_series_equal(s.nsmallest(), s.iloc[[2, 3, 0, 4]])
 
     def test_rank(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         from scipy.stats import rankdata
 
         self.ts[::2] = np.nan
@@ -4639,7 +4620,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         assert_series_equal(result, ts)
 
     def test_getitem_setitem_datetime_tz_pytz(self):
-        _skip_if_no_pytz();
+        tm._skip_if_no_pytz();
         from pytz import timezone as tz
 
         from pandas import date_range
@@ -4675,7 +4656,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
 
     def test_getitem_setitem_datetime_tz_dateutil(self):
-        _skip_if_no_dateutil();
+        tm._skip_if_no_dateutil();
         from dateutil.tz import gettz, tzutc
         tz = lambda x: tzutc() if x == 'UTC' else gettz(x)  # handle special case for utc in dateutil
 

--- a/pandas/tests/test_tseries.py
+++ b/pandas/tests/test_tseries.py
@@ -8,13 +8,7 @@ import pandas.util.testing as tm
 from pandas.compat import range, lrange, zip
 import pandas.lib as lib
 import pandas.algos as algos
-from datetime import datetime
 
-def _skip_if_no_scipy():
-    try:
-        import scipy.stats
-    except ImportError:
-        raise nose.SkipTest("scipy not installed")
 
 class TestTseriesUtil(tm.TestCase):
     _multiprocess_can_split_ = True
@@ -342,7 +336,7 @@ def test_convert_objects_complex_number():
 
 
 def test_rank():
-    _skip_if_no_scipy()
+    tm._skip_if_no_scipy()
     from scipy.stats import rankdata
 
     def _check(arr):

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -11,29 +11,10 @@ from pandas.tseries.index import DatetimeIndex
 from pandas import Timestamp
 from pandas.tseries.offsets import generate_range
 from pandas.tseries.index import cdate_range, bdate_range, date_range
-import pandas.tseries.tools as tools
 
 import pandas.core.datetools as datetools
 from pandas.util.testing import assertRaisesRegexp
 import pandas.util.testing as tm
-
-
-def _skip_if_no_pytz():
-    try:
-        import pytz
-    except ImportError:
-        raise nose.SkipTest("pytz not installed")
-
-def _skip_if_no_dateutil():
-    try:
-        import dateutil
-    except ImportError:
-        raise nose.SkipTest("dateutil not installed")
-
-
-def _skip_if_no_cday():
-    if datetools.cday is None:
-        raise nose.SkipTest("CustomBusinessDay not available.")
 
 
 def _skip_if_windows_python_3():
@@ -56,7 +37,7 @@ class TestGenRangeGeneration(tm.TestCase):
         self.assert_numpy_array_equal(rng1, rng2)
 
     def test_generate_cday(self):
-        _skip_if_no_cday()
+        tm._skip_if_no_cday()
         rng1 = list(generate_range(START, END, offset=datetools.cday))
         rng2 = list(generate_range(START, END, time_rule='C'))
         self.assert_numpy_array_equal(rng1, rng2)
@@ -298,12 +279,12 @@ class TestDateRange(tm.TestCase):
         self.rng[2:2].summary()
 
     def test_summary_pytz(self):
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
         import pytz
         bdate_range('1/1/2005', '1/1/2009', tz=pytz.utc).summary()
 
     def test_summary_dateutil(self):
-        _skip_if_no_dateutil()
+        tm._skip_if_no_dateutil()
         import dateutil
         bdate_range('1/1/2005', '1/1/2009', tz=dateutil.tz.tzutc()).summary()
 
@@ -372,7 +353,7 @@ class TestDateRange(tm.TestCase):
 
     def test_range_tz_pytz(self):
         # GH 2906
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
         from pytz import timezone as tz
 
         start = datetime(2011, 1, 1, tzinfo=tz('US/Eastern'))
@@ -395,11 +376,11 @@ class TestDateRange(tm.TestCase):
 
     def test_range_tz_dateutil(self):
         # GH 2906
-        _skip_if_no_dateutil()
+        tm._skip_if_no_dateutil()
         # Use maybe_get_tz to fix filename in tz under dateutil.
         from pandas.tslib import maybe_get_tz
         tz = lambda x: maybe_get_tz('dateutil/' + x)
-        
+
         start = datetime(2011, 1, 1, tzinfo=tz('US/Eastern'))
         end = datetime(2011, 1, 3, tzinfo=tz('US/Eastern'))
 
@@ -419,7 +400,7 @@ class TestDateRange(tm.TestCase):
         self.assert_(dr[2] == end)
 
     def test_month_range_union_tz_pytz(self):
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
         from pytz import timezone
         tz = timezone('US/Eastern')
 
@@ -436,7 +417,7 @@ class TestDateRange(tm.TestCase):
 
     def test_month_range_union_tz_dateutil(self):
         _skip_if_windows_python_3()
-        _skip_if_no_dateutil()
+        tm._skip_if_no_dateutil()
         from dateutil.tz import gettz as timezone
         tz = timezone('US/Eastern')
 
@@ -470,7 +451,7 @@ class TestDateRange(tm.TestCase):
 class TestCustomDateRange(tm.TestCase):
 
     def setUp(self):
-        _skip_if_no_cday()
+        tm._skip_if_no_cday()
         self.rng = cdate_range(START, END)
 
     def test_constructor(self):
@@ -634,12 +615,12 @@ class TestCustomDateRange(tm.TestCase):
         self.rng[2:2].summary()
 
     def test_summary_pytz(self):
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
         import pytz
         cdate_range('1/1/2005', '1/1/2009', tz=pytz.utc).summary()
 
     def test_summary_dateutil(self):
-        _skip_if_no_dateutil()
+        tm._skip_if_no_dateutil()
         import dateutil
         cdate_range('1/1/2005', '1/1/2009', tz=dateutil.tz.tzutc()).summary()
 

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -9,7 +9,7 @@ from nose.tools import assert_raises
 import numpy as np
 
 from pandas.core.datetools import (
-    bday, BDay, cday, CDay, BQuarterEnd, BMonthEnd,
+    bday, BDay, CDay, BQuarterEnd, BMonthEnd,
     CBMonthEnd, CBMonthBegin,
     BYearEnd, MonthEnd, MonthBegin, BYearBegin,
     QuarterBegin, BQuarterBegin, BMonthBegin, DateOffset, Week,
@@ -40,11 +40,6 @@ def test_monthrange():
     for y in range(2000, 2013):
         for m in range(1, 13):
             assert monthrange(y, m) == calendar.monthrange(y, m)
-
-
-def _skip_if_no_cday():
-    if cday is None:
-        raise nose.SkipTest("CustomBusinessDay not available.")
 
 
 ####
@@ -594,7 +589,7 @@ class TestCustomBusinessDay(Base):
         self.d = datetime(2008, 1, 1)
         self.nd = np.datetime64('2008-01-01 00:00:00Z')
 
-        _skip_if_no_cday()
+        tm._skip_if_no_cday()
         self.offset = CDay()
         self.offset2 = CDay(2)
 
@@ -813,7 +808,7 @@ class CustomBusinessMonthBase(object):
     def setUp(self):
         self.d = datetime(2008, 1, 1)
 
-        _skip_if_no_cday()
+        tm._skip_if_no_cday()
         self.offset = self._object()
         self.offset2 = self._object(2)
 

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -17,19 +17,7 @@ from pandas.tseries.resample import DatetimeIndex
 from pandas.util.testing import assert_series_equal, ensure_clean
 import pandas.util.testing as tm
 
-
-def _skip_if_no_scipy():
-    try:
-        import scipy
-    except ImportError:
-        raise nose.SkipTest("scipy not installed")
-
-def _skip_if_no_scipy_gaussian_kde():
-    try:
-        import scipy
-        from scipy.stats import gaussian_kde
-    except ImportError:
-        raise nose.SkipTest("scipy version doesn't support gaussian_kde")
+from pandas.tests.test_graphics import _skip_if_no_scipy_gaussian_kde
 
 
 @tm.mplskip
@@ -573,7 +561,7 @@ class TestTSPlot(tm.TestCase):
 
     @slow
     def test_secondary_kde(self):
-        _skip_if_no_scipy()
+        tm._skip_if_no_scipy()
         _skip_if_no_scipy_gaussian_kde()
 
         import matplotlib.pyplot as plt

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -26,13 +26,6 @@ import pandas.util.testing as tm
 bday = BDay()
 
 
-def _skip_if_no_pytz():
-    try:
-        import pytz
-    except ImportError:
-        raise nose.SkipTest("pytz not installed")
-
-
 class TestResample(tm.TestCase):
     _multiprocess_can_split_ = True
 

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1,7 +1,6 @@
 # pylint: disable-msg=E1101,W0612
 from datetime import datetime, time, timedelta, date
 import sys
-import os
 import operator
 
 import nose
@@ -40,18 +39,6 @@ from pandas import _np_version_under1p7
 
 from numpy.testing.decorators import slow
 
-
-def _skip_if_no_dateutil():
-    try:
-        import dateutil
-    except ImportError:
-        raise nose.SkipTest("dateutil not installed")
-
-def _skip_if_no_pytz():
-    try:
-        import pytz
-    except ImportError:
-        raise nose.SkipTest("pytz not installed")
 
 def _skip_if_has_locale():
     import locale
@@ -402,7 +389,7 @@ class TestTimeSeries(tm.TestCase):
                           freq='s', periods=10)
 
     def test_timestamp_to_datetime(self):
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
         rng = date_range('20090415', '20090519',
                          tz='US/Eastern')
 
@@ -412,7 +399,7 @@ class TestTimeSeries(tm.TestCase):
         self.assertEqual(stamp.tzinfo, dtval.tzinfo)
 
     def test_timestamp_to_datetime_dateutil(self):
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
         rng = date_range('20090415', '20090519',
                          tz='dateutil/US/Eastern')
 
@@ -422,7 +409,7 @@ class TestTimeSeries(tm.TestCase):
         self.assertEqual(stamp.tzinfo, dtval.tzinfo)
 
     def test_timestamp_to_datetime_explicit_pytz(self):
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
         import pytz
         rng = date_range('20090415', '20090519',
                          tz=pytz.timezone('US/Eastern'))
@@ -434,7 +421,7 @@ class TestTimeSeries(tm.TestCase):
 
     def test_timestamp_to_datetime_explicit_dateutil(self):
         _skip_if_windows_python_3()
-        _skip_if_no_dateutil()
+        tm._skip_if_no_dateutil()
         import dateutil
         rng = date_range('20090415', '20090519',
                          tz=dateutil.tz.gettz('US/Eastern'))
@@ -445,7 +432,7 @@ class TestTimeSeries(tm.TestCase):
         self.assertEquals(stamp.tzinfo, dtval.tzinfo)
 
     def test_index_convert_to_datetime_array(self):
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
 
         def _check_rng(rng):
             converted = rng.to_pydatetime()
@@ -464,7 +451,7 @@ class TestTimeSeries(tm.TestCase):
         _check_rng(rng_utc)
 
     def test_index_convert_to_datetime_array_explicit_pytz(self):
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
         import pytz
 
         def _check_rng(rng):
@@ -484,7 +471,7 @@ class TestTimeSeries(tm.TestCase):
         _check_rng(rng_utc)
 
     def test_index_convert_to_datetime_array_dateutil(self):
-        _skip_if_no_dateutil()
+        tm._skip_if_no_dateutil()
         import dateutil
 
         def _check_rng(rng):
@@ -1515,7 +1502,7 @@ class TestTimeSeries(tm.TestCase):
         self.assertEqual(period[1], Period('2007-01-01 10:11:13.789123Z', 'U'))
 
     def test_to_period_tz_pytz(self):
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
         from dateutil.tz import tzlocal
         from pytz import utc as UTC
 
@@ -1546,7 +1533,7 @@ class TestTimeSeries(tm.TestCase):
         self.assertTrue(ts.to_period().equals(xp))
 
     def test_to_period_tz_explicit_pytz(self):
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
         import pytz
         from dateutil.tz import tzlocal
 
@@ -1577,7 +1564,7 @@ class TestTimeSeries(tm.TestCase):
         self.assert_(ts.to_period().equals(xp))
 
     def test_to_period_tz_dateutil(self):
-        _skip_if_no_dateutil()
+        tm._skip_if_no_dateutil()
         import dateutil
         from dateutil.tz import tzlocal
 
@@ -1764,7 +1751,7 @@ class TestTimeSeries(tm.TestCase):
 
     def test_append_concat_tz(self):
         #GH 2938
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
 
         rng = date_range('5/8/2012 1:45', periods=10, freq='5T',
                          tz='US/Eastern')
@@ -1787,7 +1774,7 @@ class TestTimeSeries(tm.TestCase):
 
     def test_append_concat_tz_explicit_pytz(self):
         # GH 2938
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
         from pytz import timezone as timezone
 
         rng = date_range('5/8/2012 1:45', periods=10, freq='5T',
@@ -1811,7 +1798,7 @@ class TestTimeSeries(tm.TestCase):
 
     def test_append_concat_tz_dateutil(self):
         # GH 2938
-        _skip_if_no_dateutil()
+        tm._skip_if_no_dateutil()
         from dateutil.tz import gettz as timezone
 
         rng = date_range('5/8/2012 1:45', periods=10, freq='5T',
@@ -2013,7 +2000,7 @@ class TestTimeSeries(tm.TestCase):
 
     def test_period_resample_with_local_timezone_pytz(self):
         # GH5430
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
         import pytz
 
         local_timezone = pytz.timezone('America/Los_Angeles')
@@ -2034,7 +2021,7 @@ class TestTimeSeries(tm.TestCase):
 
     def test_period_resample_with_local_timezone_dateutil(self):
         # GH5430
-        _skip_if_no_dateutil()
+        tm._skip_if_no_dateutil()
         import dateutil
 
         local_timezone = 'dateutil/America/Los_Angeles'
@@ -2437,7 +2424,7 @@ class TestDatetimeIndex(tm.TestCase):
         self.assertTrue(result.freq is None)
 
         # GH 7299
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
         import pytz
 
         idx = date_range('1/1/2000', periods=3, freq='D', tz='Asia/Tokyo', name='idx')
@@ -3244,7 +3231,7 @@ class TestSeriesDatetime64(tm.TestCase):
 class TestTimestamp(tm.TestCase):
 
     def test_class_ops_pytz(self):
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
         from pytz import timezone
 
         def compare(x, y):
@@ -3256,7 +3243,7 @@ class TestTimestamp(tm.TestCase):
         compare(Timestamp.today(), datetime.today())
 
     def test_class_ops_dateutil(self):
-        _skip_if_no_dateutil()
+        tm._skip_if_no_dateutil()
         from dateutil.tz import tzutc
 
         def compare(x,y):
@@ -3370,7 +3357,7 @@ class TestTimestamp(tm.TestCase):
         self.assertTrue(other >= val)
 
     def test_cant_compare_tz_naive_w_aware(self):
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
         # #1404
         a = Timestamp('3/12/2012')
         b = Timestamp('3/12/2012', tz='utc')
@@ -3392,7 +3379,7 @@ class TestTimestamp(tm.TestCase):
             self.assertFalse(a.to_pydatetime() == b)
 
     def test_cant_compare_tz_naive_w_aware_explicit_pytz(self):
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
         from pytz import utc
         # #1404
         a = Timestamp('3/12/2012')
@@ -3415,7 +3402,7 @@ class TestTimestamp(tm.TestCase):
             self.assertFalse(a.to_pydatetime() == b)
 
     def test_cant_compare_tz_naive_w_aware_dateutil(self):
-        _skip_if_no_dateutil()
+        tm._skip_if_no_dateutil()
         from dateutil.tz import tzutc
         utc = tzutc()
         # #1404

--- a/pandas/tseries/tests/test_timeseries_legacy.py
+++ b/pandas/tseries/tests/test_timeseries_legacy.py
@@ -2,7 +2,6 @@
 from datetime import datetime, time, timedelta
 import sys
 import os
-import unittest
 
 import nose
 
@@ -15,39 +14,19 @@ from pandas import (Index, Series, TimeSeries, DataFrame,
 
 import pandas.core.datetools as datetools
 import pandas.tseries.offsets as offsets
-import pandas.tseries.frequencies as fmod
 import pandas as pd
 
 from pandas.util.testing import assert_series_equal, assert_almost_equal
 import pandas.util.testing as tm
 
-from pandas.tslib import NaT, iNaT
-import pandas.lib as lib
-import pandas.tslib as tslib
-
-import pandas.index as _index
-
 from pandas.compat import(
     range, long, StringIO, lrange, lmap, map, zip, cPickle as pickle, product
 )
 from pandas import read_pickle
-import pandas.core.datetools as dt
 from numpy.random import rand
-from numpy.testing import assert_array_equal
-from pandas.util.testing import assert_frame_equal
 import pandas.compat as compat
 from pandas.core.datetools import BDay
-import pandas.core.common as com
-from pandas import concat
 
-from numpy.testing.decorators import slow
-
-
-def _skip_if_no_pytz():
-    try:
-        import pytz
-    except ImportError:
-        raise nose.SkipTest("pytz not installed")
 
 # infortunately, too much has changed to handle these legacy pickles
 # class TestLegacySupport(unittest.TestCase):

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -2,7 +2,6 @@
 from datetime import datetime, timedelta, tzinfo, date
 import sys
 import os
-import unittest
 import nose
 
 import numpy as np
@@ -26,17 +25,6 @@ from pandas.compat import lrange, zip
 
 from pandas import _np_version_under1p7
 
-def _skip_if_no_pytz():
-    try:
-        import pytz
-    except ImportError:
-        raise nose.SkipTest("pytz not installed")
-
-def _skip_if_no_dateutil():
-    try:
-        import dateutil
-    except ImportError:
-        raise nose.SkipTest
 
 try:
     import pytz
@@ -73,7 +61,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
     _multiprocess_can_split_ = True
 
     def setUp(self):
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
 
     def tz(self, tz):
         ''' Construct a timezone object from a string. Overridden in subclass to parameterize tests. '''
@@ -493,7 +481,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         self.assertTrue(result.equals(expected))
 
     def test_take_dont_lose_meta(self):
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
         rng = date_range('1/1/2000', periods=20, tz=self.tzstr('US/Eastern'))
 
         result = rng.take(lrange(5))
@@ -759,7 +747,7 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
     _multiprocess_can_split_ = True
 
     def setUp(self):
-        _skip_if_no_dateutil()
+        tm._skip_if_no_dateutil()
 
     def tz(self, tz):
         '''
@@ -816,7 +804,7 @@ class TestTimeZones(tm.TestCase):
     _multiprocess_can_split_ = True
 
     def setUp(self):
-        _skip_if_no_pytz()
+        tm._skip_if_no_pytz()
 
     def test_index_equals_with_tz(self):
         left = date_range('1/1/2011', periods=100, freq='H', tz='utc')

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -209,12 +209,41 @@ def mplskip(cls):
     cls.setUpClass = setUpClass
     return cls
 
+def _skip_if_no_scipy():
+    try:
+        import scipy.stats
+    except ImportError:
+        import nose
+        raise nose.SkipTest("no scipy.stats module")
+    try:
+        import scipy.interpolate
+    except ImportError:
+        import nose
+        raise nose.SkipTest('scipy.interpolate missing')
+
+
 def _skip_if_no_pytz():
     try:
         import pytz
     except ImportError:
         import nose
         raise nose.SkipTest("pytz not installed")
+
+
+def _skip_if_no_dateutil():
+    try:
+        import dateutil
+    except ImportError:
+        import nose
+        raise nose.SkipTest("dateutil not installed")
+
+
+def _skip_if_no_cday():
+    from pandas.core.datetools import cday
+    if cday is None:
+        import nose
+        raise nose.SkipTest("CustomBusinessDay not available.")
+
 
 #------------------------------------------------------------------------------
 # locale utilities


### PR DESCRIPTION
- Moved duplicated module check functions to `util.testing`
- Remove some unnecessary import
