### PR TITLE
BUG: support TimedeltaIndex serialization in fixed stores (GH9635)

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -72,7 +72,7 @@ Bug Fixes
 
 
 
-
+- Bug : TimdeltaIndex serialisation wasn't supported in fixed stores (:issue:`9635`)
 
 
 

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas
 import pandas as pd
 from pandas import (Series, DataFrame, Panel, MultiIndex, Categorical, bdate_range,
-                    date_range, Index, DatetimeIndex, isnull)
+                    date_range, timedelta_range, Index, DatetimeIndex, TimedeltaIndex, isnull)
 
 from pandas.io.pytables import _tables
 try:
@@ -4587,6 +4587,18 @@ class TestHDFStore(tm.TestCase):
             df.to_hdf(path, 'df', format='table')
             other = read_hdf(path, 'df')
             tm.assert_frame_equal(df, other)
+
+    def test_preserve_timedeltaindex_type(self):
+        # GH9635 
+        # Storing TimedeltaIndexed DataFrames in fixed stores did not preserve
+        # the type of the index.
+        df = DataFrame(np.random.normal(size=(10,5)))
+        df.index = timedelta_range(start='0s',periods=10,freq='1s',name='example')
+
+        with ensure_clean_store(self.path) as store:
+            
+            store['df'] = df
+            assert_frame_equal(store['df'], df)
 
 
 def _test_sort(obj):


### PR DESCRIPTION
closes #9635

Hop, revival of PR9662, after some bad git moves.
