### PR TITLE
ENH: add Timestamp.to_datetime64

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -63,6 +63,7 @@ Enhancements
 - Paths beginning with ~ will now be expanded to begin with the user's home directory (:issue:`9066`)
 - Added time interval selection in get_data_yahoo (:issue:`9071`)
 - Added ``Series.str.slice_replace()``, which previously raised NotImplementedError (:issue:`8888`)
+- Added ``Timestamp.to_datetime64()`` to complement ``Timedelta.to_timedelta64()`` (:issue:`9255`)
 
 
 Performance

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -136,6 +136,21 @@ class TestTimestamp(tm.TestCase):
         self.assertEqual(repr(result), expected_repr)
         self.assertEqual(result, eval(repr(result)))
 
+    def test_conversion(self):
+        # GH 9255
+        ts = Timestamp('2000-01-01')
+
+        result = ts.to_pydatetime()
+        expected = datetime.datetime(2000, 1, 1)
+        self.assertEqual(result, expected)
+        self.assertEqual(type(result), type(expected))
+
+        result = ts.to_datetime64()
+        expected = np.datetime64(ts.value, 'ns')
+        self.assertEqual(result, expected)
+        self.assertEqual(type(result), type(expected))
+        self.assertEqual(result.dtype, expected.dtype)
+
     def test_repr(self):
         tm._skip_if_no_pytz()
         tm._skip_if_no_dateutil()

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -852,6 +852,10 @@ cdef class _Timestamp(datetime):
                         dts.hour, dts.min, dts.sec,
                         dts.us, ts.tzinfo)
 
+    cpdef to_datetime64(self):
+        """ Returns a numpy.datetime64 object with 'ns' precision """
+        return np.datetime64(self.value, 'ns')
+
     def __add__(self, other):
         cdef int64_t other_int
 


### PR DESCRIPTION
This PR adds a `Timestamp.to_datetime64()` method to complement the `Timedelta.to_timedelta64()` method I added in #8884. It is a continuation of the aborted #8916.

Arguably, there should also be the alias `Timestamp.values` to complement the series property but I haven't added that yet.
