### PR TITLE
DOC: further clean-up of removed timedelta attributes in whatsnew docs

### DIFF
--- a/doc/source/whatsnew/v0.15.0.txt
+++ b/doc/source/whatsnew/v0.15.0.txt
@@ -111,16 +111,25 @@ This type is very similar to how ``Timestamp`` works for ``datetimes``. It is a 
 
    ``Timedelta`` scalars (and ``TimedeltaIndex``) component fields are *not the same* as the component fields on a ``datetime.timedelta`` object. For example, ``.seconds`` on a ``datetime.timedelta`` object returns the total number of seconds combined between ``hours``, ``minutes`` and ``seconds``. In contrast, the pandas ``Timedelta`` breaks out hours, minutes, microseconds and nanoseconds separately.
 
-   .. ipython:: python
+   .. code-block:: python
 
       # Timedelta accessor
-      tds = Timedelta('31 days 5 min 3 sec')
-      tds.minutes
-      tds.seconds
+      In [9]: tds = Timedelta('31 days 5 min 3 sec')
+
+      In [10]: tds.minutes
+      Out[10]: 5L
+
+      In [11]: tds.seconds
+      Out[11]: 3L
 
       # datetime.timedelta accessor
       # this is 5 minutes * 60 + 3 seconds
-      tds.to_pytimedelta().seconds
+      In [12]: tds.to_pytimedelta().seconds
+      Out[12]: 303
+
+   **Note**: this is no longer true starting from v0.16.0, where full
+   compatibility with ``datetime.timedelta`` is introduced. See the
+   :ref:`0.16.0 whatsnew entry <whatsnew_0160.api_breaking.timedelta>`
 
 .. warning::
 
@@ -149,8 +158,7 @@ Access fields for a ``Timedelta``
 .. ipython:: python
 
    td = Timedelta('1 hour 3m 15.5us')
-   td.hours
-   td.minutes
+   td.seconds
    td.microseconds
    td.nanoseconds
 

--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -22,14 +22,29 @@ New features
 
 .. _whatsnew_0160.api:
 
+.. _whatsnew_0160.api_breaking:
+
 Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. _whatsnew_0160.api_breaking:
+.. _whatsnew_0160.api_breaking.timedelta:
 
-- In v0.15.0 a new scalar type ``Timedelta`` was introduced, that is a sub-class of ``datetime.timedelta``. Mentioned :ref:`here <whatsnew_0150.timedeltaindex>` was a notice of an API change w.r.t. the ``.seconds`` accessor. The intent was to provide a user-friendly set of accessors that give the 'natural' value for that unit, e.g. if you had a ``Timedelta('1 day, 10:11:12')``, then ``.seconds`` would return 12. However, this is at odds with the definition of ``datetime.timedelta``, which defines ``.seconds`` as ``10 * 3600 + 11 * 60 + 12 == 36672``.
+- In v0.15.0 a new scalar type ``Timedelta`` was introduced, that is a
+  sub-class of ``datetime.timedelta``.
+  Mentioned :ref:`here <whatsnew_0150.timedeltaindex>` was a notice of an API
+  change w.r.t. the ``.seconds`` accessor. The intent was to provide a
+  user-friendly set of accessors that give the 'natural' value for that unit,
+  e.g. if you had a ``Timedelta('1 day, 10:11:12')``, then ``.seconds`` would
+  return 12. However, this is at odds with the definition of
+  ``datetime.timedelta``, which defines ``.seconds`` as
+  ``10 * 3600 + 11 * 60 + 12 == 36672``.
 
-  So in v0.16.0, we are restoring the API to match that of ``datetime.timedelta``. Further, the component values are still available through the ``.components`` accessor. This affects the ``.seconds`` and ``.microseconds`` accessors, and removes the ``.hours``, ``.minutes``, ``.milliseconds`` accessors. These changes affect ``TimedeltaIndex`` and the Series ``.dt`` accessor as well. (:issue:`9185`, :issue:`9139`)
+  So in v0.16.0, we are restoring the API to match that of
+  ``datetime.timedelta``. Further, the component values are still available
+  through the ``.components`` accessor. This affects the ``.seconds`` and
+  ``.microseconds`` accessors, and removes the ``.hours``, ``.minutes``,
+  ``.milliseconds`` accessors. These changes affect ``TimedeltaIndex``
+  and the Series ``.dt`` accessor as well. (:issue:`9185`, :issue:`9139`)
 
   Previous Behavior
 


### PR DESCRIPTION
Follow-up #9318 (and that one from #9257).

whatsnew v0.15.0 was giving some errors now, so made it into a code-block
