### PR TITLE
BUG: fix bounds for negative ints when using iloc (GH 10779)

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -658,3 +658,5 @@ Bug Fixes
 - Bug in ``DatetimeIndex.take`` and ``TimedeltaIndex.take`` may not raise ``IndexError`` against invalid index (:issue:`10295`)
 - Bug in ``Series([np.nan]).astype('M8[ms]')``, which now returns ``Series([pd.NaT])`` (:issue:`10747`)
 - Bug in ``PeriodIndex.order`` reset freq (:issue:`10295`)
+- Bug in ``iloc`` allowing memory outside bounds of a Series to be accessed with negative integers (:issue:`10779`)
+- Bug preventing access to the first index when using ``iloc`` with a list containing the appropriate negative integer (:issue:`10547`, :issue:`10779`)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1388,7 +1388,8 @@ class _iLocIndexer(_LocationIndexer):
         # return a boolean if we have a valid integer indexer
 
         ax = self.obj._get_axis(axis)
-        if key > len(ax):
+        l = len(ax)
+        if key >= l or key < -l:
             raise IndexError("single positional indexer is out-of-bounds")
         return True
 
@@ -1400,7 +1401,7 @@ class _iLocIndexer(_LocationIndexer):
         arr = np.array(key)
         ax = self.obj._get_axis(axis)
         l = len(ax)
-        if len(arr) and (arr.max() >= l or arr.min() <= -l):
+        if len(arr) and (arr.max() >= l or arr.min() < -l):
             raise IndexError("positional indexers are out-of-bounds")
 
         return True


### PR DESCRIPTION
This fixes the issues raised in [GH 10779](https://github.com/pydata/pandas/issues/10779).
closes #10547 

Previously, negative integers used in `iloc` were not stopped from going beyond the bounds of the Series. For instance, if `s = pd.Series([1,2,3])` then `s.iloc[-4]` returned bytes from memory outside `s`. This will now raise an IndexError instead.

Additionally, it was not possible to access the first row (index 0) of a Series or DataFrame with a negative integer in a list. For example, `s.iloc[[-3]]` raised an IndexError instead of returning a Series containing the first row of `s`. The behaviour of `iloc` has been changed to allow this.
