### PR TITLE
BUG: setitem fails on mixed-type Panel4D

### DIFF
--- a/doc/source/whatsnew/v0.15.1.txt
+++ b/doc/source/whatsnew/v0.15.1.txt
@@ -227,3 +227,5 @@ Bug Fixes
 - Fixed a bug where plotting a column ``y`` and specifying a label would mutate the index name of the original DataFrame (:issue:`8494`)
 
 - Bug in ``date_range`` where partially-specified dates would incorporate current date (:issue:`6961`)
+
+- Setting by indexer to a scalar value with a mixed-dtype `Panel4d` was failing (:issue: `8702`)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -355,7 +355,7 @@ class _NDFrameIndexer(object):
             # if we have a partial multiindex, then need to adjust the plane
             # indexer here
             if (len(labels) == 1 and
-                    isinstance(self.obj[labels[0]].index, MultiIndex)):
+                    isinstance(self.obj[labels[0]].axes[0], MultiIndex)):
                 item = labels[0]
                 obj = self.obj[item]
                 index = obj.index

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -372,6 +372,53 @@ class CheckIndexing(object):
         self.panel4d['lP'] = self.panel4d['l1'] > 0
         self.assertEqual(self.panel4d['lP'].values.dtype, np.bool_)
 
+    def test_setitem_by_indexer(self):
+
+        # Panel
+        panel4dc = self.panel4d.copy()
+        p = panel4dc.iloc[0]
+        def func():
+            self.panel4d.iloc[0] = p
+        self.assertRaises(NotImplementedError, func)
+
+        # DataFrame
+        panel4dc = self.panel4d.copy()
+        df = panel4dc.iloc[0,0]
+        df.iloc[:] = 1
+        panel4dc.iloc[0,0] = df
+        self.assertTrue((panel4dc.iloc[0,0].values == 1).all())
+
+        # Series
+        panel4dc = self.panel4d.copy()
+        s = panel4dc.iloc[0,0,:,0]
+        s.iloc[:] = 1
+        panel4dc.iloc[0,0,:,0] = s
+        self.assertTrue((panel4dc.iloc[0,0,:,0].values == 1).all())
+
+        # scalar
+        panel4dc = self.panel4d.copy()
+        panel4dc.iloc[0] = 1
+        panel4dc.iloc[1] = True
+        panel4dc.iloc[2] = 'foo'
+        self.assertTrue((panel4dc.iloc[0].values == 1).all())
+        self.assertTrue(panel4dc.iloc[1].values.all())
+        self.assertTrue((panel4dc.iloc[2].values == 'foo').all())
+
+    def test_setitem_by_indexer_mixed_type(self):
+        # GH 8702
+        self.panel4d['foo'] = 'bar'
+
+        # scalar
+        panel4dc = self.panel4d.copy()
+        panel4dc.iloc[0] = 1
+        panel4dc.iloc[1] = True
+        panel4dc.iloc[2] = 'foo'
+        self.assertTrue((panel4dc.iloc[0].values == 1).all())
+        self.assertTrue(panel4dc.iloc[1].values.all())
+        self.assertTrue((panel4dc.iloc[2].values == 'foo').all())
+
+
+
     def test_comparisons(self):
         p1 = tm.makePanel4D()
         p2 = tm.makePanel4D()


### PR DESCRIPTION
Trying to set a value on a mixed-type Panel4D currently fails:

```
In [1]: from pandas.util import testing as tmd

In [2]: p4d = tmd.makePanel4D()

In [3]: p4d['foo'] = 'bar'

In [4]: p4d.iloc[0,0,0,0] = 0
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-4-bb74b95f7244> in <module>()
----> 1 p4d.iloc[0,0,0,0] = 0

/home/stahlous/pd_dev/pandas/pandas/core/indexing.py in __setitem__(self, key, value)
    119                 indexer = self._convert_to_indexer(key, is_setter=True)
    120
--> 121         self._setitem_with_indexer(indexer, value)
    122
    123     def _has_valid_type(self, k, axis):

/home/stahlous/pd_dev/pandas/pandas/core/indexing.py in _setitem_with_indexer(self, indexer, value)
    356             # indexer here
    357             if (len(labels) == 1 and
--> 358                     isinstance(self.obj[labels[0]].index, MultiIndex)):
    359                 item = labels[0]
    360                 obj = self.obj[item]

/home/stahlous/pd_dev/pandas/pandas/core/generic.py in __getattr__(self, name)
   1927         """
   1928         if name in self._internal_names_set:
-> 1929             return object.__getattribute__(self, name)
   1930         elif name in self._metadata:
   1931             return object.__getattribute__(self, name)

AttributeError: 'Panel' object has no attribute 'index'
```

Fortunately, it looks like a simple fix. If this looks OK. I'll add a note to `v0.15.1.txt` (doesn't have a GH issue number yet).

This fix is needed for my latest attempt at the fillna bug #8395.
