### PR TITLE
BUG: datetime64 series reduces to nan when empty instead of nat

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -28,6 +28,9 @@ Other Enhancements
 API changes
 ~~~~~~~~~~~
 
+- min and max reductions on ``datetime64`` and ``timedelta64`` dtyped series now
+  result in ``NaT`` and not ``nan`` (:issue:`11245`).
+
 .. _whatsnew_0171.deprecations:
 
 Deprecations
@@ -74,3 +77,5 @@ Bug Fixes
 
 
 - Bugs in ``to_excel`` with duplicate columns (:issue:`11007`, :issue:`10982`, :issue:`10970`)
+- Fixed a bug that prevented the construction of an empty series of dtype
+  ``datetime64[ns, tz]`` (:issue:`11245`).

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1927,12 +1927,11 @@ def _possibly_cast_to_datetime(value, dtype, errors='raise'):
                     value = tslib.iNaT
 
                 # we have an array of datetime or timedeltas & nulls
-                elif np.prod(value.shape) and not is_dtype_equal(value.dtype, dtype):
+                elif np.prod(value.shape) or not is_dtype_equal(value.dtype, dtype):
                     try:
                         if is_datetime64:
                             value = to_datetime(value, errors=errors)._values
                         elif is_datetime64tz:
-
                             # input has to be UTC at this point, so just localize
                             value = to_datetime(value, errors=errors).tz_localize(dtype.tz)
                         elif is_timedelta64:

--- a/pandas/core/dtypes.py
+++ b/pandas/core/dtypes.py
@@ -138,7 +138,7 @@ class DatetimeTZDtype(ExtensionDtype):
     num = 101
     base = np.dtype('M8[ns]')
     _metadata = ['unit','tz']
-    _match = re.compile("datetime64\[(?P<unit>.+), (?P<tz>.+)\]")
+    _match = re.compile("(datetime64|M8)\[(?P<unit>.+), (?P<tz>.+)\]")
 
     def __init__(self, unit, tz=None):
         """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4624,7 +4624,7 @@ class DataFrame(NDFrame):
                 values = self.values
             result = f(values)
 
-        if is_object_dtype(result.dtype):
+        if hasattr(result, 'dtype') and is_object_dtype(result.dtype):
             try:
                 if filter_type is None or filter_type == 'numeric':
                     result = result.astype(np.float64)

--- a/pandas/tests/test_dtypes.py
+++ b/pandas/tests/test_dtypes.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from itertools import product
 
 import nose
 import numpy as np
@@ -147,6 +148,15 @@ class TestDatetimeTZDtype(Base, tm.TestCase):
         s2 = Series(dr2, name='A')
         self.assertTrue(is_datetimetz(s2))
         self.assertEqual(s1.dtype, s2.dtype)
+
+    def test_parser(self):
+        # pr #11245
+        for tz, constructor in product(('UTC', 'US/Eastern'),
+                                       ('M8', 'datetime64')):
+            self.assertEqual(
+                DatetimeTZDtype('%s[ns, %s]' % (constructor, tz)),
+                DatetimeTZDtype('ns', tz),
+            )
 
 
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -7960,6 +7960,12 @@ class TestSeriesNonUnique(tm.TestCase):
         self.assertTrue(pd.isnull(Series([],dtype='M8[ns]').quantile(.5)))
         self.assertTrue(pd.isnull(Series([],dtype='m8[ns]').quantile(.5)))
 
+    def test_empty_timeseries_redections_return_nat(self):
+        # covers #11245
+        for dtype in ('m8[ns]', 'm8[ns]', 'M8[ns]', 'M8[ns, UTC]'):
+            self.assertIs(Series([], dtype=dtype).min(), pd.NaT)
+            self.assertIs(Series([], dtype=dtype).max(), pd.NaT)
+
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
                    exit=False)


### PR DESCRIPTION
I ran into some strange behavior with a series of dtype datetime64[ns] where I called max and got back a `nan`. I think the correct behavior here is to return `nat`. I looked through test_nanops but I am not sure where the correct place to put the test for this is.

The new behavior is:

``` python
In [1]: pd.Series(dtype='datetime64[ns]').max()
Out[1]: NaT
```

where the old behavior was:

``` python
In [1]: pd.Series(dtype='datetime64[ns]').max()
Out[1]: nan
```
