### PR TITLE
BUG: Use stable algorithm for _nanvar.

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -923,3 +923,5 @@ Bug Fixes
 - Bug in plotting functions may raise ``IndexError`` when plotted on ``GridSpec`` (:issue:`10819`)
 - Bug in plot result may show unnecessary minor ticklabels (:issue:`10657`)
 - Bug in ``groupby`` incorrect computation for aggregation on ``DataFrame`` with ``NaT`` (E.g ``first``, ``last``, ``min``). (:issue:`10590`)
+- Bug when constructing ``DataFrame`` where passing a dictionary with only scalar values and specifying columns did not raise an error (:issue:`10856`)
+- Bug in ``.var()`` causing roundoff errors for highly similar values (:issue:`10242`)

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -346,11 +346,22 @@ def _get_counts_nanvar(mask, axis, ddof, dtype=float):
     return count, d
 
 
-def _nanvar(values, axis=None, skipna=True, ddof=1):
-    # private nanvar calculator
+@disallow('M8')
+@bottleneck_switch(ddof=1)
+def nanstd(values, axis=None, skipna=True, ddof=1):
+    result = np.sqrt(nanvar(values, axis=axis, skipna=skipna, ddof=ddof))
+    return _wrap_results(result, values.dtype)
+
+
+@disallow('M8')
+@bottleneck_switch(ddof=1)
+def nanvar(values, axis=None, skipna=True, ddof=1):
+
+    dtype = values.dtype
     mask = isnull(values)
     if is_any_int_dtype(values):
         values = values.astype('f8')
+        values[mask] = np.nan
 
     if is_float_dtype(values):
         count, d = _get_counts_nanvar(mask, axis, ddof, values.dtype)
@@ -361,29 +372,27 @@ def _nanvar(values, axis=None, skipna=True, ddof=1):
         values = values.copy()
         np.putmask(values, mask, 0)
 
-    X = _ensure_numeric(values.sum(axis))
-    XX = _ensure_numeric((values ** 2).sum(axis))
-    result = np.fabs((XX - X * X / count) / d)
-    return result
+    # Compute variance via two-pass algorithm, which is stable against
+    # cancellation errors and relatively accurate for small numbers of
+    # observations.
+    #
+    # See https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
+    avg = _ensure_numeric(values.sum(axis=axis, dtype=np.float64)) / count
+    if axis is not None:
+        avg = np.expand_dims(avg, axis)
+    sqr = _ensure_numeric((avg - values) ** 2)
+    np.putmask(sqr, mask, 0)
+    result = sqr.sum(axis=axis, dtype=np.float64) / d
 
-@disallow('M8')
-@bottleneck_switch(ddof=1)
-def nanstd(values, axis=None, skipna=True, ddof=1):
-
-    result = np.sqrt(_nanvar(values, axis=axis, skipna=skipna, ddof=ddof))
+    # Return variance as np.float64 (the datatype used in the accumulator),
+    # unless we were dealing with a float array, in which case use the same
+    # precision as the original values array.
+    if is_float_dtype(dtype):
+        result = result.astype(dtype)
     return _wrap_results(result, values.dtype)
 
-@disallow('M8','m8')
-@bottleneck_switch(ddof=1)
-def nanvar(values, axis=None, skipna=True, ddof=1):
 
-    # we are going to allow timedelta64[ns] here
-    # but NOT going to coerce them to the Timedelta type
-    # as this could cause overflow
-    # so var cannot be computed (but std can!)
-    return _nanvar(values, axis=axis, skipna=skipna, ddof=ddof)
-
-@disallow('M8','m8')
+@disallow('M8', 'm8')
 def nansem(values, axis=None, skipna=True, ddof=1):
     var = nanvar(values, axis, skipna, ddof=ddof)
 
@@ -391,6 +400,7 @@ def nansem(values, axis=None, skipna=True, ddof=1):
     if not is_float_dtype(values.dtype):
         values = values.astype('f8')
     count, _ = _get_counts_nanvar(mask, axis, ddof, values.dtype)
+    var = nanvar(values, axis, skipna, ddof=ddof)
 
     return np.sqrt(var) / np.sqrt(count)
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -12589,11 +12589,11 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             expected = getattr(df2[['bar', 'baz']], meth)(axis=1)
             assert_series_equal(expected, result)
 
-            assertRaisesRegexp(TypeError, 'float',
-                               getattr(df1, meth), axis=1, numeric_only=False)
-
-            assertRaisesRegexp(TypeError, 'float',
-                               getattr(df2, meth), axis=1, numeric_only=False)
+            try:
+                getattr(df1, meth)(axis=1, numeric_only=False)
+                getattr(df2, meth)(axis=1, numeric_only=False)
+            except (TypeError, ValueError) as e:
+                self.assertIn('float', str(e))
 
     def test_sem(self):
         alt = lambda x: np.std(x, ddof=1)/np.sqrt(len(x))

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -182,15 +182,15 @@ class TestnanopsDataFrame(tm.TestCase):
                                    **kwargs)
                     self.check_results(targ, res, axis)
                     if skipna:
-                        res = testfunc(testarval, axis=axis)
+                        res = testfunc(testarval, axis=axis, **kwargs)
                         self.check_results(targ, res, axis)
                     if axis is None:
-                        res = testfunc(testarval, skipna=skipna)
+                        res = testfunc(testarval, skipna=skipna, **kwargs)
                         self.check_results(targ, res, axis)
                     if skipna and axis is None:
-                        res = testfunc(testarval)
+                        res = testfunc(testarval, **kwargs)
                         self.check_results(targ, res, axis)
-                except BaseException as exc:
+                except AssertionError as exc:
                     exc.args += ('axis: %s of %s' % (axis, testarval.ndim-1),
                                  'skipna: %s' % skipna,
                                  'kwargs: %s' % kwargs)
@@ -222,7 +222,7 @@ class TestnanopsDataFrame(tm.TestCase):
         try:
             self.check_fun_data(testfunc, targfunc,
                                 testarval, targarval, targarnanval, **kwargs)
-        except BaseException as exc:
+        except AssertionError as exc:
             exc.args += ('testar: %s' % testar,
                          'targar: %s' % targar,
                          'targarnan: %s' % targarnan)
@@ -291,12 +291,13 @@ class TestnanopsDataFrame(tm.TestCase):
                         allow_date=False, allow_tdelta=False, allow_obj=True,):
         for ddof in range(3):
             try:
-                self.check_funs(self, testfunc, targfunc,
+                self.check_funs(testfunc, targfunc,
                                 allow_complex, allow_all_nan, allow_str,
                                 allow_date, allow_tdelta, allow_obj,
                                 ddof=ddof)
-            except BaseException as exc:
+            except AssertionError as exc:
                 exc.args += ('ddof %s' % ddof,)
+                raise
 
     def _badobj_wrap(self, value, func, allow_complex=True, **kwargs):
         if value.dtype.kind == 'O':
@@ -366,16 +367,28 @@ class TestnanopsDataFrame(tm.TestCase):
 
     def test_nanvar(self):
         self.check_funs_ddof(nanops.nanvar, np.var,
-                             allow_complex=False, allow_date=False, allow_tdelta=False)
+                             allow_complex=False,
+                             allow_str=False,
+                             allow_date=False,
+                             allow_tdelta=False,
+                             allow_obj='convert')
 
     def test_nanstd(self):
         self.check_funs_ddof(nanops.nanstd, np.std,
-                             allow_complex=False, allow_date=False, allow_tdelta=True)
+                             allow_complex=False,
+                             allow_str=False,
+                             allow_date=False,
+                             allow_tdelta=True,
+                             allow_obj='convert')
 
     def test_nansem(self):
         tm.skip_if_no_package('scipy.stats')
-        self.check_funs_ddof(nanops.nansem, np.var,
-                             allow_complex=False, allow_date=False, allow_tdelta=False)
+        from scipy.stats import sem
+        self.check_funs_ddof(nanops.nansem, sem,
+                             allow_complex=False,
+                             allow_str=False,
+                             allow_date=False,
+                             allow_tdelta=False)
 
     def _minmax_wrap(self, value, axis=None, func=None):
         res = func(value, axis)
@@ -663,7 +676,7 @@ class TestnanopsDataFrame(tm.TestCase):
                     self.assertTrue(res0)
                 else:
                     self.assertFalse(res0)
-            except BaseException as exc:
+            except AssertionError as exc:
                 exc.args += ('dim: %s' % getattr(value, 'ndim', value),)
                 raise
             if not hasattr(value, 'ndim'):
@@ -700,7 +713,7 @@ class TestnanopsDataFrame(tm.TestCase):
             val = getattr(self, arr)
             try:
                 self.check_bool(nanops._has_infs, val, correct)
-            except BaseException as exc:
+            except AssertionError as exc:
                 exc.args += (arr,)
                 raise
 
@@ -710,7 +723,7 @@ class TestnanopsDataFrame(tm.TestCase):
                 self.check_bool(nanops._has_infs, val, correct)
                 self.check_bool(nanops._has_infs, val.astype('f4'), correct)
                 self.check_bool(nanops._has_infs, val.astype('f2'), correct)
-            except BaseException as exc:
+            except AssertionError as exc:
                 exc.args += (arr,)
                 raise
 
@@ -743,7 +756,7 @@ class TestnanopsDataFrame(tm.TestCase):
             val = getattr(self, arr)
             try:
                 self.check_bool(func1, val, correct)
-            except BaseException as exc:
+            except AssertionError as exc:
                 exc.args += (arr,)
                 raise
 
@@ -753,7 +766,7 @@ class TestnanopsDataFrame(tm.TestCase):
                 self.check_bool(func1, val, correct)
                 self.check_bool(func1, val.astype('f4'), correct)
                 self.check_bool(func1, val.astype('f2'), correct)
-            except BaseException as exc:
+            except AssertionError as exc:
                 exc.args += (arr,)
                 raise
 

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -684,8 +684,8 @@ class TestTimedeltas(tm.TestCase):
         self.assertEqual(result[0], expected)
 
         # invalid ops
-        for op in ['skew','kurt','sem','var','prod']:
-            self.assertRaises(TypeError, lambda : getattr(td,op)())
+        for op in ['skew','kurt','sem','prod']:
+            self.assertRaises(TypeError, getattr(td,op))
 
         # GH 10040
         # make sure NaT is properly handled by median()


### PR DESCRIPTION
closes #10242

This PR replaces the sum-of-squares algorithm used to compute the variance by a more stable algorithm. The algorithm here is essentially the same as used in numpy 1.8 and up, and I've added a TODO to replace the implementation with a direct call to numpy when that version is the default.

Somewhat counter to the discussion in #10242, I chose not to go with the Welford algorithm, for two reasons: numpy, and the fact that `_nanvar` needs to be able to deal with arrays of different shape, which is tricky to get right in Cython.
