### PR TITLE
Adds the option display.escape_notebook_repr_html

### DIFF
--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -77,6 +77,12 @@ pc_nb_repr_h_doc = """
     pandas objects (if it is available).
 """
 
+pc_esc_nb_repr_h_doc = """
+: boolean
+    When True, IPython notebook will use HTML-safe sequences for
+    <, >, and & when representing pandas objects.
+"""
+
 pc_date_dayfirst_doc = """
 : boolean
     When True, prints and parses dates with the day first, eg 20/01/2005
@@ -254,6 +260,8 @@ with cf.config_prefix('display'):
     cf.register_option('colheader_justify', 'right', colheader_justify_doc,
                        validator=is_text)
     cf.register_option('notebook_repr_html', True, pc_nb_repr_h_doc,
+                       validator=is_bool)
+    cf.register_option('escape_notebook_repr_html', True, pc_esc_nb_repr_h_doc,
                        validator=is_bool)
     cf.register_option('date_dayfirst', False, pc_date_dayfirst_doc,
                        validator=is_bool)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1460,7 +1460,7 @@ class DataFrame(NDFrame):
         classes : str or list or tuple, default None
             CSS class(es) to apply to the resulting html table
         escape : boolean, default True
-            Convert the characters <, >, and & to HTML-safe sequences.=
+            Convert the characters <, >, and & to HTML-safe sequences.
         max_rows : int, optional
             Maximum number of rows to show before truncating. If None, show
             all.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -566,10 +566,11 @@ class DataFrame(NDFrame):
             max_rows = get_option("display.max_rows")
             max_cols = get_option("display.max_columns")
             show_dimensions = get_option("display.show_dimensions")
+            escape_html = get_option("display.escape_notebook_repr_html")
 
             return self.to_html(max_rows=max_rows, max_cols=max_cols,
                                 show_dimensions=show_dimensions,
-                                notebook=True)
+                                notebook=True, escape=escape_html)
         else:
             return None
 


### PR DESCRIPTION
Adds the option `display.escape_notebook_repr_html` for controlling HTML escaping when rendering DataFrames in IPython notebooks. Unset, this argument does not change the default behaviour.  

Fixes #11062
