### PR TITLE
BUG: read_csv does not set index name on an empty DataFrame

### DIFF
--- a/doc/source/whatsnew/v0.16.2.txt
+++ b/doc/source/whatsnew/v0.16.2.txt
@@ -142,6 +142,7 @@ Bug Fixes
 - Bug in `plot` not defaulting to matplotlib `axes.grid` setting (:issue:`9792`)
 
 - Bug in ``Series.align`` resets ``name`` when ``fill_value`` is specified (:issue:`10067`)
+- Bug in ``read_csv`` causing index name not to be set on an empty DataFrame (:issue:`10184`)
 - Bug in ``SparseSeries.abs`` resets ``name`` (:issue:`10241`)
 
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1170,7 +1170,9 @@ class CParserWrapper(ParserBase):
             data = self._reader.read(nrows)
         except StopIteration:
             if nrows is None:
-                return None, self.names, {}
+                return _get_empty_meta(self.orig_names,
+                                       self.index_col,
+                                       self.index_names)
             else:
                 raise
 

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -2294,6 +2294,13 @@ MyColumn
         result = self.read_csv(StringIO(data), header=None)
         self.assertEqual(len(result), 2)
 
+    def test_empty_with_index(self):
+        # GH 10184
+        data = 'x,y'
+        result = self.read_csv(StringIO(data), index_col=0)
+        expected = DataFrame([], columns=['y'], index=Index([], name='x'))
+        tm.assert_frame_equal(result, expected)
+
 
 class TestPythonParser(ParserTests, tm.TestCase):
     def test_negative_skipfooter_raises(self):


### PR DESCRIPTION
Fixes GH #10184.
