### PR TITLE
BUG: datetime/timedelta Series quantile() call

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -31,3 +31,5 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
+
+- Bug in ``Series.quantile`` on empty Series of type ``Datetime`` or ``Timedelta`` (:issue:`9675`)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2095,7 +2095,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             boxer = com.i8_boxer(self)
 
             if len(values) == 0:
-                return boxer(iNaT)
+                return boxer(tslib.iNaT)
 
             values = values.view('i8')
             result = func(values)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -6837,6 +6837,11 @@ class TestSeriesNonUnique(tm.TestCase):
     def test_unique_data_ownership(self):
         # it works! #1807
         Series(Series(["a", "c", "b"]).unique()).sort()
+    
+    def test_datetime_timedelta_quantiles(self):
+        # covers #9694
+        self.assertTrue(pd.isnull(Series([],dtype='M8[ns]').quantile(.5)))
+        self.assertTrue(pd.isnull(Series([],dtype='m8[ns]').quantile(.5)))
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
Changes to be committed:
    modified:   pandas/core/series.py
    modified:   pandas/tests/test_series.py

Fixes global reference to iNaT (should be tslib.iNaT) in series._maybe_box.
Adds test `test_datetime_timedelta_quantiles` to check for proper return value
in test_series.py.

Issue #9675
