### PR TITLE
TST add a test for repeat() method with MultiIndex, referenced in #9361

### DIFF
--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2261,6 +2261,14 @@ Thur,Lunch,Yes,51.51,17"""
         self.assertTrue(df.index.get_level_values(1).equals(idx2))
         self.assertTrue(df.index.get_level_values(2).equals(idx3))
 
+    def test_repeat(self):
+        # GH 9361
+        m_idx = pd.MultiIndex.from_tuples([(1, 2), (3, 4),
+                                           (5, 6), (7, 8)])
+        data = ['a', 'b', 'c', 'd']
+        m_df = pd.Series(data, index=m_idx)
+        assert m_df.repeat(3).shape == (3 * len(data),)
+
 
 if __name__ == '__main__':
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2263,6 +2263,7 @@ Thur,Lunch,Yes,51.51,17"""
 
     def test_repeat(self):
         # GH 9361
+        # fixed by # GH 7891
         m_idx = pd.MultiIndex.from_tuples([(1, 2), (3, 4),
                                            (5, 6), (7, 8)])
         data = ['a', 'b', 'c', 'd']


### PR DESCRIPTION
This was fixed in 0.15, presumably by #7891
