### PR TITLE
COMPAT: remove SettingWithCopy warning, and use copy-on-write, #10954

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -26,14 +26,11 @@ from pandas.core.config import get_option
 class PandasError(Exception):
     pass
 
+class SettingImmutableError(ValueError):
+    pass
 
 class SettingWithCopyError(ValueError):
     pass
-
-
-class SettingWithCopyWarning(Warning):
-    pass
-
 
 class AmbiguousIndexError(PandasError, KeyError):
     pass

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -321,13 +321,12 @@ with cf.config_prefix('mode'):
 # user warnings
 chained_assignment = """
 : string
-    Raise an exception, warn, or no action if trying to use chained assignment,
-    The default is warn
+  this option has been deprecated and has no effect
 """
 
-with cf.config_prefix('mode'):
-    cf.register_option('chained_assignment', 'warn', chained_assignment,
-                       validator=is_one_of_factory([None, 'warn', 'raise']))
+cf.register_option('mode.chained_assignment', 'warn', chained_assignment,
+                   validator=is_one_of_factory([None, 'warn', 'raise']))
+cf.deprecate_option('mode.chained_assignment', chained_assignment)
 
 
 # Set up the io.excel specific configuration.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2229,7 +2229,7 @@ class DataFrame(NDFrame):
             self._set_item(key, value)
 
     def _setitem_slice(self, key, value):
-        self._check_setitem_copy()
+        self._check_copy_on_write()
         self.ix._setitem_with_indexer(key, value)
 
     def _setitem_array(self, key, value):
@@ -2240,7 +2240,7 @@ class DataFrame(NDFrame):
                                  (len(key), len(self.index)))
             key = check_bool_indexer(self.index, key)
             indexer = key.nonzero()[0]
-            self._check_setitem_copy()
+            self._check_copy_on_write()
             self.ix._setitem_with_indexer(indexer, value)
         else:
             if isinstance(value, DataFrame):
@@ -2250,7 +2250,7 @@ class DataFrame(NDFrame):
                     self[k1] = value[k2]
             else:
                 indexer = self.ix._convert_to_indexer(key, axis=1)
-                self._check_setitem_copy()
+                self._check_copy_on_write()
                 self.ix._setitem_with_indexer((slice(None), indexer), value)
 
     def _setitem_frame(self, key, value):
@@ -2260,7 +2260,7 @@ class DataFrame(NDFrame):
             raise TypeError('Must pass DataFrame with boolean values only')
 
         self._check_inplace_setting(value)
-        self._check_setitem_copy()
+        self._check_copy_on_write()
         self.where(-key, value, inplace=True)
 
     def _ensure_valid_index(self, value):
@@ -2295,12 +2295,6 @@ class DataFrame(NDFrame):
         self._ensure_valid_index(value)
         value = self._sanitize_column(key, value)
         NDFrame._set_item(self, key, value)
-
-        # check if we are modifying a copy
-        # try to set first as we want an invalid
-        # value exeption to occur first
-        if len(self):
-            self._check_setitem_copy()
 
     def insert(self, loc, column, value, allow_duplicates=False):
         """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2300,12 +2300,13 @@ class DataFrame(NDFrame):
 
             # if we have a multi-index (which potentially has dropped levels)
             # need to raise
-            if isinstance(self._parent().columns, MultiIndex):
-                raise
+            for p in self._parent:
+                if isinstance(getattr(p(),'columns',None), MultiIndex):
+                    raise
 
             # we have a chained assignment
             # assign back to the original
-            self._parent().loc[self.index,key] = value
+            self._parent[0]().loc[self.index,key] = value
 
     def insert(self, loc, column, value, allow_duplicates=False):
         """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1825,7 +1825,7 @@ class DataFrame(NDFrame):
                     copy = isinstance(new_values,np.ndarray) and new_values.base is None
                     result = Series(new_values, index=self.columns,
                                     name=self.index[i], dtype=new_values.dtype)
-                result._set_is_copy(self, copy=copy)
+                result._set_parent(self, copy=copy)
                 return result
 
         # icol
@@ -1957,7 +1957,7 @@ class DataFrame(NDFrame):
                     if isinstance(result, Series):
                         result = self._constructor_sliced(result, index=self.index, name=key)
 
-            result._set_is_copy(self)
+            result._set_parent(self)
             return result
         else:
             return self._get_item_cache(key)
@@ -2300,12 +2300,12 @@ class DataFrame(NDFrame):
 
             # if we have a multi-index (which potentially has dropped levels)
             # need to raise
-            if isinstance(self.is_copy().columns, MultiIndex):
+            if isinstance(self._parent().columns, MultiIndex):
                 raise
 
             # we have a chained assignment
             # assign back to the original
-            self.is_copy().loc[self.index,key] = value
+            self._parent().loc[self.index,key] = value
 
     def insert(self, loc, column, value, allow_duplicates=False):
         """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2293,8 +2293,19 @@ class DataFrame(NDFrame):
         """
 
         self._ensure_valid_index(value)
-        value = self._sanitize_column(key, value)
-        NDFrame._set_item(self, key, value)
+        svalue = self._sanitize_column(key, value)
+        try:
+            NDFrame._set_item(self, key, svalue)
+        except com.SettingWithCopyError:
+
+            # if we have a multi-index (which potentially has dropped levels)
+            # need to raise
+            if isinstance(self.is_copy().columns, MultiIndex):
+                raise
+
+            # we have a chained assignment
+            # assign back to the original
+            self.is_copy().loc[self.index,key] = value
 
     def insert(self, loc, column, value, allow_duplicates=False):
         """

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -688,13 +688,14 @@ class GroupBy(PandasObject):
         def f(g):
             return func(g, *args, **kwargs)
 
-        # ignore SettingWithCopy here in case the user mutates
-        with option_context('mode.chained_assignment',None):
-            return self._python_apply_general(f)
+        return self._python_apply_general(f)
+
 
     def _python_apply_general(self, f):
+
         keys, values, mutated = self.grouper.apply(f, self._selected_obj,
                                                    self.axis)
+        self._selected_obj._allow_copy_on_write = True
 
         return self._wrap_applied_output(keys, values,
                                          not_indexed_same=mutated)
@@ -3591,6 +3592,15 @@ class DataSplitter(object):
         # Counting sort indexer
         return _get_group_index_sorter(self.labels, self.ngroups)
 
+
+    def _set_cow(self, data):
+        # we may mutate, so don't allow cow
+        try:
+            data._allow_copy_on_write=False
+        except AttributeError:
+            pass
+        return data
+
     def __iter__(self):
         sdata = self._get_sorted_data()
 
@@ -3612,7 +3622,7 @@ class DataSplitter(object):
         return self.data.take(self.sort_idx, axis=self.axis, convert=False)
 
     def _chop(self, sdata, slice_obj):
-        return sdata.iloc[slice_obj]
+        return self._set_cow(sdata.iloc[slice_obj])
 
     def apply(self, f):
         raise AbstractMethodError(self)
@@ -3625,7 +3635,7 @@ class ArraySplitter(DataSplitter):
 class SeriesSplitter(DataSplitter):
 
     def _chop(self, sdata, slice_obj):
-        return sdata._get_values(slice_obj).to_dense()
+        return self._set_cow(sdata._get_values(slice_obj).to_dense())
 
 
 class FrameSplitter(DataSplitter):
@@ -3648,9 +3658,9 @@ class FrameSplitter(DataSplitter):
 
     def _chop(self, sdata, slice_obj):
         if self.axis == 0:
-            return sdata.iloc[slice_obj]
+            return self._set_cow(sdata.iloc[slice_obj])
         else:
-            return sdata._slice(slice_obj, axis=1)  # ix[:, slice_obj]
+            return self._set_cow(sdata._slice(slice_obj, axis=1)) # ix[:, slice_obj]
 
 
 class NDFrameSplitter(DataSplitter):
@@ -3671,7 +3681,7 @@ class NDFrameSplitter(DataSplitter):
         return sorted_data
 
     def _chop(self, sdata, slice_obj):
-        return self.factory(sdata.get_slice(slice_obj, axis=self.axis))
+        return self._set_cow(self.factory(sdata.get_slice(slice_obj, axis=self.axis)))
 
 
 def get_splitter(data, *args, **kwargs):

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -695,7 +695,7 @@ class GroupBy(PandasObject):
 
         keys, values, mutated = self.grouper.apply(f, self._selected_obj,
                                                    self.axis)
-        self._selected_obj._allow_copy_on_write = True
+        self._selected_obj._parent_copy_on_write = True
 
         return self._wrap_applied_output(keys, values,
                                          not_indexed_same=mutated)
@@ -3596,7 +3596,7 @@ class DataSplitter(object):
     def _set_cow(self, data):
         # we may mutate, so don't allow cow
         try:
-            data._allow_copy_on_write=False
+            data._parent_copy_on_write=False
         except AttributeError:
             pass
         return data

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -273,7 +273,7 @@ class _NDFrameIndexer(object):
                     labels = index.insert(len(index),key)
                     self.obj._data = self.obj.reindex_axis(labels, i)._data
                     self.obj._maybe_update_cacher(clear=True)
-                    self.obj._parent=None
+                    self.obj._parent=[]
 
                     nindexer.append(labels.get_loc(key))
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -273,7 +273,7 @@ class _NDFrameIndexer(object):
                     labels = index.insert(len(index),key)
                     self.obj._data = self.obj.reindex_axis(labels, i)._data
                     self.obj._maybe_update_cacher(clear=True)
-                    self.obj.is_copy=None
+                    self.obj._parent=None
 
                     nindexer.append(labels.get_loc(key))
 

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -191,7 +191,7 @@ def add_special_arithmetic_methods(cls, arith_method=None, radd_func=None,
             # this makes sure that we are aligned like the input
             # we are updating inplace so we want to ignore is_copy
             self._update_inplace(result.reindex_like(self,copy=False)._data,
-                                 verify_is_copy=False)
+                                 verify_parent=False)
 
             return self
         return f

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -812,8 +812,7 @@ class Panel(NDFrame):
         axis_number = self._get_axis_number(axis)
         new_data = self._data.xs(key, axis=axis_number, copy=False)
         result = self._construct_return_type(new_data)
-        copy = new_data.is_mixed_type
-        result._set_is_copy(self, copy=copy)
+        result._set_parent(self)
         return result
 
     _xs = xs

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -21,7 +21,7 @@ from pandas.core.common import (isnull, notnull, is_bool_indexer,
                                 _possibly_convert_platform, _try_sort,
                                 is_int64_dtype,
                                 ABCSparseArray, _maybe_match_name,
-                                _coerce_to_dtype, SettingWithCopyError,
+                                _coerce_to_dtype, SettingImmutableError,
                                 _maybe_box_datetimelike, ABCDataFrame,
                                 _dict_compat)
 from pandas.core.index import (Index, MultiIndex, InvalidIndexError,
@@ -635,7 +635,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             try:
                 self._set_with_engine(key, value)
                 return
-            except (SettingWithCopyError):
+            except (SettingImmutableError):
                 raise
             except (KeyError, ValueError):
                 values = self.values

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -690,7 +690,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
             # we have a chained assignment
             # assign back to the original
-            self.is_copy().loc[self.name,key] = value
+            self._parent().loc[self.name,key] = value
             return
 
         setitem(key, value)

--- a/pandas/src/reduce.pyx
+++ b/pandas/src/reduce.pyx
@@ -488,6 +488,7 @@ def apply_frame_axis0(object frame, object f, object names,
     # Need to infer if our low-level mucking is going to cause a segfault
     if n > 0:
         chunk = frame.iloc[starts[0]:ends[0]]
+        chunk._allow_copy_on_write = False
         shape_before = chunk.shape
         try:
             result = f(chunk)
@@ -508,6 +509,7 @@ def apply_frame_axis0(object frame, object f, object names,
             item_cache.clear() # ugh
 
             object.__setattr__(slider.dummy, 'name', names[i])
+            object.__setattr__(slider.dummy, '_allow_copy_on_write', False)
             piece = f(slider.dummy)
 
             # I'm paying the price for index-sharing, ugh

--- a/pandas/src/reduce.pyx
+++ b/pandas/src/reduce.pyx
@@ -488,7 +488,7 @@ def apply_frame_axis0(object frame, object f, object names,
     # Need to infer if our low-level mucking is going to cause a segfault
     if n > 0:
         chunk = frame.iloc[starts[0]:ends[0]]
-        chunk._allow_copy_on_write = False
+        chunk._parent_copy_on_write = False
         shape_before = chunk.shape
         try:
             result = f(chunk)
@@ -509,7 +509,7 @@ def apply_frame_axis0(object frame, object f, object names,
             item_cache.clear() # ugh
 
             object.__setattr__(slider.dummy, 'name', names[i])
-            object.__setattr__(slider.dummy, '_allow_copy_on_write', False)
+            object.__setattr__(slider.dummy, '_parent_copy_on_write', False)
             piece = f(slider.dummy)
 
             # I'm paying the price for index-sharing, ugh

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -552,12 +552,10 @@ class CheckIndexing(object):
         self.frame['col8'] = 'foo'
         assert((self.frame['col8'] == 'foo').all())
 
-        # this is partially a view (e.g. some blocks are view)
-        # so raise/warn
+        # this is copy-on-write
         smaller = self.frame[:2]
-        def f():
-            smaller['col10'] = ['1', '2']
-        self.assertRaises(com.SettingWithCopyError, f)
+        smaller['col10'] = ['1', '2']
+
         self.assertEqual(smaller['col10'].dtype, np.object_)
         self.assertTrue((smaller['col10'] == ['1', '2']).all())
 
@@ -999,13 +997,11 @@ class CheckIndexing(object):
         sliced = self.mixed_frame.ix[:, -3:]
         self.assertEqual(sliced['D'].dtype, np.float64)
 
-        # get view with single block
-        # setting it triggers setting with copy
+        # this is copy-on-write
         sliced = self.frame.ix[:, -3:]
-        def f():
-            sliced['C'] = 4.
-        self.assertRaises(com.SettingWithCopyError, f)
-        self.assertTrue((self.frame['C'] == 4).all())
+        sliced['C'] = 4.
+        self.assertFalse((self.frame['C'] == 4).all())
+        self.assertTrue((sliced['C'] == 4).all())
 
     def test_fancy_setitem_int_labels(self):
         # integer index defers to label-based indexing
@@ -1798,14 +1794,10 @@ class CheckIndexing(object):
         expected = df.ix[8:14]
         assert_frame_equal(result, expected)
 
-        # verify slice is view
-        # setting it makes it raise/warn
-        def f():
-            result[2] = 0.
-        self.assertRaises(com.SettingWithCopyError, f)
-        exp_col = df[2].copy()
-        exp_col[4:8] = 0.
-        assert_series_equal(df[2], exp_col)
+        # copy-on-write for a slice
+        result[2] = 0.
+        self.assertFalse((df[2] == 0).all())
+        self.assertTrue((result[2] == 0).all())
 
         # list of integers
         result = df.iloc[[1, 2, 4, 6]]
@@ -1833,12 +1825,10 @@ class CheckIndexing(object):
         expected = df.ix[:, 8:14]
         assert_frame_equal(result, expected)
 
-        # verify slice is view
-        # and that we are setting a copy
-        def f():
-            result[8] = 0.
-        self.assertRaises(com.SettingWithCopyError, f)
-        self.assertTrue((df[8] == 0).all())
+        # we have a slice, but copy-on-write
+        result[8] = 0.
+        self.assertFalse((df[8] == 0).all())
+        self.assertTrue((result[8] == 0).all())
 
         # list of integers
         result = df.iloc[:, [1, 2, 4, 6]]
@@ -14489,16 +14479,15 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
     def test_stale_cached_series_bug_473(self):
 
         # this is chained, but ok
-        with option_context('chained_assignment',None):
-            Y = DataFrame(np.random.random((4, 4)), index=('a', 'b', 'c', 'd'),
-                          columns=('e', 'f', 'g', 'h'))
-            repr(Y)
-            Y['e'] = Y['e'].astype('object')
-            Y['g']['c'] = np.NaN
-            repr(Y)
-            result = Y.sum()
-            exp = Y['g'].sum()
-            self.assertTrue(isnull(Y['g']['c']))
+        Y = DataFrame(np.random.random((4, 4)), index=('a', 'b', 'c', 'd'),
+                      columns=('e', 'f', 'g', 'h'))
+        repr(Y)
+        Y['e'] = Y['e'].astype('object')
+        Y['g']['c'] = np.NaN
+        repr(Y)
+        result = Y.sum()
+        exp = Y['g'].sum()
+        self.assertTrue(isnull(Y['g']['c']))
 
     def test_index_namedtuple(self):
         from collections import namedtuple

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -2744,10 +2744,9 @@ class TestGroupBy(tm.TestCase):
         self.assertEqual(result['d'].dtype, np.float64)
 
         # this is by definition a mutating operation!
-        with option_context('mode.chained_assignment',None):
-            for key, group in grouped:
-                res = f(group)
-                assert_frame_equal(res, result.ix[key])
+        for key, group in grouped:
+            res = f(group)
+            assert_frame_equal(res, result.ix[key])
 
     def test_groupby_wrong_multi_labels(self):
         from pandas import read_csv

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -3534,10 +3534,10 @@ class TestMultiIndex(Base, tm.TestCase):
             columns=['one', 'two', 'three', 'four'],
             index=idx)
         df = df.sortlevel()
-        self.assertIsNone(df.is_copy)
+        self.assertIsNone(df._parent)
         self.assertEqual(df.index.names, ('Name', 'Number'))
         df = df.set_value(('grethe', '4'), 'one', 99.34)
-        self.assertIsNone(df.is_copy)
+        self.assertIsNone(df._parent)
         self.assertEqual(df.index.names, ('Name', 'Number'))
 
     def test_names(self):

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -3776,11 +3776,15 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         # 10954
         df = DataFrame({'col1':[1,2], 'col2':[3,4]})
         intermediate = df.loc[1:1,]
+
+        # refrence created
+        self.assertFalse(len(df._parent))
+        self.assertTrue(len(intermediate._parent) == 1)
         intermediate['col1'] = -99
 
         # reference is broken
-        self.assertIsNone(df._parent)
-        self.assertIsNone(intermediate._parent)
+        self.assertFalse(len(df._parent))
+        self.assertFalse(len(intermediate._parent))
 
         # local assignment
         expected = DataFrame([[-99,4]],index=[1],columns=['col1','col2'])
@@ -3822,17 +3826,17 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         # work with the chain
         expected = DataFrame([[-5,1],[-6,3]],columns=list('AB'))
         df = DataFrame(np.arange(4).reshape(2,2),columns=list('AB'),dtype='int64')
-        self.assertIsNone(df._parent)
+        self.assertFalse(len(df._parent))
         df['A'][0] = -5
         df['A'][1] = -6
         assert_frame_equal(df, expected)
 
         # test with the chaining
         df = DataFrame({ 'A' : Series(range(2),dtype='int64'), 'B' : np.array(np.arange(2,4),dtype=np.float64)})
-        self.assertIsNone(df._parent)
+        self.assertFalse(len(df._parent))
         df['A'][0] = -5
         df['A'][1] = np.nan
-        self.assertIsNone(df['A']._parent)
+        self.assertFalse(len(df['A']._parent))
 
         # using a copy (the chain), fails
         df = DataFrame({ 'A' : Series(range(2),dtype='int64'), 'B' : np.array(np.arange(2,4),dtype=np.float64)})
@@ -3843,7 +3847,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         df = DataFrame({'a' : ['one', 'one', 'two',
                                'three', 'two', 'one', 'six'],
                         'c' : Series(range(7),dtype='int64') })
-        self.assertIsNone(df._parent)
+        self.assertFalse(len(df._parent))
         expected = DataFrame({'a' : ['one', 'one', 'two',
                                      'three', 'two', 'one', 'six'],
                               'c' : [42,42,2,3,4,42,6]})
@@ -3868,7 +3872,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         # make sure that is_copy is picked up reconstruction
         # GH5475
         df = DataFrame({"A": [1,2]})
-        self.assertIsNone(df._parent)
+        self.assertFalse(len(df._parent))
         with tm.ensure_clean('__tmp__pickle') as path:
             df.to_pickle(path)
             df2 = pd.read_pickle(path)
@@ -3899,7 +3903,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         # explicity copy
         indexer = df.letters.apply(lambda x : len(x) > 10)
         df = df.ix[indexer].copy()
-        self.assertIsNone(df._parent)
+        self.assertFalse(len(df._parent))
         df['letters'] = df['letters'].apply(str.lower)
 
         # implicity take
@@ -3917,9 +3921,9 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         df.loc[:,'letters'] = df['letters'].apply(str.lower)
 
         # should be ok even though it's a copy!
-        self.assertIsNone(df._parent)
+        self.assertFalse(len(df._parent))
         df['letters'] = df['letters'].apply(str.lower)
-        self.assertIsNone(df._parent)
+        self.assertFalse(len(df._parent))
 
         df = random_text(100000)
         indexer = df.letters.apply(lambda x : len(x) > 10)
@@ -3927,7 +3931,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
 
         # an identical take, so no copy
         df = DataFrame({'a' : [1]}).dropna()
-        self.assertIsNone(df._parent)
+        self.assertFalse(len(df._parent))
         df['a'] += 1
 
         # inplace ops

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -3779,8 +3779,8 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         intermediate['col1'] = -99
 
         # reference is broken
-        self.assertIsNone(df.is_copy)
-        self.assertIsNone(intermediate.is_copy)
+        self.assertIsNone(df._parent)
+        self.assertIsNone(intermediate._parent)
 
         # local assignment
         expected = DataFrame([[-99,4]],index=[1],columns=['col1','col2'])
@@ -3822,17 +3822,17 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         # work with the chain
         expected = DataFrame([[-5,1],[-6,3]],columns=list('AB'))
         df = DataFrame(np.arange(4).reshape(2,2),columns=list('AB'),dtype='int64')
-        self.assertIsNone(df.is_copy)
+        self.assertIsNone(df._parent)
         df['A'][0] = -5
         df['A'][1] = -6
         assert_frame_equal(df, expected)
 
         # test with the chaining
         df = DataFrame({ 'A' : Series(range(2),dtype='int64'), 'B' : np.array(np.arange(2,4),dtype=np.float64)})
-        self.assertIsNone(df.is_copy)
+        self.assertIsNone(df._parent)
         df['A'][0] = -5
         df['A'][1] = np.nan
-        self.assertIsNone(df['A'].is_copy)
+        self.assertIsNone(df['A']._parent)
 
         # using a copy (the chain), fails
         df = DataFrame({ 'A' : Series(range(2),dtype='int64'), 'B' : np.array(np.arange(2,4),dtype=np.float64)})
@@ -3843,7 +3843,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         df = DataFrame({'a' : ['one', 'one', 'two',
                                'three', 'two', 'one', 'six'],
                         'c' : Series(range(7),dtype='int64') })
-        self.assertIsNone(df.is_copy)
+        self.assertIsNone(df._parent)
         expected = DataFrame({'a' : ['one', 'one', 'two',
                                      'three', 'two', 'one', 'six'],
                               'c' : [42,42,2,3,4,42,6]})
@@ -3868,7 +3868,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         # make sure that is_copy is picked up reconstruction
         # GH5475
         df = DataFrame({"A": [1,2]})
-        self.assertIsNone(df.is_copy)
+        self.assertIsNone(df._parent)
         with tm.ensure_clean('__tmp__pickle') as path:
             df.to_pickle(path)
             df2 = pd.read_pickle(path)
@@ -3892,34 +3892,34 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
 
         # always a copy
         x = df.iloc[[0,1,2]]
-        self.assertIsNotNone(x.is_copy)
+        self.assertIsNotNone(x._parent)
         x = df.iloc[[0,1,2,4]]
-        self.assertIsNotNone(x.is_copy)
+        self.assertIsNotNone(x._parent)
 
         # explicity copy
         indexer = df.letters.apply(lambda x : len(x) > 10)
         df = df.ix[indexer].copy()
-        self.assertIsNone(df.is_copy)
+        self.assertIsNone(df._parent)
         df['letters'] = df['letters'].apply(str.lower)
 
         # implicity take
         df = random_text(100000)
         indexer = df.letters.apply(lambda x : len(x) > 10)
         df = df.ix[indexer]
-        self.assertIsNotNone(df.is_copy)
+        self.assertIsNotNone(df._parent)
         df['letters'] = df['letters'].apply(str.lower)
 
         # implicity take 2
         df = random_text(100000)
         indexer = df.letters.apply(lambda x : len(x) > 10)
         df = df.ix[indexer]
-        self.assertIsNotNone(df.is_copy)
+        self.assertIsNotNone(df._parent)
         df.loc[:,'letters'] = df['letters'].apply(str.lower)
 
         # should be ok even though it's a copy!
-        self.assertIsNone(df.is_copy)
+        self.assertIsNone(df._parent)
         df['letters'] = df['letters'].apply(str.lower)
-        self.assertIsNone(df.is_copy)
+        self.assertIsNone(df._parent)
 
         df = random_text(100000)
         indexer = df.letters.apply(lambda x : len(x) > 10)
@@ -3927,7 +3927,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
 
         # an identical take, so no copy
         df = DataFrame({'a' : [1]}).dropna()
-        self.assertIsNone(df.is_copy)
+        self.assertIsNone(df._parent)
         df['a'] += 1
 
         # inplace ops

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -539,11 +539,9 @@ class TestMultiLevel(tm.TestCase):
         # this is a copy in 0.14
         result = self.frame.xs('two', level='second')
 
-        # setting this will give a SettingWithCopyError
-        # as we are trying to write a view
-        def f(x):
-            x[:] = 10
-        self.assertRaises(com.SettingWithCopyError, f, result)
+        # this is copy-on-write
+        result[:] = 10
+        self.assertTrue((result.values == 10).all())
 
     def test_xs_level_multiple(self):
         from pandas import read_table
@@ -562,11 +560,9 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         # this is a copy in 0.14
         result = df.xs(('a', 4), level=['one', 'four'])
 
-        # setting this will give a SettingWithCopyError
-        # as we are trying to write a view
-        def f(x):
-            x[:] = 10
-        self.assertRaises(com.SettingWithCopyError, f, result)
+        # copy-on-write
+        result[:] = 10
+        self.assertTrue((result.values == 10).all())
 
         # GH2107
         dates = lrange(20111201, 20111205)
@@ -1412,7 +1408,7 @@ Thur,Lunch,Yes,51.51,17"""
         df['foo', 'four'] = 'foo'
         df = df.sortlevel(0, axis=1)
 
-        # this will work, but will raise/warn as its chained assignment
+        # chained assignment
         def f():
             df['foo']['one'] = 2
             return df

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -556,7 +556,7 @@ class CheckIndexing(object):
         # mixed-type yields a copy
         self.panel['strings'] = 'foo'
         result = self.panel.xs('D', axis=2)
-        self.assertIsNotNone(result.is_copy)
+        self.assertIsNotNone(result._parent)
 
     def test_getitem_fancy_labels(self):
         p = self.panel

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -514,7 +514,7 @@ class CheckIndexing(object):
         # mixed-type
         self.panel4d['strings'] = 'foo'
         result = self.panel4d.xs('D', axis=3)
-        self.assertIsNotNone(result.is_copy)
+        self.assertIsNotNone(result._parent)
 
     def test_getitem_fancy_labels(self):
         panel4d = self.panel4d

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -204,11 +204,10 @@ class CheckNameIntegration(object):
         with tm.assertRaisesRegexp(ValueError, "modifications"):
             s.dt.hour = 5
 
-        # trying to set a copy
-        with pd.option_context('chained_assignment','raise'):
-            def f():
-                s.dt.hour[0] = 5
-            self.assertRaises(com.SettingWithCopyError, f)
+        # trying to set an immutable
+        def f():
+            s.dt.hour[0] = 5
+        self.assertRaises(com.SettingImmutableError, f)
 
     def test_strftime(self):
         # GH 10086
@@ -4447,7 +4446,6 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # GH 3970
         # these are chained assignments as well
-        pd.set_option('chained_assignment',None)
         df = DataFrame({ "aa":range(5), "bb":[2.2]*5})
         df["cc"] = 0.0
         ck = [True]*len(df)
@@ -4455,7 +4453,6 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         df_tmp = df.iloc[ck]
         df["bb"].iloc[0] = .15
         self.assertEqual(df['bb'].iloc[0], 0.15)
-        pd.set_option('chained_assignment','raise')
 
         # GH 3217
         df = DataFrame(dict(a = [1,3], b = [np.nan, 2]))

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -157,7 +157,7 @@ class CheckNameIntegration(object):
             result = s.dt.to_pytimedelta()
             self.assertIsInstance(result,np.ndarray)
             self.assertTrue(result.dtype == object)
-            
+
             result = s.dt.total_seconds()
             self.assertIsInstance(result,pd.Series)
             self.assertTrue(result.dtype == 'float64')
@@ -1235,9 +1235,9 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         expected = s.ix[2:4]
         assert_series_equal(result, expected)
 
-        # test slice is a view
+        # this is copy-on-write
         result[:] = 0
-        self.assertTrue((s[1:3] == 0).all())
+        self.assertTrue((s[1:3] != 0).all())
 
         # list of integers
         result = s.iloc[[0, 2, 3, 4, 5]]
@@ -1473,10 +1473,10 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         self.assertTrue(tm.equalContents(numSliceEnd,
                                          np.array(self.series)[-10:]))
 
-        # test return view
+        # copy-on-write
         sl = self.series[10:20]
         sl[:] = 0
-        self.assertTrue((self.series[10:20] == 0).all())
+        self.assertTrue((self.series[10:20] != 0).all())
 
     def test_slice_can_reorder_not_uniquely_indexed(self):
         s = Series(1, index=['a', 'a', 'b', 'b', 'c'])

--- a/pandas/tseries/common.py
+++ b/pandas/tseries/common.py
@@ -77,7 +77,7 @@ class Properties(PandasDelegate):
         result = Series(result, index=self.index)
 
         # setting this object will show a ValueError if accessed
-        result.is_copy = SettingImmutableError("modifications to a property of a datetimelike object are not "
+        result._parent = SettingImmutableError("modifications to a property of a datetimelike object are not "
                                                "supported and are discarded. Change values on the original.")
 
 
@@ -99,7 +99,7 @@ class Properties(PandasDelegate):
         result = Series(result, index=self.index)
 
         # setting this object will show a SettingImmutableError
-        result.is_copy = SettingImmutableError("modifications to a method of a datetimelike object are not "
+        result._parent = SettingImmutableError("modifications to a method of a datetimelike object are not "
                                                "supported and are discarded. Change values on the original.")
 
         return result

--- a/pandas/tseries/common.py
+++ b/pandas/tseries/common.py
@@ -9,7 +9,7 @@ from pandas.tseries.tdi import TimedeltaIndex
 from pandas import tslib
 from pandas.core.common import (_NS_DTYPE, _TD_DTYPE, is_period_arraylike,
                                 is_datetime_arraylike, is_integer_dtype, is_list_like,
-                                get_dtype_kinds)
+                                get_dtype_kinds, SettingImmutableError)
 
 def is_datetimelike(data):
     """ return a boolean if we can be successfully converted to a datetimelike """
@@ -76,15 +76,16 @@ class Properties(PandasDelegate):
         # return the result as a Series, which is by definition a copy
         result = Series(result, index=self.index)
 
-        # setting this object will show a SettingWithCopyWarning/Error
-        result.is_copy = ("modifications to a property of a datetimelike object are not "
-                          "supported and are discarded. Change values on the original.")
+        # setting this object will show a ValueError if accessed
+        result.is_copy = SettingImmutableError("modifications to a property of a datetimelike object are not "
+                                               "supported and are discarded. Change values on the original.")
+
 
         return result
 
     def _delegate_property_set(self, name, value, *args, **kwargs):
-        raise ValueError("modifications to a property of a datetimelike object are not "
-                         "supported. Change values on the original.")
+        raise SettingImmutableError("modifications to a property of a datetimelike object are not "
+                                    "supported. Change values on the original.")
 
     def _delegate_method(self, name, *args, **kwargs):
         from pandas import Series
@@ -97,9 +98,9 @@ class Properties(PandasDelegate):
 
         result = Series(result, index=self.index)
 
-        # setting this object will show a SettingWithCopyWarning/Error
-        result.is_copy = ("modifications to a method of a datetimelike object are not "
-                          "supported and are discarded. Change values on the original.")
+        # setting this object will show a SettingImmutableError
+        result.is_copy = SettingImmutableError("modifications to a method of a datetimelike object are not "
+                                               "supported and are discarded. Change values on the original.")
 
         return result
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -64,7 +64,7 @@ class TestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        pd.set_option('chained_assignment', 'raise')
+        pass
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
closes #10954
- deprecates the option `mode.chained_assignment` as its now unused (it shows the deprecation if you are explicity using it, more friendly this way).
- deprecate `NDFrame.is_copy` property
- remove `SettingWithCopyWarning` entirely

TODO:
- [ ] some systematic testing of the chaining might help (e.g. iterate thru the `iloc/loc/[]`, chain, and set various values including dtype changes
- [ ] huge note explaining the rationale & change structure

semantics:

Intermediate assignment trigger copy-on-write and do not propogate.

```
In [1]: df = DataFrame({'col1':[1,2], 'col2':[3,4]})

In [2]: intermediate = df.loc[1:1,]

In [3]: intermediate['col1'] = -99

In [4]: intermediate
Out[4]: 
   col1  col2
1   -99     4

In [5]: df
Out[5]: 
   col1  col2
0     1     3
1     2     4
```

Chained assignments _always_ work!

```
In [6]: df = DataFrame({'col1':[1,2], 'col2':[3,4]})

In [7]: df.loc[1:1,]['col1'] = -99

In [8]: df
Out[8]: 
   col1  col2
0     1     3
1   -99     4
```

Even true with cross-sections that change dtype

```
In [1]: df = DataFrame({'col1':[1,2], 'col2':[3,4]})

In [2]: df.loc[1]['col2'] = 'foo'

In [3]: df
Out[3]: 
   col1 col2
0     1    3
1     2  foo
```

except for a really egregious case, which will raise a `SettingWithCopyError`  (maybe I could even fix this....)

```
In [10]: df.loc[1:1]['col2'].replace(10,5,inplace=True)
SettingWithCopyError: chained indexing detected, you can fix this ......
```

This is an invalid assignment. I suppose we _could_ make it work, but we currently havent' allowed the `.dt` to be used as a setitem accessor

```
In [9]: s = Series(pd.date_range('20130101',periods=3))

In [12]: s.dt.hour[0] = 5
SettingImmutableError: modifications to a property of a datetimelike object are not supported and are discarded. Change values on the original.
```

cc @nickeubank 
cc @JanSchulz 
cc @ellisonbg
cc @CarstVaartjes 
@shoyer 

special thanks to @JanSchulz for some reference checking code :)
