### PR TITLE
fix crash on unicode level names

### DIFF
--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -4014,7 +4014,7 @@ class MultiIndex(Index):
         labels = list(self.labels)
         shape = list(self.levshape)
 
-        if isinstance(level, (str, int)):
+        if isinstance(level, (basestring, int)):
             level = [level]
         level = [self._get_level_number(lev) for lev in level]
 


### PR DESCRIPTION
This fixed my problem when calling DataFrame.stack(<integer level number>). Not really familiar with pandas internals, but couldn't find any reason why unicode strings won't be accepted here.
