### PR TITLE
ENC: better pandas typesetting in ipython nbconvert --to latex

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1428,7 +1428,10 @@ class DataFrame(NDFrame):
 
         if buf is None:
             return formatter.buf.getvalue()
-
+    
+    def _repr_latex_(self):
+        return self.to_latex()
+    
     def info(self, verbose=None, buf=None, max_cols=None, memory_usage=None, null_counts=None):
         """
         Concise summary of a DataFrame.


### PR DESCRIPTION
Currently, when IPython notebooks are converted to latex, pandas `DataFrame`s are appear as raw (verbatim) text. One simple solution is to include a `_repl_latex_` function. I have tried this solution and works. See https://github.com/ipython/ipython/issues/8261
