### PR TITLE
Fix shape attribute for MultiIndex

### DIFF
--- a/doc/source/whatsnew/v0.15.1.txt
+++ b/doc/source/whatsnew/v0.15.1.txt
@@ -47,4 +47,7 @@ Experimental
 
 Bug Fixes
 ~~~~~~~~~
+
 - Bug in ``cut``/``qcut`` when using ``Series`` and ``retbins=True`` (:issue:`8589`)
+
+- Fix ``shape`` attribute for ``MultiIndex`` (:issue:`8609`)

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -297,7 +297,7 @@ class IndexOpsMixin(object):
     @property
     def shape(self):
         """ return a tuple of the shape of the underlying data """
-        return self._data.shape
+        return self.values.shape
 
     @property
     def ndim(self):

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -83,6 +83,17 @@ class Base(object):
                 pass
         tm.assertRaisesRegexp(ValueError,'The truth value of a',f)
 
+    def test_ndarray_compat_properties(self):
+
+        idx = self.create_index()
+        self.assertTrue(idx.T.equals(idx))
+        self.assertTrue(idx.transpose().equals(idx))
+
+        values = idx.values
+        for prop in ['shape', 'ndim', 'size', 'itemsize', 'nbytes']:
+            self.assertEqual(getattr(idx, prop), getattr(values, prop))
+
+
 class TestIndex(Base, tm.TestCase):
     _holder = Index
     _multiprocess_can_split_ = True


### PR DESCRIPTION
This fix ensures that `idx.shape == (len(idx),)` if `idx` is a MultiIndex.

Also added tests for other ndarray compat properties.
