### PR TITLE
ENH: Add Series.dt.total_seconds GH #10817

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -176,6 +176,10 @@ Other enhancements
 
 - ``pandas.tseries.offsets`` larger than the ``Day`` offset can now be used with with ``Series`` for addition/subtraction (:issue:`10699`).  See the :ref:`Documentation <timeseries.offsetseries>` for more details.
 
+- ``pd.Series`` of type ``timedelta64`` has new method ``.dt.total_seconds()`` returning the duration of the timedelta in seconds (:issue: `10817`)
+
+- ``pd.Timedelta.total_seconds()`` now returns Timedelta duration to ns precision (previously microsecond precision) (:issue: `10939`)
+
 - ``.as_blocks`` will now take a ``copy`` optional argument to return a copy of the data, default is to copy (no change in behavior from prior versions), (:issue:`9607`)
 
 - ``regex`` argument to ``DataFrame.filter`` now handles numeric column names instead of raising ``ValueError`` (:issue:`10384`).

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -89,7 +89,7 @@ class CheckNameIntegration(object):
                                    'is_quarter_end', 'is_year_start', 'is_year_end', 'tz']
         ok_for_dt_methods = ['to_period','to_pydatetime','tz_localize','tz_convert', 'normalize', 'strftime']
         ok_for_td = ['days','seconds','microseconds','nanoseconds']
-        ok_for_td_methods = ['components','to_pytimedelta']
+        ok_for_td_methods = ['components','to_pytimedelta','total_seconds']
 
         def get_expected(s, name):
             result = getattr(Index(s.values),prop)
@@ -157,6 +157,10 @@ class CheckNameIntegration(object):
             result = s.dt.to_pytimedelta()
             self.assertIsInstance(result,np.ndarray)
             self.assertTrue(result.dtype == object)
+            
+            result = s.dt.total_seconds()
+            self.assertIsInstance(result,pd.Series)
+            self.assertTrue(result.dtype == 'float64')
 
             freq_result = s.dt.freq
             self.assertEqual(freq_result, TimedeltaIndex(s.values, freq='infer').freq)

--- a/pandas/tseries/common.py
+++ b/pandas/tseries/common.py
@@ -161,7 +161,7 @@ TimedeltaProperties._add_delegate_accessors(delegate=TimedeltaIndex,
                                             accessors=TimedeltaIndex._datetimelike_ops,
                                             typ='property')
 TimedeltaProperties._add_delegate_accessors(delegate=TimedeltaIndex,
-                                            accessors=["to_pytimedelta"],
+                                            accessors=["to_pytimedelta", "total_seconds"],
                                             typ='method')
 
 class PeriodProperties(Properties):

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -391,6 +391,10 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, Int64Index):
             result = result.astype('int64')
         return result
 
+    def total_seconds(self):
+        """ Total duration of each element expressed in seconds. """
+        return self._maybe_mask_results(1e-9*self.asi8)
+
     def to_pytimedelta(self):
         """
         Return TimedeltaIndex as object ndarray of datetime.timedelta objects

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -642,6 +642,10 @@ class NaTType(_NaT):
 
     def __reduce__(self):
         return (__nat_unpickle, (None, ))
+    
+    def total_seconds(self):
+        # GH 10939
+        return np.nan
 
 
 fields = ['year', 'quarter', 'month', 'day', 'hour',
@@ -673,7 +677,7 @@ def _make_nan_func(func_name):
 
 _nat_methods = ['date', 'now', 'replace', 'to_datetime', 'today']
 
-_nan_methods = ['weekday', 'isoweekday']
+_nan_methods = ['weekday', 'isoweekday', 'total_seconds']
 
 _implemented_methods = ['to_datetime64']
 _implemented_methods.extend(_nat_methods)
@@ -2412,6 +2416,12 @@ class Timedelta(_Timedelta):
         """
         self._ensure_components()
         return self._ns
+    
+    def total_seconds(self):
+        """
+        Total duration of timedelta in seconds (to ns precision)
+        """
+        return 1e-9*self.value
 
     def __setstate__(self, state):
         (value) = state


### PR DESCRIPTION
Implements a Series.dt.total_seconds method for timedelta64 Series.

closes #10817
