### PR TITLE
BUG: Timestamp cannot parse nanosecond from string

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -166,6 +166,8 @@ previously results in ``Exception`` or ``TypeError`` (:issue:`7812`)
 - ``DataFrame.tz_localize`` and ``DataFrame.tz_convert`` now accepts an optional ``level`` argument
   for localizing a specific level of a MultiIndex (:issue:`7846`)
 
+- ``Timestamp.__repr__`` displays ``dateutil.tz.tzoffset`` info (:issue:`7907`)
+
 .. _whatsnew_0150.dt:
 
 .dt accessor
@@ -443,7 +445,8 @@ Bug Fixes
 - Bug in ``Series.str.cat`` with an index which was filtered as to not include the first item (:issue:`7857`)
 
 
-
+- Bug in ``Timestamp`` cannot parse ``nanosecond`` from string (:issue:`7878`)
+- Bug in ``Timestamp`` with string offset and ``tz`` results incorrect (:issue:`7833`)
 
 - Bug in ``tslib.tz_convert`` and ``tslib.tz_convert_single`` may return different results (:issue:`7798`)
 - Bug in ``DatetimeIndex.intersection`` of non-overlapping timestamps with tz raises ``IndexError`` (:issue:`7880`)

--- a/pandas/src/datetime/np_datetime_strings.h
+++ b/pandas/src/datetime/np_datetime_strings.h
@@ -27,7 +27,9 @@
  *           to be cast to the 'unit' parameter.
  *
  * 'out' gets filled with the parsed date-time.
- * 'out_local' gets set to 1 if the parsed time was in local time,
+ * 'out_local' gets whether returned value contains timezone. 0 for UTC, 1 for local time.
+ * 'out_tzoffset' gets set to timezone offset by minutes
+ *      if the parsed time was in local time,
  *      to 0 otherwise. The values 'now' and 'today' don't get counted
  *      as local, and neither do UTC +/-#### timezone offsets, because
  *      they aren't using the computer's local timezone offset.
@@ -45,7 +47,8 @@ parse_iso_8601_datetime(char *str, int len,
                     PANDAS_DATETIMEUNIT unit,
                     NPY_CASTING casting,
                     pandas_datetimestruct *out,
-                    npy_bool *out_local,
+                    int *out_local,
+                    int *out_tzoffset,
                     PANDAS_DATETIMEUNIT *out_bestunit,
                     npy_bool *out_special);
 

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -15,40 +15,180 @@ import pandas.util.testing as tm
 from pandas.util.testing import assert_series_equal
 
 class TestTimestamp(tm.TestCase):
+
+    def test_constructor(self):
+        base_str = '2014-07-01 09:00'
+        base_dt = datetime.datetime(2014, 7, 1, 9)
+        base_expected = 1404205200000000000
+
+        # confirm base representation is correct
+        import calendar
+        self.assertEqual(calendar.timegm(base_dt.timetuple()) * 1000000000, base_expected)
+
+        tests = [(base_str, base_dt, base_expected),
+                 ('2014-07-01 10:00', datetime.datetime(2014, 7, 1, 10),
+                  base_expected + 3600 * 1000000000),
+                 ('2014-07-01 09:00:00.000008000',
+                  datetime.datetime(2014, 7, 1, 9, 0, 0, 8), base_expected + 8000),
+                 ('2014-07-01 09:00:00.000000005',
+                  Timestamp('2014-07-01 09:00:00.000000005'), base_expected + 5)]
+
+        tm._skip_if_no_pytz()
+        tm._skip_if_no_dateutil()
+        import pytz
+        import dateutil
+        timezones = [(None, 0), ('UTC', 0), (pytz.utc, 0),
+                     ('Asia/Tokyo', 9), ('US/Eastern', -4), ('dateutil/US/Pacific', -7),
+                     (pytz.FixedOffset(-180), -3), (dateutil.tz.tzoffset(None, 18000), 5)]
+
+        for date_str, date, expected in tests:
+            for result in [Timestamp(date_str), Timestamp(date)]:
+                # only with timestring
+                self.assertEqual(result.value, expected)
+                self.assertEqual(tslib.pydt_to_i8(result), expected)
+
+                # re-creation shouldn't affect to internal value
+                result = Timestamp(result)
+                self.assertEqual(result.value, expected)
+                self.assertEqual(tslib.pydt_to_i8(result), expected)
+
+            # with timezone
+            for tz, offset in timezones:
+                for result in [Timestamp(date_str, tz=tz), Timestamp(date, tz=tz)]:
+                    expected_tz = expected - offset * 3600 * 1000000000
+                    self.assertEqual(result.value, expected_tz)
+                    self.assertEqual(tslib.pydt_to_i8(result), expected_tz)
+
+                    # should preserve tz
+                    result = Timestamp(result)
+                    self.assertEqual(result.value, expected_tz)
+                    self.assertEqual(tslib.pydt_to_i8(result), expected_tz)
+
+                    # should convert to UTC
+                    result = Timestamp(result, tz='UTC')
+                    expected_utc = expected - offset * 3600 * 1000000000
+                    self.assertEqual(result.value, expected_utc)
+                    self.assertEqual(tslib.pydt_to_i8(result), expected_utc)
+
+    def test_constructor_with_stringoffset(self):
+        # GH 7833
+        base_str = '2014-07-01 11:00:00+02:00'
+        base_dt = datetime.datetime(2014, 7, 1, 9)
+        base_expected = 1404205200000000000
+
+        # confirm base representation is correct
+        import calendar
+        self.assertEqual(calendar.timegm(base_dt.timetuple()) * 1000000000, base_expected)
+
+        tests = [(base_str, base_expected),
+                 ('2014-07-01 12:00:00+02:00', base_expected + 3600 * 1000000000),
+                 ('2014-07-01 11:00:00.000008000+02:00', base_expected + 8000),
+                 ('2014-07-01 11:00:00.000000005+02:00', base_expected + 5)]
+
+        tm._skip_if_no_pytz()
+        tm._skip_if_no_dateutil()
+        import pytz
+        import dateutil
+        timezones = [(None, 0), ('UTC', 0), (pytz.utc, 0),
+                     ('Asia/Tokyo', 9), ('US/Eastern', -4),
+                     ('dateutil/US/Pacific', -7),
+                     (pytz.FixedOffset(-180), -3), (dateutil.tz.tzoffset(None, 18000), 5)]
+
+        for date_str, expected in tests:
+            for result in [Timestamp(date_str)]:
+                # only with timestring
+                self.assertEqual(result.value, expected)
+                self.assertEqual(tslib.pydt_to_i8(result), expected)
+
+                # re-creation shouldn't affect to internal value
+                result = Timestamp(result)
+                self.assertEqual(result.value, expected)
+                self.assertEqual(tslib.pydt_to_i8(result), expected)
+
+            # with timezone
+            for tz, offset in timezones:
+                result = Timestamp(date_str, tz=tz)
+                expected_tz = expected
+                self.assertEqual(result.value, expected_tz)
+                self.assertEqual(tslib.pydt_to_i8(result), expected_tz)
+
+                # should preserve tz
+                result = Timestamp(result)
+                self.assertEqual(result.value, expected_tz)
+                self.assertEqual(tslib.pydt_to_i8(result), expected_tz)
+
+                # should convert to UTC
+                result = Timestamp(result, tz='UTC')
+                expected_utc = expected
+                self.assertEqual(result.value, expected_utc)
+                self.assertEqual(tslib.pydt_to_i8(result), expected_utc)
+
+        # This should be 2013-11-01 05:00 in UTC -> converted to Chicago tz
+        result = Timestamp('2013-11-01 00:00:00-0500', tz='America/Chicago')
+        self.assertEqual(result.value, Timestamp('2013-11-01 05:00').value)
+        expected_repr = "Timestamp('2013-11-01 00:00:00-0500', tz='America/Chicago')"
+        self.assertEqual(repr(result), expected_repr)
+        self.assertEqual(result, eval(repr(result)))
+
+        # This should be 2013-11-01 05:00 in UTC -> converted to Tokyo tz (+09:00)
+        result = Timestamp('2013-11-01 00:00:00-0500', tz='Asia/Tokyo')
+        self.assertEqual(result.value, Timestamp('2013-11-01 05:00').value)
+        expected_repr = "Timestamp('2013-11-01 14:00:00+0900', tz='Asia/Tokyo')"
+        self.assertEqual(repr(result), expected_repr)
+        self.assertEqual(result, eval(repr(result)))
+
     def test_repr(self):
-        date = '2014-03-07'
-        tz = 'US/Eastern'
-        freq = 'M'
+        dates = ['2014-03-07', '2014-01-01 09:00', '2014-01-01 00:00:00.000000001']
+        timezones = ['UTC', 'Asia/Tokyo', 'US/Eastern', 'dateutil/US/Pacific']
+        if _np_version_under1p7:
+            freqs = ['D', 'M', 'S']
+        else:
+            freqs = ['D', 'M', 'S', 'N']
 
-        date_only = Timestamp(date)
-        self.assertIn(date, repr(date_only))
-        self.assertNotIn(tz, repr(date_only))
-        self.assertNotIn(freq, repr(date_only))
-        self.assertEqual(date_only, eval(repr(date_only)))
+        for date in dates:
+            for tz in timezones:
+                for freq in freqs:
+                    # avoid to match with timezone name
+                    freq_repr = "'{0}'".format(freq)
+                    if tz.startswith('dateutil'):
+                        tz_repr = tz.replace('dateutil', '')
+                    else:
+                        tz_repr = tz
 
-        date_tz = Timestamp(date, tz=tz)
-        self.assertIn(date, repr(date_tz))
-        self.assertIn(tz, repr(date_tz))
-        self.assertNotIn(freq, repr(date_tz))
-        self.assertEqual(date_tz, eval(repr(date_tz)))
+                    date_only = Timestamp(date)
+                    self.assertIn(date, repr(date_only))
+                    self.assertNotIn(tz_repr, repr(date_only))
+                    self.assertNotIn(freq_repr, repr(date_only))
+                    self.assertEqual(date_only, eval(repr(date_only)))
 
-        date_freq = Timestamp(date, offset=freq)
-        self.assertIn(date, repr(date_freq))
-        self.assertNotIn(tz, repr(date_freq))
-        self.assertIn(freq, repr(date_freq))
-        self.assertEqual(date_freq, eval(repr(date_freq)))
+                    date_tz = Timestamp(date, tz=tz)
+                    self.assertIn(date, repr(date_tz))
+                    self.assertIn(tz_repr, repr(date_tz))
+                    self.assertNotIn(freq_repr, repr(date_tz))
+                    self.assertEqual(date_tz, eval(repr(date_tz)))
 
-        date_tz_freq = Timestamp(date, tz=tz, offset=freq)
-        self.assertIn(date, repr(date_tz_freq))
-        self.assertIn(tz, repr(date_tz_freq))
-        self.assertIn(freq, repr(date_tz_freq))
-        self.assertEqual(date_tz_freq, eval(repr(date_tz_freq)))
+                    date_freq = Timestamp(date, offset=freq)
+                    self.assertIn(date, repr(date_freq))
+                    self.assertNotIn(tz_repr, repr(date_freq))
+                    self.assertIn(freq_repr, repr(date_freq))
+                    self.assertEqual(date_freq, eval(repr(date_freq)))
+
+                    date_tz_freq = Timestamp(date, tz=tz, offset=freq)
+                    self.assertIn(date, repr(date_tz_freq))
+                    self.assertIn(tz_repr, repr(date_tz_freq))
+                    self.assertIn(freq_repr, repr(date_tz_freq))
+                    self.assertEqual(date_tz_freq, eval(repr(date_tz_freq)))
 
         # this can cause the tz field to be populated, but it's redundant to information in the datestring
+        tm._skip_if_no_pytz()
+        import pytz
         date_with_utc_offset = Timestamp('2014-03-13 00:00:00-0400', tz=None)
         self.assertIn('2014-03-13 00:00:00-0400', repr(date_with_utc_offset))
         self.assertNotIn('tzoffset', repr(date_with_utc_offset))
-        self.assertEqual(date_with_utc_offset, eval(repr(date_with_utc_offset)))
+        self.assertIn('pytz.FixedOffset(-240)', repr(date_with_utc_offset))
+        expr = repr(date_with_utc_offset).replace("'pytz.FixedOffset(-240)'",
+                    'pytz.FixedOffset(-240)')
+        self.assertEqual(date_with_utc_offset, eval(expr))
 
     def test_bounds_with_different_units(self):
         out_of_bounds_dates = (
@@ -314,8 +454,24 @@ class TestTimestampNsOperations(tm.TestCase):
         self.assert_ns_timedelta(time, -123000000)
 
     def test_nanosecond_string_parsing(self):
-        self.timestamp = Timestamp('2013-05-01 07:15:45.123456789')
-        self.assertEqual(self.timestamp.value, 1367392545123456000)
+        ts = Timestamp('2013-05-01 07:15:45.123456789')
+        # GH 7878
+        expected_repr = '2013-05-01 07:15:45.123456789'
+        expected_value = 1367392545123456789
+        self.assertEqual(ts.value, expected_value)
+        self.assertIn(expected_repr, repr(ts))
+
+        ts = Timestamp('2013-05-01 07:15:45.123456789+09:00', tz='Asia/Tokyo')
+        self.assertEqual(ts.value, expected_value - 9 * 3600 * 1000000000)
+        self.assertIn(expected_repr, repr(ts))
+
+        ts = Timestamp('2013-05-01 07:15:45.123456789', tz='UTC')
+        self.assertEqual(ts.value, expected_value)
+        self.assertIn(expected_repr, repr(ts))
+
+        ts = Timestamp('2013-05-01 07:15:45.123456789', tz='US/Eastern')
+        self.assertEqual(ts.value, expected_value + 4 * 3600 * 1000000000)
+        self.assertIn(expected_repr, repr(ts))
 
     def test_nanosecond_timestamp(self):
         # GH 7610

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -217,12 +217,6 @@ class Timestamp(_Timestamp):
         cdef _TSObject ts
         cdef _Timestamp ts_base
 
-        if util.is_string_object(ts_input):
-            try:
-                ts_input = parse_date(ts_input)
-            except Exception:
-                pass
-
         ts = convert_to_tsobject(ts_input, tz, unit)
 
         if ts.value == NPY_NAT:
@@ -263,7 +257,7 @@ class Timestamp(_Timestamp):
         except:
             pass
 
-        tz = ", tz='{0}'".format(zone) if zone is not None and not isinstance(zone, tzoffset) else ""
+        tz = ", tz='{0}'".format(zone) if zone is not None else ""
         offset = ", offset='{0}'".format(self.offset.freqstr) if self.offset is not None else ""
 
         return "Timestamp('{stamp}'{tz}{offset})".format(stamp=stamp, tz=tz, offset=offset)
@@ -926,11 +920,40 @@ cdef convert_to_tsobject(object ts, object tz, object unit):
     cdef:
         _TSObject obj
         bint utc_convert = 1
+        int out_local = 0, out_tzoffset = 0
 
     if tz is not None:
         tz = maybe_get_tz(tz)
 
     obj = _TSObject()
+
+    if util.is_string_object(ts):
+        if ts in _nat_strings:
+            ts = NaT
+        else:
+            try:
+                _string_to_dts(ts, &obj.dts, &out_local, &out_tzoffset)
+                obj.value = pandas_datetimestruct_to_datetime(PANDAS_FR_ns, &obj.dts)
+                _check_dts_bounds(&obj.dts)
+                if out_local == 1:
+                    obj.tzinfo = pytz.FixedOffset(out_tzoffset)
+                    obj.value = tz_convert_single(obj.value, obj.tzinfo, 'UTC')
+                    if tz is None:
+                        _check_dts_bounds(&obj.dts)
+                        return obj
+                    else:
+                        # Keep the converter same as PyDateTime's
+                        ts = Timestamp(obj.value, tz=obj.tzinfo)
+                else:
+                    ts = obj.value
+                    if tz is not None:
+                        # shift for _localize_tso
+                        ts = tz_convert_single(ts, tz, 'UTC')
+            except ValueError:
+                try:
+                    ts = parse_datetime_string(ts)
+                except Exception:
+                    raise ValueError
 
     if ts is None or ts is NaT or ts is np_NaT:
         obj.value = NPY_NAT
@@ -954,12 +977,6 @@ cdef convert_to_tsobject(object ts, object tz, object unit):
             ts = cast_from_unit(ts,unit)
             obj.value = ts
             pandas_datetime_to_datetimestruct(ts, PANDAS_FR_ns, &obj.dts)
-    elif util.is_string_object(ts):
-        if ts in _nat_strings:
-            obj.value = NPY_NAT
-        else:
-            _string_to_dts(ts, &obj.dts)
-            obj.value = pandas_datetimestruct_to_datetime(PANDAS_FR_ns, &obj.dts)
     elif PyDateTime_Check(ts):
         if tz is not None:
             # sort of a temporary hack
@@ -970,6 +987,10 @@ cdef convert_to_tsobject(object ts, object tz, object unit):
                     obj.value = _pydatetime_to_dts(ts, &obj.dts)
                     obj.tzinfo = ts.tzinfo
                 else: #tzoffset
+                    try:
+                        tz = ts.astimezone(tz).tzinfo
+                    except:
+                        pass
                     obj.value = _pydatetime_to_dts(ts, &obj.dts)
                     ts_offset = _get_utcoffset(ts.tzinfo, ts)
                     obj.value -= _delta_to_nanoseconds(ts_offset)
@@ -979,10 +1000,7 @@ cdef convert_to_tsobject(object ts, object tz, object unit):
                                                       PANDAS_FR_ns, &obj.dts)
                     obj.tzinfo = tz
             elif not _is_utc(tz):
-                try:
-                    ts = tz.localize(ts)
-                except AttributeError:
-                    ts = ts.replace(tzinfo=tz)
+                ts = _localize_pydatetime(ts, tz)
                 obj.value = _pydatetime_to_dts(ts, &obj.dts)
                 obj.tzinfo = ts.tzinfo
             else:
@@ -1071,14 +1089,11 @@ def _localize_pydatetime(object dt, object tz):
         return dt.tz_localize(tz)
     elif tz == 'UTC' or tz is UTC:
         return UTC.localize(dt)
-
-    elif _treat_tz_as_pytz(tz):
-        # datetime.replace may return incorrect result in pytz
+    try:
+        # datetime.replace with pytz may be incorrect result
         return tz.localize(dt)
-    elif _treat_tz_as_dateutil(tz):
+    except AttributeError:
         return dt.replace(tzinfo=tz)
-    else:
-        raise ValueError(type(tz), tz)
 
 
 def get_timezone(tz):
@@ -1239,6 +1254,7 @@ def array_to_datetime(ndarray[object] values, raise_=False, dayfirst=False,
         bint utc_convert = bool(utc), seen_integer=0, seen_datetime=0
         _TSObject _ts
         int64_t m = cast_from_unit(None,unit)
+        int out_local = 0, out_tzoffset = 0
 
     try:
         result = np.empty(n, dtype='M8[ns]')
@@ -1321,9 +1337,12 @@ def array_to_datetime(ndarray[object] values, raise_=False, dayfirst=False,
                        iresult[i] = iNaT
                        continue
 
-                    _string_to_dts(val, &dts)
-                    iresult[i] = pandas_datetimestruct_to_datetime(PANDAS_FR_ns,
-                                                                   &dts)
+                    _string_to_dts(val, &dts, &out_local, &out_tzoffset)
+                    value = pandas_datetimestruct_to_datetime(PANDAS_FR_ns, &dts)
+                    if out_local == 1:
+                        tz = pytz.FixedOffset(out_tzoffset)
+                        value = tz_convert_single(value, tz, 'UTC')
+                    iresult[i] = value
                     _check_dts_bounds(&dts)
                 except ValueError:
                     try:
@@ -2865,14 +2884,6 @@ cdef inline int64_t _normalized_stamp(pandas_datetimestruct *dts):
     dts.us = 0
     dts.ps = 0
     return pandas_datetimestruct_to_datetime(PANDAS_FR_ns, dts)
-
-
-cdef inline void m8_populate_tsobject(int64_t stamp, _TSObject tso, object tz):
-    tso.value = stamp
-    pandas_datetime_to_datetimestruct(tso.value, PANDAS_FR_ns, &tso.dts)
-
-    if tz is not None:
-        _localize_tso(tso, tz)
 
 
 def dates_normalized(ndarray[int64_t] stamps, tz=None):


### PR DESCRIPTION
Fixes 2 problems related to `Timestamp` string parsing:
- `Timestamp` parsing results incorrect if input contains offset string (Closes #7833).
  
   NOTE: Also modified `Timestamp.__repr__` to display fixed timezone info, because this can be either `pytz` or `dateutil`.

```
# Result after the fix

# If string contains offset, it will be parsed using fixed timezone offset. Following results in 2013-11-01 05:00:00 in UTC (There is some existing tests checking this behaviour).
repr(pd.Timestamp('2013-11-01 00:00:00-0500'))
# Timestamp('2013-11-01 00:00:00-0500', tz='pytz.FixedOffset(-300)')

# If tz is specified simultaneously, it should convert the timezone. 
repr(pd.Timestamp('2013-11-01 00:00:00-0500', tz='America/Chicago'))
# Timestamp('2013-11-01 00:00:00-0500', tz='America/Chicago')

repr(pd.Timestamp('2013-11-01 00:00:00-0500', tz='Asia/Tokyo'))
# Timestamp('2013-11-01 14:00:00+0900', tz='Asia/Tokyo')
```
- `Timestamp` loses `nanosecond` info when parsing from `str`. (Closes #7878)

```
# Result after the fix

repr(pd.Timestamp('2001-01-01 00:00:00.000000005'))
# Timestamp('2001-01-01 00:00:00.000000005')

repr(pd.Timestamp('2001-01-01 00:00:00.000000005', tz='US/Eastern'))
# Timestamp('2001-01-01 00:00:00.000000005-0500', tz='US/Eastern')

repr(pd.Timestamp('2001-01-01 00:00:00.000001234+09:00'))
# Timestamp('2001-01-01 00:00:00.000001234+0900', tz='pytz.FixedOffset(540)')

repr(pd.Timestamp('2001-01-01 00:00:00.000001234+09:00', tz='Asia/Tokyo'))
# Timestamp('2001-01-01 00:00:00.000001234+0900', tz='Asia/Tokyo')

# Because non ISO 8601 format is parsed by dateutil, nanosecond will lost (no change)
repr(pd.Timestamp('01-01-01 00:00:00.000000001'))
# Timestamp('2001-01-01 00:00:00')

repr(pd.Timestamp('01-01-01 00:00:00.000000001+9:00'))
# Timestamp('2001-01-01 00:00:00+0900', tz='tzoffset(None, 32400)')
```

CC @cyber42 @ischwabacher @rockg @adamgreenhall
