### PR TITLE
ENH: Added file path existence check for read_hdf

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -255,6 +255,8 @@ API changes
 
 - ``Series.to_csv()`` now returns a string when ``path=None``, matching the behaviour of ``DataFrame.to_csv()`` (:issue:`8215`).
 
+-``read_hdf`` now raises IOError properly when a file that doesn't exist is passed in. Previously, a new, empty file was created, read and stored in an HDFStore object (:issue `7715`).
+
 .. _whatsnew_0150.index_set_ops:
 
 - The Index set operations ``+`` and ``-`` were deprecated in order to provide these for numeric type operations on certain index types. ``+`` can be replace by ``.union()`` or ``|``, and ``-`` by ``.difference()``. Further the method name ``Index.diff()`` is deprecated and can be replaced by ``Index.difference()`` (:issue:`8226`)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -332,6 +332,16 @@ def read_hdf(path_or_buf, key, **kwargs):
         key, auto_close=auto_close, **kwargs)
 
     if isinstance(path_or_buf, string_types):
+        
+        try:
+            exists = os.path.exists(path_or_buf)
+
+        #if filepath is too long
+        except (TypeError,ValueError):
+            exists = False
+
+        if not exists:
+            raise IOError('File %s does not exist' % path_or_buf)
 
         # can't auto open/close if we are using an iterator
         # so delegate to the iterator

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -288,6 +288,10 @@ class TestHDFStore(tm.TestCase):
             self.assertRaises(TypeError, df.to_hdf, path,'df',append=True,format='foo')
             self.assertRaises(TypeError, df.to_hdf, path,'df',append=False,format='bar')
 
+        #File path doesn't exist
+        path = ""
+        self.assertRaises(IOError, read_hdf, path, 'df') 
+
     def test_api_default_format(self):
 
         # default_format option


### PR DESCRIPTION
closes  #7715 

Added simple check for file path existence. It might be more advisable to deprecate this function and separate file buffer and file path read functionality, but the current form matches the rest of the API.

I wasn't sure if there was any tests I needed to add, but if there is, let me know.
