### PR TITLE
FIX: don't create 32 bit int type for int64 column (GH7433)

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -700,7 +700,8 @@ class PandasSQLTable(PandasObject):
                 pass  # this column not in results
 
     def _sqlalchemy_type(self, arr_or_dtype):
-        from sqlalchemy.types import Integer, Float, Text, Boolean, DateTime, Date, Interval
+        from sqlalchemy.types import (BigInteger, Float, Text, Boolean,
+            DateTime, Date, Interval)
 
         if arr_or_dtype is date:
             return Date
@@ -714,12 +715,12 @@ class PandasSQLTable(PandasObject):
             warnings.warn("the 'timedelta' type is not supported, and will be "
                           "written as integer values (ns frequency) to the "
                           "database.", UserWarning)
-            return Integer
+            return BigInteger
         elif com.is_float_dtype(arr_or_dtype):
             return Float
         elif com.is_integer_dtype(arr_or_dtype):
             # TODO: Refine integer size.
-            return Integer
+            return BigInteger
         elif com.is_bool(arr_or_dtype):
             return Boolean
         return Text

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -828,6 +828,14 @@ class _TestSQLAlchemy(PandasSQLTest):
         self.assertTrue(issubclass(df.BoolColWithNull.dtype.type, np.object),
                         "BoolColWithNull loaded with incorrect type")
 
+    def test_bigint(self):
+        # int64 should be converted to BigInteger, GH7433
+        df = DataFrame(data={'i64':[2**62]})
+        df.to_sql('test_bigint', self.conn, index=False)
+        result = sql.read_sql_table('test_bigint', self.conn)
+
+        tm.assert_frame_equal(df, result)
+
     def test_default_date_load(self):
         df = sql.read_sql_table("types_test_data", self.conn)
 


### PR DESCRIPTION
Closes #7433

Replace the sqlalchemy `Integer` type with `BigInteger` as the default integer type in pandas is int64. 
Probably we could be more specific in the type conversion (check for the exact integer type).
