### PR TITLE
fix _is_view for multi-block frames

### DIFF
--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2950,10 +2950,10 @@ class BlockManager(PandasObject):
 
     @property
     def is_view(self):
-        """ return a boolean if we are a single block and are a view """
-        if len(self.blocks) == 1:
-            return self.blocks[0].is_view
-
+        """ return a boolean if any block is a view """
+        for b in self.blocks:
+            if b.is_view: return True
+                
         # It is technically possible to figure out which blocks are views
         # e.g. [ b.values.base is not None for b in self.blocks ]
         # but then we have the case of possibly some blocks being a view

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -1679,7 +1679,16 @@ class TestDataFrame(tm.TestCase, Generic):
 
         assert_equal(df.y, 5)
         assert_series_equal(df['y'], Series([2, 4, 6], name='y'))
+        
+    def test_is_view(self):
+        # Ensure that if even if only one block of DF is view, 
+        # returns _is_view = True. Test for PR #11518
+        df = pd.DataFrame({'col1':[1,2], 'col2':[3,4]})
+        s = pd.Series([0.5, 0.3, 0.4])
+        df['col3'] = s[0:1]
+        self.assertTrue(df._is_view )
 
+        
 
 class TestPanel(tm.TestCase, Generic):
     _typ = Panel


### PR DESCRIPTION
_is_view previously only testing whether first block was a view, when should return `_is_view = True` if _any_ block is a view. 
