### PR TITLE
VIS: plot with `use_index=False` shouldn't plot the index name

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -93,3 +93,4 @@ Bug Fixes
 
 - Bug in `pd.infer_freq`/`DataFrame.inferred_freq` that prevented proper sub-daily frequency inference
   when the index contained DST days (:issue:`8772`).
+- Bug where index name was still used when plotting a series with ``use_index=False`` (:issue:`8558`).

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -569,6 +569,16 @@ class TestSeriesPlots(TestPlotBase):
             ax = _check_plot_works(d.plot, kind='area', stacked=False)
             self.assert_numpy_array_equal(ax.lines[0].get_ydata(), expected)
 
+    def test_line_use_index_false(self):
+        s = Series([1, 2, 3], index=['a', 'b', 'c'])
+        s.index.name = 'The Index'
+        ax = s.plot(use_index=False)
+        label = ax.get_xlabel()
+        self.assertEqual(label, '')
+        ax2 = s.plot(kind='bar', use_index=False)
+        label2 = ax2.get_xlabel()
+        self.assertEqual(label2, '')
+
     @slow
     def test_bar_log(self):
         expected = np.array([1., 10., 100., 1000.])

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1685,7 +1685,7 @@ class LinePlot(MPLPlot):
                     self.rot = 30
                 format_date_labels(ax, rot=self.rot)
 
-            if index_name is not None:
+            if index_name is not None and self.use_index:
                 ax.set_xlabel(index_name)
 
 
@@ -1874,7 +1874,7 @@ class BarPlot(MPLPlot):
                 ax.set_xticklabels(str_index)
                 if not self.log: # GH3254+
                     ax.axhline(0, color='k', linestyle='--')
-                if name is not None:
+                if name is not None and self.use_index:
                     ax.set_xlabel(name)
             elif self.kind == 'barh':
                 # horizontal bars
@@ -1882,7 +1882,7 @@ class BarPlot(MPLPlot):
                 ax.set_yticks(self.tick_pos)
                 ax.set_yticklabels(str_index)
                 ax.axvline(0, color='k', linestyle='--')
-                if name is not None:
+                if name is not None and self.use_index:
                     ax.set_ylabel(name)
             else:
                 raise NotImplementedError(self.kind)


### PR DESCRIPTION
Fixes #8558. As far as I can tell the two plot types where this applies are line and bar plots, if there any others they should also be easy to fix. Bar and line plots no longer include the index name:

``` python
import pandas as pd
from pandas import Series
import matplotlib.pyplot as plt

s = Series([1, 2, 3], index=['a', 'b', 'c'])
s.index.name = 'The Index'

ax = s.plot(use_index=False)
plt.show()
```

￼
![image](https://cloud.githubusercontent.com/assets/1460294/5041001/6095c37e-6c0c-11e4-86ca-8e1c4ec83b3c.png)

``` python
ax2 = s.plot(kind='bar', use_index=False)
plt.show()
```

![image](https://cloud.githubusercontent.com/assets/1460294/5041003/657a45d6-6c0c-11e4-92a2-642e5df917a0.png)
