### PR TITLE
BUG: DataFrame.plot raises ValueError when color name is specified by multiple characters 

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -81,7 +81,7 @@ Bug Fixes
 
 - Bug in ``pd.Series`` when setting a value on an empty ``Series`` whose index has a frequency. (:issue:`10193`)
 
-
+- Bug in ``DataFrame.plot`` raises ``ValueError`` when color name is specified by multiple characters (:issue:`10387`)
 - Bug in ``DataFrame.reset_index`` when index contains `NaT`. (:issue:`10388`)
 
 

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1146,6 +1146,53 @@ class TestSeriesPlots(TestPlotBase):
         self._check_grid_settings(Series([1,2,3]),
             plotting._series_kinds + plotting._common_kinds)
 
+    @slow
+    def test_standard_colors(self):
+        for c in ['r', 'red', 'green', '#FF0000']:
+            result = plotting._get_standard_colors(1, color=c)
+            self.assertEqual(result, [c])
+
+            result = plotting._get_standard_colors(1, color=[c])
+            self.assertEqual(result, [c])
+
+            result = plotting._get_standard_colors(3, color=c)
+            self.assertEqual(result, [c] * 3)
+
+            result = plotting._get_standard_colors(3, color=[c])
+            self.assertEqual(result, [c] * 3)
+
+    @slow
+    def test_standard_colors_all(self):
+        import matplotlib.colors as colors
+
+        # multiple colors like mediumaquamarine
+        for c in colors.cnames:
+            result = plotting._get_standard_colors(num_colors=1, color=c)
+            self.assertEqual(result, [c])
+
+            result = plotting._get_standard_colors(num_colors=1, color=[c])
+            self.assertEqual(result, [c])
+
+            result = plotting._get_standard_colors(num_colors=3, color=c)
+            self.assertEqual(result, [c] * 3)
+
+            result = plotting._get_standard_colors(num_colors=3, color=[c])
+            self.assertEqual(result, [c] * 3)
+
+        # single letter colors like k
+        for c in colors.ColorConverter.colors:
+            result = plotting._get_standard_colors(num_colors=1, color=c)
+            self.assertEqual(result, [c])
+
+            result = plotting._get_standard_colors(num_colors=1, color=[c])
+            self.assertEqual(result, [c])
+
+            result = plotting._get_standard_colors(num_colors=3, color=c)
+            self.assertEqual(result, [c] * 3)
+
+            result = plotting._get_standard_colors(num_colors=3, color=[c])
+            self.assertEqual(result, [c] * 3)
+
 
 @tm.mplskip
 class TestDataFramePlots(TestPlotBase):
@@ -1736,7 +1783,6 @@ class TestDataFramePlots(TestPlotBase):
 
         default_colors = plt.rcParams.get('axes.color_cycle')
 
-
         df = DataFrame(randn(5, 5))
         ax = df.plot(kind='bar')
         self._check_colors(ax.patches[::5], facecolors=default_colors[:5])
@@ -1762,6 +1808,11 @@ class TestDataFramePlots(TestPlotBase):
 
         ax = df.ix[:, [0]].plot(kind='bar', color='DodgerBlue')
         self._check_colors([ax.patches[0]], facecolors=['DodgerBlue'])
+        tm.close()
+
+        ax = df.plot(kind='bar', color='green')
+        self._check_colors(ax.patches[::5], facecolors=['green'] * 5)
+        tm.close()
 
     @slow
     def test_bar_linewidth(self):
@@ -2897,6 +2948,10 @@ class TestDataFramePlots(TestPlotBase):
         ax = df.ix[:, [0]].plot(color='DodgerBlue')
         self._check_colors(ax.lines, linecolors=['DodgerBlue'])
 
+        ax = df.plot(color='red')
+        self._check_colors(ax.get_lines(), linecolors=['red'] * 5)
+        tm.close()
+
     @slow
     def test_area_colors(self):
         from matplotlib import cm
@@ -2971,6 +3026,10 @@ class TestDataFramePlots(TestPlotBase):
 
         ax = df.ix[:, [0]].plot(kind='hist', color='DodgerBlue')
         self._check_colors([ax.patches[0]], facecolors=['DodgerBlue'])
+
+        ax = df.plot(kind='hist', color='green')
+        self._check_colors(ax.patches[::10], facecolors=['green'] * 5)
+        tm.close()
 
     @slow
     def test_kde_colors(self):

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -134,6 +134,32 @@ def _get_standard_colors(num_colors=None, colormap=None, color_type='default',
         else:
             raise ValueError("color_type must be either 'default' or 'random'")
 
+    if isinstance(colors, compat.string_types):
+        import matplotlib.colors
+        conv = matplotlib.colors.ColorConverter()
+        def _maybe_valid_colors(colors):
+            try:
+                [conv.to_rgba(c) for c in colors]
+                return True
+            except ValueError:
+                return False
+
+        # check whether the string can be convertable to single color
+        maybe_single_color = _maybe_valid_colors([colors])
+        # check whether each character can be convertable to colors
+        maybe_color_cycle = _maybe_valid_colors(list(colors))
+        if maybe_single_color and maybe_color_cycle and len(colors) > 1:
+            msg = ("'{0}' can be parsed as both single color and "
+                   "color cycle. Specify each color using a list "
+                   "like ['{0}'] or {1}")
+            raise ValueError(msg.format(colors, list(colors)))
+        elif maybe_single_color:
+            colors = [colors]
+        else:
+            # ``colors`` is regarded as color cycle.
+            # mpl will raise error any of them is invalid
+            pass
+
     if len(colors) != num_colors:
         multiple = num_colors//len(colors) - 1
         mod = num_colors % len(colors)


### PR DESCRIPTION
Derived from #9894. Passing color name with multiple characters results in `ValueError`. Below is the bahavior of current master.

```
# OK
df = pd.DataFrame(np.random.randn(3, 3))
df[0].plot(color='green')
# single green line

# OK
df.plot(color=['green'])
# triple green lines

# NG
df.plot(color='green')
# ValueError: to_rgba: Invalid rgba arg "e"
# -> This should be triple green lines
```

If passed str can be parsed as both single color and color cycle, following error will be raised.
- _"'green' can be parsed as both single color and color cycle. Specify each color using a list like ['green'] or ['g', 'r', 'e', 'e', 'n']"_

Currently, there is no color name which can meet above condition (thus cannot tested).
- http://matplotlib.org/examples/color/named_colors.html
