### PR TITLE
BUG: query modifies the frame when you compare with `=`

### DIFF
--- a/pandas/computation/eval.py
+++ b/pandas/computation/eval.py
@@ -138,7 +138,7 @@ def _check_for_locals(expr, stack_level, parser):
 
 def eval(expr, parser='pandas', engine='numexpr', truediv=True,
          local_dict=None, global_dict=None, resolvers=(), level=0,
-         target=None, assignment_allowed=True):
+         target=None):
     """Evaluate a Python expression as a string using various backends.
 
     The following arithmetic operations are supported: ``+``, ``-``, ``*``,
@@ -196,9 +196,6 @@ def eval(expr, parser='pandas', engine='numexpr', truediv=True,
         scope. Most users will **not** need to change this parameter.
     target : a target object for assignment, optional, default is None
         essentially this is a passed in resolver
-    assignment_allowed : bool
-        Whether the eval should be able to modify the input through
-        assigment.
 
     Returns
     -------
@@ -239,11 +236,7 @@ def eval(expr, parser='pandas', engine='numexpr', truediv=True,
 
     # assign if needed
     if env.target is not None and parsed_expr.assigner is not None:
-        if assignment_allowed:
-            env.target[parsed_expr.assigner] = ret
-            return None
-        else:
-            raise ValueError("Expression includes assignment statement: \n"
-                             "\t not allowed from DataFrame.query")
+        env.target[parsed_expr.assigner] = ret
+        return None
 
     return ret

--- a/pandas/computation/eval.py
+++ b/pandas/computation/eval.py
@@ -138,7 +138,7 @@ def _check_for_locals(expr, stack_level, parser):
 
 def eval(expr, parser='pandas', engine='numexpr', truediv=True,
          local_dict=None, global_dict=None, resolvers=(), level=0,
-         target=None):
+         target=None, assignment_allowed=True):
     """Evaluate a Python expression as a string using various backends.
 
     The following arithmetic operations are supported: ``+``, ``-``, ``*``,
@@ -196,6 +196,9 @@ def eval(expr, parser='pandas', engine='numexpr', truediv=True,
         scope. Most users will **not** need to change this parameter.
     target : a target object for assignment, optional, default is None
         essentially this is a passed in resolver
+    assignment_allowed : bool
+        Whether the eval should be able to modify the input through
+        assigment.
 
     Returns
     -------
@@ -236,7 +239,11 @@ def eval(expr, parser='pandas', engine='numexpr', truediv=True,
 
     # assign if needed
     if env.target is not None and parsed_expr.assigner is not None:
-        env.target[parsed_expr.assigner] = ret
-        return None
+        if assignment_allowed:
+            env.target[parsed_expr.assigner] = ret
+            return None
+        else:
+            raise ValueError("Expression includes assignment statement: \n"
+                             "\t not allowed from DataFrame.query")
 
     return ret

--- a/pandas/computation/expr.py
+++ b/pandas/computation/expr.py
@@ -589,6 +589,7 @@ class BaseExprVisitor(ast.NodeVisitor):
 
 _python_not_supported = frozenset(['Dict', 'Call', 'BoolOp', 'In', 'NotIn'])
 _numexpr_supported_calls = frozenset(_reductions + _mathops)
+_query_not_supported = frozenset(['Assign'])
 
 
 @disallow((_unsupported_nodes | _python_not_supported) -
@@ -600,6 +601,17 @@ class PandasExprVisitor(BaseExprVisitor):
                  preparser=partial(_preparse, f=compose(_replace_locals,
                                                         _replace_booleans))):
         super(PandasExprVisitor, self).__init__(env, engine, parser, preparser)
+
+
+@disallow((_unsupported_nodes | _python_not_supported | _query_not_supported) -
+          (_boolop_nodes | frozenset(['BoolOp', 'Attribute', 'In', 'NotIn',
+                                      'Tuple'])))
+class PandasQueryExprVisitor(BaseExprVisitor):
+
+    def __init__(self, env, engine, parser,
+                 preparser=partial(_preparse, f=compose(_replace_locals,
+                                                        _replace_booleans))):
+        super(PandasQueryExprVisitor, self).__init__(env, engine, parser, preparser)
 
 
 @disallow(_unsupported_nodes | _python_not_supported | frozenset(['Not']))
@@ -659,4 +671,5 @@ class Expr(StringMixin):
         return frozenset(term.name for term in com.flatten(self.terms))
 
 
-_parsers = {'python': PythonExprVisitor, 'pandas': PandasExprVisitor}
+_parsers = {'python': PythonExprVisitor, 'pandas': PandasExprVisitor,
+            'pandas_query': PandasQueryExprVisitor}

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1935,6 +1935,7 @@ class DataFrame(NDFrame):
         >>> df[df.a > df.b]  # same result as the previous expression
         """
         kwargs['level'] = kwargs.pop('level', 0) + 1
+        kwargs['parser'] = kwargs.pop('parser', 'pandas_query')
         res = self.eval(expr, **kwargs)
 
         try:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1935,7 +1935,7 @@ class DataFrame(NDFrame):
         >>> df[df.a > df.b]  # same result as the previous expression
         """
         kwargs['level'] = kwargs.pop('level', 0) + 1
-        res = self.eval(expr, assignment_allowed=False, **kwargs)
+        res = self.eval(expr, **kwargs)
 
         try:
             return self.loc[res]

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1935,7 +1935,7 @@ class DataFrame(NDFrame):
         >>> df[df.a > df.b]  # same result as the previous expression
         """
         kwargs['level'] = kwargs.pop('level', 0) + 1
-        res = self.eval(expr, **kwargs)
+        res = self.eval(expr, assignment_allowed=False, **kwargs)
 
         try:
             return self.loc[res]

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -15225,6 +15225,16 @@ class TestDataFrameQueryPythonPandas(TestDataFrameQueryNumExprPandas):
         result = df.query('sin > 5', engine=engine, parser=parser)
         tm.assert_frame_equal(expected, result)
 
+    def test_assignment_not_allowed(self):
+        df = DataFrame({'a': [1, 2, 3], 'b': ['a', 'b', 'c']})
+        a_before = df['a'].copy()
+        self.assertRaisesRegexp(
+            ValueError, 'assignment statement', df.query, 'a=1',
+            engine=self.engine, parser=self.parser
+        )
+        a_after = df['a'].copy()
+        assert_series_equal(a_before, a_after)
+
 
 class TestDataFrameQueryPythonPython(TestDataFrameQueryNumExprPython):
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -15210,7 +15210,7 @@ class TestDataFrameQueryPythonPandas(TestDataFrameQueryNumExprPandas):
     def setUpClass(cls):
         super(TestDataFrameQueryPythonPandas, cls).setUpClass()
         cls.engine = 'python'
-        cls.parser = 'pandas'
+        cls.parser = 'pandas_query'
         cls.frame = _frame.copy()
 
     def test_query_builtin(self):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -15225,12 +15225,12 @@ class TestDataFrameQueryPythonPandas(TestDataFrameQueryNumExprPandas):
         result = df.query('sin > 5', engine=engine, parser=parser)
         tm.assert_frame_equal(expected, result)
 
-    def test_assignment_not_allowed(self):
+    def test_query_with_assign_statement(self):
         df = DataFrame({'a': [1, 2, 3], 'b': ['a', 'b', 'c']})
         a_before = df['a'].copy()
         self.assertRaisesRegexp(
-            ValueError, 'assignment statement', df.query, 'a=1',
-            engine=self.engine, parser=self.parser
+            NotImplementedError, "'Assign' nodes are not implemented",
+            df.query, 'a=1', engine=self.engine, parser=self.parser
         )
         a_after = df['a'].copy()
         assert_series_equal(a_before, a_after)


### PR DESCRIPTION
Fix for #8664. The simplest way to fix this involved adding an `assignment_allowed=True` arg to the internal `eval()` function. All existing behaviour should be preserved. If adding the arg isn't okay I'm not quite sure how else to do it, as it's only once we reach the internal eval function that the expression is actually parsed and we know that it includes the assignment.

It also seems like a pretty bad side effect if query can silently overwrite values (obviously only if you accidentally include an assignment), so hopefully that's a good argument in favour of having the
`assignment_allowed` arg.
