### PR TITLE
DEPR: DeprecationWarning -> FutureWarning for back-compat in pytables

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -398,6 +398,7 @@ Deprecations
 - ``pd.tseries.frequencies.get_offset_name`` function is deprecated. Use offset's ``.freqstr`` property as alternative (:issue:`11192`)
 - ``pandas.stats.fama_macbeth`` routines are deprecated and will be removed in a future version (:issue:`6077`)
 - ``pandas.stats.ols``, ``pandas.stats.plm`` and ``pandas.stats.var`` routines are deprecated and will be removed in a future version (:issue:`6077`)
+- show a ``FutureWarning`` rather than a ``DeprecationWarning`` on using long-time deprecated syntax in ``HDFStore.select``, where ``where`` clause is not a string-like (:issue:`12027`)
 
 .. _whatsnew_0180.prior_deprecations:
 

--- a/pandas/computation/pytables.py
+++ b/pandas/computation/pytables.py
@@ -526,7 +526,7 @@ class Expr(expr.Expr):
                     "where must be passed as a string if op/value are passed")
             warnings.warn("passing a dict to Expr is deprecated, "
                           "pass the where as a single string",
-                          DeprecationWarning)
+                          FutureWarning, stacklevel=10)
         if isinstance(w, tuple):
             if len(w) == 2:
                 w, value = w
@@ -535,7 +535,7 @@ class Expr(expr.Expr):
                 w, op, value = w
             warnings.warn("passing a tuple into Expr is deprecated, "
                           "pass the where as a single string",
-                          DeprecationWarning, stacklevel=10)
+                          FutureWarning, stacklevel=10)
 
         if op is not None:
             if not isinstance(w, string_types):
@@ -564,7 +564,7 @@ class Expr(expr.Expr):
 
             warnings.warn("passing multiple values to Expr is deprecated, "
                           "pass the where as a single string",
-                          DeprecationWarning)
+                          FutureWarning, stacklevel=10)
 
         return w
 

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -30,7 +30,8 @@ import pandas.util.testing as tm
 from pandas.util.testing import (assert_panel4d_equal,
                                  assert_panel_equal,
                                  assert_frame_equal,
-                                 assert_series_equal)
+                                 assert_series_equal,
+                                 assert_produces_warning)
 from pandas import concat, Timestamp
 from pandas import compat
 from pandas.compat import range, lrange, u
@@ -2329,13 +2330,12 @@ class TestHDFStore(Base, tm.TestCase):
             assert_panel4d_equal(result, expected)
 
             # back compat invalid terms
-            terms = [
-                dict(field='major_axis', op='>', value='20121114'),
-                [ dict(field='major_axis', op='>', value='20121114') ],
-                [ "minor_axis=['A','B']", dict(field='major_axis', op='>', value='20121114') ]
-                ]
+            terms = [dict(field='major_axis', op='>', value='20121114'),
+                     [dict(field='major_axis', op='>', value='20121114')],
+                     ["minor_axis=['A','B']",
+                      dict(field='major_axis', op='>', value='20121114')]]
             for t in terms:
-                with tm.assert_produces_warning(expected_warning=DeprecationWarning,
+                with tm.assert_produces_warning(expected_warning=FutureWarning,
                                                 check_stacklevel=False):
                     Term(t)
 
@@ -2428,12 +2428,14 @@ class TestHDFStore(Base, tm.TestCase):
             wp = Panel(np.random.randn(2, 5, 4), items=['Item1', 'Item2'],
                        major_axis=date_range('1/1/2000', periods=5),
                        minor_axis=['A', 'B', 'C', 'D'])
-            store.append('wp',wp)
-            with tm.assert_produces_warning(expected_warning=DeprecationWarning,
-                                            check_stacklevel=not compat.PY3):
+            store.append('wp', wp)
+            with assert_produces_warning(expected_warning=FutureWarning,
+                                         check_stacklevel=False):
                 result = store.select('wp', [('major_axis>20000102'),
-                                             ('minor_axis', '=', ['A','B']) ])
-            expected = wp.loc[:,wp.major_axis>Timestamp('20000102'),['A','B']]
+                                             ('minor_axis', '=', ['A', 'B'])])
+            expected = wp.loc[:,
+                              wp.major_axis > Timestamp('20000102'),
+                              ['A', 'B']]
             assert_panel_equal(result, expected)
 
             store.remove('wp', ('major_axis>20000103'))
@@ -2446,29 +2448,40 @@ class TestHDFStore(Base, tm.TestCase):
             wp = Panel(np.random.randn(2, 5, 4), items=['Item1', 'Item2'],
                        major_axis=date_range('1/1/2000', periods=5),
                        minor_axis=['A', 'B', 'C', 'D'])
-            store.append('wp',wp)
+            store.append('wp', wp)
 
             # stringified datetimes
-            with tm.assert_produces_warning(expected_warning=DeprecationWarning,
-                                            check_stacklevel=not compat.PY3):
-                result = store.select('wp', [('major_axis','>',datetime.datetime(2000,1,2))])
-            expected = wp.loc[:,wp.major_axis>Timestamp('20000102')]
+            with assert_produces_warning(expected_warning=FutureWarning,
+                                         check_stacklevel=False):
+                result = store.select('wp',
+                                      [('major_axis',
+                                        '>',
+                                        datetime.datetime(2000, 1, 2))])
+            expected = wp.loc[:, wp.major_axis > Timestamp('20000102')]
             assert_panel_equal(result, expected)
-            with tm.assert_produces_warning(expected_warning=DeprecationWarning,
-                                            check_stacklevel=not compat.PY3):
-                result = store.select('wp', [('major_axis','>',datetime.datetime(2000,1,2,0,0))])
-            expected = wp.loc[:,wp.major_axis>Timestamp('20000102')]
+            with assert_produces_warning(expected_warning=FutureWarning,
+                                         check_stacklevel=False):
+                result = store.select('wp',
+                                      [('major_axis',
+                                        '>',
+                                        datetime.datetime(2000, 1, 2, 0, 0))])
+            expected = wp.loc[:, wp.major_axis > Timestamp('20000102')]
             assert_panel_equal(result, expected)
-            with tm.assert_produces_warning(expected_warning=DeprecationWarning,
-                                            check_stacklevel=not compat.PY3):
-                result = store.select('wp', [('major_axis','=',[datetime.datetime(2000,1,2,0,0),
-                                                                datetime.datetime(2000,1,3,0,0)])])
-            expected = wp.loc[:,[Timestamp('20000102'),Timestamp('20000103')]]
+            with assert_produces_warning(expected_warning=FutureWarning,
+                                         check_stacklevel=False):
+                result = store.select('wp',
+                                      [('major_axis',
+                                        '=',
+                                        [datetime.datetime(2000, 1, 2, 0, 0),
+                                         datetime.datetime(2000, 1, 3, 0, 0)])]
+                                      )
+            expected = wp.loc[:, [Timestamp('20000102'),
+                                  Timestamp('20000103')]]
             assert_panel_equal(result, expected)
-            with tm.assert_produces_warning(expected_warning=DeprecationWarning,
-                                            check_stacklevel=not compat.PY3):
-                result = store.select('wp', [('minor_axis','=',['A','B'])])
-            expected = wp.loc[:,:,['A','B']]
+            with assert_produces_warning(expected_warning=FutureWarning,
+                                         check_stacklevel=False):
+                result = store.select('wp', [('minor_axis', '=', ['A', 'B'])])
+            expected = wp.loc[:, :, ['A', 'B']]
             assert_panel_equal(result, expected)
 
     def test_same_name_scoping(self):


### PR DESCRIPTION
already long deprecated, changing to `FutureWarning`.
