### PR TITLE
ENH: sql support for Timestamp (GH7103)

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -441,6 +441,8 @@ Enhancements
    df.to_sql('table', engine, schema='other_schema')
    pd.read_sql_table('table', engine, schema='other_schema')
 
+- Added support for writing datetime64 columns with ``to_sql`` for all database flavors (:issue:`7103`).
+
 - Added support for bool, uint8, uint16 and uint32 datatypes in ``to_stata`` (:issue:`7097`, :issue:`7365`)
 
 - Added ``layout`` keyword to ``DataFrame.plot`` (:issue:`6667`)

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -540,6 +540,23 @@ def pandasSQL_builder(con, flavor=None, schema=None, meta=None, is_cursor=False)
         return PandasSQLLegacy(con, flavor, is_cursor=is_cursor)
 
 
+try:
+    import sqlalchemy.types as types
+    
+    class Timestamp(types.TypeDecorator):
+        """convert from pandas.tslib.Timestamp type """
+    
+        impl = types.DateTime
+    
+        def process_bind_param(self, value, dialect):
+            f = getattr(value,'to_datetime', None)
+            if f is not None:
+                return f()
+            return value
+except:
+    pass
+
+
 class PandasSQLTable(PandasObject):
     """
     For mapping Pandas tables to SQL tables.
@@ -784,7 +801,7 @@ class PandasSQLTable(PandasObject):
                 tz = col.tzinfo
                 return DateTime(timezone=True)
             except:
-                return DateTime
+                return Timestamp
         if com.is_timedelta64_dtype(col):
             warnings.warn("the 'timedelta' type is not supported, and will be "
                           "written as integer values (ns frequency) to the "

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -925,9 +925,6 @@ class _TestSQLAlchemy(PandasSQLTest):
                         "IntDateCol loaded with incorrect type")
 
     def test_datetime(self):
-        if self.driver == 'pymysql':
-             raise nose.SkipTest('writing datetime not working with pymysql')
-
         df = DataFrame({'A': date_range('2013-01-01 09:00:00', periods=3),
                         'B': np.arange(3.0)})
         df.to_sql('test_datetime', self.conn)


### PR DESCRIPTION
Superceded by #8208 (converting to object dtype also converts the datetime64 values to datetime.datetime, so it is no longer needed that sqlalchemy can work with pandas' Timestamp type.

---

Closes #7103, #7936

This adds a `pandas.io.sql.Timestamp` class to handle `Timestamp`s in `to_sql`. This basically converts it to a `datetime.datetime` before writing to the database.

Problem is that this makes it slower (I tested it with sqlite, and it's for a dataframe with only a datetime64 column about 20% slower), while it did already work before for some drivers (like psycopg2 and MySQLdb).
