### PR TITLE
COMPAT: raise SettingWithCopy in even more situations when a view is at hand

### DIFF
--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -1481,7 +1481,8 @@ which can take the values ``['raise','warn',None]``, where showing a warning is 
                            'three', 'two', 'one', 'six'],
                     'c' : np.arange(7)})
 
-   # passed via reference (will stay)
+   # This will show the SettingWithCopyWarning
+   # but the frame values will be set
    dfb['c'][dfb.a.str.startswith('o')] = 42
 
 This however is operating on a copy and will not work.

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -114,7 +114,7 @@ API changes
         df
         df.dtypes
 
-- ``SettingWithCopy`` raise/warnings (according to the option ``mode.chained_assignment``) will now be issued when setting a value on a sliced mixed-dtype DataFrame using chained-assignment. (:issue:`7845`)
+- ``SettingWithCopy`` raise/warnings (according to the option ``mode.chained_assignment``) will now be issued when setting a value on a sliced mixed-dtype DataFrame using chained-assignment. (:issue:`7845`, :issue:`7950`)
 
   .. code-block:: python
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1088,11 +1088,10 @@ class NDFrame(PandasObject):
     @property
     def _is_cached(self):
         """ boolean : return if I am cached """
-        cacher = getattr(self, '_cacher', None)
-        return cacher is not None
+        return getattr(self, '_cacher', None) is not None
 
     def _get_cacher(self):
-        """ return my cahcer or None """
+        """ return my cacher or None """
         cacher = getattr(self, '_cacher', None)
         if cacher is not None:
             cacher = cacher[1]()
@@ -1167,13 +1166,18 @@ class NDFrame(PandasObject):
         if so, then force a setitem_copy check
 
         should be called just near setting a value
+
+        will return a boolean if it we are a view and are cached, but a single-dtype
+        meaning that the cacher should be updated following setting
         """
         if self._is_view and self._is_cached:
             ref = self._get_cacher()
             if ref is not None and ref._is_mixed_type:
-                self._check_setitem_copy(stacklevel=5, t='referant', force=True)
+                self._check_setitem_copy(stacklevel=4, t='referant', force=True)
+            return True
         elif self.is_copy:
-            self._check_setitem_copy(stacklevel=5, t='referant')
+            self._check_setitem_copy(stacklevel=4, t='referant')
+        return False
 
     def _check_setitem_copy(self, stacklevel=4, t='setting', force=False):
         """

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -472,6 +472,9 @@ class _NDFrameIndexer(object):
             if isinstance(value, ABCPanel):
                 value = self._align_panel(indexer, value)
 
+            # check for chained assignment
+            self.obj._check_is_chained_assignment_possible()
+
             # actually do the set
             self.obj._data = self.obj._data.setitem(indexer=indexer, value=value)
             self.obj._maybe_update_cacher(clear=True)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -641,7 +641,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         values = self.values
         try:
             self.index._engine.set_value(values, key, value)
-            self._check_setitem_copy()
+            self._check_is_chained_assignment_possible()
             return
         except KeyError:
             values[self.index.get_loc(key)] = value

--- a/pandas/io/tests/test_json/test_pandas.py
+++ b/pandas/io/tests/test_json/test_pandas.py
@@ -305,13 +305,13 @@ class TestPandasContainer(tm.TestCase):
         # infinities get mapped to nulls which get mapped to NaNs during
         # deserialisation
         df = DataFrame([[1, 2], [4, 5, 6]])
-        df[2][0] = np.inf
+        df.loc[0,2] = np.inf
         unser = read_json(df.to_json())
         self.assertTrue(np.isnan(unser[2][0]))
         unser = read_json(df.to_json(), dtype=False)
         self.assertTrue(np.isnan(unser[2][0]))
 
-        df[2][0] = np.NINF
+        df.loc[0,2] = np.NINF
         unser = read_json(df.to_json())
         self.assertTrue(np.isnan(unser[2][0]))
         unser = read_json(df.to_json(),dtype=False)

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -1278,8 +1278,8 @@ class TestHDFStore(tm.TestCase):
             # data column selection with a string data_column
             df_new = df.copy()
             df_new['string'] = 'foo'
-            df_new['string'][1:4] = np.nan
-            df_new['string'][5:6] = 'bar'
+            df_new.loc[1:4,'string'] = np.nan
+            df_new.loc[5:6,'string'] = 'bar'
             _maybe_remove(store, 'df')
             store.append('df', df_new, data_columns=['string'])
             result = store.select('df', [Term('string=foo')])
@@ -1317,14 +1317,14 @@ class TestHDFStore(tm.TestCase):
         with ensure_clean_store(self.path) as store:
             # multiple data columns
             df_new = df.copy()
-            df_new.loc[:,'A'].iloc[0] = 1.
-            df_new.loc[:,'B'].iloc[0] = -1.
+            df_new.ix[0,'A'] = 1.
+            df_new.ix[0,'B'] = -1.
             df_new['string'] = 'foo'
-            df_new['string'][1:4] = np.nan
-            df_new['string'][5:6] = 'bar'
+            df_new.loc[1:4,'string'] = np.nan
+            df_new.loc[5:6,'string'] = 'bar'
             df_new['string2'] = 'foo'
-            df_new['string2'][2:5] = np.nan
-            df_new['string2'][7:8] = 'bar'
+            df_new.loc[2:5,'string2'] = np.nan
+            df_new.loc[7:8,'string2'] = 'bar'
             _maybe_remove(store, 'df')
             store.append(
                 'df', df_new, data_columns=['A', 'B', 'string', 'string2'])

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -1348,8 +1348,8 @@ class TestDataFrameFormatting(tm.TestCase):
                             'B': tm.makeStringIndex(200)},
                            index=lrange(200))
 
-        biggie['A'][:20] = nan
-        biggie['B'][:20] = nan
+        biggie.loc[:20,'A'] = nan
+        biggie.loc[:20,'B'] = nan
         s = biggie.to_string()
 
         buf = StringIO()
@@ -1597,8 +1597,8 @@ c  10  11  12  13  14\
                             'B': tm.makeStringIndex(200)},
                            index=lrange(200))
 
-        biggie['A'][:20] = nan
-        biggie['B'][:20] = nan
+        biggie.loc[:20,'A'] = nan
+        biggie.loc[:20,'B'] = nan
         s = biggie.to_html()
 
         buf = StringIO()
@@ -1624,8 +1624,8 @@ c  10  11  12  13  14\
                             'B': tm.makeStringIndex(200)},
                            index=lrange(200))
 
-        biggie['A'][:20] = nan
-        biggie['B'][:20] = nan
+        biggie.loc[:20,'A'] = nan
+        biggie.loc[:20,'B'] = nan
         with tm.ensure_clean('test.html') as path:
             biggie.to_html(path)
             with open(path, 'r') as f:

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4438,8 +4438,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         biggie = DataFrame({'A': randn(200),
                             'B': tm.makeStringIndex(200)},
                            index=lrange(200))
-        biggie['A'][:20] = nan
-        biggie['B'][:20] = nan
+        biggie.loc[:20,'A'] = nan
+        biggie.loc[:20,'B'] = nan
 
         foo = repr(biggie)
 
@@ -7412,19 +7412,19 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_frame_equal(df,expected)
 
     def test_fillna(self):
-        self.tsframe['A'][:5] = nan
-        self.tsframe['A'][-5:] = nan
+        self.tsframe.ix[:5,'A'] = nan
+        self.tsframe.ix[-5:,'A'] = nan
 
         zero_filled = self.tsframe.fillna(0)
-        self.assertTrue((zero_filled['A'][:5] == 0).all())
+        self.assertTrue((zero_filled.ix[:5,'A'] == 0).all())
 
         padded = self.tsframe.fillna(method='pad')
-        self.assertTrue(np.isnan(padded['A'][:5]).all())
-        self.assertTrue((padded['A'][-5:] == padded['A'][-5]).all())
+        self.assertTrue(np.isnan(padded.ix[:5,'A']).all())
+        self.assertTrue((padded.ix[-5:,'A'] == padded.ix[-5,'A']).all())
 
         # mixed type
-        self.mixed_frame['foo'][5:20] = nan
-        self.mixed_frame['A'][-10:] = nan
+        self.mixed_frame.ix[5:20,'foo'] = nan
+        self.mixed_frame.ix[-10:,'A'] = nan
         result = self.mixed_frame.fillna(value=0)
         result = self.mixed_frame.fillna(method='pad')
 
@@ -7433,7 +7433,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # mixed numeric (but no float16)
         mf = self.mixed_float.reindex(columns=['A','B','D'])
-        mf['A'][-10:] = nan
+        mf.ix[-10:,'A'] = nan
         result = mf.fillna(value=0)
         _check_mixed_float(result, dtype = dict(C = None))
 
@@ -7605,8 +7605,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.assertRaises(TypeError, self.tsframe.replace, nan)
 
         # mixed type
-        self.mixed_frame['foo'][5:20] = nan
-        self.mixed_frame['A'][-10:] = nan
+        self.mixed_frame.ix[5:20,'foo'] = nan
+        self.mixed_frame.ix[-10:,'A'] = nan
 
         result = self.mixed_frame.replace(np.nan, 0)
         expected = self.mixed_frame.fillna(value=0)
@@ -8194,8 +8194,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_series_equal(expec, res)
 
     def test_replace_mixed(self):
-        self.mixed_frame['foo'][5:20] = nan
-        self.mixed_frame['A'][-10:] = nan
+        self.mixed_frame.ix[5:20,'foo'] = nan
+        self.mixed_frame.ix[-10:,'A'] = nan
 
         result = self.mixed_frame.replace(np.nan, -18)
         expected = self.mixed_frame.fillna(value=-18)
@@ -11717,11 +11717,11 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.assertNotIn('foo', renamed)
 
     def test_fill_corner(self):
-        self.mixed_frame['foo'][5:20] = nan
-        self.mixed_frame['A'][-10:] = nan
+        self.mixed_frame.ix[5:20,'foo'] = nan
+        self.mixed_frame.ix[-10:,'A'] = nan
 
         filled = self.mixed_frame.fillna(value=0)
-        self.assertTrue((filled['foo'][5:20] == 0).all())
+        self.assertTrue((filled.ix[5:20,'foo'] == 0).all())
         del self.mixed_frame['foo']
 
         empty_float = self.frame.reindex(columns=[])
@@ -12716,6 +12716,7 @@ starting,ending,measure
                 self.assertTrue(r1.all())
 
     def test_strange_column_corruption_issue(self):
+
         df = DataFrame(index=[0, 1])
         df[0] = nan
         wasCol = {}

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -734,8 +734,8 @@ class TestDataFrame(tm.TestCase, Generic):
 
         result = df.set_index('C').interpolate()
         expected = df.set_index('C')
-        expected.A.loc[3] = 3
-        expected.B.loc[5] = 9
+        expected.loc[3,'A'] = 3
+        expected.loc[5,'B'] = 9
         assert_frame_equal(result, expected)
 
     def test_interp_bad_method(self):
@@ -810,8 +810,8 @@ class TestDataFrame(tm.TestCase, Generic):
                         'C': [1, 2, 3, 5, 8, 13, 21]})
         result = df.interpolate(method='barycentric')
         expected = df.copy()
-        expected['A'].iloc[2] = 3
-        expected['A'].iloc[5] = 6
+        expected.ix[2,'A'] = 3
+        expected.ix[5,'A'] = 6
         assert_frame_equal(result, expected)
 
         result = df.interpolate(method='barycentric', downcast='infer')
@@ -819,15 +819,13 @@ class TestDataFrame(tm.TestCase, Generic):
 
         result = df.interpolate(method='krogh')
         expectedk = df.copy()
-        # expectedk['A'].iloc[2] = 3
-        # expectedk['A'].iloc[5] = 6
         expectedk['A'] = expected['A']
         assert_frame_equal(result, expectedk)
 
         _skip_if_no_pchip()
         result = df.interpolate(method='pchip')
-        expected['A'].iloc[2] = 3
-        expected['A'].iloc[5] = 6.125
+        expected.ix[2,'A'] = 3
+        expected.ix[5,'A'] = 6.125
         assert_frame_equal(result, expected)
 
     def test_interp_rowwise(self):
@@ -838,9 +836,9 @@ class TestDataFrame(tm.TestCase, Generic):
                         4: [1, 2, 3, 4]})
         result = df.interpolate(axis=1)
         expected = df.copy()
-        expected[1].loc[3] = 5
-        expected[2].loc[0] = 3
-        expected[3].loc[1] = 3
+        expected.loc[3,1] = 5
+        expected.loc[0,2] = 3
+        expected.loc[1,3] = 3
         expected[4] = expected[4].astype(np.float64)
         assert_frame_equal(result, expected)
 

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -1664,7 +1664,7 @@ class TestGroupBy(tm.TestCase):
                 'B': ['A', 'B'] * 6,
                 'C': np.random.randn(12)}
         df = DataFrame(data)
-        df['C'][2:10:2] = nan
+        df.loc[2:10:2,'C'] = nan
 
         def _testit(op):
             # single column

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -10,6 +10,7 @@ import numpy as np
 
 import pandas as pd
 import pandas.core.common as com
+from pandas import option_context
 from pandas.core.api import (DataFrame, Index, Series, Panel, isnull,
                              MultiIndex, Float64Index, Timestamp)
 from pandas.util.testing import (assert_almost_equal, assert_series_equal,
@@ -2320,10 +2321,12 @@ class TestIndexing(tm.TestCase):
         assert_frame_equal(df,expected)
 
         # ok, but chained assignments are dangerous
-        df = pd.DataFrame({'a': lrange(4) })
-        df['b'] = np.nan
-        df['b'].ix[[1,3]] = [100,-100]
-        assert_frame_equal(df,expected)
+        # if we turn off chained assignement it will work
+        with option_context('chained_assignment',None):
+            df = pd.DataFrame({'a': lrange(4) })
+            df['b'] = np.nan
+            df['b'].ix[[1,3]] = [100,-100]
+            assert_frame_equal(df,expected)
 
     def test_ix_get_set_consistency(self):
 
@@ -3036,22 +3039,26 @@ class TestIndexing(tm.TestCase):
         self.assertEqual(result, 2)
 
     def test_slice_consolidate_invalidate_item_cache(self):
-        # #3970
-        df = DataFrame({ "aa":lrange(5), "bb":[2.2]*5})
 
-        # Creates a second float block
-        df["cc"] = 0.0
+        # this is chained assignment, but will 'work'
+        with option_context('chained_assignment',None):
 
-        # caches a reference to the 'bb' series
-        df["bb"]
+            # #3970
+            df = DataFrame({ "aa":lrange(5), "bb":[2.2]*5})
 
-        # repr machinery triggers consolidation
-        repr(df)
+            # Creates a second float block
+            df["cc"] = 0.0
 
-        # Assignment to wrong series
-        df['bb'].iloc[0] = 0.17
-        df._clear_item_cache()
-        self.assertAlmostEqual(df['bb'][0], 0.17)
+            # caches a reference to the 'bb' series
+            df["bb"]
+
+            # repr machinery triggers consolidation
+            repr(df)
+
+            # Assignment to wrong series
+            df['bb'].iloc[0] = 0.17
+            df._clear_item_cache()
+            self.assertAlmostEqual(df['bb'][0], 0.17)
 
     def test_setitem_cache_updating(self):
         # GH 5424
@@ -3135,17 +3142,19 @@ class TestIndexing(tm.TestCase):
         expected = DataFrame([[-5,1],[-6,3]],columns=list('AB'))
         df = DataFrame(np.arange(4).reshape(2,2),columns=list('AB'),dtype='int64')
         self.assertIsNone(df.is_copy)
-
         df['A'][0] = -5
         df['A'][1] = -6
         assert_frame_equal(df, expected)
 
-        expected = DataFrame([[-5,2],[np.nan,3.]],columns=list('AB'))
+        # test with the chaining
         df = DataFrame({ 'A' : Series(range(2),dtype='int64'), 'B' : np.array(np.arange(2,4),dtype=np.float64)})
         self.assertIsNone(df.is_copy)
-        df['A'][0] = -5
-        df['A'][1] = np.nan
-        assert_frame_equal(df, expected)
+        def f():
+            df['A'][0] = -5
+        self.assertRaises(com.SettingWithCopyError, f)
+        def f():
+            df['A'][1] = np.nan
+        self.assertRaises(com.SettingWithCopyError, f)
         self.assertIsNone(df['A'].is_copy)
 
         # using a copy (the chain), fails
@@ -3172,17 +3181,13 @@ class TestIndexing(tm.TestCase):
 
         expected = DataFrame({'A':[111,'bbb','ccc'],'B':[1,2,3]})
         df = DataFrame({'A':['aaa','bbb','ccc'],'B':[1,2,3]})
-        df['A'][0] = 111
+        def f():
+            df['A'][0] = 111
+        self.assertRaises(com.SettingWithCopyError, f)
         def f():
             df.loc[0]['A'] = 111
         self.assertRaises(com.SettingWithCopyError, f)
         assert_frame_equal(df,expected)
-
-        # warnings
-        pd.set_option('chained_assignment','warn')
-        df = DataFrame({'A':['aaa','bbb','ccc'],'B':[1,2,3]})
-        with tm.assert_produces_warning(expected_warning=com.SettingWithCopyWarning):
-            df.loc[0]['A'] = 111
 
         # make sure that is_copy is picked up reconstruction
         # GH5475
@@ -3196,7 +3201,6 @@ class TestIndexing(tm.TestCase):
 
         # a suprious raise as we are setting the entire column here
         # GH5597
-        pd.set_option('chained_assignment','raise')
         from string import ascii_letters as letters
 
         def random_text(nobs=100):
@@ -3294,6 +3298,28 @@ class TestIndexing(tm.TestCase):
         def f():
             df.iloc[0:5]['group'] = 'a'
         self.assertRaises(com.SettingWithCopyError, f)
+
+        # mixed type setting
+        # same dtype & changing dtype
+        df = DataFrame(dict(A=date_range('20130101',periods=5),B=np.random.randn(5),C=np.arange(5,dtype='int64'),D=list('abcde')))
+
+        def f():
+            df.ix[2]['D'] = 'foo'
+        self.assertRaises(com.SettingWithCopyError, f)
+        def f():
+            df.ix[2]['C'] = 'foo'
+        self.assertRaises(com.SettingWithCopyError, f)
+        def f():
+            df['C'][2] = 'foo'
+        self.assertRaises(com.SettingWithCopyError, f)
+
+    def test_detect_chained_assignment_warnings(self):
+
+        # warnings
+        with option_context('chained_assignment','warn'):
+            df = DataFrame({'A':['aaa','bbb','ccc'],'B':[1,2,3]})
+            with tm.assert_produces_warning(expected_warning=com.SettingWithCopyWarning):
+                df.loc[0]['A'] = 111
 
     def test_float64index_slicing_bug(self):
         # GH 5557, related to slicing a float index

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -3668,6 +3668,8 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         tm.assert_frame_equal(df,expected)
 
         # GH 3970
+        # these are chained assignments as well
+        pd.set_option('chained_assignment',None)
         df = DataFrame({ "aa":range(5), "bb":[2.2]*5})
         df["cc"] = 0.0
         ck = [True]*len(df)
@@ -3675,6 +3677,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         df_tmp = df.iloc[ck]
         df["bb"].iloc[0] = .15
         self.assertEqual(df['bb'].iloc[0], 0.15)
+        pd.set_option('chained_assignment','raise')
 
         # GH 3217
         df = DataFrame(dict(a = [1,3], b = [np.nan, 2]))

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -930,8 +930,8 @@ class TestMergeMulti(tm.TestCase):
 
         expected = left.copy()
         expected['v2'] = np.nan
-        expected['v2'][(expected.k1 == 2) & (expected.k2 == 'bar')] = 5
-        expected['v2'][(expected.k1 == 1) & (expected.k2 == 'foo')] = 7
+        expected.loc[(expected.k1 == 2) & (expected.k2 == 'bar'),'v2'] = 5
+        expected.loc[(expected.k1 == 1) & (expected.k2 == 'foo'),'v2'] = 7
 
         tm.assert_frame_equal(result, expected)
 
@@ -948,8 +948,8 @@ class TestMergeMulti(tm.TestCase):
 
         expected = left.copy()
         expected['v2'] = np.nan
-        expected['v2'][(expected.k1 == 2) & (expected.k2 == 'bar')] = 5
-        expected['v2'][(expected.k1 == 1) & (expected.k2 == 'foo')] = 7
+        expected.loc[(expected.k1 == 2) & (expected.k2 == 'bar'),'v2'] = 5
+        expected.loc[(expected.k1 == 1) & (expected.k2 == 'foo'),'v2'] = 7
 
         tm.assert_frame_equal(result, expected)
 
@@ -976,8 +976,8 @@ class TestMergeMulti(tm.TestCase):
             if dtype2.kind == 'i':
                 dtype2 = np.dtype('float64')
             expected['v2'] = np.array(np.nan,dtype=dtype2)
-            expected['v2'][(expected.k1 == 2) & (expected.k2 == 'bar')] = 5
-            expected['v2'][(expected.k1 == 1) & (expected.k2 == 'foo')] = 7
+            expected.loc[(expected.k1 == 2) & (expected.k2 == 'bar'),'v2'] = 5
+            expected.loc[(expected.k1 == 1) & (expected.k2 == 'foo'),'v2'] = 7
 
             tm.assert_frame_equal(result, expected)
 
@@ -1683,7 +1683,7 @@ class TestConcatenate(tm.TestCase):
 
         expected = df.ix[:, ['a', 'b', 'c', 'd', 'foo']]
         expected['foo'] = expected['foo'].astype('O')
-        expected['foo'][:5] = 'bar'
+        expected.loc[0:4,'foo'] = 'bar'
 
         tm.assert_frame_equal(concatted, expected)
 


### PR DESCRIPTION
This will detect even more situations where chained assignment is being used. 

FYI technically there are 2 situations where the same error is raised: 1) setting on a copy, 2) chained assignment on a view. Both are really similar and result in usually the same issue. An assignment that doesn't appear to assign anything.

This detected a number of tests that were incorrectly using chaining in the pandas test suite as well (fixed below).
