### PR TITLE
Drop & insert on subtypes of index return their subtypes

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -401,4 +401,5 @@ Bug Fixes
 - Bug in ``io.common.get_filepath_or_buffer`` which caused reading of valid S3 files to fail if the bucket also contained keys for which the user does not have read permission (:issue:`10604`)
 - Bug in vectorised setting of timestamp columns with python ``datetime.date`` and numpy ``datetime64`` (:issue:`10408`, :issue:`10412`)
 - Bug in ``pd.DataFrame`` when constructing an empty DataFrame with a string dtype (:issue:`9428`)
+- Bug in `Index` subtypes (such as `PeriodIndex`) not returning their own type for `.drop` and `.insert` methods
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -89,7 +89,6 @@ class Index(IndexOpsMixin, PandasObject):
     _left_indexer = _algos.left_join_indexer_object
     _inner_indexer = _algos.inner_join_indexer_object
     _outer_indexer = _algos.outer_join_indexer_object
-
     _box_scalars = False
 
     _typ = 'index'
@@ -204,6 +203,17 @@ class Index(IndexOpsMixin, PandasObject):
 
     @classmethod
     def _simple_new(cls, values, name=None, **kwargs):
+        """
+        we require the we have a dtype compat for the values
+        if we are passed a non-dtype compat, then coerce using the constructor
+
+        Must be careful not to recurse.
+        """
+        if not hasattr(values, 'dtype'):
+            values = np.array(values,copy=False)
+            if is_object_dtype(values):
+                values = cls(values, name=name, **kwargs).values
+
         result = object.__new__(cls)
         result._data = values
         result.name = name
@@ -341,14 +351,40 @@ class Index(IndexOpsMixin, PandasObject):
             result._id = self._id
         return result
 
-    def _shallow_copy(self, values=None, **kwargs):
-        """ create a new Index, don't copy the data, use the same object attributes
-            with passed in attributes taking precedence """
+    def _shallow_copy(self, values=None, infer=False, **kwargs):
+        """
+        create a new Index, don't copy the data, use the same object attributes
+        with passed in attributes taking precedence
+
+        *this is an internal non-public method*
+
+        Parameters
+        ----------
+        values : the values to create the new Index, optional
+        infer : boolean, default False
+            if True, infer the new type of the passed values
+        kwargs : updates the default attributes for this Index
+        """
         if values is None:
             values = self.values
         attributes = self._get_attributes_dict()
         attributes.update(kwargs)
+
+        if infer:
+            attributes['copy'] = False
+            return Index(values, **attributes)
+
         return self.__class__._simple_new(values,**attributes)
+
+    def _coerce_scalar_to_index(self, item):
+        """
+        we need to coerce a scalar to a compat for our index type
+
+        Parameters
+        ----------
+        item : scalar item to coerce
+        """
+        return Index([item], dtype=self.dtype, **self._get_attributes_dict())
 
     def copy(self, names=None, name=None, dtype=None, deep=False):
         """
@@ -1132,7 +1168,9 @@ class Index(IndexOpsMixin, PandasObject):
         appended : Index
         """
         to_concat, name = self._ensure_compat_append(other)
-        return Index(np.concatenate(to_concat), name=name)
+        attribs = self._get_attributes_dict()
+        attribs['name'] = name
+        return self._shallow_copy(np.concatenate(to_concat), infer=True, **attribs)
 
     @staticmethod
     def _ensure_compat_concat(indexes):
@@ -1548,16 +1586,12 @@ class Index(IndexOpsMixin, PandasObject):
         other, result_name_update = self._convert_can_do_setop(other)
         if result_name is None:
             result_name = result_name_update
-        the_diff_sorted = sorted(set((self.difference(other)).union(other.difference(self))))
-        if isinstance(self, MultiIndex):
-            # multiindexes don't currently work well with _shallow_copy & can't be supplied a name
-            return Index(the_diff_sorted, **self._get_attributes_dict())
-        else:
-            # convert list to Index and pull values out - required for subtypes such as PeriodIndex
-            diff_array = Index(the_diff_sorted).values
-            return self._shallow_copy(diff_array, name=result_name)
-
-
+        the_diff = sorted(set((self.difference(other)).union(other.difference(self))))
+        attribs = self._get_attributes_dict()
+        attribs['name'] = result_name
+        if 'freq' in attribs:
+            attribs['freq'] = None
+        return self._shallow_copy(the_diff, infer=True, **attribs)
 
     def get_loc(self, key, method=None):
         """
@@ -2535,7 +2569,8 @@ class Index(IndexOpsMixin, PandasObject):
         -------
         new_index : Index
         """
-        return self._shallow_copy(np.delete(self._data, loc))
+        attribs = self._get_attributes_dict()
+        return self._shallow_copy(np.delete(self._data, loc), **attribs)
 
     def insert(self, loc, item):
         """
@@ -2551,12 +2586,13 @@ class Index(IndexOpsMixin, PandasObject):
         -------
         new_index : Index
         """
-        indexes=[self[:loc],
-                 Index([item]),
-                 self[loc:]]
+        _self = np.asarray(self)
+        item = self._coerce_scalar_to_index(item).values
 
-        return indexes[0].append(indexes[1]).append(indexes[2])
-
+        idx = np.concatenate(
+            (_self[:loc], item, _self[loc:]))
+        attribs = self._get_attributes_dict()
+        return self._shallow_copy(idx, infer=True, **attribs)
 
     def drop(self, labels, errors='raise'):
         """
@@ -3687,7 +3723,7 @@ class MultiIndex(Index):
         Level of sortedness (must be lexicographically sorted by that
         level)
     names : optional sequence of objects
-        Names for each of the index levels.
+        Names for each of the index levels. (name is accepted for compat)
     copy : boolean, default False
         Copy the meta-data
     verify_integrity : boolean, default True
@@ -3703,8 +3739,11 @@ class MultiIndex(Index):
     rename = Index.set_names
 
     def __new__(cls, levels=None, labels=None, sortorder=None, names=None,
-                copy=False, verify_integrity=True, _set_identity=True, **kwargs):
+                copy=False, verify_integrity=True, _set_identity=True, name=None, **kwargs):
 
+        # compat with Index
+        if name is not None:
+            names = name
         if levels is None or labels is None:
             raise TypeError("Must pass both levels and labels")
         if len(levels) != len(labels):
@@ -4013,7 +4052,12 @@ class MultiIndex(Index):
         result._id = self._id
         return result
 
-    _shallow_copy = view
+    def _shallow_copy(self, values=None, infer=False, **kwargs):
+        if values is not None:
+            if 'name' in kwargs:
+                kwargs['names'] = kwargs.pop('name',None)
+            return MultiIndex.from_tuples(values, **kwargs)
+        return self.view()
 
     @cache_readonly
     def dtype(self):

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -396,6 +396,37 @@ class Base(object):
                 with tm.assertRaisesRegexp(TypeError, msg):
                     result = first.sym_diff([1, 2, 3])
 
+    def test_insert_base(self):
+
+        for name, idx in compat.iteritems(self.indices):
+            result = idx[1:4]
+
+            if len(idx)>0:
+                #test 0th element
+                self.assertTrue(idx[0:4].equals(
+                    result.insert(0, idx[0])))
+
+    def test_delete_base(self):
+
+        for name, idx in compat.iteritems(self.indices):
+
+            if len(idx)>0:
+
+                expected = idx[1:]
+                result = idx.delete(0)
+                self.assertTrue(result.equals(expected))
+                self.assertEqual(result.name, expected.name)
+
+                expected = idx[:-1]
+                result = idx.delete(-1)
+                self.assertTrue(result.equals(expected))
+                self.assertEqual(result.name, expected.name)
+
+                with tm.assertRaises((IndexError, ValueError)):
+                    # either depending on numpy version
+                    result = idx.delete(len(idx))
+
+
     def test_equals_op(self):
         # GH9947, GH10637
         index_a = self.create_index()

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -401,30 +401,33 @@ class Base(object):
         for name, idx in compat.iteritems(self.indices):
             result = idx[1:4]
 
-            if len(idx)>0:
-                #test 0th element
-                self.assertTrue(idx[0:4].equals(
-                    result.insert(0, idx[0])))
+            if not len(idx):
+                continue
+
+            #test 0th element
+            self.assertTrue(idx[0:4].equals(
+                result.insert(0, idx[0])))
 
     def test_delete_base(self):
 
         for name, idx in compat.iteritems(self.indices):
 
-            if len(idx)>0:
+            if not len(idx):
+                continue
 
-                expected = idx[1:]
-                result = idx.delete(0)
-                self.assertTrue(result.equals(expected))
-                self.assertEqual(result.name, expected.name)
+            expected = idx[1:]
+            result = idx.delete(0)
+            self.assertTrue(result.equals(expected))
+            self.assertEqual(result.name, expected.name)
 
-                expected = idx[:-1]
-                result = idx.delete(-1)
-                self.assertTrue(result.equals(expected))
-                self.assertEqual(result.name, expected.name)
+            expected = idx[:-1]
+            result = idx.delete(-1)
+            self.assertTrue(result.equals(expected))
+            self.assertEqual(result.name, expected.name)
 
-                with tm.assertRaises((IndexError, ValueError)):
-                    # either depending on numpy version
-                    result = idx.delete(len(idx))
+            with tm.assertRaises((IndexError, ValueError)):
+                # either depending on numpy version
+                result = idx.delete(len(idx))
 
 
     def test_equals_op(self):

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -5,7 +5,8 @@ from datetime import timedelta
 import numpy as np
 from pandas.core.common import (_NS_DTYPE, _INT64_DTYPE,
                                 _values_from_object, _maybe_box,
-                                ABCSeries, is_integer, is_float)
+                                ABCSeries, is_integer, is_float,
+                                is_object_dtype, is_datetime64_dtype)
 from pandas.core.index import Index, Int64Index, Float64Index
 import pandas.compat as compat
 from pandas.compat import u
@@ -494,9 +495,16 @@ class DatetimeIndex(DatetimeIndexOpsMixin, Int64Index):
 
     @classmethod
     def _simple_new(cls, values, name=None, freq=None, tz=None, **kwargs):
+        """
+        we require the we have a dtype compat for the values
+        if we are passed a non-dtype compat, then coerce using the constructor
+        """
+
         if not getattr(values,'dtype',None):
             values = np.array(values,copy=False)
-        if values.dtype != _NS_DTYPE:
+        if is_object_dtype(values):
+            return cls(values, name=name, freq=freq, tz=tz, **kwargs).values
+        elif not is_datetime64_dtype(values):
             values = com._ensure_int64(values).view(_NS_DTYPE)
 
         result = object.__new__(cls)


### PR DESCRIPTION
Current behavior:

``` python
In [32]:
period_index=pd.PeriodIndex(start='2015-01-01',end='2015-01-07',freq='B')
period_index
Out[32]:
PeriodIndex(['2015-01-01', '2015-01-02', '2015-01-05', '2015-01-06',
             '2015-01-07'],
            dtype='int64', freq='B')

In [33]:
period_index.drop(period_index[:2])
Out[33]:
Int64Index([11742, 11743, 11744], dtype='int64')
```

New behavior:

``` python
In [32]: period_index.drop(period_index[:2])
Out[32]: PeriodIndex(['2015-01-05', '2015-01-06', '2015-01-07'], dtype='int64', freq='B')
```

I could combine with #10599, but am having a couple of issues with this (will post below) that I need help with - I'll take direction on whether to combine or not.
