### PR TITLE
Implement Categorical.searchsorted(v, side, sorter)

### DIFF
--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -489,9 +489,9 @@ Unlike agg, apply's callable is passed a sub-DataFrame which gives you access to
 .. ipython:: python
 
    def GrowUp(x):
-      avg_weight = sum(x[x.size == 'S'].weight * 1.5) 
-      avg_weight += sum(x[x.size == 'M'].weight * 1.25)
-      avg_weight += sum(x[x.size == 'L'].weight)
+      avg_weight = sum(x[x['size'] == 'S'].weight * 1.5) 
+      avg_weight += sum(x[x['size'] == 'M'].weight * 1.25)
+      avg_weight += sum(x[x['size'] == 'L'].weight)
       avg_weight = avg_weight / len(x)
       return pd.Series(['L',avg_weight,True], index=['size', 'weight', 'adult'])
 

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -814,6 +814,8 @@ class Categorical(PandasObject):
         [apple, bread, bread, cheese, milk]
         Categories (4, object): [apple < bread < cheese < milk]
         >>> x.searchsorted('bread')
+        1
+        >>> x.searchsorted(['bread'])
         array([1])
         >>> x.searchsorted(['bread', 'eggs'])
         array([1, 4])

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -821,7 +821,7 @@ class Categorical(PandasObject):
         array([3, 4])	    # eggs before milk
         >>> x = pd.Categorical(['apple', 'bread', 'bread', 'cheese', 'milk', 'donuts' ])
         >>> x.searchsorted(['bread', 'eggs'], side='right', sorter=[0, 1, 2, 3, 5, 4])
-        array([3, 5])       # eggs before donuts, after switching milk and donuts 
+        array([3, 5])       # eggs after donuts, after switching milk and donuts 
         """
         # Fixes https://github.com/pydata/pandas/issues/8420
         # Uses searchsorted twice, first to map the value to one of the codes,

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -823,19 +823,11 @@ class Categorical(PandasObject):
         >>> x.searchsorted(['bread', 'eggs'], side='right', sorter=[0, 1, 2, 3, 5, 4])
         array([3, 5])       # eggs after donuts, after switching milk and donuts 
         """
-        # Fixes https://github.com/pydata/pandas/issues/8420
-        # Uses searchsorted twice, first to map the value to one of the codes,
-        # then to map the found code to the index into the Categorical.
-        # 'side' gets applied to the first one only, otherwise when side='right'
-        # any non-matching values jump too far to the right.
         if not self.ordered:
             raise ValueError("searchsorted requires an ordered Categorical.")
 
-        from pandas.core.series import Series	# Local import to avoid circular ref
-        values_as_codes = self.categories.values.searchsorted(Series(v).values, side)
-        indices = self.codes.searchsorted(values_as_codes, sorter=sorter)
-        return indices
-
+        values_as_codes = self.categories.values.searchsorted(np.asarray(v), side)
+        return self.codes.searchsorted(values_as_codes, sorter=sorter)
 
     def isnull(self):
         """

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -882,24 +882,57 @@ class TestCategorical(tm.TestCase):
         self.assertEqual(cat.nbytes, exp)
 
     def test_searchsorted(self):
-        cats1 = ['apple', 'bread', 'bread', 'cheese', 'milk' ]
-        cats2 = ['apple', 'bread', 'bread', 'cheese', 'milk', 'donuts' ]
+        # https://github.com/pydata/pandas/issues/8420
+        s1 = pd.Series(['apple', 'bread', 'bread', 'cheese', 'milk' ])
+        s2 = pd.Series(['apple', 'bread', 'bread', 'cheese', 'milk', 'donuts' ])
+        c1 = pd.Categorical(s1)
+        c2 = pd.Categorical(s2)
 
-        for values in ( 'bread', ['bread'], ['bread','eggs'] ):
-            for side in ( 'left', 'right' ):
-                for cats, sorter in [ (cats1, None), (cats2, [0,1,2,3,5,4] ) ]:
-                    s = pd.Series(cats)
-                    c = pd.Categorical(cats)
-                    # print("values=%r, side=%r, sorter=%r" % (values, side, sorter))
-                    catRes = c.searchsorted(values, side=side, sorter=sorter)
-                    seriesRes = s.searchsorted(values, side=side, sorter=sorter)
-                    #print("--> %r" % (catRes,))
-                    assert type(catRes) == type(seriesRes)
-                    if isinstance( catRes, np.ndarray  ):
-                        self.assertTrue( (catRes - seriesRes == 0).all() )
-                    else:
-                        self.assertEqual(catRes, seriesRes)
+        # Single item array
+        res = c1.searchsorted(['bread'])
+        chk = s1.searchsorted(['bread'])
+        exp = np.array([1])
+        self.assert_numpy_array_equal(res, exp)
+        self.assert_numpy_array_equal(res, chk)
 
+        # Scalar version of single item array
+        # Ambiguous what Categorical should return as np.array returns
+        # a scalar and pd.Series returns an array.
+        # We get different results depending on whether 
+        # Categorical.searchsorted(v) passes v through np.asarray()
+        # or pd.Series(v).values. The former returns scalar, the 
+        # latter an array. 
+        # Test code here follows np.array.searchsorted().
+        # Commented out lines below follow pd.Series.
+        res = c1.searchsorted('bread')
+        chk = np.array(s1).searchsorted('bread')
+        exp = 1
+        #exp = np.array([1])
+        #chk = s1.searchsorted('bread')
+        #exp = np.array([1])
+        self.assert_numpy_array_equal(res, exp)
+        self.assert_numpy_array_equal(res, chk)
+       
+        # Searching for a value that is not present in the Categorical 
+        res = c1.searchsorted(['bread', 'eggs'])
+        chk = s1.searchsorted(['bread', 'eggs'])
+        exp = np.array([1, 4])
+        self.assert_numpy_array_equal(res, exp)
+        self.assert_numpy_array_equal(res, chk)
+
+        # Searching for a value that is not present, to the right
+        res = c1.searchsorted(['bread', 'eggs'], side='right')
+        chk = s1.searchsorted(['bread', 'eggs'], side='right')
+        exp = np.array([3, 4])	    # eggs before milk
+        self.assert_numpy_array_equal(res, exp)
+        self.assert_numpy_array_equal(res, chk)
+
+        # As above, but with a sorter array to reorder an unsorted array
+        res = c2.searchsorted(['bread', 'eggs'], side='right', sorter=[0, 1, 2, 3, 5, 4])
+        chk = s2.searchsorted(['bread', 'eggs'], side='right', sorter=[0, 1, 2, 3, 5, 4])
+        exp = np.array([3, 5])       # eggs after donuts, after switching milk and donuts 
+        self.assert_numpy_array_equal(res, exp)
+        self.assert_numpy_array_equal(res, chk)
 
     def test_deprecated_labels(self):
         # TODO: labels is deprecated and should be removed in 0.18 or 2017, whatever is earlier

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -882,13 +882,24 @@ class TestCategorical(tm.TestCase):
         self.assertEqual(cat.nbytes, exp)
 
     def test_searchsorted(self):
+        cats1 = ['apple', 'bread', 'bread', 'cheese', 'milk' ]
+        cats2 = ['apple', 'bread', 'bread', 'cheese', 'milk', 'donuts' ]
 
-        # See https://github.com/pydata/pandas/issues/8420
-        # TODO: implement me...
-        cat = pd.Categorical([1,2,3])
-        def f():
-            cat.searchsorted(3)
-        self.assertRaises(NotImplementedError, f)
+        for values in ( 'bread', ['bread'], ['bread','eggs'] ):
+            for side in ( 'left', 'right' ):
+                for cats, sorter in [ (cats1, None), (cats2, [0,1,2,3,5,4] ) ]:
+                    s = pd.Series(cats)
+                    c = pd.Categorical(cats)
+                    # print("values=%r, side=%r, sorter=%r" % (values, side, sorter))
+                    catRes = c.searchsorted(values, side=side, sorter=sorter)
+                    seriesRes = s.searchsorted(values, side=side, sorter=sorter)
+                    #print("--> %r" % (catRes,))
+                    assert type(catRes) == type(seriesRes)
+                    if isinstance( catRes, np.ndarray  ):
+                        self.assertTrue( (catRes - seriesRes == 0).all() )
+                    else:
+                        self.assertEqual(catRes, seriesRes)
+
 
     def test_deprecated_labels(self):
         # TODO: labels is deprecated and should be removed in 0.18 or 2017, whatever is earlier

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -888,13 +888,24 @@ class TestCategorical(tm.TestCase):
         self.assertEqual(cat.nbytes, exp)
 
     def test_searchsorted(self):
+        cats1 = ['apple', 'bread', 'bread', 'cheese', 'milk' ]
+        cats2 = ['apple', 'bread', 'bread', 'cheese', 'milk', 'donuts' ]
 
-        # See https://github.com/pydata/pandas/issues/8420
-        # TODO: implement me...
-        cat = pd.Categorical([1,2,3])
-        def f():
-            cat.searchsorted(3)
-        self.assertRaises(NotImplementedError, f)
+        for values in ( 'bread', ['bread'], ['bread','eggs'] ):
+            for side in ( 'left', 'right' ):
+                for cats, sorter in [ (cats1, None), (cats2, [0,1,2,3,5,4] ) ]:
+                    s = pd.Series(cats)
+                    c = pd.Categorical(cats)
+                    # print("values=%r, side=%r, sorter=%r" % (values, side, sorter))
+                    catRes = c.searchsorted(values, side=side, sorter=sorter)
+                    seriesRes = s.searchsorted(values, side=side, sorter=sorter)
+                    #print("--> %r" % (catRes,))
+                    assert type(catRes) == type(seriesRes)
+                    if isinstance( catRes, np.ndarray  ):
+                        self.assertTrue( (catRes - seriesRes == 0).all() )
+                    else:
+                        self.assertEqual(catRes, seriesRes)
+
 
     def test_deprecated_labels(self):
         # TODO: labels is deprecated and should be removed in 0.18 or 2017, whatever is earlier


### PR DESCRIPTION
Continued in #8972

This closes #8420, with code that supports searchsorted in Categorical, for both side='left'/'right' and with an optional sorter. The case of side='right' was tricky, as we look to the right only when matching the category name, not when matching the codes. The docstring and unit tests cover the various cases.

One thing I wasn't sure about was forcing scalar input to a Series. I copied this behaviour from Series.searchsorted to match its docstring examples. To avoid circular imports from series.py importing categorical.py, I got Series via a local import. Probably there is a better way to do this.
