### PR TITLE
Allowing empty slice in multi-indices

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -45,3 +45,4 @@ Bug Fixes
 ~~~~~~~~~
 - Bug in ``groupby`` signatures that didn't include *args or **kwargs (:issue:`8733`).
 - ``io.data.Options`` now raises ``RemoteDataError`` when no expiry dates are available from Yahoo (:issue:`8761`).
+- Bug in slicing a multi-index with an empty list and at least one boolean indexer (:issue:`8781`)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -4148,9 +4148,9 @@ class MultiIndex(Index):
                         # ignore not founds
                         continue
                 if len(k):
-                    ranges.append(reduce(np.logical_or,indexers))
+                    ranges.append(reduce(np.logical_or, indexers))
                 else:
-                    ranges.append(tuple([]))
+                    ranges.append(np.zeros(self.labels[i].shape, dtype=bool))
 
             elif _is_null_slice(k):
                 # empty slice

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -2139,9 +2139,11 @@ class TestIndexing(tm.TestCase):
         df = DataFrame(np.random.randn(5, 6), index=range(5), columns=multi_index)
         df = df.sortlevel(0, axis=1)
 
-        result = df.loc[:, ([], slice(None))]
+        result1 = df.loc[:, ([], slice(None))]
+        result2 = df.loc[:, (['foo'], [])]
         expected = DataFrame(index=range(5),columns=multi_index.reindex([])[0])
-        assert_frame_equal(result, expected)
+        assert_frame_equal(result1, expected)
+        assert_frame_equal(result2, expected)
 
         # regression from < 0.14.0
         # GH 7914


### PR DESCRIPTION
This solves #8737 in the case where there is at least one boolean indexer. The patch of  #8739 does not allow the following:

``` python
import pandas as pd
import numpy as np
multi_index = pd.MultiIndex.from_product((['foo', 'bar', 'baz'], ['alpha', 'beta']))
df = pd.DataFrame(np.random.randn(5, 6), index=range(5), columns=multi_index)
df = df.sortlevel(0, axis=1)
df.loc[:, (['foo'], [])]
```
