### PR TITLE
TST: test_read_famafrench fails with HTTP 404

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -327,3 +327,5 @@ Bug Fixes
 - Bug in ``Series.plot(kind='hist')`` Y Label not informative (:issue:`10485`)
 
 - Bug in operator equal on Index not being consistent with Series (:issue:`9947`)
+
+- Reading "famafrench" data via ``DataReader`` results in HTTP 404 error because of the website url is changed (:issue:`10591`).

--- a/pandas/io/data.py
+++ b/pandas/io/data.py
@@ -504,7 +504,7 @@ _FAMAFRENCH_URL = 'http://mba.tuck.dartmouth.edu/pages/faculty/ken.french/ftp'
 
 def get_data_famafrench(name):
     # path of zip files
-    zip_file_path = '{0}/{1}.zip'.format(_FAMAFRENCH_URL, name)
+    zip_file_path = '{0}/{1}_TXT.zip'.format(_FAMAFRENCH_URL, name)
 
     with urlopen(zip_file_path) as url:
         raw = url.read()

--- a/pandas/io/tests/test_data.py
+++ b/pandas/io/tests/test_data.py
@@ -481,8 +481,6 @@ class TestDataReader(tm.TestCase):
         for name in ("F-F_Research_Data_Factors",
                      "F-F_Research_Data_Factors_weekly", "6_Portfolios_2x3",
                      "F-F_ST_Reversal_Factor", "F-F_Momentum_Factor"):
-            raise nose.SkipTest('getting 404 errors as of 7/15/15')
-
             ff = DataReader(name, "famafrench")
             self.assertTrue(ff is not None)
             self.assertIsInstance(ff, dict)


### PR DESCRIPTION
Closes #10591. The same fix as pydata/pandas-datareader#53.

Though it is not a bug, added it to the bug section because users likely to check it when they meet 404.
