### PR TITLE
DOC: Fix index error for remote data docs.

### DIFF
--- a/doc/source/remote_data.rst
+++ b/doc/source/remote_data.rst
@@ -69,13 +69,13 @@ to the specific option you want.
       from pandas.io.data import Options
       aapl = Options('aapl', 'yahoo')
       data = aapl.get_all_data()
-      data.iloc[0:5:, 0:5]
+      data.iloc[0:5, 0:5]
 
       #Show the $100 strike puts at all expiry dates:
-      data.loc[(100, slice(None), 'put'),:].iloc[0:5:, 0:5]
+      data.loc[(100, slice(None), 'put'),:].iloc[0:5, 0:5]
 
       #Show the volume traded of $100 strike puts at all expiry dates:
-      data.loc[(100, slice(None), 'put'),'Vol'].iloc[0:5:, 0:5]
+      data.loc[(100, slice(None), 'put'),'Vol'].head()
 
 If you don't want to download all the data, more specific requests can be made.
 

--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -148,7 +148,7 @@ Performance
 Experimental
 ~~~~~~~~~~~~
 
-``pandas.io.data.Options`` has a get_all_data method and now consistently returns a multi-indexed ``DataFrame`` (PR `#5602`)
+``pandas.io.data.Options`` has a get_all_data method and now consistently returns a multi-indexed ``DataFrame`` (:issue:`5602`)
     See :ref:`the docs<remote_data.yahoo_Options>` ***Experimental***
 
       .. ipython:: python
@@ -156,15 +156,7 @@ Experimental
       from pandas.io.data import Options
       aapl = Options('aapl', 'yahoo')
       data = aapl.get_all_data()
-      data.iloc[0:5:, 0:5]
-
-
-      .. ipython:: python
-
-      from pandas.io.data import Options
-      aapl = Options('aapl', 'yahoo')
-      data = aapl.get_all_data()
-      data.iloc[0:5:, 0:5]
+      data.iloc[0:5, 0:5]
 
 
 .. _whatsnew_0141.bug_fixes:


### PR DESCRIPTION
Fixes the index error caused by #7484.  Also removes duplicate example in v0.14.1.txt
