### PR TITLE
BUG: pivot_table raises KeyError with nameless index and columns

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -628,7 +628,7 @@ Bug Fixes
 
 
 
-
+- Bug in ``pivot_table`` performed with nameless ``index`` and ``columns`` raises ``KeyError`` (:issue:`8103`)
 
 
 

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -116,7 +116,7 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
 
     table = agged
     if table.index.nlevels > 1:
-        to_unstack = [agged.index.names[i]
+        to_unstack = [agged.index.names[i] or i
                       for i in range(len(index), len(keys))]
         table = agged.unstack(to_unstack)
 

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -527,6 +527,50 @@ class TestPivotTable(tm.TestCase):
                              aggfunc=[np.sum, np.mean])
         tm.assert_frame_equal(result, expected)
 
+    def test_pivot_dtaccessor(self):
+        # GH 8103
+        dates1 = ['2011-07-19 07:00:00', '2011-07-19 08:00:00', '2011-07-19 09:00:00',
+                  '2011-07-19 07:00:00', '2011-07-19 08:00:00', '2011-07-19 09:00:00']
+        dates2 = ['2013-01-01 15:00:00', '2013-01-01 15:00:00', '2013-01-01 15:00:00',
+                  '2013-02-01 15:00:00', '2013-02-01 15:00:00', '2013-02-01 15:00:00']
+        df = DataFrame({'label': ['a', 'a', 'a', 'b', 'b', 'b'],
+                        'dt1': dates1, 'dt2': dates2,
+                        'value1': np.arange(6,dtype='int64'), 'value2': [1, 2] * 3})
+        df['dt1'] = df['dt1'].apply(lambda d: pd.Timestamp(d))
+        df['dt2'] = df['dt2'].apply(lambda d: pd.Timestamp(d))
+
+        result = pivot_table(df, index='label', columns=df['dt1'].dt.hour,
+                             values='value1')
+
+        exp_idx = Index(['a', 'b'], name='label')
+        expected = DataFrame({7: [0, 3], 8: [1, 4], 9:[2, 5]},
+                             index=exp_idx, columns=[7, 8, 9])
+        tm.assert_frame_equal(result, expected)
+
+        result = pivot_table(df, index=df['dt2'].dt.month, columns=df['dt1'].dt.hour,
+                             values='value1')
+
+        expected = DataFrame({7: [0, 3], 8: [1, 4], 9:[2, 5]},
+                             index=[1, 2], columns=[7, 8, 9])
+        tm.assert_frame_equal(result, expected)
+
+        result = pivot_table(df, index=df['dt2'].dt.year,
+                             columns=[df['dt1'].dt.hour, df['dt2'].dt.month],
+                             values='value1')
+
+        exp_col = MultiIndex.from_arrays([[7, 7, 8, 8, 9, 9], [1, 2] * 3])
+        expected = DataFrame(np.array([[0, 3, 1, 4, 2, 5]]),
+                             index=[2013], columns=exp_col)
+        tm.assert_frame_equal(result, expected)
+
+        result = pivot_table(df, index=np.array(['X', 'X', 'X', 'X', 'Y', 'Y']),
+                             columns=[df['dt1'].dt.hour, df['dt2'].dt.month],
+                             values='value1')
+        expected = DataFrame(np.array([[0, 3, 1, np.nan, 2, np.nan],
+                                       [np.nan, np.nan, np.nan, 4, np.nan, 5]]),
+                             index=['X', 'Y'], columns=exp_col)
+        tm.assert_frame_equal(result, expected)
+
 
 class TestCrosstab(tm.TestCase):
 


### PR DESCRIPTION
`pivot_table` raises `KeyError` when args passed to `index` and `columns` don't have `name` attribute. The fix looks especially useful when pivotting by `dt` accessor.

```
df = pd.DataFrame({'dt1': [datetime.datetime(2011, 1, 1), datetime.datetime(2011, 2, 1),
                           datetime.datetime(2011, 3, 1), datetime.datetime(2011, 4, 1),
                           datetime.datetime(2011, 5, 1), datetime.datetime(2012, 1, 1),
                           datetime.datetime(2012, 2, 1), datetime.datetime(2012, 3, 1),
                           datetime.datetime(2012, 4, 1)],
                   'col1': 'A A A B B B C C C'.split(),
                   'val1': [1, 2, 3, 4, 5, 6, 7, 8, 9]})

pd.pivot_table(df, index=df['dt1'].dt.month, columns=df['dt1'].dt.year, values='val1'))
# KeyError: 'Level None not found'
```
### After fix

```
pd.pivot_table(df, index=df['dt1'].dt.month, columns=df['dt1'].dt.year, values='val1'))
#    2011  2012
#1     1     6
#2     2     7
#3     3     8
#4     4     9
#5     5   NaN
```
