### PR TITLE
PERF: more flexible iso8601 parsing

### DIFF
--- a/asv_bench/benchmarks/timeseries.py
+++ b/asv_bench/benchmarks/timeseries.py
@@ -1059,32 +1059,26 @@ class timeseries_to_datetime_iso8601(object):
     goal_time = 0.2
 
     def setup(self):
-        self.N = 100000
-        self.rng = date_range(start='1/1/2000', periods=self.N, freq='T')
-        if hasattr(Series, 'convert'):
-            Series.resample = Series.convert
-        self.ts = Series(np.random.randn(self.N), index=self.rng)
         self.rng = date_range(start='1/1/2000', periods=20000, freq='H')
         self.strings = [x.strftime('%Y-%m-%d %H:%M:%S') for x in self.rng]
+        self.strings_nosep = [x.strftime('%Y%m%d %H:%M:%S') for x in self.rng]
+        self.strings_tz_space = [x.strftime('%Y-%m-%d %H:%M:%S') + ' -0800'
+                                 for x in self.rng]
 
     def time_timeseries_to_datetime_iso8601(self):
         to_datetime(self.strings)
 
-
-class timeseries_to_datetime_iso8601_format(object):
-    goal_time = 0.2
-
-    def setup(self):
-        self.N = 100000
-        self.rng = date_range(start='1/1/2000', periods=self.N, freq='T')
-        if hasattr(Series, 'convert'):
-            Series.resample = Series.convert
-        self.ts = Series(np.random.randn(self.N), index=self.rng)
-        self.rng = date_range(start='1/1/2000', periods=20000, freq='H')
-        self.strings = [x.strftime('%Y-%m-%d %H:%M:%S') for x in self.rng]
+    def time_timeseries_to_datetime_iso8601_nosep(self):
+        to_datetime(self.strings_nosep)
 
     def time_timeseries_to_datetime_iso8601_format(self):
         to_datetime(self.strings, format='%Y-%m-%d %H:%M:%S')
+
+    def time_timeseries_to_datetime_iso8601_format_no_sep(self):
+        to_datetime(self.strings_nosep, format='%Y%m%d %H:%M:%S')
+
+    def time_timeseries_to_datetime_iso8601_tz_spaceformat(self):
+        to_datetime(self.strings_tz_space)
 
 
 class timeseries_with_format_no_exact(object):

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -461,7 +461,7 @@ Performance Improvements
 
 
 
-
+- Improved performance of ISO 8601 date parsing for dates without separators (:issue:`11899`), leading zeros (:issue:`11871`) and with whitespace preceding the time zone (:issue:`9714`)
 
 
 

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -2454,7 +2454,7 @@ class TestDatetimeIndex(tm.TestCase):
             idx = date_range('2013/1/1 0:00:00-5:00', '2016/1/1 23:59:59-5:00',
                              freq=freq)
             expected = date_range('2013-01-01T00:00:00', '2016-01-01T23:59:59',
-                                  freq=freq, tz=tzoffset(None, -18000))
+                                  freq=freq, tz=pytz.FixedOffset(-300))
             tm.assert_index_equal(idx, expected)
             # Unable to use `US/Eastern` because of DST
             expected_i8 = date_range('2013-01-01T00:00:00',
@@ -2465,7 +2465,7 @@ class TestDatetimeIndex(tm.TestCase):
             idx = date_range('2013/1/1 0:00:00+9:00',
                              '2016/1/1 23:59:59+09:00', freq=freq)
             expected = date_range('2013-01-01T00:00:00', '2016-01-01T23:59:59',
-                                  freq=freq, tz=tzoffset(None, 32400))
+                                  freq=freq, tz=pytz.FixedOffset(540))
             tm.assert_index_equal(idx, expected)
             expected_i8 = date_range('2013-01-01T00:00:00',
                                      '2016-01-01T23:59:59', freq=freq,
@@ -4833,6 +4833,15 @@ class TestToDatetimeInferFormat(tm.TestCase):
             pd.to_datetime(test_series, infer_datetime_format=True)
         )
 
+    def test_to_datetime_iso8601_noleading_0s(self):
+        # GH 11871
+        test_series = pd.Series(['2014-1-1', '2014-2-2', '2015-3-3'])
+        expected = pd.Series([pd.Timestamp('2014-01-01'),
+                              pd.Timestamp('2014-02-02'),
+                              pd.Timestamp('2015-03-03')])
+        tm.assert_series_equal(pd.to_datetime(test_series), expected)
+        tm.assert_series_equal(pd.to_datetime(test_series, format='%Y-%m-%d'),
+                               expected)
 
 class TestGuessDatetimeFormat(tm.TestCase):
     def test_guess_datetime_format_with_parseable_formats(self):

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -688,6 +688,32 @@ class TestDatetimeParsingWrappers(tm.TestCase):
             converted_time = dt_time.tz_localize('UTC').tz_convert(tz)
             self.assertEqual(dt_string_repr, repr(converted_time))
 
+    def test_parsers_iso8601(self):
+        # GH 12060
+        # test only the iso parser - flexibility to different
+        # separators and leadings 0s
+        # Timestamp construction falls back to dateutil
+        cases = {'2011-01-02': datetime.datetime(2011, 1, 2),
+                 '2011-1-2': datetime.datetime(2011, 1, 2),
+                 '2011-01': datetime.datetime(2011, 1, 1),
+                 '2011-1': datetime.datetime(2011, 1, 1),
+                 '2011 01 02': datetime.datetime(2011, 1, 2),
+                 '2011.01.02': datetime.datetime(2011, 1, 2),
+                 '2011/01/02': datetime.datetime(2011, 1, 2),
+                 '2011\\01\\02': datetime.datetime(2011, 1, 2),
+                 '2013-01-01 05:30:00': datetime.datetime(2013, 1, 1, 5, 30),
+                 '2013-1-1 5:30:00': datetime.datetime(2013, 1, 1, 5, 30)}
+        for date_str, exp in compat.iteritems(cases):
+            actual = tslib._test_parse_iso8601(date_str)
+            self.assertEqual(actual, exp)
+
+        # seperators must all match - YYYYMM not valid
+        invalid_cases = ['2011-01/02', '2011^11^11', '201401',
+                         '201111', '200101']
+        for date_str in invalid_cases:
+            with tm.assertRaises(ValueError):
+                tslib._test_parse_iso8601(date_str)
+
 
 class TestArrayToDatetime(tm.TestCase):
     def test_parsing_valid_dates(self):


### PR DESCRIPTION
closes #9714
closes #11899
closes #11871

makes ISO parser in C handle the following. I think 2 & 3 aren't actually iso8601 anymore, but close and unambiguous.
1. dates without '-' separator 
2. dates without space before tz
3. dates without leading 0s in month/day
   (this ONLY works if the date has separators, eg. `"2015-1-1"` parses, but `"201511"` doesn't because it's ambiguous)

asv results - adds a small amount of overhead to the standard case (`'2014-01-01'`)

```
    before     after       ratio
  [1ae6384 ] [e922b05 ]
     5.17ms     5.34ms      1.03  timeseries.timeseries_to_datetime_iso8601.time_timeseries_to_datetime_iso8601
     5.15ms     5.50ms      1.07  timeseries.timeseries_to_datetime_iso8601.time_timeseries_to_datetime_iso8601_format
-  111.89ms     5.27ms      0.05  timeseries.timeseries_to_datetime_iso8601.time_timeseries_to_datetime_iso8601_format_no_sep
-     2.02s     5.33ms      0.00  timeseries.timeseries_to_datetime_iso8601.time_timeseries_to_datetime_iso8601_nosep
-     2.97s   218.25ms      0.07  timeseries.timeseries_to_datetime_iso8601.time_timeseries_to_datetime_iso8601_tz_spaceformat

```
