### PR TITLE
ENH: tolerance argument for limiting pad, backfill and nearest neighbor reindexing

### DIFF
--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -1100,6 +1100,30 @@ Note that the same result could have been achieved using
 increasing or descreasing. :meth:`~Series.fillna` and :meth:`~Series.interpolate`
 will not make any checks on the order of the index.
 
+.. _basics.limits_on_reindex_fill:
+
+Limits on filling while reindexing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``limit`` and ``tolerance`` arguments provide additional control over
+filling while reindexing. Limit specifies the maximum count of consecutive
+matches:
+
+.. ipython:: python
+
+   ts2.reindex(ts.index, method='ffill', limit=1)
+
+In contrast, tolerance specifies the maximum distance between the index and
+indexer values:
+
+.. ipython:: python
+
+   ts2.reindex(ts.index, method='ffill', tolerance='1 day')
+
+Notice that when used on a ``DatetimeIndex``, ``TimedeltaIndex`` or
+``PeriodIndex``, ``tolerance`` will coerced into a ``Timedelta`` if possible.
+This allows you to specify tolerance with appropriate strings.
+
 .. _basics.drop:
 
 Dropping labels from an axis

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -180,6 +180,22 @@ Other enhancements
    s.drop_duplicates(keep=False)
 
 
+- Reindex now has a ``tolerance`` argument that allows for finer control of :ref:`basics.limits_on_reindex_fill`:
+
+  .. ipython:: python
+
+     df = pd.DataFrame({'x': range(5), 't': pd.date_range('2000-01-01', periods=5)})
+     df.reindex([0.1, 1.9, 3.5], method='nearest', tolerance=0.2)
+
+  When used on a ``DatetimeIndex``, ``TimedeltaIndex`` or ``PeriodIndex``, ``tolerance`` will coerced into a ``Timedelta`` if possible. This allows you to specify tolerance with a string:
+
+  .. ipython:: python
+
+     df = df.set_index('t')
+     df.reindex(pd.to_datetime(['1999-12-31']), method='nearest', tolerance='1 day')
+
+  ``tolerance`` is also exposed by the lower level ``Index.get_indexer`` and ``Index.get_loc`` methods.
+
 .. _whatsnew_0170.api:
 
 .. _whatsnew_0170.api_breaking:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2518,33 +2518,36 @@ class DataFrame(NDFrame):
     #----------------------------------------------------------------------
     # Reindexing and alignment
 
-    def _reindex_axes(self, axes, level, limit, method, fill_value, copy):
+    def _reindex_axes(self, axes, level, limit, tolerance, method,
+                      fill_value, copy):
         frame = self
 
         columns = axes['columns']
         if columns is not None:
             frame = frame._reindex_columns(columns, copy, level, fill_value,
-                                           limit)
+                                           limit, tolerance)
 
         index = axes['index']
         if index is not None:
             frame = frame._reindex_index(index, method, copy, level,
-                                         fill_value, limit)
+                                         fill_value, limit, tolerance)
 
         return frame
 
     def _reindex_index(self, new_index, method, copy, level, fill_value=NA,
-                       limit=None):
+                       limit=None, tolerance=None):
         new_index, indexer = self.index.reindex(new_index, method, level,
-                                                limit=limit)
+                                                limit=limit,
+                                                tolerance=tolerance)
         return self._reindex_with_indexers({0: [new_index, indexer]},
                                            copy=copy, fill_value=fill_value,
                                            allow_dups=False)
 
     def _reindex_columns(self, new_columns, copy, level, fill_value=NA,
-                         limit=None):
+                         limit=None, tolerance=None):
         new_columns, indexer = self.columns.reindex(new_columns, level=level,
-                                                    limit=limit)
+                                                    limit=limit,
+                                                    tolerance=tolerance)
         return self._reindex_with_indexers({1: [new_columns, indexer]},
                                            copy=copy, fill_value=fill_value,
                                            allow_dups=False)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1602,28 +1602,38 @@ class Index(IndexOpsMixin, PandasObject):
             attribs['freq'] = None
         return self._shallow_copy(the_diff, infer=True, **attribs)
 
-    def get_loc(self, key, method=None):
+    def get_loc(self, key, method=None, tolerance=None):
         """
         Get integer location for requested label
 
         Parameters
         ----------
         key : label
-        method : {None, 'pad'/'ffill', 'backfill'/'bfill', 'nearest'}
+        method : {None, 'pad'/'ffill', 'backfill'/'bfill', 'nearest'}, optional
             * default: exact matches only.
             * pad / ffill: find the PREVIOUS index value if no exact match.
             * backfill / bfill: use NEXT index value if no exact match
             * nearest: use the NEAREST index value if no exact match. Tied
               distances are broken by preferring the larger index value.
+        tolerance : optional
+            Maximum distance from index value for inexact matches. The value of
+            the index at the matching location most satisfy the equation
+            ``abs(index[loc] - key) <= tolerance``.
+
+            .. versionadded:: 0.17.0
 
         Returns
         -------
         loc : int if unique index, possibly slice or mask if not
         """
         if method is None:
+            if tolerance is not None:
+                raise ValueError('tolerance argument only valid if using pad, '
+                                 'backfill or nearest lookups')
             return self._engine.get_loc(_values_from_object(key))
 
-        indexer = self.get_indexer([key], method=method)
+        indexer = self.get_indexer([key], method=method,
+                                   tolerance=tolerance)
         if indexer.ndim > 1 or indexer.size > 1:
             raise TypeError('get_loc requires scalar valued input')
         loc = indexer.item()
@@ -1692,7 +1702,7 @@ class Index(IndexOpsMixin, PandasObject):
         self._validate_index_level(level)
         return self
 
-    def get_indexer(self, target, method=None, limit=None):
+    def get_indexer(self, target, method=None, limit=None, tolerance=None):
         """
         Compute indexer and mask for new index given the current index. The
         indexer should be then used as an input to ndarray.take to align the
@@ -1701,15 +1711,21 @@ class Index(IndexOpsMixin, PandasObject):
         Parameters
         ----------
         target : Index
-        method : {None, 'pad'/'ffill', 'backfill'/'bfill', 'nearest'}
+        method : {None, 'pad'/'ffill', 'backfill'/'bfill', 'nearest'}, optional
             * default: exact matches only.
             * pad / ffill: find the PREVIOUS index value if no exact match.
             * backfill / bfill: use NEXT index value if no exact match
             * nearest: use the NEAREST index value if no exact match. Tied
               distances are broken by preferring the larger index value.
-        limit : int
-            Maximum number of consecuctive labels in ``target`` to match for
+        limit : int, optional
+            Maximum number of consecutive labels in ``target`` to match for
             inexact matches.
+        tolerance : optional
+            Maximum distance between original and new labels for inexact
+            matches. The values of the index at the matching locations most
+            satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
+
+            .. versionadded:: 0.17.0
 
         Examples
         --------
@@ -1725,36 +1741,54 @@ class Index(IndexOpsMixin, PandasObject):
         """
         method = com._clean_reindex_fill_method(method)
         target = _ensure_index(target)
+        if tolerance is not None:
+            tolerance = self._convert_tolerance(tolerance)
 
         pself, ptarget = self._possibly_promote(target)
         if pself is not self or ptarget is not target:
-            return pself.get_indexer(ptarget, method=method, limit=limit)
+            return pself.get_indexer(ptarget, method=method, limit=limit,
+                                     tolerance=tolerance)
 
-        if not is_dtype_equal(self.dtype,target.dtype):
+        if not is_dtype_equal(self.dtype, target.dtype):
             this = self.astype(object)
             target = target.astype(object)
-            return this.get_indexer(target, method=method, limit=limit)
+            return this.get_indexer(target, method=method, limit=limit,
+                                    tolerance=tolerance)
 
         if not self.is_unique:
             raise InvalidIndexError('Reindexing only valid with uniquely'
                                     ' valued Index objects')
 
         if method == 'pad' or method == 'backfill':
-            indexer = self._get_fill_indexer(target, method, limit)
+            indexer = self._get_fill_indexer(target, method, limit, tolerance)
         elif method == 'nearest':
-            indexer = self._get_nearest_indexer(target, limit)
+            indexer = self._get_nearest_indexer(target, limit, tolerance)
         else:
+            if tolerance is not None:
+                raise ValueError('tolerance argument only valid if doing pad, '
+                                 'backfill or nearest reindexing')
+            if limit is not None:
+                raise ValueError('limit argument only valid if doing pad, '
+                                 'backfill or nearest reindexing')
+
             indexer = self._engine.get_indexer(target.values)
 
         return com._ensure_platform_int(indexer)
 
-    def _get_fill_indexer(self, target, method, limit=None):
+    def _convert_tolerance(self, tolerance):
+        # override this method on subclasses
+        return tolerance
+
+    def _get_fill_indexer(self, target, method, limit=None, tolerance=None):
         if self.is_monotonic_increasing and target.is_monotonic_increasing:
             method = (self._engine.get_pad_indexer if method == 'pad'
                       else self._engine.get_backfill_indexer)
             indexer = method(target.values, limit)
         else:
             indexer = self._get_fill_indexer_searchsorted(target, method, limit)
+        if tolerance is not None:
+            indexer = self._filter_indexer_tolerance(
+                target.values, indexer, tolerance)
         return indexer
 
     def _get_fill_indexer_searchsorted(self, target, method, limit=None):
@@ -1787,7 +1821,7 @@ class Index(IndexOpsMixin, PandasObject):
             indexer[indexer == len(self)] = -1
         return indexer
 
-    def _get_nearest_indexer(self, target, limit):
+    def _get_nearest_indexer(self, target, limit, tolerance):
         """
         Get the indexer for the nearest index labels; requires an index with
         values that can be subtracted from each other (e.g., not strings or
@@ -1804,6 +1838,14 @@ class Index(IndexOpsMixin, PandasObject):
         indexer = np.where(op(left_distances, right_distances)
                            | (right_indexer == -1),
                            left_indexer, right_indexer)
+        if tolerance is not None:
+            indexer = self._filter_indexer_tolerance(
+                target, indexer, tolerance)
+        return indexer
+
+    def _filter_indexer_tolerance(self, target, indexer, tolerance):
+        distance = abs(self.values[indexer] - target)
+        indexer = np.where(distance <= tolerance, indexer, -1)
         return indexer
 
     def get_indexer_non_unique(self, target):
@@ -1911,7 +1953,8 @@ class Index(IndexOpsMixin, PandasObject):
         if not self.is_unique and len(indexer):
             raise ValueError("cannot reindex from a duplicate axis")
 
-    def reindex(self, target, method=None, level=None, limit=None):
+    def reindex(self, target, method=None, level=None, limit=None,
+                tolerance=None):
         """
         Create index with target's values (move/add/delete values as necessary)
 
@@ -1951,7 +1994,8 @@ class Index(IndexOpsMixin, PandasObject):
             else:
                 if self.is_unique:
                     indexer = self.get_indexer(target, method=method,
-                                               limit=limit)
+                                               limit=limit,
+                                               tolerance=tolerance)
                 else:
                     if method is not None or limit is not None:
                         raise ValueError("cannot reindex a non-unique index "
@@ -3098,7 +3142,8 @@ class CategoricalIndex(Index, PandasDelegate):
         """ always allow reindexing """
         pass
 
-    def reindex(self, target, method=None, level=None, limit=None):
+    def reindex(self, target, method=None, level=None, limit=None,
+                tolerance=None):
         """
         Create index with target's values (move/add/delete values as necessary)
 
@@ -3167,7 +3212,7 @@ class CategoricalIndex(Index, PandasDelegate):
 
         return new_target, indexer, new_indexer
 
-    def get_indexer(self, target, method=None, limit=None):
+    def get_indexer(self, target, method=None, limit=None, tolerance=None):
         """
         Compute indexer and mask for new index given the current index. The
         indexer should be then used as an input to ndarray.take to align the
@@ -3415,6 +3460,14 @@ class NumericIndex(Index):
             self._invalid_indexer('slice',label)
 
         return label
+
+    def _convert_tolerance(self, tolerance):
+        try:
+            return float(tolerance)
+        except ValueError:
+            raise ValueError('tolerance argument for %s must be numeric: %r'
+                             % (type(self).__name__, tolerance))
+
 
 class Int64Index(NumericIndex):
 
@@ -3672,7 +3725,7 @@ class Float64Index(NumericIndex):
         except:
             return False
 
-    def get_loc(self, key, method=None):
+    def get_loc(self, key, method=None, tolerance=None):
         try:
             if np.all(np.isnan(key)):
                 nan_idxs = self._nan_idxs
@@ -3684,7 +3737,8 @@ class Float64Index(NumericIndex):
                     return nan_idxs
         except (TypeError, NotImplementedError):
             pass
-        return super(Float64Index, self).get_loc(key, method=method)
+        return super(Float64Index, self).get_loc(key, method=method,
+                                                 tolerance=tolerance)
 
     @property
     def is_all_dates(self):
@@ -4906,7 +4960,7 @@ class MultiIndex(Index):
 
         return new_index, indexer
 
-    def get_indexer(self, target, method=None, limit=None):
+    def get_indexer(self, target, method=None, limit=None, tolerance=None):
         """
         Compute indexer and mask for new index given the current index. The
         indexer should be then used as an input to ndarray.take to align the
@@ -4952,6 +5006,9 @@ class MultiIndex(Index):
         self_index = self._tuple_index
 
         if method == 'pad' or method == 'backfill':
+            if tolerance is not None:
+                raise NotImplementedError("tolerance not implemented yet "
+                                          'for MultiIndex')
             indexer = self_index._get_fill_indexer(target, method, limit)
         elif method == 'nearest':
             raise NotImplementedError("method='nearest' not implemented yet "
@@ -4961,7 +5018,8 @@ class MultiIndex(Index):
 
         return com._ensure_platform_int(indexer)
 
-    def reindex(self, target, method=None, level=None, limit=None):
+    def reindex(self, target, method=None, level=None, limit=None,
+                tolerance=None):
         """
         Create index with target's values (move/add/delete values as necessary)
 
@@ -5000,7 +5058,8 @@ class MultiIndex(Index):
             else:
                 if self.is_unique:
                     indexer = self.get_indexer(target, method=method,
-                                               limit=limit)
+                                               limit=limit,
+                                               tolerance=tolerance)
                 else:
                     raise Exception(
                         "cannot handle a non-unique multi-index!")

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1929,6 +1929,12 @@ class CheckIndexing(object):
             actual = df.reindex(target, method=method)
             assert_frame_equal(expected, actual)
 
+            actual = df.reindex_like(df, method=method, tolerance=0)
+            assert_frame_equal(df, actual)
+
+            actual = df.reindex(target, method=method, tolerance=1)
+            assert_frame_equal(expected, actual)
+
             e2 = expected[::-1]
             actual = df.reindex(target[::-1], method=method)
             assert_frame_equal(e2, actual)
@@ -1943,6 +1949,10 @@ class CheckIndexing(object):
                                else method)
             actual = df[::-1].reindex(target, method=switched_method)
             assert_frame_equal(expected, actual)
+
+        expected = pd.DataFrame({'x': [0, 1, 1, np.nan]}, index=target)
+        actual = df.reindex(target, method='nearest', tolerance=0.2)
+        assert_frame_equal(expected, actual)
 
     def test_non_monotonic_reindex_methods(self):
         dr = pd.date_range('2013-08-01', periods=6, freq='B')

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -6465,6 +6465,13 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         actual = s.reindex_like(actual, method='nearest')
         assert_series_equal(expected, actual)
 
+        actual = s.reindex_like(actual, method='nearest', tolerance=1)
+        assert_series_equal(expected, actual)
+
+        actual = s.reindex(target, method='nearest', tolerance=0.2)
+        expected = Series([0, 1, np.nan, 2], target)
+        assert_series_equal(expected, actual)
+
     def test_reindex_backfill(self):
         pass
 

--- a/pandas/tseries/base.py
+++ b/pandas/tseries/base.py
@@ -203,6 +203,14 @@ class DatetimeIndexOpsMixin(object):
         from pandas.core.index import Index
         return Index(self._box_values(self.asi8), name=self.name, dtype=object)
 
+    def _convert_tolerance(self, tolerance):
+        try:
+            return tslib.Timedelta(tolerance).to_timedelta64()
+        except ValueError:
+            raise ValueError('tolerance argument for %s must be convertible '
+                             'to Timedelta: %r'
+                             % (type(self).__name__, tolerance))
+
     def _maybe_mask_results(self, result, fill_value=None, convert=None):
         """
         Parameters

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -645,7 +645,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, Int64Index):
         values = self._engine.get_value(_values_from_object(series), key)
         return _maybe_box(self, values, series, key)
 
-    def get_loc(self, key, method=None):
+    def get_loc(self, key, method=None, tolerance=None):
         """
         Get integer location for requested label
 
@@ -653,12 +653,17 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, Int64Index):
         -------
         loc : int
         """
+        if tolerance is not None:
+            # try converting tolerance now, so errors don't get swallowed by
+            # the try/except clauses below
+            tolerance = self._convert_tolerance(tolerance)
+
         if _is_convertible_to_td(key):
             key = Timedelta(key)
-            return Index.get_loc(self, key, method=method)
+            return Index.get_loc(self, key, method, tolerance)
 
         try:
-            return Index.get_loc(self, key, method=method)
+            return Index.get_loc(self, key, method, tolerance)
         except (KeyError, ValueError, TypeError):
             try:
                 return self._get_string_slice(key)
@@ -667,7 +672,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, Int64Index):
 
             try:
                 stamp = Timedelta(key)
-                return Index.get_loc(self, stamp, method=method)
+                return Index.get_loc(self, stamp, method, tolerance)
             except (KeyError, ValueError):
                 raise KeyError(key)
 


### PR DESCRIPTION
xref #9817

This does not entirely solve the floating point precision issues, but gets us part of the way there -- we can explicitly lookup data with a fixed tolerance for nearest neighbor matches.

It is also is useful in its own right, mostly as a simple sanity check to verify that labels are not entirely misaligned.

Example usage:

```
In [2]: df = pd.DataFrame({'x': range(5)})

In [3]: df.reindex([0.1, 1.9, 3.5], method='nearest', max_distance=0.2)
Out[3]:
      x
0.1   0
1.9   2
3.5 NaN
```
