### PR TITLE
GH 9273: Timedelta constructor should accept nanoseconds keyword.

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -101,6 +101,7 @@ Enhancements
 - Added ``Timestamp.to_datetime64()`` to complement ``Timedelta.to_timedelta64()`` (:issue:`9255`)
 - ``tseries.frequencies.to_offset()`` now accepts ``Timedelta`` as input (:issue:`9064`)
 
+- ``Timedelta`` will now accept nanoseconds keyword in constructor (:issue:`9273`)
 
 Performance
 ~~~~~~~~~~~

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -683,6 +683,30 @@ class TestTimedeltas(tm.TestCase):
         actual = pd.to_timedelta(pd.NaT)
         self.assertEqual(actual.value, timedelta_NaT.astype('int64'))
 
+    def test_to_timedelta_on_nanoseconds(self):
+        # GH 9273
+        result = Timedelta(nanoseconds=100)
+        expected = Timedelta('100ns')
+        self.assertEqual(result, expected)
+
+        result = Timedelta(days=1,hours=1,minutes=1,weeks=1,seconds=1,milliseconds=1,microseconds=1,nanoseconds=1)
+        expected = Timedelta(694861001001001)
+        self.assertEqual(result, expected)
+
+        result = Timedelta(microseconds=1) + Timedelta(nanoseconds=1)
+        expected = Timedelta('1us1ns')
+        self.assertEqual(result, expected)
+
+        result = Timedelta(microseconds=1) - Timedelta(nanoseconds=1)
+        expected = Timedelta('999ns')
+        self.assertEqual(result, expected)
+
+        result = Timedelta(microseconds=1) + 5*Timedelta(nanoseconds=-2)
+        expected = Timedelta('990ns')
+        self.assertEqual(result, expected)
+
+        self.assertRaises(TypeError, lambda: Timedelta(nanoseconds='abc'))
+
     def test_timedelta_ops_with_missing_values(self):
         # setup
         s1 = pd.to_timedelta(Series(['00:00:01']))

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -1722,10 +1722,11 @@ class Timedelta(_Timedelta):
             kwargs = dict([ (k, _to_py_int_float(v)) for k, v in iteritems(kwargs) ])
 
             try:
-                value = timedelta(**kwargs)
+                nano = kwargs.pop('nanoseconds',0)
+                value = convert_to_timedelta64(timedelta(**kwargs),'ns',False) + nano
             except TypeError as e:
                 raise ValueError("cannot construct a TimeDelta from the passed arguments, allowed keywords are "
-                                 "[days, seconds, microseconds, milliseconds, minutes, hours, weeks]")
+                                 "[weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds]")
 
         if isinstance(value, Timedelta):
             value = value.value


### PR DESCRIPTION
closes #9273 

This patch adds nanoseconds keyword support in Timedelta constructor.

<pre>
In [1]: from pandas import Timedelta

In [2]: td = Timedelta(nanoseconds=1)

In [3]: td1 = Timedelta(microseconds=1)

In [4]: td.components
Out[4]: Components(days=0, hours=0, minutes=0, seconds=0, milliseconds=0, microseconds=0, nanoseconds=1)

In [5]: (td + td1).components
Out[5]: Components(days=0, hours=0, minutes=0, seconds=0, milliseconds=0, microseconds=1, nanoseconds=1)
</pre>
