### PR TITLE
Use tz.gettz() instead of zoneinfo.gettz()

### DIFF
--- a/pandas/util/print_versions.py
+++ b/pandas/util/print_versions.py
@@ -89,7 +89,7 @@ def show_versions(as_json=False):
         ("sqlalchemy", lambda mod: mod.__version__),
         ("pymysql", lambda mod: mod.__version__),
         ("psycopg2", lambda mod: mod.__version__),
-        ("Jinja2", lambda mod: mod.__version__)
+        ("jinja2", lambda mod: mod.__version__)
     ]
 
     deps_blob = list()


### PR DESCRIPTION
zoneinfo.gettz() seems to have problems (1 & 2) on system which do not install
the zoninfo tarball (e.g. Debian, Gentoo and Fedora) but rely on the system
zoneinfo files. This results in test failures (3 & 4)
tz.gettz() doesn't suffer from this problem.

1 https://github.com/dateutil/dateutil/issues/8
2 https://github.com/dateutil/dateutil/issues/11
3 https://github.com/pydata/pandas/issues/9059
4 https://github.com/pydata/pandas/issues/8639

Signed-off-by: Justin Lecher jlec@gentoo.org
