### PR TITLE
BUG: Fix for Timestamp handling in xlwt and xlsxwriter engines.

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -96,6 +96,8 @@ Bug Fixes
 - Bug in ``pivot`` and `unstack`` where ``nan`` values would break index alignment (:issue:`7466`)
 
 
+- Fixed bug where minutes and seconds components were zeroed when writing
+  Timestamp objects to Excel using xlwt and xlsxwriter (:issue:`9138`).
 
 
 

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -16,6 +16,7 @@ from pandas import json
 from pandas.compat import map, zip, reduce, range, lrange, u, add_metaclass
 from pandas.core import config
 from pandas.core.common import pprint_thing
+from pandas import Timestamp
 import pandas.compat as compat
 import pandas.compat.openpyxl_compat as openpyxl_compat
 import pandas.core.common as com
@@ -1118,6 +1119,10 @@ class _XlwtWriter(ExcelWriter):
             val = _conv_value(cell.val)
 
             num_format_str = None
+
+            if isinstance(val, Timestamp):
+                val = val.to_pydatetime()
+
             if isinstance(cell.val, datetime.datetime):
                 num_format_str = self.datetime_format
             elif isinstance(cell.val, datetime.date):
@@ -1239,6 +1244,10 @@ class _XlsxWriter(ExcelWriter):
 
         for cell in cells:
             num_format_str = None
+
+            if isinstance(cell.val, Timestamp):
+                cell.val = cell.val.to_pydatetime()
+
             if isinstance(cell.val, datetime.datetime):
                 num_format_str = self.datetime_format
             elif isinstance(cell.val, datetime.date):

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -1151,6 +1151,28 @@ class ExcelWriterBase(SharedItems):
             tm.assert_series_equal(write_frame['A'], read_frame['A'])
             tm.assert_series_equal(write_frame['B'], read_frame['B'])
 
+    def test_datetimes(self):
+        # Test writing and reading datetimes. For issue #9139.
+        _skip_if_no_xlrd()
+
+        datetimes = [datetime(2013, 1, 13, 1, 2, 3),
+                     datetime(2013, 1, 13, 2, 45, 56),
+                     datetime(2013, 1, 13, 4, 29, 49),
+                     datetime(2013, 1, 13, 6, 13, 42),
+                     datetime(2013, 1, 13, 7, 57, 35),
+                     datetime(2013, 1, 13, 9, 41, 28),
+                     datetime(2013, 1, 13, 11, 25, 21),
+                     datetime(2013, 1, 13, 13, 9, 14),
+                     datetime(2013, 1, 13, 14, 53, 7),
+                     datetime(2013, 1, 13, 16, 37, 0),
+                     datetime(2013, 1, 13, 18, 20, 52)]
+
+        with ensure_clean(self.ext) as path:
+            write_frame = DataFrame.from_items([('A', datetimes)])
+            write_frame.to_excel(path, 'Sheet1')
+            read_frame = read_excel(path, 'Sheet1', header=0)
+
+            tm.assert_series_equal(write_frame['A'], read_frame['A'])
 
 def raise_wrapper(major_ver):
     def versioned_raise_wrapper(orig_method):


### PR DESCRIPTION
Fix for writing Timestamp objects using the xlwt and xlsxwriter
engines. Both modules write Excel dates and times using
datetime.timedelta which differs from pandas.Timedelta. This
fix coerces Timestamp objects to datetime objects.

fixes #9139.
