### PR TITLE
DOC: Cookbook recipe for emulating R's expand.grid() (#7426)

### DIFF
--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -663,3 +663,25 @@ To globally provide aliases for axis names, one can define these 2 functions:
    df2 = DataFrame(randn(3,2),columns=['c1','c2'],index=['i1','i2','i3'])
    df2.sum(axis='myaxis2')
    clear_axis_alias(DataFrame,'columns', 'myaxis2')
+
+Creating Example Data
+---------------------
+
+To create a dataframe from every combination of some given values, like R's ``expand.grid()``
+function, we can create a dict where the keys are column names and the values are lists
+of the data values:
+
+.. ipython:: python
+
+    import itertools
+
+    def expand_grid(data_dict):
+        rows = itertools.product(*data_dict.values())
+        return pd.DataFrame.from_records(rows, columns=data_dict.keys())
+
+    df = expand_grid(
+        {'height': [60, 70],
+         'weight': [100, 140, 180],
+         'sex': ['Male', 'Female']}
+    )
+    df


### PR DESCRIPTION
closes #7426 

As suggested by @jreback in #7426, I've added a quick cookbook recipe for emulating R's `expand.grid()`, which creates a dataframe from every combination of the values you give it.

None of the existing sections really seemed to apply, so I've added it in a new section.

Example usage:

``` python
import itertools
import pandas as pd

def expand_grid(data_dict):
    rows = itertools.product(*data_dict.values())
    return pd.DataFrame.from_records(rows, columns=data_dict.keys())

df = expand_grid(
    {'height': [60, 70],
     'weight': [100, 140, 180],
     'sex': ['Male', 'Female']}
)

df
Out[2]: 
       sex  weight  height
0     Male     100      60
1     Male     100      70
2     Male     140      60
3     Male     140      70
4     Male     180      60
5     Male     180      70
6   Female     100      60
7   Female     100      70
8   Female     140      60
9   Female     140      70
10  Female     180      60
11  Female     180      70
```
