### PR TITLE
BUG: to_clipboard output formatting

### DIFF
--- a/pandas/io/clipboard.py
+++ b/pandas/io/clipboard.py
@@ -1,5 +1,5 @@
 """ io on the clipboard """
-from pandas import compat, get_option, DataFrame
+from pandas import compat, get_option, option_context, DataFrame
 from pandas.compat import StringIO
 
 
@@ -91,7 +91,8 @@ def to_clipboard(obj, excel=None, sep=None, **kwargs):  # pragma: no cover
 
     if isinstance(obj, DataFrame):
         # str(df) has various unhelpful defaults, like truncation
-        objstr = obj.to_string()
+        with option_context('display.max_colwidth', 999999):
+            objstr = obj.to_string(sep=sep, **kwargs)
     else:
         objstr = str(obj)
     clipboard_set(objstr)

--- a/pandas/io/clipboard.py
+++ b/pandas/io/clipboard.py
@@ -92,7 +92,7 @@ def to_clipboard(obj, excel=None, sep=None, **kwargs):  # pragma: no cover
     if isinstance(obj, DataFrame):
         # str(df) has various unhelpful defaults, like truncation
         with option_context('display.max_colwidth', 999999):
-            objstr = obj.to_string(sep=sep, **kwargs)
+            objstr = obj.to_string(**kwargs)
     else:
         objstr = str(obj)
     clipboard_set(objstr)

--- a/pandas/io/tests/test_clipboard.py
+++ b/pandas/io/tests/test_clipboard.py
@@ -35,6 +35,12 @@ class TestClipboard(tm.TestCase):
         cls.data['mixed'] = DataFrame({'a': np.arange(1.0, 6.0) + 0.01,
                                        'b': np.arange(1, 6),
                                        'c': list('abcde')})
+
+        # Test columns exceeding "max_colwidth"
+        _cw = get_option('display.max_colwidth') + 1
+        cls.data['colwidth'] = mkdf(5, 3, data_gen_f=lambda *args: 'x' * _cw,
+                                   c_idx_type='s', r_idx_type='i',
+                                   c_idx_names=[None], r_idx_names=[None])
         # Test GH-5346
         max_rows = get_option('display.max_rows')
         cls.data['longdf'] = mkdf(max_rows+1, 3, data_gen_f=lambda *args: randint(2),


### PR DESCRIPTION
closes  https://github.com/pydata/pandas/issues/8305

@jreback I made the simple patch as you suggested for fixing truncated columns, although problem seems to be https://github.com/pydata/pandas/blob/master/pandas/core/format.py#L2118 called from https://github.com/pydata/pandas/blob/master/pandas/core/format.py#L411
Perhaps `conf_max` should respect if caller passes `minimum` argument so it wont truncate?

Second issue, where `index=False` was ignored (or just any other argument when `excel=False`) was because arguments were not passed to underlying function `obj.to_string()` and that was easy fix.

I added test for checking if column width greater then `max_colwidth` passes clipboard test.
