### PR TITLE
BUG: pivot_table with margins=True fails for categorical dtype, #10989

### DIFF
--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -170,7 +170,8 @@ def _add_margins(table, data, values, rows, cols, aggfunc):
             return _convert(ind)
 
     table.index = convert_categorical(table.index)
-    table.columns = convert_categorical(table.columns)
+    if hasattr(table, 'columns'):
+        table.columns = convert_categorical(table.columns)
 
     if not values and isinstance(table, Series):
         # If there are no values and the table is a series, then there is only

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -159,6 +159,19 @@ def _add_margins(table, data, values, rows, cols, aggfunc):
 
     grand_margin = _compute_grand_margin(data, values, aggfunc)
 
+    # categorical index or columns will fail below when 'All' is added
+    # here we'll convert all categorical indices to object
+    def convert_categorical(ind):
+        _convert = lambda ind: (ind.astype('object')
+                                if ind.dtype.name == 'category' else ind)
+        if isinstance(ind, MultiIndex):
+            return ind.set_levels([_convert(lev) for lev in ind.levels])
+        else:
+            return _convert(ind)
+
+    table.index = convert_categorical(table.index)
+    table.columns = convert_categorical(table.columns)
+
     if not values and isinstance(table, Series):
         # If there are no values and the table is a series, then there is only
         # one column in the data. Compute grand margin and return it.

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -719,6 +719,20 @@ class TestCrosstab(tm.TestCase):
                                     ('two', 'dull'), ('two', 'shiny')])
         assert_equal(res.columns.values, m.values)
 
+    def test_categorical_margins(self):
+        # GH 10989
+        data = pd.DataFrame({'x': np.arange(8),
+                             'y': np.arange(8) // 4,
+                             'z': np.arange(8) % 2})
+        data.y = data.y.astype('category')
+        data.z = data.z.astype('category')
+        table = data.pivot_table('x', 'y', 'z', margins=True)
+        assert_equal(table.values, [[1, 2, 1.5],
+                                    [5, 6, 5.5],
+                                    [3, 4, 3.5]])
+                                    
+        
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
This is a fix for the issue reported in #10989. I suspect this is an example of "fixing the symptom" rather than "fixing the problem", but I think it makes clear what the source of the problem is: to compute margins, the pivot table must add a row and/or column to the result. If the index or column is categorical, a new value cannot be added.

Let me know if you think there are better approaches to this.
