### PR TITLE
BUG: Fix for extraneous default cell format in xlsxwriter files.

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -141,3 +141,7 @@ Bug Fixes
 - Bug in read_csv when using skiprows on a file with CR line endings with the c engine. (:issue:`9079`)
 - isnull now detects NaT in PeriodIndex (:issue:`9129`)
 - Bug in groupby ``.nth()`` with a multiple column groupby (:issue:`8979`)
+
+- Fixed issue in the ``xlsxwriter`` engine where it added a default 'General'
+  format to cells if no other format wass applied. This prevented other row or
+  column formatting being applied. (:issue:`9167`)

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -1274,6 +1274,10 @@ class _XlsxWriter(ExcelWriter):
         num_format_str: optional number format string
         """
 
+        # If there is no formatting we don't create a format object.
+        if num_format_str is None and style_dict is None:
+            return None
+
         # Create a XlsxWriter format object.
         xl_format = self.book.add_format()
 


### PR DESCRIPTION
Fix for issue in the xlsxwriter engine where is adds a default
'General' format to cells if no other format is applied. This
isn't a bug, per se, but it prevents other row or column formatting.

closes #9167
