### PR TITLE
Deprecate detection of IPython frontends

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -2599,6 +2599,8 @@ def in_interactive_session():
 def in_qtconsole():
     """
     check if we're inside an IPython qtconsole
+    
+    DEPRECATED: This is no longer needed, or working, in IPython 3 and above.
     """
     try:
         ip = get_ipython()
@@ -2616,6 +2618,9 @@ def in_qtconsole():
 def in_ipnb():
     """
     check if we're inside an IPython Notebook
+    
+    DEPRECATED: This is no longer used in pandas, and won't work in IPython 3
+    and above.
     """
     try:
         ip = get_ipython()

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -473,6 +473,9 @@ class DataFrame(NDFrame):
         # qtconsole doesn't report it's line width, and also
         # behaves badly when outputting an HTML table
         # that doesn't fit the window, so disable it.
+        # XXX: In IPython 3.x and above, the Qt console will not attempt to
+        # display HTML, so this check can be removed when support for IPython 2.x
+        # is no longer needed.
         if com.in_qtconsole():
             # 'HTML output is disabled in QtConsole'
             return None

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -470,11 +470,6 @@ class DataFrame(NDFrame):
         Return a html representation for a particular DataFrame.
         Mainly for IPython notebook.
         """
-        # ipnb in html repr mode allows scrolling
-        # users strongly prefer to h-scroll a wide HTML table in the browser
-        # then to get a summary view. GH3541, GH3573
-        ipnbh = com.in_ipnb() and get_option('display.notebook_repr_html')
-
         # qtconsole doesn't report it's line width, and also
         # behaves badly when outputting an HTML table
         # that doesn't fit the window, so disable it.


### PR DESCRIPTION
The check for the Qt console won't be necessary in IPython 3 and above: we decided that the Qt console's display of HTML reprs was so bad that it shouldn't attempt to show them. We also want to remove the `parent_appname` config value (ipython/ipython#4980), which will break both of these functions (making them always return False).

The assignment to `ipnbh` was redundant - nothing used that variable. I guess it was used previously and didn't get cleaned up during some changes (quite possibly my own omission).
