### PR TITLE
Fix asymmetric error bars for series (closes #9536)

### DIFF
--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -1366,9 +1366,10 @@ Horizontal and vertical errorbars can be supplied to the ``xerr`` and ``yerr`` k
 
 - As a :class:`DataFrame` or ``dict`` of errors with column names matching the ``columns`` attribute of the plotting :class:`DataFrame` or matching the ``name`` attribute of the :class:`Series`
 - As a ``str`` indicating which of the columns of plotting :class:`DataFrame` contain the error values
+- As a single ``number`` which is used as the error for every value
 - As raw values (``list``, ``tuple``, or ``np.ndarray``). Must be the same length as the plotting :class:`DataFrame`/:class:`Series`
 
-Asymmetrical error bars are also supported, however raw error values must be provided in this case. For a ``M`` length :class:`Series`, a ``Mx2`` array should be provided indicating lower and upper (or left and right) errors. For a ``MxN`` :class:`DataFrame`, asymmetrical errors should be in a ``Mx2xN`` array.
+Asymmetrical error bars are also supported, however raw error values must be provided in this case. For a ``N`` length :class:`Series`, a ``2xN`` array should be provided indicating lower and upper (or left and right) errors. For a ``MxN`` :class:`DataFrame`, asymmetrical errors should be in a ``Mx2xN`` array.
 
 Here is an example of one way to easily plot group means with standard deviations from the raw data.
 

--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -60,12 +60,13 @@ Other Enhancements
 - ``pd.read_msgpack()`` now always gives writeable ndarrays even when compression is used (:issue:`12359`).
 - ``Index.take`` now handles ``allow_fill`` and ``fill_value`` consistently (:issue:`12631`)
 
-.. ipython:: python
+  .. ipython:: python
 
-   idx = pd.Index([1., 2., 3., 4.], dtype='float')
-   idx.take([2, -1])     # default, allow_fill=True, fill_value=None
-   idx.take([2, -1], fill_value=True)
+     idx = pd.Index([1., 2., 3., 4.], dtype='float')
+     idx.take([2, -1])     # default, allow_fill=True, fill_value=None
+     idx.take([2, -1], fill_value=True)
 
+- ``Series.plot`` allows now asymmetric error bars in the shape of 2xN array (:issue:`9536`)
 
 .. _whatsnew_0181.api:
 

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1180,6 +1180,20 @@ class TestSeriesPlots(TestPlotBase):
         with tm.assertRaises((ValueError, TypeError)):
             s.plot(yerr=s_err)
 
+    def test_errorbar_asymmetrical(self):
+        # github issue #9536
+        s = Series(np.random.randn(5))
+        err = np.random.rand(2, 5)
+
+        ax = _check_plot_works(s.plot, yerr=err, xerr=(err / 2))
+        self._check_has_errorbars(ax, yerr=1, xerr=1)
+
+        assert_allclose(ax.lines[2].get_ydata(), s.values - err[0])
+        assert_allclose(ax.lines[3].get_ydata(), s.values + err[1])
+
+        assert_allclose(ax.lines[0].get_xdata(), s.index - (err[0] / 2))
+        assert_allclose(ax.lines[1].get_xdata(), s.index + (err[1] / 2))
+
     def test_table(self):
         _check_plot_works(self.series.plot, table=True)
         _check_plot_works(self.series.plot, table=self.series)


### PR DESCRIPTION
closes #9536

This fix is for handling asymmetric error bars for series.
It adapts to the syntax for
http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.errorbar
where a sequence of shape 2xN is expected in case of asymmetric error bars.

If a single series is to be plotted and the error sequence is of shape 2xN
it will be used as asymmetric error bars.
Previously a 2xN error sequence was assumed to be 2 symmetric error sequences
for 2 series. Thus in the end only the first error sequence was used.
