### PR TITLE
DOC: minor doc fix for Series.append; indices can overlap

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1442,7 +1442,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def append(self, to_append, verify_integrity=False):
         """
-        Concatenate two or more Series. The indexes must not overlap
+        Concatenate two or more Series.
 
         Parameters
         ----------


### PR DESCRIPTION
Old docstring seemed to be incorrect; overlapping indices are supported e.g.

``` python
>>> import pandas as pd
>>> x = pd.Series(['A', 'B', 'C'])
>>> y = pd.Series(['D', 'E', 'F'])
>>> x.append(y)
0    A
1    B
2    C
0    D
1    E
2    F
dtype: object
```
