### PR TITLE
Refs BUG-9099: Support simultaneous copy and dtype args in DataFrame init

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -51,3 +51,4 @@ Bug Fixes
 
 - Fixed compatibility issue in ``DatetimeIndex`` affecting architectures where ``numpy.int_`` defaults to ``numpy.int32`` (:issue:`8943`)
 - Bug in ``MultiIndex.has_duplicates`` when having many levels causes an indexer overflow (:issue:`9075`)
+- DataFrame now properly supports simultaneous ``copy`` and ``dtype`` arguments in constructor (:issue:`9099`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -121,11 +121,11 @@ class NDFrame(PandasObject):
                 mgr = mgr.reindex_axis(
                     axe, axis=self._get_block_manager_axis(a), copy=False)
 
-        # do not copy BlockManager unless explicitly done
-        if copy and dtype is None:
+        # make a copy if explicitly requested
+        if copy:
             mgr = mgr.copy()
-        elif dtype is not None:
-            # avoid copy if we can
+        if dtype is not None:
+            # avoid further copies if we can
             if len(mgr.blocks) > 1 or mgr.blocks[0].values.dtype != dtype:
                 mgr = mgr.astype(dtype=dtype)
         return mgr

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2489,6 +2489,17 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # this is ok
         df['foo2'] = np.ones((4,2)).tolist()
 
+    def test_constructor_dtype_copy(self):
+        orig_df = DataFrame({
+            'col1': [1.],
+            'col2': [2.],
+            'col3': [3.]})
+
+        new_df = pd.DataFrame(orig_df, dtype=float, copy=True)
+
+        new_df['col1'] = 200.
+        self.assertEqual(orig_df['col1'][0], 1.)
+
     def test_constructor_dtype_nocast_view(self):
         df = DataFrame([[1, 2]])
         should_be_view = DataFrame(df, dtype=df[0].dtype)


### PR DESCRIPTION
closes #9099
This is a somewhat brute-force fix for supporting copy and dtype arguments in DataFrame constructor. Some data might be copied twice if both arguments are set, but if I did the operations in a different order, one other unit test would fail.
