### PR TITLE
PERF: fast inf checking in to_excel

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -43,6 +43,7 @@
         "numexpr": [],
         "pytables": [],
         "openpyxl": [],
+        "xlsxwriter": [],
         "xlrd": [],
         "xlwt": []
     },

--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -62,6 +62,8 @@ Performance Improvements
 - Release the GIL on most datetime field operations (e.g. ``DatetimeIndex.year``, ``Series.dt.year``), normalization, and conversion to and from ``Period``, ``DatetimeIndex.to_period`` and ``PeriodIndex.to_timestamp`` (:issue:`11263`)
 
 
+- Improved performance to ``to_excel`` (:issue:`11352`)
+
 .. _whatsnew_0171.bug_fixes:
 
 Bug Fixes

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -1708,9 +1708,9 @@ class ExcelFormatter(object):
         if lib.checknull(val):
             val = self.na_rep
         elif com.is_float(val):
-            if np.isposinf(val):
+            if lib.isposinf_scalar(val):
                 val = self.inf_rep
-            elif np.isneginf(val):
+            elif lib.isneginf_scalar(val):
                 val = '-%s' % self.inf_rep
             elif self.float_format is not None:
                 val = float(self.float_format % val)

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -269,6 +269,18 @@ cpdef checknull_old(object val):
     else:
         return util._checknull(val)
 
+cpdef isposinf_scalar(object val):
+    if util.is_float_object(val) and val == INF:
+        return True
+    else:
+        return False
+
+cpdef isneginf_scalar(object val):
+    if util.is_float_object(val) and val == NEGINF:
+        return True
+    else:
+        return False
+
 def isscalar(object val):
     """
     Return True if given value is scalar.

--- a/pandas/tests/test_lib.py
+++ b/pandas/tests/test_lib.py
@@ -161,6 +161,19 @@ class TestMisc(tm.TestCase):
             self.assert_numpy_array_equal(maybe_slice, indices)
             self.assert_numpy_array_equal(target[indices], target[maybe_slice])
 
+    def test_isinf_scalar(self):
+        #GH 11352
+        self.assertTrue(lib.isposinf_scalar(float('inf')))
+        self.assertTrue(lib.isposinf_scalar(np.inf))
+        self.assertFalse(lib.isposinf_scalar(-np.inf))
+        self.assertFalse(lib.isposinf_scalar(1))
+        self.assertFalse(lib.isposinf_scalar('a'))
+
+        self.assertTrue(lib.isneginf_scalar(float('-inf')))
+        self.assertTrue(lib.isneginf_scalar(-np.inf))
+        self.assertFalse(lib.isneginf_scalar(np.inf))
+        self.assertFalse(lib.isneginf_scalar(1))
+        self.assertFalse(lib.isneginf_scalar('a'))
 
 class Testisscalar(tm.TestCase):
 


### PR DESCRIPTION
Adds new functions to check for infinity rather than calling `np.isposinf` and `np.isneginf`, which were (surprising to me) a significant drag on `to_excel`.

I also added `xlsxwriter` to the asv build configuration.  `openpyxl` is still failing, I'm assuming something do with the specific version on conda?

```
    before     after       ratio
  [472e6e0e] [8002555d]
   156.36ms   154.16ms      0.99  packers.packers_read_excel.time_packers_read_excel
     failed     failed       n/a  packers.packers_write_excel_openpyxl.time_packers_write_excel_openpyxl
   469.69ms   357.49ms      0.76  packers.packers_write_excel_xlsxwriter.time_packers_write_excel_xlsxwriter
   368.96ms   270.60ms      0.73  packers.packers_write_excel_xlwt.time_packers_write_excel_xlwt
```
