### PR TITLE
Moved caching in AbstractHolidayCalendar to the instance level

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -154,3 +154,4 @@ Bug Fixes
 
 - Bug where dividing a dataframe containing values of type ``Decimal`` by another ``Decimal`` would raise. (:issue:`9787`)
 - Bug where using DataFrames asfreq would remove the name of the index. (:issue:`9885`)
+- Changed caching in ``AbstractHolidayCalendar`` to be at the instance level rather than at the class level as the latter can result in unexpected behaviour. (:issue:`9552`)

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -279,7 +279,7 @@ class AbstractHolidayCalendar(object):
     rules = []
     start_date = Timestamp(datetime(1970, 1, 1))
     end_date = Timestamp(datetime(2030, 12, 31))
-    _holiday_cache = None
+    _cache = None
 
     def __init__(self, name=None, rules=None):
         """
@@ -350,14 +350,6 @@ class AbstractHolidayCalendar(object):
             return holidays
         else:
             return holidays.index
-
-    @property
-    def _cache(self):
-        return self.__class__._holiday_cache
-
-    @_cache.setter
-    def _cache(self, values):
-        self.__class__._holiday_cache = values
 
     @staticmethod
     def merge_class(base, other):

--- a/pandas/tseries/tests/test_holiday.py
+++ b/pandas/tseries/tests/test_holiday.py
@@ -1,6 +1,7 @@
 
 from datetime import datetime
 import pandas.util.testing as tm
+from pandas import DatetimeIndex
 from pandas.tseries.holiday import (
     USFederalHolidayCalendar, USMemorialDay, USThanksgivingDay,
     nearest_workday, next_monday_or_tuesday, next_monday,
@@ -49,6 +50,29 @@ class TestCalendar(tm.TestCase):
                          self.holiday_list)
         self.assertEqual(list(holidays_2.to_pydatetime()),
                          self.holiday_list)
+
+    def test_calendar_caching(self):
+        # Test for issue #9552
+
+        class TestCalendar(AbstractHolidayCalendar):
+            def __init__(self, name=None, rules=None):
+                super(TestCalendar, self).__init__(
+                    name=name,
+                    rules=rules
+                )
+
+        jan1 = TestCalendar(rules=[Holiday('jan1', year=2015, month=1, day=1)])
+        jan2 = TestCalendar(rules=[Holiday('jan2', year=2015, month=1, day=2)])
+
+        tm.assert_index_equal(
+            jan1.holidays(),
+            DatetimeIndex(['01-Jan-2015'])
+        )
+        tm.assert_index_equal(
+            jan2.holidays(),
+            DatetimeIndex(['02-Jan-2015'])
+        )
+
 
 class TestHoliday(tm.TestCase):
 


### PR DESCRIPTION
Closes #9552
