### PR TITLE
BUG: DTI.value_counts doesnt preserve tz

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -290,6 +290,12 @@ Bug Fixes
 
 
 
+- Bug in ``DatetimeIndex.value_counts`` doesn't preserve tz  (:issue:`7735`)
+- Bug in ``PeriodIndex.value_counts`` results in ``Int64Index`` (:issue:`7735`)
+
+
+
+
 
 
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -275,8 +275,18 @@ class IndexOpsMixin(object):
         counts : Series
         """
         from pandas.core.algorithms import value_counts
-        return value_counts(self.values, sort=sort, ascending=ascending,
-                            normalize=normalize, bins=bins, dropna=dropna)
+        from pandas.tseries.api import DatetimeIndex, PeriodIndex
+        result = value_counts(self, sort=sort, ascending=ascending,
+                              normalize=normalize, bins=bins, dropna=dropna)
+
+        if isinstance(self, PeriodIndex):
+            # preserve freq
+            result.index = self._simple_new(result.index.values, self.name,
+                                            freq=self.freq)
+        elif isinstance(self, DatetimeIndex):
+            result.index = self._simple_new(result.index.values, self.name,
+                                            tz=getattr(self, 'tz', None))
+        return result
 
     def unique(self):
         """
@@ -542,5 +552,3 @@ class DatetimeIndexOpsMixin(object):
 
     def _add_delta(self, other):
         return NotImplemented
-
-


### PR DESCRIPTION
Found 2 problems related to `value_counts`.
- `DatetimeIndex.value_counts` loses tz.

```
didx = pd.date_range('2011-01-01 09:00', freq='H', periods=3, tz='Asia/Tokyo')
print(didx.value_counts())
#2011-01-01 00:00:00    1
#2011-01-01 01:00:00    1
#2011-01-01 02:00:00    1
# dtype: int64
```
- `PeriodIndex.value_counts` results in `Int64Index`, and unable to drop `NaT`.

```
pidx = pd.PeriodIndex(['2011-01-01 09:00', '2011-01-01 10:00', pd.NaT], freq='H')
print(pidx.value_counts())
#  359410                 1
#  359409                 1
# -9223372036854775808    1
# dtype: int64
```
