### PR TITLE
BUG/CLN: Repeated time-series plot may raise TypeError

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -108,6 +108,7 @@ Bug Fixes
 - Bug in plotting continuously using ``secondary_y`` may not show legend properly. (:issue:`9610`, :issue:`9779`)
 
 - Bug in ``DataFrame.plot(kind="hist")`` results in ``TypeError`` when ``DataFrame`` contains non-numeric columns  (:issue:`9853`)
+- Bug where repeated plotting of ``DataFrame`` with a ``DatetimeIndex`` may raise ``TypeError`` (:issue:`9852`)
 
 - Bug in ``Series.quantile`` on empty Series of type ``Datetime`` or ``Timedelta`` (:issue:`9675`)
 - Bug in ``where`` causing incorrect results when upcasting was required (:issue:`9731`)

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -636,6 +636,38 @@ class TestTSPlot(tm.TestCase):
         x2 = lines[1].get_xdata()
         assert_array_equal(x2, s1.index.asobject.values)
 
+    def test_mixed_freq_regular_first_df(self):
+        # GH 9852
+        import matplotlib.pyplot as plt
+        s1 = tm.makeTimeSeries().to_frame()
+        s2 = s1.iloc[[0, 5, 10, 11, 12, 13, 14, 15], :]
+        ax = s1.plot()
+        ax2 = s2.plot(style='g', ax=ax)
+        lines = ax2.get_lines()
+        idx1 = PeriodIndex(lines[0].get_xdata())
+        idx2 = PeriodIndex(lines[1].get_xdata())
+        self.assertTrue(idx1.equals(s1.index.to_period('B')))
+        self.assertTrue(idx2.equals(s2.index.to_period('B')))
+        left, right = ax2.get_xlim()
+        pidx = s1.index.to_period()
+        self.assertEqual(left, pidx[0].ordinal)
+        self.assertEqual(right, pidx[-1].ordinal)
+
+    @slow
+    def test_mixed_freq_irregular_first_df(self):
+        # GH 9852
+        import matplotlib.pyplot as plt
+        s1 = tm.makeTimeSeries().to_frame()
+        s2 = s1.iloc[[0, 5, 10, 11, 12, 13, 14, 15], :]
+        ax = s2.plot(style='g')
+        ax = s1.plot(ax=ax)
+        self.assertFalse(hasattr(ax, 'freq'))
+        lines = ax.get_lines()
+        x1 = lines[0].get_xdata()
+        assert_array_equal(x1, s2.index.asobject.values)
+        x2 = lines[1].get_xdata()
+        assert_array_equal(x2, s1.index.asobject.values)
+
     def test_mixed_freq_hf_first(self):
         idxh = date_range('1/1/1999', periods=365, freq='D')
         idxl = date_range('1/1/1999', periods=12, freq='M')


### PR DESCRIPTION
This repeated time-series plotting works:

```
import pandas.util.testing as tm
s1 = tm.makeTimeSeries()
s2 = s1[[0, 5, 10, 11, 12, 13, 14, 15]]
ax = s1.plot()
ax2 = s2.plot(style='g')
```

![line_incorrectsecondary](https://cloud.githubusercontent.com/assets/1696302/7101339/f74b566a-e08f-11e4-8b7f-5ed58327cc5c.png)

But if converted to `DateFrame`, it doesn't:

```
s1 = s1.to_frame()
s2 = s1.iloc[[0, 5, 10, 11, 12, 13, 14, 15]]
print(s2.index.freq)
ax = s1.plot()
ax2 = s2.plot(style='g', ax=ax)
# TypeError: expected string or buffer
```

Fixed the problem, and cleaned up the code to merge `Series` and `DataFrame` flows.
#### After the Fix:

```
import pandas.util.testing as tm
fig, axes = plt.subplots(2, 1)
s1 = tm.makeTimeSeries()
s2 = s1[[0, 5, 10, 11, 12, 13, 14, 15]]
ax = s1.plot(ax=axes[0])
ax2 = s2.plot(style='g', ax=axes[0])

s1 = s1.to_frame(name='x')
s2 = s1.iloc[[0, 5, 10, 11, 12, 13, 14, 15]]
ax = s1.plot(ax=axes[1])
ax2 = s2.plot(style='g', ax=axes[1])
```

![line_incorrectsecondary](https://cloud.githubusercontent.com/assets/1696302/7103495/55f95316-e0e4-11e4-8086-6aedfae82006.png)
