### PR TITLE
ENH: Add support for s3 in read_excel #11447

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -32,6 +32,7 @@ Other enhancements
 ^^^^^^^^^^^^^^^^^^
 
 - Handle truncated floats in SAS xport files (:issue:`11713`)
+- ``read_excel`` now supports s3 urls of the format ``s3://bucketname/filename`` (:issue:`11447`)
 
 .. _whatsnew_0180.enhancements.rounding:
 

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from pandas.core.frame import DataFrame
 from pandas.io.parsers import TextParser
-from pandas.io.common import _is_url, _urlopen, _validate_header_arg
+from pandas.io.common import _is_url, _urlopen, _validate_header_arg, get_filepath_or_buffer, _is_s3_url
 from pandas.tseries.period import Period
 from pandas import json
 from pandas.compat import (map, zip, reduce, range, lrange, u, add_metaclass,
@@ -199,7 +199,10 @@ class ExcelFile(object):
             raise ValueError("Unknown engine: %s" % engine)
 
         if isinstance(io, compat.string_types):
-            if _is_url(io):
+            if _is_s3_url(io):
+                buffer, _, _ = get_filepath_or_buffer(io)
+                self.book = xlrd.open_workbook(file_contents=buffer.read())
+            elif _is_url(io):
                 data = _urlopen(io).read()
                 self.book = xlrd.open_workbook(file_contents=data)
             else:

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -65,6 +65,13 @@ def _skip_if_no_excelsuite():
     _skip_if_no_openpyxl()
 
 
+def _skip_if_no_boto():
+    try:
+        import boto  # NOQA
+    except ImportError:
+        raise nose.SkipTest('boto not installed, skipping')
+
+
 _seriesd = tm.getSeriesData()
 _tsd = tm.getTimeSeriesData()
 _frame = DataFrame(_seriesd)[:10]
@@ -425,6 +432,15 @@ class XlrdTests(ReadingTestsBase):
     def test_read_from_http_url(self):
         url = ('https://raw.github.com/pydata/pandas/master/'
                'pandas/io/tests/data/test1' + self.ext)
+        url_table = read_excel(url)
+        local_table = self.get_exceldf('test1')
+        tm.assert_frame_equal(url_table, local_table)
+
+    @tm.network(check_before_test=True)
+    def test_read_from_s3_url(self):
+        _skip_if_no_boto()
+
+        url = ('s3://pandas-test/test1' + self.ext)
         url_table = read_excel(url)
         local_table = self.get_exceldf('test1')
         tm.assert_frame_equal(url_table, local_table)


### PR DESCRIPTION
closes #11447 

Updated excel.py to use pandas.io.common.get_filepath_or_buffer (handles s3 urls) instead of urlopen, only when _is_s3_url returns true.    This was the minimally invasive change.
