### PR TITLE
BUG: SparseSeries constructor ignores input data name

### DIFF
--- a/doc/source/whatsnew/v0.16.2.txt
+++ b/doc/source/whatsnew/v0.16.2.txt
@@ -80,6 +80,6 @@ Bug Fixes
 
 
 - Bug in GroupBy.get_group raises ValueError when group key contains NaT (:issue:`6992`)
-
+- Bug in ``SparseSeries`` constructor ignores input data name (:issue:`10258`)
 
 - Bug where infer_freq infers timerule (WOM-5XXX) unsupported by to_offset (:issue:`9425`)

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -121,6 +121,9 @@ class SparseSeries(Series):
             if data is None:
                 data = []
 
+            if isinstance(data, Series) and name is None:
+                name = data.name
+
             is_sparse_array = isinstance(data, SparseArray)
             if fill_value is None:
                 if is_sparse_array:

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -128,14 +128,15 @@ class TestSparseSeries(tm.TestCase,
 
         date_index = bdate_range('1/1/2011', periods=len(index))
 
-        self.bseries = SparseSeries(arr, index=index, kind='block')
-        self.bseries.name = 'bseries'
+        self.bseries = SparseSeries(arr, index=index, kind='block',
+                                    name='bseries')
 
         self.ts = self.bseries
 
         self.btseries = SparseSeries(arr, index=date_index, kind='block')
 
-        self.iseries = SparseSeries(arr, index=index, kind='integer')
+        self.iseries = SparseSeries(arr, index=index, kind='integer',
+                                    name='iseries')
 
         arr, index = _test_data2()
         self.bseries2 = SparseSeries(arr, index=index, kind='block')
@@ -143,7 +144,7 @@ class TestSparseSeries(tm.TestCase,
 
         arr, index = _test_data1_zero()
         self.zbseries = SparseSeries(arr, index=index, kind='block',
-                                     fill_value=0)
+                                     fill_value=0, name='zbseries')
         self.ziseries = SparseSeries(arr, index=index, kind='integer',
                                      fill_value=0)
 
@@ -234,12 +235,21 @@ class TestSparseSeries(tm.TestCase,
                      self.bseries.to_dense().fillna(0).values)
 
         # pass SparseSeries
-        s2 = SparseSeries(self.bseries)
-        s3 = SparseSeries(self.iseries)
-        s4 = SparseSeries(self.zbseries)
-        assert_sp_series_equal(s2, self.bseries)
-        assert_sp_series_equal(s3, self.iseries)
-        assert_sp_series_equal(s4, self.zbseries)
+        def _check_const(sparse, name):
+            # use passed series name
+            result = SparseSeries(sparse)
+            assert_sp_series_equal(result, sparse)
+            self.assertEqual(sparse.name, name)
+            self.assertEqual(result.name, name)
+
+            # use passed name
+            result = SparseSeries(sparse, name='x')
+            assert_sp_series_equal(result, sparse)
+            self.assertEqual(result.name, 'x')
+
+        _check_const(self.bseries, 'bseries')
+        _check_const(self.iseries, 'iseries')
+        _check_const(self.zbseries, 'zbseries')
 
         # Sparse time series works
         date_index = bdate_range('1/1/2000', periods=len(self.bseries))


### PR DESCRIPTION
When constructing `Series` from `Series`, name attribute is preserved otherwise specified.

```
import pandas as pd
s = pd.Series([1, 2, 3], name='a')
pd.Series(s)
#0    1
#1    2
#2    3
# Name: a, dtype: int64

pd.Series(s, name='x')
#0    1
#1    2
#2    3
# Name: x, dtype: int64
```

But `SparseSeries` doesn't preserve its name.

```
s = pd.SparseSeries([1, 2, 3], name='a')
pd.SparseSeries(s)
#0    1
#1    2
#2    3
# dtype: int64
# BlockIndex
# Block locations: array([0], dtype=int32)
# Block lengths: array([3], dtype=int32)
```
