### PR TITLE
BUG: GH10209 fix bug where date_format in to_csv is sometimes ignored

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -95,3 +95,7 @@ Bug Fixes
 
 - Bug where infer_freq infers timerule (WOM-5XXX) unsupported by to_offset (:issue:`9425`)
 
+
+- Bug in to_csv where data_format is ignored if the datetime is not 
+an integral date value (i.e. it is fractional) (:issue:`10209`)
+

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -96,6 +96,6 @@ Bug Fixes
 - Bug where infer_freq infers timerule (WOM-5XXX) unsupported by to_offset (:issue:`9425`)
 
 
-- Bug in to_csv where data_format is ignored if the datetime is not 
+- Bug in ``to_csv`` where ``data_format`` is ignored if the ``datetime`` is not 
 an integral date value (i.e. it is fractional) (:issue:`10209`)
 

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -2114,7 +2114,7 @@ def _get_format_datetime64_from_values(values, date_format):
     is_dates_only = _is_dates_only(values)
     if is_dates_only:
         return date_format or "%Y-%m-%d"
-    return None
+    return date_format
 
 
 class Timedelta64Formatter(GenericArrayFormatter):

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -2451,14 +2451,24 @@ $1$,$2$
 
     def test_to_csv_date_format(self):
         # GH 10209
-        df = DataFrame({'A' : pd.date_range('20130101',periods=5,freq='s')})
+        df_sec = DataFrame({'A': pd.date_range('20130101',periods=5,freq='s')})
+        df_day = DataFrame({'A': pd.date_range('20130101',periods=5,freq='d')})
 
-        expected_default = ',A\n0,2013-01-01 00:00:00\n1,2013-01-01 00:00:01\n2,2013-01-01 00:00:02' + \
-                           '\n3,2013-01-01 00:00:03\n4,2013-01-01 00:00:04\n'
-        self.assertEqual(df.to_csv(), expected_default)
+        expected_default_sec = ',A\n0,2013-01-01 00:00:00\n1,2013-01-01 00:00:01\n2,2013-01-01 00:00:02' + \
+                               '\n3,2013-01-01 00:00:03\n4,2013-01-01 00:00:04\n'
+        self.assertEqual(df_sec.to_csv(), expected_default_sec)
 
-        expected_ymd = ',A\n0,2013-01-01\n1,2013-01-01\n2,2013-01-01\n3,2013-01-01\n4,2013-01-01\n'
-        self.assertEqual(df.to_csv(date_format='%Y-%m-%d'), expected_ymd)
+        expected_ymdhms_day = ',A\n0,2013-01-01 00:00:00\n1,2013-01-02 00:00:00\n2,2013-01-03 00:00:00' + \
+                              '\n3,2013-01-04 00:00:00\n4,2013-01-05 00:00:00\n'
+        self.assertEqual(df_day.to_csv(date_format='%Y-%m-%d %H:%M:%S'), expected_ymdhms_day)
+
+        expected_ymd_sec = ',A\n0,2013-01-01\n1,2013-01-01\n2,2013-01-01\n3,2013-01-01\n4,2013-01-01\n'
+        self.assertEqual(df_sec.to_csv(date_format='%Y-%m-%d'), expected_ymd_sec)
+
+        expected_default_day = ',A\n0,2013-01-01\n1,2013-01-02\n2,2013-01-03\n3,2013-01-04\n4,2013-01-05\n'
+        self.assertEqual(df_day.to_csv(), expected_default_day)
+        self.assertEqual(df_day.to_csv(date_format='%Y-%m-%d'), expected_default_day)
+
 
 class TestSeriesFormatting(tm.TestCase):
     _multiprocess_can_split_ = True

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -2449,6 +2449,17 @@ $1$,$2$
         expected_float_format = ';col1;col2;col3\n0;1;a;10,10\n'
         self.assertEqual(df.to_csv(decimal=',',sep=';', float_format = '%.2f'), expected_float_format)
 
+    def test_to_csv_date_format(self):
+        # GH 10209
+        df = DataFrame({'A' : pd.date_range('20130101',periods=5,freq='s')})
+
+        expected_default = ',A\n0,2013-01-01 00:00:00\n1,2013-01-01 00:00:01\n2,2013-01-01 00:00:02' + \
+                           '\n3,2013-01-01 00:00:03\n4,2013-01-01 00:00:04\n'
+        self.assertEqual(df.to_csv(), expected_default)
+
+        expected_ymd = ',A\n0,2013-01-01\n1,2013-01-01\n2,2013-01-01\n3,2013-01-01\n4,2013-01-01\n'
+        self.assertEqual(df.to_csv(date_format='%Y-%m-%d'), expected_ymd)
+
 class TestSeriesFormatting(tm.TestCase):
     _multiprocess_can_split_ = True
 


### PR DESCRIPTION
closes #10209

When datetimes are not dates only i.e. have fractional day values, date_format passed to to_csv is ignored.  
