### PR TITLE
reindex multi-index at level with reordered labels

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -119,6 +119,7 @@ Bug Fixes
 - Bug in ``BlockManager`` where setting values with different type would break block integrity (:issue:`8850`)
 - Bug in ``DatetimeIndex`` when using ``time`` object as key (:issue:`8667`)
 - Bug in ``merge`` where ``how='left'`` and ``sort=False`` would not preserve left frame order (:issue:`7331`)
+- Bug in ``MultiIndex.reindex`` where reindexing at level would not reorder labels (:issue:`4088`)
 
 - Fix negative step support for label-based slices (:issue:`8753`)
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1828,13 +1828,41 @@ class Index(IndexOpsMixin, PandasObject):
         else:
             return join_index
 
-    def _join_level(self, other, level, how='left', return_indexers=False):
+    def _join_level(self, other, level, how='left',
+                    return_indexers=False,
+                    keep_order=True):
         """
         The join method *only* affects the level of the resulting
         MultiIndex. Otherwise it just exactly aligns the Index data to the
-        labels of the level in the MultiIndex. The order of the data indexed by
-        the MultiIndex will not be changed (currently)
+        labels of the level in the MultiIndex. If `keep_order` == True, the
+        order of the data indexed by the MultiIndex will not be changed;
+        otherwise, it will tie out with `other`.
         """
+        from pandas.algos import groupsort_indexer
+
+        def _get_leaf_sorter(labels):
+            '''
+            returns sorter for the inner most level while preserving the
+            order of higher levels
+            '''
+            if labels[0].size == 0:
+                return np.empty(0, dtype='int64')
+
+            if len(labels) == 1:
+                lab = com._ensure_int64(labels[0])
+                sorter, _ = groupsort_indexer(lab, 1 + lab.max())
+                return sorter
+
+            # find indexers of begining of each set of
+            # same-key labels w.r.t all but last level
+            tic = labels[0][:-1] != labels[0][1:]
+            for lab in labels[1:-1]:
+                tic |= lab[:-1] != lab[1:]
+
+            starts = np.hstack(([True], tic, [True])).nonzero()[0]
+            lab = com._ensure_int64(labels[-1])
+            return lib.get_level_sorter(lab, starts)
+
         if isinstance(self, MultiIndex) and isinstance(other, MultiIndex):
             raise TypeError('Join on level between two MultiIndex objects '
                             'is ambiguous')
@@ -1849,33 +1877,69 @@ class Index(IndexOpsMixin, PandasObject):
         level = left._get_level_number(level)
         old_level = left.levels[level]
 
+        if not right.is_unique:
+            raise NotImplementedError('Index._join_level on non-unique index '
+                                      'is not implemented')
+
         new_level, left_lev_indexer, right_lev_indexer = \
             old_level.join(right, how=how, return_indexers=True)
 
-        if left_lev_indexer is not None:
+        if left_lev_indexer is None:
+            if keep_order or len(left) == 0:
+                left_indexer = None
+                join_index = left
+            else:  # sort the leaves
+                left_indexer = _get_leaf_sorter(left.labels[:level + 1])
+                join_index = left[left_indexer]
+
+        else:
             left_lev_indexer = com._ensure_int64(left_lev_indexer)
             rev_indexer = lib.get_reverse_indexer(left_lev_indexer,
                                                   len(old_level))
 
             new_lev_labels = com.take_nd(rev_indexer, left.labels[level],
                                          allow_fill=False)
-            omit_mask = new_lev_labels != -1
 
             new_labels = list(left.labels)
             new_labels[level] = new_lev_labels
 
-            if not omit_mask.all():
-                new_labels = [lab[omit_mask] for lab in new_labels]
-
             new_levels = list(left.levels)
             new_levels[level] = new_level
 
-            join_index = MultiIndex(levels=new_levels, labels=new_labels,
-                                    names=left.names, verify_integrity=False)
-            left_indexer = np.arange(len(left))[new_lev_labels != -1]
-        else:
-            join_index = left
-            left_indexer = None
+            if keep_order:  # just drop missing values. o.w. keep order
+                left_indexer = np.arange(len(left))
+                mask = new_lev_labels != -1
+                if not mask.all():
+                    new_labels = [lab[mask] for lab in new_labels]
+                    left_indexer = left_indexer[mask]
+
+            else:  # tie out the order with other
+                if level == 0:  # outer most level, take the fast route
+                    ngroups = 1 + new_lev_labels.max()
+                    left_indexer, counts = groupsort_indexer(new_lev_labels,
+                                                             ngroups)
+                    # missing values are placed first; drop them!
+                    left_indexer = left_indexer[counts[0]:]
+                    new_labels = [lab[left_indexer] for lab in new_labels]
+
+                else:  # sort the leaves
+                    mask = new_lev_labels != -1
+                    mask_all = mask.all()
+                    if not mask_all:
+                        new_labels = [lab[mask] for lab in new_labels]
+
+                    left_indexer = _get_leaf_sorter(new_labels[:level + 1])
+                    new_labels = [lab[left_indexer] for lab in new_labels]
+
+                    # left_indexers are w.r.t masked frame.
+                    # reverse to original frame!
+                    if not mask_all:
+                        left_indexer = mask.nonzero()[0][left_indexer]
+
+            join_index = MultiIndex(levels=new_levels,
+                                    labels=new_labels,
+                                    names=left.names,
+                                    verify_integrity=False)
 
         if right_lev_indexer is not None:
             right_indexer = com.take_nd(right_lev_indexer,
@@ -3925,7 +3989,8 @@ class MultiIndex(Index):
             else:
                 target = _ensure_index(target)
             target, indexer, _ = self._join_level(target, level, how='right',
-                                                  return_indexers=True)
+                                                  return_indexers=True,
+                                                  keep_order=False)
         else:
             if self.equals(target):
                 indexer = None

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -1138,6 +1138,27 @@ def row_bool_subset_object(ndarray[object, ndim=2] values,
 
     return out
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def get_level_sorter(ndarray[int64_t, ndim=1] label,
+                     ndarray[int64_t, ndim=1] starts):
+    """
+    argsort for a single level of a multi-index, keeping the order of higher
+    levels unchanged. `starts` points to starts of same-key indices w.r.t
+    to leading levels; equivalent to:
+        np.hstack([label[starts[i]:starts[i+1]].argsort(kind='mergesort')
+            + starts[i] for i in range(len(starts) - 1)])
+    """
+    cdef:
+        int64_t l, r
+        Py_ssize_t i
+        ndarray[int64_t, ndim=1] out = np.empty(len(label), dtype=np.int64)
+
+    for i in range(len(starts) - 1):
+        l, r = starts[i], starts[i + 1]
+        out[l:r] = l + label[l:r].argsort(kind='mergesort')
+
+    return out
 
 def group_count(ndarray[int64_t] values, Py_ssize_t size):
     cdef:


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/4088

on branch:

```
>>> df
                     vals
first second third       
mid   3rd    992     1.96
             562    12.06
      1st    73     -6.46
             818   -15.75
             658     5.90
btm   2nd    915     9.75
             474    -1.47
             905    -6.03
      1st    717     8.01
             909   -21.12
      3rd    616    11.91
             675     1.06
             579    -4.01
top   1st    241     1.79
             363     1.71
      3rd    677    13.38
             238   -16.77
             407    17.19
      2nd    728   -21.55
             36      8.09
>>> df.reindex(['top', 'mid', 'btm'], level='first')
                     vals
first second third       
top   1st    241     1.79
             363     1.71
      3rd    677    13.38
             238   -16.77
             407    17.19
      2nd    728   -21.55
             36      8.09
mid   3rd    992     1.96
             562    12.06
      1st    73     -6.46
             818   -15.75
             658     5.90
btm   2nd    915     9.75
             474    -1.47
             905    -6.03
      1st    717     8.01
             909   -21.12
      3rd    616    11.91
             675     1.06
             579    -4.01
>>> df.reindex(['1st', '2nd', '3rd'], level='second')
                     vals
first second third       
mid   1st    73     -6.46
             818   -15.75
             658     5.90
      3rd    992     1.96
             562    12.06
btm   1st    717     8.01
             909   -21.12
      2nd    915     9.75
             474    -1.47
             905    -6.03
      3rd    616    11.91
             675     1.06
             579    -4.01
top   1st    241     1.79
             363     1.71
      2nd    728   -21.55
             36      8.09
      3rd    677    13.38
             238   -16.77
             407    17.19
>>> df.reindex(['top', 'btm'], level='first').reindex(['1st', '2nd'], level='second')
                     vals
first second third       
top   1st    241     1.79
             363     1.71
      2nd    728   -21.55
             36      8.09
btm   1st    717     8.01
             909   -21.12
      2nd    915     9.75
             474    -1.47
             905    -6.03
```
