### PR TITLE
BUG: Timestamp.__new__ doesnt preserve nanosecond

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -255,7 +255,7 @@ Bug Fixes
 
 - Bug in ``Timestamp.tz_localize`` resets ``nanosecond`` info (:issue:`7534`)
 - Bug in ``DatetimeIndex.asobject`` raises ``ValueError`` when it contains ``NaT`` (:issue:`7539`)
-
+- Bug in ``Timestamp.__new__`` doesn't preserve nanosecond properly (:issue:`7610`)
 
 - Bug in ``Index.astype(float)`` where it would return an ``object`` dtype
   ``Index`` (:issue:`7464`).

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -283,13 +283,47 @@ class TestTimestampNsOperations(tm.TestCase):
     def test_timedelta_us_arithmetic(self):
         self.assert_ns_timedelta(self.timestamp + np.timedelta64(-123, 'us'), -123000)
 
-    def test_timedelta_ns_arithmetic(self):
+    def test_timedelta_ms_arithmetic(self):
         time = self.timestamp + np.timedelta64(-123, 'ms')
         self.assert_ns_timedelta(time, -123000000)
 
     def test_nanosecond_string_parsing(self):
         self.timestamp = Timestamp('2013-05-01 07:15:45.123456789')
         self.assertEqual(self.timestamp.value, 1367392545123456000)
+
+    def test_nanosecond_timestamp(self):
+        # GH 7610
+        expected = 1293840000000000005
+        t = Timestamp('2011-01-01') + offsets.Nano(5)
+        self.assertEqual(repr(t), "Timestamp('2011-01-01 00:00:00.000000005')")
+        self.assertEqual(t.value, expected)
+        self.assertEqual(t.nanosecond, 5)
+
+        t = Timestamp(t)
+        self.assertEqual(repr(t), "Timestamp('2011-01-01 00:00:00.000000005')")
+        self.assertEqual(t.value, expected)
+        self.assertEqual(t.nanosecond, 5)
+
+        t = Timestamp(np.datetime64('2011-01-01 00:00:00.000000005Z'))
+        self.assertEqual(repr(t), "Timestamp('2011-01-01 00:00:00.000000005')")
+        self.assertEqual(t.value, expected)
+        self.assertEqual(t.nanosecond, 5)
+
+        expected = 1293840000000000010
+        t = t + offsets.Nano(5)
+        self.assertEqual(repr(t), "Timestamp('2011-01-01 00:00:00.000000010')")
+        self.assertEqual(t.value, expected)
+        self.assertEqual(t.nanosecond, 10)
+
+        t = Timestamp(t)
+        self.assertEqual(repr(t), "Timestamp('2011-01-01 00:00:00.000000010')")
+        self.assertEqual(t.value, expected)
+        self.assertEqual(t.nanosecond, 10)
+
+        t = Timestamp(np.datetime64('2011-01-01 00:00:00.000000010Z'))
+        self.assertEqual(repr(t), "Timestamp('2011-01-01 00:00:00.000000010')")
+        self.assertEqual(t.value, expected)
+        self.assertEqual(t.nanosecond, 10)
 
     def test_nat_arithmetic(self):
         # GH 6873

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -956,6 +956,7 @@ cdef convert_to_tsobject(object ts, object tz, object unit):
 
         if is_timestamp(ts):
             obj.value += ts.nanosecond
+            obj.dts.ps = ts.nanosecond * 1000
         _check_dts_bounds(&obj.dts)
         return obj
     elif PyDate_Check(ts):


### PR DESCRIPTION
When `Timestamp.__new__` accepts a timestamp with nanosecond, nanosecond is not preserved properly.

```
# create Timestamp with ns (OK)
t = pd.Timestamp('2011-01-01') + pd.offsets.Nano(5)
t, t.value
# (Timestamp('2011-01-01 00:00:00.000000005'), 1293840000000000005)

# If it is passed to Timestamp.__init__, ns is not displayed even though internal value includes it. (NG)
t = pd.Timestamp(t)
t, t.value
# (Timestamp('2011-01-01 00:00:00'), 1293840000000000005)

# If offset is added to above result, ns is displayed properly (OK)
t = t + pd.offsets.Nano(5)
t, t.value
# (Timestamp('2011-01-01 00:00:00.000000010'), 1293840000000000010)
```

NOTE: Unrelated to this issue, test_tslib had `test_timedelta_ns_arithmetic` method duplicatelly. Thus renamed.
