### PR TITLE
DEPR: deprecate `engine` keyword from to_csv #11274

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -40,6 +40,8 @@ API changes
 
 .. _whatsnew_0171.deprecations:
 
+- ``engine`` keyword is deprecated from ``.to_csv()`` and will be removed in a future version (:issue:`11274`)
+
 Deprecations
 ^^^^^^^^^^^^
 

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -23,6 +23,7 @@ import numpy as np
 
 import itertools
 import csv
+import warnings
 
 common_docstring = """
     Parameters
@@ -1264,7 +1265,11 @@ class CSVFormatter(object):
                  tupleize_cols=False, quotechar='"', date_format=None,
                  doublequote=True, escapechar=None, decimal='.'):
 
-        self.engine = engine  # remove for 0.13
+        if engine is not None:
+            warnings.warn("'engine' keyword is deprecated and "
+                          "will be removed in a future version",
+                          FutureWarning, stacklevel=3)
+        self.engine = engine  # remove for 0.18
         self.obj = obj
 
         if path_or_buf is None:

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -2952,6 +2952,12 @@ $1$,$2$
         self.assertEqual(df_day.to_csv(), expected_default_day)
         self.assertEqual(df_day.to_csv(date_format='%Y-%m-%d'), expected_default_day)
 
+    # deprecation GH11274
+    def test_to_csv_engine_kw_deprecation(self):
+        with tm.assert_produces_warning(FutureWarning):
+            df = DataFrame({'col1' : [1], 'col2' : ['a'], 'col3' : [10.1] })
+            df.to_csv(engine='python')
+
     def test_round_dataframe(self):
 
         # GH 2665


### PR DESCRIPTION
closes #11274 
