### PR TITLE
DOC: Added get_group() example to grouby.html

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -132,7 +132,7 @@ If you want to do a full clean build, do::
     python make.py build
 
 
-Staring with 0.13.1 you can tell ``make.py`` to compile only a single section
+Starting with 0.13.1 you can tell ``make.py`` to compile only a single section
 of the docs, greatly reducing the turn-around time for checking your changes.
 You will be prompted to delete `.rst` files that aren't required, since the
 last committed version can always be restored from git.

--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -338,6 +338,21 @@ In the case of grouping by multiple keys, the group name will be a tuple:
 It's standard Python-fu but remember you can unpack the tuple in the for loop
 statement if you wish: ``for (k1, k2), group in grouped:``.
 
+Selecting a group
+-----------------
+
+A single group can be selected using ``GroupBy.get_group()``:
+
+.. ipython:: python
+
+   grouped.get_group('bar')
+   
+Or for an object grouped on multiple columns:
+
+.. ipython:: python
+
+   df.groupby(['A', 'B']).get_group(('bar', 'one'))
+
 .. _groupby.aggregate:
 
 Aggregation


### PR DESCRIPTION
Added a get_group example in the Iterating through groups section of grouby.html to demonstrate selecting
single group from a DataFrameGrouBy object

Fixed typo in README
