### PR TITLE
ENH: add support for datetime.date/time in to_sql (GH6932)

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -427,6 +427,7 @@ Enhancements
 ~~~~~~~~~~~~
 
 - Added support for a ``chunksize`` parameter to ``to_sql`` function.  This allows DataFrame to be written in chunks and avoid packet-size overflow errors (:issue:`8062`)
+- Added support for writing ``datetime.date`` and ``datetime.time`` object columns with ``to_sql`` (:issue:`6932`).
 
 - Added support for bool, uint8, uint16 and uint32 datatypes in ``to_stata`` (:issue:`7097`, :issue:`7365`)
 


### PR DESCRIPTION
Closes #6932

Support for writing `datetime.date` and `datetime.time` object columns with `to_sql`.

Works nicely for the sqlalchemy mode, for sqlite fallback it writes OK for `datetime.date`, but comes back as object strings (this is also the case for datetime)

Remaining question:
- when reading the data back in `TIME` columns are converted back to `datetime.time`, but `DATE` columns are converted to `datetime64` and not `datetime.date`. Is this OK? Or better try to convert to `datetime.date`?
- `datetime.time` does not work with sqlite fallback for some reason (`datetime.date` does)
