### PR TITLE
use z-scores in rolling skew/kurt calculations

### DIFF
--- a/pandas/stats/tests/test_moments.py
+++ b/pandas/stats/tests/test_moments.py
@@ -321,6 +321,21 @@ class TestMoments(tm.TestCase):
         self._check_moment_func(mom.rolling_kurt,
                                 lambda x: kurtosis(x, bias=False))
 
+    def test_affine_invariance(self):
+        """
+        rolling skew/kurt should be invariant under affine transformations
+        """
+
+        xs = np.random.rand(50)
+        window = 10
+
+        for f in mom.rolling_skew, mom.rolling_kurt:
+            left = f(xs, window)
+
+            for a, b in [(1, 100), (1, 5000), (100, 100), (100, 5000)]:
+                right = f(a*xs  + b, window)
+                assert_almost_equal(left, right)
+
     def test_fperr_robustness(self):
         # TODO: remove this once python 2.5 out of picture
         if PY3:
@@ -524,7 +539,7 @@ class TestMoments(tm.TestCase):
         self.assertTrue(np.abs(result - 1) < 1e-2)
 
         s = Series([1.0, 2.0, 4.0, 8.0])
-        
+
         expected = Series([1.0, 1.6, 2.736842, 4.923077])
         for f in [lambda s: mom.ewma(s, com=2.0, adjust=True),
                   lambda s: mom.ewma(s, com=2.0, adjust=True, ignore_na=False),
@@ -750,7 +765,7 @@ class TestMoments(tm.TestCase):
 
             for (std, var, cov) in [(std_biased, var_biased, cov_biased),
                                     (std_unbiased, var_unbiased, cov_unbiased)]:
-                
+
                 # check that var(x), std(x), and cov(x) are all >= 0
                 var_x = var(x)
                 std_x = std(x)
@@ -762,7 +777,7 @@ class TestMoments(tm.TestCase):
 
                     # check that var(x) == cov(x, x)
                     assert_equal(var_x, cov_x_x)
-                
+
                 # check that var(x) == std(x)^2
                 assert_equal(var_x, std_x * std_x)
 
@@ -796,7 +811,7 @@ class TestMoments(tm.TestCase):
                             cov_x_y = cov(x, y)
                             cov_y_x = cov(y, x)
                             assert_equal(cov_x_y, cov_y_x)
-                    
+
                             # check that cov(x, y) == (var(x+y) - var(x) - var(y)) / 2
                             var_x_plus_y = var(x + y)
                             var_y = var(y)
@@ -1007,7 +1022,7 @@ class TestMoments(tm.TestCase):
                                         expected.iloc[:, i, j] = rolling_f(x.iloc[:, i], x.iloc[:, j],
                                                                            window=window, min_periods=min_periods, center=center)
                                 assert_panel_equal(rolling_f_result, expected)
-    
+
     # binary moments
     def test_rolling_cov(self):
         A = self.series
@@ -1432,7 +1447,7 @@ class TestMoments(tm.TestCase):
         assert_frame_equal(result2, expected)
         assert_frame_equal(result3, expected)
         assert_frame_equal(result4, expected)
-    
+
     def test_pairwise_stats_column_names_order(self):
         # GH 7738
         df1s = [DataFrame([[2,4],[1,2],[5,2],[8,1]], columns=[0,1]),


### PR DESCRIPTION
adds _some_ stability to rolling `skew` and `kurt` calculation by using the `z-scores` instead of original values;  related: https://github.com/pydata/pandas/issues/6929

on master:

```
In [3]: np.random.seed(2718281)
In [4]: xs = np.random.rand(10)

In [5]: pd.stats.moments.rolling_skew(xs, 4) - pd.stats.moments.rolling_skew(xs + 5000, 4)
Out[5]: 
array([             nan,              nan,              nan,
        -1.64816426e-03,   1.10392004e-03,   1.09544324e-03,
         7.99253200e-03,   8.66733795e-05,  -4.48450842e-03,
        -6.03475754e-03])

In [6]: pd.stats.moments.rolling_kurt(xs, 4) - pd.stats.moments.rolling_kurt(xs + 100, 4)
Out[6]: 
array([             nan,              nan,              nan,
        -1.39880824e-04,  -2.91491317e-04,  -2.35463343e-04,
        -7.36046530e-04,  -3.99141811e-04,  -8.61177376e-05,
         9.26058376e-06])
```

on branch:

```
In [7]: pd.stats.moments.rolling_skew(xs, 4) - pd.stats.moments.rolling_skew(xs + 5000, 4)
Out[7]: 
array([             nan,              nan,              nan,
        -1.03450581e-12,   7.36521955e-13,   2.42605935e-12,
        -2.43799425e-12,  -1.85962357e-12,  -1.06048503e-12,
         1.66638925e-12])

In [8]: pd.stats.moments.rolling_kurt(xs, 4) - pd.stats.moments.rolling_kurt(xs + 100, 4)
Out[8]: 
array([             nan,              nan,              nan,
        -1.24344979e-13,  -7.99360578e-14,   6.75015599e-14,
        -9.05941988e-14,  -5.15143483e-14,  -1.11910481e-13,
        -5.15143483e-14])
```

This does _not_ handle all situations that causes instability, but I think it is generally more stable to work with z-scores; In particular, affine transformations generate same results.

Also, `input` is a python 3 built-in. I suggest renaming all instances of `input` in `algo.pyx` file to `inp` or something else.
