### PR TITLE
counting sort instead of np.argsort in left outer join

### DIFF
--- a/pandas/src/join.pyx
+++ b/pandas/src/join.pyx
@@ -106,7 +106,7 @@ def left_outer_join(ndarray[int64_t] left, ndarray[int64_t] right,
     if not sort:  # if not asked to sort, revert to original order
         if len(left) == len(left_indexer):
             # no multiple matches for any row on the left
-            # this is a short-cut to avoid np.argsort;
+            # this is a short-cut to avoid groupsort_indexer
             # otherwise, the `else` path also works in this case
             if left_sorter.dtype != np.int_:
                 left_sorter = left_sorter.astype(np.int_)
@@ -114,7 +114,7 @@ def left_outer_join(ndarray[int64_t] left, ndarray[int64_t] right,
             rev = np.empty(len(left), dtype=np.int_)
             rev.put(left_sorter, np.arange(len(left)))
         else:
-            rev = np.argsort(left_indexer)
+            rev, _ = groupsort_indexer(left_indexer, len(left))
 
         right_indexer = right_indexer.take(rev)
         left_indexer = left_indexer.take(rev)

--- a/vb_suite/join_merge.py
+++ b/vb_suite/join_merge.py
@@ -237,3 +237,16 @@ temp = TimeSeries(1.0, index)
 join_non_unique_equal = Benchmark('fracofday * temp[fracofday.index]', setup,
                                    start_date=datetime(2013, 1, 1))
 
+
+setup = common_setup + '''
+np.random.seed(2718281)
+n = 50000
+
+left = DataFrame(np.random.randint(1, n/500, (n, 2)),
+        columns=['jim', 'joe'])
+
+right = DataFrame(np.random.randint(1, n/500, (n, 2)),
+        columns=['jolie', 'jolia']).set_index('jolie')
+'''
+
+left_outer_join_index = Benchmark("left.join(right, on='jim')", setup)


### PR DESCRIPTION
Previously I had submitted https://github.com/pydata/pandas/pull/7853. Given that we are sorting indexers, for performance reasons I should have used `groupsort_indexer` instead of `np.argsort`.

on master:

```
In [7]: np.random.seed(2718281)

In [8]: n = 50000

In [9]: left = DataFrame(np.random.randint(1, n/500, (n, 2)),
   ...:         columns=['jim', 'joe'])

In [10]: right = DataFrame(np.random.randint(1, n/500, (n, 2)),
   ....:         columns=['jolie', 'jolia']).set_index('jolie')

In [11]: %timeit left.join(right, on='jim')
1 loops, best of 3: 3.53 s per loop
```

on branch:

```
In [13]: %timeit left.join(right, on='jim')
1 loops, best of 3: 2.46 s per loop
```
