### PR TITLE
Check whether GBQ Job is finished

### DIFF
--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -185,7 +185,7 @@ class GbqConnector:
 
         job_reference = query_reply['jobReference']
 
-        while(not 'jobComplete' in query_reply):
+        while(not 'jobComplete' in query_reply) or (query_reply['jobComplete'] is False):
             print('Job not yet complete...')
             query_reply = job_collection.getQueryResults(
                             projectId=job_reference['projectId'],

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -185,7 +185,8 @@ class GbqConnector:
 
         job_reference = query_reply['jobReference']
 
-        while(not 'jobComplete' in query_reply) or (query_reply['jobComplete'] is False):
+        # Verify the job has finished running
+        while(not query_reply.get('jobComplete', False)):
             print('Job not yet complete...')
             query_reply = job_collection.getQueryResults(
                             projectId=job_reference['projectId'],


### PR DESCRIPTION
xref #8728 

jobComplete can be False in query_reply. Simply checking for the existence of the field isn't enough, as a False value will cause a KeyError when checking for query_reply['totalRows']
