### PR TITLE
DOC: Fixing 'chunksize' parameter name typo io.rst

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -2722,7 +2722,7 @@ The default is 50,000 rows returned in a chunk.
 
    .. code-block:: python
 
-      for df in read_hdf('store.h5','df', chunsize=3):
+      for df in read_hdf('store.h5','df', chunksize=3):
           print(df)
 
 Note, that the chunksize keyword applies to the **source** rows. So if you


### PR DESCRIPTION
Fixing an error in the 'chunksize' parameter name for the io doc.  With the typo (parameter called 'chunsize'), the sample code from the documentation fails silently / confusingly - returns an iterator over individual dataframe elements rather than dataframe chunks.
