### PR TITLE
PERF: performance gains in DataFrame groupby.transform for ufuncs (GH7383)

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -137,6 +137,7 @@ Performance
 ~~~~~~~~~~~
 - Improvements in dtype inference for numeric operations involving yielding performance gains for dtypes: ``int64``, ``timedelta64``, ``datetime64`` (:issue:`7223`)
 - Improvements in Series.transform for signifcant performance gains (:issue`6496`)
+- Improvements in DataFrame.transform with ufuncs and built-in grouper functions for signifcant performance gains (:issue`7383`)
 
 
 

--- a/vb_suite/groupby.py
+++ b/vb_suite/groupby.py
@@ -376,6 +376,7 @@ f_fillna = lambda x: x.fillna(method='pad')
 """
 
 groupby_transform = Benchmark("data.groupby(level='security_id').transform(f_fillna)", setup)
+groupby_transform_ufunc = Benchmark("data.groupby(level='date').transform(np.max)", setup)
 
 setup = common_setup + """
 np.random.seed(0)
@@ -393,4 +394,4 @@ g = transitions.cumsum()
 df = DataFrame({ 'signal' : np.random.rand(N)})
 """
 
-groupby_transform2 = Benchmark("df['signal'].groupby(g).transform(np.mean)", setup)
+groupby_transform_series = Benchmark("df['signal'].groupby(g).transform(np.mean)", setup)


### PR DESCRIPTION
accelerates non-modifying transformations, e.g.
closes #7383 

`DataFrame.groupby(...).transform(np.max)`

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
groupby_transform_ufunc                      |   6.1977 | 215.6494 |   0.0287 |
groupby_transform2                           | 155.9653 | 155.1824 |   1.0050 |
groupby_transform                            | 167.5134 | 165.7823 |   1.0104 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [3d3715b] : WPI: fast tranform on DataFrame
Base   [eb1ae6b] : Merge pull request #7458 from sinhrks/intersection
```
