### PR TITLE
BUG: masking empty DataFrame

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -345,3 +345,4 @@ Bug Fixes
 
 - Bug in ``read_sql`` with pymysql connections failing to return chunked data (:issue:`11522`)
 
+- Bug in ``DataFrame`` when masking an empty ``DataFrame`` (:issue:`11859`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2047,7 +2047,7 @@ class DataFrame(NDFrame):
             return self._get_item_cache(key)
 
     def _getitem_frame(self, key):
-        if key.values.dtype != np.bool_:
+        if key.values.size and not com.is_bool_dtype(key.values):
             raise ValueError('Must pass DataFrame with boolean values only')
         return self.where(key)
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -826,6 +826,13 @@ class CheckIndexing(object):
                 df[df > df2] = 47
                 assert_frame_equal(df, df2)
 
+    def test_getitem_empty_frame_with_boolean(self):
+        # Test for issue #11859
+
+        df = pd.DataFrame()
+        df2 = df[df>0]
+        assert_frame_equal(df, df2)
+
     def test_delitem_corner(self):
         f = self.frame.copy()
         del f['D']


### PR DESCRIPTION
closes #11859 

A `ValueError` was raised when trying to mask an empty DataFrame. In addition to solve the bug I've also added a simple new unit test in `test_frame.py`. I didn't add a line in `whatsnew` because this was already done in #10126 
