### PR TITLE
BUG: Make copies of certain interpolate arguments (GH7295)

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1538,6 +1538,14 @@ def _interpolate_scipy_wrapper(x, y, new_x, method, fill_value=None,
         terp = interpolate.UnivariateSpline(x, y, k=order)
         new_y = terp(new_x)
     else:
+        # GH 7295: need to be able to write for some reason
+        # in some circumstances: check all three
+        if not x.flags.writeable:
+            x = x.copy()
+        if not y.flags.writeable:
+            y = y.copy()
+        if not new_x.flags.writeable:
+            new_x = new_x.copy()
         method = alt_methods[method]
         new_y = method(x, y, new_x)
     return new_y


### PR DESCRIPTION
closes #7295
On the alt_methods branch in interpolate_1d, make copies if x, y, and new_x don't have their `writeable` attribute set.  It seems a little weird that we need to do this, but it'll work around the issue so that the test can pass, anyway.
