### PR TITLE
TST: Remove assertEquals

### DIFF
--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -1457,7 +1457,7 @@ class TestCategoricalAsBlock(tm.TestCase):
 
         # Categoricals should not show up together with numerical columns
         result = self.cat.describe()
-        self.assertEquals(len(result.columns),1)
+        self.assertEqual(len(result.columns),1)
 
 
         # In a frame, describe() for the cat should be the same as for string arrays (count, unique,

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -955,7 +955,7 @@ class TestMaybe(tm.TestCase):
         self.assertTrue(result.dtype == object)
 
         result = com._maybe_convert_string_to_object(1)
-        self.assertEquals(result, 1)
+        self.assertEqual(result, 1)
 
         arr = np.array(['x', 'y'], dtype=str)
         result = com._maybe_convert_string_to_object(arr)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -10411,7 +10411,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df['timedelta'] = Timedelta('1 min')
         result = df.applymap(str)
         for f in ['datetime','timedelta']:
-            self.assertEquals(result.loc[0,f],str(df.loc[0,f]))
+            self.assertEqual(result.loc[0,f],str(df.loc[0,f]))
 
     def test_filter(self):
         # items

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -899,22 +899,22 @@ class TestIndexing(tm.TestCase):
         # GH 7814
         s = Series([1,2,3], index=list('abc'))
         result = s.at['a']
-        self.assertEquals(result, 1)
+        self.assertEqual(result, 1)
         self.assertRaises(ValueError, lambda : s.at[0])
 
         df = DataFrame({'A' : [1,2,3]},index=list('abc'))
         result = df.at['a','A']
-        self.assertEquals(result, 1)
+        self.assertEqual(result, 1)
         self.assertRaises(ValueError, lambda : df.at['a',0])
 
         s = Series([1,2,3], index=[3,2,1])
         result = s.at[1]
-        self.assertEquals(result, 3)
+        self.assertEqual(result, 3)
         self.assertRaises(ValueError, lambda : s.at['a'])
 
         df = DataFrame({0 : [1,2,3]},index=[3,2,1])
         result = df.at[1,0]
-        self.assertEquals(result, 3)
+        self.assertEqual(result, 3)
         self.assertRaises(ValueError, lambda : df.at['a',0])
 
     def test_loc_getitem_label_slice(self):

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -92,18 +92,18 @@ class TestMultiLevel(tm.TestCase):
                            (1.2, datetime.datetime(2011, 1, 2, tzinfo=tz)),
                            (1.3, datetime.datetime(2011, 1, 3, tzinfo=tz))]
         expected = Index([1.1, 1.2, 1.3] + expected_tuples)
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         result = midx_lv2.append(idx1)
         expected = Index(expected_tuples + [1.1, 1.2, 1.3])
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         result = midx_lv2.append(midx_lv2)
         expected = MultiIndex.from_arrays([idx1.append(idx1), idx2.append(idx2)])
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         result = midx_lv2.append(midx_lv3)
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
         result = midx_lv3.append(midx_lv2)
         expected = Index._simple_new(
@@ -111,7 +111,7 @@ class TestMultiLevel(tm.TestCase):
                       (1.2, datetime.datetime(2011, 1, 2, tzinfo=tz), 'B'),
                       (1.3, datetime.datetime(2011, 1, 3, tzinfo=tz), 'C')]
                       + expected_tuples), None)
-        self.assert_(result.equals(expected))
+        self.assertTrue(result.equals(expected))
 
     def test_dataframe_constructor(self):
         multi = DataFrame(np.random.randn(4, 4),

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -303,14 +303,14 @@ class CheckNameIntegration(object):
         df = pd.DataFrame({'i':[0]*3, 'b':[False]*3})
         vc = df.i.value_counts()
         result = vc.get(99,default='Missing')
-        self.assertEquals(result,'Missing')
+        self.assertEqual(result,'Missing')
 
         vc = df.b.value_counts()
         result = vc.get(False,default='Missing')
-        self.assertEquals(result,3)
+        self.assertEqual(result,3)
 
         result = vc.get(True,default='Missing')
-        self.assertEquals(result,'Missing')
+        self.assertEqual(result,'Missing')
 
     def test_delitem(self):
 
@@ -2240,7 +2240,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # 1 - element series with ddof=1
         s = self.ts.iloc[[0]]
         result = s.sem(ddof=1)
-        self.assert_(isnull(result))
+        self.assertTrue(isnull(result))
 
     def test_skew(self):
         tm._skip_if_no_scipy()
@@ -2606,7 +2606,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # Alternative types, with implicit 'object' dtype.
         s = Series(['abc', True])
-        self.assertEquals('abc', s.any())  # 'abc' || True => 'abc'
+        self.assertEqual('abc', s.any())  # 'abc' || True => 'abc'
 
     def test_all_any_params(self):
         # Check skipna, with implicit 'object' dtype.
@@ -6414,17 +6414,17 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
     def test_autocorr(self):
         # Just run the function
         corr1 = self.ts.autocorr()
-        
+
         # Now run it with the lag parameter
         corr2 = self.ts.autocorr(lag=1)
-        
+
         # corr() with lag needs Series of at least length 2
         if len(self.ts) <= 2:
             self.assertTrue(np.isnan(corr1))
             self.assertTrue(np.isnan(corr2))
         else:
             self.assertEqual(corr1, corr2)
-        
+
         # Choose a random lag between 1 and length of Series - 2
         # and compare the result with the Series corr() function
         n = 1 + np.random.randint(max(1, len(self.ts) - 2))

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -653,13 +653,13 @@ class TestStringMethods(tm.TestCase):
         tm.assert_series_equal(str_s.str.isupper(), Series(upper_e))
         tm.assert_series_equal(str_s.str.istitle(), Series(title_e))
 
-        self.assertEquals(str_s.str.isalnum().tolist(), [v.isalnum() for v in values])
-        self.assertEquals(str_s.str.isalpha().tolist(), [v.isalpha() for v in values])
-        self.assertEquals(str_s.str.isdigit().tolist(), [v.isdigit() for v in values])
-        self.assertEquals(str_s.str.isspace().tolist(), [v.isspace() for v in values])
-        self.assertEquals(str_s.str.islower().tolist(), [v.islower() for v in values])
-        self.assertEquals(str_s.str.isupper().tolist(), [v.isupper() for v in values])
-        self.assertEquals(str_s.str.istitle().tolist(), [v.istitle() for v in values])
+        self.assertEqual(str_s.str.isalnum().tolist(), [v.isalnum() for v in values])
+        self.assertEqual(str_s.str.isalpha().tolist(), [v.isalpha() for v in values])
+        self.assertEqual(str_s.str.isdigit().tolist(), [v.isdigit() for v in values])
+        self.assertEqual(str_s.str.isspace().tolist(), [v.isspace() for v in values])
+        self.assertEqual(str_s.str.islower().tolist(), [v.islower() for v in values])
+        self.assertEqual(str_s.str.isupper().tolist(), [v.isupper() for v in values])
+        self.assertEqual(str_s.str.istitle().tolist(), [v.istitle() for v in values])
 
     def test_isnumeric(self):
         # 0x00bc: ¼ VULGAR FRACTION ONE QUARTER
@@ -675,8 +675,8 @@ class TestStringMethods(tm.TestCase):
         tm.assert_series_equal(s.str.isdecimal(), Series(decimal_e))
         unicodes = [u('A'), u('3'), unichr(0x00bc), unichr(0x2605),
                   unichr(0x1378), unichr(0xFF13), u('four')]
-        self.assertEquals(s.str.isnumeric().tolist(), [v.isnumeric() for v in unicodes])
-        self.assertEquals(s.str.isdecimal().tolist(), [v.isdecimal() for v in unicodes])
+        self.assertEqual(s.str.isnumeric().tolist(), [v.isnumeric() for v in unicodes])
+        self.assertEqual(s.str.isdecimal().tolist(), [v.isdecimal() for v in unicodes])
 
         values = ['A', np.nan, unichr(0x00bc), unichr(0x2605),
                   np.nan, unichr(0xFF13), 'four']

--- a/pandas/tests/test_util.py
+++ b/pandas/tests/test_util.py
@@ -60,6 +60,26 @@ class TestDecorators(tm.TestCase):
                 pass
 
 
+class TestTesting(tm.TestCase):
+
+    def test_warning(self):
+
+        with tm.assert_produces_warning(FutureWarning):
+            self.assertEquals(1, 1)
+
+        with tm.assert_produces_warning(FutureWarning):
+            self.assertNotEquals(1, 2)
+
+        with tm.assert_produces_warning(FutureWarning):
+            self.assert_(True)
+
+        with tm.assert_produces_warning(FutureWarning):
+            self.assertAlmostEquals(1.0, 1.0000000001)
+
+        with tm.assert_produces_warning(FutureWarning):
+            self.assertNotAlmostEquals(1, 2)
+
+
 def test_rands():
     r = tm.rands(10)
     assert(len(r) == 10)

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -39,9 +39,9 @@ class TestDatetimeIndexOps(Ops):
 
         # attribute access should still work!
         s = Series(dict(year=2000,month=1,day=10))
-        self.assertEquals(s.year,2000)
-        self.assertEquals(s.month,1)
-        self.assertEquals(s.day,10)
+        self.assertEqual(s.year,2000)
+        self.assertEqual(s.month,1)
+        self.assertEqual(s.day,10)
         self.assertRaises(AttributeError, lambda : s.weekday)
 
     def test_asobject_tolist(self):

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -408,19 +408,19 @@ class TestDateRange(tm.TestCase):
         end = datetime(2011, 1, 3, tzinfo=tz('US/Eastern'))
 
         dr = date_range(start=start, periods=3)
-        self.assert_(dr.tz == tz('US/Eastern'))
-        self.assert_(dr[0] == start)
-        self.assert_(dr[2] == end)
+        self.assertTrue(dr.tz == tz('US/Eastern'))
+        self.assertTrue(dr[0] == start)
+        self.assertTrue(dr[2] == end)
 
         dr = date_range(end=end, periods=3)
-        self.assert_(dr.tz == tz('US/Eastern'))
-        self.assert_(dr[0] == start)
-        self.assert_(dr[2] == end)
+        self.assertTrue(dr.tz == tz('US/Eastern'))
+        self.assertTrue(dr[0] == start)
+        self.assertTrue(dr[2] == end)
 
         dr = date_range(start=start, end=end)
-        self.assert_(dr.tz == tz('US/Eastern'))
-        self.assert_(dr[0] == start)
-        self.assert_(dr[2] == end)
+        self.assertTrue(dr.tz == tz('US/Eastern'))
+        self.assertTrue(dr[0] == start)
+        self.assertTrue(dr[2] == end)
 
     def test_month_range_union_tz_pytz(self):
         tm._skip_if_no_pytz()

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -391,7 +391,7 @@ class TestCommon(Base):
             for tz in self.timezones:
                 expected_localize = expected.tz_localize(tz)
                 result = Timestamp(dt, tz=tz) + offset_s
-                self.assert_(isinstance(result, Timestamp))
+                self.assertTrue(isinstance(result, Timestamp))
                 self.assertEqual(result, expected_localize)
 
             # normalize=True
@@ -407,7 +407,7 @@ class TestCommon(Base):
             for tz in self.timezones:
                 expected_localize = expected.tz_localize(tz)
                 result = Timestamp(dt, tz=tz) + offset_s
-                self.assert_(isinstance(result, Timestamp))
+                self.assertTrue(isinstance(result, Timestamp))
                 self.assertEqual(result, expected_localize)
 
 
@@ -2842,10 +2842,10 @@ class TestTicks(tm.TestCase):
         assertEq(2 * Hour(), datetime(2010, 1, 1), datetime(2010, 1, 1, 2))
         assertEq(-1 * Hour(), datetime(2010, 1, 1, 1), datetime(2010, 1, 1))
 
-        self.assertEquals(Hour(3) + Hour(2), Hour(5))
-        self.assertEquals(Hour(3) - Hour(2), Hour())
+        self.assertEqual(Hour(3) + Hour(2), Hour(5))
+        self.assertEqual(Hour(3) - Hour(2), Hour())
 
-        self.assertNotEquals(Hour(4), Hour(1))
+        self.assertNotEqual(Hour(4), Hour(1))
 
     def test_Minute(self):
         assertEq(Minute(), datetime(2010, 1, 1), datetime(2010, 1, 1, 0, 1))
@@ -2853,9 +2853,9 @@ class TestTicks(tm.TestCase):
         assertEq(2 * Minute(), datetime(2010, 1, 1), datetime(2010, 1, 1, 0, 2))
         assertEq(-1 * Minute(), datetime(2010, 1, 1, 0, 1), datetime(2010, 1, 1))
 
-        self.assertEquals(Minute(3) + Minute(2), Minute(5))
-        self.assertEquals(Minute(3) - Minute(2), Minute())
-        self.assertNotEquals(Minute(5), Minute())
+        self.assertEqual(Minute(3) + Minute(2), Minute(5))
+        self.assertEqual(Minute(3) - Minute(2), Minute())
+        self.assertNotEqual(Minute(5), Minute())
 
     def test_Second(self):
         assertEq(Second(), datetime(2010, 1, 1), datetime(2010, 1, 1, 0, 0, 1))
@@ -2864,8 +2864,8 @@ class TestTicks(tm.TestCase):
         assertEq(
             -1 * Second(), datetime(2010, 1, 1, 0, 0, 1), datetime(2010, 1, 1))
 
-        self.assertEquals(Second(3) + Second(2), Second(5))
-        self.assertEquals(Second(3) - Second(2), Second())
+        self.assertEqual(Second(3) + Second(2), Second(5))
+        self.assertEqual(Second(3) - Second(2), Second())
 
     def test_Millisecond(self):
         assertEq(Milli(), datetime(2010, 1, 1), datetime(2010, 1, 1, 0, 0, 0, 1000))
@@ -2874,8 +2874,8 @@ class TestTicks(tm.TestCase):
         assertEq(2 * Milli(), datetime(2010, 1, 1), datetime(2010, 1, 1, 0, 0, 0, 2000))
         assertEq(-1 * Milli(), datetime(2010, 1, 1, 0, 0, 0, 1000), datetime(2010, 1, 1))
 
-        self.assertEquals(Milli(3) + Milli(2), Milli(5))
-        self.assertEquals(Milli(3) - Milli(2), Milli())
+        self.assertEqual(Milli(3) + Milli(2), Milli(5))
+        self.assertEqual(Milli(3) - Milli(2), Milli())
 
     def test_MillisecondTimestampArithmetic(self):
         assertEq(Milli(), Timestamp('2010-01-01'), Timestamp('2010-01-01 00:00:00.001'))
@@ -2887,18 +2887,18 @@ class TestTicks(tm.TestCase):
         assertEq(2 * Micro(), datetime(2010, 1, 1), datetime(2010, 1, 1, 0, 0, 0, 2))
         assertEq(-1 * Micro(), datetime(2010, 1, 1, 0, 0, 0, 1), datetime(2010, 1, 1))
 
-        self.assertEquals(Micro(3) + Micro(2), Micro(5))
-        self.assertEquals(Micro(3) - Micro(2), Micro())
+        self.assertEqual(Micro(3) + Micro(2), Micro(5))
+        self.assertEqual(Micro(3) - Micro(2), Micro())
 
     def test_NanosecondGeneric(self):
         timestamp = Timestamp(datetime(2010, 1, 1))
-        self.assertEquals(timestamp.nanosecond, 0)
+        self.assertEqual(timestamp.nanosecond, 0)
 
         result = timestamp + Nano(10)
-        self.assertEquals(result.nanosecond, 10)
+        self.assertEqual(result.nanosecond, 10)
 
         reverse_result = Nano(10) + timestamp
-        self.assertEquals(reverse_result.nanosecond, 10)
+        self.assertEqual(reverse_result.nanosecond, 10)
 
     def test_Nanosecond(self):
         timestamp = Timestamp(datetime(2010, 1, 1))
@@ -2907,40 +2907,40 @@ class TestTicks(tm.TestCase):
         assertEq(2 * Nano(), timestamp, timestamp + np.timedelta64(2, 'ns'))
         assertEq(-1 * Nano(), timestamp + np.timedelta64(1, 'ns'), timestamp)
 
-        self.assertEquals(Nano(3) + Nano(2), Nano(5))
-        self.assertEquals(Nano(3) - Nano(2), Nano())
+        self.assertEqual(Nano(3) + Nano(2), Nano(5))
+        self.assertEqual(Nano(3) - Nano(2), Nano())
 
         # GH9284
-        self.assertEquals(Nano(1) + Nano(10), Nano(11))
-        self.assertEquals(Nano(5) + Micro(1), Nano(1005))
-        self.assertEquals(Micro(5) + Nano(1), Nano(5001))
+        self.assertEqual(Nano(1) + Nano(10), Nano(11))
+        self.assertEqual(Nano(5) + Micro(1), Nano(1005))
+        self.assertEqual(Micro(5) + Nano(1), Nano(5001))
 
     def test_tick_zero(self):
         for t1 in self.ticks:
             for t2 in self.ticks:
-                self.assertEquals(t1(0), t2(0))
-                self.assertEquals(t1(0) + t2(0), t1(0))
+                self.assertEqual(t1(0), t2(0))
+                self.assertEqual(t1(0) + t2(0), t1(0))
 
                 if t1 is not Nano:
-                    self.assertEquals(t1(2) + t2(0), t1(2))
+                    self.assertEqual(t1(2) + t2(0), t1(2))
             if t1 is Nano:
-                self.assertEquals(t1(2) + Nano(0), t1(2))
+                self.assertEqual(t1(2) + Nano(0), t1(2))
 
     def test_tick_equalities(self):
         for t in self.ticks:
-            self.assertEquals(t(3), t(3))
-            self.assertEquals(t(), t(1))
+            self.assertEqual(t(3), t(3))
+            self.assertEqual(t(), t(1))
 
             # not equals
-            self.assertNotEquals(t(3), t(2))
-            self.assertNotEquals(t(3), t(-3))
+            self.assertNotEqual(t(3), t(2))
+            self.assertNotEqual(t(3), t(-3))
 
     def test_tick_operators(self):
         for t in self.ticks:
-            self.assertEquals(t(3) + t(2), t(5))
-            self.assertEquals(t(3) - t(2), t(1))
-            self.assertEquals(t(800) + t(300), t(1100))
-            self.assertEquals(t(1000) - t(5), t(995))
+            self.assertEqual(t(3) + t(2), t(5))
+            self.assertEqual(t(3) - t(2), t(1))
+            self.assertEqual(t(800) + t(300), t(1100))
+            self.assertEqual(t(1000) - t(5), t(995))
 
     def test_tick_offset(self):
         for t in self.ticks:

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -226,11 +226,11 @@ class TestTimedeltas(tm.TestCase):
 
         td = Timedelta('1 days 2 hours 3 ns')
         result = td / np.timedelta64(1,'D')
-        self.assertEquals(result, td.value/float(86400*1e9))
+        self.assertEqual(result, td.value/float(86400*1e9))
         result = td / np.timedelta64(1,'s')
-        self.assertEquals(result, td.value/float(1e9))
+        self.assertEqual(result, td.value/float(1e9))
         result = td / np.timedelta64(1,'ns')
-        self.assertEquals(result, td.value)
+        self.assertEqual(result, td.value)
 
     def test_ops_ndarray(self):
         td = Timedelta('1 day')

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -411,8 +411,8 @@ class TestTimeSeries(tm.TestCase):
 
         stamp = rng[0]
         dtval = stamp.to_pydatetime()
-        self.assertEquals(stamp, dtval)
-        self.assertEquals(stamp.tzinfo, dtval.tzinfo)
+        self.assertEqual(stamp, dtval)
+        self.assertEqual(stamp.tzinfo, dtval.tzinfo)
 
     def test_timestamp_to_datetime_explicit_dateutil(self):
         _skip_if_windows_python_3()
@@ -423,8 +423,8 @@ class TestTimeSeries(tm.TestCase):
 
         stamp = rng[0]
         dtval = stamp.to_pydatetime()
-        self.assertEquals(stamp, dtval)
-        self.assertEquals(stamp.tzinfo, dtval.tzinfo)
+        self.assertEqual(stamp, dtval)
+        self.assertEqual(stamp.tzinfo, dtval.tzinfo)
 
     def test_index_convert_to_datetime_array(self):
         tm._skip_if_no_pytz()
@@ -454,8 +454,8 @@ class TestTimeSeries(tm.TestCase):
             tm.assert_isinstance(converted, np.ndarray)
             for x, stamp in zip(converted, rng):
                 tm.assert_isinstance(x, datetime)
-                self.assertEquals(x, stamp.to_pydatetime())
-                self.assertEquals(x.tzinfo, stamp.tzinfo)
+                self.assertEqual(x, stamp.to_pydatetime())
+                self.assertEqual(x.tzinfo, stamp.tzinfo)
 
         rng = date_range('20090415', '20090519')
         rng_eastern = date_range('20090415', '20090519', tz=pytz.timezone('US/Eastern'))
@@ -474,8 +474,8 @@ class TestTimeSeries(tm.TestCase):
             tm.assert_isinstance(converted, np.ndarray)
             for x, stamp in zip(converted, rng):
                 tm.assert_isinstance(x, datetime)
-                self.assertEquals(x, stamp.to_pydatetime())
-                self.assertEquals(x.tzinfo, stamp.tzinfo)
+                self.assertEqual(x, stamp.to_pydatetime())
+                self.assertEqual(x.tzinfo, stamp.tzinfo)
 
         rng = date_range('20090415', '20090519')
         rng_eastern = date_range('20090415', '20090519', tz='dateutil/US/Eastern')
@@ -1542,24 +1542,24 @@ class TestTimeSeries(tm.TestCase):
         result = ts.to_period()[0]
         expected = ts[0].to_period()
 
-        self.assert_(result == expected)
-        self.assert_(ts.to_period().equals(xp))
+        self.assertTrue(result == expected)
+        self.assertTrue(ts.to_period().equals(xp))
 
         ts = date_range('1/1/2000', '4/1/2000', tz=pytz.utc)
 
         result = ts.to_period()[0]
         expected = ts[0].to_period()
 
-        self.assert_(result == expected)
-        self.assert_(ts.to_period().equals(xp))
+        self.assertTrue(result == expected)
+        self.assertTrue(ts.to_period().equals(xp))
 
         ts = date_range('1/1/2000', '4/1/2000', tz=tzlocal())
 
         result = ts.to_period()[0]
         expected = ts[0].to_period()
 
-        self.assert_(result == expected)
-        self.assert_(ts.to_period().equals(xp))
+        self.assertTrue(result == expected)
+        self.assertTrue(ts.to_period().equals(xp))
 
     def test_to_period_tz_dateutil(self):
         tm._skip_if_no_dateutil()
@@ -1573,24 +1573,24 @@ class TestTimeSeries(tm.TestCase):
         result = ts.to_period()[0]
         expected = ts[0].to_period()
 
-        self.assert_(result == expected)
-        self.assert_(ts.to_period().equals(xp))
+        self.assertTrue(result == expected)
+        self.assertTrue(ts.to_period().equals(xp))
 
         ts = date_range('1/1/2000', '4/1/2000', tz=dateutil.tz.tzutc())
 
         result = ts.to_period()[0]
         expected = ts[0].to_period()
 
-        self.assert_(result == expected)
-        self.assert_(ts.to_period().equals(xp))
+        self.assertTrue(result == expected)
+        self.assertTrue(ts.to_period().equals(xp))
 
         ts = date_range('1/1/2000', '4/1/2000', tz=tzlocal())
 
         result = ts.to_period()[0]
         expected = ts[0].to_period()
 
-        self.assert_(result == expected)
-        self.assert_(ts.to_period().equals(xp))
+        self.assertTrue(result == expected)
+        self.assertTrue(ts.to_period().equals(xp))
 
     def test_frame_to_period(self):
         K = 5
@@ -1788,11 +1788,11 @@ class TestTimeSeries(tm.TestCase):
 
         result = ts.append(ts2)
         result_df = df.append(df2)
-        self.assert_(result.index.equals(rng3))
-        self.assert_(result_df.index.equals(rng3))
+        self.assertTrue(result.index.equals(rng3))
+        self.assertTrue(result_df.index.equals(rng3))
 
         appended = rng.append(rng2)
-        self.assert_(appended.equals(rng3))
+        self.assertTrue(appended.equals(rng3))
 
     def test_append_concat_tz_dateutil(self):
         # GH 2938
@@ -1812,11 +1812,11 @@ class TestTimeSeries(tm.TestCase):
 
         result = ts.append(ts2)
         result_df = df.append(df2)
-        self.assert_(result.index.equals(rng3))
-        self.assert_(result_df.index.equals(rng3))
+        self.assertTrue(result.index.equals(rng3))
+        self.assertTrue(result_df.index.equals(rng3))
 
         appended = rng.append(rng2)
-        self.assert_(appended.equals(rng3))
+        self.assertTrue(appended.equals(rng3))
 
     def test_set_dataframe_column_ns_dtype(self):
         x = DataFrame([datetime.now(), datetime.now()])

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -81,9 +81,9 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         rng_eastern = rng.tz_convert(self.tzstr('US/Eastern'))
 
         # Values are unmodified
-        self.assert_(np.array_equal(rng.asi8, rng_eastern.asi8))
+        self.assertTrue(np.array_equal(rng.asi8, rng_eastern.asi8))
 
-        self.assert_(self.cmptz(rng_eastern.tz, self.tz('US/Eastern')))
+        self.assertTrue(self.cmptz(rng_eastern.tz, self.tz('US/Eastern')))
 
     def test_utc_to_local_no_modify_explicit(self):
         rng = date_range('3/11/2012', '3/12/2012', freq='H', tz='utc')
@@ -119,7 +119,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         rng = date_range('3/10/2012', '3/11/2012', freq='30T')
         converted = rng.tz_localize(self.tz('US/Eastern'))
         expected_naive = rng + offsets.Hour(5)
-        self.assert_(np.array_equal(converted.asi8, expected_naive.asi8))
+        self.assertTrue(np.array_equal(converted.asi8, expected_naive.asi8))
 
         # DST ambiguity, this should fail
         rng = date_range('3/11/2012', '3/12/2012', freq='30T')
@@ -159,8 +159,8 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         result = Timestamp(date(2012, 3, 11), tz=self.tz('US/Eastern'))
 
         expected = Timestamp('3/11/2012', tz=self.tz('US/Eastern'))
-        self.assertEquals(result.hour, expected.hour)
-        self.assertEquals(result, expected)
+        self.assertEqual(result.hour, expected.hour)
+        self.assertEqual(result, expected)
 
     def test_timestamp_to_datetime_tzoffset(self):
         # tzoffset
@@ -181,7 +181,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         # spring forward, + "7" hours
         expected = Timestamp('3/11/2012 05:00', tz=self.tzstr('US/Eastern'))
 
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_timedelta_push_over_dst_boundary_explicit(self):
         # #1389
@@ -332,7 +332,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         rng_eastern = rng.tz_convert(self.tzstr('US/Eastern'))
         # test not valid for dateutil timezones.
         # self.assertIn('EDT', repr(rng_eastern[0].tzinfo))
-        self.assert_('EDT' in repr(rng_eastern[0].tzinfo) or 'tzfile' in repr(rng_eastern[0].tzinfo))
+        self.assertTrue('EDT' in repr(rng_eastern[0].tzinfo) or 'tzfile' in repr(rng_eastern[0].tzinfo))
 
     def test_timestamp_tz_convert(self):
         strdates = ['1/1/2012', '3/1/2012', '4/1/2012']

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -42,6 +42,7 @@ from pandas import bdate_range
 from pandas.tseries.index import DatetimeIndex
 from pandas.tseries.tdi import TimedeltaIndex
 from pandas.tseries.period import PeriodIndex
+from pandas.util.decorators import deprecate
 
 from pandas import _testing
 
@@ -96,6 +97,23 @@ class TestCase(unittest.TestCase):
         with ensure_clean(path) as path:
             pd.to_pickle(obj, path)
             return pd.read_pickle(path)
+
+    # https://docs.python.org/3/library/unittest.html#deprecated-aliases
+    def assertEquals(self, *args, **kwargs):
+        return deprecate('assertEquals', self.assertEqual)(*args, **kwargs)
+
+    def assertNotEquals(self, *args, **kwargs):
+        return deprecate('assertNotEquals', self.assertNotEqual)(*args, **kwargs)
+
+    def assert_(self, *args, **kwargs):
+        return deprecate('assert_', self.assertTrue)(*args, **kwargs)
+
+    def assertAlmostEquals(self, *args, **kwargs):
+        return deprecate('assertAlmostEquals', self.assertAlmostEqual)(*args, **kwargs)
+
+    def assertNotAlmostEquals(self, *args, **kwargs):
+        return deprecate('assertNotAlmostEquals', self.assertNotAlmostEqual)(*args, **kwargs)
+
 
 # NOTE: don't pass an NDFrame or index to this function - may not handle it
 # well.


### PR DESCRIPTION
Same as #7165. I've also added some of these tests :(

One idea to prevent this is to override ``tm.TestCase.assertEquals` to raise more explicit warning or exception.
