### PR TITLE
BUG: Check complib values

### DIFF
--- a/doc/source/whatsnew/v0.16.2.txt
+++ b/doc/source/whatsnew/v0.16.2.txt
@@ -174,3 +174,5 @@ Bug Fixes
 
 - Bug in ``read_hdf`` where ``auto_close`` could not be passed (:issue:`9327`).
 - Bug in ``read_hdf`` where open stores could not be used (:issue:`10330`).
+
+- Bug in ``to_hdf`` and ``HDFStore`` which did not check that complib choices were valid (:issue:`4582`, :issue:`8874`).

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -389,6 +389,10 @@ class HDFStore(StringMixin):
         except ImportError as ex:  # pragma: no cover
             raise ImportError('HDFStore requires PyTables, "{ex}" problem importing'.format(ex=str(ex)))
 
+        if complib not in (None, 'blosc', 'bzip2', 'lzo', 'zlib'):
+            raise ValueError("complib only supports 'blosc', 'bzip2', lzo' "
+                             "or 'zlib' compression.")
+
         self._path = path
         if mode is None:
             mode = 'a'

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -4718,6 +4718,13 @@ class TestHDFStore(tm.TestCase):
             with open(path, mode='r') as store:
                 self.assertRaises(NotImplementedError, read_hdf, store, 'df')
 
+    def test_invalid_complib(self):
+        df = DataFrame(np.random.rand(4, 5),
+                       index=list('abcd'),
+                       columns=list('ABCDE'))
+        with ensure_clean_path(self.path) as path:
+            self.assertRaises(ValueError, df.to_hdf, path, 'df', complib='blosc:zlib')
+
 def _test_sort(obj):
     if isinstance(obj, DataFrame):
         return obj.reindex(sorted(obj.index))


### PR DESCRIPTION
Add check for complib when opening a HDFStore

closes #4582
closes #8874
