### PR TITLE
add support for numpy 1.8+ data types for conversion to r dataframe

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -287,7 +287,7 @@ API changes
 - ``DataFrame.info()`` now ends its output with a newline character (:issue:`8114`)
 - add ``copy=True`` argument to ``pd.concat`` to enable pass thrue of complete blocks (:issue:`8252`)
 
-
+- Added support for numpy 1.8+ data types (bool_, int_, float_, string_) for conversion to R dataframe  (:issue:`8400`)
 
 .. _whatsnew_0150.dt:
 

--- a/pandas/rpy/common.py
+++ b/pandas/rpy/common.py
@@ -4,6 +4,7 @@ developer-friendly.
 """
 from __future__ import print_function
 
+from distutils.version import LooseVersion
 from pandas.compat import zip, range
 import numpy as np
 
@@ -72,7 +73,7 @@ def _convert_array(obj):
             return list(item)
         except TypeError:
             return []
-        
+
     # For iris3, HairEyeColor, UCBAdmissions, Titanic
     dim = list(obj.dim)
     values = np.array(list(obj))
@@ -101,9 +102,9 @@ def _convert_vector(obj):
     except AttributeError:
         return list(obj)
     if 'names' in attributes:
-        return pd.Series(list(obj), index=r['names'](obj)) 
+        return pd.Series(list(obj), index=r['names'](obj))
     elif 'tsp' in attributes:
-        return pd.Series(list(obj), index=r['time'](obj)) 
+        return pd.Series(list(obj), index=r['time'](obj))
     elif 'labels' in attributes:
         return pd.Series(list(obj), index=r['labels'](obj))
     if _rclass(obj) == 'dist':
@@ -268,6 +269,7 @@ VECTOR_TYPES = {np.float64: robj.FloatVector,
                 np.str: robj.StrVector,
                 np.bool: robj.BoolVector}
 
+
 NA_TYPES = {np.float64: robj.NA_Real,
             np.float32: robj.NA_Real,
             np.float: robj.NA_Real,
@@ -277,6 +279,16 @@ NA_TYPES = {np.float64: robj.NA_Real,
             np.object_: robj.NA_Character,
             np.str: robj.NA_Character,
             np.bool: robj.NA_Logical}
+
+
+if LooseVersion(np.__version__) >= LooseVersion('1.8'):
+    for dict_ in (VECTOR_TYPES, NA_TYPES):
+        dict_.update({
+            np.bool_: dict_[np.bool],
+            np.int_: dict_[np.int],
+            np.float_: dict_[np.float],
+            np.string_: dict_[np.str]
+        })
 
 
 def convert_to_r_dataframe(df, strings_as_factors=False):


### PR DESCRIPTION
Numpy changed the names of their data types in 1.8
http://docs.scipy.org/doc/numpy-dev/user/basics.types.html

specifically, bool, int, float, and complex are now bool_, int_, float_ and complex_

this requires changing the VECTOR_TYPES and NA_TYPES dictionaries used by convert_to_r_dataframe in pandas/rpy/common.py

numpy 1.7 isn't feasible to include as a project dependency (too many packages require 1.8)

Unfortunately, bool_ etc don't exist in numpy < 1.8, so you'll have to try/except that bit. I can change it and submit a pull request if you like
