### PR TITLE
Raise more specific exception on concat([None])

### DIFF
--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -41,7 +41,7 @@ if __debug__:
     merge.__doc__ = _merge_doc % '\nleft : DataFrame'
 
 
-class MergeError(Exception):
+class MergeError(ValueError):
     pass
 
 

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -679,7 +679,7 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
         If a dict is passed, the sorted keys will be used as the `keys`
         argument, unless it is passed, in which case the values will be
         selected (see below). Any None objects will be dropped silently unless
-        they are all None in which case an Exception will be raised
+        they are all None in which case a ValueError will be raised
     axis : {0, 1, ...}, default 0
         The axis to concatenate along
     join : {'inner', 'outer'}, default 'outer'
@@ -764,7 +764,7 @@ class _Concatenator(object):
             keys = clean_keys
 
         if len(objs) == 0:
-            raise Exception('All objects passed were None')
+            raise ValueError('All objects passed were None')
 
         # consolidate data & figure out what our result ndim is going to be
         ndims = set()

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -2122,7 +2122,7 @@ class TestConcatenate(tm.TestCase):
         pieces = [df[:5], None, None, df[5:]]
         result = concat(pieces)
         tm.assert_frame_equal(result, df)
-        self.assertRaises(Exception, concat, [None, None])
+        self.assertRaises(ValueError, concat, [None, None])
 
     def test_concat_datetime64_block(self):
         from pandas.tseries.index import date_range


### PR DESCRIPTION
More specific exception allows for a safer, more explicit catch by a caller.
ConcatenationError follows the pattern of MergeError which is used in the same file when something is wrong with a caller's inputs to  merge().
