### PR TITLE
Speed up max_len_string_array

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -171,7 +171,7 @@ Performance Improvements
 
 - Improved csv write performance with mixed dtypes, including datetimes by up to 5x (:issue:`9940`)
 - Improved csv write performance generally by 2x (:issue:`9940`)
-
+- Improved the performance of ``pd.lib.max_len_string_array`` by 5-7x (:issue:`10024`)
 
 
 

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1626,7 +1626,7 @@ def _dtype_to_stata_type(dtype, column):
     elif dtype.type == np.object_:  # try to coerce it to the biggest string
                                     # not memory efficient, what else could we
                                     # do?
-        itemsize = max_len_string_array(column.values)
+        itemsize = max_len_string_array(com._ensure_object(column.values))
         return chr(max(itemsize, 1))
     elif dtype == np.float64:
         return chr(255)
@@ -1664,7 +1664,7 @@ def _dtype_to_default_stata_fmt(dtype, column):
         if not (inferred_dtype in ('string', 'unicode')
                 or len(column) == 0):
             raise ValueError('Writing general object arrays is not supported')
-        itemsize = max_len_string_array(column.values)
+        itemsize = max_len_string_array(com._ensure_object(column.values))
         if itemsize > 244:
             raise ValueError(excessive_string_length_error % column.name)
         return "%" + str(max(itemsize, 1)) + "s"

--- a/pandas/io/tests/test_data.py
+++ b/pandas/io/tests/test_data.py
@@ -105,6 +105,7 @@ class TestGoogle(tm.TestCase):
         sl = ['INVALID', 'INVALID2', 'INVALID3']
         self.assertRaises(RemoteDataError, web.get_data_google, sl, '2012')
 
+    @network
     def test_get_multi2(self):
         with warnings.catch_warnings(record=True) as w:
             for locale in self.locales:

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -18,7 +18,10 @@ from cpython cimport (PyDict_New, PyDict_GetItem, PyDict_SetItem,
                       PyBytes_Check,
                       PyTuple_SetItem,
                       PyTuple_New,
-                      PyObject_SetAttrString)
+                      PyObject_SetAttrString,
+                      PyString_GET_SIZE,
+                      PyBytes_GET_SIZE,
+                      PyUnicode_GET_SIZE)
 
 cdef extern from "Python.h":
     Py_ssize_t PY_SSIZE_T_MAX
@@ -901,18 +904,20 @@ def clean_index_list(list obj):
 def max_len_string_array(ndarray arr):
     """ return the maximum size of elements in a 1-dim string array """
     cdef:
-        int i, m, l
-        int length = arr.shape[0]
+        Py_ssize_t i, m = 0, l = 0, length = arr.shape[0]
         object v
 
-    m = 0
-    for i from 0 <= i < length:
+    for i in range(length):
         v = arr[i]
-        if PyString_Check(v) or PyBytes_Check(v) or PyUnicode_Check(v):
-            l = len(v)
+        if PyString_Check(v):
+            l = PyString_GET_SIZE(v)
+        elif PyBytes_Check(v):
+            l = PyBytes_GET_SIZE(v)
+        elif PyUnicode_Check(v):
+            l = PyUnicode_GET_SIZE(v)
 
-            if l > m:
-                m = l
+        if l > m:
+            m = l
 
     return m
 

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -905,7 +905,7 @@ def clean_index_list(list obj):
     return maybe_convert_objects(converted), 0
 
 
-ctypedef fused pandas_t:
+ctypedef fused pandas_string:
     str
     unicode
     bytes
@@ -913,11 +913,11 @@ ctypedef fused pandas_t:
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef Py_ssize_t max_len_string_array(pandas_t[:] arr):
+cpdef Py_ssize_t max_len_string_array(pandas_string[:] arr):
     """ return the maximum size of elements in a 1-dim string array """
     cdef:
         Py_ssize_t i, m = 0, l = 0, length = arr.shape[0]
-        pandas_t v
+        pandas_string v
 
     for i in range(length):
         v = arr[i]

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -903,21 +903,11 @@ def clean_index_list(list obj):
 ctypedef fused pandas_t:
     str
     unicode
-    float32_t
-    float64_t
-    uint8_t
-    uint16_t
-    uint32_t
-    uint64_t
-    int8_t
-    int16_t
-    int32_t
-    int64_t
 
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def max_len_string_array(pandas_t[:] arr):
+cpdef Py_ssize_t max_len_string_array(pandas_t[:] arr):
     """ return the maximum size of elements in a 1-dim string array """
     cdef:
         Py_ssize_t i, m = 0, l = 0, length = arr.shape[0]

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -901,7 +901,7 @@ def clean_index_list(list obj):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def max_len_string_array(ndarray arr):
+def max_len_string_array(ndarray[object] arr):
     """ return the maximum size of elements in a 1-dim string array """
     cdef:
         Py_ssize_t i, m = 0, l = 0, length = arr.shape[0]

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -1,6 +1,7 @@
 cimport numpy as np
 cimport cython
 import numpy as np
+import sys
 
 from numpy cimport *
 
@@ -9,6 +10,7 @@ np.import_array()
 cdef extern from "numpy/arrayobject.h":
     cdef enum NPY_TYPES:
         NPY_intp "NPY_INTP"
+
 
 from cpython cimport (PyDict_New, PyDict_GetItem, PyDict_SetItem,
                       PyDict_Contains, PyDict_Keys,
@@ -19,9 +21,13 @@ from cpython cimport (PyDict_New, PyDict_GetItem, PyDict_SetItem,
                       PyTuple_SetItem,
                       PyTuple_New,
                       PyObject_SetAttrString,
-                      PyString_GET_SIZE,
                       PyBytes_GET_SIZE,
                       PyUnicode_GET_SIZE)
+
+try:
+    from cpython cimport PyString_GET_SIZE
+except ImportError:
+    from cpython cimport PyUnicode_GET_SIZE as PyString_GET_SIZE
 
 cdef extern from "Python.h":
     Py_ssize_t PY_SSIZE_T_MAX
@@ -33,7 +39,6 @@ cdef extern from "Python.h":
         PySliceObject* s, Py_ssize_t length,
         Py_ssize_t *start, Py_ssize_t *stop, Py_ssize_t *step,
         Py_ssize_t *slicelength) except -1
-
 
 
 cimport cpython
@@ -903,6 +908,7 @@ def clean_index_list(list obj):
 ctypedef fused pandas_t:
     str
     unicode
+    bytes
 
 
 @cython.boundscheck(False)

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -899,13 +899,29 @@ def clean_index_list(list obj):
 
     return maybe_convert_objects(converted), 0
 
+
+ctypedef fused pandas_t:
+    str
+    unicode
+    float32_t
+    float64_t
+    uint8_t
+    uint16_t
+    uint32_t
+    uint64_t
+    int8_t
+    int16_t
+    int32_t
+    int64_t
+
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def max_len_string_array(ndarray[object] arr):
+def max_len_string_array(pandas_t[:] arr):
     """ return the maximum size of elements in a 1-dim string array """
     cdef:
         Py_ssize_t i, m = 0, l = 0, length = arr.shape[0]
-        object v
+        pandas_t v
 
     for i in range(length):
         v = arr[i]

--- a/pandas/tests/test_lib.py
+++ b/pandas/tests/test_lib.py
@@ -16,7 +16,7 @@ class TestMisc(tm.TestCase):
         self.assertTrue(max_len_string_array(arr),3)
 
         # unicode
-        arr = arr.astype('U')
+        arr = arr.astype('U').astype(object)
         self.assertTrue(max_len_string_array(arr),3)
 
 class TestIsscalar(tm.TestCase):

--- a/pandas/tests/test_lib.py
+++ b/pandas/tests/test_lib.py
@@ -19,6 +19,10 @@ class TestMisc(tm.TestCase):
         arr = arr.astype('U').astype(object)
         self.assertTrue(max_len_string_array(arr),3)
 
+        # raises
+        tm.assertRaises(TypeError,
+                        lambda: max_len_string_array(arr.astype('U')))
+
 class TestIsscalar(tm.TestCase):
     def test_isscalar_builtin_scalars(self):
         self.assertTrue(isscalar(None))

--- a/pandas/tests/test_lib.py
+++ b/pandas/tests/test_lib.py
@@ -8,22 +8,29 @@ from pandas.lib import isscalar, item_from_zerodim, max_len_string_array
 import pandas.util.testing as tm
 from pandas.compat import u
 
+
 class TestMisc(tm.TestCase):
 
     def test_max_len_string_array(self):
 
-        arr = np.array(['foo','b',np.nan],dtype='object')
-        self.assertTrue(max_len_string_array(arr),3)
+        arr = a = np.array(['foo', 'b', np.nan], dtype='object')
+        self.assertTrue(max_len_string_array(arr), 3)
 
         # unicode
-        arr = arr.astype('U').astype(object)
-        self.assertTrue(max_len_string_array(arr),3)
+        arr = a.astype('U').astype(object)
+        self.assertTrue(max_len_string_array(arr), 3)
+
+        # bytes for python3
+        arr = a.astype('S').astype(object)
+        self.assertTrue(max_len_string_array(arr), 3)
 
         # raises
         tm.assertRaises(TypeError,
                         lambda: max_len_string_array(arr.astype('U')))
 
+
 class TestIsscalar(tm.TestCase):
+
     def test_isscalar_builtin_scalars(self):
         self.assertTrue(isscalar(None))
         self.assertTrue(isscalar(True))


### PR DESCRIPTION
Before:

``` python
In [5]: x = np.array(['abcd', 'abcde', 'abcdef', 'abcdefg'] * int(1e7), object)

In [2]: f = pd.lib.max_len_string_array

In [6]: %timeit f(x)
1 loops, best of 3: 501 ms per loop
```

After:

``` python
In [1]: x = np.array(['abcd', 'abcde', 'abcdef', 'abcdefg'] * int(1e7), object)

In [2]: f = pd.lib.max_len_string_array

In [3]: %timeit f(x)
10 loops, best of 3: 68.4 ms per loop
```
