### PR TITLE
PERF: Series.dropna with non-nan dtype blocks

### DIFF
--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -71,3 +71,23 @@ class series_nsmallest2(object):
     def time_series_nsmallest2(self):
         self.s2.nsmallest(3, take_last=True)
         self.s2.nsmallest(3, take_last=False)
+
+
+class series_dropna_int64(object):
+    goal_time = 0.2
+
+    def setup(self):
+        self.s = Series(np.random.randint(1, 10, 1000000))
+
+    def time_series_dropna_int64(self):
+        self.s.dropna()
+
+class series_dropna_datetime(object):
+    goal_time = 0.2
+
+    def setup(self):
+        self.s = Series(pd.date_range('2000-01-01', freq='S', periods=1000000))
+        self.s[np.random.randint(1, 1000000, 100)] = pd.NaT
+
+    def time_series_dropna_datetime(self):
+        self.s.dropna()

--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -53,6 +53,7 @@ Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Checking monotonic-ness before sorting on an index (:issue:`11080`)
+- ``Series.dropna`` performance improvement when its dtype can't contain ``NaN`` (:issue:`11159`)
 
 .. _whatsnew_0171.bug_fixes:
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2501,11 +2501,19 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                     'argument "{0}"'.format(list(kwargs.keys())[0]))
 
         axis = self._get_axis_number(axis or 0)
-        result = remove_na(self)
-        if inplace:
-            self._update_inplace(result)
+
+        if self._can_hold_na:
+            result = remove_na(self)
+            if inplace:
+                self._update_inplace(result)
+            else:
+                return result
         else:
-            return result
+            if inplace:
+                # do nothing
+                pass
+            else:
+                return self.copy()
 
     valid = lambda self, inplace=False, **kwargs: self.dropna(inplace=inplace,
                                                               **kwargs)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -5117,7 +5117,6 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         # invalid axis
         self.assertRaises(ValueError, s.dropna, axis=1)
 
-
     def test_datetime64_tz_dropna(self):
         # DatetimeBlock
         s = Series([Timestamp('2011-01-01 10:00'), pd.NaT,
@@ -5139,6 +5138,18 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
                           index=[0, 2])
         self.assertEqual(result.dtype, 'datetime64[ns, Asia/Tokyo]')
         self.assert_series_equal(result, expected)
+
+    def test_dropna_no_nan(self):
+        for s in [Series([1, 2, 3], name='x'),
+                  Series([False, True, False], name='x')]:
+
+            result = s.dropna()
+            self.assert_series_equal(result, s)
+            self.assertFalse(result is s)
+
+            s2 = s.copy()
+            s2.dropna(inplace=True)
+            self.assert_series_equal(s2, s)
 
     def test_axis_alias(self):
         s = Series([1, 2, np.nan])


### PR DESCRIPTION
Minor improvement when `dropna` actually does nothing. If OK for 0.17, I'll add a release note.

```
import numpy as np
import pandas as pd

s = pd.Series(np.random.randint(0, 1000, 50000000))

# before
%timeit s.dropna()
#1 loops, best of 3: 1.58 s per loop

# after
%timeit s.dropna()
#1 loops, best of 3: 568 ms per loop
```
