### PR TITLE
BUG: declare and use correctly self.unique_check

### DIFF
--- a/pandas/index.pyx
+++ b/pandas/index.pyx
@@ -87,6 +87,7 @@ cdef class IndexEngine:
 
         self.initialized = 0
         self.monotonic_check = 0
+        self.unique_check = 0
 
         self.unique = 0
         self.monotonic_inc = 0
@@ -269,7 +270,7 @@ cdef class IndexEngine:
 
         if len(self.mapping) == len(values):
             self.unique = 1
-            self.unique_check = 1
+        self.unique_check = 1
 
         self.initialized = 1
 


### PR DESCRIPTION
I am not sure I understood the last comment in [the previous pull request](https://github.com/pydata/pandas/pull/9526), but anyway this is a rebased version.

In the previous PR I proposed to simply make the `__get__` of `is_unique` directly rely on `self.initialized`, but I am no more so sure it is a good idea, since the current status is slightly redundant but clearer (and coherent with the use of "is_monotonic").
