### PR TITLE
ENH Add check for inferred compression before `get_filepath_or_buffer`

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -481,6 +481,8 @@ Other enhancements
 
 - Read CSV files from AWS S3 incrementally, instead of first downloading the entire file. (Full file download still required for compressed files in Python 2.) (:issue:`11070`, :issue:`11073`)
 
+- ``pd.read_csv`` is now able to infer compression type for files read from AWS S3 storage (:issue:`11070`, :issue:`11074`).
+
 .. _whatsnew_0170.api:
 
 .. _whatsnew_0170.api_breaking:

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -217,6 +217,8 @@ def get_filepath_or_buffer(filepath_or_buffer, encoding=None,
             content_encoding = req.headers.get('Content-Encoding', None)
             if content_encoding == 'gzip':
                 compression = 'gzip'
+            else:
+                compression = None
         # cat on the compression to the tuple returned by the function
         to_return = list(maybe_read_encoded_stream(req, encoding, compression)) + \
                     [compression]
@@ -237,7 +239,9 @@ def get_filepath_or_buffer(filepath_or_buffer, encoding=None,
             conn = boto.connect_s3(anon=True)
 
         b = conn.get_bucket(parsed_url.netloc, validate=False)
-        if compat.PY2 and compression == 'gzip':
+        if compat.PY2 and (compression == 'gzip' or
+                           (compression == 'infer' and
+                            filepath_or_buffer.endswith(".gz"))):
             k = boto.s3.key.Key(b, parsed_url.path)
             filepath_or_buffer = BytesIO(k.get_contents_as_string(
                 encoding=encoding))

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -4342,6 +4342,15 @@ class TestS3(tm.TestCase):
             tm.assert_frame_equal(pd.read_csv(tm.get_data_path('tips.csv')), df)
 
     @tm.network
+    def test_infer_s3_compression(self):
+        for ext in ['', '.gz', '.bz2']:
+            df = pd.read_csv('s3://pandas-test/tips.csv' + ext,
+                             engine='python', compression='infer')
+            self.assertTrue(isinstance(df, pd.DataFrame))
+            self.assertFalse(df.empty)
+            tm.assert_frame_equal(pd.read_csv(tm.get_data_path('tips.csv')), df)
+
+    @tm.network
     def test_parse_public_s3_bucket_nrows_python(self):
         for ext, comp in [('', None), ('.gz', 'gzip'), ('.bz2', 'bz2')]:
             df = pd.read_csv('s3://pandas-test/tips.csv' + ext, engine='python',

--- a/pandas/parser.pyx
+++ b/pandas/parser.pyx
@@ -541,17 +541,6 @@ cdef class TextReader:
         self.parser.cb_io = NULL
         self.parser.cb_cleanup = NULL
 
-        if self.compression == 'infer':
-            if isinstance(source, basestring):
-                if source.endswith('.gz'):
-                    self.compression = 'gzip'
-                elif source.endswith('.bz2'):
-                    self.compression = 'bz2'
-                else:
-                    self.compression = None
-            else:
-                self.compression = None
-
         if self.compression:
             if self.compression == 'gzip':
                 import gzip


### PR DESCRIPTION
When reading CSVs, if `compression='infer'`, check the input before calling `get_filepath_or_buffer` in the `_read` function. This way we can catch compresion extensions on S3 files. Partially resolves issue #11070 .

Checking for the file extension in the `_read` function should make the checks inside the parsers redundant. When I tried to remove them, however, I discovered that there's tests which assume the parsers can take an "infer" compression, so I left their checks.

I also discovered that the URL-reading code has a test which reads a URL ending in "gz" but which appears not to be gzip encoded, so this PR attempts to preserve its verdict in that case.
