### PR TITLE
BUG: Bug in slicing a multi-index level with an empty-list (GH8737)

### DIFF
--- a/doc/source/whatsnew/v0.15.1.txt
+++ b/doc/source/whatsnew/v0.15.1.txt
@@ -246,7 +246,7 @@ Bug Fixes
 - Bug in ``Categorical`` reflected comparison operator raising if the first argument was a numpy array scalar (e.g. np.int64) (:issue:`8658`)
 - Bug in Panel indexing with a list-like (:issue:`8710`)
 - Compat issue is ``DataFrame.dtypes`` when ``options.mode.use_inf_as_null`` is True (:issue:`8722`)
-
+- Bug in slicing a multi-index level with an empty-list (:issue:`8737`)
 
 
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -4147,8 +4147,10 @@ class MultiIndex(Index):
 
                         # ignore not founds
                         continue
-
-                ranges.append(reduce(np.logical_or,indexers))
+                if len(k):
+                    ranges.append(reduce(np.logical_or,indexers))
+                else:
+                    ranges.append(tuple([]))
 
             elif _is_null_slice(k):
                 # empty slice

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -2133,6 +2133,16 @@ class TestIndexing(tm.TestCase):
         result = s.loc[idx[:,['foo','bah']]]
         assert_series_equal(result,expected)
 
+        # GH 8737
+        # empty indexer
+        multi_index = pd.MultiIndex.from_product((['foo', 'bar', 'baz'], ['alpha', 'beta']))
+        df = DataFrame(np.random.randn(5, 6), index=range(5), columns=multi_index)
+        df = df.sortlevel(0, axis=1)
+
+        result = df.loc[:, ([], slice(None))]
+        expected = DataFrame(index=range(5),columns=multi_index.reindex([])[0])
+        assert_frame_equal(result, expected)
+
         # regression from < 0.14.0
         # GH 7914
         df = DataFrame([[np.mean, np.median],['mean','median']],


### PR DESCRIPTION
closes #8737 

```
In [5]: multi_index = pd.MultiIndex.from_product((['foo', 'bar', 'baz'], ['alpha', 'beta']))

In [6]: df = DataFrame(np.random.randn(5, 6), index=range(5), columns=multi_index).sortlevel(0,axis=1) 

In [7]: df
Out[7]: 
        bar                 baz                 foo          
      alpha      beta     alpha      beta     alpha      beta
0 -0.725086 -0.715498  1.141087 -0.586018  0.906581 -0.260218
1 -1.111794 -0.393149  2.101567  0.648850  0.366892  0.554206
2  1.258239  1.472659 -0.174970 -0.355639 -0.843127  1.101716
3 -0.775790  0.419361 -0.521444  1.245519  0.759791  0.183877
4 -0.001001 -1.526741 -1.721501  0.527531  0.407099 -0.415245

In [8]: df.loc[:, ([], slice(None))] 
Out[8]: 
Empty DataFrame
Columns: []
Index: [0, 1, 2, 3, 4]

In [9]: df.loc[:, ([], slice(None))].columns
Out[9]: 
MultiIndex(levels=[[u'bar', u'baz', u'foo'], [u'alpha', u'beta']],
           labels=[[], []])
```
