### PR TITLE
DOC: example of pandas to R transfer of DataFrame using HDF5 file

### DIFF
--- a/doc/source/comparison_with_r.rst
+++ b/doc/source/comparison_with_r.rst
@@ -27,6 +27,10 @@ libraries, we care about the following things:
 This page is also here to offer a bit of a translation guide for users of these
 R packages.
 
+For transfer of ``DataFrame`` objects from ``pandas`` to R, one option is to
+use HDF5 files, see :ref:`io.external_compatibility` for an
+example.
+
 Base R
 ------
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -3271,6 +3271,8 @@ You could inadvertently turn an actual ``nan`` value into a missing value.
    store.append('dfss2', dfss, nan_rep='_nan_')
    store.select('dfss2')
 
+.. _io.external_compatibility:
+
 External Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -3276,7 +3276,7 @@ You could inadvertently turn an actual ``nan`` value into a missing value.
 External Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~
 
-``HDFStore`` write ``table`` format objects in specific formats suitable for
+``HDFStore`` writes ``table`` format objects in specific formats suitable for
 producing loss-less round trips to pandas objects. For external
 compatibility, ``HDFStore`` can read native ``PyTables`` format
 tables. It is possible to write an ``HDFStore`` object that can easily

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -3290,7 +3290,7 @@ be imported into ``R`` using the
                                  "second": np.random.rand(100),
                                  "class": np.random.randint(0, 2, (100,))},
                                  index=range(100))
-        print(df_for_r.head())
+        df_for_r.head()
 
         store_export = HDFStore('export.h5')
         store_export.append('df_for_r', df_for_r, data_columns=df_dc.columns)

--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -198,7 +198,9 @@ Other enhancements
 - Added ``days_in_month`` (compatibility alias ``daysinmonth``) property to ``Timestamp``, ``DatetimeIndex``, ``Period``, ``PeriodIndex``, and ``Series.dt`` (:issue:`9572`)
 - Added ``decimal`` option in ``to_csv`` to provide formatting for non-'.' decimal separators (:issue:`781`)
 - Added ``normalize`` option for ``Timestamp`` to normalized to midnight (:issue:`8794`)
-
+- Added example for ``DataFrame`` import to R using HDF5 file and ``rhdf5``
+  library. See the :ref:`documentation <io.external_compatibility>` for more
+  (:issue:`9636`).
 
 .. _whatsnew_0160.api:
 


### PR DESCRIPTION
closes #9636 
I had some trouble getting the HDF5 import of DataFrame objects to work on the R side (pandas is fine). I've added an example to the documentation with a simple load function in R which assembles an R data.frame from the corresponding *_items and *_values nodes in the HDF5 file.

NOTE: Any improvements to the R code are welcome, I'm just starting to work with R. :-)
