### PR TITLE
BUG: Option context applies on __enter__

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -142,7 +142,7 @@ Bug Fixes
 
 
 
-
+- BUG: Option context applies on __enter__ (:issue:`8514`)
 
 
 

--- a/pandas/core/config.py
+++ b/pandas/core/config.py
@@ -384,18 +384,17 @@ class option_context(object):
                 'option_context(pat, val, [(pat, val), ...)).'
             )
 
-        ops = list(zip(args[::2], args[1::2]))
+        self.ops = list(zip(args[::2], args[1::2]))
+
+    def __enter__(self):
         undo = []
-        for pat, val in ops:
+        for pat, val in self.ops:
             undo.append((pat, _get_option(pat, silent=True)))
 
         self.undo = undo
 
-        for pat, val in ops:
+        for pat, val in self.ops:
             _set_option(pat, val, silent=True)
-
-    def __enter__(self):
-        pass
 
     def __exit__(self, *args):
         if self.undo:

--- a/pandas/tests/test_config.py
+++ b/pandas/tests/test_config.py
@@ -425,3 +425,24 @@ class TestConfig(unittest.TestCase):
         options.c = 1
         self.assertEqual(len(holder), 1)
 
+    def test_option_context_scope(self):
+        # Ensure that creating a context does not affect the existing
+        # environment as it is supposed to be used with the `with` statement.
+        # See https://github.com/pydata/pandas/issues/8514
+
+        original_value = 60
+        context_value = 10
+        option_name = 'a'
+
+        self.cf.register_option(option_name, original_value)
+
+        # Ensure creating contexts didn't affect the current context.
+        ctx = self.cf.option_context(option_name, context_value)
+        self.assertEqual(self.cf.get_option(option_name), original_value)
+
+        # Ensure the correct value is available inside the context.
+        with ctx:
+            self.assertEqual(self.cf.get_option(option_name), context_value)
+
+        # Ensure the current context is reset
+        self.assertEqual(self.cf.get_option(option_name), original_value)


### PR DESCRIPTION
Option context no longer overrides options when used outside a `with`
statement.

Added test TestConfig.test_option_config_scope

Closes #8514
