### PR TITLE
BUG: fix Index.reindex to preserve name when target is list/ndarray

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -1012,3 +1012,4 @@ Bug Fixes
 - Bug in masked series assignment where mismatching types would break alignment (:issue:`8387`)
 - Bug in NDFrame.equals gives false negatives with dtype=object (:issue:`8437`)
 - Bug in assignment with indexer where type diversity would break alignment (:issue:`8258`)
+- Bug in ``NDFrame.loc`` indexing when row/column names were lost when target was a list/ndarray (:issue:`6552`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2260,8 +2260,7 @@ class DataFrame(NDFrame):
     def _reindex_index(self, new_index, method, copy, level, fill_value=NA,
                        limit=None):
         new_index, indexer = self.index.reindex(new_index, method, level,
-                                                limit=limit,
-                                                copy_if_needed=True)
+                                                limit=limit)
         return self._reindex_with_indexers({0: [new_index, indexer]},
                                            copy=copy, fill_value=fill_value,
                                            allow_dups=False)
@@ -2269,8 +2268,7 @@ class DataFrame(NDFrame):
     def _reindex_columns(self, new_columns, copy, level, fill_value=NA,
                          limit=None):
         new_columns, indexer = self.columns.reindex(new_columns, level=level,
-                                                    limit=limit,
-                                                    copy_if_needed=True)
+                                                    limit=limit)
         return self._reindex_with_indexers({1: [new_columns, indexer]},
                                            copy=copy, fill_value=fill_value,
                                            allow_dups=False)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1776,8 +1776,8 @@ class NDFrame(PandasObject):
         axis_name = self._get_axis_name(axis)
         axis_values = self._get_axis(axis_name)
         method = com._clean_fill_method(method)
-        new_index, indexer = axis_values.reindex(
-            labels, method, level, limit=limit, copy_if_needed=True)
+        new_index, indexer = axis_values.reindex(labels, method, level,
+                                                 limit=limit)
         return self._reindex_with_indexers(
             {axis: [new_index, indexer]}, method=method, fill_value=fill_value,
             limit=limit, copy=copy)

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -3088,7 +3088,7 @@ class BlockManager(PandasObject):
         """
         new_index = _ensure_index(new_index)
         new_index, indexer = self.axes[axis].reindex(
-            new_index, method=method, limit=limit, copy_if_needed=True)
+            new_index, method=method, limit=limit)
 
         return self.reindex_indexer(new_index, indexer, axis=axis,
                                     fill_value=fill_value, copy=copy)

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -3836,9 +3836,7 @@ class TestIndexing(tm.TestCase):
         assert_frame_equal(df.iloc[[],:], df.iloc[:0, :])  # horizontal empty
         assert_frame_equal(df.iloc[[]], df.iloc[:0, :])  # horizontal empty
 
-    # FIXME: fix loc & xs
     def test_loc_empty_list_indexer_is_ok(self):
-        raise nose.SkipTest('loc discards columns names')
         from pandas.util.testing import makeCustomDataframe as mkdf
         df = mkdf(5, 2)
         assert_frame_equal(df.loc[:,[]], df.iloc[:, :0])  # vertical empty
@@ -3846,7 +3844,6 @@ class TestIndexing(tm.TestCase):
         assert_frame_equal(df.loc[[]], df.iloc[:0, :])  # horizontal empty
 
     def test_ix_empty_list_indexer_is_ok(self):
-        raise nose.SkipTest('ix discards columns names')
         from pandas.util.testing import makeCustomDataframe as mkdf
         df = mkdf(5, 2)
         assert_frame_equal(df.ix[:,[]], df.iloc[:, :0])  # vertical empty


### PR DESCRIPTION
This PR fixes #6552 and also includes:

CLN: drop copy_if_needed kwarg of Index.reindex, it's True everywhere
TST: enable back empty-list loc/ix tests that failed before
DOC: Bump Index.reindex docstring
