### PR TITLE
PERF/CLN: Improve datetime-like index ops perf

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -139,6 +139,8 @@ Performance Improvements
 
 - Improved performance of ``andrews_curves`` (:issue:`11534`)
 
+- Improved huge ``DatetimeIndex``, ``PeriodIndex`` and ``TimedeltaIndex``'s ops performance including ``NaT`` (:issue:`10277`)
+
 
 
 

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -93,9 +93,8 @@ def _dt_index_cmp(opname, nat_result=False):
             if o_mask.any():
                 result[o_mask] = nat_result
 
-        mask = self.asi8 == tslib.iNaT
-        if mask.any():
-            result[mask] = nat_result
+        if self.hasnans:
+            result[self._isnan] = nat_result
 
         # support of bool dtype indexers
         if com.is_bool_dtype(result):

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -589,9 +589,9 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
         -------
         shifted : PeriodIndex
         """
-        mask = self.values == tslib.iNaT
         values = self.values + n * self.freq.n
-        values[mask] = tslib.iNaT
+        if self.hasnans:
+            values[self._isnan] = tslib.iNaT
         return PeriodIndex(data=values, name=self.name, freq=self.freq)
 
     @cache_readonly

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -51,9 +51,8 @@ def _td_index_cmp(opname, nat_result=False):
             if o_mask.any():
                 result[o_mask] = nat_result
 
-        mask = self.asi8 == tslib.iNaT
-        if mask.any():
-            result[mask] = nat_result
+        if self.hasnans:
+            result[self._isnan] = nat_result
 
         # support of bool dtype indexers
         if com.is_bool_dtype(result):
@@ -334,7 +333,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         hasnans = self.hasnans
         if hasnans:
             result = np.empty(len(self), dtype='float64')
-            mask = values == tslib.iNaT
+            mask = self._isnan
             imask = ~mask
             result.flat[imask] = np.array([ getattr(Timedelta(val),m) for val in values[imask] ])
             result[mask] = np.nan

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -124,6 +124,8 @@ class TestDatetimeIndexOps(Ops):
             for idx in [idx1, idx2]:
                 self.assertEqual(idx.min(), pd.Timestamp('2011-01-01', tz=tz))
                 self.assertEqual(idx.max(), pd.Timestamp('2011-01-03', tz=tz))
+                self.assertEqual(idx.argmin(), 0)
+                self.assertEqual(idx.argmax(), 2)
 
         for op in ['min', 'max']:
             # Return NaT
@@ -579,6 +581,8 @@ class TestTimedeltaIndexOps(Ops):
         for idx in [idx1, idx2]:
             self.assertEqual(idx.min(), Timedelta('1 days')),
             self.assertEqual(idx.max(), Timedelta('3 days')),
+            self.assertEqual(idx.argmin(), 0)
+            self.assertEqual(idx.argmax(), 2)
 
         for op in ['min', 'max']:
             # Return NaT
@@ -1209,6 +1213,10 @@ class TestPeriodIndexOps(Ops):
         for idx in [idx1, idx2]:
             self.assertEqual(idx.min(), pd.Period('2011-01-01', freq='D'))
             self.assertEqual(idx.max(), pd.Period('2011-01-03', freq='D'))
+        self.assertEqual(idx1.argmin(), 1)
+        self.assertEqual(idx2.argmin(), 0)
+        self.assertEqual(idx1.argmax(), 3)
+        self.assertEqual(idx2.argmax(), 2)
 
         for op in ['min', 'max']:
             # Return NaT


### PR DESCRIPTION
Add `_isnan` to `DatetimeIndexOpsMixin` to cache `NaT` mask. 

This leads to some perf improvement which is noticeable in larger data.
### after fix

```
import pandas as pd
import numpy as np

np.random.seed(1)
idx = pd.DatetimeIndex(np.append(np.array([pd.tslib.iNaT]),
                       np.random.randint(500, 1000, size=100000000)))
%timeit idx.max()
1 loops, best of 3: 599 ms per loop

%timeit idx.min()
1 loops, best of 3: 608 ms per loop
```
### before fix:

```
%timeit idx.max()
1 loops, best of 3: 940 ms per loop

%timeit idx.min()
1 loops, best of 3: 883 ms per loop
```
