### PR TITLE
BUG: .loc with duplicated label may have incorrect index dtype

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -112,3 +112,7 @@ Bug Fixes
 - Bug in ``.loc`` against ``CategoricalIndex`` may result in normal ``Index`` (:issue:`11586`)
 - Bug groupby on tz-aware data where selection not returning ``Timestamp`` (:issue:`11616`)
 - Bug in timezone info lost when broadcasting scalar datetime to ``DataFrame`` (:issue:`11682`)
+
+
+- Bug in ``.loc`` result with duplicated key may have ``Index`` with incorrect dtype (:issue:`11497`)
+

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -3516,44 +3516,163 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         # Regression from GH4825
         ser = Series([0.1, 0.2], index=[1, 2])
 
-        # ToDo: check_index_type can be True after GH 11497
-
         # loc
         expected = Series([np.nan, 0.2, np.nan], index=[3, 2, 3])
         result = ser.loc[[3, 2, 3]]
-        assert_series_equal(result, expected, check_index_type=False)
+        assert_series_equal(result, expected, check_index_type=True)
+
+        expected = Series([np.nan, 0.2, np.nan, np.nan], index=[3, 2, 3, 'x'])
+        result = ser.loc[[3, 2, 3, 'x']]
+        assert_series_equal(result, expected, check_index_type=True)
+
+        expected = Series([0.2, 0.2, 0.1], index=[2, 2, 1])
+        result = ser.loc[[2, 2, 1]]
+        assert_series_equal(result, expected, check_index_type=True)
+
+        expected = Series([0.2, 0.2, np.nan, 0.1], index=[2, 2, 'x', 1])
+        result = ser.loc[[2, 2, 'x', 1]]
+        assert_series_equal(result, expected, check_index_type=True)
 
         # raises as nothing in in the index
         self.assertRaises(KeyError, lambda : ser.loc[[3, 3, 3]])
 
         expected = Series([0.2, 0.2, np.nan], index=[2, 2, 3])
         result = ser.loc[[2, 2, 3]]
-        assert_series_equal(result, expected, check_index_type=False)
+        assert_series_equal(result, expected, check_index_type=True)
 
         expected = Series([0.3, np.nan, np.nan], index=[3, 4, 4])
         result = Series([0.1, 0.2, 0.3], index=[1, 2, 3]).loc[[3, 4, 4]]
-        assert_series_equal(result, expected, check_index_type=False)
+        assert_series_equal(result, expected, check_index_type=True)
 
         expected = Series([np.nan, 0.3, 0.3], index=[5, 3, 3])
         result = Series([0.1, 0.2, 0.3, 0.4], index=[1, 2, 3, 4]).loc[[5, 3, 3]]
-        assert_series_equal(result, expected, check_index_type=False)
+        assert_series_equal(result, expected, check_index_type=True)
 
         expected = Series([np.nan, 0.4, 0.4], index=[5, 4, 4])
         result = Series([0.1, 0.2, 0.3, 0.4], index=[1, 2, 3, 4]).loc[[5, 4, 4]]
-        assert_series_equal(result, expected, check_index_type=False)
+        assert_series_equal(result, expected, check_index_type=True)
 
         expected = Series([0.4, np.nan, np.nan], index=[7, 2, 2])
         result = Series([0.1, 0.2, 0.3, 0.4], index=[4, 5, 6, 7]).loc[[7, 2, 2]]
-        assert_series_equal(result, expected, check_index_type=False)
+        assert_series_equal(result, expected, check_index_type=True)
 
         expected = Series([0.4, np.nan, np.nan], index=[4, 5, 5])
         result = Series([0.1, 0.2, 0.3, 0.4], index=[1, 2, 3, 4]).loc[[4, 5, 5]]
-        assert_series_equal(result, expected, check_index_type=False)
+        assert_series_equal(result, expected, check_index_type=True)
 
         # iloc
         expected = Series([0.2, 0.2, 0.1, 0.1], index=[2, 2, 1, 1])
         result = ser.iloc[[1, 1, 0, 0]]
-        assert_series_equal(result, expected, check_index_type=False)
+        assert_series_equal(result, expected, check_index_type=True)
+
+    def test_series_partial_set_with_name(self):
+        # GH 11497
+
+        idx = Index([1, 2], dtype='int64', name='idx')
+        ser = Series([0.1, 0.2], index=idx, name='s')
+
+        # loc
+        exp_idx = Index([3, 2, 3], dtype='int64', name='idx')
+        expected = Series([np.nan, 0.2, np.nan], index=exp_idx, name='s')
+        result = ser.loc[[3, 2, 3]]
+        assert_series_equal(result, expected, check_index_type=True)
+
+        exp_idx = Index([3, 2, 3, 'x'], dtype='object', name='idx')
+        expected = Series([np.nan, 0.2, np.nan, np.nan], index=exp_idx, name='s')
+        result = ser.loc[[3, 2, 3, 'x']]
+        assert_series_equal(result, expected, check_index_type=True)
+
+        exp_idx = Index([2, 2, 1], dtype='int64', name='idx')
+        expected = Series([0.2, 0.2, 0.1], index=exp_idx, name='s')
+        result = ser.loc[[2, 2, 1]]
+        assert_series_equal(result, expected, check_index_type=True)
+
+        exp_idx = Index([2, 2, 'x', 1], dtype='object', name='idx')
+        expected = Series([0.2, 0.2, np.nan, 0.1], index=exp_idx, name='s')
+        result = ser.loc[[2, 2, 'x', 1]]
+        assert_series_equal(result, expected, check_index_type=True)
+
+        # raises as nothing in in the index
+        self.assertRaises(KeyError, lambda : ser.loc[[3, 3, 3]])
+
+        exp_idx = Index([2, 2, 3], dtype='int64', name='idx')
+        expected = Series([0.2, 0.2, np.nan], index=exp_idx, name='s')
+        result = ser.loc[[2, 2, 3]]
+        assert_series_equal(result, expected, check_index_type=True)
+
+        exp_idx = Index([3, 4, 4], dtype='int64', name='idx')
+        expected = Series([0.3, np.nan, np.nan], index=exp_idx, name='s')
+        idx = Index([1, 2, 3], dtype='int64', name='idx')
+        result = Series([0.1, 0.2, 0.3], index=idx, name='s').loc[[3, 4, 4]]
+        assert_series_equal(result, expected, check_index_type=True)
+
+        exp_idx = Index([5, 3, 3], dtype='int64', name='idx')
+        expected = Series([np.nan, 0.3, 0.3], index=exp_idx, name='s')
+        idx = Index([1, 2, 3, 4], dtype='int64', name='idx')
+        result = Series([0.1, 0.2, 0.3, 0.4], index=idx, name='s').loc[[5, 3, 3]]
+        assert_series_equal(result, expected, check_index_type=True)
+
+        exp_idx = Index([5, 4, 4], dtype='int64', name='idx')
+        expected = Series([np.nan, 0.4, 0.4], index=exp_idx, name='s')
+        idx = Index([1, 2, 3, 4], dtype='int64', name='idx')
+        result = Series([0.1, 0.2, 0.3, 0.4], index=idx, name='s').loc[[5, 4, 4]]
+        assert_series_equal(result, expected, check_index_type=True)
+
+        exp_idx = Index([7, 2, 2], dtype='int64', name='idx')
+        expected = Series([0.4, np.nan, np.nan], index=exp_idx, name='s')
+        idx = Index([4, 5, 6, 7], dtype='int64', name='idx')
+        result = Series([0.1, 0.2, 0.3, 0.4], index=idx, name='s').loc[[7, 2, 2]]
+        assert_series_equal(result, expected, check_index_type=True)
+
+        exp_idx = Index([4, 5, 5], dtype='int64', name='idx')
+        expected = Series([0.4, np.nan, np.nan], index=exp_idx, name='s')
+        idx = Index([1, 2, 3, 4], dtype='int64', name='idx')
+        result = Series([0.1, 0.2, 0.3, 0.4], index=idx, name='s').loc[[4, 5, 5]]
+        assert_series_equal(result, expected, check_index_type=True)
+
+        # iloc
+        exp_idx = Index([2, 2, 1, 1], dtype='int64', name='idx')
+        expected = Series([0.2, 0.2, 0.1, 0.1], index=exp_idx, name='s')
+        result = ser.iloc[[1,1,0,0]]
+        assert_series_equal(result, expected, check_index_type=True)
+
+    def test_series_partial_set_datetime(self):
+        # GH 11497
+
+        idx = date_range('2011-01-01', '2011-01-02', freq='D', name='idx')
+        ser = Series([0.1, 0.2], index=idx, name='s')
+
+        result = ser.loc[[Timestamp('2011-01-01'), Timestamp('2011-01-02')]]
+        exp = Series([0.1, 0.2], index=idx, name='s')
+        assert_series_equal(result, exp, check_index_type=True)
+
+        keys = [Timestamp('2011-01-02'), Timestamp('2011-01-02'), Timestamp('2011-01-01')]
+        exp = Series([0.2, 0.2, 0.1], index=pd.DatetimeIndex(keys, name='idx'), name='s')
+        assert_series_equal(ser.loc[keys], exp, check_index_type=True)
+
+        keys = [Timestamp('2011-01-03'), Timestamp('2011-01-02'), Timestamp('2011-01-03')]
+        exp = Series([np.nan, 0.2, np.nan], index=pd.DatetimeIndex(keys, name='idx'), name='s')
+        assert_series_equal(ser.loc[keys], exp, check_index_type=True)
+
+    def test_series_partial_set_period(self):
+        # GH 11497
+
+        idx = pd.period_range('2011-01-01', '2011-01-02', freq='D', name='idx')
+        ser = Series([0.1, 0.2], index=idx, name='s')
+
+        result = ser.loc[[pd.Period('2011-01-01', freq='D'), pd.Period('2011-01-02', freq='D')]]
+        exp = Series([0.1, 0.2], index=idx, name='s')
+        assert_series_equal(result, exp, check_index_type=True)
+
+        keys = [pd.Period('2011-01-02', freq='D'), pd.Period('2011-01-02', freq='D'),
+                pd.Period('2011-01-01', freq='D')]
+        exp = Series([0.2, 0.2, 0.1], index=pd.PeriodIndex(keys, name='idx'), name='s')
+        assert_series_equal(ser.loc[keys], exp, check_index_type=True)
+
+        keys = [pd.Period('2011-01-03', freq='D'), pd.Period('2011-01-02', freq='D'),
+                pd.Period('2011-01-03', freq='D')]
+        exp = Series([np.nan, 0.2, np.nan], index=pd.PeriodIndex(keys, name='idx'), name='s')
+        assert_series_equal(ser.loc[keys], exp, check_index_type=True)
 
     def test_partial_set_invalid(self):
 

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -197,7 +197,7 @@ class DatetimeIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
                          'is_quarter_start','is_quarter_end','is_year_start','is_year_end',
                          'tz','freq']
     _is_numeric_dtype = False
-
+    _infer_as_myclass = True
 
     @deprecate_kwarg(old_arg_name='infer_dst', new_arg_name='ambiguous',
                      mapping={True: 'infer', False: 'raise'})
@@ -778,7 +778,7 @@ class DatetimeIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
         elif dtype == _NS_DTYPE and self.tz is not None:
             return self.tz_convert('UTC').tz_localize(None)
         elif dtype == str:
-            return self._shallow_copy(values=self.format(), infer=True)
+            return Index(self.format(), name=self.name, dtype=object)
         else:  # pragma: no cover
             raise ValueError('Cannot cast DatetimeIndex to dtype %s' % dtype)
 

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -156,6 +156,8 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
     _datetimelike_ops = ['year','month','day','hour','minute','second',
                          'weekofyear','week','dayofweek','weekday','dayofyear','quarter', 'qyear', 'freq', 'days_in_month', 'daysinmonth']
     _is_numeric_dtype = False
+    _infer_as_myclass = True
+
     freq = None
 
     __eq__ = _period_index_cmp('__eq__')
@@ -279,9 +281,15 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
         result._reset_identity()
         return result
 
-    def _shallow_copy(self, values=None, infer=False, **kwargs):
+    def _shallow_copy_with_infer(self, values=None, **kwargs):
         """ we always want to return a PeriodIndex """
-        return super(PeriodIndex, self)._shallow_copy(values=values, infer=False, **kwargs)
+        return self._shallow_copy(values=values, **kwargs)
+
+    def _shallow_copy(self, values=None, **kwargs):
+        if kwargs.get('freq') is None:
+            # freq must be provided
+            kwargs['freq'] = self.freq
+        return super(PeriodIndex, self)._shallow_copy(values=values, **kwargs)
 
     def _coerce_scalar_to_index(self, item):
         """

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -129,6 +129,8 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, Int64Index):
     _comparables = ['name', 'freq']
     _attributes = ['name', 'freq']
     _is_numeric_dtype = True
+    _infer_as_myclass = True
+
     freq = None
 
     def __new__(cls, data=None, unit=None,
@@ -514,8 +516,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, Int64Index):
         name = self.name if self.name == other.name else None
         if (isinstance(other, TimedeltaIndex) and  self.freq == other.freq
             and self._can_fast_union(other)):
-            joined = self._shallow_copy(joined)
-            joined.name = name
+            joined = self._shallow_copy(joined, name=name)
             return joined
         else:
             return self._simple_new(joined, name)


### PR DESCRIPTION
`.loc` result with duplicated keys may have incorred `Index` dtype.

```
import pandas as pd

ser = pd.Series([0.1, 0.2], index=pd.Index([1, 2], name='idx'))

# OK
ser.loc[[2, 2, 1]].index
# Int64Index([2, 2, 1], dtype='int64', name=u'idx')

# NG, Int64Index(dtype=object) 
ser.loc[[3, 2, 3]].index 
# Int64Index([3, 2, 3], dtype='object', name=u'idx')
ser.loc[[3, 2, 3, 'x']].index 
# Int64Index([3, 2, 3, u'x'], dtype='object', name=u'idx')

idx = pd.date_range('2011-01-01', '2011-01-02', freq='D', name='idx')
ser = pd.Series([0.1, 0.2], index=idx, name='s')

# OK
ser.loc[[pd.Timestamp('2011-01-02'), pd.Timestamp('2011-01-02'), pd.Timestamp('2011-01-01')]].index
# DatetimeIndex(['2011-01-02', '2011-01-02', '2011-01-01'], dtype='datetime64[ns]', name=u'idx', freq=None)

# NG, ValueError
ser.loc[[pd.Timestamp('2011-01-03'), pd.Timestamp('2011-01-02'), pd.Timestamp('2011-01-03')]].index
# ValueError: Inferred frequency None from passed dates does not conform to passed frequency D
```
## After the PR:

Above OK results are unchanged.

```
import pandas as pd
ser = pd.Series([0.1, 0.2], index=pd.Index([1, 2], name='idx'))

ser.loc[[3, 2, 3]].index 
# Int64Index([3, 2, 3], dtype='int64', name=u'idx')
ser.loc[[3, 2, 3, 'x']].index 
# Index([3, 2, 3, u'x'], dtype='object', name=u'idx')

idx = pd.date_range('2011-01-01', '2011-01-02', freq='D', name='idx')
ser = pd.Series([0.1, 0.2], index=idx, name='s')

ser.loc[[pd.Timestamp('2011-01-03'), pd.Timestamp('2011-01-02'), pd.Timestamp('2011-01-03')]].index
# DatetimeIndex(['2011-01-03', '2011-01-02', '2011-01-03'], dtype='datetime64[ns]', name=u'idx', freq=None)
```
