### PR TITLE
BUG: DataFrame.round() drops column index name #11986

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -482,6 +482,8 @@ Bug Fixes
 
 - Bug in rich comparison of ``Timedelta`` with a ``numpy.array`` of ``Timedelta`` that caused an infinite recursion (:issue:`11835`)
 
+- Bug in ``DataFrame.round`` dropping column index name (:issue:`11986`)
+
 - Bug in ``df.replace`` while replacing value in mixed dtype ``Dataframe`` (:issue:`11698`)
 
 - Bug in ``Index`` prevents copying name of passed ``Index``, when a new name is not provided (:issue:`11193`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4462,7 +4462,7 @@ class DataFrame(NDFrame):
             raise TypeError("decimals must be an integer, a dict-like or a Series")
 
         if len(new_cols) > 0:
-            return concat(new_cols, axis=1)
+            return DataFrame(concat(new_cols, axis=1), self.index, self.columns)
         else:
             return self
 

--- a/pandas/tests/test_frame.py
+++ b/pandas/tests/test_frame.py
@@ -13545,6 +13545,18 @@ class TestDataFrame(tm.TestCase, CheckIndexing,
         # Make sure this doesn't break existing Series.round
         tm.assert_series_equal(df['col1'].round(1), expected_rounded['col1'])
 
+        # named columns
+        # GH 11986
+        decimals = 2
+        expected_rounded = DataFrame(
+            {'col1': [1.12, 2.12, 3.12], 'col2': [1.23, 2.23, 3.23]})
+        df.columns.name = "cols"
+        expected_rounded.columns.name = "cols"
+        tm.assert_frame_equal(df.round(decimals), expected_rounded)
+
+        # interaction of named columns & series
+        tm.assert_series_equal(df['col1'].round(decimals), expected_rounded['col1'])
+        tm.assert_series_equal(df.round(decimals)['col1'], expected_rounded['col1'])
 
     def test_round_mixed_type(self):
         # GH11885

--- a/pandas/tests/test_series.py
+++ b/pandas/tests/test_series.py
@@ -3004,6 +3004,7 @@ class TestSeries(tm.TestCase, CheckNameIntegration):
     def test_round(self):
         # numpy.round doesn't preserve metadata, probably a numpy bug,
         # re: GH #314
+        self.ts.index.name = "index_name"
         result = self.ts.round(2)
         expected = Series(np.round(self.ts.values, 2), index=self.ts.index,
                           name='ts')


### PR DESCRIPTION
Fixes #11986. Used the same reconstruction method as `DataFrame.isin()` to ensure that column names are kept through rounding. Works with `np.round` as well.

Pretty minor fix -- does this need a release note or anything else?
