### PR TITLE
ENH: Reduce for loops in df.corr(method='kendall')

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -116,14 +116,14 @@ suffixes : 2-length sequence (tuple, list, ...)
 copy : boolean, default True
     If False, do not copy data unnecessarily
 indicator : boolean or string, default False
-    If True, adds a column to output DataFrame called "_merge" with 
-    information on the source of each row. 
-    If string, column with information on source of each row will be added to 
-    output DataFrame, and column will be named value of string. 
-    Information column is Categorical-type and takes on a value of "left_only" 
-    for observations whose merge key only appears in 'left' DataFrame, 
-    "right_only" for observations whose merge key only appears in 'right' 
-    DataFrame, and "both" if the observation's merge key is found in both. 
+    If True, adds a column to output DataFrame called "_merge" with
+    information on the source of each row.
+    If string, column with information on source of each row will be added to
+    output DataFrame, and column will be named value of string.
+    Information column is Categorical-type and takes on a value of "left_only"
+    for observations whose merge key only appears in 'left' DataFrame,
+    "right_only" for observations whose merge key only appears in 'right'
+    DataFrame, and "both" if the observation's merge key is found in both.
 
     .. versionadded:: 0.17.0
 
@@ -4381,7 +4381,7 @@ class DataFrame(NDFrame):
             correl = np.empty((K, K), dtype=float)
             mask = np.isfinite(mat)
             for i, ac in enumerate(mat):
-                for j, bc in enumerate(mat):
+                for j, bc in enumerate(mat[i:], i):
                     valid = mask[i] & mask[j]
                     if valid.sum() < min_periods:
                         c = NA


### PR DESCRIPTION
Reduce `for` loops in `df.corr(method='kendall')`

Don't need to loop through lower triangle of the matrix.
