### PR TITLE
BUG: GH12050 Setting values on Series using .loc with a TZ-aware DatetimeIndex fails

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -536,3 +536,5 @@ of columns didn't match the number of series provided (:issue:`12039`).
 
 - Removed ``millisecond`` property of ``DatetimeIndex``. This would always raise a ``ValueError`` (:issue:`12019`).
 - Bug in ``Series`` constructor with read-only data (:issue:`11502`)
+
+- Bug in ``.loc`` setitem indexer preventing the use of a TZ-aware DatetimeIndex (:issue:`12050`)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1114,7 +1114,8 @@ class _NDFrameIndexer(object):
                 return inds
             else:
                 if isinstance(obj, Index):
-                    objarr = obj.values
+                    # want Index objects to pass through untouched
+                    objarr = obj
                 else:
                     objarr = _asarray_tuplesafe(obj)
 

--- a/pandas/tests/test_indexing.py
+++ b/pandas/tests/test_indexing.py
@@ -970,6 +970,55 @@ class TestIndexing(tm.TestCase):
         df.loc[df.new_col == 'new', 'time'] = v
         assert_series_equal(df.loc[df.new_col == 'new', 'time'], v)
 
+    def test_indexing_with_datetimeindex_tz(self):
+
+        # GH 12050
+        # indexing on a series with a datetimeindex with tz
+        index = pd.date_range('2015-01-01', periods=2, tz='utc')
+
+        ser = pd.Series(range(2), index=index)
+
+        # list-like indexing
+
+        for sel in (index, list(index)):
+            # getitem
+            assert_series_equal(ser[sel], ser)
+
+            # setitem
+            result = ser.copy()
+            result[sel] = 1
+            expected = pd.Series(1, index=index)
+            assert_series_equal(result, expected)
+
+            # .loc getitem
+            assert_series_equal(ser.loc[sel], ser)
+
+            # .loc setitem
+            result = ser.copy()
+            result.loc[sel] = 1
+            expected = pd.Series(1, index=index)
+            assert_series_equal(result, expected)
+
+        # single element indexing
+
+        # getitem
+        self.assertEqual(ser[index[1]], 1)
+
+        # setitem
+        result = ser.copy()
+        result[index[1]] = 5
+        expected = pd.Series([0, 5], index=index)
+        assert_series_equal(result, expected)
+
+        # .loc getitem
+        self.assertEqual(ser.loc[index[1]], 1)
+
+        # .loc setitem
+        result = ser.copy()
+        result.loc[index[1]] = 5
+        expected = pd.Series([0, 5], index=index)
+        assert_series_equal(result, expected)
+
     def test_loc_setitem_dups(self):
 
         # GH 6541


### PR DESCRIPTION
Fixes https://github.com/pydata/pandas/issues/12050 .

Taking just the values of an index object looses the timezone information.
