### PR TITLE
VIS: register datetime64 in matplotlib units registry (GH8614)

### DIFF
--- a/doc/source/whatsnew/v0.15.0.txt
+++ b/doc/source/whatsnew/v0.15.0.txt
@@ -801,21 +801,8 @@ a transparent change with only very limited API implications (:issue:`5080`, :is
 - MultiIndexes will now raise similary to other pandas objects w.r.t. truth testing, see :ref:`here <gotchas.truth>` (:issue:`7897`).
 - When plotting a DatetimeIndex directly with matplotlib's `plot` function,
   the axis labels will no longer be formatted as dates but as integers (the
-  internal representation of a ``datetime64``). To keep the old behaviour you
-  should add the :meth:`~DatetimeIndex.to_pydatetime()` method:
-
-  .. code-block:: python
-
-      import matplotlib.pyplot as plt
-      df = pd.DataFrame({'col': np.random.randint(1, 50, 60)},
-                        index=pd.date_range("2012-01-01", periods=60))
-
-      # this will now format the x axis labels as integers
-      plt.plot(df.index, df['col'])
-
-      # to keep the date formating, convert the index explicitely to python datetime values
-      plt.plot(df.index.to_pydatetime(), df['col'])
-
+  internal representation of a ``datetime64``). **UPDATE** This is fixed
+  in 0.15.1, see :ref:`here <whatsnew_0151.datetime64_plotting>`.
 
 .. _whatsnew_0150.deprecations:
 

--- a/doc/source/whatsnew/v0.15.1.txt
+++ b/doc/source/whatsnew/v0.15.1.txt
@@ -169,6 +169,7 @@ API changes
 
 - added Index properties `is_monotonic_increasing` and `is_monotonic_decreasing` (:issue:`8680`).
 
+
 .. note:: io.data.Options has been fixed for a change in the format of the Yahoo Options page (:issue:`8612`)
 
   As a result of a change in Yahoo's option page layout, when an expiry date is given,
@@ -201,6 +202,15 @@ API changes
      aapl.get_near_stock_price(expiry=aapl.expiry_dates[0:3]).iloc[0:5,0:1]
 
   See the Options documentation in :ref:`Remote Data  <remote_data.yahoo_options>`
+
+.. _whatsnew_0151.datetime64_plotting:
+
+- pandas now also registers the ``datetime64`` dtype in matplotlib's units registry
+  to plot such values as datetimes. This is activated once pandas is imported. In
+  previous versions, plotting an array of ``datetime64`` values will have resulted
+  in plotted integer values. To keep the previous behaviour, you can do
+  ``del matplotlib.units.registry[np.datetime64]`` (:issue:`8614`).
+
 
 .. _whatsnew_0151.enhancements:
 
@@ -283,8 +293,15 @@ Bug Fixes
 
 
 
+<<<<<<< HEAD
 - Fixed a bug where plotting a column ``y`` and specifying a label would mutate the index name of the original DataFrame (:issue:`8494`)
 
 - Bug in ``date_range`` where partially-specified dates would incorporate current date (:issue:`6961`)
 
 - Bug in Setting by indexer to a scalar value with a mixed-dtype `Panel4d` was failing (:issue:`8702`)
+=======
+- Fixed a bug where plotting a column ``y`` and specifying a label
+would mutate the index name of the DataFrame ``y`` came from (:issue:`8494`)
+
+- Fix regression in plotting of a DatetimeIndex directly with matplotlib (:issue:`8614`).
+>>>>>>> VIS: register datetime64 in matplotlib units registry (GH8614)

--- a/pandas/tseries/converter.py
+++ b/pandas/tseries/converter.py
@@ -30,6 +30,7 @@ def register():
     units.registry[pydt.datetime] = DatetimeConverter()
     units.registry[pydt.date] = DatetimeConverter()
     units.registry[pydt.time] = TimeConverter()
+    units.registry[np.datetime64] = DatetimeConverter()
 
 
 def _to_ordinalf(tm):
@@ -165,6 +166,8 @@ class DatetimeConverter(dates.DateConverter):
 
         if isinstance(values, (datetime, pydt.date)):
             return _dt_to_float_ordinal(values)
+        elif isinstance(values, np.datetime64):
+            return _dt_to_float_ordinal(lib.Timestamp(values))
         elif isinstance(values, pydt.time):
             return dates.date2num(values)
         elif (com.is_integer(values) or com.is_float(values)):

--- a/pandas/tseries/tests/test_converter.py
+++ b/pandas/tseries/tests/test_converter.py
@@ -52,6 +52,17 @@ class TestDateTimeConverter(tm.TestCase):
         rs = self.dtc.convert(Timestamp('2012-1-1'), None, None)
         self.assertEqual(rs, xp)
 
+        # also testing datetime64 dtype (GH8614)
+        rs = self.dtc.convert(np.datetime64('2012-01-01'), None, None)
+        self.assertEqual(rs, xp)
+
+        rs = self.dtc.convert(np.datetime64('2012-01-01 00:00:00+00:00'), None, None)
+        self.assertEqual(rs, xp)
+
+        rs = self.dtc.convert(np.array([np.datetime64('2012-01-01 00:00:00+00:00'),
+                                        np.datetime64('2012-01-02 00:00:00+00:00')]), None, None)
+        self.assertEqual(rs[0], xp)
+
     def test_conversion_float(self):
         decimals = 9
 


### PR DESCRIPTION
Closes #8614 
