### PR TITLE
ENH: allow as_blocks to take a copy argument (#9607)

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2290,13 +2290,17 @@ class NDFrame(PandasObject):
         return Series(self._data.get_ftypes(), index=self._info_axis,
                       dtype=np.object_)
 
-    def as_blocks(self):
+    def as_blocks(self, copy=True):
         """
         Convert the frame to a dict of dtype -> Constructor Types that each has
         a homogeneous dtype.
 
         NOTE: the dtypes of the blocks WILL BE PRESERVED HERE (unlike in
               as_matrix)
+
+        Parameters
+        ----------
+        copy : boolean, default True
 
         Returns
         -------
@@ -2312,7 +2316,7 @@ class NDFrame(PandasObject):
         for dtype, blocks in bd.items():
             # Must combine even after consolidation, because there may be
             # sparse items which are never consolidated into one block.
-            combined = self._data.combine(blocks, copy=True)
+            combined = self._data.combine(blocks, copy=copy)
             result[dtype] = self._constructor(combined).__finalize__(self)
 
         return result

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -6108,7 +6108,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # use the default copy=True, change a column
         blocks = df.as_blocks()
-        for dtype, _df in blocks.iteritems():
+        for dtype, _df in blocks.items():
             if column in _df:
                 _df.ix[:, column] = _df[column] + 1
 
@@ -6122,7 +6122,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # use the copy=False, change a column
         blocks = df.as_blocks(copy=False)
-        for dtype, _df in blocks.iteritems():
+        for dtype, _df in blocks.items():
             if column in _df:
                 _df.ix[:, column] = _df[column] + 1
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -6101,6 +6101,34 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.assertTrue(df0.equals(df1))
         self.assertTrue(df1.equals(df0))
 
+    def test_copy_blocks(self):
+        # API/ENH 9607
+        df = DataFrame(self.frame, copy=True)
+        column = df.columns[0]
+
+        # use the default copy=True, change a column
+        blocks = df.as_blocks()
+        for dtype, _df in blocks.iteritems():
+            if column in _df:
+                _df.ix[:, column] = _df[column] + 1
+
+        # make sure we did not change the original DataFrame
+        self.assertFalse(_df[column].equals(df[column]))
+
+    def test_no_copy_blocks(self):
+        # API/ENH 9607
+        df = DataFrame(self.frame, copy=True)
+        column = df.columns[0]
+
+        # use the copy=False, change a column
+        blocks = df.as_blocks(copy=False)
+        for dtype, _df in blocks.iteritems():
+            if column in _df:
+                _df.ix[:, column] = _df[column] + 1
+
+        # make sure we did change the original DataFrame
+        self.assertTrue(_df[column].equals(df[column]))
+
     def test_to_csv_from_csv(self):
 
         pname = '__tmp_to_csv_from_csv__'


### PR DESCRIPTION
closes #9607

Added copy argument in as_blocks. Defaults to True as per the original code.

Wrote test cases to check the copy=True and copy=False cases work.
