### PR TITLE
ENH: #2679 - DataFrame.to_html() urls_as_links parameter.

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1349,7 +1349,8 @@ class DataFrame(NDFrame):
                 header=True, index=True, na_rep='NaN', formatters=None,
                 float_format=None, sparsify=None, index_names=True,
                 justify=None, bold_rows=True, classes=None, escape=True,
-                max_rows=None, max_cols=None, show_dimensions=False):
+                max_rows=None, max_cols=None, show_dimensions=False,
+                urls_as_links=False):
         """
         Render a DataFrame as an HTML table.
 
@@ -1367,6 +1368,8 @@ class DataFrame(NDFrame):
         max_cols : int, optional
             Maximum number of columns to show before truncating. If None, show
             all.
+        urls_as_links : boolean, default False
+            Convert urls to HTML links.
 
         """
 
@@ -1387,7 +1390,8 @@ class DataFrame(NDFrame):
                                            escape=escape,
                                            max_rows=max_rows,
                                            max_cols=max_cols,
-                                           show_dimensions=show_dimensions)
+                                           show_dimensions=show_dimensions,
+                                           urls_as_links=urls_as_links)
         formatter.to_html(classes=classes)
 
         if buf is None:

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -731,6 +731,77 @@ class TestDataFrameFormatting(tm.TestCase):
 </table>"""
             self.assertEqual(result, expected)
 
+    def test_to_html_with_hyperlinks(self):
+        data = [
+            {
+                'foo': 0,
+                'bar': 'http://pandas.pydata.org/',
+                None: 'pydata.org',
+            },
+            {
+                'foo': 0,
+                'bar': 'http://pandas.pydata.org/?q1=a&q2=b',
+                None: 'pydata.org',
+            },
+        ]
+        df = DataFrame(data, columns=['foo', 'bar', None],
+                       index=range(len(data)))
+
+        result_no_links = df.to_html()
+        result_with_links = df.to_html(urls_as_links=True)
+        expected_no_links = """\
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>foo</th>
+      <th>bar</th>
+      <th>None</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0</td>
+      <td>http://pandas.pydata.org/</td>
+      <td>pydata.org</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>0</td>
+      <td>http://pandas.pydata.org/?q1=a&amp;q2=b</td>
+      <td>pydata.org</td>
+    </tr>
+  </tbody>
+</table>"""
+        expected_with_links = """\
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>foo</th>
+      <th>bar</th>
+      <th>None</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>0</td>
+      <td><a href="http://pandas.pydata.org/">http://pandas.pydata.org/</a></td>
+      <td>pydata.org</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>0</td>
+      <td><a href="http://pandas.pydata.org/?q1=a&q2=b">http://pandas.pydata.org/?q1=a&amp;q2=b</a></td>
+      <td>pydata.org</td>
+    </tr>
+  </tbody>
+</table>"""
+        self.assertEqual(result_with_links, expected_with_links)
+        self.assertEqual(result_no_links, expected_no_links)
+
     def test_to_html_multiindex_sparsify(self):
         index = MultiIndex.from_arrays([[0, 0, 1, 1], [0, 1, 0, 1]],
                                           names=['foo', None])


### PR DESCRIPTION
New urls_as_links boolean paramater that will output urls as href html
links. ref #2679 

Thanks for @tdas14 for initial code.
