### PR TITLE
Close mysql connection in TestXMySQL to prevent tests freezing

### DIFF
--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -2195,6 +2195,13 @@ class TestXMySQL(tm.TestCase):
                 "[pandas] in your system's mysql default file, "
                 "typically located at ~/.my.cnf or /etc/.my.cnf. ")
 
+    def tearDown(self):
+        from pymysql.err import Error
+        try:
+            self.db.close()
+        except Error:
+            pass
+
     def test_basic(self):
         _skip_if_no_pymysql()
         frame = tm.makeTimeDataFrame()


### PR DESCRIPTION
The unit tests freeze on my machine without this change because you can't drop a table until other connections that are using that table disconnect.
