### PR TITLE
BUG GH11600  - MultiIndex column level names lost when to_sparse() called

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -156,3 +156,4 @@ Bug Fixes
 - Bug in the link-time error caused by C ``inline`` functions on FreeBSD 10+ (with ``clang``) (:issue:`10510`)
 - Bug in ``DataFrame.to_csv`` in passing through arguments for formatting ``MultiIndexes``, including ``date_format`` (:issue:`7791`)
 - Bug in ``DataFrame.join()`` with ``how='right'`` producing a ``TypeError`` (:issue:`11519`)
+- Bug in ``DataFrame.to_sparse()`` loses column names for MultIndexes (:issue:`11600`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1191,7 +1191,7 @@ class DataFrame(NDFrame):
         y : SparseDataFrame
         """
         from pandas.core.sparse import SparseDataFrame
-        return SparseDataFrame(self._series, index=self.index,
+        return SparseDataFrame(self._series, index=self.index, columns=self.columns,
                                default_kind=kind,
                                default_fill_value=fill_value)
 

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -246,7 +246,7 @@ class SparseDataFrame(DataFrame):
         df : DataFrame
         """
         data = dict((k, v.to_dense()) for k, v in compat.iteritems(self))
-        return DataFrame(data, index=self.index)
+        return DataFrame(data, index=self.index,columns=self.columns)
 
     def astype(self, dtype):
         raise NotImplementedError

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -2637,35 +2637,32 @@ class TestDatetimeIndex(tm.TestCase):
                 assert_func(klass([x - op for x in s]), s - op)
 
 
-            # split by fast/slow path to test perf warning
-            off = {False:
-                   ['YearBegin', ('YearBegin', {'month': 5}),
-                    'YearEnd', ('YearEnd', {'month': 5}),
-                    'MonthBegin', 'MonthEnd', 'Week', ('Week', {'weekday': 3}),
-                    'BusinessDay', 'BDay', 'QuarterEnd', 'QuarterBegin'],
-                   PerformanceWarning:
-                   ['CustomBusinessDay', 'CDay', 'CBMonthEnd','CBMonthBegin',
-                    'BMonthBegin', 'BMonthEnd', 'BusinessHour', 'BYearBegin',
-                    'BYearEnd','BQuarterBegin', ('LastWeekOfMonth', {'weekday':2}),
-                    ('FY5253Quarter', {'qtr_with_extra_week': 1, 'startingMonth': 1,
-                                       'weekday': 2, 'variation': 'nearest'}),
-                    ('FY5253',{'weekday': 0, 'startingMonth': 2, 'variation': 'nearest'}),
-                    ('WeekOfMonth', {'weekday': 2, 'week': 2}), 'Easter',
-                    ('DateOffset', {'day': 4}), ('DateOffset', {'month': 5})]}
+            # assert these are equal on a piecewise basis
+            offsets = ['YearBegin', ('YearBegin', {'month': 5}),
+                       'YearEnd', ('YearEnd', {'month': 5}),
+                       'MonthBegin', 'MonthEnd', 'Week', ('Week', {'weekday': 3}),
+                       'BusinessDay', 'BDay', 'QuarterEnd', 'QuarterBegin',
+                       'CustomBusinessDay', 'CDay', 'CBMonthEnd','CBMonthBegin',
+                       'BMonthBegin', 'BMonthEnd', 'BusinessHour', 'BYearBegin',
+                       'BYearEnd','BQuarterBegin', ('LastWeekOfMonth', {'weekday':2}),
+                       ('FY5253Quarter', {'qtr_with_extra_week': 1, 'startingMonth': 1,
+                                          'weekday': 2, 'variation': 'nearest'}),
+                       ('FY5253',{'weekday': 0, 'startingMonth': 2, 'variation': 'nearest'}),
+                       ('WeekOfMonth', {'weekday': 2, 'week': 2}), 'Easter',
+                       ('DateOffset', {'day': 4}), ('DateOffset', {'month': 5})]
 
             for normalize in (True, False):
-                for warning, offsets in off.items():
-                    for do in offsets:
-                        if isinstance(do, tuple):
-                            do, kwargs = do
-                        else:
-                            do = do
-                            kwargs = {}
-                        op = getattr(pd.offsets,do)(5, normalize=normalize, **kwargs)
-                        with tm.assert_produces_warning(warning):
-                            assert_func(klass([x + op for x in s]), s + op)
-                            assert_func(klass([x - op for x in s]), s - op)
-                            assert_func(klass([op + x for x in s]), op + s)
+                for do in offsets:
+                    if isinstance(do, tuple):
+                        do, kwargs = do
+                    else:
+                        do = do
+                        kwargs = {}
+                    op = getattr(pd.offsets,do)(5, normalize=normalize, **kwargs)
+                    assert_func(klass([x + op for x in s]), s + op)
+                    assert_func(klass([x - op for x in s]), s - op)
+                    assert_func(klass([op + x for x in s]), op + s)
+
     # def test_add_timedelta64(self):
     #     rng = date_range('1/1/2000', periods=5)
     #     delta = rng.values[3] - rng.values[1]


### PR DESCRIPTION
closes #11600 

Fixed problem with multi-index column level names not propagating into sparse frames or back out to dense on a round trip through sparse. Includes 4 new tests to cover some relevant scenarios. Problem fixed for the conventions to_sparse path, I'm not sure about other paths where something else is passed to SparseDataSeries directly, those would be outside scope of bug.
