### PR TITLE
PERF: Slowness in multi-level indexes with datetime levels (part 2)

### DIFF
--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -2335,6 +2335,18 @@ class TestMultiIndex(Base, tm.TestCase):
                                               (2, pd.Timestamp('2000-01-02'))])
         assert_array_equal(mi.values, etalon)
 
+    def test_values_boxed(self):
+        tuples = [(1, pd.Timestamp('2000-01-01')),
+                  (2, pd.NaT),
+                  (3, pd.Timestamp('2000-01-03')),
+                  (1, pd.Timestamp('2000-01-04')),
+                  (2, pd.Timestamp('2000-01-02')),
+                  (3, pd.Timestamp('2000-01-03'))]
+        mi = pd.MultiIndex.from_tuples(tuples)
+        assert_array_equal(mi.values, pd.lib.list_to_object_array(tuples))
+        # Check that code branches for boxed values produce identical results
+        assert_array_equal(mi.values[:4], mi[:4].values)
+
     def test_append(self):
         result = self.index[:3].append(self.index[3:])
         self.assertTrue(result.equals(self.index))

--- a/vb_suite/index_object.py
+++ b/vb_suite/index_object.py
@@ -108,7 +108,7 @@ index_float64_div = Benchmark('idx / 2', setup, name='index_float64_div',
 
 
 # Constructing MultiIndex from cartesian product of iterables
-# 
+#
 
 setup = common_setup + """
 iterables = [tm.makeStringIndex(10000), xrange(20)]
@@ -123,10 +123,17 @@ multiindex_from_product = Benchmark('MultiIndex.from_product(iterables)',
 
 setup = common_setup + """
 level1 = range(1000)
-level2 = date_range(start='1/1/2012', periods=10)
+level2 = date_range(start='1/1/2012', periods=100)
+mi = MultiIndex.from_product([level1, level2])
 """
 
-multiindex_with_datetime_level = \
-    Benchmark("MultiIndex.from_product([level1, level2]).values", setup,
-              name='multiindex_with_datetime_level',
+multiindex_with_datetime_level_full = \
+    Benchmark("mi.copy().values", setup,
+              name='multiindex_with_datetime_level_full',
+              start_date=datetime(2014, 10, 11))
+
+
+multiindex_with_datetime_level_sliced = \
+    Benchmark("mi[:10].values", setup,
+              name='multiindex_with_datetime_level_sliced',
               start_date=datetime(2014, 10, 11))


### PR DESCRIPTION
Corrects some deficiencies noted here: https://github.com/pydata/pandas/pull/8544#issuecomment-58909397. Adds a test case and an additional vbench test.
