### PR TITLE
DOC: delete removed Timedelta properties (see GH9257) from API overview

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -498,10 +498,7 @@ Due to implementation details the methods show up here as methods of the
    :toctree: generated/
 
    TimedeltaProperties.days
-   TimedeltaProperties.hours
-   TimedeltaProperties.minutes
    TimedeltaProperties.seconds
-   TimedeltaProperties.milliseconds
    TimedeltaProperties.microseconds
    TimedeltaProperties.nanoseconds
    TimedeltaProperties.components
@@ -1358,10 +1355,7 @@ Components
    :toctree: generated/
 
    TimedeltaIndex.days
-   TimedeltaIndex.hours
-   TimedeltaIndex.minutes
    TimedeltaIndex.seconds
-   TimedeltaIndex.milliseconds
    TimedeltaIndex.microseconds
    TimedeltaIndex.nanoseconds
    TimedeltaIndex.components

--- a/pandas/tseries/common.py
+++ b/pandas/tseries/common.py
@@ -139,6 +139,15 @@ class TimedeltaProperties(Properties):
 
     @property
     def components(self):
+        """
+        Return a dataframe of the components (days, hours, minutes,
+        seconds, milliseconds, microseconds, nanoseconds) of the Timedeltas.
+
+        Returns
+        -------
+        a DataFrame
+
+        """
         return self.values.components.set_index(self.index)
 
 TimedeltaProperties._add_delegate_accessors(delegate=TimedeltaIndex,

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -370,7 +370,8 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, Int64Index):
     @property
     def components(self):
         """
-        Return a dataframe of the components of the Timedeltas
+        Return a dataframe of the components (days, hours, minutes,
+        seconds, milliseconds, microseconds, nanoseconds) of the Timedeltas.
 
         Returns
         -------


### PR DESCRIPTION
Related to #9257. The removed TimedeltaProperties were not removed from the api.rst overview.
