### PR TITLE
Support is_dst indicators in tz_localize

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -465,6 +465,10 @@ Deprecations
 
 - The ``convert_dummies`` method has been deprecated in favor of
   ``get_dummies`` (:issue:`8140`)
+- The ``infer_dst`` argument in ``tz_localize`` will be deprecated in favor of
+  ``ambiguous`` to allow for more flexibility in dealing with DST transitions.
+  Replace ``infer_dst=True`` with ``ambiguous='infer'`` for the same behavior (:issue:`7943`).
+  See :ref:`the docs<timeseries.timezone_ambiguous>` for more details.
 
 .. _whatsnew_0150.knownissues:
 
@@ -543,7 +547,10 @@ Enhancements
 
 
 
-
+- ``tz_localize`` now accepts the ``ambiguous`` keyword which allows for passing an array of bools 
+  indicating whether the date belongs in DST or not, 'NaT' for setting transition times to NaT, 
+  'infer' for inferring DST/non-DST, and 'raise' (default) for an AmbiguousTimeError to be raised (:issue:`7943`).
+  See :ref:`the docs<timeseries.timezone_ambiguous>` for more details.
 
 
 

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -344,7 +344,6 @@ API changes
 - ``Series.to_csv()`` now returns a string when ``path=None``, matching the behaviour of
     ``DataFrame.to_csv()`` (:issue:`8215`).
 
-
 .. _whatsnew_0150.index_set_ops:
 
 - The Index set operations ``+`` and ``-`` were deprecated in order to provide these for numeric type operations on certain index types. ``+`` can be replace by ``.union()`` or ``|``, and ``-`` by ``.difference()``. Further the method name ``Index.diff()`` is deprecated and can be replaced by ``Index.difference()`` (:issue:`8226`)

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -232,6 +232,17 @@ class TestTimestamp(tm.TestCase):
         conv = local.tz_convert('US/Eastern')
         self.assertEqual(conv.nanosecond, 5)
         self.assertEqual(conv.hour, 19)
+        
+    def test_tz_localize_ambiguous(self):
+        
+        ts = Timestamp('2014-11-02 01:00')
+        ts_dst = ts.tz_localize('US/Eastern', ambiguous=True)
+        ts_no_dst = ts.tz_localize('US/Eastern', ambiguous=False)
+        
+        rng = date_range('2014-11-02', periods=3, freq='H', tz='US/Eastern')
+        self.assertEqual(rng[1], ts_dst)
+        self.assertEqual(rng[2], ts_no_dst)
+        self.assertRaises(ValueError, ts.tz_localize, 'US/Eastern', ambiguous='infer')
 
         # GH 8025
         with tm.assertRaisesRegexp(TypeError, 'Cannot localize tz-aware Timestamp, use '


### PR DESCRIPTION
The indicators are useful for assigning the correct offset when there are ambiguous transition times 
closes #7943.
