### PR TITLE
Update plotting.py (issue #2916)

### DIFF
--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -2906,6 +2906,7 @@ def boxplot_frame_groupby(grouped, subplots=True, column=None, fontsize=None,
     fontsize : int or string
     rot : label rotation angle
     grid : Setting this to True will show the grid
+    ax : Matplotlib axis object, default None
     figsize : A tuple (width, height) in inches
     layout : tuple (optional)
         (rows, columns) for the layout of the plot


### PR DESCRIPTION
Added ax docstring. 
Address issue generated by `scripts/find_undoc_args.py`:
[+2892 tools/plotting.py boxplot_frame_groupby()](https://github.com/pydata/pandas/blob/master/pandas/tools/plotting.py#L2892): Missing[1/9]=['ax']
