### PR TITLE
BUG: fix setting dataframe column to a sparse array

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -910,3 +910,4 @@ Bug Fixes
 - Bug where ``col_space`` was ignored in ``DataFrame.to_string()`` when ``header=False`` (:issue:`8230`).
 - Bug with ``DatetimeIndex.asof`` incorrectly matching partial strings and returning the wrong date (:issue:`8245`).
 - Bug in plotting methods modifying the global matplotlib rcParams (:issue:`8242`).
+- Bug in ``DataFrame.__setitem__`` that caused errors when setting a dataframe column to a sparse array (:issue:`8131`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -43,6 +43,7 @@ from numpy import percentile as _quantile
 from pandas.compat import(range, zip, lrange, lmap, lzip, StringIO, u,
                           OrderedDict, raise_with_traceback)
 from pandas import compat
+from pandas.sparse.array import SparseArray
 from pandas.util.decorators import deprecate, Appender, Substitution, \
     deprecate_kwarg
 
@@ -2164,8 +2165,8 @@ class DataFrame(NDFrame):
             value = np.repeat(value, len(self.index)).astype(dtype)
             value = com._possibly_cast_to_datetime(value, dtype)
 
-        # return categoricals directly
-        if isinstance(value, Categorical):
+        # return unconsolidatables directly
+        if isinstance(value, (Categorical, SparseArray)):
             return value
 
         # broadcast across multiple columns if necessary

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1791,6 +1791,20 @@ class CheckIndexing(object):
         expect = df.iloc[[1, -1], 0]
         tm.assert_series_equal(df.loc[0.2, 'a'], expect)
 
+    def test_setitem_with_sparse_value(self):
+        # GH8131
+        df = pd.DataFrame({'c_1':['a', 'b', 'c'], 'n_1': [1., 2., 3.]})
+        sp_series = pd.Series([0, 0, 1]).to_sparse(fill_value=0)
+        df['new_column'] = sp_series
+        tm.assert_series_equal(df['new_column'], sp_series)
+
+    def test_setitem_with_unaligned_sparse_value(self):
+        df = pd.DataFrame({'c_1':['a', 'b', 'c'], 'n_1': [1., 2., 3.]})
+        sp_series = (pd.Series([0, 0, 1], index=[2, 1, 0])
+                     .to_sparse(fill_value=0))
+        df['new_column'] = sp_series
+        tm.assert_series_equal(df['new_column'], pd.Series([1, 0, 0]))
+
 
 _seriesd = tm.getSeriesData()
 _tsd = tm.getTimeSeriesData()


### PR DESCRIPTION
This should fix #8131.
