### PR TITLE
ERR: better concat error messages #9157

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -494,8 +494,7 @@ Other API Changes
 ^^^^^^^^^^^^^^^^^
 
 - Line and kde plot with ``subplots=True`` now uses default colors, not all black. Specify ``color='k'`` to draw all lines in black (:issue:`9894`)
-- Calling the ``.value_counts`` method on a Series with ``categorical`` dtype now returns a
-Series with a ``CategoricalIndex`` (:issue:`10704`)
+- Calling the ``.value_counts`` method on a Series with ``categorical`` dtype now returns a Series with a ``CategoricalIndex`` (:issue:`10704`)
 - Enable writing Excel files in :ref:`memory <_io.excel_writing_buffer>` using StringIO/BytesIO (:issue:`7074`)
 - Enable serialization of lists and dicts to strings in ExcelWriter (:issue:`8188`)
 - Allow passing `kwargs` to the interpolation methods (:issue:`10378`).

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -526,6 +526,7 @@ Series with a ``CategoricalIndex`` (:issue:`10704`)
    ``return np.datetime64('NaT')``     ``to_datetime64`` (unchanged)
    ``raise ValueError``                All other public methods (names not beginning with underscores)
    ===============================     ===============================================================
+- Improved error message when concatenating an empty iterable of dataframes (:issue:`9157`)
 
 .. _whatsnew_0170.deprecations:
 

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1,7 +1,6 @@
 """
 SQL-style merge routines
 """
-import types
 
 import numpy as np
 from pandas.compat import range, long, lrange, lzip, zip, map, filter
@@ -17,11 +16,9 @@ from pandas.core.internals import (items_overlap_with_suffix,
                                    concatenate_block_managers)
 from pandas.util.decorators import Appender, Substitution
 from pandas.core.common import ABCSeries
-from pandas.io.parsers import TextFileReader
 
 import pandas.core.common as com
 
-import pandas.lib as lib
 import pandas.algos as algos
 import pandas.hashtable as _hash
 

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -775,9 +775,14 @@ class _Concatenator(object):
             if keys is None:
                 keys = sorted(objs)
             objs = [objs[k] for k in keys]
+        else:
+            objs = list(objs)
+
+        if len(objs) == 0:
+            raise ValueError('No objects to concatenate')
 
         if keys is None:
-            objs = [obj for obj in objs if obj is not None ]
+            objs = [obj for obj in objs if obj is not None]
         else:
             # #1649
             clean_keys = []

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -2552,6 +2552,23 @@ class TestOrderedMerge(tm.TestCase):
 
         tm.assertIsInstance(result, NotADataFrame)
 
+    def test_empty_sequence_concat(self):
+        # GH 9157
+        empty_pat = "[Nn]o objects"
+        none_pat = "objects.*None"
+        test_cases = [
+            ((), empty_pat),
+            ([], empty_pat),
+            ({}, empty_pat),
+            ([None], none_pat),
+            ([None, None], none_pat)
+        ]
+        for df_seq, pattern in test_cases:
+            assertRaisesRegexp(ValueError, pattern, pd.concat, df_seq)
+
+        pd.concat([pd.DataFrame()])
+        pd.concat([None, pd.DataFrame()])
+        pd.concat([pd.DataFrame(), None])
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
closes #9157 

This is a first attempt to improve the error message when trying to concat an empty list/set of objects:

`pd.concat([])` currently raises following error:

```
/Users/ch/miniconda/envs/sci33/lib/python3.3/site-packages/pandas/tools/merge.py in __init__(self, objs, axis, join, join_axes, keys, levels, names, ignore_index, verify_integrity, copy)
    765 
    766         if len(objs) == 0:
--> 767             raise ValueError('All objects passed were None')
    768 
    769         # consolidate data & figure out what our result ndim is going to be

ValueError: All objects passed were None
```

After the tiny fix it is:

```
/Users/ch/repo/pandas/pandas/tools/merge.py in __init__(self, objs, axis, join, join_axes, keys, levels, names, ignore_index, verify_integrity, copy)
    767 
    768         if len(objs) == 0:
--> 769             raise ValueError('No objects passed')
    770 
    771         if isinstance(objs, dict):

ValueError: No objects passed
```
