### PR TITLE
Disallow Series indexing by DataFrame

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -1026,3 +1026,4 @@ Bug Fixes
 - Bug in assignment with indexer where type diversity would break alignment (:issue:`8258`)
 - Bug in ``NDFrame.loc`` indexing when row/column names were lost when target was a list/ndarray (:issue:`6552`)
 - Regression in ``NDFrame.loc`` indexing when rows/columns were converted to Float64Index if target was an empty list/ndarray (:issue:`7774`)
+- Bug in Series that allows it to be indexed by a DataFrame which has unexpected results.  Such indexing is no longer permitted (:issue:`8444`)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -21,7 +21,7 @@ from pandas.core.common import (isnull, notnull, _is_bool_indexer,
                                 _possibly_convert_platform, _try_sort,
                                 ABCSparseArray, _maybe_match_name, _coerce_to_dtype,
                                 _ensure_object, SettingWithCopyError,
-                                _maybe_box_datetimelike)
+                                _maybe_box_datetimelike, ABCDataFrame)
 from pandas.core.index import (Index, MultiIndex, InvalidIndexError,
                                _ensure_index)
 from pandas.core.indexing import _check_bool_indexer, _maybe_convert_indices
@@ -545,6 +545,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         if isinstance(key, slice):
             indexer = self.index._convert_slice_indexer(key, typ='getitem')
             return self._get_values(indexer)
+        elif isinstance(key, ABCDataFrame):
+            raise TypeError('Indexing a Series with DataFrame is not supported, '\
+                            'use the appropriate DataFrame column')
         else:
             if isinstance(key, tuple):
                 try:

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1222,6 +1222,12 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         expected = Series([3,4],index=['C','C'],dtype=np.int64)
         result = s['C']
         assert_series_equal(result, expected)
+        
+    def test_getitem_dataframe(self):
+        rng = list(range(10))
+        s   = pd.Series(10, index=rng)
+        df  = pd.DataFrame(rng, index=rng)
+        self.assertRaises(TypeError, s.__getitem__, df>5)
 
     def test_setitem_ambiguous_keyerror(self):
         s = Series(lrange(10), index=lrange(0, 20, 2))


### PR DESCRIPTION
Fixes #8444.  I don't like importing DataFrame, but this was most obvious way to do it.
