### PR TITLE
BUG: interpolate with no nans and limit

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -756,3 +756,8 @@ Bug Fixes
 - Bug with kde plot and NaNs (:issue:`8182`)
 - Bug in ``GroupBy.count`` with float32 data type were nan values were not excluded (:issue:`8169`).
 - Bug with stacked barplots and NaNs (:issue:`8175`).
+
+
+
+- Bug in interpolation methods with the ``limit`` keyword when no values
+needed interpolating (:issue:`7173`).

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1534,6 +1534,8 @@ def interpolate_1d(xvalues, yvalues, method='linear', limit=None,
     def _interp_limit(invalid, limit):
         """mask off values that won't be filled since they exceed the limit"""
         all_nans = np.where(invalid)[0]
+        if all_nans.size == 0: # no nans anyway
+            return []
         violate = [invalid[x:x + limit + 1] for x in all_nans]
         violate = np.array([x.all() & (x.size > limit) for x in violate])
         return all_nans[violate] + limit

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -656,6 +656,13 @@ class TestSeries(tm.TestCase, Generic):
         expected = Series([1., 1., 3.], index=date_range('1/1/2000', periods=3))
         assert_series_equal(result, expected)
 
+    def test_interp_limit_no_nans(self):
+        # GH 7173
+        s = pd.Series([1., 2., 3.])
+        result = s.interpolate(limit=1)
+        expected = s
+        assert_series_equal(result, expected)
+
     def test_describe(self):
         _ = self.series.describe()
         _ = self.ts.describe()


### PR DESCRIPTION
Closes https://github.com/pydata/pandas/issues/7173

I was assuming that there would be at least one NaN when I was adjusting for the limits. Pretty simple fix. 
Here's the intended behavior:

``` python
In [1]: s = pd.Series([1., 2, 3])

In [2]: s.interpolate()
Out[2]: 
0    1
1    2
2    3
dtype: float64

In [3]: s.interpolate(limit=1)
Out[3]: 
0    1
1    2
2    3
dtype: float64
```
