### PR TITLE
BUG: Timestamp.tz_localize resets nanosecond

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -248,7 +248,7 @@ Bug Fixes
 
 - BUG in ``resample`` raises ``ValueError`` when target contains ``NaT`` (:issue:`7227`)
 
-
+- Bug in ``Timestamp.tz_convert`` resets ``nanosecond`` info (:issue:`7534`)
 
 - Bug in ``Index.astype(float)`` where it would return an ``object`` dtype
   ``Index`` (:issue:`7464`).

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -1,5 +1,5 @@
 # pylint: disable-msg=E1101,W0612
-from datetime import datetime, time, timedelta, tzinfo, date
+from datetime import datetime, timedelta, tzinfo, date
 import sys
 import os
 import unittest
@@ -8,10 +8,9 @@ import nose
 import numpy as np
 import pytz
 
-from pandas import (Index, Series, TimeSeries, DataFrame, isnull,
-                    date_range, Timestamp)
+from pandas import (Index, Series, DataFrame, isnull, Timestamp)
 
-from pandas import DatetimeIndex, Int64Index, to_datetime, NaT
+from pandas import DatetimeIndex, to_datetime, NaT
 from pandas import tslib
 
 import pandas.core.datetools as datetools
@@ -20,17 +19,10 @@ from pandas.tseries.index import bdate_range, date_range
 import pandas.tseries.tools as tools
 from pytz import NonExistentTimeError
 
-from pandas.util.testing import assert_series_equal, assert_almost_equal, assertRaisesRegexp
 import pandas.util.testing as tm
 
-import pandas.lib as lib
-import pandas.core.datetools as dt
-from numpy.random import rand
 from pandas.util.testing import assert_frame_equal
-import pandas.compat as compat
-from pandas.compat import range, lrange, zip, cPickle as pickle
-from pandas.core.datetools import BDay
-import pandas.core.common as com
+from pandas.compat import lrange, zip
 
 from pandas import _np_version_under1p7
 
@@ -544,13 +536,13 @@ class TestTimeZoneSupportPytz(tm.TestCase):
 
         result = ts_local.at_time(time(10, 0))
         expected = ts.at_time(time(10, 0)).tz_localize(self.tzstr('US/Eastern'))
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         self.assertTrue(self.cmptz(result.index.tz, self.tz('US/Eastern')))
 
         t1, t2 = time(10, 0), time(11, 0)
         result = ts_local.between_time(t1, t2)
         expected = ts.between_time(t1, t2).tz_localize(self.tzstr('US/Eastern'))
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         self.assertTrue(self.cmptz(result.index.tz, self.tz('US/Eastern')))
 
     def test_string_index_alias_tz_aware(self):
@@ -631,7 +623,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
                         'datetimes_with_tz' : datetimes_with_tz })
         result = df.get_dtype_counts()
         expected = Series({ 'datetime64[ns]' : 3, 'object' : 1 })
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_hongkong_tz_convert(self):
         # #1673
@@ -863,7 +855,7 @@ class TestTimeZones(tm.TestCase):
         # Can't localize if already tz-aware
         rng = date_range('1/1/2011', periods=100, freq='H', tz='utc')
         ts = Series(1, index=rng)
-        assertRaisesRegexp(TypeError, 'Already tz-aware', ts.tz_localize, 'US/Eastern')
+        tm.assertRaisesRegexp(TypeError, 'Already tz-aware', ts.tz_localize, 'US/Eastern')
 
     def test_series_frame_tz_convert(self):
         rng = date_range('1/1/2011', periods=200, freq='D',
@@ -887,7 +879,7 @@ class TestTimeZones(tm.TestCase):
         # can't convert tz-naive
         rng = date_range('1/1/2011', periods=200, freq='D')
         ts = Series(1, index=rng)
-        assertRaisesRegexp(TypeError, "Cannot convert tz-naive", ts.tz_convert, 'US/Eastern')
+        tm.assertRaisesRegexp(TypeError, "Cannot convert tz-naive", ts.tz_convert, 'US/Eastern')
 
     def test_join_utc_convert(self):
         rng = date_range('1/1/2011', periods=100, freq='H', tz='utc')
@@ -1033,7 +1025,7 @@ class TestTimeZones(tm.TestCase):
         expected = uts1 + uts2
 
         self.assertEqual(result.index.tz, pytz.UTC)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_intersection(self):
         rng = date_range('1/1/2011', periods=100, freq='H', tz='utc')

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -341,13 +341,15 @@ class Timestamp(_Timestamp):
     def is_year_end(self):
         return self._get_start_end_field('is_year_end')
 
-    def tz_localize(self, tz):
+    def tz_localize(self, tz, infer_dst=False):
         """
         Convert naive Timestamp to local time zone
 
         Parameters
         ----------
         tz : pytz.timezone or dateutil.tz.tzfile
+        infer_dst : boolean, default False
+            Attempt to infer fall dst-transition hours based on order
 
         Returns
         -------
@@ -355,7 +357,10 @@ class Timestamp(_Timestamp):
         """
         if self.tzinfo is None:
             # tz naive, localize
-            return Timestamp(self.to_pydatetime(), tz=tz)
+            tz = maybe_get_tz(tz)
+            value = tz_localize_to_utc(np.array([self.value]), tz,
+                                       infer_dst=infer_dst)[0]
+            return Timestamp(value, tz=tz)
         else:
             raise Exception('Cannot localize tz-aware Timestamp, use '
                             'tz_convert for conversions')


### PR DESCRIPTION
`Timestamp.tz_localize` resets `nanosecond`.

```
t = pd.Timestamp('2011-01-01') + pd.offsets.Nano(1)
t.tz_localize('US/Eastern')
# Warning: discarding nonzero nanoseconds
#2011-01-01 00:00:00-05:00
```

Even though `DatetimeIndex.tz_convert` can preserve it.

```
idx = pd.date_range('3/11/2012 04:00', periods=10, freq='N')
idx.tz_localize('US/Eastern')
# <class 'pandas.tseries.index.DatetimeIndex'>
# [2012-03-11 04:00:00-04:00, ..., 2012-03-11 04:00:00.000000009-04:00]
# Length: 10, Freq: N, Timezone: US/Eastern
```
