### PR TITLE
BUG: LooseVersion was used incorrectly

### DIFF
--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -43,7 +43,7 @@ if not compat.PY3:
             _GOOGLE_API_CLIENT_INSTALLED=True
             _GOOGLE_API_CLIENT_VERSION = pkg_resources.get_distribution('google-api-python-client').version
 
-            if LooseVersion(_GOOGLE_API_CLIENT_VERSION >= '1.2.0'):
+            if LooseVersion(_GOOGLE_API_CLIENT_VERSION) >= '1.2.0':
                 _GOOGLE_API_CLIENT_VALID_VERSION = True
 
         except ImportError:
@@ -56,7 +56,7 @@ if not compat.PY3:
 
             _GOOGLE_FLAGS_VERSION = pkg_resources.get_distribution('python-gflags').version
 
-            if LooseVersion(_GOOGLE_FLAGS_VERSION >= '2.0.0'):
+            if LooseVersion(_GOOGLE_FLAGS_VERSION) >= '2.0.0':
                 _GOOGLE_FLAGS_VALID_VERSION = True
 
         except ImportError:

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -56,7 +56,7 @@ if not compat.PY3:
 
             _GOOGLE_FLAGS_VERSION = pkg_resources.get_distribution('python-gflags').version
 
-            if LooseVersion(_GOOGLE_FLAGS_VERSION) >= '2.0.0':
+            if LooseVersion(_GOOGLE_FLAGS_VERSION) >= '2.0':
                 _GOOGLE_FLAGS_VALID_VERSION = True
 
         except ImportError:


### PR DESCRIPTION
closes #8581 

Version comparison had a formatting error resulting in "TypeError: expected string or buffer" and preventing Spyder from loading (and probably other issues). Fixed.
