### PR TITLE
BUG: Categorical.remove_categories(np.nan) fails when underlying dtype is float

### DIFF
--- a/doc/source/whatsnew/v0.16.2.txt
+++ b/doc/source/whatsnew/v0.16.2.txt
@@ -163,6 +163,8 @@ Bug Fixes
 - Bug in GroupBy.get_group raises ValueError when group key contains NaT (:issue:`6992`)
 - Bug in ``SparseSeries`` constructor ignores input data name (:issue:`10258`)
 
+- Bug in ``Categorical.remove_categories`` causing a ValueError when removing the ``NaN`` category if underlying dtype is floating-point (:issue:`10156`)
+
 - Bug where infer_freq infers timerule (WOM-5XXX) unsupported by to_offset (:issue:`9425`)
 - Bug in ``DataFrame.to_hdf()`` where table format would raise a seemingly unrelated error for invalid (non-string) column names. This is now explicitly forbidden. (:issue:`9057`)
 - Bug to handle masking empty ``DataFrame``(:issue:`10126`)

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -749,11 +749,19 @@ class Categorical(PandasObject):
         """
         if not is_list_like(removals):
             removals = [removals]
-        removals = set(list(removals))
-        not_included = removals - set(self._categories)
+
+        removal_set = set(list(removals))
+        not_included = removal_set - set(self._categories)
+        new_categories = [ c for c in self._categories if c not in removal_set ]
+
+        # GH 10156
+        if any(isnull(removals)):
+            not_included = [x for x in not_included if notnull(x)]
+            new_categories = [x for x in new_categories if notnull(x)]
+
         if len(not_included) != 0:
             raise ValueError("removals must all be in old categories: %s" % str(not_included))
-        new_categories = [ c for c in self._categories if c not in removals ]
+
         return self.set_categories(new_categories, ordered=self.ordered, rename=False,
                                    inplace=inplace)
 


### PR DESCRIPTION
Fixes GH #10156. This also makes different null values indistinguishable inside of remove_categories, but they're already indistinguishable in most other contexts:

``` .python
>>> pd.Categorical([], categories=[np.nan, None])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pandas/core/categorical.py", line 289, in __init__
    categories = self._validate_categories(categories)
  File "pandas/core/categorical.py", line 447, in _validate_categories
    raise ValueError('Categorical categories must be unique')
ValueError: Categorical categories must be unique
```
