### PR TITLE
Fix import-time DeprecationWarning on Python 3.5

### DIFF
--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -4773,8 +4773,8 @@ class TimeRE(dict):
         # format directives (%m, etc.).
         regex_chars = re_compile(r"([\\.^$*+?\(\){}\[\]|])")
         format = regex_chars.sub(r"\\\1", format)
-        whitespace_replacement = re_compile('\s+')
-        format = whitespace_replacement.sub('\s+', format)
+        whitespace_replacement = re_compile(r'\s+')
+        format = whitespace_replacement.sub(r'\\s+', format)
         while '%' in format:
             directive_index = format.index('%')+1
             processed_format = "%s%s%s" % (processed_format,


### PR DESCRIPTION
Fixes the following:

```
$ python3.5 -Wall
Python 3.5.0 (default, Sep 18 2015, 09:31:01) 
[GCC 4.4.7 20120313 (Red Hat 4.4.7-11)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pandas.tslib
pandas/__init__.py:7: DeprecationWarning: bad escape \s
  from pandas import hashtable, tslib, lib
```

In Python 3.5 re.sub replacement patterns containing unrecognized character escapes are deprecated.  This raw string format is needed to substitute `\s` literally.
