### PR TITLE
TST: corrected URL for newly added Excel test data file

### DIFF
--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -415,11 +415,8 @@ class XlrdTests(ReadingTestsBase):
 
     @tm.network
     def test_read_from_http_url(self):
-        # TODO: remove this when merging into master
-        url = ('https://raw.github.com/davidovitch/pandas/master/'
+        url = ('https://raw.github.com/pydata/pandas/master/'
                'pandas/io/tests/data/test1' + self.ext)
-#        url = ('https://raw.github.com/pydata/pandas/master/'
-#               'pandas/io/tests/data/test' + self.ext)
         url_table = read_excel(url)
         local_table = self.get_exceldf('test1')
         tm.assert_frame_equal(url_table, local_table)


### PR DESCRIPTION
There was one small thing overlooked when merging PR #10964: the url of the renamed test file was still pointing to my repo instead of pydata/pandas.
