### PR TITLE
MAINT: get rid of some compiler warnings

### DIFF
--- a/pandas/src/datetime/np_datetime_strings.c
+++ b/pandas/src/datetime/np_datetime_strings.c
@@ -117,6 +117,7 @@ fail:
     return -1;
 }
 
+#if 0
 /*
  * Wraps `gmtime` functionality for multiple platforms. This
  * converts a time value to a time structure in UTC.
@@ -161,6 +162,7 @@ fail:
                                 "to a UTC time", func_name);
     return -1;
 }
+#endif
 
 /*
  * Converts a datetimestruct in UTC to a datetimestruct in local time,
@@ -1144,7 +1146,7 @@ make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
 #ifdef _WIN32
     tmplen = _snprintf(substr, sublen, "%04" NPY_INT64_FMT, dts->year);
 #else
-    tmplen = snprintf(substr, sublen, "%04" NPY_INT64_FMT, (long long)dts->year);
+    tmplen = snprintf(substr, sublen, "%04" NPY_INT64_FMT, dts->year);
 #endif
     /* If it ran out of space or there isn't space for the NULL terminator */
     if (tmplen < 0 || tmplen > sublen) {

--- a/pandas/src/parse_helper.h
+++ b/pandas/src/parse_helper.h
@@ -6,7 +6,7 @@ static double xstrtod(const char *p, char **q, char decimal, char sci,
 
 int to_double(char *item, double *p_value, char sci, char decimal, int *maybe_int)
 {
-    char *p_end;
+    char *p_end = NULL;
 
     *p_value = xstrtod(item, &p_end, decimal, sci, 1, maybe_int);
 

--- a/pandas/src/period_helper.h
+++ b/pandas/src/period_helper.h
@@ -166,5 +166,5 @@ double getAbsTime(int freq, npy_int64 dailyDate, npy_int64 originalDate);
 char *c_strftime(struct date_info *dinfo, char *fmt);
 int get_yq(npy_int64 ordinal, int freq, int *quarter, int *year);
 
-void initialize_daytime_conversion_factor_matrix();
+void initialize_daytime_conversion_factor_matrix(void);
 #endif

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -29,7 +29,7 @@ cdef extern from "datetime_helper.h":
     double total_seconds(object)
 
 # this is our datetime.pxd
-from datetime cimport *
+from datetime cimport cmp_pandas_datetimestruct
 from util cimport is_integer_object, is_float_object, is_datetime64_object, is_timedelta64_object
 
 from libc.stdlib cimport free


### PR DESCRIPTION
- uninitialized pointer
- unused variables
- unused function
- ISO C prototypes
- `cimport *`
- useless cast before `snprintf`
