### PR TITLE
ENH/VIS: Pass DataFrame column to size argument in DataFrame.scatter

### DIFF
--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -8,7 +8,7 @@
    import pandas as pd
    from numpy.random import randn, rand, randint
    np.random.seed(123456)
-   from pandas import DataFrame, Series, date_range, options
+   from pandas import DataFrame, Series, date_range, options, Categorical
    import pandas.util.testing as tm
    np.set_printoptions(precision=4, suppress=True)
    import matplotlib.pyplot as plt
@@ -587,18 +587,39 @@ each point:
 
    plt.close('all')
 
-You can pass other keywords supported by matplotlib ``scatter``.
-Below example shows a bubble chart using a dataframe column values as bubble size.
+You can also pass a column name as the ``s`` (size) argument to have
+the point sizes scale according to that column's values. The minimum and
+maximum sizes of the bubbles (in points) are controlled by the
+``size_range`` argument, with a default range of ``(50, 1000)``. The
+below example shows a bubble chart using a dataframe column values
+as bubble size.
 
 .. ipython:: python
 
-   @savefig scatter_plot_bubble.png
-   df.plot(kind='scatter', x='a', y='b', s=df['c']*200);
+   @savefig scatter_plot_sizes.png
+   df.plot(kind='scatter', x='a', y='b', s='c');
 
 .. ipython:: python
    :suppress:
 
    plt.close('all')
+
+Categorical columns can also be used to set point sizes, producing
+a set of equally spaced point sizes:
+
+.. ipython:: python
+
+    df['group'] = Categorical(randint(1, 4, 50))
+    @savefig scatter_plot_categorical_sizes.png
+    df.plot(kind='scatter', x='a', y='b', s='group')
+
+.. ipython:: python
+   :suppress:
+
+   plt.close('all')
+
+You can pass other keywords supported by matplotlib ``scatter``, e.g. ``alpha``
+to control the transparency of points.
 
 See the :meth:`scatter <matplotlib.axes.Axes.scatter>` method and the
 `matplotlib scatter documenation <http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.scatter>`__ for more.

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -622,9 +622,8 @@ a set of equally spaced point sizes:
    plt.close('all')
 
 You can pass other keywords supported by matplotlib ``scatter``, e.g. ``alpha``
-to control the transparency of points.
-
-See the :meth:`scatter <matplotlib.axes.Axes.scatter>` method and the
+to control the transparency of points. See the
+:meth:`scatter <matplotlib.axes.Axes.scatter>` method and the
 `matplotlib scatter documenation <http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.scatter>`__ for more.
 
 .. _visualization.hexbin:

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -588,7 +588,10 @@ each point:
    plt.close('all')
 
 You can also pass a column name as the ``s`` (size) argument to have
-the point sizes scale according to that column's values. The minimum and
+the point sizes scale according to that column's values. Currently
+this is only supported for string column names.
+
+The minimum and
 maximum sizes of the bubbles (in points) are controlled by the
 ``size_range`` argument, with a default range of ``(50, 1000)``. The
 below example shows a bubble chart using a dataframe column values

--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -66,6 +66,7 @@ Enhancements
 - Added support for ``utcfromtimestamp()``, ``fromtimestamp()``, and ``combine()`` on `Timestamp` class (:issue:`5351`).
 - Added Google Analytics (`pandas.io.ga`) basic documentation (:issue:`8835`). See :ref:`here<remote_data.ga>`.
 - Added flag ``order_categoricals`` to ``StataReader`` and ``read_stata`` to select whether to order imported categorical data (:issue:`8836`).  See :ref:`here <io.stata-categorical>` for more information on importing categorical variables from Stata data files.
+- Added support for passing a column name as the size argument to ``DataFrame.plot(kind='scatter')``, along with a ``size_range`` argument to control scaling (:issue:`8244`).
 
 .. _whatsnew_0152.performance:
 

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1374,7 +1374,8 @@ class MPLPlot(object):
 class ScatterPlot(MPLPlot):
     _layout_type = 'single'
 
-    def __init__(self, data, x, y, c=None, **kwargs):
+    def __init__(self, data, x, y, c=None, s=None,
+                 size_range=(50, 1000), **kwargs):
         MPLPlot.__init__(self, data, **kwargs)
         if x is None or y is None:
             raise ValueError( 'scatter requires and x and y column')
@@ -1387,6 +1388,8 @@ class ScatterPlot(MPLPlot):
         self.x = x
         self.y = y
         self.c = c
+        self.s = s
+        self.size_range = size_range
 
     @property
     def nseries(self):
@@ -1398,7 +1401,7 @@ class ScatterPlot(MPLPlot):
 
         import matplotlib.pyplot as plt
 
-        x, y, c, data = self.x, self.y, self.c, self.data
+        x, y, c, s, data = self.x, self.y, self.c, self.s, self.data
         ax = self.axes[0]
 
         # plot a colorbar only if a colormap is provided or necessary
@@ -1415,12 +1418,20 @@ class ScatterPlot(MPLPlot):
         else:
             c_values = c
 
+        # Set up size scaling if necessary
+        if s is None:
+            s_values = self.plt.rcParams['lines.markersize']
+        elif s in self.data.columns:
+            s_values = self._convert_size_vals_to_points(self.data[s].values)
+        else:
+            s_values = s
+
         if self.legend and hasattr(self, 'label'):
             label = self.label
         else:
             label = None
         scatter = ax.scatter(data[x].values, data[y].values, c=c_values,
-                             label=label, cmap=cmap, **self.kwds)
+                             s=s_values, label=label, cmap=cmap, **self.kwds)
         if cb:
             img = ax.collections[0]
             kws = dict(ax=ax)
@@ -1436,6 +1447,13 @@ class ScatterPlot(MPLPlot):
             err_kwds = dict(errors_x, **errors_y)
             err_kwds['ecolor'] = scatter.get_facecolor()[0]
             ax.errorbar(data[x].values, data[y].values, linestyle='none', **err_kwds)
+
+    def _convert_size_vals_to_points(self, vals):
+        min_size, max_size = self.size_range
+        val_range = vals.max() - vals.min()
+        normalized_vals = (vals - vals.min()) / val_range
+        point_sizes = (min_size + (normalized_vals * (max_size - min_size)))
+        return point_sizes
 
     def _post_plot_logic(self):
         ax = self.axes[0]

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1394,7 +1394,7 @@ class ScatterPlot(MPLPlot):
         # generation starts and non-numeric data thrown away
         if s is None:
             self.s_values = self.plt.rcParams['lines.markersize']
-        elif s in self.data.columns:
+        elif isinstance(s, str) and s in self.data.columns:
             self.s_values = self._convert_column_to_size(s)
         else:
             self.s_values = s


### PR DESCRIPTION
Originally discussed in #8244. Currently this only uses the column from the dataframe if the `s` argument is a string, supporting int column names is ambiguous and liable to break existing code, but if people can think of a good way to do this I'll try to add it.

Example output:

``` python
import pandas as pd
import numpy as np
import random

df = pd.DataFrame({
    'x': np.linspace(0, 50, 6),
    'y': np.linspace(0, 20, 6),
    'cat_column': random.sample('abcdabcdabcd', 6)
})
df['cat_column'] = pd.Categorical(df['cat_column'])

# Numeric column: linear scaling of point sizes
df.plot(kind='scatter', x='x', y='y', s='x')
```

![image](https://cloud.githubusercontent.com/assets/1460294/5163679/70a09820-7422-11e4-8bf3-7a15fb072f71.png)

``` python
# Categorical columns: fixed set of sizes
df.plot(kind='scatter', x='x', y='y', s='cat_column')
```

![image](https://cloud.githubusercontent.com/assets/1460294/5163691/91671f16-7422-11e4-92fd-18b7f67b5b41.png)

The minimum and maximum point sizes we scale have a default range of  `(50, 1000)`, and
can be adjusted with the `size_range` arg:

``` python
# Smaller range of sizes than default
df.plot(kind='scatter', x='x', y='y', s='x',
        size_range=(200, 800))
```

![image](https://cloud.githubusercontent.com/assets/1460294/5163729/04e4f44a-7423-11e4-9e85-902d9dd1caaa.png)

Picking good defaults for the range of sizes is pretty hard as these sizes are absolute- matplotlib
sets the size in terms of points. The ability to tweak up and down with the `size_range` arg is
probably going to be needed, but open to suggestions on good defaults.
. 
