### PR TITLE
BUG: Error in rolling_var if window is larger than array, fixes #7297

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -271,6 +271,8 @@ Bug Fixes
 - Bug in non-monotonic ``Index.union`` may preserve ``name`` incorrectly (:issue:`7458`)
 - Bug in ``DatetimeIndex.intersection`` doesn't preserve timezone (:issue:`4690`)
 
+- Bug in ``rolling_var`` where a window larger than the array would raise an error(:issue:`7297`)
+
 - Bug with last plotted timeseries dictating ``xlim`` (:issue:`2960`)
 - Bug with ``secondary_y`` axis not being considered for timeseries ``xlim`` (:issue:`3490`)
 

--- a/pandas/stats/tests/test_moments.py
+++ b/pandas/stats/tests/test_moments.py
@@ -366,7 +366,8 @@ class TestMoments(tm.TestCase):
                        preserve_nan=True,
                        has_center=True,
                        fill_value=None,
-                       test_stable=False):
+                       test_stable=False,
+                       test_window=True):
 
         result = func(self.arr, window)
         assert_almost_equal(result[-1],
@@ -428,6 +429,27 @@ class TestMoments(tm.TestCase):
             result = func(self.arr + 1e9, window)
             assert_almost_equal(result[-1],
                                 static_comp(self.arr[-50:] + 1e9))
+
+        # Test window larger than array, #7297
+        if test_window:
+            if has_min_periods:
+                for minp in (0, len(self.arr)-1, len(self.arr)):
+                    result = func(self.arr, len(self.arr)+1, min_periods=minp)
+                    expected = func(self.arr, len(self.arr), min_periods=minp)
+                    nan_mask = np.isnan(result)
+                    self.assertTrue(np.array_equal(nan_mask,
+                                                   np.isnan(expected)))
+                    nan_mask = ~nan_mask
+                    assert_almost_equal(result[nan_mask], expected[nan_mask])
+            else:
+                result = func(self.arr, len(self.arr)+1)
+                expected = func(self.arr, len(self.arr))
+                nan_mask = np.isnan(result)
+                self.assertTrue(np.array_equal(nan_mask, np.isnan(expected)))
+                nan_mask = ~nan_mask
+                assert_almost_equal(result[nan_mask], expected[nan_mask])
+
+
 
 
     def _check_structures(self, func, static_comp,


### PR DESCRIPTION
fixes #7297

Other rolling window functions rely on the logic in `_check_minp`, and split the iteration into the ranges `[0, minp-1)` and `(minp-1, N)`. Because of the way `rolling_var` handles things, splitting the iteration into `[0, win)` and `(win, N)` makes more sense. Added also some comments as to what is going on elsewhere in the code.

No tests have been added, as @kdiether seems to have that very advanced.
