### PR TITLE
DOC: Add note regarding 0-len string to default NA values in IO docs

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -731,7 +731,9 @@ the corresponding equivalent values will also imply a missing value (in this cas
 
 To completely override the default values that are recognized as missing, specify ``keep_default_na=False``.
 The default ``NaN`` recognized values are ``['-1.#IND', '1.#QNAN', '1.#IND', '-1.#QNAN', '#N/A','N/A', 'NA',
-'#NA', 'NULL', 'NaN', '-NaN', 'nan', '-nan']``.
+'#NA', 'NULL', 'NaN', '-NaN', 'nan', '-nan']``. Although a 0-length string
+``''`` is not included in the default ``NaN`` values list, it is still treated
+as a missing value.
 
 .. code-block:: python
 


### PR DESCRIPTION
Fixes https://github.com/pydata/pandas/issues/10700
