### PR TITLE
BUG: reset_index with MultiIndex contains PeriodIndex raises ValueError

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -193,6 +193,8 @@ Bug Fixes
 
 
 
+- Bug in ``DataFrame.reset_index`` which has ``MultiIndex`` contains ``PeriodIndex`` or ``DatetimeIndex`` with tz raises ``ValueError`` (:issue:`7746`, :issue:`7793`)
+
 
 
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2452,13 +2452,13 @@ class DataFrame(NDFrame):
                 if values.dtype == np.object_:
                     values = lib.maybe_convert_objects(values)
 
-                # if we have the labels, extract the values with a mask
-                if labels is not None:
-                    mask = labels == -1
-                    values = values.take(labels)
-                    if mask.any():
-                        values, changed = com._maybe_upcast_putmask(values,
-                                                                    mask, np.nan)
+            # if we have the labels, extract the values with a mask
+            if labels is not None:
+                mask = labels == -1
+                values = values.take(labels)
+                if mask.any():
+                    values, changed = com._maybe_upcast_putmask(values,
+                                                                mask, np.nan)
             return values
 
         new_index = np.arange(len(new_obj))


### PR DESCRIPTION
Closes #7746, Closes #7793.

Sorry, caused by #7533. The `ValueError` is being raised when  `PeriodIndex` or `DatetimeIndex` with tz 's unique values are less than `MultiIndex` length.
