### PR TITLE
BUG: fixes pd.Grouper for non-datetimelike groupings #8866

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -42,6 +42,8 @@ API changes
 
 - Bug in concat of Series with ``category`` dtype which were coercing to ``object``. (:issue:`8641`)
 
+- Bug in pd.Grouper when specifying non-datetimelike grouping. (:issue:`8844`)
+
 - ``Series.all`` and ``Series.any`` now support the ``level`` and ``skipna`` parameters. ``Series.all``, ``Series.any``, ``Index.all``, and ``Index.any`` no longer support the ``out`` and ``keepdims`` parameters, which existed for compatibility with ndarray. Various index types no longer support the ``all`` and ``any`` aggregation functions and will now raise ``TypeError``. (:issue:`8302`):
 
   .. ipython:: python

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -245,7 +245,6 @@ class Grouper(object):
             return self.grouper
         else:
             self._set_basegrouper(obj)
-            return self.grouper
 
     def _set_timegrouper(self, obj, sort=False):
         """
@@ -350,6 +349,7 @@ class Grouper(object):
         grouper = BaseGrouper(ax, grouping)
         self.obj = obj
         self.grouper = grouper
+        return self.grouper
 
     def _get_binner_for_grouping(self, obj):
         raise NotImplementedError

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -198,7 +198,7 @@ class Grouper(object):
             cls = TimeGrouper
         return super(Grouper, cls).__new__(cls)
 
-    def __init__(self, key=None, level=None, freq=None, axis=None, sort=False):
+    def __init__(self, key=None, level=None, freq=None, axis=0, sort=False):
         self.key=key
         self.level=level
         self.freq=freq

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -3677,6 +3677,16 @@ class TestGroupBy(tm.TestCase):
                 dt = pd.Timestamp(t)
                 result = grouped.get_group(dt)
                 assert_frame_equal(result, expected)
+                
+    def test_grouper_with_nondatetime(self):
+        # GH 8866
+        s = Series(np.arange(8),index=pd.MultiIndex.from_product([list('ab'),
+                   range(2),pd.date_range('20130101',periods=2)],
+                   names=['one','two','three']))
+
+        expected = Series(data = [6,22], index=pd.Index(['a','b'], name='one'))
+        result = s.groupby(pd.Grouper(level='one')).sum()
+        assert_series_equal(result,expected)
 
     def test_cumcount(self):
         df = DataFrame([['a'], ['a'], ['a'], ['b'], ['a']], columns=['A'])


### PR DESCRIPTION
closes #8866 

The bug was caused by a couple of things, firstly when specifying only a level, the axis default was None. This meant it failed to create the internal grouper breaking on line 254 of groupby.py: 

``` python
ax = obj._get_axis(self.axis)
```

Secondly, the aggregate function is set up to take a basegrouper class whereas for datetime resampling we need to pass a datetime index. I split the `_set_grouper` method to return a datetime index when a resampling frequency is specified and a `BaseGrouper` class otherwise. I opted to split that out into two functions to reduce complexity with much of the `_set_basegrouper` function being borrowed from the `_get_grouper` function. Let me know if there's a better way to fix this.
