### PR TITLE
DOC: fix some doc build errors/warnings

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -267,11 +267,11 @@ Optional Dependencies
   installation.
 * Google's `python-gflags <http://code.google.com/p/python-gflags/>`__
   and `google-api-python-client <http://github.com/google/google-api-python-client>`__
-   * Needed for :mod:`~pandas.io.gbq`
+  * Needed for :mod:`~pandas.io.gbq`
 * `setuptools <https://pypi.python.org/pypi/setuptools/>`__
-   * Needed for :mod:`~pandas.io.gbq` (specifically, it utilizes `pkg_resources`)
+  * Needed for :mod:`~pandas.io.gbq` (specifically, it utilizes `pkg_resources`)
 * `httplib2 <http://pypi.python.org/pypi/httplib2>`__
-   * Needed for :mod:`~pandas.io.gbq`
+  * Needed for :mod:`~pandas.io.gbq`
 * One of the following combinations of libraries is needed to use the
   top-level :func:`~pandas.io.html.read_html` function:
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -3610,7 +3610,7 @@ below and the SQLAlchemy `documentation <http://docs.sqlalchemy.org/en/rel_0_9/c
 
 If you want to manage your own connections you can pass one of those instead:
 
-.. ipython:: python
+.. code-block:: python
 
    with engine.connect() as conn, conn.begin():
        data = pd.read_sql_table('data', conn)

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -1649,6 +1649,7 @@ values, the resulting grid has two columns and two rows. A histogram is
 displayed for each cell of the grid.
 
 .. ipython:: python
+   :okwarning:
 
    plt.figure()
 
@@ -1680,6 +1681,7 @@ Example below is the same as previous except the plot is set to kernel density
 estimation. A ``seaborn`` example is included beneath.
 
 .. ipython:: python
+   :okwarning:
 
    plt.figure()
 
@@ -1706,6 +1708,7 @@ The plot below shows that it is possible to have two or more plots for the same
 data displayed on the same Trellis grid cell.
 
 .. ipython:: python
+   :okwarning:
 
    plt.figure()
 
@@ -1745,6 +1748,7 @@ Below is a similar plot but with 2D kernel density estimation plot superimposed,
 followed by a ``seaborn`` equivalent:
 
 .. ipython:: python
+   :okwarning:
 
    plt.figure()
 
@@ -1774,6 +1778,7 @@ only uses 'sex' attribute. If the second grouping attribute is not specified,
 the plots will be arranged in a column.
 
 .. ipython:: python
+   :okwarning:
 
    plt.figure()
 
@@ -1792,6 +1797,7 @@ the plots will be arranged in a column.
 If the first grouping attribute is not specified the plots will be arranged in a row.
 
 .. ipython:: python
+   :okwarning:
 
    plt.figure()
 
@@ -1816,6 +1822,7 @@ scale objects to specify these mappings. The list of scale classes is
 given below with initialization arguments for quick reference.
 
 .. ipython:: python
+   :okwarning:
 
    plt.figure()
 

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -13,13 +13,13 @@ users upgrade to this version.
 
 Highlights include:
 
-  - Release the Global Interpreter Lock (GIL) on some cython operations, see :ref:`here <whatsnew_0170.gil>`
-  - The default for ``to_datetime`` will now be to ``raise`` when presented with unparseable formats,
-    previously this would return the original input, see :ref:`here <whatsnew_0170.api_breaking.to_datetime>`
-  - The default for ``dropna`` in ``HDFStore`` has changed to ``False``, to store by default all rows even
-    if they are all ``NaN``, see :ref:`here <whatsnew_0170.api_breaking.hdf_dropna>`
-  - Support for ``Series.dt.strftime`` to generate formatted strings for datetime-likes, see :ref:`here <whatsnew_0170.strftime>`
-  - Development installed versions of pandas will now have ``PEP440`` compliant version strings (:issue:`9518`)
+- Release the Global Interpreter Lock (GIL) on some cython operations, see :ref:`here <whatsnew_0170.gil>`
+- The default for ``to_datetime`` will now be to ``raise`` when presented with unparseable formats,
+  previously this would return the original input, see :ref:`here <whatsnew_0170.api_breaking.to_datetime>`
+- The default for ``dropna`` in ``HDFStore`` has changed to ``False``, to store by default all rows even
+  if they are all ``NaN``, see :ref:`here <whatsnew_0170.api_breaking.hdf_dropna>`
+- Support for ``Series.dt.strftime`` to generate formatted strings for datetime-likes, see :ref:`here <whatsnew_0170.strftime>`
+- Development installed versions of pandas will now have ``PEP440`` compliant version strings (:issue:`9518`)
 
 Check the :ref:`API Changes <whatsnew_0170.api>` and :ref:`deprecations <whatsnew_0170.deprecations>` before updating.
 
@@ -448,6 +448,7 @@ from ``7``.
 
 .. ipython:: python
   :suppress:
+
   pd.set_option('display.precision', 6)
 
 
@@ -481,9 +482,9 @@ Series with a ``CategoricalIndex`` (:issue:`10704`)
 - ``groupby`` using ``Categorical`` follows the same rule as ``Categorical.unique`` described above  (:issue:`10508`)
 - ``NaT``'s methods now either raise ``ValueError``, or return ``np.nan`` or ``NaT`` (:issue:`9513`)
 
-   ===============================     ==============================================================
+   ===============================     ===============================================================
    Behavior                            Methods
-   ===============================     ==============================================================
+   ===============================     ===============================================================
    ``return np.nan``                   ``weekday``, ``isoweekday``
    ``return NaT``                      ``date``, ``now``, ``replace``, ``to_datetime``, ``today``
    ``return np.datetime64('NaT')``     ``to_datetime64`` (unchanged)


### PR DESCRIPTION
This should get the sphinx doc build again warning/error free (apart from the one handled in #10602)
