### PR TITLE
DOC: Fix misspelling of max_colwidth in documentation.

### DIFF
--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -187,7 +187,7 @@ dataframes to stretch across pages, wrapped over the full column vs row-wise.
    pd.reset_option('large_repr')
    pd.reset_option('max_rows')
 
-``display.max_columnwidth`` sets the maximum width of columns.  Cells
+``display.max_colwidth`` sets the maximum width of columns.  Cells
 of this length or longer will be truncated with an ellipsis.
 
 .. ipython:: python


### PR DESCRIPTION
One location referencing `display.max_colwidth` was incorrectly spelled as `display.max_columnwidth`.
