### PR TITLE
BUG/PERF: Stata value labels

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -416,10 +416,9 @@ Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Improved performance of ``andrews_curves`` (:issue:`11534`)
-
 - Improved huge ``DatetimeIndex``, ``PeriodIndex`` and ``TimedeltaIndex``'s ops performance including ``NaT`` (:issue:`10277`)
 - Improved performance of ``pandas.concat`` (:issue:`11958`)
-
+- Improved performance of ``StataReader`` (PR #`11591`)
 
 
 
@@ -440,6 +439,7 @@ Bug Fixes
 - Bug in consistency of passing nested dicts to ``.groupby(...).agg(...)`` (:issue:`9052`)
 - Accept unicode in ``Timedelta`` constructor (:issue:`11995`)
 
+- Bug in value label reading for ``StataReader`` when reading incrementally (:issue:`12014`)
 
 
 - Bug in vectorized ``DateOffset`` when ``n`` parameter is ``0`` (:issue:`11370`)


### PR DESCRIPTION
closes #12014 

This PR fixes a minor bug and introduces some performance enhancements, all related to value label reading in Stata files.  

The bug is that when reading a Stata file incrementally, the value labels will be read even when specifying convert_categoricals=False (this does not happen when reading the entire file at once).

The performance enhancements are:
1. Read key/value information as an ndarray using np.frombuffer rather than as a Python loop.
2. When splitting the value labels at the offsets, we currently pass txt[off[i]:] to null_terminate, which creates many copies of large segments of a potentially large byte array.  I changed it so that
   only the relevant part of the string is copied.

Relating to 2, further performance improvements might be possible since there is no trailing null byte to remove except for the last element of `txt` (thus some of the work in `_null_terminate` is superfluous).

Background:  This is an issue when processing large Stata files with millions of distinct value labels.
