### PR TITLE
BUG: rolling_* functions should not shrink window

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -37,6 +37,30 @@ API changes
 
 - Raise a ``ValueError`` in ``df.to_hdf`` with 'fixed' format, if ``df`` has non-unique columns as the resulting file will be broken (:issue:`7761`)
 
+- :func:`rolling_min`, :func:`rolling_max`, :func:`rolling_cov`, and :func:`rolling_corr`
+  now return objects with all ``NaN``s when ``len(arg) < min_periods <= window``
+  (like all other rolling functions do) rather than producing an error message.  (:issue:`7766`)
+  For example, this is the old behavior:
+	.. ipython:: python
+		In [14]: s = Series([10, 11, 12, 13])
+
+		In [15]: rolling_min(s, window=10, min_periods=5)
+		---------------------------------------------------------------------------
+		ValueError                                Traceback (most recent call last)
+		<ipython-input-15-f622819d7987> in <module>()
+		----> 1 rolling_min(s, window=10, min_periods=5)
+		...
+		ValueError: min_periods (5) must be <= window (4)
+  whereas this is the new behavior:
+	.. ipython:: python
+		In [16]: rolling_min(s, window=10, min_periods=5)
+		Out[16]:
+		0   NaN
+		1   NaN
+		2   NaN
+		3   NaN
+		dtype: float64
+
 .. _whatsnew_0150.cat:
 
 Categoricals in Series/DataFrame

--- a/pandas/algos.pyx
+++ b/pandas/algos.pyx
@@ -1551,8 +1551,6 @@ def roll_max2(ndarray[float64_t] a, int window, int minp):
 
     minp = _check_minp(window, minp, n0)
 
-    window = min(window, n0)
-
     ring = <pairs*>stdlib.malloc(window * sizeof(pairs))
     end = ring + window
     last = ring
@@ -1649,8 +1647,6 @@ def roll_min2(np.ndarray[np.float64_t, ndim=1] a, int window, int minp):
     if minp > window:
         raise ValueError('Invalid min_periods size %d greater than window %d'
                         % (minp, window))
-
-    window = min(window, n0)
 
     minp = _check_minp(window, minp, n0)
 

--- a/pandas/stats/moments.py
+++ b/pandas/stats/moments.py
@@ -211,9 +211,8 @@ def rolling_cov(arg1, arg2=None, window=None, min_periods=None, freq=None,
     arg2 = _conv_timerule(arg2, freq, how)
 
     def _get_cov(X, Y):
-        adj_window = min(window, len(X), len(Y))
-        mean = lambda x: rolling_mean(x, adj_window, min_periods, center=center)
-        count = rolling_count(X + Y, adj_window, center=center)
+        mean = lambda x: rolling_mean(x, window, min_periods, center=center)
+        count = rolling_count(X + Y, window, center=center)
         bias_adj = count / (count - 1)
         return (mean(X * Y) - mean(X) * mean(Y)) * bias_adj
     rs = _flex_binary_moment(arg1, arg2, _get_cov, pairwise=bool(pairwise))
@@ -236,12 +235,11 @@ def rolling_corr(arg1, arg2=None, window=None, min_periods=None, freq=None,
     arg2 = _conv_timerule(arg2, freq, how)
 
     def _get_corr(a, b):
-        adj_window = min(window, len(a), len(b))
-        num = rolling_cov(a, b, adj_window, min_periods, freq=freq,
+        num = rolling_cov(a, b, window, min_periods, freq=freq,
                           center=center)
-        den = (rolling_std(a, adj_window, min_periods, freq=freq,
+        den = (rolling_std(a, window, min_periods, freq=freq,
                            center=center) *
-               rolling_std(b, adj_window, min_periods, freq=freq,
+               rolling_std(b, window, min_periods, freq=freq,
                            center=center))
         return num / den
 


### PR DESCRIPTION
Closes https://github.com/pydata/pandas/issues/7764.
