### PR TITLE
ENH: Move any/all to NDFrame, support additional arguments for Series. GH8302

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -22,6 +22,20 @@ API changes
 
 - Bug in concat of Series with ``category`` dtype which were coercing to ``object``. (:issue:`8641`)
 
+- ``Series.all`` and ``Series.any`` now support the ``level`` and ``skipna`` parameters. ``Series.all``, ``Series.any``, ``Index.all``, and ``Index.any`` no longer support the ``out`` and ``keepdims`` parameters, which existed for compatibility with ndarray. Various index types no longer support the ``all`` and ``any`` aggregation functions. (:issue:`8302`):
+
+  .. ipython:: python
+
+     s = pd.Series([False, True, False], index=[0, 0, 1])
+     s.any(level=0)
+
+- ``Panel`` now supports the ``all`` and ``any`` aggregation functions. (:issue:`8302`):
+
+  .. ipython:: python
+
+     p = pd.Panel(np.random.rand(2, 5, 4) > 0.1)
+     p.all()
+
 .. _whatsnew_0152.enhancements:
 
 Enhancements

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -268,18 +268,6 @@ class FrozenNDArray(PandasObject, np.ndarray):
                                  quote_strings=True)
         return "%s(%s, dtype='%s')" % (type(self).__name__, prepr, self.dtype)
 
-def _unbox(func):
-    @Appender(func.__doc__)
-    def f(self, *args, **kwargs):
-        result = func(self.values, *args, **kwargs)
-        from pandas.core.index import Index
-        if isinstance(result, (np.ndarray, com.ABCSeries, Index)) and result.ndim == 0:
-            # return NumPy type
-            return result.dtype.type(result.item())
-        else:  # pragma: no cover
-            return result
-    f.__name__ = func.__name__
-    return f
 
 class IndexOpsMixin(object):
     """ common ops mixin to support a unified inteface / docs for Series / Index """
@@ -527,12 +515,6 @@ class IndexOpsMixin(object):
         except AttributeError:
             from pandas.core.index import Index
             return Index(duplicated)
-
-    #----------------------------------------------------------------------
-    # unbox reductions
-
-    all = _unbox(np.ndarray.all)
-    any = _unbox(np.ndarray.any)
 
     #----------------------------------------------------------------------
     # abstracts

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4133,68 +4133,6 @@ class DataFrame(NDFrame):
         else:
             return result
 
-    def any(self, axis=None, bool_only=None, skipna=True, level=None,
-            **kwargs):
-        """
-        Return whether any element is True over requested axis.
-        %(na_action)s
-
-        Parameters
-        ----------
-        axis : {0, 1}
-            0 for row-wise, 1 for column-wise
-        skipna : boolean, default True
-            Exclude NA/null values. If an entire row/column is NA, the result
-            will be NA
-        level : int or level name, default None
-            If the axis is a MultiIndex (hierarchical), count along a
-            particular level, collapsing into a DataFrame
-        bool_only : boolean, default None
-            Only include boolean data.
-
-        Returns
-        -------
-        any : Series (or DataFrame if level specified)
-        """
-        if axis is None:
-            axis = self._stat_axis_number
-        if level is not None:
-            return self._agg_by_level('any', axis=axis, level=level,
-                                      skipna=skipna)
-        return self._reduce(nanops.nanany, 'any', axis=axis, skipna=skipna,
-                            numeric_only=bool_only, filter_type='bool')
-
-    def all(self, axis=None, bool_only=None, skipna=True, level=None,
-            **kwargs):
-        """
-        Return whether all elements are True over requested axis.
-        %(na_action)s
-
-        Parameters
-        ----------
-        axis : {0, 1}
-            0 for row-wise, 1 for column-wise
-        skipna : boolean, default True
-            Exclude NA/null values. If an entire row/column is NA, the result
-            will be NA
-        level : int or level name, default None
-            If the axis is a MultiIndex (hierarchical), count along a
-            particular level, collapsing into a DataFrame
-        bool_only : boolean, default None
-            Only include boolean data.
-
-        Returns
-        -------
-        any : Series (or DataFrame if level specified)
-        """
-        if axis is None:
-            axis = self._stat_axis_number
-        if level is not None:
-            return self._agg_by_level('all', axis=axis, level=level,
-                                      skipna=skipna)
-        return self._reduce(nanops.nanall, 'all', axis=axis, skipna=skipna,
-                            numeric_only=bool_only, filter_type='bool')
-
     def _reduce(self, op, name, axis=0, skipna=True, numeric_only=None,
                 filter_type=None, **kwds):
         axis = self._get_axis_number(axis)

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -75,6 +75,15 @@ class Base(object):
                               "cannot perform __floordiv__",
                               lambda : 1 // idx)
 
+    def test_logical_compat(self):
+        idx = self.create_index()
+        tm.assertRaisesRegexp(TypeError,
+                              'cannot perform all',
+                              lambda : idx.all())
+        tm.assertRaisesRegexp(TypeError,
+                              'cannot perform any',
+                              lambda : idx.any())
+
     def test_boolean_context_compat(self):
 
         # boolean context compat
@@ -820,6 +829,11 @@ class TestIndex(Base, tm.TestCase):
         expected = self.dateIndex[indexer]
         self.assertTrue(result.equals(expected))
 
+    def test_logical_compat(self):
+        idx = self.create_index()
+        self.assertEqual(idx.all(), idx.values.all())
+        self.assertEqual(idx.any(), idx.values.any())
+
     def _check_method_works(self, method):
         method(self.empty)
         method(self.dateIndex)
@@ -1466,6 +1480,11 @@ class TestInt64Index(Numeric, tm.TestCase):
         same_values = Index(self.index, dtype=object)
         self.assertTrue(self.index.equals(same_values))
         self.assertTrue(same_values.equals(self.index))
+
+    def test_logical_compat(self):
+        idx = self.create_index()
+        self.assertEqual(idx.all(), idx.values.all())
+        self.assertEqual(idx.any(), idx.values.any())
 
     def test_identical(self):
         i = Index(self.index.copy())

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from pandas import Series, DataFrame, Index, isnull, notnull, pivot, MultiIndex
 from pandas.core.datetools import bday
+from pandas.core.nanops import nanall, nanany
 from pandas.core.panel import Panel
 from pandas.core.series import remove_na
 import pandas.core.common as com
@@ -2101,6 +2102,24 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
 
         np.testing.assert_raises(Exception, pan.update, *(pan,),
                                  **{'raise_conflict': True})
+
+    def test_all_any(self):
+        self.assertTrue((self.panel.all(axis=0).values ==
+                         nanall(self.panel, axis=0)).all())
+        self.assertTrue((self.panel.all(axis=1).values ==
+                         nanall(self.panel, axis=1).T).all())
+        self.assertTrue((self.panel.all(axis=2).values ==
+                         nanall(self.panel, axis=2).T).all())
+        self.assertTrue((self.panel.any(axis=0).values ==
+                         nanany(self.panel, axis=0)).all())
+        self.assertTrue((self.panel.any(axis=1).values ==
+                         nanany(self.panel, axis=1).T).all())
+        self.assertTrue((self.panel.any(axis=2).values ==
+                         nanany(self.panel, axis=2).T).all())
+
+    def test_all_any_unhandled(self):
+        self.assertRaises(NotImplementedError, self.panel.all, bool_only=True)
+        self.assertRaises(NotImplementedError, self.panel.any, bool_only=True)
 
 
 class TestLongPanel(tm.TestCase):

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -2474,6 +2474,33 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         self.assertFalse(bool_series.all())
         self.assertTrue(bool_series.any())
 
+        # Alternative types, with implicit 'object' dtype.
+        s = Series(['abc', True])
+        self.assertEquals('abc', s.any())  # 'abc' || True => 'abc'
+
+    def test_all_any_params(self):
+        # Check skipna, with implicit 'object' dtype.
+        s1 = Series([np.nan, True])
+        s2 = Series([np.nan, False])
+        self.assertTrue(s1.all(skipna=False))  # nan && True => True
+        self.assertTrue(s1.all(skipna=True))
+        self.assertTrue(np.isnan(s2.any(skipna=False)))  # nan || False => nan
+        self.assertFalse(s2.any(skipna=True))
+
+        # Check level.
+        s = pd.Series([False, False, True, True, False, True],
+                      index=[0, 0, 1, 1, 2, 2])
+        assert_series_equal(s.all(level=0), Series([False, True, False]))
+        assert_series_equal(s.any(level=0), Series([False, True, True]))
+
+        # bool_only is not implemented with level option.
+        self.assertRaises(NotImplementedError, s.any, bool_only=True, level=0)
+        self.assertRaises(NotImplementedError, s.all, bool_only=True, level=0)
+
+        # bool_only is not implemented alone.
+        self.assertRaises(NotImplementedError, s.any, bool_only=True)
+        self.assertRaises(NotImplementedError, s.all, bool_only=True)
+
     def test_op_method(self):
         def check(series, other, check_reverse=False):
             simple_ops = ['add', 'sub', 'mul', 'floordiv', 'truediv', 'pow']

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1665,8 +1665,12 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
                              self.microsecond/3600.0/1e+6 +
                              self.nanosecond/3600.0/1e+9
                             )/24.0)
+
+
 DatetimeIndex._add_numeric_methods_disabled()
+DatetimeIndex._add_logical_methods_disabled()
 DatetimeIndex._add_datetimelike_methods()
+
 
 def _generate_regular_range(start, end, periods, offset):
     if isinstance(offset, Tick):

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -1262,8 +1262,11 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
         """
         raise NotImplementedError("Not yet implemented for PeriodIndex")
 
+
 PeriodIndex._add_numeric_methods_disabled()
+PeriodIndex._add_logical_methods_disabled()
 PeriodIndex._add_datetimelike_methods()
+
 
 def _get_ordinal_range(start, end, periods, freq):
     if com._count_not_none(start, end, periods) < 2:

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -890,8 +890,11 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, Int64Index):
 
         return TimedeltaIndex(new_tds, name=self.name, freq=freq)
 
+
 TimedeltaIndex._add_numeric_methods()
+TimedeltaIndex._add_logical_methods_disabled()
 TimedeltaIndex._add_datetimelike_methods()
+
 
 def _is_convertible_to_index(other):
     """ return a boolean whether I can attempt conversion to a TimedeltaIndex """


### PR DESCRIPTION
closes #8302
- Move any/all implementations from DataFrame to NDFrame, adding support for Series
- Special case single dimension case in NDFrame, to handle numpy.any/all specific arguments
- Add assorted NotImplementedErrors in cases where arguments are ignored (including in preexisting _reduce functions)
- Move the other any/all implementations from IndexOpsMixin to Index, outside of Series’ inheritance tree
