### PR TITLE
ENH: allow duplicate column names if they are not merged upon

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -80,6 +80,8 @@ Other enhancements
 
 - ``regex`` argument to ``DataFrame.filter`` now handles numeric column names instead of raising ``ValueError`` (:issue:`10384`).
 
+- ``merge`` will now allow duplicate column names if they are not merged upon (:issue:`10639`).
+
 .. _whatsnew_0170.api:
 
 .. _whatsnew_0170.api_breaking:

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -80,7 +80,7 @@ Other enhancements
 
 - ``regex`` argument to ``DataFrame.filter`` now handles numeric column names instead of raising ``ValueError`` (:issue:`10384`).
 
-- ``merge`` will now allow duplicate column names if they are not merged upon (:issue:`10639`).
+- ``pd.merge`` will now allow duplicate column names if they are not merged upon (:issue:`10639`).
 
 .. _whatsnew_0170.api:
 

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -402,19 +402,14 @@ class _MergeOperation(object):
                 if self.left_on is None:
                     raise MergeError('Must pass left_on or left_index=True')
             else:
-                if not self.left.columns.is_unique:
-                    raise MergeError("Left data columns not unique: %s"
-                                     % repr(self.left.columns))
-
-                if not self.right.columns.is_unique:
-                    raise MergeError("Right data columns not unique: %s"
-                                     % repr(self.right.columns))
-
                 # use the common columns
                 common_cols = self.left.columns.intersection(
                     self.right.columns)
                 if len(common_cols) == 0:
                     raise MergeError('No common columns to perform merge on')
+                if not common_cols.is_unique:
+                    raise MergeError("Data columns not unique: %s"
+                                     % repr(common_cols))
                 self.left_on = self.right_on = common_cols
         elif self.on is not None:
             if self.left_on is not None or self.right_on is not None:

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -843,7 +843,6 @@ class TestMerge(tm.TestCase):
         assert_frame_equal(result, expected)
 
     def test_overlapping_columns_error_message(self):
-        # #2649
         df = DataFrame({'key': [1, 2, 3],
                         'v1': [4, 5, 6],
                         'v2': [7, 8, 9]})
@@ -853,7 +852,16 @@ class TestMerge(tm.TestCase):
 
         df.columns = ['key', 'foo', 'foo']
         df2.columns = ['key', 'bar', 'bar']
+        expected = DataFrame({'key': [1, 2, 3],
+                         'v1': [4, 5, 6],
+                         'v2': [7, 8, 9],
+                         'v3': [4, 5, 6],
+                         'v4': [7, 8, 9]})
+        expected.columns = ['key', 'foo', 'foo', 'bar', 'bar']
+        assert_frame_equal(merge(df, df2), expected)
 
+        # #2649
+        df2.columns = ['key1', 'foo', 'foo']
         self.assertRaises(ValueError, merge, df, df2)
 
 def _check_merge(x, y):


### PR DESCRIPTION
Currently merge columns are not automatically inferred when there are duplicate column names. Instead a `MergeError` is raised. This pull request enables merging with duplicate column names as long as they are not merged upon.

```
df = DataFrame({'key': [1, 2, 3],
                'v1': [4, 5, 6],
                'v2': [7, 8, 9]})
df.columns = ['key', 'foo', 'foo']
df2 = DataFrame({'key': [1, 2, 3],
                'v1': [4, 5, 6],
                'v2': [7, 8, 9]})
df2.columns = ['key', 'bar', 'bar']

# worked before
merge(df, df2, on=['key'])
# now works as well since 'foo' and 'bar' don't interfere
merge(df, df2)
```

If the common cols are not unique a `MergeError` is still raised as in #2649
