### PR TITLE
PERF: improves SeriesGroupBy.nunique performance

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -679,6 +679,7 @@ Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 - Added vbench benchmarks for alternative ExcelWriter engines and reading Excel files (:issue:`7171`)
 - Performance improvements in ``Categorical.value_counts`` (:issue:`10804`)
+- Performance improvements in ``SeriesGroupBy.nunique`` (:issue:`10820`)
 
 - 4x improvement in ``timedelta`` string parsing (:issue:`6755`, :issue:`10426`)
 - 8x improvement in ``timedelta64`` and ``datetime64`` ops (:issue:`6755`)


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/10820

on master:

``` ipython
In [2]: df = pd.DataFrame({'a': np.random.randint(10000, size=100000),
   ...:                    'b': np.random.randint(10, size=100000)})

In [3]: %timeit df.groupby('a')['b'].nunique()
1 loops, best of 3: 1.66 s per loop

In [4]: %timeit df.groupby(['a', 'b'])['b'].first().groupby(level=0).size()
10 loops, best of 3: 36.3 ms per loop
```

on branch:

``` ipython
In [2]: %timeit df.groupby('a')['b'].nunique()
10 loops, best of 3: 29.2 ms per loop
```
