### PR TITLE
BUG: Fixed DataFrame info() for duplicated columns, GH11761

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -196,3 +196,9 @@ Bug Fixes
 - Bug in ``pd.rolling_median`` where memory allocation failed even with sufficient memory (:issue:`11696`)
 
 - Bug in ``df.replace`` while replacing value in mixed dtype ``Dataframe`` (:issue:`11698`)
+
+
+
+
+
+- Bug in ``DataFrame.info`` when duplicated column names exist (:issue:`11761`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1655,7 +1655,7 @@ class DataFrame(NDFrame):
 
             dtypes = self.dtypes
             for i, col in enumerate(self.columns):
-                dtype = dtypes[col]
+                dtype = dtypes.iloc[i]
                 col = com.pprint_thing(col)
 
                 count = ""

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -7559,6 +7559,18 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
                           columns=['a', 'a', 'b', 'b'])
         frame.info(buf=io)
 
+    def test_info_duplicate_columns_shows_correct_dtypes(self):
+        # GH11761
+        io = StringIO()
+
+        frame = DataFrame([[1, 2.0]],
+                          columns=['a', 'a'])
+        frame.info(buf=io)
+        io.seek(0)
+        lines = io.readlines()
+        self.assertEqual('a    1 non-null int64\n', lines[3])
+        self.assertEqual('a    1 non-null float64\n', lines[4])
+
     def test_info_shows_column_dtypes(self):
         dtypes = ['int64', 'float64', 'datetime64[ns]', 'timedelta64[ns]',
                   'complex128', 'object', 'bool']


### PR DESCRIPTION
See #11761.
