### PR TITLE
ENH: column label filtering via regexes to work for numeric names

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -26,7 +26,8 @@ New features
 
 Other enhancements
 ^^^^^^^^^^^^^^^^^^
-
+- `regex` argument to DataFrame.filter now handles numeric column names instead of raising an exception.
+  
 .. _whatsnew_0170.api:
 
 Backwards incompatible API changes

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -26,7 +26,7 @@ New features
 
 Other enhancements
 ^^^^^^^^^^^^^^^^^^
-- `regex` argument to DataFrame.filter now handles numeric column names instead of raising an exception.
+- ``regex`` argument to ``DataFrame.filter`` now handles numeric column names instead of raising ``ValueError`` (:issue:`10384`).
   
 .. _whatsnew_0170.api:
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1928,7 +1928,7 @@ class NDFrame(PandasObject):
             return self.select(matchf, axis=axis_name)
         elif regex:
             matcher = re.compile(regex)
-            return self.select(lambda x: matcher.search(x) is not None,
+            return self.select(lambda x: matcher.search(str(x)) is not None,
                                axis=axis_name)
         else:
             raise TypeError('Must pass either `items`, `like`, or `regex`')

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -10741,7 +10741,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         idx = self.frame.index[0:4]
         filtered = self.frame.filter(idx, axis='index')
         expected = self.frame.reindex(index=idx)
-        assert_frame_equal(filtered,expected)
+        assert_frame_equal(filtered, expected)
 
         # like
         fcopy = self.frame.copy()
@@ -10755,6 +10755,16 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df = DataFrame(0., index=[0, 1, 2], columns=[0, 1, '_A', '_B'])
         filtered = df.filter(like='_')
         self.assertEqual(len(filtered.columns), 2)
+        
+        # regex with ints in column names
+        # from PR #10384
+        df = DataFrame(0., index=[0, 1, 2], columns=[0, 1, 'A1', 'B'])
+        filtered = df.filter(regex='^[0-9]+$')
+        self.assertEqual(len(filtered.columns), 2)
+        
+        expected = DataFrame(0., index=[0, 1, 2], columns=[0, 1, '0', '1'])
+        filtered = expected.filter(regex='^[0-9]+$') # shouldn't remove anything
+        self.assert_frame_equal(filtered, expected)
 
         # pass in None
         with assertRaisesRegexp(TypeError, 'Must pass'):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -10382,6 +10382,13 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             [[1, 2, 3], [4, 5, 6], [7, 8, 9]], index=['a', 'a', 'c'])
         self.assertRaises(ValueError, df.apply, lambda x: x, 2)
 
+        # GH9573
+        df = DataFrame({'c0':['A','A','B','B'], 'c1':['C','C','D','D']})
+        df = df.apply(lambda ts: ts.astype('category'))
+        self.assertEqual(df.shape, (4, 2))
+        self.assertTrue(isinstance(df['c0'].dtype, com.CategoricalDtype))
+        self.assertTrue(isinstance(df['c1'].dtype, com.CategoricalDtype))
+
     def test_apply_mixed_datetimelike(self):
         # mixed datetimelike
         # GH 7778

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -10741,7 +10741,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         idx = self.frame.index[0:4]
         filtered = self.frame.filter(idx, axis='index')
         expected = self.frame.reindex(index=idx)
-        assert_frame_equal(filtered,expected)
+        assert_frame_equal(filtered, expected)
 
         # like
         fcopy = self.frame.copy()
@@ -10757,9 +10757,15 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.assertEqual(len(filtered.columns), 2)
         
         # regex with ints in column names
+        # from PR #10384
         df = DataFrame(0., index=[0, 1, 2], columns=[0, 1, 'A1', 'B'])
         filtered = df.filter(regex='^[0-9]+$')
         self.assertEqual(len(filtered.columns), 2)
+        
+        expected = DataFrame(0., index=[0, 1, 2], columns=[0, 1, '0', '1'])
+        filtered = expected.filter(regex='^[0-9]+$') # shouldn't remove anything
+        self.assert_frame_equal(filtered, expected)
+
         # pass in None
         with assertRaisesRegexp(TypeError, 'Must pass'):
             self.frame.filter(items=None)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -10758,12 +10758,13 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         
         # regex with ints in column names
         # from PR #10384
-        df = DataFrame(0., index=[0, 1, 2], columns=[0, 1, 'A1', 'B'])
+        df = DataFrame(0., index=[0, 1, 2], columns=['A1', 1, 'B', 2, 'C'])
+        expected = DataFrame(0., index=[0, 1, 2], columns=[1, 2])
         filtered = df.filter(regex='^[0-9]+$')
-        self.assertEqual(len(filtered.columns), 2)
+        self.assert_frame_equal(filtered, expected)
         
-        expected = DataFrame(0., index=[0, 1, 2], columns=[0, 1, '0', '1'])
-        filtered = expected.filter(regex='^[0-9]+$') # shouldn't remove anything
+        expected = DataFrame(0., index=[0, 1, 2], columns=[0, '0', 1, '1'])
+        filtered = expected.filter(regex='^[0-9]+$')  # shouldn't remove anything
         self.assert_frame_equal(filtered, expected)
 
         # pass in None

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -10734,7 +10734,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         idx = self.frame.index[0:4]
         filtered = self.frame.filter(idx, axis='index')
         expected = self.frame.reindex(index=idx)
-        assert_frame_equal(filtered,expected)
+        assert_frame_equal(filtered, expected)
 
         # like
         fcopy = self.frame.copy()
@@ -10748,6 +10748,16 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df = DataFrame(0., index=[0, 1, 2], columns=[0, 1, '_A', '_B'])
         filtered = df.filter(like='_')
         self.assertEqual(len(filtered.columns), 2)
+        
+        # regex with ints in column names
+        # from PR #10384
+        df = DataFrame(0., index=[0, 1, 2], columns=[0, 1, 'A1', 'B'])
+        filtered = df.filter(regex='^[0-9]+$')
+        self.assertEqual(len(filtered.columns), 2)
+        
+        expected = DataFrame(0., index=[0, 1, 2], columns=[0, 1, '0', '1'])
+        filtered = expected.filter(regex='^[0-9]+$') # shouldn't remove anything
+        self.assert_frame_equal(filtered, expected)
 
         # pass in None
         with assertRaisesRegexp(TypeError, 'Must pass'):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -10765,6 +10765,9 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         
         expected = DataFrame(0., index=[0, 1, 2], columns=[0, '0', 1, '1'])
         filtered = expected.filter(regex='^[0-9]+$')  # shouldn't remove anything
+        
+        expected = DataFrame(0., index=[0, 1, 2], columns=[0, 1, '0', '1'])
+        filtered = expected.filter(regex='^[0-9]+$')  # shouldn't remove anything
         self.assert_frame_equal(filtered, expected)
 
         # pass in None

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -10755,7 +10755,11 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df = DataFrame(0., index=[0, 1, 2], columns=[0, 1, '_A', '_B'])
         filtered = df.filter(like='_')
         self.assertEqual(len(filtered.columns), 2)
-
+        
+        # regex with ints in column names
+        df = DataFrame(0., index=[0, 1, 2], columns=[0, 1, 'A1', 'B'])
+        filtered = df.filter(regex='^[0-9]+$')
+        self.assertEqual(len(filtered.columns), 2)
         # pass in None
         with assertRaisesRegexp(TypeError, 'Must pass'):
             self.frame.filter(items=None)


### PR DESCRIPTION
Simple fix to allow regex filtering to work for numeric column labels, e.g. df.filter(regex="[12][34]")

closes #10506 
