### PR TITLE
BUG: Allow __name__less callables as groupby hows (GH7929)

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -389,9 +389,8 @@ Bug Fixes
 - Bug in ``GroupBy.transform()`` where int groups with a transform that
   didn't preserve the index were incorrectly truncated (:issue:`7972`).
 
-
-
-
+- Bug in ``groupby`` where callable objects without name attributes would take the wrong path,
+  and produce a ``DataFrame`` instead of a ``Series`` (:issue:`7929`)
 
 
 - Bug in ``read_html`` where the ``infer_types`` argument forced coercion of

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -9,6 +9,7 @@ import codecs
 import csv
 import types
 from datetime import datetime, timedelta
+from functools import partial
 
 from numpy.lib.format import read_array, write_array
 import numpy as np
@@ -2432,7 +2433,22 @@ def _is_sequence(x):
     except (TypeError, AttributeError):
         return False
 
-
+def _get_callable_name(obj):
+    # typical case has name
+    if hasattr(obj, '__name__'):
+        return getattr(obj, '__name__')
+    # some objects don't; could recurse
+    if isinstance(obj, partial):
+        return _get_callable_name(obj.func)
+    # fall back to class name
+    if hasattr(obj, '__call__'):
+        return obj.__class__.__name__
+    # everything failed (probably because the argument
+    # wasn't actually callable); we return None
+    # instead of the empty string in this case to allow
+    # distinguishing between no name and a name of ''
+    return None
+    
 _string_dtypes = frozenset(map(_get_dtype_from_object, (compat.binary_type,
                                                         compat.text_type)))
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1221,7 +1221,8 @@ class BaseGrouper(object):
         group_keys = self._get_group_keys()
 
         # oh boy
-        if (f.__name__ not in _plotting_methods and
+        f_name = com._get_callable_name(f)
+        if (f_name not in _plotting_methods and
                 hasattr(splitter, 'fast_apply') and axis == 0):
             try:
                 values, mutated = splitter.fast_apply(f, group_keys)
@@ -2185,11 +2186,11 @@ class SeriesGroupBy(GroupBy):
                 if isinstance(f, compat.string_types):
                     columns.append(f)
                 else:
-                    columns.append(f.__name__)
+                    # protect against callables without names
+                    columns.append(com._get_callable_name(f))
             arg = lzip(columns, arg)
 
         results = {}
-
         for name, func in arg:
             if name in results:
                 raise SpecificationError('Function names must be unique, '

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -38,6 +38,26 @@ def test_is_sequence():
 
     assert(not is_seq(A()))
 
+def test_get_callable_name():
+    from functools import partial
+    getname = com._get_callable_name
+
+    def fn(x): 
+        return x
+    lambda_ = lambda x: x
+    part1 = partial(fn)
+    part2 = partial(part1)
+    class somecall(object):
+        def __call__(self):
+            return x
+
+    assert getname(fn) == 'fn'
+    assert getname(lambda_)
+    assert getname(part1) == 'fn'
+    assert getname(part2) == 'fn'
+    assert getname(somecall()) == 'somecall'
+    assert getname(1) is None
+
 
 def test_notnull():
     assert notnull(1.)


### PR DESCRIPTION
Allow `functools.partial` objects (and similar callables without `__name__` attributes) to be used as `groupby` functions, which also adds support along the tree (e.g. `resample`, which is specifically tested.)

Closes #7929.

This does not address the potential enhancements allowing automatic naming of duplicate-named functions (relatively minor) and the use of a Series to specify names (more useful).
