### PR TITLE
ENH: Adds gcs module for IO with Google Cloud Storage

### DIFF
--- a/pandas/io/gcs.py
+++ b/pandas/io/gcs.py
@@ -1,0 +1,243 @@
+from StringIO import StringIO
+import logging
+
+import pandas as pd
+
+_GOOGLE_API_CLIENT_INSTALLED = True
+_GOOGLE_API_CLIENT_VALID_VERSION = True
+_GOOGLE_FLAGS_INSTALLED = True
+_GOOGLE_FLAGS_VALID_VERSION = True
+_HTTPLIB2_INSTALLED = True
+_SETUPTOOLS_INSTALLED = True
+
+try:
+    import pkg_resources
+    _SETUPTOOLS_INSTALLED = True
+except ImportError:
+    _SETUPTOOLS_INSTALLED = False
+
+if _SETUPTOOLS_INSTALLED:
+    try:
+        from apiclient.discovery import build
+        from apiclient.errors import HttpError
+        from apiclient.http import MediaFileUpload, MediaIoBaseUpload
+
+        from oauth2client.client import AccessTokenRefreshError
+        from oauth2client.client import OAuth2WebServerFlow
+        from oauth2client.client import SignedJwtAssertionCredentials
+        from oauth2client.client import flow_from_clientsecrets
+        from oauth2client.file import Storage
+        from oauth2client.tools import run
+
+        _GOOGLE_API_CLIENT_INSTALLED=True
+        _GOOGLE_API_CLIENT_VERSION = pkg_resources.get_distribution('google-api-python-client').version
+
+        #if LooseVersion(_GOOGLE_API_CLIENT_VERSION) >= '1.2.0':
+            #_GOOGLE_API_CLIENT_VALID_VERSION = True
+
+    except ImportError:
+        _GOOGLE_API_CLIENT_INSTALLED = False
+
+
+    try:
+        import gflags as flags
+        _GOOGLE_FLAGS_INSTALLED = True
+
+        _GOOGLE_FLAGS_VERSION = pkg_resources.get_distribution('python-gflags').version
+
+        #if LooseVersion(_GOOGLE_FLAGS_VERSION) >= '2.0':
+            #_GOOGLE_FLAGS_VALID_VERSION = True
+
+    except ImportError:
+        _GOOGLE_FLAGS_INSTALLED = False
+
+    try:
+        import httplib2
+        _HTTPLIB2_INSTALLED = True
+    except ImportError:
+        _HTTPLIB2_INSTALLED = False
+
+def _test_imports():
+    _GOOGLE_API_CLIENT_INSTALLED
+    _GOOGLE_API_CLIENT_VALID_VERSION
+    _GOOGLE_FLAGS_INSTALLED
+    _GOOGLE_FLAGS_VALID_VERSION
+    _HTTPLIB2_INSTALLED
+    _SETUPTOOLS_INSTALLED
+
+    #if compat.PY3:
+        #raise NotImplementedError("Google's libraries do not support Python 3 yet")
+
+    if not _SETUPTOOLS_INSTALLED:
+        raise ImportError('Could not import pkg_resources (setuptools).')
+
+    if not _GOOGLE_API_CLIENT_INSTALLED:
+        raise ImportError('Could not import Google API Client.')
+
+    if not _GOOGLE_FLAGS_INSTALLED:
+        raise ImportError('Could not import Google Command Line Flags Module.')
+
+    if not _GOOGLE_API_CLIENT_VALID_VERSION:
+        raise ImportError("pandas requires google-api-python-client >= 1.2.0 for Google "
+                          "BigQuery support, current version " + _GOOGLE_API_CLIENT_VERSION)
+
+    if not _GOOGLE_FLAGS_VALID_VERSION:
+        raise ImportError("pandas requires python-gflags >= 2.0.0 for Google "
+                          "BigQuery support, current version " + _GOOGLE_FLAGS_VERSION)
+
+    if not _HTTPLIB2_INSTALLED:
+        raise ImportError("pandas requires httplib2 for Google BigQuery support")
+
+CHUNK_SIZE = 2 * 1024 * 1024
+
+logger = logging.getLogger('pandas.io.gcs')
+logger.setLevel(logging.DEBUG)
+
+class GCSConnector(object):
+
+    def __init__(self, project_id, service_account=None, private_key=None):
+        self.project_id = project_id
+
+        self.service_account = service_account
+        self.private_key = private_key
+
+        self.credentials = self.get_credentials(service_account, private_key)
+        self.service = self.get_service(self.credentials)
+
+    def get_service(self, credentials):
+
+        http = httplib2.Http()
+        http = credentials.authorize(http)
+
+        service = build('storage', 'v1', http=http)
+
+        return service
+
+    def get_credentials(self, service_account, private_key):
+
+        scope = "https://www.googleapis.com/auth/devstorage.read_write"
+
+        if service_account and private_key:
+            flow = SignedJwtAssertionCredentials(service_account, private_key, scope)
+        else:
+            flow = OAuth2WebServerFlow(client_id='495642085510-k0tmvj2m941jhre2nbqka17vqpjfddtd.apps.googleusercontent.com',
+                                       client_secret='kOc9wMptUtxkcIFbtZCcrEAc',
+                                       scope=scope,
+                                       redirect_uri='urn:ietf:wg:oauth:2.0:oob')
+
+        storage = Storage("gcs_credentials.dat")
+        credentials = storage.get()
+
+        if credentials is None or credentials.invalid:
+            credentials = run(flow, storage)
+
+        return credentials
+
+    def upload(self, dataframe, bucket, name, project_id,
+               to_gcs_kwargs=None, to_csv_kwargs=None):
+
+        resumable = to_gcs_kwargs.get("resumable", False)
+
+        string_df = StringIO()
+        dataframe.to_csv(string_df, **to_csv_kwargs)
+
+        media = MediaIoBaseUpload(string_df, mimetype='text/csv', **to_gcs_kwargs)
+
+        request = self.service.objects().insert(bucket=bucket,
+                                                name=name,
+                                                media_body=media)
+
+        if resumable:
+            response = None
+            while response is None:
+                progress, response = request.next_chunk()
+
+        else:
+            request.execute()
+
+    def download(self, bucket, name, project_id):
+
+        request = (self.service.objects()
+                        .get_media(bucket="th-code", object="pandas.csv")
+                        .execute())
+
+        in_memory_df = StringIO(request)
+
+        df = pd.read_csv(in_memory_df)
+
+        return df
+
+def from_gcs(bucket, name, project_id, service_account, private_key):
+    """
+    Read a DataFrame from Google Cloud Storage.
+
+    Parameters
+    ----------
+    bucket : string
+        Bucket in GCS where the object resides
+    name : string
+        Name of the object, or regex matching the name of the object
+    project_id : string
+        ProjectId in google
+    service_account : string
+        Service account email
+    private_key : string
+        Path to private key file
+
+    Returns
+    -------
+    dataframe : Dataframe
+    """
+
+    _test_imports()
+
+    g = GCSConnector(project_id=project_id,
+                     service_account=service_account,
+                     private_key=private_key)
+
+    return g.download(bucket, name, project_id)
+
+
+def to_gcs(dataframe, bucket, name, project_id,
+           service_account=None, private_key=None, to_gcs_kwargs=None, to_csv_kwargs=None):
+    """
+    Write a DataFrame to Google Cloud Storage.
+
+    Parameters
+    ----------
+    dataframe : DataFrame
+        DataFrame to be written
+    bucket : string
+        Bucket in GCS where the dataframe will be written
+    name : string
+        Object name in GCS
+    project_id : string
+        ProjectId in google
+    service_account : string
+        Service account email
+    private_key : string
+        Path to private key file
+    to_gcs_kwargs : dict
+        Dictionary of keywords passed directly to insert objects
+    to_csv_kwargs : dict
+        Dictionary of keywords passed  directly `to_csv`
+    """
+
+    _test_imports()
+
+    if to_gcs_kwargs is None:
+        to_gcs_kwargs = {}
+
+    if to_csv_kwargs is None:
+        to_csv_kwargs = {}
+
+    gcs_connection = GCSConnector(project_id=project_id,
+                                  service_account=service_account,
+                                  private_key=private_key)
+
+    gcs_connection.upload(dataframe=dataframe,
+                          bucket=bucket,
+                          name=name,
+                          project_id=project_id,
+                          to_gcs_kwargs=to_gcs_kwargs,
+                          to_csv_kwargs=to_csv_kwargs)

--- a/pandas/io/gcs.py
+++ b/pandas/io/gcs.py
@@ -3,59 +3,70 @@ import logging
 
 import pandas as pd
 
-_GOOGLE_API_CLIENT_INSTALLED = True
-_GOOGLE_API_CLIENT_VALID_VERSION = True
-_GOOGLE_FLAGS_INSTALLED = True
-_GOOGLE_FLAGS_VALID_VERSION = True
-_HTTPLIB2_INSTALLED = True
-_SETUPTOOLS_INSTALLED = True
+from distutils.version import LooseVersion
+from pandas import compat
+from pandas.core.api import DataFrame
+from pandas.tools.merge import concat
+from pandas.core.common import PandasError
 
-try:
-    import pkg_resources
-    _SETUPTOOLS_INSTALLED = True
-except ImportError:
-    _SETUPTOOLS_INSTALLED = False
+_GOOGLE_API_CLIENT_INSTALLED = False
+_GOOGLE_API_CLIENT_VALID_VERSION = False
+_GOOGLE_FLAGS_INSTALLED = False
+_GOOGLE_FLAGS_VALID_VERSION = False
+_HTTPLIB2_INSTALLED = False
+_SETUPTOOLS_INSTALLED = False
 
-if _SETUPTOOLS_INSTALLED:
-    try:
-        from apiclient.discovery import build
-        from apiclient.errors import HttpError
-        from apiclient.http import MediaFileUpload, MediaIoBaseUpload
-
-        from oauth2client.client import AccessTokenRefreshError
-        from oauth2client.client import OAuth2WebServerFlow
-        from oauth2client.client import SignedJwtAssertionCredentials
-        from oauth2client.client import flow_from_clientsecrets
-        from oauth2client.file import Storage
-        from oauth2client.tools import run
-
-        _GOOGLE_API_CLIENT_INSTALLED=True
-        _GOOGLE_API_CLIENT_VERSION = pkg_resources.get_distribution('google-api-python-client').version
-
-        #if LooseVersion(_GOOGLE_API_CLIENT_VERSION) >= '1.2.0':
-            #_GOOGLE_API_CLIENT_VALID_VERSION = True
-
-    except ImportError:
-        _GOOGLE_API_CLIENT_INSTALLED = False
-
+if not compat.PY3:
 
     try:
-        import gflags as flags
-        _GOOGLE_FLAGS_INSTALLED = True
-
-        _GOOGLE_FLAGS_VERSION = pkg_resources.get_distribution('python-gflags').version
-
-        #if LooseVersion(_GOOGLE_FLAGS_VERSION) >= '2.0':
-            #_GOOGLE_FLAGS_VALID_VERSION = True
-
+        import pkg_resources
+        _SETUPTOOLS_INSTALLED = True
     except ImportError:
-        _GOOGLE_FLAGS_INSTALLED = False
+        _SETUPTOOLS_INSTALLED = False
 
-    try:
-        import httplib2
-        _HTTPLIB2_INSTALLED = True
-    except ImportError:
-        _HTTPLIB2_INSTALLED = False
+    if _SETUPTOOLS_INSTALLED:
+        try:
+            from apiclient.discovery import build
+            from apiclient.errors import HttpError
+            from apiclient.http import MediaFileUpload, MediaIoBaseUpload
+
+            from oauth2client.client import AccessTokenRefreshError
+            from oauth2client.client import OAuth2WebServerFlow
+            from oauth2client.client import SignedJwtAssertionCredentials
+            from oauth2client.client import flow_from_clientsecrets
+            from oauth2client.file import Storage
+            from oauth2client.tools import run
+
+            _GOOGLE_API_CLIENT_INSTALLED=True
+            _GOOGLE_API_CLIENT_VERSION = pkg_resources.get_distribution('google-api-python-client').version
+
+            if LooseVersion(_GOOGLE_API_CLIENT_VERSION) >= '1.2.0':
+                _GOOGLE_API_CLIENT_VALID_VERSION = True
+
+        except ImportError:
+            _GOOGLE_API_CLIENT_INSTALLED = False
+
+
+        try:
+            import gflags as flags
+            _GOOGLE_FLAGS_INSTALLED = True
+
+            _GOOGLE_FLAGS_VERSION = pkg_resources.get_distribution('python-gflags').version
+
+            if LooseVersion(_GOOGLE_FLAGS_VERSION) >= '2.0':
+                _GOOGLE_FLAGS_VALID_VERSION = True
+
+        except ImportError:
+            _GOOGLE_FLAGS_INSTALLED = False
+
+        try:
+            import httplib2
+            _HTTPLIB2_INSTALLED = True
+        except ImportError:
+            _HTTPLIB2_INSTALLED = False
+
+logger = logging.getLogger('pandas.io.gcs')
+logger.setLevel(logging.DEBUG)
 
 def _test_imports():
     _GOOGLE_API_CLIENT_INSTALLED
@@ -65,8 +76,8 @@ def _test_imports():
     _HTTPLIB2_INSTALLED
     _SETUPTOOLS_INSTALLED
 
-    #if compat.PY3:
-        #raise NotImplementedError("Google's libraries do not support Python 3 yet")
+    if compat.PY3:
+        raise NotImplementedError("Google's libraries do not support Python 3 yet")
 
     if not _SETUPTOOLS_INSTALLED:
         raise ImportError('Could not import pkg_resources (setuptools).')
@@ -87,11 +98,6 @@ def _test_imports():
 
     if not _HTTPLIB2_INSTALLED:
         raise ImportError("pandas requires httplib2 for Google BigQuery support")
-
-CHUNK_SIZE = 2 * 1024 * 1024
-
-logger = logging.getLogger('pandas.io.gcs')
-logger.setLevel(logging.DEBUG)
 
 class GCSConnector(object):
 

--- a/pandas/io/tests/test_gcs.py
+++ b/pandas/io/tests/test_gcs.py
@@ -1,0 +1,79 @@
+import pandas.io.gcs as gcs
+import pandas.util.testing as tm
+import pandas as pd
+from time import sleep
+
+import subprocess
+
+import nose
+
+PROJECT_ID = "eighth-physics-623"
+
+def missing_gsutil():
+    try:
+        subprocess.call(['which', 'gsutil'])
+        return False
+    except OSError:
+        return True
+
+def test_requirements():
+    try:
+        gcs._test_imports()
+    except (ImportError, NotImplementedError) as import_exception:
+        raise nose.SkipTest(import_exception)
+
+class TestGCSConnectorIntegration(tm.TestCase):
+    def setUp(self):
+        test_requirements()
+
+        if not PROJECT_ID:
+            raise nose.SkipTest("Cannot run integration tests without a project id")
+
+        self.sut = gcs.GCSConnector(PROJECT_ID)
+
+    def test_should_be_able_to_make_a_connector(self):
+        self.assertTrue(self.sut is not None, 'Could not create a GCSConnector')
+
+    def test_should_be_able_to_get_valid_credentials(self):
+        credentials = self.sut.get_credentials()
+        self.assertFalse(credentials.invalid, 'Returned credentials invalid')
+
+    def test_should_be_able_to_get_a_cloudstorage_service(self):
+        credentials = self.sut.get_credentials()
+        cloudstorage_service = self.sut.get_service(credentials)
+        self.assertTrue(cloudstorage_service is not None, 'No service returned')
+
+class TestGCSReadWrite(tm.TestCase):
+
+    def setUp(self):
+        test_requirements()
+
+        if not PROJECT_ID:
+            raise nose.SkipTest("Cannot run write tests without a project id")
+        if missing_gsutil():
+            raise nose.SkipTest("Cannot run write tests without a gsutil.")
+
+    @classmethod
+    def setUpClass(cls):
+        if PROJECT_ID and not missing_gsutil():
+            subprocess.call(["gsutil", "mb", "gs://pandas-write-test"])
+
+    @classmethod
+    def tearDownClass(cls):
+        if PROJECT_ID and not missing_gsutil():
+            subprocess.call(['gsutil', 'rb', '-f', 'gs://pandas-write-test'])
+
+    def test_upload_data(self):
+        #test that we can upload data and that from_csv_kwargs works correctly
+        fake_df = pd.DataFrame({'a': [1, 2, 3]}, index=pd.Index([1, 2, 3], name='test_idx'))
+        gcs.to_gcs(fake_df, "pandas-write-test", "new_test.csv", project_id=PROJECT_ID)
+
+        sleep(60)
+
+        result = gcs.from_gcs("pandas-write-test", "new_test.csv", project_id=PROJECT_ID,
+                              from_csv_kwargs={'index_col': 'test_idx'})
+
+        tm.assert_frame_equal(fake_df, result)
+
+if __name__ == '__main__':
+    nose.runmodule(argv=[__file__, '-vvs', '-x'], exit=False)


### PR DESCRIPTION
Hi,

This isn't ready for primetime yet, but I wanted to see if there was feedback, since it would be a new io module.

Basic usage:

```
import pandas.io.gcs as gcs
import pandas as pd
import numpy as np

df = pd.DataFrame({
    'a': np.random.normal(size=1e4),
    'b': np.random.normal(size=1e4)
})

gcs.to_gcs(df, "th-code", "pandas2.csv", "eighth-physics-623", to_gcs_kwargs={'resumable': True}, to_csv_kwargs={'index': False})
i = gcs.from_gcs("th-code", "pandas2.csv", "eighth-physics-623")
```

This borrows some of the connection patterns from `gbq`, though it can do service account auth in addition to OAuth2WebServer auth.  Might be nice at some point to centralize google api connection stuff.  If this is accepted the code to connect to google's APIs will be in 3 places.

I'm not sure everything this would need to be accepted, besides tests...
