### PR TITLE
ENH: str.extractall for several matches

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -526,6 +526,7 @@ strings and apply several methods to it. These can be accessed like
    Series.str.encode
    Series.str.endswith
    Series.str.extract
+   Series.str.extractall
    Series.str.find
    Series.str.findall
    Series.str.get

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -136,6 +136,92 @@ New Behavior:
    s.index
    s.index.nbytes
 
+.. _whatsnew_0180.enhancements.extract:
+
+Changes to str.extract
+^^^^^^^^^^^^^^^^^^^^^^
+
+The :ref:`.str.extract <text.extract>` method takes a regular
+expression with capture groups, finds the first match in each subject
+string, and returns the contents of the capture groups
+(:issue:`11386`). In v0.18.0, the ``expand`` argument was added to
+``extract``. When ``expand=False`` it returns a ``Series``, ``Index``,
+or ``DataFrame``, depending on the subject and regular expression
+pattern (same behavior as pre-0.18.0). When ``expand=True`` it always
+returns a ``DataFrame``, which is more consistent and less confusing
+from the perspective of a user. Currently the default is
+``expand=None`` which gives a ``FutureWarning`` and uses
+``expand=False``. To avoid this warning, please explicitly specify
+``expand``.
+
+.. ipython:: python
+
+   pd.Series(['a1', 'b2', 'c3']).str.extract('[ab](\d)')
+
+Extracting a regular expression with one group returns a ``DataFrame``
+with one column if ``expand=True``.
+
+.. ipython:: python
+
+   pd.Series(['a1', 'b2', 'c3']).str.extract('[ab](\d)', expand=True)
+
+It returns a Series if ``expand=False``.
+
+.. ipython:: python
+
+   pd.Series(['a1', 'b2', 'c3']).str.extract('[ab](\d)', expand=False)
+
+Calling on an ``Index`` with a regex with exactly one capture group
+returns a ``DataFrame`` with one column if ``expand=True``,
+
+.. ipython:: python
+
+   s = pd.Series(["a1", "b2", "c3"], ["A11", "B22", "C33"])
+   s
+   s.index.str.extract("(?P<letter>[a-zA-Z])", expand=True)
+
+It returns an ``Index`` if ``expand=False``.
+
+.. ipython:: python
+
+   s.index.str.extract("(?P<letter>[a-zA-Z])", expand=False)
+
+Calling on an ``Index`` with a regex with more than one capture group
+returns a ``DataFrame`` if ``expand=True``.
+
+.. ipython:: python
+
+   s.index.str.extract("(?P<letter>[a-zA-Z])([0-9]+)", expand=True)
+
+It raises ``ValueError`` if ``expand=False``.
+
+.. code-block:: python
+
+    >>> s.index.str.extract("(?P<letter>[a-zA-Z])([0-9]+)", expand=False)
+    ValueError: only one regex group is supported with Index
+
+In summary, ``extract(expand=True)`` always returns a ``DataFrame``
+with a row for every subject string, and a column for every capture
+group.
+
+.. _whatsnew_0180.enhancements.extractall:
+
+The :ref:`.str.extractall <text.extractall>` method was added
+(:issue:`11386`).  Unlike ``extract`` (which returns only the first
+match),
+
+.. ipython:: python
+
+   s = pd.Series(["a1a2", "b1", "c1"], ["A", "B", "C"])
+   s
+   s.str.extract("(?P<letter>[ab])(?P<digit>\d)")
+
+the ``extractall`` method returns all matches.
+
+.. ipython:: python
+
+   s.str.extractall("(?P<letter>[ab])(?P<digit>\d)")
+
 .. _whatsnew_0180.enhancements.rounding:
 
 Datetimelike rounding

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -418,67 +418,10 @@ def _get_single_group_name(rx):
         return None
 
 
-def str_extract(arr, pat, flags=0):
-    """
-    Find groups in each string in the Series using passed regular
-    expression.
-
-    Parameters
-    ----------
-    pat : string
-        Pattern or regular expression
-    flags : int, default 0 (no flags)
-        re module flags, e.g. re.IGNORECASE
-
-    Returns
-    -------
-    extracted groups : Series (one group) or DataFrame (multiple groups)
-        Note that dtype of the result is always object, even when no match is
-        found and the result is a Series or DataFrame containing only NaN
-        values.
-
-    Examples
-    --------
-    A pattern with one group will return a Series. Non-matches will be NaN.
-
-    >>> Series(['a1', 'b2', 'c3']).str.extract('[ab](\d)')
-    0      1
-    1      2
-    2    NaN
-    dtype: object
-
-    A pattern with more than one group will return a DataFrame.
-
-    >>> Series(['a1', 'b2', 'c3']).str.extract('([ab])(\d)')
-         0    1
-    0    a    1
-    1    b    2
-    2  NaN  NaN
-
-    A pattern may contain optional groups.
-
-    >>> Series(['a1', 'b2', 'c3']).str.extract('([ab])?(\d)')
-         0  1
-    0    a  1
-    1    b  2
-    2  NaN  3
-
-    Named groups will become column names in the result.
-
-    >>> Series(['a1', 'b2', 'c3']).str.extract('(?P<letter>[ab])(?P<digit>\d)')
-      letter digit
-    0      a     1
-    1      b     2
-    2    NaN   NaN
-
-    """
-    from pandas.core.frame import DataFrame
-    from pandas.core.index import Index
-
-    regex = re.compile(pat, flags=flags)
-    # just to be safe, check this
+def _groups_or_na_fun(regex):
+    """Used in both extract_noexpand and extract_frame"""
     if regex.groups == 0:
-        raise ValueError("This pattern contains no groups to capture.")
+        raise ValueError("pattern contains no capture groups")
     empty_row = [np.nan] * regex.groups
 
     def f(x):
@@ -489,9 +432,24 @@ def str_extract(arr, pat, flags=0):
             return [np.nan if item is None else item for item in m.groups()]
         else:
             return empty_row
+    return f
+
+
+def _str_extract_noexpand(arr, pat, flags=0):
+    """
+    Find groups in each string in the Series using passed regular
+    expression. This function is called from
+    str_extract(expand=False), and can return Series, DataFrame, or
+    Index.
+
+    """
+    from pandas import DataFrame, Index
+
+    regex = re.compile(pat, flags=flags)
+    groups_or_na = _groups_or_na_fun(regex)
 
     if regex.groups == 1:
-        result = np.array([f(val)[0] for val in arr], dtype=object)
+        result = np.array([groups_or_na(val)[0] for val in arr], dtype=object)
         name = _get_single_group_name(regex)
     else:
         if isinstance(arr, Index):
@@ -502,9 +460,237 @@ def str_extract(arr, pat, flags=0):
         if arr.empty:
             result = DataFrame(columns=columns, dtype=object)
         else:
-            result = DataFrame([f(val) for val in arr], columns=columns,
-                               index=arr.index, dtype=object)
+            result = DataFrame(
+                [groups_or_na(val) for val in arr],
+                columns=columns,
+                index=arr.index,
+                dtype=object)
     return result, name
+
+
+def _str_extract_frame(arr, pat, flags=0):
+    """
+    For each subject string in the Series, extract groups from the
+    first match of regular expression pat. This function is called from
+    str_extract(expand=True), and always returns a DataFrame.
+
+    """
+    from pandas import DataFrame
+
+    regex = re.compile(pat, flags=flags)
+    groups_or_na = _groups_or_na_fun(regex)
+    names = dict(zip(regex.groupindex.values(), regex.groupindex.keys()))
+    columns = [names.get(1 + i, i) for i in range(regex.groups)]
+
+    if len(arr) == 0:
+        return DataFrame(columns=columns, dtype=object)
+    try:
+        result_index = arr.index
+    except AttributeError:
+        result_index = None
+    return DataFrame(
+        [groups_or_na(val) for val in arr],
+        columns=columns,
+        index=result_index,
+        dtype=object)
+
+
+def str_extract(arr, pat, flags=0, expand=None):
+    """
+    For each subject string in the Series, extract groups from the
+    first match of regular expression pat.
+
+    .. versionadded:: 0.13.0
+
+    Parameters
+    ----------
+    pat : string
+        Regular expression pattern with capturing groups
+    flags : int, default 0 (no flags)
+        re module flags, e.g. re.IGNORECASE
+
+    .. versionadded:: 0.18.0
+    expand : bool, default False
+        * If True, return DataFrame.
+        * If False, return Series/Index/DataFrame.
+
+    Returns
+    -------
+    DataFrame with one row for each subject string, and one column for
+    each group. Any capture group names in regular expression pat will
+    be used for column names; otherwise capture group numbers will be
+    used. The dtype of each result column is always object, even when
+    no match is found. If expand=True and pat has only one capture group,
+    then return a Series (if subject is a Series) or Index (if subject
+    is an Index).
+
+    See Also
+    --------
+    extractall : returns all matches (not just the first match)
+
+    Examples
+    --------
+    A pattern with two groups will return a DataFrame with two columns.
+    Non-matches will be NaN.
+
+    >>> s = Series(['a1', 'b2', 'c3'])
+    >>> s.str.extract('([ab])(\d)')
+         0    1
+    0    a    1
+    1    b    2
+    2  NaN  NaN
+
+    A pattern may contain optional groups.
+
+    >>> s.str.extract('([ab])?(\d)')
+         0  1
+    0    a  1
+    1    b  2
+    2  NaN  3
+
+    Named groups will become column names in the result.
+
+    >>> s.str.extract('(?P<letter>[ab])(?P<digit>\d)')
+      letter digit
+    0      a     1
+    1      b     2
+    2    NaN   NaN
+
+    A pattern with one group will return a DataFrame with one column
+    if expand=True.
+
+    >>> s.str.extract('[ab](\d)', expand=True)
+         0
+    0    1
+    1    2
+    2  NaN
+
+    A pattern with one group will return a Series if expand=False.
+
+    >>> s.str.extract('[ab](\d)', expand=False)
+    0      1
+    1      2
+    2    NaN
+    dtype: object
+
+    """
+    if expand is None:
+        warnings.warn(
+            "currently extract(expand=None) " +
+            "means expand=False (return Index/Series/DataFrame) " +
+            "but in a future version of pandas this will be changed " +
+            "to expand=True (return DataFrame)",
+            FutureWarning,
+            stacklevel=3)
+        expand = False
+    if not isinstance(expand, bool):
+        raise ValueError("expand must be True or False")
+    if expand:
+        return _str_extract_frame(arr._orig, pat, flags=flags)
+    else:
+        result, name = _str_extract_noexpand(arr._data, pat, flags=flags)
+        return arr._wrap_result(result, name=name)
+
+
+def str_extractall(arr, pat, flags=0):
+    """
+    For each subject string in the Series, extract groups from all
+    matches of regular expression pat. When each subject string in the
+    Series has exactly one match, extractall(pat).xs(0, level='match')
+    is the same as extract(pat).
+
+    .. versionadded:: 0.18.0
+
+    Parameters
+    ----------
+    pat : string
+        Regular expression pattern with capturing groups
+    flags : int, default 0 (no flags)
+        re module flags, e.g. re.IGNORECASE
+
+    Returns
+    -------
+    A DataFrame with one row for each match, and one column for each
+    group. Its rows have a MultiIndex with first levels that come from
+    the subject Series. The last level is named 'match' and indicates
+    the order in the subject. Any capture group names in regular
+    expression pat will be used for column names; otherwise capture
+    group numbers will be used.
+
+    See Also
+    --------
+    extract : returns first match only (not all matches)
+
+    Examples
+    --------
+    A pattern with one group will return a DataFrame with one column.
+    Indices with no matches will not appear in the result.
+
+    >>> s = Series(["a1a2", "b1", "c1"], index=["A", "B", "C"])
+    >>> s.str.extractall("[ab](\d)")
+             0
+      match
+    A 0      1
+      1      2
+    B 0      1
+
+    Capture group names are used for column names of the result.
+
+    >>> s.str.extractall("[ab](?P<digit>\d)")
+            digit
+      match
+    A 0         1
+      1         2
+    B 0         1
+
+    A pattern with two groups will return a DataFrame with two columns.
+
+    >>> s.str.extractall("(?P<letter>[ab])(?P<digit>\d)")
+            letter digit
+      match
+    A 0          a     1
+      1          a     2
+    B 0          b     1
+
+    Optional groups that do not match are NaN in the result.
+
+    >>> s.str.extractall("(?P<letter>[ab])?(?P<digit>\d)")
+            letter digit
+      match
+    A 0          a     1
+      1          a     2
+    B 0          b     1
+    C 0        NaN     1
+
+    """
+    from pandas import DataFrame, MultiIndex
+    regex = re.compile(pat, flags=flags)
+    # the regex must contain capture groups.
+    if regex.groups == 0:
+        raise ValueError("pattern contains no capture groups")
+    names = dict(zip(regex.groupindex.values(), regex.groupindex.keys()))
+    columns = [names.get(1 + i, i) for i in range(regex.groups)]
+    match_list = []
+    index_list = []
+    for subject_key, subject in arr.iteritems():
+        if isinstance(subject, compat.string_types):
+            try:
+                key_list = list(subject_key)
+            except TypeError:
+                key_list = [subject_key]
+            for match_i, match_tuple in enumerate(regex.findall(subject)):
+                na_tuple = [
+                    np.NaN if group == "" else group for group in match_tuple]
+                match_list.append(na_tuple)
+                result_key = tuple(key_list + [match_i])
+                index_list.append(result_key)
+    if 0 < len(index_list):
+        index = MultiIndex.from_tuples(
+            index_list, names=arr.index.names + ["match"])
+    else:
+        index = None
+    result = DataFrame(match_list, index, columns)
+    return result
 
 
 def str_get_dummies(arr, sep='|'):
@@ -599,6 +785,10 @@ def str_findall(arr, pat, flags=0):
     Returns
     -------
     matches : Series/Index of lists
+
+    See Also
+    --------
+    extractall : returns DataFrame with one column per capture group
     """
     regex = re.compile(pat, flags=flags)
     return _na_map(regex.findall, arr)
@@ -1403,9 +1593,12 @@ class StringMethods(NoNewAttributesMixin):
     findall = _pat_wrapper(str_findall, flags=True)
 
     @copy(str_extract)
-    def extract(self, pat, flags=0):
-        result, name = str_extract(self._data, pat, flags=flags)
-        return self._wrap_result(result, name=name)
+    def extract(self, pat, flags=0, expand=None):
+        return str_extract(self, pat, flags=flags, expand=expand)
+
+    @copy(str_extractall)
+    def extractall(self, pat, flags=0):
+        return str_extractall(self._orig, pat, flags=flags)
 
     _shared_docs['find'] = ("""
     Return %(side)s indexes in each strings in the Series/Index

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -4110,6 +4110,7 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
             ('encode', ("UTF-8",), {}),
             ('endswith', ("a",), {}),
             ('extract', ("([a-z]*) ",), {}),
+            ('extractall', ("([a-z]*) ",), {}),
             ('find', ("a",), {}),
             ('findall', ("a",), {}),
             ('index', (" ",), {}),


### PR DESCRIPTION
For a series `S`, the excellent `S.str.extract` method returns the first match in each subject of the series:

``` python
>>> import re
>>> import pandas as pd
>>> import numpy as np
>>> data = {
...     'Dave': 'dave@google.com',
...     'multiple': 'rob@gmail.com some text steve@gmail.com',
...     'none': np.nan,
...     }
>>> pattern = r'''
... (?P<user>[a-z]+)
... @
... (?P<domain>[a-z]+)
... \.
... (?P<tld>[a-z]{2,4})
... '''
>>> S = pd.Series(data)
>>> S.str.extract(pattern, re.VERBOSE)
          user  domain  tld
Dave      dave  google  com
multiple   rob   gmail  com
none       NaN     NaN  NaN
>>> 
```

That's great, but sometimes we want to extract all matches in each element of the series. You can do that with `S.str.findall` but its result does not include the names specified in the capturing groups of the regular expression:

``` python
>>> S.str.findall(pattern, re.VERBOSE)
Dave                           [(dave, google, com)]
multiple    [(rob, gmail, com), (steve, gmail, com)]
none                                             NaN
dtype: object
>>> 
```

I propose the `S.str.extractall` method which returns a `Series` the same length as the subject `S`. Each element of the series is a `DataFrame` with a row for each match and a column for each group:

``` python
>>> result = S.str.extractall(pattern, re.VERBOSE)
>>> result[0]
   user  domain  tld
0  dave  google  com
>>> result[1]
    user domain  tld
0    rob  gmail  com
1  steve  gmail  com
>>> result[2]
Empty DataFrame
Columns: [user, domain, tld]
Index: []
>>> 
```

Before I write any more testing code, can we start a discussion about whether or not this is an acceptable design choice, in relation to the other functionality of pandas? @sinhrks @jorisvandenbossche @jreback @mortada since you seem to be discussing extract in #10103

Also do you have any ideas about how to get the result (a Series of DataFrames) to print more nicely? With my current fork we have

``` python
>>> result
Dave                   user  domain  tld
0  dave  google  com
multiple        user domain  tld
0    rob  gmail  com
1  s...
none        Empty DataFrame
Columns: [user, domain, tld]
I...
dtype: object
>>> 
```

In R the equivalent functionality is provided by the https://github.com/tdhock/namedCapture package (str_match_all_named returns a list of data.frames), and the resulting printout is readable because of the way that R prints lists:

``` r
> library(namedCapture)
> S <- c(
+   Dave='dave@google.com',
+   multiple='rob@gmail.com some text steve@gmail.com',
+   none=NA)
> pattern <- paste0(
+   "(?P<user>[a-z]+)",
+   "@",
+   "(?P<domain>[a-z]+)",
+   "[.]",
+   "(?P<tld>[a-z]{2,4})")
> str_match_all_named(S, pattern)
$Dave
     user   domain   tld  
[1,] "dave" "google" "com"

$multiple
     user    domain  tld  
[1,] "rob"   "gmail" "com"
[2,] "steve" "gmail" "com"

$none
<0 x 0 matrix>

> 
```
