### PR TITLE
Add sharex and sharey to grouped boxplot

### DIFF
--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -2685,7 +2685,7 @@ def grouped_hist(data, column=None, by=None, ax=None, bins=50, figsize=None,
 
 def boxplot_frame_groupby(grouped, subplots=True, column=None, fontsize=None,
                           rot=0, grid=True, ax=None, figsize=None,
-                          layout=None, **kwds):
+                          layout=None, sharex=False, sharey=False, **kwds):
     """
     Make box plots from DataFrameGroupBy data.
 
@@ -2703,6 +2703,8 @@ def boxplot_frame_groupby(grouped, subplots=True, column=None, fontsize=None,
     figsize : A tuple (width, height) in inches
     layout : tuple (optional)
         (rows, columns) for the layout of the plot
+    sharex: boolean, default False
+    sharey: boolean, default False    
     kwds : other plotting keyword arguments to be passed to matplotlib boxplot
            function
 
@@ -2732,7 +2734,7 @@ def boxplot_frame_groupby(grouped, subplots=True, column=None, fontsize=None,
         naxes = len(grouped)
         nrows, ncols = _get_layout(naxes, layout=layout)
         fig, axes = _subplots(nrows=nrows, ncols=ncols, naxes=naxes, squeeze=False,
-                              ax=ax, sharex=False, sharey=True, figsize=figsize)
+                              ax=ax, sharex=sharex, sharey=sharey, figsize=figsize)
         axes = _flatten(axes)
 
         ret = compat.OrderedDict()


### PR DESCRIPTION
sharex and sharey should be settable and by default False in a grouped boxplot. E.g. 

```
n [97]: df = DataFrame(np.random.rand(10,2), columns=['Col1', 'Col2'] )

In [98]: df['X'] =['A','A','A','A','A','B','B','B','B','B']

In [99]: df.iloc[0:5, :2] += 10000

In [100]: df.groupby('X').boxplot()  # this is unreadable
```
