### PR TITLE
ENH: Infer dtype from non-nulls when pushing to SQL

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -115,6 +115,7 @@ Enhancements
 - ``to_datetime`` gains an ``exact`` keyword to allow for a format to not require an exact match for a provided format string (if its ``False). ``exact`` defaults to ``True`` (meaning that exact matching is still the default)  (:issue:`8904`)
 - Added ``axvlines`` boolean option to parallel_coordinates plot function, determines whether vertical lines will be printed, default is True
 - Added ability to read table footers to read_html (:issue:`8552`)
+- ``to_sql`` now infers datatypes of non-NA values for columns that contain NA values and have dtype ``object`` (:issue:`8778`).
 
 .. _whatsnew_0152.performance:
 


### PR DESCRIPTION
Closes  #8778

This infers dtype from non-null values for insertion into SQL database.  See #8778 .  I had to alter @tiagoantao test a bit.

Like @tiagoantao, I skipped writing tests for legacy MySQL. Support for this will be removed soon, right?

As a side note, `lib.infer_dtype` throws an exception for categorical data -- probably shouldn't happen, right?

@jorisvandenbossche 
@jahfet
@tiagoantao
