### PR TITLE
allow for empty SparseSeries SparsePanel constructors

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -202,3 +202,6 @@ Bug Fixes
 - Fixed issue in the ``xlsxwriter`` engine where it added a default 'General' format to cells if no other format wass applied. This prevented other row or column formatting being applied. (:issue:`9167`)
 - Fixes issue with ``index_col=False`` when ``usecols`` is also specified in ``read_csv``. (:issue:`9082`)
 - Bug where ``wide_to_long`` would modify the input stubnames list (:issue:`9204`)
+
+
+- ``SparseSeries`` and ``SparsePanel`` now accept zero argument constructors (same as their non-sparse counterparts) (:issue:`9272`).

--- a/pandas/sparse/panel.py
+++ b/pandas/sparse/panel.py
@@ -65,9 +65,13 @@ class SparsePanel(Panel):
     _typ = 'panel'
     _subtyp = 'sparse_panel'
 
-    def __init__(self, frames, items=None, major_axis=None, minor_axis=None,
+    def __init__(self, frames=None, items=None, major_axis=None, minor_axis=None,
                  default_fill_value=np.nan, default_kind='block',
                  copy=False):
+                 
+        if frames is None:
+            frames = {}
+            
         if isinstance(frames, np.ndarray):
             new_frames = {}
             for item, vals in zip(items, frames):

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -103,7 +103,7 @@ class SparseSeries(Series):
     """
     _subtyp = 'sparse_series'
 
-    def __init__(self, data, index=None, sparse_index=None, kind='block',
+    def __init__(self, data=None, index=None, sparse_index=None, kind='block',
                  fill_value=None, name=None, dtype=None, copy=False,
                  fastpath=False):
 
@@ -115,6 +115,9 @@ class SparseSeries(Series):
             if copy:
                 data = data.copy()
         else:
+            
+            if data is None:
+                data = []
 
             is_sparse_array = isinstance(data, SparseArray)
             if fill_value is None:

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -280,6 +280,11 @@ class TestSparseSeries(tm.TestCase,
         arr = [0, 0, 0, nan, nan]
         sp_series = SparseSeries(arr, fill_value=0)
         assert_equal(sp_series.values.values, arr)
+        
+    # GH 9272
+    def test_constructor_empty(self):
+        sp = SparseSeries()
+        self.assertEqual(len(sp.index), 0)
 
     def test_copy_astype(self):
         cop = self.bseries.astype(np.float64)
@@ -862,6 +867,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
             ValueError, "^Column length", SparseDataFrame, self.frame.values,
             columns=self.frame.columns[:-1])
 
+    # GH 9272 
     def test_constructor_empty(self):
         sp = SparseDataFrame()
         self.assertEqual(len(sp.index), 0)
@@ -1605,6 +1611,13 @@ class TestSparsePanel(tm.TestCase,
         with tm.assertRaisesRegexp(TypeError,
                                    "input must be a dict, a 'list' was passed"):
             SparsePanel(['a', 'b', 'c'])
+        
+    # GH 9272    
+    def test_constructor_empty(self):
+        sp = SparsePanel()
+        self.assertEqual(len(sp.items), 0)
+        self.assertEqual(len(sp.major_axis), 0)
+        self.assertEqual(len(sp.minor_axis), 0)
 
     def test_from_dict(self):
         fd = SparsePanel.from_dict(self.data_dict)


### PR DESCRIPTION
Closes #9272.

Note that my solution is to provide a default `data=[]` for SparseSeries and `frames={}` for SparsePanel. This differs from the dense implementations that have `None` defaults that are then changed to the above. Doesn't seem like a big deal to me, but I can do that here if needed.
