### PR TITLE
BUG: Fix mismatched logic error in compatibility check

### DIFF
--- a/pandas/compat/openpyxl_compat.py
+++ b/pandas/compat/openpyxl_compat.py
@@ -21,4 +21,4 @@ def is_compat():
     """
     import openpyxl
     ver = LooseVersion(openpyxl.__version__)
-    return LooseVersion(start_ver) < ver <= LooseVersion(stop_ver)
+    return LooseVersion(start_ver) <= ver < LooseVersion(stop_ver)


### PR DESCRIPTION
We want to support below 2.0 (non-inclusive), but including 1.6.1. Check was
doing the opposite. Not worth merging if we accept #7565 , but just wanted this
here as a ping if we don't so we're internally consistent.
