### PR TITLE
Allow deprecate_kwarg to transform arguments

### DIFF
--- a/pandas/tests/test_util.py
+++ b/pandas/tests/test_util.py
@@ -1,0 +1,64 @@
+
+import warnings
+
+import nose
+
+import pandas.util
+from pandas.util.decorators import deprecate_kwarg
+import pandas.util.testing as tm
+
+class TestDecorators(tm.TestCase):
+    def setUp(self):
+        @deprecate_kwarg('old', 'new')
+        def _f1(new=False):
+            return new
+
+        @deprecate_kwarg('old', 'new', {'yes': True, 'no': False})
+        def _f2(new=False):
+            return new
+
+        @deprecate_kwarg('old', 'new', lambda x: x+1)
+        def _f3(new=0):
+            return new
+
+        self.f1 = _f1
+        self.f2 = _f2
+        self.f3 = _f3
+
+    def test_deprecate_kwarg(self):
+        x = 78
+        with tm.assert_produces_warning(FutureWarning):
+            result = self.f1(old=x)
+        self.assertIs(result, x)
+        with tm.assert_produces_warning(None):
+            self.f1(new=x)
+
+    def test_dict_deprecate_kwarg(self):
+        x = 'yes'
+        with tm.assert_produces_warning(FutureWarning):
+            result = self.f2(old=x)
+        self.assertEqual(result, True)
+
+    def test_missing_deprecate_kwarg(self):
+        x = 'bogus'
+        with tm.assert_produces_warning(FutureWarning):
+            result = self.f2(old=x)
+        self.assertEqual(result, 'bogus')
+
+    def test_callable_deprecate_kwarg(self):
+        x = 5
+        with tm.assert_produces_warning(FutureWarning):
+            result = self.f3(old=x)
+        self.assertEqual(result, x+1)
+        with tm.assertRaises(TypeError):
+            self.f3(old='hello')
+
+    def test_bad_deprecate_kwarg(self):
+        with tm.assertRaises(TypeError):
+            @deprecate_kwarg('old', 'new', 0)
+            def f4(new=None):
+                pass
+
+if __name__ == '__main__':
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   exit=False)


### PR DESCRIPTION
This will allow deprecated kwargs to be transformed before being passed to a function.  For example, in #7963, one could write

``` python

@deprecate_kwarg(old_arg_name='infer_dst', new_arg_name='ambiguous',
                 mapping={True: 'infer', False: 'raise'})
def tz_localize(self, tz, ambiguous=None):
    ...

```

Open issues:
- should we test for a bad mapping at creation time?  (in this PR: yes)
- how much error checking should we do?  (in this PR: pass args unrecognized by a mapping through unchanged; assume a function will do its own error handling)
- should we support both mappings and callables?  (in this PR: yes)
- if so, how should we recognize mappings?  (in this PR: existence of a `get` method)
