### PR TITLE
VIS: Hide labels for NaN/zeros in boxplt [WIP]

### DIFF
--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -628,6 +628,13 @@ class TestSeriesPlots(TestPlotBase):
         ax = _check_plot_works(series.plot, kind='pie')
         self._check_text_labels(ax.texts, series.index)
 
+    def test_pie_nan(self):
+        s = Series([1, np.nan, 1, 1])
+        ax = s.plot(kind='pie', legend=True)
+        expected = ['0', '', '2', '3']
+        result = [x.get_text() for x in ax.texts]
+        self.assertEqual(result, expected)
+
     @slow
     def test_hist_df_kwargs(self):
         df = DataFrame(np.random.randn(10, 2))
@@ -2717,6 +2724,22 @@ class TestDataFramePlots(TestPlotBase):
             self._check_text_labels(ax.texts, labels)
             self._check_colors(ax.patches, facecolors=color_args)
 
+    def test_pie_df_nan(self):
+        df = DataFrame(np.random.rand(4, 4))
+        for i in range(4):
+            df.iloc[i, i] = np.nan
+        fig, axes = self.plt.subplots(ncols=4)
+        df.plot(kind='pie', subplots=True, ax=axes, legend=True)
+
+        base_expected = ['0', '1', '2', '3']
+        for i, ax in enumerate(axes):
+            expected = list(base_expected)  # copy
+            expected[i] = ''
+            result = [x.get_text() for x in ax.texts]
+            self.assertEqual(result, expected)
+            # legend labels
+            self.assertEqual([x.get_text() for x in ax.get_legend().get_texts()],
+                              base_expected)
     def test_errorbar_plot(self):
         d = {'x': np.arange(12), 'y': np.arange(12, 0, -1)}
         df = DataFrame(d)

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -2033,10 +2033,20 @@ class PiePlot(MPLPlot):
 
             kwds = self.kwds.copy()
 
+            def blank_labeler(label, value):
+                if value == 0:
+                    return ''
+                else:
+                    return label
+
             idx = [com.pprint_thing(v) for v in self.data.index]
             labels = kwds.pop('labels', idx)
             # labels is used for each wedge's labels
-            results = ax.pie(y, labels=labels, **kwds)
+            # Blank out labels for values of 0 so they don't overlap
+            # with nonzero wedges
+            blabels = [blank_labeler(label, value) for
+                       label, value in zip(labels, y)]
+            results = ax.pie(y, labels=blabels, **kwds)
 
             if kwds.get('autopct', None) is not None:
                 patches, texts, autotexts = results


### PR DESCRIPTION
Closes: https://github.com/pydata/pandas/issues/8198

The idea is to hide the labels around the pie plot so they don't overlap w/ nonzero labels. The NaN/zero labels should still be visible in the legend to indicate that there's missing data. There's a picture of the problem in the linked issue.

NaNs in the top row of plots:

```
In [1]: df = pd.DataFrame(np.random.rand(4, 4))

In [2]: df2 = df.copy()

In [3]: for i in range(len(df)):
   ...:     df.iloc[i, i] = np.nan
   ...:     

In [4]: fig, axes = plt.subplots(figsize=(16, 8), nrows=2, ncols=4)

In [5]: df.plot(kind='pie', subplots=True, ax=axes.ravel()[:4])
In [6]: df2.plot(kind='pie', subplots=True, ax=axes.ravel()[4:])
```

![ex](https://cloud.githubusercontent.com/assets/1312546/4320249/881bf944-3f35-11e4-85c8-bb5c4d539435.png)

Right now, for **DataFrames only** the NaN/zero labels aren't being put in the legend (or they aren't showing up). Still need to figure out why. It works fine for Series:

```
In [8]: df[0].plot(kind='pie', figsize=(4,4), legend=True)
```

![ex2](https://cloud.githubusercontent.com/assets/1312546/4320269/b75df6ee-3f35-11e4-9774-50f8aed26594.png)
