### PR TITLE
BUG: DataFrame constructor should not promote complex64 dtypes (GH10952)

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -866,3 +866,4 @@ Bug Fixes
 - Bug in plotting functions may raise ``IndexError`` when plotted on ``GridSpec`` (:issue:`10819`)
 - Bug in plot result may show unnecessary minor ticklabels (:issue:`10657`)
 - Bug when constructing ``DataFrame`` where passing a dictionary with only scalar values and specifying columns did not raise an error (:issue:`10856`)
+- Bug when constructing ``DataFrame`` with an array of complex64 dtype that meant the corresponding column was automatically promoted to the complex128 dtype (:issue:`10952`)

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -3657,8 +3657,7 @@ def form_blocks(arrays, names, axes):
         blocks.extend(float_blocks)
 
     if len(complex_items):
-        complex_blocks = _simple_blockify(
-            complex_items, np.complex128)
+        complex_blocks = _multi_blockify(complex_items)
         blocks.extend(complex_blocks)
 
     if len(int_items):

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2668,6 +2668,15 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df     = _make_mixed_dtypes_df('int')
         _check_mixed_dtypes(df)
 
+    def test_constructor_complex_dtypes(self):
+        # GH10952
+        a = np.random.rand(10).astype(np.complex64)
+        b = np.random.rand(10).astype(np.complex128)
+
+        df = DataFrame({'a': a, 'b': b})
+        self.assertEqual(a.dtype, df.a.dtype)
+        self.assertEqual(b.dtype, df.b.dtype)
+
     def test_constructor_rec(self):
         rec = self.frame.to_records(index=False)
 


### PR DESCRIPTION
Addresses [GH10952](https://github.com/pydata/pandas/issues/10952).

When passing an array with complex64 dtype to the DataFrame constructor, that array will no longer be automatically promoted to the complex128 dtype (different complex dtypes are now allowed).
