### PR TITLE
Bug#11637 fix to_csv

### DIFF
--- a/doc/source/whatsnew/v0.17.1.txt
+++ b/doc/source/whatsnew/v0.17.1.txt
@@ -164,6 +164,7 @@ Bug Fixes
 - Bug in ``squeeze()`` with zero length arrays (:issue:`11230`, :issue:`8999`)
 - Bug in ``describe()`` dropping column names for hierarchical indexes (:issue:`11517`)
 - Bug in ``DataFrame.pct_change()`` not propagating ``axis`` keyword on ``.fillna`` method (:issue:`11150`)
+- Bug in ``.to_csv()`` incorrect output when a mix of integer and string column names passed as columns parameter (:issue:`11637`)
 
 
 

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -1327,7 +1327,7 @@ class CSVFormatter(object):
                                             date_format=date_format,
                                             quoting=self.quoting)
             else:
-                cols = np.asarray(list(cols))
+                cols = list(cols)
             self.obj = self.obj.loc[:, cols]
 
         # update columns to include possible multiplicity of dupes
@@ -1339,7 +1339,7 @@ class CSVFormatter(object):
                                         date_format=date_format,
                                         quoting=self.quoting)
         else:
-            cols = np.asarray(list(cols))
+            cols = list(cols)
 
         # save it
         self.cols = cols

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -39,6 +39,7 @@ from pandas.parser import CParserError
 from pandas.util.misc import is_little_endian
 
 from pandas.util.testing import (assert_almost_equal,
+                                 assert_equal,
                                  assert_numpy_array_equal,
                                  assert_series_equal,
                                  assert_frame_equal,
@@ -6986,6 +6987,15 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             df.to_csv(path, index=False)
             result = read_csv(path)
             assert_frame_equal(df,result)
+
+    def test_to_csv_with_mix_columns(self):
+        #GH11637, incorrect output when a mix of integer and string column
+        # names passed as columns parameter in to_csv
+
+        df = DataFrame({0: ['a', 'b', 'c'],
+                        1: ['aa', 'bb', 'cc']})
+        df['test'] = 'txt'
+        assert_equal(df.to_csv(), df.to_csv(columns=[0, 1, 'test']))
 
     def test_to_csv_headers(self):
         # GH6186, the presence or absence of `index` incorrectly


### PR DESCRIPTION
This is a fix to Bug #11637. 
Error Description : incorrect output when a mix of integer and string column names passed as columns parameter in to_csv(). 
[format.py](https://github.com/pydata/pandas/blob/master/pandas/core/format.py#L1330) is the cause of this discrepancy. 

Please review .
