### PR TITLE
BUG: read_excel fails when empty sheets exist and sheetname=None #11711

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -230,3 +230,5 @@ Bug Fixes
 
 
 - Bug in ``df.replace`` while replacing value in mixed dtype ``Dataframe`` (:issue:`11698`)
+
+- Bug in ``read_excel`` failing to read any non-empty sheets when empty sheets exist and ``sheetname=None`` (:issue:`11711`)

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -391,7 +391,8 @@ class ExcelFile(object):
                 data.append(row)
 
             if sheet.nrows == 0:
-                return DataFrame()
+                output[asheetname] = DataFrame()
+                continue
 
             if com.is_list_like(header) and len(header) == 1:
                 header = header[0]

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -382,6 +382,15 @@ class ReadingTestsBase(SharedItems):
         tm.assert_contains_all(expected_keys, dfs.keys())
         assert len(expected_keys) == len(dfs.keys())
 
+    def test_reading_all_sheets_with_blank(self):
+        # Test reading all sheetnames by setting sheetname to None,
+        # In the case where some sheets are blank.
+        # Issue #11711
+        basename = 'blank_with_header'
+        dfs = self.get_exceldf(basename, sheetname=None)
+        expected_keys = ['Sheet1', 'Sheet2', 'Sheet3']
+        tm.assert_contains_all(expected_keys, dfs.keys())        
+
     # GH6403
     def test_read_excel_blank(self):
         actual = self.get_exceldf('blank', 'Sheet1')


### PR DESCRIPTION
Fixes issue #11711.

Existing code prematurely returns an empty dataframe when an empty sheet in the source excel file is encountered.
Fix is to store an empty dataframe in the output dict and continue to the next sheet.
