### PR TITLE
parsing latitude and longitude in wb.get_countries

### DIFF
--- a/pandas/io/wb.py
+++ b/pandas/io/wb.py
@@ -213,6 +213,9 @@ def _get_data(indicator="NY.GNS.ICTR.GN.ZS", country='US',
 
 def get_countries():
     '''Query information about countries
+    
+    Provides information such as: 
+    country code, region, income level, capital city, latitude and longitude
     '''
     url = 'http://api.worldbank.org/countries/?per_page=1000&format=json'
     with urlopen(url) as response:
@@ -222,6 +225,8 @@ def get_countries():
     data.adminregion = [x['value'] for x in data.adminregion]
     data.incomeLevel = [x['value'] for x in data.incomeLevel]
     data.lendingType = [x['value'] for x in data.lendingType]
+    data.latitude = [float(x) if x != "" else np.nan for x in data.latitude]
+    data.longitude = [float(x) if x != "" else np.nan for x in data.longitude]
     data.region = [x['value'] for x in data.region]
     data = data.rename(columns={'id': 'iso3c', 'iso2Code': 'iso2c'})
     return data


### PR DESCRIPTION
World Bank provides latitude and longitude as strings (and an empty string as a missing value). It's inconvenient so, I parse it to floats. Additionally, I added some description to the `wb.get_countries` function.
