### PR TITLE
BUG: Bug in ix/loc block splitting on setitem (manifests with integer-like dtypes, eg. datetime64) (GH8607)

### DIFF
--- a/doc/source/whatsnew/v0.15.1.txt
+++ b/doc/source/whatsnew/v0.15.1.txt
@@ -50,4 +50,5 @@ Bug Fixes
 
 - Bug in ``cut``/``qcut`` when using ``Series`` and ``retbins=True`` (:issue:`8589`)
 - Bug in numeric index operations of add/sub with Float/Index Index with numpy arrays (:issue:`8608`)
+- Bug in ix/loc block splitting on setitem (manifests with integer-like dtypes, e.g. datetime64) (:issue:`8607`)
 - Fix ``shape`` attribute for ``MultiIndex`` (:issue:`8609`)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -482,6 +482,14 @@ class _NDFrameIndexer(object):
             if isinstance(indexer, tuple):
                 indexer = _maybe_convert_ix(*indexer)
 
+                # if we are setting on the info axis ONLY
+                # set using those methods to avoid block-splitting
+                # logic here
+                if len(indexer) > info_axis and com.is_integer(indexer[info_axis]) and all(
+                    _is_null_slice(idx) for i, idx in enumerate(indexer) if i != info_axis):
+                    self.obj[item_labels[indexer[info_axis]]] = value
+                    return
+
             if isinstance(value, ABCSeries):
                 value = self._align_series(indexer, value)
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1000,7 +1000,10 @@ class CheckIndexing(object):
         tmp = df.copy()
         exp = df.copy()
         tmp.ix[:, 2] = 5
-        exp.values[:, 2] = 5
+
+        # tmp correctly sets the dtype
+        # so match the exp way
+        exp[2] = 5
         assert_frame_equal(tmp, exp)
 
     def test_fancy_getitem_int_labels(self):

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -605,7 +605,8 @@ class TestIndexing(tm.TestCase):
         expected = Series([0,1,0],index=[4,5,6])
         assert_series_equal(s, expected)
 
-    def test_loc_setitem(self):
+    def test_ix_loc_setitem(self):
+
         # GH 5771
         # loc with slice and series
         s = Series(0,index=[4,5,6])
@@ -626,6 +627,31 @@ class TestIndexing(tm.TestCase):
         df['a'].ix[[0,1,2]] = -df['a'].ix[[0,1,2]].astype('float64') + 0.5
         expected = DataFrame({'a' : [0.5,-0.5,-1.5], 'b' : [0,1,2] })
         assert_frame_equal(df,expected)
+
+        # GH 8607
+        # ix setitem consistency
+        df = DataFrame(
+            {'timestamp':[1413840976, 1413842580, 1413760580],
+             'delta':[1174, 904, 161],
+             'elapsed':[7673, 9277, 1470]
+             })
+        expected = DataFrame(
+            {'timestamp':pd.to_datetime([1413840976, 1413842580, 1413760580], unit='s'),
+             'delta':[1174, 904, 161],
+             'elapsed':[7673, 9277, 1470]
+             })
+
+        df2 = df.copy()
+        df2['timestamp'] = pd.to_datetime(df['timestamp'], unit='s')
+        assert_frame_equal(df2,expected)
+
+        df2 = df.copy()
+        df2.loc[:,'timestamp'] = pd.to_datetime(df['timestamp'], unit='s')
+        assert_frame_equal(df2,expected)
+
+        df2 = df.copy()
+        df2.ix[:,2] = pd.to_datetime(df['timestamp'], unit='s')
+        assert_frame_equal(df2,expected)
 
     def test_loc_setitem_multiindex(self):
 


### PR DESCRIPTION
closes #8607 
