### PR TITLE
Improve categorical concat speed by ~20x

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -276,6 +276,7 @@ Performance Improvements
 - 8x improvement in ``timedelta64`` and ``datetime64`` ops (:issue:`6755`)
 - Significantly improved performance of indexing ``MultiIndex`` with slicers (:issue:`10287`)
 - Improved performance of ``Series.isin`` for datetimelike/integer Series (:issue:`10287`)
+- 20x improvement in ``concat`` of Categoricals when categories are identical (:issue:`10587`)
 
 .. _whatsnew_0170.bug_fixes:
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -4388,7 +4388,11 @@ class JoinUnit(object):
         # Usually it's enough to check but a small fraction of values to see if
         # a block is NOT null, chunks should help in such cases.  1000 value
         # was chosen rather arbitrarily.
-        values_flat = self.block.values.ravel()
+        values = self.block.values
+        if self.block.is_categorical:
+            values_flat = values.categories
+        else:
+            values_flat = values.ravel()
         total_len = values_flat.shape[0]
         chunk_len = max(total_len // 40, 1000)
         for i in range(0, total_len, chunk_len):

--- a/vb_suite/categoricals.py
+++ b/vb_suite/categoricals.py
@@ -1,0 +1,16 @@
+from vbench.benchmark import Benchmark
+from datetime import datetime
+
+common_setup = """from pandas_vb_common import *
+"""
+
+#----------------------------------------------------------------------
+# Series constructors
+
+setup = common_setup + """
+s = pd.Series(list('aabbcd') * 1000000).astype('category')
+"""
+
+concat_categorical = \
+    Benchmark("concat([s, s])", setup=setup, name='concat_categorical',
+              start_date=datetime(year=2015, month=7, day=15))


### PR DESCRIPTION
closes #10587

before (current master):

``` python
In [1]: s = pd.Series(list('aabbcd')*1000000).astype('category')

In [2]: timeit pd.concat([s,s])
1 loops, best of 3: 573 ms per loop
```

after (this PR):

``` python
In [1]: s = pd.Series(list('aabbcd')*1000000).astype('category')

In [2]: timeit pd.concat([s,s])
10 loops, best of 3: 30.1 ms per loop
```
