### PR TITLE
PERF: nunique perf improved by using len(unique) rather than value_counts

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -440,9 +440,10 @@ class IndexOpsMixin(object):
         -------
         nunique : int
         """
+        result = self.unique()
         if dropna:
-            return len(set(self.unique()) - {None})
-        return len(self.unique())
+            return len(result) - np.isnan(np.sum(result))
+        return len(result)
 
     def factorize(self, sort=False, na_sentinel=-1):
         """

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -440,7 +440,9 @@ class IndexOpsMixin(object):
         -------
         nunique : int
         """
-        return len(self.value_counts(dropna=dropna))
+        if dropna:
+            return len(set(self.unique()) - {None})
+        return len(self.unique())
 
     def factorize(self, sort=False, na_sentinel=-1):
         """


### PR DESCRIPTION
Before:

```
In [1]: s=pandas.Series(range(100)*1000)
In [2]: %timeit s.nunique()
1000 loops, best of 3: 1.43 ms per loop
```

After:

```
In [1]: s=pandas.Series(range(100)*1000)
In [4]: %timeit s.nunique()
1000 loops, best of 3: 440 µs per loop
```
