### PR TITLE
BUG: Raise ImportError when provided URI, but sqlalchemy is not installed.

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -631,6 +631,8 @@ def pandasSQL_builder(con, flavor=None, schema=None, meta=None,
     con = _engine_builder(con)
     if _is_sqlalchemy_connectable(con):
         return SQLDatabase(con, schema=schema, meta=meta)
+    elif isinstance(con, string_types):
+        raise ImportError("Using URI string without sqlalchemy installed.")
     else:
         if flavor == 'mysql':
             warnings.warn(_MYSQL_WARNING, FutureWarning, stacklevel=3)


### PR DESCRIPTION
Rather than presume that it is an sqlite database and provide a confusing error.

Running (without sqlalchemy installed):

``` python
import pandas

db_uri = "postgresql://user:pass@localhost/db"
sql_query = "SELECT * FROM test"

pandas.read_sql(sql_query, db_uri)
```

Produces:

``` python
pandas/io/sql.pyc in execute(self, *args, **kwargs)
   1532             cur = self.con
   1533         else:
-> 1534             cur = self.con.cursor()
   1535         try:
   1536             if kwargs:

AttributeError: 'str' object has no attribute 'cursor'
```

Which links to:

https://github.com/pydata/pandas/blob/master/pandas/io/sql.py#L1534

Zooming into the problem:
1. https://github.com/pydata/pandas/blob/master/pandas/io/sql.py#L631-L637
2. https://github.com/pydata/pandas/blob/master/pandas/io/sql.py#L612-L619
3. https://github.com/pydata/pandas/blob/master/pandas/io/sql.py#L64-L68

So it looks like the URI is passed through and simply assumed to be a sqlite/mysql database object (using the old method), even if it isn't.

Raising an import error when a `URI string` is passed back by `_engine_builder` should solve the issue.
