### PR TITLE
DOC/TST: index followup

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -235,8 +235,8 @@ Constructor
 
    Series
 
-Attributes and underlying data
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Attributes
+~~~~~~~~~~
 **Axes**
   * **index**: axis labels
 
@@ -246,6 +246,14 @@ Attributes and underlying data
    Series.values
    Series.dtype
    Series.ftype
+   Series.shape
+   Series.size
+   Series.nbytes
+   Series.ndim
+   Series.strides
+   Series.itemsize
+   Series.base
+   Series.T
 
 Conversion
 ~~~~~~~~~~
@@ -1087,11 +1095,36 @@ used before calling these methods directly.**
 
    Index
 
+Attributes
+~~~~~~~~~~
+
+.. autosummary::
+   :toctree: generated/
+
+   Index.values
+   Index.is_monotonic
+   Index.is_unique
+   Index.dtype
+   Index.inferred_type
+   Index.is_all_dates
+   Index.shape
+   Index.size
+   Index.nbytes
+   Index.ndim
+   Index.strides
+   Index.itemsize
+   Index.base
+   Index.T
+
 Modifying and Computations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
 
+   Index.all
+   Index.any
+   Index.argmin
+   Index.argmax
    Index.copy
    Index.delete
    Index.diff
@@ -1101,6 +1134,8 @@ Modifying and Computations
    Index.factorize
    Index.identical
    Index.insert
+   Index.min
+   Index.max
    Index.order
    Index.reindex
    Index.repeat
@@ -1160,14 +1195,6 @@ Selecting
    Index.isin
    Index.slice_indexer
    Index.slice_locs
-
-Properties
-~~~~~~~~~~
-.. autosummary::
-   :toctree: generated/
-
-   Index.is_monotonic
-   Index.is_numeric
 
 .. _api.datetimeindex:
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -2101,7 +2101,8 @@ any pickled pandas object (or any other pickled object) from file:
 
 .. warning::
 
-   In 0.13, pickle preserves compatibility with pickles created prior to 0.13. These must
+   Several internal refactorings, 0.13 (:ref:`Series Refactoring <whatsnew_0130.refactoring>`), and 0.15 (:ref:`Index Refactoring <whatsnew_0150.refactoring>`),
+   preserve compatibility with pickles created prior to these versions. However, these must
    be read with ``pd.read_pickle``, rather than the default python ``pickle.load``.
    See `this question <http://stackoverflow.com/questions/20444593/pandas-compiled-from-source-default-pickle-behavior-changed>`__
    for a detailed explanation.

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -173,6 +173,7 @@ a transparent change with only very limited API implications (:issue:`5080`, :is
 
 - you may need to unpickle pandas version < 0.15.0 pickles using ``pd.read_pickle`` rather than ``pickle.load``. See :ref:`pickle docs <io.pickle>`
 - when plotting with a ``PeriodIndex``. The ``matplotlib`` internal axes will now be arrays of ``Period`` rather than a ``PeriodIndex``. (this is similar to how a ``DatetimeIndex`` passes arrays of ``datetimes`` now)
+- MultiIndexes will now raise similary to other pandas objects w.r.t. truth testing, See :ref:`here <gotchas.truth>` (:issue:`7897`).
 
 .. _whatsnew_0150.cat:
 

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -169,10 +169,10 @@ Internal Refactoring
 
 In 0.15.0 ``Index`` has internally been refactored to no longer sub-class ``ndarray``
 but instead subclass ``PandasObject``, similarly to the rest of the pandas objects. This change allows very easy sub-classing and creation of new index types. This should be
-a transparent change with only very limited API implications (:issue:`5080`,:issue:`7439`,:issue:`7796`)
+a transparent change with only very limited API implications (:issue:`5080`, :issue:`7439`, :issue:`7796`)
 
 - you may need to unpickle pandas version < 0.15.0 pickles using ``pd.read_pickle`` rather than ``pickle.load``. See :ref:`pickle docs <io.pickle>`
-- when plotting with a ``PeriodIndex``. The ``matplotlib`` internal axes will now be arrays of ``Period`` rather than a ``PeriodIndex``. (this is similar to how a ``DatetimeIndex`` passess arrays of ``datetimes`` now)
+- when plotting with a ``PeriodIndex``. The ``matplotlib`` internal axes will now be arrays of ``Period`` rather than a ``PeriodIndex``. (this is similar to how a ``DatetimeIndex`` passes arrays of ``datetimes`` now)
 
 .. _whatsnew_0150.cat:
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -313,9 +313,33 @@ class IndexOpsMixin(object):
         """ The maximum value of the object """
         return nanops.nanmax(self.values)
 
+    def argmax(self, axis=None):
+        """
+        return a ndarray of the maximum argument indexer
+
+        See also
+        --------
+        numpy.ndarray.argmax
+        """
+        return nanops.nanargmax(self.values)
+
     def min(self):
         """ The minimum value of the object """
         return nanops.nanmin(self.values)
+
+    def argmin(self, axis=None):
+        """
+        return a ndarray of the minimum argument indexer
+
+        See also
+        --------
+        numpy.ndarray.argmin
+        """
+        return nanops.nanargmin(self.values)
+
+    def hasnans(self):
+        """ return if I have any nans; enables various perf speedups """
+        return com.isnull(self).any()
 
     def value_counts(self, normalize=False, sort=True, ascending=False,
                      bins=None, dropna=True):
@@ -554,10 +578,11 @@ class DatetimeIndexOpsMixin(object):
         numpy.ndarray.argmin
         """
 
-        ##### FIXME: need some tests (what do do if all NaT?)
         i8 = self.asi8
         if self.hasnans:
             mask = i8 == tslib.iNaT
+            if mask.all():
+                return -1
             i8 = i8.copy()
             i8[mask] = np.iinfo('int64').max
         return i8.argmin()
@@ -596,10 +621,11 @@ class DatetimeIndexOpsMixin(object):
         numpy.ndarray.argmax
         """
 
-        #### FIXME: need some tests (what do do if all NaT?)
         i8 = self.asi8
         if self.hasnans:
             mask = i8 == tslib.iNaT
+            if mask.all():
+                return -1
             i8 = i8.copy()
             i8[mask] = 0
         return i8.argmax()

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -560,6 +560,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     @property
     def is_monotonic(self):
+        """ return if the index has monotonic (only equaly or increasing) values """
         return self._engine.is_monotonic
 
     def is_lexsorted_for_tuple(self, tup):
@@ -567,6 +568,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     @cache_readonly(allow_setting=True)
     def is_unique(self):
+        """ return if the index has unique values """
         return self._engine.is_unique
 
     def is_integer(self):
@@ -788,6 +790,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     @cache_readonly
     def inferred_type(self):
+        """ return a string of the type inferred from the values """
         return lib.infer_dtype(self)
 
     def is_type_compatible(self, typ):
@@ -2142,6 +2145,11 @@ class Int64Index(NumericIndex):
     @property
     def inferred_type(self):
         return 'integer'
+
+    @cache_readonly
+    def hasnans(self):
+        # by definition
+        return False
 
     @property
     def asi8(self):

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -838,6 +838,13 @@ class Index(IndexOpsMixin, PandasObject):
     def __deepcopy__(self, memo={}):
         return self.copy(deep=True)
 
+    def __nonzero__(self):
+        raise ValueError("The truth value of a {0} is ambiguous. "
+                         "Use a.empty, a.bool(), a.item(), a.any() or a.all()."
+                         .format(self.__class__.__name__))
+
+    __bool__ = __nonzero__
+
     def __contains__(self, key):
         hash(key)
         # work around some kind of odd cython bug

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -261,6 +261,27 @@ class TestIndexOps(Ops):
                 # check DatetimeIndex non-monotonic path
                 self.assertEqual(getattr(obj, op)(), datetime(2011, 11, 1))
 
+        # argmin/max
+        obj = Index(np.arange(5,dtype='int64'))
+        self.assertEqual(obj.argmin(),0)
+        self.assertEqual(obj.argmax(),4)
+
+        obj = Index([np.nan, 1, np.nan, 2])
+        self.assertEqual(obj.argmin(),1)
+        self.assertEqual(obj.argmax(),3)
+
+        obj = Index([np.nan])
+        self.assertEqual(obj.argmin(),-1)
+        self.assertEqual(obj.argmax(),-1)
+
+        obj = Index([pd.NaT, datetime(2011, 11, 1), datetime(2011,11,2),pd.NaT])
+        self.assertEqual(obj.argmin(),1)
+        self.assertEqual(obj.argmax(),2)
+
+        obj = Index([pd.NaT])
+        self.assertEqual(obj.argmin(),-1)
+        self.assertEqual(obj.argmax(),-1)
+
     def test_value_counts_unique_nunique(self):
         for o in self.objs:
             klass = type(o)

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -74,6 +74,15 @@ class Base(object):
                               "cannot perform floor division",
                               lambda : 1 // idx)
 
+    def test_boolean_context_compat(self):
+
+        # boolean context compat
+        idx = self.create_index()
+        def f():
+            if idx:
+                pass
+        tm.assertRaisesRegexp(ValueError,'The truth value of a',f)
+
 class TestIndex(Base, tm.TestCase):
     _holder = Index
     _multiprocess_can_split_ = True
@@ -1655,6 +1664,19 @@ class TestMultiIndex(Base, tm.TestCase):
 
     def create_index(self):
         return self.index
+
+    def test_boolean_context_compat2(self):
+
+        # boolean context compat
+        # GH7897
+        i1 = MultiIndex.from_tuples([('A', 1), ('A', 2)])
+        i2 = MultiIndex.from_tuples([('A', 1), ('A', 3)])
+        common = i1.intersection(i2)
+
+        def f():
+            if common:
+                pass
+        tm.assertRaisesRegexp(ValueError,'The truth value of a',f)
 
     def test_hash_error(self):
         with tm.assertRaisesRegexp(TypeError,

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1490,13 +1490,6 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
     def is_type_compatible(self, typ):
         return typ == self.inferred_type or typ == 'datetime'
 
-    def argmin(self):
-        # hack to workaround argmin failure
-        try:
-            return self.values.argmin()
-        except Exception:  # pragma: no cover
-            return self.asi8.argmin()
-
     @property
     def inferred_type(self):
         # b/c datetime is represented as microseconds since the epoch, make


### PR DESCRIPTION
TST: argmin/max impl, tests, and doc-strings
DOC: release notes corrections
API: raise on `__nonzero__` for Indexes, closes  #7897

partial close of #7904 
