### PR TITLE
BUG: fix common.is_hashable for NumPy scalars on Python 3

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -2537,13 +2537,13 @@ def is_hashable(arg):
     >>> is_hashable(a)
     False
     """
-    # don't consider anything not collections.Hashable, so as not to broaden
-    # the definition of hashable beyond that. For example, old-style classes
-    # are not collections.Hashable but they won't fail hash().
-    if not isinstance(arg, collections.Hashable):
-        return False
+    # unfortunately, we can't use isinstance(arg, collections.Hashable), which
+    # can be faster than calling hash, because numpy scalars on Python 3 fail
+    # this test
 
-    # narrow the definition of hashable if hash(arg) fails in practice
+    # reconsider this decision once this numpy bug is fixed:
+    # https://github.com/numpy/numpy/issues/5562
+
     try:
         hash(arg)
     except TypeError:

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -424,7 +424,7 @@ def test_is_hashable():
             raise TypeError("Not hashable")
 
     hashable = (
-        1, 'a', tuple(), (1,), HashableClass(),
+        1, 3.14, np.float64(3.14), 'a', tuple(), (1,), HashableClass(),
     )
     not_hashable = (
         [], UnhashableClass1(),
@@ -434,13 +434,10 @@ def test_is_hashable():
     )
 
     for i in hashable:
-        assert isinstance(i, collections.Hashable)
         assert com.is_hashable(i)
     for i in not_hashable:
-        assert not isinstance(i, collections.Hashable)
         assert not com.is_hashable(i)
     for i in abc_hashable_not_really_hashable:
-        assert isinstance(i, collections.Hashable)
         assert not com.is_hashable(i)
 
     # numpy.array is no longer collections.Hashable as of
@@ -455,7 +452,7 @@ def test_is_hashable():
             pass
         c = OldStyleClass()
         assert not isinstance(c, collections.Hashable)
-        assert not com.is_hashable(c)
+        assert com.is_hashable(c)
         hash(c)  # this will not raise
 
 


### PR DESCRIPTION
Fixes #9276

This now relies entirely on the result of calling `hash` on the argument.

Note: I had to change the test for old style classes on Python 2 -- these are
now considered hashable by `is_hashable`, because they don't fail `hash`.

CC @aevri
