### PR TITLE
BUG: series.fillna() fails with quoted numbers

### DIFF
--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -4009,7 +4009,7 @@ def _putmask_smart(v, m, n):
             nv = v.copy()
             nv[m] = nn_at
             return nv
-    except (ValueError, IndexError, TypeError):
+    except (ValueError, IndexError, TypeError, AttributeError):
         pass
 
     # change the dtype


### PR DESCRIPTION
Here's a simple example:

``` python
import pandas as pd
import numpy as np

x = pd.Series(range(5))
x.iloc[1] = np.nan
x.fillna(0) # works
x.fillna('foo') # works
x.fillna('0') # crash
```

in the function `_putmask_smart()`, two numpy arrays are compared to determine if they have compatible dtypes. However if one array contains quoted numbers, then the test does NOT resolve as element wise compare, but rather as a "normal" python comparison. This means the result is `False`, rather than an array, and the attempt to get `False.all()` obviously fails.

Not sure exactly why the arrays don't compare as expected -- perhaps there are other criteria that would trigger it -- but an easy fix is to add `AttributeError` to the try/except clause as a "valid" error. 
