### PR TITLE
Fix randomly failing test in test_frame.py

### DIFF
--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1938,7 +1938,11 @@ class CheckIndexing(object):
                         'joe':['3rd'] * 2 + ['1st'] * 3 + ['2nd'] * 3 +
                               ['1st'] * 2 + ['3rd'] * 3 + ['1st'] * 2 +
                               ['3rd'] * 3 + ['2nd'] * 2,
-                        'jolie':np.random.randint(0, 1000, 20),
+                        # this needs to be jointly unique with jim and joe or
+                        # reindexing will fail ~1.5% of the time, this works
+                        # out to needing unique groups of same size as joe
+                        'jolie': np.concatenate([np.random.choice(1000, x, replace=False)
+                                                 for x in [2, 3, 3, 2, 3, 2, 3, 2]]),
                         'joline': np.random.randn(20).round(3) * 10})
 
         for idx in permutations(df['jim'].unique()):


### PR DESCRIPTION
@jreback I noticed a randomly failing test while doing a full suite run a week or two ago. The test is using random integers as part of a `MultiIndex`, which randomly leads to a non-unique index. Attempting to re-index the `DataFrame` therefore randomly fails. The solution is to just sample without replacement.

The following code gives a failure rate of ~1.5%, which is in line with birthday problem estimates (`d=1000` and four iterations each of `n=3` and `n=2`):

```
import subprocess

total = 0
n = 10
for i in range(n):
    result = subprocess.call('nosetests pandas/tests/test_frame.py:TestDataFrame.test_reindex_level', shell=True)
    if result:
        print i
        total += 1
print 'Total error rate of {0:.6f}'.format(total/float(n))
```
