### PR TITLE
Return from to_timedelta is forced to dtype timedelta64[ns]. 

### DIFF
--- a/doc/source/whatsnew/v0.15.2.txt
+++ b/doc/source/whatsnew/v0.15.2.txt
@@ -268,3 +268,5 @@ Bug Fixes
 - Fixed ValueError raised by cummin/cummax when datetime64 Series contains NaT. (:issue:`8965`)
 - Bug in Datareader returns object dtype if there are missing values (:issue:`8980`)
 - Bug in plotting if sharex was enabled and index was a timeseries, would show labels on multiple axes (:issue:`3964`).
+
+- Bug where passing a unit to the TimedeltaIndex constructor applied the to nano-second conversion twice. (:issue:`9011`).

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -525,6 +525,22 @@ class TestTimedeltas(tm.TestCase):
         expected = TimedeltaIndex([ np.timedelta64(1,'D') ]*5)
         tm.assert_index_equal(result, expected)
 
+        # Test with lists as input when box=false
+        expected = np.array(np.arange(3)*1000000000, dtype='timedelta64[ns]')
+        result = to_timedelta(range(3), unit='s', box=False)
+        tm.assert_numpy_array_equal(expected, result)
+
+        result = to_timedelta(np.arange(3), unit='s', box=False)
+        tm.assert_numpy_array_equal(expected, result)
+
+        result = to_timedelta([0, 1, 2], unit='s', box=False)
+        tm.assert_numpy_array_equal(expected, result)
+
+        # Tests with fractional seconds as input:
+        expected = np.array([0, 500000000, 800000000, 1200000000], dtype='timedelta64[ns]')
+        result = to_timedelta([0., 0.5, 0.8, 1.2], unit='s', box=False)
+        tm.assert_numpy_array_equal(expected, result)
+       
         def testit(unit, transform):
 
             # array
@@ -851,6 +867,13 @@ class TestTimedeltaIndex(tm.TestCase):
                                  timedelta(days=2,seconds=2),
                                  pd.offsets.Second(3)])
         tm.assert_index_equal(result,expected)
+
+        expected = TimedeltaIndex(['0 days 00:00:00', '0 days 00:00:01', '0 days 00:00:02'])
+        tm.assert_index_equal(TimedeltaIndex(range(3), unit='s'), expected)
+        expected = TimedeltaIndex(['0 days 00:00:00', '0 days 00:00:05', '0 days 00:00:09'])
+        tm.assert_index_equal(TimedeltaIndex([0, 5, 9], unit='s'), expected)
+        expected = TimedeltaIndex(['0 days 00:00:00.400', '0 days 00:00:00.450', '0 days 00:00:01.200'])
+        tm.assert_index_equal(TimedeltaIndex([400, 450, 1200], unit='ms'), expected)
 
     def test_constructor_coverage(self):
         rng = timedelta_range('1 days', periods=10.5)

--- a/pandas/tseries/timedeltas.py
+++ b/pandas/tseries/timedeltas.py
@@ -52,6 +52,7 @@ def to_timedelta(arg, unit='ns', box=True, coerce=False):
                     value = np.array([ _get_string_converter(r, unit=unit)() for r in arg ],dtype='m8[ns]')
                 except:
                     value = np.array([ _coerce_scalar_to_timedelta_type(r, unit=unit, coerce=coerce) for r in arg ])
+            value = value.astype('timedelta64[ns]', copy=False)
 
         if box:
             from pandas import TimedeltaIndex


### PR DESCRIPTION
This is a revised change, fixing the issue I experienced (issue #9011). The proper change seems to be setting the dtype to `'timedelta64[ns]'`, as was already done for the other cases in the `to_timedelta` routine. 

I have also added more tests, and moved them to the `test_timedeltas` function (next to the other tests of the functionality of the constructor method). I have not looked too much at #8886, it is difficult for me to understand the issue.
