### PR TITLE
ER: clarify import error message of BeautifulSoup (read_html)

### DIFF
--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -645,9 +645,9 @@ def _parser_dispatch(flavor):
 
     if flavor in ('bs4', 'html5lib'):
         if not _HAS_HTML5LIB:
-            raise ImportError("html5lib not found please install it")
+            raise ImportError("html5lib not found, please install it")
         if not _HAS_BS4:
-            raise ImportError("bs4 not found please install it")
+            raise ImportError("BeautifulSoup4 (bs4) not found, please install it")
         if bs4.__version__ == LooseVersion('4.2.0'):
             raise ValueError("You're using a version"
                              " of BeautifulSoup4 (4.2.0) that has been"
@@ -658,7 +658,7 @@ def _parser_dispatch(flavor):
                              " and later releases will work.")
     else:
         if not _HAS_LXML:
-            raise ImportError("lxml not found please install it")
+            raise ImportError("lxml not found, please install it")
     return _valid_parsers[flavor]
 
 


### PR DESCRIPTION
You still have to install it with pip/conda as BeautifulSoup4 and not bs4, so I think this is a bit more clear.

@cpcloud 
