### PR TITLE
CI: Py3.5 / numpy 1.10 testing

### DIFF
--- a/ci/requirements-3.5.build
+++ b/ci/requirements-3.5.build
@@ -1,4 +1,4 @@
 python-dateutil
 pytz
-numpy=1.9.3
+numpy
 cython

--- a/ci/requirements-3.5.run
+++ b/ci/requirements-3.5.run
@@ -1,6 +1,6 @@
 python-dateutil
 pytz
-numpy=1.9.3
+numpy
 openpyxl
 xlsxwriter
 xlrd

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -87,11 +87,7 @@ class TestCategorical(tm.TestCase):
         self.assertFalse(factor.ordered)
 
         # this however will raise as cannot be sorted
-        # but fixed in newer versions of numpy
-        if LooseVersion(np.__version__) < "1.10":
-            self.assertRaises(TypeError, lambda :  Categorical.from_array(arr, ordered=True))
-        else:
-            Categorical.from_array(arr, ordered=True)
+        self.assertRaises(TypeError, lambda :  Categorical.from_array(arr, ordered=True))
 
     def test_is_equal_dtype(self):
 


### PR DESCRIPTION
closes #11187
closes #11138
