### PR TITLE
BUG: pivot table bug with Categorical indexes, #10993

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -87,7 +87,7 @@ Bug Fixes
 
 - Bug in list-like indexing with a mixed-integer Index (:issue:`11320`)
 
-
+- Bug in ``pivot_table`` with ``margins=True`` when indexes are of ``Categorical`` dtype (:issue:`10993`)
 - Bug in ``DataFrame.plot`` cannot use hex strings colors (:issue:`10299`)
 
 

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -627,6 +627,10 @@ class Index(IndexOpsMixin, PandasObject):
         return Index(self.values.astype(dtype), name=self.name,
                      dtype=dtype)
 
+    def _to_safe_for_reshape(self):
+        """ convert to object if we are a categorical """
+        return self
+
     def to_datetime(self, dayfirst=False):
         """
         For an Index containing strings or datetime.datetime objects, attempt
@@ -3190,6 +3194,10 @@ class CategoricalIndex(Index, PandasDelegate):
         from pandas.hashtable import duplicated_int64
         return duplicated_int64(self.codes.astype('i8'), keep)
 
+    def _to_safe_for_reshape(self):
+        """ convert to object if we are a categorical """
+        return self.astype('object')
+
     def get_loc(self, key, method=None):
         """
         Get integer location for requested label
@@ -4528,6 +4536,10 @@ class MultiIndex(Index):
             return adj.adjoin(space, *result_levels).split('\n')
         else:
             return result_levels
+
+    def _to_safe_for_reshape(self):
+        """ convert to object if we are a categorical """
+        return self.set_levels([ i._to_safe_for_reshape() for i in self.levels ])
 
     def to_hierarchical(self, n_repeat, n_shuffle=1):
         """

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -3427,6 +3427,9 @@ class BlockManager(PandasObject):
         if not isinstance(loc, int):
             raise TypeError("loc must be int")
 
+        # insert to the axis; this could possibly raise a TypeError
+        new_axis = self.items.insert(loc, item)
+
         block = make_block(values=value,
                            ndim=self.ndim,
                            placement=slice(loc, loc+1))
@@ -3449,8 +3452,7 @@ class BlockManager(PandasObject):
             self._blklocs = np.insert(self._blklocs, loc, 0)
             self._blknos = np.insert(self._blknos, loc, len(self.blocks))
 
-        self.axes[0] = self.items.insert(loc, item)
-
+        self.axes[0] = new_axis
         self.blocks += (block,)
         self._shape = None
 

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -159,6 +159,20 @@ def _add_margins(table, data, values, rows, cols, aggfunc):
 
     grand_margin = _compute_grand_margin(data, values, aggfunc)
 
+    # categorical index or columns will fail below when 'All' is added
+    # here we'll convert all categorical indices to object
+    def convert_categorical(ind):
+        _convert = lambda ind: (ind.astype('object')
+                                if ind.dtype.name == 'category' else ind)
+        if isinstance(ind, MultiIndex):
+            return ind.set_levels([_convert(lev) for lev in ind.levels])
+        else:
+            return _convert(ind)
+
+    table.index = convert_categorical(table.index)
+    if hasattr(table, 'columns'):
+        table.columns = convert_categorical(table.columns)
+
     if not values and isinstance(table, Series):
         # If there are no values and the table is a series, then there is only
         # one column in the data. Compute grand margin and return it.

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -159,20 +159,6 @@ def _add_margins(table, data, values, rows, cols, aggfunc):
 
     grand_margin = _compute_grand_margin(data, values, aggfunc)
 
-    # categorical index or columns will fail below when 'All' is added
-    # here we'll convert all categorical indices to object
-    def convert_categorical(ind):
-        _convert = lambda ind: (ind.astype('object')
-                                if ind.dtype.name == 'category' else ind)
-        if isinstance(ind, MultiIndex):
-            return ind.set_levels([_convert(lev) for lev in ind.levels])
-        else:
-            return _convert(ind)
-
-    table.index = convert_categorical(table.index)
-    if hasattr(table, 'columns'):
-        table.columns = convert_categorical(table.columns)
-
     if not values and isinstance(table, Series):
         # If there are no values and the table is a series, then there is only
         # one column in the data. Compute grand margin and return it.
@@ -203,7 +189,13 @@ def _add_margins(table, data, values, rows, cols, aggfunc):
     margin_dummy = DataFrame(row_margin, columns=[key]).T
 
     row_names = result.index.names
-    result = result.append(margin_dummy)
+    try:
+        result = result.append(margin_dummy)
+    except TypeError:
+
+        # we cannot reshape, so coerce the axis
+        result.index = result.index._to_safe_for_reshape()
+        result = result.append(margin_dummy)
     result.index.names = row_names
 
     return result
@@ -232,6 +224,7 @@ def _compute_grand_margin(data, values, aggfunc):
 
 
 def _generate_marginal_results(table, data, values, rows, cols, aggfunc, grand_margin):
+
     if len(cols) > 0:
         # need to "interleave" the margins
         table_pieces = []
@@ -249,7 +242,13 @@ def _generate_marginal_results(table, data, values, rows, cols, aggfunc, grand_m
 
                 # we are going to mutate this, so need to copy!
                 piece = piece.copy()
-                piece[all_key] = margin[key]
+                try:
+                    piece[all_key] = margin[key]
+                except TypeError:
+
+                    # we cannot reshape, so coerce the axis
+                    piece.set_axis(cat_axis, piece._get_axis(cat_axis)._to_safe_for_reshape())
+                    piece[all_key] = margin[key]
 
                 table_pieces.append(piece)
                 margin_keys.append(all_key)

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -721,17 +721,23 @@ class TestCrosstab(tm.TestCase):
 
     def test_categorical_margins(self):
         # GH 10989
-        data = pd.DataFrame({'x': np.arange(8),
-                             'y': np.arange(8) // 4,
-                             'z': np.arange(8) % 2})
+        df = pd.DataFrame({'x': np.arange(8),
+                           'y': np.arange(8) // 4,
+                           'z': np.arange(8) % 2})
+
+        expected = pd.DataFrame([[1.0, 2.0, 1.5],[5, 6, 5.5],[3, 4, 3.5]])
+        expected.index = Index([0,1,'All'],name='y')
+        expected.columns = Index([0,1,'All'],name='z')
+
+        data = df.copy()
+        table = data.pivot_table('x', 'y', 'z', margins=True)
+        tm.assert_frame_equal(table, expected)
+
+        data = df.copy()
         data.y = data.y.astype('category')
         data.z = data.z.astype('category')
         table = data.pivot_table('x', 'y', 'z', margins=True)
-        assert_equal(table.values, [[1, 2, 1.5],
-                                    [5, 6, 5.5],
-                                    [3, 4, 3.5]])
-                                    
-        
+        tm.assert_frame_equal(table, expected)
 
 if __name__ == '__main__':
     import nose

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -719,6 +719,20 @@ class TestCrosstab(tm.TestCase):
                                     ('two', 'dull'), ('two', 'shiny')])
         assert_equal(res.columns.values, m.values)
 
+    def test_categorical_margins(self):
+        # GH 10989
+        data = pd.DataFrame({'x': np.arange(8),
+                             'y': np.arange(8) // 4,
+                             'z': np.arange(8) % 2})
+        data.y = data.y.astype('category')
+        data.z = data.z.astype('category')
+        table = data.pivot_table('x', 'y', 'z', margins=True)
+        assert_equal(table.values, [[1, 2, 1.5],
+                                    [5, 6, 5.5],
+                                    [3, 4, 3.5]])
+                                    
+        
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
closes #10993 
replaces #10989 

So issue #10993 involves the insertion of a key into a multi-index that has as one of its levels a `CategoricalIndex`. This causes the semantics to break down because we are inserting an new key.

Existing

```
In [16]: df = DataFrame({'A' : [1,2], 'B' : [3,4] })

In [17]: df.columns = MultiIndex([pd.CategoricalIndex(list('ab')),[1,2]],[[0,1],[0,1]])

In [3]: df.columns.levels[0]
Out[3]: CategoricalIndex([u'a', u'b'], categories=[u'a', u'b'], ordered=False, dtype='category')

In [18]: df
Out[18]: 
   a  b
   1  2
0  1  3
1  2  4

In [19]: df.columns
Out[19]: 
MultiIndex(levels=[[u'a', u'b'], [1, 2]],
           labels=[[0, 1], [0, 1]])

In [20]: df[('c',3)] = 5
TypeError: cannot insert an item into a CategoricalIndex that is not already an existing category
```

New

```
In [4]: df[('c',3)] = 5

In [5]: df
Out[5]: 
   a  b  c
   1  2  3
0  1  3  5
1  2  4  5

In [8]: df.columns.levels[0]
Out[8]: CategoricalIndex([u'a', u'b', u'c'], categories=[u'a', u'b', u'c'], ordered=False, dtype='category')
```

The only issue that was slightly controversial is that `.insert` will retain the `ordered` attribute (and new categories go to the end). while `.append` will always have `ordered=False`. In theory we could do the same, but `.append` is used to generally append _another_ `CategoricalIndex`, so you would have some possiblity of interleaving of the 'ordered' categories (IOW, if self has `[1,2,3]` and other has `[3,2,1,4]`, then the result will be `[1,2,3,4]`.

We _could_ raise if we have mixed ordering (e.g. self is `ordered=False`, other is `ordered=True`).

Of course the user is free to reorder and such, but the default should be intuitive.

Futher note that we can now concat pandas objects with `CategoricalIndexes` (I don't think was specified before, certainly not tested), e.g.

```
In [1]: df = DataFrame({'A' : np.arange(5)},index=pd.CategoricalIndex(list('aabbc')))

In [2]: df2 = DataFrame({'A' : np.arange(5)},index=pd.CategoricalIndex(list('bbcde')))

In [3]: pd.concat([df,df2])
Out[3]: 
   A
a  0
a  1
b  2
b  3
c  4
b  0
b  1
c  2
d  3
e  4

In [4]: pd.concat([df,df2]).index
Out[4]: CategoricalIndex([u'a', u'a', u'b', u'b', u'c', u'b', u'b', u'c', u'd', u'e'], categories=[u'a', u'b', u'c', u'd', u'e'], ordered=False, dtype='category')

```
