### PR TITLE
TST: Fix skipped unit tests in test_ga. Install python-gflags using p…

### DIFF
--- a/ci/requirements-2.7.pip
+++ b/ci/requirements-2.7.pip
@@ -1,3 +1,4 @@
 blosc
 httplib2
 google-api-python-client == 1.2
+python-gflags == 2.0

--- a/ci/requirements-2.7.txt
+++ b/ci/requirements-2.7.txt
@@ -20,4 +20,3 @@ patsy
 pymysql=0.6.3
 html5lib=1.0b2
 beautiful-soup=4.2.1
-python-gflags=2.0

--- a/ci/requirements-2.7_SLOW.txt
+++ b/ci/requirements-2.7_SLOW.txt
@@ -20,4 +20,3 @@ psycopg2
 pymysql
 html5lib
 beautiful-soup
-python-gflags


### PR DESCRIPTION
closes #11090 

This commit should resolve the following error in the travis build log.

```
-------------------------------------------------------------
#15 nose.failure.Failure.runTest: need httplib2 and auth libs
-------------------------------------------------------------
```

Valid Google credentials are required to run the ga unit tests. 
