### PR TITLE
CLN: cleanup up platform / python version checks. fix GB10151

### DIFF
--- a/bench/bench_sparse.py
+++ b/bench/bench_sparse.py
@@ -1,4 +1,3 @@
-import sys
 import numpy as np
 
 from pandas import *
@@ -30,7 +29,7 @@ is2 = SparseSeries(arr2, kind='integer', index=index)
 s1_dense = s1.to_dense()
 s2_dense = s2.to_dense()
 
-if 'linux' in sys.platform:
+if compat.is_platform_linux():
     pth = '/home/wesm/code/pandas/example'
 else:
     pth = '/Users/wesm/code/pandas/example'

--- a/pandas/computation/tests/test_eval.py
+++ b/pandas/computation/tests/test_eval.py
@@ -163,9 +163,7 @@ class TestEvalNumexprPandas(tm.TestCase):
             self.check_floor_division(lhs, '//', rhs)
 
     def test_pow(self):
-        import platform
-        if platform.system() == 'Windows':
-            raise nose.SkipTest('not testing pow on Windows')
+        tm._skip_if_windows()
 
         # odd failure on win32 platform, so skip
         for lhs, rhs in product(self.lhses, self.rhses):

--- a/pandas/io/tests/test_json/test_ujson.py
+++ b/pandas/io/tests/test_json/test_ujson.py
@@ -36,7 +36,7 @@ def _skip_if_python_ver(skip_major, skip_minor=None):
         raise nose.SkipTest("skipping Python version %d.%d" % (major, minor))
 
 
-json_unicode = (json.dumps if sys.version_info[0] >= 3
+json_unicode = (json.dumps if compat.PY3
                 else partial(json.dumps, encoding="utf-8"))
 
 class UltraJSONTests(TestCase):

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -163,7 +163,7 @@ g,7,seven
 
     def test_read_csv(self):
         if not compat.PY3:
-            if 'win' in sys.platform:
+            if compat.is_platform_windows():
                 prefix = u("file:///")
             else:
                 prefix = u("file://")

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -2067,9 +2067,8 @@ class TestHDFStore(tm.TestCase):
         # GH2852
         # issue storing datetime.date with a timezone as it resets when read back in a new timezone
 
-        import platform
-        if platform.system() == "Windows":
-            raise nose.SkipTest("timezone setting not supported on windows")
+        # timezone setting not supported on windows
+        tm._skip_if_windows()
 
         import datetime
         import time

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -2,7 +2,6 @@
 import collections
 from datetime import datetime
 import re
-import sys
 
 import nose
 from nose.tools import assert_equal
@@ -447,7 +446,7 @@ def test_is_hashable():
 
     # old-style classes in Python 2 don't appear hashable to
     # collections.Hashable but also seem to support hash() by default
-    if sys.version_info[0] == 2:
+    if compat.PY2:
         class OldStyleClass():
             pass
         c = OldStyleClass()

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -990,7 +990,7 @@ class TestDataFrameFormatting(tm.TestCase):
 </table>
 <p>20 rows × 20 columns</p>
 </div>'''.format(div_style)
-        if sys.version_info[0] < 3:
+        if compat.PY2:
             expected = expected.decode('utf-8')
         self.assertEqual(result, expected)
 
@@ -1106,7 +1106,7 @@ class TestDataFrameFormatting(tm.TestCase):
 </table>
 <p>8 rows × 8 columns</p>
 </div>'''.format(div_style)
-        if sys.version_info[0] < 3:
+        if compat.PY2:
             expected = expected.decode('utf-8')
         self.assertEqual(result, expected)
 
@@ -1216,7 +1216,7 @@ class TestDataFrameFormatting(tm.TestCase):
 </table>
 <p>8 rows × 8 columns</p>
 </div>'''.format(div_style)
-        if sys.version_info[0] < 3:
+        if compat.PY2:
             expected = expected.decode('utf-8')
         self.assertEqual(result, expected)
 

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -1022,7 +1022,7 @@ class TestIndex(Base, tm.TestCase):
         # windows has different precision on datetime.datetime.now (it doesn't include us
         # since the default for Timestamp shows these but Index formating does not
         # we are skipping
-        if not is_platform_windows:
+        if not is_platform_windows():
             formatted = index.format()
             expected = [str(index[0])]
             self.assertEqual(formatted, expected)

--- a/pandas/tools/tests/test_util.py
+++ b/pandas/tools/tests/test_util.py
@@ -43,8 +43,7 @@ class TestLocaleUtils(tm.TestCase):
         if not cls.locales:
             raise nose.SkipTest("No locales found")
 
-        if os.name == 'nt':  # we're on windows
-            raise nose.SkipTest("Running on Windows")
+        tm._skip_if_windows()
 
     @classmethod
     def tearDownClass(cls):

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from pandas.compat import range
 import nose
-import sys
 import numpy as np
 
 from pandas.core.index import Index
@@ -14,11 +13,6 @@ from pandas.tseries.index import cdate_range, bdate_range, date_range
 import pandas.core.datetools as datetools
 from pandas.util.testing import assertRaisesRegexp
 import pandas.util.testing as tm
-
-
-def _skip_if_windows_python_3():
-    if sys.version_info > (3,) and sys.platform == 'win32':
-        raise nose.SkipTest("not used on python 3/win32")
 
 
 def eq_gen_range(kwargs, expected):
@@ -459,7 +453,7 @@ class TestDateRange(tm.TestCase):
         early_dr.union(late_dr)
 
     def test_month_range_union_tz_dateutil(self):
-        _skip_if_windows_python_3()
+        tm._skip_if_windows_python_3()
         tm._skip_if_no_dateutil()
         from pandas.tslib import _dateutil_gettz as timezone
         tz = timezone('US/Eastern')

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -46,14 +46,6 @@ def _skip_if_has_locale():
     if lang is not None:
         raise nose.SkipTest("Specific locale is set {0}".format(lang))
 
-def _skip_if_windows_python_3():
-    if sys.version_info > (3,) and sys.platform == 'win32':
-        raise nose.SkipTest("not used on python 3/win32")
-
-def _skip_if_not_windows_python_3():
-    if sys.version_info < (3,) or sys.platform != 'win32':
-        raise nose.SkipTest("only run on python 3/win32")
-
 
 class TestTimeSeriesDuplicates(tm.TestCase):
     _multiprocess_can_split_ = True
@@ -417,7 +409,7 @@ class TestTimeSeries(tm.TestCase):
         self.assertEqual(stamp.tzinfo, dtval.tzinfo)
 
     def test_timestamp_to_datetime_explicit_dateutil(self):
-        _skip_if_windows_python_3()
+        tm._skip_if_windows_python_3()
         tm._skip_if_no_dateutil()
         from pandas.tslib import _dateutil_gettz as gettz
         rng = date_range('20090415', '20090519',

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -1,7 +1,5 @@
 # pylint: disable-msg=E1101,W0612
 from datetime import datetime, timedelta, tzinfo, date
-import sys
-import os
 import nose
 
 import numpy as np
@@ -837,8 +835,8 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
         return x.replace(tzinfo=tz)
 
     def test_utc_with_system_utc(self):
-        if sys.platform == 'win32':
-            raise nose.SkipTest('Skipped on win32 due to dateutil bug.')
+        # Skipped on win32 due to dateutil bug
+        tm._skip_if_windows()
 
         from pandas.tslib import maybe_get_tz
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -28,7 +28,7 @@ from pandas.core.common import is_sequence, array_equivalent, is_list_like, is_n
 import pandas.compat as compat
 from pandas.compat import(
     filter, map, zip, range, unichr, lrange, lmap, lzip, u, callable, Counter,
-    raise_with_traceback, httplib
+    raise_with_traceback, httplib, is_platform_windows
 )
 
 from pandas.computation import expressions as expr
@@ -221,6 +221,17 @@ def _skip_if_no_dateutil():
     except ImportError:
         import nose
         raise nose.SkipTest("dateutil not installed")
+
+
+def _skip_if_windows_python_3():
+    if compat.PY3 and is_platform_windows():
+        import nose
+        raise nose.SkipTest("not used on python 3/win32")
+
+def _skip_if_windows():
+    if is_platform_windows():
+        import nose
+        raise nose.SkipTest("Running on Windows")
 
 
 def _skip_if_no_cday():


### PR DESCRIPTION
Notes:
- I did not use `is_platform_xxx` on `pandas/util/clipboard.py` because this module is a fork. So I guess better not deviate from the original, right?
- I added the helper `_skip_if_windows` function in `pandas/util/testing.py`, I added an underscore before `skip` to maintain consistency with other `skip` functions (although none of them should have this underscore...)

> I think we could use an update on the wiki on the same 

I didnt find any references on the wiki or docs.
