### PR TITLE
BUG: loc against CategoricalIndex may results in normal Index

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -105,3 +105,7 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
+
+
+
+- Bug in ``.loc`` against ``CategoricalIndex`` may result in normal ``Index`` (:issue:`11586`)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -3362,8 +3362,8 @@ class CategoricalIndex(Index, PandasDelegate):
         # filling in missing if needed
         if len(missing):
             cats = self.categories.get_indexer(target)
-            if (cats==-1).any():
 
+            if (cats==-1).any():
                 # coerce to a regular index here!
                 result = Index(np.array(self),name=self.name)
                 new_target, indexer, _ = result._reindex_non_unique(np.array(target))
@@ -3396,6 +3396,12 @@ class CategoricalIndex(Index, PandasDelegate):
         if check.any():
             new_indexer = np.arange(len(self.take(indexer)))
             new_indexer[check] = -1
+
+        cats = self.categories.get_indexer(target)
+        if not (cats == -1).any():
+            # .reindex returns normal Index. Revert to CategoricalIndex if
+            # all targets are included in my categories
+            new_target = self._shallow_copy(new_target)
 
         return new_target, indexer, new_indexer
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -984,6 +984,9 @@ class _NDFrameIndexer(object):
                 # asarray can be unsafe, NumPy strings are weird
                 keyarr = _asarray_tuplesafe(key)
 
+            if com.is_categorical_dtype(labels):
+                keyarr = labels._shallow_copy(keyarr)
+
             # have the index handle the indexer and possibly return
             # an indexer or raising
             indexer = labels._convert_list_indexer(keyarr, kind=self.name)

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -2314,6 +2314,23 @@ class TestCategoricalIndex(Base, tm.TestCase):
             actual = ci.get_indexer(finder)
             tm.assert_numpy_array_equal(expected, actual)
 
+    def test_reindex_dtype(self):
+        res, indexer = CategoricalIndex(['a', 'b', 'c', 'a']).reindex(['a', 'c'])
+        tm.assert_index_equal(res, Index(['a', 'a', 'c']), exact=True)
+        tm.assert_numpy_array_equal(indexer, np.array([0, 3, 2]))
+
+        res, indexer = CategoricalIndex(['a', 'b', 'c', 'a']).reindex(Categorical(['a', 'c']))
+        tm.assert_index_equal(res, CategoricalIndex(['a', 'a', 'c'], categories=['a', 'c']), exact=True)
+        tm.assert_numpy_array_equal(indexer, np.array([0, 3, 2]))
+
+        res, indexer = CategoricalIndex(['a', 'b', 'c', 'a'], categories=['a', 'b', 'c', 'd']).reindex(['a', 'c'])
+        tm.assert_index_equal(res, Index(['a', 'a', 'c'], dtype='object'), exact=True)
+        tm.assert_numpy_array_equal(indexer, np.array([0, 3, 2]))
+
+        res, indexer = CategoricalIndex(['a', 'b', 'c', 'a'], categories=['a', 'b', 'c', 'd']).reindex(Categorical(['a', 'c']))
+        tm.assert_index_equal(res, CategoricalIndex(['a', 'a', 'c'], categories=['a', 'c']), exact=True)
+        tm.assert_numpy_array_equal(indexer, np.array([0, 3, 2]))
+
     def test_duplicates(self):
 
         idx = CategoricalIndex([0, 0, 0], name='foo')


### PR DESCRIPTION
Closes #11586.

After the PR:

```
import pandas as pd
index = pd.CategoricalIndex(list('aabbca'), categories=list('cabe'))
df = pd.DataFrame({'A' : np.arange(6,dtype='int64')}, index=index)

# OK (not changed)
df.loc[['a', 'b']].index
# CategoricalIndex([u'a', u'a', u'a', u'b', u'b'], categories=[u'c', u'a', u'b', u'e'], ordered=False, dtype='category')

# Fixed to return Categorical Index if value exists in categories
df.loc[['a', 'b', 'e']].index
# CategoricalIndex([u'a', u'a', u'a', u'b', u'b', u'e'], categories=[u'a', u'b', u'e'], ordered=False, dtype='category')

# raise KeyError otherwise (not changed)
df.loc[['a', 'b', 'x']].index
# KeyError: 'a list-indexer must only include values that are in the categories'
```

There are separate paths when `CategoricalIndex` values (codes) are unique and not-unique and both fixed.

Also, `.reindex` intentionally returns normal `Index` when passed values are not `Categorical`, I kept the behavior as it is. If `.reindex` can always return `CategoricalIndex`, above 2 separate fixes are not required (fixing `.reindex` to return `CategoricalIndex` should work both paths).

```
# return normal Index(not changed)
df.index.reindex(['a', 'b'])
# (Index([u'a', u'a', u'a', u'b', u'b'], dtype='object'), array([0, 1, 5, 2, 3]))

# return CategoricalIndex(not changed)
df.index.reindex(pd.Categorical(['a', 'b']))
# (CategoricalIndex([u'a', u'a', u'a', u'b', u'b'], categories=[u'a', u'b'], ordered=False, dtype='category'), array([0, 1, 5, 2, 3]))
```
