### PR TITLE
BUG: GH11344 in pandas.json when file to read is big

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -111,7 +111,7 @@ Bug Fixes
 - Bug in ``DataFrame.to_latex()`` produces an extra rule when ``header=False`` (:issue:`7124`)
 
 
-
+- Bug in ``pandas.json`` when file to load is big (:issue:`11344`)
 - Bugs in ``to_excel`` with duplicate columns (:issue:`11007`, :issue:`10982`, :issue:`10970`)
 - Fixed a bug that prevented the construction of an empty series of dtype
   ``datetime64[ns, tz]`` (:issue:`11245`).

--- a/pandas/src/ujson/lib/ultrajsondec.c
+++ b/pandas/src/ujson/lib/ultrajsondec.c
@@ -443,7 +443,7 @@ FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_string ( struct DecoderState *ds)
 
     if (ds->escHeap)
     {
-      if (newSize > (UINT_MAX / sizeof(wchar_t)))
+      if (newSize > (SIZE_MAX / sizeof(wchar_t)))
       {
         return SetError(ds, -1, "Could not reserve memory block");
       }
@@ -458,8 +458,7 @@ FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_string ( struct DecoderState *ds)
     else
     {
       wchar_t *oldStart = ds->escStart;
-      ds->escHeap = 1;
-      if (newSize > (UINT_MAX / sizeof(wchar_t)))
+      if (newSize > (SIZE_MAX / sizeof(wchar_t)))
       {
         return SetError(ds, -1, "Could not reserve memory block");
       }
@@ -468,6 +467,7 @@ FASTCALL_ATTR JSOBJ FASTCALL_MSVC decode_string ( struct DecoderState *ds)
       {
         return SetError(ds, -1, "Could not reserve memory block");
       }
+      ds->escHeap = 1;
       memcpy(ds->escStart, oldStart, escLen * sizeof(wchar_t));
     }
 


### PR DESCRIPTION
closes #11344
taken from esnme/ultrajson#145

test code 

```
import json
import pandas
from pandas.compat import zip, range
SIZE = 5*10**7
FILENAME = 'generated.json'
with open(FILENAME, 'w') as fileh:
    json.dump(dict(zip(range(SIZE), range(SIZE))), fileh)
with open(FILENAME) as fileh:
    pandas.json.load(fileh)
```
