### PR TITLE
BUG: .plot modifing `colors` input

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -489,7 +489,8 @@ Bug Fixes
 - Bug in ``DataFrame`` when masking an empty ``DataFrame`` (:issue:`11859`)
 
 
-
+- Bug in ``.plot`` potentially modifying the ``colors`` input when the number
+of columns didn't match the number of series provided (:issue:`12039`).
 
 
 

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -2718,6 +2718,12 @@ class TestDataFramePlots(TestPlotBase):
             _check_plot_works(df.plot, color=custom_colors)
 
     @slow
+    def test_dont_modify_colors(self):
+        colors = ['r', 'g', 'b']
+        pd.DataFrame(np.random.rand(10, 2)).plot(color=colors)
+        self.assertEqual(len(colors), 3)
+
+    @slow
     def test_line_colors_and_styles_subplots(self):
         # GH 9894
         from matplotlib import cm

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -158,7 +158,7 @@ def _get_standard_colors(num_colors=None, colormap=None, color_type='default',
         if colormap is not None:
             warnings.warn("'color' and 'colormap' cannot be used "
                           "simultaneously. Using 'color'")
-        colors = color
+        colors = list(color) if com.is_list_like(color) else color
     else:
         if color_type == 'default':
             # need to call list() on the result to copy so we don't


### PR DESCRIPTION
Closes https://github.com/pydata/pandas/issues/12039

Just added a defensive copy in `_get_standard_colors` on list-likes.
