### PR TITLE
TST: adding sdist and install tests to the 2.6 regression - closes #9878

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
       - LOCALE_OVERRIDE="it_IT.UTF-8"
       - BUILD_TYPE=conda
       - JOB_NAME: "26_nslow_nnet"
+      - INSTALL_TEST=true
     - python: 2.7
       env:
       - NOSE_ARGS="slow and not network and not disabled"
@@ -183,6 +184,7 @@ script:
 # nothing here, or failed tests won't fail travis
 
 after_script:
+  - ci/install_test.sh
   - if [ -f /tmp/doc.log ]; then cat /tmp/doc.log; fi
   - source activate pandas && ci/print_versions.py
   - ci/print_skipped.py /tmp/nosetests.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
       - LOCALE_OVERRIDE="it_IT.UTF-8"
       - BUILD_TYPE=conda
       - JOB_NAME: "26_nslow_nnet"
+      - INSTALL_TEST=true
     - python: 2.7
       env:
       - NOSE_ARGS="slow and not network and not disabled"

--- a/ci/install_test.sh
+++ b/ci/install_test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "inside $0"
+
+if [ "$INSTALL_TEST" ]; then
+    source activate pandas
+    echo "Starting installation test."
+    conda uninstall cython || exit 1
+    python "$TRAVIS_BUILD_DIR"/setup.py sdist --formats=zip,gztar || exit 1
+    pip install "$TRAVIS_BUILD_DIR"/dist/*tar.gz || exit 1
+    nosetests --exe -A "$NOSE_ARGS" pandas/tests/test_series.py --with-xunit --xunit-file=/tmp/nosetests_install.xml
+else
+    echo "Skipping installation test."
+fi
+RET="$?"
+
+exit "$RET"

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -23,6 +23,13 @@ else
     nosetests --exe -A "$NOSE_ARGS" pandas --with-xunit --xunit-file=/tmp/nosetests.xml
 fi
 
+if [ "$INSTALL_TEST" ]; then
+    echo "Starting installation test."
+    conda uninstall cython || exit 1
+    python "$TRAVIS_BUILD_DIR"/setup.py sdist --formats=zip,gztar || exit 1
+    pip install "$TRAVIS_BUILD_DIR"/dist/*tar.gz || exit 1
+    nosetests --exe -A "$NOSE_ARGS" pandas/tests/test_series.py --with-xunit --xunit-file=/tmp/nosetests_install.xml
+fi
 RET="$?"
 
 # wait until subprocesses finish (build_docs.sh)


### PR DESCRIPTION
closes #9878 

This PR adds a test for packaging and installing pandas from a tarball, inside of the 2.6 regression.

After regular nosetests complete, cython is removed from the venv, pandas is packaged with cdist command, and the package is installed via pip. Limited nosetests run once installed.

The travis log output is a little messy with the pip command output; ideally I wanted to 'fold'/collapse the output unless there was a failure but I don't think you can do that from within the 'script' portion of the regression, only the before and after scripts, see:
http://blog.travis-ci.com/2013-05-22-improving-build-visibility-log-folds/
If there is a way to do this maybe we can add it later, or move where this INSTALL_TEST is happening to a before or after script.
