### PR TITLE
DOC: add intersphinx mapping to numpy

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -278,7 +278,8 @@ latex_documents = [
 intersphinx_mapping = {
     'statsmodels': ('http://statsmodels.sourceforge.net/devel/', None),
     'matplotlib': ('http://matplotlib.org/', None),
-    'python': ('http://docs.python.org/', None)
+    'python': ('http://docs.python.org/', None),
+    'numpy': ('http://docs.scipy.org/doc/numpy', None)
 }
 import glob
 autosummary_generate = glob.glob("*.rst")


### PR DESCRIPTION
There are already some references in the API docs to numpy functions, but the links did not yet work up to now.
