### PR TITLE
Remove from start/end dates if tz is not None (#7901, #7835)

### DIFF
--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -1364,6 +1364,12 @@ tz-aware data to another time zone:
        is localized using one version and operated on with a different version.  
        See :ref:`here<io.hdf5-notes>` for how to handle such a situation.
 
+.. warning::
+
+       It is incorrect to pass a timezone directly into the ``datetime.datetime`` constructor (e.g.,
+       ``datetime.datetime(2011, 1, 1, tz=timezone('US/Eastern'))``.  Instead, the datetime
+       needs to be localized using the the localize method on the timezone.
+
 Under the hood, all timestamps are stored in UTC. Scalar values from a
 ``DatetimeIndex`` with a time zone will have their fields (day, hour, minute)
 localized to the time zone. However, timestamps with the same UTC value are

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -358,7 +358,9 @@ Bug Fixes
 
 
 - Bug in ``GroupBy.filter()`` where fast path vs. slow path made the filter
-  return a non scalar value that appeared valid but wasnt' (:issue:`7870`).
+  return a non scalar value that appeared valid but wasn't (:issue:`7870`).
+- Bug in ``date_range()``/``DatetimeIndex()`` when the timezone was inferred from input dates yet incorrect
+  times were returned when crossing DST boundaries (:issue:`7835`, :issue:`7901`).  
 
 
 

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -416,7 +416,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
 
         else:
 
-            if inferred_tz is None and tz is not None:
+            if tz is not None:
                 # naive dates
                 if start is not None and start.tz is not None:
                     start = start.replace(tzinfo=None)


### PR DESCRIPTION
Below fixes date_range when input dates are localized.  In that case inferred_freq is not None and so the dates do not have their tzinfo removed.  This causes a fixed offset to be applied when the range is created.  If tzinfo is removed, they will be correctly localized.  

Fixes #7901 
Fixes #7835.
