### PR TITLE
API: multi-line, not inplace eval

### DIFF
--- a/doc/source/enhancingperf.rst
+++ b/doc/source/enhancingperf.rst
@@ -570,17 +570,50 @@ prefix the name of the :class:`~pandas.DataFrame` to the column(s) you're
 interested in evaluating.
 
 In addition, you can perform assignment of columns within an expression.
-This allows for *formulaic evaluation*. Only a single assignment is permitted.
-The assignment target can be a new column name or an existing column name, and
-it must be a valid Python identifier.
+This allows for *formulaic evaluation*.  The assignment target can be a
+new column name or an existing column name, and it must be a valid Python
+identifier.
+
+.. versionadded:: 0.18.0
+
+The ``inplace`` keyword determines whether this assignment will performed
+on the original ``DataFrame`` or return a copy with the new column.
+
+.. warning::
+
+   For backwards compatability, ``inplace`` defaults to ``True`` if not
+   specified. This will change in a future version of pandas - if your
+   code depends on an inplace assignment you should update to explicitly
+   set ``inplace=True``
 
 .. ipython:: python
 
    df = pd.DataFrame(dict(a=range(5), b=range(5, 10)))
-   df.eval('c = a + b')
-   df.eval('d = a + b + c')
-   df.eval('a = 1')
+   df.eval('c = a + b', inplace=True)
+   df.eval('d = a + b + c', inplace=True)
+   df.eval('a = 1', inplace=True)
    df
+
+When ``inplace`` is set to ``False``, a copy of the ``DataFrame`` with the
+new or modified columns is returned and the original frame is unchanged.
+
+.. ipython:: python
+
+   df
+   df.eval('e = a - c', inplace=False)
+   df
+
+.. versionadded:: 0.18.0
+
+As a convenience, multiple assignments can be performed by using a
+multi-line string.
+
+.. ipython:: python
+
+   df.eval("""
+   c = a + b
+   d = a + b + c
+   a = 1""", inplace=False)
 
 The equivalent in standard Python would be
 
@@ -591,6 +624,23 @@ The equivalent in standard Python would be
    df['d'] = df.a + df.b + df.c
    df['a'] = 1
    df
+
+.. versionadded:: 0.18.0
+
+The ``query`` method gained the ``inplace`` keyword which determines
+whether the query modifies the original frame.
+
+.. ipython:: python
+
+   df = pd.DataFrame(dict(a=range(5), b=range(5, 10)))
+   df.query('a > 2')
+   df.query('a > 2', inplace=True)
+   df
+
+.. warning::
+
+   Unlike with ``eval``, the default value for ``inplace`` for ``query``
+   is ``False``.  This is consistent with prior versions of pandas.
 
 Local Variables
 ~~~~~~~~~~~~~~~

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -295,15 +295,60 @@ Other API Changes
 
 - ``.memory_usage`` now includes values in the index, as does memory_usage in ``.info`` (:issue:`11597`)
 
+Changes to eval
+^^^^^^^^^^^^^^^
 
+In prior versions, new columns assignments in an ``eval`` expression resulted
+in an inplace change to the ``DataFrame``. (:issue:`9297`)
 
+.. ipython:: python
 
+   df = pd.DataFrame({'a': np.linspace(0, 10, 5), 'b': range(5)})
+   df.eval('c = a + b')
+   df
 
+In version 0.18.0, a new ``inplace`` keyword was added to choose whether the
+assignment should be done inplace or return a copy.
 
+.. ipython:: python
 
+   df
+   df.eval('d = c - b', inplace=False)
+   df
+   df.eval('d = c - b', inplace=True)
+   df
 
+.. warning::
 
+   For backwards compatability, ``inplace`` defaults to ``True`` if not specified.
+   This will change in a future version of pandas - if your code depends on an
+   inplace assignment you should update to explicitly set ``inplace=True``
 
+The ``inplace`` keyword parameter was also added the ``query`` method.  
+
+.. ipython:: python
+
+   df.query('a > 5')
+   df.query('a > 5', inplace=True)
+   df
+
+.. warning::
+
+   Note that the default value for ``inplace`` in a ``query``
+   is ``False``, which is consistent with prior verions.
+
+``eval`` has also been updated to allow multi-line expressions for multiple
+assignments.  These expressions will be evaluated one at a time in order.  Only
+assginments are valid for multi-line expressions.
+
+.. ipython:: python
+
+   df
+   df.eval("""
+   e = d + a
+   f = e - 22
+   g = f / 2.0""", inplace=True)
+   df
 
 .. _whatsnew_0180.deprecations:
 
@@ -410,7 +455,7 @@ Bug Fixes
 - Bug in ``pd.read_clipboard`` and ``pd.to_clipboard`` functions not supporting Unicode; upgrade included ``pyperclip`` to v1.5.15 (:issue:`9263`)
 
 
-
+- Bug in ``DataFrame.query`` containing an assignment (:issue:`8664`)
 
 
 


### PR DESCRIPTION
closes #9297
closes #8664

This is just a proof of concept at this point - the idea is to allow multiple assignments within an eval block, and also include an `inplace` argument (currently default True to match old behavior, although maybe that should be changed) for chaining.

```
In [15]: df = pd.DataFrame({'a': np.linspace(0, 100), 'b': range(50)})

In [16]: df.eval("""
    ...: c = a * 2
    ...: d = c / 2.0
    ...: e = a + b + c""")

In [17]: df.head()
Out[17]: 
        a  b          c         d          e
0  0.000000  0   0.000000  0.000000   0.000000
1  2.040816  1   4.081633  2.040816   7.122449
2  4.081633  2   8.163265  4.081633  14.244898
3  6.122449  3  12.244898  6.122449  21.367347
4  8.163265  4  16.326531  8.163265  28.489796

In [18]: df.eval("""
    ...: f = e * 2
    ...: g = f * 1.5""", inplace=False).head()
Out[18]: 
        a  b          c         d          e          f          g
0  0.000000  0   0.000000  0.000000   0.000000   0.000000   0.000000
1  2.040816  1   4.081633  2.040816   7.122449  14.244898  21.367347
2  4.081633  2   8.163265  4.081633  14.244898  28.489796  42.734694
3  6.122449  3  12.244898  6.122449  21.367347  42.734694  64.102041
4  8.163265  4  16.326531  8.163265  28.489796  56.979592  85.469388
```
