### PR TITLE
FIX: Scalar timedelta NaT results raise

### DIFF
--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -230,7 +230,9 @@ def _wrap_results(result, dtype):
             from pandas import Series
 
             # coerce float to results
-            if is_float(result):
+            if isnull(result):
+                result = tslib.NaT
+            elif is_float(result):
                 result = int(result)
             result = Series([result], dtype='timedelta64[ns]')
         else:

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -30,6 +30,8 @@ class TestnanopsDataFrame(tm.TestCase):
                                             self.arr_shape).astype('m8[ns]')
 
         self.arr_nan = np.tile(np.nan, self.arr_shape)
+        self.arr_datenat = np.tile(np.datetime64('NaT'), self.arr_shape)
+        self.arr_tdeltanat = np.tile(np.timedelta64('NaT'), self.arr_shape)
         self.arr_float_nan = np.vstack([self.arr_float, self.arr_nan])
         self.arr_float1_nan = np.vstack([self.arr_float1, self.arr_nan])
         self.arr_nan_float1 = np.vstack([self.arr_nan, self.arr_float1])
@@ -244,13 +246,18 @@ class TestnanopsDataFrame(tm.TestCase):
             else:
                 self.check_fun(testfunc, targfunc, 'arr_date', **kwargs)
                 objs += [self.arr_date.astype('O')]
+                if allow_all_nan:
+                    self.check_fun(testfunc, targfunc, 'arr_datenat',
+                                   **kwargs)
             try:
                 targfunc(self.arr_tdelta)
             except TypeError:
                 pass
             else:
                 self.check_fun(testfunc, targfunc, 'arr_tdelta', **kwargs)
-                objs += [self.arr_tdelta.astype('O')]
+                if allow_all_nan:
+                    self.check_fun(testfunc, targfunc, 'arr_tdeltanat',
+                                   **kwargs)
 
         if allow_obj:
             self.arr_obj = np.vstack(objs)
@@ -291,18 +298,15 @@ class TestnanopsDataFrame(tm.TestCase):
                         allow_all_nan=False, allow_str=False, allow_date=False)
 
     def test_nansum(self):
-        self.check_funs(nanops.nansum, np.sum,
-                        allow_str=False, allow_date=False)
+        self.check_funs(nanops.nansum, np.sum, allow_str=False)
 
     def test_nanmean(self):
-        self.check_funs(nanops.nanmean, np.mean,
-                        allow_complex=False, allow_obj=False,
-                        allow_str=False, allow_date=False)
+        self.check_funs(nanops.nanmean, np.mean, allow_complex=False,
+                        allow_obj=False, allow_str=False)
 
     def test_nanmedian(self):
-        self.check_funs(nanops.nanmedian, np.median,
-                        allow_complex=False, allow_str=False, allow_date=False,
-                        allow_obj='convert')
+        self.check_funs(nanops.nanmedian, np.median, allow_complex=False,
+                        allow_str=False, allow_obj='convert')
 
     def test_nanvar(self):
         self.check_funs_ddof(nanops.nanvar, np.var,
@@ -349,7 +353,6 @@ class TestnanopsDataFrame(tm.TestCase):
         func = partial(self._argminmax_wrap, func=np.argmin)
         if tm.sys.version_info[0:2] == (2, 6):
             self.check_funs(nanops.nanargmin, func,
-                            allow_date=False,
                             allow_str=False, allow_obj=False)
         else:
             self.check_funs(nanops.nanargmin, func,

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -5,6 +5,7 @@ from functools import partial
 import numpy as np
 
 from pandas.core.common import isnull
+from pandas.tslib import iNaT
 import pandas.core.nanops as nanops
 import pandas.util.testing as tm
 
@@ -30,9 +31,8 @@ class TestnanopsDataFrame(tm.TestCase):
                                             self.arr_shape).astype('m8[ns]')
 
         self.arr_nan = np.tile(np.nan, self.arr_shape)
-        self.arr_datenat = np.tile(np.datetime64('NaT', 'ns'), self.arr_shape)
-        self.arr_tdeltanat = np.tile(np.timedelta64('NaT', 'ns'),
-                                     self.arr_shape)
+        self.arr_datenat = np.tile(iNaT, self.arr_shape).astype('M8[ns]')
+        self.arr_tdeltanat = np.tile(iNaT, self.arr_shape).astype('m8[ns]')
         self.arr_float_nan = np.vstack([self.arr_float, self.arr_nan])
         self.arr_float1_nan = np.vstack([self.arr_float1, self.arr_nan])
         self.arr_nan_float1 = np.vstack([self.arr_nan, self.arr_float1])

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -30,8 +30,9 @@ class TestnanopsDataFrame(tm.TestCase):
                                             self.arr_shape).astype('m8[ns]')
 
         self.arr_nan = np.tile(np.nan, self.arr_shape)
-        self.arr_datenat = np.tile(np.datetime64('NaT'), self.arr_shape)
-        self.arr_tdeltanat = np.tile(np.timedelta64('NaT'), self.arr_shape)
+        self.arr_datenat = np.tile(np.datetime64('NaT', 'ns'), self.arr_shape)
+        self.arr_tdeltanat = np.tile(np.timedelta64('NaT', 'ns'),
+                                     self.arr_shape)
         self.arr_float_nan = np.vstack([self.arr_float, self.arr_nan])
         self.arr_float1_nan = np.vstack([self.arr_float1, self.arr_nan])
         self.arr_nan_float1 = np.vstack([self.arr_nan, self.arr_float1])

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -255,6 +255,7 @@ class TestnanopsDataFrame(tm.TestCase):
                 pass
             else:
                 self.check_fun(testfunc, targfunc, 'arr_tdelta', **kwargs)
+                objs += [self.arr_date.astype('O')]
                 if allow_all_nan:
                     self.check_fun(testfunc, targfunc, 'arr_tdeltanat',
                                    **kwargs)


### PR DESCRIPTION
Currently, coercion of scalar results from `float` to `timedelta64[ns]` passes through `int`, which raises when attempting to coerce `NaN` to `NaT`.

To reproduce:

``` python

import pandas as pd
import numpy as np
pd.Series([np.timedelta64('NaT')]).sum()
# TypeError: reduction operation 'sum' not allowed for this dtype
```
