### PR TITLE
BUGFIX: length_of_indexer() can return incorrect values that break slice assignments

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -205,6 +205,7 @@ Bug Fixes
 - Bug in ``to_msgpack`` and ``read_msgpack`` zlib and blosc compression support (:issue:`9783`)
 
 - Bug ``GroupBy.size`` doesn't attach index name properly if grouped by ``TimeGrouper`` (:issue:`9925`)
+- Bug causing an exception in slice assignments because ``length_of_indexer`` returns wrong results (:issue:`9995`)
 
 
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1591,8 +1591,8 @@ def length_of_indexer(indexer, target=None):
         if step is None:
             step = 1
         elif step < 0:
-            step = abs(step)
-        return (stop - start) / step
+            step = -step
+        return (stop - start + step-1) // step
     elif isinstance(indexer, (ABCSeries, Index, np.ndarray, list)):
         return len(indexer)
     elif not is_list_like_indexer(indexer):

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -1438,6 +1438,13 @@ class TestIndexing(tm.TestCase):
         result = s.iloc[:4]
         assert_series_equal(result, expected)
 
+        s= Series([-1]*6)
+        s.iloc[0::2]= [0,2,4]
+        s.iloc[1::2]= [1,3,5]
+        result  = s
+        expected= Series([0,1,2,3,4,5])
+        assert_series_equal(result, expected)
+
     def test_iloc_setitem_list_of_lists(self):
 
         # GH 7551


### PR DESCRIPTION
... assignments.

BUG DESCRIPTION:
length_of_indexer() (defined in pandas/core/indexing.py) returns incorrect result
if (stop-start) is not divisible by step. As a consequence some slice assignments
throw exceptions. Affected panda versions: 0.16.x, 0.15.x, current git master.

HOW TO REPRODUCE:

import pandas as pd
sr= pd.Series([-1]*6) # series with 6 elements indexed from 0 to 5.
sr[0::2]= [0,2,4] # setting even elements works fine!
sr[1::2]= [1,3,5] # setting odd elements results in error:

.../pandas/core/internals.pyc in setitem(self, indexer, value)
    568             if is_list_like(value) and l:
    569                 if len(value) != length_of_indexer(indexer, values):
--> 570                     raise ValueError("cannot set using a slice indexer with a "
    571                                      "different length than the value")
    572
ValueError: cannot set using a slice indexer with a different length than the value
