### PR TITLE
DOC: Update pip reference links

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ cloning the git repo), execute:
 python setup.py install
 ```
 
-or for installing in [development mode](http://www.pip-installer.org/en/latest/usage.html):
+or for installing in [development mode](https://pip.pypa.io/en/latest/reference/pip_install.html#editable-installs):
 
 ```sh
 python setup.py develop
@@ -229,7 +229,7 @@ python setup.py develop
 
 Alternatively, you can use `pip` if you want all the dependencies pulled
 in automatically (the `-e` option is for installing it in [development
-mode](http://www.pip-installer.org/en/latest/usage.html)):
+mode](https://pip.pypa.io/en/latest/reference/pip_install.html#editable-installs)):
 
 ```sh
 pip install -e .


### PR DESCRIPTION
Change to link to https://pip.pypa.io/en/latest/reference/pip_install.html#editable-installs
