### PR TITLE
PERF: value_counts_float64 #10821

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -585,7 +585,7 @@ Performance Improvements
 - Improved performance of ``Series.isin`` for datetimelike/integer Series (:issue:`10287`)
 - 20x improvement in ``concat`` of Categoricals when categories are identical (:issue:`10587`)
 - Improved performance of ``to_datetime`` when specified format string is ISO8601 (:issue:`10178`)
-
+- 2x improvement of ``Series.value_counts`` for float dtype (:issue:`10821`)
 
 .. _whatsnew_0170.bug_fixes:
 

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -232,7 +232,7 @@ def value_counts(values, sort=True, ascending=False, normalize=False,
                 values = PeriodIndex(values, name=name)
 
             values = values.view(np.int64)
-            keys, counts = htable.value_count_int64(values)
+            keys, counts = htable.value_count_scalar64(values, dropna)
 
             if dropna:
                 from pandas.tslib import iNaT
@@ -244,10 +244,10 @@ def value_counts(values, sort=True, ascending=False, normalize=False,
 
         elif com.is_integer_dtype(dtype):
             values = com._ensure_int64(values)
-            keys, counts = htable.value_count_int64(values)
+            keys, counts = htable.value_count_scalar64(values, dropna)
         elif com.is_float_dtype(dtype):
             values = com._ensure_float64(values)
-            keys, counts = htable.value_count_float64(values, dropna)
+            keys, counts = htable.value_count_scalar64(values, dropna)
 
         else:
             values = com._ensure_object(values)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -245,6 +245,9 @@ def value_counts(values, sort=True, ascending=False, normalize=False,
         elif com.is_integer_dtype(dtype):
             values = com._ensure_int64(values)
             keys, counts = htable.value_count_int64(values)
+        elif com.is_float_dtype(dtype):
+            values = com._ensure_float64(values)
+            keys, counts = htable.value_count_float64(values, dropna)
 
         else:
             values = com._ensure_object(values)

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -1030,7 +1030,7 @@ class Categorical(PandasObject):
         from pandas.core.index import CategoricalIndex
 
         cat = self.dropna() if dropna else self
-        keys, counts = htable.value_count_int64(com._ensure_int64(cat._codes))
+        keys, counts = htable.value_count_scalar64(com._ensure_int64(cat._codes), dropna)
         result = Series(counts, index=keys)
 
         ix = np.arange(len(cat.categories), dtype='int64')

--- a/vb_suite/groupby.py
+++ b/vb_suite/groupby.py
@@ -194,6 +194,15 @@ s = Series(np.tile(uniques, N // K))
 series_value_counts_strings = Benchmark('s.value_counts()', setup,
                                         start_date=datetime(2011, 10, 21))
 
+#value_counts on float dtype
+
+setup = common_setup + """
+s = Series(np.random.randint(0, 1000, size=100000)).astype(float)
+"""
+
+series_value_counts_float64 = Benchmark('s.value_counts()', setup,
+                                      start_date=datetime(2015, 8, 17))
+
 #----------------------------------------------------------------------
 # pivot_table
 


### PR DESCRIPTION
Adresses #10821 - I get a doubling of performance for `value_counts` for a `Series` with a float dtype.  Couldn't think of any new tests needed not covered by existing [here](https://github.com/pydata/pandas/blob/master/pandas/tests/test_algos.py#L416)

```
In [1]: f = np.hstack([np.hstack(np.linspace(0,1,1000)  for _ in range(1000)), np.array([np.nan] * 1000)])
   ...: i = range(1000) * 1001
   ...: df = pd.DataFrame({'f':f, 'i':i})
```
### master

```
In [2]: %timeit df['i'].value_counts()
10 loops, best of 3: 21.1 ms per loop

In [3]: %timeit df['f'].value_counts()
10 loops, best of 3: 114 ms per loop
```
### pr

```
In [3]: %timeit df['i'].value_counts()
10 loops, best of 3: 21 ms per loop

In [2]: %timeit df['f'].value_counts()
10 loops, best of 3: 56 ms per loop
```
