### PR TITLE
PERF: Utilize mixed dtypes in df.count() with MultiIndexes

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -68,6 +68,7 @@ Performance
 - Performance improvements in ``MultiIndex.duplicated`` by working with labels instead of values (:issue:`9125`)
 - Improved the speed of `nunique` by calling `unique` instead of `value_counts` (:issue:`9129`, :issue:`7771`)
 - Performance improvement of up to 10x in ``DataFrame.count`` and ``DataFrame.dropna`` by taking advantage of homogeneous/heterogeneous dtypes appropriately (:issue:`9136`)
+- Performance improvement of up to 20x in ``DataFrame.count`` when using a ``MultiIndex`` and the ``level`` keyword argument  (:issue:`9163`)
 
 Bug Fixes
 ~~~~~~~~~

--- a/vb_suite/frame_methods.py
+++ b/vb_suite/frame_methods.py
@@ -328,6 +328,38 @@ frame_dropna_axis1_any_mixed_dtypes  = Benchmark('df.dropna(how="any",axis=1)', 
 frame_dropna_axis1_all_mixed_dtypes  = Benchmark('df.dropna(how="all",axis=1)', dropna_mixed_setup,
                                                  start_date=datetime(2012,1,1))
 
+## dropna multi
+dropna_setup = common_setup + """
+data = np.random.randn(10000, 1000)
+df = DataFrame(data)
+df.ix[50:1000,20:50] = np.nan
+df.ix[2000:3000] = np.nan
+df.ix[:,60:70] = np.nan
+df.index = MultiIndex.from_tuples(df.index.map(lambda x: (x, x)))
+df.columns = MultiIndex.from_tuples(df.columns.map(lambda x: (x, x)))
+"""
+frame_count_level_axis0_multi = Benchmark('df.count(axis=0, level=1)', dropna_setup,
+                                          start_date=datetime(2012,1,1))
+
+frame_count_level_axis1_multi = Benchmark('df.count(axis=1, level=1)', dropna_setup,
+                                          start_date=datetime(2012,1,1))
+
+# dropna on mixed dtypes
+dropna_mixed_setup = common_setup + """
+data = np.random.randn(10000, 1000)
+df = DataFrame(data)
+df.ix[50:1000,20:50] = np.nan
+df.ix[2000:3000] = np.nan
+df.ix[:,60:70] = np.nan
+df['foo'] = 'bar'
+df.index = MultiIndex.from_tuples(df.index.map(lambda x: (x, x)))
+df.columns = MultiIndex.from_tuples(df.columns.map(lambda x: (x, x)))
+"""
+frame_count_level_axis0_mixed_dtypes_multi  = Benchmark('df.count(axis=0, level=1)', dropna_mixed_setup,
+                                                        start_date=datetime(2012,1,1))
+
+frame_count_level_axis1_mixed_dtypes_multi  = Benchmark('df.count(axis=1, level=1)', dropna_mixed_setup,
+                                                        start_date=datetime(2012,1,1))
 
 #----------------------------------------------------------------------
 # apply


### PR DESCRIPTION
@jreback Same underlying cause as #9136 but the solution is a bit more involved here.

Basically, we're transposing a potentially mixed-type frame before calling `notnull(frame.values)`; the same result can be obtained by deferring the transpose until after `notnull` gives us a non-mixed frame.

Here are the vbench results:

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
frame_count_level_axis1_mixed_dtypes_multi   |  82.2484 | 1489.9830 |   0.0552 |
frame_count_level_axis0_mixed_dtypes_multi   | 101.2537 | 1737.6347 |   0.0583 |
frame_count_level_axis0_multi                |  51.0643 |  51.3713 |   0.9940 |
frame_count_level_axis1_multi                |  98.5887 |  82.6767 |   1.1925 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [04ec4c6] : PERF: Utilize mixed dtypes in df.count() with MultiIndexes
Base   [def58c9] : Merge pull request #9128 from hsperr/expanduser
```
