### PR TITLE
PERF: improve perf of index iteration (GH7683)

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -150,6 +150,7 @@ Enhancements
 Performance
 ~~~~~~~~~~~
 
+- Performance improvements in ``DatetimeIndex.__iter__`` to allow faster iteration (:issue:`7683`)
 
 
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -390,6 +390,9 @@ class DatetimeIndexOpsMixin(object):
     is_year_start = _field_accessor('is_year_start', "Logical indicating if first day of year (defined by frequency)")
     is_year_end = _field_accessor('is_year_end', "Logical indicating if last day of year (defined by frequency)")
 
+    def __iter__(self):
+        return (self._box_func(v) for v in self.asi8)
+
     @property
     def _box_func(self):
         """

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -738,10 +738,6 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
             return Index(self.values, dtype)
         raise ValueError('Cannot cast PeriodIndex to dtype %s' % dtype)
 
-    def __iter__(self):
-        for val in self.values:
-            yield Period(ordinal=val, freq=self.freq)
-
     def searchsorted(self, key, side='left'):
         if isinstance(key, compat.string_types):
             key = Period(key, freq=self.freq).ordinal

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -1027,7 +1027,6 @@ class TestTimeZones(tm.TestCase):
 
     def test_timestamp_equality_different_timezones(self):
         utc_range = date_range('1/1/2000', periods=20, tz='UTC')
-
         eastern_range = utc_range.tz_convert('US/Eastern')
         berlin_range = utc_range.tz_convert('Europe/Berlin')
 

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -74,41 +74,72 @@ try:
 except NameError: # py3
     basestring = str
 
-def ints_to_pydatetime(ndarray[int64_t] arr, tz=None):
+cdef inline object create_timestamp_from_ts(int64_t value, pandas_datetimestruct dts, object tz, object offset):
+    cdef _Timestamp ts_base
+    ts_base = _Timestamp.__new__(Timestamp, dts.year, dts.month,
+                                 dts.day, dts.hour, dts.min,
+                                 dts.sec, dts.us, tz)
+
+    ts_base.value = value
+    ts_base.offset = offset
+    ts_base.nanosecond = dts.ps / 1000
+
+    return ts_base
+
+cdef inline object create_datetime_from_ts(int64_t value, pandas_datetimestruct dts, object tz, object offset):
+    return datetime(dts.year, dts.month, dts.day, dts.hour,
+                    dts.min, dts.sec, dts.us, tz)
+
+def ints_to_pydatetime(ndarray[int64_t] arr, tz=None, offset=None, box=False):
+    # convert an i8 repr to an ndarray of datetimes or Timestamp (if box == True)
+
     cdef:
         Py_ssize_t i, n = len(arr)
         pandas_datetimestruct dts
+        object dt
+        int64_t value
         ndarray[object] result = np.empty(n, dtype=object)
+        object (*func_create)(int64_t, pandas_datetimestruct, object, object)
+
+    if box and util.is_string_object(offset):
+        from pandas.tseries.frequencies import to_offset
+        offset = to_offset(offset)
+
+    if box:
+      func_create = create_timestamp_from_ts
+    else:
+      func_create = create_datetime_from_ts
 
     if tz is not None:
         if _is_utc(tz):
             for i in range(n):
-                if arr[i] == iNaT:
-                    result[i] = np.nan
+                value = arr[i]
+                if value == iNaT:
+                    result[i] = NaT
                 else:
-                    pandas_datetime_to_datetimestruct(arr[i], PANDAS_FR_ns, &dts)
-                    result[i] = datetime(dts.year, dts.month, dts.day, dts.hour,
-                                         dts.min, dts.sec, dts.us, tz)
+                    pandas_datetime_to_datetimestruct(value, PANDAS_FR_ns, &dts)
+                    result[i] = func_create(value, dts, tz, offset)
         elif _is_tzlocal(tz) or _is_fixed_offset(tz):
             for i in range(n):
-                if arr[i] == iNaT:
-                    result[i] = np.nan
+                value = arr[i]
+                if value == iNaT:
+                    result[i] = NaT
                 else:
-                    pandas_datetime_to_datetimestruct(arr[i], PANDAS_FR_ns, &dts)
-                    dt = datetime(dts.year, dts.month, dts.day, dts.hour,
-                                  dts.min, dts.sec, dts.us, tz)
+                    pandas_datetime_to_datetimestruct(value, PANDAS_FR_ns, &dts)
+                    dt = func_create(value, dts, tz, offset)
                     result[i] = dt + tz.utcoffset(dt)
         else:
             trans = _get_transitions(tz)
             deltas = _get_deltas(tz)
             for i in range(n):
 
-                if arr[i] == iNaT:
-                    result[i] = np.nan
+                value = arr[i]
+                if value == iNaT:
+                    result[i] = NaT
                 else:
 
                     # Adjust datetime64 timestamp, recompute datetimestruct
-                    pos = trans.searchsorted(arr[i], side='right') - 1
+                    pos = trans.searchsorted(value, side='right') - 1
                     if _treat_tz_as_pytz(tz):
                         # find right representation of dst etc in pytz timezone
                         new_tz = tz._tzinfos[tz._transition_info[pos]]
@@ -116,19 +147,17 @@ def ints_to_pydatetime(ndarray[int64_t] arr, tz=None):
                         # no zone-name change for dateutil tzs - dst etc represented in single object.
                         new_tz = tz
 
-                    pandas_datetime_to_datetimestruct(arr[i] + deltas[pos],
-                                                      PANDAS_FR_ns, &dts)
-                    result[i] = datetime(dts.year, dts.month, dts.day, dts.hour,
-                                         dts.min, dts.sec, dts.us,
-                                         new_tz)
+                    pandas_datetime_to_datetimestruct(value + deltas[pos], PANDAS_FR_ns, &dts)
+                    result[i] = func_create(value, dts, new_tz, offset)
     else:
         for i in range(n):
-            if arr[i] == iNaT:
-                result[i] = np.nan
+
+            value = arr[i]
+            if value == iNaT:
+                result[i] = NaT
             else:
-                pandas_datetime_to_datetimestruct(arr[i], PANDAS_FR_ns, &dts)
-                result[i] = datetime(dts.year, dts.month, dts.day, dts.hour,
-                                     dts.min, dts.sec, dts.us)
+                pandas_datetime_to_datetimestruct(value, PANDAS_FR_ns, &dts)
+                result[i] = func_create(value, dts, None, offset)
 
     return result
 
@@ -182,6 +211,7 @@ class Timestamp(_Timestamp):
     @classmethod
     def utcnow(cls):
         return cls.now('UTC')
+
 
     def __new__(cls, object ts_input, object offset=None, tz=None, unit=None):
         cdef _TSObject ts

--- a/vb_suite/timeseries.py
+++ b/vb_suite/timeseries.py
@@ -333,3 +333,28 @@ rng = date_range('1/1/1', periods=N, freq='B')
 
 timeseries_is_month_start = Benchmark('rng.is_month_start', setup,
                                   start_date=datetime(2014, 4, 1))
+
+#----------------------------------------------------------------------
+# iterate over DatetimeIndex/PeriodIndex
+setup = common_setup + """
+N = 1000000
+M = 10000
+idx1 = date_range(start='20140101', freq='T', periods=N)
+idx2 = period_range(start='20140101', freq='T', periods=N)
+
+def iter_n(iterable, n=None):
+  i = 0
+  for _ in iterable:
+    i += 1
+    if n is not None and i > n:
+      break
+"""
+
+timeseries_iter_datetimeindex = Benchmark('iter_n(idx1)', setup)
+
+timeseries_iter_periodindex = Benchmark('iter_n(idx2)', setup)
+
+timeseries_iter_datetimeindex_preexit = Benchmark('iter_n(idx1, M)', setup)
+
+timeseries_iter_periodindex_preexit = Benchmark('iter_n(idx2, M)', setup)
+


### PR DESCRIPTION
closes #7683

`PeriodIndex` creation is still in python space, not much help

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
timeseries_iter_datetimeindex_preexit        |  12.7254 | 3657.9890 |   0.0035 |
timeseries_iter_datetimeindex                | 679.8913 | 3726.6284 |   0.1824 |
timeseries_iter_periodindex_preexit          |  69.0370 |  62.8881 |   1.0978 |
timeseries_iter_periodindex                  | 6941.9633 | 6024.2947 |   1.1523 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [142718e] : PERF: DatetimeIndex.__iter__ now uses ints_to_pydatetime with boxing
Base   [f9493ea] : Merge pull request #7713 from jorisvandenbossche/doc-fixes3

DOC: fix doc build warnings
```
