### PR TITLE
REGR: ensure passed binlabels to pd.cut have a compat dtype on output (#10140)

### DIFF
--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -792,6 +792,8 @@ excluded. So there will never be an "NA group" or "NaT group". This was not the 
 versions of pandas, but users were generally discarding the NA group anyway
 (and supporting it was an implementation headache).
 
+.. _groupby.categorical:
+
 Grouping with ordered factors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -801,9 +803,14 @@ can be used as group keys. If so, the order of the levels will be preserved:
 .. ipython:: python
 
    data = Series(np.random.randn(100))
-
    factor = qcut(data, [0, .25, .5, .75, 1.])
+   data.groupby(factor).mean()
 
+Further, one can name the bins to produce a custom-labeled binner.
+
+.. ipython:: python
+
+   factor = qcut(data, [0, .25, .5, .75, 1.], labels=['small','medium','large','x-large'])
    data.groupby(factor).mean()
 
 .. _groupby.specify:

--- a/doc/source/reshaping.rst
+++ b/doc/source/reshaping.rst
@@ -417,7 +417,8 @@ Tiling
 
 The ``cut`` function computes groupings for the values of the input array and
 is often used to transform continuous variables to discrete or categorical
-variables:
+variables. These will result in a ``Categorical`` dtype, where the categories
+are the bins.
 
 .. ipython:: python
 
@@ -433,6 +434,13 @@ Alternatively we can specify custom bin-edges:
 
    pd.cut(ages, bins=[0, 18, 35, 70])
 
+Furthermore, one can specify ``labels`` to have custom labels.
+
+.. ipython:: python
+
+   pd.cut(ages, bins=[0, 18, 35, 70], labels=['child','adult','senior'])
+
+``cut/qcut`` are often used as groupers, see the :ref:`grouping with ordered factors<groupby.categorical>` for more.
 
 .. _reshaping.dummies:
 

--- a/doc/source/whatsnew/v0.16.2.txt
+++ b/doc/source/whatsnew/v0.16.2.txt
@@ -69,6 +69,7 @@ Bug Fixes
 - Bung in ``Series`` arithmetic methods may incorrectly hold names (:issue:`10068`)
 
 - Bug in ``DatetimeIndex`` and ``TimedeltaIndex`` names are lost after timedelta arithmetics ( :issue:`9926`)
+- Regression in ``pd.cut` to ensure passed ``binlabels`` have a compat dtype on output (:issue:`10140`)
 
 
 - Bug in `Series.plot(label="LABEL")` not correctly setting the label (:issue:`10119`)


### PR DESCRIPTION
From the original issue, closes #10140

```
In [1]: df = pd.DataFrame()

In [2]: df['x'] = 100 * np.random.random(100)

In [3]: df['y'] = df.x**2

In [4]: binedges = np.arange(0,110,10)

In [5]: binlabels = np.arange(5,105,10)

```

This now yields an `Int64Index`

```
In [6]: df.groupby(pd.cut(df.x,bins=binedges ,labels=binlabels )).y.mean()
Out[6]: 
5       43.485680
15     227.648305
25     680.165208
35    1244.704812
45    1977.675209
55    3159.067969
65    4435.735803
75    5649.164598
85    7027.956570
95    8997.975423
Name: y, dtype: float64

In [7]: df.groupby(pd.cut(df.x,bins=binedges ,labels=binlabels )).y.mean().index
Out[7]: Int64Index([5, 15, 25, 35, 45, 55, 65, 75, 85, 95], dtype='int64')
```

If you pass an index in, then you will get that out, specifically a `Categorical` will preserve the categories (note the 2nd example has reversed labels - why anyone would do this, don't know.......)

```
In [8]: df.groupby(pd.cut(df.x,bins=binedges ,labels=pd.Categorical(binlabels) )).y.mean().index
Out[8]: CategoricalIndex([5, 15, 25, 35, 45, 55, 65, 75, 85, 95], categories=[5, 15, 25, 35, 45, 55, 65, 75, ...], ordered=True, name=u'x', dtype='category')

In [9]: df.groupby(pd.cut(df.x,bins=binedges ,labels=pd.Categorical(binlabels,categories=binlabels[::-1]) )).y.mean().index
Out[9]: CategoricalIndex([95, 85, 75, 65, 55, 45, 35, 25, 15, 5], categories=[95, 85, 75, 65, 55, 45, 35, 25, ...], ordered=True, name=u'x', dtype='category')

In [10]: df.groupby(pd.cut(df.x,bins=binedges ,labels=pd.Categorical(binlabels,categories=binlabels[::-1]) )).y.mean()      
Out[10]: 
x
95      43.485680
85     227.648305
75     680.165208
65    1244.704812
55    1977.675209
45    3159.067969
35    4435.735803
25    5649.164598
15    7027.956570
5     8997.975423
Name: y, dtype: float64
```
