### PR TITLE
BUG: get_group fails when multi-grouping with a categorical

### DIFF
--- a/doc/source/whatsnew/v0.16.2.txt
+++ b/doc/source/whatsnew/v0.16.2.txt
@@ -68,7 +68,9 @@ Bug Fixes
 - Bug in getting timezone data with ``dateutil`` on various platforms ( :issue:`9059`, :issue:`8639`, :issue:`9663`, :issue:`10121`)
 - Bug in display datetimes with mixed frequencies uniformly; display 'ms' datetimes to the proper precision. (:issue:`10170`)
 
-- Bung in ``Series`` arithmetic methods may incorrectly hold names (:issue:`10068`)
+- Bug in ``Series`` arithmetic methods may incorrectly hold names (:issue:`10068`)
+
+- Bug in ``GroupBy.get_group`` when grouping on multiple keys, one of which is categorical. (:issue:`10132`)
 
 - Bug in ``DatetimeIndex`` and ``TimedeltaIndex`` names are lost after timedelta arithmetics ( :issue:`9926`)
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -2964,6 +2964,10 @@ class CategoricalIndex(Index, PandasDelegate):
         """ return the underlying data, which is a Categorical """
         return self._data
 
+    def get_values(self):
+        """ return the underlying data as an ndarray """
+        return self._data.get_values()
+
     @property
     def codes(self):
         return self._data.codes

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -5140,6 +5140,13 @@ class TestGroupBy(tm.TestCase):
                          "ints": [1,2,1,2,1,2]}).set_index(["cat","ints"])
         tm.assert_frame_equal(res, exp)
 
+        # GH 10132
+        for key in [('a', 1), ('b', 2), ('b', 1), ('a', 2)]:
+            c, i = key
+            result = groups_double_key.get_group(key)
+            expected = test[(test.cat == c) & (test.ints == i)]
+            assert_frame_equal(result, expected)
+
         d = {'C1': [3, 3, 4, 5], 'C2': [1, 2, 3, 4], 'C3': [10, 100, 200, 34]}
         test = pd.DataFrame(d)
         values = pd.cut(test['C1'], [1, 2, 3, 6])


### PR DESCRIPTION
Example:

``` .python
>>> df = pd.DataFrame({'a' : pd.Categorical('xyxy'), 'b' : 1, 'c' : 2})
>>> df.groupby(['a', 'b']).get_group(('x', 1))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/evanpw/Workspace/pandas/pandas/core/groupby.py", line 601, in get_group
    inds = self._get_index(name)
  File "/home/evanpw/Workspace/pandas/pandas/core/groupby.py", line 429, in _get_index
    sample = next(iter(self.indices))
  File "/home/evanpw/Workspace/pandas/pandas/core/groupby.py", line 414, in indices
    return self.grouper.indices
  File "pandas/src/properties.pyx", line 34, in pandas.lib.cache_readonly.__get__ (pandas/lib.c:41912)
  File "/home/evanpw/Workspace/pandas/pandas/core/groupby.py", line 1305, in indices
    return _get_indices_dict(label_list, keys)
  File "/home/evanpw/Workspace/pandas/pandas/core/groupby.py", line 3762, in _get_indices_dict
    return lib.indices_fast(sorter, group_index, keys, sorted_labels)
  File "pandas/lib.pyx", line 1385, in pandas.lib.indices_fast (pandas/lib.c:23843)
TypeError: Cannot convert Categorical to numpy.ndarray
```

The problem is that `Grouping.group_index` is a CategoricalIndex, so calling `get_values()` gives you a `Categorical`, which needs one more application of `get_values()` to get an `ndarray`
