### PR TITLE
Allow DateOffset addition with Series

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1444,6 +1444,7 @@ Conversion
 
    DatetimeIndex.to_datetime
    DatetimeIndex.to_period
+   DatetimeIndex.to_perioddelta
    DatetimeIndex.to_pydatetime
    DatetimeIndex.to_series
 

--- a/doc/source/timedeltas.rst
+++ b/doc/source/timedeltas.rst
@@ -97,6 +97,8 @@ It will construct Series if the input is a Series, a scalar if the input is scal
    to_timedelta(np.arange(5),unit='s')
    to_timedelta(np.arange(5),unit='d')
 
+.. _timedeltas.operations:
+
 Operations
 ----------
 

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -647,6 +647,46 @@ Another example is parameterizing ``YearEnd`` with the specific ending month:
    d + YearEnd()
    d + YearEnd(month=6)
 
+
+.. _timeseries.offsetseries:
+
+Using offsets with ``Series`` / ``DatetimeIndex``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Offsets can be used with either a ``Series`` or ``DatetimeIndex`` to
+apply the offset to each element.
+
+.. ipython:: python
+
+   rng = date_range('2012-01-01', '2012-01-03')
+   s = Series(rng)
+   rng
+   rng + DateOffset(months=2)
+   s + DateOffset(months=2)
+   s - DateOffset(months=2)
+   
+If the offset class maps directly to a ``Timedelta`` (``Day``, ``Hour``,
+``Minute``, ``Second``, ``Micro``, ``Milli``, ``Nano``) it can be
+used exactly like a ``Timedelta`` - see the
+:ref:`Timedelta section<timedeltas.operations>` for more examples.
+
+.. ipython:: python
+
+   s - Day(2)
+   td = s - Series(date_range('2011-12-29', '2011-12-31'))
+   td
+   td + Minute(15)
+
+Note that some offsets (such as ``BQuarterEnd``) do not have a
+vectorized implementation.  They can still be used but may 
+calculate signficantly slower and will raise a ``PerformanceWarning``
+
+.. ipython:: python
+   :okwarning:
+
+   rng + BQuarterEnd()
+
+
 .. _timeseries.alias:
 
 Custom Business Days (Experimental)

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -133,6 +133,8 @@ Other enhancements
 
 - ``to_datetime`` can now accept ``yearfirst`` keyword (:issue:`7599`)
 
+- ``pandas.tseries.offsets`` larger than the ``Day`` offset can now be used with with ``Series`` for addition/subtraction (:issue:`10699`).  See the :ref:`Documentation <timeseries.offsetseries>` for more details.
+
 - ``.as_blocks`` will now take a ``copy`` optional argument to return a copy of the data, default is to copy (no change in behavior from prior versions), (:issue:`9607`)
 
 - ``regex`` argument to ``DataFrame.filter`` now handles numeric column names instead of raising ``ValueError`` (:issue:`10384`).

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -3286,14 +3286,37 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
             s + op(5)
             op(5) + s
 
-        # invalid DateOffsets
-        for do in [ 'Week', 'BDay', 'BQuarterEnd', 'BMonthEnd', 'BYearEnd',
-                    'BYearBegin','BQuarterBegin', 'BMonthBegin',
-                    'MonthEnd','YearBegin', 'YearEnd',
-                    'MonthBegin', 'QuarterBegin' ]:
+
+    def test_timedelta64_operations_with_DateOffset(self):
+        # GH 10699
+        td = Series([timedelta(minutes=5, seconds=3)] * 3)
+        result = td + pd.offsets.Minute(1)
+        expected = Series([timedelta(minutes=6, seconds=3)] * 3)
+        assert_series_equal(result, expected)
+
+        result = td - pd.offsets.Minute(1)
+        expected = Series([timedelta(minutes=4, seconds=3)] * 3)
+        assert_series_equal(result, expected)
+
+        result = td + Series([pd.offsets.Minute(1), pd.offsets.Second(3),
+                              pd.offsets.Hour(2)])
+        expected = Series([timedelta(minutes=6, seconds=3),
+                           timedelta(minutes=5, seconds=6),
+                           timedelta(hours=2, minutes=5, seconds=3)])
+        assert_series_equal(result, expected)
+
+        result = td + pd.offsets.Minute(1) + pd.offsets.Second(12)
+        expected = Series([timedelta(minutes=6, seconds=15)] * 3)
+        assert_series_equal(result, expected)
+
+        # valid DateOffsets
+        for do in [ 'Hour', 'Minute', 'Second', 'Day', 'Micro',
+                    'Milli', 'Nano' ]:
             op = getattr(pd.offsets,do)
-            self.assertRaises(TypeError, s.__add__, op(5))
-            self.assertRaises(TypeError, s.__radd__, op(5))
+            td + op(5)
+            op(5) + td
+            td - op(5)
+            op(5) - td
 
     def test_timedelta64_operations_with_timedeltas(self):
 

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -4,6 +4,8 @@ from pandas import compat
 import numpy as np
 
 from pandas.tseries.tools import to_datetime
+from pandas.tseries.timedeltas import to_timedelta
+from pandas.core.common import ABCSeries, ABCDatetimeIndex
 
 # import after tools, dateutil check
 from dateutil.relativedelta import relativedelta, weekday
@@ -92,6 +94,15 @@ def apply_wraps(func):
         return result
     return wrapper
 
+
+def apply_index_wraps(func):
+    @functools.wraps(func)
+    def wrapper(self, other):
+        result = func(self, other)
+        if self.normalize:
+            result  = result.to_period('D').to_timestamp()
+        return result
+    return wrapper
 
 def _is_normalized(dt):
     if (dt.hour != 0 or dt.minute != 0 or dt.second != 0
@@ -221,6 +232,67 @@ class DateOffset(object):
         else:
             return other + timedelta(self.n)
 
+    @apply_index_wraps
+    def apply_index(self, i):
+        """
+        Vectorized apply of DateOffset to DatetimeIndex,
+        raises NotImplentedError for offsets without a
+        vectorized implementation
+
+        .. versionadded:: 0.17.0
+
+        Parameters
+        ----------
+        i : DatetimeIndex
+
+        Returns
+        -------
+        y : DatetimeIndex
+        """
+
+        if not type(self) is DateOffset:
+            raise NotImplementedError("DateOffset subclass %s "
+                                     "does not have a vectorized "
+                                     "implementation"
+                                     % (self.__class__.__name__,))
+        relativedelta_fast = set(['years', 'months', 'weeks',
+                                'days', 'hours', 'minutes',
+                                'seconds', 'microseconds'])
+        # relativedelta/_offset path only valid for base DateOffset
+        if (self._use_relativedelta and
+            set(self.kwds).issubset(relativedelta_fast)):
+            months = ((self.kwds.get('years', 0) * 12
+                        + self.kwds.get('months', 0)) * self.n)
+            if months:
+                base = (i.to_period('M') + months).to_timestamp()
+                time = i.to_perioddelta('D')
+                days = i.to_perioddelta('M') - time
+                # minimum prevents month-end from wrapping
+                day_offset = np.minimum(days,
+                                        to_timedelta(base.days_in_month - 1, unit='D'))
+                i = base + day_offset + time
+
+            weeks = (self.kwds.get('weeks', 0)) * self.n
+            if weeks:
+                i = (i.to_period('W') + weeks).to_timestamp() + i.to_perioddelta('W')
+
+            timedelta_kwds = dict((k,v) for k,v in self.kwds.items()
+                                    if k in ['days','hours','minutes',
+                                            'seconds','microseconds'])
+            if timedelta_kwds:
+                delta = Timedelta(**timedelta_kwds)
+                i = i + (self.n * delta)
+            return i
+        elif not self._use_relativedelta and hasattr(self, '_offset'):
+            # timedelta
+            return i + (self._offset * self.n)
+        else:
+            # relativedelta with other keywords
+            raise NotImplementedError("DateOffset with relativedelta "
+                                      "keyword(s) %s not able to be "
+                                      "applied vectorized" %
+                                      (set(self.kwds) - relativedelta_fast),)
+
     def isAnchored(self):
         return (self.n == 1)
 
@@ -307,6 +379,8 @@ class DateOffset(object):
         return self.apply(other)
 
     def __add__(self, other):
+        if isinstance(other, (ABCDatetimeIndex, ABCSeries)):
+            return other + self
         try:
             return self.apply(other)
         except ApplyTypeError:
@@ -324,6 +398,8 @@ class DateOffset(object):
             return NotImplemented
 
     def __rsub__(self, other):
+        if isinstance(other, (ABCDatetimeIndex, ABCSeries)):
+            return other - self
         return self.__class__(-self.n, normalize=self.normalize, **self.kwds) + other
 
     def __mul__(self, someInt):
@@ -362,6 +438,37 @@ class DateOffset(object):
         a = dt
         b = ((dt + self) - self)
         return a == b
+
+    # helpers for vectorized offsets
+    def _beg_apply_index(self, i, freq):
+        """Offsets index to beginning of Period frequency"""
+
+        off = i.to_perioddelta('D')
+        base_period = i.to_period(freq)
+        if self.n < 0:
+            # when subtracting, dates on start roll to prior
+            roll = np.where(base_period.to_timestamp() == i - off,
+                            self.n, self.n + 1)
+        else:
+            roll = self.n
+
+        base = (base_period + roll).to_timestamp()
+        return base + off
+
+    def _end_apply_index(self, i, freq):
+        """Offsets index to end of Period frequency"""
+
+        off = i.to_perioddelta('D')
+        base_period = i.to_period(freq)
+        if self.n > 0:
+            # when adding, dtates on end roll to next
+            roll = np.where(base_period.to_timestamp(how='end') == i - off,
+                            self.n, self.n - 1)
+        else:
+            roll = self.n
+
+        base = (base_period + roll).to_timestamp(how='end')
+        return base + off
 
     # way to get around weirdness with rule_code
     @property
@@ -528,6 +635,19 @@ class BusinessDay(BusinessMixin, SingleConstructorOffset):
         else:
             raise ApplyTypeError('Only know how to combine business day with '
                                  'datetime or timedelta.')
+
+    @apply_index_wraps
+    def apply_index(self, i):
+        time = i.to_perioddelta('D')
+        # to_period rolls forward to next BDay; track and
+        # reduce n where it does when rolling forward
+        shifted = (i.to_perioddelta('B') - time).asi8 != 0
+        if self.n > 0:
+            roll = np.where(shifted, self.n - 1, self.n)
+        else:
+            roll = self.n
+
+        return (i.to_period('B') + roll).to_timestamp() + time
 
     def onOffset(self, dt):
         if self.normalize and not _is_normalized(dt):
@@ -902,6 +1022,9 @@ class CustomBusinessDay(BusinessDay):
             raise ApplyTypeError('Only know how to combine trading day with '
                                  'datetime, datetime64 or timedelta.')
 
+    def apply_index(self, i):
+        raise NotImplementedError
+
     @staticmethod
     def _to_dt64(dt, dtype='datetime64'):
         # Currently
@@ -949,6 +1072,10 @@ class MonthEnd(MonthOffset):
         other = other + relativedelta(months=n, day=31)
         return other
 
+    @apply_index_wraps
+    def apply_index(self, i):
+        return self._end_apply_index(i, 'M')
+
     def onOffset(self, dt):
         if self.normalize and not _is_normalized(dt):
             return False
@@ -969,6 +1096,10 @@ class MonthBegin(MonthOffset):
             n += 1
 
         return other + relativedelta(months=n, day=1)
+
+    @apply_index_wraps
+    def apply_index(self, i):
+        return self._beg_apply_index(i, 'M')
 
     def onOffset(self, dt):
         if self.normalize and not _is_normalized(dt):
@@ -1210,6 +1341,13 @@ class Week(DateOffset):
         other = datetime(other.year, other.month, other.day,
                          base.hour, base.minute, base.second, base.microsecond)
         return other
+
+    @apply_index_wraps
+    def apply_index(self, i):
+        if self.weekday is None:
+            return (i.to_period('W') + self.n).to_timestamp() + i.to_perioddelta('W')
+        else:
+            return self._end_apply_index(i, self.freqstr)
 
     def onOffset(self, dt):
         if self.normalize and not _is_normalized(dt):
@@ -1587,6 +1725,10 @@ class QuarterEnd(QuarterOffset):
         other = other + relativedelta(months=monthsToGo + 3 * n, day=31)
         return other
 
+    @apply_index_wraps
+    def apply_index(self, i):
+        return self._end_apply_index(i, self.freqstr)
+
     def onOffset(self, dt):
         if self.normalize and not _is_normalized(dt):
             return False
@@ -1621,6 +1763,11 @@ class QuarterBegin(QuarterOffset):
         other = other + relativedelta(months=3 * n - monthsSince, day=1)
         return other
 
+    @apply_index_wraps
+    def apply_index(self, i):
+        freq_month = 12 if self.startingMonth == 1 else self.startingMonth - 1
+        freqstr =  'Q-%s' % (_int_to_month[freq_month],)
+        return self._beg_apply_index(i, freqstr)
 
 class YearOffset(DateOffset):
     """DateOffset that just needs a month"""
@@ -1764,6 +1911,11 @@ class YearEnd(YearOffset):
             result = _rollf(result)
         return result
 
+    @apply_index_wraps
+    def apply_index(self, i):
+        # convert month anchor to annual period tuple
+        return self._end_apply_index(i, self.freqstr)
+
     def onOffset(self, dt):
         if self.normalize and not _is_normalized(dt):
             return False
@@ -1808,6 +1960,12 @@ class YearBegin(YearOffset):
             # n == 0, roll forward
             result = _rollf(result)
         return result
+
+    @apply_index_wraps
+    def apply_index(self, i):
+        freq_month = 12 if self.month == 1 else self.month - 1
+        freqstr =  'A-%s' % (_int_to_month[freq_month],)
+        return self._beg_apply_index(i, freqstr)
 
     def onOffset(self, dt):
         if self.normalize and not _is_normalized(dt):
@@ -2310,6 +2468,7 @@ class Tick(SingleConstructorOffset):
             raise ApplyTypeError('Unhandled type: %s' % type(other).__name__)
 
     _prefix = 'undefined'
+
 
     def isAnchored(self):
         return False

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -31,6 +31,7 @@ import pandas.index as _index
 from pandas.compat import range, long, StringIO, lrange, lmap, zip, product
 from numpy.random import rand
 from pandas.util.testing import assert_frame_equal
+from pandas.io.common import PerformanceWarning
 import pandas.compat as compat
 import pandas.core.common as com
 from pandas import concat
@@ -2454,6 +2455,91 @@ class TestDatetimeIndex(tm.TestCase):
         result = index_1 & index_2
         self.assertEqual(len(result), 0)
 
+    # GH 10699
+    def test_datetime64_with_DateOffset(self):
+        for klass, assert_func in zip([Series, DatetimeIndex],
+                                      [self.assert_series_equal,
+                                       tm.assert_index_equal]):
+            s = klass(date_range('2000-01-01', '2000-01-31'))
+            result = s + pd.DateOffset(years=1)
+            result2 = pd.DateOffset(years=1) + s
+            exp = klass(date_range('2001-01-01', '2001-01-31'))
+            assert_func(result, exp)
+            assert_func(result2, exp)
+
+            result = s - pd.DateOffset(years=1)
+            exp = klass(date_range('1999-01-01', '1999-01-31'))
+            assert_func(result, exp)
+
+            s = klass([Timestamp('2000-01-15 00:15:00', tz='US/Central'),
+                       pd.Timestamp('2000-02-15', tz='US/Central')])
+            result = s + pd.offsets.MonthEnd()
+            result2 = pd.offsets.MonthEnd() + s
+            exp = klass([Timestamp('2000-01-31 00:15:00', tz='US/Central'),
+                         Timestamp('2000-02-29', tz='US/Central')])
+            assert_func(result, exp)
+            assert_func(result2, exp)
+
+            # array of offsets - valid for Series only
+            if klass is Series:
+                with tm.assert_produces_warning(PerformanceWarning):
+                    s = klass([Timestamp('2000-1-1'), Timestamp('2000-2-1')])
+                    result = s + Series([pd.offsets.DateOffset(years=1),
+                                        pd.offsets.MonthEnd()])
+                    exp = klass([Timestamp('2001-1-1'), Timestamp('2000-2-29')])
+                    assert_func(result, exp)
+
+                    # same offset
+                    result = s + Series([pd.offsets.DateOffset(years=1),
+                                         pd.offsets.DateOffset(years=1)])
+                    exp = klass([Timestamp('2001-1-1'), Timestamp('2001-2-1')])
+                    assert_func(result, exp)
+
+            s = klass([Timestamp('2000-01-05 00:15:00'), Timestamp('2000-01-31 00:23:00'),
+                       Timestamp('2000-01-01'), Timestamp('2000-02-29'), Timestamp('2000-12-31')])
+
+            #DateOffset relativedelta fastpath
+            relative_kwargs = [('years', 2), ('months', 5), ('days', 3),
+                            ('hours', 5), ('minutes', 10), ('seconds', 2),
+                            ('microseconds', 5)]
+            for i, kwd in enumerate(relative_kwargs):
+                op = pd.DateOffset(**dict([kwd]))
+                assert_func(klass([x + op for x in s]), s + op)
+                assert_func(klass([x - op for x in s]), s - op)
+                op = pd.DateOffset(**dict(relative_kwargs[:i+1]))
+                assert_func(klass([x + op for x in s]), s + op)
+                assert_func(klass([x - op for x in s]), s - op)
+
+
+            # split by fast/slow path to test perf warning
+            off = {False:
+                   ['YearBegin', ('YearBegin', {'month': 5}),
+                    'YearEnd', ('YearEnd', {'month': 5}),
+                    'MonthBegin', 'MonthEnd', 'Week', ('Week', {'weekday': 3}),
+                    'BusinessDay', 'BDay', 'QuarterEnd', 'QuarterBegin'],
+                   PerformanceWarning:
+                   ['CustomBusinessDay', 'CDay', 'CBMonthEnd','CBMonthBegin',
+                    'BMonthBegin', 'BMonthEnd', 'BusinessHour', 'BYearBegin',
+                    'BYearEnd','BQuarterBegin', ('LastWeekOfMonth', {'weekday':2}),
+                    ('FY5253Quarter', {'qtr_with_extra_week': 1, 'startingMonth': 1,
+                                       'weekday': 2, 'variation': 'nearest'}),
+                    ('FY5253',{'weekday': 0, 'startingMonth': 2, 'variation': 'nearest'}),
+                    ('WeekOfMonth', {'weekday': 2, 'week': 2}), 'Easter',
+                    ('DateOffset', {'day': 4}), ('DateOffset', {'month': 5})]}
+
+            for normalize in (True, False):
+                for warning, offsets in off.items():
+                    for do in offsets:
+                        if isinstance(do, tuple):
+                            do, kwargs = do
+                        else:
+                            do = do
+                            kwargs = {}
+                        op = getattr(pd.offsets,do)(5, normalize=normalize, **kwargs)
+                        with tm.assert_produces_warning(warning):
+                            assert_func(klass([x + op for x in s]), s + op)
+                            assert_func(klass([x - op for x in s]), s - op)
+                            assert_func(klass([op + x for x in s]), op + s)
     # def test_add_timedelta64(self):
     #     rng = date_range('1/1/2000', periods=5)
     #     delta = rng.values[3] - rng.values[1]
@@ -4222,12 +4308,12 @@ class TimeConversionFormats(tm.TestCase):
 
     def test_to_datetime_format_time(self):
         data = [
-                ['01/10/2010 15:20', '%m/%d/%Y %H:%M', Timestamp('2010-01-10 15:20')],
-	            ['01/10/2010 05:43', '%m/%d/%Y %I:%M', Timestamp('2010-01-10 05:43')],
-	            ['01/10/2010 13:56:01', '%m/%d/%Y %H:%M:%S', Timestamp('2010-01-10 13:56:01')]#,
-	            #['01/10/2010 08:14 PM', '%m/%d/%Y %I:%M %p', Timestamp('2010-01-10 20:14')],
-	            #['01/10/2010 07:40 AM', '%m/%d/%Y %I:%M %p', Timestamp('2010-01-10 07:40')],
-	            #['01/10/2010 09:12:56 AM', '%m/%d/%Y %I:%M:%S %p', Timestamp('2010-01-10 09:12:56')]
+               ['01/10/2010 15:20', '%m/%d/%Y %H:%M', Timestamp('2010-01-10 15:20')],
+             ['01/10/2010 05:43', '%m/%d/%Y %I:%M', Timestamp('2010-01-10 05:43')],
+             ['01/10/2010 13:56:01', '%m/%d/%Y %H:%M:%S', Timestamp('2010-01-10 13:56:01')]#,
+             #['01/10/2010 08:14 PM', '%m/%d/%Y %I:%M %p', Timestamp('2010-01-10 20:14')],
+             #['01/10/2010 07:40 AM', '%m/%d/%Y %I:%M %p', Timestamp('2010-01-10 07:40')],
+             #['01/10/2010 09:12:56 AM', '%m/%d/%Y %I:%M:%S %p', Timestamp('2010-01-10 09:12:56')]
             ]
         for s, format, dt in data:
             self.assertEqual(to_datetime(s, format=format), dt)

--- a/vb_suite/timeseries.py
+++ b/vb_suite/timeseries.py
@@ -405,3 +405,33 @@ timeseries_iter_periodindex = Benchmark('iter_n(idx2)', setup)
 timeseries_iter_datetimeindex_preexit = Benchmark('iter_n(idx1, M)', setup)
 
 timeseries_iter_periodindex_preexit = Benchmark('iter_n(idx2, M)', setup)
+
+
+#----------------------------------------------------------------------
+# apply an Offset to a  DatetimeIndex
+setup = common_setup + """
+N = 100000
+idx1 = date_range(start='20140101', freq='T', periods=N)
+delta_offset = Day()
+fast_offset = DateOffset(months=2, days=2)
+slow_offset = offsets.BusinessDay()
+
+"""
+
+timeseries_datetimeindex_offset_delta = Benchmark('idx1 + delta_offset', setup)
+timeseries_datetimeindex_offset_fast = Benchmark('idx1 + fast_offset', setup)
+timeseries_datetimeindex_offset_slow = Benchmark('idx1 + slow_offset', setup)
+
+# apply an Offset to a Series containing datetime64 values
+setup = common_setup + """
+N = 100000
+s = Series(date_range(start='20140101', freq='T', periods=N))
+delta_offset = Day()
+fast_offset = DateOffset(months=2, days=2)
+slow_offset = offsets.BusinessDay()
+
+"""
+
+timeseries_series_offset_delta = Benchmark('s + delta_offset', setup)
+timeseries_series_offset_fast = Benchmark('s + fast_offset', setup)
+timeseries_series_offset_slow = Benchmark('s + slow_offset', setup)


### PR DESCRIPTION
Addresses #10699 - allowing relative offsets like `DateOffset(years=1)` to to be added to a `Series` containing datetimes for element-wise addition.

Previously only non-relative offsets that could be mapped to a time_delta (`Tick`, `Day`, etc) worked.

Some performance numbers are below - `Tick` based offsets should be unchanged, a subset of offsets (`DateOffset`, `YearEnd/Begin`, `MonthEnd/Begin`, `QuarterEnd/Begin`, `Week`, `BusinessDay`) will be sped up significantly; and other offsets will still fallback to a slow path, but now will raise a performance warning.
### Master

```
In [1]: idx = pd.date_range(start='20140101', freq='T', periods=100000)

In [2]: %timeit idx + pd.offsets.Day()
100 loops, best of 3: 5.72 ms per loop

In [3]: %timeit idx + pd.Timedelta(1, 'D')
100 loops, best of 3: 5.67 ms per loop

In [4]: %timeit idx + pd.offsets.DateOffset(years=1, months=2, days=1)
1 loops, best of 3: 1.79 s per loop

In [5]: %timeit idx + pd.offsets.WeekOfMonth(week=2, weekday=4)
1 loops, best of 3: 22.8 s per loop
```
### PR

```
In [3]: %timeit idx + pd.offsets.Day()
100 loops, best of 3: 5.8 ms per loop

In [4]: %timeit idx + pd.Timedelta(1, 'D')
100 loops, best of 3: 5.73 ms per loop

In [5]: %timeit idx + pd.offsets.DateOffset(years=1, months=2, days=1)
10 loops, best of 3: 86.9 ms per loop

In [6]: %timeit idx + pd.offsets.WeekOfMonth(week=2, weekday=4)
1 loops, best of 3: 23.4 s per loop
c:\users\chris\documents\python-dev\pandas\pandas\tseries\index.py:695: PerformanceWarning:     Non-vectorized DateOffset being applied to Series or DatetimeIndex  PerformanceWarning)
```
