### PR TITLE
WIP: Better formatting for .set_precision

### DIFF
--- a/pandas/core/style.py
+++ b/pandas/core/style.py
@@ -259,7 +259,6 @@ class Styler(object):
                     precision=precision, table_styles=table_styles,
                     caption=caption, table_attributes=self.table_attributes)
 
-<<<<<<< HEAD
     def format(self, formatter, subset=None):
         '''
         formatter is either an `a` or a dict `{column_name: a}` where
@@ -301,10 +300,6 @@ class Styler(object):
             for i, j in locs:
                 self._display_funcs[(i, j)] = lambda x: formatter.format(x)
         return self
-=======
-    def format(self, columns=None):
-        pass
->>>>>>> c02a4f4... WIP: display_format for style
 
     def render(self):
         """

--- a/pandas/core/style.py
+++ b/pandas/core/style.py
@@ -263,8 +263,8 @@ class Styler(object):
         '''
         formatter is either an `a` or a dict `{column_name: a}` where
         a is one of
-            - str: wrapped in: ``a.format(x)``
-            - callable: called with x.
+            - str: wrapped in: `a`.format(x)`
+            - callable: called with x and the column and row index of x.
 
         now `.set_precision(2)` becomes
 
@@ -275,9 +275,6 @@ class Styler(object):
         from itertools import product
         from collections.abc import MutableMapping
 
-        just_row_subset = (com.is_list_like(subset) and
-                           not isinstance(subset, tuple))
-
         if issubclass(type(formatter), MutableMapping):
             # formatter is a dict
             for col, col_formatter in formatter.items():
@@ -286,9 +283,7 @@ class Styler(object):
                 if not callable(col_formatter):
                     formatter_func = lambda x: col_formatter.format(x)
 
-                if subset is not None and just_row_subset:
-                    locs = self.data.index.get_indexer_for(subset)
-                elif subset is not None:
+                if subset is not None:
                     locs = self.data.index.get_indexer_for(subset)
                 else:
                     locs = range(len(self.data))

--- a/pandas/core/style.py
+++ b/pandas/core/style.py
@@ -234,8 +234,9 @@ class Styler(object):
                 cs.extend(cell_context.get("data", {}).get(r, {}).get(c, []))
                 row_d = {"type": "td", "value": self.data.iloc[r][c],
                          "class": " ".join(cs), "id": "_".join(cs[1:])}
-                if c in self.precision:
-                    row_d['precision'] = self.precision[c]
+                
+                if col in self.precision:
+                    row_d['precision'] = self.precision[col]
                 row_es.append(row_d)
                 props = []
                 for x in ctx[r, c]:
@@ -420,7 +421,7 @@ class Styler(object):
                           kwargs))
         return self
 
-    def set_precision(self, precision=None, **kwargs):
+    def set_precision(self, precision=None, column_formats={}):
         """
         Set the precision used to render.
 
@@ -435,7 +436,7 @@ class Styler(object):
         self
         """
         
-        if not kwargs and precision is None:
+        if not column_formats and precision is None:
             # reset everything
             self.precision = {'__default__': pd.options.display.precision}
             return self
@@ -445,8 +446,8 @@ class Styler(object):
         elif isinstance(precision, numbers.Integral):
             self.precision['__default__'] = precision
 
-        for k in kwargs:
-            self.precision[k] = kwargs[k]
+        for k in column_formats:
+            self.precision[k] = column_formats[k]
 
         return self
 

--- a/pandas/core/style.py
+++ b/pandas/core/style.py
@@ -117,7 +117,7 @@ class Styler(object):
                         {% if c.precision is defined and c.precision is number %}
                             {{c.value|round(c.precision)}}
                         {% elif c.precision is defined and c.precision is string %}
-                            {{str.format(c.precision, c.value)}}
+                            {{c.precision.format(c.value)}}
                         {% else %}
                             {{c.value|round(precision.__default__)}}
                         {% endif %}

--- a/pandas/core/style.py
+++ b/pandas/core/style.py
@@ -119,7 +119,7 @@ class Styler(object):
                         {% elif c.precision is defined and c.precision is string %}
                             {{str.format(c.precision, c.value)}}
                         {% else %}
-                            {{c.value|round(precision)}}
+                            {{c.value|round(precision.__default__)}}
                         {% endif %}
                     {% else %}
                         {{c.value}}

--- a/pandas/core/style.py
+++ b/pandas/core/style.py
@@ -442,7 +442,7 @@ class Styler(object):
 
         if precision is None:
             self.precision['__default__'] = pd.options.display.precision
-        elif isinstance(precision, types.Integral):
+        elif isinstance(precision, numbers.Integral):
             self.precision['__default__'] = precision
 
         for k in kwargs:

--- a/pandas/core/style.py
+++ b/pandas/core/style.py
@@ -421,7 +421,7 @@ class Styler(object):
                           kwargs))
         return self
 
-    def set_precision(self, precision=None, column_formats={}):
+    def set_precision(self, precision=None, subsets={}):
         """
         Set the precision used to render.
 
@@ -436,7 +436,7 @@ class Styler(object):
         self
         """
         
-        if not column_formats and precision is None:
+        if not subsets and precision is None:
             # reset everything
             self.precision = {'__default__': pd.options.display.precision}
             return self
@@ -446,8 +446,8 @@ class Styler(object):
         elif isinstance(precision, numbers.Integral):
             self.precision['__default__'] = precision
 
-        for k in column_formats:
-            self.precision[k] = column_formats[k]
+        for k in subsets:
+            self.precision[k] = subsets[k]
 
         return self
 


### PR DESCRIPTION
closes #11656 

I found some extra time behind the sofa and started working on this. I made quite a few additions but by default everything should work as it did.
- just calling `.set_precision` with an `int` will truncate all columns to that many decimal places as before
- precision can be set per column as an extra `dict` to `.set_precision`
- the precision values can be either `int`s or valid python `str.format` strings
  - I wanted to add this to allow formats like `{:.2e}` and possibly some string/date manipulations
  - the `.set_precision` should perhaps be called `set_format` (or `format_cells`) as a result
- all formatting can be reset by calling `.set_precision()` (no args)

_what's missing?_
- the documentation needs to be updated to reflect these changes (if you're happy with what's here I'll move on to updating the docs)
- should leave the index alone and just format the data columns
- tests?
- support for `pd.IndexSlice` for subsets?

---

```
import itertools
import pandas as pd
import numpy as np

jobs = itertools.product(['a', 'b', 'c', 'd'], np.arange(1e-4, 1e-3, .0003), range(10))
rows = []
for v, v2, itr in jobs:
    rows.append({'param_1': v, 'param_2': v2, 'iter': itr,
                 'score_1': np.random.randint(0, 100, size=(1,))[0],
                 'score_2': np.random.rand(1, )[0]})
df_multi = pd.DataFrame(rows)
agg = df_multi.groupby(by=['param_1', 'param_2'])[['score_1', 'score_2']].agg(['mean', 'sem'])
```

---

printing with just the defaults
![screen shot 2015-11-20 at 18 56 56](https://cloud.githubusercontent.com/assets/1055719/11307455/96b42fc4-8fb8-11e5-8a52-0a1ae860f57e.png)

crazy awesome new formatting (forget that the `kwarg` is called `column_formats` that's been changed to `subsets`)

![screen shot 2015-11-20 at 18 59 09](https://cloud.githubusercontent.com/assets/1055719/11307501/e6e04a0a-8fb8-11e5-873c-7381e14a3099.png)
