### PR TITLE
Fix DataFrame.to_latex() midrule positioning with MultiIndex columns

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -429,7 +429,7 @@ Bug Fixes
 - ``Period`` and ``PeriodIndex`` addition/subtraction with ``np.timedelta64`` results in incorrect internal representations (:issue:`7740`)
 
 
-
+- Bug in ``DataFrame.to_latex`` formatting when columns or index is a ``MultiIndex`` (:issue:`7982`).
 
 
 

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -532,7 +532,7 @@ class DataFrameFormatter(TableFormatter):
                 buf.write('\\begin{longtable}{%s}\n' % column_format)
                 buf.write('\\toprule\n')
 
-            nlevels = frame.index.nlevels
+            nlevels = frame.columns.nlevels
             for i, row in enumerate(zip(*strcols)):
                 if i == nlevels:
                     buf.write('\\midrule\n')  # End of header

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -2083,6 +2083,31 @@ c  10  11  12  13  14\
 """
         self.assertEqual(withoutindex_result, withoutindex_expected)
 
+    def test_to_latex_multiindex(self):
+        df = DataFrame({('x', 'y'): ['a']})
+        result = df.to_latex()
+        expected = r"""\begin{tabular}{ll}
+\toprule
+{} &  x \\
+{} &  y \\
+\midrule
+0 &  a \\
+\bottomrule
+\end{tabular}
+"""
+        self.assertEqual(result, expected)
+
+        result = df.T.to_latex()
+        expected = r"""\begin{tabular}{ll}
+\toprule
+{} &  0 \\
+\midrule
+x y &  a \\
+\bottomrule
+\end{tabular}
+"""
+        self.assertEqual(result, expected)
+
     def test_to_latex_escape(self):
         a = 'a'
         b = 'b'


### PR DESCRIPTION
Currently, the positioning of \midrule is determined by the number of index
levels, not columns levels:

```
>>> print pd.DataFrame({('x', 'y'): ['a']}).to_latex()
\begin{tabular}{ll}
\toprule
{} &  x \\
\midrule
{} &  y \\
0 &  a \\
\bottomrule
\end{tabular}
```

The fix is simple: use the number of column levels instead of the number
of index levels.
