### PR TITLE
ENH/BUG: allow timedelta resamples

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -563,7 +563,7 @@ TimedeltaIndex/Scalar
 We introduce a new scalar type ``Timedelta``, which is a subclass of ``datetime.timedelta``, and behaves in a similar manner,
 but allows compatibility with ``np.timedelta64`` types as well as a host of custom representation, parsing, and attributes.
 This type is very similar to how ``Timestamp`` works for ``datetimes``. It is a nice-API box for the type. See the :ref:`docs <timedeltas.timedeltas>`.
-(:issue:`3009`, :issue:`4533`, :issue:`8209`, :issue:`8187`, :issue:`8190`, :issue:`7869`, :issue:`7661`)
+(:issue:`3009`, :issue:`4533`, :issue:`8209`, :issue:`8187`, :issue:`8190`, :issue:`7869`, :issue:`7661`, :issue:`8345`)
 
 .. warning::
 

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -146,7 +146,7 @@ class TestResample(tm.TestCase):
         data = np.arange(5, dtype=np.int64)
         ind = pd.DatetimeIndex(start='2014-01-01', periods=len(data), freq='d')
         df = pd.DataFrame({"A": data, "B": data}, index=ind)
-        
+
         def fn(x, a=1):
             return str(type(x))
 
@@ -164,7 +164,18 @@ class TestResample(tm.TestCase):
         assert_frame_equal(df_standard, df_partial)
         assert_frame_equal(df_standard, df_partial2)
         assert_frame_equal(df_standard, df_class)
-        
+
+    def test_resample_with_timedeltas(self):
+
+        expected = DataFrame({'A' : np.arange(1480)})
+        expected = expected.groupby(expected.index // 30).sum()
+        expected.index = pd.timedelta_range('0 days',freq='30T',periods=50)
+
+        df = DataFrame({'A' : np.arange(1480)},index=pd.to_timedelta(np.arange(1480),unit='T'))
+        result = df.resample('30T',how='sum')
+
+        assert_frame_equal(result, expected)
+
     def test_resample_basic_from_daily(self):
         # from daily
         dti = DatetimeIndex(

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -265,6 +265,10 @@ class TestTimedeltas(tm.TestCase):
         result = timedelta_range('1 days, 00:00:02',periods=5,freq='2D')
         tm.assert_index_equal(result, expected)
 
+        expected = to_timedelta(np.arange(50),unit='T')*30
+        result = timedelta_range('0 days',freq='30T',periods=50)
+        tm.assert_index_equal(result, expected)
+
     def test_numeric_conversions(self):
         self.assertEqual(ct(0), np.timedelta64(0,'ns'))
         self.assertEqual(ct(10), np.timedelta64(10,'ns'))


### PR DESCRIPTION
- [x] docs

```
In [4]: pd.set_option('max_rows',10)

In [5]: df = DataFrame({'A' : np.arange(1480)},index=pd.to_timedelta(np.arange(1480),unit='T'))

In [6]: df
Out[6]: 
                    A
0 days 00:00:00     0
0 days 00:01:00     1
0 days 00:02:00     2
0 days 00:03:00     3
0 days 00:04:00     4
...               ...
1 days 00:35:00  1475
1 days 00:36:00  1476
1 days 00:37:00  1477
1 days 00:38:00  1478
1 days 00:39:00  1479

[1480 rows x 1 columns]

In [7]: df.resample('30T',how='sum')
Out[7]: 
                     A
0 days 00:00:00    435
0 days 00:30:00   1335
0 days 01:00:00   2235
0 days 01:30:00   3135
0 days 02:00:00   4035
...                ...
0 days 22:30:00  40935
0 days 23:00:00  41835
0 days 23:30:00  42735
1 days 00:00:00  43635
1 days 00:30:00  14745

[50 rows x 1 columns]
```
