### PR TITLE
BUG: DataFrame.to_string ignores col_space when header=False

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -756,3 +756,5 @@ Bug Fixes
 - Bug with kde plot and NaNs (:issue:`8182`)
 - Bug in ``GroupBy.count`` with float32 data type were nan values were not excluded (:issue:`8169`).
 - Bug with stacked barplots and NaNs (:issue:`8175`).
+- Bug where ``col_space`` was ignored in ``DataFrame.to_string()`` when ``header=False``
+  (:issue:`8230`).

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -391,7 +391,8 @@ class DataFrameFormatter(TableFormatter):
             for i, c in enumerate(frame):
                 formatter = self._get_formatter(i)
                 fmt_values = self._format_col(i)
-                fmt_values = _make_fixed_width(fmt_values, self.justify)
+                fmt_values = _make_fixed_width(fmt_values, self.justify,
+                                               minimum=(self.col_space or 0))
 
                 stringified.append(fmt_values)
 

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -385,6 +385,13 @@ class TestDataFrameFormatting(tm.TestCase):
         c30 = len(df.to_string(col_space=30).split("\n")[1])
         self.assertTrue(c10 < c20 < c30)
 
+        # GH 8230
+        # col_space wasn't being applied with header=False
+        with_header = df.to_string(col_space=20)
+        with_header_row1 = with_header.splitlines()[1]
+        no_header = df.to_string(col_space=20, header=False)
+        self.assertEqual(len(with_header_row1), len(no_header))
+
     def test_to_string_truncate_indices(self):
         for index in [ tm.makeStringIndex, tm.makeUnicodeIndex, tm.makeIntIndex,
                        tm.makeDateIndex, tm.makePeriodIndex ]:


### PR DESCRIPTION
Fixes #8230. I think this is a pretty easy fix, `col_space` wasn't being used at all when `header` was `False` so just had to add the minimum width. 

Results:

``` python
import pandas as pd
df = pd.DataFrame([[0,1,2]], index=['Sum'], columns=['A','B','C'])

print(df.to_string(col_space=20))
# Output:
                       A                    B                    C
Sum                    0                    1                    2


print(df.to_string(col_space=20, header=False))
# Output:
Sum                    0                    1                    2
```
