### PR TITLE
BUG: scatter with errorbar raises IndexError

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -650,6 +650,7 @@ Bug Fixes
 
 - Bug in ``pivot_table`` performed with nameless ``index`` and ``columns`` raises ``KeyError`` (:issue:`8103`)
 
+- Bug in ``DataFrame.plot(kind='scatter')`` draws points and errorbars with different colors when the color is specified by ``c`` keyword (:issue:`8081`)
 
 
 

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -349,7 +349,6 @@ class TestPlotBase(tm.TestCase):
         yerr : number
             expected number of y errorbar
         """
-
         axes = self._flatten_visible(axes)
         for ax in axes:
             containers = ax.containers
@@ -2805,11 +2804,27 @@ class TestDataFramePlots(TestPlotBase):
         self._check_has_errorbars(ax, xerr=0, yerr=0)
         ax = _check_plot_works(df.plot, kind='scatter', x='x', y='y', xerr=df_err)
         self._check_has_errorbars(ax, xerr=1, yerr=0)
+
         ax = _check_plot_works(df.plot, kind='scatter', x='x', y='y', yerr=df_err)
         self._check_has_errorbars(ax, xerr=0, yerr=1)
         ax = _check_plot_works(df.plot, kind='scatter', x='x', y='y',
                                xerr=df_err, yerr=df_err)
         self._check_has_errorbars(ax, xerr=1, yerr=1)
+
+        def _check_errorbar_color(containers, expected, has_err='has_xerr'):
+            errs = [c.lines[1][0] for c in ax.containers if getattr(c, has_err, False)]
+            self._check_colors(errs, linecolors=[expected] * len(errs))
+
+        # GH 8081
+        df = DataFrame(np.random.randn(10, 5), columns=['a', 'b', 'c', 'd', 'e'])
+        ax = df.plot(kind='scatter', x='a', y='b', xerr='d', yerr='e', c='red')
+        self._check_has_errorbars(ax, xerr=1, yerr=1)
+        _check_errorbar_color(ax.containers, 'red', has_err='has_xerr')
+        _check_errorbar_color(ax.containers, 'red', has_err='has_yerr')
+
+        ax = df.plot(kind='scatter', x='a', y='b', yerr='e', color='green')
+        self._check_has_errorbars(ax, xerr=0, yerr=1)
+        _check_errorbar_color(ax.containers, 'green', has_err='has_yerr')
 
 
 @tm.mplskip

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1394,15 +1394,13 @@ class ScatterPlot(MPLPlot):
             label = None
         scatter = ax.scatter(data[x].values, data[y].values, label=label,
                              **self.kwds)
-
         self._add_legend_handle(scatter, label)
 
         errors_x = self._get_errorbars(label=x, index=0, yerr=False)
-        errors_y = self._get_errorbars(label=y, index=1, xerr=False)
+        errors_y = self._get_errorbars(label=y, index=0, xerr=False)
         if len(errors_x) > 0 or len(errors_y) > 0:
             err_kwds = dict(errors_x, **errors_y)
-            if 'color' in self.kwds:
-                err_kwds['color'] = self.kwds['color']
+            err_kwds['ecolor'] = scatter.get_facecolor()[0]
             ax.errorbar(data[x].values, data[y].values, linestyle='none', **err_kwds)
 
     def _post_plot_logic(self):


### PR DESCRIPTION
Closes #8081.

Also fixes a color problem with `c` kw found in #7780. (But should work with single color. It looks `errorbar` doesn't accept multiple colors).
