### PR TITLE
PERF: Improve performance CustmBusinessDay

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -563,7 +563,7 @@ Performance
 - Performance improvements in ``StataWriter`` when writing large files (:issue:`8079`)
 - Performance and memory usage improvements in multi-key ``groupby`` (:issue:`8128`)
 - Performance improvements in groupby ``.agg`` and ``.apply`` where builtins max/min were not mapped to numpy/cythonized versions (:issue:`7722`)
-
+- Performance improvement in ``CustomBusinessDay``, ``CustomBusinessMonth`` (:issue:`8236`)
 
 
 

--- a/vb_suite/timeseries.py
+++ b/vb_suite/timeseries.py
@@ -293,7 +293,11 @@ dt64 = np.datetime64('2011-01-01 09:00Z')
 day = pd.offsets.Day()
 year = pd.offsets.YearBegin()
 cday = pd.offsets.CustomBusinessDay()
+cmb = pd.offsets.CustomBusinessMonthBegin()
 cme = pd.offsets.CustomBusinessMonthEnd()
+
+hcal = pd.tseries.holiday.USFederalHolidayCalendar()
+cdayh = pd.offsets.CustomBusinessDay.from_various(calendar=hcal)
 """
 timeseries_day_incr = Benchmark("date + day",setup)
 
@@ -306,15 +310,26 @@ timeseries_year_apply = Benchmark("year.apply(date)",setup)
 timeseries_custom_bday_incr = \
     Benchmark("date + cday",setup)
 
+timeseries_custom_bday_decr = \
+    Benchmark("date - cday",setup)
+
 timeseries_custom_bday_apply = \
     Benchmark("cday.apply(date)",setup)
 
 timeseries_custom_bday_apply_dt64 = \
     Benchmark("cday.apply(dt64)",setup)
 
-# Increment by n
-timeseries_custom_bday_incr_n = \
-    Benchmark("date + 10 * cday",setup)
+timeseries_custom_bday_cal_incr = \
+    Benchmark("date + 1 * cdayh",setup)
+
+timeseries_custom_bday_cal_decr = \
+    Benchmark("date - 1 * cdayh",setup)
+
+timeseries_custom_bday_cal_incr_n = \
+    Benchmark("date + 10 * cdayh",setup)
+
+timeseries_custom_bday_cal_incr_neg_n = \
+    Benchmark("date - 10 * cdayh",setup)
 
 # Increment custom business month
 timeseries_custom_bmonthend_incr = \
@@ -322,6 +337,16 @@ timeseries_custom_bmonthend_incr = \
 
 timeseries_custom_bmonthend_incr_n = \
     Benchmark("date + 10 * cme",setup)
+
+timeseries_custom_bmonthend_decr_n = \
+    Benchmark("date - 10 * cme",setup)
+
+timeseries_custom_bmonthbegin_incr_n = \
+    Benchmark("date + 10 * cmb",setup)
+
+timeseries_custom_bmonthbegin_decr_n = \
+    Benchmark("date - 10 * cmb",setup)
+
 
 #----------------------------------------------------------------------
 # month/quarter/year start/end accessors
@@ -357,4 +382,3 @@ timeseries_iter_periodindex = Benchmark('iter_n(idx2)', setup)
 timeseries_iter_datetimeindex_preexit = Benchmark('iter_n(idx1, M)', setup)
 
 timeseries_iter_periodindex_preexit = Benchmark('iter_n(idx2, M)', setup)
-


### PR DESCRIPTION
Closes #8236 

`CustomBusinessDay` is now fast with holiday calendar and incrementing in different ways. 
import pandas as pd
import numpy as np
import datetime as dt

date = pd.Timestamp('20120101')
cbday = pd.offsets.CustomBusinessDay()
date + cbday
%timeit date + cbday
10000 loops, best of 3: 17.2 µs per loop

hdays = [dt.datetime(2013,1,1) for ele in range(1000)]
cbdayh = pd.offsets.CustomBusinessDay.from_various(holidays=hdays)
%timeit date + cbdayh
%timeit date + 2 \* cbdayh
%timeit date - 1 \* cbdayh
%timeit date - 10 \* cbday

100000 loops, best of 3: 14.6 µs per loop
100000 loops, best of 3: 19.7 µs per loop
10000 loops, best of 3: 22.7 µs per loop
10000 loops, best of 3: 22.3 µs per loop

Please check whether you agree with the way I initialize custom offsets now (using classmethod). 
