### PR TITLE
API: Series.to_csv(path=None) should return string to match DataFrame.to_csv()

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -309,6 +309,9 @@ API changes
      df
      df.dtypes
 
+- ``Series.to_csv()`` now returns a string when ``path=None``, matching the behaviour of
+    ``DataFrame.to_csv()`` (:issue:`8215`).
+
 .. _whatsnew_0150.dt:
 
 .dt accessor

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2200,7 +2200,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Parameters
         ----------
-        path : string file path or file handle / StringIO
+        path : string file path or file handle / StringIO. If None is provided
+            the result is returned as a string.
         na_rep : string, default ''
             Missing data representation
         float_format : string, default None
@@ -2224,10 +2225,13 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         from pandas.core.frame import DataFrame
         df = DataFrame(self)
-        df.to_csv(path, index=index, sep=sep, na_rep=na_rep,
+        # result is only a string if no path provided, otherwise None
+        result = df.to_csv(path, index=index, sep=sep, na_rep=na_rep,
                   float_format=float_format, header=header,
                   index_label=index_label, mode=mode, nanRep=nanRep,
                   encoding=encoding, date_format=date_format)
+        if path is None:
+            return result
 
     def dropna(self, axis=0, inplace=False, **kwargs):
         """

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -6428,6 +6428,14 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df2.to_csv(exp)
         self.assertEqual(res.getvalue(), exp.getvalue())
 
+    def test_to_csv_path_is_none(self):
+        # GH 8215
+        # Make sure we return string for consistency with
+        # Series.to_csv()
+        csv_str = self.frame.to_csv(path=None)
+        self.assertIsInstance(csv_str, str)
+        recons = pd.read_csv(StringIO(csv_str), index_col=0)
+        assert_frame_equal(self.frame, recons)
 
     def test_info(self):
         io = StringIO()

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -4371,6 +4371,14 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         buf = StringIO()
         split.to_csv(buf)
 
+    def test_to_csv_path_is_none(self):
+        # GH 8215
+        # Series.to_csv() was returning None, inconsistent with
+        # DataFrame.to_csv() which returned string
+        s = Series([1, 2, 3])
+        csv_str = s.to_csv(path=None)
+        self.assertIsInstance(csv_str, str)
+
     def test_clip(self):
         val = self.ts.median()
 


### PR DESCRIPTION
Addresses #8215. Currently, `Series.to_csv(path=None)` returns `None`. The `DataFrame` method returns a string, and already had this behaviour mentioned in the docstring, so it should be OK to make the `Series` method match this.
