### PR TITLE
added axvlines_color parameter to parallel_coordinates

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -25,6 +25,7 @@ Enhancements
   objects for the ``filepath_or_buffer`` argument. (:issue:`11033`)
 - ``DataFrame`` now uses the fields of a ``namedtuple`` as columns, if columns are not supplied (:issue:`11181`)
 - Improve the error message displayed in :func:`pandas.io.gbq.to_gbq` when the DataFrame does not match the schema of the destination table (:issue:`11359`)
+- Added ``axvlines_kwds`` to parallel coordinates plot (:issue: `10709`)
 
 .. _whatsnew_0171.api:
 

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -638,7 +638,7 @@ def bootstrap_plot(series, fig=None, size=50, samples=500, **kwds):
 @deprecate_kwarg(old_arg_name='data', new_arg_name='frame', stacklevel=3)
 def parallel_coordinates(frame, class_column, cols=None, ax=None, color=None,
                          use_columns=False, xticks=None, colormap=None,
-                         axvlines=True, **kwds):
+                         axvlines=True, axvlines_kwds={'linewidth':1,'color':'black'}, **kwds):
     """Parallel coordinates plotting.
 
     Parameters
@@ -660,6 +660,8 @@ def parallel_coordinates(frame, class_column, cols=None, ax=None, color=None,
         Colormap to use for line colors.
     axvlines: bool, optional
         If true, vertical lines will be added at each xtick
+    axvlines_kwds: keywords, optional
+        Options to be passed to axvline method for vertical lines
     kwds: keywords
         Options to pass to matplotlib plotting method
 
@@ -726,7 +728,7 @@ def parallel_coordinates(frame, class_column, cols=None, ax=None, color=None,
 
     if axvlines:
         for i in x:
-            ax.axvline(i, linewidth=1, color='black')
+            ax.axvline(i, **axvlines_kwds)
 
     ax.set_xticks(x)
     ax.set_xticklabels(df.columns)


### PR DESCRIPTION
parallel_coordinates are in pandas.tools.plotting
'black' color was hard-coded for vertical lines, I suggest to make it an option
