### PR TITLE
Use 'python-dateutil' instead of 'dateutil' for requirement files

### DIFF
--- a/ci/requirements-2.7_32.txt
+++ b/ci/requirements-2.7_32.txt
@@ -1,4 +1,4 @@
-dateutil
+python-dateutil
 pytz
 xlwt
 numpy

--- a/ci/requirements-2.7_64.txt
+++ b/ci/requirements-2.7_64.txt
@@ -1,4 +1,4 @@
-dateutil
+python-dateutil
 pytz
 xlwt
 numpy

--- a/ci/requirements-2.7_LOCALE.txt
+++ b/ci/requirements-2.7_LOCALE.txt
@@ -1,4 +1,4 @@
-dateutil
+python-dateutil
 pytz=2013b
 xlwt=0.7.5
 openpyxl=1.6.2

--- a/ci/requirements-2.7_SLOW.txt
+++ b/ci/requirements-2.7_SLOW.txt
@@ -1,4 +1,4 @@
-dateutil
+python-dateutil
 pytz
 numpy
 cython

--- a/ci/requirements-3.3.txt
+++ b/ci/requirements-3.3.txt
@@ -1,4 +1,4 @@
-dateutil
+python-dateutil
 pytz=2013b
 openpyxl=1.6.2
 xlsxwriter=0.4.6

--- a/ci/requirements-3.4.txt
+++ b/ci/requirements-3.4.txt
@@ -1,4 +1,4 @@
-dateutil
+python-dateutil
 pytz
 openpyxl
 xlsxwriter

--- a/ci/requirements-3.4_32.txt
+++ b/ci/requirements-3.4_32.txt
@@ -1,4 +1,4 @@
-dateutil
+python-dateutil
 pytz
 openpyxl
 xlrd

--- a/ci/requirements-3.4_64.txt
+++ b/ci/requirements-3.4_64.txt
@@ -1,4 +1,4 @@
-dateutil
+python-dateutil
 pytz
 openpyxl
 xlrd

--- a/ci/requirements-3.4_SLOW.txt
+++ b/ci/requirements-3.4_SLOW.txt
@@ -1,4 +1,4 @@
-dateutil
+python-dateutil
 pytz
 openpyxl
 xlsxwriter

--- a/ci/requirements_all.txt
+++ b/ci/requirements_all.txt
@@ -1,7 +1,7 @@
 nose
 sphinx
 ipython
-dateutil
+python-dateutil
 pytz
 openpyxl
 xlsxwriter

--- a/ci/requirements_dev.txt
+++ b/ci/requirements_dev.txt
@@ -1,4 +1,4 @@
-dateutil
+python-dateutil
 pytz
 numpy
 cython


### PR DESCRIPTION
The former also is known to the 'pip install' command, and still works with conda install. Making requirements files compatible with 'pip install' is more relevant now that packages like numpy have a (binary) wheel available.
