### PR TITLE
DOC: StringMethods html doc fixes

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -553,6 +553,7 @@ strings and apply several methods to it. These can be acccessed like
    Series.str.swapcase
    Series.str.title
    Series.str.upper
+   Series.str.wrap
    Series.str.zfill
    Series.str.isalnum
    Series.str.isalpha

--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -266,7 +266,7 @@ Method Summary
     :meth:`~Series.str.upper`,Equivalent to ``str.upper``
     :meth:`~Series.str.find`,Equivalent to ``str.find``
     :meth:`~Series.str.rfind`,Equivalent to ``str.rfind``
-    :meth:`~Series.str.capicalize`,Equivalent to ``str.capitalize``
+    :meth:`~Series.str.capitalize`,Equivalent to ``str.capitalize``
     :meth:`~Series.str.swapcase`,Equivalent to ``str.swapcase``
     :meth:`~Series.str.isalnum`,Equivalent to ``str.isalnum``
     :meth:`~Series.str.isalpha`,Equivalent to ``str.isalpha``
@@ -276,4 +276,4 @@ Method Summary
     :meth:`~Series.str.isupper`,Equivalent to ``str.isupper``
     :meth:`~Series.str.istitle`,Equivalent to ``str.istitle``
     :meth:`~Series.str.isnumeric`,Equivalent to ``str.isnumeric``
-    :meth:`~Series.str.isnumeric`,Equivalent to ``str.isdecimal``
+    :meth:`~Series.str.isdecimal`,Equivalent to ``str.isdecimal``


### PR DESCRIPTION
I noticed some of the HTML links are broken in `text.rst`

@sinhrks @jorisvandenbossche this is related to https://github.com/pydata/pandas/pull/9843 but can be independently merged
