### PR TITLE
BUG: Index does not inherit existing Index or DatatetimeIndex object …

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -238,4 +238,6 @@ Bug Fixes
 
 - Bug in ``df.replace`` while replacing value in mixed dtype ``Dataframe`` (:issue:`11698`)
 
+- Bug in ``Index`` prevent copying name of passed ``Index`` or ``DatetimeIndex`` objects, when a new name is not provided (:issue:`11193`)
+
 - Bug in ``read_excel`` failing to read any non-empty sheets when empty sheets exist and ``sheetname=None`` (:issue:`11711`)

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -120,6 +120,9 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
     def __new__(cls, data=None, dtype=None, copy=False, name=None, fastpath=False,
                 tupleize_cols=True, **kwargs):
 
+        if name is None and hasattr(data, 'name'):
+            name = data.name
+
         # no class inference!
         if fastpath:
             return cls._simple_new(data, name)
@@ -128,6 +131,7 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
             return CategoricalIndex(data, copy=copy, name=name, **kwargs)
 
         if isinstance(data, (np.ndarray, Index, ABCSeries)):
+
             if issubclass(data.dtype.type, np.datetime64) or is_datetimetz(data):
                 from pandas.tseries.index import DatetimeIndex
                 result = DatetimeIndex(data, copy=copy, name=name, **kwargs)
@@ -4052,6 +4056,8 @@ class MultiIndex(Index):
         # compat with Index
         if name is not None:
             names = name
+#        elif cls.names is not None:
+#            names = cls.names
         if levels is None or labels is None:
             raise TypeError("Must pass both levels and labels")
         if len(levels) != len(labels):

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -415,6 +415,7 @@ class TestIndexOps(Ops):
 
                 # resets name from Index
                 expected_index = pd.Index(o[::-1])
+                expected_index.name = None
 
                 # attach name to klass
                 o = o.repeat(range(1, len(o) + 1))
@@ -424,16 +425,18 @@ class TestIndexOps(Ops):
 
                 # resets name from Index
                 expected_index = pd.Index(o[::-1])
+                expected_index.name = None
 
                 # attach name to klass
                 o = o.repeat(range(1, len(o) + 1))
                 o.name = 'a'
 
             # don't test boolean
-            elif isinstance(o,Index) and o.is_boolean():
+            elif isinstance(o, Index) and o.is_boolean():
                 continue
             elif isinstance(o, Index):
                 expected_index = pd.Index(values[::-1])
+                expected_index.name = None
                 o = o.repeat(range(1, len(o) + 1))
                 o.name = 'a'
             else:


### PR DESCRIPTION
This PR is meant to fix issue #11193 
The issue prevent, when creating a new `Index` object based on a passed `Index` or `DatetimeIndex` object, to inherit the existing `Index` name if a new name is not provided. 

I've also created two unit test which test the new behaviour on both cases (passing an `Index` or `DatetimeIndex` object) and added a comment in the whatsnew documentation.
