### PR TITLE
amend sample to return copy and align weight axis

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -628,6 +628,8 @@ Bug Fixes
 - Bug in ``stack`` when index or columns are not unique. (:issue:`10417`)
 - Bug in setting a Panel when an axis has a multi-index (:issue:`10360`)
 - Bug in ``USFederalHolidayCalendar`` where ``USMemorialDay`` and ``USMartinLutherKingJr`` were incorrect (:issue:`10278` and :issue:`9760` )
+- Bug in ``.sample()`` where returned object, if set, gives unnecessary ``SettingWithCopyWarning`` (:issue:`10738`)
+- Bug in ``.sample()`` where weights passed as Series were not aligned along axis before being treated positionally, potentially causing problems if weight indices were not aligned with sampled object. (:issue:`10738`)
 
 
 

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -374,7 +374,7 @@ class Generic(object):
 
             self._compare(o.sample(frac=0.7,random_state=np.random.RandomState(test)),
                           o.sample(frac=0.7, random_state=np.random.RandomState(test)))
-
+ 
 
         # Check for error when random_state argument invalid.
         with tm.assertRaises(ValueError):
@@ -415,6 +415,10 @@ class Generic(object):
             bad_weights = [0.5]*11
             o.sample(n=3, weights=bad_weights)
 
+        with tm.assertRaises(ValueError):
+            bad_weight_series = Series([0,0,0.2])
+            o.sample(n=4, weights=bad_weight_series)
+            
         # Check won't accept negative weights
         with tm.assertRaises(ValueError):
             bad_weights = [-0.1]*10
@@ -430,6 +434,16 @@ class Generic(object):
             weights_with_ninf = [0.1]*10
             weights_with_ninf[0] =  -np.inf
             o.sample(n=3, weights=weights_with_ninf)
+
+        # All zeros raises errors
+        zero_weights = [0]*10
+        with tm.assertRaises(ValueError):
+            o.sample(n=3, weights=zero_weights)
+
+        # All missing weights
+        nan_weights = [np.nan]*10
+        with tm.assertRaises(ValueError):
+            o.sample(n=3, weights=nan_weights)
 
 
         # A few dataframe test with degenerate weights.
@@ -496,7 +510,6 @@ class Generic(object):
         assert_frame_equal(df.sample(n=1, axis='index', weights=weight),
                            df.iloc[5:6])
 
-
         # Check out of range axis values
         with tm.assertRaises(ValueError):
             df.sample(n=1, axis=2)
@@ -526,6 +539,26 @@ class Generic(object):
         p = pd.Panel(items = ['a','b','c'], major_axis=[2,4,6], minor_axis=[1,3,5])
         assert_panel_equal(p.sample(n=3, random_state=42), p.sample(n=3, axis=1, random_state=42))
         assert_frame_equal(df.sample(n=3, random_state=42), df.sample(n=3, axis=0, random_state=42))
+
+        # Test that function aligns weights with frame
+        df = DataFrame({'col1':[5,6,7], 'col2':['a','b','c'], }, index = [9,5,3])
+        s = Series([1,0,0], index=[3,5,9])
+        assert_frame_equal(df.loc[[3]], df.sample(1, weights=s))
+
+        # Weights have index values to be dropped because not in 
+        # sampled DataFrame
+        s2 = Series([0.001,0,10000], index=[3,5,10])
+        assert_frame_equal(df.loc[[3]], df.sample(1, weights=s2))
+
+        # Weights have empty values to be filed with zeros
+        s3 = Series([0.01,0], index=[3,5])
+        assert_frame_equal(df.loc[[3]], df.sample(1, weights=s3))
+
+        # No overlap in weight and sampled DataFrame indices
+        s4 = Series([1,0], index=[1,2])
+        with tm.assertRaises(ValueError):
+            df.sample(1, weights=s4)
+
 
     def test_size_compat(self):
         # GH8846


### PR DESCRIPTION
Two bug fixes:
- Makes sure to return copies, not views. 
- makes sure if a separate series is passed as weights that the axis are aligned before arguments get converted into numpy arrays and handled positionally

closes #10736 
