### PR TITLE
BUG: Exception when setting a major- or minor-axis slice of a Panel with RHS a DataFrame

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -964,6 +964,8 @@ Bug Fixes
 
 - Bug causes memory leak in time-series line and area plot (:issue:`9003`)
 
+- Bug when setting a ``Panel`` sliced along the major or minor axes when the right-hand side is a ``DataFrame`` (:issue:`11014`)
+
 
 - Bug in line and kde plot cannot accept multiple colors when ``subplots=True`` (:issue:`9894`)
 - Bug in ``DataFrame.plot`` raises ``ValueError`` when color name is specified by multiple characters (:issue:`10387`)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -442,11 +442,15 @@ class _NDFrameIndexer(object):
 
                 # we have an equal len Frame
                 if isinstance(value, ABCDataFrame) and value.ndim > 1:
+                    sub_indexer = list(indexer)
 
                     for item in labels:
-                        # align to
-                        v = np.nan if item not in value else \
-                                self._align_series(indexer[0], value[item])
+                        if item in value:
+                            sub_indexer[info_axis] = item
+                            v = self._align_series(tuple(sub_indexer), value[item])
+                        else:
+                            v = np.nan
+
                         setter(item, v)
 
                 # we have an equal len ndarray/convertible to our labels

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -506,6 +506,20 @@ class CheckIndexing(object):
 
         assert_almost_equal(P[key].values, data)
 
+    def test_set_minor_major(self):
+        # GH 11014
+        df1 = DataFrame(['a', 'a', 'a', np.nan, 'a', np.nan])
+        df2 = DataFrame([1.0, np.nan, 1.0, np.nan, 1.0, 1.0])
+        panel = Panel({'Item1' : df1, 'Item2': df2})
+
+        newminor = notnull(panel.iloc[:, :, 0])
+        panel.loc[:, :, 'NewMinor'] = newminor
+        assert_frame_equal(panel.loc[:, :, 'NewMinor'], newminor.astype(object))
+
+        newmajor = notnull(panel.iloc[:, 0, :])
+        panel.loc[:, 'NewMajor', :] = newmajor
+        assert_frame_equal(panel.loc[:, 'NewMajor', :], newmajor.astype(object))
+
     def test_major_xs(self):
         ref = self.panel['ItemA']
 


### PR DESCRIPTION
Fixes GH #11014

This isn't actually a recent regression. The bug was introduced in 0.15.0 with this commit: https://github.com/pydata/pandas/commit/30246a7d2b113b7115fd0708655ae8e1c3f2e6c5; it was just made more common (i.e., it happens on panels without mixed dtype) in 0.16.2 by this commit: https://github.com/pydata/pandas/commit/5c394677e10dac38fe3375e2564bb76cf8bbffca.
