### PR TITLE
DOC: suppress warning + fix reshape example

### DIFF
--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -1476,6 +1476,7 @@ You can control the action of a chained assignment via the option ``mode.chained
 which can take the values ``['raise','warn',None]``, where showing a warning is the default.
 
 .. ipython:: python
+   :okwarning:
 
    dfb = DataFrame({'a' : ['one', 'one', 'two',
                            'three', 'two', 'one', 'six'],

--- a/doc/source/reshaping.rst
+++ b/doc/source/reshaping.rst
@@ -151,6 +151,15 @@ unstacks the **last level**:
    stacked.unstack(1)
    stacked.unstack(0)
 
+.. _reshaping.unstack_by_name:
+
+If the indexes have names, you can use the level names instead of specifying
+the level numbers:
+
+.. ipython:: python
+
+   stacked.unstack('second')
+
 Notice that the ``stack`` and ``unstack`` methods implicitly sort the index
 levels involved. Hence a call to ``stack`` and then ``unstack``, or viceversa,
 will result in a **sorted** copy of the original DataFrame or Series:
@@ -164,15 +173,6 @@ will result in a **sorted** copy of the original DataFrame or Series:
 
 while the above code will raise a ``TypeError`` if the call to ``sort`` is
 removed.
-
-.. _reshaping.unstack_by_name:
-
-If the indexes have names, you can use the level names instead of specifying
-the level numbers:
-
-.. ipython:: python
-
-   stacked.unstack('second')
 
 .. _reshaping.stack_multiple:
 
@@ -218,6 +218,8 @@ calling ``sortlevel``, of course). Here is a more complex example:
    columns = MultiIndex.from_tuples([('A', 'cat'), ('B', 'dog'),
                                      ('B', 'cat'), ('A', 'dog')],
                                     names=['exp', 'animal'])
+   index = MultiIndex.from_product([('bar', 'baz', 'foo', 'qux'), ('one', 'two')],
+                                   names=['first', 'second'])
    df = DataFrame(randn(8, 4), index=index, columns=columns)
    df2 = df.ix[[0, 1, 2, 4, 5, 7]]
    df2


### PR DESCRIPTION
https://github.com/pydata/pandas/commit/bc610104f96699ff73ce507e79b8be070f126454 defined new `index`, but the previous was still used in later example, and suppress SettingWIthCopyWarning from https://github.com/pydata/pandas/commit/70a17da4003af0b1882deb5bcb28e188335fb9dd
