### PR TITLE
ENH: plotting numerical expressions

### DIFF
--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -2421,7 +2421,7 @@ def _plot(data, x=None, y=None, subplots=False,
                 if com.is_integer(y) and not data.columns.holds_integer():
                     y = data.columns[y]
                 label = kwds['label'] if 'label' in kwds else y
-                series = data[y].copy()  # Don't modify
+                series = data.eval(y).copy()  # Don't modify
                 series.name = label
 
                 for kw in ['xerr', 'yerr']:

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -2421,7 +2421,15 @@ def _plot(data, x=None, y=None, subplots=False,
                 if com.is_integer(y) and not data.columns.holds_integer():
                     y = data.columns[y]
                 label = kwds['label'] if 'label' in kwds else y
-                series = data.eval(y).copy()  # Don't modify
+                
+                if com.is_string_like(y) and y not in data.columns:
+                    data = data.assign(**{y:data.eval(y)})
+                elif com.is_list_like:
+                    for column in y:
+                        if column not in data.columns:
+                            data = data.assign(**{column:data.eval(column)})
+                            
+                series = data[y].copy()  # Don't modify
                 series.name = label
 
                 for kw in ['xerr', 'yerr']:


### PR DESCRIPTION
Passing the `y` argument of a plot to `DataFrame.eval` allows plotting a numerical expression.
Makes numerical data exploration much easier. E.g. graphically finding the norm of two curves.
See example here:
[example notebook](https://gist.github.com/TsvikiHirsh/46fd47bc35dc1874234d)

No support for multicolumn plotting, e.g. for `["a","4*b"]`
Should be very easy to apply the same on the `index`.

Could be very useful for data exploration, without modifying the original `DataFrame`
