### PR TITLE
ENH: tz_localize(None) allows to reset tz

### DIFF
--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -1454,6 +1454,19 @@ to determine the right offset.
    rng_hourly_eastern = rng_hourly.tz_localize('US/Eastern', infer_dst=True)
    rng_hourly_eastern.values
 
+
+To remove timezone from tz-aware ``DatetimeIndex``, use ``tz_localize(None)`` or ``tz_convert(None)``. ``tz_localize(None)`` will remove timezone holding local time representations. ``tz_convert(None)`` will remove timezone after converting to UTC time.
+
+.. ipython:: python
+
+   didx = DatetimeIndex(start='2014-08-01 09:00', freq='H', periods=10, tz='US/Eastern')
+   didx
+   didx.tz_localize(None)
+   didx.tz_convert(None)
+
+   # tz_convert(None) is identical with tz_convert('UTC').tz_localize(None)
+   didx.tz_convert('UCT').tz_localize(None)
+
 .. _timeseries.timedeltas:
 
 Time Deltas

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -142,6 +142,18 @@ API changes
      In [3]: idx.isin(['a', 'c', 'e'], level=1)
      Out[3]: array([ True, False,  True,  True, False,  True], dtype=bool)
 
+- ``tz_localize(None)`` for tz-aware ``Timestamp`` and ``DatetimeIndex`` now removes timezone holding local time,
+previously results in ``Exception`` or ``TypeError`` (:issue:`7812`)
+
+  .. ipython:: python
+
+     ts = Timestamp('2014-08-01 09:00', tz='US/Eastern')
+     ts
+     ts.tz_localize(None)
+
+     didx = DatetimeIndex(start='2014-08-01 09:00', freq='H', periods=10, tz='US/Eastern')
+     didx
+     didx.tz_localize(None)
 
 .. _whatsnew_0150.cat:
 

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -97,6 +97,33 @@ class TestTimestamp(tm.TestCase):
         self.assertEqual(conv.nanosecond, 5)
         self.assertEqual(conv.hour, 19)
 
+    def test_tz_localize_roundtrip(self):
+        for tz in ['UTC', 'Asia/Tokyo', 'US/Eastern', 'dateutil/US/Pacific']:
+            for t in ['2014-02-01 09:00', '2014-07-08 09:00', '2014-11-01 17:00',
+                      '2014-11-05 00:00']:
+                ts = Timestamp(t)
+                localized = ts.tz_localize(tz)
+                self.assertEqual(localized, Timestamp(t, tz=tz))
+
+                with tm.assertRaises(Exception):
+                    localized.tz_localize(tz)
+
+                reset = localized.tz_localize(None)
+                self.assertEqual(reset, ts)
+                self.assertTrue(reset.tzinfo is None)
+
+    def test_tz_convert_roundtrip(self):
+        for tz in ['UTC', 'Asia/Tokyo', 'US/Eastern', 'dateutil/US/Pacific']:
+            for t in ['2014-02-01 09:00', '2014-07-08 09:00', '2014-11-01 17:00',
+                      '2014-11-05 00:00']:
+                ts = Timestamp(t, tz='UTC')
+                converted = ts.tz_convert(tz)
+
+                reset = converted.tz_convert(None)
+                self.assertEqual(reset, Timestamp(t))
+                self.assertTrue(reset.tzinfo is None)
+                self.assertEqual(reset, converted.tz_convert('UTC').tz_localize(None))
+
     def test_barely_oob_dts(self):
         one_us = np.timedelta64(1).astype('timedelta64[us]')
 

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -373,11 +373,14 @@ class Timestamp(_Timestamp):
 
     def tz_localize(self, tz, infer_dst=False):
         """
-        Convert naive Timestamp to local time zone
+        Convert naive Timestamp to local time zone, or remove
+        timezone from tz-aware Timestamp.
 
         Parameters
         ----------
-        tz : pytz.timezone or dateutil.tz.tzfile
+        tz : string, pytz.timezone, dateutil.tz.tzfile or None
+            Time zone for time which Timestamp will be converted to.
+            None will remove timezone holding local time.
         infer_dst : boolean, default False
             Attempt to infer fall dst-transition hours based on order
 
@@ -392,8 +395,13 @@ class Timestamp(_Timestamp):
                                        infer_dst=infer_dst)[0]
             return Timestamp(value, tz=tz)
         else:
-            raise Exception('Cannot localize tz-aware Timestamp, use '
-                            'tz_convert for conversions')
+            if tz is None:
+                # reset tz
+                value = tz_convert_single(self.value, 'UTC', self.tz)
+                return Timestamp(value, tz=None)
+            else:
+                raise Exception('Cannot localize tz-aware Timestamp, use '
+                                'tz_convert for conversions')
 
     def tz_convert(self, tz):
         """
@@ -402,7 +410,9 @@ class Timestamp(_Timestamp):
 
         Parameters
         ----------
-        tz : pytz.timezone or dateutil.tz.tzfile
+        tz : string, pytz.timezone, dateutil.tz.tzfile or None
+            Time zone for time which Timestamp will be converted to.
+            None will remove timezone holding UTC time.
 
         Returns
         -------


### PR DESCRIPTION
Closes #7812. Allow `tz_localize(None)` for tz-aware `Timestamp` and `DatetimeIndex` to reset tz.
CC @rockg, @nehalecky 

```
t = pd.Timestamp('2014-01-01 09:00', tz='Asia/Tokyo')

# tz_localize resets tz holding current tz representation
t.tz_localize(None)
#2014-01-01 09:00:00

# tz_convert reset tz using UTC representation (no changes by this PR)
t.tz_convert(None)
#2014-01-01 00:00:00

idx = pd.date_range(start='2011-01-01 09:00', freq='H', periods=10, tz='Asia/Tokyo')

idx.tz_localize(None)
# <class 'pandas.tseries.index.DatetimeIndex'
# [2011-01-01 09:00:00, ..., 2011-01-01 18:00:00]
# Length: 10, Freq: H, Timezone: None

#  (no changes by this PR)
idx.tz_convert(None)
# <class 'pandas.tseries.index.DatetimeIndex'>
# [2011-01-01 00:00:00, ..., 2011-01-01 09:00:00]
# Length: 10, Freq: H, Timezone: None
```
