### PR TITLE
DOC: remove unused matplotlib directives from conf.py

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -44,12 +44,9 @@ extensions = ['sphinx.ext.autodoc',
               'ipython_sphinxext.ipython_directive',
               'ipython_sphinxext.ipython_console_highlighting',
               'sphinx.ext.intersphinx',
-              'sphinx.ext.todo',
               'sphinx.ext.coverage',
               'sphinx.ext.pngmath',
               'sphinx.ext.ifconfig',
-              'matplotlib.sphinxext.only_directives',
-              'matplotlib.sphinxext.plot_directive',
               ]
 
 


### PR DESCRIPTION
I don't think we use the matplotlib directives anywhere (and the todo was twice in the list), so removed them from conf.py
