### PR TITLE
Exception handler should use column NA values if available

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1028,7 +1028,7 @@ class ParserBase(object):
                 try:
                     values = lib.map_infer(values, conv_f)
                 except ValueError:
-                    mask = lib.ismember(values, na_values).view(np.uint8)
+                    mask = lib.ismember(values, col_na_values).view(np.uint8)
                     values = lib.map_infer_mask(values, conv_f, mask)
                 coerce_type = False
 


### PR DESCRIPTION
Exception handler didn't use the list of columnar NaN types if they were generated.
