### PR TITLE
BUG: bug in json serialization when frame has mixed types

### DIFF
--- a/doc/source/whatsnew/v0.16.2.txt
+++ b/doc/source/whatsnew/v0.16.2.txt
@@ -117,6 +117,7 @@ Bug Fixes
 - Bug where some of the nan funcs do not have consistent return dtypes (:issue:`10251`)
 - Bug in groupby.apply aggregation for Categorical not preserving categories (:issue:`10138`)
 - Bug in ``to_csv`` where ``date_format`` is ignored if the ``datetime`` is fractional (:issue:`10209`)
+- Bug in ``DataFrame.to_json`` with mixed data types (:issue:`10289`)
 
 - Bug in cache updating when consolidating (:issue:`10264`)
 

--- a/pandas/io/tests/test_json/test_pandas.py
+++ b/pandas/io/tests/test_json/test_pandas.py
@@ -333,6 +333,33 @@ class TestPandasContainer(tm.TestCase):
         self.assertTrue(df._is_mixed_type)
         assert_frame_equal(read_json(df.to_json(), dtype=dict(df.dtypes)), df)
 
+    def test_frame_mixedtype_orient(self):  # GH10289
+        vals = [[10, 1, 'foo', .1, .01],
+                [20, 2, 'bar', .2, .02],
+                [30, 3, 'baz', .3, .03],
+                [40, 4, 'qux', .4, .04]]
+
+        df = DataFrame(vals, index=list('abcd'),
+                       columns=['1st', '2nd', '3rd', '4th', '5th'])
+
+        self.assertTrue(df._is_mixed_type)
+        right = df.copy()
+
+        for orient in ['split', 'index', 'columns']:
+            inp = df.to_json(orient=orient)
+            left = read_json(inp, orient=orient, convert_axes=False)
+            assert_frame_equal(left, right)
+
+        right.index = np.arange(len(df))
+        inp = df.to_json(orient='records')
+        left = read_json(inp, orient='records', convert_axes=False)
+        assert_frame_equal(left, right)
+
+        right.columns = np.arange(df.shape[1])
+        inp = df.to_json(orient='values')
+        left = read_json(inp, orient='values', convert_axes=False)
+        assert_frame_equal(left, right)
+
     def test_v12_compat(self):
         df = DataFrame(
             [[1.56808523,  0.65727391,  1.81021139, -0.17251653],

--- a/pandas/src/ujson/lib/ultrajson.h
+++ b/pandas/src/ujson/lib/ultrajson.h
@@ -309,5 +309,6 @@ typedef struct __JSONObjectDecoder
 } JSONObjectDecoder;
 
 EXPORTFUNCTION JSOBJ JSON_DecodeObject(JSONObjectDecoder *dec, const char *buffer, size_t cbBuffer);
+EXPORTFUNCTION void encode(JSOBJ, JSONObjectEncoder *, const char *, size_t);
 
 #endif

--- a/pandas/src/ujson/lib/ultrajsondec.c
+++ b/pandas/src/ujson/lib/ultrajsondec.c
@@ -803,7 +803,7 @@ FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_object( struct DecoderState *ds)
       return NULL;
     }
 
-  if (!ds->dec->objectAddKey (ds->prv, newObj, itemName, itemValue)) 
+  if (!ds->dec->objectAddKey (ds->prv, newObj, itemName, itemValue))
   {
     ds->dec->releaseObject(ds->prv, newObj, ds->dec);
     ds->dec->releaseObject(ds->prv, itemName, ds->dec);
@@ -907,7 +907,7 @@ JSOBJ JSON_DecodeObject(JSONObjectDecoder *dec, const char *buffer, size_t cbBuf
     setlocale(LC_NUMERIC, locale);
     free(locale);
   }
-  else 
+  else
   {
     ret = decode_any (&ds);
   }

--- a/pandas/src/ujson/python/objToJSON.c
+++ b/pandas/src/ujson/python/objToJSON.c
@@ -161,6 +161,8 @@ enum PANDAS_FORMAT
 //#define PRINTMARK() fprintf(stderr, "%s: MARK(%d)\n", __FILE__, __LINE__)
 #define PRINTMARK()
 
+int PdBlock_iterNext(JSOBJ, JSONTypeContext *);
+
 // import_array() compat
 #if (PY_VERSION_HEX >= 0x03000000)
 void *initObjToJSON(void)
@@ -835,7 +837,10 @@ char *PdBlock_iterGetName(JSOBJ obj, JSONTypeContext *tc, size_t *outLen)
   }
   else
   {
-    idx = npyarr->index[npyarr->stridedim - npyarr->inc] - 1;
+    idx = GET_TC(tc)->iterNext != PdBlock_iterNext
+        ? npyarr->index[npyarr->stridedim - npyarr->inc] - 1
+        : npyarr->index[npyarr->stridedim];
+
     NpyArr_getLabel(obj, tc, outLen, idx, npyarr->rowLabels);
   }
   return NULL;
@@ -2374,7 +2379,7 @@ ISITERABLE:
       }
       goto INVALID;
     }
-    encode (tmpObj, enc, NULL, 0);
+    encode (tmpObj, (JSONObjectEncoder*) enc, NULL, 0);
     Py_DECREF(tmpObj);
     goto INVALID;
   }


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/10289

on master:

``` python
>>> df
   1st  2nd  3rd  4th   5th
a   10    1  foo  0.1  0.01
b   20    2  bar  0.2  0.02
c   30    3  baz  0.3  0.03
d   40    4  qux  0.4  0.04

>>> read_json(df.to_json(orient='index'), orient='index', convert_axes=False)
   1st  2nd  3rd  4th   5th
a   40    4  qux  0.4  0.04
```

on branch:

``` python
>>> read_json(df.to_json(orient='index'), orient='index', convert_axes=False)
   1st  2nd  3rd  4th   5th
a   10    1  foo  0.1  0.01
b   20    2  bar  0.2  0.02
c   30    3  baz  0.3  0.03
d   40    4  qux  0.4  0.04
```
