### PR TITLE
ENH: New `level` argument for DataFrame.tz_localize and DataFrame.tz_convert (GH7846)

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -162,6 +162,9 @@ previously results in ``Exception`` or ``TypeError`` (:issue:`7812`)
      didx
      didx.tz_localize(None)
 
+- ``DataFrame.tz_localize`` and ``DataFrame.tz_convert`` now accepts an optional ``level`` argument 
+  for localizing a specific level of a MultiIndex (:issue:`7846`)
+
 .. _whatsnew_0150.refactoring:
 
 Internal Refactoring

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -1174,6 +1174,52 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
         else:
             raise Exception("invalid pickle state")
     _unpickle_compat = __setstate__
+
+    def tz_convert(self, tz):
+        """
+        Convert tz-aware DatetimeIndex from one time zone to another (using pytz/dateutil)
+
+        Parameters
+        ----------
+        tz : string, pytz.timezone, dateutil.tz.tzfile or None
+            Time zone for time. Corresponding timestamps would be converted to
+            time zone of the TimeSeries.
+            None will remove timezone holding UTC time.
+
+        Returns
+        -------
+        normalized : DatetimeIndex
+
+        Note
+        ----
+        Not currently implemented for PeriodIndex
+        """
+        raise NotImplementedError("Not yet implemented for PeriodIndex")
+
+    def tz_localize(self, tz, infer_dst=False):
+        """
+        Localize tz-naive DatetimeIndex to given time zone (using pytz/dateutil),
+        or remove timezone from tz-aware DatetimeIndex
+
+        Parameters
+        ----------
+        tz : string, pytz.timezone, dateutil.tz.tzfile or None
+            Time zone for time. Corresponding timestamps would be converted to
+            time zone of the TimeSeries.
+            None will remove timezone holding local time.
+        infer_dst : boolean, default False
+            Attempt to infer fall dst-transition hours based on order
+
+        Returns
+        -------
+        localized : DatetimeIndex
+
+        Note
+        ----
+        Not currently implemented for PeriodIndex
+        """
+        raise NotImplementedError("Not yet implemented for PeriodIndex")
+
 PeriodIndex._add_numeric_methods_disabled()
 
 def _get_ordinal_range(start, end, periods, freq):


### PR DESCRIPTION
Closes #7846

New `level` argument for `DataFrame.tz_localize()` and `DataFrame.tz_convert()`, needed for a DataFrame with MultiIndex:

```
tz_convert(self, tz, axis=0, level=None, copy=True)
tz_localize(self, tz, axis=0, level=None, copy=True, infer_dst=False)
```

@jreback Not sure if `test_generic.py` is the right place to add the tests.
