### PR TITLE
DOC: some hacks to get rid of warnings

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -611,7 +611,7 @@ strings and apply several methods to it. These can be acccessed like
 
 ..
     The following is needed to ensure the generated pages are created with the
-    correct template (otherwise they would be created in the Series class page)
+    correct template (otherwise they would be created in the Series/Index class page)
 
 ..
     .. autosummary::
@@ -621,6 +621,10 @@ strings and apply several methods to it. These can be acccessed like
        Series.str
        Series.cat
        Series.dt
+       Index.str
+       CategoricalIndex.str
+       DatetimeIndex.str
+       TimedeltaIndex.str
 
 
 .. _api.categorical:

--- a/doc/sphinxext/numpydoc/docscrape_sphinx.py
+++ b/doc/sphinxext/numpydoc/docscrape_sphinx.py
@@ -115,11 +115,13 @@ class SphinxDocString(NumpyDocString):
                         or inspect.isgetsetdescriptor(param_obj)):
                     param_obj = None
 
-                if param_obj and (pydoc.getdoc(param_obj) or not desc):
-                    # Referenced object has a docstring
-                    autosum += ["   %s%s" % (prefix, param)]
-                else:
-                    others.append((param, param_type, desc))
+                # pandas HACK - do not exclude attributes wich are None
+                # if param_obj and (pydoc.getdoc(param_obj) or not desc):
+                #     # Referenced object has a docstring
+                #     autosum += ["   %s%s" % (prefix, param)]
+                # else:
+                #     others.append((param, param_type, desc))
+                autosum += ["   %s%s" % (prefix, param)]
 
             if autosum:
                 out += ['.. autosummary::']

--- a/doc/sphinxext/numpydoc/docscrape_sphinx.py
+++ b/doc/sphinxext/numpydoc/docscrape_sphinx.py
@@ -19,6 +19,7 @@ class SphinxDocString(NumpyDocString):
     def load_config(self, config):
         self.use_plots = config.get('use_plots', False)
         self.class_members_toctree = config.get('class_members_toctree', True)
+        self.class_members_list = config.get('class_members_list', True)
 
     # string conversion routines
     def _str_header(self, name, symbol='`'):
@@ -95,7 +96,7 @@ class SphinxDocString(NumpyDocString):
 
         """
         out = []
-        if self[name]:
+        if self[name] and self.class_members_list:
             out += ['.. rubric:: %s' % name, '']
             prefix = getattr(self, '_name', '')
 

--- a/doc/sphinxext/numpydoc/numpydoc.py
+++ b/doc/sphinxext/numpydoc/numpydoc.py
@@ -42,6 +42,10 @@ def mangle_docstrings(app, what, name, obj, options, lines,
                class_members_toctree=app.config.numpydoc_class_members_toctree,
               )
 
+    # PANDAS HACK (to remove the list of methods/attributes for Categorical)
+    if what == "class" and name.endswith(".Categorical"):
+        cfg['class_members_list'] = False
+
     if what == 'module':
         # Strip top title
         title_re = re.compile(sixu('^\\s*[#*=]{4,}\\n[a-z0-9 -]+\\n[#*=]{4,}\\s*'),


### PR DESCRIPTION
This PR includes some hacks to numpydoc to get rid of a bunch of warnings (split of from https://github.com/pydata/pandas/pull/11069 as I want these merged for 0.17.0). There is some more explanation in the commit messages.

Closes #6100

The disadvantage of this is that this causes a deviation from numpydoc upstream, and makes it more difficult to update to that one.
