### PR TITLE
BUG: consistency between logical ops & type casts

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -650,4 +650,4 @@ Bug Fixes
 - Bug in accessing groups from a ``GroupBy`` when the original grouper
   was a tuple (:issue:`8121`).
 
-
+- Bug in logical operations of series and their consistency with type casts (:issue:`6528`)

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -636,10 +636,12 @@ def _bool_method_SERIES(op, name, str_rep):
         if isinstance(other, pd.Series):
             name = _maybe_match_name(self, other)
 
-            other = other.reindex_like(self).fillna(False).astype(bool)
-            return self._constructor(na_op(self.values, other.values),
+            left  = self.astype(bool).values
+            right = other.astype(bool).reindex_like(self)
+            right = right.fillna(False).values
+            return self._constructor(na_op(left, right),
                                      index=self.index,
-                                     name=name).fillna(False).astype(bool)
+                                     name=name)
         elif isinstance(other, pd.DataFrame):
             return NotImplemented
         else:

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4992,7 +4992,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # GH4947
         # bool comparisons should return bool
         result = d['a'] | d['b']
-        expected = Series([False, True])
+        expected = Series(np.logical_or(d['a'], d['b']), dtype='bool')
         assert_series_equal(result, expected)
 
         # GH4604, automatic casting here


### PR DESCRIPTION
Closes [#6528](https://github.com/pydata/pandas/issues/6528).
Currently series logical operations are bound to return a series with `dtype='bool'`. That being a good decision or not, it is good to have some internal consistency:

```
>>> a = pd.Series([nan, nan, nan])
>>> b = pd.Series([False, True, nan])
>>> a | b == b | a  # not symmetric
0     True
1    False
2     True
dtype: bool
>>> a & b == a.astype(bool) & b.astype(bool)  # not consistent w/ type casts
0     True
1    False
2    False
dtype: bool
```

With this patch, [all these tests pass.](https://github.com/pydata/pandas/pull/8151/files#diff-933180870dd152b775952fc54a99dba7R2371)
