### PR TITLE
DEPR: deprecate irow,icol,iget_value,iget in Series/DataFrame, #10711

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1558,7 +1558,6 @@ application to columns of a specific data type.
    DataFrameGroupBy.hist
    DataFrameGroupBy.idxmax
    DataFrameGroupBy.idxmin
-   DataFrameGroupBy.irow
    DataFrameGroupBy.mad
    DataFrameGroupBy.pct_change
    DataFrameGroupBy.plot

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -121,18 +121,6 @@ the specification are assumed to be ``:``. (e.g. ``p.loc['a']`` is equiv to
     DataFrame; ``df.loc[row_indexer,column_indexer]``
     Panel; ``p.loc[item_indexer,major_indexer,minor_indexer]``
 
-Deprecations
-------------
-
-Beginning with version 0.11.0, it's recommended that you transition away from
-the following methods as they *may* be deprecated in future versions.
-
-  - ``irow``
-  - ``icol``
-  - ``iget_value``
-
-See the section :ref:`Selection by Position <indexing.integer>` for substitutes.
-
 .. _indexing.basics:
 
 Basics
@@ -432,19 +420,13 @@ Select via integer list
 
    df1.iloc[[1,3,5],[1,3]]
 
-For slicing rows explicitly (equiv to deprecated ``df.irow(slice(1,3))``).
-
 .. ipython:: python
 
    df1.iloc[1:3,:]
 
-For slicing columns explicitly (equiv to deprecated ``df.icol(slice(1,3))``).
-
 .. ipython:: python
 
    df1.iloc[:,1:3]
-
-For getting a scalar via integer position (equiv to deprecated ``df.get_value(1,1)``)
 
 .. ipython:: python
 

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -434,6 +434,26 @@ Other API Changes
 Deprecations
 ^^^^^^^^^^^^
 
+.. note:: These indexing function have been deprecated in the documentation since 0.11.0.
+
+- For ``Series`` the following indexing functions are deprecated (:issue:`10177`).
+  =====================     ==============================================================
+  Deprecated Function       Replacement
+  =====================     ==============================================================
+  ``.irow(i)``              ``.iloc[i]`` or ``.iat[i]``
+  ``.iget(i)``              ``.iloc[i]`` or ``.iat[i]``
+  ``.iget_value(i)``        ``.iloc[i]`` or ``.iat[i]``
+  =====================     ==============================================================
+
+- For ``DataFrame`` the following indexing functions are deprecated (:issue:`10177`).
+  =====================     ==============================================================
+  Deprecated Function       Replacement
+  =====================     ==============================================================
+  ``.irow(i)``              ``.iloc[i]``
+  ``.iget_value(i, j)``     ``.iloc[i, j]`` or ``.iat[i, j]``
+  ``.icol(j)``              ``.iloc[:, j]``
+  =====================     ==============================================================
+
 .. _whatsnew_0170.prior_deprecations:
 
 Removal of prior version deprecations/changes

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -552,7 +552,7 @@ class DataFrame(NDFrame):
                 yield k, self._get_item_cache(k)
         else:
             for i, k in enumerate(self.columns):
-                yield k, self.icol(i)
+                yield k, self._ixs(i,axis=1)
 
     def iterrows(self):
         """
@@ -1697,9 +1697,20 @@ class DataFrame(NDFrame):
             return self
 
     def irow(self, i, copy=False):
+        """
+        DEPRECATED. Use ``.iloc[i]`` instead
+        """
+
+        warnings.warn("irow(i) is deprecated. Please use .iloc[i]",
+                      FutureWarning, stacklevel=2)
         return self._ixs(i, axis=0)
 
     def icol(self, i):
+        """
+        DEPRECATED. Use ``.iloc[:, i]`` instead
+        """
+        warnings.warn("icol(i) is deprecated. Please use .iloc[:,i]",
+                      FutureWarning, stacklevel=2)
         return self._ixs(i, axis=1)
 
     def _ixs(self, i, axis=0):
@@ -1773,6 +1784,11 @@ class DataFrame(NDFrame):
                 return result
 
     def iget_value(self, i, j):
+        """
+        DEPRECATED. Use ``.iat[i, j]`` instead
+        """
+        warnings.warn("iget_value(i, j) is deprecated. Please use .iat[i, j]",
+                      FutureWarning, stacklevel=2)
         return self.iat[i, j]
 
     def __getitem__(self, key):
@@ -3769,7 +3785,7 @@ class DataFrame(NDFrame):
 
         dtype = object if self._is_mixed_type else None
         if axis == 0:
-            series_gen = (self.icol(i) for i in range(len(self.columns)))
+            series_gen = (self._ixs(i,axis=1) for i in range(len(self.columns)))
             res_index = self.columns
             res_columns = self.index
         elif axis == 1:
@@ -4900,11 +4916,11 @@ def _to_arrays(data, columns, coerce_float=False, dtype=None):
     """
     if isinstance(data, DataFrame):
         if columns is not None:
-            arrays = [data.icol(i).values for i, col in enumerate(data.columns)
+            arrays = [data._ixs(i,axis=1).values for i, col in enumerate(data.columns)
                       if col in columns]
         else:
             columns = data.columns
-            arrays = [data.icol(i).values for i in range(len(columns))]
+            arrays = [data._ixs(i,axis=1).values for i in range(len(columns))]
 
         return arrays, columns
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -3,6 +3,7 @@ from functools import wraps
 import numpy as np
 import datetime
 import collections
+import warnings
 
 from pandas.compat import(
     zip, builtins, range, long, lzip,
@@ -71,7 +72,7 @@ _common_apply_whitelist = frozenset([
     'fillna',
     'mad',
     'any', 'all',
-    'irow', 'take',
+    'take',
     'idxmax', 'idxmin',
     'shift', 'tshift',
     'ffill', 'bfill',
@@ -170,7 +171,7 @@ class Grouper(object):
     freq : string / frequency object, defaults to None
         This will groupby the specified frequency if the target selection (via key or level) is
         a datetime-like object. For full specification of available frequencies, please see
-        `here <http://pandas.pydata.org/pandas-docs/stable/timeseries.html>`_. 
+        `here <http://pandas.pydata.org/pandas-docs/stable/timeseries.html>`_.
     axis : number/name of the axis, defaults to 0
     sort : boolean, default to False
         whether to sort the resulting labels
@@ -188,7 +189,7 @@ class Grouper(object):
 
     Examples
     --------
-    
+
     Syntactic sugar for ``df.groupby('A')``
 
     >>> df.groupby(Grouper(key='A'))
@@ -198,9 +199,9 @@ class Grouper(object):
     >>> df.groupby(Grouper(key='date', freq='60s'))
 
     Specify a resample operation on the level 'date' on the columns axis
-    with a frequency of 60s 
+    with a frequency of 60s
 
-    >>> df.groupby(Grouper(level='date', freq='60s', axis=1)) 
+    >>> df.groupby(Grouper(level='date', freq='60s', axis=1))
     """
 
     def __new__(cls, *args, **kwargs):
@@ -710,6 +711,16 @@ class GroupBy(PandasObject):
 
     def transform(self, func, *args, **kwargs):
         raise AbstractMethodError(self)
+
+    def irow(self, i):
+        """
+        DEPRECATED. Use ``.nth(i)`` instead
+        """
+
+        # 10177
+        warnings.warn("irow(i) is deprecated. Please use .nth(i)",
+                      FutureWarning, stacklevel=2)
+        return self.nth(i)
 
     def mean(self):
         """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -781,9 +781,30 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         return self.values.reshape(shape, **kwargs)
 
-    iget_value = _ixs
-    iget = _ixs
-    irow = _ixs
+    def iget_value(self, i, axis=0):
+        """
+        DEPRECATED. Use ``.iloc[i]`` or ``.iat[i]`` instead
+        """
+        warnings.warn("iget_value(i) is deprecated. Please use .iloc[i] or .iat[i]",
+                      FutureWarning, stacklevel=2)
+        return self._ixs(i)
+
+    def iget(self, i, axis=0):
+        """
+        DEPRECATED. Use ``.iloc[i]`` or ``.iat[i]`` instead
+        """
+
+        warnings.warn("iget(i) is deprecated. Please use .iloc[i] or .iat[i]",
+                      FutureWarning, stacklevel=2)
+        return self._ixs(i)
+
+    def irow(self, i, axis=0):
+        """
+        DEPRECATED. Use ``.iloc[i]`` or ``.iat[i]`` instead
+        """
+        warnings.warn("irow(i) is deprecated. Please use .iloc[i] or iat[i]",
+                      FutureWarning, stacklevel=2)
+        return self._ixs(i)
 
     def get_value(self, label, takeable=False):
         """
@@ -2323,7 +2344,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                                 sep=sep, parse_dates=parse_dates,
                                 encoding=encoding,
                                 infer_datetime_format=infer_datetime_format)
-        result = df.icol(0)
+        result = df.iloc[:,0]
         if header is None:
             result.index.name = result.name = None
 

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -1240,8 +1240,10 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
         self.assertRaises(Exception, sdf.__getitem__, ['a', 'd'])
 
     def test_icol(self):
+        # 10711 deprecated
+
         # 2227
-        result = self.frame.icol(0)
+        result = self.frame.iloc[:, 0]
         self.assertTrue(isinstance(result, SparseSeries))
         assert_sp_series_equal(result, self.frame['A'])
 
@@ -1249,7 +1251,7 @@ class TestSparseDataFrame(tm.TestCase, test_frame.SafeForSparse):
         data = {'A': [0, 1]}
         iframe = SparseDataFrame(data, default_kind='integer')
         self.assertEqual(type(iframe['A'].sp_index),
-                         type(iframe.icol(0).sp_index))
+                         type(iframe.iloc[:, 0].sp_index))
 
     def test_set_value(self):
 

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -2203,27 +2203,27 @@ class TestCategoricalAsBlock(tm.TestCase):
         self.assertEqual(res_val, exp_val)
 
         # i : int, slice, or sequence of integers
-        res_row = df.irow(2)
+        res_row = df.iloc[2]
         tm.assert_series_equal(res_row, exp_row)
         tm.assertIsInstance(res_row["cats"], compat.string_types)
 
-        res_df = df.irow(slice(2,4))
+        res_df = df.iloc[slice(2,4)]
         tm.assert_frame_equal(res_df, exp_df)
         self.assertTrue(com.is_categorical_dtype(res_df["cats"]))
 
-        res_df = df.irow([2,3])
+        res_df = df.iloc[[2,3]]
         tm.assert_frame_equal(res_df, exp_df)
         self.assertTrue(com.is_categorical_dtype(res_df["cats"]))
 
-        res_col = df.icol(0)
+        res_col = df.iloc[:,0]
         tm.assert_series_equal(res_col, exp_col)
         self.assertTrue(com.is_categorical_dtype(res_col))
 
-        res_df = df.icol(slice(0,2))
+        res_df = df.iloc[:,slice(0,2)]
         tm.assert_frame_equal(res_df, df)
         self.assertTrue(com.is_categorical_dtype(res_df["cats"]))
 
-        res_df = df.icol([0,1])
+        res_df = df.iloc[:,[0,1]]
         tm.assert_frame_equal(res_df, df)
         self.assertTrue(com.is_categorical_dtype(res_df["cats"]))
 

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -97,7 +97,7 @@ class TestExpressions(tm.TestCase):
     def test_integer_arithmetic(self):
         self.run_arithmetic_test(self.integer, self.integer,
                                  assert_frame_equal)
-        self.run_arithmetic_test(self.integer.icol(0), self.integer.icol(0),
+        self.run_arithmetic_test(self.integer.iloc[:,0], self.integer.iloc[:, 0],
                                  assert_series_equal, check_dtype=True)
 
     @nose.tools.nottest
@@ -182,7 +182,7 @@ class TestExpressions(tm.TestCase):
         self.run_frame(self.integer, self.integer)
 
     def test_integer_arithmetic_series(self):
-        self.run_series(self.integer.icol(0), self.integer.icol(0))
+        self.run_series(self.integer.iloc[:, 0], self.integer.iloc[:, 0])
 
     @slow
     def test_integer_panel(self):
@@ -192,7 +192,7 @@ class TestExpressions(tm.TestCase):
         self.run_frame(self.frame2, self.frame2)
 
     def test_float_arithmetic_series(self):
-        self.run_series(self.frame2.icol(0), self.frame2.icol(0))
+        self.run_series(self.frame2.iloc[:, 0], self.frame2.iloc[:, 0])
 
     @slow
     def test_float_panel(self):
@@ -220,7 +220,7 @@ class TestExpressions(tm.TestCase):
 
     def test_float_arithemtic(self):
         self.run_arithmetic_test(self.frame, self.frame, assert_frame_equal)
-        self.run_arithmetic_test(self.frame.icol(0), self.frame.icol(0),
+        self.run_arithmetic_test(self.frame.iloc[:, 0], self.frame.iloc[:, 0],
                                  assert_series_equal, check_dtype=True)
 
     def test_mixed_arithmetic(self):
@@ -232,7 +232,7 @@ class TestExpressions(tm.TestCase):
     def test_integer_with_zeros(self):
         self.integer *= np.random.randint(0, 2, size=np.shape(self.integer))
         self.run_arithmetic_test(self.integer, self.integer, assert_frame_equal)
-        self.run_arithmetic_test(self.integer.icol(0), self.integer.icol(0),
+        self.run_arithmetic_test(self.integer.iloc[:, 0], self.integer.iloc[:, 0],
                                  assert_series_equal)
 
     def test_invalid(self):

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -4884,7 +4884,7 @@ class TestGroupBy(tm.TestCase):
             'fillna',
             'mad',
             'any', 'all',
-            'irow', 'take',
+            'take',
             'idxmax', 'idxmin',
             'shift', 'tshift',
             'ffill', 'bfill',
@@ -4905,7 +4905,7 @@ class TestGroupBy(tm.TestCase):
             'fillna',
             'mad',
             'any', 'all',
-            'irow', 'take',
+            'take',
             'idxmax', 'idxmin',
             'shift', 'tshift',
             'ffill', 'bfill',
@@ -4929,6 +4929,20 @@ class TestGroupBy(tm.TestCase):
     AGG_FUNCTIONS = ['sum', 'prod', 'min', 'max', 'median', 'mean', 'skew',
                      'mad', 'std', 'var', 'sem']
     AGG_FUNCTIONS_WITH_SKIPNA = ['skew', 'mad']
+
+    def test_groupby_whitelist_deprecations(self):
+        from string import ascii_lowercase
+        letters = np.array(list(ascii_lowercase))
+        N = 10
+        random_letters = letters.take(np.random.randint(0, 26, N))
+        df = DataFrame({'floats': N / 10 * Series(np.random.random(N)),
+                        'letters': Series(random_letters)})
+
+        # 10711 deprecated
+        with tm.assert_produces_warning(FutureWarning):
+            df.groupby('letters').irow(0)
+        with tm.assert_produces_warning(FutureWarning):
+            df.groupby('letters').floats.irow(0)
 
     def test_regression_whitelist_methods(self) :
 
@@ -5000,16 +5014,17 @@ class TestGroupBy(tm.TestCase):
         grp = self.mframe.groupby(level='second')
         results = set([v for v in dir(grp) if not v.startswith('_')])
         expected = set(['A','B','C',
-            'agg','aggregate','apply','boxplot','filter','first','get_group',
-            'groups','hist','indices','last','max','mean','median',
-            'min','name','ngroups','nth','ohlc','plot', 'prod',
-            'size', 'std', 'sum', 'transform', 'var', 'sem', 'count', 'head',
-            'describe', 'cummax', 'quantile', 'rank', 'cumprod', 'tail',
-            'resample', 'cummin', 'fillna', 'cumsum', 'cumcount',
-            'all', 'shift', 'skew', 'bfill', 'irow', 'ffill',
-            'take', 'tshift', 'pct_change', 'any', 'mad', 'corr', 'corrwith',
-            'cov', 'dtypes', 'diff', 'idxmax', 'idxmin'
-        ])
+                        'agg','aggregate','apply','boxplot','filter','first','get_group',
+                        'groups','hist','indices','last','max','mean','median',
+                        'min','name','ngroups','nth','ohlc','plot', 'prod',
+                        'size', 'std', 'sum', 'transform', 'var', 'sem', 'count', 'head',
+                        'irow',
+                        'describe', 'cummax', 'quantile', 'rank', 'cumprod', 'tail',
+                        'resample', 'cummin', 'fillna', 'cumsum', 'cumcount',
+                        'all', 'shift', 'skew', 'bfill', 'ffill',
+                        'take', 'tshift', 'pct_change', 'any', 'mad', 'corr', 'corrwith',
+                        'cov', 'dtypes', 'diff', 'idxmax', 'idxmin'
+                        ])
         self.assertEqual(results, expected)
 
     def test_lexsort_indexer(self):

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -559,16 +559,17 @@ class TestIndexing(tm.TestCase):
 
     def test_iloc_getitem_multiindex(self):
 
-        df = DataFrame(np.random.randn(3, 3),
+        arr = np.random.randn(3, 3)
+        df = DataFrame(arr,
                        columns=[[2,2,4],[6,8,10]],
                        index=[[4,4,8],[8,10,12]])
 
         rs = df.iloc[2]
-        xp = df.irow(2)
+        xp = Series(arr[2],index=df.columns)
         assert_series_equal(rs, xp)
 
         rs = df.iloc[:,2]
-        xp = df.icol(2)
+        xp = Series(arr[:, 2],index=df.index)
         assert_series_equal(rs, xp)
 
         rs = df.iloc[2,2]

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1993,7 +1993,7 @@ Thur,Lunch,Yes,51.51,17"""
                           columns=columns)
 
         result = frame.ix[:, 1]
-        exp = frame.icol(1)
+        exp = frame.loc[:, ('Ohio', 'Red')]
         tm.assertIsInstance(result, Series)
         assert_series_equal(result, exp)
 

--- a/pandas/tests/test_rplot.py
+++ b/pandas/tests/test_rplot.py
@@ -160,7 +160,7 @@ class TestScaleGradient(tm.TestCase):
 
     def test_gradient(self):
         for index in range(len(self.data)):
-            row = self.data.irow(index)
+            row = self.data.iloc[index]
             r, g, b = self.gradient(self.data, index)
             r1, g1, b1 = self.gradient.colour1
             r2, g2, b2 = self.gradient.colour2
@@ -178,7 +178,7 @@ class TestScaleGradient2(tm.TestCase):
 
     def test_gradient2(self):
         for index in range(len(self.data)):
-            row = self.data.irow(index)
+            row = self.data.iloc[index]
             r, g, b = self.gradient(self.data, index)
             r1, g1, b1 = self.gradient.colour1
             r2, g2, b2 = self.gradient.colour2

--- a/pandas/tools/rplot.py
+++ b/pandas/tools/rplot.py
@@ -363,7 +363,7 @@ class GeomPoint(Layer):
             else:
                 ax = fig.gca()
         for index in range(len(self.data)):
-            row = self.data.irow(index)
+            row = self.data.iloc[index]
             x = row[self.aes['x']]
             y = row[self.aes['y']]
             size_scaler = self.aes['size']

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -240,47 +240,47 @@ class TestResample(tm.TestCase):
 
         self.assertEqual(len(result), 3)
         self.assertTrue((result.index.dayofweek == [6, 6, 6]).all())
-        self.assertEqual(result.irow(0), s['1/2/2005'])
-        self.assertEqual(result.irow(1), s['1/9/2005'])
-        self.assertEqual(result.irow(2), s.irow(-1))
+        self.assertEqual(result.iloc[0], s['1/2/2005'])
+        self.assertEqual(result.iloc[1], s['1/9/2005'])
+        self.assertEqual(result.iloc[2], s.iloc[-1])
 
         result = s.resample('W-MON', how='last')
         self.assertEqual(len(result), 2)
         self.assertTrue((result.index.dayofweek == [0, 0]).all())
-        self.assertEqual(result.irow(0), s['1/3/2005'])
-        self.assertEqual(result.irow(1), s['1/10/2005'])
+        self.assertEqual(result.iloc[0], s['1/3/2005'])
+        self.assertEqual(result.iloc[1], s['1/10/2005'])
 
         result = s.resample('W-TUE', how='last')
         self.assertEqual(len(result), 2)
         self.assertTrue((result.index.dayofweek == [1, 1]).all())
-        self.assertEqual(result.irow(0), s['1/4/2005'])
-        self.assertEqual(result.irow(1), s['1/10/2005'])
+        self.assertEqual(result.iloc[0], s['1/4/2005'])
+        self.assertEqual(result.iloc[1], s['1/10/2005'])
 
         result = s.resample('W-WED', how='last')
         self.assertEqual(len(result), 2)
         self.assertTrue((result.index.dayofweek == [2, 2]).all())
-        self.assertEqual(result.irow(0), s['1/5/2005'])
-        self.assertEqual(result.irow(1), s['1/10/2005'])
+        self.assertEqual(result.iloc[0], s['1/5/2005'])
+        self.assertEqual(result.iloc[1], s['1/10/2005'])
 
         result = s.resample('W-THU', how='last')
         self.assertEqual(len(result), 2)
         self.assertTrue((result.index.dayofweek == [3, 3]).all())
-        self.assertEqual(result.irow(0), s['1/6/2005'])
-        self.assertEqual(result.irow(1), s['1/10/2005'])
+        self.assertEqual(result.iloc[0], s['1/6/2005'])
+        self.assertEqual(result.iloc[1], s['1/10/2005'])
 
         result = s.resample('W-FRI', how='last')
         self.assertEqual(len(result), 2)
         self.assertTrue((result.index.dayofweek == [4, 4]).all())
-        self.assertEqual(result.irow(0), s['1/7/2005'])
-        self.assertEqual(result.irow(1), s['1/10/2005'])
+        self.assertEqual(result.iloc[0], s['1/7/2005'])
+        self.assertEqual(result.iloc[1], s['1/10/2005'])
 
         # to biz day
         result = s.resample('B', how='last')
         self.assertEqual(len(result), 7)
         self.assertTrue((result.index.dayofweek == [4, 0, 1, 2, 3, 4, 0]).all())
-        self.assertEqual(result.irow(0), s['1/2/2005'])
-        self.assertEqual(result.irow(1), s['1/3/2005'])
-        self.assertEqual(result.irow(5), s['1/9/2005'])
+        self.assertEqual(result.iloc[0], s['1/2/2005'])
+        self.assertEqual(result.iloc[1], s['1/3/2005'])
+        self.assertEqual(result.iloc[5], s['1/9/2005'])
         self.assertEqual(result.index.name, 'index')
 
     def test_resample_upsampling_picked_but_not_correct(self):
@@ -407,13 +407,13 @@ class TestResample(tm.TestCase):
         self.assertEqual(len(result), len(expect))
         self.assertEqual(len(result.columns), 4)
 
-        xs = result.irow(-2)
+        xs = result.iloc[-2]
         self.assertEqual(xs['open'], s[-6])
         self.assertEqual(xs['high'], s[-6:-1].max())
         self.assertEqual(xs['low'], s[-6:-1].min())
         self.assertEqual(xs['close'], s[-2])
 
-        xs = result.irow(0)
+        xs = result.iloc[0]
         self.assertEqual(xs['open'], s[0])
         self.assertEqual(xs['high'], s[:5].max())
         self.assertEqual(xs['low'], s[:5].min())

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -1401,7 +1401,7 @@ class TestSlicing(tm.TestCase):
         assert_series_equal(result, expected)
 
         result = s['6 days, 23:11:12']
-        self.assertEqual(result, s.irow(133))
+        self.assertEqual(result, s.iloc[133])
 
         self.assertRaises(KeyError, s.__getitem__, '50 days')
 
@@ -1420,7 +1420,7 @@ class TestSlicing(tm.TestCase):
         assert_series_equal(result, expected)
 
         result = s['1 days, 10:11:12.001001']
-        self.assertEqual(result, s.irow(1001))
+        self.assertEqual(result, s.iloc[1001])
 
     def test_slice_with_negative_step(self):
         ts = Series(np.arange(20),

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -366,7 +366,7 @@ class TestTimeSeries(tm.TestCase):
         s = Series(rng, index=rng)
         tm.assertIsInstance(s[5], Timestamp)
 
-        tm.assertIsInstance(s.iget_value(5), Timestamp)
+        tm.assertIsInstance(s.iat[5], Timestamp)
 
     def test_date_range_ambiguous_arguments(self):
         # #2538
@@ -3854,7 +3854,7 @@ class TestSlicing(tm.TestCase):
         assert_series_equal(result, expected)
 
         result = s['2005-1-1']
-        self.assertEqual(result, s.irow(0))
+        self.assertEqual(result, s.iloc[0])
 
         self.assertRaises(Exception, s.__getitem__, '2004-12-31')
 
@@ -4065,12 +4065,12 @@ class TestSlicing(tm.TestCase):
                         'L': lvls})
 
         result = df.TS.max()
-        exp = Timestamp(df.TS.iget(-1))
+        exp = Timestamp(df.TS.iat[-1])
         self.assertTrue(isinstance(result, Timestamp))
         self.assertEqual(result, exp)
 
         result = df.TS.min()
-        exp = Timestamp(df.TS.iget(0))
+        exp = Timestamp(df.TS.iat[0])
         self.assertTrue(isinstance(result, Timestamp))
         self.assertEqual(result, exp)
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -734,8 +734,8 @@ def assert_frame_equal(left, right, check_dtype=True,
     else:
         for i, col in enumerate(left.columns):
             assert col in right
-            lcol = left.icol(i)
-            rcol = right.icol(i)
+            lcol = left.iloc[:, i]
+            rcol = right.iloc[:, i]
             assert_series_equal(lcol, rcol,
                                 check_dtype=check_dtype,
                                 check_index_type=check_index_type,

--- a/vb_suite/test_perf.py
+++ b/vb_suite/test_perf.py
@@ -425,7 +425,7 @@ def print_report(df,h_head=None,h_msg="",h_baseline=None,b_msg=""):
         lfmt = ("{:%s}" % name_width)
         lfmt += ("| {:%d.4f} " % (col_width-2))* len(df.columns)
         lfmt += "|\n"
-        s += lfmt.format(df.index[i],*list(df.irow(i).values))
+        s += lfmt.format(df.index[i],*list(df.iloc[i].values))
 
     s+= ftr + "\n"
 


### PR DESCRIPTION
closes #10711 
