### PR TITLE
ENH: StringMethods supports is_xxx methods

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -549,6 +549,13 @@ strings and apply several methods to it. These can be acccessed like
    Series.str.strip
    Series.str.title
    Series.str.upper
+   Series.str.isalnum
+   Series.str.isalpha
+   Series.str.isdigit
+   Series.str.isspace
+   Series.str.islower
+   Series.str.isupper
+   Series.str.istitle
    Series.str.get_dummies
 
 .. _api.categorical:

--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -228,3 +228,10 @@ Method Summary
     :meth:`~Series.str.lstrip`,Equivalent to ``str.lstrip``
     :meth:`~Series.str.lower`,Equivalent to ``str.lower``
     :meth:`~Series.str.upper`,Equivalent to ``str.upper``
+    :meth:`~Series.str.isalnum`,Equivalent to ``str.isalnum``
+    :meth:`~Series.str.isalpha`,Equivalent to ``str.isalpha``
+    :meth:`~Series.str.isdigit`,Equivalent to ``str.isdigit``
+    :meth:`~Series.str.isspace`,Equivalent to ``str.isspace``
+    :meth:`~Series.str.islower`,Equivalent to ``str.islower``
+    :meth:`~Series.str.isupper`,Equivalent to ``str.isupper``
+    :meth:`~Series.str.istitle`,Equivalent to ``str.istitle``

--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -104,11 +104,12 @@ Enhancements
 - Added ``Series.str.slice_replace()``, which previously raised NotImplementedError (:issue:`8888`)
 - Added ``Timestamp.to_datetime64()`` to complement ``Timedelta.to_timedelta64()`` (:issue:`9255`)
 - ``tseries.frequencies.to_offset()`` now accepts ``Timedelta`` as input (:issue:`9064`)
-
 - ``Timedelta`` will now accept nanoseconds keyword in constructor (:issue:`9273`)
 - SQL code now safely escapes table and column names (:issue:`8986`)
 
 - Added auto-complete for ``Series.str.<tab>``, ``Series.dt.<tab>`` and ``Series.cat.<tab>`` (:issue:`9322`)
+- Added ``StringMethods.isalnum()``, ``isalpha()``, ``isdigit()``, ``isspace()``, ``islower()``,
+``isupper()``, ``istitle()`` which behave as the same as standard ``str`` (:issue:`9282`)
 
 Performance
 ~~~~~~~~~~~

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -623,6 +623,41 @@ class TestStringMethods(tm.TestCase):
         tm.assert_series_equal(empty_str, empty.str.get(0))
         tm.assert_series_equal(empty_str, empty_bytes.str.decode('ascii'))
         tm.assert_series_equal(empty_bytes, empty.str.encode('ascii'))
+        tm.assert_series_equal(empty_str, empty.str.isalnum())
+        tm.assert_series_equal(empty_str, empty.str.isalpha())
+        tm.assert_series_equal(empty_str, empty.str.isdigit())
+        tm.assert_series_equal(empty_str, empty.str.isspace())
+        tm.assert_series_equal(empty_str, empty.str.islower())
+        tm.assert_series_equal(empty_str, empty.str.isupper())
+        tm.assert_series_equal(empty_str, empty.str.istitle())
+
+    def test_ismethods(self):
+        values = ['A', 'b', 'Xy', '4', '3A', '', 'TT', '55', '-', '  ']
+        str_s = Series(values)
+        alnum_e = [True, True, True, True, True, False, True, True, False, False]
+        alpha_e = [True, True, True, False, False, False, True, False, False, False]
+        digit_e = [False, False, False, True, False, False, False, True, False, False]
+        num_e = [False, False, False, True, False, False, False, True, False, False]
+        space_e = [False, False, False, False, False, False, False, False, False, True]
+        lower_e = [False, True, False, False, False, False, False, False, False, False]
+        upper_e = [True, False, False, False, True, False, True, False, False, False]
+        title_e = [True, False, True, False, True, False, False, False, False, False]
+
+        tm.assert_series_equal(str_s.str.isalnum(), Series(alnum_e))
+        tm.assert_series_equal(str_s.str.isalpha(), Series(alpha_e))
+        tm.assert_series_equal(str_s.str.isdigit(), Series(digit_e))
+        tm.assert_series_equal(str_s.str.isspace(), Series(space_e))
+        tm.assert_series_equal(str_s.str.islower(), Series(lower_e))
+        tm.assert_series_equal(str_s.str.isupper(), Series(upper_e))
+        tm.assert_series_equal(str_s.str.istitle(), Series(title_e))
+
+        self.assertEquals(str_s.str.isalnum().tolist(), [v.isalnum() for v in values])
+        self.assertEquals(str_s.str.isalpha().tolist(), [v.isalpha() for v in values])
+        self.assertEquals(str_s.str.isdigit().tolist(), [v.isdigit() for v in values])
+        self.assertEquals(str_s.str.isspace().tolist(), [v.isspace() for v in values])
+        self.assertEquals(str_s.str.islower().tolist(), [v.islower() for v in values])
+        self.assertEquals(str_s.str.isupper().tolist(), [v.isupper() for v in values])
+        self.assertEquals(str_s.str.istitle().tolist(), [v.istitle() for v in values])
 
     def test_get_dummies(self):
         s = Series(['a|b', 'a|c', np.nan])


### PR DESCRIPTION
Derived from #9111.

Add following methods to be compat with standard `str`.
- StringMethods.isalnum
- StringMethods.isalpha
- StringMethods.isdigit
- StringMethods.isspace
- StringMethods.islower
- StringMethods.isupper
- StringMethods.istitle
