### PR TITLE
ENH: axvlines - boolean option to parallel_coordinates plot

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -80,6 +80,7 @@ Enhancements
 - ``Series`` now works with map objects the same way as generators (:issue:`8909`).
 - Added context manager to ``HDFStore`` for automatic closing (:issue:`8791`).
 - ``to_datetime`` gains an ``exact`` keyword to allow for a format to not require an exact match for a provided format string (if its ``False). ``exact`` defaults to ``True`` (meaning that exact matching is still the default)  (:issue:`8904`)
+- Added ``axvlines`` boolean option to parallel_coordinates plot function, determines whether vertical lines will be printed, default is True
 
 .. _whatsnew_0152.performance:
 

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -2354,7 +2354,9 @@ class TestDataFramePlots(TestPlotBase):
 
         df = self.iris
 
-        _check_plot_works(parallel_coordinates, df, 'Name')
+        ax = _check_plot_works(parallel_coordinates, df, 'Name')
+        nlines = len(ax.get_lines())
+        nxticks = len(ax.xaxis.get_ticklabels())
 
         rgba = ('#556270', '#4ECDC4', '#C7F464')
         ax = _check_plot_works(parallel_coordinates, df, 'Name', color=rgba)
@@ -2367,6 +2369,9 @@ class TestDataFramePlots(TestPlotBase):
         ax = _check_plot_works(parallel_coordinates, df, 'Name', colormap=cm.jet)
         cmaps = lmap(cm.jet, np.linspace(0, 1, df['Name'].nunique()))
         self._check_colors(ax.get_lines()[:10], linecolors=cmaps, mapping=df['Name'][:10])
+
+        ax = _check_plot_works(parallel_coordinates, df, 'Name', axvlines=False)
+        assert len(ax.get_lines()) == (nlines - nxticks)
 
         colors = ['b', 'g', 'r']
         df = DataFrame({"A": [1, 2, 3],

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -581,7 +581,7 @@ def bootstrap_plot(series, fig=None, size=50, samples=500, **kwds):
 @deprecate_kwarg(old_arg_name='data', new_arg_name='frame')
 def parallel_coordinates(frame, class_column, cols=None, ax=None, color=None,
                          use_columns=False, xticks=None, colormap=None,
-                         **kwds):
+                         axvlines=True, **kwds):
     """Parallel coordinates plotting.
 
     Parameters
@@ -601,6 +601,8 @@ def parallel_coordinates(frame, class_column, cols=None, ax=None, color=None,
         A list of values to use for xticks
     colormap: str or matplotlib colormap, default None
         Colormap to use for line colors.
+    axvlines: bool, optional
+        If true, vertical lines will be added at each xtick
     kwds: keywords
         Options to pass to matplotlib plotting method
 
@@ -665,8 +667,9 @@ def parallel_coordinates(frame, class_column, cols=None, ax=None, color=None,
         else:
             ax.plot(x, y, color=colors[kls], **kwds)
 
-    for i in x:
-        ax.axvline(i, linewidth=1, color='black')
+    if axvlines:
+        for i in x:
+            ax.axvline(i, linewidth=1, color='black')
 
     ax.set_xticks(x)
     ax.set_xticklabels(df.columns)


### PR DESCRIPTION
Determines whether vertical lines will be added to parallel_coordinates plot. I was using parallel coordinates to make a seasonality chart - plotting years on top of each other (days/months of year on x-axis). With that many xticks, the vertical lines were overwhelming. It's possible to remove the lines after the fact, but without specific line identifiers, it isn't a straight forward process. However, preventing them from being added is a one-liner...
