### PR TITLE
kwarg for Categorical.fillna should be value instead of fill_value

### DIFF
--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1693,7 +1693,7 @@ class CategoricalBlock(NonConsolidatableMixIn, ObjectBlock):
                                       "not been implemented yet")
 
         values = self.values if inplace else self.values.copy()
-        return [self.make_block_same_class(values=values.fillna(fill_value=value,
+        return [self.make_block_same_class(values=values.fillna(value=value,
                                                                 limit=limit),
                                            placement=self.mgr_locs)]
 


### PR DESCRIPTION
It seems inconsistent that all the other `fillna()` methods (`DataFrame.fillna`, `Series.fillna`, etc) have `value` as the first kwarg but `Categorical` has `fill_value` instead
