### PR TITLE
BUG: unstack with nulls & Timedelta/DateTime index

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -205,6 +205,7 @@ Bug Fixes
 - Bug in left ``join`` on multi-index with ``sort=True`` or null values (:issue:`9210`).
 - Bug in ``MultiIndex`` where inserting new keys would fail (:issue:`9250`).
 - Bug in ``groupby`` when key space exceeds ``int64`` bounds (:issue:`9096`).
+- Bug in ``unstack`` with ``TimedeltaIndex`` or ``DatetimeIndex`` and nulls (:issue:`9491`).
 
 
 - Fixed character encoding bug in ``read_stata`` and ``StataReader`` when loading data from a URL (:issue:`9231`).

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -828,7 +828,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, Int64Index):
                 pass
 
         freq = None
-        if isinstance(item, Timedelta):
+        if isinstance(item, (Timedelta, tslib.NaTType)):
 
             # check freq can be preserved on edge cases
             if self.freq is not None:


### PR DESCRIPTION
xref https://github.com/pydata/pandas/pull/9292#discussion_r24620887

on branch:

```
>>> df
           a       b    c
0 2014-02-01 -1 days  100
1        NaT     NaT  101
2 2014-02-03  1 days  102
3        NaT  2 days  103
4 2014-02-05     NaT  104
5 2014-02-06  4 days  105

>>> df.pivot('a', 'b', 'c').fillna('-')
b           NaT -1 days 1 days 2 days 4 days
a
NaT         101       -      -    103      -
2014-02-01    -     100      -      -      -
2014-02-03    -       -    102      -      -
2014-02-05  104       -      -      -      -
2014-02-06    -       -      -      -    105

>>> df.pivot('b', 'a', 'c').fillna('-')
a        NaT 2014-02-01 2014-02-03 2014-02-05 2014-02-06
b
NaT      101          -          -        104          -
-1 days    -        100          -          -          -
1 days     -          -        102          -          -
2 days   103          -          -          -          -
4 days     -          -          -          -        105
```
