### PR TITLE
Switch default colormap for scatterplot to 'Greys'

### DIFF
--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1605,8 +1605,8 @@ class TestDataFramePlots(TestPlotBase):
         axes = [df.plot(kind='scatter', x='x', y='y', c='z'),
                 df.plot(kind='scatter', x=0, y=1, c=2)]
         for ax in axes:
-            # default to RdBu
-            self.assertEqual(ax.collections[0].cmap.name, 'RdBu')
+            # default to Greys
+            self.assertEqual(ax.collections[0].cmap.name, 'Greys')
 
             if self.mpl_ge_1_3_1:
 

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1405,7 +1405,7 @@ class ScatterPlot(MPLPlot):
         cb = self.kwds.pop('colorbar', self.colormap or c in self.data.columns)
 
         # pandas uses colormap, matplotlib uses cmap.
-        cmap = self.colormap or 'RdBu'
+        cmap = self.colormap or 'Greys'
         cmap = plt.cm.get_cmap(cmap)
 
         if c is None:


### PR DESCRIPTION
In #7780, I added colormap support to scatter, but choose to override the
default rainbow colormap (https://github.com/pydata/pandas/pull/7780#issuecomment-49533995).

I'm now regreting choosing 'RdBu' as the default colormap. I think a simple
black-white colormap is a more conservative and better default choice for
coloring scatter plots -- binary colormaps really only make sense if the data
is signed. 'Greys' is also the default colormap set by the seaborn package,
and @mwaskom has done far more thinking about colormaps than I have.

If possible, I would love to get this in before 0.15 is released, so we don't
have to worry about changing how anyone's plots look.

CC @sinhrks
