### PR TITLE
ENH: Store in SQL using double precision

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -202,3 +202,4 @@ Bug Fixes
 - Fixed issue in the ``xlsxwriter`` engine where it added a default 'General' format to cells if no other format wass applied. This prevented other row or column formatting being applied. (:issue:`9167`)
 - Fixes issue with ``index_col=False`` when ``usecols`` is also specified in ``read_csv``. (:issue:`9082`)
 - Bug where ``wide_to_long`` would modify the input stubnames list (:issue:`9204`)
+- Bug in to_sql not storing float64 values using double precision. (:issue:`9009`)


### PR DESCRIPTION
Closes #9009 . @jorisvandenbossche -- do you think this should test/use single precision ?  We could test for float32 perhaps? My own feeling is that this is the safer default.
