### PR TITLE
BUG: Defined .size attribute across NDFrame objects to provide compat with numpy 1.9.1

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -75,7 +75,7 @@ Bug Fixes
 
 
 
-
+- Defined ``.size`` attribute across ``NDFrame`` objects to provide compat with numpy >= 1.9.1; buggy with ``np.array_split`` (:issue:`8846`)
 
 
 - Skip testing of histogram plots for matplotlib <= 1.2 (:issue:`8648`).

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -381,6 +381,11 @@ class NDFrame(PandasObject):
         "Number of axes / array dimensions"
         return self._data.ndim
 
+    @property
+    def size(self):
+        "number of elements in the NDFrame"
+        return np.prod(self.shape)
+
     def _expand_axes(self, key):
         new_axes = []
         for k, ax in zip(key, self.axes):

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -352,6 +352,21 @@ class Generic(object):
             self._compare(o.head(-3), o.head(7))
             self._compare(o.tail(-3), o.tail(7))
 
+
+    def test_size_compat(self):
+        # GH8846
+        # size property should be defined
+
+        o = self._construct(shape=10)
+        self.assertTrue(o.size == np.prod(o.shape))
+        self.assertTrue(o.size == 10**len(o.axes))
+
+    def test_split_compat(self):
+        # xref GH8846
+        o = self._construct(shape=10)
+        self.assertTrue(len(np.array_split(o,5)) == 5)
+        self.assertTrue(len(np.array_split(o,2)) == 2)
+
 class TestSeries(tm.TestCase, Generic):
     _typ = Series
     _comparator = lambda self, x, y: assert_series_equal(x,y)
@@ -1422,8 +1437,8 @@ class TestNDFrame(tm.TestCase):
         self.assertTrue(a.equals(c))
         self.assertTrue(a.equals(d))
         self.assertFalse(a.equals(e))
-        self.assertTrue(e.equals(f)) 
-        
+        self.assertTrue(e.equals(f))
+
     def test_describe_raises(self):
         with tm.assertRaises(NotImplementedError):
             tm.makePanel().describe()


### PR DESCRIPTION
closes #8846 
