### PR TITLE
Fix timezone comparison in DatetimeIndex._generate

### DIFF
--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -376,7 +376,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
 
         try:
             inferred_tz = tools._infer_tzinfo(start, end)
-        except:
+        except AssertionError:
             raise ValueError('Start and end cannot both be tz-aware with '
                              'different timezones')
 
@@ -390,7 +390,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
                 tz = tz.localize(date.replace(tzinfo=None)).tzinfo
 
         if tz is not None and inferred_tz is not None:
-            if not inferred_tz == tz:
+            if not tslib.get_timezone(inferred_tz) == tslib.get_timezone(tz):
                 raise AssertionError("Inferred time zone not equal to passed "
                                      "time zone")
 


### PR DESCRIPTION
This fix is just a band-aid-- a real fix will have to wait for PEP 431 to unite all the time zone implementations.

Also refine a bare `except:` in the same method.

Fixes #8616 
