### PR TITLE
REF: refactor **kwargs usage

### DIFF
--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -913,7 +913,7 @@ class Categorical(PandasObject):
             result = result[::-1]
         return result
 
-    def order(self, inplace=False, ascending=True, na_position='last', **kwargs):
+    def order(self, inplace=False, ascending=True, na_position='last'):
         """ Sorts the Category by category value returning a new Categorical by default.
 
         Only ordered Categoricals can be sorted!
@@ -972,7 +972,7 @@ class Categorical(PandasObject):
                                name=self.name, fastpath=True)
 
 
-    def sort(self, inplace=True, ascending=True, na_position='last', **kwargs):
+    def sort(self, inplace=True, ascending=True, na_position='last'):
         """ Sorts the Category inplace by category value.
 
         Only ordered Categoricals can be sorted!
@@ -997,7 +997,8 @@ class Categorical(PandasObject):
         --------
         Category.order
         """
-        return self.order(inplace=inplace, ascending=ascending, **kwargs)
+        return self.order(inplace=inplace, ascending=ascending,
+                na_position=na_position)
 
     def ravel(self, order='C'):
         """ Return a flattened (numpy) array.
@@ -1033,7 +1034,7 @@ class Categorical(PandasObject):
         """
         return np.asarray(self)
 
-    def fillna(self, fill_value=None, method=None, limit=None, **kwargs):
+    def fillna(self, fill_value=None, method=None, limit=None):
         """ Fill NA/NaN values using the specified method.
 
         Parameters

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1559,7 +1559,7 @@ def backfill_2d(values, limit=None, mask=None, dtype=None):
     return values
 
 
-def _clean_interp_method(method, order=None, **kwargs):
+def _clean_interp_method(method, order=None):
     valid = ['linear', 'time', 'index', 'values', 'nearest', 'zero', 'slinear',
              'quadratic', 'cubic', 'barycentric', 'polynomial',
              'krogh', 'piecewise_polynomial',
@@ -1574,7 +1574,7 @@ def _clean_interp_method(method, order=None, **kwargs):
 
 
 def interpolate_1d(xvalues, yvalues, method='linear', limit=None,
-                   fill_value=None, bounds_error=False, **kwargs):
+                   fill_value=None, bounds_error=False, order=None):
     """
     Logic for the 1-d interpolation.  The result should be 1-d, inputs
     xvalues and yvalues will each be 1-d arrays of the same length.
@@ -1657,14 +1657,14 @@ def interpolate_1d(xvalues, yvalues, method='linear', limit=None,
 
         result[firstIndex:][invalid] = _interpolate_scipy_wrapper(
             valid_x, valid_y, new_x, method=method, fill_value=fill_value,
-            bounds_error=bounds_error, **kwargs)
+            bounds_error=bounds_error, order=order)
         if limit:
             result[violate_limit] = np.nan
         return result
 
 
 def _interpolate_scipy_wrapper(x, y, new_x, method, fill_value=None,
-                               bounds_error=False, order=None, **kwargs):
+                               bounds_error=False, order=None):
     """
     passed off to scipy.interpolate.interp1d. method is scipy's kind.
     Returns an array interpolated at new_x.  Add any new methods to

--- a/pandas/core/config.py
+++ b/pandas/core/config.py
@@ -109,7 +109,11 @@ def _set_option(*args, **kwargs):
                              "arguments")
 
     # default to false
-    silent = kwargs.get('silent', False)
+    silent = kwargs.pop('silent', False)
+
+    if kwargs:
+        raise TypeError('_set_option() got an unexpected keyword '
+                'argument "{0}"'.format(list(kwargs.keys())[0]))
 
     for k, v in zip(args[::2], args[1::2]):
         key = _get_single_key(k, silent)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -910,7 +910,7 @@ class GroupBy(PandasObject):
 
         return result
 
-    def cumcount(self, **kwargs):
+    def cumcount(self, ascending=True):
         """
         Number each item in each group from 0 to the length of that group - 1.
 
@@ -955,7 +955,6 @@ class GroupBy(PandasObject):
 
         """
         self._set_selection_from_grouper()
-        ascending = kwargs.pop('ascending', True)
 
         index = self._selected_obj.index
         cumcounts = self._cumcount_array(ascending=ascending)
@@ -1016,15 +1015,13 @@ class GroupBy(PandasObject):
         tail = obj[in_tail]
         return tail
 
-    def _cumcount_array(self, arr=None, **kwargs):
+    def _cumcount_array(self, arr=None, ascending=True):
         """
         arr is where cumcount gets its values from
 
         note: this is currently implementing sort=False (though the default is sort=True)
               for groupby in general
         """
-        ascending = kwargs.pop('ascending', True)
-
         if arr is None:
             arr = np.arange(self.grouper._max_groupsize, dtype='int64')
 
@@ -3094,7 +3091,7 @@ class NDFrameGroupBy(GroupBy):
         for name, group in gen:
             object.__setattr__(group, 'name', name)
 
-            res = func(group)
+            res = func(group, *args, **kwargs)
 
             try:
                 res = res.squeeze()

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -415,7 +415,7 @@ class Index(IndexOpsMixin, PandasObject):
                                  quote_strings=True)
         return "%s(%s, dtype='%s')" % (type(self).__name__, prepr, self.dtype)
 
-    def to_series(self, **kwargs):
+    def to_series(self):
         """
         Create a Series with both index and values equal to the index keys
         useful with map for returning an indexer based on an index
@@ -1604,7 +1604,7 @@ class Index(IndexOpsMixin, PandasObject):
                            left_indexer, right_indexer)
         return indexer
 
-    def get_indexer_non_unique(self, target, **kwargs):
+    def get_indexer_non_unique(self, target):
         """ return an indexer suitable for taking from a non unique index
             return the labels in the same order as the target, and
             return a missing indexer into the target (missing are marked as -1
@@ -3766,7 +3766,7 @@ class MultiIndex(Index):
             return Index(new_tuples)
 
     def argsort(self, *args, **kwargs):
-        return self.values.argsort()
+        return self.values.argsort(*args, **kwargs)
 
     def repeat(self, n):
         return MultiIndex(levels=self.levels,

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -278,7 +278,7 @@ class Block(PandasObject):
 
     def apply(self, func, **kwargs):
         """ apply the function to my values; return a block if we are not one """
-        result = func(self.values)
+        result = func(self.values, **kwargs)
         if not isinstance(result, Block):
             result = make_block(values=_block_shape(result), placement=self.mgr_locs,)
 

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -145,7 +145,12 @@ class Panel(NDFrame):
         if dtype is not None:
             dtype = self._validate_dtype(dtype)
 
-        passed_axes = [kwargs.get(a) for a in self._AXIS_ORDERS]
+        passed_axes = [kwargs.pop(a, None) for a in self._AXIS_ORDERS]
+
+        if kwargs:
+            raise TypeError('_init_data() got an unexpected keyword '
+                    'argument "{0}"'.format(list(kwargs.keys())[0]))
+
         axes = None
         if isinstance(data, BlockManager):
             if any(x is not None for x in passed_axes):
@@ -471,7 +476,11 @@ class Panel(NDFrame):
             raise TypeError('There must be an argument for each axis, you gave'
                             ' {0} args, but {1} are required'.format(nargs,
                                                                      nreq))
-        takeable = kwargs.get('takeable')
+        takeable = kwargs.pop('takeable', None)
+
+        if kwargs:
+            raise TypeError('get_value() got an unexpected keyword '
+                    'argument "{0}"'.format(list(kwargs.keys())[0]))
 
         if takeable is True:
             lower = self._iget_item_cache(args[0])
@@ -506,7 +515,11 @@ class Panel(NDFrame):
             raise TypeError('There must be an argument for each axis plus the '
                             'value provided, you gave {0} args, but {1} are '
                             'required'.format(nargs, nreq))
-        takeable = kwargs.get('takeable')
+        takeable = kwargs.pop('takeable', None)
+
+        if kwargs:
+            raise TypeError('set_value() got an unexpected keyword '
+                    'argument "{0}"'.format(list(kwargs.keys())[0]))
 
         try:
             if takeable is True:
@@ -607,7 +620,7 @@ class Panel(NDFrame):
         """ don't allow a multi reindex on Panel or above ndim """
         return False
 
-    def dropna(self, axis=0, how='any', inplace=False, **kwargs):
+    def dropna(self, axis=0, how='any', inplace=False):
         """
         Drop 2D from panel, holding passed axis constant
 
@@ -1065,7 +1078,7 @@ class Panel(NDFrame):
 
         return self._construct_return_type(result, axes)
 
-    def _construct_return_type(self, result, axes=None, **kwargs):
+    def _construct_return_type(self, result, axes=None):
         """ return the type for the ndim of the result """
         ndim = getattr(result,'ndim',None)
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2374,6 +2374,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         inplace : boolean, default False
             Do operation in place.
         """
+        kwargs.pop('how', None)
+        if kwargs:
+            raise TypeError('dropna() got an unexpected keyword '
+                    'argument "{0}"'.format(list(kwargs.keys())[0]))
+
         axis = self._get_axis_number(axis or 0)
         result = remove_na(self)
         if inplace:

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -369,6 +369,26 @@ class Generic(object):
         self.assertTrue(len(np.array_split(o,5)) == 5)
         self.assertTrue(len(np.array_split(o,2)) == 2)
 
+    def test_unexpected_keyword(self):  # GH8597
+        from pandas.util.testing import assertRaisesRegexp
+
+        df = DataFrame(np.random.randn(5, 2), columns=['jim', 'joe'])
+        ca = pd.Categorical([0, 0, 2, 2, 3, np.nan])
+        ts = df['joe'].copy()
+        ts[2] = np.nan
+
+        with assertRaisesRegexp(TypeError, 'unexpected keyword'):
+            df.drop('joe', axis=1, in_place=True)
+
+        with assertRaisesRegexp(TypeError, 'unexpected keyword'):
+            df.reindex([1, 0], inplace=True)
+
+        with assertRaisesRegexp(TypeError, 'unexpected keyword'):
+            ca.fillna(0, inplace=True)
+
+        with assertRaisesRegexp(TypeError, 'unexpected keyword'):
+            ts.fillna(0, in_place=True)
+
 class TestSeries(tm.TestCase, Generic):
     _typ = Series
     _comparator = lambda self, x, y: assert_series_equal(x,y)
@@ -602,7 +622,7 @@ class TestSeries(tm.TestCase, Generic):
         result = s.interpolate(method='slinear')
         assert_series_equal(result, expected)
 
-        result = s.interpolate(method='slinear', donwcast='infer')
+        result = s.interpolate(method='slinear', downcast='infer')
         assert_series_equal(result, expected)
         # nearest
         expected = Series([1, 3, 3, 12, 12, 25])

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -4708,26 +4708,6 @@ class TestGroupBy(tm.TestCase):
                 expected = getattr(frame,op)(level=level,axis=axis)
                 assert_frame_equal(result, expected)
 
-    def test_regression_kwargs_whitelist_methods(self):
-        # GH8733
-
-        index = MultiIndex(levels=[['foo', 'bar', 'baz', 'qux'],
-                                   ['one', 'two', 'three']],
-                           labels=[[0, 0, 0, 1, 1, 2, 2, 3, 3, 3],
-                                   [0, 1, 2, 0, 1, 1, 2, 0, 1, 2]],
-                           names=['first', 'second'])
-        raw_frame = DataFrame(np.random.randn(10, 3), index=index,
-                               columns=Index(['A', 'B', 'C'], name='exp'))
-
-        grouped = raw_frame.groupby(level=0, axis=1)
-        grouped.all(test_kwargs='Test kwargs')
-        grouped.any(test_kwargs='Test kwargs')
-        grouped.cumcount(test_kwargs='Test kwargs')
-        grouped.mad(test_kwargs='Test kwargs')
-        grouped.cummin(test_kwargs='Test kwargs')
-        grouped.skew(test_kwargs='Test kwargs')
-        grouped.cumprod(test_kwargs='Test kwargs')
-
     def test_groupby_blacklist(self):
         from string import ascii_lowercase
         letters = np.array(list(ascii_lowercase))


### PR DESCRIPTION
related issue: https://github.com/pydata/pandas/issues/8597. 

among changes:

[tests/test_generic.py](https://github.com/pydata/pandas/blob/0a2ea0ac39a74771d54b91522728f6092b0ef897/pandas/tests/test_generic.py#L603) `downcast` is misspelled `donwcast`, but no error is raised, because of how `**kwargs` is used.

[core/categorical.py:sort](https://github.com/pydata/pandas/blob/0a2ea0ac39a74771d54b91522728f6092b0ef897/pandas/core/categorical.py#L945) `na_position` is not passed to `self.order`.

[core/categorical.py:fillna](https://github.com/pydata/pandas/blob/0a2ea0ac39a74771d54b91522728f6092b0ef897/pandas/core/categorical.py#L981) `Categorical.fillna` does not support `inplace` as opposed to say `Series.fillna` or `DataFrame.fillna`, but `**kwargs` being there causes below code to just silently ignore passed argument:

```
>>> ca = pd.Categorical([0, 0, 2, 2, 3, np.nan])
>>> ca.fillna(0, inplace=True)
[0, 0, 2, 2, 3, 0]
Categories (3, int64): [0 < 2 < 3]
>>> ca
[0, 0, 2, 2, 3, NaN]
Categories (3, int64): [0 < 2 < 3]
```

[This test](https://github.com/pydata/pandas/blob/0a2ea0ac39a74771d54b91522728f6092b0ef897/pandas/tests/test_groupby.py#L4418) is basically testing that you can specify _any_ keyword argument and it is just silently ignored. I cannot think of any case that this would be a good idea, or has any use case.

multiple instances where `*args` or `*kwargs` are not passed to inner function or have any use at all, as can be seen in the PR diff.
