### PR TITLE
added random_split in generic.py, for DataFrames etc.

### DIFF
--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -6,7 +6,7 @@ import numpy as np
 from pandas.core.algorithms import factorize, match, unique, value_counts
 from pandas.core.common import isnull, notnull
 from pandas.core.categorical import Categorical
-from pandas.core.groupby import Grouper
+from pandas.core.groupby import Grouper, RandomGrouper, OrderedGrouper
 from pandas.core.format import set_eng_float_format
 from pandas.core.index import Index, CategoricalIndex, Int64Index, Float64Index, MultiIndex
 

--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -6,7 +6,7 @@ import numpy as np
 from pandas.core.algorithms import factorize, match, unique, value_counts
 from pandas.core.common import isnull, notnull
 from pandas.core.categorical import Categorical
-from pandas.core.groupby import Grouper, RandomGrouper, OrderedGrouper
+from pandas.core.groupby import Grouper, RandomPartitioner, Partitioner
 from pandas.core.format import set_eng_float_format
 from pandas.core.index import Index, CategoricalIndex, Int64Index, Float64Index, MultiIndex
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2036,8 +2036,7 @@ class NDFrame(PandasObject):
             return self
         return self.iloc[-n:]
 
-
-    def random_split(self, weights=(50,50), random_state=None, axis=None):
+    def split(self, weights=(50, 50), random=False, axis=None):
         """
         Returns a random split from an axis of this object
 
@@ -2047,9 +2046,11 @@ class NDFrame(PandasObject):
             The passed collection of weights serves as relative sizes of the splits
             of the returned datasets.
             Default = (50,50).
-        random_state : int or numpy.random.RandomState, optional
-            Seed for the random number generator (if int), or numpy RandomState
-            object.
+        random : boolean or int or numpy.random.RandomState, optional
+            If False (=default value), makes consecutive splits from beginning to end.
+            If not False, a seed for the random number generator can be provided (if int) or
+            a numpy RandomState object. If True, default random behavior.
+            Default = False.
         axis : int or string, optional
             Axis to sample. Accepts axis number or name. Default is stat axis
             for given data type (0 for Series and DataFrames, 1 for Panels).
@@ -2066,7 +2067,12 @@ class NDFrame(PandasObject):
         axis_length = self.shape[axis]
 
         # Process random_state argument
-        rs = com._random_state(random_state)
+
+        if random is not None and random is not False:
+            random_state = random
+            if random_state is True:
+                random_state = None
+            rs = com._random_state(random_state)
 
         # check weight type
         if len(weights) < 2:
@@ -2088,8 +2094,10 @@ class NDFrame(PandasObject):
         thresholds = thresholds + [axis_length]
 
         idxs = range(axis_length)
-        rs.shuffle(idxs)
+        if random is not None and random is not False:
+            rs.shuffle(idxs)
 
+        # TODO: maybe more efficient way exists? maybe with generators?
         splits = []
         for ti in range(1, len(thresholds)):
             idxst = idxs[thresholds[ti-1]:thresholds[ti]]

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2060,11 +2060,11 @@ class NDFrame(PandasObject):
         Multiple objects of the same type as original object. The number of returned objects
         is the same as the number of weights provided as parameter.
         """
-        g = pd.OrderedGrouper(weights, axis)
+        g = pd.Partitioner(weights, axis)
         if random is not False and random is not None:
             if random is True:
                 random = None
-            g = pd.RandomGrouper(weights, axis, random)
+            g = pd.RandomPartitioner(weights, axis, random)
         return self.groupby(g).split()
 
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -317,9 +317,6 @@ class OrderedGrouper(Grouper):
         super(OrderedGrouper, self).__init__()
 
     def _get_grouper(self, obj):
-        return self._go_get_grouper(obj)
-
-    def _go_get_grouper(self, obj):
         if self._axis is None:
             self._axis = obj._stat_axis_number
         self._axis = obj._get_axis_number(self._axis)

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -354,11 +354,11 @@ class Generic(object):
             self._compare(o.head(-3), o.head(7))
             self._compare(o.tail(-3), o.tail(7))
 
-    def test_random_split(self):
+    def test_split(self):
         o = self._construct(shape=10)
-        a, b = o.random_split((1,1))
-        self.assertTrue(len(a) == 5)
-        self.assertTrue(len(b) == 5)
+        a, b = o.split((1, 1), axis=0, random=True)
+        self.assertTrue(a.shape[0] == 5)
+        self.assertTrue(b.shape[0] == 5)
 
     def test_sample(self):
         # Fixes issue: 2419

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -354,6 +354,12 @@ class Generic(object):
             self._compare(o.head(-3), o.head(7))
             self._compare(o.tail(-3), o.tail(7))
 
+    def test_random_split(self):
+        o = self._construct(shape=10)
+        a, b = o.random_split((1,1))
+        self.assertTrue(len(a) == 5)
+        self.assertTrue(len(b) == 5)
+
     def test_sample(self):
         # Fixes issue: 2419
 

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -400,15 +400,12 @@ class TestGroupBy(tm.TestCase):
         assert_frame_equal(result, expected)
 
     def test_grouper_random(self):
-        print("testing random grouper")
         df = DataFrame({"A": [0,1,2,3,4,5], "b": [10,11,12,13,14,15]})
         g = df.groupby(pd.RandomGrouper((1,2)))
         a, b = g.split()
         assert_frame_equal(df, df)
 
     def test_grouper_creation_bug(self):
-        #self.test_grouper_random() # TODO remove
-
         # GH 8795
         df = DataFrame({'A':[0,0,1,1,2,2], 'B':[1,2,3,4,5,6]})
         g = df.groupby('A')

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -399,7 +399,15 @@ class TestGroupBy(tm.TestCase):
                              pd.Grouper(level=1, freq='W')]).sum()
         assert_frame_equal(result, expected)
 
+    def test_grouper_random(self):
+        print("testing random grouper")
+        df = DataFrame({"A": [0,1,2,3,4,5], "b": [10,11,12,13,14,15]})
+        g = df.groupby(pd.RandomGrouper((1,2)))
+        a, b = g.split()
+        assert_frame_equal(df, df)
+
     def test_grouper_creation_bug(self):
+        #self.test_grouper_random() # TODO remove
 
         # GH 8795
         df = DataFrame({'A':[0,0,1,1,2,2], 'B':[1,2,3,4,5,6]})

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -401,7 +401,7 @@ class TestGroupBy(tm.TestCase):
 
     def test_grouper_random(self):
         df = DataFrame({"A": [0,1,2,3,4,5], "b": [10,11,12,13,14,15]})
-        g = df.groupby(pd.RandomGrouper((1,2)))
+        g = df.groupby(pd.RandomPartitioner((1,2)))
         a, b = g.split()
         assert_frame_equal(df, df)
 


### PR DESCRIPTION
Added a method random_split() for NDFrames, to split the Frame into several frames according to one axis. 

Basic use: for train/test or train/validation/test splitting of a dataframe.

Note: I'm not sure this feature fits well in NDFrame. If you think this feature can be added, I'll add more tests and docs.
