### PR TITLE
BUG: Unable to infer negative freq

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -1009,4 +1009,6 @@ Bug Fixes
 - Bug in ``.var()`` causing roundoff errors for highly similar values (:issue:`10242`)
 - Bug in ``DataFrame.plot(subplots=True)`` with duplicated columns outputs incorrect result (:issue:`10962`)
 - Bug in ``Index`` arithmetic may result in incorrect class (:issue:`10638`)
+- Bug in ``date_range`` results in empty if freq is negative annualy, quarterly and monthly (:issue:`11018`)
+- Bug in ``DatetimeIndex`` cannot infer negative freq (:issue:`11018`)
 

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -3329,7 +3329,7 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
             exp = TimedeltaIndex(['-2H', '-4H', '-6H', '-8H', '-10H'],
                                  freq='-2H', name='x')
             tm.assert_index_equal(result, exp)
-            self.assertEqual(result.freq, None)
+            self.assertEqual(result.freq, '-2H')
 
         idx = TimedeltaIndex(['-2H', '-1H', '0H', '1H', '2H'],
                                 freq='H', name='x')

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -2615,15 +2615,24 @@ def generate_range(start=None, end=None, periods=None,
         start = end - (periods - 1) * offset
 
     cur = start
+    if offset.n >= 0:
+        while cur <= end:
+            yield cur
 
-    while cur <= end:
-        yield cur
+            # faster than cur + offset
+            next_date = offset.apply(cur)
+            if next_date <= cur:
+                raise ValueError('Offset %s did not increment date' % offset)
+            cur = next_date
+    else:
+        while cur >= end:
+            yield cur
 
-        # faster than cur + offset
-        next_date = offset.apply(cur)
-        if next_date <= cur:
-            raise ValueError('Offset %s did not increment date' % offset)
-        cur = next_date
+            # faster than cur + offset
+            next_date = offset.apply(cur)
+            if next_date >= cur:
+                raise ValueError('Offset %s did not decrement date' % offset)
+            cur = next_date
 
 prefix_mapping = dict((offset._prefix, offset) for offset in [
     YearBegin,                # 'AS'

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -494,6 +494,15 @@ Freq: H"""
             self.assert_index_equal(result, expected)
             self.assertIsNone(result.freq)
 
+    def test_infer_freq(self):
+        # GH 11018
+        for freq in ['A', '2A', '-2A', 'Q', '-1Q', 'M', '-1M', 'D', '3D', '-3D',
+                     'W', '-1W', 'H', '2H', '-2H', 'T', '2T', 'S', '-3S']:
+            idx = pd.date_range('2011-01-01 09:00:00', freq=freq, periods=10)
+            result = pd.DatetimeIndex(idx.asi8, freq='infer')
+            tm.assert_index_equal(idx, result)
+            self.assertEqual(result.freq, freq)
+
 
 class TestTimedeltaIndexOps(Ops):
 
@@ -1107,6 +1116,14 @@ Freq: D"""
             expected = TimedeltaIndex(['29 day', '3 day', '6 day'], name='idx')
             self.assert_index_equal(result, expected)
             self.assertIsNone(result.freq)
+
+    def test_infer_freq(self):
+        # GH 11018
+        for freq in ['D', '3D', '-3D', 'H', '2H', '-2H', 'T', '2T', 'S', '-3S']:
+            idx = pd.timedelta_range('1', freq=freq, periods=10)
+            result = pd.TimedeltaIndex(idx.asi8, freq='infer')
+            tm.assert_index_equal(idx, result)
+            self.assertEqual(result.freq, freq)
 
 
 class TestPeriodIndexOps(Ops):

--- a/pandas/tseries/tests/test_frequencies.py
+++ b/pandas/tseries/tests/test_frequencies.py
@@ -539,7 +539,7 @@ class TestFrequencyInference(tm.TestCase):
     def test_not_monotonic(self):
         rng = _dti(['1/31/2000', '1/31/2001', '1/31/2002'])
         rng = rng[::-1]
-        self.assertIsNone(rng.inferred_freq)
+        self.assertEqual(rng.inferred_freq, '-1A-JAN')
 
     def test_non_datetimeindex(self):
         rng = _dti(['1/31/2000', '1/31/2001', '1/31/2002'])

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -1539,8 +1539,7 @@ class TestSlicing(tm.TestCase):
         result = - rng
         exp = timedelta_range('-2 days', periods=5, freq='-2D', name='x')
         tm.assert_index_equal(result, exp)
-        # tdi doesn't infer negative freq
-        self.assertEqual(result.freq, None)
+        self.assertEqual(result.freq, '-2D')
 
         rng = pd.timedelta_range('-2 days', periods=5, freq='D', name='x')
 
@@ -1548,7 +1547,6 @@ class TestSlicing(tm.TestCase):
         exp = TimedeltaIndex(['2 days', '1 days', '0 days', '1 days',
                               '2 days'], name='x')
         tm.assert_index_equal(result, exp)
-        # tdi doesn't infer negative freq
         self.assertEqual(result.freq, None)
 
 

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1260,6 +1260,18 @@ class TestTimeSeries(tm.TestCase):
         rng = date_range('1/1/2000 00:00', '1/1/2000 00:18', freq='5min')
         self.assertEqual(len(rng), 4)
 
+    def test_date_range_negative_freq(self):
+        # GH 11018
+        rng = date_range('2011-12-31', freq='-2A', periods=3)
+        exp = pd.DatetimeIndex(['2011-12-31', '2009-12-31', '2007-12-31'], freq='-2A')
+        self.assert_index_equal(rng, exp)
+        self.assertEqual(rng.freq, '-2A')
+
+        rng = date_range('2011-01-31', freq='-2M', periods=3)
+        exp = pd.DatetimeIndex(['2011-01-31', '2010-11-30', '2010-09-30'], freq='-2M')
+        self.assert_index_equal(rng, exp)
+        self.assertEqual(rng.freq, '-2M')
+
     def test_first_subset(self):
         ts = _simple_ts('1/1/2000', '1/1/2010', freq='12h')
         result = ts.first('10d')


### PR DESCRIPTION
Fixed 2 issues:
- `date_range` can't handle negative calendar-based freq (like `A`, `Q` and `M`).

```
import pandas as pd

# OK
pd.date_range('2011-01-01', freq='-1D', periods=3)
# DatetimeIndex(['2011-01-01', '2010-12-31', '2010-12-30'], dtype='datetime64[ns]', freq='-1D')

# NG
pd.date_range('2011-01-01', freq='-1M', periods=3)
# DatetimeIndex([], dtype='datetime64[ns]', freq='-1M')
```
- Unable to infer negative freq.

```
pd.DatetimeIndex(['2011-01-05', '2011-01-03', '2011-01-01'], freq='infer')
# DatetimeIndex(['2011-01-05', '2011-01-03', '2011-01-01'], dtype='datetime64[ns]', freq=None)

pd.TimedeltaIndex(['-1 days', '-3 days', '-5 days'], freq='infer')
# TimedeltaIndex(['-1 days', '-3 days', '-5 days'], dtype='timedelta64[ns]', freq=None)
```
