### PR TITLE
ENH: Data formatting with unicode length

### DIFF
--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -440,3 +440,56 @@ For instance:
    pd.reset_option('^display\.')
 
 To round floats on a case-by-case basis, you can also use :meth:`~pandas.Series.round` and :meth:`~pandas.DataFrame.round`.
+
+.. _options.east_asian_width:
+
+Unicode Formatting
+------------------
+
+.. warning::
+
+   Enabling this option will affect the performance for printing of DataFrame and Series (about 2 times slower).
+   Use only when it is actually required.
+
+Some East Asian countries use Unicode characters its width is corresponding to 2 alphabets.
+If DataFrame or Series contains these characters, default output cannot be aligned properly.
+
+.. ipython:: python
+
+   df = pd.DataFrame({u'国籍': ['UK', u'日本'], u'名前': ['Alice', u'しのぶ']})
+   df
+
+Enable ``display.unicode.east_asian_width`` allows pandas to check each character's "East Asian Width" property.
+These characters can be aligned properly by checking this property, but it takes longer time than standard ``len`` function.
+
+.. ipython:: python
+
+   pd.set_option('display.unicode.east_asian_width', True)
+   df
+
+In addition, Unicode contains characters which width is "Ambiguous". These character's width should be either 1 or 2 depending on terminal setting or encoding. Because this cannot be distinguished from Python, ``display.unicode.ambiguous_as_wide`` option is added to handle this.
+
+By default, "Ambiguous" character's width, "¡" (inverted exclamation) in below example, is regarded as 1.
+
+.. note::
+
+   This should be aligned properly in terminal which uses monospaced font.
+
+.. ipython:: python
+
+   df = pd.DataFrame({'a': ['xxx', u'¡¡'], 'b': ['yyy', u'¡¡']})
+   df
+
+Enabling ``display.unicode.ambiguous_as_wide`` lets pandas to regard these character's width as 2. Note that this option will be effective only when ``display.unicode.east_asian_width`` is enabled. Confirm starting position has been changed, but not aligned properly because the setting is mismatched with this environment.
+
+.. ipython:: python
+
+   pd.set_option('display.unicode.ambiguous_as_wide', True)
+   df
+
+.. ipython:: python
+   :suppress:
+
+   pd.set_option('display.unicode.east_asian_width', False)
+   pd.set_option('display.unicode.ambiguous_as_wide', False)
+

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -49,6 +49,7 @@ Highlights include:
 - Support for reading SAS xport files, see :ref:`here <whatsnew_0170.enhancements.sas_xport>`
 - Documentation comparing SAS to *pandas*, see :ref:`here <compare_with_sas>`
 - Removal of the automatic TimeSeries broadcasting, deprecated since 0.8.0, see :ref:`here <whatsnew_0170.prior_deprecations>`
+- Display format with plain text can optionally align with Unicode East Asian Width, see :ref:`here <whatsnew_0170.east_asian_width>`
 - Compatibility with Python 3.5 (:issue:`11097`)
 - Compatibility with matplotlib 1.5.0 (:issue:`11111`)
 
@@ -333,6 +334,36 @@ Google BigQuery Enhancements
 - ``InvalidColumnOrder`` and ``InvalidPageToken`` in the gbq module will raise ``ValueError`` instead of ``IOError``.
 - The ``generate_bq_schema()`` function is now deprecated and will be removed in a future version (:issue:`11121`)
 - Update the gbq module to support Python 3 (:issue:`11094`).
+
+.. _whatsnew_0170.east_asian_width:
+
+Display Alignemnt with Unicode East Asian Width
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. warning::
+
+   Enabling this option will affect the performance for printing of DataFrame and Series (about 2 times slower).
+   Use only when it is actually required.
+
+Some East Asian countries use Unicode characters its width is corresponding to 2 alphabets. If DataFrame or Series contains these characters, default output cannot be aligned properly. The following options are added to enable precise handling for these characters.
+
+- ``display.unicode.east_asian_width``: Whether to use the Unicode East Asian Width to calculate the display text width. (:issue:`2612`)
+- ``display.unicode.ambiguous_as_wide``: Whether to handle Unicode characters belong to Ambiguous as Wide. (:issue:`11102`)
+
+.. ipython:: python
+
+   df = pd.DataFrame({u'国籍': ['UK', u'日本'], u'名前': ['Alice', u'しのぶ']})
+   df
+
+   pd.set_option('display.unicode.east_asian_width', True)
+   df
+
+For further details, see :ref:`here <options.east_asian_width>`
+
+.. ipython:: python
+   :suppress:
+
+   pd.set_option('display.unicode.east_asian_width', False)
 
 .. _whatsnew_0170.enhancements.other:
 

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -35,6 +35,7 @@ from distutils.version import LooseVersion
 from itertools import product
 import sys
 import types
+from unicodedata import east_asian_width
 
 PY2 = sys.version_info[0] == 2
 PY3 = (sys.version_info[0] >= 3)
@@ -90,6 +91,7 @@ if PY3:
 
     def lfilter(*args, **kwargs):
         return list(filter(*args, **kwargs))
+
 else:
     # Python 2
     import re
@@ -176,6 +178,11 @@ def bind_method(cls, name, func):
 # The license for this library can be found in LICENSES/SIX and the code can be
 # found at https://bitbucket.org/gutworth/six
 
+# Definition of East Asian Width
+# http://unicode.org/reports/tr11/
+# Ambiguous width can be changed by option
+_EAW_MAP = {'Na': 1, 'N': 1, 'W': 2, 'F': 2, 'H': 1}
+
 if PY3:
     string_types = str,
     integer_types = int,
@@ -188,6 +195,20 @@ if PY3:
 
     def u_safe(s):
         return s
+
+    def strlen(data, encoding=None):
+        # encoding is for compat with PY2
+        return len(data)
+
+    def east_asian_len(data, encoding=None, ambiguous_width=1):
+        """
+        Calculate display width considering unicode East Asian Width
+        """
+        if isinstance(data, text_type):
+            return sum([_EAW_MAP.get(east_asian_width(c), ambiguous_width) for c in data])
+        else:
+            return len(data)
+
 else:
     string_types = basestring,
     integer_types = (int, long)
@@ -204,6 +225,25 @@ else:
         except:
             return s
 
+    def strlen(data, encoding=None):
+        try:
+            data = data.decode(encoding)
+        except UnicodeError:
+            pass
+        return len(data)
+
+    def east_asian_len(data, encoding=None, ambiguous_width=1):
+        """
+        Calculate display width considering unicode East Asian Width
+        """
+        if isinstance(data, text_type):
+            try:
+                data = data.decode(encoding)
+            except UnicodeError:
+                pass
+            return sum([_EAW_MAP.get(east_asian_width(c), ambiguous_width) for c in data])
+        else:
+            return len(data)
 
 string_and_binary_types = string_types + (binary_type,)
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -2149,21 +2149,33 @@ def _count_not_none(*args):
 
 
 
-def adjoin(space, *lists):
+def adjoin(space, *lists, **kwargs):
     """
     Glues together two sets of strings using the amount of space requested.
     The idea is to prettify.
+
+    ----------
+    space : int
+        number of spaces for padding
+    lists : str
+        list of str which being joined
+    strlen : callable
+        function used to calculate the length of each str. Needed for unicode
+        handling.
+    justfunc : callable
+        function used to justify str. Needed for unicode handling.
     """
+    strlen = kwargs.pop('strlen', len)
+    justfunc = kwargs.pop('justfunc', _justify)
+
     out_lines = []
     newLists = []
-    lengths = [max(map(len, x)) + space for x in lists[:-1]]
-
+    lengths = [max(map(strlen, x)) + space for x in lists[:-1]]
     # not the last one
     lengths.append(max(map(len, lists[-1])))
-
     maxLen = max(map(len, lists))
     for i, lst in enumerate(lists):
-        nl = [x.ljust(lengths[i]) for x in lst]
+        nl = justfunc(lst, lengths[i], mode='left')
         nl.extend([' ' * lengths[i]] * (maxLen - len(lst)))
         newLists.append(nl)
     toJoin = zip(*newLists)
@@ -2171,6 +2183,16 @@ def adjoin(space, *lists):
         out_lines.append(_join_unicode(lines))
     return _join_unicode(out_lines, sep='\n')
 
+def _justify(texts, max_len, mode='right'):
+    """
+    Perform ljust, center, rjust against string or list-like
+    """
+    if mode == 'left':
+        return [x.ljust(max_len) for x in texts]
+    elif mode == 'center':
+        return [x.center(max_len) for x in texts]
+    else:
+        return [x.rjust(max_len) for x in texts]
 
 def _join_unicode(lines, sep=''):
     try:

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -144,6 +144,17 @@ pc_line_width_doc = """
     Deprecated.
 """
 
+pc_east_asian_width_doc = """
+: boolean
+    Whether to use the Unicode East Asian Width to calculate the display text width
+    Enabling this may affect to the performance (default: False)
+"""
+pc_ambiguous_as_wide_doc = """
+: boolean
+    Whether to handle Unicode characters belong to Ambiguous as Wide (width=2)
+    (default: False)
+"""
+
 pc_line_width_deprecation_warning = """\
 line_width has been deprecated, use display.width instead (currently both are
 identical)
@@ -282,6 +293,10 @@ with cf.config_prefix('display'):
                        pc_line_width_doc)
     cf.register_option('memory_usage', True, pc_memory_usage_doc,
                         validator=is_instance_factory([type(None), bool]))
+    cf.register_option('unicode.east_asian_width', False,
+                       pc_east_asian_width_doc, validator=is_bool)
+    cf.register_option('unicode.ambiguous_as_wide', False,
+                       pc_east_asian_width_doc, validator=is_bool)
 
 cf.deprecate_option('display.line_width',
                     msg=pc_line_width_deprecation_warning,

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -2,7 +2,7 @@
 # pylint: disable=E1101,E1103,W0232
 
 from datetime import datetime
-from pandas.compat import range, lrange, u
+from pandas.compat import range, lrange, u, PY3
 import os
 import pickle
 import re
@@ -533,6 +533,33 @@ class TestCategorical(tm.TestCase):
 
         with option_context("display.width", None):
             self.assertEqual(exp, repr(a))
+
+    def test_unicode_print(self):
+        if PY3:
+            _rep = repr
+        else:
+            _rep = unicode
+
+        c = pd.Categorical(['aaaaa', 'bb', 'cccc'] * 20)
+        expected = u"""[aaaaa, bb, cccc, aaaaa, bb, ..., bb, cccc, aaaaa, bb, cccc]
+Length: 60
+Categories (3, object): [aaaaa, bb, cccc]"""
+        self.assertEqual(_rep(c), expected)
+
+        c = pd.Categorical([u'ああああ', u'いいいいい', u'ううううううう'] * 20)
+        expected = u"""[ああああ, いいいいい, ううううううう, ああああ, いいいいい, ..., いいいいい, ううううううう, ああああ, いいいいい, ううううううう]
+Length: 60
+Categories (3, object): [ああああ, いいいいい, ううううううう]"""
+        self.assertEqual(_rep(c), expected)
+
+        # unicode option should not affect to Categorical, as it doesn't care the repr width
+        with option_context('display.unicode.east_asian_width', True):
+
+            c = pd.Categorical([u'ああああ', u'いいいいい', u'ううううううう'] * 20)
+            expected = u"""[ああああ, いいいいい, ううううううう, ああああ, いいいいい, ..., いいいいい, ううううううう, ああああ, いいいいい, ううううううう]
+Length: 60
+Categories (3, object): [ああああ, いいいいい, ううううううう]"""
+            self.assertEqual(_rep(c), expected)
 
     def test_periodindex(self):
         idx1 = PeriodIndex(['2014-01', '2014-01', '2014-02', '2014-02',

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -14,6 +14,7 @@ from pandas.compat import range, long, lrange, lmap, u
 from pandas.core.common import notnull, isnull, array_equivalent
 import pandas.core.common as com
 import pandas.core.convert as convert
+import pandas.core.format as fmt
 import pandas.util.testing as tm
 import pandas.core.config as cf
 
@@ -330,6 +331,99 @@ def test_adjoin():
     adjoined = com.adjoin(2, *data)
 
     assert(adjoined == expected)
+
+
+
+class TestFormattBase(tm.TestCase):
+
+    def test_adjoin(self):
+        data = [['a', 'b', 'c'],
+                ['dd', 'ee', 'ff'],
+                ['ggg', 'hhh', 'iii']]
+        expected = 'a  dd  ggg\nb  ee  hhh\nc  ff  iii'
+
+        adjoined = com.adjoin(2, *data)
+
+        self.assertEqual(adjoined, expected)
+
+    def test_adjoin_unicode(self):
+        data = [[u'あ', 'b', 'c'],
+                ['dd', u'ええ', 'ff'],
+                ['ggg', 'hhh', u'いいい']]
+        expected = u'あ  dd  ggg\nb  ええ  hhh\nc  ff  いいい'
+        adjoined = com.adjoin(2, *data)
+        self.assertEqual(adjoined, expected)
+
+        adj = fmt.EastAsianTextAdjustment()
+
+        expected = u"""あ  dd    ggg
+b   ええ  hhh
+c   ff    いいい"""
+        adjoined = adj.adjoin(2, *data)
+        self.assertEqual(adjoined, expected)
+        cols = adjoined.split('\n')
+        self.assertEqual(adj.len(cols[0]), 13)
+        self.assertEqual(adj.len(cols[1]), 13)
+        self.assertEqual(adj.len(cols[2]), 16)
+
+        expected = u"""あ       dd         ggg
+b        ええ       hhh
+c        ff         いいい"""
+        adjoined = adj.adjoin(7, *data)
+        self.assertEqual(adjoined, expected)
+        cols = adjoined.split('\n')
+        self.assertEqual(adj.len(cols[0]), 23)
+        self.assertEqual(adj.len(cols[1]), 23)
+        self.assertEqual(adj.len(cols[2]), 26)
+
+    def test_justify(self):
+        adj = fmt.EastAsianTextAdjustment()
+
+        def just(x, *args, **kwargs):
+            # wrapper to test single str
+            return adj.justify([x], *args, **kwargs)[0]
+
+        self.assertEqual(just('abc', 5, mode='left'), 'abc  ')
+        self.assertEqual(just('abc', 5, mode='center'), ' abc ')
+        self.assertEqual(just('abc', 5, mode='right'), '  abc')
+        self.assertEqual(just(u'abc', 5, mode='left'), 'abc  ')
+        self.assertEqual(just(u'abc', 5, mode='center'), ' abc ')
+        self.assertEqual(just(u'abc', 5, mode='right'), '  abc')
+
+        self.assertEqual(just(u'パンダ', 5, mode='left'), u'パンダ')
+        self.assertEqual(just(u'パンダ', 5, mode='center'), u'パンダ')
+        self.assertEqual(just(u'パンダ', 5, mode='right'), u'パンダ')
+
+        self.assertEqual(just(u'パンダ', 10, mode='left'), u'パンダ    ')
+        self.assertEqual(just(u'パンダ', 10, mode='center'), u'  パンダ  ')
+        self.assertEqual(just(u'パンダ', 10, mode='right'), u'    パンダ')
+
+    def test_east_asian_len(self):
+        adj = fmt.EastAsianTextAdjustment()
+
+        self.assertEqual(adj.len('abc'), 3)
+        self.assertEqual(adj.len(u'abc'), 3)
+
+        self.assertEqual(adj.len(u'パンダ'), 6)
+        self.assertEqual(adj.len(u'ﾊﾟﾝﾀﾞ'), 5)
+        self.assertEqual(adj.len(u'パンダpanda'), 11)
+        self.assertEqual(adj.len(u'ﾊﾟﾝﾀﾞpanda'), 10)
+
+
+    def test_ambiguous_width(self):
+        adj = fmt.EastAsianTextAdjustment()
+        self.assertEqual(adj.len(u'¡¡ab'), 4)
+
+        with cf.option_context('display.unicode.ambiguous_as_wide', True):
+            adj = fmt.EastAsianTextAdjustment()
+            self.assertEqual(adj.len(u'¡¡ab'), 6)
+
+        data = [[u'あ', 'b', 'c'],
+                ['dd', u'ええ', 'ff'],
+                ['ggg', u'¡¡ab', u'いいい']]
+        expected = u'あ  dd    ggg \nb   ええ  ¡¡ab\nc   ff    いいい'
+        adjoined = adj.adjoin(2, *data)
+        self.assertEqual(adjoined, expected)
 
 
 def test_iterpairs():

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -2,7 +2,7 @@
 # pylint: disable=E1101,E1103,W0232
 
 from datetime import datetime, timedelta, time
-from pandas.compat import range, lrange, lzip, u, zip
+from pandas.compat import range, lrange, lzip, u, zip, PY3
 import operator
 import re
 import nose
@@ -1842,6 +1842,137 @@ class TestIndex(Base, tm.TestCase):
         self.assertEqual(i.name, pd.to_datetime(i).name)
         self.assertEqual(i.name, pd.to_timedelta(i).name)
 
+    def test_string_index_repr(self):
+        # py3/py2 repr can differ because of "u" prefix
+        # which also affects to displayed element size
+
+        # short
+        idx = pd.Index(['a', 'bb', 'ccc'])
+        if PY3:
+            expected = u"""Index(['a', 'bb', 'ccc'], dtype='object')"""
+            self.assertEqual(repr(idx), expected)
+        else:
+            expected = u"""Index([u'a', u'bb', u'ccc'], dtype='object')"""
+            self.assertEqual(unicode(idx), expected)
+
+        # multiple lines
+        idx = pd.Index(['a', 'bb', 'ccc'] * 10)
+        if PY3:
+            expected = u"""Index(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc',
+       'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc',
+       'a', 'bb', 'ccc', 'a', 'bb', 'ccc'],
+      dtype='object')"""
+            self.assertEqual(repr(idx), expected)
+        else:
+            expected = u"""Index([u'a', u'bb', u'ccc', u'a', u'bb', u'ccc', u'a', u'bb', u'ccc', u'a',
+       u'bb', u'ccc', u'a', u'bb', u'ccc', u'a', u'bb', u'ccc', u'a', u'bb',
+       u'ccc', u'a', u'bb', u'ccc', u'a', u'bb', u'ccc', u'a', u'bb', u'ccc'],
+      dtype='object')"""
+            self.assertEqual(unicode(idx), expected)
+
+        # truncated
+        idx = pd.Index(['a', 'bb', 'ccc'] * 100)
+        if PY3:
+            expected = u"""Index(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a',
+       ...
+       'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc'],
+      dtype='object', length=300)"""
+            self.assertEqual(repr(idx), expected)
+        else:
+            expected = u"""Index([u'a', u'bb', u'ccc', u'a', u'bb', u'ccc', u'a', u'bb', u'ccc', u'a',
+       ...
+       u'ccc', u'a', u'bb', u'ccc', u'a', u'bb', u'ccc', u'a', u'bb', u'ccc'],
+      dtype='object', length=300)"""
+            self.assertEqual(unicode(idx), expected)
+
+        # short
+        idx = pd.Index([u'あ', u'いい', u'ううう'])
+        if PY3:
+            expected = u"""Index(['あ', 'いい', 'ううう'], dtype='object')"""
+            self.assertEqual(repr(idx), expected)
+        else:
+            expected = u"""Index([u'あ', u'いい', u'ううう'], dtype='object')"""
+            self.assertEqual(unicode(idx), expected)
+
+        # multiple lines
+        idx = pd.Index([u'あ', u'いい', u'ううう'] * 10)
+        if PY3:
+            expected = u"""Index(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう',
+       'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう',
+       'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう'],
+      dtype='object')"""
+            self.assertEqual(repr(idx), expected)
+        else:
+            expected = u"""Index([u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ',
+       u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい',
+       u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう'],
+      dtype='object')"""
+            self.assertEqual(unicode(idx), expected)
+
+        # truncated
+        idx = pd.Index([u'あ', u'いい', u'ううう'] * 100)
+        if PY3:
+            expected = u"""Index(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ',
+       ...
+       'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう'],
+      dtype='object', length=300)"""
+            self.assertEqual(repr(idx), expected)
+        else:
+            expected = u"""Index([u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ',
+       ...
+       u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう'],
+      dtype='object', length=300)"""
+            self.assertEqual(unicode(idx), expected)
+
+        # Emable Unicode option -----------------------------------------
+        with cf.option_context('display.unicode.east_asian_width', True):
+
+            # short
+            idx = pd.Index([u'あ', u'いい', u'ううう'])
+            if PY3:
+                expected = u"""Index(['あ', 'いい', 'ううう'], dtype='object')"""
+                self.assertEqual(repr(idx), expected)
+            else:
+                expected = u"""Index([u'あ', u'いい', u'ううう'], dtype='object')"""
+                self.assertEqual(unicode(idx), expected)
+
+            # multiple lines
+            idx = pd.Index([u'あ', u'いい', u'ううう'] * 10)
+            if PY3:
+                expected = u"""Index(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう',
+       'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう',
+       'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう',
+       'あ', 'いい', 'ううう'],
+      dtype='object')"""
+                self.assertEqual(repr(idx), expected)
+            else:
+                expected = u"""Index([u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい',
+       u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ',
+       u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい',
+       u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう'],
+      dtype='object')"""
+                self.assertEqual(unicode(idx), expected)
+
+            # truncated
+            idx = pd.Index([u'あ', u'いい', u'ううう'] * 100)
+            if PY3:
+                expected = u"""Index(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう',
+       'あ',
+       ...
+       'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい',
+       'ううう'],
+      dtype='object', length=300)"""
+                self.assertEqual(repr(idx), expected)
+            else:
+                expected = u"""Index([u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい',
+       u'ううう', u'あ',
+       ...
+       u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ',
+       u'いい', u'ううう'],
+      dtype='object', length=300)"""
+                self.assertEqual(unicode(idx), expected)
+
+
 class TestCategoricalIndex(Base, tm.TestCase):
     _holder = CategoricalIndex
 
@@ -2210,6 +2341,180 @@ class TestCategoricalIndex(Base, tm.TestCase):
 
         self.assertFalse(CategoricalIndex(list('aabca') + [np.nan],categories=['c','a','b']).equals(list('aabca')))
         self.assertTrue(CategoricalIndex(list('aabca') + [np.nan],categories=['c','a','b']).equals(list('aabca') + [np.nan]))
+
+    def test_string_categorical_index_repr(self):
+        # short
+        idx = pd.CategoricalIndex(['a', 'bb', 'ccc'])
+        if PY3:
+            expected = u"""CategoricalIndex(['a', 'bb', 'ccc'], categories=['a', 'bb', 'ccc'], ordered=False, dtype='category')"""
+            self.assertEqual(repr(idx), expected)
+        else:
+            expected = u"""CategoricalIndex([u'a', u'bb', u'ccc'], categories=[u'a', u'bb', u'ccc'], ordered=False, dtype='category')"""
+            self.assertEqual(unicode(idx), expected)
+
+        # multiple lines
+        idx = pd.CategoricalIndex(['a', 'bb', 'ccc'] * 10)
+        if PY3:
+            expected = u"""CategoricalIndex(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a',
+                  'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb',
+                  'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc'],
+                 categories=['a', 'bb', 'ccc'], ordered=False, dtype='category')"""
+            self.assertEqual(repr(idx), expected)
+        else:
+            expected = u"""CategoricalIndex([u'a', u'bb', u'ccc', u'a', u'bb', u'ccc', u'a', u'bb',
+                  u'ccc', u'a', u'bb', u'ccc', u'a', u'bb', u'ccc', u'a',
+                  u'bb', u'ccc', u'a', u'bb', u'ccc', u'a', u'bb', u'ccc',
+                  u'a', u'bb', u'ccc', u'a', u'bb', u'ccc'],
+                 categories=[u'a', u'bb', u'ccc'], ordered=False, dtype='category')"""
+            self.assertEqual(unicode(idx), expected)
+
+        # truncated
+        idx = pd.CategoricalIndex(['a', 'bb', 'ccc'] * 100)
+        if PY3:
+            expected = u"""CategoricalIndex(['a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a',
+                  ...
+                  'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc', 'a', 'bb', 'ccc'],
+                 categories=['a', 'bb', 'ccc'], ordered=False, dtype='category', length=300)"""
+            self.assertEqual(repr(idx), expected)
+        else:
+            expected = u"""CategoricalIndex([u'a', u'bb', u'ccc', u'a', u'bb', u'ccc', u'a', u'bb',
+                  u'ccc', u'a',
+                  ...
+                  u'ccc', u'a', u'bb', u'ccc', u'a', u'bb', u'ccc', u'a',
+                  u'bb', u'ccc'],
+                 categories=[u'a', u'bb', u'ccc'], ordered=False, dtype='category', length=300)"""
+            self.assertEqual(unicode(idx), expected)
+
+        # larger categories
+        idx = pd.CategoricalIndex(list('abcdefghijklmmo'))
+        if PY3:
+            expected = u"""CategoricalIndex(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
+                  'm', 'm', 'o'],
+                 categories=['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', ...], ordered=False, dtype='category')"""
+            self.assertEqual(repr(idx), expected)
+        else:
+            expected = u"""CategoricalIndex([u'a', u'b', u'c', u'd', u'e', u'f', u'g', u'h', u'i', u'j',
+                  u'k', u'l', u'm', u'm', u'o'],
+                 categories=[u'a', u'b', u'c', u'd', u'e', u'f', u'g', u'h', ...], ordered=False, dtype='category')"""
+
+            self.assertEqual(unicode(idx), expected)
+
+        # short
+        idx = pd.CategoricalIndex([u'あ', u'いい', u'ううう'])
+        if PY3:
+            expected = u"""CategoricalIndex(['あ', 'いい', 'ううう'], categories=['あ', 'いい', 'ううう'], ordered=False, dtype='category')"""
+            self.assertEqual(repr(idx), expected)
+        else:
+            expected = u"""CategoricalIndex([u'あ', u'いい', u'ううう'], categories=[u'あ', u'いい', u'ううう'], ordered=False, dtype='category')"""
+            self.assertEqual(unicode(idx), expected)
+
+        # multiple lines
+        idx = pd.CategoricalIndex([u'あ', u'いい', u'ううう'] * 10)
+        if PY3:
+            expected = u"""CategoricalIndex(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ',
+                  'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい',
+                  'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう'],
+                 categories=['あ', 'いい', 'ううう'], ordered=False, dtype='category')"""
+            self.assertEqual(repr(idx), expected)
+        else:
+            expected = u"""CategoricalIndex([u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい',
+                  u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ',
+                  u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう',
+                  u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう'],
+                 categories=[u'あ', u'いい', u'ううう'], ordered=False, dtype='category')"""
+            self.assertEqual(unicode(idx), expected)
+
+        # truncated
+        idx = pd.CategoricalIndex([u'あ', u'いい', u'ううう'] * 100)
+        if PY3:
+            expected = u"""CategoricalIndex(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ',
+                  ...
+                  'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう'],
+                 categories=['あ', 'いい', 'ううう'], ordered=False, dtype='category', length=300)"""
+            self.assertEqual(repr(idx), expected)
+        else:
+            expected = u"""CategoricalIndex([u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい',
+                  u'ううう', u'あ',
+                  ...
+                  u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ',
+                  u'いい', u'ううう'],
+                 categories=[u'あ', u'いい', u'ううう'], ordered=False, dtype='category', length=300)"""
+            self.assertEqual(unicode(idx), expected)
+
+        # larger categories
+        idx = pd.CategoricalIndex(list(u'あいうえおかきくけこさしすせそ'))
+        if PY3:
+            expected = u"""CategoricalIndex(['あ', 'い', 'う', 'え', 'お', 'か', 'き', 'く', 'け', 'こ', 'さ', 'し',
+                  'す', 'せ', 'そ'],
+                 categories=['あ', 'い', 'う', 'え', 'お', 'か', 'き', 'く', ...], ordered=False, dtype='category')"""
+            self.assertEqual(repr(idx), expected)
+        else:
+            expected = u"""CategoricalIndex([u'あ', u'い', u'う', u'え', u'お', u'か', u'き', u'く', u'け', u'こ',
+                  u'さ', u'し', u'す', u'せ', u'そ'],
+                 categories=[u'あ', u'い', u'う', u'え', u'お', u'か', u'き', u'く', ...], ordered=False, dtype='category')"""
+            self.assertEqual(unicode(idx), expected)
+
+        # Emable Unicode option -----------------------------------------
+        with cf.option_context('display.unicode.east_asian_width', True):
+
+            # short
+            idx = pd.CategoricalIndex([u'あ', u'いい', u'ううう'])
+            if PY3:
+                expected = u"""CategoricalIndex(['あ', 'いい', 'ううう'], categories=['あ', 'いい', 'ううう'], ordered=False, dtype='category')"""
+                self.assertEqual(repr(idx), expected)
+            else:
+                expected = u"""CategoricalIndex([u'あ', u'いい', u'ううう'], categories=[u'あ', u'いい', u'ううう'], ordered=False, dtype='category')"""
+                self.assertEqual(unicode(idx), expected)
+
+            # multiple lines
+            idx = pd.CategoricalIndex([u'あ', u'いい', u'ううう'] * 10)
+            if PY3:
+                expected = u"""CategoricalIndex(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい',
+                  'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう',
+                  'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい',
+                  'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう'],
+                 categories=['あ', 'いい', 'ううう'], ordered=False, dtype='category')"""
+                self.assertEqual(repr(idx), expected)
+            else:
+                expected = u"""CategoricalIndex([u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ',
+                  u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ',
+                  u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ',
+                  u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ',
+                  u'いい', u'ううう', u'あ', u'いい', u'ううう'],
+                 categories=[u'あ', u'いい', u'ううう'], ordered=False, dtype='category')"""
+                self.assertEqual(unicode(idx), expected)
+
+            # truncated
+            idx = pd.CategoricalIndex([u'あ', u'いい', u'ううう'] * 100)
+            if PY3:
+                expected = u"""CategoricalIndex(['あ', 'いい', 'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい',
+                  'ううう', 'あ',
+                  ...
+                  'ううう', 'あ', 'いい', 'ううう', 'あ', 'いい', 'ううう',
+                  'あ', 'いい', 'ううう'],
+                 categories=['あ', 'いい', 'ううう'], ordered=False, dtype='category', length=300)"""
+                self.assertEqual(repr(idx), expected)
+            else:
+                expected = u"""CategoricalIndex([u'あ', u'いい', u'ううう', u'あ', u'いい', u'ううう', u'あ',
+                  u'いい', u'ううう', u'あ',
+                  ...
+                  u'ううう', u'あ', u'いい', u'ううう', u'あ', u'いい',
+                  u'ううう', u'あ', u'いい', u'ううう'],
+                 categories=[u'あ', u'いい', u'ううう'], ordered=False, dtype='category', length=300)"""
+                self.assertEqual(unicode(idx), expected)
+
+            # larger categories
+            idx = pd.CategoricalIndex(list(u'あいうえおかきくけこさしすせそ'))
+            if PY3:
+                expected = u"""CategoricalIndex(['あ', 'い', 'う', 'え', 'お', 'か', 'き', 'く', 'け', 'こ',
+                  'さ', 'し', 'す', 'せ', 'そ'],
+                 categories=['あ', 'い', 'う', 'え', 'お', 'か', 'き', 'く', ...], ordered=False, dtype='category')"""
+                self.assertEqual(repr(idx), expected)
+            else:
+                expected = u"""CategoricalIndex([u'あ', u'い', u'う', u'え', u'お', u'か', u'き', u'く',
+                  u'け', u'こ', u'さ', u'し', u'す', u'せ', u'そ'],
+                 categories=[u'あ', u'い', u'う', u'え', u'お', u'か', u'き', u'く', ...], ordered=False, dtype='category')"""
+                self.assertEqual(unicode(idx), expected)
 
 
 class Numeric(Base):


### PR DESCRIPTION
Closes #2612. Added `display.unicode.east_asian_width` options, which calculate text width considering East Asian Width. Enabling this option affects to a performance as width must be calculated per characters.
#### Current results (captured)

![2015-09-15 20 57 27](https://cloud.githubusercontent.com/assets/1696302/9875847/7928d98c-5bec-11e5-98d9-a218c3a6b425.png)
- [x] Basic impl and test
- [x] Series / DataFrame truncation
- [x] Perf test
- [x] Doc / Release note
