### PR TITLE
BUG: Fix groupby duplicate column error message

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -600,7 +600,7 @@ Bug Fixes
 - Bug in ``groupby`` where callable objects without name attributes would take the wrong path,
   and produce a ``DataFrame`` instead of a ``Series`` (:issue:`7929`)
 
-- Bug in ``groupby`` when a DataFrame grouping column is duplicated (:issue:`7511`)
+- Bug in ``groupby`` error message when a DataFrame grouping column is duplicated (:issue:`7511`)
 
 - Bug in ``read_html`` where the ``infer_types`` argument forced coercion of
   date-likes incorrectly (:issue:`7762`, :issue:`7032`).

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -600,6 +600,7 @@ Bug Fixes
 - Bug in ``groupby`` where callable objects without name attributes would take the wrong path,
   and produce a ``DataFrame`` instead of a ``Series`` (:issue:`7929`)
 
+- Bug in ``groupby`` when a DataFrame grouping column is duplicated (:issue:`7511`)
 
 - Bug in ``read_html`` where the ``infer_types`` argument forced coercion of
   date-likes incorrectly (:issue:`7762`, :issue:`7032`).

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2083,8 +2083,13 @@ def _get_grouper(obj, key=None, axis=0, level=None, sort=True):
             errmsg = "Categorical grouper must have len(grouper) == len(data)"
             raise AssertionError(errmsg)
 
-        ping = Grouping(group_axis, gpr, obj=obj, name=name, level=level, sort=sort)
-        groupings.append(ping)
+        if gpr.ndim > 1:
+            for name, gpr in gpr.iteritems():
+                ping = Grouping(group_axis, gpr, obj=obj, name=name, level=level, sort=sort)
+                groupings.append(ping)
+        else:
+            ping = Grouping(group_axis, gpr, obj=obj, name=name, level=level, sort=sort)
+            groupings.append(ping)
 
     if len(groupings) == 0:
         raise ValueError('No group keys passed!')

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2086,12 +2086,11 @@ def _get_grouper(obj, key=None, axis=0, level=None, sort=True):
             raise AssertionError(errmsg)
 
         if isinstance(gpr, DataFrame) and gpr.ndim > 1:
-            for name, gpr in gpr.iteritems():
-                ping = Grouping(group_axis, gpr, obj=obj, name=name, level=level, sort=sort)
-                groupings.append(ping)
-        else:
-            ping = Grouping(group_axis, gpr, obj=obj, name=name, level=level, sort=sort)
-            groupings.append(ping)
+            errmsg = "Grouper result is not unique for '%s'" % name
+            raise AssertionError(errmsg)
+
+        ping = Grouping(group_axis, gpr, obj=obj, name=name, level=level, sort=sort)
+        groupings.append(ping)
 
     if len(groupings) == 0:
         raise ValueError('No group keys passed!')

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2083,7 +2083,7 @@ def _get_grouper(obj, key=None, axis=0, level=None, sort=True):
             errmsg = "Categorical grouper must have len(grouper) == len(data)"
             raise AssertionError(errmsg)
 
-        if gpr.ndim > 1:
+        if isinstance(gpr, DataFrame) and gpr.ndim > 1:
             for name, gpr in gpr.iteritems():
                 ping = Grouping(group_axis, gpr, obj=obj, name=name, level=level, sort=sort)
                 groupings.append(ping)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1923,7 +1923,7 @@ class Grouping(object):
             # no level passed
             if not isinstance(self.grouper, (Series, Index, np.ndarray)):
                 if getattr(self.grouper,'ndim', 1) != 1:
-                    raise AssertionError("Grouper result with an ndim != 1")
+                    raise ValueError("Grouper result with an ndim != 1")
                 self.grouper = self.index.map(self.grouper)
                 if not (hasattr(self.grouper, "__len__") and
                         len(self.grouper) == len(self.index)):

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1922,6 +1922,8 @@ class Grouping(object):
 
             # no level passed
             if not isinstance(self.grouper, (Series, Index, np.ndarray)):
+                if getattr(self.grouper,'ndim', 1) != 1:
+                    raise AssertionError("Grouper result with an ndim != 1")
                 self.grouper = self.index.map(self.grouper)
                 if not (hasattr(self.grouper, "__len__") and
                         len(self.grouper) == len(self.index)):

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -668,7 +668,7 @@ class TestGroupBy(tm.TestCase):
 
     def test_grouping_error_on_multidim_input(self):
         from pandas.core.groupby import Grouping
-        self.assertRaises(AssertionError, \
+        self.assertRaises(ValueError, \
             Grouping, self.df.index, self.df[['A','A']])
 
     def test_agg_python_multiindex(self):

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -342,20 +342,21 @@ class TestGroupBy(tm.TestCase):
         assert_frame_equal(result, expected)
 
     def test_groupby_duplicated_column(self):
+        # GH7511
         df = DataFrame(columns=['A','B','A','C'], \
                 data=[range(4), range(2,6), range(0, 8, 2)])
 
         grouped = df.groupby('A')
-        assert grouped.count().index.nlevels == 2
+        self.assertTrue(grouped.count().index.nlevels == 2)
         grouped = df.groupby(['A','B'])
-        assert grouped.count().index.nlevels == 3
+        self.assertTrue(grouped.count().index.nlevels == 3)
         grouped = df.groupby(['A','A'])
-        assert grouped.count().index.nlevels == 4
+        self.assertTrue(grouped.count().index.nlevels == 4)
 
         grouped = df.groupby(['B'])
         c = grouped.count()
-        assert c.columns.nlevels == 1
-        assert c.columns.size == 3
+        self.assertTrue(c.columns.nlevels == 1)
+        self.assertTrue(c.columns.size == 3)
 
     def test_groupby_dict_mapping(self):
         # GH #679

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -341,6 +341,22 @@ class TestGroupBy(tm.TestCase):
         expected = grouped.mean()
         assert_frame_equal(result, expected)
 
+    def test_groupby_duplicated_column(self):
+        df = DataFrame(columns=['A','B','A','C'], \
+                data=[range(4), range(2,6), range(0, 8, 2)])
+
+        grouped = df.groupby('A')
+        assert grouped.count().index.nlevels == 2
+        grouped = df.groupby(['A','B'])
+        assert grouped.count().index.nlevels == 3
+        grouped = df.groupby(['A','A'])
+        assert grouped.count().index.nlevels == 4
+
+        grouped = df.groupby(['B'])
+        c = grouped.count()
+        assert c.columns.nlevels == 1
+        assert c.columns.size == 3
+
     def test_groupby_dict_mapping(self):
         # GH #679
         from pandas import Series

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -666,6 +666,11 @@ class TestGroupBy(tm.TestCase):
         expected = grouped.mean()
         tm.assert_frame_equal(result, expected)
 
+    def test_grouping_error_on_multidim_input(self):
+        from pandas.core.groupby import Grouping
+        self.assertRaises(AssertionError, \
+            Grouping, self.df.index, self.df[['A','A']])
+
     def test_agg_python_multiindex(self):
         grouped = self.mframe.groupby(['A', 'B'])
 

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -341,19 +341,15 @@ class TestGroupBy(tm.TestCase):
         expected = grouped.mean()
         assert_frame_equal(result, expected)
 
-    def test_groupby_duplicated_column(self):
+    def test_groupby_duplicated_column_errormsg(self):
         # GH7511
         df = DataFrame(columns=['A','B','A','C'], \
                 data=[range(4), range(2,6), range(0, 8, 2)])
 
-        grouped = df.groupby('A')
-        self.assertTrue(grouped.count().index.nlevels == 2)
-        grouped = df.groupby(['A','B'])
-        self.assertTrue(grouped.count().index.nlevels == 3)
-        grouped = df.groupby(['A','A'])
-        self.assertTrue(grouped.count().index.nlevels == 4)
+        self.assertRaises(AssertionError, df.groupby, 'A')
+        self.assertRaises(AssertionError, df.groupby, ['A', 'B'])
 
-        grouped = df.groupby(['B'])
+        grouped = df.groupby('B')
         c = grouped.count()
         self.assertTrue(c.columns.nlevels == 1)
         self.assertTrue(c.columns.size == 3)


### PR DESCRIPTION
closes #7511

Though having duplicated column names in a dataframe is never a good idea, it may happen, and that shouldn't confuse groupby() with a meaningless message. Currently

``` python
>>> obj=pd.DataFrame(columns=["A","B","A", "C"], data=[range(4), range(2,6), range(0, 8, 2)])
>>> obj.groupby("A").mean()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pandas/core/generic.py", line 2846, in groupby
    sort=sort, group_keys=group_keys, squeeze=squeeze)
  File "pandas/core/groupby.py", line 1173, in groupby
    return klass(obj, by, **kwds)
  File "pandas/core/groupby.py", line 390, in __init__
    level=level, sort=sort)
  File "pandas/core/groupby.py", line 2086, in _get_grouper
    ping = Grouping(group_axis, gpr, obj=obj, name=name, level=level, sort=sort)
  File "pandas/core/groupby.py", line 1925, in __init__
    self.grouper = self.index.map(self.grouper)
  File "pandas/core/index.py", line 1524, in map
    return self._arrmap(self.values, mapper)
  File "generated.pyx", line 2203, in pandas.algos.arrmap_int64 (pandas/algos.c:72274)
TypeError: 'DataFrame' object is not callable
```

This patch fixes that.

``` python
>>> obj.groupby("A").mean()
     B  C
A A      
0 2  1  3
  4  2  6
2 4  3  5
```

Thanks.
