### PR TITLE
ENH: support __radd__ operation on Index

### DIFF
--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1181,12 +1181,18 @@ class Index(IndexOpsMixin, PandasObject):
     def __add__(self, other):
         if com.is_list_like(other):
             warnings.warn("using '+' to provide set union with Indexes is deprecated, "
-                          "use '|' or .union()",FutureWarning)
+                          "use '|' or .union()", FutureWarning)
         if isinstance(other, Index):
             return self.union(other)
         return Index(np.array(self) + other)
+
+    def __radd__(self, other):
+        if com.is_list_like(other):
+            warnings.warn("using '+' to provide set union with Indexes is deprecated, "
+                          "use '|' or .union()", FutureWarning)
+        return Index(other + np.array(self))
+
     __iadd__ = __add__
-    __radd__ = __add__
 
     def __sub__(self, other):
         warnings.warn("using '-' to provide set differences with Indexes is deprecated, "

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -705,6 +705,13 @@ class TestIndex(Base, tm.TestCase):
         tm.assert_contains_all(self.strIndex, secondCat)
         tm.assert_contains_all(self.dateIndex, firstCat)
 
+        # test add and radd
+        idx = Index(list('abc'))
+        expected = Index(['a1', 'b1', 'c1'])
+        self.assert_index_equal(idx + '1', expected)
+        expected = Index(['1a', '1b', '1c'])
+        self.assert_index_equal('1' + idx, expected)
+
     def test_append_multiple(self):
         index = Index(['a', 'b', 'c', 'd', 'e', 'f'])
 


### PR DESCRIPTION
closed #10083

Currently the following would raise a `TypeError`:

```
In [1]: import pandas as pd
In [2]: idx = pd.Index(list('abc'))
In [3]: idx + '1'
Out[3]: Index(['a1', 'b1', 'c1'], dtype='object')
In [4]: '1' + idx
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-5e2fbeff7266> in <module>()
----> 1 '1' + idx

TypeError: Can't convert 'Index' object to str implicitly
```

While for `Series` this works fine:

```
In [5]: s = pd.Series(list('abc'))

In [6]: '1' + s
Out[6]:
0    1a
1    1b
2    1c
dtype: object

In [7]: s + '1'
Out[7]:
0    a1
1    b1
2    c1
dtype: object
```

This PR implements the `__radd__` method so that adding from the left would work for `Index`. 
