### PR TITLE
BUG: broadcasting with numpy scalars (GH8116)

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -625,7 +625,7 @@ Bug Fixes
   ``_read`` (:issue:`7927`).
 
 - Bug in ``DataFrame.stack()`` when one of the column levels was a datelike (:issue:`8039`)
-
+- Bug in broadcasting numpy scalars with DataFrames (:issue:`8116`)
 
 
 

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -784,7 +784,7 @@ def _arith_method_FRAME(op, name, str_rep=None, default_axis='columns',
                 # casted = self._constructor_sliced(other, index=self.columns)
                 casted = pd.Series(other, index=self.columns)
             return self._combine_series(casted, na_op, fill_value, axis, level)
-        elif isinstance(other, np.ndarray):
+        elif isinstance(other, np.ndarray) and other.ndim:  # skips np scalar
             if other.ndim == 1:
                 if axis is not None and self._get_axis_name(axis) == 'index':
                     # casted = self._constructor_sliced(other,

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4712,6 +4712,19 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df = DataFrame({'a': ['a', None, 'b']})
         assert_frame_equal(df + df, DataFrame({'a': ['aa', np.nan, 'bb']}))
 
+    def test_ops_np_scalar(self):
+        vals, xs = np.random.rand(5, 3), [nan, 7, -23, 2.718, -3.14, np.inf]
+        f = lambda x: DataFrame(x, index=list('ABCDE'),
+                columns=['jim', 'joe', 'jolie'])
+
+        df = f(vals)
+
+        for x in xs:
+            assert_frame_equal(df / np.array(x), f(vals / x))
+            assert_frame_equal(np.array(x) * df, f(vals * x))
+            assert_frame_equal(df + np.array(x), f(vals + x))
+            assert_frame_equal(np.array(x) - df, f(x - vals))
+
     def test_operators_boolean(self):
 
         # GH 5808


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/8116
