### PR TITLE
BUG: Better axis label handling for partial layout

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -143,7 +143,7 @@ Performance
 
 
 
-
+- Bug in subplots displays ``ticklabels`` and ``labels`` in different rule (:issue:`5897`)
 
 
 

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -822,6 +822,12 @@ class TestDataFramePlots(TestPlotBase):
 
         axes = _check_plot_works(df.plot, subplots=True, title='blah')
         self._check_axes_shape(axes, axes_num=3, layout=(3, 1))
+        for ax in axes[:2]:
+            self._check_visible(ax.get_xticklabels(), visible=False)
+            self._check_visible([ax.xaxis.get_label()], visible=False)
+        for ax in [axes[2]]:
+            self._check_visible(ax.get_xticklabels())
+            self._check_visible([ax.xaxis.get_label()])
 
         _check_plot_works(df.plot, title='blah')
 
@@ -2331,8 +2337,16 @@ class TestDataFrameGroupByPlots(TestPlotBase):
                                 column='height', return_type='dict')
         self._check_axes_shape(self.plt.gcf().axes, axes_num=3, layout=(2, 2))
 
-        box = df.boxplot(column=['height', 'weight', 'category'], by='gender')
+        # GH 5897
+        axes = df.boxplot(column=['height', 'weight', 'category'], by='gender',
+                          return_type='axes')
         self._check_axes_shape(self.plt.gcf().axes, axes_num=3, layout=(2, 2))
+        for ax in [axes['height']]:
+            self._check_visible(ax.get_xticklabels(), visible=False)
+            self._check_visible([ax.xaxis.get_label()], visible=False)
+        for ax in [axes['weight'], axes['category']]:
+            self._check_visible(ax.get_xticklabels())
+            self._check_visible([ax.xaxis.get_label()])
 
         box = df.groupby('classroom').boxplot(
             column=['height', 'weight', 'category'], return_type='dict')

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -3022,15 +3022,16 @@ def _subplots(nrows=1, ncols=1, naxes=None, sharex=False, sharey=False, squeeze=
 
     if nplots > 1:
         if sharex and nrows > 1:
-            for i, ax in enumerate(axarr):
-                if np.ceil(float(i + 1) / ncols) < nrows:  # only last row
-                    [label.set_visible(
-                        False) for label in ax.get_xticklabels()]
+            for ax in axarr[:naxes][:-ncols]:    # only bottom row
+                for label in ax.get_xticklabels():
+                    label.set_visible(False)
+                ax.xaxis.get_label().set_visible(False)
         if sharey and ncols > 1:
             for i, ax in enumerate(axarr):
                 if (i % ncols) != 0:  # only first column
-                    [label.set_visible(
-                        False) for label in ax.get_yticklabels()]
+                    for label in ax.get_yticklabels():
+                        label.set_visible(False)
+                    ax.yaxis.get_label().set_visible(False)
 
     if naxes != nplots:
         for ax in axarr[naxes:]:


### PR DESCRIPTION
Closes #5897.

Handle `ticklabels` and `labels` based on below rules. Currently `labels` are always displayed even if `ticklabels` are hidden and causes confusion.
- If `sharex` is `True`, display only most bottom `xticklabels` on each columns. (Because #7035 hides the bottom-right axes). Hide `xlabel` as the same manner as `xticklabels`
- If `sharey` is True, display most left `yticklabels` (no change). Hide `ylabel` as the same manner as `yticklabels` (changed)

```
import pandas as pd
from numpy.random import randn
import matplotlib.pyplot as plt

d = pd.DataFrame({'one':randn(5), 'two':randn(5), 'three':randn(5), 'label':['label'] * 5},
        columns = ['one','two','three', 'label'])
bp= d.boxplot(by='label', rot=45)
```

![figure_1](https://cloud.githubusercontent.com/assets/1696302/3074667/70d267ea-e34c-11e3-8996-24db3e31ed67.png)
