### PR TITLE
BUG: Fix computation of invalid NaN indexes for interpolate.

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -383,7 +383,7 @@ Other enhancements
 
 - ``DataFrame`` has gained the ``nlargest`` and ``nsmallest`` methods (:issue:`10393`)
 
-- Add a ``limit_direction`` keyword argument that works with ``limit`` to enable ``interpolate`` to fill ``NaN`` values forward, backward, or both (:issue:`9218` and :issue:`10420`)
+- Add a ``limit_direction`` keyword argument that works with ``limit`` to enable ``interpolate`` to fill ``NaN`` values forward, backward, or both (:issue:`9218`, :issue:`10420`, :issue:`11115`)
 
   .. ipython:: python
 

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -878,7 +878,6 @@ class TestSeries(tm.TestCase, Generic):
 
     def test_interp_limit_bad_direction(self):
         s = Series([1, 3, np.nan, np.nan, np.nan, 11])
-        expected = Series([1., 3., 5., 7., 9., 11.])
 
         self.assertRaises(ValueError, s.interpolate,
                           method='linear', limit=2,
@@ -928,6 +927,25 @@ class TestSeries(tm.TestCase, Generic):
         expected = Series([5., 5., 5., 7., 9., 9.])
         result = s.interpolate(
             method='linear', limit=2, limit_direction='both')
+        assert_series_equal(result, expected)
+
+    def test_interp_limit_before_ends(self):
+        # These test are for issue #11115 -- limit ends properly.
+        s = Series([np.nan, np.nan, 5, 7, np.nan, np.nan])
+
+        expected = Series([np.nan, np.nan, 5., 7., 7., np.nan])
+        result = s.interpolate(
+            method='linear', limit=1, limit_direction='forward')
+        assert_series_equal(result, expected)
+
+        expected = Series([np.nan, 5., 5., 7., np.nan, np.nan])
+        result = s.interpolate(
+            method='linear', limit=1, limit_direction='backward')
+        assert_series_equal(result, expected)
+
+        expected = Series([np.nan, 5., 5., 7., 7., np.nan])
+        result = s.interpolate(
+            method='linear', limit=1, limit_direction='both')
         assert_series_equal(result, expected)
 
     def test_interp_all_good(self):


### PR DESCRIPTION
Fixes issue #11115.

This change fixes up a couple edge cases for the computation of invalid NaN indexes for interpolation limits.

I've also added a test explicitly for the reported bug (and similar behaviors at the opposite end of the series) in #11115.

/cc @jreback 
