### PR TITLE
BUG: nested construction with timedelta #11129

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -1154,3 +1154,4 @@ Bug Fixes
 - Remove use of some deprecated numpy comparison operations, mainly in tests. (:issue:`10569`)
 - Bug in ``Index`` dtype may not applied properly (:issue:`11017`)
 - Bug in ``io.gbq`` when testing for minimum google api client version (:issue:`10652`)
+- Bug in ``DataFrame`` construction from nested ``dict`` with ``timedelta`` keys (:issue:`11129`)

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1851,9 +1851,9 @@ def _maybe_box(indexer, values, obj, key):
 def _maybe_box_datetimelike(value):
     # turn a datetime like into a Timestamp/timedelta as needed
 
-    if isinstance(value, np.datetime64):
+    if isinstance(value, (np.datetime64, datetime)):
         value = tslib.Timestamp(value)
-    elif isinstance(value, np.timedelta64):
+    elif isinstance(value, (np.timedelta64, timedelta)):
         value = tslib.Timedelta(value)
 
     return value

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -3037,6 +3037,29 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         assert_frame_equal(result_datetime, expected)
         assert_frame_equal(result_Timestamp, expected)
 
+    def test_constructor_dict_timedelta64_index(self):
+        # GH 10160
+        td_as_int = [1, 2, 3, 4]
+
+        def create_data(constructor):
+            return dict((i, {constructor(s): 2*i}) for i, s in enumerate(td_as_int))
+
+        data_timedelta64 = create_data(lambda x: np.timedelta64(x, 'D'))
+        data_timedelta = create_data(lambda x: timedelta(days=x))
+        data_Timedelta = create_data(lambda x: Timedelta(x, 'D'))
+
+        expected = DataFrame([{0: 0, 1: None, 2: None, 3: None},
+                              {0: None, 1: 2, 2: None, 3: None},
+                              {0: None, 1: None, 2: 4, 3: None},
+                              {0: None, 1: None, 2: None, 3: 6}],
+                             index=[Timedelta(td, 'D') for td in td_as_int])
+
+        result_timedelta64 = DataFrame(data_timedelta64)
+        result_timedelta = DataFrame(data_timedelta)
+        result_Timedelta = DataFrame(data_Timedelta)
+        assert_frame_equal(result_timedelta64, expected)
+        assert_frame_equal(result_timedelta, expected)
+        assert_frame_equal(result_Timedelta, expected)
 
     def _check_basic_constructor(self, empty):
         "mat: 2d matrix with shpae (3, 2) to input. empty - makes sized objects"

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -885,6 +885,24 @@ class TestTimedeltas(tm.TestCase):
         v_p = self.round_trip_pickle(v)
         self.assertEqual(v,v_p)
 
+    def test_timedelta_hash_equality(self):
+        #GH 11129
+        v = Timedelta(1, 'D')
+        td = timedelta(days=1)
+        self.assertEqual(hash(v), hash(td))
+
+        d = {td: 2}
+        self.assertEqual(d[v], 2)
+
+        tds = timedelta_range('1 second', periods=20)
+        self.assertTrue(
+            all(hash(td) == hash(td.to_pytimedelta()) for td in tds))
+
+        # python timedeltas drop ns resolution
+        ns_td = Timedelta(1, 'ns')
+        self.assertNotEqual(hash(ns_td), hash(ns_td.to_pytimedelta()))
+
+
 class TestTimedeltaIndex(tm.TestCase):
     _multiprocess_can_split_ = True
 


### PR DESCRIPTION
Closes #11129

Per discussion in issue this adds similar hash equality to `_Timedelta` / `datetime.timedelta`
that exists for `_Timestamp` / `datetime.datime`.

I tried inlining `_Timedelta._ensure_components` and it actually hurt performance a bit, so I left it
as a plain `def` but did build a seperate `_has_ns` check for hashing.

Adds a little overhead to hashing:

```
In [1]: tds = pd.timedelta_range('1 day', periods=100000)

# PR
In [2]: %timeit [hash(td) for td in tds]
1 loops, best of 3: 810 ms per loop

# Master
In [2]: %timeit [hash(td) for td in tds]
1 loops, best of 3: 765 ms per loop
```
