### PR TITLE
Update __init__.py

### DIFF
--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -47,7 +47,9 @@ try:
     BytesIO = StringIO
     import cPickle
     import httplib
+    from inspect import signature
 except ImportError:
+    from inspect import getargspec
     import builtins
     from io import StringIO, BytesIO
     cStringIO = StringIO


### PR DESCRIPTION
getargspec is dprecated in python 3; signature is used instead
