### PR TITLE
BUG: bug in deep copy of datetime tz-aware objects, #11794

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -170,7 +170,7 @@ Bug Fixes
 - Bug in ``Timedelta.round`` with negative values (:issue:`11690`)
 - Bug in ``.loc`` against ``CategoricalIndex`` may result in normal ``Index`` (:issue:`11586`)
 - Bug in ``DataFrame.info`` when duplicated column names exist (:issue:`11761`)
-
+- Bug in ``.copy`` of datetime tz-aware objects (:issue:`11794`)
 
 
 

--- a/pandas/core/dtypes.py
+++ b/pandas/core/dtypes.py
@@ -65,6 +65,9 @@ class ExtensionDtype(object):
     def __eq__(self, other):
         raise NotImplementedError("sub-classes should implement an __eq__ method")
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     @classmethod
     def is_dtype(cls, dtype):
         """ Return a boolean if we if the passed type is an actual dtype that we can match (via string or type) """

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -168,17 +168,11 @@ class Block(PandasObject):
 
         return make_block(values, placement=placement, ndim=ndim, **kwargs)
 
-    def make_block_same_class(self, values, placement, copy=False, fastpath=True,
-                              **kwargs):
-        """
-        Wrap given values in a block of same type as self.
-
-        `kwargs` are used in SparseBlock override.
-
-        """
-        if copy:
-            values = values.copy()
-        return make_block(values, placement, klass=self.__class__,
+    def make_block_same_class(self, values, placement=None, fastpath=True, **kwargs):
+        """ Wrap given values in a block of same type as self. """
+        if placement is None:
+            placement = self.mgr_locs
+        return make_block(values, placement=placement, klass=self.__class__,
                           fastpath=fastpath, **kwargs)
 
     @mgr_locs.setter
@@ -573,12 +567,11 @@ class Block(PandasObject):
 
     # block actions ####
     def copy(self, deep=True, mgr=None):
+        """ copy constructor """
         values = self.values
         if deep:
             values = values.copy()
-        return self.make_block(values,
-                               klass=self.__class__,
-                               fastpath=True)
+        return self.make_block_same_class(values)
 
     def replace(self, to_replace, value, inplace=False, filter=None,
                 regex=False, convert=True, mgr=None):
@@ -2140,6 +2133,13 @@ class DatetimeTZBlock(NonConsolidatableMixIn, DatetimeBlock):
                                               placement=placement,
                                               ndim=ndim,
                                               **kwargs)
+    def copy(self, deep=True, mgr=None):
+        """ copy constructor """
+        values = self.values
+        if deep:
+            values = values.copy(deep=True)
+        return self.make_block_same_class(values)
+
     def external_values(self):
         """ we internally represent the data as a DatetimeIndex, but for external
         compat with ndarray, export as a ndarray of Timestamps """
@@ -3257,10 +3257,14 @@ class BlockManager(PandasObject):
         full_loc = list(ax.get_loc(x)
                         for ax, x in zip(self.axes, tup))
         blk = self.blocks[self._blknos[full_loc[0]]]
-        full_loc[0] = self._blklocs[full_loc[0]]
+        values = blk.values
 
         # FIXME: this may return non-upcasted types?
-        return blk.values[tuple(full_loc)]
+        if values.ndim == 1:
+            return values[full_loc[1]]
+
+        full_loc[0] = self._blklocs[full_loc[0]]
+        return values[tuple(full_loc)]
 
     def delete(self, item):
         """

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -4419,11 +4419,14 @@ def _putmask_smart(v, m, n):
     try:
         nn = n[m]
         nn_at = nn.astype(v.dtype)
-        comp = (nn == nn_at)
-        if is_list_like(comp) and comp.all():
-            nv = v.copy()
-            nv[m] = nn_at
-            return nv
+
+        # avoid invalid dtype comparisons
+        if not is_numeric_v_string_like(nn, nn_at):
+            comp = (nn == nn_at)
+            if is_list_like(comp) and comp.all():
+                nv = v.copy()
+                nv[m] = nn_at
+                return nv
     except (ValueError, IndexError, TypeError):
         pass
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -5111,12 +5111,27 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
         self.assertTrue(isnull(ts1.cov(ts2, min_periods=12)))
 
     def test_copy(self):
-        ts = self.ts.copy()
 
-        ts[::2] = np.NaN
+        for deep in [False, True]:
+            s = Series(np.arange(10),dtype='float64')
+            s2 = s.copy(deep=deep)
+            s2[::2] = np.NaN
 
-        # Did not modify original Series
-        self.assertFalse(np.isnan(self.ts[0]))
+            # Did not modify original Series
+            self.assertTrue(np.isnan(s2[0]))
+            self.assertFalse(np.isnan(s[0]))
+
+        # GH 11794
+        # copy of tz-aware
+        expected = Series([Timestamp('2012/01/01', tz='UTC')])
+        expected2 = Series([Timestamp('1999/01/01', tz='UTC')])
+
+        for deep in [False, True]:
+            s = Series([Timestamp('2012/01/01', tz='UTC')])
+            s2 = s.copy()
+            s2[0] = pd.Timestamp('1999/01/01', tz='UTC')
+            assert_series_equal(s, expected)
+            assert_series_equal(s2, expected2)
 
     def test_count(self):
         self.assertEqual(self.ts.count(), len(self.ts))

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -5112,26 +5112,49 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
     def test_copy(self):
 
-        for deep in [False, True]:
+        for deep in [None, False, True]:
             s = Series(np.arange(10),dtype='float64')
-            s2 = s.copy(deep=deep)
+
+            # default deep is True
+            if deep is None:
+                s2 = s.copy()
+            else:
+                s2 = s.copy(deep=deep)
+
             s2[::2] = np.NaN
 
-            # Did not modify original Series
-            self.assertTrue(np.isnan(s2[0]))
-            self.assertFalse(np.isnan(s[0]))
+            if deep is None or deep is True:
+                # Did not modify original Series
+                self.assertTrue(np.isnan(s2[0]))
+                self.assertFalse(np.isnan(s[0]))
+            else:
+
+                # we DID modify the original Series
+                self.assertTrue(np.isnan(s2[0]))
+                self.assertTrue(np.isnan(s[0]))
 
         # GH 11794
         # copy of tz-aware
         expected = Series([Timestamp('2012/01/01', tz='UTC')])
         expected2 = Series([Timestamp('1999/01/01', tz='UTC')])
 
-        for deep in [False, True]:
+        for deep in [None, False, True]:
             s = Series([Timestamp('2012/01/01', tz='UTC')])
-            s2 = s.copy()
+
+            if deep is None:
+                s2 = s.copy()
+            else:
+                s2 = s.copy(deep=deep)
+
             s2[0] = pd.Timestamp('1999/01/01', tz='UTC')
-            assert_series_equal(s, expected)
-            assert_series_equal(s2, expected2)
+
+            # default deep is True
+            if deep is None or deep is True:
+                assert_series_equal(s, expected)
+                assert_series_equal(s2, expected2)
+            else:
+                assert_series_equal(s, expected2)
+                assert_series_equal(s2, expected2)
 
     def test_count(self):
         self.assertEqual(self.ts.count(), len(self.ts))


### PR DESCRIPTION
closes #11794 

cleanups in copy / remove warnings 
