### PR TITLE
BUG: made behavior of operator equal for CategoricalIndex consistent,…

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -155,7 +155,7 @@ in the method call.
 Changes to Index Comparisons
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Operator equal on Index should behavior similarly to Series (:issue:`9947`)
+Operator equal on Index should behavior similarly to Series (:issue:`9947`, :issue:`10637`)
 
 Starting in v0.17.0, comparing ``Index`` objects of different lengths will raise
 a ``ValueError``. This is to be consistent with the behavior of ``Series``.
@@ -390,7 +390,6 @@ Bug Fixes
 
 
 
-- Bug in operator equal on Index not being consistent with Series (:issue:`9947`)
 - Reading "famafrench" data via ``DataReader`` results in HTTP 404 error because of the website url is changed (:issue:`10591`).
 - Bug in `read_msgpack` where DataFrame to decode has duplicate column names (:issue:`9618`)
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -3260,8 +3260,12 @@ class CategoricalIndex(Index, PandasDelegate):
                 elif isinstance(other, Index):
                     other = self._create_categorical(self, other.values, categories=self.categories, ordered=self.ordered)
 
+                if isinstance(other, (ABCCategorical, np.ndarray, ABCSeries)):
+                    if len(self.values) != len(other):
+                        raise ValueError("Lengths must match to compare")
+
                 if isinstance(other, ABCCategorical):
-                    if not (self.values.is_dtype_equal(other) and len(self.values) == len(other)):
+                    if not self.values.is_dtype_equal(other):
                         raise TypeError("categorical index comparisions must have the same categories and ordered attributes")
 
                 return getattr(self.values, op)(other)


### PR DESCRIPTION
… improved unit tests

this is a follow-up to https://github.com/pydata/pandas/pull/9947

@jreback 
