### PR TITLE
TST: Remove else after except in tests for io.data.Options.

### DIFF
--- a/pandas/io/data.py
+++ b/pandas/io/data.py
@@ -680,6 +680,10 @@ class Options(object):
 
         root = self._parse_url(url)
         tables = root.xpath('.//table')
+        ntables = len(tables)
+        if ntables == 0:
+            raise RemoteDataError("No tables found at {0!r}".format(url))
+
         table_name = '_tables' + m1 + str(year)[-2:]
         setattr(self, table_name, tables)
 
@@ -723,9 +727,7 @@ class Options(object):
 
         ntables = len(tables)
         table_loc = self._TABLE_LOC[name]
-        if ntables == 0:
-            raise RemoteDataError("No tables found at {0!r}".format(url))
-        elif table_loc - 1 > ntables:
+        if table_loc - 1 > ntables:
             raise RemoteDataError("Table location {0} invalid, {1} tables"
                              " found".format(table_loc, ntables))
 

--- a/pandas/io/tests/test_data.py
+++ b/pandas/io/tests/test_data.py
@@ -266,8 +266,7 @@ class TestYahooOptions(tm.TestCase):
             options = self.aapl.get_options_data(expiry=self.expiry)
         except RemoteDataError as e:
             nose.SkipTest(e)
-        else:
-            assert len(options) > 1
+        self.assertTrue(len(options) > 1)
 
     @network
     def test_get_near_stock_price(self):
@@ -276,9 +275,6 @@ class TestYahooOptions(tm.TestCase):
                                                      expiry=self.expiry)
         except RemoteDataError as e:
             nose.SkipTest(e)
-        else:
-            assert len(options) > 1
-
         self.assertTrue(len(options) > 1)
 
     @network
@@ -287,8 +283,7 @@ class TestYahooOptions(tm.TestCase):
             calls = self.aapl.get_call_data(expiry=self.expiry)
         except RemoteDataError as e:
             nose.SkipTest(e)
-        else:
-            assert len(calls) > 1
+        self.assertTrue(len(calls) > 1)
 
     @network
     def test_get_put_data(self):
@@ -296,33 +291,30 @@ class TestYahooOptions(tm.TestCase):
             puts = self.aapl.get_put_data(expiry=self.expiry)
         except RemoteDataError as e:
             nose.SkipTest(e)
-        else:
-            assert len(puts) > 1
+        self.assertTrue(len(puts) > 1)
 
     @network
     def test_get_expiry_months(self):
         try:
             dates = self.aapl._get_expiry_months()
-        except RemoteDataError:
-            raise nose.SkipTest("RemoteDataError thrown no dates found")
+        except RemoteDataError as e:
+            raise nose.SkipTest(e)
         self.assertTrue(len(dates) > 1)
 
     @network
     def test_get_all_data(self):
         try:
             data = self.aapl.get_all_data(put=True)
-        except RemoteDataError:
-            raise nose.SkipTest("RemoteDataError thrown")
-
+        except RemoteDataError as e:
+            raise nose.SkipTest(e)
         self.assertTrue(len(data) > 1)
 
     @network
     def test_get_all_data_calls_only(self):
         try:
             data = self.aapl.get_all_data(call=True, put=False)
-        except RemoteDataError:
-            raise nose.SkipTest("RemoteDataError thrown")
-
+        except RemoteDataError as e:
+            raise nose.SkipTest(e)
         self.assertTrue(len(data) > 1)
 
     @network


### PR DESCRIPTION
Also moved no tables found error to get_options_tables method (url was not defined in the get_option_data method).

Fixes #7561
