### PR TITLE
ENH : Allow to_sql to recognize single sql type #11886

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -463,6 +463,7 @@ Bug Fixes
 - Bug in ``pd.read_clipboard`` and ``pd.to_clipboard`` functions not supporting Unicode; upgrade included ``pyperclip`` to v1.5.15 (:issue:`9263`)
 - Bug in ``DataFrame.query`` containing an assignment (:issue:`8664`)
 
+- Bug in ``from_msgpack`` where ``__contains__()`` fails for columns of the unpacked ``DataFrame``, if the ``DataFrame`` has object columns. (:issue: `11880`)
 
 
 - Bug in timezone info lost when broadcasting scalar datetime to ``DataFrame`` (:issue:`11682`)

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -303,6 +303,9 @@ Other API Changes
 
 - ``.memory_usage`` now includes values in the index, as does memory_usage in ``.info`` (:issue:`11597`)
 
+- ``DataFrame.to_latex()`` now supports non-ascii encodings (eg utf-8) in Python 2 with the parameter ``encoding`` (:issue:`7061`)
+
+
 Changes to eval
 ^^^^^^^^^^^^^^^
 

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -118,6 +118,7 @@ Other enhancements
 - ``Series`` gained an ``is_unique`` attribute (:issue:`11946`)
 - ``DataFrame.quantile`` and ``Series.quantile`` now accept ``interpolation`` keyword (:issue:`10174`).
 - ``DataFrame.select_dtypes`` now allows the ``np.float16`` typecode (:issue:`11990`)
+- ``DataFrame.to_sql `` now allows a single value as the SQL type for all columns (:issue:`11886`).
 
 .. _whatsnew_0180.enhancements.rounding:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1547,7 +1547,7 @@ class DataFrame(NDFrame):
                  header=True, index=True, na_rep='NaN', formatters=None,
                  float_format=None, sparsify=None, index_names=True,
                  bold_rows=True, column_format=None,
-                 longtable=None, escape=None):
+                 longtable=None, escape=None, encoding=None):
         """
         Render a DataFrame to a tabular environment table. You can splice
         this into a LaTeX document. Requires \\usepackage{booktabs}.
@@ -1567,7 +1567,8 @@ class DataFrame(NDFrame):
             default: True
             When set to False prevents from escaping latex special
             characters in column names.
-
+        encoding : str, default None
+            Default encoding is ascii in Python 2 and utf-8 in Python 3
         """
 
         if colSpace is not None:  # pragma: no cover
@@ -1589,7 +1590,8 @@ class DataFrame(NDFrame):
                                            sparsify=sparsify,
                                            index_names=index_names,
                                            escape=escape)
-        formatter.to_latex(column_format=column_format, longtable=longtable)
+        formatter.to_latex(column_format=column_format, longtable=longtable,
+                           encoding=encoding)
 
         if buf is None:
             return formatter.buf.getvalue()

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -965,6 +965,7 @@ bias : boolean, default False
    Use a standard estimation bias correction
 """
 
+
 class EWM(_Rolling):
     r"""
     Provides exponential weighted functions

--- a/pandas/hashtable.pyx
+++ b/pandas/hashtable.pyx
@@ -342,7 +342,7 @@ cdef class Int64HashTable(HashTable):
                 self.table.vals[k] = <Py_ssize_t> values[i]
 
     @cython.boundscheck(False)
-    def map_locations(self, int64_t[:] values):
+    def map_locations(self, ndarray[int64_t, ndim=1] values):
         cdef:
             Py_ssize_t i, n = len(values)
             int ret = 0
@@ -570,7 +570,7 @@ cdef class Float64HashTable(HashTable):
         return np.asarray(labels)
 
     @cython.boundscheck(False)
-    def map_locations(self, float64_t[:] values):
+    def map_locations(self, ndarray[float64_t, ndim=1] values):
         cdef:
             Py_ssize_t i, n = len(values)
             int ret = 0

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -549,9 +549,11 @@ def to_sql(frame, name, con, flavor='sqlite', schema=None, if_exists='fail',
     chunksize : int, default None
         If not None, then rows will be written in batches of this size at a
         time.  If None, all rows will be written at once.
-    dtype : dict of column name to SQL type, default None
+    dtype : single SQL type or dict of column name to SQL type, default None
         Optional specifying the datatype for columns. The SQL type should
         be a SQLAlchemy type, or a string for sqlite3 fallback connection.
+        If all columns are of the same type, one single value can be 
+        used.
 
     """
     if if_exists not in ('fail', 'replace', 'append'):
@@ -1224,9 +1226,11 @@ class SQLDatabase(PandasSQL):
         chunksize : int, default None
             If not None, then rows will be written in batches of this size at a
             time.  If None, all rows will be written at once.
-        dtype : dict of column name to SQL type, default None
+        dtype : single SQL type or dict of column name to SQL type, default None
             Optional specifying the datatype for columns. The SQL type should
-            be a SQLAlchemy type.
+            be a SQLAlchemy type.If all columns are of the same type, one 
+            single value can be used.
+
 
         """
         if dtype and not is_dictlike(dtype):
@@ -1623,9 +1627,10 @@ class SQLiteDatabase(PandasSQL):
         chunksize : int, default None
             If not None, then rows will be written in batches of this
             size at a time. If None, all rows will be written at once.
-        dtype : dict of column name to SQL type, default None
+        dtype : single SQL type or dict of column name to SQL type, default None
             Optional specifying the datatype for columns. The SQL type should
-            be a string.
+            be a string. If all columns are of the same type, one single 
+            value can be used.
 
         """
         if dtype and not is_dictlike(dtype):

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -565,9 +565,6 @@ def to_sql(frame, name, con, flavor='sqlite', schema=None, if_exists='fail',
         raise NotImplementedError("'frame' argument should be either a "
                                   "Series or a DataFrame")
 
-    if dtype and not is_dictlike(dtype):
-        temp_type = dtype
-        dtype = { col_name : temp_type for col_name in frame }
         
     pandas_sql.to_sql(frame, name, if_exists=if_exists, index=index,
                       index_label=index_label, schema=schema,
@@ -1232,6 +1229,9 @@ class SQLDatabase(PandasSQL):
             be a SQLAlchemy type.
 
         """
+        if dtype and not is_dictlike(dtype):
+            temp_type = dtype
+            dtype = { col_name : temp_type for col_name in frame }
         if dtype is not None:
             from sqlalchemy.types import to_instance, TypeEngine
             for col, my_type in dtype.items():
@@ -1628,6 +1628,10 @@ class SQLiteDatabase(PandasSQL):
             be a string.
 
         """
+        if dtype and not is_dictlike(dtype):
+            temp_type = dtype
+            dtype = { col_name : temp_type for col_name in frame }
+
         if dtype is not None:
             for col, my_type in dtype.items():
                 if not isinstance(my_type, str):

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -551,7 +551,7 @@ def to_sql(frame, name, con, flavor='sqlite', schema=None, if_exists='fail',
         time.  If None, all rows will be written at once.
     dtype : single SQL type or dict of column name to SQL type, default None
         Optional specifying the datatype for columns. The SQL type should
-        be a SQLAlchemy type, or a string for sqlite3 fallback connection.
+        be a SQLAlchemy type, or a string for sqlite3 fallback connection. 
         If all columns are of the same type, one single value can be 
         used.
 
@@ -1227,14 +1227,13 @@ class SQLDatabase(PandasSQL):
             time.  If None, all rows will be written at once.
         dtype : single SQL type or dict of column name to SQL type, default None
             Optional specifying the datatype for columns. The SQL type should
-            be a SQLAlchemy type.If all columns are of the same type, one 
+            be a SQLAlchemy type. If all columns are of the same type, one 
             single value can be used.
 
 
         """
         if dtype and not is_dictlike(dtype):
-            temp_type = dtype
-            dtype = { col_name : temp_type for col_name in frame }
+            dtype = { col_name : dtype for col_name in frame }
         if dtype is not None:
             from sqlalchemy.types import to_instance, TypeEngine
             for col, my_type in dtype.items():
@@ -1633,8 +1632,7 @@ class SQLiteDatabase(PandasSQL):
 
         """
         if dtype and not is_dictlike(dtype):
-            temp_type = dtype
-            dtype = { col_name : temp_type for col_name in frame }
+            dtype = { col_name : dtype for col_name in frame }
 
         if dtype is not None:
             for col, my_type in dtype.items():

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -566,7 +566,6 @@ def to_sql(frame, name, con, flavor='sqlite', schema=None, if_exists='fail',
     elif not isinstance(frame, DataFrame):
         raise NotImplementedError("'frame' argument should be either a "
                                   "Series or a DataFrame")
-
         
     pandas_sql.to_sql(frame, name, if_exists=if_exists, index=index,
                       index_label=index_label, schema=schema,

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -564,6 +564,10 @@ def to_sql(frame, name, con, flavor='sqlite', schema=None, if_exists='fail',
         raise NotImplementedError("'frame' argument should be either a "
                                   "Series or a DataFrame")
 
+    if dtype and not isinstance(dtype,dict):
+        temp_type = dtype
+        dtype = { col_name : temp_type for col_name in frame }
+        
     pandas_sql.to_sql(frame, name, if_exists=if_exists, index=index,
                       index_label=index_label, schema=schema,
                       chunksize=chunksize, dtype=dtype)

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -19,6 +19,7 @@ from pandas.core.api import DataFrame, Series
 from pandas.core.common import isnull
 from pandas.core.base import PandasObject
 from pandas.core.dtypes import DatetimeTZDtype
+from pandas.core.generic import is_dictlike
 from pandas.tseries.tools import to_datetime
 from pandas.util.decorators import Appender
 
@@ -564,7 +565,7 @@ def to_sql(frame, name, con, flavor='sqlite', schema=None, if_exists='fail',
         raise NotImplementedError("'frame' argument should be either a "
                                   "Series or a DataFrame")
 
-    if dtype and not isinstance(dtype,dict):
+    if dtype and not is_dictlike(dtype):
         temp_type = dtype
         dtype = { col_name : temp_type for col_name in frame }
         

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -367,6 +367,14 @@ class PandasSQLTest(unittest.TestCase):
         self.drop_table('test_frame1')
         self.pandasSQL.to_sql(self.test_frame1.iloc[:0], 'test_frame1')
 
+    def _to_sql_single_dtype(self,dtype):
+        self.drop_table('test_frame1')
+        self.pandasSQL.to_sql(self.test_frame1[['A','B']],'test_frame1',dtype=dtype)
+        self.assertTrue(self.pandasSQL.has_table(
+            'test_frame1'), 'Table not written to DB')
+
+        self.drop_table('test_frame1')
+
     def _to_sql_fail(self):
         self.drop_table('test_frame1')
 
@@ -1166,8 +1174,8 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
         self._to_sql_empty()
 
     def test_to_sql_single_dtype(self):
-        self.to_sql_single_dtype()
-        
+        self._to_sql_single_dtype(dtype=sqltypes.NVARCHAR)
+
     def test_to_sql_fail(self):
         self._to_sql_fail()
 
@@ -1882,7 +1890,7 @@ class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest):
         self._to_sql_empty()
 
     def test_to_sql_single_dtype(self):
-        self.to_sql_single_dtype()
+        self._to_sql_single_dtype(dtype='float64')
 
     def test_to_sql_fail(self):
         self._to_sql_fail()

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -1165,6 +1165,9 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
     def test_to_sql_empty(self):
         self._to_sql_empty()
 
+    def test_to_sql_single_dtype(self):
+        self.to_sql_single_dtype()
+        
     def test_to_sql_fail(self):
         self._to_sql_fail()
 
@@ -1877,6 +1880,9 @@ class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest):
 
     def test_to_sql_empty(self):
         self._to_sql_empty()
+
+    def test_to_sql_single_dtype(self):
+        self.to_sql_single_dtype()
 
     def test_to_sql_fail(self):
         self._to_sql_fail()

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -1165,21 +1165,6 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
     def test_to_sql_empty(self):
         self._to_sql_empty()
 
-    def test_to_sql_single_dtype(self):
-        self.drop_table('single_dtype_test')
-        cols = ['A','B']
-        data = [('a','b'),
-                ('c','d')]
-        df = DataFrame(data,columns=cols)
-        df.to_sql('single_dtype_test',self.conn,dtype=sqlalchemy.TEXT)
-        meta = sqlalchemy.schema.MetaData(bind=self.conn)
-        meta.reflect()
-        sqltypea = meta.tables['single_dtype_test'].columns['A'].type
-        sqltypeb = meta.tables['single_dtype_test'].columns['B'].type
-        self.assertTrue(isinstance(sqltypea, sqlalchemy.TEXT))
-        self.assertTrue(isinstance(sqltypeb, sqlalchemy.TEXT))
-        self.drop_table('single_dtype_test')
-
     def test_to_sql_fail(self):
         self._to_sql_fail()
 
@@ -1523,6 +1508,21 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
         sqltype = meta.tables['dtype_test3'].columns['B'].type
         self.assertTrue(isinstance(sqltype, sqlalchemy.String))
         self.assertEqual(sqltype.length, 10)
+
+    def test_to_sql_single_dtype(self):
+        self.drop_table('single_dtype_test')
+        cols = ['A','B']
+        data = [('a','b'),
+                ('c','d')]
+        df = DataFrame(data,columns=cols)
+        df.to_sql('single_dtype_test',self.conn,dtype=sqlalchemy.TEXT)
+        meta = sqlalchemy.schema.MetaData(bind=self.conn)
+        meta.reflect()
+        sqltypea = meta.tables['single_dtype_test'].columns['A'].type
+        sqltypeb = meta.tables['single_dtype_test'].columns['B'].type
+        self.assertTrue(isinstance(sqltypea, sqlalchemy.TEXT))
+        self.assertTrue(isinstance(sqltypeb, sqlalchemy.TEXT))
+        self.drop_table('single_dtype_test')
 
     def test_notnull_dtype(self):
         cols = {'Bool': Series([True,None]),
@@ -1893,19 +1893,6 @@ class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest):
     def test_to_sql_empty(self):
         self._to_sql_empty()
 
-    def test_to_sql_single_dtype(self):
-        if self.flavor == 'mysql':
-            raise nose.SkipTest('Not applicable to MySQL legacy')
-        self.drop_table('single_dtype_test')
-        cols = ['A','B']
-        data = [('a','b'),
-                ('c','d')]
-        df = DataFrame(data,columns=cols)
-        df.to_sql('single_dtype_test',self.conn,dtype='STRING')
-        self.assertEqual(self._get_sqlite_column_type('single_dtype_test','A'),'STRING')
-        self.assertEqual(self._get_sqlite_column_type('single_dtype_test','B'),'STRING')
-        self.drop_table('single_dtype_test')
-
     def test_to_sql_fail(self):
         self._to_sql_fail()
 
@@ -1994,6 +1981,19 @@ class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest):
         self.assertEqual(self._get_sqlite_column_type('dtype_test2', 'B'), 'STRING')
         self.assertRaises(ValueError, df.to_sql,
                           'error', self.conn, dtype={'B': bool})
+
+    def test_to_sql_single_dtype(self):
+        if self.flavor == 'mysql':
+            raise nose.SkipTest('Not applicable to MySQL legacy')
+        self.drop_table('single_dtype_test')
+        cols = ['A','B']
+        data = [('a','b'),
+                ('c','d')]
+        df = DataFrame(data,columns=cols)
+        df.to_sql('single_dtype_test',self.conn,dtype='STRING')
+        self.assertEqual(self._get_sqlite_column_type('single_dtype_test','A'),'STRING')
+        self.assertEqual(self._get_sqlite_column_type('single_dtype_test','B'),'STRING')
+        self.drop_table('single_dtype_test')
 
     def test_notnull_dtype(self):
         if self.flavor == 'mysql':

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -1174,7 +1174,7 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
         self._to_sql_empty()
 
     def test_to_sql_single_dtype(self):
-        self._to_sql_single_dtype(dtype=sqltypes.NVARCHAR)
+        self._to_sql_single_dtype(dtype=sqltypes.Float)
 
     def test_to_sql_fail(self):
         self._to_sql_fail()

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -15,6 +15,8 @@ from numpy import nan
 from numpy.random import randn
 import numpy as np
 
+import codecs
+
 div_style = ''
 try:
     import IPython
@@ -2553,6 +2555,24 @@ c  10  11  12  13  14\
 
             with open(path, 'r') as f:
                 self.assertEqual(self.frame.to_latex(), f.read())
+
+        # test with utf-8 and encoding option (GH 7061)
+        df = DataFrame([[u'au\xdfgangen']])
+        with tm.ensure_clean('test.tex') as path:
+            df.to_latex(path, encoding='utf-8')
+            with codecs.open(path, 'r', encoding='utf-8') as f:
+                self.assertEqual(df.to_latex(), f.read())
+
+        # test with utf-8 without encoding option
+        if compat.PY3:  # python3 default encoding is utf-8
+            with tm.ensure_clean('test.tex') as path:
+                df.to_latex(path)
+                with codecs.open(path, 'r') as f:
+                    self.assertEqual(df.to_latex(), f.read())
+        else:
+            # python2 default encoding is ascii, so an error should be raised
+            with tm.ensure_clean('test.tex') as path:
+                self.assertRaises(UnicodeEncodeError, df.to_latex, path)
 
     def test_to_latex(self):
         # it works!


### PR DESCRIPTION
Continued in #13252 

---

This solves #11886 
It checks whether the passed dtype variable is a dictionary.
If not, it creates a new dictionary with keys as the columns of the dataframe.
It then passes this dictionary  to the pandasSQL_builder.
