### PR TITLE
DOC: use _shared_docs for fillna methods

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -66,7 +66,7 @@ from pandas.core.config import get_option
 # Docstring templates
 
 _shared_doc_kwargs = dict(axes='index, columns', klass='DataFrame',
-                          axes_single_arg="{0,1,'index','columns'}")
+                          axes_single_arg="{0, 1, 'index', 'columns'}")
 
 _numeric_only_doc = """numeric_only : boolean, default None
     Include only float, int, boolean data. If None, will attempt to use
@@ -2513,6 +2513,14 @@ class DataFrame(NDFrame):
     @Appender(_shared_docs['rename'] % _shared_doc_kwargs)
     def rename(self, index=None, columns=None, **kwargs):
         return super(DataFrame, self).rename(index=index, columns=columns,
+                                             **kwargs)
+
+    @Appender(_shared_docs['fillna'] % _shared_doc_kwargs)
+    def fillna(self, value=None, method=None, axis=None, inplace=False,
+               limit=None, downcast=None, **kwargs):
+        return super(DataFrame, self).fillna(value=value, method=method,
+                                             axis=axis, inplace=inplace,
+                                             limit=limit, downcast=downcast,
                                              **kwargs)
 
     def set_index(self, keys, drop=True, append=False, inplace=False,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2295,8 +2295,7 @@ class NDFrame(PandasObject):
     #----------------------------------------------------------------------
     # Filling NA's
 
-    def fillna(self, value=None, method=None, axis=None, inplace=False,
-               limit=None, downcast=None):
+    _shared_docs['fillna'] = (
         """
         Fill NA/NaN values using the specified method
 
@@ -2311,9 +2310,7 @@ class NDFrame(PandasObject):
             values specifying which value to use for each index (for a Series) or
             column (for a DataFrame). (values not in the dict/Series/DataFrame will not be
             filled). This value cannot be a list.
-        axis : {0, 1}, default 0
-            * 0: fill column-by-column
-            * 1: fill row-by-row
+        axis : %(axes_single_arg)s
         inplace : boolean, default False
             If True, fill in place. Note: this will modify any
             other views on this object, (e.g. a no-copy slice for a column in a
@@ -2336,8 +2333,13 @@ class NDFrame(PandasObject):
 
         Returns
         -------
-        filled : same type as caller
+        filled : %(klass)s
         """
+    )
+
+    @Appender(_shared_docs['fillna'] % _shared_doc_kwargs)
+    def fillna(self, value=None, method=None, axis=None, inplace=False,
+               limit=None, downcast=None):
         if isinstance(value, (list, tuple)):
             raise TypeError('"value" parameter must be a scalar or dict, but '
                             'you passed a "{0}"'.format(type(value).__name__))

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -34,7 +34,7 @@ from pandas import lib
 _shared_doc_kwargs = dict(
     axes='items, major_axis, minor_axis',
     klass="Panel",
-    axes_single_arg="{0,1,2,'items','major_axis','minor_axis'}")
+    axes_single_arg="{0, 1, 2, 'items', 'major_axis', 'minor_axis'}")
 _shared_doc_kwargs['args_transpose'] = ("three positional arguments: each one"
                                         "of\n        %s" %
                                         _shared_doc_kwargs['axes_single_arg'])
@@ -1160,6 +1160,14 @@ class Panel(NDFrame):
     @Appender(_shared_docs['transpose'] % _shared_doc_kwargs)
     def transpose(self, *args, **kwargs):
         return super(Panel, self).transpose(*args, **kwargs)
+
+    @Appender(_shared_docs['fillna'] % _shared_doc_kwargs)
+    def fillna(self, value=None, method=None, axis=None, inplace=False,
+               limit=None, downcast=None, **kwargs):
+        return super(Panel, self).fillna(value=value, method=method,
+                                         axis=axis, inplace=inplace,
+                                         limit=limit, downcast=downcast,
+                                         **kwargs)
 
     def count(self, axis='major'):
         """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -59,7 +59,7 @@ __all__ = ['Series']
 _shared_doc_kwargs = dict(
     axes='index',
     klass='Series',
-    axes_single_arg="{0,'index'}",
+    axes_single_arg="{0, 'index'}",
     inplace="""inplace : boolean, default False
             If True, performs operation inplace and returns None.""",
     duplicated='Series'
@@ -2142,6 +2142,14 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     @Appender(generic._shared_docs['reindex'] % _shared_doc_kwargs)
     def reindex(self, index=None, **kwargs):
         return super(Series, self).reindex(index=index, **kwargs)
+
+    @Appender(generic._shared_docs['fillna'] % _shared_doc_kwargs)
+    def fillna(self, value=None, method=None, axis=None, inplace=False,
+               limit=None, downcast=None, **kwargs):
+        return super(Series, self).fillna(value=value, method=method,
+                                          axis=axis, inplace=inplace,
+                                          limit=limit, downcast=downcast,
+                                          **kwargs)
 
     def reindex_axis(self, labels, axis=0, **kwargs):
         """ for compatibility with higher dims """


### PR DESCRIPTION
currently the docstring for `DataFrame.fillna` is shown for `Series.fillna` and `Panel.fillna`. http://pandas.pydata.org/pandas-docs/version/0.16.0/generated/pandas.Panel.fillna.html?highlight=fillna#pandas.Panel.fillna 

this is not accurate in particular for the `axis` values. This PR makes it such that they share the same template with different `axis` descriptions. 
