### PR TITLE
BUG: DTI.freqstr raises AttributeError when freq is None

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -258,7 +258,7 @@ Bug Fixes
 - Bug in ``Index.astype(float)`` where it would return an ``object`` dtype
   ``Index`` (:issue:`7464`).
 - Bug in ``DataFrame.reset_index`` loses ``tz`` (:issue:`3950`)
-
+- Bug in ``DatetimeIndex.freqstr`` raises ``AttributeError`` when ``freq`` is ``None`` (:issue:`7606`)
 
 - Bug in non-monotonic ``Index.union`` may preserve ``name`` incorrectly (:issue:`7458`)
 - Bug in ``DatetimeIndex.intersection`` doesn't preserve timezone (:issue:`4690`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4311,12 +4311,8 @@ class DataFrame(NDFrame):
 
         axis = self._get_axis_number(axis)
         if axis == 0:
-            if freq is None:
-                freq = self.index.freqstr or self.index.inferred_freq
             new_data.set_axis(1, self.index.to_period(freq=freq))
         elif axis == 1:
-            if freq is None:
-                freq = self.columns.freqstr or self.columns.inferred_freq
             new_data.set_axis(0, self.columns.to_period(freq=freq))
         else:  # pragma: no cover
             raise AssertionError('Axis must be 0 or 1. Got %s' % str(axis))

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2374,8 +2374,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         if copy:
             new_values = new_values.copy()
 
-        if freq is None:
-            freq = self.index.freqstr or self.index.inferred_freq
         new_index = self.index.to_period(freq=freq)
         return self._constructor(new_values,
                                  index=new_index).__finalize__(self)


### PR DESCRIPTION
`DatetimeIndex.freqstr` raises `AttributeError` if `freq/offset` is `None`, even though docstring says "return the frequency object as a string if its set, otherwise None"

```
idx = pd.DatetimeIndex(['2011-01-01', '2011-01-02', '2011-01-03', '2011-01-04'])
idx.freqstr
# AttributeError: 'NoneType' object has no attribute 'freqstr'
```

Also,  `DataFrame/Series.to_period` has a logic to use `inferred_freq` when the freq is not passed, but it doesn't work actually because of the bug. Moved the logic to `DatetimeIndex.to_period` for consistency and made it works.

The fix will simplify #7602 a little.
