### PR TITLE
BUG: bug in non-evently divisible offsets when resampling (e.g. '7s') (GH8371)

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -954,7 +954,7 @@ Bug Fixes
 - Bug with kde plot and NaNs (:issue:`8182`)
 - Bug in ``GroupBy.count`` with float32 data type were nan values were not excluded (:issue:`8169`).
 - Bug with stacked barplots and NaNs (:issue:`8175`).
-
+- Bug in resample with non evenly divisible offsets (e.g. '7s') (:issue:`8371`)
 
 
 - Bug in interpolation methods with the ``limit`` keyword when no values needed interpolating (:issue:`7173`).

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -6,7 +6,7 @@ from pandas.core.groupby import BinGrouper, Grouper
 from pandas.tseries.frequencies import to_offset, is_subperiod, is_superperiod
 from pandas.tseries.index import DatetimeIndex, date_range
 from pandas.tseries.tdi import TimedeltaIndex
-from pandas.tseries.offsets import DateOffset, Tick, _delta_to_nanoseconds
+from pandas.tseries.offsets import DateOffset, Tick, Day, _delta_to_nanoseconds
 from pandas.tseries.period import PeriodIndex, period_range
 import pandas.tseries.tools as tools
 import pandas.core.common as com
@@ -385,9 +385,11 @@ def _get_range_edges(first, last, offset, closed='left', base=0):
         offset = to_offset(offset)
 
     if isinstance(offset, Tick):
+        is_day = isinstance(offset, Day)
         day_nanos = _delta_to_nanoseconds(timedelta(1))
+
         # #1165
-        if (day_nanos % offset.nanos) == 0:
+        if (is_day and day_nanos % offset.nanos == 0) or not is_day:
             return _adjust_dates_anchored(first, last, offset,
                                           closed=closed, base=base)
 

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -176,6 +176,54 @@ class TestResample(tm.TestCase):
 
         assert_frame_equal(result, expected)
 
+    def test_resample_rounding(self):
+        # GH 8371
+        # odd results when rounding is needed
+
+        data = """date,time,value
+11-08-2014,00:00:01.093,1
+11-08-2014,00:00:02.159,1
+11-08-2014,00:00:02.667,1
+11-08-2014,00:00:03.175,1
+11-08-2014,00:00:07.058,1
+11-08-2014,00:00:07.362,1
+11-08-2014,00:00:08.324,1
+11-08-2014,00:00:08.830,1
+11-08-2014,00:00:08.982,1
+11-08-2014,00:00:09.815,1
+11-08-2014,00:00:10.540,1
+11-08-2014,00:00:11.061,1
+11-08-2014,00:00:11.617,1
+11-08-2014,00:00:13.607,1
+11-08-2014,00:00:14.535,1
+11-08-2014,00:00:15.525,1
+11-08-2014,00:00:17.960,1
+11-08-2014,00:00:20.674,1
+11-08-2014,00:00:21.191,1"""
+
+        from pandas.compat import StringIO
+        df = pd.read_csv(StringIO(data), parse_dates={'timestamp': ['date', 'time']}, index_col='timestamp')
+        df.index.name = None
+        result = df.resample('6s', how='sum')
+        expected = DataFrame({'value' : [4,9,4,2]},index=date_range('2014-11-08',freq='6s',periods=4))
+        assert_frame_equal(result,expected)
+
+        result = df.resample('7s', how='sum')
+        expected = DataFrame({'value' : [4,10,4,1]},index=date_range('2014-11-08',freq='7s',periods=4))
+        assert_frame_equal(result,expected)
+
+        result = df.resample('11s', how='sum')
+        expected = DataFrame({'value' : [11,8]},index=date_range('2014-11-08',freq='11s',periods=2))
+        assert_frame_equal(result,expected)
+
+        result = df.resample('13s', how='sum')
+        expected = DataFrame({'value' : [13,6]},index=date_range('2014-11-08',freq='13s',periods=2))
+        assert_frame_equal(result,expected)
+
+        result = df.resample('17s', how='sum')
+        expected = DataFrame({'value' : [16,3]},index=date_range('2014-11-08',freq='17s',periods=2))
+        assert_frame_equal(result,expected)
+
     def test_resample_basic_from_daily(self):
         # from daily
         dti = DatetimeIndex(


### PR DESCRIPTION
closes #8371

```
In [1]:         data = """date,time,value
   ...: 11-08-2014,00:00:01.093,1
   ...: 11-08-2014,00:00:02.159,1
   ...: 11-08-2014,00:00:02.667,1
   ...: 11-08-2014,00:00:03.175,1
   ...: 11-08-2014,00:00:07.058,1
   ...: 11-08-2014,00:00:07.362,1
   ...: 11-08-2014,00:00:08.324,1
   ...: 11-08-2014,00:00:08.830,1
   ...: 11-08-2014,00:00:08.982,1
   ...: 11-08-2014,00:00:09.815,1
   ...: 11-08-2014,00:00:10.540,1
   ...: 11-08-2014,00:00:11.061,1
   ...: 11-08-2014,00:00:11.617,1
   ...: 11-08-2014,00:00:13.607,1
   ...: 11-08-2014,00:00:14.535,1
   ...: 11-08-2014,00:00:15.525,1
   ...: 11-08-2014,00:00:17.960,1
   ...: 11-08-2014,00:00:20.674,1
   ...: 11-08-2014,00:00:21.191,1"""

In [2]:         df = pd.read_csv(StringIO(data), parse_dates={'timestamp': ['date', 'time']}, index_col='timestamp')

In [3]: df
Out[3]: 
                            value
timestamp                        
2014-11-08 00:00:01.093000      1
2014-11-08 00:00:02.159000      1
2014-11-08 00:00:02.667000      1
2014-11-08 00:00:03.175000      1
2014-11-08 00:00:07.058000      1
2014-11-08 00:00:07.362000      1
2014-11-08 00:00:08.324000      1
2014-11-08 00:00:08.830000      1
2014-11-08 00:00:08.982000      1
2014-11-08 00:00:09.815000      1
2014-11-08 00:00:10.540000      1
2014-11-08 00:00:11.061000      1
2014-11-08 00:00:11.617000      1
2014-11-08 00:00:13.607000      1
2014-11-08 00:00:14.535000      1
2014-11-08 00:00:15.525000      1
2014-11-08 00:00:17.960000      1
2014-11-08 00:00:20.674000      1
2014-11-08 00:00:21.191000      1

In [4]: df.resample('6s', how='sum')
Out[4]: 
                     value
timestamp                 
2014-11-08 00:00:00      4
2014-11-08 00:00:06      9
2014-11-08 00:00:12      4
2014-11-08 00:00:18      2
In [5]: df.resample('7s', how='sum')
Out[5]: 
                     value
timestamp                 
2014-11-08 00:00:00      4
2014-11-08 00:00:07     10
2014-11-08 00:00:14      4
2014-11-08 00:00:21      1

In [6]: df.resample('11s', how='sum')
Out[6]: 
                     value
timestamp                 
2014-11-08 00:00:00     11
2014-11-08 00:00:11      8

In [7]: df.resample('13s', how='sum')
Out[7]: 
                     value
timestamp                 
2014-11-08 00:00:00     13
2014-11-08 00:00:13      6

In [8]: df.resample('17s', how='sum')
Out[8]: 
                     value
timestamp                 
2014-11-08 00:00:00     16
2014-11-08 00:00:17      3
```
