### PR TITLE
TST/CLN: remove assert_isinstance

### DIFF
--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -424,27 +424,27 @@ class ExcelReaderTests(SharedItems, tm.TestCase):
         for path in (xls_path, xlsx_path):
             actual = read_excel(path, 'Sheet1', converters=converters)
             tm.assert_frame_equal(actual, expected)
-    
+
     def test_reading_all_sheets(self):
         # Test reading all sheetnames by setting sheetname to None,
         # Ensure a dict is returned.
         # See PR #9450
-    
+
         _skip_if_no_xlrd()
-        
+
         dfs = read_excel(self.multisheet,sheetname=None)
         expected_keys = ['Alpha','Beta','Charlie']
         tm.assert_contains_all(expected_keys,dfs.keys())
 
     def test_reading_multiple_specific_sheets(self):
-        # Test reading specific sheetnames by specifying a mixed list 
+        # Test reading specific sheetnames by specifying a mixed list
         # of integers and strings, and confirm that duplicated sheet
         # references (positions/names) are removed properly.
-        
+
         # Ensure a dict is returned
         # See PR #9450
         _skip_if_no_xlrd()
-        
+
         #Explicitly request duplicates.  Only the set should be returned.
         expected_keys = [2,'Charlie','Charlie']
         dfs = read_excel(self.multisheet,sheetname=expected_keys)
@@ -456,19 +456,19 @@ class ExcelReaderTests(SharedItems, tm.TestCase):
         # Test reading multiple sheets, from a runtime created excel file
         # with multiple sheets.
         # See PR #9450
-    
+
         _skip_if_no_xlrd()
         _skip_if_no_xlwt()
-               
+
         def tdf(sheetname):
             d, i = [11,22,33], [1,2,3]
             return DataFrame(d,i,columns=[sheetname])
-        
+
         sheets = ['AAA','BBB','CCC']
-        
+
         dfs = [tdf(s) for s in sheets]
         dfs = dict(zip(sheets,dfs))
-  
+
         with ensure_clean('.xlsx') as pth:
             with ExcelWriter(pth) as ew:
                 for sheetname, df in iteritems(dfs):
@@ -476,7 +476,7 @@ class ExcelReaderTests(SharedItems, tm.TestCase):
             dfs_returned = pd.read_excel(pth,sheetname=sheets)
             for s in sheets:
                 tm.assert_frame_equal(dfs[s],dfs_returned[s])
-    
+
     def test_reader_seconds(self):
         # Test reading times with and without milliseconds. GH5945.
         _skip_if_no_xlrd()
@@ -1575,12 +1575,12 @@ class ExcelWriterEngineTests(tm.TestCase):
 
         with ensure_clean('.xlsx') as path:
             writer = ExcelWriter(path)
-            tm.assert_isinstance(writer, writer_klass)
+            tm.assertIsInstance(writer, writer_klass)
 
         _skip_if_no_xlwt()
         with ensure_clean('.xls') as path:
             writer = ExcelWriter(path)
-            tm.assert_isinstance(writer, _XlwtWriter)
+            tm.assertIsInstance(writer, _XlwtWriter)
 
     def test_register_writer(self):
         # some awkward mocking to test out dispatch and such actually works
@@ -1608,7 +1608,7 @@ class ExcelWriterEngineTests(tm.TestCase):
 
         register_writer(DummyClass)
         writer = ExcelWriter('something.test')
-        tm.assert_isinstance(writer, DummyClass)
+        tm.assertIsInstance(writer, DummyClass)
         df = tm.makeCustomDataframe(1, 1)
         panel = tm.makePanel()
         func = lambda: df.to_excel('something.test')

--- a/pandas/io/tests/test_html.py
+++ b/pandas/io/tests/test_html.py
@@ -159,12 +159,12 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
     def test_spam_no_match(self):
         dfs = self.read_html(self.spam_data)
         for df in dfs:
-            tm.assert_isinstance(df, DataFrame)
+            tm.assertIsInstance(df, DataFrame)
 
     def test_banklist_no_match(self):
         dfs = self.read_html(self.banklist_data, attrs={'id': 'table'})
         for df in dfs:
-            tm.assert_isinstance(df, DataFrame)
+            tm.assertIsInstance(df, DataFrame)
 
     def test_spam_header(self):
         df = self.read_html(self.spam_data, '.*Water.*', header=1)[0]
@@ -307,9 +307,9 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
         url = self.banklist_data
         dfs = self.read_html(file_path_to_url(url), 'First',
                              attrs={'id': 'table'})
-        tm.assert_isinstance(dfs, list)
+        tm.assertIsInstance(dfs, list)
         for df in dfs:
-            tm.assert_isinstance(df, DataFrame)
+            tm.assertIsInstance(df, DataFrame)
 
     @slow
     def test_invalid_table_attrs(self):
@@ -325,34 +325,34 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
     @slow
     def test_multiindex_header(self):
         df = self._bank_data(header=[0, 1])[0]
-        tm.assert_isinstance(df.columns, MultiIndex)
+        tm.assertIsInstance(df.columns, MultiIndex)
 
     @slow
     def test_multiindex_index(self):
         df = self._bank_data(index_col=[0, 1])[0]
-        tm.assert_isinstance(df.index, MultiIndex)
+        tm.assertIsInstance(df.index, MultiIndex)
 
     @slow
     def test_multiindex_header_index(self):
         df = self._bank_data(header=[0, 1], index_col=[0, 1])[0]
-        tm.assert_isinstance(df.columns, MultiIndex)
-        tm.assert_isinstance(df.index, MultiIndex)
+        tm.assertIsInstance(df.columns, MultiIndex)
+        tm.assertIsInstance(df.index, MultiIndex)
 
     @slow
     def test_multiindex_header_skiprows_tuples(self):
         df = self._bank_data(header=[0, 1], skiprows=1, tupleize_cols=True)[0]
-        tm.assert_isinstance(df.columns, Index)
+        tm.assertIsInstance(df.columns, Index)
 
     @slow
     def test_multiindex_header_skiprows(self):
         df = self._bank_data(header=[0, 1], skiprows=1)[0]
-        tm.assert_isinstance(df.columns, MultiIndex)
+        tm.assertIsInstance(df.columns, MultiIndex)
 
     @slow
     def test_multiindex_header_index_skiprows(self):
         df = self._bank_data(header=[0, 1], index_col=[0, 1], skiprows=1)[0]
-        tm.assert_isinstance(df.index, MultiIndex)
-        tm.assert_isinstance(df.columns, MultiIndex)
+        tm.assertIsInstance(df.index, MultiIndex)
+        tm.assertIsInstance(df.columns, MultiIndex)
 
     @slow
     def test_regex_idempotency(self):
@@ -360,9 +360,9 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
         dfs = self.read_html(file_path_to_url(url),
                              match=re.compile(re.compile('Florida')),
                              attrs={'id': 'table'})
-        tm.assert_isinstance(dfs, list)
+        tm.assertIsInstance(dfs, list)
         for df in dfs:
-            tm.assert_isinstance(df, DataFrame)
+            tm.assertIsInstance(df, DataFrame)
 
     def test_negative_skiprows(self):
         with tm.assertRaisesRegexp(ValueError,
@@ -426,10 +426,10 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
         res1 = self.read_html(StringIO(data1))
         res2 = self.read_html(StringIO(data2))
         assert_framelist_equal(res1, res2)
-    
+
     def test_tfoot_read(self):
         """
-        Make sure that read_html reads tfoot, containing td or th. 
+        Make sure that read_html reads tfoot, containing td or th.
         Ignores empty tfoot
         """
         data_template = '''<table>
@@ -452,10 +452,10 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
 
         data1 = data_template.format(footer = "")
         data2 = data_template.format(footer ="<tr><td>footA</td><th>footB</th></tr>")
-    
+
         d1 = {'A': ['bodyA'], 'B': ['bodyB']}
         d2 = {'A': ['bodyA', 'footA'], 'B': ['bodyB', 'footB']}
-    
+
         tm.assert_frame_equal(self.read_html(data1)[0], DataFrame(d1))
         tm.assert_frame_equal(self.read_html(data2)[0], DataFrame(d2))
 
@@ -721,8 +721,8 @@ class TestReadHtmlLxml(tm.TestCase, ReadHtmlMixin):
     def test_works_on_valid_markup(self):
         filename = os.path.join(DATA_PATH, 'valid_markup.html')
         dfs = self.read_html(filename, index_col=0)
-        tm.assert_isinstance(dfs, list)
-        tm.assert_isinstance(dfs[0], DataFrame)
+        tm.assertIsInstance(dfs, list)
+        tm.assertIsInstance(dfs[0], DataFrame)
 
     @slow
     def test_fallback_success(self):

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -276,7 +276,7 @@ c,3
         expected = Series([1, 2, 3], name=1, index=idx)
         result = self.read_table(StringIO(data), sep=',', index_col=0,
                                  header=None, squeeze=True)
-        tm.assert_isinstance(result, Series)
+        tm.assertIsInstance(result, Series)
         tm.assert_series_equal(result, expected)
 
     def test_squeeze_no_view(self):
@@ -1016,7 +1016,7 @@ c,4,5
         expected['aux_date'] = to_datetime(expected['aux_date'],
                                            dayfirst=True)
         expected['aux_date'] = lmap(Timestamp, expected['aux_date'])
-        tm.assert_isinstance(expected['aux_date'][0], datetime)
+        tm.assertIsInstance(expected['aux_date'][0], datetime)
 
         df = self.read_csv(StringIO(data), sep=";", index_col=lrange(4),
                            parse_dates=[0, 5], dayfirst=True)
@@ -1117,7 +1117,7 @@ baz,7,8,9
     def test_read_table_unicode(self):
         fin = BytesIO(u('\u0141aski, Jan;1').encode('utf-8'))
         df1 = read_table(fin, sep=";", encoding="utf-8", header=None)
-        tm.assert_isinstance(df1[0].values[0], compat.text_type)
+        tm.assertIsInstance(df1[0].values[0], compat.text_type)
 
     def test_read_table_wrong_num_columns(self):
         # too few!
@@ -1300,7 +1300,7 @@ baz,7,8,9
 
             treader = self.read_table(StringIO(self.data1), sep=',', index_col=0,
                                       iterator=True)
-            tm.assert_isinstance(treader, TextFileReader)
+            tm.assertIsInstance(treader, TextFileReader)
 
             # stopping iteration when on chunksize is specified, GH 3967
             data = """A,B,C
@@ -1601,7 +1601,7 @@ c,4,5,01/03/2009
         expected = self.read_csv(StringIO(data))
         expected['D'] = expected['D'].map(parse_date)
 
-        tm.assert_isinstance(result['D'][0], (datetime, Timestamp))
+        tm.assertIsInstance(result['D'][0], (datetime, Timestamp))
         tm.assert_frame_equal(result, expected)
         tm.assert_frame_equal(result2, expected)
 
@@ -2727,7 +2727,7 @@ eight,1,2,3"""
 
         treader = self.read_table(StringIO(self.data1), sep=',', index_col=0,
                                   iterator=True)
-        tm.assert_isinstance(treader, TextFileReader)
+        tm.assertIsInstance(treader, TextFileReader)
 
         # stopping iteration when on chunksize is specified, GH 3967
         data = """A,B,C

--- a/pandas/sparse/tests/test_array.py
+++ b/pandas/sparse/tests/test_array.py
@@ -129,19 +129,19 @@ class TestSparseArray(tm.TestCase):
             res = op(first, second)
             exp = SparseArray(op(first.values, second.values),
                               fill_value=first.fill_value)
-            tm.assert_isinstance(res, SparseArray)
+            tm.assertIsInstance(res, SparseArray)
             assert_almost_equal(res.values, exp.values)
 
             res2 = op(first, second.values)
-            tm.assert_isinstance(res2, SparseArray)
+            tm.assertIsInstance(res2, SparseArray)
             assert_sp_array_equal(res, res2)
 
             res3 = op(first.values, second)
-            tm.assert_isinstance(res3, SparseArray)
+            tm.assertIsInstance(res3, SparseArray)
             assert_sp_array_equal(res, res3)
 
             res4 = op(first, 4)
-            tm.assert_isinstance(res4, SparseArray)
+            tm.assertIsInstance(res4, SparseArray)
 
             # ignore this if the actual op raises (e.g. pow)
             try:

--- a/pandas/sparse/tests/test_libsparse.py
+++ b/pandas/sparse/tests/test_libsparse.py
@@ -287,7 +287,7 @@ class TestIntIndex(tm.TestCase):
             # see if survive the round trip
             xbindex = xindex.to_int_index().to_block_index()
             ybindex = yindex.to_int_index().to_block_index()
-            tm.assert_isinstance(xbindex, BlockIndex)
+            tm.assertIsInstance(xbindex, BlockIndex)
             self.assertTrue(xbindex.equals(xindex))
             self.assertTrue(ybindex.equals(yindex))
         check_cases(_check_case)

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -230,9 +230,9 @@ class TestSparseSeries(tm.TestCase,
     def test_constructor(self):
         # test setup guys
         self.assertTrue(np.isnan(self.bseries.fill_value))
-        tm.assert_isinstance(self.bseries.sp_index, BlockIndex)
+        tm.assertIsInstance(self.bseries.sp_index, BlockIndex)
         self.assertTrue(np.isnan(self.iseries.fill_value))
-        tm.assert_isinstance(self.iseries.sp_index, IntIndex)
+        tm.assertIsInstance(self.iseries.sp_index, IntIndex)
 
         self.assertEqual(self.zbseries.fill_value, 0)
         assert_equal(self.zbseries.values.values,
@@ -258,7 +258,7 @@ class TestSparseSeries(tm.TestCase,
         # Sparse time series works
         date_index = bdate_range('1/1/2000', periods=len(self.bseries))
         s5 = SparseSeries(self.bseries, index=date_index)
-        tm.assert_isinstance(s5, SparseTimeSeries)
+        tm.assertIsInstance(s5, SparseTimeSeries)
 
         # pass Series
         bseries2 = SparseSeries(self.bseries.to_dense())
@@ -404,13 +404,13 @@ class TestSparseSeries(tm.TestCase,
     def test_getitem_slice(self):
         idx = self.bseries.index
         res = self.bseries[::2]
-        tm.assert_isinstance(res, SparseSeries)
+        tm.assertIsInstance(res, SparseSeries)
 
         expected = self.bseries.reindex(idx[::2])
         assert_sp_series_equal(res, expected)
 
         res = self.bseries[:5]
-        tm.assert_isinstance(res, SparseSeries)
+        tm.assertIsInstance(res, SparseSeries)
         assert_sp_series_equal(res, self.bseries.reindex(idx[:5]))
 
         res = self.bseries[5:]
@@ -756,13 +756,13 @@ class TestSparseSeries(tm.TestCase,
     def test_cumsum(self):
         result = self.bseries.cumsum()
         expected = self.bseries.to_dense().cumsum()
-        tm.assert_isinstance(result, SparseSeries)
+        tm.assertIsInstance(result, SparseSeries)
         self.assertEqual(result.name, self.bseries.name)
         assert_series_equal(result.to_dense(), expected)
 
         result = self.zbseries.cumsum()
         expected = self.zbseries.to_dense().cumsum()
-        tm.assert_isinstance(result, Series)
+        tm.assertIsInstance(result, Series)
         assert_series_equal(result, expected)
 
     def test_combine_first(self):
@@ -957,7 +957,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
 
     def test_copy(self):
         cp = self.frame.copy()
-        tm.assert_isinstance(cp, SparseDataFrame)
+        tm.assertIsInstance(cp, SparseDataFrame)
         assert_sp_frame_equal(cp, self.frame)
 
         # as of v0.15.0
@@ -966,9 +966,9 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
 
     def test_constructor(self):
         for col, series in compat.iteritems(self.frame):
-            tm.assert_isinstance(series, SparseSeries)
+            tm.assertIsInstance(series, SparseSeries)
 
-        tm.assert_isinstance(self.iframe['A'].sp_index, IntIndex)
+        tm.assertIsInstance(self.iframe['A'].sp_index, IntIndex)
 
         # constructed zframe from matrix above
         self.assertEqual(self.zframe['A'].fill_value, 0)
@@ -978,7 +978,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
         # construct no data
         sdf = SparseDataFrame(columns=np.arange(10), index=np.arange(10))
         for col, series in compat.iteritems(sdf):
-            tm.assert_isinstance(series, SparseSeries)
+            tm.assertIsInstance(series, SparseSeries)
 
         # construct from nested dict
         data = {}
@@ -1047,9 +1047,9 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
         # GH 2873
         x = Series(np.random.randn(10000), name='a')
         x = x.to_sparse(fill_value=0)
-        tm.assert_isinstance(x, SparseSeries)
+        tm.assertIsInstance(x, SparseSeries)
         df = SparseDataFrame(x)
-        tm.assert_isinstance(df, SparseDataFrame)
+        tm.assertIsInstance(df, SparseDataFrame)
 
         x = Series(np.random.randn(10000), name='a')
         y = Series(np.random.randn(10000), name='b')
@@ -1098,13 +1098,13 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
         df = DataFrame({'A': [nan, nan, nan, 1, 2],
                         'B': [1, 2, nan, nan, nan]})
         sdf = df.to_sparse()
-        tm.assert_isinstance(sdf, SparseDataFrame)
+        tm.assertIsInstance(sdf, SparseDataFrame)
         self.assertTrue(np.isnan(sdf.default_fill_value))
-        tm.assert_isinstance(sdf['A'].sp_index, BlockIndex)
+        tm.assertIsInstance(sdf['A'].sp_index, BlockIndex)
         tm.assert_frame_equal(sdf.to_dense(), df)
 
         sdf = df.to_sparse(kind='integer')
-        tm.assert_isinstance(sdf['A'].sp_index, IntIndex)
+        tm.assertIsInstance(sdf['A'].sp_index, IntIndex)
 
         df = DataFrame({'A': [0, 0, 0, 1, 2],
                         'B': [1, 2, 0, 0, 0]}, dtype=float)
@@ -1172,7 +1172,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
 
             if isinstance(a, DataFrame) and isinstance(db, DataFrame):
                 mixed_result = op(a, db)
-                tm.assert_isinstance(mixed_result, SparseDataFrame)
+                tm.assertIsInstance(mixed_result, SparseDataFrame)
                 assert_sp_frame_equal(mixed_result, sparse_result,
                                       exact_indices=False)
 
@@ -1220,7 +1220,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
         self.assertTrue(empty.empty)
 
         foo = self.frame + self.empty
-        tm.assert_isinstance(foo.index, DatetimeIndex)
+        tm.assertIsInstance(foo.index, DatetimeIndex)
         assert_frame_equal(foo, self.frame * np.nan)
 
         foo = self.empty + self.frame
@@ -1304,7 +1304,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
 
             # insert SparseSeries
             frame['E'] = frame['A']
-            tm.assert_isinstance(frame['E'], SparseSeries)
+            tm.assertIsInstance(frame['E'], SparseSeries)
             assert_sp_series_equal(frame['E'], frame['A'], check_names=False)
 
             # insert SparseSeries differently-indexed
@@ -1318,7 +1318,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
 
             # insert Series
             frame['F'] = frame['A'].to_dense()
-            tm.assert_isinstance(frame['F'], SparseSeries)
+            tm.assertIsInstance(frame['F'], SparseSeries)
             assert_sp_series_equal(frame['F'], frame['A'], check_names=False)
 
             # insert Series differently-indexed
@@ -1331,7 +1331,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
 
             # insert ndarray
             frame['H'] = np.random.randn(N)
-            tm.assert_isinstance(frame['H'], SparseSeries)
+            tm.assertIsInstance(frame['H'], SparseSeries)
 
             to_sparsify = np.random.randn(N)
             to_sparsify[N // 2:] = frame.default_fill_value
@@ -1407,7 +1407,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
 
     def test_apply(self):
         applied = self.frame.apply(np.sqrt)
-        tm.assert_isinstance(applied, SparseDataFrame)
+        tm.assertIsInstance(applied, SparseDataFrame)
         assert_almost_equal(applied.values, np.sqrt(self.frame.values))
 
         applied = self.fill_frame.apply(np.sqrt)
@@ -1415,7 +1415,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
 
         # agg / broadcast
         broadcasted = self.frame.apply(np.sum, broadcast=True)
-        tm.assert_isinstance(broadcasted, SparseDataFrame)
+        tm.assertIsInstance(broadcasted, SparseDataFrame)
         assert_frame_equal(broadcasted.to_dense(),
                            self.frame.to_dense().apply(np.sum, broadcast=True))
 
@@ -1443,7 +1443,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
     def test_applymap(self):
         # just test that it works
         result = self.frame.applymap(lambda x: x * 2)
-        tm.assert_isinstance(result, SparseDataFrame)
+        tm.assertIsInstance(result, SparseDataFrame)
 
     def test_astype(self):
         self.assertRaises(Exception, self.frame.astype, np.int64)
@@ -1635,7 +1635,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
     def test_cumsum(self):
         result = self.frame.cumsum()
         expected = self.frame.to_dense().cumsum()
-        tm.assert_isinstance(result, SparseDataFrame)
+        tm.assertIsInstance(result, SparseDataFrame)
         assert_frame_equal(result.to_dense(), expected)
 
     def _check_all(self, check_func):
@@ -1794,9 +1794,9 @@ class TestSparsePanel(tm.TestCase,
     def test_pickle(self):
         def _test_roundtrip(panel):
             result = self.round_trip_pickle(panel)
-            tm.assert_isinstance(result.items, Index)
-            tm.assert_isinstance(result.major_axis, Index)
-            tm.assert_isinstance(result.minor_axis, Index)
+            tm.assertIsInstance(result.items, Index)
+            tm.assertIsInstance(result.major_axis, Index)
+            tm.assertIsInstance(result.minor_axis, Index)
             assert_sp_panel_equal(panel, result)
 
         _test_roundtrip(self.panel)
@@ -1804,7 +1804,7 @@ class TestSparsePanel(tm.TestCase,
     def test_dense_to_sparse(self):
         wp = Panel.from_dict(self.data_dict)
         dwp = wp.to_sparse()
-        tm.assert_isinstance(dwp['ItemA']['A'], SparseSeries)
+        tm.assertIsInstance(dwp['ItemA']['A'], SparseSeries)
 
     def test_to_dense(self):
         dwp = self.panel.to_dense()

--- a/pandas/stats/tests/test_moments.py
+++ b/pandas/stats/tests/test_moments.py
@@ -574,7 +574,7 @@ class TestMoments(Base):
                           fill_value=None):
 
         series_result = func(self.series, 50)
-        tm.assert_isinstance(series_result, Series)
+        tm.assertIsInstance(series_result, Series)
 
         frame_result = func(self.frame, 50)
         self.assertEqual(type(frame_result), DataFrame)
@@ -782,7 +782,7 @@ class TestMoments(Base):
 
     def _check_ew_structures(self, func):
         series_result = func(self.series, com=10)
-        tm.assert_isinstance(series_result, Series)
+        tm.assertIsInstance(series_result, Series)
         frame_result = func(self.frame, com=10)
         self.assertEqual(type(frame_result), DataFrame)
 
@@ -1844,7 +1844,7 @@ class TestMomentsConsistency(Base):
 
     def _check_expanding_structures(self, func):
         series_result = func(self.series)
-        tm.assert_isinstance(series_result, Series)
+        tm.assertIsInstance(series_result, Series)
         frame_result = func(self.frame)
         self.assertEqual(type(frame_result), DataFrame)
 

--- a/pandas/stats/tests/test_ols.py
+++ b/pandas/stats/tests/test_ols.py
@@ -41,7 +41,7 @@ def _check_repr(obj):
 
 
 def _compare_ols_results(model1, model2):
-    tm.assert_isinstance(model1, type(model2))
+    tm.assertIsInstance(model1, type(model2))
 
     if hasattr(model1, '_window_type'):
         _compare_moving_ols(model1, model2)
@@ -370,7 +370,7 @@ class TestOLSMisc(tm.TestCase):
         y = lp.pop('ItemA')
         model = ols(y=y, x=lp, entity_effects=True, window=20)
         self.assertTrue(notnull(model.beta.values).all())
-        tm.assert_isinstance(model, PanelOLS)
+        tm.assertIsInstance(model, PanelOLS)
         model.summary
 
     def test_series_rhs(self):
@@ -394,7 +394,7 @@ class TestOLSMisc(tm.TestCase):
 
         for attr in series_attrs:
             value = getattr(model, attr)
-            tm.assert_isinstance(value, Series)
+            tm.assertIsInstance(value, Series)
 
         # works
         model._results

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -174,13 +174,13 @@ class TestUnique(tm.TestCase):
         arr = np.random.randint(0, 100, size=50)
 
         result = algos.unique(arr)
-        tm.assert_isinstance(result, np.ndarray)
+        tm.assertIsInstance(result, np.ndarray)
 
     def test_objects(self):
         arr = np.random.randint(0, 100, size=50).astype('O')
 
         result = algos.unique(arr)
-        tm.assert_isinstance(result, np.ndarray)
+        tm.assertIsInstance(result, np.ndarray)
 
     def test_object_refcount_bug(self):
         lst = ['A', 'B', 'C', 'D', 'E']
@@ -211,7 +211,7 @@ class TestValueCounts(tm.TestCase):
         arr = np.random.randn(4)
         factor = cut(arr, 4)
 
-        tm.assert_isinstance(factor, Categorical)
+        tm.assertIsInstance(factor, Categorical)
 
         result = algos.value_counts(factor)
         expected = algos.value_counts(np.asarray(factor))

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -8,7 +8,7 @@ import pandas as pd
 from pandas.compat import u, StringIO
 from pandas.core.base import FrozenList, FrozenNDArray, PandasDelegate
 from pandas.tseries.base import DatetimeIndexOpsMixin
-from pandas.util.testing import assertRaisesRegexp, assert_isinstance
+from pandas.util.testing import assertRaisesRegexp, assertIsInstance
 from pandas.tseries.common import is_datetimelike
 from pandas import Series, Index, Int64Index, DatetimeIndex, TimedeltaIndex, PeriodIndex, Timedelta
 import pandas.tslib as tslib
@@ -68,7 +68,7 @@ class CheckImmutable(object):
 
     def check_result(self, result, expected, klass=None):
         klass = klass or self.klass
-        assert_isinstance(result, klass)
+        assertIsInstance(result, klass)
         self.assertEqual(result, expected)
 
 
@@ -109,12 +109,12 @@ class TestFrozenNDArray(CheckImmutable, CheckStringMixin, tm.TestCase):
 
     def test_shallow_copying(self):
         original = self.container.copy()
-        assert_isinstance(self.container.view(), FrozenNDArray)
+        assertIsInstance(self.container.view(), FrozenNDArray)
         self.assertFalse(isinstance(self.container.view(np.ndarray), FrozenNDArray))
         self.assertIsNot(self.container.view(), self.container)
         self.assert_numpy_array_equal(self.container, original)
         # shallow copy should be the same too
-        assert_isinstance(self.container._shallow_copy(), FrozenNDArray)
+        assertIsInstance(self.container._shallow_copy(), FrozenNDArray)
         # setting should not be allowed
         def testit(container): container[0] = 16
 

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -2068,7 +2068,7 @@ class TestCategoricalAsBlock(tm.TestCase):
         # row
         res_row = df.iloc[2,:]
         tm.assert_series_equal(res_row, exp_row)
-        tm.assert_isinstance(res_row["cats"], compat.string_types)
+        tm.assertIsInstance(res_row["cats"], compat.string_types)
 
         # col
         res_col = df.iloc[:,0]
@@ -2088,7 +2088,7 @@ class TestCategoricalAsBlock(tm.TestCase):
         # row
         res_row = df.loc["j",:]
         tm.assert_series_equal(res_row, exp_row)
-        tm.assert_isinstance(res_row["cats"], compat.string_types)
+        tm.assertIsInstance(res_row["cats"], compat.string_types)
 
         # col
         res_col = df.loc[:,"cats"]
@@ -2109,7 +2109,7 @@ class TestCategoricalAsBlock(tm.TestCase):
         # row
         res_row = df.ix["j",:]
         tm.assert_series_equal(res_row, exp_row)
-        tm.assert_isinstance(res_row["cats"], compat.string_types)
+        tm.assertIsInstance(res_row["cats"], compat.string_types)
 
         # col
         res_col = df.ix[:,"cats"]
@@ -2143,7 +2143,7 @@ class TestCategoricalAsBlock(tm.TestCase):
         # i : int, slice, or sequence of integers
         res_row = df.irow(2)
         tm.assert_series_equal(res_row, exp_row)
-        tm.assert_isinstance(res_row["cats"], compat.string_types)
+        tm.assertIsInstance(res_row["cats"], compat.string_types)
 
         res_df = df.irow(slice(2,4))
         tm.assert_frame_equal(res_df, exp_df)

--- a/pandas/tests/test_compat.py
+++ b/pandas/tests/test_compat.py
@@ -16,7 +16,7 @@ class TestBuiltinIterators(tm.TestCase):
     def check_result(self, actual, expected, lengths):
         for (iter_res, list_res), exp, length in zip(actual, expected, lengths):
             self.assertNotIsInstance(iter_res, list)
-            tm.assert_isinstance(list_res, list)
+            tm.assertIsInstance(list_res, list)
             iter_res = list(iter_res)
             self.assertEqual(len(list_res), length)
             self.assertEqual(len(iter_res), length)

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -395,7 +395,7 @@ class TestDataFrameFormatting(tm.TestCase):
         buf.getvalue()
 
         result = self.frame.to_string()
-        tm.assert_isinstance(result, compat.text_type)
+        tm.assertIsInstance(result, compat.text_type)
 
     def test_to_string_utf8_columns(self):
         n = u("\u05d0").encode('utf-8')
@@ -1470,7 +1470,7 @@ class TestDataFrameFormatting(tm.TestCase):
         self.assertIsNone(retval)
         self.assertEqual(buf.getvalue(), s)
 
-        tm.assert_isinstance(s, compat.string_types)
+        tm.assertIsInstance(s, compat.string_types)
 
         # print in right order
         result = biggie.to_string(columns=['B', 'A'], col_space=17,
@@ -1719,7 +1719,7 @@ c  10  11  12  13  14\
         self.assertIsNone(retval)
         self.assertEqual(buf.getvalue(), s)
 
-        tm.assert_isinstance(s, compat.string_types)
+        tm.assertIsInstance(s, compat.string_types)
 
         biggie.to_html(columns=['B', 'A'], col_space=17)
         biggie.to_html(columns=['B', 'A'],

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -1841,13 +1841,13 @@ class CheckIndexing(object):
 
         result = df.irow(0)
         result2 = df.ix[0]
-        tm.assert_isinstance(result, Series)
+        tm.assertIsInstance(result, Series)
         assert_almost_equal(result.values, df.values[0])
         assert_series_equal(result, result2)
 
         result = df.T.icol(0)
         result2 = df.T.ix[:, 0]
-        tm.assert_isinstance(result, Series)
+        tm.assertIsInstance(result, Series)
         assert_almost_equal(result.values, df.values[0])
         assert_series_equal(result, result2)
 
@@ -2439,7 +2439,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                         'B': np.random.randn(1000)})
 
         idf = df.set_index('A')
-        tm.assert_isinstance(idf.index, DatetimeIndex)
+        tm.assertIsInstance(idf.index, DatetimeIndex)
 
         # don't cast a DatetimeIndex WITH a tz, leave as object
         # GH 6032
@@ -2602,7 +2602,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.assertEqual(result.shape, (1,0))
 
         result = DataFrame([DataFrame(dict(A = lrange(5)))])
-        tm.assert_isinstance(result.iloc[0,0], DataFrame)
+        tm.assertIsInstance(result.iloc[0,0], DataFrame)
 
     def test_constructor_mixed_dtypes(self):
 
@@ -2922,10 +2922,10 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
     def test_constructor_dict_dont_upcast(self):
         d = {'Col1': {'Row1': 'A String', 'Row2': np.nan}}
         df = DataFrame(d)
-        tm.assert_isinstance(df['Col1']['Row2'], float)
+        tm.assertIsInstance(df['Col1']['Row2'], float)
 
         dm = DataFrame([[1, 2], ['a', 'b']], index=[1, 2], columns=[1, 2])
-        tm.assert_isinstance(dm[1][1], int)
+        tm.assertIsInstance(dm[1][1], int)
 
     def test_constructor_dict_of_tuples(self):
         # GH #1491
@@ -3575,7 +3575,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                                       columns=self.mixed_frame.columns,
                                       orient='index')
         assert_frame_equal(recons, self.mixed_frame)
-        tm.assert_isinstance(recons['foo'][0], tuple)
+        tm.assertIsInstance(recons['foo'][0], tuple)
 
         rs = DataFrame.from_items([('A', [1, 2, 3]), ('B', [4, 5, 6])],
                                   orient='index', columns=['one', 'two', 'three'])
@@ -4368,7 +4368,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
     def test_array_interface(self):
         result = np.sqrt(self.frame)
-        tm.assert_isinstance(result, type(self.frame))
+        tm.assertIsInstance(result, type(self.frame))
         self.assertIs(result.index, self.frame.index)
         self.assertIs(result.columns, self.frame.columns)
 
@@ -5134,7 +5134,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                         'ints': lrange(5)}, columns=['floats', 'ints'])
 
         for tup in df.itertuples(index=False):
-            tm.assert_isinstance(tup[1], np.integer)
+            tm.assertIsInstance(tup[1], np.integer)
 
         df = DataFrame(data={"a": [1, 2, 3], "b": [4, 5, 6]})
         dfaa = df[['a', 'a']]
@@ -7332,10 +7332,10 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                        index=[datetime(2011, 11, 1), datetime(2011, 11, 2),
                               datetime(2011, 11, 3)])
         df = df.asfreq('B')
-        tm.assert_isinstance(df.index, DatetimeIndex)
+        tm.assertIsInstance(df.index, DatetimeIndex)
 
         ts = df['A'].asfreq('B')
-        tm.assert_isinstance(ts.index, DatetimeIndex)
+        tm.assertIsInstance(ts.index, DatetimeIndex)
 
     def test_at_time_between_time_datetimeindex(self):
         index = date_range("2012-01-01", "2012-01-05", freq='30min')
@@ -10554,10 +10554,10 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                 res = df.apply(f, axis=axis, raw=raw)
                 if is_reduction:
                     agg_axis = df._get_agg_axis(axis)
-                    tm.assert_isinstance(res, Series)
+                    tm.assertIsInstance(res, Series)
                     self.assertIs(res.index, agg_axis)
                 else:
-                    tm.assert_isinstance(res, DataFrame)
+                    tm.assertIsInstance(res, DataFrame)
 
             _checkit()
             _checkit(axis=1)
@@ -10570,7 +10570,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         _check(no_index, lambda x: x.mean())
 
         result = no_cols.apply(lambda x: x.mean(), broadcast=True)
-        tm.assert_isinstance(result, DataFrame)
+        tm.assertIsInstance(result, DataFrame)
 
     def test_apply_with_args_kwds(self):
         def add_some(x, howmuch=0):
@@ -10729,7 +10729,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         s.index = MultiIndex.from_arrays([['a','a','b'], ['c','d','d']])
         s.columns = ['col1','col2']
         res = s.apply(lambda x: Series({'min': min(x), 'max': max(x)}), 1)
-        tm.assert_isinstance(res.index, MultiIndex)
+        tm.assertIsInstance(res.index, MultiIndex)
 
     def test_applymap(self):
         applied = self.frame.applymap(lambda x: x * 2)
@@ -10738,7 +10738,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # GH #465, function returning tuples
         result = self.frame.applymap(lambda x: (x, x))
-        tm.assert_isinstance(result['A'][0], tuple)
+        tm.assertIsInstance(result['A'][0], tuple)
 
         # GH 2909, object conversion to float in constructor?
         df = DataFrame(data=[1,'a'])
@@ -11721,10 +11721,10 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # corner case
         frame = DataFrame()
         ct1 = frame.count(1)
-        tm.assert_isinstance(ct1, Series)
+        tm.assertIsInstance(ct1, Series)
 
         ct2 = frame.count(0)
-        tm.assert_isinstance(ct2, Series)
+        tm.assertIsInstance(ct2, Series)
 
         # GH #423
         df = DataFrame(index=lrange(10))
@@ -12083,8 +12083,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
     def test_sum_corner(self):
         axis0 = self.empty.sum(0)
         axis1 = self.empty.sum(1)
-        tm.assert_isinstance(axis0, Series)
-        tm.assert_isinstance(axis1, Series)
+        tm.assertIsInstance(axis0, Series)
+        tm.assertIsInstance(axis1, Series)
         self.assertEqual(len(axis0), 0)
         self.assertEqual(len(axis1), 0)
 

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -549,7 +549,7 @@ class TestGroupBy(tm.TestCase):
             return dataf["val2"]  - dataf["val2"].mean()
 
         result = df1.groupby("val1", squeeze=True).apply(func)
-        tm.assert_isinstance(result,Series)
+        tm.assertIsInstance(result,Series)
 
         df2 = DataFrame([{"val1": 1, "val2" : 20}, {"val1":1, "val2": 19},
                          {"val1":1, "val2": 27}, {"val1":1, "val2": 12}])
@@ -557,12 +557,12 @@ class TestGroupBy(tm.TestCase):
             return dataf["val2"]  - dataf["val2"].mean()
 
         result = df2.groupby("val1", squeeze=True).apply(func)
-        tm.assert_isinstance(result,Series)
+        tm.assertIsInstance(result,Series)
 
         # GH3596, return a consistent type (regression in 0.11 from 0.10.1)
         df = DataFrame([[1,1],[1,1]],columns=['X','Y'])
         result = df.groupby('X',squeeze=False).count()
-        tm.assert_isinstance(result,DataFrame)
+        tm.assertIsInstance(result,DataFrame)
 
         # GH5592
         # inconcistent return type
@@ -670,7 +670,7 @@ class TestGroupBy(tm.TestCase):
         prng = period_range('2012-1-1', freq='M', periods=3)
         df = DataFrame(np.random.randn(3, 2), index=prng)
         rs = df.groupby(level=0).sum()
-        tm.assert_isinstance(rs.index, PeriodIndex)
+        tm.assertIsInstance(rs.index, PeriodIndex)
 
         # GH 3579
         index = period_range(start='1999-01', periods=5, freq='M')
@@ -912,7 +912,7 @@ class TestGroupBy(tm.TestCase):
         def aggfun(ser):
             return ser.size
         result = DataFrame().groupby(self.df.A).agg(aggfun)
-        tm.assert_isinstance(result, DataFrame)
+        tm.assertIsInstance(result, DataFrame)
         self.assertEqual(len(result), 0)
 
     def test_agg_item_by_item_raise_typeerror(self):
@@ -1642,22 +1642,22 @@ class TestGroupBy(tm.TestCase):
 
         result = grouped['C'].agg(np.sum)
         expected = grouped.agg(np.sum).ix[:, ['A', 'C']]
-        tm.assert_isinstance(result, DataFrame)
+        tm.assertIsInstance(result, DataFrame)
         assert_frame_equal(result, expected)
 
         result2 = grouped2['C'].agg(np.sum)
         expected2 = grouped2.agg(np.sum).ix[:, ['A', 'B', 'C']]
-        tm.assert_isinstance(result2, DataFrame)
+        tm.assertIsInstance(result2, DataFrame)
         assert_frame_equal(result2, expected2)
 
         result = grouped['C'].sum()
         expected = grouped.sum().ix[:, ['A', 'C']]
-        tm.assert_isinstance(result, DataFrame)
+        tm.assertIsInstance(result, DataFrame)
         assert_frame_equal(result, expected)
 
         result2 = grouped2['C'].sum()
         expected2 = grouped2.sum().ix[:, ['A', 'B', 'C']]
-        tm.assert_isinstance(result2, DataFrame)
+        tm.assertIsInstance(result2, DataFrame)
         assert_frame_equal(result2, expected2)
 
         # corner case
@@ -2023,7 +2023,7 @@ class TestGroupBy(tm.TestCase):
 
         keys = [np.array([0, 0, 1]), np.array([0, 0, 1])]
         agged = df.groupby(keys).agg(np.mean)
-        tm.assert_isinstance(agged.columns, MultiIndex)
+        tm.assertIsInstance(agged.columns, MultiIndex)
 
         def aggfun(ser):
             if ser.name == ('foo', 'one'):
@@ -2181,7 +2181,7 @@ class TestGroupBy(tm.TestCase):
         grouped = ts.groupby(lambda x: x.month)
         result = grouped.apply(f)
 
-        tm.assert_isinstance(result, DataFrame)
+        tm.assertIsInstance(result, DataFrame)
         self.assertTrue(result.index.equals(ts.index))
 
     def test_apply_series_yield_constant(self):
@@ -2779,11 +2779,11 @@ class TestGroupBy(tm.TestCase):
 
         result = grouped.agg(convert_fast)
         self.assertEqual(result.dtype, np.object_)
-        tm.assert_isinstance(result[0], Decimal)
+        tm.assertIsInstance(result[0], Decimal)
 
         result = grouped.agg(convert_force_pure)
         self.assertEqual(result.dtype, np.object_)
-        tm.assert_isinstance(result[0], Decimal)
+        tm.assertIsInstance(result[0], Decimal)
 
     def test_fast_apply(self):
         # make sure that fast apply is correctly called
@@ -3225,7 +3225,7 @@ class TestGroupBy(tm.TestCase):
         result = self.df.groupby('A')['C'].apply(f)
         expected = self.df.groupby('A')['C'].apply(g)
 
-        tm.assert_isinstance(result, Series)
+        tm.assertIsInstance(result, Series)
         assert_series_equal(result, expected)
 
     def test_getitem_list_of_columns(self):
@@ -3534,7 +3534,7 @@ class TestGroupBy(tm.TestCase):
 
         # it works!
         groups = grouped.groups
-        tm.assert_isinstance(list(groups.keys())[0], datetime)
+        tm.assertIsInstance(list(groups.keys())[0], datetime)
 
     def test_groupby_groups_datetimeindex_tz(self):
         # GH 3950

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -425,7 +425,7 @@ class TestIndex(Base, tm.TestCase):
     def test_new_axis(self):
         new_index = self.dateIndex[None, :]
         self.assertEqual(new_index.ndim, 2)
-        tm.assert_isinstance(new_index, np.ndarray)
+        tm.assertIsInstance(new_index, np.ndarray)
 
     def test_copy_and_deepcopy(self):
         super(TestIndex, self).test_copy_and_deepcopy()
@@ -447,7 +447,7 @@ class TestIndex(Base, tm.TestCase):
         # copy
         arr = np.array(self.strIndex)
         index = Index(arr, copy=True, name='name')
-        tm.assert_isinstance(index, Index)
+        tm.assertIsInstance(index, Index)
         self.assertEqual(index.name, 'name')
         assert_array_equal(arr, index)
         arr[0] = "SOMEBIGLONGSTRING"
@@ -507,7 +507,7 @@ class TestIndex(Base, tm.TestCase):
         xp = period_range('2012-1-1', freq='M', periods=3)
         rs = Index(xp)
         assert_array_equal(rs, xp)
-        tm.assert_isinstance(rs, PeriodIndex)
+        tm.assertIsInstance(rs, PeriodIndex)
 
     def test_constructor_simple_new(self):
         idx = Index([1, 2, 3, 4, 5], name='int')
@@ -664,7 +664,7 @@ class TestIndex(Base, tm.TestCase):
         self.assertEqual(self.dateIndex.asof(d + timedelta(1)), d)
 
         d = self.dateIndex[0].to_datetime()
-        tm.assert_isinstance(self.dateIndex.asof(d), Timestamp)
+        tm.assertIsInstance(self.dateIndex.asof(d), Timestamp)
 
     def test_asof_datetime_partial(self):
         idx = pd.date_range('2010-01-01', periods=2, freq='m')
@@ -2272,11 +2272,11 @@ class TestInt64Index(Numeric, tm.TestCase):
     def test_coerce_list(self):
         # coerce things
         arr = Index([1, 2, 3, 4])
-        tm.assert_isinstance(arr, Int64Index)
+        tm.assertIsInstance(arr, Int64Index)
 
         # but not if explicit dtype passed
         arr = Index([1, 2, 3, 4], dtype=object)
-        tm.assert_isinstance(arr, Index)
+        tm.assertIsInstance(arr, Index)
 
     def test_dtype(self):
         self.assertEqual(self.index.dtype, np.int64)
@@ -2374,7 +2374,7 @@ class TestInt64Index(Numeric, tm.TestCase):
         eridx = np.array([-1, 3, 4, -1, 5, -1, 0, -1, -1, 1, -1, -1, -1, 2],
                          dtype=np.int64)
 
-        tm.assert_isinstance(res, Int64Index)
+        tm.assertIsInstance(res, Int64Index)
         self.assertTrue(res.equals(eres))
         self.assert_numpy_array_equal(lidx, elidx)
         self.assert_numpy_array_equal(ridx, eridx)
@@ -2387,7 +2387,7 @@ class TestInt64Index(Numeric, tm.TestCase):
 
         eridx = np.array([-1, 0, 1, -1, 2, -1, 3, -1, -1, 4, -1, -1, -1, 5],
                          dtype=np.int64)
-        tm.assert_isinstance(res, Int64Index)
+        tm.assertIsInstance(res, Int64Index)
         self.assertTrue(res.equals(eres))
         self.assert_numpy_array_equal(lidx, elidx)
         self.assert_numpy_array_equal(ridx, eridx)
@@ -2410,7 +2410,7 @@ class TestInt64Index(Numeric, tm.TestCase):
         elidx = np.array([1, 6])
         eridx = np.array([4, 1])
 
-        tm.assert_isinstance(res, Int64Index)
+        tm.assertIsInstance(res, Int64Index)
         self.assertTrue(res.equals(eres))
         self.assert_numpy_array_equal(lidx, elidx)
         self.assert_numpy_array_equal(ridx, eridx)
@@ -2423,7 +2423,7 @@ class TestInt64Index(Numeric, tm.TestCase):
         self.assertTrue(res.equals(res2))
 
         eridx = np.array([1, 4])
-        tm.assert_isinstance(res, Int64Index)
+        tm.assertIsInstance(res, Int64Index)
         self.assertTrue(res.equals(eres))
         self.assert_numpy_array_equal(lidx, elidx)
         self.assert_numpy_array_equal(ridx, eridx)
@@ -2439,7 +2439,7 @@ class TestInt64Index(Numeric, tm.TestCase):
         eridx = np.array([-1, 4, -1, -1, -1, -1, 1, -1, -1, -1],
                          dtype=np.int64)
 
-        tm.assert_isinstance(res, Int64Index)
+        tm.assertIsInstance(res, Int64Index)
         self.assertTrue(res.equals(eres))
         self.assertIsNone(lidx)
         self.assert_numpy_array_equal(ridx, eridx)
@@ -2449,7 +2449,7 @@ class TestInt64Index(Numeric, tm.TestCase):
                                           return_indexers=True)
         eridx = np.array([-1, 1, -1, -1, -1, -1, 4, -1, -1, -1],
                          dtype=np.int64)
-        tm.assert_isinstance(res, Int64Index)
+        tm.assertIsInstance(res, Int64Index)
         self.assertTrue(res.equals(eres))
         self.assertIsNone(lidx)
         self.assert_numpy_array_equal(ridx, eridx)
@@ -2478,7 +2478,7 @@ class TestInt64Index(Numeric, tm.TestCase):
         elidx = np.array([-1, 6, -1, -1, 1, -1],
                          dtype=np.int64)
 
-        tm.assert_isinstance(other, Int64Index)
+        tm.assertIsInstance(other, Int64Index)
         self.assertTrue(res.equals(eres))
         self.assert_numpy_array_equal(lidx, elidx)
         self.assertIsNone(ridx)
@@ -2489,7 +2489,7 @@ class TestInt64Index(Numeric, tm.TestCase):
         eres = other_mono
         elidx = np.array([-1, 1, -1, -1, 6, -1],
                          dtype=np.int64)
-        tm.assert_isinstance(other, Int64Index)
+        tm.assertIsInstance(other, Int64Index)
         self.assertTrue(res.equals(eres))
         self.assert_numpy_array_equal(lidx, elidx)
         self.assertIsNone(ridx)
@@ -3339,7 +3339,7 @@ class TestMultiIndex(Base, tm.TestCase):
         single_level = MultiIndex(levels=[['foo', 'bar', 'baz', 'qux']],
                                   labels=[[0, 1, 2, 3]],
                                   names=['first'])
-        tm.assert_isinstance(single_level, Index)
+        tm.assertIsInstance(single_level, Index)
         self.assertNotIsInstance(single_level, MultiIndex)
         self.assertEqual(single_level.name, 'first')
 
@@ -4149,7 +4149,7 @@ class TestMultiIndex(Base, tm.TestCase):
                                           sortorder=0,
                                           names=self.index.names)
 
-        tm.assert_isinstance(result, MultiIndex)
+        tm.assertIsInstance(result, MultiIndex)
         self.assertTrue(result.equals(expected))
         self.assertEqual(result.names, self.index.names)
 
@@ -4459,7 +4459,7 @@ class TestMultiIndex(Base, tm.TestCase):
         # some corner cases
         idx = Index(['three', 'one', 'two'])
         result = idx.join(self.index, level='second')
-        tm.assert_isinstance(result, MultiIndex)
+        tm.assertIsInstance(result, MultiIndex)
 
         assertRaisesRegexp(TypeError, "Join.*MultiIndex.*ambiguous",
                            self.index.join, self.index, level=1)
@@ -4473,11 +4473,11 @@ class TestMultiIndex(Base, tm.TestCase):
 
     def test_reindex(self):
         result, indexer = self.index.reindex(list(self.index[:4]))
-        tm.assert_isinstance(result, MultiIndex)
+        tm.assertIsInstance(result, MultiIndex)
         self.check_level_names(result, self.index[:4].names)
 
         result, indexer = self.index.reindex(list(self.index))
-        tm.assert_isinstance(result, MultiIndex)
+        tm.assertIsInstance(result, MultiIndex)
         self.assertIsNone(indexer)
         self.check_level_names(result, self.index.names)
 

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -814,7 +814,7 @@ class TestIndexing(tm.TestCase):
         # Regression in chained getitem indexing with embedded list-like from 0.12
         def check(result, expected):
             self.assert_numpy_array_equal(result,expected)
-            tm.assert_isinstance(result, np.ndarray)
+            tm.assertIsInstance(result, np.ndarray)
 
 
         df = DataFrame({'A': 5*[np.zeros(3)], 'B':5*[np.ones(3)]})

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -117,26 +117,26 @@ class TestMultiLevel(tm.TestCase):
         multi = DataFrame(np.random.randn(4, 4),
                           index=[np.array(['a', 'a', 'b', 'b']),
                                  np.array(['x', 'y', 'x', 'y'])])
-        tm.assert_isinstance(multi.index, MultiIndex)
+        tm.assertIsInstance(multi.index, MultiIndex)
         self.assertNotIsInstance(multi.columns, MultiIndex)
 
         multi = DataFrame(np.random.randn(4, 4),
                           columns=[['a', 'a', 'b', 'b'],
                                    ['x', 'y', 'x', 'y']])
-        tm.assert_isinstance(multi.columns, MultiIndex)
+        tm.assertIsInstance(multi.columns, MultiIndex)
 
     def test_series_constructor(self):
         multi = Series(1., index=[np.array(['a', 'a', 'b', 'b']),
                                   np.array(['x', 'y', 'x', 'y'])])
-        tm.assert_isinstance(multi.index, MultiIndex)
+        tm.assertIsInstance(multi.index, MultiIndex)
 
         multi = Series(1., index=[['a', 'a', 'b', 'b'],
                                   ['x', 'y', 'x', 'y']])
-        tm.assert_isinstance(multi.index, MultiIndex)
+        tm.assertIsInstance(multi.index, MultiIndex)
 
         multi = Series(lrange(4), index=[['a', 'a', 'b', 'b'],
                                         ['x', 'y', 'x', 'y']])
-        tm.assert_isinstance(multi.index, MultiIndex)
+        tm.assertIsInstance(multi.index, MultiIndex)
 
     def test_reindex_level(self):
         # axis=0
@@ -702,7 +702,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         s = dft['foo', 'two']
         dft['foo', 'two'] = s > s.median()
         assert_series_equal(dft['foo', 'two'], s > s.median())
-        # tm.assert_isinstance(dft._data.blocks[1].items, MultiIndex)
+        # tm.assertIsInstance(dft._data.blocks[1].items, MultiIndex)
 
         reindexed = dft.reindex(columns=[('foo', 'two')])
         assert_series_equal(reindexed['foo', 'two'], s > s.median())
@@ -798,12 +798,12 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         self.assertEqual(len(deleveled.columns), len(self.ymd.columns))
 
         deleveled = self.series.reset_index()
-        tm.assert_isinstance(deleveled, DataFrame)
+        tm.assertIsInstance(deleveled, DataFrame)
         self.assertEqual(len(deleveled.columns),
                          len(self.series.index.levels) + 1)
 
         deleveled = self.series.reset_index(drop=True)
-        tm.assert_isinstance(deleveled, Series)
+        tm.assertIsInstance(deleveled, Series)
 
     def test_sortlevel_by_name(self):
         self.frame.index.names = ['first', 'second']
@@ -1325,7 +1325,7 @@ Thur,Lunch,Yes,51.51,17"""
     def test_insert_index(self):
         df = self.ymd[:5].T
         df[2000, 1, 10] = df[2000, 1, 7]
-        tm.assert_isinstance(df.columns, MultiIndex)
+        tm.assertIsInstance(df.columns, MultiIndex)
         self.assertTrue((df[2000, 1, 10] == df[2000, 1, 7]).all())
 
     def test_alignment(self):
@@ -1994,7 +1994,7 @@ Thur,Lunch,Yes,51.51,17"""
 
         result = frame.ix[:, 1]
         exp = frame.icol(1)
-        tm.assert_isinstance(result, Series)
+        tm.assertIsInstance(result, Series)
         assert_series_equal(result, exp)
 
     def test_nonunique_assignment_1750(self):

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -821,7 +821,7 @@ class CheckIndexing(object):
 
         # resize
         res = self.panel.set_value('ItemE', 'foo', 'bar', 1.5)
-        tm.assert_isinstance(res, Panel)
+        tm.assertIsInstance(res, Panel)
         self.assertIsNot(res, self.panel)
         self.assertEqual(res.get_value('ItemE', 'foo', 'bar'), 1.5)
 

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -584,7 +584,7 @@ class CheckIndexing(object):
 
         # resize
         res = self.panel4d.set_value('l4', 'ItemE', 'foo', 'bar', 1.5)
-        tm.assert_isinstance(res, Panel4D)
+        tm.assertIsInstance(res, Panel4D)
         self.assertIsNot(res, self.panel4d)
         self.assertEqual(res.get_value('l4', 'ItemE', 'foo', 'bar'), 1.5)
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -781,7 +781,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         df = tm.makeTimeDataFrame()
         objs = [df, df]
         s = Series(objs, index=[0, 1])
-        tm.assert_isinstance(s, Series)
+        tm.assertIsInstance(s, Series)
 
     def test_constructor_sanitize(self):
         s = Series(np.array([1., 1., 8.]), dtype='i8')
@@ -1069,7 +1069,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # works
         series = self.series.copy()
         series.index = np.arange(len(series))
-        tm.assert_isinstance(series.index, Index)
+        tm.assertIsInstance(series.index, Index)
 
     def test_array_finalize(self):
         pass
@@ -1326,7 +1326,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
     def test_getitem_box_float64(self):
         value = self.ts[5]
-        tm.assert_isinstance(value, np.float64)
+        tm.assertIsInstance(value, np.float64)
 
     def test_getitem_ambiguous_keyerror(self):
         s = Series(lrange(10), index=lrange(0, 20, 2))
@@ -3132,7 +3132,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # scalar Timestamp on rhs
         maxa = df['A'].max()
-        tm.assert_isinstance(maxa, Timestamp)
+        tm.assertIsInstance(maxa, Timestamp)
 
         resultb = df['A'] - df['A'].max()
         self.assertEqual(resultb.dtype, 'timedelta64[ns]')
@@ -5102,7 +5102,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         result = self.ts.clip(-0.5, 0.5)
         expected = np.clip(self.ts, -0.5, 0.5)
         assert_series_equal(result, expected)
-        tm.assert_isinstance(expected, Series)
+        tm.assertIsInstance(expected, Series)
 
     def test_clip_types_and_nulls(self):
 
@@ -5798,7 +5798,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         result = self.series.map(lambda x: Decimal(str(x)))
         self.assertEqual(result.dtype, np.object_)
-        tm.assert_isinstance(result[0], Decimal)
+        tm.assertIsInstance(result[0], Decimal)
 
     def test_map_na_exclusion(self):
         s = Series([1.5, np.nan, 3, np.nan, 5])
@@ -5980,7 +5980,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         result = s.apply(str.split, args=(',',))
         self.assertEqual(result[0], ['foo', 'bar'])
-        tm.assert_isinstance(result[0], list)
+        tm.assertIsInstance(result[0], list)
 
     def test_align(self):
         def _check_align(a, b, how='left', fill=None):
@@ -7081,7 +7081,7 @@ class TestSeriesNonUnique(tm.TestCase):
 
         rs = s.reset_index(level=[0, 2], drop=True)
         self.assertTrue(rs.index.equals(Index(index.get_level_values(1))))
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
 
     def test_set_index_makes_timeseries(self):
         idx = tm.makeDateIndex(10)

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -49,7 +49,7 @@ class TestStringMethods(tm.TestCase):
 
         for s in ds.str:
             # iter must yield a Series
-            tm.assert_isinstance(s, Series)
+            tm.assertIsInstance(s, Series)
 
             # indices of each yielded Series should be equal to the index of
             # the original Series
@@ -135,7 +135,7 @@ class TestStringMethods(tm.TestCase):
         tm.assert_almost_equal(result, exp)
 
         result = Series(values).str.count('f[o]+')
-        tm.assert_isinstance(result, Series)
+        tm.assertIsInstance(result, Series)
         tm.assert_almost_equal(result, exp)
 
         # mixed
@@ -145,7 +145,7 @@ class TestStringMethods(tm.TestCase):
         tm.assert_almost_equal(rs, xp)
 
         rs = Series(mixed).str.count('a')
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         # unicode
@@ -156,7 +156,7 @@ class TestStringMethods(tm.TestCase):
         tm.assert_almost_equal(result, exp)
 
         result = Series(values).str.count('f[o]+')
-        tm.assert_isinstance(result, Series)
+        tm.assertIsInstance(result, Series)
         tm.assert_almost_equal(result, exp)
 
     def test_contains(self):
@@ -195,7 +195,7 @@ class TestStringMethods(tm.TestCase):
         tm.assert_almost_equal(rs, xp)
 
         rs = Series(mixed).str.contains('o')
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         # unicode
@@ -235,7 +235,7 @@ class TestStringMethods(tm.TestCase):
         tm.assert_almost_equal(rs, xp)
 
         rs = Series(mixed).str.startswith('f')
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         # unicode
@@ -263,7 +263,7 @@ class TestStringMethods(tm.TestCase):
         tm.assert_almost_equal(rs, xp)
 
         rs = Series(mixed).str.endswith('f')
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         # unicode
@@ -315,7 +315,7 @@ class TestStringMethods(tm.TestCase):
         mixed = mixed.str.upper()
         rs = Series(mixed).str.lower()
         xp = ['a', NA, 'b', NA, NA, 'foo', NA, NA, NA]
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         # unicode
@@ -392,7 +392,7 @@ class TestStringMethods(tm.TestCase):
 
         rs = Series(mixed).str.replace('BAD[_]*', '')
         xp = ['a', NA, 'b', NA, NA, 'foo', NA, NA, NA]
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         # unicode
@@ -429,7 +429,7 @@ class TestStringMethods(tm.TestCase):
 
         rs = Series(mixed).str.repeat(3)
         xp = ['aaa', NA, 'bbb', NA, NA, 'foofoofoo', NA, NA, NA]
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         # unicode
@@ -462,7 +462,7 @@ class TestStringMethods(tm.TestCase):
         with tm.assert_produces_warning():
             rs = Series(mixed).str.match('.*(BAD[_]+).*(BAD)')
         xp = [('BAD_', 'BAD'), NA, ('BAD_', 'BAD'), NA, NA, [], NA, NA, NA]
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         # unicode
@@ -495,7 +495,7 @@ class TestStringMethods(tm.TestCase):
         with tm.assert_produces_warning():
             rs = Series(mixed).str.match('.*(BAD[_]+).*(BAD)', as_indexer=True)
         xp = [True, NA, True, NA, NA, False, NA, NA, NA]
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         # unicode
@@ -796,7 +796,7 @@ class TestStringMethods(tm.TestCase):
         rs = Series(mixed).str.split('_').str.join('_')
         xp = Series(['a_b', NA, 'asdf_cas_asdf', NA, NA, 'foo', NA, NA, NA])
 
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         # unicode
@@ -819,7 +819,7 @@ class TestStringMethods(tm.TestCase):
         rs = Series(mixed).str.len()
         xp = Series([3, NA, 13, NA, NA, 3, NA, NA, NA])
 
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         # unicode
@@ -844,7 +844,7 @@ class TestStringMethods(tm.TestCase):
         rs = Series(mixed).str.findall('BAD[_]*')
         xp = Series([['BAD__', 'BAD'], NA, [], NA, NA, ['BAD'], NA, NA, NA])
 
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         # unicode
@@ -982,7 +982,7 @@ class TestStringMethods(tm.TestCase):
         rs = Series(mixed).str.pad(5, side='left')
         xp = Series(['    a', NA, '    b', NA, NA, '   ee', NA, NA, NA])
 
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         mixed = Series(['a', NA, 'b', True, datetime.today(),
@@ -991,7 +991,7 @@ class TestStringMethods(tm.TestCase):
         rs = Series(mixed).str.pad(5, side='right')
         xp = Series(['a    ', NA, 'b    ', NA, NA, 'ee   ', NA, NA, NA])
 
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         mixed = Series(['a', NA, 'b', True, datetime.today(),
@@ -1000,7 +1000,7 @@ class TestStringMethods(tm.TestCase):
         rs = Series(mixed).str.pad(5, side='both')
         xp = Series(['  a  ', NA, '  b  ', NA, NA, '  ee ', NA, NA, NA])
 
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         # unicode
@@ -1097,19 +1097,19 @@ class TestStringMethods(tm.TestCase):
         rs = Series(mixed).str.center(5)
         xp = Series(['  a  ', NA, '  b  ', NA, NA, '  c  ', ' eee ', NA, NA,
                      NA])
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         rs = Series(mixed).str.ljust(5)
         xp = Series(['a    ', NA, 'b    ', NA, NA, 'c    ', 'eee  ', NA, NA,
                      NA])
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         rs = Series(mixed).str.rjust(5)
         xp = Series(['    a', NA, '    b', NA, NA, '    c', '  eee', NA, NA,
                      NA])
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         # unicode
@@ -1214,11 +1214,11 @@ class TestStringMethods(tm.TestCase):
         result = mixed.str.split('_')
         exp = Series([['a', 'b', 'c'], NA, ['d', 'e', 'f'], NA, NA,
                      NA, NA, NA])
-        tm.assert_isinstance(result, Series)
+        tm.assertIsInstance(result, Series)
         tm.assert_almost_equal(result, exp)
 
         result = mixed.str.split('_', expand=False)
-        tm.assert_isinstance(result, Series)
+        tm.assertIsInstance(result, Series)
         tm.assert_almost_equal(result, exp)
 
         # unicode
@@ -1261,11 +1261,11 @@ class TestStringMethods(tm.TestCase):
         result = mixed.str.rsplit('_')
         exp = Series([['a', 'b', 'c'], NA, ['d', 'e', 'f'], NA, NA,
                      NA, NA, NA])
-        tm.assert_isinstance(result, Series)
+        tm.assertIsInstance(result, Series)
         tm.assert_almost_equal(result, exp)
 
         result = mixed.str.rsplit('_', expand=False)
-        tm.assert_isinstance(result, Series)
+        tm.assertIsInstance(result, Series)
         tm.assert_almost_equal(result, exp)
 
         # unicode
@@ -1612,7 +1612,7 @@ class TestStringMethods(tm.TestCase):
         xp = Series(['foo', NA, 'bar', NA, NA,
                      NA, NA, NA])
 
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         rs = Series(mixed).str.slice(2, 5, -1)
@@ -1690,21 +1690,21 @@ class TestStringMethods(tm.TestCase):
         xp = Series(['aa', NA, 'bb', NA, NA,
                      NA, NA, NA])
 
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         rs = Series(mixed).str.lstrip()
         xp = Series(['aa  ', NA, 'bb \t\n', NA, NA,
                      NA, NA, NA])
 
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         rs = Series(mixed).str.rstrip()
         xp = Series(['  aa', NA, ' bb', NA, NA,
                      NA, NA, NA])
 
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
     def test_strip_lstrip_rstrip_unicode(self):
@@ -1797,7 +1797,7 @@ class TestStringMethods(tm.TestCase):
         xp = Series(['b', NA, 'd', NA, NA,
                      NA, NA, NA])
 
-        tm.assert_isinstance(rs, Series)
+        tm.assertIsInstance(rs, Series)
         tm.assert_almost_equal(rs, xp)
 
         # unicode

--- a/pandas/tests/test_testing.py
+++ b/pandas/tests/test_testing.py
@@ -7,15 +7,16 @@ import nose
 import numpy as np
 import sys
 from pandas import Series, DataFrame
+import pandas.util.testing as tm
 from pandas.util.testing import (
-    assert_almost_equal, assertRaisesRegexp, raise_with_traceback, 
-    assert_series_equal, assert_frame_equal,
+    assert_almost_equal, assertRaisesRegexp, raise_with_traceback,
+    assert_series_equal, assert_frame_equal, assert_isinstance,
     RNGContext
 )
 
 # let's get meta.
 
-class TestAssertAlmostEqual(unittest.TestCase):
+class TestAssertAlmostEqual(tm.TestCase):
     _multiprocess_can_split_ = True
 
     def _assert_almost_equal_both(self, a, b, **kwargs):
@@ -112,7 +113,8 @@ class TestAssertAlmostEqual(unittest.TestCase):
 
         self._assert_not_almost_equal_both(np.inf, 0)
 
-class TestUtilTesting(unittest.TestCase):
+
+class TestUtilTesting(tm.TestCase):
     _multiprocess_can_split_ = True
 
     def test_raise_with_traceback(self):
@@ -130,7 +132,8 @@ class TestUtilTesting(unittest.TestCase):
                 _, _, traceback = sys.exc_info()
                 raise_with_traceback(e, traceback)
 
-class TestAssertSeriesEqual(unittest.TestCase):
+
+class TestAssertSeriesEqual(tm.TestCase):
     _multiprocess_can_split_ = True
 
     def _assert_equal(self, x, y, **kwargs):
@@ -190,7 +193,7 @@ class TestAssertSeriesEqual(unittest.TestCase):
         self._assert_not_equal(df1.c, df2.c, check_index_type=True)
 
 
-class TestAssertFrameEqual(unittest.TestCase):
+class TestAssertFrameEqual(tm.TestCase):
     _multiprocess_can_split_ = True
 
     def _assert_equal(self, x, y, **kwargs):
@@ -221,7 +224,7 @@ class TestAssertFrameEqual(unittest.TestCase):
         df2=pd.DataFrame(columns=["col1","col2"])
         self._assert_equal(df1, df2, check_dtype=False)
         self._assert_not_equal(df1, df2, check_dtype=True)
-        
+
 
 class TestRNGContext(unittest.TestCase):
 
@@ -233,3 +236,43 @@ class TestRNGContext(unittest.TestCase):
             with RNGContext(1):
                 self.assertEqual(np.random.randn(), expected1)
             self.assertEqual(np.random.randn(), expected0)
+
+
+
+class TestDeprecatedTests(tm.TestCase):
+
+    def test_warning(self):
+
+        with tm.assert_produces_warning(FutureWarning):
+            self.assertEquals(1, 1)
+
+        with tm.assert_produces_warning(FutureWarning):
+            self.assertNotEquals(1, 2)
+
+        with tm.assert_produces_warning(FutureWarning):
+            self.assert_(True)
+
+        with tm.assert_produces_warning(FutureWarning):
+            self.assertAlmostEquals(1.0, 1.0000000001)
+
+        with tm.assert_produces_warning(FutureWarning):
+            self.assertNotAlmostEquals(1, 2)
+
+        with tm.assert_produces_warning(FutureWarning):
+            assert_isinstance(Series([1, 2]), Series, msg='xxx')
+
+
+class TestLocale(tm.TestCase):
+
+    def test_locale(self):
+        if sys.platform == 'win32':
+            raise nose.SkipTest("skipping on win platforms as locale not available")
+
+        #GH9744
+        locales = tm.get_locales()
+        self.assertTrue(len(locales) >= 1)
+
+
+if __name__ == '__main__':
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   exit=False)

--- a/pandas/tests/test_util.py
+++ b/pandas/tests/test_util.py
@@ -61,33 +61,6 @@ class TestDecorators(tm.TestCase):
                 pass
 
 
-class TestTesting(tm.TestCase):
-
-    def test_warning(self):
-
-        with tm.assert_produces_warning(FutureWarning):
-            self.assertEquals(1, 1)
-
-        with tm.assert_produces_warning(FutureWarning):
-            self.assertNotEquals(1, 2)
-
-        with tm.assert_produces_warning(FutureWarning):
-            self.assert_(True)
-
-        with tm.assert_produces_warning(FutureWarning):
-            self.assertAlmostEquals(1.0, 1.0000000001)
-
-        with tm.assert_produces_warning(FutureWarning):
-            self.assertNotAlmostEquals(1, 2)
-
-    def test_locale(self):
-        if sys.platform == 'win32':
-            raise nose.SkipTest("skipping on win platforms as locale not available")
-
-        #GH9744
-        locales = pandas.util.testing.get_locales()
-        self.assertTrue(len(locales) >= 1)
-
 def test_rands():
     r = tm.rands(10)
     assert(len(r) == 10)

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -790,7 +790,7 @@ class TestMerge(tm.TestCase):
         nad = NotADataFrame(self.df)
         result = nad.merge(self.df2, on='key1')
 
-        tm.assert_isinstance(result, NotADataFrame)
+        tm.assertIsInstance(result, NotADataFrame)
 
     def test_append_dtype_coerce(self):
 
@@ -2535,7 +2535,7 @@ class TestOrderedMerge(tm.TestCase):
         nad = NotADataFrame(self.left)
         result = nad.merge(self.right, on='key')
 
-        tm.assert_isinstance(result, NotADataFrame)
+        tm.assertIsInstance(result, NotADataFrame)
 
 
 if __name__ == '__main__':

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -268,7 +268,7 @@ class TestPivotTable(tm.TestCase):
         # no rows
         rtable = self.data.pivot_table(columns=['AA', 'BB'], margins=True,
                                        aggfunc=np.mean)
-        tm.assert_isinstance(rtable, Series)
+        tm.assertIsInstance(rtable, Series)
         for item in ['DD', 'EE', 'FF']:
             gmarg = table[item]['All', '']
             self.assertEqual(gmarg, self.data[item].mean())

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 import numpy as np
 import pandas as pd
 from pandas.tseries.base import DatetimeIndexOpsMixin
-from pandas.util.testing import assertRaisesRegexp, assert_isinstance
+from pandas.util.testing import assertRaisesRegexp, assertIsInstance
 from pandas.tseries.common import is_datetimelike
 from pandas import (Series, Index, Int64Index, Timestamp, DatetimeIndex, PeriodIndex,
                     TimedeltaIndex, Timedelta, timedelta_range, date_range, Float64Index)

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -138,7 +138,7 @@ class TestDateRange(tm.TestCase):
 
         fancy_indexed = self.rng[[4, 3, 2, 1, 0]]
         self.assertEqual(len(fancy_indexed), 5)
-        tm.assert_isinstance(fancy_indexed, DatetimeIndex)
+        tm.assertIsInstance(fancy_indexed, DatetimeIndex)
         self.assertIsNone(fancy_indexed.freq)
 
         # 32-bit vs. 64-bit platforms
@@ -176,21 +176,21 @@ class TestDateRange(tm.TestCase):
         right = self.rng[5:10]
 
         the_union = left.union(right)
-        tm.assert_isinstance(the_union, DatetimeIndex)
+        tm.assertIsInstance(the_union, DatetimeIndex)
 
         # non-overlapping, gap in middle
         left = self.rng[:5]
         right = self.rng[10:]
 
         the_union = left.union(right)
-        tm.assert_isinstance(the_union, Index)
+        tm.assertIsInstance(the_union, Index)
 
         # non-overlapping, no gap
         left = self.rng[:5]
         right = self.rng[5:10]
 
         the_union = left.union(right)
-        tm.assert_isinstance(the_union, DatetimeIndex)
+        tm.assertIsInstance(the_union, DatetimeIndex)
 
         # order does not matter
         self.assert_numpy_array_equal(right.union(left), the_union)
@@ -199,7 +199,7 @@ class TestDateRange(tm.TestCase):
         rng = date_range(START, END, freq=datetools.bmonthEnd)
 
         the_union = self.rng.union(rng)
-        tm.assert_isinstance(the_union, DatetimeIndex)
+        tm.assertIsInstance(the_union, DatetimeIndex)
 
     def test_outer_join(self):
         # should just behave as union
@@ -209,14 +209,14 @@ class TestDateRange(tm.TestCase):
         right = self.rng[5:10]
 
         the_join = left.join(right, how='outer')
-        tm.assert_isinstance(the_join, DatetimeIndex)
+        tm.assertIsInstance(the_join, DatetimeIndex)
 
         # non-overlapping, gap in middle
         left = self.rng[:5]
         right = self.rng[10:]
 
         the_join = left.join(right, how='outer')
-        tm.assert_isinstance(the_join, DatetimeIndex)
+        tm.assertIsInstance(the_join, DatetimeIndex)
         self.assertIsNone(the_join.freq)
 
         # non-overlapping, no gap
@@ -224,13 +224,13 @@ class TestDateRange(tm.TestCase):
         right = self.rng[5:10]
 
         the_join = left.join(right, how='outer')
-        tm.assert_isinstance(the_join, DatetimeIndex)
+        tm.assertIsInstance(the_join, DatetimeIndex)
 
         # overlapping, but different offset
         rng = date_range(START, END, freq=datetools.bmonthEnd)
 
         the_join = self.rng.join(rng, how='outer')
-        tm.assert_isinstance(the_join, DatetimeIndex)
+        tm.assertIsInstance(the_join, DatetimeIndex)
         self.assertIsNone(the_join.freq)
 
     def test_union_not_cacheable(self):
@@ -253,7 +253,7 @@ class TestDateRange(tm.TestCase):
         the_int = rng1.intersection(rng2)
         expected = rng[10:25]
         self.assertTrue(the_int.equals(expected))
-        tm.assert_isinstance(the_int, DatetimeIndex)
+        tm.assertIsInstance(the_int, DatetimeIndex)
         self.assertEqual(the_int.offset, rng.offset)
 
         the_int = rng1.intersection(rng2.view(DatetimeIndex))
@@ -333,7 +333,7 @@ class TestDateRange(tm.TestCase):
         rng2.offset = datetools.BDay()
 
         result = rng1.union(rng2)
-        tm.assert_isinstance(result, DatetimeIndex)
+        tm.assertIsInstance(result, DatetimeIndex)
 
     def test_error_with_zero_monthends(self):
         self.assertRaises(ValueError, date_range, '1/1/2000', '1/1/2001',
@@ -535,7 +535,7 @@ class TestCustomDateRange(tm.TestCase):
 
         fancy_indexed = self.rng[[4, 3, 2, 1, 0]]
         self.assertEqual(len(fancy_indexed), 5)
-        tm.assert_isinstance(fancy_indexed, DatetimeIndex)
+        tm.assertIsInstance(fancy_indexed, DatetimeIndex)
         self.assertIsNone(fancy_indexed.freq)
 
         # 32-bit vs. 64-bit platforms
@@ -573,21 +573,21 @@ class TestCustomDateRange(tm.TestCase):
         right = self.rng[5:10]
 
         the_union = left.union(right)
-        tm.assert_isinstance(the_union, DatetimeIndex)
+        tm.assertIsInstance(the_union, DatetimeIndex)
 
         # non-overlapping, gap in middle
         left = self.rng[:5]
         right = self.rng[10:]
 
         the_union = left.union(right)
-        tm.assert_isinstance(the_union, Index)
+        tm.assertIsInstance(the_union, Index)
 
         # non-overlapping, no gap
         left = self.rng[:5]
         right = self.rng[5:10]
 
         the_union = left.union(right)
-        tm.assert_isinstance(the_union, DatetimeIndex)
+        tm.assertIsInstance(the_union, DatetimeIndex)
 
         # order does not matter
         self.assert_numpy_array_equal(right.union(left), the_union)
@@ -596,7 +596,7 @@ class TestCustomDateRange(tm.TestCase):
         rng = date_range(START, END, freq=datetools.bmonthEnd)
 
         the_union = self.rng.union(rng)
-        tm.assert_isinstance(the_union, DatetimeIndex)
+        tm.assertIsInstance(the_union, DatetimeIndex)
 
     def test_outer_join(self):
         # should just behave as union
@@ -606,14 +606,14 @@ class TestCustomDateRange(tm.TestCase):
         right = self.rng[5:10]
 
         the_join = left.join(right, how='outer')
-        tm.assert_isinstance(the_join, DatetimeIndex)
+        tm.assertIsInstance(the_join, DatetimeIndex)
 
         # non-overlapping, gap in middle
         left = self.rng[:5]
         right = self.rng[10:]
 
         the_join = left.join(right, how='outer')
-        tm.assert_isinstance(the_join, DatetimeIndex)
+        tm.assertIsInstance(the_join, DatetimeIndex)
         self.assertIsNone(the_join.freq)
 
         # non-overlapping, no gap
@@ -621,13 +621,13 @@ class TestCustomDateRange(tm.TestCase):
         right = self.rng[5:10]
 
         the_join = left.join(right, how='outer')
-        tm.assert_isinstance(the_join, DatetimeIndex)
+        tm.assertIsInstance(the_join, DatetimeIndex)
 
         # overlapping, but different offset
         rng = date_range(START, END, freq=datetools.bmonthEnd)
 
         the_join = self.rng.join(rng, how='outer')
-        tm.assert_isinstance(the_join, DatetimeIndex)
+        tm.assertIsInstance(the_join, DatetimeIndex)
         self.assertIsNone(the_join.freq)
 
     def test_intersection_bug(self):
@@ -682,7 +682,7 @@ class TestCustomDateRange(tm.TestCase):
         rng2.offset = datetools.CDay()
 
         result = rng1.union(rng2)
-        tm.assert_isinstance(result, DatetimeIndex)
+        tm.assertIsInstance(result, DatetimeIndex)
 
     def test_cdaterange(self):
         rng = cdate_range('2013-05-01', periods=3)

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -79,7 +79,7 @@ def test_normalize_date():
 def test_to_m8():
     valb = datetime(2007, 10, 1)
     valu = _to_m8(valb)
-    tm.assert_isinstance(valu, np.datetime64)
+    tm.assertIsInstance(valu, np.datetime64)
     # assert valu == np.datetime64(datetime(2007,10,1))
 
 # def test_datetime64_box():

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -282,7 +282,7 @@ class TestPeriodProperties(tm.TestCase):
         p = Period('2000-1-1 12:34:12', freq='S')
         res = p.strftime('%Y-%m-%d %H:%M:%S')
         self.assertEqual(res,  '2000-01-01 12:34:12')
-        tm.assert_isinstance(res, compat.text_type) # GH3363
+        tm.assertIsInstance(res, compat.text_type) # GH3363
 
     def test_sub_delta(self):
         left, right = Period('2011', freq='A'), Period('2007', freq='A')
@@ -1192,7 +1192,7 @@ class TestPeriodIndex(tm.TestCase):
     def test_make_time_series(self):
         index = PeriodIndex(freq='A', start='1/1/2001', end='12/1/2009')
         series = Series(1, index=index)
-        tm.assert_isinstance(series, TimeSeries)
+        tm.assertIsInstance(series, TimeSeries)
 
     def test_astype(self):
         idx = period_range('1990', '2009', freq='A')
@@ -1350,7 +1350,7 @@ class TestPeriodIndex(tm.TestCase):
 
         result = idx[:, None]
         # MPL kludge
-        tm.assert_isinstance(result, PeriodIndex)
+        tm.assertIsInstance(result, PeriodIndex)
 
     def test_getitem_partial(self):
         rng = period_range('2007-01', periods=50, freq='M')
@@ -1442,7 +1442,7 @@ class TestPeriodIndex(tm.TestCase):
     def test_tolist(self):
         index = PeriodIndex(freq='A', start='1/1/2001', end='12/1/2009')
         rs = index.tolist()
-        [tm.assert_isinstance(x, Period) for x in rs]
+        [tm.assertIsInstance(x, Period) for x in rs]
 
         recon = PeriodIndex(rs)
         self.assertTrue(index.equals(recon))
@@ -1562,7 +1562,7 @@ class TestPeriodIndex(tm.TestCase):
         self.assertTrue(rs.equals(rng))
 
         rs = df.reset_index().set_index('index')
-        tm.assert_isinstance(rs.index, PeriodIndex)
+        tm.assertIsInstance(rs.index, PeriodIndex)
         self.assertTrue(rs.index.equals(rng))
 
     def test_period_set_index_reindex(self):
@@ -2212,7 +2212,7 @@ class TestPeriodIndex(tm.TestCase):
         index = PeriodIndex(start='1/1/10', periods=4, freq='B')
 
         result = list(index)
-        tm.assert_isinstance(result[0], Period)
+        tm.assertIsInstance(result[0], Period)
         self.assertEqual(result[0].freq, index.freq)
 
     def test_take(self):
@@ -2226,7 +2226,7 @@ class TestPeriodIndex(tm.TestCase):
 
         for taken in [taken1, taken2]:
             self.assertTrue(taken.equals(expected))
-            tm.assert_isinstance(taken, PeriodIndex)
+            tm.assertIsInstance(taken, PeriodIndex)
             self.assertEqual(taken.freq, index.freq)
             self.assertEqual(taken.name, expected.name)
 
@@ -2236,7 +2236,7 @@ class TestPeriodIndex(tm.TestCase):
         for kind in ['inner', 'outer', 'left', 'right']:
             joined = index.join(index[:-5], how=kind)
 
-            tm.assert_isinstance(joined, PeriodIndex)
+            tm.assertIsInstance(joined, PeriodIndex)
             self.assertEqual(joined.freq, index.freq)
 
     def test_join_self(self):
@@ -2409,7 +2409,7 @@ class TestPeriodIndex(tm.TestCase):
             res = index.map(t)
 
             # should return an array
-            tm.assert_isinstance(res, np.ndarray)
+            tm.assertIsInstance(res, np.ndarray)
 
             # preserve element types
             self.assertTrue(all(isinstance(resi, t) for resi in res))
@@ -2425,7 +2425,7 @@ class TestPeriodIndex(tm.TestCase):
         periods = list(rng)
 
         result = pd.Index(periods)
-        tm.assert_isinstance(result, PeriodIndex)
+        tm.assertIsInstance(result, PeriodIndex)
 
     def test_with_multi_index(self):
         # #1705
@@ -2434,9 +2434,9 @@ class TestPeriodIndex(tm.TestCase):
 
         s = Series([0, 1, 2, 3], index_as_arrays)
 
-        tm.assert_isinstance(s.index.levels[0], PeriodIndex)
+        tm.assertIsInstance(s.index.levels[0], PeriodIndex)
 
-        tm.assert_isinstance(s.index.values[0][0], Period)
+        tm.assertIsInstance(s.index.values[0][0], Period)
 
     def test_to_datetime_1703(self):
         index = period_range('1/1/2012', periods=4, freq='D')
@@ -2467,7 +2467,7 @@ class TestPeriodIndex(tm.TestCase):
 
         # drops index
         result = pd.concat([s1, s2])
-        tm.assert_isinstance(result.index, PeriodIndex)
+        tm.assertIsInstance(result.index, PeriodIndex)
         self.assertEqual(result.index[0], s1.index[0])
 
     def test_pickle_freq(self):

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -472,7 +472,7 @@ class TestTSPlot(tm.TestCase):
         self.assertEqual(len(lines), 1)
         l = lines[0]
         data = l.get_xydata()
-        tm.assert_isinstance(data, np.ma.core.MaskedArray)
+        tm.assertIsInstance(data, np.ma.core.MaskedArray)
         mask = data.mask
         self.assertTrue(mask[5:25, 1].all())
         plt.close(ax.get_figure())
@@ -486,7 +486,7 @@ class TestTSPlot(tm.TestCase):
         self.assertEqual(len(lines), 1)
         l = lines[0]
         data = l.get_xydata()
-        tm.assert_isinstance(data, np.ma.core.MaskedArray)
+        tm.assertIsInstance(data, np.ma.core.MaskedArray)
         mask = data.mask
         self.assertTrue(mask[2:5, 1].all())
         plt.close(ax.get_figure())
@@ -500,7 +500,7 @@ class TestTSPlot(tm.TestCase):
         self.assertEqual(len(lines), 1)
         l = lines[0]
         data = l.get_xydata()
-        tm.assert_isinstance(data, np.ma.core.MaskedArray)
+        tm.assertIsInstance(data, np.ma.core.MaskedArray)
         mask = data.mask
         self.assertTrue(mask[2:5, 1].all())
 
@@ -518,7 +518,7 @@ class TestTSPlot(tm.TestCase):
         self.assertEqual(len(ax.right_ax.get_lines()), 1)
         l = lines[0]
         data = l.get_xydata()
-        tm.assert_isinstance(data, np.ma.core.MaskedArray)
+        tm.assertIsInstance(data, np.ma.core.MaskedArray)
         mask = data.mask
         self.assertTrue(mask[5:25, 1].all())
 

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -463,7 +463,7 @@ class TestResample(tm.TestCase):
         bs = s.resample('B', closed='right', label='right')
         result = bs.resample('8H')
         self.assertEqual(len(result), 22)
-        tm.assert_isinstance(result.index.freq, offsets.DateOffset)
+        tm.assertIsInstance(result.index.freq, offsets.DateOffset)
         self.assertEqual(result.index.freq, offsets.Hour(8))
 
     def test_resample_timestamp_to_period(self):
@@ -789,7 +789,7 @@ class TestResample(tm.TestCase):
         ts = Series(np.random.randn(len(rng)), index=rng)
 
         result = ts.resample('20min', how=['mean', 'sum'])
-        tm.assert_isinstance(result, DataFrame)
+        tm.assertIsInstance(result, DataFrame)
 
     def test_resample_not_monotonic(self):
         rng = pd.date_range('2012-06-12', periods=200, freq='h')

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -877,7 +877,7 @@ class TestTimedeltaIndex(tm.TestCase):
         idx = Index(['a', 'b', 'c', 'd'])
 
         result = rng.append(idx)
-        tm.assert_isinstance(result[0], Timedelta)
+        tm.assertIsInstance(result[0], Timedelta)
 
         # it works
         rng.join(idx, how='outer')
@@ -1103,7 +1103,7 @@ class TestTimedeltaIndex(tm.TestCase):
 
         rng = timedelta_range('1 day', periods=5)
         result = rng.groupby(rng.days)
-        tm.assert_isinstance(list(result.values())[0][0], Timedelta)
+        tm.assertIsInstance(list(result.values())[0][0], Timedelta)
 
         idx = TimedeltaIndex(['3d','1d','2d'])
         self.assertTrue(idx.equals(list(idx)))
@@ -1309,7 +1309,7 @@ class TestTimedeltaIndex(tm.TestCase):
 
         for taken in [taken1, taken2]:
             self.assertTrue(taken.equals(expected))
-            tm.assert_isinstance(taken, TimedeltaIndex)
+            tm.assertIsInstance(taken, TimedeltaIndex)
             self.assertIsNone(taken.freq)
             self.assertEqual(taken.name, expected.name)
 

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -68,8 +68,8 @@ class TestTimeSeriesDuplicates(tm.TestCase):
         self.dups = Series(np.random.randn(len(dates)), index=dates)
 
     def test_constructor(self):
-        tm.assert_isinstance(self.dups, TimeSeries)
-        tm.assert_isinstance(self.dups.index, DatetimeIndex)
+        tm.assertIsInstance(self.dups, TimeSeries)
+        tm.assertIsInstance(self.dups.index, DatetimeIndex)
 
     def test_is_unique_monotonic(self):
         self.assertFalse(self.dups.index.is_unique)
@@ -369,13 +369,13 @@ class TestTimeSeries(tm.TestCase):
         rng = date_range('20090415', '20090519', freq='B')
         s = Series(rng)
 
-        tm.assert_isinstance(s[5], Timestamp)
+        tm.assertIsInstance(s[5], Timestamp)
 
         rng = date_range('20090415', '20090519', freq='B')
         s = Series(rng, index=rng)
-        tm.assert_isinstance(s[5], Timestamp)
+        tm.assertIsInstance(s[5], Timestamp)
 
-        tm.assert_isinstance(s.iget_value(5), Timestamp)
+        tm.assertIsInstance(s.iget_value(5), Timestamp)
 
     def test_date_range_ambiguous_arguments(self):
         # #2538
@@ -433,9 +433,9 @@ class TestTimeSeries(tm.TestCase):
 
         def _check_rng(rng):
             converted = rng.to_pydatetime()
-            tm.assert_isinstance(converted, np.ndarray)
+            tm.assertIsInstance(converted, np.ndarray)
             for x, stamp in zip(converted, rng):
-                tm.assert_isinstance(x, datetime)
+                tm.assertIsInstance(x, datetime)
                 self.assertEqual(x, stamp.to_pydatetime())
                 self.assertEqual(x.tzinfo, stamp.tzinfo)
 
@@ -453,9 +453,9 @@ class TestTimeSeries(tm.TestCase):
 
         def _check_rng(rng):
             converted = rng.to_pydatetime()
-            tm.assert_isinstance(converted, np.ndarray)
+            tm.assertIsInstance(converted, np.ndarray)
             for x, stamp in zip(converted, rng):
-                tm.assert_isinstance(x, datetime)
+                tm.assertIsInstance(x, datetime)
                 self.assertEqual(x, stamp.to_pydatetime())
                 self.assertEqual(x.tzinfo, stamp.tzinfo)
 
@@ -473,9 +473,9 @@ class TestTimeSeries(tm.TestCase):
 
         def _check_rng(rng):
             converted = rng.to_pydatetime()
-            tm.assert_isinstance(converted, np.ndarray)
+            tm.assertIsInstance(converted, np.ndarray)
             for x, stamp in zip(converted, rng):
-                tm.assert_isinstance(x, datetime)
+                tm.assertIsInstance(x, datetime)
                 self.assertEqual(x, stamp.to_pydatetime())
                 self.assertEqual(x.tzinfo, stamp.tzinfo)
 
@@ -856,7 +856,7 @@ class TestTimeSeries(tm.TestCase):
         assert_almost_equal(result, expected)
 
         result2 = to_datetime(strings)
-        tm.assert_isinstance(result2, DatetimeIndex)
+        tm.assertIsInstance(result2, DatetimeIndex)
         self.assert_numpy_array_equal(result, result2)
 
         malformed = np.array(['1/100/2000', np.nan], dtype=object)
@@ -2092,7 +2092,7 @@ class TestDatetimeIndex(tm.TestCase):
         idx = Index(['a', 'b', 'c', 'd'])
 
         result = rng.append(idx)
-        tm.assert_isinstance(result[0], Timestamp)
+        tm.assertIsInstance(result[0], Timestamp)
 
         # it works
         rng.join(idx, how='outer')
@@ -2357,7 +2357,7 @@ class TestDatetimeIndex(tm.TestCase):
     def test_misc_coverage(self):
         rng = date_range('1/1/2000', periods=5)
         result = rng.groupby(rng.day)
-        tm.assert_isinstance(list(result.values())[0][0], Timestamp)
+        tm.assertIsInstance(list(result.values())[0][0], Timestamp)
 
         idx = DatetimeIndex(['2000-01-03', '2000-01-01', '2000-01-02'])
         self.assertTrue(idx.equals(list(idx)))
@@ -2643,7 +2643,7 @@ class TestDatetimeIndex(tm.TestCase):
 
             for taken in [taken1, taken2]:
                 self.assertTrue(taken.equals(expected))
-                tm.assert_isinstance(taken, DatetimeIndex)
+                tm.assertIsInstance(taken, DatetimeIndex)
                 self.assertIsNone(taken.freq)
                 self.assertEqual(taken.tz, expected.tz)
                 self.assertEqual(taken.name, expected.name)
@@ -2662,7 +2662,7 @@ class TestDatetimeIndex(tm.TestCase):
         monthly_group = df.groupby(lambda x: (x.year, x.month))
 
         result = monthly_group.mean()
-        tm.assert_isinstance(result.index[0], tuple)
+        tm.assertIsInstance(result.index[0], tuple)
 
     def test_append_numpy_bug_1681(self):
         # another datetime64 bug
@@ -3137,11 +3137,11 @@ class TestDatetime64(tm.TestCase):
         empty = Index([])
 
         result = dti.union(empty)
-        tm.assert_isinstance(result, DatetimeIndex)
+        tm.assertIsInstance(result, DatetimeIndex)
         self.assertIs(result, result)
 
         result = dti.join(empty)
-        tm.assert_isinstance(result, DatetimeIndex)
+        tm.assertIsInstance(result, DatetimeIndex)
 
     def test_series_set_value(self):
         # #1561
@@ -4003,8 +4003,8 @@ class TestSlicing(tm.TestCase):
 
         the_min = rng2.min()
         the_max = rng2.max()
-        tm.assert_isinstance(the_min, Timestamp)
-        tm.assert_isinstance(the_max, Timestamp)
+        tm.assertIsInstance(the_min, Timestamp)
+        tm.assertIsInstance(the_max, Timestamp)
         self.assertEqual(the_min, rng[0])
         self.assertEqual(the_max, rng[-1])
 

--- a/pandas/tseries/tests/test_timeseries_legacy.py
+++ b/pandas/tseries/tests/test_timeseries_legacy.py
@@ -90,7 +90,7 @@ class LegacySupport(object):
         ex_index = DatetimeIndex([], freq='B')
 
         self.assertTrue(result.index.equals(ex_index))
-        tm.assert_isinstance(result.index.freq, offsets.BDay)
+        tm.assertIsInstance(result.index.freq, offsets.BDay)
         self.assertEqual(len(result), 0)
 
     def test_arithmetic_interaction(self):
@@ -102,12 +102,12 @@ class LegacySupport(object):
 
         result = dseries + oseries
         expected = dseries * 2
-        tm.assert_isinstance(result.index, DatetimeIndex)
+        tm.assertIsInstance(result.index, DatetimeIndex)
         assert_series_equal(result, expected)
 
         result = dseries + oseries[:5]
         expected = dseries + dseries[:5]
-        tm.assert_isinstance(result.index, DatetimeIndex)
+        tm.assertIsInstance(result.index, DatetimeIndex)
         assert_series_equal(result, expected)
 
     def test_join_interaction(self):
@@ -119,7 +119,7 @@ class LegacySupport(object):
             ea, eb, ec = left.join(DatetimeIndex(right), how=how,
                                    return_indexers=True)
 
-            tm.assert_isinstance(ra, DatetimeIndex)
+            tm.assertIsInstance(ra, DatetimeIndex)
             self.assertTrue(ra.equals(ea))
 
             assert_almost_equal(rb, eb)
@@ -143,8 +143,8 @@ class LegacySupport(object):
         filepath = os.path.join(pth, 'data', 'daterange_073.pickle')
 
         rng = read_pickle(filepath)
-        tm.assert_isinstance(rng[0], datetime)
-        tm.assert_isinstance(rng.offset, offsets.BDay)
+        tm.assertIsInstance(rng[0], datetime)
+        tm.assertIsInstance(rng.offset, offsets.BDay)
         self.assertEqual(rng.values.dtype, object)
 
     def test_setops(self):
@@ -153,17 +153,17 @@ class LegacySupport(object):
 
         result = index[:5].union(obj_index[5:])
         expected = index
-        tm.assert_isinstance(result, DatetimeIndex)
+        tm.assertIsInstance(result, DatetimeIndex)
         self.assertTrue(result.equals(expected))
 
         result = index[:10].intersection(obj_index[5:])
         expected = index[5:10]
-        tm.assert_isinstance(result, DatetimeIndex)
+        tm.assertIsInstance(result, DatetimeIndex)
         self.assertTrue(result.equals(expected))
 
         result = index[:10] - obj_index[5:]
         expected = index[:5]
-        tm.assert_isinstance(result, DatetimeIndex)
+        tm.assertIsInstance(result, DatetimeIndex)
         self.assertTrue(result.equals(expected))
 
     def test_index_conversion(self):
@@ -179,7 +179,7 @@ class LegacySupport(object):
         rng = date_range('1/1/2000', periods=10)
 
         result = rng.tolist()
-        tm.assert_isinstance(result[0], Timestamp)
+        tm.assertIsInstance(result[0], Timestamp)
 
     def test_object_convert_fail(self):
         idx = DatetimeIndex([NaT])

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -238,7 +238,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         expected = utc.tz_convert(self.tzstr('US/Eastern'))
         result = utc.astimezone(self.tzstr('US/Eastern'))
         self.assertEqual(expected, result)
-        tm.assert_isinstance(result, Timestamp)
+        tm.assertIsInstance(result, Timestamp)
 
     def test_create_with_tz(self):
         stamp = Timestamp('3/11/2012 05:00', tz=self.tzstr('US/Eastern'))
@@ -1045,11 +1045,11 @@ class TestTimeZones(tm.TestCase):
 
         for how in ['inner', 'outer', 'left', 'right']:
             result = left.join(left[:-5], how=how)
-            tm.assert_isinstance(result, DatetimeIndex)
+            tm.assertIsInstance(result, DatetimeIndex)
             self.assertEqual(result.tz, left.tz)
 
             result = left.join(right[:-5], how=how)
-            tm.assert_isinstance(result, DatetimeIndex)
+            tm.assertIsInstance(result, DatetimeIndex)
             self.assertEqual(result.tz.zone, 'UTC')
 
     def test_join_aware(self):

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -511,13 +511,6 @@ def equalContents(arr1, arr2):
     return frozenset(arr1) == frozenset(arr2)
 
 
-def assert_isinstance(obj, class_type_or_tuple, msg=''):
-    """asserts that obj is an instance of class_type_or_tuple"""
-    assert isinstance(obj, class_type_or_tuple), (
-        "%sExpected object to be of type %r, found %r instead" % (
-            msg, class_type_or_tuple, type(obj)))
-
-
 def assert_equal(a, b, msg=""):
     """asserts that a equals b, like nose's assert_equal, but allows custom message to start.
     Passes a and b to format string as well. So you can use '{0}' and '{1}' to display a and b.
@@ -534,8 +527,8 @@ def assert_equal(a, b, msg=""):
 
 
 def assert_index_equal(left, right, exact=False, check_names=True):
-    assert_isinstance(left, Index, '[index] ')
-    assert_isinstance(right, Index, '[index] ')
+    assertIsInstance(left, Index, '[index] ')
+    assertIsInstance(right, Index, '[index] ')
     if not left.equals(right) or (exact and type(left) != type(right)):
         raise AssertionError("[index] left [{0} {1}], right [{2} {3}]".format(left.dtype,
                                                                               left,
@@ -601,6 +594,8 @@ def assertIsInstance(obj, cls, msg=''):
         "%sExpected object to be of type %r, found %r instead" % (
             msg, cls, type(obj)))
 
+def assert_isinstance(obj, class_type_or_tuple, msg=''):
+    return deprecate('assert_isinstance', assertIsInstance)(obj, class_type_or_tuple, msg=msg)
 
 def assertNotIsInstance(obj, cls, msg=''):
     """Test that obj is not an instance of cls
@@ -670,7 +665,7 @@ def assert_series_equal(left, right, check_dtype=True,
                         check_exact=False,
                         check_names=True):
     if check_series_type:
-        assert_isinstance(left, type(right))
+        assertIsInstance(left, type(right))
     if check_dtype:
         assert_attr_equal('dtype', left, right)
     if check_exact:
@@ -688,7 +683,7 @@ def assert_series_equal(left, right, check_dtype=True,
         for level in range(left.index.nlevels):
             lindex = left.index.get_level_values(level)
             rindex = right.index.get_level_values(level)
-            assert_isinstance(lindex, type(rindex))
+            assertIsInstance(lindex, type(rindex))
             assert_attr_equal('dtype', lindex, rindex)
             assert_attr_equal('inferred_type', lindex, rindex)
     if check_names:
@@ -711,9 +706,9 @@ def assert_frame_equal(left, right, check_dtype=True,
                        by_blocks=False,
                        check_exact=False):
     if check_frame_type:
-        assert_isinstance(left, type(right))
-    assert_isinstance(left, DataFrame)
-    assert_isinstance(right, DataFrame)
+        assertIsInstance(left, type(right))
+    assertIsInstance(left, DataFrame)
+    assertIsInstance(right, DataFrame)
 
     if check_less_precise:
         if not by_blocks:
@@ -749,11 +744,11 @@ def assert_frame_equal(left, right, check_dtype=True,
         for level in range(left.index.nlevels):
             lindex = left.index.get_level_values(level)
             rindex = right.index.get_level_values(level)
-            assert_isinstance(lindex, type(rindex))
+            assertIsInstance(lindex, type(rindex))
             assert_attr_equal('dtype', lindex, rindex)
             assert_attr_equal('inferred_type', lindex, rindex)
     if check_column_type:
-        assert_isinstance(left.columns, type(right.columns))
+        assertIsInstance(left.columns, type(right.columns))
         assert_attr_equal('dtype', left.columns, right.columns)
         assert_attr_equal('inferred_type', left.columns, right.columns)
     if check_names:
@@ -767,7 +762,7 @@ def assert_panelnd_equal(left, right,
                          assert_func=assert_frame_equal,
                          check_names=False):
     if check_panel_type:
-        assert_isinstance(left, type(right))
+        assertIsInstance(left, type(right))
 
     for axis in ['items', 'major_axis', 'minor_axis']:
         left_ind = getattr(left, axis)


### PR DESCRIPTION
`testing.py` has `assert_isinstance` and `assertIsInstance` duplicately, and each test case uses either of them by choice. 

Changed to use `assertIsInstance` in all cases, and make `assert_isinstance` show warning.
