### PR TITLE
BUG: Timedeltas with no specified units (and frac) should raise, #10426

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -61,7 +61,7 @@ Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 - Added vbench benchmarks for alternative ExcelWriter engines and reading Excel files (:issue:`7171`)
 
-- 4x improvement in ``timedelta`` string parsing (:issue:`6755`)
+- 4x improvement in ``timedelta`` string parsing (:issue:`6755`, :issue:`10426`)
 - 8x improvement in ``timedelta64`` and ``datetime64`` ops (:issue:`6755`)
 
 .. _whatsnew_0170.bug_fixes:

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -112,6 +112,20 @@ class TestTimedeltas(tm.TestCase):
         # only leading neg signs are allowed
         self.assertRaises(ValueError, lambda : Timedelta('10 days -1 h 1.5m 1s 3us'))
 
+        # no units specified
+        self.assertRaises(ValueError, lambda : Timedelta('3.1415'))
+
+        # invalid construction
+        tm.assertRaisesRegexp(ValueError,
+                              "cannot construct a TimeDelta",
+                              lambda : Timedelta())
+        tm.assertRaisesRegexp(ValueError,
+                              "unit abbreviation w/o a number",
+                              lambda : Timedelta('foo'))
+        tm.assertRaisesRegexp(ValueError,
+                              "cannot construct a TimeDelta from the passed arguments, allowed keywords are ",
+                              lambda : Timedelta(day=10))
+
         # roundtripping both for string and value
         for v in ['1s',
                   '-1s',
@@ -148,17 +162,6 @@ class TestTimedeltas(tm.TestCase):
         self.assertEqual(to_timedelta(pd.offsets.Hour(2)),Timedelta('0 days, 02:00:00'))
         self.assertEqual(Timedelta(pd.offsets.Hour(2)),Timedelta('0 days, 02:00:00'))
         self.assertEqual(Timedelta(pd.offsets.Second(2)),Timedelta('0 days, 00:00:02'))
-
-        # invalid
-        tm.assertRaisesRegexp(ValueError,
-                              "cannot construct a TimeDelta",
-                              lambda : Timedelta())
-        tm.assertRaisesRegexp(ValueError,
-                              "unit abbreviation w/o a number",
-                              lambda : Timedelta('foo'))
-        tm.assertRaisesRegexp(ValueError,
-                              "cannot construct a TimeDelta from the passed arguments, allowed keywords are ",
-                              lambda : Timedelta(day=10))
 
     def test_repr(self):
 

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -2400,7 +2400,6 @@ cdef inline parse_timedelta_string(object ts, coerce=False):
             have_value = 1
             have_dot = 0
 
-
     # we had a dot, but we have a fractional
     # value since we have an unit
     if have_dot and len(unit):
@@ -2415,6 +2414,10 @@ cdef inline parse_timedelta_string(object ts, coerce=False):
     # we have a dot as part of a regular format
     # e.g. hh:mm:ss.fffffff
     elif have_dot:
+
+        if (len(number) or len(frac)) and not len(unit) and current_unit is None:
+            raise ValueError("no units specified")
+
         if len(frac) > 0 and len(frac) <= 3:
             m = 10**(3-len(frac)) * 1000L * 1000L
         elif len(frac) > 3 and len(frac) <= 6:


### PR DESCRIPTION
closes #10426 
