### PR TITLE
BUG: to_excel duplicate columns

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -70,3 +70,7 @@ Bug Fixes
 
 
 - Bug in ``DataFrame.to_latex()`` produces an extra rule when ``header=False`` (:issue:`7124`)
+
+
+
+- Bugs in ``to_excel`` with duplicate columns (:issue:`11007`, :issue:`10982`, :issue:`10970`)

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -1683,12 +1683,12 @@ class ExcelFormatter(object):
     def __init__(self, df, na_rep='', float_format=None, cols=None,
                  header=True, index=True, index_label=None, merge_cells=False,
                  inf_rep='inf'):
-        self.df = df
         self.rowcounter = 0
         self.na_rep = na_rep
-        self.columns = cols
-        if cols is None:
-            self.columns = df.columns
+        self.df = df
+        if cols is not None:
+            self.df = df.loc[:, cols]
+        self.columns = self.df.columns
         self.float_format = float_format
         self.index = index
         self.index_label = index_label
@@ -1843,12 +1843,9 @@ class ExcelFormatter(object):
             for idx, idxval in enumerate(index_values):
                 yield ExcelCell(self.rowcounter + idx, 0, idxval, header_style)
 
-        # Get a frame that will account for any duplicates in the column names.
-        col_mapped_frame = self.df.loc[:, self.columns]
-
         # Write the body of the frame data series by series.
         for colidx in range(len(self.columns)):
-            series = col_mapped_frame.iloc[:, colidx]
+            series = self.df.iloc[:, colidx]
             for i, val in enumerate(series):
                 yield ExcelCell(self.rowcounter + i, colidx + coloffset, val)
 
@@ -1917,12 +1914,9 @@ class ExcelFormatter(object):
                                         header_style)
                     gcolidx += 1
 
-        # Get a frame that will account for any duplicates in the column names.
-        col_mapped_frame = self.df.loc[:, self.columns]
-
         # Write the body of the frame data series by series.
         for colidx in range(len(self.columns)):
-            series = col_mapped_frame.iloc[:, colidx]
+            series = self.df.iloc[:, colidx]
             for i, val in enumerate(series):
                 yield ExcelCell(self.rowcounter + i, gcolidx + colidx, val)
 


### PR DESCRIPTION
closes #11007 
closes #10970 (data in wrong order)
closes #10982 (columns lost).    

Using the approach suggested [here](https://github.com/pydata/pandas/issues/11007#issuecomment-141019207)

All three occurred when using `to_excel` with duplicate columns in the `DataFrame`
