### PR TITLE
TST in .drop and .groupby for dataframes with multi-indexed columns

### DIFF
--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -1092,7 +1092,7 @@ class MultiIndex(Index):
                 elif is_bool_indexer(loc):
                     if self.lexsort_depth == 0:
                         warnings.warn('dropping on a non-lexsorted multi-index'
-                                      'without a level parameter may impact '
+                                      ' without a level parameter may impact '
                                       'performance.',
                                       PerformanceWarning,
                                       stacklevel=2)

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -114,6 +114,29 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
         df.drop(labels=df[df.b > 0].index, inplace=True)
         assert_frame_equal(df, expected)
 
+    def test_drop_multiindex_not_lexsorted(self):
+        # GH 11640
+
+        # define the lexsorted version
+        lexsorted_mi = MultiIndex.from_tuples(
+            [('a', ''), ('b1', 'c1'), ('b2', 'c2')], names=['b', 'c'])
+        lexsorted_df = DataFrame([[1, 3, 4]], columns=lexsorted_mi)
+        self.assertTrue(lexsorted_df.columns.is_lexsorted())
+
+        # define the non-lexsorted version
+        not_lexsorted_df = DataFrame(columns=['a', 'b', 'c', 'd'],
+                                        data=[[1, 'b1', 'c1', 3],
+                                              [1, 'b2', 'c2', 4]])
+        not_lexsorted_df = not_lexsorted_df.pivot_table(
+            index='a', columns=['b', 'c'], values='d')
+        not_lexsorted_df = not_lexsorted_df.reset_index()
+        self.assertFalse(not_lexsorted_df.columns.is_lexsorted())
+
+        # compare the results
+        tm.assert_frame_equal(lexsorted_df, not_lexsorted_df)
+        tm.assert_frame_equal(lexsorted_df.drop('a', axis=1),
+                              not_lexsorted_df.drop('a', axis=1))
+
     def test_reindex(self):
         newFrame = self.frame.reindex(self.ts1.index)
 

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -4198,6 +4198,29 @@ class TestGroupBy(tm.TestCase):
 
         tm.assert_frame_equal(res, exp)
 
+    def test_groupby_multiindex_not_lexsorted(self):
+        # GH 11640
+
+        # define the lexsorted version
+        lexsorted_mi = MultiIndex.from_tuples(
+            [('a', ''), ('b1', 'c1'), ('b2', 'c2')], names=['b', 'c'])
+        lexsorted_df = DataFrame([[1, 3, 4]], columns=lexsorted_mi)
+        self.assertTrue(lexsorted_df.columns.is_lexsorted())
+
+        # define the non-lexsorted version
+        not_lexsorted_df = DataFrame(columns=['a', 'b', 'c', 'd'],
+                                     data=[[1, 'b1', 'c1', 3],
+                                           [1, 'b2', 'c2', 4]])
+        not_lexsorted_df = not_lexsorted_df.pivot_table(
+            index='a', columns=['b', 'c'], values='d')
+        not_lexsorted_df = not_lexsorted_df.reset_index()
+        self.assertFalse(not_lexsorted_df.columns.is_lexsorted())
+
+        # compare the results
+        tm.assert_frame_equal(lexsorted_df, not_lexsorted_df)
+        tm.assert_frame_equal(lexsorted_df.groupby('a').mean(),
+                              not_lexsorted_df.groupby('a').mean())
+
     def test_groupby_levels_and_columns(self):
         # GH9344, GH9049
         idx_names = ['x', 'y']


### PR DESCRIPTION
## Bug 1 [edit: issues #11640 and #12078, fixed by PR #12158 but not entirely tested]

There was a bug deeply hidden in `pandas/core/index.py`, where it was assumed that the `.get_loc` method of an index would only return an integer or a slice, while it can also return a mask.

Simply correcting that bug has two consequences:
- now for a dataframe `df` with multi-indexed columns, `df.drop('a', axis=1)` works if `df['a']` returns something, e.g. if the column `('a', '')` exists
- likewise, `df.groupby('a')` also works in that case

Example:

```
In [2]: df = pd.DataFrame(columns=['a','b','c','d'], data=[[1,'b1','c1',3], [1,'b2','c2',4]])

In [3]: dg = df.pivot_table(index='a', columns=['b','c'], values='d').reset_index()

In [4]: dg
Out[4]: 
b  a b1 b2
c    c1 c2
0  1  3  4

In [5]: dg['a']
Out[5]: 
0    1
Name: a, dtype: int64

In [8]: dg.drop('a', axis=1)
Out[8]: 
b b1 b2
c c1 c2
0  3  4

In [9]: dg.groupby('a').mean()
Out[9]: 
b b1 b2
c c1 c2
a      
1  3  4
```
## Bug 2 [edit: #11741, solved by PR #12063]

I also correct a little bug I mentioned in the talk on issue #11640: `.groupby` failed to raise a `KeyError` for a non-existing column when there was only one row:

```
In [6]: dg.groupby('z').mean()
Out[6]: 
b  a b1 b2
c    c1 c2
z  1  3  4
```

Now we do have:

```
In [4]: dg.groupby('z').mean()
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
...
KeyError: 'z'
```
