### PR TITLE
BUG/ENH: cleanup for Timedelta arithmetic

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -66,6 +66,11 @@ Enhancements
 - Added support for ``utcfromtimestamp()``, ``fromtimestamp()``, and ``combine()`` on `Timestamp` class (:issue:`5351`).
 - Added Google Analytics (`pandas.io.ga`) basic documentation (:issue:`8835`). See :ref:`here<remote_data.ga>`.
 - Added flag ``order_categoricals`` to ``StataReader`` and ``read_stata`` to select whether to order imported categorical data (:issue:`8836`).  See :ref:`here <io.stata-categorical>` for more information on importing categorical variables from Stata data files.
+- ``Timedelta`` arithmetic returns ``NotImplemented`` in unknown cases, allowing extensions
+by custom classes (:issue:`8813`).
+- ``Timedelta`` now supports arithemtic with ``numpy.ndarray`` objects of the appropriate
+dtype (numpy 1.8 or newer only) (:issue:`8884`).
+- Added ``Timedelta.to_timedelta64`` method to the public API (:issue:`8884`).
 
 .. _whatsnew_0152.performance:
 
@@ -89,6 +94,8 @@ Bug Fixes
 - Bug in slicing a multi-index with an empty list and at least one boolean indexer (:issue:`8781`)
 - ``io.data.Options`` now raises ``RemoteDataError`` when no expiry dates are available from Yahoo (:issue:`8761`).
 - ``Timedelta`` kwargs may now be numpy ints and floats (:issue:`8757`).
+- Fixed several outstanding bugs for ``Timedelta`` arithmetic and comparisons
+(:issue:`8813`, :issue:`5963`, :issue:`5436`).
 - ``sql_schema`` now generates dialect appropriate ``CREATE TABLE`` statements (:issue:`8697`)
 - ``slice`` string method now takes step into account (:issue:`8754`)
 - Bug in ``BlockManager`` where setting values with different type would break block integrity (:issue:`8850`)

--- a/pandas/tseries/base.py
+++ b/pandas/tseries/base.py
@@ -321,6 +321,7 @@ class DatetimeIndexOpsMixin(object):
             else:  # pragma: no cover
                 return NotImplemented
         cls.__add__ = __add__
+        cls.__radd__ = __add__
 
         def __sub__(self, other):
             from pandas.core.index import Index
@@ -343,6 +344,10 @@ class DatetimeIndexOpsMixin(object):
             else:  # pragma: no cover
                 return NotImplemented
         cls.__sub__ = __sub__
+
+        def __rsub__(self, other):
+            return -self + other
+        cls.__rsub__ = __rsub__
 
         cls.__iadd__ = __add__
         cls.__isub__ = __sub__

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -311,7 +311,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, Int64Index):
                 result = self._maybe_mask_results(result,convert='float64')
                 return Index(result,name=self.name,copy=False)
 
-        raise TypeError("can only perform ops with timedelta like values")
+        return NotImplemented
 
     def _add_datelike(self, other):
 


### PR DESCRIPTION
Fixes #8813 
Fixes #5963
Fixes #5436

If the other argument has a dtype attribute, I assume that it is ndarray-like
and convert the `Timedelta` into a `np.timedelta64` object. Alternatively, we
could just return `NotImplemented` and let the other type handle it, but this
has the bonus of making `Timedelta` compatible with ndarrays.

I also added a `Timedelta.to_timedelta64()` method to the public API. I
couldn't find a listing for `Timedelta` in the API docs -- we should probably
add that, right?

Next up would be a similar treatment for `Timestamp`.

CC @immerrr
