### PR TITLE
should fix issue #7520, test_nanargmin fails with datetime64 objects

### DIFF
--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -237,10 +237,20 @@ class TestnanopsDataFrame(tm.TestCase):
                      self.arr_utf.astype('O')]
 
         if allow_date:
-            self.check_fun(testfunc, targfunc, 'arr_date', **kwargs)
-            self.check_fun(testfunc, targfunc, 'arr_tdelta', **kwargs)
-            objs += [self.arr_date.astype('O'),
-                     self.arr_tdelta.astype('O')]
+            try:
+                targfunc(self.arr_date)
+            except TypeError:
+                pass
+            else:
+                self.check_fun(testfunc, targfunc, 'arr_date', **kwargs)
+                objs += [self.arr_date.astype('O')]
+            try:
+                targfunc(self.arr_tdelta)
+            except TypeError:
+                pass
+            else:
+                self.check_fun(testfunc, targfunc, 'arr_tdelta', **kwargs)
+                objs += [self.arr_tdelta.astype('O')]
 
         if allow_obj:
             self.arr_obj = np.vstack(objs)


### PR DESCRIPTION
I think this will fix the issue #7520.  The issue appears to be that older versions of `numpy`, probably less than `1.7.0`, can't handle `datetime64` dtypes very well.  I have added simple check to see if `numpy` can handle a standard operation with `datetime64` dtypes, and if not it skips those tests.

I can't test this personally since I don't have the older version of `numpy`.
