### PR TITLE
API: GH11885 DataFrame.round() now returns non-numeric columns unchanged

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -165,6 +165,7 @@ Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - The parameter ``out`` has been removed from the ``Series.round()`` method. (:issue:`11763`)
+- ``DataFrame.round()`` leaves non-numeric columns unchanged in its return, rather than raises. (:issue:`11885`)
 
 Bug in QuarterBegin with n=0
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4416,9 +4416,14 @@ class DataFrame(NDFrame):
         def _dict_round(df, decimals):
             for col, vals in df.iteritems():
                 try:
-                    yield vals.round(decimals[col])
+                    yield _series_round(vals, decimals[col])
                 except KeyError:
                     yield vals
+
+        def _series_round(s, decimals):
+            if com.is_integer_dtype(s) or com.is_float_dtype(s):
+                return s.round(decimals)
+            return s
 
         if isinstance(decimals, (dict, Series)):
             if isinstance(decimals, Series):
@@ -4427,7 +4432,7 @@ class DataFrame(NDFrame):
             new_cols = [col for col in _dict_round(self, decimals)]
         elif com.is_integer(decimals):
             # Dispatch to Series.round
-            new_cols = [v.round(decimals) for _, v in self.iteritems()]
+            new_cols = [_series_round(v, decimals) for _, v in self.iteritems()]
         else:
             raise TypeError("decimals must be an integer, a dict-like or a Series")
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -13523,6 +13523,21 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # Make sure this doesn't break existing Series.round
         tm.assert_series_equal(df['col1'].round(1), expected_rounded['col1'])
 
+
+    def test_round_mixed_type(self):
+        # GH11885
+        df = DataFrame({'col1': [1.1, 2.2, 3.3, 4.4], 'col2': ['1', 'a', 'c', 'f'],
+                        'col3': date_range('20111111', periods=4)})
+        round_0 = DataFrame({'col1': [1., 2., 3., 4.], 'col2': ['1', 'a', 'c' ,'f'],
+                              'col3': date_range('20111111', periods=4)})
+        tm.assert_frame_equal(df.round(), round_0)
+        tm.assert_frame_equal(df.round(1), df)
+        tm.assert_frame_equal(df.round({'col1':1}), df)
+        tm.assert_frame_equal(df.round({'col1':0}), round_0)
+        tm.assert_frame_equal(df.round({'col1':0, 'col2':1}), round_0)
+        tm.assert_frame_equal(df.round({'col3':1}), df)
+
+
     def test_round_issue(self):
         # GH11611
 


### PR DESCRIPTION
closes #11885 
