### PR TITLE
REGR: Regression in datetimelike slice indexing with a duplicated index and non-exact end-points (GH7523)

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -167,6 +167,7 @@ Bug Fixes
 ~~~~~~~~~
 - Bug in ``DataFrame.where`` with a symmetric shaped frame and a passed other of a DataFrame (:issue:`7506`)
 - Bug in Panel indexing with a multi-index axis (:issue:`7516`)
+- Regression in datetimelike slice indexing with a duplicated index and non-exact end-points (:issue:`7523`)
 
 - Bug in timeops with non-aligned Series (:issue:`7500`)
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1758,7 +1758,11 @@ class Index(IndexOpsMixin, FrozenNDArray):
 
             except KeyError:
                 if self.is_monotonic:
-                    if not is_unique:
+
+                    # we are duplicated but non-unique
+                    # so if we have an indexer then we are done
+                    # else search for it (GH 7523)
+                    if not is_unique and is_integer(search_value):
                         slc = search_value
                     else:
                         slc = self.searchsorted(search_value,

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -2966,6 +2966,42 @@ class TestDatetime64(tm.TestCase):
         s = Series(lrange(100000), times)
         s.ix[datetime(1900, 1, 1):datetime(2100, 1, 1)]
 
+    def test_slicing_datetimes(self):
+
+        # GH 7523
+
+        # unique
+        df = DataFrame(np.arange(4.,dtype='float64'),
+                       index=[datetime(2001, 1, i, 10, 00) for i in [1,2,3,4]])
+        result = df.ix[datetime(2001,1,1,10):]
+        assert_frame_equal(result,df)
+        result = df.ix[:datetime(2001,1,4,10)]
+        assert_frame_equal(result,df)
+        result = df.ix[datetime(2001,1,1,10):datetime(2001,1,4,10)]
+        assert_frame_equal(result,df)
+
+        result = df.ix[datetime(2001,1,1,11):]
+        expected = df.iloc[1:]
+        assert_frame_equal(result,expected)
+        result = df.ix['20010101 11':]
+        assert_frame_equal(result,expected)
+
+        # duplicates
+        df = pd.DataFrame(np.arange(5.,dtype='float64'),
+                          index=[datetime(2001, 1, i, 10, 00) for i in [1,2,2,3,4]])
+
+        result = df.ix[datetime(2001,1,1,10):]
+        assert_frame_equal(result,df)
+        result = df.ix[:datetime(2001,1,4,10)]
+        assert_frame_equal(result,df)
+        result = df.ix[datetime(2001,1,1,10):datetime(2001,1,4,10)]
+        assert_frame_equal(result,df)
+
+        result = df.ix[datetime(2001,1,1,11):]
+        expected = df.iloc[1:]
+        assert_frame_equal(result,expected)
+        result = df.ix['20010101 11':]
+        assert_frame_equal(result,expected)
 
 class TestSeriesDatetime64(tm.TestCase):
 
@@ -3054,7 +3090,7 @@ class TestSeriesDatetime64(tm.TestCase):
         for tz in [None, 'Asia/Tokyo']:
             rng = date_range('6/1/2000', '6/30/2000', freq='D', name='idx')
 
-            # if target has the same name, it is preserved 
+            # if target has the same name, it is preserved
             rng2 = date_range('5/15/2000', '6/20/2000', freq='D', name='idx')
             expected2 = date_range('6/1/2000', '6/20/2000', freq='D', name='idx')
 


### PR DESCRIPTION
closes #7523 
