### PR TITLE
PERF: use unique and isnull in nunique instead of value_counts.

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -45,7 +45,11 @@ Performance
 
 .. _whatsnew_0160.performance:
 
+
 - Fixed a severe performance regression for ``.loc`` indexing with an array or list (:issue:9126:).
+
+- Improved the speed of `nunique` by calling `unique` instead of `value_counts` (:issue:`9129`, :issue:`7771`)
+
 
 Bug Fixes
 ~~~~~~~~~
@@ -114,3 +118,4 @@ Bug Fixes
 
 - DataFrame now properly supports simultaneous ``copy`` and ``dtype`` arguments in constructor (:issue:`9099`)
 - Bug in read_csv when using skiprows on a file with CR line endings with the c engine. (:issue:`9079`)
+- isnull now detects NaT in PeriodIndex (:issue:`9129`)

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -441,7 +441,12 @@ class IndexOpsMixin(object):
         -------
         nunique : int
         """
-        return len(self.value_counts(dropna=dropna))
+        uniqs = self.unique()
+        n = len(uniqs)
+        if dropna and com.isnull(uniqs).any():
+            n -= 1
+        return n
+
 
     def factorize(self, sort=False, na_sentinel=-1):
         """

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -302,7 +302,7 @@ def _isnull_ndarraylike(obj):
                 vec = lib.isnullobj(values.ravel())
                 result[...] = vec.reshape(shape)
 
-    elif dtype in _DATELIKE_DTYPES:
+    elif is_datetimelike(obj):
         # this is the NaT pattern
         result = values.view('i8') == tslib.iNaT
     else:
@@ -2365,6 +2365,9 @@ def is_datetime_arraylike(arr):
     elif isinstance(arr, (np.ndarray, ABCSeries)):
         return arr.dtype == object and lib.infer_dtype(arr) == 'datetime'
     return getattr(arr, 'inferred_type', None) == 'datetime'
+
+def is_datetimelike(arr):
+    return arr.dtype in _DATELIKE_DTYPES or isinstance(arr, ABCPeriodIndex)
 
 def _coerce_to_dtype(dtype):
     """ coerce a string / np.dtype to a dtype """

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -157,6 +157,15 @@ def test_isnull_datetime():
     assert(mask[0])
     assert(not mask[1:].any())
 
+    # GH 9129
+    pidx = idx.to_period(freq='M')
+    mask = isnull(pidx)
+    assert(mask[0])
+    assert(not mask[1:].any())
+
+    mask = isnull(pidx[1:])
+    assert(not mask.any())
+
 
 class TestIsNull(tm.TestCase):
     def test_0d_array(self):


### PR DESCRIPTION
closes #9129

Currently, `Series.nunique` [(source)](https://github.com/pydata/pandas/blob/master/pandas/core/base.py#L429) calls `Series.value_counts` [(source)](https://github.com/pydata/pandas/blob/master/pandas/core/base.py#L371), which by default, sorts the values. 

Counting unique values certainly doesn't require sorting, so we could fix this
by passing `sort=False` to `value_counts`.

But `nunique` can also be calculated by calling `Series.unique` instead of
`value_counts`, and using `com.isnull` to handle the `dropna` parameter.

This PR attempts to implement this. Here is a vbench perf test which seems to show an improvement for tests using `nunique`.

```
/usr/bin/time -v ./test_perf.sh -b master -t nunique-unique -r groupby
```

Here are the best and worst ratios:

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
groupby_ngroups_10000_nunique                | 900.9844 | 3768.5087 |   0.2391 |
groupby_ngroups_100_nunique                  |   9.6850 |  38.9043 |   0.2489 |
groupby_ngroups_100_sem                      |   0.7834 |   1.4904 |   0.5256 |
groupby_ngroups_100_size                     |   0.4920 |   0.8560 |   0.5748 |
groupby_ngroups_10000_max                    |   2.5337 |   4.1683 |   0.6078 |
groupby_frame_nth_none                       |   2.3570 |   3.2880 |   0.7168 |
groupby_ngroups_10000_var                    |   2.4277 |   3.3390 |   0.7271 |
groupby_ngroups_10000_sem                    |   3.5107 |   4.6523 |   0.7546 |
...
groupby_transform_multi_key3                 | 630.2720 | 599.7047 |   1.0510 |
groupby_nth_datetimes_none                   | 424.5253 | 403.6326 |   1.0518 |
groupby_transform_series2                    | 109.7130 | 104.1580 |   1.0533 |
groupby_transform_multi_key1                 |  58.9686 |  55.7120 |   1.0585 |
groupby_nth_datetimes_any                    | 1206.7020 | 1132.4236 |   1.0656 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
```

While working on this PR I ran into issue GH 9129.
This PR includes Jeff's suggested fix.
