### PR TITLE
ENH: make sure return dtypes for nan funcs are consistent

### DIFF
--- a/doc/source/whatsnew/v0.16.2.txt
+++ b/doc/source/whatsnew/v0.16.2.txt
@@ -57,7 +57,7 @@ Bug Fixes
 - Bug where read_hdf store.select modifies the passed columns list when
   multi-indexed (:issue:`7212`)
 - Bug in ``Categorical`` repr with ``display.width`` of ``None`` in Python 3 (:issue:`10087`)
-
+- Bug where some of the nan funcs do not have consistent return dtypes (:issue:`10251`)
 - Bug in groupby.apply aggregation for Categorical not preserving categories (:issue:`10138`)
 - Bug in ``mean()`` where integer dtypes can overflow (:issue:`10172`)
 - Bug where Panel.from_dict does not set dtype when specified (:issue:`10058`)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -528,7 +528,6 @@ class TestNanops(tm.TestCase):
         assert_almost_equal(result, 1)
 
     def test_overflow(self):
-
         # GH 6915
         # overflowing on the smaller int dtypes
         for dtype in ['int32','int64']:
@@ -551,25 +550,25 @@ class TestNanops(tm.TestCase):
             result = s.max()
             self.assertEqual(int(result),v[-1])
 
-        for dtype in ['float32','float64']:
-            v = np.arange(5000000,dtype=dtype)
+        for dtype in ['float32', 'float64']:
+            v = np.arange(5000000, dtype=dtype)
             s = Series(v)
 
             # no bottleneck
             result = s.sum(skipna=False)
-            self.assertTrue(np.allclose(float(result),v.sum(dtype='float64')))
+            self.assertEqual(result, v.sum(dtype=dtype))
             result = s.min(skipna=False)
-            self.assertTrue(np.allclose(float(result),0.0))
+            self.assertTrue(np.allclose(float(result), 0.0))
             result = s.max(skipna=False)
-            self.assertTrue(np.allclose(float(result),v[-1]))
+            self.assertTrue(np.allclose(float(result), v[-1]))
 
             # use bottleneck if available
             result = s.sum()
-            self.assertTrue(np.allclose(float(result),v.sum(dtype='float64')))
+            self.assertEqual(result, v.sum(dtype=dtype))
             result = s.min()
-            self.assertTrue(np.allclose(float(result),0.0))
+            self.assertTrue(np.allclose(float(result), 0.0))
             result = s.max()
-            self.assertTrue(np.allclose(float(result),v[-1]))
+            self.assertTrue(np.allclose(float(result), v[-1]))
 
 class SafeForSparse(object):
     pass


### PR DESCRIPTION
this is a follow-up to https://github.com/pydata/pandas/pull/10172

In addition to `mean()`, this PR also makes sure the returned dtype is consistent for `std()`, `var()`, `skew()`, and `kurt()`
