### PR TITLE
BUG: normalize rolling_window() weights, remove scikits-timeseries dependency for testing

### DIFF
--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -310,7 +310,7 @@ keyword. The list of recognized types are:
 
    rolling_window(ser, 5, 'triang')
 
-Note that the ``boxcar`` window is equivalent to ``rolling_mean``:
+Note that the ``boxcar`` window is equivalent to ``rolling_mean``.
 
 .. ipython:: python
 
@@ -336,6 +336,19 @@ This keyword is available in other rolling functions as well.
 
    rolling_mean(ser, 5, center=True)
 
+.. _stats.moments.normalization
+
+.. note::
+
+    In rolling sum mode (``mean=False``) there is no normalization done to the 
+    weights. Passing custom weights of ``[1, 1, 1]`` will yield a different 
+    result than passing weights of ``[2, 2, 2]``, for example. When passing a 
+    ``win_type`` instead of explicitly specifying the weights, the weights are 
+    already normalized so that the largest weight is 1. 
+
+    In contrast, the nature of the rolling mean calculation (``mean=True``)is 
+    such that the weights are normalized with respect to each other. Weights 
+    of ``[1, 1, 1]`` and ``[2, 2, 2]`` yield the same result.
 
 .. _stats.moments.binary:
 

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -383,6 +383,34 @@ Rolling/Expanding Moments API changes
 
     rolling_sum(Series(range(4)), window=3, min_periods=0, center=True)
 
+- :func:`rolling_window` now normalizes the weights properly in rolling mean mode (`mean=True`) so that 
+  the calculated weighted means (e.g. 'triang', 'gaussian') are distributed about the same means as those 
+  calculated without weighting (i.e. 'boxcar'). See :ref:`the note on normalization 
+  <stats.moments.normalization>` for further details. (:issue:`7618`)
+
+  .. ipython:: python
+
+    s = Series([10.5, 8.8, 11.4, 9.7, 9.3])
+
+  Behavior prior to 0.15.0:
+  
+  .. code-block:: python
+
+    In [39]: rolling_window(s, window=3, win_type='triang', center=True)
+    Out[39]:
+    0         NaN
+    1    6.583333
+    2    6.883333
+    3    6.683333
+    4         NaN
+    dtype: float64
+
+  New behavior
+
+  .. ipython:: python
+
+    rolling_window(s, window=3, win_type='triang', center=True)
+
 - Removed ``center`` argument from :func:`expanding_max`, :func:`expanding_min`, :func:`expanding_sum`,
   :func:`expanding_mean`, :func:`expanding_median`, :func:`expanding_std`, :func:`expanding_var`,
   :func:`expanding_skew`, :func:`expanding_kurt`, :func:`expanding_quantile`, :func:`expanding_count`,

--- a/pandas/algos.pyx
+++ b/pandas/algos.pyx
@@ -1897,7 +1897,7 @@ def roll_generic(ndarray[float64_t, cast=True] input,
 
 def roll_window(ndarray[float64_t, ndim=1, cast=True] input,
                 ndarray[float64_t, ndim=1, cast=True] weights,
-                int minp, bint avg=True, bint avg_wgt=False):
+                int minp, bint avg=True):
     """
     Assume len(weights) << len(input)
     """
@@ -1915,7 +1915,7 @@ def roll_window(ndarray[float64_t, ndim=1, cast=True] input,
 
     minp = _check_minp(len(weights), minp, in_n)
 
-    if avg_wgt:
+    if avg:
         for win_i from 0 <= win_i < win_n:
             val_win = weights[win_i]
             if val_win != val_win:
@@ -1956,8 +1956,6 @@ def roll_window(ndarray[float64_t, ndim=1, cast=True] input,
             c = counts[in_i]
             if c < minp:
                 output[in_i] = NaN
-            elif avg:
-                output[in_i] /= c
 
     return output
 

--- a/pandas/util/print_versions.py
+++ b/pandas/util/print_versions.py
@@ -68,7 +68,6 @@ def show_versions(as_json=False):
         ("IPython", lambda mod: mod.__version__),
         ("sphinx", lambda mod: mod.__version__),
         ("patsy", lambda mod: mod.__version__),
-        ("scikits.timeseries", lambda mod: mod.__version__),
         ("dateutil", lambda mod: mod.__version__),
         ("pytz", lambda mod: mod.VERSION),
         ("bottleneck", lambda mod: mod.__version__),


### PR DESCRIPTION
This closes #7618 and removes the dependency on scikits-timeseries for testing rolling_window functions. Scikits-timeseries has not been maintained since 2009, and I had difficulty simply installing it on my system. Instead of using scikits-timeseries to calculate the various rolling moments on randomly generated data, the tests use pre-calculated data.
