### PR TITLE
CI: lint for rest of pandas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -175,3 +175,4 @@ after_script:
   - source activate pandas && ci/print_versions.py
   - ci/print_skipped.py /tmp/nosetests.xml
   - ci/lint.sh
+  - ci/lint_ok_for_now.sh

--- a/ci/lint_ok_for_now.sh
+++ b/ci/lint_ok_for_now.sh
@@ -4,9 +4,9 @@ echo "inside $0"
 
 source activate pandas
 
-for path in 'core'
+for path in 'io' 'stats' 'computation' 'tseries' 'util' 'compat' 'tools' 'sparse' 'tests'
 do
-    echo "linting -> pandas/$path"
+    echo "linting [ok_for_now] -> pandas/$path"
     flake8 pandas/$path --filename '*.py' --statistics -q
 done
 


### PR DESCRIPTION
see output at the end: https://travis-ci.org/jreback/pandas/jobs/102213682

this only shows the summary stats. Once these are much lower we can remove the `-q` and 
show the actual errors.

As more files are fixed can move the checks to `lint.sh`
