### PR TITLE
BUG: Bug in using a pd.Grouper(key=...) with no level/axis or level only (GH8795, GH8866)

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -98,6 +98,7 @@ Bug Fixes
 
 - Bug in Timestamp-Timestamp not returning a Timedelta type and datelike-datelike ops with timezones (:issue:`8865`)
 - Made consistent a timezone mismatch exception (either tz operated with None or incompatible timezone), will now return ``TypeError`` rather than ``ValueError`` (a couple of edge cases only), (:issue:`8865`)
+- Bug in using a ``pd.Grouper(key=...)`` with no level/axis or level only (:issue:`8795`, :issue:`8866`)
 - Report a ``TypeError`` when invalid/no paramaters are passed in a groupby (:issue:`8015`)
 - Bug in packaging pandas with ``py2app/cx_Freeze`` (:issue:`8602`, :issue:`8831`)
 - Bug in ``groupby`` signatures that didn't include \*args or \*\*kwargs (:issue:`8733`).

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -168,7 +168,7 @@ class Grouper(object):
     freq : string / freqency object, defaults to None
         This will groupby the specified frequency if the target selection (via key or level) is
         a datetime-like object
-    axis : number/name of the axis, defaults to None
+    axis : number/name of the axis, defaults to 0
     sort : boolean, default to False
         whether to sort the resulting labels
 
@@ -198,7 +198,7 @@ class Grouper(object):
             cls = TimeGrouper
         return super(Grouper, cls).__new__(cls)
 
-    def __init__(self, key=None, level=None, freq=None, axis=None, sort=False):
+    def __init__(self, key=None, level=None, freq=None, axis=0, sort=False):
         self.key=key
         self.level=level
         self.freq=freq
@@ -228,6 +228,8 @@ class Grouper(object):
         """
 
         self._set_grouper(obj)
+        self.grouper, exclusions, self.obj = _get_grouper(self.obj, [self.key], axis=self.axis,
+                                                          level=self.level, sort=self.sort)
         return self.binner, self.grouper, self.obj
 
     def _set_grouper(self, obj, sort=False):


### PR DESCRIPTION
closes #8795
closes #8866
