### PR TITLE
BUG: Adding empty dataframes should result in empty blocks #10181

### DIFF
--- a/doc/source/whatsnew/v0.16.2.txt
+++ b/doc/source/whatsnew/v0.16.2.txt
@@ -41,6 +41,8 @@ Other API Changes
 
 - ``Holiday`` now raises ``NotImplementedError`` if both ``offset`` and ``observance`` are used in constructor instead of returning an incorrect result (:issue:`10217`).
 
+- Adding empty ``DataFrame``s results in a ``DataFrame`` that ``.equals`` an empty ``DataFrame`` (:issue:`10181`)
+
 .. _whatsnew_0162.performance:
 
 Performance Improvements

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -3530,11 +3530,15 @@ def construction_error(tot_items, block_shape, axes, e=None):
 def create_block_manager_from_blocks(blocks, axes):
     try:
         if len(blocks) == 1 and not isinstance(blocks[0], Block):
-            # It's OK if a single block is passed as values, its placement is
-            # basically "all items", but if there're many, don't bother
-            # converting, it's an error anyway.
-            blocks = [make_block(values=blocks[0],
-                                 placement=slice(0, len(axes[0])))]
+            # if blocks[0] is of length 0, return empty blocks
+            if not len(blocks[0]):
+                blocks = []
+            else:
+                # It's OK if a single block is passed as values, its placement is
+                # basically "all items", but if there're many, don't bother
+                # converting, it's an error anyway.
+                blocks = [make_block(values=blocks[0],
+                                     placement=slice(0, len(axes[0])))]
 
         mgr = BlockManager(blocks, axes)
         mgr._consolidate_inplace()

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5142,6 +5142,17 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df = DataFrame({'a': ['a', None, 'b']})
         assert_frame_equal(df + df, DataFrame({'a': ['aa', np.nan, 'bb']}))
 
+        # Test for issue #10181
+        for dtype in ('float', 'int64'):
+            frames = [
+                DataFrame(dtype=dtype),
+                DataFrame(columns=['A'], dtype=dtype),
+                DataFrame(index=[0], dtype=dtype),
+            ]
+            for df in frames:
+                self.assertTrue((df + df).equals(df))
+                assert_frame_equal(df + df, df)
+
     def test_ops_np_scalar(self):
         vals, xs = np.random.rand(5, 3), [nan, 7, -23, 2.718, -3.14, np.inf]
         f = lambda x: DataFrame(x, index=list('ABCDE'),


### PR DESCRIPTION
Fixes #10181 

I added a couple of lines to the dataframe test `test_operators` to assert that  adding two empty dataframes returns a dataframe that is equal (both using `assert_frame_equal` as well as `.equals`) to an empty dataframe.

I couldn't get vbench to install (I am running on windows) - the error was:

```
c:\dev\code\opensource\pandas-rekcahpassyla>pip install git+https://github.com/pydata/vbench
You are using pip version 6.0.8, however version 6.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Collecting git+https://github.com/pydata/vbench
  Cloning https://github.com/pydata/vbench to c:\users\redacted\appdata\local\temp\pip-ruiahg-build
fatal: unable to connect to github.com:
github.com[0: 192.30.252.129]: errno=No error

Clone of 'git://github.com/yarikoptic/vbenchtest.git' into submodule path 'vbench/tests/vbenchtest/vbenchtest' failed
  Complete output from command C:\dev\bin\git\cmd\git.exe submodule update --init --recursive -q:

  ----------------------------------------
  Command "C:\dev\bin\git\cmd\git.exe submodule update --init --recursive -q" failed with error code 1 in c:\users\redacted\appdata\local\temp\pip-ruiahg-build
```

The test suite failed for me in master with 1 failure. The same failure, but no others, were observed when running in my branch. 
