### PR TITLE
Update tokenizer to fix #8679 #8661

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -74,6 +74,7 @@ Enhancements
 
 Performance
 ~~~~~~~~~~~
+- Reduce memory usage when skiprows is an integer in read_csv (:issue:`8681`)
 
 .. _whatsnew_0152.experimental:
 
@@ -155,3 +156,4 @@ Bug Fixes
   of the level names are numbers (:issue:`8584`).
 - Bug in ``MultiIndex`` where ``__contains__`` returns wrong result if index is
   not lexically sorted or unique (:issue:`7724`)
+- BUG CSV: fix problem with trailing whitespace in skipped rows, (:issue:`8679`), (:issue:`8661`)

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -3048,6 +3048,29 @@ A,B,C
         df = self.read_csv(StringIO(data), comment='#', skiprows=4)
         tm.assert_almost_equal(df.values, expected)
 
+    def test_trailing_spaces(self):
+        data = """skip
+random line with trailing spaces    
+skip
+1,2,3
+1,2.,4.
+random line with trailing tabs\t\t\t
+     
+5.,NaN,10.0
+"""
+        expected = pd.DataFrame([[1., 2., 4.],
+                    [5., np.nan, 10.]])
+        # this should ignore six lines including lines with trailing 
+        # whitespace and blank lines.  issues 8661, 8679
+        df = self.read_csv(StringIO(data.replace(',', '  ')), 
+                           header=None, delim_whitespace=True,
+                           skiprows=[0,1,2,3,5,6], skip_blank_lines=True)
+        tm.assert_frame_equal(df, expected)
+        df = self.read_table(StringIO(data.replace(',', '  ')), 
+                             header=None, delim_whitespace=True,
+                             skiprows=[0,1,2,3,5,6], skip_blank_lines=True)
+        tm.assert_frame_equal(df, expected)
+
     def test_comment_header(self):
         data = """# empty
 # second empty line

--- a/pandas/parser.pyx
+++ b/pandas/parser.pyx
@@ -86,6 +86,7 @@ cdef extern from "parser/tokenizer.h":
         EAT_COMMENT
         EAT_LINE_COMMENT
         WHITESPACE_LINE
+        SKIP_LINE
         FINISHED
 
     enum: ERROR_OVERFLOW
@@ -158,6 +159,7 @@ cdef extern from "parser/tokenizer.h":
         int header_end # header row end
 
         void *skipset
+        int64_t skip_first_N_rows
         int skip_footer
         double (*converter)(const char *, char **, char, char, char, int)
 
@@ -180,6 +182,8 @@ cdef extern from "parser/tokenizer.h":
     int parser_init(parser_t *self) nogil
     void parser_free(parser_t *self) nogil
     int parser_add_skiprow(parser_t *self, int64_t row)
+
+    int parser_set_skipfirstnrows(parser_t *self, int64_t nrows)
 
     void parser_set_default_options(parser_t *self)
 
@@ -524,10 +528,10 @@ cdef class TextReader:
 
     cdef _make_skiprow_set(self):
         if isinstance(self.skiprows, (int, np.integer)):
-            self.skiprows = range(self.skiprows)
-
-        for i in self.skiprows:
-            parser_add_skiprow(self.parser, i)
+            parser_set_skipfirstnrows(self.parser, self.skiprows)
+        else:
+            for i in self.skiprows:
+                parser_add_skiprow(self.parser, i)
 
     cdef _setup_parser_source(self, source):
         cdef:

--- a/pandas/src/parser/tokenizer.h
+++ b/pandas/src/parser/tokenizer.h
@@ -127,6 +127,7 @@ typedef enum {
     EAT_COMMENT,
     EAT_LINE_COMMENT,
     WHITESPACE_LINE,
+    SKIP_LINE,
     FINISHED
 } ParserState;
 
@@ -203,6 +204,7 @@ typedef struct parser_t {
     int header_end;   // header row end
 
     void *skipset;
+    int64_t skip_first_N_rows;
     int skip_footer;
     double (*converter)(const char *, char **, char, char, char, int);
 
@@ -239,6 +241,8 @@ int parser_consume_rows(parser_t *self, size_t nrows);
 int parser_trim_buffers(parser_t *self);
 
 int parser_add_skiprow(parser_t *self, int64_t row);
+
+int parser_set_skipfirstnrows(parser_t *self, int64_t nrows);
 
 void parser_free(parser_t *self);
 

--- a/vb_suite/io_bench.py
+++ b/vb_suite/io_bench.py
@@ -21,6 +21,22 @@ df.to_csv('__test__.csv')
 read_csv_standard = Benchmark("read_csv('__test__.csv')", setup1,
                               start_date=datetime(2011, 9, 15))
 
+#----------------------------------
+# skiprows
+
+setup1 = common_setup + """
+index = tm.makeStringIndex(20000)
+df = DataFrame({'float1' : randn(20000),
+                'float2' : randn(20000),
+                'string1' : ['foo'] * 20000,
+                'bool1' : [True] * 20000,
+                'int1' : np.random.randint(0, 200000, size=20000)},
+               index=index)
+df.to_csv('__test__.csv')
+"""
+
+read_csv_skiprows = Benchmark("read_csv('__test__.csv', skiprows=10000)", setup1,
+                              start_date=datetime(2011, 9, 15))
 
 #----------------------------------------------------------------------
 # write_csv


### PR DESCRIPTION
Update tokenizer's handling of skipped lines.  
Fixes a problem with read_csv(delim_whitespace=True) and 
read_table(engine='c') when lines being skipped have trailing 
whitespace. 

closes #8679 
closes #8681 
