### PR TITLE
CLN/INT: remove Index as a sub-class of NDArray

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1104,6 +1104,8 @@ Modifying and Computations
    Index.order
    Index.reindex
    Index.repeat
+   Index.take
+   Index.putmask
    Index.set_names
    Index.unique
    Index.nunique

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -52,6 +52,12 @@ indexing.
    should be avoided.  See :ref:`Returning a View versus Copy
    <indexing.view_versus_copy>`
 
+.. warning::
+
+   In 0.15.0 ``Index`` has internally been refactored to no longer sub-class ``ndarray``
+   but instead subclass ``PandasObject``, similarly to the rest of the pandas objects. This should be
+   a transparent change with only very limited API implications (See the :ref:`Internal Refactoring <whatsnew_0150.refactoring>`)
+
 See the :ref:`cookbook<cookbook.selection>` for some advanced strategies
 
 Different Choices for Indexing (``loc``, ``iloc``, and ``ix``)
@@ -2175,7 +2181,7 @@ you can specify ``inplace=True`` to have the data change in place.
 
 .. versionadded:: 0.15.0
 
-``set_names``, ``set_levels``, and ``set_labels`` also take an optional 
+``set_names``, ``set_levels``, and ``set_labels`` also take an optional
 `level`` argument
 
 .. ipython:: python

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -10,6 +10,7 @@ users upgrade to this version.
 - Highlights include:
 
   - The ``Categorical`` type was integrated as a first-class pandas type, see :ref:`here <whatsnew_0150.cat>`
+  - Internal refactoring of the ``Index`` class to no longer sub-class ``ndarray``, see :ref:`Internal Refactoring <whatsnew_0150.refactoring>`
 
 - :ref:`Other Enhancements <whatsnew_0150.enhancements>`
 
@@ -24,6 +25,12 @@ users upgrade to this version.
 - :ref:`Known Issues <whatsnew_0150.knownissues>`
 
 - :ref:`Bug Fixes <whatsnew_0150.bug_fixes>`
+
+.. warning::
+
+   In 0.15.0 ``Index`` has internally been refactored to no longer sub-class ``ndarray``
+   but instead subclass ``PandasObject``, similarly to the rest of the pandas objects. This change allows very easy sub-classing and creation of new index types. This should be
+   a transparent change with only very limited API implications (See the :ref:`Internal Refactoring <whatsnew_0150.refactoring>`)
 
 .. _whatsnew_0150.api:
 
@@ -155,6 +162,18 @@ previously results in ``Exception`` or ``TypeError`` (:issue:`7812`)
      didx
      didx.tz_localize(None)
 
+.. _whatsnew_0150.refactoring:
+
+Internal Refactoring
+~~~~~~~~~~~~~~~~~~~~
+
+In 0.15.0 ``Index`` has internally been refactored to no longer sub-class ``ndarray``
+but instead subclass ``PandasObject``, similarly to the rest of the pandas objects. This change allows very easy sub-classing and creation of new index types. This should be
+a transparent change with only very limited API implications (:issue:`5080`,:issue:`7439`,:issue:`7796`)
+
+- you may need to unpickle pandas version < 0.15.0 pickles using ``pd.read_pickle`` rather than ``pickle.load``. See :ref:`pickle docs <io.pickle>`
+- when plotting with a ``PeriodIndex``. The ``matplotlib`` internal axes will now be arrays of ``Period`` rather than a ``PeriodIndex``. (this is similar to how a ``DatetimeIndex`` passess arrays of ``datetimes`` now)
+
 .. _whatsnew_0150.cat:
 
 Categoricals in Series/DataFrame
@@ -278,7 +297,7 @@ Performance
 ~~~~~~~~~~~
 
 - Performance improvements in ``DatetimeIndex.__iter__`` to allow faster iteration (:issue:`7683`)
-
+- Performance improvements in ``Period`` creation (and ``PeriodIndex`` setitem) (:issue:`5155`)
 
 
 
@@ -386,7 +405,7 @@ Bug Fixes
 - Bug in ``GroupBy.filter()`` where fast path vs. slow path made the filter
   return a non scalar value that appeared valid but wasn't (:issue:`7870`).
 - Bug in ``date_range()``/``DatetimeIndex()`` when the timezone was inferred from input dates yet incorrect
-  times were returned when crossing DST boundaries (:issue:`7835`, :issue:`7901`).  
+  times were returned when crossing DST boundaries (:issue:`7835`, :issue:`7901`).
 
 
 

--- a/pandas/compat/pickle_compat.py
+++ b/pandas/compat/pickle_compat.py
@@ -5,29 +5,32 @@ import numpy as np
 import pandas
 import copy
 import pickle as pkl
-from pandas import compat
+from pandas import compat, Index
 from pandas.compat import u, string_types
-from pandas.core.series import Series, TimeSeries
-from pandas.sparse.series import SparseSeries, SparseTimeSeries
-
 
 def load_reduce(self):
     stack = self.stack
     args = stack.pop()
     func = stack[-1]
+
     if type(args[0]) is type:
         n = args[0].__name__
-        if n == u('DeprecatedSeries') or n == u('DeprecatedTimeSeries'):
-            stack[-1] = object.__new__(Series)
-            return
-        elif (n == u('DeprecatedSparseSeries') or
-              n == u('DeprecatedSparseTimeSeries')):
-            stack[-1] = object.__new__(SparseSeries)
-            return
 
     try:
-        value = func(*args)
-    except:
+        stack[-1] = func(*args)
+        return
+    except Exception as e:
+
+        # if we have a deprecated function
+        # try to replace and try again
+
+        if '_reconstruct: First argument must be a sub-type of ndarray' in str(e):
+            try:
+                cls = args[0]
+                stack[-1] = object.__new__(cls)
+                return
+            except:
+                pass
 
         # try to reencode the arguments
         if getattr(self,'encoding',None) is not None:
@@ -57,6 +60,35 @@ else:
 Unpickler.dispatch = copy.copy(Unpickler.dispatch)
 Unpickler.dispatch[pkl.REDUCE[0]] = load_reduce
 
+def load_newobj(self):
+    args = self.stack.pop()
+    cls = self.stack[-1]
+
+    # compat
+    if issubclass(cls, Index):
+        obj = object.__new__(cls)
+    else:
+        obj = cls.__new__(cls, *args)
+
+    self.stack[-1] = obj
+Unpickler.dispatch[pkl.NEWOBJ[0]] = load_newobj
+
+# py3 compat
+def load_newobj_ex(self):
+    kwargs = self.stack.pop()
+    args = self.stack.pop()
+    cls = self.stack.pop()
+
+    # compat
+    if issubclass(cls, Index):
+        obj = object.__new__(cls)
+    else:
+        obj = cls.__new__(cls, *args, **kwargs)
+    self.append(obj)
+try:
+    Unpickler.dispatch[pkl.NEWOBJ_EX[0]] = load_newobj_ex
+except:
+    pass
 
 def load(fh, encoding=None, compat=False, is_verbose=False):
     """load a pickle, with a provided encoding
@@ -74,11 +106,6 @@ def load(fh, encoding=None, compat=False, is_verbose=False):
     """
 
     try:
-        if compat:
-            pandas.core.series.Series = DeprecatedSeries
-            pandas.core.series.TimeSeries = DeprecatedTimeSeries
-            pandas.sparse.series.SparseSeries = DeprecatedSparseSeries
-            pandas.sparse.series.SparseTimeSeries = DeprecatedSparseTimeSeries
         fh.seek(0)
         if encoding is not None:
             up = Unpickler(fh, encoding=encoding)
@@ -89,25 +116,3 @@ def load(fh, encoding=None, compat=False, is_verbose=False):
         return up.load()
     except:
         raise
-    finally:
-        if compat:
-            pandas.core.series.Series = Series
-            pandas.core.series.Series = TimeSeries
-            pandas.sparse.series.SparseSeries = SparseSeries
-            pandas.sparse.series.SparseTimeSeries = SparseTimeSeries
-
-
-class DeprecatedSeries(np.ndarray, Series):
-    pass
-
-
-class DeprecatedTimeSeries(DeprecatedSeries):
-    pass
-
-
-class DeprecatedSparseSeries(DeprecatedSeries):
-    pass
-
-
-class DeprecatedSparseTimeSeries(DeprecatedSparseSeries):
-    pass

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -939,6 +939,6 @@ def _get_codes_for_values(values, levels):
         levels = com._ensure_object(levels)
     (hash_klass, vec_klass), vals = _get_data_algo(values, _hashtables)
     t = hash_klass(len(levels))
-    t.map_locations(levels)
+    t.map_locations(com._values_from_object(levels))
     return com._ensure_platform_int(t.lookup(values))
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -205,7 +205,7 @@ def _isnull_new(obj):
     # hack (for now) because MI registers as ndarray
     elif isinstance(obj, pd.MultiIndex):
         raise NotImplementedError("isnull is not defined for MultiIndex")
-    elif isinstance(obj, (ABCSeries, np.ndarray)):
+    elif isinstance(obj, (ABCSeries, np.ndarray, pd.Index)):
         return _isnull_ndarraylike(obj)
     elif isinstance(obj, ABCGeneric):
         return obj._constructor(obj._data.isnull(func=isnull))
@@ -231,7 +231,7 @@ def _isnull_old(obj):
     # hack (for now) because MI registers as ndarray
     elif isinstance(obj, pd.MultiIndex):
         raise NotImplementedError("isnull is not defined for MultiIndex")
-    elif isinstance(obj, (ABCSeries, np.ndarray)):
+    elif isinstance(obj, (ABCSeries, np.ndarray, pd.Index)):
         return _isnull_ndarraylike_old(obj)
     elif isinstance(obj, ABCGeneric):
         return obj._constructor(obj._data.isnull(func=_isnull_old))
@@ -2024,8 +2024,7 @@ def _is_bool_indexer(key):
 def _default_index(n):
     from pandas.core.index import Int64Index
     values = np.arange(n, dtype=np.int64)
-    result = values.view(Int64Index)
-    result.name = None
+    result = Int64Index(values,name=None)
     result.is_unique = True
     return result
 

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -1186,7 +1186,7 @@ class CSVFormatter(object):
         if cols is None:
             cols = self.columns
 
-        has_aliases = isinstance(header, (tuple, list, np.ndarray))
+        has_aliases = isinstance(header, (tuple, list, np.ndarray, Index))
         if has_aliases or header:
             if index:
                 # should write something for index label
@@ -1205,7 +1205,7 @@ class CSVFormatter(object):
                             else:
                                 index_label = [index_label]
                     elif not isinstance(index_label,
-                                        (list, tuple, np.ndarray)):
+                                        (list, tuple, np.ndarray, Index)):
                         # given a string for a DF with Index
                         index_label = [index_label]
 
@@ -1327,7 +1327,7 @@ class CSVFormatter(object):
         header = self.header
         encoded_labels = []
 
-        has_aliases = isinstance(header, (tuple, list, np.ndarray))
+        has_aliases = isinstance(header, (tuple, list, np.ndarray, Index))
         if not (has_aliases or self.header):
             return
         if has_aliases:
@@ -1355,7 +1355,7 @@ class CSVFormatter(object):
                             index_label = ['']
                         else:
                             index_label = [index_label]
-                elif not isinstance(index_label, (list, tuple, np.ndarray)):
+                elif not isinstance(index_label, (list, tuple, np.ndarray, Index)):
                     # given a string for a DF with Index
                     index_label = [index_label]
 
@@ -1520,7 +1520,7 @@ class ExcelFormatter(object):
         return val
 
     def _format_header_mi(self):
-        has_aliases = isinstance(self.header, (tuple, list, np.ndarray))
+        has_aliases = isinstance(self.header, (tuple, list, np.ndarray, Index))
         if not(has_aliases or self.header):
             return
 
@@ -1566,7 +1566,7 @@ class ExcelFormatter(object):
         self.rowcounter = lnum
 
     def _format_header_regular(self):
-        has_aliases = isinstance(self.header, (tuple, list, np.ndarray))
+        has_aliases = isinstance(self.header, (tuple, list, np.ndarray, Index))
         if has_aliases or self.header:
             coloffset = 0
 
@@ -1611,7 +1611,7 @@ class ExcelFormatter(object):
             return self._format_regular_rows()
 
     def _format_regular_rows(self):
-        has_aliases = isinstance(self.header, (tuple, list, np.ndarray))
+        has_aliases = isinstance(self.header, (tuple, list, np.ndarray, Index))
         if has_aliases or self.header:
             self.rowcounter += 1
 
@@ -1621,7 +1621,7 @@ class ExcelFormatter(object):
             # chek aliases
             # if list only take first as this is not a MultiIndex
             if self.index_label and isinstance(self.index_label,
-                                               (list, tuple, np.ndarray)):
+                                               (list, tuple, np.ndarray, Index)):
                 index_label = self.index_label[0]
             # if string good to go
             elif self.index_label and isinstance(self.index_label, str):
@@ -1661,7 +1661,7 @@ class ExcelFormatter(object):
                 yield ExcelCell(self.rowcounter + i, colidx + coloffset, val)
 
     def _format_hierarchical_rows(self):
-        has_aliases = isinstance(self.header, (tuple, list, np.ndarray))
+        has_aliases = isinstance(self.header, (tuple, list, np.ndarray, Index))
         if has_aliases or self.header:
             self.rowcounter += 1
 
@@ -1671,7 +1671,7 @@ class ExcelFormatter(object):
             index_labels = self.df.index.names
             # check for aliases
             if self.index_label and isinstance(self.index_label,
-                                               (list, tuple, np.ndarray)):
+                                               (list, tuple, np.ndarray, Index)):
                 index_labels = self.index_label
 
             # if index labels are not empty go ahead and dump

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1505,7 +1505,7 @@ class NDFrame(PandasObject):
             if level is not None:
                 if not isinstance(axis, MultiIndex):
                     raise AssertionError('axis must be a MultiIndex')
-                indexer = ~lib.ismember(axis.get_level_values(level),
+                indexer = ~lib.ismember(axis.get_level_values(level).values,
                                         set(labels))
             else:
                 indexer = ~axis.isin(labels)
@@ -2135,16 +2135,14 @@ class NDFrame(PandasObject):
 
         Parameters
         ----------
-        deep : boolean, default True
+        deep : boolean or string, default True
             Make a deep copy, i.e. also copy data
 
         Returns
         -------
         copy : type of caller
         """
-        data = self._data
-        if deep:
-            data = data.copy()
+        data = self._data.copy(deep=deep)
         return self._constructor(data).__finalize__(self)
 
     def convert_objects(self, convert_dates=True, convert_numeric=False,

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -7,7 +7,8 @@ import pandas.compat as compat
 import pandas.core.common as com
 from pandas.core.common import (_is_bool_indexer, is_integer_dtype,
                                 _asarray_tuplesafe, is_list_like, isnull,
-                                ABCSeries, ABCDataFrame, ABCPanel, is_float)
+                                ABCSeries, ABCDataFrame, ABCPanel, is_float,
+                                _values_from_object)
 import pandas.lib as lib
 
 import numpy as np
@@ -1086,7 +1087,7 @@ class _NDFrameIndexer(object):
                         return {'key': obj}
                     raise KeyError('%s not in index' % objarr[mask])
 
-                return indexer
+                return _values_from_object(indexer)
 
         else:
             try:
@@ -1512,7 +1513,7 @@ def _length_of_indexer(indexer, target=None):
         elif step < 0:
             step = abs(step)
         return (stop - start) / step
-    elif isinstance(indexer, (ABCSeries, np.ndarray, list)):
+    elif isinstance(indexer, (ABCSeries, Index, np.ndarray, list)):
         return len(indexer)
     elif not is_list_like(indexer):
         return 1

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2617,15 +2617,22 @@ class BlockManager(PandasObject):
 
         Parameters
         ----------
-        deep : boolean, default True
+        deep : boolean o rstring, default True
             If False, return shallow copy (do not copy data)
+            If 'all', copy data and a deep copy of the index
 
         Returns
         -------
         copy : BlockManager
         """
+
+        # this preserves the notion of view copying of axes
         if deep:
-            new_axes = [ax.view() for ax in self.axes]
+            if deep == 'all':
+                copy = lambda ax: ax.copy(deep=True)
+            else:
+                copy = lambda ax: ax.view()
+            new_axes = [ copy(ax) for ax in self.axes]
         else:
             new_axes = list(self.axes)
         return self.apply('copy', axes=new_axes, deep=deep,

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -1,6 +1,5 @@
 from pandas.compat import cPickle as pkl, pickle_compat as pc, PY3
 
-
 def to_pickle(obj, path):
     """
     Pickle (serialize) object to input file path
@@ -45,7 +44,7 @@ def read_pickle(path):
         try:
             with open(path, 'rb') as fh:
                 return pkl.load(fh)
-        except:
+        except (Exception) as e:
 
             # reg/patched pickle
             try:

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3564,7 +3564,7 @@ class LegacyTable(Table):
                 # need a better algorithm
                 tuple_index = long_index._tuple_index
 
-                unique_tuples = lib.fast_unique(tuple_index)
+                unique_tuples = lib.fast_unique(tuple_index.values)
                 unique_tuples = _asarray_tuplesafe(unique_tuples)
 
                 indexer = match(unique_tuples, tuple_index)

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -857,10 +857,15 @@ class TestHDFStore(tm.TestCase):
                 assert_frame_equal(df,store['df'])
 
             for index in [ tm.makeFloatIndex, tm.makeStringIndex, tm.makeIntIndex,
-                           tm.makeDateIndex, tm.makePeriodIndex ]:
+                           tm.makeDateIndex ]:
 
                 check('table',index)
                 check('fixed',index)
+
+            # period index currently broken for table
+            # seee GH7796 FIXME
+            check('fixed',tm.makePeriodIndex)
+            #check('table',tm.makePeriodIndex)
 
             # unicode
             index = tm.makeUnicodeIndex
@@ -2285,7 +2290,7 @@ class TestHDFStore(tm.TestCase):
 
             # deleted number (entire table)
             n = store.remove('wp', [])
-            assert(n == 120)
+            self.assertTrue(n == 120)
 
             # non - empty where
             _maybe_remove(store, 'wp')
@@ -2379,7 +2384,8 @@ class TestHDFStore(tm.TestCase):
             crit4 = Term('major_axis=date4')
             store.put('wp3', wp, format='t')
             n = store.remove('wp3', where=[crit4])
-            assert(n == 36)
+            self.assertTrue(n == 36)
+
             result = store.select('wp3')
             expected = wp.reindex(major_axis=wp.major_axis - date4)
             assert_panel_equal(result, expected)
@@ -2392,11 +2398,10 @@ class TestHDFStore(tm.TestCase):
             crit1 = Term('major_axis>date')
             crit2 = Term("minor_axis=['A', 'D']")
             n = store.remove('wp', where=[crit1])
-
-            assert(n == 56)
+            self.assertTrue(n == 56)
 
             n = store.remove('wp', where=[crit2])
-            assert(n == 32)
+            self.assertTrue(n == 32)
 
             result = store['wp']
             expected = wp.truncate(after=date).reindex(minor=['B', 'C'])

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -813,7 +813,7 @@ def clean_index_list(list obj):
 
     for i in range(n):
         v = obj[i]
-        if not (PyList_Check(v) or np.PyArray_Check(v)):
+        if not (PyList_Check(v) or np.PyArray_Check(v) or hasattr(v,'_data')):
             all_arrays = 0
             break
 
@@ -823,7 +823,7 @@ def clean_index_list(list obj):
     converted = np.empty(n, dtype=object)
     for i in range(n):
         v = obj[i]
-        if PyList_Check(v) or np.PyArray_Check(v):
+        if PyList_Check(v) or np.PyArray_Check(v) or hasattr(v,'_data'):
             converted[i] = tuple(v)
         else:
             converted[i] = v

--- a/pandas/sparse/tests/test_array.py
+++ b/pandas/sparse/tests/test_array.py
@@ -4,7 +4,6 @@ from numpy import nan, ndarray
 import numpy as np
 
 import operator
-import pickle
 
 from pandas.core.series import Series
 from pandas.core.common import notnull
@@ -169,8 +168,7 @@ class TestSparseArray(tm.TestCase):
 
     def test_pickle(self):
         def _check_roundtrip(obj):
-            pickled = pickle.dumps(obj)
-            unpickled = pickle.loads(pickled)
+            unpickled = self.round_trip_pickle(obj)
             assert_sp_array_equal(unpickled, obj)
 
         _check_roundtrip(self.arr)

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -21,7 +21,7 @@ from pandas.tseries.index import DatetimeIndex
 import pandas.core.datetools as datetools
 from pandas.core.common import isnull
 import pandas.util.testing as tm
-from pandas.compat import range, lrange, cPickle as pickle, StringIO, lrange
+from pandas.compat import range, lrange, StringIO, lrange
 from pandas import compat
 
 import pandas.sparse.frame as spf
@@ -315,8 +315,7 @@ class TestSparseSeries(tm.TestCase,
 
     def test_pickle(self):
         def _test_roundtrip(series):
-            pickled = pickle.dumps(series, protocol=pickle.HIGHEST_PROTOCOL)
-            unpickled = pickle.loads(pickled)
+            unpickled = self.round_trip_pickle(series)
             assert_sp_series_equal(series, unpickled)
             assert_series_equal(series.to_dense(), unpickled.to_dense())
 
@@ -793,7 +792,10 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
         cp = self.frame.copy()
         tm.assert_isinstance(cp, SparseDataFrame)
         assert_sp_frame_equal(cp, self.frame)
-        self.assertTrue(cp.index.is_(self.frame.index))
+
+        # as of v0.15.0
+        # this is now identical (but not is_a )
+        self.assertTrue(cp.index.identical(self.frame.index))
 
     def test_constructor(self):
         for col, series in compat.iteritems(self.frame):
@@ -918,9 +920,8 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
 
     def test_pickle(self):
         def _test_roundtrip(frame):
-            pickled = pickle.dumps(frame, protocol=pickle.HIGHEST_PROTOCOL)
-            unpickled = pickle.loads(pickled)
-            assert_sp_frame_equal(frame, unpickled)
+            result = self.round_trip_pickle(frame)
+            assert_sp_frame_equal(frame, result)
 
         _test_roundtrip(SparseDataFrame())
         self._check_all(_test_roundtrip)
@@ -1608,12 +1609,11 @@ class TestSparsePanel(tm.TestCase,
 
     def test_pickle(self):
         def _test_roundtrip(panel):
-            pickled = pickle.dumps(panel, protocol=pickle.HIGHEST_PROTOCOL)
-            unpickled = pickle.loads(pickled)
-            tm.assert_isinstance(unpickled.items, Index)
-            tm.assert_isinstance(unpickled.major_axis, Index)
-            tm.assert_isinstance(unpickled.minor_axis, Index)
-            assert_sp_panel_equal(panel, unpickled)
+            result = self.round_trip_pickle(panel)
+            tm.assert_isinstance(result.items, Index)
+            tm.assert_isinstance(result.major_axis, Index)
+            tm.assert_isinstance(result.minor_axis, Index)
+            assert_sp_panel_equal(panel, result)
 
         _test_roundtrip(self.panel)
 

--- a/pandas/src/generate_code.py
+++ b/pandas/src/generate_code.py
@@ -55,6 +55,17 @@ cpdef ensure_platform_int(object arr):
     else:
         return np.array(arr, dtype=np.int_)
 
+cpdef ensure_object(object arr):
+    if util.is_array(arr):
+        if (<ndarray> arr).descr.type_num == NPY_OBJECT:
+            return arr
+        else:
+            return arr.astype(np.object_)
+    elif hasattr(arr,'asobject'):
+        return arr.asobject
+    else:
+        return np.array(arr, dtype=np.object_)
+
 """
 
 
@@ -2189,7 +2200,7 @@ ensure_functions = [
     ('int32', 'INT32', 'int32'),
     ('int64', 'INT64', 'int64'),
     # ('platform_int', 'INT', 'int_'),
-    ('object', 'OBJECT', 'object_'),
+    #('object', 'OBJECT', 'object_'),
 ]
 
 def generate_ensure_dtypes():

--- a/pandas/src/generated.pyx
+++ b/pandas/src/generated.pyx
@@ -49,6 +49,17 @@ cpdef ensure_platform_int(object arr):
     else:
         return np.array(arr, dtype=np.int_)
 
+cpdef ensure_object(object arr):
+    if util.is_array(arr):
+        if (<ndarray> arr).descr.type_num == NPY_OBJECT:
+            return arr
+        else:
+            return arr.astype(np.object_)
+    elif hasattr(arr,'asobject'):
+        return arr.asobject
+    else:
+        return np.array(arr, dtype=np.object_)
+
 
 
 cpdef ensure_float64(object arr):
@@ -109,16 +120,6 @@ cpdef ensure_int64(object arr):
             return arr.astype(np.int64)
     else:
         return np.array(arr, dtype=np.int64)
-
-
-cpdef ensure_object(object arr):
-    if util.is_array(arr):
-        if (<ndarray> arr).descr.type_num == NPY_OBJECT:
-            return arr
-        else:
-            return arr.astype(np.object_)
-    else:
-        return np.array(arr, dtype=np.object_)
 
 
 @cython.wraparound(False)
@@ -5932,7 +5933,7 @@ def group_mean_bin_float64(ndarray[float64_t, ndim=2] out,
     for i in range(ngroups):
         for j in range(K):
             count = nobs[i, j]
-            if nobs[i, j] == 0:
+            if count == 0:
                 out[i, j] = nan
             else:
                 out[i, j] = sumx[i, j] / count
@@ -5985,7 +5986,7 @@ def group_mean_bin_float32(ndarray[float32_t, ndim=2] out,
     for i in range(ngroups):
         for j in range(K):
             count = nobs[i, j]
-            if nobs[i, j] == 0:
+            if count == 0:
                 out[i, j] = nan
             else:
                 out[i, j] = sumx[i, j] / count

--- a/pandas/src/ujson/python/objToJSON.c
+++ b/pandas/src/ujson/python/objToJSON.c
@@ -1537,7 +1537,7 @@ ISITERABLE:
       PRINTMARK();
       tc->type = JT_OBJECT;
       pc->columnLabelsLen = PyArray_DIM(pc->newObj, 0);
-      pc->columnLabels = NpyArr_encodeLabels((PyArrayObject*) PyObject_GetAttrString(obj, "index"), (JSONObjectEncoder*) enc, pc->columnLabelsLen);
+      pc->columnLabels = NpyArr_encodeLabels((PyArrayObject*) PyObject_GetAttrString(PyObject_GetAttrString(obj, "index"), "values"), (JSONObjectEncoder*) enc, pc->columnLabelsLen);
       if (!pc->columnLabels)
       {
         goto INVALID;
@@ -1614,7 +1614,7 @@ ISITERABLE:
       PRINTMARK();
       tc->type = JT_ARRAY;
       pc->columnLabelsLen = PyArray_DIM(pc->newObj, 1);
-      pc->columnLabels = NpyArr_encodeLabels((PyArrayObject*) PyObject_GetAttrString(obj, "columns"), (JSONObjectEncoder*) enc, pc->columnLabelsLen);
+      pc->columnLabels = NpyArr_encodeLabels((PyArrayObject*) PyObject_GetAttrString(PyObject_GetAttrString(obj, "columns"), "values"), (JSONObjectEncoder*) enc, pc->columnLabelsLen);
       if (!pc->columnLabels)
       {
         goto INVALID;
@@ -1632,7 +1632,7 @@ ISITERABLE:
         goto INVALID;
       }
       pc->columnLabelsLen = PyArray_DIM(pc->newObj, 1);
-      pc->columnLabels = NpyArr_encodeLabels((PyArrayObject*) PyObject_GetAttrString(obj, "columns"), (JSONObjectEncoder*) enc, pc->columnLabelsLen);
+      pc->columnLabels = NpyArr_encodeLabels((PyArrayObject*) PyObject_GetAttrString(PyObject_GetAttrString(obj, "columns"), "values"), (JSONObjectEncoder*) enc, pc->columnLabelsLen);
       if (!pc->columnLabels)
       {
         NpyArr_freeLabels(pc->rowLabels, pc->rowLabelsLen);
@@ -1645,7 +1645,7 @@ ISITERABLE:
       PRINTMARK();
       tc->type = JT_OBJECT;
       pc->rowLabelsLen = PyArray_DIM(pc->newObj, 1);
-      pc->rowLabels = NpyArr_encodeLabels((PyArrayObject*) PyObject_GetAttrString(obj, "columns"), (JSONObjectEncoder*) enc, pc->rowLabelsLen);
+      pc->rowLabels = NpyArr_encodeLabels((PyArrayObject*) PyObject_GetAttrString(PyObject_GetAttrString(obj, "columns"), "values"), (JSONObjectEncoder*) enc, pc->rowLabelsLen);
       if (!pc->rowLabels)
       {
         goto INVALID;

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -187,15 +187,16 @@ class TestUnique(tm.TestCase):
             len(algos.unique(lst))
 
     def test_on_index_object(self):
+
         mindex = pd.MultiIndex.from_arrays([np.arange(5).repeat(5),
                                             np.tile(np.arange(5), 5)])
+        expected = mindex.values
+        expected.sort()
+
         mindex = mindex.repeat(2)
 
         result = pd.unique(mindex)
         result.sort()
-
-        expected = mindex.values
-        expected.sort()
 
         tm.assert_almost_equal(result, expected)
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -16,7 +16,7 @@ from distutils.version import LooseVersion
 
 from pandas.compat import(
     map, zip, range, long, lrange, lmap, lzip,
-    OrderedDict, cPickle as pickle, u, StringIO
+    OrderedDict, u, StringIO
 )
 from pandas import compat
 
@@ -3620,6 +3620,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df = DataFrame()
         df['a'] = i
         assert_frame_equal(df, expected)
+
         df = DataFrame( {'a' : i } )
         assert_frame_equal(df, expected)
 
@@ -3925,14 +3926,14 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_frame_equal(result, self.frame.apply(np.sqrt))
 
     def test_pickle(self):
-        unpickled = pickle.loads(pickle.dumps(self.mixed_frame))
+        unpickled = self.round_trip_pickle(self.mixed_frame)
         assert_frame_equal(self.mixed_frame, unpickled)
 
         # buglet
         self.mixed_frame._data.ndim
 
         # empty
-        unpickled = pickle.loads(pickle.dumps(self.empty))
+        unpickled = self.round_trip_pickle(self.empty)
         repr(unpickled)
 
     def test_to_dict(self):
@@ -12578,6 +12579,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.assertTrue(df.T.empty)
 
     def test_any_all(self):
+
         self._check_bool_op('any', np.any, has_skipna=True, has_bool_only=True)
         self._check_bool_op('all', np.all, has_skipna=True, has_bool_only=True)
 

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1000,7 +1000,8 @@ class TestDataFramePlots(TestPlotBase):
         pd.plot_params['x_compat'] = False
         ax = df.plot()
         lines = ax.get_lines()
-        tm.assert_isinstance(lines[0].get_xdata(), PeriodIndex)
+        self.assertNotIsInstance(lines[0].get_xdata(), PeriodIndex)
+        self.assertIsInstance(PeriodIndex(lines[0].get_xdata()), PeriodIndex)
 
         tm.close()
         # useful if you're plotting a bunch together
@@ -1012,7 +1013,8 @@ class TestDataFramePlots(TestPlotBase):
         tm.close()
         ax = df.plot()
         lines = ax.get_lines()
-        tm.assert_isinstance(lines[0].get_xdata(), PeriodIndex)
+        self.assertNotIsInstance(lines[0].get_xdata(), PeriodIndex)
+        self.assertIsInstance(PeriodIndex(lines[0].get_xdata()), PeriodIndex)
 
     def test_unsorted_index(self):
         df = DataFrame({'y': np.arange(100)},

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -9,7 +9,7 @@ from pandas.sparse.array import SparseArray
 from pandas.core.internals import *
 import pandas.core.internals as internals
 import pandas.util.testing as tm
-
+import pandas as pd
 from pandas.util.testing import (
     assert_almost_equal, assert_frame_equal, randn)
 from pandas.compat import zip, u
@@ -182,12 +182,9 @@ class TestBlock(tm.TestCase):
         self.assertEqual(int32block.dtype, np.int32)
 
     def test_pickle(self):
-        import pickle
 
         def _check(blk):
-            pickled = pickle.dumps(blk)
-            unpickled = pickle.loads(pickled)
-            assert_block_equal(blk, unpickled)
+            assert_block_equal(self.round_trip_pickle(blk), blk)
 
         _check(self.fblock)
         _check(self.cblock)
@@ -341,12 +338,8 @@ class TestBlockManager(tm.TestCase):
         self.assertNotIn('baz', self.mgr)
 
     def test_pickle(self):
-        import pickle
 
-        pickled = pickle.dumps(self.mgr)
-        mgr2 = pickle.loads(pickled)
-
-        # same result
+        mgr2 = self.round_trip_pickle(self.mgr)
         assert_frame_equal(DataFrame(self.mgr), DataFrame(mgr2))
 
         # share ref_items
@@ -361,13 +354,13 @@ class TestBlockManager(tm.TestCase):
         self.assertFalse(mgr2._known_consolidated)
 
     def test_non_unique_pickle(self):
-        import pickle
+
         mgr = create_mgr('a,a,a:f8')
-        mgr2 = pickle.loads(pickle.dumps(mgr))
+        mgr2 = self.round_trip_pickle(mgr)
         assert_frame_equal(DataFrame(mgr), DataFrame(mgr2))
 
         mgr = create_mgr('a: f8; a: i8')
-        mgr2 = pickle.loads(pickle.dumps(mgr))
+        mgr2 = self.round_trip_pickle(mgr)
         assert_frame_equal(DataFrame(mgr), DataFrame(mgr2))
 
     def test_get_scalar(self):

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -14,7 +14,7 @@ from pandas.util.testing import (assert_almost_equal,
                                  assertRaisesRegexp)
 import pandas.core.common as com
 import pandas.util.testing as tm
-from pandas.compat import (range, lrange, StringIO, lzip, u, cPickle,
+from pandas.compat import (range, lrange, StringIO, lzip, u,
                                 product as cart_product, zip)
 import pandas as pd
 
@@ -181,8 +181,7 @@ class TestMultiLevel(tm.TestCase):
     def test_pickle(self):
 
         def _test_roundtrip(frame):
-            pickled = cPickle.dumps(frame)
-            unpickled = cPickle.loads(pickled)
+            unpickled = self.round_trip_pickle(frame)
             assert_frame_equal(frame, unpickled)
 
         _test_roundtrip(self.frame)
@@ -445,6 +444,7 @@ class TestMultiLevel(tm.TestCase):
             ]
         df = DataFrame(acc, columns=['a1','a2','cnt']).set_index(['a1','a2'])
         expected = DataFrame({ 'cnt' : [24,26,25,26] }, index=Index(['xbcde',np.nan,'zbcde','ybcde'],name='a2'))
+
         result = df.xs('z',level='a1')
         assert_frame_equal(result, expected)
 
@@ -2106,13 +2106,13 @@ Thur,Lunch,Yes,51.51,17"""
             idx1 = pd.date_range('1/1/2011', periods=5, freq='D', tz=tz, name='idx1')
             idx2 = pd.Index(range(5), name='idx2',dtype='int64')
             idx = pd.MultiIndex.from_arrays([idx1, idx2])
-            df = pd.DataFrame({'a': np.arange(5,dtype='int64'), 'b': ['A', 'B', 'C', 'D', 'E']}, index=idx) 
+            df = pd.DataFrame({'a': np.arange(5,dtype='int64'), 'b': ['A', 'B', 'C', 'D', 'E']}, index=idx)
 
             expected = pd.DataFrame({'idx1': [datetime.datetime(2011, 1, 1),
                                               datetime.datetime(2011, 1, 2),
                                               datetime.datetime(2011, 1, 3),
                                               datetime.datetime(2011, 1, 4),
-                                              datetime.datetime(2011, 1, 5)], 
+                                              datetime.datetime(2011, 1, 5)],
                                      'idx2': np.arange(5,dtype='int64'),
                                      'a': np.arange(5,dtype='int64'), 'b': ['A', 'B', 'C', 'D', 'E']},
                                      columns=['idx1', 'idx2', 'a', 'b'])
@@ -2122,19 +2122,19 @@ Thur,Lunch,Yes,51.51,17"""
 
             idx3 = pd.date_range('1/1/2012', periods=5, freq='MS', tz='Europe/Paris', name='idx3')
             idx = pd.MultiIndex.from_arrays([idx1, idx2, idx3])
-            df = pd.DataFrame({'a': np.arange(5,dtype='int64'), 'b': ['A', 'B', 'C', 'D', 'E']}, index=idx) 
+            df = pd.DataFrame({'a': np.arange(5,dtype='int64'), 'b': ['A', 'B', 'C', 'D', 'E']}, index=idx)
 
             expected = pd.DataFrame({'idx1': [datetime.datetime(2011, 1, 1),
                                               datetime.datetime(2011, 1, 2),
                                               datetime.datetime(2011, 1, 3),
                                               datetime.datetime(2011, 1, 4),
-                                              datetime.datetime(2011, 1, 5)], 
+                                              datetime.datetime(2011, 1, 5)],
                                      'idx2': np.arange(5,dtype='int64'),
                                      'idx3': [datetime.datetime(2012, 1, 1),
                                               datetime.datetime(2012, 2, 1),
                                               datetime.datetime(2012, 3, 1),
                                               datetime.datetime(2012, 4, 1),
-                                              datetime.datetime(2012, 5, 1)], 
+                                              datetime.datetime(2012, 5, 1)],
                                      'a': np.arange(5,dtype='int64'), 'b': ['A', 'B', 'C', 'D', 'E']},
                                      columns=['idx1', 'idx2', 'idx3', 'a', 'b'])
             expected['idx1'] = expected['idx1'].apply(lambda d: pd.Timestamp(d, tz=tz))
@@ -2148,7 +2148,7 @@ Thur,Lunch,Yes,51.51,17"""
             expected = pd.DataFrame({'level_0': 'a a a b b b'.split(),
                                      'level_1': [datetime.datetime(2013, 1, 1),
                                                  datetime.datetime(2013, 1, 2),
-                                                 datetime.datetime(2013, 1, 3)] * 2, 
+                                                 datetime.datetime(2013, 1, 3)] * 2,
                                      'a': np.arange(6, dtype='int64')},
                                      columns=['level_0', 'level_1', 'a'])
             expected['level_1'] = expected['level_1'].apply(lambda d: pd.Timestamp(d, offset='D', tz=tz))

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -12,7 +12,7 @@ from pandas.core.panel import Panel
 from pandas.core.series import remove_na
 import pandas.core.common as com
 from pandas import compat
-from pandas.compat import range, lrange, StringIO, cPickle, OrderedDict
+from pandas.compat import range, lrange, StringIO, OrderedDict
 
 from pandas.util.testing import (assert_panel_equal,
                                  assert_frame_equal,
@@ -31,8 +31,7 @@ class PanelTests(object):
     panel = None
 
     def test_pickle(self):
-        pickled = cPickle.dumps(self.panel)
-        unpickled = cPickle.loads(pickled)
+        unpickled = self.round_trip_pickle(self.panel)
         assert_frame_equal(unpickled['ItemA'], self.panel['ItemA'])
 
     def test_cumsum(self):

--- a/pandas/tests/test_tseries.py
+++ b/pandas/tests/test_tseries.py
@@ -32,7 +32,7 @@ class TestTseriesUtil(tm.TestCase):
         old = Index([1, 5, 10])
         new = Index(lrange(12))
 
-        filler = algos.backfill_int64(old, new)
+        filler = algos.backfill_int64(old.values, new.values)
 
         expect_filler = [0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, -1]
         self.assert_numpy_array_equal(filler, expect_filler)
@@ -40,7 +40,7 @@ class TestTseriesUtil(tm.TestCase):
         # corner case
         old = Index([1, 4])
         new = Index(lrange(5, 10))
-        filler = algos.backfill_int64(old, new)
+        filler = algos.backfill_int64(old.values, new.values)
 
         expect_filler = [-1, -1, -1, -1, -1]
         self.assert_numpy_array_equal(filler, expect_filler)
@@ -49,7 +49,7 @@ class TestTseriesUtil(tm.TestCase):
         old = Index([1, 5, 10])
         new = Index(lrange(12))
 
-        filler = algos.pad_int64(old, new)
+        filler = algos.pad_int64(old.values, new.values)
 
         expect_filler = [-1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2]
         self.assert_numpy_array_equal(filler, expect_filler)
@@ -57,7 +57,7 @@ class TestTseriesUtil(tm.TestCase):
         # corner case
         old = Index([5, 10])
         new = Index(lrange(5))
-        filler = algos.pad_int64(old, new)
+        filler = algos.pad_int64(old.values, new.values)
         expect_filler = [-1, -1, -1, -1, -1]
         self.assert_numpy_array_equal(filler, expect_filler)
 
@@ -165,7 +165,7 @@ def test_left_join_indexer2():
     idx = Index([1, 1, 2, 5])
     idx2 = Index([1, 2, 5, 7, 9])
 
-    res, lidx, ridx = algos.left_join_indexer_int64(idx2, idx)
+    res, lidx, ridx = algos.left_join_indexer_int64(idx2.values, idx.values)
 
     exp_res = np.array([1, 1, 2, 5, 7, 9], dtype=np.int64)
     assert_almost_equal(res, exp_res)
@@ -181,7 +181,7 @@ def test_outer_join_indexer2():
     idx = Index([1, 1, 2, 5])
     idx2 = Index([1, 2, 5, 7, 9])
 
-    res, lidx, ridx = algos.outer_join_indexer_int64(idx2, idx)
+    res, lidx, ridx = algos.outer_join_indexer_int64(idx2.values, idx.values)
 
     exp_res = np.array([1, 1, 2, 5, 7, 9], dtype=np.int64)
     assert_almost_equal(res, exp_res)
@@ -197,7 +197,7 @@ def test_inner_join_indexer2():
     idx = Index([1, 1, 2, 5])
     idx2 = Index([1, 2, 5, 7, 9])
 
-    res, lidx, ridx = algos.inner_join_indexer_int64(idx2, idx)
+    res, lidx, ridx = algos.inner_join_indexer_int64(idx2.values, idx.values)
 
     exp_res = np.array([1, 1, 2, 5], dtype=np.int64)
     assert_almost_equal(res, exp_res)
@@ -688,6 +688,10 @@ class TestReducer(tm.TestCase):
         result = lib.reduce(arr, np.sum, axis=1,
                             dummy=dummy, labels=Index(np.arange(100)))
         expected = arr.sum(1)
+        assert_almost_equal(result, expected)
+
+        result = lib.reduce(arr, np.sum, axis=1,
+                            dummy=dummy, labels=Index(np.arange(100)))
         assert_almost_equal(result, expected)
 
 

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -3,7 +3,7 @@
 import warnings
 
 from pandas import Series, DataFrame
-from pandas.core.index import MultiIndex
+from pandas.core.index import MultiIndex, Index
 from pandas.core.groupby import Grouper
 from pandas.tools.merge import concat
 from pandas.tools.util import cartesian_product
@@ -307,7 +307,7 @@ def _generate_marginal_results_without_values(table, data, rows, cols, aggfunc):
 def _convert_by(by):
     if by is None:
         by = []
-    elif (np.isscalar(by) or isinstance(by, (np.ndarray, Series, Grouper))
+    elif (np.isscalar(by) or isinstance(by, (np.ndarray, Index, Series, Grouper))
           or hasattr(by, '__call__')):
         by = [by]
     else:

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -12,7 +12,7 @@ import numpy as np
 from pandas.util.decorators import cache_readonly, deprecate_kwarg
 import pandas.core.common as com
 from pandas.core.generic import _shared_docs, _shared_doc_kwargs
-from pandas.core.index import MultiIndex
+from pandas.core.index import Index, MultiIndex
 from pandas.core.series import Series, remove_na
 from pandas.tseries.index import DatetimeIndex
 from pandas.tseries.period import PeriodIndex, Period
@@ -821,7 +821,7 @@ class MPLPlot(object):
         for kw, err in zip(['xerr', 'yerr'], [xerr, yerr]):
             self.errors[kw] = self._parse_errorbars(kw, err)
 
-        if not isinstance(secondary_y, (bool, tuple, list, np.ndarray)):
+        if not isinstance(secondary_y, (bool, tuple, list, np.ndarray, Index)):
             secondary_y = [secondary_y]
         self.secondary_y = secondary_y
 
@@ -872,7 +872,7 @@ class MPLPlot(object):
             data = self.data
 
         from pandas.core.frame import DataFrame
-        if isinstance(data, (Series, np.ndarray)):
+        if isinstance(data, (Series, np.ndarray, Index)):
             if keep_index is True:
                 yield self.label, data
             else:
@@ -1223,7 +1223,7 @@ class MPLPlot(object):
             return self.secondary_y
 
         if (isinstance(self.data, DataFrame) and
-                isinstance(self.secondary_y, (tuple, list, np.ndarray))):
+                isinstance(self.secondary_y, (tuple, list, np.ndarray, Index))):
             return self.data.columns[i] in self.secondary_y
 
     def _get_style(self, i, col_name):
@@ -2485,7 +2485,7 @@ def hist_frame(data, column=None, by=None, grid=True, xlabelsize=None,
         return axes
 
     if column is not None:
-        if not isinstance(column, (list, np.ndarray)):
+        if not isinstance(column, (list, np.ndarray, Index)):
             column = [column]
         data = data[column]
     data = data._get_numeric_data()
@@ -2962,7 +2962,7 @@ def _subplots(nrows=1, ncols=1, naxes=None, sharex=False, sharey=False, squeeze=
         axarr[i] = ax
 
     if nplots > 1:
-        
+
         if sharex and nrows > 1:
             for ax in axarr[:naxes][:-ncols]:    # only bottom row
                 for label in ax.get_xticklabels():
@@ -3015,7 +3015,7 @@ def _subplots(nrows=1, ncols=1, naxes=None, sharex=False, sharey=False, squeeze=
 def _flatten(axes):
     if not com.is_list_like(axes):
         axes = [axes]
-    elif isinstance(axes, np.ndarray):
+    elif isinstance(axes, (np.ndarray, Index)):
         axes = axes.ravel()
     return axes
 

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -517,10 +517,10 @@ class TestPivotTable(tm.TestCase):
         exp_col3 = pd.DatetimeIndex(['2013-01-01 15:00:00', '2013-02-01 15:00:00'] * 4,
                                     tz='Asia/Tokyo', name='dt2')
         exp_col = MultiIndex.from_arrays([exp_col1, exp_col2, exp_col3])
-        expected = DataFrame(np.array([[0, 3, 1, 2, 0, 3, 1, 2], 
+        expected = DataFrame(np.array([[0, 3, 1, 2, 0, 3, 1, 2],
                                        [1, 4, 2, 1, 1, 4, 2, 1],
-                                       [2, 5, 1, 2, 2, 5, 1, 2]], dtype='int64'), 
-                             index=exp_idx, 
+                                       [2, 5, 1, 2, 2, 5, 1, 2]], dtype='int64'),
+                             index=exp_idx,
                              columns=exp_col)
 
         result = pivot_table(df, index=['dt1'], columns=['dt2'], values=['value1', 'value2'],

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -59,10 +59,10 @@ def _field_accessor(name, field, docstring=None):
 def _join_i8_wrapper(joinf, with_indexers=True):
     @staticmethod
     def wrapper(left, right):
-        if isinstance(left, (np.ndarray, ABCSeries)):
-            left = left.view('i8', type=np.ndarray)
-        if isinstance(right, (np.ndarray, ABCSeries)):
-            right = right.view('i8', type=np.ndarray)
+        if isinstance(left, (np.ndarray, Index, ABCSeries)):
+            left = left.view('i8')
+        if isinstance(right, (np.ndarray, Index, ABCSeries)):
+            right = right.view('i8')
         results = joinf(left, right)
         if with_indexers:
             join_index, left_indexer, right_indexer = results
@@ -86,9 +86,10 @@ def _dt_index_cmp(opname, nat_result=False):
         else:
             if isinstance(other, list):
                 other = DatetimeIndex(other)
-            elif not isinstance(other, (np.ndarray, ABCSeries)):
+            elif not isinstance(other, (np.ndarray, Index, ABCSeries)):
                 other = _ensure_datetime64(other)
             result = func(other)
+            result = _values_from_object(result)
 
             if isinstance(other, Index):
                 o_mask = other.values.view('i8') == tslib.iNaT
@@ -101,7 +102,11 @@ def _dt_index_cmp(opname, nat_result=False):
         mask = self.asi8 == tslib.iNaT
         if mask.any():
             result[mask] = nat_result
-        return result.view(np.ndarray)
+
+        # support of bool dtype indexers
+        if com.is_bool_dtype(result):
+            return result
+        return Index(result)
 
     return wrapper
 
@@ -143,8 +148,9 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
     name : object
         Name to be stored in the index
     """
-    _join_precedence = 10
 
+    _typ = 'datetimeindex'
+    _join_precedence = 10
     _inner_indexer = _join_i8_wrapper(_algos.inner_join_indexer_int64)
     _outer_indexer = _join_i8_wrapper(_algos.outer_join_indexer_int64)
     _left_indexer = _join_i8_wrapper(_algos.left_join_indexer_int64)
@@ -167,17 +173,19 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
     tz = None
     offset = None
     _comparables = ['name','freqstr','tz']
+    _attributes = ['name','freq','tz']
     _allow_datetime_index_ops = True
+    _is_numeric_dtype = False
 
     def __new__(cls, data=None,
                 freq=None, start=None, end=None, periods=None,
                 copy=False, name=None, tz=None,
                 verify_integrity=True, normalize=False,
-                closed=None, **kwds):
+                closed=None, **kwargs):
 
-        dayfirst = kwds.pop('dayfirst', None)
-        yearfirst = kwds.pop('yearfirst', None)
-        infer_dst = kwds.pop('infer_dst', False)
+        dayfirst = kwargs.pop('dayfirst', None)
+        yearfirst = kwargs.pop('yearfirst', None)
+        infer_dst = kwargs.pop('infer_dst', False)
 
         freq_infer = False
         if not isinstance(freq, DateOffset):
@@ -205,7 +213,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
                                  tz=tz, normalize=normalize, closed=closed,
                                  infer_dst=infer_dst)
 
-        if not isinstance(data, (np.ndarray, ABCSeries)):
+        if not isinstance(data, (np.ndarray, Index, ABCSeries)):
             if np.isscalar(data):
                 raise ValueError('DatetimeIndex() must be called with a '
                                  'collection of some kind, %s was passed'
@@ -262,7 +270,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
             else:
                 subarr = data.view(_NS_DTYPE)
         else:
-            if isinstance(data, ABCSeries):
+            if isinstance(data, (ABCSeries, Index)):
                 values = data.values
             else:
                 values = data
@@ -302,10 +310,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
 
                 subarr = subarr.view(_NS_DTYPE)
 
-        subarr = subarr.view(cls)
-        subarr.name = name
-        subarr.offset = freq
-        subarr.tz = tz
+        subarr = cls._simple_new(subarr, name=name, freq=freq, tz=tz)
 
         if verify_integrity and len(subarr) > 0:
             if freq is not None and not freq_infer:
@@ -442,10 +447,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
                                                  infer_dst=infer_dst)
                 index = index.view(_NS_DTYPE)
 
-        index = index.view(cls)
-        index.name = name
-        index.offset = offset
-        index.tz = tz
+        index = cls._simple_new(index, name=name, freq=offset, tz=tz)
 
         if not left_closed:
             index = index[1:]
@@ -474,15 +476,18 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
             return result.take(reverse)
 
     @classmethod
-    def _simple_new(cls, values, name, freq=None, tz=None):
+    def _simple_new(cls, values, name=None, freq=None, tz=None):
+        if not getattr(values,'dtype',None):
+            values = np.array(values,copy=False)
         if values.dtype != _NS_DTYPE:
             values = com._ensure_int64(values).view(_NS_DTYPE)
 
-        result = values.view(cls)
+        result = object.__new__(cls)
+        result._data = values
         result.name = name
         result.offset = freq
         result.tz = tslib.maybe_get_tz(tz)
-
+        result._reset_identity()
         return result
 
     @property
@@ -517,7 +522,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
 
             arr = tools.to_datetime(list(xdr), box=False)
 
-            cachedRange = arr.view(DatetimeIndex)
+            cachedRange = DatetimeIndex._simple_new(arr)
             cachedRange.offset = offset
             cachedRange.tz = None
             cachedRange.name = None
@@ -575,29 +580,37 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
         formatter = _get_format_datetime64(is_dates_only=self._is_dates_only)
         return lambda x: formatter(x, tz=self.tz)
 
-    def __reduce__(self):
-        """Necessary for making this object picklable"""
-        object_state = list(np.ndarray.__reduce__(self))
-        subclass_state = self.name, self.offset, self.tz
-        object_state[2] = (object_state[2], subclass_state)
-        return tuple(object_state)
-
     def __setstate__(self, state):
         """Necessary for making this object picklable"""
-        if len(state) == 2:
-            nd_state, own_state = state
-            self.name = own_state[0]
-            self.offset = own_state[1]
-            self.tz = own_state[2]
-            np.ndarray.__setstate__(self, nd_state)
+        if isinstance(state, dict):
+            super(DatetimeIndex, self).__setstate__(state)
 
-            # provide numpy < 1.7 compat
-            if nd_state[2] == 'M8[us]':
-                new_state = np.ndarray.__reduce__(self.values.astype('M8[ns]'))
-                np.ndarray.__setstate__(self, new_state[2])
+        elif isinstance(state, tuple):
 
-        else:  # pragma: no cover
-            np.ndarray.__setstate__(self, state)
+            # < 0.15 compat
+            if len(state) == 2:
+                nd_state, own_state = state
+                data = np.empty(nd_state[1], dtype=nd_state[2])
+                np.ndarray.__setstate__(data, nd_state)
+
+                self.name = own_state[0]
+                self.offset = own_state[1]
+                self.tz = own_state[2]
+
+                # provide numpy < 1.7 compat
+                if nd_state[2] == 'M8[us]':
+                    new_state = np.ndarray.__reduce__(data.astype('M8[ns]'))
+                    np.ndarray.__setstate__(data, new_state[2])
+
+            else:  # pragma: no cover
+                data = np.empty(state)
+                np.ndarray.__setstate__(data, state)
+
+            self._data = data
+
+        else:
+            raise Exception("invalid pickle state")
+    _unpickle_compat = __setstate__
 
     def _add_delta(self, delta):
         if isinstance(delta, (Tick, timedelta)):
@@ -662,7 +675,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
         return self.copy()
 
     def groupby(self, f):
-        objs = self.asobject
+        objs = self.asobject.values
         return _algos.groupby_object(objs, f)
 
     def summary(self, name=None):
@@ -982,7 +995,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
         if (isinstance(other, DatetimeIndex)
             and self.offset == other.offset
                 and self._can_fast_union(other)):
-            joined = self._view_like(joined)
+            joined = self._shallow_copy(joined)
             joined.name = name
             return joined
         else:
@@ -1044,7 +1057,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
                 loc = right.searchsorted(left_end, side='right')
                 right_chunk = right.values[loc:]
                 dates = com._concat_compat((left.values, right_chunk))
-                return self._view_like(dates)
+                return self._shallow_copy(dates)
             else:
                 return left
         else:
@@ -1140,7 +1153,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
         else:
             lslice = slice(*left.slice_locs(start, end))
             left_chunk = left.values[lslice]
-            return self._view_like(left_chunk)
+            return self._shallow_copy(left_chunk)
 
     def _partial_date_slice(self, reso, parsed, use_lhs=True, use_rhs=True):
 
@@ -1357,10 +1370,9 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
         return Index.slice_locs(self, start, end)
 
     def __getitem__(self, key):
-        """Override numpy.ndarray's __getitem__ method to work as desired"""
-        arr_idx = self.view(np.ndarray)
+        getitem = self._data.__getitem__
         if np.isscalar(key):
-            val = arr_idx[key]
+            val = getitem(key)
             return Timestamp(val, offset=self.offset, tz=self.tz)
         else:
             if com._is_bool_indexer(key):
@@ -1377,7 +1389,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
                 else:
                     new_offset = self.offset
 
-            result = arr_idx[key]
+            result = getitem(key)
             if result.ndim > 1:
                 return result
 
@@ -1388,17 +1400,19 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
     def map(self, f):
         try:
             result = f(self)
-            if not isinstance(result, np.ndarray):
+            if not isinstance(result, (np.ndarray, Index)):
                 raise TypeError
             return result
         except Exception:
-            return _algos.arrmap_object(self.asobject, f)
+            return _algos.arrmap_object(self.asobject.values, f)
 
     # alias to offset
-    @property
-    def freq(self):
-        """ return the frequency object if its set, otherwise None """
+    def _get_freq(self):
         return self.offset
+
+    def _set_freq(self, value):
+        self.offset = value
+    freq = property(fget=_get_freq, fset=_set_freq, doc="get/set the frequncy of the Index")
 
     @cache_readonly
     def inferred_freq(self):
@@ -1443,14 +1457,14 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
         """
         # can't call self.map() which tries to treat func as ufunc
         # and causes recursion warnings on python 2.6
-        return _algos.arrmap_object(self.asobject, lambda x: x.time())
+        return _algos.arrmap_object(self.asobject.values, lambda x: x.time())
 
     @property
     def _date(self):
         """
         Returns numpy array of datetime.date. The date part of the Timestamps.
         """
-        return _algos.arrmap_object(self.asobject, lambda x: x.date())
+        return _algos.arrmap_object(self.asobject.values, lambda x: x.date())
 
 
     def normalize(self):
@@ -1466,7 +1480,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
                              tz=self.tz)
 
     def searchsorted(self, key, side='left'):
-        if isinstance(key, np.ndarray):
+        if isinstance(key, (np.ndarray, Index)):
             key = np.array(key, dtype=_NS_DTYPE, copy=False)
         else:
             key = _to_m8(key, tz=self.tz)
@@ -1609,13 +1623,6 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
             new_dates = tslib.tz_convert(new_dates, 'UTC', self.tz)
         return DatetimeIndex(new_dates, name=self.name, freq=freq, tz=self.tz)
 
-    def _view_like(self, ndarray):
-        result = ndarray.view(type(self))
-        result.offset = self.offset
-        result.tz = self.tz
-        result.name = self.name
-        return result
-
     def tz_convert(self, tz):
         """
         Convert tz-aware DatetimeIndex from one time zone to another (using pytz/dateutil)
@@ -1639,7 +1646,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
                             'tz_localize to localize')
 
         # No conversion since timestamps are all UTC to begin with
-        return self._simple_new(self.values, self.name, self.offset, tz)
+        return self._shallow_copy(tz=tz)
 
     def tz_localize(self, tz, infer_dst=False):
         """
@@ -1669,7 +1676,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
             # Convert to UTC
             new_dates = tslib.tz_localize_to_utc(self.asi8, tz, infer_dst=infer_dst)
         new_dates = new_dates.view(_NS_DTYPE)
-        return self._simple_new(new_dates, self.name, self.offset, tz)
+        return self._shallow_copy(new_dates, tz=tz)
 
     def indexer_at_time(self, time, asof=False):
         """
@@ -1782,7 +1789,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
                              self.microsecond/3600.0/1e+6 +
                              self.nanosecond/3600.0/1e+9
                             )/24.0)
-
+DatetimeIndex._add_numeric_methods_disabled()
 
 def _generate_regular_range(start, end, periods, offset):
     if isinstance(offset, Tick):

--- a/pandas/tseries/plotting.py
+++ b/pandas/tseries/plotting.py
@@ -61,7 +61,7 @@ def tsplot(series, plotf, **kwargs):
     if not hasattr(ax, '_plot_data'):
         ax._plot_data = []
     ax._plot_data.append((series, plotf, kwargs))
-    lines = plotf(ax, series.index, series.values, **kwargs)
+    lines = plotf(ax, series.index._mpl_repr(), series.values, **kwargs)
 
     # set date formatter, locators and rescale limits
     format_dateaxis(ax, ax.freq)
@@ -152,7 +152,7 @@ def _replot_ax(ax, freq, kwargs):
             idx = series.index.asfreq(freq, how='S')
             series.index = idx
             ax._plot_data.append(series)
-            lines.append(plotf(ax, series.index, series.values, **kwds)[0])
+            lines.append(plotf(ax, series.index._mpl_repr(), series.values, **kwds)[0])
             labels.append(com.pprint_thing(series.name))
 
     return lines, labels

--- a/pandas/tseries/tests/test_converter.py
+++ b/pandas/tseries/tests/test_converter.py
@@ -84,8 +84,8 @@ class TestDateTimeConverter(tm.TestCase):
             if not val1 < val2:
                 raise AssertionError('{0} is not less than {1}.'.format(val1, val2))
 
-        # Matplotlib's time representation using floats cannot distinguish intervals smaller 
-        # than ~10 microsecond in the common range of years. 
+        # Matplotlib's time representation using floats cannot distinguish intervals smaller
+        # than ~10 microsecond in the common range of years.
         ts = Timestamp('2012-1-1')
         _assert_less(ts, ts + Second())
         _assert_less(ts, ts + Milli())

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from pandas.compat import range
-import pickle
 import nose
 import sys
 import numpy as np
@@ -168,9 +167,7 @@ class TestDateRange(tm.TestCase):
         self.assertEqual(shifted[0], rng[0] + datetools.bday)
 
     def test_pickle_unpickle(self):
-        pickled = pickle.dumps(self.rng)
-        unpickled = pickle.loads(pickled)
-
+        unpickled = self.round_trip_pickle(self.rng)
         self.assertIsNotNone(unpickled.offset)
 
     def test_union(self):
@@ -561,9 +558,7 @@ class TestCustomDateRange(tm.TestCase):
         self.assertEqual(shifted[0], rng[0] + datetools.cday)
 
     def test_pickle_unpickle(self):
-        pickled = pickle.dumps(self.rng)
-        unpickled = pickle.loads(pickled)
-
+        unpickled = self.round_trip_pickle(self.rng)
         self.assertIsNotNone(unpickled.offset)
 
     def test_union(self):

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -2052,7 +2052,7 @@ class TestPeriodIndex(tm.TestCase):
 
         for idx in [didx, pidx]:
             df = DataFrame(dict(units=[100 + i for i in range(10)]), index=idx)
-            empty = DataFrame(index=DatetimeIndex([], freq='D'), columns=['units'])
+            empty = DataFrame(index=idx.__class__([], freq='D'), columns=['units'])
 
             tm.assert_frame_equal(df['2013/09/01':'2013/09/30'], empty)
             tm.assert_frame_equal(df['2013/09/30':'2013/10/02'], df.iloc[:2])
@@ -2408,7 +2408,7 @@ class TestPeriodIndex(tm.TestCase):
         # GH2891
         import pickle
         prng = period_range('1/1/2011', '1/1/2012', freq='M')
-        new_prng = pickle.loads(pickle.dumps(prng))
+        new_prng = self.round_trip_pickle(prng)
         self.assertEqual(new_prng.freq,'M')
 
     def test_slice_keep_name(self):

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -298,7 +298,7 @@ class TestTSPlot(tm.TestCase):
         bts = DataFrame({'a': tm.makeTimeSeries()})
         ax = bts.plot()
         idx = ax.get_lines()[0].get_xdata()
-        assert_array_equal(bts.index.to_period(), idx)
+        assert_array_equal(bts.index.to_period(), PeriodIndex(idx))
 
     @slow
     def test_axis_limits(self):
@@ -605,8 +605,8 @@ class TestTSPlot(tm.TestCase):
         ax = s1.plot()
         ax2 = s2.plot(style='g')
         lines = ax2.get_lines()
-        idx1 = lines[0].get_xdata()
-        idx2 = lines[1].get_xdata()
+        idx1 = PeriodIndex(lines[0].get_xdata())
+        idx2 = PeriodIndex(lines[1].get_xdata())
         self.assertTrue(idx1.equals(s1.index.to_period('B')))
         self.assertTrue(idx2.equals(s2.index.to_period('B')))
         left, right = ax2.get_xlim()
@@ -881,9 +881,9 @@ class TestTSPlot(tm.TestCase):
         low.plot()
         ax = high.plot(secondary_y=True)
         for l in ax.get_lines():
-            self.assertEqual(l.get_xdata().freq, 'D')
+            self.assertEqual(PeriodIndex(l.get_xdata()).freq, 'D')
         for l in ax.right_ax.get_lines():
-            self.assertEqual(l.get_xdata().freq, 'D')
+            self.assertEqual(PeriodIndex(l.get_xdata()).freq, 'D')
 
     @slow
     def test_secondary_legend(self):

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -98,6 +98,13 @@ class TestCase(unittest.TestCase):
             return
         raise AssertionError('{0} is not equal to {1}.'.format(np_array, assert_equal))
 
+    def round_trip_pickle(self, obj, path=None):
+        if path is None:
+            path = u('__%s__.pickle' % rands(10))
+        with ensure_clean(path) as path:
+            pd.to_pickle(obj, path)
+            return pd.read_pickle(path)
+
     def assert_numpy_array_equivalent(self, np_array, assert_equal):
         """Checks that 'np_array' is equivalent to 'assert_equal'
 


### PR DESCRIPTION
make `Index` now subclass `PandasObject/IndexOpsMixin` rather than `ndarray`
should allow much easier new Index classes (e.g. #7640)

This doesn't change the public API at all, and provides compat

closes #5080
back compat for pickles is now way simpler

ToDo:
- docs
  - [x] release note
  - [x] warnings in io.rst about this change
  - [x] fixes `.repeat` on MultiIndex (broken in master)
  - [x] minor API compat issue with comparisons of `DatetimeIndex` with `NaT` vs ndarrays
- [x] merge with searchsorted issues/PR ( #6712, #7447, #6469)
- [x] tests fixed (FIXMES), just a few left
- [x] perf
- [x] json completely broken ATM
- [x] #7796 FIXME (PeriodIndex not supported in HDF), not really a big deal
- [x] #7439 since `Index` now doesn't have implicit ops (aside from `__sub__/__add__`, these need to be added in (e.g. `__mul__,__div__,__truediv__`).
- [x] bool(Index/MultiIndex) : https://github.com/pydata/pandas/issues/7897 (will address this later)

closes #5155 (perf fix for Period creation), slight increase on the plotting
because of the the plottling routines holding array of Periods (rather than PeriodIndex).

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
period_setitem                               |  16.2210 | 122.9340 |   0.1319 |
timeseries_iter_periodindex                  | 1197.7839 | 6906.1464 |   0.1734 |
timeseries_iter_periodindex_preexit          |  12.4850 |  69.8563 |   0.1787 |
timeseries_period_downsample_mean            |  11.2850 |  11.1457 |   1.0125 |
plot_timeseries_period                       | 107.6056 |  86.5277 |   1.2436 |
```
