### PR TITLE
DOC: fixed docstrings for StringMethods ljust and rjust

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1270,11 +1270,11 @@ class StringMethods(object):
     def center(self, width, fillchar=' '):
         return self.pad(width, side='both', fillchar=fillchar)
 
-    @Appender(_shared_docs['str_pad'] % dict(side='right', method='right'))
+    @Appender(_shared_docs['str_pad'] % dict(side='right', method='ljust'))
     def ljust(self, width, fillchar=' '):
         return self.pad(width, side='right', fillchar=fillchar)
 
-    @Appender(_shared_docs['str_pad'] % dict(side='left', method='left'))
+    @Appender(_shared_docs['str_pad'] % dict(side='left', method='rjust'))
     def rjust(self, width, fillchar=' '):
         return self.pad(width, side='left', fillchar=fillchar)
 


### PR DESCRIPTION
Very minor fix but `str.ljust()` and `str.rjust()` have broken links in the docstrings. 

You can see in http://pandas.pydata.org/pandas-docs/version/0.16.2/generated/pandas.Series.str.ljust.html#pandas.Series.str.ljust that it should be linking to `str.ljust()` instead of `str.right()` (which doesn't exist) 
