### PR TITLE
BUG: Fix for passing multiple ints as levels in DataFrame.stack() (#7660)

### DIFF
--- a/doc/source/reshaping.rst
+++ b/doc/source/reshaping.rst
@@ -160,9 +160,33 @@ the level numbers:
 
    stacked.unstack('second')
 
+.. _reshaping.stack_multiple:
+
 You may also stack or unstack more than one level at a time by passing a list
 of levels, in which case the end result is as if each level in the list were
 processed individually.
+
+.. ipython:: python
+
+    columns = MultiIndex.from_tuples([
+            ('A', 'cat', 'long'), ('B', 'cat', 'long'),
+            ('A', 'dog', 'short'), ('B', 'dog', 'short')
+        ],
+        names=['exp', 'animal', 'hair_length']
+    )
+    df = DataFrame(randn(4, 4), columns=columns)
+    df
+
+    df.stack(level=['animal', 'hair_length'])
+
+The list of levels can contain either level names or level numbers (but
+not a mixture of the two).
+
+.. ipython:: python
+
+    # df.stack(level=['animal', 'hair_length'])
+    # from above is equivalent to:
+    df.stack(level=[1, 2])
 
 These functions are intelligent about handling missing data and do not expect
 each subgroup within the hierarchical index to have the same set of labels.

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -30,6 +30,11 @@ users upgrade to this version.
 API changes
 ~~~~~~~~~~~
 
+- Passing multiple levels to `DataFrame.stack()` will now work when multiple level
+  numbers are passed (:issue:`7660`), and will raise a ``ValueError`` when the
+  levels aren't all level names or all level numbers. See
+  :ref:`Reshaping by stacking and unstacking <reshaping.stack_multiple>`.
+
 .. _whatsnew_0150.cat:
 
 Categoricals in Series/DataFrame

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3311,13 +3311,10 @@ class DataFrame(NDFrame):
         -------
         stacked : DataFrame or Series
         """
-        from pandas.core.reshape import stack
+        from pandas.core.reshape import stack, stack_multiple
 
         if isinstance(level, (tuple, list)):
-            result = self
-            for lev in level:
-                result = stack(result, lev, dropna=dropna)
-            return result
+            return stack_multiple(self, level, dropna=dropna)
         else:
             return stack(self, level, dropna=dropna)
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -2490,6 +2490,12 @@ class MultiIndex(Index):
                 raise KeyError('Level %s not found' % str(level))
             elif level < 0:
                 level += self.nlevels
+                if level < 0:
+                    orig_level = level - self.nlevels
+                    raise IndexError(
+                        'Too many levels: Index has only %d levels, '
+                        '%d is not a valid level number' % (self.nlevels, orig_level)
+                    )
             # Note: levels are zero-based
             elif level >= self.nlevels:
                 raise IndexError('Too many levels: Index has only %d levels, '

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -11725,6 +11725,29 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_frame_equal(unstacked_cols.T, self.frame)
         assert_frame_equal(unstacked_cols_df['bar'].T, self.frame)
 
+    def test_stack_ints(self):
+        df = DataFrame(
+             np.random.randn(30, 27),
+             columns=MultiIndex.from_tuples(
+                list(itertools.product(range(3), repeat=3))
+            )
+        )
+        assert_frame_equal(
+            df.stack(level=[1, 2]),
+            df.stack(level=1).stack(level=1)
+        )
+        assert_frame_equal(
+            df.stack(level=[-2, -1]),
+            df.stack(level=1).stack(level=1)
+        )
+
+        df_named = df.copy()
+        df_named.columns.set_names(range(3), inplace=True)
+        assert_frame_equal(
+            df_named.stack(level=[1, 2]),
+            df_named.stack(level=1).stack(level=1)
+        )
+
     def test_unstack_bool(self):
         df = DataFrame([False, False],
                        index=MultiIndex.from_arrays([['a', 'b'], ['c', 'l']]),


### PR DESCRIPTION
closes #7660
The specific case that came up in #7660 (and originally in #7653) seems easy enough to fix, so I've covered that in the PR. I feel like this raises a few other potential problems though, e.g.:
- If the list of level numbers is not in order, is there any sensible way to deal with them? I've sorted the level list in my fix, as that seems like the most straightforward way of making sure that when you do each stack, it's only the level numbers higher than the current that are affected. This might produce undesired results though, so maybe we should just raise a `ValueError` if the level numbers aren't sorted?
- I'm not sure how to extend this to deal with negative level numbers.
