### PR TITLE
Series.from_csv not loading header names

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -131,3 +131,5 @@ Bug Fixes
 - Bug in ``DatetimeIndex`` and ``PeriodIndex.value_counts`` resets name from its result, but retains in result's ``Index``. (:issue:`10150`)
 
 - Bug in `pandas.concat` with ``axis=0`` when column is of dtype ``category`` (:issue:`10177`)
+
+- Bug in `Series.from_csv` with ``header`` kwarg not setting the ``Series.name`` or the ``Series.index.name`` (:issue:`10483`) 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2330,7 +2330,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                                 encoding=encoding,
                                 infer_datetime_format=infer_datetime_format)
         result = df.icol(0)
-        result.index.name = result.name = None
+        if header is None:
+            result.index.name = result.name = None
+
         return result
 
     def to_csv(self, path, index=True, sep=",", na_rep='',

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -4979,6 +4979,11 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
             self.assertTrue(ts.name is None)
             self.assertTrue(ts.index.name is None)
 
+            # GH10483
+            self.ts.to_csv(path, header=True)
+            ts_h = Series.from_csv(path, header=0)
+            self.assertTrue(ts_h.name == 'ts')
+
             self.series.to_csv(path)
             series = Series.from_csv(path)
             self.assertIsNone(series.name)
@@ -4986,6 +4991,10 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
             assert_series_equal(self.series, series, check_names=False)
             self.assertTrue(series.name is None)
             self.assertTrue(series.index.name is None)
+
+            self.series.to_csv(path, header=True)
+            series_h = Series.from_csv(path, header=0)
+            self.assertTrue(series_h.name == 'series')
 
             outfile = open(path, 'w')
             outfile.write('1998-01-01|1.0\n1999-01-01|2.0')


### PR DESCRIPTION
Series.from_csv at the moment does not load the series.name and series.index.name when the header keyword argument is stated.

This was introduced in 6078fba9410918baa486ca008cc9e3ba066c03ec.  The issue was that `Series.from_csv` uses `DataFrame.from_csv`, which automatically indexes columns (in practice, the index column gets labelled 0 and the values column gets labelled 1).  Converting this to a series will then cause the `series.name` to be 1, and the `series.index.name` to be 0.  The fix was to explicitly set the names in Series.from_csv to `None`.

This caused the headers to be deleted even if they were provided by setting the header kwarg.

The fix is simple, to check if the headers are provided, and only setting the names to None if they are not.

I included some tests, please let me know if this is enough as I am new to open-source and pandas.

Thanks!
