### PR TITLE
BUG: where behaves badly when dtype of self is datetime or timedelta, and dtype of other is not

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -79,3 +79,4 @@ Bug Fixes
 
 - Bug in ``Series.quantile`` on empty Series of type ``Datetime`` or ``Timedelta`` (:issue:`9675`)
 - Bug in ``where`` causing incorrect results when upcasting was required (:issue:`9731`)
+- Bug in ``where`` when dtype of self is datetime64 or timedelta64, but dtype of other is not

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3323,7 +3323,8 @@ class NDFrame(PandasObject):
                 except ValueError:
                     new_other = np.array(other)
 
-                if not (new_other == np.array(other)).all():
+                matches = (new_other == np.array(other))
+                if matches is False or not matches.all():
                     other = np.array(other)
 
                     # we can't use our existing dtype

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1855,6 +1855,48 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         expected = Series([5,11,2,5,11,2],index=[0,1,2,0,1,2])
         assert_series_equal(comb, expected)
 
+    def test_where_datetime(self):
+        s = Series(date_range('20130102', periods=2))
+        expected = Series([10, 10], dtype='datetime64[ns]')
+        mask = np.array([False, False])
+
+        rs = s.where(mask, [10, 10])
+        assert_series_equal(rs, expected)
+
+        rs = s.where(mask, 10)
+        assert_series_equal(rs, expected)
+
+        rs = s.where(mask, 10.0)
+        assert_series_equal(rs, expected)
+
+        rs = s.where(mask, [10.0, 10.0])
+        assert_series_equal(rs, expected)
+
+        rs = s.where(mask, [10.0, np.nan])
+        expected = Series([10, None], dtype='datetime64[ns]')
+        assert_series_equal(rs, expected)
+
+    def test_where_timedelta(self):
+        s = Series([1, 2], dtype='timedelta64[ns]')
+        expected = Series([10, 10], dtype='timedelta64[ns]')
+        mask = np.array([False, False])
+
+        rs = s.where(mask, [10, 10])
+        assert_series_equal(rs, expected)
+
+        rs = s.where(mask, 10)
+        assert_series_equal(rs, expected)
+
+        rs = s.where(mask, 10.0)
+        assert_series_equal(rs, expected)
+
+        rs = s.where(mask, [10.0, 10.0])
+        assert_series_equal(rs, expected)
+
+        rs = s.where(mask, [10.0, np.nan])
+        expected = Series([10, None], dtype='timedelta64[ns]')
+        assert_series_equal(rs, expected)
+
     def test_mask(self):
         s = Series(np.random.randn(5))
         cond = s > 0


### PR DESCRIPTION
There are a few weird behaviors that this fixes:
1. If `other` is an `int` or `float`, then `where` throws an Exception while trying to call `other.view`
2. If `other` is an np.int64, it works fine
3. If `other` is an np.float64, there is no error, but the result is bizarre (it reinterprets the bits of the float as an integer, rather than casting it)
4. If `other` is list-like and has a numerical dtype, then it throws an exception while try to call `all` on the value False (for some reason, comparing an ndarray with dtype datetime64 and an ndarray with an integer dtype just returns a scalar False rather than a boolean ndarray)

```
>>> s = Series(date_range('20130102', periods=2))
>>> s.where(s.isnull(), 0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/evanpw/Workspace/pandas/pandas/core/generic.py", line 3399, in where
    try_cast=try_cast)
  File "/home/evanpw/Workspace/pandas/pandas/core/internals.py", line 2469, in where
    return self.apply('where', **kwargs)
  File "/home/evanpw/Workspace/pandas/pandas/core/internals.py", line 2451, in apply
    applied = getattr(b, f)(**kwargs)
  File "/home/evanpw/Workspace/pandas/pandas/core/internals.py", line 1080, in where
    result = func(cond, values, other)
  File "/home/evanpw/Workspace/pandas/pandas/core/internals.py", line 1063, in func
    v, o = self._try_coerce_args(v, o)
  File "/home/evanpw/Workspace/pandas/pandas/core/internals.py", line 1819, in _try_coerce_args
    other = other.view('i8')
AttributeError: 'int' object has no attribute 'view'
>>> s.where(s.isnull(), np.int64(10))
0   1970-01-01 00:00:00.000000010
1   1970-01-01 00:00:00.000000010
dtype: datetime64[ns]
>>> s.where(s.isnull(), np.float64(10))
0   2116-06-17 06:38:37.588971520
1   2116-06-17 06:38:37.588971520
dtype: datetime64[ns]
>>> s.where(s.isnull(), [0, 1])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/evanpw/Workspace/pandas/pandas/core/generic.py", line 3326, in where
    if not (new_other == np.array(other)).all():
AttributeError: 'bool' object has no attribute 'all'
```
