### PR TITLE
Make .str/.dt available for Series of type category with string/datetime

### DIFF
--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -515,6 +515,50 @@ To get a single value `Series` of type ``category`` pass in a list with a single
 
     df.loc[["h"],"cats"]
 
+String and datetime accessors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 0.17.1
+
+The accessors  ``.dt`` and ``.str`` will work if the ``s.cat.categories`` are of an appropriate
+type:
+
+
+.. ipython:: python
+
+    str_s = pd.Series(list('aabb'))
+    str_cat = str_s.astype('category')
+    str_cat.str.contains("a")
+
+    date_s = pd.Series(date_range('1/1/2015', periods=5))
+    date_cat = date_s.astype('category')
+    date_cat.dt.day
+
+.. note::
+
+    The returned ``Series`` (or ``DataFrame``) is of the same type as if you used the
+    ``.str.<method>`` / ``.dt.<method>`` on a ``Series`` of that type (and not of
+    type ``category``!).
+
+That means, that the returned values from methods and properties on the accessors of a
+``Series`` and the returned values from methods and properties on the accessors of this
+``Series`` transformed to one of type `category` will be equal:
+
+.. ipython:: python
+
+    ret_s = str_s.str.contains("a")
+    ret_cat = str_cat.str.contains("a")
+    ret_s.dtype == ret_cat.dtype
+    ret_s == ret_cat
+
+.. note::
+
+    The work is done on the ``categories`` and then a new ``Series`` is constructed. This has
+    some performance implication if you have a ``Series`` of type string, where lots of elements
+    are repeated (i.e. the number of unique elements in the ``Series`` is a lot smaller than the
+    length of the ``Series``). In this case it can be faster to convert the original ``Series``
+    to one of type ``category`` and use ``.str.<method>`` or ``.dt.<property>`` on that.
+
 Setting
 ~~~~~~~
 

--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -63,6 +63,22 @@ and replacing any remaining whitespaces with underscores:
    df.columns = df.columns.str.strip().str.lower().str.replace(' ', '_')
    df
 
+.. note::
+
+    If you do a lot of string munging and have a ``Series`` where lots of elements are repeated
+    (i.e. the number of unique elements in the ``Series`` is a lot smaller than the length of the
+    ``Series``), it can be faster to convert the original ``Series`` to one of type
+    ``category`` and then use ``.str.<method>`` or ``.dt.<property>`` on that. The
+    performance difference comes from the fact that, for ``Series`` of type ``category``, the
+    string operations are done on the ``.categories`` and not on each element of the
+    ``Series``. Please note that a ``Series`` of type ``category`` with string ``.categories`` has
+    some limitations in comparison of ``Series`` of type string (e.g. you can't add strings to
+    each other: ``s + " " + s`` won't work if ``s`` is a ``Series`` of type ``category``). Also,
+    ``.str`` methods which operate on elements of type ``list`` are not available on such a
+    ``Series``. If you are interested in having these performance gains on all string ``Series``,
+    please look at `this bug report <https://github.com/pydata/pandas/issues/8640>`_.
+
+
 Splitting and Replacing Strings
 -------------------------------
 

--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -65,6 +65,8 @@ Enhancements
 
      pd.Index([1, np.nan, 3]).fillna(2)
 
+- Series of type ``"category"`` now make ``.str.<...>`` and ``.dt.<...>`` accessor methods / properties available, if the categories are of that type. (:issue:`10661`)
+
 - ``pivot_table`` now has a ``margins_name`` argument so you can use something other than the default of 'All' (:issue:`3335`)
 
 .. _whatsnew_0171.api:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2704,12 +2704,10 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin, generic.NDFrame,):
 
     def _dir_additions(self):
         rv = set()
-        # these accessors are mutually exclusive, so break loop when one exists
         for accessor in self._accessors:
             try:
                 getattr(self, accessor)
                 rv.add(accessor)
-                break
             except AttributeError:
                 pass
         return rv

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -3712,6 +3712,81 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
             invalid.str
         self.assertFalse(hasattr(invalid, 'str'))
 
+    def test_dt_accessor_api_for_categorical(self):
+        # https://github.com/pydata/pandas/issues/10661
+        from pandas.tseries.common import Properties
+        from pandas.tseries.index import date_range, DatetimeIndex
+        from pandas.tseries.period import period_range, PeriodIndex
+        from pandas.tseries.tdi import timedelta_range, TimedeltaIndex
+
+        s_dr = Series(date_range('1/1/2015', periods=5, tz="MET"))
+        c_dr = s_dr.astype("category")
+
+        s_pr = Series(period_range('1/1/2015', freq='D', periods=5))
+        c_pr = s_pr.astype("category")
+
+        s_tdr = Series(timedelta_range('1 days','10 days'))
+        c_tdr = s_tdr.astype("category")
+
+        test_data = [
+            ("Datetime", DatetimeIndex._datetimelike_ops, s_dr, c_dr),
+            ("Period", PeriodIndex._datetimelike_ops, s_pr, c_pr),
+            ("Timedelta", TimedeltaIndex._datetimelike_ops, s_tdr, c_tdr)]
+
+        self.assertIsInstance(c_dr.dt, Properties)
+
+        special_func_defs = [
+            ('strftime', ("%Y-%m-%d",), {}),
+            ('tz_convert', ("EST",), {}),
+            #('tz_localize', ("UTC",), {}),
+        ]
+        _special_func_names = [f[0] for f in special_func_defs]
+
+        # the series is already localized
+        _ignore_names = ['tz_localize']
+
+        for name, attr_names, s, c in test_data:
+            func_names = [f for f in dir(s.dt) if not (f.startswith("_") or
+                                                       f in attr_names or
+                                                       f in _special_func_names or
+                                                       f in _ignore_names)]
+
+            func_defs = [(f, (), {}) for f in func_names]
+            for f_def in special_func_defs:
+                if f_def[0] in dir(s.dt):
+                    func_defs.append(f_def)
+
+            for func, args, kwargs in func_defs:
+                res = getattr(c.dt, func)(*args, **kwargs)
+                exp = getattr(s.dt, func)(*args, **kwargs)
+
+                if isinstance(res, pd.DataFrame):
+                    tm.assert_frame_equal(res, exp)
+                elif isinstance(res, pd.Series):
+                    tm.assert_series_equal(res, exp)
+                else:
+                    tm.assert_numpy_array_equal(res, exp)
+
+            for attr in attr_names:
+                try:
+                    res = getattr(c.dt, attr)
+                    exp = getattr(s.dt, attr)
+                except Exception as e:
+                    print(name, attr)
+                    raise e
+
+            if isinstance(res, pd.DataFrame):
+                tm.assert_frame_equal(res, exp)
+            elif isinstance(res, pd.Series):
+                tm.assert_series_equal(res, exp)
+            else:
+                tm.assert_numpy_array_equal(res, exp)
+
+        invalid = Series([1,2,3]).astype('category')
+        with tm.assertRaisesRegexp(AttributeError, "Can only use .dt accessor with datetimelike"):
+            invalid.dt
+        self.assertFalse(hasattr(invalid, 'str'))
+
     def test_pickle_v0_14_1(self):
 
         # we have the name warning

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -3640,6 +3640,78 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
         with tm.assertRaisesRegexp(AttributeError, "You cannot add any new attribute"):
             c.cat.xlabel = "a"
 
+    def test_str_accessor_api_for_categorical(self):
+        # https://github.com/pydata/pandas/issues/10661
+        from pandas.core.strings import StringMethods
+        s = Series(list('aabb'))
+        s = s + " " + s
+        c = s.astype('category')
+        self.assertIsInstance(c.str, StringMethods)
+
+        # str functions, which need special arguments
+        special_func_defs = [
+            ('cat', (list("zyxw"),), {"sep": ","}),
+            ('center', (10,), {}),
+            ('contains', ("a",), {}),
+            ('count', ("a",), {}),
+            ('decode', ("UTF-8",), {}),
+            ('encode', ("UTF-8",), {}),
+            ('endswith', ("a",), {}),
+            ('extract', ("([a-z]*) ",), {}),
+            ('find', ("a",), {}),
+            ('findall', ("a",), {}),
+            ('index', (" ",), {}),
+            ('ljust', (10,), {}),
+            ('match', ("a"), {}), # deprecated...
+            ('normalize', ("NFC",), {}),
+            ('pad', (10,), {}),
+            ('partition', (" ",), {"expand": False}), # not default
+            ('partition', (" ",), {"expand": True}), # default
+            ('repeat', (3,), {}),
+            ('replace', ("a", "z"), {}),
+            ('rfind', ("a",), {}),
+            ('rindex', (" ",), {}),
+            ('rjust', (10,), {}),
+            ('rpartition', (" ",), {"expand": False}), # not default
+            ('rpartition', (" ",), {"expand": True}), # default
+            ('slice', (0,1), {}),
+            ('slice_replace', (0,1,"z"), {}),
+            ('split', (" ",), {"expand":False}), #default
+            ('split', (" ",), {"expand":True}), # not default
+            ('startswith', ("a",), {}),
+            ('wrap', (2,), {}),
+            ('zfill', (10,), {})
+        ]
+        _special_func_names = [f[0] for f in special_func_defs]
+
+        # * get, join: they need a individual elements of type lists, but
+        #   we can't make a categorical with lists as individual categories.
+        #   -> `s.str.split(" ").astype("category")` will error!
+        # * `translate` has different interfaces for py2 vs. py3
+        _ignore_names = ["get", "join", "translate"]
+
+        str_func_names = [f for f in dir(s.str) if not (f.startswith("_") or
+                                                        f in _special_func_names or
+                                                        f in _ignore_names)]
+
+        func_defs = [(f, (), {}) for f in str_func_names]
+        func_defs.extend(special_func_defs)
+
+
+        for func, args, kwargs in func_defs:
+            res = getattr(c.str, func)(*args, **kwargs)
+            exp = getattr(s.str, func)(*args, **kwargs)
+
+            if isinstance(res, pd.DataFrame):
+                tm.assert_frame_equal(res, exp)
+            else:
+                tm.assert_series_equal(res, exp)
+
+        invalid = Series([1,2,3]).astype('category')
+        with tm.assertRaisesRegexp(AttributeError, "Can only use .str accessor with string"):
+            invalid.str
+        self.assertFalse(hasattr(invalid, 'str'))
+
     def test_pickle_v0_14_1(self):
 
         # we have the name warning

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -362,11 +362,19 @@ class CheckNameIntegration(object):
         self.assertTrue('str' not in dir(s))
         self.assertTrue('cat' not in dir(s))
 
-        # similiarly for .cat
+        # similiarly for .cat, but with the twist that str and dt should be there
+        # if the categories are of that type
+        # first cat and str
         s = Series(list('abbcd'), dtype="category")
         self.assertTrue('cat' in dir(s))
-        self.assertTrue('str' not in dir(s))
+        self.assertTrue('str' in dir(s)) # as it is a string categorical
         self.assertTrue('dt' not in dir(s))
+
+        # similar to cat and str
+        s = Series(date_range('1/1/2015', periods=5)).astype("category")
+        self.assertTrue('cat' in dir(s))
+        self.assertTrue('str' not in dir(s))
+        self.assertTrue('dt' in dir(s)) # as it is a datetime categorical
 
     def test_binop_maybe_preserve_name(self):
         # names match, preserve

--- a/pandas/tseries/common.py
+++ b/pandas/tseries/common.py
@@ -10,8 +10,8 @@ from pandas import tslib
 from pandas.core.common import (_NS_DTYPE, _TD_DTYPE, is_period_arraylike,
                                 is_datetime_arraylike, is_integer_dtype, is_list_like,
                                 is_datetime64_dtype, is_datetime64tz_dtype,
-                                is_timedelta64_dtype,
-                                get_dtype_kinds)
+                                is_timedelta64_dtype, is_categorical_dtype,
+                                get_dtype_kinds, take_1d)
 
 def is_datetimelike(data):
     """ return a boolean if we can be successfully converted to a datetimelike """
@@ -45,26 +45,36 @@ def maybe_to_datetimelike(data, copy=False):
         raise TypeError("cannot convert an object of type {0} to a datetimelike index".format(type(data)))
 
     index = data.index
+    name = data.name
+    orig = data if is_categorical_dtype(data) else None
+    if orig is not None:
+        data = orig.values.categories
+
     if is_datetime64_dtype(data.dtype):
-        return DatetimeProperties(DatetimeIndex(data, copy=copy, freq='infer'), index, name=data.name)
+        return DatetimeProperties(DatetimeIndex(data, copy=copy, freq='infer'), index, name=name,
+                                                orig=orig)
     elif is_datetime64tz_dtype(data.dtype):
-        return DatetimeProperties(DatetimeIndex(data, copy=copy, freq='infer', ambiguous='infer'), index, name=data.name)
+        return DatetimeProperties(DatetimeIndex(data, copy=copy, freq='infer', ambiguous='infer'),
+                                  index, data.name, orig=orig)
     elif is_timedelta64_dtype(data.dtype):
-        return TimedeltaProperties(TimedeltaIndex(data, copy=copy, freq='infer'), index, name=data.name)
+        return TimedeltaProperties(TimedeltaIndex(data, copy=copy, freq='infer'), index,
+                                   name=name, orig=orig)
     else:
         if is_period_arraylike(data):
-            return PeriodProperties(PeriodIndex(data, copy=copy), index, name=data.name)
+            return PeriodProperties(PeriodIndex(data, copy=copy), index, name=name, orig=orig)
         if is_datetime_arraylike(data):
-            return DatetimeProperties(DatetimeIndex(data, copy=copy, freq='infer'), index, name=data.name)
+            return DatetimeProperties(DatetimeIndex(data, copy=copy, freq='infer'), index,
+                                      name=name, orig=orig)
 
     raise TypeError("cannot convert an object of type {0} to a datetimelike index".format(type(data)))
 
 class Properties(PandasDelegate, NoNewAttributesMixin):
 
-    def __init__(self, values, index, name):
+    def __init__(self, values, index, name, orig=None):
         self.values = values
         self.index = index
         self.name = name
+        self.orig = orig
         self._freeze()
 
     def _delegate_property_get(self, name):
@@ -78,6 +88,10 @@ class Properties(PandasDelegate, NoNewAttributesMixin):
                 result = result.astype('int64')
         elif not is_list_like(result):
             return result
+
+        # blow up if we operate on categories
+        if self.orig is not None:
+            result = take_1d(result, self.orig.cat.codes)
 
         # return the result as a Series, which is by definition a copy
         result = Series(result, index=self.index, name=self.name)


### PR DESCRIPTION
If a series is a type category and the underlying Categorical has categories of type string or datetime, then make it possible to use the `.str`/`.dt` assessor on such a series.

The string/dt methods work on the categories (and therefore fast if we have
only a few categories), but return a Series with a dtype other than
category (integer, boolean, string,...), so that it is no different if we use
`.str` / `.dt` on a series of type string or of type category.

The main reason for that is that I think things like `s.str.slice(...) + s.str.slice(...)` should work.

Closes: https://github.com/pydata/pandas/issues/10661
