### PR TITLE
DOC: fix startrow typo in docstrings

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1177,7 +1177,7 @@ class DataFrame(NDFrame):
             Column label for index column(s) if desired. If None is given, and
             `header` and `index` are True, then the index names are used. A
             sequence should be given if the DataFrame uses MultiIndex.
-        startow :
+        startrow :
             upper left cell row to dump data frame
         startcol :
             upper left cell column to dump data frame

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -417,7 +417,7 @@ class Panel(NDFrame):
             Column label for index column(s) if desired. If None is given, and
             `header` and `index` are True, then the index names are used. A
             sequence should be given if the DataFrame uses MultiIndex.
-        startow : upper left cell row to dump data frame
+        startrow : upper left cell row to dump data frame
         startcol : upper left cell column to dump data frame
 
         Notes


### PR DESCRIPTION
Minor, but worth fixing.
