### PR TITLE
BUG: timeseries subplots may display unnecessary minor ticklabels

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -199,6 +199,7 @@ Bug Fixes
 
 
 
+- Bug in ``DataFrame.plot`` with ``subplots=True`` may draw unnecessary minor xticks and yticks (:issue:`7801`)
 
 
 

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -2972,16 +2972,35 @@ def _subplots(nrows=1, ncols=1, naxes=None, sharex=False, sharey=False, squeeze=
         axarr[i] = ax
 
     if nplots > 1:
+        
         if sharex and nrows > 1:
             for ax in axarr[:naxes][:-ncols]:    # only bottom row
                 for label in ax.get_xticklabels():
                     label.set_visible(False)
+                try:
+                    # set_visible will not be effective if
+                    # minor axis has NullLocator and NullFormattor (default)
+                    import matplotlib.ticker as ticker
+                    ax.xaxis.set_minor_locator(ticker.AutoLocator())
+                    ax.xaxis.set_minor_formatter(ticker.FormatStrFormatter(''))
+                    for label in ax.get_xticklabels(minor=True):
+                        label.set_visible(False)
+                except Exception:   # pragma no cover
+                    pass
                 ax.xaxis.get_label().set_visible(False)
         if sharey and ncols > 1:
             for i, ax in enumerate(axarr):
                 if (i % ncols) != 0:  # only first column
                     for label in ax.get_yticklabels():
                         label.set_visible(False)
+                    try:
+                        import matplotlib.ticker as ticker
+                        ax.yaxis.set_minor_locator(ticker.AutoLocator())
+                        ax.yaxis.set_minor_formatter(ticker.FormatStrFormatter(''))
+                        for label in ax.get_yticklabels(minor=True):
+                            label.set_visible(False)
+                    except Exception:   # pragma no cover
+                        pass
                     ax.yaxis.get_label().set_visible(False)
 
     if naxes != nplots:


### PR DESCRIPTION
Related to #7457. The fix was incomplete because it only hides major ticklabels, not minor ticklabels. This causes incorrect result in time-series plot.

(And another problem is `rot` default is not applied to minor ticks. I'll check this separatelly)

```
df = pd.DataFrame(np.random.randn(10, 4), index=pd.date_range(start='2014-07-01', freq='M', periods=10))
df.plot(subplots=True)
```
### Current result:

Minor ticklabels of top 3 axes are not hidden.
![figure_ng](https://cloud.githubusercontent.com/assets/1696302/3634314/36ebc68c-0f22-11e4-9f9c-da803dd27d5e.png)
### Result after fix:

![figure_ok](https://cloud.githubusercontent.com/assets/1696302/3634865/57a28f1a-0f4e-11e4-847f-fff225740439.png)
