### PR TITLE
FIX: Add endianness missing flag when reading data

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -99,7 +99,7 @@ Bug Fixes
 
 
 
-
+- Fixed bug on bug endian platforms which produced incorrect results in ``StataReader`` (:issue:`8688`).
 
 - Bug in ``MultiIndex.has_duplicates`` when having many levels causes an indexer overflow (:issue:`9075`, :issue:`5873`)
 - Bug in ``pivot`` and `unstack`` where ``nan`` values would break index alignment (:issue:`7466`)


### PR DESCRIPTION
Added endianess flat to data type to allow data to be read cross platforms

closes #8688
