### PR TITLE
BUG: closes bug in reset_index when index contains NaT

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -60,3 +60,4 @@ Bug Fixes
 ~~~~~~~~~
 - Bug in ``DataFrame.apply`` when function returns categorical series. (:issue:`9573`)
 - Bug in ``pd.Series`` when setting a value on an empty ``Series`` whose index has a frequency. (:issue:`10193`)
+- Bug in ``DataFrame.reset_index`` when index contains `NaT`. (:issue:`10388`)

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1194,7 +1194,7 @@ def _maybe_upcast_putmask(result, mask, other):
         if result.dtype in _DATELIKE_DTYPES:
             if lib.isscalar(other):
                 if isnull(other):
-                    other = tslib.iNaT
+                    other = result.dtype.type('nat')
                 elif is_integer(other):
                     other = np.array(other, dtype=result.dtype)
             elif is_integer_dtype(other):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -9494,6 +9494,18 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df.index = df.index.astype('object')
         tm.assert_frame_equal(df.reindex(i), df.iloc[j])
 
+        # GH10388
+        df = pd.DataFrame({'other':['a', 'b', np.nan, 'c'],
+                           'date':['2015-03-22', np.nan, '2012-01-08', np.nan],
+                           'amount':[2, 3, 4, 5]})
+
+        df['date'] = pd.to_datetime(df.date)
+        df['delta'] = (pd.to_datetime('2015-06-18') - df['date']).shift(1)
+
+        left = df.set_index(['delta', 'other', 'date']).reset_index()
+        right = df.reindex(columns=['delta', 'other', 'date', 'amount'])
+        assert_frame_equal(left, right)
+
     def test_reindex_name_remains(self):
         s = Series(random.rand(10))
         df = DataFrame(s, index=np.arange(len(s)))


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/10388
