### PR TITLE
Fix passing args in groupby plot (GH11805)

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -330,8 +330,9 @@ Bug Fixes
 - Bug in ``to_numeric`` where it does not raise if input is more than one dimension (:issue:`11776`)
 
 - Bug in parsing timezone offset strings with non-zero minutes (:issue:`11708`)
-
 - Bug in ``df.plot`` using incorrect colors for bar plots under matplotlib 1.5+ (:issue:`11614`)
+- Bug in the ``groupby`` ``plot`` method when using keyword arguments (:issue:`11805`).
+
 
 - Bug in ``.loc`` result with duplicated key may have ``Index`` with incorrect dtype (:issue:`11497`)
 - Bug in ``pd.rolling_median`` where memory allocation failed even with sufficient memory (:issue:`11696`)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -287,7 +287,7 @@ class GroupByPlot(PandasObject):
         self._groupby = groupby
 
     def __call__(self, *args, **kwargs):
-        def f(self, *args, **kwargs):
+        def f(self):
             return self.plot(*args, **kwargs)
         f.__name__ = 'plot'
         return self._groupby.apply(f)

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -3718,7 +3718,7 @@ class TestDataFramePlots(TestPlotBase):
 
     def test_passed_bar_colors(self):
         import matplotlib as mpl
-        color_tuples = [(0.9, 0, 0, 1), (0, 0.9, 0, 1), (0, 0, 0.9, 1)] 
+        color_tuples = [(0.9, 0, 0, 1), (0, 0.9, 0, 1), (0, 0, 0.9, 1)]
         colormap = mpl.colors.ListedColormap(color_tuples)
         barplot = pd.DataFrame([[1,2,3]]).plot(kind="bar", cmap=colormap)
         self.assertEqual(color_tuples, [c.get_facecolor() for c in barplot.patches])
@@ -3780,6 +3780,21 @@ class TestDataFrameGroupByPlots(TestPlotBase):
         tm.close()
         df.groupby('z')['x'].plot.line()
         tm.close()
+
+    def test_plot_kwargs(self):
+
+        df = DataFrame({'x': [1, 2, 3, 4, 5],
+                        'y': [1, 2, 3, 2, 1],
+                        'z': list('ababa')})
+
+        res = df.groupby('z').plot(kind='scatter', x='x', y='y')
+        # check that a scatter plot is effectively plotted: the axes should
+        # contain a PathCollection from the scatter plot (GH11805)
+        self.assertEqual(len(res['a'].collections), 1)
+
+        res = df.groupby('z').plot.scatter(x='x', y='y')
+        self.assertEqual(len(res['a'].collections), 1)
+
 
 def assert_is_valid_plot_return_object(objs):
     import matplotlib.pyplot as plt


### PR DESCRIPTION
Closes https://github.com/pydata/pandas/issues/11805

So probably all groupby plot calls that use kwargs are broken in 0.17.x. 
@shoyer it was only a very small change actually!

Still need to add tests.
