### PR TITLE
BUG: GH9428 promote string dtype to object dtype for empty DataFrame

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -395,4 +395,5 @@ Bug Fixes
 - Bug in `read_msgpack` where DataFrame to decode has duplicate column names (:issue:`9618`)
 - Bug in ``io.common.get_filepath_or_buffer`` which caused reading of valid S3 files to fail if the bucket also contained keys for which the user does not have read permission (:issue:`10604`)
 - Bug in vectorised setting of timestamp columns with python ``datetime.date`` and numpy ``datetime64`` (:issue:`10408`, :issue:`10412`)
+- Bug in ``pd.DataFrame`` when constructing an empty DataFrame with a string dtype (:issue:`9428`)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -322,6 +322,8 @@ class DataFrame(NDFrame):
                     if dtype is None:
                         # 1783
                         v = np.empty(len(index), dtype=object)
+                    elif np.issubdtype(dtype, np.flexible):
+                        v = np.empty(len(index), dtype=object)
                     else:
                         v = np.empty(len(index), dtype=dtype)
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3617,6 +3617,20 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                           [('a', [8]), ('a', [5]), ('b', [6])],
                           columns=['b', 'a', 'a'])
 
+    def test_constructor_empty_with_string_dtype(self):
+        # GH 9428
+        expected = DataFrame(index=[0, 1], columns=[0, 1], dtype=object)
+
+        df = DataFrame(index=[0, 1], columns=[0, 1], dtype=str)
+        assert_frame_equal(df, expected)
+        df = DataFrame(index=[0, 1], columns=[0, 1], dtype=np.str_)
+        assert_frame_equal(df, expected)
+        df = DataFrame(index=[0, 1], columns=[0, 1], dtype=np.unicode_)
+        assert_frame_equal(df, expected)
+        df = DataFrame(index=[0, 1], columns=[0, 1], dtype='U5')
+        assert_frame_equal(df, expected)
+
+
     def test_column_dups_operations(self):
 
         def check(result, expected=None):


### PR DESCRIPTION
Addresses [GH9428](https://github.com/pydata/pandas/issues/9428).

When constructing an empty DataFrame with a string dtype (e.g. `str`, `np.unicode_`, `U5`), the dtype is now promoted to the `object` dtype. This is now consistent with Series and avoids the confusing behaviour described in the original issue.
