### PR TITLE
fix issue #8000 - interpolation extrapolates over trailing missing values

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1543,7 +1543,8 @@ def interpolate_1d(xvalues, yvalues, method='linear', limit=None,
         inds = inds[firstIndex:]
 
         result[firstIndex:][invalid] = np.interp(inds[invalid], inds[valid],
-                                                 yvalues[firstIndex:][valid])
+                                                 yvalues[firstIndex:][valid],
+                                                 np.nan, np.nan)
 
         if limit:
             result[violate_limit] = np.nan

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -638,6 +638,12 @@ class TestSeries(tm.TestCase, Generic):
         result = df.interpolate(method='nearest')
         expected = Series([1., 1., 3.], index=date_range('1/1/2000', periods=3))
         assert_series_equal(result, expected)
+        
+    def test_interp_trailing_nan(self):
+        s = Series([np.nan, 1, np.nan, 3, np.nan])
+        result = s.interpolate()
+        expected = Series([np.nan, 1, 2, 3, np.nan])
+        assert_series_equal(result, expected)
 
     def test_describe(self):
         _ = self.series.describe()


### PR DESCRIPTION
This pull request is in response to [issue #8000](https://github.com/pydata/pandas/issues/8000).

Changes to core/common.py add np.nan as the default value for missing values to the left and right non-missing values during interpolation. This prevents DataFrame.interpolate() from extrapolating the last non-missing value over all trailing missing values (the default).

Changes to tests/test_generic.py add test coverage to the above change. A passing test is where an interpolated series with a trailing missing value maintains that trailing missing value after interpolation.
