### PR TITLE
API: Series.sum() will now return 0.0 for all-NaN series

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -551,6 +551,20 @@ Other API Changes
 
 - Improved error message when concatenating an empty iterable of dataframes (:issue:`9157`)
 
+- ``Series.sum()`` will now return 0.0, and ``Series.prod()`` will return 1.0 for all-NaN series rather than ``NaN``; this is for compat with ``numpy`` >= 1.8.2 and ``bottleneck`` >= 1.0 (:issue:`9422`).
+
+   .. ipython:: python
+
+      s = Series([np.nan])
+      s.sum()
+      s.sum(skipna=False)
+      s.prod()
+      s.prod(skipna=False)
+
+   .. warning::
+
+      ``bottleneck`` is used for these calculations. If you have ``bottleneck`` < 1.0, then these will all return ``NaN``.
+
 .. _whatsnew_0170.deprecations:
 
 Deprecations

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -27,6 +27,7 @@ from distutils.version import LooseVersion
 _np_version = np.version.short_version
 _np_version_under1p8 = LooseVersion(_np_version) < '1.8'
 _np_version_under1p9 = LooseVersion(_np_version) < '1.9'
+_np_version_under1p10 = LooseVersion(_np_version) < '1.10'
 
 
 from pandas.info import __doc__

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -9,7 +9,7 @@ except ImportError:  # pragma: no cover
     _USE_BOTTLENECK = False
 
 import pandas.hashtable as _hash
-from pandas import compat, lib, algos, tslib
+from pandas import compat, lib, algos, tslib, _np_version_under1p10
 from pandas.compat import builtins
 from pandas.core.common import (isnull, notnull, _values_from_object,
                                 _maybe_upcast_putmask,
@@ -243,12 +243,14 @@ def nanall(values, axis=None, skipna=True):
 @disallow('M8')
 @bottleneck_switch(zero_value=0)
 def nansum(values, axis=None, skipna=True):
+    dtype = values.dtype
     values, mask, dtype, dtype_max = _get_values(values, skipna, 0)
     dtype_sum = dtype_max
     if is_float_dtype(dtype):
         dtype_sum = dtype
     the_sum = values.sum(axis, dtype=dtype_sum)
-    the_sum = _maybe_null_out(the_sum, axis, mask)
+    the_sum = _maybe_null_out(the_sum, axis, mask, allow_all_null=not skipna,
+                              dtype=dtype, fill_value=0)
 
     return _wrap_results(the_sum, dtype)
 
@@ -549,12 +551,14 @@ def nankurt(values, axis=None, skipna=True):
 
 @disallow('M8','m8')
 def nanprod(values, axis=None, skipna=True):
+    dtype = values.dtype
     mask = isnull(values)
     if skipna and not is_any_int_dtype(values):
         values = values.copy()
         values[mask] = 1
     result = values.prod(axis)
-    return _maybe_null_out(result, axis, mask)
+    return _maybe_null_out(result, axis, mask, allow_all_null=not skipna, dtype=dtype,
+                           fill_value=1)
 
 
 def _maybe_arg_null_out(result, axis, mask, skipna):
@@ -588,7 +592,29 @@ def _get_counts(mask, axis, dtype=float):
         return np.array(count, dtype=dtype)
 
 
-def _maybe_null_out(result, axis, mask):
+def _maybe_null_out(result, axis, mask, allow_all_null=True, dtype=None, fill_value=None):
+
+
+    # 9422
+    # if we have all nulls we normally return a
+    # null, but for numpy >= 1.8.2 and bottleneck >= 1.0
+    # nansum/nanprod are set to be the fill_values
+    if not allow_all_null and dtype is not None:
+
+        if is_complex_dtype(dtype) or not is_float_dtype(dtype):
+
+            # we don't mask complex
+            # object or non-floats
+            # if numpy changes this, we will as well
+
+            # IOW, np.nansum(np.array([np.nan],dtype='object')) is np.nan
+            # https://github.com/numpy/numpy/issues/6209
+            allow_all_null = True
+            fill_value = np.nan
+
+    else:
+        fill_value = np.nan
+
     if axis is not None and getattr(result, 'ndim', False):
         null_mask = (mask.shape[axis] - mask.sum(axis)) == 0
         if np.any(null_mask):
@@ -596,11 +622,19 @@ def _maybe_null_out(result, axis, mask):
                 result = result.astype('c16')
             else:
                 result = result.astype('f8')
+
+            # mark nans
             result[null_mask] = np.nan
+
+            # masker if for only all nan
+            if not allow_all_null:
+                null_mask = mask.all(axis)
+                if null_mask.any():
+                    result[null_mask] = fill_value
     else:
         null_mask = mask.size - mask.sum()
-        if null_mask == 0:
-            result = np.nan
+        if null_mask == 0 and (mask.size > 0 or allow_all_null):
+            result = fill_value
 
     return result
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -12230,10 +12230,10 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_series_equal(result, expected)
 
     def test_sum(self):
-        self._check_stat_op('sum', np.sum, has_numeric_only=True)
+        self._check_stat_op('sum', np.sum, has_numeric_only=True, fillna=0.0)
 
         # mixed types (with upcasting happening)
-        self._check_stat_op('sum', np.sum, frame=self.mixed_float.astype('float32'),
+        self._check_stat_op('sum', np.sum, frame=self.mixed_float.astype('float32'), fillna=0.0,
                             has_numeric_only=True, check_dtype=False, check_less_precise=True)
 
     def test_stat_operators_attempt_obj_array(self):
@@ -12247,23 +12247,32 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df1 = DataFrame(data, index=['foo', 'bar', 'baz'],
                         dtype='O')
         methods = ['sum', 'mean', 'prod', 'var', 'std', 'skew', 'min', 'max']
+        fills = [0.0, np.nan, 1.0, np.nan, np.nan, np.nan, np.nan, np.nan]
 
         # GH #676
         df2 = DataFrame({0: [np.nan, 2], 1: [np.nan, 3],
                         2: [np.nan, 4]}, dtype=object)
 
         for df in [df1, df2]:
-            for meth in methods:
+            for meth, fill in zip(methods, fills):
                 self.assertEqual(df.values.dtype, np.object_)
                 result = getattr(df, meth)(1)
+
+                # 9422
+                # all-NaN object array is still NaN, while floats are not :<
                 expected = getattr(df.astype('f8'), meth)(1)
+                if not np.isnan(fill):
+                    mask = df.isnull().all(1)
+                    if mask.any():
+                        expected[mask] = np.nan
+
                 assert_series_equal(result, expected)
 
     def test_mean(self):
         self._check_stat_op('mean', np.mean, check_dates=True)
 
     def test_product(self):
-        self._check_stat_op('product', np.prod)
+        self._check_stat_op('product', np.prod, fillna=1.0)
 
     def test_median(self):
         def wrapper(x):
@@ -12435,7 +12444,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
     def _check_stat_op(self, name, alternative, frame=None, has_skipna=True,
                        has_numeric_only=False, check_dtype=True, check_dates=False,
-                       check_less_precise=False):
+                       check_less_precise=False, fillna=None):
         if frame is None:
             frame = self.frame
             # set some NAs
@@ -12478,11 +12487,20 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             wrapper = alternative
 
         result0 = f(axis=0)
-        result1 = f(axis=1)
-        assert_series_equal(result0, frame.apply(skipna_wrapper),
+        expected0 = frame.apply(skipna_wrapper)
+        assert_series_equal(result0, expected0,
                             check_dtype=check_dtype,
                             check_less_precise=check_less_precise)
-        assert_series_equal(result1, frame.apply(skipna_wrapper, axis=1),
+
+        result1 = f(axis=1)
+
+        # 9422
+        # all-nan rows get the fillna
+        expected1 = frame.apply(skipna_wrapper, axis=1)
+        if fillna is not None:
+            expected1[isnull(frame).all(axis=1)] = fillna
+
+        assert_series_equal(result1, expected1,
                             check_dtype=False,
                             check_less_precise=check_less_precise)
 
@@ -12513,8 +12531,14 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             all_na = self.frame * np.NaN
             r0 = getattr(all_na, name)(axis=0)
             r1 = getattr(all_na, name)(axis=1)
-            self.assertTrue(np.isnan(r0).all())
-            self.assertTrue(np.isnan(r1).all())
+
+            # 9422
+            if fillna is not None:
+                self.assertTrue((r0==fillna).all())
+                self.assertTrue((r1==fillna).all())
+            else:
+                self.assertTrue(np.isnan(r0).all())
+                self.assertTrue(np.isnan(r1).all())
 
     def test_mode(self):
         df = pd.DataFrame({"A": [12, 12, 11, 12, 19, 11],

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -2762,7 +2762,9 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
                     self.assertTrue(bn.__version__ >= LooseVersion('1.0'))
                     self.assertEqual(f(allna),0.0)
                 except:
-                    self.assertTrue(np.isnan(f(allna)))
+
+                    # 10815 pandas does as well
+                    self.assertEqual(f(allna),0.0)
 
             # dtype=object with None, it works!
             s = Series([1, 2, 3, None, 5])


### PR DESCRIPTION
compat with `numpy` >= 1.8.2 and `bottleneck` >= 1.0, #9422
note that passing skipna=False will still return a NaN
