### PR TITLE
removes categories & ordered from CategoricalIndex attributes

### DIFF
--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -2910,7 +2910,7 @@ class CategoricalIndex(Index, PandasDelegate):
 
     _typ = 'categoricalindex'
     _engine_type = _index.Int64Engine
-    _attributes = ['name','categories','ordered']
+    _attributes = ['name']
 
     def __new__(cls, data=None, categories=None, ordered=None, dtype=None, copy=False, name=None, fastpath=False, **kwargs):
 


### PR DESCRIPTION
`categories` and `ordered` are properties not attributes ([index.py#L3085-L3091](https://github.com/pydata/pandas/blob/3e35c842f37265ac7339908869d4cc7bdef784d9/pandas/core/index.py#L3085-L3091)). The side effect is that the categories are rehashed too often:

on master:

``` ipython
In [1]: from pandas.core.index import CategoricalIndex

In [2]: np.random.seed(2718281)

In [3]: n = 100000

In [4]: val = map('{:->4}'.format, np.random.randint(0, 10000, n))

In [5]: idx = CategoricalIndex(list(val))

In [6]: %timeit idx[::-1]
100 loops, best of 3: 14.1 ms per loop

In [7]: %timeit idx[idx.argsort()]
10 loops, best of 3: 22 ms per loop

In [8]: cProfile.run("idx[::-1]", sort=1)
         174 function calls (171 primitive calls) in 0.025 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.014    0.014    0.014    0.014 {method 'lookup' of 'pandas.hashtable.PyObjectHashTable' objects}
        1    0.004    0.004    0.004    0.004 {pandas.algos.take_1d_object_object}
        1    0.003    0.003    0.003    0.003 {method 'map_locations' of 'pandas.hashtable.PyObjectHashTable' objects}
```

on branch:

``` ipython
In [6]: %timeit idx[::-1]
The slowest run took 6.78 times longer than the fastest. This could mean that an intermediate result is being cached
10000 loops, best of 3: 29 µs per loop

In [7]: %timeit idx[idx.argsort()]
100 loops, best of 3: 9.38 ms per loop
```
