### PR TITLE
BUG: Resample across multiple days

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -145,7 +145,8 @@ Bug Fixes
 
 
 
-
+- Bug in resample that causes a ValueError when resampling across multiple days
+  and the last offset is not calculated from the start of the range (:issue:`8683`)
 
 
 - Bug in `pd.infer_freq`/`DataFrame.inferred_freq` that prevented proper sub-daily frequency inference

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -411,15 +411,19 @@ def _get_range_edges(first, last, offset, closed='left', base=0):
 def _adjust_dates_anchored(first, last, offset, closed='right', base=0):
     from pandas.tseries.tools import normalize_date
 
+    # First and last offsets should be calculated from the start day to fix an
+    # error cause by resampling across multiple days when a one day period is
+    # not a multiple of the frequency.
+    #
+    # See https://github.com/pydata/pandas/issues/8683
+
     start_day_nanos = Timestamp(normalize_date(first)).value
-    last_day_nanos = Timestamp(normalize_date(last)).value
 
     base_nanos = (base % offset.n) * offset.nanos // offset.n
     start_day_nanos += base_nanos
-    last_day_nanos += base_nanos
 
     foffset = (first.value - start_day_nanos) % offset.nanos
-    loffset = (last.value - last_day_nanos) % offset.nanos
+    loffset = (last.value - start_day_nanos) % offset.nanos
 
     if closed == 'right':
         if foffset > 0:


### PR DESCRIPTION
Fixes an issue where resampling over multiple days causes a ValueError
when a number of days between the normalized first and normalized last
days is not a multiple of the frequency.

Added test TestSeries.test_resample

Closes #8683
