### PR TITLE
ENH: raise exception when sqlalchemy is required for database string URI

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -528,6 +528,8 @@ def pandasSQL_builder(con, flavor=None, schema=None, meta=None,
     con = _engine_builder(con)
     if _is_sqlalchemy_connectable(con):
         return SQLDatabase(con, schema=schema, meta=meta)
+    elif isinstance(con, string_types):
+        raise ImportError("Using URI string without sqlalchemy installed.")
     else:
         return SQLiteDatabase(con, is_cursor=is_cursor)
 

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -1051,6 +1051,14 @@ class TestSQLiteFallbackApi(SQLiteMixIn, _TestSQLApi):
 
         tm.assert_frame_equal(self.test_frame3, result)
 
+    def test_con_string_import_error(self):
+        if not SQLALCHEMY_INSTALLED:
+            conn = 'mysql://root@localhost/pandas_nosetest'
+            self.assertRaises(ImportError, sql.read_sql, "SELECT * FROM iris",
+                              conn)
+        else:
+            raise nose.SkipTest('SQLAlchemy is installed')
+
     def test_read_sql_delegate(self):
         iris_frame1 = sql.read_sql_query("SELECT * FROM iris", self.conn)
         iris_frame2 = sql.read_sql("SELECT * FROM iris", self.conn)


### PR DESCRIPTION
- I get a cryptic error `AttributeError: 'str' object has no attribute 'cursor'` if sqlalchemy is not installed and I pass a database string URI to `pandas.read_sql`. I think the error should be made more explicit.
- Also I think there is a shadowing issue with`_SQLALCHEMY_INSTALLED` in `_engine_builder`.

```
/opt/conda/lib/python3.4/site-packages/pandas/io/sql.py in read_sql_query(sql, con, index_col, coerce_float, params, parse_dates, chunksize)
    427     return pandas_sql.read_query(
    428         sql, index_col=index_col, params=params, coerce_float=coerce_float,
--> 429         parse_dates=parse_dates, chunksize=chunksize)
    430 
    431 

/opt/conda/lib/python3.4/site-packages/pandas/io/sql.py in read_query(self, sql, index_col, coerce_float, params, parse_dates, chunksize)
   1569 
   1570         args = _convert_params(sql, params)
-> 1571         cursor = self.execute(*args)
   1572         columns = [col_desc[0] for col_desc in cursor.description]
   1573 

/opt/conda/lib/python3.4/site-packages/pandas/io/sql.py in execute(self, *args, **kwargs)
   1532             cur = self.con
   1533         else:
-> 1534             cur = self.con.cursor()
   1535         try:
   1536             if kwargs:

AttributeError: 'str' object has no attribute 'cursor'
```
