### PR TITLE
EHN encoding parameter for to_latex

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -303,6 +303,9 @@ Other API Changes
 
 - ``.memory_usage`` now includes values in the index, as does memory_usage in ``.info`` (:issue:`11597`)
 
+- ``DataFrame.to_latex()`` now supports non-ascii encodings (eg utf-8) in Python 2 with the parameter ``encoding`` (:issue:`7061`)
+
+
 Changes to eval
 ^^^^^^^^^^^^^^^
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1547,7 +1547,7 @@ class DataFrame(NDFrame):
                  header=True, index=True, na_rep='NaN', formatters=None,
                  float_format=None, sparsify=None, index_names=True,
                  bold_rows=True, column_format=None,
-                 longtable=None, escape=None):
+                 longtable=None, escape=None, encoding=None):
         """
         Render a DataFrame to a tabular environment table. You can splice
         this into a LaTeX document. Requires \\usepackage{booktabs}.
@@ -1567,7 +1567,8 @@ class DataFrame(NDFrame):
             default: True
             When set to False prevents from escaping latex special
             characters in column names.
-
+        encoding : str, default None
+            Default encoding is ascii in Python 2 and utf-8 in Python 3
         """
 
         if colSpace is not None:  # pragma: no cover
@@ -1589,7 +1590,8 @@ class DataFrame(NDFrame):
                                            sparsify=sparsify,
                                            index_names=index_names,
                                            escape=escape)
-        formatter.to_latex(column_format=column_format, longtable=longtable)
+        formatter.to_latex(column_format=column_format, longtable=longtable,
+                           encoding=encoding)
 
         if buf is None:
             return formatter.buf.getvalue()

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -15,6 +15,8 @@ from numpy import nan
 from numpy.random import randn
 import numpy as np
 
+import codecs
+
 div_style = ''
 try:
     import IPython
@@ -2553,6 +2555,24 @@ c  10  11  12  13  14\
 
             with open(path, 'r') as f:
                 self.assertEqual(self.frame.to_latex(), f.read())
+
+        # test with utf-8 and encoding option (GH 7061)
+        df = DataFrame([[u'au\xdfgangen']])
+        with tm.ensure_clean('test.tex') as path:
+            df.to_latex(path, encoding='utf-8')
+            with codecs.open(path, 'r', encoding='utf-8') as f:
+                self.assertEqual(df.to_latex(), f.read())
+
+        # test with utf-8 without encoding option
+        if compat.PY3:  # python3 default encoding is utf-8
+            with tm.ensure_clean('test.tex') as path:
+                df.to_latex(path)
+                with codecs.open(path, 'r') as f:
+                    self.assertEqual(df.to_latex(), f.read())
+        else:
+            # python2 default encoding is ascii, so an error should be raised
+            with tm.ensure_clean('test.tex') as path:
+                self.assertRaises(UnicodeEncodeError, df.to_latex, path)
 
     def test_to_latex(self):
         # it works!


### PR DESCRIPTION
closes #7061 

I'm working on solving issue #7061: currently, with Python 2 it is not possible to use `.to_latex()` when the dataframe contains utf-8 strings. This PR adds an `encoding` parameter to make it possible.

The work is not completely done though, and I'm making this PR to start a discussion here. In its current state, the PR quickly fixes the issue and provides tests, so it is kind of a minimal PR.

@jreback in the discussion on issue #7061, you made the following suggestion:

> you _may_ want to add a `LatexFormatter` (as a sub-class of `DataFrameFormatter`) as this will allow some re-factoring to be internally done later on. 

I would be glad to work in that direction, but I'm a bit confused by the current organization of the code. This `LatexFormatter` would seem to me to be similar to `HTMLFormatter`, which inherits from `TableFormatter` (exactly as `DataFrameFormatter`). In that case, `DataFrameFormatter` would use `LatexFormatter` for `.to_latex()` exactly as it uses `HTMLFormatter` for `.to_html()`.  Is that what you had in mind?
