### PR TITLE
BUG: subplots with layout kw may show unnecessary warning

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -237,6 +237,7 @@ Bug Fixes
 
 
 - Bug in boxplot, scatter and hexbin plot may show an unnecessary warning (:issue:`8877`)
+- Bug in subplot with ``layout`` kw may show unnecessary warning (:issue:`9464`)
 
 
 

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -5,6 +5,7 @@ import nose
 import itertools
 import os
 import string
+import warnings
 from distutils.version import LooseVersion
 
 from datetime import datetime, date
@@ -1245,6 +1246,7 @@ class TestDataFramePlots(TestPlotBase):
                 self._check_visible(ax.get_yticklabels())
                 self._check_ticks_props(ax, xlabelsize=7, xrot=45, ylabelsize=7)
 
+    @slow
     def test_subplots_layout(self):
         # GH 6667
         df = DataFrame(np.random.rand(10, 3),
@@ -1289,6 +1291,21 @@ class TestDataFramePlots(TestPlotBase):
         axes = df.plot(subplots=True, layout=(3, 3))
         self._check_axes_shape(axes, axes_num=1, layout=(3, 3))
         self.assertEqual(axes.shape, (3, 3))
+
+    @slow
+    def test_subplots_warnings(self):
+        # GH 9464
+        warnings.simplefilter('error')
+        try:
+            df = DataFrame(np.random.randn(100, 4))
+            df.plot(subplots=True, layout=(3, 2))
+
+            df = DataFrame(np.random.randn(100, 4),
+                           index=date_range('1/1/2000', periods=100))
+            df.plot(subplots=True, layout=(3, 2))
+        except Warning as w:
+            self.fail(w)
+        warnings.simplefilter('default')
 
     @slow
     def test_subplots_multiple_axes(self):

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1126,7 +1126,8 @@ class MPLPlot(object):
 
         elif self.subplots and self.legend:
             for ax in self.axes:
-                ax.legend(loc='best')
+                if ax.get_visible():
+                    ax.legend(loc='best')
 
     def _get_ax_legend(self, ax):
         leg = ax.get_legend()


### PR DESCRIPTION
Related to #8877 and #9278. There is remaining case which shows unnecessary warning.

Occurrence condition:
- `subplots=True`.
- `layout` is specified larger than the number of required subplot axes.

In this case, `legend` is called against blank axes and results in warning.
