### PR TITLE
BUG: DataFrame.to_html() fails when index=False and max_rows is specified

### DIFF
--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -962,12 +962,17 @@ class HTMLFormatter(TableFormatter):
         else:
             index_values = self.fmt.tr_frame.index.format()
 
+        if include_index:
+            nindex_levels = 1
+        else:
+            nindex_levels = 0
+
         for i in range(nrows):
 
             if truncate_v and i == (self.fmt.tr_row_num):
                 str_sep_row = [ '...' for ele in row ]
                 self.write_tr(str_sep_row, indent, self.indent_delta, tags=None,
-                              nindex_levels=1)
+                              nindex_levels=nindex_levels)
 
             row = []
             if include_index:
@@ -977,10 +982,7 @@ class HTMLFormatter(TableFormatter):
             if truncate_h:
                 dot_col_ix = self.fmt.tr_col_num + 1
                 row.insert(dot_col_ix, '...')
-            if include_index:
-                nindex_levels = 1
-            else:
-                nindex_levels = 0
+
             self.write_tr(row, indent, self.indent_delta, tags=None,
                           nindex_levels=nindex_levels)
 

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -937,9 +937,12 @@ class HTMLFormatter(TableFormatter):
             else:
                 self._write_regular_rows(fmt_values, indent)
         else:
-            for i in range(len(self.frame)):
-                row = [fmt_values[j][i] for j in range(len(self.columns))]
-                self.write_tr(row, indent, self.indent_delta, tags=None)
+            if isinstance(self.frame.index, MultiIndex):
+                for i in range(len(self.frame)):
+                    row = [fmt_values[j][i] for j in range(len(self.columns))]
+                    self.write_tr(row, indent, self.indent_delta, tags=None)
+            else:
+                self._write_regular_rows(fmt_values, indent, include_index=False)
 
         indent -= self.indent_delta
         self.write('</tbody>', indent)
@@ -947,7 +950,7 @@ class HTMLFormatter(TableFormatter):
 
         return indent
 
-    def _write_regular_rows(self, fmt_values, indent):
+    def _write_regular_rows(self, fmt_values, indent, include_index=True):
         truncate_h = self.fmt.truncate_h
         truncate_v = self.fmt.truncate_v
 
@@ -967,14 +970,19 @@ class HTMLFormatter(TableFormatter):
                               nindex_levels=1)
 
             row = []
-            row.append(index_values[i])
+            if include_index:
+                row.append(index_values[i])
             row.extend(fmt_values[j][i] for j in range(ncols))
 
             if truncate_h:
                 dot_col_ix = self.fmt.tr_col_num + 1
                 row.insert(dot_col_ix, '...')
+            if include_index:
+                nindex_levels = 1
+            else:
+                nindex_levels = 0
             self.write_tr(row, indent, self.indent_delta, tags=None,
-                          nindex_levels=1)
+                          nindex_levels=nindex_levels)
 
     def _write_hierarchical_rows(self, fmt_values, indent):
         template = 'rowspan="%d" valign="top"'

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -881,6 +881,36 @@ class TestDataFrameFormatting(tm.TestCase):
             expected = expected.decode('utf-8')
         self.assertEqual(result, expected)
 
+    def test_to_html_truncate_no_index(self):
+        df = pd.DataFrame({'a': np.arange(0, 10), 'b': np.arange(9, -1, -1)})
+        result = df.to_html(index=False, max_rows=3)
+        expected = '''\
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th>a</th>
+      <th>b</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td> 0</td>
+      <td> 9</td>
+    </tr>
+    <tr>
+      <th>...</th>
+      <td>...</td>
+    </tr>
+    <tr>
+      <td> 9</td>
+      <td> 0</td>
+    </tr>
+  </tbody>
+</table>'''
+        if sys.version_info[0] < 3:
+            expected = expected.decode('utf-8')
+        self.assertEqual(result, expected)
+
     def test_to_html_truncate_multi_index(self):
         arrays = [['bar', 'bar', 'baz', 'baz', 'foo', 'foo', 'qux', 'qux'],
                   ['one', 'two', 'one', 'two', 'one', 'two', 'one', 'two']]

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -898,7 +898,7 @@ class TestDataFrameFormatting(tm.TestCase):
       <td> 9</td>
     </tr>
     <tr>
-      <th>...</th>
+      <td>...</td>
       <td>...</td>
     </tr>
     <tr>


### PR DESCRIPTION
This addresses #8273, but it doesn't actually fully fix the issue, since the same bug still occurs when we have a MultiIndex. I've got a fix for the single-index case, and I'm not sure if I have time to decipher what's happening with hierarchical indexes right now. I'll open a new issue for the MultiIndex case if that's OK, having a MultiIndexed dataframe and then not printing the index seems like a bit of an edge case to me anyway.

``` python
import pandas as pd
import numpy as np

df = pd.DataFrame({'a': np.arange(0, 10), 'b': np.arange(9, -1, -1)})
df.to_html(max_rows=3, index=False)
```

now produces:

<table border="1" class="dataframe">
  <thead>
    <tr style="text-align: right;">
      <th>a</th>
      <th>b</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td> 0</td>
      <td> 9</td>
    </tr>
    <tr>
      <td>...</td>
      <td>...</td>
    </tr>
    <tr>
      <td> 9</td>
      <td> 0</td>
    </tr>
  </tbody>
</table>


as expected.
