### PR TITLE
BUG: SparseSeries.abs() resets name

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -83,7 +83,7 @@ Bug Fixes
 - Bug in `plot` not defaulting to matplotlib `axes.grid` setting (:issue:`9792`)
 
 - Bug in ``Series.align`` resets ``name`` when ``fill_value`` is specified (:issue:`10067`)
-
+- Bug in ``SparseSeries.abs`` resets ``name`` (:issue:`10241`)
 
 
 - Bug in GroupBy.get_group raises ValueError when group key contains NaT (:issue:`6992`)

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -399,7 +399,7 @@ class SparseSeries(Series):
         res_sp_values = np.abs(self.sp_values)
         return self._constructor(res_sp_values, index=self.index,
                                  sparse_index=self.sp_index,
-                                 fill_value=self.fill_value)
+                                 fill_value=self.fill_value).__finalize__(self)
 
     def get(self, label, default=None):
         """

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -509,6 +509,21 @@ class TestSparseSeries(tm.TestCase,
             _check_inplace_op(
                 getattr(operator, "i%s" % op), getattr(operator, op))
 
+    def test_abs(self):
+        s = SparseSeries([1, 2, -3], name='x')
+        expected = SparseSeries([1, 2, 3], name='x')
+        result = s.abs()
+        assert_sp_series_equal(result, expected)
+        self.assertEqual(result.name, 'x')
+
+        result = abs(s)
+        assert_sp_series_equal(result, expected)
+        self.assertEqual(result.name, 'x')
+
+        result = np.abs(s)
+        assert_sp_series_equal(result, expected)
+        self.assertEqual(result.name, 'x')
+
     def test_reindex(self):
         def _compare_with_series(sps, new_index):
             spsre = sps.reindex(new_index)

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -404,6 +404,8 @@ class SafeForSparse(object):
         expected = np.abs(s)
         assert_series_equal(result, expected)
         assert_series_equal(result2, expected)
+        self.assertEqual(result.name, 'A')
+        self.assertEqual(result2.name, 'A')
 
 
 class CheckIndexing(object):


### PR DESCRIPTION
```
# OK: name is preserved
s = pd.Series([1, 2, -3], name='a')
s.abs()
#0    1
#1    2
#2    3
# Name: a, dtype: int64

# NG: name is reset
s = pd.SparseSeries([1, 0, -3], name='a')
s.name
# 'a'

s.abs()
#0    1
#1    0
#2    3
# dtype: int64
# BlockIndex
# Block locations: array([0], dtype=int32)
# Block lengths: array([3], dtype=int32)
```
