### PR TITLE
DOC: remove mention of TimeSeries in docs

### DIFF
--- a/doc/source/dsintro.rst
+++ b/doc/source/dsintro.rst
@@ -577,10 +577,8 @@ row-wise. For example:
 
    df - df.iloc[0]
 
-In the special case of working with time series data, if the Series is a
-TimeSeries (which it will be automatically if the index contains datetime
-objects), and the DataFrame index also contains dates, the broadcasting will be
-column-wise:
+In the special case of working with time series data, and the DataFrame index
+also contains dates, the broadcasting will be column-wise:
 
 .. ipython:: python
    :okwarning:

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -207,9 +207,9 @@ properties. Here are the pandas equivalents:
 Frequency conversion
 ~~~~~~~~~~~~~~~~~~~~
 
-Frequency conversion is implemented using the ``resample`` method on TimeSeries
-and DataFrame objects (multiple time series). ``resample`` also works on panels
-(3D). Here is some code that resamples daily data to monthly:
+Frequency conversion is implemented using the ``resample`` method on Series
+and DataFrame objects with a DatetimeIndex or PeriodIndex. ``resample`` also
+works on panels (3D). Here is some code that resamples daily data to montly:
 
 .. ipython:: python
 
@@ -369,4 +369,3 @@ just a thin layer around the ``QTableView``.
 	    mw = MainWidget()
 	    mw.show()
 	    app.exec_()
-

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -9,7 +9,7 @@ Package overview
 :mod:`pandas` consists of the following things
 
  * A set of labeled array data structures, the primary of which are
-   Series/TimeSeries and DataFrame
+   Series and DataFrame
  * Index objects enabling both simple axis indexing and multi-level /
    hierarchical axis indexing
  * An integrated group by engine for aggregating and transforming data sets
@@ -32,7 +32,6 @@ Data structures at a glance
     :widths: 15, 20, 50
 
     1, Series, "1D labeled homogeneously-typed array"
-    1, TimeSeries, "Series with index containing datetimes"
     2, DataFrame, "General 2D labeled, size-mutable tabular structure with
     potentially heterogeneously-typed columns"
     3, Panel, "General 3D labeled, also size-mutable array"

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -1008,7 +1008,7 @@ Time series-related instance methods
 Shifting / lagging
 ~~~~~~~~~~~~~~~~~~
 
-One may want to *shift* or *lag* the values in a TimeSeries back and forward in
+One may want to *shift* or *lag* the values in a time series back and forward in
 time. The method for this is ``shift``, which is available on all of the pandas
 objects.
 
@@ -1026,7 +1026,7 @@ The shift method accepts an ``freq`` argument which can accept a
    ts.shift(5, freq='BM')
 
 Rather than changing the alignment of the data and the index, ``DataFrame`` and
-``TimeSeries`` objects also have a ``tshift`` convenience method that changes
+``Series`` objects also have a ``tshift`` convenience method that changes
 all the dates in the index by a specified number of offsets:
 
 .. ipython:: python
@@ -1569,7 +1569,7 @@ time zones using ``tz_convert``:
    rng_berlin[5]
    rng_eastern[5].tz_convert('Europe/Berlin')
 
-Localization of Timestamps functions just like DatetimeIndex and TimeSeries:
+Localization of Timestamps functions just like DatetimeIndex and Series:
 
 .. ipython:: python
 
@@ -1577,8 +1577,8 @@ Localization of Timestamps functions just like DatetimeIndex and TimeSeries:
    rng[5].tz_localize('Asia/Shanghai')
 
 
-Operations between TimeSeries in different time zones will yield UTC
-TimeSeries, aligning the data on the UTC timestamps:
+Operations between Series in different time zones will yield UTC
+Series, aligning the data on the UTC timestamps:
 
 .. ipython:: python
 


### PR DESCRIPTION
As a Series with a DatetimeIndex is no longer presented as a `TimeSeries`, I think we also should not longer mention it in the docs as a 'seperate object', so removed the last few mentions.
