### PR TITLE
BUG: Fix dtypes order when ordering is different from original file in pandas.io.stata.read_stata

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -598,7 +598,7 @@ Bug Fixes
 - Bug in ``DataFrame.plot`` raises ``ValueError`` when color name is specified by multiple characters (:issue:`10387`)
 
 
-
+- Bug in ``read_stata`` when reading a file with a different order set in ``columns`` (:issue:`10757`)
 
 - Reading "famafrench" data via ``DataReader`` results in HTTP 404 error because of the website url is changed (:issue:`10591`).
 - Bug in ``read_msgpack`` where DataFrame to decode has duplicate column names (:issue:`9618`)

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1614,14 +1614,12 @@ class StataReader(StataParser):
             typlist = []
             fmtlist = []
             lbllist = []
-            matched = set()
-            for i, col in enumerate(data.columns):
-                if col in column_set:
-                    matched.update([col])
-                    dtyplist.append(self.dtyplist[i])
-                    typlist.append(self.typlist[i])
-                    fmtlist.append(self.fmtlist[i])
-                    lbllist.append(self.lbllist[i])
+            for col in columns:
+                i = data.columns.get_loc(col)
+                dtyplist.append(self.dtyplist[i])
+                typlist.append(self.typlist[i])
+                fmtlist.append(self.fmtlist[i])
+                lbllist.append(self.lbllist[i])
 
             self.dtyplist = dtyplist
             self.typlist = typlist

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -782,6 +782,14 @@ class TestStata(tm.TestCase):
                              columns=columns)
 
         tm.assert_frame_equal(expected, dropped)
+
+        # See PR 10757
+        columns = ['int_', 'long_', 'byte_']
+        expected = expected[columns]
+        reordered = read_stata(self.dta15_117, convert_dates=True,
+                               columns=columns)
+        tm.assert_frame_equal(expected, reordered)
+
         with tm.assertRaises(ValueError):
             columns = ['byte_', 'byte_']
             read_stata(self.dta15_117, convert_dates=True, columns=columns)


### PR DESCRIPTION
This fixes http://stackoverflow.com/questions/31783392/pandas-adding-columns-to-filter-will-mess-with-data-structure
The dtypes of the DataFrame returned by read_stata have the same order as the original stata file, even if columns are specified with a different order.
