### PR TITLE
`read_hdf` opens the store in `rw` mode by default.

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -344,3 +344,4 @@ Bug Fixes
 - Bug in groupby MultiIndex with missing pair (:issue:`9049`, :issue:`9344`)
 - Fixed bug in ``Series.groupby`` where grouping on ``MultiIndex`` levels would ignore the sort argument (:issue:`9444`)
 - Fix bug in ``DataFrame.Groupby`` where sort=False is ignored in case of Categorical columns. (:issue:`8868`)
+- Fix issue on when reading HDF5 files using ``read_hdf`` from a Windows file share without write-permissions. (:issue:`9551`)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -318,6 +318,7 @@ def read_hdf(path_or_buf, key, **kwargs):
 
         # can't auto open/close if we are using an iterator
         # so delegate to the iterator
+        kwargs.setdefault("mode", "r")
         store = HDFStore(path_or_buf, **kwargs)
         try:
             return f(store, True)


### PR DESCRIPTION
Currently the `HDFStore` in `read_hdf` is opened in `rw` mode by default, leading to permission
errors when reading a non-writeable file.

This patch changes the default mode to `r`.
