### PR TITLE
BUG: Panel4D setitem by indexer to Series fails for mixed-dtype

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -151,3 +151,4 @@ Bug Fixes
   of the level names are numbers (:issue:`8584`).
 - Bug in ``MultiIndex`` where ``__contains__`` returns wrong result if index is
   not lexically sorted or unique (:issue:`7724`)
+- Bug for mixed-dtype Panel4D that prevented doing a setitem to a series using an indexer (:issue:`8854`)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -421,7 +421,7 @@ class _NDFrameIndexer(object):
 
                 l = len(value)
                 item = labels[0]
-                index = self.obj[item].index
+                index = self.obj[item]._stat_axis
 
                 # equal len list/ndarray
                 if len(index) == l:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -419,9 +419,14 @@ class _NDFrameIndexer(object):
                 if not len(labels) == 1 or not np.iterable(value):
                     return False
 
+                try:
+                    axis_number = next(i for i in range(len(plane_indexer)) 
+                                       if _is_null_slice(plane_indexer[i]))
+                except StopIteration:
+                    return False
                 l = len(value)
                 item = labels[0]
-                index = self.obj[item]._stat_axis
+                index = self.obj[item].axes[axis_number]
 
                 # equal len list/ndarray
                 if len(index) == l:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -423,7 +423,7 @@ class _NDFrameIndexer(object):
                     axis_number = next(i for i in range(len(plane_indexer)) 
                                        if _is_null_slice(plane_indexer[i]))
                 except StopIteration:
-                    return False
+                    axis_number = 0
                 l = len(value)
                 item = labels[0]
                 index = self.obj[item].axes[axis_number]

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -408,6 +408,14 @@ class CheckIndexing(object):
         # GH 8702
         self.panel4d['foo'] = 'bar'
 
+        # Series
+        # GH 8854
+        panel4dc = self.panel4d.copy()
+        s = panel4dc.iloc[0,0,:,0]
+        s.iloc[:] = 1
+        panel4dc.iloc[0,0,:,0] = s
+        self.assertTrue((panel4dc.iloc[0,0,:,0].values == 1).all())
+
         # scalar
         panel4dc = self.panel4d.copy()
         panel4dc.iloc[0] = 1
@@ -416,8 +424,6 @@ class CheckIndexing(object):
         self.assertTrue((panel4dc.iloc[0].values == 1).all())
         self.assertTrue(panel4dc.iloc[1].values.all())
         self.assertTrue((panel4dc.iloc[2].values == 'foo').all())
-
-
 
     def test_comparisons(self):
         p1 = tm.makePanel4D()


### PR DESCRIPTION
This is another tweak to `_setitem_with_indexer` that allows it better to comprehend higher dimensional frames of mixed-dtype. With this tweak setting by indexer to a Series now works. Unfortunately setting to a DataFrame is still broken. I plan to open an issue for that.
