### PR TITLE
Allows for more options when getting data from dictionaries.

### DIFF
--- a/pandas/core/cloud_patch.py
+++ b/pandas/core/cloud_patch.py
@@ -1,15 +1,3 @@
-#!/usr/bin/python3
-'''
-Useful tools for working with the python library pandas
-Written in 2015 by Garrett Berg <garrett@cloudformdesign.com>
-
-© Creative Commons 0
-To the extent possible under law, the author(s) have dedicated all copyright
-and related and neighboring rights to this software to the public domain
-worldwide. THIS SOFTWARE IS DISTRIBUTED WITHOUT ANY WARRANTY.
-<http://creativecommons.org/publicdomain/zero/1.0/>
-'''
-
 
 def _dataframe_dict(data, index=None, filler='', header=None):
     if isinstance(data, dict):

--- a/pandas/core/cloud_patch.py
+++ b/pandas/core/cloud_patch.py
@@ -1,0 +1,201 @@
+#!/usr/bin/python3
+'''
+Useful tools for working with the python library pandas
+Written in 2015 by Garrett Berg <garrett@cloudformdesign.com>
+
+© Creative Commons 0
+To the extent possible under law, the author(s) have dedicated all copyright
+and related and neighboring rights to this software to the public domain
+worldwide. THIS SOFTWARE IS DISTRIBUTED WITHOUT ANY WARRANTY.
+<http://creativecommons.org/publicdomain/zero/1.0/>
+'''
+import pandas as pd
+
+
+def _dataframe_dict(data, index=None, filler='', header=None):
+    if isinstance(data, dict):
+        try:
+            if depth(data, isiter=True) < 2:
+                return data
+        except TypeError:
+            return data
+    if isinstance(data, dict):
+        header = resolve_header(header)
+        if header is None:
+            header = get_header(data)
+    else:
+        header = resolve_header(header)
+        if header is None:
+            header = get_header(data[0])
+        data = unpack(data, header)
+        data = flatten(data)
+    data = fill_keys(data, filler)
+    return data
+
+
+def dataframe_dict(data, index=None, filler='', header=None):
+    '''General loader of dataframes from python objects. Can either be a
+    dict of lists or a list of dicts.
+    Header is detected automatically and will be multiindex if the dict
+    is nested'''
+    data = _dataframe_dict(data, index, filler, header)
+    data = pd.DataFrame.from_dict(data)
+    if index is not None:
+        data.set_index(index, inplace=True)
+        data.sort_index(inplace=True)
+    return data
+
+
+# Helper funcitons
+def resolve_header(header):
+    if header is None:
+        return None
+    if isinstance(header, dict):
+        return get_header(header)
+    else:
+        return header
+
+
+#!/usr/bin/python3
+'''
+Useful tools to inspect and work with dictionaries
+Written in 2015 by Garrett Berg <garrett@cloudformdesign.com>
+
+© Creative Commons 0
+To the extent possible under law, the author(s) have dedicated all copyright
+and related and neighboring rights to this software to the public domain
+worldwide. THIS SOFTWARE IS DISTRIBUTED WITHOUT ANY WARRANTY.
+<http://creativecommons.org/publicdomain/zero/1.0/>
+'''
+
+# builtins
+import itertools
+import collections
+
+def isiter(obj, exclude=(str, bytes, bytearray)):
+    '''Returns True if object is an iterator.
+    Returns False for str, bytes and bytearray objects
+    by default'''
+    return (False if isinstance(obj, exclude)
+            else True if hasattr(obj, '__iter__')
+            else False)
+
+def consume(iterator, n=None):
+    "Advance the iterator n-steps ahead. If n is none, consume entirely."
+    # Use functions that consume iterators at C speed.
+    if n is None:
+        # feed the entire iterator into a zero-length deque
+        collections.deque(iterator, maxlen=0)
+    else:
+        # advance to the empty slice starting at position n
+        next(itertools.islice(iterator, n, n), None)
+
+
+def throw(exception):
+    '''Raises an exception. Can be used inside compressions'''
+    raise exception
+
+def depth(d, deep=0, isiter=False):
+    '''Find the depth of a nested dictionary'''
+    if not isinstance(d, dict) or not d:  # not a dict or an empty dict
+        throw(TypeError) if isiter and \
+            not isiter(d) else None
+        return deep
+    return max(depth(v, deep + 1, isiter) for k, v in d.items())
+
+
+# Dictionary methods
+def get_header(item, extra_levels=None, filler=''):
+    '''Returns the header of a nested dictionary
+    The header is a list of tuples detailing the structure of the dictionary
+    Very useful in pandas'''
+    levels = extra_levels
+    if levels is None:
+        levels = depth(item)
+    keys = []
+    for key, value in item.items():
+        if isinstance(value, dict):
+            keys.extend((key,) + v for v in
+                        get_header(value, levels - 1, filler))
+        else:
+            keys.append((key,))
+    return keys
+
+
+def getitem(dic, item):
+    '''Dictionary item access with tuples'''
+    for i in item:
+        dic = dic[i]
+    return dic
+
+
+def setitem(dic, item, value):
+    '''Dictionary item setting with tuples'''
+    for i, k in enumerate(item):
+        if i < len(item) - 1:
+            if k not in dic:
+                dic[k] = {}
+            dic = dic[k]
+        else:
+            dic[k] = value
+            break
+    else:
+        assert False
+    return dic
+
+
+def unpack(data, header=None):
+    '''Unpacks a list of dictionaries into a dictionary of lists
+    according to the header'''
+    if header is None:
+        header = get_header(data[0])
+    out = type(data[0])()
+    for key in header:
+        setitem(out, key, [])
+    for d in data:
+        for h in header:
+            getitem(out, h).append(getitem(d, h))
+    return out
+
+
+def flatten(data, start=()):
+    '''Flattens a dictionary so that the keys are all tuples of keys'''
+    flat = type(data)()
+    for key, value in data.items():
+        if isinstance(value, dict):
+            flat.update(flatten(value, start=start + (key,)))
+        else:
+            flat[start + (key,)] = value
+    return flat
+
+
+def fill_keys(data, filler=None):
+    '''Makes all dictionary keys tuples of the same length'''
+    keys, values = zip(*data.items())
+    # convert all keys to tuples
+    keys = tuple(key if isinstance(key, tuple) else (key,) for key in keys)
+    maxlen = max(map(len, keys))
+    return type(data)({key + ((filler,) * (maxlen - len(key))): value for
+                       (key, value) in zip(keys, values)})
+
+
+def update(todict, fromdict, keys=None):
+    '''Copy only keys from one dictionary to another
+
+    keys=None is equivalent to todict.update(fromdict)
+    '''
+    todict.update(fromdict if keys is None else
+                  {key: fromdict[key] for key in keys})
+
+
+def remove(obj, keys, check=True):
+    '''remove unwanted keys
+    Arguments:
+        obj -- object on which keys should be removed
+        keys -- iterator of keys to remove
+        check -- whether to check whether keys exist
+        '''
+    if check:
+        consume(map(obj.pop, keys))
+    else:
+        consume(map(obj.pop, keys, itertools.repeat(None)))

--- a/pandas/core/cloud_patch.py
+++ b/pandas/core/cloud_patch.py
@@ -9,7 +9,6 @@ and related and neighboring rights to this software to the public domain
 worldwide. THIS SOFTWARE IS DISTRIBUTED WITHOUT ANY WARRANTY.
 <http://creativecommons.org/publicdomain/zero/1.0/>
 '''
-import pandas as pd
 
 
 def _dataframe_dict(data, index=None, filler='', header=None):
@@ -19,16 +18,12 @@ def _dataframe_dict(data, index=None, filler='', header=None):
                 return data
         except TypeError:
             return data
-    if isinstance(data, dict):
-        header = resolve_header(header)
-        if header is None:
-            header = get_header(data)
-    else:
+    if not isinstance(data, dict):
         header = resolve_header(header)
         if header is None:
             header = get_header(data[0])
         data = unpack(data, header)
-        data = flatten(data)
+    data = flatten(data)
     data = fill_keys(data, filler)
     return data
 
@@ -72,7 +67,7 @@ worldwide. THIS SOFTWARE IS DISTRIBUTED WITHOUT ANY WARRANTY.
 import itertools
 import collections
 
-def isiter(obj, exclude=(str, bytes, bytearray)):
+def _isiter(obj, exclude=(str, bytes, bytearray)):
     '''Returns True if object is an iterator.
     Returns False for str, bytes and bytearray objects
     by default'''
@@ -99,7 +94,7 @@ def depth(d, deep=0, isiter=False):
     '''Find the depth of a nested dictionary'''
     if not isinstance(d, dict) or not d:  # not a dict or an empty dict
         throw(TypeError) if isiter and \
-            not isiter(d) else None
+            not _isiter(d) else None
         return deep
     return max(depth(v, deep + 1, isiter) for k, v in d.items())
 
@@ -134,7 +129,7 @@ def setitem(dic, item, value):
     for i, k in enumerate(item):
         if i < len(item) - 1:
             if k not in dic:
-                dic[k] = {}
+                dic[k] = type(dic)()
             dic = dic[k]
         else:
             dic[k] = value
@@ -175,8 +170,8 @@ def fill_keys(data, filler=None):
     # convert all keys to tuples
     keys = tuple(key if isinstance(key, tuple) else (key,) for key in keys)
     maxlen = max(map(len, keys))
-    return type(data)({key + ((filler,) * (maxlen - len(key))): value for
-                       (key, value) in zip(keys, values)})
+    return type(data)((key + ((filler,) * (maxlen - len(key))), value) for
+                       (key, value) in zip(keys, values))
 
 
 def update(todict, fromdict, keys=None):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -11,6 +11,7 @@ labeling information
 from __future__ import division
 # pylint: disable=E1101,E1103
 # pylint: disable=W0212,W0231,W0703,W0622
+from cloudtb.pandas import _dataframe_dict
 
 import functools
 import collections
@@ -637,7 +638,7 @@ class DataFrame(NDFrame):
     # IO methods (to / from other formats)
 
     @classmethod
-    def from_dict(cls, data, orient='columns', dtype=None):
+    def _from_dict(cls, data, orient='columns', dtype=None):
         """
         Construct DataFrame from dict of array-like or dicts
 
@@ -667,6 +668,11 @@ class DataFrame(NDFrame):
             raise ValueError('only recognize index or columns for orient')
 
         return cls(data, index=index, columns=columns, dtype=dtype)
+
+    @classmethod
+    def from_dict(cls, data, orient='columns', dtype=None):
+        data = _dataframe_dict(data)
+        return cls._from_dict(data, orient, dtype)
 
     @deprecate_kwarg(old_arg_name='outtype', new_arg_name='orient')
     def to_dict(self, orient='dict'):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -11,7 +11,7 @@ labeling information
 from __future__ import division
 # pylint: disable=E1101,E1103
 # pylint: disable=W0212,W0231,W0703,W0622
-from cloudtb.pandas import _dataframe_dict
+from pandas.core.cloud_patch import _dataframe_dict
 
 import functools
 import collections

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3257,6 +3257,40 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         result = DataFrame(data)
         assert_frame_equal(result, result_custom)
 
+    def test_constructor_nested_dict(self):
+        names = 'abcdef'
+        # create a nested dictionary
+        data = OrderedDict((key, list(range(len(names)))) for key in names)
+        data['self'] = OrderedDict(data)
+        result = DataFrame.from_dict(data)
+
+        # mimick the keys for checking
+        keys = [(n, '') for n in names]
+        keys.extend(('self', n) for n in names)
+        data_custom = list(list(range(len(names))) for _ in range(len(names) * 2))
+        expected = DataFrame(data_custom).T
+        expected.columns = MultiIndex.from_tuples(keys)
+
+        assert_frame_equal(result, expected)
+
+    def test_constructor_list_of_nested_dict(self):
+        names = 'abcdef'
+        data = []
+        for i in range(len(names)):
+            d = OrderedDict((key, i) for key in names)
+            d['self'] = OrderedDict(d)
+            data.append(d)
+        result = DataFrame.from_dict(data)
+
+        # mimick the keys for checking
+        keys = [(n, '') for n in names]
+        keys.extend(('self', n) for n in names)
+        data_custom = list(list(range(len(names))) for _ in
+                           range(len(names) * 2))
+        expected = DataFrame(data_custom).T
+        expected.columns = MultiIndex.from_tuples(keys)
+
+        assert_frame_equal(result, expected)
     def test_constructor_ragged(self):
         data = {'A': randn(10),
                 'B': randn(8)}


### PR DESCRIPTION
Fixes #9502 

See the [cloudtb tests/test_pandas.py](https://github.com/cloudformdesign/cloudtb/blob/f/pandas/tests/test_pandas.py) for more examples of use.

Once it is approved to go forward, I will add tests to show more about how
it can be used and make sure that every edge case if functional.

Has no effect on unit tests, although on my machine two were failing
before change, and several were skipped (and still fail after change). 
Please re-run unit tests.

Should have a negligible effect on performance, as it first checks whether
it should be used. If performance does end up being an issue, I
recommend adding a kwarg `flat=False` to the `DataFrame.from_dict`
method for speedups when the user knows their dictionary is flat
(i.e. is not nested)
