### PR TITLE
BUG: DatetimeIndex.asobject raises ValueError when contains NaT

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -248,7 +248,7 @@ Bug Fixes
 - BUG in ``resample`` raises ``ValueError`` when target contains ``NaT`` (:issue:`7227`)
 
 - Bug in ``Timestamp.tz_localize`` resets ``nanosecond`` info (:issue:`7534`)
-
+- Bug in ``DatetimeIndex.asobject`` raises ``ValueError`` when it contains ``NaT`` (:issue:`7539`)
 
 
 - Bug in ``Index.astype(float)`` where it would return an ``object`` dtype

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -376,3 +376,29 @@ class DatetimeIndexOpsMixin(object):
     is_quarter_end = _field_accessor('is_quarter_end', "Logical indicating if last day of quarter (defined by frequency)")
     is_year_start = _field_accessor('is_year_start', "Logical indicating if first day of year (defined by frequency)")
     is_year_end = _field_accessor('is_year_end', "Logical indicating if last day of year (defined by frequency)")
+
+    @property
+    def _box_func(self):
+        """
+        box function to get object from internal representation
+        """
+        raise NotImplementedError
+
+    def _box_values(self, values):
+        """
+        apply box func to passed values
+        """
+        import pandas.lib as lib
+        return lib.map_infer(values, self._box_func)
+
+    @property
+    def asobject(self):
+        from pandas.core.index import Index
+        return Index(self._box_values(self.asi8), name=self.name, dtype=object)
+
+    def tolist(self):
+        """
+        See ndarray.tolist
+        """
+        return list(self.asobject)
+

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -515,6 +515,44 @@ class TestDatetimeIndexOps(Ops):
         self.assertEquals(s.day,10)
         self.assertRaises(AttributeError, lambda : s.weekday)
 
+    def test_asobject_tolist(self):
+        idx = pd.date_range(start='2013-01-01', periods=4, freq='M', name='idx')
+        expected_list = [pd.Timestamp('2013-01-31'), pd.Timestamp('2013-02-28'),
+                         pd.Timestamp('2013-03-31'), pd.Timestamp('2013-04-30')]
+        expected = pd.Index(expected_list, dtype=object, name='idx')
+        result = idx.asobject
+        self.assertTrue(isinstance(result, Index))
+        self.assertEqual(result.dtype, object)
+        self.assertTrue(result.equals(expected))
+        self.assertEqual(result.name, expected.name)
+        self.assertEqual(idx.tolist(), expected_list)
+
+        idx = pd.date_range(start='2013-01-01', periods=4, freq='M', name='idx', tz='Asia/Tokyo')
+        expected_list = [pd.Timestamp('2013-01-31', tz='Asia/Tokyo'),
+                         pd.Timestamp('2013-02-28', tz='Asia/Tokyo'),
+                         pd.Timestamp('2013-03-31', tz='Asia/Tokyo'),
+                         pd.Timestamp('2013-04-30', tz='Asia/Tokyo')]
+        expected = pd.Index(expected_list, dtype=object, name='idx')
+        result = idx.asobject
+        self.assertTrue(isinstance(result, Index))
+        self.assertEqual(result.dtype, object)
+        self.assertTrue(result.equals(expected))
+        self.assertEqual(result.name, expected.name)
+        self.assertEqual(idx.tolist(), expected_list)
+
+        idx = DatetimeIndex([datetime(2013, 1, 1), datetime(2013, 1, 2),
+                             pd.NaT, datetime(2013, 1, 4)], name='idx')
+        expected_list = [pd.Timestamp('2013-01-01'), pd.Timestamp('2013-01-02'),
+                         pd.NaT, pd.Timestamp('2013-01-04')]
+        expected = pd.Index(expected_list, dtype=object, name='idx')
+        result = idx.asobject
+        self.assertTrue(isinstance(result, Index))
+        self.assertEqual(result.dtype, object)
+        self.assertTrue(result.equals(expected))
+        self.assertEqual(result.name, expected.name)
+        self.assertEqual(idx.tolist(), expected_list)
+
+
 class TestPeriodIndexOps(Ops):
     _allowed = '_allow_period_index_ops'
 
@@ -527,6 +565,38 @@ class TestPeriodIndexOps(Ops):
     def test_ops_properties(self):
         self.check_ops_properties(['year','month','day','hour','minute','second','weekofyear','week','dayofweek','dayofyear','quarter'])
         self.check_ops_properties(['qyear'], lambda x: isinstance(x,PeriodIndex))
+
+    def test_asobject_tolist(self):
+        idx = pd.period_range(start='2013-01-01', periods=4, freq='M', name='idx')
+        expected_list = [pd.Period('2013-01-31', freq='M'), pd.Period('2013-02-28', freq='M'),
+                         pd.Period('2013-03-31', freq='M'), pd.Period('2013-04-30', freq='M')]
+        expected = pd.Index(expected_list, dtype=object, name='idx')
+        result = idx.asobject
+        self.assertTrue(isinstance(result, Index))
+        self.assertEqual(result.dtype, object)
+        self.assertTrue(result.equals(expected))
+        self.assertEqual(result.name, expected.name)
+        self.assertEqual(idx.tolist(), expected_list)
+
+        idx = PeriodIndex(['2013-01-01', '2013-01-02', 'NaT', '2013-01-04'], freq='D', name='idx')
+        expected_list = [pd.Period('2013-01-01', freq='D'), pd.Period('2013-01-02', freq='D'),
+                         pd.Period('NaT', freq='D'), pd.Period('2013-01-04', freq='D')]
+        expected = pd.Index(expected_list, dtype=object, name='idx')
+        result = idx.asobject
+        self.assertTrue(isinstance(result, Index))
+        self.assertEqual(result.dtype, object)
+        for i in [0, 1, 3]:
+            self.assertTrue(result[i], expected[i])
+        self.assertTrue(result[2].ordinal, pd.tslib.iNaT)
+        self.assertTrue(result[2].freq, 'D')
+        self.assertEqual(result.name, expected.name)
+
+        result_list = idx.tolist()
+        for i in [0, 1, 3]:
+            self.assertTrue(result_list[i], expected_list[i])
+        self.assertTrue(result_list[2].ordinal, pd.tslib.iNaT)
+        self.assertTrue(result_list[2].freq, 'D')
+
 
 if __name__ == '__main__':
     import nose

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -723,9 +723,9 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
             return False
         return key.ordinal in self._engine
 
-    def _box_values(self, values):
-        f = lambda x: Period(ordinal=x, freq=self.freq)
-        return lib.map_infer(values, f)
+    @property
+    def _box_func(self):
+        return lambda x: Period(ordinal=x, freq=self.freq)
 
     def asof_locs(self, where, mask):
         """
@@ -746,10 +746,6 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
         result[(locs == 0) & (where_idx.values < self.values[first])] = -1
 
         return result
-
-    @property
-    def asobject(self):
-        return Index(self._box_values(self.values), name=self.name, dtype=object)
 
     def _array_values(self):
         return self.asobject
@@ -853,12 +849,6 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
             return True
 
         return np.array_equal(self.asi8, other.asi8)
-
-    def tolist(self):
-        """
-        Return a list of Period objects
-        """
-        return self._get_object_array().tolist()
 
     def to_timestamp(self, freq=None, how='start'):
         """

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -1448,18 +1448,6 @@ class TestPeriodIndex(tm.TestCase):
         self.assertTrue(result2.equals(index))
         self.assertEqual(result2.name, 'idx')
 
-    def test_asobject_period_nat(self):
-        index = PeriodIndex(['NaT', '2011-01', '2011-02'], freq='M', name='idx')
-
-        result = index.asobject
-        self.assertTrue(isinstance(result, Index))
-        self.assertEqual(result.dtype, object)
-        self.assertTrue(isinstance(result[0], Period))
-        self.assertEqual(result[0].ordinal, tslib.iNaT)
-        self.assertEqual(result[1], Period('2011-01', freq='M'))
-        self.assertEqual(result[2], Period('2011-02', freq='M'))
-        self.assertEqual(result.name, 'idx')
-
     def test_as_frame_columns(self):
         rng = period_range('1/1/2000', periods=5)
         df = DataFrame(randn(10, 5), columns=rng)

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1,5 +1,5 @@
 # pylint: disable-msg=E1101,W0612
-from datetime import datetime, time, timedelta, date
+from datetime import datetime, time, timedelta
 import sys
 import operator
 
@@ -2362,16 +2362,6 @@ class TestDatetimeIndex(tm.TestCase):
         ordered, dexer = idx.order(return_indexer=True, ascending=False)
         self.assertTrue(ordered[::-1].is_monotonic)
         self.assert_numpy_array_equal(dexer, [0, 2, 1])
-
-    def test_asobject(self):
-        idx = date_range(start='2013-01-01', periods=4, freq='M', name='idx')
-        expected = Index([Timestamp('2013-01-31'), Timestamp('2013-02-28'),
-                          Timestamp('2013-03-31'), Timestamp('2013-04-30')],
-                         dtype=object, name='idx')
-
-        result = idx.asobject
-        self.assertTrue(result.equals(expected))
-        self.assertEqual(result.name, expected.name)
 
     def test_insert(self):
         idx = DatetimeIndex(['2000-01-04', '2000-01-01', '2000-01-02'], name='idx')


### PR DESCRIPTION
Closes #7539. 

Also, this fixed #7112 case 3 and case 4 to preserve tz. I've modified the tests for it.

Related to #6469.
