### PR TITLE
BUG: type diversity breaks alignment

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -1007,3 +1007,4 @@ Bug Fixes
 - Bug in Index.intersection on non-monotonic non-unique indexes (:issue:`8362`).
 - Bug in masked series assignment where mismatching types would break alignment (:issue:`8387`)
 - Bug in NDFrame.equals gives false negatives with dtype=object (:issue:`8437`)
+- Bug in assignment with indexer where type diversity would break alignment (:issue:`8258`)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1405,6 +1405,7 @@ class CheckIndexing(object):
         # key is unaligned with values
         f = self.mixed_frame.copy()
         piece = f.ix[:2, ['A']]
+        piece.index = f.index[-2:]
         key = (slice(-2, None), ['A', 'B'])
         f.ix[key] = piece
         piece['B'] = np.nan


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/8258, but more generally, on pandas master, assignment with indexer will align _both rows and columns_ if all columns have the same type:

```
>>> cols, idx = ['jim', 'joe', 'jolie'], ['first', 'last']
>>> vals = np.arange(1, 7).reshape(2, 3, order='F')
>>> df = DataFrame(vals, columns=cols, index=idx)
>>> left, rhs = df.copy(), - df.iloc[::-1, -2::-1]
>>> print(left, rhs, sep='\n')
       jim  joe  jolie
first    1    3      5
last     2    4      6
       joe  jim
last    -4   -2
first   -3   -1
>>> 
>>> left.loc[:, ['jim', 'joe']] = rhs
>>> left
       jim  joe  jolie
first   -1   -3      5
last    -2   -4      6
```

However, if I change the type of a column even _outside_ the section which gets assigned to, _only columns_ are aligned:

```
>>> df = DataFrame(vals, columns=cols, index=idx)
>>> df['jolie'] = df['jolie'].astype('float64')
>>> left, rhs = df.copy(), - df.iloc[::-1, -2::-1]
>>> print(left, rhs, sep='\n')
       jim  joe  jolie
first    1    3      5
last     2    4      6
       joe  jim
last    -4   -2
first   -3   -1
>>> 
>>> left.loc[:, ['jim', 'joe']] = rhs
>>> left
       jim  joe  jolie
first   -2   -4      5
last    -1   -3      6
```

Code-wise this is a bug, because [this line](https://github.com/pydata/pandas/blob/fccd7feabfe0bf15c30d712f3a4a4ff71e76ad4a/pandas/core/indexing.py#L446) is taking the _entire frame_'s index and re-indexes to that, regardless of the actual indexer which selects a section of the frame to assign to. That said, there are two places in tests where they rely on this behaviour, [here](https://github.com/pydata/pandas/blob/fccd7feabfe0bf15c30d712f3a4a4ff71e76ad4a/pandas/tests/test_frame.py#L1405) and [here](https://github.com/pydata/pandas/blob/fccd7feabfe0bf15c30d712f3a4a4ff71e76ad4a/pandas/tests/test_indexing.py#L1033).
