### PR TITLE
ENH Warn about panel.to_frame() discarding NaN GH7879

### DIFF
--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -8,6 +8,7 @@ from pandas.compat import (map, zip, range, lrange, lmap, u, OrderedDict,
 from pandas import compat
 import sys
 import numpy as np
+import warnings
 from pandas.core.common import (PandasError, _try_sort, _default_index,
                                 _infer_dtype_from_scalar, notnull)
 from pandas.core.categorical import Categorical
@@ -846,6 +847,7 @@ class Panel(NDFrame):
         filter_observations : boolean, default True
             Drop (major, minor) pairs without a complete set of observations
             across all the items
+            Default will be changed to False in future versions
 
         Returns
         -------
@@ -858,6 +860,13 @@ class Panel(NDFrame):
             mask = com.notnull(self.values).all(axis=0)
             # size = mask.sum()
             selector = mask.ravel()
+            if not selector.all():
+                warnings.warn("Panel to_frame method discards entries with "
+                              "NaN/None in the data by default, use "
+                              "filter_observations = False to save them. "
+                              "This will be default behaviour "
+                              "in future versions.",
+                              FutureWarning)
         else:
             # size = N * K
             selector = slice(None, None)

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1496,7 +1496,11 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         assert_frame_equal(result, expected)
 
         wp.iloc[0, 0].iloc[0] = np.nan  # BUG on setting. GH #5773
-        result = wp.to_frame()
+
+        with tm.assert_produces_warning(FutureWarning):
+            setattr(panelm, '__warningregistry__', {}) 
+            result = wp.to_frame()
+
         assert_frame_equal(result, expected[1:])
 
         idx = MultiIndex.from_tuples([(1, 'two'), (1, 'one'), (2, 'one'),


### PR DESCRIPTION
Also there was unimported module warnings with calls to it. In pandas/core/panel.py lines 718, 748 for example.

closes #7879 
