### PR TITLE
PERF: improve perf of writing csv's with datetimes

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -89,7 +89,8 @@ API changes
 Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Improved csv write performance with mixed dtypes, including datetimes (:issue:`9940`)
+- Improved csv write performance with mixed dtypes, including datetimes by up to 5x (:issue:`9940`)
+- Improved csv write performance generally by 2x (:issue:`9940`)
 
 
 

--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -89,7 +89,7 @@ API changes
 Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-
+- Improved csv write performance with mixed dtypes, including datetimes (:issue:`9940`)
 
 
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1071,12 +1071,16 @@ class Index(IndexOpsMixin, PandasObject):
             values = values[slicer]
         return values._format_native_types(**kwargs)
 
-    def _format_native_types(self, na_rep='', **kwargs):
+    def _format_native_types(self, na_rep='', quoting=None, **kwargs):
         """ actually format my specific types """
         mask = isnull(self)
-        values = np.array(self, dtype=object, copy=True)
+        if not self.is_object() and not quoting:
+            values = np.asarray(self).astype(str)
+        else:
+            values = np.array(self, dtype=object, copy=True)
+
         values[mask] = na_rep
-        return values.tolist()
+        return values
 
     def equals(self, other):
         """
@@ -3298,7 +3302,7 @@ class MultiIndex(Index):
         return np.sum(name == np.asarray(self.names)) > 1
 
     def _format_native_types(self, **kwargs):
-        return self.tolist()
+        return self.values
 
     @property
     def _constructor(self):

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1870,23 +1870,12 @@ class DatetimeBlock(Block):
         values = self.values
         if slicer is not None:
             values = values[:, slicer]
-        mask = isnull(values)
 
-        rvalues = np.empty(values.shape, dtype=object)
-        if na_rep is None:
-            na_rep = 'NaT'
-        rvalues[mask] = na_rep
-        imask = (~mask).ravel()
-
-        if date_format is None:
-            date_formatter = lambda x: Timestamp(x)._repr_base
-        else:
-            date_formatter = lambda x: Timestamp(x).strftime(date_format)
-
-        rvalues.flat[imask] = np.array([date_formatter(val) for val in
-                                        values.ravel()[imask]], dtype=object)
-
-        return rvalues.tolist()
+        result = tslib.format_array_from_datetime(values.view('i8').ravel(),
+                                                  tz=None,
+                                                  format=date_format,
+                                                  na_rep=na_rep).reshape(values.shape)
+        return result.tolist()
 
     def should_store(self, value):
         return issubclass(value.dtype.type, np.datetime64)

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -933,7 +933,7 @@ def string_array_replace_from_nan_rep(ndarray[object, ndim=1] arr, object nan_re
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def write_csv_rows(list data, list data_index, int nlevels, list cols, object writer):
+def write_csv_rows(list data, ndarray data_index, int nlevels, ndarray cols, object writer):
 
     cdef int N, j, i, ncols
     cdef list rows

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -3010,12 +3010,12 @@ class TestFloatArrayFormatter(tm.TestCase):
 
     def test_output_significant_digits(self):
         # Issue #9764
-        
+
         # In case default display precision changes:
         with pd.option_context('display.precision', 7):
             # DataFrame example from issue #9764
             d=pd.DataFrame({'col1':[9.999e-8, 1e-7, 1.0001e-7, 2e-7, 4.999e-7, 5e-7, 5.0001e-7, 6e-7, 9.999e-7, 1e-6, 1.0001e-6, 2e-6, 4.999e-6, 5e-6, 5.0001e-6, 6e-6]})
-            
+
             expected_output={
                 (0,6):'           col1\n0  9.999000e-08\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07',
                 (1,6):'           col1\n1  1.000000e-07\n2  1.000100e-07\n3  2.000000e-07\n4  4.999000e-07\n5  5.000000e-07',

--- a/pandas/tseries/base.py
+++ b/pandas/tseries/base.py
@@ -61,7 +61,7 @@ class DatetimeIndexOpsMixin(object):
         return _algos.groupby_object(objs, f)
 
     def _format_with_header(self, header, **kwargs):
-        return header + self._format_native_types(**kwargs)
+        return header + list(self._format_native_types(**kwargs))
 
     def __contains__(self, key):
         try:

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -673,9 +673,8 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
 
     def _format_native_types(self, na_rep=u('NaT'),
                              date_format=None, **kwargs):
-        data = self.asobject
         from pandas.core.format import Datetime64Formatter
-        return Datetime64Formatter(values=data,
+        return Datetime64Formatter(values=self,
                                    nat_rep=na_rep,
                                    date_format=date_format,
                                    justify='all').get_result()

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -673,11 +673,13 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
 
     def _format_native_types(self, na_rep=u('NaT'),
                              date_format=None, **kwargs):
-        from pandas.core.format import Datetime64Formatter
-        return Datetime64Formatter(values=self,
-                                   nat_rep=na_rep,
-                                   date_format=date_format,
-                                   justify='all').get_result()
+        from pandas.core.format import _get_format_datetime64_from_values
+        format = _get_format_datetime64_from_values(self, date_format)
+
+        return tslib.format_array_from_datetime(self.asi8,
+                                                tz=self.tz,
+                                                format=format,
+                                                na_rep=na_rep)
 
     def to_datetime(self, dayfirst=False):
         return self.copy()

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -387,7 +387,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
     qyear = _field_accessor('qyear', 1)
     days_in_month = _field_accessor('days_in_month', 11, "The number of days in the month")
     daysinmonth = days_in_month
-    
+
     def _get_object_array(self):
         freq = self.freq
         return np.array([ Period._from_ordinal(ordinal=x, freq=freq) for x in self.values], copy=False)
@@ -687,7 +687,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
 
         imask = ~mask
         values[imask] = np.array([u('%s') % dt for dt in values[imask]])
-        return values.tolist()
+        return values
 
     def __array_finalize__(self, obj):
         if not self.ndim:  # pragma: no cover

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -1398,6 +1398,60 @@ def parse_datetime_string(date_string, **kwargs):
     dt = parse_date(date_string, **kwargs)
     return dt
 
+def format_array_from_datetime(ndarray[int64_t] values, object tz=None, object format=None, object na_rep=None):
+    """
+    return a np object array of the string formatted values
+
+    Parameters
+    ----------
+    values : a 1-d i8 array
+    tz : the timezone (or None)
+    format : optional, default is None
+          a strftime capable string
+    na_rep : optional, default is None
+          a nat format
+
+    """
+    cdef:
+        int64_t val, ns, N = len(values)
+        ndarray[object] result = np.empty(N, dtype=object)
+        object ts, res
+        pandas_datetimestruct dts
+
+    if na_rep is None:
+       na_rep = 'NaT'
+
+    for i in range(N):
+       val = values[i]
+
+       if val == iNaT:
+          result[i] = na_rep
+       else:
+          if format is None and tz is None:
+
+            pandas_datetime_to_datetimestruct(val, PANDAS_FR_ns, &dts)
+            res = '%d-%.2d-%.2d %.2d:%.2d:%.2d' % (dts.year,
+                                                   dts.month,
+                                                   dts.day,
+                                                   dts.hour,
+                                                   dts.min,
+                                                   dts.sec)
+
+            ns = dts.ps / 1000
+
+            if ns != 0:
+               res += '.%.9d' % (ns + 1000 * dts.us)
+            elif dts.us != 0:
+               res += '.%.6d' % dts.us
+
+            result[i] = res
+
+          else:
+             ts = Timestamp(val, tz=tz)
+             result[i] = ts.strftime(format)
+
+    return result
+
 def array_to_datetime(ndarray[object] values, raise_=False, dayfirst=False,
                       format=None, utc=None, coerce=False, unit=None):
     cdef:

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -1448,7 +1448,16 @@ def format_array_from_datetime(ndarray[int64_t] values, object tz=None, object f
 
           else:
              ts = Timestamp(val, tz=tz)
-             result[i] = ts.strftime(format)
+             if format is None:
+                 result[i] = str(ts)
+             else:
+
+                 # invalid format string
+                 # requires dates > 1900
+                 try:
+                     result[i] = ts.strftime(format)
+                 except ValueError:
+                     result[i] = str(ts)
 
     return result
 


### PR DESCRIPTION
```

-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
frame_to_csv_mixed                           | 107.7774 | 668.5090 |   0.1612 |
frame_to_csv                                 |  55.9403 | 140.1517 |   0.3991 |
write_csv_standard                           |  25.6400 |  49.6367 |   0.5166 |
packers_write_csv                            | 663.6736 | 1228.0974 |   0.5404 |
read_csv_standard                            |  10.2447 |  15.0284 |   0.6817 |
read_csv_skiprows                            |  12.1686 |  16.3487 |   0.7443 |
frame_to_csv_date_formatting                 |  10.2980 |  13.3820 |   0.7695 |
```
