### PR TITLE
BUG/TST: fix tests for groupby nth on Series (GH7559)

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -173,6 +173,7 @@ Bug Fixes
 - Bug in setitem with list-of-lists and single vs mixed types (:issue:`7551`:)
 - Bug in timeops with non-aligned Series (:issue:`7500`)
 - Bug in timedelta inference when assigning an incomplete Series (:issue:`7592`)
+- Bug in groupby ``.nth`` with a Series and integer-like column name (:issue:`7559`)
 
 - Bug in ``value_counts`` where ``NaT`` did not qualify as missing (``NaN``) (:issue:`7423`)
 

--- a/vb_suite/groupby.py
+++ b/vb_suite/groupby.py
@@ -244,11 +244,14 @@ groupby_last_float64 = Benchmark('data.groupby(labels).last()', setup,
 groupby_last_float32 = Benchmark('data2.groupby(labels).last()', setup,
                                  start_date=datetime(2013, 1, 1))
 
-groupby_nth_float64 = Benchmark('data.groupby(labels).nth(0)', setup,
-                         start_date=datetime(2012, 5, 1))
-
-groupby_nth_float32 = Benchmark('data2.groupby(labels).nth(0)', setup,
-                                 start_date=datetime(2013, 1, 1))
+groupby_nth_float64_none = Benchmark('data.groupby(labels).nth(0)', setup,
+                                     start_date=datetime(2012, 5, 1))
+groupby_nth_float32_none = Benchmark('data2.groupby(labels).nth(0)', setup,
+                                     start_date=datetime(2013, 1, 1))
+groupby_nth_float64_any = Benchmark('data.groupby(labels).nth(0,dropna="all")', setup,
+                                     start_date=datetime(2012, 5, 1))
+groupby_nth_float32_any = Benchmark('data2.groupby(labels).nth(0,dropna="all")', setup,
+                                    start_date=datetime(2013, 1, 1))
 
 # with datetimes (GH7555)
 setup = common_setup + """
@@ -259,8 +262,10 @@ groupby_first_datetimes = Benchmark('df.groupby("b").first()', setup,
                                  start_date=datetime(2013, 5, 1))
 groupby_last_datetimes = Benchmark('df.groupby("b").last()', setup,
                                  start_date=datetime(2013, 5, 1))
-groupby_nth_datetimes = Benchmark('df.groupby("b").nth(0)', setup,
-                                 start_date=datetime(2013, 5, 1))
+groupby_nth_datetimes_none = Benchmark('df.groupby("b").nth(0)', setup,
+                                       start_date=datetime(2013, 5, 1))
+groupby_nth_datetimes_any = Benchmark('df.groupby("b").nth(0,dropna="all")', setup,
+                                      start_date=datetime(2013, 5, 1))
 
 # with object
 setup = common_setup + """
@@ -271,8 +276,10 @@ groupby_first_object = Benchmark('df.groupby("b").first()', setup,
                                  start_date=datetime(2013, 5, 1))
 groupby_last_object = Benchmark('df.groupby("b").last()', setup,
                                  start_date=datetime(2013, 5, 1))
-groupby_nth_object = Benchmark('df.groupby("b").nth(0)', setup,
-                                 start_date=datetime(2013, 5, 1))
+groupby_nth_object_none = Benchmark('df.groupby("b").nth(0)', setup,
+                                    start_date=datetime(2013, 5, 1))
+groupby_nth_object_any = Benchmark('df.groupby("b").nth(0,dropna="any")', setup,
+                                   start_date=datetime(2013, 5, 1))
 
 #----------------------------------------------------------------------
 # groupby_indices replacement, chop up Series
@@ -351,11 +358,16 @@ df = DataFrame(np.random.randint(1, 100, (10000, 2)))
 """
 
 # Not really a fair test as behaviour has changed!
-groupby_frame_nth = Benchmark("df.groupby(0).nth(0)", setup,
-                              start_date=datetime(2014, 3, 1))
+groupby_frame_nth_none = Benchmark("df.groupby(0).nth(0)", setup,
+                                   start_date=datetime(2014, 3, 1))
 
-groupby_series_nth = Benchmark("df[1].groupby(df[0]).nth(0)", setup,
-                               start_date=datetime(2014, 3, 1))
+groupby_series_nth_none = Benchmark("df[1].groupby(df[0]).nth(0)", setup,
+                                    start_date=datetime(2014, 3, 1))
+groupby_frame_nth_any= Benchmark("df.groupby(0).nth(0,dropna='any')", setup,
+                                 start_date=datetime(2014, 3, 1))
+
+groupby_series_nth_any = Benchmark("df[1].groupby(df[0]).nth(0,dropna='any')", setup,
+                                   start_date=datetime(2014, 3, 1))
 
 
 #----------------------------------------------------------------------


### PR DESCRIPTION
closes #7559 
related #7287

And some improvements when using any/all for nth
(still the nth are 10x slower than the cythonized first/last, but that's another issue)

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
groupby_nth_object_any                       | 503.6680 | 17163.4649 |   0.0293 |
groupby_nth_datetimes_any                    | 553.3033 | 13455.8423 |   0.0411 |
groupby_series_nth_any                       |   2.7003 |  26.1161 |   0.1034 |
groupby_frame_nth_any                        |   5.4483 |  15.4017 |   0.3537 |
groupby_multi_different_functions            |  11.3816 |  12.2033 |   0.9327 |
groupby_multi_different_numpy_functions      |  10.4934 |  11.1040 |   0.9450 |
groupby_object_nth                           | 397.3277 | 416.7441 |   0.9534 |
groupby_pivot_table                          |  16.2361 |  16.9867 |   0.9558 |
groupby_frame_apply_overhead                 |   8.8013 |   9.1234 |   0.9647 |
groupby_multi_python                         | 129.7946 | 133.2393 |   0.9741 |
groupby_apply_dict_return                    |  37.9413 |  38.7277 |   0.9797 |
groupby_frame_apply                          |  41.9403 |  42.6593 |   0.9831 |
groupby_object_first                         |  15.0506 |  15.2097 |   0.9895 |
groupby_frame_cython_many_columns            |   3.3430 |   3.3733 |   0.9910 |
groupby_nth_float64                          |  51.4960 |  51.9506 |   0.9912 |
groupby_frame_nth                            |   2.7520 |   2.7746 |   0.9918 |
groupby_multi_size                           |  21.6714 |  21.8496 |   0.9918 |
groupby_transform2                           | 159.0919 | 160.3904 |   0.9919 |
groupby_indices                              |   6.2350 |   6.2837 |   0.9923 |
groupby_multi_cython                         |  13.9600 |  14.0460 |   0.9939 |
groupby_frame_median                         |   6.1007 |   6.1367 |   0.9941 |
groupby_sum_booleans                         |   1.2400 |   1.2473 |   0.9941 |
groupby_datetimes_last                       |  10.7520 |  10.8067 |   0.9949 |
groupby_series_simple_cython                 | 178.8233 | 179.7036 |   0.9951 |
groupby_nth_float32                          |  52.6213 |  52.8786 |   0.9951 |
groupby_multi_series_op                      |  12.5150 |  12.5673 |   0.9958 |
groupby_transform                            | 166.5533 | 167.0943 |   0.9968 |
groupby_frame_singlekey_integer              |   2.3321 |   2.3394 |   0.9969 |
groupby_multi_count                          |   8.7133 |   8.7360 |   0.9974 |
groupby_last_float32                         |   3.5094 |   3.5140 |   0.9987 |
groupby_transform_ufunc                      |   6.1913 |   6.1987 |   0.9988 |
groupby_last                                 |   3.5419 |   3.5423 |   0.9999 |
groupby_first                                |   3.3600 |   3.3563 |   1.0011 |
groupby_object_last                          |  14.8129 |  14.7574 |   1.0038 |
groupby_int_count                            |   4.4247 |   4.4080 |   1.0038 |
groupby_first_float32                        |   3.3464 |   3.3300 |   1.0049 |
groupby_mixed_first                          |  10.9203 |  10.8653 |   1.0051 |
groupby_datetimes_nth                        | 445.6376 | 423.4857 |   1.0523 |
groupby_simple_compress_timing               |  33.8430 |  27.2744 |   1.2408 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [def0155] : BUG/TST: fix tests for groupby nth on Series (GH7559)
Base   [4082c1a] : Merge pull request #7593 from jreback/timedelta_nat

BUG: Bug in timedelta inference when assigning an incomplete Series (GH7592)
```
