### PR TITLE
API: raise on setops for + and - for Indexes (GH8226)

### DIFF
--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -1616,28 +1616,33 @@ display:
    df
    df['A']
 
+.. _indexing.setops:
 
 Set operations on Index objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. warning::
+
+   In 0.15.0. the set operations ``+`` and ``-`` were deprecated in order to provide these for numeric type operations on certain
+   index types. ``+`` can be replace by ``.union()`` or ``|``, and ``-`` by ``.difference()``.
+
 .. _indexing.set_ops:
 
-The three main operations are ``union (|)``, ``intersection (&)``, and ``diff
-(-)``. These can be directly called as instance methods or used via overloaded
-operators:
+The two main operations are ``union (|)``, ``intersection (&)``
+These can be directly called as instance methods or used via overloaded
+operators. Difference is provided via the ``.difference()`` method.
 
 .. ipython:: python
 
    a = Index(['c', 'b', 'a'])
    b = Index(['c', 'e', 'd'])
-   a.union(b)
    a | b
    a & b
-   a - b
+   a.difference(b)
 
 Also available is the ``sym_diff (^)`` operation, which returns elements
 that appear in either ``idx1`` or ``idx2`` but not both. This is
-equivalent to the Index created by ``(idx1 - idx2) + (idx2 - idx1)``,
+equivalent to the Index created by ``(idx1.difference(idx2)).union(idx2.difference(idx1))``,
 with duplicates dropped.
 
 .. ipython:: python

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -19,6 +19,7 @@ users upgrade to this version.
   - Internal refactoring of the ``Index`` class to no longer sub-class ``ndarray``, see :ref:`Internal Refactoring <whatsnew_0150.refactoring>`
   - New datetimelike properties accessor ``.dt`` for Series, see :ref:`Datetimelike Properties <whatsnew_0150.dt>`
   - dropping support for ``PyTables`` less than version 3.0.0, and ``numexpr`` less than version 2.1 (:issue:`7990`)
+  - API change in using Indexs set operations, see :ref:`here <whatsnew_0150.index_set_ops>`
 
 - :ref:`Other Enhancements <whatsnew_0150.enhancements>`
 
@@ -342,6 +343,11 @@ API changes
 
 - ``Series.to_csv()`` now returns a string when ``path=None``, matching the behaviour of
     ``DataFrame.to_csv()`` (:issue:`8215`).
+
+
+.. _whatsnew_0150.index_set_ops:
+
+- The Index set operations ``+`` and ``-`` were deprecated in order to provide these for numeric type operations on certain index types. ``+`` can be replace by ``.union()`` or ``|``, and ``-`` by ``.difference()``. Further the method name ``Index.diff()`` is deprecated and can be replaced by ``Index.difference()``
 
 .. _whatsnew_0150.dt:
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -711,8 +711,10 @@ class DatetimeIndexOpsMixin(object):
         from pandas.core.index import Index
         from pandas.tseries.offsets import DateOffset
         if isinstance(other, Index):
+            warnings.warn("using '+' to provide set union with Indexes is deprecated, "
+                          "use .union()",FutureWarning)
             return self.union(other)
-        elif isinstance(other, (DateOffset, datetime.timedelta, np.timedelta64)):
+        if isinstance(other, (DateOffset, datetime.timedelta, np.timedelta64)):
             return self._add_delta(other)
         elif com.is_integer(other):
             return self.shift(other)
@@ -723,8 +725,10 @@ class DatetimeIndexOpsMixin(object):
         from pandas.core.index import Index
         from pandas.tseries.offsets import DateOffset
         if isinstance(other, Index):
-            return self.diff(other)
-        elif isinstance(other, (DateOffset, datetime.timedelta, np.timedelta64)):
+            warnings.warn("using '-' to provide set differences with Indexes is deprecated, "
+                          "use .difference()",FutureWarning)
+            return self.difference(other)
+        if isinstance(other, (DateOffset, datetime.timedelta, np.timedelta64)):
             return self._add_delta(-other)
         elif com.is_integer(other):
             return self.shift(-other)

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -435,7 +435,7 @@ class Categorical(PandasObject):
         """
         new_levels = self._validate_levels(new_levels)
 
-        if len(new_levels) < len(self._levels) or len(self._levels-new_levels):
+        if len(new_levels) < len(self._levels) or len(self._levels.difference(new_levels)):
             raise ValueError('Reordered levels must include all original levels')
         values = self.__array__()
         self._codes = _get_codes_for_values(values, new_levels)
@@ -887,7 +887,7 @@ class Categorical(PandasObject):
                 raise ValueError("cannot set a Categorical with another, without identical levels")
 
         rvalue = value if com.is_list_like(value) else [value]
-        to_add = Index(rvalue)-self.levels
+        to_add = Index(rvalue).difference(self.levels)
         # no assignments of values not in levels, but it's always ok to set something to np.nan
         if len(to_add) and not isnull(to_add).all():
             raise ValueError("cannot setitem on a Categorical with a new level,"

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3682,7 +3682,7 @@ class DataFrame(NDFrame):
                                 'ignore_index=True')
 
             index = None if other.name is None else [other.name]
-            combined_columns = self.columns.tolist() + ((self.columns | other.index) - self.columns).tolist()
+            combined_columns = self.columns.tolist() + (self.columns | other.index).difference(self.columns).tolist()
             other = other.reindex(combined_columns, copy=False)
             other = DataFrame(other.values.reshape((1, len(other))),
                               index=index, columns=combined_columns).convert_objects()

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -473,7 +473,7 @@ class GroupBy(PandasObject):
             ax = self.obj._info_axis
             groupers = [ g.name for g in grp.groupings if g.level is None and g.name is not None and g.name in ax ]
             if len(groupers):
-                self._group_selection = (ax-Index(groupers)).tolist()
+                self._group_selection = ax.difference(Index(groupers)).tolist()
 
     def _set_result_index_ordered(self, result):
         # set the result index on the passed values object

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1128,9 +1128,10 @@ class Index(IndexOpsMixin, PandasObject):
 
     def __add__(self, other):
         if isinstance(other, Index):
+            warnings.warn("using '+' to provide set union with Indexes is deprecated, "
+                          "use '|' or .union()",FutureWarning)
             return self.union(other)
-        else:
-            return Index(np.array(self) + other)
+        return Index(np.array(self) + other)
 
     __iadd__ = __add__
     __eq__ = _indexOp('__eq__')
@@ -1141,7 +1142,10 @@ class Index(IndexOpsMixin, PandasObject):
     __ge__ = _indexOp('__ge__')
 
     def __sub__(self, other):
-        return self.diff(other)
+        if isinstance(other, Index):
+            warnings.warn("using '-' to provide set differences with Indexes is deprecated, "
+                          "use .difference()",FutureWarning)
+        return self.difference(other)
 
     def __and__(self, other):
         return self.intersection(other)
@@ -1273,7 +1277,7 @@ class Index(IndexOpsMixin, PandasObject):
             taken.name = None
         return taken
 
-    def diff(self, other):
+    def difference(self, other):
         """
         Compute sorted set difference of two Index objects
 
@@ -1289,8 +1293,7 @@ class Index(IndexOpsMixin, PandasObject):
         -----
         One can do either of these and achieve the same result
 
-        >>> index - index2
-        >>> index.diff(index2)
+        >>> index.difference(index2)
         """
 
         if not hasattr(other, '__iter__'):
@@ -1307,6 +1310,8 @@ class Index(IndexOpsMixin, PandasObject):
 
         theDiff = sorted(set(self) - set(other))
         return Index(theDiff, name=result_name)
+
+    diff = deprecate('diff',difference)
 
     def sym_diff(self, other, result_name=None):
         """
@@ -1350,7 +1355,7 @@ class Index(IndexOpsMixin, PandasObject):
             other = Index(other)
             result_name = result_name or self.name
 
-        the_diff = sorted(set((self - other) + (other - self)))
+        the_diff = sorted(set((self.difference(other)).union(other.difference(self))))
         return Index(the_diff, name=result_name)
 
     def get_loc(self, key):
@@ -4135,6 +4140,8 @@ class MultiIndex(Index):
         Returns
         -------
         Index
+
+        >>> index.union(index2)
         """
         self._assert_can_do_setop(other)
 
@@ -4177,7 +4184,7 @@ class MultiIndex(Index):
             return MultiIndex.from_arrays(lzip(*uniq_tuples), sortorder=0,
                                           names=result_names)
 
-    def diff(self, other):
+    def difference(self, other):
         """
         Compute sorted set difference of two MultiIndex objects
 

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -678,9 +678,9 @@ class Panel(NDFrame):
                                  self.minor_axis)
 
     def _combine_panel(self, other, func):
-        items = self.items + other.items
-        major = self.major_axis + other.major_axis
-        minor = self.minor_axis + other.minor_axis
+        items = self.items.union(other.items)
+        major = self.major_axis.union(other.major_axis)
+        minor = self.minor_axis.union(other.minor_axis)
 
         # could check that everything's the same size, but forget it
         this = self.reindex(items=items, major=major, minor=minor)

--- a/pandas/core/panelnd.py
+++ b/pandas/core/panelnd.py
@@ -82,7 +82,7 @@ def create_nd_panel_factory(klass_name, orders, slices, slicer, aliases=None,
         # combine labels to form new axes
         new_axes = []
         for a in self._AXIS_ORDERS:
-            new_axes.append(getattr(self, a) + getattr(other, a))
+            new_axes.append(getattr(self, a).union(getattr(other, a)))
 
         # reindex: could check that everything's the same size, but forget it
         d = dict([(a, ax) for a, ax in zip(self._AXIS_ORDERS, new_axes)])

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -848,7 +848,7 @@ def lreshape(data, groups, dropna=True, label=None):
         keys, values = zip(*groups)
 
     all_cols = list(set.union(*[set(x) for x in values]))
-    id_cols = list(data.columns.diff(all_cols))
+    id_cols = list(data.columns.difference(all_cols))
 
     K = len(values[0])
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1458,7 +1458,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         result : Series
         """
         if isinstance(other, Series):
-            new_index = self.index + other.index
+            new_index = self.index.union(other.index)
             new_name = _maybe_match_name(self, other)
             new_values = pa.empty(len(new_index), dtype=self.dtype)
             for i, idx in enumerate(new_index):
@@ -1484,7 +1484,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         -------
         y : Series
         """
-        new_index = self.index + other.index
+        new_index = self.index.union(other.index)
         this = self.reindex(new_index, copy=False)
         other = other.reindex(new_index, copy=False)
         name = _maybe_match_name(self, other)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -970,7 +970,7 @@ class HDFStore(StringMixin):
                 remain_values.extend(v)
         if remain_key is not None:
             ordered = value.axes[axis]
-            ordd = ordered - Index(remain_values)
+            ordd = ordered.difference(Index(remain_values))
             ordd = sorted(ordered.get_indexer(ordd))
             d[remain_key] = ordered.take(ordd)
 
@@ -3245,7 +3245,7 @@ class Table(Fixed):
                 data_columns, min_itemsize)
             if len(data_columns):
                 mgr = block_obj.reindex_axis(
-                    Index(axis_labels) - Index(data_columns),
+                    Index(axis_labels).difference(Index(data_columns)),
                     axis=axis
                 )._data
 
@@ -3362,7 +3362,7 @@ class Table(Fixed):
                             # if we have a multi-index, then need to include
                             # the levels
                             if self.is_multi_index:
-                                filt = filt + Index(self.levels)
+                                filt = filt.union(Index(self.levels))
 
                             takers = op(axis_values, filt)
                             return obj.ix._getitem_axis(takers,

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -2320,7 +2320,7 @@ class TestHDFStore(tm.TestCase):
             n = store.remove('wp5', start=16, stop=-16)
             self.assertTrue(n == 120-32)
             result = store.select('wp5')
-            expected = wp.reindex(major_axis=wp.major_axis[:16//4]+wp.major_axis[-16//4:])
+            expected = wp.reindex(major_axis=wp.major_axis[:16//4].union(wp.major_axis[-16//4:]))
             assert_panel_equal(result, expected)
 
             _maybe_remove(store, 'wp6')
@@ -2339,7 +2339,7 @@ class TestHDFStore(tm.TestCase):
             n = store.remove('wp7', where=[crit], stop=80)
             self.assertTrue(n == 28)
             result = store.select('wp7')
-            expected = wp.reindex(major_axis=wp.major_axis-wp.major_axis[np.arange(0,20,3)])
+            expected = wp.reindex(major_axis=wp.major_axis.difference(wp.major_axis[np.arange(0,20,3)]))
             assert_panel_equal(result, expected)
 
     def test_remove_crit(self):
@@ -2357,7 +2357,7 @@ class TestHDFStore(tm.TestCase):
             self.assertTrue(n == 36)
 
             result = store.select('wp3')
-            expected = wp.reindex(major_axis=wp.major_axis - date4)
+            expected = wp.reindex(major_axis=wp.major_axis.difference(date4))
             assert_panel_equal(result, expected)
 
             # upper half
@@ -2385,7 +2385,7 @@ class TestHDFStore(tm.TestCase):
             crit1 = Term('major_axis=date1')
             store.remove('wp2', where=[crit1])
             result = store.select('wp2')
-            expected = wp.reindex(major_axis=wp.major_axis - date1)
+            expected = wp.reindex(major_axis=wp.major_axis.difference(date1))
             assert_panel_equal(result, expected)
 
             date2 = wp.major_axis[5]
@@ -2393,7 +2393,7 @@ class TestHDFStore(tm.TestCase):
             store.remove('wp2', where=[crit2])
             result = store['wp2']
             expected = wp.reindex(
-                major_axis=wp.major_axis - date1 - Index([date2]))
+                major_axis=wp.major_axis.difference(date1).difference(Index([date2])))
             assert_panel_equal(result, expected)
 
             date3 = [wp.major_axis[7], wp.major_axis[9]]
@@ -2401,7 +2401,7 @@ class TestHDFStore(tm.TestCase):
             store.remove('wp2', where=[crit3])
             result = store['wp2']
             expected = wp.reindex(
-                major_axis=wp.major_axis - date1 - Index([date2]) - Index(date3))
+                major_axis=wp.major_axis.difference(date1).difference(Index([date2])).difference(Index(date3)))
             assert_panel_equal(result, expected)
 
             # corners

--- a/pandas/sparse/panel.py
+++ b/pandas/sparse/panel.py
@@ -427,9 +427,9 @@ class SparsePanel(Panel):
                            default_kind=self.default_kind)
 
     def _combinePanel(self, other, func):
-        items = self.items + other.items
-        major = self.major_axis + other.major_axis
-        minor = self.minor_axis + other.minor_axis
+        items = self.items.union(other.items)
+        major = self.major_axis.union(other.major_axis)
+        minor = self.minor_axis.union(other.minor_axis)
 
         # could check that everything's the same size, but forget it
 

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -790,13 +790,8 @@ Length: 3, Freq: None, Timezone: US/Eastern"""
 
             for rng, other, expected in [(rng1, other1, expected1), (rng2, other2, expected2),
                                          (rng3, other3, expected3)]:
-                result_add = rng + other
                 result_union = rng.union(other)
-
-                tm.assert_index_equal(result_add, expected)
                 tm.assert_index_equal(result_union, expected)
-                rng += other
-                tm.assert_index_equal(rng, expected)
 
             # offset
             offsets = [pd.offsets.Hour(2), timedelta(hours=2), np.timedelta64(2, 'h')]
@@ -834,13 +829,8 @@ Length: 3, Freq: None, Timezone: US/Eastern"""
 
             for rng, other, expected in [(rng1, other1, expected1), (rng2, other2, expected2),
                                          (rng3, other3, expected3)]:
-                result_add = rng - other
-                result_union = rng.diff(other)
-
-                tm.assert_index_equal(result_add, expected)
+                result_union = rng.difference(other)
                 tm.assert_index_equal(result_union, expected)
-                rng -= other
-                tm.assert_index_equal(rng, expected)
 
             # offset
             offsets = [pd.offsets.Hour(2), timedelta(hours=2), np.timedelta64(2, 'h')]
@@ -1063,14 +1053,8 @@ Length: 3, Freq: Q-DEC"""
                                      (rng5, other5, expected5), (rng6, other6, expected6),
                                      (rng7, other7, expected7)]:
 
-            result_add = rng + other
             result_union = rng.union(other)
-
-            tm.assert_index_equal(result_add, expected)
             tm.assert_index_equal(result_union, expected)
-            # GH 6527
-            rng += other
-            tm.assert_index_equal(rng, expected)
 
         # offset
         # DateOffset
@@ -1176,13 +1160,8 @@ Length: 3, Freq: Q-DEC"""
                                      (rng3, other3, expected3), (rng4, other4, expected4),
                                      (rng5, other5, expected5), (rng6, other6, expected6),
                                      (rng7, other7, expected7),]:
-            result_add = rng - other
-            result_union = rng.diff(other)
-
-            tm.assert_index_equal(result_add, expected)
+            result_union = rng.difference(other)
             tm.assert_index_equal(result_union, expected)
-            rng -= other
-            tm.assert_index_equal(rng, expected)
 
         # offset
         # DateOffset

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -8974,8 +8974,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.assertTrue(bf.columns.equals(other.columns))
         # test fill value
         join_idx = self.frame.index.join(other.index)
-        diff_a = self.frame.index.diff(join_idx)
-        diff_b = other.index.diff(join_idx)
+        diff_a = self.frame.index.difference(join_idx)
+        diff_b = other.index.difference(join_idx)
         diff_a_vals = af.reindex(diff_a).values
         diff_b_vals = bf.reindex(diff_b).values
         self.assertTrue((diff_a_vals == -1).all())
@@ -8993,8 +8993,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # test fill value
         join_idx = self.frame.index.join(other.index)
-        diff_a = self.frame.index.diff(join_idx)
-        diff_b = other.index.diff(join_idx)
+        diff_a = self.frame.index.difference(join_idx)
+        diff_b = other.index.difference(join_idx)
         diff_a_vals = af.reindex(diff_a).values
         diff_b_vals = bf.reindex(diff_b).values
         self.assertTrue((diff_a_vals == -1).all())

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -124,12 +124,12 @@ class Generic(object):
         # _get_numeric_data is includes _get_bool_data, so can't test for non-inclusion
 
     def test_get_default(self):
-        
+
         # GH 7725
         d0 = "a", "b", "c", "d"
         d1 = np.arange(4, dtype='int64')
         others = "e", 10
-        
+
         for data, index in ((d0, d1), (d1, d0)):
             s = Series(data, index=index)
             for i,d in zip(index, data):
@@ -501,7 +501,7 @@ class TestSeries(tm.TestCase, Generic):
         ser = Series(np.sort(np.random.uniform(size=100)))
 
         # interpolate at new_index
-        new_index = ser.index + Index([49.25, 49.5, 49.75, 50.25, 50.5, 50.75])
+        new_index = ser.index.union(Index([49.25, 49.5, 49.75, 50.25, 50.5, 50.75]))
         interp_s = ser.reindex(new_index).interpolate(method='pchip')
         # does not blow up, GH5977
         interp_s[49:51]
@@ -1153,7 +1153,7 @@ class TestDataFrame(tm.TestCase, Generic):
 
                 # MultiIndex
                 # GH7846
-                df2 = DataFrame(np.ones(5), 
+                df2 = DataFrame(np.ones(5),
                                 MultiIndex.from_arrays([l0, l1]))
 
                 df3 = getattr(df2, fn)('US/Pacific', level=0)

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -2261,10 +2261,10 @@ class TestDataFramePlots(TestPlotBase):
             self._check_legend_labels(ax, labels=df.columns)
 
             ax = df3.plot(kind=kind, legend=True, ax=ax)
-            self._check_legend_labels(ax, labels=df.columns + df3.columns)
+            self._check_legend_labels(ax, labels=df.columns.union(df3.columns))
 
             ax = df4.plot(kind=kind, legend='reverse', ax=ax)
-            expected = list(df.columns + df3.columns) + list(reversed(df4.columns))
+            expected = list(df.columns.union(df3.columns)) + list(reversed(df4.columns))
             self._check_legend_labels(ax, labels=expected)
 
         # Secondary Y

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -557,8 +557,13 @@ class TestIndex(Base, tm.TestCase):
         self.assertIsNone(union.name)
 
     def test_add(self):
-        firstCat = self.strIndex + self.dateIndex
-        secondCat = self.strIndex + self.strIndex
+
+        # - API change GH 8226
+        with tm.assert_produces_warning():
+            self.strIndex + self.dateIndex
+
+        firstCat = self.strIndex.union(self.dateIndex)
+        secondCat = self.strIndex.union(self.strIndex)
 
         if self.dateIndex.dtype == np.object_:
             appended = np.append(self.strIndex, self.dateIndex)
@@ -611,29 +616,30 @@ class TestIndex(Base, tm.TestCase):
         index += '_x'
         self.assertIn('a_x', index)
 
-    def test_diff(self):
+    def test_difference(self):
+
         first = self.strIndex[5:20]
         second = self.strIndex[:10]
         answer = self.strIndex[10:20]
         first.name = 'name'
         # different names
-        result = first - second
+        result = first.difference(second)
 
         self.assertTrue(tm.equalContents(result, answer))
         self.assertEqual(result.name, None)
 
         # same names
         second.name = 'name'
-        result = first - second
+        result = first.difference(second)
         self.assertEqual(result.name, 'name')
 
         # with empty
-        result = first.diff([])
+        result = first.difference([])
         self.assertTrue(tm.equalContents(result, first))
         self.assertEqual(result.name, first.name)
 
         # with everythin
-        result = first.diff(first)
+        result = first.difference(first)
         self.assertEqual(len(result), 0)
         self.assertEqual(result.name, first.name)
 
@@ -2580,7 +2586,6 @@ class TestMultiIndex(Base, tm.TestCase):
         self.assertEqual(result[3], '1  0  0  0')
 
     def test_format_sparse_config(self):
-        import warnings
         warn_filters = warnings.filters
         warnings.filterwarnings('ignore',
                                 category=FutureWarning,
@@ -2775,9 +2780,15 @@ class TestMultiIndex(Base, tm.TestCase):
         # result = self.index & tuples
         # self.assertTrue(result.equals(tuples))
 
-    def test_diff(self):
+    def test_difference(self):
+
         first = self.index
-        result = first - self.index[-3:]
+        result = first.difference(self.index[-3:])
+
+        # - API change GH 8226
+        with tm.assert_produces_warning():
+            first - self.index[-3:]
+
         expected = MultiIndex.from_tuples(sorted(self.index[:-3].values),
                                           sortorder=0,
                                           names=self.index.names)
@@ -2787,19 +2798,19 @@ class TestMultiIndex(Base, tm.TestCase):
         self.assertEqual(result.names, self.index.names)
 
         # empty difference: reflexive
-        result = self.index - self.index
+        result = self.index.difference(self.index)
         expected = self.index[:0]
         self.assertTrue(result.equals(expected))
         self.assertEqual(result.names, self.index.names)
 
         # empty difference: superset
-        result = self.index[-3:] - self.index
+        result = self.index[-3:].difference(self.index)
         expected = self.index[:0]
         self.assertTrue(result.equals(expected))
         self.assertEqual(result.names, self.index.names)
 
         # empty difference: degenerate
-        result = self.index[:0] - self.index
+        result = self.index[:0].difference(self.index)
         expected = self.index[:0]
         self.assertTrue(result.equals(expected))
         self.assertEqual(result.names, self.index.names)
@@ -2807,31 +2818,31 @@ class TestMultiIndex(Base, tm.TestCase):
         # names not the same
         chunklet = self.index[-3:]
         chunklet.names = ['foo', 'baz']
-        result = first - chunklet
+        result = first.difference(chunklet)
         self.assertEqual(result.names, (None, None))
 
         # empty, but non-equal
-        result = self.index - self.index.sortlevel(1)[0]
+        result = self.index.difference(self.index.sortlevel(1)[0])
         self.assertEqual(len(result), 0)
 
         # raise Exception called with non-MultiIndex
-        result = first.diff(first._tuple_index)
+        result = first.difference(first._tuple_index)
         self.assertTrue(result.equals(first[:0]))
 
         # name from empty array
-        result = first.diff([])
+        result = first.difference([])
         self.assertTrue(first.equals(result))
         self.assertEqual(first.names, result.names)
 
         # name from non-empty array
-        result = first.diff([('foo', 'one')])
+        result = first.difference([('foo', 'one')])
         expected = pd.MultiIndex.from_tuples([('bar', 'one'), ('baz', 'two'),
                                             ('foo', 'two'), ('qux', 'one'),
                                             ('qux', 'two')])
         expected.names = first.names
         self.assertEqual(first.names, result.names)
         assertRaisesRegexp(TypeError, "other must be a MultiIndex or a list"
-                           " of tuples", first.diff, [1, 2, 3, 4, 5])
+                           " of tuples", first.difference, [1, 2, 3, 4, 5])
 
     def test_from_tuples(self):
         assertRaisesRegexp(TypeError, 'Cannot infer number of levels from'

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -5199,8 +5199,8 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
             join_index = a.index.join(b.index, how=how)
             if fill is not None:
-                diff_a = aa.index.diff(join_index)
-                diff_b = ab.index.diff(join_index)
+                diff_a = aa.index.difference(join_index)
+                diff_b = ab.index.difference(join_index)
                 if len(diff_a) > 0:
                     self.assertTrue((aa.reindex(diff_a) == fill).all())
                 if len(diff_b) > 0:

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -387,7 +387,7 @@ class TestMerge(tm.TestCase):
         df2 = df2.sortlevel(0)
 
         joined = df1.join(df2, how='outer')
-        ex_index = index1._tuple_index + index2._tuple_index
+        ex_index = index1._tuple_index.union(index2._tuple_index)
         expected = df1.reindex(ex_index).join(df2.reindex(ex_index))
         expected.index.names = index1.names
         assert_frame_equal(joined, expected)
@@ -397,7 +397,7 @@ class TestMerge(tm.TestCase):
         df2 = df2.sortlevel(1)
 
         joined = df1.join(df2, how='outer').sortlevel(0)
-        ex_index = index1._tuple_index + index2._tuple_index
+        ex_index = index1._tuple_index.union(index2._tuple_index)
         expected = df1.reindex(ex_index).join(df2.reindex(ex_index))
         expected.index.names = index1.names
 

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -59,7 +59,7 @@ class TestTSPlot(tm.TestCase):
         _check_plot_works(df.plot)
 
         # axes freq
-        idx = idx[0:40] + idx[45:99]
+        idx = idx[0:40].union(idx[45:99])
         df2 = DataFrame(np.random.randn(len(idx), 3), index=idx)
         _check_plot_works(df2.plot)
 

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -2898,7 +2898,7 @@ class TestDatetime64(tm.TestCase):
                              periods=100)
         dti2 = DatetimeIndex(freq='Q-JAN', start=datetime(1997, 12, 31),
                              periods=98)
-        self.assertEqual(len(dti1.diff(dti2)), 2)
+        self.assertEqual(len(dti1.difference(dti2)), 2)
 
     def test_fancy_getitem(self):
         dti = DatetimeIndex(freq='WOM-1FRI', start=datetime(2005, 1, 1),


### PR DESCRIPTION
closes #8226 
- ToDo
  - [x] currently a raise `TypeError` (need a better message), possibly could deprecate and just warn
  - [x]  API example

Combining indexes via `+` now requires `.union()`
Diffing indexes via `-` now requires `.diff()`

These make the Indexes use setops (`&`,`|`,`^`) ONLY
numeric ops will work on appropriate Index ONLY (see #8184) (e.g. `DatetimeIndex` +/- `Timedelta` or `TimedeltaIndex` +/- `TImedeltaIndex`)
Also `Int64/Float64Index` would gain ability to `+/-` as well 

This will promote consistency that `+` means add (and not union), and `-` means subtract (and not difference), which IIRC has come up in a few issues
