### PR TITLE
BUG: Issue with to_latex and MultiIndex column format. GH8336

### DIFF
--- a/doc/source/10min.rst
+++ b/doc/source/10min.rst
@@ -12,7 +12,11 @@
    from pandas import options
    import pandas as pd
    np.set_printoptions(precision=4, suppress=True)
-   options.display.mpl_style='default'
+   import matplotlib
+   try:
+      matplotlib.style.use('ggplot')
+   except AttributeError:
+      options.display.mpl_style = 'default'
    options.display.max_rows=15
 
    #### portions of this were borrowed from the
@@ -695,8 +699,6 @@ Plotting
 
    import matplotlib.pyplot as plt
    plt.close('all')
-   from pandas import options
-   options.display.mpl_style='default'
 
 .. ipython:: python
 

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -517,8 +517,6 @@ String handling
 strings and apply several methods to it. These can be acccessed like
 ``Series.str.<function/property>``.
 
-.. currentmodule:: pandas.core.strings
-
 .. autosummary::
    :toctree: generated/
    :template: autosummary/accessor_method.rst

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -861,6 +861,7 @@ Combining / joining / merging
    :toctree: generated/
 
    DataFrame.append
+   DataFrame.assign
    DataFrame.join
    DataFrame.merge
    DataFrame.update

--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -13,7 +13,6 @@
    from pandas import *
    import pandas as pd
    np.set_printoptions(precision=4, suppress=True)
-   options.display.mpl_style='default'
    options.display.max_rows=15
 
 

--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -10,9 +10,13 @@
    import pandas.util.testing as tm
    randn = np.random.randn
    np.set_printoptions(precision=4, suppress=True)
+   import matplotlib
+   try:
+      matplotlib.style.use('ggplot')
+   except AttributeError:
+      options.display.mpl_style = 'default'
    import matplotlib.pyplot as plt
    plt.close('all')
-   options.display.mpl_style='default'
    options.display.max_rows=15
 
 Computational tools

--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -17,7 +17,12 @@
    np.random.seed(123456)
 
    pd.options.display.max_rows=15
-   pd.options.display.mpl_style='default'
+
+   import matplotlib
+   try:
+      matplotlib.style.use('ggplot')
+   except AttributeError:
+      pd.options.display.mpl_style = 'default'
 
    np.set_printoptions(precision=4, suppress=True)
 

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -21,7 +21,11 @@ Frequently Asked Questions (FAQ)
    from pandas.tseries.offsets import *
    import matplotlib.pyplot as plt
    plt.close('all')
-   options.display.mpl_style='default'
+   import matplotlib
+   try:
+      matplotlib.style.use('ggplot')
+   except AttributeError:
+      options.display.mpl_style = 'default'
    from pandas.compat import lrange
 
 

--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -12,7 +12,11 @@
    np.set_printoptions(precision=4, suppress=True)
    import matplotlib.pyplot as plt
    plt.close('all')
-   options.display.mpl_style='default'
+   import matplotlib
+   try:
+      matplotlib.style.use('ggplot')
+   except AttributeError:
+      options.display.mpl_style = 'default'
    from pandas.compat import zip
 
 *****************************
@@ -346,7 +350,7 @@ A single group can be selected using ``GroupBy.get_group()``:
 .. ipython:: python
 
    grouped.get_group('bar')
-   
+
 Or for an object grouped on multiple columns:
 
 .. ipython:: python

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -1137,6 +1137,16 @@ should be taken instead.
    df2.drop_duplicates(['a','b'])
    df2.drop_duplicates(['a','b'], take_last=True)
 
+An easier way to drop duplicates on the index than to temporarily forgo it is
+``groupby(level=0)`` combined with ``first()`` or ``last()``.
+
+.. ipython:: python
+
+   df3 = df2.set_index('b')
+   df3
+   df3.reset_index().drop_duplicates(subset='b', take_last=False).set_index('b')
+   df3.groupby(level=0).first()
+
 .. _indexing.dictionarylike:
 
 Dictionary-like :meth:`~pandas.DataFrame.get` method

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -1137,15 +1137,16 @@ should be taken instead.
    df2.drop_duplicates(['a','b'])
    df2.drop_duplicates(['a','b'], take_last=True)
 
-An easier way to drop duplicates on the index than to temporarily forgo it is
-``groupby(level=0)`` combined with ``first()`` or ``last()``.
+An alternative way to drop duplicates on the index is ``.groupby(level=0)`` combined with ``first()`` or ``last()``.
 
 .. ipython:: python
 
    df3 = df2.set_index('b')
    df3
-   df3.reset_index().drop_duplicates(subset='b', take_last=False).set_index('b')
    df3.groupby(level=0).first()
+
+   # a bit more verbose
+   df3.reset_index().drop_duplicates(subset='b', take_last=False).set_index('b')
 
 .. _indexing.dictionarylike:
 

--- a/doc/source/sparse.rst
+++ b/doc/source/sparse.rst
@@ -10,9 +10,6 @@
    import pandas.util.testing as tm
    randn = np.random.randn
    np.set_printoptions(precision=4, suppress=True)
-   import matplotlib.pyplot as plt
-   plt.close('all')
-   options.display.mpl_style='default'
    options.display.max_rows = 15
 
 **********************
@@ -222,4 +219,3 @@ row and columns coordinates of the matrix. Note that this will consume a signifi
 
    ss_dense = SparseSeries.from_coo(A, dense_index=True)
    ss_dense
-

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -31,10 +31,14 @@ We use the standard convention for referencing the matplotlib API:
 
    import matplotlib.pyplot as plt
 
-.. versionadded:: 0.11.0
+The plots in this document are made using matplotlib's ``ggplot`` style (new in version 1.4):
 
-The plots in this document are made using matplotlib's ``ggplot`` style (new in version 1.4).
-If your version of matplotlib is 1.3 or lower, setting the ``display.mpl_style`` to ``'default'``
+.. code-block:: python
+
+   import matplotlib
+   matplotlib.style.use('ggplot')
+
+If your version of matplotlib is 1.3 or lower, you can set ``display.mpl_style`` to ``'default'``
 with ``pd.options.display.mpl_style = 'default'``
 to produce more appealing plots.
 When set, matplotlib's ``rcParams`` are changed (globally!) to nicer-looking settings.

--- a/doc/source/whatsnew.rst
+++ b/doc/source/whatsnew.rst
@@ -18,6 +18,8 @@ What's New
 
 These are new features and improvements of note in each release.
 
+.. include:: whatsnew/v0.16.1.txt
+
 .. include:: whatsnew/v0.16.0.txt
 
 .. include:: whatsnew/v0.15.2.txt

--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -31,3 +31,5 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
+
+- Bug in ``transform`` causing length mismatch when null entries were present and a fast aggregator was being used (:issue:`9697`)

--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -47,4 +47,17 @@ Performance Improvements
 Bug Fixes
 ~~~~~~~~~
 
+
+
+
+
 - Bug in ``transform`` causing length mismatch when null entries were present and a fast aggregator was being used (:issue:`9697`)
+
+
+
+
+
+
+
+
+- Bug in ``Series.quantile`` on empty Series of type ``Datetime`` or ``Timedelta`` (:issue:`9675`)

--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -3,29 +3,44 @@
 v0.16.1 (April ??, 2015)
 ------------------------
 
-This is a minor bug-fix release from 0.16.0 and includes a small number of API changes, several new features,
-enhancements, and performance improvements along with a large number of bug fixes. We recommend that all
-users upgrade to this version.
+This is a minor bug-fix release from 0.16.0 and includes a a large number of
+bug fixes along several new features, enhancements, and performance improvements.
+We recommend that all users upgrade to this version.
 
-- :ref:`Enhancements <whatsnew_0161.enhancements>`
-- :ref:`API Changes <whatsnew_0161.api>`
-- :ref:`Performance Improvements <whatsnew_0161.performance>`
-- :ref:`Bug Fixes <whatsnew_0161.bug_fixes>`
+.. contents:: What's new in v0.16.1
+    :local:
+    :backlinks: none
 
-.. _whatsnew_0161.api:
-
-API changes
-~~~~~~~~~~~
 
 .. _whatsnew_0161.enhancements:
 
 Enhancements
 ~~~~~~~~~~~~
 
+
+
+
+
+
+.. _whatsnew_0161.api:
+
+API changes
+~~~~~~~~~~~
+
+
+
+
+
+
 .. _whatsnew_0161.performance:
 
 Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+
+
+
 
 .. _whatsnew_0161.bug_fixes:
 

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -581,14 +581,20 @@ class DataFrameFormatter(TableFormatter):
             strcols = self._to_str_columns()
 
         if self.index and isinstance(self.frame.index, MultiIndex):
-            clevels = self.frame.columns.nlevels
             strcols.pop(0)
-            name = any(self.frame.columns.names)
-            for i, lev in enumerate(self.frame.index.levels):
-                lev2 = lev.format(name=name)
-                width = len(lev2[0])
-                lev3 = [' ' * width] * clevels + lev2
-                strcols.insert(i, lev3)
+
+
+            fmt = self._get_formatter('__index__')
+            fmt_index = self.frame.index.format(sparsify=self.sparsify,
+                                                adjoin=False,
+                                                names=False,
+                                                formatter=fmt)
+
+            for i, lev in enumerate(fmt_index):
+                width = len(lev[0])
+                lev2 = [width * ' ' if l == '' else l for l in lev]
+                lev2.insert(0, width * ' ')
+                strcols.insert(i, lev2)
 
         if column_format is None:
             dtypes = self.frame.dtypes.values

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -608,14 +608,20 @@ class DataFrameFormatter(TableFormatter):
             strcols = self._to_str_columns()
 
         if self.index and isinstance(self.frame.index, MultiIndex):
-            clevels = self.frame.columns.nlevels
             strcols.pop(0)
-            name = any(self.frame.columns.names)
-            for i, lev in enumerate(self.frame.index.levels):
-                lev2 = lev.format(name=name)
-                width = len(lev2[0])
-                lev3 = [' ' * width] * clevels + lev2
-                strcols.insert(i, lev3)
+
+
+            fmt = self._get_formatter('__index__')
+            fmt_index = self.frame.index.format(sparsify=self.sparsify,
+                                                adjoin=False,
+                                                names=False,
+                                                formatter=fmt)
+
+            for i, lev in enumerate(fmt_index):
+                width = len(lev[0])
+                lev2 = [width * ' ' if l == '' else l for l in lev]
+                lev2.insert(0, width * ' ')
+                strcols.insert(i, lev2)
 
         if column_format is None:
             dtypes = self.frame.dtypes.values

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -614,7 +614,7 @@ class DataFrameFormatter(TableFormatter):
             fmt = self._get_formatter('__index__')
             fmt_index = self.frame.index.format(sparsify=self.sparsify,
                                                 adjoin=False,
-                                                names=False,
+                                                names=True,
                                                 formatter=fmt)
 
             for i, lev in enumerate(fmt_index):

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -587,7 +587,7 @@ class DataFrameFormatter(TableFormatter):
             fmt = self._get_formatter('__index__')
             fmt_index = self.frame.index.format(sparsify=self.sparsify,
                                                 adjoin=False,
-                                                names=False,
+                                                names=True,
                                                 formatter=fmt)
 
             for i, lev in enumerate(fmt_index):

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2453,7 +2453,7 @@ class SeriesGroupBy(GroupBy):
         if isinstance(func, compat.string_types):
             func = getattr(self,func)
         values = func().values
-        counts = self.count().values
+        counts = self.size().values
         values = np.repeat(values, com._ensure_platform_int(counts))
 
         return self._set_result_index_ordered(Series(values))

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2095,7 +2095,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             boxer = com.i8_boxer(self)
 
             if len(values) == 0:
-                return boxer(iNaT)
+                return boxer(tslib.iNaT)
 
             values = values.view('i8')
             result = func(values)

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -1058,6 +1058,19 @@ class TestGroupBy(tm.TestCase):
         expected = self.df.groupby('A')['C'].transform(np.mean)
         assert_series_equal(result, expected)
 
+    def test_transform_length(self):
+        # GH 9697
+        df = pd.DataFrame({'col1':[1,1,2,2], 'col2':[1,2,3,np.nan]})
+        expected = pd.Series([3.0]*4)
+        def nsum(x):
+            return np.nansum(x)
+        results = [df.groupby('col1').transform(sum)['col2'],
+                   df.groupby('col1')['col2'].transform(sum),
+                   df.groupby('col1').transform(nsum)['col2'],
+                   df.groupby('col1')['col2'].transform(nsum)]
+        for result in results:
+            assert_series_equal(result, expected)
+
     def test_with_na(self):
         index = Index(np.arange(10))
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -6837,6 +6837,11 @@ class TestSeriesNonUnique(tm.TestCase):
     def test_unique_data_ownership(self):
         # it works! #1807
         Series(Series(["a", "c", "b"]).unique()).sort()
+    
+    def test_datetime_timedelta_quantiles(self):
+        # covers #9694
+        self.assertTrue(pd.isnull(Series([],dtype='M8[ns]').quantile(.5)))
+        self.assertTrue(pd.isnull(Series([],dtype='m8[ns]').quantile(.5)))
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -167,7 +167,7 @@ class TestTimestamp(tm.TestCase):
 
         # dateutil zone change (only matters for repr)
         import dateutil
-        if dateutil.__version__ >= LooseVersion('2.3') and dateutil.__version__ <= LooseVersion('2.4'):
+        if dateutil.__version__ >= LooseVersion('2.3') and dateutil.__version__ <= LooseVersion('2.4.0'):
             timezones = ['UTC', 'Asia/Tokyo', 'US/Eastern', 'dateutil/US/Pacific']
         else:
             timezones = ['UTC', 'Asia/Tokyo', 'US/Eastern', 'dateutil/America/Los_Angeles']


### PR DESCRIPTION
closes #8336 

This is a potential resolution to GH8336 It borrows the same code flow from _get_formatted_index in
pandas.core.format

``` python
import pandas as pd
pd.show_versions()

df = pd.DataFrame({
    "A": [191, 191, 193, 193, 193],
    "B": [1, 1, 2, 2, 3],
    "C": ["foo", "foo", "foo", "foo", "foo"],
    "D": ["bar", "bar", "bar", "bar", "bar"]})

print "\nOutput:"
print df.set_index(["A", "B"]).to_latex()
```

``` latex
INSTALLED VERSIONS
------------------
commit: None
python: 2.7.8.final.0
python-bits: 64
OS: Linux
OS-release: 3.17.2-1-ARCH
machine: x86_64
processor: 
byteorder: little
LC_ALL: None
LANG: C

pandas: 0.15.1
nose: 1.3.4
Cython: 0.21.1
numpy: 1.9.1
scipy: 0.14.0
statsmodels: 0.6.0
IPython: 2.3.0
sphinx: 1.2.3
patsy: 0.3.0
dateutil: 2.2
pytz: 2014.9
bottleneck: None
tables: None
numexpr: None
matplotlib: 1.4.0
openpyxl: 2.1.1
xlrd: 0.9.3
xlwt: None
xlsxwriter: None
lxml: None
bs4: 4.3.2
html5lib: None
httplib2: 0.9
apiclient: None
rpy2: None
sqlalchemy: 0.9.8
pymysql: None
psycopg2: None

Output:
\begin{tabular}{llll}
\toprule
    &   &    C &    D \\
\midrule
191 & 1 &      &      \\
193 & 2 &  foo &  bar \\
\bottomrule
\end{tabular}
```

After PR

``` latex
INSTALLED VERSIONS
------------------
commit: None
python: 2.7.8.final.0
python-bits: 64
OS: Linux
OS-release: 3.17.2-1-ARCH
machine: x86_64
processor: 
byteorder: little
LC_ALL: None
LANG: C

pandas: 0.15.1-18-g81c8a5f
nose: None
Cython: None
numpy: 1.9.1
scipy: None
statsmodels: None
IPython: 2.3.0
sphinx: None
patsy: None
dateutil: 2.2
pytz: 2014.9
bottleneck: None
tables: None
numexpr: None
matplotlib: None
openpyxl: None
xlrd: None
xlwt: None
xlsxwriter: None
lxml: None
bs4: None
html5lib: None
httplib2: None
apiclient: None
rpy2: None
sqlalchemy: None
pymysql: None
psycopg2: None

Output:
\begin{tabular}{llll}
\toprule
    &   &    C &    D \\
\midrule
191 & 1 &      &      \\
    & 1 &  foo &  bar \\
193 & 2 &  foo &  bar \\
    & 2 &  foo &  bar \\
    & 3 &  foo &  bar \\
\bottomrule
\end{tabular}

```
