### PR TITLE
DEPR: Bunch o deprecation removals part 2

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -665,6 +665,7 @@ Deprecations
   ``DataFrame.add(other, fill_value=0)`` and ``DataFrame.mul(other, fill_value=1.)``
   (:issue:`10735`).
 - ``TimeSeries`` deprecated in favor of ``Series`` (note that this has been alias since 0.13.0), (:issue:`10890`)
+- ``WidePanel`` deprecated in favor of ``Panel``, ``LongPanel`` in favor of ``DataFrame`` (note these have been aliases since < 0.11.0), (:issue:`10892`)
 
 .. _whatsnew_0170.prior_deprecations:
 

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -705,6 +705,13 @@ Removal of prior version deprecations/changes
 
       df.add(df.A,axis='index')
 
+
+
+
+- Remove the ``table`` keyword in ``HDFStore.put/append``, in favor of using ``format=`` (:issue:`4645`)
+
+
+
 .. _whatsnew_0170.performance:
 
 Performance Improvements

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -709,7 +709,7 @@ Removal of prior version deprecations/changes
 
 
 - Remove the ``table`` keyword in ``HDFStore.put/append``, in favor of using ``format=`` (:issue:`4645`)
-
+- Remove unused keyword ``kind`` in ``read_excel/ExcelFile`` (:issue:`4712`)
 
 
 .. _whatsnew_0170.performance:

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -711,7 +711,7 @@ Removal of prior version deprecations/changes
 - Remove ``table`` keyword in ``HDFStore.put/append``, in favor of using ``format=`` (:issue:`4645`)
 - Remove ``kind`` in ``read_excel/ExcelFile`` as its unused (:issue:`4712`)
 - Remove ``infer_type`` keyword from ``pd.read_html`` as its unused (:issue:`4770`, :issue:`7032`)
-
+- Remove ``offset`` and ``timeRule`` keywords from ``Series.tshift/shift``, in favor of ``freq`` (:issue:`4853`, :issue:`4864`)
 
 .. _whatsnew_0170.performance:
 

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -712,6 +712,7 @@ Removal of prior version deprecations/changes
 - Remove ``kind`` in ``read_excel/ExcelFile`` as its unused (:issue:`4712`)
 - Remove ``infer_type`` keyword from ``pd.read_html`` as its unused (:issue:`4770`, :issue:`7032`)
 - Remove ``offset`` and ``timeRule`` keywords from ``Series.tshift/shift``, in favor of ``freq`` (:issue:`4853`, :issue:`4864`)
+- Remove ``pd.load/pd.save`` aliases in favor of ``pd.to_pickle/pd.read_pickle`` (:issue:`3787`)
 
 .. _whatsnew_0170.performance:
 

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -708,8 +708,9 @@ Removal of prior version deprecations/changes
 
 
 
-- Remove the ``table`` keyword in ``HDFStore.put/append``, in favor of using ``format=`` (:issue:`4645`)
-- Remove unused keyword ``kind`` in ``read_excel/ExcelFile`` (:issue:`4712`)
+- Remove ``table`` keyword in ``HDFStore.put/append``, in favor of using ``format=`` (:issue:`4645`)
+- Remove ``kind`` in ``read_excel/ExcelFile`` as its unused (:issue:`4712`)
+- Remove ``infer_type`` keyword from ``pd.read_html`` as its unused (:issue:`4770`, :issue:`7032`)
 
 
 .. _whatsnew_0170.performance:

--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -29,7 +29,6 @@ from pandas.tseries.tdi import TimedeltaIndex, Timedelta
 from pandas.tseries.period import Period, PeriodIndex
 
 # legacy
-from pandas.core.common import save, load  # deprecated, remove in 0.13
 import pandas.core.datetools as datetools
 
 from pandas.core.config import (get_option, set_option, reset_option,

--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -12,13 +12,11 @@ from pandas.core.index import Index, CategoricalIndex, Int64Index, Float64Index,
 
 from pandas.core.series import Series, TimeSeries
 from pandas.core.frame import DataFrame
-from pandas.core.panel import Panel
+from pandas.core.panel import Panel, WidePanel
 from pandas.core.panel4d import Panel4D
 from pandas.core.groupby import groupby
 from pandas.core.reshape import (pivot_simple as pivot, get_dummies,
                                  lreshape, wide_to_long)
-
-WidePanel = Panel
 
 from pandas.core.indexing import IndexSlice
 from pandas.tseries.offsets import DateOffset

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -3313,46 +3313,6 @@ def console_encode(object, **kwds):
     return pprint_thing_encoded(object,
                                 get_option("display.encoding"))
 
-
-def load(path):  # TODO remove in 0.13
-    """
-    Load pickled pandas object (or any other pickled object) from the specified
-    file path
-
-    Warning: Loading pickled data received from untrusted sources can be
-    unsafe. See: http://docs.python.org/2.7/library/pickle.html
-
-    Parameters
-    ----------
-    path : string
-        File path
-
-    Returns
-    -------
-    unpickled : type of object stored in file
-    """
-    import warnings
-    warnings.warn("load is deprecated, use read_pickle", FutureWarning)
-    from pandas.io.pickle import read_pickle
-    return read_pickle(path)
-
-
-def save(obj, path):  # TODO remove in 0.13
-    """
-    Pickle (serialize) object to input file path
-
-    Parameters
-    ----------
-    obj : any object
-    path : string
-        File path
-    """
-    import warnings
-    warnings.warn("save is deprecated, use obj.to_pickle", FutureWarning)
-    from pandas.io.pickle import to_pickle
-    return to_pickle(obj, path)
-
-
 def _maybe_match_name(a, b):
     a_has = hasattr(a, 'name')
     b_has = hasattr(b, 'name')

--- a/pandas/core/datetools.py
+++ b/pandas/core/datetools.py
@@ -41,23 +41,3 @@ thisQuarterEnd = QuarterEnd(0)
 isBusinessDay = BDay().onOffset
 isMonthEnd = MonthEnd().onOffset
 isBMonthEnd = BMonthEnd().onOffset
-
-
-def _resolve_offset(freq, kwds):
-    if 'timeRule' in kwds or 'offset' in kwds:
-        offset = kwds.get('offset', None)
-        offset = kwds.get('timeRule', offset)
-        if isinstance(offset, compat.string_types):
-            offset = getOffset(offset)
-        warn = True
-    else:
-        offset = freq
-        warn = False
-
-    if warn:
-        import warnings
-        warnings.warn("'timeRule' and 'offset' parameters are deprecated,"
-                      " please use 'freq' instead",
-                      FutureWarning)
-
-    return offset

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2618,9 +2618,9 @@ class DataFrame(NDFrame):
                                              **kwargs)
 
     @Appender(_shared_docs['shift'] % _shared_doc_kwargs)
-    def shift(self, periods=1, freq=None, axis=0, **kwargs):
+    def shift(self, periods=1, freq=None, axis=0):
         return super(DataFrame, self).shift(periods=periods, freq=freq,
-                                            axis=axis, **kwargs)
+                                            axis=axis)
 
     def set_index(self, keys, drop=True, append=False, inplace=False,
                   verify_integrity=False):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1006,20 +1006,6 @@ class NDFrame(PandasObject):
         from pandas.io.pickle import to_pickle
         return to_pickle(self, path)
 
-    def save(self, path):  # TODO remove in 0.14
-        "Deprecated. Use to_pickle instead"
-        import warnings
-        from pandas.io.pickle import to_pickle
-        warnings.warn("save is deprecated, use to_pickle", FutureWarning)
-        return to_pickle(self, path)
-
-    def load(self, path):  # TODO remove in 0.14
-        "Deprecated. Use read_pickle instead."
-        import warnings
-        from pandas.io.pickle import read_pickle
-        warnings.warn("load is deprecated, use pd.read_pickle", FutureWarning)
-        return read_pickle(path)
-
     def to_clipboard(self, excel=None, sep=None, **kwargs):
         """
         Attempt to write text representation of object to the system clipboard

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3806,15 +3806,15 @@ class NDFrame(PandasObject):
         shifted : %(klass)s
     """)
     @Appender(_shared_docs['shift'] % _shared_doc_kwargs)
-    def shift(self, periods=1, freq=None, axis=0, **kwargs):
+    def shift(self, periods=1, freq=None, axis=0):
         if periods == 0:
             return self
 
         block_axis = self._get_block_manager_axis(axis)
-        if freq is None and not len(kwargs):
+        if freq is None:
             new_data = self._data.shift(periods=periods, axis=block_axis)
         else:
-            return self.tshift(periods, freq, **kwargs)
+            return self.tshift(periods, freq)
 
         return self._constructor(new_data).__finalize__(self)
 
@@ -3854,7 +3854,7 @@ class NDFrame(PandasObject):
 
         return new_obj.__finalize__(self)
 
-    def tshift(self, periods=1, freq=None, axis=0, **kwargs):
+    def tshift(self, periods=1, freq=None, axis=0):
         """
         Shift the time index, using the index's frequency if available
 
@@ -3877,7 +3877,6 @@ class NDFrame(PandasObject):
         -------
         shifted : NDFrame
         """
-        from pandas.core.datetools import _resolve_offset
 
         index = self._get_axis(axis)
         if freq is None:
@@ -3893,24 +3892,22 @@ class NDFrame(PandasObject):
         if periods == 0:
             return self
 
-        offset = _resolve_offset(freq, kwargs)
-
-        if isinstance(offset, string_types):
-            offset = datetools.to_offset(offset)
+        if isinstance(freq, string_types):
+            freq = datetools.to_offset(freq)
 
         block_axis = self._get_block_manager_axis(axis)
         if isinstance(index, PeriodIndex):
-            orig_offset = datetools.to_offset(index.freq)
-            if offset == orig_offset:
+            orig_freq = datetools.to_offset(index.freq)
+            if freq == orig_freq:
                 new_data = self._data.copy()
                 new_data.axes[block_axis] = index.shift(periods)
             else:
                 msg = ('Given freq %s does not match PeriodIndex freq %s' %
-                       (offset.rule_code, orig_offset.rule_code))
+                       (freq.rule_code, orig_freq.rule_code))
                 raise ValueError(msg)
         else:
             new_data = self._data.copy()
-            new_data.axes[block_axis] = index.shift(periods, offset)
+            new_data.axes[block_axis] = index.shift(periods, freq)
 
         return self._constructor(new_data).__finalize__(self)
 

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -1509,5 +1509,23 @@ ops.add_special_arithmetic_methods(Panel, **ops.panel_special_funcs)
 Panel._add_aggregate_operations()
 Panel._add_numeric_operations()
 
-WidePanel = Panel
-LongPanel = DataFrame
+# legacy
+class WidePanel(Panel):
+
+    def __init__(self, *args, **kwargs):
+
+        # deprecation, #10892
+        warnings.warn("WidePanel is deprecated. Please use Panel",
+                      FutureWarning, stacklevel=2)
+
+        super(WidePanel, self).__init__(*args, **kwargs)
+
+class LongPanel(DataFrame):
+
+    def __init__(self, *args, **kwargs):
+
+        # deprecation, #10892
+        warnings.warn("LongPanel is deprecated. Please use DataFrame",
+                      FutureWarning, stacklevel=2)
+
+        super(LongPanel, self).__init__(*args, **kwargs)

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -1210,8 +1210,8 @@ class Panel(NDFrame):
 
         return super(Panel, self).slice_shift(periods, axis=axis)
 
-    def tshift(self, periods=1, freq=None, axis='major', **kwds):
-        return super(Panel, self).tshift(periods, freq, axis, **kwds)
+    def tshift(self, periods=1, freq=None, axis='major'):
+        return super(Panel, self).tshift(periods, freq, axis)
 
     def join(self, other, how='left', lsuffix='', rsuffix=''):
         """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2182,9 +2182,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                                           **kwargs)
 
     @Appender(generic._shared_docs['shift'] % _shared_doc_kwargs)
-    def shift(self, periods=1, freq=None, axis=0, **kwargs):
+    def shift(self, periods=1, freq=None, axis=0):
         return super(Series, self).shift(periods=periods, freq=freq,
-                                         axis=axis, **kwargs)
+                                         axis=axis)
 
     def reindex_axis(self, labels, axis=0, **kwargs):
         """ for compatibility with higher dims """

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -78,17 +78,17 @@ def read_excel(io, sheetname=0, **kwds):
         and file. For file URLs, a host is expected. For instance, a local
         file could be file://localhost/path/to/workbook.xlsx
     sheetname : string, int, mixed list of strings/ints, or None, default 0
-        
-        Strings are used for sheet names, Integers are used in zero-indexed sheet 
-        positions. 
-        
+
+        Strings are used for sheet names, Integers are used in zero-indexed sheet
+        positions.
+
         Lists of strings/integers are used to request multiple sheets.
-        
+
         Specify None to get all sheets.
-        
+
         str|int -> DataFrame is returned.
         list|None -> Dict of DataFrames is returned, with keys representing sheets.
-               
+
         Available Cases
 
         * Defaults to 0 -> 1st sheet as a DataFrame
@@ -143,11 +143,6 @@ def read_excel(io, sheetname=0, **kwds):
         for more information on when a Dict of Dataframes is returned.
 
     """
-    if 'kind' in kwds:
-        kwds.pop('kind')
-        warn("kind keyword is no longer supported in read_excel and may be "
-             "removed in a future version", FutureWarning)
-
     engine = kwds.pop('engine', None)
 
     return ExcelFile(io, engine=engine).parse(sheetname=sheetname, **kwds)
@@ -207,19 +202,19 @@ class ExcelFile(object):
         Parameters
         ----------
         sheetname : string, int, mixed list of strings/ints, or None, default 0
-            
-            Strings are used for sheet names, Integers are used in zero-indexed sheet 
-            positions. 
-            
+
+            Strings are used for sheet names, Integers are used in zero-indexed sheet
+            positions.
+
             Lists of strings/integers are used to request multiple sheets.
-            
+
             Specify None to get all sheets.
-            
+
             str|int -> DataFrame is returned.
             list|None -> Dict of DataFrames is returned, with keys representing sheets.
-                   
+
             Available Cases
-    
+
             * Defaults to 0 -> 1st sheet as a DataFrame
             * 1 -> 2nd sheet as a DataFrame
             * "Sheet1" -> 1st sheet as a DataFrame
@@ -336,7 +331,7 @@ class ExcelFile(object):
         def _parse_cell(cell_contents,cell_typ):
             """converts the contents of the cell into a pandas
                appropriate object"""
-               
+
             if cell_typ == XL_CELL_DATE:
                 if xlrd_0_9_3:
                     # Use the newer xlrd datetime handling.
@@ -379,9 +374,9 @@ class ExcelFile(object):
             xlrd_0_9_3 = True
         else:
             xlrd_0_9_3 = False
-        
+
         ret_dict = False
-        
+
         #Keep sheetname to maintain backwards compatibility.
         if isinstance(sheetname, list):
             sheets = sheetname
@@ -391,31 +386,31 @@ class ExcelFile(object):
             ret_dict = True
         else:
             sheets = [sheetname]
-        
+
         #handle same-type duplicates.
         sheets = list(set(sheets))
-        
+
         output = {}
-        
+
         for asheetname in sheets:
             if verbose:
                 print("Reading sheet %s" % asheetname)
-            
+
             if isinstance(asheetname, compat.string_types):
                 sheet = self.book.sheet_by_name(asheetname)
-            else:  # assume an integer if not a string    
-                sheet = self.book.sheet_by_index(asheetname)   
-            
+            else:  # assume an integer if not a string
+                sheet = self.book.sheet_by_index(asheetname)
+
             data = []
             should_parse = {}
-            
+
             for i in range(sheet.nrows):
                 row = []
                 for j, (value, typ) in enumerate(zip(sheet.row_values(i),
                                                      sheet.row_types(i))):
                     if parse_cols is not None and j not in should_parse:
                         should_parse[j] = self._should_parse(j, parse_cols)
-    
+
                     if parse_cols is None or should_parse[j]:
                         row.append(_parse_cell(value,typ))
                 data.append(row)
@@ -436,14 +431,14 @@ class ExcelFile(object):
                                 skip_footer=skip_footer,
                                 chunksize=chunksize,
                                 **kwds)
-            
+
             output[asheetname] = parser.read()
-            
+
         if ret_dict:
             return output
         else:
             return output[asheetname]
-        
+
 
     @property
     def sheet_names(self):

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -604,7 +604,7 @@ def _expand_elements(body):
         body[ind] += empty * (lens_max - length)
 
 
-def _data_to_frame(data, header, index_col, skiprows, infer_types,
+def _data_to_frame(data, header, index_col, skiprows,
                    parse_dates, tupleize_cols, thousands):
     head, body, foot = data
 
@@ -707,7 +707,7 @@ def _validate_flavor(flavor):
     return flavor
 
 
-def _parse(flavor, io, match, header, index_col, skiprows, infer_types,
+def _parse(flavor, io, match, header, index_col, skiprows,
            parse_dates, tupleize_cols, thousands, attrs, encoding):
     flavor = _validate_flavor(flavor)
     compiled_match = re.compile(match)  # you can pass a compiled regex here
@@ -730,15 +730,20 @@ def _parse(flavor, io, match, header, index_col, skiprows, infer_types,
     ret = []
     for table in tables:
         try:
-            ret.append(_data_to_frame(table, header, index_col, skiprows,
-                        infer_types, parse_dates, tupleize_cols, thousands))
+            ret.append(_data_to_frame(data=table,
+                                      header=header,
+                                      index_col=index_col,
+                                      skiprows=skiprows,
+                                      parse_dates=parse_dates,
+                                      tupleize_cols=tupleize_cols,
+                                      thousands=thousands))
         except StopIteration: # empty table
             continue
     return ret
 
 
 def read_html(io, match='.+', flavor=None, header=None, index_col=None,
-              skiprows=None, infer_types=None, attrs=None, parse_dates=False,
+              skiprows=None, attrs=None, parse_dates=False,
               tupleize_cols=False, thousands=',', encoding=None):
     r"""Read HTML tables into a ``list`` of ``DataFrame`` objects.
 
@@ -775,9 +780,6 @@ def read_html(io, match='.+', flavor=None, header=None, index_col=None,
         sequence of integers or a slice is given, will skip the rows indexed by
         that sequence.  Note that a single element sequence means 'skip the nth
         row' whereas an integer means 'skip n rows'.
-
-    infer_types : None, optional
-        This has no effect since 0.15.0. It is here for backwards compatibility.
 
     attrs : dict or None, optional
         This is a dictionary of attributes that you can pass to use to identify
@@ -853,13 +855,11 @@ def read_html(io, match='.+', flavor=None, header=None, index_col=None,
     pandas.read_csv
     """
     _importers()
-    if infer_types is not None:
-        warnings.warn("infer_types has no effect since 0.15", FutureWarning)
 
     # Type check here. We don't want to parse only to fail because of an
     # invalid value of an integer skiprows.
     if isinstance(skiprows, numbers.Integral) and skiprows < 0:
         raise ValueError('cannot skip rows starting from the end of the '
                          'data (you passed a negative value)')
-    return _parse(flavor, io, match, header, index_col, skiprows, infer_types,
+    return _parse(flavor, io, match, header, index_col, skiprows,
                   parse_dates, tupleize_cols, thousands, attrs, encoding)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1117,17 +1117,6 @@ class HDFStore(StringMixin):
         """ validate / deprecate formats; return the new kwargs """
         kwargs = kwargs.copy()
 
-        # table arg
-        table = kwargs.pop('table', None)
-
-        if table is not None:
-            warnings.warn(format_deprecate_doc, FutureWarning)
-
-            if table:
-                format = 'table'
-            else:
-                format = 'fixed'
-
         # validate
         try:
             kwargs['format'] = _FORMAT_MAP[format.lower()]

--- a/pandas/io/tests/test_html.py
+++ b/pandas/io/tests/test_html.py
@@ -137,12 +137,10 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
         assert_framelist_equal(df1, df2)
 
     def test_spam_no_types(self):
-        with tm.assert_produces_warning(FutureWarning):
-            df1 = self.read_html(self.spam_data, '.*Water.*',
-                                 infer_types=False)
-        with tm.assert_produces_warning(FutureWarning):
-            df2 = self.read_html(self.spam_data, 'Unit', infer_types=False)
 
+        # infer_types removed in #10892
+        df1 = self.read_html(self.spam_data, '.*Water.*')
+        df2 = self.read_html(self.spam_data, 'Unit')
         assert_framelist_equal(df1, df2)
 
         self.assertEqual(df1[0].ix[0, 0], 'Proximates')
@@ -230,12 +228,9 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
         assert_framelist_equal(df1, df2)
 
     def test_header_and_index_no_types(self):
-        with tm.assert_produces_warning(FutureWarning):
-            df1 = self.read_html(self.spam_data, '.*Water.*', header=1,
-                                 index_col=0, infer_types=False)
-        with tm.assert_produces_warning(FutureWarning):
-            df2 = self.read_html(self.spam_data, 'Unit', header=1, index_col=0,
-                                 infer_types=False)
+        df1 = self.read_html(self.spam_data, '.*Water.*', header=1,
+                             index_col=0)
+        df2 = self.read_html(self.spam_data, 'Unit', header=1, index_col=0)
         assert_framelist_equal(df1, df2)
 
     def test_header_and_index_with_types(self):
@@ -245,18 +240,10 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
         assert_framelist_equal(df1, df2)
 
     def test_infer_types(self):
-        with tm.assert_produces_warning(FutureWarning):
-            df1 = self.read_html(self.spam_data, '.*Water.*', index_col=0,
-                                 infer_types=False)
-        with tm.assert_produces_warning(FutureWarning):
-            df2 = self.read_html(self.spam_data, 'Unit', index_col=0,
-                                 infer_types=False)
-        assert_framelist_equal(df1, df2)
 
-        with tm.assert_produces_warning(FutureWarning):
-            df2 = self.read_html(self.spam_data, 'Unit', index_col=0,
-                                 infer_types=True)
-
+        # 10892 infer_types removed
+        df1 = self.read_html(self.spam_data, '.*Water.*', index_col=0)
+        df2 = self.read_html(self.spam_data, 'Unit', index_col=0)
         assert_framelist_equal(df1, df2)
 
     def test_string_io(self):
@@ -641,8 +628,7 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
         with tm.assertRaisesRegexp(CParserError, r"Passed header=\[0,1\] are "
                                    "too many rows for this multi_index "
                                    "of columns"):
-            with tm.assert_produces_warning(FutureWarning):
-                self.read_html(data, infer_types=False, header=[0, 1])
+            self.read_html(data, header=[0, 1])
 
     def test_wikipedia_states_table(self):
         data = os.path.join(DATA_PATH, 'wikipedia_states.html')
@@ -751,8 +737,7 @@ class TestReadHtmlLxml(tm.TestCase, ReadHtmlMixin):
 
     def test_computer_sales_page(self):
         data = os.path.join(DATA_PATH, 'computer_sales_page.html')
-        with tm.assert_produces_warning(FutureWarning):
-            self.read_html(data, infer_types=False, header=[0, 1])
+        self.read_html(data, header=[0, 1])
 
 
 def test_invalid_flavor():

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -1040,7 +1040,7 @@ class TestHDFStore(Base):
             store.append('df2', df[10:], dropna=False)
             tm.assert_frame_equal(store['df2'], df)
 
-        # Test to make sure defaults are to not drop. 
+        # Test to make sure defaults are to not drop.
         # Corresponding to Issue 9382
         df_with_missing = DataFrame({'col1':[0, np.nan, 2], 'col2':[1, np.nan,  np.nan]})
 
@@ -1059,7 +1059,7 @@ class TestHDFStore(Base):
 
         with ensure_clean_path(self.path) as path:
            panel_with_missing.to_hdf(path, 'panel_with_missing', format='table')
-           reloaded_panel = read_hdf(path, 'panel_with_missing') 
+           reloaded_panel = read_hdf(path, 'panel_with_missing')
            tm.assert_panel_equal(panel_with_missing, reloaded_panel)
 
     def test_append_frame_column_oriented(self):
@@ -2440,9 +2440,9 @@ class TestHDFStore(Base):
             p4d = tm.makePanel4D()
             wpneg = Panel.fromDict({-1: tm.makeDataFrame(), 0: tm.makeDataFrame(),
                                     1: tm.makeDataFrame()})
-            store.put('wp', wp, table=True)
-            store.put('p4d', p4d, table=True)
-            store.put('wpneg', wpneg, table=True)
+            store.put('wp', wp, format='table')
+            store.put('p4d', p4d, format='table')
+            store.put('wpneg', wpneg, format='table')
 
             # panel
             result = store.select('wp', [Term(
@@ -2607,7 +2607,7 @@ class TestHDFStore(Base):
 
             import pandas as pd
             df  = DataFrame(np.random.randn(20, 2),index=pd.date_range('20130101',periods=20))
-            store.put('df', df, table=True)
+            store.put('df', df, format='table')
             expected = df[df.index>pd.Timestamp('20130105')]
 
             import datetime
@@ -3608,7 +3608,7 @@ class TestHDFStore(Base):
         df.loc[df.index[0:4],'string'] = 'bar'
 
         with ensure_clean_store(self.path) as store:
-            store.put('df', df, table=True, data_columns=['string'])
+            store.put('df', df, format='table', data_columns=['string'])
 
             # empty
             result = store.select('df', 'index>df.index[3] & string="bar"')
@@ -3717,7 +3717,7 @@ class TestHDFStore(Base):
         df = tm.makeTimeDataFrame()
 
         with ensure_clean_store(self.path) as store:
-            store.put('df', df, table=True)
+            store.put('df', df, format='table')
 
             # not implemented
             self.assertRaises(NotImplementedError, store.select, 'df', "columns=['A'] | columns=['B']")

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -604,13 +604,10 @@ class SparseSeries(Series):
             dense_valid = dense_valid[dense_valid != self.fill_value]
             return dense_valid.to_sparse(fill_value=self.fill_value)
 
-    def shift(self, periods, freq=None, **kwds):
+    def shift(self, periods, freq=None):
         """
         Analogous to Series.shift
         """
-        from pandas.core.datetools import _resolve_offset
-
-        offset = _resolve_offset(freq, kwds)
 
         # no special handling of fill values yet
         if not isnull(self.fill_value):
@@ -622,10 +619,10 @@ class SparseSeries(Series):
         if periods == 0:
             return self.copy()
 
-        if offset is not None:
+        if freq is not None:
             return self._constructor(self.sp_values,
                                      sparse_index=self.sp_index,
-                                     index=self.index.shift(periods, offset),
+                                     index=self.index.shift(periods, freq),
                                      fill_value=self.fill_value).__finalize__(self)
 
         int_index = self.sp_index.to_int_index()

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -5385,10 +5385,10 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         self.assertRaises(ValueError, ps.shift, freq='D')
 
         # legacy support
-        shifted4 = ps.shift(1, timeRule='B')
+        shifted4 = ps.shift(1, freq='B')
         assert_series_equal(shifted2, shifted4)
 
-        shifted5 = ps.shift(1, offset=datetools.bday)
+        shifted5 = ps.shift(1, freq=datetools.bday)
         assert_series_equal(shifted5, shifted4)
 
         # 32-bit taking


### PR DESCRIPTION
- Remove the table keyword in HDFStore.put/append, in favor of using format= #4645
- Remove unused keyword `kind` in `read_excel/ExcelFile` #4712 
- Remove `infer_type` keyword from `pd.read_html` as its unused, #4770, #7032
- Remove `offset` and `timeRule` keywords from `Series.tshift/shift`, in favor of `freq`, #4853, #4864
- Remove `pd.load/pd.save` aliases in favor of `pd.to_pickle/pd.read_pickle`, #3787
- Deprecate `WidePanel/LongPanel`
