### PR TITLE
COMPAT: Need to read Bytes on Python

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -83,6 +83,7 @@ Bug Fixes
 
 .. _whatsnew_0160.bug_fixes:
 
+- Fixed issue using `read_csv` on s3 with Python 3.
 - Fixed compatibility issue in ``DatetimeIndex`` affecting architectures where ``numpy.int_`` defaults to ``numpy.int32`` (:issue:`8943`)
 - Bug in Panel indexing with an object-like (:issue:`9140`)
 

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -5,7 +5,7 @@ import os
 import zipfile
 from contextlib import contextmanager, closing
 
-from pandas.compat import StringIO, string_types
+from pandas.compat import StringIO, string_types, BytesIO
 from pandas import compat
 
 
@@ -154,7 +154,7 @@ def get_filepath_or_buffer(filepath_or_buffer, encoding=None):
         b = conn.get_bucket(parsed_url.netloc)
         k = boto.s3.key.Key(b)
         k.key = parsed_url.path
-        filepath_or_buffer = StringIO(k.get_contents_as_string())
+        filepath_or_buffer = BytesIO(k.get_contents_as_string())
         return filepath_or_buffer, None
 
 


### PR DESCRIPTION
Reading from s3 on Python 3 returns a Bytes object.
