### PR TITLE
API: kdeplot fails with NaNs.

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -667,3 +667,5 @@ Bug Fixes
 
 - Bug in accessing groups from a ``GroupBy`` when the original grouper
   was a tuple (:issue:`8121`).
+
+- Bug with kde plot and NaNs (:issue:`8182`)

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -746,6 +746,14 @@ class TestSeriesPlots(TestPlotBase):
         self._check_text_labels(ax.yaxis.get_label(), 'Density')
 
     @slow
+    def test_kde_missing_vals(self):
+        tm._skip_if_no_scipy()
+        _skip_if_no_scipy_gaussian_kde()
+        s = Series(np.random.uniform(size=50))
+        s[0] = np.nan
+        ax = _check_plot_works(s.plot, kind='kde')
+
+    @slow
     def test_hist_kwargs(self):
         ax = self.ts.plot(kind='hist', bins=5)
         self.assertEqual(len(ax.patches), 5)
@@ -1875,6 +1883,14 @@ class TestDataFramePlots(TestPlotBase):
 
         axes = df.plot(kind='kde', logy=True, subplots=True)
         self._check_ax_scales(axes, yaxis='log')
+
+    @slow
+    def test_kde_missing_vals(self):
+        tm._skip_if_no_scipy()
+        _skip_if_no_scipy_gaussian_kde()
+        df = DataFrame(np.random.uniform(size=(100, 4)))
+        df.loc[0, 0] = np.nan
+        ax = _check_plot_works(df.plot, kind='kde')
 
     @slow
     def test_hist_df(self):

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1954,6 +1954,7 @@ class KdePlot(HistPlot):
         from scipy import __version__ as spv
         f = MPLPlot._get_plot_function(self)
         def plotf(ax, y, style=None, column_num=None, **kwds):
+            y = remove_na(y)
             if LooseVersion(spv) >= '0.11.0':
                 gkde = gaussian_kde(y, bw_method=self.bw_method)
             else:


### PR DESCRIPTION
I think the most sensible thing to do here is to drop NaN's, like histograms do, rather than filling 0's. The table in #8177 should be updated to reflect that NaN's are dropped, can do that myself after 8177 gets merged.
