### PR TITLE
[DEPR]: Deprecate setting nans in categories

### DIFF
--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -1,5 +1,5 @@
 from .pandas_vb_common import *
-
+import string
 
 class concat_categorical(object):
     goal_time = 0.2
@@ -25,3 +25,21 @@ class categorical_value_counts(object):
 
     def time_value_counts_dropna(self):
         self.ts.value_counts(dropna=True)
+
+class categorical_constructor(object):
+    goal_time = 0.2
+
+    def setup(self):
+        n = 5
+        N = 1e6
+        self.categories = list(string.ascii_letters[:n])
+        self.cat_idx = Index(self.categories)
+        self.values = np.tile(self.categories, N)
+        self.codes = np.tile(range(n), N)
+
+    def time_regular_constructor(self):
+        Categorical(self.values, self.categories)
+
+    def time_fastpath(self):
+        Categorical(self.codes, self.cat_idx, fastpath=True)
+

--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -632,41 +632,35 @@ Missing Data
 
 pandas primarily uses the value `np.nan` to represent missing data. It is by
 default not included in computations. See the :ref:`Missing Data section
-<missing_data>`
+<missing_data>`.
 
-There are two ways a `np.nan` can be represented in categorical data: either the value is not
-available ("missing value") or `np.nan` is a valid category.
+Missing values should **not** be included in the Categorical's ``categories``,
+only in the ``values``.
+Instead, it is understood that NaN is different, and is always a possibility.
+When working with the Categorical's ``codes``, missing values will always have
+a code of ``-1``.
 
 .. ipython:: python
 
     s = pd.Series(["a","b",np.nan,"a"], dtype="category")
     # only two categories
     s
-    s2 = pd.Series(["a","b","c","a"], dtype="category")
-    s2.cat.categories = [1,2,np.nan]
-    # three categories, np.nan included
-    s2
+    s.codes
 
-.. note::
-    As integer `Series` can't include NaN, the categories were converted to `object`.
 
-.. note::
-    Missing value methods like ``isnull`` and ``fillna`` will take both missing values as well as
-    `np.nan` categories into account:
+Methods for working with missing data, e.g. :meth:`~Series.isnull`, :meth:`~Series.fillna`,
+:meth:`~Series.dropna`, all work normally:
 
 .. ipython:: python
 
     c = pd.Series(["a","b",np.nan], dtype="category")
-    c.cat.set_categories(["a","b",np.nan], inplace=True)
-    # will be inserted as a NA category:
-    c[0] = np.nan
     s = pd.Series(c)
     s
     pd.isnull(s)
     s.fillna("a")
 
 Differences to R's `factor`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------
 
 The following differences to R's factor functions can be observed:
 
@@ -677,6 +671,9 @@ The following differences to R's factor functions can be observed:
 * In contrast to R's `factor` function, using categorical data as the sole input to create a
   new categorical series will *not* remove unused categories but create a new categorical series
   which is equal to the passed in one!
+* R allows for missing values to be included in its `levels` (pandas' `categories`). Pandas
+  does not allow `NaN` categories, but missing values can still be in the `values`.
+
 
 Gotchas
 -------

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -652,6 +652,7 @@ Deprecations
   =====================  =================================
 
 - ``Categorical.name`` was deprecated to make ``Categorical`` more ``numpy.ndarray`` like. Use ``Series(cat, name="whatever")`` instead (:issue:`10482`).
+- Setting missing values (NaN) in a ``Categorical``'s ``categories`` will issue a warning (:issue:`10748`). You can still have missing values in the ``values``.
 - ``drop_duplicates`` and ``duplicated``'s ``take_last`` keyword was deprecated in favor of ``keep``. (:issue:`6511`, :issue:`8505`)
 - ``Series.nsmallest`` and ``nlargest``'s ``take_last`` keyword was deprecated in favor of ``keep``. (:issue:`10792`)
 - ``DataFrame.combineAdd`` and ``DataFrame.combineMult`` are deprecated. They

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -392,6 +392,7 @@ class IndexOpsMixin(object):
         """
         return nanops.nanargmin(self.values)
 
+    @cache_readonly
     def hasnans(self):
         """ return if I have any nans; enables various perf speedups """
         return com.isnull(self).any()

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -129,7 +129,8 @@ class TestCategorical(tm.TestCase):
             Categorical(["a","b"], ["a","b","b"])
         self.assertRaises(ValueError, f)
         def f():
-            Categorical([1,2], [1,2,np.nan, np.nan])
+            with tm.assert_produces_warning(FutureWarning):
+                Categorical([1,2], [1,2,np.nan, np.nan])
         self.assertRaises(ValueError, f)
 
         # The default should be unordered
@@ -879,15 +880,18 @@ class TestCategorical(tm.TestCase):
                 base = Categorical([], with_null)
             expected = Categorical([], without)
 
-            with tm.assert_produces_warning(FutureWarning):
-                for nullval in null_values:
-                    result = base.remove_categories(nullval)
-                self.assert_categorical_equal(result, expected)
+            for nullval in null_values:
+                result = base.remove_categories(nullval)
+            self.assert_categorical_equal(result, expected)
 
         # Different null values are indistinguishable
         for i, j in [(0, 1), (0, 2), (1, 2)]:
             nulls = [null_values[i], null_values[j]]
-            self.assertRaises(ValueError, lambda: Categorical([], categories=nulls))
+
+            def f():
+                with tm.assert_produces_warning(FutureWarning):
+                    Categorical([], categories=nulls)
+            self.assertRaises(ValueError, f)
 
 
     def test_isnull(self):
@@ -3488,8 +3492,8 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
         c[0] = np.nan
         df = pd.DataFrame({"cats":c, "vals":[1,2,3]})
         df_exp = pd.DataFrame({"cats": Categorical(["a","b","a"]), "vals": [1,2,3]})
-        with tm.assert_produces_warning(FutureWarning):
-            res = df.fillna("a")
+
+        res = df.fillna("a")
         tm.assert_frame_equal(res, df_exp)
 
 

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -187,17 +187,21 @@ class TestCategorical(tm.TestCase):
         cat = pd.Categorical([np.nan, 1., 2., 3. ])
         self.assertTrue(com.is_float_dtype(cat.categories))
 
+        # Deprecating NaNs in categoires (GH #10748)
         # preserve int as far as possible by converting to object if NaN is in categories
-        cat = pd.Categorical([np.nan, 1, 2, 3], categories=[np.nan, 1, 2, 3])
+        with tm.assert_produces_warning(FutureWarning):
+            cat = pd.Categorical([np.nan, 1, 2, 3], categories=[np.nan, 1, 2, 3])
         self.assertTrue(com.is_object_dtype(cat.categories))
         # This doesn't work -> this would probably need some kind of "remember the original type"
         # feature to try to cast the array interface result to...
         #vals = np.asarray(cat[cat.notnull()])
         #self.assertTrue(com.is_integer_dtype(vals))
-        cat = pd.Categorical([np.nan,"a", "b", "c"], categories=[np.nan,"a", "b", "c"])
+        with tm.assert_produces_warning(FutureWarning):
+            cat = pd.Categorical([np.nan,"a", "b", "c"], categories=[np.nan,"a", "b", "c"])
         self.assertTrue(com.is_object_dtype(cat.categories))
         # but don't do it for floats
-        cat = pd.Categorical([np.nan, 1., 2., 3.], categories=[np.nan, 1., 2., 3.])
+        with tm.assert_produces_warning(FutureWarning):
+            cat = pd.Categorical([np.nan, 1., 2., 3.], categories=[np.nan, 1., 2., 3.])
         self.assertTrue(com.is_float_dtype(cat.categories))
 
 
@@ -465,8 +469,9 @@ class TestCategorical(tm.TestCase):
         tm.assert_frame_equal(desc, expected)
 
         # NA as a category
-        cat = pd.Categorical(["a","c","c",np.nan], categories=["b","a","c",np.nan])
-        result = cat.describe()
+        with tm.assert_produces_warning(FutureWarning):
+            cat = pd.Categorical(["a","c","c",np.nan], categories=["b","a","c",np.nan])
+            result = cat.describe()
 
         expected = DataFrame([[0,0],[1,0.25],[2,0.5],[1,0.25]],
                              columns=['counts','freqs'],
@@ -474,8 +479,9 @@ class TestCategorical(tm.TestCase):
         tm.assert_frame_equal(result,expected)
 
         # NA as an unused category
-        cat = pd.Categorical(["a","c","c"], categories=["b","a","c",np.nan])
-        result = cat.describe()
+        with tm.assert_produces_warning(FutureWarning):
+            cat = pd.Categorical(["a","c","c"], categories=["b","a","c",np.nan])
+            result = cat.describe()
 
         expected = DataFrame([[0,0],[1,1/3.],[2,2/3.],[0,0]],
                              columns=['counts','freqs'],
@@ -827,29 +833,37 @@ class TestCategorical(tm.TestCase):
         self.assert_numpy_array_equal(c._codes , np.array([0,-1,-1,0]))
 
         # If categories have nan included, the code should point to that instead
-        c = Categorical(["a","b",np.nan,"a"], categories=["a","b",np.nan])
-        self.assert_numpy_array_equal(c.categories , np.array(["a","b",np.nan],dtype=np.object_))
-        self.assert_numpy_array_equal(c._codes , np.array([0,1,2,0]))
+        with tm.assert_produces_warning(FutureWarning):
+            c = Categorical(["a","b",np.nan,"a"], categories=["a","b",np.nan])
+        self.assert_numpy_array_equal(c.categories, np.array(["a","b",np.nan],
+                                                             dtype=np.object_))
+        self.assert_numpy_array_equal(c._codes, np.array([0,1,2,0]))
         c[1] = np.nan
-        self.assert_numpy_array_equal(c.categories , np.array(["a","b",np.nan],dtype=np.object_))
-        self.assert_numpy_array_equal(c._codes , np.array([0,2,2,0]))
+        self.assert_numpy_array_equal(c.categories, np.array(["a","b",np.nan],
+                                                             dtype=np.object_))
+        self.assert_numpy_array_equal(c._codes, np.array([0,2,2,0]))
 
         # Changing categories should also make the replaced category np.nan
         c = Categorical(["a","b","c","a"])
-        c.categories = ["a","b",np.nan]
-        self.assert_numpy_array_equal(c.categories , np.array(["a","b",np.nan],dtype=np.object_))
-        self.assert_numpy_array_equal(c._codes , np.array([0,1,2,0]))
+        with tm.assert_produces_warning(FutureWarning):
+            c.categories = ["a","b",np.nan]
+        self.assert_numpy_array_equal(c.categories, np.array(["a","b",np.nan],
+                                                             dtype=np.object_))
+        self.assert_numpy_array_equal(c._codes, np.array([0,1,2,0]))
 
         # Adding nan to categories should make assigned nan point to the category!
         c = Categorical(["a","b",np.nan,"a"])
         self.assert_numpy_array_equal(c.categories , np.array(["a","b"]))
         self.assert_numpy_array_equal(c._codes , np.array([0,1,-1,0]))
-        c.set_categories(["a","b",np.nan], rename=True, inplace=True)
-        self.assert_numpy_array_equal(c.categories , np.array(["a","b",np.nan],dtype=np.object_))
-        self.assert_numpy_array_equal(c._codes , np.array([0,1,-1,0]))
+        with tm.assert_produces_warning(FutureWarning):
+            c.set_categories(["a","b",np.nan], rename=True, inplace=True)
+        self.assert_numpy_array_equal(c.categories, np.array(["a","b",np.nan],
+                                                             dtype=np.object_))
+        self.assert_numpy_array_equal(c._codes, np.array([0,1,-1,0]))
         c[1] = np.nan
-        self.assert_numpy_array_equal(c.categories , np.array(["a","b",np.nan],dtype=np.object_))
-        self.assert_numpy_array_equal(c._codes , np.array([0,2,-1,0]))
+        self.assert_numpy_array_equal(c.categories , np.array(["a","b",np.nan],
+                                                              dtype=np.object_))
+        self.assert_numpy_array_equal(c._codes, np.array([0,2,-1,0]))
 
         # Remove null categories (GH 10156)
         cases = [
@@ -861,11 +875,13 @@ class TestCategorical(tm.TestCase):
         null_values = [np.nan, None, pd.NaT]
 
         for with_null, without in cases:
-            base = Categorical([], with_null)
+            with tm.assert_produces_warning(FutureWarning):
+                base = Categorical([], with_null)
             expected = Categorical([], without)
 
-            for nullval in null_values:
-                result = base.remove_categories(nullval)
+            with tm.assert_produces_warning(FutureWarning):
+                for nullval in null_values:
+                    result = base.remove_categories(nullval)
                 self.assert_categorical_equal(result, expected)
 
         # Different null values are indistinguishable
@@ -880,14 +896,16 @@ class TestCategorical(tm.TestCase):
         res = c.isnull()
         self.assert_numpy_array_equal(res, exp)
 
-        c = Categorical(["a","b",np.nan], categories=["a","b",np.nan])
+        with tm.assert_produces_warning(FutureWarning):
+            c = Categorical(["a","b",np.nan], categories=["a","b",np.nan])
         res = c.isnull()
         self.assert_numpy_array_equal(res, exp)
 
         # test both nan in categories and as -1
         exp = np.array([True, False, True])
         c = Categorical(["a","b",np.nan])
-        c.set_categories(["a","b",np.nan], rename=True, inplace=True)
+        with tm.assert_produces_warning(FutureWarning):
+            c.set_categories(["a","b",np.nan], rename=True, inplace=True)
         c[0] = np.nan
         res = c.isnull()
         self.assert_numpy_array_equal(res, exp)
@@ -1087,31 +1105,36 @@ class TestCategorical(tm.TestCase):
 
         # if nan in categories, the proper code should be set!
         cat = pd.Categorical([1,2,3, np.nan], categories=[1,2,3])
-        cat.set_categories([1,2,3, np.nan], rename=True, inplace=True)
+        with tm.assert_produces_warning(FutureWarning):
+            cat.set_categories([1,2,3, np.nan], rename=True, inplace=True)
         cat[1] = np.nan
         exp = np.array([0,3,2,-1])
         self.assert_numpy_array_equal(cat.codes, exp)
 
         cat = pd.Categorical([1,2,3, np.nan], categories=[1,2,3])
-        cat.set_categories([1,2,3, np.nan], rename=True, inplace=True)
+        with tm.assert_produces_warning(FutureWarning):
+            cat.set_categories([1,2,3, np.nan], rename=True, inplace=True)
         cat[1:3] = np.nan
         exp = np.array([0,3,3,-1])
         self.assert_numpy_array_equal(cat.codes, exp)
 
         cat = pd.Categorical([1,2,3, np.nan], categories=[1,2,3])
-        cat.set_categories([1,2,3, np.nan], rename=True, inplace=True)
+        with tm.assert_produces_warning(FutureWarning):
+            cat.set_categories([1,2,3, np.nan], rename=True, inplace=True)
         cat[1:3] = [np.nan, 1]
         exp = np.array([0,3,0,-1])
         self.assert_numpy_array_equal(cat.codes, exp)
 
         cat = pd.Categorical([1,2,3, np.nan], categories=[1,2,3])
-        cat.set_categories([1,2,3, np.nan], rename=True, inplace=True)
+        with tm.assert_produces_warning(FutureWarning):
+            cat.set_categories([1,2,3, np.nan], rename=True, inplace=True)
         cat[1:3] = [np.nan, np.nan]
         exp = np.array([0,3,3,-1])
         self.assert_numpy_array_equal(cat.codes, exp)
 
         cat = pd.Categorical([1,2, np.nan, 3], categories=[1,2,3])
-        cat.set_categories([1,2,3, np.nan], rename=True, inplace=True)
+        with tm.assert_produces_warning(FutureWarning):
+            cat.set_categories([1,2,3, np.nan], rename=True, inplace=True)
         cat[pd.isnull(cat)] = np.nan
         exp = np.array([0,1,3,2])
         self.assert_numpy_array_equal(cat.codes, exp)
@@ -1555,14 +1578,16 @@ class TestCategoricalAsBlock(tm.TestCase):
         self.assert_numpy_array_equal(s.values.codes, np.array([0,1,-1,0]))
 
         # If categories have nan included, the label should point to that instead
-        s2 = Series(Categorical(["a","b",np.nan,"a"], categories=["a","b",np.nan]))
+        with tm.assert_produces_warning(FutureWarning):
+            s2 = Series(Categorical(["a","b",np.nan,"a"], categories=["a","b",np.nan]))
         self.assert_numpy_array_equal(s2.cat.categories,
                                       np.array(["a","b",np.nan], dtype=np.object_))
         self.assert_numpy_array_equal(s2.values.codes, np.array([0,1,2,0]))
 
         # Changing categories should also make the replaced category np.nan
         s3 = Series(Categorical(["a","b","c","a"]))
-        s3.cat.categories = ["a","b",np.nan]
+        with tm.assert_produces_warning(FutureWarning):
+            s3.cat.categories = ["a","b",np.nan]
         self.assert_numpy_array_equal(s3.cat.categories,
                                       np.array(["a","b",np.nan], dtype=np.object_))
         self.assert_numpy_array_equal(s3.values.codes, np.array([0,1,2,0]))
@@ -2415,28 +2440,32 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
             s.value_counts(dropna=False, sort=False),
             pd.Series([2, 1, 3], index=["a", "b", np.nan]))
 
-        s = pd.Series(pd.Categorical(["a", "b", "a"], categories=["a", "b", np.nan]))
-        tm.assert_series_equal(
-            s.value_counts(dropna=True),
-            pd.Series([2, 1], index=["a", "b"]))
-        tm.assert_series_equal(
-            s.value_counts(dropna=False),
-            pd.Series([2, 1, 0], index=["a", "b", np.nan]))
+        with tm.assert_produces_warning(FutureWarning):
+            s = pd.Series(pd.Categorical(["a", "b", "a"], categories=["a", "b", np.nan]))
+            tm.assert_series_equal(
+                s.value_counts(dropna=True),
+                pd.Series([2, 1], index=["a", "b"]))
+            tm.assert_series_equal(
+                s.value_counts(dropna=False),
+                pd.Series([2, 1, 0], index=["a", "b", np.nan]))
 
-        s = pd.Series(pd.Categorical(["a", "b", None, "a", None, None], categories=["a", "b", np.nan]))
-        tm.assert_series_equal(
-            s.value_counts(dropna=True),
-            pd.Series([2, 1], index=["a", "b"]))
-        tm.assert_series_equal(
-            s.value_counts(dropna=False),
-            pd.Series([3, 2, 1], index=[np.nan, "a", "b"]))
+        with tm.assert_produces_warning(FutureWarning):
+            s = pd.Series(pd.Categorical(["a", "b", None, "a", None, None],
+                                         categories=["a", "b", np.nan]))
+            tm.assert_series_equal(
+                s.value_counts(dropna=True),
+                pd.Series([2, 1], index=["a", "b"]))
+            tm.assert_series_equal(
+                s.value_counts(dropna=False),
+                pd.Series([3, 2, 1], index=[np.nan, "a", "b"]))
 
     def test_groupby(self):
 
         cats = Categorical(["a", "a", "a", "b", "b", "b", "c", "c", "c"], categories=["a","b","c","d"], ordered=True)
         data = DataFrame({"a":[1,1,1,2,2,2,3,4,5], "b":cats})
 
-        expected = DataFrame({ 'a' : Series([1,2,4,np.nan],index=Index(['a','b','c','d'],name='b')) })
+        expected = DataFrame({'a': Series([1, 2, 4, np.nan],
+                             index=Index(['a', 'b', 'c', 'd'], name='b'))})
         result = data.groupby("b").mean()
         tm.assert_frame_equal(result, expected)
 
@@ -3454,11 +3483,13 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
 
         # make sure that fillna takes both missing values and NA categories into account
         c = Categorical(["a","b",np.nan])
-        c.set_categories(["a","b",np.nan], rename=True, inplace=True)
+        with tm.assert_produces_warning(FutureWarning):
+            c.set_categories(["a","b",np.nan], rename=True, inplace=True)
         c[0] = np.nan
         df = pd.DataFrame({"cats":c, "vals":[1,2,3]})
         df_exp = pd.DataFrame({"cats": Categorical(["a","b","a"]), "vals": [1,2,3]})
-        res = df.fillna("a")
+        with tm.assert_produces_warning(FutureWarning):
+            res = df.fillna("a")
         tm.assert_frame_equal(res, df_exp)
 
 


### PR DESCRIPTION
WIP still

Closes https://github.com/pydata/pandas/issues/10748

I have to run for now, but will pick this up later today.
I think I'm missing a few in the tests, since the warning is showing up in a bunch of places (there's a way to convert those to errors for testing right?)

I had to refactor a couple function that were setting `._categories` directly instead of using `Categorical._set_categories`. I kept that in a separate commit. Could do a bit more refactoring with the `validate_categories` stuff, but that can be separate.

And I need to figure out the proper `stacklevel` for this warning. I think I used 3 for now.
