### PR TITLE
Update holiday.py to reflect that MLK Jr. Day was first observed in 1986. 

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -587,8 +587,6 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
-
-
 - Bug in ``DataFrame.to_html(index=False)`` renders unnecessary ``name`` row (:issue:`10344`)
 - Bug in ``DataFrame.apply`` when function returns categorical series. (:issue:`9573`)
 - Bug in ``to_datetime`` with invalid dates and formats supplied (:issue:`10154`)
@@ -602,6 +600,7 @@ Bug Fixes
 - Bug in ``offsets.generate_range`` where ``start`` and ``end`` have finer precision than ``offset`` (:issue:`9907`)
 - Bug in ``pd.rolling_*`` where ``Series.name`` would be lost in the output (:issue:`10565`)
 - Bug in ``stack`` when index or columns are not unique. (:issue:`10417`)
+- Bug in ``USFederalHolidayCalendar`` where ``USMemorialDay`` and ``USMartinLutherKingJr`` were incorrect (:issue:`10278` and :issue:`9760` )
 
 
 

--- a/pandas/tests/test_tseries.py
+++ b/pandas/tests/test_tseries.py
@@ -9,7 +9,10 @@ from pandas.compat import range, lrange, zip
 import pandas.lib as lib
 import pandas._period as period
 import pandas.algos as algos
-from pandas.tseries.holiday import Holiday, SA, next_monday
+from pandas.tseries.holiday import Holiday, SA, next_monday,USMartinLutherKingJr,USMemorialDay,AbstractHolidayCalendar 
+import datetime
+
+
 from pandas import DateOffset
 
 
@@ -750,6 +753,28 @@ class TestPeriodField(tm.TestCase):
 
     def test_get_period_field_array_raises_on_out_of_range(self):
         self.assertRaises(ValueError, period.get_period_field_arr, -1, np.empty(1), 0)
+
+class TestFederalHolidayCalendar(tm.TestCase):
+    # Test for issue 10278
+    def test_no_mlk_before_1984(self):
+        class MLKCalendar(AbstractHolidayCalendar):
+            rules=[USMartinLutherKingJr]
+        holidays = MLKCalendar().holidays(start='1984', end='1988').to_pydatetime().tolist()
+        # Testing to make sure holiday is not incorrectly observed before 1986
+        self.assertEqual(holidays, [datetime.datetime(1986, 1, 20, 0, 0), datetime.datetime(1987, 1, 19, 0, 0)])
+
+    def test_memorial_day(self):
+        class MemorialDay(AbstractHolidayCalendar):
+            rules=[USMemorialDay]
+        holidays = MemorialDay().holidays(start='1971', end='1980').to_pydatetime().tolist()
+        # Fixes 5/31 error and checked manually against wikipedia
+        self.assertEqual(holidays, [datetime.datetime(1971, 5, 31, 0, 0), datetime.datetime(1972, 5, 29, 0, 0), 
+            datetime.datetime(1973, 5, 28, 0, 0), datetime.datetime(1974, 5, 27, 0, 0), 
+            datetime.datetime(1975, 5, 26, 0, 0), datetime.datetime(1976, 5, 31, 0, 0), 
+            datetime.datetime(1977, 5, 30, 0, 0), datetime.datetime(1978, 5, 29, 0, 0), 
+            datetime.datetime(1979, 5, 28, 0, 0)]) 
+
+
 
 
 class TestHolidayConflictingArguments(tm.TestCase):

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -405,15 +405,15 @@ class AbstractHolidayCalendar(object):
         else:
             return holidays
 
-USMemorialDay = Holiday('MemorialDay', month=5, day=24,
-                        offset=DateOffset(weekday=MO(1)))
+USMemorialDay = Holiday('MemorialDay', month=5, day=31,
+                        offset=DateOffset(weekday=MO(-1)))
 USLaborDay = Holiday('Labor Day', month=9, day=1,
                      offset=DateOffset(weekday=MO(1)))
 USColumbusDay = Holiday('Columbus Day', month=10, day=1,
                         offset=DateOffset(weekday=MO(2)))
 USThanksgivingDay = Holiday('Thanksgiving', month=11, day=1,
                             offset=DateOffset(weekday=TH(4)))
-USMartinLutherKingJr = Holiday('Dr. Martin Luther King Jr.', month=1, day=1,
+USMartinLutherKingJr = Holiday('Dr. Martin Luther King Jr.', start_date=datetime(1986,1,1), month=1, day=1,
                                offset=DateOffset(weekday=MO(3)))
 USPresidentsDay = Holiday('President''s Day', month=2, day=1,
                           offset=DateOffset(weekday=MO(3)))


### PR DESCRIPTION
closes #9760

Fixing MLK day not observed before 1986, per https://github.com/pydata/pandas/issues/10278#issuecomment-109002244
