### PR TITLE
Tests for ABC Types

### DIFF
--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -104,8 +104,6 @@ def test_abc_types():
     assert(isinstance(period, com.ABCPeriod))
 
 
-
-
 def test_notnull():
     assert notnull(1.)
     assert not notnull(None)

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -6,8 +6,9 @@ import re
 import nose
 from nose.tools import assert_equal, assert_true
 import numpy as np
+import pandas as pd
 from pandas.tslib import iNaT, NaT
-from pandas import Series, DataFrame, date_range, DatetimeIndex, Timestamp, Float64Index
+from pandas import Series, DataFrame, date_range, DatetimeIndex, Timestamp
 from pandas import compat
 from pandas.compat import range, long, lrange, lmap, u
 from pandas.core.common import notnull, isnull, array_equivalent
@@ -40,6 +41,7 @@ def test_is_sequence():
 
     assert(not is_seq(A()))
 
+
 def test_get_callable_name():
     from functools import partial
     getname = com._get_callable_name
@@ -49,6 +51,7 @@ def test_get_callable_name():
     lambda_ = lambda x: x
     part1 = partial(fn)
     part2 = partial(part1)
+
     class somecall(object):
         def __call__(self):
             return x
@@ -59,6 +62,48 @@ def test_get_callable_name():
     assert getname(part2) == 'fn'
     assert getname(somecall()) == 'somecall'
     assert getname(1) is None
+
+
+def test_abc_types():
+    tuples = [('bar', 'one'), ('bar', 'two')]
+    names = ['first', 'second']
+    values = [1, 2, 3, 4]
+    index = pd.Index(['a', 'b', 'c'])
+    int64_index = pd.Int64Index([1, 2, 3])
+    float64_index = pd.Float64Index([1, 2, 3])
+    multi_index = pd.MultiIndex.from_tuples(tuples, names=names)
+    datetime_index = pd.to_datetime(['2000/1/1', '2010/1/1'])
+    timedelta_index = pd.to_timedelta(np.arange(5), unit='s')
+    period_index = pd.period_range('2000/1/1', '2010/1/1/', freq='M')
+    categorical = pd.Categorical([1, 2, 3, 4], categories=[4, 2, 3, 1])
+    categorical_df = pd.DataFrame({"values": values}, index=categorical)
+    categorical_index = categorical_df.index
+    series = pd.Series(values)
+    df = pd.DataFrame({"names": names}, index=multi_index)
+    panel = df.to_panel()
+    sparse_series = series.to_sparse()
+    sparse_array = pd.SparseArray(np.random.randn(10))
+    period = pd.Period('2012', freq='A-DEC')
+
+    assert(isinstance(index, com.ABCIndex))
+    assert(isinstance(int64_index, com.ABCInt64Index))
+    assert(isinstance(float64_index, com.ABCFloat64Index))
+    assert(isinstance(multi_index, com.ABCMultiIndex))
+    assert(isinstance(datetime_index, com.ABCDatetimeIndex))
+    assert(isinstance(timedelta_index, com.ABCTimedeltaIndex))
+    assert(isinstance(period_index, com.ABCPeriodIndex))
+    assert(isinstance(categorical_index, com.ABCCategoricalIndex))
+    assert(isinstance(index, com.ABCIndexClass))
+    assert(isinstance(int64_index, com.ABCIndexClass))
+    assert(isinstance(series, com.ABCSeries))
+    assert(isinstance(df, com.ABCDataFrame))
+    assert(isinstance(panel, com.ABCPanel))
+    assert(isinstance(sparse_series, com.ABCSparseSeries))
+    assert(isinstance(sparse_array, com.ABCSparseArray))
+    assert(isinstance(categorical, com.ABCCategorical))
+    assert(isinstance(period, com.ABCPeriod))
+
+
 
 
 def test_notnull():
@@ -229,8 +274,6 @@ def test_array_equivalent():
     assert not array_equivalent(np.array([np.nan, 1, np.nan]),
                                 np.array([np.nan, 2, np.nan]))
     assert not array_equivalent(np.array(['a', 'b', 'c', 'd']), np.array(['e', 'e']))
-    assert array_equivalent(Float64Index([0, np.nan]), Float64Index([0, np.nan]))
-    assert not array_equivalent(Float64Index([0, np.nan]), Float64Index([1, np.nan]))
     assert array_equivalent(DatetimeIndex([0, np.nan]), DatetimeIndex([0, np.nan]))
     assert not array_equivalent(DatetimeIndex([0, np.nan]), DatetimeIndex([1, np.nan]))
 
@@ -942,7 +985,7 @@ class TestTake(tm.TestCase):
 
     def test_2d_datetime64(self):
         # 2005/01/01 - 2006/01/01
-        arr = np.random.randint(long(11045376), long(11360736), (5,3))*100000000000
+        arr = np.random.randint(long(11045376), long(11360736), (5, 3))*100000000000
         arr = arr.view(dtype='datetime64[ns]')
         indexer = [0, 2, -1, 1, -1]
 
@@ -1025,6 +1068,7 @@ def test_dict_compat():
     assert(com._dict_compat(data_datetime64) == expected)
     assert(com._dict_compat(expected) == expected)
     assert(com._dict_compat(data_unchanged) == data_unchanged)
+
 
 def test_possibly_convert_objects_copy():
     values = np.array([1, 2])


### PR DESCRIPTION
closes #10828

I used self.assertIsInstance(obj, type) and inlined as many of the expressions as I could while staying PEP8 compliant. I added in the two tests that I took out, that was an accident. Let me know if this looks okay!
