### PR TITLE
ENH: repr now shows index name #6482

### DIFF
--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -412,7 +412,13 @@ class Index(IndexOpsMixin, PandasObject):
         """
         prepr = com.pprint_thing(self, escape_chars=('\t', '\r', '\n'),
                                  quote_strings=True)
-        return "%s(%s, dtype='%s')" % (type(self).__name__, prepr, self.dtype)
+
+        name_attr=''
+        if self.name:
+            name_attr = u(" %s=%r,") % ('name', self.name)
+
+        return "%s(%s,%s dtype='%s')" % (type(self).__name__,
+                prepr, name_attr, self.dtype)
 
     def to_series(self, **kwargs):
         """


### PR DESCRIPTION
Let me know if that is not good enough, I played around with indenting it but it doesn't look good with big indexes.

This, current:
![screen shot 2015-04-14 at 11 06 30 am](https://cloud.githubusercontent.com/assets/1778723/7139869/836ff68e-e296-11e4-89d9-9512df67b150.png)
vs with indention
![screen shot 2015-04-14 at 11 07 18 am](https://cloud.githubusercontent.com/assets/1778723/7139870/8370d48c-e296-11e4-8fc6-65d5b9fe725d.png)
