### PR TITLE
BUG: remove midrule in latex output with header=False

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -42,3 +42,5 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
+
+- Bug in ``DataFrame.to_latex()`` produces an extra rule when ``header=False`` (:issue:`7124`)

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -668,7 +668,7 @@ class DataFrameFormatter(TableFormatter):
 
             nlevels = frame.columns.nlevels
             for i, row in enumerate(zip(*strcols)):
-                if i == nlevels:
+                if i == nlevels and self.header:
                     buf.write('\\midrule\n')  # End of header
                     if longtable:
                         buf.write('\\endhead\n')

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -2749,6 +2749,30 @@ b &       b &     b \\
 """
         self.assertEqual(observed, expected)
 
+    def test_to_latex_no_header(self):
+        # GH 7124
+        df = DataFrame({'a': [1, 2],
+                        'b': ['b1', 'b2']})
+        withindex_result = df.to_latex(header=False)
+        withindex_expected = r"""\begin{tabular}{lrl}
+\toprule
+0 &  1 &  b1 \\
+1 &  2 &  b2 \\
+\bottomrule
+\end{tabular}
+"""
+        self.assertEqual(withindex_result, withindex_expected)
+
+        withoutindex_result = df.to_latex(index=False, header=False)
+        withoutindex_expected = r"""\begin{tabular}{rl}
+\toprule
+ 1 &  b1 \\
+ 2 &  b2 \\
+\bottomrule
+\end{tabular}
+"""
+        self.assertEqual(withoutindex_result, withoutindex_expected)
+
     def test_to_csv_quotechar(self):
         df = DataFrame({'col' : [1,2]})
         expected = """\


### PR DESCRIPTION
This bug fix addresses issue #7124. If `to_latex` is called with option `header=False`, the output should not contain a `\midrule` which is used to separate the column headers from the data.
