### PR TITLE
fixes division by zero error for kurt()

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -141,3 +141,4 @@ Bug Fixes
 - Bug in read_csv when using skiprows on a file with CR line endings with the c engine. (:issue:`9079`)
 - isnull now detects NaT in PeriodIndex (:issue:`9129`)
 - Bug in groupby ``.nth()`` with a multiple column groupby (:issue:`8979`)
+- Fixed division by zero error for ``Series.kurt()`` when all values are equal (:issue:`9197`)

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -514,17 +514,21 @@ def nankurt(values, axis=None, skipna=True):
     C = _zero_out_fperr(C)
     D = _zero_out_fperr(D)
 
+    if not isinstance(B, np.ndarray):
+        # if B is a scalar, check these corner cases first before doing division
+        if count < 4:
+            return np.nan
+        if B == 0:
+            return 0
+
     result = (((count * count - 1.) * D / (B * B) - 3 * ((count - 1.) ** 2)) /
               ((count - 2.) * (count - 3.)))
+
     if isinstance(result, np.ndarray):
         result = np.where(B == 0, 0, result)
         result[count < 4] = np.nan
-        return result
-    else:
-        result = 0 if B == 0 else result
-        if count < 4:
-            return np.nan
-        return result
+
+    return result
 
 
 @disallow('M8','m8')

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -2212,6 +2212,18 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         alt = lambda x: skew(x, bias=False)
         self._check_stat_op('skew', alt)
 
+        # test corner cases, skew() returns NaN unless there's at least 3 values
+        min_N = 3
+        for i in range(1, min_N + 1):
+            s = Series(np.ones(i))
+            df = DataFrame(np.ones((i, i)))
+            if i < min_N:
+                self.assertTrue(np.isnan(s.skew()))
+                self.assertTrue(np.isnan(df.skew()).all())
+            else:
+                self.assertEqual(0, s.skew())
+                self.assertTrue((df.skew() == 0).all())
+
     def test_kurt(self):
         tm._skip_if_no_scipy()
 
@@ -2225,6 +2237,18 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
                                    [0, 1, 0, 1, 0, 1]])
         s = Series(np.random.randn(6), index=index)
         self.assertAlmostEqual(s.kurt(), s.kurt(level=0)['bar'])
+
+        # test corner cases, kurt() returns NaN unless there's at least 4 values
+        min_N = 4
+        for i in range(1, min_N + 1):
+            s = Series(np.ones(i))
+            df = DataFrame(np.ones((i, i)))
+            if i < min_N:
+                self.assertTrue(np.isnan(s.kurt()))
+                self.assertTrue(np.isnan(df.kurt()).all())
+            else:
+                self.assertEqual(0, s.kurt())
+                self.assertTrue((df.kurt() == 0).all())
 
     def test_argsort(self):
         self._check_accum_op('argsort')


### PR DESCRIPTION
Currently if `kurt()` is called on a `Series` with equal values, it throws a `ZeroDivisionError`

```
In [1]: import pandas as pd
In [2]: import numpy as np
In [3]: s = pd.Series(np.ones(5))
In [4]: s.kurt()
ZeroDivisionError: float division by zero
```

This is not consistent with the case when `kurt()` is called on a `DataFrame` of equal values

```
In [5]: df = pd.DataFrame(np.ones((5, 5)))
In [6]: df.kurt()
Out[6]:
0    0
1    0
2    0
3    0
4    0
dtype: float64
```

with this patch `s.kurt()` will return `0` instead of throwing.
