### PR TITLE
Fix plotting memory leak

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -141,7 +141,6 @@ Bug Fixes
 
 
 
-
 - Bug in unequal comparisons between categorical data and a scalar, which was not in the categories (e.g. ``Series(Categorical(list("abc"), ordered=True)) > "d"``. This returned ``False`` for all elements, but now raises a ``TypeError``. Equality comparisons also now return ``False`` for ``==`` and ``True`` for ``!=``. (:issue:`9848`)
 - Bug in DataFrame ``__setitem__`` when right hand side is a dictionary (:issue:`9874`)
 - Bug in ``where`` when dtype is ``datetime64/timedelta64``, but dtype of other is not (:issue:`9804`)
@@ -164,3 +163,4 @@ Bug Fixes
 
 - Fixed latex output for multi-indexed dataframes (:issue:`9778`)
 - Bug causing an exception when setting an empty range using ``DataFrame.loc`` (:issue:`9596`)
+- Fixed memory leak in ``AreaPlot`` and ``LinePlot`` that prevented calls to ``plt.close()`` from having any effect. (:issue:`9003`)


### PR DESCRIPTION
This PR resolves #9003 (and explains matplotlib/matplotlib#3892). The root cause of the memory leak is a reference cycle between `MPLPlot` objects and the `AxesSubplot` objects they create.

Specifically, a `plotf` function object is stored in `ax._plot_data` for the purposes of potentially redrawing if the data needs to be resampled. This would be fine if this were a top-level function; however, these are all nested functions that make use of `self`. This means that by `plotf` pulls in `self.ax` and `self.axes`, which point to the `AxesSubplot` that `plotf` is being attached to. We therefore have a reference cycle:

```
AxesSubplot -> AxesSubplot._plot_data -> plotf -> self -> self.ax -> AxesSubplot
```

In order to make the objects collectable, we need to either explicitly break a link or replace it with a weakref. Weakrefs don't work as `AxesSubplot` and `MPLPlot` have the same lifetime. Just not using `_plot_data` prevents the leak but breaks functionality.

The final option as I see it is to change `plotf` to not depend on `self`. This works but involves a fair amount of modifications. I elected to make each of the `plotf`s top-level functions to make the lack of `self`-dependency explicit. This also required making several other functions `classmethods` and moving some data from `MPLPlot` to the `AxesSubplot` object.

The key assumption being made by this change is that either `MPLPlot` objects are discarded immediately after use _or_ we don't want any modifications to the `MPLPlot` (e.g., adding errors post-plotting) to be reflected if redrawing. I believe both cases are true but this patch has the potential for behavioral changes if `MPLPlot` objects are regularly being retained and modified.

I've also added a memory-leak test to prevent a regression; the test fails as expected if applied without the other commits in this patch.
