### PR TITLE
ENH: Series.idxnonzero() to return the index of nonzero entries

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -143,6 +143,7 @@ Enhancements
 
 .. _whatsnew_0160.enhancements:
 
+- Added ``Series.idxnonzero()`` to return the index entries of the nonzero values
 - Paths beginning with ~ will now be expanded to begin with the user's home directory (:issue:`9066`)
 - Added time interval selection in ``get_data_yahoo`` (:issue:`9071`)
 - Added ``Series.str.slice_replace()``, which previously raised ``NotImplementedError`` (:issue:`8888`)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -357,6 +357,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         See Also
         --------
         numpy.nonzero
+        Series.idxnonzero
         """
         return self.values.nonzero()
 
@@ -1218,6 +1219,16 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     # ndarray compat
     argmin = idxmin
     argmax = idxmax
+
+    def idxnonzero(self):
+        """
+        Indices of the elements that are non-zero
+
+        See Also
+        --------
+        Series.nonzero
+        """
+        return self.index[self.values.nonzero()[0]]
 
     @Appender(np.ndarray.round.__doc__)
     def round(self, decimals=0, out=None):

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -4006,6 +4006,12 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         result = s.idxmin()
         self.assertEqual(result, 1.1)
 
+    def test_idxnonzero(self):
+
+        dat = pd.Series(index=list("abcde"), data=[0, 1, 2, "3", False])
+        self.assertEqual(dat.idxnonzero().tolist(), list("bcd"))
+        self.assertTrue(pd.Index([]).identical( (dat==5).idxnonzero() ))
+
     def test_ndarray_compat(self):
 
         # test numpy compat with Series as sub-class of NDFrame


### PR DESCRIPTION
Added a straightforward Serie function '`idxnonzero`', similar to `idxmin`/`idxmax`

When filtering data, a `nonzero` pattern is actually very handy; yet panda’s version returns the iloc (for compatibility with numpy), which prevent to use the result on a differently-shaped dataframe, defeating the power of pandas indexing.

This simple patch propose a version of nonzero which returns an actual pandas Index.
