### PR TITLE
PERF: vectorized DateOffset with months

### DIFF
--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -1056,6 +1056,7 @@ Performance Improvements
 - 2x improvement of ``Series.value_counts`` for float dtype (:issue:`10821`)
 - Enable ``infer_datetime_format`` in ``to_datetime`` when date components do not have 0 padding (:issue:`11142`)
 - Regression from 0.16.1 in constructing ``DataFrame`` from nested dictionary (:issue:`11084`)
+- Performance improvements in addition/subtraction operations for ``DateOffset`` with ``Series`` or ``DatetimeIndex``  (issue:`10744`, :issue:`11205`)
 
 .. _whatsnew_0170.bug_fixes:
 

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -2565,32 +2565,32 @@ class TestDatetimeIndex(tm.TestCase):
         for klass, assert_func in zip([Series, DatetimeIndex],
                                       [self.assert_series_equal,
                                        tm.assert_index_equal]):
-            s = klass(date_range('2000-01-01', '2000-01-31'))
+            s = klass(date_range('2000-01-01', '2000-01-31'), name='a')
             result = s + pd.DateOffset(years=1)
             result2 = pd.DateOffset(years=1) + s
-            exp = klass(date_range('2001-01-01', '2001-01-31'))
+            exp = klass(date_range('2001-01-01', '2001-01-31'), name='a')
             assert_func(result, exp)
             assert_func(result2, exp)
 
             result = s - pd.DateOffset(years=1)
-            exp = klass(date_range('1999-01-01', '1999-01-31'))
+            exp = klass(date_range('1999-01-01', '1999-01-31'), name='a')
             assert_func(result, exp)
 
             s = klass([Timestamp('2000-01-15 00:15:00', tz='US/Central'),
-                       pd.Timestamp('2000-02-15', tz='US/Central')])
+                       pd.Timestamp('2000-02-15', tz='US/Central')], name='a')
             result = s + pd.offsets.Day()
             result2 = pd.offsets.Day() + s
             exp = klass([Timestamp('2000-01-16 00:15:00', tz='US/Central'),
-                         Timestamp('2000-02-16', tz='US/Central')])
+                         Timestamp('2000-02-16', tz='US/Central')], name='a')
             assert_func(result, exp)
             assert_func(result2, exp)
 
             s = klass([Timestamp('2000-01-15 00:15:00', tz='US/Central'),
-                       pd.Timestamp('2000-02-15', tz='US/Central')])
+                       pd.Timestamp('2000-02-15', tz='US/Central')], name='a')
             result = s + pd.offsets.MonthEnd()
             result2 = pd.offsets.MonthEnd() + s
             exp = klass([Timestamp('2000-01-31 00:15:00', tz='US/Central'),
-                         Timestamp('2000-02-29', tz='US/Central')])
+                         Timestamp('2000-02-29', tz='US/Central')], name='a')
             assert_func(result, exp)
             assert_func(result2, exp)
 

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -949,6 +949,17 @@ class TestTslib(tm.TestCase):
                                   tslib.maybe_get_tz('Asia/Tokyo'))
         self.assert_numpy_array_equal(result, np.array([tslib.iNaT], dtype=np.int64))
 
+    def test_shift_months(self):
+        s = DatetimeIndex([Timestamp('2000-01-05 00:15:00'), Timestamp('2000-01-31 00:23:00'),
+                           Timestamp('2000-01-01'), Timestamp('2000-02-29'), Timestamp('2000-12-31')])
+        for years in [-1, 0, 1]:
+            for months in [-2, 0, 2]:
+                actual = DatetimeIndex(tslib.shift_months(s.asi8, years * 12 + months))
+                expected = DatetimeIndex([x + offsets.DateOffset(years=years, months=months) for x in s])
+                tm.assert_index_equal(actual, expected)
+
+
+
 class TestTimestampOps(tm.TestCase):
     def test_timestamp_and_datetime(self):
         self.assertEqual((Timestamp(datetime.datetime(2013, 10, 13)) - datetime.datetime(2013, 10, 12)).days, 1)


### PR DESCRIPTION
This is a follow-up to https://github.com/pydata/pandas/pull/10744.  In that, vectorized versions of some offsets were implemented, mostly by changing to periods and back.  

The case of shifting by years/months (which is actually most useful to me) required some extra hoops and had poorer performance - this PR implements a special cython routine for that, for about a 10x improvement. 

```
In [3]: s = pd.Series(pd.date_range('1900-1-1', periods=100000))

# Master
In [4]: %timeit s + pd.DateOffset(months=1)
1 loops, best of 3: 140 ms per loop

# PR
In [2]: %timeit s + pd.DateOffset(months=1)
100 loops, best of 3: 14.2 ms per loo
```
