### PR TITLE
DOC: setuptools is a required runtime dependency

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -251,6 +251,7 @@ Dependencies
   * `python-dateutil <http://labix.org/python-dateutil>`__ 1.5
   * `pytz <http://pytz.sourceforge.net/>`__
      * Needed for time zone support
+  * `setuptools <https://pypi.python.org/pypi/setuptools>`__
 
 .. _install.recommended_dependencies:
 


### PR DESCRIPTION
Without setuptools pandas fails to import at https://github.com/pydata/pandas/blob/master/pandas/io/gbq.py#L9
