### PR TITLE
Return the right class, when subclassing a DataFrame with multi-level index

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -300,3 +300,4 @@ Bug Fixes
 - Bug in ``transform`` when groups are equal in number and dtype to the input index (:issue:`9700`)
 - Google BigQuery connector now imports dependencies on a per-method basis.(:issue:`9713`)
 - Updated BigQuery connector to no longer use deprecated ``oauth2client.tools.run()`` (:issue:`8327`)
+- Bug in subclassed ``DataFrame``. It may not return the correct class, when slicing or subsetting it. (:issue:`9632`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1839,7 +1839,7 @@ class DataFrame(NDFrame):
                 result.columns = result_columns
             else:
                 new_values = self.values[:, loc]
-                result = DataFrame(new_values, index=self.index,
+                result = self._constructor(new_values, index=self.index,
                                    columns=result_columns).__finalize__(self)
             if len(result.columns) == 1:
                 top = result.columns[0]
@@ -1847,7 +1847,7 @@ class DataFrame(NDFrame):
                         (type(top) == tuple and top[0] == '')):
                     result = result['']
                     if isinstance(result, Series):
-                        result = Series(result, index=self.index, name=key)
+                        result = self._constructor_sliced(result, index=self.index, name=key)
 
             result._set_is_copy(self)
             return result


### PR DESCRIPTION
Subclassing pandas.DataFrame had some issues, when a multi-level index was used. This PR should fix that.
