### PR TITLE
ERR/DEPR: Fix quantile error message / remove percentile_width

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -654,6 +654,7 @@ Removal of prior version deprecations/changes
 
 - Remove use of some deprecated numpy comparison operations, mainly in tests. (:issue:`10569`)
 - Removal of ``na_last`` parameters from ``Series.order()`` and ``Series.sort()``, in favor of ``na_position``, xref (:issue:`5231`)
+- Remove of ``percentile_width`` from ``.describe()``, in favor of ``percentiles``. (:issue:`7088`)
 
 .. _whatsnew_0170.performance:
 
@@ -678,6 +679,7 @@ Bug Fixes
 - Bug in ``DataFrame.apply`` when function returns categorical series. (:issue:`9573`)
 - Bug in ``to_datetime`` with invalid dates and formats supplied (:issue:`10154`)
 - Bug in ``Index.drop_duplicates`` dropping name(s) (:issue:`10115`)
+- Bug in ``Series.quantile`` dropping name (:issue:`10881`)
 - Bug in ``pd.Series`` when setting a value on an empty ``Series`` whose index has a frequency. (:issue:`10193`)
 - Bug in ``pd.Series.interpolate`` with invalid ``order`` keyword values. (:issue:`10633`)
 - Bug in ``DataFrame.plot`` raises ``ValueError`` when color name is specified by multiple characters (:issue:`10387`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4684,6 +4684,7 @@ class DataFrame(NDFrame):
         0.1  1.3   3.7
         0.5  2.5  55.0
         """
+        self._check_percentile(q)
         per = np.asarray(q) * 100
 
         if not com.is_list_like(per):
@@ -4718,7 +4719,9 @@ class DataFrame(NDFrame):
 
         quantiles = [[f(vals, x) for x in per]
                      for (_, vals) in data.iteritems()]
-        result = DataFrame(quantiles, index=data._info_axis, columns=q).T
+
+        result = self._constructor(quantiles, index=data._info_axis,
+                                   columns=q).T
         if len(is_dt_col) > 0:
             result[is_dt_col] = result[is_dt_col].applymap(lib.Timestamp)
         if squeeze:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1266,11 +1266,12 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         dtype: float64
         """
         valid = self.dropna()
+        self._check_percentile(q)
 
         def multi(values, qs):
             if com.is_list_like(qs):
-                return Series([_quantile(values, x*100)
-                               for x in qs], index=qs)
+                values = [_quantile(values, x*100) for x in qs]
+                return self._constructor(values, index=qs, name=self.name)
             else:
                 return _quantile(values, qs*100)
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -12837,6 +12837,12 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                              index=[0.5], columns=[0, 1])
         assert_frame_equal(result, expected)
 
+    def test_quantile_invalid(self):
+        msg = 'percentiles should all be in the interval \\[0, 1\\]'
+        for invalid in [-1, 2, [0.5, -1], [0.5, 2]]:
+            with tm.assertRaisesRegexp(ValueError, msg):
+                self.tsframe.quantile(invalid)
+
     def test_cumsum(self):
         self.tsframe.ix[5:10, 0] = nan
         self.tsframe.ix[10:15, 1] = nan

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -909,17 +909,6 @@ class TestSeries(tm.TestCase, Generic):
         _ = self.series.describe()
         _ = self.ts.describe()
 
-    def test_describe_percentiles(self):
-        with tm.assert_produces_warning(FutureWarning):
-            desc = self.series.describe(percentile_width=50)
-        assert '75%' in desc.index
-        assert '25%' in desc.index
-
-        with tm.assert_produces_warning(FutureWarning):
-            desc = self.series.describe(percentile_width=95)
-        assert '97.5%' in desc.index
-        assert '2.5%' in desc.index
-
     def test_describe_objects(self):
         s = Series(['a', 'b', 'b', np.nan, np.nan, np.nan, 'c', 'd', 'a', 'a'])
         result = s.describe()
@@ -1181,26 +1170,18 @@ class TestDataFrame(tm.TestCase, Generic):
         desc = tm.makeMixedDataFrame().describe()
         desc = tm.makeTimeDataFrame().describe()
 
-    def test_describe_percentiles(self):
-        with tm.assert_produces_warning(FutureWarning):
-            desc = tm.makeDataFrame().describe(percentile_width=50)
-        assert '75%' in desc.index
-        assert '25%' in desc.index
-
-        with tm.assert_produces_warning(FutureWarning):
-            desc = tm.makeDataFrame().describe(percentile_width=95)
-        assert '97.5%' in desc.index
-        assert '2.5%' in desc.index
-
-    def test_describe_quantiles_both(self):
-        with tm.assertRaises(ValueError):
-            tm.makeDataFrame().describe(percentile_width=50,
-                                        percentiles=[25, 75])
-
     def test_describe_percentiles_percent_or_raw(self):
+        msg = 'percentiles should all be in the interval \\[0, 1\\]'
+
         df = tm.makeDataFrame()
-        with tm.assertRaises(ValueError):
+        with tm.assertRaisesRegexp(ValueError, msg):
             df.describe(percentiles=[10, 50, 100])
+
+        with tm.assertRaisesRegexp(ValueError, msg):
+            df.describe(percentiles=[2])
+
+        with tm.assertRaisesRegexp(ValueError, msg):
+            df.describe(percentiles=[-2])
 
     def test_describe_percentiles_equivalence(self):
         df = tm.makeDataFrame()
@@ -1213,16 +1194,29 @@ class TestDataFrame(tm.TestCase, Generic):
         d1 = df.describe(percentiles=[.25, .75])
         d2 = df.describe(percentiles=[.25, .5, .75])
         assert_frame_equal(d1, d2)
+        self.assertTrue('25%' in d1.index)
+        self.assertTrue('75%' in d2.index)
 
         # none above
         d1 = df.describe(percentiles=[.25, .45])
         d2 = df.describe(percentiles=[.25, .45, .5])
         assert_frame_equal(d1, d2)
+        self.assertTrue('25%' in d1.index)
+        self.assertTrue('45%' in d2.index)
 
         # none below
         d1 = df.describe(percentiles=[.75, 1])
         d2 = df.describe(percentiles=[.5, .75, 1])
         assert_frame_equal(d1, d2)
+        self.assertTrue('75%' in d1.index)
+        self.assertTrue('100%' in d2.index)
+
+        # edge
+        d1 = df.describe(percentiles=[0, 1])
+        d2 = df.describe(percentiles=[0, .5, 1])
+        assert_frame_equal(d1, d2)
+        self.assertTrue('0%' in d1.index)
+        self.assertTrue('100%' in d2.index)
 
     def test_describe_no_numeric(self):
         df = DataFrame({'A': ['foo', 'foo', 'bar'] * 8,


### PR DESCRIPTION
Currently, error is raised from `numpy` and incorrect for `pandas`

```
s = pd.Series([1, 2, 3])
s.quantile(2)
#   File ".../numpy/lib/function_base.py", line 3078, in _percentile
#     raise ValueError("Percentiles must be in the range [0,100]")
# ValueError: Percentiles must be in the range [0,100]
```

`describe` using `percentiles` option outputs better error message, but not check lower limit.

```
# OK
s.describe(percentiles=[2])
# Traceback (most recent call last):
#   File "pandas/core/generic.py", line 4167, in describe
#    raise ValueError(msg.format(list(percentiles)))
# ValueError: percentiles should all be in the interval [0, 1]. Try [0.02] instead.

# NG
s.describe(percentiles=[-2])
#   File ".../numpy/lib/function_base.py", line 3078, in _percentile
#     raise ValueError("Percentiles must be in the range [0,100]")
# ValueError: Percentiles must be in the range [0,100]
```

This PR fix both error messages. Also, remove deprecated `percentile_width` option in `describe`. 
