### PR TITLE
PERF: increase performance of str_split when returning a frame

### DIFF
--- a/doc/source/whatsnew/v0.16.2.txt
+++ b/doc/source/whatsnew/v0.16.2.txt
@@ -47,6 +47,7 @@ Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Improved ``Series.resample`` performance with dtype=datetime64[ns] (:issue:`7754`)
+- Increase performance of ``str.split`` when ``expand=True`` (:issue:`10081`)
 
 .. _whatsnew_0162.bug_fixes:
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from pandas.compat import zip
-from pandas.core.common import isnull, _values_from_object, is_bool_dtype
+from pandas.core.common import isnull, _values_from_object, is_bool_dtype, is_list_like
 import pandas.compat as compat
 from pandas.util.decorators import Appender, deprecate_kwarg
 import re
@@ -1090,7 +1090,11 @@ class StringMethods(object):
         else:
             index = self.series.index
             if expand:
-                cons_row = self.series._constructor
+                def cons_row(x):
+                    if is_list_like(x):
+                        return x
+                    else:
+                        return [ x ]
                 cons = self.series._constructor_expanddim
                 data = [cons_row(x) for x in result]
                 return cons(data, index=index)

--- a/vb_suite/strings.py
+++ b/vb_suite/strings.py
@@ -35,6 +35,7 @@ strings_repeat = Benchmark(
 strings_match = Benchmark("many.str.match(r'mat..this')", setup)
 strings_extract = Benchmark("many.str.extract(r'(\w*)matchthis(\w*)')", setup)
 strings_join_split = Benchmark("many.str.join(r'--').str.split('--')", setup)
+strings_join_split_expand = Benchmark("many.str.join(r'--').str.split('--',expand=True)", setup)
 strings_len = Benchmark("many.str.len()", setup)
 strings_findall = Benchmark("many.str.findall(r'[A-Z]+')", setup)
 strings_pad = Benchmark("many.str.pad(100, side='both')", setup)


### PR DESCRIPTION
Closes #10081. 

This simply removes the unnecessary `Series()` in the creation of the DataFrame for the split values in `str_split`. It vastly improves performance (20ms vs 3s for a series of 20,000 strings as a test) while not changing current behavior.
