### PR TITLE
BUG/ENH: GH10319 added higher_precision argument to rolling_mean/sum

### DIFF
--- a/doc/source/whatsnew/v0.16.2.txt
+++ b/doc/source/whatsnew/v0.16.2.txt
@@ -86,6 +86,8 @@ See the :ref:`documentation <basics.pipe>` for more. (:issue:`10129`)
 Other enhancements
 ^^^^^^^^^^^^^^^^^^
 
+- ``rolling_mean`` and ``rolling_sum`` accept ``higher_precision`` (``True``/``False``) argument (:issue:`10319`)
+
 .. _whatsnew_0162.api:
 
 Backwards incompatible API changes

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -307,6 +307,33 @@ def test_unique_label_indices():
     right = np.unique(a, return_index=True)[1][1:]
     tm.assert_array_equal(left, right)
 
+
+class TestNumericalAccuracy(tm.TestCase):
+
+    def test_roll_mean_accuracy(self):
+        # GH10319
+        values = [1, 0.0003, -0.0, -0.0]
+        values_expected = [x + 0 for x in values]
+        dates = pd.date_range('1999-02-03', '1999-02-06')
+        s = pd.Series(data=values, index=dates)
+
+        roll_mean = pd.rolling_mean(s, 1, higher_precision=True)
+        expected = pd.Series(data=values_expected, index=dates)
+
+        tm.assert_series_equal(roll_mean, expected, check_exact=True)
+
+    def test_roll_sum_accuracy(self):
+        # GH10319
+        values = [1, 0.0003, -0.0, -0.0]
+        values_expected = [x + 0 for x in values]
+        dates = pd.date_range('1999-02-03', '1999-02-06')
+        s = pd.Series(data=values, index=dates)
+
+        roll_sum = pd.rolling_sum(s, 1, higher_precision=True)
+        expected = pd.Series(data=values_expected, index=dates)
+
+        tm.assert_series_equal(roll_sum, expected, check_exact=True)
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
This is not specifically for #10319, but should close it for most cases, should users pass in `higher_precision=True`. #10319 is not really a bug in the Cython code, just precision loss when you do finite-precision arithmetic naively. 

```
>>> sum([0.00012456, 0.0003, -0.00012456, -0.0003])
-5.421010862427522e-20
```

This is `2**-64` and quite negligible, although it can be made much bigger with carefully chosen numbers.  I think rolling_\* functions that require summation could use some more precision, since doing everything in one pass accumulates rounding error, even if the rolling window is narrow.
The only reason why [0.00012456, 0.0003, 0.0, 0.0] currently returns the 'correct' result while [0.00012456, 0.0003, -0.0, -0.0] doesn't is because of explicit negative entry counting. This is only done in rolling_mean but not rolling_sum, and the lack of symmetry doesn't seem desirable. Perhaps we could remove the counting, or add it to rolling_sum as well? 
