### PR TITLE
CLN: Clean tslib, frequencies import

### DIFF
--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -16,7 +16,7 @@ from pandas.core.index import MultiIndex
 from pandas.core.series import Series, remove_na
 from pandas.tseries.index import DatetimeIndex
 from pandas.tseries.period import PeriodIndex, Period
-from pandas.tseries.frequencies import get_period_alias, get_base_alias
+import pandas.tseries.frequencies as frequencies
 from pandas.tseries.offsets import DateOffset
 from pandas.compat import range, lrange, lmap, map, zip, string_types
 import pandas.compat as compat
@@ -1504,8 +1504,8 @@ class LinePlot(MPLPlot):
         if isinstance(freq, DateOffset):
             freq = freq.rule_code
         else:
-            freq = get_base_alias(freq)
-        freq = get_period_alias(freq)
+            freq = frequencies.get_base_alias(freq)
+        freq = frequencies.get_period_alias(freq)
         return freq is not None and self._no_base(freq)
 
     def _no_base(self, freq):
@@ -1513,10 +1513,9 @@ class LinePlot(MPLPlot):
         from pandas.core.frame import DataFrame
         if (isinstance(self.data, (Series, DataFrame))
             and isinstance(self.data.index, DatetimeIndex)):
-            import pandas.tseries.frequencies as freqmod
-            base = freqmod.get_freq(freq)
+            base = frequencies.get_freq(freq)
             x = self.data.index
-            if (base <= freqmod.FreqGroup.FR_DAY):
+            if (base <= frequencies.FreqGroup.FR_DAY):
                 return x[:1].is_normalized
 
             return Period(x[0], freq).to_timestamp(tz=x.tz) == x[0]
@@ -1632,8 +1631,8 @@ class LinePlot(MPLPlot):
                 freq = getattr(data.index, 'inferred_freq', None)
             if isinstance(freq, DateOffset):
                 freq = freq.rule_code
-            freq = get_base_alias(freq)
-            freq = get_period_alias(freq)
+            freq = frequencies.get_base_alias(freq)
+            freq = frequencies.get_period_alias(freq)
 
             if freq is None:
                 ax = self._get_ax(0)

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -19,7 +19,7 @@ from pandas.core.datetools import (
 
 from pandas.tseries.frequencies import _offset_map
 from pandas.tseries.index import _to_m8, DatetimeIndex, _daterange_cache, date_range
-from pandas.tseries.tools import parse_time_string, _maybe_get_tz
+from pandas.tseries.tools import parse_time_string
 import pandas.tseries.offsets as offsets
 
 from pandas.tslib import NaT, Timestamp
@@ -243,7 +243,7 @@ class TestCommon(Base):
 
         for tz in self.timezones:
             expected_localize = expected.tz_localize(tz)
-            tz_obj = _maybe_get_tz(tz)
+            tz_obj = tslib.maybe_get_tz(tz)
             dt_tz = tslib._localize_pydatetime(dt, tz_obj)
 
             result = func(dt_tz)

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -15,7 +15,7 @@ from pandas.tseries.frequencies import MONTHS, DAYS, _period_code_map
 from pandas.tseries.period import Period, PeriodIndex, period_range
 from pandas.tseries.index import DatetimeIndex, date_range, Index
 from pandas.tseries.tools import to_datetime
-import pandas.tseries.period as pmod
+import pandas.tseries.period as period
 
 import pandas.core.datetools as datetools
 import pandas as pd
@@ -508,7 +508,7 @@ class TestPeriodProperties(tm.TestCase):
     def test_pnow(self):
         dt = datetime.now()
 
-        val = pmod.pnow('D')
+        val = period.pnow('D')
         exp = Period(dt, freq='D')
         self.assertEqual(val, exp)
 

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -15,7 +15,7 @@ from pandas import (Index, Series, TimeSeries, DataFrame,
 import pandas.core.datetools as datetools
 import pandas.tseries.offsets as offsets
 import pandas.tseries.tools as tools
-import pandas.tseries.frequencies as fmod
+import pandas.tseries.frequencies as frequencies
 import pandas as pd
 
 from pandas.util.testing import assert_series_equal, assert_almost_equal
@@ -28,7 +28,6 @@ import pandas.tslib as tslib
 import pandas.index as _index
 
 from pandas.compat import range, long, StringIO, lrange, lmap, zip, product
-import pandas.core.datetools as dt
 from numpy.random import rand
 from numpy.testing import assert_array_equal
 from pandas.util.testing import assert_frame_equal
@@ -2961,7 +2960,7 @@ class TestDatetime64(tm.TestCase):
         edate = datetime(2000, 1, 1)
         idx = DatetimeIndex(start=sdate, freq='1B', periods=20)
         self.assertEqual(len(idx), 20)
-        self.assertEqual(idx[0], sdate + 0 * dt.bday)
+        self.assertEqual(idx[0], sdate + 0 * datetools.bday)
         self.assertEqual(idx.freq, 'B')
 
         idx = DatetimeIndex(end=edate, freq=('D', 5), periods=20)
@@ -2971,19 +2970,19 @@ class TestDatetime64(tm.TestCase):
 
         idx1 = DatetimeIndex(start=sdate, end=edate, freq='W-SUN')
         idx2 = DatetimeIndex(start=sdate, end=edate,
-                             freq=dt.Week(weekday=6))
+                             freq=datetools.Week(weekday=6))
         self.assertEqual(len(idx1), len(idx2))
         self.assertEqual(idx1.offset, idx2.offset)
 
         idx1 = DatetimeIndex(start=sdate, end=edate, freq='QS')
         idx2 = DatetimeIndex(start=sdate, end=edate,
-                             freq=dt.QuarterBegin(startingMonth=1))
+                             freq=datetools.QuarterBegin(startingMonth=1))
         self.assertEqual(len(idx1), len(idx2))
         self.assertEqual(idx1.offset, idx2.offset)
 
         idx1 = DatetimeIndex(start=sdate, end=edate, freq='BQ')
         idx2 = DatetimeIndex(start=sdate, end=edate,
-                             freq=dt.BQuarterEnd(startingMonth=12))
+                             freq=datetools.BQuarterEnd(startingMonth=12))
         self.assertEqual(len(idx1), len(idx2))
         self.assertEqual(idx1.offset, idx2.offset)
 
@@ -3474,31 +3473,31 @@ class TestTimestamp(tm.TestCase):
         self.assertEqual(result.nanosecond, val.nanosecond)
 
     def test_frequency_misc(self):
-        self.assertEqual(fmod.get_freq_group('T'),
-                          fmod.FreqGroup.FR_MIN)
+        self.assertEqual(frequencies.get_freq_group('T'),
+                          frequencies.FreqGroup.FR_MIN)
 
-        code, stride = fmod.get_freq_code(offsets.Hour())
-        self.assertEqual(code, fmod.FreqGroup.FR_HR)
+        code, stride = frequencies.get_freq_code(offsets.Hour())
+        self.assertEqual(code, frequencies.FreqGroup.FR_HR)
 
-        code, stride = fmod.get_freq_code((5, 'T'))
-        self.assertEqual(code, fmod.FreqGroup.FR_MIN)
+        code, stride = frequencies.get_freq_code((5, 'T'))
+        self.assertEqual(code, frequencies.FreqGroup.FR_MIN)
         self.assertEqual(stride, 5)
 
         offset = offsets.Hour()
-        result = fmod.to_offset(offset)
+        result = frequencies.to_offset(offset)
         self.assertEqual(result, offset)
 
-        result = fmod.to_offset((5, 'T'))
+        result = frequencies.to_offset((5, 'T'))
         expected = offsets.Minute(5)
         self.assertEqual(result, expected)
 
-        self.assertRaises(ValueError, fmod.get_freq_code, (5, 'baz'))
+        self.assertRaises(ValueError, frequencies.get_freq_code, (5, 'baz'))
 
-        self.assertRaises(ValueError, fmod.to_offset, '100foo')
+        self.assertRaises(ValueError, frequencies.to_offset, '100foo')
 
-        self.assertRaises(ValueError, fmod.to_offset, ('', ''))
+        self.assertRaises(ValueError, frequencies.to_offset, ('', ''))
 
-        result = fmod.get_standard_freq(offsets.Hour())
+        result = frequencies.get_standard_freq(offsets.Hour())
         self.assertEqual(result, 'H')
 
     def test_hash_equivalent(self):
@@ -3936,7 +3935,7 @@ class TimeConversionFormats(tm.TestCase):
         val = '01-Apr-2011 00:00:01.978'
         format = '%d-%b-%Y %H:%M:%S.%f'
         result = to_datetime(val, format=format)
-        exp = dt.datetime.strptime(val, format)
+        exp = datetime.strptime(val, format)
         self.assertEqual(result, exp)
 
     def test_to_datetime_format_time(self):

--- a/pandas/tseries/tools.py
+++ b/pandas/tseries/tools.py
@@ -56,20 +56,6 @@ def _infer_tzinfo(start, end):
     return tz
 
 
-def _maybe_get_tz(tz, date=None):
-    tz = tslib.maybe_get_tz(tz)
-    if com.is_integer(tz):
-        import pytz
-        tz = pytz.FixedOffset(tz / 60)
-
-    # localize and get the tz
-    if date is not None and tz is not None:
-        if date.tzinfo is not None and hasattr(tz,'localize'):
-            tz = tz.localize(date.replace(tzinfo=None)).tzinfo
-
-    return tz
-
-
 def _guess_datetime_format(dt_str, dayfirst=False,
                            dt_str_parse=compat.parse_date,
                            dt_str_split=_DATEUTIL_LEXER_SPLIT):

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -1121,9 +1121,10 @@ cpdef inline object maybe_get_tz(object tz):
                 tz._filename = zone
         else:
             tz = pytz.timezone(tz)
-        return tz
-    else:
-        return tz
+    elif util.is_integer_object(tz):
+        tz = pytz.FixedOffset(tz / 60)
+    return tz
+
 
 
 class OutOfBoundsDatetime(ValueError):
@@ -2223,7 +2224,7 @@ def tz_localize_to_utc(ndarray[int64_t] vals, object tz, bint infer_dst=False):
     result_b.fill(NPY_NAT)
 
     # left side
-    idx_shifted = _ensure_int64(
+    idx_shifted = ensure_int64(
         np.maximum(0, trans.searchsorted(vals - DAY_NS, side='right') - 1))
 
     for i in range(n):
@@ -2235,7 +2236,7 @@ def tz_localize_to_utc(ndarray[int64_t] vals, object tz, bint infer_dst=False):
             result_a[i] = v
 
     # right side
-    idx_shifted = _ensure_int64(
+    idx_shifted = ensure_int64(
         np.maximum(0, trans.searchsorted(vals + DAY_NS, side='right') - 1))
 
     for i in range(n):
@@ -2313,14 +2314,8 @@ def tz_localize_to_utc(ndarray[int64_t] vals, object tz, bint infer_dst=False):
 
     return result
 
-cdef _ensure_int64(object arr):
-    if util.is_array(arr):
-        if (<ndarray> arr).descr.type_num == NPY_INT64:
-            return arr
-        else:
-            return arr.astype(np.int64)
-    else:
-        return np.array(arr, dtype=np.int64)
+import pandas.algos as algos
+ensure_int64 = algos.ensure_int64
 
 
 cdef inline bisect_right_i8(int64_t *data, int64_t val, Py_ssize_t n):


### PR DESCRIPTION
Fixed:
- Some modules are imported different aliases
- Merge duplicated functions (`maybe_get_tz` and `ensure_int64`)
