### PR TITLE
DOC/CLN: docs fixes for Series.shift and DataFrame.shift

### DIFF
--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -1010,8 +1010,7 @@ Shifting / lagging
 
 One may want to *shift* or *lag* the values in a TimeSeries back and forward in
 time. The method for this is ``shift``, which is available on all of the pandas
-objects. In DataFrame, ``shift`` will currently only shift along the ``index``
-and in Panel along the ``major_axis``.
+objects.
 
 .. ipython:: python
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2525,6 +2525,11 @@ class DataFrame(NDFrame):
                                              limit=limit, downcast=downcast,
                                              **kwargs)
 
+    @Appender(_shared_docs['shift'] % _shared_doc_kwargs)
+    def shift(self, periods=1, freq=None, axis=0, **kwargs):
+        return super(DataFrame, self).shift(periods=periods, freq=freq,
+                                            axis=axis, **kwargs)
+
     def set_index(self, keys, drop=True, append=False, inplace=False,
                   verify_integrity=False):
         """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3584,8 +3584,7 @@ class NDFrame(PandasObject):
         return self.where(~cond, other=other, inplace=inplace, axis=axis,
             level=level, try_cast=try_cast, raise_on_error=raise_on_error)
 
-    def shift(self, periods=1, freq=None, axis=0, **kwargs):
-        """
+    _shared_docs['shift'] = ("""
         Shift index by desired number of periods with an optional time freq
 
         Parameters
@@ -3595,6 +3594,7 @@ class NDFrame(PandasObject):
         freq : DateOffset, timedelta, or time rule string, optional
             Increment to use from datetools module or time rule (e.g. 'EOM').
             See Notes.
+        axis : %(axes_single_arg)s
 
         Notes
         -----
@@ -3604,8 +3604,10 @@ class NDFrame(PandasObject):
 
         Returns
         -------
-        shifted : same type as caller
-        """
+        shifted : %(klass)s
+    """)
+    @Appender(_shared_docs['shift'] % _shared_doc_kwargs)
+    def shift(self, periods=1, freq=None, axis=0, **kwargs):
         if periods == 0:
             return self
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2151,6 +2151,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                                           limit=limit, downcast=downcast,
                                           **kwargs)
 
+    @Appender(generic._shared_docs['shift'] % _shared_doc_kwargs)
+    def shift(self, periods=1, freq=None, axis=0, **kwargs):
+        return super(Series, self).shift(periods=periods, freq=freq,
+                                         axis=axis, **kwargs)
+
     def reindex_axis(self, labels, axis=0, **kwargs):
         """ for compatibility with higher dims """
         if axis != 0:


### PR DESCRIPTION
1. currently `Series.shift()` and `DataFrame.shift()` are both missing `axis` information in the docstring.
2. comment in `timeseries.rst` about shifting only possible along `index` or `major_axis` is not true anymore 
