### PR TITLE
PERF: better perf on min/max on indices not containing NaT for DatetimeIndex/PeriodsIndex 

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -6,7 +6,7 @@ import numpy as np
 from pandas.core import common as com
 import pandas.core.nanops as nanops
 import pandas.tslib as tslib
-
+from pandas.util.decorators import cache_readonly
 
 class StringMixin(object):
 
@@ -392,6 +392,11 @@ class DatetimeIndexOpsMixin(object):
         import pandas.lib as lib
         return lib.map_infer(values, self._box_func)
 
+    @cache_readonly
+    def hasnans(self):
+        """ return if I have any nans; enables various perf speedups """
+        return (self.asi8 == tslib.iNaT).any()
+
     @property
     def asobject(self):
         from pandas.core.index import Index
@@ -408,11 +413,18 @@ class DatetimeIndexOpsMixin(object):
         Overridden ndarray.min to return an object
         """
         try:
-            mask = self.asi8 == tslib.iNaT
-            if mask.any():
+            i8 = self.asi8
+
+            # quick check
+            if len(i8) and self.is_monotonic:
+                if i8[0] != tslib.iNaT:
+                    return self._box_func(i8[0])
+
+            if self.hasnans:
+                mask = i8 == tslib.iNaT
                 min_stamp = self[~mask].asi8.min()
             else:
-                min_stamp = self.asi8.min()
+                min_stamp = i8.min()
             return self._box_func(min_stamp)
         except ValueError:
             return self._na_value
@@ -422,11 +434,18 @@ class DatetimeIndexOpsMixin(object):
         Overridden ndarray.max to return an object
         """
         try:
-            mask = self.asi8 == tslib.iNaT
-            if mask.any():
+            i8 = self.asi8
+
+            # quick check
+            if len(i8) and self.is_monotonic:
+                if i8[-1] != tslib.iNaT:
+                    return self._box_func(i8[-1])
+
+            if self.hasnans:
+                mask = i8 == tslib.iNaT
                 max_stamp = self[~mask].asi8.max()
             else:
-                max_stamp = self.asi8.max()
+                max_stamp = i8.max()
             return self._box_func(max_stamp)
         except ValueError:
             return self._na_value

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -2072,7 +2072,7 @@ class Float64Index(Index):
 
         try:
             # if other is a sequence this throws a ValueError
-            return np.isnan(other) and self._hasnans
+            return np.isnan(other) and self.hasnans
         except ValueError:
             try:
                 return len(other) <= 1 and _try_get_item(other) in self
@@ -2109,7 +2109,7 @@ class Float64Index(Index):
         return np.isnan(self.values)
 
     @cache_readonly
-    def _hasnans(self):
+    def hasnans(self):
         return self._isnan.any()
 
     @cache_readonly

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -958,7 +958,7 @@ def is_lexsorted(list list_of_arrays):
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def generate_bins_dt64(ndarray[int64_t] values, ndarray[int64_t] binner,
-                       object closed='left'):
+                       object closed='left', bint hasnans=0):
     """
     Int64 (datetime64) version of generic python version in groupby.py
     """
@@ -968,9 +968,9 @@ def generate_bins_dt64(ndarray[int64_t] values, ndarray[int64_t] binner,
         int64_t l_bin, r_bin, nat_count
         bint right_closed = closed == 'right'
 
-    mask = values == iNaT
     nat_count = 0
-    if mask.any():
+    if hasnans:
+        mask = values == iNaT
         nat_count = np.sum(mask)
         values = values[~mask]
 

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -174,7 +174,7 @@ class TimeGrouper(Grouper):
         binner, bin_edges = self._adjust_bin_edges(binner, ax_values)
 
         # general version, knowing nothing about relative frequencies
-        bins = lib.generate_bins_dt64(ax_values, bin_edges, self.closed)
+        bins = lib.generate_bins_dt64(ax_values, bin_edges, self.closed, hasnans=ax.hasnans)
 
         if self.closed == 'right':
             labels = binner
@@ -188,7 +188,7 @@ class TimeGrouper(Grouper):
             elif not trimmed:
                 labels = labels[:-1]
 
-        if (ax_values == tslib.iNaT).any():
+        if ax.hasnans:
             binner = binner.insert(0, tslib.NaT)
             labels = labels.insert(0, tslib.NaT)
 


### PR DESCRIPTION
closes #7633

close to what it was in 0.14.0
key was to not keep recomputing whether an index `hasnans` every time we need it (it is now cached).
further `min/max` are optimized if the index is monotonic

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
timeseries_timestamp_downsample_mean         |   4.5697 |   7.8034 |   0.5856 |
dataframe_resample_min_string                |   1.8380 |   2.5294 |   0.7266 |
dataframe_resample_min_numpy                 |   1.8580 |   2.5463 |   0.7297 |
dataframe_resample_max_numpy                 |   1.8887 |   2.5803 |   0.7320 |
dataframe_resample_max_string                |   1.9130 |   2.5553 |   0.7486 |
dataframe_resample_mean_numpy                |   2.6687 |   3.3340 |   0.8004 |
dataframe_resample_mean_string               |   2.7773 |   3.3080 |   0.8396 |
timeseries_period_downsample_mean            |  12.2183 |  11.6010 |   1.0532 |

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [d2d30c7] : PERF: better perf on min/max on indices not containing NaT for DatetimeIndex/PeriodIndex
Base   [e060616] : DOC: minor corrections in v0.14.1
```
