### PR TITLE
VIS: default LinePlot rotation of 0

### DIFF
--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -1118,6 +1118,7 @@ or columns needed, given the other.
 The above example is identical to using
 
 .. ipython:: python
+
    df.plot(subplots=True, layout=(-1, 3), figsize=(6, 6));
 
 The required number of rows (2) is inferred from the number of series to plot

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -573,6 +573,10 @@ class TestSeriesPlots(TestPlotBase):
 
     def test_rotation(self):
         df = DataFrame(randn(5, 5))
+        # Default rot 0
+        axes = df.plot()
+        self._check_ticks_props(axes, xrot=0)
+
         axes = df.plot(rot=30)
         self._check_ticks_props(axes, xrot=30)
 
@@ -974,7 +978,7 @@ class TestDataFramePlots(TestPlotBase):
             self._check_visible(ax.xaxis)
             self._check_visible(ax.get_xticklabels())
             self._check_visible([ax.xaxis.get_label()])
-            self._check_ticks_props(ax, xrot=30)
+            self._check_ticks_props(ax, xrot=0)
 
         _check_plot_works(df.plot, title='blah')
 
@@ -1178,7 +1182,7 @@ class TestDataFramePlots(TestPlotBase):
             self._check_visible(axes[-1].get_xticklabels(minor=True))
             self._check_visible(axes[-1].xaxis.get_label())
             self._check_visible(axes[-1].get_yticklabels())
-            self._check_ticks_props(axes, xrot=30)
+            self._check_ticks_props(axes, xrot=0)
 
             axes = df.plot(kind=kind, subplots=True, sharex=False, rot=45, fontsize=7)
             for ax in axes:

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -799,7 +799,11 @@ class MPLPlot(object):
 
         if rot is not None:
             self.rot = rot
+            # need to know for format_date_labels since it's rotated to 30 by
+            # default
+            self._rot_set = True
         else:
+            self._rot_set = False
             if isinstance(self._default_rot, dict):
                 self.rot = self._default_rot[self.kind]
             else:
@@ -1498,7 +1502,7 @@ class HexBinPlot(MPLPlot):
 
 class LinePlot(MPLPlot):
 
-    _default_rot = 30
+    _default_rot = 0
     orientation = 'vertical'
 
     def __init__(self, data, **kwargs):
@@ -1679,6 +1683,10 @@ class LinePlot(MPLPlot):
 
         for ax in self.axes:
             if condition:
+                # irregular TS rotated 30 deg. by default
+                # probably a better place to check / set this.
+                if not self._rot_set:
+                    self.rot = 30
                 format_date_labels(ax, rot=self.rot)
 
             if index_name is not None:


### PR DESCRIPTION
Closes https://github.com/pydata/pandas/issues/8150

``` python
In [1]: s = pd.Series([1,2,3])

In [2]: s.plot()
Out[2]: <matplotlib.axes._subplots.AxesSubplot at 0x10da02d68>
```

![ex](https://cloud.githubusercontent.com/assets/1312546/4310965/f43fd70c-3eaa-11e4-9e2a-aed38bd73ae3.png)

No release notes since this is just changing it back to how it was for the last release.
