### PR TITLE
Made line comments work with delim_whitespace and custom line terminator

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -638,6 +638,8 @@ Bug Fixes
 - Bug in ``Float64Index`` where ``iat`` and ``at`` were not testing and were
   failing (:issue:`8092`).
 
+- Bug in ``read_csv`` where line comments were not handled correctly given
+  a custom line terminator or ``delim_whitespace=True`` (:issue:`8122`).
 
 
 

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -2944,6 +2944,14 @@ A,B,C
                     [5., np.nan, 10.]]
         df = self.read_csv(StringIO(data), comment='#')
         tm.assert_almost_equal(df.values, expected)
+        # check with delim_whitespace=True
+        df = self.read_csv(StringIO(data.replace(',', ' ')), comment='#',
+                            delim_whitespace=True)
+        tm.assert_almost_equal(df.values, expected)
+        # check with custom line terminator
+        df = self.read_csv(StringIO(data.replace('\n', '*')), comment='#',
+                            lineterminator='*')
+        tm.assert_almost_equal(df.values, expected)
 
     def test_comment_skiprows(self):
         data = """# empty


### PR DESCRIPTION
This extends the functionality in #7582 to whitespace-delimited and custom line terminated parsing in the C reader (fixes #8115).
