### PR TITLE
PERF: json support for blocks GH9037

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -28,6 +28,22 @@ Backwards incompatible API changes
 .. _whatsnew_0160.api_breaking:
 
 - ``Index.duplicated`` now returns `np.array(dtype=bool)` rather than `Index(dtype=object)` containing `bool` values. (:issue:`8875`)
+- ``DataFrame.to_json`` now returns accurate type serialisation for each column for frames of mixed dtype (:issue:`9037`)
+
+  Previously data was coerced to a common dtype before serialisation, which for
+  example resulted in integers being serialised to floats:
+
+  .. code-block:: python
+
+    In [2]: pd.DataFrame({'i': [1,2], 'f': [3.0, 4.2]}).to_json()
+    Out[2]: '{"f":{"0":3.0,"1":4.2},"i":{"0":1.0,"1":2.0}}'
+
+  Now each column is serialised using its correct dtype:
+
+  .. code-block:: python
+
+    In [2]:  pd.DataFrame({'i': [1,2], 'f': [3.0, 4.2]}).to_json()
+    Out[2]: '{"f":{"0":3.0,"1":4.2},"i":{"0":1,"1":2}}'
 
 Deprecations
 ~~~~~~~~~~~~
@@ -46,9 +62,9 @@ Performance
 .. _whatsnew_0160.performance:
 
 - Fixed a performance regression for ``.loc`` indexing with an array or list-like (:issue:`9126`:).
+- ``DataFrame.to_json`` 30x performance improvement for mixed dtype frames. (:issue:`9037`)
 - Performance improvements in ``MultiIndex.duplicated`` by working with labels instead of values (:issue:`9125`)
 - Improved the speed of `nunique` by calling `unique` instead of `value_counts` (:issue:`9129`, :issue:`7771`)
-
 
 Bug Fixes
 ~~~~~~~~~

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2160,20 +2160,12 @@ class NDFrame(PandasObject):
         Convert the frame to a dict of dtype -> Constructor Types that each has
         a homogeneous dtype.
 
-        are presented in sorted order unless a specific list of columns is
-        provided.
-
         NOTE: the dtypes of the blocks WILL BE PRESERVED HERE (unlike in
               as_matrix)
 
-        Parameters
-        ----------
-        columns : array-like
-            Specific column order
-
         Returns
         -------
-        values : a list of Object
+        values : a dict of dtype -> Constructor Types
         """
         self._consolidate_inplace()
 

--- a/pandas/io/tests/test_json/test_pandas.py
+++ b/pandas/io/tests/test_json/test_pandas.py
@@ -1,5 +1,5 @@
 # pylint: disable-msg=W0612,E1101
-from pandas.compat import range, lrange, StringIO
+from pandas.compat import range, lrange, StringIO, OrderedDict
 from pandas import compat
 import os
 
@@ -337,13 +337,43 @@ class TestPandasContainer(tm.TestCase):
 
         v12_json = os.path.join(self.dirpath, 'tsframe_v012.json')
         df_unser = pd.read_json(v12_json)
-        df_unser = pd.read_json(v12_json)
         assert_frame_equal(df, df_unser)
 
         df_iso = df.drop(['modified'], axis=1)
         v12_iso_json = os.path.join(self.dirpath, 'tsframe_iso_v012.json')
         df_unser_iso = pd.read_json(v12_iso_json)
         assert_frame_equal(df_iso, df_unser_iso)
+
+    def test_blocks_compat_GH9037(self):
+        index = pd.date_range('20000101', periods=10, freq='H')
+        df_mixed = DataFrame(OrderedDict(
+            float_1=[-0.92077639, 0.77434435, 1.25234727, 0.61485564,
+                     -0.60316077, 0.24653374, 0.28668979, -2.51969012,
+                     0.95748401, -1.02970536],
+            int_1=[19680418, 75337055, 99973684, 65103179, 79373900,
+                   40314334, 21290235,  4991321, 41903419, 16008365],
+            str_1=['78c608f1', '64a99743', '13d2ff52', 'ca7f4af2', '97236474',
+                   'bde7e214', '1a6bde47', 'b1190be5', '7a669144', '8d64d068'],
+            float_2=[-0.0428278, -1.80872357,  3.36042349, -0.7573685,
+                     -0.48217572, 0.86229683, 1.08935819, 0.93898739,
+                     -0.03030452, 1.43366348],
+            str_2=['14f04af9', 'd085da90', '4bcfac83', '81504caf', '2ffef4a9',
+                   '08e2f5c4', '07e1af03', 'addbd4a7', '1f6a09ba', '4bfc4d87'],
+            int_2=[86967717, 98098830, 51927505, 20372254, 12601730, 20884027,
+                   34193846, 10561746, 24867120, 76131025]
+        ), index=index)
+
+        # JSON deserialisation always creates unicode strings
+        df_mixed.columns = df_mixed.columns.astype('unicode')
+
+        df_roundtrip = pd.read_json(df_mixed.to_json(orient='split'),
+                                    orient='split')
+        assert_frame_equal(df_mixed, df_roundtrip,
+                           check_index_type=True,
+                           check_column_type=True,
+                           check_frame_type=True,
+                           by_blocks=True,
+                           check_exact=True)
 
     def test_series_non_unique_index(self):
         s = Series(['a', 'b'], index=[1, 1])

--- a/pandas/src/datetime_helper.h
+++ b/pandas/src/datetime_helper.h
@@ -13,8 +13,11 @@ void mangle_nat(PyObject *val) {
 }
 
 npy_int64 get_long_attr(PyObject *o, const char *attr) {
+  npy_int64 long_val;
   PyObject *value = PyObject_GetAttrString(o, attr);
-  return PyLong_Check(value) ? PyLong_AsLongLong(value) : PyInt_AS_LONG(value);
+  long_val = (PyLong_Check(value) ? PyLong_AsLongLong(value) : PyInt_AS_LONG(value));
+  Py_DECREF(value);
+  return long_val;
 }
 
 npy_float64 total_seconds(PyObject *td) {

--- a/pandas/src/ujson/python/py_defines.h
+++ b/pandas/src/ujson/python/py_defines.h
@@ -42,6 +42,7 @@ http://www.opensource.apple.com/source/tcl/tcl-14/tcl/license.terms
 #define PyInt_Check             PyLong_Check
 #define PyInt_AS_LONG           PyLong_AsLong
 #define PyInt_FromLong          PyLong_FromLong
+#define PyInt_FromSsize_t       PyLong_FromSsize_t
 
 #define PyString_Check          PyBytes_Check
 #define PyString_GET_SIZE       PyBytes_GET_SIZE

--- a/vb_suite/packers.py
+++ b/vb_suite/packers.py
@@ -140,8 +140,50 @@ packers_read_json = Benchmark("pd.read_json(f, orient='split')", setup, start_da
 setup = common_setup + """
 """
 packers_write_json_date_index = Benchmark("df.to_json(f,orient='split')", setup, cleanup="remove(f)", start_date=start_date)
+
 setup = setup + setup_int_index
 packers_write_json = Benchmark("df.to_json(f,orient='split')", setup, cleanup="remove(f)", start_date=start_date)
+packers_write_json_T = Benchmark("df.to_json(f,orient='columns')", setup, cleanup="remove(f)", start_date=start_date)
+
+setup = common_setup + """
+from numpy.random import randint
+from collections import OrderedDict
+
+cols = [
+  lambda i: ("{0}_timedelta".format(i), [pd.Timedelta('%d seconds' % randrange(1e6)) for _ in range(N)]),
+  lambda i: ("{0}_int".format(i), randint(1e8, size=N)),
+  lambda i: ("{0}_timestamp".format(i), [pd.Timestamp( 1418842918083256000 + randrange(1e9, 1e18, 200)) for _ in range(N)])
+  ]
+df_mixed = DataFrame(OrderedDict([cols[i % len(cols)](i) for i in range(C)]),
+                     index=index)
+"""
+packers_write_json_mixed_delta_int_tstamp = Benchmark("df_mixed.to_json(f,orient='split')", setup, cleanup="remove(f)", start_date=start_date)
+
+setup = common_setup + """
+from numpy.random import randint
+from collections import OrderedDict
+cols = [
+  lambda i: ("{0}_float".format(i), randn(N)),
+  lambda i: ("{0}_int".format(i), randint(1e8, size=N))
+  ]
+df_mixed = DataFrame(OrderedDict([cols[i % len(cols)](i) for i in range(C)]),
+                     index=index)
+"""
+packers_write_json_mixed_float_int = Benchmark("df_mixed.to_json(f,orient='index')", setup, cleanup="remove(f)", start_date=start_date)
+packers_write_json_mixed_float_int_T = Benchmark("df_mixed.to_json(f,orient='columns')", setup, cleanup="remove(f)", start_date=start_date)
+
+setup = common_setup + """
+from numpy.random import randint
+from collections import OrderedDict
+cols = [
+  lambda i: ("{0}_float".format(i), randn(N)),
+  lambda i: ("{0}_int".format(i), randint(1e8, size=N)),
+  lambda i: ("{0}_str".format(i), ['%08x'%randrange(16**8) for _ in range(N)])
+  ]
+df_mixed = DataFrame(OrderedDict([cols[i % len(cols)](i) for i in range(C)]),
+                     index=index)
+"""
+packers_write_json_mixed_float_int_str = Benchmark("df_mixed.to_json(f,orient='split')", setup, cleanup="remove(f)", start_date=start_date)
 
 #----------------------------------------------------------------------
 # stata


### PR DESCRIPTION
This adds block support to the JSON serialiser, as per #9037. I also added code to directly cast and serialise numpy data, which replaces the previous use of intermediate Python objects.

Large performance improvement (~25x) for mixed frames containing datetimes / timedeltas. 

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
packers_write_json_mixed_delta_int_tstamp    |  97.1374 | 2633.7843 |   0.0369 |
packers_write_json_mixed_float_int_T         |  68.7390 |  86.4150 |   0.7955 |
packers_write_json_date_index                |  68.9886 |  83.2930 |   0.8283 |
packers_write_json_T                         |  61.1283 |  72.9477 |   0.8380 |
packers_write_json                           |  60.7293 |  71.3053 |   0.8517 |
packers_read_json_date_index                 | 157.4903 | 161.6703 |   0.9741 |
packers_read_json                            | 157.4220 | 157.8477 |   0.9973 |
packers_write_json_mixed_float_int           |  98.1897 |  98.1696 |   1.0002 |
packers_write_json_mixed_float_int_str       |  84.0390 |  83.6937 |   1.0041 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
```

Some questions, any comments appreciated:
1. there's a little overhead to dealing with blocks so I'm avoiding using them and using `values` instead if the frame is 'simple'. I'm using the BlockManager methods `_is_single_block` and `is_mixed_dtype` for this to check for a simple frame.
2. I'm using the DataFrame `_data` attr and `mgr_locs` to get access to the block data and the block-to-column mapping. Are there any caveats to this? I know the DataFrame does some caching, but I'm not familiar enough with the details.

Tested locally on Python 2.7 for 32 & 64 bit linux and 3.3. on 64 bit linux. JSON tests run through valgrind. Would appreciate if someone could give it a bash on Windows before merging.

@cpcloud I also fixed a ref leak and added support for `date_unit` in the #9028 code.
