### PR TITLE
defer or remove loading of openhub in docs

### DIFF
--- a/doc/source/themes/nature_with_gtoc/layout.html
+++ b/doc/source/themes/nature_with_gtoc/layout.html
@@ -38,7 +38,7 @@ by Andi Albrecht.
 
                 <p>
                     <script type="text/javascript"
-                            src="http://www.ohloh.net/p/482908/widgets/project_partner_badge.js"></script>
+                            src="http://www.ohloh.net/p/482908/widgets/project_partner_badge.js" defer></script>
                 </p>
             </div>
             {%- endblock %}

--- a/doc/source/themes/nature_with_gtoc/layout.html
+++ b/doc/source/themes/nature_with_gtoc/layout.html
@@ -34,12 +34,6 @@ by Andi Albrecht.
                     {{ _('Enter search terms or a module, class or function name.') }}
                 </p>
 
-                <p>
-
-                <p>
-                    <script type="text/javascript"
-                            src="http://www.ohloh.net/p/482908/widgets/project_partner_badge.js" defer></script>
-                </p>
             </div>
             {%- endblock %}
             {# possible location for sidebar #} {% endblock %}


### PR DESCRIPTION
Their service was slowing down the loading of our docs. I've added a defer tag so that our docs load first.

Or we can delete that entirely, anyone know why it's in there to begin with?
