### PR TITLE
ENH: less verbose merging on index

### DIFF
--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -166,6 +166,11 @@ class _MergeOperation(object):
         self.how = how
         self.axis = axis
 
+        if on is Index:
+            on = None
+            left_index = True
+            right_index = True
+
         self.on = com._maybe_make_list(on)
         self.left_on = com._maybe_make_list(left_on)
         self.right_on = com._maybe_make_list(right_on)


### PR DESCRIPTION
This is a proposal for a simple API enhancement that would make merging on indices much more convenient. I've put in an initial commit to show the change needed in the library. Here's the old way of merging on indices:

``` python
In [1]: from pandas import Index, DataFrame, merge

In [2]: df1 = DataFrame({'data1':[0, 1, 2]})

In [3]: df2 = DataFrame({'data2':[3, 4, 5]})

In [4]: merge(df1, df2, left_index=True, right_index=True)
Out[4]: 
   data1  data2
0      0      3
1      1      4
2      2      5
```

Here is the new behavior enabled by this PR:

``` python
In [5]: merge(df1, df2, on=Index)
Out[5]: 
   data1  data2
0      0      3
1      1      4
2      2      5
```

This is a bit hackish, I admit, but I find myself wanting to do this often and the alternatives (using `left_index` and `right_index`, or using `concat([df1, df2], axis='cols')`) are inconvenient and less clear to the reader of the code. That said, I completely understand if folks think this is not a good fit for the pandas API.

Any thoughts on this idea?
