### PR TITLE
ENH: Add Index.fillna

### DIFF
--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -1367,6 +1367,31 @@ with duplicates dropped.
    idx1.sym_diff(idx2)
    idx1 ^ idx2
 
+Missing values
+~~~~~~~~~~~~~~
+
+.. _indexing.missing:
+
+.. versionadded:: 0.17.1
+
+.. important::
+
+   Even though ``Index`` can hold missing values (``NaN``), it should be avoided
+   if you do not want any unexpected results. For example, some operations
+   exclude missing values implicitly.
+
+``Index.fillna`` fills missing values with specified scalar value.
+
+.. ipython:: python
+
+   idx1 = pd.Index([1, np.nan, 3, 4])
+   idx1
+   idx1.fillna(2)
+
+   idx2 = pd.DatetimeIndex([pd.Timestamp('2011-01-01'), pd.NaT, pd.Timestamp('2011-01-03')])
+   idx2
+   idx2.fillna(pd.Timestamp('2011-01-02'))
+
 Set / Reset Index
 -----------------
 

--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -26,6 +26,12 @@ Enhancements
 - ``DataFrame`` now uses the fields of a ``namedtuple`` as columns, if columns are not supplied (:issue:`11181`)
 - Improve the error message displayed in :func:`pandas.io.gbq.to_gbq` when the DataFrame does not match the schema of the destination table (:issue:`11359`)
 
+- ``Index`` now has ``fillna`` method (:issue:`10089`)
+
+.. ipython:: python
+
+   pd.Index([1, np.nan, 3]).fillna(2)
+
 .. _whatsnew_0171.api:
 
 API changes

--- a/pandas/src/period.pyx
+++ b/pandas/src/period.pyx
@@ -452,7 +452,7 @@ def extract_ordinals(ndarray[object] values, freq):
         p = values[i]
         ordinals[i] = p.ordinal
         if p.freqstr != freqstr:
-            raise ValueError("%s is wrong freq" % p)
+            raise ValueError(_DIFFERENT_FREQ_INDEX.format(freqstr, p.freqstr))
 
     return ordinals
 
@@ -624,8 +624,8 @@ cdef ndarray[int64_t] localize_dt64arr_to_period(ndarray[int64_t] stamps,
     return result
 
 
-_DIFFERENT_FREQ_ERROR = "Input has different freq={1} from Period(freq={0})"
-
+_DIFFERENT_FREQ = "Input has different freq={1} from Period(freq={0})"
+_DIFFERENT_FREQ_INDEX = "Input has different freq={1} from PeriodIndex(freq={0})"
 
 cdef class Period(object):
     """
@@ -766,7 +766,7 @@ cdef class Period(object):
         if isinstance(other, Period):
             from pandas.tseries.frequencies import get_freq_code as _gfc
             if other.freq != self.freq:
-                msg = _DIFFERENT_FREQ_ERROR.format(self.freqstr, other.freqstr)
+                msg = _DIFFERENT_FREQ.format(self.freqstr, other.freqstr)
                 raise ValueError(msg)
             if self.ordinal == tslib.iNaT or other.ordinal == tslib.iNaT:
                 return _nat_scalar_rules[op]
@@ -807,7 +807,7 @@ cdef class Period(object):
                 else:
                     ordinal = self.ordinal + other.n
                 return Period(ordinal=ordinal, freq=self.freq)
-            msg = _DIFFERENT_FREQ_ERROR.format(self.freqstr, other.freqstr)
+            msg = _DIFFERENT_FREQ.format(self.freqstr, other.freqstr)
             raise ValueError(msg)
         else: # pragma no cover
             return NotImplemented

--- a/pandas/tseries/base.py
+++ b/pandas/tseries/base.py
@@ -202,9 +202,14 @@ class DatetimeIndexOpsMixin(object):
         return self._simple_new(values)
 
     @cache_readonly
+    def _isnan(self):
+        """ return if each value is nan"""
+        return (self.asi8 == tslib.iNaT)
+
+    @cache_readonly
     def hasnans(self):
         """ return if I have any nans; enables various perf speedups """
-        return (self.asi8 == tslib.iNaT).any()
+        return self._isnan.any()
 
     @property
     def asobject(self):

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -57,7 +57,7 @@ def dt64arr_to_periodarr(data, freq, tz):
 
 # --- Period index sketch
 
-_DIFFERENT_FREQ_ERROR = "Input has different freq={1} from PeriodIndex(freq={0})"
+_DIFFERENT_FREQ_INDEX = period._DIFFERENT_FREQ_INDEX
 
 def _period_index_cmp(opname, nat_result=False):
     """
@@ -68,13 +68,13 @@ def _period_index_cmp(opname, nat_result=False):
             func = getattr(self.values, opname)
             other_base, _ = _gfc(other.freq)
             if other.freq != self.freq:
-                msg = _DIFFERENT_FREQ_ERROR.format(self.freqstr, other.freqstr)
+                msg = _DIFFERENT_FREQ_INDEX.format(self.freqstr, other.freqstr)
                 raise ValueError(msg)
 
             result = func(other.ordinal)
         elif isinstance(other, PeriodIndex):
             if other.freq != self.freq:
-                msg = _DIFFERENT_FREQ_ERROR.format(self.freqstr, other.freqstr)
+                msg = _DIFFERENT_FREQ_INDEX.format(self.freqstr, other.freqstr)
                 raise ValueError(msg)
 
             result = getattr(self.values, opname)(other.values)
@@ -336,6 +336,10 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
     def _box_func(self):
         return lambda x: Period._from_ordinal(ordinal=x, freq=self.freq)
 
+    def _convert_for_op(self):
+        """ Convert value to be insertable to ndarray """
+        return self._box_func(value)
+
     def _to_embed(self, keep_tz=False):
         """ return an array repr of this object, potentially casting to object """
         return self.asobject.values
@@ -378,7 +382,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
     def searchsorted(self, key, side='left'):
         if isinstance(key, Period):
             if key.freq != self.freq:
-                msg = _DIFFERENT_FREQ_ERROR.format(self.freqstr, key.freqstr)
+                msg = _DIFFERENT_FREQ_INDEX.format(self.freqstr, key.freqstr)
                 raise ValueError(msg)
             key = key.ordinal
         elif isinstance(key, compat.string_types):
@@ -764,7 +768,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
             raise ValueError('can only call with other PeriodIndex-ed objects')
 
         if self.freq != other.freq:
-            msg = _DIFFERENT_FREQ_ERROR.format(self.freqstr, other.freqstr)
+            msg = _DIFFERENT_FREQ_INDEX.format(self.freqstr, other.freqstr)
             raise ValueError(msg)
 
     def _wrap_union_result(self, other, result):

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -642,7 +642,7 @@ class NaTType(_NaT):
 
     def __reduce__(self):
         return (__nat_unpickle, (None, ))
-    
+
     def total_seconds(self):
         # GH 10939
         return np.nan
@@ -1749,7 +1749,8 @@ def dateutil_parse(object timestr, object default, ignoretz=False,
         res, _ = res
 
     if res is None:
-        raise ValueError("unknown string format")
+        msg = "Unknown datetime string format, unable to parse: {0}"
+        raise ValueError(msg.format(timestr))
 
     for attr in ["year", "month", "day", "hour",
                  "minute", "second", "microsecond"]:
@@ -1759,7 +1760,8 @@ def dateutil_parse(object timestr, object default, ignoretz=False,
             reso = attr
 
     if reso is None:
-        raise ValueError("Cannot parse date.")
+        msg = "Unable to parse datetime string: {0}"
+        raise ValueError(msg.format(timestr))
 
     if reso == 'microsecond':
         if repl['microsecond'] == 0:


### PR DESCRIPTION
Closes #10089. 
- `value` can only accept scalar.
- `MultiIndex.fillna` raises `NotImplementedError` because `isnull` is not defined for MI.
- Moved `hasnans` and related properties to base `Index`.
