### PR TITLE
API: Closes #7879: (drops not nan in panel.to_frame() by default)

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -63,6 +63,7 @@ Highlights include:
 - Development support for benchmarking with the `Air Speed Velocity library <https://github.com/spacetelescope/asv/>`_ (:issue:`8316`)
 - Support for reading SAS xport files, see :ref:`here <whatsnew_0170.enhancements.sas_xport>`
 - Removal of the automatic TimeSeries broadcasting, deprecated since 0.8.0, see :ref:`here <whatsnew_0170.prior_deprecations>`
+- Deprecated ``filter_observations`` by ``dropna`` in ``Panel.to_frame`` and changed default to ``True`` (:issue:`7879`)
 
 See the :ref:`v0.17.0 Whatsnew <whatsnew_0170>` overview for an extensive list
 of all enhancements and bugs that have been fixed in 0.17.0.

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -862,7 +862,8 @@ class Panel(NDFrame):
         axis = self._get_axis_number(axis)
         return PanelGroupBy(self, function, axis=axis)
 
-    def to_frame(self, filter_observations=True):
+    @deprecate_kwarg(old_arg_name='filter_observations', new_arg_name='dropna')
+    def to_frame(self, dropna=False):
         """
         Transform wide format into long (stacked) format as DataFrame whose
         columns are the Panel's items and whose index is a MultiIndex formed
@@ -870,7 +871,11 @@ class Panel(NDFrame):
 
         Parameters
         ----------
-        filter_observations : boolean, default True
+        dropna : boolean, default False
+            Drop (major, minor) pairs without a complete set of observations
+            across all the items
+
+        filter_observations : boolean, default False, [deprecated]
             Drop (major, minor) pairs without a complete set of observations
             across all the items
 
@@ -880,7 +885,7 @@ class Panel(NDFrame):
         """
         _, N, K = self.shape
 
-        if filter_observations:
+        if dropna is True:
             # shaped like the return DataFrame
             mask = com.notnull(self.values).all(axis=0)
             # size = mask.sum()


### PR DESCRIPTION
closes #7879 by changing API (filter_observations=True now deprecated and replaced with dropna=False)
