### PR TITLE
BUG in DataFrameGroupBy.rank raising an obscure TypeError

### DIFF
--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1397,7 +1397,14 @@ class GroupBy(_GroupBy):
             return values.rank(axis=axis, method=method, na_option=na_option,
                                ascending=ascending, pct=pct)
 
-        return data.transform(wrapper)
+        try:
+            return data.transform(wrapper)
+        except ValueError:
+            if not numeric_only and method=='first':
+                raise ValueError('first not supported for non-numeric data')
+                # such a ValueError is raised by pandas.algos.rank_2d_generic
+                # for regular (non-grouped) dataframes
+
 
     @Substitution(name='groupby')
     @Appender(_doc_template)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1385,26 +1385,24 @@ class GroupBy(_GroupBy):
         """Compute numerical data ranks (1 through n) along axis.
         """
 
-        if numeric_only:
-            data = self._obj_with_exclusions._get_numeric_data()
-            if data.size == 0:
-                raise DataError('No numeric types to aggregate')
-            data = data.groupby(self.grouper)
-        else:
-            data = self
-
         def wrapper(values):
             return values.rank(axis=axis, method=method, na_option=na_option,
                                ascending=ascending, pct=pct)
 
         try:
-            return data.transform(wrapper)
+            return self.transform(wrapper)
         except ValueError:
-            if not numeric_only and method=='first':
+            if not numeric_only and method == 'first':
                 raise ValueError('first not supported for non-numeric data')
                 # such a ValueError is raised by pandas.algos.rank_2d_generic
                 # for regular (non-grouped) dataframes
-
+            if numeric_only:
+                data = self._obj_with_exclusions._get_numeric_data()
+                if data.size == 0:
+                    raise DataError('No numeric types to aggregate')
+                data = data.groupby(self.grouper)
+                return data.transform(wrapper)
+            raise
 
     @Substitution(name='groupby')
     @Appender(_doc_template)

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -3646,6 +3646,24 @@ class TestGroupBy(tm.TestCase):
         expected = self.df.groupby('A').agg(np.mean)
         assert_frame_equal(result, expected)
 
+    def test_rank(self):
+        # GH 11759
+        df = DataFrame({'a': ['A1', 'A1', 'A1'],
+                        'b': ['B1', 'B1', 'B2'],
+                        'c': 1.})
+        df = df.set_index('a')
+        dg = df.groupby('c')
+        self.assertRaises(DataError, dg.rank, method='first')
+
+        # with another numeric column
+        df = DataFrame({'a': ['A1', 'A1', 'A1'],
+                        'b': ['B1', 'B1', 'B2'],
+                        'c': 1.,
+                        'd': 1.})
+        df = df.set_index('a')
+        expected = df.drop('b', axis=1).groupby('c').rank(method='first')
+        assert_frame_equal(df.groupby('c').rank(method='first'), expected)
+
     def test_rank_apply(self):
         lev1 = tm.rands_array(10, 100)
         lev2 = tm.rands_array(10, 130)
@@ -5753,7 +5771,6 @@ class TestGroupBy(tm.TestCase):
             'cumcount',
             'resample',
             'describe',
-            'rank',
             'quantile',
             'fillna',
             'mad',
@@ -5794,7 +5811,6 @@ class TestGroupBy(tm.TestCase):
             'cumcount',
             'resample',
             'describe',
-            'rank',
             'quantile',
             'fillna',
             'mad',

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -3653,7 +3653,14 @@ class TestGroupBy(tm.TestCase):
                         'c': 1.})
         df = df.set_index('a')
         dg = df.groupby('c')
-        self.assertRaises(DataError, dg.rank, method='first')
+        self.assertRaises(DataError, dg.rank,
+                          method='first')
+        self.assertRaises(DataError, dg.rank,
+                          method='first', numeric_only=True)
+        self.assertRaises(ValueError, dg.rank,
+                          method='first', numeric_only=False)
+        # such a ValueError is raised by pandas.algos.rank_2d_generic
+        # for regular (non-grouped) dataframes
 
         # with another numeric column
         df = DataFrame({'a': ['A1', 'A1', 'A1'],
@@ -3661,8 +3668,18 @@ class TestGroupBy(tm.TestCase):
                         'c': 1.,
                         'd': 1.})
         df = df.set_index('a')
+        dg = df.groupby('c')
         expected = df.drop('b', axis=1).groupby('c').rank(method='first')
-        assert_frame_equal(df.groupby('c').rank(method='first'), expected)
+
+        result = dg.rank(method='first')
+        assert_frame_equal(result, expected)
+
+        result = dg.rank(method='first', numeric_only=True)
+        assert_frame_equal(result, expected)
+
+        self.assertRaises(ValueError, dg.rank,
+                          method='first', numeric_only=False)
+        # same remark as above
 
     def test_rank_apply(self):
         lev1 = tm.rands_array(10, 100)


### PR DESCRIPTION
Fix issue #11759

Two things:
1. `Series.rank` and `DataFrame.rank` have been moved to `generic.py` and get the same signature [done with PR #11924]
2. It can happen that aggregate functions are applied to grouped object in a recursive way. Instead of raising a plain `ValueError` when that fails, and catching it afterwards indistinctly, I propose to raise an `_ErrorContainer` exception containing the last meaningful error to have been raised. Thus, when everything else has failed, we can still recover a meaningful exception and throw it back at the user.
