### PR TITLE
BUG: boxplot fails when one column is all NaNs

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -764,3 +764,4 @@ Bug Fixes
 needed interpolating (:issue:`7173`).
 - Bug where ``col_space`` was ignored in ``DataFrame.to_string()`` when ``header=False``
   (:issue:`8230`).
+- Bug where ``Dataframe.boxplot()`` failed when entire column was empty (:issue:`8181`).

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1881,6 +1881,11 @@ class TestDataFramePlots(TestPlotBase):
         self.assertEqual(age_ax._sharey, height_ax)
         self.assertIsNone(dummy_ax._sharey)
 
+    @slow
+    def test_boxplot_empty_column(self):
+        df = DataFrame(np.random.randn(20, 4))
+        df.loc[:, 0] = np.nan
+        _check_plot_works(df.boxplot, return_type='axes')
 
     @slow
     def test_kde_df(self):

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -2055,6 +2055,10 @@ class BoxPlot(LinePlot):
         def plotf(ax, y, column_num=None, **kwds):
             if y.ndim == 2:
                 y = [remove_na(v) for v in y]
+                # Boxplot fails with empty arrays, so need to add a NaN
+                #   if any cols are empty
+                # GH 8181
+                y = [v if v.size > 0 else np.array([np.nan]) for v in y]
             else:
                 y = remove_na(y)
             bp = ax.boxplot(y, **kwds)


### PR DESCRIPTION
Fixes #8181. Currently the boxplot fails when trying to compute quantiles on an empty array, which numpy can't deal with. Works okay if we use an array with a single `np.nan` instead, the empty column is just left out of the plot as expected. 

I guess that might be a bit of a hack, relying on how numpy deals with a single `np.nan` in an array versus an empty array? If people think it's too risky to depend on that behaviour I'll try to rethink.

New output:

``` python
import pandas as pd
import numpy as np
import matplotlib.pyplot as plt

df = pd.DataFrame(np.random.randn(100, 4))
df.loc[:, 0] = np.nan
df.plot(kind='box')
plt.show()
```

![missing_boxplot](https://cloud.githubusercontent.com/assets/1460294/4228586/39e763e4-395e-11e4-83d6-2f79fc12e4c3.png)
