### PR TITLE
DOC: Add Index.difference to API doc

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1262,8 +1262,6 @@ Modifying and Computations
    Index.argmax
    Index.copy
    Index.delete
-   Index.diff
-   Index.sym_diff
    Index.drop
    Index.drop_duplicates
    Index.duplicated
@@ -1309,15 +1307,17 @@ Time-specific operations
 
    Index.shift
 
-Combining / joining / merging
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Combining / joining / set operations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
 
    Index.append
-   Index.intersection
    Index.join
+   Index.intersection
    Index.union
+   Index.difference
+   Index.sym_diff
 
 Selecting
 ~~~~~~~~~


### PR DESCRIPTION
Add `Index.difference` to api doc rather than deprecated `Index.diff`  (#8226)

And is it OK to remove `Index.diff` alias because #6581 lists #8227 (which closes #8226)?
