### PR TITLE
BUG: Panel.from_dict does not set dtype when specified

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -63,6 +63,7 @@ Bug Fixes
 - Bug in ``Categorical`` repr with ``display.width`` of ``None`` in Python 3 (:issue:`10087`)
 
 
+- Bug where Panel.from_dict does not set dtype when specified (:issue:`10058`)
 - Bug in ``Timestamp``'s' ``microsecond``, ``quarter``, ``dayofyear``, ``week`` and ``daysinmonth`` properties return ``np.int`` type, not built-in ``int``. (:issue:`10050`)
 - Bug in ``NaT`` raises ``AttributeError`` when accessing to ``daysinmonth``, ``dayofweek`` properties. (:issue:`10096`)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -662,6 +662,8 @@ class DataFrame(NDFrame):
             The "orientation" of the data. If the keys of the passed dict
             should be the columns of the resulting DataFrame, pass 'columns'
             (default). Otherwise if the keys should be rows, pass 'index'.
+        dtype : dtype, default None
+            Data type to force, otherwise infer
 
         Returns
         -------

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -239,7 +239,8 @@ class Panel(NDFrame):
             (default). Otherwise if the columns of the values of the passed
             DataFrame objects should be the items (which in the case of
             mixed-dtype data you should do), instead pass 'minor'
-
+        dtype : dtype, default None
+            Data type to force, otherwise infer
 
         Returns
         -------
@@ -1383,6 +1384,7 @@ class Panel(NDFrame):
                 result[key] = None
 
         axes_dict['data'] = result
+        axes_dict['dtype'] = dtype
         return axes_dict
 
     @staticmethod

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -962,6 +962,12 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
             panel = Panel(np.random.randn(2,10,5),items=lrange(2),major_axis=lrange(10),minor_axis=lrange(5),dtype=dtype)
             _check_dtype(panel,dtype)
 
+        for dtype in ['float64', 'float32', 'int64', 'int32', 'object']:
+            df1 = DataFrame(np.random.randn(2, 5), index=lrange(2), columns=lrange(5))
+            df2 = DataFrame(np.random.randn(2, 5), index=lrange(2), columns=lrange(5))
+            panel = Panel.from_dict({'a': df1, 'b': df2}, dtype=dtype)
+            _check_dtype(panel, dtype)
+
     def test_constructor_fails_with_not_3d_input(self):
         with tm.assertRaisesRegexp(ValueError,
                                    "The number of dimensions required is 3"):


### PR DESCRIPTION
currently `Panel.from_dict` is just ignoring the `dtype` argument:

```
In [1]: import pandas as pd
In [2]: import numpy as np
In [3]: df = pd.DataFrame(np.array(range(6)).reshape(3, 2))
In [4]: pa = pd.Panel.from_dict({'a': df, 'b': df}, dtype=float)
In [5]: pa.dtypes
Out[5]:
a    int64
b    int64
dtype: object
```

this PR sets the `dtype` and fixes the docstrings in some places 
