### PR TITLE
BUG/PERF: perf issues in object groupby aggregations (GH7555)

### DIFF
--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1414,10 +1414,11 @@ class BaseGrouper(object):
         else:
             is_numeric = issubclass(values.dtype.type, (np.datetime64,
                                                         np.timedelta64))
-            out_dtype = 'float64'
             if is_numeric:
+                out_dtype = 'float64'
                 values = values.view('int64')
             else:
+                out_dtype = 'object'
                 values = values.astype(object)
 
         # will be filled in Cython function

--- a/pandas/src/generate_code.py
+++ b/pandas/src/generate_code.py
@@ -2234,7 +2234,7 @@ def generate_put_template(template, use_ints=True, use_floats=True,
     date_like_list = [
         ('int64', 'int64_t', 'float64_t', 'np.float64'),
     ]
-    object_list = [('object', 'object', 'float64_t', 'np.float64')]
+    object_list = [('object', 'object', 'object', 'np.object_')]
     function_list = []
     if use_floats:
         function_list.extend(floats_list)

--- a/pandas/src/generated.pyx
+++ b/pandas/src/generated.pyx
@@ -6697,7 +6697,7 @@ def group_count_float32(ndarray[float32_t, ndim=2] out,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def group_count_object(ndarray[float64_t, ndim=2] out,
+def group_count_object(ndarray[object, ndim=2] out,
                          ndarray[int64_t] counts,
                          ndarray[object, ndim=2] values,
                          ndarray[int64_t] labels):
@@ -6838,7 +6838,7 @@ def group_count_bin_float32(ndarray[float32_t, ndim=2] out,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def group_count_bin_object(ndarray[float64_t, ndim=2] out,
+def group_count_bin_object(ndarray[object, ndim=2] out,
                              ndarray[int64_t] counts,
                              ndarray[object, ndim=2] values,
                              ndarray[int64_t] bins):

--- a/vb_suite/groupby.py
+++ b/vb_suite/groupby.py
@@ -232,16 +232,22 @@ data2[1::3] = np.nan
 labels = labels.take(np.random.permutation(len(labels)))
 """
 
-groupby_first = Benchmark('data.groupby(labels).first()', setup,
+groupby_first_float64 = Benchmark('data.groupby(labels).first()', setup,
                           start_date=datetime(2012, 5, 1))
 
 groupby_first_float32 = Benchmark('data2.groupby(labels).first()', setup,
                                   start_date=datetime(2013, 1, 1))
 
-groupby_last = Benchmark('data.groupby(labels).last()', setup,
+groupby_last_float64 = Benchmark('data.groupby(labels).last()', setup,
                          start_date=datetime(2012, 5, 1))
 
 groupby_last_float32 = Benchmark('data2.groupby(labels).last()', setup,
+                                 start_date=datetime(2013, 1, 1))
+
+groupby_nth_float64 = Benchmark('data.groupby(labels).nth(0)', setup,
+                         start_date=datetime(2012, 5, 1))
+
+groupby_nth_float32 = Benchmark('data2.groupby(labels).nth(0)', setup,
                                  start_date=datetime(2013, 1, 1))
 
 # with datetimes (GH7555)
@@ -249,7 +255,23 @@ setup = common_setup + """
 df = DataFrame({'a' : date_range('1/1/2011',periods=100000,freq='s'),'b' : range(100000)})
 """
 
-groupby_mixed_first = Benchmark('df.groupby("b").first()', setup,
+groupby_first_datetimes = Benchmark('df.groupby("b").first()', setup,
+                                 start_date=datetime(2013, 5, 1))
+groupby_last_datetimes = Benchmark('df.groupby("b").last()', setup,
+                                 start_date=datetime(2013, 5, 1))
+groupby_nth_datetimes = Benchmark('df.groupby("b").nth(0)', setup,
+                                 start_date=datetime(2013, 5, 1))
+
+# with object
+setup = common_setup + """
+df = DataFrame({'a' : ['foo']*100000,'b' : range(100000)})
+"""
+
+groupby_first_object = Benchmark('df.groupby("b").first()', setup,
+                                 start_date=datetime(2013, 5, 1))
+groupby_last_object = Benchmark('df.groupby("b").last()', setup,
+                                 start_date=datetime(2013, 5, 1))
+groupby_nth_object = Benchmark('df.groupby("b").nth(0)', setup,
                                  start_date=datetime(2013, 5, 1))
 
 #----------------------------------------------------------------------


### PR DESCRIPTION
related #7555

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
groupby_object_last                          |  15.2340 | 4175.6846 |   0.0036 |
groupby_object_first                         |  15.6957 | 4166.6920 |   0.0038 |
groupby_transform_ufunc                      |   5.4990 |   5.7740 |   0.9524 |
groupby_indices                              |   6.7443 |   7.0153 |   0.9614 |
groupby_multi_different_functions            |  12.6866 |  12.9040 |   0.9832 |
groupby_multi_series_op                      |  13.2560 |  13.4466 |   0.9858 |
groupby_multi_cython                         |  15.0924 |  15.2720 |   0.9882 |
groupby_multi_different_numpy_functions      |  11.1883 |  11.2376 |   0.9956 |
groupby_first_float32                        |   3.4907 |   3.4963 |   0.9984 |
groupby_last_float32                         |   3.6677 |   3.6586 |   1.0025 |
groupby_frame_apply_overhead                 |   9.2754 |   9.2440 |   1.0034 |
groupby_first                                |   3.5706 |   3.5577 |   1.0036 |
groupby_pivot_table                          |  17.2007 |  17.1343 |   1.0039 |
groupby_transform                            | 174.6823 | 173.8520 |   1.0048 |
groupby_frame_singlekey_integer              |   2.4533 |   2.4397 |   1.0056 |
groupby_frame_nth                            |   2.7863 |   2.7630 |   1.0085 |
groupby_simple_compress_timing               |  35.6836 |  35.3360 |   1.0098 |
groupby_sum_booleans                         |   1.2880 |   1.2727 |   1.0121 |
groupby_transform2                           | 162.5650 | 160.2323 |   1.0146 |
groupby_apply_dict_return                    |  39.7460 |  39.1597 |   1.0150 |
groupby_multi_size                           |  23.2656 |  22.9087 |   1.0156 |
groupby_datetimes_last                       |  12.0660 |  11.8797 |   1.0157 |
groupby_series_simple_cython                 | 192.2614 | 188.9360 |   1.0176 |
groupby_last                                 |   3.8017 |   3.7254 |   1.0205 |
groupby_int_count                            |   4.6777 |   4.5680 |   1.0240 |
groupby_mixed_first                          |  12.3363 |  12.0014 |   1.0279 |
groupby_frame_median                         |   7.6403 |   7.4034 |   1.0320 |
groupby_frame_apply                          |  45.0197 |  43.6123 |   1.0323 |
groupby_object_nth                           | 430.5693 | 416.2673 |   1.0344 |
groupby_datetimes_nth                        | 428.6557 | 414.3833 |   1.0344 |
groupby_frame_cython_many_columns            |   4.3843 |   4.2194 |   1.0391 |
groupby_multi_python                         | 142.0707 | 135.8123 |   1.0461 |
groupby_nth_float32                          |  63.5343 |  59.9463 |   1.0599 |
groupby_nth_float64                          |  64.0316 |  59.8179 |   1.0704 |
groupby_multi_count                          |   9.0540 |   8.2114 |   1.1026 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [e28ec0d] : BUG/PERF: perf issues in object groupby aggregations (GH7555)
Base   [69bb0e8] : Merge pull request #7556 from onesandzeroes/expand-grid

DOC: Cookbook recipe for emulating R's expand.grid() (#7426)

```
