### PR TITLE
BUG/API: QuarterBegin n=0 #11406

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -89,12 +89,40 @@ In addition, ``.round()`` will be available thru the ``.dt`` accessor of ``Serie
 Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Bug in QuarterBegin with n=0
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+In previous versions, the behavior of the QuarterBegin offset was inconsistent
+depending on the date when the ``n`` parameter was 0.
 
+The general semantics of anchored offsets for ``n=0`` is to not move the date
+when it is an anchor point (e.g., a quarter start date), and otherwise roll
+forward to the next anchor point.
 
+.. ipython:: python
 
+   d = pd.Timestamp('2014-02-01')
+   d
+   d + pd.offsets.QuarterBegin(n=0, startingMonth=2)
+   d + pd.offsets.QuarterBegin(n=0, startingMonth=1)
 
+For the ``QuarterBegin`` offset in previous versions, the date would be rolled
+*backwards* if date was in the same month as the quarter start date.
 
+.. code-block:: python
+
+   In [3]: d = pd.Timestamp('2014-02-15')
+
+   In [4]: d + pd.offsets.QuarterBegin(n=0, startingMonth=2)
+   Out[4]: Timestamp('2014-02-01 00:00:00')
+
+This behavior has been corrected in version 0.18.0, which is consistent with
+other anchored offsets like ``MonthBegin`` and ``YearBegin``.
+
+.. ipython:: python
+
+   d = pd.Timestamp('2014-02-15')
+   d + pd.offsets.QuarterBegin(n=0, startingMonth=2)
 
 
 Other API Changes

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -1767,7 +1767,7 @@ class QuarterBegin(QuarterOffset):
             # make sure you roll forward, so negate
             monthsSince = monthsSince - 3
 
-        if n < 0 and (monthsSince == 0 and other.day > 1):
+        if n <= 0 and (monthsSince == 0 and other.day > 1):
             # after start, so come back an extra period as if rolled forward
             n = n + 1
 

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -2918,8 +2918,8 @@ class TestQuarterBegin(Base):
                        datetime(2008, 2, 29): datetime(2008, 4, 1),
                        datetime(2008, 3, 15): datetime(2008, 4, 1),
                        datetime(2008, 3, 31): datetime(2008, 4, 1),
-                       datetime(2008, 4, 15): datetime(2008, 4, 1),
-                       datetime(2008, 4, 30): datetime(2008, 4, 1), }))
+                       datetime(2008, 4, 15): datetime(2008, 7, 1),
+                       datetime(2008, 4, 30): datetime(2008, 7, 1), }))
 
         tests.append((QuarterBegin(startingMonth=1, n=-1),
                       {datetime(2008, 1, 1): datetime(2007, 10, 1),


### PR DESCRIPTION
closes #11406 - makes `QuarterBegin` for `n=0` match Month/Year.

xref #11427 - once this is merged the failures there should pass - there is also a little more documentation about general offset semantics in that PR.
