### PR TITLE
FIX: Add Categorical.searchsorted stub

### DIFF
--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -726,6 +726,9 @@ class Categorical(PandasObject):
     def nbytes(self):
         return self._codes.nbytes + self._categories.values.nbytes
 
+    def searchsorted(self, v, side='left', sorter=None):
+        raise NotImplementedError("See https://github.com/pydata/pandas/issues/8420")
+
     def isnull(self):
         """
         Detect missing values

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -889,6 +889,15 @@ class TestCategorical(tm.TestCase):
         exp = cat._codes.nbytes + cat._categories.values.nbytes
         self.assertEqual(cat.nbytes, exp)
 
+    def test_searchsorted(self):
+
+        # See https://github.com/pydata/pandas/issues/8420
+        # TODO: implement me...
+        cat = pd.Categorical([1,2,3])
+        def f():
+            cat.searchsorted(3)
+        self.assertRaises(NotImplementedError, f)
+
     def test_deprecated_labels(self):
         # TODO: labels is deprecated and should be removed in 0.18 or 2017, whatever is earlier
         cat = pd.Categorical([1,2,3, np.nan], categories=[1,2,3])


### PR DESCRIPTION
For https://github.com/pydata/pandas/pull/7447, add a searchsorted
stub, which simple raises `NotImplementedError`, so that we raise a
more clear error than attribute not found.

xref #8420 
