### PR TITLE
PERF: improves performance and memory usage of DataFrame.duplicated

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -208,6 +208,7 @@ Performance
 - Performance and memory usage improvements in ``merge`` when key space exceeds ``int64`` bounds (:issue:`9151`)
 - Performance improvements in multi-key ``groupby`` (:issue:`9429`)
 - Performance improvements in ``MultiIndex.sortlevel`` (:issue:`9445`)
+- Performance and memory usage improvements in ``DataFrame.duplicated`` (:issue:`9398`)
 - Cythonized ``Period`` (:issue:`9440`)
 
 Bug Fixes

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -1278,7 +1278,7 @@ def fast_zip_fillna(list ndarrays, fill_value=pandas_null):
 def duplicated(ndarray[object] values, take_last=False):
     cdef:
         Py_ssize_t i, n
-        dict seen = {}
+        set seen = set()
         object row
 
     n = len(values)
@@ -1291,7 +1291,7 @@ def duplicated(ndarray[object] values, take_last=False):
             if row in seen:
                 result[i] = 1
             else:
-                seen[row] = None
+                seen.add(row)
                 result[i] = 0
     else:
         for i from 0 <= i < n:
@@ -1299,7 +1299,7 @@ def duplicated(ndarray[object] values, take_last=False):
             if row in seen:
                 result[i] = 1
             else:
-                seen[row] = None
+                seen.add(row)
                 result[i] = 0
 
     return result.view(np.bool_)

--- a/vb_suite/frame_methods.py
+++ b/vb_suite/frame_methods.py
@@ -506,3 +506,17 @@ frame_from_records_generator_nrows = Benchmark('df = DataFrame.from_records(get_
                                 setup,
                                 name='frame_from_records_generator_nrows',
                                 start_date=datetime(2013,10,04))  # issue-4911
+
+setup = common_setup + '''
+n = 1 << 20
+
+t = date_range('2015-01-01', freq='S', periods=n // 64)
+xs = np.random.randn(n // 64).round(2)
+
+df = DataFrame({'a':np.random.randint(- 1 << 8, 1 << 8, n),
+                'b':np.random.choice(t, n),
+                'c':np.random.choice(xs, n)})
+'''
+
+frame_duplicated = Benchmark('df.duplicated()', setup,
+                             name='frame_duplicated')


### PR DESCRIPTION
on master:

```
In [1]: np.random.seed(2718281)

In [2]: n = 1 << 20

In [3]: t = pd.date_range('2015-01-01', freq='S', periods=n // 64)

In [4]: xs = np.random.randn(n // 64).round(2)

In [5]: df = DataFrame({'a':np.random.randint(- 1 << 8, 1 << 8, n),
   ...:                 'b':np.random.choice(t, n),
   ...:                 'c':np.random.choice(xs, n)})

In [6]: %timeit df.duplicated()
1 loops, best of 3: 8.03 s per loop

In [7]: %memit df.duplicated()
peak memory: 461.79 MiB, increment: 356.10 MiB
```

on branch:

```
In [6]: %timeit df.duplicated()
1 loops, best of 3: 259 ms per loop

In [7]: %memit df.duplicated()
peak memory: 154.62 MiB, increment: 49.36 MiB
```

benchmarks:

```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
frame_duplicated                             | 308.4060 | 7809.8300 |   0.0395 |
frame_drop_duplicates                        |  16.1637 |  28.8030 |   0.5612 |
frame_drop_duplicates_na                     |  17.1696 |  28.3937 |   0.6047 |
multiindex_duplicated                        | 136.1593 | 141.6107 |   0.9615 |
series_drop_duplicates_int                   |   1.1793 |   1.1443 |   1.0306 |
series_drop_duplicates_string                |   0.7900 |   0.7540 |   1.0479 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [76459d2] : performance improvement in DataFrame.duplicated
Base   [ef48c6f] : Merge pull request #9377 from cmeeren/patch-1

DOC: Clarify how date_parser is called (GH9376)
```
