### PR TITLE
BUG: Fixed bug in len(DataFrame.groupby) causing IndexError when there's a NaN-only column (issue11016)

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -954,7 +954,7 @@ Bug Fixes
 - Bug in ``Categorical.__iter__`` may not returning correct ``datetime`` and ``Period`` (:issue:`10713`)
 
 - Bug in ``read_csv`` with ``engine='c'``: EOF preceded by a comment, blank line, etc. was not handled correctly (:issue:`10728`, :issue:`10548`)
-
+- Bug in ``len(DataFrame.groupby)`` causing IndexError when there's a column containing only NaNs (:issue: `11016`)
 - Reading "famafrench" data via ``DataReader`` results in HTTP 404 error because of the website url is changed (:issue:`10591`).
 - Bug in ``read_msgpack`` where DataFrame to decode has duplicate column names (:issue:`9618`)
 - Bug in ``io.common.get_filepath_or_buffer`` which caused reading of valid S3 files to fail if the bucket also contained keys for which the user does not have read permission (:issue:`10604`)
@@ -986,4 +986,4 @@ Bug Fixes
 - Bug when constructing ``DataFrame`` where passing a dictionary with only scalar values and specifying columns did not raise an error (:issue:`10856`)
 - Bug in ``.var()`` causing roundoff errors for highly similar values (:issue:`10242`)
 - Bug in ``DataFrame.plot(subplots=True)`` with duplicated columns outputs incorrect result (:issue:`10962`)
-- Bug in ``len(DataFrame.groupby)`` causing IndexError when there's a column containing only NaNs (:issue: `11016`)
+

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -986,3 +986,4 @@ Bug Fixes
 - Bug when constructing ``DataFrame`` where passing a dictionary with only scalar values and specifying columns did not raise an error (:issue:`10856`)
 - Bug in ``.var()`` causing roundoff errors for highly similar values (:issue:`10242`)
 - Bug in ``DataFrame.plot(subplots=True)`` with duplicated columns outputs incorrect result (:issue:`10962`)
+- Bug in ``len(DataFrame.groupby)`` causing IndexError when there's a column containing only NaNs (:issue: `11016`)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -403,7 +403,7 @@ class GroupBy(PandasObject):
         self.exclusions = set(exclusions) if exclusions else set()
 
     def __len__(self):
-        return len(self.indices)
+        return len(self.groups)
 
     def __unicode__(self):
         # TODO: Better unicode/repr for GroupBy object

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -837,6 +837,12 @@ class TestGroupBy(tm.TestCase):
         expected = len(set([(x.year, x.month) for x in df.index]))
         self.assertEqual(len(grouped), expected)
 
+        # issue 11016
+        df = pd.DataFrame(dict(a=[np.nan]*3, b=[1,2,3]))
+        self.assertEqual(len(df.groupby(('a'))), 0)
+        self.assertEqual(len(df.groupby(('b'))), 3)
+        self.assertEqual(len(df.groupby(('a', 'b'))), 3)
+
     def test_groups(self):
         grouped = self.df.groupby(['A'])
         groups = grouped.groups


### PR DESCRIPTION
Fixed #11016 
