### PR TITLE
BUG: to_sql with datetime.time values with sqlite

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -1094,7 +1094,7 @@ Bug Fixes
 
 - Bug in ``.plot`` potentially modifying the ``colors`` input when the number of columns didn't match the number of series provided (:issue:`12039`).
 - Bug in ``Series.plot`` failing when index has a ``CustomBusinessDay`` frequency (:issue:`7222`).
-
+- Bug in ``.to_sql`` for ``datetime.time`` values with sqlite fallback (:issue:`8341`)
 - Bug in ``read_excel`` failing to read data with one column when ``squeeze=True`` (:issue:`12157`)
 - Bug in ``.groupby`` where a ``KeyError`` was not raised for a wrong column if there was only one row in the dataframe (:issue:`11741`)
 - Bug in ``.read_csv`` with dtype specified on empty data producing an error (:issue:`12048`)

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -5,7 +5,7 @@ retrieval and to reduce dependency on DB-specific API.
 """
 
 from __future__ import print_function, division
-from datetime import datetime, date
+from datetime import datetime, date, time
 
 import warnings
 import traceback
@@ -1402,6 +1402,15 @@ class SQLiteTable(SQLTable):
     Patch the SQLTable for fallback support.
     Instead of a table variable just use the Create Table statement.
     """
+
+    def __init__(self, *args, **kwargs):
+        # GH 8341
+        # register an adapter callable for datetime.time object
+        import sqlite3
+        # this will transform time(12,34,56,789) into '12:34:56.000789'
+        # (this is what sqlalchemy does)
+        sqlite3.register_adapter(time, lambda _: _.strftime("%H:%M:%S.%f"))
+        super(SQLiteTable, self).__init__(*args, **kwargs)
 
     def sql_schema(self):
         return str(";\n".join(self.table))


### PR DESCRIPTION
I'm proposing a solution to #8341

As @jorisvandenbossche suggested, I use a sqlite3 adapter to transform `datetime.time` objects into string (`hh:mm:ss.ffffff`, as this what sqlalchemy... I think?)

I added a test in the class `_TestSQLApi`, so that the solution is tested with both sqlalchemy and the sqlite3 fallback. Thus, the result should be consistent.
