### PR TITLE
BUG: stack with datetimes

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -548,8 +548,7 @@ Bug Fixes
 - Bug in ``read_html`` where ``bytes`` objects were not tested for in
   ``_read`` (:issue:`7927`).
 
-
-
+- Bug in ``DataFrame.stack()`` when one of the column levels was a datelike (:issue: `8039`)
 
 
 

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -601,7 +601,7 @@ def _stack_multi_columns(frame, level=-1, dropna=True):
     # tuple list excluding level for grouping columns
     if len(frame.columns.levels) > 2:
         tuples = list(zip(*[
-            lev.values.take(lab) for lev, lab in
+            lev.take(lab) for lev, lab in
             zip(this.columns.levels[:-1], this.columns.labels[:-1])
         ]))
         unique_groups = [key for key, _ in itertools.groupby(tuples)]

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -11857,6 +11857,17 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         with tm.assertRaises(ValueError):
             df.T.stack('c1')
 
+    def test_stack_datetime_column_multiIndex(self):
+        # GH 8039
+        t = datetime(2014, 1, 1)
+        df = DataFrame([1, 2, 3, 4], columns=MultiIndex.from_tuples([(t, 'A', 'B')]))
+        result = df.stack()
+
+        eidx = MultiIndex.from_product([(0, 1, 2, 3), ('B',)])
+        ecols = MultiIndex.from_tuples([(t, 'A')])
+        expected = DataFrame([1, 2, 3, 4], index=eidx, columns=ecols)
+        assert_frame_equal(result, expected)
+
     def test_repr_with_mi_nat(self):
         df = DataFrame({'X': [1, 2]},
                        index=[[pd.NaT, pd.Timestamp('20130101')], ['a', 'b']])


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/8039

The only change I made was to select from the MultiIndex itself, rather than the underlying `.values` attribute. The test set passed but I want to look at this a bit more closely to make sure everything is ok.
