### PR TITLE
ENH/BUG: color cannot be applied to line subplots

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -87,6 +87,8 @@ Other enhancements
 Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+- Line and kde plot with ``subplots=True`` now uses default colors, not all black. Specify ``color='k'`` to draw all lines in black (:issue:`9894`)
+
 .. _whatsnew_0170.api_breaking.convert_objects:
 
 Changes to convert_objects
@@ -341,6 +343,7 @@ Bug Fixes
 - Bug in ``Index.drop_duplicates`` dropping name(s) (:issue:`10115`)
 - Bug in ``pd.Series`` when setting a value on an empty ``Series`` whose index has a frequency. (:issue:`10193`)
 - Bug in ``DataFrame.plot`` raises ``ValueError`` when color name is specified by multiple characters (:issue:`10387`)
+
 - Bug in ``DataFrame.reset_index`` when index contains `NaT`. (:issue:`10388`)
 - Bug in ``ExcelReader`` when worksheet is empty (:issue:`6403`)
 - Bug in ``Table.select_column`` where name is not preserved (:issue:`10392`)
@@ -381,7 +384,8 @@ Bug Fixes
 
 
 
-
+- Bug in line and kde plot cannot accept multiple colors when ``subplots=True`` (:issue:`9894`)
+- Bug in ``DataFrame.plot`` raises ``ValueError`` when color name is specified by multiple characters (:issue:`10387`)
 
 
 

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -2593,6 +2593,67 @@ class TestDataFramePlots(TestPlotBase):
         tm.close()
 
     @slow
+    def test_line_colors_and_styles_subplots(self):
+        # GH 9894
+        from matplotlib import cm
+        default_colors = self.plt.rcParams.get('axes.color_cycle')
+
+        df = DataFrame(randn(5, 5))
+
+        axes = df.plot(subplots=True)
+        for ax, c in zip(axes, list(default_colors)):
+            self._check_colors(ax.get_lines(), linecolors=c)
+        tm.close()
+
+        # single color char
+        axes = df.plot(subplots=True, color='k')
+        for ax in axes:
+            self._check_colors(ax.get_lines(), linecolors=['k'])
+        tm.close()
+
+        # single color str
+        axes = df.plot(subplots=True, color='green')
+        for ax in axes:
+            self._check_colors(ax.get_lines(), linecolors=['green'])
+        tm.close()
+
+        custom_colors = 'rgcby'
+        axes = df.plot(color=custom_colors, subplots=True)
+        for ax, c in zip(axes, list(custom_colors)):
+            self._check_colors(ax.get_lines(), linecolors=[c])
+        tm.close()
+
+        axes = df.plot(color=list(custom_colors), subplots=True)
+        for ax, c in zip(axes, list(custom_colors)):
+            self._check_colors(ax.get_lines(), linecolors=[c])
+        tm.close()
+
+        rgba_colors = lmap(cm.jet, np.linspace(0, 1, len(df)))
+        for cmap in ['jet', cm.jet]:
+            axes = df.plot(colormap=cmap, subplots=True)
+            for ax, c in zip(axes, rgba_colors):
+                self._check_colors(ax.get_lines(), linecolors=[c])
+            tm.close()
+
+        # make color a list if plotting one column frame
+        # handles cases like df.plot(color='DodgerBlue')
+        axes = df.ix[:, [0]].plot(color='DodgerBlue', subplots=True)
+        self._check_colors(axes[0].lines, linecolors=['DodgerBlue'])
+
+        # single character style
+        axes = df.plot(style='r', subplots=True)
+        for ax in axes:
+            self._check_colors(ax.get_lines(), linecolors=['r'])
+        tm.close()
+
+        # list of styles
+        styles = list('rgcby')
+        axes = df.plot(style=styles, subplots=True)
+        for ax, c in zip(axes, styles):
+            self._check_colors(ax.get_lines(), linecolors=[c])
+        tm.close()
+
+    @slow
     def test_area_colors(self):
         from matplotlib import cm
         from matplotlib.collections import PolyCollection
@@ -2693,6 +2754,64 @@ class TestDataFramePlots(TestPlotBase):
         ax = df.plot(kind='kde', colormap=cm.jet)
         rgba_colors = lmap(cm.jet, np.linspace(0, 1, len(df)))
         self._check_colors(ax.get_lines(), linecolors=rgba_colors)
+
+    @slow
+    def test_kde_colors_and_styles_subplots(self):
+        tm._skip_if_no_scipy()
+        _skip_if_no_scipy_gaussian_kde()
+
+        from matplotlib import cm
+        default_colors = self.plt.rcParams.get('axes.color_cycle')
+
+        df = DataFrame(randn(5, 5))
+
+        axes = df.plot(kind='kde', subplots=True)
+        for ax, c in zip(axes, list(default_colors)):
+            self._check_colors(ax.get_lines(), linecolors=[c])
+        tm.close()
+
+        # single color char
+        axes = df.plot(kind='kde', color='k', subplots=True)
+        for ax in axes:
+            self._check_colors(ax.get_lines(), linecolors=['k'])
+        tm.close()
+
+        # single color str
+        axes = df.plot(kind='kde', color='red', subplots=True)
+        for ax in axes:
+            self._check_colors(ax.get_lines(), linecolors=['red'])
+        tm.close()
+
+        custom_colors = 'rgcby'
+        axes = df.plot(kind='kde', color=custom_colors, subplots=True)
+        for ax, c in zip(axes, list(custom_colors)):
+            self._check_colors(ax.get_lines(), linecolors=[c])
+        tm.close()
+
+        rgba_colors = lmap(cm.jet, np.linspace(0, 1, len(df)))
+        for cmap in ['jet', cm.jet]:
+            axes = df.plot(kind='kde', colormap=cmap, subplots=True)
+            for ax, c in zip(axes, rgba_colors):
+                self._check_colors(ax.get_lines(), linecolors=[c])
+            tm.close()
+
+        # make color a list if plotting one column frame
+        # handles cases like df.plot(color='DodgerBlue')
+        axes = df.ix[:, [0]].plot(kind='kde', color='DodgerBlue', subplots=True)
+        self._check_colors(axes[0].lines, linecolors=['DodgerBlue'])
+
+        # single character style
+        axes = df.plot(kind='kde', style='r', subplots=True)
+        for ax in axes:
+            self._check_colors(ax.get_lines(), linecolors=['r'])
+        tm.close()
+
+        # list of styles
+        styles = list('rgcby')
+        axes = df.plot(kind='kde', style=styles, subplots=True)
+        for ax, c in zip(axes, styles):
+            self._check_colors(ax.get_lines(), linecolors=[c])
+        tm.close()
 
     @slow
     def test_boxplot_colors(self):


### PR DESCRIPTION
Specifying `subplots=True` in line and kde plot draws all lines in black, and may not accept colors and styles keyword. Summarized a table to compare current / expected (fixed) behaviour.

Sample data:

```
df = pd.DataFrame(np.random.randn(10, 3))
```

| Command | Current Behavior | Expected Behavior |
| --- | --- | --- |
| `df.plot(subplots=True)` | All 3 lines are in black (OK) | 3 lines are in default color cycle. |
| `df.plot(style='r', subplots=True)` | All 3 lines are in red (OK) | No change |
| `df.plot(color='r', subplots=True)` | All 3 lines are in red (OK) | No change |
| `df.plot(color='red', subplots=True)` | All 3 lines are in red (OK) (thanks to #10387) | No change |
| `df.plot(color=['r', 'g', 'b'], subplots=True)` | ValueError: to_rgba: Invalid rgba arg "['r', 'g', 'b']" (NG) | 3 lines are drawn in red, green, blue |
| `df.plot(style=['r', 'g', 'b'], subplots=True)` | 3 lines are drawn in red, green, blue (OK) | No change |
