### PR TITLE
BUG: fix for interp with axis=1 and inplace

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -31,3 +31,6 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
+
+
+- Fixed bug with inplace interpolace along the "columns" axis (:issue:`9687`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2736,10 +2736,11 @@ class NDFrame(PandasObject):
         if self.ndim > 2:
             raise NotImplementedError("Interpolate has not been implemented "
                                       "on Panel and Panel 4D objects.")
-
+        axis = self._get_axis_number(axis)
         if axis == 0:
             ax = self._info_axis_name
         elif axis == 1:
+            orig = self
             self = self.T
             ax = 1
         ax = self._get_axis_number(ax)
@@ -2777,7 +2778,7 @@ class NDFrame(PandasObject):
         if inplace:
             if axis == 1:
                 self._update_inplace(new_data)
-                self = self.T
+                orig._data = self.T._data
             else:
                 self._update_inplace(new_data)
         else:

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -8683,9 +8683,6 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         result = df.replace({'col': {-1: '-', 1: 'a', 4: 'b'}})
         tm.assert_frame_equal(expected, result)
 
-    def test_interpolate(self):
-        pass
-
     def test_replace_value_is_none(self):
         self.assertRaises(TypeError, self.tsframe.replace, nan)
         orig_value = self.tsframe.iloc[0, 0]

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -963,6 +963,20 @@ class TestDataFrame(tm.TestCase, Generic):
         result = df[['B', 'D']].interpolate(downcast=None)
         assert_frame_equal(result, df[['B', 'D']])
 
+    def test_interp_inplace_axis1(self):
+        # GH 9687
+        df = DataFrame({'A': [1, 2, 3], 'B': [2, np.nan, 6],
+                        'C': [3, 4, 5]})
+        df.interpolate(axis=1, inplace=True)
+        # dtypes... a bit strange here.
+        # df.T w/ [int, float, int] -> [float, float, float] dtypes
+        # this test may break if we change that in the future.
+        expected = DataFrame({'A': [1., 2, 3], 'B': [2., 3, 6],
+                              'C': [3., 4, 5]})
+        assert_frame_equal(df, expected)
+        self.assertIs(df, df)
+
+
     def test_describe(self):
         desc = tm.makeDataFrame().describe()
         desc = tm.makeMixedDataFrame().describe()


### PR DESCRIPTION
Closes https://github.com/pydata/pandas/issues/9687

There's still some weird issues with dtypes. In my test case there's a DataFrame with dtypes [int, float, int]. After the interpolation they should be downcasts to [int, int, int] when the missing value is filled. But along the way a transpose changes things to `[float, float, float]` before filling. And then (I think) `self._update_inplace` doesn't change dtypes, so the actual result is `[float, float, float]`.
