### PR TITLE
BUG: workaround PyTables 319, but not setting expected rows (GH8265, GH9676)

### DIFF
--- a/doc/source/whatsnew/v0.16.0.txt
+++ b/doc/source/whatsnew/v0.16.0.txt
@@ -609,6 +609,7 @@ Bug Fixes
 - Bug in ``Series.values_counts`` with excluding ``NaN`` for categorical type ``Series`` with ``dropna=True`` (:issue:`9443`)
 - Fixed mising numeric_only option for ``DataFrame.std/var/sem`` (:issue:`9201`)
 - Support constructing ``Panel`` or ``Panel4D`` with scalar data (:issue:`8285`)
+- Work around Pytables 319 by not passing expectedrows in constructing a HDFStore (:issue:`8265`, :issue:`9676`)
 - ``Series`` text representation disconnected from `max_rows`/`max_columns` (:issue:`7508`).
 - ``Series`` number formatting inconsistent when truncated (:issue:`8532`).
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3509,9 +3509,8 @@ class Table(Fixed):
                            fletcher32=False, expectedrows=None):
         """ create the description of the table from the axes & values """
 
-        # expected rows estimate
-        if expectedrows is None:
-            expectedrows = max(self.nrows_expected, 10000)
+
+        # provided expected rows if its passed
         d = dict(name='table', expectedrows=expectedrows)
 
         # description from the axes & values


### PR DESCRIPTION
closes #8265
closes #9676 
