### PR TITLE
BUG: PeriodIndex.min/max returns int

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -185,6 +185,7 @@ Bug Fixes
 - Bug in ``DatetimeIndex.asobject`` doesn't preserve ``name`` (:issue:`7299`)
 - Bug in multi-index slicing with datetimelike ranges (strings and Timestamps), (:issue:`7429`)
 - Bug in ``Index.min`` and ``max`` doesn't handle ``nan`` and ``NaT`` properly (:issue:`7261`)
+- Bug in ``PeriodIndex.min/max`` results in ``int`` (:issue:`7609`)
 - Bug in ``resample`` where ``fill_method`` was ignored if you passed ``how`` (:issue:`7261`)
 - Bug in ``TimeGrouper`` doesn't exclude column specified by ``key`` (:issue:`7227`)
 - Bug in ``DataFrame`` and ``Series`` bar and barh plot raises ``TypeError`` when ``bottom``

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -402,3 +402,34 @@ class DatetimeIndexOpsMixin(object):
         """
         return list(self.asobject)
 
+    def min(self, axis=None):
+        """
+        Overridden ndarray.min to return an object
+        """
+        import pandas.tslib as tslib
+        mask = self.asi8 == tslib.iNaT
+        masked = self[~mask]
+        if len(masked) == 0:
+            return self._na_value
+        elif self.is_monotonic:
+            return masked[0]
+        else:
+            min_stamp = masked.asi8.min()
+            return self._box_func(min_stamp)
+
+    def max(self, axis=None):
+        """
+        Overridden ndarray.max to return an object
+        """
+        import pandas.tslib as tslib
+        mask = self.asi8 == tslib.iNaT
+        masked = self[~mask]
+        if len(masked) == 0:
+            return self._na_value
+        elif self.is_monotonic:
+            return masked[-1]
+        else:
+            max_stamp = masked.asi8.max()
+            return self._box_func(max_stamp)
+
+

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1783,34 +1783,6 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
 
         return mask.nonzero()[0]
 
-    def min(self, axis=None):
-        """
-        Overridden ndarray.min to return a Timestamp
-        """
-        mask = self.asi8 == tslib.iNaT
-        masked = self[~mask]
-        if len(masked) == 0:
-            return tslib.NaT
-        elif self.is_monotonic:
-            return masked[0]
-        else:
-            min_stamp = masked.asi8.min()
-            return Timestamp(min_stamp, tz=self.tz)
-
-    def max(self, axis=None):
-        """
-        Overridden ndarray.max to return a Timestamp
-        """
-        mask = self.asi8 == tslib.iNaT
-        masked = self[~mask]
-        if len(masked) == 0:
-            return tslib.NaT
-        elif self.is_monotonic:
-            return masked[-1]
-        else:
-            max_stamp = masked.asi8.max()
-            return Timestamp(max_stamp, tz=self.tz)
-
     def to_julian_date(self):
         """
         Convert DatetimeIndex to Float64Index of Julian Dates.

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -712,6 +712,10 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
         result.freq = freq
         return result
 
+    @property
+    def _na_value(self):
+        return self._box_func(tslib.iNaT)
+
     def __contains__(self, key):
         if not isinstance(key, Period) or key.freq != self.freq:
             if isinstance(key, compat.string_types):


### PR DESCRIPTION
Related to #7279. `PeriodIndex.min/max` should return `Period` ignoring `NaT`.

```
pidx = pd.PeriodIndex(['2011-01', 'NaT'], freq='M')
pidx.min()
# -9223372036854775808
pidx.max()
#492
```
