### PR TITLE
REGR: change in output formatting for long floats/nan, #11302

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -34,7 +34,7 @@ API changes
 
 - min and max reductions on ``datetime64`` and ``timedelta64`` dtyped series now
   result in ``NaT`` and not ``nan`` (:issue:`11245`).
-
+- Regression from 0.16.2 for output formatting of long floats/nan, restored in (:issue:`11302`)
 - Prettyprinting sets (e.g. in DataFrame cells) now uses set literal syntax (``{x, y}``) instead of
   Legacy Python syntax (``set([x, y])``) (:issue:`11215`)
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -435,7 +435,15 @@ class Block(PandasObject):
             if values is None:
 
                 if issubclass(dtype.type, (compat.text_type, compat.string_types)):
-                    values = self.to_native_types()
+
+                    # use native type formatting for datetime/tz/timedelta
+                    if self.is_datelike:
+                        values = self.to_native_types()
+
+                    # astype formatting
+                    else:
+                        values = self.values
+
                 else:
                     values = self.get_values(dtype=dtype)
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4621,6 +4621,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
 
         df = DataFrame({'a' : a, 'b' : b, 'c' : c, 'd' : d, 'e' : e})
 
+        # datetimelike
         # Test str and unicode on python 2.x and just str on python 3.x
         for tt in set([str, compat.text_type]):
             result = df.astype(tt)
@@ -4633,6 +4634,18 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                 'e' : list(map(tt, e._values)),
                 })
 
+            assert_frame_equal(result, expected)
+
+        # float/nan
+        # 11302
+        # consistency in astype(str)
+        for tt in set([str, compat.text_type]):
+            result = DataFrame([np.NaN]).astype(tt)
+            expected = DataFrame(['nan'])
+            assert_frame_equal(result, expected)
+
+            result = DataFrame([1.12345678901234567890]).astype(tt)
+            expected = DataFrame(['1.12345678901'])
             assert_frame_equal(result, expected)
 
     def test_array_interface(self):


### PR DESCRIPTION
closes #11302 
