### PR TITLE
BUG: sql_schema does not generate dialect-specific DDL

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -63,7 +63,7 @@ Bug Fixes
 - Bug in slicing a multi-index with an empty list and at least one boolean indexer (:issue:`8781`)
 - ``io.data.Options`` now raises ``RemoteDataError`` when no expiry dates are available from Yahoo (:issue:`8761`).
 - ``Timedelta`` kwargs may now be numpy ints and floats (:issue:`8757`).
-
+- ``sql_schema`` now generates dialect appropriate ``CREATE TABLE`` statements (:issue:`8697`)
 
 
 

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -621,7 +621,7 @@ class SQLTable(PandasObject):
 
     def sql_schema(self):
         from sqlalchemy.schema import CreateTable
-        return str(CreateTable(self.table))
+        return str(CreateTable(self.table).compile(self.pd_sql.engine))
 
     def _execute_create(self):
         # Inserting table into database, add to MetaData object

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -1155,6 +1155,19 @@ class _TestSQLAlchemy(PandasSQLTest):
     def test_transactions(self):
         self._transaction_test()
 
+    def test_get_schema_create_table(self):
+        self._load_test2_data()
+        tbl = 'test_get_schema_create_table'
+        create_sql = sql.get_schema(self.test_frame2, tbl, con=self.conn)
+        blank_test_df = self.test_frame2.iloc[:0]
+
+        self.drop_table(tbl)
+        self.conn.execute(create_sql)
+        returned_df = sql.read_sql_table(tbl, self.conn)
+        tm.assert_frame_equal(returned_df, blank_test_df)
+        self.drop_table(tbl)
+
+
 class TestSQLiteAlchemy(_TestSQLAlchemy):
     """
     Test the sqlalchemy backend against an in-memory sqlite database.


### PR DESCRIPTION
Closes #8697 .

sqlalchemy `CreateTable` needs to be called slightly differently to create dialect-specific SQL.  See http://stackoverflow.com/questions/2128717/sqlalchemy-printing-raw-sql-from-create .
