### PR TITLE
Fix unrecognized 'Z' UTC designator

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -93,3 +93,4 @@ Bug Fixes
 
 - Bug in `pd.infer_freq`/`DataFrame.inferred_freq` that prevented proper sub-daily frequency inference
   when the index contained DST days (:issue:`8772`).
+- Regression in ``Timestamp`` does not parse 'Z' zone designator for UTC (:issue:`8771`)

--- a/pandas/src/datetime/np_datetime_strings.c
+++ b/pandas/src/datetime/np_datetime_strings.c
@@ -363,7 +363,8 @@ convert_datetimestruct_local_to_utc(pandas_datetimestruct *out_dts_utc,
  *           to be cast to the 'unit' parameter.
  *
  * 'out' gets filled with the parsed date-time.
- * 'out_local' gets whether returned value contains timezone. 0 for UTC, 1 for local time.
+ * 'out_local' gets set to 1 if the parsed time contains timezone, 
+ *      to 0 otherwise.
  * 'out_tzoffset' gets set to timezone offset by minutes
  *      if the parsed time was in local time,
  *      to 0 otherwise. The values 'now' and 'today' don't get counted
@@ -785,9 +786,13 @@ parse_timezone:
 
     /* UTC specifier */
     if (*substr == 'Z') {
-        /* "Z" means not local */
+        /* "Z" should be equivalent to tz offset "+00:00" */
         if (out_local != NULL) {
-            *out_local = 0;
+            *out_local = 1;
+        }
+
+        if (out_tzoffset != NULL) {
+            *out_tzoffset = 0;
         }
 
         if (sublen == 1) {

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -6,7 +6,7 @@ from pandas import tslib
 import datetime
 
 from pandas.core.api import Timestamp, Series
-from pandas.tslib import period_asfreq, period_ordinal
+from pandas.tslib import period_asfreq, period_ordinal, get_timezone
 from pandas.tseries.index import date_range
 from pandas.tseries.frequencies import get_freq
 import pandas.tseries.offsets as offsets
@@ -297,6 +297,11 @@ class TestTimestamp(tm.TestCase):
 
         # One us more than the maximum is an error
         self.assertRaises(ValueError, Timestamp, max_ts_us + one_us)
+
+    def test_utc_z_designator(self):
+        self.assertEqual(get_timezone(Timestamp('2014-11-02 01:00Z').tzinfo), 'UTC')
+        self.assertEqual(get_timezone(Timestamp('2014-11-02 01:00Z00').tzinfo), 'UTC')
+        self.assertRaises(ValueError, Timestamp, '2014-11-02 01:00Z0')
 
 
 class TestDatetimeParsingWrappers(tm.TestCase):


### PR DESCRIPTION
closes [#8771](https://github.com/pydata/pandas/issues/8771)
