### PR TITLE
API: Unify SQLTable code for fallback and SQLAlchemy mode and move differences into database class

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1033,8 +1033,8 @@ class SQLDatabase(SQLBackend):
         column_names_and_types = \
             _get_column_names_and_types(frame, self._sqlalchemy_type, index)
 
-        columns = [Column(name, typ, index=is_index)
-                   for name, typ, is_index in column_names_and_types]
+        columns = [Column(colname, typ, index=is_index)
+                   for colname, typ, is_index in column_names_and_types]
 
         if keys is not None:
             pkc = PrimaryKeyConstraint(keys, name=self.name + '_pk')
@@ -1059,7 +1059,7 @@ class SQLDatabase(SQLBackend):
 
     def create_table(self, backend_table):
         # Inserting table into database, add to MetaData object
-        table = backend_table.tometadata(self.meta)
+        backend_table = backend_table.tometadata(self.meta)
         backend_table.create()
 
         # check for potentially case sensitivity issues (GH7815)


### PR DESCRIPTION
In discussion of the SQL API in #7960 , it has been suggested that it may be possible to factor out differences in SQLAlchemy and fallback backend .  This is an initial attempt to do so.  Now `SQLTable` is uncoupled from the backend.  `PandasSQL` is base class for `SQLDatabase` (SQLAlchemy backend) and `SQLiteDatabase` (fallback backend).  This allows for the removal of some duplicate code.
