### PR TITLE
TST: Moving testing method outside of TestCase

### DIFF
--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -94,9 +94,7 @@ class TestCase(unittest.TestCase):
 
         If the expected array includes `np.nan` use `assert_numpy_array_equivalent(...)`.
         """
-        if np.array_equal(np_array, assert_equal):
-            return
-        raise AssertionError('{0} is not equal to {1}.'.format(np_array, assert_equal))
+        return assert_numpy_array_equal(np_array, assert_equal)
 
     def round_trip_pickle(self, obj, path=None):
         if path is None:
@@ -585,6 +583,19 @@ def isiterable(obj):
 
 def is_sorted(seq):
     return assert_almost_equal(seq, np.sort(np.array(seq)))
+
+def assert_numpy_array_equal(np_array, assert_equal):
+    """Checks that 'np_array' is equal to 'assert_equal'
+
+    Note that the expected array should not contain `np.nan`! Two numpy arrays are equal if all
+    elements are equal, which is not possible if `np.nan` is such an element!
+
+    If the expected array includes `np.nan` use `assert_numpy_array_equivalent(...)`.
+    """
+    if np.array_equal(np_array, assert_equal):
+        return
+    raise AssertionError('{0} is not equal to {1}.'.format(np_array, assert_equal))
+
 
 # This could be refactored to use the NDFrame.equals method
 def assert_series_equal(left, right, check_dtype=True,

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -113,9 +113,8 @@ class TestCase(unittest.TestCase):
         similar to `assert_numpy_array_equal()`. If the expected array includes `np.nan` use this
         function.
         """
-        if array_equivalent(np_array, assert_equal, strict_nan=strict_nan):
-            return
-        raise AssertionError('{0} is not equivalent to {1}.'.format(np_array, assert_equal))
+        return assert_numpy_array_equivalent(np_array, assert_equal, strict_nan)
+
 
     def assertIs(self, first, second, msg=''):
         """Checks that 'first' is 'second'"""
@@ -595,6 +594,21 @@ def assert_numpy_array_equal(np_array, assert_equal):
     if np.array_equal(np_array, assert_equal):
         return
     raise AssertionError('{0} is not equal to {1}.'.format(np_array, assert_equal))
+
+
+def assert_numpy_array_equivalent(np_array, assert_equal, strict_nan=False):
+    """Checks that 'np_array' is equivalent to 'assert_equal'
+
+    Two numpy arrays are equivalent if the arrays have equal non-NaN elements, and
+    `np.nan` in corresponding locations.
+
+    If the the expected array does not contain `np.nan` `assert_numpy_array_equivalent` is the
+    similar to `assert_numpy_array_equal()`. If the expected array includes `np.nan` use this
+    function.
+    """
+    if array_equivalent(np_array, assert_equal, strict_nan=strict_nan):
+        return True
+    raise AssertionError('{0} is not equivalent to {1}.'.format(np_array, assert_equal))
 
 
 # This could be refactored to use the NDFrame.equals method


### PR DESCRIPTION
Make assert_numpy_array_equal available without subclassing TestCase; see #8023
