### PR TITLE
ENH: Allow get_dummies to return SparseDataFrame

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -48,6 +48,7 @@ Enhancements
     df.drop(['A', 'X'], axis=1, errors='ignore')
 
 - Allow conversion of values with dtype ``datetime64`` or ``timedelta64`` to strings using ``astype(str)`` (:issue:`9757`)
+- ``get_dummies`` function now accepts ``sparse`` keyword.  If set to ``True``, the return DataFrame is sparse. (:issue:`8823`)
 
 .. _whatsnew_0161.api:
 


### PR DESCRIPTION
For dataframes with a large number of unique values, `get_dummies` can use enormous amounts of memory.  This provides a `sparse` flag to `get_dummies` which returns a much more memory-efficient structure.

For example:

```
import pandas as pd
df1 = pd.get_dummies(pd.DataFrame({'a':range(1000)}, dtype='category').a, sparse=False)
print 'dense:', df1.memory_usage().sum()
df2 = pd.get_dummies(pd.DataFrame({'a':range(1000)}, dtype='category').a, sparse=True)
print 'sparse:', df2.memory_usage().sum()
pd.util.testing.assert_frame_equal(df1, df2)
```

returns

```
dense: 8000000
sparse: 8000
```

Performance could probably be improved a lot.

Fails `pandas/tests/test_reshape.py:TestGetDummiesSparse.test_include_na` due to #8822 .
