### PR TITLE
ENH to_latex mi index will use & sep for levels

### DIFF
--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -2098,11 +2098,11 @@ c  10  11  12  13  14\
         self.assertEqual(result, expected)
 
         result = df.T.to_latex()
-        expected = r"""\begin{tabular}{ll}
+        expected = r"""\begin{tabular}{lll}
 \toprule
-{} &  0 \\
+  &   &  0 \\
 \midrule
-x y &  a \\
+x & y &  a \\
 \bottomrule
 \end{tabular}
 """


### PR DESCRIPTION
follow up of #7982

_One question I had was the use of `{ }` (is that a convention? I removed it and it seems to compile ok.)_

Note: should test MI cols and MI index. Ah cripes... the names of the column Index don't print, not did they before...
