### PR TITLE
WIP/ENH: allow read_excel to accept URLs (GH6809)

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -108,6 +108,9 @@ Enhancements
 - ``read_html`` now sports an ``encoding`` argument that is passed to the
   underlying parser library. You can use this to read non-ascii encoded web
   pages (:issue:`7323`).
+- ``read_excel`` now supports reading from URLs in the same way
+  that ``read_csv`` does.  (:issue:`6809`)
+
 
 - Support for dateutil timezones, which can now be used in the same way as
   pytz timezones across pandas. (:issue:`4688`)


### PR DESCRIPTION
closes #6809

This borrows the mechanisms already used in read_csv to enable reading of Excel objects via URLs.

Not sure what tests are appropriate, and I'm not certain what the various decorators do, so I tried to mirror the read_csv tests as best I could.
