### PR TITLE
BUG: DatetimeIndex.__iter__ creates a temp array of Timestamp (GH7683)

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -152,6 +152,7 @@ There are no experimental changes in 0.15.0
 Bug Fixes
 ~~~~~~~~~
 
+- Bug in ``DatetimeIndex``, ``__iter__`` creates a temp array of ``Timestamp`` (:issue:`7683`)
 
 
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -387,6 +387,9 @@ class DatetimeIndexOpsMixin(object):
     is_year_start = _field_accessor('is_year_start', "Logical indicating if first day of year (defined by frequency)")
     is_year_end = _field_accessor('is_year_end', "Logical indicating if last day of year (defined by frequency)")
 
+    def __iter__(self):
+        return (self._box_func(v) for v in self.asi8)
+
     @property
     def _box_func(self):
         """

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1476,9 +1476,6 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
         return DatetimeIndex(new_values, freq='infer', name=self.name,
                              tz=self.tz)
 
-    def __iter__(self):
-        return iter(self.asobject)
-
     def searchsorted(self, key, side='left'):
         if isinstance(key, np.ndarray):
             key = np.array(key, dtype=_NS_DTYPE, copy=False)

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -738,10 +738,6 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
             return Index(self.values, dtype)
         raise ValueError('Cannot cast PeriodIndex to dtype %s' % dtype)
 
-    def __iter__(self):
-        for val in self.values:
-            yield Period(ordinal=val, freq=self.freq)
-
     def searchsorted(self, key, side='left'):
         if isinstance(key, compat.string_types):
             key = Period(key, freq=self.freq).ordinal

--- a/vb_suite/timeseries.py
+++ b/vb_suite/timeseries.py
@@ -333,3 +333,28 @@ rng = date_range('1/1/1', periods=N, freq='B')
 
 timeseries_is_month_start = Benchmark('rng.is_month_start', setup,
                                   start_date=datetime(2014, 4, 1))
+
+#----------------------------------------------------------------------
+# iterate over DatetimeIndex/PeriodIndex
+setup = common_setup + """
+N = 1000000
+M = 10000
+idx1 = date_range(start='20140101', freq='T', periods=N)
+idx2 = period_range(start='20140101', freq='T', periods=N)
+
+def iter_n(iterable, n=None):
+  i = 0
+  for _ in iterable:
+    i += 1
+    if n is not None and i > n:
+      break
+"""
+
+timeseries_iter_datetimeindex = Benchmark('iter_n(idx1)', setup)
+
+timeseries_iter_periodindex = Benchmark('iter_n(idx2)', setup)
+
+timeseries_iter_datetimeindex_preexit = Benchmark('iter_n(idx1, M)', setup)
+
+timeseries_iter_periodindex_preexit = Benchmark('iter_n(idx2, M)', setup)
+


### PR DESCRIPTION
closes #7683

Move `__iter__` from `DatatimeIndex/PeriodIndex` to `DatetimeIndexOpsMixin`
Adding perf tests for change

```
 -------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
 -------------------------------------------------------------------------------
timeseries_iter_datetimeindex_preexit        |  35.6683 | 2546.9604 |   0.0140 |
timeseries_iter_periodindex                  | 5051.6427 | 4353.0200 |   1.1605 |
timeseries_iter_periodindex_preexit          |  50.9930 |  43.8580 |   1.1627 |
timeseries_iter_datetimeindex                | 3463.0601 | 2596.2270 |   1.3339 |
```
