### PR TITLE
be more careful with half-opened date_range

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -190,6 +190,7 @@ Bug Fixes
 - Bug in ``GroupBy.size`` when data-frame is empty. (:issue:`11699`)
 - Bug in ``Period.end_time`` when a multiple of time period is requested (:issue:`11738`)
 - Regression in ``.clip`` with tz-aware datetimes (:issue:`11838`)
+- Bug in ``date_range`` when the boundaries fell on the frequency (:issue:`11804`)
 
 
 

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -486,10 +486,9 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin, Int64Index)
                 index = index.view(_NS_DTYPE)
 
         index = cls._simple_new(index, name=name, freq=offset, tz=tz)
-
-        if not left_closed:
+        if not left_closed and len(index) and  index[0] == start:
             index = index[1:]
-        if not right_closed:
+        if not right_closed and len(index) and index[-1] == end:
             index = index[:-1]
 
         return index

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -477,12 +477,36 @@ class TestDateRange(tm.TestCase):
             closed = date_range(begin, end, closed=None, freq=freq)
             left = date_range(begin, end, closed="left", freq=freq)
             right = date_range(begin, end, closed="right", freq=freq)
+            expected_left = left
+            expected_right = right
 
-            expected_left = closed[:-1]
-            expected_right = closed[1:]
+            if end == closed[-1]:
+                expected_left = closed[:-1]
+            if begin == closed[0]:
+                expected_right = closed[1:]
 
             self.assertTrue(expected_left.equals(left))
             self.assertTrue(expected_right.equals(right))
+
+    def test_range_closed_boundary(self):
+        # GH 11804
+        for closed in ['right', 'left', None]:
+            right_boundary = date_range('2015-09-12', '2015-12-01', freq='QS-MAR', closed=closed)
+            left_boundary = date_range('2015-09-01', '2015-09-12', freq='QS-MAR', closed=closed)
+            both_boundary = date_range('2015-09-01', '2015-12-01', freq='QS-MAR', closed=closed)
+            expected_right = expected_left = expected_both = both_boundary
+
+            if closed == 'right':
+                expected_left = both_boundary[1:]
+            if closed == 'left':
+                expected_right = both_boundary[:-1]
+            if closed is None:
+                expected_right = both_boundary[1:]
+                expected_left = both_boundary[:-1]
+
+            self.assertTrue(right_boundary.equals(expected_right))
+            self.assertTrue(left_boundary.equals(expected_left))
+            self.assertTrue(both_boundary.equals(expected_both))
 
     def test_years_only(self):
         # GH 6961


### PR DESCRIPTION
closes #11804 

This changes the definition of 'left' and 'right'. If the generated_dates are strictly within (start, end), then changing the value of closed has no impact. Before the code would always remove the leftmost date or rightmost date independently of the value of start and end.
