### PR TITLE
Bug: Access unknown attribute of timedeltaindexed series used to raise ValueError

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -70,11 +70,7 @@ Bug Fixes
 
 - Bug in ``transform`` causing length mismatch when null entries were present and a fast aggregator was being used (:issue:`9697`)
 
-
-
-
-
-
+- Bug : Trying to access absent attributes in TimedeltaIndex use to raise ValueError instead of AttributeError(:issue:`9680`)
 
 
 - Bug in ``Series.quantile`` on empty Series of type ``Datetime`` or ``Timedelta`` (:issue:`9675`)

--- a/pandas/tseries/base.py
+++ b/pandas/tseries/base.py
@@ -67,7 +67,7 @@ class DatetimeIndexOpsMixin(object):
         try:
             res = self.get_loc(key)
             return np.isscalar(res) or type(res) == slice or np.any(res)
-        except (KeyError, TypeError):
+        except (KeyError, TypeError, ValueError):
             return False
 
     @property

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -745,6 +745,13 @@ Freq: D"""
                                         ['00:01:00', '00:01:00', '00:00:01'])):
             tm.assertIn(idx[0], idx)
 
+    def test_unknown_attribute(self):
+        #GH 9680
+        tdi = pd.timedelta_range(start=0,periods=10,freq='1s')
+        ts = pd.Series(np.random.normal(size=10),index=tdi)
+        self.assertNotIn('foo',ts.__dict__.keys())
+        self.assertRaises(AttributeError,lambda : ts.foo)
+
 
 class TestPeriodIndexOps(Ops):
 


### PR DESCRIPTION
closes #9680

And now it raises AttributeError.
