### PR TITLE
PERF: write basic datetimes faster

### DIFF
--- a/doc/source/whatsnew/v0.16.2.txt
+++ b/doc/source/whatsnew/v0.16.2.txt
@@ -47,6 +47,7 @@ Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Improved ``Series.resample`` performance with dtype=datetime64[ns] (:issue:`7754`)
+- Modest improvement in datetime writing speed in to_csv (:issue:`10271`)
 
 .. _whatsnew_0162.bug_fixes:
 


### PR DESCRIPTION
with PR

```
In [2]: df = DataFrame({'A' : pd.date_range('20130101',periods=100000,freq='s')})

In [3]: %timeit df.to_csv('test.csv',mode='w')
1 loops, best of 3: 282 ms per loop
```

0.16.1

```
In [2]: %timeit df.to_csv('test.csv',mode='w')
1 loops, best of 3: 352 ms per loop
```
