### PR TITLE
BUG: fix concat to work with more iterables (GH8645)

### DIFF
--- a/doc/source/whatsnew/v0.15.1.txt
+++ b/doc/source/whatsnew/v0.15.1.txt
@@ -75,6 +75,28 @@ API changes
 
      gr.apply(sum)
 
+- ``concat`` permits a wider variety of iterables of pandas objects to be
+  passed as the first parameter (:issue:`8645`):
+
+  .. ipython:: python
+
+     from collections import deque
+     df1 = pd.DataFrame([1, 2, 3])
+     df2 = pd.DataFrame([4, 5, 6])
+
+  previous behavior:
+
+  .. code-block:: python
+
+     In [7]: pd.concat(deque((df1, df2)))
+     TypeError: first argument must be a list-like of pandas objects, you passed an object of type "deque"
+
+  current behavior:
+
+  .. ipython:: python
+
+     pd.concat(deque((df1, df2)))
+
 .. _whatsnew_0151.enhancements:
 
 Enhancements

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -675,7 +675,7 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
 
     Parameters
     ----------
-    objs : list or dict of Series, DataFrame, or Panel objects
+    objs : a sequence or mapping of Series, DataFrame, or Panel objects
         If a dict is passed, the sorted keys will be used as the `keys`
         argument, unless it is passed, in which case the values will be
         selected (see below). Any None objects will be dropped silently unless
@@ -731,8 +731,8 @@ class _Concatenator(object):
     def __init__(self, objs, axis=0, join='outer', join_axes=None,
                  keys=None, levels=None, names=None,
                  ignore_index=False, verify_integrity=False, copy=True):
-        if not isinstance(objs, (list,tuple,types.GeneratorType,dict,TextFileReader)):
-            raise TypeError('first argument must be a list-like of pandas '
+        if isinstance(objs, (NDFrame, compat.string_types)):
+            raise TypeError('first argument must be an iterable of pandas '
                             'objects, you passed an object of type '
                             '"{0}"'.format(type(objs).__name__))
 


### PR DESCRIPTION
closes #8645

Enhances `pd.concat` to work with any iterable (except specifically undesired ones like pandas objects and strings). A new test is included covering tuples, lists, generator expressions, deques, and custom sequences, and all existing tests still pass. Finally, a "what's new" entry is included (not sure this last is correct - but [pull requests guidelines](https://github.com/pydata/pandas/blob/master/CONTRIBUTING.md) mentioned it)
