### PR TITLE
PERF: groupby / frame apply optimization

### DIFF
--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -635,11 +635,11 @@ class GroupBy(PandasObject):
 
         @wraps(func)
         def f(g):
-            # ignore SettingWithCopy here in case the user mutates
-            with option_context('mode.chained_assignment',None):
-                return func(g, *args, **kwargs)
+            return func(g, *args, **kwargs)
 
-        return self._python_apply_general(f)
+        # ignore SettingWithCopy here in case the user mutates
+        with option_context('mode.chained_assignment',None):
+            return self._python_apply_general(f)
 
     def _python_apply_general(self, f):
         keys, values, mutated = self.grouper.apply(f, self._selected_obj,

--- a/pandas/io/tests/test_data.py
+++ b/pandas/io/tests/test_data.py
@@ -445,7 +445,10 @@ class TestFred(tm.TestCase):
         end = datetime(2013, 1, 27)
 
         received = web.DataReader("GDP", "fred", start, end)['GDP'].tail(1)[0]
-        self.assertEqual(int(received), 16535)
+
+        # < 7/30/14 16535 was returned
+        #self.assertEqual(int(received), 16535)
+        self.assertEqual(int(received), 16502)
 
         self.assertRaises(Exception, web.DataReader, "NON EXISTENT SERIES",
                           'fred', start, end)


### PR DESCRIPTION
```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
groupby_frame_apply_overhead                 |   9.1400 |  70.3743 |   0.1299 |
groupby_frame_apply                          |  43.5640 | 186.6427 |   0.2334 |
groupby_apply_dict_return                    |  39.6016 |  80.1926 |   0.4938 |
```
