### PR TITLE
BUG: passing columns and dict with scalar values should raise error

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -836,3 +836,4 @@ Bug Fixes
 - Bug in ``to_json`` which was causing segmentation fault when serializing 0-rank ndarray (:issue:`9576`)
 - Bug in plotting functions may raise ``IndexError`` when plotted on ``GridSpec`` (:issue:`10819`)
 - Bug in plot result may show unnecessary minor ticklabels (:issue:`10657`)
+- Bug when constructing ``DataFrame`` where passing a dictionary with only scalar values and specifying columns did not raise an error (:issue:`10856`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -298,13 +298,18 @@ class DataFrame(NDFrame):
         if columns is not None:
             columns = _ensure_index(columns)
 
-            # prefilter if columns passed
+            # GH10856
+            # raise ValueError if only scalars in dict
+            if index is None:
+                extract_index(list(data.values()))
 
+            # prefilter if columns passed
             data = dict((k, v) for k, v in compat.iteritems(data)
                         if k in columns)
 
             if index is None:
                 index = extract_index(list(data.values()))
+
             else:
                 index = _ensure_index(index)
 
@@ -330,6 +335,7 @@ class DataFrame(NDFrame):
                     v = data[k]
                 data_names.append(k)
                 arrays.append(v)
+
         else:
             keys = list(data.keys())
             if not isinstance(data, OrderedDict):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2762,6 +2762,17 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         frame = DataFrame({'A': [], 'B': []}, columns=['A', 'B'])
         self.assertTrue(frame.index.equals(Index([])))
 
+        # GH10856
+        # dict with scalar values should raise error, even if columns passed
+        with tm.assertRaises(ValueError):
+            DataFrame({'a': 0.7})
+
+        with tm.assertRaises(ValueError):
+            DataFrame({'a': 0.7}, columns=['a'])
+
+        with tm.assertRaises(ValueError):
+            DataFrame({'a': 0.7}, columns=['b'])
+
     def test_constructor_multi_index(self):
         # GH 4078
         # construction error with mi and all-nan frame


### PR DESCRIPTION
Fixes [GH10856](https://github.com/pydata/pandas/issues/10856).

``` Python
>>> pd.DataFrame({'a':0.1}, columns=['b'])
ValueError: If using all scalar values, you must pass an index
```

Trying to raise this error was slightly trickier than I anticipated - this was the only way that didn't break existing tests. If no index is passed to the constructor, `extract_index` is called to check whether the dictionary contacts only scalar values (and raises the ValueError if so).

This check now happens _prior_ to preselecting any columns. If people are happy with this approach I can write tests for the PR.
