### PR TITLE
CLN: remove an unnecessary warning from test_index.py

### DIFF
--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1357,7 +1357,7 @@ class Index(IndexOpsMixin, PandasObject):
         theDiff = sorted(set(self) - set(other))
         return Index(theDiff, name=result_name)
 
-    diff = deprecate('diff',difference)
+    diff = deprecate('diff', difference)
 
     def sym_diff(self, other, result_name=None):
         """

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -769,7 +769,7 @@ class TestIndex(Base, tm.TestCase):
         self.assertEqual(result.name, first.name)
 
         # non-iterable input
-        assertRaisesRegexp(TypeError, "iterable", first.diff, 0.5)
+        assertRaisesRegexp(TypeError, "iterable", first.difference, 0.5)
 
     def test_symmetric_diff(self):
         # smoke


### PR DESCRIPTION
Just a minor cleanup. `diff` is deprecated and it triggers a warning. 
