### PR TITLE
ENH: add to_xarray conversion method

### DIFF
--- a/ci/requirements-2.7.run
+++ b/ci/requirements-2.7.run
@@ -20,3 +20,4 @@ html5lib=1.0b2
 beautiful-soup=4.2.1
 statsmodels
 jinja2=2.8
+xarray

--- a/ci/requirements-3.5.run
+++ b/ci/requirements-3.5.run
@@ -17,6 +17,7 @@ bottleneck
 sqlalchemy
 pymysql
 psycopg2
+xarray
 
 # incompat with conda ATM
 # beautiful-soup

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -684,6 +684,7 @@ Serialization / IO / Conversion
    Series.to_csv
    Series.to_dict
    Series.to_frame
+   Series.to_xarray
    Series.to_hdf
    Series.to_sql
    Series.to_msgpack
@@ -918,6 +919,7 @@ Reshaping, sorting, transposing
    DataFrame.unstack
    DataFrame.T
    DataFrame.to_panel
+   DataFrame.to_xarray
    DataFrame.transpose
 
 Combining / joining / merging
@@ -1216,6 +1218,7 @@ Serialization / IO / Conversion
    Panel.to_json
    Panel.to_sparse
    Panel.to_frame
+   Panel.to_xarray
    Panel.to_clipboard
 
 .. _api.panel4d:
@@ -1229,6 +1232,13 @@ Constructor
    :toctree: generated/
 
    Panel4D
+
+Serialization / IO / Conversion
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autosummary::
+   :toctree: generated/
+
+   Panel4D.to_xarray
 
 Attributes and underlying data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -244,6 +244,7 @@ Optional Dependencies
 * `Cython <http://www.cython.org>`__: Only necessary to build development
   version. Version 0.19.1 or higher.
 * `SciPy <http://www.scipy.org>`__: miscellaneous statistical functions
+* `xarray <http://xarray.readthedocs.org>`__: pandas like handling for > 2 dims, needed for converting Panels to xarray objects. Version 0.7.0 or higher is recommended.
 * `PyTables <http://www.pytables.org>`__: necessary for HDF5-based storage. Version 3.0.0 or higher required, Version 3.2.1 or higher highly recommended.
 * `SQLAlchemy <http://www.sqlalchemy.org>`__: for SQL database support. Version 0.8.1 or higher recommended. Besides SQLAlchemy, you also need a database specific driver. You can find an overview of supported drivers for each SQL dialect in the `SQLAlchemy docs <http://docs.sqlalchemy.org/en/latest/dialects/index.html>`__. Some common drivers are:
 

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -271,6 +271,7 @@ In addition, ``.round()``, ``.floor()`` and ``.ceil()`` will be available thru t
    s
    s.dt.round('D')
 
+<<<<<<< 6693a723aa2a8a53a071860a43804c173a7f92c6
 
 Formatting of integer in FloatIndex
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -312,6 +313,35 @@ New Behavior:
    s.index
    print(s.to_csv(path=None))
 
+.. _whatsnew_0180.enhancements.xarray:
+
+to_xarray
+^^^^^^^^^
+
+In a future version of pandas, we will be deprecating ``Panel`` and other > 2 ndim objects. In order to provide for continuity,
+all ``NDFrame`` objects have gained the ``.to_xarray()`` method in order to convert to ``xarray`` objects, which have
+a pandas-like interface for > 2 ndim.
+
+See the `xarray full-documentation here <http://xarray.pydata.org/en/stable/>`__.
+
+.. code-block:: python
+
+   In [1]: p = Panel(np.arange(2*3*4).reshape(2,3,4))
+
+   In [2]: p.to_xarray()
+   Out[2]:
+   <xarray.DataArray (items: 2, major_axis: 3, minor_axis: 4)>
+   array([[[ 0,  1,  2,  3],
+           [ 4,  5,  6,  7],
+           [ 8,  9, 10, 11]],
+
+          [[12, 13, 14, 15],
+           [16, 17, 18, 19],
+           [20, 21, 22, 23]]])
+   Coordinates:
+     * items       (items) int64 0 1
+     * major_axis  (major_axis) int64 0 1 2
+     * minor_axis  (minor_axis) int64 0 1 2 3
 
 .. _whatsnew_0180.enhancements.other:
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1039,6 +1039,32 @@ class NDFrame(PandasObject):
         from pandas.io import clipboard
         clipboard.to_clipboard(self, excel=excel, sep=sep, **kwargs)
 
+    def to_xarray(self):
+        """
+        Return an xarray object from the pandas object.
+
+        Returns
+        -------
+        a DataArray for a Series
+        a Dataset for a DataFrame
+        a DataArray for higher dims
+
+        See Also
+        --------
+        `xarray docs <http://xarray.pydata.org/en/stable/>`__
+        """
+        import xarray
+        if self.ndim == 1:
+            return xarray.DataArray.from_series(self)
+        elif self.ndim == 2:
+            return xarray.Dataset.from_dataframe(self)
+
+        # > 2 dims
+        coords = [(a, self._get_axis(a)) for a in self._AXIS_ORDERS]
+        return xarray.DataArray(self,
+                                coords=coords,
+                                )
+
     # ----------------------------------------------------------------------
     # Fancy Indexing
 

--- a/pandas/util/print_versions.py
+++ b/pandas/util/print_versions.py
@@ -68,6 +68,7 @@ def show_versions(as_json=False):
         ("numpy", lambda mod: mod.version.version),
         ("scipy", lambda mod: mod.version.version),
         ("statsmodels", lambda mod: mod.__version__),
+        ("xarray", lambda mod: mod.__version__),
         ("IPython", lambda mod: mod.__version__),
         ("sphinx", lambda mod: mod.__version__),
         ("patsy", lambda mod: mod.__version__),

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -224,6 +224,18 @@ def _skip_if_scipy_0_17():
         import nose
         raise nose.SkipTest("scipy 0.17")
 
+def _skip_if_no_xarray():
+    try:
+        import xarray
+    except ImportError:
+        import nose
+        raise nose.SkipTest("xarray not installed")
+
+    v = xarray.__version__
+    if v < LooseVersion('0.7.0'):
+        import nose
+        raise nose.SkipTest("xarray not version is too low: {0}".format(v))
+
 def _skip_if_no_pytz():
     try:
         import pytz


### PR DESCRIPTION
supersedes #11950 
xref #10000 

using `xarray` >= 07.0

```
In [10]: Series([1,2,3]).to_xarray()
Out[10]: 
<xarray.DataArray (index: 3)>
array([1, 2, 3])
Coordinates:
  * index    (index) int64 0 1 2

In [11]: DataFrame({'A' : [1,2,3], 'B' : ['foo','bar','baz']}).to_xarray()
Out[11]: 
<xarray.Dataset>
Dimensions:  (index: 3)
Coordinates:
  * index    (index) int64 0 1 2
Data variables:
    A        (index) int64 1 2 3
    B        (index) object 'foo' 'bar' 'baz'

In [14]: Panel(np.random.randn(2, 3, 4)).to_xarray()
Out[14]: 
<xarray.DataArray (items: 2, major_axis: 3, minor_axis: 4)>
array([[[ 0.23726039,  0.44636322,  0.04425575,  1.06178388],
        [-0.58236405,  0.62602167,  0.36156612, -0.12687913],
        [-0.67854107,  0.72270844, -1.15402631, -1.89758909]],

       [[ 0.42948622,  0.93227075, -0.13943692,  0.83043343],
        [ 1.0355157 , -0.30532004, -0.16337369, -0.29283026],
        [ 0.65199775, -0.11131818,  0.37853134,  1.56620844]]])
Coordinates:
  * items       (items) int64 0 1
  * major_axis  (major_axis) int64 0 1 2
  * minor_axis  (minor_axis) int64 0 1 2 3
```

TODO:
- [ ] examples in doc-string
- [ ] how-to-convert/use xarray
