### PR TITLE
BUG: handle NotImplementedError in Index comparisons

### DIFF
--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -55,9 +55,17 @@ def _indexOp(opname):
 
         # This is required because Numpy has a nasty bug:
         # https://github.com/numpy/numpy/issues/2091
-        if result == np.array(NotImplemented):
-            msg = 'This operation cannot be performed using numpy because of a nasty bug: https://github.com/numpy/numpy/issues/2091.'
-            raise NotImplementedError(msg, (self, other, opname))
+        # It can be removed if the test test_index/Base/test_numpy_bug_triggered_with__eq__
+        # no longer covers this code.
+        try:
+            if result == np.array(NotImplemented):
+                url = 'https://github.com/numpy/numpy/issues/2091'
+                msg = 'This operation cannot be performed using numpy because of a nasty bug: {}'.format(url)
+                raise NotImplementedError(msg, (self, other, opname))
+        except NotImplementedError as e:
+            raise(e)
+        except Exception:
+            pass
 
         # technically we could support bool dtyped Index
         # for now just return the indexing array directly

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -53,6 +53,12 @@ def _indexOp(opname):
         func = getattr(self._data.view(np.ndarray), opname)
         result = func(np.asarray(other))
 
+        # This is required because Numpy has a nasty bug:
+        # https://github.com/numpy/numpy/issues/2091
+        if result == np.array(NotImplemented):
+            msg = 'This operation cannot be performed using numpy because of a nasty bug: https://github.com/numpy/numpy/issues/2091.'
+            raise NotImplementedError(msg, (self, other, opname))
+
         # technically we could support bool dtyped Index
         # for now just return the indexing array directly
         if com.is_bool_dtype(result):

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -44,7 +44,7 @@ class Base(object):
     def verify_pickle(self,index):
         unpickled = self.round_trip_pickle(index)
         self.assertTrue(index.equals(unpickled))
-
+        
     def test_pickle_compat_construction(self):
         # this is testing for pickle compat
         if self._holder is None:
@@ -53,6 +53,21 @@ class Base(object):
         # need an object to create with
         self.assertRaises(TypeError, self._holder)
 
+    def test_numpy_bug_triggered_with__eq__(self):
+        # At least three rows are required to trigger the numpy bug:
+        # https://github.com/numpy/numpy/issues/2091.
+        raised = False
+        try:
+            pd.DataFrame([[1],[2],[3]]).index == [1, 2]
+        except NotImplementedError:
+            raised = True
+            
+        if not raised:
+            raise AssertionError('This test no longer covers the try except statement that '\
+                                 'tests result == np.array(NotImplemented) within the _indexOp '\
+                                 'function within core/index.py. That code and this test can '\
+                                 'thus safely be removed.')
+        
     def test_numeric_compat(self):
 
         idx = self.create_index()


### PR DESCRIPTION
Fixes issue #9432

A very specific fix that is not anticipated to impact performance.  
The test performed is safe and documents that the origin of the 
problem is actually numpy.  When this numpy bug is fixed it will 
be easy to remove this code. 
