### PR TITLE
Series string  operators

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -961,6 +961,20 @@ class StringMethods(object):
             i += 1
             g = self.get(i)
 
+    def __mod__(self, other):
+        return _na_map(lambda s: s % other, self.series)
+
+    def __rmod__(self, other):
+        return _na_map(lambda s: other % s, self.series)
+
+    def __add__(self, other):
+        return _na_map(lambda s: s + other, self.series)
+    __radd__ = __add__
+
+    def __mul__(self, other):
+        return _na_map(lambda s: s * other, self.series)
+    __rmul__ = __mul__
+
     def _wrap_result(self, result):
         from pandas.core.series import Series
         from pandas.core.frame import DataFrame

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -5008,6 +5008,18 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         with self.assertRaisesRegexp(AttributeError, 'only use .str accessor'):
             s.str.repeat(2)
 
+    def test_str_mod(self):
+        s = Series(['%s', '%s'])
+        self.assertTrue(all((s.str % 1) == Series(['1', '1'])))
+
+    def test_str_add(self):
+        s = Series(['a', 'b'])
+        self.assertTrue(all((s.str + 'c') == Series(['ac', 'bc'])))
+
+    def test_str_mul(self):
+        s = Series(['a', 'b'])
+        self.assertTrue(all((s.str * 2) == Series(['aa', 'bb'])))
+
     def test_clip(self):
         val = self.ts.median()
 


### PR DESCRIPTION
Makes the string operators available to the `Series.str` object

``` python
In [1]: a = pd.Series(['%s', '%s'])

In [2]: a.str % 2
Out[2]: array(['2', '2'], dtype=object)

In [3]: a = pd.Series(['a', 'b'])

In [4]: a.str * 2
Out[4]: array(['aa', 'bb'], dtype=object)

In [5]: a.str + 'test'
Out[5]: array(['atest', 'btest'], dtype=object)
```
