### PR TITLE
BUG/PERF: offsets.apply doesnt preserve nanosecond

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -256,6 +256,9 @@ Bug Fixes
 - Bug in repeated timeseries line and area plot may result in ``ValueError`` or  incorrect kind (:issue:`7733`)
 
 
+- Bug in ``offsets.apply``, ``rollforward`` and ``rollback`` may reset nanosecond (:issue:`7697`)
+- Bug in ``offsets.apply``, ``rollforward`` and ``rollback`` may raise ``AttributeError`` if ``Timestamp`` has ``dateutil`` tzinfo (:issue:`7697`)
+
 
 - Bug in ``is_superperiod`` and ``is_subperiod`` cannot handle higher frequencies than ``S`` (:issue:`7760`, :issue:`7772`, :issue:`7803`)
 

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -1051,6 +1051,26 @@ cdef inline void _localize_tso(_TSObject obj, object tz):
             obj.tzinfo = tz
 
 
+def _localize_pydatetime(object dt, object tz):
+    '''
+    Take a datetime/Timestamp in UTC and localizes to timezone tz.
+    '''
+    if tz is None:
+        return dt
+    elif isinstance(dt, Timestamp):
+        return dt.tz_localize(tz)
+    elif tz == 'UTC' or tz is UTC:
+        return UTC.localize(dt)
+
+    elif _treat_tz_as_pytz(tz):
+        # datetime.replace may return incorrect result in pytz
+        return tz.localize(dt)
+    elif _treat_tz_as_dateutil(tz):
+        return dt.replace(tzinfo=tz)
+    else:
+        raise ValueError(type(tz), tz)
+
+
 def get_timezone(tz):
     return _get_zone(tz)
 


### PR DESCRIPTION
Main Fix is to preserve nanosecond info which can lost during `offset.apply`, but it also includes:
- Support dateutil timezone
- Little performance improvement. Even though v0.14.1 should take longer than v0.14.0 because perf test in v0.14 doesn't perform timestamp conversion which was fixed in #7502.
  NOTE: This caches `Tick.delta` because it was calculated 3 times repeatedly, but does it cause any side effect?
### Before

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
timeseries_year_incr                         |   0.0164 |   0.0103 |   1.5846 |
timeseries_year_apply                        |   0.0153 |   0.0094 |   1.6356 |
timeseries_day_incr                          |   0.0187 |   0.0053 |   3.5075 |
timeseries_day_apply                         |   0.0164 |   0.0033 |   4.9048 |

Target [d0076db] : PERF: Improve index.min and max perf
Base   [da0f7ae] : RLS: 0.14.0 final
```
### After the fix

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
timeseries_year_incr                         |   0.0150 |   0.0087 |   1.7339 |
timeseries_year_apply                        |   0.0126 |   0.0073 |   1.7283 |
timeseries_day_incr                          |   0.0130 |   0.0053 |   2.4478 |
timeseries_day_apply                         |   0.0107 |   0.0033 |   3.2143 |

Target [64dd021] : BUG: offsets.apply doesnt preserve nanosecond
Base   [da0f7ae] : RLS: 0.14.0 final
```
