### PR TITLE
PERF: fixup datetime_index repr perf (GH8556)

### DIFF
--- a/vb_suite/index_object.py
+++ b/vb_suite/index_object.py
@@ -108,7 +108,7 @@ index_float64_div = Benchmark('idx / 2', setup, name='index_float64_div',
 
 
 # Constructing MultiIndex from cartesian product of iterables
-# 
+#
 
 setup = common_setup + """
 iterables = [tm.makeStringIndex(10000), xrange(20)]
@@ -130,3 +130,14 @@ multiindex_with_datetime_level = \
     Benchmark("MultiIndex.from_product([level1, level2]).values", setup,
               name='multiindex_with_datetime_level',
               start_date=datetime(2014, 10, 11))
+
+#----------------------------------------------------------------------
+# repr
+
+setup = common_setup + """
+dr = pd.date_range('20000101', freq='D', periods=100000)
+"""
+
+datetime_index_repr = \
+    Benchmark("dr._is_dates_only", setup,
+              start_date=datetime(2012, 1, 11))


### PR DESCRIPTION
closes #8556 

low hanging fruit (and now is pretty scale independent).

```
In [1]: dr = pd.date_range('20000101', freq='D', periods=100000)

In [2]: %timeit dr._is_dates_only
10000000 loops, best of 3: 87.6 ns per loop

In [3]: pd.__version__
Out[3]: '0.15.0rc1-38-g857042f'
```

I do recall this slipping in sometime maybe in 0.14.0 was the changing in how the default display would be handled for dates with and w/o times.
