### PR TITLE
Update common.py

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1436,7 +1436,7 @@ def interpolate_1d(xvalues, yvalues, method='linear', limit=None,
         all_nans = np.where(invalid)[0]
         violate = [invalid[x:x + limit + 1] for x in all_nans]
         violate = np.array([x.all() & (x.size > limit) for x in violate],
-                  dtype='int')
+                           dtype=bool)
         return all_nans[violate] + limit
 
     xvalues = getattr(xvalues, 'values', xvalues)

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1435,7 +1435,8 @@ def interpolate_1d(xvalues, yvalues, method='linear', limit=None,
         """mask off values that won't be filled since they exceed the limit"""
         all_nans = np.where(invalid)[0]
         violate = [invalid[x:x + limit + 1] for x in all_nans]
-        violate = np.array([x.all() & (x.size > limit) for x in violate])
+        violate = np.array([x.all() & (x.size > limit) for x in violate],
+                  dtype='int')
         return all_nans[violate] + limit
 
     xvalues = getattr(xvalues, 'values', xvalues)


### PR DESCRIPTION
Force violate array to be of type int. When no nan values are found, the array defaults to an empty array of type float, so you get an error: **\* IndexError: arrays used as indices must be of integer (or boolean) type
