### PR TITLE
BUG: years-only in date_range uses current date (GH6961)

### DIFF
--- a/doc/source/whatsnew/v0.15.1.txt
+++ b/doc/source/whatsnew/v0.15.1.txt
@@ -171,3 +171,5 @@ Bug Fixes
 
 
 - Fixed a bug where plotting a column ``y`` and specifying a label would mutate the index name of the original DataFrame (:issue:`8494`)
+
+- Bug in ``date_range`` where partially-specified dates would incorporate current date (:issue:`6961`)

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -470,6 +470,12 @@ class TestDateRange(tm.TestCase):
             self.assertTrue(expected_left.equals(left))
             self.assertTrue(expected_right.equals(right))
 
+    def test_years_only(self):
+        # GH 6961
+        dr = date_range('2014', '2015', freq='M')
+        self.assertEqual(dr[0], datetime(2014, 1, 31))
+        self.assertEqual(dr[-1], datetime(2014, 12, 31))
+
 
 class TestCustomDateRange(tm.TestCase):
 


### PR DESCRIPTION
closes #6961 this was probably fixed by #7907 but just adding an explicit test and release note.
(in a sense, it should really be the 0.15.0 release note, but that release has shipped...)
