### PR TITLE
BUG: using .ix with a multi-index indexer

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -70,7 +70,7 @@ Bug Fixes
 - Bug in ``HDFStore.append`` with strings whose encoded length exceded the max unencoded length (:issue:`11234`)
 - Bug in merging ``datetime64[ns, tz]`` dtypes (:issue:`11405`)
 - Bug in ``HDFStore.select`` when comparing with a numpy scalar in a where clause (:issue:`11283`)
-
+- Bug in using ``DataFrame.ix`` with a multi-index indexer(:issue:`11372`) 
 
 
 - Bug in tz-conversions with an ambiguous time and ``.dt`` accessors (:issue:`11295`)


### PR DESCRIPTION
closes #11372 

Add an optional argument to _NDFrameIndexer to indicate
if the indexer is from a MultiIndex
