### PR TITLE
BUG: DatetimeIndex.delete with tz raises ValueError

### DIFF
--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1626,7 +1626,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
                     freq = self.freq
 
         if self.tz is not None:
-            new_dates = tslib.date_normalize(new_dates, self.tz)
+            new_dates = _tz_convert_with_transitions(new_dates, 'UTC', self.tz)
         return DatetimeIndex(new_dates, name=self.name, freq=freq, tz=self.tz)
 
     def _view_like(self, ndarray):


### PR DESCRIPTION
Found and fixed `DatetimeIndex.delete` (#7302) results in `ValueError` when it has `tz` and `freq` is less than daily..

```
idx = pd.date_range(start='2011-01-01 09:00', periods=40, freq='H', tz='Asia/Tokyo')
idx.delete(0)
# ValueError: Inferred frequency None from passed dates does notconform to passed frequency H
```

`insert` (#7299) and `take` don't have problems, but changed test case to use hourly frequencies to detect this kind of problem.
