### PR TITLE
API: disallow inplace setting with where and a non-np.nan value (GH7656)

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -24,11 +24,6 @@ users upgrade to this version.
 API changes
 ~~~~~~~~~~~
 
-
-
-
-
-
 - All ``offsets`` suppports ``normalize`` keyword to specify whether ``offsets.apply``, ``rollforward`` and ``rollback`` resets time (hour, minute, etc) or not (default ``False``, preserves time) (:issue:`7156`)
 
 
@@ -60,6 +55,8 @@ API changes
 
 - Bug in ``.loc`` performing fallback integer indexing with ``object`` dtype indices (:issue:`7496`)
 - Add back ``#N/A N/A`` as a default NA value in text parsing, (regresion from 0.12) (:issue:`5521`)
+- Raise a ``TypeError`` on inplace-setting with a ``.where`` and a non ``np.nan`` value as this is inconsistent
+  with a set-item expression like ``df[mask] = None`` (:issue:`7656`)
 
 .. _whatsnew_0141.prior_deprecations:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -679,8 +679,8 @@ class DataFrame(NDFrame):
         the defined table schema and column types. For simplicity, this method
         uses the Google BigQuery streaming API. The to_gbq method chunks data
         into a default chunk size of 10,000. Failures return the complete error
-        response which can be quite long depending on the size of the insert. 
-        There are several important limitations of the Google streaming API 
+        response which can be quite long depending on the size of the insert.
+        There are several important limitations of the Google streaming API
         which are detailed at:
         https://developers.google.com/bigquery/streaming-data-into-bigquery.
 
@@ -1925,11 +1925,7 @@ class DataFrame(NDFrame):
         if key.values.dtype != np.bool_:
             raise TypeError('Must pass DataFrame with boolean values only')
 
-        if self._is_mixed_type:
-            if not self._is_numeric_mixed_type:
-                raise TypeError(
-                    'Cannot do boolean setting on mixed-type frame')
-
+        self._check_inplace_setting(value)
         self._check_setitem_copy()
         self.where(-key, value, inplace=True)
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -9242,6 +9242,12 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         expected = DataFrame({'series': Series([0,1,2,3,4,5,6,7,np.nan,np.nan]) })
         assert_frame_equal(df, expected)
 
+        # GH 7656
+        df = DataFrame([{'A': 1, 'B': np.nan, 'C': 'Test'}, {'A': np.nan, 'B': 'Test', 'C': np.nan}])
+        expected = df.where(~isnull(df), None)
+        with tm.assertRaisesRegexp(TypeError, 'boolean setting on mixed-type'):
+            df.where(~isnull(df), None, inplace=True)
+
     def test_where_align(self):
 
         def create():


### PR DESCRIPTION
closes #7656 
