### PR TITLE
BUG: Strings with exponent but no decimal point parsed as integers in python csv engine

### DIFF
--- a/doc/source/whatsnew/v0.16.2.txt
+++ b/doc/source/whatsnew/v0.16.2.txt
@@ -77,6 +77,8 @@ Bug Fixes
 
 - Bug in `plot` not defaulting to matplotlib `axes.grid` setting (:issue:`9792`)
 
+- Bug causing strings containing an exponent but no decimal to be parsed as ints instead of floats in python csv parser. (:issue:`9565`)
+
 - Bug in ``Series.align`` resets ``name`` when ``fill_value`` is specified (:issue:`10067`)
 - Bug in ``SparseSeries.abs`` resets ``name`` (:issue:`10241`)
 


### PR DESCRIPTION
Fixes GH #9565. I also made the handling of out-of-range integers consistent with the C engine: parse as a string rather than a double.
