### PR TITLE
BUG: Fixed font size (set it on both x and y axis). #8765

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -99,6 +99,7 @@ Bug Fixes
 - Bug in ``BlockManager`` where setting values with different type would break block integrity (:issue:`8850`)
 - Bug in ``DatetimeIndex`` when using ``time`` object as key (:issue:`8667`)
 - Fix negative step support for label-based slices (:issue:`8753`)
+- Fix: The font size was only set on x axis if vertical or the y axis if horizontal. (:issue:`8765`)
 
   Old behavior:
 

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1051,13 +1051,15 @@ class MPLPlot(object):
                     xticklabels = [labels.get(x, '') for x in ax.get_xticks()]
                     ax.set_xticklabels(xticklabels)
                 self._apply_axis_properties(ax.xaxis, rot=self.rot,
-                                           fontsize=self.fontsize)
+                                            fontsize=self.fontsize)
+                self._apply_axis_properties(ax.yaxis, fontsize=self.fontsize)
             elif self.orientation == 'horizontal':
                 if self._need_to_set_index:
                     yticklabels = [labels.get(y, '') for y in ax.get_yticks()]
                     ax.set_yticklabels(yticklabels)
                 self._apply_axis_properties(ax.yaxis, rot=self.rot,
-                                           fontsize=self.fontsize)
+                                            fontsize=self.fontsize)
+                self._apply_axis_properties(ax.xaxis, fontsize=self.fontsize)
 
     def _apply_axis_properties(self, axis, rot=None, fontsize=None):
         labels = axis.get_majorticklabels() + axis.get_minorticklabels()

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -48,6 +48,14 @@ class TestTSPlot(tm.TestCase):
         ts = Series([188.5, 328.25], index=index)
         _check_plot_works(ts.plot)
 
+    def test_fontsize_set_correctly(self):
+        # For issue #8765
+        import matplotlib.pyplot as plt
+        df = DataFrame(np.random.randn(10, 9), index=range(10))
+        ax = df.plot(fontsize=2)
+        for label in (ax.get_xticklabels() + ax.get_yticklabels()):
+            self.assertEqual(label.get_fontsize(), 2)
+
     @slow
     def test_frame_inferred(self):
         # inferred freq


### PR DESCRIPTION
Fix for https://github.com/pydata/pandas/issues/8765 
The font size was only set on x axis if vertical or the y axis if horizontal.
