### PR TITLE
Docstring: pd.to_datetime (issue #9107)

### DIFF
--- a/pandas/tseries/tools.py
+++ b/pandas/tseries/tools.py
@@ -226,16 +226,30 @@ def to_datetime(arg, errors='ignore', dayfirst=False, utc=None, box=True,
     >>> i = pd.date_range('20000101',periods=100)
     >>> df = pd.DataFrame(dict(year = i.year, month = i.month, day = i.day))
     >>> pd.to_datetime(df.year*10000 + df.month*100 + df.day, format='%Y%m%d')
+    0    2000-01-01
+    1    2000-01-02
+    ...
+    98   2000-04-08
+    99   2000-04-09
+    Length: 100, dtype: datetime64[ns]
 
     Or from strings
 
     >>> df = df.astype(str)
     >>> pd.to_datetime(df.day + df.month + df.year, format="%d%m%Y")
+    0    2000-01-01
+    1    2000-01-02
+    ...
+    98   2000-04-08
+    99   2000-04-09
+    Length: 100, dtype: datetime64[ns]
 
     Date that does not meet timestamp limitations:
 
-    >>> print pd.to_datetime('1300-01-01', format='%Y-%m-%d')
-    >>> print pd.to_datetime('1300-01-01', format='%Y-%m-%d', coerce=True)
+    >>> pd.to_datetime('13000101', format='%Y%m%d')
+    datetime.datetime(1300, 1, 1, 0, 0)
+    >>> pd.to_datetime('13000101', format='%Y%m%d', coerce=True)
+    NaT
     """
     from pandas import Timestamp
     from pandas.core.series import Series

--- a/pandas/tseries/tools.py
+++ b/pandas/tseries/tools.py
@@ -200,6 +200,8 @@ def to_datetime(arg, errors='ignore', dayfirst=False, utc=None, box=True,
         If True, require an exact format match.
         If False, allow the format to match anywhere in the target string.
     coerce : force errors to NaT (False by default)
+        Timestamps outside the interval between Timestamp.min and Timestamp.max
+        (approximately 1677-09-22 to 2262-04-11) will be also forced to NaT.
     unit : unit of the arg (D,s,ms,us,ns) denote the unit in epoch
         (e.g. a unix timestamp), which is an integer/float number
     infer_datetime_format : boolean, default False
@@ -212,6 +214,9 @@ def to_datetime(arg, errors='ignore', dayfirst=False, utc=None, box=True,
         - list-like: DatetimeIndex
         - Series: Series of datetime64 dtype
         - scalar: Timestamp
+        In case when it is not possible to return designated types (e.g. when
+        any element of input is before Timestamp.min or after Timestamp.max)
+        return will have datetime.datetime type (or correspoding array/Series).
 
     Examples
     --------
@@ -226,6 +231,11 @@ def to_datetime(arg, errors='ignore', dayfirst=False, utc=None, box=True,
 
     >>> df = df.astype(str)
     >>> pd.to_datetime(df.day + df.month + df.year, format="%d%m%Y")
+
+    Date that does not meet timestamp limitations:
+
+    >>> print pd.to_datetime('1300-01-01', format='%Y-%m-%d')
+    >>> print pd.to_datetime('1300-01-01', format='%Y-%m-%d', coerce=True)
     """
     from pandas import Timestamp
     from pandas.core.series import Series


### PR DESCRIPTION
Following the issue "to_datetime returns NaT for old dates with coerce=True".

Do I understand correctly that online documentation is build automatically from docstrings? I.e. are there any other files to change?

Also it would be good to make a link to [this section of "Caveats and Gotchas"](http://pandas.pydata.org/pandas-docs/version/0.15.0/gotchas.html#timestamp-limitations), but I'm not sure if the docstring is a good place to do this.
