### PR TITLE
DOC: Remove auto_close option form read_hdf

### DIFF
--- a/doc/source/whatsnew/v0.16.2.txt
+++ b/doc/source/whatsnew/v0.16.2.txt
@@ -168,4 +168,8 @@ Bug Fixes
 
 - Bug where MySQL interface could not handle numeric table/column names (:issue:`10255`)
 
-- Bug in ``read_csv`` with a ``date_parser`` that returned a ``datetime64`` array of other time resolution than ``[ns]`` (:issue:`10245`)
+
+- Bug in ``read_csv`` with a ``date_parser`` that returned a ``datetime64`` array of other time resolution than ``[ns]`` (:issue:`10245`).
+
+- Bug in ``read_hdf`` where ``auto_close`` could not be passed (:issue:`9327`).
+- Bug in ``read_hdf`` where open stores could not be used (:issue:`10330`).

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -13,7 +13,7 @@ import pandas as pd
 from pandas import (Series, DataFrame, Panel, MultiIndex, Categorical, bdate_range,
                     date_range, timedelta_range, Index, DatetimeIndex, TimedeltaIndex, isnull)
 
-from pandas.io.pytables import _tables
+from pandas.io.pytables import _tables, TableIterator
 try:
     _tables()
 except ImportError as e:
@@ -4669,6 +4669,53 @@ class TestHDFStore(tm.TestCase):
                 result = pd.read_hdf(path, 'df', where="index = [{0}]".format(df.index[0]))
                 assert(len(result))
 
+
+    def test_read_hdf_open_store(self):
+        # GH10330
+        # No check for non-string path_or-buf, and no test of open store
+        df = DataFrame(np.random.rand(4, 5),
+                       index=list('abcd'),
+                       columns=list('ABCDE'))
+        df.index.name = 'letters'
+        df = df.set_index(keys='E', append=True)
+
+        with ensure_clean_path(self.path) as path:
+            df.to_hdf(path, 'df', mode='w')
+            direct = read_hdf(path, 'df')
+            store = HDFStore(path, mode='r')
+            indirect = read_hdf(store, 'df')
+            tm.assert_frame_equal(direct, indirect)
+            self.assertTrue(store.is_open)
+            store.close()
+
+    def test_read_hdf_iterator(self):
+        df = DataFrame(np.random.rand(4, 5),
+                       index=list('abcd'),
+                       columns=list('ABCDE'))
+        df.index.name = 'letters'
+        df = df.set_index(keys='E', append=True)
+
+        with ensure_clean_path(self.path) as path:
+            df.to_hdf(path, 'df', mode='w', format='t')
+            direct = read_hdf(path, 'df')
+            iterator = read_hdf(path, 'df', iterator=True)
+            self.assertTrue(isinstance(iterator, TableIterator))
+            indirect = next(iterator.__iter__())
+            tm.assert_frame_equal(direct, indirect)
+
+    def test_read_hdf_errors(self):
+        df = DataFrame(np.random.rand(4, 5),
+                       index=list('abcd'),
+                       columns=list('ABCDE'))
+
+        with ensure_clean_path(self.path) as path:
+            self.assertRaises(IOError, read_hdf, path, 'key')
+            df.to_hdf(path, 'df')
+            store = HDFStore(path, mode='r')
+            store.close()
+            self.assertRaises(IOError, read_hdf, store, 'df')
+            with open(path, mode='r') as store:
+                self.assertRaises(NotImplementedError, read_hdf, store, 'df')
 
 def _test_sort(obj):
     if isinstance(obj, DataFrame):


### PR DESCRIPTION
Remove docstring indicating auto_close can be used in read_hdf.
This value is always ignored.
Also removes unreachable code.

xref #9327
