### PR TITLE
BUG: Repeated timeseries plot may result in incorrect kind

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -199,10 +199,16 @@ Bug Fixes
 - Bug in ``HDFStore.select_column()`` not preserving UTC timezone info when selecting a DatetimeIndex (:issue:`7777`)
 
 
+
 - Bug in pickles contains ``DateOffset`` may raise ``AttributeError`` when ``normalize`` attribute is reffered internally (:issue:`7748`)
 
 - Bug in pickle deserialization that failed for pre-0.14.1 containers with dup items trying to avoid ambiguity
   when matching block and manager items, when there's only one block there's no ambiguity (:issue:`7794`)
+
+
+
+- Bug in repeated timeseries line and area plot may result in ``ValueError`` or  incorrect kind (:issue:`7733`)
+
 
 
 - Bug in ``is_superperiod`` and ``is_subperiod`` cannot handle higher frequencies than ``S`` (:issue:`7760`, :issue:`7772`, :issue:`7803`)

--- a/pandas/tseries/plotting.py
+++ b/pandas/tseries/plotting.py
@@ -60,8 +60,7 @@ def tsplot(series, plotf, **kwargs):
     # how to make sure ax.clear() flows through?
     if not hasattr(ax, '_plot_data'):
         ax._plot_data = []
-    ax._plot_data.append((series, kwargs))
-
+    ax._plot_data.append((series, plotf, kwargs))
     lines = plotf(ax, series.index, series.values, **kwargs)
 
     # set date formatter, locators and rescale limits
@@ -118,7 +117,7 @@ def _is_sup(f1, f2):
 
 def _upsample_others(ax, freq, plotf, kwargs):
     legend = ax.get_legend()
-    lines, labels = _replot_ax(ax, freq, plotf, kwargs)
+    lines, labels = _replot_ax(ax, freq, kwargs)
 
     other_ax = None
     if hasattr(ax, 'left_ax'):
@@ -127,7 +126,7 @@ def _upsample_others(ax, freq, plotf, kwargs):
         other_ax = ax.right_ax
 
     if other_ax is not None:
-        rlines, rlabels = _replot_ax(other_ax, freq, plotf, kwargs)
+        rlines, rlabels = _replot_ax(other_ax, freq, kwargs)
         lines.extend(rlines)
         labels.extend(rlabels)
 
@@ -139,7 +138,7 @@ def _upsample_others(ax, freq, plotf, kwargs):
         ax.legend(lines, labels, loc='best', title=title)
 
 
-def _replot_ax(ax, freq, plotf, kwargs):
+def _replot_ax(ax, freq, kwargs):
     data = getattr(ax, '_plot_data', None)
     ax._plot_data = []
     ax.clear()
@@ -148,7 +147,7 @@ def _replot_ax(ax, freq, plotf, kwargs):
     lines = []
     labels = []
     if data is not None:
-        for series, kwds in data:
+        for series, plotf, kwds in data:
             series = series.copy()
             idx = series.index.asfreq(freq, how='S')
             series.index = idx


### PR DESCRIPTION
Must be revisited after #7717.

Repeated line and area plot may result incorrect if it requires resampling.

```
import pandas as pd
import numpy as np
import matplotlib.pyplot as plt

fig, axes = plt.subplots(2, 2, figsize=(7, 5))
np.random.seed(1)

df1 = pd.DataFrame(np.random.rand(5, 2), pd.date_range('2011-01-01', periods=5, freq='D'))
df2 = pd.DataFrame(np.random.rand(2, 2), pd.date_range('2011-01-01', periods=2, freq='M'))

df1.plot(kind='line', ax=axes[0][0], legend=False)
df2.plot(kind='area', ax=axes[0][0], legend=False)

df1.plot(kind='area', ax=axes[1][0], legend=False)
df2.plot(kind='line', ax=axes[1][0], legend=False)

df2.plot(kind='line', ax=axes[0][1], legend=False)
df1.plot(kind='area', ax=axes[0][1], legend=False)
# ValueError: Argument dimensions are incompatible

df2.plot(kind='area', ax=axes[1][1], legend=False)
df1.plot(kind='line', ax=axes[1][1], legend=False)
```
### Result using current master
- line with low  freq -> area with high freq results in `ValueError` (top-right axes)
- area with low  freq -> line with high freq results in all lines, not area (bottom-right axes)
  ![figure_ng](https://cloud.githubusercontent.com/assets/1696302/3560065/dd93e976-0958-11e4-83e1-acd1dbffa1df.png)
### Result after fix

![figure_ok](https://cloud.githubusercontent.com/assets/1696302/3560079/622f2eb6-0959-11e4-90ed-5e7eee5dea52.png)
