### PR TITLE
ENH: let get_dummies take a DataFrame

### DIFF
--- a/doc/source/reshaping.rst
+++ b/doc/source/reshaping.rst
@@ -480,6 +480,49 @@ This function is often used along with discretization functions like ``cut``:
 
 See also :func:`Series.str.get_dummies <pandas.core.strings.StringMethods.get_dummies>`.
 
+.. versionadded:: 0.15.0
+
+:func:`get_dummies` also accepts a DataFrame. By default all categorical
+variables (categorical in the statistical sense,
+those with `object` or `categorical` dtype) are encoded as dummy variables.
+
+
+.. ipython:: python
+
+    df = pd.DataFrame({'A': ['a', 'b', 'a'], 'B': ['c', 'c', 'b'],
+                       'C': [1, 2, 3]})
+    pd.get_dummies(df)
+
+All non-object columns are included untouched in the output.
+
+You can control the columns that are encoded with the ``columns`` keyword.
+
+.. ipython:: python
+
+    pd.get_dummies(df, columns=['A'])
+
+Notice that the ``B`` column is still included in the output, it just hasn't
+been encoded. You can drop ``B`` before calling ``get_dummies`` if you don't
+want to include it in the output.
+
+As with the Series version, you can pass values for the ``prefix`` and
+``prefix_sep``. By default the column name is used as the prefix, and '_' as
+the prefix separator. You can specify ``prefix`` and ``prefix_sep`` in 3 ways
+
+- string: Use the same value for ``prefix`` or ``prefix_sep`` for each column
+  to be encoded
+- list: Must be the same length as the number of columns being encoded.
+- dict: Mapping column name to prefix
+
+.. ipython:: python
+
+    simple = pd.get_dummies(df, prefix='new_prefix')
+    simple
+    from_list = pd.get_dummies(df, prefix=['from_A', 'from_B'])
+    from_list
+    from_dict = pd.get_dummies(df, prefix={'B': 'from_B', 'A': 'from_A'})
+    from_dict
+
 Factorizing values
 ------------------
 

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -417,6 +417,9 @@ There are no prior version deprecations that are taking effect as of 0.15.0.
 Deprecations
 ~~~~~~~~~~~~
 
+The ``convert_dummies`` method has been deprecated in favor of
+``get_dummies``(:issue:`8140`)
+
 .. _whatsnew_0150.knownissues:
 
 Known Issues

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -461,7 +461,15 @@ Enhancements
 
 
 
+- The ``get_dummies`` method can now be used on DataFrames. By default only
+catagorical columns are encoded as 0's and 1's, while other columns are
+left untouched.
 
+  .. ipython:: python
+
+    df = pd.DataFrame({'A': ['a', 'b', 'a'], 'B': ['c', 'c', 'b'],
+                       'C': [1, 2, 3]})
+    pd.get_dummies(df)
 
 
 

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -979,6 +979,12 @@ def convert_dummies(data, cat_variables, prefix_sep='_'):
     -------
     dummies : DataFrame
     """
+    import warnings
+
+    warnings.warn("'convert_dummies' is deprecated and will be removed "
+                  "in a future release. Use 'get_dummies' instead.",
+                  FutureWarning)
+
     result = data.drop(cat_variables, axis=1)
     for variable in cat_variables:
         dummies = _get_dummies_1d(data[variable], prefix=variable,

--- a/pandas/tests/test_reshape.py
+++ b/pandas/tests/test_reshape.py
@@ -331,8 +331,9 @@ class TestConvertDummies(tm.TestCase):
                         'C': np.random.randn(8),
                         'D': np.random.randn(8)})
 
-        result = convert_dummies(df, ['A', 'B'])
-        result2 = convert_dummies(df, ['A', 'B'], prefix_sep='.')
+        with tm.assert_produces_warning(FutureWarning):
+            result = convert_dummies(df, ['A', 'B'])
+            result2 = convert_dummies(df, ['A', 'B'], prefix_sep='.')
 
         expected = DataFrame({'A_foo': [1, 0, 1, 0, 1, 0, 1, 1],
                               'A_bar': [0, 1, 0, 1, 0, 1, 0, 0],

--- a/pandas/tests/test_reshape.py
+++ b/pandas/tests/test_reshape.py
@@ -149,6 +149,11 @@ class TestMelt(tm.TestCase):
 
 
 class TestGetDummies(tm.TestCase):
+
+    def setUp(self):
+        self.df = DataFrame({'A': ['a', 'b', 'a'], 'B': ['b', 'b', 'c'],
+                             'C': [1, 2, 3]})
+
     def test_basic(self):
         s_list = list('abc')
         s_series = Series(s_list)
@@ -208,6 +213,114 @@ class TestGetDummies(tm.TestCase):
         exp = DataFrame({'letter_e': {0: 1.0, 1: 0.0, 2: 0.0},
                         u('letter_%s') % eacute: {0: 0.0, 1: 1.0, 2: 1.0}})
         assert_frame_equal(res, exp)
+
+    def test_dataframe_dummies_all_obj(self):
+        df = self.df[['A', 'B']]
+        result = get_dummies(df)
+        expected = DataFrame({'A_a': [1., 0, 1], 'A_b': [0., 1, 0],
+                              'B_b': [1., 1, 0], 'B_c': [0., 0, 1]})
+        assert_frame_equal(result, expected)
+
+    def test_dataframe_dummies_mix_default(self):
+        df = self.df
+        result = get_dummies(df)
+        expected = DataFrame({'C': [1, 2, 3], 'A_a': [1., 0, 1],
+                              'A_b': [0., 1, 0], 'B_b': [1., 1, 0],
+                              'B_c': [0., 0, 1]})
+        expected = expected[['C', 'A_a', 'A_b', 'B_b', 'B_c']]
+        assert_frame_equal(result, expected)
+
+    def test_dataframe_dummies_prefix_list(self):
+        prefixes = ['from_A', 'from_B']
+        df = DataFrame({'A': ['a', 'b', 'a'], 'B': ['b', 'b', 'c'],
+                        'C': [1, 2, 3]})
+        result = get_dummies(df, prefix=prefixes)
+        expected = DataFrame({'C': [1, 2, 3], 'from_A_a': [1., 0, 1],
+                              'from_A_b': [0., 1, 0], 'from_B_b': [1., 1, 0],
+                              'from_B_c': [0., 0, 1]})
+        expected = expected[['C', 'from_A_a', 'from_A_b', 'from_B_b',
+                             'from_B_c']]
+        assert_frame_equal(result, expected)
+
+    def test_datafrmae_dummies_prefix_str(self):
+        # not that you should do this...
+        df = self.df
+        result = get_dummies(df, prefix='bad')
+        expected = DataFrame([[1, 1., 0., 1., 0.],
+                              [2, 0., 1., 1., 0.],
+                              [3, 1., 0., 0., 1.]],
+                             columns=['C', 'bad_a', 'bad_b', 'bad_b', 'bad_c'])
+        assert_frame_equal(result, expected)
+
+    def test_dataframe_dummies_subset(self):
+        df = self.df
+        result = get_dummies(df, prefix=['from_A'],
+                             columns=['A'])
+        expected = DataFrame({'from_A_a': [1., 0, 1], 'from_A_b': [0., 1, 0],
+                              'B': ['b', 'b', 'c'], 'C': [1, 2, 3]})
+        assert_frame_equal(result, expected)
+
+    def test_dataframe_dummies_prefix_sep(self):
+        df = self.df
+        result = get_dummies(df, prefix_sep='..')
+        expected = DataFrame({'C': [1, 2, 3], 'A..a': [1., 0, 1],
+                              'A..b': [0., 1, 0], 'B..b': [1., 1, 0],
+                              'B..c': [0., 0, 1]})
+        expected = expected[['C', 'A..a', 'A..b', 'B..b', 'B..c']]
+        assert_frame_equal(result, expected)
+
+        result = get_dummies(df, prefix_sep=['..', '__'])
+        expected = expected.rename(columns={'B..b': 'B__b', 'B..c': 'B__c'})
+        assert_frame_equal(result, expected)
+
+        result = get_dummies(df, prefix_sep={'A': '..', 'B': '__'})
+        assert_frame_equal(result, expected)
+
+    def test_dataframe_dummies_prefix_bad_length(self):
+        with tm.assertRaises(ValueError):
+            get_dummies(self.df, prefix=['too few'])
+
+    def test_dataframe_dummies_prefix_sep_bad_length(self):
+        with tm.assertRaises(ValueError):
+            get_dummies(self.df, prefix_sep=['bad'])
+
+    def test_dataframe_dummies_prefix_dict(self):
+        prefixes = {'A': 'from_A', 'B': 'from_B'}
+        df = DataFrame({'A': ['a', 'b', 'a'], 'B': ['b', 'b', 'c'],
+                        'C': [1, 2, 3]})
+        result = get_dummies(df, prefix=prefixes)
+        expected = DataFrame({'from_A_a': [1., 0, 1], 'from_A_b': [0., 1, 0],
+                              'from_B_b': [1., 1, 0], 'from_B_c': [0., 0, 1],
+                              'C': [1, 2, 3]})
+        assert_frame_equal(result, expected)
+
+    def test_dataframe_dummies_with_na(self):
+        df = self.df
+        df.loc[3, :] = [np.nan, np.nan, np.nan]
+        result = get_dummies(df, dummy_na=True)
+        expected = DataFrame({'C': [1, 2, 3, np.nan], 'A_a': [1., 0, 1, 0],
+            'A_b': [0., 1, 0, 0], 'A_nan': [0., 0, 0, 1], 'B_b': [1., 1, 0, 0],
+            'B_c': [0., 0, 1, 0], 'B_nan': [0., 0, 0, 1]})
+        expected = expected[['C', 'A_a', 'A_b', 'A_nan', 'B_b', 'B_c',
+                             'B_nan']]
+        assert_frame_equal(result, expected)
+
+        result = get_dummies(df, dummy_na=False)
+        expected = expected[['C', 'A_a', 'A_b', 'B_b', 'B_c']]
+        assert_frame_equal(result, expected)
+
+    def test_dataframe_dummies_with_categorical(self):
+        df = self.df
+        df['cat'] = pd.Categorical(['x', 'y', 'y'])
+        result = get_dummies(df)
+        expected = DataFrame({'C': [1, 2, 3], 'A_a': [1., 0, 1],
+                              'A_b': [0., 1, 0], 'B_b': [1., 1, 0],
+                              'B_c': [0., 0, 1], 'cat_x': [1., 0, 0],
+                              'cat_y': [0., 1, 1]})
+        expected = expected[['C', 'A_a', 'A_b', 'B_b', 'B_c',
+                             'cat_x', 'cat_y']]
+        assert_frame_equal(result, expected)
+
 
 class TestConvertDummies(tm.TestCase):
     def test_convert_dummies(self):


### PR DESCRIPTION
Closes https://github.com/pydata/pandas/issues/8133

Thoughts? I encode every column with `object` dtype. You can control the ones that get encoded with `categorical_variables`. The encoded columns are `concat`ed to the columns that don't need encoding.

`prefix` and `prefix_sep` can be passed as a string, list, or dict mapping column names to strs.

``` python
In [1]: from pandas import *

In [2]: df = DataFrame({'A': ['a', 'b', 'a'], 'B': ['b', 'a', 'c'],
                        'C': [1, 2, 3]})

In [3]: df
Out[3]: 
   A  B  C
0  a  b  1
1  b  a  2
2  a  c  3

In [4]: get_dummies(df)
Out[4]: 
   C  A_a  A_b  B_a  B_b  B_c
0  1    1    0    0    1    0
1  2    0    1    1    0    0
2  3    1    0    0    0    1

In [5]: get_dummies(df, prefix=['from_A', 'from_B'])
Out[5]: 
   C  from_A_a  from_A_b  from_B_a  from_B_b  from_B_c
0  1         1         0         0         1         0
1  2         0         1         1         0         0
2  3         1         0         0         0         1

In [6]: get_dummies(df, prefix={"A": 'from_A', "B": 'from_B'})
Out[6]: 
   C  from_A_a  from_A_b  from_B_a  from_B_b  from_B_c
0  1         1         0         0         1         0
1  2         0         1         1         0         0
2  3         1         0         0         0         1

In [7]: get_dummies(df, prefix_sep='.')
Out[7]: 
   C  A.a  A.b  B.a  B.b  B.c
0  1    1    0    0    1    0
1  2    0    1    1    0    0
2  3    1    0    0    0    1

In [8]: get_dummies(df, prefix_sep='.', categorical_variables=['A'])
Out[8]: 
   B  C  A.a  A.b
0  b  1    1    0
1  a  2    0    1
2  c  3    1    0
```
