### PR TITLE
BUG: MultiIndex.get_level_values created from Categorical raises AttributeError

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -94,7 +94,7 @@ Bug Fixes
 
 - Bug in ``DataFrame.interpolate`` with ``axis=1`` and ``inplace=True`` (:issue:`10395`)
 
-
+- Bug in ``MultiIndex.get_level_values`` including ``Categorical`` raises ``AttributeError`` (:issue:`10460`)
 
 - Bug in ``test_categorical`` on big-endian builds (:issue:`10425`)
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -4238,7 +4238,7 @@ class MultiIndex(Index):
         num = self._get_level_number(level)
         unique = self.levels[num]  # .values
         labels = self.labels[num]
-        filled = com.take_1d(unique.values, labels, fill_value=unique._na_value)
+        filled = com.take_1d(unique.get_values(), labels, fill_value=unique._na_value)
         values = unique._simple_new(filled, self.names[num],
                                     freq=getattr(unique, 'freq', None),
                                     tz=getattr(unique, 'tz', None))

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -3476,6 +3476,13 @@ class TestGroupBy(tm.TestCase):
         expected.index.names = ['myfactor', None]
         assert_frame_equal(desc_result, expected)
 
+        # GH 10460
+        exp = CategoricalIndex(['foo'] * 8 + ['bar'] * 8 + ['baz'] * 8 + ['qux'] * 8,
+                               name='myfactor')
+        self.assert_index_equal(desc_result.index.get_level_values(0), exp)
+        exp = Index(['count', 'mean', 'std', 'min', '25%', '50%', '75%', 'max'] * 4)
+        self.assert_index_equal(desc_result.index.get_level_values(1), exp)
+
     def test_groupby_datetime_categorical(self):
         # GH9049: ensure backward compatibility
         levels = pd.date_range('2014-01-01', periods=4)

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -3567,6 +3567,16 @@ class TestMultiIndex(Base, tm.TestCase):
         values = index.get_level_values(0)
         self.assertEqual(values.shape, (0,))
 
+        # GH 10460
+        index = MultiIndex(levels=[CategoricalIndex(['A', 'B']),
+                                   CategoricalIndex([1, 2, 3])],
+                           labels=[np.array([0, 0, 0, 1, 1, 1]),
+                                   np.array([0, 1, 2, 0, 1, 2])])
+        exp = CategoricalIndex(['A', 'A', 'A', 'B', 'B', 'B'])
+        self.assert_index_equal(index.get_level_values(0), exp)
+        exp = CategoricalIndex([1, 2 ,3, 1, 2, 3])
+        self.assert_index_equal(index.get_level_values(1), exp)
+
     def test_reorder_levels(self):
         # this blows up
         assertRaisesRegexp(IndexError, '^Too many levels',


### PR DESCRIPTION
Closes #10460.

xref: #10464.
