### PR TITLE
bug in groupby when key space exceeds int64 bounds

### DIFF
--- a/bench/bench_groupby.py
+++ b/bench/bench_groupby.py
@@ -47,7 +47,8 @@ shape = [len(ping.ids) for ping in grouped.groupings]
 from pandas.core.groupby import get_group_index
 
 
-group_index = get_group_index(label_list, shape).astype('i4')
+group_index = get_group_index(label_list, shape,
+                              sort=True, xnull=True).astype('i4')
 
 ngroups = np.prod(shape)
 

--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -156,6 +156,7 @@ Bug Fixes
 - Bug in ``pivot`` and `unstack`` where ``nan`` values would break index alignment (:issue:`4862`, :issue:`7401`, :issue:`7403`, :issue:`7405`, :issue:`7466`)
 - Bug in left ``join`` on multi-index with ``sort=True`` or null values (:issue:`9210`).
 - Bug in ``MultiIndex`` where inserting new keys would fail (:issue:`9250`).
+- Bug in ``groupby`` when key space exceeds ``int64`` bounds (:issue:`9096`).
 
 
 - Fixed character encoding bug in ``read_stata`` and ``StataReader`` when loading data from a URL (:issue:`9231`).

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -3229,11 +3229,11 @@ class MultiIndex(Index):
 
     @Appender(_shared_docs['duplicated'] % _index_doc_kwargs)
     def duplicated(self, take_last=False):
-        from pandas.core.groupby import get_flat_ids
+        from pandas.core.groupby import get_group_index
         from pandas.hashtable import duplicated_int64
 
         shape = map(len, self.levels)
-        ids = get_flat_ids(self.labels, shape, False)
+        ids = get_group_index(self.labels, shape, sort=False, xnull=False)
 
         return duplicated_int64(ids, take_last)
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -261,6 +261,21 @@ def test_quantile():
     expected = algos.quantile(s.values, [0, .25, .5, .75, 1.])
     tm.assert_almost_equal(result, expected)
 
+def test_unique_label_indices():
+    from pandas.hashtable import unique_label_indices
+
+    a = np.random.randint(1, 1 << 10, 1 << 15).astype('i8')
+
+    left = unique_label_indices(a)
+    right = np.unique(a, return_index=True)[1]
+
+    tm.assert_array_equal(left, right)
+
+    a[np.random.choice(len(a), 10)] = -1
+    left= unique_label_indices(a)
+    right = np.unique(a, return_index=True)[1][1:]
+    tm.assert_array_equal(left, right)
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/vb_suite/groupby.py
+++ b/vb_suite/groupby.py
@@ -485,6 +485,22 @@ df = DataFrame(np.random.randint(1, n / 100, (n, 3)),
 groupby_agg_builtins1 = Benchmark("df.groupby('jim').agg([sum, min, max])", setup)
 groupby_agg_builtins2 = Benchmark("df.groupby(['jim', 'joe']).agg([sum, min, max])", setup)
 
+
+setup = common_setup + '''
+arr = np.random.randint(- 1 << 12, 1 << 12, (1 << 17, 5))
+i = np.random.choice(len(arr), len(arr) * 5)
+arr = np.vstack((arr, arr[i]))  # add sume duplicate rows
+
+i = np.random.permutation(len(arr))
+arr = arr[i]  # shuffle rows
+
+df = DataFrame(arr, columns=list('abcde'))
+df['jim'], df['joe'] = np.random.randn(2, len(df)) * 10
+'''
+
+groupby_int64_overflow = Benchmark("df.groupby(list('abcde')).max()", setup,
+                                   name='groupby_int64_overflow')
+
 #----------------------------------------------------------------------
 # groupby with a variable value for ngroups
 


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/9096

also improves performance when there is `int64` overflow; complete groupby benchmarks [here](https://gist.github.com/behzadnouri/e142fbd65f41357a7360).

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
groupby_int64_overflow                       | 637.6967 | 3021.1190 |   0.2111 |
-------------------------------------------------------------------------------

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [d6e3cb7] : bug in groupby when key space exceeds int64 bounds
Base   [391f46a] : BUG: allow for empty SparseSeries SparsePanel constructors (GH9272)
```
