### PR TITLE
PERF: improves performance in SeriesGroupBy.transform

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -1021,7 +1021,7 @@ Performance Improvements
 - Development support for benchmarking with the `Air Speed Velocity library <https://github.com/spacetelescope/asv/>`_ (:issue:`8316`)
 - Added vbench benchmarks for alternative ExcelWriter engines and reading Excel files (:issue:`7171`)
 - Performance improvements in ``Categorical.value_counts`` (:issue:`10804`)
-- Performance improvements in ``SeriesGroupBy.nunique`` and ``SeriesGroupBy.value_counts`` (:issue:`10820`, :issue:`11077`)
+- Performance improvements in ``SeriesGroupBy.nunique`` and ``SeriesGroupBy.value_counts`` and ``SeriesGroupby.transform`` (:issue:`10820`, :issue:`11077`)
 - Performance improvements in ``DataFrame.drop_duplicates`` with integer dtypes (:issue:`10917`)
 - 4x improvement in ``timedelta`` string parsing (:issue:`6755`, :issue:`10426`)
 - 8x improvement in ``timedelta64`` and ``datetime64`` ops (:issue:`6755`)


### PR DESCRIPTION
```
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------
groupby_transform_series2                    |   6.3464 | 167.3844 |   0.0379 |
groupby_transform_multi_key3                 |  99.4797 | 1078.2626 |   0.0923 |
groupby_transform_multi_key1                 |  10.9547 |  98.5500 |   0.1112 |
groupby_transform_multi_key2                 |   9.0899 |  67.2680 |   0.1351 |
groupby_transform_series                     |   5.4360 |  30.5537 |   0.1779 |
groupby_transform_multi_key4                 |  39.9816 | 187.1406 |   0.2136 |
-------------------------------------------------------------------------------
Test name                                    | head[ms] | base[ms] |  ratio   |
-------------------------------------------------------------------------------

Ratio < 1.0 means the target commit is faster then the baseline.
Seed used: 1234

Target [0470a10] : PERF: improves performance in SeriesGroupBy.transform
Base   [7b9fe14] : revers import .pandas_vb_common
```
