### PR TITLE
DOC: Use correct, non-deprecated arg name

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1166,7 +1166,7 @@ class DataFrame(NDFrame):
             Missing data representation
         float_format : string, default None
             Format string for floating point numbers
-        cols : sequence, optional
+        columns : sequence, optional
             Columns to write
         header : boolean or list of string, default True
             Write out column names. If a list of string is given it is


### PR DESCRIPTION
Fix a minor typo in the `pandas.frame.to_excel` docstring.
