### PR TITLE
CI: latest ipython version for doc build

### DIFF
--- a/ci/requirements-2.7_DOC_BUILD.run
+++ b/ci/requirements-2.7_DOC_BUILD.run
@@ -1,4 +1,4 @@
-ipython=3.2.1
+ipython
 nbconvert
 matplotlib
 scipy


### PR DESCRIPTION
See https://github.com/pydata/pandas/pull/12002#issuecomment-174550631

Doc builds are failing, testing if using the latest `ipython` version solves it.
