### PR TITLE
BUG: closes bug in BinGrouper.group_info where returned values are not compatible with base class

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -747,6 +747,7 @@ Bug Fixes
 - Bug in ``Index`` construction with a mixed list of tuples (:issue:`10697`)
 - Bug in ``DataFrame.reset_index`` when index contains `NaT`. (:issue:`10388`)
 - Bug in ``ExcelReader`` when worksheet is empty (:issue:`6403`)
+- Bug in ``BinGrouper.group_info`` where returned values are not compatible with base class (:issue:`10914`)
 
 
 - Bug causing ``DataFrame.where`` to not respect the ``axis`` parameter when the frame has a symmetric shape. (:issue:`9736`)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1790,8 +1790,10 @@ class BinGrouper(BaseGrouper):
 
     @cache_readonly
     def group_info(self):
-        # for compat
-        return self.bins, self.binlabels, self.ngroups
+        ngroups = self.ngroups
+        obs_group_ids = np.arange(ngroups)
+        comp_ids = np.repeat(np.arange(ngroups), np.diff(np.r_[0, self.bins]))
+        return comp_ids, obs_group_ids, ngroups
 
     @cache_readonly
     def ngroups(self):


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/10914
