### PR TITLE
API: DataFrame.to_csv formatting parameters for float indexes

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -325,6 +325,7 @@ Bug Fixes
 
 
 - Bug in timezone info lost when broadcasting scalar datetime to ``DataFrame`` (:issue:`11682`)
+
 - Bug in ``Index`` creation from ``Timestamp`` with mixed tz coerces to UTC (:issue:`11488`)
 - Bug in ``to_numeric`` where it does not raise if input is more than one dimension (:issue:`11776`)
 
@@ -347,5 +348,7 @@ Bug Fixes
 - Bug in ``read_excel`` failing to raise ``NotImplemented`` error when keywords `parse_dates` and `date_parser` are provided (:issue:`11544`)
 
 - Bug in ``read_sql`` with pymysql connections failing to return chunked data (:issue:`11522`)
+
+- Bug in ``.to_csv`` ignoring formatting parameters ``decimal``, ``na_rep``, ``float_format`` for float indexes (:issue:`11553`)
 
 - Bug in ``DataFrame`` when masking an empty ``DataFrame`` (:issue:`11859`)

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1390,28 +1390,12 @@ class FloatBlock(FloatOrComplexBlock):
         values = self.values
         if slicer is not None:
             values = values[:, slicer]
-        mask = isnull(values)
 
-        formatter = None
-        if float_format and decimal != '.':
-            formatter = lambda v : (float_format % v).replace('.',decimal,1)
-        elif decimal != '.':
-            formatter = lambda v : ('%g' % v).replace('.',decimal,1)
-        elif float_format:
-            formatter = lambda v : float_format % v
-
-        if formatter is None and not quoting:
-            values = values.astype(str)
-        else:
-            values = np.array(values, dtype='object')
-
-        values[mask] = na_rep
-        if formatter:
-            imask = (~mask).ravel()
-            values.flat[imask] = np.array(
-                [formatter(val) for val in values.ravel()[imask]])
-
-        return values
+        from pandas.core.format import FloatArrayFormatter
+        formatter = FloatArrayFormatter(values, na_rep=na_rep,
+                                        float_format=float_format,
+                                        decimal=decimal, quoting=quoting)
+        return formatter.get_formatted_data()
 
     def should_store(self, value):
         # when inserting a column should not coerce integers to floats


### PR DESCRIPTION
Fix issue #11553 

Two things:

1) I've created a `Float64Index._format_native_types` method which is a copy-paste of  `FloatBlock.to_native_types`. I would have preferred to call the latter directly, but I'm not sure what the `placement` parameter of the `FloatBlock` constructor means. I guess I doesn't really matters, since I could put whatever value and it should work (I think), and my hesitation a bit unfounded, but I don't know if it would be really a clean solution. Maybe someone can think of a more elegant way?

2) Since a `Float64Index` containing only NaNs collapses when part of a multi-index, its NaNs values would not be converted using `na_rep`, so I had to hack a solution. I put a comment in the relevant part. I'm not quite convinced myself of the elegance of the solution, though.

What do you think?
