### PR TITLE
head(0) and tail(0) return empty DataFrames

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -166,6 +166,8 @@ Backwards incompatible API changes
 
 - The parameter ``out`` has been removed from the ``Series.round()`` method. (:issue:`11763`)
 - ``DataFrame.round()`` leaves non-numeric columns unchanged in its return, rather than raises. (:issue:`11885`)
+- ``DataFrame.head(0)`` and ``DataFrame.tail(0)`` return empty frames, rather than ``self``.  (:issue:`11937`)
+- ``Series.head(0)`` and ``Series.tail(0)`` return empty series, rather than ``self``.  (:issue:`11937`)
 
 NaT and Timedelta operations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2136,18 +2136,14 @@ class NDFrame(PandasObject):
         """
         Returns first n rows
         """
-        l = len(self)
-        if l == 0 or n==0:
-            return self
         return self.iloc[:n]
 
     def tail(self, n=5):
         """
         Returns last n rows
         """
-        l = len(self)
-        if l == 0 or n == 0:
-            return self
+        if n == 0:
+            return self.iloc[0:0]
         return self.iloc[-n:]
 
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -5457,8 +5457,10 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
     def test_head_tail(self):
         assert_frame_equal(self.frame.head(), self.frame[:5])
         assert_frame_equal(self.frame.tail(), self.frame[-5:])
-        assert_frame_equal(self.frame.head(0), self.frame)
-        assert_frame_equal(self.frame.tail(0), self.frame)
+         
+        assert_frame_equal(self.frame.head(0), self.frame[0:0])
+        assert_frame_equal(self.frame.tail(0), self.frame[0:0])
+        
         assert_frame_equal(self.frame.head(-1), self.frame[:-1])
         assert_frame_equal(self.frame.tail(-1), self.frame[1:])
         assert_frame_equal(self.frame.head(1), self.frame[:1])
@@ -5468,8 +5470,8 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         df.index = np.arange(len(self.frame)) + 0.1
         assert_frame_equal(df.head(), df.iloc[:5])
         assert_frame_equal(df.tail(), df.iloc[-5:])
-        assert_frame_equal(df.head(0), df)
-        assert_frame_equal(df.tail(0), df)
+        assert_frame_equal(df.head(0), df[0:0])
+        assert_frame_equal(df.tail(0), df[0:0])
         assert_frame_equal(df.head(-1), df.iloc[:-1])
         assert_frame_equal(df.tail(-1), df.iloc[1:])
         #test empty dataframe

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -342,8 +342,8 @@ class Generic(object):
             self._compare(o.tail(), o.iloc[-5:])
 
             # 0-len
-            self._compare(o.head(0), o.iloc[:])
-            self._compare(o.tail(0), o.iloc[0:])
+            self._compare(o.head(0), o.iloc[0:0])
+            self._compare(o.tail(0), o.iloc[0:0])
 
             # bounded
             self._compare(o.head(len(o)+1), o)

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -7642,8 +7642,9 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
 
     def test_head_tail(self):
         assert_series_equal(self.series.head(), self.series[:5])
+        assert_series_equal(self.series.head(0), self.series[0:0])
         assert_series_equal(self.series.tail(), self.series[-5:])
-
+        assert_series_equal(self.series.tail(0), self.series[0:0])
     def test_isin(self):
         s = Series(['A', 'B', 'C', 'a', 'B', 'B', 'A', 'C'])
 


### PR DESCRIPTION
closes #11930 

frame.head(0)  and frame.tail(0) now return empty DataFrames.
