### PR TITLE
CLN: cleaned RangeIndex._min_fitting_element

### DIFF
--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -3,8 +3,6 @@ import datetime
 import warnings
 import operator
 from functools import partial
-from math import ceil, floor
-
 from sys import getsizeof
 
 import numpy as np
@@ -4267,16 +4265,14 @@ class RangeIndex(Int64Index):
         return new_index
 
     def _min_fitting_element(self, lower_limit):
-        """Returns the value of the smallest element greater than the limit"""
-        round = ceil if self._step > 0 else floor
-        no_steps = round((float(lower_limit) - self._start) / self._step)
-        return self._start + self._step * no_steps
+        """Returns the smallest element greater than or equal to the limit"""
+        no_steps = -(-(lower_limit - self._start) // abs(self._step))
+        return self._start + abs(self._step) * no_steps
 
     def _max_fitting_element(self, upper_limit):
-        """Returns the value of the largest element smaller than the limit"""
-        round = floor if self._step > 0 else ceil
-        no_steps = round((float(upper_limit) - self._start) / self._step)
-        return self._start + self._step * no_steps
+        """Returns the largest element smaller than or equal to the limit"""
+        no_steps = (upper_limit - self._start) // abs(self._step)
+        return self._start + abs(self._step) * no_steps
 
     def _extended_gcd(self, a, b):
         """

--- a/pandas/tests/test_index.py
+++ b/pandas/tests/test_index.py
@@ -4266,6 +4266,11 @@ class TestRangeIndex(Numeric, tm.TestCase):
         result = RangeIndex(5, 0, -1)._min_fitting_element(1)
         self.assertEqual(1, result)
 
+        big_num = 500000000000000000000000
+
+        result = RangeIndex(5, big_num * 2, 1)._min_fitting_element(big_num)
+        self.assertEqual(big_num, result)
+
     def test_max_fitting_element(self):
         result = RangeIndex(0, 20, 2)._max_fitting_element(17)
         self.assertEqual(16, result)
@@ -4278,6 +4283,11 @@ class TestRangeIndex(Numeric, tm.TestCase):
 
         result = RangeIndex(5, 0, -1)._max_fitting_element(4)
         self.assertEqual(4, result)
+
+        big_num = 500000000000000000000000
+
+        result = RangeIndex(5, big_num * 2, 1)._max_fitting_element(big_num)
+        self.assertEqual(big_num, result)
 
     def test_pickle_compat_construction(self):
         # RangeIndex() is a valid constructor


### PR DESCRIPTION
Added test cases for `_min_fitting_element` and `_max_fitting_element` (unused) that would fail in master because of precision
