### PR TITLE
BUG: offsets.apply may return datetime

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -244,11 +244,14 @@ Bug Fixes
 - Bug in ``DatetimeIndex.to_period``, ``PeriodIndex.asobject``, ``PeriodIndex.to_timestamp`` doesn't preserve ``name`` (:issue:`7485`)
 - Bug in ``DatetimeIndex.to_period`` and ``PeriodIndex.to_timestanp`` handle ``NaT`` incorrectly (:issue:`7228`)
 
+- BUG in ``offsets.apply``, ''rollforward`` and ``rollback`` may return normal ``datetime`` (:issue:`7502`)
 
 
 - BUG in ``resample`` raises ``ValueError`` when target contains ``NaT`` (:issue:`7227`)
 
 - Bug in ``Timestamp.tz_localize`` resets ``nanosecond`` info (:issue:`7534`)
+
+
 
 - Bug in ``Index.astype(float)`` where it would return an ``object`` dtype
   ``Index`` (:issue:`7464`).

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -45,7 +45,7 @@ def apply_wraps(func):
             return tslib.NaT
         if type(other) == date:
             other = datetime(other.year, other.month, other.day)
-        elif isinstance(other, np.datetime64):
+        if isinstance(other, (np.datetime64, datetime)):
             other = as_timestamp(other)
 
         tz = getattr(other, 'tzinfo', None)
@@ -57,11 +57,8 @@ def apply_wraps(func):
         if isinstance(other, Timestamp) and not isinstance(result, Timestamp):
             result = as_timestamp(result)
 
-        if tz is not None:
-            if isinstance(result, Timestamp) and result.tzinfo is None:
-                result = result.tz_localize(tz)
-            elif isinstance(result, datetime) and result.tzinfo is None:
-                result = tz.localize(result)
+        if tz is not None and result.tzinfo is None:
+            result = result.tz_localize(tz)
         return result
     return wrapper
 

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -209,7 +209,7 @@ class TestCommon(Base):
         func = getattr(offset_s, funcname)
 
         result = func(dt)
-        self.assert_(isinstance(result, datetime))
+        self.assert_(isinstance(result, Timestamp))
         self.assertEqual(result, expected)
 
         result = func(Timestamp(dt))
@@ -227,11 +227,11 @@ class TestCommon(Base):
 
             dt_tz = pytz.timezone(tz).localize(dt)
             result = func(dt_tz)
-            self.assert_(isinstance(result, datetime))
+            self.assert_(isinstance(result, Timestamp))
             self.assertEqual(result, expected_localize)
 
             result = func(Timestamp(dt, tz=tz))
-            self.assert_(isinstance(result, datetime))
+            self.assert_(isinstance(result, Timestamp))
             self.assertEqual(result, expected_localize)
 
     def _check_nanofunc_works(self, offset, funcname, dt, expected):


### PR DESCRIPTION
Currently, `offsets.appy`, `rollforward` and `rollback` returns `Timestamp` if argument is `Timestamp` or `np.datetime64`. 

If input is `datetime`, these functions return `datetime` or `Timestamp` inconsistently depending on internal process. It may better to always return `Timestanp`? 
### Affected Offsets
- 'pandas.tseries.offsets.Day'
- 'pandas.tseries.offsets.MonthBegin'
- 'pandas.tseries.offsets.FY5253Quarter'
- 'pandas.tseries.offsets.FY5253'
- 'pandas.tseries.offsets.Week'
- 'pandas.tseries.offsets.WeekOfMonth'
- 'pandas.tseries.offsets.Easter'
- 'pandas.tseries.offsets.Hour'
- 'pandas.tseries.offsets.Minute'
- 'pandas.tseries.offsets.Second'
- 'pandas.tseries.offsets.Milli'
- 'pandas.tseries.offsets.Micro'
