### PR TITLE
CLN: Series.asof uses reindex GH10343

### DIFF
--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1316,22 +1316,6 @@ class Index(IndexOpsMixin, PandasObject):
                 loc = loc.indices(len(self))[-1]
             return self[loc]
 
-    def asof_locs(self, where, mask):
-        """
-        where : array of timestamps
-        mask : array of booleans where data is not NA
-
-        """
-        locs = self.values[mask].searchsorted(where.values, side='right')
-
-        locs = np.where(locs > 0, locs - 1, 0)
-        result = np.arange(len(self))[mask].take(locs)
-
-        first = mask.argmax()
-        result[(locs == 0) & (where < self.values[first])] = -1
-
-        return result
-
     def order(self, return_indexer=False, ascending=True):
         """
         Return sorted copy of Index

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2461,6 +2461,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         If there is no good value, NaN is returned.
 
+        Note that this is really just a convenient shorthand for `Series.reindex`,
+        and is equivalent to `s.dropna().reindex(where, method='ffill')` for
+        an array of dates.
+
         Parameters
         ----------
         where : date or array of dates
@@ -2476,29 +2480,18 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         if isinstance(where, compat.string_types):
             where = datetools.to_datetime(where)
 
-        values = self.values
-
         if not hasattr(where, '__iter__'):
-            start = self.index[0]
-            if isinstance(self.index, PeriodIndex):
-                where = Period(where, freq=self.index.freq).ordinal
-                start = start.ordinal
+            is_scalar = True
+            where = [where]
+        else:
+            is_scalar = False
 
-            if where < start:
-                return np.nan
-            loc = self.index.searchsorted(where, side='right')
-            if loc > 0:
-                loc -= 1
-            while isnull(values[loc]) and loc > 0:
-                loc -= 1
-            return values[loc]
+        ret = self.dropna().reindex(where, method='ffill')
 
-        if not isinstance(where, Index):
-            where = Index(where)
-
-        locs = self.index.asof_locs(where, notnull(values))
-        new_values = com.take_1d(values, locs)
-        return self._constructor(new_values, index=where).__finalize__(self)
+        if is_scalar:
+            return ret.iloc[0]
+        else:
+            return ret
 
     def to_timestamp(self, freq=None, how='start', copy=True):
         """

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -318,26 +318,6 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
     def _formatter_func(self):
         return lambda x: "'%s'" % x
 
-    def asof_locs(self, where, mask):
-        """
-        where : array of timestamps
-        mask : array of booleans where data is not NA
-
-        """
-        where_idx = where
-        if isinstance(where_idx, DatetimeIndex):
-            where_idx = PeriodIndex(where_idx.values, freq=self.freq)
-
-        locs = self.values[mask].searchsorted(where_idx.values, side='right')
-
-        locs = np.where(locs > 0, locs - 1, 0)
-        result = np.arange(len(self))[mask].take(locs)
-
-        first = mask.argmax()
-        result[(locs == 0) & (where_idx.values < self.values[first])] = -1
-
-        return result
-
     def _array_values(self):
         return self.asobject
 


### PR DESCRIPTION
closes #10343 as discussed in #10345 , changed `Series.asof` to use `reindex` internally, and remove the unused leftovers from index classes. All existing tests in test_series.py:TestSeries.test_asof pass with the new implementation.
