### PR TITLE
ENH: dataframe memory usage

### DIFF
--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -24,6 +24,81 @@ Frequently Asked Questions (FAQ)
    options.display.mpl_style='default'
    from pandas.compat import lrange
 
+
+.. _df-memory-usage:
+
+DataFrame memory usage
+~~~~~~~~~~~~~~~~~~~~~~
+As of pandas version 0.15.0, the memory usage of a dataframe (including
+the index) is shown when accessing the ``info`` method of a dataframe. A
+configuration option, ``display.memory_usage`` (see :ref:`options`),
+specifies if the dataframe's memory usage will be displayed when
+invoking the df.info() method.
+
+For example, the memory usage of the dataframe below is shown
+when calling df.info():
+
+.. ipython:: python
+
+    dtypes = ['int64', 'float64', 'datetime64[ns]', 'timedelta64[ns]',
+                'complex128', 'object', 'bool']
+    n = 5000
+    data = dict([ (t, np.random.randint(100, size=n).astype(t))
+                    for t in dtypes])
+    df = DataFrame(data)
+
+    df.info()
+
+By default the display option is set to True but can be explicitly
+overridden by passing the memory_usage argument when invoking df.info().
+Note that ``memory_usage=None`` is the default value for the  df.info()
+method and follows the setting specified by display.memory_usage.
+
+The memory usage of each column can be found by calling the ``memory_usage``
+method. This returns a Series with an index represented by column names
+and memory usage of each column shown in bytes. For the dataframe above,
+the memory usage of each column and the total memory usage of the
+dataframe can be found with the memory_usage method:
+
+.. ipython:: python
+
+    df.memory_usage()
+
+    # total memory usage of dataframe
+    df.memory_usage().sum()
+
+By default the memory usage of the dataframe's index is not shown in the
+returned Series, the memory usage of the index can be shown by passing
+the ``index=True`` argument:
+
+.. ipython:: python
+
+    df.memory_usage(index=True)
+
+The memory usage displayed by the ``info`` method utilizes the
+``memory_usage`` method to determine the memory usage of a dataframe
+while also formatting the output in human-readable units (base-2
+representation; i.e., 1KB = 1024 bytes).
+
+Pandas version 0.15.0 introduces a new categorical data type (see
+:ref:`categorical`), which can be used in Series and DataFrames.
+Significant memory savings can be achieved when using the category
+datatype. This is demonstrated below:
+
+.. ipython:: python
+
+  df['bases_object'] = Series(np.array(['adenine', 'cytosine', 'guanine', 'thymine']).take(np.random.randint(0,4,size=len(df))))
+
+  df['bases_categorical'] = df['bases_object'].astype('category')
+
+  df.memory_usage()
+
+While the *base_object* and *bases_categorical* appear as identical
+columns in the dataframe, the memory savings of the categorical
+datatype, versus the object datatype, is revealed by ``memory_usage``.
+
+
+
 .. _ref-monkey-patching:
 
 Adding Features to your pandas Installation

--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -348,6 +348,9 @@ display.max_seq_items      100          when pretty-printing a long sequence,
                                         of "..." to the resulting string.
                                         If set to None, the number of items
                                         to be printed is unlimited.
+display.memory_usage       True         This specifies if the memory usage of
+                                        a DataFrame should be displayed when the
+                                        df.info() method is invoked.
 display.mpl_style          None         Setting this to 'default' will modify
                                         the rcParams used by matplotlib
                                         to give plots a more pleasing visual

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -259,6 +259,16 @@ API changes
 
 - ``DataFrame.plot`` and ``Series.plot`` keywords are now have consistent orders (:issue:`8037`)
 
+- Implements methods to find memory usage of a DataFrame (:issue:`6852`). A new display option ``display.memory_usage`` (see :ref:`options`) sets the default behavior of the ``memory_usage`` argument in the ``df.info()`` method; by default ``display.memory_usage`` is True but this can be overridden by explicitly passing the memory_usage argument to the df.info() method, as shown below. Additionally `memory_usage` is an available method for a dataframe object which returns the memory usage of each column (for more information see :ref:`df-memory-usage`):
+
+  .. ipython:: python
+
+     df = DataFrame({ 'float' : np.random.randn(1000), 'int' : np.random.randint(0,5,size=1000)})
+     df.memory_usage()
+
+     df.info(memory_usage=True)
+
+
 .. _whatsnew_0150.dt:
 
 .dt accessor

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -203,6 +203,12 @@ pc_mpl_style_doc = """
     Setting this to None/False restores the values to their initial value.
 """
 
+pc_memory_usage_doc = """
+: bool or None
+    This specifies if the memory usage of a DataFrame should be displayed when
+    df.info() is called.
+"""
+
 style_backup = dict()
 
 
@@ -274,6 +280,8 @@ with cf.config_prefix('display'):
     # redirected to width, make defval identical
     cf.register_option('line_width', get_default_val('display.width'),
                        pc_line_width_doc)
+    cf.register_option('memory_usage', True, pc_memory_usage_doc,
+                        validator=is_instance_factory([type(None), bool]))
 
 cf.deprecate_option('display.line_width',
                     msg=pc_line_width_deprecation_warning,

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -43,7 +43,7 @@ def has_info_repr(df):
 def has_non_verbose_info_repr(df):
     has_info = has_info_repr(df)
     r = repr(df)
-    nv = len(r.split('\n')) == 5  # 1. <class>, 2. Index, 3. Columns, 4. dtype, 5. trailing newline
+    nv = len(r.split('\n')) == 6  # 1. <class>, 2. Index, 3. Columns, 4. dtype, 5. memory usage, 6. trailing newline
     return has_info and nv
 
 def has_horizontally_truncated_repr(df):


### PR DESCRIPTION
Closes [#6852](https://github.com/pydata/pandas/issues/6852)

For a sample DataFrame:

``` python
df = pd.DataFrame({ 'float' : np.random.randn(10000000), 'int' : np.random.randint(0,5,size=10000000), 'date' : Timestamp('20130101'), 'string' : 'foo', 'smallint' : np.random.randint(0,5,size=10000000).astype('int16') })
```

The memory usage of the elements of each column (in units of bytes) are returned by accessing the `meminfo` method. This returns a Series:

``` python
>>> df.meminfo()
date        80000000
float       80000000
int         80000000
smallint    20000000
string      80000000
dtype: int64
```

Also, the total memory usage (in a human readable format) can be found via the `info(memory_usage=True)` method:

``` python
>>> df.info(memory_usage=True)
<class 'pandas.core.frame.DataFrame'>
Int64Index: 10000000 entries, 0 to 9999999
Data columns (total 5 columns):
date        datetime64[ns]
float       float64
int         int64
smallint    int16
string      object
dtypes: datetime64[ns](1), float64(1), int16(1), int64(1), object(1)
memory usage: 324.2 MB
```
