### PR TITLE
ENH: Intuitive Barplot Series Ordering

### DIFF
--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1874,8 +1874,11 @@ class BarPlot(MPLPlot):
                 neg_prior = neg_prior + np.where(mask, 0, y)
             else:
                 w = self.bar_width / K
-                rect = bar_f(ax, self.ax_pos + (i + 0.5) * w, y, w,
-                             start=start, label=label, **kwds)
+                if self.kind == 'barh':
+                    x = self.ax_pos - (i + 0.5) * w + 0.5
+                else:
+                    x = self.ax_pos + (i + 0.5) * w
+                rect = bar_f(ax, x, y, w, start=start, label=label, **kwds)
             self._add_legend_handle(rect, label, index=i)
 
     def _post_plot_logic(self):


### PR DESCRIPTION
Modifies the horizontal bar plot behavior to plot series in order from top-to-bottom.

Plotting a regular bar graph from a DataFrame object will plot each series of data from left-to-right in the same order as presented in the legend from top-to-bottom. When plotting a horizontal bar graph the series of data are plotted from bottom-to-top, which is the reverse of the legend and unintuitive. 

Pandas allows a `legend='reverse'` option which reverses the order of the legend and preserves series colors, but does not fix the unintuitive bottom-to-top ordering of series.
###### Pandas Standard `barh` Behavior:

![original_behaviour](https://cloud.githubusercontent.com/assets/3064019/7130265/1a2724a0-e23b-11e4-8940-9f54d8cd14c2.png)
###### Desired `barh` Behavior:

![alternate_behaviour](https://cloud.githubusercontent.com/assets/3064019/7130270/324a4242-e23b-11e4-9b29-f4bcb60c3b14.png)
###### Pandas Standard `barh` `legend='reverse'` Behavior:

![reversed_legend](https://cloud.githubusercontent.com/assets/3064019/7130274/4b5d2ec0-e23b-11e4-88e4-48e938c8e7a8.png)
