### PR TITLE
PERF: perf improvements for Series.transform (revised) (GH6496)

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -162,7 +162,7 @@ previously results in ``Exception`` or ``TypeError`` (:issue:`7812`)
      didx
      didx.tz_localize(None)
 
-- ``DataFrame.tz_localize`` and ``DataFrame.tz_convert`` now accepts an optional ``level`` argument 
+- ``DataFrame.tz_localize`` and ``DataFrame.tz_convert`` now accepts an optional ``level`` argument
   for localizing a specific level of a MultiIndex (:issue:`7846`)
 
 .. _whatsnew_0150.refactoring:
@@ -302,6 +302,7 @@ Performance
 
 - Performance improvements in ``DatetimeIndex.__iter__`` to allow faster iteration (:issue:`7683`)
 - Performance improvements in ``Period`` creation (and ``PeriodIndex`` setitem) (:issue:`5155`)
+- Improvements in Series.transform for significant performance gains (revised) (:issue:`6496`)
 
 
 

--- a/vb_suite/groupby.py
+++ b/vb_suite/groupby.py
@@ -444,5 +444,13 @@ g = transitions.cumsum()
 
 df = DataFrame({ 'signal' : np.random.rand(N)})
 """
-
 groupby_transform_series = Benchmark("df['signal'].groupby(g).transform(np.mean)", setup)
+
+setup = common_setup + """
+np.random.seed(0)
+
+df=DataFrame( { 'id' : np.arange( 100000 ) / 3,
+                'val': np.random.randn( 100000) } )
+"""
+
+groupby_transform_series2 = Benchmark("df.groupby('id')['val'].transform(np.mean)", setup)


### PR DESCRIPTION
xref #6496

Additional perf improvements for Series.transform (when specifying cythonizable functions)

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
groupby_transform_series2                    |  98.7293 | 3621.1437 |   0.0273 |
groupby_transform2                           |  19.5080 | 168.8046 |   0.1156 |
```
