### PR TITLE
pivot & unstack with nan in the index

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -67,6 +67,7 @@ Bug Fixes
 
 
 - Bug in ``MultiIndex.has_duplicates`` when having many levels causes an indexer overflow (:issue:`9075`)
+- Bug in ``pivot`` and `unstack`` where ``nan`` values would break index alignment (:issue:`7466`)
 
 
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -6,7 +6,7 @@ import collections
 
 from pandas.compat import(
     zip, builtins, range, long, lzip,
-    OrderedDict, callable
+    OrderedDict, callable, filter, map
 )
 from pandas import compat
 
@@ -3509,6 +3509,61 @@ def get_group_index(label_list, shape):
 
     np.putmask(group_index, mask, -1)
     return group_index
+
+
+def get_flat_ids(labels, shape, retain_lex_rank):
+    """
+    Given a list of labels at each level, returns a flat array of int64 ids
+    corresponding to unique tuples across the labels. If `retain_lex_rank`,
+    rank of returned ids preserve lexical ranks of labels.
+
+    Parameters
+    ----------
+    labels: sequence of arrays
+        Integers identifying levels at each location
+    shape: sequence of ints same length as labels
+        Number of unique levels at each location
+    retain_lex_rank: boolean
+        If the ranks of returned ids should match lexical ranks of labels
+
+    Returns
+    -------
+    An array of type int64 where two elements are equal if their corresponding
+    labels are equal at all location.
+    """
+    def loop(labels, shape):
+        # how many levels can be done without overflow:
+        pred = lambda i: not _int64_overflow_possible(shape[:i])
+        nlev = next(filter(pred, range(len(shape), 0, -1)))
+
+        # compute flat ids for the first `nlev` levels
+        stride = np.prod(shape[1:nlev], dtype='i8')
+        out = stride * labels[0].astype('i8', subok=False, copy=False)
+
+        for i in range(1, nlev):
+            stride //= shape[i]
+            out += labels[i] * stride
+
+        if nlev == len(shape):  # all levels done!
+            return out
+
+        # compress what has been done so far in order to avoid overflow
+        # to retain lexical ranks, obs_ids should be sorted
+        comp_ids, obs_ids = _compress_group_index(out, sort=retain_lex_rank)
+
+        labels = [comp_ids] + labels[nlev:]
+        shape = [len(obs_ids)] + shape[nlev:]
+
+        return loop(labels, shape)
+
+    def maybe_lift(lab, size):  # pormote nan values
+        return (lab + 1, size + 1) if (lab == -1).any() else (lab, size)
+
+    labels = map(com._ensure_int64, labels)
+    labels, shape = map(list, zip(*map(maybe_lift, labels, shape)))
+
+    return loop(labels, shape)
+
 
 _INT64_MAX = np.iinfo(np.int64).max
 

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -82,18 +82,10 @@ class _Unstacker(object):
 
         self.level = self.index._get_level_number(level)
 
-        levels = index.levels
-        labels = index.labels
+        # when index includes `nan`, need to lift levels/strides by 1
+        self.lift = 1 if -1 in self.index.labels[self.level] else 0
 
-        def _make_index(lev, lab):
-            values = _make_index_array_level(lev.values, lab)
-            i = lev._simple_new(values, lev.name,
-                                freq=getattr(lev, 'freq', None),
-                                tz=getattr(lev, 'tz', None))
-            return i
-
-        self.new_index_levels = [_make_index(lev, lab)
-                                 for lev, lab in zip(levels, labels)]
+        self.new_index_levels = list(index.levels)
         self.new_index_names = list(index.names)
 
         self.removed_name = self.new_index_names.pop(self.level)
@@ -134,10 +126,10 @@ class _Unstacker(object):
         ngroups = len(obs_ids)
 
         comp_index = _ensure_platform_int(comp_index)
-        stride = self.index.levshape[self.level]
+        stride = self.index.levshape[self.level] + self.lift
         self.full_shape = ngroups, stride
 
-        selector = self.sorted_labels[-1] + stride * comp_index
+        selector = self.sorted_labels[-1] + stride * comp_index + self.lift
         mask = np.zeros(np.prod(self.full_shape), dtype=bool)
         mask.put(selector, True)
 
@@ -165,20 +157,6 @@ class _Unstacker(object):
                 inds = (value_mask.sum(0) > 0).nonzero()[0]
                 values = com.take_nd(values, inds, axis=1)
                 columns = columns[inds]
-
-        # we might have a missing index
-        if len(index) != values.shape[0]:
-            mask = isnull(index)
-            if mask.any():
-                l = np.arange(len(index))
-                values, orig_values = (np.empty((len(index), values.shape[1])),
-                                       values)
-                values.fill(np.nan)
-                values_indexer = com._ensure_int64(l[~mask])
-                for i, j in enumerate(values_indexer):
-                    values[j] = orig_values[i]
-            else:
-                index = index.take(self.unique_groups)
 
         # may need to coerce categoricals here
         if self.is_categorical is not None:
@@ -220,9 +198,16 @@ class _Unstacker(object):
 
     def get_new_columns(self):
         if self.value_columns is None:
-            return self.removed_level
+            if self.lift == 0:
+                return self.removed_level
 
-        stride = len(self.removed_level)
+            lev = self.removed_level
+            vals = np.insert(lev.astype('object'), 0,
+                             _get_na_value(lev.dtype.type))
+
+            return lev._shallow_copy(vals)
+
+        stride = len(self.removed_level) + self.lift
         width = len(self.value_columns)
         propagator = np.repeat(np.arange(width), stride)
         if isinstance(self.value_columns, MultiIndex):
@@ -231,59 +216,34 @@ class _Unstacker(object):
 
             new_labels = [lab.take(propagator)
                           for lab in self.value_columns.labels]
-            new_labels.append(np.tile(np.arange(stride), width))
         else:
             new_levels = [self.value_columns, self.removed_level]
             new_names = [self.value_columns.name, self.removed_name]
+            new_labels = [propagator]
 
-            new_labels = []
-
-            new_labels.append(propagator)
-            new_labels.append(np.tile(np.arange(stride), width))
-
+        new_labels.append(np.tile(np.arange(stride) - self.lift, width))
         return MultiIndex(levels=new_levels, labels=new_labels,
                           names=new_names, verify_integrity=False)
 
     def get_new_index(self):
-        result_labels = []
-        for cur in self.sorted_labels[:-1]:
-            labels = cur.take(self.compressor)
-            labels = _make_index_array_level(labels, cur)
-            result_labels.append(labels)
+        result_labels = [lab.take(self.compressor)
+                         for lab in self.sorted_labels[:-1]]
 
         # construct the new index
         if len(self.new_index_levels) == 1:
-            new_index = self.new_index_levels[0]
-            new_index.name = self.new_index_names[0]
-        else:
-            new_index = MultiIndex(levels=self.new_index_levels,
-                                   labels=result_labels,
-                                   names=self.new_index_names,
-                                   verify_integrity=False)
+            lev, lab = self.new_index_levels[0], result_labels[0]
+            if not (lab == -1).any():
+                return lev.take(lab)
 
-        return new_index
+            vals = np.insert(lev.astype('object'), len(lev),
+                             _get_na_value(lev.dtype.type)).take(lab)
 
+            return lev._shallow_copy(vals)
 
-def _make_index_array_level(lev, lab):
-    """ create the combined index array, preserving nans, return an array """
-    mask = lab == -1
-    if not mask.any():
-        return lev
-
-    l = np.arange(len(lab))
-    mask_labels = np.empty(len(mask[mask]), dtype=object)
-    mask_labels.fill(_get_na_value(lev.dtype.type))
-    mask_indexer = com._ensure_int64(l[mask])
-
-    labels = lev
-    labels_indexer = com._ensure_int64(l[~mask])
-
-    new_labels = np.empty(tuple([len(lab)]), dtype=object)
-    new_labels[labels_indexer] = labels
-    new_labels[mask_indexer] = mask_labels
-
-    return new_labels
-
+        return MultiIndex(levels=self.new_index_levels,
+                          labels=result_labels,
+                          names=self.new_index_names,
+                          verify_integrity=False)
 
 def _unstack_multiple(data, clocs):
     if len(clocs) == 0:
@@ -483,29 +443,10 @@ def _unstack_frame(obj, level):
 
 
 def get_compressed_ids(labels, sizes):
-    # no overflow
-    if com._long_prod(sizes) < 2 ** 63:
-        group_index = get_group_index(labels, sizes)
-        comp_index, obs_ids = _compress_group_index(group_index)
-    else:
-        n = len(labels[0])
-        mask = np.zeros(n, dtype=bool)
-        for v in labels:
-            mask |= v < 0
+    from pandas.core.groupby import get_flat_ids
 
-        while com._long_prod(sizes) >= 2 ** 63:
-            i = len(sizes)
-            while com._long_prod(sizes[:i]) >= 2 ** 63:
-                i -= 1
-
-            rem_index, rem_ids = get_compressed_ids(labels[:i],
-                                                    sizes[:i])
-            sizes = [len(rem_ids)] + sizes[i:]
-            labels = [rem_index] + labels[i:]
-
-        return get_compressed_ids(labels, sizes)
-
-    return comp_index, obs_ids
+    ids = get_flat_ids(labels, sizes, True)
+    return _compress_group_index(ids, sort=True)
 
 
 def stack(frame, level=-1, dropna=True):

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -173,13 +173,16 @@ class TestPivotTable(tm.TestCase):
     def test_pivot_index_with_nan(self):
         # GH 3588
         nan = np.nan
-        df = DataFrame({"a":['R1', 'R2', nan, 'R4'], 'b':["C1", "C2", "C3" , "C4"], "c":[10, 15, nan , 20]})
+        df = DataFrame({'a':['R1', 'R2', nan, 'R4'],
+                        'b':['C1', 'C2', 'C3' , 'C4'],
+                        'c':[10, 15, 17, 20]})
         result = df.pivot('a','b','c')
-        expected = DataFrame([[nan,nan,nan,nan],[nan,10,nan,nan],
-                              [nan,nan,nan,nan],[nan,nan,15,20]],
-                             index = Index(['R1','R2',nan,'R4'],name='a'),
+        expected = DataFrame([[nan,nan,17,nan],[10,nan,nan,nan],
+                              [nan,15,nan,nan],[nan,nan,nan,20]],
+                             index = Index([nan,'R1','R2','R4'],name='a'),
                              columns = Index(['C1','C2','C3','C4'],name='b'))
         tm.assert_frame_equal(result, expected)
+        tm.assert_frame_equal(df.pivot('b', 'a', 'c'), expected.T)
 
     def test_pivot_with_tz(self):
         # GH 5878
@@ -268,12 +271,12 @@ class TestPivotTable(tm.TestCase):
 
         # issue number #8349: pivot_table with margins and dictionary aggfunc
 
-        df=DataFrame([  {'JOB':'Worker','NAME':'Bob' ,'YEAR':2013,'MONTH':12,'DAYS': 3,'SALARY': 17}, 
-                        {'JOB':'Employ','NAME':'Mary','YEAR':2013,'MONTH':12,'DAYS': 5,'SALARY': 23}, 
-                        {'JOB':'Worker','NAME':'Bob' ,'YEAR':2014,'MONTH': 1,'DAYS':10,'SALARY':100}, 
-                        {'JOB':'Worker','NAME':'Bob' ,'YEAR':2014,'MONTH': 1,'DAYS':11,'SALARY':110}, 
-                        {'JOB':'Employ','NAME':'Mary','YEAR':2014,'MONTH': 1,'DAYS':15,'SALARY':200}, 
-                        {'JOB':'Worker','NAME':'Bob' ,'YEAR':2014,'MONTH': 2,'DAYS': 8,'SALARY': 80}, 
+        df=DataFrame([  {'JOB':'Worker','NAME':'Bob' ,'YEAR':2013,'MONTH':12,'DAYS': 3,'SALARY': 17},
+                        {'JOB':'Employ','NAME':'Mary','YEAR':2013,'MONTH':12,'DAYS': 5,'SALARY': 23},
+                        {'JOB':'Worker','NAME':'Bob' ,'YEAR':2014,'MONTH': 1,'DAYS':10,'SALARY':100},
+                        {'JOB':'Worker','NAME':'Bob' ,'YEAR':2014,'MONTH': 1,'DAYS':11,'SALARY':110},
+                        {'JOB':'Employ','NAME':'Mary','YEAR':2014,'MONTH': 1,'DAYS':15,'SALARY':200},
+                        {'JOB':'Worker','NAME':'Bob' ,'YEAR':2014,'MONTH': 2,'DAYS': 8,'SALARY': 80},
                         {'JOB':'Employ','NAME':'Mary','YEAR':2014,'MONTH': 2,'DAYS': 5,'SALARY':190} ])
 
         df=df.set_index(['JOB','NAME','YEAR','MONTH'],drop=False,append=False)


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/7466
on branch:

```
>>> df
     a   b   c
0   R1  C1  10
1   R2  C2  15
2  NaN  C3  17
3   R4  C4  20
>>> df.pivot('a', 'b', 'c').fillna('.')
b    C1  C2  C3  C4
a
NaN   .   .  17   .
R1   10   .   .   .
R2    .  15   .   .
R4    .   .   .  20
>>> df.pivot('b', 'a', 'c').fillna('.')
a  NaN  R1  R2  R4
b
C1   .  10   .   .
C2   .   .  15   .
C3  17   .   .   .
C4   .   .   .  20
```

the `pivot` function requires the `unstack` function to work with `nan`s in the index:

```
>>> df
                4th     5th
1st 2nd 3rd
d   y   67   d.y.67  67.y.d
        39   d.y.39  39.y.d
    w   53   d.w.53  53.w.d
NaN w   72    .w.72  72.w. 
        57    .w.57  57.w. 
    NaN 80    . .80  80. . 
        31    . .31  31. . 
        18    . .18  18. . 
a   z   11   a.z.11  11.z.a
        30   a.z.30  30.z.a
c   z   59   c.z.59  59.z.c
        50   c.z.50  50.z.c
    NaN 62   c. .62  62. .c
e   NaN 59   e. .59  59. .e
        76   e. .76  76. .e
b   x   52   b.x.52  52.x.b
        14   b.x.14  14.x.b
        53   b.x.53  53.x.b
    NaN 60   b. .60  60. .b
        51   b. .51  51. .b
```

the `4th` and `5th` column are so that it is easy to verify the frame:

```
>>> df.unstack(level=1).fillna('-')
            4th                                     5th
2nd         NaN       w       x       y       z     NaN       w       x       y       z
1st 3rd
NaN 18    . .18       -       -       -       -  18. .        -       -       -       -
    31    . .31       -       -       -       -  31. .        -       -       -       -
    57        -   .w.57       -       -       -       -  57.w.        -       -       -
    72        -   .w.72       -       -       -       -  72.w.        -       -       -
    80    . .80       -       -       -       -  80. .        -       -       -       -
a   11        -       -       -       -  a.z.11       -       -       -       -  11.z.a
    30        -       -       -       -  a.z.30       -       -       -       -  30.z.a
b   14        -       -  b.x.14       -       -       -       -  14.x.b       -       -
    51   b. .51       -       -       -       -  51. .b       -       -       -       -
    52        -       -  b.x.52       -       -       -       -  52.x.b       -       -
    53        -       -  b.x.53       -       -       -       -  53.x.b       -       -
    60   b. .60       -       -       -       -  60. .b       -       -       -       -
c   50        -       -       -       -  c.z.50       -       -       -       -  50.z.c
    59        -       -       -       -  c.z.59       -       -       -       -  59.z.c
    62   c. .62       -       -       -       -  62. .c       -       -       -       -
d   39        -       -       -  d.y.39       -       -       -       -  39.y.d       -
    53        -  d.w.53       -       -       -       -  53.w.d       -       -       -
    67        -       -       -  d.y.67       -       -       -       -  67.y.d       -
e   59   e. .59       -       -       -       -  59. .e       -       -       -       -
    76   e. .76       -       -       -       -  76. .e       -       -       -       -
```

`nan` values are kept out of levels and are handled by labels:

```
>>> df.unstack(level=1).index
MultiIndex(levels=[['a', 'b', 'c', 'd', 'e'], [11, 14, 18, 30, 31, 39, 50, 51, 52, 53, 57, 59, 60, 62, 67, 72, 76, 80]],
           labels=[[-1, -1, -1, -1, -1, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4], [2, 4, 10, 15, 17, 0, 3, 1, 7, 8, 9, 12, 6, 11, 13, 5, 9, 14, 11, 16]],
           names=['1st', '3rd'])
>>> df.unstack(level=1).columns
MultiIndex(levels=[['4th', '5th'], ['w', 'x', 'y', 'z']],
           labels=[[0, 0, 0, 0, 0, 1, 1, 1, 1, 1], [-1, 0, 1, 2, 3, -1, 0, 1, 2, 3]],
           names=[None, '2nd'])
```
