### PR TITLE
ENH: allow Panel.shift on items axis

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -52,6 +52,7 @@ Enhancements
 - ``Period`` now accepts ``datetime64`` as value input. (:issue:`9054`)
 
 - Allow timedelta string conversion when leading zero is missing from time definition, ie `0:00:00` vs `00:00:00`. (:issue:`9570`)
+- Allow Panel.shift with ``axis='items'`` (:issue:`9890`)
 
 .. _whatsnew_0161.api:
 

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -1184,13 +1184,17 @@ class Panel(NDFrame):
     @deprecate_kwarg(old_arg_name='lags', new_arg_name='periods')
     def shift(self, periods=1, freq=None, axis='major'):
         """
-        Shift major or minor axis by specified number of leads/lags. Drops
-        periods right now compared with DataFrame.shift
+        Shift index by desired number of periods with an optional time freq.
+        The shifted data will not include the dropped periods and the
+        shifted axis will be smaller than the original. This is different
+        from the behavior of DataFrame.shift()
 
         Parameters
         ----------
-        lags : int
-        axis : {'major', 'minor'}
+        periods : int
+            Number of periods to move, can be positive or negative
+        freq : DateOffset, timedelta, or time rule string, optional
+        axis : {'items', 'major', 'minor'} or {0, 1, 2}
 
         Returns
         -------
@@ -1198,9 +1202,6 @@ class Panel(NDFrame):
         """
         if freq:
             return self.tshift(periods, freq, axis=axis)
-
-        if axis == 'items':
-            raise ValueError('Invalid axis')
 
         return super(Panel, self).slice_shift(periods, axis=axis)
 

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1696,22 +1696,23 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         # major
         idx = self.panel.major_axis[0]
         idx_lag = self.panel.major_axis[1]
-
         shifted = self.panel.shift(1)
-
         assert_frame_equal(self.panel.major_xs(idx),
                            shifted.major_xs(idx_lag))
 
         # minor
         idx = self.panel.minor_axis[0]
         idx_lag = self.panel.minor_axis[1]
-
         shifted = self.panel.shift(1, axis='minor')
-
         assert_frame_equal(self.panel.minor_xs(idx),
                            shifted.minor_xs(idx_lag))
 
-        self.assertRaises(Exception, self.panel.shift, 1, axis='items')
+        # items
+        idx = self.panel.items[0]
+        idx_lag = self.panel.items[1]
+        shifted = self.panel.shift(1, axis='items')
+        assert_frame_equal(self.panel[idx],
+                           shifted[idx_lag])
 
         # negative numbers, #2164
         result = self.panel.shift(-1)


### PR DESCRIPTION
I'm not sure why `Panel.shift` currently raises with `axis='items'`, while `axis=0` works.

This PR enables `axis='items'` and also updates the docstring to show the parameter `periods` instead of the deprecated `lags`
