### PR TITLE
BUG/ENH: cleanup for Timestamp arithmetic

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -66,9 +66,9 @@ Enhancements
 - Added support for ``utcfromtimestamp()``, ``fromtimestamp()``, and ``combine()`` on `Timestamp` class (:issue:`5351`).
 - Added Google Analytics (`pandas.io.ga`) basic documentation (:issue:`8835`). See :ref:`here<remote_data.ga>`.
 - Added flag ``order_categoricals`` to ``StataReader`` and ``read_stata`` to select whether to order imported categorical data (:issue:`8836`).  See :ref:`here <io.stata-categorical>` for more information on importing categorical variables from Stata data files.
-- ``Timedelta`` arithmetic returns ``NotImplemented`` in unknown cases, allowing extensions by custom classes (:issue:`8813`).
-- ``Timedelta`` now supports arithemtic with ``numpy.ndarray`` objects of the appropriate dtype (numpy 1.8 or newer only) (:issue:`8884`).
-- Added ``Timedelta.to_timedelta64`` method to the public API (:issue:`8884`).
+- ``Timestamp`` and ``Timedelta`` arithmetic and comparisons return ``NotImplemented`` in unknown cases, allowing extensions by custom classes (:issue:`8813`, :issue:`TBD`).
+-  ``Timestamp`` and ``Timedelta`` now support arithmetic and comparisons with ``numpy.ndarray`` objects of the appropriate dtype (numpy 1.8 or newer only) (:issue:`8884`, :issue:`TBD`).
+- Added ``Timestamp.to_datetime64`` and ``Timedelta.to_timedelta64`` methods to the public API (:issue:`8884`, :issue:`TBD`).
 
 .. _whatsnew_0152.performance:
 
@@ -93,6 +93,7 @@ Bug Fixes
 - ``io.data.Options`` now raises ``RemoteDataError`` when no expiry dates are available from Yahoo (:issue:`8761`).
 - ``Timedelta`` kwargs may now be numpy ints and floats (:issue:`8757`).
 - Fixed several outstanding bugs for ``Timedelta`` arithmetic and comparisons (:issue:`8813`, :issue:`5963`, :issue:`5436`).
+- The difference of two ``Timestamp`` objects is now a ``pandas.Timedelta`` rather than only a ``datetime.timedelta`` (:issue:`8865`).
 - ``sql_schema`` now generates dialect appropriate ``CREATE TABLE`` statements (:issue:`8697`)
 - ``slice`` string method now takes step into account (:issue:`8754`)
 - Bug in ``BlockManager`` where setting values with different type would break block integrity (:issue:`8850`)

--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -66,9 +66,9 @@ Enhancements
 - Added support for ``utcfromtimestamp()``, ``fromtimestamp()``, and ``combine()`` on `Timestamp` class (:issue:`5351`).
 - Added Google Analytics (`pandas.io.ga`) basic documentation (:issue:`8835`). See :ref:`here<remote_data.ga>`.
 - Added flag ``order_categoricals`` to ``StataReader`` and ``read_stata`` to select whether to order imported categorical data (:issue:`8836`).  See :ref:`here <io.stata-categorical>` for more information on importing categorical variables from Stata data files.
-- ``Timestamp`` and ``Timedelta`` arithmetic and comparisons return ``NotImplemented`` in unknown cases, allowing extensions by custom classes (:issue:`8813`, :issue:`TBD`).
--  ``Timestamp`` and ``Timedelta`` now support arithmetic and comparisons with ``numpy.ndarray`` objects of the appropriate dtype (numpy 1.8 or newer only) (:issue:`8884`, :issue:`TBD`).
-- Added ``Timestamp.to_datetime64`` and ``Timedelta.to_timedelta64`` methods to the public API (:issue:`8884`, :issue:`TBD`).
+- ``Timestamp`` and ``Timedelta`` arithmetic and comparisons return ``NotImplemented`` in unknown cases, allowing extensions by custom classes (:issue:`8813`, :issue:`8916`).
+-  ``Timestamp`` and ``Timedelta`` now support arithmetic and comparisons with ``numpy.ndarray`` objects of the appropriate dtype (numpy 1.8 or newer only) (:issue:`8884`, :issue:`8916`).
+- Added ``Timestamp.to_datetime64`` and ``Timedelta.to_timedelta64`` methods to the public API (:issue:`8884`, :issue:`8916`).
 
 .. _whatsnew_0152.performance:
 

--- a/pandas/tseries/base.py
+++ b/pandas/tseries/base.py
@@ -316,7 +316,7 @@ class DatetimeIndexOpsMixin(object):
                 return self._add_delta(other)
             elif com.is_integer(other):
                 return self.shift(other)
-            elif isinstance(other, (tslib.Timestamp, datetime)):
+            elif isinstance(other, (tslib.Timestamp, datetime, np.datetime64)):
                 return self._add_datelike(other)
             else:  # pragma: no cover
                 return NotImplemented
@@ -339,14 +339,18 @@ class DatetimeIndexOpsMixin(object):
                 return self._add_delta(-other)
             elif com.is_integer(other):
                 return self.shift(-other)
-            elif isinstance(other, (tslib.Timestamp, datetime)):
+            elif isinstance(other, (tslib.Timestamp, datetime, np.datetime64)):
                 return self._sub_datelike(other)
             else:  # pragma: no cover
                 return NotImplemented
         cls.__sub__ = __sub__
 
         def __rsub__(self, other):
-            return -self + other
+            from pandas.tseries.tdi import TimedeltaIndex
+            if isinstance(self, TimedeltaIndex):
+                return -self + other
+            else:
+                return -(self - other)
         cls.__rsub__ = __rsub__
 
         cls.__iadd__ = __add__

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -3680,6 +3680,30 @@ class TestTimestamp(tm.TestCase):
             result = right_f(Timestamp('nat'), s_nat)
             tm.assert_series_equal(result, expected)
 
+    def test_timestamp_compare_ndarray(self):
+        lhs = pd.to_datetime(['1999-12-31', '2000-01-02']).values
+        rhs = Timestamp('2000-01-01')
+
+        nat = Timestamp('nat')
+        expected_nat = np.array([False, False])
+
+        ops = {'gt': 'lt', 'lt': 'gt', 'ge': 'le', 'le': 'ge', 'eq': 'eq',
+               'ne': 'ne'}
+
+        for left, right in ops.items():
+            left_f = getattr(operator, left)
+            right_f = getattr(operator, right)
+            expected = left_f(lhs, rhs)
+
+            result = right_f(rhs, lhs)
+            self.assert_numpy_array_equal(result, expected)
+
+            expected = ~expected_nat if left == 'ne' else expected_nat
+            result = left_f(lhs, nat)
+            self.assert_numpy_array_equal(result, expected)
+            result = right_f(nat, lhs)
+            self.assert_numpy_array_equal(result, expected)
+
 
 class TestSlicing(tm.TestCase):
 

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -726,6 +726,11 @@ class TestTimestampOps(tm.TestCase):
         if LooseVersion(np.__version__) >= '1.8':
             self.assert_numpy_array_equal(other - ts, -expected)
 
+        tsz = Timestamp('2000-01-01', tz='EST')
+        self.assertRaises(ValueError, lambda: ts > tsz)
+        self.assertRaises(ValueError,
+            lambda: pd.to_datetime(['2000-01-02']).values > tsz)
+
     def test_ops_notimplemented(self):
         class Other:
             pass


### PR DESCRIPTION
Fixes #8865 (Timestamp - Timestamp -> Timedelta)

This PR cleans up and extends `Timestamp` arithmetic similarly to my treatment for `Timedelta` in #8884.

It includes a new `to_datetime64()` method, and arithmetic now works between Timestamp and ndarrays. I also ensure comparison operations work properly between all of (Timestamp, Timedelta, NaT) and ndarrays.

Implementation notes: wide use of the `NotImplemented` singleton let me cleanup some complex logic. I also strove to reduce the tight-coupling of `Timestamp`/`Timedelta` to pandas itself by removing use of the `_typ` property in tslib (I honestly don't quite understand why it needs to exist) and by not treating series/index any differently from any other ndarray-like objects.

CC @jreback @jorisvandenbossche @immerrr
