### PR TITLE
PERF: uses bincount instead of hash table in categorical value counts

### DIFF
--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -9,3 +9,19 @@ class concat_categorical(object):
 
     def time_concat_categorical(self):
         concat([self.s, self.s])
+
+
+class categorical_value_counts(object):
+    goal_time = 1
+
+    def setup(self):
+        n = 500000
+        np.random.seed(2718281)
+        arr = ['s%04d' % i for i in np.random.randint(0, n // 10, size=n)]
+        self.ts = Series(arr).astype('category')
+
+    def time_value_counts(self):
+        self.ts.value_counts(dropna=False)
+
+    def time_value_counts_dropna(self):
+        self.ts.value_counts(dropna=True)

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -660,6 +660,7 @@ Removal of prior version deprecations/changes
 Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 - Added vbench benchmarks for alternative ExcelWriter engines and reading Excel files (:issue:`7171`)
+- Performance improvements in ``Categorical.value_counts`` (:issue:`10804`)
 
 - 4x improvement in ``timedelta`` string parsing (:issue:`6755`, :issue:`10426`)
 - 8x improvement in ``timedelta64`` and ``datetime64`` ops (:issue:`6755`)


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/10804

``` ipython
In [1]: np.random.seed(2718281)

In [2]: n = 500000

In [3]: u = int(0.1*n)

In [4]: arr = ["s%04d" % i for i in np.random.randint(0, u, size=n)]

In [5]: ts = pd.Series(arr).astype('category')

In [6]: %timeit ts.value_counts()
10 loops, best of 3: 82.7 ms per loop
```

on branch:

``` ipython
In [6]: %timeit ts.value_counts()
10 loops, best of 3: 31.3 ms per loop
```
