### PR TITLE
TST: fix usage of assert_produces_warning

### DIFF
--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -464,7 +464,7 @@ class TestStata(tm.TestCase):
         data_label = 'This is a data file.'
         with tm.ensure_clean() as path:
             original.to_stata(path, time_stamp=time_stamp, data_label=data_label)
-	    
+
             with StataReader(path) as reader:
                 parsed_time_stamp = dt.datetime.strptime(reader.time_stamp, ('%d %b %Y %H:%M'))
                 assert parsed_time_stamp == time_stamp
@@ -475,10 +475,8 @@ class TestStata(tm.TestCase):
         original.index.name = 'index'
         with tm.ensure_clean() as path:
             # should get a warning for that format.
-            with warnings.catch_warnings(record=True) as w:
-                tm.assert_produces_warning(original.to_stata(path), InvalidColumnName)
-            # should produce a single warning
-            tm.assert_equal(len(w), 1)
+            with tm.assert_produces_warning(InvalidColumnName):
+                original.to_stata(path)
 
             written_and_read_again = self.read_dta(path)
             written_and_read_again = written_and_read_again.set_index('index')
@@ -530,11 +528,8 @@ class TestStata(tm.TestCase):
         original = DataFrame({'s0': s0, 's1': s1, 's2': s2, 's3': s3})
         original.index.name = 'index'
         with tm.ensure_clean() as path:
-            with warnings.catch_warnings(record=True) as w:
-                tm.assert_produces_warning(original.to_stata(path),
-                                           PossiblePrecisionLoss)
-            # should produce a single warning
-            tm.assert_equal(len(w), 1)
+            with tm.assert_produces_warning(PossiblePrecisionLoss):
+                original.to_stata(path)
 
             written_and_read_again = self.read_dta(path)
             modified = original.copy()
@@ -548,10 +543,8 @@ class TestStata(tm.TestCase):
         original = DataFrame([datetime(2006, 11, 19, 23, 13, 20)])
         original.index.name = 'index'
         with tm.ensure_clean() as path:
-            with warnings.catch_warnings(record=True) as w:
-                tm.assert_produces_warning(original.to_stata(path, {0: 'tc'}),
-                                           InvalidColumnName)
-            tm.assert_equal(len(w), 1)
+            with tm.assert_produces_warning(InvalidColumnName):
+                original.to_stata(path, {0: 'tc'})
 
             written_and_read_again = self.read_dta(path)
             modified = original.copy()

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -4103,9 +4103,12 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
 
         def check_iloc_compat(s):
             # invalid type for iloc (but works with a warning)
-            self.assert_produces_warning(FutureWarning, lambda : s.iloc[6.0:8])
-            self.assert_produces_warning(FutureWarning, lambda : s.iloc[6.0:8.0])
-            self.assert_produces_warning(FutureWarning, lambda : s.iloc[6:8.0])
+            with self.assert_produces_warning(FutureWarning):
+                s.iloc[6.0:8]
+            with self.assert_produces_warning(FutureWarning):
+                s.iloc[6.0:8.0]
+            with self.assert_produces_warning(FutureWarning):
+                s.iloc[6:8.0]
 
         def check_slicing_positional(index):
 


### PR DESCRIPTION
@jreback I just notices some tests were not using `assert_produces_warning` as a context manager, therefore these would never fail (you could put whatever in there).

I changed it to using `with`, as I don't think there is way to use that function not as a context?

@bashtage I also changed some of your tests. I am not familiar with this code, but I think this should still be correct
