### PR TITLE
TST/CLN: centralize numpy < 1.7 skips

### DIFF
--- a/pandas/io/tests/test_json/test_pandas.py
+++ b/pandas/io/tests/test_json/test_pandas.py
@@ -5,7 +5,7 @@ import os
 
 import numpy as np
 import nose
-from pandas import Series, DataFrame, DatetimeIndex, Timestamp, _np_version_under1p7
+from pandas import Series, DataFrame, DatetimeIndex, Timestamp
 import pandas as pd
 read_json = pd.read_json
 
@@ -601,8 +601,7 @@ class TestPandasContainer(tm.TestCase):
             self.assertEqual(result[c].dtype, 'datetime64[ns]')
 
     def test_timedelta(self):
-        if _np_version_under1p7:
-            raise nose.SkipTest("numpy < 1.7")
+        tm._skip_if_not_numpy17_friendly()
 
         from datetime import timedelta
         converter = lambda x: pd.to_timedelta(x,unit='ms')

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -2061,11 +2061,7 @@ class TestHDFStore(tm.TestCase):
     def test_append_with_timezones_dateutil(self):
 
         from datetime import timedelta
-
-        try:
-            import dateutil
-        except ImportError:
-            raise nose.SkipTest
+        tm._skip_if_no_dateutil()
 
         # use maybe_get_tz instead of dateutil.tz.gettz to handle the windows filename issues.
         from pandas.tslib import maybe_get_tz
@@ -2186,8 +2182,7 @@ class TestHDFStore(tm.TestCase):
             setTZ(orig_tz)
 
     def test_append_with_timedelta(self):
-        if _np_version_under1p7:
-            raise nose.SkipTest("requires numpy >= 1.7")
+        tm._skip_if_not_numpy17_friendly()
 
         # GH 3577
         # append timedelta

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -509,8 +509,7 @@ class _TestSQLApi(PandasSQLTest):
 
     def test_timedelta(self):
         # see #6921
-        if _np_version_under1p7:
-            raise nose.SkipTest("test only valid in numpy >= 1.7")
+        tm._skip_if_not_numpy17_friendly()
 
         df = to_timedelta(Series(['00:00:01', '00:00:03'], name='foo')).to_frame()
         with tm.assert_produces_warning(UserWarning):
@@ -659,7 +658,7 @@ class TestSQLApi(_TestSQLApi):
         self.conn.execute(qry)
         qry = """CREATE TABLE other_table (x INTEGER, y INTEGER);"""
         self.conn.execute(qry)
-        
+
         with warnings.catch_warnings(record=True) as w:
             # Cause all warnings to always be triggered.
             warnings.simplefilter("always")

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -198,8 +198,7 @@ class TestIndexOps(Ops):
         self.not_valid_objs = [ o for o in self.objs if not o._allow_index_ops ]
 
     def test_ops(self):
-        if _np_version_under1p7:
-            raise nose.SkipTest("test only valid in numpy >= 1.7")
+        tm._skip_if_not_numpy17_friendly()
         for op in ['max','min']:
             for o in self.objs:
                 result = getattr(o,op)()

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -80,13 +80,6 @@ def has_expanded_repr(df):
             return True
     return False
 
-def skip_if_np_version_under1p7():
-    if _np_version_under1p7:
-        import nose
-
-        raise nose.SkipTest('numpy >= 1.7 required')
-
-
 class TestDataFrameFormatting(tm.TestCase):
     _multiprocess_can_split_ = True
 
@@ -2736,7 +2729,7 @@ class TestFloatArrayFormatter(tm.TestCase):
 class TestRepr_timedelta64(tm.TestCase):
     @classmethod
     def setUpClass(cls):
-        skip_if_np_version_under1p7()
+        tm._skip_if_not_numpy17_friendly()
 
     def test_legacy(self):
         delta_1d = pd.to_timedelta(1, unit='D')
@@ -2784,7 +2777,7 @@ class TestRepr_timedelta64(tm.TestCase):
 class TestTimedelta64Formatter(tm.TestCase):
     @classmethod
     def setUpClass(cls):
-        skip_if_np_version_under1p7()
+        tm._skip_if_not_numpy17_friendly()
 
     def test_mixed(self):
         x = pd.to_timedelta(list(range(5)) + [pd.NaT], unit='D')

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -32,8 +32,7 @@ import pandas.core.common as com
 import pandas.core.format as fmt
 import pandas.core.datetools as datetools
 from pandas import (DataFrame, Index, Series, notnull, isnull,
-                    MultiIndex, DatetimeIndex, Timestamp, date_range, read_csv,
-                    _np_version_under1p7)
+                    MultiIndex, DatetimeIndex, Timestamp, date_range, read_csv)
 import pandas as pd
 from pandas.parser import CParserError
 from pandas.util.misc import is_little_endian
@@ -3772,8 +3771,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.assertTrue(df['off2'].dtype == 'timedelta64[ns]')
 
     def test_datetimelike_setitem_with_inference(self):
-        if _np_version_under1p7:
-            raise nose.SkipTest("numpy < 1.7")
+        tm._skip_if_not_numpy17_friendly()
 
         # GH 7592
         # assignment of timedeltas with NaT
@@ -13036,6 +13034,7 @@ starting,ending,measure
         tm.assert_frame_equal(r, e)
 
     def test_select_dtypes_not_an_attr_but_still_valid_dtype(self):
+        tm._skip_if_not_numpy17_friendly()
         df = DataFrame({'a': list('abc'),
                         'b': list(range(1, 4)),
                         'c': np.arange(3, 6).astype('u1'),

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -7,7 +7,7 @@ from numpy import nan
 import pandas as pd
 
 from pandas import (Index, Series, DataFrame, Panel,
-                    isnull, notnull,date_range, _np_version_under1p7)
+                    isnull, notnull,date_range)
 from pandas.core.index import Index, MultiIndex
 
 import pandas.core.common as com
@@ -160,8 +160,7 @@ class Generic(object):
         self.assertRaises(ValueError, lambda : not obj1)
 
     def test_numpy_1_7_compat_numeric_methods(self):
-        if _np_version_under1p7:
-            raise nose.SkipTest("numpy < 1.7")
+        tm._skip_if_not_numpy17_friendly()
 
         # GH 4435
         # numpy in 1.7 tries to pass addtional arguments to pandas functions

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -32,11 +32,6 @@ from pandas.lib import Timestamp
 
 from pandas import _np_version_under1p7
 
-def _skip_if_need_numpy_1_7():
-    if _np_version_under1p7:
-        raise nose.SkipTest('numpy >= 1.7 required')
-
-
 class TestIndex(tm.TestCase):
     _multiprocess_can_split_ = True
 
@@ -340,7 +335,7 @@ class TestIndex(tm.TestCase):
         tm.assert_isinstance(self.dateIndex.asof(d), Timestamp)
 
     def test_nanosecond_index_access(self):
-        _skip_if_need_numpy_1_7()
+        tm._skip_if_not_numpy17_friendly()
 
         s = Series([Timestamp('20130101')]).values.view('i8')[0]
         r = DatetimeIndex([s + 50 + i for i in range(100)])

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -2721,8 +2721,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
                 self.assertRaises(TypeError, sop, s2.values)
 
     def test_timedelta64_conversions(self):
-        if _np_version_under1p7:
-            raise nose.SkipTest("cannot use 2 argument form of timedelta64 conversions with numpy < 1.7")
+        tm._skip_if_not_numpy17_friendly()
 
         startdate = Series(date_range('2013-01-01', '2013-01-03'))
         enddate = Series(date_range('2013-03-01', '2013-03-03'))
@@ -2835,8 +2834,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         dt1 + td1
 
     def test_ops_datetimelike_align(self):
-        if _np_version_under1p7:
-            raise nose.SkipTest("timedelta broken in np < 1.7")
+        tm._skip_if_not_numpy17_friendly()
 
         # GH 7500
         # datetimelike ops need to align
@@ -2899,8 +2897,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         assert_series_equal(result, expected)
 
     def test_timedelta_fillna(self):
-        if _np_version_under1p7:
-            raise nose.SkipTest("timedelta broken in np 1.6.1")
+        tm._skip_if_not_numpy17_friendly()
 
         #GH 3371
         s = Series([Timestamp('20130101'), Timestamp('20130101'),
@@ -3107,8 +3104,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         assert_series_equal(ts.bfill(), ts.fillna(method='bfill'))
 
     def test_sub_of_datetime_from_TimeSeries(self):
-        if _np_version_under1p7:
-            raise nose.SkipTest("timedelta broken in np 1.6.1")
+        tm._skip_if_not_numpy17_friendly()
 
         from pandas.tseries.timedeltas import _possibly_cast_to_timedelta
         from datetime import datetime

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -812,8 +812,7 @@ class TestMerge(tm.TestCase):
 
         # timedelta64 issues with join/merge
         # GH 5695
-        if _np_version_under1p7:
-            raise nose.SkipTest("numpy < 1.7")
+        tm._skip_if_not_numpy17_friendly()
 
         d = {'d': dt.datetime(2013, 11, 5, 5, 56), 't': dt.timedelta(0, 22500)}
         df = DataFrame(columns=list('dt'))
@@ -2005,9 +2004,7 @@ class TestConcatenate(tm.TestCase):
     def test_concat_timedelta64_block(self):
 
         # not friendly for < 1.7
-        if _np_version_under1p7:
-            raise nose.SkipTest("numpy < 1.7")
-
+        tm._skip_if_not_numpy17_friendly()
         from pandas import to_timedelta
 
         rng = to_timedelta(np.arange(10),unit='s')

--- a/pandas/tseries/tests/test_frequencies.py
+++ b/pandas/tseries/tests/test_frequencies.py
@@ -137,8 +137,7 @@ class TestFrequencyInference(tm.TestCase):
         self._check_tick(timedelta(microseconds=1), 'U')
 
     def test_nanosecond(self):
-        if _np_version_under1p7:
-            raise nose.SkipTest("requires numpy >= 1.7 to run")
+        tm._skip_if_not_numpy17_friendly()
         self._check_tick(np.timedelta64(1, 'ns'), 'N')
 
     def _check_tick(self, base_delta, code):

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -180,7 +180,7 @@ class TestCommon(Base):
                           'Milli': Timestamp('2011-01-01 09:00:00.001000'),
                           'Micro': Timestamp('2011-01-01 09:00:00.000001'),
                           'Nano': Timestamp(np.datetime64('2011-01-01T09:00:00.000000001Z'))}
- 
+
         self.timezones = ['UTC', 'Asia/Tokyo', 'US/Eastern']
 
     def test_return_type(self):
@@ -2782,8 +2782,8 @@ def test_Microsecond():
 
 
 def test_NanosecondGeneric():
-    if _np_version_under1p7:
-        raise nose.SkipTest('numpy >= 1.7 required')
+    tm._skip_if_not_numpy17_friendly()
+
     timestamp = Timestamp(datetime(2010, 1, 1))
     assert timestamp.nanosecond == 0
 
@@ -2795,8 +2795,7 @@ def test_NanosecondGeneric():
 
 
 def test_Nanosecond():
-    if _np_version_under1p7:
-        raise nose.SkipTest('numpy >= 1.7 required')
+    tm._skip_if_not_numpy17_friendly()
 
     timestamp = Timestamp(datetime(2010, 1, 1))
     assertEq(Nano(), timestamp, timestamp + np.timedelta64(1, 'ns'))

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 
 from pandas import (Index, Series, DataFrame, Timestamp, isnull, notnull,
-                    bdate_range, date_range, _np_version_under1p7)
+                    bdate_range, date_range)
 import pandas.core.common as com
 from pandas.compat import StringIO, lrange, range, zip, u, OrderedDict, long
 from pandas import compat, to_timedelta, tslib
@@ -15,13 +15,9 @@ from pandas.tseries.timedeltas import _coerce_scalar_to_timedelta_type as ct
 from pandas.util.testing import (assert_series_equal,
                                  assert_frame_equal,
                                  assert_almost_equal,
-                                 ensure_clean)
+                                 ensure_clean,
+                                 _skip_if_not_numpy17_friendly)
 import pandas.util.testing as tm
-
-def _skip_if_numpy_not_friendly():
-    # not friendly for < 1.7
-    if _np_version_under1p7:
-        raise nose.SkipTest("numpy < 1.7")
 
 class TestTimedeltas(tm.TestCase):
     _multiprocess_can_split_ = True
@@ -30,7 +26,7 @@ class TestTimedeltas(tm.TestCase):
         pass
 
     def test_numeric_conversions(self):
-        _skip_if_numpy_not_friendly()
+        _skip_if_not_numpy17_friendly()
 
         self.assertEqual(ct(0), np.timedelta64(0,'ns'))
         self.assertEqual(ct(10), np.timedelta64(10,'ns'))
@@ -42,14 +38,14 @@ class TestTimedeltas(tm.TestCase):
         self.assertEqual(ct(10,unit='d'), np.timedelta64(10,'D').astype('m8[ns]'))
 
     def test_timedelta_conversions(self):
-        _skip_if_numpy_not_friendly()
+        _skip_if_not_numpy17_friendly()
 
         self.assertEqual(ct(timedelta(seconds=1)), np.timedelta64(1,'s').astype('m8[ns]'))
         self.assertEqual(ct(timedelta(microseconds=1)), np.timedelta64(1,'us').astype('m8[ns]'))
         self.assertEqual(ct(timedelta(days=1)), np.timedelta64(1,'D').astype('m8[ns]'))
 
     def test_short_format_converters(self):
-        _skip_if_numpy_not_friendly()
+        _skip_if_not_numpy17_friendly()
 
         def conv(v):
             return v.astype('m8[ns]')
@@ -97,7 +93,7 @@ class TestTimedeltas(tm.TestCase):
         self.assertRaises(ValueError, ct, 'foo')
 
     def test_full_format_converters(self):
-        _skip_if_numpy_not_friendly()
+        _skip_if_not_numpy17_friendly()
 
         def conv(v):
             return v.astype('m8[ns]')
@@ -120,13 +116,13 @@ class TestTimedeltas(tm.TestCase):
         self.assertRaises(ValueError, ct, '- 1days, 00')
 
     def test_nat_converters(self):
-        _skip_if_numpy_not_friendly()
+        _skip_if_not_numpy17_friendly()
 
         self.assertEqual(to_timedelta('nat',box=False).astype('int64'), tslib.iNaT)
         self.assertEqual(to_timedelta('nan',box=False).astype('int64'), tslib.iNaT)
 
     def test_to_timedelta(self):
-        _skip_if_numpy_not_friendly()
+        _skip_if_not_numpy17_friendly()
 
         def conv(v):
             return v.astype('m8[ns]')
@@ -235,7 +231,7 @@ class TestTimedeltas(tm.TestCase):
         self.assertRaises(ValueError, lambda : to_timedelta(1,unit='foo'))
 
     def test_to_timedelta_via_apply(self):
-        _skip_if_numpy_not_friendly()
+        _skip_if_not_numpy17_friendly()
 
         # GH 5458
         expected = Series([np.timedelta64(1,'s')])
@@ -246,7 +242,7 @@ class TestTimedeltas(tm.TestCase):
         tm.assert_series_equal(result, expected)
 
     def test_timedelta_ops(self):
-        _skip_if_numpy_not_friendly()
+        _skip_if_not_numpy17_friendly()
 
         # GH4984
         # make sure ops return timedeltas
@@ -275,7 +271,7 @@ class TestTimedeltas(tm.TestCase):
         tm.assert_almost_equal(result, expected)
 
     def test_timedelta_ops_scalar(self):
-        _skip_if_numpy_not_friendly()
+        _skip_if_not_numpy17_friendly()
 
         # GH 6808
         base = pd.to_datetime('20130101 09:01:12.123456')
@@ -309,7 +305,7 @@ class TestTimedeltas(tm.TestCase):
             self.assertEqual(result, expected_sub)
 
     def test_to_timedelta_on_missing_values(self):
-        _skip_if_numpy_not_friendly()
+        _skip_if_not_numpy17_friendly()
 
         # GH5438
         timedelta_NaT = np.timedelta64('NaT')
@@ -328,7 +324,7 @@ class TestTimedeltas(tm.TestCase):
         self.assertEqual(actual.astype('int64'), timedelta_NaT.astype('int64'))
 
     def test_timedelta_ops_with_missing_values(self):
-        _skip_if_numpy_not_friendly()
+        _skip_if_not_numpy17_friendly()
 
         # setup
         s1 = pd.to_timedelta(Series(['00:00:01']))
@@ -407,7 +403,7 @@ class TestTimedeltas(tm.TestCase):
         assert_frame_equal(actual, dfn)
 
     def test_apply_to_timedelta(self):
-        _skip_if_numpy_not_friendly()
+        _skip_if_not_numpy17_friendly()
 
         timedelta_NaT = pd.to_timedelta('NaT')
 

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -770,10 +770,12 @@ class TestTimeSeries(tm.TestCase):
         self.assertTrue((idx.values == tslib.cast_to_nanoseconds(arr)).all())
 
     def test_index_astype_datetime64(self):
-        idx = Index([datetime(2012, 1, 1)], dtype=object)
-
+        # valid only under 1.7!
         if not _np_version_under1p7:
             raise nose.SkipTest("test only valid in numpy < 1.7")
+
+        idx = Index([datetime(2012, 1, 1)], dtype=object)
+        casted = idx.astype(np.dtype('M8[D]'))
 
         casted = idx.astype(np.dtype('M8[D]'))
         expected = DatetimeIndex(idx.values)
@@ -2680,9 +2682,7 @@ class TestDatetimeIndex(tm.TestCase):
         assert index.inferred_freq == '40960N'
 
     def test_ns_index(self):
-
-        if _np_version_under1p7:
-            raise nose.SkipTest
+        tm._skip_if_not_numpy17_friendly()
 
         nsamples = 400
         ns = int(1e9 / 24414)

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -264,8 +264,7 @@ class TestArrayToDatetime(tm.TestCase):
 
 class TestTimestampNsOperations(tm.TestCase):
     def setUp(self):
-        if _np_version_under1p7:
-            raise nose.SkipTest('numpy >= 1.7 required')
+        tm._skip_if_not_numpy17_friendly()
         self.timestamp = Timestamp(datetime.datetime.utcnow())
 
     def assert_ns_timedelta(self, modified_timestamp, expected_value):

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -41,7 +41,8 @@ from pandas import bdate_range
 from pandas.tseries.index import DatetimeIndex
 from pandas.tseries.period import PeriodIndex
 
-from pandas import _testing
+from pandas import _testing, _np_version_under1p7
+
 
 from pandas.io.common import urlopen
 
@@ -208,6 +209,12 @@ def mplskip(cls):
 
     cls.setUpClass = setUpClass
     return cls
+
+def _skip_if_not_numpy17_friendly():
+    # not friendly for < 1.7
+    if _np_version_under1p7:
+        import nose
+        raise nose.SkipTest("numpy >= 1.7 is required")
 
 def _skip_if_no_scipy():
     try:


### PR DESCRIPTION
TST: skip on older numpy for (GH7694)
closes #7694 
