### PR TITLE
BUG: categorical doesn't handle display.width of None in Python 3 (GH10087)

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -57,3 +57,5 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
+
+- Bug in ``Categorical`` repr with ``display.width`` of ``None`` in Python 3 (:issue:`10087`)

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -1310,8 +1310,7 @@ class Categorical(PandasObject):
         levheader = "Categories (%d, %s): " % (len(self.categories),
                                                self.categories.dtype)
         width, height = get_terminal_size()
-        max_width = (width if get_option("display.width") == 0
-                    else get_option("display.width"))
+        max_width = get_option("display.width") or width
         if com.in_ipython_frontend():
             # 0 = no breaks
             max_width = 0

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -521,6 +521,15 @@ class TestCategorical(tm.TestCase):
         expected = ("[], Categories (0, object): []")
         self.assertEqual(expected, repr(factor))
 
+    def test_print_none_width(self):
+        # GH10087
+        a = pd.Series(pd.Categorical([1,2,3,4], name="a"))
+        exp = u("0    1\n1    2\n2    3\n3    4\n" +
+              "Name: a, dtype: category\nCategories (4, int64): [1, 2, 3, 4]")
+
+        with option_context("display.width", None):
+            self.assertEqual(exp, repr(a))
+
     def test_periodindex(self):
         idx1 = PeriodIndex(['2014-01', '2014-01', '2014-02', '2014-02',
                             '2014-03', '2014-03'], freq='M')


### PR DESCRIPTION
closes #10087

I think this is fairly straightforward, however I am not sure if the prior code comparing `display.width` to 0 was correct... is `display.width` ever supposed to be set to 0? It looks suspiciously similar to a snippet from `Series.__unicode__()`, but that is looking at `display.max_rows`. Maybe it was brought over incorrectly?

If it should just be a simple comparison to None, not 0 as it was before, just let me know and I'll amend this.
