### PR TITLE
DOC: Link to Python standard encodings from read_csv documentation

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -165,7 +165,9 @@ They can take a number of arguments:
   - ``converters``: a dictionary of functions for converting values in certain
     columns, where keys are either integers or column labels
   - ``encoding``: a string representing the encoding to use for decoding
-    unicode data, e.g. ``'utf-8``` or ``'latin-1'``.
+    unicode data, e.g. ``'utf-8``` or ``'latin-1'``. `Full list of Python
+    standard encodings
+    <https://docs.python.org/3/library/codecs.html#standard-encodings>`_
   - ``verbose``: show number of NA values inserted in non-numeric columns
   - ``squeeze``: if True then output with only one column is turned into Series
   - ``error_bad_lines``: if False then any lines causing an error will be skipped :ref:`bad lines <io.bad_lines>`
@@ -372,7 +374,9 @@ result in byte strings being decoded to unicode in the result:
    df['word'][1]
 
 Some formats which encode all characters as multiple bytes, like UTF-16, won't
-parse correctly at all without specifying the encoding.
+parse correctly at all without specifying the encoding. `Full list of Python
+standard encodings 
+<https://docs.python.org/3/library/codecs.html#standard-encodings>`_
 
 .. _io.index_col:
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -132,7 +132,9 @@ verbose : boolean, default False
 delimiter : string, default None
     Alternative argument name for sep. Regular expressions are accepted.
 encoding : string, default None
-    Encoding to use for UTF when reading/writing (ex. 'utf-8')
+    Encoding to use for UTF when reading/writing (ex. 'utf-8'). `List of Python
+    standard encodings
+    <https://docs.python.org/3/library/codecs.html#standard-encodings>`_
 squeeze : boolean, default False
     If the parsed data only contains one column then return a Series
 na_filter : boolean, default True


### PR DESCRIPTION
Trying to make it easier to access the list of encodings from the documentation. Adding this was suggested on this [SO question](http://stackoverflow.com/questions/25530142/list-of-pandas-read-csv-encoding-list/25530279#25530279).
