### PR TITLE
BUG 9188: concat of all-nan with empty frame produces object dtype

### DIFF
--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -4098,7 +4098,7 @@ def get_empty_dtype_and_na(join_units):
         # Null blocks should not influence upcast class selection, unless there
         # are only null blocks, when same upcasting rules must be applied to
         # null upcast classes.
-        if unit.is_null:
+        if unit.is_null and unit.shape[1] == 0:
             null_upcast_classes.add(upcast_cls)
         else:
             upcast_classes.add(upcast_cls)


### PR DESCRIPTION
My first stab at this issue. Would wait for comments and inputs. This is the behavior without the fix.

```
In [4]: df_1 = pd.DataFrame({"Row":[0,1,1], "EmptyCol":np.nan, "NumberCol":[1,2,3]})

In [5]: df_2 = pd.DataFrame(columns = df_1.columns)

In [6]: df_concat = pd.concat([df_1, df_2], axis=0)

In [7]: df_1.dtypes
Out[7]:
EmptyCol     float64
NumberCol      int64
Row            int64
dtype: object

In [8]: df_2.dtypes
Out[8]:
EmptyCol     object
NumberCol    object
Row          object
dtype: object

In [9]: df_concat.dtypes
Out[9]:
EmptyCol      object
NumberCol    float64
Row          float64
dtype: object

In [10]: df_concat
Out[10]:
  EmptyCol  NumberCol  Row
0      NaN          1    0
1      NaN          2    1
2      NaN          3    1

In [11]: df_1
Out[11]:
   EmptyCol  NumberCol  Row
0       NaN          1    0
1       NaN          2    1
2       NaN          3    1

In [12]: df_2
Out[12]:
Empty DataFrame
Columns: [EmptyCol, NumberCol, Row]
Index: []
```

Seeing this after the fix.

```
In [3]: df_1 = pd.DataFrame({"Row":[0,1,1], "EmptyCol":np.nan, "NumberCol":[1,2,3]})

In [4]: df_2 = pd.DataFrame(columns = df_1.columns)

In [5]: df_concat = pd.concat([df_1, df_2], axis=0)

In [6]: df_1.dtypes
Out[6]:
EmptyCol     float64
NumberCol      int64
Row            int64
dtype: object

In [7]: df_2.dtypes
Out[7]:
EmptyCol     object
NumberCol    object
Row          object
dtype: object

In [8]: df_concat.dtypes
Out[8]:
EmptyCol     float64
NumberCol    float64
Row          float64
dtype: object

In [9]: df_1
Out[9]:
   EmptyCol  NumberCol  Row
0       NaN          1    0
1       NaN          2    1
2       NaN          3    1

In [10]: df_2
Out[10]:
Empty DataFrame
Columns: [EmptyCol, NumberCol, Row]
Index: []

In [11]: df_concat
Out[11]:
   EmptyCol  NumberCol  Row
0       NaN          1    0
1       NaN          2    1
2       NaN          3    1
```

However this is causing `test_partial_setting_mixed_dtype` test to fail because after the fix dtypes change for df.

```
In [2]: df = DataFrame(columns=['A','B'])

In [3]: df.loc[0] = Series(1,index=range(4))

In [4]: df1 = DataFrame(columns=['A','B'],index=[0])

In [5]: df.dtypes
Out[5]:
A    float64
B    float64
dtype: object

In [6]: df1.dtypes
Out[6]:
A    object
B    object
dtype: object
```

whereas before the fix, the test was happy as all dtypes were same.

```
In [2]: df = DataFrame(columns=['A','B'])

In [3]: df.loc[0] = Series(1,index=range(4))

In [4]: df1 = DataFrame(columns=['A','B'],index=[0])

In [5]: df.dtypes
Out[5]:
A    object
B    object
dtype: object

In [6]: df1.dtypes
Out[6]:
A    object
B    object
dtype: object
```

Is it expected to preserve the test behavior?
