### PR TITLE
Openpyxl22

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -2230,6 +2230,8 @@ Writing Excel Files to Memory
 Pandas supports writing Excel files to buffer-like objects such as ``StringIO`` or
 ``BytesIO`` using :class:`~pandas.io.excel.ExcelWriter`.
 
+Added support for Openpyxl >= 2.2
+
 .. code-block:: python
 
    # Safe import for either Python 2.x or 3.x
@@ -2279,14 +2281,15 @@ config options <options>` ``io.excel.xlsx.writer`` and
 files if `Xlsxwriter`_ is not available.
 
 .. _XlsxWriter: http://xlsxwriter.readthedocs.org
-.. _openpyxl: http://packages.python.org/openpyxl/
+.. _openpyxl: http://openpyxl.readthedocs.org/
 .. _xlwt: http://www.python-excel.org
 
 To specify which writer you want to use, you can pass an engine keyword
 argument to ``to_excel`` and to ``ExcelWriter``. The built-in engines are:
 
-- ``openpyxl``: This includes stable support for OpenPyxl 1.6.1 up to but
-  not including 2.0.0, and experimental support for OpenPyxl 2.0.0 and later.
+- ``openpyxl``: This includes stable support for Openpyxl from 1.6.1. However,
+  it is advised to use version 2.2 and higher, especially when working with
+  styles.
 - ``xlsxwriter``
 - ``xlwt``
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -2230,6 +2230,8 @@ Writing Excel Files to Memory
 Pandas supports writing Excel files to buffer-like objects such as ``StringIO`` or
 ``BytesIO`` using :class:`~pandas.io.excel.ExcelWriter`.
 
+.. versionadded:: 0.17
+
 Added support for Openpyxl >= 2.2
 
 .. code-block:: python

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -1189,6 +1189,8 @@ class _Openpyxl22Writer(_Openpyxl20Writer):
 
         sheet_name = self._get_sheet_name(sheet_name)
 
+        _style_cache = {}
+
         if sheet_name in self.sheets:
             wks = self.sheets[sheet_name]
         else:
@@ -1205,7 +1207,11 @@ class _Openpyxl22Writer(_Openpyxl20Writer):
 
             style_kwargs = {}
             if cell.style:
-                style_kwargs = self._convert_to_style_kwargs(cell.style)
+                key = str(cell.style)
+                style_kwargs = _style_cache.get(key)
+                if style_kwargs is None:
+                    style_kwargs = self._convert_to_style_kwargs(cell.style)
+                    _style_cache[key] = style_kwargs
 
             if style_kwargs:
                 for k, v in style_kwargs.items():

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -1200,13 +1200,6 @@ class _Openpyxl22Writer(_Openpyxl20Writer):
             xcell = wks.cell(row=startrow + cell.row + 1, column=startcol + cell.col + 1)
             xcell.value = _conv_value(cell.val)
 
-            # Apply format codes before cell.style to allow override
-            if isinstance(cell.val, datetime.datetime):
-                xcell.number_format = self.datetime_format
-
-            elif isinstance(cell.val, datetime.date):
-                xcell.number_format = self.date_format
-
             style_kwargs = {}
             if cell.style:
                 style_kwargs = self._convert_to_style_kwargs(cell.style)

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -1197,7 +1197,10 @@ class _Openpyxl22Writer(_Openpyxl20Writer):
             self.sheets[sheet_name] = wks
 
         for cell in cells:
-            xcell = wks.cell(row=startrow + cell.row + 1, column=startcol + cell.col + 1)
+            xcell = wks.cell(
+                        row=startrow + cell.row + 1,
+                        column=startcol + cell.col + 1
+                        )
             xcell.value = _conv_value(cell.val)
 
             style_kwargs = {}

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -1470,113 +1470,119 @@ class OpenpyxlTests(ExcelWriterBase, tm.TestCase):
                          xlsx_style.alignment.vertical)
 
 
-@raise_on_incompat_version(2)
-class Openpyxl20Tests(ExcelWriterBase, tm.TestCase):
-    ext = '.xlsx'
-    engine_name = 'openpyxl20'
-    check_skip = staticmethod(lambda *args, **kwargs: None)
-
-    def test_to_excel_styleconverter(self):
-        _skip_if_no_openpyxl()
-        if not openpyxl_compat.is_compat(major_ver=2):
-            raise nose.SkipTest('incompatiable openpyxl version')
-
-        import openpyxl
-        from openpyxl import styles
-
-        hstyle = {
-            "font": {
-                "color": '00FF0000',
-                "bold": True,
-            },
-            "borders": {
-                "top": "thin",
-                "right": "thin",
-                "bottom": "thin",
-                "left": "thin",
-            },
-            "alignment": {
-                "horizontal": "center",
-                "vertical": "top",
-            },
-            "fill": {
-                "patternType": 'solid',
-                'fgColor': {
-                    'rgb': '006666FF',
-                    'tint': 0.3,
-                },
-            },
-            "number_format": {
-                "format_code": "0.00"
-            },
-            "protection": {
-                "locked": True,
-                "hidden": False,
-            },
-        }
-
-        font_color = styles.Color('00FF0000')
-        font = styles.Font(bold=True, color=font_color)
-        side = styles.Side(style=styles.borders.BORDER_THIN)
-        border = styles.Border(top=side, right=side, bottom=side, left=side)
-        alignment = styles.Alignment(horizontal='center', vertical='top')
-        fill_color = styles.Color(rgb='006666FF', tint=0.3)
-        fill = styles.PatternFill(patternType='solid', fgColor=fill_color)
-
-        # ahh openpyxl API changes
-        ver = openpyxl.__version__
-        if ver >= LooseVersion('2.0.0') and ver < LooseVersion('2.1.0'):
-            number_format = styles.NumberFormat(format_code='0.00')
-        else:
-            number_format = '0.00' # XXX: Only works with openpyxl-2.1.0
-
-        protection = styles.Protection(locked=True, hidden=False)
-
-        kw = _Openpyxl20Writer._convert_to_style_kwargs(hstyle)
-        self.assertEqual(kw['font'], font)
-        self.assertEqual(kw['border'], border)
-        self.assertEqual(kw['alignment'], alignment)
-        self.assertEqual(kw['fill'], fill)
-        self.assertEqual(kw['number_format'], number_format)
-        self.assertEqual(kw['protection'], protection)
-
-
-    def test_write_cells_merge_styled(self):
-        _skip_if_no_openpyxl()
-        if not openpyxl_compat.is_compat(major_ver=2):
-            raise nose.SkipTest('incompatiable openpyxl version')
-
-        from pandas.core.format import ExcelCell
-        from openpyxl import styles
-
-        sheet_name='merge_styled'
-
-        sty_b1 = {'font': {'color': '00FF0000'}}
-        sty_a2 = {'font': {'color': '0000FF00'}}
-
-        initial_cells = [
-            ExcelCell(col=1, row=0, val=42, style=sty_b1),
-            ExcelCell(col=0, row=1, val=99, style=sty_a2),
-        ]
-
-        sty_merged = {'font': { 'color': '000000FF', 'bold': True }}
-        sty_kwargs = _Openpyxl20Writer._convert_to_style_kwargs(sty_merged)
-        openpyxl_sty_merged = styles.Style(**sty_kwargs)
-        merge_cells = [
-            ExcelCell(col=0, row=0, val='pandas',
-                    mergestart=1, mergeend=1, style=sty_merged),
-        ]
-
-        with ensure_clean('.xlsx') as path:
-            writer = _Openpyxl20Writer(path)
-            writer.write_cells(initial_cells, sheet_name=sheet_name)
-            writer.write_cells(merge_cells, sheet_name=sheet_name)
-
-            wks = writer.sheets[sheet_name]
-            xcell_b1 = wks.cell('B1')
-            xcell_a2 = wks.cell('A2')
-            self.assertEqual(xcell_b1.style, openpyxl_sty_merged)
-            self.assertEqual(xcell_a2.style, openpyxl_sty_merged)
+# @raise_on_incompat_version(2)
+# class Openpyxl20Tests(ExcelWriterBase, tm.TestCase):
+#     ext = '.xlsx'
+#     engine_name = 'openpyxl20'
+#     check_skip = staticmethod(lambda *args, **kwargs: None)
+#
+#     def _check_version(self):
+#         import openpyxl
+#         ver = openpyxl.__version__
+#         return ver >= LooseVersion('2.0.0') and ver < LooseVersion('2.2.0')
+#
+#     def test_to_excel_styleconverter(self):
+#         _skip_if_no_openpyxl()
+#         if not self._check_version():
+#             raise nose.SkipTest('incompatiable openpyxl version')
+#
+#         import openpyxl
+#
+#         from openpyxl import styles
+#
+#         hstyle = {
+#             "font": {
+#                 "color": '00FF0000',
+#                 "bold": True,
+#             },
+#             "borders": {
+#                 "top": "thin",
+#                 "right": "thin",
+#                 "bottom": "thin",
+#                 "left": "thin",
+#             },
+#             "alignment": {
+#                 "horizontal": "center",
+#                 "vertical": "top",
+#             },
+#             "fill": {
+#                 "patternType": 'solid',
+#                 'fgColor': {
+#                     'rgb': '006666FF',
+#                     'tint': 0.3,
+#                 },
+#             },
+#             "number_format": {
+#                 "format_code": "0.00"
+#             },
+#             "protection": {
+#                 "locked": True,
+#                 "hidden": False,
+#             },
+#         }
+#
+#         font_color = styles.Color('00FF0000')
+#         font = styles.Font(bold=True, color=font_color)
+#         side = styles.Side(style=styles.borders.BORDER_THIN)
+#         border = styles.Border(top=side, right=side, bottom=side, left=side)
+#         alignment = styles.Alignment(horizontal='center', vertical='top')
+#         fill_color = styles.Color(rgb='006666FF', tint=0.3)
+#         fill = styles.PatternFill(patternType='solid', fgColor=fill_color)
+#
+#         # ahh openpyxl API changes
+#         ver = openpyxl.__version__
+#         if ver >= LooseVersion('2.0.0') and ver < LooseVersion('2.1.0'):
+#             number_format = styles.NumberFormat(format_code='0.00')
+#         else:
+#             number_format = '0.00' # XXX: Only works with openpyxl-2.1.0
+#
+#         protection = styles.Protection(locked=True, hidden=False)
+#
+#         kw = _Openpyxl20Writer._convert_to_style_kwargs(hstyle)
+#         self.assertEqual(kw['font'], font)
+#         self.assertEqual(kw['border'], border)
+#         self.assertEqual(kw['alignment'], alignment)
+#         self.assertEqual(kw['fill'], fill)
+#         self.assertEqual(kw['number_format'], number_format)
+#         self.assertEqual(kw['protection'], protection)
+#
+#
+#     def test_write_cells_merge_styled(self):
+#         _skip_if_no_openpyxl()
+#         if self._check_version():
+#             raise nose.SkipTest('incompatiable openpyxl version')
+#
+#         from pandas.core.format import ExcelCell
+#         from openpyxl import styles
+#
+#         sheet_name='merge_styled'
+#
+#         sty_b1 = {'font': {'color': '00FF0000'}}
+#         sty_a2 = {'font': {'color': '0000FF00'}}
+#
+#         initial_cells = [
+#             ExcelCell(col=1, row=0, val=42, style=sty_b1),
+#             ExcelCell(col=0, row=1, val=99, style=sty_a2),
+#         ]
+#
+#         sty_merged = {'font': { 'color': '000000FF', 'bold': True }}
+#         sty_kwargs = _Openpyxl20Writer._convert_to_style_kwargs(sty_merged)
+#         openpyxl_sty_merged = styles.Style(**sty_kwargs)
+#         merge_cells = [
+#             ExcelCell(col=0, row=0, val='pandas',
+#                     mergestart=1, mergeend=1, style=sty_merged),
+#         ]
+#
+#         with ensure_clean('.xlsx') as path:
+#             writer = _Openpyxl20Writer(path)
+#             writer.write_cells(initial_cells, sheet_name=sheet_name)
+#             writer.write_cells(merge_cells, sheet_name=sheet_name)
+#
+#             wks = writer.sheets[sheet_name]
+#             xcell_b1 = wks.cell('B1')
+#             xcell_a2 = wks.cell('A2')
+#             self.assertEqual(xcell_b1.style, openpyxl_sty_merged)
+#             self.assertEqual(xcell_a2.style, openpyxl_sty_merged)
 
 @raise_on_incompat_version(2)
 class Openpyxl22Tests(ExcelWriterBase, tm.TestCase):
@@ -1584,9 +1590,15 @@ class Openpyxl22Tests(ExcelWriterBase, tm.TestCase):
     engine_name = 'openpyxl22'
     check_skip = staticmethod(lambda *args, **kwargs: None)
 
+    def _check_version(self):
+        import openpyxl
+        ver = openpyxl.__version__
+        return ver >= LooseVersion('2.2.0')
+
     def test_to_excel_styleconverter(self):
         _skip_if_no_openpyxl()
-        if not openpyxl_compat.is_compat(major_ver=2):
+
+        if not self._check_version():
             raise nose.SkipTest('incompatiable openpyxl version')
 
         import openpyxl
@@ -1631,9 +1643,7 @@ class Openpyxl22Tests(ExcelWriterBase, tm.TestCase):
         fill_color = styles.Color(rgb='006666FF', tint=0.3)
         fill = styles.PatternFill(patternType='solid', fgColor=fill_color)
 
-        # ahh openpyxl API changes
-        ver = openpyxl.__version__
-        number_format = '0.00' # XXX: Only works with openpyxl-2.1.0
+        number_format = '0.00'
 
         protection = styles.Protection(locked=True, hidden=False)
 
@@ -1666,7 +1676,7 @@ class Openpyxl22Tests(ExcelWriterBase, tm.TestCase):
 
         sty_merged = {'font': { 'color': '000000FF', 'bold': True }}
         sty_kwargs = _Openpyxl22Writer._convert_to_style_kwargs(sty_merged)
-        openpyxl_sty_merged = styles.Style(**sty_kwargs)
+        openpyxl_sty_merged = sty_kwargs['font']
         merge_cells = [
             ExcelCell(col=0, row=0, val='pandas',
                     mergestart=1, mergeend=1, style=sty_merged),
@@ -1680,8 +1690,8 @@ class Openpyxl22Tests(ExcelWriterBase, tm.TestCase):
             wks = writer.sheets[sheet_name]
             xcell_b1 = wks.cell('B1')
             xcell_a2 = wks.cell('A2')
-            self.assertEqual(xcell_b1.style, openpyxl_sty_merged)
-            self.assertEqual(xcell_a2.style, openpyxl_sty_merged)
+            self.assertEqual(xcell_b1.font, openpyxl_sty_merged)
+            self.assertEqual(xcell_a2.font, openpyxl_sty_merged)
 
 
 class XlwtTests(ExcelWriterBase, tm.TestCase):

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -1525,7 +1525,7 @@ class Openpyxl20Tests(ExcelWriterBase, tm.TestCase):
                 "hidden": False,
             },
         }
-#
+
         font_color = styles.Color('00FF0000')
         font = styles.Font(bold=True, color=font_color)
         side = styles.Side(style=styles.borders.BORDER_THIN)
@@ -1533,16 +1533,16 @@ class Openpyxl20Tests(ExcelWriterBase, tm.TestCase):
         alignment = styles.Alignment(horizontal='center', vertical='top')
         fill_color = styles.Color(rgb='006666FF', tint=0.3)
         fill = styles.PatternFill(patternType='solid', fgColor=fill_color)
-#
+
         # ahh openpyxl API changes
         ver = openpyxl.__version__
         if ver >= LooseVersion('2.0.0') and ver < LooseVersion('2.1.0'):
             number_format = styles.NumberFormat(format_code='0.00')
         else:
             number_format = '0.00' # XXX: Only works with openpyxl-2.1.0
-#
+
         protection = styles.Protection(locked=True, hidden=False)
-#
+
         kw = _Openpyxl20Writer._convert_to_style_kwargs(hstyle)
         self.assertEqual(kw['font'], font)
         self.assertEqual(kw['border'], border)
@@ -1550,22 +1550,22 @@ class Openpyxl20Tests(ExcelWriterBase, tm.TestCase):
         self.assertEqual(kw['fill'], fill)
         self.assertEqual(kw['number_format'], number_format)
         self.assertEqual(kw['protection'], protection)
-#
-#
+
+
     def test_write_cells_merge_styled(self):
         from pandas.core.format import ExcelCell
         from openpyxl import styles
-#
+
         sheet_name='merge_styled'
-#
+
         sty_b1 = {'font': {'color': '00FF0000'}}
         sty_a2 = {'font': {'color': '0000FF00'}}
-#
+
         initial_cells = [
             ExcelCell(col=1, row=0, val=42, style=sty_b1),
             ExcelCell(col=0, row=1, val=99, style=sty_a2),
         ]
-#
+
         sty_merged = {'font': { 'color': '000000FF', 'bold': True }}
         sty_kwargs = _Openpyxl20Writer._convert_to_style_kwargs(sty_merged)
         openpyxl_sty_merged = styles.Style(**sty_kwargs)
@@ -1573,12 +1573,12 @@ class Openpyxl20Tests(ExcelWriterBase, tm.TestCase):
             ExcelCell(col=0, row=0, val='pandas',
                     mergestart=1, mergeend=1, style=sty_merged),
         ]
-#
+
         with ensure_clean('.xlsx') as path:
             writer = _Openpyxl20Writer(path)
             writer.write_cells(initial_cells, sheet_name=sheet_name)
             writer.write_cells(merge_cells, sheet_name=sheet_name)
-#
+
             wks = writer.sheets[sheet_name]
             xcell_b1 = wks.cell('B1')
             xcell_a2 = wks.cell('A2')

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -1470,137 +1470,143 @@ class OpenpyxlTests(ExcelWriterBase, tm.TestCase):
                          xlsx_style.alignment.vertical)
 
 
-# @raise_on_incompat_version(2)
-# class Openpyxl20Tests(ExcelWriterBase, tm.TestCase):
-#     ext = '.xlsx'
-#     engine_name = 'openpyxl20'
-#     check_skip = staticmethod(lambda *args, **kwargs: None)
-#
-#     def _check_version(self):
-#         import openpyxl
-#         ver = openpyxl.__version__
-#         return ver >= LooseVersion('2.0.0') and ver < LooseVersion('2.2.0')
-#
-#     def test_to_excel_styleconverter(self):
-#         _skip_if_no_openpyxl()
-#         if not self._check_version():
-#             raise nose.SkipTest('incompatiable openpyxl version')
-#
-#         import openpyxl
-#
-#         from openpyxl import styles
-#
-#         hstyle = {
-#             "font": {
-#                 "color": '00FF0000',
-#                 "bold": True,
-#             },
-#             "borders": {
-#                 "top": "thin",
-#                 "right": "thin",
-#                 "bottom": "thin",
-#                 "left": "thin",
-#             },
-#             "alignment": {
-#                 "horizontal": "center",
-#                 "vertical": "top",
-#             },
-#             "fill": {
-#                 "patternType": 'solid',
-#                 'fgColor': {
-#                     'rgb': '006666FF',
-#                     'tint': 0.3,
-#                 },
-#             },
-#             "number_format": {
-#                 "format_code": "0.00"
-#             },
-#             "protection": {
-#                 "locked": True,
-#                 "hidden": False,
-#             },
-#         }
-#
-#         font_color = styles.Color('00FF0000')
-#         font = styles.Font(bold=True, color=font_color)
-#         side = styles.Side(style=styles.borders.BORDER_THIN)
-#         border = styles.Border(top=side, right=side, bottom=side, left=side)
-#         alignment = styles.Alignment(horizontal='center', vertical='top')
-#         fill_color = styles.Color(rgb='006666FF', tint=0.3)
-#         fill = styles.PatternFill(patternType='solid', fgColor=fill_color)
-#
-#         # ahh openpyxl API changes
-#         ver = openpyxl.__version__
-#         if ver >= LooseVersion('2.0.0') and ver < LooseVersion('2.1.0'):
-#             number_format = styles.NumberFormat(format_code='0.00')
-#         else:
-#             number_format = '0.00' # XXX: Only works with openpyxl-2.1.0
-#
-#         protection = styles.Protection(locked=True, hidden=False)
-#
-#         kw = _Openpyxl20Writer._convert_to_style_kwargs(hstyle)
-#         self.assertEqual(kw['font'], font)
-#         self.assertEqual(kw['border'], border)
-#         self.assertEqual(kw['alignment'], alignment)
-#         self.assertEqual(kw['fill'], fill)
-#         self.assertEqual(kw['number_format'], number_format)
-#         self.assertEqual(kw['protection'], protection)
-#
-#
-#     def test_write_cells_merge_styled(self):
-#         _skip_if_no_openpyxl()
-#         if self._check_version():
-#             raise nose.SkipTest('incompatiable openpyxl version')
-#
-#         from pandas.core.format import ExcelCell
-#         from openpyxl import styles
-#
-#         sheet_name='merge_styled'
-#
-#         sty_b1 = {'font': {'color': '00FF0000'}}
-#         sty_a2 = {'font': {'color': '0000FF00'}}
-#
-#         initial_cells = [
-#             ExcelCell(col=1, row=0, val=42, style=sty_b1),
-#             ExcelCell(col=0, row=1, val=99, style=sty_a2),
-#         ]
-#
-#         sty_merged = {'font': { 'color': '000000FF', 'bold': True }}
-#         sty_kwargs = _Openpyxl20Writer._convert_to_style_kwargs(sty_merged)
-#         openpyxl_sty_merged = styles.Style(**sty_kwargs)
-#         merge_cells = [
-#             ExcelCell(col=0, row=0, val='pandas',
-#                     mergestart=1, mergeend=1, style=sty_merged),
-#         ]
-#
-#         with ensure_clean('.xlsx') as path:
-#             writer = _Openpyxl20Writer(path)
-#             writer.write_cells(initial_cells, sheet_name=sheet_name)
-#             writer.write_cells(merge_cells, sheet_name=sheet_name)
-#
-#             wks = writer.sheets[sheet_name]
-#             xcell_b1 = wks.cell('B1')
-#             xcell_a2 = wks.cell('A2')
-#             self.assertEqual(xcell_b1.style, openpyxl_sty_merged)
-#             self.assertEqual(xcell_a2.style, openpyxl_sty_merged)
+def skip_openpyxl_gt21(cls):
+    """Skip a TestCase instance if openpyxl >= 2.2"""
+
+    @classmethod
+    def setUpClass(cls):
+        _skip_if_no_openpyxl()
+        import openpyxl
+        ver = openpyxl.__version__
+        if not (ver >= LooseVersion('2.0.0') and ver < LooseVersion('2.2.0')):
+            raise nose.SkipTest("openpyxl >= 2.2")
+
+    cls.setUpClass = setUpClass
+    return cls
 
 @raise_on_incompat_version(2)
+@skip_openpyxl_gt21
+class Openpyxl20Tests(ExcelWriterBase, tm.TestCase):
+    ext = '.xlsx'
+    engine_name = 'openpyxl20'
+    check_skip = staticmethod(lambda *args, **kwargs: None)
+
+    def test_to_excel_styleconverter(self):
+        import openpyxl
+        from openpyxl import styles
+
+        hstyle = {
+            "font": {
+                "color": '00FF0000',
+                "bold": True,
+            },
+            "borders": {
+                "top": "thin",
+                "right": "thin",
+                "bottom": "thin",
+                "left": "thin",
+            },
+            "alignment": {
+                "horizontal": "center",
+                "vertical": "top",
+            },
+            "fill": {
+                "patternType": 'solid',
+                'fgColor': {
+                    'rgb': '006666FF',
+                    'tint': 0.3,
+                },
+            },
+            "number_format": {
+                "format_code": "0.00"
+            },
+            "protection": {
+                "locked": True,
+                "hidden": False,
+            },
+        }
+#
+        font_color = styles.Color('00FF0000')
+        font = styles.Font(bold=True, color=font_color)
+        side = styles.Side(style=styles.borders.BORDER_THIN)
+        border = styles.Border(top=side, right=side, bottom=side, left=side)
+        alignment = styles.Alignment(horizontal='center', vertical='top')
+        fill_color = styles.Color(rgb='006666FF', tint=0.3)
+        fill = styles.PatternFill(patternType='solid', fgColor=fill_color)
+#
+        # ahh openpyxl API changes
+        ver = openpyxl.__version__
+        if ver >= LooseVersion('2.0.0') and ver < LooseVersion('2.1.0'):
+            number_format = styles.NumberFormat(format_code='0.00')
+        else:
+            number_format = '0.00' # XXX: Only works with openpyxl-2.1.0
+#
+        protection = styles.Protection(locked=True, hidden=False)
+#
+        kw = _Openpyxl20Writer._convert_to_style_kwargs(hstyle)
+        self.assertEqual(kw['font'], font)
+        self.assertEqual(kw['border'], border)
+        self.assertEqual(kw['alignment'], alignment)
+        self.assertEqual(kw['fill'], fill)
+        self.assertEqual(kw['number_format'], number_format)
+        self.assertEqual(kw['protection'], protection)
+#
+#
+    def test_write_cells_merge_styled(self):
+        from pandas.core.format import ExcelCell
+        from openpyxl import styles
+#
+        sheet_name='merge_styled'
+#
+        sty_b1 = {'font': {'color': '00FF0000'}}
+        sty_a2 = {'font': {'color': '0000FF00'}}
+#
+        initial_cells = [
+            ExcelCell(col=1, row=0, val=42, style=sty_b1),
+            ExcelCell(col=0, row=1, val=99, style=sty_a2),
+        ]
+#
+        sty_merged = {'font': { 'color': '000000FF', 'bold': True }}
+        sty_kwargs = _Openpyxl20Writer._convert_to_style_kwargs(sty_merged)
+        openpyxl_sty_merged = styles.Style(**sty_kwargs)
+        merge_cells = [
+            ExcelCell(col=0, row=0, val='pandas',
+                    mergestart=1, mergeend=1, style=sty_merged),
+        ]
+#
+        with ensure_clean('.xlsx') as path:
+            writer = _Openpyxl20Writer(path)
+            writer.write_cells(initial_cells, sheet_name=sheet_name)
+            writer.write_cells(merge_cells, sheet_name=sheet_name)
+#
+            wks = writer.sheets[sheet_name]
+            xcell_b1 = wks.cell('B1')
+            xcell_a2 = wks.cell('A2')
+            self.assertEqual(xcell_b1.style, openpyxl_sty_merged)
+            self.assertEqual(xcell_a2.style, openpyxl_sty_merged)
+
+def skip_openpyxl_lt22(cls):
+    """Skip a TestCase instance if openpyxl < 2.2"""
+
+    @classmethod
+    def setUpClass(cls):
+        _skip_if_no_openpyxl()
+        import openpyxl
+        ver = openpyxl.__version__
+        if ver < LooseVersion('2.2.0'):
+            raise nose.SkipTest("openpyxl < 2.2")
+
+    cls.setUpClass = setUpClass
+    return cls
+
+@raise_on_incompat_version(2)
+@skip_openpyxl_lt22
 class Openpyxl22Tests(ExcelWriterBase, tm.TestCase):
     ext = '.xlsx'
     engine_name = 'openpyxl22'
     check_skip = staticmethod(lambda *args, **kwargs: None)
 
-    def _check_version(self):
-        import openpyxl
-        ver = openpyxl.__version__
-        return ver >= LooseVersion('2.2.0')
-
     def test_to_excel_styleconverter(self):
-        _skip_if_no_openpyxl()
-
-        if not self._check_version():
-            raise nose.SkipTest('incompatiable openpyxl version')
-
         import openpyxl
         from openpyxl import styles
 
@@ -1657,7 +1663,6 @@ class Openpyxl22Tests(ExcelWriterBase, tm.TestCase):
 
 
     def test_write_cells_merge_styled(self):
-        _skip_if_no_openpyxl()
         if not openpyxl_compat.is_compat(major_ver=2):
             raise nose.SkipTest('incompatiable openpyxl version')
 

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -1796,9 +1796,9 @@ class XlsxWriterTests(ExcelWriterBase, tm.TestCase):
             cell = read_worksheet.cell('B2')
 
             try:
-                read_num_format = cell.style.number_format._format_code
+                read_num_format = cell.number_format
             except:
-                read_num_format = cell.style.number_format
+                read_num_format = cell.style.number_format._format_code
 
             self.assertEqual(read_num_format, num_format)
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ deps =
     python-dateutil
     beautifulsoup4
     lxml
-    openpyxl<2.0.0
     xlsxwriter
     xlrd
     six
@@ -70,3 +69,24 @@ deps =
 deps =
     numpy==1.8.0
     {[testenv]deps}
+
+[testenv:openpyxl1]
+usedevelop = True
+deps =
+    {[testenv]deps}
+    openpyxl<2.0.0
+commands = {envbindir}/nosetests {toxinidir}/pandas/io/tests/test_excel.py
+
+[testenv:openpyxl20]
+usedevelop = True
+deps =
+    {[testenv]deps}
+    openpyxl<2.2.0
+commands = {envbindir}/nosetests {toxinidir}/pandas/io/tests/test_excel.py
+
+[testenv:openpyxl22]
+usedevelop = True
+deps =
+    {[testenv]deps}
+    openpyxl>=2.2.0
+commands = {envbindir}/nosetests {toxinidir}/pandas/io/tests/test_excel.py

--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,7 @@ usedevelop = True
 deps =
     {[testenv]deps}
     openpyxl<2.2.0
-commands = {envbindir}/nosetests {toxinidir}/pandas/io/tests/test_excel.py
+commands = {envbindir}/nosetests {posargs} {toxinidir}/pandas/io/tests/test_excel.py
 
 [testenv:openpyxl22]
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -89,4 +89,4 @@ usedevelop = True
 deps =
     {[testenv]deps}
     openpyxl>=2.2.0
-commands = {envbindir}/nosetests {toxinidir}/pandas/io/tests/test_excel.py
+commands = {envbindir}/nosetests {posargs} {toxinidir}/pandas/io/tests/test_excel.py


### PR DESCRIPTION
closes #10125 

I've added preliminary tests for openpyxl >= 2.2 styles. Unfortunately, I don't know how to get a whole test class to be skipped so tests will only run with either the Openpyxl20 or Openpyxl22 test class disabled, depending upon which version is installed. I hope this can be fixed fairly easily. Some code somewhere is still calling `openpyxl.styles.Style()` which needs changing. The aggregate Style object is an irrelevancy in client code.
