### PR TITLE
BUG: df.join(df2, how='right') TypeError

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -120,3 +120,5 @@ Bug Fixes
 - Bug in ``to_excel`` with openpyxl 2.2+ and merging (:issue:`11408`)
 
 - Bug in ``DataFrame.to_dict()`` produces a ``np.datetime64`` object instead of ``Timestamp`` when only datetime is present in data (:issue:`11327`)
+
+- Bug in ``DataFrame.join()`` with ``how='right'`` producing a ``TypeError`` (:issue:`11519`)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -2490,7 +2490,7 @@ class Index(IndexOpsMixin, PandasObject):
             if how == 'left':
                 join_index, lidx, ridx = self._left_indexer(sv, ov)
             elif how == 'right':
-                join_index, ridx, lidx = self._left_indexer(other, self)
+                join_index, ridx, lidx = self._left_indexer(ov, sv)
             elif how == 'inner':
                 join_index, lidx, ridx = self._inner_indexer(sv, ov)
             elif how == 'outer':

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -1682,6 +1682,7 @@ class TestIndex(Base, tm.TestCase):
             for kind in kinds:
                 joined = res.join(res, how=kind)
                 self.assertIs(res, joined)
+
     def test_str_attribute(self):
         # GH9068
         methods = ['strip', 'rstrip', 'lstrip']
@@ -3056,17 +3057,15 @@ class TestInt64Index(Numeric, tm.TestCase):
         tm.assert_numpy_array_equal(ridx, eridx)
 
         # non-unique
-        """
-        idx = Index([1,1,2,5])
-        idx2 = Index([1,2,5,7,9])
+        idx = Index([1, 1, 2, 5])
+        idx2 = Index([1, 2, 5, 7, 9])
         res, lidx, ridx = idx2.join(idx, how='left', return_indexers=True)
-        eres = idx2
-        eridx = np.array([0, 2, 3, -1, -1])
-        elidx = np.array([0, 1, 2, 3, 4])
+        eres = Index([1, 1, 2, 5, 7, 9])  # 1 is in idx2, so it should be x2
+        eridx = np.array([0, 1, 2, 3, -1, -1])
+        elidx = np.array([0, 0, 1, 2, 3, 4])
         self.assertTrue(res.equals(eres))
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
-        """
 
     def test_join_right(self):
         other = Int64Index([7, 12, 25, 1, 2, 5])
@@ -3096,23 +3095,15 @@ class TestInt64Index(Numeric, tm.TestCase):
         self.assertIsNone(ridx)
 
         # non-unique
-        """
-        idx = Index([1,1,2,5])
-        idx2 = Index([1,2,5,7,9])
+        idx = Index([1, 1, 2, 5])
+        idx2 = Index([1, 2, 5, 7, 9])
         res, lidx, ridx = idx.join(idx2, how='right', return_indexers=True)
-        eres = idx2
-        elidx = np.array([0, 2, 3, -1, -1])
-        eridx = np.array([0, 1, 2, 3, 4])
+        eres = Index([1, 1, 2, 5, 7, 9])  # 1 is in idx2, so it should be x2
+        elidx = np.array([0, 1, 2, 3, -1, -1])
+        eridx = np.array([0, 0, 1, 2, 3, 4])
         self.assertTrue(res.equals(eres))
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
-
-        idx = Index([1,1,2,5])
-        idx2 = Index([1,2,5,9,7])
-        res = idx.join(idx2, how='right', return_indexers=False)
-        eres = idx2
-        self.assert(res.equals(eres))
-        """
 
     def test_join_non_int_index(self):
         other = Index([3, 6, 7, 8, 10], dtype=object)

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -517,6 +517,23 @@ class TestMerge(tm.TestCase):
 
         assert_frame_equal(result, expected.ix[:, result.columns])
 
+        # GH 11519
+        df = DataFrame({'A': ['foo', 'bar', 'foo', 'bar',
+                              'foo', 'bar', 'foo', 'foo'],
+                        'B': ['one', 'one', 'two', 'three',
+                              'two', 'two', 'one', 'three'],
+                        'C': np.random.randn(8),
+                        'D': np.random.randn(8)})
+        s = Series(np.repeat(np.arange(8), 2),
+                   index=np.repeat(np.arange(8), 2), name='TEST')
+        inner = df.join(s, how='inner')
+        outer = df.join(s, how='outer')
+        left = df.join(s, how='left')
+        right = df.join(s, how='right')
+        assert_frame_equal(inner, outer)
+        assert_frame_equal(inner, left)
+        assert_frame_equal(inner, right)
+
     def test_merge_index_singlekey_right_vs_left(self):
         left = DataFrame({'key': ['a', 'b', 'c', 'd', 'e', 'e', 'a'],
                           'v1': np.random.randn(7)})


### PR DESCRIPTION
Issue #11519

Somehow right joins had been forgotten in a previous bugfix. There were tests already written that should have seen the problem, but they had been commented out because the expected results were wrong, because of a subtlety in the way non-unique index are handled.

Thanks for the labels "difficulty novice" and "effort low": I'm using pandas every day, and I'm glad I could contribute that easily.
