### PR TITLE
Use lower case to load jinja2

### DIFF
--- a/pandas/util/print_versions.py
+++ b/pandas/util/print_versions.py
@@ -89,7 +89,7 @@ def show_versions(as_json=False):
         ("sqlalchemy", lambda mod: mod.__version__),
         ("pymysql", lambda mod: mod.__version__),
         ("psycopg2", lambda mod: mod.__version__),
-        ("Jinja2", lambda mod: mod.__version__)
+        ("jinja2", lambda mod: mod.__version__)
     ]
 
     deps_blob = list()


### PR DESCRIPTION
`import imp; imp.load_module("Jinja2", *imp.find_module("Jinja2"))`

raises `ImportError`, where as the lowercase version works fine.

Signed-off-by: Justin Lecher jlec@gentoo.org
