### PR TITLE
Fix docstring for na_values in parsers

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -86,7 +86,7 @@ names : array-like
     should explicitly pass header=None
 prefix : string, default None
     Prefix to add to column numbers when no header, e.g 'X' for X0, X1, ...
-na_values : list-like or dict, default None
+na_values : str, list-like or dict, default None
     Additional strings to recognize as NA/NaN. If dict passed, specific
     per-column NA values
 true_values : list


### PR DESCRIPTION
I discovered entirely by accident that the `na_values` in `pd.read_*` can be a string. According to the docstring, it can only be a sequence or a dict. This PR fixes that.
