### PR TITLE
BUG: fix DataFrame constructor w named Series

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -367,6 +367,13 @@ The behavior of a small sub-set of edge cases for using ``.loc`` have changed (:
      In [4]: df.loc[2:3]
      TypeError: Cannot do slice indexing on <class 'pandas.tseries.index.DatetimeIndex'> with <type 'int'> keys
 
+DataFrame Construction Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. _whatsnew_0160.api_breaking.construction:
+
+
+
 
 .. _whatsnew_0160.deprecations:
 
@@ -535,3 +542,7 @@ Bug Fixes
 - Fixed bug with reading CSV files from Amazon S3 on python 3 raising a TypeError (:issue:`9452`)
 
 - Bug in the Google BigQuery reader where the 'jobComplete' key may be present but False in the query results (:issue:`8728`)
+
+
+- Fixed bug with DataFrame constructor when passed a Series with a
+name and the `columns` keyword argument.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -231,7 +231,7 @@ class DataFrame(NDFrame):
                 if columns is None:
                     columns = data_columns
                 mgr = self._init_dict(data, index, columns, dtype=dtype)
-            elif getattr(data, 'name', None):
+            elif getattr(data, 'name', None) is not None:
                 mgr = self._init_dict({data.name: data}, index, columns,
                                       dtype=dtype)
             else:
@@ -295,15 +295,14 @@ class DataFrame(NDFrame):
         if columns is not None:
             columns = _ensure_index(columns)
 
-            # prefilter if columns passed
-
-            data = dict((k, v) for k, v in compat.iteritems(data)
-                        if k in columns)
-
             if index is None:
                 index = extract_index(list(data.values()))
             else:
                 index = _ensure_index(index)
+
+            # prefilter if columns passed
+            data = dict((k, v) for k, v in compat.iteritems(data)
+                        if k in columns)
 
             arrays = []
             data_names = []

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3362,6 +3362,18 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         expected = DataFrame({ 1 : s1, 0 : arr },columns=[0,1])
         assert_frame_equal(df,expected)
 
+    def test_constructor_Series_named_different(self):
+        # 9232
+        x = Series([1, 2], name=0)
+        expected = DataFrame([np.nan, np.nan], columns=[1])
+        result = DataFrame(x, columns=[1])
+        assert_frame_equal(result, expected)
+
+        x.name = 1
+        expected = DataFrame([np.nan, np.nan], columns=[0])
+        result = DataFrame(x, columns=[0])
+        assert_frame_equal(result, expected)
+
     def test_constructor_Series_differently_indexed(self):
         # name
         s1 = Series([1, 2, 3], index=['a', 'b', 'c'], name='x')


### PR DESCRIPTION
closes #7893

Closes https://github.com/pydata/pandas/issues/9232

Problem was passing Series w/ a name to DataFrame w/ the `columns` kwarg.

Before:

``` python
In [55]: x = pd.Series(range(5), name=1)

In [56]: y = pd.Series(range(5), name=0)

In [57]: pd.DataFrame(x, columns=[0])
Out[57]:
Empty DataFrame
Columns: [0]
Index: []

In [58]: pd.DataFrame(x, columns=[1])
Out[58]:
   1
0  0
1  1
2  2
3  3
4  4

In [59]: pd.DataFrame(y, columns=[0])
Out[59]:
   0
0  0
1  1
2  2
3  3
4  4

In [60]: pd.DataFrame(y, columns=[1])
Out[60]:
   1
0  0
1  1
2  2
3  3
4  4
```

after

``` python
In [1]: x = pd.Series(range(5), name=1)

In [2]: y = pd.Series(range(5), name=0)

In [4]: pd.DataFrame(x, columns=[0])
Out[4]: 
   0
0  0
1  1
2  2
3  3
4  4

In [5]: pd.DataFrame(y, columns=[1])
Out[5]: 
   1
0  0
1  1
2  2
3  3
4  4
```

There were two intertwined problems
1. we checked `if getattr(data, 'name', None):`, which returned False when data.name was `False`ish (like 0). I now compare it directly against None.
2. If `data` has a name and the columns kwarg is specified, the constructor returned an Empty DataFrame w/ the column specified in columns. Now, we do what's [documented](http://pandas.pydata.org/pandas-docs/version/0.15.2/dsintro.html#from-a-series):

> The result will be a DataFrame with the same index as the input Series, and with one column whose name is the original name of the Series (only if no other column name provided).
