### PR TITLE
ENH/CLN: add HistPlot class inheriting MPLPlot

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -168,6 +168,8 @@ previously results in ``Exception`` or ``TypeError`` (:issue:`7812`)
 
 - ``Timestamp.__repr__`` displays ``dateutil.tz.tzoffset`` info (:issue:`7907`)
 
+- Histogram from ``DataFrame.plot`` with ``kind='hist'`` (:issue:`7809`), See :ref:`the docs<visualization.hist>`.
+
 .. _whatsnew_0150.dt:
 
 .dt accessor

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -123,6 +123,7 @@ a handful of values for plots other than the default Line plot.
 These include:
 
 * :ref:`'bar' <visualization.barplot>` or :ref:`'barh' <visualization.barplot>` for bar plots
+* :ref:`'hist' <visualization.hist>` for histogram
 * :ref:`'kde' <visualization.kde>` or ``'density'`` for density plots
 * :ref:`'area' <visualization.area_plot>` for area plots
 * :ref:`'scatter' <visualization.scatter_matrix>` for scatter plots
@@ -205,6 +206,46 @@ To get horizontal bar plots, pass ``kind='barh'``:
 
 Histograms
 ~~~~~~~~~~
+
+.. versionadded:: 0.15.0
+
+Histogram can be drawn specifying ``kind='hist'``.
+
+.. ipython:: python
+
+   df4 = DataFrame({'a': randn(1000) + 1, 'b': randn(1000),
+                    'c': randn(1000) - 1}, columns=['a', 'b', 'c'])
+
+   plt.figure();
+
+   @savefig hist_new.png
+   df4.plot(kind='hist', alpha=0.5)
+
+Histogram can be stacked by ``stacked=True``. Bin size can be changed by ``bins`` keyword.
+
+.. ipython:: python
+
+   plt.figure();
+
+   @savefig hist_new_stacked.png
+   df4.plot(kind='hist', stacked=True, bins=20)
+
+You can pass other keywords supported by matplotlib ``hist``. For example, horizontal and cumulative histgram can be drawn by ``orientation='horizontal'`` and ``cumulative='True'``.
+
+.. ipython:: python
+
+   plt.figure();
+
+   @savefig hist_new_kwargs.png
+   df4['a'].plot(kind='hist', orientation='horizontal', cumulative=True)
+
+
+See the :meth:`hist <matplotlib.axes.Axes.hist>` method and the
+`matplotlib hist documenation <http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.hist>`__ for more.
+
+
+The previous interface ``DataFrame.hist`` to plot histogram still can be used.
+
 .. ipython:: python
 
    plt.figure();


### PR DESCRIPTION
Because `hist` and `boxplot` are separated from normal `plot`, there are some inconsistencies with these functions. Looks better to include them to `MPLPlot` framework.

Maybe `scatter` and `hist` can be deprecated in 0.15 if `MPLPlot` can offer better `GroupBy` plot (plan to do in separate PR).
### Example

This allows to use `kind='hist` in `DataFrame.plot` and `Series.plot`. (No changes for `DataFrame.hist`)

```
import pandas as pd
import numpy as np
import matplotlib.pyplot as plt

df = pd.DataFrame(np.random.randn(1000, 5))
df.plot(kind='hist', subplots=True)
```

![figure_1](https://cloud.githubusercontent.com/assets/1696302/3712412/16aa1896-1513-11e4-863d-e0b6d631c12f.png)

```
df.plot(kind='hist', stacked=True)
```

![figure_2](https://cloud.githubusercontent.com/assets/1696302/3712413/1bded702-1513-11e4-9ff3-3947783d5213.png)
### Remaining Items
- [x] Add a release note in API section detailing this change/enhancement
- [x] Modify doc
- [x] Add tests (both histogram and kde) 
  - [x] Add support for `rot` and `fontsize` (depending on `orientation` kw) (rely on #7844)
  - [x] Add tests for xticklabels and yticklabels
  - [x] Add tests for colors
  - [x] Handling nan
- [x] Check `stacked=True` can be supported (`DataFrame.hist` doesn't support it though..).
  - [x] Add tests for stacking
