### PR TITLE
ENH: Add uint and bool support in to_stata

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -3504,6 +3504,31 @@ into a .dta file. The format version of this file is always 115 (Stata 12).
    df = DataFrame(randn(10, 2), columns=list('AB'))
    df.to_stata('stata.dta')
 
+*Stata* data files have limited data type support; only strings with 244 or
+fewer characters, ``int8``, ``int16``, ``int32`` and ``float64`` can be stored
+in ``.dta`` files.  Additionally, *Stata* reserveds certain values to represent
+missing data, and when a value is encountered outside of the
+permitted range, the data type is upcast to the next larger size.  For
+example, ``int8`` values are restricted to lie between -127 and 100, and so
+variables with values above 100 will trigger a conversion to ``int16``. ``nan``
+values in floating points data types are stored as the basic missing data type
+(``.`` in *Stata*).  Tt is not possible to indicate missing data values for
+integer data types.
+
+The *Stata* writer gracefully handles other data types including ``int64``,
+``bool``, ``uint8``, ``uint16``, ``uint32`` and ``float32`` by upcasting to
+the smallest supported type that can represent the data.  For example, data
+with a type of ``uint8`` will be cast to ``int8`` if all values are less than
+100 (the upper bound for non-missing ``int8`` data in *Stata*), or, if values are
+outside of this range, the data is cast to ``int16``.
+
+
+.. warning::
+
+   Conversion from ``int64`` to ``float64`` may result in a loss of precision
+   if ``int64`` values are larger than 2**53.
+
+
 .. _io.stata_reader:
 
 Reading from STATA format

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -114,7 +114,7 @@ Known Issues
 
 Enhancements
 ~~~~~~~~~~~~
-
+- Added support for bool, uint8, uint16 and uint32 datatypes in ``to_stata`` (:issue:`7097`, :issue:`7365`)
 
 
 

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -527,6 +527,29 @@ class TestStata(tm.TestCase):
             tm.assert_frame_equal(written_and_read_again.set_index('index'),
                                   expected)
 
+    def test_bool_uint(self):
+        s0 = Series([0, 1, True], dtype=np.bool)
+        s1 = Series([0, 1, 100], dtype=np.uint8)
+        s2 = Series([0, 1, 255], dtype=np.uint8)
+        s3 = Series([0, 1, 2 ** 15 - 100], dtype=np.uint16)
+        s4 = Series([0, 1, 2 ** 16 - 1], dtype=np.uint16)
+        s5 = Series([0, 1, 2 ** 31 - 100], dtype=np.uint32)
+        s6 = Series([0, 1, 2 ** 32 - 1], dtype=np.uint32)
+
+        original = DataFrame({'s0': s0, 's1': s1, 's2': s2, 's3': s3,
+                              's4': s4, 's5': s5, 's6': s6})
+        original.index.name = 'index'
+        expected = original.copy()
+        expected_types = (np.int8, np.int8, np.int16, np.int16, np.int32,
+                          np.int32, np.float64)
+        for c, t in zip(expected.columns, expected_types):
+            expected[c] = expected[c].astype(t)
+
+        with tm.ensure_clean() as path:
+            original.to_stata(path)
+            written_and_read_again = self.read_dta(path)
+            written_and_read_again = written_and_read_again.set_index('index')
+            tm.assert_frame_equal(written_and_read_again, expected)
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
Added support for uint (uint8, uint16 and uint32, but not uint64) and bool
datatypes in to_stata.  
closes #7097 
closes #7365
