### PR TITLE
Check for size=0 before setting item

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -59,3 +59,4 @@ Performance Improvements
 Bug Fixes
 ~~~~~~~~~
 - Bug in ``DataFrame.apply`` when function returns categorical series. (:issue:`9573`)
+- Bug in ``pd.Series`` when setting a value on an empty ``Series`` whose index has a frequency. (:issue:`10193`)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1480,6 +1480,18 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         expected = self.series.append(app)
         assert_series_equal(s, expected)
 
+        # Test for issue #10193
+        key = pd.Timestamp('2012-01-01')
+        series = pd.Series()
+        series[key] = 47
+        expected = pd.Series(47, [key])
+        assert_series_equal(series, expected)
+
+        series = pd.Series([], pd.DatetimeIndex([], freq='D'))
+        series[key] = 47
+        expected = pd.Series(47, pd.DatetimeIndex([key], freq='D'))
+        assert_series_equal(series, expected)
+
     def test_setitem_dtypes(self):
 
         # change dtypes

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1497,7 +1497,7 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
             if zone != izone:
                 raise ValueError('Passed item and index have different timezone')
             # check freq can be preserved on edge cases
-            if self.freq is not None:
+            if self.size and self.freq is not None:
                 if (loc == 0 or loc == -len(self)) and item + self.freq == self[0]:
                     freq = self.freq
                 elif (loc == len(self)) and item - self.freq == self[-1]:


### PR DESCRIPTION
This is a second try at fixing #10193; the first try is in #10194. There is some useful discussion in that PR, so I didn't want to clobber that- not sure of the etiquette of multiple PRs for the same bug??

The discussion around setting values in views on #10194 is separate from the bug itself- I find that setting an item on a newly-constructed empty series with a frequency (thus, no views are involved) raises the same error. 

I couldn't cherry pick from my old branch easily as some commits contained more code than is necessary for this set of changes, so I have done a new one.
