### PR TITLE
BUG: Bug in .loc performing fallback integer indexing with object dtype indices (GH7496)

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -62,6 +62,8 @@ API changes
   when comparing a ``Period`` with another object using ``==`` if the other
   object isn't a ``Period`` ``False`` is returned.
 
+- Bug in ``.loc`` performing fallback integer indexing with ``object`` dtype indices (:issue:`7496`)
+
 .. _whatsnew_0141.prior_deprecations:
 
 Prior Version Deprecations/Changes

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -609,7 +609,7 @@ class Index(IndexOpsMixin, FrozenNDArray):
             and we have a mixed index (e.g. number/labels). figure out
             the indexer. return None if we can't help
         """
-        if com.is_integer_dtype(keyarr) and not self.is_floating():
+        if (typ is None or typ in ['iloc','ix']) and (com.is_integer_dtype(keyarr) and not self.is_floating()):
             if self.inferred_type != 'integer':
                 keyarr = np.where(keyarr < 0,
                                   len(self) + keyarr, keyarr)

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -806,6 +806,38 @@ class TestIndexing(tm.TestCase):
         # raise a KeyError?
         self.assertRaises(KeyError, df.loc.__getitem__, tuple([[1, 2], [1, 2]]))
 
+        # GH  7496
+        # loc should not fallback
+
+        s = Series()
+        s.loc[1] = 1
+        s.loc['a'] = 2
+
+        self.assertRaises(KeyError, lambda : s.loc[-1])
+
+        result = s.loc[[-1, -2]]
+        expected = Series(np.nan,index=[-1,-2])
+        assert_series_equal(result, expected)
+
+        result = s.loc[['4']]
+        expected = Series(np.nan,index=['4'])
+        assert_series_equal(result, expected)
+
+        s.loc[-1] = 3
+        result = s.loc[[-1,-2]]
+        expected = Series([3,np.nan],index=[-1,-2])
+        assert_series_equal(result, expected)
+
+        s['a'] = 2
+        result = s.loc[[-2]]
+        expected = Series([np.nan],index=[-2])
+        assert_series_equal(result, expected)
+
+        del s['a']
+        def f():
+            s.loc[[-2]] = 0
+        self.assertRaises(KeyError, f)
+
     def test_loc_getitem_label_slice(self):
 
         # label slices (with ints)


### PR DESCRIPTION
closes #7496

```


In [4]: s = Series()

In [5]: s.loc[1] = 1

In [6]: s.loc['a'] = 2

In [7]: s.loc[-1]
KeyError: 'the label [-1] is not in the [index]'

In [8]: s.loc[[-1, -2]]
Out[8]: 
-1   NaN
-2   NaN
dtype: float64

In [9]: s.loc[['4']]
Out[9]: 
4   NaN
dtype: float64

In [10]: s.loc[-1] = 3

In [11]: s.loc[[-1,-2]]
Out[11]: 
-1     3
-2   NaN
dtype: float64

In [12]: s['a'] = 2

In [13]: s.loc[[-2]]
Out[13]: 
-2   NaN
dtype: float64

In [14]: del s['a']

In [15]: s.loc[[-2]] = 0
KeyError: '[-2] not in index'
```
