### PR TITLE
ENH: - Fixed column_format propagation to DataFrameFormatter in to_latex

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -614,42 +614,4 @@ Bug Fixes
 
   .. code-block:: python
 
-    In [2]: pd.options.display.max_rows = 10
-    In [3]: s = pd.Series([1,1,1,1,1,1,1,1,1,1,0.9999,1,1]*10)
-    In [4]: s
-    Out[4]:
-    0    1
-    1    1
-    2    1
-    ...
-    127    0.9999
-    128    1.0000
-    129    1.0000
-    Length: 130, dtype: float64
-
-  New Behavior
-
-  .. code-block:: python
-
-    0      1.0000
-    1      1.0000
-    2      1.0000
-    3      1.0000
-    4      1.0000
-    ...
-    125    1.0000
-    126    1.0000
-    127    0.9999
-    128    1.0000
-    129    1.0000
-    dtype: float64
-
-- A Spurious ``SettingWithCopy`` Warning was generated when setting a new item in a frame in some cases (:issue:`8730`)
-
-  The following would previously report a ``SettingWithCopy`` Warning.
-
-  .. ipython:: python
-
-     df1 = DataFrame({'x': Series(['a','b','c']), 'y': Series(['d','e','f'])})
-     df2 = df1[['x']]
-     df2['y'] = ['g', 'h', 'i']
+- ``SparseSeries`` and ``SparsePanel`` now accept zero argument constructors (same as their non-sparse counterparts) (:issue:`9272`).

--- a/doc/source/whatsnew/v0.16.2.txt
+++ b/doc/source/whatsnew/v0.16.2.txt
@@ -83,3 +83,5 @@ Bug Fixes
 
 
 - Bug where infer_freq infers timerule (WOM-5XXX) unsupported by to_offset (:issue:`9425`)
+
+- Fixed ``column_format`` propagation to ``DataFrameFormatter`` in ``DataFrame.to_latex`` (:issue: `9402`)

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -589,7 +589,6 @@ class DataFrameFormatter(TableFormatter):
         """
         self.escape = self.kwds.get('escape', True)
 
-        # TODO: column_format is not settable in df.to_latex
         def get_col_type(dtype):
             if issubclass(dtype.type, np.number):
                 return 'r'

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1397,7 +1397,8 @@ class DataFrame(NDFrame):
     def to_latex(self, buf=None, columns=None, col_space=None, colSpace=None,
                  header=True, index=True, na_rep='NaN', formatters=None,
                  float_format=None, sparsify=None, index_names=True,
-                 bold_rows=True, longtable=False, escape=True):
+                 bold_rows=True, longtable=False, escape=True,
+                 column_format=None):
         """
         Render a DataFrame to a tabular environment table. You can splice
         this into a LaTeX document. Requires \\usepackage{booktabs}.
@@ -1409,6 +1410,9 @@ class DataFrame(NDFrame):
         longtable : boolean, default False
             Use a longtable environment instead of tabular. Requires adding
             a \\usepackage{longtable} to your LaTeX preamble.
+        column_format : str, default None
+            Provide a custom column alignment as part of the table environment
+            setup.
         escape : boolean, default True
             When set to False prevents from escaping latex special
             characters in column names.
@@ -1429,7 +1433,7 @@ class DataFrame(NDFrame):
                                            sparsify=sparsify,
                                            index_names=index_names,
                                            escape=escape)
-        formatter.to_latex(longtable=longtable)
+        formatter.to_latex(longtable=longtable, column_format=column_format)
 
         if buf is None:
             return formatter.buf.getvalue()

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -2187,6 +2187,33 @@ c  10  11  12  13  14\
 """
         self.assertEqual(withoutindex_result, withoutindex_expected)
 
+    def test_to_latex_with_formatted_columns(self):
+        df = DataFrame({'a': [1, 2],
+                        'b': ['b1', 'b2']})
+        withindex_result = df.to_latex(column_format="rrr")
+        withindex_expected = r"""\begin{tabular}{rrr}
+\toprule
+{} &  a &   b \\
+\midrule
+0 &  1 &  b1 \\
+1 &  2 &  b2 \\
+\bottomrule
+\end{tabular}
+"""
+        self.assertEqual(withindex_result, withindex_expected)
+
+        withoutindex_result = df.to_latex(index=False, column_format="rr")
+        withoutindex_expected = r"""\begin{tabular}{rr}
+\toprule
+ a &   b \\
+\midrule
+ 1 &  b1 \\
+ 2 &  b2 \\
+\bottomrule
+\end{tabular}
+"""
+        self.assertEqual(withoutindex_result, withoutindex_expected)
+
     def test_to_latex_multiindex(self):
         df = DataFrame({('x', 'y'): ['a']})
         result = df.to_latex()


### PR DESCRIPTION
closes #9402  
