### PR TITLE
Change pandas to never let objects share `_data`, create views instead

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -217,6 +217,7 @@ class DataFrame(NDFrame):
             dtype = self._validate_dtype(dtype)
 
         if isinstance(data, DataFrame):
+            data = data.iloc[:,:]
             data = data._data
 
         if isinstance(data, BlockManager):

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -752,8 +752,8 @@ class _NDFrameIndexer(object):
             if i >= self.obj.ndim:
                 raise IndexingError('Too many indexers')
 
-            if is_null_slice(key):
-                continue
+            #if is_null_slice(key):
+            #    continue
 
             retval = getattr(retval, self.name)._getitem_axis(key, axis=i)
 
@@ -1171,8 +1171,6 @@ class _NDFrameIndexer(object):
     def _get_slice_axis(self, slice_obj, axis=0):
         obj = self.obj
 
-        if not need_slice(slice_obj):
-            return obj
         indexer = self._convert_slice_indexer(slice_obj, axis)
 
         if isinstance(indexer, slice):
@@ -1244,8 +1242,7 @@ class _LocationIndexer(_NDFrameIndexer):
     def _get_slice_axis(self, slice_obj, axis=0):
         """ this is pretty simple as we just have to deal with labels """
         obj = self.obj
-        if not need_slice(slice_obj):
-            return obj
+
 
         labels = obj._get_axis(axis)
         indexer = labels.slice_indexer(slice_obj.start, slice_obj.stop,
@@ -1477,10 +1474,6 @@ class _iLocIndexer(_LocationIndexer):
         return retval
 
     def _get_slice_axis(self, slice_obj, axis=0):
-        obj = self.obj
-
-        if not need_slice(slice_obj):
-            return obj
 
         slice_obj = self._convert_slice_indexer(slice_obj, axis)
         if isinstance(slice_obj, slice):
@@ -1790,12 +1783,6 @@ def is_list_like_indexer(key):
 def is_label_like(key):
     # select a label or row
     return not isinstance(key, slice) and not is_list_like_indexer(key)
-
-
-def need_slice(obj):
-    return (obj.start is not None or
-            obj.stop is not None or
-            (obj.step is not None and obj.step != 1))
 
 
 def maybe_droplevels(index, key):

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -752,9 +752,6 @@ class _NDFrameIndexer(object):
             if i >= self.obj.ndim:
                 raise IndexingError('Too many indexers')
 
-            #if is_null_slice(key):
-            #    continue
-
             retval = getattr(retval, self.name)._getitem_axis(key, axis=i)
 
         return retval
@@ -1458,9 +1455,9 @@ class _iLocIndexer(_LocationIndexer):
             if i >= self.obj.ndim:
                 raise IndexingError('Too many indexers')
 
-            if is_null_slice(key):
-                axis += 1
-                continue
+            #if is_null_slice(key):
+            #    axis += 1
+            #    continue
 
             retval = getattr(retval, self.name)._getitem_axis(key, axis=axis)
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -2637,6 +2637,7 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
     def test_constructor_dtype_nocast_view(self):
         df = DataFrame([[1, 2]])
         should_be_view = DataFrame(df, dtype=df[0].dtype)
+        self.assertTrue(should_be_view._is_view)
         should_be_view[0][0] = 99
         self.assertEqual(df.values[0, 0], 99)
 

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -4912,6 +4912,14 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         expected = [1]
         self.assertEqual(result, expected)
 
+    def test_empty_indexers_return_view(self):
+        # Closes Issue 11814
+        df = pd.DataFrame({'col1':range(10,20),
+                   'col2':range(20,30)})
+        self.assertTrue(df.loc[:,:]._is_view)
+        self.assertTrue(df.iloc[:,:]._is_view)
+        self.assertTrue(df.ix[:,:]._is_view)
+
 
 class TestCategoricalIndex(tm.TestCase):
 
@@ -5195,13 +5203,6 @@ class TestCategoricalIndex(tm.TestCase):
         #         name=u'B')
         self.assertRaises(TypeError, lambda : df4[df4.index < 2])
         self.assertRaises(TypeError, lambda : df4[df4.index > 1])
-
-    def test_empty_indexers_return_view(self):
-        df = pd.DataFrame({'col1':range(10,20),
-                   'col2':range(20,30)})
-        self.assertTrue(df.loc[:,:]._is_view)
-        self.assertTrue(df.iloc[:,:]._is_view)
-        self.assertTrue(df.ix[:,:]._is_view)
 
 
 class TestSeriesNoneCoercion(tm.TestCase):

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -5196,6 +5196,14 @@ class TestCategoricalIndex(tm.TestCase):
         self.assertRaises(TypeError, lambda : df4[df4.index < 2])
         self.assertRaises(TypeError, lambda : df4[df4.index > 1])
 
+    def test_empty_indexers_return_view(self):
+        df = pd.DataFrame({'col1':range(10,20),
+                   'col2':range(20,30)})
+        self.assertTrue(df.loc[:,:]._is_view)
+        self.assertTrue(df.iloc[:,:]._is_view)
+        self.assertTrue(df.ix[:,:]._is_view)
+
+
 class TestSeriesNoneCoercion(tm.TestCase):
     EXPECTED_RESULTS = [
         # For numeric series, we should coerce to NaN.


### PR DESCRIPTION
Closes Issue #11814 

Several pandas operations create objects that share `_data` objects. In particular, all of the following result in `df_new`s and `df` sharing the same `_data` (i.e. `df_new._data is df._data` returns `True`). 

```
df = DataFrame({'col1':[0,1,2], 'col2':[2,3,4]})
df_new = DataFrame(df)
df_new1 = df.loc[:,:]
df_new2 = df.iloc[:,:]
```

Needed for PR #11500 
