### PR TITLE
BUG: Fix bad axis limits when boxplotting with 'by' (#7528)

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -640,6 +640,8 @@ Bug Fixes
 
 - Bug in ``Float64Index`` where ``iat`` and ``at`` were not testing and were
   failing (:issue:`8092`).
+- Bug in ``DataFrame.boxplot()`` where y-limits were not set correctly when
+  producing multiple axes (:issue:`7528`, :issue:`5517`).
 
 - Bug in ``read_csv`` where line comments were not handled correctly given
   a custom line terminator or ``delim_whitespace=True`` (:issue:`8122`).

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1831,6 +1831,34 @@ class TestDataFramePlots(TestPlotBase):
         self._check_box_return_type(result, 'both')
 
     @slow
+    def test_boxplot_axis_limits(self):
+
+        def _check_ax_limits(col, ax):
+            y_min, y_max = ax.get_ylim()
+            self.assertLessEqual(y_min, col.min())
+            self.assertGreaterEqual(y_max, col.max())
+
+        df = self.hist_df.copy()
+        df['age'] = np.random.randint(1, 20, df.shape[0])
+        # One full row
+        height_ax, weight_ax = df.boxplot(['height', 'weight'], by='category')
+        _check_ax_limits(df['height'], height_ax)
+        _check_ax_limits(df['weight'], weight_ax)
+        self.assertEqual(weight_ax._sharey, height_ax)
+
+        # Two rows, one partial
+        p = df.boxplot(['height', 'weight', 'age'], by='category')
+        height_ax, weight_ax, age_ax = p[0, 0], p[0, 1], p[1, 0]
+        dummy_ax = p[1, 1]
+        _check_ax_limits(df['height'], height_ax)
+        _check_ax_limits(df['weight'], weight_ax)
+        _check_ax_limits(df['age'], age_ax)
+        self.assertEqual(weight_ax._sharey, height_ax)
+        self.assertEqual(age_ax._sharey, height_ax)
+        self.assertIsNone(dummy_ax._sharey)
+
+
+    @slow
     def test_kde_df(self):
         tm._skip_if_no_scipy()
         _skip_if_no_scipy_gaussian_kde()

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -3174,7 +3174,14 @@ def _subplots(naxes=None, sharex=False, sharey=False, squeeze=True,
     # Note off-by-one counting because add_subplot uses the MATLAB 1-based
     # convention.
     for i in range(1, nplots):
-        ax = fig.add_subplot(nrows, ncols, i + 1, **subplot_kw)
+        kwds = subplot_kw.copy()
+        # Set sharex and sharey to None for blank/dummy axes, these can
+        # interfere with proper axis limits on the visible axes if
+        # they share axes e.g. issue #7528
+        if i >= naxes:
+            kwds['sharex'] = None
+            kwds['sharey'] = None
+        ax = fig.add_subplot(nrows, ncols, i + 1, **kwds)
         axarr[i] = ax
 
     if nplots > 1:


### PR DESCRIPTION
closes #5517

The original bug involved the y-limits for boxplots being wrong when using `'by': turns out it has to do with the dummy axis that gets created when the plots don't fill the axis layout, e.g. when we're plotting 3 columns in a 2 by 2 layout.

The fix for this basically involves not setting the `sharey`/`sharex` argument for blank/dummy axes.

I've tried to test this in a couple of different ways, but some feedback on better ways to test would be good. In particular, I'm not sure if it's okay to check the `_sharey` attribute of the axes, given that it's private.
