### PR TITLE
BUG: Subplotting boxplot shows unnecessary warnings

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -172,7 +172,7 @@ Bug Fixes
 
 
 
-
+- Bug in boxplot, scatter and hexbin plot may show an unnecessary warning (:issue:`8877`)
 
 
 

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1900,15 +1900,14 @@ class TestDataFramePlots(TestPlotBase):
 
         # different warning on py3
         if not PY3:
-            with tm.assert_produces_warning(UserWarning):
-                axes = _check_plot_works(df.plot, kind='box',
-                                         subplots=True, logy=True)
+            axes = _check_plot_works(df.plot, kind='box',
+                                     subplots=True, logy=True)
 
-                self._check_axes_shape(axes, axes_num=3, layout=(1, 3))
-                self._check_ax_scales(axes, yaxis='log')
-                for ax, label in zip(axes, labels):
-                    self._check_text_labels(ax.get_xticklabels(), [label])
-                    self.assertEqual(len(ax.lines), self.bp_n_objects)
+            self._check_axes_shape(axes, axes_num=3, layout=(1, 3))
+            self._check_ax_scales(axes, yaxis='log')
+            for ax, label in zip(axes, labels):
+                self._check_text_labels(ax.get_xticklabels(), [label])
+                self.assertEqual(len(ax.lines), self.bp_n_objects)
 
         axes = series.plot(kind='box', rot=40)
         self._check_ticks_props(axes, xrot=40, yrot=0)

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1451,7 +1451,10 @@ class ScatterPlot(MPLPlot):
                 kws['label'] = c if c_is_column else ''
             self.fig.colorbar(img, **kws)
 
-        self._add_legend_handle(scatter, label)
+        if label is not None:
+            self._add_legend_handle(scatter, label)
+        else:
+            self.legend = False
 
         errors_x = self._get_errorbars(label=x, index=0, yerr=False)
         errors_y = self._get_errorbars(label=y, index=0, xerr=False)
@@ -1511,6 +1514,9 @@ class HexBinPlot(MPLPlot):
         if cb:
             img = ax.collections[0]
             self.fig.colorbar(img, ax=ax)
+
+    def _make_legend(self):
+        pass
 
     def _post_plot_logic(self):
         ax = self.axes[0]
@@ -2227,6 +2233,9 @@ class BoxPlot(LinePlot):
             ax.set_xticklabels(labels)
         else:
             ax.set_yticklabels(labels)
+
+    def _make_legend(self):
+        pass
 
     def _post_plot_logic(self):
         pass


### PR DESCRIPTION
Related to #8877 and 80a730c93717e7fc01ae2f880109bc752519cecf

Because `legend=True` is default, `DataFrame.plot(kind='box', subplots=True)` shows unnecessary warnings.

```
# OK, no legend / no warnings
df.plot(kind='box')
```

```
# NG: no legend and warnings
df.plot(kind='box', subplots=True)
# UserWarning: No labelled objects found. Use label='...' kwarg on individual plots.
#   warnings.warn("No labelled objects found. "
```
