### PR TITLE
ENH: Add BusinessHour offset

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -11,15 +11,24 @@ Highlights include:
 
 - Support for a ``CategoricalIndex``, a category based index, see :ref:`here <whatsnew_0161.enhancements.categoricalindex>`
 
+- ``BusinessHour`` offset is supported, see :ref:`here <timeseries.businesshour>`
+
 .. contents:: What's new in v0.16.1
     :local:
     :backlinks: none
-
 
 .. _whatsnew_0161.enhancements:
 
 Enhancements
 ~~~~~~~~~~~~
+
+- ``BusinessHour`` offset is now supported, which represents business hours starting from 09:00 - 17:00 on ``BusinessDay`` by default. See :ref:`Here <timeseries.businesshour>` for details. (:issue:`7905`)
+
+  .. ipython:: python
+
+     Timestamp('2014-08-01 09:00') + BusinessHour()
+     Timestamp('2014-08-01 07:00') + BusinessHour()
+     Timestamp('2014-08-01 16:30') + BusinessHour()
 
 - Added ``StringMethods.capitalize()`` and ``swapcase`` which behave as the same as standard ``str`` (:issue:`9766`)
 - Added ``StringMethods`` (.str accessor) to ``Index`` (:issue:`9068`)

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -16,6 +16,7 @@ import functools
 __all__ = ['Day', 'BusinessDay', 'BDay', 'CustomBusinessDay', 'CDay',
            'CBMonthEnd','CBMonthBegin',
            'MonthBegin', 'BMonthBegin', 'MonthEnd', 'BMonthEnd',
+           'BusinessHour',
            'YearBegin', 'BYearBegin', 'YearEnd', 'BYearEnd',
            'QuarterBegin', 'BQuarterBegin', 'QuarterEnd', 'BQuarterEnd',
            'LastWeekOfMonth', 'FY5253Quarter', 'FY5253',
@@ -404,10 +405,6 @@ class BusinessMixin(object):
         if hasattr(self, '_named'):
             return self._named
         className = getattr(self, '_outputName', self.__class__.__name__)
-        attrs = []
-
-        if self.offset:
-            attrs = ['offset=%s' % repr(self.offset)]
 
         if abs(self.n) != 1:
             plural = 's'
@@ -418,10 +415,17 @@ class BusinessMixin(object):
         if self.n != 1:
             n_str = "%s * " % self.n
 
-        out = '<%s' % n_str + className + plural
+        out = '<%s' % n_str + className + plural + self._repr_attrs() + '>'
+        return out
+
+    def _repr_attrs(self):
+        if self.offset:
+            attrs = ['offset=%s' % repr(self.offset)]
+        else:
+            attrs = None
+        out = ''
         if attrs:
             out += ': ' + ', '.join(attrs)
-        out += '>'
         return out
 
 class BusinessDay(BusinessMixin, SingleConstructorOffset):
@@ -529,6 +533,234 @@ class BusinessDay(BusinessMixin, SingleConstructorOffset):
         if self.normalize and not _is_normalized(dt):
             return False
         return dt.weekday() < 5
+
+
+class BusinessHour(BusinessMixin, SingleConstructorOffset):
+    """
+    DateOffset subclass representing possibly n business days
+    """
+    _prefix = 'BH'
+    _anchor = 0
+
+    def __init__(self, n=1, normalize=False, **kwds):
+        self.n = int(n)
+        self.normalize = normalize
+
+        # must be validated here to equality check
+        kwds['start'] = self._validate_time(kwds.get('start', '09:00'))
+        kwds['end'] = self._validate_time(kwds.get('end', '17:00'))
+        self.kwds = kwds
+        self.offset = kwds.get('offset', timedelta(0))
+        self.start = kwds.get('start', '09:00')
+        self.end = kwds.get('end', '17:00')
+
+        # used for moving to next businessday
+        if self.n >= 0:
+            self.next_bday = BusinessDay(n=1)
+        else:
+            self.next_bday = BusinessDay(n=-1)
+
+    def _validate_time(self, t_input):
+        from datetime import time as dt_time
+        import time
+        if isinstance(t_input, compat.string_types):
+            try:
+                t = time.strptime(t_input, '%H:%M')
+                return dt_time(hour=t.tm_hour, minute=t.tm_min)
+            except ValueError:
+                raise ValueError("time data must match '%H:%M' format")
+        elif isinstance(t_input, dt_time):
+            if t_input.second != 0 or t_input.microsecond != 0:
+                raise ValueError("time data must be specified only with hour and minute")
+            return t_input
+        else:
+            raise ValueError("time data must be string or datetime.time")
+
+    def _get_daytime_flag(self):
+        if self.start == self.end:
+            raise ValueError('start and end must not be the same')
+        elif self.start < self.end:
+            return True
+        else:
+            return False
+
+    def _repr_attrs(self):
+        out = super(BusinessHour, self)._repr_attrs()
+        attrs = ['BH=%s-%s' % (self.start.strftime('%H:%M'),
+                               self.end.strftime('%H:%M'))]
+        out += ': ' + ', '.join(attrs)
+        return out
+
+    def _next_opening_time(self, other):
+        """
+        If n is positive, return tomorrow's business day opening time.
+        Otherwise yesterday's business day's opening time.
+
+        Opening time always locates on BusinessDay.
+        Otherwise, closing time may not if business hour extends over midnight.
+        """
+        if not self.next_bday.onOffset(other):
+            other = other + self.next_bday
+        else:
+            if self.n >= 0 and self.start < other.time():
+                other = other + self.next_bday
+            elif self.n < 0 and other.time() < self.start:
+                other = other + self.next_bday
+        return datetime(other.year, other.month, other.day,
+                        self.start.hour, self.start.minute)
+
+    def _prev_opening_time(self, other):
+        """
+        If n is positive, return yesterday's business day opening time.
+        Otherwise yesterday business day's opening time.
+        """
+        if not self.next_bday.onOffset(other):
+            other = other - self.next_bday
+        else:
+            if self.n >= 0 and other.time() < self.start:
+                other = other - self.next_bday
+            elif self.n < 0 and other.time() > self.start:
+                other = other - self.next_bday
+        return datetime(other.year, other.month, other.day,
+                        self.start.hour, self.start.minute)
+
+    def _get_business_hours_by_sec(self):
+        """
+        Return business hours in a day by seconds.
+        """
+        if self._get_daytime_flag():
+            # create dummy datetime to calcurate businesshours in a day
+            dtstart = datetime(2014, 4, 1, self.start.hour, self.start.minute)
+            until = datetime(2014, 4, 1, self.end.hour, self.end.minute)
+            return tslib.tot_seconds(until - dtstart)
+        else:
+            self.daytime = False
+            dtstart = datetime(2014, 4, 1, self.start.hour, self.start.minute)
+            until = datetime(2014, 4, 2, self.end.hour, self.end.minute)
+            return tslib.tot_seconds(until - dtstart)
+
+    @apply_wraps
+    def rollback(self, dt):
+        """Roll provided date backward to next offset only if not on offset"""
+        if not self.onOffset(dt):
+            businesshours = self._get_business_hours_by_sec()
+            if self.n >= 0:
+                dt = self._prev_opening_time(dt) + timedelta(seconds=businesshours)
+            else:
+                dt = self._next_opening_time(dt) + timedelta(seconds=businesshours)
+        return dt
+
+    @apply_wraps
+    def rollforward(self, dt):
+        """Roll provided date forward to next offset only if not on offset"""
+        if not self.onOffset(dt):
+            if self.n >= 0:
+                return self._next_opening_time(dt)
+            else:
+                return self._prev_opening_time(dt)
+        return dt
+
+    @apply_wraps
+    def apply(self, other):
+        # calcurate here because offset is not immutable
+        daytime = self._get_daytime_flag()
+        businesshours = self._get_business_hours_by_sec()
+        bhdelta = timedelta(seconds=businesshours)
+
+        if isinstance(other, datetime):
+            # used for detecting edge condition
+            nanosecond = getattr(other, 'nanosecond', 0)
+            # reset timezone and nanosecond
+            # other may be a Timestamp, thus not use replace
+            other = datetime(other.year, other.month, other.day,
+                             other.hour, other.minute,
+                             other.second, other.microsecond)
+            n = self.n
+            if n >= 0:
+                if (other.time() == self.end or
+                    not self._onOffset(other, businesshours)):
+                    other = self._next_opening_time(other)
+            else:
+                if other.time() == self.start:
+                    # adjustment to move to previous business day
+                    other = other - timedelta(seconds=1)
+                if not self._onOffset(other, businesshours):
+                    other = self._next_opening_time(other)
+                    other = other + bhdelta
+
+            bd, r = divmod(abs(n * 60), businesshours // 60)
+            if n < 0:
+                bd, r = -bd, -r
+
+            if bd != 0:
+                skip_bd = BusinessDay(n=bd)
+                # midnight busienss hour may not on BusinessDay
+                if not self.next_bday.onOffset(other):
+                    remain = other - self._prev_opening_time(other)
+                    other = self._next_opening_time(other + skip_bd) + remain
+                else:
+                    other = other + skip_bd
+
+            hours, minutes = divmod(r, 60)
+            result = other + timedelta(hours=hours, minutes=minutes)
+
+            # because of previous adjustment, time will be larger than start
+            if ((daytime and (result.time() < self.start or self.end < result.time())) or
+                not daytime and (self.end < result.time() < self.start)):
+                if n >= 0:
+                    bday_edge = self._prev_opening_time(other)
+                    bday_edge = bday_edge + bhdelta
+                    # calcurate remainder
+                    bday_remain = result - bday_edge
+                    result = self._next_opening_time(other)
+                    result += bday_remain
+                else:
+                    bday_edge = self._next_opening_time(other)
+                    bday_remain = result - bday_edge
+                    result = self._next_opening_time(result) + bhdelta
+                    result += bday_remain
+            # edge handling
+            if n >= 0:
+                if result.time() == self.end:
+                    result = self._next_opening_time(result)
+            else:
+                if result.time() == self.start and nanosecond == 0:
+                    # adjustment to move to previous business day
+                    result = self._next_opening_time(result- timedelta(seconds=1)) +bhdelta
+
+            return result
+        else:
+            raise ApplyTypeError('Only know how to combine business hour with ')
+
+    def onOffset(self, dt):
+        if self.normalize and not _is_normalized(dt):
+            return False
+
+        if dt.tzinfo is not None:
+            dt = datetime(dt.year, dt.month, dt.day, dt.hour,
+                          dt.minute, dt.second, dt.microsecond)
+        # Valid BH can be on the different BusinessDay during midnight
+        # Distinguish by the time spent from previous opening time
+        businesshours = self._get_business_hours_by_sec()
+        return self._onOffset(dt, businesshours)
+
+    def _onOffset(self, dt, businesshours):
+        """
+        Slight speedups using calcurated values
+        """
+        # if self.normalize and not _is_normalized(dt):
+        #     return False
+        # Valid BH can be on the different BusinessDay during midnight
+        # Distinguish by the time spent from previous opening time
+        if self.n >= 0:
+            op = self._prev_opening_time(dt)
+        else:
+            op = self._next_opening_time(dt)
+        span = tslib.tot_seconds(dt - op)
+        if span <= businesshours:
+            return True
+        else:
+            return False
 
 
 class CustomBusinessDay(BusinessDay):
@@ -2250,6 +2482,7 @@ prefix_mapping = dict((offset._prefix, offset) for offset in [
     BusinessMonthEnd,         # 'BM'
     BQuarterEnd,              # 'BQ'
     BQuarterBegin,            # 'BQS'
+    BusinessHour,             # 'BH'
     CustomBusinessDay,        # 'C'
     CustomBusinessMonthEnd,   # 'CBM'
     CustomBusinessMonthBegin, # 'CBMS'

--- a/pandas/tseries/tests/test_frequencies.py
+++ b/pandas/tseries/tests/test_frequencies.py
@@ -196,6 +196,7 @@ class TestFrequencyInference(tm.TestCase):
 
         index = _dti([b + base_delta * j for j in range(3)] +
                      [b + base_delta * 7])
+
         self.assertIsNone(frequencies.infer_freq(index))
 
     def test_weekly(self):
@@ -324,9 +325,39 @@ class TestFrequencyInference(tm.TestCase):
                     idx = date_range(date_pair[0], date_pair[1], freq=freq, tz=tz)
                     print(idx)
                     self.assertEqual(idx.inferred_freq, freq)
-                
+
         index = date_range("2013-11-03", periods=5, freq="3H").tz_localize("America/Chicago")
         self.assertIsNone(index.inferred_freq)
+
+    def test_infer_freq_businesshour(self):
+        # GH 7905
+        idx = DatetimeIndex(['2014-07-01 09:00', '2014-07-01 10:00', '2014-07-01 11:00',
+                             '2014-07-01 12:00', '2014-07-01 13:00', '2014-07-01 14:00'])
+        # hourly freq in a day must result in 'H'
+        self.assertEqual(idx.inferred_freq, 'H')
+
+        idx = DatetimeIndex(['2014-07-01 09:00', '2014-07-01 10:00', '2014-07-01 11:00',
+                             '2014-07-01 12:00', '2014-07-01 13:00', '2014-07-01 14:00',
+                             '2014-07-01 15:00', '2014-07-01 16:00',
+                             '2014-07-02 09:00', '2014-07-02 10:00', '2014-07-02 11:00'])
+        self.assertEqual(idx.inferred_freq, 'BH')
+
+        idx = DatetimeIndex(['2014-07-04 09:00', '2014-07-04 10:00', '2014-07-04 11:00',
+                             '2014-07-04 12:00', '2014-07-04 13:00', '2014-07-04 14:00',
+                             '2014-07-04 15:00', '2014-07-04 16:00',
+                             '2014-07-07 09:00', '2014-07-07 10:00', '2014-07-07 11:00'])
+        self.assertEqual(idx.inferred_freq, 'BH')
+
+        idx = DatetimeIndex(['2014-07-04 09:00', '2014-07-04 10:00', '2014-07-04 11:00',
+                             '2014-07-04 12:00', '2014-07-04 13:00', '2014-07-04 14:00',
+                             '2014-07-04 15:00', '2014-07-04 16:00',
+                             '2014-07-07 09:00', '2014-07-07 10:00', '2014-07-07 11:00',
+                             '2014-07-07 12:00', '2014-07-07 13:00', '2014-07-07 14:00',
+                             '2014-07-07 15:00', '2014-07-07 16:00',
+                             '2014-07-08 09:00', '2014-07-08 10:00', '2014-07-08 11:00',
+                             '2014-07-08 12:00', '2014-07-08 13:00', '2014-07-08 14:00',
+                             '2014-07-08 15:00', '2014-07-08 16:00'])
+        self.assertEqual(idx.inferred_freq, 'BH')
 
     def test_not_monotonic(self):
         rng = _dti(['1/31/2000', '1/31/2001', '1/31/2002'])

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -288,7 +288,7 @@ class TestTimeSeriesDuplicates(tm.TestCase):
         self.assertRaises(KeyError, df.__getitem__, df.index[2],)
 
     def test_recreate_from_data(self):
-        freqs = ['M', 'Q', 'A', 'D', 'B', 'T', 'S', 'L', 'U', 'H', 'N', 'C']
+        freqs = ['M', 'Q', 'A', 'D', 'B', 'BH', 'T', 'S', 'L', 'U', 'H', 'N', 'C']
 
         for f in freqs:
             org = DatetimeIndex(start='2001/02/01 09:00', freq=f, periods=1)
@@ -3346,6 +3346,29 @@ class TestSeriesDatetime64(tm.TestCase):
 
         ex_first = Timestamp('2000-01-03')
         self.assertEqual(rng[0], ex_first)
+
+    def test_date_range_businesshour(self):
+        idx = DatetimeIndex(['2014-07-04 09:00', '2014-07-04 10:00', '2014-07-04 11:00',
+                             '2014-07-04 12:00', '2014-07-04 13:00', '2014-07-04 14:00',
+                             '2014-07-04 15:00', '2014-07-04 16:00'], freq='BH')
+        rng = date_range('2014-07-04 09:00', '2014-07-04 16:00', freq='BH')
+        tm.assert_index_equal(idx, rng)
+
+        idx = DatetimeIndex(['2014-07-04 16:00', '2014-07-07 09:00'], freq='BH')
+        rng = date_range('2014-07-04 16:00', '2014-07-07 09:00', freq='BH')
+        tm.assert_index_equal(idx, rng)
+
+        idx = DatetimeIndex(['2014-07-04 09:00', '2014-07-04 10:00', '2014-07-04 11:00',
+                             '2014-07-04 12:00', '2014-07-04 13:00', '2014-07-04 14:00',
+                             '2014-07-04 15:00', '2014-07-04 16:00',
+                             '2014-07-07 09:00', '2014-07-07 10:00', '2014-07-07 11:00',
+                             '2014-07-07 12:00', '2014-07-07 13:00', '2014-07-07 14:00',
+                             '2014-07-07 15:00', '2014-07-07 16:00',
+                             '2014-07-08 09:00', '2014-07-08 10:00', '2014-07-08 11:00',
+                             '2014-07-08 12:00', '2014-07-08 13:00', '2014-07-08 14:00',
+                             '2014-07-08 15:00', '2014-07-08 16:00'], freq='BH')
+        rng = date_range('2014-07-04 09:00', '2014-07-08 16:00', freq='BH')
+        tm.assert_index_equal(idx, rng)
 
     def test_string_index_series_name_converted(self):
         # #1644


### PR DESCRIPTION
Closes #2469. Create `BusinessHour` offset to specify business hours on `BusinessDay`. Appreciated if any feedbacks regarding bahaviours, keywords, etc.
### Basic

By default, use 9:00 - 17:00 as business hours. Adding `BusinessHour` will increment timestamp by hourly on the days belong to `BusinessDay` offset.

```
bh = pd.offsets.BusinessHour()
repr(bh)
# <BusinessHour: BH=09:00-17:00>

pd.Timestamp('2014-08-01 10:00') + bh
#2014-08-01 11:00:00
pd.Timestamp('2014-08-01 08:00') + bh
#2014-08-01 10:00:00

# move to next Business Day
pd.Timestamp('2014-08-01 19:00') + bh
#2014-08-04 10:00:00

# if exceeds the closing time, remaining are added to next day
pd.Timestamp('2014-08-01 16:45') + bh
#2014-08-04 09:45:00

# if n != 1
pd.Timestamp('2014-08-01 10:00') + pd.offsets.BusinessHour(2)
#2014-08-01 12:00:00

pd.Timestamp('2014-08-01 10:00') + pd.offsets.BusinessHour(-3)
#2014-07-31 15:00:00

# Create Index
pd.date_range('2014-07-08 10:00', freq='BH', periods=40)
# [2014-07-08 10:00:00, ..., 2014-07-14 17:00:00]
# Length: 40, Freq: BH, Timezone: None
```
### Specify Opening/Closing Hour

Allow to specify opening/closing time using `start` and `end` keyword by `hour:minute` string or `datetime.time`.

```
bh = pd.offsets.BusinessHour(start='11:00', end=datetime.time(20, 0))
repr(bh)
# <BusinessHour: BH=11:00-20:00>

pd.Timestamp('2014-08-01 10:00') + bh
#2014-08-01 12:00:00
pd.Timestamp('2014-08-01 13:00') + bh
#2014-08-01 14:00:00
pd.Timestamp('2014-08-01 19:00') + bh
#2014-08-04 11:00:00

# if end < start, it will be midnight business hour
bh = pd.offsets.BusinessHour(start='17:00', end='9:00')
repr(bh)
# <BusinessHour: BH=17:00-09:00>

pd.Timestamp('2014-07-31 10:00') + bh
#2014-07-31 18:00:00
pd.Timestamp('2014-07-31 23:00') + bh
#2014-08-01 00:00:00
pd.Timestamp('2014-07-31 01:00') + bh
#2014-07-31 02:00:00
pd.Timestamp('2014-08-01 13:00') + bh
#2014-08-01 18:00:00
```
### Edge cases

`onOffset` should include both edges.

```
pd.offsets.BusinessHour().onOffset(pd.Timestamp('2014-08-01 09:00'))
# True

pd.offsets.BusinessHour().onOffset(pd.Timestamp('2014-08-01 17:00'))
# True
```

If result is on the end-edge of business hour, move to next 

```
# not 2014-08-01 17:00
pd.Timestamp('2014-08-01 16:00') + pd.offsets.BusinessHour()
#2014-08-04 09:00

# not 2014-08-01 09:00
pd.Timestamp('2014-08-01 10:00') - pd.offsets.BusinessHour()
#2014-07:31 17:00
```

In case of midnight business hour, distinguish the date by its opening hour

```
#2014-08-02 is Saturday, but handled as valid because its business hour starts on 08-01
pd.Timestamp('2014-08-02 01:00') + pd.offsets.BusinessHour(start='17:00', end='9:00')
#2014-08:02 02:00
```
### Remainings:
- [x] doc
- impl & tests
  - [x] Index creation
    - [x] Confirm better conditions whether inferred_freq results in `BH` or `H`
  - [x] `normalize`
  - ~~tsplot~~ (This can't be done without #5148, skipped)
  - [x] Correct edge handling for `rollback` and `rollforward`
  - [x] handling `nanosecond` (minor issue, but current `apply_wraps` may add preserved `nanosecond` after the closing time)
- tests
  - [x] `n` larger than business shours 
  - [x] Specifying `start` and `end`
  - [x] midnight business hours
  - [x] Error cases for initialization
  - [x] Better fix for `test_apply_out_of_range` timezone check, which fails because of DST difference.
