### PR TITLE
BUG: fixed df.info() output missing new line

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -349,6 +349,8 @@ API changes
 
 - The Index set operations ``+`` and ``-`` were deprecated in order to provide these for numeric type operations on certain index types. ``+`` can be replace by ``.union()`` or ``|``, and ``-`` by ``.difference()``. Further the method name ``Index.diff()`` is deprecated and can be replaced by ``Index.difference()``
 
+- ``DataFrame.info()`` now ends its output with a newline character (:issue:`8114`)
+
 .. _whatsnew_0150.dt:
 
 .dt accessor

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1473,7 +1473,7 @@ class DataFrame(NDFrame):
 
         counts = self.get_dtype_counts()
         dtypes = ['%s(%d)' % k for k in sorted(compat.iteritems(counts))]
-        lines.append('dtypes: %s' % ', '.join(dtypes))
+        lines.append('dtypes: %s\n' % ', '.join(dtypes))
         _put_lines(buf, lines)
 
     def transpose(self):

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -43,7 +43,7 @@ def has_info_repr(df):
 def has_non_verbose_info_repr(df):
     has_info = has_info_repr(df)
     r = repr(df)
-    nv = len(r.split('\n')) == 4  # 1. <class>, 2. Index, 3. Columns, 4. dtype
+    nv = len(r.split('\n')) == 5  # 1. <class>, 2. Index, 3. Columns, 4. dtype, 5. trailing newline
     return has_info and nv
 
 def has_horizontally_truncated_repr(df):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -6493,7 +6493,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
     def test_info_max_cols(self):
         df = DataFrame(np.random.randn(10, 5))
-        for len_, verbose in [(4, None), (4, False), (9, True)]:
+        for len_, verbose in [(5, None), (5, False), (10, True)]:
         # For verbose always      ^ setting  ^ summarize ^ full output
             with option_context('max_info_columns', 4):
                 buf = StringIO()
@@ -6501,7 +6501,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                 res = buf.getvalue()
                 self.assertEqual(len(res.split('\n')), len_)
 
-        for len_, verbose in [(9, None), (4, False), (9, True)]:
+        for len_, verbose in [(10, None), (5, False), (10, True)]:
 
             # max_cols no exceeded
             with option_context('max_info_columns', 5):
@@ -6510,7 +6510,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                 res = buf.getvalue()
                 self.assertEqual(len(res.split('\n')), len_)
 
-        for len_, max_cols in [(9, 5), (4, 4)]:
+        for len_, max_cols in [(10, 5), (5, 4)]:
             # setting truncates
             with option_context('max_info_columns', 4):
                 buf = StringIO()


### PR DESCRIPTION
Had this minor bug working with pandas from the command line

```
>>> df.info()
<class 'pandas.core.frame.DataFrame'>
Int64Index: 891 entries, 0 to 890
Data columns (total 12 columns):
PassengerId    891 non-null int64
# ... etc
Embarked       889 non-null object
dtypes: float64(2), int64(5), object(5)>>>
```

(The interpreter prompt is not on a new line at the end.) 

This most likely went unnoticed because pandas users tend to work in the ipython interpreter.

I had to change 2 tests, because they were not expecting the extra newline (using split('\n') and counting strings to determine if output was valid) and I don't know if that is a big issue or not.
