### PR TITLE
BUG: Fix not to reindex on non-Categorical groups (GH9049)

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -267,3 +267,4 @@ Bug Fixes
 - ``SparseSeries`` and ``SparsePanel`` now accept zero argument constructors (same as their non-sparse counterparts) (:issue:`9272`).
 
 - Bug in ``read_csv`` with buffer overflows with certain malformed input files (:issue:`9205`)
+- Bug in groupby MultiIndex with missing pair (:issue:`9049`, :issue:`9344`)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1862,7 +1862,6 @@ class Grouping(object):
             self.grouper = grouper.values
 
         # pre-computed
-        self._grouping_type = None
         self._should_compress = True
 
         # we have a single grouper which may be a myriad of things, some of which are
@@ -1887,8 +1886,6 @@ class Grouping(object):
                 level_values = index.levels[level].take(inds)
                 self.grouper = level_values.map(self.grouper)
             else:
-                self._grouping_type = "level"
-
                 # all levels may not be observed
                 labels, uniques = algos.factorize(inds, sort=True)
 
@@ -1913,17 +1910,10 @@ class Grouping(object):
 
             # a passed Categorical
             elif isinstance(self.grouper, Categorical):
-
-                factor = self.grouper
-                self._grouping_type = "categorical"
-
-                # Is there any way to avoid this?
-                self.grouper = np.asarray(factor)
-
-                self._labels = factor.codes
-                self._group_index = factor.categories
+                self._labels = self.grouper.codes
+                self._group_index = self.grouper.categories
                 if self.name is None:
-                    self.name = factor.name
+                    self.name = self.grouper.name
 
             # a passed Grouper like
             elif isinstance(self.grouper, Grouper):
@@ -1936,8 +1926,8 @@ class Grouping(object):
                     self.name = grouper.name
 
             # no level passed
-            if not isinstance(self.grouper, (Series, Index, np.ndarray)):
-                if getattr(self.grouper,'ndim', 1) != 1:
+            if not isinstance(self.grouper, (Series, Index, Categorical, np.ndarray)):
+                if getattr(self.grouper, 'ndim', 1) != 1:
                     t = self.name or str(type(self.grouper))
                     raise ValueError("Grouper for '%s' not 1-dimensional" % t)
                 self.grouper = self.index.map(self.grouper)
@@ -1988,22 +1978,15 @@ class Grouping(object):
         return self._group_index
 
     def _make_labels(self):
-        if self._grouping_type in ("level", "categorical"):  # pragma: no cover
-            raise Exception(
-                'Should not call this method grouping by level or categorical')
-        else:
+        if self._labels is None or self._group_index is None:
             labels, uniques = algos.factorize(self.grouper, sort=self.sort)
             uniques = Index(uniques, name=self.name)
             self._labels = labels
             self._group_index = uniques
 
-    _groups = None
-
-    @property
+    @cache_readonly
     def groups(self):
-        if self._groups is None:
-            self._groups = self.index.groupby(self.grouper)
-        return self._groups
+        return self.index.groupby(self.grouper)
 
 def _get_grouper(obj, key=None, axis=0, level=None, sort=True):
     """
@@ -3239,7 +3222,7 @@ class DataFrameGroupBy(NDFrameGroupBy):
             return result
         elif len(groupings) == 1:
             return result
-        elif not any([ping._grouping_type == "categorical"
+        elif not any([isinstance(ping.grouper, Categorical)
                       for ping in groupings]):
             return result
 

--- a/vb_suite/groupby.py
+++ b/vb_suite/groupby.py
@@ -390,6 +390,18 @@ df = DataFrame({'ii':range(N),'bb':[True for x in range(N)]})
 
 groupby_sum_booleans = Benchmark("df.groupby('ii').sum()", setup)
 
+
+#----------------------------------------------------------------------
+# multi-indexed group sum #9049
+
+setup = common_setup + """
+N = 50
+df = DataFrame({'A': range(N) * 2, 'B': range(N*2), 'C': 1}).set_index(["A", "B"])
+"""
+
+groupby_sum_multiindex = Benchmark("df.groupby(level=[0, 1]).sum()", setup)
+
+
 #----------------------------------------------------------------------
 # Transform testing
 


### PR DESCRIPTION
closes #9049.
closes #9344 

_self._was_factor_ is not appropriate to judge whether grouper is Categorical or not, because it can be "True" when we groupby indices (not columns). So, I added another flag _self._is_categorical_ to judge Categorical state.

Also, I added a GroupBy test for MultiIndexed data, which was failed before this fix.
