### PR TITLE
API: consistency with .ix and .loc for getitem operations (GH8613)

### DIFF
--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -85,7 +85,7 @@ of multi-axis indexing.
 
 - ``.iloc`` is primarily integer position based (from ``0`` to
   ``length-1`` of the axis), but may also be used with a boolean
-  array.  ``.iloc`` will raise ``IndexError`` if a requested 
+  array.  ``.iloc`` will raise ``IndexError`` if a requested
   indexer is out-of-bounds, except *slice* indexers which allow
   out-of-bounds indexing.  (this conforms with python/numpy *slice*
   semantics).  Allowed inputs are:
@@ -291,6 +291,35 @@ Selection By Label
    Whether a copy or a reference is returned for a setting operation, may depend on the context.
    This is sometimes called ``chained assignment`` and should be avoided.
    See :ref:`Returning a View versus Copy <indexing.view_versus_copy>`
+
+.. warning::
+
+   ``.loc`` is strict when you present slicers that are not compatible (or convertible) with the index type. For example
+   using integers in a ``DatetimeIndex`` or float indexers in an ``Int64Index``. These will raise a ``TypeError``.
+
+  .. ipython:: python
+
+     dfl = DataFrame(np.random.randn(5,4), columns=list('ABCD'), index=date_range('20130101',periods=5))
+     dfl
+     sl = Series(range(5),[-2,-1,1,2,3])
+     sl
+
+  .. code-block:: python
+
+     In [4]: dfl.loc[2:3]
+     TypeError: cannot do slice indexing on <class 'pandas.tseries.index.DatetimeIndex'> with these indexers [2] of <type 'int'>
+
+  .. code-block:: python
+
+     In [8]: sl.loc[-1.0:2]
+     TypeError: cannot do slice indexing on <class 'pandas.core.index.Int64Index'> with these indexers [-1.0] of <type 'float'>
+
+
+  String likes in slicing *can* be convertible to the type of the index and lead to natural slicing.
+
+  .. ipython:: python
+
+     dfl.loc['20130102':'20130104']
 
 pandas provides a suite of methods in order to have **purely label based indexing**. This is a strict inclusion based protocol.
 **at least 1** of the labels for which you ask, must be in the index or a ``KeyError`` will be raised! When slicing, the start bound is *included*, **AND** the stop bound is *included*. Integers are valid labels, but they refer to the label **and not the position**.
@@ -1486,5 +1515,3 @@ This will **not** work at all, and so should be avoided
    The chained assignment warnings / exceptions are aiming to inform the user of a possibly invalid
    assignment. There may be false positives; situations where a chained assignment is inadvertantly
    reported.
-
-

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -295,25 +295,17 @@ Selection By Label
 .. warning::
 
    ``.loc`` is strict when you present slicers that are not compatible (or convertible) with the index type. For example
-   using integers in a ``DatetimeIndex`` or float indexers in an ``Int64Index``. These will raise a ``TypeError``.
+   using integers in a ``DatetimeIndex``. These will raise a ``TypeError``.
 
   .. ipython:: python
 
      dfl = DataFrame(np.random.randn(5,4), columns=list('ABCD'), index=date_range('20130101',periods=5))
      dfl
-     sl = Series(range(5),[-2,-1,1,2,3])
-     sl
 
   .. code-block:: python
 
      In [4]: dfl.loc[2:3]
      TypeError: cannot do slice indexing on <class 'pandas.tseries.index.DatetimeIndex'> with these indexers [2] of <type 'int'>
-
-  .. code-block:: python
-
-     In [8]: sl.loc[-1.0:2]
-     TypeError: cannot do slice indexing on <class 'pandas.core.index.Int64Index'> with these indexers [-1.0] of <type 'float'>
-
 
   String likes in slicing *can* be convertible to the type of the index and lead to natural slicing.
 

--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -211,6 +211,66 @@ Backwards incompatible API changes
      p // 0
 
 
+Indexing Changes
+~~~~~~~~~~~~~~~~
+
+.. _whatsnew_0160.api_breaking.indexing:
+
+The behavior of a small sub-set of edge cases for using ``.loc`` have changed (:issue:`8613`). Furthermore we have improved the content of the error messages that are raised:
+
+- slicing with ``.loc`` where the start and/or stop bound is not found in the index is now allowed; this previously would raise a ``KeyError``. This makes the behavior the same as ``.ix`` in this case. This change is only for slicing, not when indexing with a single label.
+
+  .. ipython:: python
+
+     df = DataFrame(np.random.randn(5,4), columns=list('ABCD'), index=date_range('20130101',periods=5))
+     df
+     s = Series(range(5),[-2,-1,1,2,3])
+     s
+
+  Previous Behavior
+
+  .. code-block:: python
+
+     In [4]: df.loc['2013-01-02':'2013-01-10']
+     KeyError: 'stop bound [2013-01-10] is not in the [index]'
+
+     In [6]: s.loc[-10:3]
+     KeyError: 'start bound [-10] is not the [index]'
+
+     In [8]: s.loc[-1.0:2]
+     Out[2]:
+     -1    1
+      1    2
+      2    3
+     dtype: int64
+
+  New Behavior
+
+  .. ipython:: python
+
+     df.loc['2013-01-02':'2013-01-10']
+     s.loc[-10:3]
+
+  .. code-block:: python
+
+     In [8]: s.loc[-1.0:2]
+     TypeError: cannot do slice indexing on <class 'pandas.core.index.Int64Index'> with these indexers [-1.0] of <type 'float'>
+
+- provide a useful exception for indexing with an invalid type for that index when using ``.loc``. For example trying to use ``.loc`` on an index of type ``DatetimeIndex`` or ``PeriodIndex`` or ``TimedeltaIndex``, with an integer (or a float).
+
+  Previous Behavior
+
+  .. code-block:: python
+
+     In [4]: df.loc[2:3]
+     KeyError: 'start bound [2] is not the [index]'
+
+  New Behavior
+
+  .. code-block:: python
+
+     In [4]: df.loc[2:3]
+     TypeError: Cannot do slice indexing on <class 'pandas.tseries.index.DatetimeIndex'> with <type 'int'> keys
 
 Deprecations
 ~~~~~~~~~~~~

--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -322,13 +322,6 @@ The behavior of a small sub-set of edge cases for using ``.loc`` have changed (:
      In [6]: s.loc[-10:3]
      KeyError: 'start bound [-10] is not the [index]'
 
-     In [8]: s.loc[-1.0:2]
-     Out[2]:
-     -1    1
-      1    2
-      2    3
-     dtype: int64
-
   New Behavior
 
   .. ipython:: python
@@ -336,10 +329,25 @@ The behavior of a small sub-set of edge cases for using ``.loc`` have changed (:
      df.loc['2013-01-02':'2013-01-10']
      s.loc[-10:3]
 
+- allow slicing with float-like values on an integer index for ``.ix``. Previously this was only enabled for ``.loc``:
+
   .. code-block:: python
 
-     In [8]: s.loc[-1.0:2]
-     TypeError: cannot do slice indexing on <class 'pandas.core.index.Int64Index'> with these indexers [-1.0] of <type 'float'>
+  Previous Behavior
+
+     In [8]: s.ix[-1.0:2]
+     TypeError: the slice start value [-1.0] is not a proper indexer for this index type (Int64Index)
+
+  New Behavior
+
+  .. ipython:: python
+
+     In [8]: s.ix[-1.0:2]
+     Out[2]:
+     -1    1
+      1    2
+      2    3
+     dtype: int64
 
 - provide a useful exception for indexing with an invalid type for that index when using ``.loc``. For example trying to use ``.loc`` on an index of type ``DatetimeIndex`` or ``PeriodIndex`` or ``TimedeltaIndex``, with an integer (or a float).
 

--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -20,6 +20,8 @@ users upgrade to this version.
 New features
 ~~~~~~~~~~~~
 
+.. _whatsnew_0160.enhancements:
+
 - Reindex now supports ``method='nearest'`` for frames or series with a monotonic increasing or decreasing index (:issue:`9258`):
 
   .. ipython:: python
@@ -29,7 +31,41 @@ New features
 
   This method is also exposed by the lower level ``Index.get_indexer`` and ``Index.get_loc`` methods.
 
-- DataFrame assign method
+- Paths beginning with ~ will now be expanded to begin with the user's home directory (:issue:`9066`)
+- Added time interval selection in ``get_data_yahoo`` (:issue:`9071`)
+- Added ``Series.str.slice_replace()``, which previously raised ``NotImplementedError`` (:issue:`8888`)
+- Added ``Timestamp.to_datetime64()`` to complement ``Timedelta.to_timedelta64()`` (:issue:`9255`)
+- ``tseries.frequencies.to_offset()`` now accepts ``Timedelta`` as input (:issue:`9064`)
+- Lag parameter was added to the autocorrelation method of ``Series``, defaults to lag-1 autocorrelation (:issue:`9192`)
+- ``Timedelta`` will now accept ``nanoseconds`` keyword in constructor (:issue:`9273`)
+- SQL code now safely escapes table and column names (:issue:`8986`)
+
+- Added auto-complete for ``Series.str.<tab>``, ``Series.dt.<tab>`` and ``Series.cat.<tab>`` (:issue:`9322`)
+- Added ``StringMethods.isalnum()``, ``isalpha()``, ``isdigit()``, ``isspace()``, ``islower()``,
+  ``isupper()``, ``istitle()`` which behave as the same as standard ``str`` (:issue:`9282`)
+
+- Added ``StringMethods.find()`` and ``rfind()`` which behave as the same as standard ``str`` (:issue:`9386`)
+
+- ``Index.get_indexer`` now supports ``method='pad'`` and ``method='backfill'`` even for any target array, not just monotonic targets. These methods also work for monotonic decreasing as well as monotonic increasing indexes (:issue:`9258`).
+- ``Index.asof`` now works on all index types (:issue:`9258`).
+
+- Added ``StringMethods.isnumeric`` and ``isdecimal`` which behave as the same as standard ``str`` (:issue:`9439`)
+- The ``read_excel()`` function's :ref:`sheetname <_io.specifying_sheets>` argument now accepts a list and ``None``, to get multiple or all sheets respectively.  If more than one sheet is specified, a dictionary is returned. (:issue:`9450`)
+
+  .. code-block:: python
+
+     # Returns the 1st and 4th sheet, as a dictionary of DataFrames.
+     pd.read_excel('path_to_file.xls',sheetname=['Sheet1',3])
+
+- A ``verbose`` argument has been augmented in ``io.read_excel()``, defaults to False. Set to True to print sheet names as they are parsed. (:issue:`9450`)
+- Added ``StringMethods.ljust()`` and ``rjust()`` which behave as the same as standard ``str`` (:issue:`9352`)
+- ``StringMethods.pad()`` and ``center()`` now accept ``fillchar`` option to specify filling character (:issue:`9352`)
+- Added ``StringMethods.zfill()`` which behave as the same as standard ``str`` (:issue:`9387`)
+
+DataFrame Assign
+~~~~~~~~~~~~~~~~
+
+.. _whatsnew_0160.enhancements.assign:
 
 Inspired by `dplyr's
 <http://cran.rstudio.com/web/packages/dplyr/vignettes/introduction.html#mutate>`__ ``mutate`` verb, DataFrame has a new
@@ -70,6 +106,55 @@ calculate the ratio, and plot
   :scale: 50 %
 
 See the :ref:`documentation <dsintro.chained_assignment>` for more. (:issue:`9229`)
+
+
+Interaction with scipy.sparse
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. _whatsnew_0160.enhancements.sparse:
+
+Added :meth:`SparseSeries.to_coo` and :meth:`SparseSeries.from_coo` methods (:issue:`8048`) for converting to and from ``scipy.sparse.coo_matrix`` instances (see :ref:`here <sparse.scipysparse>`). For example, given a SparseSeries with MultiIndex we can convert to a `scipy.sparse.coo_matrix` by specifying the row and column labels as index levels:
+
+.. ipython:: python
+
+   from numpy import nan
+   s = Series([3.0, nan, 1.0, 3.0, nan, nan])
+   s.index = MultiIndex.from_tuples([(1, 2, 'a', 0),
+                                     (1, 2, 'a', 1),
+                                     (1, 1, 'b', 0),
+                                     (1, 1, 'b', 1),
+                                     (2, 1, 'b', 0),
+                                     (2, 1, 'b', 1)],
+                                     names=['A', 'B', 'C', 'D'])
+
+   s
+
+   # SparseSeries
+   ss = s.to_sparse()
+   ss
+
+   A, rows, columns = ss.to_coo(row_levels=['A', 'B'],
+                                column_levels=['C', 'D'],
+                                sort_labels=False)
+
+   A
+   A.todense()
+   rows
+   columns
+
+The from_coo method is a convenience method for creating a ``SparseSeries``
+from a ``scipy.sparse.coo_matrix``:
+
+.. ipython:: python
+
+   from scipy import sparse
+   A = sparse.coo_matrix(([3.0, 1.0, 2.0], ([1, 0, 0], [0, 2, 3])),
+                               shape=(3, 4))
+   A
+   A.todense()
+
+   ss = SparseSeries.from_coo(A)
+   ss
 
 .. _whatsnew_0160.api:
 
@@ -277,90 +362,6 @@ Deprecations
 
 .. _whatsnew_0160.deprecations:
 
-
-Enhancements
-~~~~~~~~~~~~
-
-.. _whatsnew_0160.enhancements:
-
-- Paths beginning with ~ will now be expanded to begin with the user's home directory (:issue:`9066`)
-- Added time interval selection in ``get_data_yahoo`` (:issue:`9071`)
-- Added ``Series.str.slice_replace()``, which previously raised ``NotImplementedError`` (:issue:`8888`)
-- Added ``Timestamp.to_datetime64()`` to complement ``Timedelta.to_timedelta64()`` (:issue:`9255`)
-- ``tseries.frequencies.to_offset()`` now accepts ``Timedelta`` as input (:issue:`9064`)
-- Lag parameter was added to the autocorrelation method of ``Series``, defaults to lag-1 autocorrelation (:issue:`9192`)
-- ``Timedelta`` will now accept ``nanoseconds`` keyword in constructor (:issue:`9273`)
-- SQL code now safely escapes table and column names (:issue:`8986`)
-
-- Added auto-complete for ``Series.str.<tab>``, ``Series.dt.<tab>`` and ``Series.cat.<tab>`` (:issue:`9322`)
-- Added ``StringMethods.isalnum()``, ``isalpha()``, ``isdigit()``, ``isspace()``, ``islower()``,
-  ``isupper()``, ``istitle()`` which behave as the same as standard ``str`` (:issue:`9282`)
-
-- Added ``StringMethods.find()`` and ``rfind()`` which behave as the same as standard ``str`` (:issue:`9386`)
-
-- ``Index.get_indexer`` now supports ``method='pad'`` and ``method='backfill'`` even for any target array, not just monotonic targets. These methods also work for monotonic decreasing as well as monotonic increasing indexes (:issue:`9258`).
-- ``Index.asof`` now works on all index types (:issue:`9258`).
-
-- Added ``StringMethods.isnumeric`` and ``isdecimal`` which behave as the same as standard ``str`` (:issue:`9439`)
-- The ``read_excel()`` function's :ref:`sheetname <_io.specifying_sheets>` argument now accepts a list and ``None``, to get multiple or all sheets respectively.  If more than one sheet is specified, a dictionary is returned. (:issue:`9450`)
-
-  .. code-block:: python
-
-     # Returns the 1st and 4th sheet, as a dictionary of DataFrames.
-     pd.read_excel('path_to_file.xls',sheetname=['Sheet1',3])
-
-- A ``verbose`` argument has been augmented in ``io.read_excel()``, defaults to False. Set to True to print sheet names as they are parsed. (:issue:`9450`)
-- Added ``StringMethods.ljust()`` and ``rjust()`` which behave as the same as standard ``str`` (:issue:`9352`)
-- ``StringMethods.pad()`` and ``center()`` now accept ``fillchar`` option to specify filling character (:issue:`9352`)
-- Added ``StringMethods.zfill()`` which behave as the same as standard ``str`` (:issue:`9387`)
-
-Interaction with scipy.sparse
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. _whatsnew_0160.enhancements.sparse:
-
-Added :meth:`SparseSeries.to_coo` and :meth:`SparseSeries.from_coo` methods (:issue:`8048`) for converting to and from ``scipy.sparse.coo_matrix`` instances (see :ref:`here <sparse.scipysparse>`). For example, given a SparseSeries with MultiIndex we can convert to a `scipy.sparse.coo_matrix` by specifying the row and column labels as index levels:
-
-.. ipython:: python
-
-   from numpy import nan
-   s = Series([3.0, nan, 1.0, 3.0, nan, nan])
-   s.index = MultiIndex.from_tuples([(1, 2, 'a', 0),
-                                     (1, 2, 'a', 1),
-                                     (1, 1, 'b', 0),
-                                     (1, 1, 'b', 1),
-                                     (2, 1, 'b', 0),
-                                     (2, 1, 'b', 1)],
-                                     names=['A', 'B', 'C', 'D'])
-
-   s
-
-   # SparseSeries
-   ss = s.to_sparse()
-   ss
-
-   A, rows, columns = ss.to_coo(row_levels=['A', 'B'],
-                                column_levels=['C', 'D'],
-                                sort_labels=False)
-
-   A
-   A.todense()
-   rows
-   columns
-
-The from_coo method is a convenience method for creating a ``SparseSeries``
-from a ``scipy.sparse.coo_matrix``:
-
-.. ipython:: python
-
-   from scipy import sparse
-   A = sparse.coo_matrix(([3.0, 1.0, 2.0], ([1, 0, 0], [0, 2, 3])),
-                               shape=(3, 4))
-   A
-   A.todense()
-
-   ss = SparseSeries.from_coo(A)
-   ss
 
 Performance
 ~~~~~~~~~~~

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1159,11 +1159,11 @@ class NDFrame(PandasObject):
         else:
             self._item_cache.clear()
 
-    def _slice(self, slobj, axis=0, typ=None):
+    def _slice(self, slobj, axis=0, kind=None):
         """
         Construct a slice of this container.
 
-        typ parameter is maintained for compatibility with Series slicing.
+        kind parameter is maintained for compatibility with Series slicing.
 
         """
         axis = self._get_block_manager_axis(axis)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -2134,7 +2134,7 @@ class Index(IndexOpsMixin, PandasObject):
         # pass thru float indexers if we have a numeric type index
         # which then can decide to process / or convert and warng
         if is_float(label):
-            if not self.is_floating():
+            if not (self.is_integer() or self.is_floating()):
                 self._invalid_indexer('slice',label)
 
         # we are not an integer based index, and we have an integer label

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -632,8 +632,16 @@ class Index(IndexOpsMixin, PandasObject):
     def holds_integer(self):
         return self.inferred_type in ['integer', 'mixed-integer']
 
-    def _convert_scalar_indexer(self, key, typ=None):
-        """ convert a scalar indexer, right now we are converting
+    def _convert_scalar_indexer(self, key, kind=None):
+        """
+        convert a scalar indexer
+
+        Parameters
+        ----------
+        key : label of the slice bound
+        kind : optional, type of the indexing operation (loc/ix/iloc/None)
+
+        right now we are converting
         floats -> ints if the index supports it
         """
 
@@ -643,7 +651,7 @@ class Index(IndexOpsMixin, PandasObject):
                 return self._invalid_indexer('label', key)
             return ikey
 
-        if typ == 'iloc':
+        if kind == 'iloc':
             if is_integer(key):
                 return key
             elif is_float(key):
@@ -661,14 +669,6 @@ class Index(IndexOpsMixin, PandasObject):
 
         return key
 
-    def _validate_slicer(self, key, f):
-        """ validate and raise if needed on a slice indexers according to the
-        passed in function """
-
-        for c in ['start','stop','step']:
-            if not f(getattr(key,c)):
-                self._invalid_indexer('slice {0} value'.format(c), key.start)
-
     def _convert_slice_indexer_getitem(self, key, is_index_slice=False):
         """ called from the getitem slicers, determine how to treat the key
             whether positional or not """
@@ -676,15 +676,22 @@ class Index(IndexOpsMixin, PandasObject):
             return key
         return self._convert_slice_indexer(key)
 
-    def _convert_slice_indexer(self, key, typ=None):
-        """ convert a slice indexer. disallow floats in the start/stop/step """
+    def _convert_slice_indexer(self, key, kind=None):
+        """
+        convert a slice indexer. disallow floats in the start/stop/step
+
+        Parameters
+        ----------
+        key : label of the slice bound
+        kind : optional, type of the indexing operation (loc/ix/iloc/None)
+        """
 
         # if we are not a slice, then we are done
         if not isinstance(key, slice):
             return key
 
         # validate iloc
-        if typ == 'iloc':
+        if kind == 'iloc':
 
             # need to coerce to_int if needed
             def f(c):
@@ -709,13 +716,16 @@ class Index(IndexOpsMixin, PandasObject):
 
             # dissallow floats (except for .ix)
             elif is_float(v):
-                if typ == 'ix':
+                if kind == 'ix':
                     return True
 
                 return False
 
             return True
-        self._validate_slicer(key, validate)
+        for c in ['start','stop','step']:
+            v = getattr(key,c)
+            if not validate(v):
+                self._invalid_indexer('slice {0} value'.format(c), v)
 
         # figure out if this is a positional indexer
         start, stop, step = key.start, key.stop, key.step
@@ -727,7 +737,7 @@ class Index(IndexOpsMixin, PandasObject):
         is_index_slice = is_int(start) and is_int(stop)
         is_positional = is_index_slice and not self.is_integer()
 
-        if typ == 'getitem':
+        if kind == 'getitem':
             return self._convert_slice_indexer_getitem(
                 key, is_index_slice=is_index_slice)
 
@@ -763,16 +773,16 @@ class Index(IndexOpsMixin, PandasObject):
 
         return indexer
 
-    def _convert_list_indexer(self, key, typ=None):
+    def _convert_list_indexer(self, key, kind=None):
         """ convert a list indexer. these should be locations """
         return key
 
-    def _convert_list_indexer_for_mixed(self, keyarr, typ=None):
+    def _convert_list_indexer_for_mixed(self, keyarr, kind=None):
         """ passed a key that is tuplesafe that is integer based
             and we have a mixed index (e.g. number/labels). figure out
             the indexer. return None if we can't help
         """
-        if (typ is None or typ in ['iloc','ix']) and (is_integer_dtype(keyarr) and not self.is_floating()):
+        if (kind is None or kind in ['iloc','ix']) and (is_integer_dtype(keyarr) and not self.is_floating()):
             if self.inferred_type != 'integer':
                 keyarr = np.where(keyarr < 0,
                                   len(self) + keyarr, keyarr)
@@ -793,10 +803,10 @@ class Index(IndexOpsMixin, PandasObject):
     def _invalid_indexer(self, form, key):
         """ consistent invalid indexer message """
         raise TypeError("cannot do {form} indexing on {klass} with these "
-                        "indexers [{key}] of {typ}".format(form=form,
+                        "indexers [{key}] of {kind}".format(form=form,
                                                            klass=type(self),
                                                            key=key,
-                                                           typ=type(key)))
+                                                           kind=type(key)))
 
     def get_duplicates(self):
         from collections import defaultdict
@@ -844,8 +854,8 @@ class Index(IndexOpsMixin, PandasObject):
         """ return a string of the type inferred from the values """
         return lib.infer_dtype(self)
 
-    def is_type_compatible(self, typ):
-        return typ == self.inferred_type
+    def is_type_compatible(self, kind):
+        return kind == self.inferred_type
 
     @cache_readonly
     def is_all_dates(self):
@@ -2082,7 +2092,7 @@ class Index(IndexOpsMixin, PandasObject):
         name = self.name if self.name == other.name else None
         return Index(joined, name=name)
 
-    def slice_indexer(self, start=None, end=None, step=None):
+    def slice_indexer(self, start=None, end=None, step=None, kind=None):
         """
         For an ordered Index, compute the slice indexer for input labels and
         step
@@ -2094,6 +2104,7 @@ class Index(IndexOpsMixin, PandasObject):
         end : label, default None
             If None, defaults to the end
         step : int, default None
+        kind : string, default None
 
         Returns
         -------
@@ -2103,7 +2114,7 @@ class Index(IndexOpsMixin, PandasObject):
         -----
         This function assumes that the data is sorted, so use at your own peril
         """
-        start_slice, end_slice = self.slice_locs(start, end, step=step)
+        start_slice, end_slice = self.slice_locs(start, end, step=step, kind=kind)
 
         # return a slice
         if not lib.isscalar(start_slice):
@@ -2113,7 +2124,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         return slice(start_slice, end_slice, step)
 
-    def _maybe_cast_slice_bound(self, label, side):
+    def _maybe_cast_slice_bound(self, label, side, kind):
         """
         This function should be overloaded in subclasses that allow non-trivial
         casting on label-slice bounds, e.g. datetime-like indices allowing
@@ -2123,6 +2134,7 @@ class Index(IndexOpsMixin, PandasObject):
         ----------
         label : object
         side : {'left', 'right'}
+        kind : string / None
 
         Returns
         -------
@@ -2134,15 +2146,16 @@ class Index(IndexOpsMixin, PandasObject):
 
         """
 
-        # pass thru float indexers if we have a numeric type index
-        # which then can decide to process / or convert and warng
+        # We are a plain index here (sub-class override this method if they
+        # wish to have special treatment for floats/ints, e.g. Float64Index and
+        # datetimelike Indexes
+        # reject them
         if is_float(label):
-            if not (self.is_integer() or self.is_floating()):
-                self._invalid_indexer('slice',label)
+            self._invalid_indexer('slice',label)
 
-        # we are not an integer based index, and we have an integer label
-        # treat as positional based slicing semantics
-        if not self.is_integer() and is_integer(label):
+        # we are trying to find integer bounds on a non-integer based index
+        # this is rejected (generally .loc gets you here)
+        elif is_integer(label):
             self._invalid_indexer('slice',label)
 
         return label
@@ -2160,7 +2173,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         raise ValueError('index must be monotonic increasing or decreasing')
 
-    def get_slice_bound(self, label, side):
+    def get_slice_bound(self, label, side, kind):
         """
         Calculate slice bound that corresponds to given label.
 
@@ -2171,6 +2184,7 @@ class Index(IndexOpsMixin, PandasObject):
         ----------
         label : object
         side : {'left', 'right'}
+        kind : string / None, the type of indexer
 
         """
         if side not in ('left', 'right'):
@@ -2182,7 +2196,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         # For datetime indices label may be a string that has to be converted
         # to datetime boundary according to its resolution.
-        label = self._maybe_cast_slice_bound(label, side)
+        label = self._maybe_cast_slice_bound(label, side, kind)
 
         # we need to look up the label
         try:
@@ -2217,7 +2231,7 @@ class Index(IndexOpsMixin, PandasObject):
             else:
                 return slc
 
-    def slice_locs(self, start=None, end=None, step=None):
+    def slice_locs(self, start=None, end=None, step=None, kind=None):
         """
         Compute slice locations for input labels.
 
@@ -2227,6 +2241,9 @@ class Index(IndexOpsMixin, PandasObject):
             If None, defaults to the beginning
         end : label, default None
             If None, defaults to the end
+        step : int, defaults None
+            If None, defaults to 1
+        kind : string, defaults None
 
         Returns
         -------
@@ -2241,13 +2258,13 @@ class Index(IndexOpsMixin, PandasObject):
 
         start_slice = None
         if start is not None:
-            start_slice = self.get_slice_bound(start, 'left')
+            start_slice = self.get_slice_bound(start, 'left', kind)
         if start_slice is None:
             start_slice = 0
 
         end_slice = None
         if end is not None:
-            end_slice = self.get_slice_bound(end, 'right')
+            end_slice = self.get_slice_bound(end, 'right', kind)
         if end_slice is None:
             end_slice = len(self)
 
@@ -2504,6 +2521,35 @@ class NumericIndex(Index):
     """
     _is_numeric_dtype = True
 
+    def _maybe_cast_slice_bound(self, label, side, kind):
+        """
+        This function should be overloaded in subclasses that allow non-trivial
+        casting on label-slice bounds, e.g. datetime-like indices allowing
+        strings containing formatted datetimes.
+
+        Parameters
+        ----------
+        label : object
+        side : {'left', 'right'}
+        kind : string / None
+
+        Returns
+        -------
+        label :  object
+
+        Notes
+        -----
+        Value of `side` parameter should be validated in caller.
+
+        """
+
+        # we are a numeric index, so we accept
+        # integer/floats directly
+        if not (is_integer(label) or is_float(label)):
+            self._invalid_indexer('slice',label)
+
+        return label
+
 class Int64Index(NumericIndex):
 
     """
@@ -2677,52 +2723,30 @@ class Float64Index(NumericIndex):
                             self.__class__)
         return Index(self.values, name=self.name, dtype=dtype)
 
-    def _maybe_cast_slice_bound(self, label, side):
+    def _convert_scalar_indexer(self, key, kind=None):
+        if kind == 'iloc':
+            return super(Float64Index, self)._convert_scalar_indexer(key,
+                                                                     kind=kind)
+        return key
+
+    def _convert_slice_indexer(self, key, kind=None):
         """
-        This function should be overloaded in subclasses that allow non-trivial
-        casting on label-slice bounds, e.g. datetime-like indices allowing
-        strings containing formatted datetimes.
+        convert a slice indexer, by definition these are labels
+        unless we are iloc
 
         Parameters
         ----------
-        label : object
-        side : {'left', 'right'}
-
-        Returns
-        -------
-        label :  object
-
-        Notes
-        -----
-        Value of `side` parameter should be validated in caller.
-
+        key : label of the slice bound
+        kind : optional, type of the indexing operation (loc/ix/iloc/None)
         """
-        if not (is_integer(label) or is_float(label)):
-            self._invalid_indexer('slice',label)
-
-        return label
-
-    def _convert_scalar_indexer(self, key, typ=None):
-        if typ == 'iloc':
-            return super(Float64Index, self)._convert_scalar_indexer(key,
-                                                                     typ=typ)
-        return key
-
-    def _convert_slice_indexer(self, key, typ=None):
-        """ convert a slice indexer, by definition these are labels
-            unless we are iloc """
 
         # if we are not a slice, then we are done
         if not isinstance(key, slice):
             return key
 
-        if typ == 'iloc':
+        if kind == 'iloc':
             return super(Float64Index, self)._convert_slice_indexer(key,
-                                                                    typ=typ)
-
-        # allow floats here
-        validator = lambda v: v is None or is_integer(v) or is_float(v)
-        self._validate_slicer(key, validator)
+                                                                    kind=kind)
 
         # translate to locations
         return self.slice_indexer(key.start, key.stop, key.step)
@@ -4147,12 +4171,12 @@ class MultiIndex(Index):
         """
         return Index(self.values)
 
-    def get_slice_bound(self, label, side):
+    def get_slice_bound(self, label, side, kind):
         if not isinstance(label, tuple):
             label = label,
         return self._partial_tup_index(label, side=side)
 
-    def slice_locs(self, start=None, end=None, step=None):
+    def slice_locs(self, start=None, end=None, step=None, kind=None):
         """
         For an ordered MultiIndex, compute the slice locations for input
         labels. They can be tuples representing partial levels, e.g. for a
@@ -4167,6 +4191,7 @@ class MultiIndex(Index):
             If None, defaults to the end
         step : int or None
             Slice step
+        kind : string, optional, defaults None
 
         Returns
         -------
@@ -4178,7 +4203,7 @@ class MultiIndex(Index):
         """
         # This function adds nothing to its parent implementation (the magic
         # happens in get_slice_bound method), but it adds meaningful doc.
-        return super(MultiIndex, self).slice_locs(start, end, step)
+        return super(MultiIndex, self).slice_locs(start, end, step, kind=kind)
 
     def _partial_tup_index(self, tup, side='left'):
         if len(tup) > self.lexsort_depth:

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -707,8 +707,11 @@ class Index(IndexOpsMixin, PandasObject):
             if v is None or is_integer(v):
                 return True
 
-            # dissallow floats
+            # dissallow floats (except for .ix)
             elif is_float(v):
+                if typ == 'ix':
+                    return True
+
                 return False
 
             return True

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1243,25 +1243,7 @@ class _LocIndexer(_LocationIndexer):
         # boolean
 
         if isinstance(key, slice):
-
-            if ax.is_floating():
-
-                # allowing keys to be slicers with no fallback
-                pass
-
-            else:
-                if key.start is not None:
-                    if key.start not in ax:
-                        raise KeyError(
-                            "start bound [%s] is not the [%s]" %
-                            (key.start, self.obj._get_axis_name(axis))
-                        )
-                if key.stop is not None:
-                    if key.stop not in ax:
-                        raise KeyError(
-                            "stop bound [%s] is not in the [%s]" %
-                            (key.stop, self.obj._get_axis_name(axis))
-                        )
+            return True
 
         elif is_bool_indexer(key):
             return True

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -91,8 +91,8 @@ class _NDFrameIndexer(object):
     def _get_loc(self, key, axis=0):
         return self.obj._ixs(key, axis=axis)
 
-    def _slice(self, obj, axis=0, typ=None):
-        return self.obj._slice(obj, axis=axis, typ=typ)
+    def _slice(self, obj, axis=0, kind=None):
+        return self.obj._slice(obj, axis=axis, kind=kind)
 
     def _get_setitem_indexer(self, key):
         if self.axis is not None:
@@ -163,12 +163,12 @@ class _NDFrameIndexer(object):
         # if we are accessing via lowered dim, use the last dim
         ax = self.obj._get_axis(min(axis, self.ndim - 1))
         # a scalar
-        return ax._convert_scalar_indexer(key, typ=self.name)
+        return ax._convert_scalar_indexer(key, kind=self.name)
 
     def _convert_slice_indexer(self, key, axis):
         # if we are accessing via lowered dim, use the last dim
         ax = self.obj._get_axis(min(axis, self.ndim - 1))
-        return ax._convert_slice_indexer(key, typ=self.name)
+        return ax._convert_slice_indexer(key, kind=self.name)
 
     def _has_valid_setitem_indexer(self, indexer):
         return True
@@ -960,7 +960,7 @@ class _NDFrameIndexer(object):
                 keyarr = _asarray_tuplesafe(key)
 
             # handle a mixed integer scenario
-            indexer = labels._convert_list_indexer_for_mixed(keyarr, typ=self.name)
+            indexer = labels._convert_list_indexer_for_mixed(keyarr, kind=self.name)
             if indexer is not None:
                 return self.obj.take(indexer, axis=axis)
 
@@ -1107,7 +1107,7 @@ class _NDFrameIndexer(object):
                     objarr = _asarray_tuplesafe(obj)
 
                 # If have integer labels, defer to label-based indexing
-                indexer = labels._convert_list_indexer_for_mixed(objarr, typ=self.name)
+                indexer = labels._convert_list_indexer_for_mixed(objarr, kind=self.name)
                 if indexer is not None:
                     return indexer
 
@@ -1163,7 +1163,7 @@ class _NDFrameIndexer(object):
         indexer = self._convert_slice_indexer(slice_obj, axis)
 
         if isinstance(indexer, slice):
-            return self._slice(indexer, axis=axis, typ='iloc')
+            return self._slice(indexer, axis=axis, kind='iloc')
         else:
             return self.obj.take(indexer, axis=axis, convert=False)
 
@@ -1221,7 +1221,7 @@ class _LocationIndexer(_NDFrameIndexer):
                                        slice_obj.step)
 
         if isinstance(indexer, slice):
-            return self._slice(indexer, axis=axis, typ='iloc')
+            return self._slice(indexer, axis=axis, kind='iloc')
         else:
             return self.obj.take(indexer, axis=axis, convert=False)
 
@@ -1412,7 +1412,7 @@ class _iLocIndexer(_LocationIndexer):
 
         slice_obj = self._convert_slice_indexer(slice_obj, axis)
         if isinstance(slice_obj, slice):
-            return self._slice(slice_obj, axis=axis, typ='iloc')
+            return self._slice(slice_obj, axis=axis, kind='iloc')
         else:
             return self.obj.take(slice_obj, axis=axis, convert=False)
 
@@ -1572,7 +1572,7 @@ def convert_to_index_sliceable(obj, key):
     """
     idx = obj.index
     if isinstance(key, slice):
-        return idx._convert_slice_indexer(key, typ='getitem')
+        return idx._convert_slice_indexer(key, kind='getitem')
 
     elif isinstance(key, compat.string_types):
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -491,7 +491,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             raise
         except:
             if isinstance(i, slice):
-                indexer = self.index._convert_slice_indexer(i, typ='iloc')
+                indexer = self.index._convert_slice_indexer(i, kind='iloc')
                 return self._get_values(indexer)
             else:
                 label = self.index[i]
@@ -504,8 +504,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     def _is_mixed_type(self):
         return False
 
-    def _slice(self, slobj, axis=0, typ=None):
-        slobj = self.index._convert_slice_indexer(slobj, typ=typ or 'getitem')
+    def _slice(self, slobj, axis=0, kind=None):
+        slobj = self.index._convert_slice_indexer(slobj, kind=kind or 'getitem')
         return self._get_values(slobj)
 
     def __getitem__(self, key):
@@ -536,7 +536,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             else:
 
                 # we can try to coerce the indexer (or this will raise)
-                new_key = self.index._convert_scalar_indexer(key,typ='getitem')
+                new_key = self.index._convert_scalar_indexer(key,kind='getitem')
                 if type(new_key) != type(key):
                     return self.__getitem__(new_key)
                 raise
@@ -555,7 +555,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     def _get_with(self, key):
         # other: fancy integer or otherwise
         if isinstance(key, slice):
-            indexer = self.index._convert_slice_indexer(key, typ='getitem')
+            indexer = self.index._convert_slice_indexer(key, kind='getitem')
             return self._get_values(indexer)
         elif isinstance(key, ABCDataFrame):
             raise TypeError('Indexing a Series with DataFrame is not supported, '\
@@ -693,7 +693,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     def _set_with(self, key, value):
         # other: fancy integer or otherwise
         if isinstance(key, slice):
-            indexer = self.index._convert_slice_indexer(key, typ='getitem')
+            indexer = self.index._convert_slice_indexer(key, kind='getitem')
             return self._set_values(indexer, value)
         else:
             if isinstance(key, tuple):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -536,7 +536,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             else:
 
                 # we can try to coerce the indexer (or this will raise)
-                new_key = self.index._convert_scalar_indexer(key)
+                new_key = self.index._convert_scalar_indexer(key,typ='getitem')
                 if type(new_key) != type(key):
                     return self.__getitem__(new_key)
                 raise

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -378,7 +378,7 @@ class SparseDataFrame(DataFrame):
         return dense.to_sparse(kind=self._default_kind,
                                fill_value=self._default_fill_value)
 
-    def _slice(self, slobj, axis=0, typ=None):
+    def _slice(self, slobj, axis=0, kind=None):
         if axis == 0:
             new_index = self.index[slobj]
             new_columns = self.columns

--- a/pandas/sparse/panel.py
+++ b/pandas/sparse/panel.py
@@ -68,10 +68,10 @@ class SparsePanel(Panel):
     def __init__(self, frames=None, items=None, major_axis=None, minor_axis=None,
                  default_fill_value=np.nan, default_kind='block',
                  copy=False):
-                 
+
         if frames is None:
             frames = {}
-            
+
         if isinstance(frames, np.ndarray):
             new_frames = {}
             for item, vals in zip(items, frames):
@@ -191,7 +191,7 @@ class SparsePanel(Panel):
 
         return self.xs(key, axis=axis)
 
-    def _slice(self, slobj, axis=0, typ=None):
+    def _slice(self, slobj, axis=0, kind=None):
         """
         for compat as we don't support Block Manager here
         """

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -969,11 +969,11 @@ class TestIndex(Base, tm.TestCase):
 
         # int slicing with floats
         idx = Index(np.array([0, 1, 2, 5, 6, 7, 9, 10], dtype=int))
-        self.assertRaises(TypeError, lambda : idx.slice_locs(5.0, 10.0))
-        self.assertRaises(TypeError, lambda : idx.slice_locs(4.5, 10.5))
+        self.assertEqual(idx.slice_locs(5.0, 10.0), (3, n))
+        self.assertEqual(idx.slice_locs(4.5, 10.5), (3, 8))
         idx2 = idx[::-1]
-        self.assertRaises(TypeError, lambda : idx2.slice_locs(8.5, 1.5))
-        self.assertRaises(TypeError, lambda : idx2.slice_locs(10.5, -1))
+        self.assertEqual(idx2.slice_locs(8.5, 1.5), (2, 6))
+        self.assertEqual(idx2.slice_locs(10.5, -1), (0, n))
 
     def test_slice_locs_dup(self):
         idx = Index(['a', 'a', 'b', 'c', 'd', 'd'])

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -950,16 +950,30 @@ class TestIndex(Base, tm.TestCase):
             self.assertEqual(idx.slice_locs(start=3), (3, n))
             self.assertEqual(idx.slice_locs(3, 8), (3, 6))
             self.assertEqual(idx.slice_locs(5, 10), (3, n))
-            self.assertEqual(idx.slice_locs(5.0, 10.0), (3, n))
-            self.assertEqual(idx.slice_locs(4.5, 10.5), (3, 8))
             self.assertEqual(idx.slice_locs(end=8), (0, 6))
             self.assertEqual(idx.slice_locs(end=9), (0, 7))
 
+            # reversed
             idx2 = idx[::-1]
             self.assertEqual(idx2.slice_locs(8, 2), (2, 6))
-            self.assertEqual(idx2.slice_locs(8.5, 1.5), (2, 6))
             self.assertEqual(idx2.slice_locs(7, 3), (2, 5))
-            self.assertEqual(idx2.slice_locs(10.5, -1), (0, n))
+
+        # float slicing
+        idx = Index(np.array([0, 1, 2, 5, 6, 7, 9, 10], dtype=float))
+        n = len(idx)
+        self.assertEqual(idx.slice_locs(5.0, 10.0), (3, n))
+        self.assertEqual(idx.slice_locs(4.5, 10.5), (3, 8))
+        idx2 = idx[::-1]
+        self.assertEqual(idx2.slice_locs(8.5, 1.5), (2, 6))
+        self.assertEqual(idx2.slice_locs(10.5, -1), (0, n))
+
+        # int slicing with floats
+        idx = Index(np.array([0, 1, 2, 5, 6, 7, 9, 10], dtype=int))
+        self.assertRaises(TypeError, lambda : idx.slice_locs(5.0, 10.0))
+        self.assertRaises(TypeError, lambda : idx.slice_locs(4.5, 10.5))
+        idx2 = idx[::-1]
+        self.assertRaises(TypeError, lambda : idx2.slice_locs(8.5, 1.5))
+        self.assertRaises(TypeError, lambda : idx2.slice_locs(10.5, -1))
 
     def test_slice_locs_dup(self):
         idx = Index(['a', 'a', 'b', 'c', 'd', 'd'])

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -709,10 +709,6 @@ class TestIndexing(tm.TestCase):
             compare(df2, df1)
 
         # edge cases
-        s = Series(['a','b','c','d'], [1,2,3,4])
-        self.assertRaises(TypeError, lambda : s.ix[1.5:5.5])
-        self.assertRaises(TypeError, lambda : s.loc[1.5:5.5])
-
         s = Series([1,2,3,4], index=list('abde'))
 
         result1 = s['a':'c']
@@ -4047,7 +4043,7 @@ class TestIndexing(tm.TestCase):
 
         # int
         index = tm.makeIntIndex()
-        s = Series(np.arange(len(index))+10,index)
+        s = Series(np.arange(len(index))+10,index+5)
 
         # this is positional
         result1 = s[2:5]
@@ -4059,55 +4055,80 @@ class TestIndexing(tm.TestCase):
         result3 = s.loc[2:5]
         assert_series_equal(result2, result3)
 
-        # make all float slicing fail
-        self.assertRaises(TypeError, lambda : s.loc[2.0:5])
-        self.assertRaises(TypeError, lambda : s.loc[2.0:5.0])
-        self.assertRaises(TypeError, lambda : s.loc[2:5.0])
-        self.assertRaises(TypeError, lambda : s[2.0:5])
-        self.assertRaises(TypeError, lambda : s[2.0:5.0])
-        self.assertRaises(TypeError, lambda : s[2:5.0])
+        # float slicers on an int index
+        expected = Series([11,12,13],index=[6,7,8])
+        result = s.loc[6.0:8.5]
+        assert_series_equal(result, expected)
 
-        self.assertRaises(TypeError, lambda : s.ix[2.0:5])
-        self.assertRaises(TypeError, lambda : s.ix[2.0:5.0])
-        self.assertRaises(TypeError, lambda : s.ix[2:5.0])
+        result = s.loc[5.5:8.5]
+        assert_series_equal(result, expected)
+
+        result = s.loc[5.5:8.0]
+        assert_series_equal(result, expected)
+
+        # make all float slicing fail for ix/[] with an int index
+        self.assertRaises(TypeError, lambda : s[6.0:8])
+        self.assertRaises(TypeError, lambda : s[6.0:8.0])
+        self.assertRaises(TypeError, lambda : s[6:8.0])
+        self.assertRaises(TypeError, lambda : s.ix[6.0:8])
+        self.assertRaises(TypeError, lambda : s.ix[6.0:8.0])
+        self.assertRaises(TypeError, lambda : s.ix[6:8.0])
 
         # these work for now
-        #self.assertRaises(TypeError, lambda : s.iloc[2.0:5])
-        #self.assertRaises(TypeError, lambda : s.iloc[2.0:5.0])
-        #self.assertRaises(TypeError, lambda : s.iloc[2:5.0])
+        #self.assertRaises(TypeError, lambda : s.iloc[6.0:8])
+        #self.assertRaises(TypeError, lambda : s.iloc[6.0:8.0])
+        #self.assertRaises(TypeError, lambda : s.iloc[6:8.0])
 
         # float
         index = tm.makeFloatIndex()
-        s = Series(np.arange(len(index))+10,index=index)
+        s = Series(np.arange(len(index))+10,index=index+5)
 
         # these are all value based
-        result1 = s[2:5]
-        result2 = s.ix[2:5]
-        result3 = s.loc[2:5]
+        result1 = s[6:8]
+        result2 = s.ix[6:8]
+        result3 = s.loc[6:8]
         assert_series_equal(result1, result2)
         assert_series_equal(result1, result3)
 
         # these are all valid
-        result1a = s[2.0:5]
-        result2a = s[2.0:5.0]
-        result3a = s[2:5.0]
+        result1a = s[6.0:8]
+        result2a = s[6.0:8.0]
+        result3a = s[6:8.0]
+        result1b = s[6.5:8]
+        result2b = s[6.5:8.5]
+        result3b = s[6:8.5]
         assert_series_equal(result1a, result2a)
         assert_series_equal(result1a, result3a)
-
-        result1b = s.ix[2.0:5]
-        result2b = s.ix[2.0:5.0]
-        result3b = s.ix[2:5.0]
-        assert_series_equal(result1b, result2b)
-        assert_series_equal(result1b, result3b)
-
-        result1c = s.loc[2.0:5]
-        result2c = s.loc[2.0:5.0]
-        result3c = s.loc[2:5.0]
-        assert_series_equal(result1c, result2c)
-        assert_series_equal(result1c, result3c)
-
         assert_series_equal(result1a, result1b)
+        assert_series_equal(result1a, result2b)
+        assert_series_equal(result1a, result3b)
+
+        result1c = s.ix[6.0:8]
+        result2c = s.ix[6.0:8.0]
+        result3c = s.ix[6:8.0]
+        result1d = s.ix[6.5:8]
+        result2d = s.ix[6.5:8.5]
+        result3d = s.ix[6:8.5]
         assert_series_equal(result1a, result1c)
+        assert_series_equal(result1a, result2c)
+        assert_series_equal(result1a, result3c)
+        assert_series_equal(result1a, result1d)
+        assert_series_equal(result1a, result2d)
+        assert_series_equal(result1a, result3d)
+
+        result1e = s.loc[6.0:8]
+        result2e = s.loc[6.0:8.0]
+        result3e = s.loc[6:8.0]
+        result1f = s.loc[6.5:8]
+        result2f = s.loc[6.5:8.5]
+        result3f = s.loc[6:8.5]
+        assert_series_equal(result1a, result1e)
+        assert_series_equal(result1a, result2e)
+        assert_series_equal(result1a, result3e)
+        assert_series_equal(result1a, result1f)
+        assert_series_equal(result1a, result2f)
+        assert_series_equal(result1a, result3f)
+
 
         # these work for now
         #self.assertRaises(TypeError, lambda : s.iloc[2.0:5])

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -1001,8 +1001,8 @@ class TestIndexing(tm.TestCase):
         self.check_result('lab slice', 'loc', slice('W','Z'), 'ix', slice('W','Z'), typs = ['labels'], axes=2)
 
         self.check_result('ts  slice', 'loc', slice('20130102','20130104'), 'ix', slice('20130102','20130104'), typs = ['ts'], axes=0)
-        self.check_result('ts  slice', 'loc', slice('20130102','20130104'), 'ix', slice('20130102','20130104'), typs = ['ts'], axes=1, fails=KeyError)
-        self.check_result('ts  slice', 'loc', slice('20130102','20130104'), 'ix', slice('20130102','20130104'), typs = ['ts'], axes=2, fails=KeyError)
+        self.check_result('ts  slice', 'loc', slice('20130102','20130104'), 'ix', slice('20130102','20130104'), typs = ['ts'], axes=1, fails=TypeError)
+        self.check_result('ts  slice', 'loc', slice('20130102','20130104'), 'ix', slice('20130102','20130104'), typs = ['ts'], axes=2, fails=TypeError)
 
         self.check_result('mixed slice', 'loc', slice(2,8), 'ix', slice(2,8), typs = ['mixed'], axes=0, fails=TypeError)
         self.check_result('mixed slice', 'loc', slice(2,8), 'ix', slice(2,8), typs = ['mixed'], axes=1, fails=KeyError)

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -4004,6 +4004,12 @@ class TestIndexing(tm.TestCase):
 
     def test_slice_indexer(self):
 
+        def check_iloc_compat(s):
+            # invalid type for iloc (but works with a warning)
+            self.assert_produces_warning(FutureWarning, lambda : s.iloc[6.0:8])
+            self.assert_produces_warning(FutureWarning, lambda : s.iloc[6.0:8.0])
+            self.assert_produces_warning(FutureWarning, lambda : s.iloc[6:8.0])
+
         def check_slicing_positional(index):
 
             s = Series(np.arange(len(index))+10,index=index)
@@ -4031,17 +4037,16 @@ class TestIndexing(tm.TestCase):
             self.assertRaises(TypeError, lambda : s.loc[2.0:5.0])
             self.assertRaises(TypeError, lambda : s.loc[2:5.0])
 
-            # these work for now
-            #self.assertRaises(TypeError, lambda : s.iloc[2.0:5])
-            #self.assertRaises(TypeError, lambda : s.iloc[2.0:5.0])
-            #self.assertRaises(TypeError, lambda : s.iloc[2:5.0])
+            check_iloc_compat(s)
 
         # all index types except int, float
         for index in [ tm.makeStringIndex, tm.makeUnicodeIndex,
                        tm.makeDateIndex, tm.makeTimedeltaIndex, tm.makePeriodIndex ]:
             check_slicing_positional(index())
 
-        # int
+        ############
+        # IntIndex #
+        ############
         index = tm.makeIntIndex()
         s = Series(np.arange(len(index))+10,index+5)
 
@@ -4050,38 +4055,34 @@ class TestIndexing(tm.TestCase):
         result4 = s.iloc[2:5]
         assert_series_equal(result1, result4)
 
-        # these are all value based
+        # these are all label based
         result2 = s.ix[2:5]
         result3 = s.loc[2:5]
         assert_series_equal(result2, result3)
 
         # float slicers on an int index
         expected = Series([11,12,13],index=[6,7,8])
-        result = s.loc[6.0:8.5]
-        assert_series_equal(result, expected)
+        for method in [lambda x: x.loc, lambda x: x.ix]:
+            result = method(s)[6.0:8.5]
+            assert_series_equal(result, expected)
 
-        result = s.loc[5.5:8.5]
-        assert_series_equal(result, expected)
+            result = method(s)[5.5:8.5]
+            assert_series_equal(result, expected)
 
-        result = s.loc[5.5:8.0]
-        assert_series_equal(result, expected)
+            result = method(s)[5.5:8.0]
+            assert_series_equal(result, expected)
 
-        # make all float slicing fail for ix/[] with an int index
+        # make all float slicing fail for [] with an int index
         self.assertRaises(TypeError, lambda : s[6.0:8])
         self.assertRaises(TypeError, lambda : s[6.0:8.0])
         self.assertRaises(TypeError, lambda : s[6:8.0])
-        self.assertRaises(TypeError, lambda : s.ix[6.0:8])
-        self.assertRaises(TypeError, lambda : s.ix[6.0:8.0])
-        self.assertRaises(TypeError, lambda : s.ix[6:8.0])
 
-        # these work for now
-        #self.assertRaises(TypeError, lambda : s.iloc[6.0:8])
-        #self.assertRaises(TypeError, lambda : s.iloc[6.0:8.0])
-        #self.assertRaises(TypeError, lambda : s.iloc[6:8.0])
+        check_iloc_compat(s)
 
-        # float
-        index = tm.makeFloatIndex()
-        s = Series(np.arange(len(index))+10,index=index+5)
+        ##############
+        # FloatIndex #
+        ##############
+        s.index = s.index.astype('float64')
 
         # these are all value based
         result1 = s[6:8]
@@ -4090,50 +4091,25 @@ class TestIndexing(tm.TestCase):
         assert_series_equal(result1, result2)
         assert_series_equal(result1, result3)
 
-        # these are all valid
-        result1a = s[6.0:8]
-        result2a = s[6.0:8.0]
-        result3a = s[6:8.0]
-        result1b = s[6.5:8]
-        result2b = s[6.5:8.5]
-        result3b = s[6:8.5]
-        assert_series_equal(result1a, result2a)
-        assert_series_equal(result1a, result3a)
-        assert_series_equal(result1a, result1b)
-        assert_series_equal(result1a, result2b)
-        assert_series_equal(result1a, result3b)
+        # these are valid for all methods
+        # these are treated like labels (e.g. the rhs IS included)
+        def compare(slicers, expected):
+            for method in [lambda x: x, lambda x: x.loc, lambda x: x.ix ]:
+                for slices in slicers:
 
-        result1c = s.ix[6.0:8]
-        result2c = s.ix[6.0:8.0]
-        result3c = s.ix[6:8.0]
-        result1d = s.ix[6.5:8]
-        result2d = s.ix[6.5:8.5]
-        result3d = s.ix[6:8.5]
-        assert_series_equal(result1a, result1c)
-        assert_series_equal(result1a, result2c)
-        assert_series_equal(result1a, result3c)
-        assert_series_equal(result1a, result1d)
-        assert_series_equal(result1a, result2d)
-        assert_series_equal(result1a, result3d)
+                    result = method(s)[slices]
+                    assert_series_equal(result, expected)
 
-        result1e = s.loc[6.0:8]
-        result2e = s.loc[6.0:8.0]
-        result3e = s.loc[6:8.0]
-        result1f = s.loc[6.5:8]
-        result2f = s.loc[6.5:8.5]
-        result3f = s.loc[6:8.5]
-        assert_series_equal(result1a, result1e)
-        assert_series_equal(result1a, result2e)
-        assert_series_equal(result1a, result3e)
-        assert_series_equal(result1a, result1f)
-        assert_series_equal(result1a, result2f)
-        assert_series_equal(result1a, result3f)
+        compare([slice(6.0,8),slice(6.0,8.0),slice(6,8.0)],
+                s[(s.index>=6.0)&(s.index<=8)])
+        compare([slice(6.5,8),slice(6.5,8.5)],
+                s[(s.index>=6.5)&(s.index<=8.5)])
+        compare([slice(6,8.5)],
+                s[(s.index>=6.0)&(s.index<=8.5)])
+        compare([slice(6.5,6.5)],
+                s[(s.index>=6.5)&(s.index<=6.5)])
 
-
-        # these work for now
-        #self.assertRaises(TypeError, lambda : s.iloc[2.0:5])
-        #self.assertRaises(TypeError, lambda : s.iloc[2.0:5.0])
-        #self.assertRaises(TypeError, lambda : s.iloc[2:5.0])
+        check_iloc_compat(s)
 
     def test_set_ix_out_of_bounds_axis_0(self):
         df = pd.DataFrame(randn(2, 5), index=["row%s" % i for i in range(2)], columns=["col%s" % i for i in range(5)])

--- a/pandas/tseries/base.py
+++ b/pandas/tseries/base.py
@@ -8,6 +8,7 @@ from datetime import datetime, time, timedelta
 from pandas import compat
 import numpy as np
 from pandas.core import common as com
+from pandas.core.common import is_integer, is_float
 import pandas.tslib as tslib
 import pandas.lib as lib
 from pandas.core.index import Index
@@ -296,6 +297,13 @@ class DatetimeIndexOpsMixin(object):
         """
         from pandas.tseries.frequencies import get_reso_string
         return get_reso_string(self._resolution)
+
+    def _convert_scalar_indexer(self, key, typ=None):
+        """ we don't allow integer or float indexing on datetime-like when using loc """
+        if typ in ['loc'] and lib.isscalar(key) and (is_integer(key) or is_float(key)):
+            self._invalid_indexer('index',key)
+
+        return super(DatetimeIndexOpsMixin, self)._convert_scalar_indexer(key, typ=typ)
 
     def _add_datelike(self, other):
         raise NotImplementedError

--- a/pandas/tseries/base.py
+++ b/pandas/tseries/base.py
@@ -298,12 +298,20 @@ class DatetimeIndexOpsMixin(object):
         from pandas.tseries.frequencies import get_reso_string
         return get_reso_string(self._resolution)
 
-    def _convert_scalar_indexer(self, key, typ=None):
-        """ we don't allow integer or float indexing on datetime-like when using loc """
-        if typ in ['loc'] and lib.isscalar(key) and (is_integer(key) or is_float(key)):
+    def _convert_scalar_indexer(self, key, kind=None):
+        """
+        we don't allow integer or float indexing on datetime-like when using loc
+
+        Parameters
+        ----------
+        key : label of the slice bound
+        kind : optional, type of the indexing operation (loc/ix/iloc/None)
+        """
+
+        if kind in ['loc'] and lib.isscalar(key) and (is_integer(key) or is_float(key)):
             self._invalid_indexer('index',key)
 
-        return super(DatetimeIndexOpsMixin, self)._convert_scalar_indexer(key, typ=typ)
+        return super(DatetimeIndexOpsMixin, self)._convert_scalar_indexer(key, kind=kind)
 
     def _add_datelike(self, other):
         raise NotImplementedError

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -10,7 +10,7 @@ import warnings
 
 from pandas.core.common import (_NS_DTYPE, _INT64_DTYPE,
                                 _values_from_object, _maybe_box,
-                                ABCSeries)
+                                ABCSeries, is_integer, is_float)
 from pandas.core.index import Index, Int64Index, Float64Index
 import pandas.compat as compat
 from pandas.compat import u
@@ -215,9 +215,9 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
                 freq = None
 
         if periods is not None:
-            if com.is_float(periods):
+            if is_float(periods):
                 periods = int(periods)
-            elif not com.is_integer(periods):
+            elif not is_integer(periods):
                 raise ValueError('Periods must be a number, got %s' %
                                  str(periods))
 
@@ -1271,15 +1271,17 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
         label : object
         side : {'left', 'right'}
 
+        Returns
+        -------
+        label :  object
+
         Notes
         -----
         Value of `side` parameter should be validated in caller.
 
         """
-        if isinstance(label, float):
-            raise TypeError('Cannot index datetime64 with float keys')
-        if isinstance(label, time):
-            raise KeyError('Cannot index datetime64 with time keys')
+        if is_float(label) or isinstance(label, time) or is_integer(label):
+            self._invalid_indexer('slice',label)
 
         if isinstance(label, compat.string_types):
             freq = getattr(self, 'freqstr',
@@ -1556,7 +1558,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
         new_dates = np.delete(self.asi8, loc)
 
         freq = None
-        if lib.is_integer(loc):
+        if is_integer(loc):
             if loc in (0, -len(self), -1, len(self) - 1):
                 freq = self.freq
         else:

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1262,7 +1262,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
             except (KeyError, ValueError):
                 raise KeyError(key)
 
-    def _maybe_cast_slice_bound(self, label, side):
+    def _maybe_cast_slice_bound(self, label, side, kind):
         """
         If label is a string, cast it to datetime according to resolution.
 
@@ -1270,6 +1270,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
         ----------
         label : object
         side : {'left', 'right'}
+        kind : string / None
 
         Returns
         -------
@@ -1300,7 +1301,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
                                        use_rhs=use_rhs)
         return loc
 
-    def slice_indexer(self, start=None, end=None, step=None):
+    def slice_indexer(self, start=None, end=None, step=None, kind=None):
         """
         Return indexer for specified label slice.
         Index.slice_indexer, customized to handle time slicing.
@@ -1335,11 +1336,11 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
                 (end is None or isinstance(end, compat.string_types))):
                 mask = True
                 if start is not None:
-                    start_casted = self._maybe_cast_slice_bound(start, 'left')
+                    start_casted = self._maybe_cast_slice_bound(start, 'left', kind)
                     mask = start_casted <= self
 
                 if end is not None:
-                    end_casted = self._maybe_cast_slice_bound(end, 'right')
+                    end_casted = self._maybe_cast_slice_bound(end, 'right', kind)
                     mask = (self <= end_casted) & mask
 
                 indexer = mask.nonzero()[0][::step]

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -22,7 +22,8 @@ from pandas._period import (
 
 import pandas.core.common as com
 from pandas.core.common import (isnull, _INT64_DTYPE, _maybe_box,
-                                _values_from_object, ABCSeries)
+                                _values_from_object, ABCSeries,
+                                is_integer, is_float)
 from pandas import compat
 from pandas.lib import Timestamp, Timedelta
 import pandas.lib as lib
@@ -166,9 +167,9 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
         freq = frequencies.get_standard_freq(freq)
 
         if periods is not None:
-            if com.is_float(periods):
+            if is_float(periods):
                 periods = int(periods)
-            elif not com.is_integer(periods):
+            elif not is_integer(periods):
                 raise ValueError('Periods must be a number, got %s' %
                                  str(periods))
 
@@ -533,7 +534,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
         try:
             return self._engine.get_loc(key)
         except KeyError:
-            if com.is_integer(key):
+            if is_integer(key):
                 raise
 
             try:
@@ -576,6 +577,8 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
                 return bounds[0 if side == 'left' else 1]
             except Exception:
                 raise KeyError(label)
+        elif is_integer(label) or is_float(label):
+            self._invalid_indexer('slice',label)
 
         return label
 

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -549,7 +549,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
             except KeyError:
                 raise KeyError(key)
 
-    def _maybe_cast_slice_bound(self, label, side):
+    def _maybe_cast_slice_bound(self, label, side, kind):
         """
         If label is a string or a datetime, cast it to Period.ordinal according to
         resolution.
@@ -558,6 +558,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
         ----------
         label : object
         side : {'left', 'right'}
+        kind : string / None
 
         Returns
         -------

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -675,7 +675,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, Int64Index):
             except (KeyError, ValueError):
                 raise KeyError(key)
 
-    def _maybe_cast_slice_bound(self, label, side):
+    def _maybe_cast_slice_bound(self, label, side, kind):
         """
         If label is a string, cast it to timedelta according to resolution.
 
@@ -684,6 +684,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, Int64Index):
         ----------
         label : object
         side : {'left', 'right'}
+        kind : string / None
 
         Returns
         -------


### PR DESCRIPTION
closes #8613 

```
In [1]:      df = DataFrame(np.random.randn(5,4), columns=list('ABCD'), index=date_range('20130101',periods=5))

In [2]:      df
Out[2]: 
                   A         B         C         D
2013-01-01 -1.380065  1.221596  0.279703 -0.119258
2013-01-02  1.684202 -0.202251 -0.961145 -1.595015
2013-01-03 -0.623634 -2.377577 -3.024554 -0.298809
2013-01-04 -1.251699  0.456356  1.257002  1.465878
2013-01-05  0.687818 -2.125079  1.454911  1.914207

In [5]:      s = Series(range(5),[-2,-1,1,2,3])

In [6]:      s
Out[6]: 
-2    0
-1    1
 1    2
 2    3
 3    4
dtype: int64

In [7]:      df.loc['2013-01-02':'2013-01-10']
Out[7]: 
                   A         B         C         D
2013-01-02  1.684202 -0.202251 -0.961145 -1.595015
2013-01-03 -0.623634 -2.377577 -3.024554 -0.298809
2013-01-04 -1.251699  0.456356  1.257002  1.465878
2013-01-05  0.687818 -2.125079  1.454911  1.914207

In [9]:      s.loc[-10:3]
Out[9]: 
-2    0
-1    1
 1    2
 2    3
 3    4
dtype: int64
```

```
# this used to be a KeyError
In [15]: df.loc[2:3]
TypeError: Cannot index datetime64 with <type 'int'> keys
```

Slicing with float indexers; now works for ix (loc worked before)

```
In [3]: s.loc[-1.0:2]
Out[3]: 
-1    1
 1    2
 2    3
dtype: int64

In [4]: s.ix[-1.0:2]
Out[4]: 
-1    1
 1    2
 2    3
dtype: int64

# [] raises
In [5]: s[-1.0:2]
TypeError: cannot do slice start value indexing on <class 'pandas.core.index.Int64Index'> with these indexers [-1.0] of <type 'float'>
```
