### PR TITLE
BUG: sub-frame assignment of a multi-index frame breaks alignment

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -1048,3 +1048,4 @@ Bug Fixes
 - Bug in ``NDFrame.loc`` indexing when row/column names were lost when target was a list/ndarray (:issue:`6552`)
 - Regression in ``NDFrame.loc`` indexing when rows/columns were converted to Float64Index if target was an empty list/ndarray (:issue:`7774`)
 - Bug in Series that allows it to be indexed by a DataFrame which has unexpected results.  Such indexing is no longer permitted (:issue:`8444`)
+- Bug in item assignment of a DataFrame with multi-index columns where right-hand-side columns were not aligned (:issue:`7655`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2194,6 +2194,15 @@ class DataFrame(NDFrame):
             value = reindexer(value)
 
         elif isinstance(value, DataFrame):
+            # align right-hand-side columns if self.columns
+            # is multi-index and self[key] is a sub-frame
+            if isinstance(self.columns, MultiIndex) and key in self.columns:
+                loc = self.columns.get_loc(key)
+                if isinstance(loc, (slice, Series, np.ndarray, Index)):
+                    cols = _maybe_droplevels(self.columns[loc], key)
+                    if len(cols) and not cols.equals(value.columns):
+                        value = value.reindex_axis(cols, axis=1)
+            # now align rows
             value = reindexer(value).T
 
         elif isinstance(value, Categorical):


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/7655

```
>>> df
             jim                                  joe                                jolie                               
           first              last              first              last              first              last             
            left center right left center right  left center right left center right  left center right left center right
2000-01-03     0      3     6    9     12    15    18     21    24   27     30    33    36     39    42   45     48    51
2000-01-04     1      4     7   10     13    16    19     22    25   28     31    34    37     40    43   46     49    52
2000-01-05     2      5     8   11     14    17    20     23    26   29     32    35    38     41    44   47     50    53

>>> i, j = df.index.values.copy(), it[-1][:]
>>> np.random.shuffle(i)
>>> df['jim'] = df['jolie'].loc[i, ::-1]
>>> df.loc[:, ['jim', 'jolie']]
             jim                                jolie                               
           first              last              first              last             
            left center right left center right  left center right left center right
2000-01-03    36     39    42   45     48    51    36     39    42   45     48    51
2000-01-04    37     40    43   46     49    52    37     40    43   46     49    52
2000-01-05    38     41    44   47     50    53    38     41    44   47     50    53

>>> np.random.shuffle(j)
>>> df[('joe', 'first')] = df[('jolie', 'last')].loc[i, j]
>>> np.random.shuffle(j)
>>> df[('joe', 'last')] = df[('jolie', 'first')].loc[i, j]
>>> df.loc[:, ['joe', 'jolie']]
             joe                                jolie                               
           first              last              first              last             
            left center right left center right  left center right left center right
2000-01-03    45     48    51   36     39    42    36     39    42   45     48    51
2000-01-04    46     49    52   37     40    43    37     40    43   46     49    52
2000-01-05    47     50    53   38     41    44    38     41    44   47     50    53
```
