### PR TITLE
DOC: mention that stack/unstack implicicly sort

### DIFF
--- a/doc/source/reshaping.rst
+++ b/doc/source/reshaping.rst
@@ -151,6 +151,20 @@ unstacks the **last level**:
    stacked.unstack(1)
    stacked.unstack(0)
 
+Notice that the ``stack`` and ``unstack`` methods implicitly sort the index
+levels involved. Hence a call to ``stack`` and then ``unstack``, or viceversa,
+will result in a **sorted** copy of the original DataFrame or Series:
+
+.. ipython:: python
+
+   index = MultiIndex.from_product([[2,1], ['a', 'b']])
+   df = DataFrame(randn(4), index=index, columns=['A'])
+   df
+   all(df.unstack().stack() == df.sort())
+
+while the above code will raise a ``TypeError`` if the call to ``sort`` is
+removed.
+
 .. _reshaping.unstack_by_name:
 
 If the indexes have names, you can use the level names instead of specifying

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3278,6 +3278,7 @@ class DataFrame(NDFrame):
         DataFrame (or Series in the case of an object with a single level of
         column labels) having a hierarchical index with a new inner-most level
         of row labels.
+        The level involved will automatically get sorted.
 
         Parameters
         ----------
@@ -3317,7 +3318,8 @@ class DataFrame(NDFrame):
         a DataFrame having a new level of column labels whose inner-most level
         consists of the pivoted index labels. If the index is not a MultiIndex,
         the output will be a Series (the analogue of stack when the columns are
-        not a MultiIndex)
+        not a MultiIndex).
+        The level involved will automatically get sorted.
 
         Parameters
         ----------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1884,7 +1884,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def unstack(self, level=-1):
         """
-        Unstack, a.k.a. pivot, Series with MultiIndex to produce DataFrame
+        Unstack, a.k.a. pivot, Series with MultiIndex to produce DataFrame.
+        The level involved will automatically get sorted.
 
         Parameters
         ----------


### PR DESCRIPTION
It took me a while to discover what was causing this TypeError... I guess this can be useful to other people.

(Yes, I know there is a note somewhere warning users that some operations depend on the index being sorted, but maybe this is a sligthly different case, since the operations do work after all, the problem is they do something more than what is documented)
