### PR TITLE
PERF: optimize storage type for codes in Categoricals (GH8453)

### DIFF
--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -47,7 +47,7 @@ the `categories` array.
 The categorical data type is useful in the following cases:
 
 * A string variable consisting of only a few different values. Converting such a string
-  variable to a categorical variable will save some memory.
+  variable to a categorical variable will save some memory, see :ref:`here<categorical.memory>`.
 * The lexical order of a variable is not the same as the logical order ("one", "two", "three").
   By converting to a categorical and specifying an order on the categories, sorting and
   min/max will use the logical order instead of the lexical order.
@@ -632,6 +632,27 @@ The following differences to R's factor functions can be observed:
 
 Gotchas
 -------
+
+.. _categorical.memory:
+
+Memory Usage
+~~~~~~~~~~~~
+
+The memory usage of a ``Categorical`` is proportional to the length of the categories times the length of the data. In contrast,
+the an ``object`` dtype is a fixed function of the length of the data.
+
+.. ipython:: python
+
+   s = Series(['foo','bar']*1000)
+
+   # object dtype
+   s.nbytes
+
+   # category dtype
+   s.astype('category').nbytes
+
+Note that if the number of categories approaches the length of the data, the ``Categorical`` will use nearly (or more) memory than an
+equivalent ``object`` dtype representation.
 
 Old style constructor usage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -563,7 +563,7 @@ Categoricals in Series/DataFrame
 :class:`~pandas.Categorical` can now be included in `Series` and `DataFrames` and gained new
 methods to manipulate. Thanks to Jan Schulz for much of this API/implementation. (:issue:`3943`, :issue:`5313`, :issue:`5314`,
 :issue:`7444`, :issue:`7839`, :issue:`7848`, :issue:`7864`, :issue:`7914`, :issue:`7768`, :issue:`8006`, :issue:`3678`,
-:issue:`8075`, :issue:`8076`, :issue:`8143`).
+:issue:`8075`, :issue:`8076`, :issue:`8143`, :issue:`8453`).
 
 For full docs, see the :ref:`categorical introduction <categorical>` and the
 :ref:`API documentation <api.categorical>`.


### PR DESCRIPTION
closes #8453

So easy enough to optimize the dtype of the codes array depending on the number of categories. Most
of the time will simply be `int8`. So pretty good savings.

This doesn't completely solve the storage issues as currently `factorize` returns a `int64`, but can deal with that later (as might also need some more cython definitions).

And of course in the extreme case (where len(categories) == len(codes) you are better off with an object dtype).

```
In [1]: s = Series(['foo','bar']*1000)

In [2]: s.nbytes
Out[2]: 16000

In [3]: s.astype('category').nbytes
Out[3]: 2016

In [5]: s.astype('category').values.codes
Out[5]: array([1, 0, 1, ..., 0, 1, 0], dtype=int8)
```
