### PR TITLE
BUG/API: Consistency in .where() when setting with None for both inplace in a Series (GH7939)

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -142,6 +142,7 @@ API changes
      In [3]: idx.isin(['a', 'c', 'e'], level=1)
      Out[3]: array([ True, False,  True,  True, False,  True], dtype=bool)
 
+- Consistency in ``.where()`` when setting with ``None`` for both ``inplace=True`` and ``inplace=False`` in a Series (:issue:`7939`)
 
 .. _whatsnew_0150.cat:
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -967,6 +967,10 @@ class Block(PandasObject):
                     values = values.T
                     is_transposed = True
 
+        # if we are passed a scalar None, convert it here
+        if not is_list_like(other) and isnull(other):
+            other = self.fill_value
+
         # see if we can align cond
         if not hasattr(cond, 'shape'):
             raise ValueError(

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1597,6 +1597,24 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         rs.where(cond, -s, inplace=True)
         assert_series_equal(rs, s.where(cond, -s))
 
+        # GH 7939
+        # treatment of None different in where inplace
+        s1 = Series(['a', 'b', 'c'])
+        result = s1.where(s1 != 'a', None)
+
+        s2 = Series(['a', 'b', 'c'])
+        s2.where(s1 != 'a', None, inplace=True)
+        assert_series_equal(result, s2)
+
+        # this sets None directly, a little bit inconsistent
+        # but no easy way to deal with this in object arrays
+        s3 = Series(['a', 'b', 'c'])
+        s3[0] = None
+        s3[s3 == 'b'] = None
+        expected = Series([None,np.nan,'c'])
+        assert_series_equal(s3, expected)
+
+
     def test_where_dups(self):
         # GH 4550
         # where crashes with dups in index


### PR DESCRIPTION
closes #7939
