### PR TITLE
CI: don't remove python-dateutil at end of install

### DIFF
--- a/ci/install_conda.sh
+++ b/ci/install_conda.sh
@@ -98,7 +98,7 @@ fi
 
 python setup.py build_ext --inplace && python setup.py develop
 
-for package in beautifulsoup4 'python-dateutil'; do
+for package in beautifulsoup4; do
     pip uninstall --yes $package
 done
 


### PR DESCRIPTION
puzzled why the travis ci error started happening. This seems to fix it (and I don't even remember why this was necessary in the first place).
