### PR TITLE
COMPAT: compat for python 3.5, #11097

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,13 +43,6 @@ matrix:
       - CLIPBOARD_GUI=gtk2
       - BUILD_TYPE=conda
       - DOC_BUILD=true # if rst files were changed, build docs in parallel with tests
-    - python: 3.3
-      env:
-      - JOB_NAME: "33_nslow"
-      - NOSE_ARGS="not slow and not disabled"
-      - FULL_DEPS=true
-      - CLIPBOARD=xsel
-      - BUILD_TYPE=conda
     - python: 3.4
       env:
       - JOB_NAME: "34_nslow"
@@ -61,6 +54,13 @@ matrix:
       env:
       - JOB_NAME: "35_nslow"
       - NOSE_ARGS="not slow and not network and not disabled"
+      - FULL_DEPS=true
+      - CLIPBOARD=xsel
+      - BUILD_TYPE=conda
+    - python: 3.3
+      env:
+      - JOB_NAME: "33_nslow"
+      - NOSE_ARGS="not slow and not disabled"
       - FULL_DEPS=true
       - CLIPBOARD=xsel
       - BUILD_TYPE=conda
@@ -104,10 +104,10 @@ matrix:
       - BUILD_TYPE=pydata
       - PANDAS_TESTING_MODE="deprecate"
     allow_failures:
-      - python: 3.5
+      - python: 3.3
         env:
-        - JOB_NAME: "35_nslow"
-        - NOSE_ARGS="not slow and not network and not disabled"
+        - JOB_NAME: "33_nslow"
+        - NOSE_ARGS="not slow and not disabled"
         - FULL_DEPS=true
         - CLIPBOARD=xsel
         - BUILD_TYPE=conda

--- a/ci/requirements-3.5.txt
+++ b/ci/requirements-3.5.txt
@@ -10,3 +10,15 @@ cython
 scipy
 numexpr
 pytables
+html5lib
+lxml
+
+# currently causing some warnings
+#sqlalchemy
+#pymysql
+#psycopg2
+
+# not available from conda
+#beautiful-soup
+#bottleneck
+#matplotlib

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -18,7 +18,7 @@ Instructions for installing from source,
 Python version support
 ----------------------
 
-Officially Python 2.6, 2.7, 3.3, and 3.4.
+Officially Python 2.6, 2.7, 3.3, 3.4, and 3.5
 
 Installing pandas
 -----------------

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -64,6 +64,7 @@ Highlights include:
 - Support for reading SAS xport files, see :ref:`here <whatsnew_0170.enhancements.sas_xport>`
 - Documentation comparing SAS to *pandas*, see :ref:`here <compare_with_sas>`
 - Removal of the automatic TimeSeries broadcasting, deprecated since 0.8.0, see :ref:`here <whatsnew_0170.prior_deprecations>`
+- Compatibility with Python 3.5
 
 See the :ref:`v0.17.0 Whatsnew <whatsnew_0170>` overview for an extensive list
 of all enhancements and bugs that have been fixed in 0.17.0.

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -49,6 +49,7 @@ Highlights include:
 - Support for reading SAS xport files, see :ref:`here <whatsnew_0170.enhancements.sas_xport>`
 - Documentation comparing SAS to *pandas*, see :ref:`here <compare_with_sas>`
 - Removal of the automatic TimeSeries broadcasting, deprecated since 0.8.0, see :ref:`here <whatsnew_0170.prior_deprecations>`
+- Compatibility with Python 3.5 (:issue:`11097`)
 
 Check the :ref:`API Changes <whatsnew_0170.api>` and :ref:`deprecations <whatsnew_0170.deprecations>` before updating.
 

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -36,9 +36,9 @@ from itertools import product
 import sys
 import types
 
-PY3 = (sys.version_info[0] >= 3)
 PY2 = sys.version_info[0] == 2
-
+PY3 = (sys.version_info[0] >= 3)
+PY35 = (sys.version_info >= (3, 5))
 
 try:
     import __builtin__ as builtins

--- a/pandas/io/tests/__init__.py
+++ b/pandas/io/tests/__init__.py
@@ -1,4 +1,0 @@
-
-def setUp():
-    import socket
-    socket.setdefaulttimeout(5)

--- a/pandas/io/tests/test_data.py
+++ b/pandas/io/tests/test_data.py
@@ -27,6 +27,13 @@ def _skip_if_no_lxml():
     except ImportError:
         raise nose.SkipTest("no lxml")
 
+def _skip_if_no_bs():
+    try:
+        import bs4
+        import html5lib
+    except ImportError:
+        raise nose.SkipTest("no html5lib/bs4")
+
 
 def assert_n_failed_equals_n_null_columns(wngs, obj, cls=SymbolWarning):
     all_nan_cols = pd.Series(dict((k, pd.isnull(v).all()) for k, v in
@@ -288,6 +295,7 @@ class TestYahooOptions(tm.TestCase):
     def setUpClass(cls):
         super(TestYahooOptions, cls).setUpClass()
         _skip_if_no_lxml()
+        _skip_if_no_bs()
 
         # aapl has monthlies
         cls.aapl = web.Options('aapl', 'yahoo')

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -2573,7 +2573,9 @@ class TestHDFStore(Base, tm.TestCase):
         idx = [(0., 1.), (2., 3.), (4., 5.)]
         data = np.random.randn(30).reshape((3, 10))
         DF = DataFrame(data, index=idx, columns=col)
-        with tm.assert_produces_warning(expected_warning=PerformanceWarning):
+
+        expected_warning = Warning if compat.PY35 else PerformanceWarning
+        with tm.assert_produces_warning(expected_warning=expected_warning, check_stacklevel=False):
             self._check_roundtrip(DF, tm.assert_frame_equal)
 
     def test_index_types(self):
@@ -2585,23 +2587,25 @@ class TestHDFStore(Base, tm.TestCase):
                                                    check_index_type=True,
                                                    check_series_type=True)
 
-        with tm.assert_produces_warning(expected_warning=PerformanceWarning):
+        # nose has a deprecation warning in 3.5
+        expected_warning = Warning if compat.PY35 else PerformanceWarning
+        with tm.assert_produces_warning(expected_warning=expected_warning, check_stacklevel=False):
             ser = Series(values, [0, 'y'])
             self._check_roundtrip(ser, func)
 
-        with tm.assert_produces_warning(expected_warning=PerformanceWarning):
+        with tm.assert_produces_warning(expected_warning=expected_warning, check_stacklevel=False):
             ser = Series(values, [datetime.datetime.today(), 0])
             self._check_roundtrip(ser, func)
 
-        with tm.assert_produces_warning(expected_warning=PerformanceWarning):
+        with tm.assert_produces_warning(expected_warning=expected_warning, check_stacklevel=False):
             ser = Series(values, ['y', 0])
             self._check_roundtrip(ser, func)
 
-        with tm.assert_produces_warning(expected_warning=PerformanceWarning):
+        with tm.assert_produces_warning(expected_warning=expected_warning, check_stacklevel=False):
             ser = Series(values, [datetime.date.today(), 'a'])
             self._check_roundtrip(ser, func)
 
-        with tm.assert_produces_warning(expected_warning=PerformanceWarning):
+        with tm.assert_produces_warning(expected_warning=expected_warning, check_stacklevel=False):
             ser = Series(values, [1.23, 'b'])
             self._check_roundtrip(ser, func)
 
@@ -3377,7 +3381,8 @@ class TestHDFStore(Base, tm.TestCase):
 
         with ensure_clean_path(self.path) as path:
 
-            with tm.assert_produces_warning(expected_warning=AttributeConflictWarning):
+            expected_warning = Warning if compat.PY35 else AttributeConflictWarning
+            with tm.assert_produces_warning(expected_warning=expected_warning, check_stacklevel=False):
 
                 df  = DataFrame(dict(A = Series(lrange(3), index=date_range('2000-1-1',periods=3,freq='H'))))
                 df.to_hdf(path,'data',mode='w',append=True)
@@ -3391,7 +3396,7 @@ class TestHDFStore(Base, tm.TestCase):
 
             self.assertEqual(read_hdf(path,'data').index.name, 'foo')
 
-            with tm.assert_produces_warning(expected_warning=AttributeConflictWarning):
+            with tm.assert_produces_warning(expected_warning=expected_warning, check_stacklevel=False):
 
                 idx2 = date_range('2001-1-1',periods=3,freq='H')
                 idx2.name = 'bar'

--- a/setup.py
+++ b/setup.py
@@ -181,6 +181,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
     'Programming Language :: Cython',
     'Topic :: Scientific/Engineering',
 ]


### PR DESCRIPTION
closes #11097 
- update install / compat docs for 3.5
- use visit_Call based on the version of python
- skip if html5lib is not installed in test_data
- bug in nose causes deprecation warning in some pytables tests
- remove superfluous socket timeout
