### PR TITLE
BUG: Series.fillna() raises if given a numerically convertible string

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -372,3 +372,4 @@ Bug Fixes
 - Updated BigQuery connector to no longer use deprecated ``oauth2client.tools.run()`` (:issue:`8327`)
 - Bug in subclassed ``DataFrame``. It may not return the correct class, when slicing or subsetting it. (:issue:`9632`)
 - Bug in ``.median()`` where non-float null values are not handled correctly (:issue:`10040`)
+- Bug in Series.fillna() where it raises if a numerically convertible string is given (:issue:`10092`)

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -4017,7 +4017,8 @@ def _putmask_smart(v, m, n):
     try:
         nn = n[m]
         nn_at = nn.astype(v.dtype)
-        if (nn == nn_at).all():
+        comp = (nn == nn_at)
+        if is_list_like(comp) and comp.all():
             nv = v.copy()
             nv[m] = nn_at
             return nv

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -3654,6 +3654,16 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         expected = Series([999,999,np.nan],index=[0,1,2])
         assert_series_equal(result,expected)
 
+        # GH 9043
+        # make sure a string representation of int/float values can be filled
+        # correctly without raising errors or being converted
+        vals = ['0', '1.5', '-0.3']
+        for val in vals:
+            s = Series([0, 1, np.nan, np.nan, 4], dtype='float64')
+            result = s.fillna(val)
+            expected = Series([0, 1, val, val, 4], dtype='object')
+            assert_series_equal(result, expected)
+
     def test_fillna_bug(self):
         x = Series([nan, 1., nan, 3., nan], ['z', 'a', 'b', 'c', 'd'])
         filled = x.fillna(method='ffill')


### PR DESCRIPTION
First reported here but it's been dormant for a long time: https://github.com/pydata/pandas/pull/9043 

I think it'd be good to patch this bug. @jreback please let me know which release this should go to and I can add a release note. Thanks. 
