### PR TITLE
ENH: Add duplicated/drop_duplicates to Index

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -374,6 +374,8 @@ Reindexing / Selection / Label manipulation
 
    Series.align
    Series.drop
+   Series.drop_duplicates
+   Series.duplicated
    Series.equals
    Series.first
    Series.head
@@ -1165,6 +1167,8 @@ Modifying and Computations
    Index.diff
    Index.sym_diff
    Index.drop
+   Index.drop_duplicates
+   Index.duplicated
    Index.equals
    Index.factorize
    Index.identical

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -179,6 +179,15 @@ API changes
 
 - Histogram from ``DataFrame.plot`` with ``kind='hist'`` (:issue:`7809`), See :ref:`the docs<visualization.hist>`.
 
+- ``Index`` now supports ``duplicated`` and ``drop_duplicates``. (:issue:`4060`)
+
+  .. ipython:: python
+
+     idx = Index([1, 2, 3, 4, 1, 2])
+     idx
+     idx.duplicated()
+     idx.drop_duplicates()
+
 .. _whatsnew_0150.dt:
 
 .dt accessor

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -12,7 +12,7 @@ import pandas.lib as lib
 import pandas.algos as _algos
 import pandas.index as _index
 from pandas.lib import Timestamp, is_datetime_array
-from pandas.core.base import PandasObject, FrozenList, FrozenNDArray, IndexOpsMixin
+from pandas.core.base import PandasObject, FrozenList, FrozenNDArray, IndexOpsMixin, _shared_docs
 from pandas.util.decorators import Appender, cache_readonly, deprecate
 from pandas.core.common import isnull, array_equivalent
 import pandas.core.common as com
@@ -29,6 +29,8 @@ __all__ = ['Index']
 
 
 _unsortable_types = frozenset(('mixed', 'mixed-integer'))
+
+_index_doc_kwargs = dict(klass='Index', inplace='')
 
 
 def _try_get_item(x):
@@ -208,6 +210,10 @@ class Index(IndexOpsMixin, PandasObject):
             setattr(result,k,v)
         result._reset_identity()
         return result
+
+    def _update_inplace(self, result):
+        # guard when called from IndexOpsMixin
+        raise TypeError("Index can't be updated inplace")
 
     def is_(self, other):
         """
@@ -2018,6 +2024,15 @@ class Index(IndexOpsMixin, PandasObject):
         if mask.any():
             raise ValueError('labels %s not contained in axis' % labels[mask])
         return self.delete(indexer)
+
+    @Appender(_shared_docs['drop_duplicates'] % _index_doc_kwargs)
+    def drop_duplicates(self, take_last=False):
+        result = super(Index, self).drop_duplicates(take_last=take_last)
+        return self._constructor(result)
+
+    @Appender(_shared_docs['duplicated'] % _index_doc_kwargs)
+    def duplicated(self, take_last=False):
+        return super(Index, self).duplicated(take_last=take_last)
 
     @classmethod
     def _add_numeric_methods_disabled(cls):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -52,10 +52,13 @@ from pandas.core.config import get_option
 
 __all__ = ['Series']
 
+
 _shared_doc_kwargs = dict(
     axes='index',
     klass='Series',
-    axes_single_arg="{0,'index'}"
+    axes_single_arg="{0,'index'}",
+    inplace="""inplace : boolean, default False
+            If True, performs operation inplace and returns None."""
 )
 
 
@@ -264,6 +267,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             object.__setattr__(self, '_subtyp', 'time_series')
         else:
             object.__setattr__(self, '_subtyp', 'series')
+
+    def _update_inplace(self, result):
+        return generic.NDFrame._update_inplace(self, result)
 
     # ndarray compatibility
     @property
@@ -1114,45 +1120,14 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         from pandas.core.algorithms import mode
         return mode(self)
 
+    @Appender(base._shared_docs['drop_duplicates'] % _shared_doc_kwargs)
     def drop_duplicates(self, take_last=False, inplace=False):
-        """
-        Return Series with duplicate values removed
+        return super(Series, self).drop_duplicates(take_last=take_last,
+                                                   inplace=inplace)
 
-        Parameters
-        ----------
-        take_last : boolean, default False
-            Take the last observed index in a group. Default first
-        inplace : boolean, default False
-            If True, performs operation inplace and returns None.
-
-        Returns
-        -------
-        deduplicated : Series
-        """
-        duplicated = self.duplicated(take_last=take_last)
-        result = self[-duplicated]
-        if inplace:
-            return self._update_inplace(result)
-        else:
-            return result
-
+    @Appender(base._shared_docs['duplicated'] % _shared_doc_kwargs)
     def duplicated(self, take_last=False):
-        """
-        Return boolean Series denoting duplicate values
-
-        Parameters
-        ----------
-        take_last : boolean, default False
-            Take the last observed index in a group. Default first
-
-        Returns
-        -------
-        duplicated : Series
-        """
-        keys = _ensure_object(self.values)
-        duplicated = lib.duplicated(keys, take_last=take_last)
-        return self._constructor(duplicated,
-                                 index=self.index).__finalize__(self)
+        return super(Series, self).duplicated(take_last=take_last)
 
     def idxmin(self, axis=None, out=None, skipna=True):
         """

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2031,6 +2031,20 @@ Thur,Lunch,Yes,51.51,17"""
         result = df.loc[('foo','bar')]
         assert_frame_equal(result,expected)
 
+    def test_duplicated_drop_duplicates(self):
+        # GH 4060
+        idx = MultiIndex.from_arrays(([1, 2, 3, 1, 2 ,3], [1, 1, 1, 1, 2, 2]))
+
+        expected = Index([False, False, False, True, False, False])
+        tm.assert_index_equal(idx.duplicated(), expected)
+        expected = MultiIndex.from_arrays(([1, 2, 3, 2 ,3], [1, 1, 1, 2, 2]))
+        tm.assert_index_equal(idx.drop_duplicates(), expected)
+
+        expected = Index([True, False, False, False, False, False])
+        tm.assert_index_equal(idx.duplicated(take_last=True), expected)
+        expected = MultiIndex.from_arrays(([2, 3, 1, 2 ,3], [1, 1, 1, 2, 2]))
+        tm.assert_index_equal(idx.drop_duplicates(take_last=True), expected)
+
     def test_multiindex_set_index(self):
         # segfault in #3308
         d = {'t1': [2, 2.5, 3], 't2': [4, 5, 6]}


### PR DESCRIPTION
Closes #4060.

```
idx = pd.Index([1, 2, 3, 4, 1, 2])
idx.duplicated()
# Index([False, False, False, False, True, True], dtype='bool')
idx.drop_duplicates()
# Int64Index([1, 2, 3, 4], dtype='int64')

idx.duplicated(take_last=True)
# Index([True, True, False, False, False, False], dtype='bool')
idx.drop_duplicates(take_last=True)
# Int64Index([3, 4, 1, 2], dtype='int64')
```
