### PR TITLE
BUG: Fix for to_excel +/- infinity

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -621,11 +621,11 @@ Bug Fixes
   return a non scalar value that appeared valid but wasn't (:issue:`7870`).
 - Bug in ``date_range()``/``DatetimeIndex()`` when the timezone was inferred from input dates yet incorrect
   times were returned when crossing DST boundaries (:issue:`7835`, :issue:`7901`).
-
-
+- Bug in ``to_excel()`` where a negative sign was being prepended to positive infinity and was absent for negative infinity (:issue`7949`)
 - Bug in area plot draws legend with incorrect ``alpha`` when ``stacked=True`` (:issue:`8027`)
-
 - ``Period`` and ``PeriodIndex`` addition/subtraction with ``np.timedelta64`` results in incorrect internal representations (:issue:`7740`)
+  times were returned when crossing DST boundaries (:issue:`7835`, :issue:`7901`).  
+- Bug in ``to_excel()`` where a negative sign was being prepended to positive infinity and was absent for negative infinity (:issue`7949`)
 
 - ``Holiday`` bug in Holiday with no offset or observance (:issue:`7987`)
 

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -1512,9 +1512,9 @@ class ExcelFormatter(object):
             val = self.na_rep
         elif com.is_float(val):
             if np.isposinf(val):
-                val = '-%s' % self.inf_rep
-            elif np.isneginf(val):
                 val = self.inf_rep
+            elif np.isneginf(val):
+                val = '-%s' % self.inf_rep
             elif self.float_format is not None:
                 val = float(self.float_format % val)
         return val

--- a/pandas/src/testing.pyx
+++ b/pandas/src/testing.pyx
@@ -122,6 +122,10 @@ cpdef assert_almost_equal(a, b, bint check_less_precise=False):
 
         if np.isinf(a):
             assert np.isinf(b), "First object is inf, second isn't"
+            if np.isposinf(a):
+                assert np.isposinf(b), "First object is positive inf, second is negative inf"
+            else:
+                assert np.isneginf(b), "First object is negative inf, second is positive inf"
         else:
             fa, fb = a, b
 


### PR DESCRIPTION
BUG: Previously, a negative sign was being prepended for positive infinity, not for negative infinity. (GH6812)

xref #6812 
