### PR TITLE
BUG in .groupby for single-row DF

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -497,7 +497,7 @@ Bug Fixes
 of columns didn't match the number of series provided (:issue:`12039`).
 
 
-
+- Bug in ``.groupby`` where a ``KeyError`` was not raised for a wrong column if there was only one row in the dataframe (:issue:`11741`)
 
 
 - Removed ``millisecond`` property of ``DatetimeIndex``. This would always raise a ``ValueError`` (:issue:`12019`).

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2207,11 +2207,12 @@ def _get_grouper(obj, key=None, axis=0, level=None, sort=True):
 
     if not isinstance(key, (tuple, list)):
         keys = [key]
+        match_axis_length = False
     else:
         keys = key
+        match_axis_length = len(keys) == len(group_axis)
 
     # what are we after, exactly?
-    match_axis_length = len(keys) == len(group_axis)
     any_callable = any(callable(g) or isinstance(g, dict) for g in keys)
     any_groupers = any(isinstance(g, Grouper) for g in keys)
     any_arraylike = any(isinstance(g, (list, tuple, Series, Index, np.ndarray))

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -3085,6 +3085,13 @@ class TestGroupBy(tm.TestCase):
 
         assert_frame_equal(result, expected)
 
+    def test_groupby_one_row(self):
+        # GH 11741
+        df1 = pd.DataFrame(np.random.randn(1, 4), columns=list('ABCD'))
+        self.assertRaises(KeyError, df1.groupby, 'Z')
+        df2 = pd.DataFrame(np.random.randn(2, 4), columns=list('ABCD'))
+        self.assertRaises(KeyError, df2.groupby, 'Z')
+
     def test_groupby_nat_exclude(self):
         # GH 6992
         df = pd.DataFrame({'values': np.random.randn(8),


### PR DESCRIPTION
No KeyError was raised when grouping by a non-existant column

Fixes #11741

Xref issue #11640, PR #11717
