### PR TITLE
Closes #7758 - astype(unicode) returning unicode.

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -184,8 +184,7 @@ There are no experimental changes in 0.15.0
 Bug Fixes
 ~~~~~~~~~
 
-
-
+- Bug in Series.astype("unicode") actually calling str (:issue:`7758`)
 
 
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -2492,6 +2492,9 @@ def _astype_nansafe(arr, dtype, copy=True):
     elif arr.dtype == np.object_ and np.issubdtype(dtype.type, np.integer):
         # work around NumPy brokenness, #1987
         return lib.astype_intsafe(arr.ravel(), dtype).reshape(arr.shape)
+    elif issubclass(dtype.type, compat.text_type):
+        # in Py3 that's str, in Py2 that's unicode
+        return lib.astype_unicode(arr.ravel()).reshape(arr.shape)
     elif issubclass(dtype.type, compat.string_types):
         return lib.astype_str(arr.ravel()).reshape(arr.shape)
 

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -781,6 +781,16 @@ def astype_intsafe(ndarray[object] arr, new_dtype):
 
     return result
 
+cpdef ndarray[object] astype_unicode(ndarray arr):
+    cdef:
+        Py_ssize_t i, n = arr.size
+        ndarray[object] result = np.empty(n, dtype=object)
+
+    for i in range(n):
+        util.set_value_at(result, i, unicode(arr[i]))
+
+    return result
+
 cpdef ndarray[object] astype_str(ndarray arr):
     cdef:
         Py_ssize_t i, n = arr.size


### PR DESCRIPTION
I didn't have to rely on `infer_dtype` as suggested by @jreback in #7758
as I delegated to numpy to do all the dirty job :
Just calls numpy.unicode on all the values.

Please have a critical look at this pull request before merging :
as I am unfamiliar with both pandas and cython; and may have 
misunderstood the way pandas is working.

Unit tests are attached and seem to work alright on `python 2.7.2` and `python 3.3.0`

closes #7758 
