### PR TITLE
DOC: add DataFrame.assign to API docs

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -861,6 +861,7 @@ Combining / joining / merging
    :toctree: generated/
 
    DataFrame.append
+   DataFrame.assign
    DataFrame.join
    DataFrame.merge
    DataFrame.update


### PR DESCRIPTION
@TomAugspurger does this look like the right place to put this?

@jorisvandenbossche can we possibly merge this into the docs for v0.16?
