### PR TITLE
BUG : read_csv() twice decodes stream on URL file #10424

### DIFF
--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -94,7 +94,7 @@ def maybe_read_encoded_stream(reader, encoding=None):
         else:
             errors = 'replace'
             encoding = 'utf-8'
-        reader = StringIO(reader.read().decode(encoding, errors))
+        reader = BytesIO(reader.read())
     else:
         encoding = None
     return reader, encoding


### PR DESCRIPTION
As described in #10424 , reading non-utf-8 csv files from URL leads to decoding problems, i.e. a decoding may first be made in io.common.get_filepath_or_buffer() when file is URL.
Modification done makes this function read stream from URL without decoding (this is done later, at the same place as for local files). 
It's also used by io.common.read_stata(), io.common.read_json() and io.common.read_msgpack(). Similar problems  reading stata and msgpack URL files may also be solved using this modification.

Thanks for reviewing.
