### PR TITLE
ENH: Improvement to the BigQuery streaming insert failure message #11285

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -20,6 +20,8 @@ Enhancements
 
 .. _whatsnew_0171.enhancements.other:
 
+- Improve the error message in :func:`pandas.io.gbq.to_gbq` when a streaming insert fails (:issue:`11285`)
+
 Other Enhancements
 ^^^^^^^^^^^^^^^^^^
 

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -185,7 +185,8 @@ class GbqConnector(object):
             for error in errors:
                 reason = error['reason']
                 message = error['message']
-                error_message = 'Error at Row: {0}, Reason: {1}, Message: {2}'.format(row, reason, message)
+                location = error['location']
+                error_message = 'Error at Row: {0}, Reason: {1}, Location: {2}, Message: {3}'.format(row, reason, location, message)
 
                 # Report all error messages if verbose is set
                 if verbose:


### PR DESCRIPTION
closes #11285 

This is a minor change to include `'Location'` in the error message reported when a streaming insert fails using the `df.to_gbq()`
