### PR TITLE
BUG: allow get default value upon IndexError, GH #7725

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -152,6 +152,7 @@ There are no experimental changes in 0.15.0
 Bug Fixes
 ~~~~~~~~~
 
+- Bug in ``get`` where an ``IndexError`` would not cause the default value to be returned (:issue:`7725`)
 
 
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1038,7 +1038,7 @@ class NDFrame(PandasObject):
         """
         try:
             return self[key]
-        except (KeyError, ValueError):
+        except (KeyError, ValueError, IndexError):
             return default
 
     def __getitem__(self, item):

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -123,6 +123,23 @@ class Generic(object):
 
         # _get_numeric_data is includes _get_bool_data, so can't test for non-inclusion
 
+    def test_get_default(self):
+        
+        # GH 7725
+        d0 = "a", "b", "c", "d"
+        d1 = np.arange(4, dtype='int64')
+        others = "e", 10
+        
+        for data, index in ((d0, d1), (d1, d0)):
+            s = Series(data, index=index)
+            for i,d in zip(index, data):
+                self.assertEqual(s.get(i), d)
+                self.assertEqual(s.get(i, d), d)
+                self.assertEqual(s.get(i, "z"), d)
+                for other in others:
+                    self.assertEqual(s.get(other, "z"), "z")
+                    self.assertEqual(s.get(other, other), other)
+
     def test_nonzero(self):
 
         # GH 4633


### PR DESCRIPTION
Fixes #7725 by adding IndexError to the tuple of caught exceptions.
