### PR TITLE
BUG: Bug in to_json with certain orients and a CategoricalIndex would segfault, closes #10317

### DIFF
--- a/doc/source/whatsnew/v0.16.2.txt
+++ b/doc/source/whatsnew/v0.16.2.txt
@@ -120,7 +120,7 @@ Bug Fixes
 - Bug where read_hdf store.select modifies the passed columns list when
   multi-indexed (:issue:`7212`)
 - Bug in ``Categorical`` repr with ``display.width`` of ``None`` in Python 3 (:issue:`10087`)
-
+- Bug in ``to_json`` with certain orients and a ``CategoricalIndex`` would segfault (:issue:`10307`)
 - Bug where some of the nan funcs do not have consistent return dtypes (:issue:`10251`)
 
 - Bug in ``DataFrame.quantile`` on checking that a valid axis was passed (:issue:`9543`)


### PR DESCRIPTION
xref #10317 

```
In [17]: df = DataFrame({ 'A' : pd.Series([3,2,2],index=pd.Categorical([1,2,3],categories=[1,2,3])), 'B' : pd.Categorical(list('aab')) })

In [18]: df
Out[18]: 
   A  B
1  3  a
2  2  a
3  2  b

In [19]: df.index
Out[19]: CategoricalIndex([1, 2, 3], categories=[1, 2, 3], ordered=False, dtype='category')

In [20]: df.dtypes
Out[20]: 
A       int64
B    category
dtype: object

In [31]: def f(orient):
    print "orient->%s" % orient
    print df.to_json(orient=orient)
   ....:     

In [32]: f('columns')
orient->columns
{"A":{"1":3,"2":2,"3":2},"B":{"1":"a","2":"a","3":"b"}}

In [33]: f('index')
orient->index
{"1":{"A":3,"B":"a"},"2":{"A":2,"B":"a"},"3":{"A":2,"B":"b"}}

In [34]: f('split')
orient->split
{"columns":["A","B"],"index":[1,2,3],"data":[[3,"a"],[2,"a"],[2,"b"]]}

In [35]: f('records')
orient->records
[{"A":3,"B":"a"},{"A":2,"B":"a"},{"A":2,"B":"b"}]

In [36]: f('values')
orient->values
[[3,"a"],[2,"a"],[2,"b"]]
```
