### PR TITLE
BUG: Work-around openpyxl-2.1.0 NumberFormat removal

### DIFF
--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -1029,20 +1029,20 @@ class _Openpyxl2Writer(_Openpyxl1Writer):
     @classmethod
     def _convert_to_number_format(cls, number_format_dict):
         """
-        Convert ``number_format_dict`` to an openpyxl v2 NumberFormat object.
+        Convert ``number_format_dict`` to an openpyxl v2.1.0 number format
+        initializer.
         Parameters
         ----------
         number_format_dict : dict
             A dict with zero or more of the following keys.
-                'format_code'
+                'format_code' : str
         Returns
         -------
-        number_format : openpyxl.styles.NumberFormat
+        number_format : str
         """
 
-        from openpyxl.styles import NumberFormat
-
-        return NumberFormat(**number_format_dict)
+        # XXX: Only works with openpyxl-2.1.0
+        return number_format_dict['format_code']
 
 
     @classmethod

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -1238,7 +1238,7 @@ class Openpyxl2Tests(ExcelWriterBase, tm.TestCase):
         alignment = styles.Alignment(horizontal='center', vertical='top')
         fill_color = styles.Color(rgb='006666FF', tint=0.3)
         fill = styles.PatternFill(patternType='solid', fgColor=fill_color)
-        number_format = styles.NumberFormat(format_code='0.00')
+        number_format = '0.00' # XXX: Only works with openpyxl-2.1.0
         protection = styles.Protection(locked=True, hidden=False)
 
         kw = _Openpyxl2Writer._convert_to_style_kwargs(hstyle)


### PR DESCRIPTION
See #8342. This patch should allow all tests to pass with any supported openpyxl v1, and with openpyxl 2.1.0. Consider this an interim measure, not a complete fix.
