### PR TITLE
Groupby transform preserves output dtype

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -124,3 +124,5 @@ Bug Fixes
 - Bug in which ``SparseDataFrame`` could not take `nan` as a column name (:issue:`8822`)
 
 - Bug in unequal comparisons between a ``Series`` of dtype `"category"` and a scalar (e.g. ``Series(Categorical(list("abc"), categories=list("cba"), ordered=True)) > "b"``, which wouldn't use the order of the categories but use the lexicographical order. (:issue:`9848`)
+
+- Bug in which ``groupby.transform`` incorrectly enforced output dtypes to match input dtypes. (:issue:`9807`)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -3006,7 +3006,7 @@ class NDFrameGroupBy(GroupBy):
         if ((not isinstance(obj.index,MultiIndex) and
              type(result.index) != type(obj.index)) or
             len(result.index) != len(obj.index)):
-            results = obj.values.copy()
+            results = np.empty_like(obj.values, result.values.dtype)
             indices = self.indices
             for (name, group), (i, row) in zip(self, result.iterrows()):
                 indexer = indices[name]

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -1003,6 +1003,14 @@ class TestGroupBy(tm.TestCase):
             for idx in gp.index:
                 assert_fp_equal(res.xs(idx), agged[idx])
 
+    def test_transform_dtype(self):
+        # GH 9807
+        # Check transform dtype output is preserved
+        df = DataFrame([[1, 3], [2, 3]])
+        result = df.groupby(1).transform('mean')
+        expected = DataFrame([[1.5], [1.5]])
+        assert_frame_equal(result, expected)
+
     def test_transform_bug(self):
         # GH 5712
         # transforming on a datetime column


### PR DESCRIPTION
Previously `transform` output was always the same dtype as the groupby
object. This allows the output dtype to differ from the input. Fixes #9807.
