### PR TITLE
allow rename to work with any Mapping, not just dict

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4,6 +4,8 @@ import operator
 import weakref
 import gc
 
+from collections.abc import Mapping
+
 import numpy as np
 import pandas.lib as lib
 
@@ -580,7 +582,7 @@ class NDFrame(PandasObject):
 
         # renamer function if passed a dict
         def _get_rename_function(mapper):
-            if isinstance(mapper, (dict, ABCSeries)):
+            if isinstance(mapper, (Mapping, ABCSeries)):
                 def f(x):
                     if x in mapper:
                         return mapper[x]


### PR DESCRIPTION
http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.rename.html claims to work with a dict-like object, but according to https://github.com/jab/bidict/issues/18#issuecomment-147643550 it does not. This patch changes `isinstance(..., dict)` to `isinstance(..., collections.abc.Mapping)` as a first pass attempt to bring the code more in line with the documentation.
