### PR TITLE
API: convert_objects, xref #11116, instead of warning, raise a ValueError

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -2,6 +2,7 @@
 Misc tools for implementing data structures
 """
 
+import warnings
 import re
 import collections
 import numbers
@@ -1868,7 +1869,12 @@ def _possibly_convert_objects(values,
 
     conversion_count = sum((datetime, numeric, timedelta))
     if conversion_count == 0:
-        import warnings
+
+        if coerce:
+            raise ValueError("coerce=True was provided, with no options for conversions."
+                             "excatly one of 'datetime', 'numeric' or "
+                             "'timedelta' must be True when when coerce=True.")
+
         warnings.warn('Must explicitly pass type for conversion. Defaulting to '
                       'pre-0.17 behavior where datetime=True, numeric=True, '
                       'timedelta=True and coerce=False', DeprecationWarning)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2564,24 +2564,11 @@ class NDFrame(PandasObject):
         converted : same as input object
         """
 
-        # Deprecation code to handle usage change
-        issue_warning = False
-        if datetime == 'coerce':
-            datetime = coerce = True
-            numeric = timedelta = False
-            issue_warning = True
-        elif numeric == 'coerce':
-            numeric = coerce = True
-            datetime = timedelta = False
-            issue_warning = True
-        elif timedelta == 'coerce':
-            timedelta = coerce = True
-            datetime = numeric = False
-            issue_warning = True
-        if issue_warning:
-            warnings.warn("The use of 'coerce' as an input is deprecated. "
-                          "Instead set coerce=True.",
-                          FutureWarning)
+        # passing 'coerce' is deprecated, but we don't want to accidently
+        # force conversions
+        if datetime == 'coerce' or numeric == 'coerce' or timedelta == 'coerce':
+            raise ValueError("The use of 'coerce' as an input is deprecated. "
+                             "Instead set coerce=True.")
 
         return self._constructor(
             self._data.convert(datetime=datetime,

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -6492,29 +6492,34 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
     # Remove test after deprecation to convert_objects is final
     def test_convert_objects_old_style_deprecation(self):
         s = Series(['foo', 'bar', 1, 1.0], dtype='O')
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', FutureWarning)
-            new_style = s.convert_objects(datetime=True, coerce=True)
-            old_style = s.convert_objects(convert_dates='coerce')
-            self.assertEqual(len(w), 2)
-        assert_series_equal(new_style, old_style)
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', FutureWarning)
-            new_style = s.convert_objects(numeric=True, coerce=True)
-            old_style = s.convert_objects(convert_numeric='coerce')
-            self.assertEqual(len(w), 2)
-        assert_series_equal(new_style, old_style)
+        def f():
+            with tm.assert_produces_warning(FutureWarning):
+                s.convert_objects(convert_dates='coerce')
+        self.assertRaises(ValueError, f)
+        def f():
+            with tm.assert_produces_warning(FutureWarning):
+                s.convert_objects(convert_numeric='coerce')
+        self.assertRaises(ValueError, f)
 
         dt = datetime(2001, 1, 1, 0, 0)
         td = dt - datetime(2000, 1, 1, 0, 0)
         s = Series(['a', '3.1415', dt, td])
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', FutureWarning)
-            new_style = s.convert_objects(timedelta=True, coerce=True)
-            old_style = s.convert_objects(convert_timedeltas='coerce')
-            self.assertEqual(len(w), 2)
-        assert_series_equal(new_style, old_style)
+
+        def f():
+            with tm.assert_produces_warning(FutureWarning):
+                s.convert_objects(convert_timedeltas='coerce')
+        self.assertRaises(ValueError, f)
+
+        # back-compat xref GH 11116
+        data = """foo,bar
+2015-09-14,True
+2015-09-15,
+"""
+        df = pd.read_csv(StringIO(data),sep=',')
+
+        # we want to be vocal about the changes
+        self.assertRaises(ValueError, lambda : df.convert_objects(coerce=True))
+        self.assertRaises(ValueError, lambda : df.convert_objects('coerce'))
 
     def test_convert_objects_no_arg_warning(self):
         s = Series(['1.0','2'])


### PR DESCRIPTION
closes #11116

This is a lot more noisy that the current impl. It pretty much raises on the old-style input if it had `coerce` in it. This is correct as the actual behavior of `coerce` has changed (in that it now it much more strict).

errror on old-style input
- raise a ValueError for df.convert_objects('coerce')
- raise a ValueError for df.convert_objects(convert_dates='coerce') (and convert_numeric,convert_timedelta)

```
In [1]: data = """foo,bar
   ...: 2015-09-14,True
   ...: 2015-09-15,
   ...: """

In [2]: df = pd.read_csv(StringIO(data),sep=',')

In [3]: df
Out[3]: 
          foo   bar
0  2015-09-14  True
1  2015-09-15   NaN
```

```
In [4]: df.convert_objects('coerce')
ValueError: The use of 'coerce' as an input is deprecated. Instead set coerce=True.

In [5]: df.convert_objects(coerce=True)
ValueError: coerce=True was provided, with no options for conversions.excatly one of 'datetime', 'numeric' or 'timedelta' must be True when when coerce=True.

In [8]: df.convert_objects(convert_dates='coerce')
/Users/jreback/miniconda/bin/ipython:1: FutureWarning: the 'convert_dates' keyword is deprecated, use 'datetime' instead
ValueError: The use of 'coerce' as an input is deprecated. Instead set coerce=True.
```
