### PR TITLE
BUG: [GH 11738] Fix for end_time when multiple of a frequency is requested

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ scikits
 # Performance Testing #
 #######################
 asv_bench/
+mytests/
 
 # Documentation generated files #
 #################################

--- a/pandas/src/period.pyx
+++ b/pandas/src/period.pyx
@@ -889,7 +889,8 @@ cdef class Period(object):
             ordinal = self.ordinal
         else:
             # freq.n can't be negative or 0
-            ordinal = (self + self.freq.n).start_time.value - 1
+            # ordinal = (self + self.freq.n).start_time.value - 1
+            ordinal = (self + 1).start_time.value - 1
         return Timestamp(ordinal)
 
     def to_timestamp(self, freq=None, how='start', tz=None):

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -566,19 +566,25 @@ class TestPeriodProperties(tm.TestCase):
         xp = _ex(2012, 2, 1)
         self.assertEqual(xp, p.end_time)
 
-        xp = _ex(2012, 1, 2)
         p = Period('2012', freq='D')
-        self.assertEqual(p.end_time, xp)
-
-        xp = _ex(2012, 1, 1, 1)
-        p = Period('2012', freq='H')
-        self.assertEqual(p.end_time, xp)
-
-        xp = _ex(2012, 1, 3)
-        self.assertEqual(Period('2012', freq='B').end_time, xp)
-
         xp = _ex(2012, 1, 2)
-        self.assertEqual(Period('2012', freq='W').end_time, xp)
+        self.assertEqual(xp, p.end_time)
+
+        p = Period('2012', freq='H')
+        xp = _ex(2012, 1, 1, 1)
+        self.assertEqual(xp, p.end_time)
+
+        p = Period('2012', freq='B')
+        xp = _ex(2012, 1, 3)
+        self.assertEqual(xp, p.end_time)
+
+        p = Period('2012', freq='W')
+        xp = _ex(2012, 1, 2)
+        self.assertEqual(xp, p.end_time)
+
+        p = Period('2012', freq='15D')
+        xp = _ex(2012, 1, 16)
+        self.assertEqual(xp, p.end_time)
 
         p = Period('NaT', freq='W')
         self.assertTrue(p.end_time is tslib.NaT)


### PR DESCRIPTION
closes #11738 
1. Added a new test with the multiple of a frequency. 
2. Rearranged some tests to improve readability of the code.
