### PR TITLE
(WIP) BUG/CLN: Better timeseries plotting / refactoring tsplot

### DIFF
--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -90,19 +90,16 @@ class TestTSPlot(tm.TestCase):
 
     @slow
     def test_tsplot(self):
-        from pandas.tseries.plotting import tsplot
         import matplotlib.pyplot as plt
 
         ax = plt.gca()
         ts = tm.makeTimeSeries()
 
-        f = lambda *args, **kwds: tsplot(s, plt.Axes.plot, *args, **kwds)
-
         for s in self.period_ser:
-            _check_plot_works(f, s.index.freq, ax=ax, series=s)
+            _check_plot_works(s.plot, ax=ax)
 
         for s in self.datetime_ser:
-            _check_plot_works(f, s.index.freq.rule_code, ax=ax, series=s)
+            _check_plot_works(s.plot, ax=ax)
 
         for s in self.period_ser:
             _check_plot_works(s.plot, ax=ax)
@@ -640,27 +637,35 @@ class TestTSPlot(tm.TestCase):
         self.assertEqual(axes[2].get_yaxis().get_ticks_position(), 'right')
 
     def test_mixed_freq_regular_first(self):
-        import matplotlib.pyplot as plt  # noqa
         s1 = tm.makeTimeSeries()
         s2 = s1[[0, 5, 10, 11, 12, 13, 14, 15]]
+        self.assertIsNone(s2.index.freq)
 
-        # it works!
-        s1.plot()
-
-        ax2 = s2.plot(style='g')
-        lines = ax2.get_lines()
-        idx1 = PeriodIndex(lines[0].get_xdata())
-        idx2 = PeriodIndex(lines[1].get_xdata())
+        # the result has PeriodIndex axis
+        ax1 = s1.plot()
+        lines1 = ax1.get_lines()
+        idx1 = PeriodIndex(lines1[0].get_xdata())
         self.assertTrue(idx1.equals(s1.index.to_period('B')))
-        self.assertTrue(idx2.equals(s2.index.to_period('B')))
-        left, right = ax2.get_xlim()
+        left, right = ax1.get_xlim()
         pidx = s1.index.to_period()
         self.assertEqual(left, pidx[0].ordinal)
         self.assertEqual(right, pidx[-1].ordinal)
 
+        # because s2 doesn't have freq, the result has x_compat axis
+        ax2 = s2.plot(style='g')
+        lines2 = ax2.get_lines()
+
+        exp = s1.index.to_pydatetime()
+        tm.assert_numpy_array_equal(lines2[0].get_xdata(), exp)
+        tm.assert_numpy_array_equal(lines2[1].get_xdata(),
+                                    s2.index.to_pydatetime())
+        left, right = ax2.get_xlim()
+        from matplotlib.dates import date2num
+        self.assertEqual(left, date2num(exp[0]))
+        self.assertEqual(right, date2num(exp[-1]))
+
     @slow
     def test_mixed_freq_irregular_first(self):
-        import matplotlib.pyplot as plt  # noqa
         s1 = tm.makeTimeSeries()
         s2 = s1[[0, 5, 10, 11, 12, 13, 14, 15]]
         s2.plot(style='g')
@@ -672,22 +677,33 @@ class TestTSPlot(tm.TestCase):
         x2 = lines[1].get_xdata()
         tm.assert_numpy_array_equal(x2, s1.index.asobject.values)
 
-    def test_mixed_freq_regular_first_df(self):
+    def test_aaamixed_freq_regular_first_df(self):
         # GH 9852
-        import matplotlib.pyplot as plt  # noqa
         s1 = tm.makeTimeSeries().to_frame()
         s2 = s1.iloc[[0, 5, 10, 11, 12, 13, 14, 15], :]
-        ax = s1.plot()
-        ax2 = s2.plot(style='g', ax=ax)
-        lines = ax2.get_lines()
-        idx1 = PeriodIndex(lines[0].get_xdata())
-        idx2 = PeriodIndex(lines[1].get_xdata())
+
+        # the result has PeriodIndex axis
+        ax1 = s1.plot()
+        lines1 = ax1.get_lines()
+        idx1 = PeriodIndex(lines1[0].get_xdata())
         self.assertTrue(idx1.equals(s1.index.to_period('B')))
-        self.assertTrue(idx2.equals(s2.index.to_period('B')))
-        left, right = ax2.get_xlim()
+        left, right = ax1.get_xlim()
         pidx = s1.index.to_period()
         self.assertEqual(left, pidx[0].ordinal)
         self.assertEqual(right, pidx[-1].ordinal)
+
+        # because s2 doesn't have freq, the result has x_compat axis
+        ax2 = s2.plot(style='g', ax=ax1)
+        lines2 = ax2.get_lines()
+
+        exp = s1.index.to_pydatetime()
+        tm.assert_numpy_array_equal(lines2[0].get_xdata(), exp)
+        tm.assert_numpy_array_equal(lines2[1].get_xdata(),
+                                    s2.index.to_pydatetime())
+        left, right = ax2.get_xlim()
+        from matplotlib.dates import date2num
+        self.assertEqual(left, date2num(exp[0]))
+        self.assertEqual(right, date2num(exp[-1]))
 
     @slow
     def test_mixed_freq_irregular_first_df(self):


### PR DESCRIPTION
Must be revisited after #7717.
#6608 seems to be solved by following 4 fixes.
- [ ] `PeriodIndex` should support the same freqs as `DatetimeIndex` (Related to #7222, maybe solved by #5148)
- [ ] Better logic to find common divisor frequency (try to use `tsplot` as much)
- [x] When plotting with `x_compat` to the `ax` which already holds `tsplot` lines, `tsplot` lines must be redrawn on `x_compat` coordinates.
  - [ ] Check whether `to_timestamp(how='e')` always revert `PeriodIndex` back to original `DatetimeIndex`
- [x] If target ax already holds `x_compat` lines, continuous plot should be drawn on `x_compat` coordinates (current version already have a logic, but cannot work if `ax` once have `freq` property).

Other refactoring:
- [x] Do not re-plot every row in `tsplot`
- [x] Simplify `LinePlot` flow (separated as #7717)
- [x] Store plot_func for line and area mixed time-series plot  (separated as #7733)

Result using current PR (modified #6608 a little to show legend).

```
s1 = pd.Series([1, 2, 3], index=[datetime.datetime(1995, 12, 31),
                                 datetime.datetime(2000, 12, 31),
                                 datetime.datetime(2005, 12, 31)], name='idx1')
s2 = pd.Series([1, 2, 3], index=[datetime.datetime(1997, 12, 31),
                                 datetime.datetime(2003, 12, 31),
                                 datetime.datetime(2008, 12, 31)], name='idx2')

ax = s1.plot(legend=True)
ax = s2.plot(legend=True)
s1.plot(ax=ax, legend=True)
```

![figure_1](https://cloud.githubusercontent.com/assets/1696302/3486598/477df0e8-0445-11e4-873b-dc619adaa92a.png)

One question is whether `tsplot` is categorized as public function? If so, I'll prepare separate func.
