### PR TITLE
BUG: OLS with clustering and nw_lags does not error

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -940,3 +940,6 @@ Bug Fixes
 - Bug where ``col_space`` was ignored in ``DataFrame.to_string()`` when ``header=False`` (:issue:`8230`).
 
 - Bug in DataFrame terminal display: Setting max_column/max_rows to zero did not trigger auto-resizing of dfs to fit terminal width/height (:issue:`7180`).
+- Bug in OLS where running with "cluster" and "nw_lags" parameters did not work correctly, but also did not throw an error  
+  (:issue:`5884', :issue:`8360`).
+

--- a/pandas/stats/interface.py
+++ b/pandas/stats/interface.py
@@ -83,6 +83,14 @@ def ols(**kwargs):
     The appropriate OLS object, which allows you to obtain betas and various
     statistics, such as std err, t-stat, etc.
     """
+
+    if (kwargs.get('cluster') is not None and
+        kwargs.get('nw_lags') is not None):
+        raise ValueError(
+            'Pandas OLS does not work with Newey-West correction '
+            'and clustering.')
+
+
     pool = kwargs.get('pool')
     if 'pool' in kwargs:
         del kwargs['pool']

--- a/pandas/stats/tests/test_ols.py
+++ b/pandas/stats/tests/test_ols.py
@@ -682,13 +682,15 @@ class TestPanelOLS(BaseTest):
                             cluster='time')
 
     def testRollingWithNeweyWestAndEntityCluster(self):
-        self.checkMovingOLS(self.panel_x, self.panel_y,
-                            nw_lags=1, cluster='entity')
+        self.assertRaises(ValueError, self.checkMovingOLS,
+                          self.panel_x, self.panel_y,
+                          nw_lags=1, cluster='entity')
 
     def testRollingWithNeweyWestAndTimeEffectsAndEntityCluster(self):
-        self.checkMovingOLS(self.panel_x, self.panel_y,
-                            nw_lags=1, cluster='entity',
-                            time_effects=True)
+        self.assertRaises(ValueError,
+                          self.checkMovingOLS, self.panel_x, self.panel_y,
+                          nw_lags=1, cluster='entity',
+                          time_effects=True)
 
     def testExpanding(self):
         self.checkMovingOLS(


### PR DESCRIPTION
Added statement to raise ValueError when OLS is run with clustering and
Newey-West adjustments. Closes #5884.  This is a re-attempt at
GH8170.
