### PR TITLE
BUG: Bug in .at that would accept integer indexers on a non-integer index and do fallback (GH7814)

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -909,7 +909,7 @@ Bug Fixes
 
 - Bug in accessing groups from a ``GroupBy`` when the original grouper
   was a tuple (:issue:`8121`).
-
+- Bug in ``.at`` that would accept integer indexers on a non-integer index and do fallback (:issue:`7814`)
 - Bug with kde plot and NaNs (:issue:`8182`)
 - Bug in ``GroupBy.count`` with float32 data type were nan values were not excluded (:issue:`8169`).
 - Bug with stacked barplots and NaNs (:issue:`8175`).

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1510,6 +1510,18 @@ class _AtIndexer(_ScalarAccessIndexer):
     """ label based scalar accessor """
     _takeable = False
 
+    def _convert_key(self, key):
+        """ require they keys to be the same type as the index (so we don't fallback) """
+        for ax, i in zip(self.obj.axes, key):
+            if ax.is_integer():
+                if not com.is_integer(i):
+                    raise ValueError("At based indexing on an integer index can only have integer "
+                                     "indexers")
+            else:
+                if com.is_integer(i):
+                    raise ValueError("At based indexing on an non-integer index can only have non-integer "
+                                     "indexers")
+        return key
 
 class _iAtIndexer(_ScalarAccessIndexer):
 

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -866,6 +866,28 @@ class TestIndexing(tm.TestCase):
             df.loc[[3]]
         self.assertRaises(KeyError, f)
 
+        # at should not fallback
+        # GH 7814
+        s = Series([1,2,3], index=list('abc'))
+        result = s.at['a']
+        self.assertEquals(result, 1)
+        self.assertRaises(ValueError, lambda : s.at[0])
+
+        df = DataFrame({'A' : [1,2,3]},index=list('abc'))
+        result = df.at['a','A']
+        self.assertEquals(result, 1)
+        self.assertRaises(ValueError, lambda : df.at['a',0])
+
+        s = Series([1,2,3], index=[3,2,1])
+        result = s.at[1]
+        self.assertEquals(result, 3)
+        self.assertRaises(ValueError, lambda : s.at['a'])
+
+        df = DataFrame({0 : [1,2,3]},index=[3,2,1])
+        result = df.at[1,0]
+        self.assertEquals(result, 3)
+        self.assertRaises(ValueError, lambda : df.at['a',0])
+
     def test_loc_getitem_label_slice(self):
 
         # label slices (with ints)


### PR DESCRIPTION
closes #7814 
