### PR TITLE
BUG: Fix for cython version checking closes #9827

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,24 @@ matrix:
       - FULL_DEPS=true
       - CLIPBOARD_GUI=gtk2
       - BUILD_TYPE=conda
+      - JOB_NAME: "27_build_test"
+      - JOB_TAG=_BUILD_TEST
+      - BUILD_TEST=true
+    - python: 2.7
+      env:
+      - NOSE_ARGS="not slow and not disabled"
+      - FULL_DEPS=true
+      - CLIPBOARD_GUI=gtk2
+      - BUILD_TYPE=pydata
+      - JOB_NAME: "27_build_test"
+      - JOB_TAG=_BUILD_TEST
+      - BUILD_TEST=true
+    - python: 2.7
+      env:
+      - NOSE_ARGS="not slow and not disabled"
+      - FULL_DEPS=true
+      - CLIPBOARD_GUI=gtk2
+      - BUILD_TYPE=conda
       - JOB_NAME: "27_nslow"
       - DOC_BUILD=true # if rst files were changed, build docs in parallel with tests
     - python: 2.7
@@ -115,6 +133,24 @@ matrix:
         - NUMPY_BUILD=master
         - BUILD_TYPE=pydata
         - PANDAS_TESTING_MODE="deprecate"
+      - python: 2.7
+        env:
+        - NOSE_ARGS="not slow and not disabled"
+        - FULL_DEPS=true
+        - CLIPBOARD_GUI=gtk2
+        - BUILD_TYPE=conda
+        - JOB_NAME: "27_build_test"
+        - JOB_TAG=_BUILD_TEST
+        - BUILD_TEST=true
+      - python: 2.7
+        env:
+        - NOSE_ARGS="not slow and not disabled"
+        - FULL_DEPS=true
+        - CLIPBOARD_GUI=gtk2
+        - BUILD_TYPE=pydata
+        - JOB_NAME: "27_build_test"
+        - JOB_TAG=_BUILD_TEST
+        - BUILD_TEST=true
 
 before_install:
   - echo "before_install"

--- a/ci/install_conda.sh
+++ b/ci/install_conda.sh
@@ -96,7 +96,13 @@ if [ "$IRON_TOKEN" ]; then
     export CC='ccache gcc'
 fi
 
-python setup.py build_ext --inplace && python setup.py develop
+if [ "$BUILD_TEST" ]; then
+    pip uninstall --yes cython
+    pip install cython==0.15.1
+    ( python setup.py build_ext --inplace && python setup.py develop ) || true
+else
+    python setup.py build_ext --inplace && python setup.py develop
+fi
 
 for package in beautifulsoup4; do
     pip uninstall --yes $package

--- a/ci/install_pydata.sh
+++ b/ci/install_pydata.sh
@@ -137,8 +137,15 @@ if [ "$IRON_TOKEN" ]; then
 fi
 
 # build pandas
-python setup.py build_ext --inplace
-python setup.py develop
+if [ "$BUILD_TEST" ]; then
+    pip uninstall --yes cython
+    pip install cython==0.15.1
+    ( python setup.py build_ext --inplace ) || true
+    ( python setup.py develop ) || true
+else
+    python setup.py build_ext --inplace
+    python setup.py develop
+fi
 
 # restore cython (if not numpy building)
 if [ -z "$NUMPY_BUILD" ]; then

--- a/ci/requirements-2.7_BUILD_TEST.txt
+++ b/ci/requirements-2.7_BUILD_TEST.txt
@@ -1,0 +1,5 @@
+dateutil
+pytz
+numpy
+cython
+nose

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -16,9 +16,12 @@ fi
 "$TRAVIS_BUILD_DIR"/ci/build_docs.sh 2>&1 > /tmp/doc.log &
 # doc build log will be shown after tests
 
-
-echo nosetests --exe -A "$NOSE_ARGS" pandas --with-xunit --xunit-file=/tmp/nosetests.xml
-nosetests --exe -A "$NOSE_ARGS" pandas --with-xunit --xunit-file=/tmp/nosetests.xml
+if [ "$BUILD_TEST" ]; then
+    echo "We are not running nosetests as this is simply a build test."
+else
+    echo nosetests --exe -A "$NOSE_ARGS" pandas --with-xunit --xunit-file=/tmp/nosetests.xml
+    nosetests --exe -A "$NOSE_ARGS" pandas --with-xunit --xunit-file=/tmp/nosetests.xml
+fi
 
 RET="$?"
 

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,17 @@ import sys
 import shutil
 import warnings
 import re
+from distutils.version import LooseVersion
 
 # may need to work around setuptools bug by providing a fake Pyrex
+min_cython_ver = '0.19.1'
 try:
     import Cython
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "fake_pyrex"))
+    ver = Cython.__version__
+    _CYTHON_INSTALLED = ver >= LooseVersion(min_cython_ver)
 except ImportError:
-    pass
+    _CYTHON_INSTALLED = False
 
 # try bootstrapping setuptools if it doesn't exist
 try:
@@ -74,6 +78,8 @@ from distutils.command.sdist import sdist
 from distutils.command.build_ext import build_ext as _build_ext
 
 try:
+    if not _CYTHON_INSTALLED:
+        raise ImportError('No supported version of Cython installed.')
     from Cython.Distutils import build_ext as _build_ext
     # from Cython.Distutils import Extension # to get pyrex debugging symbols
     cython = True


### PR DESCRIPTION
closes #9827

Added a cython version check at the top of setup.py; minimum version of 0.19.1. If the minimum isn't met, _CYTHON_INSTALLED sets to false, so the installation can proceed if cython is not needed, but will fail if cython is needed (with an appropriate error message).

Two new travis jobs added to test install_conda and install_pydata flows for the old cython revision, and ensure that pandas setup fails with appropriate error messages. See https://travis-ci.org/ajamian/pandas/builds/58315862 for regression.
