### PR TITLE
ENH/API: Scalar values for Series.rename and NDFrame.rename_axis

### DIFF
--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -1170,6 +1170,15 @@ The :meth:`~DataFrame.rename` method also provides an ``inplace`` named
 parameter that is by default ``False`` and copies the underlying data. Pass
 ``inplace=True`` to rename the data in place.
 
+.. versionadded:: 0.18.0
+
+Finally, :meth:`~Series.rename` also accepts a scalar or list-like
+for altering the ``Series.name`` attribute.
+
+.. ipython:: python
+
+   s.rename("scalar-name")
+
 .. _basics.rename_axis:
 
 The Panel class has a related :meth:`~Panel.rename_axis` class which can rename

--- a/doc/source/dsintro.rst
+++ b/doc/source/dsintro.rst
@@ -214,6 +214,17 @@ Series can also have a ``name`` attribute:
 The Series ``name`` will be assigned automatically in many cases, in particular
 when taking 1D slices of DataFrame as you will see below.
 
+.. versionadded:: 0.18.0
+
+You can rename a Series with the :meth:`pandas.Series.rename` method.
+
+.. ipython:: python
+
+   s2 = s.rename("different")
+   s2.name
+
+Note that ``s`` and ``s2`` refer to different objects.
+
 .. _basics.dataframe:
 
 DataFrame

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -104,6 +104,27 @@ And multiple aggregations
    r.agg({'A' : ['mean','std'],
           'B' : ['mean','std']})
 
+.. _whatsnew_0180.enhancements.rename:
+
+``Series.rename`` and ``NDFrame.rename_axis`` can now take a scalar or list-like
+argument for altering the Series or axis *name*, in addition to their old behaviors of altering labels. (:issue:`9494`, :issue:`11965`)
+
+.. ipython: python
+
+   s = pd.Series(np.random.randn(10))
+   s.rename('newname')
+
+.. ipython: python
+
+   df = pd.DataFrame(np.random.randn(10, 2))
+   (df.rename_axis("indexname")
+      .rename_axis("columns_name", axis="columns"))
+
+The new functionality works well in method chains.
+Previously these methods only accepted functions or dicts mapping a *label* to a new label.
+This continues to work as before for function or dict-like values.
+
+
 .. _whatsnew_0180.enhancements.rangeindex:
 
 Range Index

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -2456,6 +2456,10 @@ def is_list_like(arg):
             not isinstance(arg, compat.string_and_binary_types))
 
 
+def is_dict_like(arg):
+    return hasattr(arg, '__getitem__') and hasattr(arg, 'keys')
+
+
 def is_named_tuple(arg):
     return isinstance(arg, tuple) and hasattr(arg, '_fields')
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -8,6 +8,7 @@ from __future__ import division
 
 import types
 import warnings
+from collections import MutableMapping
 
 from numpy import nan, ndarray
 import numpy as np
@@ -1108,6 +1109,20 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         from pandas.core.sparse import SparseSeries
         return SparseSeries(self, kind=kind,
                             fill_value=fill_value).__finalize__(self)
+
+    def _set_name(self, name, inplace=False):
+        '''
+        Set the Series name.
+
+        Parameters
+        ----------
+        name : str
+        inplace : bool
+            whether to modify `self` directly or return a copy
+        '''
+        ser = self if inplace else self.copy()
+        ser.name = name
+        return ser
 
     # ----------------------------------------------------------------------
     # Statistics, overridden ndarray methods
@@ -2313,6 +2328,12 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
 
     @Appender(generic._shared_docs['rename'] % _shared_doc_kwargs)
     def rename(self, index=None, **kwargs):
+        is_scalar_or_list = (
+            (not com.is_sequence(index) and not callable(index)) or
+            (com.is_list_like(index) and not isinstance(index, MutableMapping))
+        )
+        if is_scalar_or_list:
+            return self._set_name(index, inplace=kwargs.get('inplace'))
         return super(Series, self).rename(index=index, **kwargs)
 
     @Appender(generic._shared_docs['reindex'] % _shared_doc_kwargs)

--- a/pandas/tests/series/test_alter_axes.py
+++ b/pandas/tests/series/test_alter_axes.py
@@ -55,6 +55,29 @@ class TestSeriesAlterAxes(TestData, tm.TestCase):
         renamed = renamer.rename({})
         self.assertEqual(renamed.index.name, renamer.index.name)
 
+    def test_rename_set_name(self):
+        s = Series(range(4), index=list('abcd'))
+        for name in ['foo', ['foo'], ('foo',)]:
+            result = s.rename(name)
+            self.assertEqual(result.name, name)
+            self.assert_numpy_array_equal(result.index.values, s.index.values)
+            self.assertTrue(s.name is None)
+
+    def test_rename_set_name_inplace(self):
+        s = Series(range(3), index=list('abc'))
+        for name in ['foo', ['foo'], ('foo',)]:
+            s.rename(name, inplace=True)
+            self.assertEqual(s.name, name)
+            self.assert_numpy_array_equal(s.index.values,
+                                          np.array(['a', 'b', 'c']))
+
+    def test_set_name(self):
+        s = Series([1, 2, 3])
+        s2 = s._set_name('foo')
+        self.assertEqual(s2.name, 'foo')
+        self.assertTrue(s.name is None)
+        self.assertTrue(s is not s2)
+
     def test_rename_inplace(self):
         renamer = lambda x: x.strftime('%Y%m%d')
         expected = renamer(self.ts.index[0])

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -631,6 +631,17 @@ def test_is_list_like():
         assert not com.is_list_like(f)
 
 
+def test_is_dict_like():
+    passes = [{}, {'A': 1}, pd.Series([1])]
+    fails = ['1', 1, [1, 2], (1, 2), range(2), pd.Index([1])]
+
+    for p in passes:
+        assert com.is_dict_like(p)
+
+    for f in fails:
+        assert not com.is_dict_like(f)
+
+
 def test_is_named_tuple():
     passes = (collections.namedtuple('Test', list('abc'))(1, 2, 3), )
     fails = ((1, 2, 3), 'a', Series({'pi': 3.14}))

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable-msg=E1101,W0612
 
+from operator import methodcaller
 import nose
 import numpy as np
 from numpy import nan
@@ -630,6 +631,33 @@ class TestSeries(tm.TestCase, Generic):
                        [("A", x) for x in ["a", "B", "c"]]))
         s.rename(str.lower)
 
+    def test_set_axis_name(self):
+        s = Series([1, 2, 3], index=['a', 'b', 'c'])
+        funcs = ['rename_axis', '_set_axis_name']
+        name = 'foo'
+        for func in funcs:
+            result = methodcaller(func, name)(s)
+            self.assertTrue(s.index.name is None)
+            self.assertEqual(result.index.name, name)
+
+    def test_set_axis_name_mi(self):
+        s = Series([11, 21, 31], index=MultiIndex.from_tuples(
+            [("A", x) for x in ["a", "B", "c"]],
+            names=['l1', 'l2'])
+        )
+        funcs = ['rename_axis', '_set_axis_name']
+        for func in funcs:
+            result = methodcaller(func, ['L1', 'L2'])(s)
+            self.assertTrue(s.index.name is None)
+            self.assertEqual(s.index.names, ['l1', 'l2'])
+            self.assertTrue(result.index.name is None)
+            self.assertTrue(result.index.names, ['L1', 'L2'])
+
+    def test_set_axis_name_raises(self):
+        s = pd.Series([1])
+        with tm.assertRaises(ValueError):
+            s._set_axis_name(name='a', axis=1)
+
     def test_get_numeric_data_preserve_dtype(self):
 
         # get the numeric data
@@ -1067,6 +1095,36 @@ class TestDataFrame(tm.TestCase, Generic):
             11, 21, 31
         ], index=MultiIndex.from_tuples([("A", x) for x in ["a", "B", "c"]]))
         df.rename(str.lower)
+
+    def test_set_axis_name(self):
+        df = pd.DataFrame([[1, 2], [3, 4]])
+        funcs = ['_set_axis_name', 'rename_axis']
+        for func in funcs:
+            result = methodcaller(func, 'foo')(df)
+            self.assertTrue(df.index.name is None)
+            self.assertEqual(result.index.name, 'foo')
+
+            result = methodcaller(func, 'cols', axis=1)(df)
+            self.assertTrue(df.columns.name is None)
+            self.assertEqual(result.columns.name, 'cols')
+
+    def test_set_axis_name_mi(self):
+        df = DataFrame(
+            np.empty((3, 3)),
+            index=MultiIndex.from_tuples([("A", x) for x in list('aBc')]),
+            columns=MultiIndex.from_tuples([('C', x) for x in list('xyz')])
+        )
+
+        level_names = ['L1', 'L2']
+        funcs = ['_set_axis_name', 'rename_axis']
+        for func in funcs:
+            result = methodcaller(func, level_names)(df)
+            self.assertEqual(result.index.names, level_names)
+            self.assertEqual(result.columns.names, [None, None])
+
+            result = methodcaller(func, level_names, axis=1)(df)
+            self.assertEqual(result.columns.names, ["L1", "L2"])
+            self.assertEqual(result.index.names, [None, None])
 
     def test_nonzero_single_element(self):
 
@@ -1957,7 +2015,6 @@ class TestNDFrame(tm.TestCase):
 
         with tm.assertRaises(ValueError):
             result = wp.pipe((f, 'y'), x=1, y=1)
-
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/9494
closes https://github.com/pydata/pandas/issues/11965

Okay refactored to overload `NDFrame.rename` and `NDFrame.rename_axis`

New rules:
- Series.rename(scalar) or Series.rename(list-like) will alter `Series.name`
- NDFrame.rename(mapping) and NDFrame.rename(function) operate as before (alter labels)
- NDFrame.rename_axis(scaler) or NDFrame.rename_axis(list-like) will change the Index.name or MutliIndex.names
- NDFrame.rename_axis(mapping) and NDFrame.rename_axis(function) operate as before.

I don't like overloading the method like this, but `rename` and `rename_axis` are the right method names. It's _mostly_ backwards compatible, aside from people doing things like `try: series.rename(x): except TypeError: ...` and I don't know what our guarantees are around things like that.
