### PR TITLE
DOC: clarify requirements for read_stata's args

### DIFF
--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -74,7 +74,7 @@ _read_stata_doc = """Read Stata file into DataFrame
 Parameters
 ----------
 filepath_or_buffer : string or file-like object
-    Path to .dta file or object implementing a binary read() functions
+    Path to .dta file or object implementing a binary read() and seek() functions
 %s
 %s
 %s


### PR DESCRIPTION
read_stata(buf) needs a buf which implements both read() and seek(). read() is not enough. For example, the object returned from zipfile.ZipFile.open('filename') only provides read() and not seek() and cannot be used.
