### PR TITLE
Gh9010 yahoo options parsing bug

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -221,3 +221,5 @@ Bug Fixes
 
 
 - Fixed ValueError raised by cummin/cummax when datetime64 Series contains NaT. (:issue:`8965`)
+
+- Bug in ``Options`` where parsing the underlying price returns a ValueError when the price has a thousands separator in the HTML text. (:issue:`9010`)

--- a/pandas/io/data.py
+++ b/pandas/io/data.py
@@ -6,7 +6,6 @@ Module contains tools for collecting data from various remote sources
 import warnings
 import tempfile
 import datetime as dt
-import locale
 import time
 
 from collections import defaultdict
@@ -673,20 +672,6 @@ class Options(object):
 
         return self._FINANCE_BASE_URL + expiry_links[expiry]
 
-    @staticmethod
-    def _string_to_float(string):
-        """
-        Take a string representation of a floating number that may have a
-        thousands separator in it and turn it into a float
-        """
-        old_loc = locale.getlocale()
-        # Yahoo seems to report its prices in English/US format,
-        # regardless of locale settings in the browser
-        locale.setlocale( locale.LC_NUMERIC, 'en_US' )
-        floatret = locale.atof( string )
-        locale.setlocale( locale.LC_NUMERIC, old_loc )
-        return floatret
-
     def _option_frames_from_url(self, url):
         frames = read_html(url)
         nframes = len(frames)
@@ -713,8 +698,19 @@ class Options(object):
 
     def _get_underlying_price(self, url):
         root = self._parse_url(url)
-        underlying_price = self._string_to_float(root.xpath('.//*[@class="time_rtq_ticker Fz-30 Fw-b"]')[0]\
-            .getchildren()[0].text)
+
+	underlying_price = root.xpath('.//*[@class="time_rtq_ticker Fz-30 Fw-b"]')[0]\
+            	.getchildren()[0].text
+	try:
+            underlying_price = float(underlying_price)
+	except ValueError:
+	    # see if there is a comma thousands separator in here that needs to be filtered out
+            # filtering via join works in both Python 2.7 and Python 3
+            underlying_price = ''.join(c for c in underlying_price if c != ',')
+	    try:
+               underlying_price = float(underlying_price)
+	    except ValueError:
+               underlying_price = np.nan
 
         #Gets the time of the quote, note this is actually the time of the underlying price.
         try:
@@ -1207,6 +1203,7 @@ class Options(object):
             frame["Quote_Time"] = np.nan
         frame.rename(columns={'Open Int': 'Open_Int'}, inplace=True)
         frame['Type'] = type
+
         frame.set_index(['Strike', 'Expiry', 'Type', 'Symbol'], inplace=True)
 
         return frame

--- a/pandas/io/data.py
+++ b/pandas/io/data.py
@@ -6,6 +6,7 @@ Module contains tools for collecting data from various remote sources
 import warnings
 import tempfile
 import datetime as dt
+import locale
 import time
 
 from collections import defaultdict
@@ -672,6 +673,20 @@ class Options(object):
 
         return self._FINANCE_BASE_URL + expiry_links[expiry]
 
+    @staticmethod
+    def _string_to_float(string):
+        """
+        Take a string representation of a floating number that may have a
+        thousands separator in it and turn it into a float
+        """
+        old_loc = locale.getlocale()
+        # Yahoo seems to report its prices in English/US format,
+        # regardless of locale settings in the browser
+        locale.setlocale( locale.LC_NUMERIC, 'en_US' )
+        floatret = locale.atof( string )
+        locale.setlocale( locale.LC_NUMERIC, old_loc )
+        return floatret
+
     def _option_frames_from_url(self, url):
         frames = read_html(url)
         nframes = len(frames)
@@ -698,7 +713,7 @@ class Options(object):
 
     def _get_underlying_price(self, url):
         root = self._parse_url(url)
-        underlying_price = float(root.xpath('.//*[@class="time_rtq_ticker Fz-30 Fw-b"]')[0]\
+        underlying_price = self._string_to_float(root.xpath('.//*[@class="time_rtq_ticker Fz-30 Fw-b"]')[0]\
             .getchildren()[0].text)
 
         #Gets the time of the quote, note this is actually the time of the underlying price.

--- a/pandas/io/tests/test_data.py
+++ b/pandas/io/tests/test_data.py
@@ -321,6 +321,17 @@ class TestYahooOptions(tm.TestCase):
         self.assertTrue(len(dates) > 1)
 
     @network
+    def test_get_underlying_price(self):
+        try:
+             options_object = web.Options('^spxpm', 'yahoo')
+             expiry_dates, urls = options_object._get_expiry_dates_and_links()
+             url = options_object._FINANCE_BASE_URL +  urls.values()[0]
+             quote_price, quote_time = options_object._get_underlying_price( url )
+        except RemoteDataError as e:
+            raise nose.SkipTest(e)
+        self.assertIsInstance( quote_price, float )
+
+    @network
     def test_get_all_data(self):
         try:
             data = self.aapl.get_all_data(put=True)


### PR DESCRIPTION
closes #9010. Fix for Yahoo Options parse error for underlying prices of 1,000.00 or larger.
