### PR TITLE
DOC: Updated doc-string using new doc-string design for DataFrameFormatter

### DIFF
--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -58,18 +58,13 @@ justify_docstring  = """
         the print configuration (controlled by set_option), 'right' out
         of the box."""
 
-force_unicode_docstring = """
-    force_unicode : bool, default False
-        Always return a unicode result. Deprecated in v0.10.0 as string
-        formatting is now rendered to unicode by default."""
-
 return_docstring = """
 
     Returns
     -------
     formatted : string (or unicode, depending on data and options)"""
 
-docstring_to_string = common_docstring + justify_docstring + force_unicode_docstring + return_docstring
+docstring_to_string = common_docstring + justify_docstring + return_docstring
 
 class CategoricalFormatter(object):
 
@@ -300,7 +295,7 @@ class DataFrameFormatter(TableFormatter):
     """
 
     __doc__ = __doc__ if __doc__ else ''
-    __doc__ += docstring_to_string
+    __doc__ += common_docstring + justify_docstring + return_docstring
 
     def __init__(self, frame, buf=None, columns=None, col_space=None,
                  header=True, index=True, na_rep='NaN', formatters=None,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1414,7 +1414,7 @@ class DataFrame(NDFrame):
                              write_index=write_index)
         writer.write_file()
 
-    @Appender(fmt.common_docstring + fmt.justify_docstring + fmt.return_docstring, indents=1)
+    @Appender(fmt.docstring_to_string, indents=1)
     def to_string(self, buf=None, columns=None, col_space=None,
                   header=True, index=True, na_rep='NaN', formatters=None,
                   float_format=None, sparsify=None, index_names=True,
@@ -1442,7 +1442,7 @@ class DataFrame(NDFrame):
             result = formatter.buf.getvalue()
             return result
 
-    @Appender(fmt.common_docstring + fmt.justify_docstring + fmt.return_docstring, indents=1)
+    @Appender(fmt.docstring_to_string, indents=1)
     def to_html(self, buf=None, columns=None, col_space=None, colSpace=None,
                 header=True, index=True, na_rep='NaN', formatters=None,
                 float_format=None, sparsify=None, index_names=True,


### PR DESCRIPTION
`DataFrameFormatter` does not have this parameter: `force_unicode_docstring`. This change uses the doc-string re-design in #11011 
