### PR TITLE
ENH Make year and quarter dash-separatable

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -22,6 +22,9 @@ API changes
 Enhancements
 ~~~~~~~~~~~~
 
+- Add support for separating years and quarters using dashes, for
+  example 2014-Q1.  (:issue:`9688`)
+
 .. _whatsnew_0161.performance:
 
 Performance Improvements

--- a/pandas/tseries/tools.py
+++ b/pandas/tseries/tools.py
@@ -383,10 +383,10 @@ def _attempt_YYYYMMDD(arg, coerce):
     return None
 
 # patterns for quarters like '4Q2005', '05Q1'
-qpat1full = re.compile(r'(\d)Q(\d\d\d\d)')
-qpat2full = re.compile(r'(\d\d\d\d)Q(\d)')
-qpat1 = re.compile(r'(\d)Q(\d\d)')
-qpat2 = re.compile(r'(\d\d)Q(\d)')
+qpat1full = re.compile(r'(\d)Q-?(\d\d\d\d)')
+qpat2full = re.compile(r'(\d\d\d\d)-?Q(\d)')
+qpat1 = re.compile(r'(\d)Q-?(\d\d)')
+qpat2 = re.compile(r'(\d\d)-?Q(\d)')
 ypat = re.compile(r'(\d\d\d\d)$')
 has_time = re.compile('(.+)([\s]|T)+(.+)')
 
@@ -424,18 +424,18 @@ def parse_time_string(arg, freq=None, dayfirst=None, yearfirst=None):
                                         second=0, microsecond=0)
 
     # special handling for possibilities eg, 2Q2005, 2Q05, 2005Q1, 05Q1
-    if len(arg) in [4, 6]:
+    if len(arg) in [4, 5, 6, 7]:
         m = ypat.match(arg)
         if m:
             ret = default.replace(year=int(m.group(1)))
             return ret, ret, 'year'
 
         add_century = False
-        if len(arg) == 4:
+        if len(arg) > 5:
+            qpats = [(qpat1full, 1), (qpat2full, 0)]
+        else:
             add_century = True
             qpats = [(qpat1, 1), (qpat2, 0)]
-        else:
-            qpats = [(qpat1full, 1), (qpat2full, 0)]
 
         for pat, yfirst in qpats:
             qparse = pat.match(arg)


### PR DESCRIPTION
This closes #9688 by making years and quarters separable by dashes.
