### PR TITLE
DOC: Remove infer_types from the documentation of read_html GH 11764

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1790,12 +1790,6 @@ as well)
 
    dfs = read_html(url, skiprows=range(2))
 
-Don't infer numeric and date types
-
-.. code-block:: python
-
-   dfs = read_html(url, infer_types=False)
-
 Specify an HTML attribute
 
 .. code-block:: python


### PR DESCRIPTION
Remove infer_types from read_html.

Closes #11764
