### PR TITLE
BUG: Parsing offset strings with non-zero minutes was incorrect

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -187,7 +187,7 @@ Bug Fixes
 
 
 
-
+- Bug in parsing timezone offset strings with non-zero minutes (:issue:`11708`)
 
 
 

--- a/pandas/src/datetime/np_datetime_strings.c
+++ b/pandas/src/datetime/np_datetime_strings.c
@@ -869,7 +869,7 @@ parse_timezone:
         if (out_local != NULL) {
             *out_local = 1;
             // Unlike NumPy, do not change internal value to local time
-            *out_tzoffset = 60 * offset_hour - offset_minute;
+            *out_tzoffset = 60 * offset_hour + offset_minute;
         }
     }
 

--- a/pandas/tests/test_tseries.py
+++ b/pandas/tests/test_tseries.py
@@ -10,7 +10,6 @@ import pandas.lib as lib
 import pandas._period as period
 import pandas.algos as algos
 from pandas.core import common as com
-from pandas.tseries.holiday import Holiday, SA, next_monday,USMartinLutherKingJr,USMemorialDay,AbstractHolidayCalendar
 import datetime
 from pandas import DateOffset
 
@@ -693,40 +692,6 @@ class TestPeriodField(tm.TestCase):
 
     def test_get_period_field_array_raises_on_out_of_range(self):
         self.assertRaises(ValueError, period.get_period_field_arr, -1, np.empty(1), 0)
-
-class TestFederalHolidayCalendar(tm.TestCase):
-
-    # Test for issue 10278
-    def test_no_mlk_before_1984(self):
-        class MLKCalendar(AbstractHolidayCalendar):
-            rules=[USMartinLutherKingJr]
-        holidays = MLKCalendar().holidays(start='1984', end='1988').to_pydatetime().tolist()
-        # Testing to make sure holiday is not incorrectly observed before 1986
-        self.assertEqual(holidays, [datetime.datetime(1986, 1, 20, 0, 0), datetime.datetime(1987, 1, 19, 0, 0)])
-
-    def test_memorial_day(self):
-        class MemorialDay(AbstractHolidayCalendar):
-            rules=[USMemorialDay]
-        holidays = MemorialDay().holidays(start='1971', end='1980').to_pydatetime().tolist()
-        # Fixes 5/31 error and checked manually against wikipedia
-        self.assertEqual(holidays, [datetime.datetime(1971, 5, 31, 0, 0), datetime.datetime(1972, 5, 29, 0, 0),
-            datetime.datetime(1973, 5, 28, 0, 0), datetime.datetime(1974, 5, 27, 0, 0),
-            datetime.datetime(1975, 5, 26, 0, 0), datetime.datetime(1976, 5, 31, 0, 0),
-            datetime.datetime(1977, 5, 30, 0, 0), datetime.datetime(1978, 5, 29, 0, 0),
-            datetime.datetime(1979, 5, 28, 0, 0)])
-
-
-
-
-class TestHolidayConflictingArguments(tm.TestCase):
-
-    # GH 10217
-
-    def test_both_offset_observance_raises(self):
-
-        with self.assertRaises(NotImplementedError) as cm:
-            h = Holiday("Cyber Monday", month=11, day=1,
-                        offset=[DateOffset(weekday=SA(4))], observance=next_monday)
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
Closes #11708

Minutes needed to be added to the hour offset rather than subtracted.
