### PR TITLE
FIX: Fix some instances where idx[0] not in idx

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -293,7 +293,7 @@ Bug Fixes
 - Bug in ``DataFrame.where`` and ``Series.where`` coerce numerics to string incorrectly (:issue:`9280`)
 - Bug in ``DataFrame.where`` and ``Series.where`` raise ``ValueError`` when string list-like is passed. (:issue:`9280`)
 - Accessing ``Series.str`` methods on with non-string values now raises ``TypeError`` instead of producing incorrect results (:issue:`9184`)
-
+- Bug in ``DatetimeIndex.__contains__`` when index has duplicates and is not monotonic increasing (:issue:`9512`)
 - Fixed division by zero error for ``Series.kurt()`` when all values are equal (:issue:`9197`)
 
 

--- a/pandas/tseries/base.py
+++ b/pandas/tseries/base.py
@@ -65,7 +65,7 @@ class DatetimeIndexOpsMixin(object):
     def __contains__(self, key):
         try:
             res = self.get_loc(key)
-            return np.isscalar(res) or type(res) == slice
+            return np.isscalar(res) or type(res) == slice or np.any(res)
         except (KeyError, TypeError):
             return False
 

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -292,6 +292,12 @@ Freq: H"""
 
             tm.assert_index_equal(idx.unique(), exp_idx)
 
+    def test_nonunique_contains(self):
+        # GH 9512
+        for idx in map(DatetimeIndex, ([0, 1, 0], [0, 0, -1], [0, -1, -1],
+                                       ['2015', '2015', '2016'], ['2015', '2015', '2014'])):
+            tm.assertIn(idx[0], idx)
+
 
 class TestTimedeltaIndexOps(Ops):
 
@@ -683,6 +689,14 @@ Freq: D"""
         tm.assert_series_equal(idx.value_counts(dropna=False), expected)
 
         tm.assert_index_equal(idx.unique(), exp_idx)
+
+    def test_nonunique_contains(self):
+        # GH 9512
+        for idx in map(TimedeltaIndex, ([0, 1, 0], [0, 0, -1], [0, -1, -1],
+                                        ['00:01:00', '00:01:00', '00:02:00'],
+                                        ['00:01:00', '00:01:00', '00:00:01'])):
+            tm.assertIn(idx[0], idx)
+
 
 class TestPeriodIndexOps(Ops):
 


### PR DESCRIPTION
`DatetimeIndex.__contains__` and `TimedeltaIndex.__contains__` were failing to see duplicated elements in some circumstances.

Fixes #9512
