### PR TITLE
BUG: StataWriter uses incorrect string length

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -166,3 +166,10 @@ Bug Fixes
   not lexically sorted or unique (:issue:`7724`)
 - BUG CSV: fix problem with trailing whitespace in skipped rows, (:issue:`8679`), (:issue:`8661`)
 - Regression in ``Timestamp`` does not parse 'Z' zone designator for UTC (:issue:`8771`)
+
+
+
+
+
+- Bug in `StataWriter` the produces writes strings with 244 characters irrespective of actual size (:issue:`8969`)
+

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -593,10 +593,12 @@ class TestStata(tm.TestCase):
         with tm.ensure_clean() as path:
             original.to_stata(path, write_index=False)
             sr = StataReader(path)
+            typlist = sr.typlist
             variables = sr.varlist
             formats = sr.fmtlist
-            for variable, fmt in zip(variables, formats):
+            for variable, fmt, typ in zip(variables, formats, typlist):
                 self.assertTrue(int(variable[1:]) == int(fmt[1:-1]))
+                self.assertTrue(int(variable[1:]) == typ)
 
     def test_excessively_long_string(self):
         str_lens = (1, 244, 500)
@@ -850,7 +852,6 @@ class TestStata(tm.TestCase):
         # Check identity of codes
         for col in expected:
             if is_categorical_dtype(expected[col]):
-                print(col)
                 tm.assert_series_equal(expected[col].cat.codes,
                                        parsed_115[col].cat.codes)
                 tm.assert_index_equal(expected[col].cat.categories,

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -898,17 +898,17 @@ def clean_index_list(list obj):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def max_len_string_array(ndarray[object, ndim=1] arr):
+def max_len_string_array(ndarray arr):
     """ return the maximum size of elements in a 1-dim string array """
     cdef:
         int i, m, l
-        length = arr.shape[0]
+        int length = arr.shape[0]
         object v
 
     m = 0
     for i from 0 <= i < length:
         v = arr[i]
-        if PyString_Check(v) or PyBytes_Check(v):
+        if PyString_Check(v) or PyBytes_Check(v) or PyUnicode_Check(v):
             l = len(v)
 
             if l > m:


### PR DESCRIPTION
Fixes bug where StataWriter always writes strings with
a size of 244.

closes #8969
