### PR TITLE
BUG: format small floats correctly (GH9764)

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -79,3 +79,4 @@ Bug Fixes
 
 - Bug in ``Series.quantile`` on empty Series of type ``Datetime`` or ``Timedelta`` (:issue:`9675`)
 - Bug in ``where`` causing incorrect results when upcasting was required (:issue:`9731`)
+- Bug in ``FloatArrayFormatter`` where decision boundary for displaying "small" floats in decimal format is off by one order of magnitude for a given display.precision (:issue:`9764`)

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -1996,7 +1996,7 @@ class FloatArrayFormatter(GenericArrayFormatter):
 
             # this is pretty arbitrary for now
             has_large_values = (abs_vals > 1e8).any()
-            has_small_values = ((abs_vals < 10 ** (-self.digits)) &
+            has_small_values = ((abs_vals < 10 ** (-self.digits+1)) &
                                 (abs_vals > 0)).any()
 
             if too_long and has_large_values:

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -2990,25 +2990,21 @@ class TestFloatArrayFormatter(tm.TestCase):
         # Issue #9764
         
         # In case default display precision changes:
-        saved_option=pd.get_option('display.precision')
-        pd.set_option('display.precision', 7)
+        with pd.option_context('display.precision', 7):
+            # DataFrame example from issue #9764
+            d=pd.DataFrame({'col1':[9.999e-8, 1e-7, 1.0001e-7, 2e-7, 4.999e-7, 5e-7, 5.0001e-7, 6e-7, 9.999e-7, 1e-6, 1.0001e-6, 2e-6, 4.999e-6, 5e-6, 5.0001e-6, 6e-6]})
+            
+            expected_output={
+                (0,6):'           col1\n0  9.999000e-08\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07',
+                (1,6):'           col1\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07',
+                (1,8):'           col1\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07\n6  5.000100e-07\n7  6.000000e-07',
+                (8,16):'            col1\n8   9.999000e-07\n9   1.000000e-06\n10  1.000100e-06\n11  2.000000e-06\n12  4.999000e-06\n13  5.000000e-06\n14  5.000100e-06\n15  6.000000e-06',
+                (9,16):'        col1\n9   0.000001\n10  0.000001\n11  0.000002\n12  0.000005\n13  0.000005\n14  0.000005\n15  0.000006'
+            }
 
-        # DataFrame from issue #9764
-        d=pd.DataFrame({'col1':[9.999e-8, 1e-7, 1.0001e-7, 2e-7, 4.999e-7, 5e-7, 5.0001e-7, 6e-7, 9.999e-7, 1e-6, 1.0001e-6, 2e-6, 4.999e-6, 5e-6, 5.0001e-6, 6e-6]})
-        
-        expected_output={
-            (0,6):'           col1\n0  9.999000e-08\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07',
-            (1,6):'           col1\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07',
-            (1,8):'           col1\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07\n6  5.000100e-07\n7  6.000000e-07',
-            (8,16):'            col1\n8   9.999000e-07\n9   1.000000e-06\n10  1.000100e-06\n11  2.000000e-06\n12  4.999000e-06\n13  5.000000e-06\n14  5.000100e-06\n15  6.000000e-06',
-            (9,16):'        col1\n9   0.000001\n10  0.000001\n11  0.000002\n12  0.000005\n13  0.000005\n14  0.000005\n15  0.000006'
-        }
+            for (start, stop), v in expected_output.items():
+                self.assertEqual(str(d[start:stop]), v)
 
-        for k, v in expected_output.items():
-            self.assertEqual(d[k[0]:k[1]].__str__(), v)
-
-        # Restore precision
-        pd.set_option('display.precision', saved_option)
 
 class TestRepr_timedelta64(tm.TestCase):
 

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -2986,6 +2986,20 @@ class TestFloatArrayFormatter(tm.TestCase):
         self.assertEqual(result[0], " 12")
         self.assertEqual(result[1], "  0")
 
+    def test_output_significant_digits(self):
+        # relevant to issue #9764
+        d=pd.DataFrame({'col1':[9.999e-8, 1e-7, 1.0001e-7, 2e-7, 4.999e-7, 5e-7, 5.0001e-7, 6e-7, 9.999e-7, 1e-6, 1.0001e-6, 2e-6, 4.999e-6, 5e-6, 5.0001e-6, 6e-6]})
+        
+        expected_output={
+            (0,6):'           col1\n0  9.999000e-08\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07',
+            (1,6):'           col1\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07',
+            (1,8):'           col1\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07\n6  5.000100e-07\n7  6.000000e-07',
+            (8,16):'            col1\n8   9.999000e-07\n9   1.000000e-06\n10  1.000100e-06\n11  2.000000e-06\n12  4.999000e-06\n13  5.000000e-06\n14  5.000100e-06\n15  6.000000e-06',
+            (9,16):'        col1\n9   0.000001\n10  0.000001\n11  0.000002\n12  0.000005\n13  0.000005\n14  0.000005\n15  0.000006'
+        }
+
+        for k, v in expected_output.items():
+            self.assertEqual(d[k[0]:k[1]].__str__(), v)
 
 class TestRepr_timedelta64(tm.TestCase):
 

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -2987,7 +2987,13 @@ class TestFloatArrayFormatter(tm.TestCase):
         self.assertEqual(result[1], "  0")
 
     def test_output_significant_digits(self):
-        # relevant to issue #9764
+        # Issue #9764
+        
+        # In case default display precision changes:
+        saved_option=pd.get_option('display.precision')
+        pd.set_option('display.precision', 7)
+
+        # DataFrame from issue #9764
         d=pd.DataFrame({'col1':[9.999e-8, 1e-7, 1.0001e-7, 2e-7, 4.999e-7, 5e-7, 5.0001e-7, 6e-7, 9.999e-7, 1e-6, 1.0001e-6, 2e-6, 4.999e-6, 5e-6, 5.0001e-6, 6e-6]})
         
         expected_output={
@@ -3000,6 +3006,9 @@ class TestFloatArrayFormatter(tm.TestCase):
 
         for k, v in expected_output.items():
             self.assertEqual(d[k[0]:k[1]].__str__(), v)
+
+        # Restore precision
+        pd.set_option('display.precision', saved_option)
 
 class TestRepr_timedelta64(tm.TestCase):
 


### PR DESCRIPTION
closes #9764 

In order to display a number from range (0,1) in decimal format with N significant digits (and not in scientific format), the number needs to be greater than or equal to 1e(-N+1), not 1e-N. 

Did not test for range of display.precision, as this does not seem to current practice.

Did not include tests as they would imply an output format which might change in the future.
