### PR TITLE
DOC: fix notes in plot() docstring

### DIFF
--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -2310,8 +2310,7 @@ df_unique = """stacked : boolean, default False in line and
         Sort column names to determine plot ordering
     secondary_y : boolean or sequence, default False
         Whether to plot on the secondary y-axis
-        If a list/tuple, which columns to plot on secondary y-axis
-"""
+        If a list/tuple, which columns to plot on secondary y-axis"""
 series_unique = """label : label argument to provide to plot
     secondary_y : boolean or sequence of ints, default False
         If True then y-axis will be on the right"""
@@ -2328,9 +2327,8 @@ df_ax = """ax : matplotlib axes object, default None
 series_ax = """ax : matplotlib axes object
         If not passed, uses gca()"""
 
-df_note = """- If `kind` = 'bar' or 'barh', you can specify relative alignments
-      for bar plot layout by `position` keyword.
-      From 0 (left/bottom-end) to 1 (right/top-end). Default is 0.5 (center)
+df_note = """- If `kind` = 'scatter' and the argument `c` is the name of a dataframe
+      column, the values of that column are used to color each point.
     - If `kind` = 'hexbin', you can control the size of the bins with the
       `gridsize` argument. By default, a histogram of the counts around each
       `(x, y)` point is computed. You can specify alternative aggregations
@@ -2425,19 +2423,12 @@ _shared_docs['plot'] = """
     Notes
     -----
 
-    If `kind` = 'hexbin', you can control the size of the bins with the
-    `gridsize` argument. By default, a histogram of the counts around each
-    `(x, y)` point is computed. You can specify alternative aggregations
-    by passing values to the `C` and `reduce_C_function` arguments.
-    `C` specifies the value at each `(x, y)` point and `reduce_C_function`
-    is a function of one argument that reduces all the values in a bin to
-    a single number (e.g. `mean`, `max`, `sum`, `std`).
-
-    If `kind` = 'scatter' and the argument `c` is the name of a dataframe column,
-    the values of that column are used to color each point.
     - See matplotlib documentation online for more on this subject
+    - If `kind` = 'bar' or 'barh', you can specify relative alignments
+      for bar plot layout by `position` keyword.
+      From 0 (left/bottom-end) to 1 (right/top-end). Default is 0.5 (center)
     %(klass_note)s
-    
+
     """
 
 @Appender(_shared_docs['plot'] % _shared_doc_df_kwargs)


### PR DESCRIPTION
There was some repetition in the docstring note of `plot` since the refactor of the docstring (hexbin part) + scatter is only needed for dataframe docstring (not series)
