### PR TITLE
fixed header=list (to create a MultiIndex) for read_excel

### DIFF
--- a/pandas/hashtable.pyx
+++ b/pandas/hashtable.pyx
@@ -970,7 +970,7 @@ cdef build_count_table_object(ndarray[object] values,
 cpdef value_count_object(ndarray[object] values,
                        ndarray[uint8_t, cast=True] mask):
     cdef:
-        Py_ssize_t i = len(values)
+        Py_ssize_t i
         kh_pymap_t *table
         int k
 

--- a/pandas/hashtable.pyx
+++ b/pandas/hashtable.pyx
@@ -211,7 +211,6 @@ cdef class StringHashTable(HashTable):
     def unique(self, ndarray[object] values):
         cdef:
             Py_ssize_t i, n = len(values)
-            Py_ssize_t idx, count = 0
             int ret = 0
             object val
             char *buf
@@ -225,7 +224,6 @@ cdef class StringHashTable(HashTable):
             if k == self.table.n_buckets:
                 k = kh_put_str(self.table, buf, &ret)
                 # print 'putting %s, %s' % (val, count)
-                count += 1
                 uniques.append(val)
 
         # return None
@@ -319,7 +317,6 @@ cdef class Int32HashTable(HashTable):
     def lookup(self, ndarray[int32_t] values):
         cdef:
             Py_ssize_t i, n = len(values)
-            int ret = 0
             int32_t val
             khiter_t k
             ndarray[int32_t] locs = np.empty(n, dtype=np.int64)
@@ -518,7 +515,6 @@ cdef class Int64HashTable: #(HashTable):
     def unique(self, ndarray[int64_t] values):
         cdef:
             Py_ssize_t i, n = len(values)
-            Py_ssize_t idx, count = 0
             int ret = 0
             ndarray result
             int64_t val
@@ -531,7 +527,6 @@ cdef class Int64HashTable: #(HashTable):
             if k == self.table.n_buckets:
                 k = kh_put_int64(self.table, val, &ret)
                 uniques.append(val)
-                count += 1
 
         result = uniques.to_array()
 
@@ -644,7 +639,6 @@ cdef class Float64HashTable(HashTable):
     def unique(self, ndarray[float64_t] values):
         cdef:
             Py_ssize_t i, n = len(values)
-            Py_ssize_t idx, count = 0
             int ret = 0
             float64_t val
             khiter_t k
@@ -659,7 +653,6 @@ cdef class Float64HashTable(HashTable):
                 if k == self.table.n_buckets:
                     k = kh_put_float64(self.table, val, &ret)
                     uniques.append(val)
-                    count += 1
             elif not seen_na:
                 seen_na = 1
                 uniques.append(ONAN)
@@ -786,7 +779,6 @@ cdef class PyObjectHashTable(HashTable):
     def unique(self, ndarray[object] values):
         cdef:
             Py_ssize_t i, n = len(values)
-            Py_ssize_t idx, count = 0
             int ret = 0
             object val
             ndarray result
@@ -938,7 +930,6 @@ cpdef value_count_int64(ndarray[int64_t] values):
     cdef:
         Py_ssize_t i
         kh_int64_t *table
-        int ret = 0
         int k
 
     table = kh_init_int64()
@@ -1008,9 +999,7 @@ def mode_object(ndarray[object] values, ndarray[uint8_t, cast=True] mask):
         int count, max_count = 2
         int j = -1 # so you can do +=
         int k
-        Py_ssize_t i, n = len(values)
         kh_pymap_t *table
-        int ret = 0
 
     table = kh_init_pymap()
     build_count_table_object(values, mask, table)
@@ -1040,7 +1029,6 @@ def mode_int64(ndarray[int64_t] values):
         int j = -1 # so you can do +=
         int k
         kh_int64_t *table
-        list uniques = []
 
     table = kh_init_int64()
 

--- a/pandas/hashtable.pyx
+++ b/pandas/hashtable.pyx
@@ -1021,7 +1021,7 @@ def mode_object(ndarray[object] values, ndarray[uint8_t, cast=True] mask):
 
 def mode_int64(ndarray[int64_t] values):
     cdef:
-        int val, max_val = 2
+        int count, max_count = 2
         int j = -1 # so you can do +=
         int k
         kh_int64_t *table
@@ -1033,12 +1033,12 @@ def mode_int64(ndarray[int64_t] values):
     modes = np.empty(table.n_buckets, dtype=np.int64)
     for k in range(table.n_buckets):
         if kh_exist_int64(table, k):
-            val = table.vals[k]
+            count = table.vals[k]
 
-            if val == max_val:
+            if count == max_count:
                 j += 1
-            elif val > max_val:
-                max_val = val
+            elif count > max_count:
+                max_count = count
                 j = 0
             else:
                 continue

--- a/pandas/hashtable.pyx
+++ b/pandas/hashtable.pyx
@@ -222,7 +222,7 @@ cdef class StringHashTable(HashTable):
             buf = util.get_c_string(val)
             k = kh_get_str(self.table, buf)
             if k == self.table.n_buckets:
-                k = kh_put_str(self.table, buf, &ret)
+                kh_put_str(self.table, buf, &ret)
                 # print 'putting %s, %s' % (val, count)
                 uniques.append(val)
 
@@ -525,7 +525,7 @@ cdef class Int64HashTable: #(HashTable):
             val = values[i]
             k = kh_get_int64(self.table, val)
             if k == self.table.n_buckets:
-                k = kh_put_int64(self.table, val, &ret)
+                kh_put_int64(self.table, val, &ret)
                 uniques.append(val)
 
         result = uniques.to_array()
@@ -651,7 +651,7 @@ cdef class Float64HashTable(HashTable):
             if val == val:
                 k = kh_get_float64(self.table, val)
                 if k == self.table.n_buckets:
-                    k = kh_put_float64(self.table, val, &ret)
+                    kh_put_float64(self.table, val, &ret)
                     uniques.append(val)
             elif not seen_na:
                 seen_na = 1
@@ -792,7 +792,7 @@ cdef class PyObjectHashTable(HashTable):
             if not _checknan(val):
                 k = kh_get_pymap(self.table, <PyObject*>val)
                 if k == self.table.n_buckets:
-                    k = kh_put_pymap(self.table, <PyObject*>val, &ret)
+                    kh_put_pymap(self.table, <PyObject*>val, &ret)
                     uniques.append(val)
             elif not seen_na:
                 seen_na = 1

--- a/pandas/hashtable.pyx
+++ b/pandas/hashtable.pyx
@@ -906,7 +906,7 @@ cdef class Int64Factorizer:
 
 cdef build_count_table_int64(ndarray[int64_t] values, kh_int64_t *table):
     cdef:
-        int k
+        khiter_t k
         Py_ssize_t i, n = len(values)
         int ret = 0
 
@@ -948,7 +948,7 @@ cdef build_count_table_object(ndarray[object] values,
                               ndarray[uint8_t, cast=True] mask,
                               kh_pymap_t *table):
     cdef:
-        int k
+        khiter_t k
         Py_ssize_t i, n = len(values)
         int ret = 0
 

--- a/pandas/hashtable.pyx
+++ b/pandas/hashtable.pyx
@@ -223,10 +223,8 @@ cdef class StringHashTable(HashTable):
             k = kh_get_str(self.table, buf)
             if k == self.table.n_buckets:
                 kh_put_str(self.table, buf, &ret)
-                # print 'putting %s, %s' % (val, count)
                 uniques.append(val)
 
-        # return None
         return uniques.to_array()
 
     def factorize(self, ndarray[object] values):
@@ -256,7 +254,6 @@ cdef class StringHashTable(HashTable):
                 labels[i] = count
                 count += 1
 
-        # return None
         return reverse, labels
 
 cdef class Int32HashTable(HashTable):
@@ -354,7 +351,6 @@ cdef class Int32HashTable(HashTable):
                 labels[i] = count
                 count += 1
 
-        # return None
         return reverse, labels
 
 cdef class Int64HashTable: #(HashTable):

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -419,7 +419,11 @@ class ExcelFile(object):
                 data.append(row)
     
             if header is not None:
-                data[header] = _trim_excel_header(data[header])
+                if isinstance(header, (list, tuple, np.ndarray)):
+                    for rownum in header:
+                        data[rownum] = _trim_excel_header(data[rownum])
+                else:
+                    data[header] = _trim_excel_header(data[header])
     
             parser = TextParser(data, header=header, index_col=index_col,
                                 has_index_names=has_index_names,


### PR DESCRIPTION
closes #4679 

This is a very simple fix to allow passing a list go the header argument of read_excel so that it creates a MultiIndex for columns. Given what is said in issue #4679, I am not really sure it is supposed to work, but with this fix, it works for my files. One thing discussed in issue #4679, which I did not do anything about (and thus probably still does not work) is if the header cells are merged, but my opinion is that this should be a separate issue, as it is already useful to be able to read files with the header duplicated (the files I receive are usually like this).  If this PR is accepted (at least in spirit), the docstring for read_excel should probably be updated to reflect the "new" capability and the changelog updated, but I wanted to check first what you think.

As a side note, I am not entirely sure that _trim_excel_header is a good thing to do anyway, but that is another debate entirely.
