### PR TITLE
Closes #9795 (Stata writer changes input frame)

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -65,7 +65,7 @@ Bug Fixes
 
 - Bug in ``scatter_matrix`` draws unexpected axis ticklabels (:issue:`5662`)
 
-
+- Fixed bug in ``StataWriter`` resulting in changes to input ``DataFrame`` upon save (:issue:`9795`).
 
 
 - Bug in ``transform`` causing length mismatch when null entries were present and a fast aggregator was being used (:issue:`9697`)

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1885,6 +1885,8 @@ class StataWriter(StataParser):
         #NOTE: we might need a different API / class for pandas objects so
         # we can set different semantics - handle this with a PR to pandas.io
 
+        data = data.copy()
+
         if self._write_index:
             data = data.reset_index()
 
@@ -2013,7 +2015,7 @@ class StataWriter(StataParser):
                 self._write(_pad_bytes("", 81))
 
     def _prepare_data(self):
-        data = self.data.copy()
+        data = self.data
         typlist = self.typlist
         convert_dates = self._convert_dates
         # 1. Convert dates

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -290,6 +290,15 @@ class TestStata(tm.TestCase):
             df = DataFrame(np.random.randn(10, 2), columns=list('AB'))
             df.to_stata(path)
 
+    def test_write_preserves_original(self):
+        # 9795
+        np.random.seed(423)
+        df = pd.DataFrame(np.random.randn(5,4), columns=list('abcd'))
+        df.ix[2, 'a':'c'] = np.nan
+        df_copy = df.copy()
+        df.to_stata('test.dta', write_index=False)
+        tm.assert_frame_equal(df, df_copy)
+
     def test_encoding(self):
 
         # GH 4626, proper encoding handling


### PR DESCRIPTION
closes #9795 

Just needed to move the data frame copy earlier in the execution path.
