### PR TITLE
CI: install sphinx with conda for doc build

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -18,7 +18,6 @@ if [ x"$DOC_BUILD" != x"" ]; then
 
     source activate pandas
     conda install -n pandas -c r r rpy2 --yes
-    pip install sphinx -U
 
     time sudo apt-get $APT_ARGS install dvipng
 

--- a/ci/requirements-2.7_DOC_BUILD.run
+++ b/ci/requirements-2.7_DOC_BUILD.run
@@ -1,4 +1,5 @@
 ipython
+sphinx
 nbconvert
 matplotlib
 scipy


### PR DESCRIPTION
Sphinx > 1.3.1 is now available in conda,
so not needed to isntall this separately with pip to get latest version.
