### PR TITLE
DOC: try to use matplotlib style (mpl >= 1.4) in all docs

### DIFF
--- a/doc/source/10min.rst
+++ b/doc/source/10min.rst
@@ -12,7 +12,11 @@
    from pandas import options
    import pandas as pd
    np.set_printoptions(precision=4, suppress=True)
-   options.display.mpl_style='default'
+   import matplotlib
+   try:
+      matplotlib.style.use('ggplot')
+   except AttributeError:
+      options.display.mpl_style = 'default'
    options.display.max_rows=15
 
    #### portions of this were borrowed from the
@@ -695,8 +699,6 @@ Plotting
 
    import matplotlib.pyplot as plt
    plt.close('all')
-   from pandas import options
-   options.display.mpl_style='default'
 
 .. ipython:: python
 

--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -13,7 +13,6 @@
    from pandas import *
    import pandas as pd
    np.set_printoptions(precision=4, suppress=True)
-   options.display.mpl_style='default'
    options.display.max_rows=15
 
 

--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -10,9 +10,13 @@
    import pandas.util.testing as tm
    randn = np.random.randn
    np.set_printoptions(precision=4, suppress=True)
+   import matplotlib
+   try:
+      matplotlib.style.use('ggplot')
+   except AttributeError:
+      options.display.mpl_style = 'default'
    import matplotlib.pyplot as plt
    plt.close('all')
-   options.display.mpl_style='default'
    options.display.max_rows=15
 
 Computational tools

--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -17,7 +17,12 @@
    np.random.seed(123456)
 
    pd.options.display.max_rows=15
-   pd.options.display.mpl_style='default'
+
+   import matplotlib
+   try:
+      matplotlib.style.use('ggplot')
+   except AttributeError:
+      pd.options.display.mpl_style = 'default'
 
    np.set_printoptions(precision=4, suppress=True)
 

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -21,7 +21,11 @@ Frequently Asked Questions (FAQ)
    from pandas.tseries.offsets import *
    import matplotlib.pyplot as plt
    plt.close('all')
-   options.display.mpl_style='default'
+   import matplotlib
+   try:
+      matplotlib.style.use('ggplot')
+   except AttributeError:
+      options.display.mpl_style = 'default'
    from pandas.compat import lrange
 
 

--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -12,7 +12,11 @@
    np.set_printoptions(precision=4, suppress=True)
    import matplotlib.pyplot as plt
    plt.close('all')
-   options.display.mpl_style='default'
+   import matplotlib
+   try:
+      matplotlib.style.use('ggplot')
+   except AttributeError:
+      options.display.mpl_style = 'default'
    from pandas.compat import zip
 
 *****************************
@@ -346,7 +350,7 @@ A single group can be selected using ``GroupBy.get_group()``:
 .. ipython:: python
 
    grouped.get_group('bar')
-   
+
 Or for an object grouped on multiple columns:
 
 .. ipython:: python

--- a/doc/source/sparse.rst
+++ b/doc/source/sparse.rst
@@ -10,9 +10,6 @@
    import pandas.util.testing as tm
    randn = np.random.randn
    np.set_printoptions(precision=4, suppress=True)
-   import matplotlib.pyplot as plt
-   plt.close('all')
-   options.display.mpl_style='default'
    options.display.max_rows = 15
 
 **********************
@@ -222,4 +219,3 @@ row and columns coordinates of the matrix. Note that this will consume a signifi
 
    ss_dense = SparseSeries.from_coo(A, dense_index=True)
    ss_dense
-

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -31,10 +31,14 @@ We use the standard convention for referencing the matplotlib API:
 
    import matplotlib.pyplot as plt
 
-.. versionadded:: 0.11.0
+The plots in this document are made using matplotlib's ``ggplot`` style (new in version 1.4):
 
-The plots in this document are made using matplotlib's ``ggplot`` style (new in version 1.4).
-If your version of matplotlib is 1.3 or lower, setting the ``display.mpl_style`` to ``'default'``
+.. code-block:: python
+
+   import matplotlib
+   matplotlib.style.use('ggplot')
+
+If your version of matplotlib is 1.3 or lower, you can set ``display.mpl_style`` to ``'default'``
 with ``pd.options.display.mpl_style = 'default'``
 to produce more appealing plots.
 When set, matplotlib's ``rcParams`` are changed (globally!) to nicer-looking settings.


### PR DESCRIPTION
now this was only done in the plotting docs itself, with as a result that the actual style used is a mixture between the two
