### PR TITLE
FIX: Fix problems with Series text representation. 

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -567,3 +567,39 @@ Bug Fixes
 - Bug in ``Series.values_counts`` with excluding ``NaN`` for categorical type ``Series`` with ``dropna=True`` (:issue:`9443`)
 - Fixed mising numeric_only option for ``DataFrame.std/var/sem`` (:issue:`9201`)
 - Support constructing ``Panel`` or ``Panel4D`` with scalar data (:issue:`8285`)
+- ``Series`` text representation disconnected from `max_rows`/`max_columns` (:issue:`7508`).
+- ``Series`` number formatting inconsistent when truncated (:issue:`8532`).
+
+  Previous Behavior
+
+  .. code-block:: python
+
+    In [2]: pd.options.display.max_rows = 10
+    In [3]: s = pd.Series([1,1,1,1,1,1,1,1,1,1,0.9999,1,1]*10)
+    In [4]: s
+    Out[4]:
+    0    1
+    1    1
+    2    1
+    ...
+    127    0.9999
+    128    1.0000
+    129    1.0000
+    Length: 130, dtype: float64
+
+  New Behavior
+
+  .. code-block:: python
+
+    0      1.0000
+    1      1.0000
+    2      1.0000
+    3      1.0000
+    4      1.0000
+    ...
+    125    1.0000
+    126    1.0000
+    127    0.9999
+    128    1.0000
+    129    1.0000
+    dtype: float64

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -13,6 +13,7 @@ import pandas as pd
 
 from pandas import Categorical, Index, Series, DataFrame, PeriodIndex, Timestamp
 
+from pandas.core.config import option_context
 import pandas.core.common as com
 import pandas.compat as compat
 import pandas.util.testing as tm
@@ -1559,12 +1560,12 @@ class TestCategoricalAsBlock(tm.TestCase):
 
         self.assertEqual(exp, a.__unicode__())
 
-        a = pd.Series(pd.Categorical(["a","b"] *25, name="a", ordered=True))
-        exp = u("".join(["%s    a\n%s    b\n"%(i,i+1) for i in range(0,10,2)]) + "...\n" +
-                "".join(["%s    a\n%s    b\n"%(i,i+1) for i in range(40,50,2)]) +
-                "Name: a, Length: 50, dtype: category\n" +
-                "Categories (2, object): [a < b]")
-        self.assertEqual(exp,a._tidy_repr())
+        a = pd.Series(pd.Categorical(["a","b"] *25, name="a"))
+        exp = u("0     a\n1     b\n" + "     ..\n" +
+                "48    a\n49    b\n" +
+                "Name: a, dtype: category\nCategories (2, object): [a, b]")
+        with option_context("display.max_rows", 5):
+            self.assertEqual(exp, repr(a))
 
         levs = list("abcdefghijklmnopqrstuvwxyz")
         a = pd.Series(pd.Categorical(["a","b"], name="a", categories=levs, ordered=True))
@@ -1572,7 +1573,6 @@ class TestCategoricalAsBlock(tm.TestCase):
                 "Name: a, dtype: category\n"
                 "Categories (26, object): [a < b < c < d ... w < x < y < z]")
         self.assertEqual(exp,a.__unicode__())
-
 
     def test_info(self):
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -2046,7 +2046,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # with empty series (#4651)
         s = Series([], dtype=np.int64, name='foo')
-        self.assertEqual(repr(s), 'Series([], name: foo, dtype: int64)')
+        self.assertEqual(repr(s), 'Series([], Name: foo, dtype: int64)')
 
         s = Series([], dtype=np.int64, name=None)
         self.assertEqual(repr(s), 'Series([], dtype: int64)')


### PR DESCRIPTION
This PR harmonizes the way DataFrame and Series are printed. 
closes #8532 
closes #7508 
Before 

```
In [1]: import pandas as pd

In [2]: pd.options.display.max_rows = 10

In [3]: s = pd.Series([1,1,1,1,1,1,1,1,1,1,0.9999,1,1]*10)

In [4]: s
Out[4]:
0    1
1    1
2    1
...
127    0.9999
128    1.0000
129    1.0000
Length: 130, dtype: float64
```

Now

```
0      1.0000
1      1.0000
2      1.0000
3      1.0000
4      1.0000
        ...  
125    1.0000
126    1.0000
127    0.9999
128    1.0000
129    1.0000
dtype: float64
```
