### PR TITLE
PERF: Cythonize groupby transforms #4095

### DIFF
--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -772,3 +772,19 @@ class groupby_transform_series2(object):
 
     def time_groupby_transform_series2(self):
         self.df.groupby('id')['val'].transform(np.mean)
+
+class groupby_transform_cythonized(object):
+    goal_time = 0.2
+
+    def setup(self):
+        np.random.seed(0)
+        self.df = DataFrame({'id': (np.arange(100000) / 3), 'val': np.random.randn(100000), })
+
+    def time_groupby_transform_cumprod(self):
+        self.df.groupby('id').cumprod()
+
+    def time_groupby_transform_cumsum(self):
+        self.df.groupby('id').cumsum()
+
+    def time_groupby_transform_shift(self):
+        self.df.groupby('id').shift()

--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -93,6 +93,8 @@ Performance Improvements
 - Performance bug in repr of ``Categorical`` categories, which was rendering the strings before chopping them for display (:issue:`11305`)
 - Improved performance of ``Series`` constructor with no data and ``DatetimeIndex`` (:issue:`11433`)
 
+- Improved performance ``shift``, ``cumprod``, and ``cumsum`` with groupby (:issue:`4095`)
+
 .. _whatsnew_0171.bug_fixes:
 
 

--- a/pandas/algos.pyx
+++ b/pandas/algos.pyx
@@ -50,7 +50,6 @@ cdef np.float64_t MAXfloat64 = np.inf
 cdef double NaN = <double> np.NaN
 cdef double nan = NaN
 
-
 cdef inline int int_max(int a, int b): return a if a >= b else b
 cdef inline int int_min(int a, int b): return a if a <= b else b
 
@@ -2265,43 +2264,6 @@ def group_last_bin_object(ndarray[object, ndim=2] out,
                 out[i, j] = nan
             else:
                 out[i, j] = resx[i, j]
-
-
-
-#----------------------------------------------------------------------
-# median
-
-def group_median(ndarray[float64_t, ndim=2] out,
-                 ndarray[int64_t] counts,
-                 ndarray[float64_t, ndim=2] values,
-                 ndarray[int64_t] labels):
-    '''
-    Only aggregates on axis=0
-    '''
-    cdef:
-        Py_ssize_t i, j, N, K, ngroups, size
-        ndarray[int64_t] _counts
-        ndarray data
-        float64_t* ptr
-    ngroups = len(counts)
-    N, K = (<object> values).shape
-
-    indexer, _counts = groupsort_indexer(labels, ngroups)
-    counts[:] = _counts[1:]
-
-    data = np.empty((K, N), dtype=np.float64)
-    ptr = <float64_t*> data.data
-
-    take_2d_axis1_float64_float64(values.T, indexer, out=data)
-
-    for i in range(K):
-        # exclude NA group
-        ptr += _counts[0]
-        for j in range(ngroups):
-            size = _counts[j + 1]
-            out[j, i] = _median_linear(ptr, size)
-            ptr += size
-
 
 cdef inline float64_t _median_linear(float64_t* a, int n):
     cdef int i, j, na_count = 0

--- a/pandas/src/generated.pyx
+++ b/pandas/src/generated.pyx
@@ -7933,6 +7933,141 @@ def group_max_int64(ndarray[int64_t, ndim=2] out,
                     out[i, j] = maxx[i, j]
 
 
+
+def group_median_float64(ndarray[float64_t, ndim=2] out,
+                         ndarray[int64_t] counts,
+                         ndarray[float64_t, ndim=2] values,
+                         ndarray[int64_t] labels):
+    '''
+    Only aggregates on axis=0
+    '''
+    cdef:
+        Py_ssize_t i, j, N, K, ngroups, size
+        ndarray[int64_t] _counts
+        ndarray data
+        float64_t* ptr
+    ngroups = len(counts)
+    N, K = (<object> values).shape
+
+    indexer, _counts = groupsort_indexer(labels, ngroups)
+    counts[:] = _counts[1:]
+
+    data = np.empty((K, N), dtype=np.float64)
+    ptr = <float64_t*> data.data
+
+    take_2d_axis1_float64_float64(values.T, indexer, out=data)
+
+    for i in range(K):
+        # exclude NA group
+        ptr += _counts[0]
+        for j in range(ngroups):
+            size = _counts[j + 1]
+            out[j, i] = _median_linear(ptr, size)
+            ptr += size
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_cumprod_float64(float64_t[:,:] out,
+                          float64_t[:,:] values,
+                          int64_t[:] labels,
+                          float64_t[:,:] accum):
+    '''
+    Only transforms on axis=0
+    '''
+    cdef:
+        Py_ssize_t i, j, N, K, size
+        float64_t val
+        int64_t lab
+
+    N, K = (<object> values).shape
+    accum = np.ones_like(accum)
+
+    with nogil:
+        for i in range(N):
+            lab = labels[i]
+
+            if lab < 0:
+                continue
+            for j in range(K):
+                val = values[i, j]
+                if val == val:
+                    accum[lab, j] *= val
+                    out[i, j] = accum[lab, j]
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_cumsum(numeric[:,:] out,
+                 numeric[:,:] values,
+                 int64_t[:] labels,
+                 numeric[:,:] accum):
+    '''
+    Only transforms on axis=0
+    '''
+    cdef:
+        Py_ssize_t i, j, N, K, size
+        numeric val
+        int64_t lab
+
+    N, K = (<object> values).shape
+    accum = np.zeros_like(accum)
+
+    with nogil:
+        for i in range(N):
+            lab = labels[i]
+
+            if lab < 0:
+                continue
+            for j in range(K):
+                val = values[i,j]
+                if val == val:
+                    accum[lab,j] += val
+                    out[i,j] = accum[lab,j]
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_shift_indexer(int64_t[:] out, int64_t[:] labels,
+                        int ngroups, int periods):
+    cdef:
+        Py_ssize_t N, i, j, ii
+        int offset, sign
+        int64_t lab, idxer, idxer_slot
+        int64_t[:] label_seen = np.zeros(ngroups, dtype=np.int64)
+        int64_t[:,:] label_indexer
+
+    N, = (<object> labels).shape
+
+    if periods < 0:
+        periods = -periods
+        offset = N - 1
+        sign = -1
+    elif periods > 0:
+        offset = 0
+        sign = 1
+
+    if periods == 0:
+        with nogil:
+            for i in range(N):
+                out[i] = i
+    else:
+        # array of each previous indexer seen
+        label_indexer = np.zeros((ngroups, periods), dtype=np.int64)
+        with nogil:
+            for i in range(N):
+                ## reverse iterator if shifting backwards
+                ii = offset + sign * i
+                lab = labels[ii]
+                label_seen[lab] += 1
+
+                idxer_slot = label_seen[lab] % periods
+                idxer = label_indexer[lab, idxer_slot]
+
+                if label_seen[lab] > periods:
+                    out[ii] = idxer
+                else:
+                    out[ii] = -1
+
+                label_indexer[lab, idxer_slot] = ii
+
 @cython.wraparound(False)
 @cython.boundscheck(False)
 def left_join_indexer_unique_float64(ndarray[float64_t] left,

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -2636,7 +2636,7 @@ class TestGroupBy(tm.TestCase):
         result = df.groupby('A').cumsum()
         assert_frame_equal(result,expected)
 
-        expected = DataFrame([[1, 2, np.nan], [2, np.nan, 9], [3, 4, 9]], columns=['A', 'B', 'C']).astype('float64')
+        # GH 5755 - cumsum is a transformer and should ignore as_index
         result = df.groupby('A', as_index=False).cumsum()
         assert_frame_equal(result,expected)
 
@@ -5359,6 +5359,157 @@ class TestGroupBy(tm.TestCase):
             except BaseException as exc:
                 exc.args += ('operation: %s' % op,)
                 raise
+
+    def test_cython_group_transform_algos(self):
+        #GH 4095
+        dtypes = [np.int8, np.int16, np.int32, np.int64,
+                  np.uint8, np.uint32, np.uint64,
+                  np.float32, np.float64]
+
+        ops = [(pd.algos.group_cumprod_float64, np.cumproduct, [np.float64]),
+               (pd.algos.group_cumsum, np.cumsum, dtypes)]
+
+        for pd_op, np_op, dtypes in ops:
+            for dtype in dtypes:
+                data = np.array([[1],[2],[3],[4]], dtype=dtype)
+                ans = np.zeros_like(data)
+                accum = np.array([[0]], dtype=dtype)
+                labels = np.array([0,0,0,0], dtype=np.int64)
+                pd_op(ans, data, labels, accum)
+                self.assert_numpy_array_equal(np_op(data), ans[:,0])
+
+
+
+        # with nans
+        labels = np.array([0,0,0,0,0], dtype=np.int64)
+
+        data = np.array([[1],[2],[3],[np.nan],[4]], dtype='float64')
+        accum = np.array([[0.0]])
+        actual = np.zeros_like(data)
+        actual.fill(np.nan)
+        pd.algos.group_cumprod_float64(actual, data, labels, accum)
+        expected = np.array([1, 2, 6, np.nan, 24], dtype='float64')
+        self.assert_numpy_array_equal(actual[:, 0], expected)
+
+        accum = np.array([[0.0]])
+        actual = np.zeros_like(data)
+        actual.fill(np.nan)
+        pd.algos.group_cumsum(actual, data, labels, accum)
+        expected = np.array([1, 3, 6, np.nan, 10], dtype='float64')
+        self.assert_numpy_array_equal(actual[:, 0], expected)
+
+        # timedelta
+        data = np.array([np.timedelta64(1, 'ns')] * 5, dtype='m8[ns]')[:, None]
+        accum = np.array([[0]], dtype='int64')
+        actual = np.zeros_like(data, dtype='int64')
+        actual.fill(np.nan)
+        pd.algos.group_cumsum(actual, data.view('int64'), labels, accum)
+        expected = np.array(
+            [np.timedelta64(1, 'ns'), np.timedelta64(2, 'ns'),
+             np.timedelta64(3, 'ns'), np.timedelta64(4, 'ns'),
+             np.timedelta64(5, 'ns')])
+        self.assert_numpy_array_equal(actual[:, 0].view('m8[ns]'), expected)
+
+
+
+    def test_cython_transform(self):
+        # GH 4095
+        ops = [(('cumprod', ()), lambda x: x.cumprod()),
+               (('cumsum', ()), lambda x: x.cumsum()),
+               (('shift', (-1,)), lambda x: x.shift(-1)),
+               (('shift', (1,)), lambda x: x.shift())]
+
+        s = Series(np.random.randn(1000))
+        s_missing = s.copy()
+        s_missing.iloc[2:10] = np.nan
+        labels = np.random.randint(0, 50, size=1000).astype(float)
+
+        #series
+        for (op, args), targop in ops:
+            for data in [s, s_missing]:
+                # print(data.head())
+                expected = data.groupby(labels).transform(targop)
+
+                tm.assert_series_equal(expected,
+                                       data.groupby(labels).transform(op, *args))
+                tm.assert_series_equal(expected,
+                                       getattr(data.groupby(labels), op)(*args))
+
+        strings = list('qwertyuiopasdfghjklz')
+        strings_missing = strings[:]
+        strings_missing[5] = np.nan
+        df = DataFrame({'float': s,
+                        'float_missing': s_missing,
+                        'int': [1,1,1,1,2] * 200,
+                        'datetime': pd.date_range('1990-1-1', periods=1000),
+                        'timedelta': pd.timedelta_range(1, freq='s', periods=1000),
+                        'string': strings * 50,
+                        'string_missing': strings_missing * 50})
+        df['cat'] = df['string'].astype('category')
+
+        df2 = df.copy()
+        df2.index = pd.MultiIndex.from_product([range(100), range(10)])
+
+        #DataFrame - Single and MultiIndex,
+        #group by values, index level, columns
+        for df in [df, df2]:
+            for gb_target in [dict(by=labels),  dict(level=0),
+                              dict(by='string')]: # dict(by='string_missing')]:
+                             # dict(by=['int','string'])]:
+
+                gb = df.groupby(**gb_target)
+                # whitelisted methods set the selection before applying
+                # bit a of hack to make sure the cythonized shift
+                # is equivalent to pre 0.17.1 behavior
+                if op == 'shift':
+                    gb._set_selection_from_grouper()
+
+                for (op, args), targop in ops:
+                    print(op)
+                    if op != 'shift' and 'int' not in gb_target:
+                        # numeric apply fastpath promotes dtype so have
+                        # to apply seperately and concat
+                        i = gb[['int']].apply(targop)
+                        f = gb[['float','float_missing']].apply(targop)
+                        expected = pd.concat([f,i], axis=1)
+                    else:
+                        expected = gb.apply(targop)
+
+                    expected = expected.sort_index(axis=1)
+                    tm.assert_frame_equal(expected,
+                                        gb.transform(op, *args).sort_index(axis=1))
+                    tm.assert_frame_equal(expected,
+                                        getattr(gb, op)(*args))
+                    # individual columns
+                    for c in df:
+                        if c not in ['float', 'int', 'float_missing'] and op != 'shift':
+                            self.assertRaises(DataError, gb[c].transform, op)
+                            self.assertRaises(DataError, getattr(gb[c], op))
+                        else:
+                            expected = gb[c].apply(targop)
+                            expected.name = c
+                            tm.assert_series_equal(expected,
+                                                   gb[c].transform(op, *args))
+                            tm.assert_series_equal(expected,
+                                                   getattr(gb[c], op)(*args))
+    def test_groupby_cumprod(self):
+        # GH 4095
+        df = pd.DataFrame({'key': ['b'] * 10, 'value': 2})
+
+        actual = df.groupby('key')['value'].cumprod()
+        expected = df.groupby('key')['value'].apply(lambda x: x.cumprod())
+        expected.name = 'value'
+        tm.assert_series_equal(actual, expected)
+
+        df = pd.DataFrame({'key': ['b'] * 100, 'value': 2})
+        actual = df.groupby('key')['value'].cumprod()
+        # if overflows, groupby product casts to float
+        # while numpy passes back invalid values
+        df['value'] = df['value'].astype(float)
+        expected = df.groupby('key')['value'].apply(lambda x: x.cumprod())
+        expected.name = 'value'
+        tm.assert_series_equal(actual, expected)
+
 
     def test_ops_general(self):
         ops = [('mean', np.mean),


### PR DESCRIPTION
closes - #4095 - adding Cythonized versions of `shift`, `cumprod` and `cumsum`, along with a helper `GroupBy._cython_transform` that other cythonized transform-ops could be added to.

I'm using fused types here instead of adding to `generated.pyx` - as far as I can tell that is working well, looking back through the old issues (#255) it looks like that wasn't done originally because of older versions of Cython?
### 0.16.2

```
In [17]: df = pd.DataFrame({'i':range(1000) * 1000, 
                            'f':np.linspace(0, 2000, 1000000),    
                            'f2':np.linspace(1, 2, 1000000)})

In [18]: %timeit df.groupby('i').cumsum()
1 loops, best of 3: 614 ms per loop

In [19]: %timeit df.groupby('i').shift()
1 loops, best of 3: 499 ms per loop
```
### PR

```
In [2]: %timeit df.groupby('i').cumsum()
10 loops, best of 3: 58.6 ms per loop

In [3]: %timeit df.groupby('i').shift()
10 loops, best of 3: 73.4 ms per loop
```
