### PR TITLE
SQL: suppress warning for BIGINT with sqlite and sqlalchemy<0.8.2 (GH7433)

### DIFF
--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -1079,6 +1079,16 @@ class TestSQLiteAlchemy(_TestSQLAlchemy):
         self.assertFalse(issubclass(df.DateCol.dtype.type, np.datetime64),
                          "DateCol loaded with incorrect type")
 
+    def test_bigint_warning(self):
+        # test no warning for BIGINT (to support int64) is raised (GH7433)
+        df = DataFrame({'a':[1,2]}, dtype='int64')
+        df.to_sql('test_bigintwarning', self.conn, index=False)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            sql.read_sql_table('test_bigintwarning', self.conn)
+            self.assertEqual(len(w), 0, "Warning triggered for other table")
+
 
 class TestMySQLAlchemy(_TestSQLAlchemy):
     """


### PR DESCRIPTION
From discussion here: https://github.com/pydata/pandas/pull/7634#issuecomment-48111148 
Due to switching from Integer to BigInteger (to support int64 on some database systems), reading a table from sqlite with integers leads to a warning when you have an slqalchemy version of below 0.8.2.

I know it is very very late and goes against all reservations of putting in new stuff just before a release, but after some more consideration, I think we should include this (or at least something that fixes it, and I think this does). @jreback, you said not to worry about it (it is just a warning), but the sqlalchemy release that fixes it is only just a year old and this is something most users will try as the first thing I think when using the sqlalchemy functions (writing/reading simple dataframe with some numbers with sqlite), so should not get a warning they don't understand.

I tested it locally with sqlalchemy 0.7.8 (on Windows), and on travis it is tested with 0.7.1 (the py2.6 build) and there also the warnings disappeared.

What do you think?
