### PR TITLE
Fix handling of EOF in 'c' csv parser

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -649,6 +649,7 @@ Bug Fixes
 - Bug in ``Categorical`` may not representing properly when category contains ``tz`` or ``Period`` (:issue:`10713`)
 - Bug in ``Categorical.__iter__`` may not returning correct ``datetime`` and ``Period`` (:issue:`10713`)
 
+- Bug in ``read_csv`` with ``engine='c'``: EOF preceded by a comment, blank line, etc. was not handled correctly (:issue:`10728`, :issue:`10548`)
 
 - Reading "famafrench" data via ``DataReader`` results in HTTP 404 error because of the website url is changed (:issue:`10591`).
 - Bug in ``read_msgpack`` where DataFrame to decode has duplicate column names (:issue:`9618`)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -241,6 +241,12 @@ def _skip_if_no_cday():
         raise nose.SkipTest("CustomBusinessDay not available.")
 
 
+def _skip_if_python26():
+    if sys.version_info[:2] == (2, 6):
+        import nose
+        raise nose.SkipTest("skipping on python2.6")
+
+
 #------------------------------------------------------------------------------
 # locale utilities
 


### PR DESCRIPTION
Fixes GH #10728
fixes #10548.

Also fixes:
- '\r' followed by EOF should be considered a blank line
- Escape character followed by EOF should produce an exception
- Line containing only whitespace should be skipped if `skip_blank_lines` and `delim_whitespace` are both `True`
