### PR TITLE
CLN/COMPAT: Remove raise StopIteration syntax in SparseArray.__iter__

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -58,6 +58,7 @@ API changes
   Legacy Python syntax (``set([x, y])``) (:issue:`11215`)
 - Indexing with a null key will raise a ``TypeError``, instead of a ``ValueError`` (:issue:`11356`)
 - ``Series.sort_index()`` now correctly handles the ``inplace`` option (:issue:`11402`)
+- ``SparseArray.__iter__()`` now does not cause ``PendingDeprecationWarning`` in Python 3.5 (:issue:`11622`)
 
 - ``DataFrame.itertuples()`` now returns ``namedtuple`` objects, when possible. (:issue:`11269`)
 - ``Series.ptp`` will now ignore missing values by default (:issue:`11163`)

--- a/pandas/sparse/array.py
+++ b/pandas/sparse/array.py
@@ -274,7 +274,6 @@ to sparse
     def __iter__(self):
         for i in range(len(self)):
             yield self._get_val_at(i)
-        raise StopIteration
 
     def __getitem__(self, key):
         """

--- a/pandas/sparse/tests/test_array.py
+++ b/pandas/sparse/tests/test_array.py
@@ -4,6 +4,7 @@ from numpy import nan, ndarray
 import numpy as np
 
 import operator
+import warnings
 
 from pandas.core.series import Series
 from pandas.core.common import notnull
@@ -173,6 +174,18 @@ class TestSparseArray(tm.TestCase):
 
         _check_roundtrip(self.arr)
         _check_roundtrip(self.zarr)
+
+    def test_generator_warnings(self):
+        sp_arr = SparseArray([1, 2, 3])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings(action='always',
+                                    category=DeprecationWarning)
+            warnings.filterwarnings(action='always',
+                                    category=PendingDeprecationWarning)
+            for _ in sp_arr:
+                pass
+            assert len(w)==0
+
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
closes #11108 
