### PR TITLE
BUG: GH11517 add multiindex column names after describe()

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -95,6 +95,8 @@ Bug Fixes
 - Bug in ``pd.eval`` where unary ops in a list error (:issue:`11235`)
 - Bug in ``squeeze()`` with zero length arrays (:issue:`11230`, :issue:`8999`)
 
+- Bug in ``describe()`` dropping column names for hierarchical indexes (:issue:`11517`)
+
 
 
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4516,6 +4516,7 @@ class NDFrame(PandasObject):
                 if name not in names:
                     names.append(name)
         d = pd.concat(ldesc, join_axes=pd.Index([names]), axis=1)
+        d.columns.names = data.columns.names
         return d
 
     def _check_percentile(self, q):

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -1471,6 +1471,25 @@ class TestDataFrame(tm.TestCase, Generic):
         self.assertTrue(G.describe(include=['number', 'object']).shape == (22, 3))
         self.assertTrue(G.describe(include='all').shape == (26, 4))
 
+    def test_describe_multi_index_df_column_names(self):
+        """ Test that column names persist after the describe operation."""
+
+        df = pd.DataFrame({'A': ['foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'foo'],
+                           'B': ['one', 'one', 'two', 'three', 'two', 'two', 'one', 'three'],
+                           'C': np.random.randn(8),
+                           'D': np.random.randn(8)})
+
+        # GH 11517
+        # test for hierarchical index
+        hierarchical_index_df = df.groupby(['A', 'B']).mean().T
+        self.assertTrue(hierarchical_index_df.columns.names == ['A', 'B'])
+        self.assertTrue(hierarchical_index_df.describe().columns.names == ['A', 'B'])
+
+        # test for non-hierarchical index
+        non_hierarchical_index_df = df.groupby(['A']).mean().T
+        self.assertTrue(non_hierarchical_index_df.columns.names == ['A'])
+        self.assertTrue(non_hierarchical_index_df.describe().columns.names == ['A'])
+
     def test_no_order(self):
         tm._skip_if_no_scipy()
         s = Series([0, 1, np.nan, 3])


### PR DESCRIPTION
Hi,

This fixes the bug mentioned in https://github.com/pydata/pandas/issues/11517
I have added column names after the describe operation. 
Request you to review the change and merge it. 

Thanks 
