### PR TITLE
DEPR: removal of deprecation warnings for float indexers

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -52,6 +52,7 @@ Highlights include:
 - ``pd.test()`` top-level nose test runner is available (:issue:`4327`)
 - Adding support for a ``RangeIndex`` as a specialized form of the ``Int64Index`` for memory savings, see :ref:`here <whatsnew_0180.enhancements.rangeindex>`.
 - API breaking ``.resample`` changes to make it more ``.groupby`` like, see :ref:`here <whatsnew_0180.breaking.resample>`.
+- Removal of support for deprecated float indexers; these will now raise a ``TypeError``, see :ref:`here <whatsnew_0180.enhancements.float_indexers>`.
 
 See the :ref:`v0.18.0 Whatsnew <whatsnew_0180>` overview for an extensive list
 of all enhancements and bugs that have been fixed in 0.17.1.

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -21,6 +21,7 @@ Highlights include:
 - ``pd.test()`` top-level nose test runner is available (:issue:`4327`)
 - Adding support for a ``RangeIndex`` as a specialized form of the ``Int64Index`` for memory savings, see :ref:`here <whatsnew_0180.enhancements.rangeindex>`.
 - API breaking ``.resample`` changes to make it more ``.groupby`` like, see :ref:`here <whatsnew_0180.breaking.resample>`.
+- Removal of support for deprecated float indexers; these will now raise a ``TypeError``, see :ref:`here <whatsnew_0180.enhancements.float_indexers>`.
 
 Check the :ref:`API Changes <whatsnew_0180.api_breaking>` and :ref:`deprecations <whatsnew_0180.deprecations>` before updating.
 
@@ -865,9 +866,45 @@ Deprecations
   is better handled by matplotlib's `style sheets`_ (:issue:`11783`).
 
 
-
-
 .. _style sheets: http://matplotlib.org/users/style_sheets.html
+
+.. _whatsnew_0180.float_indexers:
+
+Removal of deprecated float indexers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In :issue:`4892` indexing with floating point numbers on a non-``Float64Index`` was deprecated (in version 0.14.0).
+In 0.18.0, this deprecation warning is removed and these will now raise a ``TypeError``. (:issue:`12165`)
+
+Previous Behavior:
+
+.. code-block:
+
+   In [1]: s = Series([1,2,3])
+   In [2]: s[1.0]
+   FutureWarning: scalar indexers for index type Int64Index should be integers and not floating point
+   Out[2]: 2
+
+   In [3]: s.iloc[1.0]
+   FutureWarning: scalar indexers for index type Int64Index should be integers and not floating point
+   Out[3]: 2
+
+   In [4]: s.loc[1.0]
+   FutureWarning: scalar indexers for index type Int64Index should be integers and not floating point
+   Out[4]: 2
+
+New Behavior:
+
+.. code-block:
+
+   In [4]: s[1.0]
+   TypeError: cannot do label indexing on <class 'pandas.indexes.range.RangeIndex'> with these indexers [1.0] of <type 'float'>
+
+   In [4]: s.iloc[1.0]
+   TypeError: cannot do label indexing on <class 'pandas.indexes.range.RangeIndex'> with these indexers [1.0] of <type 'float'>
+
+   In [4]: s.loc[1.0]
+   TypeError: cannot do label indexing on <class 'pandas.indexes.range.RangeIndex'> with these indexers [1.0] of <type 'float'>
 
 .. _whatsnew_0180.prior_deprecations:
 

--- a/pandas/indexes/numeric.py
+++ b/pandas/indexes/numeric.py
@@ -42,9 +42,14 @@ class NumericIndex(Index):
         """
 
         # we are a numeric index, so we accept
-        # integer/floats directly
-        if not (com.is_integer(label) or com.is_float(label)):
-            self._invalid_indexer('slice', label)
+        # integer directly
+        if com.is_integer(label):
+            pass
+
+        # disallow floats only if we not-strict
+        elif com.is_float(label):
+            if not (self.is_floating() or kind in ['ix']):
+                self._invalid_indexer('slice', label)
 
         return label
 
@@ -200,6 +205,18 @@ class Float64Index(NumericIndex):
 
         if dtype is None:
             dtype = np.float64
+        dtype = np.dtype(dtype)
+
+        # allow integer / object dtypes to be passed, but coerce to float64
+        if dtype.kind in ['i', 'O']:
+            dtype = np.float64
+
+        elif dtype.kind in ['f']:
+            pass
+
+        else:
+            raise TypeError("cannot support {0} dtype in "
+                            "Float64Index".format(dtype))
 
         try:
             subarr = np.array(data, dtype=dtype, copy=copy)

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -212,11 +212,9 @@ class TestDataFrameIndexing(tm.TestCase, TestData):
         assert_frame_equal(subframe_obj, subframe)
 
         # test that Series indexers reindex
-        with tm.assert_produces_warning(UserWarning):
-            indexer_obj = indexer_obj.reindex(self.tsframe.index[::-1])
-
-            subframe_obj = self.tsframe[indexer_obj]
-            assert_frame_equal(subframe_obj, subframe)
+        indexer_obj = indexer_obj.reindex(self.tsframe.index[::-1])
+        subframe_obj = self.tsframe[indexer_obj]
+        assert_frame_equal(subframe_obj, subframe)
 
         # test df[df > 0]
         for df in [self.tsframe, self.mixed_frame,
@@ -1309,37 +1307,25 @@ class TestDataFrameIndexing(tm.TestCase, TestData):
         df = DataFrame(np.random.randn(5, 5), index=index)
 
         # positional slicing only via iloc!
-        # stacklevel=False -> needed stacklevel depends on index type
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            result = df.iloc[1.0:5]
-
-        expected = df.reindex([2.5, 3.5, 4.5, 5.0])
-        assert_frame_equal(result, expected)
-        self.assertEqual(len(result), 4)
+        self.assertRaises(TypeError, lambda: df.iloc[1.0:5])
 
         result = df.iloc[4:5]
         expected = df.reindex([5.0])
         assert_frame_equal(result, expected)
         self.assertEqual(len(result), 1)
 
-        # GH 4892, float indexers in iloc are deprecated
-        import warnings
-        warnings.filterwarnings(action='error', category=FutureWarning)
-
         cp = df.copy()
 
         def f():
             cp.iloc[1.0:5] = 0
-        self.assertRaises(FutureWarning, f)
+        self.assertRaises(TypeError, f)
 
         def f():
             result = cp.iloc[1.0:5] == 0  # noqa
 
-        self.assertRaises(FutureWarning, f)
+        self.assertRaises(TypeError, f)
         self.assertTrue(result.values.all())
         self.assertTrue((cp.iloc[0:1] == df.iloc[0:1]).values.all())
-
-        warnings.filterwarnings(action='default', category=FutureWarning)
 
         cp = df.copy()
         cp.iloc[4:5] = 0

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -180,53 +180,46 @@ class TestIndex(Base, tm.TestCase):
 
     def test_constructor_dtypes(self):
 
-        for idx in [Index(np.array([1, 2, 3], dtype=int)), Index(
-                np.array(
-                    [1, 2, 3], dtype=int), dtype=int), Index(
-                        np.array(
-                            [1., 2., 3.], dtype=float), dtype=int), Index(
-                                [1, 2, 3], dtype=int), Index(
-                                    [1., 2., 3.], dtype=int)]:
+        for idx in [Index(np.array([1, 2, 3], dtype=int)),
+                    Index(np.array([1, 2, 3], dtype=int), dtype=int),
+                    Index([1, 2, 3], dtype=int)]:
             self.assertIsInstance(idx, Int64Index)
 
-        for idx in [Index(np.array([1., 2., 3.], dtype=float)), Index(
-                np.array(
-                    [1, 2, 3], dtype=int), dtype=float), Index(
-                        np.array(
-                            [1., 2., 3.], dtype=float), dtype=float), Index(
-                                [1, 2, 3], dtype=float), Index(
-                                    [1., 2., 3.], dtype=float)]:
+        # these should coerce
+        for idx in [Index(np.array([1., 2., 3.], dtype=float), dtype=int),
+                    Index([1., 2., 3.], dtype=int)]:
+            self.assertIsInstance(idx, Int64Index)
+
+        for idx in [Index(np.array([1., 2., 3.], dtype=float)),
+                    Index(np.array([1, 2, 3], dtype=int), dtype=float),
+                    Index(np.array([1., 2., 3.], dtype=float), dtype=float),
+                    Index([1, 2, 3], dtype=float),
+                    Index([1., 2., 3.], dtype=float)]:
             self.assertIsInstance(idx, Float64Index)
 
-        for idx in [Index(np.array(
-                [True, False, True], dtype=bool)), Index([True, False, True]),
-                Index(
-                np.array(
-                    [True, False, True], dtype=bool), dtype=bool),
-                Index(
-                [True, False, True], dtype=bool)]:
+        for idx in [Index(np.array([True, False, True], dtype=bool)),
+                    Index([True, False, True]),
+                    Index(np.array([True, False, True], dtype=bool), dtype=bool),
+                    Index([True, False, True], dtype=bool)]:
             self.assertIsInstance(idx, Index)
             self.assertEqual(idx.dtype, object)
 
-        for idx in [Index(
-                np.array([1, 2, 3], dtype=int), dtype='category'), Index(
-                    [1, 2, 3], dtype='category'), Index(
-                        np.array([np.datetime64('2011-01-01'), np.datetime64(
-                            '2011-01-02')]), dtype='category'), Index(
-                                [datetime(2011, 1, 1), datetime(2011, 1, 2)
-                                 ], dtype='category')]:
+        for idx in [Index(np.array([1, 2, 3], dtype=int), dtype='category'),
+                    Index([1, 2, 3], dtype='category'),
+                    Index(np.array([np.datetime64('2011-01-01'),
+                                    np.datetime64('2011-01-02')]), dtype='category'),
+                    Index([datetime(2011, 1, 1), datetime(2011, 1, 2)], dtype='category')]:
             self.assertIsInstance(idx, CategoricalIndex)
 
-        for idx in [Index(np.array([np.datetime64('2011-01-01'), np.datetime64(
-                    '2011-01-02')])),
+        for idx in [Index(np.array([np.datetime64('2011-01-01'),
+                                    np.datetime64('2011-01-02')])),
                     Index([datetime(2011, 1, 1), datetime(2011, 1, 2)])]:
             self.assertIsInstance(idx, DatetimeIndex)
 
-        for idx in [Index(
-                np.array([np.datetime64('2011-01-01'), np.datetime64(
-                    '2011-01-02')]), dtype=object), Index(
-                        [datetime(2011, 1, 1), datetime(2011, 1, 2)
-                         ], dtype=object)]:
+        for idx in [Index(np.array([np.datetime64('2011-01-01'),
+                                    np.datetime64('2011-01-02')]), dtype=object),
+                    Index([datetime(2011, 1, 1),
+                           datetime(2011, 1, 2)], dtype=object)]:
             self.assertNotIsInstance(idx, DatetimeIndex)
             self.assertIsInstance(idx, Index)
             self.assertEqual(idx.dtype, object)
@@ -235,10 +228,9 @@ class TestIndex(Base, tm.TestCase):
                 1, 'D')])), Index([timedelta(1), timedelta(1)])]:
             self.assertIsInstance(idx, TimedeltaIndex)
 
-        for idx in [Index(
-                np.array([np.timedelta64(1, 'D'), np.timedelta64(1, 'D')]),
-                dtype=object), Index(
-                    [timedelta(1), timedelta(1)], dtype=object)]:
+        for idx in [Index(np.array([np.timedelta64(1, 'D'),
+                                    np.timedelta64(1, 'D')]), dtype=object),
+                    Index([timedelta(1), timedelta(1)], dtype=object)]:
             self.assertNotIsInstance(idx, TimedeltaIndex)
             self.assertIsInstance(idx, Index)
             self.assertEqual(idx.dtype, object)
@@ -942,12 +934,17 @@ class TestIndex(Base, tm.TestCase):
         self.assertEqual(idx2.slice_locs(10.5, -1), (0, n))
 
         # int slicing with floats
+        # GH 4892, these are all TypeErrors
         idx = Index(np.array([0, 1, 2, 5, 6, 7, 9, 10], dtype=int))
-        self.assertEqual(idx.slice_locs(5.0, 10.0), (3, n))
-        self.assertEqual(idx.slice_locs(4.5, 10.5), (3, 8))
+        self.assertRaises(TypeError,
+                          lambda: idx.slice_locs(5.0, 10.0), (3, n))
+        self.assertRaises(TypeError,
+                          lambda: idx.slice_locs(4.5, 10.5), (3, 8))
         idx2 = idx[::-1]
-        self.assertEqual(idx2.slice_locs(8.5, 1.5), (2, 6))
-        self.assertEqual(idx2.slice_locs(10.5, -1), (0, n))
+        self.assertRaises(TypeError,
+                          lambda: idx2.slice_locs(8.5, 1.5), (2, 6))
+        self.assertRaises(TypeError,
+                          lambda: idx2.slice_locs(10.5, -1), (0, n))
 
     def test_slice_locs_dup(self):
         idx = Index(['a', 'a', 'b', 'c', 'd', 'd'])

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -379,9 +379,18 @@ class TestInt64Index(Numeric, tm.TestCase):
         new_index = Int64Index(arr, copy=True)
         tm.assert_numpy_array_equal(new_index, self.index)
         val = arr[0] + 3000
+
         # this should not change index
         arr[0] = val
         self.assertNotEqual(new_index[0], val)
+
+        # interpret list-like
+        expected = Int64Index([5, 0])
+        for cls in [Index, Int64Index]:
+            for idx in [cls([5, 0], dtype='int64'),
+                        cls(np.array([5, 0]), dtype='int64'),
+                        cls(Series([5, 0]), dtype='int64')]:
+                tm.assert_index_equal(idx, expected)
 
     def test_constructor_corner(self):
         arr = np.array([1, 2, 3, 4], dtype=object)

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -678,7 +678,12 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
             except TypeError:
                 pass
 
-            key = Period(key, freq=self.freq)
+            try:
+                key = Period(key, freq=self.freq)
+            except ValueError:
+                # we cannot construct the Period
+                # as we have an invalid type
+                return self._invalid_indexer('label', key)
             try:
                 return Index.get_loc(self, key.ordinal, method, tolerance)
             except KeyError:


### PR DESCRIPTION
raise a `TypeError` instead, xref #4892
closes #11836

similar to numpy in 1.11 [here](https://github.com/numpy/numpy/pull/6271)
