### PR TITLE
API: add 'level' kwarg to 'Index.isin' method

### DIFF
--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -582,7 +582,7 @@ and :ref:`Advanced Indexing <indexing.advanced>` you may select along more than 
 .. _indexing.basics.indexing_isin:
 
 Indexing with isin
-~~~~~~~~~~~~~~~~~~
+------------------
 
 Consider the ``isin`` method of Series, which returns a boolean vector that is
 true wherever the Series elements exist in the passed list. This allows you to
@@ -591,13 +591,30 @@ select rows where one or more columns have values you want:
 .. ipython:: python
 
    s = Series(np.arange(5),index=np.arange(5)[::-1],dtype='int64')
-
    s
+   s.isin([2, 4, 6])
+   s[s.isin([2, 4, 6])]
 
-   s.isin([2, 4])
+The same method is available for ``Index`` objects and is useful for the cases
+when you don't know which of the sought labels are in fact present:
 
-   s[s.isin([2, 4])]
+.. ipython:: python
 
+   s[s.index.isin([2, 4, 6])]
+
+   # compare it to the following
+   s[[2, 4, 6]]
+
+In addition to that, ``MultiIndex`` allows selecting a separate level to use
+in the membership check:
+
+.. ipython:: python
+
+   s_mi = Series(np.arange(6),
+                 index=pd.MultiIndex.from_product([[0, 1], ['a', 'b', 'c']]))
+   s_mi
+   s_mi.iloc[s_mi.index.isin([(1, 'a'), (2, 'b'), (0, 'c')])]
+   s_mi.iloc[s_mi.index.isin(['a', 'c', 'e'], level=1)]
 
 DataFrame also has an ``isin`` method.  When calling ``isin``, pass a set of
 values as either an array or dict.  If values is an array, ``isin`` returns
@@ -1621,12 +1638,6 @@ with duplicates dropped.
    idx2 = Index([2, 3, 4, 5])
    idx1.sym_diff(idx2)
    idx1 ^ idx2
-
-The ``isin`` method of Index objects
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-One additional operation is the ``isin`` method that works analogously to the
-``Series.isin`` method found :ref:`here <indexing.boolean>`.
 
 .. _indexing.hierarchical:
 

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -129,6 +129,19 @@ API changes
   strings must contain 244 or fewer characters.  Attempting to write Stata
   dta files with strings longer than 244 characters raises a ``ValueError``. (:issue:`7858`)
 
+- ``Index.isin`` now supports a ``level`` argument to specify which index level
+  to use for membership tests (:issue:`7892`, :issue:`7890`)
+
+  .. code-block:: python
+
+     In [1]: idx = pd.MultiIndex.from_product([[0, 1], ['a', 'b', 'c']])
+
+     In [2]: idx.values
+     Out[2]: array([(0, 'a'), (0, 'b'), (0, 'c'), (1, 'a'), (1, 'b'), (1, 'c')], dtype=object)
+
+     In [3]: idx.isin(['a', 'c', 'e'], level=1)
+     Out[3]: array([ True, False,  True,  True, False,  True], dtype=bool)
+
 
 .. _whatsnew_0150.cat:
 


### PR DESCRIPTION
closes #7890

This PR adds `level` kwarg for `Index` objects as discussed (briefly in #7890):

``` python

Index.isin(iterable, level=None)
```
### Summary
- for non-`MultiIndex` classes:
  - no functional changes in the actual membership test
  - valid `level` values are `None`, `0`, `-1` and `self.name`
  - if `level` doesn't match the name, it's a `KeyError` (was `AssertionError` before)
- for `MultiIndex` classes:
  - if `level=None`, elements of `self.values` (tuples) are used
  - otherwise elements of corresponding level are used
  - valid `level` values are the same as in `MultiIndex.get_level_values` method, `-self.nlevels..(self.nlevels - 1)` plus all unique index names
### TODO
- [x] add to documentation
- [x] optimize MultiIndex case
