### PR TITLE
DOC/REL: clean-up and restructure v0.15.0 whatsnew file (GH8477)

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -190,6 +190,8 @@ Standard moving window functions
    rolling_quantile
    rolling_window
 
+.. _api.functions_expanding:
+
 Standard expanding window functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/whatsnew/v0.10.0.txt
+++ b/doc/source/whatsnew/v0.10.0.txt
@@ -48,6 +48,7 @@ want to broadcast, we are phasing out this special case (Zen of Python:
 talking about:
 
 .. ipython:: python
+   :okwarning:
 
    import pandas as pd
    df = pd.DataFrame(np.random.randn(6, 4),

--- a/doc/source/whatsnew/v0.15.0.txt
+++ b/doc/source/whatsnew/v0.15.0.txt
@@ -17,26 +17,22 @@ users upgrade to this version.
 
   - The ``Categorical`` type was integrated as a first-class pandas type, see :ref:`here <whatsnew_0150.cat>`
   - New scalar type ``Timedelta``, and a new index type ``TimedeltaIndex``, see :ref:`here <whatsnew_0150.timedeltaindex>`
-  - New DataFrame default display for ``df.info()`` to include memory usage, see :ref:`Memory Usage <whatsnew_0150.memory>`
   - New datetimelike properties accessor ``.dt`` for Series, see :ref:`Datetimelike Properties <whatsnew_0150.dt>`
-  - Split indexing documentation into :ref:`Indexing and Selecting Data <indexing>` and :ref:`MultiIndex / Advanced Indexing <advanced>`
-  - Split out string methods documentation into :ref:`Working with Text Data <text>`
+  - New DataFrame default display for ``df.info()`` to include memory usage, see :ref:`Memory Usage <whatsnew_0150.memory>`
   - ``read_csv`` will now by default ignore blank lines when parsing, see :ref:`here <whatsnew_0150.blanklines>`
   - API change in using Indexes in set operations, see :ref:`here <whatsnew_0150.index_set_ops>`
+  - Enhancements in the handling of timezones, see :ref:`here <whatsnew_0150.tz>`
+  - A lot of improvements to the rolling and expanding moment funtions, see :ref:`here <whatsnew_0150.roll>`
   - Internal refactoring of the ``Index`` class to no longer sub-class ``ndarray``, see :ref:`Internal Refactoring <whatsnew_0150.refactoring>`
   - dropping support for ``PyTables`` less than version 3.0.0, and ``numexpr`` less than version 2.1 (:issue:`7990`)
+  - Split indexing documentation into :ref:`Indexing and Selecting Data <indexing>` and :ref:`MultiIndex / Advanced Indexing <advanced>`
+  - Split out string methods documentation into :ref:`Working with Text Data <text>`
 
+- Check the :ref:`API Changes <whatsnew_0150.api>` and :ref:`deprecations <whatsnew_0150.deprecations>` before updating
+  
 - :ref:`Other Enhancements <whatsnew_0150.enhancements>`
 
-- :ref:`API Changes <whatsnew_0150.api>`
-
-- :ref:`Timezone API Change <whatsnew_0150.tz>`
-
-- :ref:`Rolling/Expanding Moments API Changes <whatsnew_0150.roll>`
-
 - :ref:`Performance Improvements <whatsnew_0150.performance>`
-
-- :ref:`Deprecations <whatsnew_0150.deprecations>`
 
 - :ref:`Bug Fixes <whatsnew_0150.bug_fixes>`
 
@@ -49,285 +45,169 @@ users upgrade to this version.
 .. warning::
 
    The refactorings in :class:`~pandas.Categorical` changed the two argument constructor from
-   "codes/labels and levels" to "values and levels". This can lead to subtle bugs. If you use
+   "codes/labels and levels" to "values and levels (now called 'categories')". This can lead to subtle bugs. If you use
    :class:`~pandas.Categorical` directly, please audit your code before updating to this pandas
    version and change it to use the :meth:`~pandas.Categorical.from_codes` constructor. See more on ``Categorical`` :ref:`here <whatsnew_0150.cat>`
 
-.. _whatsnew_0150.api:
 
-API changes
-~~~~~~~~~~~
-- :func:`describe` on mixed-types DataFrames is more flexible. Type-based column filtering is now possible via the ``include``/``exclude`` arguments.
-  See the :ref:`docs <basics.describe>` (:issue:`8164`).
+New features
+~~~~~~~~~~~~
 
-  .. ipython:: python
+.. _whatsnew_0150.cat:
 
-    df = DataFrame({'catA': ['foo', 'foo', 'bar'] * 8,
-                    'catB': ['a', 'b', 'c', 'd'] * 6,
-                    'numC': np.arange(24),
-                    'numD': np.arange(24.) + .5})
-    df.describe(include=["object"])
-    df.describe(include=["number", "object"], exclude=["float"])
+Categoricals in Series/DataFrame
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Requesting all columns is possible with the shorthand 'all'
+:class:`~pandas.Categorical` can now be included in `Series` and `DataFrames` and gained new
+methods to manipulate. Thanks to Jan Schulz for much of this API/implementation. (:issue:`3943`, :issue:`5313`, :issue:`5314`,
+:issue:`7444`, :issue:`7839`, :issue:`7848`, :issue:`7864`, :issue:`7914`, :issue:`7768`, :issue:`8006`, :issue:`3678`,
+:issue:`8075`, :issue:`8076`, :issue:`8143`, :issue:`8453`, :issue:`8518`).
 
-  .. ipython:: python
+For full docs, see the :ref:`categorical introduction <categorical>` and the
+:ref:`API documentation <api.categorical>`.
 
-    df.describe(include='all')
+.. ipython:: python
 
-  Without those arguments, 'describe` will behave as before, including only numerical columns or, if none are, only categorical columns. See also the :ref:`docs <basics.describe>`
+    df = DataFrame({"id":[1,2,3,4,5,6], "raw_grade":['a', 'b', 'b', 'a', 'a', 'e']})
 
-- Passing multiple levels to :meth:`~pandas.DataFrame.stack()` will now work when multiple level
-  numbers are passed (:issue:`7660`), and will raise a ``ValueError`` when the
-  levels aren't all level names or all level numbers. See
-  :ref:`Reshaping by stacking and unstacking <reshaping.stack_multiple>`.
+    df["grade"] = df["raw_grade"].astype("category")
+    df["grade"]
 
-- :func:`set_names`, :func:`set_labels`, and :func:`set_levels` methods now take an optional ``level`` keyword argument to all modification of specific level(s) of a MultiIndex. Additionally :func:`set_names` now accepts a scalar string value when operating on an ``Index`` or on a specific level of a ``MultiIndex`` (:issue:`7792`)
+    # Rename the categories
+    df["grade"].cat.categories = ["very good", "good", "very bad"]
 
-  .. ipython:: python
+    # Reorder the categories and simultaneously add the missing categories
+    df["grade"] = df["grade"].cat.set_categories(["very bad", "bad", "medium", "good", "very good"])
+    df["grade"]
+    df.sort("grade")
+    df.groupby("grade").size()
 
-      idx = MultiIndex.from_product([['a'], range(3), list("pqr")], names=['foo', 'bar', 'baz'])
-      idx.set_names('qux', level=0)
-      idx.set_names(['qux','baz'], level=[0,1])
-      idx.set_levels(['a','b','c'], level='bar')
-      idx.set_levels([['a','b','c'],[1,2,3]], level=[1,2])
+- ``pandas.core.group_agg`` and ``pandas.core.factor_agg`` were removed. As an alternative, construct
+  a dataframe and use ``df.groupby(<group>).agg(<func>)``.
 
-- Raise a ``ValueError`` in ``df.to_hdf`` with 'fixed' format, if ``df`` has non-unique columns as the resulting file will be broken (:issue:`7761`)
+- Supplying "codes/labels and levels" to the :class:`~pandas.Categorical` constructor is not
+  supported anymore. Supplying two arguments to the constructor is now interpreted as
+  "values and levels (now called 'categories')". Please change your code to use the :meth:`~pandas.Categorical.from_codes`
+  constructor.
 
-.. _whatsnew_0150.blanklines:
+- The ``Categorical.labels`` attribute was renamed to ``Categorical.codes`` and is read
+  only. If you want to manipulate codes, please use one of the
+  :ref:`API methods on Categoricals <api.categorical>`.
 
-- Made both the C-based and Python engines for `read_csv` and `read_table` ignore empty lines in input as well as
-  whitespace-filled lines, as long as ``sep`` is not whitespace. This is an API change
-  that can be controlled by the keyword parameter ``skip_blank_lines``.  See :ref:`the docs <io.skiplines>` (:issue:`4466`)
+- The ``Categorical.levels`` attribute is renamed to ``Categorical.categories``.
 
-- Bug in passing a ``DatetimeIndex`` with a timezone that was not being retained in DataFrame construction from a dict (:issue:`7822`)
 
-  In prior versions this would drop the timezone.
+.. _whatsnew_0150.timedeltaindex:
 
-  .. ipython:: python
+TimedeltaIndex/Scalar
+^^^^^^^^^^^^^^^^^^^^^
 
-        i = date_range('1/1/2011', periods=3, freq='10s', tz = 'US/Eastern')
-        i
-        df = DataFrame( {'a' : i } )
-        df
-        df.dtypes
+We introduce a new scalar type ``Timedelta``, which is a subclass of ``datetime.timedelta``, and behaves in a similar manner,
+but allows compatibility with ``np.timedelta64`` types as well as a host of custom representation, parsing, and attributes.
+This type is very similar to how ``Timestamp`` works for ``datetimes``. It is a nice-API box for the type. See the :ref:`docs <timedeltas.timedeltas>`.
+(:issue:`3009`, :issue:`4533`, :issue:`8209`, :issue:`8187`, :issue:`8190`, :issue:`7869`, :issue:`7661`, :issue:`8345`, :issue:`8471`)
 
-  This behavior is unchanged.
+.. warning::
 
-  .. ipython:: python
+   ``Timedelta`` scalars (and ``TimedeltaIndex``) component fields are *not the same* as the component fields on a ``datetime.timedelta`` object. For example, ``.seconds`` on a ``datetime.timedelta`` object returns the total number of seconds combined between ``hours``, ``minutes`` and ``seconds``. In contrast, the pandas ``Timedelta`` breaks out hours, minutes, microseconds and nanoseconds separately.
 
-        df = DataFrame( )
-        df['a'] = i
-        df
-        df.dtypes
+   .. ipython:: python
 
-- ``SettingWithCopy`` raise/warnings (according to the option ``mode.chained_assignment``) will now be issued when setting a value on a sliced mixed-dtype DataFrame using chained-assignment. (:issue:`7845`, :issue:`7950`)
+      # Timedelta accessor
+      tds = Timedelta('31 days 5 min 3 sec')
+      tds.minutes
+      tds.seconds
 
-  .. code-block:: python
+      # datetime.timedelta accessor
+      # this is 5 minutes * 60 + 3 seconds
+      tds.to_pytimedelta().seconds
 
-     In [1]: df = DataFrame(np.arange(0,9), columns=['count'])
+.. warning::
 
-     In [2]: df['group'] = 'b'
+       Prior to 0.15.0 ``pd.to_timedelta`` would return a ``Series`` for list-like/Series input, and a ``np.timedelta64`` for scalar input.
+       It will now return a ``TimedeltaIndex`` for list-like input, ``Series`` for Series input, and ``Timedelta`` for scalar input.
 
-     In [3]: df.iloc[0:5]['group'] = 'a'
-     /usr/local/bin/ipython:1: SettingWithCopyWarning:
-     A value is trying to be set on a copy of a slice from a DataFrame.
-     Try using .loc[row_indexer,col_indexer] = value instead
+       The arguments to ``pd.to_timedelta`` are now ``(arg,unit='ns',box=True,coerce=False)``, previously were ``(arg,box=True,unit='ns')`` as these are more logical.
 
-     See the the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy
+Consruct a scalar
 
-- The ``infer_types`` argument to :func:`~pandas.io.html.read_html` now has no
-  effect (:issue:`7762`, :issue:`7032`).
+.. ipython:: python
 
-- ``DataFrame.to_stata`` and ``StataWriter`` check string length for
-  compatibility with limitations imposed in dta files where fixed-width
-  strings must contain 244 or fewer characters.  Attempting to write Stata
-  dta files with strings longer than 244 characters raises a ``ValueError``. (:issue:`7858`)
+   Timedelta('1 days 06:05:01.00003')
+   Timedelta('15.5us')
+   Timedelta('1 hour 15.5us')
 
-- ``read_stata`` and ``StataReader`` can import missing data information into a
-  ``DataFrame`` by setting the argument ``convert_missing`` to ``True``. When
-  using this options, missing values are returned as ``StataMissingValue``
-  objects and columns containing missing values have ``object`` data type. (:issue:`8045`)
+   # negative Timedeltas have this string repr
+   # to be more consistent with datetime.timedelta conventions
+   Timedelta('-1us')
 
-- ``Index.isin`` now supports a ``level`` argument to specify which index level
-  to use for membership tests (:issue:`7892`, :issue:`7890`)
+   # a NaT
+   Timedelta('nan')
 
-  .. code-block:: python
+Access fields for a ``Timedelta``
 
-     In [1]: idx = MultiIndex.from_product([[0, 1], ['a', 'b', 'c']])
+.. ipython:: python
 
-     In [2]: idx.values
-     Out[2]: array([(0, 'a'), (0, 'b'), (0, 'c'), (1, 'a'), (1, 'b'), (1, 'c')], dtype=object)
+   td = Timedelta('1 hour 3m 15.5us')
+   td.hours
+   td.minutes
+   td.microseconds
+   td.nanoseconds
 
-     In [3]: idx.isin(['a', 'c', 'e'], level=1)
-     Out[3]: array([ True, False,  True,  True, False,  True], dtype=bool)
+Construct a ``TimedeltaIndex``
 
-- ``merge``, ``DataFrame.merge``, and ``ordered_merge`` now return the same type
-  as the ``left`` argument.  (:issue:`7737`)
+.. ipython:: python
+   :suppress:
 
-- Histogram from ``DataFrame.plot`` with ``kind='hist'`` (:issue:`7809`), See :ref:`the docs<visualization.hist>`.
-- Boxplot from ``DataFrame.plot`` with ``kind='box'`` (:issue:`7998`), See :ref:`the docs<visualization.box>`.
-- Consistency when indexing with ``.loc`` and a list-like indexer when no values are found.
+   import datetime
+   from datetime import timedelta
 
-  .. ipython:: python
+.. ipython:: python
 
-     df = DataFrame([['a'],['b']],index=[1,2])
-     df
+   TimedeltaIndex(['1 days','1 days, 00:00:05',
+                   np.timedelta64(2,'D'),timedelta(days=2,seconds=2)])
 
-  In prior versions there was a difference in these two constructs:
+Constructing a ``TimedeltaIndex`` with a regular range
 
-  - ``df.loc[[3]]`` would return a frame reindexed by 3 (with all ``np.nan`` values)
-  - ``df.loc[[3],:]`` would raise ``KeyError``.
+.. ipython:: python
 
-  Both will now raise a ``KeyError``. The rule is that *at least 1* indexer must be found when using a list-like and ``.loc`` (:issue:`7999`)
+   timedelta_range('1 days',periods=5,freq='D')
+   timedelta_range(start='1 days',end='2 days',freq='30T')
 
-  Furthermore in prior versions these were also different:
+You can now use a ``TimedeltaIndex`` as the index of a pandas object
 
-  - ``df.loc[[1,3]]`` would return a frame reindexed by [1,3]
-  - ``df.loc[[1,3],:]`` would raise ``KeyError``.
+.. ipython:: python
 
-  Both will now return a frame reindex by [1,3]. E.g.
+   s = Series(np.arange(5),
+              index=timedelta_range('1 days',periods=5,freq='s'))
+   s
 
-  .. ipython:: python
+You can select with partial string selections
 
-     df.loc[[1,3]]
-     df.loc[[1,3],:]
+.. ipython:: python
 
-  This can also be seen in multi-axis indexing with a ``Panel``.
+   s['1 day 00:00:02']
+   s['1 day':'1 day 00:00:02']
 
-  .. ipython:: python
+Finally, the combination of ``TimedeltaIndex`` with ``DatetimeIndex`` allow certain combination operations that are ``NaT`` preserving:
 
-     p = Panel(np.arange(2*3*4).reshape(2,3,4),
-               items=['ItemA','ItemB'],
-               major_axis=[1,2,3],
-               minor_axis=['A','B','C','D'])
-     p
+.. ipython:: python
 
-  The following would raise ``KeyError`` prior to 0.15.0:
+   tdi = TimedeltaIndex(['1 days',pd.NaT,'2 days'])
+   tdi.tolist()
+   dti = date_range('20130101',periods=3)
+   dti.tolist()
 
-  .. ipython:: python
+   (dti + tdi).tolist()
+   (dti - tdi).tolist()
 
-     p.loc[['ItemA','ItemD'],:,'D']
+- iteration of a ``Series`` e.g. ``list(Series(...))`` of ``timedelta64[ns]`` would prior to v0.15.0 return ``np.timedelta64`` for each element. These will now be wrapped in ``Timedelta``.
 
-  Furthermore, ``.loc`` will raise If no values are found in a multi-index with a list-like indexer:
-
-  .. ipython:: python
-     :okexcept:
-
-     s = Series(np.arange(3,dtype='int64'),
-                index=MultiIndex.from_product([['A'],['foo','bar','baz']],
-                                              names=['one','two'])
-               ).sortlevel()
-     s
-     try:
-        s.loc[['D']]
-     except KeyError as e:
-        print("KeyError: " + str(e))
-
-- ``Index`` now supports ``duplicated`` and ``drop_duplicates``. (:issue:`4060`)
-
-  .. ipython:: python
-
-     idx = Index([1, 2, 3, 4, 1, 2])
-     idx
-     idx.duplicated()
-     idx.drop_duplicates()
-
-- Assigning values to ``None`` now considers the dtype when choosing an 'empty' value (:issue:`7941`).
-
-  Previously, assigning to ``None`` in numeric containers changed the
-  dtype to object (or errored, depending on the call). It now uses
-  ``NaN``:
-
-  .. ipython:: python
-
-     s = Series([1, 2, 3])
-     s.loc[0] = None
-     s
-
-  ``NaT`` is now used similarly for datetime containers.
-
-  For object containers, we now preserve ``None`` values (previously these
-  were converted to ``NaN`` values).
-
-  .. ipython:: python
-
-     s = Series(["a", "b", "c"])
-     s.loc[0] = None
-     s
-
-  To insert a ``NaN``, you must explicitly use ``np.nan``. See the :ref:`docs <missing.inserting>`.
-
-- Previously an enlargement with a mixed-dtype frame would act unlike ``.append`` which will preserve dtypes (related :issue:`2578`, :issue:`8176`):
-
-  .. ipython:: python
-
-     df = DataFrame([[True, 1],[False, 2]],
-                    columns=["female","fitness"])
-     df
-     df.dtypes
-
-     # dtypes are now preserved
-     df.loc[2] = df.loc[1]
-     df
-     df.dtypes
-
-- In prior versions, updating a pandas object inplace would not reflect in other python references to this object. (:issue:`8511`,:issue:`5104`)
-
-  .. ipython:: python
-
-     s = Series([1, 2, 3])
-     s2 = s
-     s += 1.5
-
-  Behavior prior to v0.15.0
-
-  .. code-block:: python
-
-
-     # the original object
-     In [5]: s
-     Out[5]:
-     0    2.5
-     1    3.5
-     2    4.5
-     dtype: float64
-
-
-     # a reference to the original object
-     In [7]: s2
-     Out[7]:
-     0    1
-     1    2
-     2    3
-     dtype: int64
-
-  This is now the correct behavior
-
-  .. ipython:: python
-
-     # the original object
-     s
-
-     # a reference to the original object
-     s2
-
-- ``Series.to_csv()`` now returns a string when ``path=None``, matching the behaviour of ``DataFrame.to_csv()`` (:issue:`8215`).
-
-- ``read_hdf`` now raises ``IOError`` when a file that doesn't exist is passed in. Previously, a new, empty file was created, and a ``KeyError`` raised (:issue:`7715`).
-
-- ``DataFrame.info()`` now ends its output with a newline character (:issue:`8114`)
-- add ``copy=True`` argument to ``pd.concat`` to enable pass thru of complete blocks (:issue:`8252`)
-
-- Added support for numpy 1.8+ data types (``bool_``, ``int_``, ``float_``, ``string_``) for conversion to R dataframe  (:issue:`8400`)
-- Concatenating no objects will now raise a ``ValueError`` rather than a bare ``Exception``.
-- Merge errors will now be sub-classes of ``ValueError`` rather than raw ``Exception`` (:issue:`8501`)
-- ``DataFrame.plot`` and ``Series.plot`` keywords are now have consistent orders (:issue:`8037`)
 
 .. _whatsnew_0150.memory:
 
 Memory Usage
-~~~~~~~~~~~~~
+^^^^^^^^^^^^
 
 Implemented methods to find memory usage of a DataFrame. See the :ref:`FAQ <df-memory-usage>` for more. (:issue:`6852`).
 
@@ -351,10 +231,11 @@ Additionally :meth:`~pandas.DataFrame.memory_usage` is an available method for a
 
     df.memory_usage(index=True)
 
+
 .. _whatsnew_0150.dt:
 
 .dt accessor
-~~~~~~~~~~~~
+^^^^^^^^^^^^
 
 ``Series`` has gained an accessor to succinctly return datetime like properties for the *values* of the Series, if its a datetime/period like Series. (:issue:`7207`)
 This will return a Series, indexed like the existing Series. See the :ref:`docs <basics.dt_accessors>`
@@ -408,10 +289,11 @@ The ``.dt`` accessor works for period and timedelta dtypes.
    s.dt.seconds
    s.dt.components
 
+
 .. _whatsnew_0150.tz:
 
-Timezone API changes
-~~~~~~~~~~~~~~~~~~~~
+Timezone handling improvements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - ``tz_localize(None)`` for tz-aware ``Timestamp`` and ``DatetimeIndex`` now removes timezone holding local time,
   previously this resulted in ``Exception`` or ``TypeError`` (:issue:`7812`)
@@ -439,14 +321,15 @@ Timezone API changes
 
 - ``Timestamp.__repr__`` displays ``dateutil.tz.tzoffset`` info (:issue:`7907`)
 
+
 .. _whatsnew_0150.roll:
 
-Rolling/Expanding Moments API changes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Rolling/Expanding Moments improvements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - :func:`rolling_min`, :func:`rolling_max`, :func:`rolling_cov`, and :func:`rolling_corr`
   now return objects with all ``NaN`` when ``len(arg) < min_periods <= window`` rather
-  than raising. (This makes all rolling functions consistent in this behavior), (:issue:`7766`)
+  than raising. (This makes all rolling functions consistent in this behavior). (:issue:`7766`)
 
   Prior to 0.15.0
 
@@ -520,10 +403,7 @@ Rolling/Expanding Moments API changes
 
     rolling_window(s, window=3, win_type='triang', center=True)
 
-- Removed ``center`` argument from :func:`expanding_max`, :func:`expanding_min`, :func:`expanding_sum`,
-  :func:`expanding_mean`, :func:`expanding_median`, :func:`expanding_std`, :func:`expanding_var`,
-  :func:`expanding_skew`, :func:`expanding_kurt`, :func:`expanding_quantile`, :func:`expanding_count`,
-  :func:`expanding_cov`, :func:`expanding_corr`, :func:`expanding_corr_pairwise`, and :func:`expanding_apply`,
+- Removed ``center`` argument from all :func:`expanding_ <expanding_apply>` functions (see :ref:`list <api.functions_expanding>`), 
   as the results produced when ``center=True`` did not make much sense. (:issue:`7925`)
 
 - Added optional ``ddof`` argument to :func:`expanding_cov` and :func:`rolling_cov`.
@@ -643,178 +523,307 @@ Rolling/Expanding Moments API changes
 
   See :ref:`Exponentially weighted moment functions <stats.moments.exponentially_weighted>` for details. (:issue:`7912`)
 
+
+.. _whatsnew_0150.sql:
+
+Improvements in the sql io module
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Added support for a ``chunksize`` parameter to ``to_sql`` function. This allows DataFrame to be written in chunks and avoid packet-size overflow errors (:issue:`8062`).
+- Added support for a ``chunksize`` parameter to ``read_sql`` function. Specifying this argument will return an iterator through chunks of the query result (:issue:`2908`).
+- Added support for writing ``datetime.date`` and ``datetime.time`` object columns with ``to_sql`` (:issue:`6932`).
+- Added support for specifying a ``schema`` to read from/write to with ``read_sql_table`` and ``to_sql`` (:issue:`7441`, :issue:`7952`).
+  For example:
+
+  .. code-block:: python
+
+         df.to_sql('table', engine, schema='other_schema')
+         pd.read_sql_table('table', engine, schema='other_schema')
+
+- Added support for writing ``NaN`` values with ``to_sql`` (:issue:`2754`).
+- Added support for writing datetime64 columns with ``to_sql`` for all database flavors (:issue:`7103`).
+
+
+.. _whatsnew_0150.api:
+
+Backwards incompatible API changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. _whatsnew_0150.api_breaking:
+
+Breaking changes
+^^^^^^^^^^^^^^^^
+
+API changes related to ``Categorical`` (see :ref:`here <whatsnew_0150.cat>`
+for more details):
+
+- The ``Categorical`` constructor with two arguments changed from
+  "codes/labels and levels" to "values and levels (now called 'categories')".
+  This can lead to subtle bugs. If you use :class:`~pandas.Categorical` directly,
+  please audit your code by changing it to use the :meth:`~pandas.Categorical.from_codes`
+  constructor.
+
+  An old function call like (prior to 0.15.0):
+
+  .. code-block:: python
+
+    pd.Categorical([0,1,0,2,1], levels=['a', 'b', 'c'])
+
+  will have to adapted to the following to keep the same behaviour:
+
+  .. code-block:: python
+
+    In [2]: pd.Categorical.from_codes([0,1,0,2,1], categories=['a', 'b', 'c'])
+    Out[2]: 
+    [a, b, a, c, b]
+    Categories (3, object): [a, b, c]
+
+API changes related to the introduction of the ``Timedelta`` scalar (see
+:ref:`above <whatsnew_0150.timedeltaindex>` for more details):
+  
+- Prior to 0.15.0 :func:`to_timedelta` would return a ``Series`` for list-like/Series input,
+  and a ``np.timedelta64`` for scalar input. It will now return a ``TimedeltaIndex`` for
+  list-like input, ``Series`` for Series input, and ``Timedelta`` for scalar input.
+
+For API changes related to the rolling and expanding functions, see detailed overview :ref:`above <whatsnew_0150.roll>`.
+
+Other notable API changes:  
+
+- Consistency when indexing with ``.loc`` and a list-like indexer when no values are found.
+
+  .. ipython:: python
+
+     df = DataFrame([['a'],['b']],index=[1,2])
+     df
+
+  In prior versions there was a difference in these two constructs:
+
+  - ``df.loc[[3]]`` would return a frame reindexed by 3 (with all ``np.nan`` values)
+  - ``df.loc[[3],:]`` would raise ``KeyError``.
+
+  Both will now raise a ``KeyError``. The rule is that *at least 1* indexer must be found when using a list-like and ``.loc`` (:issue:`7999`)
+
+  Furthermore in prior versions these were also different:
+
+  - ``df.loc[[1,3]]`` would return a frame reindexed by [1,3]
+  - ``df.loc[[1,3],:]`` would raise ``KeyError``.
+
+  Both will now return a frame reindex by [1,3]. E.g.
+
+  .. ipython:: python
+
+     df.loc[[1,3]]
+     df.loc[[1,3],:]
+
+  This can also be seen in multi-axis indexing with a ``Panel``.
+
+  .. ipython:: python
+
+     p = Panel(np.arange(2*3*4).reshape(2,3,4),
+               items=['ItemA','ItemB'],
+               major_axis=[1,2,3],
+               minor_axis=['A','B','C','D'])
+     p
+
+  The following would raise ``KeyError`` prior to 0.15.0:
+
+  .. ipython:: python
+
+     p.loc[['ItemA','ItemD'],:,'D']
+
+  Furthermore, ``.loc`` will raise If no values are found in a multi-index with a list-like indexer:
+
+  .. ipython:: python
+     :okexcept:
+
+     s = Series(np.arange(3,dtype='int64'),
+                index=MultiIndex.from_product([['A'],['foo','bar','baz']],
+                                              names=['one','two'])
+               ).sortlevel()
+     s
+     try:
+        s.loc[['D']]
+     except KeyError as e:
+        print("KeyError: " + str(e))
+
+- Assigning values to ``None`` now considers the dtype when choosing an 'empty' value (:issue:`7941`).
+
+  Previously, assigning to ``None`` in numeric containers changed the
+  dtype to object (or errored, depending on the call). It now uses
+  ``NaN``:
+
+  .. ipython:: python
+
+     s = Series([1, 2, 3])
+     s.loc[0] = None
+     s
+
+  ``NaT`` is now used similarly for datetime containers.
+
+  For object containers, we now preserve ``None`` values (previously these
+  were converted to ``NaN`` values).
+
+  .. ipython:: python
+
+     s = Series(["a", "b", "c"])
+     s.loc[0] = None
+     s
+
+  To insert a ``NaN``, you must explicitly use ``np.nan``. See the :ref:`docs <missing.inserting>`.
+
+- In prior versions, updating a pandas object inplace would not reflect in other python references to this object. (:issue:`8511`, :issue:`5104`)
+
+  .. ipython:: python
+
+     s = Series([1, 2, 3])
+     s2 = s
+     s += 1.5
+
+  Behavior prior to v0.15.0
+
+  .. code-block:: python
+
+
+     # the original object
+     In [5]: s
+     Out[5]:
+     0    2.5
+     1    3.5
+     2    4.5
+     dtype: float64
+
+
+     # a reference to the original object
+     In [7]: s2
+     Out[7]:
+     0    1
+     1    2
+     2    3
+     dtype: int64
+
+  This is now the correct behavior
+
+  .. ipython:: python
+
+     # the original object
+     s
+
+     # a reference to the original object
+     s2
+
+.. _whatsnew_0150.blanklines:
+
+- Made both the C-based and Python engines for `read_csv` and `read_table` ignore empty lines in input as well as
+  whitespace-filled lines, as long as ``sep`` is not whitespace. This is an API change
+  that can be controlled by the keyword parameter ``skip_blank_lines``.  See :ref:`the docs <io.skiplines>` (:issue:`4466`)
+
+- A timeseries/index localized to UTC when inserted into a Series/DataFrame will preserve the UTC timezone
+  and inserted as ``object`` dtype rather than being converted to a naive ``datetime64[ns]`` (:issue:`8411`).
+
+- Bug in passing a ``DatetimeIndex`` with a timezone that was not being retained in DataFrame construction from a dict (:issue:`7822`)
+
+  In prior versions this would drop the timezone, now it retains the timezone,
+  but gives a column of ``object`` dtype:
+
+  .. ipython:: python
+
+        i = date_range('1/1/2011', periods=3, freq='10s', tz = 'US/Eastern')
+        i
+        df = DataFrame( {'a' : i } )
+        df
+        df.dtypes
+
+  Previously this would have yielded a column of ``datetime64`` dtype, but without timezone info.
+
+  The behaviour of assigning a column to an existing dataframe as `df['a'] = i`
+  remains unchanged (this already returned an  ``object`` column with a timezone).
+
+- When passing multiple levels to :meth:`~pandas.DataFrame.stack()`, it will now raise a ``ValueError`` when the
+  levels aren't all level names or all level numbers (:issue:`7660`). See
+  :ref:`Reshaping by stacking and unstacking <reshaping.stack_multiple>`.
+
+- Raise a ``ValueError`` in ``df.to_hdf`` with 'fixed' format, if ``df`` has non-unique columns as the resulting file will be broken (:issue:`7761`)
+
+- ``SettingWithCopy`` raise/warnings (according to the option ``mode.chained_assignment``) will now be issued when setting a value on a sliced mixed-dtype DataFrame using chained-assignment. (:issue:`7845`, :issue:`7950`)
+
+  .. code-block:: python
+
+     In [1]: df = DataFrame(np.arange(0,9), columns=['count'])
+
+     In [2]: df['group'] = 'b'
+
+     In [3]: df.iloc[0:5]['group'] = 'a'
+     /usr/local/bin/ipython:1: SettingWithCopyWarning:
+     A value is trying to be set on a copy of a slice from a DataFrame.
+     Try using .loc[row_indexer,col_indexer] = value instead
+
+     See the the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy
+
+- ``merge``, ``DataFrame.merge``, and ``ordered_merge`` now return the same type
+  as the ``left`` argument (:issue:`7737`).
+
+- Previously an enlargement with a mixed-dtype frame would act unlike ``.append`` which will preserve dtypes (related :issue:`2578`, :issue:`8176`):
+
+  .. ipython:: python
+
+     df = DataFrame([[True, 1],[False, 2]],
+                    columns=["female","fitness"])
+     df
+     df.dtypes
+
+     # dtypes are now preserved
+     df.loc[2] = df.loc[1]
+     df
+     df.dtypes
+
+- ``Series.to_csv()`` now returns a string when ``path=None``, matching the behaviour of ``DataFrame.to_csv()`` (:issue:`8215`).
+
+- ``read_hdf`` now raises ``IOError`` when a file that doesn't exist is passed in. Previously, a new, empty file was created, and a ``KeyError`` raised (:issue:`7715`).
+
+- ``DataFrame.info()`` now ends its output with a newline character (:issue:`8114`)
+- Concatenating no objects will now raise a ``ValueError`` rather than a bare ``Exception``.
+- Merge errors will now be sub-classes of ``ValueError`` rather than raw ``Exception`` (:issue:`8501`)
+- ``DataFrame.plot`` and ``Series.plot`` keywords are now have consistent orders (:issue:`8037`)
+
+
 .. _whatsnew_0150.refactoring:
 
 Internal Refactoring
-~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^
 
 In 0.15.0 ``Index`` has internally been refactored to no longer sub-class ``ndarray``
-but instead subclass ``PandasObject``, similarly to the rest of the pandas objects. This change allows very easy sub-classing and creation of new index types. This should be
-a transparent change with only very limited API implications (:issue:`5080`, :issue:`7439`, :issue:`7796`, :issue:`8024`, :issue:`8367`, :issue:`7997`, :issue:`8522`)
+but instead subclass ``PandasObject``, similarly to the rest of the pandas objects. This
+change allows very easy sub-classing and creation of new index types. This should be
+a transparent change with only very limited API implications (:issue:`5080`, :issue:`7439`, :issue:`7796`, :issue:`8024`, :issue:`8367`, :issue:`7997`, :issue:`8522`):
 
 - you may need to unpickle pandas version < 0.15.0 pickles using ``pd.read_pickle`` rather than ``pickle.load``. See :ref:`pickle docs <io.pickle>`
-- when plotting with a ``PeriodIndex``. The ``matplotlib`` internal axes will now be arrays of ``Period`` rather than a ``PeriodIndex``. (this is similar to how a ``DatetimeIndex`` passes arrays of ``datetimes`` now)
-- MultiIndexes will now raise similary to other pandas objects w.r.t. truth testing, See :ref:`here <gotchas.truth>` (:issue:`7897`).
+- when plotting with a ``PeriodIndex``, the matplotlib internal axes will now be arrays of ``Period`` rather than a ``PeriodIndex`` (this is similar to how a ``DatetimeIndex`` passes arrays of ``datetimes`` now)
+- MultiIndexes will now raise similary to other pandas objects w.r.t. truth testing, see :ref:`here <gotchas.truth>` (:issue:`7897`).
+- When plotting a DatetimeIndex directly with matplotlib's `plot` function,
+  the axis labels will no longer be formatted as dates but as integers (the
+  internal representation of a ``datetime64``). To keep the old behaviour you
+  should add the :meth:`~DatetimeIndex.to_pydatetime()` method:
 
-.. _whatsnew_0150.cat:
+  .. code-block:: python
 
-Categoricals in Series/DataFrame
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      import matplotlib.pyplot as plt
+      df = pd.DataFrame({'col': np.random.randint(1, 50, 60)},
+                        index=pd.date_range("2012-01-01", periods=60))
 
-:class:`~pandas.Categorical` can now be included in `Series` and `DataFrames` and gained new
-methods to manipulate. Thanks to Jan Schulz for much of this API/implementation. (:issue:`3943`, :issue:`5313`, :issue:`5314`,
-:issue:`7444`, :issue:`7839`, :issue:`7848`, :issue:`7864`, :issue:`7914`, :issue:`7768`, :issue:`8006`, :issue:`3678`,
-:issue:`8075`, :issue:`8076`, :issue:`8143`, :issue:`8453`, :issue:`8518`).
+      # this will now format the x axis labels as integers
+      plt.plot(df.index, df['col'])
 
-For full docs, see the :ref:`categorical introduction <categorical>` and the
-:ref:`API documentation <api.categorical>`.
+      # to keep the date formating, convert the index explicitely to python datetime values
+      plt.plot(df.index.to_pydatetime(), df['col'])
 
-.. ipython:: python
-
-    df = DataFrame({"id":[1,2,3,4,5,6], "raw_grade":['a', 'b', 'b', 'a', 'a', 'e']})
-
-    df["grade"] = df["raw_grade"].astype("category")
-    df["grade"]
-
-    # Rename the categories
-    df["grade"].cat.categories = ["very good", "good", "very bad"]
-
-    # Reorder the categories and simultaneously add the missing categories
-    df["grade"] = df["grade"].cat.set_categories(["very bad", "bad", "medium", "good", "very good"])
-    df["grade"]
-    df.sort("grade")
-    df.groupby("grade").size()
-
-- ``pandas.core.group_agg`` and ``pandas.core.factor_agg`` were removed. As an alternative, construct
-  a dataframe and use ``df.groupby(<group>).agg(<func>)``.
-
-- Supplying "codes/labels and levels" to the :class:`~pandas.Categorical` constructor is not
-  supported anymore. Supplying two arguments to the constructor is now interpreted as
-  "values and levels". Please change your code to use the :meth:`~pandas.Categorical.from_codes`
-  constructor.
-
-- The ``Categorical.labels`` attribute was renamed to ``Categorical.codes`` and is read
-  only. If you want to manipulate codes, please use one of the
-  :ref:`API methods on Categoricals <api.categorical>`.
-
-.. _whatsnew_0150.timedeltaindex:
-
-TimedeltaIndex/Scalar
-~~~~~~~~~~~~~~~~~~~~~
-
-We introduce a new scalar type ``Timedelta``, which is a subclass of ``datetime.timedelta``, and behaves in a similar manner,
-but allows compatibility with ``np.timedelta64`` types as well as a host of custom representation, parsing, and attributes.
-This type is very similar to how ``Timestamp`` works for ``datetimes``. It is a nice-API box for the type. See the :ref:`docs <timedeltas.timedeltas>`.
-(:issue:`3009`, :issue:`4533`, :issue:`8209`, :issue:`8187`, :issue:`8190`, :issue:`7869`, :issue:`7661`, :issue:`8345`, :issue:`8471`)
-
-.. warning::
-
-   ``Timedelta`` scalars (and ``TimedeltaIndex``) component fields are *not the same* as the component fields on a ``datetime.timedelta`` object. For example, ``.seconds`` on a ``datetime.timedelta`` object returns the total number of seconds combined between ``hours``, ``minutes`` and ``seconds``. In contrast, the pandas ``Timedelta`` breaks out hours, minutes, microseconds and nanoseconds separately.
-
-   .. ipython:: python
-
-      # Timedelta accessor
-      tds = Timedelta('31 days 5 min 3 sec')
-      tds.minutes
-      tds.seconds
-
-      # datetime.timedelta accessor
-      # this is 5 minutes * 60 + 3 seconds
-      tds.to_pytimedelta().seconds
-
-.. warning::
-
-       Prior to 0.15.0 ``pd.to_timedelta`` would return a ``Series`` for list-like/Series input, and a ``np.timedelta64`` for scalar input.
-       It will now return a ``TimedeltaIndex`` for list-like input, ``Series`` for Series input, and ``Timedelta`` for scalar input.
-
-       The arguments to ``pd.to_timedelta`` are now ``(arg,unit='ns',box=True,coerce=False)``, previously were ``(arg,box=True,unit='ns')`` as these are more logical.
-
-Consruct a scalar
-
-.. ipython:: python
-
-   Timedelta('1 days 06:05:01.00003')
-   Timedelta('15.5us')
-   Timedelta('1 hour 15.5us')
-
-   # negative Timedeltas have this string repr
-   # to be more consistent with datetime.timedelta conventions
-   Timedelta('-1us')
-
-   # a NaT
-   Timedelta('nan')
-
-Access fields for a ``Timedelta``
-
-.. ipython:: python
-
-   td = Timedelta('1 hour 3m 15.5us')
-   td.hours
-   td.minutes
-   td.microseconds
-   td.nanoseconds
-
-Construct a ``TimedeltaIndex``
-
-.. ipython:: python
-   :suppress:
-
-   import datetime
-   from datetime import timedelta
-
-.. ipython:: python
-
-   TimedeltaIndex(['1 days','1 days, 00:00:05',
-                   np.timedelta64(2,'D'),timedelta(days=2,seconds=2)])
-
-Constructing a ``TimedeltaIndex`` with a regular range
-
-.. ipython:: python
-
-   timedelta_range('1 days',periods=5,freq='D')
-   timedelta_range(start='1 days',end='2 days',freq='30T')
-
-You can now use a ``TimedeltaIndex`` as the index of a pandas object
-
-.. ipython:: python
-
-   s = Series(np.arange(5),
-              index=timedelta_range('1 days',periods=5,freq='s'))
-   s
-
-You can select with partial string selections
-
-.. ipython:: python
-
-   s['1 day 00:00:02']
-   s['1 day':'1 day 00:00:02']
-
-Finally, the combination of ``TimedeltaIndex`` with ``DatetimeIndex`` allow certain combination operations that are ``NaT`` preserving:
-
-.. ipython:: python
-
-   tdi = TimedeltaIndex(['1 days',pd.NaT,'2 days'])
-   tdi.tolist()
-   dti = date_range('20130101',periods=3)
-   dti.tolist()
-
-   (dti + tdi).tolist()
-   (dti - tdi).tolist()
-
-- iteration of a ``Series`` e.g. ``list(Series(...))`` of ``timedelta64[ns]`` would prior to v0.15.0 return ``np.timedelta64`` for each element. These will now be wrapped in ``Timedelta``.
-
-.. _whatsnew_0150.prior_deprecations:
-
-Prior Version Deprecations/Changes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-- Remove ``DataFrame.delevel`` method in favor of ``DataFrame.reset_index``
 
 .. _whatsnew_0150.deprecations:
 
 Deprecations
-~~~~~~~~~~~~
+^^^^^^^^^^^^
 
+- The attributes ``Categorical`` ``labels`` and ``levels`` attributes are
+  deprecated and renamed to ``codes`` and ``categories``.
 - The ``outtype`` argument to ``pd.DataFrame.to_dict`` has been deprecated in favor of ``orient``. (:issue:`7840`)
 - The ``convert_dummies`` method has been deprecated in favor of
   ``get_dummies`` (:issue:`8140`)
@@ -826,7 +835,7 @@ Deprecations
 
 .. _whatsnew_0150.index_set_ops:
 
-- The ``Index`` set operations ``+`` and ``-`` were deprecated in order to provide these for numeric type operations on certain index types. ``+`` can be replace by ``.union()`` or ``|``, and ``-`` by ``.difference()``. Further the method name ``Index.diff()`` is deprecated and can be replaced by ``Index.difference()`` (:issue:`8226`)
+- The ``Index`` set operations ``+`` and ``-`` were deprecated in order to provide these for numeric type operations on certain index types. ``+`` can be replaced by ``.union()`` or ``|``, and ``-`` by ``.difference()``. Further the method name ``Index.diff()`` is deprecated and can be replaced by ``Index.difference()`` (:issue:`8226`)
 
   .. code-block:: python
 
@@ -844,33 +853,82 @@ Deprecations
      # should be replaced by
      Index(['a','b','c']).difference(Index(['b','c','d']))
 
+- The ``infer_types`` argument to :func:`~pandas.read_html` now has no
+  effect and is deprecated (:issue:`7762`, :issue:`7032`).
+
+
+.. _whatsnew_0150.prior_deprecations:
+
+Removal of prior version deprecations/changes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Remove ``DataFrame.delevel`` method in favor of ``DataFrame.reset_index``
+
+
+
 .. _whatsnew_0150.enhancements:
 
 Enhancements
 ~~~~~~~~~~~~
 
-- Added support for a ``chunksize`` parameter to ``to_sql`` function. This allows DataFrame to be written in chunks and avoid packet-size overflow errors (:issue:`8062`).
-- Added support for a ``chunksize`` parameter to ``read_sql`` function. Specifying this argument will return an iterator through chunks of the query result (:issue:`2908`).
-- Added support for writing ``datetime.date`` and ``datetime.time`` object columns with ``to_sql`` (:issue:`6932`).
-- Added support for specifying a ``schema`` to read from/write to with ``read_sql_table`` and ``to_sql`` (:issue:`7441`, :issue:`7952`).
-  For example:
-
-  .. code-block:: python
-
-         df.to_sql('table', engine, schema='other_schema')
-         pd.read_sql_table('table', engine, schema='other_schema')
-
-- Added support for writing ``NaN`` values with ``to_sql`` (:issue:`2754`).
-- Added support for writing datetime64 columns with ``to_sql`` for all database flavors (:issue:`7103`).
+Enhancements in the importing/exporting of Stata files:
 
 - Added support for bool, uint8, uint16 and uint32 datatypes in ``to_stata`` (:issue:`7097`, :issue:`7365`)
 - Added conversion option when importing Stata files (:issue:`8527`)
+- ``DataFrame.to_stata`` and ``StataWriter`` check string length for
+  compatibility with limitations imposed in dta files where fixed-width
+  strings must contain 244 or fewer characters.  Attempting to write Stata
+  dta files with strings longer than 244 characters raises a ``ValueError``. (:issue:`7858`)
+- ``read_stata`` and ``StataReader`` can import missing data information into a
+  ``DataFrame`` by setting the argument ``convert_missing`` to ``True``. When
+  using this options, missing values are returned as ``StataMissingValue``
+  objects and columns containing missing values have ``object`` data type. (:issue:`8045`)
 
+Enhancements in the plotting functions:
+  
 - Added ``layout`` keyword to ``DataFrame.plot``. You can pass a tuple of ``(rows, columns)``, one of which can be ``-1`` to automatically infer (:issue:`6667`, :issue:`8071`).
 - Allow to pass multiple axes to ``DataFrame.plot``, ``hist`` and ``boxplot`` (:issue:`5353`, :issue:`6970`, :issue:`7069`)
 - Added support for ``c``, ``colormap`` and ``colorbar`` arguments for ``DataFrame.plot`` with ``kind='scatter'`` (:issue:`7780`)
+- Histogram from ``DataFrame.plot`` with ``kind='hist'`` (:issue:`7809`), See :ref:`the docs<visualization.hist>`.
+- Boxplot from ``DataFrame.plot`` with ``kind='box'`` (:issue:`7998`), See :ref:`the docs<visualization.box>`.
+
+Other:
 
 - ``read_csv`` now has a keyword parameter ``float_precision`` which specifies which floating-point converter the C engine should use during parsing, see :ref:`here <io.float_precision>` (:issue:`8002`, :issue:`8044`)
+
+- Added ``searchsorted`` method to ``Series`` objects (:issue:`7447`)
+
+- :func:`describe` on mixed-types DataFrames is more flexible. Type-based column filtering is now possible via the ``include``/``exclude`` arguments.
+  See the :ref:`docs <basics.describe>` (:issue:`8164`).
+
+  .. ipython:: python
+
+    df = DataFrame({'catA': ['foo', 'foo', 'bar'] * 8,
+                    'catB': ['a', 'b', 'c', 'd'] * 6,
+                    'numC': np.arange(24),
+                    'numD': np.arange(24.) + .5})
+    df.describe(include=["object"])
+    df.describe(include=["number", "object"], exclude=["float"])
+
+  Requesting all columns is possible with the shorthand 'all'
+
+  .. ipython:: python
+
+    df.describe(include='all')
+
+  Without those arguments, 'describe` will behave as before, including only numerical columns or, if none are, only categorical columns. See also the :ref:`docs <basics.describe>`
+
+- Added ``split`` as an option to the ``orient`` argument in ``pd.DataFrame.to_dict``. (:issue:`7840`)
+
+- The ``get_dummies`` method can now be used on DataFrames. By default only
+  catagorical columns are encoded as 0's and 1's, while other columns are
+  left untouched.
+
+  .. ipython:: python
+
+    df = DataFrame({'A': ['a', 'b', 'a'], 'B': ['c', 'c', 'b'],
+                    'C': [1, 2, 3]})
+    pd.get_dummies(df)
 
 - ``PeriodIndex`` supports ``resolution`` as the same as ``DatetimeIndex`` (:issue:`7708`)
 - ``pandas.tseries.holiday`` has added support for additional holidays and ways to observe holidays (:issue:`7070`)
@@ -900,20 +958,6 @@ Enhancements
     idx
     idx + pd.offsets.MonthEnd(3)
 
-- Added ``split`` as an option to the ``orient`` argument in ``pd.DataFrame.to_dict``. (:issue:`7840`)
-
-- The ``get_dummies`` method can now be used on DataFrames. By default only
-  catagorical columns are encoded as 0's and 1's, while other columns are
-  left untouched.
-
-  .. ipython:: python
-
-    df = DataFrame({'A': ['a', 'b', 'a'], 'B': ['c', 'c', 'b'],
-                    'C': [1, 2, 3]})
-    pd.get_dummies(df)
-
-
-
 - Added experimental compatibility with ``openpyxl`` for versions >= 2.0. The ``DataFrame.to_excel``
   method ``engine`` keyword now recognizes ``openpyxl1`` and ``openpyxl2``
   which will explicitly require openpyxl v1 and v2 respectively, failing if
@@ -923,7 +967,47 @@ Enhancements
 
 - ``DataFrame.fillna`` can now accept a ``DataFrame`` as a fill value (:issue:`8377`)
 
-- Added ``searchsorted`` method to ``Series`` objects (:issue:`7447`)
+- Passing multiple levels to :meth:`~pandas.DataFrame.stack()` will now work when multiple level
+  numbers are passed (:issue:`7660`). See
+  :ref:`Reshaping by stacking and unstacking <reshaping.stack_multiple>`.
+
+- :func:`set_names`, :func:`set_labels`, and :func:`set_levels` methods now take an optional ``level`` keyword argument to all modification of specific level(s) of a MultiIndex. Additionally :func:`set_names` now accepts a scalar string value when operating on an ``Index`` or on a specific level of a ``MultiIndex`` (:issue:`7792`)
+
+  .. ipython:: python
+
+      idx = MultiIndex.from_product([['a'], range(3), list("pqr")], names=['foo', 'bar', 'baz'])
+      idx.set_names('qux', level=0)
+      idx.set_names(['qux','baz'], level=[0,1])
+      idx.set_levels(['a','b','c'], level='bar')
+      idx.set_levels([['a','b','c'],[1,2,3]], level=[1,2])
+
+- ``Index.isin`` now supports a ``level`` argument to specify which index level
+  to use for membership tests (:issue:`7892`, :issue:`7890`)
+
+  .. code-block:: python
+
+     In [1]: idx = MultiIndex.from_product([[0, 1], ['a', 'b', 'c']])
+
+     In [2]: idx.values
+     Out[2]: array([(0, 'a'), (0, 'b'), (0, 'c'), (1, 'a'), (1, 'b'), (1, 'c')], dtype=object)
+
+     In [3]: idx.isin(['a', 'c', 'e'], level=1)
+     Out[3]: array([ True, False,  True,  True, False,  True], dtype=bool)
+
+- ``Index`` now supports ``duplicated`` and ``drop_duplicates``. (:issue:`4060`)
+
+  .. ipython:: python
+
+     idx = Index([1, 2, 3, 4, 1, 2])
+     idx
+     idx.duplicated()
+     idx.drop_duplicates()
+
+- add ``copy=True`` argument to ``pd.concat`` to enable pass thru of complete blocks (:issue:`8252`)
+
+- Added support for numpy 1.8+ data types (``bool_``, ``int_``, ``float_``, ``string_``) for conversion to R dataframe  (:issue:`8400`)
+
+
 
 .. _whatsnew_0150.performance:
 
@@ -944,27 +1028,11 @@ Performance
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 .. _whatsnew_0150.bug_fixes:
 
 Bug Fixes
 ~~~~~~~~~
+
 - Bug in pivot_table, when using margins and a dict aggfunc (:issue:`8349`)
 - Bug in ``read_csv`` where ``squeeze=True`` would return a view (:issue:`8217`)
 - Bug in checking of table name in ``read_sql`` in certain cases (:issue:`7826`).
@@ -1002,44 +1070,26 @@ Bug Fixes
 - Bug in ``PeriodIndex.unique`` returns int64 ``np.ndarray`` (:issue:`7540`)
 - Bug in ``groupby.apply`` with a non-affecting mutation in the function (:issue:`8467`)
 - Bug in ``DataFrame.reset_index`` which has ``MultiIndex`` contains ``PeriodIndex`` or ``DatetimeIndex`` with tz raises ``ValueError`` (:issue:`7746`, :issue:`7793`)
-
-
 - Bug in ``DataFrame.plot`` with ``subplots=True`` may draw unnecessary minor xticks and yticks (:issue:`7801`)
 - Bug in ``StataReader`` which did not read variable labels in 117 files due to difference between Stata documentation and implementation (:issue:`7816`)
 - Bug in ``StataReader`` where strings were always converted to 244 characters-fixed width irrespective of underlying string size (:issue:`7858`)
-
 - Bug in ``DataFrame.plot`` and ``Series.plot`` may ignore ``rot`` and ``fontsize`` keywords (:issue:`7844`)
-
-
 - Bug in ``DatetimeIndex.value_counts`` doesn't preserve tz  (:issue:`7735`)
 - Bug in ``PeriodIndex.value_counts`` results in ``Int64Index`` (:issue:`7735`)
 - Bug in ``DataFrame.join`` when doing left join on index and there are multiple matches (:issue:`5391`)
-
-
-
 - Bug in ``GroupBy.transform()`` where int groups with a transform that
   didn't preserve the index were incorrectly truncated (:issue:`7972`).
-
 - Bug in ``groupby`` where callable objects without name attributes would take the wrong path,
   and produce a ``DataFrame`` instead of a ``Series`` (:issue:`7929`)
-
 - Bug in ``groupby`` error message when a DataFrame grouping column is duplicated (:issue:`7511`)
-
 - Bug in ``read_html`` where the ``infer_types`` argument forced coercion of
   date-likes incorrectly (:issue:`7762`, :issue:`7032`).
-
-
 - Bug in ``Series.str.cat`` with an index which was filtered as to not include the first item (:issue:`7857`)
-
-
 - Bug in ``Timestamp`` cannot parse ``nanosecond`` from string (:issue:`7878`)
 - Bug in ``Timestamp`` with string offset and ``tz`` results incorrect (:issue:`7833`)
-
 - Bug in ``tslib.tz_convert`` and ``tslib.tz_convert_single`` may return different results (:issue:`7798`)
 - Bug in ``DatetimeIndex.intersection`` of non-overlapping timestamps with tz raises ``IndexError`` (:issue:`7880`)
 - Bug in alignment with TimeOps and non-unique indexes (:issue:`8363`)
-
-
 - Bug in ``GroupBy.filter()`` where fast path vs. slow path made the filter
   return a non scalar value that appeared valid but wasn't (:issue:`7870`).
 - Bug in ``date_range()``/``DatetimeIndex()`` when the timezone was inferred from input dates yet incorrect
@@ -1048,46 +1098,23 @@ Bug Fixes
 - Bug in area plot draws legend with incorrect ``alpha`` when ``stacked=True`` (:issue:`8027`)
 - ``Period`` and ``PeriodIndex`` addition/subtraction with ``np.timedelta64`` results in incorrect internal representations (:issue:`7740`)
 - Bug in ``Holiday`` with no offset or observance (:issue:`7987`)
-
 - Bug in ``DataFrame.to_latex`` formatting when columns or index is a ``MultiIndex`` (:issue:`7982`).
-
 - Bug in ``DateOffset`` around Daylight Savings Time produces unexpected results (:issue:`5175`).
-
-
-
-
-
 - Bug in ``DataFrame.shift`` where empty columns would throw ``ZeroDivisionError`` on numpy 1.7 (:issue:`8019`)
-
-
-
-
-
 - Bug in installation where ``html_encoding/*.html`` wasn't installed and
   therefore some tests were not running correctly (:issue:`7927`).
-
 - Bug in ``read_html`` where ``bytes`` objects were not tested for in
   ``_read`` (:issue:`7927`).
-
 - Bug in ``DataFrame.stack()`` when one of the column levels was a datelike (:issue:`8039`)
 - Bug in broadcasting numpy scalars with ``DataFrame`` (:issue:`8116`)
-
-
 - Bug in ``pivot_table`` performed with nameless ``index`` and ``columns`` raises ``KeyError`` (:issue:`8103`)
-
 - Bug in ``DataFrame.plot(kind='scatter')`` draws points and errorbars with different colors when the color is specified by ``c`` keyword (:issue:`8081`)
-
-
-
-
 - Bug in ``Float64Index`` where ``iat`` and ``at`` were not testing and were
   failing (:issue:`8092`).
 - Bug in ``DataFrame.boxplot()`` where y-limits were not set correctly when
   producing multiple axes (:issue:`7528`, :issue:`5517`).
-
 - Bug in ``read_csv`` where line comments were not handled correctly given
   a custom line terminator or ``delim_whitespace=True`` (:issue:`8122`).
-
 - Bug in ``read_html`` where empty tables caused a ``StopIteration`` (:issue:`7575`)
 - Bug in casting when setting a column in a same-dtype block (:issue:`7704`)
 - Bug in accessing groups from a ``GroupBy`` when the original grouper
@@ -1097,7 +1124,6 @@ Bug Fixes
 - Bug in ``GroupBy.count`` with float32 data type were nan values were not excluded (:issue:`8169`).
 - Bug with stacked barplots and NaNs (:issue:`8175`).
 - Bug in resample with non evenly divisible offsets (e.g. '7s') (:issue:`8371`)
-
 - Bug in interpolation methods with the ``limit`` keyword when no values needed interpolating (:issue:`7173`).
 - Bug where ``col_space`` was ignored in ``DataFrame.to_string()`` when ``header=False`` (:issue:`8230`).
 - Bug with ``DatetimeIndex.asof`` incorrectly matching partial strings and returning the wrong date (:issue:`8245`).
@@ -1121,6 +1147,6 @@ Bug Fixes
 - Bug in ``Series`` that allows it to be indexed by a ``DataFrame`` which has unexpected results.  Such indexing is no longer permitted (:issue:`8444`)
 - Bug in item assignment of a ``DataFrame`` with multi-index columns where right-hand-side columns were not aligned (:issue:`7655`)
 - Suppress FutureWarning generated by NumPy when comparing object arrays containing NaN for equality (:issue:`7065`)
-
 - Bug in ``DataFrame.eval()`` where the dtype of the ``not`` operator (``~``)
   was not correctly inferred as ``bool``.
+


### PR DESCRIPTION
Closes #8477 

What did I change:
- some general clean-up (blank lines, ..)
- put the different new feature sections in front (as also in the highlights section)
- the 2-level menu structure as discussed in #8477 
- API section: move some entries to the 'enhancements' section (entries that were not 'real' (in sense of breaking) API changes):
  - describe keywords include/exclude
  - new 'level' keyword for Index.set_names/set_levels
  - new 'level' keyword for Index isin
  - histogram/boxplot also via `plot`
  - index new methods duplicated and drop_duplicates

Still work in progress!
