### PR TITLE
DOC: Clarified PyTables "natural" names

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -3179,9 +3179,10 @@ Notes & Caveats
 .. warning::
 
    ``PyTables`` will show a ``NaturalNameWarning`` if a  column name
-   cannot be used as an attribute selector. Generally identifiers that
-   have spaces, start with numbers, or ``_``, or have ``-`` embedded are not considered
-   *natural*. These types of identifiers cannot be used in a ``where`` clause
+   cannot be used as an attribute selector.
+   *Natural* identifiers contain only letters, numbers, and underscores,
+   and may not begin with a number.
+   Other identifiers cannot be used in a ``where`` clause
    and are generally a bad idea.
 
 DataTypes


### PR DESCRIPTION
The HDF5 documentation "Notes & Caveats" defines a PyTables NaturalNameWarning vaguely, and incorrectly states that a natural name may not begin with an underscore. I clarified the definition of a natural identifier. The relevant regex is defined [here](https://github.com/PyTables/PyTables/blob/2fde39957c7b5263dd4d0b11aa797900250f16bc/tables/path.py#L39) in the PyTables source.
