### PR TITLE
BUG: fix Series.plot label setting

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -72,3 +72,7 @@ Bug Fixes
 
 
 - Bug in ``DatetimeIndex`` and ``TimedeltaIndex`` names are lost after timedelta arithmetics ( :issue:`9926`)
+
+- Bug in `Series.plot(label="LABEL")` not correctly setting the label (:issue:`10119`)
+
+

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -553,6 +553,29 @@ class TestSeriesPlots(TestPlotBase):
         self.assertEqual(xmin, line[0])
         self.assertEqual(xmax, line[-1])
 
+    def test_label(self):
+        s = Series([1, 2])
+        ax = s.plot(label='LABEL', legend=True)
+        self._check_legend_labels(ax, labels=['LABEL'])
+        self.plt.close()
+        ax = s.plot(legend=True)
+        self._check_legend_labels(ax, labels=['None'])
+        self.plt.close()
+        # get name from index
+        s.name = 'NAME'
+        ax = s.plot(legend=True)
+        self._check_legend_labels(ax, labels=['NAME'])
+        self.plt.close()
+        # override the default
+        ax = s.plot(legend=True, label='LABEL')
+        self._check_legend_labels(ax, labels=['LABEL'])
+        self.plt.close()
+        # Add lebel info, but don't draw
+        ax = s.plot(legend=False, label='LABEL')
+        self.assertEqual(ax.get_legend(), None)  # Hasn't been drawn
+        ax.legend()  # draw it
+        self._check_legend_labels(ax, labels=['LABEL'])
+
     def test_line_area_nan_series(self):
         values = [1, 2, np.nan, 3]
         s = Series(values)

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -999,7 +999,7 @@ class MPLPlot(object):
         data = self.data
 
         if isinstance(data, Series):
-            label = self.kwds.pop('label', None)
+            label = self.label
             if label is None and data.name is None:
                 label = 'None'
             data = data.to_frame(name=label)


### PR DESCRIPTION
Closes https://github.com/pydata/pandas/issues/10119, a regression in 0.16.1

Basically `Series.plot(label='foo')` isn't actually setting the label.

I want to look at one more thing. With this fix you'd need

``` python
s.plot(label='foo', legend=True
```

to get the legend to actually show up. I can't remember what the old behavior was. At least for seaborn, setting a label implies that the legend should be drawn (e.g. `sns.kdeplot(s, label='foo')`)
