### PR TITLE
SQL: add warning for mismatch in provided and written table name (GH7815)

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -886,6 +886,12 @@ class PandasSQLAlchemy(PandasSQL):
             name, self, frame=frame, index=index, if_exists=if_exists,
             index_label=index_label, schema=schema)
         table.insert(chunksize)
+        # check for potentially case sensitivity issues (GH7815)
+        if name not in self.engine.table_names(schema=schema or self.meta.schema):
+            warnings.warn("The provided table name '{0}' is not found exactly "
+                          "as such in the database after writing the table, "
+                          "possibly due to case sensitivity issues. Consider "
+                          "using lower case table names.".format(name), UserWarning)
 
     @property
     def tables(self):

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -681,6 +681,19 @@ class TestSQLApi(_TestSQLApi):
             # Verify some things
             self.assertEqual(len(w), 0, "Warning triggered for other table")
 
+    def test_warning_case_insensitive_table_name(self):
+        # see GH7815.
+        # We can't test that this warning is triggered, a the database
+        # configuration would have to be altered. But here we test that
+        # the warning is certainly NOT triggered in a normal case.
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            # This should not trigger a Warning
+            self.test_frame1.to_sql('CaseSensitive', self.conn)
+            # Verify some things
+            self.assertEqual(len(w), 0, "Warning triggered for writing a table")
+
 
 class TestSQLLegacyApi(_TestSQLApi):
     """


### PR DESCRIPTION
Closes #7815

Adds a warning if the provided table name in `to_sql` and the actually used table name in the database do not match (eg converted to lower case due to case insensitivity settings of database, eg MySQL on Windows). When user is not aware of this, and keeps using the upper case table name, this leads to bugs in subsequent `to_sql` calls.

@maxgrenderjones 
