### PR TITLE
BUG: fix Panel.fillna() ignoring axis parameter

### DIFF
--- a/doc/source/whatsnew/v0.15.1.txt
+++ b/doc/source/whatsnew/v0.15.1.txt
@@ -227,3 +227,5 @@ Bug Fixes
 - Fixed a bug where plotting a column ``y`` and specifying a label would mutate the index name of the original DataFrame (:issue:`8494`)
 
 - Bug in ``date_range`` where partially-specified dates would incorporate current date (:issue:`6961`)
+
+- Fixed a bug that prevented setting values in a mixed-type Panel4D

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -3118,3 +3118,21 @@ def _maybe_match_name(a, b):
     if a_name == b_name:
         return a_name
     return None
+
+def _get_cats(f):
+    from pandas.core.common import CategoricalDtype
+    if f._stat_axis_number == 0:
+        return dict((pt, f[pt].cat) for pt in f if
+                    isinstance(f[pt].dtype, CategoricalDtype))
+    else:
+        return dict((pt, _get_cats(f[pt])) for pt in f)
+
+def _restore_cats(f, cats):
+    from pandas.core.categorical import Categorical
+    for pt, sub in cats.items():
+        if isinstance(sub, dict):
+            _restore_cats(f[pt], sub)
+        else:
+            f[pt] = Categorical(f[pt], 
+                                categories=sub.categories, 
+                                ordered=sub.ordered)

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -3118,21 +3118,3 @@ def _maybe_match_name(a, b):
     if a_name == b_name:
         return a_name
     return None
-
-def _get_cats(f):
-    from pandas.core.common import CategoricalDtype
-    if f._stat_axis_number == 0:
-        return dict((pt, f[pt].cat) for pt in f if
-                    isinstance(f[pt].dtype, CategoricalDtype))
-    else:
-        return dict((pt, _get_cats(f[pt])) for pt in f)
-
-def _restore_cats(f, cats):
-    from pandas.core.categorical import Categorical
-    for pt, sub in cats.items():
-        if isinstance(sub, dict):
-            _restore_cats(f[pt], sub)
-        else:
-            f[pt] = Categorical(f[pt], 
-                                categories=sub.categories, 
-                                ordered=sub.ordered)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2299,11 +2299,18 @@ class NDFrame(PandasObject):
                     self.apply(interp_func, axis=axis)
                     new_data = self._data
                 else:
+                    cats = None
+                    if self._is_mixed_type:
+                        cats = com._get_cats(self)
+
                     result = self.apply(lambda s: s.fillna(method=method,
                                                            limit=limit,
                                                            downcast=downcast),
                                         axis=axis)
-                    new_data = result.convert_objects(copy=False)._data
+                    result = result.convert_objects(copy=False)
+                    if cats:
+                        com._restore_cats(result, cats)
+                    new_data = result._data
             else:
                 new_data = interp_func(self)
         else:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2309,14 +2309,11 @@ class NDFrame(PandasObject):
                                 axis=new_axis, inplace=inplace,
                                 limit=limit, downcast=downcast))
                                 for col, s in compat.iteritems(data)])
-                result = self._constructor.from_dict(result)
 
-                if axis == 0:
-                    result = result.transpose(1, 0 ,2)
-                if inplace:
-                    self._update_inplace(self._data)
-                    return
-                else:
+                if not inplace:
+                    result = self._constructor.from_dict(result)
+                    if axis == 0:
+                        result = result.transpose(1, 0 ,2)
                     return result.__finalize__(self)
 
             if self._is_mixed_type and axis == 1:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2253,8 +2253,8 @@ class NDFrame(PandasObject):
             Method to use for filling holes in reindexed Series
             pad / ffill: propagate last valid observation forward to next valid
             backfill / bfill: use NEXT valid observation to fill gap
-        axis : {0, 1, 2}, defaults to the stat axis
-            The stat axis is 0 for Series and DataFrame and 1 for Panel
+        axis : {0, 1, 2, 3}, defaults to the stat axis
+            The stat axis is 0 for Series and DataFrame, 1 for Panel, and 2 for Panel4D
         inplace : boolean, default False
             If True, fill in place. Note: this will modify any
             other views on this object, (e.g. a no-copy slice for a column in a

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2386,12 +2386,12 @@ class NDFrame(PandasObject):
         else:
             return self._constructor(new_data).__finalize__(self)
 
-    def ffill(self, axis=0, inplace=False, limit=None, downcast=None):
+    def ffill(self, axis=None, inplace=False, limit=None, downcast=None):
         "Synonym for NDFrame.fillna(method='ffill')"
         return self.fillna(method='ffill', axis=axis, inplace=inplace,
                            limit=limit, downcast=downcast)
 
-    def bfill(self, axis=0, inplace=False, limit=None, downcast=None):
+    def bfill(self, axis=None, inplace=False, limit=None, downcast=None):
         "Synonym for NDFrame.fillna(method='bfill')"
         return self.fillna(method='bfill', axis=axis, inplace=inplace,
                            limit=limit, downcast=downcast)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2300,10 +2300,10 @@ class NDFrame(PandasObject):
             elif self.ndim == 3:
                 if axis == 0:
                     new_axis = 1
-                    apply_axes = (0,1)
+                    apply_axes = (0, 1)
                 else:
                     new_axis = axis - 1
-                    apply_axes = (1,2)
+                    apply_axes = (1, 2)
                 result = self.apply(lambda s: s.fillna(value=value, 
                                                        method=method,
                                                        axis=new_axis, 
@@ -2311,8 +2311,9 @@ class NDFrame(PandasObject):
                                                        limit=limit, 
                                                        downcast=downcast), 
                                     axis=apply_axes)
-
                 if not inplace:
+                    if axis == 0:
+                        result = result.transpose(2, 1, 0)
                     return result.__finalize__(self)
                 else:
                     return

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2311,12 +2311,9 @@ class NDFrame(PandasObject):
                                                        limit=limit, 
                                                        downcast=downcast), 
                                     axis=apply_axes)
-                if not inplace:
-                    if axis == 0:
-                        result = result.transpose(2, 1, 0)
-                    return result.__finalize__(self)
-                else:
-                    return
+                if axis == 0:
+                    result = result.transpose(2, 1, 0)
+                return result if not inplace else None
 
             if self._is_mixed_type and axis == 1:
                 if inplace:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2293,8 +2293,7 @@ class NDFrame(PandasObject):
                                                        limit=limit,
                                                        downcast=downcast),
                                     axis=axis)
-                result = result.convert_objects(convert_numeric=True)
-                new_data = result._data
+                new_data = result.convert_objects()._data
             else:
                 new_data = self._data.interpolate(method=method,
                                                   axis=axis,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2260,9 +2260,9 @@ class NDFrame(PandasObject):
             other views on this object, (e.g. a no-copy slice for a column in a
             DataFrame).
         limit : int, default None
-            eaxinum size gap to forward or backward fill
+            Maximum size gap to forward or backward fill
         downcast : dict, default is None
-            a dict of item->dtype of what to downcast if possible,
+            A dict of item->dtype of what to downcast if possible,
             or the string 'infer' which will try to downcast to an appropriate
             equal type (e.g. float64 to int64 if possible)
 
@@ -2277,7 +2277,7 @@ class NDFrame(PandasObject):
         self._consolidate_inplace()
 
         if axis is None:
-            axis = self._get_axis_number(self._stat_axis_name)
+            axis = self._stat_axis_number
         else:
             axis = self._get_axis_number(axis)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2315,6 +2315,8 @@ class NDFrame(PandasObject):
                     if axis == 0:
                         result = result.transpose(1, 0 ,2)
                     return result.__finalize__(self)
+                else:
+                    return
 
             if self._is_mixed_type and axis == 1:
                 if inplace:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2299,21 +2299,20 @@ class NDFrame(PandasObject):
             # 3d
             elif self.ndim == 3:
                 if axis == 0:
-                    data = self.transpose(1, 0, 2)
-                    new_axis = 0
+                    new_axis = 1
+                    apply_axes = (0,1)
                 else:
-                    data = self
                     new_axis = axis - 1
-
-                result = dict([(col, s.fillna(value=value, method=method,
-                                axis=new_axis, inplace=inplace,
-                                limit=limit, downcast=downcast))
-                                for col, s in compat.iteritems(data)])
+                    apply_axes = (1,2)
+                result = self.apply(lambda s: s.fillna(value=value, 
+                                                       method=method,
+                                                       axis=new_axis, 
+                                                       inplace=inplace, 
+                                                       limit=limit, 
+                                                       downcast=downcast), 
+                                    axis=apply_axes)
 
                 if not inplace:
-                    result = self._constructor.from_dict(result)
-                    if axis == 0:
-                        result = result.transpose(1, 0 ,2)
                     return result.__finalize__(self)
                 else:
                     return

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2300,19 +2300,24 @@ class NDFrame(PandasObject):
             elif self.ndim == 3:
                 if axis == 0:
                     data = self.transpose(1, 0, 2)
-                    result = dict([(col, s.fillna(method=method, value=value,
-                                    axis=0, limit=limit))
-                                   for col, s in compat.iteritems(data)])
-                    result = self._constructor.from_dict(result)
-                    result = result.transpose(1, 0, 2)
-
+                    new_axis = 0
                 else:
-                    result = dict([(col, s.fillna(method=method, value=value,
-                                    axis=axis-1, limit=limit))
-                                    for col, s in compat.iteritems(self)])
-                    result = self._constructor.from_dict(result)
+                    data = self
+                    new_axis = axis - 1
 
-                return result.__finalize__(self)
+                result = dict([(col, s.fillna(value=value, method=method,
+                                axis=new_axis, inplace=inplace,
+                                limit=limit, downcast=downcast))
+                                for col, s in compat.iteritems(data)])
+                result = self._constructor.from_dict(result)
+
+                if axis == 0:
+                    result = result.transpose(1, 0 ,2)
+                if inplace:
+                    self._update_inplace(self._data)
+                    return
+                else:
+                    return result.__finalize__(self)
 
             if self._is_mixed_type and axis == 1:
                 if inplace:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2290,31 +2290,35 @@ class NDFrame(PandasObject):
             if method is None:
                 raise ValueError('must specify a fill method or value')
 
-            # > 3d
+            # >3d
             if self.ndim > 3:
                 raise NotImplementedError(
                     'Cannot fillna with a method for > 3dims'
                 )
 
+
             # 3d
-            elif self.ndim == 3:
+            if self.ndim == 3:
                 if axis == 0:
-                    new_axis = 1
+                    fill_axis = 1
                     apply_axes = (0, 1)
                 else:
-                    new_axis = axis - 1
+                    fill_axis = axis - 1
                     apply_axes = (1, 2)
-                result = self.apply(lambda s: s.fillna(value=value, 
+
+                result = self.apply(lambda f: f.fillna(value=value,
                                                        method=method,
-                                                       axis=new_axis, 
-                                                       inplace=inplace, 
-                                                       limit=limit, 
-                                                       downcast=downcast), 
+                                                       axis=fill_axis,
+                                                       inplace=inplace,
+                                                       limit=limit,
+                                                       downcast=downcast),
                                     axis=apply_axes)
+
                 if axis == 0:
                     result = result.transpose(2, 1, 0)
                 return result if not inplace else None
 
+            # 2d or less
             if self._is_mixed_type and axis == 1:
                 if inplace:
                     raise NotImplementedError()
@@ -2325,7 +2329,6 @@ class NDFrame(PandasObject):
 
                 return result
 
-            # 2d or less
             method = com._clean_fill_method(method)
             new_data = self._data.interpolate(method=method,
                                               axis=axis,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2290,15 +2290,14 @@ class NDFrame(PandasObject):
             if method is None:
                 raise ValueError('must specify a fill method or value')
 
-            # >3d
-            if self.ndim > 3:
+            # >4d
+            if self.ndim > 4:
                 raise NotImplementedError(
-                    'Cannot fillna with a method for > 3dims'
+                    'Cannot fillna with a method for >4 dims'
                 )
 
-
-            # 3d
-            if self.ndim == 3:
+            # 3d or 4d
+            if self.ndim >= 3:
                 if axis == 0:
                     fill_axis = 1
                     apply_axes = (0, 1)
@@ -2315,7 +2314,10 @@ class NDFrame(PandasObject):
                                     axis=apply_axes)
 
                 if axis == 0:
-                    result = result.transpose(2, 1, 0)
+                    if self.ndim == 3:
+                        result = result.transpose(2, 1, 0)
+                    else:
+                        result = result.transpose(1, 2, 0, 3)
                 return result if not inplace else None
 
             # 2d or less

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2303,7 +2303,7 @@ class NDFrame(PandasObject):
                                                            limit=limit,
                                                            downcast=downcast),
                                         axis=axis)
-                    new_data = result.convert_objects()._data
+                    new_data = result.convert_objects(copy=False)._data
             else:
                 new_data = interp_func(self)
         else:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2366,8 +2366,7 @@ class NDFrame(PandasObject):
         if inplace:
             self._update_inplace(new_data)
         else:
-            result = self._constructor(new_data).__finalize__(self)
-            return result
+            return self._constructor(new_data).__finalize__(self)
 
     def _get_cats(self):
         if self._stat_axis_number == 0:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2285,15 +2285,6 @@ class NDFrame(PandasObject):
         if value is None:
             if method is None:
                 raise ValueError('must specify a fill method or value')
-            if self._is_mixed_type and axis == 1:
-                if inplace:
-                    raise NotImplementedError()
-                result = self.T.fillna(method=method, limit=limit).T
-
-                # need to downcast here because of all of the transposes
-                result._data = result._data.downcast()
-
-                return result
 
             # > 3d
             if self.ndim > 3:
@@ -2318,6 +2309,16 @@ class NDFrame(PandasObject):
                     result = self._constructor.from_dict(result)
 
                 return result.__finalize__(self)
+
+            if self._is_mixed_type and axis == 1:
+                if inplace:
+                    raise NotImplementedError()
+                result = self.T.fillna(method=method, limit=limit).T
+
+                # need to downcast here because of all of the transposes
+                result._data = result._data.downcast()
+
+                return result
 
             # 2d or less
             method = com._clean_fill_method(method)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2237,7 +2237,7 @@ class NDFrame(PandasObject):
     #----------------------------------------------------------------------
     # Filling NA's
 
-    def fillna(self, value=None, method=None, axis=0, inplace=False,
+    def fillna(self, value=None, method=None, axis=None, inplace=False,
                limit=None, downcast=None):
         """
         Fill NA/NaN values using the specified method
@@ -2253,7 +2253,8 @@ class NDFrame(PandasObject):
             Method to use for filling holes in reindexed Series
             pad / ffill: propagate last valid observation forward to next valid
             backfill / bfill: use NEXT valid observation to fill gap
-        axis : {0, 1, 2}, default 0
+        axis : {0, 1, 2}, defaults to the stat axis
+            The stat axis is 0 for Series and DataFrame and 1 for Panel
         inplace : boolean, default False
             If True, fill in place. Note: this will modify any
             other views on this object, (e.g. a no-copy slice for a column in a
@@ -2278,7 +2279,10 @@ class NDFrame(PandasObject):
                             'you passed a "{0}"'.format(type(value).__name__))
         self._consolidate_inplace()
 
-        axis = self._get_axis_number(axis)
+        if axis is None:
+            axis = self._get_axis_number(self._stat_axis_name)
+        else:
+            axis = self._get_axis_number(axis)
         method = com._clean_fill_method(method)
 
         from pandas import DataFrame

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -355,7 +355,7 @@ class _NDFrameIndexer(object):
             # if we have a partial multiindex, then need to adjust the plane
             # indexer here
             if (len(labels) == 1 and
-                    isinstance(self.obj[labels[0]].index, MultiIndex)):
+                    isinstance(self.obj[labels[0]].axes[0], MultiIndex)):
                 item = labels[0]
                 obj = self.obj[item]
                 index = obj.index

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -421,7 +421,7 @@ class _NDFrameIndexer(object):
 
                 l = len(value)
                 item = labels[0]
-                index = self.obj[item].index
+                index = self.obj[item].axes[0]
 
                 # equal len list/ndarray
                 if len(index) == l:

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1345,16 +1345,19 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         filled = self.panel.fillna(0)
         self.assertTrue(np.isfinite(filled.values).all())
 
-        filled = self.panel.fillna(method='backfill')
+        filled = self.panel.fillna(method='backfill', axis=1)
         assert_frame_equal(filled['ItemA'],
                            self.panel['ItemA'].fillna(method='backfill'))
 
         panel = self.panel.copy()
         panel['str'] = 'foo'
 
-        filled = panel.fillna(method='backfill')
+        filled = panel.fillna(method='backfill', axis=1)
         assert_frame_equal(filled['ItemA'],
                            panel['ItemA'].fillna(method='backfill'))
+
+        filled = self.panel.fillna(method='ffill', axis=0)
+        self.assertEqual(filled.iloc[2,3,3], self.panel.iloc[0,3,3])
 
         empty = self.panel.reindex(items=[])
         filled = empty.fillna(0)

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1345,14 +1345,14 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         filled = self.panel.fillna(0)
         self.assertTrue(np.isfinite(filled.values).all())
 
-        filled = self.panel.fillna(method='backfill')
+        filled = self.panel.fillna(method='backfill', axis=1)
         assert_frame_equal(filled['ItemA'],
                            self.panel['ItemA'].fillna(method='backfill'))
 
         panel = self.panel.copy()
         panel['str'] = 'foo'
 
-        filled = panel.fillna(method='backfill')
+        filled = panel.fillna(method='backfill', axis=1)
         assert_frame_equal(filled['ItemA'],
                            panel['ItemA'].fillna(method='backfill'))
 

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1356,23 +1356,84 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         assert_frame_equal(filled['ItemA'],
                            panel['ItemA'].fillna(method='backfill'))
 
-        filled = self.panel.fillna(method='ffill', axis=0)
-        self.assertEqual(filled.iloc[2,3,3], self.panel.iloc[0,3,3])
+        # Fill forward.
+        filled = self.panel.fillna(method='ffill')
+        assert_frame_equal(filled['ItemA'],
+                           self.panel['ItemA'].fillna(method='ffill'))
 
+        # With limit.
+        filled = self.panel.fillna(method='backfill', limit=1)
+        assert_frame_equal(filled['ItemA'],
+                           self.panel['ItemA'].fillna(method='backfill', limit=1))
+
+        # With downcast.
+        rounded = self.panel.apply(lambda x: x.apply(np.round))
+        filled = rounded.fillna(method='backfill', downcast='infer')
+        assert_frame_equal(filled['ItemA'],
+                           rounded['ItemA'].fillna(method='backfill', downcast='infer'))
+
+        # Now explicitly request axis 1.
+        filled = self.panel.fillna(method='backfill', axis=1)
+        assert_frame_equal(filled['ItemA'],
+                           self.panel['ItemA'].fillna(method='backfill', axis=0))
+
+        # Fill along axis 2, equivalent to filling along axis 1 of each
+        # DataFrame.
+        filled = self.panel.fillna(method='backfill', axis=2)
+        assert_frame_equal(filled['ItemA'],
+                           self.panel['ItemA'].fillna(method='backfill', axis=1))
+
+        # Fill an empty panel.
         empty = self.panel.reindex(items=[])
         filled = empty.fillna(0)
         assert_panel_equal(filled, empty)
 
+        # either method or value must be specified
         self.assertRaises(ValueError, self.panel.fillna)
+        # method and value can not both be specified
         self.assertRaises(ValueError, self.panel.fillna, 5, method='ffill')
 
+        # can't pass list or tuple, only scalar
         self.assertRaises(TypeError, self.panel.fillna, [1, 2])
         self.assertRaises(TypeError, self.panel.fillna, (1, 2))
 
         # limit not implemented when only value is specified
         p = Panel(np.random.randn(3,4,5))
         p.iloc[0:2,0:2,0:2] = np.nan
-        self.assertRaises(NotImplementedError, lambda : p.fillna(999,limit=1))
+        self.assertRaises(NotImplementedError, lambda : p.fillna(999, limit=1))
+
+    def test_fillna_axis_0(self):
+        # Forward fill along axis 0, interpolating values across DataFrames.
+        filled = self.panel.fillna(method='ffill', axis=0)
+        nan_indexes = self.panel['ItemB']['C'].index[
+            self.panel['ItemB']['C'].apply(np.isnan)]
+        # Values from ItemA are filled into ItemB.
+        assert_series_equal(filled['ItemB']['C'][nan_indexes],
+                            self.panel['ItemA']['C'][nan_indexes])
+
+        # Backfill along axis 0.
+        filled = self.panel.fillna(method='backfill', axis=0)
+        # The test data lacks values that can be backfilled on axis 0.
+        assert_panel_equal(filled, self.panel)
+        # Reverse the panel and backfill along axis 0, to properly test
+        # backfill.
+        reverse_panel = self.panel.reindex_axis(reversed(self.panel.axes[0]))
+        filled = reverse_panel.fillna(method='bfill', axis=0)
+        nan_indexes = reverse_panel['ItemB']['C'].index[
+            reverse_panel['ItemB']['C'].apply(np.isnan)]
+        assert_series_equal(filled['ItemB']['C'][nan_indexes],
+                            reverse_panel['ItemA']['C'][nan_indexes])
+
+        # Fill along axis 0 with limit.
+        filled = self.panel.fillna(method='ffill', axis=0, limit=1)
+        a_nan = self.panel['ItemA']['C'].index[
+            self.panel['ItemA']['C'].apply(np.isnan)]
+        b_nan = self.panel['ItemB']['C'].index[
+            self.panel['ItemB']['C'].apply(np.isnan)]
+        # Cells that are nan in ItemB but not in ItemA remain unfilled in
+        # ItemC.
+        self.assertTrue(
+            filled['ItemC']['C'][b_nan.diff(a_nan)].apply(np.isnan).all())
 
     def test_ffill_bfill(self):
         assert_panel_equal(self.panel.ffill(),

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1345,14 +1345,14 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         filled = self.panel.fillna(0)
         self.assertTrue(np.isfinite(filled.values).all())
 
-        filled = self.panel.fillna(method='backfill', axis=1)
+        filled = self.panel.fillna(method='backfill')
         assert_frame_equal(filled['ItemA'],
                            self.panel['ItemA'].fillna(method='backfill'))
 
         panel = self.panel.copy()
         panel['str'] = 'foo'
 
-        filled = panel.fillna(method='backfill', axis=1)
+        filled = panel.fillna(method='backfill')
         assert_frame_equal(filled['ItemA'],
                            panel['ItemA'].fillna(method='backfill'))
 
@@ -1403,18 +1403,23 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         self.assertRaises(NotImplementedError, lambda : p.fillna(999, limit=1))
 
     def test_fillna_axis_0(self):
+        # GH 8395
+
         # Forward fill along axis 0, interpolating values across DataFrames.
         filled = self.panel.fillna(method='ffill', axis=0)
         nan_indexes = self.panel['ItemB']['C'].index[
             self.panel['ItemB']['C'].apply(np.isnan)]
+
         # Values from ItemA are filled into ItemB.
         assert_series_equal(filled['ItemB']['C'][nan_indexes],
                             self.panel['ItemA']['C'][nan_indexes])
 
         # Backfill along axis 0.
         filled = self.panel.fillna(method='backfill', axis=0)
+
         # The test data lacks values that can be backfilled on axis 0.
         assert_panel_equal(filled, self.panel)
+
         # Reverse the panel and backfill along axis 0, to properly test
         # backfill.
         reverse_panel = self.panel.reindex_axis(reversed(self.panel.axes[0]))
@@ -1430,6 +1435,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
             self.panel['ItemA']['C'].apply(np.isnan)]
         b_nan = self.panel['ItemB']['C'].index[
             self.panel['ItemB']['C'].apply(np.isnan)]
+
         # Cells that are nan in ItemB but not in ItemA remain unfilled in
         # ItemC.
         self.assertTrue(

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1345,14 +1345,14 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         filled = self.panel.fillna(0)
         self.assertTrue(np.isfinite(filled.values).all())
 
-        filled = self.panel.fillna(method='backfill', axis=1)
+        filled = self.panel.fillna(method='backfill')
         assert_frame_equal(filled['ItemA'],
                            self.panel['ItemA'].fillna(method='backfill'))
 
         panel = self.panel.copy()
         panel['str'] = 'foo'
 
-        filled = panel.fillna(method='backfill', axis=1)
+        filled = panel.fillna(method='backfill')
         assert_frame_equal(filled['ItemA'],
                            panel['ItemA'].fillna(method='backfill'))
 

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -845,11 +845,107 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
         # assert_panel_equal(sorted_panel, self.panel)
 
     def test_fillna(self):
+        # GH 8395
         self.assertFalse(np.isfinite(self.panel4d.values).all())
         filled = self.panel4d.fillna(0)
         self.assertTrue(np.isfinite(filled.values).all())
 
-        self.assertRaises(NotImplementedError, self.panel4d.fillna, method='pad')
+        filled = self.panel4d.fillna(method='backfill')
+        assert_frame_equal(filled['l1']['ItemA'],
+                           self.panel4d['l1']['ItemA'].fillna(method='backfill'))
+
+        panel4d = self.panel4d.copy()
+        panel4d['str'] = 'foo'
+
+        filled = panel4d.fillna(method='backfill')
+        assert_frame_equal(filled['l1']['ItemA'],
+                           panel4d['l1']['ItemA'].fillna(method='backfill'))
+
+        # Fill forward.
+        filled = self.panel4d.fillna(method='ffill')
+        assert_frame_equal(filled['l1']['ItemA'],
+                           self.panel4d['l1']['ItemA'].fillna(method='ffill'))
+
+        # With limit.
+        filled = self.panel4d.fillna(method='backfill', limit=1)
+        assert_frame_equal(filled['l1']['ItemA'],
+                           self.panel4d['l1']['ItemA'].fillna(method='backfill', limit=1))
+
+        # With downcast.
+        rounded = self.panel4d.apply(lambda x: x.apply(np.round))
+        filled = rounded.fillna(method='backfill', downcast='infer')
+        assert_frame_equal(filled['l1']['ItemA'],
+                           rounded['l1']['ItemA'].fillna(method='backfill', downcast='infer'))
+
+        # Now explicitly request axis 2.
+        filled = self.panel4d.fillna(method='backfill', axis=2)
+        assert_frame_equal(filled['l1']['ItemA'],
+                           self.panel4d['l1']['ItemA'].fillna(method='backfill', axis=0))
+
+        # Fill along axis 3, equivalent to filling along axis 1 of each
+        # DataFrame.
+        filled = self.panel4d.fillna(method='backfill', axis=3)
+        assert_frame_equal(filled['l1']['ItemA'],
+                           self.panel4d['l1']['ItemA'].fillna(method='backfill', axis=1))
+
+        # Fill an empty panel.
+        empty = self.panel4d.reindex(items=[])
+        filled = empty.fillna(0)
+        assert_panel4d_equal(filled, empty)
+
+        # either method or value must be specified
+        self.assertRaises(ValueError, self.panel4d.fillna)
+        # method and value can not both be specified
+        self.assertRaises(ValueError, self.panel4d.fillna, 5, method='ffill')
+
+        # can't pass list or tuple, only scalar
+        self.assertRaises(TypeError, self.panel4d.fillna, [1, 2])
+        self.assertRaises(TypeError, self.panel4d.fillna, (1, 2))
+
+        # limit not implemented when only value is specified
+        p = Panel4D(np.random.randn(3,4,5,6))
+        p.iloc[0:2,0:2,0:2,0:2] = np.nan
+        self.assertRaises(NotImplementedError, lambda : p.fillna(999, limit=1))
+
+    def test_fillna_axis_0(self):
+        # GH 8395
+
+        # Forward fill along axis 0, interpolating values across DataFrames.
+        filled = self.panel4d.fillna(method='ffill', axis=0)
+        nan_indexes = self.panel4d['l1']['ItemB']['C'].index[
+            self.panel4d['l1']['ItemB']['C'].apply(np.isnan)]
+
+        # Values from ItemA are filled into ItemB.
+        assert_series_equal(filled['l1']['ItemB']['C'][nan_indexes],
+                            self.panel4d['l1']['ItemA']['C'][nan_indexes])
+
+        # Backfill along axis 0.
+        filled = self.panel4d.fillna(method='backfill', axis=0)
+
+        # The test data lacks values that can be backfilled on axis 0.
+        assert_panel4d_equal(filled, self.panel4d)
+
+        # Reverse the panel and backfill along axis 0, to properly test
+        # backfill.
+        reverse_panel = self.panel4d.reindex_axis(reversed(self.panel4d.axes[0]))
+        filled = reverse_panel.fillna(method='bfill', axis=0)
+        nan_indexes = reverse_panel['l3']['ItemB']['C'].index[
+            reverse_panel['l3']['ItemB']['C'].apply(np.isnan)]
+        assert_series_equal(filled['l1']['ItemB']['C'][nan_indexes],
+                            reverse_panel['l3']['ItemB']['C'][nan_indexes])
+
+        # Fill along axis 0 with limit.
+        filled = self.panel4d.fillna(method='ffill', axis=0, limit=1)
+        a_nan = self.panel4d['l1']['ItemA']['C'].index[
+            self.panel4d['l1']['ItemA']['C'].apply(np.isnan)]
+        b_nan = self.panel4d['l1']['ItemB']['C'].index[
+            self.panel4d['l1']['ItemB']['C'].apply(np.isnan)]
+
+        # Cells that are nan in ItemB but not in ItemA remain unfilled in
+        # ItemC.
+        self.assertTrue(
+            filled['l1']['ItemC']['C'][b_nan.diff(a_nan)].apply(np.isnan).all())
+
 
     def test_swapaxes(self):
         result = self.panel4d.swapaxes('labels', 'items')

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -910,41 +910,41 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
     def test_fillna_axis_0(self):
         # GH 8395
 
-        # Forward fill along axis 0, interpolating values across DataFrames.
-        filled = self.panel4d.fillna(method='ffill', axis=0)
+        # Back fill along axis 0, interpolating values across Panels
+        filled = self.panel4d.fillna(method='bfill', axis=0)
         nan_indexes = self.panel4d['l1']['ItemB']['C'].index[
             self.panel4d['l1']['ItemB']['C'].apply(np.isnan)]
 
-        # Values from ItemA are filled into ItemB.
+        # Values from ItemC are filled into ItemB.
         assert_series_equal(filled['l1']['ItemB']['C'][nan_indexes],
-                            self.panel4d['l1']['ItemA']['C'][nan_indexes])
+                            self.panel4d['l1']['ItemC']['C'][nan_indexes])
 
-        # Backfill along axis 0.
-        filled = self.panel4d.fillna(method='backfill', axis=0)
+        # Forward fill along axis 0.
+        filled = self.panel4d.fillna(method='ffill', axis=0)
 
         # The test data lacks values that can be backfilled on axis 0.
         assert_panel4d_equal(filled, self.panel4d)
 
         # Reverse the panel and backfill along axis 0, to properly test
-        # backfill.
+        # forward fill.
         reverse_panel = self.panel4d.reindex_axis(reversed(self.panel4d.axes[0]))
-        filled = reverse_panel.fillna(method='bfill', axis=0)
+        filled = reverse_panel.fillna(method='ffill', axis=0)
         nan_indexes = reverse_panel['l3']['ItemB']['C'].index[
             reverse_panel['l3']['ItemB']['C'].apply(np.isnan)]
-        assert_series_equal(filled['l1']['ItemB']['C'][nan_indexes],
-                            reverse_panel['l3']['ItemB']['C'][nan_indexes])
+        assert_series_equal(filled['l3']['ItemB']['C'][nan_indexes],
+                            reverse_panel['l1']['ItemB']['C'][nan_indexes])
 
         # Fill along axis 0 with limit.
-        filled = self.panel4d.fillna(method='ffill', axis=0, limit=1)
-        a_nan = self.panel4d['l1']['ItemA']['C'].index[
-            self.panel4d['l1']['ItemA']['C'].apply(np.isnan)]
+        filled = self.panel4d.fillna(method='bfill', axis=0, limit=1)
+        c_nan = self.panel4d['l1']['ItemC']['C'].index[
+            self.panel4d['l1']['ItemC']['C'].apply(np.isnan)]
         b_nan = self.panel4d['l1']['ItemB']['C'].index[
             self.panel4d['l1']['ItemB']['C'].apply(np.isnan)]
 
-        # Cells that are nan in ItemB but not in ItemA remain unfilled in
-        # ItemC.
+        # Cells that are nan in ItemB but not in ItemC remain unfilled in
+        # ItemA.
         self.assertTrue(
-            filled['l1']['ItemC']['C'][b_nan.diff(a_nan)].apply(np.isnan).all())
+            filled['l1']['ItemA']['C'][b_nan.diff(c_nan)].apply(np.isnan).all())
 
 
     def test_swapaxes(self):


### PR DESCRIPTION
This fixes #8251. It may need some more comprehensive tests but before I go too much farther I want to make sure the axis numbering scheme makes sense . The default behavior of `fillna` is to fill along `axis=0`. In the case of a DataFrame this fills along the columns. However, in the case of a Panel, filling along `axis=0` means you're filling along items. I'm not sure if that's the behavior that most users would think is the default. You might note that I also removed the references to what the behavior of each axis value is in the docstring since it gets a bit arbitrary when you consider both DataFrames and Panels.
