### PR TITLE
ENH: add 'asm8' to NaT

### DIFF
--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -388,6 +388,17 @@ class TestTimestamp(tm.TestCase):
         self.assertTrue(abs(ts_from_string_tz.tz_localize(None)
                             - ts_from_method_tz.tz_localize(None)) < delta)
 
+    def test_asm8(self):
+        np.random.seed(7960929)
+        ns = np.random.randint(
+            Timestamp.min.value,
+            Timestamp.max.value,
+            1000,
+        )
+        for n in ns:
+            self.assertEqual(Timestamp(n).asm8, np.datetime64(int(n), 'ns'), n)
+        self.assertEqual(Timestamp('nat').asm8, np.datetime64('nat', 'ns'))
+
     def test_fields(self):
 
         def check(value, equal):

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -447,10 +447,6 @@ class Timestamp(_Timestamp):
         return getattr(self.offset, 'freqstr', self.offset)
 
     @property
-    def asm8(self):
-        return np.int64(self.value).view('M8[ns]')
-
-    @property
     def is_month_start(self):
         return self._get_start_end_field('is_month_start')
 
@@ -1062,6 +1058,10 @@ cdef class _Timestamp(datetime):
         freqstr = self.freqstr if self.freq else None
         out = get_start_end_field(np.array([self.value], dtype=np.int64), field, freqstr, month_kw)
         return out[0]
+
+    property asm8:
+        def __get__(self):
+            return np.datetime64(self.value, 'ns')
 
 
 cdef PyTypeObject* ts_type = <PyTypeObject*> Timestamp


### PR DESCRIPTION
I was suprised to find that `NaT.asm8` does not exist though there is a valid nat form for `numpy.datetime64`.

This also adds tests for the asm8 behavior for a random sample of times and `NaT`
