### PR TITLE
Start python3 compatibility

### DIFF
--- a/vb_suite/frame_methods.py
+++ b/vb_suite/frame_methods.py
@@ -505,7 +505,7 @@ frame_from_records_generator = Benchmark('df = DataFrame.from_records(get_data()
 frame_from_records_generator_nrows = Benchmark('df = DataFrame.from_records(get_data(), nrows=1000)',
                                 setup,
                                 name='frame_from_records_generator_nrows',
-                                start_date=datetime(2013,10,04))  # issue-4911
+                                start_date=datetime(2013,10,4))  # issue-4911
 
 #-----------------------------------------------------------------------------
 # duplicated

--- a/vb_suite/suite.py
+++ b/vb_suite/suite.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from vbench.api import Benchmark, GitRepo
 from datetime import datetime
 
@@ -128,7 +129,7 @@ def generate_rst_files(benchmarks):
             f.write(rst_text)
 
     with open(os.path.join(RST_BASE, 'index.rst'), 'w') as f:
-        print >> f, """
+        print("""
 Performance Benchmarks
 ======================
 
@@ -149,15 +150,15 @@ Produced on a machine with
 .. toctree::
     :hidden:
     :maxdepth: 3
-"""
+""", file=f)
         for modname, mod_bmks in sorted(by_module.items()):
-            print >> f, '    vb_%s' % modname
+            print('    vb_%s' % modname, file=f)
             modpath = os.path.join(RST_BASE, 'vb_%s.rst' % modname)
             with open(modpath, 'w') as mh:
                 header = '%s\n%s\n\n' % (modname, '=' * len(modname))
-                print >> mh, header
+                print(header, file=mh)
 
                 for bmk in mod_bmks:
-                    print >> mh, bmk.name
-                    print >> mh, '-' * len(bmk.name)
-                    print >> mh, '.. include:: vbench/%s.txt\n' % bmk.name
+                    print(bmk.name, file=mh)
+                    print('-' * len(bmk.name), file=mh)
+                    print('.. include:: vbench/%s.txt\n' % bmk.name, file=mh)


### PR DESCRIPTION
Start for #9660

These are changes to get vbench running under python3.  There are quite a few tests that need modification, but with these changes the code will parse and the suite can run (along with [vbench#36](https://github.com/pydata/vbench/pull/36)).
