### PR TITLE
BUG: type change breaks BlockManager integrity

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -71,6 +71,7 @@ Bug Fixes
 - ``Timedelta`` kwargs may now be numpy ints and floats (:issue:`8757`).
 - ``sql_schema`` now generates dialect appropriate ``CREATE TABLE`` statements (:issue:`8697`)
 - ``slice`` string method now takes step into account (:issue:`8754`)
+- Bug in ``BlockManager`` where setting values with different type would break block integrity (:issue:`8850`)
 - Fix negative step support for label-based slices (:issue:`8753`)
 
   Old behavior:

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2985,7 +2985,7 @@ class BlockManager(PandasObject):
             loc = [loc]
 
         blknos = self._blknos[loc]
-        blklocs = self._blklocs[loc]
+        blklocs = self._blklocs[loc].copy()
 
         unfit_mgr_locs = []
         unfit_val_locs = []

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -430,6 +430,17 @@ class TestBlockManager(tm.TestCase):
         mgr2.set('quux', randn(N))
         self.assertEqual(mgr2.get('quux').dtype, np.float_)
 
+    def test_set_change_dtype_slice(self): # GH8850
+        cols = MultiIndex.from_tuples([('1st','a'), ('2nd','b'), ('3rd','c')])
+        df = DataFrame([[1.0, 2, 3], [4.0, 5, 6]], columns=cols)
+        df['2nd'] = df['2nd'] * 2.0
+
+        self.assertEqual(sorted(df.blocks.keys()), ['float64', 'int64'])
+        assert_frame_equal(df.blocks['float64'],
+                DataFrame([[1.0, 4.0], [4.0, 10.0]], columns=cols[:2]))
+        assert_frame_equal(df.blocks['int64'],
+                DataFrame([[3], [6]], columns=cols[2:]))
+
     def test_copy(self):
         shallow = self.mgr.copy(deep=False)
 


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/8850

on master:

```
>>> cols = MultiIndex.from_tuples([('1st', 'a'), ('2nd', 'b'), ('3rd', 'c')])
>>> df = DataFrame([[1.0, 2, 3], [4.0, 5, 6]], columns=cols)
>>> df['2nd'] = df['2nd'] * 2.0  # type change in block manager
/usr/lib/python3.4/site-packages/numpy/lib/function_base.py:3612: FutureWarning: in the future negative indices will not be ignored by `numpy.delete`.
  "`numpy.delete`.", FutureWarning)
>>> df.values
...
  File "/usr/lib/python3.4/site-packages/pandas-0.15.1_72_gf504885-py3.4-linux-x86_64.egg/pandas/core/internals.py", line 2392, in _verify_integrity
    tot_items))
AssertionError: Number of manager items must equal union of block items
# manager items: 3, # tot_items: 4
>>> df.blocks
...
  File "/usr/lib/python3.4/site-packages/pandas-0.15.1_72_gf504885-py3.4-linux-x86_64.egg/pandas/core/internals.py", line 2392, in _verify_integrity
    tot_items))
AssertionError: Number of manager items must equal union of block items
# manager items: 3, # tot_items: 4
```

`._data` is also broken:

```
>>> df._data
BlockManager
Items:       
1st  a
2nd  b
3rd  c
Axis 1: Int64Index([0, 1], dtype='int64')
FloatBlock: slice(0, 1, 1), 1 x 2, dtype: float64
IntBlock: slice(1, 3, 1), 2 x 2, dtype: int64
FloatBlock: slice(1, 2, 1), 1 x 2, dtype: float64
```

integer block is bigger than what it should be and overlaps with one of the float blocks.
