### PR TITLE
Closes #8943:  COMPAT: periods needs coercion to np.int64

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -48,3 +48,6 @@ Bug Fixes
 ~~~~~~~~~
 
 .. _whatsnew_0160.bug_fixes:
+
+- Fixed compatibility issue in ``DatetimeIndex`` affecting architectures where ``numpy.int_`` defaults to ``numpy.int32`` (:issue:`8943`)
+

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -1909,6 +1909,22 @@ class TestDatetimeIndex(Base, tm.TestCase):
             right.iloc[i] *= -10
             tm.assert_series_equal(left, right)
 
+    def test_time_overflow_for_32bit_machines(self):
+        # GH8943.  On some machines NumPy defaults to np.int32 (for example,
+        # 32-bit Linux machines).  In the function _generate_regular_range
+        # found in tseries/index.py, `periods` gets multiplied by `strides`
+        # (which has value 1e9) and since the max value for np.int32 is ~2e9,
+        # and since those machines won't promote np.int32 to np.int64, we get
+        # overflow.
+        periods = np.int_(1000)
+
+        idx1 = pd.date_range(start='2000', periods=periods, freq='S')
+        self.assertEqual(len(idx1), periods)
+
+        idx2 = pd.date_range(end='2000', periods=periods, freq='S')
+        self.assertEqual(len(idx2), periods)
+
+
 class TestPeriodIndex(Base, tm.TestCase):
     _holder = PeriodIndex
     _multiprocess_can_split_ = True

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1781,11 +1781,11 @@ def _generate_regular_range(start, end, periods, offset):
             tz = start.tz
         elif start is not None:
             b = Timestamp(start).value
-            e = b + periods * stride
+            e = b + np.int64(periods) * stride
             tz = start.tz
         elif end is not None:
             e = Timestamp(end).value + stride
-            b = e - periods * stride
+            b = e - np.int64(periods) * stride
             tz = end.tz
         else:
             raise NotImplementedError


### PR DESCRIPTION
Let me know if this needs any work.

closes #8943 
