### PR TITLE
DataFrame.plot error when both 'color' and 'style' arguments are passed (GH9671)

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -82,3 +82,5 @@ Bug Fixes
 - Bug in ``Series.quantile`` on empty Series of type ``Datetime`` or ``Timedelta`` (:issue:`9675`)
 - Bug in ``where`` causing incorrect results when upcasting was required (:issue:`9731`)
 - Bug in ``FloatArrayFormatter`` where decision boundary for displaying "small" floats in decimal format is off by one order of magnitude for a given display.precision (:issue:`9764`)
+
+- Fixed bug (:issue:`9671`) where ``DataFrame.plot()`` raised an error when both ``color`` and ``style`` keywords were passed and there was no color symbol in the style strings (this should be allowed).

--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -79,3 +79,4 @@ Bug Fixes
 
 - Bug in ``Series.quantile`` on empty Series of type ``Datetime`` or ``Timedelta`` (:issue:`9675`)
 - Bug in ``where`` causing incorrect results when upcasting was required (:issue:`9731`)
+- Bug in ``FloatArrayFormatter`` where decision boundary for displaying "small" floats in decimal format is off by one order of magnitude for a given display.precision (:issue:`9764`)

--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -71,6 +71,7 @@ Bug Fixes
 
 - Bug in ``transform`` causing length mismatch when null entries were present and a fast aggregator was being used (:issue:`9697`)
 
+- Bug in ``equals`` causing false negatives when block order differed (:issue:`9330`)
 
 - Bug in ``DataFrame`` slicing may not retain metadata (:issue:`9776`)
 - Bug where ``TimdeltaIndex`` were not properly serialized in fixed ``HDFStore`` (:issue:`9635`)

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -1996,7 +1996,7 @@ class FloatArrayFormatter(GenericArrayFormatter):
 
             # this is pretty arbitrary for now
             has_large_values = (abs_vals > 1e8).any()
-            has_small_values = ((abs_vals < 10 ** (-self.digits)) &
+            has_small_values = ((abs_vals < 10 ** (-self.digits+1)) &
                                 (abs_vals > 0)).any()
 
             if too_long and has_large_values:

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -3310,8 +3310,20 @@ class BlockManager(PandasObject):
             return False
         self._consolidate_inplace()
         other._consolidate_inplace()
+        if len(self.blocks) != len(other.blocks):
+            return False
+
+        # canonicalize block order, using a tuple combining the type
+        # name and then mgr_locs because there might be unconsolidated
+        # blocks (say, Categorical) which can only be distinguished by
+        # the iteration order
+        def canonicalize(block):
+            return (block.dtype.name, block.mgr_locs.as_array.tolist())
+
+        self_blocks = sorted(self.blocks, key=canonicalize)
+        other_blocks = sorted(other.blocks, key=canonicalize)
         return all(block.equals(oblock) for block, oblock in
-                   zip(self.blocks, other.blocks))
+                   zip(self_blocks, other_blocks))
 
 
 class SingleBlockManager(BlockManager):

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -4586,17 +4586,31 @@ class TestHDFStore(tm.TestCase):
 
             df.to_hdf(path, 'df', format='table')
             other = read_hdf(path, 'df')
+
             tm.assert_frame_equal(df, other)
+            self.assertTrue(df.equals(other))
+            self.assertTrue(other.equals(df))
+
+    def test_round_trip_equals(self):
+        # GH 9330
+        df = DataFrame({"B": [1,2], "A": ["x","y"]})
+
+        with ensure_clean_path(self.path) as path:
+            df.to_hdf(path, 'df', format='table')
+            other = read_hdf(path, 'df')
+            tm.assert_frame_equal(df, other)
+            self.assertTrue(df.equals(other))
+            self.assertTrue(other.equals(df))
 
     def test_preserve_timedeltaindex_type(self):
-        # GH9635 
+        # GH9635
         # Storing TimedeltaIndexed DataFrames in fixed stores did not preserve
         # the type of the index.
         df = DataFrame(np.random.normal(size=(10,5)))
         df.index = timedelta_range(start='0s',periods=10,freq='1s',name='example')
 
         with ensure_clean_store(self.path) as store:
-            
+
             store['df'] = df
             assert_frame_equal(store['df'], df)
 

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -2990,25 +2990,21 @@ class TestFloatArrayFormatter(tm.TestCase):
         # Issue #9764
         
         # In case default display precision changes:
-        saved_option=pd.get_option('display.precision')
-        pd.set_option('display.precision', 7)
+        with pd.option_context('display.precision', 7):
+            # DataFrame example from issue #9764
+            d=pd.DataFrame({'col1':[9.999e-8, 1e-7, 1.0001e-7, 2e-7, 4.999e-7, 5e-7, 5.0001e-7, 6e-7, 9.999e-7, 1e-6, 1.0001e-6, 2e-6, 4.999e-6, 5e-6, 5.0001e-6, 6e-6]})
+            
+            expected_output={
+                (0,6):'           col1\n0  9.999000e-08\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07',
+                (1,6):'           col1\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07',
+                (1,8):'           col1\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07\n6  5.000100e-07\n7  6.000000e-07',
+                (8,16):'            col1\n8   9.999000e-07\n9   1.000000e-06\n10  1.000100e-06\n11  2.000000e-06\n12  4.999000e-06\n13  5.000000e-06\n14  5.000100e-06\n15  6.000000e-06',
+                (9,16):'        col1\n9   0.000001\n10  0.000001\n11  0.000002\n12  0.000005\n13  0.000005\n14  0.000005\n15  0.000006'
+            }
 
-        # DataFrame from issue #9764
-        d=pd.DataFrame({'col1':[9.999e-8, 1e-7, 1.0001e-7, 2e-7, 4.999e-7, 5e-7, 5.0001e-7, 6e-7, 9.999e-7, 1e-6, 1.0001e-6, 2e-6, 4.999e-6, 5e-6, 5.0001e-6, 6e-6]})
-        
-        expected_output={
-            (0,6):'           col1\n0  9.999000e-08\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07',
-            (1,6):'           col1\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07',
-            (1,8):'           col1\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07\n6  5.000100e-07\n7  6.000000e-07',
-            (8,16):'            col1\n8   9.999000e-07\n9   1.000000e-06\n10  1.000100e-06\n11  2.000000e-06\n12  4.999000e-06\n13  5.000000e-06\n14  5.000100e-06\n15  6.000000e-06',
-            (9,16):'        col1\n9   0.000001\n10  0.000001\n11  0.000002\n12  0.000005\n13  0.000005\n14  0.000005\n15  0.000006'
-        }
+            for (start, stop), v in expected_output.items():
+                self.assertEqual(str(d[start:stop]), v)
 
-        for k, v in expected_output.items():
-            self.assertEqual(d[k[0]:k[1]].__str__(), v)
-
-        # Restore precision
-        pd.set_option('display.precision', saved_option)
 
 class TestRepr_timedelta64(tm.TestCase):
 

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -2986,6 +2986,20 @@ class TestFloatArrayFormatter(tm.TestCase):
         self.assertEqual(result[0], " 12")
         self.assertEqual(result[1], "  0")
 
+    def test_output_significant_digits(self):
+        # relevant to issue #9764
+        d=pd.DataFrame({'col1':[9.999e-8, 1e-7, 1.0001e-7, 2e-7, 4.999e-7, 5e-7, 5.0001e-7, 6e-7, 9.999e-7, 1e-6, 1.0001e-6, 2e-6, 4.999e-6, 5e-6, 5.0001e-6, 6e-6]})
+        
+        expected_output={
+            (0,6):'           col1\n0  9.999000e-08\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07',
+            (1,6):'           col1\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07',
+            (1,8):'           col1\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07\n6  5.000100e-07\n7  6.000000e-07',
+            (8,16):'            col1\n8   9.999000e-07\n9   1.000000e-06\n10  1.000100e-06\n11  2.000000e-06\n12  4.999000e-06\n13  5.000000e-06\n14  5.000100e-06\n15  6.000000e-06',
+            (9,16):'        col1\n9   0.000001\n10  0.000001\n11  0.000002\n12  0.000005\n13  0.000005\n14  0.000005\n15  0.000006'
+        }
+
+        for k, v in expected_output.items():
+            self.assertEqual(d[k[0]:k[1]].__str__(), v)
 
 class TestRepr_timedelta64(tm.TestCase):
 

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -2987,7 +2987,13 @@ class TestFloatArrayFormatter(tm.TestCase):
         self.assertEqual(result[1], "  0")
 
     def test_output_significant_digits(self):
-        # relevant to issue #9764
+        # Issue #9764
+        
+        # In case default display precision changes:
+        saved_option=pd.get_option('display.precision')
+        pd.set_option('display.precision', 7)
+
+        # DataFrame from issue #9764
         d=pd.DataFrame({'col1':[9.999e-8, 1e-7, 1.0001e-7, 2e-7, 4.999e-7, 5e-7, 5.0001e-7, 6e-7, 9.999e-7, 1e-6, 1.0001e-6, 2e-6, 4.999e-6, 5e-6, 5.0001e-6, 6e-6]})
         
         expected_output={
@@ -3000,6 +3006,9 @@ class TestFloatArrayFormatter(tm.TestCase):
 
         for k, v in expected_output.items():
             self.assertEqual(d[k[0]:k[1]].__str__(), v)
+
+        # Restore precision
+        pd.set_option('display.precision', saved_option)
 
 class TestRepr_timedelta64(tm.TestCase):
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5944,6 +5944,20 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.assertRaises(ValueError, lambda : df == (2,2))
         self.assertRaises(ValueError, lambda : df == [2,2])
 
+    def test_equals_different_blocks(self):
+        # GH 9330
+        df0 = pd.DataFrame({"A": ["x","y"], "B": [1,2], 
+                            "C": ["w","z"]})
+        df1 = df0.reset_index()[["A","B","C"]]
+        # this assert verifies that the above operations have 
+        # induced a block rearrangement
+        self.assertTrue(df0._data.blocks[0].dtype != 
+                        df1._data.blocks[0].dtype)
+        # do the real tests
+        self.assert_frame_equal(df0, df1)
+        self.assertTrue(df0.equals(df1))
+        self.assertTrue(df1.equals(df0))
+        
     def test_to_csv_from_csv(self):
 
         pname = '__tmp_to_csv_from_csv__'

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -991,6 +991,18 @@ class TestDataFramePlots(TestPlotBase):
         df = DataFrame({'x': [1, 2], 'y': [3, 4]})
         with tm.assertRaises(TypeError):
             df.plot(kind='line', blarg=True)
+        try:
+            df.plot(color = ['red', 'black'], style = ['-', '--'])
+            df['x'].plot(color = 'red', style = '-')
+        except:
+            self.fail("Calling 'plot()' on a dataframe/series and passing both 'color' and 'style' arguments should be allowed if there is no color symbol in the style string(s)")
+        try:
+            df.plot(color = ['red', 'black'], style = ['k-', 'r--'])
+            df['x'].plot(color = 'red', style = 'k-')
+        except:
+            pass
+        else:
+            self.fail("Calling 'plot()' on a dataframe/series and passing both 'color' and 'style' arguments should raise an error if there is a color symbol in the style string(s)")
 
         df = DataFrame(np.random.rand(10, 3),
                        index=list(string.ascii_letters[:10]))

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1154,6 +1154,22 @@ class TestDataFramePlots(TestPlotBase):
         self.assertEqual(len(axes), 1)
         self.assertIs(ax.get_axes(), axes[0])
 
+    def test_color_and_style_arguments(self):
+        df = DataFrame({'x': [1, 2], 'y': [3, 4]})
+        # passing both 'color' and 'style' arguments should be allowed
+        # if there is no color symbol in the style strings:
+        ax = df.plot(color = ['red', 'black'], style = ['-', '--'])
+        # check that the linestyles are correctly set:
+        linestyle = [line.get_linestyle() for line in ax.lines]
+        self.assertEqual(linestyle, ['-', '--'])
+        # check that the colors are correctly set:
+        color = [line.get_color() for line in ax.lines]
+        self.assertEqual(color, ['red', 'black'])
+        # passing both 'color' and 'style' arguments should not be allowed
+        # if there is a color symbol in the style strings:
+        with tm.assertRaises(ValueError):
+            df.plot(color = ['red', 'black'], style = ['k-', 'r--'])
+
     def test_nonnumeric_exclude(self):
         df = DataFrame({'A': ["x", "y", "z"], 'B': [1, 2, 3]})
         ax = df.plot()

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -991,18 +991,6 @@ class TestDataFramePlots(TestPlotBase):
         df = DataFrame({'x': [1, 2], 'y': [3, 4]})
         with tm.assertRaises(TypeError):
             df.plot(kind='line', blarg=True)
-        try:
-            df.plot(color = ['red', 'black'], style = ['-', '--'])
-            df['x'].plot(color = 'red', style = '-')
-        except:
-            self.fail("Calling 'plot()' on a dataframe/series and passing both 'color' and 'style' arguments should be allowed if there is no color symbol in the style string(s)")
-        try:
-            df.plot(color = ['red', 'black'], style = ['k-', 'r--'])
-            df['x'].plot(color = 'red', style = 'k-')
-        except:
-            pass
-        else:
-            self.fail("Calling 'plot()' on a dataframe/series and passing both 'color' and 'style' arguments should raise an error if there is a color symbol in the style string(s)")
 
         df = DataFrame(np.random.rand(10, 3),
                        index=list(string.ascii_letters[:10]))
@@ -1064,6 +1052,22 @@ class TestDataFramePlots(TestPlotBase):
         axes = df.plot(kind='bar', subplots=True, ax=ax)
         self.assertEqual(len(axes), 1)
         self.assertIs(ax.get_axes(), axes[0])
+
+    def test_color_and_style_arguments(self):
+        df = DataFrame({'x': [1, 2], 'y': [3, 4]})
+        # passing both 'color' and 'style' arguments should be allowed
+        # if there is no color symbol in the style strings:
+        ax = df.plot(color = ['red', 'black'], style = ['-', '--'])
+        # check that the linestyles are correctly set:
+        linestyle = [line.get_linestyle() for line in ax.lines]
+        self.assertEqual(linestyle, ['-', '--'])
+        # check that the colors are correctly set:
+        color = [line.get_color() for line in ax.lines]
+        self.assertEqual(color, ['red', 'black'])
+        # passing both 'color' and 'style' arguments should not be allowed
+        # if there is a color symbol in the style strings:
+        with tm.assertRaises(ValueError):
+            df.plot(color = ['red', 'black'], style = ['k-', 'r--'])
 
     def test_nonnumeric_exclude(self):
         df = DataFrame({'A': ["x", "y", "z"], 'B': [1, 2, 3]})

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -871,12 +871,17 @@ class MPLPlot(object):
                           "simultaneously. Using 'color'")
 
         if 'color' in self.kwds and self.style is not None:
+            if com.is_list_like(self.style):
+                styles = self.style
+            else:
+                styles = [self.style]
             # need only a single match
-            if re.match('^[a-z]+?', self.style) is not None:
-                raise ValueError("Cannot pass 'style' string with a color "
-                                 "symbol and 'color' keyword argument. Please"
-                                 " use one or the other or pass 'style' "
-                                 "without a color symbol")
+            for s in styles:
+                if re.match('^[a-z]+?', s) is not None:
+                    raise ValueError("Cannot pass 'style' string with a color "
+                                     "symbol and 'color' keyword argument. Please"
+                                     " use one or the other or pass 'style' "
+                                     "without a color symbol")
 
     def _iter_data(self, data=None, keep_index=False, fillna=None):
         if data is None:

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -867,12 +867,17 @@ class MPLPlot(object):
                           "simultaneously. Using 'color'")
 
         if 'color' in self.kwds and self.style is not None:
+            if com.is_list_like(self.style):
+                styles = self.style
+            else:
+                styles = [self.style]
             # need only a single match
-            if re.match('^[a-z]+?', self.style) is not None:
-                raise ValueError("Cannot pass 'style' string with a color "
-                                 "symbol and 'color' keyword argument. Please"
-                                 " use one or the other or pass 'style' "
-                                 "without a color symbol")
+            for s in styles:
+                if re.match('^[a-z]+?', s) is not None:
+                    raise ValueError("Cannot pass 'style' string with a color "
+                                     "symbol and 'color' keyword argument. Please"
+                                     " use one or the other or pass 'style' "
+                                     "without a color symbol")
 
     def _iter_data(self, data=None, keep_index=False, fillna=None):
         if data is None:


### PR DESCRIPTION
closes #9671

`self.style` can be a list of strings or a string. If it is a string, we make a list containing that string, so that we only have to deal with a list of strings. We check every element in that list and raise an error if it has a color symbol.
The test makes sure that calling `plot()` and passing both `color` and `style` arguments is allowed if there is no color symbol in the style string(s), and that passing both `color` and `style` arguments is not allowed if there is a color symbol in the style string(s). This test is done for a dataframe and for a series.
