### PR TITLE
PERF: GH10213 kth_smallest GIL release

### DIFF
--- a/asv_bench/benchmarks/gil.py
+++ b/asv_bench/benchmarks/gil.py
@@ -299,3 +299,24 @@ class nogil_take1d_int64(object):
     @test_parallel(num_threads=2)
     def take_1d_pg2_float64(self):
         com.take_1d(self.df.float64.values, self.indexer)
+
+
+class nogil_kth_smallest(object):
+    number = 1
+    repeat = 5
+
+    def setup(self):
+        if (not have_real_test_parallel):
+            raise NotImplementedError
+        np.random.seed(1234)
+        self.N = 10000000
+        self.k = 500000
+        self.a = np.random.randn(self.N)
+        self.b = self.a.copy()
+        self.kwargs_list = [{'arr': self.a}, {'arr': self.b}]
+
+    def time_nogil_kth_smallest(self):
+        @test_parallel(num_threads=2, kwargs_list=self.kwargs_list)
+        def run(arr):
+            algos.kth_smallest(arr, self.k)
+        run()

--- a/asv_bench/benchmarks/pandas_vb_common.py
+++ b/asv_bench/benchmarks/pandas_vb_common.py
@@ -7,6 +7,7 @@ from numpy.random import permutation
 import pandas.util.testing as tm
 import random
 import numpy as np
+import threading
 try:
     from pandas.compat import range
 except ImportError:

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -69,14 +69,15 @@ Releasing the GIL
 
 We are releasing the global-interpreter-lock (GIL) on some cython operations.
 This will allow other threads to run simultaneously during computation, potentially allowing performance improvements
-from multi-threading. Notably ``groupby`` and some indexing operations are a benefit from this. (:issue:`8882`)
+from multi-threading. Notably ``groupby``, ``nsmallest`` and some indexing operations benefit from this. (:issue:`8882`)
 
 For example the groupby expression in the following code will have the GIL released during the factorization step, e.g. ``df.groupby('key')``
 as well as the ``.sum()`` operation.
 
 .. code-block:: python
 
-   N = 1e6
+   N = 1000000
+   ngroups = 10
    df = DataFrame({'key' : np.random.randint(0,ngroups,size=N),
                    'data' : np.random.randn(N) })
    df.groupby('key')['data'].sum()

--- a/pandas/algos.pyx
+++ b/pandas/algos.pyx
@@ -740,7 +740,7 @@ ctypedef fused numeric:
     float64_t
 
 
-cdef inline Py_ssize_t swap(numeric *a, numeric *b) except -1:
+cdef inline Py_ssize_t swap(numeric *a, numeric *b) nogil except -1:
     cdef numeric t
 
     # cython doesn't allow pointer dereference so use array syntax
@@ -756,27 +756,27 @@ cpdef numeric kth_smallest(numeric[:] a, Py_ssize_t k):
     cdef:
         Py_ssize_t i, j, l, m, n = a.size
         numeric x
+    with nogil:
+        l = 0
+        m = n - 1
 
-    l = 0
-    m = n - 1
+        while l < m:
+            x = a[k]
+            i = l
+            j = m
 
-    while l < m:
-        x = a[k]
-        i = l
-        j = m
+            while 1:
+                while a[i] < x: i += 1
+                while x < a[j]: j -= 1
+                if i <= j:
+                    swap(&a[i], &a[j])
+                    i += 1; j -= 1
 
-        while 1:
-            while a[i] < x: i += 1
-            while x < a[j]: j -= 1
-            if i <= j:
-                swap(&a[i], &a[j])
-                i += 1; j -= 1
+                if i > j: break
 
-            if i > j: break
-
-        if j < k: l = i
-        if k < i: m = j
-    return a[k]
+            if j < k: l = i
+            if k < i: m = j
+        return a[k]
 
 
 cdef inline kth_smallest_c(float64_t* a, Py_ssize_t k, Py_ssize_t n):


### PR DESCRIPTION
One tiny part of #10213 

```
import timeit

setup_seq = '''
import pandas
import numpy
numpy.random.seed(1234)
x = numpy.random.randn(10000000)
a = x.copy()
b = x.copy()

def f(s):
    pandas.algos.kth_smallest(s, 500000)

def seq():
    f(a)
    f(b)
'''

setup_parallel = '''
import pandas
import numpy
import threading
numpy.random.seed(1234)
x = numpy.random.randn(10000000)
a = x.copy()
b = x.copy()

def f(s):
    pandas.algos.kth_smallest(s, 500000)

def parallel():
    thread1 = threading.Thread(target=f, args=(a,))
    thread2 = threading.Thread(target=f, args=(b,))
    thread1.start()
    thread2.start()
    thread1.join()
    thread2.join()
'''

print(min(timeit.repeat(stmt='seq()', setup=setup_seq, repeat=100, number=1)))
print(min(timeit.repeat(stmt='parallel()', setup=setup_parallel, repeat=100, number=1)))
```

On master

```
0.15268295999976544
0.15424678300041705
```

On branch

```
0.1544521670002723
0.08813380599985976
```

Testing of `nsmallest`/`nlargest`/`median` (I don't think `median` calls `kth_smallest` though)

```
import pandas, numpy
from pandas.util.testing import test_parallel
n = 1000000
k = 50000
numpy.random.seed(1234)
s = pandas.Series(numpy.random.randn(n))

def f():
    s.nlargest(k)

def seq():
    f()
    f()

@test_parallel(num_threads=2)
def g():
    f()
```

Master `nsmallest`

```
In [2]: %timeit f()
10 loops, best of 3: 42.4 ms per loop

In [3]: %timeit g()
10 loops, best of 3: 79.9 ms per loop

In [4]: %timeit seq()
10 loops, best of 3: 84.9 ms per loop
```

Branch `nsmallest`

```
In [10]: %timeit f()
10 loops, best of 3: 42.8 ms per loop

In [11]: %timeit g()
10 loops, best of 3: 68.6 ms per loop

In [12]: %timeit seq()
10 loops, best of 3: 91.2 ms per loop
```

Master `nlargest`

```
In [2]: %timeit f()
10 loops, best of 3: 47.5 ms per loop

In [3]: %timeit g()
10 loops, best of 3: 86 ms per loop

In [4]: %timeit seq()
```

Branch `nlargest`

```
In [10]: %timeit f()
10 loops, best of 3: 48.1 ms per loop

In [11]: %timeit g()
10 loops, best of 3: 71 ms per loop

In [12]: %timeit seq()
10 loops, best of 3: 95.7 ms per loop
```

Master `median`

```
In [2]: %timeit f()
100 loops, best of 3: 15.4 ms per loop

In [3]: %timeit g()
10 loops, best of 3: 20.7 ms per loop

In [4]: %timeit seq()
10 loops, best of 3: 30.7 ms per loop
```

Branch `median`

```
In [12]: %timeit f()
100 loops, best of 3: 15 ms per loop

In [13]: %timeit g()
10 loops, best of 3: 21.5 ms per loop

In [14]: %timeit seq()
10 loops, best of 3: 30 ms per loop
```

Results are pretty in line with expectations -- `nsmallest` does quite a bit more than `kth_smallest`, such as copying and indexing. 
