### PR TITLE
BUG/VIS: rot and fontsize are not applied to timeseries plots

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -305,7 +305,7 @@ Bug Fixes
   (except for the case of two DataFrames with ``pairwise=False``, where behavior is unchanged) (:issue:`7542`)
 
 
-
+- Bug in ``DataFrame.plot`` and ``Series.plot`` may ignore ``rot`` and ``fontsize`` keywords (:issue:`7844`)
 
 
 - Bug in ``DatetimeIndex.value_counts`` doesn't preserve tz  (:issue:`7735`)


### PR DESCRIPTION
In some plots, `rot` and `fontsize` arguments are not applied properly.
- timeseries line / area plot: `rot` is not applied to minor ticklabels, and `fontsize` is completely ignored. (Fixed to apply to xticklabels)
- kde plot: `rot` and `fontsize` are completely ignored. (Fixed to apply to xticklabels)
- scatter and hexbin plots: `rot` and `fontsize` are completely ignored. (Under confirmation)

```
import pandas as pd
import numpy as np

df = pd.DataFrame(np.random.randn(10, 4), index=pd.date_range(start='2014-07-01', freq='M', periods=10))
df.plot(rot=80, fontsize=15)
```
### Current Result

![figure_ng](https://cloud.githubusercontent.com/assets/1696302/3709379/7841977e-1454-11e4-8396-fc42e943d54a.png)
### After Fix

![figure_ok](https://cloud.githubusercontent.com/assets/1696302/3709380/7cc1037a-1454-11e4-9456-a9335907473b.png)
