### PR TITLE
ERR: Boolean comparisons of a Series vs None will now be equivalent to null comparisons

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -232,6 +232,7 @@ Other API Changes
 - Allow passing `kwargs` to the interpolation methods (:issue:`10378`).
 - Serialize metadata properties of subclasses of pandas objects (:issue:`10553`).
 - Boolean comparisons of a ``Series`` vs None will now be equivalent to comparing with np.nan, rather than raise ``TypeError``, xref (:issue:`1079`).
+- Remove use of some deprecated numpy comparisons (:issue:`10569`)
 
 .. _whatsnew_0170.deprecations:
 

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -230,8 +230,6 @@ Other API Changes
 - Enable serialization of lists and dicts to strings in ExcelWriter (:issue:`8188`)
 - Allow passing `kwargs` to the interpolation methods (:issue:`10378`).
 - Serialize metadata properties of subclasses of pandas objects (:issue:`10553`).
-- Boolean comparisons of a ``Series`` vs ``None`` will now be equivalent to comparing with ``np.nan``, rather than raise ``TypeError``, xref (:issue:`1079`).
-- Remove use of some deprecated numpy comparisons (:issue:`10569`)
 
 .. _whatsnew_0170.deprecations:
 
@@ -242,6 +240,8 @@ Deprecations
 
 Removal of prior version deprecations/changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Remove use of some deprecated numpy comparison operations, mainly in tests. (:issue:`10569`)
 
 .. _dask: https://dask.readthedocs.org/en/latest/
 
@@ -285,6 +285,7 @@ Performance Improvements
 Bug Fixes
 ~~~~~~~~~
 
+- Boolean comparisons of a ``Series`` vs ``None`` will now be equivalent to comparing with ``np.nan``, rather than raise ``TypeError``, xref (:issue:`1079`).
 - Bug in ``DataFrame.apply`` when function returns categorical series. (:issue:`9573`)
 - Bug in ``to_datetime`` with invalid dates and formats supplied (:issue:`10154`)
 - Bug in ``Index.drop_duplicates`` dropping name(s) (:issue:`10115`)

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -231,7 +231,7 @@ Other API Changes
 - Enable serialization of lists and dicts to strings in ExcelWriter (:issue:`8188`)
 - Allow passing `kwargs` to the interpolation methods (:issue:`10378`).
 - Serialize metadata properties of subclasses of pandas objects (:issue:`10553`).
-
+- Boolean comparisons of a ``Series`` vs None will now be equivalent to comparing with np.nan, rather than raise ``TypeError``, xref (:issue:`1079`).
 
 .. _whatsnew_0170.deprecations:
 

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -34,6 +34,7 @@ New features
 
 Other enhancements
 ^^^^^^^^^^^^^^^^^^
+
 - Enable `read_hdf` to be used without specifying a key when the HDF file contains a single dataset (:issue:`10443`)
 
 - ``DatetimeIndex`` can be instantiated using strings contains ``NaT`` (:issue:`7599`)
@@ -91,7 +92,7 @@ Backwards incompatible API changes
 Changes to convert_objects
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- ``DataFrame.convert_objects`` keyword arguments have been shortened. (:issue:`10265`)
+``DataFrame.convert_objects`` keyword arguments have been shortened. (:issue:`10265`)
 
   =====================   =============
   Old                     New
@@ -101,70 +102,65 @@ Changes to convert_objects
   ``convert_timedelta``   ``timedelta``
   =====================   =============
 
-- Coercing types with ``DataFrame.convert_objects`` is now implemented using the
-  keyword argument ``coerce=True``.  Previously types were coerced by setting a
-  keyword argument to ``'coerce'`` instead of ``True``, as in ``convert_dates='coerce'``.
+Coercing types with ``DataFrame.convert_objects`` is now implemented using the
+keyword argument ``coerce=True``.  Previously types were coerced by setting a
+keyword argument to ``'coerce'`` instead of ``True``, as in ``convert_dates='coerce'``.
 
-  .. ipython:: python
+.. ipython:: python
 
-    df = pd.DataFrame({'i': ['1','2'],
-                       'f': ['apple', '4.2'],
-                       's': ['apple','banana']})
-    df
+   df = pd.DataFrame({'i': ['1','2'],
+                      'f': ['apple', '4.2'],
+                      's': ['apple','banana']})
+   df
 
-  The old usage of ``DataFrame.convert_objects`` used `'coerce'` along with the
-  type.
+The old usage of ``DataFrame.convert_objects`` used `'coerce'` along with the
+type.
 
-  .. code-block:: python
+.. code-block:: python
 
-    In [2]: df.convert_objects(convert_numeric='coerce')
+   In [2]: df.convert_objects(convert_numeric='coerce')
 
-  Now the ``coerce`` keyword must be explicitly used.
+Now the ``coerce`` keyword must be explicitly used.
 
-  .. ipython:: python
+.. ipython:: python
 
-    df.convert_objects(numeric=True, coerce=True)
+   df.convert_objects(numeric=True, coerce=True)
 
-- In earlier versions of pandas, ``DataFrame.convert_objects`` would not coerce
-  numeric types when there were no values convertible to a numeric type.  For example,
+In earlier versions of pandas, ``DataFrame.convert_objects`` would not coerce
+numeric types when there were no values convertible to a numeric type. This returns
+the original DataFrame with no conversion. This change alters
+this behavior so that converts all non-number-like strings to ``NaN``.
 
-  .. code-block:: python
+.. code-block:: python
 
-    In [1]: df = pd.DataFrame({'s': ['a','b']})
-    In [2]: df.convert_objects(convert_numeric='coerce')
-    Out[2]:
-        s
-     0  a
-     1  b
+   In [1]: df = pd.DataFrame({'s': ['a','b']})
+   In [2]: df.convert_objects(convert_numeric='coerce')
+   Out[2]:
+          s
+       0  a
+       1  b
 
-  returns the original DataFrame with no conversion. This change alters
-  this behavior so that
+.. ipython:: python
 
-  .. ipython:: python
+   pd.DataFrame({'s': ['a','b']})
+   df.convert_objects(numeric=True, coerce=True)
 
-    pd.DataFrame({'s': ['a','b']})
-    df.convert_objects(numeric=True, coerce=True)
+In earlier versions of pandas, the default behavior was to try and convert
+datetimes and timestamps. The new default is for ``DataFrame.convert_objects``
+to do nothing, and so it is necessary to pass at least one conversion target
+in the method call.
 
-  converts all non-number-like strings to ``NaN``.
+Changes to Index Comparisons
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- In earlier versions of pandas, the default behavior was to try and convert
-  datetimes and timestamps. The new default is for ``DataFrame.convert_objects``
-  to do nothing, and so it is necessary to pass at least one conversion target
-  in the method call.
+Operator equal on Index should behavior similarly to Series (:issue:`9947`)
 
-.. _whatsnew_0170.api_breaking.other:
+Starting in v0.17.0, comparing ``Index`` objects of different lengths will raise
+a ``ValueError``. This is to be consistent with the behavior of ``Series``.
 
-Other API Changes
-^^^^^^^^^^^^^^^^^
+Previous behavior:
 
-- Operator equal on Index should behavior similarly to Series (:issue:`9947`)
-
-  Starting in v0.17.0, comparing ``Index`` objects of different lengths will raise
-  a ``ValueError``. This is to be consistent with the behavior of ``Series``.
-
-  Previous behavior:
-
-  .. code-block:: python
+.. code-block:: python
 
    In [2]: pd.Index([1, 2, 3]) == pd.Index([1, 4, 5])
    Out[2]: array([ True, False, False], dtype=bool)
@@ -188,9 +184,9 @@ Other API Changes
    In [7]: pd.Series([1, 2, 3]) == pd.Series([1, 2])
    ValueError: Series lengths must match to compare
 
-  New behavior:
+New behavior:
 
-  .. code-block:: python
+.. code-block:: python
 
    In [8]: pd.Index([1, 2, 3]) == pd.Index([1, 4, 5])
    Out[8]: array([ True, False, False], dtype=bool)
@@ -214,24 +210,27 @@ Other API Changes
    In [13]: pd.Series([1, 2, 3]) == pd.Series([1, 2])
    ValueError: Series lengths must match to compare
 
-  Note that this is different from the ``numpy`` behavior where a comparison can
-  be broadcast:
+Note that this is different from the ``numpy`` behavior where a comparison can
+be broadcast:
 
-  .. ipython:: python
+.. ipython:: python
 
    np.array([1, 2, 3]) == np.array([1])
 
-  or it can return False if broadcasting can not be done:
+or it can return False if broadcasting can not be done:
 
-  .. ipython:: python
+.. ipython:: python
 
    np.array([1, 2, 3]) == np.array([1, 2])
+
+Other API Changes
+^^^^^^^^^^^^^^^^^
 
 - Enable writing Excel files in :ref:`memory <_io.excel_writing_buffer>` using StringIO/BytesIO (:issue:`7074`)
 - Enable serialization of lists and dicts to strings in ExcelWriter (:issue:`8188`)
 - Allow passing `kwargs` to the interpolation methods (:issue:`10378`).
 - Serialize metadata properties of subclasses of pandas objects (:issue:`10553`).
-- Boolean comparisons of a ``Series`` vs None will now be equivalent to comparing with np.nan, rather than raise ``TypeError``, xref (:issue:`1079`).
+- Boolean comparisons of a ``Series`` vs ``None`` will now be equivalent to comparing with ``np.nan``, rather than raise ``TypeError``, xref (:issue:`1079`).
 - Remove use of some deprecated numpy comparisons (:issue:`10569`)
 
 .. _whatsnew_0170.deprecations:
@@ -288,46 +287,48 @@ Bug Fixes
 
 - Bug in ``DataFrame.apply`` when function returns categorical series. (:issue:`9573`)
 - Bug in ``to_datetime`` with invalid dates and formats supplied (:issue:`10154`)
-
 - Bug in ``Index.drop_duplicates`` dropping name(s) (:issue:`10115`)
-
-
 - Bug in ``pd.Series`` when setting a value on an empty ``Series`` whose index has a frequency. (:issue:`10193`)
-
 - Bug in ``DataFrame.plot`` raises ``ValueError`` when color name is specified by multiple characters (:issue:`10387`)
 - Bug in ``DataFrame.reset_index`` when index contains `NaT`. (:issue:`10388`)
-
-
 - Bug in ``ExcelReader`` when worksheet is empty (:issue:`6403`)
-
-
 - Bug in ``Table.select_column`` where name is not preserved (:issue:`10392`)
 - Bug in ``offsets.generate_range`` where ``start`` and ``end`` have finer precision than ``offset`` (:issue:`9907`)
 
 
-- Bug in ``DataFrame.interpolate`` with ``axis=1`` and ``inplace=True`` (:issue:`10395`)
 
+
+
+
+- Bug in ``DataFrame.interpolate`` with ``axis=1`` and ``inplace=True`` (:issue:`10395`)
 - Bug in ``io.sql.get_schema`` when specifying multiple columns as primary
   key (:issue:`10385`).
-
-
 - Bug in ``test_categorical`` on big-endian builds (:issue:`10425`)
 - Bug in ``Series.map`` using categorical ``Series`` raises ``AttributeError`` (:issue:`10324`)
 - Bug in ``MultiIndex.get_level_values`` including ``Categorical`` raises ``AttributeError`` (:issue:`10460`)
 
+
+
+
+
+
+
 - Bug that caused segfault when resampling an empty Series (:issue:`10228`)
 - Bug in ``DatetimeIndex`` and ``PeriodIndex.value_counts`` resets name from its result, but retains in result's ``Index``. (:issue:`10150`)
-
 - Bug in `pandas.concat` with ``axis=0`` when column is of dtype ``category`` (:issue:`10177`)
-
 - Bug in ``read_msgpack`` where input type is not always checked (:issue:`10369`)
-
 - Bug in `pandas.read_csv` with ``index_col=False`` or with ``index_col=['a', 'b']``  (:issue:`10413`, :issue:`10467`)
-
 - Bug in `Series.from_csv` with ``header`` kwarg not setting the ``Series.name`` or the ``Series.index.name`` (:issue:`10483`)
-
 - Bug in `groupby.var` which caused variance to be inaccurate for small float values (:issue:`10448`)
-
 - Bug in ``Series.plot(kind='hist')`` Y Label not informative (:issue:`10485`)
+
+
+
+
+
+
+
+
+
 
 - Bug in operator equal on Index not being consistent with Series (:issue:`9947`)

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -2553,6 +2553,16 @@ def is_datetimelike_v_numeric(a, b):
     return (needs_i8_conversion(a) and f(b)) or (
         needs_i8_conversion(b) and f(a))
 
+def is_datetimelike_v_object(a, b):
+    # return if we have an i8 convertible and object comparision
+    if not hasattr(a,'dtype'):
+        a = np.asarray(a)
+    if not hasattr(b, 'dtype'):
+        b = np.asarray(b)
+    f = lambda x: is_object_dtype(x)
+    return (needs_i8_conversion(a) and f(b)) or (
+        needs_i8_conversion(b) and f(a))
+
 needs_i8_conversion = is_datetime_or_timedelta_dtype
 
 def i8_boxer(arr_or_dtype):

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -463,7 +463,7 @@ def array_equivalent(left, right, strict_nan=False):
         return ((left == right) | (np.isnan(left) & np.isnan(right))).all()
 
     # numpy will will not allow this type of datetimelike vs integer comparison
-    elif is_datetimelike_v_integer(left, right):
+    elif is_datetimelike_v_numeric(left, right):
         return False
 
     # NaNs cannot occur otherwise.
@@ -2543,12 +2543,15 @@ def is_datetime_or_timedelta_dtype(arr_or_dtype):
     return issubclass(tipo, (np.datetime64, np.timedelta64))
 
 
-def is_datetimelike_v_integer(a, b):
-    # return if we have an i8 convertible and and integer comparision
-    a = np.asarray(a)
-    b = np.asarray(b)
-    return (needs_i8_conversion(a) and is_integer_dtype(b)) or (
-        needs_i8_conversion(b) and is_integer_dtype(a))
+def is_datetimelike_v_numeric(a, b):
+    # return if we have an i8 convertible and numeric comparision
+    if not hasattr(a,'dtype'):
+        a = np.asarray(a)
+    if not hasattr(b, 'dtype'):
+        b = np.asarray(b)
+    f = lambda x: is_integer_dtype(x) or is_float_dtype(x)
+    return (needs_i8_conversion(a) and f(b)) or (
+        needs_i8_conversion(b) and f(a))
 
 needs_i8_conversion = is_datetime_or_timedelta_dtype
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -462,6 +462,10 @@ def array_equivalent(left, right, strict_nan=False):
     if issubclass(left.dtype.type, (np.floating, np.complexfloating)):
         return ((left == right) | (np.isnan(left) & np.isnan(right))).all()
 
+    # numpy will will not allow this type of datetimelike vs integer comparison
+    elif is_datetimelike_v_integer(left, right):
+        return False
+
     # NaNs cannot occur otherwise.
     return np.array_equal(left, right)
 
@@ -2538,6 +2542,13 @@ def is_datetime_or_timedelta_dtype(arr_or_dtype):
     tipo = _get_dtype_type(arr_or_dtype)
     return issubclass(tipo, (np.datetime64, np.timedelta64))
 
+
+def is_datetimelike_v_integer(a, b):
+    # return if we have an i8 convertible and and integer comparision
+    a = np.asarray(a)
+    b = np.asarray(b)
+    return (needs_i8_conversion(a) and is_integer_dtype(b)) or (
+        needs_i8_conversion(b) and is_integer_dtype(a))
 
 needs_i8_conversion = is_datetime_or_timedelta_dtype
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3574,7 +3574,14 @@ class NDFrame(PandasObject):
                 except ValueError:
                     new_other = np.array(other)
 
-                matches = (new_other == np.array(other))
+                # we can end up comparing integers and m8[ns]
+                # which is a numpy no no
+                is_i8 = com.needs_i8_conversion(self.dtype)
+                if is_i8:
+                    matches = False
+                else:
+                    matches = (new_other == np.array(other))
+
                 if matches is False or not matches.all():
 
                     # coerce other to a common dtype if we can

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -164,18 +164,18 @@ class Index(IndexOpsMixin, PandasObject):
         elif data is None or np.isscalar(data):
             cls._scalar_data_error(data)
         else:
-            if tupleize_cols and isinstance(data, list) and data:
+            if tupleize_cols and isinstance(data, list) and data and isinstance(data[0], tuple):
                 try:
-                    sorted(data)
-                    has_mixed_types = False
-                except (TypeError, UnicodeDecodeError):
-                    has_mixed_types = True  # python3 only
-                if isinstance(data[0], tuple) and not has_mixed_types:
-                    try:
-                        return MultiIndex.from_tuples(
-                            data, names=name or kwargs.get('names'))
-                    except (TypeError, KeyError):
-                        pass  # python2 - MultiIndex fails on mixed types
+
+                    # must be orderable in py3
+                    if compat.PY3:
+                        sorted(data)
+                    return MultiIndex.from_tuples(
+                        data, names=name or kwargs.get('names'))
+                except (TypeError, KeyError):
+                    # python2 - MultiIndex fails on mixed types
+                    pass
+
             # other iterable of some kind
             subarr = com._asarray_tuplesafe(data, dtype=object)
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -14,7 +14,7 @@ from pandas.core.common import (_possibly_downcast_to_dtype, isnull,
                                 is_null_datelike_scalar, _maybe_promote,
                                 is_timedelta64_dtype, is_datetime64_dtype,
                                 array_equivalent, _maybe_convert_string_to_object,
-                                is_categorical, needs_i8_conversion, is_datetimelike_v_integer)
+                                is_categorical, needs_i8_conversion, is_datetimelike_v_numeric)
 from pandas.core.index import Index, MultiIndex, _ensure_index
 from pandas.core.indexing import maybe_convert_indices, length_of_indexer
 from pandas.core.categorical import Categorical, maybe_to_categorical
@@ -3890,7 +3890,7 @@ def _possibly_compare(a, b, op):
     is_b_array = isinstance(b, np.ndarray)
 
     # numpy deprecation warning to have i8 vs integer comparisions
-    if is_datetimelike_v_integer(a, b):
+    if is_datetimelike_v_numeric(a, b):
         res = False
     else:
         res = op(a, b)

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -14,7 +14,7 @@ from pandas.core.common import (_possibly_downcast_to_dtype, isnull,
                                 is_null_datelike_scalar, _maybe_promote,
                                 is_timedelta64_dtype, is_datetime64_dtype,
                                 array_equivalent, _maybe_convert_string_to_object,
-                                is_categorical)
+                                is_categorical, needs_i8_conversion, is_datetimelike_v_integer)
 from pandas.core.index import Index, MultiIndex, _ensure_index
 from pandas.core.indexing import maybe_convert_indices, length_of_indexer
 from pandas.core.categorical import Categorical, maybe_to_categorical
@@ -3885,9 +3885,16 @@ def _vstack(to_stack, dtype):
 
 
 def _possibly_compare(a, b, op):
-    res = op(a, b)
+
     is_a_array = isinstance(a, np.ndarray)
     is_b_array = isinstance(b, np.ndarray)
+
+    # numpy deprecation warning to have i8 vs integer comparisions
+    if is_datetimelike_v_integer(a, b):
+        res = False
+    else:
+        res = op(a, b)
+
     if np.isscalar(res) and (is_a_array or is_b_array):
         type_names = [type(a).__name__, type(b).__name__]
 

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -17,7 +17,7 @@ from pandas.lib import isscalar
 from pandas.tslib import iNaT
 from pandas.core.common import(bind_method, is_list_like, notnull, isnull,
                                _values_from_object, _maybe_match_name,
-                               needs_i8_conversion, is_datetimelike_v_integer, is_integer_dtype)
+                               needs_i8_conversion, is_datetimelike_v_numeric, is_integer_dtype)
 
 # -----------------------------------------------------------------------------
 # Functions that add arithmetic methods to objects, given arithmetic factory
@@ -565,17 +565,17 @@ def _comp_method_SERIES(op, name, str_rep, masker=False):
                 result = lib.scalar_compare(x, y, op)
         else:
 
-            # numpy does not like comparisons vs None
-            if lib.isscalar(y) and isnull(y):
-                y = np.nan
-
             # we want to compare like types
             # we only want to convert to integer like if
             # we are not NotImplemented, otherwise
             # we would allow datetime64 (but viewed as i8) against
             # integer comparisons
-            if is_datetimelike_v_integer(x, y):
+            if is_datetimelike_v_numeric(x, y):
                 raise TypeError("invalid type comparison")
+
+            # numpy does not like comparisons vs None
+            if lib.isscalar(y) and isnull(y):
+                y = np.nan
 
             # we have a datetime/timedelta and may need to convert
             mask = None

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -17,7 +17,9 @@ from pandas.lib import isscalar
 from pandas.tslib import iNaT
 from pandas.core.common import(bind_method, is_list_like, notnull, isnull,
                                _values_from_object, _maybe_match_name,
-                               needs_i8_conversion, is_datetimelike_v_numeric, is_integer_dtype)
+                               needs_i8_conversion, is_datetimelike_v_numeric,
+                               is_integer_dtype, is_categorical_dtype, is_object_dtype,
+                               is_timedelta64_dtype, is_datetime64_dtype, is_bool_dtype)
 
 # -----------------------------------------------------------------------------
 # Functions that add arithmetic methods to objects, given arithmetic factory
@@ -276,11 +278,11 @@ class _TimeOp(object):
         lvalues = self._convert_to_array(left, name=name)
         rvalues = self._convert_to_array(right, name=name, other=lvalues)
 
-        self.is_timedelta_lhs = com.is_timedelta64_dtype(left)
-        self.is_datetime_lhs = com.is_datetime64_dtype(left)
+        self.is_timedelta_lhs = is_timedelta64_dtype(left)
+        self.is_datetime_lhs = is_datetime64_dtype(left)
         self.is_integer_lhs = left.dtype.kind in ['i', 'u']
-        self.is_datetime_rhs = com.is_datetime64_dtype(rvalues)
-        self.is_timedelta_rhs = com.is_timedelta64_dtype(rvalues)
+        self.is_datetime_rhs = is_datetime64_dtype(rvalues)
+        self.is_timedelta_rhs = is_timedelta64_dtype(rvalues)
         self.is_integer_rhs = rvalues.dtype.kind in ('i', 'u')
 
         self._validate()
@@ -355,7 +357,7 @@ class _TimeOp(object):
             elif isinstance(values, pd.DatetimeIndex):
                 values = values.to_series()
             elif not (isinstance(values, (np.ndarray, pd.Series)) and
-                      com.is_datetime64_dtype(values)):
+                      is_datetime64_dtype(values)):
                 values = tslib.array_to_datetime(values)
         elif inferred_type in ('timedelta', 'timedelta64'):
             # have a timedelta, convert to to ns here
@@ -448,8 +450,8 @@ class _TimeOp(object):
         that the data is not the right type for time ops.
         """
         # decide if we can do it
-        is_timedelta_lhs = com.is_timedelta64_dtype(left)
-        is_datetime_lhs = com.is_datetime64_dtype(left)
+        is_timedelta_lhs = is_timedelta64_dtype(left)
+        is_datetime_lhs = is_datetime64_dtype(left)
         if not (is_datetime_lhs or is_timedelta_lhs):
             return None
 
@@ -547,17 +549,17 @@ def _comp_method_SERIES(op, name, str_rep, masker=False):
 
         # dispatch to the categorical if we have a categorical
         # in either operand
-        if com.is_categorical_dtype(x):
+        if is_categorical_dtype(x):
             return op(x,y)
-        elif com.is_categorical_dtype(y) and not lib.isscalar(y):
+        elif is_categorical_dtype(y) and not isscalar(y):
             return op(y,x)
 
-        if com.is_object_dtype(x.dtype):
+        if is_object_dtype(x.dtype):
             if isinstance(y, list):
                 y = lib.list_to_object_array(y)
 
             if isinstance(y, (np.ndarray, pd.Series)):
-                if not com.is_object_dtype(y.dtype):
+                if not is_object_dtype(y.dtype):
                     result = lib.vec_compare(x, y.astype(np.object_), op)
                 else:
                     result = lib.vec_compare(x, y, op)
@@ -574,7 +576,7 @@ def _comp_method_SERIES(op, name, str_rep, masker=False):
                 raise TypeError("invalid type comparison")
 
             # numpy does not like comparisons vs None
-            if lib.isscalar(y) and isnull(y):
+            if isscalar(y) and isnull(y):
                 y = np.nan
 
             # we have a datetime/timedelta and may need to convert
@@ -624,13 +626,13 @@ def _comp_method_SERIES(op, name, str_rep, masker=False):
             return self._constructor(na_op(self.values, np.asarray(other)),
                                      index=self.index).__finalize__(self)
         elif isinstance(other, pd.Categorical):
-            if not com.is_categorical_dtype(self):
+            if not is_categorical_dtype(self):
                 msg = "Cannot compare a Categorical for op {op} with Series of dtype {typ}.\n"\
                       "If you want to compare values, use 'series <op> np.asarray(other)'."
                 raise TypeError(msg.format(op=op,typ=self.dtype))
 
 
-        if com.is_categorical_dtype(self):
+        if is_categorical_dtype(self):
             # cats are a special case as get_values() would return an ndarray, which would then
             # not take categories ordering into account
             # we can go directly to op, as the na_op would just test again and dispatch to it.
@@ -641,7 +643,7 @@ def _comp_method_SERIES(op, name, str_rep, masker=False):
                 other = np.asarray(other)
 
             res = na_op(values, other)
-            if lib.isscalar(res):
+            if isscalar(res):
                 raise TypeError('Could not compare %s type with Series'
                                 % type(other))
 
@@ -667,7 +669,7 @@ def _bool_method_SERIES(op, name, str_rep):
                 y = lib.list_to_object_array(y)
 
             if isinstance(y, (np.ndarray, pd.Series)):
-                if (com.is_bool_dtype(x.dtype) and com.is_bool_dtype(y.dtype)):
+                if (is_bool_dtype(x.dtype) and is_bool_dtype(y.dtype)):
                     result = op(x, y)  # when would this be hit?
                 else:
                     x = com._ensure_object(x)
@@ -1069,7 +1071,7 @@ def _arith_method_PANEL(op, name, str_rep=None, fill_zeros=None,
 
     # work only for scalars
     def f(self, other):
-        if not lib.isscalar(other):
+        if not isscalar(other):
             raise ValueError('Simple arithmetic with %s can only be '
                              'done with scalar values' %
                              self._constructor.__name__)

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -23,6 +23,7 @@ from pandas import compat, to_timedelta, to_datetime, isnull, DatetimeIndex
 from pandas.compat import lrange, lmap, lzip, text_type, string_types, range, \
     zip, BytesIO
 from pandas.util.decorators import Appender
+import pandas as pd
 import pandas.core.common as com
 from pandas.io.common import get_filepath_or_buffer
 from pandas.lib import max_len_string_array, infer_dtype
@@ -291,7 +292,7 @@ def _stata_elapsed_date_to_datetime_vec(dates, fmt):
         warn("Encountered %tC format. Leaving in Stata Internal Format.")
         conv_dates = Series(dates, dtype=np.object)
         if has_bad_values:
-            conv_dates[bad_locs] = np.nan
+            conv_dates[bad_locs] = pd.NaT
         return conv_dates
     elif fmt in ["%td", "td", "%d", "d"]:  # Delta days relative to base
         base = stata_epoch

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -914,7 +914,8 @@ class TestStata(tm.TestCase):
                             warnings.simplefilter("always")
                             parsed = read_stata(fname, convert_categoricals=convert_categoricals,
                                                 convert_dates=convert_dates)
-                        itr = read_stata(fname, iterator=True)
+                        itr = read_stata(fname, iterator=True, convert_categoricals=convert_categoricals,
+                                         convert_dates=convert_dates)
 
                         pos = 0
                         for j in range(5):
@@ -967,13 +968,15 @@ class TestStata(tm.TestCase):
                 for convert_categoricals in False, True:
                     for convert_dates in False, True:
 
+                        # Read the whole file
                         with warnings.catch_warnings(record=True) as w:
                             warnings.simplefilter("always")
                             parsed = read_stata(fname, convert_categoricals=convert_categoricals,
                                                 convert_dates=convert_dates)
-                        itr = read_stata(fname, iterator=True,
-                                         convert_categoricals=convert_categoricals)
 
+                        # Compare to what we get when reading by chunk
+                        itr = read_stata(fname, iterator=True, convert_dates=convert_dates,
+                                         convert_categoricals=convert_categoricals)
                         pos = 0
                         for j in range(5):
                             with warnings.catch_warnings(record=True) as w:

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -904,7 +904,6 @@ class TestStata(tm.TestCase):
                      self.dta16_117, self.dta17_117, self.dta18_117,
                      self.dta19_117, self.dta20_117]
 
-        raise nose.SkipTest("buggy test: #10606")
         for fname in files_117:
             for chunksize in 1,2:
                 for convert_categoricals in False, True:
@@ -962,7 +961,6 @@ class TestStata(tm.TestCase):
                      self.dta17_115, self.dta18_115, self.dta19_115,
                      self.dta20_115]
 
-        raise nose.SkipTest("buggy test: #10606")
         for fname in files_115:
             for chunksize in 1,2:
                 for convert_categoricals in False, True:

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -378,7 +378,7 @@ def isnullobj2d_old(ndarray[object, ndim=2] arr):
 @cython.boundscheck(False)
 cpdef ndarray[object] list_to_object_array(list obj):
     '''
-    Convert list to object ndarray. Seriously can't believe I had to write this
+    Convert list to object ndarray. Seriously can\'t believe I had to write this
     function
     '''
     cdef:
@@ -682,6 +682,7 @@ def scalar_compare(ndarray[object] values, object val, object op):
     cdef:
         Py_ssize_t i, n = len(values)
         ndarray[uint8_t, cast=True] result
+        bint isnull_val
         int flag
         object x
 
@@ -701,11 +702,14 @@ def scalar_compare(ndarray[object] values, object val, object op):
         raise ValueError('Unrecognized operator')
 
     result = np.empty(n, dtype=bool).view(np.uint8)
+    isnull_val = _checknull(val)
 
     if flag == cpython.Py_NE:
         for i in range(n):
             x = values[i]
             if _checknull(x):
+                result[i] = True
+            elif isnull_val:
                 result[i] = True
             else:
                 try:
@@ -717,6 +721,8 @@ def scalar_compare(ndarray[object] values, object val, object op):
             x = values[i]
             if _checknull(x):
                 result[i] = False
+            elif isnull_val:
+                result[i] = False
             else:
                 try:
                     result[i] = cpython.PyObject_RichCompareBool(x, val, flag)
@@ -727,6 +733,8 @@ def scalar_compare(ndarray[object] values, object val, object op):
         for i in range(n):
             x = values[i]
             if _checknull(x):
+                result[i] = False
+            elif isnull_val:
                 result[i] = False
             else:
                 result[i] = cpython.PyObject_RichCompareBool(x, val, flag)

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -10,14 +10,13 @@ import warnings
 import os
 
 import numpy as np
-from numpy.testing import assert_array_equal
 
 from pandas import (period_range, date_range, Categorical, Series,
                     Index, Float64Index, Int64Index, MultiIndex,
                     CategoricalIndex, DatetimeIndex, TimedeltaIndex, PeriodIndex)
 from pandas.core.index import InvalidIndexError, NumericIndex
 from pandas.util.testing import (assert_almost_equal, assertRaisesRegexp,
-                                 assert_copy)
+                                 assert_copy, assert_numpy_array_equivalent, assert_numpy_array_equal)
 from pandas import compat
 from pandas.compat import long, is_platform_windows
 
@@ -101,7 +100,7 @@ class Base(object):
         expected = np.arange(idx.size)
 
         actual = idx.get_indexer(idx)
-        assert_array_equal(expected, actual)
+        assert_numpy_array_equivalent(expected, actual)
 
         with tm.assertRaisesRegexp(ValueError, 'Invalid fill method'):
             idx.get_indexer(idx, method='invalid')
@@ -449,7 +448,7 @@ class TestIndex(Base, tm.TestCase):
         index = Index(arr, copy=True, name='name')
         tm.assertIsInstance(index, Index)
         self.assertEqual(index.name, 'name')
-        assert_array_equal(arr, index)
+        assert_numpy_array_equivalent(arr, index)
         arr[0] = "SOMEBIGLONGSTRING"
         self.assertNotEqual(index[0], "SOMEBIGLONGSTRING")
 
@@ -506,7 +505,7 @@ class TestIndex(Base, tm.TestCase):
     def test_index_ctor_infer_periodindex(self):
         xp = period_range('2012-1-1', freq='M', periods=3)
         rs = Index(xp)
-        assert_array_equal(rs, xp)
+        assert_numpy_array_equivalent(rs, xp)
         tm.assertIsInstance(rs, PeriodIndex)
 
     def test_constructor_simple_new(self):
@@ -1111,11 +1110,11 @@ class TestIndex(Base, tm.TestCase):
         all_methods = ['pad', 'backfill', 'nearest']
         for method in all_methods:
             actual = idx.get_indexer([0, 5, 9], method=method)
-            self.assert_array_equal(actual, [0, 5, 9])
+            self.assert_numpy_array_equivalent(actual, [0, 5, 9])
 
         for method, expected in zip(all_methods, [[0, 1, 8], [1, 2, 9], [0, 2, 9]]):
             actual = idx.get_indexer([0.2, 1.8, 8.5], method=method)
-            self.assert_array_equal(actual, expected)
+            self.assert_numpy_array_equivalent(actual, expected)
 
         with tm.assertRaisesRegexp(ValueError, 'limit argument'):
             idx.get_indexer([1, 0], method='nearest', limit=1)
@@ -1126,22 +1125,22 @@ class TestIndex(Base, tm.TestCase):
         all_methods = ['pad', 'backfill', 'nearest']
         for method in all_methods:
             actual = idx.get_indexer([0, 5, 9], method=method)
-            self.assert_array_equal(actual, [9, 4, 0])
+            self.assert_numpy_array_equivalent(actual, [9, 4, 0])
 
         for method, expected in zip(all_methods, [[8, 7, 0], [9, 8, 1], [9, 7, 0]]):
             actual = idx.get_indexer([0.2, 1.8, 8.5], method=method)
-            self.assert_array_equal(actual, expected)
+            self.assert_numpy_array_equivalent(actual, expected)
 
     def test_get_indexer_strings(self):
         idx = pd.Index(['b', 'c'])
 
         actual = idx.get_indexer(['a', 'b', 'c', 'd'], method='pad')
         expected = [-1, 0, 1, 1]
-        self.assert_array_equal(actual, expected)
+        self.assert_numpy_array_equivalent(actual, expected)
 
         actual = idx.get_indexer(['a', 'b', 'c', 'd'], method='backfill')
         expected = [0, 0, 1, -1]
-        self.assert_array_equal(actual, expected)
+        self.assert_numpy_array_equivalent(actual, expected)
 
         with tm.assertRaises(TypeError):
             idx.get_indexer(['a', 'b', 'c', 'd'], method='nearest')
@@ -1447,7 +1446,7 @@ class TestIndex(Base, tm.TestCase):
         # test boolean case, should return np.array instead of boolean Index
         idx = Index(['a1', 'a2', 'b1', 'b2'])
         expected = np.array([True, True, False, False])
-        self.assert_array_equal(idx.str.startswith('a'), expected)
+        self.assert_numpy_array_equivalent(idx.str.startswith('a'), expected)
         self.assertIsInstance(idx.str.startswith('a'), np.ndarray)
         s = Series(range(4), index=idx)
         expected = Series(range(2), index=['a1', 'a2'])
@@ -1557,8 +1556,8 @@ class TestIndex(Base, tm.TestCase):
         index_d = Index(['foo'])
         with tm.assertRaisesRegexp(ValueError, "Lengths must match"):
             index_a == index_b
-        assert_array_equal(index_a == index_a, np.array([True, True, True]))
-        assert_array_equal(index_a == index_c, np.array([True, True, False]))
+        assert_numpy_array_equivalent(index_a == index_a, np.array([True, True, True]))
+        assert_numpy_array_equivalent(index_a == index_c, np.array([True, True, False]))
 
         # test comparisons with numpy arrays
         array_a = np.array(['foo', 'bar', 'baz'])
@@ -1567,8 +1566,8 @@ class TestIndex(Base, tm.TestCase):
         array_d = np.array(['foo'])
         with tm.assertRaisesRegexp(ValueError, "Lengths must match"):
             index_a == array_b
-        assert_array_equal(index_a == array_a, np.array([True, True, True]))
-        assert_array_equal(index_a == array_c, np.array([True, True, False]))
+        assert_numpy_array_equivalent(index_a == array_a, np.array([True, True, True]))
+        assert_numpy_array_equivalent(index_a == array_c, np.array([True, True, False]))
 
         # test comparisons with Series
         series_a = Series(['foo', 'bar', 'baz'])
@@ -1577,8 +1576,8 @@ class TestIndex(Base, tm.TestCase):
         series_d = Series(['foo'])
         with tm.assertRaisesRegexp(ValueError, "Lengths must match"):
             index_a == series_b
-        assert_array_equal(index_a == series_a, np.array([True, True, True]))
-        assert_array_equal(index_a == series_c, np.array([True, True, False]))
+        assert_numpy_array_equivalent(index_a == series_a, np.array([True, True, True]))
+        assert_numpy_array_equivalent(index_a == series_c, np.array([True, True, False]))
 
         # cases where length is 1 for one of them
         with tm.assertRaisesRegexp(ValueError, "Lengths must match"):
@@ -1593,27 +1592,26 @@ class TestIndex(Base, tm.TestCase):
             series_a == array_d
 
         # comparing with scalar should broadcast
-        assert_array_equal(index_a == 'foo', np.array([True, False, False]))
-        assert_array_equal(series_a == 'foo', np.array([True, False, False]))
-        assert_array_equal(array_a == 'foo', np.array([True, False, False]))
+        assert_numpy_array_equivalent(index_a == 'foo', np.array([True, False, False]))
+        assert_numpy_array_equivalent(series_a == 'foo', np.array([True, False, False]))
+        assert_numpy_array_equivalent(array_a == 'foo', np.array([True, False, False]))
 
         # GH9785
         # test comparisons of multiindex
         from pandas.compat import StringIO
         df = pd.read_csv(StringIO('a,b,c\n1,2,3\n4,5,6'), index_col=[0, 1])
-        assert_array_equal(df.index == df.index, np.array([True, True]))
+        assert_numpy_array_equivalent(df.index == df.index, np.array([True, True]))
 
         mi1 = MultiIndex.from_tuples([(1, 2), (4, 5)])
-        assert_array_equal(df.index == mi1, np.array([True, True]))
+        assert_numpy_array_equivalent(df.index == mi1, np.array([True, True]))
         mi2 = MultiIndex.from_tuples([(1, 2), (4, 6)])
-        assert_array_equal(df.index == mi2, np.array([True, False]))
+        assert_numpy_array_equivalent(df.index == mi2, np.array([True, False]))
         mi3 = MultiIndex.from_tuples([(1, 2), (4, 5), (8, 9)])
         with tm.assertRaisesRegexp(ValueError, "Lengths must match"):
             df.index == mi3
         with tm.assertRaisesRegexp(ValueError, "Lengths must match"):
             df.index == index_a
-        assert_array_equal(index_a == mi3, np.array([False, False, False]))
-
+        assert_numpy_array_equivalent(index_a == mi3, np.array([False, False, False]))
 
 class TestCategoricalIndex(Base, tm.TestCase):
     _holder = CategoricalIndex
@@ -1868,7 +1866,7 @@ class TestCategoricalIndex(Base, tm.TestCase):
         expected = np.array([4,0,1,5,2,3])
 
         actual = idx.get_indexer(idx)
-        assert_array_equal(expected, actual)
+        assert_numpy_array_equivalent(expected, actual)
 
         with tm.assertRaisesRegexp(ValueError, 'Invalid fill method'):
             idx.get_indexer(idx, method='invalid')
@@ -1883,7 +1881,7 @@ class TestCategoricalIndex(Base, tm.TestCase):
             expected = oidx.get_indexer_non_unique(finder)[0]
 
             actual = ci.get_indexer(finder)
-            assert_array_equal(expected, actual)
+            assert_numpy_array_equivalent(expected, actual)
 
     def test_duplicates(self):
 
@@ -2184,12 +2182,12 @@ class TestFloat64Index(Numeric, tm.TestCase):
 
     def test_get_indexer(self):
         idx = Float64Index([0.0, 1.0, 2.0])
-        self.assert_array_equal(idx.get_indexer(idx), [0, 1, 2])
+        self.assert_numpy_array_equivalent(idx.get_indexer(idx), [0, 1, 2])
 
         target = [-0.1, 0.5, 1.1]
-        self.assert_array_equal(idx.get_indexer(target, 'pad'), [-1, 0, 1])
-        self.assert_array_equal(idx.get_indexer(target, 'backfill'), [0, 1, 2])
-        self.assert_array_equal(idx.get_indexer(target, 'nearest'), [0, 1, 1])
+        self.assert_numpy_array_equivalent(idx.get_indexer(target, 'pad'), [-1, 0, 1])
+        self.assert_numpy_array_equivalent(idx.get_indexer(target, 'backfill'), [0, 1, 2])
+        self.assert_numpy_array_equivalent(idx.get_indexer(target, 'nearest'), [0, 1, 1])
 
     def test_get_loc(self):
         idx = Float64Index([0.0, 1.0, 2.0])
@@ -2227,15 +2225,15 @@ class TestFloat64Index(Numeric, tm.TestCase):
 
     def test_nan_multiple_containment(self):
         i = Float64Index([1.0, np.nan])
-        np.testing.assert_array_equal(i.isin([1.0]), np.array([True, False]))
-        np.testing.assert_array_equal(i.isin([2.0, np.pi]),
+        assert_numpy_array_equivalent(i.isin([1.0]), np.array([True, False]))
+        assert_numpy_array_equivalent(i.isin([2.0, np.pi]),
                                       np.array([False, False]))
-        np.testing.assert_array_equal(i.isin([np.nan]),
+        assert_numpy_array_equivalent(i.isin([np.nan]),
                                       np.array([False, True]))
-        np.testing.assert_array_equal(i.isin([1.0, np.nan]),
+        assert_numpy_array_equivalent(i.isin([1.0, np.nan]),
                                       np.array([True, True]))
         i = Float64Index([1.0, 2.0])
-        np.testing.assert_array_equal(i.isin([np.nan]),
+        assert_numpy_array_equivalent(i.isin([np.nan]),
                                       np.array([False, False]))
 
     def test_astype_from_object(self):
@@ -2784,19 +2782,19 @@ class TestDatetimeIndex(DatetimeLike, tm.TestCase):
 
         # time indexing
         idx = pd.date_range('2000-01-01', periods=24, freq='H')
-        assert_array_equal(idx.get_loc(time(12)), [12])
-        assert_array_equal(idx.get_loc(time(12, 30)), [])
+        assert_numpy_array_equivalent(idx.get_loc(time(12)), [12])
+        assert_numpy_array_equivalent(idx.get_loc(time(12, 30)), [])
         with tm.assertRaises(NotImplementedError):
             idx.get_loc(time(12, 30), method='pad')
 
     def test_get_indexer(self):
         idx = pd.date_range('2000-01-01', periods=3)
-        self.assert_array_equal(idx.get_indexer(idx), [0, 1, 2])
+        self.assert_numpy_array_equivalent(idx.get_indexer(idx), [0, 1, 2])
 
         target = idx[0] + pd.to_timedelta(['-1 hour', '12 hours', '1 day 1 hour'])
-        self.assert_array_equal(idx.get_indexer(target, 'pad'), [-1, 0, 1])
-        self.assert_array_equal(idx.get_indexer(target, 'backfill'), [0, 1, 2])
-        self.assert_array_equal(idx.get_indexer(target, 'nearest'), [0, 1, 1])
+        self.assert_numpy_array_equivalent(idx.get_indexer(target, 'pad'), [-1, 0, 1])
+        self.assert_numpy_array_equivalent(idx.get_indexer(target, 'backfill'), [0, 1, 2])
+        self.assert_numpy_array_equivalent(idx.get_indexer(target, 'nearest'), [0, 1, 1])
 
     def test_roundtrip_pickle_with_tz(self):
 
@@ -2826,7 +2824,7 @@ class TestDatetimeIndex(DatetimeLike, tm.TestCase):
             ts = pd.Series(np.random.randn(n), index=idx)
             i = np.arange(start, n, step)
 
-            tm.assert_array_equal(ts.index.get_loc(key), i)
+            tm.assert_numpy_array_equivalent(ts.index.get_loc(key), i)
             tm.assert_series_equal(ts[key], ts.iloc[i])
 
             left, right = ts.copy(), ts.copy()
@@ -2906,13 +2904,13 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
 
     def test_get_indexer(self):
         idx = pd.period_range('2000-01-01', periods=3).asfreq('H', how='start')
-        self.assert_array_equal(idx.get_indexer(idx), [0, 1, 2])
+        self.assert_numpy_array_equivalent(idx.get_indexer(idx), [0, 1, 2])
 
         target = pd.PeriodIndex(['1999-12-31T23', '2000-01-01T12',
                                  '2000-01-02T01'], freq='H')
-        self.assert_array_equal(idx.get_indexer(target, 'pad'), [-1, 0, 1])
-        self.assert_array_equal(idx.get_indexer(target, 'backfill'), [0, 1, 2])
-        self.assert_array_equal(idx.get_indexer(target, 'nearest'), [0, 1, 1])
+        self.assert_numpy_array_equivalent(idx.get_indexer(target, 'pad'), [-1, 0, 1])
+        self.assert_numpy_array_equivalent(idx.get_indexer(target, 'backfill'), [0, 1, 2])
+        self.assert_numpy_array_equivalent(idx.get_indexer(target, 'nearest'), [0, 1, 1])
 
         with self.assertRaisesRegexp(ValueError, 'different freq'):
             idx.asfreq('D').get_indexer(idx)
@@ -2950,12 +2948,12 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
 
     def test_get_indexer(self):
         idx = pd.to_timedelta(['0 days', '1 days', '2 days'])
-        self.assert_array_equal(idx.get_indexer(idx), [0, 1, 2])
+        self.assert_numpy_array_equivalent(idx.get_indexer(idx), [0, 1, 2])
 
         target = pd.to_timedelta(['-1 hour', '12 hours', '1 day 1 hour'])
-        self.assert_array_equal(idx.get_indexer(target, 'pad'), [-1, 0, 1])
-        self.assert_array_equal(idx.get_indexer(target, 'backfill'), [0, 1, 2])
-        self.assert_array_equal(idx.get_indexer(target, 'nearest'), [0, 1, 1])
+        self.assert_numpy_array_equivalent(idx.get_indexer(target, 'pad'), [-1, 0, 1])
+        self.assert_numpy_array_equivalent(idx.get_indexer(target, 'backfill'), [0, 1, 2])
+        self.assert_numpy_array_equivalent(idx.get_indexer(target, 'nearest'), [0, 1, 1])
 
     def test_numeric_compat(self):
 
@@ -3535,7 +3533,7 @@ class TestMultiIndex(Base, tm.TestCase):
                   ('buz', 'a'), ('buz', 'b'), ('buz', 'c')]
         expected = MultiIndex.from_tuples(tuples, names=names)
 
-        assert_array_equal(result, expected)
+        assert_numpy_array_equivalent(result, expected)
         self.assertEqual(result.names, names)
 
     def test_from_product_datetimeindex(self):
@@ -3545,7 +3543,7 @@ class TestMultiIndex(Base, tm.TestCase):
                                               (1, pd.Timestamp('2000-01-02')),
                                               (2, pd.Timestamp('2000-01-01')),
                                               (2, pd.Timestamp('2000-01-02'))])
-        assert_array_equal(mi.values, etalon)
+        assert_numpy_array_equivalent(mi.values, etalon)
 
     def test_values_boxed(self):
         tuples = [(1, pd.Timestamp('2000-01-01')),
@@ -3555,9 +3553,9 @@ class TestMultiIndex(Base, tm.TestCase):
                   (2, pd.Timestamp('2000-01-02')),
                   (3, pd.Timestamp('2000-01-03'))]
         mi = pd.MultiIndex.from_tuples(tuples)
-        assert_array_equal(mi.values, pd.lib.list_to_object_array(tuples))
+        assert_numpy_array_equivalent(mi.values, pd.lib.list_to_object_array(tuples))
         # Check that code branches for boxed values produce identical results
-        assert_array_equal(mi.values[:4], mi[:4].values)
+        assert_numpy_array_equivalent(mi.values[:4], mi[:4].values)
 
     def test_append(self):
         result = self.index[:3].append(self.index[3:])
@@ -3597,28 +3595,28 @@ class TestMultiIndex(Base, tm.TestCase):
         index = pd.MultiIndex.from_arrays(arrays)
         values = index.get_level_values(1)
         expected = [1, np.nan, 2]
-        assert_array_equal(values.values.astype(float), expected)
+        assert_numpy_array_equivalent(values.values.astype(float), expected)
 
         arrays = [['a', 'b', 'b'], [np.nan, np.nan, 2]]
         index = pd.MultiIndex.from_arrays(arrays)
         values = index.get_level_values(1)
         expected = [np.nan, np.nan, 2]
-        assert_array_equal(values.values.astype(float), expected)
+        assert_numpy_array_equivalent(values.values.astype(float), expected)
 
         arrays = [[np.nan, np.nan, np.nan], ['a', np.nan, 1]]
         index = pd.MultiIndex.from_arrays(arrays)
         values = index.get_level_values(0)
         expected = [np.nan, np.nan, np.nan]
-        assert_array_equal(values.values.astype(float), expected)
+        assert_numpy_array_equivalent(values.values.astype(float), expected)
         values = index.get_level_values(1)
         expected = np.array(['a', np.nan, 1],dtype=object)
-        assert_array_equal(values.values, expected)
+        assert_numpy_array_equivalent(values.values, expected)
 
         arrays = [['a', 'b', 'b'], pd.DatetimeIndex([0, 1, pd.NaT])]
         index = pd.MultiIndex.from_arrays(arrays)
         values = index.get_level_values(1)
         expected = pd.DatetimeIndex([0, 1, pd.NaT])
-        assert_array_equal(values.values, expected.values)
+        assert_numpy_array_equivalent(values.values, expected.values)
 
         arrays = [[], []]
         index = pd.MultiIndex.from_arrays(arrays)
@@ -4644,14 +4642,14 @@ class TestMultiIndex(Base, tm.TestCase):
         for take_last in [False, True]:
             left = mi.duplicated(take_last=take_last)
             right = pd.lib.duplicated(mi.values, take_last=take_last)
-            tm.assert_array_equal(left, right)
+            tm.assert_numpy_array_equivalent(left, right)
 
         # GH5873
         for a in [101, 102]:
             mi = MultiIndex.from_arrays([[101, a], [3.5, np.nan]])
             self.assertFalse(mi.has_duplicates)
             self.assertEqual(mi.get_duplicates(), [])
-            self.assert_array_equal(mi.duplicated(), np.zeros(2, dtype='bool'))
+            self.assert_numpy_array_equivalent(mi.duplicated(), np.zeros(2, dtype='bool'))
 
         for n in range(1, 6):  # 1st level shape
             for m in range(1, 5):  # 2nd level shape
@@ -4662,7 +4660,7 @@ class TestMultiIndex(Base, tm.TestCase):
                 self.assertEqual(len(mi), (n + 1) * (m + 1))
                 self.assertFalse(mi.has_duplicates)
                 self.assertEqual(mi.get_duplicates(), [])
-                self.assert_array_equal(mi.duplicated(),
+                self.assert_numpy_array_equivalent(mi.duplicated(),
                                         np.zeros(len(mi), dtype='bool'))
 
     def test_duplicate_meta_data(self):
@@ -4865,7 +4863,6 @@ class TestMultiIndex(Base, tm.TestCase):
     def test_equals_operator(self):
         # GH9785
         self.assertTrue((self.index == self.index).all())
-
 
 def test_get_combined_index():
     from pandas.core.index import _get_combined_index

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -753,15 +753,15 @@ class TestBlockManager(tm.TestCase):
 
     def test_equals_block_order_different_dtypes(self):
         # GH 9330
-        
-        mgr_strings = [ 
+
+        mgr_strings = [
             "a:i8;b:f8", # basic case
             "a:i8;b:f8;c:c8;d:b", # many types
             "a:i8;e:dt;f:td;g:string", # more types
             "a:i8;b:category;c:category2;d:category2", # categories
             "c:sparse;d:sparse_na;b:f8", # sparse
             ]
-        
+
         for mgr_string in mgr_strings:
             bm = create_mgr(mgr_string)
             block_perms = itertools.permutations(bm.blocks)
@@ -812,6 +812,13 @@ class TestIndexing(object):
         def assert_slice_ok(mgr, axis, slobj):
             # import pudb; pudb.set_trace()
             mat = mgr.as_matrix()
+
+            # we maybe using an ndarray to test slicing and
+            # might not be the full length of the axis
+            if isinstance(slobj, np.ndarray):
+                ax = mgr.axes[axis]
+                if len(ax) and len(slobj) and len(slobj) != len(ax):
+                    slobj = np.concatenate([slobj, np.zeros(len(ax)-len(slobj),dtype=bool)])
             sliced = mgr.get_slice(slobj, axis=axis)
             mat_slobj = (slice(None),) * axis + (slobj,)
             assert_almost_equal(mat[mat_slobj], sliced.as_matrix())

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -504,11 +504,6 @@ class TestNanops(tm.TestCase):
         s == s2
         s2 == s
 
-    def test_none_comparison(self):
-        # bug brought up by #1079
-        s = Series(np.random.randn(10), index=lrange(0, 20, 2))
-        self.assertRaises(TypeError, s.__eq__, None)
-
     def test_sum_zero(self):
         arr = np.array([])
         self.assertEqual(nanops.nansum(arr), 0)

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -849,11 +849,11 @@ class TestTimeSeries(tm.TestCase):
 
         result2 = to_datetime(strings)
         tm.assertIsInstance(result2, DatetimeIndex)
-        self.assert_numpy_array_equal(result, result2)
+        self.assert_numpy_array_equivalent(result, result2)
 
         malformed = np.array(['1/100/2000', np.nan], dtype=object)
         result = to_datetime(malformed)
-        self.assert_numpy_array_equal(result, malformed)
+        self.assert_numpy_array_equivalent(result, malformed)
 
         self.assertRaises(ValueError, to_datetime, malformed,
                           errors='raise')

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -24,7 +24,8 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 import pandas as pd
-from pandas.core.common import is_sequence, array_equivalent, is_list_like, is_number, is_datetimelike_v_numeric
+from pandas.core.common import (is_sequence, array_equivalent, is_list_like, is_number,
+                                is_datetimelike_v_numeric, is_datetimelike_v_object)
 import pandas.compat as compat
 from pandas.compat import(
     filter, map, zip, range, unichr, lrange, lmap, lzip, u, callable, Counter,
@@ -688,10 +689,10 @@ def assert_series_equal(left, right, check_dtype=True,
     elif check_datetimelike_compat:
         # we want to check only if we have compat dtypes
         # e.g. integer and M|m are NOT compat, but we can simply check the values in that case
-        if is_datetimelike_v_numeric(left, right):
-            # datetime.datetime and pandas.tslib.Timestamp may hold
-            # equivalent values but fail assert_frame_equal
-            if not all([x == y for x, y in zip(left, right)]):
+        if is_datetimelike_v_numeric(left, right) or is_datetimelike_v_object(left, right):
+
+            # datetimelike may have different objects (e.g. datetime.datetime vs Timestamp) but will compare equal
+            if not Index(left.values).equals(Index(right.values)):
                 raise AssertionError(
                     '[datetimelike_compat=True] {0} is not equal to {1}.'.format(left.values,
                                                                                  right.values))

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -59,7 +59,6 @@ def reset_testing_mode():
 
 set_testing_mode()
 
-
 class TestCase(unittest.TestCase):
 
     @classmethod
@@ -634,7 +633,7 @@ def assert_categorical_equal(res, exp):
         raise AssertionError("name not the same")
 
 
-def assert_numpy_array_equal(np_array, assert_equal):
+def assert_numpy_array_equal(np_array, assert_equal, err_msg=None):
     """Checks that 'np_array' is equal to 'assert_equal'
 
     Note that the expected array should not contain `np.nan`!
@@ -646,11 +645,12 @@ def assert_numpy_array_equal(np_array, assert_equal):
     """
     if np.array_equal(np_array, assert_equal):
         return
-    raise AssertionError(
-        '{0} is not equal to {1}.'.format(np_array, assert_equal))
+    if err_msg is None:
+        err_msg = '{0} is not equal to {1}.'.format(np_array, assert_equal)
+    raise AssertionError(err_msg)
 
 
-def assert_numpy_array_equivalent(np_array, assert_equal, strict_nan=False):
+def assert_numpy_array_equivalent(np_array, assert_equal, strict_nan=False, err_msg=None):
     """Checks that 'np_array' is equivalent to 'assert_equal'
 
     Two numpy arrays are equivalent if the arrays have equal non-NaN elements,
@@ -664,8 +664,9 @@ def assert_numpy_array_equivalent(np_array, assert_equal, strict_nan=False):
     """
     if array_equivalent(np_array, assert_equal, strict_nan=strict_nan):
         return
-    raise AssertionError(
-        '{0} is not equivalent to {1}.'.format(np_array, assert_equal))
+    if err_msg is None:
+        err_msg = '{0} is not equivalent to {1}.'.format(np_array, assert_equal)
+    raise AssertionError(err_msg)
 
 
 # This could be refactored to use the NDFrame.equals method


### PR DESCRIPTION
xref, #1079

numpy 1.10 shows a deprecation warning for this. this should eliminate a bunch of these.
