### PR TITLE
ENH/API: offsets funcs now accepts datetime64

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -126,7 +126,7 @@ Enhancements
 
 
 
-
+- All offsets ``apply``, ``rollforward`` and ``rollback`` can now handle ``np.datetime64``, previously results in ``ApplyTypeError`` (:issue:`7452`)
 
 
 

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -45,6 +45,8 @@ def apply_wraps(func):
             return tslib.NaT
         if type(other) == date:
             other = datetime(other.year, other.month, other.day)
+        elif isinstance(other, np.datetime64):
+            other = as_timestamp(other)
 
         result = func(self, other)
 
@@ -549,20 +551,6 @@ class CustomBusinessDay(BusinessDay):
 
             dt_date = np_incr_dt.astype(datetime)
             result = datetime.combine(dt_date, date_in.time())
-
-            if self.offset:
-                result = result + self.offset
-
-            return as_timestamp(result)
-
-        elif isinstance(other, np.datetime64):
-            date_in = other
-            np_day = date_in.astype('datetime64[D]')
-            np_time = date_in - np_day
-
-            np_incr_dt = np.busday_offset(np_day, self.n, roll=roll,
-                                  busdaycal=self.busdaycalendar)
-            result = np_incr_dt + np_time
 
             if self.offset:
                 result = result + self.offset

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -222,19 +222,20 @@ class TestCommon(Base):
         self.assertEqual(func(t1), expected)
 
     def test_apply(self):
-        dt = datetime(2011, 1, 1, 9, 0)
+        sdt = datetime(2011, 1, 1, 9, 0)
+        ndt = np.datetime64('2011-01-01 09:00Z')
 
         for offset in self.offset_types:
-            expected = self.expecteds[offset.__name__]
+            for dt in [sdt, ndt]:
+                expected = self.expecteds[offset.__name__]
+                if offset == Nano:
+                    self._check_nanofunc_works(offset, 'apply', dt, expected)
+                else:
+                    self._check_offsetfunc_works(offset, 'apply', dt, expected)
 
-            if offset == Nano:
-                self._check_nanofunc_works(offset, 'apply', dt, expected)
-            else:
-                self._check_offsetfunc_works(offset, 'apply', dt, expected)
-
-                expected = Timestamp(expected.date())
-                self._check_offsetfunc_works(offset, 'apply', dt, expected,
-                                             normalize=True)
+                    expected = Timestamp(expected.date())
+                    self._check_offsetfunc_works(offset, 'apply', dt, expected,
+                                                 normalize=True)
 
     def test_rollforward(self):
         expecteds = self.expecteds.copy()
@@ -261,17 +262,19 @@ class TestCommon(Base):
                       'Micro': Timestamp('2011-01-01 00:00:00')}
         norm_expected.update(normalized)
 
-        dt = datetime(2011, 1, 1, 9, 0)
-        for offset in self.offset_types:
-            expected = expecteds[offset.__name__]
+        sdt = datetime(2011, 1, 1, 9, 0)
+        ndt = np.datetime64('2011-01-01 09:00Z')
 
-            if offset == Nano:
-                self._check_nanofunc_works(offset, 'rollforward', dt, expected)
-            else:
-                self._check_offsetfunc_works(offset, 'rollforward', dt, expected)
-                expected = norm_expected[offset.__name__]
-                self._check_offsetfunc_works(offset, 'rollforward', dt, expected,
-                                             normalize=True)
+        for offset in self.offset_types:
+            for dt in [sdt, ndt]:
+                expected = expecteds[offset.__name__]
+                if offset == Nano:
+                    self._check_nanofunc_works(offset, 'rollforward', dt, expected)
+                else:
+                    self._check_offsetfunc_works(offset, 'rollforward', dt, expected)
+                    expected = norm_expected[offset.__name__]
+                    self._check_offsetfunc_works(offset, 'rollforward', dt, expected,
+                                                 normalize=True)
 
     def test_rollback(self):
         expecteds = {'BusinessDay': Timestamp('2010-12-31 09:00:00'),
@@ -315,18 +318,20 @@ class TestCommon(Base):
                       'Micro': Timestamp('2011-01-01 00:00:00')}
         norm_expected.update(normalized)
 
-        dt = datetime(2011, 1, 1, 9, 0)
+        sdt = datetime(2011, 1, 1, 9, 0)
+        ndt = np.datetime64('2011-01-01 09:00Z')
+
         for offset in self.offset_types:
-            expected = expecteds[offset.__name__]
+            for dt in [sdt, ndt]:
+                expected = expecteds[offset.__name__]
+                if offset == Nano:
+                    self._check_nanofunc_works(offset, 'rollback', dt, expected)
+                else:
+                    self._check_offsetfunc_works(offset, 'rollback', dt, expected)
 
-            if offset == Nano:
-                self._check_nanofunc_works(offset, 'rollback', dt, expected)
-            else:
-                self._check_offsetfunc_works(offset, 'rollback', dt, expected)
-
-                expected = norm_expected[offset.__name__]
-                self._check_offsetfunc_works(offset, 'rollback',
-                                             dt, expected, normalize=True)
+                    expected = norm_expected[offset.__name__]
+                    self._check_offsetfunc_works(offset, 'rollback',
+                                                 dt, expected, normalize=True)
 
     def test_onOffset(self):
 

--- a/vb_suite/timeseries.py
+++ b/vb_suite/timeseries.py
@@ -285,13 +285,32 @@ datetimeindex_converter = \
 setup = common_setup + """
 import datetime as dt
 import pandas as pd
+import numpy as np
 
 date = dt.datetime(2011,1,1)
+dt64 = np.datetime64('2011-01-01 09:00Z')
+
+day = pd.offsets.Day()
+year = pd.offsets.YearBegin()
 cday = pd.offsets.CustomBusinessDay()
 cme = pd.offsets.CustomBusinessMonthEnd()
 """
+timeseries_day_incr = Benchmark("date + day",setup)
+
+timeseries_day_apply = Benchmark("day.apply(date)",setup)
+
+timeseries_year_incr = Benchmark("date + year",setup)
+
+timeseries_year_apply = Benchmark("year.apply(date)",setup)
+
 timeseries_custom_bday_incr = \
     Benchmark("date + cday",setup)
+
+timeseries_custom_bday_apply = \
+    Benchmark("cday.apply(date)",setup)
+
+timeseries_custom_bday_apply_dt64 = \
+    Benchmark("cday.apply(dt64)",setup)
 
 # Increment by n
 timeseries_custom_bday_incr_n = \


### PR DESCRIPTION
Even though `CustomBusinessDay.apply` can handle `np.datetime64`, most of other offsets cannot accept `datetime64` and raises `ApplyTypeError`. The fix allows all offsets `apply`, `rollforward` and `rollback` to handle `np.datetime64` properly.

```
import pandas as pd
import numpy as np
t = np.datetime64('2011-01-01 09:00Z')

cday = pd.offsets.CustomBusinessDay()
cday.apply(t)
#2011-01-02 09:00:00

day = pd.offsets.Day()
day.apply(t)
# pandas.tseries.offsets.ApplyTypeError: Unhandled type: datetime64
```

**NOTE:** `CustomBusinessDay` had separate logic for `datetime` and `np.datetime64`. Based on the comparison using current master, `np.datetime64` logic looks slower. Thus I removed it.

```
import timeit
setup = """
import pandas as pd
import numpy as np

cday = pd.offsets.CustomBusinessDay()

np_dt64 = [np.datetime64('2014-05-{0:02} 09:00Z'.format(i)) for i in range(1, 31)]
timestamps = [pd.Timestamp('2014-05-{0:02} 09:00Z'.format(i)) for i in range(1, 31)]
"""

t = timeit.Timer('[cday.apply(d) for d in np_dt64]', setup)
print t.timeit(1000)
#1.6253619194
t = timeit.Timer('[cday.apply(d) for d in timestamps]', setup)
print t.timeit(1000)
#0.959406137466
```
