### PR TITLE
BUG: fix Panel.fillna() ignoring axis parameter (re-submission)

### DIFF
--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -10,7 +10,7 @@ from pandas.compat import u
 from pandas.core.algorithms import factorize
 from pandas.core.base import PandasObject, PandasDelegate, NoNewAttributesMixin
 import pandas.core.common as com
-from pandas.core.missing import interpolate_2d
+from pandas.core.missing import pad
 from pandas.util.decorators import cache_readonly, deprecate_kwarg
 
 from pandas.core.common import (ABCSeries, ABCIndexClass, ABCPeriodIndex, ABCCategoricalIndex,
@@ -1340,8 +1340,7 @@ class Categorical(PandasObject):
         if method is not None:
 
             values = self.to_dense().reshape(-1, len(self))
-            values = interpolate_2d(
-                values, method, 0, None, value).astype(self.categories.dtype)[0]
+            values = pad(values, method, 0, None, value).astype(self.categories.dtype)[0]
             values = _get_codes_for_values(values, self.categories)
 
         else:

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -49,9 +49,9 @@ def _clean_interp_method(method, **kwargs):
     return method
 
 
-def interpolate_1d(xvalues, yvalues, method='linear', limit=None,
-                   limit_direction='forward',
-                   fill_value=None, bounds_error=False, order=None, **kwargs):
+def interpolate(xvalues, yvalues, method='linear', limit=None,
+                limit_direction='forward',
+                fill_value=None, bounds_error=False, order=None, **kwargs):
     """
     Logic for the 1-d interpolation.  The result should be 1-d, inputs
     xvalues and yvalues will each be 1-d arrays of the same length.
@@ -219,20 +219,42 @@ def _interpolate_scipy_wrapper(x, y, new_x, method, fill_value=None,
     return new_y
 
 
-def interpolate_2d(values, method='pad', axis=0, limit=None, fill_value=None, dtype=None):
-    """ perform an actual interpolation of values, values will be make 2-d if
-    needed fills inplace, returns the result
+def pad(values, method='pad', axis=0, limit=None, fill_value=None, dtype=None):
+    """ 
+    Perform an actual interpolation of values. 1-d values will be made 2-d temporarily. 
+    Returns the result
     """
 
-    transf = (lambda x: x) if axis == 0 else (lambda x: x.T)
+    ndim = values.ndim
 
     # reshape a 1 dim if needed
-    ndim = values.ndim
-    if values.ndim == 1:
+    if ndim == 1:
         if axis != 0:  # pragma: no cover
             raise AssertionError("cannot interpolate on a ndim == 1 with "
                                  "axis != 0")
         values = values.reshape(tuple((1,) + values.shape))
+    # recursively slice n-dimension frames (n>2) into (n-1)-dimension frames
+    elif ndim > 2:
+        slice_axis = 1 if axis == 0 else 0
+        slicer = [slice(None)]*ndim
+
+        if ndim == 3:
+            axis = 0 if (axis > 1) else 1
+        else:
+            axis = axis - 1 if (axis > 0) else 0
+
+        for n in range(values.shape[slice_axis]):
+            slicer[slice_axis] = n            
+            values[slicer] = pad(values[slicer], 
+                                 method=method, 
+                                 axis=axis, 
+                                 limit=limit, 
+                                 fill_value=fill_value, 
+                                 dtype=dtype)
+
+        return values
+
+    transf = (lambda x: x) if axis == 0 else (lambda x: x.T)
 
     if fill_value is None:
         mask = None

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -909,11 +909,106 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
         # assert_panel_equal(sorted_panel, self.panel)
 
     def test_fillna(self):
+        # GH 11445
         self.assertFalse(np.isfinite(self.panel4d.values).all())
         filled = self.panel4d.fillna(0)
         self.assertTrue(np.isfinite(filled.values).all())
 
-        self.assertRaises(NotImplementedError, self.panel4d.fillna, method='pad')
+        filled = self.panel4d.fillna(method='backfill')
+        assert_frame_equal(filled['l1']['ItemA'],
+                           self.panel4d['l1']['ItemA'].fillna(method='backfill'))
+
+        panel4d = self.panel4d.copy()
+        panel4d['str'] = 'foo'
+
+        filled = panel4d.fillna(method='backfill')
+        assert_frame_equal(filled['l1']['ItemA'],
+                           panel4d['l1']['ItemA'].fillna(method='backfill'))
+
+        # Fill forward.
+        filled = self.panel4d.fillna(method='ffill')
+        assert_frame_equal(filled['l1']['ItemA'],
+                           self.panel4d['l1']['ItemA'].fillna(method='ffill'))
+
+        # With limit.
+        filled = self.panel4d.fillna(method='backfill', limit=1)
+        assert_frame_equal(filled['l1']['ItemA'],
+                           self.panel4d['l1']['ItemA'].fillna(method='backfill', limit=1))
+
+        # With downcast.
+        rounded = self.panel4d.apply(lambda x: x.apply(np.round))
+        filled = rounded.fillna(method='backfill', downcast='infer')
+        assert_frame_equal(filled['l1']['ItemA'],
+                           rounded['l1']['ItemA'].fillna(method='backfill', downcast='infer'))
+
+        # Now explicitly request axis 2.
+        filled = self.panel4d.fillna(method='backfill', axis=2)
+        assert_frame_equal(filled['l1']['ItemA'],
+                           self.panel4d['l1']['ItemA'].fillna(method='backfill', axis=0))
+
+        # Fill along axis 3, equivalent to filling along axis 1 of each
+        # DataFrame.
+        filled = self.panel4d.fillna(method='backfill', axis=3)
+        assert_frame_equal(filled['l1']['ItemA'],
+                           self.panel4d['l1']['ItemA'].fillna(method='backfill', axis=1))
+
+        # Fill an empty panel.
+        empty = self.panel4d.reindex(items=[])
+        filled = empty.fillna(0)
+        assert_panel4d_equal(filled, empty)
+
+        # either method or value must be specified
+        self.assertRaises(ValueError, self.panel4d.fillna)
+        # method and value can not both be specified
+        self.assertRaises(ValueError, self.panel4d.fillna, 5, method='ffill')
+
+        # can't pass list or tuple, only scalar
+        self.assertRaises(TypeError, self.panel4d.fillna, [1, 2])
+        self.assertRaises(TypeError, self.panel4d.fillna, (1, 2))
+
+        # limit not implemented when only value is specified
+        p = Panel4D(np.random.randn(3,4,5,6))
+        p.iloc[0:2,0:2,0:2,0:2] = np.nan
+        self.assertRaises(NotImplementedError, lambda : p.fillna(999, limit=1))
+
+    def test_fillna_axis_0(self):
+        # GH 11445
+
+        # Back fill along axis 0, interpolating values across Panels
+        filled = self.panel4d.fillna(method='bfill', axis=0)
+        nan_indexes = self.panel4d.loc['l1', 'ItemB', :, 'C'].index[
+            self.panel4d.loc['l1', 'ItemB', :, 'C'].apply(np.isnan)]
+
+        # Values from ItemC are filled into ItemB.
+        assert_series_equal(filled.loc['l1', 'ItemB', :, 'C'][nan_indexes],
+                            self.panel4d.loc['l1', 'ItemC', :, 'C'][nan_indexes])
+
+        # Forward fill along axis 0.
+        filled = self.panel4d.fillna(method='ffill', axis=0)
+
+        # The test data lacks values that can be backfilled on axis 0.
+        assert_panel4d_equal(filled, self.panel4d)
+
+        # Reverse the panel and backfill along axis 0, to properly test
+        # forward fill.
+        reverse_panel = self.panel4d.reindex_axis(reversed(self.panel4d.axes[0]))
+        filled = reverse_panel.fillna(method='ffill', axis=0)
+        nan_indexes = reverse_panel.loc['l3', 'ItemB', :, 'C'].index[
+            reverse_panel.loc['l3', 'ItemB', :, 'C'].apply(np.isnan)]
+        assert_series_equal(filled.loc['l3', 'ItemB', :, 'C'][nan_indexes],
+                            reverse_panel.loc['l1', 'ItemB', :, 'C'][nan_indexes])
+
+        # Fill along axis 0 with limit.
+        filled = self.panel4d.fillna(method='bfill', axis=0, limit=1)
+        c_nan = self.panel4d.loc['l1', 'ItemC', :, 'C'].index[
+            self.panel4d.loc['l1', 'ItemC', :, 'C'].apply(np.isnan)]
+        b_nan = self.panel4d.loc['l1', 'ItemB', :, 'C'].index[
+            self.panel4d.loc['l1', 'ItemB', :, 'C'].apply(np.isnan)]
+
+        # Cells that are nan in ItemB but not in ItemC remain unfilled in
+        # ItemA.
+        self.assertTrue(
+            filled.loc['l1', 'ItemA', :, 'C'][b_nan.difference(c_nan)].apply(np.isnan).all())
 
     def test_swapaxes(self):
         result = self.panel4d.swapaxes('labels', 'items')


### PR DESCRIPTION
closes #3570 
closes #8251

This is a re-submission of PR #8395 and addresses issue #8251. My apologies for the duplicate PR, but despite rebasing to pydata/pandas master, the original PR would not update with my new commits and I couldn't get rid of the `LooseVersion()` errors in the Travis build.

This PR may need some fleshing out still, but I wanted to submit this to see what the thoughts are on this approach. For this PR I've created a new interpolation mechanism at the block level to implement filling across 3 or more dimensions. This avoids the fiddly problems of trying to implement filling of 3+ dimensions at the frame level. However, it isn't possible with this technique to fill across blocks of different dtypes, although that seems like that should be a rare occurrence. 

Incidentally, this will also address #3570, which is one of the issues referenced in #9862.
