### PR TITLE
Clarification to .ix functionality

### DIFF
--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -96,14 +96,18 @@ of multi-axis indexing.
   See more at :ref:`Selection by Position <indexing.integer>`
 
 - ``.ix`` supports mixed integer and label based access. It is primarily label
-  based, but will fall back to integer positional access. ``.ix`` is the most
-  general and will support any of the inputs to ``.loc`` and ``.iloc``, as well
-  as support for floating point label schemes. ``.ix`` is especially useful
-  when dealing with mixed positional and label based hierarchical indexes.
-  As using integer slices with ``.ix`` have different behavior depending on
-  whether the slice is interpreted as position based or label based, it's
-  usually better to be explicit and use ``.iloc`` or ``.loc``.
+  based, but will fall back to integer positional access unless the corresponding
+  row or column index is of integer type. ``.ix`` is the most general and will 
+  support any of the inputs in ``.loc`` and ``.iloc`` with a notable exception that 
+  ``.ix`` does not support positional access in the case when the corresponding
+  row or column index is of integer type. ``.ix`` also supports floating point
+  label schemes. ``.ix`` is exceptionally useful when dealing with mixed positional
+  and label based hierachical indexes.
 
+  When the DataFrame has an integer index or integer columns, positional access
+  is not supported in the corresponding dimension. Thus, in such cases it's 
+  usually better to be explicit and use ``.iloc`` or ``.loc``.
+  
   See more at :ref:`Advanced Indexing <advanced>`, :ref:`Advanced
   Hierarchical <advanced.advanced_hierarchical>` and :ref:`Fallback Indexing
   <advanced.fallback>`


### PR DESCRIPTION
Made clear that .ix does not support positional indexing
in the case where the corresponding dimension has an
integer index.
