### PR TITLE
PERF: Checking monotonic-ness before sorting on an index #11080

### DIFF
--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -930,6 +930,16 @@ class frame_xs_row(object):
         self.df.xs(50000)
 
 
+class frame_sort_index(object):
+    goal_time = 0.2
+
+    def setup(self):
+        self.df = DataFrame(randn(1000000, 2), columns=list('AB'))
+
+    def time_frame_sort_index(self):
+        self.df.sort_index()
+
+
 class series_string_vector_slice(object):
     goal_time = 0.2
 

--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -52,6 +52,8 @@ Deprecations
 Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
+- Checking monotonic-ness before sorting on an index (:issue:`11080`)
+
 .. _whatsnew_0171.bug_fixes:
 
 Bug Fixes

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3157,6 +3157,15 @@ class DataFrame(NDFrame):
         else:
             from pandas.core.groupby import _nargsort
 
+            # GH11080 - Check monotonic-ness before sort an index
+            # if monotonic (already sorted), return None or copy() according to 'inplace'
+            if (ascending and labels.is_monotonic_increasing) or \
+               (not ascending and labels.is_monotonic_decreasing):
+                if inplace:
+                    return
+                else:
+                    return self.copy()
+
             indexer = _nargsort(labels, kind=kind, ascending=ascending,
                                 na_position=na_position)
 


### PR DESCRIPTION
closes #11080 

Worked for this during PyCon JP 2015 pandas sprint /w @sinhrks 

I found `test_frame.py:TestDataFrame.test_sort_index` cover this change.
