### PR TITLE
BUG FIX: wide_to_long modifies stubnames

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -153,3 +153,5 @@ Bug Fixes
 
 
 - Fixed issue in the ``xlsxwriter`` engine where it added a default 'General' format to cells if no other format wass applied. This prevented other row or column formatting being applied. (:issue:`9167`)
+
+- Bug in ``wide_to_long``, modifies stubnames list (:issue:`9204`) 

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -930,10 +930,9 @@ def wide_to_long(df, stubnames, i, j):
     if i not in id_vars:
         id_vars += [i]
 
-    stub = stubnames.pop(0)
-    newdf = melt_stub(df, stub, id_vars, j)
+    newdf = melt_stub(df, stubnames[0], id_vars, j)
 
-    for stub in stubnames:
+    for stub in stubnames[1:]:
         new = melt_stub(df, stub, id_vars, j)
         newdf = newdf.merge(new, how="outer", on=id_vars + [j], copy=False)
     return newdf.set_index([i, j])

--- a/pandas/tests/test_reshape.py
+++ b/pandas/tests/test_reshape.py
@@ -443,6 +443,13 @@ class TestWideToLong(tm.TestCase):
         long_frame = wide_to_long(df, ["A", "B"], i="id", j="year")
         tm.assert_frame_equal(long_frame, exp_frame)
 
+    def test_stubs(self):
+        df = pd.DataFrame([[0,1,2,3,8],[4,5,6,7,9]])
+        df.columns = ['id', 'inc1', 'inc2', 'edu1', 'edu2']
+        stubs = ['inc', 'edu']
+        df_long = pd.wide_to_long(df, stubs, i='id', j='age')
+
+        assert stubs == ['inc', 'edu']
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/pandas/tests/test_reshape.py
+++ b/pandas/tests/test_reshape.py
@@ -443,6 +443,7 @@ class TestWideToLong(tm.TestCase):
         long_frame = wide_to_long(df, ["A", "B"], i="id", j="year")
         tm.assert_frame_equal(long_frame, exp_frame)
 
+    # Issue GH9204
     def test_stubs(self):
         df = pd.DataFrame([[0,1,2,3,8],[4,5,6,7,9]])
         df.columns = ['id', 'inc1', 'inc2', 'edu1', 'edu2']


### PR DESCRIPTION
Simple fix that prevents modification of the list `stubnames`, which is an argument to `wide_to_long`. 

Closes #9204
