### PR TITLE
ERR: DataFrame.from_records raises misleading exception on shape mismatch

### DIFF
--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -3507,7 +3507,7 @@ def create_block_manager_from_arrays(arrays, names, axes):
         mgr._consolidate_inplace()
         return mgr
     except (ValueError) as e:
-        construction_error(len(arrays), arrays[0].shape[1:], axes, e)
+        construction_error(len(arrays), arrays[0].shape, axes, e)
 
 
 def form_blocks(arrays, names, axes):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4032,7 +4032,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         tm.assert_frame_equal(DataFrame.from_records(arr2), DataFrame(arr2))
 
         # wrong length
-        msg = r'Shape of passed values is \(3,\), indices imply \(3, 1\)'
+        msg = r'Shape of passed values is \(3, 2\), indices imply \(3, 1\)'
         with assertRaisesRegexp(ValueError, msg):
             DataFrame.from_records(arr, index=index[:-1])
 


### PR DESCRIPTION
Currently, `DataFrame.from_records` raises a misleading exception when the shape of the input data do not match the shape implied by the axes:

``` python
In [1]: import pandas as pd

In [2]: pd.DataFrame.from_records([(0, 1), (0, 1), (0, 1)], index=[0, 1],
   ...:                           columns=['A', 'B'])
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-b8c920ac0f12> in <module>()
      1 pd.DataFrame.from_records([(0, 1), (0, 1), (0, 1)], index=[0, 1],
----> 2                           columns=['A', 'B'])

/Users/afni/homebrew/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pandas/core/frame.pyc in from_records(cls, data, index, exclude, columns, coerce_float, nrows)
    833 
    834         mgr = _arrays_to_mgr(arrays, arr_columns, result_index,
--> 835                              columns)
    836 
    837         return cls(mgr)

/Users/afni/homebrew/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pandas/core/frame.pyc in _arrays_to_mgr(arrays, arr_names, index, columns, dtype)
   4628     axes = [_ensure_index(columns), _ensure_index(index)]
   4629 
-> 4630     return create_block_manager_from_arrays(arrays, arr_names, axes)
   4631 
   4632 

/Users/afni/homebrew/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pandas/core/internals.pyc in create_block_manager_from_arrays(arrays, names, axes)
   3238         return mgr
   3239     except (ValueError) as e:
-> 3240         construction_error(len(arrays), arrays[0].shape[1:], axes, e)
   3241 
   3242 

/Users/afni/homebrew/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/pandas/core/internals.pyc in construction_error(tot_items, block_shape, axes, e)
   3209         raise e
   3210     raise ValueError("Shape of passed values is {0}, indices imply {1}".format(
-> 3211         passed,implied))
   3212 
   3213 

ValueError: Shape of passed values is (2,), indices imply (2, 2)
```

This error message leads the user to believe that the error is internal (after all, the input data were _definitely_ 2-dimensional) and hides the true error, which is that the shape of the passed values is actually `(2, 3)`.

For some reason, this behavior was explicitly specified by a test.
