### PR TITLE
API: add Series.dt delegator for datetimelike methods (GH7207)

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -436,12 +436,47 @@ Time series-related
    Series.tz_convert
    Series.tz_localize
 
+Datetimelike Properties
+~~~~~~~~~~~~~~~~~~~~~~~
+``Series.dt`` can be used to access the values of the series as
+datetimelike and return several properties.
+Due to implementation details the methods show up here as methods of the
+``DatetimeProperties/PeriodProperties`` classes. These can be accessed like ``Series.dt.<property>``.
+
+.. currentmodule:: pandas.tseries.common
+
+.. autosummary::
+   :toctree: generated/
+
+   DatetimeProperties.date
+   DatetimeProperties.time
+   DatetimeProperties.year
+   DatetimeProperties.month
+   DatetimeProperties.day
+   DatetimeProperties.hour
+   DatetimeProperties.minute
+   DatetimeProperties.second
+   DatetimeProperties.microsecond
+   DatetimeProperties.nanosecond
+   DatetimeProperties.second
+   DatetimeProperties.weekofyear
+   DatetimeProperties.dayofweek
+   DatetimeProperties.weekday
+   DatetimeProperties.dayofyear
+   DatetimeProperties.quarter
+   DatetimeProperties.is_month_start
+   DatetimeProperties.is_month_end
+   DatetimeProperties.is_quarter_start
+   DatetimeProperties.is_quarter_end
+   DatetimeProperties.is_year_start
+   DatetimeProperties.is_year_end
+
 String handling
 ~~~~~~~~~~~~~~~
 ``Series.str`` can be used to access the values of the series as
 strings and apply several methods to it. Due to implementation
 details the methods show up here as methods of the
-``StringMethods`` class.
+``StringMethods`` class. These can be acccessed like ``Series.str.<function/property>``.
 
 .. currentmodule:: pandas.core.strings
 

--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -1099,6 +1099,41 @@ For instance,
    for r in df2.itertuples():
        print(r)
 
+.. _basics.dt_accessors:
+
+.dt accessor
+~~~~~~~~~~~~
+
+``Series`` has an accessor to succinctly return datetime like properties for the *values* of the Series, if its a datetime/period like Series.
+This will return a Series, indexed like the existing Series.
+
+.. ipython:: python
+
+   # datetime
+   s = Series(date_range('20130101 09:10:12',periods=4))
+   s
+   s.dt.hour
+   s.dt.second
+   s.dt.day
+
+This enables nice expressions like this:
+
+.. ipython:: python
+
+   s[s.dt.day==2]
+
+.. ipython:: python
+
+   # period
+   s = Series(period_range('20130101',periods=4,freq='D').asobject)
+   s
+   s.dt.year
+   s.dt.day
+
+.. note::
+
+   ``Series.dt`` will raise a ``TypeError`` if you access with a non-datetimelike values
+
 .. _basics.string_methods:
 
 Vectorized string methods

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -444,6 +444,7 @@ There are several time/date properties that one can access from ``Timestamp`` or
     is_year_start,"Logical indicating if first day of year (defined by frequency)"
     is_year_end,"Logical indicating if last day of year (defined by frequency)"
 
+Furthermore, if you have a ``Series`` with datetimelike values, then you can access these properties via the ``.dt`` accessor, see the :ref:`docs <basics.dt_accessors>`
 
 DateOffset objects
 ------------------

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -11,6 +11,7 @@ users upgrade to this version.
 
   - The ``Categorical`` type was integrated as a first-class pandas type, see :ref:`here <whatsnew_0150.cat>`
   - Internal refactoring of the ``Index`` class to no longer sub-class ``ndarray``, see :ref:`Internal Refactoring <whatsnew_0150.refactoring>`
+  - New datetimelike properties accessor ``.dt`` for Series, see :ref:`Dateimelike Properties <whatsnew_0150.dt>`
 
 - :ref:`Other Enhancements <whatsnew_0150.enhancements>`
 
@@ -164,6 +165,37 @@ previously results in ``Exception`` or ``TypeError`` (:issue:`7812`)
 
 - ``DataFrame.tz_localize`` and ``DataFrame.tz_convert`` now accepts an optional ``level`` argument
   for localizing a specific level of a MultiIndex (:issue:`7846`)
+
+.. _whatsnew_0150.dt:
+
+.dt accessor
+~~~~~~~~~~~~
+
+``Series`` has gained an accessor to succinctly return datetime like properties for the *values* of the Series, if its a datetime/period like Series. (:issue:`7207`)
+This will return a Series, indexed like the existing Series. See the :ref:`docs <basics.dt_accessors>`
+
+.. ipython:: python
+
+   # datetime
+   s = Series(date_range('20130101 09:10:12',periods=4))
+   s
+   s.dt.hour
+   s.dt.second
+   s.dt.day
+
+This enables nice expressions like this:
+
+.. ipython:: python
+
+   s[s.dt.day==2]
+
+.. ipython:: python
+
+   # period
+   s = Series(period_range('20130101',periods=4,freq='D').asobject)
+   s
+   s.dt.year
+   s.dt.day
 
 .. _whatsnew_0150.refactoring:
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -100,6 +100,62 @@ class PandasObject(StringMixin):
         else:
             self._cache.pop(key, None)
 
+class PandasDelegate(PandasObject):
+    """ an abstract base class for delegating methods/properties """
+
+    def _delegate_property_get(self, name, *args, **kwargs):
+        raise TypeError("You cannot access the property {name}".format(name=name))
+
+    def _delegate_property_set(self, name, value, *args, **kwargs):
+        raise TypeError("The property {name} cannot be set".format(name=name))
+
+    def _delegate_method(self, name, *args, **kwargs):
+        raise TypeError("You cannot call method {name}".format(name=name))
+
+    @classmethod
+    def _add_delegate_accessors(cls, delegate, accessors, typ):
+        """
+        add accessors to cls from the delegate class
+
+        Parameters
+        ----------
+        cls : the class to add the methods/properties to
+        delegate : the class to get methods/properties & doc-strings
+        acccessors : string list of accessors to add
+        typ : 'property' or 'method'
+
+        """
+
+        def _create_delegator_property(name):
+
+            def _getter(self):
+                return self._delegate_property_get(name)
+            def _setter(self, new_values):
+                return self._delegate_property_set(name, new_values)
+
+            _getter.__name__ = name
+            _setter.__name__ = name
+
+            return property(fget=_getter, fset=_setter, doc=getattr(delegate,name).__doc__)
+
+        def _create_delegator_method(name):
+
+            def f(self, *args, **kwargs):
+                return self._delegate_method(name, *args, **kwargs)
+
+            f.__name__ = name
+            f.__doc__ = getattr(delegate,name).__doc__
+
+            return f
+
+        for name in accessors:
+
+            if typ == 'property':
+                f = _create_delegator_property(name)
+            else:
+                f = _create_delegator_method(name)
+
+            setattr(cls,name,f)
 
 class FrozenList(PandasObject, list):
 
@@ -220,36 +276,6 @@ def _unbox(func):
 
 class IndexOpsMixin(object):
     """ common ops mixin to support a unified inteface / docs for Series / Index """
-
-    def _is_allowed_index_op(self, name):
-        if not self._allow_index_ops:
-            raise TypeError("cannot perform an {name} operations on this type {typ}".format(
-                name=name,typ=type(self._get_access_object())))
-
-    def _ops_compat(self, name, op_accessor):
-
-        obj = self._get_access_object()
-        try:
-            return self._wrap_access_object(getattr(obj,op_accessor))
-        except AttributeError:
-            raise TypeError("cannot perform an {name} operations on this type {typ}".format(
-                name=name,typ=type(obj)))
-
-    def _get_access_object(self):
-        if isinstance(self, com.ABCSeries):
-            return self.index
-        return self
-
-    def _wrap_access_object(self, obj):
-        # we may need to coerce the input as we don't want non int64 if
-        # we have an integer result
-        if hasattr(obj,'dtype') and com.is_integer_dtype(obj):
-            obj = obj.astype(np.int64)
-
-        if isinstance(self, com.ABCSeries):
-            return self._constructor(obj,index=self.index).__finalize__(self)
-
-        return obj
 
     # ndarray compatibility
     __array_priority__ = 1000
@@ -449,67 +475,8 @@ class IndexOpsMixin(object):
     all = _unbox(np.ndarray.all)
     any = _unbox(np.ndarray.any)
 
-# facilitate the properties on the wrapped ops
-def _field_accessor(name, docstring=None):
-    op_accessor = '_{0}'.format(name)
-    def f(self):
-        return self._ops_compat(name,op_accessor)
-
-    f.__name__ = name
-    f.__doc__ = docstring
-    return property(f)
-
 class DatetimeIndexOpsMixin(object):
     """ common ops mixin to support a unified inteface datetimelike Index """
-
-    def _is_allowed_datetime_index_op(self, name):
-        if not self._allow_datetime_index_ops:
-            raise TypeError("cannot perform an {name} operations on this type {typ}".format(
-                name=name,typ=type(self._get_access_object())))
-
-    def _is_allowed_period_index_op(self, name):
-        if not self._allow_period_index_ops:
-            raise TypeError("cannot perform an {name} operations on this type {typ}".format(
-                name=name,typ=type(self._get_access_object())))
-
-    def _ops_compat(self, name, op_accessor):
-
-        from pandas.tseries.index import DatetimeIndex
-        from pandas.tseries.period import PeriodIndex
-        obj = self._get_access_object()
-        if isinstance(obj, DatetimeIndex):
-            self._is_allowed_datetime_index_op(name)
-        elif isinstance(obj, PeriodIndex):
-            self._is_allowed_period_index_op(name)
-        try:
-            return self._wrap_access_object(getattr(obj,op_accessor))
-        except AttributeError:
-            raise TypeError("cannot perform an {name} operations on this type {typ}".format(
-                name=name,typ=type(obj)))
-
-    date = _field_accessor('date','Returns numpy array of datetime.date. The date part of the Timestamps')
-    time = _field_accessor('time','Returns numpy array of datetime.time. The time part of the Timestamps')
-    year = _field_accessor('year', "The year of the datetime")
-    month = _field_accessor('month', "The month as January=1, December=12")
-    day = _field_accessor('day', "The days of the datetime")
-    hour = _field_accessor('hour', "The hours of the datetime")
-    minute = _field_accessor('minute', "The minutes of the datetime")
-    second = _field_accessor('second', "The seconds of the datetime")
-    microsecond = _field_accessor('microsecond', "The microseconds of the datetime")
-    nanosecond = _field_accessor('nanosecond', "The nanoseconds of the datetime")
-    weekofyear = _field_accessor('weekofyear', "The week ordinal of the year")
-    week = weekofyear
-    dayofweek = _field_accessor('dayofweek', "The day of the week with Monday=0, Sunday=6")
-    weekday = dayofweek
-    dayofyear = _field_accessor('dayofyear', "The ordinal day of the year")
-    quarter = _field_accessor('quarter', "The quarter of the date")
-    qyear = _field_accessor('qyear')
-    is_month_start = _field_accessor('is_month_start', "Logical indicating if first day of month (defined by frequency)")
-    is_month_end = _field_accessor('is_month_end', "Logical indicating if last day of month (defined by frequency)")
-    is_quarter_start = _field_accessor('is_quarter_start', "Logical indicating if first day of quarter (defined by frequency)")
-    is_quarter_end = _field_accessor('is_quarter_end', "Logical indicating if last day of quarter (defined by frequency)")
-    is_year_start = _field_accessor('is_year_start', "Logical indicating if first day of year (defined by frequency)")
-    is_year_end = _field_accessor('is_year_end', "Logical indicating if last day of year (defined by frequency)")
 
     def __iter__(self):
         return (self._box_func(v) for v in self.asi8)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1193,12 +1193,17 @@ class NDFrame(PandasObject):
             except:
                 pass
 
-            if t == 'referant':
+            # a custom message
+            if isinstance(self.is_copy, string_types):
+                t = self.is_copy
+
+            elif t == 'referant':
                 t = ("\n"
                      "A value is trying to be set on a copy of a slice from a "
                      "DataFrame\n\n"
                      "See the the caveats in the documentation: "
                      "http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy")
+
             else:
                 t = ("\n"
                      "A value is trying to be set on a copy of a slice from a "

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -37,7 +37,6 @@ def _try_get_item(x):
     except AttributeError:
         return x
 
-
 def _indexOp(opname):
     """
     Wrapper function for index comparison operations, to avoid
@@ -4280,7 +4279,6 @@ class MultiIndex(Index):
             else:
                 return np.lib.arraysetops.in1d(labs, sought_labels)
 MultiIndex._add_numeric_methods_disabled()
-
 
 # For utility purposes
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -107,18 +107,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     _metadata = ['name']
     _allow_index_ops = True
 
-    @property
-    def _allow_datetime_index_ops(self):
-        # disabling to invalidate datetime index ops (GH7206)
-        # return self.index.is_all_dates and isinstance(self.index, DatetimeIndex)
-        return False
-
-    @property
-    def _allow_period_index_ops(self):
-        # disabling to invalidate period index ops (GH7206)
-        # return self.index.is_all_dates and isinstance(self.index, PeriodIndex)
-        return False
-
     def __init__(self, data=None, index=None, dtype=None, name=None,
                  copy=False, fastpath=False):
 
@@ -2405,6 +2393,18 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         new_index = self.index.to_period(freq=freq)
         return self._constructor(new_values,
                                  index=new_index).__finalize__(self)
+
+    #------------------------------------------------------------------------------
+    # Datetimelike delegation methods
+
+    @cache_readonly
+    def dt(self):
+        from pandas.tseries.common import maybe_to_datetimelike
+        try:
+            return maybe_to_datetimelike(self)
+        except (Exception):
+            raise TypeError("Can only use .dt accessor with datetimelike values")
+
     #------------------------------------------------------------------------------
     # Categorical methods
 

--- a/pandas/tseries/common.py
+++ b/pandas/tseries/common.py
@@ -1,0 +1,115 @@
+## datetimelike delegation ##
+
+import numpy as np
+from pandas.core.base import PandasDelegate
+from pandas.core import common as com
+from pandas import Series, DatetimeIndex, PeriodIndex
+from pandas import lib, tslib
+
+def is_datetimelike(data):
+    """ return a boolean if we can be successfully converted to a datetimelike """
+    try:
+        maybe_to_datetimelike(data)
+        return True
+    except (Exception):
+        pass
+    return False
+
+def maybe_to_datetimelike(data, copy=False):
+    """
+    return a DelegatedClass of a Series that is datetimelike (e.g. datetime64[ns] dtype or a Series of Periods)
+    raise TypeError if this is not possible.
+
+    Parameters
+    ----------
+    data : Series
+    copy : boolean, default False
+           copy the input data
+
+    Returns
+    -------
+    DelegatedClass
+
+    """
+
+    if not isinstance(data, Series):
+        raise TypeError("cannot convert an object of type {0} to a datetimelike index".format(type(data)))
+
+    index = data.index
+    if issubclass(data.dtype.type, np.datetime64):
+        return DatetimeProperties(DatetimeIndex(data, copy=copy), index)
+    else:
+
+        if isinstance(data, PeriodIndex):
+            return PeriodProperties(PeriodIndex(data, copy=copy), index)
+
+        data = com._values_from_object(data)
+        inferred = lib.infer_dtype(data)
+        if inferred == 'period':
+            return PeriodProperties(PeriodIndex(data), index)
+
+    raise TypeError("cannot convert an object of type {0} to a datetimelike index".format(type(data)))
+
+class Properties(PandasDelegate):
+
+    def __init__(self, values, index):
+        self.values = values
+        self.index = index
+
+    def _delegate_property_get(self, name):
+        result = getattr(self.values,name)
+
+        # maybe need to upcast (ints)
+        if isinstance(result, np.ndarray):
+            if com.is_integer_dtype(result):
+                result = result.astype('int64')
+
+        # return the result as a Series, which is by definition a copy
+        result = Series(result, index=self.index)
+
+        # setting this object will show a SettingWithCopyWarning/Error
+        result.is_copy = ("modifications to a property of a datetimelike object are not "
+                          "supported and are discarded. Change values on the original.")
+
+        return result
+
+    def _delegate_property_set(self, name, value, *args, **kwargs):
+        raise ValueError("modifications to a property of a datetimelike object are not "
+                         "supported. Change values on the original.")
+
+
+class DatetimeProperties(Properties):
+    """
+    Accessor object for datetimelike properties of the Series values.
+
+    Examples
+    --------
+    >>> s.dt.hour
+    >>> s.dt.second
+    >>> s.dt.quarter
+
+    Returns a Series indexed like the original Series.
+    Raises TypeError if the Series does not contain datetimelike values.
+    """
+
+DatetimeProperties._add_delegate_accessors(delegate=DatetimeIndex,
+                                           accessors=DatetimeIndex._datetimelike_ops,
+                                           typ='property')
+
+class PeriodProperties(Properties):
+    """
+    Accessor object for datetimelike properties of the Series values.
+
+    Examples
+    --------
+    >>> s.dt.hour
+    >>> s.dt.second
+    >>> s.dt.quarter
+
+    Returns a Series indexed like the original Series.
+    Raises TypeError if the Series does not contain datetimelike values.
+    """
+
+PeriodProperties._add_delegate_accessors(delegate=PeriodIndex,
+                                         accessors=PeriodIndex._datetimelike_ops,
+                                         typ='property')

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -174,7 +174,10 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
     offset = None
     _comparables = ['name','freqstr','tz']
     _attributes = ['name','freq','tz']
-    _allow_datetime_index_ops = True
+    _datetimelike_ops = ['year','month','day','hour','minute','second',
+                         'weekofyear','week','dayofweek','weekday','dayofyear','quarter',
+                         'date','time','microsecond','nanosecond','is_month_start','is_month_end',
+                         'is_quarter_start','is_quarter_end','is_year_start','is_year_end']
     _is_numeric_dtype = False
 
     def __new__(cls, data=None,
@@ -1428,30 +1431,31 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
             return None
         return self.offset.freqstr
 
-    _year = _field_accessor('year', 'Y')
-    _month = _field_accessor('month', 'M', "The month as January=1, December=12")
-    _day = _field_accessor('day', 'D')
-    _hour = _field_accessor('hour', 'h')
-    _minute = _field_accessor('minute', 'm')
-    _second = _field_accessor('second', 's')
-    _microsecond = _field_accessor('microsecond', 'us')
-    _nanosecond = _field_accessor('nanosecond', 'ns')
-    _weekofyear = _field_accessor('weekofyear', 'woy')
-    _week = _weekofyear
-    _dayofweek = _field_accessor('dayofweek', 'dow',
+    year = _field_accessor('year', 'Y', "The year of the datetime")
+    month = _field_accessor('month', 'M', "The month as January=1, December=12")
+    day = _field_accessor('day', 'D', "The days of the datetime")
+    hour = _field_accessor('hour', 'h', "The hours of the datetime")
+    minute = _field_accessor('minute', 'm', "The minutes of the datetime")
+    second = _field_accessor('second', 's', "The seconds of the datetime")
+    millisecond = _field_accessor('millisecond', 'ms', "The milliseconds of the datetime")
+    microsecond = _field_accessor('microsecond', 'us', "The microseconds of the datetime")
+    nanosecond = _field_accessor('nanosecond', 'ns', "The nanoseconds of the datetime")
+    weekofyear = _field_accessor('weekofyear', 'woy', "The week ordinal of the year")
+    week = weekofyear
+    dayofweek = _field_accessor('dayofweek', 'dow',
                                  "The day of the week with Monday=0, Sunday=6")
-    _weekday = _dayofweek
-    _dayofyear = _field_accessor('dayofyear', 'doy')
-    _quarter = _field_accessor('quarter', 'q')
-    _is_month_start = _field_accessor('is_month_start', 'is_month_start')
-    _is_month_end = _field_accessor('is_month_end', 'is_month_end')
-    _is_quarter_start = _field_accessor('is_quarter_start', 'is_quarter_start')
-    _is_quarter_end = _field_accessor('is_quarter_end', 'is_quarter_end')
-    _is_year_start = _field_accessor('is_year_start', 'is_year_start')
-    _is_year_end = _field_accessor('is_year_end', 'is_year_end')
+    weekday = dayofweek
+    dayofyear = _field_accessor('dayofyear', 'doy', "The ordinal day of the year")
+    quarter = _field_accessor('quarter', 'q', "The quarter of the date")
+    is_month_start = _field_accessor('is_month_start', 'is_month_start', "Logical indicating if first day of month (defined by frequency)")
+    is_month_end = _field_accessor('is_month_end', 'is_month_end', "Logical indicating if last day of month (defined by frequency)")
+    is_quarter_start = _field_accessor('is_quarter_start', 'is_quarter_start', "Logical indicating if first day of quarter (defined by frequency)")
+    is_quarter_end = _field_accessor('is_quarter_end', 'is_quarter_end', "Logical indicating if last day of quarter (defined by frequency)")
+    is_year_start = _field_accessor('is_year_start', 'is_year_start', "Logical indicating if first day of year (defined by frequency)")
+    is_year_end = _field_accessor('is_year_end', 'is_year_end', "Logical indicating if last day of year (defined by frequency)")
 
     @property
-    def _time(self):
+    def time(self):
         """
         Returns numpy array of datetime.time. The time part of the Timestamps.
         """
@@ -1460,7 +1464,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
         return _algos.arrmap_object(self.asobject.values, lambda x: x.time())
 
     @property
-    def _date(self):
+    def date(self):
         """
         Returns numpy array of datetime.date. The date part of the Timestamps.
         """

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -33,13 +33,13 @@ def _period_field_accessor(name, alias):
     return property(f)
 
 
-def _field_accessor(name, alias):
+def _field_accessor(name, alias, docstring=None):
     def f(self):
         base, mult = _gfc(self.freq)
         return tslib.get_period_field_arr(alias, self.values, base)
     f.__name__ = name
+    f.__doc__ = docstring
     return property(f)
-
 
 class Period(PandasObject):
     """
@@ -572,8 +572,9 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
     >>> idx2 = PeriodIndex(start='2000', end='2010', freq='A')
     """
     _box_scalars = True
-    _allow_period_index_ops = True
     _attributes = ['name','freq']
+    _datetimelike_ops = ['year','month','day','hour','minute','second',
+                         'weekofyear','week','dayofweek','weekday','dayofyear','quarter', 'qyear']
     _is_numeric_dtype = False
 
     __eq__ = _period_index_cmp('__eq__')
@@ -786,19 +787,19 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
     def to_datetime(self, dayfirst=False):
         return self.to_timestamp()
 
-    _year = _field_accessor('year', 0)
-    _month = _field_accessor('month', 3)
-    _day = _field_accessor('day', 4)
-    _hour = _field_accessor('hour', 5)
-    _minute = _field_accessor('minute', 6)
-    _second = _field_accessor('second', 7)
-    _weekofyear = _field_accessor('week', 8)
-    _week = _weekofyear
-    _dayofweek = _field_accessor('dayofweek', 10)
-    _weekday = _dayofweek
-    _dayofyear = day_of_year = _field_accessor('dayofyear', 9)
-    _quarter = _field_accessor('quarter', 2)
-    _qyear = _field_accessor('qyear', 1)
+    year = _field_accessor('year', 0, "The year of the period")
+    month = _field_accessor('month', 3, "The month as January=1, December=12")
+    day = _field_accessor('day', 4, "The days of the period")
+    hour = _field_accessor('hour', 5, "The hour of the period")
+    minute = _field_accessor('minute', 6, "The minute of the period")
+    second = _field_accessor('second', 7, "The second of the period")
+    weekofyear = _field_accessor('week', 8, "The week ordinal of the year")
+    week = weekofyear
+    dayofweek = _field_accessor('dayofweek', 10, "The day of the week with Monday=0, Sunday=6")
+    weekday = dayofweek
+    dayofyear = day_of_year = _field_accessor('dayofyear', 9, "The ordinal day of the year")
+    quarter = _field_accessor('quarter', 2, "The quarter of the date")
+    qyear = _field_accessor('qyear', 1)
 
     # Try to run function on index first, and then on elements of index
     # Especially important for group-by functionality


### PR DESCRIPTION
closes #7207

```
In [1]: s = Series(date_range('20130101',periods=3))

In [2]: s.dt.
s.dt.date              s.dt.dayofweek         s.dt.hour              s.dt.is_month_start    s.dt.is_quarter_start  s.dt.is_year_start     s.dt.minute            s.dt.nanosecond        s.dt.second            s.dt.week              s.dt.year              
s.dt.day               s.dt.dayofyear         s.dt.is_month_end      s.dt.is_quarter_end    s.dt.is_year_end       s.dt.microsecond       s.dt.month             s.dt.quarter           s.dt.time              s.dt.weekofyear        

In [3]: s.dt.year
Out[3]: array([2013, 2013, 2013])

In [4]: s.dt.hour
Out[4]: array([0, 0, 0])

In [5]: Series(np.arange(5)).dt
TypeError: Can only use .dt accessor with datetimelike values
```

Tab completion is specific to the type of wrapped delegate (DatetimeIndex or PeriodIndex)

```
In [5]: p = Series(period_range('20130101',periods=3,freq='D').asobject)

In [6]: p.dt.
p.dt.day         p.dt.dayofweek   p.dt.dayofyear   p.dt.hour        p.dt.minute      p.dt.month       p.dt.quarter     p.dt.qyear       p.dt.second      p.dt.week        p.dt.weekofyear  p.dt.year        
```
