### PR TITLE
TST: tests for GH4862, GH7401, GH7403, GH7405

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -146,7 +146,7 @@ Bug Fixes
 - Fixed bug on bug endian platforms which produced incorrect results in ``StataReader`` (:issue:`8688`).
 
 - Bug in ``MultiIndex.has_duplicates`` when having many levels causes an indexer overflow (:issue:`9075`, :issue:`5873`)
-- Bug in ``pivot`` and `unstack`` where ``nan`` values would break index alignment (:issue:`7466`)
+- Bug in ``pivot`` and `unstack`` where ``nan`` values would break index alignment (:issue:`4862`, :issue:`7401`, :issue:`7403`, :issue:`7405`, :issue:`7466`)
 - Bug in left ``join`` on multi-index with ``sort=True`` or null values (:issue:`9210`).
 - Bug in ``MultiIndex`` where inserting new keys would fail (:issue:`9250`).
 

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -17,7 +17,7 @@ from pandas.core.groupby import (get_group_index, _compress_group_index,
 import pandas.core.common as com
 import pandas.algos as algos
 
-from pandas.core.index import MultiIndex, _get_na_value
+from pandas.core.index import MultiIndex
 
 
 class _Unstacker(object):
@@ -198,14 +198,8 @@ class _Unstacker(object):
 
     def get_new_columns(self):
         if self.value_columns is None:
-            if self.lift == 0:
-                return self.removed_level
-
-            lev = self.removed_level
-            vals = np.insert(lev.astype('object'), 0,
-                             _get_na_value(lev.dtype.type))
-
-            return lev._shallow_copy(vals)
+            return _make_new_index(self.removed_level, None) \
+                    if self.lift != 0 else self.removed_level
 
         stride = len(self.removed_level) + self.lift
         width = len(self.value_columns)
@@ -232,18 +226,30 @@ class _Unstacker(object):
         # construct the new index
         if len(self.new_index_levels) == 1:
             lev, lab = self.new_index_levels[0], result_labels[0]
-            if not (lab == -1).any():
-                return lev.take(lab)
-
-            vals = np.insert(lev.astype('object'), len(lev),
-                             _get_na_value(lev.dtype.type)).take(lab)
-
-            return lev._shallow_copy(vals)
+            return _make_new_index(lev, lab) \
+                    if (lab == -1).any() else lev.take(lab)
 
         return MultiIndex(levels=self.new_index_levels,
                           labels=result_labels,
                           names=self.new_index_names,
                           verify_integrity=False)
+
+
+def _make_new_index(lev, lab):
+    from pandas.core.index import Index, _get_na_value
+
+    nan = _get_na_value(lev.dtype.type)
+    vals = lev.values.astype('object')
+    vals = np.insert(vals, 0, nan) if lab is None else \
+           np.insert(vals, len(vals), nan).take(lab)
+
+    try:
+        vals = vals.astype(lev.dtype, subok=False, copy=False)
+    except ValueError:
+        return Index(vals, **lev._get_attributes_dict())
+
+    return lev._shallow_copy(vals)
+
 
 def _unstack_multiple(data, clocs):
     if len(clocs) == 0:

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -5954,7 +5954,6 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         idx = pd.MultiIndex.from_arrays([[101, 102], [3.5, np.nan]])
         ts = pd.Series([1,2], index=idx)
         left = ts.unstack()
-        left.columns = left.columns.astype('float64')
         right = DataFrame([[nan, 1], [2, nan]], index=[101, 102],
                           columns=[nan, 3.5])
         assert_frame_equal(left, right)


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/4862
closes https://github.com/pydata/pandas/issues/7401
closes https://github.com/pydata/pandas/issues/7403
closes https://github.com/pydata/pandas/issues/7405

minor code change to https://github.com/pydata/pandas/pull/9061; otherwise only tests. the code change is to avoid https://github.com/pydata/pandas/issues/9170 issue.
