### PR TITLE
Empty subtypes of Index return their type, rather than Index

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -357,7 +357,9 @@ Bug Fixes
 - Bug in ``ExcelReader`` when worksheet is empty (:issue:`6403`)
 - Bug in ``Table.select_column`` where name is not preserved (:issue:`10392`)
 - Bug in ``offsets.generate_range`` where ``start`` and ``end`` have finer precision than ``offset`` (:issue:`9907`)
+- Bug in ``Subclasses of Index with no values returned Index objects rather than their own classes, in some cases`` (:issue:`10596`)
 - Bug in ``pd.rolling_*`` where ``Series.name`` would be lost in the output (:issue:`10565`)
+
 
 
 

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -357,9 +357,7 @@ Bug Fixes
 - Bug in ``ExcelReader`` when worksheet is empty (:issue:`6403`)
 - Bug in ``Table.select_column`` where name is not preserved (:issue:`10392`)
 - Bug in ``offsets.generate_range`` where ``start`` and ``end`` have finer precision than ``offset`` (:issue:`9907`)
-- Bug in ``Subclasses of Index with no values returned Index objects rather than their own classes, in some cases`` (:issue:`10596`)
 - Bug in ``pd.rolling_*`` where ``Series.name`` would be lost in the output (:issue:`10565`)
-
 
 
 
@@ -374,6 +372,7 @@ Bug Fixes
 - Bug in ``pd.get_dummies`` with `sparse=True` not returning ``SparseDataFrame`` (:issue:`10531`)
 - Bug in ``Index`` subtypes (such as ``PeriodIndex``) not returning their own type for ``.drop`` and ``.insert`` methods (:issue:`10620`)
 
+- Bug in subclasses of ``Index`` with no values returned Index objects rather than their own classes, in some cases (:issue:`10596`)
 
 
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1538,7 +1538,7 @@ class Index(IndexOpsMixin, PandasObject):
         self._assert_can_do_setop(other)
 
         if self.equals(other):
-            return Index([], name=self.name)
+            return self._shallow_copy(np.asarray([]))
 
         other, result_name = self._convert_can_do_setop(other)
 

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -367,6 +367,12 @@ class Base(object):
                 with tm.assertRaisesRegexp(TypeError, msg):
                     result = first.difference([1, 2, 3])
 
+            # GH 10596 - empty difference retains index's type
+
+            result = idx.difference(idx)
+            expected = idx[0:0]
+            self.assertTrue(result.equals(expected))
+
     def test_symmetric_diff(self):
         for name, idx in compat.iteritems(self.indices):
             first = idx[1:]

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -733,9 +733,9 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
                 # values = np.asarray(list(values), dtype=object)
                 # return values.reshape(result.shape)
 
-                return PeriodIndex(result, name=self.name, freq=self.freq)
+                return self._shallow_copy(result)
 
-            return PeriodIndex(result, name=self.name, freq=self.freq)
+            return self._shallow_copy(result)
 
     def _format_native_types(self, na_rep=u('NaT'), **kwargs):
 
@@ -796,7 +796,7 @@ class PeriodIndex(DatetimeIndexOpsMixin, Int64Index):
                 to_concat = [x.asobject.values for x in to_concat]
             else:
                 cat_values = np.concatenate([x.values for x in to_concat])
-                return PeriodIndex(cat_values, freq=self.freq, name=name)
+                return self._shallow_copy(cat_values, name=name)
 
         to_concat = [x.values if isinstance(x, Index) else x
                      for x in to_concat]

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -644,7 +644,7 @@ Freq: D"""
 
         with tm.assert_produces_warning(FutureWarning):
             result = dti-dti
-            expected = Index([])
+            expected = dti[0:0]
             tm.assert_index_equal(result,expected)
 
         with tm.assert_produces_warning(FutureWarning):
@@ -654,7 +654,7 @@ Freq: D"""
 
         with tm.assert_produces_warning(FutureWarning):
             result = dti_tz-dti_tz
-            expected = Index([])
+            expected = dti_tz[0:0]
             tm.assert_index_equal(result,expected)
 
         with tm.assert_produces_warning(FutureWarning):


### PR DESCRIPTION
Resolves #10596 

Prior was in #10599 FYI

I think this has a PyTables error which I need to resolve
