### PR TITLE
ENH: get_dummies can accept value and na_value kw

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -152,6 +152,14 @@ Enhancements
 - ``Timedelta`` will now accept ``nanoseconds`` keyword in constructor (:issue:`9273`)
 - SQL code now safely escapes table and column names (:issue:`8986`)
 
+- ``pd.get_dummies`` can accept ``pos_value`` and ``neg_value`` keywords for filling with positive and negative valriables (:issue:`8028`)
+
+  .. ipython:: python
+
+     s = pd.Series(['X', 'Y', 'X', 'Y'])
+     pd.get_dummies(s, pos_value='YES', neg_value='NO')
+
+
 - Added auto-complete for ``Series.str.<tab>``, ``Series.dt.<tab>`` and ``Series.cat.<tab>`` (:issue:`9322`)
 - Added ``StringMethods.isalnum()``, ``isalpha()``, ``isdigit()``, ``isspace()``, ``islower()``,
   ``isupper()``, ``istitle()`` which behave as the same as standard ``str`` (:issue:`9282`)

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -16,6 +16,7 @@ from pandas.core.groupby import get_group_index, _compress_group_index
 
 import pandas.core.common as com
 import pandas.algos as algos
+import pandas.lib as lib
 
 from pandas.core.index import MultiIndex
 
@@ -975,7 +976,7 @@ def convert_dummies(data, cat_variables, prefix_sep='_'):
 
 
 def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False,
-                columns=None):
+                columns=None, pos_value=None, neg_value=None):
     """
     Convert categorical variable into dummy/indicator variables
 
@@ -996,6 +997,10 @@ def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False,
         Column names in the DataFrame to be encoded.
         If `columns` is None then all the columns with
         `object` or `category` dtype will be converted.
+    pos_value : scalar value or dict
+        replacement value corresponding to positive variables (dummy variables)
+    neg_value : list-like, default None
+        replacement value corresponding to negative variables
 
     Returns
     -------
@@ -1088,6 +1093,19 @@ def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False,
         result = concat(with_dummies, axis=1)
     else:
         result = _get_dummies_1d(data, prefix, prefix_sep, dummy_na)
+
+    if pos_value is not None:
+        if isinstance(pos_value, dict) or lib.isscalar(pos_value):
+            result = result.replace(to_replace=1, value=pos_value)
+        else:
+            raise ValueError('invalid pos_value, use scalar or dict: %s' % type(pos_value))
+
+    if neg_value is not None:
+        if isinstance(neg_value, dict) or lib.isscalar(neg_value):
+            result = result.replace(to_replace=0, value=neg_value)
+        else:
+            raise ValueError('invalid neg_value, use scalar or dict: %s' % type(neg_value))
+
     return result
 
 

--- a/pandas/tests/test_reshape.py
+++ b/pandas/tests/test_reshape.py
@@ -322,6 +322,138 @@ class TestGetDummies(tm.TestCase):
                              'cat_x', 'cat_y']]
         assert_frame_equal(result, expected)
 
+    def test_series_fill_scalar(self):
+        s_list = ['a', 'b', 'c', 'a']
+        s_series = Series(s_list)
+        s_series_index = Series(s_list, index=['A', 'B', 'C', 'D'])
+
+        expected = DataFrame({'a': ['Yes', 0.0, 0.0, 'Yes'],
+                              'b': [0.0, 'Yes', 0.0, 0.0],
+                              'c': [0.0, 0.0, 'Yes', 0.0]})
+        result = get_dummies(s_series, pos_value='Yes')
+
+        assert_frame_equal(result, expected)
+
+        expected.index = list('ABCD')
+        result = get_dummies(s_series_index, pos_value='Yes')
+        assert_frame_equal(result, expected)
+
+        expected = DataFrame({'a': ['Yes', 'No', 'No', 'Yes'],
+                              'b': ['No', 'Yes', 'No', 'No'],
+                              'c': ['No', 'No', 'Yes', 'No']})
+        result = get_dummies(s_series, pos_value='Yes', neg_value='No')
+        assert_frame_equal(result, expected)
+
+        expected.index = list('ABCD')
+        result = get_dummies(s_series_index, pos_value='Yes', neg_value='No')
+        assert_frame_equal(result, expected)
+
+    def test_dataframe_fill_scalar(self):
+        df = DataFrame({'A': ['X', 'Y', 'X'], 'B':['x', 'x', 'y']})
+
+        expected = DataFrame({'A_X': ['Yes', 0, 'Yes'],
+                              'A_Y': [0, 'Yes', 0],
+                              'B_x': ['Yes', 'Yes', 0],
+                              'B_y': [0, 0, 'Yes']})
+        result = get_dummies(df, pos_value='Yes')
+        assert_frame_equal(result, expected)
+
+        expected = DataFrame({'A_X': ['Yes', 'No', 'Yes'],
+                              'A_Y': ['No', 'Yes', 'No'],
+                              'B_x': ['Yes', 'Yes', 'No'],
+                              'B_y': ['No', 'No', 'Yes']})
+        result = get_dummies(df, pos_value='Yes', neg_value='No')
+        assert_frame_equal(result, expected)
+
+    def test_series_fill_dict(self):
+        s_list = ['a', 'b', 'c', 'a']
+        s_series = Series(['a', 'b', 'c', 'a'])
+        s_series_index = Series(s_list, index=['A', 'B', 'C', 'D'])
+
+        d_true = {'a': 'Y_a', 'b': 'Y_b', 'c': 'Y_c'}
+        d_na = {'a': 'N_a', 'b': 'N_b', 'c': 'N_c'}
+        expected = DataFrame({'a': [1.0, 'N_a', 'N_a', 1.0],
+                              'b': ['N_b', 1.0, 'N_b', 'N_b'],
+                              'c': ['N_c', 'N_c', 1.0, 'N_c']})
+        result = get_dummies(s_series, neg_value=d_na)
+        assert_frame_equal(result, expected)
+
+        expected.index = list('ABCD')
+        result = get_dummies(s_series_index, neg_value=d_na)
+        assert_frame_equal(result, expected)
+
+        expected = DataFrame({'a': ['Y_a', 'N_a', 'N_a', 'Y_a'],
+                              'b': ['N_b', 'Y_b', 'N_b', 'N_b'],
+                              'c': ['N_c', 'N_c', 'Y_c', 'N_c']})
+        result = get_dummies(s_series, pos_value=d_true, neg_value=d_na)
+        assert_frame_equal(result, expected)
+
+        expected.index = list('ABCD')
+        result = get_dummies(s_series_index, pos_value=d_true, neg_value=d_na)
+        assert_frame_equal(result, expected)
+
+    def test_dataframe_fill_dict(self):
+        df = DataFrame({'A': ['X', 'Y', 'X'], 'B':['x', 'x', 'y']})
+
+        expected = DataFrame({'A_X': ['Y_AX', 0, 'Y_AX'],
+                              'A_Y': [0, 'Y_AY', 0],
+                              'B_x': ['Y_Bx', 'Y_Bx', 0],
+                              'B_y': [0, 0, 'Y_By']})
+        result = get_dummies(df, pos_value={'A_X': 'Y_AX', 'A_Y': 'Y_AY',
+                                            'B_x': 'Y_Bx', 'B_y': 'Y_By'})
+        assert_frame_equal(result, expected)
+
+        expected = DataFrame({'A_X': [1, 'N_AX', 1],
+                              'A_Y': ['N_AY', 1, 'N_AY'],
+                              'B_x': [1, 1, 'N_Bx'],
+                              'B_y': ['N_By', 'N_By', 1]})
+        result = get_dummies(df, neg_value={'A_X': 'N_AX', 'A_Y': 'N_AY',
+                                            'B_x': 'N_Bx', 'B_y': 'N_By'})
+        assert_frame_equal(result, expected)
+
+        expected = DataFrame({'A_X': ['Y_AX', 'N_AX', 'Y_AX'],
+                              'A_Y': ['N_AY', 'Y_AY', 'N_AY'],
+                              'B_x': ['Y_Bx', 'Y_Bx', 'N_Bx'],
+                              'B_y': ['N_By', 'N_By', 'Y_By']})
+        result = get_dummies(df, pos_value={'A_X': 'Y_AX', 'A_Y': 'Y_AY',
+                                            'B_x': 'Y_Bx', 'B_y': 'Y_By'},
+                                 neg_value={'A_X': 'N_AX', 'A_Y': 'N_AY',
+                                            'B_x': 'N_Bx', 'B_y': 'N_By'})
+        assert_frame_equal(result, expected)
+
+    def test_series_dummies_fill_list(self):
+        # must be all errors
+        s = Series(['a', 'b', 'c', 'a'])
+
+        s_list = [1, 1, 0, 1]
+        s_series = Series([0, 1, 1, 0])
+        v_msg = "invalid pos_value, use scalar or dict"
+        na_msg = "invalid neg_value, use scalar or dict"
+        with tm.assertRaisesRegexp(ValueError, v_msg):
+            result = get_dummies(s, pos_value=s_list)
+        with tm.assertRaisesRegexp(ValueError, v_msg):
+            result = get_dummies(s, pos_value=s_series)
+        with tm.assertRaisesRegexp(ValueError, na_msg):
+            result = get_dummies(s, neg_value=s_list)
+        with tm.assertRaisesRegexp(ValueError, na_msg):
+            result = get_dummies(s, neg_value=s_series)
+
+    def test_dataframe_dummies_fill_list(self):
+        df = DataFrame({'A': ['a', 'b', 'c'], 'B': ['x', 'y', 'z']})
+
+        s_list = ['a', 'b', 'c', 'a']
+        s_series = Series(['a', 'b', 'c', 'a'])
+        v_msg = "invalid pos_value, use scalar or dict"
+        na_msg = "invalid neg_value, use scalar or dict"
+        with tm.assertRaisesRegexp(ValueError, v_msg):
+            result = get_dummies(df, pos_value=s_list)
+        with tm.assertRaisesRegexp(ValueError, v_msg):
+            result = get_dummies(df, pos_value=s_series)
+        with tm.assertRaisesRegexp(ValueError, na_msg):
+            result = get_dummies(df, neg_value=s_list)
+        with tm.assertRaisesRegexp(ValueError, na_msg):
+            result = get_dummies(df, neg_value=s_series)
+
 
 class TestConvertDummies(tm.TestCase):
     def test_convert_dummies(self):


### PR DESCRIPTION
Closes #8028. It is still under work, but want to clarify a point. Currently it  works as:

```
s = pd.Series(['A', 'B', 'A', 'C'])
s
#0    A
#1    B
#2    A
#3    C
# dtype: object

pd.get_dummies(s)
#    A  B  C
#0  1  0  0
#1  0  1  0
#2  1  0  0
#3  0  0  1

pd.get_dummies(s, value='YES', na_value='NO')
#      A    B    C
#0  YES   NO   NO
#1   NO  YES   NO
#2  YES   NO   NO
#3   NO   NO  YES

pd.get_dummies(s, value={'A': 'X', 'B': 'Y', 'C': 'Z'})
#    A  B  C
#0  X  0  0
#1  0  Y  0
#2  X  0  0
#3  0  0  Z
```

And what I'm concerning is cases for list-likes. 

```
# This is natural and compat with replace, because the number of the hole will be the same number as list (one hole in each column).
pd.get_dummies(s, value=['A', 'B', 'A', 'C'])
#    A  B  C
#0  A  0  0
#1  0  B  0
#2  A  0  0
#3  0  0  C

# When we specify na_value and make it compat with replace, behavior should be:
pd.get_dummies(s, na_value=['A', 'B', 'A', 'C'])
#    A  B  C
0  1  A  B
1  A  1  C
2  1  A  B
3  A  C  1

# Or it needs different broadcasting rule?
pd.get_dummies(s, na_value=['A', 'B', 'A', 'C'])
#    A  B  C
#0  1  A  A
#1  B  1  B
#2  1  A  A
#3  C  C  1
```
