### PR TITLE
BUG: fix Categorical comparison to work with datetime

### DIFF
--- a/doc/source/whatsnew/v0.15.1.txt
+++ b/doc/source/whatsnew/v0.15.1.txt
@@ -156,6 +156,7 @@ Bug Fixes
 - Bug in ``Categorical`` not created properly with ``Series.to_frame()`` (:issue:`8626`)
 - Bug in coercing in astype of a ``Categorical`` of a passed ``pd.Categorical`` (this now raises ``TypeError`` correctly), (:issue:`8626`)
 - Bug in ``cut``/``qcut`` when using ``Series`` and ``retbins=True`` (:issue:`8589`)
+- Bug in comparing ``Categorical`` of datetime raising when being compared to a scalar datetime (:issue:`8687`)
 
 
 
@@ -165,7 +166,7 @@ Bug Fixes
 
 
 
-- Bug in numeric index operations of add/sub with Float/Index Index with numpy arrays (:issue:`8608`
+- Bug in numeric index operations of add/sub with Float/Index Index with numpy arrays (:issue:`8608`)
 - Bug in setitem with empty indexer and unwanted coercion of dtypes (:issue:`8669`)
 
 

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -4,7 +4,7 @@ import numpy as np
 from warnings import warn
 import types
 
-from pandas import compat
+from pandas import compat, lib
 from pandas.compat import u
 
 from pandas.core.algorithms import factorize
@@ -42,7 +42,7 @@ def _cat_compare_op(op):
                 # In other series, the leads to False, so do that here too
                 ret[na_mask] = False
             return ret
-        elif np.isscalar(other):
+        elif lib.isscalar(other):
             if other in self.categories:
                 i = self.categories.get_loc(other)
                 return getattr(self._codes, op)(i)

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -912,6 +912,11 @@ class TestCategorical(tm.TestCase):
 
         self.assertFalse(LooseVersion(pd.__version__) >= '0.18')
 
+    def test_datetime_categorical_comparison(self):
+        dt_cat = pd.Categorical(pd.date_range('2014-01-01', periods=3))
+        self.assert_numpy_array_equal(dt_cat > dt_cat[0], [False, True, True])
+        self.assert_numpy_array_equal(dt_cat[0] < dt_cat, [False, True, True])
+
 
 class TestCategoricalAsBlock(tm.TestCase):
     _multiprocess_can_split_ = True


### PR DESCRIPTION
`pd.Timestamp` is one of types that don't pass `np.isscalar` test previously
used in _cat_compare_op, `pd.lib.isscalar` should be used instead.

``` python
In [1]: cat = pd.Categorical(pd.date_range('2014', periods=5))

In [2]: cat > cat[0]
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-77883e4783fe> in <module>()
----> 1 cat > cat[0]

/home/dshpektorov/sources/pandas/pandas/core/categorical.py in f(self, other)
     52             msg = "Cannot compare a Categorical for op {op} with type {typ}. If you want to \n" \
     53                   "compare values, use 'np.asarray(cat) <op> other'."
---> 54             raise TypeError(msg.format(op=op,typ=type(other)))
     55 
     56     f.__name__ = op

TypeError: Cannot compare a Categorical for op __gt__ with type <class 'pandas.tslib.Timestamp'>. If you want to 
compare values, use 'np.asarray(cat) <op> other'.

```
