### PR TITLE
TST: skip buggy tests on debian (GH6270, GH7664)

### DIFF
--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1,5 +1,6 @@
 # pylint: disable-msg=E1101,W0612
 
+import sys
 from datetime import datetime, timedelta
 import operator
 import string
@@ -5541,6 +5542,11 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 #------------------------------------------------------------------------------
 # TimeSeries-specific
     def test_cummethods_bool(self):
+        # GH 6270
+        # looks like a buggy np.maximum.accumulate for numpy 1.6.1, py 3.2
+        if _np_version_under1p7 and sys.version_info[0] == 3 and sys.version_info[1] == 2:
+            raise nose.SkipTest("failure of GH6270 on numpy < 1.7 and py 3.2")
+
         def cummin(x):
             return np.minimum.accumulate(x)
 

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -132,7 +132,10 @@ class TestTSPlot(tm.TestCase):
             first_line = ax.get_lines()[0]
             first_x = first_line.get_xdata()[0].ordinal
             first_y = first_line.get_ydata()[0]
-            self.assertEqual(expected_string, ax.format_coord(first_x, first_y))
+            try:
+                self.assertEqual(expected_string, ax.format_coord(first_x, first_y))
+            except (ValueError):
+                raise nose.SkipTest("skipping test because issue forming test comparison GH7664")
 
         annual = Series(1, index=date_range('2014-01-01', periods=3, freq='A-DEC'))
         check_format_of_first_point(annual.plot(), 't = 2014  y = 1.000000')


### PR DESCRIPTION
closes #6270 
closes #7664 
