### PR TITLE
BUG: Fix typo in parsers.py

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -997,7 +997,7 @@ class ParserBase(object):
                 try:
                     values = lib.map_infer(values, conv_f)
                 except ValueError:
-                    mask = lib.ismember(values, na_values).view(np.uin8)
+                    mask = lib.ismember(values, na_values).view(np.uint8)
                     values = lib.map_infer_mask(values, conv_f, mask)
                 coerce_type = False
 


### PR DESCRIPTION
closes #9266 

np.uin8 should be np.uint8
