### PR TITLE
added mising numeric_only option for DataFrame.std/var/sem

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -486,3 +486,5 @@ Bug Fixes
 - Fixed bug with reading CSV files from Amazon S3 on python 3 raising a TypeError (:issue:`9452`)
 - Bug in the Google BigQuery reader where the 'jobComplete' key may be present but False in the query results (:issue:`8728`)
 - Bug in ``Series.values_counts`` with excluding ``NaN`` for categorical type ``Series`` with ``dropna=True`` (:issue:`9443`)
+
+- Fixed mising numeric_only option for ``DataFrame.std/var/sem`` (:issue:`9201`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4090,7 +4090,7 @@ equivalent of the ``numpy.ndarray`` method ``argmin``.""", nanops.nanmin)
             @Substitution(outname=name, desc=desc)
             @Appender(_num_doc)
             def stat_func(self, axis=None, skipna=None, level=None, ddof=1,
-                          **kwargs):
+                          numeric_only=None, **kwargs):
                 if skipna is None:
                     skipna = True
                 if axis is None:
@@ -4099,6 +4099,7 @@ equivalent of the ``numpy.ndarray`` method ``argmin``.""", nanops.nanmin)
                     return self._agg_by_level(name, axis=axis, level=level,
                                               skipna=skipna, ddof=ddof)
                 return self._reduce(f, name, axis=axis,
+                                    numeric_only=numeric_only,
                                     skipna=skipna, ddof=ddof)
             stat_func.__name__ = name
             return stat_func

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -332,7 +332,7 @@ def _get_counts_nanvar(mask, axis, ddof):
 def _nanvar(values, axis=None, skipna=True, ddof=1):
     # private nanvar calculator
     mask = isnull(values)
-    if not is_floating_dtype(values):
+    if is_any_int_dtype(values):
         values = values.astype('f8')
 
     count, d = _get_counts_nanvar(mask, axis, ddof)


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/9201, the `numeric_only` option is missing for `DataFrame.std()` (and also `DataFrame.var()` and `DataFrame.sem()`), this is a fix for it
