### PR TITLE
BUG: Fix Datareader dtypes if there are missing values from Google.

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -222,3 +222,4 @@ Bug Fixes
 
 
 - Fixed ValueError raised by cummin/cummax when datetime64 Series contains NaT. (:issue:`8965`)
+- Bug in Datareader returns object dtype if there are missing values (:issue:`8980`)

--- a/pandas/io/data.py
+++ b/pandas/io/data.py
@@ -166,7 +166,7 @@ def _retry_read_url(url, retry_count, pause, name):
             pass
         else:
             rs = read_csv(StringIO(bytes_to_str(lines)), index_col=0,
-                          parse_dates=True)[::-1]
+                          parse_dates=True, na_values='-')[::-1]
             # Yahoo! Finance sometimes does this awesome thing where they
             # return 2 rows for the most recent business day
             if len(rs) > 2 and rs.index[-1] == rs.index[-2]:  # pragma: no cover

--- a/pandas/io/tests/test_data.py
+++ b/pandas/io/tests/test_data.py
@@ -118,8 +118,8 @@ class TestGoogle(tm.TestCase):
                 assert_n_failed_equals_n_null_columns(w, result)
 
     def test_dtypes(self):
-        #GH3995
-        data = web.get_data_google('MSFT', 'JAN-01-12', 'JAN-31-12')
+        #GH3995, #GH8980
+        data = web.get_data_google('F', start='JAN-01-10', end='JAN-27-13')
         assert np.issubdtype(data.Open.dtype, np.number)
         assert np.issubdtype(data.Close.dtype, np.number)
         assert np.issubdtype(data.Low.dtype, np.number)


### PR DESCRIPTION
Fixes #8980 
