### PR TITLE
BUG: Raise TypeError when serializing 0d ndarray

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -143,3 +143,6 @@ Bug Fixes
 - Bug in `Series.from_csv` with ``header`` kwarg not setting the ``Series.name`` or the ``Series.index.name`` (:issue:`10483`)
 
 - Bug in `groupby.var` which caused variance to be inaccurate for small float values (:issue:`10448`)
+
+- Bug in ``to_json`` which was causing segmentation fault when serializing
+  0-rank ndarray (:issue:`9576`)

--- a/pandas/io/tests/test_json/test_ujson.py
+++ b/pandas/io/tests/test_json/test_ujson.py
@@ -1033,6 +1033,12 @@ class NumpyJSONTests(TestCase):
         outp = ujson.decode(ujson.encode(arr), numpy=True, dtype=np.float32)
         assert_array_almost_equal_nulp(arr, outp)
 
+    def testOdArray(self):
+        def will_raise():
+            ujson.encode(np.array(1))
+
+        self.assertRaises(TypeError, will_raise)
+
     def testArrayNumpyExcept(self):
 
         input = ujson.dumps([42, {}, 'a'])

--- a/pandas/src/ujson/python/objToJSON.c
+++ b/pandas/src/ujson/python/objToJSON.c
@@ -1863,7 +1863,7 @@ void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc)
   }
   tc->prv = pc;
 
-  if (PyIter_Check(obj) || PyArray_Check(obj))
+  if (PyIter_Check(obj) || (PyArray_Check(obj) && !PyArray_CheckScalar(obj) ))
   {
     PRINTMARK();
     goto ISITERABLE;
@@ -2063,6 +2063,23 @@ void Object_beginTypeContext (JSOBJ _obj, JSONTypeContext *tc)
   {
     PRINTMARK();
     pc->PyTypeToJSON = NpyFloatToDOUBLE; tc->type = JT_DOUBLE;
+    return;
+  }
+  else
+  if (PyArray_Check(obj) && PyArray_CheckScalar(obj)) {
+    #if PY_MAJOR_VERSION >= 3
+      PyErr_Format(
+        PyExc_TypeError,
+        "%R (0d array) is not JSON serializable at the moment",
+        obj
+      );
+    #else
+      PyErr_Format(
+        PyExc_TypeError,
+        "%s (0d array) is not JSON serializable at the moment",
+        PyString_AsString(PyObject_Repr(obj))
+      );
+    #endif
     return;
   }
 


### PR DESCRIPTION
Previously pandas ujson Segfault. see #9576 

This is an initial fix. I'll try to make sens out of ujson and see if 0d array can be handle in a better way. However, At the moment raising an exception is still better than a Segfault.
