### PR TITLE
API: read_excel signature

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1980,9 +1980,10 @@ Excel files
 -----------
 
 The :func:`~pandas.read_excel` method can read Excel 2003 (``.xls``) and
-Excel 2007 (``.xlsx``) files using the ``xlrd`` Python
-module and use the same parsing code as the above to convert tabular data into
-a DataFrame. See the :ref:`cookbook<cookbook.excel>` for some
+Excel 2007+ (``.xlsx``) files using the ``xlrd`` Python
+module.  The :meth:`~DataFrame.to_excel` instance method is used for
+saving a ``DataFrame`` to Excel.  Generally the semantics are
+similar to working with :ref:`csv<io.read_csv_table>` data.  See the :ref:`cookbook<cookbook.excel>` for some
 advanced strategies
 
 .. _io.excel_reader:
@@ -1990,90 +1991,74 @@ advanced strategies
 Reading Excel Files
 '''''''''''''''''''
 
-.. versionadded:: 0.17
-
-``read_excel`` can read a ``MultiIndex`` index, by passing a list of columns to ``index_col``
-and a ``MultiIndex`` column by passing a list of rows to ``header``.  If either the ``index``
-or ``columns`` have serialized level names those will be read in as well by specifying
-the rows/columns that make up the levels.
-
-.. ipython:: python
-
-   # MultiIndex index - no names
-   df = pd.DataFrame({'a':[1,2,3,4], 'b':[5,6,7,8]},
-                     index=pd.MultiIndex.from_product([['a','b'],['c','d']]))
-   df.to_excel('path_to_file.xlsx')
-   df = pd.read_excel('path_to_file.xlsx', index_col=[0,1])
-   df
-
-   # MultiIndex index - with names
-   df.index = df.index.set_names(['lvl1', 'lvl2'])
-   df.to_excel('path_to_file.xlsx')
-   df = pd.read_excel('path_to_file.xlsx', index_col=[0,1])
-   df
-
-   # MultiIndex index and column - with names
-   df.columns = pd.MultiIndex.from_product([['a'],['b', 'd']], names=['c1', 'c2'])
-   df.to_excel('path_to_file.xlsx')
-   df = pd.read_excel('path_to_file.xlsx',
-                       index_col=[0,1], header=[0,1])
-   df
-
-.. ipython:: python
-   :suppress:
-
-   import os
-   os.remove('path_to_file.xlsx')
-
-.. warning::
-
-   Excel files saved in version 0.16.2 or prior that had index names will still able to be read in,
-   but the ``has_index_names`` argument must specified to ``True``.
-
-.. versionadded:: 0.16
-
-``read_excel`` can read more than one sheet, by setting ``sheetname`` to either
-a list of sheet names, a list of sheet positions, or ``None`` to read all sheets.
-
-.. versionadded:: 0.13
-
-Sheets can be specified by sheet index or sheet name, using an integer or string,
-respectively.
-
-.. versionadded:: 0.12
-
-``ExcelFile`` has been moved to the top level namespace.
-
-There are two approaches to reading an excel file.  The ``read_excel`` function
-and the ``ExcelFile`` class.  ``read_excel`` is for reading one file
-with file-specific arguments (ie. identical data formats across sheets).
-``ExcelFile`` is for reading one file with sheet-specific arguments (ie. various data
-formats across sheets).  Choosing the approach is largely a question of
-code readability and execution speed.
-
-Equivalent class and function approaches to read a single sheet:
+In the most basic use-case, ``read_excel`` takes a path to an Excel
+file, and the ``sheetname`` indicating which sheet to parse.
 
 .. code-block:: python
 
-    # using the ExcelFile class
-    xls = pd.ExcelFile('path_to_file.xls')
-    data = xls.parse('Sheet1', index_col=None, na_values=['NA'])
+   # Returns a DataFrame
+   read_excel('path_to_file.xls', sheetname='Sheet1')
 
-    # using the read_excel function
-    data = read_excel('path_to_file.xls', 'Sheet1', index_col=None, na_values=['NA'])
 
-Equivalent class and function approaches to read multiple sheets:
+.. _io.excel.excelfile_class:
+
+``ExcelFile`` class
++++++++++++++++++++
+
+To faciliate working with multiple sheets from the same file, the ``ExcelFile``
+class can be used to wrap the file and can be be passed into ``read_excel``
+There will be a performance benefit for reading multiple sheets as the file is
+read into memory only once.
+
+.. code-block:: python
+
+   xlsx = pd.ExcelFile('path_to_file.xls)
+   df = pd.read_excel(xlsx, 'Sheet1')
+
+The ``ExcelFile`` class can also be used as a context manager.
+
+.. code-block:: python
+
+   with pd.ExcelFile('path_to_file.xls') as xls:
+       df1 = pd.read_excel(xls, 'Sheet1')
+       df2 = pd.read_excel(xls, 'Sheet2')
+
+The ``sheet_names`` property will generate
+a list of the sheet names in the file.
+
+The primary use-case for an ``ExcelFile`` is parsing multiple sheets with
+different parameters
 
 .. code-block:: python
 
     data = {}
     # For when Sheet1's format differs from Sheet2
-    xls = pd.ExcelFile('path_to_file.xls')
-    data['Sheet1'] = xls.parse('Sheet1', index_col=None, na_values=['NA'])
-    data['Sheet2'] = xls.parse('Sheet2', index_col=1)
+    with pd.ExcelFile('path_to_file.xls') as xls:
+        data['Sheet1'] = pd.read_excel(xls, 'Sheet1', index_col=None, na_values=['NA'])
+        data['Sheet2'] = pd.read_excel(xls, 'Sheet2', index_col=1)
 
-    # For when Sheet1's format is identical to Sheet2
-    data = read_excel('path_to_file.xls', ['Sheet1','Sheet2'], index_col=None, na_values=['NA'])
+Note that if the same parsing parameters are used for all sheets, a list
+of sheet names can simply be passed to ``read_excel`` with no loss in performance.
+
+.. code-block:: python
+
+    # using the ExcelFile class
+    data = {}
+    with pd.ExcelFile('path_to_file.xls') as xls:
+        data['Sheet1'] = read_excel(xls, 'Sheet1', index_col=None, na_values=['NA'])
+        data['Sheet2'] = read_excel(xls, 'Sheet2', index_col=None, na_values=['NA'])
+
+    # equivalent using the read_excel function
+    data = read_excel('path_to_file.xls', ['Sheet1', 'Sheet2'], index_col=None, na_values=['NA'])
+
+.. versionadded:: 0.12
+
+``ExcelFile`` has been moved to the top level namespace.
+
+.. versionadded:: 0.17
+
+``read_excel`` can take an ``ExcelFile`` object as input
+
 
 .. _io.excel.specifying_sheets:
 
@@ -2124,6 +2109,72 @@ Using a list to get multiple sheets:
 
    # Returns the 1st and 4th sheet, as a dictionary of DataFrames.
    read_excel('path_to_file.xls',sheetname=['Sheet1',3])
+
+.. versionadded:: 0.16
+
+``read_excel`` can read more than one sheet, by setting ``sheetname`` to either
+a list of sheet names, a list of sheet positions, or ``None`` to read all sheets.
+
+.. versionadded:: 0.13
+
+Sheets can be specified by sheet index or sheet name, using an integer or string,
+respectively.
+
+.. _io.excel.reading_multiindex:
+
+Reading a ``MultiIndex``
+++++++++++++++++++++++++
+
+.. versionadded:: 0.17
+
+``read_excel`` can read a ``MultiIndex`` index, by passing a list of columns to ``index_col``
+and a ``MultiIndex`` column by passing a list of rows to ``header``.  If either the ``index``
+or ``columns`` have serialized level names those will be read in as well by specifying
+the rows/columns that make up the levels.
+
+For example, to read in a ``MultiIndex`` index without names:
+
+.. ipython:: python
+
+   df = pd.DataFrame({'a':[1,2,3,4], 'b':[5,6,7,8]},
+                     index=pd.MultiIndex.from_product([['a','b'],['c','d']]))
+   df.to_excel('path_to_file.xlsx')
+   df = pd.read_excel('path_to_file.xlsx', index_col=[0,1])
+   df
+
+If the index has level names, they will parsed as well, using the same
+parameters.
+
+.. ipython:: python
+
+   df.index = df.index.set_names(['lvl1', 'lvl2'])
+   df.to_excel('path_to_file.xlsx')
+   df = pd.read_excel('path_to_file.xlsx', index_col=[0,1])
+   df
+
+
+If the source file has both ``MultiIndex`` index and columns, lists specifying each
+should be passed to ``index_col`` and ``header``
+
+.. ipython:: python
+
+   df.columns = pd.MultiIndex.from_product([['a'],['b', 'd']], names=['c1', 'c2'])
+   df.to_excel('path_to_file.xlsx')
+   df = pd.read_excel('path_to_file.xlsx',
+                       index_col=[0,1], header=[0,1])
+   df
+
+.. ipython:: python
+   :suppress:
+
+   import os
+   os.remove('path_to_file.xlsx')
+
+.. warning::
+
+   Excel files saved in version 0.16.2 or prior that had index names will still able to be read in,
+   but the ``has_index_names`` argument must specified to ``True``.
+
 
 Parsing Specific Columns
 ++++++++++++++++++++++++

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -937,6 +937,8 @@ Other API Changes
 - When constructing ``DataFrame`` with an array of ``complex64`` dtype previously meant the corresponding column
   was automatically promoted to the ``complex128`` dtype. Pandas will now preserve the itemsize of the input for complex data (:issue:`10952`)
 - some numeric reduction operators would return ``ValueError``, rather than ``TypeError`` on object types that includes strings and numbers (:issue:`11131`)
+- Passing currently unsupported ``chunksize`` argument to ``read_excel`` or ``ExcelFile.parse`` will now raise ``NotImplementedError`` (:issue:`8011`)
+- Allow an ``ExcelFile`` object to be passed into ``read_excel`` (:issue:`11198`)
 - ``DatetimeIndex.union`` does not infer ``freq`` if ``self`` and the input have ``None`` as ``freq`` (:issue:`11086`)
 - ``NaT``'s methods now either raise ``ValueError``, or return ``np.nan`` or ``NaT`` (:issue:`9513`)
 

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -70,12 +70,20 @@ def get_writer(engine_name):
     except KeyError:
         raise ValueError("No Excel writer '%s'" % engine_name)
 
-
-excel_doc_common = """
+def read_excel(io, sheetname=0, header=0, skiprows=None, skip_footer=0,
+               index_col=None, parse_cols=None, parse_dates=False,
+               date_parser=None, na_values=None, thousands=None,
+               convert_float=True, has_index_names=None, converters=None,
+               engine=None, **kwds):
+    """
     Read an Excel table into a pandas DataFrame
 
     Parameters
-    ----------%(io)s
+    ----------
+    io : string, file-like object, pandas ExcelFile, or xlrd workbook.
+        The string could be a URL. Valid URL schemes include http, ftp, s3,
+        and file. For file URLs, a host is expected. For instance, a local
+        file could be file://localhost/path/to/workbook.xlsx
     sheetname : string, int, mixed list of strings/ints, or None, default 0
 
         Strings are used for sheet names, Integers are used in zero-indexed sheet
@@ -122,18 +130,24 @@ excel_doc_common = """
     na_values : list-like, default None
         List of additional strings to recognize as NA/NaN
     thousands : str, default None
-        Thousands separator
+        Thousands separator for parsing string columns to numeric.  Note that
+        this parameter is only necessary for columns stored as TEXT in Excel,
+        any numeric columns will automatically be parsed, regardless of display
+        format.
     keep_default_na : bool, default True
         If na_values are specified and keep_default_na is False the default NaN
         values are overridden, otherwise they're appended to
     verbose : boolean, default False
-        Indicate number of NA values placed in non-numeric columns%(eng)s
+        Indicate number of NA values placed in non-numeric columns
+    engine: string, default None
+        If io is not a buffer or path, this must be set to identify io.
+        Acceptable values are None or xlrd
     convert_float : boolean, default True
         convert integral floats to int (i.e., 1.0 --> 1). If False, all numeric
         data will be read in as floats: Excel stores all numbers as floats
         internally
     has_index_names : boolean, default None
-        DEPCRECATED: for version 0.17+ index names will be automatically inferred
+        DEPRECATED: for version 0.17+ index names will be automatically inferred
         based on index_col.  To read Excel output from 0.16.2 and prior that
         had saved index names, use True.
 
@@ -144,28 +158,21 @@ excel_doc_common = """
         for more information on when a Dict of Dataframes is returned.
 
     """
-read_excel_kwargs = dict()
-read_excel_kwargs['io'] = """
-    io : string, file-like object, or xlrd workbook.
-        The string could be a URL. Valid URL schemes include http, ftp, s3,
-        and file. For file URLs, a host is expected. For instance, a local
-        file could be file://localhost/path/to/workbook.xlsx"""
-read_excel_kwargs['eng'] = """
-    engine: string, default None
-        If io is not a buffer or path, this must be set to identify io.
-        Acceptable values are None or xlrd"""
 
-@Appender(excel_doc_common % read_excel_kwargs)
-def read_excel(io, sheetname=0, **kwds):
-    engine = kwds.pop('engine', None)
+    if not isinstance(io, ExcelFile):
+        io = ExcelFile(io, engine=engine)
 
-    return ExcelFile(io, engine=engine).parse(sheetname=sheetname, **kwds)
-
+    return io._parse_excel(
+        sheetname=sheetname, header=header, skiprows=skiprows,
+        index_col=index_col, parse_cols=parse_cols, parse_dates=parse_dates,
+        date_parser=date_parser, na_values=na_values, thousands=thousands,
+        convert_float=convert_float, has_index_names=has_index_names,
+        skip_footer=skip_footer, converters=converters, **kwds)
 
 class ExcelFile(object):
     """
     Class for parsing tabular excel sheets into DataFrame objects.
-    Uses xlrd. See ExcelFile.parse for more documentation
+    Uses xlrd. See read_excel for more documentation
 
     Parameters
     ----------
@@ -207,23 +214,16 @@ class ExcelFile(object):
             raise ValueError('Must explicitly set engine if not passing in'
                              ' buffer or path for io.')
 
-    @Appender(excel_doc_common % dict(io='', eng=''))
     def parse(self, sheetname=0, header=0, skiprows=None, skip_footer=0,
               index_col=None, parse_cols=None, parse_dates=False,
-              date_parser=None, na_values=None, thousands=None, chunksize=None,
+              date_parser=None, na_values=None, thousands=None,
               convert_float=True, has_index_names=None, converters=None, **kwds):
+        """
+        Parse specified sheet(s) into a DataFrame
 
-        skipfooter = kwds.pop('skipfooter', None)
-        if skipfooter is not None:
-            skip_footer = skipfooter
-
-        _validate_header_arg(header)
-        if has_index_names is not None:
-            warn("\nThe has_index_names argument is deprecated; index names "
-                 "will be automatically inferred based on index_col.\n"
-                 "This argmument is still necessary if reading Excel output "
-                 "from 0.16.2 or prior with index names.", FutureWarning,
-                 stacklevel=3)
+        Equivalent to read_excel(ExcelFile, ...)  See the read_excel
+        docstring for more info on accepted parameters
+        """
 
         return self._parse_excel(sheetname=sheetname, header=header,
                                  skiprows=skiprows,
@@ -232,7 +232,7 @@ class ExcelFile(object):
                                  parse_cols=parse_cols,
                                  parse_dates=parse_dates,
                                  date_parser=date_parser, na_values=na_values,
-                                 thousands=thousands, chunksize=chunksize,
+                                 thousands=thousands,
                                  skip_footer=skip_footer,
                                  convert_float=convert_float,
                                  converters=converters,
@@ -274,8 +274,25 @@ class ExcelFile(object):
     def _parse_excel(self, sheetname=0, header=0, skiprows=None, skip_footer=0,
                      index_col=None, has_index_names=None, parse_cols=None,
                      parse_dates=False, date_parser=None, na_values=None,
-                     thousands=None, chunksize=None, convert_float=True,
+                     thousands=None, convert_float=True,
                      verbose=False, **kwds):
+
+        skipfooter = kwds.pop('skipfooter', None)
+        if skipfooter is not None:
+            skip_footer = skipfooter
+
+        _validate_header_arg(header)
+        if has_index_names is not None:
+            warn("\nThe has_index_names argument is deprecated; index names "
+                 "will be automatically inferred based on index_col.\n"
+                 "This argmument is still necessary if reading Excel output "
+                 "from 0.16.2 or prior with index names.", FutureWarning,
+                 stacklevel=3)
+
+        if 'chunksize' in kwds:
+            raise NotImplementedError("Reading an Excel file in chunks "
+                                      "is not implemented")
+
         import xlrd
         from xlrd import (xldate, XL_CELL_DATE,
                           XL_CELL_ERROR, XL_CELL_BOOLEAN,
@@ -416,7 +433,6 @@ class ExcelFile(object):
                                 date_parser=date_parser,
                                 skiprows=skiprows,
                                 skip_footer=skip_footer,
-                                chunksize=chunksize,
                                 **kwds)
 
             output[asheetname] = parser.read()

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -158,76 +158,67 @@ class ReadingTestsBase(SharedItems):
     def test_parse_cols_int(self):
 
         dfref = self.get_csv_refdf('test1')
-        excel = self.get_excelfile('test1')
         dfref = dfref.reindex(columns=['A', 'B', 'C'])
-        df1 = excel.parse('Sheet1', index_col=0, parse_dates=True,
-                         parse_cols=3)
-        df2 = excel.parse('Sheet2', skiprows=[1], index_col=0,
-                          parse_dates=True, parse_cols=3)
+        df1 = self.get_exceldf('test1', 'Sheet1', index_col=0, parse_dates=True,
+                               parse_cols=3)
+        df2 = self.get_exceldf('test1', 'Sheet2', skiprows=[1], index_col=0,
+                               parse_dates=True, parse_cols=3)
         # TODO add index to xls file)
         tm.assert_frame_equal(df1, dfref, check_names=False)
         tm.assert_frame_equal(df2, dfref, check_names=False)
 
     def test_parse_cols_list(self):
 
-        excel = self.get_excelfile('test1')
         dfref = self.get_csv_refdf('test1')
         dfref = dfref.reindex(columns=['B', 'C'])
-        df1 = excel.parse('Sheet1', index_col=0, parse_dates=True,
-                         parse_cols=[0, 2, 3])
-        df2 = excel.parse('Sheet2', skiprows=[1], index_col=0,
-                          parse_dates=True,
-                          parse_cols=[0, 2, 3])
+        df1 = self.get_exceldf('test1', 'Sheet1', index_col=0, parse_dates=True,
+                               parse_cols=[0, 2, 3])
+        df2 = self.get_exceldf('test1', 'Sheet2', skiprows=[1], index_col=0,
+                               parse_dates=True,
+                               parse_cols=[0, 2, 3])
         # TODO add index to xls file)
         tm.assert_frame_equal(df1, dfref, check_names=False)
         tm.assert_frame_equal(df2, dfref, check_names=False)
 
     def test_parse_cols_str(self):
 
-        excel = self.get_excelfile('test1')
         dfref = self.get_csv_refdf('test1')
 
         df1 = dfref.reindex(columns=['A', 'B', 'C'])
-        df2 = excel.parse('Sheet1', index_col=0, parse_dates=True,
-                         parse_cols='A:D')
-        df3 = excel.parse('Sheet2', skiprows=[1], index_col=0,
-                          parse_dates=True, parse_cols='A:D')
+        df2 = self.get_exceldf('test1', 'Sheet1', index_col=0, parse_dates=True,
+                               parse_cols='A:D')
+        df3 = self.get_exceldf('test1', 'Sheet2', skiprows=[1], index_col=0,
+                               parse_dates=True, parse_cols='A:D')
         # TODO add index to xls, read xls ignores index name ?
         tm.assert_frame_equal(df2, df1, check_names=False)
         tm.assert_frame_equal(df3, df1, check_names=False)
 
         df1 = dfref.reindex(columns=['B', 'C'])
-        df2 = excel.parse('Sheet1', index_col=0, parse_dates=True,
-                         parse_cols='A,C,D')
-        df3 = excel.parse('Sheet2', skiprows=[1], index_col=0,
-                          parse_dates=True,
-                          parse_cols='A,C,D')
+        df2 = self.get_exceldf('test1', 'Sheet1', index_col=0, parse_dates=True,
+                               parse_cols='A,C,D')
+        df3 = self.get_exceldf('test1', 'Sheet2', skiprows=[1], index_col=0,
+                               parse_dates=True, parse_cols='A,C,D')
         # TODO add index to xls file
         tm.assert_frame_equal(df2, df1, check_names=False)
         tm.assert_frame_equal(df3, df1, check_names=False)
 
         df1 = dfref.reindex(columns=['B', 'C'])
-        df2 = excel.parse('Sheet1', index_col=0, parse_dates=True,
-                         parse_cols='A,C:D')
-        df3 = excel.parse('Sheet2', skiprows=[1], index_col=0,
-                          parse_dates=True,
-                          parse_cols='A,C:D')
+        df2 = self.get_exceldf('test1', 'Sheet1', index_col=0, parse_dates=True,
+                               parse_cols='A,C:D')
+        df3 = self.get_exceldf('test1', 'Sheet2', skiprows=[1], index_col=0,
+                               parse_dates=True, parse_cols='A,C:D')
         tm.assert_frame_equal(df2, df1, check_names=False)
         tm.assert_frame_equal(df3, df1, check_names=False)
 
     def test_excel_stop_iterator(self):
 
-        excel = self.get_excelfile('test2')
-
-        parsed = excel.parse('Sheet1')
+        parsed = self.get_exceldf('test2', 'Sheet1')
         expected = DataFrame([['aaaa', 'bbbbb']], columns=['Test', 'Test1'])
         tm.assert_frame_equal(parsed, expected)
 
     def test_excel_cell_error_na(self):
 
-        excel = self.get_excelfile('test3')
-
-        parsed = excel.parse('Sheet1')
+        parsed = self.get_exceldf('test3', 'Sheet1')
         expected = DataFrame([[np.nan]], columns=['Test'])
         tm.assert_frame_equal(parsed, expected)
 
@@ -235,13 +226,13 @@ class ReadingTestsBase(SharedItems):
 
         excel = self.get_excelfile('test4')
 
-        parsed = excel.parse('Sheet1', keep_default_na=False,
+        parsed = read_excel(excel, 'Sheet1', keep_default_na=False,
                              na_values=['apple'])
         expected = DataFrame([['NA'], [1], ['NA'], [np.nan], ['rabbit']],
                              columns=['Test'])
         tm.assert_frame_equal(parsed, expected)
 
-        parsed = excel.parse('Sheet1', keep_default_na=True,
+        parsed = read_excel(excel, 'Sheet1', keep_default_na=True,
                              na_values=['apple'])
         expected = DataFrame([[np.nan], [1], [np.nan], [np.nan], ['rabbit']],
                              columns=['Test'])
@@ -252,10 +243,20 @@ class ReadingTestsBase(SharedItems):
         excel = self.get_excelfile('test1')
         dfref = self.get_csv_refdf('test1')
 
+        df1 = read_excel(excel, 0, index_col=0, parse_dates=True)
+        df2 = read_excel(excel, 1, skiprows=[1], index_col=0, parse_dates=True)
+        tm.assert_frame_equal(df1, dfref, check_names=False)
+        tm.assert_frame_equal(df2, dfref, check_names=False)
+
         df1 = excel.parse(0, index_col=0, parse_dates=True)
         df2 = excel.parse(1, skiprows=[1], index_col=0, parse_dates=True)
         tm.assert_frame_equal(df1, dfref, check_names=False)
         tm.assert_frame_equal(df2, dfref, check_names=False)
+
+        df3 = read_excel(excel, 0, index_col=0, parse_dates=True, skipfooter=1)
+        df4 = read_excel(excel, 0, index_col=0, parse_dates=True, skip_footer=1)
+        tm.assert_frame_equal(df3, df1.ix[:-1])
+        tm.assert_frame_equal(df3, df4)
 
         df3 = excel.parse(0, index_col=0, parse_dates=True, skipfooter=1)
         df4 = excel.parse(0, index_col=0, parse_dates=True, skip_footer=1)
@@ -263,24 +264,24 @@ class ReadingTestsBase(SharedItems):
         tm.assert_frame_equal(df3, df4)
 
         import xlrd
-        self.assertRaises(xlrd.XLRDError, excel.parse, 'asdf')
+        with tm.assertRaises(xlrd.XLRDError):
+            read_excel(excel, 'asdf')
 
     def test_excel_table(self):
 
-        excel = self.get_excelfile('test1')
         dfref = self.get_csv_refdf('test1')
 
-        df1 = excel.parse('Sheet1', index_col=0, parse_dates=True)
-        df2 = excel.parse('Sheet2', skiprows=[1], index_col=0,
-                          parse_dates=True)
+        df1 = self.get_exceldf('test1', 'Sheet1', index_col=0, parse_dates=True)
+        df2 = self.get_exceldf('test1', 'Sheet2', skiprows=[1], index_col=0,
+                               parse_dates=True)
         # TODO add index to file
         tm.assert_frame_equal(df1, dfref, check_names=False)
         tm.assert_frame_equal(df2, dfref, check_names=False)
 
-        df3 = excel.parse('Sheet1', index_col=0, parse_dates=True,
-                          skipfooter=1)
-        df4 = excel.parse('Sheet1', index_col=0, parse_dates=True,
-                          skip_footer=1)
+        df3 = self.get_exceldf('test1', 'Sheet1', index_col=0, parse_dates=True,
+                               skipfooter=1)
+        df4 = self.get_exceldf('test1', 'Sheet1', index_col=0, parse_dates=True,
+                               skip_footer=1)
         tm.assert_frame_equal(df3, df1.ix[:-1])
         tm.assert_frame_equal(df3, df4)
 
@@ -384,8 +385,6 @@ class ReadingTestsBase(SharedItems):
         tm.assert_frame_equal(actual, expected)
 
 
-
-
 class XlrdTests(ReadingTestsBase):
     """
     This is the base class for the xlrd tests, and 3 different file formats
@@ -395,10 +394,15 @@ class XlrdTests(ReadingTestsBase):
     def test_excel_read_buffer(self):
 
         pth = os.path.join(self.dirpath, 'test1' + self.ext)
-        f = open(pth, 'rb')
-        xls = ExcelFile(f)
-        # it works
-        xls.parse('Sheet1', index_col=0, parse_dates=True)
+        expected = read_excel(pth, 'Sheet1', index_col=0, parse_dates=True)
+        with open(pth, 'rb') as f:
+            actual = read_excel(f, 'Sheet1', index_col=0, parse_dates=True)
+            tm.assert_frame_equal(expected, actual)
+
+        with open(pth, 'rb') as f:
+            xls = ExcelFile(f)
+            actual = read_excel(xls, 'Sheet1', index_col=0, parse_dates=True)
+            tm.assert_frame_equal(expected, actual)
 
     def test_read_xlrd_Book(self):
         _skip_if_no_xlwt()
@@ -410,7 +414,7 @@ class XlrdTests(ReadingTestsBase):
             book = xlrd.open_workbook(pth)
 
             with ExcelFile(book, engine="xlrd") as xl:
-                result = xl.parse("SheetA")
+                result = read_excel(xl, "SheetA")
                 tm.assert_frame_equal(df, result)
 
             result = read_excel(book, sheetname="SheetA", engine="xlrd")
@@ -450,7 +454,7 @@ class XlrdTests(ReadingTestsBase):
         f = open(pth, 'rb')
         with ExcelFile(f) as xlsx:
             # parses okay
-            xlsx.parse('Sheet1', index_col=0)
+            read_excel(xlsx, 'Sheet1', index_col=0)
 
         self.assertTrue(f.closed)
 
@@ -650,6 +654,12 @@ class XlrdTests(ReadingTestsBase):
                 pd.read_excel(os.path.join(self.dirpath, 'test1' + self.ext),
                               header=arg)
 
+    def test_read_excel_chunksize(self):
+        #GH 8011
+        with tm.assertRaises(NotImplementedError):
+            pd.read_excel(os.path.join(self.dirpath, 'test1' + self.ext),
+                          chunksize=100)
+
 class XlsReaderTests(XlrdTests, tm.TestCase):
     ext = '.xls'
     engine_name = 'xlrd'
@@ -700,10 +710,11 @@ class ExcelWriterBase(SharedItems):
             gt = DataFrame(np.random.randn(10, 2))
             gt.to_excel(pth)
             xl = ExcelFile(pth)
-            df = xl.parse(0)
+            df = read_excel(xl, 0)
             tm.assert_frame_equal(gt, df)
 
-            self.assertRaises(xlrd.XLRDError, xl.parse, '0')
+            with tm.assertRaises(xlrd.XLRDError):
+                read_excel(xl, '0')
 
     def test_excelwriter_contextmanager(self):
         _skip_if_no_xlrd()
@@ -714,8 +725,8 @@ class ExcelWriterBase(SharedItems):
                 self.frame2.to_excel(writer, 'Data2')
 
             with ExcelFile(pth) as reader:
-                found_df = reader.parse('Data1')
-                found_df2 = reader.parse('Data2')
+                found_df = read_excel(reader, 'Data1')
+                found_df2 = read_excel(reader, 'Data2')
                 tm.assert_frame_equal(found_df, self.frame)
                 tm.assert_frame_equal(found_df2, self.frame2)
 
@@ -769,7 +780,7 @@ class ExcelWriterBase(SharedItems):
         with ensure_clean(self.ext) as path:
             self.mixed_frame.to_excel(path, 'test1')
             reader = ExcelFile(path)
-            recons = reader.parse('test1', index_col=0)
+            recons = read_excel(reader, 'test1', index_col=0)
             tm.assert_frame_equal(self.mixed_frame, recons)
 
     def test_tsframe(self):
@@ -780,7 +791,7 @@ class ExcelWriterBase(SharedItems):
         with ensure_clean(self.ext) as path:
             df.to_excel(path, 'test1')
             reader = ExcelFile(path)
-            recons = reader.parse('test1')
+            recons = read_excel(reader, 'test1')
             tm.assert_frame_equal(df, recons)
 
     def test_basics_with_nan(self):
@@ -804,7 +815,7 @@ class ExcelWriterBase(SharedItems):
                                   dtype=np_type)
                 frame.to_excel(path, 'test1')
                 reader = ExcelFile(path)
-                recons = reader.parse('test1')
+                recons = read_excel(reader, 'test1')
                 int_frame = frame.astype(np.int64)
                 tm.assert_frame_equal(int_frame, recons)
                 recons2 = read_excel(path, 'test1')
@@ -824,7 +835,7 @@ class ExcelWriterBase(SharedItems):
                 frame = DataFrame(np.random.random_sample(10), dtype=np_type)
                 frame.to_excel(path, 'test1')
                 reader = ExcelFile(path)
-                recons = reader.parse('test1').astype(np_type)
+                recons = read_excel(reader, 'test1').astype(np_type)
                 tm.assert_frame_equal(frame, recons, check_dtype=False)
 
     def test_bool_types(self):
@@ -836,7 +847,7 @@ class ExcelWriterBase(SharedItems):
                 frame = (DataFrame([1, 0, True, False], dtype=np_type))
                 frame.to_excel(path, 'test1')
                 reader = ExcelFile(path)
-                recons = reader.parse('test1').astype(np_type)
+                recons = read_excel(reader, 'test1').astype(np_type)
                 tm.assert_frame_equal(frame, recons)
 
     def test_inf_roundtrip(self):
@@ -846,7 +857,7 @@ class ExcelWriterBase(SharedItems):
         with ensure_clean(self.ext) as path:
             frame.to_excel(path, 'test1')
             reader = ExcelFile(path)
-            recons = reader.parse('test1')
+            recons = read_excel(reader, 'test1')
             tm.assert_frame_equal(frame, recons)
 
     def test_sheets(self):
@@ -866,9 +877,9 @@ class ExcelWriterBase(SharedItems):
             self.tsframe.to_excel(writer, 'test2')
             writer.save()
             reader = ExcelFile(path)
-            recons = reader.parse('test1', index_col=0)
+            recons = read_excel(reader, 'test1', index_col=0)
             tm.assert_frame_equal(self.frame, recons)
-            recons = reader.parse('test2', index_col=0)
+            recons = read_excel(reader, 'test2', index_col=0)
             tm.assert_frame_equal(self.tsframe, recons)
             np.testing.assert_equal(2, len(reader.sheet_names))
             np.testing.assert_equal('test1', reader.sheet_names[0])
@@ -889,7 +900,7 @@ class ExcelWriterBase(SharedItems):
             col_aliases = Index(['AA', 'X', 'Y', 'Z'])
             self.frame2.to_excel(path, 'test1', header=col_aliases)
             reader = ExcelFile(path)
-            rs = reader.parse('test1', index_col=0)
+            rs = read_excel(reader, 'test1', index_col=0)
             xp = self.frame2.copy()
             xp.columns = col_aliases
             tm.assert_frame_equal(xp, rs)
@@ -912,7 +923,7 @@ class ExcelWriterBase(SharedItems):
                            index_label=['test'],
                            merge_cells=self.merge_cells)
             reader = ExcelFile(path)
-            recons = reader.parse('test1',
+            recons = read_excel(reader, 'test1',
                                   index_col=0,
                                   ).astype(np.int64)
             frame.index.names = ['test']
@@ -924,7 +935,7 @@ class ExcelWriterBase(SharedItems):
                            index_label=['test', 'dummy', 'dummy2'],
                            merge_cells=self.merge_cells)
             reader = ExcelFile(path)
-            recons = reader.parse('test1',
+            recons = read_excel(reader, 'test1',
                                   index_col=0,
                                   ).astype(np.int64)
             frame.index.names = ['test']
@@ -936,7 +947,7 @@ class ExcelWriterBase(SharedItems):
                            index_label='test',
                            merge_cells=self.merge_cells)
             reader = ExcelFile(path)
-            recons = reader.parse('test1',
+            recons = read_excel(reader, 'test1',
                                   index_col=0,
                                   ).astype(np.int64)
             frame.index.names = ['test']
@@ -953,7 +964,7 @@ class ExcelWriterBase(SharedItems):
             df = df.set_index(['A', 'B'])
 
             reader = ExcelFile(path)
-            recons = reader.parse('test1', index_col=[0, 1])
+            recons = read_excel(reader, 'test1', index_col=[0, 1])
             tm.assert_frame_equal(df, recons, check_less_precise=True)
 
     def test_excel_roundtrip_indexname(self):
@@ -966,7 +977,7 @@ class ExcelWriterBase(SharedItems):
             df.to_excel(path, merge_cells=self.merge_cells)
 
             xf = ExcelFile(path)
-            result = xf.parse(xf.sheet_names[0],
+            result = read_excel(xf, xf.sheet_names[0],
                               index_col=0)
 
             tm.assert_frame_equal(result, df)
@@ -982,7 +993,7 @@ class ExcelWriterBase(SharedItems):
             tsf.index = [x.date() for x in self.tsframe.index]
             tsf.to_excel(path, 'test1', merge_cells=self.merge_cells)
             reader = ExcelFile(path)
-            recons = reader.parse('test1')
+            recons = read_excel(reader, 'test1')
             tm.assert_frame_equal(self.tsframe, recons)
 
     # GH4133 - excel output format strings
@@ -1015,8 +1026,8 @@ class ExcelWriterBase(SharedItems):
                 reader1 = ExcelFile(filename1)
                 reader2 = ExcelFile(filename2)
 
-                rs1 = reader1.parse('test1', index_col=None)
-                rs2 = reader2.parse('test1', index_col=None)
+                rs1 = read_excel(reader1, 'test1', index_col=None)
+                rs2 = read_excel(reader2, 'test1', index_col=None)
 
                 tm.assert_frame_equal(rs1, rs2)
 
@@ -1034,7 +1045,7 @@ class ExcelWriterBase(SharedItems):
             xp.to_excel(path, 'sht1')
 
             reader = ExcelFile(path)
-            rs = reader.parse('sht1', index_col=0, parse_dates=True)
+            rs = read_excel(reader, 'sht1', index_col=0, parse_dates=True)
             tm.assert_frame_equal(xp, rs.to_period('M'))
 
     def test_to_excel_multiindex(self):
@@ -1053,7 +1064,7 @@ class ExcelWriterBase(SharedItems):
             # round trip
             frame.to_excel(path, 'test1', merge_cells=self.merge_cells)
             reader = ExcelFile(path)
-            df = reader.parse('test1', index_col=[0, 1],
+            df = read_excel(reader, 'test1', index_col=[0, 1],
                               parse_dates=False)
             tm.assert_frame_equal(frame, df)
             self.assertEqual(frame.index.names, df.index.names)
@@ -1070,7 +1081,7 @@ class ExcelWriterBase(SharedItems):
             tsframe.index.names = ['time', 'foo']
             tsframe.to_excel(path, 'test1', merge_cells=self.merge_cells)
             reader = ExcelFile(path)
-            recons = reader.parse('test1',
+            recons = read_excel(reader, 'test1',
                                   index_col=[0, 1])
 
             tm.assert_frame_equal(tsframe, recons)
@@ -1096,7 +1107,7 @@ class ExcelWriterBase(SharedItems):
 
             # Read it back in.
             reader = ExcelFile(path)
-            frame3 = reader.parse('test1')
+            frame3 = read_excel(reader, 'test1')
 
             # Test that it is the same as the initial frame.
             tm.assert_frame_equal(frame1, frame3)
@@ -1112,7 +1123,7 @@ class ExcelWriterBase(SharedItems):
             df.to_excel(filename, 'test1', float_format='%.2f')
 
             reader = ExcelFile(filename)
-            rs = reader.parse('test1', index_col=None)
+            rs = read_excel(reader, 'test1', index_col=None)
             xp = DataFrame([[0.12, 0.23, 0.57],
                             [12.32, 123123.20, 321321.20]],
                             index=['A', 'B'], columns=['X', 'Y', 'Z'])
@@ -1148,7 +1159,7 @@ class ExcelWriterBase(SharedItems):
             df.to_excel(filename, 'test1', float_format='%.2f')
 
             reader = ExcelFile(filename)
-            rs = reader.parse('test1', index_col=None)
+            rs = read_excel(reader, 'test1', index_col=None)
             xp = DataFrame([[0.12, 0.23, 0.57],
                             [12.32, 123123.20, 321321.20]],
                             index=['A', 'B'], columns=['X', 'Y', 'Z'])
@@ -1270,7 +1281,7 @@ class ExcelWriterBase(SharedItems):
             with ensure_clean(self.ext) as path:
                 df.to_excel(path, header=header, merge_cells=self.merge_cells, index=index)
                 xf = ExcelFile(path)
-                res = xf.parse(xf.sheet_names[0], header=parser_hdr)
+                res = read_excel(xf, xf.sheet_names[0], header=parser_hdr)
                 return res
 
         nrows = 5
@@ -1324,7 +1335,7 @@ class ExcelWriterBase(SharedItems):
             with ensure_clean(self.ext) as path:
                 df.to_excel(path, header=header, merge_cells=self.merge_cells, index=index)
                 xf = ExcelFile(path)
-                res = xf.parse(xf.sheet_names[0], header=parser_hdr)
+                res = read_excel(xf, xf.sheet_names[0], header=parser_hdr)
                 return res
 
         nrows = 5; ncols = 3


### PR DESCRIPTION
Replace the `**kwds` in `read_excel` with the actual list of supported keyword args. This doesn't
change any functionality, just nicer for interactive use.  Also a bit of clarification on the `thousands`
arg in the docstring.

Additionally, `chunksize` was a parameter in the `ExcelFile.parse` signature, but didn't do anything (xref #8011).  I removed this and raise `NotImplementedError` if passed, which is potentially breaking.
