### PR TITLE
DOC: mention other packages in IO docs (for now, just xray for netCDF)

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -3996,6 +3996,24 @@ whether imported ``Categorical`` variables are ordered.
     a ``Categorial`` with string categories for the values that are labeled and
     numeric categories for values with no label.
 
+.. _io.other:
+
+Other file formats
+------------------
+
+pandas itself only supports IO with a limited set of file formats that map
+cleanly to its tabular data model. For reading and writing other file formats
+into and from pandas, we recommend these packages from the broader community.
+
+netCDF
+~~~~~~
+
+xray_ provides data structures inspired by the pandas DataFrame for working
+with multi-dimensional datasets, with a focus on the netCDF file format and
+easy conversion to and from pandas.
+
+.. _xray: http://xray.readthedocs.org/
+
 .. _io.perf:
 
 Performance Considerations


### PR DESCRIPTION
As discussed in #5487.

This would also be a nice place to mention other packages that connect the
pandas DataFrames with other file formats. Right now, the only one I can think
of off-hand is `root_pandas` (#9378, CC @ibab), but I'm sure there are more.
