### PR TITLE
TST: Fix tseries.converter test for MPL1.4

### DIFF
--- a/pandas/tseries/tests/test_converter.py
+++ b/pandas/tseries/tests/test_converter.py
@@ -74,7 +74,7 @@ class TestDateTimeConverter(tm.TestCase):
         for freq in ('B', 'L', 'S'):
             dateindex = tm.makeDateIndex(k = 10, freq = freq)
             rs = self.dtc.convert(dateindex, None, None)
-            xp = converter.dates.date2num(dateindex)
+            xp = converter.dates.date2num(dateindex._mpl_repr())
             np_assert_almost_equal(rs, xp, decimals)
 
     def test_resolution(self):


### PR DESCRIPTION
Closes #7233.

Other tests have no problem with MPL1.4.dev:
- tests\test_graphics.py
- tseries\tests\test_plotting.py
