### PR TITLE
Missing _repr_latex_ method for latex/pdf conversion in jupyter notebooks

### DIFF
--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -307,6 +307,10 @@ display.large_repr         truncate     For DataFrames exceeding max_rows/max_co
                                         or switch to the view from df.info()
                                         (the behaviour in earlier versions of pandas).
                                         allowable settings, ['truncate', 'info']
+display.latex.escape       True         Escapes special caracters in Dataframes, when
+                                        using the to_latex method.
+display.latex.longtable    False        Specifies if the to_latex method of a Dataframe
+                                        uses the longtable format.
 display.line_width         80           Deprecated. Use `display.width` instead.
 display.max_columns        20           max_rows and max_columns are used
                                         in __repr__() methods to decide if
@@ -498,3 +502,5 @@ Enabling ``display.unicode.ambiguous_as_wide`` lets pandas to figure these chara
 
    pd.set_option('display.unicode.east_asian_width', False)
    pd.set_option('display.unicode.ambiguous_as_wide', False)
+
+

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -26,7 +26,6 @@ Check the :ref:`API Changes <whatsnew_0180.api>` and :ref:`deprecations <whatsne
 New features
 ~~~~~~~~~~~~
 
-
 .. _whatsnew_0180.enhancements.moments:
 
 Window functions are now methods
@@ -108,6 +107,7 @@ Other enhancements
 - ``read_excel`` now supports s3 urls of the format ``s3://bucketname/filename`` (:issue:`11447`)
 - A simple version of ``Panel.round()`` is now implemented (:issue:`11763`)
 - For Python 3.x, ``round(DataFrame)``, ``round(Series)``, ``round(Panel)`` will work (:issue:`11763`)
+- ``Dataframe`` has gained a ``_repr_latex_`` method in order to allow for automatic conversion to latex in a ipython/jupyter notebook using nbconvert. Options ``display.latex.escape`` and ``display.latex.longtable`` have been added to the configuration and are used automatically by the ``to_latex`` method.(:issue:`11778`)
 
 .. _whatsnew_0180.enhancements.rounding:
 

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -220,6 +220,19 @@ pc_memory_usage_doc = """
     df.info() is called. Valid values True,False,'deep'
 """
 
+pc_latex_escape = """
+: bool
+    This specifies if the to_latex method of a Dataframe uses escapes special 
+    characters.
+    method. Valid values: False,True    
+"""
+
+pc_latex_longtable = """
+:bool
+    This specifies if the to_latex method of a Dataframe uses the longtable format.
+    method. Valid values: False,True 
+"""
+
 style_backup = dict()
 
 
@@ -297,6 +310,10 @@ with cf.config_prefix('display'):
                        pc_east_asian_width_doc, validator=is_bool)
     cf.register_option('unicode.ambiguous_as_wide', False,
                        pc_east_asian_width_doc, validator=is_bool)
+    cf.register_option('latex.escape',True, pc_latex_escape,
+                        validator=is_bool)
+    cf.register_option('latex.longtable',False,pc_latex_longtable,
+                        validator=is_bool)
 
 cf.deprecate_option('display.line_width',
                     msg=pc_line_width_deprecation_warning,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -576,6 +576,13 @@ class DataFrame(NDFrame):
         else:
             return None
 
+    def _repr_latex_(self):
+        """
+        Returns a LaTeX representation for a particular Dataframe.
+        Mainly for use with nbconvert (jupyter notebook conversion to pdf).
+        """
+        return self.to_latex()
+
     @property
     def style(self):
         """
@@ -1540,7 +1547,7 @@ class DataFrame(NDFrame):
                  header=True, index=True, na_rep='NaN', formatters=None,
                  float_format=None, sparsify=None, index_names=True,
                  bold_rows=True, column_format=None,
-                 longtable=False, escape=True):
+                 longtable=None, escape=None):
         """
         Render a DataFrame to a tabular environment table. You can splice
         this into a LaTeX document. Requires \\usepackage{booktabs}.
@@ -1552,10 +1559,12 @@ class DataFrame(NDFrame):
         column_format : str, default None
             The columns format as specified in `LaTeX table format
             <https://en.wikibooks.org/wiki/LaTeX/Tables>`__ e.g 'rcl' for 3 columns
-        longtable : boolean, default False
+        longtable : boolean, default will be read from the pandas config module
+            default: False
             Use a longtable environment instead of tabular. Requires adding
             a \\usepackage{longtable} to your LaTeX preamble.
-        escape : boolean, default True
+        escape : boolean, default will be read from the pandas config module
+            default: True
             When set to False prevents from escaping latex special
             characters in column names.
 
@@ -1565,7 +1574,12 @@ class DataFrame(NDFrame):
             warnings.warn("colSpace is deprecated, use col_space",
                           FutureWarning, stacklevel=2)
             col_space = colSpace
-
+        # Get defaults from the pandas config
+        if longtable is None:
+            longtable = get_option("display.latex.longtable")
+        if escape is None:
+            escape = get_option("display.latex.escape")
+            
         formatter = fmt.DataFrameFormatter(self, buf=buf, columns=columns,
                                            col_space=col_space, na_rep=na_rep,
                                            header=header, index=index,

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -4752,6 +4752,21 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
             for k2, v2 in compat.iteritems(v):
                 self.assertEqual(v2, recons_data[k2][k])
 
+    def test_latex_repr(self):
+        result=r"""\begin{tabular}{llll}
+\toprule
+{} &         0 &  1 &  2 \\
+\midrule
+0 &  $\alpha$ &  b &  c \\
+1 &         1 &  2 &  3 \\
+\bottomrule
+\end{tabular}
+"""
+        with option_context("display.latex.escape",False):
+            df=DataFrame([[r'$\alpha$','b','c'],[1,2,3]])
+            self.assertEqual(result,df._repr_latex_())
+
+
     def test_to_dict_timestamp(self):
 
         # GH11247


### PR DESCRIPTION
Hello, this is my very first pull request on github. I added latex/pdf conversion capabilities to the dataframe when used in a Jupyter/Ipython notebook. The method simply uses the existing to_latex method of the Dataframe class. I believe teh following Issues or PR have already attempted this, but they seem closed: #11399 and  #9821

The _repr_latex_ method looks for newly created options:
    - display.latex_escape
    - display.latex_longtable
which are passed as arguments to the to_latex method.

a simple test has been added to check if the conversion works. However, if the
implementation of the to_latex method changes, the test function would also have to be updated.
