### PR TITLE
BUG: read_hdf modifying passed columns list (GH7212)

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -60,6 +60,8 @@ Performance Improvements
 Bug Fixes
 ~~~~~~~~~
 
+- Bug where read_hdf store.select modifies the passed columns list when
+  multi-indexed (:issue:`7212`)
 - Bug in ``Categorical`` repr with ``display.width`` of ``None`` in Python 3 (:issue:`10087`)
 
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3453,6 +3453,10 @@ class Table(Fixed):
     def process_axes(self, obj, columns=None):
         """ process axes filters """
 
+        # make a copy to avoid side effects
+        if columns is not None:
+            columns = list(columns)
+
         # make sure to include levels if we have them
         if columns is not None and self.is_multi_index:
             for n in self.levels:


### PR DESCRIPTION
Closes #7212. If this object is a list, make a copy and then pass to process_axes - otherwise, just pass the object directly (in this case it is most likely none).

A test for this behavior seems complex and somewhat contrived when compared with what exists in test_pytables.py, so I didn't add one --- let me know any thoughts on this.
