### PR TITLE
ERR: read_csv with dtype on empty data, #12048.

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -537,4 +537,5 @@ of columns didn't match the number of series provided (:issue:`12039`).
 - Bug in ``Series`` constructor with read-only data (:issue:`11502`)
 
 - Bug in ``.loc`` setitem indexer preventing the use of a TZ-aware DatetimeIndex (:issue:`12050`)
-- Big in ``.style`` indexes and multi-indexes not appearing (:issue:`11655`)
+- Bug in ``.style`` indexes and multi-indexes not appearing (:issue:`11655`)
+- Bug in ``.read_csv`` with dtype specified on empty data producing an error (:issue:`12048`)

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -4,6 +4,7 @@ Module contains tools for processing files into DataFrames or other objects
 from __future__ import print_function
 from pandas.compat import range, lrange, StringIO, lzip, zip, string_types, map
 from pandas import compat
+from collections import defaultdict
 import re
 import csv
 import warnings
@@ -2264,6 +2265,8 @@ def _get_empty_meta(columns, index_col, index_names, dtype=None):
     if dtype is None:
         dtype = {}
     else:
+        if not isinstance(dtype, dict):
+            dtype = defaultdict(lambda: dtype)
         # Convert column indexes to column names.
         dtype = dict((columns[k] if com.is_integer(k) else k, v)
                      for k, v in compat.iteritems(dtype))

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -1112,5 +1112,5 @@ class TestDataFrameToCSV(tm.TestCase, TestData):
     def test_to_csv_empty_frame(self):
         # GH12048
         actual = read_csv(StringIO('A,B'), dtype=str)
-        expected = pd.DataFrame({'A': [], 'B': []}, dtype=str).reset_index(drop=True)
-        assert_frame_equal(actual, expected, check_names=False, check_index_type=False)
+        expected = pd.DataFrame({'A': [], 'B': []}, index=[], dtype=str)
+        assert_frame_equal(actual, expected)

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -1108,3 +1108,9 @@ class TestDataFrameToCSV(tm.TestCase, TestData):
             df.to_pickle(path)
             result = pd.read_pickle(path)
             assert_frame_equal(result, df)
+
+    def test_to_csv_empty_frame(self):
+        # GH12048
+        actual = read_csv(StringIO('A,B'), dtype=str)
+        expected = pd.DataFrame({'A': [], 'B': []}, dtype=str).reset_index(drop=True)
+        assert_frame_equal(actual, expected, check_names=False, check_index_type=False)


### PR DESCRIPTION
ERR: read_csv with dtype specified on empty data 

closes #12048.
