### PR TITLE
ENH: support CategoricalIndex (GH7629)

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1291,6 +1291,34 @@ Selecting
    Index.slice_indexer
    Index.slice_locs
 
+.. _api.categoricalindex:
+
+CategoricalIndex
+----------------
+
+.. autosummary::
+   :toctree: generated/
+
+   CategoricalIndex
+
+Categorical Components
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: generated/
+
+   CategoricalIndex.codes
+   CategoricalIndex.categories
+   CategoricalIndex.ordered
+   CategoricalIndex.rename_categories
+   CategoricalIndex.reorder_categories
+   CategoricalIndex.add_categories
+   CategoricalIndex.remove_categories
+   CategoricalIndex.remove_unused_categories
+   CategoricalIndex.set_categories
+   CategoricalIndex.as_ordered
+   CategoricalIndex.as_unordered
+
 .. _api.datetimeindex:
 
 DatetimeIndex

--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -7,6 +7,10 @@ This is a minor bug-fix release from 0.16.0 and includes a a large number of
 bug fixes along several new features, enhancements, and performance improvements.
 We recommend that all users upgrade to this version.
 
+Highlights include:
+
+- Support for a ``CategoricalIndex``, a category based index, see :ref:`here <whatsnew_0161`.enhancements.categoricalindex>`
+
 .. contents:: What's new in v0.16.1
     :local:
     :backlinks: none
@@ -31,6 +35,7 @@ Enhancements
   will return a `np.array` instead of a boolean `Index` (:issue:`8875`). This enables the following expression
   to work naturally:
 
+
   .. ipython:: python
 
      idx = Index(['a1', 'a2', 'b1', 'b2'])
@@ -40,6 +45,7 @@ Enhancements
      s[s.index.str.startswith('a')]
 
 - ``DataFrame.mask()`` and ``Series.mask()`` now support same keywords as ``where`` (:issue:`8801`)
+
 - ``drop`` function can now accept ``errors`` keyword to suppress ValueError raised when any of label does not exist in the target data. (:issue:`6736`)
 
   .. ipython:: python
@@ -57,6 +63,75 @@ Enhancements
 - Trying to write an excel file now raises ``NotImplementedError`` if the ``DataFrame`` has a ``MultiIndex`` instead of writing a broken Excel file. (:issue:`9794`)
 
 - ``DataFrame`` and ``Series`` now have ``_constructor_expanddim`` property as overridable constructor for one higher dimensionality data. This should be used only when it is really needed, see :ref:`here <ref-subclassing-pandas>`
+
+.. _whatsnew_0161.enhancements.categoricalindex:
+
+CategoricalIndex
+^^^^^^^^^^^^^^^^
+
+We introduce a ``CategoricalIndex``, a new type of index object that is useful for supporting
+indexing with duplicates. This is a container around a ``Categorical`` (introduced in v0.15.0)
+and allows efficient indexing and storage of an index with a large number of duplicated elements. Prior to 0.16.1,
+setting the index of a ``DataFrame/Series`` with a ``category`` dtype would convert this to regular object-based ``Index``.
+
+.. ipython :: python
+
+   df = DataFrame({'A' : np.arange(6),
+                   'B' : Series(list('aabbca')).astype('category',
+                                                       categories=list('cab'))
+                  })
+   df
+   df.dtypes
+   df.B.cat.categories
+
+setting the index, will create create a CategoricalIndex
+
+.. ipython :: python
+
+   df2 = df.set_index('B')
+   df2.index
+
+indexing with ``__getitem__/.iloc/.loc/.ix`` works similarly to an Index with duplicates.
+The indexers MUST be in the category or the operation will raise.
+
+.. ipython :: python
+
+   df2.loc['a']
+
+and preserves the ``CategoricalIndex``
+
+.. ipython :: python
+
+   df2.loc['a'].index
+
+sorting will order by the order of the categories
+
+.. ipython :: python
+
+   df2.sort_index()
+
+groupby operations on the index will preserve the index nature as well
+
+.. ipython :: python
+
+   df2.groupby(level=0).sum()
+   df2.groupby(level=0).sum().index
+
+reindexing operations, will return a resulting index based on the type of the passed
+indexer, meaning that passing a list will return a plain-old-``Index``; indexing with
+a ``Categorical`` will return a ``CategoricalIndex``, indexed according to the categories
+of the PASSED ``Categorical`` dtype. This allows one to arbitrarly index these even with
+values NOT in the categories, similarly to how you can reindex ANY pandas index.
+
+.. ipython :: python
+
+   df2.reindex(['a','e'])
+   df2.reindex(['a','e']).index
+   df2.reindex(pd.Categorical(['a','e'],categories=list('abcde')))
+   df2.reindex(pd.Categorical(['a','e'],categories=list('abcde'))).index
+
+See the :ref:`documentation <advanced.categoricalindex>` for more. (:issue:`7629`)
+>>>>>>> support CategoricalIndex
 
 .. _whatsnew_0161.api:
 

--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -8,7 +8,7 @@ from pandas.core.common import isnull, notnull
 from pandas.core.categorical import Categorical
 from pandas.core.groupby import Grouper
 from pandas.core.format import set_eng_float_format
-from pandas.core.index import Index, Int64Index, Float64Index, MultiIndex
+from pandas.core.index import Index, CategoricalIndex, Int64Index, Float64Index, MultiIndex
 
 from pandas.core.series import Series, TimeSeries
 from pandas.core.frame import DataFrame

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -121,7 +121,7 @@ class PandasDelegate(PandasObject):
         raise TypeError("You cannot call method {name}".format(name=name))
 
     @classmethod
-    def _add_delegate_accessors(cls, delegate, accessors, typ):
+    def _add_delegate_accessors(cls, delegate, accessors, typ, overwrite=False):
         """
         add accessors to cls from the delegate class
 
@@ -131,6 +131,8 @@ class PandasDelegate(PandasObject):
         delegate : the class to get methods/properties & doc-strings
         acccessors : string list of accessors to add
         typ : 'property' or 'method'
+        overwrite : boolean, default False
+           overwrite the method/property in the target class if it exists
 
         """
 
@@ -164,7 +166,7 @@ class PandasDelegate(PandasObject):
                 f = _create_delegator_method(name)
 
             # don't overwrite existing methods/properties
-            if not hasattr(cls, name):
+            if overwrite or not hasattr(cls, name):
                 setattr(cls,name,f)
 
 

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -9,12 +9,11 @@ from pandas.compat import u
 
 from pandas.core.algorithms import factorize
 from pandas.core.base import PandasObject, PandasDelegate
-from pandas.core.index import Index, _ensure_index
-from pandas.tseries.period import PeriodIndex
 import pandas.core.common as com
 from pandas.util.decorators import cache_readonly
 
-from pandas.core.common import (CategoricalDtype, ABCSeries, isnull, notnull,
+from pandas.core.common import (CategoricalDtype, ABCSeries, ABCIndexClass, ABCPeriodIndex, ABCCategoricalIndex,
+                                isnull, notnull, is_dtype_equal,
                                 is_categorical_dtype, is_integer_dtype, is_object_dtype,
                                 _possibly_infer_to_datetimelike, get_dtype_kinds,
                                 is_list_like, is_sequence, is_null_slice, is_bool,
@@ -22,7 +21,6 @@ from pandas.core.common import (CategoricalDtype, ABCSeries, isnull, notnull,
                                 _coerce_indexer_dtype, _values_from_object, take_1d)
 from pandas.util.terminal import get_terminal_size
 from pandas.core.config import get_option
-from pandas.core import format as fmt
 
 def _cat_compare_op(op):
     def f(self, other):
@@ -86,7 +84,7 @@ def _cat_compare_op(op):
 
 def maybe_to_categorical(array):
     """ coerce to a categorical if a series is given """
-    if isinstance(array, ABCSeries):
+    if isinstance(array, (ABCSeries, ABCCategoricalIndex)):
         return array.values
     return array
 
@@ -236,15 +234,17 @@ class Categorical(PandasObject):
         # sanitize input
         if is_categorical_dtype(values):
 
-            # we are either a Series or a Categorical
-            cat = values
-            if isinstance(values, ABCSeries):
-                cat = values.values
+            # we are either a Series or a CategoricalIndex
+            if isinstance(values, (ABCSeries, ABCCategoricalIndex)):
+                values = values.values
+
+            if ordered is None:
+                ordered = values.ordered
             if categories is None:
-                categories = cat.categories
+                categories = values.categories
             values = values.__array__()
 
-        elif isinstance(values, Index):
+        elif isinstance(values, ABCIndexClass):
             pass
 
         else:
@@ -295,11 +295,11 @@ class Categorical(PandasObject):
                 warn("Values and categories have different dtypes. Did you mean to use\n"
                      "'Categorical.from_codes(codes, categories)'?", RuntimeWarning)
 
-            if is_integer_dtype(values) and (codes == -1).all():
+            if len(values) and is_integer_dtype(values) and (codes == -1).all():
                 warn("None of the categories were found in values. Did you mean to use\n"
                      "'Categorical.from_codes(codes, categories)'?", RuntimeWarning)
 
-        self.set_ordered(ordered, inplace=True)
+        self.set_ordered(ordered or False, inplace=True)
         self.categories = categories
         self.name = name
         self._codes = _coerce_indexer_dtype(codes, categories)
@@ -309,10 +309,26 @@ class Categorical(PandasObject):
         return Categorical(values=self._codes.copy(),categories=self.categories,
                            name=self.name, ordered=self.ordered, fastpath=True)
 
+    def astype(self, dtype):
+        """ coerce this type to another dtype """
+        if is_categorical_dtype(dtype):
+            return self
+        return np.array(self, dtype=dtype)
+
     @cache_readonly
     def ndim(self):
         """Number of dimensions of the Categorical """
         return self._codes.ndim
+
+    @cache_readonly
+    def size(self):
+        """ return the len of myself """
+        return len(self)
+
+    @cache_readonly
+    def itemsize(self):
+        """ return the size of a single category """
+        return self.categories.itemsize
 
     def reshape(self, new_shape, **kwargs):
         """ compat with .reshape """
@@ -395,7 +411,8 @@ class Categorical(PandasObject):
     codes = property(fget=_get_codes, fset=_set_codes, doc=_codes_doc)
 
     def _get_labels(self):
-        """ Get the category labels (deprecated).
+        """
+        Get the category labels (deprecated).
 
         Deprecated, use .codes!
         """
@@ -409,8 +426,10 @@ class Categorical(PandasObject):
 
     @classmethod
     def _validate_categories(cls, categories):
-        """" Validates that we have good categories """
-        if not isinstance(categories, Index):
+        """
+        Validates that we have good categories
+        """
+        if not isinstance(categories, ABCIndexClass):
             dtype = None
             if not hasattr(categories, "dtype"):
                 categories = _convert_to_list_like(categories)
@@ -421,6 +440,8 @@ class Categorical(PandasObject):
                     with_na = np.array(categories)
                     if with_na.dtype != without_na.dtype:
                         dtype = "object"
+
+            from pandas import Index
             categories = Index(categories, dtype=dtype)
         if not categories.is_unique:
             raise ValueError('Categorical categories must be unique')
@@ -761,6 +782,8 @@ class Categorical(PandasObject):
         cat = self if inplace else self.copy()
         _used = sorted(np.unique(cat._codes))
         new_categories = cat.categories.take(_ensure_platform_int(_used))
+
+        from pandas.core.index import _ensure_index
         new_categories = _ensure_index(new_categories)
         cat._codes = _get_codes_for_values(cat.__array__(), new_categories)
         cat._categories = new_categories
@@ -790,7 +813,8 @@ class Categorical(PandasObject):
         return tuple([len(self._codes)])
 
     def __array__(self, dtype=None):
-        """ The numpy array interface.
+        """
+        The numpy array interface.
 
         Returns
         -------
@@ -799,7 +823,7 @@ class Categorical(PandasObject):
             dtype as categorical.categories.dtype
         """
         ret = take_1d(self.categories.values, self._codes)
-        if dtype and dtype != self.categories.dtype:
+        if dtype and not is_dtype_equal(dtype,self.categories.dtype):
             return np.asarray(ret, dtype)
         return ret
 
@@ -997,7 +1021,7 @@ class Categorical(PandasObject):
         """
 
         # if we are a period index, return a string repr
-        if isinstance(self.categories, PeriodIndex):
+        if isinstance(self.categories, ABCPeriodIndex):
             return take_1d(np.array(self.categories.to_native_types(), dtype=object),
                            self._codes)
 
@@ -1243,7 +1267,8 @@ class Categorical(PandasObject):
         """Returns an Iterator over the values of this Categorical."""
         return iter(np.array(self))
 
-    def _tidy_repr(self, max_vals=10):
+    def _tidy_repr(self, max_vals=10, footer=True):
+        """ a short repr displaying only max_vals and an optional (but default footer) """
         num = max_vals // 2
         head = self[:num]._get_repr(length=False, name=False, footer=False)
         tail = self[-(max_vals - num):]._get_repr(length=False,
@@ -1251,23 +1276,31 @@ class Categorical(PandasObject):
                                                   footer=False)
 
         result = '%s, ..., %s' % (head[:-1], tail[1:])
-        result = '%s\n%s' % (result, self._repr_footer())
+        if footer:
+            result = '%s\n%s' % (result, self._repr_footer())
 
         return compat.text_type(result)
 
-    def _repr_categories_info(self):
-        """ Returns a string representation of the footer."""
-
+    def _repr_categories(self):
+        """ return the base repr for the categories """
         max_categories = (10 if get_option("display.max_categories") == 0
                     else get_option("display.max_categories"))
+        from pandas.core import format as fmt
         category_strs = fmt.format_array(self.categories.get_values(), None)
         if len(category_strs) > max_categories:
             num = max_categories // 2
             head = category_strs[:num]
             tail = category_strs[-(max_categories - num):]
             category_strs = head + ["..."] + tail
+
         # Strip all leading spaces, which format_array adds for columns...
         category_strs = [x.strip() for x in category_strs]
+        return category_strs
+
+    def _repr_categories_info(self):
+        """ Returns a string representation of the footer."""
+
+        category_strs = self._repr_categories()
         levheader = "Categories (%d, %s): " % (len(self.categories),
                                                self.categories.dtype)
         width, height = get_terminal_size()
@@ -1299,8 +1332,11 @@ class Categorical(PandasObject):
                                        len(self), self._repr_categories_info())
 
     def _get_repr(self, name=False, length=True, na_rep='NaN', footer=True):
-        formatter = fmt.CategoricalFormatter(self, name=name,
-                                             length=length, na_rep=na_rep,
+        from pandas.core import format as fmt
+        formatter = fmt.CategoricalFormatter(self,
+                                             name=name,
+                                             length=length,
+                                             na_rep=na_rep,
                                              footer=footer)
         result = formatter.to_string()
         return compat.text_type(result)
@@ -1315,9 +1351,9 @@ class Categorical(PandasObject):
                                     name=True)
         else:
             result = '[], %s' % self._get_repr(name=True,
-                                                           length=False,
-                                                           footer=True,
-                                                           ).replace("\n",", ")
+                                               length=False,
+                                               footer=True,
+                                               ).replace("\n",", ")
 
         return result
 
@@ -1358,6 +1394,8 @@ class Categorical(PandasObject):
                                  "categories")
 
         rvalue = value if is_list_like(value) else [value]
+
+        from pandas import Index
         to_add = Index(rvalue).difference(self.categories)
 
         # no assignments of values not in categories, but it's always ok to set something to np.nan
@@ -1516,11 +1554,27 @@ class Categorical(PandasObject):
         -------
         are_equal : boolean
         """
-        if not isinstance(other, Categorical):
-            return False
         # TODO: should this also test if name is equal?
-        return (self.categories.equals(other.categories) and self.ordered == other.ordered and
-                np.array_equal(self._codes, other._codes))
+        return self.is_dtype_equal(other) and np.array_equal(self._codes, other._codes)
+
+    def is_dtype_equal(self, other):
+        """
+        Returns True if categoricals are the same dtype
+          same categories, and same ordered
+
+        Parameters
+        ----------
+        other : Categorical
+
+        Returns
+        -------
+        are_equal : boolean
+        """
+
+        try:
+            return self.categories.equals(other.categories) and self.ordered == other.ordered
+        except (AttributeError, TypeError):
+            return False
 
     def describe(self):
         """ Describes this Categorical
@@ -1604,18 +1658,20 @@ CategoricalAccessor._add_delegate_accessors(delegate=Categorical,
 ##### utility routines #####
 
 def _get_codes_for_values(values, categories):
-    """"
+    """
     utility routine to turn values into codes given the specified categories
     """
 
     from pandas.core.algorithms import _get_data_algo, _hashtables
-    if values.dtype != categories.dtype:
+    if not is_dtype_equal(values.dtype,categories.dtype):
         values = _ensure_object(values)
         categories = _ensure_object(categories)
+
     (hash_klass, vec_klass), vals = _get_data_algo(values, _hashtables)
-    t = hash_klass(len(categories))
-    t.map_locations(_values_from_object(categories))
-    return _coerce_indexer_dtype(t.lookup(values), categories)
+    (_, _), cats = _get_data_algo(categories, _hashtables)
+    t = hash_klass(len(cats))
+    t.map_locations(cats)
+    return _coerce_indexer_dtype(t.lookup(vals), cats)
 
 def _convert_to_list_like(list_like):
     if hasattr(list_like, "dtype"):

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -83,6 +83,16 @@ ABCMultiIndex = create_pandas_abc_type("ABCMultiIndex", "_typ", ("multiindex",))
 ABCDatetimeIndex = create_pandas_abc_type("ABCDatetimeIndex", "_typ", ("datetimeindex",))
 ABCTimedeltaIndex = create_pandas_abc_type("ABCTimedeltaIndex", "_typ", ("timedeltaindex",))
 ABCPeriodIndex = create_pandas_abc_type("ABCPeriodIndex", "_typ", ("periodindex",))
+ABCCategoricalIndex = create_pandas_abc_type("ABCCategoricalIndex", "_typ", ("categoricalindex",))
+ABCIndexClass = create_pandas_abc_type("ABCIndexClass", "_typ", ("index",
+                                                                 "int64index",
+                                                                 "float64index",
+                                                                 "multiindex",
+                                                                 "datetimeindex",
+                                                                 "timedeltaindex",
+                                                                 "periodindex",
+                                                                 "categoricalindex"))
+
 ABCSeries = create_pandas_abc_type("ABCSeries", "_typ", ("series",))
 ABCDataFrame = create_pandas_abc_type("ABCDataFrame", "_typ", ("dataframe",))
 ABCPanel = create_pandas_abc_type("ABCPanel", "_typ", ("panel",))
@@ -2455,11 +2465,27 @@ def _get_dtype_type(arr_or_dtype):
         return np.dtype(arr_or_dtype).type
     elif isinstance(arr_or_dtype, CategoricalDtype):
         return CategoricalDtypeType
+    elif isinstance(arr_or_dtype, compat.string_types):
+        if is_categorical_dtype(arr_or_dtype):
+            return CategoricalDtypeType
+        return _get_dtype_type(np.dtype(arr_or_dtype))
     try:
         return arr_or_dtype.dtype.type
     except AttributeError:
         raise ValueError('%r is not a dtype' % arr_or_dtype)
 
+def is_dtype_equal(source, target):
+    """ return a boolean if the dtypes are equal """
+    source = _get_dtype_type(source)
+    target = _get_dtype_type(target)
+
+    try:
+        return source == target
+    except TypeError:
+
+        # invalid comparison
+        # object == category will hit this
+        return False
 
 def is_any_int_dtype(arr_or_dtype):
     tipo = _get_dtype_type(arr_or_dtype)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -253,7 +253,7 @@ class _NDFrameIndexer(object):
                     # just replacing the block manager here
                     # so the object is the same
                     index = self.obj._get_axis(i)
-                    labels = safe_append_to_index(index, key)
+                    labels = index.insert(len(index),key)
                     self.obj._data = self.obj.reindex_axis(labels, i)._data
                     self.obj._maybe_update_cacher(clear=True)
                     self.obj.is_copy=None
@@ -274,10 +274,7 @@ class _NDFrameIndexer(object):
                 # and set inplace
                 if self.ndim == 1:
                     index = self.obj.index
-                    if len(index) == 0:
-                        new_index = Index([indexer])
-                    else:
-                        new_index = safe_append_to_index(index, indexer)
+                    new_index = index.insert(len(index),indexer)
 
                     # this preserves dtype of the value
                     new_values = Series([value]).values
@@ -928,24 +925,6 @@ class _NDFrameIndexer(object):
 
         labels = self.obj._get_axis(axis)
 
-        def _reindex(keys, level=None):
-
-            try:
-                result = self.obj.reindex_axis(keys, axis=axis, level=level)
-            except AttributeError:
-                # Series
-                if axis != 0:
-                    raise AssertionError('axis must be 0')
-                return self.obj.reindex(keys, level=level)
-
-            # this is an error as we are trying to find
-            # keys in a multi-index that don't exist
-            if isinstance(labels, MultiIndex) and level is not None:
-                if hasattr(result,'ndim') and not np.prod(result.shape) and len(keys):
-                    raise KeyError("cannot index a multi-index axis with these keys")
-
-            return result
-
         if is_bool_indexer(key):
             key = check_bool_indexer(labels, key)
             inds, = key.nonzero()
@@ -958,8 +937,9 @@ class _NDFrameIndexer(object):
                 # asarray can be unsafe, NumPy strings are weird
                 keyarr = _asarray_tuplesafe(key)
 
-            # handle a mixed integer scenario
-            indexer = labels._convert_list_indexer_for_mixed(keyarr, kind=self.name)
+            # have the index handle the indexer and possibly return
+            # an indexer or raising
+            indexer = labels._convert_list_indexer(keyarr, kind=self.name)
             if indexer is not None:
                 return self.obj.take(indexer, axis=axis)
 
@@ -970,65 +950,48 @@ class _NDFrameIndexer(object):
             else:
                 level = None
 
-            keyarr_is_unique = Index(keyarr).is_unique
+            # existing labels are unique and indexer are unique
+            if labels.is_unique and Index(keyarr).is_unique:
 
-            # existing labels are unique and indexer is unique
-            if labels.is_unique and keyarr_is_unique:
-                return _reindex(keyarr, level=level)
+                try:
+                    result = self.obj.reindex_axis(keyarr, axis=axis, level=level)
 
+                    # this is an error as we are trying to find
+                    # keys in a multi-index that don't exist
+                    if isinstance(labels, MultiIndex) and level is not None:
+                        if hasattr(result,'ndim') and not np.prod(result.shape) and len(keyarr):
+                            raise KeyError("cannot index a multi-index axis with these keys")
+
+                    return result
+
+                except AttributeError:
+
+                    # Series
+                    if axis != 0:
+                        raise AssertionError('axis must be 0')
+                    return self.obj.reindex(keyarr, level=level)
+
+            # existing labels are non-unique
             else:
-                indexer, missing = labels.get_indexer_non_unique(keyarr)
-                check = indexer != -1
-                result = self.obj.take(indexer[check], axis=axis,
-                                       convert=False)
 
-                # need to merge the result labels and the missing labels
-                if len(missing):
-                    l = np.arange(len(indexer))
+                # reindex with the specified axis
+                if axis + 1 > self.obj.ndim:
+                    raise AssertionError("invalid indexing error with "
+                                         "non-unique index")
 
-                    missing = com._ensure_platform_int(missing)
-                    missing_labels = keyarr.take(missing)
-                    missing_indexer = com._ensure_int64(l[~check])
-                    cur_labels = result._get_axis(axis).values
-                    cur_indexer = com._ensure_int64(l[check])
+                new_target, indexer, new_indexer = labels._reindex_non_unique(keyarr)
 
-                    new_labels = np.empty(tuple([len(indexer)]), dtype=object)
-                    new_labels[cur_indexer] = cur_labels
-                    new_labels[missing_indexer] = missing_labels
-
-                    # reindex with the specified axis
-                    ndim = self.obj.ndim
-                    if axis + 1 > ndim:
-                        raise AssertionError("invalid indexing error with "
-                                             "non-unique index")
-
-                    # a unique indexer
-                    if keyarr_is_unique:
-
-                        # see GH5553, make sure we use the right indexer
-                        new_indexer = np.arange(len(indexer))
-                        new_indexer[cur_indexer] = np.arange(
-                            len(result._get_axis(axis))
-                        )
-                        new_indexer[missing_indexer] = -1
-
-                    # we have a non_unique selector, need to use the original
-                    # indexer here
-                    else:
-
-                        # need to retake to have the same size as the indexer
-                        rindexer = indexer.values
-                        rindexer[~check] = 0
-                        result = self.obj.take(rindexer, axis=axis,
-                                               convert=False)
-
-                        # reset the new indexer to account for the new size
-                        new_indexer = np.arange(len(result))
-                        new_indexer[~check] = -1
+                if new_indexer is not None:
+                    result = self.obj.take(indexer[indexer!=-1], axis=axis,
+                                           convert=False)
 
                     result = result._reindex_with_indexers({
-                        axis: [new_labels, new_indexer]
-                    }, copy=True, allow_dups=True)
+                        axis: [new_target, new_indexer]
+                        }, copy=True, allow_dups=True)
+
+                else:
+                    result = self.obj.take(indexer, axis=axis,
+                                           convert=False)
 
                 return result
 
@@ -1105,8 +1068,9 @@ class _NDFrameIndexer(object):
                 else:
                     objarr = _asarray_tuplesafe(obj)
 
-                # If have integer labels, defer to label-based indexing
-                indexer = labels._convert_list_indexer_for_mixed(objarr, kind=self.name)
+                # The index may want to handle a list indexer differently
+                # by returning an indexer or raising
+                indexer = labels._convert_list_indexer(objarr, kind=self.name)
                 if indexer is not None:
                     return indexer
 
@@ -1717,19 +1681,6 @@ def convert_from_missing_indexer_tuple(indexer, axes):
         return (axes[_i].get_loc(_idx['key'])
                 if isinstance(_idx, dict) else _idx)
     return tuple([get_indexer(_i, _idx) for _i, _idx in enumerate(indexer)])
-
-
-def safe_append_to_index(index, key):
-    """ a safe append to an index, if incorrect type, then catch and recreate
-    """
-    try:
-        return index.insert(len(index), key)
-    except:
-
-        # raise here as this is basically an unsafe operation and we want
-        # it to be obvious that you are doing something wrong
-        raise ValueError("unsafe appending to index of type {0} with a key "
-                         "{1}".format(index.__class__.__name__, key))
 
 
 def maybe_convert_indices(indices, n):

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -3134,7 +3134,6 @@ class BlockManager(PandasObject):
 
         pandas-indexer with -1's only.
         """
-
         if indexer is None:
             if new_axis is self.axes[axis] and not copy:
                 return self
@@ -3146,10 +3145,9 @@ class BlockManager(PandasObject):
 
         self._consolidate_inplace()
 
-        # trying to reindex on an axis with duplicates
-        if (not allow_dups and not self.axes[axis].is_unique
-            and len(indexer)):
-            raise ValueError("cannot reindex from a duplicate axis")
+        # some axes don't allow reindexing with dups
+        if not allow_dups:
+            self.axes[axis]._can_reindex(indexer)
 
         if axis >= self.ndim:
             raise IndexError("Requested axis not found in manager")

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2594,8 +2594,9 @@ def _sanitize_array(data, index, dtype=None, copy=False,
 
     # GH #846
     if isinstance(data, (np.ndarray, Index, Series)):
-        subarr = np.array(data, copy=False)
+
         if dtype is not None:
+            subarr = np.array(data, copy=False)
 
             # possibility of nan -> garbage
             if com.is_float_dtype(data.dtype) and com.is_integer_dtype(dtype):

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -11,7 +11,7 @@ from distutils.version import LooseVersion
 import numpy as np
 import pandas as pd
 
-from pandas import Categorical, Index, Series, DataFrame, PeriodIndex, Timestamp
+from pandas import Categorical, Index, Series, DataFrame, PeriodIndex, Timestamp, CategoricalIndex
 
 from pandas.core.config import option_context
 import pandas.core.common as com
@@ -92,6 +92,24 @@ class TestCategorical(tm.TestCase):
             self.assertRaises(TypeError, lambda :  Categorical.from_array(arr, ordered=True))
         else:
             Categorical.from_array(arr, ordered=True)
+
+    def test_is_equal_dtype(self):
+
+        # test dtype comparisons between cats
+
+        c1 = Categorical(list('aabca'),categories=list('abc'),ordered=False)
+        c2 = Categorical(list('aabca'),categories=list('cab'),ordered=False)
+        c3 = Categorical(list('aabca'),categories=list('cab'),ordered=True)
+        self.assertTrue(c1.is_dtype_equal(c1))
+        self.assertTrue(c2.is_dtype_equal(c2))
+        self.assertTrue(c3.is_dtype_equal(c3))
+        self.assertFalse(c1.is_dtype_equal(c2))
+        self.assertFalse(c1.is_dtype_equal(c3))
+        self.assertFalse(c1.is_dtype_equal(Index(list('aabca'))))
+        self.assertFalse(c1.is_dtype_equal(c1.astype(object)))
+        self.assertTrue(c1.is_dtype_equal(CategoricalIndex(c1)))
+        self.assertFalse(c1.is_dtype_equal(CategoricalIndex(c1,categories=list('cab'))))
+        self.assertFalse(c1.is_dtype_equal(CategoricalIndex(c1,ordered=True)))
 
     def test_constructor(self):
 
@@ -223,6 +241,18 @@ class TestCategorical(tm.TestCase):
         with tm.assert_produces_warning(None):
             c_old2 = Categorical([0, 1, 2, 0, 1, 2], [1, 2, 3])
             cat = Categorical([1,2], categories=[1,2,3])
+
+        # this is a legitimate constructor
+        with tm.assert_produces_warning(None):
+            c = Categorical(np.array([],dtype='int64'),categories=[3,2,1],ordered=True)
+
+    def test_constructor_with_index(self):
+
+        ci = CategoricalIndex(list('aabbca'),categories=list('cab'))
+        self.assertTrue(ci.values.equals(Categorical(ci)))
+
+        ci = CategoricalIndex(list('aabbca'),categories=list('cab'))
+        self.assertTrue(ci.values.equals(Categorical(ci.astype(object),categories=ci.categories)))
 
     def test_constructor_with_generator(self):
         # This was raising an Error in isnull(single_val).any() because isnull returned a scalar
@@ -2562,6 +2592,8 @@ class TestCategoricalAsBlock(tm.TestCase):
         dfx['grade'].cat.categories
         self.assert_numpy_array_equal(df['grade'].cat.categories, dfx['grade'].cat.categories)
 
+    def test_concat_preserve(self):
+
         # GH 8641
         # series concat not preserving category dtype
         s = Series(list('abc'),dtype='category')
@@ -2578,6 +2610,28 @@ class TestCategoricalAsBlock(tm.TestCase):
         result = pd.concat([s,s])
         expected = Series(list('abcabc'),index=[0,1,2,0,1,2]).astype('category')
         tm.assert_series_equal(result, expected)
+
+        a = Series(np.arange(6,dtype='int64'))
+        b = Series(list('aabbca'))
+
+        df2 = DataFrame({'A' : a, 'B' : b.astype('category',categories=list('cab')) })
+        result = pd.concat([df2,df2])
+        expected = DataFrame({'A' : pd.concat([a,a]), 'B' : pd.concat([b,b]).astype('category',categories=list('cab')) })
+        tm.assert_frame_equal(result, expected)
+
+    def test_categorical_index_preserver(self):
+
+        a = Series(np.arange(6,dtype='int64'))
+        b = Series(list('aabbca'))
+
+        df2 = DataFrame({'A' : a, 'B' : b.astype('category',categories=list('cab')) }).set_index('B')
+        result = pd.concat([df2,df2])
+        expected = DataFrame({'A' : pd.concat([a,a]), 'B' : pd.concat([b,b]).astype('category',categories=list('cab')) }).set_index('B')
+        tm.assert_frame_equal(result, expected)
+
+        # wrong catgories
+        df3 = DataFrame({'A' : a, 'B' : b.astype('category',categories=list('abc')) }).set_index('B')
+        self.assertRaises(TypeError, lambda : pd.concat([df2,df3]))
 
     def test_append(self):
         cat = pd.Categorical(["a","b"], categories=["a","b"])
@@ -2713,6 +2767,14 @@ class TestCategoricalAsBlock(tm.TestCase):
                         lambda x: x.astype('object').astype(pd.Categorical)]:
             self.assertRaises(TypeError, lambda : invalid(s))
 
+
+    def test_astype_categorical(self):
+
+        cat = Categorical(['a', 'b', 'b', 'a', 'a', 'c', 'c', 'c'])
+        tm.assert_categorical_equal(cat,cat.astype('category'))
+        tm.assert_almost_equal(np.array(cat),cat.astype('object'))
+
+        self.assertRaises(ValueError, lambda : cat.astype(float))
 
     def test_to_records(self):
 

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -12,14 +12,10 @@ import os
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from pandas import period_range, date_range
-
-from pandas.core.index import (Index, Float64Index, Int64Index, MultiIndex,
-                               InvalidIndexError, NumericIndex)
-from pandas.tseries.index import DatetimeIndex
-from pandas.tseries.tdi import TimedeltaIndex
-from pandas.tseries.period import PeriodIndex
-from pandas.core.series import Series
+from pandas import (period_range, date_range, Categorical, Series,
+                    Index, Float64Index, Int64Index, MultiIndex,
+                    CategoricalIndex, DatetimeIndex, TimedeltaIndex, PeriodIndex)
+from pandas.core.index import InvalidIndexError, NumericIndex
 from pandas.util.testing import (assert_almost_equal, assertRaisesRegexp,
                                  assert_copy)
 from pandas import compat
@@ -40,6 +36,11 @@ class Base(object):
     """ base class for index sub-class tests """
     _holder = None
     _compat_props = ['shape', 'ndim', 'size', 'itemsize', 'nbytes']
+
+    def setup_indices(self):
+        # setup the test indices in the self.indicies dict
+        for name, ind in self.indices.items():
+            setattr(self, name, ind)
 
     def verify_pickle(self,index):
         unpickled = self.round_trip_pickle(index)
@@ -98,6 +99,7 @@ class Base(object):
     def test_reindex_base(self):
         idx = self.create_index()
         expected = np.arange(idx.size)
+
         actual = idx.get_indexer(idx)
         assert_array_equal(expected, actual)
 
@@ -118,6 +120,123 @@ class Base(object):
         idx.nbytes
         idx.values.nbytes
 
+    def test_wrong_number_names(self):
+        def testit(ind):
+            ind.names = ["apple", "banana", "carrot"]
+
+        for ind in self.indices.values():
+            assertRaisesRegexp(ValueError, "^Length", testit, ind)
+
+    def test_set_name_methods(self):
+        new_name = "This is the new name for this index"
+        for ind in self.indices.values():
+
+            # don't tests a MultiIndex here (as its tested separated)
+            if isinstance(ind, MultiIndex):
+                continue
+
+            original_name = ind.name
+            new_ind = ind.set_names([new_name])
+            self.assertEqual(new_ind.name, new_name)
+            self.assertEqual(ind.name, original_name)
+            res = ind.rename(new_name, inplace=True)
+
+            # should return None
+            self.assertIsNone(res)
+            self.assertEqual(ind.name, new_name)
+            self.assertEqual(ind.names, [new_name])
+            #with assertRaisesRegexp(TypeError, "list-like"):
+            #    # should still fail even if it would be the right length
+            #    ind.set_names("a")
+            with assertRaisesRegexp(ValueError, "Level must be None"):
+                ind.set_names("a", level=0)
+
+            # rename in place just leaves tuples and other containers alone
+            name = ('A', 'B')
+            ind.rename(name, inplace=True)
+            self.assertEqual(ind.name, name)
+            self.assertEqual(ind.names, [name])
+
+    def test_hash_error(self):
+        for ind in self.indices.values():
+            with tm.assertRaisesRegexp(TypeError,
+                                       "unhashable type: %r" %
+                                       type(ind).__name__):
+                hash(ind)
+
+    def test_copy_and_deepcopy(self):
+        from copy import copy, deepcopy
+
+        for ind in self.indices.values():
+
+            # don't tests a MultiIndex here (as its tested separated)
+            if isinstance(ind, MultiIndex):
+                continue
+
+            for func in (copy, deepcopy):
+                idx_copy = func(ind)
+                self.assertIsNot(idx_copy, ind)
+                self.assertTrue(idx_copy.equals(ind))
+
+            new_copy = ind.copy(deep=True, name="banana")
+            self.assertEqual(new_copy.name, "banana")
+
+    def test_duplicates(self):
+        for ind in self.indices.values():
+
+            if not len(ind):
+                continue
+            idx = self._holder([ind[0]]*5)
+            self.assertFalse(idx.is_unique)
+            self.assertTrue(idx.has_duplicates)
+
+    def test_sort(self):
+        for ind in self.indices.values():
+            self.assertRaises(TypeError, ind.sort)
+
+    def test_mutability(self):
+        for ind in self.indices.values():
+            if not len(ind):
+                continue
+            self.assertRaises(TypeError, ind.__setitem__, 0, ind[0])
+
+    def test_view(self):
+        for ind in self.indices.values():
+            i_view = ind.view()
+            self.assertEqual(i_view.name, ind.name)
+
+    def test_compat(self):
+        for ind in self.indices.values():
+            self.assertEqual(ind.tolist(),list(ind))
+
+    def test_argsort(self):
+        for k, ind in self.indices.items():
+
+            # sep teststed
+            if k in ['catIndex']:
+                continue
+
+            result = ind.argsort()
+            expected = np.array(ind).argsort()
+            self.assert_numpy_array_equal(result, expected)
+
+    def test_pickle(self):
+        for ind in self.indices.values():
+            self.verify_pickle(ind)
+            ind.name = 'foo'
+            self.verify_pickle(ind)
+
+    def test_take(self):
+        indexer = [4, 3, 0, 2]
+        for k, ind in self.indices.items():
+
+            # separate
+            if k in ['boolIndex','tuples','empty']:
+                continue
+
+            result = ind.take(indexer)
+            expected = ind[indexer]
+            self.assertTrue(result.equals(expected))
 
 class TestIndex(Base, tm.TestCase):
     _holder = Index
@@ -128,57 +247,20 @@ class TestIndex(Base, tm.TestCase):
             unicodeIndex = tm.makeUnicodeIndex(100),
             strIndex = tm.makeStringIndex(100),
             dateIndex = tm.makeDateIndex(100),
+            periodIndex = tm.makePeriodIndex(100),
+            tdIndex = tm.makeTimedeltaIndex(100),
             intIndex = tm.makeIntIndex(100),
             floatIndex = tm.makeFloatIndex(100),
             boolIndex = Index([True,False]),
+            catIndex = tm.makeCategoricalIndex(100),
             empty = Index([]),
             tuples = MultiIndex.from_tuples(lzip(['foo', 'bar', 'baz'],
                                                  [1, 2, 3]))
         )
-        for name, ind in self.indices.items():
-            setattr(self, name, ind)
+        self.setup_indices()
 
     def create_index(self):
         return Index(list('abcde'))
-
-    def test_wrong_number_names(self):
-        def testit(ind):
-            ind.names = ["apple", "banana", "carrot"]
-
-        for ind in self.indices.values():
-            assertRaisesRegexp(ValueError, "^Length", testit, ind)
-
-    def test_set_name_methods(self):
-        new_name = "This is the new name for this index"
-        indices = (self.dateIndex, self.intIndex, self.unicodeIndex,
-                   self.empty)
-        for ind in indices:
-            original_name = ind.name
-            new_ind = ind.set_names([new_name])
-            self.assertEqual(new_ind.name, new_name)
-            self.assertEqual(ind.name, original_name)
-            res = ind.rename(new_name, inplace=True)
-            # should return None
-            self.assertIsNone(res)
-            self.assertEqual(ind.name, new_name)
-            self.assertEqual(ind.names, [new_name])
-            #with assertRaisesRegexp(TypeError, "list-like"):
-            #    # should still fail even if it would be the right length
-            #    ind.set_names("a")
-            with assertRaisesRegexp(ValueError, "Level must be None"):
-                ind.set_names("a", level=0)
-        # rename in place just leaves tuples and other containers alone
-        name = ('A', 'B')
-        ind = self.intIndex
-        ind.rename(name, inplace=True)
-        self.assertEqual(ind.name, name)
-        self.assertEqual(ind.names, [name])
-
-    def test_hash_error(self):
-        with tm.assertRaisesRegexp(TypeError,
-                                   "unhashable type: %r" %
-                                   type(self.strIndex).__name__):
-            hash(self.strIndex)
 
     def test_new_axis(self):
         new_index = self.dateIndex[None, :]
@@ -186,27 +268,10 @@ class TestIndex(Base, tm.TestCase):
         tm.assert_isinstance(new_index, np.ndarray)
 
     def test_copy_and_deepcopy(self):
-        from copy import copy, deepcopy
+        super(TestIndex, self).test_copy_and_deepcopy()
 
-        for func in (copy, deepcopy):
-            idx_copy = func(self.strIndex)
-            self.assertIsNot(idx_copy, self.strIndex)
-            self.assertTrue(idx_copy.equals(self.strIndex))
-
-        new_copy = self.strIndex.copy(deep=True, name="banana")
-        self.assertEqual(new_copy.name, "banana")
         new_copy2 = self.intIndex.copy(dtype=int)
         self.assertEqual(new_copy2.dtype.kind, 'i')
-
-    def test_duplicates(self):
-        idx = Index([0, 0, 0])
-        self.assertFalse(idx.is_unique)
-
-    def test_sort(self):
-        self.assertRaises(TypeError, self.strIndex.sort)
-
-    def test_mutability(self):
-        self.assertRaises(TypeError, self.strIndex.__setitem__, 0, 'foo')
 
     def test_constructor(self):
         # regular instance creation
@@ -297,18 +362,22 @@ class TestIndex(Base, tm.TestCase):
         result = idx._simple_new(idx, 'obj')
         self.assertTrue(result.equals(idx))
 
-    def test_copy(self):
-        i = Index([], name='Foo')
-        i_copy = i.copy()
-        self.assertEqual(i_copy.name, 'Foo')
+    def test_view_with_args(self):
 
-    def test_view(self):
-        i = Index([], name='Foo')
-        i_view = i.view()
-        self.assertEqual(i_view.name, 'Foo')
+        restricted = ['unicodeIndex','strIndex','catIndex','boolIndex','empty']
 
-        # with arguments
-        self.assertRaises(TypeError, lambda : i.view('i8'))
+        for i in restricted:
+            ind = self.indices[i]
+
+            # with arguments
+            self.assertRaises(TypeError, lambda : ind.view('i8'))
+
+        # these are ok
+        for i in list(set(self.indices.keys())-set(restricted)):
+            ind = self.indices[i]
+
+            # with arguments
+            ind.view('i8')
 
     def test_legacy_pickle_identity(self):
 
@@ -329,9 +398,6 @@ class TestIndex(Base, tm.TestCase):
         self.intIndex.name = 'foobar'
         casted = self.intIndex.astype('i8')
         self.assertEqual(casted.name, 'foobar')
-
-    def test_compat(self):
-        self.strIndex.tolist()
 
     def test_equals(self):
         # same
@@ -458,11 +524,6 @@ class TestIndex(Base, tm.TestCase):
         #self.assertEqual(first_value, x['2013-01-01 00:00:00.000000050+0000'])
 
         self.assertEqual(first_value, x[Timestamp(np.datetime64('2013-01-01 00:00:00.000000050+0000', 'ns'))])
-
-    def test_argsort(self):
-        result = self.strIndex.argsort()
-        expected = np.array(self.strIndex).argsort()
-        self.assert_numpy_array_equal(result, expected)
 
     def test_comparators(self):
         index = self.dateIndex
@@ -760,22 +821,17 @@ class TestIndex(Base, tm.TestCase):
         with tm.assertRaises(TypeError):
             Index(idx1,dtype='object') - 1
 
-    def test_pickle(self):
-
-        self.verify_pickle(self.strIndex)
-        self.strIndex.name = 'foo'
-        self.verify_pickle(self.strIndex)
-        self.verify_pickle(self.dateIndex)
-
     def test_is_numeric(self):
         self.assertFalse(self.dateIndex.is_numeric())
         self.assertFalse(self.strIndex.is_numeric())
         self.assertTrue(self.intIndex.is_numeric())
         self.assertTrue(self.floatIndex.is_numeric())
+        self.assertFalse(self.catIndex.is_numeric())
 
     def test_is_object(self):
         self.assertTrue(self.strIndex.is_object())
         self.assertTrue(self.boolIndex.is_object())
+        self.assertFalse(self.catIndex.is_object())
         self.assertFalse(self.intIndex.is_object())
         self.assertFalse(self.dateIndex.is_object())
         self.assertFalse(self.floatIndex.is_object())
@@ -839,12 +895,6 @@ class TestIndex(Base, tm.TestCase):
         idx.format()
         self.assertIsNone(idx[3])
 
-    def test_take(self):
-        indexer = [4, 3, 0, 2]
-        result = self.dateIndex.take(indexer)
-        expected = self.dateIndex[indexer]
-        self.assertTrue(result.equals(expected))
-
     def test_logical_compat(self):
         idx = self.create_index()
         self.assertEqual(idx.all(), idx.values.all())
@@ -857,6 +907,7 @@ class TestIndex(Base, tm.TestCase):
         method(self.strIndex)
         method(self.intIndex)
         method(self.tuples)
+        method(self.catIndex)
 
     def test_get_indexer(self):
         idx1 = Index([1, 2, 3, 4, 5])
@@ -1338,6 +1389,352 @@ class TestIndex(Base, tm.TestCase):
             index_b == index_a,
         )
 
+class TestCategoricalIndex(Base, tm.TestCase):
+    _holder = CategoricalIndex
+
+    def setUp(self):
+        self.indices = dict(catIndex = tm.makeCategoricalIndex(100))
+        self.setup_indices()
+
+    def create_index(self, categories=None, ordered=False):
+        if categories is None:
+            categories = list('cab')
+        return CategoricalIndex(list('aabbca'), categories=categories, ordered=ordered)
+
+    def test_construction(self):
+
+        ci = self.create_index(categories=list('abcd'))
+        categories = ci.categories
+
+        result = Index(ci)
+        tm.assert_index_equal(result,ci,exact=True)
+        self.assertFalse(result.ordered)
+
+        result = Index(ci.values)
+        tm.assert_index_equal(result,ci,exact=True)
+        self.assertFalse(result.ordered)
+
+        # empty
+        result = CategoricalIndex(categories=categories)
+        self.assertTrue(result.categories.equals(Index(categories)))
+        self.assert_numpy_array_equal(result.codes,np.array([],dtype='int8'))
+        self.assertFalse(result.ordered)
+
+        # passing categories
+        result = CategoricalIndex(list('aabbca'),categories=categories)
+        self.assertTrue(result.categories.equals(Index(categories)))
+        self.assert_numpy_array_equal(result.codes,np.array([0,0,1,1,2,0],dtype='int8'))
+
+        c = pd.Categorical(list('aabbca'))
+        result = CategoricalIndex(c)
+        self.assertTrue(result.categories.equals(Index(list('abc'))))
+        self.assert_numpy_array_equal(result.codes,np.array([0,0,1,1,2,0],dtype='int8'))
+        self.assertFalse(result.ordered)
+
+        result = CategoricalIndex(c,categories=categories)
+        self.assertTrue(result.categories.equals(Index(categories)))
+        self.assert_numpy_array_equal(result.codes,np.array([0,0,1,1,2,0],dtype='int8'))
+        self.assertFalse(result.ordered)
+
+        ci = CategoricalIndex(c,categories=list('abcd'))
+        result = CategoricalIndex(ci)
+        self.assertTrue(result.categories.equals(Index(categories)))
+        self.assert_numpy_array_equal(result.codes,np.array([0,0,1,1,2,0],dtype='int8'))
+        self.assertFalse(result.ordered)
+
+        result = CategoricalIndex(ci, categories=list('ab'))
+        self.assertTrue(result.categories.equals(Index(list('ab'))))
+        self.assert_numpy_array_equal(result.codes,np.array([0,0,1,1,-1,0],dtype='int8'))
+        self.assertFalse(result.ordered)
+
+        result = CategoricalIndex(ci, categories=list('ab'), ordered=True)
+        self.assertTrue(result.categories.equals(Index(list('ab'))))
+        self.assert_numpy_array_equal(result.codes,np.array([0,0,1,1,-1,0],dtype='int8'))
+        self.assertTrue(result.ordered)
+
+        # turn me to an Index
+        result = Index(np.array(ci))
+        self.assertIsInstance(result, Index)
+        self.assertNotIsInstance(result, CategoricalIndex)
+
+    def test_construction_with_dtype(self):
+
+        # specify dtype
+        ci = self.create_index(categories=list('abc'))
+
+        result = Index(np.array(ci), dtype='category')
+        tm.assert_index_equal(result,ci,exact=True)
+
+        result = Index(np.array(ci).tolist(), dtype='category')
+        tm.assert_index_equal(result,ci,exact=True)
+
+        # these are generally only equal when the categories are reordered
+        ci = self.create_index()
+
+        result = Index(np.array(ci), dtype='category').reorder_categories(ci.categories)
+        tm.assert_index_equal(result,ci,exact=True)
+
+        # make sure indexes are handled
+        expected = CategoricalIndex([0,1,2], categories=[0,1,2], ordered=True)
+        idx = Index(range(3))
+        result = CategoricalIndex(idx, categories=idx, ordered=True)
+        tm.assert_index_equal(result, expected, exact=True)
+
+    def test_method_delegation(self):
+
+        ci = CategoricalIndex(list('aabbca'), categories=list('cabdef'))
+        result = ci.set_categories(list('cab'))
+        tm.assert_index_equal(result, CategoricalIndex(list('aabbca'), categories=list('cab')))
+
+        ci = CategoricalIndex(list('aabbca'), categories=list('cab'))
+        result = ci.rename_categories(list('efg'))
+        tm.assert_index_equal(result, CategoricalIndex(list('ffggef'), categories=list('efg')))
+
+        ci = CategoricalIndex(list('aabbca'), categories=list('cab'))
+        result = ci.add_categories(['d'])
+        tm.assert_index_equal(result, CategoricalIndex(list('aabbca'), categories=list('cabd')))
+
+        ci = CategoricalIndex(list('aabbca'), categories=list('cab'))
+        result = ci.remove_categories(['c'])
+        tm.assert_index_equal(result, CategoricalIndex(list('aabb') + [np.nan] + ['a'], categories=list('ab')))
+
+        ci = CategoricalIndex(list('aabbca'), categories=list('cabdef'))
+        result = ci.as_unordered()
+        tm.assert_index_equal(result, ci)
+
+        ci = CategoricalIndex(list('aabbca'), categories=list('cabdef'))
+        result = ci.as_ordered()
+        tm.assert_index_equal(result, CategoricalIndex(list('aabbca'), categories=list('cabdef'), ordered=True))
+
+        # invalid
+        self.assertRaises(ValueError, lambda : ci.set_categories(list('cab'), inplace=True))
+
+    def test_contains(self):
+
+        ci = self.create_index(categories=list('cabdef'))
+
+        self.assertTrue('a' in ci)
+        self.assertTrue('z' not in ci)
+        self.assertTrue('e' not in ci)
+        self.assertTrue(np.nan not in ci)
+
+        # assert codes NOT in index
+        self.assertFalse(0 in ci)
+        self.assertFalse(1 in ci)
+
+        ci = CategoricalIndex(list('aabbca'), categories=list('cabdef') + [np.nan])
+        self.assertFalse(np.nan in ci)
+
+        ci = CategoricalIndex(list('aabbca') + [np.nan], categories=list('cabdef') + [np.nan])
+        self.assertTrue(np.nan in ci)
+
+    def test_min_max(self):
+
+        ci = self.create_index(ordered=False)
+        self.assertRaises(TypeError, lambda : ci.min())
+        self.assertRaises(TypeError, lambda : ci.max())
+
+        ci = self.create_index(ordered=True)
+
+        self.assertEqual(ci.min(),'c')
+        self.assertEqual(ci.max(),'b')
+
+    def test_append(self):
+
+        ci = self.create_index()
+        categories = ci.categories
+
+        # append cats with the same categories
+        result = ci[:3].append(ci[3:])
+        tm.assert_index_equal(result,ci,exact=True)
+
+        foos = [ci[:1], ci[1:3], ci[3:]]
+        result = foos[0].append(foos[1:])
+        tm.assert_index_equal(result,ci,exact=True)
+
+        # empty
+        result = ci.append([])
+        tm.assert_index_equal(result,ci,exact=True)
+
+        # appending with different categories or reoreded is not ok
+        self.assertRaises(TypeError, lambda : ci.append(ci.values.set_categories(list('abcd'))))
+        self.assertRaises(TypeError, lambda : ci.append(ci.values.reorder_categories(list('abc'))))
+
+        # with objects
+        result = ci.append(['c','a'])
+        expected = CategoricalIndex(list('aabbcaca'), categories=categories)
+        tm.assert_index_equal(result,expected,exact=True)
+
+        # invalid objects
+        self.assertRaises(TypeError, lambda : ci.append(['a','d']))
+
+    def test_insert(self):
+
+        ci = self.create_index()
+        categories = ci.categories
+
+        #test 0th element
+        result = ci.insert(0, 'a')
+        expected = CategoricalIndex(list('aaabbca'),categories=categories)
+        tm.assert_index_equal(result,expected,exact=True)
+
+        #test Nth element that follows Python list behavior
+        result = ci.insert(-1, 'a')
+        expected = CategoricalIndex(list('aabbcaa'),categories=categories)
+        tm.assert_index_equal(result,expected,exact=True)
+
+        #test empty
+        result = CategoricalIndex(categories=categories).insert(0, 'a')
+        expected = CategoricalIndex(['a'],categories=categories)
+        tm.assert_index_equal(result,expected,exact=True)
+
+        # invalid
+        self.assertRaises(TypeError, lambda : ci.insert(0,'d'))
+
+    def test_delete(self):
+
+        ci = self.create_index()
+        categories = ci.categories
+
+        result = ci.delete(0)
+        expected = CategoricalIndex(list('abbca'),categories=categories)
+        tm.assert_index_equal(result,expected,exact=True)
+
+        result = ci.delete(-1)
+        expected = CategoricalIndex(list('aabbc'),categories=categories)
+        tm.assert_index_equal(result,expected,exact=True)
+
+        with tm.assertRaises((IndexError, ValueError)):
+            # either depeidnig on numpy version
+            result = ci.delete(10)
+
+    def test_astype(self):
+
+        ci = self.create_index()
+        result = ci.astype('category')
+        tm.assert_index_equal(result,ci,exact=True)
+
+        result = ci.astype(object)
+        self.assertTrue(result.equals(Index(np.array(ci))))
+
+        # this IS equal, but not the same class
+        self.assertTrue(result.equals(ci))
+        self.assertIsInstance(result, Index)
+        self.assertNotIsInstance(result, CategoricalIndex)
+
+    def test_reindex_base(self):
+
+        # determined by cat ordering
+        idx = self.create_index()
+        expected = np.array([4,0,1,5,2,3])
+
+        actual = idx.get_indexer(idx)
+        assert_array_equal(expected, actual)
+
+        with tm.assertRaisesRegexp(ValueError, 'Invalid fill method'):
+            idx.get_indexer(idx, method='invalid')
+
+    def test_reindexing(self):
+
+        ci = self.create_index()
+        oidx = Index(np.array(ci))
+
+        for n in [1,2,5,len(ci)]:
+            finder = oidx[np.random.randint(0,len(ci),size=n)]
+            expected = oidx.get_indexer_non_unique(finder)[0]
+
+            actual = ci.get_indexer(finder)
+            assert_array_equal(expected, actual)
+
+    def test_duplicates(self):
+
+        idx = CategoricalIndex([0, 0, 0])
+        self.assertFalse(idx.is_unique)
+        self.assertTrue(idx.has_duplicates)
+
+    def test_get_indexer(self):
+
+        idx1 = CategoricalIndex(list('aabcde'),categories=list('edabc'))
+        idx2 = CategoricalIndex(list('abf'))
+
+        for indexer in [idx2, list('abf'), Index(list('abf'))]:
+            r1 = idx1.get_indexer(idx2)
+            assert_almost_equal(r1, [0, 1, 2, -1])
+
+        self.assertRaises(NotImplementedError, lambda : idx2.get_indexer(idx1, method='pad'))
+        self.assertRaises(NotImplementedError, lambda : idx2.get_indexer(idx1, method='backfill'))
+        self.assertRaises(NotImplementedError, lambda : idx2.get_indexer(idx1, method='nearest'))
+
+    def test_repr(self):
+
+        ci = CategoricalIndex(['a', 'b'], categories=['a', 'b'], ordered=True)
+        str(ci)
+        tm.assert_index_equal(eval(repr(ci)),ci,exact=True)
+
+        # formatting
+        if compat.PY3:
+            str(ci)
+        else:
+            compat.text_type(ci)
+
+        # long format
+        ci = CategoricalIndex(np.random.randint(0,5,size=100))
+        result = str(ci)
+        tm.assert_index_equal(eval(repr(ci)),ci,exact=True)
+
+    def test_isin(self):
+
+        ci = CategoricalIndex(list('aabca') + [np.nan],categories=['c','a','b',np.nan])
+        self.assert_numpy_array_equal(ci.isin(['c']),np.array([False,False,False,True,False,False]))
+        self.assert_numpy_array_equal(ci.isin(['c','a','b']),np.array([True]*5 + [False]))
+        self.assert_numpy_array_equal(ci.isin(['c','a','b',np.nan]),np.array([True]*6))
+
+        # mismatched categorical -> coerced to ndarray so doesn't matter
+        self.assert_numpy_array_equal(ci.isin(ci.set_categories(list('abcdefghi'))),np.array([True]*6))
+        self.assert_numpy_array_equal(ci.isin(ci.set_categories(list('defghi'))),np.array([False]*5 + [True]))
+
+    def test_identical(self):
+
+        ci1 = CategoricalIndex(['a', 'b'], categories=['a', 'b'], ordered=True)
+        ci2 = CategoricalIndex(['a', 'b'], categories=['a', 'b', 'c'], ordered=True)
+        self.assertTrue(ci1.identical(ci1))
+        self.assertTrue(ci1.identical(ci1.copy()))
+        self.assertFalse(ci1.identical(ci2))
+
+    def test_equals(self):
+
+        ci1 = CategoricalIndex(['a', 'b'], categories=['a', 'b'], ordered=True)
+        ci2 = CategoricalIndex(['a', 'b'], categories=['a', 'b', 'c'], ordered=True)
+
+        self.assertTrue(ci1.equals(ci1))
+        self.assertFalse(ci1.equals(ci2))
+        self.assertTrue(ci1.equals(ci1.astype(object)))
+        self.assertTrue(ci1.astype(object).equals(ci1))
+
+        self.assertTrue((ci1 == ci1).all())
+        self.assertFalse((ci1 != ci1).all())
+        self.assertFalse((ci1 > ci1).all())
+        self.assertFalse((ci1 < ci1).all())
+        self.assertTrue((ci1 <= ci1).all())
+        self.assertTrue((ci1 >= ci1).all())
+
+        self.assertFalse((ci1 == 1).all())
+        self.assertTrue((ci1 == Index(['a','b'])).all())
+        self.assertTrue((ci1 == ci1.values).all())
+
+        # invalid comparisons
+        self.assertRaises(TypeError, lambda : ci1 == Index(['a','b','c']))
+        self.assertRaises(TypeError, lambda : ci1 == ci2)
+        self.assertRaises(TypeError, lambda : ci1 == Categorical(ci1.values, ordered=False))
+        self.assertRaises(TypeError, lambda : ci1 == Categorical(ci1.values, categories=list('abc')))
+
+        # tests
+        # make sure that we are testing for category inclusion properly
+        self.assertTrue(CategoricalIndex(list('aabca'),categories=['c','a','b']).equals(list('aabca')))
+        self.assertTrue(CategoricalIndex(list('aabca'),categories=['c','a','b',np.nan]).equals(list('aabca')))
+
+        self.assertFalse(CategoricalIndex(list('aabca') + [np.nan],categories=['c','a','b',np.nan]).equals(list('aabca')))
+        self.assertTrue(CategoricalIndex(list('aabca') + [np.nan],categories=['c','a','b',np.nan]).equals(list('aabca') + [np.nan]))
 
 class Numeric(Base):
 
@@ -1417,17 +1814,12 @@ class TestFloat64Index(Numeric, tm.TestCase):
     _multiprocess_can_split_ = True
 
     def setUp(self):
-        self.mixed = Float64Index([1.5, 2, 3, 4, 5])
-        self.float = Float64Index(np.arange(5) * 2.5)
+        self.indices = dict(mixed = Float64Index([1.5, 2, 3, 4, 5]),
+                            float = Float64Index(np.arange(5) * 2.5))
+        self.setup_indices()
 
     def create_index(self):
         return Float64Index(np.arange(5,dtype='float64'))
-
-    def test_hash_error(self):
-        with tm.assertRaisesRegexp(TypeError,
-                                   "unhashable type: %r" %
-                                   type(self.float).__name__):
-            hash(self.float)
 
     def test_repr_roundtrip(self):
         for ind in (self.mixed, self.float):
@@ -1594,7 +1986,8 @@ class TestInt64Index(Numeric, tm.TestCase):
     _multiprocess_can_split_ = True
 
     def setUp(self):
-        self.index = Int64Index(np.arange(0, 20, 2))
+        self.indices = dict(index = Int64Index(np.arange(0, 20, 2)))
+        self.setup_indices()
 
     def create_index(self):
         return Int64Index(np.arange(5,dtype='int64'))
@@ -1641,18 +2034,14 @@ class TestInt64Index(Numeric, tm.TestCase):
         with tm.assertRaisesRegexp(TypeError, 'casting'):
             Int64Index(arr_with_floats)
 
-    def test_hash_error(self):
-        with tm.assertRaisesRegexp(TypeError,
-                                   "unhashable type: %r" %
-                                   type(self.index).__name__):
-            hash(self.index)
-
     def test_copy(self):
         i = Int64Index([], name='Foo')
         i_copy = i.copy()
         self.assertEqual(i_copy.name, 'Foo')
 
     def test_view(self):
+        super(TestInt64Index, self).test_view()
+
         i = Int64Index([], name='Foo')
         i_view = i.view()
         self.assertEqual(i_view.name, 'Foo')
@@ -2053,6 +2442,7 @@ class TestInt64Index(Numeric, tm.TestCase):
 class DatetimeLike(Base):
 
     def test_view(self):
+        super(DatetimeLike, self).test_view()
 
         i = self.create_index()
 
@@ -2067,6 +2457,10 @@ class DatetimeLike(Base):
 class TestDatetimeIndex(DatetimeLike, tm.TestCase):
     _holder = DatetimeIndex
     _multiprocess_can_split_ = True
+
+    def setUp(self):
+        self.indices = dict(index = tm.makeDateIndex(10))
+        self.setup_indices()
 
     def create_index(self):
         return date_range('20130101',periods=5)
@@ -2186,6 +2580,10 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
     _holder = PeriodIndex
     _multiprocess_can_split_ = True
 
+    def setUp(self):
+        self.indices = dict(index = tm.makePeriodIndex(10))
+        self.setup_indices()
+
     def create_index(self):
         return period_range('20130101',periods=5,freq='D')
 
@@ -2219,6 +2617,10 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
 class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
     _holder = TimedeltaIndex
     _multiprocess_can_split_ = True
+
+    def setUp(self):
+        self.indices = dict(index = tm.makeTimedeltaIndex(10))
+        self.setup_indices()
 
     def create_index(self):
         return pd.to_timedelta(range(5),unit='d') + pd.offsets.Hour(1)
@@ -2294,9 +2696,10 @@ class TestMultiIndex(Base, tm.TestCase):
         major_labels = np.array([0, 0, 1, 2, 3, 3])
         minor_labels = np.array([0, 1, 0, 1, 0, 1])
         self.index_names = ['first', 'second']
-        self.index = MultiIndex(levels=[major_axis, minor_axis],
-                                labels=[major_labels, minor_labels],
-                                names=self.index_names, verify_integrity=False)
+        self.indices = dict(index = MultiIndex(levels=[major_axis, minor_axis],
+                                               labels=[major_labels, minor_labels],
+                                               names=self.index_names, verify_integrity=False))
+        self.setup_indices()
 
     def create_index(self):
         return self.index
@@ -2332,13 +2735,7 @@ class TestMultiIndex(Base, tm.TestCase):
         self.assertTrue((i.labels[0]>=0).all())
         self.assertTrue((i.labels[1]>=0).all())
 
-    def test_hash_error(self):
-        with tm.assertRaisesRegexp(TypeError,
-                                   "unhashable type: %r" %
-                                   type(self.index).__name__):
-            hash(self.index)
-
-    def test_set_names_and_rename(self):
+    def test_set_name_methods(self):
         # so long as these are synonyms, we don't need to test set_names
         self.assertEqual(self.index.rename, self.index.set_names)
         new_names = [name + "SUFFIX" for name in self.index_names]
@@ -3838,7 +4235,7 @@ class TestMultiIndex(Base, tm.TestCase):
         assertRaisesRegexp(TypeError, "Fill method not supported",
                            idx.reindex, idx, method='bfill', level='first')
 
-    def test_has_duplicates(self):
+    def test_duplicates(self):
         self.assertFalse(self.index.has_duplicates)
         self.assertTrue(self.index.append(self.index).has_duplicates)
 

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -2366,6 +2366,7 @@ class TestIndexing(tm.TestCase):
 
         rows = ['C','B','E']
         expected = DataFrame({'test' : [11,9,np.nan], 'test1': [7.,6,np.nan], 'other': ['d','c',np.nan]},index=rows)
+
         result = df.ix[rows]
         assert_frame_equal(result, expected)
 
@@ -4421,6 +4422,212 @@ class TestIndexing(tm.TestCase):
         expected.loc[5] = [9, 99]
         tm.assert_frame_equal(df, expected)
 
+
+
+class TestCategoricalIndex(tm.TestCase):
+
+    def setUp(self):
+
+        self.df = DataFrame({'A' : np.arange(6,dtype='int64'),
+                             'B' : Series(list('aabbca')).astype('category',categories=list('cab')) }).set_index('B')
+        self.df2 = DataFrame({'A' : np.arange(6,dtype='int64'),
+                              'B' : Series(list('aabbca')).astype('category',categories=list('cabe')) }).set_index('B')
+        self.df3 = DataFrame({'A' : np.arange(6,dtype='int64'),
+                              'B' : Series([1,1,2,1,3,2]).astype('category',categories=[3,2,1],ordered=True) }).set_index('B')
+        self.df4 = DataFrame({'A' : np.arange(6,dtype='int64'),
+                              'B' : Series([1,1,2,1,3,2]).astype('category',categories=[3,2,1],ordered=False) }).set_index('B')
+
+
+    def test_loc_scalar(self):
+
+        result = self.df.loc['a']
+        expected = DataFrame({'A' : [0,1,5],
+                              'B' : Series(list('aaa')).astype('category',categories=list('cab')) }).set_index('B')
+        assert_frame_equal(result, expected)
+
+
+        df = self.df.copy()
+        df.loc['a'] = 20
+        expected = DataFrame({'A' : [20,20,2,3,4,20],
+                              'B' : Series(list('aabbca')).astype('category',categories=list('cab')) }).set_index('B')
+        assert_frame_equal(df, expected)
+
+        # value not in the categories
+        self.assertRaises(KeyError, lambda : df.loc['d'])
+
+        def f():
+            df.loc['d'] = 10
+        self.assertRaises(TypeError, f)
+
+        def f():
+            df.loc['d','A'] = 10
+        self.assertRaises(TypeError, f)
+
+        def f():
+            df.loc['d','C'] = 10
+        self.assertRaises(TypeError, f)
+
+    def test_loc_listlike(self):
+
+        # list of labels
+        result = self.df.loc[['c','a']]
+        expected = self.df.iloc[[4,0,1,5]]
+        assert_frame_equal(result, expected)
+
+        result = self.df2.loc[['a','b','e']]
+        expected = DataFrame({'A' : [0,1,5,2,3,np.nan],
+                              'B' : Series(list('aaabbe')).astype('category',categories=list('cabe')) }).set_index('B')
+        assert_frame_equal(result, expected)
+
+        # element in the categories but not in the values
+        self.assertRaises(KeyError, lambda : self.df2.loc['e'])
+
+        # assign is ok
+        df = self.df2.copy()
+        df.loc['e'] = 20
+        result = df.loc[['a','b','e']]
+        expected = DataFrame({'A' : [0,1,5,2,3,20],
+                              'B' : Series(list('aaabbe')).astype('category',categories=list('cabe')) }).set_index('B')
+        assert_frame_equal(result, expected)
+
+        df = self.df2.copy()
+        result = df.loc[['a','b','e']]
+        expected = DataFrame({'A' : [0,1,5,2,3,np.nan],
+                              'B' : Series(list('aaabbe')).astype('category',categories=list('cabe')) }).set_index('B')
+        assert_frame_equal(result, expected)
+
+
+        # not all labels in the categories
+        self.assertRaises(KeyError, lambda : self.df2.loc[['a','d']])
+
+    def test_reindexing(self):
+
+        # reindexing
+        # convert to a regular index
+        result = self.df2.reindex(['a','b','e'])
+        expected = DataFrame({'A' : [0,1,5,2,3,np.nan],
+                              'B' : Series(list('aaabbe')) }).set_index('B')
+        assert_frame_equal(result, expected)
+
+        result = self.df2.reindex(['a','b'])
+        expected = DataFrame({'A' : [0,1,5,2,3],
+                              'B' : Series(list('aaabb')) }).set_index('B')
+        assert_frame_equal(result, expected)
+
+        result = self.df2.reindex(['e'])
+        expected = DataFrame({'A' : [np.nan],
+                              'B' : Series(['e']) }).set_index('B')
+        assert_frame_equal(result, expected)
+
+        result = self.df2.reindex(['d'])
+        expected = DataFrame({'A' : [np.nan],
+                              'B' : Series(['d']) }).set_index('B')
+        assert_frame_equal(result, expected)
+
+        # since we are actually reindexing with a Categorical
+        # then return a Categorical
+        cats = list('cabe')
+
+        result = self.df2.reindex(pd.Categorical(['a','d'],categories=cats))
+        expected = DataFrame({'A' : [0,1,5,np.nan],
+                              'B' : Series(list('aaad')).astype('category',categories=cats) }).set_index('B')
+        assert_frame_equal(result, expected)
+
+        result = self.df2.reindex(pd.Categorical(['a'],categories=cats))
+        expected = DataFrame({'A' : [0,1,5],
+                              'B' : Series(list('aaa')).astype('category',categories=cats) }).set_index('B')
+        assert_frame_equal(result, expected)
+
+        result = self.df2.reindex(['a','b','e'])
+        expected = DataFrame({'A' : [0,1,5,2,3,np.nan],
+                              'B' : Series(list('aaabbe')) }).set_index('B')
+        assert_frame_equal(result, expected)
+
+        result = self.df2.reindex(['a','b'])
+        expected = DataFrame({'A' : [0,1,5,2,3],
+                              'B' : Series(list('aaabb')) }).set_index('B')
+        assert_frame_equal(result, expected)
+
+        result = self.df2.reindex(['e'])
+        expected = DataFrame({'A' : [np.nan],
+                              'B' : Series(['e']) }).set_index('B')
+        assert_frame_equal(result, expected)
+
+        # give back the type of categorical that we received
+        result = self.df2.reindex(pd.Categorical(['a','d'],categories=cats,ordered=True))
+        expected = DataFrame({'A' : [0,1,5,np.nan],
+                              'B' : Series(list('aaad')).astype('category',categories=cats,ordered=True) }).set_index('B')
+        assert_frame_equal(result, expected)
+
+        result = self.df2.reindex(pd.Categorical(['a','d'],categories=['a','d']))
+        expected = DataFrame({'A' : [0,1,5,np.nan],
+                              'B' : Series(list('aaad')).astype('category',categories=['a','d']) }).set_index('B')
+        assert_frame_equal(result, expected)
+
+        # passed duplicate indexers are not allowed
+        self.assertRaises(ValueError, lambda : self.df2.reindex(['a','a']))
+
+        # args NotImplemented ATM
+        self.assertRaises(NotImplementedError, lambda : self.df2.reindex(['a'],method='ffill'))
+        self.assertRaises(NotImplementedError, lambda : self.df2.reindex(['a'],level=1))
+        self.assertRaises(NotImplementedError, lambda : self.df2.reindex(['a'],limit=2))
+
+    def test_loc_slice(self):
+
+        # slicing
+        # not implemented ATM
+        # GH9748
+
+        self.assertRaises(TypeError, lambda : self.df.loc[1:5])
+
+        #result = df.loc[1:5]
+        #expected = df.iloc[[1,2,3,4]]
+        #assert_frame_equal(result, expected)
+
+    def test_boolean_selection(self):
+
+        df3 = self.df3
+        df4 = self.df4
+
+        result = df3[df3.index == 'a']
+        expected = df3.iloc[[]]
+        assert_frame_equal(result,expected)
+
+        result = df4[df4.index == 'a']
+        expected = df4.iloc[[]]
+        assert_frame_equal(result,expected)
+
+        result = df3[df3.index == 1]
+        expected = df3.iloc[[0,1,3]]
+        assert_frame_equal(result,expected)
+
+        result = df4[df4.index == 1]
+        expected = df4.iloc[[0,1,3]]
+        assert_frame_equal(result,expected)
+
+        # since we have an ordered categorical
+
+        # CategoricalIndex([1, 1, 2, 1, 3, 2],
+        #         categories=[3, 2, 1],
+        #         ordered=True,
+        #         name=u'B')
+        result = df3[df3.index < 2]
+        expected = df3.iloc[[4]]
+        assert_frame_equal(result,expected)
+
+        result = df3[df3.index > 1]
+        expected = df3.iloc[[]]
+        assert_frame_equal(result,expected)
+
+        # unordered
+        # cannot be compared
+
+        # CategoricalIndex([1, 1, 2, 1, 3, 2],
+        #         categories=[3, 2, 1],
+        #         ordered=False,
+        #         name=u'B')
+        self.assertRaises(TypeError, lambda : df4[df4.index < 2])
+        self.assertRaises(TypeError, lambda : df4[df4.index > 1])
 
 class TestSeriesNoneCoercion(tm.TestCase):
     EXPECTED_RESULTS = [

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -25,11 +25,6 @@ from numpy.testing import assert_array_equal
 
 import pandas as pd
 from pandas.core.common import is_sequence, array_equivalent, is_list_like
-import pandas.core.index as index
-import pandas.core.series as series
-import pandas.core.frame as frame
-import pandas.core.panel as panel
-import pandas.core.panel4d as panel4d
 import pandas.compat as compat
 from pandas.compat import(
     filter, map, zip, range, unichr, lrange, lmap, lzip, u, callable, Counter,
@@ -38,23 +33,11 @@ from pandas.compat import(
 
 from pandas.computation import expressions as expr
 
-from pandas import bdate_range
-from pandas.tseries.index import DatetimeIndex
-from pandas.tseries.tdi import TimedeltaIndex
-from pandas.tseries.period import PeriodIndex
+from pandas import (bdate_range, CategoricalIndex, DatetimeIndex, TimedeltaIndex, PeriodIndex,
+                    Index, MultiIndex, Series, DataFrame, Panel, Panel4D)
 from pandas.util.decorators import deprecate
-
 from pandas import _testing
-
-
 from pandas.io.common import urlopen
-
-Index = index.Index
-MultiIndex = index.MultiIndex
-Series = series.Series
-DataFrame = frame.DataFrame
-Panel = panel.Panel
-Panel4D = panel4d.Panel4D
 
 N = 30
 K = 4
@@ -550,16 +533,14 @@ def assert_equal(a, b, msg=""):
     assert a == b, "%s: %r != %r" % (msg.format(a,b), a, b)
 
 
-def assert_index_equal(left, right):
+def assert_index_equal(left, right, exact=False):
     assert_isinstance(left, Index, '[index] ')
     assert_isinstance(right, Index, '[index] ')
-    if not left.equals(right):
+    if not left.equals(right) or (exact and type(left) != type(right)):
         raise AssertionError("[index] left [{0} {1}], right [{2} {3}]".format(left.dtype,
                                                                               left,
                                                                               right,
                                                                               right.dtype))
-
-
 def assert_attr_equal(attr, left, right):
     """checks attributes are equal. Both objects must have attribute."""
     left_attr = getattr(left, attr)
@@ -627,6 +608,7 @@ def assertNotIsInstance(obj, cls, msg=''):
 
 
 def assert_categorical_equal(res, exp):
+
     if not array_equivalent(res.categories, exp.categories):
         raise AssertionError(
             'categories not equivalent: {0} vs {1}.'.format(res.categories,
@@ -826,6 +808,11 @@ def makeStringIndex(k=10):
 
 def makeUnicodeIndex(k=10):
     return Index(randu_array(nchars=10, size=k))
+
+def makeCategoricalIndex(k=10, n=3):
+    """ make a length k index or n categories """
+    x = rands_array(nchars=4, size=n)
+    return CategoricalIndex(np.random.choice(x,k))
 
 def makeBoolIndex(k=10):
     if k == 1:


### PR DESCRIPTION
closes #7629
xref #8613 
xref #8074 
- [x] docs / whatsnew
- [x] ~~auto-create a `CategoricalIndex` when grouping by a `Categorical` (this doesn't ATM)~~
- [x] adding a value not in the Index, e.g. `df2.loc['d'] = 5` should do what? (currently will coerce to an `Index`)
- [x] `pd.concat([df2,df])` should STILL have a `CategoricalIndex` (yep)?
- [x] implement `min/max`
- [x] fix groupby on cat column
- [x] add `Categorical` wrapper methods
- [x] make repr evalable / fix
- [x] contains should be on values not categories

A `CategoricalIndex` is essentially a drop-in replacement for `Index`, that works nicely for non-unique values. It uses a `Categorical` to represent itself. The behavior is very similar to using a duplicated Index (for say indexing).

Groupby works naturally (and returns another `CategoricalIndex`). The only real departure is that `.sort_index()` works like you would expected (which is a good thing:). Clearly this will provide idempotency for `set/reset` index w.r.t. Categoricals, and thus memory savings by its representation.

This doesn't change the API at all. IOW, this is not turned on by default, you have to either use `set/reset`, assign an index, or pass a `Categorical` to `Index`.

```
In [1]: df = DataFrame({'A' : np.arange(6,dtype='int64'),
   ...:                         'B' : Series(list('aabbca')).astype('category',categories=list('cab')) })

In [2]: df
Out[2]: 
   A  B
0  0  a
1  1  a
2  2  b
3  3  b
4  4  c
5  5  a

In [3]: df.dtypes
Out[3]: 
A       int64
B    category
dtype: object

In [5]: df.B.cat.categories
Out[5]: Index([u'c', u'a', u'b'], dtype='object')

In [6]: df2 = df.set_index('B')
In [7]: df2
Out[7]: 
   A
B   
a  0
a  1
b  2
b  3
c  4
a  5

In [8]: df2.index
Out[8]: CategoricalIndex([u'a', u'a', u'b', u'b', u'c', u'a'], dtype='category')

In [9]: df2.index.categories
Out[9]: Index([u'c', u'a', u'b'], dtype='object')

In [10]: df2.index.codes     
Out[10]: array([1, 1, 2, 2, 0, 1], dtype=int8)

In [11]: df2.loc['a']
Out[11]: 
   A
B   
a  0
a  1
a  5

In [12]: df2.loc['a'].index 
Out[12]: CategoricalIndex([u'a', u'a', u'a'], dtype='category')

In [13]: df2.loc['a'].index.categories
Out[13]: Index([u'c', u'a', u'b'], dtype='object')

In [14]: df2.sort_index() 
Out[14]: 
   A
B   
c  4
a  0
a  1
a  5
b  2
b  3

In [15]: df2.groupby(level=0).sum()
Out[15]: 
   A
B   
a  6
b  5
c  4

In [16]: df2.groupby(level=0).sum().index
Out[16]: CategoricalIndex([u'a', u'b', u'c'], dtype='category')
```
