### PR TITLE
DOC: Included halflife as one 3 optional params that must be specified

### DIFF
--- a/pandas/stats/moments.py
+++ b/pandas/stats/moments.py
@@ -97,7 +97,7 @@ ignore_na : boolean, default False
 _ewm_notes = r"""
 Notes
 -----
-Either center of mass or span must be specified
+Either center of mass, span or halflife must be specified
 
 EWMA is sometimes specified using a "span" parameter `s`, we have that the
 decay parameter :math:`\alpha` is related to the span as


### PR DESCRIPTION
This documentation appears to not be consistent with the function usage, i.e. halflife can also be specified as an alternative to center of mass or span.
