### PR TITLE
	modified:   pandas/io/ga.py

### DIFF
--- a/pandas/io/ga.py
+++ b/pandas/io/ga.py
@@ -324,7 +324,7 @@ class GDataReader(OAuthDataReader):
                 
                 parse_items = ['index_col', 'parse_dates', 'keep_date_col', \
                                 'date_parser', 'dayfirst', 'na_values', \
-                                'converters', 'sort', 'ascending']
+                                'converters', 'sort']
                 
                 # in case a reverse sort has been sent to GA...
                 def _maybe_fix_sort(item):
@@ -375,10 +375,12 @@ class GDataReader(OAuthDataReader):
                 'dayfirst'      : False,
                 'na_values'     : None,
                 'converters'    : None,
-                'sort'          : True, 
+                'sort'          : True,
+                'ascending'     : True,
                 'header'        : None, }
         
         parse_opts.update(kwargs)
+        asc = parse_opts.pop('ascending')
         
         parse_opts['names'] = _get_col_names(col_info)
         df = psr._read(rows, parse_opts)
@@ -389,7 +391,7 @@ class GDataReader(OAuthDataReader):
         elif isinstance(parse_opts['sort'], \
                 (compat.string_types, list, tuple, np.ndarray)):
             return df.sort(columns=parse_opts['sort'], \
-                            ascending=parse_opts['ascending'])
+                            ascending=asc)
 
         return df
 


### PR DESCRIPTION
```
        ENH
    I've made a number of alterations to this module to improve the
    usability of it.

    1.  A feature has been added to the 'filters' keyword, in that
        compound filters can now be created with AND and OR combinations
        as in the API, while still allowing the user to create
        the filters via lists of strings without the 'ga:' prefix. In
        particulare, compound filters can be formed as:

        filters = ['filter_00', 'and', 'filter_01', 'or', 'filter_02']

        where no defuault behaviour has been created, thus ensuring that
        the compound item is formed the way the user intends it to be.
        The 'and' and 'or' separators are case-insensitive.

    2.  The 'sort' keyword is now passed to the query, and works as
        it should with the API. That is, the current 'sort' keyword only
        acts on the retrieved data when the parser is constructing the
        local DataFrame object. This behaviour is now changed, in that
        the 'sort' keyword is included in the query, as well as acting
        as previous on the parser. Reverse-ordering as in the API is
        maintained by simply including negaitve sign in front of the
        metric / dimension that is being sorted on.

        This is a sublte but important difference, in that the user can
        now include something like:

        sort = '-pageviews'

        to obtain the top N-many results in a query, which is currently
        not possible without obtaining all results and sorting them
        locally.

        Defualt behaviour has been altered, in that the defualt sort
        is now None (sent to query) while the local dataframe is still
        sorted on it's index.

    3.  I didn't like the combination of positional and named keyword
        arguments in the methods, so I have altered the bahaviour of
        the module to use only named keyword aguments.  Thus, the user
        is now able to form a query as a single dictionary item and pass
        it to, say, the read_ga() method.
```
