### PR TITLE
BUG: Bug in DataFrameGroupby.transform when transforming with a passed non-sorted key (GH8046)

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -465,7 +465,7 @@ Bug Fixes
   when matching block and manager items, when there's only one block there's no ambiguity (:issue:`7794`)
 
 - Bug in HDFStore iteration when passing a where (:issue:`8014`)
-
+- Bug in DataFrameGroupby.transform when transforming with a passed non-sorted key (:issue:`8046`)
 - Bug in repeated timeseries line and area plot may result in ``ValueError`` or incorrect kind (:issue:`7733`)
 
 


### PR DESCRIPTION
closes #8046 
