### PR TITLE
Test added and patch to fix python-version-dependent issues when len ro...

### DIFF
--- a/pandas/sparse/scipy_sparse.py
+++ b/pandas/sparse/scipy_sparse.py
@@ -8,7 +8,7 @@ from pandas.core.index import MultiIndex, Index
 from pandas.core.series import Series
 import itertools
 import numpy as np
-from pandas.compat import OrderedDict
+from pandas.compat import OrderedDict, lmap
 from pandas.tools.util import cartesian_product
 
 
@@ -54,7 +54,7 @@ def _to_ijv(ss, row_levels=(0,), column_levels=(1,), sort_labels=False):
         def _get_label_to_i_dict(labels, sort_labels=False):
             """ Return OrderedDict of unique labels to number.
             Optionally sort by label. """
-            labels = Index(map(tuple, labels)).unique().tolist()  # squish
+            labels = Index(lmap(tuple, labels)).unique().tolist()  # squish
             if sort_labels:
                 labels = sorted(list(labels))
             d = OrderedDict((k, i) for i, k in enumerate(labels))
@@ -73,7 +73,8 @@ def _to_ijv(ss, row_levels=(0,), column_levels=(1,), sort_labels=False):
             labels_to_i = _get_label_to_i_dict(
                 ilabels, sort_labels=sort_labels)
             labels_to_i = Series(labels_to_i)
-            labels_to_i.index = MultiIndex.from_tuples(labels_to_i.index)
+            if len(subset) > 1:
+                labels_to_i.index = MultiIndex.from_tuples(labels_to_i.index)
             labels_to_i.index.names = [index.names[i] for i in subset]
             labels_to_i.name = 'value'
             return(labels_to_i)

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -783,8 +783,10 @@ class TestSparseSeriesScipyInteraction(tm.TestCase):
             ([3.0, 1.0, 2.0], ([0, 1, 1], [0, 2, 3])), shape=(3, 4)))
         self.coo_matrices.append(scipy.sparse.coo_matrix(
             ([3.0, 1.0, 2.0], ([1, 0, 0], [0, 2, 3])), shape=(3, 4)))
-        self.ils = [[(1, 2), (1, 1), (2, 1)], [(1, 1), (1, 2), (2, 1)]]
-        self.jls = [[('a', 0), ('a', 1), ('b', 0), ('b', 1)]]
+        self.coo_matrices.append(scipy.sparse.coo_matrix(
+            ([3.0, 1.0, 2.0], ([0, 1, 1], [0, 0, 1])), shape=(3, 2)))
+        self.ils = [[(1, 2), (1, 1), (2, 1)], [(1, 1), (1, 2), (2, 1)], [(1, 2, 'a'), (1, 1, 'b'), (2, 1, 'b')]]
+        self.jls = [[('a', 0), ('a', 1), ('b', 0), ('b', 1)], [0, 1]]
 
     def test_to_coo_text_names_integer_row_levels_nosort(self):
         ss = self.sparse_series[0]
@@ -797,6 +799,13 @@ class TestSparseSeriesScipyInteraction(tm.TestCase):
         kwargs = {'row_levels': [0, 1],
                   'column_levels': [2, 3], 'sort_labels': True}
         result = (self.coo_matrices[1], self.ils[1], self.jls[0])
+        self._run_test(ss, kwargs, result)
+
+    def test_to_coo_text_names_text_row_levels_nosort_col_level_single(self):
+        ss = self.sparse_series[0]
+        kwargs = {'row_levels': ['A', 'B', 'C'],
+                  'column_levels': ['D'], 'sort_labels': False}
+        result = (self.coo_matrices[2], self.ils[2], self.jls[1])
         self._run_test(ss, kwargs, result)
 
     def test_to_coo_integer_names_integer_row_levels_nosort(self):


### PR DESCRIPTION
...w/col_levels is 1.

The docs for sparse to_coo methods failed to build. There was some case (row_levels len 1) that failed in python 2.7 only that I failed to test (and I have been building docs in python 3). Have added test and patched. Also needed to expand the interator (list(map(... ) in the "# squish" line as there was some tupleizing differences between python 3 and 2.

Perhaps there is a better way to avoid these issues? Waiting for Travis.
