### PR TITLE
BUG: Bug in multi-index slicing with various edge cases (GH8132)

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -532,6 +532,7 @@ Bug Fixes
 - Bug in adding and subtracting ``PeriodIndex`` with ``PeriodIndex`` raise ``TypeError`` (:issue:`7741`)
 - Bug in ``combine_first`` with ``PeriodIndex`` data raises ``TypeError`` (:issue:`3367`)
 - Bug in multi-index slicing with missing indexers (:issue:`7866`)
+- Bug in multi-index slicing with various edge cases (:issue:`8132`)
 - Regression in multi-index indexing with a non-scalar type object (:issue:`7914`)
 - Bug in Timestamp comparisons with ``==`` and dtype of int64 (:issue:`8058`)
 - Bug in pickles contains ``DateOffset`` may raise ``AttributeError`` when ``normalize`` attribute is reffered internally (:issue:`7748`)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -3927,9 +3927,21 @@ class MultiIndex(Index):
             # handle a slice, returnig a slice if we can
             # otherwise a boolean indexer
 
-            start = level_index.get_loc(key.start or  0)
-            stop  = level_index.get_loc(key.stop or len(level_index)-1)
-            step = key.step
+            try:
+                if key.start is not None:
+                    start = level_index.get_loc(key.start)
+                else:
+                    start = 0
+                if key.stop is not None:
+                    stop  = level_index.get_loc(key.stop)
+                else:
+                    stop = len(level_index)-1
+                step = key.step
+            except (KeyError):
+
+                # we have a partial slice (like looking up a partial date string)
+                start = stop = level_index.slice_indexer(key.start, key.stop, key.step)
+                step = start.step
 
             if isinstance(start,slice) or isinstance(stop,slice):
                 # we have a slice for start and/or stop


### PR DESCRIPTION
closes #8132 

```
# A1 - Works - Get all values under "A0" and "A1"
df1.loc[(slice('A1')),:]

                  VALUES
A  B  DATE              
A0 B0 2013-06-11      22
      2013-07-02      35
   B1 2013-07-09      14
      2013-07-30       9
   B2 2013-08-06       4
A1 B0 2013-06-11      40
      2013-07-02      18
   B1 2013-07-09       4
      2013-07-30       2
   B2 2013-08-06       5
```

```
# A2 - Works - Get all values from the start to "A2"
df1.loc[(slice('A2')),:]

                  VALUES
A  B  DATE              
A0 B0 2013-06-11      22
      2013-07-02      35
   B1 2013-07-09      14
      2013-07-30       9
   B2 2013-08-06       4
A1 B0 2013-06-11      40
      2013-07-02      18
   B1 2013-07-09       4
      2013-07-30       2
   B2 2013-08-06       5
A2 B0 2013-09-03       1
      2013-10-01       2
   B1 2013-07-09       3
      2013-08-06       4
   B2 2013-09-03       2
```

```
# A3 - Works - Get all values under "B1" or "B2"
df1.loc[(slice(None),slice('B1','B2')),:]

                  VALUES
A  B  DATE              
A0 B1 2013-07-09      14
      2013-07-30       9
   B2 2013-08-06       4
A1 B1 2013-07-09       4
      2013-07-30       2
   B2 2013-08-06       5
A2 B1 2013-07-09       3
      2013-08-06       4
   B2 2013-09-03       2
```

```
# A4 - Works - Get all values between 2013-07-02 and 2013-07-09
df1.loc[(slice(None),slice(None),slice('20130702','20130709')),:]

                  VALUES
A  B  DATE              
A0 B0 2013-07-02      35
   B1 2013-07-09      14
A1 B0 2013-07-02      18
   B1 2013-07-09       4
A2 B1 2013-07-09       3
```

```
# B1 -  Get all values in B0 that are also under A0, A1 and A2
df1.loc[(slice('A2'),slice('B0')),:]

                  VALUES
A  B  DATE              
A0 B0 2013-06-11      22
      2013-07-02      35
A1 B0 2013-06-11      40
      2013-07-02      18
A2 B0 2013-09-03       1
      2013-10-01       2
```

```
# B2 - Get all values in B0, B1 and B2 (similar to what #2 is doing for the As)
df1.loc[(slice(None),slice('B2')),:]

                 VALUES
A  B  DATE              
A0 B0 2013-06-11      22
      2013-07-02      35
   B1 2013-07-09      14
      2013-07-30       9
   B2 2013-08-06       4
A1 B0 2013-06-11      40
      2013-07-02      18
   B1 2013-07-09       4
      2013-07-30       2
   B2 2013-08-06       5
A2 B0 2013-09-03       1
      2013-10-01       2
   B1 2013-07-09       3
      2013-08-06       4
   B2 2013-09-03       2
```

```
# B3 - Get all values from B1 to B2 and up to 2013-08-06
df1.loc[(slice(None),slice('B1','B2'),slice('2013-08-06')),:]

                  VALUES
A  B  DATE              
A0 B1 2013-07-09      14
      2013-07-30       9
   B2 2013-08-06       4
A1 B1 2013-07-09       4
      2013-07-30       2
   B2 2013-08-06       5
A2 B1 2013-07-09       3
      2013-08-06       4
```

```
# B4 - Same as A4 but the start of the date slice is not a key.
df1.loc[(slice(None),slice(None),slice('20130701','20130709')),:]
                  VALUES
A  B  DATE              
A0 B0 2013-07-02      35
   B1 2013-07-09      14
A1 B0 2013-07-02      18
   B1 2013-07-09       4
A2 B1 2013-07-09       3
```
