### PR TITLE
Update README to use pydata instead of pystatsmodels google group

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,6 @@ has been under active development since then.
 Since pandas development is related to a number of other scientific
 Python projects, questions are welcome on the scipy-user mailing
 list. Specialized discussions or design issues should take place on
-the pystatsmodels mailing list / Google group, where
-``scikits.statsmodels`` and other libraries will also be discussed:
+the PyData mailing list / Google group:
 
-http://groups.google.com/group/pystatsmodels
+https://groups.google.com/forum/#!forum/pydata


### PR DESCRIPTION
I'm pretty sure PyData is the main mailing list for pandas now, e.g., as seen on the website:
http://pandas.pydata.org/community.html
