### PR TITLE
Bug on pivot_table with margins and dict aggfunc

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -854,7 +854,7 @@ Performance
 
 Bug Fixes
 ~~~~~~~~~
-
+- Bug in pivot_table, "key error" using margins and dict aggfunc (:issue:`8349`) 
 - Bug in ``read_csv`` where ``squeeze=True`` would return a view (:issue:`8217`)
 - Bug in checking of table name in ``read_sql`` in certain cases (:issue:`7826`).
 - Bug in ``DataFrame.groupby`` where ``Grouper`` does not recognize level when frequency is specified (:issue:`7885`)

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -207,6 +207,11 @@ def _compute_grand_margin(data, values, aggfunc):
             try:
                 if isinstance(aggfunc, compat.string_types):
                     grand_margin[k] = getattr(v, aggfunc)()
+                elif isinstance(aggfunc, dict):
+                    if isinstance(aggfunc[k], compat.string_types):
+                        grand_margin[k] = getattr(v, aggfunc[k])()
+                    else:
+                        grand_margin[k] = aggfunc[k](v)
                 else:
                     grand_margin[k] = aggfunc(v)
             except TypeError:

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -266,6 +266,34 @@ class TestPivotTable(tm.TestCase):
             gmarg = table[item]['All', '']
             self.assertEqual(gmarg, self.data[item].mean())
 
+        # issue number #8349: pivot_table with margins and dictionary aggfunc
+
+        df=DataFrame([  {'JOB':'Worker','NAME':'Bob' ,'YEAR':2013,'MONTH':12,'DAYS': 3,'SALARY': 17}, 
+                        {'JOB':'Employ','NAME':'Mary','YEAR':2013,'MONTH':12,'DAYS': 5,'SALARY': 23}, 
+                        {'JOB':'Worker','NAME':'Bob' ,'YEAR':2014,'MONTH': 1,'DAYS':10,'SALARY':100}, 
+                        {'JOB':'Worker','NAME':'Bob' ,'YEAR':2014,'MONTH': 1,'DAYS':11,'SALARY':110}, 
+                        {'JOB':'Employ','NAME':'Mary','YEAR':2014,'MONTH': 1,'DAYS':15,'SALARY':200}, 
+                        {'JOB':'Worker','NAME':'Bob' ,'YEAR':2014,'MONTH': 2,'DAYS': 8,'SALARY': 80}, 
+                        {'JOB':'Employ','NAME':'Mary','YEAR':2014,'MONTH': 2,'DAYS': 5,'SALARY':190} ])
+
+        df=df.set_index(['JOB','NAME','YEAR','MONTH'],drop=False,append=False)
+
+        rs=df.pivot_table(  index=['JOB','NAME'],
+                            columns=['YEAR','MONTH'],
+                            values=['DAYS','SALARY'],
+                            aggfunc={'DAYS':'mean','SALARY':'sum'},
+                            margins=True)
+
+        ex=df.pivot_table(index=['JOB','NAME'],columns=['YEAR','MONTH'],values=['DAYS'],aggfunc='mean',margins=True)
+
+        tm.assert_frame_equal(rs['DAYS'], ex['DAYS'])
+
+        ex=df.pivot_table(index=['JOB','NAME'],columns=['YEAR','MONTH'],values=['SALARY'],aggfunc='sum',margins=True)
+
+        tm.assert_frame_equal(rs['SALARY'], ex['SALARY'])
+
+
+
     def test_pivot_integer_columns(self):
         # caused by upstream bug in unstack
 


### PR DESCRIPTION
closes #8349

bug on pandas 0.14.1 pivot_table using dictionary aggfunc and margins.

Test code:

<pre>
<code>
df=pandas.DataFrame([ 
{'JOB':'Worker','NAME':'Bob' ,'YEAR':2013,'MONTH':12,'DAYS': 3,'SALARY': 17}, 
{'JOB':'Employ','NAME':'Mary','YEAR':2013,'MONTH':12,'DAYS': 5,'SALARY': 23}, 
{'JOB':'Worker','NAME':'Bob' ,'YEAR':2014,'MONTH': 1,'DAYS':10,'SALARY':100}, 
{'JOB':'Worker','NAME':'Bob' ,'YEAR':2014,'MONTH': 1,'DAYS':11,'SALARY':110}, 
{'JOB':'Employ','NAME':'Mary','YEAR':2014,'MONTH': 1,'DAYS':15,'SALARY':200}, 
{'JOB':'Worker','NAME':'Bob' ,'YEAR':2014,'MONTH': 2,'DAYS': 8,'SALARY': 80}, 
{'JOB':'Employ','NAME':'Mary','YEAR':2014,'MONTH': 2,'DAYS': 5,'SALARY':190} ])

df=df.set_index(['JOB','NAME','YEAR','MONTH'],drop=False,append=False)

df=df.pivot_table(index=['JOB','NAME'],
columns=['YEAR','MONTH'],
values=['DAYS','SALARY'],
aggfunc={'DAYS':'mean','SALARY':'sum'})
</code>
</pre>


All works fine but raise error using margins:

<pre>
<code>
df=df.pivot_table(index=['JOB','NAME'],
columns=['YEAR','MONTH'],
values=['DAYS','SALARY'],
aggfunc={'DAYS':'mean','SALARY':'sum'},
margins=True)
</code>
</pre>


df=df.pivot_table(index=['JOB','NAME'],columns=['YEAR','MONTH'],values=['DAYS','SALARY'],aggfunc={'DAYS':'mean','SALARY':'sum'},margins=True)
File "/usr/local/lib/python2.7/site-packages/pandas-0.14.1-py2.7-linux-x86_64.egg/pandas/util/decorators.py", line 60, in wrapper
return func(_args, *_kwargs)
File "/usr/local/lib/python2.7/site-packages/pandas-0.14.1-py2.7-linux-x86_64.egg/pandas/util/decorators.py", line 60, in wrapper
return func(_args, *_kwargs)
File "/usr/local/lib/python2.7/site-packages/pandas-0.14.1-py2.7-linux-x86_64.egg/pandas/tools/pivot.py", line 147, in pivot_table
cols=columns, aggfunc=aggfunc)
File "/usr/local/lib/python2.7/site-packages/pandas-0.14.1-py2.7-linux-x86_64.egg/pandas/tools/pivot.py", line 191, in _add_margins
row_margin[k] = grand_margin[k[0]]

KeyError: 'SALARY'
