### PR TITLE
BUG: DataFrame.stack(..., dropna=False) with partial MultiIndex.

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -113,7 +113,8 @@ Bug Fixes
 
 - Bug where ``get_data_google``returned object dtypes (:issue:`3995`)
 
-
+- Bug in ``DataFrame.stack(..., dropna=False)`` when the DataFrame's ``columns`` is a ``MultiIndex``
+  whose ``labels`` do not reference all its ``levels``. (:issue:`8844`)
 
 
 

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -648,7 +648,9 @@ def _stack_multi_columns(frame, level_num=-1, dropna=True):
     # time to ravel the values
     new_data = {}
     level_vals = this.columns.levels[-1]
-    levsize = len(level_vals)
+    level_labels = sorted(set(this.columns.labels[-1]))
+    level_vals_used = level_vals[level_labels]
+    levsize = len(level_labels)
     drop_cols = []
     for key in unique_groups:
         loc = this.columns.get_loc(key)
@@ -661,7 +663,7 @@ def _stack_multi_columns(frame, level_num=-1, dropna=True):
         elif slice_len != levsize:
             chunk = this.ix[:, this.columns[loc]]
             chunk.columns = level_vals.take(chunk.columns.labels[-1])
-            value_slice = chunk.reindex(columns=level_vals).values
+            value_slice = chunk.reindex(columns=level_vals_used).values
         else:
             if frame._is_mixed_type:
                 value_slice = this.ix[:, this.columns[loc]].values
@@ -685,7 +687,7 @@ def _stack_multi_columns(frame, level_num=-1, dropna=True):
         new_names = [this.index.name]  # something better?
 
     new_levels.append(frame.columns.levels[level_num])
-    new_labels.append(np.tile(np.arange(levsize), N))
+    new_labels.append(np.tile(level_labels, N))
     new_names.append(frame.columns.names[level_num])
 
     new_index = MultiIndex(levels=new_levels, labels=new_labels,


### PR DESCRIPTION
Closes #8844

Fixes `DataFrame.stack(..., dropna=False)` when the columns consist of a "partial" `MultiIndex`, i.e. one in which the `labels` don't reference all the `levels`.
