### PR TITLE
TST: Skip hist testing for matplotlib <= 1.2

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -63,3 +63,4 @@ Bug Fixes
 - Bug in slicing a multi-index with an empty list and at least one boolean indexer (:issue:`8781`)
 - ``io.data.Options`` now raises ``RemoteDataError`` when no expiry dates are available from Yahoo (:issue:`8761`).
 - ``Timedelta`` kwargs may now be numpy ints and floats (:issue:`8757`).
+- Skip testing of histogram plots for matplotlib <= 1.2 (:issue:`8648`).

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -2041,6 +2041,9 @@ class TestDataFramePlots(TestPlotBase):
 
     @slow
     def test_hist_df(self):
+        if self.mpl_le_1_2_1:
+            raise nose.SkipTest("not supported in matplotlib <= 1.2.x")
+
         df = DataFrame(randn(100, 4))
         series = df[0]
 


### PR DESCRIPTION
Not a huge issue, just skipping an incompatible test when testing with matplotlib 1.2. 

closes #8648.
