### PR TITLE
ENH: Series.resample performance with datetime64[ns] #7754

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -53,6 +53,8 @@ Removal of prior version deprecations/changes
 Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
+- Improved ``Series.resample`` performance with dtype=datetime64[ns] (:issue:`7754`)
+
 .. _whatsnew_0170.bug_fixes:
 
 Bug Fixes

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1496,6 +1496,8 @@ class BaseGrouper(object):
 
         if is_datetime_or_timedelta_dtype(values.dtype):
             values = values.view('int64')
+            # GH 7754
+            is_numeric = True
         elif is_bool_dtype(values.dtype):
             values = _algos.ensure_float64(values)
         elif com.is_integer_dtype(values):

--- a/vb_suite/timeseries.py
+++ b/vb_suite/timeseries.py
@@ -135,6 +135,16 @@ timeseries_timestamp_downsample_mean = \
     Benchmark("ts.resample('D', how='mean')", setup,
               start_date=datetime(2012, 4, 25))
 
+# GH 7754
+setup = common_setup + """
+rng = date_range(start='2000-01-01 00:00:00',
+                    end='2000-01-01 10:00:00', freq='555000U')
+int_ts = Series(5, rng, dtype='int64')
+ts = int_ts.astype('datetime64[ns]')
+"""
+
+timeseries_resample_datetime64 = Benchmark("ts.resample('1S', how='last')", setup)
+
 #----------------------------------------------------------------------
 # to_datetime
 


### PR DESCRIPTION
It fixes the performance drop.
See %timeit result [here](http://nbviewer.ipython.org/gist/scari/1173a9519d8b89000c08).
closes #7754 

@jreback Would you review this PR? Thanks!
