### PR TITLE
TST: Use unicode literals in string test

### DIFF
--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -747,20 +747,18 @@ class TestStringMethods(tm.TestCase):
         # 0x2605: ★ not number
         # 0x1378: ፸ ETHIOPIC NUMBER SEVENTY
         # 0xFF13: ３ Em 3
-        values = ['A', '3', unichr(0x00bc), unichr(0x2605),
-                  unichr(0x1378), unichr(0xFF13), 'four']
+        values = ['A', '3', u'¼', u'★', u'፸', u'３', 'four']
         s = Series(values)
         numeric_e = [False, True, True, False, True, True, False]
         decimal_e = [False, True, False, False, False, True, False]
         tm.assert_series_equal(s.str.isnumeric(), Series(numeric_e))
         tm.assert_series_equal(s.str.isdecimal(), Series(decimal_e))
-        unicodes = [u('A'), u('3'), unichr(0x00bc), unichr(0x2605),
-                  unichr(0x1378), unichr(0xFF13), u('four')]
+
+        unicodes = [u'A', u'3', u'¼', u'★', u'፸', u'３', u'four']
         self.assertEqual(s.str.isnumeric().tolist(), [v.isnumeric() for v in unicodes])
         self.assertEqual(s.str.isdecimal().tolist(), [v.isdecimal() for v in unicodes])
 
-        values = ['A', np.nan, unichr(0x00bc), unichr(0x2605),
-                  np.nan, unichr(0xFF13), 'four']
+        values = ['A', np.nan, u'¼', u'★', np.nan, u'３', 'four']
         s = Series(values)
         numeric_e = [False, np.nan, True, False, np.nan, True, False]
         decimal_e = [False, np.nan, False, False, np.nan, True, False]
@@ -1950,33 +1948,16 @@ class TestStringMethods(tm.TestCase):
         tm.assert_series_equal(result, exp)
 
     def test_normalize(self):
-        def unistr(codes):
-            # build unicode string from unichr
-            # we cannot use six.u() here because it escapes unicode
-            return ''.join([unichr(c) for c in codes])
-
-        values = ['ABC', # ASCII
-                  unistr([0xFF21, 0xFF22, 0xFF23]), # ＡＢＣ
-                  unistr([0xFF11, 0xFF12, 0xFF13]), # １２３
-                  np.nan,
-                  unistr([0xFF71, 0xFF72, 0xFF74])] # ｱｲｴ
+        values = ['ABC', u'ＡＢＣ', u'１２３', np.nan, u'ｱｲｴ']
         s = Series(values, index=['a', 'b', 'c', 'd', 'e'])
 
-        normed = [compat.u_safe('ABC'),
-                  compat.u_safe('ABC'),
-                  compat.u_safe('123'),
-                  np.nan,
-                  unistr([0x30A2, 0x30A4, 0x30A8])] # アイエ
+        normed = [u'ABC', u'ABC', u'123', np.nan, u'アイエ']
         expected = Series(normed, index=['a', 'b', 'c', 'd', 'e'])
 
         result = s.str.normalize('NFKC')
         tm.assert_series_equal(result, expected)
 
-        expected = Series([compat.u_safe('ABC'),
-                           unistr([0xFF21, 0xFF22, 0xFF23]), # ＡＢＣ
-                           unistr([0xFF11, 0xFF12, 0xFF13]), # １２３
-                           np.nan,
-                           unistr([0xFF71, 0xFF72, 0xFF74])], # ｱｲｴ
+        expected = Series([u'ABC', u'ＡＢＣ', u'１２３', np.nan, u'ｱｲｴ'],
                           index=['a', 'b', 'c', 'd', 'e'])
 
         result = s.str.normalize('NFC')
@@ -1985,12 +1966,8 @@ class TestStringMethods(tm.TestCase):
         with tm.assertRaisesRegexp(ValueError, "invalid normalization form"):
             s.str.normalize('xxx')
 
-        s = Index([unistr([0xFF21, 0xFF22, 0xFF23]),  # ＡＢＣ
-                   unistr([0xFF11, 0xFF12, 0xFF13]),  # １２３
-                   unistr([0xFF71, 0xFF72, 0xFF74])]) # ｱｲｴ
-        expected = Index([compat.u_safe('ABC'),
-                          compat.u_safe('123'),
-                          unistr([0x30A2, 0x30A4, 0x30A8])])
+        s = Index([u'ＡＢＣ', u'１２３', u'ｱｲｴ'])
+        expected = Index([u'ABC', u'123', u'アイエ'])
         result = s.str.normalize('NFKC')
         tm.assert_index_equal(result, expected)
 


### PR DESCRIPTION
Follow-up of #10397. Fix some ugly unicode tests. Shall I fix followings also?
- Remove `compat.u()` completely, because the escaped literal is different from normal unicode literals internally.
- Remove `compat.callable` brought back in v3.2 ([some code](https://github.com/pydata/pandas/blob/master/pandas/core/frame.py#L2307) doesn't use `compat.callable` already)
