### PR TITLE
PERF: optimize MultiIndex.from_product

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -145,7 +145,7 @@ Performance
 - Improvements in Series.transform for significant performance gains (:issue:`6496`)
 - Improvements in DataFrame.transform with ufuncs and built-in grouper functions for signifcant performance gains (:issue:`7383`)
 - Regression in groupby aggregation of datetime64 dtypes (:issue:`7555`)
-
+- Improvements in `MultiIndex.from_product` for large iterables (:issue:`7627`)
 
 
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -2875,10 +2875,14 @@ class MultiIndex(Index):
         MultiIndex.from_arrays : Convert list of arrays to MultiIndex
         MultiIndex.from_tuples : Convert list of tuples to MultiIndex
         """
+        from pandas.core.categorical import Categorical
         from pandas.tools.util import cartesian_product
-        product = cartesian_product(iterables)
-        return MultiIndex.from_arrays(product, sortorder=sortorder,
-                                      names=names)
+
+        categoricals = [Categorical.from_array(it) for it in iterables]
+        labels = cartesian_product([c.labels for c in categoricals])
+
+        return MultiIndex(levels=[c.levels for c in categoricals],
+                          labels=labels, sortorder=sortorder, names=names)
 
     @property
     def nlevels(self):

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -1861,6 +1861,15 @@ class TestMultiIndex(tm.TestCase):
         assert_array_equal(result, expected)
         self.assertEqual(result.names, names)
 
+    def test_from_product_datetimeindex(self):
+        dt_index = pd.date_range('2000-01-01', periods=2)
+        mi = pd.MultiIndex.from_product([[1, 2], dt_index])
+        etalon = pd.lib.list_to_object_array([(1, pd.Timestamp('2000-01-01')),
+                                              (1, pd.Timestamp('2000-01-02')),
+                                              (2, pd.Timestamp('2000-01-01')),
+                                              (2, pd.Timestamp('2000-01-02'))])
+        assert_array_equal(mi.values, etalon)
+
     def test_append(self):
         result = self.index[:3].append(self.index[3:])
         self.assertTrue(result.equals(self.index))

--- a/vb_suite/index_object.py
+++ b/vb_suite/index_object.py
@@ -105,3 +105,15 @@ index_float64_mul = Benchmark('idx * 2', setup, name='index_float64_mul',
                               start_date=datetime(2014, 4, 13))
 index_float64_div = Benchmark('idx / 2', setup, name='index_float64_div',
                               start_date=datetime(2014, 4, 13))
+
+
+# Constructing MultiIndex from cartesian product of iterables
+# 
+
+setup = common_setup + """
+iterables = [tm.makeStringIndex(10000), xrange(20)]
+"""
+
+multiindex_from_product = Benchmark('MultiIndex.from_product(iterables)',
+                                    setup, name='multiindex_from_product',
+                                    start_date=datetime(2014, 6, 30))


### PR DESCRIPTION
This PR speeds up MultiIndex.from_product employing the fact that operating on categorical codes is faster than on the values themselves.  

This yields about 2x improvement in the benchmark

``` python
In [1]: import pandas.util.testing as tm

In [2]: data = [tm.makeStringIndex(10000), tm.makeFloatIndex(20)]

In [3]: %timeit pd.MultiIndex.from_product(data)
100 loops, best of 3: 10.6 ms per loop

In [4]: %timeit pd.MultiIndex.from_arrays(pd.tools.util.cartesian_product(data))
10 loops, best of 3: 23.4 ms per loop
```

It's only marginally slower in small size cases:

``` python
In [1]: data = [np.arange(20).astype(object), np.arange(20)]

In [2]: %timeit pd.MultiIndex.from_product(data)
1000 loops, best of 3: 317 µs per loop

In [3]: %timeit pd.MultiIndex.from_arrays(pd.tools.util.cartesian_product(data))
1000 loops, best of 3: 308 µs per loop

In [4]: data_int = [np.arange(20), np.arange(20)]

In [5]: %timeit pd.MultiIndex.from_product(data_int)
1000 loops, best of 3: 285 µs per loop

In [6]: %timeit pd.MultiIndex.from_arrays(pd.tools.util.cartesian_product(data_int))
1000 loops, best of 3: 269 µs per loop
```

And this case came as a surprise because the cartesian product is blazingly fast both in old and new versions, but profiling showed that factorization is a lot faster when done on a smaller array:

``` python
In [7]: data_large = [np.arange(10000), np.arange(20)]

In [8]: %timeit pd.MultiIndex.from_arrays(pd.tools.util.cartesian_product(data_large))
100 loops, best of 3: 9.88 ms per loop

In [9]: %timeit pd.MultiIndex.from_product(data_large)
100 loops, best of 3: 2.74 ms per loop
```
