### PR TITLE
TST: Fix dateutil version check

### DIFF
--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -167,7 +167,7 @@ class TestTimestamp(tm.TestCase):
 
         # dateutil zone change (only matters for repr)
         import dateutil
-        if dateutil.__version__ >= LooseVersion('2.3') and dateutil.__version__ <= LooseVersion('2.4'):
+        if dateutil.__version__ >= LooseVersion('2.3') and dateutil.__version__ <= LooseVersion('2.4.0'):
             timezones = ['UTC', 'Asia/Tokyo', 'US/Eastern', 'dateutil/US/Pacific']
         else:
             timezones = ['UTC', 'Asia/Tokyo', 'US/Eastern', 'dateutil/America/Los_Angeles']


### PR DESCRIPTION
This allows the test to pass when using dateutil version 2.4.0

```
In [2]: '2.4.0' <= LooseVersion('2.4')
Out[2]: False

In [3]: '2.4.0' <= LooseVersion('2.4.0')
Out[3]: True
```
