### PR TITLE
TST: Deprecate assert_numpy_array_equivalent

### DIFF
--- a/pandas/computation/tests/test_eval.py
+++ b/pandas/computation/tests/test_eval.py
@@ -220,7 +220,7 @@ class TestEvalNumexprPandas(tm.TestCase):
                 expected = _eval_single_bin(
                     lhs_new, binop, rhs_new, self.engine)
                 result = pd.eval(ex, engine=self.engine, parser=self.parser)
-                tm.assert_numpy_array_equivalent(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
 
     def check_chained_cmp_op(self, lhs, cmp1, mid, cmp2, rhs):
         skip_these = _scalar_skip
@@ -240,7 +240,7 @@ class TestEvalNumexprPandas(tm.TestCase):
             for ex in (ex1, ex2, ex3):
                 result = pd.eval(ex, engine=self.engine,
                                  parser=self.parser)
-                tm.assert_numpy_array_equivalent(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
 
     def check_simple_cmp_op(self, lhs, cmp1, rhs):
         ex = 'lhs {0} rhs'.format(cmp1)
@@ -251,13 +251,13 @@ class TestEvalNumexprPandas(tm.TestCase):
         else:
             expected = _eval_single_bin(lhs, cmp1, rhs, self.engine)
             result = pd.eval(ex, engine=self.engine, parser=self.parser)
-            tm.assert_numpy_array_equivalent(result, expected)
+            tm.assert_numpy_array_equal(result, expected)
 
     def check_binary_arith_op(self, lhs, arith1, rhs):
         ex = 'lhs {0} rhs'.format(arith1)
         result = pd.eval(ex, engine=self.engine, parser=self.parser)
         expected = _eval_single_bin(lhs, arith1, rhs, self.engine)
-        tm.assert_numpy_array_equivalent(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
         ex = 'lhs {0} rhs {0} rhs'.format(arith1)
         result = pd.eval(ex, engine=self.engine, parser=self.parser)
         nlhs = _eval_single_bin(lhs, arith1, rhs,
@@ -273,7 +273,7 @@ class TestEvalNumexprPandas(tm.TestCase):
             pass
         else:
             expected = self.ne.evaluate('nlhs {0} ghs'.format(op))
-            tm.assert_numpy_array_equivalent(result, expected)
+            tm.assert_numpy_array_equal(result, expected)
 
     # modulus, pow, and floor division require special casing
 
@@ -291,7 +291,7 @@ class TestEvalNumexprPandas(tm.TestCase):
         if self.engine == 'python':
             res = pd.eval(ex, engine=self.engine, parser=self.parser)
             expected = lhs // rhs
-            tm.assert_numpy_array_equivalent(res, expected)
+            tm.assert_numpy_array_equal(res, expected)
         else:
             self.assertRaises(TypeError, pd.eval, ex, local_dict={'lhs': lhs,
                                                                   'rhs': rhs},
@@ -325,8 +325,8 @@ class TestEvalNumexprPandas(tm.TestCase):
 
         if (np.isscalar(lhs) and np.isscalar(rhs) and
                 _is_py3_complex_incompat(result, expected)):
-            self.assertRaises(AssertionError, tm.assert_numpy_array_equivalent, result,
-                              expected)
+            self.assertRaises(AssertionError, tm.assert_numpy_array_equal,
+                              result, expected)
         else:
             assert_allclose(result, expected)
 
@@ -345,12 +345,12 @@ class TestEvalNumexprPandas(tm.TestCase):
                 elb = np.array([bool(el)])
             expected = ~elb
             result = pd.eval('~elb', engine=self.engine, parser=self.parser)
-            tm.assert_numpy_array_equivalent(expected, result)
+            tm.assert_numpy_array_equal(expected, result)
 
             for engine in self.current_engines:
                 tm.skip_if_no_ne(engine)
-                tm.assert_numpy_array_equivalent(result, pd.eval('~elb', engine=engine,
-                                                   parser=self.parser))
+                tm.assert_numpy_array_equal(result, pd.eval('~elb', engine=engine,
+                                            parser=self.parser))
 
     def check_compound_invert_op(self, lhs, cmp1, rhs):
         skip_these = 'in', 'not in'
@@ -370,13 +370,13 @@ class TestEvalNumexprPandas(tm.TestCase):
             else:
                 expected = ~expected
             result = pd.eval(ex, engine=self.engine, parser=self.parser)
-            tm.assert_numpy_array_equivalent(expected, result)
+            tm.assert_numpy_array_equal(expected, result)
 
             # make sure the other engines work the same as this one
             for engine in self.current_engines:
                 tm.skip_if_no_ne(engine)
                 ev = pd.eval(ex, engine=self.engine, parser=self.parser)
-                tm.assert_numpy_array_equivalent(ev, result)
+                tm.assert_numpy_array_equal(ev, result)
 
     def ex(self, op, var_name='lhs'):
         return '{0}{1}'.format(op, var_name)
@@ -639,17 +639,17 @@ class TestEvalNumexprPandas(tm.TestCase):
 
         x = np.array([1])
         result = pd.eval('x', engine=self.engine, parser=self.parser)
-        tm.assert_numpy_array_equivalent(result, np.array([1]))
+        tm.assert_numpy_array_equal(result, np.array([1]))
         self.assertEqual(result.shape, (1, ))
 
         x = np.array([1.5])
         result = pd.eval('x', engine=self.engine, parser=self.parser)
-        tm.assert_numpy_array_equivalent(result, np.array([1.5]))
+        tm.assert_numpy_array_equal(result, np.array([1.5]))
         self.assertEqual(result.shape, (1, ))
 
         x = np.array([False])
         result = pd.eval('x', engine=self.engine, parser=self.parser)
-        tm.assert_numpy_array_equivalent(result, np.array([False]))
+        tm.assert_numpy_array_equal(result, np.array([False]))
         self.assertEqual(result.shape, (1, ))
 
 
@@ -707,7 +707,7 @@ class TestEvalPythonPython(TestEvalNumexprPython):
             pass
         else:
             expected = eval('nlhs {0} ghs'.format(op))
-            tm.assert_numpy_array_equivalent(result, expected)
+            tm.assert_numpy_array_equal(result, expected)
 
 
 class TestEvalPythonPandas(TestEvalPythonPython):
@@ -1118,10 +1118,10 @@ class TestOperationsNumExprPandas(tm.TestCase):
 
         if PY3:
             res = self.eval(ex, truediv=False)
-            tm.assert_numpy_array_equivalent(res, np.array([1.0]))
+            tm.assert_numpy_array_equal(res, np.array([1.0]))
 
             res = self.eval(ex, truediv=True)
-            tm.assert_numpy_array_equivalent(res, np.array([1.0]))
+            tm.assert_numpy_array_equal(res, np.array([1.0]))
 
             res = self.eval('1 / 2', truediv=True)
             expec = 0.5
@@ -1140,10 +1140,10 @@ class TestOperationsNumExprPandas(tm.TestCase):
             self.assertEqual(res, expec)
         else:
             res = self.eval(ex, truediv=False)
-            tm.assert_numpy_array_equivalent(res, np.array([1]))
+            tm.assert_numpy_array_equal(res, np.array([1]))
 
             res = self.eval(ex, truediv=True)
-            tm.assert_numpy_array_equivalent(res, np.array([1.0]))
+            tm.assert_numpy_array_equal(res, np.array([1.0]))
 
             res = self.eval('1 / 2', truediv=True)
             expec = 0.5
@@ -1446,8 +1446,8 @@ class TestScope(object):
 
     def check_global_scope(self, e, engine, parser):
         tm.skip_if_no_ne(engine)
-        tm.assert_numpy_array_equivalent(_var_s * 2, pd.eval(e, engine=engine,
-                                         parser=parser))
+        tm.assert_numpy_array_equal(_var_s * 2, pd.eval(e, engine=engine,
+                                    parser=parser))
 
     def test_global_scope(self):
         e = '_var_s * 2'

--- a/pandas/io/tests/test_data.py
+++ b/pandas/io/tests/test_data.py
@@ -14,7 +14,6 @@ from pandas.io.data import DataReader, SymbolWarning, RemoteDataError, _yahoo_co
 from pandas.util.testing import (assert_series_equal, assert_produces_warning,
                                  network, assert_frame_equal)
 import pandas.util.testing as tm
-from numpy.testing import assert_array_equal
 
 if compat.PY3:
     from urllib.error import HTTPError
@@ -533,7 +532,7 @@ class TestFred(tm.TestCase):
                     [848.3],
                     [933.3]]
         result = web.get_data_fred("A09024USA144NNBR", start="1915").ix[:5]
-        assert_array_equal(result.values, np.array(expected))
+        tm.assert_numpy_array_equal(result.values, np.array(expected))
 
     @network
     def test_invalid_series(self):

--- a/pandas/io/tests/test_json/test_ujson.py
+++ b/pandas/io/tests/test_json/test_ujson.py
@@ -21,8 +21,7 @@ import pandas.json as ujson
 import pandas.compat as compat
 
 import numpy as np
-from numpy.testing import (assert_array_equal,
-                           assert_array_almost_equal_nulp,
+from numpy.testing import (assert_array_almost_equal_nulp,
                            assert_approx_equal)
 import pytz
 import dateutil
@@ -166,7 +165,7 @@ class UltraJSONTests(TestCase):
         #self.assertEqual(output, json.dumps(input))
         self.assertEqual(input, ujson.decode(output))
         input = np.array(input)
-        assert_array_equal(input, ujson.decode(output, numpy=True, dtype=input.dtype))
+        tm.assert_numpy_array_equal(input, ujson.decode(output, numpy=True, dtype=input.dtype))
 
     def test_encodeArrayOfDoubles(self):
         input = [ 31337.31337, 31337.31337, 31337.31337, 31337.31337] * 10
@@ -174,7 +173,7 @@ class UltraJSONTests(TestCase):
         self.assertEqual(input, json.loads(output))
         #self.assertEqual(output, json.dumps(input))
         self.assertEqual(input, ujson.decode(output))
-        assert_array_equal(np.array(input), ujson.decode(output, numpy=True))
+        tm.assert_numpy_array_equal(np.array(input), ujson.decode(output, numpy=True))
 
     def test_doublePrecisionTest(self):
         input = 30.012345678901234
@@ -271,7 +270,7 @@ class UltraJSONTests(TestCase):
         self.assertEqual(input, json.loads(output))
         self.assertEqual(output, json.dumps(input))
         self.assertEqual(input, ujson.decode(output))
-        assert_array_equal(np.array(input), ujson.decode(output, numpy=True))
+        tm.assert_numpy_array_equal(np.array(input), ujson.decode(output, numpy=True))
         pass
 
     def test_encodeIntConversion(self):
@@ -307,7 +306,7 @@ class UltraJSONTests(TestCase):
         output = ujson.encode(input)
         self.assertEqual(input, json.loads(output))
         self.assertEqual(input, ujson.decode(output))
-        assert_array_equal(np.array(input), ujson.decode(output, numpy=True))
+        tm.assert_numpy_array_equal(np.array(input), ujson.decode(output, numpy=True))
         pass
 
     def test_encodeDictConversion(self):
@@ -676,8 +675,8 @@ class UltraJSONTests(TestCase):
         output = ujson.encode(input)
         self.assertEqual(input, json.loads(output))
         self.assertEqual(input, ujson.decode(output))
-        assert_array_equal(np.array(input), ujson.decode(output, numpy=True,
-                                                         dtype=np.int64))
+        tm.assert_numpy_array_equal(np.array(input), ujson.decode(output, numpy=True,
+                                                                  dtype=np.int64))
         pass
 
     def test_encodeLongConversion(self):
@@ -755,7 +754,7 @@ class UltraJSONTests(TestCase):
         f = StringIO("[1,2,3,4]")
         self.assertEqual([1, 2, 3, 4], ujson.load(f))
         f = StringIO("[1,2,3,4]")
-        assert_array_equal(np.array([1, 2, 3, 4]), ujson.load(f, numpy=True))
+        tm.assert_numpy_array_equal(np.array([1, 2, 3, 4]), ujson.load(f, numpy=True))
 
     def test_loadFileLikeObject(self):
         class filelike:
@@ -768,7 +767,7 @@ class UltraJSONTests(TestCase):
         f = filelike()
         self.assertEqual([1, 2, 3, 4], ujson.load(f))
         f = filelike()
-        assert_array_equal(np.array([1, 2, 3, 4]), ujson.load(f, numpy=True))
+        tm.assert_numpy_array_equal(np.array([1, 2, 3, 4]), ujson.load(f, numpy=True))
 
     def test_loadFileArgsError(self):
         try:
@@ -906,7 +905,7 @@ class NumpyJSONTests(TestCase):
         inpt = np.array([True, False, True, True, False, True, False , False],
                          dtype=np.bool)
         outp = np.array(ujson.decode(ujson.encode(inpt)), dtype=np.bool)
-        assert_array_equal(inpt, outp)
+        tm.assert_numpy_array_equal(inpt, outp)
 
     def testInt(self):
         num = np.int(2562010)
@@ -943,7 +942,7 @@ class NumpyJSONTests(TestCase):
         for dtype in dtypes:
             inpt = arr.astype(dtype)
             outp = np.array(ujson.decode(ujson.encode(inpt)), dtype=dtype)
-            assert_array_equal(inpt, outp)
+            tm.assert_numpy_array_equal(inpt, outp)
 
     def testIntMax(self):
         num = np.int(np.iinfo(np.int).max)
@@ -1008,26 +1007,26 @@ class NumpyJSONTests(TestCase):
         arr = np.arange(100);
 
         arr = arr.reshape((10, 10))
-        assert_array_equal(np.array(ujson.decode(ujson.encode(arr))), arr)
-        assert_array_equal(ujson.decode(ujson.encode(arr), numpy=True), arr)
+        tm.assert_numpy_array_equal(np.array(ujson.decode(ujson.encode(arr))), arr)
+        tm.assert_numpy_array_equal(ujson.decode(ujson.encode(arr), numpy=True), arr)
 
         arr = arr.reshape((5, 5, 4))
-        assert_array_equal(np.array(ujson.decode(ujson.encode(arr))), arr)
-        assert_array_equal(ujson.decode(ujson.encode(arr), numpy=True), arr)
+        tm.assert_numpy_array_equal(np.array(ujson.decode(ujson.encode(arr))), arr)
+        tm.assert_numpy_array_equal(ujson.decode(ujson.encode(arr), numpy=True), arr)
 
         arr = arr.reshape((100, 1))
-        assert_array_equal(np.array(ujson.decode(ujson.encode(arr))), arr)
-        assert_array_equal(ujson.decode(ujson.encode(arr), numpy=True), arr)
+        tm.assert_numpy_array_equal(np.array(ujson.decode(ujson.encode(arr))), arr)
+        tm.assert_numpy_array_equal(ujson.decode(ujson.encode(arr), numpy=True), arr)
 
         arr = np.arange(96);
         arr = arr.reshape((2, 2, 2, 2, 3, 2))
-        assert_array_equal(np.array(ujson.decode(ujson.encode(arr))), arr)
-        assert_array_equal(ujson.decode(ujson.encode(arr), numpy=True), arr)
+        tm.assert_numpy_array_equal(np.array(ujson.decode(ujson.encode(arr))), arr)
+        tm.assert_numpy_array_equal(ujson.decode(ujson.encode(arr), numpy=True), arr)
 
         l = ['a', list(), dict(), dict(), list(),
              42, 97.8, ['a', 'b'], {'key': 'val'}]
         arr = np.array(l)
-        assert_array_equal(np.array(ujson.decode(ujson.encode(arr))), arr)
+        tm.assert_numpy_array_equal(np.array(ujson.decode(ujson.encode(arr))), arr)
 
         arr = np.arange(100.202, 200.202, 1, dtype=np.float32);
         arr = arr.reshape((5, 5, 4))
@@ -1158,19 +1157,19 @@ class PandasJSONTests(TestCase):
         # column indexed
         outp = DataFrame(ujson.decode(ujson.encode(df)))
         self.assertTrue((df == outp).values.all())
-        assert_array_equal(df.columns, outp.columns)
-        assert_array_equal(df.index, outp.index)
+        tm.assert_numpy_array_equal(df.columns, outp.columns)
+        tm.assert_numpy_array_equal(df.index, outp.index)
 
         dec = _clean_dict(ujson.decode(ujson.encode(df, orient="split")))
         outp = DataFrame(**dec)
         self.assertTrue((df == outp).values.all())
-        assert_array_equal(df.columns, outp.columns)
-        assert_array_equal(df.index, outp.index)
+        tm.assert_numpy_array_equal(df.columns, outp.columns)
+        tm.assert_numpy_array_equal(df.index, outp.index)
 
         outp = DataFrame(ujson.decode(ujson.encode(df, orient="records")))
         outp.index = df.index
         self.assertTrue((df == outp).values.all())
-        assert_array_equal(df.columns, outp.columns)
+        tm.assert_numpy_array_equal(df.columns, outp.columns)
 
         outp = DataFrame(ujson.decode(ujson.encode(df, orient="values")))
         outp.index = df.index
@@ -1178,8 +1177,8 @@ class PandasJSONTests(TestCase):
 
         outp = DataFrame(ujson.decode(ujson.encode(df, orient="index")))
         self.assertTrue((df.transpose() == outp).values.all())
-        assert_array_equal(df.transpose().columns, outp.columns)
-        assert_array_equal(df.transpose().index, outp.index)
+        tm.assert_numpy_array_equal(df.transpose().columns, outp.columns)
+        tm.assert_numpy_array_equal(df.transpose().index, outp.index)
 
     def testDataFrameNumpy(self):
         df = DataFrame([[1,2,3], [4,5,6]], index=['a', 'b'], columns=['x', 'y', 'z'])
@@ -1187,20 +1186,20 @@ class PandasJSONTests(TestCase):
         # column indexed
         outp = DataFrame(ujson.decode(ujson.encode(df), numpy=True))
         self.assertTrue((df == outp).values.all())
-        assert_array_equal(df.columns, outp.columns)
-        assert_array_equal(df.index, outp.index)
+        tm.assert_numpy_array_equal(df.columns, outp.columns)
+        tm.assert_numpy_array_equal(df.index, outp.index)
 
         dec = _clean_dict(ujson.decode(ujson.encode(df, orient="split"),
                           numpy=True))
         outp = DataFrame(**dec)
         self.assertTrue((df == outp).values.all())
-        assert_array_equal(df.columns, outp.columns)
-        assert_array_equal(df.index, outp.index)
+        tm.assert_numpy_array_equal(df.columns, outp.columns)
+        tm.assert_numpy_array_equal(df.index, outp.index)
 
         outp = DataFrame(ujson.decode(ujson.encode(df, orient="index"), numpy=True))
         self.assertTrue((df.transpose() == outp).values.all())
-        assert_array_equal(df.transpose().columns, outp.columns)
-        assert_array_equal(df.transpose().index, outp.index)
+        tm.assert_numpy_array_equal(df.transpose().columns, outp.columns)
+        tm.assert_numpy_array_equal(df.transpose().index, outp.index)
 
     def testDataFrameNested(self):
         df = DataFrame([[1,2,3], [4,5,6]], index=['a', 'b'], columns=['x', 'y', 'z'])
@@ -1233,18 +1232,18 @@ class PandasJSONTests(TestCase):
         # column indexed
         outp = DataFrame(*ujson.decode(ujson.encode(df), numpy=True, labelled=True))
         self.assertTrue((df.T == outp).values.all())
-        assert_array_equal(df.T.columns, outp.columns)
-        assert_array_equal(df.T.index, outp.index)
+        tm.assert_numpy_array_equal(df.T.columns, outp.columns)
+        tm.assert_numpy_array_equal(df.T.index, outp.index)
 
         outp = DataFrame(*ujson.decode(ujson.encode(df, orient="records"), numpy=True, labelled=True))
         outp.index = df.index
         self.assertTrue((df == outp).values.all())
-        assert_array_equal(df.columns, outp.columns)
+        tm.assert_numpy_array_equal(df.columns, outp.columns)
 
         outp = DataFrame(*ujson.decode(ujson.encode(df, orient="index"), numpy=True, labelled=True))
         self.assertTrue((df == outp).values.all())
-        assert_array_equal(df.columns, outp.columns)
-        assert_array_equal(df.index, outp.index)
+        tm.assert_numpy_array_equal(df.columns, outp.columns)
+        tm.assert_numpy_array_equal(df.index, outp.index)
 
     def testSeries(self):
         s = Series([10, 20, 30, 40, 50, 60], name="series", index=[6,7,8,9,10,15])

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -33,7 +33,6 @@ from pandas.tseries.index import date_range
 import pandas.tseries.tools as tools
 
 from numpy.testing.decorators import slow
-from numpy.testing import assert_array_equal
 
 import pandas.parser
 
@@ -747,7 +746,7 @@ Klosterdruckerei\tKlosterdruckerei <Kempten> (1609-1805)\tHochfurstliche Buchhan
         _NA_VALUES = set(['-1.#IND', '1.#QNAN', '1.#IND', '-1.#QNAN',
                           '#N/A','N/A', 'NA', '#NA', 'NULL', 'NaN',
                           'nan', '-NaN', '-nan', '#N/A N/A',''])
-        assert_array_equal (_NA_VALUES, parsers._NA_VALUES)
+        self.assertEqual(_NA_VALUES, parsers._NA_VALUES)
         nv = len(_NA_VALUES)
         def f(i, v):
             if i == 0:

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -13,7 +13,7 @@ dec = np.testing.dec
 
 from pandas.util.testing import (assert_almost_equal, assert_series_equal,
                                  assert_frame_equal, assert_panel_equal, assertRaisesRegexp,
-                                 assert_array_equal, assert_attr_equal)
+                                 assert_numpy_array_equal, assert_attr_equal)
 from numpy.testing import assert_equal
 
 from pandas import Series, DataFrame, bdate_range, Panel, MultiIndex
@@ -575,7 +575,7 @@ class TestSparseSeries(tm.TestCase,
 
         reindexed = self.bseries.reindex(self.bseries.index, copy=False)
         reindexed.sp_values[:] = 1.
-        np.testing.assert_array_equal(self.bseries.sp_values, 1.)
+        tm.assert_numpy_array_equal(self.bseries.sp_values, np.repeat(1., 10))
 
     def test_sparse_reindex(self):
         length = 10
@@ -899,7 +899,7 @@ class TestSparseSeriesScipyInteraction(tm.TestCase):
         (A, il, jl) = results
         (A_result, il_result, jl_result) = check
         # convert to dense and compare
-        assert_array_equal(A.todense(), A_result.todense())
+        assert_numpy_array_equal(A.todense(), A_result.todense())
         # or compare directly as difference of sparse
         # assert(abs(A - A_result).max() < 1e-12) # max is failing in python
         # 2.6

--- a/pandas/stats/tests/test_moments.py
+++ b/pandas/stats/tests/test_moments.py
@@ -539,7 +539,7 @@ class TestMoments(Base):
                 result = func(arr, 20, center=True)
                 expected = func(np.concatenate((arr, np.array([np.NaN] * 9))), 20)[9:]
 
-            self.assert_numpy_array_equivalent(result, expected)
+            self.assert_numpy_array_equal(result, expected)
 
         if test_stable:
             result = func(self.arr + 1e9, window)
@@ -1684,7 +1684,7 @@ class TestMomentsConsistency(Base):
                     assert_index_equal(result.columns, df.columns)
                 for i, result in enumerate(results):
                     if i > 0:
-                        self.assert_numpy_array_equivalent(result, results[0])
+                        self.assert_numpy_array_equal(result, results[0])
 
             # DataFrame with itself, pairwise=True
             for f in [lambda x: mom.expanding_cov(x, pairwise=True),
@@ -1701,7 +1701,7 @@ class TestMomentsConsistency(Base):
                     assert_index_equal(result.minor_axis, df.columns)
                 for i, result in enumerate(results):
                     if i > 0:
-                        self.assert_numpy_array_equivalent(result, results[0])
+                        self.assert_numpy_array_equal(result, results[0])
 
             # DataFrame with itself, pairwise=False
             for f in [lambda x: mom.expanding_cov(x, pairwise=False),
@@ -1717,7 +1717,7 @@ class TestMomentsConsistency(Base):
                     assert_index_equal(result.columns, df.columns)
                 for i, result in enumerate(results):
                     if i > 0:
-                        self.assert_numpy_array_equivalent(result, results[0])
+                        self.assert_numpy_array_equal(result, results[0])
 
             # DataFrame with another DataFrame, pairwise=True
             for f in [lambda x, y: mom.expanding_cov(x, y, pairwise=True),
@@ -1734,7 +1734,7 @@ class TestMomentsConsistency(Base):
                     assert_index_equal(result.minor_axis, df2.columns)
                 for i, result in enumerate(results):
                     if i > 0:
-                        self.assert_numpy_array_equivalent(result, results[0])
+                        self.assert_numpy_array_equal(result, results[0])
 
             # DataFrame with another DataFrame, pairwise=False
             for f in [lambda x, y: mom.expanding_cov(x, y, pairwise=False),
@@ -1769,7 +1769,7 @@ class TestMomentsConsistency(Base):
                     assert_index_equal(result.columns, df.columns)
                 for i, result in enumerate(results):
                     if i > 0:
-                        self.assert_numpy_array_equivalent(result, results[0])
+                        self.assert_numpy_array_equal(result, results[0])
 
     def test_rolling_skew_edge_cases(self):
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -305,7 +305,7 @@ class GroupVarTestMixin(object):
 
         self.algo(out, counts, values, labels)
         np.testing.assert_allclose(out, expected_out, self.rtol)
-        tm.assert_array_equal(counts, expected_counts)
+        tm.assert_numpy_array_equal(counts, expected_counts)
 
     def test_group_var_generic_1d_flat_labels(self):
         prng = RandomState(1234)
@@ -321,7 +321,7 @@ class GroupVarTestMixin(object):
         self.algo(out, counts, values, labels)
 
         np.testing.assert_allclose(out, expected_out, self.rtol)
-        tm.assert_array_equal(counts, expected_counts)
+        tm.assert_numpy_array_equal(counts, expected_counts)
 
     def test_group_var_generic_2d_all_finite(self):
         prng = RandomState(1234)
@@ -337,7 +337,7 @@ class GroupVarTestMixin(object):
 
         self.algo(out, counts, values, labels)
         np.testing.assert_allclose(out, expected_out, self.rtol)
-        tm.assert_array_equal(counts, expected_counts)
+        tm.assert_numpy_array_equal(counts, expected_counts)
 
     def test_group_var_generic_2d_some_nan(self):
         prng = RandomState(1234)
@@ -356,7 +356,7 @@ class GroupVarTestMixin(object):
 
         self.algo(out, counts, values, labels)
         np.testing.assert_allclose(out, expected_out, self.rtol)
-        tm.assert_array_equal(counts, expected_counts)
+        tm.assert_numpy_array_equal(counts, expected_counts)
 
     def test_group_var_constant(self):
         # Regression test from GH 10448.
@@ -421,12 +421,12 @@ def test_unique_label_indices():
     left = unique_label_indices(a)
     right = np.unique(a, return_index=True)[1]
 
-    tm.assert_array_equal(left, right)
+    tm.assert_numpy_array_equal(left, right)
 
     a[np.random.choice(len(a), 10)] = -1
     left= unique_label_indices(a)
     right = np.unique(a, return_index=True)[1][1:]
-    tm.assert_array_equal(left, right)
+    tm.assert_numpy_array_equal(left, right)
 
 if __name__ == '__main__':
     import nose

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -553,7 +553,7 @@ class TestIndexOps(Ops):
             expected = Series([4, 3, 2], index=['b', 'a', 'd'])
             tm.assert_series_equal(s.value_counts(), expected)
 
-            self.assert_numpy_array_equivalent(s.unique(), np.array(['a', 'b', np.nan, 'd'], dtype='O'))
+            self.assert_numpy_array_equal(s.unique(), np.array(['a', 'b', np.nan, 'd'], dtype='O'))
             self.assertEqual(s.nunique(), 3)
 
             s = klass({})

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -9,7 +9,6 @@ from numpy.random import randn
 
 import operator
 import numpy as np
-from numpy.testing import assert_array_equal
 
 from pandas.core.api import DataFrame, Panel
 from pandas.computation import expressions as expr
@@ -271,7 +270,7 @@ class TestExpressions(tm.TestCase):
 
                         result   = expr.evaluate(op, op_str, f, f, use_numexpr=True)
                         expected = expr.evaluate(op, op_str, f, f, use_numexpr=False)
-                        assert_array_equal(result,expected.values)
+                        tm.assert_numpy_array_equal(result,expected.values)
 
                         result   = expr._can_use_numexpr(op, op_str, f2, f2, 'evaluate')
                         self.assertFalse(result)
@@ -306,7 +305,7 @@ class TestExpressions(tm.TestCase):
 
                     result   = expr.evaluate(op, op_str, f11, f12, use_numexpr=True)
                     expected = expr.evaluate(op, op_str, f11, f12, use_numexpr=False)
-                    assert_array_equal(result,expected.values)
+                    tm.assert_numpy_array_equal(result,expected.values)
 
                     result   = expr._can_use_numexpr(op, op_str, f21, f22, 'evaluate')
                     self.assertFalse(result)
@@ -331,7 +330,7 @@ class TestExpressions(tm.TestCase):
                     c.fill(cond)
                     result   = expr.where(c, f.values, f.values+1)
                     expected = np.where(c, f.values, f.values+1)
-                    assert_array_equal(result,expected)
+                    tm.assert_numpy_array_equal(result,expected)
 
         expr.set_use_numexpr(False)
         testit()

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -24,7 +24,6 @@ from numpy import random, nan, inf
 from numpy.random import randn
 import numpy as np
 import numpy.ma as ma
-from numpy.testing import assert_array_equal
 import numpy.ma.mrecords as mrecords
 
 import pandas.core.nanops as nanops
@@ -40,6 +39,7 @@ from pandas.parser import CParserError
 from pandas.util.misc import is_little_endian
 
 from pandas.util.testing import (assert_almost_equal,
+                                 assert_numpy_array_equal,
                                  assert_series_equal,
                                  assert_frame_equal,
                                  assertRaisesRegexp,
@@ -125,7 +125,7 @@ class CheckIndexing(object):
         df['@awesome_domain'] = ad
         self.assertRaises(KeyError, df.__getitem__, 'df["$10"]')
         res = df['@awesome_domain']
-        assert_array_equal(ad, res.values)
+        assert_numpy_array_equal(ad, res.values)
 
     def test_getitem_dupe_cols(self):
         df = DataFrame([[1, 2, 3], [4, 5, 6]], columns=['a', 'a', 'b'])
@@ -4664,13 +4664,13 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
     def test_from_records_empty_with_nonempty_fields_gh3682(self):
         a = np.array([(1, 2)], dtype=[('id', np.int64), ('value', np.int64)])
         df = DataFrame.from_records(a, index='id')
-        assert_array_equal(df.index, Index([1], name='id'))
+        assert_numpy_array_equal(df.index, Index([1], name='id'))
         self.assertEqual(df.index.name, 'id')
-        assert_array_equal(df.columns, Index(['value']))
+        assert_numpy_array_equal(df.columns, Index(['value']))
 
         b = np.array([], dtype=[('id', np.int64), ('value', np.int64)])
         df = DataFrame.from_records(b, index='id')
-        assert_array_equal(df.index, Index([], name='id'))
+        assert_numpy_array_equal(df.index, Index([], name='id'))
         self.assertEqual(df.index.name, 'id')
 
     def test_from_records_with_datetimes(self):
@@ -6108,7 +6108,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_frame_equal(result,expected)
 
         result = df.values>b
-        assert_array_equal(result,expected.values)
+        assert_numpy_array_equal(result,expected.values)
 
         result = df>l
         assert_frame_equal(result,expected)
@@ -6120,7 +6120,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_frame_equal(result,expected)
 
         result = df.values>b_r
-        assert_array_equal(result,expected.values)
+        assert_numpy_array_equal(result,expected.values)
 
         self.assertRaises(ValueError, df.__gt__, b_c)
         self.assertRaises(ValueError, df.values.__gt__, b_c)
@@ -6140,7 +6140,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_frame_equal(result,expected)
 
         result = df.values == b_r
-        assert_array_equal(result,expected.values)
+        assert_numpy_array_equal(result,expected.values)
 
         self.assertRaises(ValueError, lambda : df == b_c)
         self.assertFalse((df.values == b_c))

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -25,7 +25,7 @@ import numpy as np
 from numpy import random
 from numpy.random import rand, randn
 
-from numpy.testing import assert_array_equal, assert_allclose
+from numpy.testing import assert_allclose
 from numpy.testing.decorators import slow
 import pandas.tools.plotting as plotting
 
@@ -646,11 +646,11 @@ class TestSeriesPlots(TestPlotBase):
             expected = np.hstack((.1, expected, 1e4))
 
         ax = Series([200, 500]).plot(log=True, kind='bar')
-        assert_array_equal(ax.yaxis.get_ticklocs(), expected)
+        tm.assert_numpy_array_equal(ax.yaxis.get_ticklocs(), expected)
         tm.close()
 
         ax = Series([200, 500]).plot(log=True, kind='barh')
-        assert_array_equal(ax.xaxis.get_ticklocs(), expected)
+        tm.assert_numpy_array_equal(ax.xaxis.get_ticklocs(), expected)
         tm.close()
 
         # GH 9905
@@ -660,13 +660,13 @@ class TestSeriesPlots(TestPlotBase):
             expected = np.hstack((1.0e-04, expected, 1.0e+01))
 
         ax = Series([0.1, 0.01, 0.001]).plot(log=True, kind='bar')
-        assert_array_equal(ax.get_ylim(), (0.001, 0.10000000000000001))
-        assert_array_equal(ax.yaxis.get_ticklocs(), expected)
+        tm.assert_numpy_array_equal(ax.get_ylim(), (0.001, 0.10000000000000001))
+        tm.assert_numpy_array_equal(ax.yaxis.get_ticklocs(), expected)
         tm.close()
 
         ax = Series([0.1, 0.01, 0.001]).plot(log=True, kind='barh')
-        assert_array_equal(ax.get_xlim(), (0.001, 0.10000000000000001))
-        assert_array_equal(ax.xaxis.get_ticklocs(), expected)
+        tm.assert_numpy_array_equal(ax.get_xlim(), (0.001, 0.10000000000000001))
+        tm.assert_numpy_array_equal(ax.xaxis.get_ticklocs(), expected)
 
     @slow
     def test_bar_ignore_index(self):
@@ -2154,7 +2154,7 @@ class TestDataFramePlots(TestPlotBase):
         # no subplots
         df = DataFrame({'A': [3] * 5, 'B': lrange(1, 6)}, index=lrange(5))
         ax = df.plot(kind='bar', grid=True, log=True)
-        assert_array_equal(ax.yaxis.get_ticklocs(), expected)
+        tm.assert_numpy_array_equal(ax.yaxis.get_ticklocs(), expected)
 
     @slow
     def test_bar_log_subplots(self):
@@ -2166,8 +2166,8 @@ class TestDataFramePlots(TestPlotBase):
                         Series([300, 500])]).plot(log=True, kind='bar',
                                                   subplots=True)
 
-        assert_array_equal(ax[0].yaxis.get_ticklocs(), expected)
-        assert_array_equal(ax[1].yaxis.get_ticklocs(), expected)
+        tm.assert_numpy_array_equal(ax[0].yaxis.get_ticklocs(), expected)
+        tm.assert_numpy_array_equal(ax[1].yaxis.get_ticklocs(), expected)
 
     @slow
     def test_boxplot(self):
@@ -2178,7 +2178,7 @@ class TestDataFramePlots(TestPlotBase):
 
         ax = _check_plot_works(df.plot, kind='box')
         self._check_text_labels(ax.get_xticklabels(), labels)
-        assert_array_equal(ax.xaxis.get_ticklocs(),
+        tm.assert_numpy_array_equal(ax.xaxis.get_ticklocs(),
                            np.arange(1, len(numeric_cols) + 1))
         self.assertEqual(len(ax.lines),
                          self.bp_n_objects * len(numeric_cols))
@@ -2205,7 +2205,7 @@ class TestDataFramePlots(TestPlotBase):
         numeric_cols = df._get_numeric_data().columns
         labels = [com.pprint_thing(c) for c in numeric_cols]
         self._check_text_labels(ax.get_xticklabels(), labels)
-        assert_array_equal(ax.xaxis.get_ticklocs(), positions)
+        tm.assert_numpy_array_equal(ax.xaxis.get_ticklocs(), positions)
         self.assertEqual(len(ax.lines), self.bp_n_objects * len(numeric_cols))
 
     @slow
@@ -2231,7 +2231,7 @@ class TestDataFramePlots(TestPlotBase):
         positions = np.array([3, 2, 8])
         ax = df.plot(kind='box', positions=positions, vert=False)
         self._check_text_labels(ax.get_yticklabels(), labels)
-        assert_array_equal(ax.yaxis.get_ticklocs(), positions)
+        tm.assert_numpy_array_equal(ax.yaxis.get_ticklocs(), positions)
         self.assertEqual(len(ax.lines), self.bp_n_objects * len(numeric_cols))
 
     @slow
@@ -2888,7 +2888,7 @@ class TestDataFramePlots(TestPlotBase):
         xticks = ax.lines[0].get_xdata()
         self.assertTrue(xticks[0] < xticks[1])
         ydata = ax.lines[0].get_ydata()
-        assert_array_equal(ydata, np.array([1.0, 2.0, 3.0]))
+        tm.assert_numpy_array_equal(ydata, np.array([1.0, 2.0, 3.0]))
 
     def test_all_invalid_plot_data(self):
         df = DataFrame(list('abcd'))

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -3735,7 +3735,7 @@ class TestGroupBy(tm.TestCase):
         result = data.groupby("b").mean()
         result = result["a"].values
         exp = np.array([1,2,4,np.nan])
-        self.assert_numpy_array_equivalent(result, exp)
+        self.assert_numpy_array_equal(result, exp)
 
     def test_groupby_non_arithmetic_agg_types(self):
         # GH9311, GH6620

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -813,7 +813,7 @@ class TestIndexing(tm.TestCase):
         # GH6394
         # Regression in chained getitem indexing with embedded list-like from 0.12
         def check(result, expected):
-            self.assert_numpy_array_equal(result,expected)
+            tm.assert_numpy_array_equal(result,expected)
             tm.assertIsInstance(result, np.ndarray)
 
 
@@ -4765,7 +4765,7 @@ class TestSeriesNoneCoercion(tm.TestCase):
             expected_series = Series(expected_result)
 
             assert_attr_equal('dtype', start_series, expected_series)
-            self.assert_numpy_array_equivalent(
+            tm.assert_numpy_array_equal(
                 start_series.values,
                 expected_series.values, strict_nan=True)
 
@@ -4777,7 +4777,7 @@ class TestSeriesNoneCoercion(tm.TestCase):
             expected_series = Series(expected_result)
 
             assert_attr_equal('dtype', start_series, expected_series)
-            self.assert_numpy_array_equivalent(
+            tm.assert_numpy_array_equal(
                 start_series.values,
                 expected_series.values, strict_nan=True)
 
@@ -4789,7 +4789,7 @@ class TestSeriesNoneCoercion(tm.TestCase):
             expected_series = Series(expected_result)
 
             assert_attr_equal('dtype', start_series, expected_series)
-            self.assert_numpy_array_equivalent(
+            tm.assert_numpy_array_equal(
                 start_series.values,
                 expected_series.values, strict_nan=True)
 
@@ -4801,7 +4801,7 @@ class TestSeriesNoneCoercion(tm.TestCase):
             expected_series = Series(expected_result)
 
             assert_attr_equal('dtype', start_series, expected_series)
-            self.assert_numpy_array_equivalent(
+            tm.assert_numpy_array_equal(
                 start_series.values,
                 expected_series.values, strict_nan=True)
 
@@ -4828,7 +4828,7 @@ class TestDataframeNoneCoercion(tm.TestCase):
             expected_dataframe = DataFrame({'foo': expected_result})
 
             assert_attr_equal('dtype', start_dataframe['foo'], expected_dataframe['foo'])
-            self.assert_numpy_array_equivalent(
+            tm.assert_numpy_array_equal(
                 start_dataframe['foo'].values,
                 expected_dataframe['foo'].values, strict_nan=True)
 
@@ -4840,7 +4840,7 @@ class TestDataframeNoneCoercion(tm.TestCase):
             expected_dataframe = DataFrame({'foo': expected_result})
 
             assert_attr_equal('dtype', start_dataframe['foo'], expected_dataframe['foo'])
-            self.assert_numpy_array_equivalent(
+            tm.assert_numpy_array_equal(
                 start_dataframe['foo'].values,
                 expected_dataframe['foo'].values, strict_nan=True)
 
@@ -4852,7 +4852,7 @@ class TestDataframeNoneCoercion(tm.TestCase):
             expected_dataframe = DataFrame({'foo': expected_result})
 
             assert_attr_equal('dtype', start_dataframe['foo'], expected_dataframe['foo'])
-            self.assert_numpy_array_equivalent(
+            tm.assert_numpy_array_equal(
                 start_dataframe['foo'].values,
                 expected_dataframe['foo'].values, strict_nan=True)
 
@@ -4872,7 +4872,7 @@ class TestDataframeNoneCoercion(tm.TestCase):
 
         for column in expected_dataframe.columns:
             assert_attr_equal('dtype', start_dataframe[column], expected_dataframe[column])
-            self.assert_numpy_array_equivalent(
+            tm.assert_numpy_array_equal(
                 start_dataframe[column].values,
                 expected_dataframe[column].values, strict_nan=True)
 

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -658,7 +658,9 @@ class TestBlockManager(tm.TestCase):
 
         df_unique = df.copy()
         df_unique.columns = ['x', 'y']
-        np.testing.assert_array_equal(df_unique.values, df.values)
+        self.assertEqual(df_unique.values.shape, df.values.shape)
+        tm.assert_numpy_array_equal(df_unique.values[0], df.values[0])
+        tm.assert_numpy_array_equal(df_unique.values[1], df.values[1])
 
     def test_consolidate(self):
         pass
@@ -1066,7 +1068,7 @@ class TestBlockPlacement(tm.TestCase):
 
     def test_slice_to_array_conversion(self):
         def assert_as_array_equals(slc, asarray):
-            np.testing.assert_array_equal(
+            tm.assert_numpy_array_equal(
                 BlockPlacement(slc).as_array,
                 np.asarray(asarray))
 

--- a/pandas/tests/test_reshape.py
+++ b/pandas/tests/test_reshape.py
@@ -15,7 +15,6 @@ from numpy import nan
 import numpy as np
 
 from pandas.util.testing import assert_frame_equal
-from numpy.testing import assert_array_equal
 
 from pandas.core.reshape import (melt, lreshape, get_dummies,
                                  wide_to_long)
@@ -234,7 +233,7 @@ class TestGetDummies(tm.TestCase):
 
         res_just_na = get_dummies([nan], dummy_na=True, sparse=self.sparse)
         exp_just_na = DataFrame(Series(1.0,index=[0]),columns=[nan])
-        assert_array_equal(res_just_na.values, exp_just_na.values)
+        tm.assert_numpy_array_equal(res_just_na.values, exp_just_na.values)
 
     def test_unicode(self):  # See GH 6885 - get_dummies chokes on unicode values
         import unicodedata

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -1562,7 +1562,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         a = Series([1, 2, 3, 4])
         result = a.reshape(2, 2)
         expected = a.values.reshape(2, 2)
-        np.testing.assert_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
         self.assertTrue(type(result) is type(expected))
 
     def test_reshape_2d_return_array(self):
@@ -7070,13 +7070,13 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         r = s.searchsorted([30])
         e = np.array([2])
-        tm.assert_array_equal(r, e)
+        tm.assert_numpy_array_equal(r, e)
 
     def test_searchsorted_numeric_dtypes_vector(self):
         s = Series([1, 2, 90, 1000, 3e9])
         r = s.searchsorted([91, 2e6])
         e = np.array([3, 4])
-        tm.assert_array_equal(r, e)
+        tm.assert_numpy_array_equal(r, e)
 
     def test_search_sorted_datetime64_scalar(self):
         s = Series(pd.date_range('20120101', periods=10, freq='2D'))
@@ -7090,14 +7090,14 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         v = [pd.Timestamp('20120102'), pd.Timestamp('20120104')]
         r = s.searchsorted(v)
         e = np.array([1, 2])
-        tm.assert_array_equal(r, e)
+        tm.assert_numpy_array_equal(r, e)
 
     def test_searchsorted_sorter(self):
         # GH8490
         s = Series([3, 1, 2])
         r = s.searchsorted([0, 3], sorter=np.argsort(s))
         e = np.array([0, 2])
-        tm.assert_array_equal(r, e)
+        tm.assert_numpy_array_equal(r, e)
 
     def test_to_frame_expanddim(self):
         # GH 9762

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -11,7 +11,6 @@ import nose
 
 from numpy import nan as NA
 import numpy as np
-from numpy.testing import assert_array_equal
 from numpy.random import randint
 
 from pandas.compat import range, lrange, u, unichr
@@ -53,7 +52,7 @@ class TestStringMethods(tm.TestCase):
 
             # indices of each yielded Series should be equal to the index of
             # the original Series
-            assert_array_equal(s.index, ds.index)
+            tm.assert_numpy_array_equal(s.index, ds.index)
 
             for el in s:
                 # each element of the series is either a basestring/str or nan
@@ -561,7 +560,7 @@ class TestStringMethods(tm.TestCase):
             s_or_idx = klass(['A1', 'A2'])
             result = s_or_idx.str.extract(r'(?P<uno>A)\d')
             tm.assert_equal(result.name, 'uno')
-            tm.assert_array_equal(result, klass(['A', 'A']))
+            tm.assert_numpy_array_equal(result, klass(['A', 'A']))
 
         s = Series(['A1', 'B2', 'C3'])
         # one group, no matches
@@ -918,34 +917,34 @@ class TestStringMethods(tm.TestCase):
             s = klass(['ABCDEFG', 'BCDEFEF', 'DEFGHIJEF', 'EFGHEF'])
 
             result = s.str.index('EF')
-            tm.assert_array_equal(result, klass([4, 3, 1, 0]))
+            tm.assert_numpy_array_equal(result, klass([4, 3, 1, 0]))
             expected = np.array([v.index('EF') for v in s.values])
-            tm.assert_array_equal(result.values, expected)
+            tm.assert_numpy_array_equal(result.values, expected)
 
             result = s.str.rindex('EF')
-            tm.assert_array_equal(result, klass([4, 5, 7, 4]))
+            tm.assert_numpy_array_equal(result, klass([4, 5, 7, 4]))
             expected = np.array([v.rindex('EF') for v in s.values])
-            tm.assert_array_equal(result.values, expected)
+            tm.assert_numpy_array_equal(result.values, expected)
 
             result = s.str.index('EF', 3)
-            tm.assert_array_equal(result, klass([4, 3, 7, 4]))
+            tm.assert_numpy_array_equal(result, klass([4, 3, 7, 4]))
             expected = np.array([v.index('EF', 3) for v in s.values])
-            tm.assert_array_equal(result.values, expected)
+            tm.assert_numpy_array_equal(result.values, expected)
 
             result = s.str.rindex('EF', 3)
-            tm.assert_array_equal(result, klass([4, 5, 7, 4]))
+            tm.assert_numpy_array_equal(result, klass([4, 5, 7, 4]))
             expected = np.array([v.rindex('EF', 3) for v in s.values])
-            tm.assert_array_equal(result.values, expected)
+            tm.assert_numpy_array_equal(result.values, expected)
 
             result = s.str.index('E', 4, 8)
-            tm.assert_array_equal(result, klass([4, 5, 7, 4]))
+            tm.assert_numpy_array_equal(result, klass([4, 5, 7, 4]))
             expected = np.array([v.index('E', 4, 8) for v in s.values])
-            tm.assert_array_equal(result.values, expected)
+            tm.assert_numpy_array_equal(result.values, expected)
 
             result = s.str.rindex('E', 0, 5)
-            tm.assert_array_equal(result, klass([4, 3, 1, 4]))
+            tm.assert_numpy_array_equal(result, klass([4, 3, 1, 4]))
             expected = np.array([v.rindex('E', 0, 5) for v in s.values])
-            tm.assert_array_equal(result.values, expected)
+            tm.assert_numpy_array_equal(result.values, expected)
 
             with tm.assertRaisesRegexp(ValueError, "substring not found"):
                 result = s.str.index('DE')
@@ -956,9 +955,9 @@ class TestStringMethods(tm.TestCase):
         # test with nan
         s = Series(['abcb', 'ab', 'bcbe', np.nan])
         result = s.str.index('b')
-        tm.assert_array_equal(result, Series([1, 1, 0, np.nan]))
+        tm.assert_numpy_array_equal(result, Series([1, 1, 0, np.nan]))
         result = s.str.rindex('b')
-        tm.assert_array_equal(result, Series([3, 1, 2, np.nan]))
+        tm.assert_numpy_array_equal(result, Series([3, 1, 2, np.nan]))
 
     def test_pad(self):
         values = Series(['a', 'b', NA, 'c', NA, 'eeeeee'])
@@ -1054,17 +1053,17 @@ class TestStringMethods(tm.TestCase):
                 table = str.maketrans('abc', 'cde')
             result = s.str.translate(table)
             expected = klass(['cdedefg', 'cdee', 'edddfg', 'edefggg'])
-            tm.assert_array_equal(result, expected)
+            tm.assert_numpy_array_equal(result, expected)
 
             # use of deletechars is python 2 only
             if not compat.PY3:
                 result = s.str.translate(table, deletechars='fg')
                 expected = klass(['cdede', 'cdee', 'eddd', 'ede'])
-                tm.assert_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
 
                 result = s.str.translate(None, deletechars='fg')
                 expected = klass(['abcde', 'abcc', 'cddd', 'cde'])
-                tm.assert_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
             else:
                 with tm.assertRaisesRegexp(ValueError, "deletechars is not a valid argument"):
                     result = s.str.translate(table, deletechars='fg')
@@ -1073,7 +1072,7 @@ class TestStringMethods(tm.TestCase):
         s = Series(['a', 'b', 'c', 1.2])
         expected = Series(['c', 'd', 'e', np.nan])
         result = s.str.translate(table)
-        tm.assert_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_center_ljust_rjust(self):
         values = Series(['a', 'b', NA, 'c', NA, 'eeeeee'])

--- a/pandas/tests/test_testing.py
+++ b/pandas/tests/test_testing.py
@@ -10,8 +10,7 @@ from pandas import Series, DataFrame
 import pandas.util.testing as tm
 from pandas.util.testing import (
     assert_almost_equal, assertRaisesRegexp, raise_with_traceback,
-    assert_series_equal, assert_frame_equal, assert_isinstance,
-    RNGContext
+    assert_series_equal, assert_frame_equal, RNGContext
 )
 
 # let's get meta.
@@ -259,7 +258,7 @@ class TestDeprecatedTests(tm.TestCase):
             self.assertNotAlmostEquals(1, 2)
 
         with tm.assert_produces_warning(FutureWarning):
-            assert_isinstance(Series([1, 2]), Series, msg='xxx')
+            tm.assert_isinstance(Series([1, 2]), Series, msg='xxx')
 
 
 class TestLocale(tm.TestCase):

--- a/pandas/tools/tests/test_tile.py
+++ b/pandas/tools/tests/test_tile.py
@@ -13,8 +13,6 @@ from pandas.core.algorithms import quantile
 from pandas.tools.tile import cut, qcut
 import pandas.tools.tile as tmod
 
-from numpy.testing import assert_equal, assert_almost_equal
-
 
 class TestCut(tm.TestCase):
 
@@ -22,31 +20,31 @@ class TestCut(tm.TestCase):
         data = np.ones(5)
         result = cut(data, 4, labels=False)
         desired = [1, 1, 1, 1, 1]
-        assert_equal(result, desired)
+        tm.assert_numpy_array_equal(result, desired)
 
     def test_bins(self):
         data = np.array([.2, 1.4, 2.5, 6.2, 9.7, 2.1])
         result, bins = cut(data, 3, retbins=True)
-        assert_equal(result.codes, [0, 0, 0, 1, 2, 0])
-        assert_almost_equal(bins, [0.1905, 3.36666667, 6.53333333, 9.7])
+        tm.assert_numpy_array_equal(result.codes, [0, 0, 0, 1, 2, 0])
+        tm.assert_almost_equal(bins, [0.1905, 3.36666667, 6.53333333, 9.7])
 
     def test_right(self):
         data = np.array([.2, 1.4, 2.5, 6.2, 9.7, 2.1, 2.575])
         result, bins = cut(data, 4, right=True, retbins=True)
-        assert_equal(result.codes, [0, 0, 0, 2, 3, 0, 0])
-        assert_almost_equal(bins, [0.1905, 2.575, 4.95, 7.325, 9.7])
+        tm.assert_numpy_array_equal(result.codes, [0, 0, 0, 2, 3, 0, 0])
+        tm.assert_almost_equal(bins, [0.1905, 2.575, 4.95, 7.325, 9.7])
 
     def test_noright(self):
         data = np.array([.2, 1.4, 2.5, 6.2, 9.7, 2.1, 2.575])
         result, bins = cut(data, 4, right=False, retbins=True)
-        assert_equal(result.codes, [0, 0, 0, 2, 3, 0, 1])
-        assert_almost_equal(bins, [0.2, 2.575, 4.95, 7.325, 9.7095])
+        tm.assert_numpy_array_equal(result.codes, [0, 0, 0, 2, 3, 0, 1])
+        tm.assert_almost_equal(bins, [0.2, 2.575, 4.95, 7.325, 9.7095])
 
     def test_arraylike(self):
         data = [.2, 1.4, 2.5, 6.2, 9.7, 2.1]
         result, bins = cut(data, 3, retbins=True)
-        assert_equal(result.codes, [0, 0, 0, 1, 2, 0])
-        assert_almost_equal(bins, [0.1905, 3.36666667, 6.53333333, 9.7])
+        tm.assert_numpy_array_equal(result.codes, [0, 0, 0, 1, 2, 0])
+        tm.assert_almost_equal(bins, [0.1905, 3.36666667, 6.53333333, 9.7])
 
     def test_bins_not_monotonic(self):
         data = [.2, 1.4, 2.5, 6.2, 9.7, 2.1]
@@ -68,7 +66,7 @@ class TestCut(tm.TestCase):
         s = Series([0, -1, 0, 1, -3])
         ind = cut(s, [0, 1], labels=False)
         exp = [np.nan, np.nan, np.nan, 0, np.nan]
-        assert_almost_equal(ind, exp)
+        tm.assert_almost_equal(ind, exp)
 
     def test_labels(self):
         arr = np.tile(np.arange(0, 1.01, 0.1), 4)
@@ -122,8 +120,8 @@ class TestCut(tm.TestCase):
 
         ex_categories = ['(-inf, 2]', '(2, 4]', '(4, inf]']
 
-        np.testing.assert_array_equal(result.categories, ex_categories)
-        np.testing.assert_array_equal(result_ser.cat.categories, ex_categories)
+        tm.assert_numpy_array_equal(result.categories, ex_categories)
+        tm.assert_numpy_array_equal(result_ser.cat.categories, ex_categories)
         self.assertEqual(result[5], '(4, inf]')
         self.assertEqual(result[0], '(-inf, 2]')
         self.assertEqual(result_ser[5], '(4, inf]')
@@ -134,7 +132,7 @@ class TestCut(tm.TestCase):
 
         labels, bins = qcut(arr, 4, retbins=True)
         ex_bins = quantile(arr, [0, .25, .5, .75, 1.])
-        assert_almost_equal(bins, ex_bins)
+        tm.assert_almost_equal(bins, ex_bins)
 
         ex_levels = cut(arr, ex_bins, include_lowest=True)
         self.assert_numpy_array_equal(labels, ex_levels)
@@ -252,12 +250,12 @@ class TestCut(tm.TestCase):
         # GH 8589
         s = Series(np.arange(4))
         result, bins = cut(s, 2, retbins=True)
-        assert_equal(result.cat.codes.values, [0, 0, 1, 1])
-        assert_almost_equal(bins, [-0.003, 1.5, 3])
+        tm.assert_numpy_array_equal(result.cat.codes.values, [0, 0, 1, 1])
+        tm.assert_almost_equal(bins, [-0.003, 1.5, 3])
 
         result, bins = qcut(s, 2, retbins=True)
-        assert_equal(result.cat.codes.values, [0, 0, 1, 1])
-        assert_almost_equal(bins, [0, 1.5, 3])
+        tm.assert_numpy_array_equal(result.cat.codes.values, [0, 0, 1, 1])
+        tm.assert_almost_equal(bins, [0, 1.5, 3])
 
 
 def curpath():

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -30,7 +30,6 @@ from pandas.util.testing import(assert_series_equal, assert_almost_equal,
                                 assertRaisesRegexp)
 import pandas.util.testing as tm
 from pandas import compat
-from numpy.testing import assert_array_equal
 
 
 class TestPeriodProperties(tm.TestCase):
@@ -1979,7 +1978,7 @@ class TestPeriodIndex(tm.TestCase):
 
         idx1 = PeriodIndex(ordinal=[-1, 0, 1], freq='A')
         idx2 = PeriodIndex(ordinal=np.array([-1, 0, 1]), freq='A')
-        assert_array_equal(idx1,idx2)
+        tm.assert_numpy_array_equal(idx1,idx2)
 
     def test_dti_to_period(self):
         dti = DatetimeIndex(start='1/1/2005', end='12/1/2005', freq='M')
@@ -2393,7 +2392,7 @@ class TestPeriodIndex(tm.TestCase):
 
         result = index.map(lambda x: x.ordinal)
         exp = [x.ordinal for x in index]
-        assert_array_equal(result, exp)
+        tm.assert_numpy_array_equal(result, exp)
 
     def test_map_with_string_constructor(self):
         raw = [2005, 2007, 2009]
@@ -2418,7 +2417,7 @@ class TestPeriodIndex(tm.TestCase):
             self.assertEqual(res.dtype, np.dtype('object').type)
 
             # lastly, values should compare equal
-            assert_array_equal(res, expected)
+            tm.assert_numpy_array_equal(res, expected)
 
     def test_convert_array_of_periods(self):
         rng = period_range('1/1/2000', periods=20, freq='D')

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -5,7 +5,6 @@ from pandas.compat import lrange, zip
 
 import numpy as np
 from numpy.testing.decorators import slow
-from numpy.testing import assert_array_equal
 
 from pandas import Index, Series, DataFrame
 
@@ -306,7 +305,7 @@ class TestTSPlot(tm.TestCase):
         bts = DataFrame({'a': tm.makeTimeSeries()})
         ax = bts.plot()
         idx = ax.get_lines()[0].get_xdata()
-        assert_array_equal(bts.index.to_period(), PeriodIndex(idx))
+        tm.assert_numpy_array_equal(bts.index.to_period(), PeriodIndex(idx))
 
     @slow
     def test_axis_limits(self):
@@ -642,9 +641,9 @@ class TestTSPlot(tm.TestCase):
         self.assertFalse(hasattr(ax, 'freq'))
         lines = ax.get_lines()
         x1 = lines[0].get_xdata()
-        assert_array_equal(x1, s2.index.asobject.values)
+        tm.assert_numpy_array_equal(x1, s2.index.asobject.values)
         x2 = lines[1].get_xdata()
-        assert_array_equal(x2, s1.index.asobject.values)
+        tm.assert_numpy_array_equal(x2, s1.index.asobject.values)
 
     def test_mixed_freq_regular_first_df(self):
         # GH 9852
@@ -674,9 +673,9 @@ class TestTSPlot(tm.TestCase):
         self.assertFalse(hasattr(ax, 'freq'))
         lines = ax.get_lines()
         x1 = lines[0].get_xdata()
-        assert_array_equal(x1, s2.index.asobject.values)
+        tm.assert_numpy_array_equal(x1, s2.index.asobject.values)
         x2 = lines[1].get_xdata()
-        assert_array_equal(x2, s1.index.asobject.values)
+        tm.assert_numpy_array_equal(x2, s1.index.asobject.values)
 
     def test_mixed_freq_hf_first(self):
         idxh = date_range('1/1/1999', periods=365, freq='D')
@@ -1044,7 +1043,7 @@ class TestTSPlot(tm.TestCase):
         fig = plt.figure()
         ax = fig.add_subplot(111)
         lines = ax.plot(x, y, label='Y')
-        assert_array_equal(DatetimeIndex(lines[0].get_xdata()), x)
+        tm.assert_numpy_array_equal(DatetimeIndex(lines[0].get_xdata()), x)
 
     @slow
     def test_mpl_nopandas(self):
@@ -1063,9 +1062,9 @@ class TestTSPlot(tm.TestCase):
         ax.plot_date([x.toordinal() for x in dates], values2, **kw)
 
         line1, line2 = ax.get_lines()
-        assert_array_equal(np.array([x.toordinal() for x in dates]),
+        tm.assert_numpy_array_equal(np.array([x.toordinal() for x in dates]),
                            line1.get_xydata()[:, 0])
-        assert_array_equal(np.array([x.toordinal() for x in dates]),
+        tm.assert_numpy_array_equal(np.array([x.toordinal() for x in dates]),
                            line2.get_xydata()[:, 0])
 
     @slow

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -30,7 +30,6 @@ import pandas.index as _index
 
 from pandas.compat import range, long, StringIO, lrange, lmap, zip, product
 from numpy.random import rand
-from numpy.testing import assert_array_equal
 from pandas.util.testing import assert_frame_equal
 import pandas.compat as compat
 import pandas.core.common as com
@@ -849,11 +848,11 @@ class TestTimeSeries(tm.TestCase):
 
         result2 = to_datetime(strings)
         tm.assertIsInstance(result2, DatetimeIndex)
-        self.assert_numpy_array_equivalent(result, result2)
+        tm.assert_numpy_array_equal(result, result2)
 
         malformed = np.array(['1/100/2000', np.nan], dtype=object)
         result = to_datetime(malformed)
-        self.assert_numpy_array_equivalent(result, malformed)
+        tm.assert_numpy_array_equal(result, malformed)
 
         self.assertRaises(ValueError, to_datetime, malformed,
                           errors='raise')
@@ -936,7 +935,7 @@ class TestTimeSeries(tm.TestCase):
             result = getattr(idx, field)
             expected = [getattr(x, field) if x is not NaT else np.nan
                         for x in idx]
-            self.assert_numpy_array_equivalent(result, np.array(expected))
+            self.assert_numpy_array_equal(result, np.array(expected))
 
     def test_nat_scalar_field_access(self):
         fields = ['year', 'quarter', 'month', 'day', 'hour',
@@ -2758,7 +2757,7 @@ class TestDatetimeIndex(tm.TestCase):
         joined = cols.join(df.columns)
         self.assertEqual(cols.dtype, np.dtype('O'))
         self.assertEqual(cols.dtype, joined.dtype)
-        assert_array_equal(cols.values, joined.values)
+        tm.assert_numpy_array_equal(cols.values, joined.values)
 
     def test_slice_keeps_name(self):
         # GH4226

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -21,7 +21,6 @@ from distutils.version import LooseVersion
 
 from numpy.random import randn, rand
 import numpy as np
-from numpy.testing import assert_array_equal
 
 import pandas as pd
 from pandas.core.common import (is_sequence, array_equivalent, is_list_like, is_number,
@@ -631,34 +630,14 @@ def assert_categorical_equal(res, exp):
         raise AssertionError("ordered not the same")
 
 
-def assert_numpy_array_equal(np_array, assert_equal, err_msg=None):
-    """Checks that 'np_array' is equal to 'assert_equal'
+def assert_numpy_array_equal(np_array, assert_equal,
+                             strict_nan=False, err_msg=None):
+    """Checks that 'np_array' is equivalent to 'assert_equal'.
 
-    Note that the expected array should not contain `np.nan`!
-    Two numpy arrays are equal if all
-    elements are equal, which is not possible if `np.nan` is such an element!
-
-    If the expected array includes `np.nan` use
-    `assert_numpy_array_equivalent(...)`.
-    """
-    if np.array_equal(np_array, assert_equal):
-        return
-    if err_msg is None:
-        err_msg = '{0} is not equal to {1}.'.format(np_array, assert_equal)
-    raise AssertionError(err_msg)
-
-
-def assert_numpy_array_equivalent(np_array, assert_equal, strict_nan=False, err_msg=None):
-    """Checks that 'np_array' is equivalent to 'assert_equal'
-
-    Two numpy arrays are equivalent if the arrays have equal non-NaN elements,
-     and `np.nan` in corresponding locations.
-
-    If the the expected array does not contain `np.nan`
-    `assert_numpy_array_equivalent` is the similar to
-    `assert_numpy_array_equal()`. If the expected array includes
-    `np.nan` use this
-    function.
+    This is similar to ``numpy.testing.assert_array_equal``, but can
+    check equality including ``np.nan``. Two numpy arrays are regarded as
+    equivalent if the arrays have equal non-NaN elements,
+    and `np.nan` in corresponding locations.
     """
     if array_equivalent(np_array, assert_equal, strict_nan=strict_nan):
         return
@@ -694,7 +673,7 @@ def assert_series_equal(left, right, check_dtype=True,
                     '[datetimelike_compat=True] {0} is not equal to {1}.'.format(left.values,
                                                                                  right.values))
         else:
-            assert_numpy_array_equivalent(left.values, right.values)
+            assert_numpy_array_equal(left.values, right.values)
     else:
         assert_almost_equal(left.values, right.values, check_less_precise)
     if check_less_precise:


### PR DESCRIPTION
Closes #10427.
