### PR TITLE
API: #10636, changing default of to_datetime to raise, deprecating coerce in favor of errors

### DIFF
--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -197,18 +197,30 @@ or ``format``, use ``to_datetime`` if these are required.
 Invalid Data
 ~~~~~~~~~~~~
 
-Pass ``coerce=True`` to convert invalid data to ``NaT`` (not a time):
+.. note::
+
+   In version 0.17.0, the default for ``to_datetime`` is now ``errors='raise'``, rather than ``errors='ignore'``. This means
+   that invalid parsing will raise rather that return the original input as in previous versions.
+
+Pass ``errors='coerce'`` to convert invalid data to ``NaT`` (not a time):
 
 .. ipython:: python
+   :okexcept:
 
-   to_datetime(['2009-07-31', 'asd'])
+   # this is the default, raise when unparseable
+   to_datetime(['2009-07-31', 'asd'], errors='raise')
 
-   to_datetime(['2009-07-31', 'asd'], coerce=True)
+   # return the original input when unparseable
+   to_datetime(['2009-07-31', 'asd'], errors='ignore')
+
+   # return NaT for input when unparseable
+   to_datetime(['2009-07-31', 'asd'], errors='coerce')
 
 
 Take care, ``to_datetime`` may not act as you expect on mixed data:
 
 .. ipython:: python
+   :okexcept:
 
    to_datetime([1, '1'])
 

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -65,10 +65,11 @@ Other enhancements
 - Enable `read_hdf` to be used without specifying a key when the HDF file contains a single dataset (:issue:`10443`)
 
 - ``DatetimeIndex`` can be instantiated using strings contains ``NaT`` (:issue:`7599`)
-- The string parsing of ``to_datetime``, ``Timestamp`` and ``DatetimeIndex`` has been made consistent" (:issue:`7599`)
+- The string parsing of ``to_datetime``, ``Timestamp`` and ``DatetimeIndex`` has been made consistent. (:issue:`7599`)
 
-  Prior to v0.17.0, ``Timestamp`` and ``to_datetime`` may parse year-only datetime-string incorrectly using today's date, otherwise ``DatetimeIndex`` uses the beginning of the year.
-  ``Timestamp`` and ``to_datetime`` may raise ``ValueError`` in some types of datetime-string which ``DatetimeIndex`` can parse, such as quarterly string.
+  Prior to v0.17.0, ``Timestamp`` and ``to_datetime`` may parse year-only datetime-string incorrectly using today's date, otherwise ``DatetimeIndex``
+  uses the beginning of the year. ``Timestamp`` and ``to_datetime`` may raise ``ValueError`` in some types of datetime-string which ``DatetimeIndex``
+  can parse, such as a quarterly string.
 
   Previous Behavior
 
@@ -118,6 +119,45 @@ Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Line and kde plot with ``subplots=True`` now uses default colors, not all black. Specify ``color='k'`` to draw all lines in black (:issue:`9894`)
+
+.. _whatsnew_0170.api_breaking.to_datetime
+
+Changes to to_datetime and to_timedelta
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The default for ``pd.to_datetime`` error handling has changed to ``errors='raise'``. In prior versions it was ``errors='ignore'``.
+Furthermore, the ``coerce`` argument has been deprecated in favor of ``errors='coerce'``. This means that invalid parsing will raise rather that return the original
+input as in previous versions. (:issue:`10636`)
+
+Previous Behavior:
+
+  .. code-block:: python
+
+     In [2]: pd.to_datetime(['2009-07-31', 'asd'])
+     Out[2]: array(['2009-07-31', 'asd'], dtype=object)
+
+New Behavior:
+
+  .. ipython:: python
+     :okexcept:
+
+     pd.to_datetime(['2009-07-31', 'asd'])
+
+  Of course you can coerce this as well.
+
+  .. ipython:: python
+
+     to_datetime(['2009-07-31', 'asd'], errors='coerce')
+
+  To keep the previous behaviour, you can use `errors='ignore'`:
+
+  .. ipython:: python
+    :okexcept:
+
+    to_datetime(['2009-07-31', 'asd'], errors='ignore')
+
+``pd.to_timedelta`` gained a similar API, of ``errors='raise'|'ignore'|'coerce'``, and the ``coerce`` keyword
+has been deprecated in favor of ``errors='coerce'``.
 
 .. _whatsnew_0170.api_breaking.convert_objects:
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1903,9 +1903,9 @@ def _possibly_convert_objects(values,
 
         # Immediate return if coerce
         if datetime:
-            return pd.to_datetime(values, coerce=True, box=False)
+            return pd.to_datetime(values, errors='coerce', box=False)
         elif timedelta:
-            return pd.to_timedelta(values, coerce=True, box=False)
+            return pd.to_timedelta(values, errors='coerce', box=False)
         elif numeric:
             return lib.maybe_convert_numeric(values, set(), coerce_numeric=True)
 
@@ -1958,7 +1958,7 @@ def _possibly_convert_platform(values):
     return values
 
 
-def _possibly_cast_to_datetime(value, dtype, coerce=False):
+def _possibly_cast_to_datetime(value, dtype, errors='raise'):
     """ try to cast the array/value to a datetimelike dtype, converting float
     nan to iNaT
     """
@@ -2002,9 +2002,9 @@ def _possibly_cast_to_datetime(value, dtype, coerce=False):
                 elif np.prod(value.shape) and value.dtype != dtype:
                     try:
                         if is_datetime64:
-                            value = to_datetime(value, coerce=coerce).values
+                            value = to_datetime(value, errors=errors).values
                         elif is_timedelta64:
-                            value = to_timedelta(value, coerce=coerce).values
+                            value = to_timedelta(value, errors=errors).values
                     except (AttributeError, ValueError):
                         pass
 
@@ -2066,7 +2066,7 @@ def _possibly_infer_to_datetimelike(value, convert_dates=False):
         def _try_datetime(v):
             # safe coerce to datetime64
             try:
-                return tslib.array_to_datetime(v, raise_=True).reshape(shape)
+                return tslib.array_to_datetime(v, errors='raise').reshape(shape)
             except:
                 return v
 

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -341,7 +341,6 @@ class _TimeOp(object):
         """converts values to ndarray"""
         from pandas.tseries.timedeltas import to_timedelta
 
-        coerce = True
         if not is_list_like(values):
             values = np.array([values])
         inferred_type = lib.infer_dtype(values)
@@ -362,7 +361,7 @@ class _TimeOp(object):
                 values = tslib.array_to_datetime(values)
         elif inferred_type in ('timedelta', 'timedelta64'):
             # have a timedelta, convert to to ns here
-            values = to_timedelta(values, coerce=coerce)
+            values = to_timedelta(values, errors='coerce')
         elif inferred_type == 'integer':
             # py3 compat where dtype is 'm' but is an integer
             if values.dtype.kind == 'm':
@@ -381,7 +380,7 @@ class _TimeOp(object):
                                 "datetime/timedelta operations [{0}]".format(
                                     ', '.join([com.pprint_thing(v)
                                                for v in values[mask]])))
-            values = to_timedelta(os, coerce=coerce)
+            values = to_timedelta(os, errors='coerce')
         elif inferred_type == 'floating':
 
             # all nan, so ok, use the other dtype (e.g. timedelta or datetime)

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2057,6 +2057,7 @@ def _make_date_converter(date_parser=None, dayfirst=False,
                     utc=None,
                     box=False,
                     dayfirst=dayfirst,
+                    errors='ignore',
                     infer_datetime_format=infer_datetime_format
                 )
             except:
@@ -2064,7 +2065,7 @@ def _make_date_converter(date_parser=None, dayfirst=False,
                     lib.try_parse_dates(strs, dayfirst=dayfirst))
         else:
             try:
-                result = tools.to_datetime(date_parser(*date_cols))
+                result = tools.to_datetime(date_parser(*date_cols), errors='ignore')
                 if isinstance(result, datetime.datetime):
                     raise Exception('scalar parser')
                 return result
@@ -2073,7 +2074,8 @@ def _make_date_converter(date_parser=None, dayfirst=False,
                     return tools.to_datetime(
                         lib.try_parse_dates(_concat_date_cols(date_cols),
                                             parser=date_parser,
-                                            dayfirst=dayfirst))
+                                            dayfirst=dayfirst),
+                        errors='ignore')
                 except Exception:
                     return generic_parser(date_parser, *date_cols)
 

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -80,17 +80,17 @@ def _convert_params(sql, params):
 
 def _handle_date_column(col, format=None):
     if isinstance(format, dict):
-        return to_datetime(col, **format)
+        return to_datetime(col, errors='ignore', **format)
     else:
         if format in ['D', 's', 'ms', 'us', 'ns']:
-            return to_datetime(col, coerce=True, unit=format, utc=True)
+            return to_datetime(col, errors='coerce', unit=format, utc=True)
         elif (issubclass(col.dtype.type, np.floating)
                 or issubclass(col.dtype.type, np.integer)):
             # parse dates as timestamp
             format = 's' if format is None else format
-            return to_datetime(col, coerce=True, unit=format, utc=True)
+            return to_datetime(col, errors='coerce', unit=format, utc=True)
         else:
-            return to_datetime(col, coerce=True, format=format, utc=True)
+            return to_datetime(col, errors='coerce', format=format, utc=True)
 
 
 def _parse_date_columns(data_frame, parse_dates):

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -216,7 +216,7 @@ class SQLAlchemyMixIn(MixInBase):
 
     def _close_conn(self):
         pass
-           
+
 class PandasSQLTest(unittest.TestCase):
     """
     Base class with common private methods for SQLAlchemy and fallback cases.
@@ -1271,7 +1271,7 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
         result = sql.read_sql_query('SELECT * FROM test_datetime', self.conn)
         if self.flavor == 'sqlite':
             self.assertTrue(isinstance(result.loc[0, 'A'], string_types))
-            result['A'] = to_datetime(result['A'], coerce=True)
+            result['A'] = to_datetime(result['A'], errors='coerce')
             tm.assert_frame_equal(result, df)
         else:
             tm.assert_frame_equal(result, df)
@@ -1720,7 +1720,7 @@ class TestMySQLAlchemy(_TestMySQLAlchemy, _TestSQLAlchemy):
     pass
 
 
-class TestMySQLAlchemyConn(_TestMySQLAlchemy, _TestSQLAlchemyConn): 
+class TestMySQLAlchemyConn(_TestMySQLAlchemy, _TestSQLAlchemyConn):
     pass
 
 

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -419,7 +419,7 @@ class TestStata(tm.TestCase):
         for col in cols:
             expected[col] = expected[col].convert_objects(datetime=True, numeric=True)
         expected['float_'] = expected['float_'].astype(np.float32)
-        expected['date_td'] = pd.to_datetime(expected['date_td'], coerce=True)
+        expected['date_td'] = pd.to_datetime(expected['date_td'], errors='coerce')
 
         parsed_113 = self.read_dta(self.dta14_113)
         parsed_113.index.name = 'index'
@@ -464,7 +464,7 @@ class TestStata(tm.TestCase):
         data_label = 'This is a data file.'
         with tm.ensure_clean() as path:
             original.to_stata(path, time_stamp=time_stamp, data_label=data_label)
-	    
+
             with StataReader(path) as reader:
                 parsed_time_stamp = dt.datetime.strptime(reader.time_stamp, ('%d %b %Y %H:%M'))
                 assert parsed_time_stamp == time_stamp

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -68,7 +68,7 @@ def test_to_datetime1():
 
     # unparseable
     s = 'Month 1, 1999'
-    assert to_datetime(s) == s
+    assert to_datetime(s, errors='ignore') == s
 
 
 def test_normalize_date():

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -607,12 +607,22 @@ class TestTimedeltas(tm.TestCase):
         # ms
         testit('L',lambda x: 'ms')
 
+    def test_to_timedelta_invalid(self):
+
         # these will error
         self.assertRaises(ValueError, lambda : to_timedelta([1,2],unit='foo'))
         self.assertRaises(ValueError, lambda : to_timedelta(1,unit='foo'))
 
         # time not supported ATM
         self.assertRaises(ValueError, lambda :to_timedelta(time(second=1)))
+        self.assertTrue(to_timedelta(time(second=1), errors='coerce') is pd.NaT)
+
+        self.assertRaises(ValueError, lambda : to_timedelta(['foo','bar']))
+        tm.assert_index_equal(TimedeltaIndex([pd.NaT,pd.NaT]),
+                              to_timedelta(['foo','bar'], errors='coerce'))
+
+        tm.assert_index_equal(TimedeltaIndex(['1 day', pd.NaT, '1 min']),
+                              to_timedelta(['1 day','bar','1 min'], errors='coerce'))
 
     def test_to_timedelta_via_apply(self):
         # GH 5458

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -652,10 +652,10 @@ class TestArrayToDatetime(tm.TestCase):
         # These strings don't look like datetimes so they shouldn't be
         # attempted to be converted
         arr = np.array(['-352.737091', '183.575577'], dtype=object)
-        self.assert_numpy_array_equal(tslib.array_to_datetime(arr), arr)
+        self.assert_numpy_array_equal(tslib.array_to_datetime(arr, errors='ignore'), arr)
 
         arr = np.array(['1', '2', '3', '4', '5'], dtype=object)
-        self.assert_numpy_array_equal(tslib.array_to_datetime(arr), arr)
+        self.assert_numpy_array_equal(tslib.array_to_datetime(arr, errors='ignore'), arr)
 
     def test_coercing_dates_outside_of_datetime64_ns_bounds(self):
         invalid_dates = [
@@ -671,13 +671,12 @@ class TestArrayToDatetime(tm.TestCase):
                 ValueError,
                 tslib.array_to_datetime,
                 np.array([invalid_date], dtype='object'),
-                coerce=False,
-                raise_=True,
+                errors='raise',
             )
             self.assertTrue(
                 np.array_equal(
                     tslib.array_to_datetime(
-                        np.array([invalid_date], dtype='object'), coerce=True
+                        np.array([invalid_date], dtype='object'), errors='coerce',
                     ),
                     np.array([tslib.iNaT], dtype='M8[ns]')
                 )
@@ -685,7 +684,7 @@ class TestArrayToDatetime(tm.TestCase):
 
         arr = np.array(['1/1/1000', '1/1/2000'], dtype=object)
         self.assert_numpy_array_equal(
-            tslib.array_to_datetime(arr, coerce=True),
+            tslib.array_to_datetime(arr, errors='coerce'),
             np.array(
                     [
                         tslib.iNaT,
@@ -700,11 +699,11 @@ class TestArrayToDatetime(tm.TestCase):
 
         # Without coercing, the presence of any invalid dates prevents
         # any values from being converted
-        self.assert_numpy_array_equal(tslib.array_to_datetime(arr), arr)
+        self.assert_numpy_array_equal(tslib.array_to_datetime(arr,errors='ignore'), arr)
 
         # With coercing, the invalid dates becomes iNaT
         self.assert_numpy_array_equal(
-            tslib.array_to_datetime(arr, coerce=True),
+            tslib.array_to_datetime(arr, errors='coerce'),
             np.array(
                     [
                         '2013-01-01T00:00:00.000000000-0000',

--- a/pandas/tseries/tools.py
+++ b/pandas/tseries/tools.py
@@ -9,6 +9,7 @@ import pandas.tslib as tslib
 import pandas.core.common as com
 from pandas.compat import StringIO, callable
 import pandas.compat as compat
+from pandas.util.decorators import deprecate_kwarg
 
 try:
     import dateutil
@@ -171,8 +172,10 @@ def _guess_datetime_format_for_array(arr, **kwargs):
         return _guess_datetime_format(arr[non_nan_elements[0]], **kwargs)
 
 
-def to_datetime(arg, errors='ignore', dayfirst=False, yearfirst=False,
-                utc=None, box=True, format=None, exact=True, coerce=False,
+@deprecate_kwarg(old_arg_name='coerce', new_arg_name='errors',
+                 mapping={True: 'coerce', False: 'raise'})
+def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
+                utc=None, box=True, format=None, exact=True, coerce=None,
                 unit='ns', infer_datetime_format=False):
     """
     Convert argument to datetime.
@@ -180,8 +183,10 @@ def to_datetime(arg, errors='ignore', dayfirst=False, yearfirst=False,
     Parameters
     ----------
     arg : string, datetime, array of strings (with possible NAs)
-    errors : {'ignore', 'raise'}, default 'ignore'
-        Errors are ignored by default (values left untouched).
+    errors : {'ignore', 'raise', 'coerce'}, default 'raise'
+        - If 'raise', then invalid parsing will raise an exception
+        - If 'coerce', then invalid parsing will be set as NaT
+        - If 'ignore', then invalid parsing will return the input
     dayfirst : boolean, default False
         Specify a date parse order if `arg` is str or its list-likes.
         If True, parses dates with the day first, eg 10/11/12 is parsed as 2012-11-10.
@@ -189,24 +194,22 @@ def to_datetime(arg, errors='ignore', dayfirst=False, yearfirst=False,
         with day first (this is a known bug, based on dateutil behavior).
     yearfirst : boolean, default False
         Specify a date parse order if `arg` is str or its list-likes.
-        If True parses dates with the year first, eg 10/11/12 is parsed as 2010-11-12.
-        If both dayfirst and yearfirst are True, yearfirst is preceded (same as dateutil).
+        - If True parses dates with the year first, eg 10/11/12 is parsed as 2010-11-12.
+        - If both dayfirst and yearfirst are True, yearfirst is preceded (same as dateutil).
         Warning: yearfirst=True is not strict, but will prefer to parse
         with year first (this is a known bug, based on dateutil beahavior).
     utc : boolean, default None
         Return UTC DatetimeIndex if True (converting any tz-aware
         datetime.datetime objects as well).
     box : boolean, default True
-        If True returns a DatetimeIndex, if False returns ndarray of values.
+        - If True returns a DatetimeIndex
+        - If False returns ndarray of values.
     format : string, default None
         strftime to parse time, eg "%d/%m/%Y", note that "%f" will parse
         all the way up to nanoseconds.
     exact : boolean, True by default
-        If True, require an exact format match.
-        If False, allow the format to match anywhere in the target string.
-    coerce : force errors to NaT (False by default)
-        Timestamps outside the interval between Timestamp.min and Timestamp.max
-        (approximately 1677-09-22 to 2262-04-11) will be also forced to NaT.
+        - If True, require an exact format match.
+        - If False, allow the format to match anywhere in the target string.
     unit : unit of the arg (D,s,ms,us,ns) denote the unit in epoch
         (e.g. a unix timestamp), which is an integer/float number.
     infer_datetime_format : boolean, default False
@@ -256,16 +259,16 @@ def to_datetime(arg, errors='ignore', dayfirst=False, yearfirst=False,
 
     >>> pd.to_datetime('13000101', format='%Y%m%d')
     datetime.datetime(1300, 1, 1, 0, 0)
-    >>> pd.to_datetime('13000101', format='%Y%m%d', coerce=True)
+    >>> pd.to_datetime('13000101', format='%Y%m%d', errors='coerce')
     NaT
     """
     return _to_datetime(arg, errors=errors, dayfirst=dayfirst, yearfirst=yearfirst,
-                        utc=utc, box=box, format=format, exact=exact, coerce=coerce,
+                        utc=utc, box=box, format=format, exact=exact,
                         unit=unit, infer_datetime_format=infer_datetime_format)
 
 
-def _to_datetime(arg, errors='ignore', dayfirst=False, yearfirst=False,
-                 utc=None, box=True, format=None, exact=True, coerce=False,
+def _to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
+                 utc=None, box=True, format=None, exact=True,
                  unit='ns', freq=None, infer_datetime_format=False):
     """
     Same as to_datetime, but accept freq for
@@ -322,7 +325,7 @@ def _to_datetime(arg, errors='ignore', dayfirst=False, yearfirst=False,
                 # shortcut formatting here
                 if format == '%Y%m%d':
                     try:
-                        result = _attempt_YYYYMMDD(arg, coerce=coerce)
+                        result = _attempt_YYYYMMDD(arg, errors=errors)
                     except:
                         raise ValueError("cannot convert the input to '%Y%m%d' date format")
 
@@ -330,8 +333,7 @@ def _to_datetime(arg, errors='ignore', dayfirst=False, yearfirst=False,
                 if result is None:
                     try:
                         result = tslib.array_strptime(
-                            arg, format, exact=exact, coerce=coerce
-                        )
+                            arg, format, exact=exact, errors=errors)
                     except (tslib.OutOfBoundsDatetime):
                         if errors == 'raise':
                             raise
@@ -346,10 +348,10 @@ def _to_datetime(arg, errors='ignore', dayfirst=False, yearfirst=False,
                             result = arg
 
             if result is None and (format is None or infer_datetime_format):
-                result = tslib.array_to_datetime(arg, raise_=errors=='raise',
+                result = tslib.array_to_datetime(arg, errors=errors,
                                                  utc=utc, dayfirst=dayfirst,
                                                  yearfirst=yearfirst, freq=freq,
-                                                 coerce=coerce, unit=unit,
+                                                 unit=unit,
                                                  require_iso8601=require_iso8601)
 
             if com.is_datetime64_dtype(result) and box:
@@ -376,14 +378,20 @@ def _to_datetime(arg, errors='ignore', dayfirst=False, yearfirst=False,
     return _convert_listlike(np.array([ arg ]), box, format)[0]
 
 
-def _attempt_YYYYMMDD(arg, coerce):
+def _attempt_YYYYMMDD(arg, errors):
     """ try to parse the YYYYMMDD/%Y%m%d format, try to deal with NaT-like,
-        arg is a passed in as an object dtype, but could really be ints/strings with nan-like/or floats (e.g. with nan) """
+        arg is a passed in as an object dtype, but could really be ints/strings with nan-like/or floats (e.g. with nan)
+
+        Parameters
+        ----------
+        arg : passed value
+        errors : 'raise','ignore','coerce'
+        """
 
     def calc(carg):
         # calculate the actual result
         carg = carg.astype(object)
-        return tslib.array_to_datetime(lib.try_parse_year_month_day(carg/10000,carg/100 % 100, carg % 100), coerce=coerce)
+        return tslib.array_to_datetime(lib.try_parse_year_month_day(carg/10000,carg/100 % 100, carg % 100), errors=errors)
 
     def calc_with_mask(carg,mask):
         result = np.empty(carg.shape, dtype='M8[ns]')

--- a/pandas/util/decorators.py
+++ b/pandas/util/decorators.py
@@ -43,7 +43,7 @@ def deprecate_kwarg(old_arg_name, new_arg_name, mapping=None):
     FutureWarning: cols is deprecated, use columns instead
       warnings.warn(msg, FutureWarning)
     should raise warning
-    >>> f(cols='should error', columns="can't pass do both")
+    >>> f(cols='should error', columns="can\'t pass do both")
     TypeError: Can only specify 'cols' or 'columns', not both
     >>> @deprecate_kwarg('old', 'new', {'yes': True, 'no': False})
     ... def f(new=False):
@@ -78,6 +78,7 @@ def deprecate_kwarg(old_arg_name, new_arg_name, mapping=None):
                     new_arg_value = old_arg_value
                     msg = "the '%s' keyword is deprecated, " \
                           "use '%s' instead" % (old_arg_name, new_arg_name)
+
                 warnings.warn(msg, FutureWarning)
                 if kwargs.get(new_arg_name, None) is not None:
                     msg = "Can only specify '%s' or '%s', not both" % \
@@ -287,4 +288,3 @@ def make_signature(func) :
     if spec.keywords:
         args.append('**' + spec.keywords)
     return args, spec.args
-


### PR DESCRIPTION
closes #10636 

changes `to_timedelta` API as well to similar effect.
