### PR TITLE
REGR: Regression in multi-index indexing with a non-scalar type object (GH7914)

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -296,7 +296,7 @@ Bug Fixes
 - Bug in adding and subtracting ``PeriodIndex`` with ``PeriodIndex`` raise ``TypeError`` (:issue:`7741`)
 - Bug in ``combine_first`` with ``PeriodIndex`` data raises ``TypeError`` (:issue:`3367`)
 - Bug in multi-index slicing with missing indexers (:issue:`7866`)
-
+- Regression in multi-index indexing with a non-scalar type object (:issue:`7914`)
 
 - Bug in pickles contains ``DateOffset`` may raise ``AttributeError`` when ``normalize`` attribute is reffered internally (:issue:`7748`)
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -838,7 +838,7 @@ class _NDFrameIndexer(object):
             axis += 1
 
             # if we have a scalar, we are done
-            if np.isscalar(obj):
+            if np.isscalar(obj) or not hasattr(obj,'ndim'):
                 break
 
             # has the dim of the obj changed?

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -1974,6 +1974,15 @@ class TestIndexing(tm.TestCase):
         result = s.loc[idx[:,['foo','bah']]]
         assert_series_equal(result,expected)
 
+        # regression from < 0.14.0
+        # GH 7914
+        df = DataFrame([[np.mean, np.median],['mean','median']],
+                       columns=MultiIndex.from_tuples([('functs','mean'),
+                                                       ('functs','median')]),
+                       index=['function', 'name'])
+        result = df.loc['function',('functs','mean')]
+        self.assertEqual(result,np.mean)
+
     def test_setitem_dtype_upcast(self):
 
         # GH3216


### PR DESCRIPTION
closes #7914
