### PR TITLE
BUG: Some offsets.apply cannot handle tz properly

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -224,6 +224,8 @@ Bug Fixes
 
 
 
+- Bug in passing input with ``tzinfo`` to some offsets ``apply``, ``rollforward`` or ``rollback`` resets ``tzinfo`` or raises ``ValueError`` (:issue:`7465`)
+
 
 - BUG in ``resample`` raises ``ValueError`` when target contains ``NaT`` (:issue:`7227`)
 

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -309,13 +309,6 @@ class TestTimeSeriesDuplicates(tm.TestCase):
             idx = DatetimeIndex(org, freq=f)
             self.assertTrue(idx.equals(org))
 
-        # unbale to create tz-aware 'A' and 'C' freq
-        if _np_version_under1p7:
-            freqs = ['M', 'Q', 'D', 'B', 'T', 'S', 'L', 'U', 'H']
-        else:
-            freqs = ['M', 'Q', 'D', 'B', 'T', 'S', 'L', 'U', 'H', 'N']
-
-        for f in freqs:
             org = DatetimeIndex(start='2001/02/01 09:00', freq=f, tz='US/Pacific', periods=1)
             idx = DatetimeIndex(org, freq=f, tz='US/Pacific')
             self.assertTrue(idx.equals(org))

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -209,6 +209,12 @@ def mplskip(cls):
     cls.setUpClass = setUpClass
     return cls
 
+def _skip_if_no_pytz():
+    try:
+        import pytz
+    except ImportError:
+        import nose
+        raise nose.SkipTest("pytz not installed")
 
 #------------------------------------------------------------------------------
 # locale utilities


### PR DESCRIPTION
There are some offsets which cannot handle input with `tz` properly

```
pd.offsets.Day().apply(pd.Timestamp('2010-01-01 9:00', tz='US/Eastern'))
#2010-01-02 09:00:00-05:00 (Expected)

pd.offsets.CustomBusinessDay().apply(pd.Timestamp('2010-01-01 9:00', tz='US/Eastern'))
#2010-01-04 09:00:00 (tzinfo lost)

pd.offsets.CustomBusinessMonthEnd().apply(pd.Timestamp('2010-01-01 9:00', tz='US/Eastern'))
# ValueError: Cannot compare tz-naive and tz-aware timestamps
```
### Affected Offsets
- pandas.tseries.offsets.CustomBusinessDay'
- 'pandas.tseries.offsets.CustomBusinessMonthEnd'
- 'pandas.tseries.offsets.CustomBusinessMonthBegin'
- 'pandas.tseries.offsets.BusinessMonthBegin'
- 'pandas.tseries.offsets.YearBegin'
- 'pandas.tseries.offsets.BYearBegin'
- 'pandas.tseries.offsets.YearEnd'
- 'pandas.tseries.offsets.BYearEnd'
- 'pandas.tseries.offsets.BQuarterBegin'
- 'pandas.tseries.offsets.LastWeekOfMonth'
- 'pandas.tseries.offsets.FY5253Quarter'
- 'pandas.tseries.offsets.FY5253'
- 'pandas.tseries.offsets.Week'
- 'pandas.tseries.offsets.WeekOfMonth'
- 'pandas.tseries.offsets.Easter'
