### PR TITLE
BUG: tslib.tz_convert and tslib.tz_convert_single may output different result in DST

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -233,8 +233,8 @@ Enhancements
 
 
 
-
-
+- Bug in ``tslib.tz_convert`` and ``tslib.tz_convert_single`` may return different results (:issue:`7798`)
+- Bug in ``DatetimeIndex.intersection`` of non-overlapping timestamps with tz raises ``IndexError`` (:issue:`7880`)
 
 
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -12636,23 +12636,6 @@ starting,ending,measure
         assert_array_equal(df.starting.values, ser_starting.index.values)
         assert_array_equal(df.ending.values, ser_ending.index.values)
 
-    def test_tslib_tz_convert_trans_pos_plus_1__bug(self):
-        # Regression test for tslib.tz_convert(vals, tz1, tz2).
-        # See https://github.com/pydata/pandas/issues/4496 for details.
-        idx = pd.date_range(datetime(2011, 3, 26, 23), datetime(2011, 3, 27, 1), freq='1min')
-        idx = idx.tz_localize('UTC')
-        idx = idx.tz_convert('Europe/Moscow')
-
-        test_vector = pd.Series([3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-                                 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-                                 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-                                 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-                                 4, 4, 4, 4, 4, 4, 4, 4, 5], dtype=int)
-
-        hours = idx.hour
-
-        np.testing.assert_equal(hours, test_vector.values)
-
     def _check_bool_op(self, name, alternative, frame=None, has_skipna=True,
                        has_bool_only=False):
         if frame is None:

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -14,7 +14,7 @@ import pandas.compat as compat
 from pandas.compat import u
 from pandas.tseries.frequencies import (
     infer_freq, to_offset, get_period_alias,
-    Resolution, _tz_convert_with_transitions)
+    Resolution)
 from pandas.core.base import DatetimeIndexOpsMixin
 from pandas.tseries.offsets import DateOffset, generate_range, Tick, CDay
 from pandas.tseries.tools import parse_time_string, normalize_date
@@ -1569,7 +1569,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
             new_dates = np.concatenate((self[:loc].asi8, [item.view(np.int64)],
                                         self[loc:].asi8))
             if self.tz is not None:
-                new_dates = _tz_convert_with_transitions(new_dates,'UTC',self.tz)
+                new_dates = tslib.tz_convert(new_dates, 'UTC', self.tz)
             return DatetimeIndex(new_dates, name=self.name, freq=freq, tz=self.tz)
 
         except (AttributeError, TypeError):
@@ -1606,7 +1606,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
                     freq = self.freq
 
         if self.tz is not None:
-            new_dates = _tz_convert_with_transitions(new_dates, 'UTC', self.tz)
+            new_dates = tslib.tz_convert(new_dates, 'UTC', self.tz)
         return DatetimeIndex(new_dates, name=self.name, freq=freq, tz=self.tz)
 
     def _view_like(self, ndarray):

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -3203,8 +3203,8 @@ class TestSeriesDatetime64(tm.TestCase):
 
     def test_intersection(self):
         # GH 4690 (with tz)
-        for tz in [None, 'Asia/Tokyo']:
-            rng = date_range('6/1/2000', '6/30/2000', freq='D', name='idx')
+        for tz in [None, 'Asia/Tokyo', 'US/Eastern', 'dateutil/US/Pacific']:
+            base = date_range('6/1/2000', '6/30/2000', freq='D', name='idx')
 
             # if target has the same name, it is preserved
             rng2 = date_range('5/15/2000', '6/20/2000', freq='D', name='idx')
@@ -3214,16 +3214,18 @@ class TestSeriesDatetime64(tm.TestCase):
             rng3 = date_range('5/15/2000', '6/20/2000', freq='D', name='other')
             expected3 = date_range('6/1/2000', '6/20/2000', freq='D', name=None)
 
-            result2 = rng.intersection(rng2)
-            result3 = rng.intersection(rng3)
-            for (result, expected) in [(result2, expected2), (result3, expected3)]:
+            rng4 = date_range('7/1/2000', '7/31/2000', freq='D', name='idx')
+            expected4 = DatetimeIndex([], name='idx')
+
+            for (rng, expected) in [(rng2, expected2), (rng3, expected3), (rng4, expected4)]:
+                result = base.intersection(rng)
                 self.assertTrue(result.equals(expected))
                 self.assertEqual(result.name, expected.name)
                 self.assertEqual(result.freq, expected.freq)
                 self.assertEqual(result.tz, expected.tz)
 
             # non-monotonic
-            rng = DatetimeIndex(['2011-01-05', '2011-01-04', '2011-01-02', '2011-01-03'],
+            base = DatetimeIndex(['2011-01-05', '2011-01-04', '2011-01-02', '2011-01-03'],
                                 tz=tz, name='idx')
 
             rng2 = DatetimeIndex(['2011-01-04', '2011-01-02', '2011-02-02', '2011-02-03'],
@@ -3234,10 +3236,12 @@ class TestSeriesDatetime64(tm.TestCase):
                                  tz=tz, name='other')
             expected3 = DatetimeIndex(['2011-01-04', '2011-01-02'], tz=tz, name=None)
 
-            result2 = rng.intersection(rng2)
-            result3 = rng.intersection(rng3)
-            for (result, expected) in [(result2, expected2), (result3, expected3)]:
-                print(result, expected)
+            # GH 7880
+            rng4 = date_range('7/1/2000', '7/31/2000', freq='D', tz=tz, name='idx')
+            expected4 = DatetimeIndex([], tz=tz, name='idx')
+
+            for (rng, expected) in [(rng2, expected2), (rng3, expected3), (rng4, expected4)]:
+                result = base.intersection(rng)
                 self.assertTrue(result.equals(expected))
                 self.assertEqual(result.name, expected.name)
                 self.assertIsNone(result.freq)


### PR DESCRIPTION
These functions may return different result in case of DST. There seems to be 2 problems:
- `tslib.tz_convert` checks DST and change `deltas` by adjusting `pos` by 1. If input has time-gaps more than 2 DST spans, result will be incorrect.
- `tslib.tz_convert_single` results incorrect if input is just on DST edge.

```
import pandas as pd
import numpy as np
import datetime
import pytz

idx = pd.date_range('2014-03-01', '2015-01-10', freq='H')

f = lambda x: pd.tslib.tz_convert_single(x, pd.tslib.maybe_get_tz('US/Eastern'), 'UTC')
result = pd.tslib.tz_convert(idx.asi8, pd.tslib.maybe_get_tz('US/Eastern'), 'UTC')
result_single = np.vectorize(f)(idx.asi8)
result[result != result_single]
# [1394370000000000000 1394373600000000000 1394377200000000000 ...,
#  1414918800000000000 1414922400000000000 1414926000000000000]
```
#### Note

Additionally, it was modifed to close #7880 also.
