### PR TITLE
Make Timestamp('now') equivalent to Timestamp.now()

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -62,6 +62,9 @@ API changes
 
 - Allow equality comparisons of Series with a categorical dtype and object dtype; previously these would raise ``TypeError`` (:issue:`8938`)
 
+- Timestamp('now') is now equivalent to Timestamp.now() in that it returns the local time rather than UTC. Also, Timestamp('today') is now
+  equivalent to Timestamp.today() and both have tz as a possible argument. (:issue:`9000`)
+
 .. _whatsnew_0152.enhancements:
 
 Enhancements

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -301,6 +301,36 @@ class TestTimestamp(tm.TestCase):
     def test_utc_z_designator(self):
         self.assertEqual(get_timezone(Timestamp('2014-11-02 01:00Z').tzinfo), 'UTC')
 
+    def test_now(self):
+        # #9000
+        ts_from_string = Timestamp('now')
+        ts_from_method = Timestamp.now()
+        ts_datetime = datetime.datetime.now()
+        
+        ts_from_string_tz = Timestamp('now', tz='US/Eastern')
+        ts_from_method_tz = Timestamp.now(tz='US/Eastern')
+        
+        # Check that the delta between the times is less than 1s (arbitrarily small)
+        delta = Timedelta(seconds=1)
+        self.assertTrue((ts_from_method - ts_from_string) < delta)
+        self.assertTrue((ts_from_method_tz - ts_from_string_tz) < delta)
+        self.assertTrue((ts_from_string_tz.tz_localize(None) - ts_from_string) < delta)
+
+    def test_today(self):
+
+        ts_from_string = Timestamp('today')
+        ts_from_method = Timestamp.today()
+        ts_datetime = datetime.datetime.today()
+        
+        ts_from_string_tz = Timestamp('today', tz='US/Eastern')
+        ts_from_method_tz = Timestamp.today(tz='US/Eastern')
+        
+        # Check that the delta between the times is less than 1s (arbitrarily small)
+        delta = Timedelta(seconds=1)
+        self.assertTrue((ts_from_method - ts_from_string) < delta)
+        self.assertTrue((ts_datetime - ts_from_method) < delta)
+        self.assertTrue((ts_datetime - ts_from_method) < delta)
+        self.assertTrue((ts_from_string_tz.tz_localize(None) - ts_from_string) < delta)
 
 class TestDatetimeParsingWrappers(tm.TestCase):
     def test_does_not_convert_mixed_integer(self):

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -173,9 +173,9 @@ def ints_to_pytimedelta(ndarray[int64_t] arr, box=False):
             result[i] = NaT
         else:
             if box:
-               result[i] = Timedelta(value)
+                result[i] = Timedelta(value)
             else:
-               result[i] = timedelta(microseconds=int(value)/1000)
+                result[i] = timedelta(microseconds=int(value)/1000)
 
     return result
 
@@ -216,15 +216,32 @@ class Timestamp(_Timestamp):
 
     @classmethod
     def now(cls, tz=None):
-        """ compat now with datetime """
+        """ 
+        Return the current time in the local timezone.  Equivalent
+        to datetime.now([tz])
+        
+        Parameters
+        ----------
+        tz : string / timezone object, default None
+            Timezone to localize to
+        """
         if isinstance(tz, basestring):
             tz = maybe_get_tz(tz)
         return cls(datetime.now(tz))
 
     @classmethod
-    def today(cls):
-        """ compat today with datetime """
-        return cls(datetime.today())
+    def today(cls, tz=None):
+        """
+        Return the current time in the local timezone.  This differs
+        from datetime.today() in that it can be localized to a
+        passed timezone.
+        
+        Parameters
+        ----------
+        tz : string / timezone object, default None
+            Timezone to localize to
+        """
+        return cls.now(tz)
 
     @classmethod
     def utcnow(cls):
@@ -1021,6 +1038,14 @@ cdef convert_to_tsobject(object ts, object tz, object unit):
     if util.is_string_object(ts):
         if ts in _nat_strings:
             ts = NaT
+        elif ts == 'now': 
+            # Issue 9000, we short-circuit rather than going 
+            # into np_datetime_strings which returns utc
+            ts = Timestamp.now(tz)
+        elif ts == 'today': 
+            # Issue 9000, we short-circuit rather than going 
+            # into np_datetime_strings which returns a normalized datetime
+            ts = Timestamp.today(tz)
         else:
             try:
                 _string_to_dts(ts, &obj.dts, &out_local, &out_tzoffset)


### PR DESCRIPTION
closes #9000 
I opted to not change np_datetime_strings but instead short-circuit in Timestamp.  I don't have a strong preference one way or another.
