### PR TITLE
DEPR: deprecating series asof GH10343

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -449,7 +449,6 @@ Time series-related
    :toctree: generated/
 
    Series.asfreq
-   Series.asof
    Series.shift
    Series.first_valid_index
    Series.last_valid_index

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -521,6 +521,11 @@ Deprecations
 
 - ``Categorical.name`` was deprecated to make ``Categorical`` more ``numpy.ndarray`` like. Use ``Series(cat, name="whatever")`` instead (:issue:`10482`).
 
+- :meth:`Series.asof` is deprecated. Please use :meth:`Series.reindex(where, method='ffill')`
+  instead. This method does not drop missing values in the original series.
+
+  So `Series.asof(where)` is equivalent to `Series.dropna().reindex(where, method='ffill')`.
+
 .. _whatsnew_0170.prior_deprecations:
 
 Removal of prior version deprecations/changes

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2452,6 +2452,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def asof(self, where):
         """
+        DEPRECATED. Please use :meth:`Series.reindex` instead.
+
+        So a `Series.asof(where)` can be replaced by
+        `Series.dropna().reindex(where, method='ffill')`.
+
         Return last good (non-NaN) value in TimeSeries if value is NaN for
         requested date.
 
@@ -2468,7 +2473,14 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         Returns
         -------
         value or NaN
+
+        See Also
+        --------
+        pandas.Series.reindex
+
         """
+        warnings.warn("`Series.asof` is deprecated, use "
+                      "`Series.reindex` instead.", FutureWarning)
         if isinstance(where, compat.string_types):
             where = datetools.to_datetime(where)
 


### PR DESCRIPTION
closes #10343 and discussion on #10266 - deprecating `Series.asof(where)` in favour of `Series.reindex(where, method='ffill')`.
