### PR TITLE
ENH: Add prefix parameters for join method.

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3702,6 +3702,7 @@ class DataFrame(NDFrame):
                       verify_integrity=verify_integrity)
 
     def join(self, other, on=None, how='left', lsuffix='', rsuffix='',
+             lprefix='', rprefix='',
              sort=False):
         """
         Join columns with other DataFrame either on index or on a key
@@ -3746,9 +3747,11 @@ class DataFrame(NDFrame):
         """
         # For SparseDataFrame's benefit
         return self._join_compat(other, on=on, how=how, lsuffix=lsuffix,
-                                 rsuffix=rsuffix, sort=sort)
+                                 rsuffix=rsuffix, lprefix=lprefix,
+                                 rprefix=rprefix, sort=sort)
 
     def _join_compat(self, other, on=None, how='left', lsuffix='', rsuffix='',
+                     lprefix='', rprefix='',
                      sort=False):
         from pandas.tools.merge import merge, concat
 
@@ -3760,7 +3763,9 @@ class DataFrame(NDFrame):
         if isinstance(other, DataFrame):
             return merge(self, other, left_on=on, how=how,
                          left_index=on is None, right_index=True,
-                         suffixes=(lsuffix, rsuffix), sort=sort)
+                         suffixes=(lsuffix, rsuffix),
+                         prefixes=(lprefix, rprefix),
+                         sort=sort)
         else:
             if on is not None:
                 raise ValueError('Joining multiple DataFrames only supported'

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -3898,6 +3898,31 @@ def items_overlap_with_suffix(left, lsuffix, right, rsuffix):
                 _transform_index(right, rrenamer))
 
 
+def items_overlap_with_suffix_and_prefix(
+        left, lsuffix, lprefix, right, rsuffix, rprefix):
+    to_rename = left.intersection(right)
+    if len(to_rename) == 0:
+        return left, right
+    else:
+        if not lsuffix and not rsuffix and not lprefix and not rprefix:
+            raise ValueError('columns overlap but no suffix or prefix specified: %s' %
+                             to_rename)
+
+        def lrenamer(x):
+            if x in to_rename:
+                return '%s%s%s' % (lprefix, x, lsuffix)
+            return x
+
+        def rrenamer(x):
+            if x in to_rename:
+                return '%s%s%s' % (rprefix, x, rsuffix)
+            return x
+
+        return (_transform_index(left, lrenamer),
+                _transform_index(right, rrenamer))
+
+
+
 def _transform_index(index, func):
     """
     Apply function to all values found in index.

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -15,6 +15,7 @@ from pandas.core.index import (Index, MultiIndex, _get_combined_index,
                                _ensure_index, _get_consensus_names,
                                _all_indexes_same)
 from pandas.core.internals import (items_overlap_with_suffix,
+                                   items_overlap_with_suffix_and_prefix,
                                    concatenate_block_managers)
 from pandas.util.decorators import Appender, Substitution
 from pandas.core.common import ABCSeries
@@ -31,10 +32,11 @@ import pandas.hashtable as _hash
 @Appender(_merge_doc, indents=0)
 def merge(left, right, how='inner', on=None, left_on=None, right_on=None,
           left_index=False, right_index=False, sort=False,
-          suffixes=('_x', '_y'), copy=True):
+          suffixes=('_x', '_y'), prefixes=('', ''), copy=True):
     op = _MergeOperation(left, right, how=how, on=on, left_on=left_on,
                          right_on=right_on, left_index=left_index,
                          right_index=right_index, sort=sort, suffixes=suffixes,
+                         prefixes=prefixes,
                          copy=copy)
     return op.get_result()
 if __debug__:
@@ -161,7 +163,7 @@ class _MergeOperation(object):
     def __init__(self, left, right, how='inner', on=None,
                  left_on=None, right_on=None, axis=1,
                  left_index=False, right_index=False, sort=True,
-                 suffixes=('_x', '_y'), copy=True):
+                 suffixes=('_x', '_y'), prefixes=('', ''), copy=True):
         self.left = self.orig_left = left
         self.right = self.orig_right = right
         self.how = how
@@ -173,6 +175,7 @@ class _MergeOperation(object):
 
         self.copy = copy
         self.suffixes = suffixes
+        self.prefixes = prefixes
         self.sort = sort
 
         self.left_index = left_index
@@ -188,9 +191,12 @@ class _MergeOperation(object):
 
         ldata, rdata = self.left._data, self.right._data
         lsuf, rsuf = self.suffixes
+        lpre, rpre = self.prefixes
 
-        llabels, rlabels = items_overlap_with_suffix(ldata.items, lsuf,
-                                                     rdata.items, rsuf)
+        llabels, rlabels = items_overlap_with_suffix_and_prefix(
+            ldata.items, lsuf, lpre,
+            rdata.items, rsuf, rpre
+        )
 
         lindexers = {1: left_indexer} if left_indexer is not None else {}
         rindexers = {1: right_indexer} if right_indexer is not None else {}


### PR DESCRIPTION
Addresses #8139. Not sure how people feel about this one, in terms of adding clutter to the api, but it _was_ pretty easy to get working, so I thought I'd put this together to show what changes would need to be made. I might still need to go over `DataFrame.merge()` to see if the same arguments can be added for consistency. 
