### PR TITLE
BUG: GH10160 DataFrame construction from nested dict

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -95,3 +95,5 @@ Bug Fixes
 
 - Bug where infer_freq infers timerule (WOM-5XXX) unsupported by to_offset (:issue:`9425`)
 
+
+- Bug in DataFrame constructor from nested ``dict`` type where the index is ``datatime64`` (:issue:`10160`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5095,8 +5095,9 @@ def _homogenize(data, index, dtype=None):
                 v = v.reindex(index, copy=False)
         else:
             if isinstance(v, dict):
-                if oindex is None:
-                    oindex = index.astype('O')
+                if lib.infer_dtype(v) in ['datetime64']:
+                    v = dict((lib.Timestamp(key), v[key]) for key in v)
+                oindex = index.astype('O')
                 if type(v) == dict:
                     # fast cython method
                     v = lib.fast_multiget(v, oindex.values, default=NA)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2941,6 +2941,21 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df = df.reindex(columns=expected.columns, index=expected.index)
         check(df, expected)
 
+    def test_constructor_dict_datetime64_index(self):
+        # GH 10160
+        data = {1: {np.datetime64('1990-03-15'): 1},
+                2: {np.datetime64('1989-12-03'): 3},
+                3: {np.datetime64('1988-11-06'): 5},
+                4: {np.datetime64('1984-02-19'): 7}}
+        data_expected = {1: {Timestamp('1990-03-15'): 1},
+                         2: {Timestamp('1989-12-03'): 3},
+                         3: {Timestamp('1988-11-06'): 5},
+                         4: {Timestamp('1984-02-19'): 7}}
+        result = DataFrame(data)
+        expected = DataFrame(data_expected)
+        assert_frame_equal(result, expected)
+
+
     def _check_basic_constructor(self, empty):
         "mat: 2d matrix with shpae (3, 2) to input. empty - makes sized objects"
         mat = empty((2, 3), dtype=float)


### PR DESCRIPTION
This is to fix #10160, where `DataFrame` construction from nested `dict` with `datetime64` index returns a `DataFrame` of `NaN`s or `None`s.
