### PR TITLE
BUG GH10425 test_categorical big-endian fix

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -78,3 +78,4 @@ Bug Fixes
 - Bug in ``ExcelReader`` when worksheet is empty (:issue:`6403`)
 - Bug in ``Table.select_column`` where name is not preserved (:issue:`10392`)
 - Bug in ``DataFrame.interpolate`` with ``axis=1`` and ``inplace=True`` (:issue:`10395`)
+- Bug in ``test_categorical`` on big-endian builds (:issue:`10425`)

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -2883,7 +2883,7 @@ class TestCategoricalAsBlock(tm.TestCase):
         # this coerces
         result = df.to_records()
         expected = np.rec.array([(0, 'a'), (1, 'b'), (2, 'c')],
-                                dtype=[('index', '<i8'), ('0', 'O')])
+                                dtype=[('index', '=i8'), ('0', 'O')])
         tm.assert_almost_equal(result, expected)
 
     def test_numeric_like_ops(self):


### PR DESCRIPTION
BUG: Changing test_categorical to compare with native byte ordering instead of comparing with little-endian one

closes #10425
