### PR TITLE
improved error message for invalid chart types

### DIFF
--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -2266,7 +2266,7 @@ def _plot(data, x=None, y=None, subplots=False,
     if kind in _all_kinds:
         klass = _plot_klass[kind]
     else:
-        raise ValueError('Invalid chart type given %s' % kind)
+        raise ValueError("%r is not a valid plot kind" % kind)
 
     from pandas import DataFrame
     if kind in _dataframe_kinds:
@@ -2274,7 +2274,8 @@ def _plot(data, x=None, y=None, subplots=False,
             plot_obj = klass(data, x=x, y=y, subplots=subplots, ax=ax,
                              kind=kind, **kwds)
         else:
-            raise ValueError('Invalid chart type given %s' % kind)
+            raise ValueError("plot kind %r can only be used for data frames"
+                             % kind)
 
     elif kind in _series_kinds:
         if isinstance(data, DataFrame):


### PR DESCRIPTION
Closes #9400

`pd.Series([2,3,4]).plot("quiver")` now gives an improved error message:

```
Users/ch/miniconda/envs/pd_dev34/lib/python3.4/site-packages/pandas/tools/plotting.py in _plot(data, x, y, subplots, ax, kind, **kwds)
   2269         klass = _plot_klass[kind]
   2270     else:
-> 2271         raise ValueError(invalid_ct_fmtstr % kind)
   2272 
   2273     from pandas import DataFrame

ValueError: 'quiver' is not a valid chart type
```

instead of:

```
/Users/ch/miniconda/envs/sci33/lib/python3.3/site-packages/pandas/tools/plotting.py in _plot(data, x, y, subplots, ax, kind, **kwds)
   2267         klass = _plot_klass[kind]
   2268     else:
-> 2269         raise ValueError('Invalid chart type given %s' % kind)
   2270 
   2271     from pandas import DataFrame

ValueError: Invalid chart type given quiver
```
