### PR TITLE
update NDFrame __setattr__ to match behavior of __getattr__

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -61,6 +61,23 @@ API changes
 
 - Allow equality comparisons of Series with a categorical dtype and object dtype; previously these would raise ``TypeError`` (:issue:`8938`)
 
+- Bug in ``NDFrame``: conflicting attribute/column names now behave consistently between getting and setting. Previously, when both a column and attribute named ``y`` existed, ``data.y`` would return the attribute, while ``data.y = z`` would update the column (:issue:`8994`)
+
+  .. ipython:: python
+
+     data = pd.DataFrame({'x':[1, 2, 3]})
+     data.y = 2
+     data['y'] = [2, 4, 6]
+     data.y = 5  # this assignment was inconsistent
+
+     print(data.y)
+     # prior output : 2
+     # 0.15.2 output: 5
+
+     print(data['y'].values)
+     # prior output : [5, 5, 5]
+     # 0.15.2 output: [2, 4, 6]
+
 .. _whatsnew_0152.enhancements:
 
 Enhancements

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -19,6 +19,7 @@ from pandas.util.testing import (assert_series_equal,
                                  assert_frame_equal,
                                  assert_panel_equal,
                                  assert_almost_equal,
+                                 assert_equal,
                                  ensure_clean)
 import pandas.util.testing as tm
 
@@ -1315,6 +1316,18 @@ class TestDataFrame(tm.TestCase, Generic):
             with tm.assertRaisesRegexp(ValueError, 'not valid'):
                 df = DataFrame(index=l0)
                 df = getattr(df, fn)('US/Pacific', level=1)
+
+    def test_set_attribute(self):
+        # Test for consistent setattr behavior when an attribute and a column
+        # have the same name (Issue #8994)
+        df = DataFrame({'x':[1, 2, 3]})
+
+        df.y = 2
+        df['y'] = [2, 4, 6]
+        df.y = 5
+
+        assert_equal(df.y, 5)
+        assert_series_equal(df['y'], Series([2, 4, 6]))
 
 
 class TestPanel(tm.TestCase, Generic):


### PR DESCRIPTION
This addresses the issue raised in #8994.
Here is the behavior before this PR:

``` python
data = pd.DataFrame({'x':[1, 2, 3]})

data.y = 2
data['y'] = [2, 4, 6]
data.y = 5

print(data.y)
#2
print(data['y'].values)
# [5, 5, 5]
```

Here is the behavior after this PR:

``` python
data = pd.DataFrame({'x':[1, 2, 3]})

data.y = 2
data['y'] = [2, 4, 6]
data.y = 5

print(data.y)
#5
print(data['y'].values)
# [2, 4, 6]
```

The fix boils down to the fact that when `data.y` is called, Python first calls `data.__getattribute__('y')` before calling `data.__getattr__('y')`, but when `data.y = 5` is called, Python goes directly to `data.__setattr__('y', 5)` without any prior search for defined attributes.

I don't think there are any unintended side-effects to this change, but I'd appreciate some other folks thinking through whether this is the right solution. Thanks!
