### PR TITLE
PERF: Performance improvement for MultiIndexes with a DatetimeIndex levels

### DIFF
--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -932,6 +932,7 @@ Performance
 - Performance improvement in writing to sql (``to_sql``) of up to 50% (:issue:`8208`).
 - Performance benchmarking of groupby for large value of ngroups (:issue:`6787`)
 - Performance improvement in ``CustomBusinessDay``, ``CustomBusinessMonth`` (:issue:`8236`)
+- Performance improvement for ``MultiIndex.values`` for multi-level indexes containing datetimes (:issue:`8543`)
 
 
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -2937,10 +2937,11 @@ class MultiIndex(Index):
 
         values = []
         for lev, lab in zip(self.levels, self.labels):
-            taken = com.take_1d(lev.values, lab)
+            lev_values = lev.values
             # Need to box timestamps, etc.
             if hasattr(lev, '_box_values'):
-                taken = lev._box_values(taken)
+                lev_values = lev._box_values(lev_values)
+            taken = com.take_1d(lev_values, lab)
             values.append(taken)
 
         self._tuples = lib.fast_zip(values)

--- a/vb_suite/index_object.py
+++ b/vb_suite/index_object.py
@@ -117,3 +117,16 @@ iterables = [tm.makeStringIndex(10000), xrange(20)]
 multiindex_from_product = Benchmark('MultiIndex.from_product(iterables)',
                                     setup, name='multiindex_from_product',
                                     start_date=datetime(2014, 6, 30))
+
+#----------------------------------------------------------------------
+# MultiIndex with DatetimeIndex level
+
+setup = common_setup + """
+level1 = range(1000)
+level2 = date_range(start='1/1/2012', periods=10)
+"""
+
+multiindex_with_datetime_level = \
+    Benchmark("MultiIndex.from_product([level1, level2]).values", setup,
+              name='multiindex_with_datetime_level',
+              start_date=datetime(2014, 10, 11))


### PR DESCRIPTION
Addresses #8543. The benefits are most pronounced when there are a small number of distinct datetimes relative to the number of rows in the index.

vbench results with `-r multi`:

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
multi_with_datetime_level                    |   1.5767 |  46.8633 |   0.0336 |
reindex_multiindex                           |   1.1919 |   1.2113 |   0.9840 |
groupby_transform_multi_key4                 | 121.5626 | 123.5036 |   0.9843 |
frame_multi_and_st                           |  33.3813 |  33.5990 |   0.9935 |
groupby_multi_series_op                      |  11.2731 |  11.3403 |   0.9941 |
groupby_multi_count                          |   7.2227 |   7.2653 |   0.9941 |
groupby_multi_different_functions            |   9.5117 |   9.5397 |   0.9971 |
groupby_multi_size                           |  19.4443 |  19.4850 |   0.9979 |
frame_multi_and_no_ne                        |  55.7680 |  55.8747 |   0.9981 |
groupby_multi_different_numpy_functions      |   9.5197 |   9.5037 |   1.0017 |
groupby_transform_multi_key1                 |  65.6123 |  65.4763 |   1.0021 |
read_table_multiple_date                     | 148.9107 | 148.2257 |   1.0046 |
join_dataframe_index_multi                   |  15.1207 |  15.0447 |   1.0051 |
stat_ops_level_frame_sum_multiple            |   6.7097 |   6.6660 |   1.0065 |
groupby_multi_cython                         |  12.6956 |  12.5817 |   1.0091 |
frame_multi_and                              |  19.6610 |  19.4677 |   1.0099 |
read_table_multiple_date_baseline            |  68.1753 |  67.3580 |   1.0121 |
multiindex_from_product                      |  10.0873 |   9.9500 |   1.0138 |
groupby_transform_multi_key2                 |  45.2770 |  44.5527 |   1.0163 |
groupby_multi_python                         | 122.5337 | 119.1190 |   1.0287 |
stat_ops_level_series_sum_multiple           |   5.2770 |   5.1050 |   1.0337 |
groupby_transform_multi_key3                 | 788.8023 | 736.1453 |   1.0715 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------

```
