### PR TITLE
ENC: better pandas typesetting in ipython nbconvert --to latex (updated)

### DIFF
--- a/doc/source/whatsnew/v0.16.1.txt
+++ b/doc/source/whatsnew/v0.16.1.txt
@@ -21,6 +21,7 @@ Enhancements
 
 - ``DataFrame.mask()`` and ``Series.mask()`` now support same keywords as ``where`` (:issue:`8801`)
 
+- Added support for rendering DataFrames correctly when converting Jupyter/IPython notebooks to LaTeX (:issue:`9821`)
 
 
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1430,6 +1430,11 @@ class DataFrame(NDFrame):
             return formatter.buf.getvalue()
     
     def _repr_latex_(self):
+        """
+        Used for rendering a DataFrame when converting a Jupyter/IPython notebook to LaTeX.
+        For other uses refer to the `to_latex` function.
+        See https://github.com/pydata/pandas/pull/9821 for aditional information.
+        """
         return self.to_latex()
     
     def info(self, verbose=None, buf=None, max_cols=None, memory_usage=None, null_counts=None):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1428,7 +1428,10 @@ class DataFrame(NDFrame):
 
         if buf is None:
             return formatter.buf.getvalue()
-
+    
+    def _repr_latex_(self):
+        return self.to_latex()
+    
     def info(self, verbose=None, buf=None, max_cols=None, memory_usage=None, null_counts=None):
         """
         Concise summary of a DataFrame.

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4752,6 +4752,14 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         self.assertFalse("\t" in repr(df))
         self.assertFalse("\r" in repr(df))
         self.assertFalse("a\n" in repr(df))
+    
+    def test_repr_latex(self):
+        # #9821
+        
+        df = DataFrame({'A': [1., 2., 3.],
+                       'B': ['a', 'b', 'c']},
+                       index=np.arange(3))
+        self.assertEqual(df._repl_latex_(), df.to_latex())
 
     def test_repr_dimensions(self):
         df = DataFrame([[1, 2,], [3, 4]])


### PR DESCRIPTION
New pull request with tests and comments. See https://github.com/pydata/pandas/pull/9821 for original PR.
