### PR TITLE
DOC: XportReader not top-level API

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -89,7 +89,6 @@ SAS
    :toctree: generated/
 
    read_sas
-   XportReader
 
 SQL
 ~~~


### PR DESCRIPTION
@kshedden `XportReader` is not top-level API, so it was erroring in the doc build.

I now removed it from api.rst (the `TextFileReader` what you get back with chunksize for read_csv is also not included), but I can also adapt it to use `.. currentmodule:: pandas.io.sas` so it builds correctly if you want.
