### PR TITLE
ENH/BUG: DatetimeIndex and PeriodIndex in-place ops behaves incorrectly

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -198,6 +198,10 @@ Bug Fixes
 - Bug in ``DataFrame.as_matrix()`` with mixed ``datetime64[ns]`` and ``timedelta64[ns]`` dtypes (:issue:`7778`)
 - Bug in ``HDFStore.select_column()`` not preserving UTC timezone info when selecting a DatetimeIndex (:issue:`7777`)
 
+- Bug in ``DatetimeIndex`` and ``PeriodIndex`` in-place addition and subtraction cause different result from normal one (:issue:`6527`)
+- Bug in adding and subtracting ``PeriodIndex`` with ``PeriodIndex`` raise ``TypeError`` (:issue:`7741`)
+- Bug in ``combine_first`` with ``PeriodIndex`` data raises ``TypeError`` (:issue:`3367`)
+
 
 - Bug in pickles contains ``DateOffset`` may raise ``AttributeError`` when ``normalize`` attribute is reffered internally (:issue:`7748`)
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1,6 +1,8 @@
 """
 Base and utility classes for pandas objects.
 """
+import datetime
+
 from pandas import compat
 import numpy as np
 from pandas.core import common as com
@@ -510,5 +512,35 @@ class DatetimeIndexOpsMixin(object):
         """
         from pandas.tseries.frequencies import get_reso_string
         return get_reso_string(self._resolution)
+
+    def __add__(self, other):
+        from pandas.core.index import Index
+        from pandas.tseries.offsets import DateOffset
+        if isinstance(other, Index):
+            return self.union(other)
+        elif isinstance(other, (DateOffset, datetime.timedelta, np.timedelta64)):
+            return self._add_delta(other)
+        elif com.is_integer(other):
+            return self.shift(other)
+        else:  # pragma: no cover
+            return NotImplemented
+
+    def __sub__(self, other):
+        from pandas.core.index import Index
+        from pandas.tseries.offsets import DateOffset
+        if isinstance(other, Index):
+            return self.diff(other)
+        elif isinstance(other, (DateOffset, datetime.timedelta, np.timedelta64)):
+            return self._add_delta(-other)
+        elif com.is_integer(other):
+            return self.shift(-other)
+        else:  # pragma: no cover
+            return NotImplemented
+
+    __iadd__ = __add__
+    __isub__ = __sub__
+
+    def _add_delta(self, other):
+        return NotImplemented
 
 

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -595,30 +595,6 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
         else:  # pragma: no cover
             np.ndarray.__setstate__(self, state)
 
-    def __add__(self, other):
-        if isinstance(other, Index):
-            return self.union(other)
-        elif isinstance(other, (DateOffset, timedelta)):
-            return self._add_delta(other)
-        elif isinstance(other, np.timedelta64):
-            return self._add_delta(other)
-        elif com.is_integer(other):
-            return self.shift(other)
-        else:  # pragma: no cover
-            raise TypeError(other)
-
-    def __sub__(self, other):
-        if isinstance(other, Index):
-            return self.diff(other)
-        elif isinstance(other, (DateOffset, timedelta)):
-            return self._add_delta(-other)
-        elif isinstance(other, np.timedelta64):
-            return self._add_delta(-other)
-        elif com.is_integer(other):
-            return self.shift(-other)
-        else:  # pragma: no cover
-            raise TypeError(other)
-
     def _add_delta(self, delta):
         if isinstance(delta, (Tick, timedelta)):
             inc = offsets._delta_to_nanoseconds(delta)

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -872,19 +872,6 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
         values[mask] = tslib.iNaT
         return PeriodIndex(data=values, name=self.name, freq=self.freq)
 
-    def __add__(self, other):
-        try:
-            return self.shift(other)
-        except TypeError:
-            # self.values + other raises TypeError for invalid input
-            return NotImplemented
-
-    def __sub__(self, other):
-        try:
-            return self.shift(-other)
-        except TypeError:
-            return NotImplemented
-
     @property
     def inferred_type(self):
         # b/c data is represented as ints make sure we can't have ambiguous

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -2450,6 +2450,20 @@ class TestPeriodIndex(tm.TestCase):
             idx = PeriodIndex(org.values, freq=o)
             self.assertTrue(idx.equals(org))
 
+    def test_combine_first(self):
+        # GH 3367
+        didx = pd.DatetimeIndex(start='1950-01-31', end='1950-07-31', freq='M')
+        pidx = pd.PeriodIndex(start=pd.Period('1950-1'), end=pd.Period('1950-7'), freq='M')
+        # check to be consistent with DatetimeIndex
+        for idx in [didx, pidx]:
+            a = pd.Series([1, np.nan, np.nan, 4, 5, np.nan, 7], index=idx)
+            b = pd.Series([9, 9, 9, 9, 9, 9, 9], index=idx)
+
+            result = a.combine_first(b)
+            expected = pd.Series([1, 9, 9, 4, 5, 9, 7], index=idx, dtype=np.float64)
+            tm.assert_series_equal(result, expected)
+
+
 def _permute(obj):
     return obj.take(np.random.permutation(len(obj)))
 

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1235,13 +1235,6 @@ class TestTimeSeries(tm.TestCase):
         result = ts[:0].last('3M')
         assert_series_equal(result, ts[:0])
 
-    def test_add_offset(self):
-        rng = date_range('1/1/2000', '2/1/2000')
-
-        result = rng + offsets.Hour(2)
-        expected = date_range('1/1/2000 02:00', '2/1/2000 02:00')
-        self.assertTrue(result.equals(expected))
-
     def test_format_pre_1900_dates(self):
         rng = date_range('1/1/1850', '1/1/1950', freq='A-DEC')
         rng.format()
@@ -2313,14 +2306,6 @@ class TestDatetimeIndex(tm.TestCase):
         result = rng.map(f)
         exp = [f(x) for x in rng]
         self.assert_numpy_array_equal(result, exp)
-
-    def test_add_union(self):
-        rng = date_range('1/1/2000', periods=5)
-        rng2 = date_range('1/6/2000', periods=5)
-
-        result = rng + rng2
-        expected = rng.union(rng2)
-        self.assertTrue(result.equals(expected))
 
     def test_misc_coverage(self):
         rng = date_range('1/1/2000', periods=5)


### PR DESCRIPTION
Fixes 2 issues related to `DetetimeIndex` and `PeriodIndex` ops.
- Addition / subtraction between `PeriodIndex` raise `TypeError` (Closes #3367).

```
pidx + pidx
# TypeError: unsupported operand type(s) for +: 'PeriodIndex' and 'PeriodIndex'
```
- In-place addition / subtraction doesn't return the same result as normal addition / subtraction.  Specifically, `PeriodIndex` in-place operation results in `Int64Index` (Closes #6527)

```
didx = pd.date_range('2011-01-01', freq='D', periods=5)

# This results shift (expected)
didx + 1
# <class 'pandas.tseries.index.DatetimeIndex'>
# [2011-01-02, ..., 2011-01-06]
# Length: 5, Freq: D, Timezone: None

# This result adding 1 unit (nano second) (NG)
didx += 1
didx 
# <class 'pandas.tseries.index.DatetimeIndex'>
# [2011-01-01 00:00:00.000000001, ..., 2011-01-05 00:00:00.000000001]
# Length: 5, Freq: None, Timezone: None
```
