### PR TITLE
BUG: Raise TypeError only if key DataFrame is not empty #10126

### DIFF
--- a/doc/source/whatsnew/v0.16.2.txt
+++ b/doc/source/whatsnew/v0.16.2.txt
@@ -83,3 +83,5 @@ Bug Fixes
 
 
 - Bug where infer_freq infers timerule (WOM-5XXX) unsupported by to_offset (:issue:`9425`)
+
+- Bug to handle masking empty ``DataFrame``(:issue:`10126`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2151,7 +2151,7 @@ class DataFrame(NDFrame):
     def _setitem_frame(self, key, value):
         # support boolean setting with DataFrame input, e.g.
         # df[df > df2] = 0
-        if key.values.dtype != np.bool_:
+        if key.values.size and not com.is_bool_dtype(key.values):
             raise TypeError('Must pass DataFrame with boolean values only')
 
         self._check_inplace_setting(value)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -794,6 +794,19 @@ class CheckIndexing(object):
         result.loc[result.b.isnull(), 'a'] = result.a
         assert_frame_equal(result, df)
 
+    def test_setitem_empty_frame_with_boolean(self):
+        # Test for issue #10126
+
+        for dtype in ('float', 'int64'):
+            for df in [
+                    pd.DataFrame(dtype=dtype),
+                    pd.DataFrame(dtype=dtype, index=[1]),
+                    pd.DataFrame(dtype=dtype, columns=['A']),
+            ]:
+                df2 = df.copy()
+                df[df > df2] = 47
+                assert_frame_equal(df, df2)
+
     def test_delitem_corner(self):
         f = self.frame.copy()
         del f['D']
@@ -2821,7 +2834,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         data = {'col1': range(10),
                 'col2': range(10)}
         cdf = CustomDataFrame(data)
-        
+
         # Did we get back our own DF class?
         self.assertTrue(isinstance(cdf, CustomDataFrame))
 
@@ -2833,7 +2846,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # Do we get back our own DF class after slicing row-wise?
         cdf_rows = cdf[1:5]
         self.assertTrue(isinstance(cdf_rows, CustomDataFrame))
-        self.assertEqual(cdf_rows.custom_frame_function(), 'OK')        
+        self.assertEqual(cdf_rows.custom_frame_function(), 'OK')
 
         # Make sure sliced part of multi-index frame is custom class
         mcol = pd.MultiIndex.from_tuples([('A', 'A'), ('A', 'B')])


### PR DESCRIPTION
Proposed fix for #10126
