### PR TITLE
BUG: consistent datetime display format with < ms #10170

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -68,7 +68,7 @@ Bug Fixes
 - Bug in ``NaT`` raises ``AttributeError`` when accessing to ``daysinmonth``, ``dayofweek`` properties. (:issue:`10096`)
 
 - Bug in getting timezone data with ``dateutil`` on various platforms ( :issue:`9059`, :issue:`8639`, :issue:`9663`, :issue:`10121`)
-
+- Bug in display datetimes with mixed frequencies uniformly; display 'ms' datetimes to the proper precision. (:issue:`10170`)
 
 
 - Bug in ``DatetimeIndex`` and ``TimedeltaIndex`` names are lost after timedelta arithmetics ( :issue:`9926`)

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -14,7 +14,7 @@ from numpy import nan
 from numpy.random import randn
 import numpy as np
 
-from pandas import DataFrame, Series, Index, Timestamp, MultiIndex
+from pandas import DataFrame, Series, Index, Timestamp, MultiIndex, date_range, NaT
 
 import pandas.core.format as fmt
 import pandas.util.testing as tm
@@ -2495,7 +2495,7 @@ class TestSeriesFormatting(tm.TestCase):
 
     def test_freq_name_separation(self):
         s = Series(np.random.randn(10),
-                   index=pd.date_range('1/1/2000', periods=10), name=0)
+                   index=date_range('1/1/2000', periods=10), name=0)
 
         result = repr(s)
         self.assertTrue('Freq: D, Name: 0' in result)
@@ -2556,7 +2556,6 @@ class TestSeriesFormatting(tm.TestCase):
 
     def test_datetimeindex(self):
 
-        from pandas import date_range, NaT
         index = date_range('20130102',periods=6)
         s = Series(1,index=index)
         result = s.to_string()
@@ -2574,7 +2573,6 @@ class TestSeriesFormatting(tm.TestCase):
 
     def test_timedelta64(self):
 
-        from pandas import date_range
         from datetime import datetime, timedelta
 
         Series(np.array([1100, 20], dtype='timedelta64[ns]')).to_string()
@@ -3179,6 +3177,44 @@ class TestDatetime64Formatter(tm.TestCase):
         result = fmt.Datetime64Formatter(x).get_result()
         self.assertEqual(result[0].strip(), "1970-01-01 00:00:00.000000200")
 
+    def test_dates_display(self):
+
+        # 10170
+        # make sure that we are consistently display date formatting
+        x = Series(date_range('20130101 09:00:00',periods=5,freq='D'))
+        x.iloc[1] = np.nan
+        result = fmt.Datetime64Formatter(x).get_result()
+        self.assertEqual(result[0].strip(), "2013-01-01 09:00:00")
+        self.assertEqual(result[1].strip(), "NaT")
+        self.assertEqual(result[4].strip(), "2013-01-05 09:00:00")
+
+        x = Series(date_range('20130101 09:00:00',periods=5,freq='s'))
+        x.iloc[1] = np.nan
+        result = fmt.Datetime64Formatter(x).get_result()
+        self.assertEqual(result[0].strip(), "2013-01-01 09:00:00")
+        self.assertEqual(result[1].strip(), "NaT")
+        self.assertEqual(result[4].strip(), "2013-01-01 09:00:04")
+
+        x = Series(date_range('20130101 09:00:00',periods=5,freq='ms'))
+        x.iloc[1] = np.nan
+        result = fmt.Datetime64Formatter(x).get_result()
+        self.assertEqual(result[0].strip(), "2013-01-01 09:00:00.000")
+        self.assertEqual(result[1].strip(), "NaT")
+        self.assertEqual(result[4].strip(), "2013-01-01 09:00:00.004")
+
+        x = Series(date_range('20130101 09:00:00',periods=5,freq='us'))
+        x.iloc[1] = np.nan
+        result = fmt.Datetime64Formatter(x).get_result()
+        self.assertEqual(result[0].strip(), "2013-01-01 09:00:00.000000")
+        self.assertEqual(result[1].strip(), "NaT")
+        self.assertEqual(result[4].strip(), "2013-01-01 09:00:00.000004")
+
+        x = Series(date_range('20130101 09:00:00',periods=5,freq='N'))
+        x.iloc[1] = np.nan
+        result = fmt.Datetime64Formatter(x).get_result()
+        self.assertEqual(result[0].strip(), "2013-01-01 09:00:00.000000000")
+        self.assertEqual(result[1].strip(), "NaT")
+        self.assertEqual(result[4].strip(), "2013-01-01 09:00:00.000000004")
 
 class TestNaTFormatting(tm.TestCase):
     def test_repr(self):

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -791,7 +791,7 @@ class TestTimeSeries(tm.TestCase):
         series = Series([0, 1000, 2000, iNaT], dtype='M8[ns]')
 
         result = repr(series)
-        expected = ('0          1970-01-01 00:00:00\n'
+        expected = ('0   1970-01-01 00:00:00.000000\n'
                     '1   1970-01-01 00:00:00.000001\n'
                     '2   1970-01-01 00:00:00.000002\n'
                     '3                          NaT\n'


### PR DESCRIPTION
closes #10170

```
In [3]: Series(date_range('20130101 09:00:00',periods=5,freq='D'))
Out[3]: 
0   2013-01-01 09:00:00
1   2013-01-02 09:00:00
2   2013-01-03 09:00:00
3   2013-01-04 09:00:00
4   2013-01-05 09:00:00
dtype: datetime64[ns]

In [4]: Series(date_range('20130101 09:00:00',periods=5,freq='s'))
Out[4]: 
0   2013-01-01 09:00:00
1   2013-01-01 09:00:01
2   2013-01-01 09:00:02
3   2013-01-01 09:00:03
4   2013-01-01 09:00:04
dtype: datetime64[ns]

In [2]: s = Series(date_range('20130101 09:00:00',periods=5,freq='ms'))

In [3]: s.iloc[1] = np.nan

In [4]: s
Out[4]: 
0   2013-01-01 09:00:00.000
1                       NaT
2   2013-01-01 09:00:00.002
3   2013-01-01 09:00:00.003
4   2013-01-01 09:00:00.004
dtype: datetime64[ns]

In [6]: Series(date_range('20130101 09:00:00',periods=5,freq='us'))
Out[6]: 
0   2013-01-01 09:00:00.000000
1   2013-01-01 09:00:00.000001
2   2013-01-01 09:00:00.000002
3   2013-01-01 09:00:00.000003
4   2013-01-01 09:00:00.000004
dtype: datetime64[ns]

In [7]: Series(date_range('20130101 09:00:00',periods=5,freq='N'))
Out[7]: 
0   2013-01-01 09:00:00.000000000
1   2013-01-01 09:00:00.000000001
2   2013-01-01 09:00:00.000000002
3   2013-01-01 09:00:00.000000003
4   2013-01-01 09:00:00.000000004
dtype: datetime64[ns]
```
