### PR TITLE
DOC: Fix broken formatting on docstring examples with first-line comments

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2723,7 +2723,8 @@ class NDFrame(PandasObject):
         Examples
         --------
 
-        # Filling in NaNs:
+        Filling in NaNs
+
         >>> s = pd.Series([0, 1, np.nan, 3])
         >>> s.interpolate()
         0    0
@@ -2902,13 +2903,13 @@ class NDFrame(PandasObject):
 
         Examples
         --------
-        # DataFrame result
-        >>> data.groupby(func, axis=0).mean()
+        DataFrame results
 
-        # DataFrame result
+        >>> data.groupby(func, axis=0).mean()
         >>> data.groupby(['col1', 'col2'])['col3'].mean()
 
-        # DataFrame with hierarchical index
+        DataFrame with hierarchical index
+
         >>> data.groupby(['col1', 'col2']).mean()
 
         Returns


### PR DESCRIPTION
Examples for `interpolate` and `groupby` weren't being formatted correctly. See http://pandas.pydata.org/pandas-docs/version/0.16.0/generated/pandas.Series.interpolate.html and http://pandas.pydata.org/pandas-docs/version/0.16.0/generated/pandas.Series.groupby.html
