### PR TITLE
implemented fix for groupby date bug, #11324

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -117,3 +117,5 @@ Bug Fixes
 - Bug in ``to_excel`` with openpyxl 2.2+ and merging (:issue:`11408`)
 
 - Bug in ``DataFrame.to_dict()`` produces a ``np.datetime64`` object instead of ``Timestamp`` when only datetime is present in data (:issue:`11327`)
+
+- Bug in ``pandas.core.groupby`` raises exception when ``func`` in ``df.groupby(...).apply(func)`` doesn't return existing time columns (:issue:`11324`)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -3124,6 +3124,7 @@ class NDFrameGroupBy(GroupBy):
                     result = result._convert(numeric=True)
                     date_cols = self._selected_obj.select_dtypes(
                         include=list(_DATELIKE_DTYPES)).columns
+                    date_cols = date_cols.intersection(result.columns)
                     result[date_cols] = (result[date_cols]
                                          ._convert(datetime=True,
                                                           coerce=True))


### PR DESCRIPTION
This is a fix for issue #11324 in which grouping when datetime fields are involved raises an exceptoin
