### PR TITLE
Allow from_tuples to accept and iterator

### DIFF
--- a/pandas/core/index.py
+++ b/pandas/core/index.py
@@ -5619,6 +5619,8 @@ class MultiIndex(Index):
         MultiIndex.from_product : Make a MultiIndex from cartesian product
                                   of iterables
         """
+        tuples = list(tuples)
+        
         if len(tuples) == 0:
             # I think this is right? Not quite sure...
             raise TypeError('Cannot infer number of levels from empty list')


### PR DESCRIPTION
Since many methods of constructing a list of tuples in Python3 return iterators, this flattens them. Although using from_arrays often works better.
