### PR TITLE
DOC: remove extra spaces from option descriptions 

### DIFF
--- a/pandas/core/config.py
+++ b/pandas/core/config.py
@@ -334,8 +334,8 @@ Available options:
 
 Parameters
 ----------
-pat : str/regex 
-    If specified only options matching `prefix*` will be reset. 
+pat : str/regex
+    If specified only options matching `prefix*` will be reset.
     Note: partial matches are supported for convenience, but unless you
     use the full option name (e.g. x.y.z.option_name), your code may break
     in future versions if new options with similar names are introduced.
@@ -368,7 +368,7 @@ class option_context(object):
     Context manager to temporarily set options in the `with` statement context.
 
     You need to invoke as ``option_context(pat, val, [(pat, val), ...])``.
-    
+
     Examples
     --------
 
@@ -628,20 +628,21 @@ def _build_option_description(k):
     o = _get_registered_option(k)
     d = _get_deprecated_option(k)
 
-    s = u('%s : ') % k
-    if o:
-        s += u('[default: %s] [currently: %s]') % (o.defval,
-                                                   _get_option(k, True))
+    s = u('%s ') % k
 
     if o.doc:
-        s += '\n    '.join(o.doc.strip().split('\n'))
+        s += '\n'.join(o.doc.strip().split('\n'))
     else:
-        s += 'No description available.\n'
+        s += 'No description available.'
+
+    if o:
+        s += u('\n    [default: %s] [currently: %s]') % (o.defval,
+                                                         _get_option(k, True))
 
     if d:
         s += u('\n\t(Deprecated')
         s += (u(', use `%s` instead.') % d.rkey if d.rkey else '')
-        s += u(')\n')
+        s += u(')')
 
     s += '\n\n'
     return s


### PR DESCRIPTION
There are already 4 spaces in the description strings in config_init.py, so no need to add some more. 
This caused the descriptions to be longer than 79 characters, and so line wrapping in the terminal. Closes #6838.

Plus, moved the default and current values to the last line of the description as proposed by @jseabold 

Example output now is:

```
display.max_colwidth : int
    The maximum width in characters of a column in the repr of
    a pandas data structure. When the column overflows, a "..."
    placeholder is embedded in the output.
    [default: 50] [currently: 50]

display.max_info_columns : int
    max_info_columns is used in DataFrame.info method to decide if
    per column information will be printed.
    [default: 100] [currently: 100]
```

Previous in 0.14 this was:

```
display.max_colwidth : [default: 50] [currently: 50]: int
        The maximum width in characters of a column in the repr of
        a pandas data structure. When the column overflows, a "..."
        placeholder is embedded in the output.

display.max_info_columns : [default: 100] [currently: 100]: int
        max_info_columns is used in DataFrame.info method to decide if
        per column information will be printed.
```

Before 0.14 it was worse (as reported in #6838), but I already improved it a bit some time ago.
