### PR TITLE
Add override_header_style option to data_frame.to_excel()

### DIFF
--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -1583,15 +1583,6 @@ class ExcelCell(object):
         self.mergestart = mergestart
         self.mergeend = mergeend
 
-
-header_style = {"font": {"bold": True},
-                "borders": {"top": "thin",
-                            "right": "thin",
-                            "bottom": "thin",
-                            "left": "thin"},
-                "alignment": {"horizontal": "center", "vertical": "top"}}
-
-
 class ExcelFormatter(object):
 
     """
@@ -1608,6 +1599,7 @@ class ExcelFormatter(object):
     header : boolean or list of string, default True
         Write out column names. If a list of string is given it is
         assumed to be aliases for the column names
+    header_style : Format dict, default None
     index : boolean, default True
         output row names (index)
     index_label : string or sequence, default None
@@ -1623,7 +1615,7 @@ class ExcelFormatter(object):
 
     def __init__(self, df, na_rep='', float_format=None, cols=None,
                  header=True, index=True, index_label=None, merge_cells=False,
-                 inf_rep='inf'):
+                 inf_rep='inf', header_style=None):
         self.df = df
         self.rowcounter = 0
         self.na_rep = na_rep
@@ -1636,6 +1628,7 @@ class ExcelFormatter(object):
         self.header = header
         self.merge_cells = merge_cells
         self.inf_rep = inf_rep
+        self.header_style = header_style
 
     def _format_value(self, val):
         if lib.checknull(val):
@@ -1667,7 +1660,7 @@ class ExcelFormatter(object):
             # Format multi-index as a merged cells.
             for lnum in range(len(level_lengths)):
                 name = columns.names[lnum]
-                yield ExcelCell(lnum, coloffset, name, header_style)
+                yield ExcelCell(lnum, coloffset, name, self.header_style)
 
             for lnum, (spans, levels, labels) in enumerate(zip(level_lengths,
                                                                columns.levels,
@@ -1679,19 +1672,19 @@ class ExcelFormatter(object):
                         yield ExcelCell(lnum,
                                         coloffset + i + 1,
                                         values[i],
-                                        header_style,
+                                        self.header_style,
                                         lnum,
                                         coloffset + i + spans[i])
                     else:
                         yield ExcelCell(lnum,
                                         coloffset + i + 1,
                                         values[i],
-                                        header_style)
+                                        self.header_style)
         else:
             # Format in legacy format with dots to indicate levels.
             for i, values in enumerate(zip(*level_strs)):
                 v = ".".join(map(com.pprint_thing, values))
-                yield ExcelCell(lnum, coloffset + i + 1, v, header_style)
+                yield ExcelCell(lnum, coloffset + i + 1, v, self.header_style)
 
         self.rowcounter = lnum
 
@@ -1715,7 +1708,7 @@ class ExcelFormatter(object):
 
             for colindex, colname in enumerate(colnames):
                 yield ExcelCell(self.rowcounter, colindex + coloffset, colname,
-                                header_style)
+                                self.header_style)
 
     def _format_header(self):
         if isinstance(self.columns, MultiIndex):
@@ -1728,7 +1721,7 @@ class ExcelFormatter(object):
             row = [x if x is not None else ''
                    for x in self.df.index.names] + [''] * len(self.columns)
             if reduce(lambda x, y: x and y, map(lambda x: x != '', row)):
-                gen2 = (ExcelCell(self.rowcounter, colindex, val, header_style)
+                gen2 = (ExcelCell(self.rowcounter, colindex, val, self.header_style)
                         for colindex, val in enumerate(row))
                 self.rowcounter += 1
         return itertools.chain(gen, gen2)
@@ -1764,13 +1757,13 @@ class ExcelFormatter(object):
                     yield ExcelCell(self.rowcounter,
                                     0,
                                     index_label,
-                                    header_style)
+                                    self.header_style)
                     self.rowcounter += 1
                 else:
                     yield ExcelCell(self.rowcounter - 1,
                                     0,
                                     index_label,
-                                    header_style)
+                                    self.header_style)
 
             # write index_values
             index_values = self.df.index
@@ -1779,7 +1772,7 @@ class ExcelFormatter(object):
 
             coloffset = 1
             for idx, idxval in enumerate(index_values):
-                yield ExcelCell(self.rowcounter + idx, 0, idxval, header_style)
+                yield ExcelCell(self.rowcounter + idx, 0, idxval, self.header_style)
 
         # Get a frame that will account for any duplicates in the column names.
         col_mapped_frame = self.df.loc[:, self.columns]
@@ -1815,7 +1808,7 @@ class ExcelFormatter(object):
                     yield ExcelCell(self.rowcounter,
                                     cidx,
                                     name,
-                                    header_style)
+                                    self.header_style)
                 self.rowcounter += 1
 
             if self.merge_cells:
@@ -1833,14 +1826,14 @@ class ExcelFormatter(object):
                             yield ExcelCell(self.rowcounter + i,
                                             gcolidx,
                                             values[i],
-                                            header_style,
+                                            self.header_style,
                                             self.rowcounter + i + spans[i] - 1,
                                             gcolidx)
                         else:
                             yield ExcelCell(self.rowcounter + i,
                                             gcolidx,
                                             values[i],
-                                            header_style)
+                                            self.header_style)
                     gcolidx += 1
 
             else:
@@ -1850,7 +1843,7 @@ class ExcelFormatter(object):
                         yield ExcelCell(self.rowcounter + idx,
                                         gcolidx,
                                         indexcolval,
-                                        header_style)
+                                        self.header_style)
                     gcolidx += 1
 
         # Get a frame that will account for any duplicates in the column names.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1190,7 +1190,7 @@ class DataFrame(NDFrame):
     def to_excel(self, excel_writer, sheet_name='Sheet1', na_rep='',
                  float_format=None, columns=None, header=True, index=True,
                  index_label=None, startrow=0, startcol=0, engine=None,
-                 merge_cells=True, encoding=None, inf_rep='inf'):
+                 merge_cells=True, encoding=None, inf_rep='inf', override_header_style='default'):
         """
         Write DataFrame to a excel sheet
 
@@ -1215,6 +1215,9 @@ class DataFrame(NDFrame):
             Column label for index column(s) if desired. If None is given, and
             `header` and `index` are True, then the index names are used. A
             sequence should be given if the DataFrame uses MultiIndex.
+        override_header_style : dict, default None
+            Provide a dict with styles to be applied to header cells,
+            or set to None to use the default header cell formatting.  
         startrow :
             upper left cell row to dump data frame
         startcol :
@@ -1256,6 +1259,19 @@ class DataFrame(NDFrame):
             excel_writer = ExcelWriter(excel_writer, engine=engine)
             need_save = True
 
+        if override_header_style == {}:
+            header_style = None
+        elif override_header_style != None:
+            header_style = override_header_style
+        else:
+            header_style = {"font": {"bold": True},
+                            "borders": {"top": "thin",
+                                        "right": "thin",
+                                        "bottom": "thin",
+                                        "left": "thin"},
+                            "alignment": {"horizontal": "center", "vertical": "top"}}
+        
+
         formatter = fmt.ExcelFormatter(self,
                                        na_rep=na_rep,
                                        cols=columns,
@@ -1264,7 +1280,8 @@ class DataFrame(NDFrame):
                                        index=index,
                                        index_label=index_label,
                                        merge_cells=merge_cells,
-                                       inf_rep=inf_rep)
+                                       inf_rep=inf_rep,
+                                       header_style=header_style)
         formatted_cells = formatter.get_formatted_cells()
         excel_writer.write_cells(formatted_cells, sheet_name,
                                  startrow=startrow, startcol=startcol)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1264,6 +1264,7 @@ class DataFrame(NDFrame):
         elif override_header_style != None:
             header_style = override_header_style
         else:
+            # The following is the old "global" style.  
             header_style = {"font": {"bold": True},
                             "borders": {"top": "thin",
                                         "right": "thin",

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -1364,17 +1364,17 @@ class _XlsxWriter(ExcelWriter):
         if style_dict.get('font'):
             font = style_dict['font']
             if font.get('bold'):
-                xl_format.set_bold()
+                xl_format.set_bold( font['bold'] )
+            if font.get('font_color'):
+                xl_format.set_font_color( font['font_color'] )
 
         # Map the alignment to XlsxWriter alignment properties.
         alignment = style_dict.get('alignment')
         if alignment:
-            if (alignment.get('horizontal')
-                    and alignment['horizontal'] == 'center'):
-                xl_format.set_align('center')
-            if (alignment.get('vertical')
-                    and alignment['vertical'] == 'top'):
-                xl_format.set_align('top')
+            if (alignment.get('horizontal')):
+                xl_format.set_align(alignment['horizontal'])
+            if (alignment.get('vertical')):
+                xl_format.set_align(alignment['vertical'])
 
         # Map the cell borders to XlsxWriter border properties.
         if style_dict.get('borders'):


### PR DESCRIPTION
[Pandas v0.16.0]

The Excel export (`data_frame.to_excel`) currently hard codes cell styles for all header frames.  This pull request allows this style to be overridden by the user.

Don't override the default header style (Default)
`data_frame.to_excel(..... "override_header_style":None)`

Don't style the header at all
`data_frame.to_excel(..... "override_header_style": {} )`

Pass in a custom style
`data_frame.to_excel(..... "override_header_style": { "font" : {"font_color" : "#990000", "bold" : False }, "align" : {"horizontal" : "right"} } )`

There are currently no tests for the to_excel function mentioned here.  (All the other, existing tests pass.)  I'd be happy to write some tests, though it might mean refactoring some functionality out of constructors as **init** is notoriously difficult to mock.  (mock.assert_called_with ?)
