### PR TITLE
BUG: DataFrame subplot with duplicated columns output incorrect result

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -922,3 +922,4 @@ Bug Fixes
 - Bug in ``groupby`` incorrect computation for aggregation on ``DataFrame`` with ``NaT`` (E.g ``first``, ``last``, ``min``). (:issue:`10590`)
 - Bug when constructing ``DataFrame`` where passing a dictionary with only scalar values and specifying columns did not raise an error (:issue:`10856`)
 - Bug in ``.var()`` causing roundoff errors for highly similar values (:issue:`10242`)
+- Bug in ``DataFrame.plot(subplots=True)`` with duplicated columns outputs incorrect result (:issue:`10962`)

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1646,6 +1646,28 @@ class TestDataFramePlots(TestPlotBase):
         for ax in axes.ravel():
             self._check_visible(ax.get_yticklabels(), visible=True)
 
+    @slow
+    def test_subplots_dup_columns(self):
+        # GH 10962
+        df = DataFrame(np.random.rand(5, 5), columns=list('aaaaa'))
+        axes = df.plot(subplots=True)
+        for ax in axes:
+            self._check_legend_labels(ax, labels=['a'])
+            self.assertEqual(len(ax.lines), 1)
+        tm.close()
+
+        axes = df.plot(subplots=True, secondary_y='a')
+        for ax in axes:
+            # (right) is only attached when subplots=False
+            self._check_legend_labels(ax, labels=['a'])
+            self.assertEqual(len(ax.lines), 1)
+        tm.close()
+
+        ax = df.plot(secondary_y='a')
+        self._check_legend_labels(ax, labels=['a (right)'] * 5)
+        self.assertEqual(len(ax.lines), 0)
+        self.assertEqual(len(ax.right_ax.lines), 5)
+
     def test_negative_log(self):
         df = - DataFrame(rand(6, 4),
                        index=list(string.ascii_letters[:6]),

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -920,11 +920,11 @@ class MPLPlot(object):
         else:
             columns = data.columns
 
-        for col in columns:
+        for col, values in data.iteritems():
             if keep_index is True:
-                yield col, data[col]
+                yield col, values
             else:
-                yield col, data[col].values
+                yield col, values.values
 
     @property
     def nseries(self):


### PR DESCRIPTION
When `DataFrame` has duplicated column name, each subplot will contain all the lines with same name.

```
import pandas as pd
import numpy as np
df = pd.DataFrame(np.random.rand(5, 5), columns=list('aaaaa'))
df.plot(subplots=True)
```

![figure_1](https://cloud.githubusercontent.com/assets/1696302/9609047/7acba4d0-510c-11e5-872d-1fcc1fcf8ce6.png)
