### PR TITLE
ENH add level argument to set_names, set_levels and set_labels (GH7792)

### DIFF
--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -2162,6 +2162,17 @@ you can specify ``inplace=True`` to have the data change in place.
   ind.name = "bob"
   ind
 
+.. versionadded:: 0.15.0
+
+``set_names``, ``set_levels``, and ``set_labels`` also take an optional 
+`level`` argument
+
+.. ipython:: python
+
+  index
+  index.levels[1]
+  index.set_levels(["a", "b"], level=1)
+
 Adding an index to an existing DataFrame
 ----------------------------------------
 

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -35,6 +35,16 @@ API changes
   levels aren't all level names or all level numbers. See
   :ref:`Reshaping by stacking and unstacking <reshaping.stack_multiple>`.
 
+- :func:`set_names`, :func:`set_labels`, and :func:`set_levels` methods now take an optional ``level`` keyword argument to all modification of specific level(s) of a MultiIndex. Additionally :func:`set_names` now accepts a scalar string value when operating on an ``Index`` or on a specific level of a ``MultiIndex`` (:issue:`7792`)
+
+  .. ipython:: python
+
+      idx = pandas.MultiIndex.from_product([['a'], range(3), list("pqr")], names=['foo', 'bar', 'baz'])
+      idx.set_names('qux', level=0)
+      idx.set_names(['qux','baz'], level=[0,1])
+      idx.set_levels(['a','b','c'], level='bar')
+      idx.set_levels([['a','b','c'],[1,2,3]], level=[1,2])
+
 - Raise a ``ValueError`` in ``df.to_hdf`` with 'fixed' format, if ``df`` has non-unique columns as the resulting file will be broken (:issue:`7761`)
 
 - :func:`rolling_min`, :func:`rolling_max`, :func:`rolling_cov`, and :func:`rolling_corr`


### PR DESCRIPTION
Closes #7792

New `level` argument:

```
set_names(self, names, level=None, inplace=False)
set_levels(self, levels, level=None, inplace=False, verify_integrity=True)
set_labels(self, labels, level=None, inplace=False, verify_integrity=True)
```

e.g.
    set_names('foo',level=1)
    set_names(['foo','bar'],level=[1,2])
    set_levels(['a','b','c'],level=1)
    set_levels([['a','b','c'],[1,2,3]],level=[1,2])
