### PR TITLE
add biweight midcorrelation as option for series correlation

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -37,6 +37,9 @@ New features
 - SQL io functions now accept a SQLAlchemy connectable. (:issue:`7877`)
 - Enable writing complex values to HDF stores when using table format (:issue:`10447`)
 - Enable reading gzip compressed files via URL, either by explicitly setting the compression parameter or by inferring from the presence of the HTTP Content-Encoding header in the response (:issue:`8685`)
+- ``Series.corr()`` and ``DataFrame.corr()`` now supports `Biweight Midcorrelation`_, a median-based correlation metric, a robust alternative to Pearson's R. (:issue:`9826`)
+
+_Biweight Midcorrelation: http://www.ncbi.nlm.nih.gov/pmc/articles/PMC3465711/
 
 .. _whatsnew_0170.gil:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4232,10 +4232,11 @@ class DataFrame(NDFrame):
 
         Parameters
         ----------
-        method : {'pearson', 'kendall', 'spearman'}
+        method : {'pearson', 'kendall', 'spearman', 'bicor'}
             * pearson : standard correlation coefficient
             * kendall : Kendall Tau correlation coefficient
             * spearman : Spearman rank correlation
+            * bicor : Biweight midcorrelation, a median-based similarity metric
         min_periods : int, optional
             Minimum number of observations required per pair of columns
             to have a valid result. Currently only available for pearson

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -652,24 +652,25 @@ def get_corr_func(method):
         return spearmanr(a, b)[0]
 
     def _biweight_midcorrelation(a, b):
-        a_median = a.median()
-        b_median = b.median()
+        a_median = np.median(a)
+        b_median = np.median(b)
 
         # Median absolute deviation
-        a_mad = (a - a_median).abs().median()
-        b_mad = (b - b_median).abs().median()
+        a_mad = np.median(np.abs(a - a_median))
+        b_mad = np.median(np.abs(b - b_median))
 
         u = (a - a_median) / (9 * a_mad)
         v = (b - b_median) / (9 * b_mad)
 
-        w_a = np.square(1 - np.square(u)) * ((1 - u.abs()) > 0)
-        w_b = np.square(1 - np.square(v)) * ((1 - v.abs()) > 0)
+        w_a = np.square(1 - np.square(u)) * ((1 - np.abs(u)) > 0)
+        w_b = np.square(1 - np.square(v)) * ((1 - np.abs(v)) > 0)
 
         a_item = (a - a_median) * w_a
         b_item = (b - b_median) * w_b
 
         return (a_item * b_item).sum() / (
-            np.sqrt(np.square(a_item).sum()) * np.sqrt(np.square(b_item).sum()))
+            np.sqrt(np.square(a_item).sum()) *
+            np.sqrt(np.square(b_item).sum()))
 
     _cor_methods = {
         'pearson': _pearson,

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -651,10 +651,31 @@ def get_corr_func(method):
     def _spearman(a, b):
         return spearmanr(a, b)[0]
 
+    def _biweight_midcorrelation(a, b):
+        a_median = a.median()
+        b_median = b.median()
+
+        # Median absolute deviation
+        a_mad = (a - a_median).abs().median()
+        b_mad = (b - b_median).abs().median()
+
+        u = (a - a_median) / (9 * a_mad)
+        v = (b - b_median) / (9 * b_mad)
+
+        w_a = np.square(1 - np.square(u)) * ((1 - u.abs()) > 0)
+        w_b = np.square(1 - np.square(v)) * ((1 - v.abs()) > 0)
+
+        a_item = (a - a_median) * w_a
+        b_item = (b - b_median) * w_b
+
+        return (a_item * b_item).sum() / (
+            np.sqrt(np.square(a_item).sum()) * np.sqrt(np.square(b_item).sum()))
+
     _cor_methods = {
         'pearson': _pearson,
         'kendall': _kendall,
-        'spearman': _spearman
+        'spearman': _spearman,
+        'bicor': _biweight_midcorrelation
     }
     return _cor_methods[method]
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1284,10 +1284,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         Parameters
         ----------
         other : Series
-        method : {'pearson', 'kendall', 'spearman'}
+        method : {'pearson', 'kendall', 'spearman', 'bicor}
             * pearson : standard correlation coefficient
             * kendall : Kendall Tau correlation coefficient
             * spearman : Spearman rank correlation
+            * bicor : Biweight midcorrelation, a median-based similarity metric
         min_periods : int, optional
             Minimum number of observations needed to have a valid result
 

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -584,15 +584,56 @@ class TestnanopsDataFrame(tm.TestCase):
                                      method='spearman')
 
     def test_nancorr_bicor(self):
-        targ0 = spearmanr(self.arr_float_2d, self.arr_float1_2d)[0]
-        targ1 = spearmanr(self.arr_float_2d.flat, self.arr_float1_2d.flat)[0]
+        a = self.arr_float_2d
+        b = self.arr_float1_2d
+        a_median = np.median(a)
+        b_median = np.median(b)
+
+        # Median absolute deviation
+        a_mad = np.median(np.abs(self.arr_float_2d - a_median))
+        b_mad = np.median(np.abs(self.arr_float1_2d - b_median))
+
+        u = (self.arr_float_2d - a_median) / (9 * a_mad)
+        v = (self.arr_float1_2d - b_median) / (9 * b_mad)
+
+        w_a = np.square(1 - np.square(u)) * ((1 - np.abs(u)) > 0)
+        w_b = np.square(1 - np.square(v)) * ((1 - np.abs(v)) > 0)
+
+        a_item = (self.arr_float_2d - a_median) * w_a
+        b_item = (self.arr_float1_2d - b_median) * w_b
+
+        targ0 = (a_item * b_item).sum() / (
+            np.sqrt(np.square(a_item).sum()) *
+            np.sqrt(np.square(b_item).sum()))
+
+        a = self.arr_float_2d.flat
+        b = self.arr_float1_2d.flat
+        a_median = np.median(a)
+        b_median = np.median(b)
+
+        # Median absolute deviation
+        a_mad = np.median(np.abs(self.arr_float_2d - a_median))
+        b_mad = np.median(np.abs(self.arr_float1_2d - b_median))
+
+        u = (self.arr_float_2d - a_median) / (9 * a_mad)
+        v = (self.arr_float1_2d - b_median) / (9 * b_mad)
+
+        w_a = np.square(1 - np.square(u)) * ((1 - np.abs(u)) > 0)
+        w_b = np.square(1 - np.square(v)) * ((1 - np.abs(v)) > 0)
+
+        a_item = (self.arr_float_2d - a_median) * w_a
+        b_item = (self.arr_float1_2d - b_median) * w_b
+
+        targ1 = (a_item * b_item).sum() / (
+            np.sqrt(np.square(a_item).sum()) *
+            np.sqrt(np.square(b_item).sum()))
         self.check_nancorr_nancov_2d(nanops.nancorr, targ0, targ1,
                                      method='bicor')
 
-        targ0 = spearmanr(self.arr_float_1d, self.arr_float1_1d)[0]
-        targ1 = spearmanr(self.arr_float_1d.flat, self.arr_float1_1d.flat)[0]
-        self.check_nancorr_nancov_1d(nanops.nancorr, targ0, targ1,
-                                     method='bicor')
+        # targ0 = spearmanr(self.arr_float_1d, self.arr_float1_1d)
+        # targ1 = spearmanr(self.arr_float_1d.flat, self.arr_float1_1d.flat)
+        # self.check_nancorr_nancov_1d(nanops.nancorr, targ0, targ1,
+        #                              method='bicor')
 
     def test_nancov(self):
         targ0 = np.cov(self.arr_float_2d, self.arr_float1_2d)[0, 1]

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -590,17 +590,17 @@ class TestnanopsDataFrame(tm.TestCase):
         b_median = np.median(b)
 
         # Median absolute deviation
-        a_mad = np.median(np.abs(self.arr_float_1d - a_median))
-        b_mad = np.median(np.abs(self.arr_float1_1d - b_median))
+        a_mad = np.median(np.abs(a - a_median))
+        b_mad = np.median(np.abs(b - b_median))
 
-        u = (self.arr_float_1d - a_median) / (9 * a_mad)
-        v = (self.arr_float1_1d - b_median) / (9 * b_mad)
+        u = (a - a_median) / (9 * a_mad)
+        v = (b - b_median) / (9 * b_mad)
 
         w_a = np.square(1 - np.square(u)) * ((1 - np.abs(u)) > 0)
         w_b = np.square(1 - np.square(v)) * ((1 - np.abs(v)) > 0)
 
-        a_item = (self.arr_float_1d - a_median) * w_a
-        b_item = (self.arr_float1_1d - b_median) * w_b
+        a_item = (a - a_median) * w_a
+        b_item = (b - b_median) * w_b
 
         targ0 = (a_item * b_item).sum() / (
             np.sqrt(np.square(a_item).sum()) *
@@ -612,17 +612,17 @@ class TestnanopsDataFrame(tm.TestCase):
         b_median = np.median(b)
 
         # Median absolute deviation
-        a_mad = np.median(np.abs(self.arr_float_1d - a_median))
-        b_mad = np.median(np.abs(self.arr_float1_1d - b_median))
+        a_mad = np.median(np.abs(a - a_median))
+        b_mad = np.median(np.abs(b - b_median))
 
-        u = (self.arr_float_1d - a_median) / (9 * a_mad)
-        v = (self.arr_float1_1d - b_median) / (9 * b_mad)
+        u = (a - a_median) / (9 * a_mad)
+        v = (b - b_median) / (9 * b_mad)
 
         w_a = np.square(1 - np.square(u)) * ((1 - np.abs(u)) > 0)
         w_b = np.square(1 - np.square(v)) * ((1 - np.abs(v)) > 0)
 
-        a_item = (self.arr_float_1d - a_median) * w_a
-        b_item = (self.arr_float1_1d - b_median) * w_b
+        a_item = (a - a_median) * w_a
+        b_item = (b - b_median) * w_b
 
         targ1 = (a_item * b_item).sum() / (
             np.sqrt(np.square(a_item).sum()) *
@@ -635,17 +635,17 @@ class TestnanopsDataFrame(tm.TestCase):
         b_median = np.median(b)
 
         # Median absolute deviation
-        a_mad = np.median(np.abs(self.arr_float_2d - a_median))
-        b_mad = np.median(np.abs(self.arr_float1_2d - b_median))
+        a_mad = np.median(np.abs(a - a_median))
+        b_mad = np.median(np.abs(b - b_median))
 
-        u = (self.arr_float_2d - a_median) / (9 * a_mad)
-        v = (self.arr_float1_2d - b_median) / (9 * b_mad)
+        u = (a - a_median) / (9 * a_mad)
+        v = (b - b_median) / (9 * b_mad)
 
         w_a = np.square(1 - np.square(u)) * ((1 - np.abs(u)) > 0)
         w_b = np.square(1 - np.square(v)) * ((1 - np.abs(v)) > 0)
 
-        a_item = (self.arr_float_2d - a_median) * w_a
-        b_item = (self.arr_float1_2d - b_median) * w_b
+        a_item = (a - a_median) * w_a
+        b_item = (b - b_median) * w_b
 
         targ0 = (a_item * b_item).sum() / (
             np.sqrt(np.square(a_item).sum()) *
@@ -657,17 +657,17 @@ class TestnanopsDataFrame(tm.TestCase):
         b_median = np.median(b)
 
         # Median absolute deviation
-        a_mad = np.median(np.abs(self.arr_float_2d - a_median))
-        b_mad = np.median(np.abs(self.arr_float1_2d - b_median))
+        a_mad = np.median(np.abs(a - a_median))
+        b_mad = np.median(np.abs(b - b_median))
 
-        u = (self.arr_float_2d - a_median) / (9 * a_mad)
-        v = (self.arr_float1_2d - b_median) / (9 * b_mad)
+        u = (a - a_median) / (9 * a_mad)
+        v = (b - b_median) / (9 * b_mad)
 
         w_a = np.square(1 - np.square(u)) * ((1 - np.abs(u)) > 0)
         w_b = np.square(1 - np.square(v)) * ((1 - np.abs(v)) > 0)
 
-        a_item = (self.arr_float_2d - a_median) * w_a
-        b_item = (self.arr_float1_2d - b_median) * w_b
+        a_item = (a - a_median) * w_a
+        b_item = (b - b_median) * w_b
 
         targ1 = (a_item * b_item).sum() / (
             np.sqrt(np.square(a_item).sum()) *

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -629,6 +629,51 @@ class TestnanopsDataFrame(tm.TestCase):
             np.sqrt(np.square(b_item).sum()))
         self.check_nancorr_nancov_2d(nanops.nancorr, targ0, targ1,
                                      method='bicor')
+        a = self.arr_float_1d
+        b = self.arr_float1_1d
+        a_median = np.median(a)
+        b_median = np.median(b)
+
+        # Median absolute deviation
+        a_mad = np.median(np.abs(self.arr_float_2d - a_median))
+        b_mad = np.median(np.abs(self.arr_float1_2d - b_median))
+
+        u = (self.arr_float_2d - a_median) / (9 * a_mad)
+        v = (self.arr_float1_2d - b_median) / (9 * b_mad)
+
+        w_a = np.square(1 - np.square(u)) * ((1 - np.abs(u)) > 0)
+        w_b = np.square(1 - np.square(v)) * ((1 - np.abs(v)) > 0)
+
+        a_item = (self.arr_float_2d - a_median) * w_a
+        b_item = (self.arr_float1_2d - b_median) * w_b
+
+        targ0 = (a_item * b_item).sum() / (
+            np.sqrt(np.square(a_item).sum()) *
+            np.sqrt(np.square(b_item).sum()))
+
+        a = self.arr_float_1d.flat
+        b = self.arr_float1_1d.flat
+        a_median = np.median(a)
+        b_median = np.median(b)
+
+        # Median absolute deviation
+        a_mad = np.median(np.abs(self.arr_float_2d - a_median))
+        b_mad = np.median(np.abs(self.arr_float1_2d - b_median))
+
+        u = (self.arr_float_2d - a_median) / (9 * a_mad)
+        v = (self.arr_float1_2d - b_median) / (9 * b_mad)
+
+        w_a = np.square(1 - np.square(u)) * ((1 - np.abs(u)) > 0)
+        w_b = np.square(1 - np.square(v)) * ((1 - np.abs(v)) > 0)
+
+        a_item = (self.arr_float_2d - a_median) * w_a
+        b_item = (self.arr_float1_2d - b_median) * w_b
+
+        targ1 = (a_item * b_item).sum() / (
+            np.sqrt(np.square(a_item).sum()) *
+            np.sqrt(np.square(b_item).sum()))
+        self.check_nancorr_nancov_1d(nanops.nancorr, targ0, targ1,
+                                     method='bicor')
 
         # targ0 = spearmanr(self.arr_float_1d, self.arr_float1_1d)
         # targ1 = spearmanr(self.arr_float_1d.flat, self.arr_float1_1d.flat)

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -590,17 +590,17 @@ class TestnanopsDataFrame(tm.TestCase):
         b_median = np.median(b)
 
         # Median absolute deviation
-        a_mad = np.median(np.abs(self.arr_float_2d - a_median))
-        b_mad = np.median(np.abs(self.arr_float1_2d - b_median))
+        a_mad = np.median(np.abs(self.arr_float_1d - a_median))
+        b_mad = np.median(np.abs(self.arr_float1_1d - b_median))
 
-        u = (self.arr_float_2d - a_median) / (9 * a_mad)
-        v = (self.arr_float1_2d - b_median) / (9 * b_mad)
+        u = (self.arr_float_1d - a_median) / (9 * a_mad)
+        v = (self.arr_float1_1d - b_median) / (9 * b_mad)
 
         w_a = np.square(1 - np.square(u)) * ((1 - np.abs(u)) > 0)
         w_b = np.square(1 - np.square(v)) * ((1 - np.abs(v)) > 0)
 
-        a_item = (self.arr_float_2d - a_median) * w_a
-        b_item = (self.arr_float1_2d - b_median) * w_b
+        a_item = (self.arr_float_1d - a_median) * w_a
+        b_item = (self.arr_float1_1d - b_median) * w_b
 
         targ0 = (a_item * b_item).sum() / (
             np.sqrt(np.square(a_item).sum()) *
@@ -612,17 +612,17 @@ class TestnanopsDataFrame(tm.TestCase):
         b_median = np.median(b)
 
         # Median absolute deviation
-        a_mad = np.median(np.abs(self.arr_float_2d - a_median))
-        b_mad = np.median(np.abs(self.arr_float1_2d - b_median))
+        a_mad = np.median(np.abs(self.arr_float_1d - a_median))
+        b_mad = np.median(np.abs(self.arr_float1_1d - b_median))
 
-        u = (self.arr_float_2d - a_median) / (9 * a_mad)
-        v = (self.arr_float1_2d - b_median) / (9 * b_mad)
+        u = (self.arr_float_1d - a_median) / (9 * a_mad)
+        v = (self.arr_float1_1d - b_median) / (9 * b_mad)
 
         w_a = np.square(1 - np.square(u)) * ((1 - np.abs(u)) > 0)
         w_b = np.square(1 - np.square(v)) * ((1 - np.abs(v)) > 0)
 
-        a_item = (self.arr_float_2d - a_median) * w_a
-        b_item = (self.arr_float1_2d - b_median) * w_b
+        a_item = (self.arr_float_1d - a_median) * w_a
+        b_item = (self.arr_float1_1d - b_median) * w_b
 
         targ1 = (a_item * b_item).sum() / (
             np.sqrt(np.square(a_item).sum()) *

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -583,7 +583,6 @@ class TestnanopsDataFrame(tm.TestCase):
         self.check_nancorr_nancov_1d(nanops.nancorr, targ0, targ1,
                                      method='spearman')
 
-
     def test_nancorr_bicor(self):
         targ0 = spearmanr(self.arr_float_2d, self.arr_float1_2d)[0]
         targ1 = spearmanr(self.arr_float_2d.flat, self.arr_float1_2d.flat)[0]

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -583,6 +583,18 @@ class TestnanopsDataFrame(tm.TestCase):
         self.check_nancorr_nancov_1d(nanops.nancorr, targ0, targ1,
                                      method='spearman')
 
+
+    def test_nancorr_bicor(self):
+        targ0 = spearmanr(self.arr_float_2d, self.arr_float1_2d)[0]
+        targ1 = spearmanr(self.arr_float_2d.flat, self.arr_float1_2d.flat)[0]
+        self.check_nancorr_nancov_2d(nanops.nancorr, targ0, targ1,
+                                     method='bicor')
+
+        targ0 = spearmanr(self.arr_float_1d, self.arr_float1_1d)[0]
+        targ1 = spearmanr(self.arr_float_1d.flat, self.arr_float1_1d.flat)[0]
+        self.check_nancorr_nancov_1d(nanops.nancorr, targ0, targ1,
+                                     method='bicor')
+
     def test_nancov(self):
         targ0 = np.cov(self.arr_float_2d, self.arr_float1_2d)[0, 1]
         targ1 = np.cov(self.arr_float_2d.flat, self.arr_float1_2d.flat)[0, 1]


### PR DESCRIPTION
Add [Biweight Midcorrelation](http://download-v2.springer.com/static/pdf/95/chp%253A10.1007%252F978-3-642-39678-6_14.pdf?token2=exp=1428360548~acl=%2Fstatic%2Fpdf%2F95%2Fchp%25253A10.1007%25252F978-3-642-39678-6_14.pdf*~hmac=980c2edddba12bbb73ebbadaa682092cde9d534bc8738d65785647402b683c21), an alternative correlation method to Pearson that is robust to outliers, to the series correlation method repertoire.
