### PR TITLE
SQL/ERR: raise error when insert failed with sqlite fallback (GH8341)

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1155,6 +1155,7 @@ class PandasSQLLegacy(PandasSQL):
             self.con.commit()
         except:
             self.con.rollback()
+            raise
         finally:
             cur.close()
 


### PR DESCRIPTION
Related to #8341, does not closes it, but deals with the fact that it now fails silently
