### PR TITLE
PERF: Removed the GIL from parts of the TextReader class

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -60,6 +60,7 @@ Performance Improvements
 
 - Release the GIL on most datetime field operations (e.g. ``DatetimeIndex.year``, ``Series.dt.year``), normalization, and conversion to and from ``Period``, ``DatetimeIndex.to_period`` and ``PeriodIndex.to_timestamp`` (:issue:`11263`)
 - Release the GIL on some srolling algos (``rolling_median``, ``rolling_mean``, ``rolling_max``, ``rolling_min``, ``rolling_var``, ``rolling_kurt``, `rolling_skew`` (:issue:`11450`)
+- Release the GIL when reading and parsing text files in ``read_csv``, ``read_table`` (:issue:`11272`)
 - Improved performance of ``rolling_median`` (:issue:`11450`)
 
 - Improved performance to ``to_excel`` (:issue:`11352`)


### PR DESCRIPTION
The GIL was removed around the tokenizer functions and the conversion function(_string_convert excluded).
## Benchmark:
### Data Generation:

``` python
import pandas as pd
import numpy as np

df = pd.DataFrame(np.random.randn(1000000,10))
df.to_csv('test.csv')
```
### Benchmark Code:

``` python
import pandas as pd
from pandas.util.testing import test_parallel

def f():
    for i in range(4):
        pd.read_csv('test.csv', index_col=0)

@test_parallel(4)
def g():
    pd.read_csv('test.csv', index_col=0)
```
### Before:

```
In [4]: %timeit pd.read_csv('test.csv', index_col=0)
1 loops, best of 3: 2.3 s per loop

In [7]: %timeit f()
1 loops, best of 3: 9.15 s per loop

In [8]: %timeit g()
1 loops, best of 3: 9.25 s per loop
```
### After:

``` pycon
In [6]: %timeit pd.read_csv('test.csv', index_col=0)
1 loops, best of 3: 2.35 s per loop

In [9]: %timeit f()
1 loops, best of 3: 9.55 s per loop

In [10]: %timeit g()
1 loops, best of 3: 4.38 s per loop
```
