### PR TITLE
DOC: fix some doc errors/warnings

### DIFF
--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -386,9 +386,9 @@ categories or a categorical with any list-like object, will raise a TypeError.
 
 .. ipython:: python
 
-    cat = Series(Categorical([1,2,3], categories=[3,2,1]))
-    cat_base = Series(Categorical([2,2,2], categories=[3,2,1]))
-    cat_base2 = Series(Categorical([2,2,2]))
+    cat = Series([1,2,3]).astype("category", categories=[3,2,1], ordered=True)
+    cat_base = Series([2,2,2]).astype("category", categories=[3,2,1], ordered=True)
+    cat_base2 = Series([2,2,2]).astype("category", ordered=True)
 
     cat
     cat_base

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1098,7 +1098,7 @@ class of the csv module. For this, you have to specify ``sep=None``.
 .. ipython:: python
 
     print(open('tmp2.sv').read())
-    pd.read_csv('tmp2.sv', sep=None)
+    pd.read_csv('tmp2.sv', sep=None, engine='python')
 
 .. _io.chunking:
 


### PR DESCRIPTION
- `pd.read_csv('tmp2.sv', sep=None)` was given the warning "_ParserWarning: Falling back to the 'python' engine because the 'c' engine does not support sep=None with delim_whitespace=False; you can avoid this warning by specifying engine='python'_"  
  Is this correct? (assuming so I just added what the warning message was saying)
- with the ordered -> unordered change in the Categoricals, the example on comparing them was failing (see http://pandas-docs.github.io/pandas-docs-travis/categorical.html#comparisons)
