### PR TITLE
ENH: Add StringMethods.zfill

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -551,6 +551,7 @@ strings and apply several methods to it. These can be acccessed like
    Series.str.strip
    Series.str.title
    Series.str.upper
+   Series.str.zfill
    Series.str.isalnum
    Series.str.isalpha
    Series.str.isdigit

--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -215,6 +215,7 @@ Method Summary
     :meth:`~Series.str.center`,Equivalent to ``str.center``
     :meth:`~Series.str.ljust`,Equivalent to ``str.ljust``
     :meth:`~Series.str.rjust`,Equivalent to ``str.rjust``
+    :meth:`~Series.str.zfill`,Equivalent to ``str.zfill``
     :meth:`~Series.str.wrap`,Split long strings into lines with length less than a given width
     :meth:`~Series.str.slice`,Slice each string in the Series
     :meth:`~Series.str.slice_replace`,Replace slice in each string with passed value

--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -116,6 +116,7 @@ Enhancements
 
 - Added ``StringMethods.ljust()`` and ``rjust()`` which behave as the same as standard ``str`` (:issue:`9352`)
 - ``StringMethods.pad()`` and ``center()`` now accept `fillchar` option to specify filling character (:issue:`9352`)
+- Added ``StringMethods.zfill()`` which behave as the same as standard ``str`` (:issue:`9387`)
 
 Performance
 ~~~~~~~~~~~

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -977,7 +977,7 @@ class StringMethods(object):
         return self._wrap_result(result)
 
     _shared_docs['str_pad'] = ("""
-    "Center" strings, filling %s side with an additional character
+    Filling %s side of strings with an additional character
 
     Parameters
     ----------
@@ -989,7 +989,7 @@ class StringMethods(object):
 
     Returns
     -------
-    centered : array
+    filled : array
     """)
 
     @Appender(_shared_docs['str_pad'] % 'left and right')
@@ -1003,6 +1003,23 @@ class StringMethods(object):
     @Appender(_shared_docs['str_pad'] % 'left')
     def rjust(self, width, fillchar=' '):
         return self.pad(width, side='left', fillchar=fillchar)
+
+    def zfill(self, width):
+        """"
+        Filling left side with 0
+
+        Parameters
+        ----------
+        width : int
+            Minimum width of resulting string; additional characters will be filled
+            with 0
+
+        Returns
+        -------
+        filled : array
+        """
+        result = str_pad(self.series, width, side='left', fillchar='0')
+        return self._wrap_result(result)
 
     @copy(str_slice)
     def slice(self, start=None, stop=None, step=None):

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -925,6 +925,26 @@ class TestStringMethods(tm.TestCase):
         with tm.assertRaisesRegexp(TypeError, "fillchar must be a character, not int"):
             result = values.str.rjust(5, fillchar=1)
 
+    def test_zfill(self):
+        values = Series(['1', '22', 'aaa', '333', '45678'])
+
+        result = values.str.zfill(5)
+        expected = Series(['00001', '00022', '00aaa', '00333', '45678'])
+        tm.assert_series_equal(result, expected)
+        expected = np.array([v.zfill(5) for v in values.values])
+        tm.assert_numpy_array_equal(result.values, expected)
+
+        result = values.str.zfill(3)
+        expected = Series(['001', '022', 'aaa', '333', '45678'])
+        tm.assert_series_equal(result, expected)
+        expected = np.array([v.zfill(3) for v in values.values])
+        tm.assert_numpy_array_equal(result.values, expected)
+
+        values = Series(['1', np.nan, 'aaa', np.nan, '45678'])
+        result = values.str.zfill(5)
+        expected = Series(['00001', np.nan, '00aaa', np.nan, '45678'])
+        tm.assert_series_equal(result, expected)
+
     def test_split(self):
         values = Series(['a_b_c', 'c_d_e', NA, 'f_g_h'])
 


### PR DESCRIPTION
Derived from #9111. Fixed docstring of `str_pad` which is inprecise.
