### PR TITLE
Function pointer misspecified in io documentaion

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -3411,7 +3411,7 @@ Of course, you can specify a more "complex" query.
 
    pd.read_sql_query("SELECT id, Col_1, Col_2 FROM data WHERE id = 42;", engine)
 
-The func:`~pandas.read_sql_query` function supports a ``chunksize`` argument.
+The :func:`~pandas.read_sql_query` function supports a ``chunksize`` argument.
 Specifying this will return an iterator through chunks of the query result:
 
 .. ipython:: python


### PR DESCRIPTION
The pointer to `read_sql_query` is not specified correctly in `doc/source/io.rst` .
