### PR TITLE
DEPR: Series.is_timeseries

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -964,6 +964,7 @@ Deprecations
   ``DataFrame.add(other, fill_value=0)`` and ``DataFrame.mul(other, fill_value=1.)``
   (:issue:`10735`).
 - ``TimeSeries`` deprecated in favor of ``Series`` (note that this has been alias since 0.13.0), (:issue:`10890`)
+- ``Series.is_time_series`` deprecated in favor of ``Series.index.is_all_dates`` (:issue:`11135`)
 - Legacy offsets (like ``'A@JAN'``) listed in :ref:`here <timeseries.legacyaliases>` are deprecated (note that this has been alias since 0.8.0), (:issue:`10878`)
 - ``WidePanel`` deprecated in favor of ``Panel``, ``LongPanel`` in favor of ``DataFrame`` (note these have been aliases since < 0.11.0), (:issue:`10892`)
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -251,7 +251,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     @property
     def is_time_series(self):
-        return self._subtyp in ['time_series', 'sparse_time_series']
+        msg = "is_time_series is deprecated. Please use Series.index.is_all_dates"
+        warnings.warn(msg, FutureWarning, stacklevel=2)
+        # return self._subtyp in ['time_series', 'sparse_time_series']
+        return self.index.is_all_dates
+
 
     _index = None
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -703,11 +703,15 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
     def test_constructor(self):
         # Recognize TimeSeries
-        self.assertTrue(self.ts.is_time_series)
+        with tm.assert_produces_warning(FutureWarning):
+            self.assertTrue(self.ts.is_time_series)
+        self.assertTrue(self.ts.index.is_all_dates)
 
         # Pass in Series
         derived = Series(self.ts)
-        self.assertTrue(derived.is_time_series)
+        with tm.assert_produces_warning(FutureWarning):
+            self.assertTrue(derived.is_time_series)
+        self.assertTrue(derived.index.is_all_dates)
 
         self.assertTrue(tm.equalContents(derived.index, self.ts.index))
         # Ensure new index is not created
@@ -718,9 +722,12 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         self.assertEqual(mixed.dtype, np.object_)
         self.assertIs(mixed[1], np.NaN)
 
-        self.assertFalse(self.empty.is_time_series)
-        self.assertFalse(Series({}).is_time_series)
-
+        with tm.assert_produces_warning(FutureWarning):
+            self.assertFalse(self.empty.is_time_series)
+        self.assertFalse(self.empty.index.is_all_dates)
+        with tm.assert_produces_warning(FutureWarning):
+            self.assertFalse(Series({}).is_time_series)
+        self.assertFalse(Series({}).index.is_all_dates)
         self.assertRaises(Exception, Series, np.random.randn(3, 3),
                           index=np.arange(3))
 
@@ -7693,12 +7700,16 @@ class TestSeriesNonUnique(tm.TestCase):
         s = Series(lrange(10))
         s.index = idx
 
-        self.assertTrue(s.is_time_series == True)
+        with tm.assert_produces_warning(FutureWarning):
+            self.assertTrue(s.is_time_series == True)
+        self.assertTrue(s.index.is_all_dates == True)
 
     def test_timeseries_coercion(self):
         idx = tm.makeDateIndex(10000)
         ser = Series(np.random.randn(len(idx)), idx.astype(object))
-        self.assertTrue(ser.is_time_series)
+        with tm.assert_produces_warning(FutureWarning):
+            self.assertTrue(ser.is_time_series)
+        self.assertTrue(ser.index.is_all_dates)
         self.assertIsInstance(ser.index, DatetimeIndex)
 
     def test_replace(self):


### PR DESCRIPTION
Follow-up for #10890. Deprecate `Series.is_timeseries`.
