### PR TITLE
DOC: fix cython example (failed on Windows) (GH6002)

### DIFF
--- a/doc/source/enhancingperf.rst
+++ b/doc/source/enhancingperf.rst
@@ -274,8 +274,8 @@ advanced cython techniques:
       ...:     return s * dx
       ...: @cython.boundscheck(False)
       ...: @cython.wraparound(False)
-      ...: cpdef np.ndarray[double] apply_integrate_f_wrap(np.ndarray[double] col_a, np.ndarray[double] col_b, np.ndarray[Py_ssize_t] col_N):
-      ...:     cdef Py_ssize_t i, n = len(col_N)
+      ...: cpdef np.ndarray[double] apply_integrate_f_wrap(np.ndarray[double] col_a, np.ndarray[double] col_b, np.ndarray[int] col_N):
+      ...:     cdef int i, n = len(col_N)
       ...:     assert len(col_a) == len(col_b) == n
       ...:     cdef np.ndarray[double] res = np.empty(n)
       ...:     for i in range(n):


### PR DESCRIPTION
Closes  #6002

The signature of `apply_integrate_f_wrap` (http://pandas-docs.github.io/pandas-docs-travis/enhancingperf.html#more-advanced-techniques) used `Py_ssize_t` but on Windows that gives an error, as the dataframe is generated with numpy random arrays, which gives int32 on Windows, while `Py_ssize_t` is int64 on 64 bit Windows.
