### PR TITLE
BUG: numericlike set ops on unsupported Indexes

### DIFF
--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1179,17 +1179,18 @@ class Index(IndexOpsMixin, PandasObject):
         return result.argsort(*args, **kwargs)
 
     def __add__(self, other):
-        if isinstance(other, Index):
+        if com.is_list_like(other):
             warnings.warn("using '+' to provide set union with Indexes is deprecated, "
                           "use '|' or .union()",FutureWarning)
+        if isinstance(other, Index):
             return self.union(other)
         return Index(np.array(self) + other)
     __iadd__ = __add__
+    __radd__ = __add__
 
     def __sub__(self, other):
-        if isinstance(other, Index):
-            warnings.warn("using '-' to provide set differences with Indexes is deprecated, "
-                          "use .difference()",FutureWarning)
+        warnings.warn("using '-' to provide set differences with Indexes is deprecated, "
+                      "use .difference()",FutureWarning)
         return self.difference(other)
 
     def __and__(self, other):
@@ -2481,8 +2482,8 @@ class Index(IndexOpsMixin, PandasObject):
             invalid_op.__name__ = name
             return invalid_op
 
-        cls.__add__ = cls.__add__ = __iadd__ = _make_invalid_op('__add__')
-        cls.__sub__ = cls.__sub__ = __isub__ = _make_invalid_op('__sub__')
+        cls.__add__ = cls.__radd__ = __iadd__ = _make_invalid_op('__add__')
+        cls.__sub__ = __isub__ = _make_invalid_op('__sub__')
 
     @classmethod
     def _add_numeric_methods_disabled(cls):

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -2470,6 +2470,21 @@ class Index(IndexOpsMixin, PandasObject):
         cls.__ge__ = _make_compare('__ge__')
 
     @classmethod
+    def _add_numericlike_set_methods_disabled(cls):
+        """ add in the numeric set-like methods to disable """
+
+        def _make_invalid_op(name):
+
+            def invalid_op(self, other=None):
+                raise TypeError("cannot perform {name} with this index type: {typ}".format(name=name,
+                                                                                           typ=type(self)))
+            invalid_op.__name__ = name
+            return invalid_op
+
+        cls.__add__ = cls.__add__ = __iadd__ = _make_invalid_op('__add__')
+        cls.__sub__ = cls.__sub__ = __isub__ = _make_invalid_op('__sub__')
+
+    @classmethod
     def _add_numeric_methods_disabled(cls):
         """ add in numeric methods to disable """
 
@@ -3148,6 +3163,7 @@ class CategoricalIndex(Index, PandasDelegate):
                                                  overwrite=True)
 
 
+CategoricalIndex._add_numericlike_set_methods_disabled()
 CategoricalIndex._add_numeric_methods_disabled()
 CategoricalIndex._add_logical_methods_disabled()
 CategoricalIndex._add_comparison_methods()

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -612,7 +612,7 @@ def _stack_multi_columns(frame, level_num=-1, dropna=True):
         new_data[key] = value_slice.ravel()
 
     if len(drop_cols) > 0:
-        new_columns = new_columns - drop_cols
+        new_columns = new_columns.difference(drop_cols)
 
     N = len(this)
 
@@ -1045,7 +1045,7 @@ def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False,
         with_dummies = [result]
         for (col, pre, sep) in zip(columns_to_encode, prefix, prefix_sep):
 
-            dummy = _get_dummies_1d(data[col], prefix=pre, prefix_sep=sep, 
+            dummy = _get_dummies_1d(data[col], prefix=pre, prefix_sep=sep,
                                     dummy_na=dummy_na, sparse=sparse)
             with_dummies.append(dummy)
         result = concat(with_dummies, axis=1)

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -3613,7 +3613,7 @@ class TestHDFStore(tm.TestCase):
 
             # invert ok for filters
             result = store.select('df', "~(columns=['A','B'])")
-            expected = df.loc[:,df.columns-['A','B']]
+            expected = df.loc[:,df.columns.difference(['A','B'])]
             tm.assert_frame_equal(result, expected)
 
             # in

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -1488,6 +1488,19 @@ class TestCategoricalIndex(Base, tm.TestCase):
         result = CategoricalIndex(idx, categories=idx, ordered=True)
         tm.assert_index_equal(result, expected, exact=True)
 
+    def test_disallow_set_ops(self):
+
+        # GH 10039
+        # set ops (+/-) raise TypeError
+        idx = pd.Index(pd.Categorical(['a', 'b']))
+
+        self.assertRaises(TypeError, lambda : idx - idx)
+        self.assertRaises(TypeError, lambda : idx + idx)
+        self.assertRaises(TypeError, lambda : idx - ['a','b'])
+        self.assertRaises(TypeError, lambda : idx + ['a','b'])
+        self.assertRaises(TypeError, lambda : ['a','b'] - idx)
+        self.assertRaises(TypeError, lambda : ['a','b'] + idx)
+
     def test_method_delegation(self):
 
         ci = CategoricalIndex(list('aabbca'), categories=list('cabdef'))
@@ -3882,6 +3895,12 @@ class TestMultiIndex(Base, tm.TestCase):
         # - API change GH 8226
         with tm.assert_produces_warning():
             first - self.index[-3:]
+        with tm.assert_produces_warning():
+            self.index[-3:] - first
+        with tm.assert_produces_warning():
+            self.index[-3:] - first.tolist()
+        with tm.assert_produces_warning():
+            first.tolist() - self.index[-3:]
 
         expected = MultiIndex.from_tuples(sorted(self.index[:-3].values),
                                           sortorder=0,

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -686,6 +686,10 @@ class TestIndex(Base, tm.TestCase):
         # - API change GH 8226
         with tm.assert_produces_warning():
             self.strIndex + self.strIndex
+        with tm.assert_produces_warning():
+            self.strIndex + self.strIndex.tolist()
+        with tm.assert_produces_warning():
+            self.strIndex.tolist() + self.strIndex
 
         firstCat = self.strIndex.union(self.dateIndex)
         secondCat = self.strIndex.union(self.strIndex)
@@ -772,6 +776,7 @@ class TestIndex(Base, tm.TestCase):
         assertRaisesRegexp(TypeError, "iterable", first.difference, 0.5)
 
     def test_symmetric_diff(self):
+
         # smoke
         idx1 = Index([1, 2, 3, 4], name='idx1')
         idx2 = Index([2, 3, 4, 5])
@@ -819,7 +824,7 @@ class TestIndex(Base, tm.TestCase):
 
         # other isn't iterable
         with tm.assertRaises(TypeError):
-            Index(idx1,dtype='object') - 1
+            Index(idx1,dtype='object').difference(1)
 
     def test_is_numeric(self):
         self.assertFalse(self.dateIndex.is_numeric())
@@ -3899,8 +3904,8 @@ class TestMultiIndex(Base, tm.TestCase):
             self.index[-3:] - first
         with tm.assert_produces_warning():
             self.index[-3:] - first.tolist()
-        with tm.assert_produces_warning():
-            first.tolist() - self.index[-3:]
+
+        self.assertRaises(TypeError, lambda : first.tolist() - self.index[-3:])
 
         expected = MultiIndex.from_tuples(sorted(self.index[:-3].values),
                                           sortorder=0,


### PR DESCRIPTION
closes #10038 
closes #10039
- `CategoricalIndex` now raise `TypeError` on ops like : `idx - idx` (we are moving all non-numeric Indexes to this, but just deprecated for now on existing index types)
- Index ops with lists will now show the same warning (e.g. `idx - ['a','b']`)
