### PR TITLE
BUG: DTI.intersection doesnt preserve tz

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -232,4 +232,5 @@ Bug Fixes
 
 
 
-
+- Bug in non-monotonic ``Index.union`` may preserve ``name`` incorrectly (:issue:`7458`)
+- Bug in ``DatetimeIndex.intersection`` doesn't preserve timezone (:issue:`4690`)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -777,7 +777,8 @@ class Index(IndexOpsMixin, FrozenNDArray):
         """
         indexer = com._ensure_platform_int(indexer)
         taken = self.view(np.ndarray).take(indexer)
-        return self._constructor(taken, name=self.name)
+        return self._simple_new(taken, name=self.name, freq=None,
+                                tz=getattr(self, 'tz', None))
 
     def format(self, name=False, formatter=None, **kwargs):
         """
@@ -1075,7 +1076,10 @@ class Index(IndexOpsMixin, FrozenNDArray):
             # duplicates
             indexer = self.get_indexer_non_unique(other.values)[0].unique()
 
-        return self.take(indexer)
+        taken = self.take(indexer)
+        if self.name != other.name:
+            taken.name = None
+        return taken
 
     def diff(self, other):
         """

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime, timedelta
 from pandas.compat import range, lrange, lzip, u, zip
-import sys
 import operator
 import pickle
 import re
@@ -446,6 +445,33 @@ class TestIndex(tm.TestCase):
 
         # non-iterable input
         assertRaisesRegexp(TypeError, "iterable", first.intersection, 0.5)
+
+        idx1 = Index([1, 2, 3, 4, 5], name='idx')
+        # if target has the same name, it is preserved 
+        idx2 = Index([3, 4, 5, 6, 7], name='idx')
+        expected2 = Index([3, 4, 5], name='idx')
+        result2 = idx1.intersection(idx2)
+        self.assertTrue(result2.equals(expected2))
+        self.assertEqual(result2.name, expected2.name)
+
+        # if target name is different, it will be reset
+        idx3 = Index([3, 4, 5, 6, 7], name='other')
+        expected3 = Index([3, 4, 5], name=None)
+        result3 = idx1.intersection(idx3)
+        self.assertTrue(result3.equals(expected3))
+        self.assertEqual(result3.name, expected3.name)
+
+        # non monotonic
+        idx1 = Index([5, 3, 2, 4, 1], name='idx')
+        idx2 = Index([4, 7, 6, 5, 3], name='idx')
+        result2 = idx1.intersection(idx2)
+        self.assertTrue(tm.equalContents(result2, expected2))
+        self.assertEqual(result2.name, expected2.name)
+
+        idx3 = Index([4, 7, 6, 5, 3], name='other')
+        result3 = idx1.intersection(idx3)
+        self.assertTrue(tm.equalContents(result3, expected3))
+        self.assertEqual(result3.name, expected3.name)
 
     def test_union(self):
         first = self.strIndex[5:20]

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -900,9 +900,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
         maybe_slice = lib.maybe_indices_to_slice(com._ensure_int64(indices))
         if isinstance(maybe_slice, slice):
             return self[maybe_slice]
-        indices = com._ensure_platform_int(indices)
-        taken = self.values.take(indices, axis=axis)
-        return self._simple_new(taken, self.name, None, self.tz)
+        return super(DatetimeIndex, self).take(indices, axis)
 
     def unique(self):
         """
@@ -1124,6 +1122,12 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
         self.tz = getattr(obj, 'tz', None)
         self.name = getattr(obj, 'name', None)
         self._reset_identity()
+
+    def _wrap_union_result(self, other, result):
+        name = self.name if self.name == other.name else None
+        if self.tz != other.tz:
+            raise ValueError('Passed item and index have different timezone')
+        return self._simple_new(result, name=name, freq=None, tz=self.tz)
 
     def intersection(self, other):
         """

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -1133,10 +1133,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
         """
         indices = com._ensure_platform_int(indices)
         taken = self.values.take(indices, axis=axis)
-        taken = taken.view(PeriodIndex)
-        taken.freq = self.freq
-        taken.name = self.name
-        return taken
+        return self._simple_new(taken, self.name, freq=self.freq)
 
     def append(self, other):
         """

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -2070,14 +2070,19 @@ class TestPeriodIndex(tm.TestCase):
         self.assertEqual(result[0].freq, index.freq)
 
     def test_take(self):
-        index = PeriodIndex(start='1/1/10', end='12/31/12', freq='D')
+        index = PeriodIndex(start='1/1/10', end='12/31/12', freq='D', name='idx')
+        expected = PeriodIndex([datetime(2010, 1, 6), datetime(2010, 1, 7),
+                                datetime(2010, 1, 9), datetime(2010, 1, 13)],
+                                freq='D', name='idx')
 
-        taken = index.take([5, 6, 8, 12])
+        taken1 = index.take([5, 6, 8, 12])
         taken2 = index[[5, 6, 8, 12]]
-        tm.assert_isinstance(taken, PeriodIndex)
-        self.assertEqual(taken.freq, index.freq)
-        tm.assert_isinstance(taken2, PeriodIndex)
-        self.assertEqual(taken2.freq, index.freq)
+
+        for taken in [taken1, taken2]:
+            self.assertTrue(taken.equals(expected))
+            tm.assert_isinstance(taken, PeriodIndex)
+            self.assertEqual(taken.freq, index.freq)
+            self.assertEqual(taken.name, expected.name)
 
     def test_joins(self):
         index = period_range('1/1/2000', '1/20/2000', freq='D')


### PR DESCRIPTION
Closes #4690.

Also, found and fixed a bug which non-monotonic `Index.union` incorrectly preserves `name` when `Index` have different names.

```
# monotonic
idx1 = pd.Index([1, 2, 3, 4, 5], name='idx1')
idx2 = pd.Index([4, 5, 6, 7, 8], name='other')
idx1.intersection(idx2).name
# None (Expected)

# non-monotonic
idx1 = pd.Index([5, 4, 3, 2, 1], name='idx1')
idx2 = pd.Index([4, 5, 6, 7, 8], name='other')
idx1.intersection(idx2).name
# idx1
```
