### PR TITLE
BUG: Holiday observance rules could not be applied

### DIFF
--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -1043,10 +1043,14 @@ An example of how holidays and holiday calendars are defined:
     cal.holidays(datetime(2012, 1, 1), datetime(2012, 12, 31))
 
 Using this calendar, creating an index or doing offset arithmetic skips weekends
-and holidays (i.e., Memorial Day/July 4th).
+and holidays (i.e., Memorial Day/July 4th).  For example, the below defines
+a custom business day offset using the ``ExampleCalendar``.  Like any other offset,
+it can be used to create a ``DatetimeIndex`` or added to ``datetime`` 
+or ``Timestamp`` objects.
 
 .. ipython:: python
 
+    from pandas.tseries.offsets import CDay
     DatetimeIndex(start='7/1/2012', end='7/10/2012',
         freq=CDay(calendar=cal)).to_pydatetime()
     offset = CustomBusinessDay(calendar=cal)

--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -115,6 +115,8 @@ Bug Fixes
 
 
 - Fix regression in setting of ``xticks`` in ``plot`` (:issue:`11529`).
+- Bug in ``holiday.dates`` where observance rules could not be applied to holiday and doc enhancement (:issue:`11477`, :issue:`11533`)
+
 
 
 

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -3,6 +3,7 @@ from pandas.compat import add_metaclass
 from datetime import datetime, timedelta
 from dateutil.relativedelta import MO, TU, WE, TH, FR, SA, SU
 from pandas.tseries.offsets import Easter, Day
+import numpy as np
 
 
 def next_monday(dt):
@@ -156,8 +157,8 @@ class Holiday(object):
         self.month = month
         self.day = day
         self.offset = offset
-        self.start_date = start_date
-        self.end_date = end_date
+        self.start_date = Timestamp(start_date) if start_date is not None else start_date
+        self.end_date = Timestamp(end_date) if end_date is not None else end_date
         self.observance = observance
         assert (days_of_week is None or type(days_of_week) == tuple)
         self.days_of_week = days_of_week
@@ -179,7 +180,7 @@ class Holiday(object):
 
     def dates(self, start_date, end_date, return_name=False):
         """
-        Calculate holidays between start date and end date
+        Calculate holidays observed between start date and end date
 
         Parameters
         ----------
@@ -189,6 +190,12 @@ class Holiday(object):
             If True, return a series that has dates and holiday names.
             False will only return dates.
         """
+        start_date = Timestamp(start_date)
+        end_date = Timestamp(end_date)
+        
+        filter_start_date = start_date 
+        filter_end_date = end_date
+        
         if self.year is not None:
             dt = Timestamp(datetime(self.year, self.month, self.day))
             if return_name:
@@ -196,40 +203,57 @@ class Holiday(object):
             else:
                 return [dt]
 
-        if self.start_date is not None:
-            start_date = self.start_date
-
-        if self.end_date is not None:
-            end_date = self.end_date
-
-        start_date = Timestamp(start_date)
-        end_date = Timestamp(end_date)
-
-        year_offset = DateOffset(years=1)
-        base_date = Timestamp(
-            datetime(start_date.year, self.month, self.day),
-            tz=start_date.tz,
-        )
-        dates = DatetimeIndex(start=base_date, end=end_date, freq=year_offset)
+        dates = self._reference_dates(start_date, end_date)
         holiday_dates = self._apply_rule(dates)
         if self.days_of_week is not None:
-            holiday_dates = list(filter(lambda x: x is not None and
-                                                  x.dayofweek in self.days_of_week,
-                                                  holiday_dates))
-        else:
-            holiday_dates = list(filter(lambda x: x is not None, holiday_dates))
+            holiday_dates = holiday_dates[np.in1d(holiday_dates.dayofweek,
+                                                  self.days_of_week)]
+            
+        if self.start_date is not None:
+            filter_start_date = max(self.start_date.tz_localize(filter_start_date.tz), filter_start_date)
+        if self.end_date is not None:
+            filter_end_date = min(self.end_date.tz_localize(filter_end_date.tz), filter_end_date)
+        holiday_dates = holiday_dates[(holiday_dates >= filter_start_date) & 
+                                      (holiday_dates <= filter_end_date)]
         if return_name:
             return Series(self.name, index=holiday_dates)
         return holiday_dates
+        
+        
+    def _reference_dates(self, start_date, end_date):
+        """
+        Get reference dates for the holiday.
+        
+        Return reference dates for the holiday also returning the year
+        prior to the start_date and year following the end_date.  This ensures
+        that any offsets to be applied will yield the holidays within
+        the passed in dates.
+        """
+        if self.start_date is not None:
+            start_date = self.start_date.tz_localize(start_date.tz)
+
+        if self.end_date is not None:
+            end_date = self.end_date.tz_localize(start_date.tz)
+
+        year_offset = DateOffset(years=1)
+        reference_start_date = Timestamp(
+            datetime(start_date.year-1, self.month, self.day))
+        
+        reference_end_date = Timestamp(
+            datetime(end_date.year+1, self.month, self.day))
+        # Don't process unnecessary holidays
+        dates = DatetimeIndex(start=reference_start_date, end=reference_end_date, 
+                              freq=year_offset, tz=start_date.tz)
+        
+        return dates
 
     def _apply_rule(self, dates):
         """
-        Apply the given offset/observance to an
-        iterable of dates.
+        Apply the given offset/observance to a DatetimeIndex of dates.
 
         Parameters
         ----------
-        dates : array-like
+        dates : DatetimeIndex
             Dates to apply the given offset/observance rule
 
         Returns
@@ -237,7 +261,7 @@ class Holiday(object):
         Dates with rules applied
         """
         if self.observance is not None:
-            return map(lambda d: self.observance(d), dates)
+            return dates.map(lambda d: self.observance(d))
 
         if self.offset is not None:
             if not isinstance(self.offset, list):
@@ -245,7 +269,7 @@ class Holiday(object):
             else:
                 offsets = self.offset
             for offset in offsets:
-                dates = list(map(lambda d: d + offset, dates))
+                dates += offset
         return dates
 
 holiday_calendars = {}
@@ -303,6 +327,13 @@ class AbstractHolidayCalendar(object):
 
         if rules is not None:
             self.rules = rules
+            
+    def rule_from_name(self, name):
+        for rule in self.rules:
+            if rule.name == name:
+                return rule
+            
+        return None
 
     def holidays(self, start=None, end=None, return_name=False):
         """


### PR DESCRIPTION
Closes #11477
Closes #11533 

There were some other bugs here that I added tests for.  For example, `holiday.dates` for MLK day was returning all holidays from the holiday start date up to the end date rather than just between the range.
