### PR TITLE
BUG: DatetimeIndex.__iter__ creates a temp array of Timestamp (GH7683)

### DIFF
--- a/doc/source/v0.14.1.txt
+++ b/doc/source/v0.14.1.txt
@@ -292,3 +292,4 @@ Bug Fixes
 - Bug in ``to_sql`` taking the boolean column as text column (:issue:`7678`)
 - Bug in grouped `hist` doesn't handle `rot` kw and `sharex` kw properly (:issue:`7234`)
 
+- Bug in ``DatetimeIndex``, ``__iter__`` creates a temp array of ``Timestamp`` (:issue:`7683`)

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1477,7 +1477,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
                              tz=self.tz)
 
     def __iter__(self):
-        return iter(self.asobject)
+        return (self._box_func(v) for v in self.asi8)
 
     def searchsorted(self, key, side='left'):
         if isinstance(key, np.ndarray):


### PR DESCRIPTION
closes #7683 
