### PR TITLE
Fix bdist_wheel. Add Tag information to WHEEL dist info.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -392,6 +392,20 @@ cmdclass = {'clean': CleanCommand,
             'build': build,
             'sdist': CheckSDist}
 
+try:
+    from wheel.bdist_wheel import bdist_wheel
+
+    class BdistWheel(bdist_wheel):
+        def get_tag(self):
+            tag = bdist_wheel.get_tag(self)
+            repl = 'macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64'
+            if tag[2] == 'macosx_10_6_intel':
+                tag = (tag[0], tag[1], repl)
+            return tag
+    cmdclass['bdist_wheel'] = BdistWheel
+except ImportError:
+    pass
+
 if cython:
     suffix = '.pyx'
     cmdclass['build_ext'] = CheckingBuildExt


### PR DESCRIPTION
The wheel build with https://github.com/MacPython/pandas-wheels

```
# file: pandas-0.14.1.dist-info/WHEEL
Wheel-Version: 1.0
Generator: bdist_wheel (0.24.0)
Root-Is-Purelib: false
Tag: cp27-none-macosx_10_6_intel
```

Although it was renamed to `macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64`, the real
tag didn't change.

This patch would fix the `Tag` like what I did in [mistune](https://github.com/lepture/mistune)

```
# file: mistune-0.4.dist-info/WHEEL
Wheel-Version: 1.0
Generator: bdist_wheel (0.24.0)
Root-Is-Purelib: false
Tag: cp27-none-macosx_10_6_intel
Tag: cp27-none-macosx_10_9_intel
Tag: cp27-none-macosx_10_9_x86_64
```

Related: http://lepture.com/en/2014/python-on-a-hard-wheel
