### PR TITLE
BUG: Fixed bug in len(DataFrame.groupby) causing IndexError when there's a NaN-only column (issue11016)

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -951,7 +951,7 @@ Bug Fixes
 
 
 - Bug in ``to_datetime`` and ``to_timedelta`` causing ``Index`` name to be lost (:issue:`10875`)
-
+- Bug in ``len(DataFrame.groupby)`` causing IndexError when there's a column containing only NaNs (:issue: `11016`)
 
 - Bug that caused segfault when resampling an empty Series (:issue:`10228`)
 - Bug in ``DatetimeIndex`` and ``PeriodIndex.value_counts`` resets name from its result, but retains in result's ``Index``. (:issue:`10150`)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -400,7 +400,7 @@ class GroupBy(PandasObject):
         self.exclusions = set(exclusions) if exclusions else set()
 
     def __len__(self):
-        return len(self.indices)
+        return len(self.groups)
 
     def __unicode__(self):
         # TODO: Better unicode/repr for GroupBy object

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -837,6 +837,12 @@ class TestGroupBy(tm.TestCase):
         expected = len(set([(x.year, x.month) for x in df.index]))
         self.assertEqual(len(grouped), expected)
 
+        # issue 11016
+        df = pd.DataFrame(dict(a=[np.nan]*3, b=[1,2,3]))
+        self.assertEqual(len(df.groupby(('a'))), 0)
+        self.assertEqual(len(df.groupby(('b'))), 3)
+        self.assertEqual(len(df.groupby(('a', 'b'))), 3)
+
     def test_groups(self):
         grouped = self.df.groupby(['A'])
         groups = grouped.groups


### PR DESCRIPTION
This is the new PR for Fixed issue #11016 
