### PR TITLE
BUG: fix Index.reindex to preserve type when target is empty list/ndarray

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -1025,3 +1025,4 @@ Bug Fixes
 - Bug in NDFrame.equals gives false negatives with dtype=object (:issue:`8437`)
 - Bug in assignment with indexer where type diversity would break alignment (:issue:`8258`)
 - Bug in ``NDFrame.loc`` indexing when row/column names were lost when target was a list/ndarray (:issue:`6552`)
+- Regression in ``NDFrame.loc`` indexing when rows/columns were converted to Float64Index if target was an empty list/ndarray (:issue:`7774`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1707,15 +1707,11 @@ class NDFrame(PandasObject):
             if labels is None:
                 continue
 
-            # convert to an index if we are not a multi-selection
             ax = self._get_axis(a)
-            if level is None:
-                labels = _ensure_index(labels)
-
-            axis = self._get_axis_number(a)
             new_index, indexer = ax.reindex(
                 labels, level=level, limit=limit, method=method)
 
+            axis = self._get_axis_number(a)
             obj = obj._reindex_with_indexers(
                 {axis: [new_index, indexer]}, method=method,
                 fill_value=fill_value, limit=limit, copy=copy,

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -3832,23 +3832,41 @@ class TestIndexing(tm.TestCase):
     def test_iloc_empty_list_indexer_is_ok(self):
         from pandas.util.testing import makeCustomDataframe as mkdf
         df = mkdf(5, 2)
-        assert_frame_equal(df.iloc[:,[]], df.iloc[:, :0])  # vertical empty
-        assert_frame_equal(df.iloc[[],:], df.iloc[:0, :])  # horizontal empty
-        assert_frame_equal(df.iloc[[]], df.iloc[:0, :])  # horizontal empty
+        # vertical empty
+        assert_frame_equal(df.iloc[:, []], df.iloc[:, :0],
+                           check_index_type=True, check_column_type=True)
+        # horizontal empty
+        assert_frame_equal(df.iloc[[], :], df.iloc[:0, :],
+                           check_index_type=True, check_column_type=True)
+        # horizontal empty
+        assert_frame_equal(df.iloc[[]], df.iloc[:0, :],
+                           check_index_type=True, check_column_type=True)
 
     def test_loc_empty_list_indexer_is_ok(self):
         from pandas.util.testing import makeCustomDataframe as mkdf
         df = mkdf(5, 2)
-        assert_frame_equal(df.loc[:,[]], df.iloc[:, :0])  # vertical empty
-        assert_frame_equal(df.loc[[],:], df.iloc[:0, :])  # horizontal empty
-        assert_frame_equal(df.loc[[]], df.iloc[:0, :])  # horizontal empty
+        # vertical empty
+        assert_frame_equal(df.loc[:, []], df.iloc[:, :0],
+                           check_index_type=True, check_column_type=True)
+        # horizontal empty
+        assert_frame_equal(df.loc[[], :], df.iloc[:0, :],
+                           check_index_type=True, check_column_type=True)
+        # horizontal empty
+        assert_frame_equal(df.loc[[]], df.iloc[:0, :],
+                           check_index_type=True, check_column_type=True)
 
     def test_ix_empty_list_indexer_is_ok(self):
         from pandas.util.testing import makeCustomDataframe as mkdf
         df = mkdf(5, 2)
-        assert_frame_equal(df.ix[:,[]], df.iloc[:, :0])  # vertical empty
-        assert_frame_equal(df.ix[[],:], df.iloc[:0, :])  # horizontal empty
-        assert_frame_equal(df.ix[[]], df.iloc[:0, :])  # horizontal empty
+        # vertical empty
+        assert_frame_equal(df.ix[:, []], df.iloc[:, :0],
+                           check_index_type=True, check_column_type=True)
+        # horizontal empty
+        assert_frame_equal(df.ix[[], :], df.iloc[:0, :],
+                           check_index_type=True, check_column_type=True)
+        # horizontal empty
+        assert_frame_equal(df.ix[[]], df.iloc[:0, :],
+                           check_index_type=True, check_column_type=True)
 
     def test_deprecate_float_indexers(self):
 


### PR DESCRIPTION
This PR fixes #7774 and also includes:

TST: check index/columns types when doing empty loc/ix tests

CLN: don't _ensure_index in NDFrame._reindex_axes, it is done in Index.reindex
