### PR TITLE
Fix bug in multiindex series groupby where sort argument is ignored

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -268,3 +268,4 @@ Bug Fixes
 
 - Bug in ``read_csv`` with buffer overflows with certain malformed input files (:issue:`9205`)
 - Bug in groupby MultiIndex with missing pair (:issue:`9049`, :issue:`9344`)
+- Fixed bug in ``Series.groupby`` where grouping on ``MultiIndex`` levels would ignore the sort argument (:issue:`9444`)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1368,7 +1368,7 @@ class BaseGrouper(object):
         if len(all_labels) > 1:
             group_index = get_group_index(all_labels, self.shape,
                                           sort=True, xnull=True)
-            return _compress_group_index(group_index)
+            return _compress_group_index(group_index, sort=self.sort)
 
         ping = self.groupings[0]
         return ping.labels, np.arange(len(ping.group_index))

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -3270,6 +3270,23 @@ class TestGroupBy(tm.TestCase):
                                   self.df['B'].values]).sum()
         self.assertEqual(result.index.names, (None, None))
 
+    def test_groupby_sort_multiindex_series(self):
+        # series multiindex groupby sort argument was not being passed through _compress_group_index
+        # GH 9444
+        index = MultiIndex(levels=[[1, 2], [1, 2]],
+                           labels=[[0, 0, 0, 0, 1, 1], [1, 1, 0, 0, 0, 0]],
+                           names=['a', 'b'])
+        mseries = Series([0, 1, 2, 3, 4, 5], index=index)
+        index = MultiIndex(levels=[[1, 2], [1, 2]],
+                           labels=[[0, 0, 1], [1, 0, 0]],
+                           names=['a', 'b'])
+        mseries_result = Series([0, 2, 4], index=index)
+
+        result = mseries.groupby(level=['a', 'b'], sort=False).first()
+        assert_series_equal(result, mseries_result)
+        result = mseries.groupby(level=['a', 'b'], sort=True).first()
+        assert_series_equal(result, mseries_result.sort_index())
+
     def test_groupby_categorical(self):
         levels = ['foo', 'bar', 'baz', 'qux']
         codes = np.random.randint(0, 4, size=100)


### PR DESCRIPTION
PR as per. 

One test added. Test fails without the fix.

closes https://github.com/pydata/pandas/issues/9444
