### PR TITLE
ERR: GH9513 NaT methods now raise ValueError

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -232,6 +232,16 @@ Other API Changes
 - Serialize metadata properties of subclasses of pandas objects (:issue:`10553`).
 
 
+- ``NaT``'s methods now either raise ``ValueError``, or return ``np.nan`` or ``NaT`` (:issue:`9513`)
+===========================     ==============================================================
+Behavior                        Methods  
+===========================     ==============================================================
+``return np.nan``               ``weekday``, ``isoweekday``
+``return NaT``                  ``date``, ``now``, ``replace``, ``to_datetime``, ``today``
+``return np.datetime64('NaT')`` ``to_datetime64`` (unchanged)   
+``raise ValueError``            All other public methods (names not beginning with underscores)
+===========================     ===============================================================
+
 .. _whatsnew_0170.deprecations:
 
 Deprecations

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -2879,6 +2879,9 @@ class TestDatetimeIndex(DatetimeLike, tm.TestCase):
             result = first.union(case)
             self.assertTrue(tm.equalContents(result, everything))
 
+    def test_nat(self):
+        self.assertIs(DatetimeIndex([np.nan])[0], pd.NaT)
+
 
 class TestPeriodIndex(DatetimeLike, tm.TestCase):
     _holder = PeriodIndex

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -210,7 +210,6 @@ class CheckNameIntegration(object):
 
         # GH 8689
         s = Series(date_range('20130101',periods=5,freq='D'))
-        s_orig = s.copy()
         s.iloc[2] = pd.NaT
 
         for attr in ['microsecond','nanosecond','second','minute','hour','day']:

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1392,7 +1392,8 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
         """
         # can't call self.map() which tries to treat func as ufunc
         # and causes recursion warnings on python 2.6
-        return self._maybe_mask_results(_algos.arrmap_object(self.asobject.values, lambda x: x.time()))
+        return self._maybe_mask_results(_algos.arrmap_object(self.asobject.values,
+                                                             lambda x: np.nan if x is tslib.NaT else x.time()))
 
     @property
     def date(self):

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -941,12 +941,34 @@ class TestTimeSeries(tm.TestCase):
     def test_nat_scalar_field_access(self):
         fields = ['year', 'quarter', 'month', 'day', 'hour',
                   'minute', 'second', 'microsecond', 'nanosecond',
-                  'week', 'dayofyear', 'days_in_month']
+                  'week', 'dayofyear', 'days_in_month', 'daysinmonth',
+                  'dayofweek']
         for field in fields:
             result = getattr(NaT, field)
             self.assertTrue(np.isnan(result))
 
-        self.assertTrue(np.isnan(NaT.weekday()))
+    def test_NaT_methods(self):
+        # GH 9513
+        raise_methods = ['astimezone', 'combine', 'ctime', 'dst', 'fromordinal',
+                         'fromtimestamp', 'isocalendar', 'isoformat',
+                         'strftime', 'strptime',
+                         'time', 'timestamp', 'timetuple', 'timetz',
+                         'toordinal', 'tzname', 'utcfromtimestamp',
+                         'utcnow', 'utcoffset', 'utctimetuple']
+        nat_methods = ['date', 'now', 'replace', 'to_datetime', 'today']
+        nan_methods = ['weekday', 'isoweekday']
+
+        for method in raise_methods:
+            if hasattr(NaT, method):
+                self.assertRaises(ValueError, getattr(NaT, method))
+
+        for method in nan_methods:
+            if hasattr(NaT, method):
+                self.assertTrue(np.isnan(getattr(NaT, method)()))
+
+        for method in nat_methods:
+            if hasattr(NaT, method):
+                self.assertIs(getattr(NaT, method)(), NaT)
 
     def test_to_datetime_types(self):
 
@@ -3518,6 +3540,9 @@ class TestTimestamp(tm.TestCase):
         self.assertIs(result, NaT)
 
         result = Timestamp(NaT)
+        self.assertIs(result, NaT)
+
+        result = Timestamp('NaT')
         self.assertIs(result, NaT)
 
     def test_roundtrip(self):


### PR DESCRIPTION
This is to close #9513. `NaT` methods now raise `ValueError` or return `np.nan`.
