### PR TITLE
BUG: Area plot legend has incorrect color

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -472,7 +472,7 @@ Bug Fixes
   times were returned when crossing DST boundaries (:issue:`7835`, :issue:`7901`).
 
 
-
+- Bug in area plot draws legend with incorrect ``alpha`` when ``stacked=True`` (:issue:`8027`)
 
 - ``Period`` and ``PeriodIndex`` addition/subtraction with ``np.timedelta64`` results in incorrect internal representations (:issue:`7740`)
 

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1718,7 +1718,7 @@ class TestDataFramePlots(TestPlotBase):
         normal_df = DataFrame({'A': np.repeat(np.array([1, 2, 3, 4, 5]),
                                               np.array([10, 9, 8, 7, 6])),
                                'B': np.repeat(np.array([1, 2, 3, 4, 5]),
-                                              np.array([8, 8, 8, 8, 8])), 
+                                              np.array([8, 8, 8, 8, 8])),
                                'C': np.repeat(np.array([1, 2, 3, 4, 5]),
                                               np.array([6, 7, 8, 9, 10]))},
                                columns=['A', 'B', 'C'])
@@ -1726,7 +1726,7 @@ class TestDataFramePlots(TestPlotBase):
         nan_df = DataFrame({'A': np.repeat(np.array([np.nan, 1, 2, 3, 4, 5]),
                                            np.array([3, 10, 9, 8, 7, 6])),
                             'B': np.repeat(np.array([1, np.nan, 2, 3, 4, 5]),
-                                           np.array([8, 3, 8, 8, 8, 8])), 
+                                           np.array([8, 3, 8, 8, 8, 8])),
                             'C': np.repeat(np.array([1, 2, 3, np.nan, 4, 5]),
                                            np.array([6, 7, 8, 3, 9, 10]))},
                            columns=['A', 'B', 'C'])
@@ -2157,20 +2157,38 @@ class TestDataFramePlots(TestPlotBase):
         self._check_colors(ax.get_lines(), linecolors=custom_colors)
         poly = [o for o in ax.get_children() if isinstance(o, PolyCollection)]
         self._check_colors(poly, facecolors=custom_colors)
+
+        handles, labels = ax.get_legend_handles_labels()
+        # legend is stored as Line2D, thus check linecolors
+        self._check_colors(handles, linecolors=custom_colors)
+        for h in handles:
+            self.assertTrue(h.get_alpha() is None)
         tm.close()
 
         ax = df.plot(kind='area', colormap='jet')
-        rgba_colors = lmap(cm.jet, np.linspace(0, 1, len(df)))
-        self._check_colors(ax.get_lines(), linecolors=rgba_colors)
+        jet_colors = lmap(cm.jet, np.linspace(0, 1, len(df)))
+        self._check_colors(ax.get_lines(), linecolors=jet_colors)
         poly = [o for o in ax.get_children() if isinstance(o, PolyCollection)]
-        self._check_colors(poly, facecolors=rgba_colors)
+        self._check_colors(poly, facecolors=jet_colors)
+
+        handles, labels = ax.get_legend_handles_labels()
+        self._check_colors(handles, linecolors=jet_colors)
+        for h in handles:
+            self.assertTrue(h.get_alpha() is None)
         tm.close()
 
-        ax = df.plot(kind='area', colormap=cm.jet)
-        rgba_colors = lmap(cm.jet, np.linspace(0, 1, len(df)))
-        self._check_colors(ax.get_lines(), linecolors=rgba_colors)
+        # When stacked=True, alpha is set to 0.5
+        ax = df.plot(kind='area', colormap=cm.jet, stacked=False)
+        self._check_colors(ax.get_lines(), linecolors=jet_colors)
         poly = [o for o in ax.get_children() if isinstance(o, PolyCollection)]
-        self._check_colors(poly, facecolors=rgba_colors)
+        jet_with_alpha = [(c[0], c[1], c[2], 0.5) for c in jet_colors]
+        self._check_colors(poly, facecolors=jet_with_alpha)
+
+        handles, labels = ax.get_legend_handles_labels()
+        # Line2D can't have alpha in its linecolor
+        self._check_colors(handles, linecolors=jet_colors)
+        for h in handles:
+            self.assertEqual(h.get_alpha(), 0.5)
 
     @slow
     def test_hist_colors(self):

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1686,7 +1686,7 @@ class AreaPlot(LinePlot):
         from matplotlib.patches import Rectangle
         # Because fill_between isn't supported in legend,
         # specifically add Rectangle handle here
-        alpha = self.kwds.get('alpha', 0.5)
+        alpha = self.kwds.get('alpha', None)
         handle = Rectangle((0, 0), 1, 1, fc=handle.get_color(), alpha=alpha)
         LinePlot._add_legend_handle(self, handle, label, index=index)
 


### PR DESCRIPTION
Derived from #7636. Area plot sets incorrect `alpha` values to legend when `stacked=True`.
#### NG: Each areas are drawn with `alpha=1.0`, but legend has `alpha=0.5`

![figure_ng](https://cloud.githubusercontent.com/assets/1696302/3919509/643924e0-23a9-11e4-983d-23a16e9c01bc.png)
#### After fix

```
df = pd.DataFrame(np.random.rand(20, 5), columns=['A', 'B', 'C', 'D', 'E'])
df.plot(kind='area')
```

![figure_1](https://cloud.githubusercontent.com/assets/1696302/3919515/8b4ecf4e-23a9-11e4-926b-85101760882a.png)

```
# When alpha is specified
df.plot(kind='area', alpha=0.2)
```

![figure_2](https://cloud.githubusercontent.com/assets/1696302/3919516/8fc2c166-23a9-11e4-8ea6-b14479d6a72b.png)
