### PR TITLE
Updated to_hdf doc string

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -879,7 +879,7 @@ class NDFrame(PandasObject):
 
         Parameters
         ----------
-        path_or_buf : the path (string) or buffer to put the store
+        path_or_buf : the path (string) or HDFStore object
         key : string
             indentifier for the group in the store
         mode : optional, {'a', 'w', 'r', 'r+'}, default 'a'


### PR DESCRIPTION
Updated the docstring to make clear that a HDFStore is required for a buffer, if a path is not directly passed. See issue #10491
