### PR TITLE
Deprecation for 0.16 (#6581)

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -217,6 +217,12 @@ Deprecations
 
 .. _whatsnew_0160.deprecations:
 
+- ``DataFrame.pivot_table`` and ``crosstab``'s ``rows`` and ``cols`` keyword arguments were removed in favor
+  of ``index`` and ``columns`` (:issue:`6581`)
+- ``DataFrame.to_excel`` and ``DataFrame.to_csv`` ``cols`` keyword argument was removed in favor of ``columns`` (:issue:`6581`)
+- Removed ``covert_dummies`` in favor of ``get_dummies`` (:issue:`6581`)
+- Removed ``value_range`` in favor of ``describe`` (:issue:`6581`)
+
 
 Enhancements
 ~~~~~~~~~~~~

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -57,7 +57,6 @@ from pandas.tools.merge import merge, concat, ordered_merge
 from pandas.tools.pivot import pivot_table, crosstab
 from pandas.tools.plotting import scatter_matrix, plot_params
 from pandas.tools.tile import cut, qcut
-from pandas.tools.util import value_range
 from pandas.core.reshape import melt
 from pandas.util.print_versions import show_versions
 import pandas.util.testing

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1107,7 +1107,6 @@ class DataFrame(NDFrame):
 
     to_wide = deprecate('to_wide', to_panel)
 
-    @deprecate_kwarg(old_arg_name='cols', new_arg_name='columns')
     def to_csv(self, path_or_buf=None, sep=",", na_rep='', float_format=None,
                columns=None, header=True, index=True, index_label=None,
                mode='w', encoding=None, quoting=None,
@@ -1165,7 +1164,6 @@ class DataFrame(NDFrame):
             or new (expanded format) if False)
         date_format : string, default None
             Format string for datetime objects
-        cols : kwarg only alias of columns [deprecated]
         """
 
         formatter = fmt.CSVFormatter(self, path_or_buf,
@@ -1186,7 +1184,6 @@ class DataFrame(NDFrame):
         if path_or_buf is None:
             return formatter.path_or_buf.getvalue()
 
-    @deprecate_kwarg(old_arg_name='cols', new_arg_name='columns')
     def to_excel(self, excel_writer, sheet_name='Sheet1', na_rep='',
                  float_format=None, columns=None, header=True, index=True,
                  index_label=None, startrow=0, startcol=0, engine=None,
@@ -1228,7 +1225,6 @@ class DataFrame(NDFrame):
         encoding: string, default None
             encoding of the resulting excel file. Only necessary for xlwt,
             other writers support unicode natively.
-        cols : kwarg only alias of columns [deprecated]
         inf_rep : string, default 'inf'
             Representation for infinity (there is no native representation for
             infinity in Excel)

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -929,39 +929,6 @@ def wide_to_long(df, stubnames, i, j):
         newdf = newdf.merge(new, how="outer", on=id_vars + [j], copy=False)
     return newdf.set_index([i, j])
 
-
-def convert_dummies(data, cat_variables, prefix_sep='_'):
-    """
-    Compute DataFrame with specified columns converted to dummy variables (0 /
-    1). Result columns will be prefixed with the column name, then the level
-    name, e.g. 'A_foo' for column A and level foo
-
-    Parameters
-    ----------
-    data : DataFrame
-    cat_variables : list-like
-        Must be column names in the DataFrame
-    prefix_sep : string, default '_'
-        String to use to separate column name from dummy level
-
-    Returns
-    -------
-    dummies : DataFrame
-    """
-    import warnings
-
-    warnings.warn("'convert_dummies' is deprecated and will be removed "
-                  "in a future release. Use 'get_dummies' instead.",
-                  FutureWarning)
-
-    result = data.drop(cat_variables, axis=1)
-    for variable in cat_variables:
-        dummies = _get_dummies_1d(data[variable], prefix=variable,
-                                  prefix_sep=prefix_sep)
-        result = result.join(dummies)
-    return result
-
-
 def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False,
                 columns=None):
     """

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -556,14 +556,6 @@ class ExcelWriterBase(SharedItems):
 
             self.assertRaises(xlrd.XLRDError, xl.parse, '0')
 
-    def test_excel_deprecated_options(self):
-        with ensure_clean(self.ext) as path:
-            with tm.assert_produces_warning(FutureWarning):
-                self.frame.to_excel(path, 'test1', cols=['A', 'B'])
-
-            with tm.assert_produces_warning(False):
-                self.frame.to_excel(path, 'test1', columns=['A', 'B'])
-
     def test_excelwriter_contextmanager(self):
         _skip_if_no_xlrd()
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5944,23 +5944,6 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.assertRaises(ValueError, lambda : df == (2,2))
         self.assertRaises(ValueError, lambda : df == [2,2])
 
-    def test_to_csv_deprecated_options(self):
-
-        pname = '__tmp_to_csv_deprecated_options__'
-        with ensure_clean(pname) as path:
-
-            self.tsframe[1:3] = np.nan
-            self.tsframe.to_csv(path, nanRep='foo')
-            recons = read_csv(path,index_col=0,parse_dates=[0],na_values=['foo'])
-            assert_frame_equal(self.tsframe, recons)
-
-        with tm.assert_produces_warning(FutureWarning):
-            self.frame.to_csv(path, cols=['A', 'B'])
-
-        with tm.assert_produces_warning(False):
-            self.frame.to_csv(path, columns=['A', 'B'])
-
-
     def test_to_csv_from_csv(self):
 
         pname = '__tmp_to_csv_from_csv__'

--- a/pandas/tests/test_reshape.py
+++ b/pandas/tests/test_reshape.py
@@ -16,7 +16,7 @@ import numpy as np
 from pandas.util.testing import assert_frame_equal
 from numpy.testing import assert_array_equal
 
-from pandas.core.reshape import (melt, convert_dummies, lreshape, get_dummies,
+from pandas.core.reshape import (melt, lreshape, get_dummies,
                                  wide_to_long)
 import pandas.util.testing as tm
 from pandas.compat import StringIO, cPickle, range, u
@@ -321,34 +321,6 @@ class TestGetDummies(tm.TestCase):
         expected = expected[['C', 'A_a', 'A_b', 'B_b', 'B_c',
                              'cat_x', 'cat_y']]
         assert_frame_equal(result, expected)
-
-
-class TestConvertDummies(tm.TestCase):
-    def test_convert_dummies(self):
-        df = DataFrame({'A': ['foo', 'bar', 'foo', 'bar',
-                              'foo', 'bar', 'foo', 'foo'],
-                        'B': ['one', 'one', 'two', 'three',
-                              'two', 'two', 'one', 'three'],
-                        'C': np.random.randn(8),
-                        'D': np.random.randn(8)})
-
-        with tm.assert_produces_warning(FutureWarning):
-            result = convert_dummies(df, ['A', 'B'])
-            result2 = convert_dummies(df, ['A', 'B'], prefix_sep='.')
-
-        expected = DataFrame({'A_foo': [1, 0, 1, 0, 1, 0, 1, 1],
-                              'A_bar': [0, 1, 0, 1, 0, 1, 0, 0],
-                              'B_one': [1, 1, 0, 0, 0, 0, 1, 0],
-                              'B_two': [0, 0, 1, 0, 1, 1, 0, 0],
-                              'B_three': [0, 0, 0, 1, 0, 0, 0, 1],
-                              'C': df['C'].values,
-                              'D': df['D'].values},
-                             columns=result.columns, dtype=float)
-        expected2 = expected.rename(columns=lambda x: x.replace('_', '.'))
-
-        tm.assert_frame_equal(result, expected)
-        tm.assert_frame_equal(result2, expected2)
-
 
 class TestLreshape(tm.TestCase):
 

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -13,8 +13,6 @@ from pandas import compat
 import pandas.core.common as com
 import numpy as np
 
-@deprecate_kwarg(old_arg_name='cols', new_arg_name='columns')
-@deprecate_kwarg(old_arg_name='rows', new_arg_name='index')
 def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
                 fill_value=None, margins=False, dropna=True):
     """
@@ -42,8 +40,6 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
         Add all row / columns (e.g. for subtotal / grand totals)
     dropna : boolean, default True
         Do not include columns whose entries are all NaN
-    rows : kwarg only alias of index [deprecated]
-    cols : kwarg only alias of columns [deprecated]
 
     Examples
     --------
@@ -319,8 +315,6 @@ def _convert_by(by):
         by = list(by)
     return by
 
-@deprecate_kwarg(old_arg_name='cols', new_arg_name='columns')
-@deprecate_kwarg(old_arg_name='rows', new_arg_name='index')
 def crosstab(index, columns, values=None, rownames=None, colnames=None,
              aggfunc=None, margins=False, dropna=True):
     """
@@ -346,8 +340,6 @@ def crosstab(index, columns, values=None, rownames=None, colnames=None,
         Add row/column margins (subtotals)
     dropna : boolean, default True
         Do not include columns whose entries are all NaN
-    rows : kwarg only alias of index [deprecated]
-    cols : kwarg only alias of columns [deprecated]
 
     Notes
     -----

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -53,19 +53,6 @@ class TestPivotTable(tm.TestCase):
         expected = self.data.groupby(index + [columns])['D'].agg(np.mean).unstack()
         tm.assert_frame_equal(table, expected)
 
-    def test_pivot_table_warnings(self):
-        index = ['A', 'B']
-        columns = 'C'
-        with tm.assert_produces_warning(FutureWarning):
-            table = pivot_table(self.data, values='D', rows=index,
-                                cols=columns)
-
-        with tm.assert_produces_warning(False):
-            table2 = pivot_table(self.data, values='D', index=index,
-                                 columns=columns)
-
-        tm.assert_frame_equal(table, table2)
-
     def test_pivot_table_nocols(self):
         df = DataFrame({'rows': ['a', 'b', 'c'],
                         'cols': ['x', 'y', 'z'],

--- a/pandas/tools/util.py
+++ b/pandas/tools/util.py
@@ -48,22 +48,3 @@ def compose(*funcs):
     """Compose 2 or more callables"""
     assert len(funcs) > 1, 'At least 2 callables must be passed to compose'
     return reduce(_compose2, funcs)
-
-### FIXME: remove in 0.16
-def value_range(df):
-    """
-    Return the minimum and maximum of a dataframe in a series object
-
-    Parameters
-    ----------
-    df : DataFrame
-
-    Returns
-    -------
-    (maximum, minimum) : Series
-
-    """
-    from pandas import Series
-    warnings.warn("value_range is deprecated. Use .describe() instead", FutureWarning)
-
-    return Series((min(df.min()), max(df.max())), ('Minimum', 'Maximum'))


### PR DESCRIPTION
These are the deprecations that are to be removed in 0.16, per #6581, except for the deprecations around the boxplot function.
