### PR TITLE
Make pivot values work with most iterables

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -152,6 +152,7 @@ Other enhancements
 - ``Series`` gained an ``is_unique`` attribute (:issue:`11946`)
 - ``DataFrame.quantile`` and ``Series.quantile`` now accept ``interpolation`` keyword (:issue:`10174`).
 - ``DataFrame.select_dtypes`` now allows the ``np.float16`` typecode (:issue:`11990`)
+- ``pivot_table()`` now accepts most iterables for the ``values`` parameter (:issue:`12017`)
 
 .. _whatsnew_0180.enhancements.rounding:
 

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -94,8 +94,9 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
 
     values_passed = values is not None
     if values_passed:
-        if isinstance(values, (list, tuple)):
+        if com.is_list_like(values):
             values_multi = True
+            values = list(values)
         else:
             values_multi = False
             values = [values]

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -737,6 +737,7 @@ class TestPivotTable(tm.TestCase):
         tm.assert_frame_equal(result, expected)
 
     def test_pivot_table_with_iterator_values(self):
+        # GH 12017
         aggs = {'D': 'sum', 'E': 'mean'}
 
         pivot_values_list = pd.pivot_table(

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -736,6 +736,24 @@ class TestPivotTable(tm.TestCase):
                              index=['X', 'Y'], columns=exp_col)
         tm.assert_frame_equal(result, expected)
 
+    def test_pivot_table_with_iterator_values(self):
+        aggs = {'D': 'sum', 'E': 'mean'}
+
+        pivot_values_list = pd.pivot_table(
+            self.data, index=['A'], values=list(aggs.keys()), aggfunc=aggs,
+        )
+
+        pivot_values_keys = pd.pivot_table(
+            self.data, index=['A'], values=aggs.keys(), aggfunc=aggs,
+        )
+        tm.assert_frame_equal(pivot_values_keys, pivot_values_list)
+
+        agg_values_gen = (value for value in aggs.keys())
+        pivot_values_gen = pd.pivot_table(
+            self.data, index=['A'], values=agg_values_gen, aggfunc=aggs,
+        )
+        tm.assert_frame_equal(pivot_values_gen, pivot_values_list)
+
 
 class TestCrosstab(tm.TestCase):
 


### PR DESCRIPTION
Previously the values check for pivot tables was only looking for lists or tuples. This patch allows for any generators or other iterables (such as dict.keys() in python 3) to be passed as values. They will be converted to lists when they are identified as iterables, excluding strings. The performance hit from the extra list type assignment to iterables that are already lists or tuples should be minor.
