### PR TITLE
BUG: pd.eval with numexpr engine coerces 1 element numpy array to scalar

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -366,6 +366,7 @@ Bug Fixes
 
 - Bug that caused segfault when resampling an empty Series (:issue:`10228`)
 - Bug in ``DatetimeIndex`` and ``PeriodIndex.value_counts`` resets name from its result, but retains in result's ``Index``. (:issue:`10150`)
+- Bug in `pd.eval` using ``numexpr`` engine coerces 1 element numpy array to scalar (:issue:`10546`)
 - Bug in `pandas.concat` with ``axis=0`` when column is of dtype ``category`` (:issue:`10177`)
 - Bug in ``read_msgpack`` where input type is not always checked (:issue:`10369`)
 - Bug in `pandas.read_csv` with kwargs ``index_col=False``, ``index_col=['a', 'b']`` or ``dtype``

--- a/pandas/computation/align.py
+++ b/pandas/computation/align.py
@@ -172,12 +172,11 @@ def _reconstruct_object(typ, obj, axes, dtype):
         ret_value = res_t.type(obj)
     else:
         ret_value = typ(obj).astype(res_t)
+        # The condition is to distinguish 0-dim array (returned in case of scalar)
+        # and 1 element array
+        # e.g. np.array(0) and np.array([0])
+        if len(obj.shape) == 1 and len(obj) == 1:
+            if not isinstance(ret_value, np.ndarray):
+                ret_value = np.array([ret_value]).astype(res_t)
 
-    try:
-        ret = ret_value.item()
-    except (ValueError, IndexError):
-        # XXX: we catch IndexError to absorb a
-        # regression in numpy 1.7.0
-        # fixed by numpy/numpy@04b89c63
-        ret = ret_value
-    return ret
+    return ret_value


### PR DESCRIPTION
Closes #10546. Used `assert_numpy_atray_equivalent` to guarantee array comparison, not scalar. This should be prior to #10542 and being changed to use `assert_numpy_array_equal` in #10542.
