### PR TITLE
FIX integer column names for older sqlalchemy version GH6340, GH7330

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -567,7 +567,7 @@ class PandasSQLTable(PandasObject):
         ins = self.insert_statement()
         data_list = []
         temp = self.insert_data()
-        keys = temp.columns
+        keys = list(map(str, temp.columns))
 
         for t in temp.itertuples():
             data = dict((k, self.maybe_asscalar(v))


### PR DESCRIPTION
Closes #7330. Should enable to merge #7022 (#6340).
