### PR TITLE
COMPAT: GH11769 Fix msgpack ExtType unpack errors on Windows in Python 3.5

### DIFF
--- a/pandas/src/msgpack/unpack.h
+++ b/pandas/src/msgpack/unpack.h
@@ -265,9 +265,9 @@ static inline int unpack_callback_ext(unpack_user* u, const char* base, const ch
     }
     // length also includes the typecode, so the actual data is length-1
 #if PY_MAJOR_VERSION == 2
-    py = PyObject_CallFunction(u->ext_hook, "(is#)", typecode, pos, length-1);
+    py = PyObject_CallFunction(u->ext_hook, "(is#)", typecode, pos, (Py_ssize_t)length-1);
 #else
-    py = PyObject_CallFunction(u->ext_hook, "(iy#)", typecode, pos, length-1);
+    py = PyObject_CallFunction(u->ext_hook, "(iy#)", typecode, pos, (Py_ssize_t)length-1);
 #endif
     if (!py)
         return -1;


### PR DESCRIPTION
closes #11769 
