### PR TITLE
operator equal on Index should behavior similarly to Series

### DIFF
--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -240,14 +240,14 @@ way to summarize a boolean result.
 
 .. ipython:: python
 
-   (df>0).all()
-   (df>0).any()
+   (df > 0).all()
+   (df > 0).any()
 
 You can reduce to a final boolean value.
 
 .. ipython:: python
 
-   (df>0).any().any()
+   (df > 0).any().any()
 
 You can test if a pandas object is empty, via the :attr:`~DataFrame.empty` property.
 
@@ -330,6 +330,48 @@ equality to be True:
    df1.equals(df2)
    df1.equals(df2.sort())
 
+Comparing array-like objects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can conveniently do element-wise comparisons when comparing a pandas
+data structure with a scalar value:
+
+.. ipython:: python
+
+   pd.Series(['foo', 'bar', 'baz']) == 'foo'
+   pd.Index(['foo', 'bar', 'baz']) == 'foo'
+
+Pandas also handles element-wise comparisons between different array-like
+objects of the same length:
+
+.. ipython:: python
+
+    pd.Series(['foo', 'bar', 'baz']) == pd.Index(['foo', 'bar', 'qux'])
+    pd.Series(['foo', 'bar', 'baz']) == np.array(['foo', 'bar', 'qux'])
+
+Trying to compare ``Index`` or ``Series`` objects of different lengths will
+raise a ValueError:
+
+.. code-block:: python
+
+    In [55]: pd.Series(['foo', 'bar', 'baz']) == pd.Series(['foo', 'bar'])
+    ValueError: Series lengths must match to compare
+
+    In [56]: pd.Series(['foo', 'bar', 'baz']) == pd.Series(['foo'])
+    ValueError: Series lengths must match to compare
+
+Note that this is different from the numpy behavior where a comparison can
+be broadcast:
+
+.. ipython:: python
+
+    np.array([1, 2, 3]) == np.array([2])
+
+or it can return False if broadcasting can not be done:
+
+.. ipython:: python
+
+    np.array([1, 2, 3]) == np.array([1, 2])
 
 Combining overlapping data sets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -46,6 +46,76 @@ Backwards incompatible API changes
 
 .. _whatsnew_0170.api_breaking:
 
+- Operator equal on Index should behavior similarly to Series (:issue:`9947`)
+
+Starting in v0.17.0, comparing ``Index`` objects of different lengths will raise
+a ``ValueError``. This is to be consistent with the behavior of ``Series``.
+
+Previous behavior:
+
+.. code-block:: python
+
+   In [2]: pd.Index([1, 2, 3]) == pd.Index([1, 4, 5])
+   Out[2]: array([ True, False, False], dtype=bool)
+
+   In [3]: pd.Index([1, 2, 3]) == pd.Index([2])
+   Out[3]: array([False,  True, False], dtype=bool)
+
+   In [4]: pd.Index([1, 2, 3]) == pd.Index([1, 2])
+   Out[4]: False
+
+   In [5]: pd.Series([1, 2, 3]) == pd.Series([1, 4, 5])
+   Out[5]:
+   0     True
+   1    False
+   2    False
+   dtype: bool
+
+   In [6]: pd.Series([1, 2, 3]) == pd.Series([2])
+   ValueError: Series lengths must match to compare
+
+   In [7]: pd.Series([1, 2, 3]) == pd.Series([1, 2])
+   ValueError: Series lengths must match to compare
+
+New behavior:
+
+.. code-block:: python
+
+   In [8]: pd.Index([1, 2, 3]) == pd.Index([1, 4, 5])
+   Out[8]: array([ True, False, False], dtype=bool)
+
+   In [9]: pd.Index([1, 2, 3]) == pd.Index([2])
+   ValueError: Lengths must match to compare
+
+   In [10]: pd.Index([1, 2, 3]) == pd.Index([1, 2])
+   ValueError: Lengths must match to compare
+
+   In [11]: pd.Series([1, 2, 3]) == pd.Series([1, 4, 5])
+   Out[11]:
+   0     True
+   1    False
+   2    False
+   dtype: bool
+
+   In [12]: pd.Series([1, 2, 3]) == pd.Series([2])
+   ValueError: Series lengths must match to compare
+
+   In [13]: pd.Series([1, 2, 3]) == pd.Series([1, 2])
+   ValueError: Series lengths must match to compare
+
+Note that this is different from the ``numpy`` behavior where a comparison can
+be broadcast:
+
+.. ipython:: python
+
+   np.array([1, 2, 3]) == np.array([1])
+
+or it can return False if broadcasting can not be done:
+
+.. ipython:: python
+
+   np.array([1, 2, 3]) == np.array([1, 2])
+
 .. _whatsnew_0170.api_breaking.other:
 
 Other API Changes
@@ -149,3 +219,4 @@ Bug Fixes
 
 - Bug in ``Series.plot(kind='hist')`` Y Label not informative (:issue:`10485`)
 
+- Bug in operator equal on Index not being consistent with Series (:issue:`9947`)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -2593,6 +2593,9 @@ class Index(IndexOpsMixin, PandasObject):
         def _make_compare(op):
 
             def _evaluate_compare(self, other):
+                if isinstance(other, (np.ndarray, Index, ABCSeries)):
+                    if other.ndim > 0 and len(self) != len(other):
+                        raise ValueError('Lengths must match to compare')
                 func = getattr(self.values, op)
                 result = func(np.asarray(other))
 


### PR DESCRIPTION
currently on `master` (after the PR https://github.com/pydata/pandas/issues/9785), we have the following behavior when comparing two Indexes with `==`:

```
In [3]: index_a = Index(['a', 'b', 'c'])
In [4]: index_b = Index(['a', 'b', 'c', 'd'])
In [5]: index_a == index_b
Out[5]: False
```

Firstly, `==` should be element-wise comparison, so it really shouldn't return just a scalar `bool`. That should be the case for `Index.equals()` instead.

Secondly it is also not consistent with the behavior with `Series`

```
In [6]: series_a = Series(['a', 'b', 'c'])
In [7]: series_b = Series(['a', 'b', 'c', 'd'])
In [8]: series_a == series_b
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-8-97f84083a0cd> in <module>()
----> 1 series_a == series_b

/Users/mortada_mehyar/code/github/pandas/pandas/core/ops.py in wrapper(self, other)
    576             name = _maybe_match_name(self, other)
    577             if len(self) != len(other):
--> 578                 raise ValueError('Series lengths must match to compare')
    579             return self._constructor(na_op(self.values, other.values),
    580                                      index=self.index, name=name)

ValueError: Series lengths must match to compare
```

This PR makes the behavior consistent by checking the Index lengths. Also fixes a few unit tests which seem to incorrectly assume `.equal()` should return the same output as `==` 
