### PR TITLE
ENH: improve datetime string parsing with CustomBusinessDay

### DIFF
--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -603,7 +603,7 @@ class CustomBusinessDay(BusinessDay):
             i8 = tslib.pydt_to_i8(dt)
             dt = tslib.tz_convert_single(i8, 'UTC', dt.tzinfo)
             dt = Timestamp(dt)
-        dt = np.datetime64(dt)
+        dt = np.datetime64(to_datetime(dt))
         if dt.dtype.name != dtype:
             dt = dt.astype(dtype)
         return dt

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -815,6 +815,14 @@ class TestCustomBusinessDay(Base):
             rs = dt + tday
             self.assertEqual(rs, xp)
 
+        # test ability to do date parsing
+        holidays = ['5/13/2014', '20140514', '2014/05/15']
+        tday = CDay(holidays=holidays)
+        dt = datetime(2014, 5, 12)
+        xp = datetime(2014, 5, 16)
+        rs = dt + tday
+        self.assertEqual(rs, xp)
+
     def test_weekmask(self):
         weekmask_saudi = 'Sat Sun Mon Tue Wed'  # Thu-Fri Weekend
         weekmask_uae = '1111001'                # Fri-Sat Weekend


### PR DESCRIPTION
Currently CustomBusinessDay requires a strict format for holiday definition

```
CustomBusinessDay(holidays=['2014-05-12'])
```

but the following would raise a ValueError:

```
CustomBusinessDay(holidays=['5/12/2014'])
```

this PR makes the date parsing easier and adds a unit test
