### PR TITLE
PERF: Switch to try/except in extract() rather than instance check

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -465,7 +465,9 @@ def str_extract(arr, pat, flags=0):
         raise ValueError("This pattern contains no groups to capture.")
     empty_row = [np.nan]*regex.groups
     def f(x):
-        if not isinstance(x, compat.string_types):
+        try:
+            regex.search(x)
+        except TypeError:
             return empty_row
         m = regex.search(x)
         if m:


### PR DESCRIPTION
See #7269 for more. (doesn't completely resolve the speed difference, but it gets a 10-15% improvement).

Timing improvement is there, but it's small.

```
In [20]: %timeit test.str.match(pattern2)
10 loops, best of 3: 170 ms per loop

In [21]: %timeit test.str.extract(pattern2)
10 loops, best of 3: 317 ms per loop

In [22]: %timeit -n try_except_str_extract2(test, pattern2)
10 loops, best of 3: 265 ms per loop
```

@jreback - this is very minor, but if you think this needs a release note,
where should I put it?

This passed locally for me, but if Travis fails I'll fix it up.
