### PR TITLE
PERF: performance improvements in multi-key groupby

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -174,6 +174,7 @@ Performance
 - Performance improvement of up to 10x in ``DataFrame.count`` and ``DataFrame.dropna`` by taking advantage of homogeneous/heterogeneous dtypes appropriately (:issue:`9136`)
 - Performance improvement of up to 20x in ``DataFrame.count`` when using a ``MultiIndex`` and the ``level`` keyword argument  (:issue:`9163`)
 - Performance and memory usage improvements in ``merge`` when key space exceeds ``int64`` bounds (:issue:`9151`)
+- Performance improvements in multi-key ``groupby`` (:issue:`9429`)
 
 Bug Fixes
 ~~~~~~~~~

--- a/vb_suite/groupby.py
+++ b/vb_suite/groupby.py
@@ -501,6 +501,25 @@ df['jim'], df['joe'] = np.random.randn(2, len(df)) * 10
 groupby_int64_overflow = Benchmark("df.groupby(list('abcde')).max()", setup,
                                    name='groupby_int64_overflow')
 
+
+setup = common_setup + '''
+from itertools import product
+from string import ascii_letters, digits
+
+n = 5 * 7 * 11 * (1 << 9)
+alpha = list(map(''.join, product(ascii_letters + digits, repeat=4)))
+f = lambda k: np.repeat(np.random.choice(alpha, n // k), k)
+
+df = DataFrame({'a': f(11), 'b': f(7), 'c': f(5), 'd': f(1)})
+df['joe'] = (np.random.randn(len(df)) * 10).round(3)
+
+i = np.random.permutation(len(df))
+df = df.iloc[i].reset_index(drop=True).copy()
+'''
+
+groupby_multi_index = Benchmark("df.groupby(list('abcd')).max()", setup,
+                                name='groupby_multi_index')
+
 #----------------------------------------------------------------------
 # groupby with a variable value for ngroups
 


### PR DESCRIPTION
```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
groupby_multi_index                          | 1008.6970 | 1861.1110 |   0.5420 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [907e1b7] : performance improvements in multi-key groupby
Base   [5dc8009] : Merge pull request #9418 from sinhrks/rn_20150205

DOC: Fix release note format
```
