### PR TITLE
BUG: bug in multi-index where insert fails

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -103,6 +103,7 @@ Bug Fixes
 - Bug in ``MultiIndex.has_duplicates`` when having many levels causes an indexer overflow (:issue:`9075`, :issue:`5873`)
 - Bug in ``pivot`` and `unstack`` where ``nan`` values would break index alignment (:issue:`7466`)
 - Bug in left ``join`` on multi-index with ``sort=True`` or null values (:issue:`9210`).
+- Bug in ``MultiIndex`` where inserting new keys would fail (:issue:`9250`).
 
 
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1351,8 +1351,8 @@ class CheckIndexing(object):
         ix = self.frame.ix
         with assertRaisesRegexp(IndexingError, 'Too many indexers'):
             ix[:, :, :]
-        with assertRaisesRegexp(IndexingError, 'only tuples of length <= 2 '
-                                'supported'):
+
+        with assertRaises(IndexingError):
             ix[:, :, :] = 1
 
     def test_getitem_setitem_boolean_misaligned(self):


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/9250

on master:

```
>>> df
         3rd
1st 2nd     
a   b      0
b   d      1
>>> df.loc[('b', 'x'), '3rd'] = 2  # this works!
>>> df
         3rd
1st 2nd     
a   b      0
b   d      1
    x      2
>>> df.loc[('b', 'a'), '3rd'] = -1  # fails! sets everything to -1
>>> df
         3rd
1st 2nd     
a   b     -1
b   d     -1
    x     -1
>>> df.loc[('b', 'b'), '3rd'] = 3  # erros!
NotImplementedError: Index._join_level on non-unique index is not implemented
```

on branch:

```
>>> df
         3rd
1st 2nd     
a   b      0
b   d      1
>>> df.loc[('b', 'x'), '3rd'] = 2
>>> df.loc[('b', 'a'), '3rd'] = -1
>>> df.loc[('b', 'b'), '3rd'] = 3
>>> df
         3rd
1st 2nd     
a   b      0
b   d      1
    x      2
    a     -1
    b      3
```
