### PR TITLE
CLN: Remove duplicate implementations of bind_method; typo in compat

### DIFF
--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -14,7 +14,7 @@ Key items to import for 2/3 compatible code:
   * Uses the original method if available, otherwise uses items, keys, values.
 * types:
     * text_type: unicode in Python 2, str in Python 3
-    * binary_type: str in Python 2, bythes in Python 3
+    * binary_type: str in Python 2, bytes in Python 3
     * string_types: basestring in Python 2, str in Python 3
 * bind_method: binds functions to classes
 * add_metaclass(metaclass) - class decorator that recreates class with with the

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -113,30 +113,6 @@ class _ABCGeneric(type):
 ABCGeneric = _ABCGeneric("ABCGeneric", tuple(), {})
 
 
-def bind_method(cls, name, func):
-    """Bind a method to class, python 2 and python 3 compatible.
-
-    Parameters
-    ----------
-
-    cls : type
-        class to receive bound method
-    name : basestring
-        name of method on class instance
-    func : function
-        function to be bound as method
-
-
-    Returns
-    -------
-    None
-    """
-    # only python 2 has bound/unbound method issue
-    if not compat.PY3:
-        setattr(cls, name, types.MethodType(func, None, cls))
-    else:
-        setattr(cls, name, func)
-
 class CategoricalDtypeType(type):
     """
     the type of CategoricalDtype, this metaclass determines subclass ability

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -15,7 +15,8 @@ import pandas.core.common as com
 import pandas.computation.expressions as expressions
 from pandas.lib import isscalar
 from pandas.tslib import iNaT
-from pandas.core.common import(bind_method, is_list_like, notnull, isnull,
+from pandas.compat import bind_method
+from pandas.core.common import(is_list_like, notnull, isnull,
                                _values_from_object, _maybe_match_name,
                                needs_i8_conversion, is_datetimelike_v_numeric,
                                is_integer_dtype, is_categorical_dtype, is_object_dtype,


### PR DESCRIPTION
#10566 removed one of the implementations of `bind_method` and fixed a typo
