### PR TITLE
BUG: GH11697 where memory allocation failed in rolling_median

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -190,3 +190,4 @@ Bug Fixes
 
 
 - Bug in ``.loc`` result with duplicated key may have ``Index`` with incorrect dtype (:issue:`11497`)
+- Bug in ``pd.rolling_median`` where memory allocation failed even with sufficient memory (:issue:`11696`)

--- a/pandas/src/skiplist.h
+++ b/pandas/src/skiplist.h
@@ -60,7 +60,7 @@ typedef struct {
 } skiplist_t;
 
 static PANDAS_INLINE double urand(void) {
-  return rand() / ((double) RAND_MAX + 1);
+  return ((double) rand() + 1) / ((double) RAND_MAX + 2);
 }
 
 static PANDAS_INLINE int int_min(int a, int b) {

--- a/pandas/stats/tests/test_moments.py
+++ b/pandas/stats/tests/test_moments.py
@@ -1919,6 +1919,12 @@ class TestMomentsConsistency(Base):
         x = mom.rolling_median(series, window=1, freq='D')
         assert_series_equal(expected, x)
 
+    def test_rolling_median_memory_error(self):
+        # GH11722
+        n = 20000
+        mom.rolling_median(Series(np.random.randn(n)), window=2, center=False)
+        mom.rolling_median(Series(np.random.randn(n)), window=2, center=False)
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
closes #11697 
thanks @ajspeck
