### PR TITLE
DOC :Updated indexer_between_time documentation

### DIFF
--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1804,7 +1804,6 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin, Int64Index)
             "%I%M%S%p")
         include_start : boolean, default True
         include_end : boolean, default True
-        tz : string or pytz.timezone or dateutil.tz.tzfile, default None
 
         Returns
         -------


### PR DESCRIPTION
A minor documentation update to the [DatetimeIndex.indexer_between_time](http://pandas.pydata.org/pandas-docs/version/0.17.1/generated/pandas.DatetimeIndex.indexer_between_time.html) function.
Closes #12038 
