### PR TITLE
BUG: Fix read_csv on S3 files for python 3

### DIFF
--- a/ci/requirements-2.7.txt
+++ b/ci/requirements-2.7.txt
@@ -13,7 +13,7 @@ lxml=3.2.1
 scipy
 xlsxwriter=0.4.6
 statsmodels
-boto=2.26.1
+boto=2.36.0
 bottleneck=0.8.0
 psycopg2=2.5.2
 patsy

--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -344,3 +344,7 @@ Bug Fixes
 - Bug in groupby MultiIndex with missing pair (:issue:`9049`, :issue:`9344`)
 - Fixed bug in ``Series.groupby`` where grouping on ``MultiIndex`` levels would ignore the sort argument (:issue:`9444`)
 - Fix bug in ``DataFrame.Groupby`` where sort=False is ignored in case of Categorical columns. (:issue:`8868`)
+
+
+
+- Fixed bug with reading CSV files from Amazon S3 on python 3 raising a TypeError (:issue:`9452`)

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -154,7 +154,8 @@ def get_filepath_or_buffer(filepath_or_buffer, encoding=None):
         b = conn.get_bucket(parsed_url.netloc)
         k = boto.s3.key.Key(b)
         k.key = parsed_url.path
-        filepath_or_buffer = BytesIO(k.get_contents_as_string())
+        filepath_or_buffer = BytesIO(k.get_contents_as_string(
+            encoding=encoding))
         return filepath_or_buffer, None
 
 

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -3802,9 +3802,6 @@ class TestS3(tm.TestCase):
         except ImportError:
             raise nose.SkipTest("boto not installed")
 
-        if compat.PY3:
-            raise nose.SkipTest("boto incompatible with Python 3")
-
     @tm.network
     def test_parse_public_s3_bucket(self):
         import nose.tools as nt


### PR DESCRIPTION
Closes https://github.com/pydata/pandas/issues/9452

Needed to pass along encoding parameter.

No tests... Kind of hard since it's only s3 only.
