### PR TITLE
API: provide Rolling/Expanding/EWM objects for deferred rolling type calculations #10702

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1505,9 +1505,9 @@ Window
 ------
 .. currentmodule:: pandas.core.window
 
-Rolling objects are returned by rolling calls: :func:`pandas.DataFrame.rolling`, :func:`pandas.Series.rolling`, etc.
-Expanding objects are returned by rolling calls: :func:`pandas.DataFrame.expanding`, :func:`pandas.Series.expanding`, etc.
-EWM objects are returned by rolling calls: :func:`pandas.DataFrame.ewm`, :func:`pandas.Series.ewm`, etc.
+Rolling objects are returned by ``.rolling`` calls: :func:`pandas.DataFrame.rolling`, :func:`pandas.Series.rolling`, etc.
+Expanding objects are returned by ``.expanding`` calls: :func:`pandas.DataFrame.expanding`, :func:`pandas.Series.expanding`, etc.
+EWM objects are returned by ``.ewm`` calls: :func:`pandas.DataFrame.ewm`, :func:`pandas.Series.ewm`, etc.
 
 Standard moving window functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1526,13 +1526,13 @@ Standard moving window functions
    Rolling.min
    Rolling.max
    Rolling.corr
-   Rolling.corr_pairwise
    Rolling.cov
    Rolling.skew
    Rolling.kurt
    Rolling.apply
    Rolling.quantile
-   Rolling.window
+   Window.mean
+   Window.sum
 
 .. _api.functions_expanding:
 
@@ -1553,7 +1553,6 @@ Standard expanding window functions
    Expanding.min
    Expanding.max
    Expanding.corr
-   Expanding.corr_pairwise
    Expanding.cov
    Expanding.skew
    Expanding.kurt

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -194,65 +194,6 @@ Top-level evaluation
 
    eval
 
-Standard moving window functions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autosummary::
-   :toctree: generated/
-
-   rolling_count
-   rolling_sum
-   rolling_mean
-   rolling_median
-   rolling_var
-   rolling_std
-   rolling_min
-   rolling_max
-   rolling_corr
-   rolling_corr_pairwise
-   rolling_cov
-   rolling_skew
-   rolling_kurt
-   rolling_apply
-   rolling_quantile
-   rolling_window
-
-.. _api.functions_expanding:
-
-Standard expanding window functions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autosummary::
-   :toctree: generated/
-
-   expanding_count
-   expanding_sum
-   expanding_mean
-   expanding_median
-   expanding_var
-   expanding_std
-   expanding_min
-   expanding_max
-   expanding_corr
-   expanding_corr_pairwise
-   expanding_cov
-   expanding_skew
-   expanding_kurt
-   expanding_apply
-   expanding_quantile
-
-Exponentially-weighted moving window functions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autosummary::
-   :toctree: generated/
-
-   ewma
-   ewmstd
-   ewmvar
-   ewmcorr
-   ewmcov
-
 .. _api.series:
 
 Series
@@ -260,6 +201,9 @@ Series
 
 Constructor
 ~~~~~~~~~~~
+
+.. currentmodule:: pandas
+
 .. autosummary::
    :toctree: generated/
 
@@ -344,14 +288,17 @@ Binary operator functions
    Series.ne
    Series.eq
 
-Function application, GroupBy
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Function application, GroupBy & Window
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
 
    Series.apply
    Series.map
    Series.groupby
+   Series.rolling
+   Series.expanding
+   Series.ewm
 
 .. _api.series.stats:
 
@@ -846,14 +793,17 @@ Binary operator functions
    DataFrame.combine
    DataFrame.combine_first
 
-Function application, GroupBy
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Function application, GroupBy & Window
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
    :toctree: generated/
 
    DataFrame.apply
    DataFrame.applymap
    DataFrame.groupby
+   DataFrame.rolling
+   DataFrame.expanding
+   DataFrame.ewm
 
 .. _api.dataframe.stats:
 
@@ -1550,6 +1500,79 @@ Conversion
    TimedeltaIndex.to_pytimedelta
    TimedeltaIndex.to_series
    TimedeltaIndex.round
+
+Window
+------
+.. currentmodule:: pandas.core.window
+
+Rolling objects are returned by rolling calls: :func:`pandas.DataFrame.rolling`, :func:`pandas.Series.rolling`, etc.
+Expanding objects are returned by rolling calls: :func:`pandas.DataFrame.expanding`, :func:`pandas.Series.expanding`, etc.
+EWM objects are returned by rolling calls: :func:`pandas.DataFrame.ewm`, :func:`pandas.Series.ewm`, etc.
+
+Standard moving window functions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: pandas.core.window
+
+.. autosummary::
+   :toctree: generated/
+
+   Rolling.count
+   Rolling.sum
+   Rolling.mean
+   Rolling.median
+   Rolling.var
+   Rolling.std
+   Rolling.min
+   Rolling.max
+   Rolling.corr
+   Rolling.corr_pairwise
+   Rolling.cov
+   Rolling.skew
+   Rolling.kurt
+   Rolling.apply
+   Rolling.quantile
+   Rolling.window
+
+.. _api.functions_expanding:
+
+Standard expanding window functions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: pandas.core.window
+
+.. autosummary::
+   :toctree: generated/
+
+   Expanding.count
+   Expanding.sum
+   Expanding.mean
+   Expanding.median
+   Expanding.var
+   Expanding.std
+   Expanding.min
+   Expanding.max
+   Expanding.corr
+   Expanding.corr_pairwise
+   Expanding.cov
+   Expanding.skew
+   Expanding.kurt
+   Expanding.apply
+   Expanding.quantile
+
+Exponentially-weighted moving window functions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: pandas.core.window
+
+.. autosummary::
+   :toctree: generated/
+
+   EWM.mean
+   EWM.std
+   EWM.var
+   EWM.corr
+   EWM.cov
 
 GroupBy
 -------

--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -220,7 +220,7 @@ and kurtosis.
 
 .. note::
 
-   The API for window statistics is quite similar to the way one works with ``Groupby`` objects, see the documentation :ref:`here <groupby>`
+   The API for window statistics is quite similar to the way one works with ``GroupBy`` objects, see the documentation :ref:`here <groupby>`
 
 We work with ``rolling``, ``expanding`` and ``exponentially weighted`` data through the corresponding
 objects, :class:`~pandas.core.window.Rolling`, :class:`~pandas.core.window.Expanding` and :class:`~pandas.core.window.EWM`.
@@ -231,7 +231,7 @@ objects, :class:`~pandas.core.window.Rolling`, :class:`~pandas.core.window.Expan
    s = s.cumsum()
    s
 
-These are created from methods on ``Series`` and ``DataFrames``.
+These are created from methods on ``Series`` and ``DataFrame``.
 
 .. ipython:: python
 
@@ -247,7 +247,7 @@ accept the following arguments:
 - ``freq``: optionally specify a :ref:`frequency string <timeseries.alias>`
   or :ref:`DateOffset <timeseries.offsets>` to pre-conform the data to.
 
-We can then call functions on these ``rolling`` objects. Which return like-indexed objects:
+We can then call methods on these ``rolling`` objects. These return like-indexed objects:
 
 .. ipython:: python
 
@@ -304,8 +304,6 @@ We provide a number of the common statistical functions:
     :meth:`~Rolling.apply`, Generic apply
     :meth:`~Rolling.cov`, Unbiased covariance (binary)
     :meth:`~Rolling.corr`, Correlation (binary)
-    :meth:`~Window.mean`, Moving window mean function
-    :meth:`~Window.sum`, Moving window sum function
 
 The :meth:`~Rolling.apply` function takes an extra ``func`` argument and performs
 generic rolling computations. The ``func`` argument should be a single function
@@ -323,9 +321,17 @@ compute the mean absolute deviation on a rolling basis:
 Rolling Windows
 ~~~~~~~~~~~~~~~
 
-The :meth:`~Window.mean`, and :meth:`~Window.sum` functions perform a generic rolling window computation
-on the input data. The weights used in the window are specified by the ``win_type``
-keyword. The list of recognized types are:
+Passing ``win_type`` to ``.rolling`` generates a generic rolling window computation, that is weighted according the ``win_type``.
+The following methods are available:
+
+.. csv-table::
+    :header: "Method", "Description"
+    :widths: 20, 80
+
+    :meth:`~Window.sum`, Sum of values
+    :meth:`~Window.mean`, Mean of values
+
+The weights used in the window are specified by the ``win_type``keyword. The list of recognized types are:
 
 - ``boxcar``
 - ``triang``
@@ -484,9 +490,9 @@ We can aggregate by passing a function to the entire DataFrame, or select a Seri
 
    r['A'].aggregate(np.sum)
 
-   r['A','B'].aggregate(np.sum)
+   r[['A','B']].aggregate(np.sum)
 
-As you can see, the result of the aggregation will have the selection columns, or all
+As you can see, the result of the aggregation will have the selected columns, or all
 columns if none are selected.
 
 .. _stats.aggregate.multifunc:
@@ -531,7 +537,7 @@ columns of a DataFrame:
           'B' : lambda x: np.std(x, ddof=1)})
 
 The function names can also be strings. In order for a string to be valid it
-must be either implemented on the Windowed object
+must be implemented on the Windowed object
 
 .. ipython:: python
 

--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -203,8 +203,12 @@ Window Functions
 
 .. warning::
 
-   Prior to version 0.18.0, these were module level functions that have been deprecated.
-   You can see the previous documentation
+   Prior to version 0.18.0, ``pd.rolling_*``, ``pd.expanding_*``, and ``pd.ewm*`` were module level
+   functions and are now deprecated and replaced by the corresponding method call.
+
+   The deprecation warning will show the new syntax, see an example :ref:`here <whatsnew_0180.window_deprecations>`
+
+   You can view the previous documentation
    `here <http://pandas.pydata.org/pandas-docs/version/0.17.1/computation.html#moving-rolling-statistics-moments>`__
 
 For working with data, a number of windows functions are provided for
@@ -242,10 +246,6 @@ accept the following arguments:
   result is NA)
 - ``freq``: optionally specify a :ref:`frequency string <timeseries.alias>`
   or :ref:`DateOffset <timeseries.offsets>` to pre-conform the data to.
-- ``how``: optionally specify method for down or re-sampling.  Default is
-  is ``min`` for :meth:`~Rolling.min`, ``max`` for :meth:`~Rolling.max`, ``median`` for
-  :meth:`~Rolling.median`, and ``mean`` for all other rolling functions.  See
-  :meth:`DataFrame.resample`'s how argument for more information.
 
 We can then call functions on these ``rolling`` objects. Which return like-indexed objects:
 
@@ -323,7 +323,7 @@ compute the mean absolute deviation on a rolling basis:
 Rolling Windows
 ~~~~~~~~~~~~~~~
 
-The :meth:`~Window.mean`, and :meth:`~Window.sum` functions performs a generic rolling window computation
+The :meth:`~Window.mean`, and :meth:`~Window.sum` functions perform a generic rolling window computation
 on the input data. The weights used in the window are specified by the ``win_type``
 keyword. The list of recognized types are:
 
@@ -360,6 +360,9 @@ For some windowing functions, additional parameters must be specified:
 .. ipython:: python
 
    ser.rolling(window=5, win_type='gaussian').mean(std=0.1)
+
+Centering Windows
+~~~~~~~~~~~~~~~~~
 
 By default the labels are set to the right edge of the window, but a
 ``center`` keyword is available so the labels can be set at the center.

--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -21,7 +21,7 @@
 Computational tools
 ===================
 
-Statistical functions
+Statistical Functions
 ---------------------
 
 .. _computation.pct_change:
@@ -196,90 +196,118 @@ parameter:
   - ``max`` : highest rank in the group
   - ``first`` : ranks assigned in the order they appear in the array
 
-
-.. currentmodule:: pandas
-
-.. currentmodule:: pandas.stats.api
-
 .. _stats.moments:
 
-Moving (rolling) statistics / moments
--------------------------------------
+Window Functions
+----------------
 
-For working with time series data, a number of functions are provided for
-computing common *moving* or *rolling* statistics. Among these are count, sum,
+.. warning::
+
+   Prior to version 0.18.0, these were module level functions that have been deprecated.
+   You can see the previous documentation
+   `here <http://pandas.pydata.org/pandas-docs/version/0.17.1/computation.html#moving-rolling-statistics-moments>`__
+
+For working with data, a number of windows functions are provided for
+computing common *window* or *rolling* statistics. Among these are count, sum,
 mean, median, correlation, variance, covariance, standard deviation, skewness,
-and kurtosis. All of these methods are in the :mod:`pandas` namespace, but
-otherwise they can be found in :mod:`pandas.stats.moments`.
+and kurtosis.
 
-.. currentmodule:: pandas
+.. currentmodule:: pandas.core.window
 
-.. csv-table::
-    :header: "Function", "Description"
-    :widths: 20, 80
+.. note::
 
-    :func:`rolling_count`, Number of non-null observations
-    :func:`rolling_sum`, Sum of values
-    :func:`rolling_mean`, Mean of values
-    :func:`rolling_median`, Arithmetic median of values
-    :func:`rolling_min`, Minimum
-    :func:`rolling_max`, Maximum
-    :func:`rolling_std`, Unbiased standard deviation
-    :func:`rolling_var`, Unbiased variance
-    :func:`rolling_skew`, Unbiased skewness (3rd moment)
-    :func:`rolling_kurt`, Unbiased kurtosis (4th moment)
-    :func:`rolling_quantile`, Sample quantile (value at %)
-    :func:`rolling_apply`, Generic apply
-    :func:`rolling_cov`, Unbiased covariance (binary)
-    :func:`rolling_corr`, Correlation (binary)
-    :func:`rolling_window`, Moving window function
+   The API for window statistics is quite similar to the way one works with ``Groupby`` objects, see the documentation :ref:`here <groupby>`
 
-Generally these methods all have the same interface. The binary operators
-(e.g. :func:`rolling_corr`) take two Series or DataFrames. Otherwise, they all
-accept the following arguments:
-
-  - ``window``: size of moving window
-  - ``min_periods``: threshold of non-null data points to require (otherwise
-    result is NA)
-  - ``freq``: optionally specify a :ref:`frequency string <timeseries.alias>`
-    or :ref:`DateOffset <timeseries.offsets>` to pre-conform the data to.
-    Note that prior to pandas v0.8.0, a keyword argument ``time_rule`` was used
-    instead of ``freq`` that referred to the legacy time rule constants
-  - ``how``: optionally specify method for down or re-sampling.  Default is
-    is min for :func:`rolling_min`, max for :func:`rolling_max`, median for
-    :func:`rolling_median`, and mean for all other rolling functions.  See
-    :meth:`DataFrame.resample`'s how argument for more information.
-
-These functions can be applied to ndarrays or Series objects:
+We work with ``rolling``, ``expanding`` and ``exponentially weighted`` data through the corresponding
+objects, :class:`~pandas.core.window.Rolling`, :class:`~pandas.core.window.Expanding` and :class:`~pandas.core.window.EWM`.
 
 .. ipython:: python
 
-   ts = pd.Series(np.random.randn(1000), index=pd.date_range('1/1/2000', periods=1000))
-   ts = ts.cumsum()
+   s = pd.Series(np.random.randn(1000), index=pd.date_range('1/1/2000', periods=1000))
+   s = s.cumsum()
+   s
 
-   ts.plot(style='k--')
+These are created from methods on ``Series`` and ``DataFrames``.
+
+.. ipython:: python
+
+   r = s.rolling(window=60)
+   r
+
+Generally these methods all have the same interface. They all
+accept the following arguments:
+
+- ``window``: size of moving window
+- ``min_periods``: threshold of non-null data points to require (otherwise
+  result is NA)
+- ``freq``: optionally specify a :ref:`frequency string <timeseries.alias>`
+  or :ref:`DateOffset <timeseries.offsets>` to pre-conform the data to.
+- ``how``: optionally specify method for down or re-sampling.  Default is
+  is ``min`` for :meth:`~Rolling.min`, ``max`` for :meth:`~Rolling.max`, ``median`` for
+  :meth:`~Rolling.median`, and ``mean`` for all other rolling functions.  See
+  :meth:`DataFrame.resample`'s how argument for more information.
+
+We can then call functions on these ``rolling`` objects. Which return like-indexed objects:
+
+.. ipython:: python
+
+   r.mean()
+
+.. ipython:: python
+
+   s.plot(style='k--')
 
    @savefig rolling_mean_ex.png
-   pd.rolling_mean(ts, 60).plot(style='k')
-
-They can also be applied to DataFrame objects. This is really just syntactic
-sugar for applying the moving window operator to all of the DataFrame's columns:
+   r.mean().plot(style='k')
 
 .. ipython:: python
    :suppress:
 
    plt.close('all')
 
+They can also be applied to DataFrame objects. This is really just syntactic
+sugar for applying the moving window operator to all of the DataFrame's columns:
+
 .. ipython:: python
 
-   df = pd.DataFrame(np.random.randn(1000, 4), index=ts.index,
-                  columns=['A', 'B', 'C', 'D'])
+   df = pd.DataFrame(np.random.randn(1000, 4), index=s.index,
+                     columns=['A', 'B', 'C', 'D'])
    df = df.cumsum()
 
    @savefig rolling_mean_frame.png
-   pd.rolling_sum(df, 60).plot(subplots=True)
+   df.rolling(window=60).sum().plot(subplots=True)
 
-The :func:`rolling_apply` function takes an extra ``func`` argument and performs
+.. _stats.summary:
+
+Method Summary
+~~~~~~~~~~~~~~
+
+We provide a number of the common statistical functions:
+
+.. currentmodule:: pandas.core.window
+
+.. csv-table::
+    :header: "Method", "Description"
+    :widths: 20, 80
+
+    :meth:`~Rolling.count`, Number of non-null observations
+    :meth:`~Rolling.sum`, Sum of values
+    :meth:`~Rolling.mean`, Mean of values
+    :meth:`~Rolling.median`, Arithmetic median of values
+    :meth:`~Rolling.min`, Minimum
+    :meth:`~Rolling.max`, Maximum
+    :meth:`~Rolling.std`, Unbiased standard deviation
+    :meth:`~Rolling.var`, Unbiased variance
+    :meth:`~Rolling.skew`, Unbiased skewness (3rd moment)
+    :meth:`~Rolling.kurt`, Unbiased kurtosis (4th moment)
+    :meth:`~Rolling.quantile`, Sample quantile (value at %)
+    :meth:`~Rolling.apply`, Generic apply
+    :meth:`~Rolling.cov`, Unbiased covariance (binary)
+    :meth:`~Rolling.corr`, Correlation (binary)
+    :meth:`~Window.mean`, Moving window mean function
+    :meth:`~Window.sum`, Moving window sum function
+
+The :meth:`~Rolling.apply` function takes an extra ``func`` argument and performs
 generic rolling computations. The ``func`` argument should be a single function
 that produces a single value from an ndarray input. Suppose we wanted to
 compute the mean absolute deviation on a rolling basis:
@@ -288,46 +316,50 @@ compute the mean absolute deviation on a rolling basis:
 
    mad = lambda x: np.fabs(x - x.mean()).mean()
    @savefig rolling_apply_ex.png
-   pd.rolling_apply(ts, 60, mad).plot(style='k')
+   s.rolling(window=60).apply(mad).plot(style='k')
 
-The :func:`rolling_window` function performs a generic rolling window computation
+.. _stats.rolling_window:
+
+Rolling Windows
+~~~~~~~~~~~~~~~
+
+The :meth:`~Window.mean`, and :meth:`~Window.sum` functions performs a generic rolling window computation
 on the input data. The weights used in the window are specified by the ``win_type``
 keyword. The list of recognized types are:
 
-    - ``boxcar``
-    - ``triang``
-    - ``blackman``
-    - ``hamming``
-    - ``bartlett``
-    - ``parzen``
-    - ``bohman``
-    - ``blackmanharris``
-    - ``nuttall``
-    - ``barthann``
-    - ``kaiser`` (needs beta)
-    - ``gaussian`` (needs std)
-    - ``general_gaussian`` (needs power, width)
-    - ``slepian`` (needs width).
+- ``boxcar``
+- ``triang``
+- ``blackman``
+- ``hamming``
+- ``bartlett``
+- ``parzen``
+- ``bohman``
+- ``blackmanharris``
+- ``nuttall``
+- ``barthann``
+- ``kaiser`` (needs beta)
+- ``gaussian`` (needs std)
+- ``general_gaussian`` (needs power, width)
+- ``slepian`` (needs width).
 
 .. ipython:: python
 
    ser = pd.Series(np.random.randn(10), index=pd.date_range('1/1/2000', periods=10))
 
-   pd.rolling_window(ser, 5, 'triang')
+   ser.rolling(window=5, win_type='triang').mean()
 
-Note that the ``boxcar`` window is equivalent to :func:`rolling_mean`.
+Note that the ``boxcar`` window is equivalent to :meth:`~Rolling.mean`.
 
 .. ipython:: python
 
-   pd.rolling_window(ser, 5, 'boxcar')
-
-   pd.rolling_mean(ser, 5)
+   ser.rolling(window=5, win_type='boxcar').mean()
+   ser.rolling(window=5).mean()
 
 For some windowing functions, additional parameters must be specified:
 
 .. ipython:: python
 
-   pd.rolling_window(ser, 5, 'gaussian', std=0.1)
+   ser.rolling(window=5, win_type='gaussian').mean(std=0.1)
 
 By default the labels are set to the right edge of the window, but a
 ``center`` keyword is available so the labels can be set at the center.
@@ -335,32 +367,32 @@ This keyword is available in other rolling functions as well.
 
 .. ipython:: python
 
-   pd.rolling_window(ser, 5, 'boxcar')
+   ser.rolling(window=5, win_type='boxcar').mean()
 
-   pd.rolling_window(ser, 5, 'boxcar', center=True)
+   ser.rolling(window=5, win_type='boxcar', center=True).mean()
 
-   pd.rolling_mean(ser, 5, center=True)
+   ser.rolling(window=5, center=True).mean()
 
 .. _stats.moments.normalization:
 
 .. note::
 
-    In rolling sum mode (``mean=False``) there is no normalization done to the
+    For ``.sum()`` with a ``win_type``, there is no normalization done to the
     weights. Passing custom weights of ``[1, 1, 1]`` will yield a different
     result than passing weights of ``[2, 2, 2]``, for example. When passing a
     ``win_type`` instead of explicitly specifying the weights, the weights are
     already normalized so that the largest weight is 1.
 
-    In contrast, the nature of the rolling mean calculation (``mean=True``)is
+    In contrast, the nature of the ``.mean()`` calculation is
     such that the weights are normalized with respect to each other. Weights
     of ``[1, 1, 1]`` and ``[2, 2, 2]`` yield the same result.
 
 .. _stats.moments.binary:
 
-Binary rolling moments
-~~~~~~~~~~~~~~~~~~~~~~
+Binary Window Functions
+~~~~~~~~~~~~~~~~~~~~~~~
 
-:func:`rolling_cov` and :func:`rolling_corr` can compute moving window statistics about
+:meth:`~Rolling.cov` and :meth:`~Rolling.corr` can compute moving window statistics about
 two ``Series`` or any combination of ``DataFrame/Series`` or
 ``DataFrame/DataFrame``. Here is the behavior in each case:
 
@@ -378,7 +410,7 @@ For example:
 .. ipython:: python
 
    df2 = df[:20]
-   pd.rolling_corr(df2, df2['B'], window=5)
+   df2.rolling(window=5).corr(df2['B'])
 
 .. _stats.moments.corr_pairwise:
 
@@ -403,23 +435,16 @@ can even be omitted:
 
 .. ipython:: python
 
-   covs = pd.rolling_cov(df[['B','C','D']], df[['A','B','C']], 50, pairwise=True)
+   covs = df[['B','C','D']].rolling(window=50).cov(df[['A','B','C']], pairwise=True)
    covs[df.index[-50]]
 
 .. ipython:: python
 
-   correls = pd.rolling_corr(df, 50)
+   correls = df.rolling(window=50).corr()
    correls[df.index[-50]]
 
-.. note::
-
-    Prior to version 0.14 this was available through ``rolling_corr_pairwise``
-    which is now simply syntactic sugar for calling ``rolling_corr(...,
-    pairwise=True)`` and deprecated. This is likely to be removed in a future
-    release.
-
 You can efficiently retrieve the time series of correlations between two
-columns using ``ix`` indexing:
+columns using ``.loc`` indexing:
 
 .. ipython:: python
    :suppress:
@@ -429,62 +454,153 @@ columns using ``ix`` indexing:
 .. ipython:: python
 
    @savefig rolling_corr_pairwise_ex.png
-   correls.ix[:, 'A', 'C'].plot()
+   correls.loc[:, 'A', 'C'].plot()
+
+.. _stats.aggregate:
+
+Aggregation
+-----------
+
+Once the ``Rolling``, ``Expanding`` or ``EWM`` objects have been created, several methods are available to
+perform multiple computations on the data. This is very similar to a ``.groupby.agg`` seen :ref:`here <groupby.aggregate>`.
+
+An obvious one is aggregation via the ``aggregate`` or equivalently ``agg`` method:
+
+.. ipython:: python
+
+   dfa = pd.DataFrame(np.random.randn(1000, 3), index=s.index,
+                     columns=['A', 'B', 'C'])
+   r = dfa.rolling(window=60,min_periods=1)
+   r
+
+We can aggregate by passing a function to the entire DataFrame, or select a Series (or multiple Series) via standard getitem.
+
+.. ipython:: python
+
+   r.aggregate(np.sum)
+
+   r['A'].aggregate(np.sum)
+
+   r['A','B'].aggregate(np.sum)
+
+As you can see, the result of the aggregation will have the selection columns, or all
+columns if none are selected.
+
+.. _stats.aggregate.multifunc:
+
+Applying multiple functions at once
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+With windowed Series you can also pass a list or dict of functions to do
+aggregation with, outputting a DataFrame:
+
+.. ipython:: python
+
+   r['A'].agg([np.sum, np.mean, np.std])
+
+If a dict is passed, the keys will be used to name the columns. Otherwise the
+function's name (stored in the function object) will be used.
+
+.. ipython:: python
+
+   r['A'].agg({'result1' : np.sum,
+               'result2' : np.mean})
+
+On a widowed DataFrame, you can pass a list of functions to apply to each
+column, which produces an aggregated result with a hierarchical index:
+
+.. ipython:: python
+
+   r.agg([np.sum, np.mean])
+
+Passing a dict of functions has different behavior by default, see the next
+section.
+
+Applying different functions to DataFrame columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By passing a dict to ``aggregate`` you can apply a different aggregation to the
+columns of a DataFrame:
+
+.. ipython:: python
+
+   r.agg({'A' : np.sum,
+          'B' : lambda x: np.std(x, ddof=1)})
+
+The function names can also be strings. In order for a string to be valid it
+must be either implemented on the Windowed object
+
+.. ipython:: python
+
+   r.agg({'A' : 'sum', 'B' : 'std'})
+
+Furthermore you can pass a nested dict to indicate different aggregations on different columns.
+
+.. ipython:: python
+
+   r.agg({'A' : {'ra' : 'sum'}, 'B' : {'rb' : 'std' }})
+
 
 .. _stats.moments.expanding:
 
-Expanding window moment functions
----------------------------------
+Expanding Windows
+-----------------
+
 A common alternative to rolling statistics is to use an *expanding* window,
 which yields the value of the statistic with all the data available up to that
-point in time. As these calculations are a special case of rolling statistics,
+point in time.
+
+These follow a similar interface to ``.rolling``, with the ``.expanding`` method
+returning an :class:`~pandas.core.window.Expanding` object.
+
+As these calculations are a special case of rolling statistics,
 they are implemented in pandas such that the following two calls are equivalent:
 
 .. ipython:: python
 
-   pd.rolling_mean(df, window=len(df), min_periods=1)[:5]
+   df.rolling(window=len(df), min_periods=1).mean()[:5]
 
-   pd.expanding_mean(df)[:5]
+   df.expanding(min_periods=1).mean()[:5]
 
-Like the ``rolling_`` functions, the following methods are included in the
-``pandas`` namespace or can be located in ``pandas.stats.moments``.
+These have a similar set of methods to ``.rolling`` methods.
 
-.. currentmodule:: pandas
+Method Summary
+~~~~~~~~~~~~~~
+
+.. currentmodule:: pandas.core.window
 
 .. csv-table::
     :header: "Function", "Description"
     :widths: 20, 80
 
-    :func:`expanding_count`, Number of non-null observations
-    :func:`expanding_sum`, Sum of values
-    :func:`expanding_mean`, Mean of values
-    :func:`expanding_median`, Arithmetic median of values
-    :func:`expanding_min`, Minimum
-    :func:`expanding_max`, Maximum
-    :func:`expanding_std`, Unbiased standard deviation
-    :func:`expanding_var`, Unbiased variance
-    :func:`expanding_skew`, Unbiased skewness (3rd moment)
-    :func:`expanding_kurt`, Unbiased kurtosis (4th moment)
-    :func:`expanding_quantile`, Sample quantile (value at %)
-    :func:`expanding_apply`, Generic apply
-    :func:`expanding_cov`, Unbiased covariance (binary)
-    :func:`expanding_corr`, Correlation (binary)
+    :meth:`~Expanding.count`, Number of non-null observations
+    :meth:`~Expanding.sum`, Sum of values
+    :meth:`~Expanding.mean`, Mean of values
+    :meth:`~Expanding.median`, Arithmetic median of values
+    :meth:`~Expanding.min`, Minimum
+    :meth:`~Expanding.max`, Maximum
+    :meth:`~Expanding.std`, Unbiased standard deviation
+    :meth:`~Expanding.var`, Unbiased variance
+    :meth:`~Expanding.skew`, Unbiased skewness (3rd moment)
+    :meth:`~Expanding.kurt`, Unbiased kurtosis (4th moment)
+    :meth:`~Expanding.quantile`, Sample quantile (value at %)
+    :meth:`~Expanding.apply`, Generic apply
+    :meth:`~Expanding.cov`, Unbiased covariance (binary)
+    :meth:`~Expanding.corr`, Correlation (binary)
 
 Aside from not having a ``window`` parameter, these functions have the same
-interfaces as their ``rolling_`` counterpart. Like above, the parameters they
+interfaces as their ``.rolling`` counterparts. Like above, the parameters they
 all accept are:
 
-  - ``min_periods``: threshold of non-null data points to require. Defaults to
-    minimum needed to compute statistic. No ``NaNs`` will be output once
-    ``min_periods`` non-null data points have been seen.
-  - ``freq``: optionally specify a :ref:`frequency string <timeseries.alias>`
-    or :ref:`DateOffset <timeseries.offsets>` to pre-conform the data to.
-    Note that prior to pandas v0.8.0, a keyword argument ``time_rule`` was used
-    instead of ``freq`` that referred to the legacy time rule constants
+- ``min_periods``: threshold of non-null data points to require. Defaults to
+  minimum needed to compute statistic. No ``NaNs`` will be output once
+  ``min_periods`` non-null data points have been seen.
+- ``freq``: optionally specify a :ref:`frequency string <timeseries.alias>`
+  or :ref:`DateOffset <timeseries.offsets>` to pre-conform the data to.
 
 .. note::
 
-   The output of the ``rolling_`` and ``expanding_`` functions do not return a
+   The output of the ``.rolling`` and ``.expanding`` methods do not return a
    ``NaN`` if there are at least ``min_periods`` non-null values in the current
    window. This differs from ``cumsum``, ``cumprod``, ``cummax``, and
    ``cummin``, which return ``NaN`` in the output wherever a ``NaN`` is
@@ -493,7 +609,7 @@ all accept are:
 An expanding window statistic will be more stable (and less responsive) than
 its rolling window counterpart as the increasing window size decreases the
 relative impact of an individual data point. As an example, here is the
-:func:`expanding_mean` output for the previous time series dataset:
+:meth:`~Expanding.mean` output for the previous time series dataset:
 
 .. ipython:: python
    :suppress:
@@ -502,31 +618,34 @@ relative impact of an individual data point. As an example, here is the
 
 .. ipython:: python
 
-   ts.plot(style='k--')
+   s.plot(style='k--')
 
    @savefig expanding_mean_frame.png
-   pd.expanding_mean(ts).plot(style='k')
+   s.expanding().mean().plot(style='k')
+
 
 .. _stats.moments.exponentially_weighted:
 
-Exponentially weighted moment functions
----------------------------------------
+Exponentially Weighted Windows
+------------------------------
 
 A related set of functions are exponentially weighted versions of several of
-the above statistics. A number of expanding EW (exponentially weighted)
-functions are provided:
+the above statistics. A similar interface to ``.rolling`` and ``.expanding`` is accessed
+thru the ``.ewm`` method to receive a :class:`~pandas.core.window.EWM` object.
+A number of expanding EW (exponentially weighted)
+methods are provided:
 
-.. currentmodule:: pandas
+.. currentmodule:: pandas.core.window
 
 .. csv-table::
     :header: "Function", "Description"
     :widths: 20, 80
 
-    :func:`ewma`, EW moving average
-    :func:`ewmvar`, EW moving variance
-    :func:`ewmstd`, EW moving standard deviation
-    :func:`ewmcorr`, EW moving correlation
-    :func:`ewmcov`, EW moving covariance
+    :meth:`~EWM.mean`, EW moving average
+    :meth:`~EWM.var`, EW moving variance
+    :meth:`~EWM.std`, EW moving standard deviation
+    :meth:`~EWM.corr`, EW moving correlation
+    :meth:`~EWM.cov`, EW moving covariance
 
 In general, a weighted moving average is calculated as
 
@@ -621,20 +740,20 @@ Here is an example for a univariate time series:
 
 .. ipython:: python
 
-   ts.plot(style='k--')
+   s.plot(style='k--')
 
    @savefig ewma_ex.png
-   pd.ewma(ts, span=20).plot(style='k')
+   s.ewm(span=20).mean().plot(style='k')
 
-All the EW functions have a ``min_periods`` argument, which has the same
-meaning it does for all the ``expanding_`` and ``rolling_`` functions:
+EWM has a ``min_periods`` argument, which has the same
+meaning it does for all the ``.expanding`` and ``.rolling`` methods:
 no output values will be set until at least ``min_periods`` non-null values
 are encountered in the (expanding) window.
 (This is a change from versions prior to 0.15.0, in which the ``min_periods``
 argument affected only the ``min_periods`` consecutive entries starting at the
 first non-null value.)
 
-All the EW functions also have an ``ignore_na`` argument, which deterines how
+EWM also has an ``ignore_na`` argument, which deterines how
 intermediate null values affect the calculation of the weights.
 When ``ignore_na=False`` (the default), weights are calculated based on absolute
 positions, so that intermediate null values affect the result.
@@ -653,7 +772,7 @@ Whereas if ``ignore_na=True``, the weighted average would be calculated as
 
 	\frac{(1-\alpha) \cdot 3 + 1 \cdot 5}{(1-\alpha) + 1}.
 
-The :func:`ewmvar`, :func:`ewmstd`, and :func:`ewmcov` functions have a ``bias`` argument,
+The :meth:`~Ewm.var`, :meth:`~Ewm.std`, and :meth:`~Ewm.cov` functions have a ``bias`` argument,
 specifying whether the result should contain biased or unbiased statistics.
 For example, if ``bias=True``, ``ewmvar(x)`` is calculated as
 ``ewmvar(x) = ewma(x**2) - ewma(x)**2``;

--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -207,7 +207,6 @@ Window Functions
    functions and are now deprecated and replaced by the corresponding method call.
 
    The deprecation warning will show the new syntax, see an example :ref:`here <whatsnew_0180.window_deprecations>`
-
    You can view the previous documentation
    `here <http://pandas.pydata.org/pandas-docs/version/0.17.1/computation.html#moving-rolling-statistics-moments>`__
 
@@ -244,8 +243,12 @@ accept the following arguments:
 - ``window``: size of moving window
 - ``min_periods``: threshold of non-null data points to require (otherwise
   result is NA)
-- ``freq``: optionally specify a :ref:`frequency string <timeseries.alias>`
-  or :ref:`DateOffset <timeseries.offsets>` to pre-conform the data to.
+
+.. warning::
+
+   The ``freq`` and ``how`` arguments were in the API prior to 0.18.0 changes. These are deprecated in the new API. You can simply resample the input prior to creating a window function.
+
+   For example, instead of ``s.rolling(window=5,freq='D').max()`` to get the max value on a rolling 5 Day window, one could use ``s.resample('D',how='max').rolling(window=5).max()``, which first resamples the data to daily data, then provides a rolling 5 day window.
 
 We can then call methods on these ``rolling`` objects. These return like-indexed objects:
 
@@ -604,8 +607,6 @@ all accept are:
 - ``min_periods``: threshold of non-null data points to require. Defaults to
   minimum needed to compute statistic. No ``NaNs`` will be output once
   ``min_periods`` non-null data points have been seen.
-- ``freq``: optionally specify a :ref:`frequency string <timeseries.alias>`
-  or :ref:`DateOffset <timeseries.offsets>` to pre-conform the data to.
 
 .. note::
 

--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -243,6 +243,7 @@ accept the following arguments:
 - ``window``: size of moving window
 - ``min_periods``: threshold of non-null data points to require (otherwise
   result is NA)
+- ``center``: boolean, whether to set the labels at the center (default is False)
 
 .. warning::
 
@@ -334,7 +335,7 @@ The following methods are available:
     :meth:`~Window.sum`, Sum of values
     :meth:`~Window.mean`, Mean of values
 
-The weights used in the window are specified by the ``win_type``keyword. The list of recognized types are:
+The weights used in the window are specified by the ``win_type`` keyword. The list of recognized types are:
 
 - ``boxcar``
 - ``triang``
@@ -370,6 +371,20 @@ For some windowing functions, additional parameters must be specified:
 
    ser.rolling(window=5, win_type='gaussian').mean(std=0.1)
 
+.. _stats.moments.normalization:
+
+.. note::
+
+    For ``.sum()`` with a ``win_type``, there is no normalization done to the
+    weights for the window. Passing custom weights of ``[1, 1, 1]`` will yield a different
+    result than passing weights of ``[2, 2, 2]``, for example. When passing a
+    ``win_type`` instead of explicitly specifying the weights, the weights are
+    already normalized so that the largest weight is 1.
+
+    In contrast, the nature of the ``.mean()`` calculation is
+    such that the weights are normalized with respect to each other. Weights
+    of ``[1, 1, 1]`` and ``[2, 2, 2]`` yield the same result.
+
 Centering Windows
 ~~~~~~~~~~~~~~~~~
 
@@ -379,25 +394,8 @@ This keyword is available in other rolling functions as well.
 
 .. ipython:: python
 
-   ser.rolling(window=5, win_type='boxcar').mean()
-
-   ser.rolling(window=5, win_type='boxcar', center=True).mean()
-
+   ser.rolling(window=5).mean()
    ser.rolling(window=5, center=True).mean()
-
-.. _stats.moments.normalization:
-
-.. note::
-
-    For ``.sum()`` with a ``win_type``, there is no normalization done to the
-    weights. Passing custom weights of ``[1, 1, 1]`` will yield a different
-    result than passing weights of ``[2, 2, 2]``, for example. When passing a
-    ``win_type`` instead of explicitly specifying the weights, the weights are
-    already normalized so that the largest weight is 1.
-
-    In contrast, the nature of the ``.mean()`` calculation is
-    such that the weights are normalized with respect to each other. Weights
-    of ``[1, 1, 1]`` and ``[2, 2, 2]`` yield the same result.
 
 .. _stats.moments.binary:
 
@@ -550,7 +548,7 @@ Furthermore you can pass a nested dict to indicate different aggregations on dif
 
 .. ipython:: python
 
-   r.agg({'A' : {'ra' : 'sum'}, 'B' : {'rb' : 'std' }})
+   r.agg({'A' : ['sum','std'], 'B' : ['mean','std'] })
 
 
 .. _stats.moments.expanding:
@@ -607,6 +605,7 @@ all accept are:
 - ``min_periods``: threshold of non-null data points to require. Defaults to
   minimum needed to compute statistic. No ``NaNs`` will be output once
   ``min_periods`` non-null data points have been seen.
+- ``center``: boolean, whether to set the labels at the center (default is False)
 
 .. note::
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -224,16 +224,7 @@ moved_api_pages = [
     'pandas.io.pickle.read_pickle', 'pandas.io.pytables.HDFStore.append', 'pandas.io.pytables.HDFStore.get',
     'pandas.io.pytables.HDFStore.put', 'pandas.io.pytables.HDFStore.select', 'pandas.io.pytables.read_hdf',
     'pandas.io.sql.read_sql', 'pandas.io.sql.read_frame', 'pandas.io.sql.write_frame',
-    'pandas.io.stata.read_stata', 'pandas.stats.moments.ewma', 'pandas.stats.moments.ewmcorr',
-    'pandas.stats.moments.ewmcov', 'pandas.stats.moments.ewmstd', 'pandas.stats.moments.ewmvar',
-    'pandas.stats.moments.expanding_apply', 'pandas.stats.moments.expanding_corr', 'pandas.stats.moments.expanding_count',
-    'pandas.stats.moments.expanding_cov', 'pandas.stats.moments.expanding_kurt', 'pandas.stats.moments.expanding_mean',
-    'pandas.stats.moments.expanding_median', 'pandas.stats.moments.expanding_quantile', 'pandas.stats.moments.expanding_skew',
-    'pandas.stats.moments.expanding_std', 'pandas.stats.moments.expanding_sum', 'pandas.stats.moments.expanding_var',
-    'pandas.stats.moments.rolling_apply', 'pandas.stats.moments.rolling_corr', 'pandas.stats.moments.rolling_count',
-    'pandas.stats.moments.rolling_cov', 'pandas.stats.moments.rolling_kurt', 'pandas.stats.moments.rolling_mean',
-    'pandas.stats.moments.rolling_median', 'pandas.stats.moments.rolling_quantile', 'pandas.stats.moments.rolling_skew',
-    'pandas.stats.moments.rolling_std', 'pandas.stats.moments.rolling_sum', 'pandas.stats.moments.rolling_var']
+    'pandas.io.stata.read_stata']
 
 html_additional_pages = {'generated/' + page: 'api_redirect.html' for page in moved_api_pages}
 

--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -517,7 +517,7 @@ Unlike agg, apply's callable is passed a sub-DataFrame which gives you access to
    def Red(x):
       return functools.reduce(CumRet,x,1.0)
 
-   pd.expanding_apply(S, Red)
+   S.expanding().apply(Red)
 
 
 `Replacing some values with mean of the rest of a group
@@ -639,7 +639,7 @@ Create a list of dataframes, split using a delineation based on logic included i
    df = pd.DataFrame(data={'Case' : ['A','A','A','B','A','A','B','A','A'],
                            'Data' : np.random.randn(9)})
 
-   dfs = list(zip(*df.groupby(pd.rolling_median((1*(df['Case']=='B')).cumsum(),3,True))))[-1]
+   dfs = list(zip(*df.groupby((1*(df['Case']=='B')).cumsum().rolling(window=3,min_periods=1).median())))[-1]
 
    dfs[0]
    dfs[1]

--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -519,7 +519,7 @@ to standardize the data within each group:
 
    index = pd.date_range('10/1/1999', periods=1100)
    ts = pd.Series(np.random.normal(0.5, 2, 1100), index)
-   ts = pd.rolling_mean(ts, 100, 100).dropna()
+   ts = ts.rolling(window=100,min_periods=100).mean().dropna()
 
    ts.head()
    ts.tail()

--- a/doc/source/whatsnew/v0.14.0.txt
+++ b/doc/source/whatsnew/v0.14.0.txt
@@ -170,11 +170,18 @@ API changes
   :ref:`Computing rolling pairwise covariances and correlations
   <stats.moments.corr_pairwise>` in the docs.
 
-  .. ipython:: python
+  .. code-block:: python
 
-    df = DataFrame(np.random.randn(10,4),columns=list('ABCD'))
-    covs = rolling_cov(df[['A','B','C']], df[['B','C','D']], 5, pairwise=True)
-    covs[df.index[-1]]
+     In [1]: df = DataFrame(np.random.randn(10,4),columns=list('ABCD'))
+
+     In [4]: covs = pd.rolling_cov(df[['A','B','C']], df[['B','C','D']], 5, pairwise=True)
+
+     In [5]: covs[df.index[-1]]
+     Out[5]:
+               B         C         D
+     A  0.035310  0.326593 -0.505430
+     B  0.137748 -0.006888 -0.005383
+     C -0.006888  0.861040  0.020762
 
 - ``Series.iteritems()`` is now lazy (returns an iterator rather than a list). This was the documented behavior prior to 0.14. (:issue:`6760`)
 

--- a/doc/source/whatsnew/v0.15.0.txt
+++ b/doc/source/whatsnew/v0.15.0.txt
@@ -68,7 +68,7 @@ For full docs, see the :ref:`categorical introduction <categorical>` and the
 
 .. ipython:: python
     :okwarning:
-    
+
     df = DataFrame({"id":[1,2,3,4,5,6], "raw_grade":['a', 'b', 'b', 'a', 'a', 'e']})
 
     df["grade"] = df["raw_grade"].astype("category")
@@ -353,9 +353,15 @@ Rolling/Expanding Moments improvements
 
   New behavior
 
-  .. ipython:: python
+  .. code-block:: python
 
-     rolling_min(s, window=10, min_periods=5)
+     In [4]: pd.rolling_min(s, window=10, min_periods=5)
+     Out[4]:
+     0   NaN
+     1   NaN
+     2   NaN
+     3   NaN
+     dtype: float64
 
 - :func:`rolling_max`, :func:`rolling_min`, :func:`rolling_sum`, :func:`rolling_mean`, :func:`rolling_median`,
   :func:`rolling_std`, :func:`rolling_var`, :func:`rolling_skew`, :func:`rolling_kurt`, :func:`rolling_quantile`,
@@ -381,9 +387,15 @@ Rolling/Expanding Moments improvements
 
   New behavior (note final value is ``5 = sum([2, 3, NaN])``):
 
-  .. ipython:: python
+  .. code-block:: python
 
-    rolling_sum(Series(range(4)), window=3, min_periods=0, center=True)
+     In [7]: rolling_sum(Series(range(4)), window=3, min_periods=0, center=True)
+     Out[7]:
+     0    1
+     1    3
+     2    6
+     3    5
+     dtype: float64
 
 - :func:`rolling_window` now normalizes the weights properly in rolling mean mode (`mean=True`) so that
   the calculated weighted means (e.g. 'triang', 'gaussian') are distributed about the same means as those
@@ -397,20 +409,27 @@ Rolling/Expanding Moments improvements
 
   .. code-block:: python
 
-    In [39]: rolling_window(s, window=3, win_type='triang', center=True)
-    Out[39]:
-    0         NaN
-    1    6.583333
-    2    6.883333
-    3    6.683333
-    4         NaN
-    dtype: float64
+     In [39]: rolling_window(s, window=3, win_type='triang', center=True)
+     Out[39]:
+     0         NaN
+     1    6.583333
+     2    6.883333
+     3    6.683333
+     4         NaN
+     dtype: float64
 
   New behavior
 
   .. ipython:: python
 
-    rolling_window(s, window=3, win_type='triang', center=True)
+     In [10]: pd.rolling_window(s, window=3, win_type='triang', center=True)
+     Out[10]:
+     0       NaN
+     1     9.875
+     2    10.325
+     3    10.025
+     4       NaN
+     dtype: float64
 
 - Removed ``center`` argument from all :func:`expanding_ <expanding_apply>` functions (see :ref:`list <api.functions_expanding>`),
   as the results produced when ``center=True`` did not make much sense. (:issue:`7925`)
@@ -449,9 +468,17 @@ Rolling/Expanding Moments improvements
 
   New behavior (note values start at index ``4``, the location of the 2nd (since ``min_periods=2``) non-empty value):
 
-  .. ipython:: python
+  .. code-block:: python
 
-    ewma(s, com=3., min_periods=2)
+     In [2]: pd.ewma(s, com=3., min_periods=2)
+     Out[2]:
+     0         NaN
+     1         NaN
+     2         NaN
+     3         NaN
+     4    1.759644
+     5    2.383784
+     dtype: float64
 
 - :func:`ewmstd`, :func:`ewmvol`, :func:`ewmvar`, :func:`ewmcov`, and :func:`ewmcorr`
   now have an optional ``adjust`` argument, just like :func:`ewma` does,
@@ -465,11 +492,28 @@ Rolling/Expanding Moments improvements
   When ``ignore_na=True`` (which reproduces the pre-0.15.0 behavior), missing values are ignored in the weights calculation.
   (:issue:`7543`)
 
-  .. ipython:: python
+  .. code-block:: python
 
-     ewma(Series([None, 1., 8.]), com=2.)
-     ewma(Series([1., None, 8.]), com=2., ignore_na=True)  # pre-0.15.0 behavior
-     ewma(Series([1., None, 8.]), com=2., ignore_na=False)  # new default
+     In [7]: pd.ewma(Series([None, 1., 8.]), com=2.)
+     Out[7]:
+     0    NaN
+     1    1.0
+     2    5.2
+     dtype: float64
+
+     In [8]: pd.ewma(Series([1., None, 8.]), com=2., ignore_na=True)  # pre-0.15.0 behavior
+     Out[8]:
+     0    1.0
+     1    1.0
+     2    5.2
+     dtype: float64
+
+     In [9]: pd.ewma(Series([1., None, 8.]), com=2., ignore_na=False)  # new default
+     Out[9]:
+     0    1.000000
+     1    1.000000
+     2    5.846154
+     dtype: float64
 
   .. warning::
 
@@ -525,10 +569,23 @@ Rolling/Expanding Moments improvements
   By comparison, the following 0.15.0 results have a ``NaN`` for entry ``0``,
   and the debiasing factors are decreasing (towards 1.25):
 
-  .. ipython:: python
+  .. code-block:: python
 
-     ewmvar(s, com=2., bias=False)
-     ewmvar(s, com=2., bias=False) / ewmvar(s, com=2., bias=True)
+     In [14]: pd.ewmvar(s, com=2., bias=False)
+     Out[14]:
+     0         NaN
+     1    0.500000
+     2    1.210526
+     3    4.089069
+     dtype: float64
+
+     In [15]: pd.ewmvar(s, com=2., bias=False) / pd.ewmvar(s, com=2., bias=True)
+     Out[15]:
+     0         NaN
+     1    2.083333
+     2    1.583333
+     3    1.425439
+     dtype: float64
 
   See :ref:`Exponentially weighted moment functions <stats.moments.exponentially_weighted>` for details. (:issue:`7912`)
 

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -210,18 +210,40 @@ Other API Changes
 Deprecations
 ^^^^^^^^^^^^
 
+.. _whatsnew_0180.window_deprecations:
 
+- Function ``pd.rolling_*``, ``pd.expanding_*``, and ``pd.ewm*`` are deprecated and replaced by the corresponding method call. Note that
+  the new suggested syntax includes all of the arguments (even if default) (:issue:`11603`)
 
+  .. code-block:: python
 
+     In [1]: s = Series(range(3))
 
+     In [2]: pd.rolling_mean(s,window=2,min_periods=1)
+             FutureWarning: pd.rolling_mean is deprecated for Series and will be removed in a future version, replace with
+                  Series.rolling(min_periods=1,window=2,center=False).mean()
+     Out[2]:
+             0    0.0
+             1    0.5
+             2    1.5
+             dtype: float64
+
+     In [3]: pd.rolling_cov(s, s, window=2)
+             FutureWarning: pd.rolling_cov is deprecated for Series and will be removed in a future version, replace with
+                  Series.rolling(window=2).cov(other=<Series>)
+     Out[3]:
+             0    NaN
+             1    0.5
+             2    0.5
+             dtype: float64
 
 .. _whatsnew_0180.prior_deprecations:
 
 Removal of prior version deprecations/changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Removal of ``rolling_corr_parwise`` in favor of ``.rolling().corr(pairwise=True)`` (:issue:`4950`)
-Removal of ``expanding_corr_parwise`` in favor of ``.expanding().corr(pairwise=True)`` (:issue:`4950`)
+- Removal of ``rolling_corr_parwise`` in favor of ``.rolling().corr(pairwise=True)`` (:issue:`4950`)
+- Removal of ``expanding_corr_parwise`` in favor of ``.expanding().corr(pairwise=True)`` (:issue:`4950`)
 
 
 

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -220,8 +220,8 @@ Deprecations
 Removal of prior version deprecations/changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-
-
+Removal of ``rolling_corr_parwise`` in favor of ``.rolling().corr(pairwise=True)`` (:issue:`4950`)
+Removal of ``expanding_corr_parwise`` in favor of ``.expanding().corr(pairwise=True)`` (:issue:`4950`)
 
 
 

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -13,6 +13,8 @@ users upgrade to this version.
 
 Highlights include:
 
+- Window functions are now methods on ``.groupby`` like objects, see :ref:`here <whatsnew_0180.moments>`.
+
 Check the :ref:`API Changes <whatsnew_0180.api>` and :ref:`deprecations <whatsnew_0180.deprecations>` before updating.
 
 .. contents:: What's new in v0.18.0
@@ -212,7 +214,7 @@ Deprecations
 
 .. _whatsnew_0180.window_deprecations:
 
-- Function ``pd.rolling_*``, ``pd.expanding_*``, and ``pd.ewm*`` are deprecated and replaced by the corresponding method call. Note that
+- The functions ``pd.rolling_*``, ``pd.expanding_*``, and ``pd.ewm*`` are deprecated and replaced by the corresponding method call. Note that
   the new suggested syntax includes all of the arguments (even if default) (:issue:`11603`)
 
   .. code-block:: python
@@ -236,6 +238,8 @@ Deprecations
              1    0.5
              2    0.5
              dtype: float64
+
+- The the ``freq`` and ``how`` arguments to the ``.rolling``, ``.expanding``, and ``.ewm`` (new) functions are deprecated, and will be removed in a future version. (:issue:`11603`)
 
 .. _whatsnew_0180.prior_deprecations:
 

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -25,10 +25,55 @@ New features
 ~~~~~~~~~~~~
 
 
+.. _whatsnew_0180.enhancements.moments:
 
+Computation moments are now methods
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Computational moments have been refactored to be method on ``Series/DataFrame`` objects, rather than top-level functions, which are now deprecated. This allows these window-type functions, to have a similar API to that of ``.groupby``. See the full documentation :ref:`here <stats.moments>` (:issue:`11603`)
 
+.. ipython:: python
 
+   np.random.seed(1234)
+   df = DataFrame({'A' : range(10), 'B' : np.random.randn(10)})
+   df
+
+Previous Behavior:
+
+.. code-block:: python
+
+   In [8]: pd.rolling_mean(df,window=3)
+   Out[8]:
+       A         B
+   0 NaN       NaN
+   1 NaN       NaN
+   2   1  0.237722
+   3   2 -0.023640
+   4   3  0.133155
+   5   4 -0.048693
+   6   5  0.342054
+   7   6  0.370076
+   8   7  0.079587
+   9   8 -0.954504
+
+  New Behavior:
+
+  .. ipython:: python
+
+    r = df.rolling(window=3)
+
+    # descriptive repr
+    r
+
+    # operate on this Rolling object itself
+    r.mean()
+
+    # getitem access
+    r['A'].mean()
+
+    # aggregates
+    r.agg({'A' : {'ra' : ['mean','std']},
+           'B' : {'rb' : ['mean','std']}})
 
 .. _whatsnew_0180.enhancements.other:
 
@@ -195,6 +240,7 @@ Bug Fixes
 - Bug in ``Period.end_time`` when a multiple of time period is requested (:issue:`11738`)
 - Regression in ``.clip`` with tz-aware datetimes (:issue:`11838`)
 - Bug in ``date_range`` when the boundaries fell on the frequency (:issue:`11804`)
+- Bug in consistency of passing nested dicts to ``.groupby(...).agg(...)`` (:issue:`9052`)
 
 
 

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -27,10 +27,10 @@ New features
 
 .. _whatsnew_0180.enhancements.moments:
 
-Computation moments are now methods
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Window functions are now methods
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Computational moments have been refactored to be method on ``Series/DataFrame`` objects, rather than top-level functions, which are now deprecated. This allows these window-type functions, to have a similar API to that of ``.groupby``. See the full documentation :ref:`here <stats.moments>` (:issue:`11603`)
+Window functions have been refactored to be methods on ``Series/DataFrame`` objects, rather than top-level functions, which are now deprecated. This allows these window-type functions, to have a similar API to that of ``.groupby``. See the full documentation :ref:`here <stats.moments>` (:issue:`11603`)
 
 .. ipython:: python
 
@@ -56,24 +56,36 @@ Previous Behavior:
    8   7  0.079587
    9   8 -0.954504
 
-  New Behavior:
+New Behavior:
 
-  .. ipython:: python
+.. ipython:: python
 
-    r = df.rolling(window=3)
+   r = df.rolling(window=3)
 
-    # descriptive repr
-    r
+These show a descriptive repr, with tab-completion of available methods
 
-    # operate on this Rolling object itself
-    r.mean()
+.. ipython:: python
 
-    # getitem access
-    r['A'].mean()
+   r
 
-    # aggregates
-    r.agg({'A' : {'ra' : ['mean','std']},
-           'B' : {'rb' : ['mean','std']}})
+The methods operate on this ``Rolling`` object itself
+
+.. ipython:: python
+
+   r.mean()
+
+They provide getitem accessors
+
+.. ipython:: python
+
+   r['A'].mean()
+
+And multiple aggregations
+
+.. ipython:: python
+
+   r.agg({'A' : {'ra' : ['mean','std']},
+          'B' : {'rb' : ['mean','std']}})
 
 .. _whatsnew_0180.enhancements.other:
 

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -86,8 +86,8 @@ And multiple aggregations
 
 .. ipython:: python
 
-   r.agg({'A' : {'ra' : ['mean','std']},
-          'B' : {'rb' : ['mean','std']}})
+   r.agg({'A' : ['mean','std'],
+          'B' : ['mean','std']})
 
 .. _whatsnew_0180.enhancements.other:
 
@@ -239,15 +239,17 @@ Deprecations
              2    0.5
              dtype: float64
 
-- The the ``freq`` and ``how`` arguments to the ``.rolling``, ``.expanding``, and ``.ewm`` (new) functions are deprecated, and will be removed in a future version. (:issue:`11603`)
+- The the ``freq`` and ``how`` arguments to the ``.rolling``, ``.expanding``, and ``.ewm`` (new) functions are deprecated, and will be removed in a future version. You can simply resample the input prior to creating a window function. (:issue:`11603`).
+
+  For example, instead of ``s.rolling(window=5,freq='D').max()`` to get the max value on a rolling 5 Day window, one could use ``s.resample('D',how='max').rolling(window=5).max()``, which first resamples the data to daily data, then provides a rolling 5 day window.
 
 .. _whatsnew_0180.prior_deprecations:
 
 Removal of prior version deprecations/changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Removal of ``rolling_corr_parwise`` in favor of ``.rolling().corr(pairwise=True)`` (:issue:`4950`)
-- Removal of ``expanding_corr_parwise`` in favor of ``.expanding().corr(pairwise=True)`` (:issue:`4950`)
+- Removal of ``rolling_corr_pairwise`` in favor of ``.rolling().corr(pairwise=True)`` (:issue:`4950`)
+- Removal of ``expanding_corr_pairwise`` in favor of ``.expanding().corr(pairwise=True)`` (:issue:`4950`)
 
 
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -361,8 +361,8 @@ aggregated : DataFrame
 
 See also
 --------
-:func:`pandas.Series.%(name)s`
-:func:`pandas.DataFrame.%(name)s`
+`pandas.Series.%(name)s`
+`pandas.DataFrame.%(name)s`
 """
 
     def aggregate(self, func, *args, **kwargs):
@@ -465,9 +465,9 @@ See also
                     # find a good name, this could be a function that we don't recognize
                     name = self._is_cython_func(a) or a
                     if not isinstance(name, compat.string_types):
-                        name = getattr(a,name,a)
+                        name = getattr(a,'name',a)
                     if not isinstance(name, compat.string_types):
-                        name = getattr(a,func_name,a)
+                        name = getattr(a,'__name__',a)
 
                     keys.append(name)
                 except (TypeError, DataError):

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -7,7 +7,8 @@ import numpy as np
 from pandas.core import common as com
 import pandas.core.nanops as nanops
 import pandas.lib as lib
-from pandas.util.decorators import Appender, cache_readonly, deprecate_kwarg
+from pandas.util.decorators import (Appender, Substitution,
+                                    cache_readonly, deprecate_kwarg)
 from pandas.core.common import AbstractMethodError
 
 _shared_docs = dict()
@@ -356,13 +357,18 @@ Returns
 aggregated : DataFrame
 """
 
-    @Appender(_agg_doc)
-    def agg(self, func, *args, **kwargs):
-        return self.aggregate(func, *args, **kwargs)
+    _see_also_template = """
 
-    @Appender(_agg_doc)
+See also
+--------
+:func:`pandas.Series.%(name)s`
+:func:`pandas.DataFrame.%(name)s`
+"""
+
     def aggregate(self, func, *args, **kwargs):
         raise AbstractMethodError(self)
+
+    agg = aggregate
 
     def _aggregate(self, arg, *args, **kwargs):
         """

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -462,13 +462,8 @@ See also
                     colg = self._gotitem(obj.name, ndim=1, subset=obj)
                     results.append(colg.aggregate(a))
 
-                    # find a good name, this could be a function that we don't recognize
-                    name = self._is_cython_func(a) or a
-                    if not isinstance(name, compat.string_types):
-                        name = getattr(a,'name',a)
-                    if not isinstance(name, compat.string_types):
-                        name = getattr(a,'__name__',a)
-
+                    # make sure we find a good name
+                    name = com._get_callable_name(a) or a
                     keys.append(name)
                 except (TypeError, DataError):
                     pass

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -358,11 +358,10 @@ aggregated : DataFrame
 """
 
     _see_also_template = """
-
 See also
 --------
-`pandas.Series.%(name)s`
-`pandas.DataFrame.%(name)s`
+pandas.Series.%(name)s
+pandas.DataFrame.%(name)s
 """
 
     def aggregate(self, func, *args, **kwargs):
@@ -422,7 +421,7 @@ See also
             else:
                 for col, agg_how in compat.iteritems(arg):
                     colg = self._gotitem(col, ndim=1)
-                    result[col] = colg.aggregate(agg_how, _level=(_level or 0) + 1)
+                    result[col] = colg.aggregate(agg_how, _level=None)
                     keys.append(col)
 
             if isinstance(list(result.values())[0], com.ABCDataFrame):
@@ -451,12 +450,16 @@ See also
         if self.axis != 0:
             raise NotImplementedError("axis other than 0 is not supported")
 
-        obj = self._obj_with_exclusions
+        if self._selected_obj.ndim == 1:
+            obj = self._selected_obj
+        else:
+            obj = self._obj_with_exclusions
+
         results = []
         keys = []
 
         # degenerate case
-        if obj.ndim == 1:
+        if obj.ndim==1:
             for a in arg:
                 try:
                     colg = self._gotitem(obj.name, ndim=1, subset=obj)

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -2,6 +2,7 @@
 Base and utility classes for pandas objects.
 """
 from pandas import compat
+from pandas.compat import builtins
 import numpy as np
 from pandas.core import common as com
 import pandas.core.nanops as nanops
@@ -217,6 +218,266 @@ class AccessorProperty(object):
     def __delete__(self, instance):
         raise AttributeError("can't delete attribute")
 
+
+class GroupByError(Exception):
+    pass
+
+
+class DataError(GroupByError):
+    pass
+
+
+class SpecificationError(GroupByError):
+    pass
+
+
+class SelectionMixin(object):
+    """
+    mixin implementing the selection & aggregation interface on a group-like object
+    sub-classes need to define: obj, exclusions
+    """
+    _selection = None
+    _internal_names = ['_cache']
+    _internal_names_set = set(_internal_names)
+    _builtin_table = {
+        builtins.sum: np.sum,
+        builtins.max: np.max,
+        builtins.min: np.min,
+        }
+    _cython_table = {
+        builtins.sum: 'sum',
+        builtins.max: 'max',
+        builtins.min: 'min',
+        np.sum: 'sum',
+        np.mean: 'mean',
+        np.prod: 'prod',
+        np.std: 'std',
+        np.var: 'var',
+        np.median: 'median',
+        np.max: 'max',
+        np.min: 'min',
+        np.cumprod: 'cumprod',
+        np.cumsum: 'cumsum'
+        }
+
+    @property
+    def name(self):
+        if self._selection is None:
+            return None  # 'result'
+        else:
+            return self._selection
+
+    @property
+    def _selection_list(self):
+        if not isinstance(self._selection, (list, tuple, com.ABCSeries, com.ABCIndex, np.ndarray)):
+            return [self._selection]
+        return self._selection
+
+    @cache_readonly
+    def _selected_obj(self):
+
+        if self._selection is None or isinstance(self.obj, com.ABCSeries):
+            return self.obj
+        else:
+            return self.obj[self._selection]
+
+    @cache_readonly
+    def _obj_with_exclusions(self):
+        if self._selection is not None and isinstance(self.obj, com.ABCDataFrame):
+            return self.obj.reindex(columns=self._selection_list)
+
+        if len(self.exclusions) > 0:
+            return self.obj.drop(self.exclusions, axis=1)
+        else:
+            return self.obj
+
+    def __getitem__(self, key):
+        if self._selection is not None:
+            raise Exception('Column(s) %s already selected' % self._selection)
+
+        if isinstance(key, (list, tuple, com.ABCSeries, com.ABCIndex, np.ndarray)):
+            if len(self.obj.columns.intersection(key)) != len(key):
+                bad_keys = list(set(key).difference(self.obj.columns))
+                raise KeyError("Columns not found: %s"
+                               % str(bad_keys)[1:-1])
+            return self._gotitem(list(key), ndim=2)
+
+        elif not getattr(self,'as_index',False):
+            if key not in self.obj.columns:
+                raise KeyError("Column not found: %s" % key)
+            return self._gotitem(key, ndim=2)
+
+        else:
+            if key not in self.obj:
+                raise KeyError("Column not found: %s" % key)
+            return self._gotitem(key, ndim=1)
+
+    def _gotitem(self, key, ndim, subset=None):
+        """
+        sub-classes to define
+        return a sliced object
+
+        Parameters
+        ----------
+        key : string / list of selections
+        ndim : 1,2
+            requested ndim of result
+        subset : object, default None
+            subset to act on
+
+        """
+        raise AbstractMethodError(self)
+
+    _agg_doc = """Aggregate using input function or dict of {column -> function}
+
+Parameters
+----------
+arg : function or dict
+    Function to use for aggregating groups. If a function, must either
+    work when passed a DataFrame or when passed to DataFrame.apply. If
+    passed a dict, the keys must be DataFrame column names.
+
+    Accepted Combinations are:
+      - string cythonized function name
+      - function
+      - list of functions
+      - dict of columns -> functions
+      - nested dict of names -> dicts of functions
+
+Notes
+-----
+Numpy functions mean/median/prod/sum/std/var are special cased so the
+default behavior is applying the function along axis=0
+(e.g., np.mean(arr_2d, axis=0)) as opposed to
+mimicking the default Numpy behavior (e.g., np.mean(arr_2d)).
+
+Returns
+-------
+aggregated : DataFrame
+"""
+
+    @Appender(_agg_doc)
+    def agg(self, func, *args, **kwargs):
+        return self.aggregate(func, *args, **kwargs)
+
+    @Appender(_agg_doc)
+    def aggregate(self, func, *args, **kwargs):
+        raise AbstractMethodError(self)
+
+    def _aggregate(self, arg, *args, **kwargs):
+        """
+        provide an implementation for the aggregators
+
+        Returns
+        -------
+        tuple of result, how
+
+        Notes
+        -----
+        how can be a string describe the required post-processing, or
+        None if not required
+        """
+
+        if isinstance(arg, compat.string_types):
+            return getattr(self, arg)(*args, **kwargs), None
+
+        result = compat.OrderedDict()
+        if isinstance(arg, dict):
+            if self.axis != 0:  # pragma: no cover
+                raise ValueError('Can only pass dict with axis=0')
+
+            obj = self._selected_obj
+
+            if any(isinstance(x, (list, tuple, dict)) for x in arg.values()):
+                new_arg = compat.OrderedDict()
+                for k, v in compat.iteritems(arg):
+                    if not isinstance(v, (tuple, list, dict)):
+                        new_arg[k] = [v]
+                    else:
+                        new_arg[k] = v
+                arg = new_arg
+
+            keys = []
+            if self._selection is not None:
+                subset = obj
+
+                for fname, agg_how in compat.iteritems(arg):
+                    colg = self._gotitem(self._selection, ndim=1, subset=subset)
+                    result[fname] = colg.aggregate(agg_how)
+                    keys.append(fname)
+            else:
+                for col, agg_how in compat.iteritems(arg):
+                    colg = self._gotitem(col, ndim=1)
+                    result[col] = colg.aggregate(agg_how)
+                    keys.append(col)
+
+            if isinstance(list(result.values())[0], com.ABCDataFrame):
+                from pandas.tools.merge import concat
+                result = concat([result[k] for k in keys], keys=keys, axis=1)
+            else:
+                from pandas import DataFrame
+                result = DataFrame(result)
+
+            return result, True
+        elif hasattr(arg, '__iter__'):
+            return self._aggregate_multiple_funcs(arg), None
+        else:
+            result = None
+
+        cy_func = self._is_cython_func(arg)
+        if cy_func and not args and not kwargs:
+            return getattr(self, cy_func)(), None
+
+        # caller can react
+        return result, True
+
+    def _aggregate_multiple_funcs(self, arg):
+        from pandas.tools.merge import concat
+
+        if self.axis != 0:
+            raise NotImplementedError("axis other than 0 is not supported")
+
+        obj = self._obj_with_exclusions
+        results = []
+        keys = []
+
+        # degenerate case
+        if obj.ndim == 1:
+            for a in arg:
+                try:
+                    colg = self._gotitem(obj.name, ndim=1, subset=obj)
+                    results.append(colg.aggregate(a))
+                    keys.append(getattr(a,'name',a))
+                except (TypeError, DataError):
+                    pass
+                except SpecificationError:
+                    raise
+
+        # multiples
+        else:
+            for col in obj:
+                try:
+                    colg = self._gotitem(col, ndim=1, subset=obj[col])
+                    results.append(colg.aggregate(arg))
+                    keys.append(col)
+                except (TypeError, DataError):
+                    pass
+                except SpecificationError:
+                    raise
+        result = concat(results, keys=keys, axis=1)
+
+        return result
+
+    def _is_cython_func(self, arg):
+        """ if we define an internal function for this argument, return it """
+        return self._cython_table.get(arg)
+
+    def _is_builtin_func(self, arg):
+        """
+        if we define an builtin function for this argument, return it,
+        otherwise return the arg
+        """
+        return self._builtin_table.get(arg, arg)
 
 class FrozenList(PandasObject, list):
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5149,6 +5149,7 @@ class DataFrame(NDFrame):
 DataFrame._setup_axes(['index', 'columns'], info_axis=1, stat_axis=0,
                       axes_are_reversed=True, aliases={'rows': 0})
 DataFrame._add_numeric_operations()
+DataFrame._add_series_or_dataframe_operations()
 
 _EMPTY_SERIES = Series([])
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4741,26 +4741,25 @@ class NDFrame(PandasObject):
 
         @Appender(rwindow.rolling.__doc__)
         def rolling(self, window, min_periods=None, freq=None, center=False,
-                    how=None, win_type=None, axis=0):
+                    win_type=None, axis=0):
             axis = self._get_axis_number(axis)
             return rwindow.rolling(self, window=window, min_periods=min_periods, freq=freq, center=center,
-                                   how=how, win_type=win_type, axis=axis)
+                                   win_type=win_type, axis=axis)
         cls.rolling = rolling
 
         @Appender(rwindow.expanding.__doc__)
-        def expanding(self, min_periods=None, freq=None, center=False,
-                      how=None, axis=0):
+        def expanding(self, min_periods=1, freq=None, center=False, axis=0):
             axis = self._get_axis_number(axis)
             return rwindow.expanding(self, min_periods=min_periods, freq=freq, center=center,
-                                     how=how, axis=axis)
+                                     axis=axis)
         cls.expanding = expanding
 
         @Appender(rwindow.ewm.__doc__)
         def ewm(self, com=None, span=None, halflife=None, min_periods=0, freq=None,
-                adjust=True, how=None, ignore_na=False, axis=0):
+                adjust=True, ignore_na=False, axis=0):
             axis = self._get_axis_number(axis)
             return rwindow.ewm(self, com=com, span=span, halflife=halflife, min_periods=min_periods,
-                               freq=freq, adjust=adjust, how=how, ignore_na=ignore_na, axis=axis)
+                               freq=freq, adjust=adjust, ignore_na=ignore_na, axis=axis)
         cls.ewm = ewm
 
 def _doc_parms(cls):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -29,7 +29,6 @@ import pandas.core.nanops as nanops
 from pandas.util.decorators import Appender, Substitution, deprecate_kwarg
 from pandas.core import config
 
-
 # goal is to be able to define the docs close to function, while still being
 # able to share
 _shared_docs = dict()
@@ -4734,6 +4733,36 @@ class NDFrame(PandasObject):
                                       method ``ptp``.""", nanptp)
 
 
+    @classmethod
+    def _add_series_or_dataframe_operations(cls):
+        """ add the series or dataframe only operations to the cls; evaluate the doc strings again """
+
+        from pandas.core import window as rwindow
+
+        @Appender(rwindow.rolling.__doc__)
+        def rolling(self, window, min_periods=None, freq=None, center=False,
+                    how=None, win_type=None, axis=0):
+            axis = self._get_axis_number(axis)
+            return rwindow.rolling(self, window=window, min_periods=min_periods, freq=freq, center=center,
+                                   how=how, win_type=win_type, axis=axis)
+        cls.rolling = rolling
+
+        @Appender(rwindow.expanding.__doc__)
+        def expanding(self, min_periods=None, freq=None, center=False,
+                      how=None, axis=0):
+            axis = self._get_axis_number(axis)
+            return rwindow.expanding(self, min_periods=min_periods, freq=freq, center=center,
+                                     how=how, axis=axis)
+        cls.expanding = expanding
+
+        @Appender(rwindow.ewm.__doc__)
+        def ewm(self, com=None, span=None, halflife=None, min_periods=0, freq=None,
+                adjust=True, how=None, ignore_na=False, axis=0):
+            axis = self._get_axis_number(axis)
+            return rwindow.ewm(self, com=com, span=span, halflife=halflife, min_periods=min_periods,
+                               freq=freq, adjust=adjust, how=how, ignore_na=ignore_na, axis=axis)
+        cls.ewm = ewm
+
 def _doc_parms(cls):
     """ return a tuple of the doc parms """
     axis_descr = "{%s}" % ', '.join([
@@ -4916,6 +4945,6 @@ def _make_logical_function(name, name1, name2, axis_descr, desc, f):
     logical_func.__name__ = name
     return logical_func
 
-# install the indexerse
+# install the indexes
 for _name, _indexer in indexing.get_indexers_list():
     NDFrame._create_indexer(_name, _indexer)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -22,6 +22,7 @@ from pandas.core.series import Series
 from pandas.core.panel import Panel
 from pandas.util.decorators import (cache_readonly, Substitution, Appender, make_signature,
                                     deprecate_kwarg)
+from textwrap import dedent
 import pandas.core.algorithms as algos
 import pandas.core.common as com
 from pandas.core.common import(_possibly_downcast_to_dtype, isnull,
@@ -39,15 +40,15 @@ import pandas.hashtable as _hash
 
 _doc_template = """
 
-Returns
--------
-same type as input
+        Returns
+        -------
+        same type as input
 
-See also
---------
-:func:`pandas.Series.%(name)s`
-:func:`pandas.DataFrame.%(name)s`
-:func:`pandas.Panel.%(name)s`
+        See also
+        --------
+        `pandas.Series.%(name)s`
+        `pandas.DataFrame.%(name)s`
+        `pandas.Panel.%(name)s`
 """
 
 # special case to prevent duplicate plots when catching exceptions when
@@ -629,43 +630,45 @@ class GroupBy(PandasObject, SelectionMixin):
     @Substitution(name='groupby')
     @Appender(_doc_template)
     def apply(self, func, *args, **kwargs):
-        """Apply function and combine results together in an intelligent way. The
-split-apply-combine combination rules attempt to be as common sense
-based as possible. For example:
+        """
+        Apply function and combine results together in an intelligent way. The
+        split-apply-combine combination rules attempt to be as common sense
+        based as possible. For example:
 
-case 1:
-group DataFrame
-apply aggregation function (f(chunk) -> Series)
-yield DataFrame, with group axis having group labels
+        case 1:
+        group DataFrame
+        apply aggregation function (f(chunk) -> Series)
+        yield DataFrame, with group axis having group labels
 
-case 2:
-group DataFrame
-apply transform function ((f(chunk) -> DataFrame with same indexes)
-yield DataFrame with resulting chunks glued together
+        case 2:
+        group DataFrame
+        apply transform function ((f(chunk) -> DataFrame with same indexes)
+        yield DataFrame with resulting chunks glued together
 
-case 3:
-group Series
-apply function with f(chunk) -> DataFrame
-yield DataFrame with result of chunks glued together
+        case 3:
+        group Series
+        apply function with f(chunk) -> DataFrame
+        yield DataFrame with result of chunks glued together
 
-Parameters
-----------
-func : function
+        Parameters
+        ----------
+        func : function
 
-Notes
------
-See online documentation for full exposition on how to use apply.
+        Notes
+        -----
+        See online documentation for full exposition on how to use apply.
 
-In the current implementation apply calls func twice on the
-first group to decide whether it can take a fast or slow code
-path. This can lead to unexpected behavior if func has
-side-effects, as they will take effect twice for the first
-group.
+        In the current implementation apply calls func twice on the
+        first group to decide whether it can take a fast or slow code
+        path. This can lead to unexpected behavior if func has
+        side-effects, as they will take effect twice for the first
+        group.
 
 
-See also
---------
-aggregate, transform"""
+        See also
+        --------
+        aggregate, transform"""
+
         func = self._is_builtin_func(func)
 
         @wraps(func)
@@ -710,7 +713,8 @@ aggregate, transform"""
     @Substitution(name='groupby')
     @Appender(_doc_template)
     def mean(self):
-        """Compute mean of groups, excluding missing values
+        """
+        Compute mean of groups, excluding missing values
 
         For multiple groupings, the result index will be a MultiIndex
         """
@@ -726,7 +730,8 @@ aggregate, transform"""
     @Substitution(name='groupby')
     @Appender(_doc_template)
     def median(self):
-        """Compute median of groups, excluding missing values
+        """
+        Compute median of groups, excluding missing values
 
         For multiple groupings, the result index will be a MultiIndex
         """
@@ -746,14 +751,16 @@ aggregate, transform"""
     @Substitution(name='groupby')
     @Appender(_doc_template)
     def std(self, ddof=1):
-        """Compute standard deviation of groups, excluding missing values
+        """
+        Compute standard deviation of groups, excluding missing values
 
-For multiple groupings, the result index will be a MultiIndex
+        For multiple groupings, the result index will be a MultiIndex
 
-Parameters
-----------
-ddof : integer, default 1
-degrees of freedom"""
+        Parameters
+        ----------
+        ddof : integer, default 1
+        degrees of freedom
+        """
 
         # todo, implement at cython level?
         return np.sqrt(self.var(ddof=ddof))
@@ -761,14 +768,16 @@ degrees of freedom"""
     @Substitution(name='groupby')
     @Appender(_doc_template)
     def var(self, ddof=1):
-        """Compute variance of groups, excluding missing values
+        """
+        Compute variance of groups, excluding missing values
 
-For multiple groupings, the result index will be a MultiIndex
+        For multiple groupings, the result index will be a MultiIndex
 
-Parameters
-----------
-ddof : integer, default 1
-degrees of freedom"""
+        Parameters
+        ----------
+        ddof : integer, default 1
+        degrees of freedom
+        """
 
         if ddof == 1:
             return self._cython_agg_general('var')
@@ -780,14 +789,16 @@ degrees of freedom"""
     @Substitution(name='groupby')
     @Appender(_doc_template)
     def sem(self, ddof=1):
-        """Compute standard error of the mean of groups, excluding missing values
+        """
+        Compute standard error of the mean of groups, excluding missing values
 
-For multiple groupings, the result index will be a MultiIndex
+        For multiple groupings, the result index will be a MultiIndex
 
-Parameters
-----------
-ddof : integer, default 1
-degrees of freedom"""
+        Parameters
+        ----------
+        ddof : integer, default 1
+        degrees of freedom
+        """
 
         return self.std(ddof=ddof)/np.sqrt(self.count())
 
@@ -809,8 +820,10 @@ degrees of freedom"""
     @Substitution(name='groupby')
     @Appender(_doc_template)
     def ohlc(self):
-        """Compute sum of values, excluding missing values
-For multiple groupings, the result index will be a MultiIndex"""
+        """
+        Compute sum of values, excluding missing values
+        For multiple groupings, the result index will be a MultiIndex
+        """
 
         return self._apply_to_column_groupbys(
             lambda x: x._cython_agg_general('ohlc'))
@@ -818,46 +831,48 @@ For multiple groupings, the result index will be a MultiIndex"""
     @Substitution(name='groupby')
     @Appender(_doc_template)
     def nth(self, n, dropna=None):
-        """Take the nth row from each group if n is an int, or a subset of rows
-if n is a list of ints.
+        """
+        Take the nth row from each group if n is an int, or a subset of rows
+        if n is a list of ints.
 
-If dropna, will take the nth non-null row, dropna is either
-Truthy (if a Series) or 'all', 'any' (if a DataFrame); this is equivalent
-to calling dropna(how=dropna) before the groupby.
+        If dropna, will take the nth non-null row, dropna is either
+        Truthy (if a Series) or 'all', 'any' (if a DataFrame); this is equivalent
+        to calling dropna(how=dropna) before the groupby.
 
-Parameters
-----------
-n : int or list of ints
-    a single nth value for the row or a list of nth values
-dropna : None or str, optional
-    apply the specified dropna operation before counting which row is
-    the nth row. Needs to be None, 'any' or 'all'
+        Parameters
+        ----------
+        n : int or list of ints
+            a single nth value for the row or a list of nth values
+        dropna : None or str, optional
+            apply the specified dropna operation before counting which row is
+            the nth row. Needs to be None, 'any' or 'all'
 
-Examples
---------
->>> df = DataFrame([[1, np.nan], [1, 4], [5, 6]], columns=['A', 'B'])
->>> g = df.groupby('A')
->>> g.nth(0)
-       A   B
-    0  1 NaN
-    2  5   6
->>> g.nth(1)
-       A  B
-    1  1  4
->>> g.nth(-1)
-       A  B
-    1  1  4
-    2  5  6
->>> g.nth(0, dropna='any')
-       B
-       A
-    1  4
-    5  6
->>> g.nth(1, dropna='any')  # NaNs denote group exhausted when using dropna
-        B
-        A
-    1 NaN
-    5 NaN"""
+        Examples
+        --------
+        >>> df = DataFrame([[1, np.nan], [1, 4], [5, 6]], columns=['A', 'B'])
+        >>> g = df.groupby('A')
+        >>> g.nth(0)
+           A   B
+        0  1 NaN
+        2  5   6
+        >>> g.nth(1)
+           A  B
+        1  1  4
+        >>> g.nth(-1)
+           A  B
+        1  1  4
+        2  5  6
+        >>> g.nth(0, dropna='any')
+           B
+           A
+        1  4
+        5  6
+        >>> g.nth(1, dropna='any')  # NaNs denote group exhausted when using dropna
+           B
+           A
+        1 NaN
+        5 NaN
+        """
 
         if isinstance(n, int):
             nth_values = [n]
@@ -953,46 +968,48 @@ Examples
     @Substitution(name='groupby')
     @Appender(_doc_template)
     def cumcount(self, ascending=True):
-        """Number each item in each group from 0 to the length of that group - 1.
+        """
+        Number each item in each group from 0 to the length of that group - 1.
 
-Essentially this is equivalent to
+        Essentially this is equivalent to
 
->>> self.apply(lambda x: Series(np.arange(len(x)), x.index))
+        >>> self.apply(lambda x: Series(np.arange(len(x)), x.index))
 
-Parameters
-----------
-ascending : bool, default True
-    If False, number in reverse, from length of group - 1 to 0.
+        Parameters
+        ----------
+        ascending : bool, default True
+        If False, number in reverse, from length of group - 1 to 0.
 
-Examples
---------
+        Examples
+        --------
 
->>> df = pd.DataFrame([['a'], ['a'], ['a'], ['b'], ['b'], ['a']],
-    ...               columns=['A'])
->>> df
-       A
-    0  a
-    1  a
-    2  a
-    3  b
-    4  b
-    5  a
->>> df.groupby('A').cumcount()
-    0    0
-    1    1
-    2    2
-    3    0
-    4    1
-    5    3
-    dtype: int64
->>> df.groupby('A').cumcount(ascending=False)
-    0    3
-    1    2
-    2    1
-    3    1
-    4    0
-    5    0
-    dtype: int64"""
+        >>> df = pd.DataFrame([['a'], ['a'], ['a'], ['b'], ['b'], ['a']],
+        ...               columns=['A'])
+        >>> df
+           A
+        0  a
+        1  a
+        2  a
+        3  b
+        4  b
+        5  a
+        >>> df.groupby('A').cumcount()
+        0    0
+        1    1
+        2    2
+        3    0
+        4    1
+        5    3
+        dtype: int64
+        >>> df.groupby('A').cumcount(ascending=False)
+        0    3
+        1    2
+        2    1
+        3    1
+        4    0
+        5    0
+        dtype: int64
+        """
 
         self._set_selection_from_grouper()
 
@@ -1021,14 +1038,16 @@ Examples
     @Substitution(name='groupby')
     @Appender(_doc_template)
     def shift(self, periods=1, freq=None, axis=0):
-        """Shift each group by periods observations
+        """
+        Shift each group by periods observations
 
-Parameters
-----------
-periods : integer, default 1
-    number of periods to shift
-freq : frequency string
-axis : axis to shift, default 0"""
+        Parameters
+        ----------
+        periods : integer, default 1
+            number of periods to shift
+        freq : frequency string
+        axis : axis to shift, default 0
+        """
 
         if freq is not None or axis != 0:
             return self.apply(lambda x: x.shift(periods, freq, axis))
@@ -1047,24 +1066,27 @@ axis : axis to shift, default 0"""
     @Substitution(name='groupby')
     @Appender(_doc_template)
     def head(self, n=5):
-        """Returns first n rows of each group.
+        """
+        Returns first n rows of each group.
 
-Essentially equivalent to ``.apply(lambda x: x.head(n))``,
-except ignores as_index flag.
+        Essentially equivalent to ``.apply(lambda x: x.head(n))``,
+        except ignores as_index flag.
 
-Examples
---------
+        Examples
+        --------
 
->>> df = DataFrame([[1, 2], [1, 4], [5, 6]],
-                   columns=['A', 'B'])
->>> df.groupby('A', as_index=False).head(1)
-       A  B
-    0  1  2
-    2  5  6
->>> df.groupby('A').head(1)
-       A  B
-    0  1  2
-    2  5  6"""
+        >>> df = DataFrame([[1, 2], [1, 4], [5, 6]],
+                           columns=['A', 'B'])
+        >>> df.groupby('A', as_index=False).head(1)
+           A  B
+        0  1  2
+        2  5  6
+        >>> df.groupby('A').head(1)
+           A  B
+        0  1  2
+        2  5  6
+        """
+
         obj = self._selected_obj
         in_head = self._cumcount_array() < n
         head = obj[in_head]
@@ -1073,24 +1095,27 @@ Examples
     @Substitution(name='groupby')
     @Appender(_doc_template)
     def tail(self, n=5):
-        """Returns last n rows of each group
+        """
+        Returns last n rows of each group
 
-Essentially equivalent to ``.apply(lambda x: x.tail(n))``,
-except ignores as_index flag.
+        Essentially equivalent to ``.apply(lambda x: x.tail(n))``,
+        except ignores as_index flag.
 
-Examples
---------
+        Examples
+        --------
 
->>> df = DataFrame([['a', 1], ['a', 2], ['b', 1], ['b', 2]],
-                   columns=['A', 'B'])
->>> df.groupby('A').tail(1)
-       A  B
-    1  a  2
-    3  b  2
->>> df.groupby('A').head(1)
-       A  B
-    0  a  1
-    2  b  1"""
+        >>> df = DataFrame([['a', 1], ['a', 2], ['b', 1], ['b', 2]],
+                           columns=['A', 'B'])
+        >>> df.groupby('A').tail(1)
+           A  B
+        1  a  2
+        3  b  2
+        >>> df.groupby('A').head(1)
+           A  B
+        0  a  1
+        2  b  1
+        """
+
         obj = self._selected_obj
         rng = np.arange(0, -self.grouper._max_groupsize, -1, dtype='int64')
         in_tail = self._cumcount_array(rng, ascending=False) > -n
@@ -1098,10 +1123,13 @@ Examples
         return tail
 
     def _cumcount_array(self, arr=None, ascending=True):
-        """arr is where cumcount gets its values from
+        """
+        arr is where cumcount gets its values from
 
-        note: this is currently implementing sort=False (though the default is sort=True)
-              for groupby in general
+        Note
+        ----
+        this is currently implementing sort=False (though the default is sort=True)
+        for groupby in general
         """
         if arr is None:
             arr = np.arange(self.grouper._max_groupsize, dtype='int64')
@@ -3379,8 +3407,8 @@ class DataFrameGroupBy(NDFrameGroupBy):
     _block_agg_axis = 1
 
     @Substitution(name='groupby')
-    @Appender(SelectionMixin._agg_doc)
     @Appender(SelectionMixin._see_also_template)
+    @Appender(SelectionMixin._agg_doc)
     def aggregate(self, arg, *args, **kwargs):
         return super(DataFrameGroupBy, self).aggregate(arg, *args, **kwargs)
 
@@ -3550,8 +3578,8 @@ DataFrameGroupBy.boxplot = boxplot_frame_groupby
 class PanelGroupBy(NDFrameGroupBy):
 
     @Substitution(name='groupby')
-    @Appender(SelectionMixin._agg_doc)
     @Appender(SelectionMixin._see_also_template)
+    @Appender(SelectionMixin._agg_doc)
     def aggregate(self, arg, *args, **kwargs):
         return super(PanelGroupBy, self).aggregate(arg, *args, **kwargs)
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -40,15 +40,11 @@ import pandas.hashtable as _hash
 
 _doc_template = """
 
-        Returns
-        -------
-        same type as input
-
         See also
         --------
-        `pandas.Series.%(name)s`
-        `pandas.DataFrame.%(name)s`
-        `pandas.Panel.%(name)s`
+        pandas.Series.%(name)s
+        pandas.DataFrame.%(name)s
+        pandas.Panel.%(name)s
 """
 
 # special case to prevent duplicate plots when catching exceptions when
@@ -628,7 +624,6 @@ class GroupBy(PandasObject, SelectionMixin):
         return self.grouper.get_iterator(self.obj, axis=self.axis)
 
     @Substitution(name='groupby')
-    @Appender(_doc_template)
     def apply(self, func, *args, **kwargs):
         """
         Apply function and combine results together in an intelligent way. The
@@ -664,10 +659,12 @@ class GroupBy(PandasObject, SelectionMixin):
         side-effects, as they will take effect twice for the first
         group.
 
-
         See also
         --------
-        aggregate, transform"""
+        aggregate, transform
+        pandas.Series.%(name)s
+        pandas.DataFrame.%(name)s
+        pandas.Panel.%(name)s"""
 
         func = self._is_builtin_func(func)
 
@@ -759,7 +756,7 @@ class GroupBy(PandasObject, SelectionMixin):
         Parameters
         ----------
         ddof : integer, default 1
-        degrees of freedom
+            degrees of freedom
         """
 
         # todo, implement at cython level?
@@ -776,7 +773,7 @@ class GroupBy(PandasObject, SelectionMixin):
         Parameters
         ----------
         ddof : integer, default 1
-        degrees of freedom
+            degrees of freedom
         """
 
         if ddof == 1:
@@ -797,7 +794,7 @@ class GroupBy(PandasObject, SelectionMixin):
         Parameters
         ----------
         ddof : integer, default 1
-        degrees of freedom
+            degrees of freedom
         """
 
         return self.std(ddof=ddof)/np.sqrt(self.count())
@@ -868,8 +865,8 @@ class GroupBy(PandasObject, SelectionMixin):
         1  4
         5  6
         >>> g.nth(1, dropna='any')  # NaNs denote group exhausted when using dropna
-           B
-           A
+            B
+            A
         1 NaN
         5 NaN
         """
@@ -978,13 +975,13 @@ class GroupBy(PandasObject, SelectionMixin):
         Parameters
         ----------
         ascending : bool, default True
-        If False, number in reverse, from length of group - 1 to 0.
+            If False, number in reverse, from length of group - 1 to 0.
 
         Examples
         --------
 
         >>> df = pd.DataFrame([['a'], ['a'], ['a'], ['b'], ['b'], ['a']],
-        ...               columns=['A'])
+        ...                   columns=['A'])
         >>> df
            A
         0  a

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2765,6 +2765,7 @@ Series._setup_axes(['index'], info_axis=0, stat_axis=0,
                    aliases={'rows': 0})
 Series._add_numeric_operations()
 Series._add_series_only_operations()
+Series._add_series_or_dataframe_operations()
 _INDEX_TYPES = ndarray, Index, list, tuple
 
 #------------------------------------------------------------------------------

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -7,6 +7,7 @@ similar to how we have a Groupby object
 """
 from __future__ import division
 
+import warnings
 import numpy as np
 from functools import wraps
 from collections import defaultdict
@@ -39,6 +40,12 @@ class _Window(PandasObject, SelectionMixin):
 
     def __init__(self, obj, window=None, min_periods=None, freq=None, center=False,
                  win_type=None, axis=0):
+
+        if freq is not None:
+            warnings.warn("The freq kw is deprecated and will be removed in a future version. You can resample prior "
+                          "to passing to a window function",
+                          FutureWarning, stacklevel=3)
+
         self.blocks = []
         self.obj = obj
         self.window = window
@@ -298,7 +305,7 @@ class Window(_Window):
         ----------
         mean : boolean, default True
             If True computes weighted mean, else weighted sum
-        how : string, default to None
+        how : string, default to None (DEPRECATED)
             how to resample
 
         Returns
@@ -378,7 +385,7 @@ class _Rolling(_Window):
         window : int/array, default to _get_window()
         center : boolean, default to self.center
         check_minp : function, default to _use_window
-        how : string, default to None
+        how : string, default to None (DEPRECATED)
             how to resample
 
         Returns
@@ -486,10 +493,15 @@ class _Rolling_and_Expanding(_Rolling):
 
     Parameters
     ----------
-    how : string, default max
+    how : string, default 'max' (DEPRECATED)
     Method for down- or re-sampling""")
-
-    def max(self, how='max'):
+    def max(self, how=None):
+        if how is not None:
+            warnings.warn("The how kw argument is deprecated and removed in a future version. You can resample prior "
+                          "to passing to a window function",
+                          FutureWarning, stacklevel=3)
+        else:
+            how = 'max'
         return self._apply('roll_max', how=how)
 
     _shared_docs['min'] = dedent("""
@@ -497,10 +509,15 @@ class _Rolling_and_Expanding(_Rolling):
 
     Parameters
     ----------
-    how : string, default min
+    how : string, default 'min' (DEPRECATED)
     Method for down- or re-sampling""")
-
-    def min(self, how='min'):
+    def min(self, how=None):
+        if how is not None:
+            warnings.warn("The how kw argument is deprecated and removed in a future version. You can resample prior "
+                          "to passing to a window function",
+                          FutureWarning, stacklevel=3)
+        else:
+            how = 'min'
         return self._apply('roll_min', how=how)
 
     _shared_docs['mean'] = """%(name)s mean"""
@@ -512,10 +529,15 @@ class _Rolling_and_Expanding(_Rolling):
 
     Parameters
     ----------
-    how : string, default median
+    how : string, default 'median' (DEPRECATED)
     Method for down- or re-sampling""")
-
-    def median(self, how='median'):
+    def median(self, how=None):
+        if how is not None:
+            warnings.warn("The how kw argument is deprecated and removed in a future version. You can resample prior "
+                          "to passing to a window function",
+                          FutureWarning, stacklevel=3)
+        else:
+            how = 'median'
         return self._apply('roll_median_c', how=how)
 
     _shared_docs['std'] = dedent("""
@@ -654,7 +676,7 @@ class Rolling(_Rolling_and_Expanding):
     min_periods : int, default None
         Minimum number of observations in window required to have a value
         (otherwise result is NA).
-    freq : string or DateOffset object, optional (default None)
+    freq : string or DateOffset object, optional (default None) (DEPRECATED)
         Frequency to conform the data to before computing the statistic. Specified
         as a frequency string or DateOffset object.
     center : boolean, default False
@@ -704,14 +726,14 @@ class Rolling(_Rolling_and_Expanding):
     @Substitution(name='rolling')
     @Appender(_doc_template)
     @Appender(_shared_docs['max'])
-    def max(self, how='max'):
-        return super(Rolling, self).max(how=how)
+    def max(self, **kwargs):
+        return super(Rolling, self).max(**kwargs)
 
     @Substitution(name='rolling')
     @Appender(_doc_template)
     @Appender(_shared_docs['min'])
-    def min(self, how='min'):
-        return super(Rolling, self).min(how=how)
+    def min(self, **kwargs):
+        return super(Rolling, self).min(**kwargs)
 
     @Substitution(name='rolling')
     @Appender(_doc_template)
@@ -722,8 +744,8 @@ class Rolling(_Rolling_and_Expanding):
     @Substitution(name='rolling')
     @Appender(_doc_template)
     @Appender(_shared_docs['median'])
-    def median(self, how='median'):
-        return super(Rolling, self).median(how=how)
+    def median(self, **kwargs):
+        return super(Rolling, self).median(**kwargs)
 
     @Substitution(name='rolling')
     @Appender(_doc_template)
@@ -778,7 +800,7 @@ class Expanding(_Rolling_and_Expanding):
     min_periods : int, default None
         Minimum number of observations in window required to have a value
         (otherwise result is NA).
-    freq : string or DateOffset object, optional (default None)
+    freq : string or DateOffset object, optional (default None) (DEPRECATED)
         Frequency to conform the data to before computing the statistic. Specified
         as a frequency string or DateOffset object.
     center : boolean, default False
@@ -843,14 +865,14 @@ class Expanding(_Rolling_and_Expanding):
     @Substitution(name='expanding')
     @Appender(_doc_template)
     @Appender(_shared_docs['max'])
-    def max(self, how='max'):
-        return super(Expanding, self).max(how=how)
+    def max(self, **kwargs):
+        return super(Expanding, self).max(**kwargs)
 
     @Substitution(name='expanding')
     @Appender(_doc_template)
     @Appender(_shared_docs['min'])
-    def min(self, how='min'):
-        return super(Expanding, self).min(how=how)
+    def min(self, **kwargs):
+        return super(Expanding, self).min(**kwargs)
 
     @Substitution(name='expanding')
     @Appender(_doc_template)
@@ -861,8 +883,8 @@ class Expanding(_Rolling_and_Expanding):
     @Substitution(name='expanding')
     @Appender(_doc_template)
     @Appender(_shared_docs['median'])
-    def median(self, how='median'):
-        return super(Expanding, self).median(how=how)
+    def median(self, **kwargs):
+        return super(Expanding, self).median(**kwargs)
 
     @Substitution(name='expanding')
     @Appender(_doc_template)
@@ -923,7 +945,7 @@ class EWM(_Rolling):
     min_periods : int, default 0
         Minimum number of observations in window required to have a value
         (otherwise result is NA).
-    freq : None or string alias / date offset object, default=None
+    freq : None or string alias / date offset object, default=None (DEPRECATED)
         Frequency to conform to before computing statistic
     adjust : boolean, default True
         Divide by decaying adjustment factor in beginning periods to account for
@@ -1004,7 +1026,7 @@ class EWM(_Rolling):
         Parameters
         ----------
         func : string/callable to apply
-        how : string, default to None
+        how : string, default to None (DEPRECATED)
             how to resample
 
         Returns

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -1,0 +1,1077 @@
+"""
+
+provide a generic structure to support window functions,
+similar to how we have a Groupby object
+
+
+"""
+from __future__ import division
+
+import numpy as np
+from functools import wraps
+from collections import defaultdict
+
+import pandas as pd
+from pandas.core.base import PandasObject, SelectionMixin, AbstractMethodError
+import pandas.core.common as com
+import pandas.algos as algos
+from pandas import compat
+from pandas.util.decorators import Substitution, Appender
+
+class _Window(PandasObject, SelectionMixin):
+    _attributes = ['window','min_periods','freq','center','how','win_type','axis']
+    exclusions = set()
+
+    def __init__(self, obj, window=None, min_periods=None, freq=None, center=False,
+                 how=None, win_type=None, axis=0):
+        self.blocks = []
+        self.obj = obj
+        self.window = window
+        self.min_periods = min_periods
+        self.freq = freq
+        self.center = center
+        self.how = how
+        self.win_type = win_type
+        self.axis = axis
+        self._convert_freq()
+        self._setup()
+
+    @property
+    def _constructor(self):
+        return Window
+
+    def _setup(self):
+        pass
+
+    def _create_blocks(self):
+        """ split data into blocks """
+        return self._selected_obj.as_blocks(copy=False).values()
+
+    def _gotitem(self, key, ndim, subset=None):
+        """
+        sub-classes to define
+        return a sliced object
+
+        Parameters
+        ----------
+        key : string / list of selections
+        ndim : 1,2
+            requested ndim of result
+        subset : object, default None
+            subset to act on
+        """
+
+        # create a new object to prevent aliasing
+        if subset is None:
+            subset = self.obj
+        new_self = self._shallow_copy(subset)
+        if ndim==2 and key in subset:
+            new_self._selection = key
+        new_self._reset_cache()
+        return new_self
+
+    def __getattr__(self, attr):
+        if attr in self._internal_names_set:
+            return object.__getattribute__(self, attr)
+        if attr in self.obj:
+            return self[attr]
+
+        raise AttributeError("%r object has no attribute %r" %
+                             (type(self).__name__, attr))
+
+    def _dir_additions(self):
+        return self.obj._dir_additions()
+
+    def _get_window(self, other=None):
+        return self.window
+
+    def __unicode__(self):
+        """ provide a nice str repr of our rolling object """
+
+        attrs = [ "{k}->{v}".format(k=k,v=getattr(self,k)) \
+                  for k in self._attributes if getattr(self,k,None) is not None ]
+        return "{klass} [{attrs}]".format(klass=self.__class__.__name__,
+                                          attrs=','.join(attrs))
+
+    def _shallow_copy(self, obj=None, **kwargs):
+        """ return a new object with the replacement attributes """
+        if obj is None:
+            obj = self._selected_obj.copy()
+        if isinstance(obj, self.__class__):
+            obj = obj.obj
+        for attr in self._attributes:
+            if attr not in kwargs:
+                kwargs[attr] = getattr(self,attr)
+        return self._constructor(obj, **kwargs)
+
+    def _prep_values(self, values=None, kill_inf=True):
+
+        if values is None:
+            values = getattr(self._selected_obj,'values',self._selected_obj)
+
+        # coerce dtypes as appropriate
+        if com.is_float_dtype(values.dtype):
+            pass
+        elif com.is_integer_dtype(values.dtype):
+            values = values.astype(float)
+        elif com.is_timedelta64_dtype(values.dtype):
+            values = values.view('i8').astype(float)
+        else:
+            try:
+                values = values.astype(float)
+            except (ValueError, TypeError):
+                raise TypeError("cannot handle this type -> {0}".format(values.dtype))
+
+        if kill_inf:
+            values = values.copy()
+            values[np.isinf(values)] = np.NaN
+
+        return values
+
+    def _wrap_result(self, result, block=None):
+        """ wrap a single result """
+
+        obj = self._selected_obj
+        if isinstance(result, np.ndarray):
+
+            # coerce if necessary
+            if block is not None:
+                if com.is_timedelta64_dtype(block.values.dtype):
+                    result = pd.to_timedelta(result.ravel(),unit='ns').values.reshape(result.shape)
+
+            if result.ndim == 1:
+                from pandas import Series
+                return Series(result, obj.index, name=obj.name)
+
+            return type(obj)(result,
+                             index=obj.index,
+                             columns=block.columns)
+        return result
+
+    def _wrap_results(self, results, blocks):
+        """ wrap lists of results, blocks """
+
+        obj = self._selected_obj
+        final = []
+        for result, block in zip(results, blocks):
+
+            result = self._wrap_result(result, block)
+            if result.ndim == 1:
+                return result
+            final.append(result)
+
+        if not len(final):
+            return obj.astype('float64')
+        return pd.concat(final,axis=1).reindex(columns=obj.columns)
+
+    def _center_window(self, result, window):
+        """ center the result in the window """
+        if self.axis > result.ndim-1:
+            raise ValueError("Requested axis is larger then no. of argument "
+                             "dimensions")
+
+        from pandas import Series, DataFrame
+        offset = _offset(window, True)
+        if offset > 0:
+            if isinstance(result, (Series, DataFrame)):
+                result = result.slice_shift(-offset, axis=self.axis)
+            else:
+                lead_indexer = [slice(None)] * result.ndim
+                lead_indexer[self.axis] = slice(offset, None)
+                result = np.copy(result[tuple(lead_indexer)])
+        return result
+
+    def _convert_freq(self):
+        """ conform to our freq """
+
+        from pandas import Series, DataFrame
+        if self.freq is not None and isinstance(self.obj, (Series, DataFrame)):
+            self.obj = self.obj.resample(self.freq, how=self.how)
+
+    @Appender(SelectionMixin._agg_doc)
+    def aggregate(self, arg, *args, **kwargs):
+        result, how = self._aggregate(arg, *args, **kwargs)
+        if result is None:
+            import pdb; pdb.set_trace()
+        return result
+
+class Window(_Window):
+
+    def _prep_window(self, **kwargs):
+        """ provide validation for our window type, return the window """
+        window = self._get_window()
+
+        if isinstance(window, (list, tuple, np.ndarray)):
+            return com._asarray_tuplesafe(window).astype(float)
+        elif com.is_integer(window):
+            try:
+                import scipy.signal as sig
+            except ImportError:
+                raise ImportError('Please install scipy to generate window weight')
+            win_type = _validate_win_type(self.win_type, kwargs)  # may pop from kwargs
+            return sig.get_window(win_type, window).astype(float)
+
+        raise ValueError('Invalid window %s' % str(window))
+
+    def _apply_window(self, mean=True, **kwargs):
+        """
+        Applies a moving window of type ``window_type`` on the data.
+
+        Parameters
+        ----------
+        mean : boolean, default True
+            If True computes weighted mean, else weighted sum
+
+        Returns
+        -------
+        y : type of input argument
+
+        """
+        window = self._prep_window(**kwargs)
+        center = self.center
+
+        results, blocks = [], self._create_blocks()
+        for b in blocks:
+            try:
+                values = self._prep_values(b.values)
+            except TypeError:
+                results.append(b.values.copy())
+                continue
+
+            if values.size == 0:
+                results.append(values.copy())
+                continue
+
+            offset = _offset(window, center)
+            additional_nans = np.array([np.NaN] * offset)
+            def f(arg, *args, **kwargs):
+                minp = _use_window(self.min_periods, len(window))
+                return algos.roll_window(np.concatenate((arg, additional_nans)) if center else arg,
+                                         window, minp, avg=mean)
+
+            result = np.apply_along_axis(f, self.axis, values)
+
+            if center:
+                result = self._center_window(result, window)
+            results.append(result)
+
+        return self._wrap_results(results, blocks)
+
+    def sum(self, **kwargs):
+        return self._apply_window(mean=False, **kwargs)
+
+    def mean(self, **kwargs):
+        return self._apply_window(mean=True, **kwargs)
+
+class _Rolling(_Window):
+
+    @property
+    def _constructor(self):
+        return Rolling
+
+    def _apply(self, func, window=None, center=None, check_minp=None, how=None, **kwargs):
+        """
+        Rolling statistical measure using supplied function. Designed to be
+        used with passed-in Cython array-based functions.
+
+        Parameters
+        ----------
+        func : string/callable to apply
+        window : int/array, default to _get_window()
+        center : boolean, default to self.center
+        check_minp : function, default to _use_window
+        how : string, default to None
+
+        Returns
+        -------
+        y : type of input
+        """
+
+        if center is None:
+            center = self.center
+        if window is None:
+            window = self._get_window()
+
+        if check_minp is None:
+            check_minp = _use_window
+
+        results, blocks = [], self._create_blocks()
+        for b in blocks:
+            try:
+                values = self._prep_values(b.values)
+            except TypeError:
+                results.append(b.values.copy())
+                continue
+
+            if values.size == 0:
+                results.append(values.copy())
+                continue
+
+            # if we have a string function name, wrap it
+            if isinstance(func, compat.string_types):
+                if not hasattr(algos, func):
+                    raise ValueError("we do not support this function algos.{0}".format(func))
+
+                cfunc = getattr(algos, func)
+                def func(arg, window, min_periods=None):
+                    minp = check_minp(min_periods, window)
+                    return cfunc(arg, window, minp, **kwargs)
+
+            # calculation function
+            if center:
+                offset = _offset(window, center)
+                additional_nans = np.array([np.NaN] * offset)
+                def calc(x):
+                    return func(np.concatenate((x, additional_nans)),
+                                window, min_periods=self.min_periods)
+            else:
+                def calc(x):
+                    return func(x,window, min_periods=self.min_periods)
+
+            if values.ndim > 1:
+                result = np.apply_along_axis(calc, self.axis, values)
+            else:
+                result = calc(values)
+
+            if center:
+                result = self._center_window(result, window)
+
+            results.append(result)
+
+        return self._wrap_results(results, blocks)
+
+class Rolling(_Rolling):
+
+    def count(self):
+        """
+        Rolling count of number of non-NaN observations inside provided window.
+
+        Returns
+        -------
+        same type as input
+        """
+
+        obj = self._selected_obj
+        window = self._get_window()
+        window = min(window, len(obj)) if not self.center else window
+        try:
+            converted = np.isfinite(obj).astype(float)
+        except TypeError:
+            converted = np.isfinite(obj.astype(float)).astype(float)
+        result = self._constructor(converted,
+                                   window=window,
+                                   min_periods=0,
+                                   center=self.center).sum()
+
+        result[result.isnull()] = 0
+        return result
+
+    def apply(self, func, args=(), kwargs={}):
+        """
+        Moving function apply
+
+        Parameters
+        ----------
+        func : function
+            Must produce a single value from an ndarray input
+        *args and **kwargs are passed to the function
+        """
+        window = self._get_window()
+        offset = _offset(window, self.center)
+        def f(arg, window, min_periods):
+            minp = _use_window(min_periods, window)
+            return algos.roll_generic(arg, window, minp, offset, func, args, kwargs)
+
+        return self._apply(f, center=False)
+
+    def sum(self):
+        """
+        Moving sum
+        """
+        return self._apply('roll_sum')
+
+    def max(self, how='max'):
+        """
+        Moving max
+
+        Parameters
+        ----------
+        how : string, default max
+          Method for down- or re-sampling
+        """
+        return self._apply('roll_max', how=how)
+
+    def min(self, how='min'):
+        """
+        Moving min
+
+        Parameters
+        ----------
+        how : string, default min
+          Method for down- or re-sampling
+        """
+        return self._apply('roll_min', how=how)
+
+    def mean(self):
+        """
+        Moving mean
+        """
+        return self._apply('roll_mean')
+
+    def median(self, how='median'):
+        """
+        Moving median
+
+        Parameters
+        ----------
+        how : string, default median
+          Method for down- or re-sampling
+        """
+
+        return self._apply('roll_median_c', how=how)
+
+    def std(self, ddof=1):
+        """
+        Moving standard deviation
+
+        Parameters
+        ----------
+        ddof : int, default 1
+           Delta Degrees of Freedom.  The divisor used in calculations
+           is ``N - ddof``, where ``N`` represents the number of elements.
+        """
+        window = self._get_window()
+        def f(arg, *args, **kwargs):
+            minp = _require_min_periods(1)(self.min_periods, window)
+            return _zsqrt(algos.roll_var(arg, window, minp, ddof))
+
+        return self._apply(f, check_minp=_require_min_periods(1))
+
+    def var(self, ddof=1):
+        """
+        Moving variance
+
+        Parameters
+        ----------
+        ddof : int, default 1
+           Delta Degrees of Freedom.  The divisor used in calculations
+           is ``N - ddof``, where ``N`` represents the number of elements.
+        """
+        return self._apply('roll_var',
+                           check_minp=_require_min_periods(1),
+                           ddof=ddof)
+
+    def skew(self):
+        """
+        Unbiased moving skewness
+        """
+        return self._apply('roll_skew',
+                           check_minp=_require_min_periods(3))
+
+    def kurt(self):
+        """
+        Unbiased moving kurtosis
+        """
+        return self._apply('roll_kurt',
+                           check_minp=_require_min_periods(4))
+
+    def quantile(self, quantile):
+        """
+        Rolling quantile
+
+        Parameters
+        ----------
+        quantile : float
+            0 <= quantile <= 1
+        """
+        window = self._get_window()
+        def f(arg, *args, **kwargs):
+            minp = _use_window(self.min_periods, window)
+            return algos.roll_quantile(arg, window, minp, quantile)
+
+        return self._apply(f)
+
+    def cov(self, other=None, pairwise=False, ddof=1):
+        """
+        Moving sample covariance
+
+        Parameters
+        ----------
+        other : Series, DataFrame, or ndarray, optional
+            if not supplied then will default to self and produce pairwise output
+        pairwise : bool, default False
+            If False then only matching columns between self and other will be used and
+            the output will be a DataFrame.
+            If True then all pairwise combinations will be calculated and the output
+            will be a Panel in the case of DataFrame inputs. In the case of missing
+            elements, only complete pairwise observations will be used.
+        ddof : int, default 1
+            Delta Degrees of Freedom.  The divisor used in calculations
+           is ``N - ddof``, where ``N`` represents the number of elements.
+        """
+        if other is None:
+            other = self._selected_obj
+            pairwise = True
+        other = self._shallow_copy(other)
+        window = self._get_window(other)
+
+        def _get_cov(X, Y):
+            mean = lambda x: x.rolling(window, self.min_periods, center=self.center).mean()
+            count = (X+Y).rolling(window=window, center=self.center).count()
+            bias_adj = count / (count - ddof)
+            return (mean(X * Y) - mean(X) * mean(Y)) * bias_adj
+        return _flex_binary_moment(self._selected_obj, other._selected_obj, _get_cov, pairwise=bool(pairwise))
+
+    def corr(self, other=None, pairwise=False):
+        """
+        Moving sample correlation
+
+        Parameters
+        ----------
+        other : Series, DataFrame, or ndarray, optional
+            if not supplied then will default to self and produce pairwise output
+        pairwise : bool, default False
+            If False then only matching columns between self and other will be used and
+            the output will be a DataFrame.
+            If True then all pairwise combinations will be calculated and the output
+            will be a Panel in the case of DataFrame inputs. In the case of missing
+            elements, only complete pairwise observations will be used.
+        """
+
+        if other is None:
+            other = self._selected_obj
+            pairwise = True
+        other = self._shallow_copy(other)
+        window = self._get_window(other)
+
+        def _get_corr(a, b):
+            a = a.rolling(window=window,
+                          min_periods=self.min_periods,
+                          freq=self.freq,
+                          center=self.center)
+            b = b.rolling(window=window,
+                          min_periods=self.min_periods,
+                          freq=self.freq,
+                          center=self.center)
+
+            return a.cov(b) / (a.std() * b.std())
+        return _flex_binary_moment(self._selected_obj, other._selected_obj, _get_corr, pairwise=bool(pairwise))
+
+class Expanding(Rolling):
+    _attributes = ['min_periods','freq','center','how','axis']
+
+    @property
+    def _constructor(self):
+        return Expanding
+
+    def _get_window(self, other=None):
+        obj = self._selected_obj
+        if other is None:
+            return max(len(obj), self.min_periods) if self.min_periods else len(obj)
+        return max((len(obj) + len(obj)), self.min_periods) if self.min_periods else (len(obj) + len(obj))
+
+class EWM(_Rolling):
+    _attributes = ['com','min_periods','freq','adjust','how','ignore_na','axis']
+
+    def __init__(self, obj, com=None, span=None, halflife=None, min_periods=0, freq=None,
+                 adjust=True, how=None, ignore_na=False, axis=0):
+        self.obj = obj
+        self.com = _get_center_of_mass(com, span, halflife)
+        self.min_periods = min_periods
+        self.freq = freq
+        self.adjust = adjust
+        self.how = how
+        self.ignore_na = ignore_na
+        self.axis = axis
+        self._convert_freq()
+
+    @property
+    def _constructor(self):
+        return EWM
+
+    def _apply(self, func, **kwargs):
+        """
+        Rolling statistical measure using supplied function. Designed to be
+        used with passed-in Cython array-based functions.
+
+        Parameters
+        ----------
+        func : string/callable to apply
+
+        Returns
+        -------
+        y : type of input argument
+
+        """
+        results, blocks = [], self._create_blocks()
+        for b in blocks:
+            try:
+                values = self._prep_values(b.values)
+            except TypeError:
+                results.append(b.values.copy())
+                continue
+
+            if values.size == 0:
+                results.append(values.copy())
+                continue
+
+            # if we have a string function name, wrap it
+            if isinstance(func, compat.string_types):
+                if not hasattr(algos, func):
+                    raise ValueError("we do not support this function algos.{0}".format(func))
+
+                cfunc = getattr(algos, func)
+                def func(arg):
+                    return cfunc(arg, self.com, int(self.adjust), int(self.ignore_na), int(self.min_periods))
+
+            results.append(np.apply_along_axis(func, self.axis, values))
+
+        return self._wrap_results(results, blocks)
+
+    def mean(self):
+        """
+        exponential weighted moving average
+        """
+        return self._apply('ewma')
+
+    def std(self, bias=False):
+        """
+        exponential weighted moving stddev
+
+        Parameters
+        ----------
+        bias : boolean, default False
+           Use a standard estimation bias correction
+        """
+        return _zsqrt(self.var(bias=bias))
+    vol=std
+
+    def var(self, bias=False):
+        """
+        exponential weighted moving average
+
+        Parameters
+        ----------
+        bias : boolean, default False
+           Use a standard estimation bias correction
+        """
+        def f(arg):
+            return algos.ewmcov(arg,
+                                arg,
+                                self.com,
+                                int(self.adjust),
+                                int(self.ignore_na),
+                                int(self.min_periods),
+                                int(bias))
+
+        return self._apply(f)
+
+    def cov(self, other=None, pairwise=False, bias=False):
+        """
+        exponential weighted sample covariance
+
+        Parameters
+        ----------
+        other : Series, DataFrame, or ndarray, optional
+            if not supplied then will default to self and produce pairwise output
+        pairwise : bool, default False
+            If False then only matching columns between self and other will be used and
+            the output will be a DataFrame.
+            If True then all pairwise combinations will be calculated and the output
+            will be a Panel in the case of DataFrame inputs. In the case of missing
+            elements, only complete pairwise observations will be used.
+        bias : boolean, default False
+           Use a standard estimation bias correction
+        """
+        if other is None:
+            other = self._selected_obj
+            pairwise = True
+        other = self._shallow_copy(other)
+
+        def _get_cov(X, Y):
+            X = self._shallow_copy(X)
+            Y = self._shallow_copy(Y)
+            cov = algos.ewmcov(X._prep_values(),
+                               Y._prep_values(),
+                               self.com,
+                               int(self.adjust),
+                               int(self.ignore_na),
+                               int(self.min_periods),
+                               int(bias))
+            return X._wrap_result(cov)
+
+        return _flex_binary_moment(self._selected_obj, other._selected_obj, _get_cov, pairwise=bool(pairwise))
+
+    def corr(self, other=None, pairwise=False):
+        """
+        exponential weighted sample correlation
+
+        Parameters
+        ----------
+        other : Series, DataFrame, or ndarray, optional
+            if not supplied then will default to self and produce pairwise output
+        pairwise : bool, default False
+            If False then only matching columns between self and other will be used and
+            the output will be a DataFrame.
+            If True then all pairwise combinations will be calculated and the output
+            will be a Panel in the case of DataFrame inputs. In the case of missing
+            elements, only complete pairwise observations will be used.
+        """
+        if other is None:
+            other = self._selected_obj
+            pairwise = True
+        other = self._shallow_copy(other)
+
+        def _get_corr(X, Y):
+            X = self._shallow_copy(X)
+            Y = self._shallow_copy(Y)
+            def _cov(x, y):
+                return algos.ewmcov(x, y, self.com, int(self.adjust), int(self.ignore_na), int(self.min_periods), 1)
+
+            x_values = X._prep_values()
+            y_values = Y._prep_values()
+            cov = _cov(x_values, y_values)
+            x_var = _cov(x_values, x_values)
+            y_var = _cov(y_values, y_values)
+            corr = cov / _zsqrt(x_var * y_var)
+            return X._wrap_result(corr)
+
+        return _flex_binary_moment(self._selected_obj, other._selected_obj, _get_corr, pairwise=bool(pairwise))
+
+########################
+##### Helper Funcs #####
+########################
+
+def _flex_binary_moment(arg1, arg2, f, pairwise=False):
+    from pandas import Series, DataFrame, Panel
+    if not (isinstance(arg1,(np.ndarray, Series, DataFrame)) and
+            isinstance(arg2,(np.ndarray, Series, DataFrame))):
+        raise TypeError("arguments to moment function must be of type "
+                         "np.ndarray/Series/DataFrame")
+
+    if isinstance(arg1, (np.ndarray, Series)) and \
+            isinstance(arg2, (np.ndarray,Series)):
+        X, Y = _prep_binary(arg1, arg2)
+        return f(X, Y)
+
+    elif isinstance(arg1, DataFrame):
+        def dataframe_from_int_dict(data, frame_template):
+            result = DataFrame(data, index=frame_template.index)
+            if len(result.columns) > 0:
+                result.columns = frame_template.columns[result.columns]
+            return result
+
+        results = {}
+        if isinstance(arg2, DataFrame):
+            if pairwise is False:
+                if arg1 is arg2:
+                    # special case in order to handle duplicate column names
+                    for i, col in enumerate(arg1.columns):
+                        results[i] = f(arg1.iloc[:, i], arg2.iloc[:, i])
+                    return dataframe_from_int_dict(results, arg1)
+                else:
+                    if not arg1.columns.is_unique:
+                        raise ValueError("'arg1' columns are not unique")
+                    if not arg2.columns.is_unique:
+                        raise ValueError("'arg2' columns are not unique")
+                    X, Y = arg1.align(arg2, join='outer')
+                    X = X + 0 * Y
+                    Y = Y + 0 * X
+                    res_columns = arg1.columns.union(arg2.columns)
+                    for col in res_columns:
+                        if col in X and col in Y:
+                            results[col] = f(X[col], Y[col])
+                    return DataFrame(results, index=X.index, columns=res_columns)
+            elif pairwise is True:
+                results = defaultdict(dict)
+                for i, k1 in enumerate(arg1.columns):
+                    for j, k2 in enumerate(arg2.columns):
+                        if j<i and arg2 is arg1:
+                            # Symmetric case
+                            results[i][j] = results[j][i]
+                        else:
+                            results[i][j] = f(*_prep_binary(arg1.iloc[:, i], arg2.iloc[:, j]))
+                p = Panel.from_dict(results).swapaxes('items', 'major')
+                if len(p.major_axis) > 0:
+                    p.major_axis = arg1.columns[p.major_axis]
+                if len(p.minor_axis) > 0:
+                    p.minor_axis = arg2.columns[p.minor_axis]
+                return p
+            else:
+                raise ValueError("'pairwise' is not True/False")
+        else:
+            results = {}
+            for i, col in enumerate(arg1.columns):
+                results[i] = f(*_prep_binary(arg1.iloc[:, i], arg2))
+            return dataframe_from_int_dict(results, arg1)
+
+    else:
+        return _flex_binary_moment(arg2, arg1, f)
+
+def _get_center_of_mass(com, span, halflife):
+    valid_count = len([x for x in [com, span, halflife] if x is not None])
+    if valid_count > 1:
+        raise Exception("com, span, and halflife are mutually exclusive")
+
+    if span is not None:
+        # convert span to center of mass
+        com = (span - 1) / 2.
+    elif halflife is not None:
+        # convert halflife to center of mass
+        decay = 1 - np.exp(np.log(0.5) / halflife)
+        com = 1 / decay - 1
+    elif com is None:
+        raise Exception("Must pass one of com, span, or halflife")
+
+    return float(com)
+
+def _offset(window, center):
+    if not com.is_integer(window):
+        window = len(window)
+    offset = (window - 1) / 2. if center else 0
+    try:
+        return int(offset)
+    except:
+        return offset.astype(int)
+
+def _require_min_periods(p):
+    def _check_func(minp, window):
+        if minp is None:
+            return window
+        else:
+            return max(p, minp)
+    return _check_func
+
+def _use_window(minp, window):
+    if minp is None:
+        return window
+    else:
+        return minp
+
+def _zsqrt(x):
+    result = np.sqrt(x)
+    mask = x < 0
+
+    from pandas import DataFrame
+    if isinstance(x, DataFrame):
+        if mask.values.any():
+            result[mask] = 0
+    else:
+        if mask.any():
+            result[mask] = 0
+
+    return result
+
+def _prep_binary(arg1, arg2):
+    if not isinstance(arg2, type(arg1)):
+        raise Exception('Input arrays must be of the same type!')
+
+    # mask out values, this also makes a common index...
+    X = arg1 + 0 * arg2
+    Y = arg2 + 0 * arg1
+
+    return X, Y
+
+def _validate_win_type(win_type, kwargs):
+    # may pop from kwargs
+    arg_map = {'kaiser': ['beta'],
+               'gaussian': ['std'],
+               'general_gaussian': ['power', 'width'],
+               'slepian': ['width']}
+    if win_type in arg_map:
+        return tuple([win_type] +
+                     _pop_args(win_type, arg_map[win_type], kwargs))
+    return win_type
+
+
+def _pop_args(win_type, arg_names, kwargs):
+    msg = '%s window requires %%s' % win_type
+    all_args = []
+    for n in arg_names:
+        if n not in kwargs:
+            raise ValueError(msg % n)
+        all_args.append(kwargs.pop(n))
+    return all_args
+
+#############################
+##### top-level exports #####
+#############################
+
+def rolling(obj, win_type=None, **kwds):
+    """
+    Provides rolling transformations.
+
+    .. versionadded:: 0.18.0
+
+    Parameters
+    ----------
+    window : int
+       Size of the moving window. This is the number of observations used for
+       calculating the statistic.
+    min_periods : int, default None
+        Minimum number of observations in window required to have a value
+        (otherwise result is NA).
+    freq : string or DateOffset object, optional (default None)
+        Frequency to conform the data to before computing the statistic. Specified
+        as a frequency string or DateOffset object.
+    center : boolean, default False
+        Set the labels at the center of the window.
+    how : string, default None
+        Method for down- or re-sampling
+    win_type : string, default None
+        prove a window type, see the notes below
+    axis : int, default 0
+
+    Returns
+    -------
+    a Window sub-classed for the particular operation
+
+    Notes
+    -----
+    By default, the result is set to the right edge of the window. This can be
+    changed to the center of the window by setting ``center=True``.
+
+    The `freq` keyword is used to conform time series data to a specified
+    frequency by resampling the data. This is done with the default parameters
+    of :meth:`~pandas.Series.resample` (i.e. using the `mean`).
+
+    The recognized window types are:
+
+        * ``boxcar``
+        * ``triang``
+        * ``blackman``
+        * ``hamming``
+        * ``bartlett``
+        * ``parzen``
+        * ``bohman``
+        * ``blackmanharris``
+        * ``nuttall``
+        * ``barthann``
+        * ``kaiser`` (needs beta)
+        * ``gaussian`` (needs std)
+        * ``general_gaussian`` (needs power, width)
+        * ``slepian`` (needs width).
+    """
+    from pandas import Series, DataFrame
+    if not isinstance(obj, (Series, DataFrame)):
+        raise TypeError('invalid type: %s' % type(obj))
+
+    if win_type is not None:
+        return Window(obj, win_type=win_type, **kwds)
+
+    return Rolling(obj, **kwds)
+
+def expanding(obj, **kwds):
+    """
+    Provides expanding transformations.
+
+    .. versionadded:: 0.18.0
+
+    Parameters
+    ----------
+    min_periods : int, default None
+        Minimum number of observations in window required to have a value
+        (otherwise result is NA).
+    freq : string or DateOffset object, optional (default None)
+        Frequency to conform the data to before computing the statistic. Specified
+        as a frequency string or DateOffset object.
+    center : boolean, default False
+        Set the labels at the center of the window.
+    how : string, default None
+        Method for down- or re-sampling
+    axis : int, default 0
+
+    Returns
+    -------
+    a Window sub-classed for the particular operation
+
+    Notes
+    -----
+    By default, the result is set to the right edge of the window. This can be
+    changed to the center of the window by setting ``center=True``.
+
+    The `freq` keyword is used to conform time series data to a specified
+    frequency by resampling the data. This is done with the default parameters
+    of :meth:`~pandas.Series.resample` (i.e. using the `mean`).
+    """
+
+    from pandas import Series, DataFrame
+    if not isinstance(obj, (Series, DataFrame)):
+        raise TypeError('invalid type: %s' % type(obj))
+
+    return Expanding(obj, **kwds)
+
+def ewm(obj, **kwds):
+    """
+    .. versionadded:: 0.18.0
+
+    Provides exponential weighted functions
+
+    Parameters
+    ----------
+    com : float. optional
+        Center of mass: :math:`\alpha = 1 / (1 + com)`,
+    span : float, optional
+        Specify decay in terms of span, :math:`\alpha = 2 / (span + 1)`
+    halflife : float, optional
+        Specify decay in terms of halflife, :math:`\alpha = 1 - exp(log(0.5) / halflife)`
+    min_periods : int, default 0
+        Minimum number of observations in window required to have a value
+        (otherwise result is NA).
+    freq : None or string alias / date offset object, default=None
+        Frequency to conform to before computing statistic
+    adjust : boolean, default True
+        Divide by decaying adjustment factor in beginning periods to account for
+        imbalance in relative weightings (viewing EWMA as a moving average)
+    how : string, default 'mean'
+        Method for down- or re-sampling
+    ignore_na : boolean, default False
+        Ignore missing values when calculating weights;
+        specify True to reproduce pre-0.15.0 behavior
+
+    Returns
+    -------
+    a Window sub-classed for the particular operation
+
+    Notes
+    -----
+    Either center of mass, span or halflife must be specified
+
+    EWMA is sometimes specified using a "span" parameter `s`, we have that the
+    decay parameter :math:`\alpha` is related to the span as
+    :math:`\alpha = 2 / (s + 1) = 1 / (1 + c)`
+
+    where `c` is the center of mass. Given a span, the associated center of mass is
+    :math:`c = (s - 1) / 2`
+
+    So a "20-day EWMA" would have center 9.5.
+
+    The `freq` keyword is used to conform time series data to a specified
+    frequency by resampling the data. This is done with the default parameters
+    of :meth:`~pandas.Series.resample` (i.e. using the `mean`).
+
+    When adjust is True (default), weighted averages are calculated using weights
+        (1-alpha)**(n-1), (1-alpha)**(n-2), ..., 1-alpha, 1.
+
+    When adjust is False, weighted averages are calculated recursively as:
+       weighted_average[0] = arg[0];
+       weighted_average[i] = (1-alpha)*weighted_average[i-1] + alpha*arg[i].
+
+    When ignore_na is False (default), weights are based on absolute positions.
+    For example, the weights of x and y used in calculating the final weighted
+    average of [x, None, y] are (1-alpha)**2 and 1 (if adjust is True), and
+    (1-alpha)**2 and alpha (if adjust is False).
+
+    When ignore_na is True (reproducing pre-0.15.0 behavior), weights are based on
+    relative positions. For example, the weights of x and y used in calculating
+    the final weighted average of [x, None, y] are 1-alpha and 1 (if adjust is
+    True), and 1-alpha and alpha (if adjust is False).
+
+    More details can be found at
+    http://pandas.pydata.org/pandas-docs/stable/computation.html#exponentially-weighted-moment-functions
+    """
+    from pandas import Series, DataFrame
+    if not isinstance(obj, (Series, DataFrame)):
+        raise TypeError('invalid type: %s' % type(obj))
+
+    return EWM(obj, **kwds)

--- a/pandas/stats/moments.py
+++ b/pandas/stats/moments.py
@@ -12,13 +12,13 @@ __all__ = ['rolling_count', 'rolling_max', 'rolling_min',
            'rolling_sum', 'rolling_mean', 'rolling_std', 'rolling_cov',
            'rolling_corr', 'rolling_var', 'rolling_skew', 'rolling_kurt',
            'rolling_quantile', 'rolling_median', 'rolling_apply',
-           'rolling_corr_pairwise', 'rolling_window',
+           'rolling_window',
            'ewma', 'ewmvar', 'ewmstd', 'ewmvol', 'ewmcorr', 'ewmcov',
            'expanding_count', 'expanding_max', 'expanding_min',
            'expanding_sum', 'expanding_mean', 'expanding_std',
            'expanding_cov', 'expanding_corr', 'expanding_var',
            'expanding_skew', 'expanding_kurt', 'expanding_quantile',
-           'expanding_median', 'expanding_apply', 'expanding_corr_pairwise']
+           'expanding_median', 'expanding_apply' ]
 
 #------------------------------------------------------------------------------
 # Docs
@@ -271,20 +271,6 @@ def rolling_corr(arg1, arg2=None, window=None, pairwise=None, **kwargs):
                          pairwise=pairwise,
                          func_kw=['other','pairwise'],
                          **kwargs)
-
-@Substitution("Deprecated. Use rolling_corr(..., pairwise=True) instead.\n\n"
-              "Pairwise moving sample correlation", _pairwise_arg,
-              _roll_kw%'None', _pairwise_retval, _roll_notes)
-@Appender(_doc_template)
-def rolling_corr_pairwise(df1, df2=None, window=None, min_periods=None,
-                          freq=None, center=False):
-    import warnings
-    msg = "rolling_corr_pairwise is deprecated, use rolling_corr(..., pairwise=True)"
-    warnings.warn(msg, FutureWarning, stacklevel=2)
-    return rolling_corr(df1, df2, window=window, min_periods=min_periods,
-                        freq=freq, center=center,
-                        pairwise=True)
-
 
 
 #------------------------------------------------------------------------------
@@ -743,18 +729,6 @@ def expanding_corr(arg1, arg2=None, min_periods=1, freq=None, pairwise=None):
                          pairwise=pairwise,
                          freq=freq,
                          func_kw=['other','pairwise','ddof'])
-
-@Substitution("Deprecated. Use expanding_corr(..., pairwise=True) instead.\n\n"
-              "Pairwise expanding sample correlation", _pairwise_arg,
-              _expanding_kw, _pairwise_retval, "")
-@Appender(_doc_template)
-def expanding_corr_pairwise(df1, df2=None, min_periods=1, freq=None):
-    import warnings
-    msg = "expanding_corr_pairwise is deprecated, use expanding_corr(..., pairwise=True)"
-    warnings.warn(msg, FutureWarning, stacklevel=2)
-    return expanding_corr(df1, df2, min_periods=min_periods,
-                          freq=freq, pairwise=True)
-
 
 def expanding_apply(arg, func, min_periods=1, freq=None,
                     args=(), kwargs={}):

--- a/pandas/stats/moments.py
+++ b/pandas/stats/moments.py
@@ -4,16 +4,8 @@ statistics implemented in Cython
 """
 from __future__ import division
 
-from functools import wraps
-from collections import defaultdict
-
-from numpy import NaN
 import numpy as np
-
-from pandas.core.api import DataFrame, Series, Panel, notnull
-import pandas.algos as algos
-import pandas.core.common as pdcom
-
+from pandas.core.api import DataFrame, Series
 from pandas.util.decorators import Substitution, Appender
 
 __all__ = ['rolling_count', 'rolling_max', 'rolling_min',
@@ -179,8 +171,38 @@ _bias_kw = r"""bias : boolean, default False
     Use a standard estimation bias correction
 """
 
+def ensure_compat(dispatch, name, arg, func_kw=None, *args, **kwargs):
+    """
+    wrapper function to dispatch to the appropriate window functions
+    wraps/unwraps ndarrays for compat
 
-def rolling_count(arg, window, freq=None, center=False, how=None):
+    can be removed when ndarray support is removed
+    """
+    is_ndarray = isinstance(arg, np.ndarray)
+    if is_ndarray:
+        if arg.ndim == 1:
+            arg = Series(arg)
+        elif arg.ndim == 2:
+            arg = DataFrame(arg)
+        else:
+            raise AssertionError("cannot support ndim > 2 for ndarray compat")
+
+    # get the functional keywords here
+    if func_kw is None:
+        func_kw = []
+    kwds = {}
+    for k in func_kw:
+        value = kwargs.pop(k,None)
+        if value is not None:
+            kwds[k] = value
+    r = getattr(arg,dispatch)(**kwargs)
+    result = getattr(r,name)(*args, **kwds)
+
+    if is_ndarray:
+        result = result.values
+    return result
+
+def rolling_count(arg, window, **kwargs):
     """
     Rolling count of number of non-NaN observations inside provided window.
 
@@ -208,26 +230,12 @@ def rolling_count(arg, window, freq=None, center=False, how=None):
     frequency by resampling the data. This is done with the default parameters
     of :meth:`~pandas.Series.resample` (i.e. using the `mean`).
     """
-    arg = _conv_timerule(arg, freq, how)
-    if not center:
-        window = min(window, len(arg))
-
-    return_hook, values = _process_data_structure(arg, kill_inf=False)
-
-    converted = np.isfinite(values).astype(float)
-    result = rolling_sum(converted, window, min_periods=0,
-                         center=center)  # already converted
-
-    # putmask here?
-    result[np.isnan(result)] = 0
-    return return_hook(result)
-
+    return ensure_compat('rolling', 'count', arg, window=window, **kwargs)
 
 @Substitution("Unbiased moving covariance.", _binary_arg_flex,
               _roll_kw%'None'+_pairwise_kw+_ddof_kw, _flex_retval, _roll_notes)
 @Appender(_doc_template)
-def rolling_cov(arg1, arg2=None, window=None, min_periods=None, freq=None,
-                center=False, pairwise=None, how=None, ddof=1):
+def rolling_cov(arg1, arg2=None, window=None, pairwise=None, **kwargs):
     if window is None and isinstance(arg2, (int, float)):
         window = arg2
         arg2 = arg1
@@ -235,23 +243,19 @@ def rolling_cov(arg1, arg2=None, window=None, min_periods=None, freq=None,
     elif arg2 is None:
         arg2 = arg1
         pairwise = True if pairwise is None else pairwise  # only default unset
-    arg1 = _conv_timerule(arg1, freq, how)
-    arg2 = _conv_timerule(arg2, freq, how)
-
-    def _get_cov(X, Y):
-        mean = lambda x: rolling_mean(x, window, min_periods, center=center)
-        count = rolling_count(X + Y, window, center=center)
-        bias_adj = count / (count - ddof)
-        return (mean(X * Y) - mean(X) * mean(Y)) * bias_adj
-    rs = _flex_binary_moment(arg1, arg2, _get_cov, pairwise=bool(pairwise))
-    return rs
-
+    return ensure_compat('rolling',
+                         'cov',
+                         arg1,
+                         other=arg2,
+                         window=window,
+                         pairwise=pairwise,
+                         func_kw=['other','pairwise','ddof'],
+                         **kwargs)
 
 @Substitution("Moving sample correlation.", _binary_arg_flex,
               _roll_kw%'None'+_pairwise_kw, _flex_retval, _roll_notes)
 @Appender(_doc_template)
-def rolling_corr(arg1, arg2=None, window=None, min_periods=None, freq=None,
-                 center=False, pairwise=None, how=None):
+def rolling_corr(arg1, arg2=None, window=None, pairwise=None, **kwargs):
     if window is None and isinstance(arg2, (int, float)):
         window = arg2
         arg2 = arg1
@@ -259,86 +263,14 @@ def rolling_corr(arg1, arg2=None, window=None, min_periods=None, freq=None,
     elif arg2 is None:
         arg2 = arg1
         pairwise = True if pairwise is None else pairwise  # only default unset
-    arg1 = _conv_timerule(arg1, freq, how)
-    arg2 = _conv_timerule(arg2, freq, how)
-
-    def _get_corr(a, b):
-        num = rolling_cov(a, b, window, min_periods, freq=freq,
-                          center=center)
-        den = (rolling_std(a, window, min_periods, freq=freq,
-                           center=center) *
-               rolling_std(b, window, min_periods, freq=freq,
-                           center=center))
-        return num / den
-
-    return _flex_binary_moment(arg1, arg2, _get_corr, pairwise=bool(pairwise))
-
-
-def _flex_binary_moment(arg1, arg2, f, pairwise=False):
-    if not (isinstance(arg1,(np.ndarray, Series, DataFrame)) and
-            isinstance(arg2,(np.ndarray, Series, DataFrame))):
-        raise TypeError("arguments to moment function must be of type "
-                         "np.ndarray/Series/DataFrame")
-
-    if isinstance(arg1, (np.ndarray, Series)) and \
-            isinstance(arg2, (np.ndarray,Series)):
-        X, Y = _prep_binary(arg1, arg2)
-        return f(X, Y)
-
-    elif isinstance(arg1, DataFrame):
-        def dataframe_from_int_dict(data, frame_template):
-            result = DataFrame(data, index=frame_template.index)
-            if len(result.columns) > 0:
-                result.columns = frame_template.columns[result.columns]
-            return result
-
-        results = {}
-        if isinstance(arg2, DataFrame):
-            if pairwise is False:
-                if arg1 is arg2:
-                    # special case in order to handle duplicate column names
-                    for i, col in enumerate(arg1.columns):
-                        results[i] = f(arg1.iloc[:, i], arg2.iloc[:, i])
-                    return dataframe_from_int_dict(results, arg1)
-                else:
-                    if not arg1.columns.is_unique:
-                        raise ValueError("'arg1' columns are not unique")
-                    if not arg2.columns.is_unique:
-                        raise ValueError("'arg2' columns are not unique")
-                    X, Y = arg1.align(arg2, join='outer')
-                    X = X + 0 * Y
-                    Y = Y + 0 * X
-                    res_columns = arg1.columns.union(arg2.columns)
-                    for col in res_columns:
-                        if col in X and col in Y:
-                            results[col] = f(X[col], Y[col])
-                    return DataFrame(results, index=X.index, columns=res_columns)
-            elif pairwise is True:
-                results = defaultdict(dict)
-                for i, k1 in enumerate(arg1.columns):
-                    for j, k2 in enumerate(arg2.columns):
-                        if j<i and arg2 is arg1:
-                            # Symmetric case
-                            results[i][j] = results[j][i]
-                        else:
-                            results[i][j] = f(*_prep_binary(arg1.iloc[:, i], arg2.iloc[:, j]))
-                p = Panel.from_dict(results).swapaxes('items', 'major')
-                if len(p.major_axis) > 0:
-                    p.major_axis = arg1.columns[p.major_axis]
-                if len(p.minor_axis) > 0:
-                    p.minor_axis = arg2.columns[p.minor_axis]
-                return p
-            else:
-                raise ValueError("'pairwise' is not True/False")
-        else:
-            results = {}
-            for i, col in enumerate(arg1.columns):
-                results[i] = f(*_prep_binary(arg1.iloc[:, i], arg2))
-            return dataframe_from_int_dict(results, arg1)
-
-    else:
-        return _flex_binary_moment(arg2, arg1, f)
-
+    return ensure_compat('rolling',
+                         'corr',
+                         arg1,
+                         other=arg2,
+                         window=window,
+                         pairwise=pairwise,
+                         func_kw=['other','pairwise'],
+                         **kwargs)
 
 @Substitution("Deprecated. Use rolling_corr(..., pairwise=True) instead.\n\n"
               "Pairwise moving sample correlation", _pairwise_arg,
@@ -354,116 +286,9 @@ def rolling_corr_pairwise(df1, df2=None, window=None, min_periods=None,
                         pairwise=True)
 
 
-def _rolling_moment(arg, window, func, minp, axis=0, freq=None, center=False,
-                    how=None, args=(), kwargs={}, **kwds):
-    """
-    Rolling statistical measure using supplied function. Designed to be
-    used with passed-in Cython array-based functions.
-
-    Parameters
-    ----------
-    arg :  DataFrame or numpy ndarray-like
-    window : Number of observations used for calculating statistic
-    func : Cython function to compute rolling statistic on raw series
-    minp : int
-        Minimum number of observations required to have a value
-    axis : int, default 0
-    freq : None or string alias / date offset object, default=None
-        Frequency to conform to before computing statistic
-    center : boolean, default False
-        Whether the label should correspond with center of window
-    how : string, default 'mean'
-        Method for down- or re-sampling
-    args : tuple
-        Passed on to func
-    kwargs : dict
-        Passed on to func
-
-    Returns
-    -------
-    y : type of input
-    """
-    arg = _conv_timerule(arg, freq, how)
-
-    return_hook, values = _process_data_structure(arg)
-
-    if values.size == 0:
-        result = values.copy()
-    else:
-        # actually calculate the moment. Faster way to do this?
-        offset = int((window - 1) / 2.) if center else 0
-        additional_nans = np.array([np.NaN] * offset)
-        calc = lambda x: func(np.concatenate((x, additional_nans)) if center else x,
-                              window, minp=minp, args=args, kwargs=kwargs,
-                              **kwds)
-        if values.ndim > 1:
-            result = np.apply_along_axis(calc, axis, values)
-        else:
-            result = calc(values)
-
-    if center:
-        result = _center_window(result, window, axis)
-
-    return return_hook(result)
-
-
-def _center_window(rs, window, axis):
-    if axis > rs.ndim-1:
-        raise ValueError("Requested axis is larger then no. of argument "
-                         "dimensions")
-
-    offset = int((window - 1) / 2.)
-    if offset > 0:
-        if isinstance(rs, (Series, DataFrame, Panel)):
-            rs = rs.slice_shift(-offset, axis=axis)
-        else:
-            lead_indexer = [slice(None)] * rs.ndim
-            lead_indexer[axis] = slice(offset, None)
-            rs = np.copy(rs[tuple(lead_indexer)])
-    return rs
-
-
-def _process_data_structure(arg, kill_inf=True):
-    if isinstance(arg, DataFrame):
-        return_hook = lambda v: type(arg)(v, index=arg.index,
-                                          columns=arg.columns)
-        values = arg.values
-    elif isinstance(arg, Series):
-        values = arg.values
-        return_hook = lambda v: Series(v, arg.index, name=arg.name)
-    else:
-        return_hook = lambda v: v
-        values = arg
-
-    if not issubclass(values.dtype.type, float):
-        values = values.astype(float)
-
-    if kill_inf:
-        values = values.copy()
-        values[np.isinf(values)] = np.NaN
-
-    return return_hook, values
 
 #------------------------------------------------------------------------------
 # Exponential moving moments
-
-
-def _get_center_of_mass(com, span, halflife):
-    valid_count = len([x for x in [com, span, halflife] if x is not None])
-    if valid_count > 1:
-        raise Exception("com, span, and halflife are mutually exclusive")
-
-    if span is not None:
-        # convert span to center of mass
-        com = (span - 1) / 2.
-    elif halflife is not None:
-        # convert halflife to center of mass
-        decay = 1 - np.exp(np.log(0.5) / halflife)
-        com = 1 / decay - 1
-    elif com is None:
-        raise Exception("Must pass one of com, span, or halflife")
-
-    return float(com)
 
 
 @Substitution("Exponentially-weighted moving average", _unary_arg, _ewm_kw,
@@ -471,47 +296,55 @@ def _get_center_of_mass(com, span, halflife):
 @Appender(_doc_template)
 def ewma(arg, com=None, span=None, halflife=None, min_periods=0, freq=None,
          adjust=True, how=None, ignore_na=False):
-    arg = _conv_timerule(arg, freq, how)
-    com = _get_center_of_mass(com, span, halflife)
-
-    def _ewma(v):
-        return algos.ewma(v, com, int(adjust), int(ignore_na), int(min_periods))
-
-    return_hook, values = _process_data_structure(arg)
-    if values.size == 0:
-        output = values.copy()
-    else:
-        output = np.apply_along_axis(_ewma, 0, values)
-    return return_hook(output)
-
+    return ensure_compat('ewm',
+                         'mean',
+                         arg,
+                         com=com,
+                         span=span,
+                         halflife=halflife,
+                         min_periods=min_periods,
+                         freq=freq,
+                         adjust=adjust,
+                         how=how,
+                         ignore_na=ignore_na)
 
 @Substitution("Exponentially-weighted moving variance", _unary_arg,
               _ewm_kw+_bias_kw, _type_of_input_retval, _ewm_notes)
 @Appender(_doc_template)
 def ewmvar(arg, com=None, span=None, halflife=None, min_periods=0, bias=False,
            freq=None, how=None, ignore_na=False, adjust=True):
-    arg = _conv_timerule(arg, freq, how)
-    com = _get_center_of_mass(com, span, halflife)
-
-    def _ewmvar(v):
-        return algos.ewmcov(v, v, com, int(adjust), int(ignore_na), int(min_periods), int(bias))
-
-    return_hook, values = _process_data_structure(arg)
-    if values.size == 0:
-        output = values.copy()
-    else:
-        output = np.apply_along_axis(_ewmvar, 0, values)
-    return return_hook(output)
-
+    return ensure_compat('ewm',
+                         'var',
+                         arg,
+                         com=com,
+                         span=span,
+                         halflife=halflife,
+                         min_periods=min_periods,
+                         freq=freq,
+                         adjust=adjust,
+                         how=how,
+                         ignore_na=ignore_na,
+                         bias=bias,
+                         func_kw=['bias'])
 
 @Substitution("Exponentially-weighted moving std", _unary_arg,
               _ewm_kw+_bias_kw, _type_of_input_retval, _ewm_notes)
 @Appender(_doc_template)
 def ewmstd(arg, com=None, span=None, halflife=None, min_periods=0, bias=False,
-           ignore_na=False, adjust=True):
-    result = ewmvar(arg, com=com, span=span, halflife=halflife,
-                    min_periods=min_periods, bias=bias, adjust=adjust, ignore_na=ignore_na)
-    return _zsqrt(result)
+           freq=None, how=None, ignore_na=False, adjust=True):
+    return ensure_compat('ewm',
+                         'std',
+                         arg,
+                         com=com,
+                         span=span,
+                         halflife=halflife,
+                         min_periods=min_periods,
+                         freq=freq,
+                         adjust=adjust,
+                         how=how,
+                         ignore_na=ignore_na,
+                         bias=bias,
+                         func_kw=['bias'])
 
 ewmvol = ewmstd
 
@@ -528,21 +361,22 @@ def ewmcov(arg1, arg2=None, com=None, span=None, halflife=None, min_periods=0,
         com = arg2
         arg2 = arg1
         pairwise = True if pairwise is None else pairwise
-    arg1 = _conv_timerule(arg1, freq, how)
-    arg2 = _conv_timerule(arg2, freq, how)
-    com = _get_center_of_mass(com, span, halflife)
 
-    def _get_ewmcov(X, Y):
-        # X and Y have the same structure (and NaNs) when called from _flex_binary_moment()
-        return_hook, x_values = _process_data_structure(X)
-        return_hook, y_values = _process_data_structure(Y)
-        cov = algos.ewmcov(x_values, y_values, com, int(adjust), int(ignore_na), int(min_periods), int(bias))
-        return return_hook(cov)
-
-    result = _flex_binary_moment(arg1, arg2, _get_ewmcov,
-                                 pairwise=bool(pairwise))
-    return result
-
+    return ensure_compat('ewm',
+                         'cov',
+                         arg1,
+                         other=arg2,
+                         com=com,
+                         span=span,
+                         halflife=halflife,
+                         min_periods=min_periods,
+                         bias=bias,
+                         freq=freq,
+                         how=how,
+                         ignore_na=ignore_na,
+                         adjust=adjust,
+                         pairwise=pairwise,
+                         func_kw=['other','pairwise','bias'])
 
 @Substitution("Exponentially-weighted moving correlation", _binary_arg_flex,
               _ewm_kw+_pairwise_kw, _type_of_input_retval, _ewm_notes)
@@ -556,80 +390,26 @@ def ewmcorr(arg1, arg2=None, com=None, span=None, halflife=None, min_periods=0,
         com = arg2
         arg2 = arg1
         pairwise = True if pairwise is None else pairwise
-    arg1 = _conv_timerule(arg1, freq, how)
-    arg2 = _conv_timerule(arg2, freq, how)
-    com = _get_center_of_mass(com, span, halflife)
-
-    def _get_ewmcorr(X, Y):
-        # X and Y have the same structure (and NaNs) when called from _flex_binary_moment()
-        return_hook, x_values = _process_data_structure(X)
-        return_hook, y_values = _process_data_structure(Y)
-        cov = algos.ewmcov(x_values, y_values, com, int(adjust), int(ignore_na), int(min_periods), 1)
-        x_var = algos.ewmcov(x_values, x_values, com, int(adjust), int(ignore_na), int(min_periods), 1)
-        y_var = algos.ewmcov(y_values, y_values, com, int(adjust), int(ignore_na), int(min_periods), 1)
-        corr = cov / _zsqrt(x_var * y_var)
-        return return_hook(corr)
-
-    result = _flex_binary_moment(arg1, arg2, _get_ewmcorr,
-                                 pairwise=bool(pairwise))
-    return result
-
-
-def _zsqrt(x):
-    result = np.sqrt(x)
-    mask = x < 0
-
-    if isinstance(x, DataFrame):
-        if mask.values.any():
-            result[mask] = 0
-    else:
-        if mask.any():
-            result[mask] = 0
-
-    return result
-
-
-def _prep_binary(arg1, arg2):
-    if not isinstance(arg2, type(arg1)):
-        raise Exception('Input arrays must be of the same type!')
-
-    # mask out values, this also makes a common index...
-    X = arg1 + 0 * arg2
-    Y = arg2 + 0 * arg1
-
-    return X, Y
+    return ensure_compat('ewm',
+                         'corr',
+                         arg1,
+                         other=arg2,
+                         com=com,
+                         span=span,
+                         halflife=halflife,
+                         min_periods=min_periods,
+                         freq=freq,
+                         how=how,
+                         ignore_na=ignore_na,
+                         adjust=adjust,
+                         pairwise=pairwise,
+                         func_kw=['other','pairwise'])
 
 #----------------------------------------------------------------------
 # Python interface to Cython functions
 
 
-def _conv_timerule(arg, freq, how):
-
-    types = (DataFrame, Series)
-    if freq is not None and isinstance(arg, types):
-        # Conform to whatever frequency needed.
-        arg = arg.resample(freq, how=how)
-
-    return arg
-
-
-def _require_min_periods(p):
-    def _check_func(minp, window):
-        if minp is None:
-            return window
-        else:
-            return max(p, minp)
-    return _check_func
-
-
-def _use_window(minp, window):
-    if minp is None:
-        return window
-    else:
-        return minp
-
-
-def _rolling_func(func, desc, check_minp=_use_window, how=None, additional_kw=''):
+def _rolling_func(name, desc, how=None, func_kw=None, additional_kw=''):
     if how is None:
         how_arg_str = 'None'
     else:
@@ -638,36 +418,33 @@ def _rolling_func(func, desc, check_minp=_use_window, how=None, additional_kw=''
     @Substitution(desc, _unary_arg, _roll_kw%how_arg_str + additional_kw,
                   _type_of_input_retval, _roll_notes)
     @Appender(_doc_template)
-    @wraps(func)
     def f(arg, window, min_periods=None, freq=None, center=False, how=how,
           **kwargs):
-        def call_cython(arg, window, minp, args=(), kwargs={}, **kwds):
-            minp = check_minp(minp, window)
-            return func(arg, window, minp, **kwds)
-        return _rolling_moment(arg, window, call_cython, min_periods, freq=freq,
-                               center=center, how=how, **kwargs)
-
+        return ensure_compat('rolling',
+                             name,
+                             arg,
+                             window=window,
+                             min_periods=min_periods,
+                             freq=freq,
+                             center=center,
+                             how=how,
+                             func_kw=func_kw,
+                             **kwargs)
     return f
 
-rolling_max = _rolling_func(algos.roll_max, 'Moving maximum.', how='max')
-rolling_min = _rolling_func(algos.roll_min, 'Moving minimum.', how='min')
-rolling_sum = _rolling_func(algos.roll_sum, 'Moving sum.')
-rolling_mean = _rolling_func(algos.roll_mean, 'Moving mean.')
-rolling_median = _rolling_func(algos.roll_median_c, 'Moving median.',
-                               how='median')
-
-_ts_std = lambda *a, **kw: _zsqrt(algos.roll_var(*a, **kw))
-rolling_std = _rolling_func(_ts_std, 'Moving standard deviation.',
-                            check_minp=_require_min_periods(1),
+rolling_max = _rolling_func('max', 'Moving maximum.', how='max')
+rolling_min = _rolling_func('min', 'Moving minimum.', how='min')
+rolling_sum = _rolling_func('sum', 'Moving sum.')
+rolling_mean = _rolling_func('mean', 'Moving mean.')
+rolling_median = _rolling_func('median', 'Moving median.', how='median')
+rolling_std = _rolling_func('std', 'Moving standard deviation.',
+                            func_kw=['ddof'],
                             additional_kw=_ddof_kw)
-rolling_var = _rolling_func(algos.roll_var, 'Moving variance.',
-                            check_minp=_require_min_periods(1),
+rolling_var = _rolling_func('var', 'Moving variance.',
+                            func_kw=['ddof'],
                             additional_kw=_ddof_kw)
-rolling_skew = _rolling_func(algos.roll_skew, 'Unbiased moving skewness.',
-                             check_minp=_require_min_periods(3))
-rolling_kurt = _rolling_func(algos.roll_kurt, 'Unbiased moving kurtosis.',
-                             check_minp=_require_min_periods(4))
-
+rolling_skew = _rolling_func('skew', 'Unbiased moving skewness.')
+rolling_kurt = _rolling_func('kurt', 'Unbiased moving kurtosis.')
 
 def rolling_quantile(arg, window, quantile, min_periods=None, freq=None,
                      center=False):
@@ -703,12 +480,15 @@ def rolling_quantile(arg, window, quantile, min_periods=None, freq=None,
     frequency by resampling the data. This is done with the default parameters
     of :meth:`~pandas.Series.resample` (i.e. using the `mean`).
     """
-
-    def call_cython(arg, window, minp, args=(), kwargs={}):
-        minp = _use_window(minp, window)
-        return algos.roll_quantile(arg, window, minp, quantile)
-    return _rolling_moment(arg, window, call_cython, min_periods, freq=freq,
-                           center=center)
+    return ensure_compat('rolling',
+                         'quantile',
+                         arg,
+                         window=window,
+                         freq=freq,
+                         center=center,
+                         min_periods=min_periods,
+                         func_kw=['quantile'],
+                         quantile=quantile)
 
 
 def rolling_apply(arg, window, func, min_periods=None, freq=None,
@@ -749,12 +529,17 @@ def rolling_apply(arg, window, func, min_periods=None, freq=None,
     frequency by resampling the data. This is done with the default parameters
     of :meth:`~pandas.Series.resample` (i.e. using the `mean`).
     """
-    offset = int((window - 1) / 2.) if center else 0
-    def call_cython(arg, window, minp, args, kwargs):
-        minp = _use_window(minp, window)
-        return algos.roll_generic(arg, window, minp, offset, func, args, kwargs)
-    return _rolling_moment(arg, window, call_cython, min_periods, freq=freq,
-                           center=False, args=args, kwargs=kwargs)
+    return ensure_compat('rolling',
+                         'apply',
+                         arg,
+                         window=window,
+                         freq=freq,
+                         center=center,
+                         min_periods=min_periods,
+                         func_kw=['func','args','kwargs'],
+                         func=func,
+                         args=args,
+                         kwargs=kwargs)
 
 
 def rolling_window(arg, window=None, win_type=None, min_periods=None,
@@ -816,97 +601,48 @@ def rolling_window(arg, window=None, win_type=None, min_periods=None,
     frequency by resampling the data. This is done with the default parameters
     of :meth:`~pandas.Series.resample` (i.e. using the `mean`).
     """
-    if isinstance(window, (list, tuple, np.ndarray)):
-        if win_type is not None:
-            raise ValueError(('Do not specify window type if using custom '
-                              'weights'))
-        window = pdcom._asarray_tuplesafe(window).astype(float)
-    elif pdcom.is_integer(window):  # window size
-        if win_type is None:
-            raise ValueError('Must specify window type')
-        try:
-            import scipy.signal as sig
-        except ImportError:
-            raise ImportError('Please install scipy to generate window weight')
-        win_type = _validate_win_type(win_type, kwargs)  # may pop from kwargs
-        window = sig.get_window(win_type, window).astype(float)
-    else:
-        raise ValueError('Invalid window %s' % str(window))
+    func = 'mean' if mean else 'sum'
+    return ensure_compat('rolling',
+                         func,
+                         arg,
+                         window=window,
+                         win_type=win_type,
+                         freq=freq,
+                         center=center,
+                         min_periods=min_periods,
+                         axis=axis,
+                         how=how,
+                         func_kw=kwargs.keys(),
+                         **kwargs)
 
-    minp = _use_window(min_periods, len(window))
-
-    arg = _conv_timerule(arg, freq, how)
-    return_hook, values = _process_data_structure(arg)
-
-    if values.size == 0:
-        result = values.copy()
-    else:
-        offset = int((len(window) - 1) / 2.) if center else 0
-        additional_nans = np.array([np.NaN] * offset)
-        f = lambda x: algos.roll_window(np.concatenate((x, additional_nans)) if center else x,
-                                        window, minp, avg=mean)
-        result = np.apply_along_axis(f, axis, values)
-
-    if center:
-        result = _center_window(result, len(window), axis)
-
-    return return_hook(result)
-
-
-def _validate_win_type(win_type, kwargs):
-    # may pop from kwargs
-    arg_map = {'kaiser': ['beta'],
-               'gaussian': ['std'],
-               'general_gaussian': ['power', 'width'],
-               'slepian': ['width']}
-    if win_type in arg_map:
-        return tuple([win_type] +
-                     _pop_args(win_type, arg_map[win_type], kwargs))
-    return win_type
-
-
-def _pop_args(win_type, arg_names, kwargs):
-    msg = '%s window requires %%s' % win_type
-    all_args = []
-    for n in arg_names:
-        if n not in kwargs:
-            raise ValueError(msg % n)
-        all_args.append(kwargs.pop(n))
-    return all_args
-
-
-def _expanding_func(func, desc, check_minp=_use_window, additional_kw=''):
+def _expanding_func(name, desc, func_kw=None, additional_kw=''):
     @Substitution(desc, _unary_arg, _expanding_kw + additional_kw,
                   _type_of_input_retval, "")
     @Appender(_doc_template)
-    @wraps(func)
     def f(arg, min_periods=1, freq=None, **kwargs):
-        window = max(len(arg), min_periods) if min_periods else len(arg)
-
-        def call_cython(arg, window, minp, args=(), kwargs={}, **kwds):
-            minp = check_minp(minp, window)
-            return func(arg, window, minp, **kwds)
-        return _rolling_moment(arg, window, call_cython, min_periods, freq=freq,
-                               **kwargs)
-
+        return ensure_compat('expanding',
+                             name,
+                             arg,
+                             min_periods=min_periods,
+                             freq=freq,
+                             func_kw=func_kw,
+                             **kwargs)
     return f
 
-expanding_max = _expanding_func(algos.roll_max, 'Expanding maximum.')
-expanding_min = _expanding_func(algos.roll_min, 'Expanding minimum.')
-expanding_sum = _expanding_func(algos.roll_sum, 'Expanding sum.')
-expanding_mean = _expanding_func(algos.roll_mean, 'Expanding mean.')
-expanding_median = _expanding_func(algos.roll_median_c, 'Expanding median.')
+expanding_max = _expanding_func('max', 'Expanding maximum.')
+expanding_min = _expanding_func('min', 'Expanding minimum.')
+expanding_sum = _expanding_func('sum', 'Expanding sum.')
+expanding_mean = _expanding_func('mean', 'Expanding mean.')
+expanding_median = _expanding_func('median', 'Expanding median.')
 
-expanding_std = _expanding_func(_ts_std, 'Expanding standard deviation.',
-                                check_minp=_require_min_periods(1),
+expanding_std = _expanding_func('std', 'Expanding standard deviation.',
+                                func_kw=['ddof'],
                                 additional_kw=_ddof_kw)
-expanding_var = _expanding_func(algos.roll_var, 'Expanding variance.',
-                                check_minp=_require_min_periods(1),
+expanding_var = _expanding_func('var', 'Expanding variance.',
+                                func_kw=['ddof'],
                                 additional_kw=_ddof_kw)
-expanding_skew = _expanding_func(algos.roll_skew, 'Unbiased expanding skewness.',
-                                 check_minp=_require_min_periods(3))
-expanding_kurt = _expanding_func(algos.roll_kurt, 'Unbiased expanding kurtosis.',
-                                 check_minp=_require_min_periods(4))
+expanding_skew = _expanding_func('skew', 'Unbiased expanding skewness.')
+expanding_kurt = _expanding_func('kurt', 'Unbiased expanding kurtosis.')
 
 
 def expanding_count(arg, freq=None):
@@ -930,7 +666,7 @@ def expanding_count(arg, freq=None):
     frequency by resampling the data. This is done with the default parameters
     of :meth:`~pandas.Series.resample` (i.e. using the `mean`).
     """
-    return rolling_count(arg, len(arg), freq=freq)
+    return ensure_compat('expanding', 'count', arg, freq=freq)
 
 
 def expanding_quantile(arg, quantile, min_periods=1, freq=None):
@@ -958,9 +694,13 @@ def expanding_quantile(arg, quantile, min_periods=1, freq=None):
     frequency by resampling the data. This is done with the default parameters
     of :meth:`~pandas.Series.resample` (i.e. using the `mean`).
     """
-    return rolling_quantile(arg, len(arg), quantile, min_periods=min_periods,
-                            freq=freq)
-
+    return ensure_compat('expanding',
+                         'quantile',
+                         arg,
+                         freq=freq,
+                         min_periods=min_periods,
+                         func_kw=['quantile'],
+                         quantile=quantile)
 
 @Substitution("Unbiased expanding covariance.", _binary_arg_flex,
               _expanding_kw+_pairwise_kw+_ddof_kw, _flex_retval, "")
@@ -973,10 +713,15 @@ def expanding_cov(arg1, arg2=None, min_periods=1, freq=None, pairwise=None, ddof
         min_periods = arg2
         arg2 = arg1
         pairwise = True if pairwise is None else pairwise
-    window = max((len(arg1) + len(arg2)), min_periods) if min_periods else (len(arg1) + len(arg2))
-    return rolling_cov(arg1, arg2, window,
-                       min_periods=min_periods, freq=freq,
-                       pairwise=pairwise, ddof=ddof)
+    return ensure_compat('expanding',
+                         'cov',
+                         arg1,
+                         other=arg2,
+                         min_periods=min_periods,
+                         pairwise=pairwise,
+                         freq=freq,
+                         ddof=ddof,
+                         func_kw=['other','pairwise','ddof'])
 
 
 @Substitution("Expanding sample correlation.", _binary_arg_flex,
@@ -990,11 +735,14 @@ def expanding_corr(arg1, arg2=None, min_periods=1, freq=None, pairwise=None):
         min_periods = arg2
         arg2 = arg1
         pairwise = True if pairwise is None else pairwise
-    window = max((len(arg1) + len(arg2)), min_periods) if min_periods else (len(arg1) + len(arg2))
-    return rolling_corr(arg1, arg2, window,
-                        min_periods=min_periods,
-                        freq=freq, pairwise=pairwise)
-
+    return ensure_compat('expanding',
+                         'corr',
+                         arg1,
+                         other=arg2,
+                         min_periods=min_periods,
+                         pairwise=pairwise,
+                         freq=freq,
+                         func_kw=['other','pairwise','ddof'])
 
 @Substitution("Deprecated. Use expanding_corr(..., pairwise=True) instead.\n\n"
               "Pairwise expanding sample correlation", _pairwise_arg,
@@ -1038,6 +786,12 @@ def expanding_apply(arg, func, min_periods=1, freq=None,
     frequency by resampling the data. This is done with the default parameters
     of :meth:`~pandas.Series.resample` (i.e. using the `mean`).
     """
-    window = max(len(arg), min_periods) if min_periods else len(arg)
-    return rolling_apply(arg, window, func, min_periods=min_periods, freq=freq,
-                         args=args, kwargs=kwargs)
+    return ensure_compat('expanding',
+                         'apply',
+                         arg,
+                         freq=freq,
+                         min_periods=min_periods,
+                         func_kw=['func','args','kwargs'],
+                         func=func,
+                         args=args,
+                         kwargs=kwargs)

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -160,6 +160,14 @@ class TestApi(Base):
                                                       ('B','rb','mean'),('B','rb','std')])
         compare(result, expected)
 
+
+        # passed lambda
+        result = r.agg({'A' : np.sum,
+                        'B' : lambda x: np.std(x, ddof=1)})
+        rcustom = r['B'].apply(lambda x: np.std(x,ddof=1))
+        expected = pd.concat([a_sum,rcustom],axis=1)
+        compare(result, expected)
+
 class TestMoments(Base):
 
     def setUp(self):

--- a/pandas/util/decorators.py
+++ b/pandas/util/decorators.py
@@ -2,6 +2,7 @@ from pandas.compat import StringIO, callable
 from pandas.lib import cache_readonly
 import sys
 import warnings
+from textwrap import dedent
 from functools import wraps
 
 
@@ -180,7 +181,7 @@ class Appender(object):
         func.__doc__ = func.__doc__ if func.__doc__ else ''
         self.addendum = self.addendum if self.addendum else ''
         docitems = [func.__doc__, self.addendum]
-        func.__doc__ = self.join.join(docitems)
+        func.__doc__ = dedent(self.join.join(docitems))
         return func
 
 


### PR DESCRIPTION
closes #10702 
closes #9052
xref #4950, removal of depr

So this basically takes all of the `pd.rolling_*`,`pd.expanding_*`,`pd.ewma_*` routines and allows an object oriented interface, similar to groupby.

Some benefits:
- nice tab completions on the Rolling/Expanding/EWM objects
- much cleaner code internally
- complete back compat, e.g. everything just works like it did
- added a `.agg/aggregate` function, similar to groupby, where you can do multiple aggregations at once
- added `__getitem__` accessing, e.g. `df.rolling(....)['A','B'].sum()` for a nicer API
- allows for much of #8659  to be done very easily
- fix for coercing Timedeltas properly
- handling nuiscance (string) columns

Other:
- along with window doc rewrite, fixed doc-strings for groupby/window to provide back-refs

ToDO:
- [x] I think that all of the doc-strings are correct, but need check
- [x] implement `.agg`
- [x] update API.rst, what's new
- [x] deprecate the `pd.expanding_*`,`pd.rolling_*`,`pd.ewma_*` interface as this is polluting the top-level namespace quite a bit
- [x] change the docs to use the new API

```
In [4]: df = DataFrame({'A' : range(5), 'B' : pd.timedelta_range('1 day',periods=5), 'C' : 'foo'})

In [5]: df.rolling(window=2).sum()
Out[5]: 
    A      B    C
0 NaN    NaT  foo
1   1 3 days  foo
2   3 5 days  foo
3   5 7 days  foo
4   7 9 days  foo

In [6]: df.rolling(window=2)['A','C'].sum()
Out[6]: 
    A    C
0 NaN  foo
1   1  foo
2   3  foo
3   5  foo
4   7  foo

In [2]: r = df.rolling(window=3)

In [3]: r.
r.A         r.C         r.corr      r.cov       r.max       r.median    r.name      r.skew      r.sum       
r.B         r.apply     r.count     r.kurt      r.mean      r.min       r.quantile  r.std       r.var       
```

do rolling/expanding/ewma ops

```
In [1]: s = Series(range(5))

In [2]: r = s.rolling(2)

I# pd.rolling_sum
In [3]: r.sum()
Out[3]: 
0   NaN
1     1
2     3
3     5
4     7
dtype: float64

# nicer repr
In [4]: r
Out[4]: Rolling [window->2,center->False,axis->0]

In [5]: e = s.expanding(min_periods=2)

# pd.expanding_sum
In [6]: e.sum()
Out[6]: 
0   NaN
1     1
2     3
3     6
4    10
dtype: float64

In [7]: em = s.ewm(com=10)

# pd.ewma
In [8]: em.mean()
Out[8]: 
0    0.000000
1    0.523810
2    1.063444
3    1.618832
4    2.189874
dtype: float64
```

and allow the various aggregation type of ops (similar to groupby)

```
In [1]: df = DataFrame({'A' : range(5), 'B' : pd.timedelta_range('1 day',periods=5), 'C' : 'foo'})

In [2]: r = df.rolling(2,min_periods=1)

In [3]: r.agg([np.sum,np.mean])
Out[3]: 
    A           B                    C     
  sum mean    sum            mean  sum mean
0   0  0.0 1 days 1 days 00:00:00  foo  foo
1   1  0.5 3 days 1 days 12:00:00  foo  foo
2   3  1.5 5 days 2 days 12:00:00  foo  foo
3   5  2.5 7 days 3 days 12:00:00  foo  foo
4   7  3.5 9 days 4 days 12:00:00  foo  foo

In [4]: r.agg({'A' : 'sum', 'B' : 'mean'})
Out[4]: 
   A               B
0  0 1 days 00:00:00
1  1 1 days 12:00:00
2  3 2 days 12:00:00
3  5 3 days 12:00:00
4  7 4 days 12:00:00
```
