### PR TITLE
ENH/BUG: Period and PeriodIndex ops supports timedelta-like

### DIFF
--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -4,7 +4,7 @@
 .. ipython:: python
    :suppress:
 
-   from datetime import datetime
+   from datetime import datetime, timedelta
    import numpy as np
    np.random.seed(123456)
    from pandas import *
@@ -1098,6 +1098,36 @@ frequency.
 
    p - 3
 
+If ``Period`` freq is daily or higher (``D``, ``H``, ``T``, ``S``, ``L``, ``U``, ``N``), ``offsets`` and ``timedelta``-like can be added if the result can have same freq. Otherise, ``ValueError`` will be raised.
+
+.. ipython:: python
+
+   p = Period('2014-07-01 09:00', freq='H')
+   p + Hour(2)
+   p + timedelta(minutes=120)
+   p + np.timedelta64(7200, 's')
+
+.. code-block:: python
+
+   In [1]: p + Minute(5)
+   Traceback
+      ...
+   ValueError: Input has different freq from Period(freq=H)
+
+If ``Period`` has other freqs, only the same ``offsets`` can be added. Otherwise, ``ValueError`` will be raised.
+
+.. ipython:: python
+
+   p = Period('2014-07', freq='M')
+   p + MonthEnd(3)
+
+.. code-block:: python
+
+   In [1]: p + MonthBegin(3)
+   Traceback
+      ...
+   ValueError: Input has different freq from Period(freq=M)
+
 Taking the difference of ``Period`` instances with the same frequency will
 return the number of frequency units between them:
 
@@ -1128,6 +1158,18 @@ objects:
 
    ps = Series(randn(len(prng)), prng)
    ps
+
+``PeriodIndex`` supports addition and subtraction as the same rule as ``Period``.
+
+.. ipython:: python
+
+   idx = period_range('2014-07-01 09:00', periods=5, freq='H')
+   idx
+   idx + Hour(2)
+
+   idx = period_range('2014-07', periods=5, freq='M')
+   idx
+   idx + MonthEnd(3)
 
 PeriodIndex Partial String Indexing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -271,10 +271,21 @@ Enhancements
 
 
 
+- ``Period`` and ``PeriodIndex`` supports addition/subtraction with ``timedelta``-likes (:issue:`7966`)
 
+  If ``Period`` freq is ``D``, ``H``, ``T``, ``S``, ``L``, ``U``, ``N``, ``timedelta``-like can be added if the result can have same freq. Otherwise, only the same ``offsets`` can be added.
 
+  .. ipython:: python
 
+    idx = pd.period_range('2014-07-01 09:00', periods=5, freq='H')
+    idx
+    idx + pd.offsets.Hour(2)
+    idx + timedelta(minutes=120)
+    idx + np.timedelta64(7200, 's')
 
+    idx = pd.period_range('2014-07', periods=5, freq='M')
+    idx
+    idx + pd.offsets.MonthEnd(3)
 
 
 
@@ -411,6 +422,10 @@ Bug Fixes
 - Bug in ``date_range()``/``DatetimeIndex()`` when the timezone was inferred from input dates yet incorrect
   times were returned when crossing DST boundaries (:issue:`7835`, :issue:`7901`).
 
+
+
+
+- ``Period`` and ``PeriodIndex`` addition/subtraction with ``np.timedelta64`` results in incorrect internal representations (:issue:`7740`)
 
 
 


### PR DESCRIPTION
Must be revisited after #7954 to remove `_skip_if_not_numpy17_friendly`

Closes #7740.

Allow `Period` and `PeriodIndex` `add` and `sub` to support `timedelta`-like. If period freq is `offsets.Tick`, offsets can be added if the result can have same freq. Otherwise, `ValueError` will be raised.

```
idx = pd.period_range('2014-07-01 09:00', periods=5, freq='H')
idx + pd.offsets.Hour(2)
# <class 'pandas.tseries.period.PeriodIndex'>
# [2014-07-01 11:00, ..., 2014-07-01 15:00]
# Length: 5, Freq: H

idx + datetime.timedelta(minutes=120)
# <class 'pandas.tseries.period.PeriodIndex'>
# [2014-07-01 11:00, ..., 2014-07-01 15:00]
# Length: 5, Freq: H

idx + np.timedelta64(7200, 's')
# <class 'pandas.tseries.period.PeriodIndex'>
# [2014-07-01 11:00, ..., 2014-07-01 15:00]
# Length: 5, Freq: H

idx + pd.offsets.Minute(5)
# ValueError: Input has different freq from PeriodIndex(freq=H)
```

 If period freq isn't `Tick`, only the same offset can be added. Otherwise, `ValueError` will be raised.

```
idx = pd.period_range('2014-07', periods=5, freq='M')
idx + pd.offsets.MonthEnd(3)
# <class 'pandas.tseries.period.PeriodIndex'>
# [2014-10, ..., 2015-02]
# Length: 5, Freq: M
idx + pd.offsets.MonthBegin(3)
# ValueError: Input has different freq from PeriodIndex(freq=M)
```
