### PR TITLE
BUG: astype(str) on datetimelike index #10442

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -17,6 +17,7 @@ Highlights include:
 
 Enhancements
 ~~~~~~~~~~~~
+- ``DatetimeIndex`` now supports conversion to strings with astype(str)(:issue:`10442`)
 
 - Support for ``compression`` (gzip/bz2) in :method:`DataFrame.to_csv` (:issue:`7615`)
 

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -756,6 +756,8 @@ class DatetimeIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
             return self.asi8.copy()
         elif dtype == _NS_DTYPE and self.tz is not None:
             return self.tz_convert('UTC').tz_localize(None)
+        elif dtype == str:
+            return self._shallow_copy(values=self.format(), infer=True)
         else:  # pragma: no cover
             raise ValueError('Cannot cast DatetimeIndex to dtype %s' % dtype)
 

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -45,6 +45,32 @@ class TestDatetimeIndexOps(Ops):
         self.assertEqual(s.day,10)
         self.assertRaises(AttributeError, lambda : s.weekday)
 
+    def test_astype_str(self):
+        # test astype string - #10442
+        result = date_range('2012-01-01', periods=4, name='test_name').astype(str)
+        expected = Index(['2012-01-01', '2012-01-02', '2012-01-03','2012-01-04'],
+                            name='test_name', dtype=object)
+        tm.assert_index_equal(result, expected)
+
+        # test astype string with tz and name
+        result = date_range('2012-01-01', periods=3, name='test_name', tz='US/Eastern').astype(str)
+        expected = Index(['2012-01-01 00:00:00-05:00', '2012-01-02 00:00:00-05:00',
+                          '2012-01-03 00:00:00-05:00'], name='test_name', dtype=object)
+        tm.assert_index_equal(result, expected)
+
+        # test astype string with freqH and name
+        result = date_range('1/1/2011', periods=3, freq='H', name='test_name').astype(str)
+        expected = Index(['2011-01-01 00:00:00', '2011-01-01 01:00:00', '2011-01-01 02:00:00'],
+                         name='test_name', dtype=object)
+        tm.assert_index_equal(result, expected)
+
+        # test astype string with freqH and timezone
+        result = date_range('3/6/2012 00:00', periods=2, freq='H',
+                            tz='Europe/London', name='test_name').astype(str)
+        expected = Index(['2012-03-06 00:00:00+00:00', '2012-03-06 01:00:00+00:00'],
+                         dtype=object, name='test_name')
+        tm.assert_index_equal(result, expected)
+
     def test_asobject_tolist(self):
         idx = pd.date_range(start='2013-01-01', periods=4, freq='M', name='idx')
         expected_list = [pd.Timestamp('2013-01-31'), pd.Timestamp('2013-02-28'),
@@ -502,7 +528,6 @@ Freq: H"""
             result = pd.DatetimeIndex(idx.asi8, freq='infer')
             tm.assert_index_equal(idx, result)
             self.assertEqual(result.freq, freq)
-
 
 class TestTimedeltaIndexOps(Ops):
 

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -2223,6 +2223,7 @@ class TestDatetimeIndex(tm.TestCase):
         # it works
         rng.join(idx, how='outer')
 
+
     def test_astype(self):
         rng = date_range('1/1/2000', periods=10)
 
@@ -2234,6 +2235,17 @@ class TestDatetimeIndex(tm.TestCase):
         result = rng.astype('datetime64[ns]')
         expected = date_range('1/1/2000', periods=10, tz='US/Eastern').tz_convert('UTC').tz_localize(None)
         tm.assert_index_equal(result, expected)
+
+        # BUG#10442 : testing astype(str) is correct for Series/DatetimeIndex
+        result = pd.Series(pd.date_range('2012-01-01', periods=3)).astype(str)
+        expected = pd.Series(['2012-01-01', '2012-01-02', '2012-01-03'], dtype=object)
+        tm.assert_series_equal(result, expected)
+
+        result = Series(pd.date_range('2012-01-01', periods=3, tz='US/Eastern')).astype(str)
+        expected = Series(['2012-01-01 00:00:00-05:00', '2012-01-02 00:00:00-05:00', '2012-01-03 00:00:00-05:00'],
+                          dtype=object)
+        tm.assert_series_equal(result, expected)
+
 
     def test_to_period_nofreq(self):
         idx = DatetimeIndex(['2000-01-01', '2000-01-02', '2000-01-04'])


### PR DESCRIPTION
closes #10442 

fix for the bug: Convert datetimelike index to strings with astype(str)
going to send pull request for test 
