### PR TITLE
BUG: Intersection buggy for non-monotonic non-unique indices (GH8362)

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -970,4 +970,5 @@ Bug Fixes
 - Bug in DataFrame terminal display: Setting max_column/max_rows to zero did not trigger auto-resizing of dfs to fit terminal width/height (:issue:`7180`).
 - Bug in OLS where running with "cluster" and "nw_lags" parameters did not work correctly, but also did not throw an error
   (:issue:`5884').
+- Bug in Index.intersection on non-monotonic non-unique indexes (:issue:`8362`).
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1275,6 +1275,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         try:
             indexer = self.get_indexer(other.values)
+            indexer = indexer[indexer != -1]
             indexer = indexer.take((indexer != -1).nonzero()[0])
         except:
             # duplicates

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1275,11 +1275,11 @@ class Index(IndexOpsMixin, PandasObject):
 
         try:
             indexer = self.get_indexer(other.values)
-            indexer = indexer[indexer != -1]
             indexer = indexer.take((indexer != -1).nonzero()[0])
         except:
             # duplicates
             indexer = self.get_indexer_non_unique(other.values)[0].unique()
+            indexer = indexer[indexer != -1]
 
         taken = self.take(indexer)
         if self.name != other.name:

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -532,6 +532,13 @@ class TestIndex(Base, tm.TestCase):
         result3 = idx1.intersection(idx3)
         self.assertTrue(tm.equalContents(result3, expected3))
         self.assertEqual(result3.name, expected3.name)
+        
+        # non-monotonic non-unique
+        idx1 = Index(['A','B','A','C'])
+        idx2 = Index(['B','D'])
+        expected = Index(['B'], dtype='object')
+        result = idx1.intersection(idx2)
+        self.assertTrue(result.equals(expected))
 
     def test_union(self):
         first = self.strIndex[5:20]


### PR DESCRIPTION
Fixes intersection bug in the case of non-monotonic non-unique indexes. 
closes #8362 
