### PR TITLE
TST: Suppress warnings of drop_duplicates tests

### DIFF
--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -683,10 +683,6 @@ class TestIndexOps(Ops):
 
     def test_duplicated_drop_duplicates(self):
         # GH 4060
-
-        import warnings
-        warnings.simplefilter('always')
-
         for original in self.objs:
 
             if isinstance(original, Index):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -7848,7 +7848,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         inp.dropna(how='all', axis=(0, 1), inplace=True)
         assert_frame_equal(inp, expected)
 
-    def test_aaa_drop_duplicates(self):
+    def test_drop_duplicates(self):
         df = DataFrame({'AAA': ['foo', 'bar', 'foo', 'bar',
                                 'foo', 'bar', 'bar', 'foo'],
                         'B': ['one', 'one', 'two', 'two',
@@ -7892,7 +7892,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_frame_equal(result, expected)
 
         # deprecate take_last
-        result = df.drop_duplicates(('AAA', 'B'), take_last=True)
+        with tm.assert_produces_warning(FutureWarning):
+            result = df.drop_duplicates(('AAA', 'B'), take_last=True)
         expected = df.ix[[0, 5, 6, 7]]
         assert_frame_equal(result, expected)
 
@@ -7913,8 +7914,10 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_frame_equal(result, expected)
 
         # deprecate take_last
-        result = df2.drop_duplicates(take_last=True)
-        expected = df2.drop_duplicates(['AAA', 'B'], take_last=True)
+        with tm.assert_produces_warning(FutureWarning):
+            result = df2.drop_duplicates(take_last=True)
+        with tm.assert_produces_warning(FutureWarning):
+            expected = df2.drop_duplicates(['AAA', 'B'], take_last=True)
         assert_frame_equal(result, expected)
 
     def test_drop_duplicates_for_take_all(self):
@@ -8008,7 +8011,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_frame_equal(result, expected)
 
         # deprecate take_last
-        result = df.drop_duplicates(('AA', 'AB'), take_last=True)
+        with tm.assert_produces_warning(FutureWarning):
+            result = df.drop_duplicates(('AA', 'AB'), take_last=True)
         expected = df.ix[[6, 7]]
         assert_frame_equal(result, expected)
 
@@ -8041,7 +8045,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.assertEqual(len(result), 0)
 
         # deprecate take_last
-        result = df.drop_duplicates('A', take_last=True)
+        with tm.assert_produces_warning(FutureWarning):
+            result = df.drop_duplicates('A', take_last=True)
         expected = df.ix[[1, 6, 7]]
         assert_frame_equal(result, expected)
 
@@ -8059,7 +8064,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_frame_equal(result, expected)
 
         # deprecate take_last
-        result = df.drop_duplicates(['A', 'B'], take_last=True)
+        with tm.assert_produces_warning(FutureWarning):
+            result = df.drop_duplicates(['A', 'B'], take_last=True)
         expected = df.ix[[1, 5, 6, 7]]
         assert_frame_equal(result, expected)
 
@@ -8086,7 +8092,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.assertEqual(len(result), 0)
 
         # deprecate take_last
-        result = df.drop_duplicates('C', take_last=True)
+        with tm.assert_produces_warning(FutureWarning):
+            result = df.drop_duplicates('C', take_last=True)
         expected = df.ix[[3, 7]]
         assert_frame_equal(result, expected)
 
@@ -8104,7 +8111,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_frame_equal(result, expected)
 
         # deprecate take_last
-        result = df.drop_duplicates(['C', 'B'], take_last=True)
+        with tm.assert_produces_warning(FutureWarning):
+            result = df.drop_duplicates(['C', 'B'], take_last=True)
         expected = df.ix[[1, 3, 6, 7]]
         assert_frame_equal(result, expected)
 
@@ -8172,7 +8180,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # deprecate take_last
         df = orig.copy()
-        df.drop_duplicates('A', take_last=True, inplace=True)
+        with tm.assert_produces_warning(FutureWarning):
+            df.drop_duplicates('A', take_last=True, inplace=True)
         expected = orig.ix[[6, 7]]
         result = df
         assert_frame_equal(result, expected)
@@ -8198,7 +8207,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # deprecate take_last
         df = orig.copy()
-        df.drop_duplicates(['A', 'B'], take_last=True, inplace=True)
+        with tm.assert_produces_warning(FutureWarning):
+            df.drop_duplicates(['A', 'B'], take_last=True, inplace=True)
         expected = orig.ix[[0, 5, 6, 7]]
         result = df
         assert_frame_equal(result, expected)
@@ -8227,8 +8237,10 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         # deprecate take_last
         df2 = orig2.copy()
-        df2.drop_duplicates(take_last=True, inplace=True)
-        expected = orig2.drop_duplicates(['A', 'B'], take_last=True)
+        with tm.assert_produces_warning(FutureWarning):
+            df2.drop_duplicates(take_last=True, inplace=True)
+        with tm.assert_produces_warning(FutureWarning):
+            expected = orig2.drop_duplicates(['A', 'B'], take_last=True)
         result = df2
         assert_frame_equal(result, expected)
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2151,11 +2151,13 @@ Thur,Lunch,Yes,51.51,17"""
 
         # deprecate take_last
         expected = np.array([True, False, False, False, False, False])
-        duplicated = idx.duplicated(take_last=True)
+        with tm.assert_produces_warning(FutureWarning):
+            duplicated = idx.duplicated(take_last=True)
         tm.assert_numpy_array_equal(duplicated, expected)
         self.assertTrue(duplicated.dtype == bool)
         expected = MultiIndex.from_arrays(([2, 3, 1, 2 ,3], [1, 1, 1, 2, 2]))
-        tm.assert_index_equal(idx.drop_duplicates(take_last=True), expected)
+        with tm.assert_produces_warning(FutureWarning):
+            tm.assert_index_equal(idx.drop_duplicates(take_last=True), expected)
 
     def test_multiindex_set_index(self):
         # segfault in #3308

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -4798,10 +4798,13 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
             sc.drop_duplicates(keep='last', inplace=True)
             assert_series_equal(sc, s[~expected])
             # deprecate take_last
-            assert_series_equal(s.duplicated(take_last=True), expected)
-            assert_series_equal(s.drop_duplicates(take_last=True), s[~expected])
+            with tm.assert_produces_warning(FutureWarning):
+                assert_series_equal(s.duplicated(take_last=True), expected)
+            with tm.assert_produces_warning(FutureWarning):
+                assert_series_equal(s.drop_duplicates(take_last=True), s[~expected])
             sc = s.copy()
-            sc.drop_duplicates(take_last=True, inplace=True)
+            with tm.assert_produces_warning(FutureWarning):
+                sc.drop_duplicates(take_last=True, inplace=True)
             assert_series_equal(sc, s[~expected])
 
             expected = Series([False, False, True, True])
@@ -4827,10 +4830,13 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
             sc.drop_duplicates(keep='last', inplace=True)
             assert_series_equal(sc, s[~expected])
             # deprecate take_last
-            assert_series_equal(s.duplicated(take_last=True), expected)
-            assert_series_equal(s.drop_duplicates(take_last=True), s[~expected])
+            with tm.assert_produces_warning(FutureWarning):
+                assert_series_equal(s.duplicated(take_last=True), expected)
+            with tm.assert_produces_warning(FutureWarning):
+                assert_series_equal(s.drop_duplicates(take_last=True), s[~expected])
             sc = s.copy()
-            sc.drop_duplicates(take_last=True, inplace=True)
+            with tm.assert_produces_warning(FutureWarning):
+                sc.drop_duplicates(take_last=True, inplace=True)
             assert_series_equal(sc, s[~expected])
 
             expected = Series([False, True, True, False, True, True, False])


### PR DESCRIPTION
Follow-up of #10236. Suppress unnecessary warnings during the test.
