### PR TITLE
BUG: multi-index excel header fails if all numeric

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -867,7 +867,7 @@ class ParserBase(object):
         field_count = len(header[0])
 
         def extract(r):
-            return tuple([r[i] for i in range(field_count) if i not in sic])
+            return tuple([str(r[i]) for i in range(field_count) if i not in sic])
 
         columns = lzip(*[extract(r) for r in header])
         names = ic + columns


### PR DESCRIPTION
If the multi-line headers come from Excel, and the header was not a string, the line all(['Unnamed' in c[n] for c in columns]): will fail because c[n] is an int and not iterable.  So either force the headers to be strings (the proposed change) or come up with some other test when looking for 'Unnamed'
