### PR TITLE
ENH: Add type conversion to read_stata and StataReader

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -3654,9 +3654,14 @@ missing values are represented as ``np.nan``.  If ``True``, missing values are
 represented using ``StataMissingValue`` objects, and columns containing missing
 values will have ``dtype`` set to ``object``.
 
-
 The StataReader supports .dta Formats 104, 105, 108, 113-115 and 117.
 Alternatively, the function :func:`~pandas.io.stata.read_stata` can be used
+
+.. note::
+
+   Setting ``preserve_dtypes=False`` will upcast all integer data types to
+   ``int64`` and all floating point data types to ``float64``.  By default,
+   the Stata data types are preserved when importing.
 
 .. ipython:: python
    :suppress:

--- a/doc/source/v0.15.0.txt
+++ b/doc/source/v0.15.0.txt
@@ -864,6 +864,7 @@ Enhancements
 - Added support for writing datetime64 columns with ``to_sql`` for all database flavors (:issue:`7103`).
 
 - Added support for bool, uint8, uint16 and uint32 datatypes in ``to_stata`` (:issue:`7097`, :issue:`7365`)
+- Added conversion option when importing Stata files (:issue:`8527`)
 
 - Added ``layout`` keyword to ``DataFrame.plot``. You can pass a tuple of ``(rows, columns)``, one of which can be ``-1`` to automatically infer (:issue:`6667`, :issue:`8071`).
 - Allow to pass multiple axes to ``DataFrame.plot``, ``hist`` and ``boxplot`` (:issue:`5353`, :issue:`6970`, :issue:`7069`)

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -83,6 +83,7 @@ class TestStata(tm.TestCase):
 
 
     def read_dta(self, file):
+        # Legacy default reader configuration
         return read_stata(file, convert_dates=True)
 
     def read_csv(self, file):
@@ -693,6 +694,35 @@ class TestStata(tm.TestCase):
             written_and_read_again = self.read_dta(path)
             tm.assert_frame_equal(written_and_read_again.set_index('index'),
                                   expected)
+
+    def test_dtype_conversion(self):
+        expected = self.read_csv(self.csv15)
+        expected['byte_'] = expected['byte_'].astype(np.int8)
+        expected['int_'] = expected['int_'].astype(np.int16)
+        expected['long_'] = expected['long_'].astype(np.int32)
+        expected['float_'] = expected['float_'].astype(np.float32)
+        expected['double_'] = expected['double_'].astype(np.float64)
+        expected['date_td'] = expected['date_td'].apply(datetime.strptime,
+                                                        args=('%Y-%m-%d',))
+
+        no_conversion = read_stata(self.dta15_117,
+                                   convert_dates=True)
+        tm.assert_frame_equal(expected, no_conversion)
+
+        conversion = read_stata(self.dta15_117,
+                                convert_dates=True,
+                                preserve_dtypes=False)
+
+        # read_csv types are the same
+        expected = self.read_csv(self.csv15)
+        expected['date_td'] = expected['date_td'].apply(datetime.strptime,
+                                                        args=('%Y-%m-%d',))
+
+        tm.assert_frame_equal(expected, conversion)
+
+
+
+
 
 
 


### PR DESCRIPTION
Added upcasting of numeric types which will default numeric data to either
int64 or float64.  This option has been enabled by default.

closes #8527
