### PR TITLE
BUG: fixed chunksize guessed to 0 (py3 only). #8621

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -99,6 +99,7 @@ Bug Fixes
 - Bug in ``BlockManager`` where setting values with different type would break block integrity (:issue:`8850`)
 - Bug in ``DatetimeIndex`` when using ``time`` object as key (:issue:`8667`)
 - Fix negative step support for label-based slices (:issue:`8753`)
+- Fixed division by 0 when reading big csv files in python 3 (:issue:`8621`)
 
   Old behavior:
 

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -1247,7 +1247,7 @@ class CSVFormatter(object):
         self.data = [None] * ncols
 
         if chunksize is None:
-            chunksize = (100000 / (len(self.cols) or 1)) or 1
+            chunksize = (100000 // (len(self.cols) or 1)) or 1
         self.chunksize = int(chunksize)
 
         self.data_index = obj.index

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -6462,6 +6462,14 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                 rs = read_csv(filename,index_col=0)
                 assert_frame_equal(rs, aa)
 
+    def test_to_csv_wide_frame_formatting(self):
+        # Issue #8621
+        df = DataFrame(np.random.randn(1, 100010), columns=None, index=None)
+        with ensure_clean() as filename:
+            df.to_csv(filename, header=False, index=False)
+            rs = read_csv(filename, header=None)
+            assert_frame_equal(rs, df)
+
     def test_to_csv_bug(self):
         f1 = StringIO('a,1.0\nb,2.0')
         df = DataFrame.from_csv(f1, header=None)


### PR DESCRIPTION
Fixes https://github.com/pydata/pandas/issues/8621
As mentioned in the github issue its a py3 only bug. I copied the test @rmorgans made
