### PR TITLE
DOC: fix docstring for DataFrame.interpolate

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1392,7 +1392,7 @@ def backfill_2d(values, limit=None, mask=None, dtype=None):
 
 
 def _clean_interp_method(method, order=None, **kwargs):
-    valid = ['linear', 'time', 'values', 'nearest', 'zero', 'slinear',
+    valid = ['linear', 'time', 'index', 'values', 'nearest', 'zero', 'slinear',
              'quadratic', 'cubic', 'barycentric', 'polynomial',
              'krogh', 'piecewise_polynomial',
              'pchip', 'spline']
@@ -1457,7 +1457,7 @@ def interpolate_1d(xvalues, yvalues, method='linear', limit=None,
         result.fill(np.nan)
         return result
 
-    if method in ['linear', 'time', 'values']:
+    if method in ['linear', 'time', 'index', 'values']:
         if method in ('values', 'index'):
             inds = np.asarray(xvalues)
             # hack for DatetimeIndex, #1646

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2532,7 +2532,7 @@ class NDFrame(PandasObject):
 
         Parameters
         ----------
-        method : {'linear', 'time', 'values', 'index' 'nearest', 'zero',
+        method : {'linear', 'time', 'index', 'values', 'nearest', 'zero',
                   'slinear', 'quadratic', 'cubic', 'barycentric', 'krogh',
                   'polynomial', 'spline' 'piecewise_polynomial', 'pchip'}
 
@@ -2540,7 +2540,7 @@ class NDFrame(PandasObject):
               spaced. default
             * 'time': interpolation works on daily and higher resolution
               data to interpolate given length of interval
-            * 'index': use the actual numerical values of the index
+            * 'index', 'values': use the actual numerical values of the index
             * 'nearest', 'zero', 'slinear', 'quadratic', 'cubic',
               'barycentric', 'polynomial' is passed to
               `scipy.interpolate.interp1d` with the order given both

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -512,7 +512,7 @@ class TestSeries(tm.TestCase, Generic):
 
         vals = s.index.values.astype(float)
 
-        result = s.interpolate(method='values')
+        result = s.interpolate(method='index')
 
         expected = s.copy()
         bad = isnull(expected.values)
@@ -521,6 +521,12 @@ class TestSeries(tm.TestCase, Generic):
             np.interp(vals[bad], vals[good], s.values[good]), index=s.index[bad])
 
         assert_series_equal(result[bad], expected)
+
+        # 'values' is synonymous with 'index' for the method kwarg
+        other_result = s.interpolate(method='values')
+
+        assert_series_equal(other_result, result)
+        assert_series_equal(other_result[bad], expected)
 
     def test_interpolate_non_ts(self):
         s = Series([1, 3, np.nan, np.nan, np.nan, 11])


### PR DESCRIPTION
In the old docstring, `'index'` is listed as a valid value for the `method` kwarg for `DataFrame.interpolate`. It looks like a typo, because there was no comma after `'index'`, and the explanation for `'index'` corresponded to `'values'`. Furthermore, it appears `'index'` is not a valid value for `method`:

``` python
In [67]: df = pd.DataFrame([[1], [2], [np.nan], [3]], index=[0, 0.7, 1.1, 4])

In [68]: df
Out[68]: 
      0
0.0   1
0.7   2
1.1 NaN
4.0   3

In [69]: df.interpolate(method="index")
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-69-4cef75cee92e> in <module>()
----> 1 df.interpolate(method="index")

/home/david/miniconda3/envs/frackoptima/lib/python3.4/site-packages/pandas/core/generic.py in interp
olate(self, method, axis, limit, inplace, downcast, **kwargs)                                      
   2580                                           inplace=inplace,
   2581                                           downcast=downcast,
-> 2582                                           **kwargs)
   2583         if inplace:
   2584             if axis == 1:

/home/david/miniconda3/envs/frackoptima/lib/python3.4/site-packages/pandas/core/internals.py in inte
rpolate(self, **kwargs)                                                                            
   2195 
   2196     def interpolate(self, **kwargs):
-> 2197         return self.apply('interpolate', **kwargs)
   2198 
   2199     def shift(self, **kwargs):

/home/david/miniconda3/envs/frackoptima/lib/python3.4/site-packages/pandas/core/internals.py in appl
y(self, f, axes, filter, do_integrity_check, **kwargs)                                             
   2162                                                  copy=align_copy)
   2163 
-> 2164             applied = getattr(b, f)(**kwargs)
   2165 
   2166             if isinstance(applied, list):

/home/david/miniconda3/envs/frackoptima/lib/python3.4/site-packages/pandas/core/internals.py in inte
rpolate(self, method, axis, index, values, inplace, limit, fill_value, coerce, downcast, **kwargs) 
    667                                      **kwargs)
    668 
--> 669         raise ValueError("invalid method '{0}' to interpolate.".format(method))
    670 
    671     def _interpolate_with_fill(self, method='pad', axis=0, inplace=False,

ValueError: invalid method 'index' to interpolate.

In [70]: df.interpolate(method="values")
Out[70]: 
            0
0.0  1.000000
0.7  2.000000
1.1  2.121212
4.0  3.000000
```
