### PR TITLE
BUG: multiple level unstack with nulls

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -235,7 +235,7 @@ Bug Fixes
 - Fixed bug on bug endian platforms which produced incorrect results in ``StataReader`` (:issue:`8688`).
 
 - Bug in ``MultiIndex.has_duplicates`` when having many levels causes an indexer overflow (:issue:`9075`, :issue:`5873`)
-- Bug in ``pivot`` and ``unstack`` where ``nan`` values would break index alignment (:issue:`4862`, :issue:`7401`, :issue:`7403`, :issue:`7405`, :issue:`7466`)
+- Bug in ``pivot`` and ``unstack`` where ``nan`` values would break index alignment (:issue:`4862`, :issue:`7401`, :issue:`7403`, :issue:`7405`, :issue:`7466`, :issue:`9497`)
 - Bug in left ``join`` on multi-index with ``sort=True`` or null values (:issue:`9210`).
 - Bug in ``MultiIndex`` where inserting new keys would fail (:issue:`9250`).
 - Bug in ``groupby`` when key space exceeds ``int64`` bounds (:issue:`9096`).

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -260,7 +260,8 @@ def _unstack_multiple(data, clocs):
     group_index = get_group_index(clabels, shape, sort=False, xnull=False)
 
     comp_ids, obs_ids = _compress_group_index(group_index, sort=False)
-    recons_labels = decons_obs_group_ids(comp_ids, obs_ids, shape, clabels)
+    recons_labels = decons_obs_group_ids(comp_ids,
+                       obs_ids, shape, clabels, xnull=False)
 
     dummy_index = MultiIndex(levels=rlevels + [obs_ids],
                              labels=rlabels + [comp_ids],

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -12494,6 +12494,24 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         left = df.ix[17264:].copy().set_index(['s_id','dosage','agent'])
         assert_frame_equal(left.unstack(), right)
 
+        # GH9497 - multiple unstack with nulls
+        df = DataFrame({'1st':[1, 2, 1, 2, 1, 2],
+                        '2nd':pd.date_range('2014-02-01', periods=6, freq='D'),
+                        'jim':100 + np.arange(6),
+                        'joe':(np.random.randn(6) * 10).round(2)})
+
+        df['3rd'] = df['2nd'] - pd.Timestamp('2014-02-02')
+        df.loc[1, '2nd'] = df.loc[3, '2nd'] = nan
+        df.loc[1, '3rd'] = df.loc[4, '3rd'] = nan
+
+        left = df.set_index(['1st', '2nd', '3rd']).unstack(['2nd', '3rd'])
+        self.assertEqual(left.notnull().values.sum(), 2 * len(df))
+
+        for col in ['jim', 'joe']:
+           for _, r in df.iterrows():
+               key = r['1st'], (col, r['2nd'], r['3rd'])
+               self.assertEqual(r[col], left.loc[key])
+
     def test_stack_datetime_column_multiIndex(self):
         # GH 8039
         t = datetime(2014, 1, 1)


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/9497

```
>>> mi
                        jim    joe
1st 2nd        3rd
1   2014-02-01 -1 days  100 -20.87
2   NaT        NaT      101   5.76
1   2014-02-03 1 days   102  -4.94
2   NaT        2 days   103  -0.79
1   2014-02-05 NaT      104 -12.51
2   2014-02-06 4 days   105  -9.89

>>> mi.unstack(['2nd', '3rd']).fillna('.')
           jim                                                     joe
2nd 2014-02-01  NaT 2014-02-03    NaT 2014-02-05 2014-02-06 2014-02-01   NaT 2014-02-03    NaT 2014-02-05 2014-02-06
3rd    -1 days  NaT     1 days 2 days        NaT     4 days    -1 days   NaT     1 days 2 days        NaT     4 days
1st
1          100    .        102      .        104          .     -20.87     .      -4.94      .     -12.51          .
2            .  101          .    103          .        105          .  5.76          .  -0.79          .      -9.89
```
