### PR TITLE
BUG: rolling_count() and expanding_*() with zero-length args; rolling/expanding_apply with min_periods=0

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -104,9 +104,9 @@ API changes
   :func:`rolling_std`, :func:`rolling_var`, :func:`rolling_skew`, :func:`rolling_kurt`, and :func:`rolling_quantile`,
   :func:`rolling_cov`, :func:`rolling_corr`, :func:`rolling_corr_pairwise`,
   :func:`rolling_window`, and :func:`rolling_apply` with ``center=True`` previously would return a result of the same
-  structure as the input ``arg`` with ``NaN``s in the final ``(window-1)/2`` entries.
+  structure as the input ``arg`` with ``NaN`` in the final ``(window-1)/2`` entries.
   Now the final ``(window-1)/2`` entries of the result are calculated as if the input ``arg`` were followed
-  by ``(window-1)/2`` ``NaN``s. (:issue:`7925`)
+  by ``(window-1)/2`` ``NaN`` values. (:issue:`7925`)
 
   Prior behavior (note final value is ``NaN``):
 
@@ -556,8 +556,8 @@ Bug Fixes
   returning results with columns sorted by name and producing an error for non-unique columns;
   now handles non-unique columns and returns columns in original order
   (except for the case of two DataFrames with ``pairwise=False``, where behavior is unchanged) (:issue:`7542`)
-
-
+- Bug in :func:`rolling_count` and ``expanding_*`` functions unnecessarily producing error message for zero-length data (:issue:`8056`)
+- Bug in :func:`rolling_apply` and :func:`expanding_apply`` interpreting ``min_periods=0`` as ``min_periods=1 (:issue:`8080`)
 - Bug in ``DataFrame.plot`` and ``Series.plot`` may ignore ``rot`` and ``fontsize`` keywords (:issue:`7844`)
 
 

--- a/pandas/algos.pyx
+++ b/pandas/algos.pyx
@@ -712,17 +712,15 @@ def rank_2d_generic(object in_arr, axis=0, ties_method='average',
 #
 # -
 
-def _check_minp(win, minp, N):
+def _check_minp(win, minp, N, floor=1):
     if minp > win:
         raise ValueError('min_periods (%d) must be <= window (%d)'
                         % (minp, win))
     elif minp > N:
         minp = N + 1
-    elif minp == 0:
-        minp = 1
     elif minp < 0:
         raise ValueError('min_periods must be >= 0')
-    return minp
+    return max(minp, floor)
 
 # original C implementation by N. Devillard.
 # This code in public domain.
@@ -1766,7 +1764,7 @@ def roll_generic(ndarray[float64_t, cast=True] input, int win,
     if n == 0:
         return input
 
-    minp = _check_minp(win, minp, n)
+    minp = _check_minp(win, minp, n, floor=0)
     output = np.empty(n, dtype=float)
     counts = roll_sum(np.isfinite(input).astype(float), win, minp)
 


### PR DESCRIPTION
Closes https://github.com/pydata/pandas/issues/8056
Closes https://github.com/pydata/pandas/issues/8080
