### PR TITLE
PERF: improve resample perf

### DIFF
--- a/pandas/src/generate_code.py
+++ b/pandas/src/generate_code.py
@@ -1584,7 +1584,7 @@ def group_mean_bin_%(name)s(ndarray[%(dest_type2)s, ndim=2] out,
     for i in range(ngroups):
         for j in range(K):
             count = nobs[i, j]
-            if nobs[i, j] == 0:
+            if count == 0:
                 out[i, j] = nan
             else:
                 out[i, j] = sumx[i, j] / count

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -152,7 +152,8 @@ class TimeGrouper(Grouper):
             binner = labels = DatetimeIndex(data=[], freq=self.freq, name=ax.name)
             return binner, [], labels
 
-        first, last = _get_range_edges(ax, self.freq, closed=self.closed,
+        first, last = ax.min(), ax.max()
+        first, last = _get_range_edges(first, last, self.freq, closed=self.closed,
                                        base=self.base)
         tz = ax.tz
         binner = labels = DatetimeIndex(freq=self.freq,
@@ -163,7 +164,7 @@ class TimeGrouper(Grouper):
 
         # a little hack
         trimmed = False
-        if (len(binner) > 2 and binner[-2] == ax.max() and
+        if (len(binner) > 2 and binner[-2] == last and
                 self.closed == 'right'):
 
             binner = binner[:-1]
@@ -353,11 +354,10 @@ def _take_new_index(obj, indexer, new_index, axis=0):
         raise NotImplementedError
 
 
-def _get_range_edges(axis, offset, closed='left', base=0):
+def _get_range_edges(first, last, offset, closed='left', base=0):
     if isinstance(offset, compat.string_types):
         offset = to_offset(offset)
 
-    first, last = axis.min(), axis.max()
     if isinstance(offset, Tick):
         day_nanos = _delta_to_nanoseconds(timedelta(1))
         # #1165

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -3134,14 +3134,21 @@ def period_asfreq_arr(ndarray[int64_t] arr, int freq1, int freq2, bint end):
     else:
         relation = START
 
-    for i in range(n):
-        if arr[i] == iNaT:
-            result[i] = iNaT
-            continue
-        val = func(arr[i], relation, &finfo)
-        if val == INT32_MIN:
-            raise ValueError("Unable to convert to desired frequency.")
-        result[i] = val
+    mask = arr == iNaT
+    if mask.any():      # NaT process
+        for i in range(n):
+            val = arr[i]
+            if val != iNaT:
+                val = func(val, relation, &finfo)
+                if val == INT32_MIN:
+                    raise ValueError("Unable to convert to desired frequency.")
+            result[i] = val
+    else:
+        for i in range(n):
+            val = func(arr[i], relation, &finfo)
+            if val == INT32_MIN:
+                raise ValueError("Unable to convert to desired frequency.")
+            result[i] = val
 
     return result
 


### PR DESCRIPTION
Related to #7633. It gets better than the result attached #7633, but still slower more than 1.2 times compared to 1.4.0

Modified:
- Avoid every time module `import` in `Index.max/min` 
- Avoid duplicated `max` call from `resample/_get_time_bins` and `_get_range_edges`.
- Optimize `lib/generate_bins_dt64` and `tslib/period_asfreq_arr`.

Remaining bottlenecks are `NaT` masking performed in `lib/generate_bins_dt64` and `tslib/period_asfreq_arr`. Is there any better way to do that?

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
dataframe_resample_mean_numpy                |   4.9963 |   3.7940 |   1.3169 |
dataframe_resample_mean_string               |   5.0424 |   3.8280 |   1.3172 |
dataframe_resample_max_numpy                 |   4.1796 |   3.0069 |   1.3900 |
dataframe_resample_min_numpy                 |   4.2127 |   2.9987 |   1.4049 |
dataframe_resample_min_string                |   4.1687 |   2.9490 |   1.4136 |
dataframe_resample_max_string                |   4.3443 |   2.9283 |   1.4835 |
timeseries_timestamp_downsample_mean         |  16.1959 |   8.6366 |   1.8753 |
timeseries_period_downsample_mean            |  47.6096 |  19.7030 |   2.4164 |
-------------------------------------------------------------------------------


Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [54fb875] : PERF: Improve index.min and max perf
Base   [da0f7ae] : RLS: 0.14.0 final
```
