### PR TITLE
CLN: Make ufunc works for Index

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -309,6 +309,8 @@ Other enhancements
 
 - ``DataFrame.apply`` will return a Series of dicts if the passed function returns a dict and ``reduce=True`` (:issue:`8735`).
 
+- ``PeriodIndex`` now supports arithmetic with ``np.ndarray`` (:issue:`10638`)
+
 - ``concat`` will now use existing Series names if provided (:issue:`10698`).
 
   .. ipython:: python
@@ -332,6 +334,7 @@ Other enhancements
   .. ipython:: python
 
     pd.concat([foo, bar, baz], 1)
+
 
 .. _whatsnew_0170.api:
 
@@ -1005,3 +1008,5 @@ Bug Fixes
 - Bug when constructing ``DataFrame`` where passing a dictionary with only scalar values and specifying columns did not raise an error (:issue:`10856`)
 - Bug in ``.var()`` causing roundoff errors for highly similar values (:issue:`10242`)
 - Bug in ``DataFrame.plot(subplots=True)`` with duplicated columns outputs incorrect result (:issue:`10962`)
+- Bug in ``Index`` arithmetic may result in incorrect class (:issue:`10638`)
+

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -613,7 +613,8 @@ def _arith_method_SERIES(op, name, str_rep, fill_zeros=None,
         else:
             # scalars
             if hasattr(lvalues, 'values') and not isinstance(lvalues, pd.DatetimeIndex):
-                 lvalues = lvalues.values
+                lvalues = lvalues.values
+
             return left._constructor(wrap_results(na_op(lvalues, rvalues)),
                                      index=left.index, name=left.name,
                                      dtype=dtype)

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1077,15 +1077,6 @@ class DatetimeIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
                               end=max(left_end, right_end),
                               freq=left.offset)
 
-    def __array_finalize__(self, obj):
-        if self.ndim == 0:  # pragma: no cover
-            return self.item()
-
-        self.offset = getattr(obj, 'offset', None)
-        self.tz = getattr(obj, 'tz', None)
-        self.name = getattr(obj, 'name', None)
-        self._reset_identity()
-
     def __iter__(self):
         """
         Return an iterator over the boxed values

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -278,6 +278,14 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, Int64Index):
             raise Exception("invalid pickle state")
     _unpickle_compat = __setstate__
 
+    def _maybe_update_attributes(self, attrs):
+        """ Update Index attributes (e.g. freq) depending on op """
+        freq = attrs.get('freq', None)
+        if freq is not None:
+            # no need to infer if freq is None
+            attrs['freq'] = 'infer'
+        return attrs
+
     def _add_delta(self, delta):
         if isinstance(delta, (Tick, timedelta, np.timedelta64)):
             new_values = self._add_delta_td(delta)
@@ -559,14 +567,6 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, Int64Index):
             return self._shallow_copy(dates)
         else:
             return left
-
-    def __array_finalize__(self, obj):
-        if self.ndim == 0:  # pragma: no cover
-            return self.item()
-
-        self.name = getattr(obj, 'name', None)
-        self.freq = getattr(obj, 'freq', None)
-        self._reset_identity()
 
     def _wrap_union_result(self, other, result):
         name = self.name if self.name == other.name else None

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -1391,6 +1391,7 @@ Freq: Q-DEC"""
 
         for o in [pd.offsets.YearBegin(2), pd.offsets.MonthBegin(1), pd.offsets.Minute(),
                   np.timedelta64(365, 'D'), timedelta(365), Timedelta(days=365)]:
+            msg = 'Input has different freq from PeriodIndex\\(freq=A-DEC\\)'
             with tm.assertRaisesRegexp(ValueError, 'Input has different freq from Period'):
                 rng + o
 
@@ -1404,7 +1405,8 @@ Freq: Q-DEC"""
         for o in [pd.offsets.YearBegin(2), pd.offsets.MonthBegin(1), pd.offsets.Minute(),
                   np.timedelta64(365, 'D'), timedelta(365),  Timedelta(days=365)]:
             rng = pd.period_range('2014-01', '2016-12', freq='M')
-            with tm.assertRaisesRegexp(ValueError, 'Input has different freq from Period'):
+            msg = 'Input has different freq from PeriodIndex\\(freq=M\\)'
+            with tm.assertRaisesRegexp(ValueError, msg):
                 rng + o
 
         # Tick
@@ -1422,7 +1424,8 @@ Freq: Q-DEC"""
         for o in [pd.offsets.YearBegin(2), pd.offsets.MonthBegin(1), pd.offsets.Minute(),
                   np.timedelta64(4, 'h'), timedelta(hours=23), Timedelta('23:00:00')]:
             rng = pd.period_range('2014-05-01', '2014-05-15', freq='D')
-            with tm.assertRaisesRegexp(ValueError, 'Input has different freq from Period'):
+            msg = 'Input has different freq from PeriodIndex\\(freq=D\\)'
+            with tm.assertRaisesRegexp(ValueError, msg):
                 rng + o
 
         offsets = [pd.offsets.Hour(2), timedelta(hours=2), np.timedelta64(2, 'h'),
@@ -1439,9 +1442,10 @@ Freq: Q-DEC"""
         for delta in [pd.offsets.YearBegin(2), timedelta(minutes=30),
                       np.timedelta64(30, 's'),  Timedelta(seconds=30)]:
             rng = pd.period_range('2014-01-01 10:00', '2014-01-05 10:00', freq='H')
-            with tm.assertRaisesRegexp(ValueError, 'Input has different freq from Period'):
+            msg = 'Input has different freq from PeriodIndex\\(freq=H\\)'
+            with tm.assertRaisesRegexp(ValueError, msg):
                 result = rng + delta
-            with tm.assertRaisesRegexp(ValueError, 'Input has different freq from Period'):
+            with tm.assertRaisesRegexp(ValueError, msg):
                 rng += delta
 
         # int
@@ -1502,7 +1506,8 @@ Freq: Q-DEC"""
         for o in [pd.offsets.YearBegin(2), pd.offsets.MonthBegin(1), pd.offsets.Minute(),
                   np.timedelta64(365, 'D'), timedelta(365)]:
             rng = pd.period_range('2014', '2024', freq='A')
-            with tm.assertRaisesRegexp(ValueError, 'Input has different freq from Period'):
+            msg = 'Input has different freq from PeriodIndex\\(freq=A-DEC\\)'
+            with tm.assertRaisesRegexp(ValueError, msg):
                 rng - o
 
         rng = pd.period_range('2014-01', '2016-12', freq='M')
@@ -1515,7 +1520,8 @@ Freq: Q-DEC"""
         for o in [pd.offsets.YearBegin(2), pd.offsets.MonthBegin(1), pd.offsets.Minute(),
                   np.timedelta64(365, 'D'), timedelta(365)]:
             rng = pd.period_range('2014-01', '2016-12', freq='M')
-            with tm.assertRaisesRegexp(ValueError, 'Input has different freq from Period'):
+            msg = 'Input has different freq from PeriodIndex\\(freq=M\\)'
+            with tm.assertRaisesRegexp(ValueError, msg):
                 rng - o
 
         # Tick
@@ -1532,7 +1538,8 @@ Freq: Q-DEC"""
         for o in [pd.offsets.YearBegin(2), pd.offsets.MonthBegin(1), pd.offsets.Minute(),
                   np.timedelta64(4, 'h'), timedelta(hours=23)]:
             rng = pd.period_range('2014-05-01', '2014-05-15', freq='D')
-            with tm.assertRaisesRegexp(ValueError, 'Input has different freq from Period'):
+            msg = 'Input has different freq from PeriodIndex\\(freq=D\\)'
+            with tm.assertRaisesRegexp(ValueError, msg):
                 rng - o
 
         offsets = [pd.offsets.Hour(2), timedelta(hours=2), np.timedelta64(2, 'h'),
@@ -1547,9 +1554,10 @@ Freq: Q-DEC"""
 
         for delta in [pd.offsets.YearBegin(2), timedelta(minutes=30), np.timedelta64(30, 's')]:
             rng = pd.period_range('2014-01-01 10:00', '2014-01-05 10:00', freq='H')
-            with tm.assertRaisesRegexp(ValueError, 'Input has different freq from Period'):
+            msg = 'Input has different freq from PeriodIndex\\(freq=H\\)'
+            with tm.assertRaisesRegexp(ValueError, msg):
                 result = rng + delta
-            with tm.assertRaisesRegexp(ValueError, 'Input has different freq from Period'):
+            with tm.assertRaisesRegexp(ValueError, msg):
                 rng += delta
 
         # int

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -1088,6 +1088,8 @@ cdef class _NaT(_Timestamp):
 
 
 def _delta_to_nanoseconds(delta):
+    if isinstance(delta, np.ndarray):
+        return delta.astype('m8[ns]').astype('int64')
     if hasattr(delta, 'nanos'):
         return delta.nanos
     if hasattr(delta, 'delta'):


### PR DESCRIPTION
closes #9966, #9974 (PR)

I understand these are never used because `Index` is no longer the subclass of `np.array`. Correct?
- [x] Add tests for ~~all~~ almost ufuncs
  - http://docs.scipy.org/doc/numpy/reference/ufuncs.html
- ~~CategoricalIndex~~: Needs to be done separately to fix `Categorical`, because number of categories can be changed.

```
np.sin(pd.Categorical([1, 2, 3]))
array([ 0.84147098,  0.90929743,  0.14112001])
```
- [x] MultiIndex: Raise `TypeError` or `AttributeError`, as ufuncs are performed to array of tuples.
