### PR TITLE
DEPR: pandas.stats.var, pandas.stats.plm, pandas.stats.ols, pandas.stats.fama_macbeth

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -253,6 +253,7 @@ Deprecations
   For example, instead of ``s.rolling(window=5,freq='D').max()`` to get the max value on a rolling 5 Day window, one could use ``s.resample('D',how='max').rolling(window=5).max()``, which first resamples the data to daily data, then provides a rolling 5 day window.
 
 - ``pd.tseries.frequencies.get_offset_name`` function is deprecated. Use offset's ``.freqstr`` property as alternative (:issue:`11192`)
+- ``pandas.fama_macbeth`` routines are deprecated and will be removed in a future version (:issue:``)
 
 .. _whatsnew_0180.prior_deprecations:
 
@@ -345,5 +346,8 @@ Bug Fixes
 - Bug in ``read_excel`` failing to raise ``NotImplemented`` error when keywords `parse_dates` and `date_parser` are provided (:issue:`11544`)
 
 - Bug in ``read_sql`` with pymysql connections failing to return chunked data (:issue:`11522`)
+<<<<<<< f67dd750a67e1e097b58407c755016d3726f21d5
 
 - Bug in ``DataFrame`` when masking an empty ``DataFrame`` (:issue:`11859`)
+=======
+>>>>>>> DEPR: deprecate pandas.fama_macbeth, #6077

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -253,7 +253,8 @@ Deprecations
   For example, instead of ``s.rolling(window=5,freq='D').max()`` to get the max value on a rolling 5 Day window, one could use ``s.resample('D',how='max').rolling(window=5).max()``, which first resamples the data to daily data, then provides a rolling 5 day window.
 
 - ``pd.tseries.frequencies.get_offset_name`` function is deprecated. Use offset's ``.freqstr`` property as alternative (:issue:`11192`)
-- ``pandas.fama_macbeth`` routines are deprecated and will be removed in a future version (:issue:``)
+- ``pandas.stats.fama_macbeth`` routines are deprecated and will be removed in a future version (:issue:`6077`)
+- ``pandas.stats.ols``, ``pandas.stats.plm`` and ``pandas.stats.var`` routines are deprecated and will be removed in a future version (:issue:`6077`)
 
 .. _whatsnew_0180.prior_deprecations:
 
@@ -346,8 +347,5 @@ Bug Fixes
 - Bug in ``read_excel`` failing to raise ``NotImplemented`` error when keywords `parse_dates` and `date_parser` are provided (:issue:`11544`)
 
 - Bug in ``read_sql`` with pymysql connections failing to return chunked data (:issue:`11522`)
-<<<<<<< f67dd750a67e1e097b58407c755016d3726f21d5
 
 - Bug in ``DataFrame`` when masking an empty ``DataFrame`` (:issue:`11859`)
-=======
->>>>>>> DEPR: deprecate pandas.fama_macbeth, #6077

--- a/pandas/stats/fama_macbeth.py
+++ b/pandas/stats/fama_macbeth.py
@@ -35,7 +35,7 @@ class FamaMacBeth(StringMixin):
         import warnings
         warnings.warn("The pandas.stats.fama_macbeth module is deprecated and will be "
                       "removed in a future version. We refer to external packages "
-                      "like statsmodels. ",
+                      "like statsmodels, see here: http://statsmodels.sourceforge.net/stable/index.html",
                       FutureWarning, stacklevel=4)
 
         if dropped_dummies is None:

--- a/pandas/stats/fama_macbeth.py
+++ b/pandas/stats/fama_macbeth.py
@@ -17,7 +17,7 @@ def fama_macbeth(**kwargs):
 
     nw_lags_beta: int
        Newey-West adjusts the betas by the given lags
-    """
+       """
     window_type = kwargs.get('window_type')
     if window_type is None:
         klass = FamaMacBeth
@@ -32,6 +32,12 @@ class FamaMacBeth(StringMixin):
                  nw_lags_beta=None,
                  entity_effects=False, time_effects=False, x_effects=None,
                  cluster=None, dropped_dummies=None, verbose=False):
+        import warnings
+        warnings.warn("The pandas.stats.fama_macbeth module is deprecated and will be "
+                      "removed in a future version. We refer to external packages "
+                      "like statsmodels. ",
+                      FutureWarning, stacklevel=4)
+
         if dropped_dummies is None:
                 dropped_dummies = {}
         self._nw_lags_beta = nw_lags_beta

--- a/pandas/stats/ols.py
+++ b/pandas/stats/ols.py
@@ -47,6 +47,12 @@ class OLS(StringMixin):
 
     def __init__(self, y, x, intercept=True, weights=None, nw_lags=None,
                  nw_overlap=False):
+        import warnings
+        warnings.warn("The pandas.stats.ols module is deprecated and will be "
+                      "removed in a future version. We refer to external packages "
+                      "like statsmodels, see some examples here: http://statsmodels.sourceforge.net/stable/regression.html",
+                      FutureWarning, stacklevel=4)
+
         try:
             import statsmodels.api as sm
         except ImportError:

--- a/pandas/stats/ols.py
+++ b/pandas/stats/ols.py
@@ -1197,8 +1197,11 @@ class MovingOLS(OLS):
 
     @cache_readonly
     def _window_time_obs(self):
-        window_obs = moments.rolling_sum(self._time_obs_count > 0,
-                                         self._window, min_periods=1)
+        window_obs = (Series(self._time_obs_count > 0)
+                      .rolling(self._window, min_periods=1)
+                      .sum()
+                      .values
+                      )
 
         window_obs[np.isnan(window_obs)] = 0
         return window_obs.astype(int)
@@ -1211,8 +1214,7 @@ class MovingOLS(OLS):
             # expanding case
             window = len(self._index)
 
-        result = moments.rolling_sum(self._time_obs_count, window,
-                                     min_periods=1)
+        result = Series(self._time_obs_count).rolling(window, min_periods=1).sum().values
 
         return result.astype(int)
 

--- a/pandas/stats/plm.py
+++ b/pandas/stats/plm.py
@@ -34,6 +34,11 @@ class PanelOLS(OLS):
                  entity_effects=False, time_effects=False, x_effects=None,
                  cluster=None, dropped_dummies=None, verbose=False,
                  nw_overlap=False):
+        import warnings
+        warnings.warn("The pandas.stats.plm module is deprecated and will be "
+                      "removed in a future version. We refer to external packages "
+                      "like statsmodels, see some examples here: http://statsmodels.sourceforge.net/stable/mixed_linear.html",
+                      FutureWarning, stacklevel=4)
         self._x_orig = x
         self._y_orig = y
         self._weights = weights
@@ -731,6 +736,12 @@ class NonPooledPanelOLS(object):
     def __init__(self, y, x, window_type='full_sample', window=None,
                  min_periods=None, intercept=True, nw_lags=None,
                  nw_overlap=False):
+
+        import warnings
+        warnings.warn("The pandas.stats.plm module is deprecated and will be "
+                      "removed in a future version. We refer to external packages "
+                      "like statsmodels, see some examples here: http://statsmodels.sourceforge.net/stable/mixed_linear.html",
+                      FutureWarning, stacklevel=4)
 
         for attr in self.ATTRIBUTES:
             setattr(self.__class__, attr, create_ols_attr(attr))

--- a/pandas/stats/tests/test_fama_macbeth.py
+++ b/pandas/stats/tests/test_fama_macbeth.py
@@ -4,6 +4,7 @@ from .common import assert_almost_equal, BaseTest
 
 from pandas.compat import range
 from pandas import compat
+import pandas.util.testing as tm
 import numpy as np
 
 
@@ -23,8 +24,9 @@ class TestFamaMacBeth(BaseTest):
     def checkFamaMacBethExtended(self, window_type, x, y, **kwds):
         window = 25
 
-        result = fama_macbeth(y=y, x=x, window_type=window_type, window=window,
-                              **kwds)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result = fama_macbeth(y=y, x=x, window_type=window_type, window=window,
+                                  **kwds)
         self._check_stuff_works(result)
 
         index = result._index
@@ -43,10 +45,12 @@ class TestFamaMacBeth(BaseTest):
                 x2[k] = v.truncate(start, end)
             y2 = y.truncate(start, end)
 
-            reference = fama_macbeth(y=y2, x=x2, **kwds)
+            with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+                reference = fama_macbeth(y=y2, x=x2, **kwds)
             assert_almost_equal(reference._stats, result._stats[:, i])
 
-        static = fama_macbeth(y=y2, x=x2, **kwds)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            static = fama_macbeth(y=y2, x=x2, **kwds)
         self._check_stuff_works(static)
 
     def _check_stuff_works(self, result):

--- a/pandas/stats/tests/test_math.py
+++ b/pandas/stats/tests/test_math.py
@@ -52,7 +52,8 @@ class TestMath(tm.TestCase):
 
         b = Series(np.random.randn(N), self.frame.index)
         result = pmath.solve(self.frame, b)
-        expected = ols(y=b, x=self.frame, intercept=False).beta
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            expected = ols(y=b, x=self.frame, intercept=False).beta
         self.assertTrue(np.allclose(result, expected))
 
     def test_inv_illformed(self):

--- a/pandas/stats/tests/test_ols.py
+++ b/pandas/stats/tests/test_ols.py
@@ -115,7 +115,8 @@ class TestOLS(BaseTest):
         self._check_wls(X, Y, weights)
 
     def _check_wls(self, x, y, weights):
-        result = ols(y=y, x=x, weights=1 / weights)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result = ols(y=y, x=x, weights=1 / weights)
 
         combined = x.copy()
         combined['__y__'] = y
@@ -153,10 +154,12 @@ class TestOLS(BaseTest):
 
     def checkOLS(self, exog, endog, x, y):
         reference = sm.OLS(endog, sm.add_constant(exog, prepend=False)).fit()
-        result = ols(y=y, x=x)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result = ols(y=y, x=x)
 
         # check that sparse version is the same
-        sparse_result = ols(y=y.to_sparse(), x=x.to_sparse())
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            sparse_result = ols(y=y.to_sparse(), x=x.to_sparse())
         _compare_ols_results(result, sparse_result)
 
         assert_almost_equal(reference.params, result._beta_raw)
@@ -177,14 +180,16 @@ class TestOLS(BaseTest):
     def checkMovingOLS(self, window_type, x, y, weights=None, **kwds):
         window = np.linalg.matrix_rank(x.values) * 2
 
-        moving = ols(y=y, x=x, weights=weights, window_type=window_type,
-                     window=window, **kwds)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            moving = ols(y=y, x=x, weights=weights, window_type=window_type,
+                         window=window, **kwds)
 
         # check that sparse version is the same
-        sparse_moving = ols(y=y.to_sparse(), x=x.to_sparse(),
-                            weights=weights,
-                            window_type=window_type,
-                            window=window, **kwds)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            sparse_moving = ols(y=y.to_sparse(), x=x.to_sparse(),
+                                weights=weights,
+                                window_type=window_type,
+                                window=window, **kwds)
         _compare_ols_results(moving, sparse_moving)
 
         index = moving._index
@@ -202,7 +207,8 @@ class TestOLS(BaseTest):
                 x_iter[k] = v.truncate(before=prior_date, after=date)
             y_iter = y.truncate(before=prior_date, after=date)
 
-            static = ols(y=y_iter, x=x_iter, weights=weights, **kwds)
+            with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+                static = ols(y=y_iter, x=x_iter, weights=weights, **kwds)
 
             self.compare(static, moving, event_index=i,
                          result_index=n)
@@ -248,7 +254,8 @@ class TestOLS(BaseTest):
 
     def test_ols_object_dtype(self):
         df = DataFrame(np.random.randn(20, 2), dtype=object)
-        model = ols(y=df[0], x=df[1])
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model = ols(y=df[0], x=df[1])
         summary = repr(model)
 
 
@@ -269,7 +276,8 @@ class TestOLSMisc(tm.TestCase):
         x = tm.makeTimeDataFrame()
         y = x.pop('A')
 
-        model = ols(y=y, x=x)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model = ols(y=y, x=x)
 
         hyp = '1*B+1*C+1*D=0'
         result = model.f_test(hyp)
@@ -289,8 +297,10 @@ class TestOLSMisc(tm.TestCase):
         x_with = x.copy()
         x_with['intercept'] = 1.
 
-        model1 = ols(y=y, x=x)
-        model2 = ols(y=y, x=x_with, intercept=False)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model1 = ols(y=y, x=x)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model2 = ols(y=y, x=x_with, intercept=False)
         assert_series_equal(model1.beta, model2.beta)
 
         # TODO: can we infer whether the intercept is there...
@@ -298,28 +308,33 @@ class TestOLSMisc(tm.TestCase):
 
         # rolling
 
-        model1 = ols(y=y, x=x, window=20)
-        model2 = ols(y=y, x=x_with, window=20, intercept=False)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model1 = ols(y=y, x=x, window=20)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model2 = ols(y=y, x=x_with, window=20, intercept=False)
         assert_frame_equal(model1.beta, model2.beta)
         self.assertTrue((model1.r2 != model2.r2).all())
 
     def test_summary_many_terms(self):
         x = DataFrame(np.random.randn(100, 20))
         y = np.random.randn(100)
-        model = ols(y=y, x=x)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model = ols(y=y, x=x)
         model.summary
 
     def test_y_predict(self):
         y = tm.makeTimeSeries()
         x = tm.makeTimeDataFrame()
-        model1 = ols(y=y, x=x)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model1 = ols(y=y, x=x)
         assert_series_equal(model1.y_predict, model1.y_fitted)
         assert_almost_equal(model1._y_predict_raw, model1._y_fitted_raw)
 
     def test_predict(self):
         y = tm.makeTimeSeries()
         x = tm.makeTimeDataFrame()
-        model1 = ols(y=y, x=x)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model1 = ols(y=y, x=x)
         assert_series_equal(model1.predict(), model1.y_predict)
         assert_series_equal(model1.predict(x=x), model1.y_predict)
         assert_series_equal(model1.predict(beta=model1.beta), model1.y_predict)
@@ -358,7 +373,8 @@ class TestOLSMisc(tm.TestCase):
 
         endog = Series(endogenous)
         exog = Series(exogenous)
-        model = ols(y=endog, x=exog)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model = ols(y=endog, x=exog)
 
         pred = model.y_predict
         self.assertTrue(pred.index.equals(exog.index))
@@ -368,7 +384,8 @@ class TestOLSMisc(tm.TestCase):
         lp = wp.to_frame()
 
         y = lp.pop('ItemA')
-        model = ols(y=y, x=lp, entity_effects=True, window=20)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model = ols(y=y, x=lp, entity_effects=True, window=20)
         self.assertTrue(notnull(model.beta.values).all())
         tm.assertIsInstance(model, PanelOLS)
         model.summary
@@ -376,8 +393,10 @@ class TestOLSMisc(tm.TestCase):
     def test_series_rhs(self):
         y = tm.makeTimeSeries()
         x = tm.makeTimeSeries()
-        model = ols(y=y, x=x)
-        expected = ols(y=y, x={'x': x})
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model = ols(y=y, x=x)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            expected = ols(y=y, x={'x': x})
         assert_series_equal(model.beta, expected.beta)
 
         # GH 5233/5250
@@ -388,7 +407,8 @@ class TestOLSMisc(tm.TestCase):
 
         x = DataFrame(np.random.randn(100, 5))
         y = np.random.randn(100)
-        model = ols(y=y, x=x, window=20)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model = ols(y=y, x=x, window=20)
 
         series_attrs = ['rank', 'df', 'forecast_mean', 'forecast_vol']
 
@@ -405,17 +425,22 @@ class TestOLSMisc(tm.TestCase):
         y = tm.makeTimeSeries()
 
         data = {'foo': df1, 'bar': df2}
-        self.assertRaises(Exception, ols, y=y, x=data)
+        def f():
+            with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+                ols(y=y, x=data)
+        self.assertRaises(Exception, f)
 
     def test_plm_ctor(self):
         y = tm.makeTimeDataFrame()
         x = {'a': tm.makeTimeDataFrame(),
              'b': tm.makeTimeDataFrame()}
 
-        model = ols(y=y, x=x, intercept=False)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model = ols(y=y, x=x, intercept=False)
         model.summary
 
-        model = ols(y=y, x=Panel(x))
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model = ols(y=y, x=Panel(x))
         model.summary
 
     def test_plm_attrs(self):
@@ -423,8 +448,10 @@ class TestOLSMisc(tm.TestCase):
         x = {'a': tm.makeTimeDataFrame(),
              'b': tm.makeTimeDataFrame()}
 
-        rmodel = ols(y=y, x=x, window=10)
-        model = ols(y=y, x=x)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            rmodel = ols(y=y, x=x, window=10)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model = ols(y=y, x=x)
         model.resid
         rmodel.resid
 
@@ -433,7 +460,8 @@ class TestOLSMisc(tm.TestCase):
         x = {'a': tm.makeTimeDataFrame(),
              'b': tm.makeTimeDataFrame()}
 
-        model = ols(y=y, x=x, window=10)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model = ols(y=y, x=x, window=10)
         result = model.lagged_y_predict(2)
 
     def test_plm_f_test(self):
@@ -441,7 +469,8 @@ class TestOLSMisc(tm.TestCase):
         x = {'a': tm.makeTimeDataFrame(),
              'b': tm.makeTimeDataFrame()}
 
-        model = ols(y=y, x=x)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model = ols(y=y, x=x)
 
         hyp = '1*a+1*b=0'
         result = model.f_test(hyp)
@@ -456,12 +485,16 @@ class TestOLSMisc(tm.TestCase):
         x = {'a': tm.makeTimeDataFrame(),
              'b': tm.makeTimeDataFrame()}
 
-        model = ols(
-            y=y, x=x, entity_effects=True, dropped_dummies={'entity': 'D'})
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model = ols(
+                y=y, x=x, entity_effects=True, dropped_dummies={'entity': 'D'})
         model.summary
 
-        self.assertRaises(Exception, ols, y=y, x=x, entity_effects=True,
-                          dropped_dummies={'entity': 'E'})
+        def f():
+            with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+                ols(y=y, x=x, entity_effects=True,
+                    dropped_dummies={'entity': 'E'})
+        self.assertRaises(Exception, f)
 
     def test_columns_tuples_summary(self):
         # #1837
@@ -469,7 +502,8 @@ class TestOLSMisc(tm.TestCase):
         Y = Series(np.random.randn(10))
 
         # it works!
-        model = ols(y=Y, x=X)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            model = ols(y=Y, x=X)
         model.summary
 
 
@@ -484,7 +518,8 @@ class TestPanelOLS(BaseTest):
     _other_fields = ['resid', 'y_fitted']
 
     def testFiltering(self):
-        result = ols(y=self.panel_y2, x=self.panel_x2)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result = ols(y=self.panel_y2, x=self.panel_x2)
 
         x = result._x
         index = x.index.get_level_values(0)
@@ -544,8 +579,10 @@ class TestPanelOLS(BaseTest):
         stack_x.index = stack_x.index._tuple_index
         stack_weights.index = stack_weights.index._tuple_index
 
-        result = ols(y=y, x=x, weights=1 / weights)
-        expected = ols(y=stack_y, x=stack_x, weights=1 / stack_weights)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result = ols(y=y, x=x, weights=1 / weights)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            expected = ols(y=stack_y, x=stack_x, weights=1 / stack_weights)
 
         assert_almost_equal(result.beta, expected.beta)
 
@@ -555,7 +592,8 @@ class TestPanelOLS(BaseTest):
             assert_almost_equal(rvals, evals)
 
     def testWithTimeEffects(self):
-        result = ols(y=self.panel_y2, x=self.panel_x2, time_effects=True)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result = ols(y=self.panel_y2, x=self.panel_x2, time_effects=True)
 
         assert_almost_equal(result._y_trans.values.flat, [0, -0.5, 0.5])
 
@@ -565,7 +603,8 @@ class TestPanelOLS(BaseTest):
         # _check_non_raw_results(result)
 
     def testWithEntityEffects(self):
-        result = ols(y=self.panel_y2, x=self.panel_x2, entity_effects=True)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result = ols(y=self.panel_y2, x=self.panel_x2, entity_effects=True)
 
         assert_almost_equal(result._y.values.flat, [1, 4, 5])
 
@@ -577,8 +616,9 @@ class TestPanelOLS(BaseTest):
         # _check_non_raw_results(result)
 
     def testWithEntityEffectsAndDroppedDummies(self):
-        result = ols(y=self.panel_y2, x=self.panel_x2, entity_effects=True,
-                     dropped_dummies={'entity': 'B'})
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result = ols(y=self.panel_y2, x=self.panel_x2, entity_effects=True,
+                         dropped_dummies={'entity': 'B'})
 
         assert_almost_equal(result._y.values.flat, [1, 4, 5])
         exp_x = DataFrame([[1., 6., 14., 1.], [1, 9, 17, 1], [0, 30, 48, 1]],
@@ -589,7 +629,8 @@ class TestPanelOLS(BaseTest):
         # _check_non_raw_results(result)
 
     def testWithXEffects(self):
-        result = ols(y=self.panel_y2, x=self.panel_x2, x_effects=['x1'])
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result = ols(y=self.panel_y2, x=self.panel_x2, x_effects=['x1'])
 
         assert_almost_equal(result._y.values.flat, [1, 4, 5])
 
@@ -600,8 +641,9 @@ class TestPanelOLS(BaseTest):
         assert_frame_equal(res, exp_x.reindex(columns=res.columns))
 
     def testWithXEffectsAndDroppedDummies(self):
-        result = ols(y=self.panel_y2, x=self.panel_x2, x_effects=['x1'],
-                     dropped_dummies={'x1': 30})
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result = ols(y=self.panel_y2, x=self.panel_x2, x_effects=['x1'],
+                         dropped_dummies={'x1': 30})
 
         res = result._x
         assert_almost_equal(result._y.values.flat, [1, 4, 5])
@@ -612,7 +654,8 @@ class TestPanelOLS(BaseTest):
         assert_frame_equal(res, exp_x.reindex(columns=res.columns))
 
     def testWithXEffectsAndConversion(self):
-        result = ols(y=self.panel_y3, x=self.panel_x3, x_effects=['x1', 'x2'])
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result = ols(y=self.panel_y3, x=self.panel_x3, x_effects=['x1', 'x2'])
 
         assert_almost_equal(result._y.values.flat, [1, 2, 3, 4])
         exp_x = [[0, 0, 0, 1, 1], [1, 0, 0, 0, 1], [0, 1, 1, 0, 1],
@@ -625,8 +668,9 @@ class TestPanelOLS(BaseTest):
         # _check_non_raw_results(result)
 
     def testWithXEffectsAndConversionAndDroppedDummies(self):
-        result = ols(y=self.panel_y3, x=self.panel_x3, x_effects=['x1', 'x2'],
-                     dropped_dummies={'x2': 'foo'})
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result = ols(y=self.panel_y3, x=self.panel_x3, x_effects=['x1', 'x2'],
+                         dropped_dummies={'x2': 'foo'})
 
         assert_almost_equal(result._y.values.flat, [1, 2, 3, 4])
         exp_x = [[0, 0, 0, 0, 1], [1, 0, 1, 0, 1], [0, 1, 0, 1, 1],
@@ -707,7 +751,8 @@ class TestPanelOLS(BaseTest):
 
     def checkNonPooled(self, x, y, **kwds):
         # For now, just check that it doesn't crash
-        result = ols(y=y, x=x, pool=False, **kwds)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result = ols(y=y, x=x, pool=False, **kwds)
 
         _check_repr(result)
         for attr in NonPooledPanelOLS.ATTRIBUTES:
@@ -716,8 +761,9 @@ class TestPanelOLS(BaseTest):
     def checkMovingOLS(self, x, y, window_type='rolling', **kwds):
         window = 25  # must be larger than rank of x
 
-        moving = ols(y=y, x=x, window_type=window_type,
-                     window=window, **kwds)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            moving = ols(y=y, x=x, window_type=window_type,
+                         window=window, **kwds)
 
         index = moving._index
 
@@ -734,7 +780,8 @@ class TestPanelOLS(BaseTest):
                 x_iter[k] = v.truncate(before=prior_date, after=date)
             y_iter = y.truncate(before=prior_date, after=date)
 
-            static = ols(y=y_iter, x=x_iter, **kwds)
+            with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+                static = ols(y=y_iter, x=x_iter, **kwds)
 
             self.compare(static, moving, event_index=i,
                          result_index=n)
@@ -743,8 +790,10 @@ class TestPanelOLS(BaseTest):
 
     def checkForSeries(self, x, y, series_x, series_y, **kwds):
         # Consistency check with simple OLS.
-        result = ols(y=y, x=x, **kwds)
-        reference = ols(y=series_y, x=series_x, **kwds)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result = ols(y=y, x=x, **kwds)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            reference = ols(y=series_y, x=series_x, **kwds)
 
         self.compare(reference, result)
 
@@ -783,9 +832,11 @@ class TestPanelOLS(BaseTest):
         data = tm.makeTimeDataFrame()
         y = data.pop('A')
 
-        window_model = ols(y=y, x=data, window=20, min_periods=10)
-        rolling_model = ols(y=y, x=data, window=20, min_periods=10,
-                            window_type='rolling')
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            window_model = ols(y=y, x=data, window=20, min_periods=10)
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            rolling_model = ols(y=y, x=data, window=20, min_periods=10,
+                                window_type='rolling')
 
         assert_frame_equal(window_model.beta, rolling_model.beta)
 

--- a/pandas/stats/tests/test_ols.py
+++ b/pandas/stats/tests/test_ols.py
@@ -175,7 +175,7 @@ class TestOLS(BaseTest):
         _check_non_raw_results(result)
 
     def checkMovingOLS(self, window_type, x, y, weights=None, **kwds):
-        window = sm.tools.tools.rank(x.values) * 2
+        window = np.linalg.matrix_rank(x.values) * 2
 
         moving = ols(y=y, x=x, weights=weights, window_type=window_type,
                      window=window, **kwds)

--- a/pandas/stats/var.py
+++ b/pandas/stats/var.py
@@ -26,6 +26,12 @@ class VAR(StringMixin):
     """
 
     def __init__(self, data, p=1, intercept=True):
+        import warnings
+        warnings.warn("The pandas.stats.var module is deprecated and will be "
+                      "removed in a future version. We refer to external packages "
+                      "like statsmodels, see some examples here: http://statsmodels.sourceforge.net/stable/vector_ar.html#var",
+                      FutureWarning, stacklevel=4)
+
         try:
             import statsmodels.tsa.vector_ar.api as sm_var
         except ImportError:


### PR DESCRIPTION
closes #6077 

this cleans ups the remainder of the `pandas.stats` modules

we are directing:
- `OLS` -> `http://statsmodels.sourceforge.net/stable/regression.html`
- `PanelOLS/MovingOLS/PooledOLS` to `http://statsmodels.sourceforge.net/stable/mixed_linear.html`
- `VAR` to `http://statsmodels.sourceforge.net/stable/vector_ar.html#var`
- `fama_macbeth` to `http://statsmodels.sourceforge.net/stable/index.html` (as not implemented in statsmodell, but good place to start)
