### PR TITLE
Fixed pandas.DataFrame().join() function.

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4175,7 +4175,7 @@ class DataFrame(NDFrame):
         return concat(to_concat, ignore_index=ignore_index,
                       verify_integrity=verify_integrity)
 
-    def join(self, other, on=None, how='left', lsuffix='', rsuffix='',
+    def join(self, other, on=None, left_on=None, right_on=None, how='left', lsuffix='', rsuffix='',
              sort=False):
         """
         Join columns with other DataFrame either on index or on a key
@@ -4193,6 +4193,10 @@ class DataFrame(NDFrame):
             columns given, the passed DataFrame must have a MultiIndex. Can
             pass an array as the join key if not already contained in the
             calling DataFrame. Like an Excel VLOOKUP operation
+        left_on : column name, tuple/list of column names, or array-like
+            Column(s) to use for joining, otherwise join on index.
+        right_on : column name, tuple/list of column names, or array-like
+            Column(s) to use for joining, otherwise join on index.    
         how : {'left', 'right', 'outer', 'inner'}
             How to handle indexes of the two objects. Default: 'left'
             for joining on index, None otherwise
@@ -4219,10 +4223,10 @@ class DataFrame(NDFrame):
         joined : DataFrame
         """
         # For SparseDataFrame's benefit
-        return self._join_compat(other, on=on, how=how, lsuffix=lsuffix,
+        return self._join_compat(other, on=on, left_on=None, right_on=None, how=how, lsuffix=lsuffix,
                                  rsuffix=rsuffix, sort=sort)
 
-    def _join_compat(self, other, on=None, how='left', lsuffix='', rsuffix='',
+    def _join_compat(self, other, on=None, left_on=None, right_on=None, how='left', lsuffix='', rsuffix='',
                      sort=False):
         from pandas.tools.merge import merge, concat
 
@@ -4232,8 +4236,9 @@ class DataFrame(NDFrame):
             other = DataFrame({other.name: other})
 
         if isinstance(other, DataFrame):
-            return merge(self, other, left_on=on, how=how,
-                         left_index=on is None, right_index=True,
+            return merge(self, other, left_on=on, right_on=on, how=how,
+                         left_index=((on is None) and (left_on is None)),
+                         right_index=((on is None and right_on is None)),
                          suffixes=(lsuffix, rsuffix), sort=sort)
         else:
             if on is not None:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4223,7 +4223,7 @@ class DataFrame(NDFrame):
         joined : DataFrame
         """
         # For SparseDataFrame's benefit
-        return self._join_compat(other, on=on, left_on=None, right_on=None, how=how, lsuffix=lsuffix,
+        return self._join_compat(other, on=on, left_on=left_on, right_on=right_on, how=how, lsuffix=lsuffix,
                                  rsuffix=rsuffix, sort=sort)
 
     def _join_compat(self, other, on=None, left_on=None, right_on=None, how='left', lsuffix='', rsuffix='',
@@ -4236,9 +4236,12 @@ class DataFrame(NDFrame):
             other = DataFrame({other.name: other})
 
         if isinstance(other, DataFrame):
-            return merge(self, other, left_on=on, right_on=on, how=how,
+            if left_on  == None and on != None: left_on = on
+            if right_on == None and on != None: right_on = on
+
+            return merge(self, other, left_on=left_on, right_on=right_on, how=how,
                          left_index=((on is None) and (left_on is None)),
-                         right_index=((on is None and right_on is None)),
+                         right_index=((on is None) and (right_on is None)),
                          suffixes=(lsuffix, rsuffix), sort=sort)
         else:
             if on is not None:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4240,6 +4240,12 @@ class DataFrame(NDFrame):
                 left_on = on
             if right_on == None and on != None:
                 right_on = on
+
+            '''Workaround to preserve the documented behavior of join()'''
+            if right_on == None and left_on == None and on != None:
+                left_on = on
+                on = None
+
             return merge(self, other, left_on=left_on, right_on=right_on, how=how,
                          left_index=((on is None) and (left_on is None)),
                          right_index=((on is None) and (right_on is None)),

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4236,9 +4236,10 @@ class DataFrame(NDFrame):
             other = DataFrame({other.name: other})
 
         if isinstance(other, DataFrame):
-            if left_on  == None and on != None: left_on = on
-            if right_on == None and on != None: right_on = on
-
+            if left_on == None and on != None:
+                left_on = on
+            if right_on == None and on != None:
+                right_on = on
             return merge(self, other, left_on=left_on, right_on=right_on, how=how,
                          left_index=((on is None) and (left_on is None)),
                          right_index=((on is None) and (right_on is None)),


### PR DESCRIPTION
Added on_right and on_left keywords.
Now a right.join(left,on=key) works as expected.

Old behavior is archived by right.join(left,left_on=key) 

Tested multi-index funtionallity.

```
import pandas as pd
from copy import copy
print pd.__file__
left = pd.DataFrame({'A': ['A0', 'A1', 'A2', 'A3','A4'],
                   'key': ['K0', 'K1', 'K3', 'K4','K5']})
right = pd.DataFrame({'C': ['C0', 'C1', 'C2', 'C3'],
                   'key': ['K0', 'K2', 'K1', 'K3']},
                    index=[4,5,6,7])

print left.join(right,on='key',how="outer",rsuffix="_r")
```

Old result:

```
     A key    C key_r
0   A0  K0  NaN   NaN
1   A1  K1  NaN   NaN
2   A2  K3  NaN   NaN
3   A3  K4  NaN   NaN
4   A4  K5  NaN   NaN
4  NaN   4   C0    K0
4  NaN   5   C1    K2
4  NaN   6   C2    K1
4  NaN   7   C3    K3
```

New result:

```
     A key    C
0   A0  K0   C0
1   A1  K1   C2
2   A2  K3   C3
3   A3  K4  NaN
4   A4  K5  NaN
5  NaN  K2   C1
```
