### PR TITLE
DataFrame to dict with index orientation.

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -174,6 +174,8 @@ Other enhancements
 
 - ``msgpack`` submodule has been updated to 0.4.6 with backward compatibility (:issue:`10581`)
 
+- ``DataFrame.to_dict`` now accepts the *index* option in ``orient`` keyword argument.
+
 .. ipython :: python
 
    s = pd.Series(['A', 'B', 'C', 'A', 'B', 'D'])

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -174,7 +174,7 @@ Other enhancements
 
 - ``msgpack`` submodule has been updated to 0.4.6 with backward compatibility (:issue:`10581`)
 
-- ``DataFrame.to_dict`` now accepts the *index* option in ``orient`` keyword argument.
+- ``DataFrame.to_dict`` now accepts the *index* option in ``orient`` keyword argument (:issue:`10844`).
 
 .. ipython :: python
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -760,6 +760,8 @@ class DataFrame(NDFrame):
               [{column -> value}, ... , {column -> value}]
             - index : dict like {index -> {column -> value}}
 
+            .. versionadded:: 0.17.0
+
             Abbreviations are allowed. `s` indicates `series` and `sp`
             indicates `split`.
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -748,7 +748,7 @@ class DataFrame(NDFrame):
 
         Parameters
         ----------
-        orient : str {'dict', 'list', 'series', 'split', 'records'}
+        orient : str {'dict', 'list', 'series', 'split', 'records', 'index'}
             Determines the type of the values of the dictionary.
 
             - dict (default) : dict like {column -> {index -> value}}
@@ -758,6 +758,7 @@ class DataFrame(NDFrame):
               {index -> [index], columns -> [columns], data -> [values]}
             - records : list like
               [{column -> value}, ... , {column -> value}]
+            - index : dict like {index -> {column -> value}}
 
             Abbreviations are allowed. `s` indicates `series` and `sp`
             indicates `split`.
@@ -782,6 +783,8 @@ class DataFrame(NDFrame):
         elif orient.lower().startswith('r'):
             return [dict((k, v) for k, v in zip(self.columns, row))
                     for row in self.values]
+        elif orient.lower().startswith('i'):
+            return dict((k, v.to_dict()) for k, v in self.iterrows())
         else:
             raise ValueError("orient '%s' not understood" % orient)
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4474,6 +4474,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         tm.assert_almost_equal(recons_data, expected_records)
 
+        # GH10844
         recons_data = DataFrame(test_data).to_dict("i")
 
         for k, v in compat.iteritems(test_data):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4474,9 +4474,15 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         tm.assert_almost_equal(recons_data, expected_records)
 
+        recons_data = DataFrame(test_data).to_dict("i")
+
+        for k, v in compat.iteritems(test_data):
+            for k2, v2 in compat.iteritems(v):
+                self.assertEqual(v2, recons_data[k2][k])
+
     def test_to_dict_invalid_orient(self):
         df = DataFrame({'A':[0, 1]})
-        self.assertRaises(ValueError, df.to_dict, orient='invalid')
+        self.assertRaises(ValueError, df.to_dict, orient='xinvalid')
 
     def test_to_records_dt64(self):
         df = DataFrame([["one", "two", "three"],


### PR DESCRIPTION
The method `DataFrame.to_dict` didn't have an option for index orientation unlike its cousin `to_json`, which does have.
