### PR TITLE
CLN: move import to top of file

### DIFF
--- a/pandas/core/config.py
+++ b/pandas/core/config.py
@@ -51,6 +51,7 @@ Implementation
 import re
 
 from collections import namedtuple
+from contextlib import contextmanager
 import warnings
 from pandas.compat import map, lmap, u
 import pandas.compat as compat
@@ -680,8 +681,6 @@ def pp_options_list(keys, width=80, _print=False):
 
 #
 # helpers
-
-from contextlib import contextmanager
 
 
 @contextmanager


### PR DESCRIPTION
For consistency with [PEP8](https://www.python.org/dev/peps/pep-0008#id17):

```
Imports are always put at the top of the file, just after any module
comments and docstrings, and before module globals and constants.
```
