### PR TITLE
BUG/API: Index creation with different tz coerces DatetimeIndex

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -187,7 +187,6 @@ Bug Fixes
 - Bug in timezone info lost when broadcasting scalar datetime to ``DataFrame`` (:issue:`11682`)
 
 
-
 - Bug in parsing timezone offset strings with non-zero minutes (:issue:`11708`)
 
 
@@ -197,3 +196,5 @@ Bug Fixes
 - Bug in ``pd.rolling_median`` where memory allocation failed even with sufficient memory (:issue:`11696`)
 
 - Bug in ``df.replace`` while replacing value in mixed dtype ``Dataframe`` (:issue:`11698`)
+- Bug in ``Index`` creation from ``Timestamp`` with mixed tz coerces to UTC (:issue:`11488`)
+

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -179,8 +179,13 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
                 elif inferred != 'string':
                     if (inferred.startswith('datetime') or
                         tslib.is_timestamp_array(subarr)):
-                        from pandas.tseries.index import DatetimeIndex
-                        return DatetimeIndex(subarr, copy=copy, name=name, **kwargs)
+
+                        if (lib.is_datetime_with_singletz_array(subarr) or
+                            'tz' in kwargs):
+                            # only when subarr has the same tz
+                            from pandas.tseries.index import DatetimeIndex
+                            return DatetimeIndex(subarr, copy=copy, name=name, **kwargs)
+
                     elif (inferred.startswith('timedelta') or
                           lib.is_timedelta_array(subarr)):
                         from pandas.tseries.tdi import TimedeltaIndex

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -718,7 +718,11 @@ def assert_attr_equal(attr, left, right, obj='Attributes'):
         # np.nan
         return True
 
-    result = left_attr == right_attr
+    try:
+        result = left_attr == right_attr
+    except TypeError:
+        # datetimetz on rhs may raise TypeError
+        result = False
     if not isinstance(result, bool):
         result = result.all()
 


### PR DESCRIPTION
Closes #11488.

Based on the type check added in #11588, the change affects to fewer functions than I originally thought.
