### PR TITLE
PERF: improves performance in GroupBy.cumcount

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -138,6 +138,47 @@ API changes
 - Provide a proper ``__name__`` and ``__qualname__`` attributes for generic functions (:issue:`12021`)
 - ``pd.concat(ignore_index=True)`` now uses ``RangeIndex`` as default (:issue:`12695`)
 
+.. _whatsnew_0181.enhancements.groubynth:
+
+Index in ``Groupby.nth`` output is now more consistent with ``as_index``
+argument passed in (:issue:`11039`):
+
+Previous Behavior:
+
+.. code-block:: ipython
+
+    In [4]: df
+    Out[4]:
+       A  B
+    0  a  1
+    1  b  2
+    2  a  3
+
+    In [5]: df.groupby('A', as_index=True)['B'].nth(0)
+    Out[5]:
+    0    1
+    1    2
+    Name: B, dtype: int64
+
+
+New Behavior:
+
+.. code-block:: ipython
+
+    In [7]: df.groupby('A', as_index=True)['B'].nth(0)
+    Out[7]:
+    A
+    a    1
+    b    2
+    Name: B, dtype: int64
+
+    In [8]: df.groupby('A', as_index=False)['B'].nth(0)
+    Out[8]:
+    0    1
+    1    2
+    Name: B, dtype: int64
+
+
 .. _whatsnew_0181.apply_resample:
 
 Using ``.apply`` on groupby resampling
@@ -239,7 +280,7 @@ Deprecations
 
 Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
-
+- Performance improvements in ``GroupBy.cumcount`` (:issue:`11039`)
 
 
 - Improved performance of ``DataFrame.to_sql`` when checking case sensitivity for tables. Now only checks if table has been created correctly when table name is not lower case. (:issue:`12876`)


### PR DESCRIPTION
closes #12839 

```
    -------------------------------------------------------------------------------
    Test name                                    | head[ms] | base[ms] |  ratio   |
    -------------------------------------------------------------------------------
    groupby_ngroups_10000_cumcount               |   3.9790 |  74.9559 |   0.0531 |
    groupby_ngroups_100_cumcount                 |   0.6043 |   0.9940 |   0.6079 |
    -------------------------------------------------------------------------------
    Test name                                    | head[ms] | base[ms] |  ratio   |
    -------------------------------------------------------------------------------

    Ratio < 1.0 means the target commit is faster then the baseline.
    Seed used: 1234

    Target [2a1c935] : PERF: improves performance in GroupBy.cumcount
    Base   [5b1f3b6] : reverts 'from .pandas_vb_common import *'
```
