### PR TITLE
BUG: Exception raised when `to_sql` used to insert empty dataframe

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -654,8 +654,15 @@ class PandasSQLTable(PandasObject):
         keys, data_list = self.insert_data()
 
         nrows = len(self.frame)
+
+        if nrows == 0:
+            return
+
         if chunksize is None: 
             chunksize = nrows
+        elif chunksize == 0:
+            raise ValueError('chunksize argument should be non-zero')
+            
         chunks = int(nrows / chunksize) + 1
 
         with self.pd_sql.run_transaction() as conn:

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -253,6 +253,10 @@ class PandasSQLTest(unittest.TestCase):
         # Nuke table
         self.drop_table('test_frame1')
 
+    def _to_sql_empty(self):
+        self.drop_table('test_frame1')
+        self.pandasSQL.to_sql(self.test_frame1.iloc[:0], 'test_frame1')
+
     def _to_sql_fail(self):
         self.drop_table('test_frame1')
 
@@ -850,6 +854,9 @@ class _TestSQLAlchemy(PandasSQLTest):
     def test_to_sql(self):
         self._to_sql()
 
+    def test_to_sql_empty(self):
+        self._to_sql_empty()
+
     def test_to_sql_fail(self):
         self._to_sql_fail()
 
@@ -1345,6 +1352,9 @@ class TestSQLiteLegacy(PandasSQLTest):
 
     def test_to_sql(self):
         self._to_sql()
+
+    def test_to_sql_empty(self):
+        self._to_sql_empty()
 
     def test_to_sql_fail(self):
         self._to_sql_fail()


### PR DESCRIPTION
Right now, if inserting an empty table (no rows) using `to_sql`, the following exception is raised:

```
...
  File "/Users/artemy/dev/pandas/pandas/io/sql.py", line 1220, in to_sql
    table.insert(chunksize)
  File "/Users/artemy/dev/pandas/pandas/io/sql.py", line 659, in insert
    chunks = int(nrows / chunksize) + 1
ZeroDivisionError: division by zero
```

This fixes this bug and adds tests for it.
