### PR TITLE
DEPR: DatetimeIndex/PeriodsIndex +/- ops (GH9094)

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -385,6 +385,8 @@ Deprecations
 - The ``pandas.rpy`` interface is deprecated and will be removed in a future version.
   Similar functionaility can be accessed thru the `rpy2 <http://rpy.sourceforge.net/>`_ project (:issue:`9602`)
 
+- Adding ``DatetimeIndex/PeriodIndex`` to another ``DatetimeIndex/PeriodIndex`` is being deprecated as a set-operation. This will be changed to a ``TypeError`` in a future version. ``.union()`` should be used for the union set operation. (:issue:`9094`)
+- Subtracting ``DatetimeIndex/PeriodIndex`` from another ``DatetimeIndex/PeriodIndex`` is being deprecated as a set-operation. This will be changed to an actual numeric subtraction yielding a ``TimeDeltaIndex`` in a future version. ``.difference()`` should be used for the differencing set operation. (:issue:`9094`)
 
 .. _whatsnew_0160.prior_deprecations:
 

--- a/pandas/tseries/base.py
+++ b/pandas/tseries/base.py
@@ -2,7 +2,7 @@
 Base and utility classes for tseries type pandas objects.
 """
 
-
+import warnings
 from datetime import datetime, time, timedelta
 
 from pandas import compat
@@ -334,6 +334,8 @@ class DatetimeIndexOpsMixin(object):
                     return other._add_delta(self)
                 raise TypeError("cannot add TimedeltaIndex and {typ}".format(typ=type(other)))
             elif isinstance(other, Index):
+                warnings.warn("using '+' to provide set union with datetimelike Indexes is deprecated, "
+                              "use .union()",FutureWarning)
                 return self.union(other)
             elif isinstance(other, (DateOffset, timedelta, np.timedelta64, tslib.Timedelta)):
                 return self._add_delta(other)
@@ -357,6 +359,8 @@ class DatetimeIndexOpsMixin(object):
                     raise TypeError("cannot subtract TimedeltaIndex and {typ}".format(typ=type(other)))
                 return self._add_delta(-other)
             elif isinstance(other, Index):
+                warnings.warn("using '-' to provide set differences with datetimelike Indexes is deprecated, "
+                              "use .difference()",FutureWarning)
                 return self.difference(other)
             elif isinstance(other, (DateOffset, timedelta, np.timedelta64, tslib.Timedelta)):
                 return self._add_delta(-other)

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -196,12 +196,16 @@ Freq: H"""
 
             for rng, other, expected in [(rng1, other1, expected1), (rng2, other2, expected2),
                                          (rng3, other3, expected3)]:
-                result_add = rng + other
+                # GH9094
+                with tm.assert_produces_warning(FutureWarning):
+                    result_add = rng + other
                 result_union = rng.union(other)
 
                 tm.assert_index_equal(result_add, expected)
                 tm.assert_index_equal(result_union, expected)
-                rng += other
+                # GH9094
+                with tm.assert_produces_warning(FutureWarning):
+                    rng += other
                 tm.assert_index_equal(rng, expected)
 
             # offset
@@ -593,6 +597,50 @@ Freq: D"""
         expected = DatetimeIndex(['20121231','20130101','20130102'],tz='US/Eastern')
         tm.assert_index_equal(result,expected)
 
+    def test_dti_dti_deprecated_ops(self):
+
+        # deprecated in 0.16.0 (GH9094)
+        # change to return subtraction -> TimeDeltaIndex in 0.17.0
+        # shoudl move to the appropriate sections above
+
+        dti = date_range('20130101',periods=3)
+        dti_tz = date_range('20130101',periods=3).tz_localize('US/Eastern')
+
+        with tm.assert_produces_warning(FutureWarning):
+            result = dti-dti
+            expected = Index([])
+            tm.assert_index_equal(result,expected)
+
+        with tm.assert_produces_warning(FutureWarning):
+            result = dti+dti
+            expected = dti
+            tm.assert_index_equal(result,expected)
+
+        with tm.assert_produces_warning(FutureWarning):
+            result = dti_tz-dti_tz
+            expected = Index([])
+            tm.assert_index_equal(result,expected)
+
+        with tm.assert_produces_warning(FutureWarning):
+            result = dti_tz+dti_tz
+            expected = dti_tz
+            tm.assert_index_equal(result,expected)
+
+        with tm.assert_produces_warning(FutureWarning):
+            result = dti_tz-dti
+            expected = dti_tz
+            tm.assert_index_equal(result,expected)
+
+        with tm.assert_produces_warning(FutureWarning):
+            result = dti-dti_tz
+            expected = dti
+            tm.assert_index_equal(result,expected)
+
+        with tm.assert_produces_warning(FutureWarning):
+            self.assertRaises(TypeError, lambda : dti_tz+dti)
+        with tm.assert_produces_warning(FutureWarning):
+            self.assertRaises(TypeError, lambda : dti+dti_tz)
+
     def test_dti_tdi_numeric_ops(self):
 
         # These are normally union/diff set-like ops
@@ -909,13 +957,19 @@ Freq: Q-DEC"""
                                      (rng5, other5, expected5), (rng6, other6, expected6),
                                      (rng7, other7, expected7)]:
 
-            result_add = rng + other
+            # GH9094
+            with tm.assert_produces_warning(FutureWarning):
+                result_add = rng + other
+
             result_union = rng.union(other)
 
             tm.assert_index_equal(result_add, expected)
             tm.assert_index_equal(result_union, expected)
+
             # GH 6527
-            rng += other
+            # GH9094
+            with tm.assert_produces_warning(FutureWarning):
+                rng += other
             tm.assert_index_equal(rng, expected)
 
         # offset


### PR DESCRIPTION
closes #9094
closes #9095 

deprecate `DatetimeIndex/PeriodIndex` `+/-` ops which are set ops. In a future version `-` will produce a `TimeDeltaIndex` and `+` a `TypeError`
