### PR TITLE
Add DataFrame.view() to display contents interactively.

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -882,6 +882,7 @@ Serialization / IO / Conversion
    DataFrame.from_items
    DataFrame.from_records
    DataFrame.info
+   DataFrame.view
    DataFrame.to_pickle
    DataFrame.to_csv
    DataFrame.to_hdf

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -226,6 +226,14 @@ Exponentially-weighted moving window functions
    ewmcorr
    ewmcov
 
+Visualization / Plotting
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: generated/
+
+   interact
+
 .. _api.series:
 
 Series
@@ -596,14 +604,15 @@ the Categorical back to a numpy array, so levels and order information is not pr
 
    Categorical.__array__
 
-Plotting
-~~~~~~~~
+Visualization / Plotting
+~~~~~~~~~~~~~~~~~~~~~~~~
 .. currentmodule:: pandas
 
 .. autosummary::
    :toctree: generated/
 
    Series.hist
+   Series.interact
    Series.plot
 
 Serialization / IO / Conversion
@@ -863,13 +872,14 @@ Time series-related
    DataFrame.tz_convert
    DataFrame.tz_localize
 
-Plotting
-~~~~~~~~
+Visualization / Plotting
+~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
 
    DataFrame.boxplot
    DataFrame.hist
+   DataFrame.interact
    DataFrame.plot
 
 Serialization / IO / Conversion
@@ -882,7 +892,6 @@ Serialization / IO / Conversion
    DataFrame.from_items
    DataFrame.from_records
    DataFrame.info
-   DataFrame.view
    DataFrame.to_pickle
    DataFrame.to_csv
    DataFrame.to_hdf
@@ -1107,6 +1116,13 @@ Serialization / IO / Conversion
    Panel.to_sparse
    Panel.to_frame
    Panel.to_clipboard
+
+Visualization / Plotting
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. autosummary::
+   :toctree: generated/
+
+   Panel.interact
 
 .. _api.panel4d:
 

--- a/doc/source/dsintro.rst
+++ b/doc/source/dsintro.rst
@@ -647,6 +647,15 @@ option:
 You can also disable this feature via the ``expand_frame_repr`` option.
 This will print the table in one block.
 
+You can visualize the contents of the DataFrame on an interactive grid using
+:meth:`~pandas.DataFrame.view`.
+
+.. ipython:: python
+
+   df = DataFrame(randn(3, 12))
+   df.view()
+
+
 DataFrame column attribute access and IPython completion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/dsintro.rst
+++ b/doc/source/dsintro.rst
@@ -648,13 +648,12 @@ You can also disable this feature via the ``expand_frame_repr`` option.
 This will print the table in one block.
 
 You can visualize the contents of the DataFrame on an interactive grid using
-:meth:`~pandas.DataFrame.view`.
+:meth:`~pandas.DataFrame.interact`.
 
 .. ipython:: python
 
    df = DataFrame(randn(3, 12))
-   df.view()
-
+   df.interact()
 
 DataFrame column attribute access and IPython completion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -58,6 +58,7 @@ from pandas.tools.pivot import pivot_table, crosstab
 from pandas.tools.plotting import scatter_matrix, plot_params
 from pandas.tools.tile import cut, qcut
 from pandas.tools.util import value_range
+from pandas.tools.interact import interact
 from pandas.core.reshape import melt
 from pandas.util.print_versions import show_versions
 import pandas.util.testing

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1543,10 +1543,20 @@ class DataFrame(NDFrame):
                             _sizeof_fmt(mem_usage, size_qualifier))
         _put_lines(buf, lines)
 
-    def view(self):
-        """Visualize the contents of the DataFrame interatively"""
-        from tabview import tabview as t
-        t.view([self.columns.tolist()] + self.values.tolist())
+    def interact(self, **kwargs):
+        """Visualize the contents of the DataFrame interatively
+
+        Parameters
+        ----------
+        See :func:`pandas.interact` for a list of keyword arguments to control
+        the display.
+
+        See Also
+        --------
+        pandas.interact
+        """
+        from pandas.tools.interact import interact
+        interact(self, **kwargs)
 
     def memory_usage(self, index=False):
         """Memory usage of DataFrame columns.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1543,6 +1543,11 @@ class DataFrame(NDFrame):
                             _sizeof_fmt(mem_usage, size_qualifier))
         _put_lines(buf, lines)
 
+    def view(self):
+        """Visualize the contents of the DataFrame interatively"""
+        from tabview import tabview as t
+        t.view([self.columns.tolist()] + self.values.tolist())
+
     def memory_usage(self, index=False):
         """Memory usage of DataFrame columns.
 

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -603,6 +603,21 @@ class Panel(NDFrame):
     def tail(self, n=5):
         raise NotImplementedError
 
+    def interact(self, **kwargs):
+        """Visualize the contents of the Panel interatively
+
+        Parameters
+        ----------
+        See :func:`pandas.interact` for a list of keyword arguments to control
+        the display.
+
+        See Also
+        --------
+        pandas.interact
+        """
+        from pandas.tools.interact import interact
+        interact(self, **kwargs)
+
     def _needs_reindex_multi(self, axes, method, level):
         """ don't allow a multi reindex on Panel or above ndim """
         return False

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -377,6 +377,21 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         return self._constructor(self.values.view(dtype),
                                  index=self.index).__finalize__(self)
 
+    def interact(self, **kwargs):
+        """Visualize the contents of the Panel interatively
+
+        Parameters
+        ----------
+        See :func:`pandas.interact` for a list of keyword arguments to control
+        the display.
+
+        See Also
+        --------
+        pandas.interact
+        """
+        from pandas.tools.interact import interact
+        interact(self, **kwargs)
+
     def __array__(self, result=None):
         """
         the array interface, return my values

--- a/pandas/tools/interact.py
+++ b/pandas/tools/interact.py
@@ -1,0 +1,81 @@
+from pandas.core.api import Int64Index, DataFrame, Series, Panel
+
+try:  # tabview optional
+    from tabview import tabview
+except ImportError:
+    pass
+
+
+def interact(data, index=None, header=None, start=None,
+             fixed_index=None, fixed_header=None, **kwargs):
+    """
+    Visualize the contents of ``data`` interactively.
+
+    Parameters
+    ----------
+    data : DataFrame, Panel, Series, or list
+        Object containing the data
+    index : bool
+        Show the index. When None, detect if an index exists.
+    header : bool
+        Show the column names or Series name. When None, detect if column names
+        or a Series name has been set.
+    start : (Y,X) tuple
+        Start the viewer at the indicated location.
+    fixed_index : bool
+        Instruct the viewer to keep the index fixed
+    fixed_header : bool
+        Instruct the viewer to keep the header fixed
+    **kwargs : dict
+        Any parameter supported by the underlying viewer.
+    """
+    if isinstance(data, (Panel, DataFrame)):
+        if isinstance(data, Panel):
+            data = data.to_frame()
+
+        # detect if data is using the built-in index for the labels/columns
+        if index is None:
+            index = type(data.index) is not Int64Index
+        if header is None:
+            header = type(data.index) is not Int64Index
+
+        if index:
+            data = data.reset_index()
+        buf = []
+        if header:
+            buf += [data.columns.tolist()]
+        buf += data.values.tolist()
+        data = buf
+
+    elif isinstance(data, Series):
+        if index is None:
+            index = type(data.index) is not Int64Index
+        if header is None:
+            header = data.name is not None and len(data.name)
+        buf = []
+        if index:
+            if header:
+                buf += [[data.index.name, data.name]]
+            buf += data.reset_index().values.tolist()
+        else:
+            if header:
+                buf += [[data.name]]
+            buf += [[x] for x in data.values]
+        data = buf
+
+    else:
+        # try to convert to a simple list
+        data = list(data)
+
+    # defaults
+    if fixed_index is None:
+        fixed_index = index
+    if fixed_header is None:
+        fixed_header = header
+
+    interact_list(data, **kwargs)
+
+
+def interact_list(data, start=None, fixed_header=None,
+                  fixed_index=None, **kwargs):
+    tabview.view(data)

--- a/pandas/tools/interact.py
+++ b/pandas/tools/interact.py
@@ -13,14 +13,14 @@ def interact(data, index=None, header=None, start=None,
 
     Parameters
     ----------
-    data : DataFrame, Panel, Series, or list
+    data : DataFrame, Panel, Series or list
         Object containing the data
     index : bool
         Show the index. When None, detect if an index exists.
     header : bool
         Show the column names or Series name. When None, detect if column names
         or a Series name has been set.
-    start : (Y,X) tuple
+    start : Y or (Y,X) tuple
         Start the viewer at the indicated location.
     fixed_index : bool
         Instruct the viewer to keep the index fixed
@@ -72,6 +72,8 @@ def interact(data, index=None, header=None, start=None,
         fixed_index = index
     if fixed_header is None:
         fixed_header = header
+    if type(start) is not tuple:
+        start = (start, 0)
 
     interact_list(data, **kwargs)
 


### PR DESCRIPTION
This is a first attempt at addressing #9179 

We add a DataFrame.view method to visualize the contents of a dataframe interactively.
The viewing itself is performed using the "tabview" module from https://github.com/firecat53/tabview

A few initial notes:
- tabview requires python3 currently, so please test using python3. There are no significant changes to make tabview work on python 2.7 as well but I'd like some feedback first.
- tabview tries to sys.exit() on quit even when loaded as a module. Also needs a fix. ipython complains, but prevents the module to exit.
- I have no idea where it would be more appropriate to put the dependency/suggestion to install tabview.
