### PR TITLE
BUG: fix incorrect xticklabels when specifying xticks (GH11529)

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -101,7 +101,7 @@ Bug Fixes
 
 
 
-
+- Fix regression in setting of ``xticks`` in ``plot`` (:issue:`11529`).
 
 
 

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1237,6 +1237,13 @@ class TestSeriesPlots(TestPlotBase):
             ax = s.plot()
         self._check_colors(ax.get_lines(), linecolors=def_colors[:ncolors])
 
+    def test_xticklabels(self):
+        # GH11529
+        s = Series(np.arange(10), index=['P%02d' % i for i in range(10)])
+        ax = s.plot(xticks=[0,3,5,9])
+        exp = ['P%02d' % i for i in [0,3,5,9]]
+        self._check_text_labels(ax.get_xticklabels(), exp)
+
 
 @tm.mplskip
 class TestDataFramePlots(TestPlotBase):

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -985,11 +985,11 @@ class MPLPlot(object):
         self._make_plot()
         self._add_table()
         self._make_legend()
+        self._adorn_subplots()
 
         for ax in self.axes:
             self._post_plot_logic_common(ax, self.data)
             self._post_plot_logic(ax, self.data)
-        self._adorn_subplots()
 
     def _args_adjust(self):
         pass


### PR DESCRIPTION
Fixes #11529

@sinhrks in PR #10717 you moved the setting of the ticklabels from `_adorn_subplots` to its own function `_post_plot_logic_common`. But this is called before `_adorn_subplots`, and the specified `xticks` are only set in `_adorn_subplots`, so now it does not use the new xticks to determine the xticklabels. 
I just switched the order of the two functions. At first sight this seems OK, but do you know if there could be any side effects of switching the order?
