### PR TITLE
FIX: Describe NotImplementedErrors or use AbstractMethodError

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -11,7 +11,7 @@ import pandas.tslib as tslib
 import pandas.lib as lib
 from pandas.util.decorators import Appender, cache_readonly
 from pandas.core.strings import StringMethods
-
+from pandas.core.common import AbstractMethodError
 
 _shared_docs = dict()
 _indexops_doc_kwargs = dict(klass='IndexOpsMixin', inplace='',
@@ -32,7 +32,7 @@ class StringMixin(object):
     # Formatting
 
     def __unicode__(self):
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     def __str__(self):
         """
@@ -566,4 +566,4 @@ class IndexOpsMixin(object):
     # abstracts
 
     def _update_inplace(self, result, **kwargs):
-        raise NotImplementedError
+        raise AbstractMethodError(self)

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -1166,7 +1166,8 @@ class Categorical(PandasObject):
         if fill_value is None:
             fill_value = np.nan
         if limit is not None:
-            raise NotImplementedError
+            raise NotImplementedError("specifying a limit for fillna has not "
+                                      "been implemented yet")
 
         values = self._codes
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -39,6 +39,17 @@ class AmbiguousIndexError(PandasError, KeyError):
     pass
 
 
+class AbstractMethodError(NotImplementedError):
+    """Raise this error instead of NotImplementedError for abstract methods
+    while keeping compatibility with Python 2 and Python 3.
+    """
+    def __init__(self, class_instance):
+        self.class_instance = class_instance
+
+    def __str__(self):
+        return "This method must be defined on the concrete class of " \
+               + self.class_instance.__class__.__name__
+
 _POSSIBLY_CAST_DTYPES = set([np.dtype(t).name
                              for t in ['O', 'int8',
                                        'uint8', 'int16', 'uint16', 'int32',

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -21,7 +21,8 @@ from pandas.compat import map, zip, lrange, string_types, isidentifier, lmap
 from pandas.core.common import (isnull, notnull, is_list_like,
                                 _values_from_object, _maybe_promote,
                                 _maybe_box_datetimelike, ABCSeries,
-                                SettingWithCopyError, SettingWithCopyWarning)
+                                SettingWithCopyError, SettingWithCopyWarning,
+                                AbstractMethodError)
 import pandas.core.nanops as nanops
 from pandas.util.decorators import Appender, Substitution, deprecate_kwarg
 from pandas.core import config
@@ -137,7 +138,7 @@ class NDFrame(PandasObject):
 
     @property
     def _constructor(self):
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     def __unicode__(self):
         # unicode representation based upon iterating over self
@@ -152,7 +153,7 @@ class NDFrame(PandasObject):
 
     @property
     def _constructor_sliced(self):
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     #----------------------------------------------------------------------
     # Axis
@@ -1100,7 +1101,7 @@ class NDFrame(PandasObject):
         return lower
 
     def _box_item_values(self, key, values):
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     def _maybe_cache_changed(self, item, value):
         """
@@ -3057,7 +3058,8 @@ class NDFrame(PandasObject):
         """
         from pandas.tseries.frequencies import to_offset
         if not isinstance(self.index, DatetimeIndex):
-            raise NotImplementedError
+            raise NotImplementedError("'first' only supports a DatetimeIndex "
+                                      "index")
 
         if len(self.index) == 0:
             return self
@@ -3091,7 +3093,8 @@ class NDFrame(PandasObject):
         """
         from pandas.tseries.frequencies import to_offset
         if not isinstance(self.index, DatetimeIndex):
-            raise NotImplementedError
+            raise NotImplementedError("'last' only supports a DatetimeIndex "
+                                      "index")
 
         if len(self.index) == 0:
             return self

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -294,7 +294,8 @@ class Block(PandasObject):
         mask = isnull(self.values)
         if limit is not None:
             if self.ndim > 2:
-                raise NotImplementedError
+                raise NotImplementedError("number of dimensions for 'fillna' "
+                                          "is currently limited to 2")
             mask[mask.cumsum(self.ndim-1)>limit]=False
 
         value = self._try_fill(value)
@@ -1681,7 +1682,8 @@ class CategoricalBlock(NonConsolidatableMixIn, ObjectBlock):
     def fillna(self, value, limit=None, inplace=False, downcast=None):
         # we may need to upcast our fill to match our dtype
         if limit is not None:
-            raise NotImplementedError
+            raise NotImplementedError("specifying a limit for 'fillna' has "
+                                      "not been implemented yet")
 
         values = self.values if inplace else self.values.copy()
         return [self.make_block_same_class(values=values.fillna(fill_value=value,
@@ -1848,7 +1850,8 @@ class DatetimeBlock(Block):
         value = self._try_fill(value)
         if limit is not None:
             if self.ndim > 2:
-                raise NotImplementedError
+                raise NotImplementedError("number of dimensions for 'fillna' "
+                                          "is currently limited to 2")
             mask[mask.cumsum(self.ndim-1)>limit]=False
 
         np.putmask(values, mask, value)
@@ -2011,7 +2014,8 @@ class SparseBlock(NonConsolidatableMixIn, Block):
     def fillna(self, value, limit=None, inplace=False, downcast=None):
         # we may need to upcast our fill to match our dtype
         if limit is not None:
-            raise NotImplementedError
+            raise NotImplementedError("specifying a limit for 'fillna' has "
+                                      "not been implemented yet")
         if issubclass(self.dtype.type, np.floating):
             value = float(value)
         values = self.values if inplace else self.values.copy()

--- a/pandas/core/panelnd.py
+++ b/pandas/core/panelnd.py
@@ -99,7 +99,7 @@ def create_nd_panel_factory(klass_name, orders, slices, slicer, aliases=None,
     for f in ['to_frame', 'to_excel', 'to_sparse', 'groupby', 'join', 'filter',
               'dropna', 'shift']:
         def func(self, *args, **kwargs):
-            raise NotImplementedError
+            raise NotImplementedError("this operation is not supported")
         setattr(klass, f, func)
 
     # add the aggregate operations

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -140,7 +140,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                 dtype = self._validate_dtype(dtype)
 
             if isinstance(data, MultiIndex):
-                raise NotImplementedError
+                raise NotImplementedError("initializing a Series from a "
+                                          "MultiIndex is not supported")
             elif isinstance(data, Index):
                 # need to copy to avoid aliasing issues
                 if name is None:

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -19,6 +19,7 @@ from pandas.compat import (lrange, lmap, u, string_types, iteritems,
                            raise_with_traceback, binary_type)
 from pandas.core import common as com
 from pandas import Series
+from pandas.core.common import AbstractMethodError
 
 _IMPORTS = False
 _HAS_BS4 = False
@@ -229,7 +230,7 @@ class _HtmlFrameParser(object):
         text : str or unicode
             The text from an individual DOM node.
         """
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     def _parse_td(self, obj):
         """Return the td elements from a row element.
@@ -243,7 +244,7 @@ class _HtmlFrameParser(object):
         columns : list of node-like
             These are the elements of each row, i.e., the columns.
         """
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     def _parse_tables(self, doc, match, attrs):
         """Return all tables from the parsed DOM.
@@ -270,7 +271,7 @@ class _HtmlFrameParser(object):
         tables : list of node-like
             A list of <table> elements to be parsed into raw data.
         """
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     def _parse_tr(self, table):
         """Return the list of row elements from the parsed table element.
@@ -285,7 +286,7 @@ class _HtmlFrameParser(object):
         rows : list of node-like
             A list row elements of a table, usually <tr> or <th> elements.
         """
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     def _parse_thead(self, table):
         """Return the header of a table.
@@ -300,7 +301,7 @@ class _HtmlFrameParser(object):
         thead : node-like
             A <thead>...</thead> element.
         """
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     def _parse_tbody(self, table):
         """Return the body of the table.
@@ -315,7 +316,7 @@ class _HtmlFrameParser(object):
         tbody : node-like
             A <tbody>...</tbody> element.
         """
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     def _parse_tfoot(self, table):
         """Return the footer of the table if any.
@@ -330,7 +331,7 @@ class _HtmlFrameParser(object):
         tfoot : node-like
             A <tfoot>...</tfoot> element.
         """
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     def _build_doc(self):
         """Return a tree-like object that can be used to iterate over the DOM.
@@ -339,7 +340,7 @@ class _HtmlFrameParser(object):
         -------
         obj : tree-like
         """
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     def _build_table(self, table):
         header = self._parse_raw_thead(table)

--- a/pandas/io/json.py
+++ b/pandas/io/json.py
@@ -11,6 +11,7 @@ from pandas.compat import long, u
 from pandas import compat, isnull
 from pandas import Series, DataFrame, to_datetime
 from pandas.io.common import get_filepath_or_buffer
+from pandas.core.common import AbstractMethodError
 import pandas.core.common as com
 
 loads = _json.loads
@@ -33,7 +34,7 @@ def to_json(path_or_buf, obj, orient=None, date_format='epoch',
             double_precision=double_precision, ensure_ascii=force_ascii,
             date_unit=date_unit, default_handler=default_handler).write()
     else:
-        raise NotImplementedError
+        raise NotImplementedError("'obj' should be a Series or a DataFrame")
 
     if isinstance(path_or_buf, compat.string_types):
         with open(path_or_buf, 'w') as fh:
@@ -64,7 +65,7 @@ class Writer(object):
         self._format_axes()
 
     def _format_axes(self):
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     def write(self):
         return dumps(
@@ -282,7 +283,7 @@ class Parser(object):
                 setattr(self.obj, axis, new_axis)
 
     def _try_convert_types(self):
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     def _try_convert_data(self, name, data, use_dtypes=True,
                           convert_dates=True):
@@ -395,7 +396,7 @@ class Parser(object):
         return data, False
 
     def _try_convert_dates(self):
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
 
 class SeriesParser(Parser):

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -14,6 +14,7 @@ from pandas.core.index import Index, MultiIndex
 from pandas.core.frame import DataFrame
 import datetime
 import pandas.core.common as com
+from pandas.core.common import AbstractMethodError
 from pandas.core.config import get_option
 from pandas.io.date_converters import generic_parser
 from pandas.io.common import get_filepath_or_buffer
@@ -707,7 +708,7 @@ class TextFileReader(object):
             self._engine = klass(self.f, **self.options)
 
     def _failover_to_python(self):
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     def read(self, nrows=None):
         if nrows is not None:

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -531,7 +531,8 @@ def to_sql(frame, name, con, flavor='sqlite', schema=None, if_exists='fail',
     if isinstance(frame, Series):
         frame = frame.to_frame()
     elif not isinstance(frame, DataFrame):
-        raise NotImplementedError
+        raise NotImplementedError("'frame' argument should be either a "
+                                  "Series or a DataFrame")
 
     pandas_sql.to_sql(frame, name, if_exists=if_exists, index=index,
                       index_label=index_label, schema=schema,
@@ -1434,7 +1435,8 @@ class SQLiteDatabase(PandasSQL):
         if flavor is None:
             flavor = 'sqlite'
         if flavor not in ['sqlite', 'mysql']:
-            raise NotImplementedError
+            raise NotImplementedError("flavors other than SQLite and MySQL "
+                                      "are not supported")
         else:
             self.flavor = flavor
 

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -418,7 +418,7 @@ class SparseDataFrame(DataFrame):
         new_index, new_columns = this.index, this.columns
 
         if level is not None:
-            raise NotImplementedError
+            raise NotImplementedError("'level' argument is not supported")
 
         if self.empty and other.empty:
             return SparseDataFrame(index=new_index).__finalize__(self)
@@ -459,9 +459,9 @@ class SparseDataFrame(DataFrame):
         new_data = {}
 
         if fill_value is not None:
-            raise NotImplementedError
+            raise NotImplementedError("'fill_value' argument is not supported")
         if level is not None:
-            raise NotImplementedError
+            raise NotImplementedError("'level' argument is not supported")
 
         new_index = self.index.union(other.index)
         this = self
@@ -494,9 +494,9 @@ class SparseDataFrame(DataFrame):
         # possible for this to happen, which is bothersome
 
         if fill_value is not None:
-            raise NotImplementedError
+            raise NotImplementedError("'fill_value' argument is not supported")
         if level is not None:
-            raise NotImplementedError
+            raise NotImplementedError("'level' argument is not supported")
 
         new_data = {}
 
@@ -567,10 +567,10 @@ class SparseDataFrame(DataFrame):
             raise TypeError('Reindex by level not supported for sparse')
 
         if com.notnull(fill_value):
-            raise NotImplementedError
+            raise NotImplementedError("'fill_value' argument is not supported")
 
         if limit:
-            raise NotImplementedError
+            raise NotImplementedError("'limit' argument is not supported")
 
         # TODO: fill value handling
         sdict = dict((k, v) for k, v in compat.iteritems(self) if k in columns)

--- a/pandas/sparse/panel.py
+++ b/pandas/sparse/panel.py
@@ -32,7 +32,7 @@ class SparsePanelAxis(object):
         value = _ensure_index(value)
 
         if isinstance(value, MultiIndex):
-            raise NotImplementedError
+            raise NotImplementedError("value cannot be a MultiIndex")
 
         for v in compat.itervalues(obj._frames):
             setattr(v, self.frame_attr, value)
@@ -159,7 +159,7 @@ class SparsePanel(Panel):
     def _set_items(self, new_items):
         new_items = _ensure_index(new_items)
         if isinstance(new_items, MultiIndex):
-            raise NotImplementedError
+            raise NotImplementedError("itemps cannot be a MultiIndex")
 
         # need to create new frames dict
 

--- a/pandas/src/generate_code.py
+++ b/pandas/src/generate_code.py
@@ -1653,7 +1653,8 @@ def group_ohlc_%(name)s(ndarray[%(dest_type2)s, ndim=2] out,
 
     b = 0
     if K > 1:
-        raise NotImplementedError
+        raise NotImplementedError("Argument 'values' must have only "
+                                  "one dimension")
     else:
         for i in range(N):
             while b < ngroups - 1 and i >= bins[b]:

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from pandas.util.decorators import cache_readonly, deprecate_kwarg
 import pandas.core.common as com
+from pandas.core.common import AbstractMethodError
 from pandas.core.generic import _shared_docs, _shared_doc_kwargs
 from pandas.core.index import Index, MultiIndex
 from pandas.core.series import Series, remove_na
@@ -131,7 +132,7 @@ def _get_standard_colors(num_colors=None, colormap=None, color_type='default',
 
             colors = lmap(random_color, lrange(num_colors))
         else:
-            raise NotImplementedError
+            raise ValueError("color_type must be either 'default' or 'random'")
 
     if len(colors) != num_colors:
         multiple = num_colors//len(colors) - 1
@@ -1017,7 +1018,7 @@ class MPLPlot(object):
         self.data = numeric_data
 
     def _make_plot(self):
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     def _add_table(self):
         if self.table is False:
@@ -1821,7 +1822,7 @@ class BarPlot(MPLPlot):
                 start = start + self.left
                 return ax.barh(x, y, w, left=start, **kwds)
         else:
-            raise NotImplementedError
+            raise ValueError("BarPlot kind must be either 'bar' or 'barh'")
 
         return f
 

--- a/pandas/tseries/base.py
+++ b/pandas/tseries/base.py
@@ -8,7 +8,7 @@ from datetime import datetime, time, timedelta
 from pandas import compat
 import numpy as np
 from pandas.core import common as com
-from pandas.core.common import is_integer, is_float
+from pandas.core.common import is_integer, is_float, AbstractMethodError
 import pandas.tslib as tslib
 import pandas.lib as lib
 from pandas.core.index import Index
@@ -48,7 +48,7 @@ class DatetimeIndexOpsMixin(object):
         """
         box function to get object from internal representation
         """
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     def _box_values(self, values):
         """
@@ -261,7 +261,7 @@ class DatetimeIndexOpsMixin(object):
         return str
 
     def _format_footer(self):
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     def __unicode__(self):
         formatter = self._formatter_func
@@ -314,10 +314,10 @@ class DatetimeIndexOpsMixin(object):
         return super(DatetimeIndexOpsMixin, self)._convert_scalar_indexer(key, kind=kind)
 
     def _add_datelike(self, other):
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     def _sub_datelike(self, other):
-        raise NotImplementedError
+        raise AbstractMethodError(self)
 
     @classmethod
     def _add_datetimelike_methods(cls):

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1655,14 +1655,15 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
         from dateutil.parser import parse
 
         if asof:
-            raise NotImplementedError
+            raise NotImplementedError("'asof' argument is not supported")
 
         if isinstance(time, compat.string_types):
             time = parse(time).time()
 
         if time.tzinfo:
             # TODO
-            raise NotImplementedError
+            raise NotImplementedError("argument 'time' with timezone info is "
+                                      "not supported")
 
         time_micros = self._get_time_micros()
         micros = _time_to_micros(time)
@@ -1694,7 +1695,8 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
             end_time = parse(end_time).time()
 
         if start_time.tzinfo or end_time.tzinfo:
-            raise NotImplementedError
+            raise NotImplementedError("argument 'time' with timezone info is "
+                                      "not supported")
 
         time_micros = self._get_time_micros()
         start_micros = _time_to_micros(start_time)
@@ -1773,7 +1775,8 @@ def _generate_regular_range(start, end, periods, offset):
             b = e - np.int64(periods) * stride
             tz = end.tz
         else:
-            raise NotImplementedError
+            raise ValueError("at least 'start' or 'end' should be specified "
+                             "if a 'period' is given.")
 
         data = np.arange(b, e, stride, dtype=np.int64)
         data = DatetimeIndex._simple_new(data, None, tz=tz)

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -373,11 +373,11 @@ def _take_new_index(obj, indexer, new_index, axis=0):
         return Series(new_values, index=new_index, name=obj.name)
     elif isinstance(obj, DataFrame):
         if axis == 1:
-            raise NotImplementedError
+            raise NotImplementedError("axis 1 is not supported")
         return DataFrame(obj._data.reindex_indexer(
             new_axis=new_index, indexer=indexer, axis=1))
     else:
-        raise NotImplementedError
+        raise ValueError("'obj' should be either a Series or a DataFrame")
 
 
 def _get_range_edges(first, last, offset, closed='left', base=0):
@@ -467,7 +467,7 @@ def asfreq(obj, freq, method=None, how=None, normalize=False):
     """
     if isinstance(obj.index, PeriodIndex):
         if method is not None:
-            raise NotImplementedError
+            raise NotImplementedError("'method' argument is not supported")
 
         if how is None:
             how = 'E'

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -927,7 +927,8 @@ def _generate_regular_range(start, end, periods, offset):
         e = Timedelta(end).value + stride
         b = e - periods * stride
     else:
-        raise NotImplementedError
+        raise ValueError("at least 'start' or 'end' should be specified "
+                         "if a 'period' is given.")
 
     data = np.arange(b, e, stride, dtype=np.int64)
     data = TimedeltaIndex._simple_new(data, None)


### PR DESCRIPTION
This issue fixes #7872 by either describing the reason why a NotImplementedError is raised,
or by throwing an AbstractMethodError in the case of abstract methods (eg: Mixins) that
should be overwritten by the inheriting classes.

This issue is based on discussion of PR #7899 which was never merged.
