### PR TITLE
FIX: to_sql takes the boolean column as text column

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -280,3 +280,5 @@ Bug Fixes
 - Bug in ``pandas.core.strings.str_contains`` does not properly match in a case insensitive fashion when ``regex=False`` and ``case=False`` (:issue:`7505`)
 
 - Bug in ``expanding_cov``, ``expanding_corr``, ``rolling_cov``, and ``rolling_corr`` for two arguments with mismatched index  (:issue:`7512`)
+
+- Bug in ``to_sql`` taking the boolean column as text column (:issue:`7678`)

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -733,7 +733,7 @@ class PandasSQLTable(PandasObject):
         elif com.is_integer_dtype(arr_or_dtype):
             # TODO: Refine integer size.
             return BigInteger
-        elif com.is_bool(arr_or_dtype):
+        elif com.is_bool_dtype(arr_or_dtype):
             return Boolean
         return Text
 


### PR DESCRIPTION
In the original code, `com.is_bool(arr_or_dtype)` checks whether `arr_or_dtype` is a boolean value instead of a boolean dtype.

A new function `is_bool_dtype` is added to `pandas.core.common` to fix this bug.
