### PR TITLE
(WIP) BUG: DatetimeTZBlock.fillna raises TypeError

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -1157,3 +1157,4 @@ Bug Fixes
 - Bug in ``Index`` dtype may not applied properly (:issue:`11017`)
 - Bug in ``io.gbq`` when testing for minimum google api client version (:issue:`10652`)
 - Bug in ``DataFrame`` construction from nested ``dict`` with ``timedelta`` keys (:issue:`11129`)
+- Bug in ``.fillna`` against may raise ``TypeError`` when data contains datetime dtype (:issue:`7095`, :issue:`11153`)

--- a/pandas/core/dtypes.py
+++ b/pandas/core/dtypes.py
@@ -181,7 +181,7 @@ class DatetimeTZDtype(ExtensionDtype):
 
     def __unicode__(self):
         # format the tz
-        return "datetime64[{unit}, {tz}]".format(unit=self.unit,tz=self.tz)
+        return "datetime64[{unit}, {tz}]".format(unit=self.unit, tz=self.tz)
 
     @property
     def name(self):

--- a/pandas/tests/test_dtypes.py
+++ b/pandas/tests/test_dtypes.py
@@ -137,6 +137,20 @@ class TestDatetimeTZDtype(Base, tm.TestCase):
         self.assertFalse(is_datetimetz(np.dtype('float64')))
         self.assertFalse(is_datetimetz(1.0))
 
+    def test_dst(self):
+
+        dr1 = date_range('2013-01-01', periods=3, tz='US/Eastern')
+        s1 = Series(dr1, name='A')
+        self.assertTrue(is_datetimetz(s1))
+
+        dr2 = date_range('2013-08-01', periods=3, tz='US/Eastern')
+        s2 = Series(dr2, name='A')
+        self.assertTrue(is_datetimetz(s2))
+        self.assertEqual(s1.dtype, s2.dtype)
+
+
+
+
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
                    exit=False)

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -8740,6 +8740,34 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             result = df.fillna(v)
             assert_frame_equal(result, expected)
 
+    def test_fillna_datetime_columns(self):
+        # GH 7095
+        df = pd.DataFrame({'A': [-1, -2, np.nan],
+                           'B': date_range('20130101', periods=3),
+                           'C': ['foo', 'bar', None],
+                           'D': ['foo2', 'bar2', None]},
+                          index=date_range('20130110', periods=3))
+        result = df.fillna('?')
+        expected = pd.DataFrame({'A': [-1, -2, '?'],
+                                 'B': date_range('20130101', periods=3),
+                                 'C': ['foo', 'bar', '?'],
+                                 'D': ['foo2', 'bar2', '?']},
+                                index=date_range('20130110', periods=3))
+        self.assert_frame_equal(result, expected)
+
+        df = pd.DataFrame({'A': [-1, -2, np.nan],
+                           'B': [pd.Timestamp('2013-01-01'), pd.Timestamp('2013-01-02'), pd.NaT],
+                           'C': ['foo', 'bar', None],
+                           'D': ['foo2', 'bar2', None]},
+                          index=date_range('20130110', periods=3))
+        result = df.fillna('?')
+        expected = pd.DataFrame({'A': [-1, -2, '?'],
+                                 'B': [pd.Timestamp('2013-01-01'), pd.Timestamp('2013-01-02'), '?'],
+                                 'C': ['foo', 'bar', '?'],
+                                 'D': ['foo2', 'bar2', '?']},
+                                index=date_range('20130110', periods=3))
+        self.assert_frame_equal(result, expected)
+
     def test_ffill(self):
         self.tsframe['A'][:5] = nan
         self.tsframe['A'][-5:] = nan

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -3937,6 +3937,89 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         result = s.fillna(method='backfill')
         assert_series_equal(result, expected)
 
+    def test_datetime64_tz_fillna(self):
+        for tz in ['US/Eastern', 'Asia/Tokyo']:
+            # DatetimeBlock
+            s = Series([Timestamp('2011-01-01 10:00'), pd.NaT,
+                        Timestamp('2011-01-03 10:00'), pd.NaT])
+            result = s.fillna(pd.Timestamp('2011-01-02 10:00'))
+            expected = Series([Timestamp('2011-01-01 10:00'), Timestamp('2011-01-02 10:00'),
+                               Timestamp('2011-01-03 10:00'), Timestamp('2011-01-02 10:00')])
+            self.assert_series_equal(expected, result)
+
+            result = s.fillna(pd.Timestamp('2011-01-02 10:00', tz=tz))
+            expected = Series([Timestamp('2011-01-01 10:00'),
+                               Timestamp('2011-01-02 10:00', tz=tz),
+                               Timestamp('2011-01-03 10:00'),
+                               Timestamp('2011-01-02 10:00', tz=tz)])
+            self.assert_series_equal(expected, result)
+
+            result = s.fillna('AAA')
+            expected = Series([Timestamp('2011-01-01 10:00'), 'AAA',
+                               Timestamp('2011-01-03 10:00'), 'AAA'], dtype=object)
+            self.assert_series_equal(expected, result)
+
+            result = s.fillna({1: pd.Timestamp('2011-01-02 10:00', tz=tz),
+                               3: pd.Timestamp('2011-01-04 10:00')})
+            expected = Series([Timestamp('2011-01-01 10:00'),
+                               Timestamp('2011-01-02 10:00', tz=tz),
+                               Timestamp('2011-01-03 10:00'),
+                               Timestamp('2011-01-04 10:00')])
+            self.assert_series_equal(expected, result)
+
+            result = s.fillna({1: pd.Timestamp('2011-01-02 10:00'),
+                               3: pd.Timestamp('2011-01-04 10:00')})
+            expected = Series([Timestamp('2011-01-01 10:00'), Timestamp('2011-01-02 10:00'),
+                               Timestamp('2011-01-03 10:00'), Timestamp('2011-01-04 10:00')])
+            self.assert_series_equal(expected, result)
+
+            # DatetimeBlockTZ
+            idx = pd.DatetimeIndex(['2011-01-01 10:00', pd.NaT,
+                                    '2011-01-03 10:00', pd.NaT], tz=tz)
+            s = pd.Series(idx)
+            result = s.fillna(pd.Timestamp('2011-01-02 10:00'))
+            expected = Series([Timestamp('2011-01-01 10:00', tz=tz),
+                               Timestamp('2011-01-02 10:00'),
+                               Timestamp('2011-01-03 10:00', tz=tz),
+                               Timestamp('2011-01-02 10:00')])
+            self.assert_series_equal(expected, result)
+
+            result = s.fillna(pd.Timestamp('2011-01-02 10:00', tz=tz))
+            idx = pd.DatetimeIndex(['2011-01-01 10:00', '2011-01-02 10:00',
+                                    '2011-01-03 10:00', '2011-01-02 10:00'],
+                                   tz=tz)
+            expected = Series(idx)
+            self.assert_series_equal(expected, result)
+
+            result = s.fillna(pd.Timestamp('2011-01-02 10:00', tz=tz).to_pydatetime())
+            idx = pd.DatetimeIndex(['2011-01-01 10:00', '2011-01-02 10:00',
+                                    '2011-01-03 10:00', '2011-01-02 10:00'],
+                                   tz=tz)
+            expected = Series(idx)
+            self.assert_series_equal(expected, result)
+
+            result = s.fillna('AAA')
+            expected = Series([Timestamp('2011-01-01 10:00', tz=tz), 'AAA',
+                               Timestamp('2011-01-03 10:00', tz=tz), 'AAA'],
+                              dtype=object)
+            self.assert_series_equal(expected, result)
+
+            result = s.fillna({1: pd.Timestamp('2011-01-02 10:00', tz=tz),
+                               3: pd.Timestamp('2011-01-04 10:00')})
+            expected = Series([Timestamp('2011-01-01 10:00', tz=tz),
+                               Timestamp('2011-01-02 10:00', tz=tz),
+                               Timestamp('2011-01-03 10:00', tz=tz),
+                               Timestamp('2011-01-04 10:00')])
+            self.assert_series_equal(expected, result)
+
+            result = s.fillna({1: pd.Timestamp('2011-01-02 10:00', tz=tz),
+                               3: pd.Timestamp('2011-01-04 10:00', tz=tz)})
+            expected = Series([Timestamp('2011-01-01 10:00', tz=tz),
+                               Timestamp('2011-01-02 10:00', tz=tz),
+                               Timestamp('2011-01-03 10:00', tz=tz),
+                               Timestamp('2011-01-04 10:00', tz=tz)])
+            self.assert_series_equal(expected, result)
+
     def test_fillna_int(self):
         s = Series(np.random.randint(-100, 100, 50))
         s.fillna(method='ffill', inplace=True)
@@ -5021,6 +5104,29 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
         # invalid axis
         self.assertRaises(ValueError, s.dropna, axis=1)
+
+
+    def test_datetime64_tz_dropna(self):
+        # DatetimeBlock
+        s = Series([Timestamp('2011-01-01 10:00'), pd.NaT,
+                    Timestamp('2011-01-03 10:00'), pd.NaT])
+        result = s.dropna()
+        expected = Series([Timestamp('2011-01-01 10:00'),
+                           Timestamp('2011-01-03 10:00')], index=[0, 2])
+        self.assert_series_equal(result, expected)
+
+        # DatetimeBlockTZ
+        idx = pd.DatetimeIndex(['2011-01-01 10:00', pd.NaT,
+                                '2011-01-03 10:00', pd.NaT],
+                               tz='Asia/Tokyo')
+        s = pd.Series(idx)
+        self.assertEqual(s.dtype, 'datetime64[ns, Asia/Tokyo]')
+        result = s.dropna()
+        expected = Series([Timestamp('2011-01-01 10:00', tz='Asia/Tokyo'),
+                           Timestamp('2011-01-03 10:00', tz='Asia/Tokyo')],
+                          index=[0, 2])
+        self.assertEqual(result.dtype, 'datetime64[ns, Asia/Tokyo]')
+        self.assert_series_equal(result, expected)
 
     def test_axis_alias(self):
         s = Series([1, 2, np.nan])


### PR DESCRIPTION
```
import pandas as pd
idx = pd.DatetimeIndex(['2011-01-01', pd.NaT, '2011-01-03'], tz='Asia/Tokyo')
s = pd.Series(idx)
s
#0   2011-01-01 00:00:00+09:00
#1                         NaT
#2   2011-01-03 00:00:00+09:00
# dtype: datetime64[ns, Asia/Tokyo]

# NG, the result must be DatetimeTZBlock
s.fillna(pd.Timestamp('2011-01-02', tz='Asia/Tokyo'))
# TypeError: putmask() argument 1 must be numpy.ndarray, not DatetimeIndex

# NG, it should be object dtype, as the same as when Series creation with mixed tz
s.fillna(pd.Timestamp('2011-01-02'))
# TypeError: putmask() argument 1 must be numpy.ndarray, not DatetimeIndex
```

Also, found existing `DatetimeBlock` doesn't handle tz properly. Closes #7095.

```
idx = pd.DatetimeIndex(['2011-01-01', pd.NaT, '2011-01-03'])
s = pd.Series(idx)

# OK, result must be DatetimeBlock
s.fillna(pd.Timestamp('2011-01-02'))
#0   2011-01-01
#1   2011-01-02
#2   2011-01-03
# dtype: datetime64[ns]

# NG, it should be object dtype, as the same as when Series creation with mixed tz
s.fillna(pd.Timestamp('2011-01-02', tz='Asia/Tokyo'))
#0   2011-01-01 00:00:00
#1   2011-01-01 15:00:00
#2   2011-01-03 00:00:00
# dtype: datetime64[ns]

# NG, unable to fill different dtypes
s.fillna('AAA')
# ValueError: Error parsing datetime string "AAA" at position 0
```
