### PR TITLE
PERF: add support for NaT in hashtable factorizers, improving Categorical construction with NaT

### DIFF
--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -46,6 +46,22 @@ class categorical_constructor(object):
         Categorical(self.codes, self.cat_idx, fastpath=True)
 
 
+class categorical_constructor_with_datetimes(object):
+    goal_time = 0.2
+
+    def setup(self):
+        self.datetimes = pd.Series(pd.date_range(
+            '1995-01-01 00:00:00', periods=10000, freq='s'))
+
+    def time_datetimes(self):
+        Categorical(self.datetimes)
+
+    def time_datetimes_with_nat(self):
+        t = self.datetimes
+        t.iloc[-1] = pd.NaT
+        Categorical(t)
+
+
 class categorical_rendering(object):
     goal_time = 3e-3
 

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -458,7 +458,7 @@ Performance Improvements
 - Improved huge ``DatetimeIndex``, ``PeriodIndex`` and ``TimedeltaIndex``'s ops performance including ``NaT`` (:issue:`10277`)
 - Improved performance of ``pandas.concat`` (:issue:`11958`)
 - Improved performance of ``StataReader`` (:issue:`11591`)
-
+- Improved performance in construction of ``Categoricals`` with Series of datetimes containing ``NaT`` (:issue:`12077`)
 
 
 
@@ -481,6 +481,7 @@ Bug Fixes
 - Bug in vectorized ``DateOffset`` when ``n`` parameter is ``0`` (:issue:`11370`)
 - Compat for numpy 1.11 w.r.t. ``NaT`` comparison changes (:issue:`12049`)
 - Bug in ``read_csv`` when reading from a ``StringIO`` in threads (:issue:`11790`)
+- Bug in not treating ``NaT`` as a missing value in datetimelikes when factorizing & with ``Categoricals`` (:issue:`12077`)
 
 
 

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -257,7 +257,7 @@ class Categorical(PandasObject):
                 categories = values.categories
             values = values.__array__()
 
-        elif isinstance(values, ABCIndexClass):
+        elif isinstance(values, (ABCIndexClass, ABCSeries)):
             pass
 
         else:
@@ -1177,7 +1177,7 @@ class Categorical(PandasObject):
         """
         # if we are a datetime and period index, return Index to keep metadata
         if com.is_datetimelike(self.categories):
-            return self.categories.take(self._codes)
+            return self.categories.take(self._codes, fill_value=np.nan)
         return np.array(self)
 
     def check_for_ordered(self, op):

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -787,7 +787,12 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         # check the rank
         expected = DataFrame([[2., nan, 1.],
                               [2., 3., 1.]])
-        result = df.rank(1, numeric_only=False)
+        result = df.rank(1, numeric_only=False, ascending=True)
+        assert_frame_equal(result, expected)
+
+        expected = DataFrame([[1., nan, 2.],
+                              [2., 1., 3.]])
+        result = df.rank(1, numeric_only=False, ascending=False)
         assert_frame_equal(result, expected)
 
         # mixed-type frames

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -832,7 +832,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
         values[imask] = np.array([formatter(dt) for dt in values[imask]])
         return values
 
-    def take(self, indices, axis=0):
+    def take(self, indices, axis=0, allow_fill=True, fill_value=None):
         """
         Analogous to ndarray.take
         """


### PR DESCRIPTION
closes #12077 

```
before     after       ratio
[1330b9fe] [404911c6]
17.25ms     1.21ms      0.07  categoricals.categorical_constructor_with_datetimes.time_datetimes_with_nat
```
