### PR TITLE
BUG: concat of Series w/o names #10698

### DIFF
--- a/doc/source/merging.rst
+++ b/doc/source/merging.rst
@@ -352,7 +352,24 @@ Passing ``ignore_index=True`` will drop all name references.
 More concatenating with group keys
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Let's consider a variation on the first example presented:
+A fairly common use of the ``keys`` argument is to override the column names when creating a new DataFrame based on existing Series.
+Notice how the default behaviour consists on letting the resulting DataFrame inherits the parent Series' name, when these existed.
+
+.. ipython:: python
+
+   s3 = pd.Series([0, 1, 2, 3], name='foo')
+   s4 = pd.Series([0, 1, 2, 3])
+   s5 = pd.Series([0, 1, 4, 5])
+
+   pd.concat([s3, s4, s5], axis=1)
+
+Through the ``keys`` argument we can override the existing column names.
+
+.. ipython:: python
+
+   pd.concat([s3, s4, s5], axis=1, keys=['red','blue','yellow'])
+
+Let's consider now a variation on the very first example presented:
 
 .. ipython:: python
 

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -226,6 +226,30 @@ Other enhancements
 
 - ``DataFrame.apply`` will return a Series of dicts if the passed function returns a dict and ``reduce=True`` (:issue:`8735`).
 
+- ``concat`` will now use existing Series names if provided (:issue:`10698`).
+
+  .. ipython:: python
+
+     foo = pd.Series([1,2], name='foo')
+     bar = pd.Series([1,2])
+     baz = pd.Series([4,5])
+
+  Previous Behavior:
+
+  .. code-block:: python
+
+     In [1] pd.concat([foo, bar, baz], 1)
+     Out[1]:
+           0  1  2
+        0  1  1  4
+        1  2  2  5
+
+  New Behavior:
+
+  .. ipython:: python
+
+    pd.concat([foo, bar, baz], 1)
+
 .. _whatsnew_0170.api:
 
 .. _whatsnew_0170.api_breaking:

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -1879,6 +1879,24 @@ class TestConcatenate(tm.TestCase):
         self.assertEqual(list(result.columns), [('t1', 'value'),
                                                 ('t2', 'value')])
 
+    def test_concat_series_partial_columns_names(self):
+        # GH10698
+        foo = pd.Series([1,2], name='foo')
+        bar = pd.Series([1,2])
+        baz = pd.Series([4,5])
+
+        result = pd.concat([foo, bar, baz], axis=1)
+        expected = DataFrame({'foo' : [1,2], 0 : [1,2], 1 : [4,5]}, columns=['foo',0,1])
+        tm.assert_frame_equal(result, expected)
+
+        result = pd.concat([foo, bar, baz], axis=1, keys=['red','blue','yellow'])
+        expected = DataFrame({'red' : [1,2], 'blue' : [1,2], 'yellow' : [4,5]}, columns=['red','blue','yellow'])
+        tm.assert_frame_equal(result, expected)
+
+        result = pd.concat([foo, bar, baz], axis=1, ignore_index=True)
+        expected = DataFrame({0 : [1,2], 1 : [1,2], 2 : [4,5]})
+        tm.assert_frame_equal(result, expected)
+
     def test_concat_dict(self):
         frames = {'foo': DataFrame(np.random.randn(4, 3)),
                   'bar': DataFrame(np.random.randn(4, 3)),
@@ -2412,7 +2430,7 @@ class TestConcatenate(tm.TestCase):
 
         s2.name = None
         result = concat([s, s2], axis=1)
-        self.assertTrue(np.array_equal(result.columns, lrange(2)))
+        self.assertTrue(np.array_equal(result.columns, Index(['A', 0], dtype='object')))
 
         # must reindex, #2603
         s = Series(randn(3), index=['c', 'a', 'b'], name='A')


### PR DESCRIPTION
closes #10698 

Let the result of 'concat' to inherit the parent Series' names. The Series' name (if present) will be used as the resulting DataFrame column name. When only one of the Series has a valid name, the resulting DataFrame will inherit the name only, and use a column name for the other columns the column index value.
