### PR TITLE
BENCH: programmatically create benchmarks for large ngroups (GH6787)

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -813,6 +813,7 @@ Performance
 - Performance and memory usage improvements in multi-key ``groupby`` (:issue:`8128`)
 - Performance improvements in groupby ``.agg`` and ``.apply`` where builtins max/min were not mapped to numpy/cythonized versions (:issue:`7722`)
 - Performance improvement in writing to sql (``to_sql``) of up to 50% (:issue:`8208`).
+- Performance benchmarking of groupby for large value of ngroups (:issue:`6787`)
 
 
 

--- a/vb_suite/groupby.py
+++ b/vb_suite/groupby.py
@@ -486,19 +486,10 @@ groupby_agg_builtins1 = Benchmark("df.groupby('jim').agg([sum, min, max])", setu
 groupby_agg_builtins2 = Benchmark("df.groupby(['jim', 'joe']).agg([sum, min, max])", setup)
 
 #----------------------------------------------------------------------
-# groupby with a large value for ngroups
+# groupby with a variable value for ngroups
 
-setup = common_setup + """
-np.random.seed(1234)
-ngroups = 10000
-size = ngroups * 10
-rng = np.arange(ngroups)
-df = DataFrame(dict(
-    timestamp=rng.take(np.random.randint(0, ngroups, size=size)),
-    value=np.random.randint(0, size, size=size)
-))
-"""
 
+ngroups_list = [100, 10000]
 no_arg_func_list = [
     'all',
     'any',
@@ -535,12 +526,23 @@ no_arg_func_list = [
 
 
 _stmt_template = "df.groupby('value')['timestamp'].%s"
+_setup_template = common_setup + """
+np.random.seed(1234)
+ngroups = %s
+size = ngroups * 10
+rng = np.arange(ngroups)
+df = DataFrame(dict(
+    timestamp=rng.take(np.random.randint(0, ngroups, size=size)),
+    value=np.random.randint(0, size, size=size)
+))
+"""
 START_DATE = datetime(2011, 7, 1)
 
 
-def make_large_ngroups_bmark(func_name, func_args=''):
-    bmark_name = 'groupby_large_ngroups_%s' % func_name
+def make_large_ngroups_bmark(ngroups, func_name, func_args=''):
+    bmark_name = 'groupby_ngroups_%s_%s' % (ngroups, func_name)
     stmt = _stmt_template % ('%s(%s)' % (func_name, func_args))
+    setup = _setup_template % ngroups
     bmark = Benchmark(stmt, setup, start_date=START_DATE)
     # MUST set name
     bmark.name = bmark_name
@@ -553,6 +555,7 @@ def inject_bmark_into_globals(bmark):
     globals()[bmark.name] = bmark
 
 
-for func_name in no_arg_func_list:
-    bmark = make_large_ngroups_bmark(func_name)
-    inject_bmark_into_globals(bmark)
+for ngroups in ngroups_list:
+    for func_name in no_arg_func_list:
+        bmark = make_large_ngroups_bmark(ngroups, func_name)
+        inject_bmark_into_globals(bmark)


### PR DESCRIPTION
closes #6787

Uses ngroups=10000 as suggested in the issue, which takes about 1 hour on my desktop.

For results (vb_suite.log, pkl file) see: https://gist.github.com/dlovell/ea3400273314e7612f6e
Note: gist references a different commit hash.  I changed the commit message and added modification to doc/source/v0.15.0.txt, but the actual modifications to vb_suite/groupby.py are principally the same.
