### PR TITLE
API/ENH: add method='nearest' to Index.get_indexer/reindex and method to get_loc

### DIFF
--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -948,15 +948,9 @@ chosen from the following table:
 
     pad / ffill, Fill values forward
     bfill / backfill, Fill values backward
+    nearest, Fill from the nearest index value
 
-Other fill methods could be added, of course, but these are the two most
-commonly used for time series data. In a way they only make sense for time
-series or otherwise ordered data, but you may have an application on non-time
-series data where this sort of "interpolation" logic is the correct thing to
-do. More sophisticated interpolation of missing values would be an obvious
-extension.
-
-We illustrate these fill methods on a simple TimeSeries:
+We illustrate these fill methods on a simple Series:
 
 .. ipython:: python
 
@@ -969,18 +963,22 @@ We illustrate these fill methods on a simple TimeSeries:
    ts2.reindex(ts.index)
    ts2.reindex(ts.index, method='ffill')
    ts2.reindex(ts.index, method='bfill')
+   ts2.reindex(ts.index, method='nearest')
 
-Note these methods require that the indexes are **order increasing**.
+These methods require that the indexes are **ordered** increasing or
+decreasing.
 
-Note the same result could have been achieved using :ref:`fillna
-<missing_data.fillna>`:
+Note that the same result could have been achieved using
+:ref:`fillna <missing_data.fillna>` (except for ``method='nearest'``) or
+:ref:`interpolate <missing_data.interpolation>`:
 
 .. ipython:: python
 
    ts2.reindex(ts.index).fillna(method='ffill')
 
-Note that ``reindex`` will raise a ValueError if the index is not
-monotonic. ``fillna`` will not make any checks on the order of the index.
+``reindex`` will raise a ValueError if the index is not monotonic increasing or
+descreasing. ``fillna`` and ``interpolate`` will not make any checks on the
+order of the index.
 
 .. _basics.drop:
 

--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -20,6 +20,15 @@ users upgrade to this version.
 New features
 ~~~~~~~~~~~~
 
+- Reindex now supports ``method='nearest'`` for frames or series with a monotonic increasing or decreasing index (:issue:`9258`):
+
+    .. ipython:: python
+
+    df = pd.DataFrame({'x': range(5)})
+    df.reindex([0.2, 1.8, 3.5], method='nearest')
+
+  This method is also exposed by the lower level ``Index.get_indexer`` and ``Index.get_loc`` methods.
+
 .. _whatsnew_0160.api:
 
 .. _whatsnew_0160.api_breaking:
@@ -189,6 +198,9 @@ Enhancements
 
 - Added ``StringMethods.find()`` and ``rfind()`` which behave as the same as standard ``str`` (:issue:`9386`)
 
+- ``Index.get_indexer`` now supports ``method='pad'`` and ``method='backfill'`` even for any target array, not just monotonic targets. These methods also work for monotonic decreasing as well as monotonic increasing indexes (:issue:`9258`).
+- ``Index.asof`` now works on all index types (:issue:`9258`).
+
 - Added ``StringMethods.isnumeric`` and ``isdecimal`` which behave as the same as standard ``str`` (:issue:`9439`)
 - Added ``StringMethods.ljust()`` and ``rjust()`` which behave as the same as standard ``str`` (:issue:`9352`)
 - ``StringMethods.pad()`` and ``center()`` now accept ``fillchar`` option to specify filling character (:issue:`9352`)
@@ -243,6 +255,22 @@ Bug Fixes
 
 
 - Fixed character encoding bug in ``read_stata`` and ``StataReader`` when loading data from a URL (:issue:`9231`).
+
+- Looking up a partial string label with ``DatetimeIndex.asof`` now includes values that match the string, even if they are after the start of the partial string label (:issue:`9258`). Old behavior:
+
+  .. ipython:: python
+    :verbatim:
+
+    In [4]: pd.to_datetime(['2000-01-31', '2000-02-28']).asof('2000-02')
+    Out[4]: Timestamp('2000-01-31 00:00:00')
+
+  Fixed behavior:
+
+  .. ipython:: python
+
+    pd.to_datetime(['2000-01-31', '2000-02-28']).asof('2000-02')
+
+  To reproduce the old behavior, simply add more precision to the label (e.g., use ``2000-02-01`` instead of ``2000-02``).
 
 
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -2682,7 +2682,7 @@ def _astype_nansafe(arr, dtype, copy=True):
     return arr.view(dtype)
 
 
-def _clean_fill_method(method):
+def _clean_fill_method(method, allow_nearest=False):
     if method is None:
         return None
     method = method.lower()
@@ -2690,11 +2690,21 @@ def _clean_fill_method(method):
         method = 'pad'
     if method == 'bfill':
         method = 'backfill'
-    if method not in ['pad', 'backfill']:
-        msg = ('Invalid fill method. Expecting pad (ffill) or backfill '
-               '(bfill). Got %s' % method)
+
+    valid_methods = ['pad', 'backfill']
+    expecting = 'pad (ffill) or backfill (bfill)'
+    if allow_nearest:
+        valid_methods.append('nearest')
+        expecting = 'pad (ffill), backfill (bfill) or nearest'
+    if method not in valid_methods:
+        msg = ('Invalid fill method. Expecting %s. Got %s'
+               % (expecting, method))
         raise ValueError(msg)
     return method
+
+
+def _clean_reindex_fill_method(method):
+    return _clean_fill_method(method, allow_nearest=True)
 
 
 def _all_none(*args):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1672,10 +1672,12 @@ class NDFrame(PandasObject):
             keywords)
             New labels / index to conform to. Preferably an Index object to
             avoid duplicating data
-        method : {'backfill', 'bfill', 'pad', 'ffill', None}, default None
-            Method to use for filling holes in reindexed DataFrame
-            pad / ffill: propagate last valid observation forward to next valid
-            backfill / bfill: use NEXT valid observation to fill gap
+        method : {None, 'backfill'/'bfill', 'pad'/'ffill', 'nearest'}, optional
+            Method to use for filling holes in reindexed DataFrame:
+              * default: don't fill gaps
+              * pad / ffill: propagate last valid observation forward to next valid
+              * backfill / bfill: use next valid observation to fill gap
+              * nearest: use nearest valid observations to fill gap
         copy : boolean, default True
             Return a new object, even if the passed indexes are the same
         level : int or name
@@ -1703,7 +1705,7 @@ class NDFrame(PandasObject):
 
         # construct the args
         axes, kwargs = self._construct_axes_from_arguments(args, kwargs)
-        method = com._clean_fill_method(kwargs.get('method'))
+        method = com._clean_reindex_fill_method(kwargs.get('method'))
         level = kwargs.get('level')
         copy = kwargs.get('copy', True)
         limit = kwargs.get('limit')
@@ -1744,9 +1746,8 @@ class NDFrame(PandasObject):
 
             axis = self._get_axis_number(a)
             obj = obj._reindex_with_indexers(
-                {axis: [new_index, indexer]}, method=method,
-                fill_value=fill_value, limit=limit, copy=copy,
-                allow_dups=False)
+                {axis: [new_index, indexer]},
+                fill_value=fill_value, copy=copy, allow_dups=False)
 
         return obj
 
@@ -1770,10 +1771,12 @@ class NDFrame(PandasObject):
             New labels / index to conform to. Preferably an Index object to
             avoid duplicating data
         axis : %(axes_single_arg)s
-        method : {'backfill', 'bfill', 'pad', 'ffill', None}, default None
-            Method to use for filling holes in reindexed object.
-            pad / ffill: propagate last valid observation forward to next valid
-            backfill / bfill: use NEXT valid observation to fill gap
+        method : {None, 'backfill'/'bfill', 'pad'/'ffill', 'nearest'}, optional
+            Method to use for filling holes in reindexed DataFrame:
+              * default: don't fill gaps
+              * pad / ffill: propagate last valid observation forward to next valid
+              * backfill / bfill: use next valid observation to fill gap
+              * nearest: use nearest valid observations to fill gap
         copy : boolean, default True
             Return a new object, even if the passed indexes are the same
         level : int or name
@@ -1802,15 +1805,14 @@ class NDFrame(PandasObject):
 
         axis_name = self._get_axis_name(axis)
         axis_values = self._get_axis(axis_name)
-        method = com._clean_fill_method(method)
+        method = com._clean_reindex_fill_method(method)
         new_index, indexer = axis_values.reindex(labels, method, level,
                                                  limit=limit)
         return self._reindex_with_indexers(
-            {axis: [new_index, indexer]}, method=method, fill_value=fill_value,
-            limit=limit, copy=copy)
+            {axis: [new_index, indexer]}, fill_value=fill_value, copy=copy)
 
-    def _reindex_with_indexers(self, reindexers, method=None,
-                               fill_value=np.nan, limit=None, copy=False,
+    def _reindex_with_indexers(self, reindexers,
+                               fill_value=np.nan, copy=False,
                                allow_dups=False):
         """ allow_dups indicates an internal call here """
 

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=E1101,E1103,W0232
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, time
 from pandas.compat import range, lrange, lzip, u, zip
 import operator
 import re
@@ -95,6 +95,15 @@ class Base(object):
                 pass
         tm.assertRaisesRegexp(ValueError,'The truth value of a',f)
 
+    def test_reindex_base(self):
+        idx = self.create_index()
+        expected = np.arange(idx.size)
+        actual = idx.get_indexer(idx)
+        assert_array_equal(expected, actual)
+
+        with tm.assertRaisesRegexp(ValueError, 'Invalid fill method'):
+            idx.get_indexer(idx, method='invalid')
+
     def test_ndarray_compat_properties(self):
 
         idx = self.create_index()
@@ -108,6 +117,7 @@ class Base(object):
         # test for validity
         idx.nbytes
         idx.values.nbytes
+
 
 class TestIndex(Base, tm.TestCase):
     _holder = Index
@@ -421,7 +431,7 @@ class TestIndex(Base, tm.TestCase):
 
     def test_asof(self):
         d = self.dateIndex[0]
-        self.assertIs(self.dateIndex.asof(d), d)
+        self.assertEqual(self.dateIndex.asof(d), d)
         self.assertTrue(np.isnan(self.dateIndex.asof(d - timedelta(1))))
 
         d = self.dateIndex[-1]
@@ -432,9 +442,10 @@ class TestIndex(Base, tm.TestCase):
 
     def test_asof_datetime_partial(self):
         idx = pd.date_range('2010-01-01', periods=2, freq='m')
-        expected = Timestamp('2010-01-31')
+        expected = Timestamp('2010-02-28')
         result = idx.asof('2010-02')
         self.assertEqual(result, expected)
+        self.assertFalse(isinstance(result, Index))
 
     def test_nanosecond_index_access(self):
         s = Series([Timestamp('20130101')]).values.view('i8')[0]
@@ -855,16 +866,80 @@ class TestIndex(Base, tm.TestCase):
         assert_almost_equal(r1, [1, 3, -1])
 
         r1 = idx2.get_indexer(idx1, method='pad')
-        assert_almost_equal(r1, [-1, 0, 0, 1, 1])
+        e1 = [-1, 0, 0, 1, 1]
+        assert_almost_equal(r1, e1)
+
+        r2 = idx2.get_indexer(idx1[::-1], method='pad')
+        assert_almost_equal(r2, e1[::-1])
 
         rffill1 = idx2.get_indexer(idx1, method='ffill')
         assert_almost_equal(r1, rffill1)
 
         r1 = idx2.get_indexer(idx1, method='backfill')
-        assert_almost_equal(r1, [0, 0, 1, 1, 2])
+        e1 = [0, 0, 1, 1, 2]
+        assert_almost_equal(r1, e1)
 
         rbfill1 = idx2.get_indexer(idx1, method='bfill')
         assert_almost_equal(r1, rbfill1)
+
+        r2 = idx2.get_indexer(idx1[::-1], method='backfill')
+        assert_almost_equal(r2, e1[::-1])
+
+    def test_get_indexer_nearest(self):
+        idx = Index(np.arange(10))
+
+        all_methods = ['pad', 'backfill', 'nearest']
+        for method in all_methods:
+            actual = idx.get_indexer([0, 5, 9], method=method)
+            self.assert_array_equal(actual, [0, 5, 9])
+
+        for method, expected in zip(all_methods, [[0, 1, 8], [1, 2, 9], [0, 2, 9]]):
+            actual = idx.get_indexer([0.2, 1.8, 8.5], method=method)
+            self.assert_array_equal(actual, expected)
+
+        with tm.assertRaisesRegexp(ValueError, 'limit argument'):
+            idx.get_indexer([1, 0], method='nearest', limit=1)
+
+    def test_get_indexer_nearest_decreasing(self):
+        idx = Index(np.arange(10))[::-1]
+
+        all_methods = ['pad', 'backfill', 'nearest']
+        for method in all_methods:
+            actual = idx.get_indexer([0, 5, 9], method=method)
+            self.assert_array_equal(actual, [9, 4, 0])
+
+        for method, expected in zip(all_methods, [[8, 7, 0], [9, 8, 1], [9, 7, 0]]):
+            actual = idx.get_indexer([0.2, 1.8, 8.5], method=method)
+            self.assert_array_equal(actual, expected)
+
+    def test_get_indexer_strings(self):
+        idx = pd.Index(['b', 'c'])
+
+        actual = idx.get_indexer(['a', 'b', 'c', 'd'], method='pad')
+        expected = [-1, 0, 1, 1]
+        self.assert_array_equal(actual, expected)
+
+        actual = idx.get_indexer(['a', 'b', 'c', 'd'], method='backfill')
+        expected = [0, 0, 1, -1]
+        self.assert_array_equal(actual, expected)
+
+        with tm.assertRaises(TypeError):
+            idx.get_indexer(['a', 'b', 'c', 'd'], method='nearest')
+
+    def test_get_loc(self):
+        idx = pd.Index([0, 1, 2])
+        all_methods = [None, 'pad', 'backfill', 'nearest']
+        for method in all_methods:
+            self.assertEqual(idx.get_loc(1, method=method), 1)
+            with tm.assertRaises(TypeError):
+                idx.get_loc([1, 2], method=method)
+
+        for method, loc in [('pad', 1), ('backfill', 2), ('nearest', 1)]:
+            self.assertEqual(idx.get_loc(1.1, method), loc)
+
+        idx = pd.Index(['a', 'c'])
+        with tm.assertRaises(TypeError):
+            idx.get_loc('a', method='nearest')
 
     def test_slice_locs(self):
         for dtype in [int, float]:
@@ -1247,6 +1322,7 @@ class Numeric(Base):
         expected = Float64Index(np.sin(np.arange(5,dtype='int64')))
         tm.assert_index_equal(result, expected)
 
+
 class TestFloat64Index(Numeric, tm.TestCase):
     _holder = Float64Index
     _multiprocess_can_split_ = True
@@ -1359,6 +1435,26 @@ class TestFloat64Index(Numeric, tm.TestCase):
 
         i2 = Float64Index([1.0,np.nan])
         self.assertTrue(i.equals(i2))
+
+    def test_get_indexer(self):
+        idx = Float64Index([0.0, 1.0, 2.0])
+        self.assert_array_equal(idx.get_indexer(idx), [0, 1, 2])
+
+        target = [-0.1, 0.5, 1.1]
+        self.assert_array_equal(idx.get_indexer(target, 'pad'), [-1, 0, 1])
+        self.assert_array_equal(idx.get_indexer(target, 'backfill'), [0, 1, 2])
+        self.assert_array_equal(idx.get_indexer(target, 'nearest'), [0, 1, 1])
+
+    def test_get_loc(self):
+        idx = Float64Index([0.0, 1.0, 2.0])
+        for method in [None, 'pad', 'backfill', 'nearest']:
+            self.assertEqual(idx.get_loc(1, method), 1)
+
+        for method, loc in [('pad', 1), ('backfill', 2), ('nearest', 1)]:
+            self.assertEqual(idx.get_loc(1.1, method), loc)
+
+        self.assertRaises(KeyError, idx.get_loc, 'foo')
+        self.assertRaises(KeyError, idx.get_loc, 1.5)
 
     def test_get_loc_na(self):
         idx = Float64Index([np.nan, 1, 2])
@@ -1897,6 +1993,54 @@ class TestDatetimeIndex(DatetimeLike, tm.TestCase):
                       lambda : pd.date_range('2000-01-01', periods=3) * np.timedelta64(1, 'D').astype('m8[ns]') ]:
                 self.assertRaises(TypeError, f)
 
+    def test_get_loc(self):
+        idx = pd.date_range('2000-01-01', periods=3)
+
+        for method in [None, 'pad', 'backfill', 'nearest']:
+            self.assertEqual(idx.get_loc(idx[1], method), 1)
+            self.assertEqual(idx.get_loc(idx[1].to_pydatetime(), method), 1)
+            self.assertEqual(idx.get_loc(str(idx[1]), method), 1)
+
+        self.assertEqual(idx.get_loc('2000-01-01', method='nearest'), 0)
+        self.assertEqual(idx.get_loc('2000-01-01T12', method='nearest'), 1)
+
+        self.assertEqual(idx.get_loc('2000', method='nearest'), slice(0, 3))
+        self.assertEqual(idx.get_loc('2000-01', method='nearest'), slice(0, 3))
+
+        self.assertEqual(idx.get_loc('1999', method='nearest'), 0)
+        self.assertEqual(idx.get_loc('2001', method='nearest'), 2)
+
+        with tm.assertRaises(KeyError):
+            idx.get_loc('1999', method='pad')
+        with tm.assertRaises(KeyError):
+            idx.get_loc('2001', method='backfill')
+
+        with tm.assertRaises(KeyError):
+            idx.get_loc('foobar')
+        with tm.assertRaises(TypeError):
+            idx.get_loc(slice(2))
+
+        idx = pd.to_datetime(['2000-01-01', '2000-01-04'])
+        self.assertEqual(idx.get_loc('2000-01-02', method='nearest'), 0)
+        self.assertEqual(idx.get_loc('2000-01-03', method='nearest'), 1)
+        self.assertEqual(idx.get_loc('2000-01', method='nearest'), slice(0, 2))
+
+        # time indexing
+        idx = pd.date_range('2000-01-01', periods=24, freq='H')
+        assert_array_equal(idx.get_loc(time(12)), [12])
+        assert_array_equal(idx.get_loc(time(12, 30)), [])
+        with tm.assertRaises(NotImplementedError):
+            idx.get_loc(time(12, 30), method='pad')
+
+    def test_get_indexer(self):
+        idx = pd.date_range('2000-01-01', periods=3)
+        self.assert_array_equal(idx.get_indexer(idx), [0, 1, 2])
+
+        target = idx[0] + pd.to_timedelta(['-1 hour', '12 hours', '1 day 1 hour'])
+        self.assert_array_equal(idx.get_indexer(target, 'pad'), [-1, 0, 1])
+        self.assert_array_equal(idx.get_indexer(target, 'backfill'), [0, 1, 2])
+        self.assert_array_equal(idx.get_indexer(target, 'nearest'), [0, 1, 1])
+
     def test_roundtrip_pickle_with_tz(self):
 
         # GH 8367
@@ -1959,12 +2103,56 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
     def test_pickle_compat_construction(self):
         pass
 
+    def test_get_loc(self):
+        idx = pd.period_range('2000-01-01', periods=3)
+
+        for method in [None, 'pad', 'backfill', 'nearest']:
+            self.assertEqual(idx.get_loc(idx[1], method), 1)
+            self.assertEqual(idx.get_loc(idx[1].asfreq('H', how='start'), method), 1)
+            self.assertEqual(idx.get_loc(idx[1].to_timestamp(), method), 1)
+            self.assertEqual(idx.get_loc(idx[1].to_timestamp().to_pydatetime(), method), 1)
+            self.assertEqual(idx.get_loc(str(idx[1]), method), 1)
+
+    def test_get_indexer(self):
+        idx = pd.period_range('2000-01-01', periods=3).asfreq('H', how='start')
+        self.assert_array_equal(idx.get_indexer(idx), [0, 1, 2])
+
+        target = pd.PeriodIndex(['1999-12-31T23', '2000-01-01T12',
+                                 '2000-01-02T01'], freq='H')
+        self.assert_array_equal(idx.get_indexer(target, 'pad'), [-1, 0, 1])
+        self.assert_array_equal(idx.get_indexer(target, 'backfill'), [0, 1, 2])
+        self.assert_array_equal(idx.get_indexer(target, 'nearest'), [0, 1, 1])
+
+        with self.assertRaisesRegexp(ValueError, 'different freq'):
+            idx.asfreq('D').get_indexer(idx)
+
+
 class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
     _holder = TimedeltaIndex
     _multiprocess_can_split_ = True
 
     def create_index(self):
         return pd.to_timedelta(range(5),unit='d') + pd.offsets.Hour(1)
+
+    def test_get_loc(self):
+        idx = pd.to_timedelta(['0 days', '1 days', '2 days'])
+
+        for method in [None, 'pad', 'backfill', 'nearest']:
+            self.assertEqual(idx.get_loc(idx[1], method), 1)
+            self.assertEqual(idx.get_loc(idx[1].to_pytimedelta(), method), 1)
+            self.assertEqual(idx.get_loc(str(idx[1]), method), 1)
+
+        for method, loc in [('pad', 1), ('backfill', 2), ('nearest', 1)]:
+            self.assertEqual(idx.get_loc('1 day 1 hour', method), loc)
+
+    def test_get_indexer(self):
+        idx = pd.to_timedelta(['0 days', '1 days', '2 days'])
+        self.assert_array_equal(idx.get_indexer(idx), [0, 1, 2])
+
+        target = pd.to_timedelta(['-1 hour', '12 hours', '1 day 1 hour'])
+        self.assert_array_equal(idx.get_indexer(target, 'pad'), [-1, 0, 1])
+        self.assert_array_equal(idx.get_indexer(target, 'backfill'), [0, 1, 2])
+        self.assert_array_equal(idx.get_indexer(target, 'nearest'), [0, 1, 1])
 
     def test_numeric_compat(self):
 
@@ -2733,6 +2921,9 @@ class TestMultiIndex(Base, tm.TestCase):
         self.assertRaises(KeyError, self.index.get_loc, ('bar', 'two'))
         self.assertRaises(KeyError, self.index.get_loc, 'quux')
 
+        self.assertRaises(NotImplementedError, self.index.get_loc, 'foo',
+                          method='nearest')
+
         # 3 levels
         index = MultiIndex(levels=[Index(lrange(4)),
                                    Index(lrange(4)),
@@ -2935,13 +3126,21 @@ class TestMultiIndex(Base, tm.TestCase):
         assert_almost_equal(r1, [1, 3, -1])
 
         r1 = idx2.get_indexer(idx1, method='pad')
-        assert_almost_equal(r1, [-1, 0, 0, 1, 1])
+        e1 = [-1, 0, 0, 1, 1]
+        assert_almost_equal(r1, e1)
+
+        r2 = idx2.get_indexer(idx1[::-1], method='pad')
+        assert_almost_equal(r2, e1[::-1])
 
         rffill1 = idx2.get_indexer(idx1, method='ffill')
         assert_almost_equal(r1, rffill1)
 
         r1 = idx2.get_indexer(idx1, method='backfill')
-        assert_almost_equal(r1, [0, 0, 1, 1, 2])
+        e1 = [0, 0, 1, 1, 2]
+        assert_almost_equal(r1, e1)
+
+        r2 = idx2.get_indexer(idx1[::-1], method='backfill')
+        assert_almost_equal(r2, e1[::-1])
 
         rbfill1 = idx2.get_indexer(idx1, method='bfill')
         assert_almost_equal(r1, rbfill1)
@@ -2960,6 +3159,11 @@ class TestMultiIndex(Base, tm.TestCase):
         assertRaisesRegexp(InvalidIndexError, "Reindexing only valid with"
                            " uniquely valued Index objects",
                            idx1.get_indexer, idx2)
+
+    def test_get_indexer_nearest(self):
+        midx = MultiIndex.from_tuples([('a', 1), ('b', 2)])
+        with tm.assertRaises(NotImplementedError):
+            midx.get_indexer(['a'], method='nearest')
 
     def test_format(self):
         self.index.format()

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -5862,8 +5862,9 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         result = s.reindex(new_index).ffill(downcast='infer')
         assert_series_equal(result, expected)
 
-        # invalid because we can't forward fill on this type of index
-        self.assertRaises(ValueError, lambda : s.reindex(new_index, method='ffill'))
+        expected = Series([1, 5, 3, 5], index=new_index)
+        result = s.reindex(new_index, method='ffill')
+        assert_series_equal(result, expected)
 
         # inferrence of new dtype
         s = Series([True,False,False,True],index=list('abcd'))
@@ -5877,6 +5878,16 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         result = s.shift(1).fillna(method='bfill')
         expected = Series(False,index=lrange(0,5))
         assert_series_equal(result, expected)
+
+    def test_reindex_nearest(self):
+        s = Series(np.arange(10, dtype='int64'))
+        target = [0.1, 0.9, 1.5, 2.0]
+        actual = s.reindex(target, method='nearest')
+        expected = Series(np.around(target).astype('int64'), target)
+        assert_series_equal(expected, actual)
+
+        actual = s.reindex_like(actual, method='nearest')
+        assert_series_equal(expected, actual)
 
     def test_reindex_backfill(self):
         pass

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -516,7 +516,13 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
             key = Period(key, self.freq).ordinal
             return _maybe_box(self, self._engine.get_value(s, key), series, key)
 
-    def get_loc(self, key):
+    def get_indexer(self, target, method=None, limit=None):
+        if hasattr(target, 'freq') and target.freq != self.freq:
+            raise ValueError('target and index have different freq: '
+                             '(%s, %s)' % (target.freq, self.freq))
+        return Index.get_indexer(self, target, method, limit)
+
+    def get_loc(self, key, method=None):
         """
         Get integer location for requested label
 
@@ -538,7 +544,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
 
             key = Period(key, self.freq)
             try:
-                return self._engine.get_loc(key.ordinal)
+                return Index.get_loc(self, key.ordinal, method=method)
             except KeyError:
                 raise KeyError(key)
 

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -649,7 +649,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, Int64Index):
         values = self._engine.get_value(_values_from_object(series), key)
         return _maybe_box(self, values, series, key)
 
-    def get_loc(self, key):
+    def get_loc(self, key, method=None):
         """
         Get integer location for requested label
 
@@ -659,11 +659,11 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, Int64Index):
         """
         if _is_convertible_to_td(key):
             key = Timedelta(key)
-            return self._engine.get_loc(key)
+            return Index.get_loc(self, key, method=method)
 
         try:
-            return Index.get_loc(self, key)
-        except (KeyError, ValueError):
+            return Index.get_loc(self, key, method=method)
+        except (KeyError, ValueError, TypeError):
             try:
                 return self._get_string_slice(key)
             except (TypeError, KeyError, ValueError):
@@ -671,7 +671,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, Int64Index):
 
             try:
                 stamp = Timedelta(key)
-                return self._engine.get_loc(stamp)
+                return Index.get_loc(self, stamp, method=method)
             except (KeyError, ValueError):
                 raise KeyError(key)
 

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -1544,7 +1544,7 @@ class TestPeriodIndex(tm.TestCase):
 
         df = df.set_index(idx1)
         self.assertTrue(df.index.equals(idx1))
-        df = df.reindex(idx2)
+        df = df.set_index(idx2)
         self.assertTrue(df.index.equals(idx2))
 
     def test_nested_dict_frame_constructor(self):

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -660,7 +660,8 @@ class TestTimeSeries(tm.TestCase):
     def test_pad_require_monotonicity(self):
         rng = date_range('1/1/2000', '3/1/2000', freq='B')
 
-        rng2 = rng[::2][::-1]
+        # neither monotonic increasing or decreasing
+        rng2 = rng[[1, 0, 2]]
 
         self.assertRaises(ValueError, rng2.get_indexer, rng,
                           method='pad')

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -6,7 +6,7 @@ from pandas import tslib
 import pandas._period as period
 import datetime
 
-from pandas.core.api import Timestamp, Series, Timedelta
+from pandas.core.api import Timestamp, Series, Timedelta, Period
 from pandas.tslib import get_timezone
 from pandas._period import period_asfreq, period_ordinal
 from pandas.tseries.index import date_range
@@ -137,6 +137,12 @@ class TestTimestamp(tm.TestCase):
         expected_repr = "Timestamp('2013-11-01 14:00:00+0900', tz='Asia/Tokyo')"
         self.assertEqual(repr(result), expected_repr)
         self.assertEqual(result, eval(repr(result)))
+
+    def test_constructor_invalid(self):
+        with tm.assertRaisesRegexp(TypeError, 'Cannot convert input'):
+            Timestamp(slice(2))
+        with tm.assertRaisesRegexp(ValueError, 'Cannot convert Period'):
+            Timestamp(Period('1000-01-01'))
 
     def test_conversion(self):
         # GH 9255

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -1154,8 +1154,10 @@ cdef convert_to_tsobject(object ts, object tz, object unit):
         # Keep the converter same as PyDateTime's
         ts = datetime.combine(ts, datetime_time())
         return convert_to_tsobject(ts, tz, None)
-    else:
+    elif getattr(ts, '_typ', None) == 'period':
         raise ValueError("Cannot convert Period to Timestamp unambiguously. Use to_timestamp")
+    else:
+        raise TypeError('Cannot convert input to Timestamp')
 
     if obj.value != NPY_NAT:
         _check_dts_bounds(&obj.dts)


### PR DESCRIPTION
Fixes #8845

Currently only an index method; I'm open to ideas for how to expose it more
directly -- maybe `df.loc_nearest`?.

In particular, I think this is usually a more useful way to do indexing for
floats than pandas's reindex based `.loc`, because floats are inherently
imprecise.

CC @jreback @jorisvandenbossche @immerrr @hugadams
