### PR TITLE
CLN: frequency.get_offset always return copy

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -252,6 +252,8 @@ Deprecations
 
   For example, instead of ``s.rolling(window=5,freq='D').max()`` to get the max value on a rolling 5 Day window, one could use ``s.resample('D',how='max').rolling(window=5).max()``, which first resamples the data to daily data, then provides a rolling 5 day window.
 
+- ``pd.tseries.frequencies.get_offset_name`` function is deprecated. Use offset's ``.freqstr`` property as alternative (:issue:`11192`)
+
 .. _whatsnew_0180.prior_deprecations:
 
 Removal of prior version deprecations/changes

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -309,8 +309,6 @@ class DateOffset(object):
         return params
 
     def __repr__(self):
-        if hasattr(self, '_named'):
-            return self._named
         className = getattr(self, '_outputName', type(self).__name__)
         exclude = set(['n', 'inc', 'normalize'])
         attrs = []
@@ -346,10 +344,7 @@ class DateOffset(object):
 
     @property
     def name(self):
-        if hasattr(self, '_named'):
-            return self._named
-        else:
-            return self.rule_code
+        return self.rule_code
 
     def __eq__(self, other):
         if other is None:
@@ -516,8 +511,6 @@ class BusinessMixin(object):
     # attributes on each object rather than the existing behavior of iterating
     # over internal ``__dict__``
     def __repr__(self):
-        if hasattr(self, '_named'):
-            return self._named
         className = getattr(self, '_outputName', self.__class__.__name__)
 
         if abs(self.n) != 1:
@@ -2668,16 +2661,3 @@ prefix_mapping = dict((offset._prefix, offset) for offset in [
 ])
 
 prefix_mapping['N'] = Nano
-
-def _make_offset(key):
-    """Gets offset based on key. KeyError if prefix is bad, ValueError if
-    suffix is bad. All handled by `get_offset` in tseries/frequencies. Not
-    public."""
-    if key is None:
-        return None
-    split = key.split('-')
-    klass = prefix_mapping[split[0]]
-    # handles case where there's no suffix (and will TypeError if too many '-')
-    obj = klass._from_name(*split[1:])
-    obj._named = key
-    return obj

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -16,7 +16,7 @@ from pandas.core.datetools import (
     QuarterBegin, BQuarterBegin, BMonthBegin, DateOffset, Week,
     YearBegin, YearEnd, Hour, Minute, Second, Day, Micro, Milli, Nano, Easter,
     WeekOfMonth, format, ole2datetime, QuarterEnd, to_datetime, normalize_date,
-    get_offset, get_offset_name, get_standard_freq)
+    get_offset, get_standard_freq)
 
 from pandas import Series
 from pandas.tseries.frequencies import _offset_map, get_freq_code, _get_freq_str
@@ -3593,19 +3593,20 @@ class TestTicks(tm.TestCase):
 
 class TestOffsetNames(tm.TestCase):
     def test_get_offset_name(self):
-        assertRaisesRegexp(ValueError, 'Bad rule.*BusinessDays', get_offset_name, BDay(2))
+        self.assertEqual(BDay().freqstr, 'B')
+        self.assertEqual(BDay(2).freqstr, '2B')
+        self.assertEqual(BMonthEnd().freqstr, 'BM')
+        self.assertEqual(Week(weekday=0).freqstr, 'W-MON')
+        self.assertEqual(Week(weekday=1).freqstr, 'W-TUE')
+        self.assertEqual(Week(weekday=2).freqstr, 'W-WED')
+        self.assertEqual(Week(weekday=3).freqstr, 'W-THU')
+        self.assertEqual(Week(weekday=4).freqstr, 'W-FRI')
 
-        assert get_offset_name(BDay()) == 'B'
-        assert get_offset_name(BMonthEnd()) == 'BM'
-        assert get_offset_name(Week(weekday=0)) == 'W-MON'
-        assert get_offset_name(Week(weekday=1)) == 'W-TUE'
-        assert get_offset_name(Week(weekday=2)) == 'W-WED'
-        assert get_offset_name(Week(weekday=3)) == 'W-THU'
-        assert get_offset_name(Week(weekday=4)) == 'W-FRI'
-
-        self.assertEqual(get_offset_name(LastWeekOfMonth(weekday=WeekDay.SUN)), "LWOM-SUN")
-        self.assertEqual(get_offset_name(makeFY5253LastOfMonthQuarter(weekday=1, startingMonth=3, qtr_with_extra_week=4)),"REQ-L-MAR-TUE-4")
-        self.assertEqual(get_offset_name(makeFY5253NearestEndMonthQuarter(weekday=1, startingMonth=3, qtr_with_extra_week=3)), "REQ-N-MAR-TUE-3")
+        self.assertEqual(LastWeekOfMonth(weekday=WeekDay.SUN).freqstr, "LWOM-SUN")
+        self.assertEqual(makeFY5253LastOfMonthQuarter(weekday=1, startingMonth=3, qtr_with_extra_week=4).freqstr,
+                         "REQ-L-MAR-TUE-4")
+        self.assertEqual(makeFY5253NearestEndMonthQuarter(weekday=1, startingMonth=3, qtr_with_extra_week=3).freqstr,
+                         "REQ-N-MAR-TUE-3")
 
 def test_get_offset():
     assertRaisesRegexp(ValueError, "rule.*GIBBERISH", get_offset, 'gibberish')
@@ -3834,13 +3835,10 @@ class TestReprNames(tm.TestCase):
         names += ['W-' + day for day in days]
         names += ['WOM-' + week + day for week in ('1', '2', '3', '4')
                                        for day in days]
-        #singletons
-        names += ['S', 'T', 'U', 'BM', 'BMS', 'BQ', 'QS'] # No 'Q'
         _offset_map.clear()
         for name in names:
             offset = get_offset(name)
-            self.assertEqual(repr(offset), name)
-            self.assertEqual(str(offset), name)
+            self.assertEqual(offset.freqstr, name)
 
 
 def get_utc_offset_hours(ts):


### PR DESCRIPTION
Closes #11192. 

Fix 2 points which should not affect to normal users (thus no release note descriptions).
- get_offset (#11192): It returns cached offset, overwriting it may leads to unexpected results. `pandas` public methods doesn't use them as it is. Thus it should not affect to almost all users, except who explicitly uses `frequencies.get_offset`
- get_offset_name: This looks leagacy impl which raises `ValueError` for `BDay` with `n != 1` which is valid input. I've marked this as deprecated, but it can be removed immediately as non-public.
