### PR TITLE
DOC: mention 'category' in select_dtypes docstring

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1903,6 +1903,7 @@ class DataFrame(NDFrame):
           this will return *all* object dtype columns
         * See the `numpy dtype hierarchy
           <http://docs.scipy.org/doc/numpy/reference/arrays.scalars.html>`__
+        * To select Pandas categorical dtypes, use 'category'
 
         Examples
         --------


### PR DESCRIPTION
Trivial update to select_dtypes docstring to hint on how to include Categorical types, as it's not part of the numpy type-hierarchy mentioned here.
