### PR TITLE
ENH: Implement Series.StringMethod.slice_replace

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -62,6 +62,8 @@ Enhancements
 
 - Paths beginning with ~ will now be expanded to begin with the user's home directory (:issue:`9066`)
 - Added time interval selection in get_data_yahoo (:issue:`9071`)
+- Added ``Series.str.slice_replace()``, which previously raised NotImplementedError (:issue:`8888`)
+
 
 Performance
 ~~~~~~~~~~~

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -687,15 +687,34 @@ def str_slice(arr, start=None, stop=None, step=None):
 
 def str_slice_replace(arr, start=None, stop=None, repl=None):
     """
+    Replace a slice of each string with another string.
 
     Parameters
     ----------
+    start : int or None
+    stop : int or None
+    repl : str or None
 
     Returns
     -------
     replaced : array
     """
-    raise NotImplementedError
+    if repl is None:
+        repl = ''
+
+    def f(x):
+        if x[start:stop] == '':
+            local_stop = start
+        else:
+            local_stop = stop
+        y = ''
+        if start is not None:
+            y += x[:start]
+        y += repl
+        if stop is not None:
+            y += x[local_stop:]
+        return y
+    return _na_map(f, arr)
 
 
 def str_strip(arr, to_strip=None):
@@ -998,9 +1017,10 @@ class StringMethods(object):
         result = str_slice(self.series, start, stop, step)
         return self._wrap_result(result)
 
-    @copy(str_slice)
-    def slice_replace(self, i=None, j=None):
-        raise NotImplementedError
+    @copy(str_slice_replace)
+    def slice_replace(self, start=None, stop=None, repl=None):
+        result = str_slice_replace(self.series, start, stop, repl)
+        return self._wrap_result(result)
 
     @copy(str_decode)
     def decode(self, encoding, errors="strict"):

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -963,7 +963,39 @@ class TestStringMethods(tm.TestCase):
         tm.assert_series_equal(result, exp)
 
     def test_slice_replace(self):
-        pass
+        values = Series(['short', 'a bit longer', 'evenlongerthanthat', '', NA])
+
+        exp = Series(['shrt', 'a it longer', 'evnlongerthanthat', '', NA])
+        result = values.str.slice_replace(2, 3)
+        tm.assert_series_equal(result, exp)
+
+        exp = Series(['shzrt', 'a zit longer', 'evznlongerthanthat', 'z', NA])
+        result = values.str.slice_replace(2, 3, 'z')
+        tm.assert_series_equal(result, exp)
+
+        exp = Series(['shzort', 'a zbit longer', 'evzenlongerthanthat', 'z', NA])
+        result = values.str.slice_replace(2, 2, 'z')
+        tm.assert_series_equal(result, exp)
+
+        exp = Series(['shzort', 'a zbit longer', 'evzenlongerthanthat', 'z', NA])
+        result = values.str.slice_replace(2, 1, 'z')
+        tm.assert_series_equal(result, exp)
+
+        exp = Series(['shorz', 'a bit longez', 'evenlongerthanthaz', 'z', NA])
+        result = values.str.slice_replace(-1, None, 'z')
+        tm.assert_series_equal(result, exp)
+
+        exp = Series(['zrt', 'zer', 'zat', 'z', NA])
+        result = values.str.slice_replace(None, -2, 'z')
+        tm.assert_series_equal(result, exp)
+
+        exp = Series(['shortz', 'a bit znger', 'evenlozerthanthat', 'z', NA])
+        result = values.str.slice_replace(6, 8, 'z')
+        tm.assert_series_equal(result, exp)
+
+        exp = Series(['zrt', 'a zit longer', 'evenlongzerthanthat', 'z', NA])
+        result = values.str.slice_replace(-10, 3, 'z')
+        tm.assert_series_equal(result, exp)
 
     def test_strip_lstrip_rstrip(self):
         values = Series(['  aa   ', ' bb \n', NA, 'cc  '])


### PR DESCRIPTION
closes #8888 

This does not implement immerrr's suggestion of implementing `__setitem__`, as all `StringMethod` methods return a new `Series` (or `DataFrame`) rather than mutating. 
