### PR TITLE
BUG: Don't call np.roll on empty arrays.

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -389,7 +389,7 @@ Enhancements
 
 
 
-
+- Bug in ``DataFrame.shift`` where empty columns would throw ``ZeroDivisionError`` on numpy 1.7 (:issue:`8019`)
 
 
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -817,7 +817,10 @@ class Block(PandasObject):
         if f_ordered:
             new_values = new_values.T
             axis = new_values.ndim - axis - 1
-        new_values = np.roll(new_values, periods, axis=axis)
+
+        if np.prod(new_values.shape):
+            new_values = np.roll(new_values, periods, axis=axis)
+
         axis_indexer = [ slice(None) ] * self.ndim
         if periods > 0:
             axis_indexer[axis] = slice(None,periods)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -9610,6 +9610,13 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                        columns=['high', 'low'])
         assert_frame_equal(rs, xp)
 
+    def test_shift_empty(self):
+        # Regression test for #8019
+        df = DataFrame({'foo': []})
+        rs = df.shift(-1)
+
+        assert_frame_equal(df, rs)
+
     def test_tshift(self):
         # PeriodIndex
         ps = tm.makePeriodFrame()


### PR DESCRIPTION
On some versions of numpy (such as 1.7, but not 1.8), this throws a
ZeroDivisionError.

Fixes #8019.
