### PR TITLE
fix issue #8000

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1543,7 +1543,8 @@ def interpolate_1d(xvalues, yvalues, method='linear', limit=None,
         inds = inds[firstIndex:]
 
         result[firstIndex:][invalid] = np.interp(inds[invalid], inds[valid],
-                                                 yvalues[firstIndex:][valid])
+                                                 yvalues[firstIndex:][valid],
+                                                 np.nan, np.nan)
 
         if limit:
             result[violate_limit] = np.nan

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -389,6 +389,12 @@ def test_groupby():
 
     for k, v in grouped:
         assert v == expected[k]
+        
+
+def test_interpolate_linear():
+    a = Series([np.nan, 1, np.nan, 3, np.nan]))
+    b = a.interpolate()
+    assert(b[4] == np.nan)
 
 
 def test_is_list_like():


### PR DESCRIPTION
This pull request is in response to [issue #8000](https://github.com/pydata/pandas/issues/8000). 

Changes to core/common.py add np.nan as the default value for missing values to the left and right non-missing values during interpolation. This prevents DataFrame.interpolate() from extrapolating the last non-missing value over all trailing missing values (the default).  

Changes to tests/test_common.py add test coverage to the above change. A passing test is where an interpolated series with a trailing missing value maintains that trailing missing value after interpolation.
