### PR TITLE
BUG, TST: Fix pandas.core.strings.str_contains when handling regex=False and case=False

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -249,3 +249,4 @@ Bug Fixes
 
 - Bug in non-monotonic ``Index.union`` may preserve ``name`` incorrectly (:issue:`7458`)
 - Bug in ``DatetimeIndex.intersection`` doesn't preserve timezone (:issue:`4690`)
+- Bug in ``pandas.core.strings.str_contains`` does not properly match in a case insensitive fashion when ``regex=False`` and ``case=False`` (:issue:`7505`)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -189,7 +189,12 @@ def str_contains(arr, pat, case=True, flags=0, na=np.nan, regex=True):
 
         f = lambda x: bool(regex.search(x))
     else:
-        f = lambda x: pat in x
+        if case:
+            f = lambda x: pat in x
+        else:
+            upper_pat = pat.upper()
+            f = lambda x: upper_pat in x
+            return _na_map(f, str_upper(arr), na, dtype=bool)
     return _na_map(f, arr, na, dtype=bool)
 
 

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -189,6 +189,17 @@ class TestStringMethods(tm.TestCase):
         self.assertEqual(result.dtype, np.bool_)
         tm.assert_almost_equal(result, expected)
 
+        # case insensitive using regex
+        values = ['Foo', 'xYz', 'fOOomMm__fOo', 'MMM_']
+        result = strings.str_contains(values, 'FOO|mmm', case=False)
+        expected = [True, False, True, True]
+        tm.assert_almost_equal(result, expected)
+
+        # case insensitive without regex
+        result = strings.str_contains(values, 'foo', regex=False, case=False)
+        expected = [True, False, True, False]
+        tm.assert_almost_equal(result, expected)
+
         # mixed
         mixed = ['a', NA, 'b', True, datetime.today(), 'foo', None, 1, 2.]
         rs = strings.str_contains(mixed, 'o')


### PR DESCRIPTION
`pandas.core.strings.str_contains` does not match in a case insensitive fashion _at all_ when given `regex=False` and `case=False`.  This PR should fix the situation.  Additionally, there is test coverage for `pandas.core.strings.str_contains` case insensitive matching both with and without regular expressions enabled.
