### PR TITLE
BUG: DataFrame constructor fails when columns is set and data=[]

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -164,3 +164,4 @@ Bug Fixes
 
 - Fixed latex output for multi-indexed dataframes (:issue:`9778`)
 - Bug causing an exception when setting an empty range using ``DataFrame.loc`` (:issue:`9596`)
+- Bug in ``DataFrame`` constructor when ``columns`` parameter is set, and ``data`` is an empty list

--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -164,4 +164,4 @@ Bug Fixes
 
 - Fixed latex output for multi-indexed dataframes (:issue:`9778`)
 - Bug causing an exception when setting an empty range using ``DataFrame.loc`` (:issue:`9596`)
-- Bug in ``DataFrame`` constructor when ``columns`` parameter is set, and ``data`` is an empty list
+- Bug in ``DataFrame`` constructor when ``columns`` parameter is set, and ``data`` is an empty list (:issue:`9939`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -265,8 +265,7 @@ class DataFrame(NDFrame):
                     mgr = self._init_ndarray(data, index, columns, dtype=dtype,
                                              copy=copy)
             else:
-                mgr = self._init_ndarray(data, index, columns, dtype=dtype,
-                                         copy=copy)
+                mgr = self._init_dict({}, index, columns, dtype=dtype)
         elif isinstance(data, collections.Iterator):
             raise TypeError("data argument can't be an iterator")
         else:

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3135,6 +3135,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         expected = DataFrame(index=[])
         assert_frame_equal(df, expected)
 
+        # GH 9939
         df = DataFrame([], columns=['A', 'B'])
         expected = DataFrame({}, columns=['A', 'B'])
         assert_frame_equal(df, expected)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3135,6 +3135,18 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         expected = DataFrame(index=[])
         assert_frame_equal(df, expected)
 
+        df = DataFrame([], columns=['A', 'B'])
+        expected = DataFrame({}, columns=['A', 'B'])
+        assert_frame_equal(df, expected)
+
+        # Empty generator: list(empty_gen()) == []
+        def empty_gen():
+            return
+            yield
+
+        df = DataFrame(empty_gen(), columns=['A', 'B'])
+        assert_frame_equal(df, expected)
+
     def test_constructor_list_of_lists(self):
         # GH #484
         l = [[1, 'a'], [2, 'b']]


### PR DESCRIPTION
From this StackOverflow question: http://stackoverflow.com/questions/29730488/setting-columns-for-an-empty-pandas-dataframe
