### PR TITLE
BUG: Index name lost in conv #10875

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -770,7 +770,7 @@ Bug Fixes
 - Bug in ``filter`` (regression from 0.16.0) and ``transform`` when grouping on multiple keys, one of which is datetime-like (:issue:`10114`)
 
 
-
+- Bug in ``to_datetime`` and ``to_timedelta`` causing ``Index`` name to be lost (:issue:`10875`)
 
 
 - Bug that caused segfault when resampling an empty Series (:issue:`10228`)

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -1732,6 +1732,11 @@ class TestIndex(Base, tm.TestCase):
             df.index == index_a
         tm.assert_numpy_array_equal(index_a == mi3, np.array([False, False, False]))
 
+    def test_conversion_preserves_name(self):
+        #GH 10875
+        i = pd.Index(['01:02:03', '01:02:04'], name='label')
+        self.assertEqual(i.name, pd.to_datetime(i).name)
+        self.assertEqual(i.name, pd.to_timedelta(i).name)
 
 class TestCategoricalIndex(Base, tm.TestCase):
     _holder = CategoricalIndex

--- a/pandas/tseries/timedeltas.py
+++ b/pandas/tseries/timedeltas.py
@@ -8,7 +8,7 @@ import pandas.tslib as tslib
 from pandas import compat
 from pandas.core.common import (ABCSeries, is_integer_dtype,
                                 is_timedelta64_dtype, is_list_like,
-                                isnull, _ensure_object)
+                                isnull, _ensure_object, ABCIndexClass)
 from pandas.util.decorators import deprecate_kwarg
 
 @deprecate_kwarg(old_arg_name='coerce', new_arg_name='errors',
@@ -35,7 +35,7 @@ def to_timedelta(arg, unit='ns', box=True, errors='raise', coerce=None):
     """
     unit = _validate_timedelta_unit(unit)
 
-    def _convert_listlike(arg, box, unit):
+    def _convert_listlike(arg, box, unit, name=None):
 
         if isinstance(arg, (list,tuple)) or ((hasattr(arg,'__iter__') and not hasattr(arg,'dtype'))):
             arg = np.array(list(arg), dtype='O')
@@ -51,7 +51,7 @@ def to_timedelta(arg, unit='ns', box=True, errors='raise', coerce=None):
 
         if box:
             from pandas import TimedeltaIndex
-            value = TimedeltaIndex(value,unit='ns')
+            value = TimedeltaIndex(value,unit='ns', name=name)
         return value
 
     if arg is None:
@@ -60,6 +60,8 @@ def to_timedelta(arg, unit='ns', box=True, errors='raise', coerce=None):
         from pandas import Series
         values = _convert_listlike(arg.values, box=False, unit=unit)
         return Series(values, index=arg.index, name=arg.name, dtype='m8[ns]')
+    elif isinstance(arg, ABCIndexClass):
+        return _convert_listlike(arg, box=box, unit=unit, name=arg.name)
     elif is_list_like(arg):
         return _convert_listlike(arg, box=box, unit=unit)
 


### PR DESCRIPTION
Addresses #10875, when `Index` is converted via `to_datetime`, `to_timedelta`
part of #9862 master issue
