### PR TITLE
API: Timetamp.tz_localize and tz_convert raises TypeError rathar

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -172,7 +172,7 @@ API changes
 
 - ``DataFrame.tz_localize`` and ``DataFrame.tz_convert`` now accepts an optional ``level`` argument
   for localizing a specific level of a MultiIndex (:issue:`7846`)
-
+- ``Timestamp.tz_localize`` and ``Timestamp.tz_convert`` now raise ``TypeError`` in error cases, rather than ``Exception`` (:issue:`8025`)
 - ``Timestamp.__repr__`` displays ``dateutil.tz.tzoffset`` info (:issue:`7907`)
 - ``merge``, ``DataFrame.merge``, and ``ordered_merge`` now return the same type
   as the ``left`` argument.  (:issue:`7737`)

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -233,6 +233,15 @@ class TestTimestamp(tm.TestCase):
         self.assertEqual(conv.nanosecond, 5)
         self.assertEqual(conv.hour, 19)
 
+        # GH 8025
+        with tm.assertRaisesRegexp(TypeError, 'Cannot localize tz-aware Timestamp, use '
+                                   'tz_convert for conversions'):
+            Timestamp('2011-01-01' ,tz='US/Eastern').tz_localize('Asia/Tokyo')
+
+        with tm.assertRaisesRegexp(TypeError, 'Cannot convert tz-naive Timestamp, use '
+                            'tz_localize to localize'):
+            Timestamp('2011-01-01').tz_convert('Asia/Tokyo')
+
     def test_tz_localize_roundtrip(self):
         for tz in ['UTC', 'Asia/Tokyo', 'US/Eastern', 'dateutil/US/Pacific']:
             for t in ['2014-02-01 09:00', '2014-07-08 09:00', '2014-11-01 17:00',
@@ -241,7 +250,7 @@ class TestTimestamp(tm.TestCase):
                 localized = ts.tz_localize(tz)
                 self.assertEqual(localized, Timestamp(t, tz=tz))
 
-                with tm.assertRaises(Exception):
+                with tm.assertRaises(TypeError):
                     localized.tz_localize(tz)
 
                 reset = localized.tz_localize(None)

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -388,7 +388,7 @@ class Timestamp(_Timestamp):
                 value = tz_convert_single(self.value, 'UTC', self.tz)
                 return Timestamp(value, tz=None)
             else:
-                raise Exception('Cannot localize tz-aware Timestamp, use '
+                raise TypeError('Cannot localize tz-aware Timestamp, use '
                                 'tz_convert for conversions')
 
     def tz_convert(self, tz):
@@ -408,7 +408,7 @@ class Timestamp(_Timestamp):
         """
         if self.tzinfo is None:
             # tz naive, use tz_localize
-            raise Exception('Cannot convert tz-naive Timestamp, use '
+            raise TypeError('Cannot convert tz-naive Timestamp, use '
                             'tz_localize to localize')
         else:
             # Same UTC timestamp, different time zone


### PR DESCRIPTION
Closes #8025.
