### PR TITLE
BUG: drop_duplicates drops name(s).

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -63,7 +63,7 @@ Bug Fixes
 ~~~~~~~~~
 - Bug in ``DataFrame.apply`` when function returns categorical series. (:issue:`9573`)
 
-
+- Bug in ``Index.drop_duplicates`` dropping name(s) (:issue:`10115`)
 - Bug in ``pd.Series`` when setting a value on an empty ``Series`` whose index has a frequency. (:issue:`10193`)
 - Bug in ``DataFrame.reset_index`` when index contains `NaT`. (:issue:`10388`)
 - Bug in ``ExcelReader`` when worksheet is empty (:issue:`6403`)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -2573,13 +2573,11 @@ class Index(IndexOpsMixin, PandasObject):
 
     @Appender(_shared_docs['drop_duplicates'] % _index_doc_kwargs)
     def drop_duplicates(self, take_last=False):
-        result = super(Index, self).drop_duplicates(take_last=take_last)
-        return self._constructor(result)
+        return super(Index, self).drop_duplicates(take_last=take_last)
 
     @Appender(_shared_docs['duplicated'] % _index_doc_kwargs)
     def duplicated(self, take_last=False):
         return super(Index, self).duplicated(take_last=take_last)
-
 
     def _evaluate_with_timedelta_like(self, other, op, opstr):
         raise TypeError("can only perform ops with timedelta like values")

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -207,9 +207,18 @@ class Base(object):
 
             if not len(ind):
                 continue
+            if isinstance(ind, MultiIndex):
+                continue
             idx = self._holder([ind[0]]*5)
             self.assertFalse(idx.is_unique)
             self.assertTrue(idx.has_duplicates)
+
+            # GH 10115
+            # preserve names
+            idx.name = 'foo'
+            result = idx.drop_duplicates()
+            self.assertEqual(result.name, 'foo')
+            self.assert_index_equal(result, Index([ind[0]],name='foo'))
 
     def test_sort(self):
         for ind in self.indices.values():
@@ -1830,9 +1839,12 @@ class TestCategoricalIndex(Base, tm.TestCase):
 
     def test_duplicates(self):
 
-        idx = CategoricalIndex([0, 0, 0])
+        idx = CategoricalIndex([0, 0, 0], name='foo')
         self.assertFalse(idx.is_unique)
         self.assertTrue(idx.has_duplicates)
+
+        expected = CategoricalIndex([0], name='foo')
+        self.assert_index_equal(idx.drop_duplicates(), expected)
 
     def test_get_indexer(self):
 
@@ -4602,6 +4614,19 @@ class TestMultiIndex(Base, tm.TestCase):
                 self.assertEqual(mi.get_duplicates(), [])
                 self.assert_array_equal(mi.duplicated(),
                                         np.zeros(len(mi), dtype='bool'))
+
+    def test_duplicate_meta_data(self):
+        # GH 10115
+        index = MultiIndex(levels=[[0, 1], [0, 1, 2]],
+                           labels=[[0, 0, 0, 0, 1, 1, 1],
+                                   [0, 1, 2, 0, 0, 1, 2]])
+        for idx in [index,
+                    index.set_names([None, None]),
+                    index.set_names([None, 'Num']),
+                    index.set_names(['Upper','Num']),
+                   ]:
+            self.assertTrue(idx.has_duplicates)
+            self.assertEqual(idx.drop_duplicates().names, idx.names)
 
     def test_tolist(self):
         result = self.index.tolist()

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -330,6 +330,20 @@ Freq: H"""
             self.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
 
+    def test_drop_duplicates_metadata(self):
+        #GH 10115
+        idx = pd.date_range('2011-01-01', '2011-01-31', freq='D', name='idx')
+        result = idx.drop_duplicates()
+        self.assert_index_equal(idx, result)
+        self.assertEqual(idx.freq, result.freq)
+
+        idx_dup = idx.append(idx)
+        self.assertIsNone(idx_dup.freq)   # freq is reset
+        result = idx_dup.drop_duplicates()
+        self.assert_index_equal(idx, result)
+        self.assertIsNone(result.freq)
+
+
 class TestTimedeltaIndexOps(Ops):
 
     def setUp(self):
@@ -802,6 +816,20 @@ Freq: D"""
             self.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
 
+    def test_drop_duplicates_metadata(self):
+        #GH 10115
+        idx = pd.timedelta_range('1 day', '31 day', freq='D', name='idx')
+        result = idx.drop_duplicates()
+        self.assert_index_equal(idx, result)
+        self.assertEqual(idx.freq, result.freq)
+
+        idx_dup = idx.append(idx)
+        self.assertIsNone(idx_dup.freq)   # freq is reset
+        result = idx_dup.drop_duplicates()
+        self.assert_index_equal(idx, result)
+        self.assertIsNone(result.freq)
+
+
 class TestPeriodIndexOps(Ops):
 
     def setUp(self):
@@ -1227,6 +1255,18 @@ Freq: Q-DEC"""
         tm.assert_series_equal(idx.value_counts(dropna=False), expected)
 
         tm.assert_index_equal(idx.unique(), exp_idx)
+
+    def test_drop_duplicates_metadata(self):
+        #GH 10115
+        idx = pd.period_range('2011-01-01', '2011-01-31', freq='D', name='idx')
+        result = idx.drop_duplicates()
+        self.assert_index_equal(idx, result)
+        self.assertEqual(idx.freq, result.freq)
+
+        idx_dup = idx.append(idx) # freq will not be reset
+        result = idx_dup.drop_duplicates()
+        self.assert_index_equal(idx, result)
+        self.assertEqual(idx.freq, result.freq)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #10115. Closes #10116.

Based on @seth-p  and @jreback 's fix, added tets for datetime-likes.
