### PR TITLE
BUG: map builtins min/max to numpy/cython versions

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -650,4 +650,4 @@ Bug Fixes
 - Bug in accessing groups from a ``GroupBy`` when the original grouper
   was a tuple (:issue:`8121`).
 
-
+- Bug in ``.agg`` and ``.apply`` where builtins max/min were not mapped to numpy/cythonized versions (:issue:`7722`)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -3618,12 +3618,16 @@ def _reorder_by_uniques(uniques, labels):
 
 
 _func_table = {
-    builtins.sum: np.sum
+    builtins.sum: np.sum,
+    builtins.max: np.max,
+    builtins.min: np.min
 }
 
 
 _cython_table = {
     builtins.sum: 'sum',
+    builtins.max: 'max',
+    builtins.min: 'min',
     np.sum: 'sum',
     np.mean: 'mean',
     np.prod: 'prod',

--- a/vb_suite/groupby.py
+++ b/vb_suite/groupby.py
@@ -474,3 +474,13 @@ df = DataFrame(np.random.randint(1, n / 10, (n, 3)),
 '''
 groupby_transform_multi_key3 = Benchmark(stmt, setup)
 groupby_transform_multi_key4 = Benchmark(stmt, setup + "df['jim'] = df['joe']")
+
+setup = common_setup + '''
+np.random.seed(27182)
+n = 100000
+df = DataFrame(np.random.randint(1, n / 100, (n, 3)),
+        columns=['jim', 'joe', 'jolie'])
+'''
+
+groupby_agg_builtins1 = Benchmark("df.groupby('jim').agg([sum, min, max])", setup)
+groupby_agg_builtins2 = Benchmark("df.groupby(['jim', 'joe']).agg([sum, min, max])", setup)


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/7722

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
groupby_agg_builtins2                        |  43.8553 | 2667.0587 |   0.0164 |
groupby_agg_builtins1                        |  11.9447 | 118.6290 |   0.1007 |
```

on master:

```
In [4]: np.random.seed(27182)

In [5]: n = 100000

In [6]: df = DataFrame(np.random.randint(1, n / 100, (n, 3)),
   ...:         columns=['jim', 'joe', 'jolie'])

In [7]: %timeit df.groupby('jim').agg([sum, min, max])
1 loops, best of 3: 204 ms per loop

In [8]: %timeit df.groupby(['jim', 'joe']).agg([sum, min, max])
1 loops, best of 3: 5.1 s per loop

In [9]: df.groupby(['jim']).apply(max).head()  # this is broken
Out[9]: 
jim
1      jolie
2      jolie
3      jolie
4      jolie
5      jolie
dtype: object
```

on branch:

```
In [9]: %timeit df.groupby('jim').agg([sum, min, max])
10 loops, best of 3: 20 ms per loop

In [10]: %timeit df.groupby(['jim', 'joe']).agg([sum, min, max])
10 loops, best of 3: 74.6 ms per loop

In [11]: df.groupby(['jim']).apply(max).head()
Out[11]: 
     jim  joe  jolie
jim                 
1      1  999    989
2      2  997    986
3      3  981    973
4      4  989    992
5      5  995    977
```
