### PR TITLE
CLN/DOC/TST: categorical fixups (GH7768)

### DIFF
--- a/doc/source/10min.rst
+++ b/doc/source/10min.rst
@@ -66,7 +66,8 @@ Creating a ``DataFrame`` by passing a dict of objects that can be converted to s
                         'B' : pd.Timestamp('20130102'),
                         'C' : pd.Series(1,index=list(range(4)),dtype='float32'),
                         'D' : np.array([3] * 4,dtype='int32'),
-                        'E' : 'foo' })
+                        'E' : pd.Categorical(["test","train","test","train"]),
+                        'F' : 'foo' })
    df2
 
 Having specific :ref:`dtypes <basics.dtypes>`
@@ -634,6 +635,32 @@ the quarter end:
    ts = pd.Series(np.random.randn(len(prng)), prng)
    ts.index = (prng.asfreq('M', 'e') + 1).asfreq('H', 's') + 9
    ts.head()
+
+Categoricals
+------------
+
+Since version 0.15, pandas can include categorical data in a `DataFrame`. For full docs, see the
+:ref:`Categorical introduction <categorical>` and the :ref:`API documentation <api.categorical>` .
+
+.. ipython:: python
+
+    df = pd.DataFrame({"id":[1,2,3,4,5,6], "raw_grade":['a', 'b', 'b', 'a', 'a', 'e']})
+
+    # convert the raw grades to a categorical
+    df["grade"] = pd.Categorical(df["raw_grade"])
+
+    # Alternative: df["grade"] = df["raw_grade"].astype("category")
+    df["grade"]
+
+    # Rename the levels
+    df["grade"].cat.levels = ["very good", "good", "very bad"]
+
+    # Reorder the levels and simultaneously add the missing levels
+    df["grade"].cat.reorder_levels(["very bad", "bad", "medium", "good", "very good"])
+    df["grade"]
+    df.sort("grade")
+    df.groupby("grade").size()
+
 
 
 Plotting

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -528,11 +528,17 @@ and has the following usable methods and properties (all available as
    :toctree: generated/
 
    Categorical
-   Categorical.from_codes
    Categorical.levels
    Categorical.ordered
    Categorical.reorder_levels
    Categorical.remove_unused_levels
+
+The following methods are considered API when using ``Categorical`` directly:
+
+.. autosummary::
+   :toctree: generated/
+
+   Categorical.from_codes
    Categorical.min
    Categorical.max
    Categorical.mode
@@ -547,7 +553,7 @@ the Categorical back to a numpy array, so levels and order information is not pr
    Categorical.__array__
 
 To create compatibility with `pandas.Series` and `numpy` arrays, the following (non-API) methods
-are also introduced.
+are also introduced and available when ``Categorical`` is used directly.
 
 .. autosummary::
    :toctree: generated/
@@ -563,7 +569,8 @@ are also introduced.
    Categorical.order
    Categorical.argsort
    Categorical.fillna
-
+   Categorical.notnull
+   Categorical.isnull
 
 Plotting
 ~~~~~~~~

--- a/doc/source/reshaping.rst
+++ b/doc/source/reshaping.rst
@@ -503,3 +503,10 @@ handling of NaN:
 
    pd.factorize(x, sort=True)
    np.unique(x, return_inverse=True)[::-1]
+
+.. note::
+    If you just want to handle one column as a categorical variable (like R's factor),
+    you can use  ``df["cat_col"] = pd.Categorical(df["col"])`` or
+    ``df["cat_col"] = df["col"].astype("category")``. For full docs on :class:`~pandas.Categorical`,
+    see the :ref:`Categorical introduction <categorical>` and the
+    :ref:`API documentation <api.categorical>`. This feature was introduced in version 0.15.

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -226,7 +226,8 @@ Categoricals in Series/DataFrame
 methods to manipulate. Thanks to Jan Schultz for much of this API/implementation. (:issue:`3943`, :issue:`5313`, :issue:`5314`,
 :issue:`7444`, :issue:`7839`, :issue:`7848`, :issue:`7864`, :issue:`7914`).
 
-For full docs, see the :ref:`Categorical introduction <categorical>` and the :ref:`API documentation <api.categorical>`.
+For full docs, see the :ref:`Categorical introduction <categorical>` and the
+:ref:`API documentation <api.categorical>`.
 
 .. ipython:: python
 

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -2,12 +2,13 @@
 
 import numpy as np
 from warnings import warn
+import types
 
 from pandas import compat
 from pandas.compat import u
 
-from pandas.core.algorithms import factorize, unique
-from pandas.core.base import PandasObject
+from pandas.core.algorithms import factorize
+from pandas.core.base import PandasObject, PandasDelegate
 from pandas.core.index import Index, _ensure_index
 from pandas.core.indexing import _is_null_slice
 from pandas.tseries.period import PeriodIndex
@@ -18,16 +19,36 @@ from pandas.core import format as fmt
 
 def _cat_compare_op(op):
     def f(self, other):
-        if isinstance(other, (Categorical, np.ndarray)):
-            values = np.asarray(self)
-            f = getattr(values, op)
-            return f(np.asarray(other))
-        else:
+        # On python2, you can usually compare any type to any type, and Categoricals can be
+        # seen as a custom type, but having different results depending whether a level are
+        # the same or not is kind of insane, so be a bit stricter here and use the python3 idea
+        # of comparing only things of equal type.
+        if not self.ordered:
+            if op in ['__lt__', '__gt__','__le__','__ge__']:
+                raise TypeError("Unordered Categoricals can only compare equality or not")
+        if isinstance(other, Categorical):
+            # Two Categoricals can only be be compared if the levels are the same
+            if (len(self.levels) != len(other.levels)) or not ((self.levels == other.levels).all()):
+                raise TypeError("Categoricals can only be compared if 'levels' are the same")
+            if not (self.ordered == other.ordered):
+                raise TypeError("Categoricals can only be compared if 'ordered' is the same")
+            na_mask = (self._codes == -1) | (other._codes == -1)
+            f = getattr(self._codes, op)
+            ret = f(other._codes)
+            if na_mask.any():
+                # In other series, the leads to False, so do that here too
+                ret[na_mask] = False
+            return ret
+        elif np.isscalar(other):
             if other in self.levels:
                 i = self.levels.get_loc(other)
                 return getattr(self._codes, op)(i)
             else:
                 return np.repeat(False, len(self))
+        else:
+            msg = "Cannot compare a Categorical for op {op} with type {typ}. If you want to \n" \
+                  "compare values, use 'np.asarray(cat) <op> other'."
+            raise TypeError(msg.format(op=op,typ=type(other)))
 
     f.__name__ = op
 
@@ -109,9 +130,9 @@ class Categorical(PandasObject):
 
     Attributes
     ----------
-    levels : ndarray
+    levels : Index
         The levels of this categorical
-    codes : Index
+    codes : ndarray
         The codes (integer positions, which point to the levels) of this categorical, read only
     ordered : boolean
         Whether or not this Categorical is ordered
@@ -171,6 +192,9 @@ class Categorical(PandasObject):
     Categorical.max
     """
 
+    # For comparisons, so that numpy uses our implementation if the compare ops, which raise
+    __array_priority__ = 1000
+
     def __init__(self, values, levels=None, ordered=None, name=None, fastpath=False, compat=False):
 
         if fastpath:
@@ -208,8 +232,23 @@ class Categorical(PandasObject):
             # under certain versions of numpy as well
             inferred = com._possibly_infer_to_datetimelike(values)
             if not isinstance(inferred, np.ndarray):
+
+                # isnull doesn't work with generators/xrange, so convert all to lists
+                if com._is_sequence(values) or isinstance(values, types.GeneratorType):
+                    values = list(values)
+                elif np.isscalar(values):
+                    values = [values]
+
                 from pandas.core.series import _sanitize_array
-                values = _sanitize_array(values, None)
+                # On list with NaNs, int values will be converted to float. Use "object" dtype
+                # to prevent this. In the end objects will be casted to int/... in the level
+                # assignment step.
+                # tuple are list_like but com.isnull(<tuple>) will return a single bool,
+                # which then raises an AttributeError: 'bool' object has no attribute 'any'
+                has_null = (com.is_list_like(values) and not isinstance(values, tuple)
+                            and com.isnull(values).any())
+                dtype = 'object' if has_null else None
+                values = _sanitize_array(values, None, dtype=dtype)
 
         if levels is None:
             try:
@@ -277,7 +316,7 @@ class Categorical(PandasObject):
         return Categorical(data)
 
     @classmethod
-    def from_codes(cls, codes, levels, ordered=True, name=None):
+    def from_codes(cls, codes, levels, ordered=False, name=None):
         """
         Make a Categorical type from codes and levels arrays.
 
@@ -294,7 +333,7 @@ class Categorical(PandasObject):
             The levels for the categorical. Items need to be unique.
         ordered : boolean, optional
             Whether or not this categorical is treated as a ordered categorical. If not given,
-            the resulting categorical will be ordered.
+            the resulting categorical will be unordered.
         name : str, optional
             Name for the Categorical variable.
         """
@@ -429,9 +468,13 @@ class Categorical(PandasObject):
         Returns
         -------
         values : numpy array
-            A numpy array of the same dtype as categorical.levels.dtype
+            A numpy array of either the specified dtype or, if dtype==None (default), the same
+            dtype as categorical.levels.dtype
         """
-        return com.take_1d(self.levels.values, self._codes)
+        ret = com.take_1d(self.levels.values, self._codes)
+        if dtype and dtype != self.levels.dtype:
+            return np.asarray(ret, dtype)
+        return ret
 
     @property
     def T(self):
@@ -503,10 +546,27 @@ class Categorical(PandasObject):
         if na_position not in ['last','first']:
             raise ValueError('invalid na_position: {!r}'.format(na_position))
 
-        codes = np.sort(self._codes.copy())
+        codes = np.sort(self._codes)
         if not ascending:
             codes = codes[::-1]
 
+        # NaN handling
+        na_mask = (codes==-1)
+        if na_mask.any():
+            n_nans = len(codes[na_mask])
+            if na_position=="first" and not ascending:
+                # in this case sort to the front
+                new_codes = codes.copy()
+                new_codes[0:n_nans] = -1
+                new_codes[n_nans:] = codes[~na_mask]
+                codes = new_codes
+            elif na_position=="last" and not ascending:
+                # ... and to the end
+                new_codes = codes.copy()
+                pos = len(codes)-n_nans
+                new_codes[0:pos] = codes[~na_mask]
+                new_codes[pos:] = -1
+                codes = new_codes
         if inplace:
             self._codes = codes
             return
@@ -541,6 +601,32 @@ class Categorical(PandasObject):
         Category.order
         """
         return self.order(inplace=inplace, ascending=ascending, **kwargs)
+
+    def isnull(self):
+        """
+        Returns
+        -------
+        a boolean array of whether my values are null
+
+        """
+
+        ret = self._codes == -1
+
+        # String/object and float levels can hold np.nan
+        if self.levels.dtype.kind in ['S', 'O', 'f']:
+            if np.nan in self.levels:
+                nan_pos = np.where(com.isnull(self.levels))
+                ret = ret | self == nan_pos
+        return ret
+
+    def notnull(self):
+        """
+        Returns
+        -------
+        a boolean array of whether my values are not null
+
+        """
+        return ~self.isnull()
 
     def ravel(self, order='C'):
         """ Return a flattened (numpy) array.
@@ -760,7 +846,8 @@ class Categorical(PandasObject):
 
         rvalue = value if com.is_list_like(value) else [value]
         to_add = Index(rvalue)-self.levels
-        if len(to_add):
+        # no assignments of values not in levels, but it's always ok to set something to np.nan
+        if len(to_add) and not com.isnull(to_add).all():
             raise ValueError("cannot setitem on a Categorical with a new level,"
                              " set the levels first")
 
@@ -786,6 +873,13 @@ class Categorical(PandasObject):
             key = self._codes[key]
 
         lindexer = self.levels.get_indexer(rvalue)
+
+        # float levels do currently return -1 for np.nan, even if np.nan is included in the index
+        # "repair" this here
+        if com.isnull(rvalue).any() and com.isnull(self.levels).any():
+            nan_pos = np.where(com.isnull(self.levels))
+            lindexer[lindexer == -1] = nan_pos
+
         self._codes[key] = lindexer
 
     #### reduction ops ####
@@ -916,15 +1010,66 @@ class Categorical(PandasObject):
             'values' : self._codes }
                            ).groupby('codes').count()
 
-        counts.index = self.levels.take(counts.index)
-        counts = counts.reindex(self.levels)
         freqs = counts / float(counts.sum())
 
         from pandas.tools.merge import concat
         result = concat([counts,freqs],axis=1)
-        result.index.name = 'levels'
         result.columns = ['counts','freqs']
+
+        # fill in the real levels
+        check = result.index == -1
+        if check.any():
+            # Sort -1 (=NaN) to the last position
+            index = np.arange(0, len(self.levels)+1)
+            index[-1] = -1
+            result = result.reindex(index)
+            # build new index
+            levels = np.arange(0,len(self.levels)+1 ,dtype=object)
+            levels[:-1] = self.levels
+            levels[-1] = np.nan
+            result.index = levels.take(result.index)
+        else:
+            result.index = self.levels.take(result.index)
+            result = result.reindex(self.levels)
+        result.index.name = 'levels'
+
         return result
+
+##### The Series.cat accessor #####
+
+class CategoricalProperties(PandasDelegate):
+    """
+    Accessor object for categorical properties of the Series values.
+
+    Examples
+    --------
+    >>> s.cat.levels
+    >>> s.cat.levels = list('abc')
+    >>> s.cat.reorder_levels('cab')
+
+    Allows accessing to specific getter and access methods
+    """
+
+    def __init__(self, values, index):
+        self.categorical = values
+        self.index = index
+
+    def _delegate_property_get(self, name):
+        return getattr(self.categorical, name)
+
+    def _delegate_property_set(self, name, new_values):
+        return setattr(self.categorical, name, new_values)
+
+    def _delegate_method(self, name, *args, **kwargs):
+        method = getattr(self.categorical, name)
+        return method(*args, **kwargs)
+
+CategoricalProperties._add_delegate_accessors(delegate=Categorical,
+                                              accessors=["levels", "codes", "ordered"],
+                                              typ='property')
+CategoricalProperties._add_delegate_accessors(delegate=Categorical,
+                                              accessors=["reorder_levels", "remove_unused_levels"],
+                                              typ='method')
 
 ##### utility routines #####
 

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -177,7 +177,7 @@ class SeriesFormatter(object):
         # level infos are added to the end and in a new line, like it is done for Categoricals
         # Only added when we request a name
         if self.name and com.is_categorical_dtype(self.series.dtype):
-            level_info = self.series.cat._repr_level_info()
+            level_info = self.series.values._repr_level_info()
             if footer:
                 footer += "\n"
             footer += level_info

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -900,7 +900,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         # Categorical
         if com.is_categorical_dtype(self.dtype):
-            level_info = self.cat._repr_level_info()
+            level_info = self.values._repr_level_info()
             return u('%sLength: %d, dtype: %s\n%s') % (namestr,
                                                        len(self),
                                                        str(self.dtype.name),
@@ -2415,11 +2415,12 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     #------------------------------------------------------------------------------
     # Categorical methods
 
-    @property
+    @cache_readonly
     def cat(self):
+        from pandas.core.categorical import CategoricalProperties
         if not com.is_categorical_dtype(self.dtype):
             raise TypeError("Can only use .cat accessor with a 'category' dtype")
-        return self.values
+        return CategoricalProperties(self.values, self.index)
 
 Series._setup_axes(['index'], info_axis=0, stat_axis=0,
                    aliases={'rows': 0})


### PR DESCRIPTION
replaces #7768 

closes #3678

Categorical([1, np.nan]) would end up with a single `1.` float level.
This commit ensures that if `values` is a list of ints and contains np.nan,
the float conversation does not take place.

Categorical: fix describe with np.nan

Categorical: ensure that one can assign np.nan

Categorical: fix assigning NaN if NaN in levels

API: change default Categorical.from_codes() to ordered=False

In the normal constructor `ordered=True` is only assumed if the levels
are given or the values are sortable (which is most of the cases), but
in `from_codes(...)` we can't asssume this so the default should be
`False`.

Categorical: add some links to Categorical in the other docs

Categorical: use s.values when calling private methods

s.values is the underlying Categorical object, s.cat will be changed
to only expose the API methods/properties.

Categorical: Change series.cat to only expose the API

Categorical: Fix order and na_position

Categorical: Fix comparison of Categoricals and Series|Categorical|np.array

Categorical can only be comapred to another Categorical with the same levels
and the same ordering or to a scalar value.

If the Categorical has no order defined (cat.ordered == False), only equal
(and not equal) are defined.

DOC: use okexcept in docs rather than try: except:

CLN: revised isnull treatement

TST: test for tab completion
