### PR TITLE
ENH/DOC: reimplement Series delegates/accessors using descriptors

### DIFF
--- a/doc/_templates/autosummary/accessor_attribute.rst
+++ b/doc/_templates/autosummary/accessor_attribute.rst
@@ -1,0 +1,6 @@
+{{ fullname }}
+{{ underline }}
+
+.. currentmodule:: {{ module.split('.')[0] }}
+
+.. autoaccessorattribute:: {{ [module.split('.')[1], objname]|join('.') }}

--- a/doc/_templates/autosummary/accessor_method.rst
+++ b/doc/_templates/autosummary/accessor_method.rst
@@ -1,0 +1,6 @@
+{{ fullname }}
+{{ underline }}
+
+.. currentmodule:: {{ module.split('.')[0] }}
+
+.. autoaccessormethod:: {{ [module.split('.')[1], objname]|join('.') }}

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -449,113 +449,112 @@ Datetimelike Properties
 
 ``Series.dt`` can be used to access the values of the series as
 datetimelike and return several properties.
-Due to implementation details the methods show up here as methods of the
-``DatetimeProperties/PeriodProperties/TimedeltaProperties`` classes. These can be accessed like ``Series.dt.<property>``.
-
-.. currentmodule:: pandas.tseries.common
+These can be accessed like ``Series.dt.<property>``.
 
 **Datetime Properties**
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/accessor_attribute.rst
 
-   DatetimeProperties.date
-   DatetimeProperties.time
-   DatetimeProperties.year
-   DatetimeProperties.month
-   DatetimeProperties.day
-   DatetimeProperties.hour
-   DatetimeProperties.minute
-   DatetimeProperties.second
-   DatetimeProperties.microsecond
-   DatetimeProperties.nanosecond
-   DatetimeProperties.second
-   DatetimeProperties.weekofyear
-   DatetimeProperties.dayofweek
-   DatetimeProperties.weekday
-   DatetimeProperties.dayofyear
-   DatetimeProperties.quarter
-   DatetimeProperties.is_month_start
-   DatetimeProperties.is_month_end
-   DatetimeProperties.is_quarter_start
-   DatetimeProperties.is_quarter_end
-   DatetimeProperties.is_year_start
-   DatetimeProperties.is_year_end
+   Series.dt.date
+   Series.dt.time
+   Series.dt.year
+   Series.dt.month
+   Series.dt.day
+   Series.dt.hour
+   Series.dt.minute
+   Series.dt.second
+   Series.dt.microsecond
+   Series.dt.nanosecond
+   Series.dt.second
+   Series.dt.weekofyear
+   Series.dt.dayofweek
+   Series.dt.weekday
+   Series.dt.dayofyear
+   Series.dt.quarter
+   Series.dt.is_month_start
+   Series.dt.is_month_end
+   Series.dt.is_quarter_start
+   Series.dt.is_quarter_end
+   Series.dt.is_year_start
+   Series.dt.is_year_end
 
 **Datetime Methods**
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/accessor_method.rst
 
-   DatetimeProperties.to_period
-   DatetimeProperties.to_pydatetime
-   DatetimeProperties.tz_localize
-   DatetimeProperties.tz_convert
+   Series.dt.to_period
+   Series.dt.to_pydatetime
+   Series.dt.tz_localize
+   Series.dt.tz_convert
 
 **Timedelta Properties**
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/accessor_attribute.rst
 
-   TimedeltaProperties.days
-   TimedeltaProperties.seconds
-   TimedeltaProperties.microseconds
-   TimedeltaProperties.nanoseconds
-   TimedeltaProperties.components
+   Series.dt.days
+   Series.dt.seconds
+   Series.dt.microseconds
+   Series.dt.nanoseconds
+   Series.dt.components
 
 **Timedelta Methods**
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/accessor_method.rst
 
-   TimedeltaProperties.to_pytimedelta
+   Series.dt.to_pytimedelta
 
 String handling
 ~~~~~~~~~~~~~~~
 ``Series.str`` can be used to access the values of the series as
-strings and apply several methods to it. Due to implementation
-details the methods show up here as methods of the
-``StringMethods`` class. These can be acccessed like ``Series.str.<function/property>``.
+strings and apply several methods to it. These can be acccessed like
+``Series.str.<function/property>``.
 
 .. currentmodule:: pandas.core.strings
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/accessor_method.rst
 
-   StringMethods.cat
-   StringMethods.center
-   StringMethods.contains
-   StringMethods.count
-   StringMethods.decode
-   StringMethods.encode
-   StringMethods.endswith
-   StringMethods.extract
-   StringMethods.findall
-   StringMethods.get
-   StringMethods.join
-   StringMethods.len
-   StringMethods.lower
-   StringMethods.lstrip
-   StringMethods.match
-   StringMethods.pad
-   StringMethods.repeat
-   StringMethods.replace
-   StringMethods.rstrip
-   StringMethods.slice
-   StringMethods.slice_replace
-   StringMethods.split
-   StringMethods.startswith
-   StringMethods.strip
-   StringMethods.title
-   StringMethods.upper
-   StringMethods.get_dummies
+   Series.str.cat
+   Series.str.center
+   Series.str.contains
+   Series.str.count
+   Series.str.decode
+   Series.str.encode
+   Series.str.endswith
+   Series.str.extract
+   Series.str.findall
+   Series.str.get
+   Series.str.join
+   Series.str.len
+   Series.str.lower
+   Series.str.lstrip
+   Series.str.match
+   Series.str.pad
+   Series.str.repeat
+   Series.str.replace
+   Series.str.rstrip
+   Series.str.slice
+   Series.str.slice_replace
+   Series.str.split
+   Series.str.startswith
+   Series.str.strip
+   Series.str.title
+   Series.str.upper
+   Series.str.get_dummies
 
 .. _api.categorical:
 
 Categorical
 ~~~~~~~~~~~
-
-.. currentmodule:: pandas.core.categorical
 
 If the Series is of dtype ``category``, ``Series.cat`` can be used to change the the categorical
 data. This accessor is similar to the ``Series.dt`` or ``Series.str`` and has the
@@ -595,7 +594,6 @@ the Categorical back to a numpy array, so levels and order information is not pr
 
 Plotting
 ~~~~~~~~
-.. currentmodule:: pandas
 
 .. autosummary::
    :toctree: generated/

--- a/doc/source/reshaping.rst
+++ b/doc/source/reshaping.rst
@@ -478,7 +478,7 @@ This function is often used along with discretization functions like ``cut``:
 
    get_dummies(cut(values, bins))
 
-See also :func:`Series.str.get_dummies <pandas.core.strings.StringMethods.get_dummies>`.
+See also :func:`Series.str.get_dummies <pandas.Series.str.get_dummies>`.
 
 .. versionadded:: 0.15.0
 

--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -204,27 +204,27 @@ Method Summary
     :header: "Method", "Description"
     :widths: 20, 80
 
-    :meth:`~core.strings.StringMethods.cat`,Concatenate strings
-    :meth:`~core.strings.StringMethods.split`,Split strings on delimiter
-    :meth:`~core.strings.StringMethods.get`,Index into each element (retrieve i-th element)
-    :meth:`~core.strings.StringMethods.join`,Join strings in each element of the Series with passed separator
-    :meth:`~core.strings.StringMethods.contains`,Return boolean array if each string contains pattern/regex
-    :meth:`~core.strings.StringMethods.replace`,Replace occurrences of pattern/regex with some other string
-    :meth:`~core.strings.StringMethods.repeat`,Duplicate values (``s.str.repeat(3)`` equivalent to ``x * 3``)
-    :meth:`~core.strings.StringMethods.pad`,"Add whitespace to left, right, or both sides of strings"
-    :meth:`~core.strings.StringMethods.center`,Equivalent to ``pad(side='both')``
-    :meth:`~core.strings.StringMethods.wrap`,Split long strings into lines with length less than a given width
-    :meth:`~core.strings.StringMethods.slice`,Slice each string in the Series
-    :meth:`~core.strings.StringMethods.slice_replace`,Replace slice in each string with passed value
-    :meth:`~core.strings.StringMethods.count`,Count occurrences of pattern
-    :meth:`~core.strings.StringMethods.startswith`,Equivalent to ``str.startswith(pat)`` for each element
-    :meth:`~core.strings.StringMethods.endswith`,Equivalent to ``str.endswith(pat)`` for each element
-    :meth:`~core.strings.StringMethods.findall`,Compute list of all occurrences of pattern/regex for each string
-    :meth:`~core.strings.StringMethods.match`,"Call ``re.match`` on each element, returning matched groups as list"
-    :meth:`~core.strings.StringMethods.extract`,"Call ``re.match`` on each element, as ``match`` does, but return matched groups as strings for convenience."
-    :meth:`~core.strings.StringMethods.len`,Compute string lengths
-    :meth:`~core.strings.StringMethods.strip`,Equivalent to ``str.strip``
-    :meth:`~core.strings.StringMethods.rstrip`,Equivalent to ``str.rstrip``
-    :meth:`~core.strings.StringMethods.lstrip`,Equivalent to ``str.lstrip``
-    :meth:`~core.strings.StringMethods.lower`,Equivalent to ``str.lower``
-    :meth:`~core.strings.StringMethods.upper`,Equivalent to ``str.upper``
+    :meth:`~Series.str.cat`,Concatenate strings
+    :meth:`~Series.str.split`,Split strings on delimiter
+    :meth:`~Series.str.get`,Index into each element (retrieve i-th element)
+    :meth:`~Series.str.join`,Join strings in each element of the Series with passed separator
+    :meth:`~Series.str.contains`,Return boolean array if each string contains pattern/regex
+    :meth:`~Series.str.replace`,Replace occurrences of pattern/regex with some other string
+    :meth:`~Series.str.repeat`,Duplicate values (``s.str.repeat(3)`` equivalent to ``x * 3``)
+    :meth:`~Series.str.pad`,"Add whitespace to left, right, or both sides of strings"
+    :meth:`~Series.str.center`,Equivalent to ``pad(side='both')``
+    :meth:`~Series.str.wrap`,Split long strings into lines with length less than a given width
+    :meth:`~Series.str.slice`,Slice each string in the Series
+    :meth:`~Series.str.slice_replace`,Replace slice in each string with passed value
+    :meth:`~Series.str.count`,Count occurrences of pattern
+    :meth:`~Series.str.startswith`,Equivalent to ``str.startswith(pat)`` for each element
+    :meth:`~Series.str.endswith`,Equivalent to ``str.endswith(pat)`` for each element
+    :meth:`~Series.str.findall`,Compute list of all occurrences of pattern/regex for each string
+    :meth:`~Series.str.match`,"Call ``re.match`` on each element, returning matched groups as list"
+    :meth:`~Series.str.extract`,"Call ``re.match`` on each element, as ``match`` does, but return matched groups as strings for convenience."
+    :meth:`~Series.str.len`,Compute string lengths
+    :meth:`~Series.str.strip`,Equivalent to ``str.strip``
+    :meth:`~Series.str.rstrip`,Equivalent to ``str.rstrip``
+    :meth:`~Series.str.lstrip`,Equivalent to ``str.lstrip``
+    :meth:`~Series.str.lower`,Equivalent to ``str.lower``
+    :meth:`~Series.str.upper`,Equivalent to ``str.upper``

--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -197,6 +197,7 @@ Bug Fixes
 - Bug in groupby ``.nth()`` with a multiple column groupby (:issue:`8979`)
 - Bug in ``DataFrame.where`` and ``Series.where`` coerce numerics to string incorrectly (:issue:`9280`)
 - Bug in ``DataFrame.where`` and ``Series.where`` raise ``ValueError`` when string list-like is passed. (:issue:`9280`)
+- Accessing ``Series.str`` methods on with non-string values now raises ``TypeError`` instead of producing incorrect results (:issue:`9184`)
 
 - Fixed division by zero error for ``Series.kurt()`` when all values are equal (:issue:`9197`)
 

--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -107,6 +107,8 @@ Enhancements
 
 - ``Timedelta`` will now accept nanoseconds keyword in constructor (:issue:`9273`)
 
+- Added auto-complete for ``Series.str.<tab>``, ``Series.dt.<tab>`` and ``Series.cat.<tab>`` (:issue:`9322`)
+
 Performance
 ~~~~~~~~~~~
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -166,6 +166,28 @@ class PandasDelegate(PandasObject):
             if not hasattr(cls, name):
                 setattr(cls,name,f)
 
+
+class AccessorProperty(object):
+    """Descriptor for implementing accessor properties like Series.str
+    """
+    def __init__(self, accessor_cls, construct_accessor):
+        self.accessor_cls = accessor_cls
+        self.construct_accessor = construct_accessor
+        self.__doc__ = accessor_cls.__doc__
+
+    def __get__(self, instance, owner=None):
+        if instance is None:
+            # this ensures that Series.str.<method> is well defined
+            return self.accessor_cls
+        return self.construct_accessor(instance)
+
+    def __set__(self, instance, value):
+        raise AttributeError("can't set attribute")
+
+    def __delete__(self, instance):
+        raise AttributeError("can't delete attribute")
+
+
 class FrozenList(PandasObject, list):
 
     """

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -829,7 +829,7 @@ class Categorical(PandasObject):
         array([3, 4])	    # eggs before milk
         >>> x = pd.Categorical(['apple', 'bread', 'bread', 'cheese', 'milk', 'donuts' ])
         >>> x.searchsorted(['bread', 'eggs'], side='right', sorter=[0, 1, 2, 3, 5, 4])
-        array([3, 5])       # eggs after donuts, after switching milk and donuts 
+        array([3, 5])       # eggs after donuts, after switching milk and donuts
         """
         if not self.ordered:
             raise ValueError("searchsorted requires an ordered Categorical.")

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2,8 +2,6 @@ import numpy as np
 
 from pandas.compat import zip
 from pandas.core.common import isnull, _values_from_object
-from pandas.core.series import Series
-from pandas.core.frame import DataFrame
 import pandas.compat as compat
 import re
 import pandas.lib as lib
@@ -12,6 +10,8 @@ import textwrap
 
 
 def _get_array_list(arr, others):
+    from pandas.core.series import Series
+
     if len(others) and isinstance(_values_from_object(others)[0],
                                   (list, np.ndarray, Series)):
         arrays = [arr] + list(others)
@@ -95,6 +95,8 @@ def _na_map(f, arr, na_result=np.nan, dtype=object):
 
 
 def _map(f, arr, na_mask=False, na_value=np.nan, dtype=object):
+    from pandas.core.series import Series
+
     if not len(arr):
         return np.ndarray(0, dtype=dtype)
 
@@ -459,6 +461,9 @@ def str_extract(arr, pat, flags=0):
     2    NaN   NaN
 
     """
+    from pandas.core.series import Series
+    from pandas.core.frame import DataFrame
+
     regex = re.compile(pat, flags=flags)
     # just to be safe, check this
     if regex.groups == 0:
@@ -510,6 +515,8 @@ def str_get_dummies(arr, sep='|'):
     See also ``pd.get_dummies``.
 
     """
+    from pandas.core.frame import DataFrame
+
     # TODO remove this hack?
     arr = arr.fillna('')
     try:
@@ -643,6 +650,9 @@ def str_split(arr, pat=None, n=None, return_type='series'):
     -------
     split : array
     """
+    from pandas.core.series import Series
+    from pandas.core.frame import DataFrame
+
     if return_type not in ('series', 'frame'):
         raise ValueError("return_type must be {'series', 'frame'}")
     if pat is None:
@@ -949,6 +959,9 @@ class StringMethods(object):
             g = self.get(i)
 
     def _wrap_result(self, result):
+        from pandas.core.series import Series
+        from pandas.core.frame import DataFrame
+
         if not hasattr(result, 'ndim'):
             return result
         elif result.ndim == 1:

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -2522,6 +2522,8 @@ class TestCategoricalAsBlock(tm.TestCase):
         self.assertIs(Series.cat, CategoricalAccessor)
         s = Series(list('aabbcde')).astype('category')
         self.assertIsInstance(s.cat, CategoricalAccessor)
+        with tm.assertRaisesRegexp(TypeError, "only use .cat accessor"):
+            Series([1]).cat
 
     def test_pickle_v0_14_1(self):
         cat = pd.Categorical(values=['a', 'b', 'c'],

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -909,8 +909,8 @@ class TestCategorical(tm.TestCase):
         exp = np.array([1])
         self.assert_numpy_array_equal(res, exp)
         self.assert_numpy_array_equal(res, chk)
-       
-        # Searching for a value that is not present in the Categorical 
+
+        # Searching for a value that is not present in the Categorical
         res = c1.searchsorted(['bread', 'eggs'])
         chk = s1.searchsorted(['bread', 'eggs'])
         exp = np.array([1, 4])
@@ -927,7 +927,7 @@ class TestCategorical(tm.TestCase):
         # As above, but with a sorter array to reorder an unsorted array
         res = c2.searchsorted(['bread', 'eggs'], side='right', sorter=[0, 1, 2, 3, 5, 4])
         chk = s2.searchsorted(['bread', 'eggs'], side='right', sorter=[0, 1, 2, 3, 5, 4])
-        exp = np.array([3, 5])       # eggs after donuts, after switching milk and donuts 
+        exp = np.array([3, 5])       # eggs after donuts, after switching milk and donuts
         self.assert_numpy_array_equal(res, exp)
         self.assert_numpy_array_equal(res, chk)
 
@@ -2515,6 +2515,13 @@ class TestCategoricalAsBlock(tm.TestCase):
         s = Series(list('aabbcde')).astype('category')
         results = get_dir(s)
         tm.assert_almost_equal(results,list(sorted(set(ok_for_cat))))
+
+    def test_cat_accessor_api(self):
+        # GH 9322
+        from pandas.core.categorical import CategoricalAccessor
+        self.assertIs(Series.cat, CategoricalAccessor)
+        s = Series(list('aabbcde')).astype('category')
+        self.assertIsInstance(s.cat, CategoricalAccessor)
 
     def test_pickle_v0_14_1(self):
         cat = pd.Categorical(values=['a', 'b', 'c'],

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -240,6 +240,9 @@ class CheckNameIntegration(object):
         s = Series(date_range('2000-01-01', periods=3))
         self.assertIsInstance(s.dt, DatetimeProperties)
 
+        with tm.assertRaisesRegexp(TypeError, "only use .dt accessor"):
+            Series([1]).dt
+
     def test_binop_maybe_preserve_name(self):
 
         # names match, preserve
@@ -5411,9 +5414,14 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         tm.assert_frame_equal(result, expected)
 
         # empty series
-        s = Series()
+        s = Series(dtype=object, name='foo', index=pd.Index([], name='bar'))
         rs = s.apply(lambda x: x)
         tm.assert_series_equal(s, rs)
+        # check all metadata (GH 9322)
+        self.assertIsNot(s, rs)
+        self.assertIs(s.index, rs.index)
+        self.assertEqual(s.dtype, rs.dtype)
+        self.assertEqual(s.name, rs.name)
 
         # index but no data
         s = Series(index=[1, 2, 3])

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -231,6 +231,15 @@ class CheckNameIntegration(object):
         expected = Series([time(0),time(0),np.nan,time(0),time(0)],dtype='object')
         tm.assert_series_equal(result, expected)
 
+    def test_dt_accessor_api(self):
+        # GH 9322
+        from pandas.tseries.common import (CombinedDatetimelikeProperties,
+                                           DatetimeProperties)
+        self.assertIs(Series.dt, CombinedDatetimelikeProperties)
+
+        s = Series(date_range('2000-01-01', periods=3))
+        self.assertIsInstance(s.dt, DatetimeProperties)
+
     def test_binop_maybe_preserve_name(self):
 
         # names match, preserve

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -32,8 +32,9 @@ class TestStringMethods(tm.TestCase):
 
     def test_api(self):
 
-        # GH 6106
-        self.assertIsNone(Series.str)
+        # GH 6106, GH 9322
+        self.assertIs(Series.str, strings.StringMethods)
+        self.assertIsInstance(Series(['']).str, strings.StringMethods)
 
     def test_iter(self):
         # GH3638

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -36,6 +36,10 @@ class TestStringMethods(tm.TestCase):
         self.assertIs(Series.str, strings.StringMethods)
         self.assertIsInstance(Series(['']).str, strings.StringMethods)
 
+        # GH 9184
+        with tm.assertRaisesRegexp(TypeError, "only use .str accessor"):
+            Series([1]).str
+
     def test_iter(self):
         # GH3638
         strs = 'google', 'wikimedia', 'wikipedia', 'wikitravel'
@@ -79,26 +83,6 @@ class TestStringMethods(tm.TestCase):
 
         self.assertFalse(i)
         assert_series_equal(ds, s)
-
-    def test_iter_numeric_try_string(self):
-        # behavior identical to empty series
-        dsi = Series(lrange(4))
-
-        i, s = 100, 'h'
-
-        for i, s in enumerate(dsi.str):
-            pass
-
-        self.assertEqual(i, 100)
-        self.assertEqual(s, 'h')
-
-        dsf = Series(np.arange(4.))
-
-        for i, s in enumerate(dsf.str):
-            pass
-
-        self.assertEqual(i, 100)
-        self.assertEqual(s, 'h')
 
     def test_iter_object_try_string(self):
         ds = Series([slice(None, randint(10), randint(10, 20))

--- a/pandas/tseries/common.py
+++ b/pandas/tseries/common.py
@@ -3,7 +3,9 @@
 import numpy as np
 from pandas.core.base import PandasDelegate
 from pandas.core import common as com
-from pandas import Series, DatetimeIndex, PeriodIndex, TimedeltaIndex
+from pandas.tseries.index import DatetimeIndex
+from pandas.tseries.period import PeriodIndex
+from pandas.tseries.tdi import TimedeltaIndex
 from pandas import lib, tslib
 from pandas.core.common import (_NS_DTYPE, _TD_DTYPE, is_period_arraylike,
                                 is_datetime_arraylike, is_integer_dtype, is_list_like,
@@ -35,6 +37,7 @@ def maybe_to_datetimelike(data, copy=False):
     DelegatedClass
 
     """
+    from pandas import Series
 
     if not isinstance(data, Series):
         raise TypeError("cannot convert an object of type {0} to a datetimelike index".format(type(data)))
@@ -59,6 +62,8 @@ class Properties(PandasDelegate):
         self.index = index
 
     def _delegate_property_get(self, name):
+        from pandas import Series
+
         result = getattr(self.values,name)
 
         # maybe need to upcast (ints)
@@ -82,6 +87,8 @@ class Properties(PandasDelegate):
                          "supported. Change values on the original.")
 
     def _delegate_method(self, name, *args, **kwargs):
+        from pandas import Series
+
         method = getattr(self.values, name)
         result = method(*args, **kwargs)
 
@@ -174,6 +181,14 @@ class PeriodProperties(Properties):
 PeriodProperties._add_delegate_accessors(delegate=PeriodIndex,
                                          accessors=PeriodIndex._datetimelike_ops,
                                          typ='property')
+
+
+class CombinedDatetimelikeProperties(DatetimeProperties, TimedeltaProperties):
+    # This class is never instantiated, and exists solely for the benefit of
+    # the Series.dt class property. For Series objects, .dt will always be one
+    # of the more specific classes above.
+    __doc__ = DatetimeProperties.__doc__
+
 
 def _concat_compat(to_concat, axis=0):
     """


### PR DESCRIPTION
Fixes #9184

This PR fixes the API docs to use `Series.str` and `Series.dt` instead of `StringMethods` and `DatetimeProperties`.

It will need a rebase once #9318 is merged.

CC @jorisvandenbossche @jreback
