### PR TITLE
BUG: "index_col=False" not working when "usecols" is specified in read_csv (GH9082)

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -139,4 +139,6 @@ Bug Fixes
 
 - DataFrame now properly supports simultaneous ``copy`` and ``dtype`` arguments in constructor (:issue:`9099`)
 - Bug in read_csv when using skiprows on a file with CR line endings with the c engine. (:issue:`9079`)
+- BUG: "index_col=False" not working when "usecols" is specified in read_csv. (:issue:`9082`)
 - isnull now detects NaT in PeriodIndex (:issue:`9129`)
+

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -509,6 +509,17 @@ KORD6,19990127, 23:00:00, 22:56:00, -0.5900, 1.7100, 4.6000, 0.0000, 280.0000"""
         tm.assert_frame_equal(xp, rs)
         self.assertEqual(xp.index.name, rs.index.name)
 
+    def test_usecols_index_col_False(self):
+        # Issue 9082
+        s = "a,b,c,d\n1,2,3,4\n5,6,7,8"
+        s_malformed = "a,b,c,d\n1,2,3,4,\n5,6,7,8,"
+        cols = ['a','c','d']
+        expected = DataFrame({'a':[1,5], 'c':[3,7], 'd':[4,8]})
+        df = self.read_csv(StringIO(s), usecols=cols, index_col=False)
+        tm.assert_frame_equal(expected, df)
+        df = self.read_csv(StringIO(s_malformed), usecols=cols, index_col=False)
+        tm.assert_frame_equal(expected, df)
+
     def test_converter_index_col_bug(self):
         # 1835
         data = "A;B\n1;2\n3;4"

--- a/pandas/parser.pyx
+++ b/pandas/parser.pyx
@@ -728,7 +728,7 @@ cdef class TextReader:
             #                        'data has %d fields'
             #                        % (passed_count, field_count))
 
-            if self.has_usecols:
+            if self.has_usecols and self.allow_leading_cols:
                 nuse = len(self.usecols)
                 if nuse == passed_count:
                     self.leading_cols = 0


### PR DESCRIPTION
Fixes #9082 
My access to the internet is spotty for the next few days. This fixes 9082 and does not break any of the existing tests so hopefully it won't break anyone's existing code.  Happy New Year!
