### PR TITLE
CI: add 3.5 build with numpy_dev installed by wheel from master, #12057

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,13 @@ matrix:
       - NUMPY_BUILD=master
       - BUILD_TYPE=pydata
       - PANDAS_TESTING_MODE="deprecate"
+    - python: 3.5
+      env:
+      - JOB_NAME: "35_numpy_dev"
+      - JOB_TAG=_NUMPY_DEV
+      - NOSE_ARGS="not slow and not network and not disabled"
+      - BUILD_TYPE=conda
+      - PANDAS_TESTING_MODE="deprecate"
     allow_failures:
       - python: 2.7
         env:
@@ -137,6 +144,13 @@ matrix:
         - FULL_DEPS=true
         - BUILD_TYPE=pydata
         - BUILD_TEST=true
+      - python: 3.5
+        env:
+        - JOB_NAME: "35_numpy_dev"
+        - JOB_TAG=_NUMPY_DEV
+        - NOSE_ARGS="not slow and not network and not disabled"
+        - BUILD_TYPE=conda
+        - PANDAS_TESTING_MODE="deprecate"
 
 before_install:
   - echo "before_install"

--- a/ci/install-3.5_NUMPY_DEV.sh
+++ b/ci/install-3.5_NUMPY_DEV.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+source activate pandas
+
+echo "install numpy master wheel"
+
+# remove the system installed numpy
+pip uninstall numpy -y
+
+# we need these for numpy
+
+# these wheels don't play nice with the conda libgfortran / openblas
+# time conda install -n pandas libgfortran openblas || exit 1
+
+time sudo apt-get $APT_ARGS install libatlas-base-dev gfortran
+
+# install numpy wheel from master
+pip install --pre --upgrade --no-index --timeout=60 --trusted-host travis-dev-wheels.scipy.org -f http://travis-dev-wheels.scipy.org/ numpy
+
+true

--- a/ci/install_conda.sh
+++ b/ci/install_conda.sh
@@ -81,6 +81,14 @@ conda info -a || exit 1
 # build deps
 REQ="ci/requirements-${TRAVIS_PYTHON_VERSION}${JOB_TAG}.build"
 time conda create -n pandas python=$TRAVIS_PYTHON_VERSION nose flake8 || exit 1
+
+# may have additional installation instructions for this build
+INSTALL="ci/install-${TRAVIS_PYTHON_VERSION}${JOB_TAG}.sh"
+if [ -e ${INSTALL} ]; then
+    time bash $INSTALL || exit 1
+fi
+
+# install deps
 time conda install -n pandas --file=${REQ} || exit 1
 
 source activate pandas

--- a/ci/requirements-3.5.run
+++ b/ci/requirements-3.5.run
@@ -13,12 +13,10 @@ html5lib
 lxml
 matplotlib
 jinja2
+bottleneck
+sqlalchemy
+pymysql
+psycopg2
 
-# currently causing some warnings
-#sqlalchemy
-#pymysql
-#psycopg2
-
-# not available from conda
-#beautiful-soup
-#bottleneck
+# incompat with conda ATM
+# beautiful-soup

--- a/ci/requirements-3.5_NUMPY_DEV.build
+++ b/ci/requirements-3.5_NUMPY_DEV.build
@@ -1,0 +1,3 @@
+python-dateutil
+pytz
+cython

--- a/ci/requirements-3.5_NUMPY_DEV.run
+++ b/ci/requirements-3.5_NUMPY_DEV.run
@@ -1,0 +1,2 @@
+python-dateutil
+pytz


### PR DESCRIPTION
- adds back some 3.5 deps previously missing in conda
- closes #12057 (adds 3.5 wheel from nump)
