### PR TITLE
BUG: The 'jobComplete' key may be present but False in the BigQuery query results

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -197,3 +197,5 @@ Bug Fixes
 - Fixed issue in the ``xlsxwriter`` engine where it added a default 'General' format to cells if no other format wass applied. This prevented other row or column formatting being applied. (:issue:`9167`)
 - Fixes issue with ``index_col=False`` when ``usecols`` is also specified in ``read_csv``. (:issue:`9082`)
 - Bug where ``wide_to_long`` would modify the input stubnames list (:issue:`9204`)
+
+- Bug in the Google BigQuery reader where the 'jobComplete' key may be present but False in the query results (:issue:`8728`)

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -185,7 +185,7 @@ class GbqConnector:
 
         job_reference = query_reply['jobReference']
 
-        while(not 'jobComplete' in query_reply):
+        while(not query_reply.get('jobComplete', False)):
             print('Job not yet complete...')
             query_reply = job_collection.getQueryResults(
                             projectId=job_reference['projectId'],


### PR DESCRIPTION
xref #9141 

Fixes an issue when looking for 'totalRows' on a large dataset that is not finished in between two subsequent checks.
