### PR TITLE
Fix a typo 'does' -> 'do'

### DIFF
--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1055,7 +1055,7 @@ class Index(IndexOpsMixin, PandasObject):
         raise TypeError("unhashable type: %r" % type(self).__name__)
 
     def __setitem__(self, key, value):
-        raise TypeError("Indexes does not support mutable operations")
+        raise TypeError("Indexes do not support mutable operations")
 
     def __getitem__(self, key):
         """


### PR DESCRIPTION
This came up during the SciPy 2015 tutorial.
