### PR TITLE
ENH: duplicated and drop_duplicates now accept keep kw

### DIFF
--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -1178,8 +1178,7 @@ takes as an argument the columns to use to identify duplicated rows.
 - ``drop_duplicates`` removes duplicate rows.
 
 By default, the first observed row of a duplicate set is considered unique, but
-each method has a ``take_last`` parameter that indicates the last observed row
-should be taken instead.
+each method has a ``keep`` parameter to specify targets to be kept.
 
 .. ipython:: python
 
@@ -1187,8 +1186,11 @@ should be taken instead.
                        'b' : ['x', 'y', 'y', 'x', 'y', 'x', 'x'],
                        'c' : np.random.randn(7)})
    df2.duplicated(['a','b'])
+   df2.duplicated(['a','b'], keep='last')
+   df2.duplicated(['a','b'], keep=False)
    df2.drop_duplicates(['a','b'])
-   df2.drop_duplicates(['a','b'], take_last=True)
+   df2.drop_duplicates(['a','b'], keep='last')
+   df2.drop_duplicates(['a','b'], keep=False)
 
 An alternative way to drop duplicates on the index is ``.groupby(level=0)`` combined with ``first()`` or ``last()``.
 
@@ -1199,7 +1201,7 @@ An alternative way to drop duplicates on the index is ``.groupby(level=0)`` comb
    df3.groupby(level=0).first()
 
    # a bit more verbose
-   df3.reset_index().drop_duplicates(subset='b', take_last=False).set_index('b')
+   df3.reset_index().drop_duplicates(subset='b', keep='first').set_index('b')
 
 .. _indexing.dictionarylike:
 

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -142,6 +142,15 @@ Other enhancements
 - ``pd.merge`` will now allow duplicate column names if they are not merged upon (:issue:`10639`).
 
 - ``pd.pivot`` will now allow passing index as ``None`` (:issue:`3962`).
+- ``drop_duplicates`` and ``duplicated`` now accept ``keep`` keyword to target first, last, and all duplicates. ``take_last`` keyword is deprecated, see :ref:`deprecations <whatsnew_0170.deprecations>` (:issue:`6511`, :issue:`8505`)
+
+.. ipython :: python
+
+   s = pd.Series(['A', 'B', 'C', 'A', 'B', 'D'])
+   s.drop_duplicates()
+   s.drop_duplicates(keep='last')
+   s.drop_duplicates(keep=False)
+
 
 .. _whatsnew_0170.api:
 
@@ -520,6 +529,7 @@ Deprecations
   =====================  =================================
 
 - ``Categorical.name`` was deprecated to make ``Categorical`` more ``numpy.ndarray`` like. Use ``Series(cat, name="whatever")`` instead (:issue:`10482`).
+- ``drop_duplicates`` and ``duplicated``'s ``take_last`` keyword was removed in favor of ``keep``. (:issue:`6511`, :issue:`8505`)
 
 .. _whatsnew_0170.prior_deprecations:
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -6,7 +6,7 @@ import numpy as np
 from pandas.core import common as com
 import pandas.core.nanops as nanops
 import pandas.lib as lib
-from pandas.util.decorators import Appender, cache_readonly
+from pandas.util.decorators import Appender, cache_readonly, deprecate_kwarg
 from pandas.core.strings import StringMethods
 from pandas.core.common import AbstractMethodError
 
@@ -543,8 +543,12 @@ class IndexOpsMixin(object):
 
         Parameters
         ----------
-        take_last : boolean, default False
-            Take the last observed index in a group. Default first
+
+        keep : {'first', 'last', False}, default 'first'
+            - ``first`` : Drop duplicates except for the first occurrence.
+            - ``last`` : Drop duplicates except for the last occurrence.
+            - False : Drop all duplicates.
+        take_last : deprecated
         %(inplace)s
 
         Returns
@@ -552,9 +556,10 @@ class IndexOpsMixin(object):
         deduplicated : %(klass)s
         """)
 
+    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last', False: 'first'})
     @Appender(_shared_docs['drop_duplicates'] % _indexops_doc_kwargs)
-    def drop_duplicates(self, take_last=False, inplace=False):
-        duplicated = self.duplicated(take_last=take_last)
+    def drop_duplicates(self, keep='first', inplace=False):
+        duplicated = self.duplicated(keep=keep)
         result = self[np.logical_not(duplicated)]
         if inplace:
             return self._update_inplace(result)
@@ -566,18 +571,22 @@ class IndexOpsMixin(object):
 
         Parameters
         ----------
-        take_last : boolean, default False
-            Take the last observed index in a group. Default first
+        keep : {'first', 'last', False}, default 'first'
+            - ``first`` : Mark duplicates as ``True`` except for the first occurrence.
+            - ``last`` : Mark duplicates as ``True`` except for the last occurrence.
+            - False : Mark all duplicates as ``True``.
+        take_last : deprecated
 
         Returns
         -------
         duplicated : %(duplicated)s
         """)
 
+    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last', False: 'first'})
     @Appender(_shared_docs['duplicated'] % _indexops_doc_kwargs)
-    def duplicated(self, take_last=False):
+    def duplicated(self, keep='first'):
         keys = com._ensure_object(self.values)
-        duplicated = lib.duplicated(keys, take_last=take_last)
+        duplicated = lib.duplicated(keys, keep=keep)
         try:
             return self._constructor(duplicated,
                                      index=self.index).__finalize__(self)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2866,8 +2866,9 @@ class DataFrame(NDFrame):
         else:
             return result
 
+    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last', False: 'first'})
     @deprecate_kwarg(old_arg_name='cols', new_arg_name='subset')
-    def drop_duplicates(self, subset=None, take_last=False, inplace=False):
+    def drop_duplicates(self, subset=None, keep='first', inplace=False):
         """
         Return DataFrame with duplicate rows removed, optionally only
         considering certain columns
@@ -2877,8 +2878,11 @@ class DataFrame(NDFrame):
         subset : column label or sequence of labels, optional
             Only consider certain columns for identifying duplicates, by
             default use all of the columns
-        take_last : boolean, default False
-            Take the last observed row in a row. Defaults to the first row
+        keep : {'first', 'last', False}, default 'first'
+            - ``first`` : Drop duplicates except for the first occurrence.
+            - ``last`` : Drop duplicates except for the last occurrence.
+            - False : Drop all duplicates.
+        take_last : deprecated
         inplace : boolean, default False
             Whether to drop duplicates in place or to return a copy
         cols : kwargs only argument of subset [deprecated]
@@ -2887,7 +2891,7 @@ class DataFrame(NDFrame):
         -------
         deduplicated : DataFrame
         """
-        duplicated = self.duplicated(subset, take_last=take_last)
+        duplicated = self.duplicated(subset, keep=keep)
 
         if inplace:
             inds, = (-duplicated).nonzero()
@@ -2896,8 +2900,9 @@ class DataFrame(NDFrame):
         else:
             return self[-duplicated]
 
+    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last', False: 'first'})
     @deprecate_kwarg(old_arg_name='cols', new_arg_name='subset')
-    def duplicated(self, subset=None, take_last=False):
+    def duplicated(self, subset=None, keep='first'):
         """
         Return boolean Series denoting duplicate rows, optionally only
         considering certain columns
@@ -2907,9 +2912,13 @@ class DataFrame(NDFrame):
         subset : column label or sequence of labels, optional
             Only consider certain columns for identifying duplicates, by
             default use all of the columns
-        take_last : boolean, default False
-            For a set of distinct duplicate rows, flag all but the last row as
-            duplicated. Default is for all but the first row to be flagged
+        keep : {'first', 'last', False}, default 'first'
+            - ``first`` : Mark duplicates as ``True`` except for the
+              first occurrence.
+            - ``last`` : Mark duplicates as ``True`` except for the
+              last occurrence.
+            - False : Mark all duplicates as ``True``.
+        take_last : deprecated
         cols : kwargs only argument of subset [deprecated]
 
         Returns
@@ -2935,7 +2944,7 @@ class DataFrame(NDFrame):
         labels, shape = map(list, zip( * map(f, vals)))
 
         ids = get_group_index(labels, shape, sort=False, xnull=False)
-        return Series(duplicated_int64(ids, take_last), index=self.index)
+        return Series(duplicated_int64(ids, keep), index=self.index)
 
     #----------------------------------------------------------------------
     # Sorting

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -16,7 +16,7 @@ import pandas.index as _index
 from pandas.lib import Timestamp, Timedelta, is_datetime_array
 from pandas.core.base import PandasObject, FrozenList, FrozenNDArray, IndexOpsMixin, _shared_docs, PandasDelegate
 from pandas.util.decorators import (Appender, Substitution, cache_readonly,
-                                    deprecate)
+                                    deprecate, deprecate_kwarg)
 import pandas.core.common as com
 from pandas.core.common import (isnull, array_equivalent, is_dtype_equal, is_object_dtype,
                                 _values_from_object, is_float, is_integer, is_iterator, is_categorical_dtype,
@@ -2623,13 +2623,15 @@ class Index(IndexOpsMixin, PandasObject):
             indexer = indexer[~mask]
         return self.delete(indexer)
 
+    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last', False: 'first'})
     @Appender(_shared_docs['drop_duplicates'] % _index_doc_kwargs)
-    def drop_duplicates(self, take_last=False):
-        return super(Index, self).drop_duplicates(take_last=take_last)
+    def drop_duplicates(self, keep='first'):
+        return super(Index, self).drop_duplicates(keep=keep)
 
+    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last', False: 'first'})
     @Appender(_shared_docs['duplicated'] % _index_doc_kwargs)
-    def duplicated(self, take_last=False):
-        return super(Index, self).duplicated(take_last=take_last)
+    def duplicated(self, keep='first'):
+        return super(Index, self).duplicated(keep=keep)
 
     def _evaluate_with_timedelta_like(self, other, op, opstr):
         raise TypeError("can only perform ops with timedelta like values")
@@ -3056,10 +3058,11 @@ class CategoricalIndex(Index, PandasDelegate):
     def is_unique(self):
         return not self.duplicated().any()
 
+    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last', False: 'first'})
     @Appender(_shared_docs['duplicated'] % _index_doc_kwargs)
-    def duplicated(self, take_last=False):
+    def duplicated(self, keep='first'):
         from pandas.hashtable import duplicated_int64
-        return duplicated_int64(self.codes.astype('i8'), take_last)
+        return duplicated_int64(self.codes.astype('i8'), keep)
 
     def get_loc(self, key, method=None):
         """
@@ -4219,15 +4222,16 @@ class MultiIndex(Index):
     def is_unique(self):
         return not self.duplicated().any()
 
+    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last', False: 'first'})
     @Appender(_shared_docs['duplicated'] % _index_doc_kwargs)
-    def duplicated(self, take_last=False):
+    def duplicated(self, keep='first'):
         from pandas.core.groupby import get_group_index
         from pandas.hashtable import duplicated_int64
 
         shape = map(len, self.levels)
         ids = get_group_index(self.labels, shape, sort=False, xnull=False)
 
-        return duplicated_int64(ids, take_last)
+        return duplicated_int64(ids, keep)
 
     def get_value(self, series, key):
         # somewhat broken encapsulation

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -46,7 +46,7 @@ import pandas.core.common as com
 import pandas.core.datetools as datetools
 import pandas.core.format as fmt
 import pandas.core.nanops as nanops
-from pandas.util.decorators import Appender, cache_readonly
+from pandas.util.decorators import Appender, cache_readonly, deprecate_kwarg
 
 import pandas.lib as lib
 import pandas.tslib as tslib
@@ -1155,14 +1155,15 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         from pandas.core.algorithms import mode
         return mode(self)
 
+    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last', False: 'first'})
     @Appender(base._shared_docs['drop_duplicates'] % _shared_doc_kwargs)
-    def drop_duplicates(self, take_last=False, inplace=False):
-        return super(Series, self).drop_duplicates(take_last=take_last,
-                                                   inplace=inplace)
+    def drop_duplicates(self, keep='first', inplace=False):
+        return super(Series, self).drop_duplicates(keep=keep, inplace=inplace)
 
+    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last', False: 'first'})
     @Appender(base._shared_docs['duplicated'] % _shared_doc_kwargs)
-    def duplicated(self, take_last=False):
-        return super(Series, self).duplicated(take_last=take_last)
+    def duplicated(self, keep='first'):
+        return super(Series, self).duplicated(keep=keep)
 
     def idxmin(self, axis=None, out=None, skipna=True):
         """

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -1348,34 +1348,46 @@ def fast_zip_fillna(list ndarrays, fill_value=pandas_null):
 
     return result
 
-def duplicated(ndarray[object] values, take_last=False):
+
+def duplicated(ndarray[object] values, object keep='first'):
     cdef:
         Py_ssize_t i, n
-        set seen = set()
+        dict seen = dict()
         object row
 
     n = len(values)
     cdef ndarray[uint8_t] result = np.zeros(n, dtype=np.uint8)
 
-    if take_last:
+    if keep == 'last':
         for i from n > i >= 0:
             row = values[i]
-
             if row in seen:
                 result[i] = 1
             else:
-                seen.add(row)
+                seen[row] = i
                 result[i] = 0
-    else:
+    elif keep == 'first':
         for i from 0 <= i < n:
             row = values[i]
             if row in seen:
                 result[i] = 1
             else:
-                seen.add(row)
+                seen[row] = i
                 result[i] = 0
+    elif keep is False:
+        for i from 0 <= i < n:
+            row = values[i]
+            if row in seen:
+                result[i] = 1
+                result[seen[row]] = 1
+            else:
+                seen[row] = i
+                result[i] = 0
+    else:
+        raise ValueError('keep must be either "first", "last" or False')
 
     return result.view(np.bool_)
+
 
 def generate_slices(ndarray[int64_t] labels, Py_ssize_t ngroups):
     cdef:

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -4711,9 +4711,9 @@ class TestMultiIndex(Base, tm.TestCase):
         labels = [np.random.choice(n, k * n) for lev in levels]
         mi = MultiIndex(levels=levels, labels=labels)
 
-        for take_last in [False, True]:
-            left = mi.duplicated(take_last=take_last)
-            right = pd.lib.duplicated(mi.values, take_last=take_last)
+        for keep in ['first', 'last', False]:
+            left = mi.duplicated(keep=keep)
+            right = pd.lib.duplicated(mi.values, keep=keep)
             tm.assert_numpy_array_equal(left, right)
 
         # GH5873

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2136,6 +2136,21 @@ Thur,Lunch,Yes,51.51,17"""
         tm.assert_index_equal(idx.drop_duplicates(), expected)
 
         expected = np.array([True, False, False, False, False, False])
+        duplicated = idx.duplicated(keep='last')
+        tm.assert_numpy_array_equal(duplicated, expected)
+        self.assertTrue(duplicated.dtype == bool)
+        expected = MultiIndex.from_arrays(([2, 3, 1, 2 ,3], [1, 1, 1, 2, 2]))
+        tm.assert_index_equal(idx.drop_duplicates(keep='last'), expected)
+
+        expected = np.array([True, False, False, True, False, False])
+        duplicated = idx.duplicated(keep=False)
+        tm.assert_numpy_array_equal(duplicated, expected)
+        self.assertTrue(duplicated.dtype == bool)
+        expected = MultiIndex.from_arrays(([2, 3, 2 ,3], [1, 1, 2, 2]))
+        tm.assert_index_equal(idx.drop_duplicates(keep=False), expected)
+
+        # deprecate take_last
+        expected = np.array([True, False, False, False, False, False])
         duplicated = idx.duplicated(take_last=True)
         tm.assert_numpy_array_equal(duplicated, expected)
         self.assertTrue(duplicated.dtype == bool)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -4782,29 +4782,63 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         self.assertEqual(s._get_axis_name('rows'), 'index')
 
     def test_drop_duplicates(self):
-        s = Series([1, 2, 3, 3])
+        # check both int and object
+        for s in [Series([1, 2, 3, 3]), Series(['1', '2', '3', '3'])]:
+            expected = Series([False, False, False, True])
+            assert_series_equal(s.duplicated(), expected)
+            assert_series_equal(s.drop_duplicates(), s[~expected])
+            sc = s.copy()
+            sc.drop_duplicates(inplace=True)
+            assert_series_equal(sc, s[~expected])
 
-        result = s.duplicated()
-        expected = Series([False, False, False, True])
-        assert_series_equal(result, expected)
+            expected = Series([False, False, True, False])
+            assert_series_equal(s.duplicated(keep='last'), expected)
+            assert_series_equal(s.drop_duplicates(keep='last'), s[~expected])
+            sc = s.copy()
+            sc.drop_duplicates(keep='last', inplace=True)
+            assert_series_equal(sc, s[~expected])
+            # deprecate take_last
+            assert_series_equal(s.duplicated(take_last=True), expected)
+            assert_series_equal(s.drop_duplicates(take_last=True), s[~expected])
+            sc = s.copy()
+            sc.drop_duplicates(take_last=True, inplace=True)
+            assert_series_equal(sc, s[~expected])
 
-        result = s.duplicated(take_last=True)
-        expected = Series([False, False, True, False])
-        assert_series_equal(result, expected)
+            expected = Series([False, False, True, True])
+            assert_series_equal(s.duplicated(keep=False), expected)
+            assert_series_equal(s.drop_duplicates(keep=False), s[~expected])
+            sc = s.copy()
+            sc.drop_duplicates(keep=False, inplace=True)
+            assert_series_equal(sc, s[~expected])
 
-        result = s.drop_duplicates()
-        expected = s[[True, True, True, False]]
-        assert_series_equal(result, expected)
-        sc = s.copy()
-        sc.drop_duplicates(inplace=True)
-        assert_series_equal(sc, expected)
+        for s in [Series([1, 2, 3, 5, 3, 2, 4]),
+                  Series(['1', '2', '3', '5', '3', '2', '4'])]:
+            expected = Series([False, False, False, False, True, True, False])
+            assert_series_equal(s.duplicated(), expected)
+            assert_series_equal(s.drop_duplicates(), s[~expected])
+            sc = s.copy()
+            sc.drop_duplicates(inplace=True)
+            assert_series_equal(sc, s[~expected])
 
-        result = s.drop_duplicates(take_last=True)
-        expected = s[[True, True, False, True]]
-        assert_series_equal(result, expected)
-        sc = s.copy()
-        sc.drop_duplicates(take_last=True, inplace=True)
-        assert_series_equal(sc, expected)
+            expected = Series([False, True, True, False, False, False, False])
+            assert_series_equal(s.duplicated(keep='last'), expected)
+            assert_series_equal(s.drop_duplicates(keep='last'), s[~expected])
+            sc = s.copy()
+            sc.drop_duplicates(keep='last', inplace=True)
+            assert_series_equal(sc, s[~expected])
+            # deprecate take_last
+            assert_series_equal(s.duplicated(take_last=True), expected)
+            assert_series_equal(s.drop_duplicates(take_last=True), s[~expected])
+            sc = s.copy()
+            sc.drop_duplicates(take_last=True, inplace=True)
+            assert_series_equal(sc, s[~expected])
+
+            expected = Series([False, True, True, False, True, True, False])
+            assert_series_equal(s.duplicated(keep=False), expected)
+            assert_series_equal(s.drop_duplicates(keep=False), s[~expected])
+            sc = s.copy()
+            sc.drop_duplicates(keep=False, inplace=True)
+            assert_series_equal(sc, s[~expected])
 
     def test_sort(self):
         ts = self.ts.copy()

--- a/pandas/tests/test_tseries.py
+++ b/pandas/tests/test_tseries.py
@@ -275,8 +275,16 @@ def test_duplicated_with_nas():
     expected = [False, False, False, True, False, True]
     assert(np.array_equal(result, expected))
 
-    result = lib.duplicated(keys, take_last=True)
+    result = lib.duplicated(keys, keep='first')
+    expected = [False, False, False, True, False, True]
+    assert(np.array_equal(result, expected))
+
+    result = lib.duplicated(keys, keep='last')
     expected = [True, False, True, False, False, False]
+    assert(np.array_equal(result, expected))
+
+    result = lib.duplicated(keys, keep=False)
+    expected = [True, False, True, True, False, True]
     assert(np.array_equal(result, expected))
 
     keys = np.empty(8, dtype=object)
@@ -289,8 +297,12 @@ def test_duplicated_with_nas():
     expected = falses + trues
     assert(np.array_equal(result, expected))
 
-    result = lib.duplicated(keys, take_last=True)
+    result = lib.duplicated(keys, keep='last')
     expected = trues + falses
+    assert(np.array_equal(result, expected))
+
+    result = lib.duplicated(keys, keep=False)
+    expected = trues + trues
     assert(np.array_equal(result, expected))
 
 


### PR DESCRIPTION
Closes #6511, Closes #8505.

Introduce `keep` kw to handle first / last / all duplicates based on the discussion above. If there is better API/kw, please lmk.
### `duplicated`
- `keep='first'` (default): mark duplicates as `True` except for the first occurrence.
- `keep='last'`: mark duplicates as `True` except for the last occurrence.
- `keep=False`: mark all duplicates as `True`.
### `drop_duplicates`
- `keep='first'` (default): drop duplicates except for the first occurrence.
- `keep='last'`: drop duplicates except for the last occurrence.
- `keep=False`: drop all duplicates.

``` python
import pandas as pd
s = pd.Series(['A', 'B', 'C', 'A', 'B', 'D'])

# mark duplicates except for the first occurrence
s.duplicated()
#0    False
#1    False
#2    False
#3     True
#4     True
#5    False
# dtype: bool

# mark duplicates except for the last occurrence
s.duplicated(keep='last')
#0     True
#1     True
#2    False
#3    False
#4    False
#5    False
# dtype: bool

# mark all duplicates
s.duplicated(keep=False)
#0     True
#1     True
#2    False
#3     True
#4     True
#5    False
# dtype: bool

# drop duplicates except for the first occurrence
s.drop_duplicates()
#0    A
#1    B
#2    C
#5    D
# dtype: object

# drop duplicates except for the last occurrence
s.drop_duplicates(keep='last')
#2    C
#3    A
#4    B
#5    D
# dtype: object

# drop all duplicates
s.drop_duplicates(keep=False)
#2    C
#5    D
# dtype: object
```

CC @shoyer, @wikiped, @socheon 
