### PR TITLE
ENH: Allow unicode separators in to_csv & read_csv

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -2732,7 +2732,7 @@ else:
                 # no matter what.
                 try:
                     kwds['delimiter'] = str(kwds['delimiter'])
-                except UnicodeEncodeError: # pragma: no cover
+                except UnicodeEncodeError:  # pragma: no cover
                     raise ValueError('cannot coerce delimiter %r to str' %
                                      kwds['delimiter'])
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -2702,7 +2702,10 @@ else:
         def __init__(self, f, dialect=csv.excel, encoding="utf-8", **kwds):
             f = UTF8Recoder(f, encoding)
             if 'delimiter' in kwds and isinstance(kwds['delimiter'], unicode):
-                kwds['delimiter'] = str(kwds['delimiter'])
+                if encoding is None:
+                    kwds['delimiter'] = kwds['delimiter'].encode()
+                else:
+                    kwds['delimiter'] = kwds['delimiter'].encode(encoding)
             self.reader = csv.reader(f, dialect=dialect, **kwds)
 
         def next(self):

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -2695,12 +2695,14 @@ else:
         A CSV reader which will iterate over lines in the CSV file "f",
         which is encoded in the given encoding.
 
-        On Python 3, this is replaced (below) by csv.reader, which handles
+        On Python 3, this is replaced (above) by csv.reader, which handles
         unicode.
         """
 
         def __init__(self, f, dialect=csv.excel, encoding="utf-8", **kwds):
             f = UTF8Recoder(f, encoding)
+            if 'delimiter' in kwds and isinstance(kwds['delimiter'], unicode):
+                kwds['delimiter'] = str(kwds['delimiter'])
             self.reader = csv.reader(f, dialect=dialect, **kwds)
 
         def next(self):
@@ -2723,9 +2725,19 @@ else:
         def __init__(self, f, dialect=csv.excel, encoding="utf-8", **kwds):
             # Redirect output to a queue
             self.queue = StringIO()
+            self.encoder = codecs.getincrementalencoder(encoding)()
+
+            if 'delimiter' in kwds and isinstance(kwds['delimiter'], unicode):
+                # python built-in csv reader can't handle non-ascii delimiters
+                # no matter what.
+                try:
+                    kwds['delimiter'] = str(kwds['delimiter'])
+                except UnicodeEncodeError: # pragma: no cover
+                    raise ValueError('cannot coerce delimiter %r to str' %
+                                     kwds['delimiter'])
+
             self.writer = csv.writer(self.queue, dialect=dialect, **kwds)
             self.stream = f
-            self.encoder = codecs.getincrementalencoder(encoding)()
             self.quoting = kwds.get("quoting", None)
 
         def writerow(self, row):

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -1182,11 +1182,21 @@ class CSVFormatter(object):
                     sep = sep.encode()
                 else:
                     sep = sep.encode(encoding)
-            except UnicodeEncodeError:
+            except UnicodeEncodeError as e:
                 raise ValueError('must specify single-byte separator'
-                                 'compatible with encoding. Got %r.', sep)
+                                 ' compatible with encoding. (%s)' % e)
+            try:
+                if encoding is None:
+                    decoded_sep = sep.decode()
+                else:
+                    decoded_sep = sep.decode(encoding)
+                sep = sep.encode('utf8')
+            except UnicodeEncodeError as e:
+                raise ValueError('must specify seprator encodable into utf8')
+
             if len(sep) > 1:
-                raise ValueError('must specify single-byte separator.')
+                raise NotImplementedError('separators that are multi-byte in'
+                                          ' utf8 are not supported in Python 2.')
 
 
         self.path_or_buf = path_or_buf

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -1178,10 +1178,15 @@ class CSVFormatter(object):
             path_or_buf = StringIO()
         if not compat.PY3 and isinstance(sep, compat.text_type):
             try:
-                sep = compat.binary_type(sep)
-            except UnicodeDecodeError:
-                raise ValueError('must specify single-character'
-                                 ' ascii-compatible separator')
+                if encoding is None:
+                    sep = sep.encode()
+                else:
+                    sep = sep.encode(encoding)
+            except UnicodeEncodeError:
+                raise ValueError('must specify single-byte separator'
+                                 'compatible with encoding. Got %r.', sep)
+            if len(sep) > 1:
+                raise ValueError('must specify single-byte separator.')
 
 
         self.path_or_buf = path_or_buf

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -1176,6 +1176,13 @@ class CSVFormatter(object):
 
         if path_or_buf is None:
             path_or_buf = StringIO()
+        if not compat.PY3 and isinstance(sep, compat.text_type):
+            try:
+                sep = compat.binary_type(sep)
+            except UnicodeDecodeError:
+                raise ValueError('must specify single-character'
+                                 ' ascii-compatible separator')
+
 
         self.path_or_buf = path_or_buf
         self.sep = sep

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -1190,9 +1190,10 @@ class CSVFormatter(object):
                     decoded_sep = sep.decode()
                 else:
                     decoded_sep = sep.decode(encoding)
-                sep = sep.encode('utf8')
-            except UnicodeEncodeError as e:
-                raise ValueError('must specify seprator encodable into utf8')
+                sep = decoded_sep.encode('utf8')
+            except (UnicodeEncodeError, UnicodeDecodeError) as e:
+                raise ValueError('must specify seprator encodable into utf8'
+                                 ' (%s)' % e)
 
             if len(sep) > 1:
                 raise NotImplementedError('separators that are multi-byte in'

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -402,6 +402,13 @@ def _make_parser_function(name, sep=','):
         else:
             engine = 'c'
             engine_specified = False
+        if engine == 'c' and isinstance(delimiter, compat.text_type):
+            try:
+                delimiter = delimiter.encode('ascii')
+            except Exception:
+                raise ValueError('cannot specify non-ascii delimiter with C'
+                                 ' engine')
+
 
         kwds = dict(delimiter=delimiter,
                     engine=engine,

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -615,10 +615,25 @@ class TextFileReader(object):
                                   " regex separators"
                 engine = 'python'
             elif len(sep) == 1 and isinstance(sep, compat.text_type):
-                if ord(sep) >= MAX_ORDINAL_FOR_CHAR:
+                try:
+                    if options.get('encoding'):
+                        sep_bytes = sep.encode(options['encoding'])
+                    else:
+                        sep_bytes = sep.encode()
+                except UnicodeEncodeError as e:
+                    raise ValueError('sep is not compatible with given'
+                                     ' encoding. (%s)' % e)
+                if len(sep_bytes) == 1:
+                    sep = sep_bytes
+                else:
+                    # python 2 CSV reader always works with bytes
+                    if compat.PY2:
+                        raise ValueError('Must specify single byte sep'
+                                         ' character')
                     fallback_reason = "the 'c' engine does not support"\
                                       " non-ASCII separators"
                     engine = 'python'
+
 
         if fallback_reason and engine_specified:
             raise ValueError(fallback_reason)

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -626,12 +626,13 @@ class TextFileReader(object):
                 if len(sep_bytes) == 1:
                     sep = sep_bytes
                 else:
-                    # python 2 CSV reader always works with bytes
-                    if compat.PY2:
+                    # python 2 CSV reader always works with bytes, so we can't
+                    # do anything else here but fail.
+                    if not compat.PY3:
                         raise ValueError('Must specify single byte sep'
                                          ' character')
                     fallback_reason = "the 'c' engine does not support"\
-                                      " non-ASCII separators"
+                                      " multi-byte separators"
                     engine = 'python'
 
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -6652,7 +6652,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
     def test_to_csv_read_csv_non_ascii_unicode_sep(self):
         with ensure_clean() as path:
             sep = u('\u2202')
-            with tm.assertRaisesRegexp(ValueError, 'delimiter'):
+            with tm.assertRaisesRegexp(ValueError, 'separator'):
                 df2 = read_csv(path, index_col=None, encoding='UTF-8',
                                sep=sep, engine='c')
             if compat.PY3:

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -6632,6 +6632,20 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         recons = pd.read_csv(StringIO(csv_str), index_col=0)
         assert_frame_equal(self.frame, recons)
 
+    def test_to_csv_read_csv_unicode_sep(self):
+        df = DataFrame({u('c/\u03c3'): [1, 2, 3]})
+        separators = [u(','), u('\u2202')]
+        with ensure_clean() as path:
+            for sep in separators:
+                df.to_csv(path, encoding='UTF-8', delimiter=sep)
+                df2 = read_csv(path, index_col=0, encoding='UTF-8', delimiter=sep)
+                assert_frame_equal(df, df2)
+
+                df.to_csv(path, encoding='UTF-8', index=False, delimiter=sep)
+                df2 = read_csv(path, index_col=None, encoding='UTF-8',
+                            delimiter=sep)
+                assert_frame_equal(df, df2)
+
     def test_info(self):
         io = StringIO()
         self.frame.info(buf=io)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -6662,6 +6662,83 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                 df.to_csv(path, encoding='UTF-8', index=False, sep=sep)
                 df2 = read_csv(path, index_col=None, encoding='UTF-8',
                                sep=sep, engine='python')
+    def test_to_csv_unicode_delimiter_with_encodings(self):
+        df = DataFrame({u('c/\u03c3'): [1, 2, 3]})
+        # broken bar varies based on encoding
+        sep = b'\xa6'.decode('latin1')
+        # broken bar in latin1 is single byte, so that's okay in Python 3 only
+        encoding = 'latin1'
+        with ensure_clean() as path:
+            if compat.PY3:
+                df.to_csv(path, encoding=encoding, sep=sep)
+                # explicit engine fails
+                with tm.assertRaisesRegexp(ValueError, 'sep'):
+                    pd.read_csv(path, index_col=0, encoding=encoding,
+                                sep=sep, engine='c')
+                df2 = pd.read_csv(path, index_col=0, encoding=encoding,
+                                 sep=sep)
+                assert_frame_equal(df, df2)
+            else:
+                # can't ever work in Python 2 that works only with single-byte UTF8
+                # seps
+                with tm.assertRaisesRegexp(NotImplementedError, 'sep'):
+                    df.to_csv(path, encoding=encoding, sep=sep)
+                # these two are based on validation before any reads
+                with tm.assertRaisesRegexp(ValueError, 'sep'):
+                    pd.read_csv(path, index_col=0, encoding=encoding,
+                                sep=sep, engine='c')
+                with tm.assertRaisesRegexp(NotImplementedError, 'sep'):
+                    pd.read_csv(path, index_col=0, encoding=encoding,
+                                sep=sep, engine='python')
+            # and with utf8 encoding we have a similar set of constraints
+            encoding = 'utf8'
+            if compat.PY3:
+                df.to_csv(path, encoding=encoding, sep=sep)
+                # explicit engine fails
+                with tm.assertRaisesRegexp(ValueError, 'sep'):
+                    pd.read_csv(path, index_col=0, encoding=encoding,
+                                sep=sep, engine='c')
+                with tm.assertRaisesRegexp(ValueError, 'sep'):
+                    # however fallback doesn't work this time because sep is multibyte
+                    pd.read_csv(path, index_col=0, encoding=encoding, sep=sep)
+            else:
+                # can't ever work in Python 2 that works only with single-byte UTF8
+                # seps
+                with tm.assertRaisesRegexp(NotImplementedError, 'sep'):
+                    df.to_csv(path, encoding=encoding, sep=sep)
+                # these two are based on validation before any reads
+                with tm.assertRaisesRegexp(ValueError, 'sep'):
+                    pd.read_csv(path, index_col=0, encoding=encoding,
+                                sep=sep, engine='c')
+                with tm.assertRaisesRegexp(NotImplementedError, 'sep'):
+                    pd.read_csv(path, index_col=0, encoding=encoding,
+                                sep=sep, engine='c')
+
+            # however, single-byte utf8 characters are fine
+            sep = compat.unichr(255)
+            encoding = 'utf8'
+
+            df.to_csv(path, encoding=encoding, sep=sep)
+
+            df2 = pd.read_csv(path, index_col=0, encoding=encoding,
+                              sep=sep)
+            assert_frame_equal(df, df2)
+
+    def test_to_csv_from_csv_unicode_delimiter_no_encoding(self):
+        # works with ascii
+        buf = StringIO()
+        sep = u(',')
+        self.frame.to_csv(buf, sep=sep)
+        buf.seek(0)
+        recons = pd.read_csv(buf, index_col=0, sep=sep)
+        assert_frame_equal(self.frame, recons)
+        # fails otherwise
+        with tm.assertRaisesRegexp(ValueError, 'sep'):
+            sep = compat.unichr(255)
+            self.frame.to_csv(buf, sep)
+        with tm.assertRaisesRegexp(ValueError, 'sep'):
+            sep = compat.unichr(255)
+            pd.read_csv(buf, sep)
 
     def test_info(self):
         io = StringIO()

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -6634,8 +6634,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
     def test_to_csv_read_csv_ascii_sep_as_unicode(self):
         df = DataFrame({u('c/\u03c3'): [1, 2, 3]})
+        sep = u('|')
         with ensure_clean() as path:
-            sep = u('|')
             df.to_csv(path, encoding='UTF-8', sep=sep)
             df2 = read_csv(path, index_col=0, encoding='UTF-8', sep=sep)
             assert_frame_equal(df, df2)
@@ -6650,13 +6650,15 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             assert_frame_equal(self.frame, recons)
 
     def test_to_csv_read_csv_non_ascii_unicode_sep(self):
+        df = DataFrame({u('c/\u03c3'): [1, 2, 3]})
+        sep = u('\u2202')
         with ensure_clean() as path:
-            sep = u('\u2202')
             with tm.assertRaisesRegexp(ValueError, 'separator'):
                 df2 = read_csv(path, index_col=None, encoding='UTF-8',
                                sep=sep, engine='c')
             if compat.PY3:
-                # non-ascii separators won't work in Python 2
+                # non-ascii separators won't work in Python 2, so can't do this
+                # regardless
                 df.to_csv(path, encoding='UTF-8', index=False, sep=sep)
                 df2 = read_csv(path, index_col=None, encoding='UTF-8',
                                sep=sep, engine='python')

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -4482,7 +4482,6 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         iranks = iseries.rank()
         assert_series_equal(iranks, exp)
 
-
     def test_from_csv(self):
 
         with ensure_clean() as path:
@@ -4532,6 +4531,31 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         s2 = Series.from_csv(buf, index_col=0, encoding='UTF-8')
 
         assert_series_equal(s, s2)
+
+    def test_to_csv_ascii_unicode_delimiter(self):
+        sep = u("|")
+        buf = StringIO()
+        s = Series([u("\u05d0"), "d2"], index=[u("\u05d0"), u("\u05d1")])
+
+        s.to_csv(buf, encoding='UTF-8', sep=sep)
+        buf.seek(0)
+
+        s2 = Series.from_csv(buf, index_col=0, encoding='UTF-8',
+                             sep=sep)
+
+        assert_series_equal(s, s2)
+        buf = StringIO()
+        self.ts.to_csv(buf, sep=sep)
+        buf.seek(0)
+        recons = Series.from_csv(buf, index_col=0, sep=sep)
+        assert_series_equal(self.ts, recons)
+
+    def test_to_csv_from_csv_non_ascii_unicode_delimiter_raises(self):
+        sep = u('\u2202')
+        buf = StringIO()
+
+        with tm.assertRaises(ValueError):
+            self.ts.to_csv(buf, encoding='UTF-8', sep=sep)
 
     def test_tolist(self):
         rs = self.ts.tolist()

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -4611,7 +4611,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         assert_series_equal(s, s2)
 
     def test_to_csv_from_csv_unicode_delimiter_no_encoding(self):
-        with self.ensure_clean() as path:
+        with ensure_clean() as path:
             # works with ascii
             sep = u(',')
             self.ts.to_csv(path, sep=sep)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -4532,32 +4532,98 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         assert_series_equal(s, s2)
 
-    def test_to_csv_ascii_unicode_delimiter(self):
-        sep = u("|")
+    def test_to_csv_unicode_delimiter_with_encodings(self):
+        # broken bar varies based on encoding
+        sep = b'\xa6'.decode('latin1')
+        # broken bar in latin1 is single byte, so that's okay in Python 3 only
+        encoding = 'latin1'
         buf = StringIO()
         s = Series([u("\u05d0"), "d2"], index=[u("\u05d0"), u("\u05d1")])
-
-        s.to_csv(buf, encoding='UTF-8', sep=sep)
-        buf.seek(0)
-
-        s2 = Series.from_csv(buf, index_col=0, encoding='UTF-8',
-                             sep=sep)
-
-        assert_series_equal(s, s2)
-        buf = StringIO()
-        self.ts.to_csv(buf, sep=sep)
-        buf.seek(0)
-        recons = Series.from_csv(buf, index_col=0, sep=sep)
-        assert_series_equal(self.ts, recons)
-
-    def test_to_csv_from_csv_non_ascii_unicode_delimiter_raises(self):
         if compat.PY3:
-            raise nose.SkipTest('non-ascii delimiter does not matter on py3')
-        sep = u('\u2202')
-        buf = StringIO()
+            buf = StringIO()
+            s.to_csv(buf, encoding=encoding, sep=sep)
+            buf.seek(0)
+            s2 = Series.from_csv(buf, index_col=0, encoding=encoding,
+                                sep=sep)
+            assert_series_equal(s, s2)
+            buf.seek(0)
+            # explicit engine fails
+            with tm.assertRaisesRegexp(ValueError, 'sep'):
+                Series.from_csv(buf, index_col=0, encoding=encoding,
+                                sep=sep, engine='c')
+            # but fallback should work
+            s2 = Series.from_csv(buf, index_col=0, encoding=encoding,
+                                 sep=sep)
+            assert_series_equal(s, s2)
+        else:
+            # can't ever work in Python 2 that works only with single-byte UTF8
+            # seps
+            with tm.assertRaisesRegexp(NotImplementedError, 'sep'):
+                buf = StringIO()
+                s.to_csv(buf, encoding=encoding, sep=sep)
+            # these two are based on validation before any reads
+            with tm.assertRaisesRegexp(ValueError, 'sep'):
+                buf = StringIO()
+                Series.from_csv(buf, index_col=0, encoding=encoding,
+                                sep=sep, engine='c')
+            with tm.assertRaisesRegexp(NotImplementedError, 'sep'):
+                buf = StringIO()
+                Series.from_csv(buf, index_col=0, encoding=encoding,
+                                sep=sep, engine='python')
+        # and with utf8 encoding we have a similar set of constraints
+        encoding = 'utf8'
+        if compat.PY3:
+            buf = StringIO()
+            s.to_csv(buf, encoding=encoding, sep=sep)
+            buf.seek(0)
+            # explicit engine fails
+            with tm.assertRaisesRegexp(ValueError, 'sep'):
+                Series.from_csv(buf, index_col=0, encoding=encoding,
+                                sep=sep, engine='c')
+            with tm.assertRaisesRegexp(ValueError, 'sep'):
+                # however fallback doesn't work this time because sep is multibyte
+                Series.from_csv(buf, index_col=0, encoding=encoding, sep=sep)
+        else:
+            # can't ever work in Python 2 that works only with single-byte UTF8
+            # seps
+            with tm.assertRaisesRegexp(NotImplementedError, 'sep'):
+                buf = StringIO()
+                s.to_csv(buf, encoding=encoding, sep=sep)
+            # these two are based on validation before any reads
+            with tm.assertRaisesRegexp(ValueError, 'sep'):
+                buf = StringIO()
+                Series.from_csv(buf, index_col=0, encoding=encoding,
+                                sep=sep, engine='c')
+            with tm.assertRaisesRegexp(NotImplementedError, 'sep'):
+                buf = StringIO()
+                Series.from_csv(buf, index_col=0, encoding=encoding,
+                                sep=sep, engine='python')
 
-        with tm.assertRaises(ValueError):
-            self.ts.to_csv(buf, encoding='UTF-8', sep=sep)
+        # however, single-byte utf8 characters are fine
+        sep = compat.unichr(255)
+        encoding = 'utf8'
+
+        s.to_csv(buf, encoding=encoding, sep=sep)
+        buf.seek(0)
+
+        s2 = Series.from_csv(buf, index_col=0, encoding=encoding,
+                             sep=sep)
+        assert_series_equal(s, s2)
+
+    def test_to_csv_from_csv_unicode_delimiter_no_encoding(self):
+        with self.ensure_clean() as path:
+            # works with ascii
+            sep = u(',')
+            self.ts.to_csv(path, sep=sep)
+            recons = Series.from_csv(path, index_col=0, sep=sep)
+            assert_series_equal(self.ts, recons)
+            # fails otherwise
+            with tm.assertRaisesRegexp(ValueError, 'sep'):
+                sep = compat.unichr(255)
+                self.ts.to_csv(path, sep)
+            with tm.assertRaisesRegexp(ValueError, 'sep'):
+                sep = compat.unichr(255)
+                Series.from_csv(path, sep)
 
     def test_tolist(self):
         rs = self.ts.tolist()

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -4551,6 +4551,8 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         assert_series_equal(self.ts, recons)
 
     def test_to_csv_from_csv_non_ascii_unicode_delimiter_raises(self):
+        if compat.PY3:
+            raise nose.SkipTest('non-ascii delimiter does not matter on py3')
         sep = u('\u2202')
         buf = StringIO()
 


### PR DESCRIPTION
- single byte UTF8 separators will always work if utf8 encoding is specified (i.e. seps in range(256))
- single byte delimiters with encodings will always work in Python 3, but will not work in Python 2 if they are multibyte when coerced to UTF8
- multi byte delimiters with encodings will not work on reads with C engine and will not work with writes in Python 2. (but I believe they'll work in Python 3 if they're considered to be length 1).

Closes #6035.

This was slightly complicated validation-wise, but I think it's in a good place
with tests and such. I'll squash together the commits and make sure I've
covered the relevant cases in tests.

I also noticed some weirdness with passing `delimiter` as a keyword argument that
might need to be addressed in the future.

CC @maxgrenderjones, @Midnighter if you want to take a look.
