### PR TITLE
BUG: Panel.fillna with method='ffill' ignores the axis parameter (GH8251)

### DIFF
--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -7628,9 +7628,11 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         expected = df.fillna(df.max().to_dict())
         assert_frame_equal(result, expected)
 
-        # disable this for now
+        # disable these for now
         with assertRaisesRegexp(NotImplementedError, 'column by column'):
             df.fillna(df.max(1), axis=1)
+        with assertRaisesRegexp(NotImplementedError, 'downcast'):
+            df.fillna(df.max(1), downcast='infer')
 
     def test_fillna_dataframe(self):
         # GH 8377
@@ -7668,6 +7670,11 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         expected = df.astype(float).fillna(method='ffill', axis=1)
         assert_frame_equal(result, expected)
 
+        # disable these for now
+        with assertRaisesRegexp(NotImplementedError, 'axis 1.*in place'):
+            df.fillna(method='ffill', axis=1, inplace=True)
+        with assertRaisesRegexp(NotImplementedError, 'axis 1.*downcast'):
+            df.fillna(method='ffill', axis=1, downcast='infer')
 
     def test_fillna_invalid_method(self):
         with assertRaisesRegexp(ValueError, 'ffil'):

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1336,9 +1336,12 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         assert_panel_equal(sorted_panel, self.panel)
 
     def test_fillna(self):
+        # Fill with a value.
         filled = self.panel.fillna(0)
         self.assertTrue(np.isfinite(filled.values).all())
 
+        # If no axis is specified, fill along axis 1, equivalent to axis 0 of
+        # each DataFrame.
         filled = self.panel.fillna(method='backfill')
         assert_frame_equal(filled['ItemA'],
                            self.panel['ItemA'].fillna(method='backfill'))
@@ -1350,10 +1353,72 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         assert_frame_equal(filled['ItemA'],
                            panel['ItemA'].fillna(method='backfill'))
 
+        # Fill forward.
+        filled = self.panel.fillna(method='ffill')
+        assert_frame_equal(filled['ItemA'],
+                           self.panel['ItemA'].fillna(method='ffill'))
+
+        # With limit.
+        filled = self.panel.fillna(method='backfill', limit=1)
+        assert_frame_equal(filled['ItemA'],
+                           self.panel['ItemA'].fillna(method='backfill', limit=1))
+
+        # With downcast.
+        rounded = self.panel.apply(lambda x: x.apply(np.round))
+        filled = rounded.fillna(method='backfill', downcast='infer')
+        assert_frame_equal(filled['ItemA'],
+                           rounded['ItemA'].fillna(method='backfill', downcast='infer'))
+
+        # Now explicitly request axis 1.
+        filled = self.panel.fillna(method='backfill', axis=1)
+        assert_frame_equal(filled['ItemA'],
+                           self.panel['ItemA'].fillna(method='backfill', axis=0))
+
+        # Fill along axis 2, equivalent to filling along axis 1 of each
+        # DataFrame.
+        filled = self.panel.fillna(method='backfill', axis=2)
+        assert_frame_equal(filled['ItemA'],
+                           self.panel['ItemA'].fillna(method='backfill', axis=1))
+
+        # Fill an empty panel.
         empty = self.panel.reindex(items=[])
         filled = empty.fillna(0)
         assert_panel_equal(filled, empty)
 
+    def test_fillna_axis_0(self):
+        # Forward fill along axis 0, interpolating values across DataFrames.
+        filled = self.panel.fillna(method='ffill', axis=0)
+        nan_indexes = self.panel['ItemB']['C'].index[
+            self.panel['ItemB']['C'].apply(np.isnan)]
+        # Values from ItemA are filled into ItemB.
+        assert_series_equal(filled['ItemB']['C'][nan_indexes],
+                            self.panel['ItemA']['C'][nan_indexes])
+
+        # Backfill along axis 0.
+        filled = self.panel.fillna(method='backfill', axis=0)
+        # The test data lacks values that can be backfilled on axis 0.
+        assert_panel_equal(filled, self.panel)
+        # Reverse the panel and backfill along axis 0, to properly test
+        # backfill.
+        reverse_panel = self.panel.reindex_axis(reversed(self.panel.axes[0]))
+        filled = reverse_panel.fillna(method='bfill', axis=0)
+        nan_indexes = reverse_panel['ItemB']['C'].index[
+            reverse_panel['ItemB']['C'].apply(np.isnan)]
+        assert_series_equal(filled['ItemB']['C'][nan_indexes],
+                            reverse_panel['ItemA']['C'][nan_indexes])
+
+        # Fill along axis 0 with limit.
+        filled = self.panel.fillna(method='ffill', axis=0, limit=1)
+        a_nan = self.panel['ItemA']['C'].index[
+            self.panel['ItemA']['C'].apply(np.isnan)]
+        b_nan = self.panel['ItemB']['C'].index[
+            self.panel['ItemB']['C'].apply(np.isnan)]
+        # Cells that are nan in ItemB but not in ItemA remain unfilled in
+        # ItemC.
+        self.assertTrue(
+            filled['ItemC']['C'][b_nan.diff(a_nan)].apply(np.isnan).all())
+
+    def test_fillna_error(self):
         self.assertRaises(ValueError, self.panel.fillna)
         self.assertRaises(ValueError, self.panel.fillna, 5, method='ffill')
 
@@ -1364,6 +1429,18 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         p = Panel(np.random.randn(3,4,5))
         p.iloc[0:2,0:2,0:2] = np.nan
         self.assertRaises(NotImplementedError, lambda : p.fillna(999,limit=1))
+
+        # Method fill is not implemented with inplace=True.
+        self.assertRaises(NotImplementedError,
+                          lambda: self.panel.fillna(method='bfill', inplace=True))
+
+        # Method fill is not implemented with downcast on axis=0.
+        self.assertRaises(NotImplementedError,
+                          lambda: self.panel.fillna(method='bfill', axis=0, downcast='infer'))
+
+        # Value fill is not implemented with dict.
+        self.assertRaises(NotImplementedError,
+                          lambda: self.panel.fillna(value={'a': 'b'}))
 
     def test_ffill_bfill(self):
         assert_panel_equal(self.panel.ffill(),


### PR DESCRIPTION
Adds support for method-based fillna along the specified axis of a Panel. Also adds some additional validation when calling fillna on DataFrame.
