### PR TITLE
BUG: import of maybe_convert_indices in pandas.core.index.py, #10610

### DIFF
--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -971,11 +971,12 @@ class Index(IndexOpsMixin, PandasObject):
 
             if self.inferred_type == 'mixed-integer':
                 indexer = self.get_indexer(keyarr)
-                if not np.all(np.in1d(indexer, self.values)):
-                    raise IndexError("At least one item not found in index.")
                 if (indexer >= 0).all():
                     return indexer
-
+                # missing values are flagged as -1 by get_indexer and negative indices are already
+                # converted to positive indices in the above if-statement, so the negative flags are changed to
+                # values outside the range of indices so as to trigger an IndexError in maybe_convert_indices
+                indexer[indexer < 0] = len(self)
                 from pandas.core.indexing import maybe_convert_indices
                 return maybe_convert_indices(indexer, len(self))
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -971,11 +971,13 @@ class Index(IndexOpsMixin, PandasObject):
 
             if self.inferred_type == 'mixed-integer':
                 indexer = self.get_indexer(keyarr)
+                if not np.all(np.in1d(indexer, self.values)):
+                    raise IndexError("At least one item not found in index.")
                 if (indexer >= 0).all():
                     return indexer
 
-                from pandas.core.indexing import _maybe_convert_indices
-                return _maybe_convert_indices(indexer, len(self))
+                from pandas.core.indexing import maybe_convert_indices
+                return maybe_convert_indices(indexer, len(self))
 
             elif not self.inferred_type == 'integer':
                 return keyarr

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -1723,6 +1723,10 @@ class TestIndex(Base, tm.TestCase):
             df.index == index_a
         tm.assert_numpy_array_equal(index_a == mi3, np.array([False, False, False]))
 
+    def test_multitype_list_index_access(self):
+        df = pd.DataFrame(np.random.random((10, 5)), columns=["a"] + [20, 21, 22, 23])
+        with self.assertRaises(IndexError):
+            vals = df[[22, 26, -8]]
 
 class TestCategoricalIndex(Base, tm.TestCase):
     _holder = CategoricalIndex

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -1723,6 +1723,11 @@ class TestIndex(Base, tm.TestCase):
             df.index == index_a
         tm.assert_numpy_array_equal(index_a == mi3, np.array([False, False, False]))
 
+    def test_multitype_list_index_access(self):
+        df = pd.DataFrame(np.random.random((10, 5)), columns=["a"] + [20, 21, 22, 23])
+        with self.assertRaises(IndexError):
+            vals = df[[22, 26, -8]]
+        self.assertEqual(df[21].shape[0], df.shape[0])
 
 class TestCategoricalIndex(Base, tm.TestCase):
     _holder = CategoricalIndex


### PR DESCRIPTION
closes #10610 

I fixed the import statement and added a test to check for proper behavior when accessing a mixed-integer index with a list of values.
