### PR TITLE
str'ified column names in DataFrame.to_hdf(); Fixes #9057

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1766,7 +1766,7 @@ class DataCol(IndexCol):
 
             # set my typ if we need
             if self.typ is None:
-                self.typ = getattr(self.description, self.cname, None)
+                self.typ = getattr(self.description, str(self.cname), None)
 
     def set_atom(self, block, block_items, existing_col, min_itemsize,
                  nan_rep, info, encoding=None, **kwargs):
@@ -3018,6 +3018,8 @@ class Table(Fixed):
 
     def read_metadata(self, key):
         """ return the meta data array for this key """
+        if str(key) != key:
+            key = str(key)
         if getattr(getattr(self.group,'meta',None),key,None) is not None:
             return self.parent.select(self._get_metadata_path(key))
         return None
@@ -3157,6 +3159,8 @@ class Table(Fixed):
 
         table = self.table
         for c in columns:
+            if str(c) != c:
+                c = str(c)
             v = getattr(table.cols, c, None)
             if v is not None:
 
@@ -3518,6 +3522,11 @@ class Table(Fixed):
 
         # description from the axes & values
         d['description'] = dict([(a.cname, a.typ) for a in self.axes])
+
+        # keys to pytables columns must be strings
+        for a in self.axes:
+            if str(a.cname) != a.cname:
+                d['description'][str(a.cname)] = d['description'].pop(a.cname)
 
         if complib:
             if complevel is None:

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -14,7 +14,6 @@ import functools
 import itertools
 from itertools import product, permutations
 from distutils.version import LooseVersion
-from tempfile import NamedTemporaryFile
 
 from pandas.compat import(
     map, zip, range, long, lrange, lmap, lzip,
@@ -14205,36 +14204,6 @@ starting,ending,measure
         self.assertEqual(df.iloc[[0, 1], :].testattr, 'XXX')
         # GH9776
         self.assertEqual(df.iloc[0:1, :].testattr, 'XXX')
-
-def skip_if_no_pytables():
-    try:
-        import tables
-    except ImportError:
-        raise nose.SkipTest("cannot check test results without pytables")
-
-
-class TestToHdfWithIntegerColumnNames(tm.TestCase):
-    # GH9057
-    def setUp(self):
-        N = 2
-        array = np.random.randint(0,8, size=N*N).astype('uint8').reshape(N,-1)
-        df = DataFrame(array, index=pd.date_range('20130206',
-                                                  periods=N,freq='ms'))
-
-        self.filename = NamedTemporaryFile(suffix='.h5', delete=False).name
-        df.to_hdf(self.filename,'df', mode='w', format='table',
-                  data_columns=True)
-
-    def test_file_is_openable(self):
-        skip_if_no_pytables()
-        import tables
-
-        with tables.open_file(self.filename, 'r') as myfile:
-            stuff = myfile.root.df
-            assert stuff
-
-    def tearDown(self):
-        os.remove(self.filename)
 
 def skip_if_no_ne(engine='numexpr'):
     if engine == 'numexpr':

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from copy import deepcopy
 from datetime import datetime, timedelta, time
 import sys
+import os
 import operator
 import re
 import csv
@@ -13,6 +14,7 @@ import functools
 import itertools
 from itertools import product, permutations
 from distutils.version import LooseVersion
+from tempfile import NamedTemporaryFile
 
 from pandas.compat import(
     map, zip, range, long, lrange, lmap, lzip,
@@ -14204,6 +14206,35 @@ starting,ending,measure
         # GH9776
         self.assertEqual(df.iloc[0:1, :].testattr, 'XXX')
 
+def skip_if_no_pytables():
+    try:
+        import tables
+    except ImportError:
+        raise nose.SkipTest("cannot check test results without pytables")
+
+
+class TestToHdfWithIntegerColumnNames(tm.TestCase):
+    # GH9057
+    def setUp(self):
+        N = 2
+        array = np.random.randint(0,8, size=N*N).astype('uint8').reshape(N,-1)
+        df = DataFrame(array, index=pd.date_range('20130206',
+                                                  periods=N,freq='ms'))
+
+        self.filename = NamedTemporaryFile(suffix='.h5', delete=False).name
+        df.to_hdf(self.filename,'df', mode='w', format='table',
+                  data_columns=True)
+
+    def test_file_is_openable(self):
+        skip_if_no_pytables()
+        import tables
+
+        with tables.open_file(self.filename, 'r') as myfile:
+            stuff = myfile.root.df
+            assert stuff
+
+    def tearDown(self):
+        os.remove(self.filename)
 
 def skip_if_no_ne(engine='numexpr'):
     if engine == 'numexpr':


### PR DESCRIPTION
closes #9057

Converted column names to strings before creating pytables metadata object

This brute force `str()`ing method _might_ not be the best approach, but AFAIK it hasn't broken any of the tests.
