### PR TITLE
9203 SQUASHED - DOCS: doc string edited pandas/core/frame.duplicated()

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2726,7 +2726,8 @@ class DataFrame(NDFrame):
             Only consider certain columns for identifying duplicates, by
             default use all of the columns
         take_last : boolean, default False
-            Take the last observed row in a row. Defaults to the first row
+            For a set of distinct duplicate rows, flag all but the last row as 
+            duplicated. Default is for all but the first row to be flagged            
         cols : kwargs only argument of subset [deprecated]
 
         Returns


### PR DESCRIPTION
Redefined `take_last` variable in doc string. Original definition only
made sense for drop_duplicates()
