### PR TITLE
BUG: Allow read_sql_table to read from views

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -142,6 +142,9 @@ Other enhancements
 - ``pd.merge`` will now allow duplicate column names if they are not merged upon (:issue:`10639`).
 
 - ``pd.pivot`` will now allow passing index as ``None`` (:issue:`3962`).
+
+- ``read_sql_table`` will now allow reading from views (:issue:`10750`).
+
 - ``drop_duplicates`` and ``duplicated`` now accept ``keep`` keyword to target first, last, and all duplicates. ``take_last`` keyword is deprecated, see :ref:`deprecations <whatsnew_0170.deprecations>` (:issue:`6511`, :issue:`8505`)
 
 .. ipython :: python

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -337,7 +337,7 @@ def read_sql_table(table_name, con, schema=None, index_col=None,
     from sqlalchemy.schema import MetaData
     meta = MetaData(con, schema=schema)
     try:
-        meta.reflect(only=[table_name])
+        meta.reflect(only=[table_name], views=True)
     except sqlalchemy.exc.InvalidRequestError:
         raise ValueError("Table %s not found" % table_name)
 

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -161,6 +161,12 @@ SQL_STRINGS = {
                 SELECT * FROM iris WHERE
                 "Name"=%(name)s AND "SepalLength"=%(length)s
                 """
+    },
+    'create_view': {
+        'sqlite': """
+                CREATE VIEW iris_view AS
+                SELECT * FROM iris
+                """
     }
 }
 
@@ -243,6 +249,10 @@ class PandasSQLTest(unittest.TestCase):
 
             for row in r:
                 self._get_exec().execute(ins, row)
+
+    def _load_iris_view(self):
+        self.drop_table('iris_view')
+        self._get_exec().execute(SQL_STRINGS['create_view'][self.flavor])
 
     def _check_iris_loaded_frame(self, iris_frame):
         pytype = iris_frame.dtypes[0].type
@@ -482,6 +492,7 @@ class _TestSQLApi(PandasSQLTest):
     def setUp(self):
         self.conn = self.connect()
         self._load_iris_data()
+        self._load_iris_view()
         self._load_test1_data()
         self._load_test2_data()
         self._load_test3_data()
@@ -490,6 +501,11 @@ class _TestSQLApi(PandasSQLTest):
     def test_read_sql_iris(self):
         iris_frame = sql.read_sql_query(
             "SELECT * FROM iris", self.conn)
+        self._check_iris_loaded_frame(iris_frame)
+
+    def test_read_sql_view(self):
+        iris_frame = sql.read_sql_query(
+            "SELECT * FROM iris_view", self.conn)
         self._check_iris_loaded_frame(iris_frame)
 
     def test_legacy_read_frame(self):


### PR DESCRIPTION
Solves #10750 

Follow-up from #10771

'read_sql_table'  will now allow reading from views. 

Added also a note in whatsnew and a unit test to check the behaviour.
