### PR TITLE
ENH: slicing with decreasing monotonic indexes

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1166,6 +1166,8 @@ Attributes
 
    Index.values
    Index.is_monotonic
+   Index.is_monotonic_increasing
+   Index.is_monotonic_decreasing
    Index.is_unique
    Index.dtype
    Index.inferred_type

--- a/doc/source/whatsnew/v0.15.1.txt
+++ b/doc/source/whatsnew/v0.15.1.txt
@@ -146,6 +146,29 @@ API changes
 
      s.dt.hour
 
+- support for slicing with monotonic decreasing indexes, even if ``start`` or ``stop`` is
+  not found in the index (:issue:`7860`):
+
+  .. ipython:: python
+
+    s = pd.Series(['a', 'b', 'c', 'd'], [4, 3, 2, 1])
+    s
+
+  previous behavior:
+
+  .. code-block:: python
+
+    In [8]: s.loc[3.5:1.5]
+    KeyError: 3.5
+
+  current behavior:
+
+  .. ipython:: python
+
+    s.loc[3.5:1.5]
+
+- added Index properties `is_monotonic_increasing` and `is_monotonic_decreasing` (:issue:`8680`).
+
 .. _whatsnew_0151.enhancements:
 
 Enhancements
@@ -208,8 +231,9 @@ Bug Fixes
 - Bug in ix/loc block splitting on setitem (manifests with integer-like dtypes, e.g. datetime64) (:issue:`8607`)
 
 
-
-
+- Bug when doing label based indexing with integers not found in the index for
+  non-unique but monotonic indexes (:issue:`8680`).
+- Bug when indexing a Float64Index with ``np.nan`` on numpy 1.7 (:issue:`8980`).
 
 
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1461,7 +1461,7 @@ class NDFrame(PandasObject):
                             name=self.index[loc])
 
         else:
-            result = self[loc]
+            result = self.iloc[loc]
             result.index = new_index
 
         # this could be a view

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -573,8 +573,22 @@ class Index(IndexOpsMixin, PandasObject):
 
     @property
     def is_monotonic(self):
-        """ return if the index has monotonic (only equaly or increasing) values """
-        return self._engine.is_monotonic
+        """ alias for is_monotonic_increasing (deprecated) """
+        return self._engine.is_monotonic_increasing
+
+    @property
+    def is_monotonic_increasing(self):
+        """ return if the index is monotonic increasing (only equal or
+        increasing) values
+        """
+        return self._engine.is_monotonic_increasing
+
+    @property
+    def is_monotonic_decreasing(self):
+        """ return if the index is monotonic decreasing (only equal or
+        decreasing values
+        """
+        return self._engine.is_monotonic_decreasing
 
     def is_lexsorted_for_tuple(self, tup):
         return True

--- a/pandas/index.pyx
+++ b/pandas/index.pyx
@@ -356,7 +356,7 @@ cdef class Int64Engine(IndexEngine):
         return _hash.Int64HashTable(n)
 
     def _call_monotonic(self, values):
-        return algos.is_monotonic_int64(values)
+        return algos.is_monotonic_int64(values, timelike=False)
 
     def get_pad_indexer(self, other, limit=None):
         return algos.pad_int64(self._get_index_values(), other,
@@ -446,7 +446,7 @@ cdef class Float64Engine(IndexEngine):
         return result
 
     def _call_monotonic(self, values):
-        return algos.is_monotonic_float64(values)
+        return algos.is_monotonic_float64(values, timelike=False)
 
     def get_pad_indexer(self, other, limit=None):
         return algos.pad_float64(self._get_index_values(), other,
@@ -500,7 +500,7 @@ cdef class ObjectEngine(IndexEngine):
         return _hash.PyObjectHashTable(n)
 
     def _call_monotonic(self, values):
-        return algos.is_monotonic_object(values)
+        return algos.is_monotonic_object(values, timelike=False)
 
     def get_pad_indexer(self, other, limit=None):
         return algos.pad_object(self._get_index_values(), other,
@@ -532,7 +532,7 @@ cdef class DatetimeEngine(Int64Engine):
         return self.vgetter().view('i8')
 
     def _call_monotonic(self, values):
-        return algos.is_monotonic_int64(values)
+        return algos.is_monotonic_int64(values, timelike=True)
 
     cpdef get_loc(self, object val):
         if is_definitely_invalid_key(val):

--- a/pandas/src/generate_code.py
+++ b/pandas/src/generate_code.py
@@ -539,7 +539,7 @@ def diff_2d_%(name)s(ndarray[%(c_type)s, ndim=2] arr,
 
 is_monotonic_template = """@cython.boundscheck(False)
 @cython.wraparound(False)
-def is_monotonic_%(name)s(ndarray[%(c_type)s] arr):
+def is_monotonic_%(name)s(ndarray[%(c_type)s] arr, bint timelike):
     '''
     Returns
     -------
@@ -554,18 +554,32 @@ def is_monotonic_%(name)s(ndarray[%(c_type)s] arr):
 
     n = len(arr)
 
-    if n < 2:
+    if n == 1:
+        if arr[0] != arr[0] or (timelike and arr[0] == iNaT):
+            # single value is NaN
+            return False, False, True
+        else:
+            return True, True, True
+    elif n < 2:
         return True, True, True
+
+    if timelike and arr[0] == iNaT:
+        return False, False, None
 
     prev = arr[0]
     for i in range(1, n):
         cur = arr[i]
+        if timelike and cur == iNaT:
+            return False, False, None
         if cur < prev:
             is_monotonic_inc = 0
         elif cur > prev:
             is_monotonic_dec = 0
         elif cur == prev:
             is_unique = 0
+        else:
+            # cur or prev is NaN
+            return False, False, None
         if not is_monotonic_inc and not is_monotonic_dec:
             return False, False, None
         prev = cur

--- a/pandas/src/generate_code.py
+++ b/pandas/src/generate_code.py
@@ -543,27 +543,33 @@ def is_monotonic_%(name)s(ndarray[%(c_type)s] arr):
     '''
     Returns
     -------
-    is_monotonic, is_unique
+    is_monotonic_inc, is_monotonic_dec, is_unique
     '''
     cdef:
         Py_ssize_t i, n
         %(c_type)s prev, cur
         bint is_unique = 1
+        bint is_monotonic_inc = 1
+        bint is_monotonic_dec = 1
 
     n = len(arr)
 
     if n < 2:
-        return True, True
+        return True, True, True
 
     prev = arr[0]
     for i in range(1, n):
         cur = arr[i]
         if cur < prev:
-            return False, None
+            is_monotonic_inc = 0
+        elif cur > prev:
+            is_monotonic_dec = 0
         elif cur == prev:
             is_unique = 0
+        if not is_monotonic_inc and not is_monotonic_dec:
+            return False, False, None
         prev = cur
-    return True, is_unique
+    return is_monotonic_inc, is_monotonic_dec, is_unique
 """
 
 map_indices_template = """@cython.wraparound(False)

--- a/pandas/src/generated.pyx
+++ b/pandas/src/generated.pyx
@@ -1799,7 +1799,7 @@ def backfill_2d_inplace_bool(ndarray[uint8_t, ndim=2] values,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def is_monotonic_float64(ndarray[float64_t] arr):
+def is_monotonic_float64(ndarray[float64_t] arr, bint timelike):
     '''
     Returns
     -------
@@ -1814,25 +1814,39 @@ def is_monotonic_float64(ndarray[float64_t] arr):
 
     n = len(arr)
 
-    if n < 2:
+    if n == 1:
+        if arr[0] != arr[0] or (timelike and arr[0] == iNaT):
+            # single value is NaN
+            return False, False, True
+        else:
+            return True, True, True
+    elif n < 2:
         return True, True, True
+
+    if timelike and arr[0] == iNaT:
+        return False, False, None
 
     prev = arr[0]
     for i in range(1, n):
         cur = arr[i]
+        if timelike and cur == iNaT:
+            return False, False, None
         if cur < prev:
             is_monotonic_inc = 0
         elif cur > prev:
             is_monotonic_dec = 0
         elif cur == prev:
             is_unique = 0
+        else:
+            # cur or prev is NaN
+            return False, False, None
         if not is_monotonic_inc and not is_monotonic_dec:
             return False, False, None
         prev = cur
     return is_monotonic_inc, is_monotonic_dec, is_unique
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def is_monotonic_float32(ndarray[float32_t] arr):
+def is_monotonic_float32(ndarray[float32_t] arr, bint timelike):
     '''
     Returns
     -------
@@ -1847,25 +1861,39 @@ def is_monotonic_float32(ndarray[float32_t] arr):
 
     n = len(arr)
 
-    if n < 2:
+    if n == 1:
+        if arr[0] != arr[0] or (timelike and arr[0] == iNaT):
+            # single value is NaN
+            return False, False, True
+        else:
+            return True, True, True
+    elif n < 2:
         return True, True, True
+
+    if timelike and arr[0] == iNaT:
+        return False, False, None
 
     prev = arr[0]
     for i in range(1, n):
         cur = arr[i]
+        if timelike and cur == iNaT:
+            return False, False, None
         if cur < prev:
             is_monotonic_inc = 0
         elif cur > prev:
             is_monotonic_dec = 0
         elif cur == prev:
             is_unique = 0
+        else:
+            # cur or prev is NaN
+            return False, False, None
         if not is_monotonic_inc and not is_monotonic_dec:
             return False, False, None
         prev = cur
     return is_monotonic_inc, is_monotonic_dec, is_unique
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def is_monotonic_object(ndarray[object] arr):
+def is_monotonic_object(ndarray[object] arr, bint timelike):
     '''
     Returns
     -------
@@ -1880,25 +1908,39 @@ def is_monotonic_object(ndarray[object] arr):
 
     n = len(arr)
 
-    if n < 2:
+    if n == 1:
+        if arr[0] != arr[0] or (timelike and arr[0] == iNaT):
+            # single value is NaN
+            return False, False, True
+        else:
+            return True, True, True
+    elif n < 2:
         return True, True, True
+
+    if timelike and arr[0] == iNaT:
+        return False, False, None
 
     prev = arr[0]
     for i in range(1, n):
         cur = arr[i]
+        if timelike and cur == iNaT:
+            return False, False, None
         if cur < prev:
             is_monotonic_inc = 0
         elif cur > prev:
             is_monotonic_dec = 0
         elif cur == prev:
             is_unique = 0
+        else:
+            # cur or prev is NaN
+            return False, False, None
         if not is_monotonic_inc and not is_monotonic_dec:
             return False, False, None
         prev = cur
     return is_monotonic_inc, is_monotonic_dec, is_unique
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def is_monotonic_int32(ndarray[int32_t] arr):
+def is_monotonic_int32(ndarray[int32_t] arr, bint timelike):
     '''
     Returns
     -------
@@ -1913,25 +1955,39 @@ def is_monotonic_int32(ndarray[int32_t] arr):
 
     n = len(arr)
 
-    if n < 2:
+    if n == 1:
+        if arr[0] != arr[0] or (timelike and arr[0] == iNaT):
+            # single value is NaN
+            return False, False, True
+        else:
+            return True, True, True
+    elif n < 2:
         return True, True, True
+
+    if timelike and arr[0] == iNaT:
+        return False, False, None
 
     prev = arr[0]
     for i in range(1, n):
         cur = arr[i]
+        if timelike and cur == iNaT:
+            return False, False, None
         if cur < prev:
             is_monotonic_inc = 0
         elif cur > prev:
             is_monotonic_dec = 0
         elif cur == prev:
             is_unique = 0
+        else:
+            # cur or prev is NaN
+            return False, False, None
         if not is_monotonic_inc and not is_monotonic_dec:
             return False, False, None
         prev = cur
     return is_monotonic_inc, is_monotonic_dec, is_unique
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def is_monotonic_int64(ndarray[int64_t] arr):
+def is_monotonic_int64(ndarray[int64_t] arr, bint timelike):
     '''
     Returns
     -------
@@ -1946,25 +2002,39 @@ def is_monotonic_int64(ndarray[int64_t] arr):
 
     n = len(arr)
 
-    if n < 2:
+    if n == 1:
+        if arr[0] != arr[0] or (timelike and arr[0] == iNaT):
+            # single value is NaN
+            return False, False, True
+        else:
+            return True, True, True
+    elif n < 2:
         return True, True, True
+
+    if timelike and arr[0] == iNaT:
+        return False, False, None
 
     prev = arr[0]
     for i in range(1, n):
         cur = arr[i]
+        if timelike and cur == iNaT:
+            return False, False, None
         if cur < prev:
             is_monotonic_inc = 0
         elif cur > prev:
             is_monotonic_dec = 0
         elif cur == prev:
             is_unique = 0
+        else:
+            # cur or prev is NaN
+            return False, False, None
         if not is_monotonic_inc and not is_monotonic_dec:
             return False, False, None
         prev = cur
     return is_monotonic_inc, is_monotonic_dec, is_unique
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def is_monotonic_bool(ndarray[uint8_t] arr):
+def is_monotonic_bool(ndarray[uint8_t] arr, bint timelike):
     '''
     Returns
     -------
@@ -1979,18 +2049,32 @@ def is_monotonic_bool(ndarray[uint8_t] arr):
 
     n = len(arr)
 
-    if n < 2:
+    if n == 1:
+        if arr[0] != arr[0] or (timelike and arr[0] == iNaT):
+            # single value is NaN
+            return False, False, True
+        else:
+            return True, True, True
+    elif n < 2:
         return True, True, True
+
+    if timelike and arr[0] == iNaT:
+        return False, False, None
 
     prev = arr[0]
     for i in range(1, n):
         cur = arr[i]
+        if timelike and cur == iNaT:
+            return False, False, None
         if cur < prev:
             is_monotonic_inc = 0
         elif cur > prev:
             is_monotonic_dec = 0
         elif cur == prev:
             is_unique = 0
+        else:
+            # cur or prev is NaN
+            return False, False, None
         if not is_monotonic_inc and not is_monotonic_dec:
             return False, False, None
         prev = cur

--- a/pandas/src/generated.pyx
+++ b/pandas/src/generated.pyx
@@ -1803,162 +1803,198 @@ def is_monotonic_float64(ndarray[float64_t] arr):
     '''
     Returns
     -------
-    is_monotonic, is_unique
+    is_monotonic_inc, is_monotonic_dec, is_unique
     '''
     cdef:
         Py_ssize_t i, n
         float64_t prev, cur
         bint is_unique = 1
+        bint is_monotonic_inc = 1
+        bint is_monotonic_dec = 1
 
     n = len(arr)
 
     if n < 2:
-        return True, True
+        return True, True, True
 
     prev = arr[0]
     for i in range(1, n):
         cur = arr[i]
         if cur < prev:
-            return False, None
+            is_monotonic_inc = 0
+        elif cur > prev:
+            is_monotonic_dec = 0
         elif cur == prev:
             is_unique = 0
+        if not is_monotonic_inc and not is_monotonic_dec:
+            return False, False, None
         prev = cur
-    return True, is_unique
+    return is_monotonic_inc, is_monotonic_dec, is_unique
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def is_monotonic_float32(ndarray[float32_t] arr):
     '''
     Returns
     -------
-    is_monotonic, is_unique
+    is_monotonic_inc, is_monotonic_dec, is_unique
     '''
     cdef:
         Py_ssize_t i, n
         float32_t prev, cur
         bint is_unique = 1
+        bint is_monotonic_inc = 1
+        bint is_monotonic_dec = 1
 
     n = len(arr)
 
     if n < 2:
-        return True, True
+        return True, True, True
 
     prev = arr[0]
     for i in range(1, n):
         cur = arr[i]
         if cur < prev:
-            return False, None
+            is_monotonic_inc = 0
+        elif cur > prev:
+            is_monotonic_dec = 0
         elif cur == prev:
             is_unique = 0
+        if not is_monotonic_inc and not is_monotonic_dec:
+            return False, False, None
         prev = cur
-    return True, is_unique
+    return is_monotonic_inc, is_monotonic_dec, is_unique
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def is_monotonic_object(ndarray[object] arr):
     '''
     Returns
     -------
-    is_monotonic, is_unique
+    is_monotonic_inc, is_monotonic_dec, is_unique
     '''
     cdef:
         Py_ssize_t i, n
         object prev, cur
         bint is_unique = 1
+        bint is_monotonic_inc = 1
+        bint is_monotonic_dec = 1
 
     n = len(arr)
 
     if n < 2:
-        return True, True
+        return True, True, True
 
     prev = arr[0]
     for i in range(1, n):
         cur = arr[i]
         if cur < prev:
-            return False, None
+            is_monotonic_inc = 0
+        elif cur > prev:
+            is_monotonic_dec = 0
         elif cur == prev:
             is_unique = 0
+        if not is_monotonic_inc and not is_monotonic_dec:
+            return False, False, None
         prev = cur
-    return True, is_unique
+    return is_monotonic_inc, is_monotonic_dec, is_unique
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def is_monotonic_int32(ndarray[int32_t] arr):
     '''
     Returns
     -------
-    is_monotonic, is_unique
+    is_monotonic_inc, is_monotonic_dec, is_unique
     '''
     cdef:
         Py_ssize_t i, n
         int32_t prev, cur
         bint is_unique = 1
+        bint is_monotonic_inc = 1
+        bint is_monotonic_dec = 1
 
     n = len(arr)
 
     if n < 2:
-        return True, True
+        return True, True, True
 
     prev = arr[0]
     for i in range(1, n):
         cur = arr[i]
         if cur < prev:
-            return False, None
+            is_monotonic_inc = 0
+        elif cur > prev:
+            is_monotonic_dec = 0
         elif cur == prev:
             is_unique = 0
+        if not is_monotonic_inc and not is_monotonic_dec:
+            return False, False, None
         prev = cur
-    return True, is_unique
+    return is_monotonic_inc, is_monotonic_dec, is_unique
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def is_monotonic_int64(ndarray[int64_t] arr):
     '''
     Returns
     -------
-    is_monotonic, is_unique
+    is_monotonic_inc, is_monotonic_dec, is_unique
     '''
     cdef:
         Py_ssize_t i, n
         int64_t prev, cur
         bint is_unique = 1
+        bint is_monotonic_inc = 1
+        bint is_monotonic_dec = 1
 
     n = len(arr)
 
     if n < 2:
-        return True, True
+        return True, True, True
 
     prev = arr[0]
     for i in range(1, n):
         cur = arr[i]
         if cur < prev:
-            return False, None
+            is_monotonic_inc = 0
+        elif cur > prev:
+            is_monotonic_dec = 0
         elif cur == prev:
             is_unique = 0
+        if not is_monotonic_inc and not is_monotonic_dec:
+            return False, False, None
         prev = cur
-    return True, is_unique
+    return is_monotonic_inc, is_monotonic_dec, is_unique
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def is_monotonic_bool(ndarray[uint8_t] arr):
     '''
     Returns
     -------
-    is_monotonic, is_unique
+    is_monotonic_inc, is_monotonic_dec, is_unique
     '''
     cdef:
         Py_ssize_t i, n
         uint8_t prev, cur
         bint is_unique = 1
+        bint is_monotonic_inc = 1
+        bint is_monotonic_dec = 1
 
     n = len(arr)
 
     if n < 2:
-        return True, True
+        return True, True, True
 
     prev = arr[0]
     for i in range(1, n):
         cur = arr[i]
         if cur < prev:
-            return False, None
+            is_monotonic_inc = 0
+        elif cur > prev:
+            is_monotonic_dec = 0
         elif cur == prev:
             is_unique = 0
+        if not is_monotonic_inc and not is_monotonic_dec:
+            return False, False, None
         prev = cur
-    return True, is_unique
+    return is_monotonic_inc, is_monotonic_dec, is_unique
 
 @cython.wraparound(False)
 @cython.boundscheck(False)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -866,7 +866,7 @@ class CheckIndexing(object):
         assert_frame_equal(result2, expected)
 
         # non-monotonic, raise KeyError
-        df2 = df[::-1]
+        df2 = df.iloc[lrange(5) + lrange(5, 10)[::-1]]
         self.assertRaises(KeyError, df2.ix.__getitem__, slice(3, 11))
         self.assertRaises(KeyError, df2.ix.__setitem__, slice(3, 11), 0)
 

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -922,6 +922,7 @@ class TestIndex(Base, tm.TestCase):
     def test_is_monotonic_incomparable(self):
         index = Index([5, datetime.now(), 7])
         self.assertFalse(index.is_monotonic)
+        self.assertFalse(index.is_monotonic_decreasing)
 
     def test_get_set_value(self):
         values = np.random.randn(100)
@@ -1403,9 +1404,17 @@ class TestInt64Index(Numeric, tm.TestCase):
 
     def test_is_monotonic(self):
         self.assertTrue(self.index.is_monotonic)
+        self.assertTrue(self.index.is_monotonic_increasing)
+        self.assertFalse(self.index.is_monotonic_decreasing)
 
         index = Int64Index([4, 3, 2, 1])
         self.assertFalse(index.is_monotonic)
+        self.assertTrue(index.is_monotonic_decreasing)
+
+        index = Int64Index([1])
+        self.assertTrue(index.is_monotonic)
+        self.assertTrue(index.is_monotonic_increasing)
+        self.assertTrue(index.is_monotonic_decreasing)
 
     def test_equals(self):
         same_values = Index(self.index, dtype=object)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1544,7 +1544,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
     def test_ix_getitem_not_monotonic(self):
         d1, d2 = self.ts.index[[5, 15]]
 
-        ts2 = self.ts[::2][::-1]
+        ts2 = self.ts[::2][[1, 2, 0]]
 
         self.assertRaises(KeyError, ts2.ix.__getitem__, slice(d1, d2))
         self.assertRaises(KeyError, ts2.ix.__setitem__, slice(d1, d2), 0)
@@ -1570,7 +1570,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         assert_series_equal(result2, expected)
 
         # non-monotonic, raise KeyError
-        s2 = s[::-1]
+        s2 = s.iloc[lrange(5) + lrange(5, 10)[::-1]]
         self.assertRaises(KeyError, s2.ix.__getitem__, slice(3, 11))
         self.assertRaises(KeyError, s2.ix.__setitem__, slice(3, 11), 0)
 

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -85,7 +85,7 @@ class TestDatetimeIndexOps(Ops):
     def test_minmax(self):
         for tz in self.tz:
             # monotonic
-            idx1 = pd.DatetimeIndex([pd.NaT, '2011-01-01', '2011-01-02',
+            idx1 = pd.DatetimeIndex(['2011-01-01', '2011-01-02',
                                      '2011-01-03'], tz=tz)
             self.assertTrue(idx1.is_monotonic)
 
@@ -305,7 +305,7 @@ class TestTimedeltaIndexOps(Ops):
     def test_minmax(self):
 
         # monotonic
-        idx1 = TimedeltaIndex(['nat', '1 days', '2 days', '3 days'])
+        idx1 = TimedeltaIndex(['1 days', '2 days', '3 days'])
         self.assertTrue(idx1.is_monotonic)
 
         # non-monotonic


### PR DESCRIPTION
Fixes #7860 

The first commit adds `Index.is_monotonic_decreasing` and `Index.is_monotonic_increasing` (alias for `is_monotonic`).

`is_monotonic` will have a performance degradation (still O(n) time) in cases where the Index is decreasing monotonic. If necessary, we could work around this, but I think we can probably get away with this because the fall-back options are much slower and in many cases (e.g., for slice indexing) the next thing we'll want to know is if it's decreasing monotonic, anyways.

Next up will be handling indexing monotonic decreasing indexes with reversed slices, e.g., `s.loc[30:10]`.

CC @jreback @hugadams @immerrr (thank you, specialities wiki!)
