### PR TITLE
DatetimeIndex 0 length shift (GH9903)

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -174,6 +174,7 @@ Performance Improvements
 Bug Fixes
 ~~~~~~~~~
 
+- Bug in `DatetimeIndex.shift` where shifting an empty index would downcast to an `Index` instead of a `DatetimeIndex`.
 - Fixed bug (:issue:`9542`) where labels did not appear properly in legend of ``DataFrame.plot()``. Passing ``label=`` args also now works, and series indices are no longer mutated.
 - Bug in json serialization when frame has length zero.(:issue:`9805`)
 - Bug in `read_csv` where missing trailing delimiters would cause segfault. (:issue:`5664`)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1163,7 +1163,12 @@ class Index(IndexOpsMixin, PandasObject):
             return self
 
         offset = periods * freq
-        return Index([idx + offset for idx in self], name=self.name)
+        # If this is called from a subclass override, it shouldn't change the
+        # type.
+        return type(self)(
+            [idx + offset for idx in self],
+            **self._get_attributes_dict()
+        )
 
     def argsort(self, *args, **kwargs):
         """

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -324,7 +324,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     def _get_attributes_dict(self):
         """ return an attributes dict for my class """
-        return dict([ (k,getattr(self,k,None)) for k in self._attributes])
+        return dict((k, getattr(self, k, None)) for k in self._attributes)
 
     def view(self, cls=None):
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1163,11 +1163,12 @@ class Index(IndexOpsMixin, PandasObject):
             return self
 
         offset = periods * freq
-        # If this is called from a subclass override, it shouldn't change the
-        # type.
-        return type(self)(
-            [idx + offset for idx in self],
-            **self._get_attributes_dict()
+        return self._shallow_copy(
+            np.array(
+                [val + offset for val in self],
+                dtype=self.dtype,
+                copy=False,
+            )
         )
 
     def argsort(self, *args, **kwargs):

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -203,7 +203,6 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
 
         dayfirst = kwargs.pop('dayfirst', None)
         yearfirst = kwargs.pop('yearfirst', None)
-
         freq_infer = False
         if not isinstance(freq, DateOffset):
 
@@ -254,7 +253,10 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
                         data.name = name
 
                     if tz is not None:
-                        return data.tz_localize(tz, ambiguous=ambiguous)
+                        if data.tz is None:
+                            return data.tz_localize(tz, ambiguous=ambiguous)
+                        else:
+                            return data.tz_convert(tz)
 
                     return data
 

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -302,6 +302,12 @@ Freq: H"""
                                        ['2015', '2015', '2016'], ['2015', '2015', '2014'])):
             tm.assertIn(idx[0], idx)
 
+    def test_shift_empty_index(self):
+        # GH 9903
+        idx = DatetimeIndex([], tz='UTC')
+        shifted = idx.shift(1, freq='10T')
+        tm.assert_index_equal(idx, shifted)
+
 
 class TestTimedeltaIndexOps(Ops):
 

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -709,7 +709,9 @@ class TestTimeZoneSupportPytz(tm.TestCase):
             # or not.
             np.testing.assert_array_equal(
                 (result - range_).minute,
-                np.full((len(dr)), 10, dtype='int32'),
+                # This would be marginally more efficient with np.fill, but it
+                # doesn't exist until numpy 1.8.0.
+                np.ones(len(dr), dtype='int32') * 10,
             )
 
     def test_tz_aware_asfreq(self):

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -701,8 +701,16 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         dr = date_range('2011/1/1', '2012/1/1', freq='W-FRI')
         dr_tz = dr.tz_localize(self.tzstr('US/Eastern'))
 
-        result = dr_tz.shift(1, '10T')
-        self.assertEqual(result.tz, dr_tz.tz)
+        for range_ in (dr, dr_tz):
+            result = range_.shift(1, '10T')
+            self.assertEqual(result.tz, range_.tz)
+
+            # Results should be 10 minutes apart whether the range is localized
+            # or not.
+            np.testing.assert_array_equal(
+                (result - range_).minute,
+                np.full((len(dr)), 10, dtype='int32'),
+            )
 
     def test_tz_aware_asfreq(self):
         dr = date_range(


### PR DESCRIPTION
closes #9903 

Fixes a bug where calling shift on an empty DatetimeIndex would result in the returned value being an Index rather than a DatetimeIndex.
