### PR TITLE
GH 9016: Bitwise operation weirdness

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -88,6 +88,35 @@ Backwards incompatible API changes
 The prior style can be achieved with matplotlib's `axhline` or `axvline`
 methods (:issue:`9088`).
 
+
+- ``Series`` now supports bitwise operation for integral types (:issue:`9016`)
+
+  Previously even if the input dtypes where integral, the output dtype was coerced to bool.
+
+  .. code-block:: python
+    In [2]: pd.Series([0,1,2,3], list('abcd')) | pd.Series([4,4,4,4], list('abcd'))
+    Out[2]:
+    a    True
+    b    True
+    c    True
+    d    True
+    dtype: bool
+
+  Now if the input dtypes are integral, the output dtype is also integral and the output
+  values are the result of the bitwise operation.
+
+  .. code-block:: python
+
+    In [2]: pd.Series([0,1,2,3], list('abcd')) | pd.Series([4,4,4,4], list('abcd'))
+    Out[2]:
+    a    4
+    b    5
+    c    6
+    d    7
+    dtype: int64
+
+
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -654,20 +654,31 @@ def _bool_method_SERIES(op, name, str_rep):
         return result
 
     def wrapper(self, other):
+        is_self_int_dtype = com.is_integer_dtype(self.dtype)
+
+        fill_int = lambda x: x.fillna(0)
+        fill_bool = lambda x: x.fillna(False).astype(bool)
+
         if isinstance(other, pd.Series):
             name = _maybe_match_name(self, other)
+            other = other.reindex_like(self)
+            is_other_int_dtype = com.is_integer_dtype(other.dtype)
+            other = fill_int(other) if is_other_int_dtype else fill_bool(other)
 
-            other = other.reindex_like(self).fillna(False).astype(bool)
-            return self._constructor(na_op(self.values, other.values),
+            filler = fill_int if is_self_int_dtype and is_other_int_dtype else fill_bool
+            return filler(self._constructor(na_op(self.values, other.values),
                                      index=self.index,
-                                     name=name).fillna(False).astype(bool)
+                                     name=name))
+
         elif isinstance(other, pd.DataFrame):
             return NotImplemented
+
         else:
-            # scalars
-            res = self._constructor(na_op(self.values, other),
-                                    index=self.index).fillna(False)
-            return res.astype(bool).__finalize__(self)
+            # scalars, list, tuple, np.array
+            filler = fill_int if is_self_int_dtype and com.is_integer_dtype(np.asarray(other)) else fill_bool
+            return filler(self._constructor(na_op(self.values, other),
+                                    index=self.index)).__finalize__(self)
+
     return wrapper
 
 


### PR DESCRIPTION
Series now supports bitwise op for integral types. 

I have made the changes in wrapper() itself instead of na_op() because it looked to me like wrapper is controlling the input and output fill and dtype. Once that is taken care of, na_op() seems to be doing the right thing by itself and so I did not have to change anything to get back the expected behavior. Happy to change if things need to be altered toward better design etc.
