### PR TITLE
Fix Styler._translate failing on numeric columns

### DIFF
--- a/pandas/core/style.py
+++ b/pandas/core/style.py
@@ -237,7 +237,7 @@ class Styler(object):
                 cs = [DATA_CLASS, "row%s" % r, "col%s" % c]
                 cs.extend(cell_context.get("data", {}).get(r, {}).get(c, []))
                 row_es.append({"type": "td",
-                               "value": self.data.iloc[r][c],
+                               "value": self.data.iloc[r, c],
                                "class": " ".join(cs),
                                "id": "_".join(cs[1:])})
                 props = []

--- a/pandas/tests/test_style.py
+++ b/pandas/tests/test_style.py
@@ -164,6 +164,12 @@ class TestStyler(TestCase):
 
         self.assertEqual(result['head'], expected)
 
+    def test_numeric_columns(self):
+        # https://github.com/pydata/pandas/issues/12125
+        # smoke test for _translate
+        df = pd.DataFrame({0: [1, 2, 3]})
+        df.style._translate()
+
     def test_apply_axis(self):
         df = pd.DataFrame({'A': [0, 0], 'B': [1, 1]})
         f = lambda x: ['val: %s' % x.max() for v in x]


### PR DESCRIPTION
Addresses https://github.com/pydata/pandas/issues/12125.

The previous behaviour was to use a `__getitem__` lookup which caused incorrect behaviour with numeric columns. The adjusted code uses `iloc` numerical indexing to resolve the issue.
