### PR TITLE
CLN: Use sentinel values instead of mutable default arguments

### DIFF
--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -475,8 +475,10 @@ class _OrderedDict(dict):
         self[key] = default
         return default
 
-    def __repr__(self, _repr_running={}):
+    def __repr__(self, _repr_running=None):
         """od.__repr__() <==> repr(od)"""
+        if _repr_running is None:
+                _repr_running = {}
         call_key = id(self), _get_ident()
         if call_key in _repr_running:
             return '...'

--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -1149,7 +1149,9 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
             raise Exception("invalid pickle state")
     _unpickle_compat = __setstate__
 
-    def __deepcopy__(self, memo={}):
+    def __deepcopy__(self, memo=None):
+        if memo is None:
+                memo = {}
         return self.copy(deep=True)
 
     def __nonzero__(self):

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -4740,8 +4740,10 @@ def trim_join_unit(join_unit, length):
 
 
 class JoinUnit(object):
-    def __init__(self, block, shape, indexers={}):
+    def __init__(self, block, shape, indexers=None):
         # Passing shape explicitly is required for cases when block is None.
+        if indexers is None:
+                indexers = {}
         self.block = block
         self.indexers = indexers
         self.shape = shape

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -55,7 +55,7 @@ def _ensure_like_indices(time, panels):
     return time, panels
 
 
-def panel_index(time, panels, names=['time', 'panel']):
+def panel_index(time, panels, names=None):
     """
     Returns a multi-index suitable for a panel-like DataFrame
 
@@ -94,6 +94,8 @@ def panel_index(time, panels, names=['time', 'panel']):
                 (1961, 'B'), (1961, 'C'), (1962, 'A'), (1962, 'B'),
                 (1962, 'C')], dtype=object)
     """
+    if names is None:
+        names = ['time', 'panel']
     time, panels = _ensure_like_indices(time, panels)
     time_factor = Categorical.from_array(time, ordered=True)
     panel_factor = Categorical.from_array(panels, ordered=True)

--- a/pandas/io/auth.py
+++ b/pandas/io/auth.py
@@ -45,12 +45,14 @@ gflags.DEFINE_enum('logging_level', 'ERROR',
 # a secure place.
 
 
-def process_flags(flags=[]):
+def process_flags(flags=None):
     """Uses the command-line flags to set the logging level.
 
     Args:
     argv: List of command line arguments passed to the python script.
     """
+    if flags is None:
+        flags = []
 
     # Let the gflags module process the command-line arguments.
     try:

--- a/pandas/io/wb.py
+++ b/pandas/io/wb.py
@@ -83,7 +83,7 @@ country_codes = ['AD', 'AE', 'AF', 'AG', 'AI', 'AL', 'AM', 'AO', 'AQ', 'AR', \
                  'VIR', 'VNM', 'VUT', 'WLF', 'WSM', 'YEM', 'ZAF', 'ZMB', \
                  'ZWE', 'all', 'ALL', 'All']
 
-def download(country=['MX', 'CA', 'US'], indicator=['NY.GDP.MKTP.CD', 'NY.GNS.ICTR.ZS'],
+def download(country=None, indicator=None,
              start=2003, end=2005,errors='warn'):
     """
     Download data series from the World Bank's World Development Indicators
@@ -123,6 +123,10 @@ def download(country=['MX', 'CA', 'US'], indicator=['NY.GDP.MKTP.CD', 'NY.GNS.IC
     indicator value.
 
     """
+    if country is None:
+        country = ['MX', 'CA', 'US']
+    if indicator is None:
+        indicator = ['NY.GDP.MKTP.CD', 'NY.GNS.ICTR.ZS']
 
     if type(country) == str:
         country = [country]

--- a/pandas/stats/fama_macbeth.py
+++ b/pandas/stats/fama_macbeth.py
@@ -31,7 +31,9 @@ class FamaMacBeth(StringMixin):
     def __init__(self, y, x, intercept=True, nw_lags=None,
                  nw_lags_beta=None,
                  entity_effects=False, time_effects=False, x_effects=None,
-                 cluster=None, dropped_dummies={}, verbose=False):
+                 cluster=None, dropped_dummies=None, verbose=False):
+        if dropped_dummies is None:
+                dropped_dummies = {}
         self._nw_lags_beta = nw_lags_beta
 
         from pandas.stats.plm import MovingPanelOLS
@@ -143,7 +145,9 @@ class MovingFamaMacBeth(FamaMacBeth):
     def __init__(self, y, x, window_type='rolling', window=10,
                  intercept=True, nw_lags=None, nw_lags_beta=None,
                  entity_effects=False, time_effects=False, x_effects=None,
-                 cluster=None, dropped_dummies={}, verbose=False):
+                 cluster=None, dropped_dummies=None, verbose=False):
+        if dropped_dummies is None:
+                dropped_dummies = {}
         self._window_type = common._get_window_type(window_type)
         self._window = window
 

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -653,7 +653,7 @@ def bootstrap_plot(series, fig=None, size=50, samples=500, **kwds):
 @deprecate_kwarg(old_arg_name='data', new_arg_name='frame', stacklevel=3)
 def parallel_coordinates(frame, class_column, cols=None, ax=None, color=None,
                          use_columns=False, xticks=None, colormap=None,
-                         axvlines=True, axvlines_kwds={'linewidth':1,'color':'black'}, **kwds):
+                         axvlines=True, axvlines_kwds=None, **kwds):
     """Parallel coordinates plotting.
 
     Parameters
@@ -693,6 +693,8 @@ def parallel_coordinates(frame, class_column, cols=None, ax=None, color=None,
     >>> parallel_coordinates(df, 'Name', color=('#556270', '#4ECDC4', '#C7F464'))
     >>> plt.show()
     """
+    if axvlines_kwds is None:
+        axvlines_kwds = {'linewidth':1,'color':'black'}
     import matplotlib.pyplot as plt
 
     n = len(frame)


### PR DESCRIPTION
From [Quantified Code](https://www.quantifiedcode.com/):

Mutable list or dictionary used as default argument to a method or function. Python creates a single persistent object and uses it for every subsequent call in which the argument is left empty. This can cause problems if the program was expecting the function to return a new list or dictionary after every call. Use a sentinel value to denote an empty list or dictionary.
