### PR TITLE
BUG: GH11235 where pd.eval doesn't handle unary ops in lists

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -94,7 +94,7 @@ Bug Fixes
 
 
 
-
+- Bug in ``pd.eval`` where unary ops in a list error (:issue:`11235`)
 - Bug in ``squeeze()`` with zero length arrays (:issue:`11230`, :issue:`8999`)
 
 

--- a/pandas/computation/expr.py
+++ b/pandas/computation/expr.py
@@ -427,7 +427,7 @@ class BaseExprVisitor(ast.NodeVisitor):
         return self.term_type(name, self.env)
 
     def visit_List(self, node, **kwargs):
-        name = self.env.add_tmp([self.visit(e).value for e in node.elts])
+        name = self.env.add_tmp([self.visit(e)(self.env) for e in node.elts])
         return self.term_type(name, self.env)
 
     visit_Tuple = visit_List
@@ -655,7 +655,7 @@ class BaseExprVisitor(ast.NodeVisitor):
         return reduce(visitor, operands)
 
 # ast.Call signature changed on 3.5,
-# conditionally change  which methods is named
+# conditionally change which methods is named
 # visit_Call depending on Python version, #11097
 if compat.PY35:
     BaseExprVisitor.visit_Call = BaseExprVisitor.visit_Call_35


### PR DESCRIPTION
closes #11235 
