### PR TITLE
Added chunksize argument to to_sql

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -3267,6 +3267,12 @@ the database using :func:`~pandas.DataFrame.to_sql`.
 
     data.to_sql('data', engine)
 
+With some databases, writing large DataFrames can result in errors due to packet size limitations being exceeded. This can be avoided by setting the ``chunksize`` parameter when calling ``to_sql``.  For example, the following writes ``data`` to the database in batches of 1000 rows at a time:
+
+.. ipython:: python
+
+    data.to_sql('data', engine, chunksize=1000)
+
 .. note::
 
     Due to the limited support for timedelta's in the different database

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -425,6 +425,9 @@ Known Issues
 
 Enhancements
 ~~~~~~~~~~~~
+
+- Added support for a ``chunksize`` parameter to ``to_sql`` function.  This allows DataFrame to be written in chunks and avoid packet-size overflow errors (:issue:`8062`)
+
 - Added support for bool, uint8, uint16 and uint32 datatypes in ``to_stata`` (:issue:`7097`, :issue:`7365`)
 
 - Added ``layout`` keyword to ``DataFrame.plot`` (:issue:`6667`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -916,7 +916,7 @@ class NDFrame(PandasObject):
         return packers.to_msgpack(path_or_buf, self, **kwargs)
 
     def to_sql(self, name, con, flavor='sqlite', if_exists='fail', index=True,
-               index_label=None):
+               index_label=None, chunksize=None):
         """
         Write records stored in a DataFrame to a SQL database.
 
@@ -942,12 +942,15 @@ class NDFrame(PandasObject):
             Column label for index column(s). If None is given (default) and
             `index` is True, then the index names are used.
             A sequence should be given if the DataFrame uses MultiIndex.
+        chunksize : int, default None
+            If not None, then rows will be written in batches of this size at a 
+            time.  If None, all rows will be written at once.
 
         """
         from pandas.io import sql
         sql.to_sql(
             self, name, con, flavor=flavor, if_exists=if_exists, index=index,
-            index_label=index_label)
+            index_label=index_label, chunksize=chunksize)
 
     def to_pickle(self, path):
         """

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -455,6 +455,14 @@ class _TestSQLApi(PandasSQLTest):
         result.index.name = None
         tm.assert_frame_equal(result, self.test_frame1)
 
+    def test_roundtrip_chunksize(self):
+        sql.to_sql(self.test_frame1, 'test_frame_roundtrip', con=self.conn, 
+            index=False, flavor='sqlite', chunksize=2)
+        result = sql.read_sql_query(
+            'SELECT * FROM test_frame_roundtrip',
+            con=self.conn)
+        tm.assert_frame_equal(result, self.test_frame1)        
+
     def test_execute_sql(self):
         # drop_sql = "DROP TABLE IF EXISTS test"  # should already be done
         iris_results = sql.execute("SELECT * FROM iris", con=self.conn)


### PR DESCRIPTION
Large dataframes may fail to write to a database in one go due to packet size errors .  This add a `chunksize` parameter which will write the dataframe to the database in batches.  See https://github.com/pydata/pandas/issues/7347 .

Notice that there is quite a bit of code duplication between the SQLAlchemy and legacy APIs. This could be factored out if desired at the cost of a few private methods.

Closes #7347
