### PR TITLE
BUG: #10445 cannot add DataFrame to empty Panel

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -351,6 +351,7 @@ Bug Fixes
 
 
 - Bug in ``DataFrame.interpolate`` with ``axis=1`` and ``inplace=True`` (:issue:`10395`)
+- Bug in adding a `DataFrame` to an empty `Panel` (:issue:`10445`)
 - Bug in ``io.sql.get_schema`` when specifying multiple columns as primary
   key (:issue:`10385`).
 - Bug in ``test_categorical`` on big-endian builds (:issue:`10425`)

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -907,6 +907,17 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing,
         vals.fill(1)
         assert_panel_equal(wp, Panel(vals, dtype='float32'))
 
+        # test creating empty panel and then adding DataFrame (GH # 10445)
+        panel = Panel()
+        df = DataFrame(np.array([[1, 2], [3, 4]]))
+        panel['item1'] = df
+        tm.assert_frame_equal(panel['item1'], df)
+
+        panel = Panel()
+        invalid_input = 'blablabla'
+        with self.assertRaises(ValueError):
+            panel['item1'] = invalid_input
+
     def test_constructor_cast(self):
         zero_filled = self.panel.fillna(0)
 


### PR DESCRIPTION
closes #10445 

I based this bugfix off how DataFrame handles the analogous situation ‒ being intialized to empty and then having a series added (cf. [DataFrame._ensure_valid_index](https://github.com/pydata/pandas/blob/master/pandas/core/frame.py#L2167))
