### PR TITLE
Remove codepath asymmetry in dataframe count()

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -48,6 +48,7 @@ Performance
 - Fixed a performance regression for ``.loc`` indexing with an array or list-like (:issue:`9126`:).
 - Performance improvements in ``MultiIndex.duplicated`` by working with labels instead of values (:issue:`9125`)
 - Improved the speed of `nunique` by calling `unique` instead of `value_counts` (:issue:`9129`, :issue:`7771`)
+- Performance improvement of up to 10x in ``DataFrame.count`` and ``DataFrame.dropna`` by taking advantage of homogeneous/heterogeneous dtypes appropriately (:issue:`9136`)
 
 
 Bug Fixes

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4094,11 +4094,11 @@ class DataFrame(NDFrame):
         if len(frame._get_axis(axis)) == 0:
             result = Series(0, index=frame._get_agg_axis(axis))
         else:
-            if axis == 1:
-                counts = notnull(frame.values).sum(1)
-                result = Series(counts, index=frame._get_agg_axis(axis))
-            else:
+            if frame._is_mixed_type:
                 result = notnull(frame).sum(axis=axis)
+            else:
+                counts = notnull(frame.values).sum(axis=axis)
+                result = Series(counts, index=frame._get_agg_axis(axis))
 
         return result.astype('int64')
 

--- a/vb_suite/frame_methods.py
+++ b/vb_suite/frame_methods.py
@@ -290,30 +290,43 @@ frame_isnull  = Benchmark('isnull(df)', setup,
                            start_date=datetime(2012,1,1))
 
 ## dropna
-setup = common_setup + """
+dropna_setup = common_setup + """
 data = np.random.randn(10000, 1000)
 df = DataFrame(data)
 df.ix[50:1000,20:50] = np.nan
 df.ix[2000:3000] = np.nan
 df.ix[:,60:70] = np.nan
 """
-frame_dropna_axis0_any  = Benchmark('df.dropna(how="any",axis=0)', setup,
+frame_dropna_axis0_any  = Benchmark('df.dropna(how="any",axis=0)', dropna_setup,
                                      start_date=datetime(2012,1,1))
-frame_dropna_axis0_all  = Benchmark('df.dropna(how="all",axis=0)', setup,
+frame_dropna_axis0_all  = Benchmark('df.dropna(how="all",axis=0)', dropna_setup,
                                      start_date=datetime(2012,1,1))
 
-setup = common_setup + """
+frame_dropna_axis1_any  = Benchmark('df.dropna(how="any",axis=1)', dropna_setup,
+                                    start_date=datetime(2012,1,1))
+
+frame_dropna_axis1_all  = Benchmark('df.dropna(how="all",axis=1)', dropna_setup,
+                                    start_date=datetime(2012,1,1))
+
+# dropna on mixed dtypes
+dropna_mixed_setup = common_setup + """
 data = np.random.randn(10000, 1000)
 df = DataFrame(data)
 df.ix[50:1000,20:50] = np.nan
 df.ix[2000:3000] = np.nan
 df.ix[:,60:70] = np.nan
+df['foo'] = 'bar'
 """
-frame_dropna_axis1_any  = Benchmark('df.dropna(how="any",axis=1)', setup,
-                                    start_date=datetime(2012,1,1))
+frame_dropna_axis0_any_mixed_dtypes  = Benchmark('df.dropna(how="any",axis=0)', dropna_mixed_setup,
+                                                 start_date=datetime(2012,1,1))
+frame_dropna_axis0_all_mixed_dtypes  = Benchmark('df.dropna(how="all",axis=0)', dropna_mixed_setup,
+                                                 start_date=datetime(2012,1,1))
 
-frame_dropna_axis1_all  = Benchmark('df.dropna(how="all",axis=1)', setup,
-                                    start_date=datetime(2012,1,1))
+frame_dropna_axis1_any_mixed_dtypes  = Benchmark('df.dropna(how="any",axis=1)', dropna_mixed_setup,
+                                                 start_date=datetime(2012,1,1))
+
+frame_dropna_axis1_all_mixed_dtypes  = Benchmark('df.dropna(how="all",axis=1)', dropna_mixed_setup,
+                                                 start_date=datetime(2012,1,1))
 
 
 #----------------------------------------------------------------------


### PR DESCRIPTION
@jreback I noticed a codepath asymmetry in core.frame.count that leads to a substantial difference in dropna() performance depending on the axis. Using the path `df.dropna(axis=0)` takes yields a 2.5-5x improvement.

```
$ python vb_suite/test_perf.py -b upstream/master -t HEAD -r "dropna" -S -n 30
Invoked with :
--ncalls: 3
--repeats: 30


-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
frame_dropna_axis1_any                       |  18.5493 | 101.6117 |   0.1826 |
frame_dropna_axis1_all                       |  48.0193 | 128.8197 |   0.3728 |
frame_dropna_axis0_any                       |  17.0240 |  17.3127 |   0.9833 |
frame_dropna_axis0_all                       |  43.1127 |  43.3304 |   0.9950 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [84ad341] : Remove codepath asymmetry in dataframe count()
Base   [099a02c] : Merge pull request #9061 from behzadnouri/nan-pivot

pivot & unstack with nan in the index


                        count       mean        std       min        25%        50%        75%         max
frame_dropna_axis1_any      3  40.114509  54.044075  0.182551   9.365917  18.549283  60.080489  101.611694
frame_dropna_axis1_all      3  59.070599  64.932673  0.372764  24.196047  48.019330  88.419517  128.819704
frame_dropna_axis0_any      3  11.773351   9.345549  0.983328   9.003684  17.024040  17.168363   17.312686
frame_dropna_axis0_all      3  29.146001  24.379745  0.994976  22.053826  43.112675  43.221513   43.330352
```
