### PR TITLE
DOC: fix escape in EWM docstring

### DIFF
--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -966,7 +966,7 @@ bias : boolean, default False
 """
 
 class EWM(_Rolling):
-    """
+    r"""
     Provides exponential weighted functions
 
     .. versionadded:: 0.18.0


### PR DESCRIPTION
Because of the `\a` in the `\alpha` otherwise being interpreted
