### PR TITLE
Fixes .nth() with groupby multiple columns

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -118,3 +118,4 @@ Bug Fixes
 - DataFrame now properly supports simultaneous ``copy`` and ``dtype`` arguments in constructor (:issue:`9099`)
 - Bug in read_csv when using skiprows on a file with CR line endings with the c engine. (:issue:`9079`)
 - isnull now detects NaT in PeriodIndex (:issue:`9129`)
+- groupby .nth() method works with MultiIndex / multiple column groupby now (:issue:`8979`)`

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -859,7 +859,7 @@ class GroupBy(PandasObject):
                     # this is a pass-thru
                     pass
                 elif all([ n in ax for n in names ]):
-                    result.index = Index(self.obj[names][is_nth].values.ravel()).set_names(names)
+                    result.index = MultiIndex.from_arrays([self.obj[name][is_nth] for name in names]).set_names(names)
                 elif self._group_selection is not None:
                     result.index = self.obj._get_axis(self.axis)[is_nth]
 

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -337,6 +337,35 @@ class TestGroupBy(tm.TestCase):
         expected = DataFrame(1, columns=['a', 'b'], index=expected_dates)
         assert_frame_equal(result, expected)
 
+    def test_nth_multi_index(self):
+        # PR 9090, related to issue 8979
+        # test nth on MultiIndex, should match .first()
+        grouped = self.three_group.groupby(['A', 'B'])
+        result = grouped.nth(0)
+        expected = grouped.first()
+        assert_frame_equal(result, expected)
+
+
+    def test_nth_multi_index_as_expected(self):
+        # PR 9090, related to issue 8979
+        # test nth on MultiIndex
+        three_group = DataFrame({'A': ['foo', 'foo', 'foo', 'foo',
+                                       'bar', 'bar', 'bar', 'bar',
+                                       'foo', 'foo', 'foo'],
+                                 'B': ['one', 'one', 'one', 'two',
+                                       'one', 'one', 'one', 'two',
+                                       'two', 'two', 'one'],
+                                 'C': ['dull', 'dull', 'shiny', 'dull',
+                                       'dull', 'shiny', 'shiny', 'dull',
+                                       'shiny', 'shiny', 'shiny']})
+        grouped = three_group.groupby(['A', 'B'])
+        result = grouped.nth(0)
+        expected = DataFrame({'C': ['dull', 'dull', 'dull', 'dull']},
+                             index=MultiIndex.from_arrays([['bar', 'bar', 'foo', 'foo'], ['one', 'two', 'one', 'two']],
+                                                          names=['A', 'B']))
+        assert_frame_equal(result, expected)
+
+
     def test_grouper_index_types(self):
         # related GH5375
         # groupby misbehaving when using a Floatlike index


### PR DESCRIPTION
closes #8979

Let me know if this makes sense

Problem mentioned in issue 8979 too
