### PR TITLE
BUG: display.precision options seems off-by-one  (GH10451)

### DIFF
--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -227,7 +227,7 @@ can specify the option ``df.info(null_counts=True)`` to override on showing a pa
    df.info()
    pd.reset_option('max_info_rows')
 
-``display.precision`` sets the output display precision. This is only a
+``display.precision`` sets the output display precision in terms of decimal places. This is only a
 suggestion.
 
 .. ipython:: python
@@ -368,9 +368,11 @@ display.notebook_repr_html True         When True, IPython notebook will
                                         pandas objects (if it is available).
 display.pprint_nest_depth  3            Controls the number of nested levels
                                         to process when pretty-printing
-display.precision          7            Floating point output precision
-                                        (number of significant digits). This is
-                                        only a suggestion
+display.precision          6            Floating point output precision in
+                                        terms of number of places after the
+                                        decimal, for regular formatting as well
+                                        as scientific notation. Similar to
+                                        numpy's ``precision`` print option
 display.show_dimensions    truncate     Whether to print out dimensions
                                         at the end of DataFrame repr.
                                         If 'truncate' is specified, only

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -391,6 +391,42 @@ New behavior:
 
 See :ref:`documentation <io.hdf5>` for more details.
 
+Changes to ``display.precision`` option
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``display.precision`` option has been clarified to refer to decimal places (:issue:`10451`).
+
+Earlier versions of pandas would format floating point numbers to have one less decimal place than the value in
+``display.precision``.
+
+.. code-block:: python
+
+  In [1]: pd.set_option('display.precision', 2)
+
+  In [2]: pd.DataFrame({'x': [123.456789]})
+  Out[2]:
+         x
+  0  123.5
+
+If interpreting precision as "significant figures" this did work for scientific notation but that same interpretation
+did not work for values with standard formatting. It was also out of step with how numpy handles formatting.
+
+Going forward the value of ``display.precision`` will directly control the number of places after the decimal, for
+regular formatting as well as scientific notation, similar to how numpy's ``precision`` print option works.
+
+.. ipython:: python
+
+  pd.set_option('display.precision', 2)
+  pd.DataFrame({'x': [123.456789]})
+
+To preserve output behavior with prior versions the default value of ``display.precision`` has been reduced to ``6``
+from ``7``.
+
+.. ipython:: python
+  :suppress:
+  pd.set_option('display.precision', 6)
+
+
 .. _whatsnew_0170.api_breaking.other:
 
 Other API Changes

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -236,7 +236,7 @@ def mpl_style_cb(key):
     return val
 
 with cf.config_prefix('display'):
-    cf.register_option('precision', 7, pc_precision_doc, validator=is_int)
+    cf.register_option('precision', 6, pc_precision_doc, validator=is_int)
     cf.register_option('float_format', None, float_format_doc)
     cf.register_option('column_space', 12, validator=is_int)
     cf.register_option('max_info_rows', 1690785, pc_max_info_rows_doc,

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -2014,7 +2014,7 @@ class FloatArrayFormatter(GenericArrayFormatter):
         if self.formatter is not None:
             fmt_values = [self.formatter(x) for x in self.values]
         else:
-            fmt_str = '%% .%df' % (self.digits - 1)
+            fmt_str = '%% .%df' % self.digits
             fmt_values = self._format_with(fmt_str)
 
             if len(fmt_values) > 0:
@@ -2022,20 +2022,20 @@ class FloatArrayFormatter(GenericArrayFormatter):
             else:
                 maxlen = 0
 
-            too_long = maxlen > self.digits + 5
+            too_long = maxlen > self.digits + 6
 
             abs_vals = np.abs(self.values)
 
             # this is pretty arbitrary for now
             has_large_values = (abs_vals > 1e8).any()
-            has_small_values = ((abs_vals < 10 ** (-self.digits+1)) &
+            has_small_values = ((abs_vals < 10 ** (-self.digits)) &
                                 (abs_vals > 0)).any()
 
             if too_long and has_large_values:
-                fmt_str = '%% .%de' % (self.digits - 1)
+                fmt_str = '%% .%de' % self.digits
                 fmt_values = self._format_with(fmt_str)
             elif has_small_values:
-                fmt_str = '%% .%de' % (self.digits - 1)
+                fmt_str = '%% .%de' % self.digits
                 fmt_values = self._format_with(fmt_str)
 
         return fmt_values


### PR DESCRIPTION
Closes #10451 

I made a call here in response to my questions on #10451 and hopefully people like it. I made it clear that "precision" refers to places after the decimal, not significant figures, and changed the default value to match so that for many pandas users no change would be detected. I updated the Options docs and also What's New. For tests I basically updated the precision setting to the new semantics, so that the expected strings wouldn't need to change.

The one question I have is the code that computes `too_long`. This compares the longest formatted string against what looks to be an arbitrary constant of "number of digits + 5". Changing the 5 to a 4 or 6 doesn't trip up any unit tests. If it's desired, this could be increased by 1 as the "new" digits value is effectively 1 less than what the old value in terms of its effects on formatting, so the 5 would need to change to a 6 to maintain behavior. I could write tests on this as well.
