### PR TITLE
PERF: use .values in index difference

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -136,6 +136,7 @@ Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Checking monotonic-ness before sorting on an index (:issue:`11080`)
+- Performance improvements in ``Index.difference``, particularly for ``PeriodIndex`` (:issue:`11278`)
 - ``Series.dropna`` performance improvement when its dtype can't contain ``NaN`` (:issue:`11159`)
 - Release the GIL on most datetime field operations (e.g. ``DatetimeIndex.year``, ``Series.dt.year``), normalization, and conversion to and from ``Period``, ``DatetimeIndex.to_period`` and ``PeriodIndex.to_timestamp`` (:issue:`11263`)
 - Release the GIL on some rolling algos: ``rolling_median``, ``rolling_mean``, ``rolling_max``, ``rolling_min``, ``rolling_var``, ``rolling_kurt``, ``rolling_skew`` (:issue:`11450`)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1711,12 +1711,12 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
         self._assert_can_do_setop(other)
 
         if self.equals(other):
-            return Index([], name=self.name)
+            return self._shallow_copy([])
 
         other, result_name = self._convert_can_do_setop(other)
 
-        theDiff = sorted(set(self) - set(other))
-        return Index(theDiff, name=result_name)
+        diff = sorted(set(self.values) - set(other.values))
+        return self._shallow_copy(diff, name=result_name)
 
     diff = deprecate('diff', difference)
 


### PR DESCRIPTION
The existing `.difference` method 'unboxed' all the objects, which has a severe performance impact on `PeriodIndex` in particular. 

``` python

In [3]: long_index = pd.period_range(start='2000', freq='s', periods=1000)

In [4]: empty_index = pd.PeriodIndex([],freq='s')


In [24]: %timeit long_index.difference(empty_index)

# existing:
1 loops, best of 1: 1.02 s per loop
# updated: 
1000 loops, best of 3: 538 µs per loop
```

...so around 2000x

I haven't worked with asv or the like - is this a case where a test like that is required?
