### PR TITLE
Show Index Headers on DataFrames with Style

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -538,3 +538,4 @@ of columns didn't match the number of series provided (:issue:`12039`).
 - Bug in ``Series`` constructor with read-only data (:issue:`11502`)
 
 - Bug in ``.loc`` setitem indexer preventing the use of a TZ-aware DatetimeIndex (:issue:`12050`)
+- Big in ``.style`` indexes and multi-indexes not appearing (:issue:`11655`)

--- a/pandas/core/style.py
+++ b/pandas/core/style.py
@@ -206,6 +206,24 @@ class Styler(object):
                                "class": " ".join(cs)})
             head.append(row_es)
 
+        if self.data.index.names:
+            index_header_row = []
+
+            for c, name in enumerate(self.data.index.names):
+                cs = [COL_HEADING_CLASS,
+                      "level%s" % (n_clvls + 1),
+                      "col%s" % c]
+                index_header_row.append({"type": "th", "value": name,
+                                         "class": " ".join(cs)})
+
+            index_header_row.extend(
+                [{"type": "th",
+                  "value": BLANK_VALUE,
+                  "class": " ".join([BLANK_CLASS])
+                  }] * len(clabels[0]))
+
+            head.append(index_header_row)
+
         body = []
         for r, idx in enumerate(self.data.index):
             cs = [ROW_HEADING_CLASS, "level%s" % c, "row%s" % r]

--- a/pandas/tests/test_style.py
+++ b/pandas/tests/test_style.py
@@ -130,6 +130,40 @@ class TestStyler(TestCase):
         expected = {(0, 0): ['color: white']}
         self.assertEqual(result, expected)
 
+    def test_index_name(self):
+        # https://github.com/pydata/pandas/issues/11655
+        df = pd.DataFrame({'A': [1, 2], 'B': [3, 4], 'C': [5, 6]})
+        result = df.set_index('A').style._translate()
+
+        expected = [[{'class': 'blank', 'type': 'th', 'value': ''},
+                     {'class': 'col_heading level0 col0', 'type': 'th',
+                      'value': 'B'},
+                     {'class': 'col_heading level0 col1', 'type': 'th',
+                      'value': 'C'}],
+                    [{'class': 'col_heading level2 col0', 'type': 'th',
+                      'value': 'A'},
+                     {'class': 'blank', 'type': 'th', 'value': ''},
+                     {'class': 'blank', 'type': 'th', 'value': ''}]]
+
+        self.assertEqual(result['head'], expected)
+
+    def test_multiindex_name(self):
+        # https://github.com/pydata/pandas/issues/11655
+        df = pd.DataFrame({'A': [1, 2], 'B': [3, 4], 'C': [5, 6]})
+        result = df.set_index(['A', 'B']).style._translate()
+
+        expected = [[{'class': 'blank', 'type': 'th', 'value': ''},
+                     {'class': 'blank', 'type': 'th', 'value': ''},
+                     {'class': 'col_heading level0 col0', 'type': 'th',
+                      'value': 'C'}],
+                    [{'class': 'col_heading level2 col0', 'type': 'th',
+                      'value': 'A'},
+                     {'class': 'col_heading level2 col1', 'type': 'th',
+                      'value': 'B'},
+                     {'class': 'blank', 'type': 'th', 'value': ''}]]
+
+        self.assertEqual(result['head'], expected)
+
     def test_apply_axis(self):
         df = pd.DataFrame({'A': [0, 0], 'B': [1, 1]})
         f = lambda x: ['val: %s' % x.max() for v in x]


### PR DESCRIPTION
Partial solution for https://github.com/pydata/pandas/issues/11655 (**Conditional HTML styling hides MultiIndex structure**) and https://github.com/pydata/pandas/issues/11610 (**Followup to Conditional HTML Styling**).

The Style API is inconsistent with `DataFrame.to_html()` when printing index names. Currently the style API doesn't print any index names but `to_html` and the standard notebook repr functions do.

This PR adds a row for index headings in the `Styler._translate` method. This PR does not cause multi-index rownames to span multiple rows, but I can work on adding that if people want. 
## Reproducing Output:

``` python
import pandas as pd
import numpy as np

np.random.seed(24)
df = pd.DataFrame({'A': np.linspace(1, 10, 10)})
df = pd.concat([df, pd.DataFrame(np.random.randn(10, 4),
                                 columns=list('BCDE'))],
               axis=1)
```

``` python
df.set_index(['A', 'B']).style
```
##### Current Output

<img width="506" alt="screen shot 2016-01-19 at 10 19 08 am" src="https://cloud.githubusercontent.com/assets/3064019/12422922/32254fb2-be97-11e5-8096-fcadbd902daa.png">
##### Patched Output:

<img width="441" alt="screen shot 2016-01-19 at 10 19 19 am" src="https://cloud.githubusercontent.com/assets/3064019/12422947/46affb6c-be97-11e5-83c7-acd276bdb88f.png">
## TODO:
- [X] Add Tests
