### PR TITLE
API: Coerce None according to the dtype of the container

### DIFF
--- a/doc/source/missing_data.rst
+++ b/doc/source/missing_data.rst
@@ -105,6 +105,34 @@ pandas objects provide intercompatibility between ``NaT`` and ``NaN``.
    df2
    df2.get_dtype_counts()
 
+.. _missing.inserting:
+
+Inserting missing data
+----------------------
+
+You can insert missing values by simply assigning to containers. The
+actual missing value used will be chosen based on the dtype.
+
+For example, numeric containers will always use ``NaN`` regardless of
+the missing value type chosen:
+
+.. ipython:: python
+
+   s = Series([1, 2, 3])
+   s.loc[0] = None
+   s
+
+Likewise, datetime containers will always use ``NaT``.
+
+For object containers, pandas will use the value given:
+
+.. ipython:: python
+
+   s = Series(["a", "b", "c"])
+   s.loc[0] = None
+   s.loc[1] = np.nan
+   s
+
 
 Calculations with missing data
 ------------------------------

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -232,6 +232,31 @@ API changes
      idx.duplicated()
      idx.drop_duplicates()
 
+- Assigning values to ``None`` now considers the dtype when choosing an 'empty' value (:issue:`7941`).
+
+  Previously, assigning to ``None`` in numeric containers changed the
+  dtype to object (or errored, depending on the call). It now uses
+  NaN:
+
+  .. ipython:: python
+
+     s = Series([1, 2, 3])
+     s.loc[0] = None
+     s
+
+  ``NaT`` is now used similarly for datetime containers.
+
+  For object containers, we now preserve None values (previously these
+  were converted to NaN values).
+
+  .. ipython:: python
+
+     s = Series(["a", "b", "c"])
+     s.loc[0] = None
+     s
+
+  To insert a NaN, you must explicitly use ``np.nan``. See the :ref:`docs <missing.inserting>`.
+
 .. _whatsnew_0150.dt:
 
 .dt accessor

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -368,7 +368,7 @@ def _is_null_datelike_scalar(other):
         return isnull(other)
     return False
 
-def array_equivalent(left, right):
+def array_equivalent(left, right, strict_nan=False):
     """
     True if two arrays, left and right, have equal non-NaN elements, and NaNs in
     corresponding locations.  False otherwise. It is assumed that left and right
@@ -379,6 +379,8 @@ def array_equivalent(left, right):
     Parameters
     ----------
     left, right : ndarrays
+    strict_nan : bool, default False
+        If True, consider NaN and None to be different.
 
     Returns
     -------
@@ -394,11 +396,32 @@ def array_equivalent(left, right):
     """
     left, right = np.asarray(left), np.asarray(right)
     if left.shape != right.shape: return False
-    # NaNs occur only in object arrays, float or complex arrays.
+
+    # Object arrays can contain None, NaN and NaT.
     if issubclass(left.dtype.type, np.object_):
-        return ((left == right) | (pd.isnull(left) & pd.isnull(right))).all()
+
+        if not strict_nan:
+            # pd.isnull considers NaN and None to be equivalent.
+            return ((left == right) | (pd.isnull(left) & pd.isnull(right))).all()
+
+        for left_value, right_value in zip(left, right):
+            if left_value is tslib.NaT and right_value is not tslib.NaT:
+                return False
+
+            elif isinstance(left_value, float) and np.isnan(left_value):
+                if not isinstance(right_value, float) or not np.isnan(right_value):
+                    return False
+            else:
+                if left_value != right_value:
+                    return False
+
+        return True
+
+    # NaNs can occur in float and complex arrays.
     if issubclass(left.dtype.type, (np.floating, np.complexfloating)):
         return ((left == right) | (np.isnan(left) & np.isnan(right))).all()
+
+    # NaNs cannot occur otherwise.
     return np.array_equal(left, right)
 
 def _iterable_not_string(x):

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -494,6 +494,11 @@ class Block(PandasObject):
         compatible shape
         """
 
+        # coerce None values, if appropriate
+        if value is None:
+            if self.is_numeric:
+                value = np.nan
+
         # coerce args
         values, value = self._try_coerce_args(self.values, value)
         arr_value = np.array(value)
@@ -587,7 +592,7 @@ class Block(PandasObject):
             mask = mask.values.T
 
         # if we are passed a scalar None, convert it here
-        if not is_list_like(new) and isnull(new):
+        if not is_list_like(new) and isnull(new) and not self.is_object:
             new = self.fill_value
 
         if self._can_hold_element(new):

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -105,7 +105,7 @@ class TestCase(unittest.TestCase):
             pd.to_pickle(obj, path)
             return pd.read_pickle(path)
 
-    def assert_numpy_array_equivalent(self, np_array, assert_equal):
+    def assert_numpy_array_equivalent(self, np_array, assert_equal, strict_nan=False):
         """Checks that 'np_array' is equivalent to 'assert_equal'
 
         Two numpy arrays are equivalent if the arrays have equal non-NaN elements, and
@@ -115,7 +115,7 @@ class TestCase(unittest.TestCase):
         similar to `assert_numpy_array_equal()`. If the expected array includes `np.nan` use this
         function.
         """
-        if array_equivalent(np_array, assert_equal):
+        if array_equivalent(np_array, assert_equal, strict_nan=strict_nan):
             return
         raise AssertionError('{0} is not equivalent to {1}.'.format(np_array, assert_equal))
 


### PR DESCRIPTION
This pull request fixes #7939 by ensuring that None coercion always obeys the following rules:
1. If the container is numeric, None should be coerced to NaN
2. If the container is for time data, None should be coerced to NaT
3. If the container contains heterogenous data (i.e. objects), None should be preserved.
## Old behaviour examples
### Assigning None in integer containers

None is sometimes preserved, sometimes coerced to NaN, and sometimes causes an error.

``` python
>>> s = Series([1, 2, 3])
>>> s[0] = None # error

>>> s = Series([1, 2, 3])
>>> s.loc[0] = None
>>> s
0    None
1       2
2       3
dtype: object

>>> s = Series([1, 2, 3])
>>> s[s == 1] = None
>>> s
0   NaN
1     2
2     3
dtype: float64

>>> s = Series([1, 2, 3])
>>> s.loc[s == 1] = None
0    None
1       2
2       3
dtype: object

```

Datetimes are similar.
### Assigning None in object containers

None is sometimes preserved, and sometimes coerced.

``` python
>>> s = Series(["a", "b", "c"])
>>> s[0] = None
0    None
1       b
2       c
dtype: object

>>> s = Series(["a", "b", "c"])
>>> s.loc[0] = None
0    None
1       b
2       c
dtype: object

>>> s = Series(["a", "b", "c"])
>>> s[s == 'a'] = None
0    NaN
1      b
2      c
dtype: object

>>> s = Series(["a", "b", "c"])
>>> s.loc[s == 'a'] = None
0    None
1       b
2       c
dtype: object
```
## New behaviour examples
### None is always coerced to NaN in integer containers

``` python
>>> s = Series([1, 2, 3])
>>> s[0] = None
0    NaN
1      2
2      3
dtype: float64

>>> s = Series([1, 2, 3])
>>> s.loc[0] = None # same

>>> s = Series([1, 2, 3])
>>> s[s == 1] = None # same

>>> s = Series([1, 2, 3])
>>> s.loc[s == 1] = None # same
```
### None is always preserved in object containers

``` python
>>> s = Series(["a", "b", "c"])
>>> s[0] = None
0    None
1       b
2       c
dtype: object

>>> s = Series(["a", "b", "c"])
>>> s.loc[0] = None # same

>>> s = Series(["a", "b", "c"])
>>> s[s == 'a'] = None

>>> s = Series(["a", "b", "c"])
>>> s.loc[s == 'a'] = None # same
```
