### PR TITLE
BUG: GH10355 groupby std() doesnt sqrt grouping cols

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -75,6 +75,7 @@ Bug Fixes
 - Bug in merging ``datetime64[ns, tz]`` dtypes (:issue:`11405`)
 - Bug in ``HDFStore.select`` when comparing with a numpy scalar in a where clause (:issue:`11283`)
 - Bug in using ``DataFrame.ix`` with a multi-index indexer(:issue:`11372`)
+- Bug in ``groupby.var()`` when using ``DataFrame.groupby`` with as_index=False (:issue:`10355`)
 
 
 - Bug in tz-conversions with an ambiguous time and ``.dt`` accessors (:issue:`11295`)


### PR DESCRIPTION
New attempt at #10355 Hopefully should address the issues raised in #11300

Previously, grouping columns were square rooted when as_index=False
We now test whether the grouping keys are in the columns, and
if so don't square root those columns.

Note that we squash TypeError which occurs when self.keys is not
Hashable, and so we can't check for existence in columns.
