### PR TITLE
ENH: GH11128 add weekday_name to DatetimeIndex and .dt

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -469,6 +469,7 @@ These can be accessed like ``Series.dt.<property>``.
    Series.dt.days_in_month
    Series.dt.tz
    Series.dt.freq
+   Series.dt.weekday_name
 
 **Datetime Methods**
 
@@ -1477,6 +1478,7 @@ Time/Date Components
    DatetimeIndex.is_year_start
    DatetimeIndex.is_year_end
    DatetimeIndex.inferred_freq
+   DatetimeIndex.weekday_name
 
 Selecting
 ~~~~~~~~~

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -491,6 +491,7 @@ There are several time/date properties that one can access from ``Timestamp`` or
     is_quarter_end,"Logical indicating if last day of quarter (defined by frequency)"
     is_year_start,"Logical indicating if first day of year (defined by frequency)"
     is_year_end,"Logical indicating if last day of year (defined by frequency)"
+    weekday_name,"The name of day in a week (ex: Friday)"
 
 Furthermore, if you have a ``Series`` with datetimelike values, then you can access these properties via the ``.dt`` accessor, see the :ref:`docs <basics.dt_accessors>`
 

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -152,6 +152,7 @@ Other enhancements
 - ``Series`` gained an ``is_unique`` attribute (:issue:`11946`)
 - ``DataFrame.quantile`` and ``Series.quantile`` now accept ``interpolation`` keyword (:issue:`10174`).
 - ``DataFrame.select_dtypes`` now allows the ``np.float16`` typecode (:issue:`11990`)
+- Added ``weekday_name`` as a component to ``DatetimeIndex`` and ``.dt`` accessor. (:issue:`11128`)
 
 .. _whatsnew_0180.enhancements.rounding:
 

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -88,7 +88,8 @@ class CheckNameIntegration(object):
         ok_for_dt = ok_for_base + ['date', 'time', 'microsecond', 'nanosecond',
                                    'is_month_start', 'is_month_end',
                                    'is_quarter_start', 'is_quarter_end',
-                                   'is_year_start', 'is_year_end', 'tz']
+                                   'is_year_start', 'is_year_end', 'tz',
+                                   'weekday_name']
         ok_for_dt_methods = ['to_period', 'to_pydatetime', 'tz_localize',
                              'tz_convert', 'normalize', 'strftime', 'round',
                              'floor', 'ceil']

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -60,6 +60,9 @@ def _field_accessor(name, field, docstring=None):
 
             result = tslib.get_start_end_field(
                 values, field, self.freqstr, month_kw)
+        elif field in ['weekday_name']:
+            result = tslib.get_date_name_field(values, field)
+            return self._maybe_mask_results(result)
         else:
             result = tslib.get_date_field(values, field)
 
@@ -207,7 +210,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
                          'daysinmonth', 'date', 'time', 'microsecond',
                          'nanosecond', 'is_month_start', 'is_month_end',
                          'is_quarter_start', 'is_quarter_end', 'is_year_start',
-                         'is_year_end', 'tz', 'freq']
+                         'is_year_end', 'tz', 'freq', 'weekday_name']
     _is_numeric_dtype = False
     _infer_as_myclass = True
 
@@ -1564,6 +1567,10 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         'is_year_end',
         'is_year_end',
         "Logical indicating if last day of year (defined by frequency)")
+    weekday_name = _field_accessor(
+        'weekday_name',
+        'weekday_name',
+        "The name of day in a week (ex: Friday)\n\n.. versionadded:: 0.18.0")
 
     @property
     def time(self):

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -31,7 +31,7 @@ class TestDatetimeIndexOps(Ops):
                                    'is_month_start', 'is_month_end',
                                    'is_quarter_start',
                                    'is_quarter_end', 'is_year_start',
-                                   'is_year_end'],
+                                   'is_year_end', 'weekday_name'],
                                   lambda x: isinstance(x, DatetimeIndex))
 
     def test_ops_properties_basic(self):

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -3369,6 +3369,15 @@ class TestDatetime64(tm.TestCase):
         self.assertEqual(dti.is_year_end[0], False)
         self.assertEqual(dti.is_year_end[364], True)
 
+        # GH 11128
+        self.assertEqual(dti.weekday_name[4], u'Monday')
+        self.assertEqual(dti.weekday_name[5], u'Tuesday')
+        self.assertEqual(dti.weekday_name[6], u'Wednesday')
+        self.assertEqual(dti.weekday_name[7], u'Thursday')
+        self.assertEqual(dti.weekday_name[8], u'Friday')
+        self.assertEqual(dti.weekday_name[9], u'Saturday')
+        self.assertEqual(dti.weekday_name[10], u'Sunday')
+
         self.assertEqual(len(dti.year), 365)
         self.assertEqual(len(dti.month), 365)
         self.assertEqual(len(dti.day), 365)
@@ -3386,6 +3395,7 @@ class TestDatetime64(tm.TestCase):
         self.assertEqual(len(dti.is_quarter_end), 365)
         self.assertEqual(len(dti.is_year_start), 365)
         self.assertEqual(len(dti.is_year_end), 365)
+        self.assertEqual(len(dti.weekday_name), 365)
 
         dti = DatetimeIndex(freq='BQ-FEB', start=datetime(1998, 1, 1),
                             periods=4)


### PR DESCRIPTION
closes #11128 

some examples:

```
In [5]: s2 = s.to_frame('value').assign(weekday=s.index.weekday_name)

In [6]: s2
Out[6]:
            value    weekday
2015-09-01      0    tuesday
2015-09-02      1  wednesday
2015-09-03      2   thursday
2015-09-04      3     friday
2015-09-05      4   saturday
2015-09-06      5     sunday
2015-09-07      6     monday
2015-09-08      7    tuesday
2015-09-09      8  wednesday
2015-09-10      9   thursday
```

and

```
In [7]: s3 = pd.Series(pd.date_range('2015-09-01', '2015-09-10'))

In [8]: s3.dt.weekday_name
Out[8]:
0      tuesday
1    wednesday
2     thursday
3       friday
4     saturday
5       sunday
6       monday
7      tuesday
8    wednesday
9     thursday
dtype: object
```

Please review my code :smile: 
