### PR TITLE
TST: Check index names

### DIFF
--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -272,7 +272,7 @@ a,1
 b,2
 c,3
 """
-        expected = Series([1, 2, 3], ['a', 'b', 'c'])
+        expected = Series([1, 2, 3], index=Index(['a', 'b', 'c'], name=0))
         result = self.read_table(StringIO(data), sep=',', index_col=0,
                                  header=None, squeeze=True)
         tm.assert_isinstance(result, Series)
@@ -981,8 +981,8 @@ c,4,5
                            parse_dates=[['date', 'time']])
         idx = DatetimeIndex([datetime(2009, 1, 31, 0, 10, 0),
                              datetime(2009, 2, 28, 10, 20, 0),
-                             datetime(2009, 3, 31, 8, 30, 0)]).asobject
-        idx.name = 'date_time'
+                             datetime(2009, 3, 31, 8, 30, 0)],
+                            dtype=object, name='date_time')
         xp = DataFrame({'B': [1, 3, 5], 'C': [2, 4, 6]}, idx)
         tm.assert_frame_equal(rs, xp)
 
@@ -990,8 +990,8 @@ c,4,5
                            parse_dates=[[0, 1]])
         idx = DatetimeIndex([datetime(2009, 1, 31, 0, 10, 0),
                              datetime(2009, 2, 28, 10, 20, 0),
-                             datetime(2009, 3, 31, 8, 30, 0)]).asobject
-        idx.name = 'date_time'
+                             datetime(2009, 3, 31, 8, 30, 0)],
+                            dtype=object, name='date_time')
         xp = DataFrame({'B': [1, 3, 5], 'C': [2, 4, 6]}, idx)
         tm.assert_frame_equal(rs, xp)
 
@@ -3110,17 +3110,17 @@ A,B,C
         expected = pd.DataFrame([['2007/01/01', '01:00', 0.2140, 'U', 'M'],
                                  ['2007/01/01', '02:00', 0.2141, 'M', 'O'],
                                  ['2007/01/01', '04:00', 0.2142, 'D', 'M']],
-                                columns=['date', 'time', 'var', 'flag', 
+                                columns=['date', 'time', 'var', 'flag',
                                          'oflag'])
         # test with the three default lineterminators LF, CR and CRLF
         df = self.read_csv(StringIO(data), skiprows=1, delim_whitespace=True,
                            names=['date', 'time', 'var', 'flag', 'oflag'])
         tm.assert_frame_equal(df, expected)
-        df = self.read_csv(StringIO(data.replace('\n', '\r')), 
+        df = self.read_csv(StringIO(data.replace('\n', '\r')),
                            skiprows=1, delim_whitespace=True,
                            names=['date', 'time', 'var', 'flag', 'oflag'])
         tm.assert_frame_equal(df, expected)
-        df = self.read_csv(StringIO(data.replace('\n', '\r\n')), 
+        df = self.read_csv(StringIO(data.replace('\n', '\r\n')),
                            skiprows=1, delim_whitespace=True,
                            names=['date', 'time', 'var', 'flag', 'oflag'])
         tm.assert_frame_equal(df, expected)

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -1593,9 +1593,10 @@ class TestHDFStore(tm.TestCase):
 
             # series
             _maybe_remove(store, 's')
-            s = Series(np.zeros(12), index=make_index(['date',None,None]))
+            s = Series(np.zeros(12), index=make_index(['date', None, None]))
             store.append('s',s)
-            tm.assert_series_equal(store.select('s'),s)
+            xp = Series(np.zeros(12), index=make_index(['date', 'level_1', 'level_2']))
+            tm.assert_series_equal(store.select('s'), xp)
 
             # dup with column
             _maybe_remove(store, 'df')

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -1323,19 +1323,19 @@ class _TestSQLAlchemy(PandasSQLTest):
                         'i64':Series([5,], dtype='int64'),
                         })
 
-        df.to_sql('test_dtypes', self.conn, index=False, if_exists='replace', 
+        df.to_sql('test_dtypes', self.conn, index=False, if_exists='replace',
             dtype={'f64_as_f32':sqlalchemy.Float(precision=23)})
         res = sql.read_sql_table('test_dtypes', self.conn)
-        
+
         # check precision of float64
-        self.assertEqual(np.round(df['f64'].iloc[0],14), 
+        self.assertEqual(np.round(df['f64'].iloc[0],14),
                          np.round(res['f64'].iloc[0],14))
 
         # check sql types
         meta = sqlalchemy.schema.MetaData(bind=self.conn)
         meta.reflect()
         col_dict = meta.tables['test_dtypes'].columns
-        self.assertEqual(str(col_dict['f32'].type), 
+        self.assertEqual(str(col_dict['f32'].type),
                          str(col_dict['f64_as_f32'].type))
         self.assertTrue(isinstance(col_dict['f32'].type, sqltypes.Float))
         self.assertTrue(isinstance(col_dict['f64'].type, sqltypes.Float))
@@ -1729,11 +1729,11 @@ class TestSQLiteFallback(PandasSQLTest):
         df = DataFrame([[1, 2], [3, 4]], columns=['a', 'b'])
 
         # Raise error on blank
-        self.assertRaises(ValueError, df.to_sql, "", self.conn, 
+        self.assertRaises(ValueError, df.to_sql, "", self.conn,
             flavor=self.flavor)
 
         for ndx, weird_name in enumerate(['test_weird_name]','test_weird_name[',
-            'test_weird_name`','test_weird_name"', 'test_weird_name\'', 
+            'test_weird_name`','test_weird_name"', 'test_weird_name\'',
             '_b.test_weird_name_01-30', '"_b.test_weird_name_01-30"']):
             df.to_sql(weird_name, self.conn, flavor=self.flavor)
             sql.table_exists(weird_name, self.conn)
@@ -1839,12 +1839,12 @@ class TestMySQLLegacy(TestSQLiteFallback):
         for ndx, illegal_name in enumerate(['test_illegal_name]','test_illegal_name[',
             'test_illegal_name`','test_illegal_name"', 'test_illegal_name\'', '']):
             df = DataFrame([[1, 2], [3, 4]], columns=['a', 'b'])
-            self.assertRaises(ValueError, df.to_sql, illegal_name, self.conn, 
+            self.assertRaises(ValueError, df.to_sql, illegal_name, self.conn,
                 flavor=self.flavor, index=False)
 
             df2 = DataFrame([[1, 2], [3, 4]], columns=['a', illegal_name])
             c_tbl = 'test_illegal_col_name%d'%ndx
-            self.assertRaises(ValueError, df2.to_sql, 'test_illegal_col_name', 
+            self.assertRaises(ValueError, df2.to_sql, 'test_illegal_col_name',
                 self.conn, flavor=self.flavor, index=False)
 
 
@@ -2021,7 +2021,7 @@ class TestXSQLite(tm.TestCase):
         frame = tm.makeTimeDataFrame()
         sql.write_frame(frame, name='test_table', con=self.db)
         result = sql.tquery("select A from test_table", self.db)
-        expected = frame.A
+        expected = Series(frame.A, frame.index) # not to have name
         result = Series(result, frame.index)
         tm.assert_series_equal(result, expected)
 
@@ -2359,7 +2359,7 @@ class TestXMySQL(tm.TestCase):
         cur.execute(drop_sql)
         sql.write_frame(frame, name='test_table', con=self.db, flavor='mysql')
         result = sql.tquery("select A from test_table", self.db)
-        expected = frame.A
+        expected = Series(frame.A, frame.index) # not to have name
         result = Series(result, frame.index)
         tm.assert_series_equal(result, expected)
 

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -875,8 +875,8 @@ class TestStata(tm.TestCase):
         parsed_117.index = np.arange(parsed_117.shape[0])
         codes = [-1, -1, 0, 1, 1, 1, 2, 2, 3, 4]
         categories = ["Poor", "Fair", "Good", "Very good", "Excellent"]
-        expected = pd.Series(pd.Categorical.from_codes(codes=codes,
-                                                       categories=categories))
+        cat = pd.Categorical.from_codes(codes=codes, categories=categories)
+        expected = pd.Series(cat, name='srh')
         tm.assert_series_equal(expected, parsed_115["srh"])
         tm.assert_series_equal(expected, parsed_117["srh"])
 

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -36,7 +36,7 @@ import pandas.tests.test_frame as test_frame
 import pandas.tests.test_panel as test_panel
 import pandas.tests.test_series as test_series
 
-from .test_array import assert_sp_array_equal
+from pandas.sparse.tests.test_array import assert_sp_array_equal
 
 import warnings
 warnings.filterwarnings(action='ignore', category=FutureWarning)
@@ -281,7 +281,7 @@ class TestSparseSeries(tm.TestCase,
         arr = [0, 0, 0, nan, nan]
         sp_series = SparseSeries(arr, fill_value=0)
         assert_equal(sp_series.values.values, arr)
-        
+
     # GH 9272
     def test_constructor_empty(self):
         sp = SparseSeries()
@@ -997,7 +997,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
             ValueError, "^Column length", SparseDataFrame, self.frame.values,
             columns=self.frame.columns[:-1])
 
-    # GH 9272 
+    # GH 9272
     def test_constructor_empty(self):
         sp = SparseDataFrame()
         self.assertEqual(len(sp.index), 0)
@@ -1283,7 +1283,9 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
             frame['E'] = to_insert
             expected = to_insert.to_dense().reindex(
                 frame.index).fillna(to_insert.fill_value)
-            assert_series_equal(frame['E'].to_dense(), expected)
+            result = frame['E'].to_dense()
+            assert_series_equal(result, expected, check_names=False)
+            self.assertEqual(result.name, 'E')
 
             # insert Series
             frame['F'] = frame['A'].to_dense()
@@ -1747,8 +1749,8 @@ class TestSparsePanel(tm.TestCase,
         with tm.assertRaisesRegexp(TypeError,
                                    "input must be a dict, a 'list' was passed"):
             SparsePanel(['a', 'b', 'c'])
-        
-    # GH 9272    
+
+    # GH 9272
     def test_constructor_empty(self):
         sp = SparsePanel()
         self.assertEqual(len(sp.items), 0)

--- a/pandas/stats/tests/test_moments.py
+++ b/pandas/stats/tests/test_moments.py
@@ -1254,7 +1254,8 @@ class TestMomentsConsistency(Base):
 
         actual = panel.ix[:, 1, 5]
         expected = func(self.frame[1], self.frame[5], *args, **kwargs)
-        tm.assert_series_equal(actual, expected)
+        tm.assert_series_equal(actual, expected, check_names=False)
+        self.assertEqual(actual.name, 5)
 
     def test_flex_binary_moment(self):
         # GH3155

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2395,22 +2395,26 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                         'B' : ci.values })
         idf = df.set_index('B')
         str(idf)
-        tm.assert_index_equal(idf.index,ci)
+        tm.assert_index_equal(idf.index, ci, check_names=False)
+        self.assertEqual(idf.index.name, 'B')
 
         # from a CategoricalIndex
         df = DataFrame({'A' : np.random.randn(10),
                         'B' : ci })
         idf = df.set_index('B')
         str(idf)
-        tm.assert_index_equal(idf.index,ci)
+        tm.assert_index_equal(idf.index, ci, check_names=False)
+        self.assertEqual(idf.index.name, 'B')
 
         idf = df.set_index('B').reset_index().set_index('B')
         str(idf)
-        tm.assert_index_equal(idf.index,ci)
+        tm.assert_index_equal(idf.index, ci, check_names=False)
+        self.assertEqual(idf.index.name, 'B')
 
         new_df = idf.reset_index()
         new_df.index = df.B
-        tm.assert_index_equal(new_df.index,ci)
+        tm.assert_index_equal(new_df.index, ci, check_names=False)
+        self.assertEqual(idf.index.name, 'B')
 
     def test_set_index_cast_datetimeindex(self):
         df = DataFrame({'A': [datetime(2000, 1, 1) + timedelta(i)
@@ -7488,19 +7492,19 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # errors = 'ignore'
         dropped = df.drop(['g'], errors='ignore')
-        expected = Index(['a', 'b', 'c'])
+        expected = Index(['a', 'b', 'c'], name='first')
         self.assert_index_equal(dropped.index, expected)
 
         dropped = df.drop(['b', 'g'], errors='ignore')
-        expected = Index(['a', 'c'])
+        expected = Index(['a', 'c'], name='first')
         self.assert_index_equal(dropped.index, expected)
 
         dropped = df.drop(['g'], axis=1, errors='ignore')
-        expected = Index(['d', 'e', 'f'])
+        expected = Index(['d', 'e', 'f'], name='second')
         self.assert_index_equal(dropped.columns, expected)
 
         dropped = df.drop(['d', 'g'], axis=1, errors='ignore')
-        expected = Index(['e', 'f'])
+        expected = Index(['e', 'f'], name='second')
         self.assert_index_equal(dropped.columns, expected)
 
     def test_dropEmptyRows(self):

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -2055,10 +2055,10 @@ class TestInt64Index(Numeric, tm.TestCase):
         self.assertEqual(i_view.name, 'Foo')
 
         i_view = i.view('i8')
-        tm.assert_index_equal(i, Int64Index(i_view))
+        tm.assert_index_equal(i, Int64Index(i_view, name='Foo'))
 
         i_view = i.view(Int64Index)
-        tm.assert_index_equal(i, Int64Index(i_view))
+        tm.assert_index_equal(i, Int64Index(i_view, name='Foo'))
 
     def test_coerce_list(self):
         # coerce things

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -509,7 +509,9 @@ class CheckIndexing(object):
         idx = self.panel.major_axis[5]
         xs = self.panel.major_xs(idx)
 
-        assert_series_equal(xs['ItemA'], ref.xs(idx))
+        result = xs['ItemA']
+        assert_series_equal(result, ref.xs(idx), check_names=False)
+        self.assertEqual(result.name, 'ItemA')
 
         # not contained
         idx = self.panel.major_axis[0] - bday
@@ -527,7 +529,7 @@ class CheckIndexing(object):
         idx = self.panel.minor_axis[1]
         xs = self.panel.minor_xs(idx)
 
-        assert_series_equal(xs['ItemA'], ref[idx])
+        assert_series_equal(xs['ItemA'], ref[idx], check_names=False)
 
         # not contained
         self.assertRaises(Exception, self.panel.minor_xs, 'E')
@@ -658,7 +660,7 @@ class CheckIndexing(object):
 
     def test_ix_align(self):
         from pandas import Series
-        b = Series(np.random.randn(10))
+        b = Series(np.random.randn(10), name=0)
         b.sort()
         df_orig = Panel(np.random.randn(3, 10, 2))
         df = df_orig.copy()

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -483,8 +483,8 @@ Freq: D"""
             tm.assert_index_equal(result,expected)
 
         # divide with nats
-        rng = TimedeltaIndex(['1 days',pd.NaT,'2 days'],name='foo')
-        expected = Float64Index([12,np.nan,24])
+        rng = TimedeltaIndex(['1 days', pd.NaT, '2 days'], name='foo')
+        expected = Float64Index([12, np.nan, 24], name='foo')
         for offset in offsets:
             result = rng / offset
             tm.assert_index_equal(result,expected)
@@ -495,8 +495,8 @@ Freq: D"""
     def test_subtraction_ops(self):
 
         # with datetimes/timedelta and tdi/dti
-        tdi = TimedeltaIndex(['1 days',pd.NaT,'2 days'],name='foo')
-        dti = date_range('20130101',periods=3)
+        tdi = TimedeltaIndex(['1 days', pd.NaT, '2 days'], name='foo')
+        dti = date_range('20130101', periods=3, name='bar')
         td = Timedelta('1 days')
         dt = Timestamp('20130101')
 
@@ -505,29 +505,29 @@ Freq: D"""
         self.assertRaises(TypeError, lambda : td - dt)
         self.assertRaises(TypeError, lambda : td - dti)
 
-        result = dt-dti
-        expected = TimedeltaIndex(['0 days','-1 days','-2 days'])
-        tm.assert_index_equal(result,expected)
+        result = dt - dti
+        expected = TimedeltaIndex(['0 days', '-1 days', '-2 days'], name='bar')
+        tm.assert_index_equal(result, expected)
 
-        result = dti-dt
-        expected = TimedeltaIndex(['0 days','1 days','2 days'])
-        tm.assert_index_equal(result,expected)
+        result = dti - dt
+        expected = TimedeltaIndex(['0 days', '1 days', '2 days'], name='bar')
+        tm.assert_index_equal(result, expected)
 
-        result = tdi-td
-        expected = TimedeltaIndex(['0 days',pd.NaT,'1 days'])
-        tm.assert_index_equal(result,expected)
+        result = tdi - td
+        expected = TimedeltaIndex(['0 days', pd.NaT, '1 days'], name='foo')
+        tm.assert_index_equal(result, expected, check_names=False)
 
-        result = td-tdi
-        expected = TimedeltaIndex(['0 days',pd.NaT,'-1 days'])
-        tm.assert_index_equal(result,expected)
+        result = td - tdi
+        expected = TimedeltaIndex(['0 days', pd.NaT, '-1 days'], name='foo')
+        tm.assert_index_equal(result, expected, check_names=False)
 
-        result = dti-td
-        expected = DatetimeIndex(['20121231','20130101','20130102'])
-        tm.assert_index_equal(result,expected)
+        result = dti - td
+        expected = DatetimeIndex(['20121231', '20130101', '20130102'], name='bar')
+        tm.assert_index_equal(result, expected, check_names=False)
 
-        result = dt-tdi
-        expected = DatetimeIndex(['20121231',pd.NaT,'20121230'])
-        tm.assert_index_equal(result,expected)
+        result = dt - tdi
+        expected = DatetimeIndex(['20121231', pd.NaT, '20121230'], name='foo')
+        tm.assert_index_equal(result, expected)
 
     def test_subtraction_ops_with_tz(self):
 
@@ -644,46 +644,46 @@ Freq: D"""
     def test_dti_tdi_numeric_ops(self):
 
         # These are normally union/diff set-like ops
-        tdi = TimedeltaIndex(['1 days',pd.NaT,'2 days'],name='foo')
-        dti = date_range('20130101',periods=3)
+        tdi = TimedeltaIndex(['1 days',pd.NaT,'2 days'], name='foo')
+        dti = date_range('20130101',periods=3, name='bar')
         td = Timedelta('1 days')
         dt = Timestamp('20130101')
 
-        result = tdi-tdi
-        expected = TimedeltaIndex(['0 days',pd.NaT,'0 days'])
-        tm.assert_index_equal(result,expected)
+        result = tdi - tdi
+        expected = TimedeltaIndex(['0 days', pd.NaT, '0 days'], name='foo')
+        tm.assert_index_equal(result, expected, check_names=False) # must be foo
 
-        result = tdi+tdi
-        expected = TimedeltaIndex(['2 days',pd.NaT,'4 days'])
-        tm.assert_index_equal(result,expected)
+        result = tdi + tdi
+        expected = TimedeltaIndex(['2 days', pd.NaT, '4 days'], name='foo')
+        tm.assert_index_equal(result, expected, check_names=False) # must be foo
 
-        result = dti-tdi
-        expected = DatetimeIndex(['20121231',pd.NaT,'20130101'])
-        tm.assert_index_equal(result,expected)
+        result = dti - tdi
+        expected = DatetimeIndex(['20121231', pd.NaT, '20130101'])
+        tm.assert_index_equal(result, expected)
 
     def test_addition_ops(self):
 
         # with datetimes/timedelta and tdi/dti
-        tdi = TimedeltaIndex(['1 days',pd.NaT,'2 days'],name='foo')
-        dti = date_range('20130101',periods=3)
+        tdi = TimedeltaIndex(['1 days',pd.NaT,'2 days'], name='foo')
+        dti = date_range('20130101', periods=3, name='bar')
         td = Timedelta('1 days')
         dt = Timestamp('20130101')
 
         result = tdi + dt
-        expected = DatetimeIndex(['20130102',pd.NaT,'20130103'])
-        tm.assert_index_equal(result,expected)
+        expected = DatetimeIndex(['20130102', pd.NaT, '20130103'], name='foo')
+        tm.assert_index_equal(result, expected)
 
         result = dt + tdi
-        expected = DatetimeIndex(['20130102',pd.NaT,'20130103'])
-        tm.assert_index_equal(result,expected)
+        expected = DatetimeIndex(['20130102', pd.NaT, '20130103'], name='foo')
+        tm.assert_index_equal(result, expected)
 
         result = td + tdi
-        expected = TimedeltaIndex(['2 days',pd.NaT,'3 days'])
-        tm.assert_index_equal(result,expected)
+        expected = TimedeltaIndex(['2 days', pd.NaT, '3 days'], name='foo')
+        tm.assert_index_equal(result, expected, check_names=False) # must be foo
 
         result = tdi + td
-        expected = TimedeltaIndex(['2 days',pd.NaT,'3 days'])
-        tm.assert_index_equal(result,expected)
+        expected = TimedeltaIndex(['2 days', pd.NaT, '3 days'], name='foo')
+        tm.assert_index_equal(result,expected, check_names=False)  # must be foo
 
         # unequal length
         self.assertRaises(ValueError, lambda : tdi + dti[0:1])
@@ -696,7 +696,7 @@ Freq: D"""
         #self.assertRaises(TypeError, lambda : Int64Index([1,2,3]) + tdi)
 
         result = tdi + dti
-        expected = DatetimeIndex(['20130102',pd.NaT,'20130105'])
+        expected = DatetimeIndex(['20130102', pd.NaT, '20130105'])
         tm.assert_index_equal(result,expected)
 
         result = dti + tdi

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -82,15 +82,17 @@ class TestResample(tm.TestCase):
                          name='index')
         s = Series(np.random.randn(14), index=rng)
         result = s.resample('5min', how='mean', closed='right', label='right')
+
+        exp_idx = date_range('1/1/2000', periods=4, freq='5min', name='index')
         expected = Series([s[0], s[1:6].mean(), s[6:11].mean(), s[11:].mean()],
-                          index=date_range('1/1/2000', periods=4, freq='5min'))
+                          index=exp_idx)
         assert_series_equal(result, expected)
         self.assertEqual(result.index.name, 'index')
 
         result = s.resample('5min', how='mean', closed='left', label='right')
-        expected = Series([s[:5].mean(), s[5:10].mean(), s[10:].mean()],
-                          index=date_range('1/1/2000 00:05', periods=3,
-                                           freq='5min'))
+
+        exp_idx = date_range('1/1/2000 00:05', periods=3, freq='5min', name='index')
+        expected = Series([s[:5].mean(), s[5:10].mean(), s[10:].mean()], index=exp_idx)
         assert_series_equal(result, expected)
 
         s = self.series
@@ -115,7 +117,7 @@ class TestResample(tm.TestCase):
             if isnull(group).all():
                 return np.repeat(np.nan, 4)
             return [group[0], group.max(), group.min(), group[-1]]
-        inds = date_range('1/1/2000', periods=4, freq='5min')
+        inds = date_range('1/1/2000', periods=4, freq='5min', name='index')
 
         for arg in args:
             if arg == 'ohlc':


### PR DESCRIPTION
Derived from #9862. Added `check_names` kw to followings testing functions:
- `assert_index_equal` (default=True).
- `assert_series_equal` (default=True). Maybe the same option can be used to check `Series.name` in the future, otherwise it may better to choose separate name such as `check_index_name`. 
- `assert_panelnd_equal` (default=False). We have to check following ToDo to specify default=True.
- https://github.com/pydata/pandas/blob/master/pandas/util/testing.py#L771
- `assert_frame_equal` is untouched as it already has the kw. Not refactored the logic because it has a path which doesn't use `assert_index_equal` internally. 

Looked through test cases which have to be `check_names=False`, and added name check tests.
