### PR TITLE
CI: fix numpy to 1.9.3 in 2.7,3.5 builds for now, as packages for 1.1.0 not released ATM

### DIFF
--- a/ci/requirements-2.7.build
+++ b/ci/requirements-2.7.build
@@ -1,4 +1,4 @@
 dateutil=2.1
 pytz=2013b
-numpy
+numpy=1.9.3
 cython=0.19.1

--- a/ci/requirements-2.7.run
+++ b/ci/requirements-2.7.run
@@ -1,6 +1,6 @@
 dateutil=2.1
 pytz=2013b
-numpy
+numpy=1.9.3
 xlwt=0.7.5
 numexpr
 pytables

--- a/ci/requirements-3.4_SLOW.build
+++ b/ci/requirements-3.4_SLOW.build
@@ -1,4 +1,4 @@
 python-dateutil
 pytz
-numpy
+numpy=1.9.3
 cython

--- a/ci/requirements-3.4_SLOW.run
+++ b/ci/requirements-3.4_SLOW.run
@@ -1,6 +1,6 @@
 python-dateutil
 pytz
-numpy
+numpy=1.9.3
 openpyxl
 xlsxwriter
 xlrd

--- a/ci/requirements-3.5.build
+++ b/ci/requirements-3.5.build
@@ -1,4 +1,4 @@
 python-dateutil
 pytz
-numpy
+numpy=1.9.3
 cython

--- a/ci/requirements-3.5.run
+++ b/ci/requirements-3.5.run
@@ -1,6 +1,6 @@
 python-dateutil
 pytz
-numpy
+numpy=1.9.3
 openpyxl
 xlsxwriter
 xlrd


### PR DESCRIPTION
xref #11187 

conda packages are not yet updated, so need to fix to 1.9.3 for now
