### PR TITLE
BUG: searchsorted sorter issue with 32bit platforms (GH8490)

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1429,6 +1429,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         >>> x.searchsorted([1, 2], side='right', sorter=[0, 2, 1])
         array([1, 3])
         """
+        if sorter is not None:
+            sorter = com._ensure_platform_int(sorter)
+
         return self.values.searchsorted(Series(v).values, side=side,
                                         sorter=sorter)
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -6199,6 +6199,12 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         e = np.array([1, 2])
         tm.assert_array_equal(r, e)
 
+    def test_searchsorted_sorter(self):
+        # GH8490
+        s = Series([3, 1, 2])
+        r = s.searchsorted([0, 3], sorter=np.argsort(s))
+        e = np.array([0, 2])
+        tm.assert_array_equal(r, e)
 
 
 


### PR DESCRIPTION
Closes #8490 
