### PR TITLE
DEV: Add static modifier to inline declarations.

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -538,3 +538,5 @@ of columns didn't match the number of series provided (:issue:`12039`).
 
 - Bug in ``.loc`` setitem indexer preventing the use of a TZ-aware DatetimeIndex (:issue:`12050`)
 - Big in ``.style`` indexes and multi-indexes not appearing (:issue:`11655`)
+
+- Bug in building Pandas with debugging symbols (:issue:`12123`)

--- a/pandas/src/helper.h
+++ b/pandas/src/helper.h
@@ -3,11 +3,11 @@
 
 #ifndef PANDAS_INLINE
   #if defined(__GNUC__)
-    #define PANDAS_INLINE __inline__
+    #define PANDAS_INLINE static __inline__
   #elif defined(_MSC_VER)
-    #define PANDAS_INLINE __inline
+    #define PANDAS_INLINE static __inline
   #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-    #define PANDAS_INLINE inline
+    #define PANDAS_INLINE static inline
   #else
     #define PANDAS_INLINE
   #endif

--- a/pandas/src/klib/khash.h
+++ b/pandas/src/klib/khash.h
@@ -132,11 +132,11 @@ typedef double khfloat64_t;
 
 #ifndef PANDAS_INLINE
   #if defined(__GNUC__)
-    #define PANDAS_INLINE __inline__
+    #define PANDAS_INLINE static __inline__
   #elif defined(_MSC_VER)
-    #define PANDAS_INLINE __inline
+    #define PANDAS_INLINE static __inline
   #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-    #define PANDAS_INLINE inline
+    #define PANDAS_INLINE static inline
   #else
     #define PANDAS_INLINE
   #endif
@@ -324,7 +324,7 @@ static const double __ac_HASH_UPPER = 0.77;
 	}
 
 #define KHASH_INIT(name, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal) \
-	KHASH_INIT2(name, static PANDAS_INLINE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
+	KHASH_INIT2(name, PANDAS_INLINE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
 
 /* --- BEGIN OF HASH FUNCTIONS --- */
 
@@ -354,7 +354,7 @@ static const double __ac_HASH_UPPER = 0.77;
   @param  s     Pointer to a null terminated string
   @return       The hash value
  */
-static PANDAS_INLINE khint_t __ac_X31_hash_string(const char *s)
+PANDAS_INLINE khint_t __ac_X31_hash_string(const char *s)
 {
 	khint_t h = *s;
 	if (h) for (++s ; *s; ++s) h = (h << 5) - h + *s;
@@ -371,7 +371,7 @@ static PANDAS_INLINE khint_t __ac_X31_hash_string(const char *s)
  */
 #define kh_str_hash_equal(a, b) (strcmp(a, b) == 0)
 
-static PANDAS_INLINE khint_t __ac_Wang_hash(khint_t key)
+PANDAS_INLINE khint_t __ac_Wang_hash(khint_t key)
 {
     key += ~(key << 15);
     key ^=  (key >> 10);

--- a/pandas/src/klib/kvec.h
+++ b/pandas/src/klib/kvec.h
@@ -54,11 +54,11 @@ int main() {
 
 #ifndef PANDAS_INLINE
   #if defined(__GNUC__)
-    #define PANDAS_INLINE __inline__
+    #define PANDAS_INLINE static __inline__
   #elif defined(_MSC_VER)
-    #define PANDAS_INLINE __inline
+    #define PANDAS_INLINE static __inline
   #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-    #define PANDAS_INLINE inline
+    #define PANDAS_INLINE static inline
   #else
     #define PANDAS_INLINE
   #endif

--- a/pandas/src/parser/tokenizer.c
+++ b/pandas/src/parser/tokenizer.c
@@ -408,7 +408,7 @@ static int push_char(parser_t *self, char c) {
     return 0;
 }
 
-static int P_INLINE end_field(parser_t *self) {
+int P_INLINE end_field(parser_t *self) {
     // XXX cruft
 //    self->numeric_field = 0;
     if (self->words_len >= self->words_cap) {

--- a/pandas/src/parser/tokenizer.h
+++ b/pandas/src/parser/tokenizer.h
@@ -41,11 +41,11 @@ See LICENSE for the license
 
 #ifndef P_INLINE
   #if defined(__GNUC__)
-    #define P_INLINE __inline__
+    #define P_INLINE static __inline__
   #elif defined(_MSC_VER)
     #define P_INLINE
   #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-    #define P_INLINE inline
+    #define P_INLINE static inline
   #else
     #define P_INLINE
   #endif

--- a/pandas/src/period_helper.c
+++ b/pandas/src/period_helper.c
@@ -283,19 +283,19 @@ static int daytime_conversion_factors[][2] = {
 
 static npy_int64** daytime_conversion_factor_matrix = NULL;
 
-PANDAS_INLINE static int max_value(int a, int b) {
+PANDAS_INLINE int max_value(int a, int b) {
     return a > b ? a : b;
 }
 
-PANDAS_INLINE static int min_value(int a, int b) {
+PANDAS_INLINE int min_value(int a, int b) {
     return a < b ? a : b;
 }
 
-PANDAS_INLINE static int get_freq_group(int freq) {
+PANDAS_INLINE int get_freq_group(int freq) {
     return (freq/1000)*1000;
 }
 
-PANDAS_INLINE static int get_freq_group_index(int freq) {
+PANDAS_INLINE int get_freq_group_index(int freq) {
     return freq/1000;
 }
 
@@ -399,7 +399,7 @@ PANDAS_INLINE npy_int64 downsample_daytime(npy_int64 ordinal, asfreq_info *af_in
     return ordinal / (af_info->intraday_conversion_factor);
 }
 
-PANDAS_INLINE static npy_int64 transform_via_day(npy_int64 ordinal, char relation, asfreq_info *af_info, freq_conv_func first_func, freq_conv_func second_func) {
+PANDAS_INLINE npy_int64 transform_via_day(npy_int64 ordinal, char relation, asfreq_info *af_info, freq_conv_func first_func, freq_conv_func second_func) {
     //printf("transform_via_day(%ld, %ld, %d)\n", ordinal, af_info->intraday_conversion_factor, af_info->intraday_conversion_upsample);
 	npy_int64 result;
 

--- a/pandas/src/skiplist.h
+++ b/pandas/src/skiplist.h
@@ -18,17 +18,17 @@
 
 #ifndef PANDAS_INLINE
   #if defined(__GNUC__)
-    #define PANDAS_INLINE __inline__
+    #define PANDAS_INLINE static __inline__
   #elif defined(_MSC_VER)
-    #define PANDAS_INLINE __inline
+    #define PANDAS_INLINE static __inline
   #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-    #define PANDAS_INLINE inline
+    #define PANDAS_INLINE static inline
   #else
     #define PANDAS_INLINE
   #endif
 #endif
 
-PANDAS_INLINE static float __skiplist_nanf(void)
+PANDAS_INLINE float __skiplist_nanf(void)
 {
     const union { int __i; float __f;} __bint = {0x7fc00000UL};
     return __bint.__f;
@@ -36,7 +36,7 @@ PANDAS_INLINE static float __skiplist_nanf(void)
 #define PANDAS_NAN ((double) __skiplist_nanf())
 
 
-static PANDAS_INLINE double Log2(double val) {
+PANDAS_INLINE double Log2(double val) {
   return log(val) / log(2.);
 }
 
@@ -59,15 +59,15 @@ typedef struct {
   int maxlevels;
 } skiplist_t;
 
-static PANDAS_INLINE double urand(void) {
+PANDAS_INLINE double urand(void) {
   return ((double) rand() + 1) / ((double) RAND_MAX + 2);
 }
 
-static PANDAS_INLINE int int_min(int a, int b) {
+PANDAS_INLINE int int_min(int a, int b) {
   return a < b ? a : b;
 }
 
-static PANDAS_INLINE node_t *node_init(double value, int levels) {
+PANDAS_INLINE node_t *node_init(double value, int levels) {
   node_t *result;
   result = (node_t*) malloc(sizeof(node_t));
   if (result) {
@@ -88,11 +88,11 @@ static PANDAS_INLINE node_t *node_init(double value, int levels) {
 }
 
 // do this ourselves
-static PANDAS_INLINE void node_incref(node_t *node) {
+PANDAS_INLINE void node_incref(node_t *node) {
   ++(node->ref_count);
 }
 
-static PANDAS_INLINE void node_decref(node_t *node) {
+PANDAS_INLINE void node_decref(node_t *node) {
   --(node->ref_count);
 }
 
@@ -115,7 +115,7 @@ static void node_destroy(node_t *node) {
   }
 }
 
-static PANDAS_INLINE void skiplist_destroy(skiplist_t *skp) {
+PANDAS_INLINE void skiplist_destroy(skiplist_t *skp) {
   if (skp) {
     node_destroy(skp->head);
     free(skp->tmp_steps);
@@ -124,7 +124,7 @@ static PANDAS_INLINE void skiplist_destroy(skiplist_t *skp) {
   }
 }
 
-static PANDAS_INLINE skiplist_t *skiplist_init(int expected_size) {
+PANDAS_INLINE skiplist_t *skiplist_init(int expected_size) {
   skiplist_t *result;
   node_t *NIL, *head;
   int maxlevels, i;
@@ -163,7 +163,7 @@ static PANDAS_INLINE skiplist_t *skiplist_init(int expected_size) {
 }
 
 // 1 if left < right, 0 if left == right, -1 if left > right
-static PANDAS_INLINE int _node_cmp(node_t* node, double value){
+PANDAS_INLINE int _node_cmp(node_t* node, double value){
   if (node->is_nil || node->value > value) {
     return -1;
   }
@@ -175,7 +175,7 @@ static PANDAS_INLINE int _node_cmp(node_t* node, double value){
   }
 }
 
-static PANDAS_INLINE double skiplist_get(skiplist_t *skp, int i, int *ret) {
+PANDAS_INLINE double skiplist_get(skiplist_t *skp, int i, int *ret) {
   node_t *node;
   int level;
 
@@ -199,7 +199,7 @@ static PANDAS_INLINE double skiplist_get(skiplist_t *skp, int i, int *ret) {
   return node->value;
 }
 
-static PANDAS_INLINE int skiplist_insert(skiplist_t *skp, double value) {
+PANDAS_INLINE int skiplist_insert(skiplist_t *skp, double value) {
   node_t *node, *prevnode, *newnode, *next_at_level;
   int *steps_at_level;
   int size, steps, level;
@@ -253,7 +253,7 @@ static PANDAS_INLINE int skiplist_insert(skiplist_t *skp, double value) {
   return 1;
 }
 
-static PANDAS_INLINE int skiplist_remove(skiplist_t *skp, double value) {
+PANDAS_INLINE int skiplist_remove(skiplist_t *skp, double value) {
   int level, size;
   node_t *node, *prevnode, *tmpnode, *next_at_level;
   node_t **chain;

--- a/pandas/src/ujson/lib/ultrajson.h
+++ b/pandas/src/ujson/lib/ultrajson.h
@@ -95,7 +95,7 @@ typedef __int64 JSLONG;
 
 #define FASTCALL_MSVC __fastcall
 #define FASTCALL_ATTR
-#define INLINE_PREFIX __inline
+#define INLINE_PREFIX static __inline
 
 #else
 
@@ -114,7 +114,7 @@ typedef uint32_t JSUINT32;
 #define FASTCALL_ATTR
 #endif
 
-#define INLINE_PREFIX inline
+#define INLINE_PREFIX static inline
 
 typedef uint8_t JSUINT8;
 typedef uint16_t JSUTF16;

--- a/setup.py
+++ b/setup.py
@@ -290,7 +290,7 @@ class CheckSDist(sdist_class):
 class CheckingBuildExt(build_ext):
     """
     Subclass build_ext to get clearer report if Cython is necessary.
-    Also, add some platform based compiler flags.
+
     """
 
     def check_cython_extensions(self, extensions):
@@ -304,26 +304,7 @@ class CheckingBuildExt(build_ext):
 
     def build_extensions(self):
         self.check_cython_extensions(self.extensions)
-        self.add_gnu_inline_flag(self.extensions)
         build_ext.build_extensions(self)
-
-    def add_gnu_inline_flag(self, extensions):
-        '''
-        Add CFLAGS `-fgnu89-inline` for clang on FreeBSD 10+
-        '''
-        if not platform.system() == 'FreeBSD':
-            return
-
-        try:
-            bsd_release = float(platform.release().split('-')[0])
-        except ValueError:  # unknow freebsd version
-            return
-
-        if bsd_release < 10:  # 9 or earlier still using gcc42
-            return
-
-        for ext in extensions:
-            ext.extra_compile_args += ['-fgnu89-inline']
 
 
 class CythonCommand(build_ext):


### PR DESCRIPTION
It is currently impossible to build a debug version of Pandas on Mac OS, since some of the C function declarations are declared as `inline`, and compiling in debug mode turns off optimizations and hence inlining. While this could be solved by adding a compile argument to `setup.py` to use the C89 behavior for inline as in #10510, I believe an ultimately cleaner solution may consist of declaring inlined functions as `static`, so that the code is properly C99-compliant.

For the implementation, I added the `static` keyword to the definitions of `PANDAS_INLINE` and `P_INLINE` (and removed duplicate occurrences of `static` from some function declarations), so that future implementations that use those defines are automatically compliant. This is slightly different from e.g. Cython, which defines `CYTHON_INLINE` as `inline` and declares everything as `static CYTHON_INLINE`.
