### PR TITLE
PERF: Improve perf of to_datetime with ISO format

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -328,6 +328,7 @@ Performance Improvements
 - Significantly improved performance of indexing ``MultiIndex`` with slicers (:issue:`10287`)
 - Improved performance of ``Series.isin`` for datetimelike/integer Series (:issue:`10287`)
 - 20x improvement in ``concat`` of Categoricals when categories are identical (:issue:`10587`)
+- Improved performance of ``to_datetime`` when specified format string is ISO8601 (:issue:`10178`)
 
 
 .. _whatsnew_0170.bug_fixes:

--- a/vb_suite/timeseries.py
+++ b/vb_suite/timeseries.py
@@ -157,6 +157,10 @@ timeseries_to_datetime_iso8601 = \
     Benchmark('to_datetime(strings)', setup,
               start_date=datetime(2012, 7, 11))
 
+timeseries_to_datetime_iso8601_format = \
+    Benchmark("to_datetime(strings, format='%Y-%m-%d %H:%M:%S')", setup,
+              start_date=datetime(2012, 7, 11))
+
 setup = common_setup + """
 rng = date_range('1/1/2000', periods=10000, freq='D')
 strings = Series(rng.year*10000+rng.month*100+rng.day,dtype=np.int64).apply(str)


### PR DESCRIPTION
Closes #10178
Closes #8154

Using the example data from the issue:

```
In [2]: df = DataFrame({'date_text':["2015-05-18" for i in range(10**6)]})
```

Before:

```
In [3]: %timeit pd.to_datetime(df['date_text'],format="%Y-%m-%d", box=False).values.view('i8')/10**9
1 loops, best of 3: 3.14 s per loop

In [4]: %timeit pd.to_datetime(df['date_text'],infer_datetime_format=True,     box=False).values.view('i8')/10**9
1 loops, best of 3: 253 ms per lo
```

After:

```
In [6]: %timeit pd.to_datetime(df['date_text'],format="%Y-%m-%d", box=False).values.view('i8')/10**9
1 loops, best of 3: 217 ms per loop

In [7]: %timeit pd.to_datetime(df['date_text'],infer_datetime_format=True, box=False).values.view('i8')/10**9
1 loops, best of 3: 243 ms per loop
```
