### PR TITLE
DOC: Release note correction for GH7534

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -248,7 +248,7 @@ Bug Fixes
 
 - BUG in ``resample`` raises ``ValueError`` when target contains ``NaT`` (:issue:`7227`)
 
-- Bug in ``Timestamp.tz_convert`` resets ``nanosecond`` info (:issue:`7534`)
+- Bug in ``Timestamp.tz_localize`` resets ``nanosecond`` info (:issue:`7534`)
 
 - Bug in ``Index.astype(float)`` where it would return an ``object`` dtype
   ``Index`` (:issue:`7464`).


### PR DESCRIPTION
Release note correction for #7534. `tz_convert` has no problem.
