### PR TITLE
BUG: Timestamp subtraction of NaT with timezones

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -870,6 +870,8 @@ Bug Fixes
 - Bug in ``Series.resample`` using a frequency of ``Nano`` when the index is a ``DatetimeIndex`` and contains non-zero nanosecond parts (:issue:`12037`)
 
 
+- Bug in ``NaT`` subtraction from ``Timestamp`` or ``DatetimeIndex`` with timezones (:issue:`11718`)
+
 - Bug in ``Timedelta.round`` with negative values (:issue:`11690`)
 - Bug in ``.loc`` against ``CategoricalIndex`` may result in normal ``Index`` (:issue:`11586`)
 - Bug in ``DataFrame.info`` when duplicated column names exist (:issue:`11761`)

--- a/pandas/tseries/base.py
+++ b/pandas/tseries/base.py
@@ -199,6 +199,27 @@ class DatetimeIndexOpsMixin(object):
         except ValueError:
             return None
 
+    def _nat_new(self, box=True):
+        """
+        Return Index or ndarray filled with NaT which has the same
+        length as the caller.
+
+        Parameters
+        ----------
+        box : boolean, default True
+            - If True returns a Index as the same as caller.
+            - If False returns ndarray of np.int64.
+        """
+        result = np.zeros(len(self), dtype=np.int64)
+        result.fill(tslib.iNaT)
+        if not box:
+            return result
+
+        attribs = self._get_attributes_dict()
+        if not isinstance(self, com.ABCPeriodIndex):
+            attribs['freq'] = None
+        return self._simple_new(result, **attribs)
+
     # Try to run function on index first, and then on elements of index
     # Especially important for group-by functionality
     def map(self, f):
@@ -224,8 +245,8 @@ class DatetimeIndexOpsMixin(object):
             sorted_values = np.sort(self.values)
             attribs = self._get_attributes_dict()
             freq = attribs['freq']
-            from pandas.tseries.period import PeriodIndex
-            if freq is not None and not isinstance(self, PeriodIndex):
+
+            if freq is not None and not isinstance(self, com.ABCPeriodIndex):
                 if freq.n > 0 and not ascending:
                     freq = freq * -1
                 elif freq.n < 0 and ascending:

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -740,20 +740,26 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
             raise Exception("invalid pickle state")
     _unpickle_compat = __setstate__
 
+    def _add_datelike(self, other):
+        # adding a timedeltaindex to a datetimelike
+        if other is tslib.NaT:
+            return self._nat_new(box=True)
+        raise TypeError("cannot add a datelike to a DatetimeIndex")
+
     def _sub_datelike(self, other):
         # subtract a datetime from myself, yielding a TimedeltaIndex
-
         from pandas import TimedeltaIndex
         other = Timestamp(other)
-
+        if other is tslib.NaT:
+            result = self._nat_new(box=False)
         # require tz compat
-        if not self._has_same_tz(other):
+        elif not self._has_same_tz(other):
             raise TypeError("Timestamp subtraction must have the same "
                             "timezones or no timezones")
-
-        i8 = self.asi8
-        result = i8 - other.value
-        result = self._maybe_mask_results(result, fill_value=tslib.iNaT)
+        else:
+            i8 = self.asi8
+            result = i8 - other.value
+            result = self._maybe_mask_results(result, fill_value=tslib.iNaT)
         return TimedeltaIndex(result, name=self.name, copy=False)
 
     def _maybe_update_attributes(self, attrs):

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -317,17 +317,24 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         return NotImplemented
 
     def _add_datelike(self, other):
-
         # adding a timedeltaindex to a datetimelike
         from pandas import Timestamp, DatetimeIndex
-        other = Timestamp(other)
-        i8 = self.asi8
-        result = i8 + other.value
-        result = self._maybe_mask_results(result, fill_value=tslib.iNaT)
+        if other is tslib.NaT:
+            result = self._nat_new(box=False)
+        else:
+            other = Timestamp(other)
+            i8 = self.asi8
+            result = i8 + other.value
+            result = self._maybe_mask_results(result, fill_value=tslib.iNaT)
         return DatetimeIndex(result, name=self.name, copy=False)
 
     def _sub_datelike(self, other):
-        raise TypeError("cannot subtract a datelike from a TimedeltaIndex")
+        from pandas import DatetimeIndex
+        if other is tslib.NaT:
+            result = self._nat_new(box=False)
+        else:
+            raise TypeError("cannot subtract a datelike from a TimedeltaIndex")
+        return DatetimeIndex(result, name=self.name, copy=False)
 
     def _format_native_types(self, na_rep=u('NaT'),
                              date_format=None, **kwargs):

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -341,6 +341,14 @@ Freq: D"""
             rng += 1
             tm.assert_index_equal(rng, expected)
 
+        idx = DatetimeIndex(['2011-01-01', '2011-01-02'])
+        msg = "cannot add a datelike to a DatetimeIndex"
+        with tm.assertRaisesRegexp(TypeError, msg):
+            idx + pd.Timestamp('2011-01-01')
+
+        with tm.assertRaisesRegexp(TypeError, msg):
+            pd.Timestamp('2011-01-01') + idx
+
     def test_sub_isub(self):
         for tz in self.tz:
             # diff
@@ -598,6 +606,16 @@ Freq: D"""
             tm.assert_index_equal(idx, result)
             self.assertEqual(result.freq, freq)
 
+    def test_nat_new(self):
+        idx = pd.date_range('2011-01-01', freq='D', periods=5, name='x')
+        result = idx._nat_new()
+        exp = pd.DatetimeIndex([pd.NaT] * 5, name='x')
+        tm.assert_index_equal(result, exp)
+
+        result = idx._nat_new(box=False)
+        exp = np.array([tslib.iNaT] * 5, dtype=np.int64)
+        tm.assert_numpy_array_equal(result, exp)
+
 
 class TestTimedeltaIndexOps(Ops):
     def setUp(self):
@@ -777,7 +795,6 @@ Freq: D"""
         tm.assert_index_equal(rng, expected)
 
     def test_sub_isub(self):
-
         # only test adding/sub offsets as - is now numeric
 
         # offset
@@ -799,6 +816,15 @@ Freq: D"""
         tm.assert_index_equal(result, expected)
         rng -= 1
         tm.assert_index_equal(rng, expected)
+
+        idx = TimedeltaIndex(['1 day', '2 day'])
+        msg = "cannot subtract a datelike from a TimedeltaIndex"
+        with tm.assertRaisesRegexp(TypeError, msg):
+            idx - pd.Timestamp('2011-01-01')
+
+        result = Timestamp('2011-01-01') + idx
+        expected = DatetimeIndex(['2011-01-02', '2011-01-03'])
+        tm.assert_index_equal(result, expected)
 
     def test_ops_compat(self):
 
@@ -1251,6 +1277,17 @@ Freq: D"""
             result = pd.TimedeltaIndex(idx.asi8, freq='infer')
             tm.assert_index_equal(idx, result)
             self.assertEqual(result.freq, freq)
+
+    def test_nat_new(self):
+
+        idx = pd.timedelta_range('1', freq='D', periods=5, name='x')
+        result = idx._nat_new()
+        exp = pd.TimedeltaIndex([pd.NaT] * 5, name='x')
+        tm.assert_index_equal(result, exp)
+
+        result = idx._nat_new(box=False)
+        exp = np.array([tslib.iNaT] * 5, dtype=np.int64)
+        tm.assert_numpy_array_equal(result, exp)
 
 
 class TestPeriodIndexOps(Ops):
@@ -2053,3 +2090,14 @@ Freq: Q-DEC"""
             self.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
             self.assertEqual(result.freq, 'D')
+
+    def test_nat_new(self):
+
+        idx = pd.period_range('2011-01', freq='M', periods=5, name='x')
+        result = idx._nat_new()
+        exp = pd.PeriodIndex([pd.NaT] * 5, freq='M', name='x')
+        tm.assert_index_equal(result, exp)
+
+        result = idx._nat_new(box=False)
+        exp = np.array([tslib.iNaT] * 5, dtype=np.int64)
+        tm.assert_numpy_array_equal(result, exp)


### PR DESCRIPTION
Closes #11718.
- Ops with `NaT` and `Timestamp` with `tz` results in `NaT`
- Ops with `NaT` and `DatetimeIndex` /  `TimedeltaIndex` results in corresponding `Index` filled with `NaT`.
