### PR TITLE
BUG: fix variable overwriting in radviz

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -920,3 +920,4 @@ Bug Fixes
 - Bug in plotting methods modifying the global matplotlib rcParams (:issue:`8242`).
 - Bug in ``DataFrame.__setitem__`` that caused errors when setting a dataframe column to a sparse array (:issue:`8131`)
 - Bug where ``Dataframe.boxplot()`` failed when entire column was empty (:issue:`8181`).
+- Bug with messed variables in ``radviz`` visualization (:issue:`8199`).

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -405,10 +405,10 @@ def radviz(frame, class_column, ax=None, color=None, colormap=None, **kwds):
     for kls in classes:
         to_plot[kls] = [[], []]
 
-    n = len(frame.columns) - 1
+    m = len(frame.columns) - 1
     s = np.array([(np.cos(t), np.sin(t))
-                  for t in [2.0 * np.pi * (i / float(n))
-                            for i in range(n)]])
+                  for t in [2.0 * np.pi * (i / float(m))
+                            for i in range(m)]])
 
     for i in range(n):
         row = df.iloc[i].values


### PR DESCRIPTION
The variable `n` is set to number of rows in dataframe, and then it overwritten with number of columns, but after that there is loop that should iterate over rows and it uses new value in `n` that holds number of columns already.
