### PR TITLE
BUG: [GH 11738] Fix for end_time when multiple of a frequency is requested

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -187,7 +187,7 @@ Bug Fixes
 
 
 
-
+- Bug in parsing timezone offset strings with non-zero minutes (:issue:`11708`)
 
 
 
@@ -196,3 +196,5 @@ Bug Fixes
 - Bug in ``pd.rolling_median`` where memory allocation failed even with sufficient memory (:issue:`11696`)
 
 - Bug in ``df.replace`` while replacing value in mixed dtype ``Dataframe`` (:issue:`11698`)
+
+- Bug in ``end_time`` computation in ``Period`` when a multiple of time period is requested (:issue: `11738`)

--- a/pandas/src/period.pyx
+++ b/pandas/src/period.pyx
@@ -889,7 +889,8 @@ cdef class Period(object):
             ordinal = self.ordinal
         else:
             # freq.n can't be negative or 0
-            ordinal = (self + self.freq.n).start_time.value - 1
+            # ordinal = (self + self.freq.n).start_time.value - 1
+            ordinal = (self + 1).start_time.value - 1
         return Timestamp(ordinal)
 
     def to_timestamp(self, freq=None, how='start', tz=None):

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -566,19 +566,26 @@ class TestPeriodProperties(tm.TestCase):
         xp = _ex(2012, 2, 1)
         self.assertEqual(xp, p.end_time)
 
-        xp = _ex(2012, 1, 2)
         p = Period('2012', freq='D')
-        self.assertEqual(p.end_time, xp)
-
-        xp = _ex(2012, 1, 1, 1)
-        p = Period('2012', freq='H')
-        self.assertEqual(p.end_time, xp)
-
-        xp = _ex(2012, 1, 3)
-        self.assertEqual(Period('2012', freq='B').end_time, xp)
-
         xp = _ex(2012, 1, 2)
-        self.assertEqual(Period('2012', freq='W').end_time, xp)
+        self.assertEqual(xp, p.end_time)
+
+        p = Period('2012', freq='H')
+        xp = _ex(2012, 1, 1, 1)
+        self.assertEqual(xp, p.end_time)
+
+        p = Period('2012', freq='B')
+        xp = _ex(2012, 1, 3)
+        self.assertEqual(xp, p.end_time)
+
+        p = Period('2012', freq='W')
+        xp = _ex(2012, 1, 2)
+        self.assertEqual(xp, p.end_time)
+
+        # Test for GH 11738
+        p = Period('2012', freq='15D')
+        xp = _ex(2012, 1, 16)
+        self.assertEqual(xp, p.end_time)
 
         p = Period('NaT', freq='W')
         self.assertTrue(p.end_time is tslib.NaT)


### PR DESCRIPTION
closes #11738 
1. Added a new test with the multiple of a frequency.
2. Rearranged some tests to improve readability of the code.
3. Added bug fix to whatsnew
4. Added a comment in the test

Didn't follow the contributing guidelines carefully in PR #11771 and hence this new PR. 
