### PR TITLE
squeeze works on 0 length arrays

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -42,3 +42,5 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
+
+- Bug in ``squeeze()`` with zero length arrays (:issue:`11230`, :issue:`8999`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -513,7 +513,7 @@ class NDFrame(PandasObject):
     def squeeze(self):
         """ squeeze length 1 dimensions """
         try:
-            return self.ix[tuple([slice(None) if len(a) > 1 else a[0]
+            return self.iloc[tuple([0 if len(a) == 1 else slice(None)
                                   for a in self.axes])]
         except:
             return self

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -1717,6 +1717,15 @@ class TestNDFrame(tm.TestCase):
         p4d = tm.makePanel4D().reindex(labels=['label1'],items=['ItemA'])
         tm.assert_frame_equal(p4d.squeeze(),p4d.ix['label1','ItemA'])
 
+        # don't fail with 0 length dimensions GH11229 & GH8999
+        empty_series=pd.Series([], name='five')
+        empty_frame=pd.DataFrame([empty_series])
+        empty_panel=pd.Panel({'six':empty_frame})
+
+        [tm.assert_series_equal(empty_series, higher_dim.squeeze())
+         for higher_dim in [empty_series, empty_frame, empty_panel]]
+
+
     def test_equals(self):
         s1 = pd.Series([1, 2, 3], index=[0, 2, 1])
         s2 = s1.copy()


### PR DESCRIPTION
fixes: https://github.com/pydata/pandas/issues/11229.
fixes: https://github.com/pydata/pandas/issues/8999.

Also a better implementation that avoids `ix`

Should I add to What's new for 0.17? Or is that closed now?
