### PR TITLE
ENH: read_csv dialect parameter can take a string (GH8703)

### DIFF
--- a/doc/source/whatsnew/v0.15.1.txt
+++ b/doc/source/whatsnew/v0.15.1.txt
@@ -213,6 +213,7 @@ Bug Fixes
 - Bug in ``Categorical`` reflected comparison operator raising if the first argument was a numpy array scalar (e.g. np.int64) (:issue:`8658`)
 - Bug in Panel indexing with a list-like (:issue:`8710`)
 - Compat issue is ``DataFrame.dtypes`` when ``options.mode.use_inf_as_null`` is True (:issue:`8722`)
+- Bug in ``read_csv``, ``dialect`` parameter would not take a string (:issue: `8703`)
 
 
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -526,6 +526,8 @@ class TextFileReader(object):
 
         if kwds.get('dialect') is not None:
             dialect = kwds['dialect']
+            if dialect in csv.list_dialects():
+                dialect = csv.get_dialect(dialect)
             kwds['delimiter'] = dialect.delimiter
             kwds['doublequote'] = dialect.doublequote
             kwds['escapechar'] = dialect.escapechar

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -191,6 +191,21 @@ index2,b,d,f
         exp.replace('a', '"a', inplace=True)
         tm.assert_frame_equal(df, exp)
 
+    def test_dialect_str(self):
+        data = """\
+fruit:vegetable
+apple:brocolli
+pear:tomato
+"""
+        exp = DataFrame({
+            'fruit': ['apple', 'pear'],
+            'vegetable': ['brocolli', 'tomato']
+        })
+        dia = csv.register_dialect('mydialect', delimiter=':')
+        df = self.read_csv(StringIO(data), dialect='mydialect')
+        tm.assert_frame_equal(df, exp)
+        csv.unregister_dialect('mydialect')
+
     def test_1000_sep(self):
         data = """A|B|C
 1|2,334|5


### PR DESCRIPTION
Closes #8703

I wasn't sure where to put the test, hopefully this is right.

Follow-up of #8718
