### PR TITLE
Remove Categorical.name

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -270,6 +270,7 @@ Other API Changes
 - Enable serialization of lists and dicts to strings in ExcelWriter (:issue:`8188`)
 - Allow passing `kwargs` to the interpolation methods (:issue:`10378`).
 - Serialize metadata properties of subclasses of pandas objects (:issue:`10553`).
+- ``Categorical.name`` was removed to make `Categorical` more ``numpy.ndarray`` like. Use ``Series(cat, name="whatever")`` instead (:issue:`10482`).
 
 - ``NaT``'s methods now either raise ``ValueError``, or return ``np.nan`` or ``NaT`` (:issue:`9513`)
 ===========================     ==============================================================

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -68,22 +68,15 @@ docstring_to_string = """
 class CategoricalFormatter(object):
 
     def __init__(self, categorical, buf=None, length=True,
-                 na_rep='NaN', name=False, footer=True):
+                 na_rep='NaN', footer=True):
         self.categorical = categorical
         self.buf = buf if buf is not None else StringIO(u(""))
-        self.name = name
         self.na_rep = na_rep
         self.length = length
         self.footer = footer
 
     def _get_footer(self):
         footer = ''
-
-        if self.name:
-            name = com.pprint_thing(self.categorical.name,
-                                    escape_chars=('\t', '\r', '\n'))
-            footer += ('Name: %s' % name if self.categorical.name is not None
-                       else '')
 
         if self.length:
             if footer:

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1960,8 +1960,6 @@ class Grouping(object):
                 self._group_index = CategoricalIndex(Categorical.from_codes(np.arange(len(c)),
                                                      categories=c,
                                                      ordered=self.grouper.ordered))
-                if self.name is None:
-                    self.name = self.grouper.name
 
             # a passed Grouper like
             elif isinstance(self.grouper, Grouper):

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -4414,7 +4414,7 @@ class MultiIndex(Index):
         levels = [c.categories for c in cats]
         labels = [c.codes for c in cats]
         if names is None:
-            names = [c.name for c in cats]
+            names = [getattr(arr, "name", None) for arr in arrays]
 
         return MultiIndex(levels=levels, labels=labels,
                           sortorder=sortorder, names=names,

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -189,8 +189,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             elif isinstance(data, Categorical):
                 if dtype is not None:
                     raise ValueError("cannot specify a dtype with a Categorical")
-                if name is None:
-                    name = data.name
             elif (isinstance(data, types.GeneratorType) or
                   (compat.PY3 and isinstance(data, map))):
                 data = list(data)

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -492,7 +492,7 @@ class TestCategorical(tm.TestCase):
     def test_big_print(self):
         factor = Categorical([0,1,2,0,1,2]*100, ['a', 'b', 'c'], name='cat', fastpath=True)
         expected = ["[a, b, c, a, b, ..., b, c, a, b, c]",
-                    "Name: cat, Length: 600",
+                    "Length: 600",
                     "Categories (3, object): [a, b, c]"]
         expected = "\n".join(expected)
 
@@ -501,15 +501,11 @@ class TestCategorical(tm.TestCase):
         self.assertEqual(actual, expected)
 
     def test_empty_print(self):
-        factor = Categorical([], ["a","b","c"], name="cat")
-        expected = ("[], Name: cat, Categories (3, object): [a, b, c]")
+        factor = Categorical([], ["a","b","c"])
+        expected = ("[], Categories (3, object): [a, b, c]")
         # hack because array_repr changed in numpy > 1.6.x
         actual = repr(factor)
         self.assertEqual(actual, expected)
-
-        factor = Categorical([], ["a","b","c"])
-        expected = ("[], Categories (3, object): [a, b, c]")
-        actual = repr(factor)
 
         self.assertEqual(expected, actual)
         factor = Categorical([], ["a","b","c"], ordered=True)
@@ -523,9 +519,9 @@ class TestCategorical(tm.TestCase):
 
     def test_print_none_width(self):
         # GH10087
-        a = pd.Series(pd.Categorical([1,2,3,4], name="a"))
+        a = pd.Series(pd.Categorical([1,2,3,4]))
         exp = u("0    1\n1    2\n2    3\n3    4\n" +
-              "Name: a, dtype: category\nCategories (4, int64): [1, 2, 3, 4]")
+              "dtype: category\nCategories (4, int64): [1, 2, 3, 4]")
 
         with option_context("display.width", None):
             self.assertEqual(exp, repr(a))
@@ -1170,6 +1166,13 @@ class TestCategorical(tm.TestCase):
 
         self.assertFalse(LooseVersion(pd.__version__) >= '0.18')
 
+    def test_removed_names_produces_warning(self):
+        with tm.assert_produces_warning(UserWarning):
+            Categorical([0,1], name="a")
+
+        with tm.assert_produces_warning(UserWarning):
+            Categorical.from_codes([1,2], ["a","b","c"], name="a")
+
     def test_datetime_categorical_comparison(self):
         dt_cat = pd.Categorical(pd.date_range('2014-01-01', periods=3), ordered=True)
         self.assert_numpy_array_equal(dt_cat > dt_cat[0], [False, True, True])
@@ -1673,23 +1676,23 @@ class TestCategoricalAsBlock(tm.TestCase):
         self.assert_numpy_array_equal(res["cat"].values, res["s"].values)
 
     def test_repr(self):
-        a = pd.Series(pd.Categorical([1,2,3,4], name="a"))
+        a = pd.Series(pd.Categorical([1,2,3,4]))
         exp = u("0    1\n1    2\n2    3\n3    4\n" +
-              "Name: a, dtype: category\nCategories (4, int64): [1, 2, 3, 4]")
+              "dtype: category\nCategories (4, int64): [1, 2, 3, 4]")
 
         self.assertEqual(exp, a.__unicode__())
 
-        a = pd.Series(pd.Categorical(["a","b"] *25, name="a"))
+        a = pd.Series(pd.Categorical(["a","b"] *25))
         exp = u("0     a\n1     b\n" + "     ..\n" +
                 "48    a\n49    b\n" +
-                "Name: a, dtype: category\nCategories (2, object): [a, b]")
+                "dtype: category\nCategories (2, object): [a, b]")
         with option_context("display.max_rows", 5):
             self.assertEqual(exp, repr(a))
 
         levs = list("abcdefghijklmnopqrstuvwxyz")
-        a = pd.Series(pd.Categorical(["a","b"], name="a", categories=levs, ordered=True))
+        a = pd.Series(pd.Categorical(["a","b"], categories=levs, ordered=True))
         exp = u("0    a\n1    b\n" +
-                "Name: a, dtype: category\n"
+                "dtype: category\n"
                 "Categories (26, object): [a < b < c < d ... w < x < y < z]")
         self.assertEqual(exp,a.__unicode__())
 
@@ -2202,8 +2205,8 @@ class TestCategoricalAsBlock(tm.TestCase):
         tm.assert_series_equal(result, expected)
 
         result = df.loc["h":"j","cats"]
-        expected = Series(Categorical(['a','b','b'], name='cats',
-                          categories=['a','b','c']), index=['h','i','j'])
+        expected = Series(Categorical(['a','b','b'],
+                          categories=['a','b','c']), index=['h','i','j'], name='cats')
         tm.assert_series_equal(result, expected)
 
         result = df.ix["h":"j",0:1]

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -3453,7 +3453,7 @@ class TestGroupBy(tm.TestCase):
         levels = ['foo', 'bar', 'baz', 'qux']
         codes = np.random.randint(0, 4, size=100)
 
-        cats = Categorical.from_codes(codes, levels, name='myfactor', ordered=True)
+        cats = Categorical.from_codes(codes, levels, ordered=True)
 
         data = DataFrame(np.random.randn(100, 4))
 
@@ -3461,10 +3461,8 @@ class TestGroupBy(tm.TestCase):
 
         expected = data.groupby(np.asarray(cats)).mean()
         expected = expected.reindex(levels)
-        expected.index.name = 'myfactor'
 
         assert_frame_equal(result, expected)
-        self.assertEqual(result.index.name, cats.name)
 
         grouped = data.groupby(cats)
         desc_result = grouped.describe()
@@ -3473,12 +3471,12 @@ class TestGroupBy(tm.TestCase):
         ord_labels = np.asarray(cats).take(idx)
         ord_data = data.take(idx)
         expected = ord_data.groupby(ord_labels, sort=False).describe()
-        expected.index.names = ['myfactor', None]
+        expected.index.names = [None, None]
         assert_frame_equal(desc_result, expected)
 
         # GH 10460
-        expc = Categorical.from_codes(np.arange(4).repeat(8), levels, name='myfactor', ordered=True)
-        exp = CategoricalIndex(expc, name='myfactor')
+        expc = Categorical.from_codes(np.arange(4).repeat(8), levels, ordered=True)
+        exp = CategoricalIndex(expc)
         self.assert_index_equal(desc_result.index.get_level_values(0), exp)
         exp = Index(['count', 'mean', 'std', 'min', '25%', '50%', '75%', 'max'] * 4)
         self.assert_index_equal(desc_result.index.get_level_values(1), exp)
@@ -3488,7 +3486,7 @@ class TestGroupBy(tm.TestCase):
         levels = pd.date_range('2014-01-01', periods=4)
         codes = np.random.randint(0, 4, size=100)
 
-        cats = Categorical.from_codes(codes, levels, name='myfactor', ordered=True)
+        cats = Categorical.from_codes(codes, levels, ordered=True)
 
         data = DataFrame(np.random.randn(100, 4))
         result = data.groupby(cats).mean()
@@ -3496,10 +3494,9 @@ class TestGroupBy(tm.TestCase):
         expected = data.groupby(np.asarray(cats)).mean()
         expected = expected.reindex(levels)
         expected.index = CategoricalIndex(expected.index, categories=expected.index,
-                                          name='myfactor', ordered=True)
+                                          ordered=True)
 
         assert_frame_equal(result, expected)
-        self.assertEqual(result.index.name, cats.name)
 
         grouped = data.groupby(cats)
         desc_result = grouped.describe()
@@ -3508,14 +3505,14 @@ class TestGroupBy(tm.TestCase):
         ord_labels = cats.take_nd(idx)
         ord_data = data.take(idx)
         expected = ord_data.groupby(ord_labels).describe()
-        expected.index.names = ['myfactor', None]
+        expected.index.names = [None, None]
         assert_frame_equal(desc_result, expected)
         tm.assert_index_equal(desc_result.index, expected.index)
         tm.assert_index_equal(desc_result.index.get_level_values(0), expected.index.get_level_values(0))
 
         # GH 10460
-        expc = Categorical.from_codes(np.arange(4).repeat(8), levels, name='myfactor', ordered=True)
-        exp = CategoricalIndex(expc, name='myfactor')
+        expc = Categorical.from_codes(np.arange(4).repeat(8), levels, ordered=True)
+        exp = CategoricalIndex(expc)
         self.assert_index_equal(desc_result.index.get_level_values(0), exp)
         exp = Index(['count', 'mean', 'std', 'min', '25%', '50%', '75%', 'max'] * 4)
         self.assert_index_equal(desc_result.index.get_level_values(1), exp)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -692,9 +692,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
     def test_constructor_categorical(self):
         cat = pd.Categorical([0, 1, 2, 0, 1, 2], ['a', 'b', 'c'], fastpath=True)
-        cat.name = 'foo'
         res = Series(cat)
-        self.assertEqual(res.name, cat.name)
         self.assertTrue(res.values.equals(cat))
 
     def test_constructor_maskedarray(self):

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -217,7 +217,7 @@ def _bins_to_cuts(x, bins, right=True, labels=None, retbins=False,
 
         levels = np.asarray(levels, dtype=object)
         np.putmask(ids, na_mask, 0)
-        fac = Categorical(ids - 1, levels, ordered=True, name=name, fastpath=True)
+        fac = Categorical(ids - 1, levels, ordered=True, fastpath=True)
     else:
         fac = ids - 1
         if has_nas:
@@ -225,7 +225,7 @@ def _bins_to_cuts(x, bins, right=True, labels=None, retbins=False,
             np.putmask(fac, na_mask, np.nan)
 
     if x_is_series:
-        fac = Series(fac, index=series_index)
+        fac = Series(fac, index=series_index, name=name)
 
     if not retbins:
         return fac

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -630,9 +630,6 @@ def assert_categorical_equal(res, exp):
     if res.ordered != exp.ordered:
         raise AssertionError("ordered not the same")
 
-    if res.name != exp.name:
-        raise AssertionError("name not the same")
-
 
 def assert_numpy_array_equal(np_array, assert_equal, err_msg=None):
     """Checks that 'np_array' is equal to 'assert_equal'


### PR DESCRIPTION
Probably work in progress... Up to now only tests locally with 'not slow' (whoever wrote  `nosetests --with-id --failed`  should be praised! :-) )

See here: https://github.com/pydata/pandas/issues/10482
