### PR TITLE
BUG: DataFrame.plot may raise IndexError / show unnessesary minor ticklabels

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -824,3 +824,5 @@ Bug Fixes
 - Bug in ``DataFrame.where`` when handling Series slicing (:issue:`10218`, :issue:`9558`)
 - Bug where ``pd.read_gbq`` throws ``ValueError`` when Bigquery returns zero rows (:issue:`10273`)
 - Bug in ``to_json`` which was causing segmentation fault when serializing 0-rank ndarray (:issue:`9576`)
+- Bug in plotting functions may raise ``IndexError`` when plotted on ``GridSpec`` (:issue:`10819`)
+- Bug in plot result may show unnecessary minor ticklabels (:issue:`10657`)


### PR DESCRIPTION
Closes #10657. Closes #10819. Both are related to the logic how `pandas` detects axes layout. Use current logic as much to support cases like #7457, and added error handing logic for gridspec.

Following is an example notebook how the fix works.
- https://gist.github.com/sinhrks/2d29e2e8ef26f2757e92

CC @TomAugspurger @JanSchulz @heelancd @williamsmj
