### PR TITLE
support sql transactions

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -62,7 +62,11 @@ def _is_sqlalchemy_connectable(con):
 
     if _SQLALCHEMY_INSTALLED:
         import sqlalchemy
-        return isinstance(con, sqlalchemy.engine.Connectable) or isinstance(con, sqlalchemy.orm.session.Session)
+        is_connectable = isinstance(con, sqlalchemy.engine.Connectable)
+        if sqlalchemy.__version__ >= '1.0.0':
+            # support sessions, if sqlalchemy version has them
+            is_connectable |= isinstance(con, sqlalchemy.orm.session.Session)
+        return is_connectable
     else:
         return False
 

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -62,7 +62,7 @@ def _is_sqlalchemy_connectable(con):
 
     if _SQLALCHEMY_INSTALLED:
         import sqlalchemy
-        return isinstance(con, sqlalchemy.engine.Connectable)
+        return isinstance(con, sqlalchemy.engine.Connectable) or isinstance(con, sqlalchemy.orm.session.Session)
     else:
         return False
 
@@ -362,7 +362,7 @@ def read_sql_query(sql, con, index_col=None, coerce_float=True, params=None,
     ----------
     sql : string
         SQL query to be executed
-    con : SQLAlchemy connectable(engine/connection) or sqlite3 DBAPI2 connection
+    con : SQLAlchemy connectable(engine/connection/session) or sqlite3 DBAPI2 connection
         Using SQLAlchemy makes it possible to use any DB supported by that
         library.
         If a DBAPI2 object, only sqlite3 is supported.
@@ -420,7 +420,7 @@ def read_sql(sql, con, index_col=None, coerce_float=True, params=None,
     ----------
     sql : string
         SQL query to be executed or database table name.
-    con : SQLAlchemy connectable(engine/connection) or DBAPI2 connection (fallback mode)
+    con : SQLAlchemy connectable(engine/connection/session) or DBAPI2 connection (fallback mode)
         Using SQLAlchemy makes it possible to use any DB supported by that
         library.
         If a DBAPI2 object, only sqlite3 is supported.

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -923,6 +923,8 @@ class TestSQLApi(SQLAlchemyMixIn, _TestSQLApi):
         read_sql_query should work within a session.
         a temporary table created within the session should be able to be queried.
         """
+        if sqlalchemy.__version__ < '1.0.0':
+            nose.SkipTest('session requires sqlalchemy>=1.0.0')
         from sqlalchemy.orm import sessionmaker
         session = sessionmaker(bind=self.conn)()
         # create a temporary table within a session
@@ -934,6 +936,8 @@ class TestSQLApi(SQLAlchemyMixIn, _TestSQLApi):
 
     def test_session_close(self):
         """read_sql_query shouldn't close the session"""
+        if sqlalchemy.__version__ < '1.0.0':
+            nose.SkipTest('session requires sqlalchemy>=1.0.0')
         from sqlalchemy.orm import sessionmaker
         session = sessionmaker(bind=self.conn)()
         session.execute("""CREATE TEMPORARY TABLE temp_iris AS SELECT * FROM iris LIMIT 5""")


### PR DESCRIPTION
this allows the `con` argument of `pd.read_sql`/`pd.read_sql_query` to be a sqlalchemy [`Session`](http://docs.sqlalchemy.org/en/rel_1_0/orm/session.html) object.

this allows for the use of temporary tables.
