### PR TITLE
ENH: improve bigquery connector to optionally allow use of gcloud credentials

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -3643,8 +3643,17 @@ You will then be authenticated to the specified BigQuery account
 via Google's Oauth2 mechanism. In general, this is as simple as following the
 prompts in a browser window which will be opened for you. Should the browser not
 be available, or fail to launch, a code will be provided to complete the process
-manually.  Additional information on the authentication mechanism can be found
+manually.  Additional information on this authentication mechanism can be found
 `here <https://developers.google.com/accounts/docs/OAuth2#clientside/>`__
+
+Alternatively, you can use a headless authentication mechanism via the Google Cloud SDK. More
+information on installing the SDK and authenticating is available `here <https://cloud.google.com/sdk/gcloud/>`__
+
+Once you have your authentication credentials setup, you can use this approach by including the gcloud_credentials parameter. It will accept either a boolean True (in which case it uses the SDK's default credentials path), or string filepath to the credentials file:
+
+.. code-block:: python
+
+   data_frame = pd.read_gbq('SELECT * FROM test_dataset.test_table', project_id = projectid, gcloud_credentials = True)
 
 You can define which column from BigQuery to use as an index in the
 destination DataFrame as well as a preferred column order as follows:

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -2537,13 +2537,13 @@ def is_hashable(arg):
     >>> is_hashable(a)
     False
     """
-    # don't consider anything not collections.Hashable, so as not to broaden
-    # the definition of hashable beyond that. For example, old-style classes
-    # are not collections.Hashable but they won't fail hash().
-    if not isinstance(arg, collections.Hashable):
-        return False
+    # unfortunately, we can't use isinstance(arg, collections.Hashable), which
+    # can be faster than calling hash, because numpy scalars on Python 3 fail
+    # this test
 
-    # narrow the definition of hashable if hash(arg) fails in practice
+    # reconsider this decision once this numpy bug is fixed:
+    # https://github.com/numpy/numpy/issues/5562
+
     try:
         hash(arg)
     except TypeError:

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import os
 import json
 import logging
 import sys
@@ -38,12 +39,13 @@ if not compat.PY3:
             from oauth2client.client import OAuth2WebServerFlow
             from oauth2client.client import AccessTokenRefreshError
             from oauth2client.client import flow_from_clientsecrets
+            from oauth2client.client import Credentials
             from oauth2client.file import Storage
             from oauth2client.tools import run
             _GOOGLE_API_CLIENT_INSTALLED=True
             _GOOGLE_API_CLIENT_VERSION = pkg_resources.get_distribution('google-api-python-client').version
 
-            if LooseVersion(_GOOGLE_API_CLIENT_VERSION) >= '1.2.0':
+            if LooseVersion(_GOOGLE_API_CLIENT_VERSION) >= '1.2':
                 _GOOGLE_API_CLIENT_VALID_VERSION = True
 
         except ImportError:
@@ -71,6 +73,13 @@ if not compat.PY3:
 
 logger = logging.getLogger('pandas.io.gbq')
 logger.setLevel(logging.ERROR)
+
+class MissingOauthCredentials(PandasError, IOError):
+    """
+    Raised when Google BigQuery authentication credentials 
+    file is missing, but was needed.
+    """
+    pass
 
 class InvalidPageToken(PandasError, IOError):
     """
@@ -119,11 +128,12 @@ class InvalidColumnOrder(PandasError, IOError):
     pass
 
 class GbqConnector:
-    def __init__(self, project_id, reauth=False):
-        self.project_id     = project_id
-        self.reauth         = reauth
-        self.credentials    = self.get_credentials()
-        self.service        = self.get_service(self.credentials)
+    def __init__(self, project_id, reauth=False, gcloud_credentials=None):
+        self.project_id         = project_id
+        self.reauth             = reauth
+        self.gcloud_credentials = gcloud_credentials
+        self.credentials        = self.get_credentials()
+        self.service            = self.get_service(self.credentials)
 
     def get_credentials(self):
         flow = OAuth2WebServerFlow(client_id='495642085510-k0tmvj2m941jhre2nbqka17vqpjfddtd.apps.googleusercontent.com',
@@ -131,8 +141,19 @@ class GbqConnector:
                                    scope='https://www.googleapis.com/auth/bigquery',
                                    redirect_uri='urn:ietf:wg:oauth:2.0:oob')
 
-        storage = Storage('bigquery_credentials.dat')
-        credentials = storage.get()
+        if self.gcloud_credentials is not None:
+            gcfp = self.gcloud_credentials		# a bit of mangling since this is dual-typed, str or bool
+            if self.gcloud_credentials == True:
+                gcfp = '~/.config/gcloud/credentials'
+            credfn = os.path.expanduser(gcfp)
+            if not os.path.exists(credfn):
+                raise MissingOauthCredentials("Required google cloud authentication credentials file {0} missing.".format(credfn))
+            gcloud_cred = json.loads(open(credfn).read())['data'][0]['credential']
+            credentials = Credentials.new_from_json(json.dumps(gcloud_cred))
+            return credentials
+        else:
+            storage = Storage('bigquery_credentials.dat')
+            credentials = storage.get()
 
         if credentials is None or credentials.invalid or self.reauth:
             credentials = run(flow, storage)
@@ -328,7 +349,8 @@ def _test_imports():
     if not _HTTPLIB2_INSTALLED:
         raise ImportError("pandas requires httplib2 for Google BigQuery support")
 
-def read_gbq(query, project_id = None, index_col=None, col_order=None, reauth=False):
+def read_gbq(query, project_id = None, index_col=None, col_order=None, reauth=False, 
+             gcloud_credentials=None):
     """Load data from Google BigQuery.
 
     THIS IS AN EXPERIMENTAL LIBRARY
@@ -353,6 +375,12 @@ def read_gbq(query, project_id = None, index_col=None, col_order=None, reauth=Fa
     reauth : boolean (default False)
         Force Google BigQuery to reauthenticate the user. This is useful
         if multiple accounts are used.
+    gcloud_credentials : boolean or str (default None)
+        Use oauth2 credentials from gcloud auth login.  This is useful
+        if pandas is being run in an ipython notebook, and the user
+        has pre-existing authentication tokens.
+        Set to True to use the default path, ~/.config/gcloud/credentials.
+        Else provide an explicit path to file to use for credentials. 
 
     Returns
     -------
@@ -366,7 +394,7 @@ def read_gbq(query, project_id = None, index_col=None, col_order=None, reauth=Fa
     if not project_id:
         raise TypeError("Missing required parameter: project_id")
 
-    connector = GbqConnector(project_id, reauth = reauth)
+    connector = GbqConnector(project_id, reauth = reauth, gcloud_credentials = gcloud_credentials)
     schema, pages = connector.run_query(query)
     dataframe_list = []
     while len(pages) > 0:
@@ -401,7 +429,7 @@ def read_gbq(query, project_id = None, index_col=None, col_order=None, reauth=Fa
     return final_df
 
 def to_gbq(dataframe, destination_table, project_id=None, chunksize=10000,
-           verbose=True, reauth=False):
+           verbose=True, reauth=False, gcloud_credentials=None):
     """Write a DataFrame to a Google BigQuery table.
 
     THIS IS AN EXPERIMENTAL LIBRARY
@@ -430,6 +458,12 @@ def to_gbq(dataframe, destination_table, project_id=None, chunksize=10000,
     reauth : boolean (default False)
         Force Google BigQuery to reauthenticate the user. This is useful
         if multiple accounts are used.
+    gcloud_credentials : boolean or str (default None)
+        Use oauth2 credentials from gcloud auth login.  This is useful
+        if pandas is being run in an ipython notebook, and the user
+        has pre-existing authentication tokens.
+        Set to True to use the default path, ~/.config/gcloud/credentials.
+        Else provide an explicit path to file to use for credentials. 
 
     """
     _test_imports()
@@ -440,7 +474,7 @@ def to_gbq(dataframe, destination_table, project_id=None, chunksize=10000,
     if not '.' in destination_table:
         raise NotFoundException("Invalid Table Name. Should be of the form 'datasetId.tableId' ")
 
-    connector = GbqConnector(project_id, reauth = reauth)
+    connector = GbqConnector(project_id, reauth = reauth, gcloud_credentials = gcloud_credentials)
     dataset_id, table_id = destination_table.rsplit('.',1)
 
     connector.load_data(dataframe, dataset_id, table_id, chunksize, verbose)

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -152,6 +152,7 @@ class GbqConnector:
                 raise MissingOauthCredentials("Required google cloud authentication credentials file {0} missing.".format(credfn))
             gcloud_cred = json.loads(open(credfn).read())['data'][0]['credential']
             credentials = Credentials.new_from_json(json.dumps(gcloud_cred))
+            return credentials
         else:
             storage = Storage('bigquery_credentials.dat')
             credentials = storage.get()

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -44,7 +44,7 @@ if not compat.PY3:
             _GOOGLE_API_CLIENT_INSTALLED=True
             _GOOGLE_API_CLIENT_VERSION = pkg_resources.get_distribution('google-api-python-client').version
 
-            if LooseVersion(_GOOGLE_API_CLIENT_VERSION) >= '1.2.0':
+            if LooseVersion(_GOOGLE_API_CLIENT_VERSION) >= '1.2':
                 _GOOGLE_API_CLIENT_VALID_VERSION = True
 
         except ImportError:

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -35,7 +35,7 @@ if not compat.PY3:
         try:
             from apiclient.discovery import build
             from apiclient.http import MediaFileUpload
-            from apiclient.errors import HttpError
+            from apiclient.errors import HttpError 
 
             from oauth2client.client import OAuth2WebServerFlow
             from oauth2client.client import AccessTokenRefreshError

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import os
 import json
 import logging
 import sys
@@ -142,8 +143,6 @@ class GbqConnector:
 
 
         if self.gcloud_credentials is not None:
-            import json
-            import os
             gcfp = self.gcloud_credentials		# a bit of mangling since this is dual-typed, str or bool
             if self.gcloud_credentials == True:
                 gcfp = '~/.config/gcloud/credentials'

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -376,7 +376,7 @@ def read_gbq(query, project_id = None, index_col=None, col_order=None, reauth=Fa
     reauth : boolean (default False)
         Force Google BigQuery to reauthenticate the user. This is useful
         if multiple accounts are used.
-    gcloud_credentials: boolean or str (default None)
+    gcloud_credentials : boolean or str (default None)
         Use oauth2 credentials from gcloud auth login.  This is useful
         if pandas is being run in an ipython notebook, and the user
         has pre-existing authentication tokens.
@@ -459,7 +459,7 @@ def to_gbq(dataframe, destination_table, project_id=None, chunksize=10000,
     reauth : boolean (default False)
         Force Google BigQuery to reauthenticate the user. This is useful
         if multiple accounts are used.
-    gcloud_credentials: boolean or str (default None)
+    gcloud_credentials : boolean or str (default None)
         Use oauth2 credentials from gcloud auth login.  This is useful
         if pandas is being run in an ipython notebook, and the user
         has pre-existing authentication tokens.

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -5,6 +5,7 @@ import logging
 import sys
 from time import sleep
 import uuid
+import traceback
 
 import numpy as np
 
@@ -49,6 +50,7 @@ if not compat.PY3:
                 _GOOGLE_API_CLIENT_VALID_VERSION = True
 
         except ImportError:
+            traceback.format_exc()
             _GOOGLE_API_CLIENT_INSTALLED = False
 
 

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -140,14 +140,14 @@ class GbqConnector:
                                    scope='https://www.googleapis.com/auth/bigquery',
                                    redirect_uri='urn:ietf:wg:oauth:2.0:oob')
 
-        gcfp = self.gcloud_credentials		# a bit of mangling since this is dual-typed, str or bool
-        if self.gcloud_credentials == True:
-            gcfp = ''
 
         if self.gcloud_credentials is not None:
             import json
             import os
-            credfn = os.path.expanduser(gcfp or '~/.config/gcloud/credentials')
+            gcfp = self.gcloud_credentials		# a bit of mangling since this is dual-typed, str or bool
+            if self.gcloud_credentials == True:
+                gcfp = '~/.config/gcloud/credentials'
+            credfn = os.path.expanduser(gcfp)
             if not os.path.exists(credfn):
                 raise MissingOauthCredentials("Required google cloud authentication credentials file {0} missing.".format(credfn))
             gcloud_cred = json.loads(open(credfn).read())['data'][0]['credential']

--- a/pandas/io/tests/data/gcloud_credentials
+++ b/pandas/io/tests/data/gcloud_credentials
@@ -1,0 +1,62 @@
+{
+  "data": [
+    {
+      "credential": {
+        "_class": "OAuth2Credentials", 
+        "_module": "oauth2client.client", 
+        "access_token": "ya29.xXx", 
+        "client_id": "1112223456.apps.googleusercontent.com", 
+        "client_secret": "aBc467", 
+        "id_token": {
+          "at_hash": "OlAp__aV", 
+          "aud": "1112223456.apps.googleusercontent.com", 
+          "azp": "1112223456.apps.googleusercontent.com", 
+          "cid": "1112223456.apps.googleusercontent.com", 
+          "email": "luv-python-pandas@somemail.com", 
+          "email_verified": true, 
+          "exp": 1414558238, 
+          "iat": 1414554338, 
+          "id": "113403125016275849302", 
+          "iss": "accounts.google.com", 
+          "sub": "113403125016229475663", 
+          "token_hash": "OlAp__aV", 
+          "verified_email": true
+        }, 
+        "invalid": @INVALID@, 
+        "refresh_token": "1/asf87bbEGsb78", 
+        "revoke_uri": "https://accounts.google.com/o/oauth2/revoke", 
+        "token_expiry": "2014-10-29T04:50:38Z", 
+        "token_response": {
+          "access_token": "ya29.bYsadfiU8542B5",
+          "expires_in": 3600, 
+          "id_token": {
+            "at_hash": "OlAp__aV", 
+            "aud": "11112233456.apps.googleusercontent.com", 
+            "azp": "11112223456.apps.googleusercontent.com", 
+            "cid": "11112223456.apps.googleusercontent.com", 
+            "email": "luv-python-pandas@somemail.com", 
+            "email_verified": true, 
+            "exp": 1414558238, 
+            "iat": 1414554338, 
+            "id": "11340312501621345098732", 
+            "iss": "accounts.google.com", 
+            "sub": "1134031250162435660892", 
+            "token_hash": "OlAp__aV", 
+            "verified_email": true
+          }, 
+          "refresh_token": "1/6v6asdf6NrR92", 
+          "token_type": "Bearer"
+        }, 
+        "token_uri": "https://accounts.google.com/o/oauth2/token", 
+        "user_agent": "Cloud SDK Command Line Tool"
+      }, 
+      "key": {
+        "account": "luv-python-pandas@somemail.com", 
+        "clientId": "11112223456.apps.googleusercontent.com", 
+        "scope": "https://www.googleapis.com/auth/appengine.admin https://www.googleapis.com/auth/bigquery https://www.googleapis.com/auth/compute https://www.googleapis.com/auth/devstorage.full_control https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/ndev.cloudman https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/sqlservice.admin https://www.googleapis.com/auth/prediction https://www.googleapis.com/auth/projecthosting", 
+        "type": "google-cloud-sdk"
+      }
+    }
+  ], 
+  "file_version": 1
+}

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -424,7 +424,7 @@ def test_is_hashable():
             raise TypeError("Not hashable")
 
     hashable = (
-        1, 'a', tuple(), (1,), HashableClass(),
+        1, 3.14, np.float64(3.14), 'a', tuple(), (1,), HashableClass(),
     )
     not_hashable = (
         [], UnhashableClass1(),
@@ -434,13 +434,10 @@ def test_is_hashable():
     )
 
     for i in hashable:
-        assert isinstance(i, collections.Hashable)
         assert com.is_hashable(i)
     for i in not_hashable:
-        assert not isinstance(i, collections.Hashable)
         assert not com.is_hashable(i)
     for i in abc_hashable_not_really_hashable:
-        assert isinstance(i, collections.Hashable)
         assert not com.is_hashable(i)
 
     # numpy.array is no longer collections.Hashable as of
@@ -455,7 +452,7 @@ def test_is_hashable():
             pass
         c = OldStyleClass()
         assert not isinstance(c, collections.Hashable)
-        assert not com.is_hashable(c)
+        assert com.is_hashable(c)
         hash(c)  # this will not raise
 
 


### PR DESCRIPTION
closes #8489

The pandas google bigquery connector can be difficult to use from an ipython notebook: when no authentication token exists, it fails silently (and can hang the notebook).  This happens because the oauth2client library is trying to bring up a browser on the console, to request an auth token.  

This PR provides an improved mechanism: an optional `use_gcloud_auth` argument which specifies that the user wants to employ a pre-existing authentication token, generated using [gcloud auth login](https://cloud.google.com/sdk/gcloud/reference/auth/login).  An error is raised if the credentials file is missing.
