### PR TITLE
CLN: Remove testing._skip_if_no_cday

### DIFF
--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -30,7 +30,6 @@ class TestGenRangeGeneration(tm.TestCase):
         self.assert_numpy_array_equal(rng1, rng2)
 
     def test_generate_cday(self):
-        tm._skip_if_no_cday()
         rng1 = list(generate_range(START, END, offset=datetools.cday))
         rng2 = list(generate_range(START, END, time_rule='C'))
         self.assert_numpy_array_equal(rng1, rng2)
@@ -546,7 +545,6 @@ class TestDateRange(tm.TestCase):
 
 class TestCustomDateRange(tm.TestCase):
     def setUp(self):
-        tm._skip_if_no_cday()
         self.rng = cdate_range(START, END)
 
     def test_constructor(self):

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -1397,7 +1397,6 @@ class TestCustomBusinessDay(Base):
         self.d = datetime(2008, 1, 1)
         self.nd = np_datetime64_compat('2008-01-01 00:00:00Z')
 
-        tm._skip_if_no_cday()
         self.offset = CDay()
         self.offset2 = CDay(2)
 
@@ -1629,7 +1628,6 @@ class CustomBusinessMonthBase(object):
     def setUp(self):
         self.d = datetime(2008, 1, 1)
 
-        tm._skip_if_no_cday()
         self.offset = self._object()
         self.offset2 = self._object(2)
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -250,14 +250,6 @@ def _skip_if_windows():
         import nose
         raise nose.SkipTest("Running on Windows")
 
-
-def _skip_if_no_cday():
-    from pandas.core.datetools import cday
-    if cday is None:
-        import nose
-        raise nose.SkipTest("CustomBusinessDay not available.")
-
-
 def _skip_if_no_pathlib():
     try:
         from pathlib import Path


### PR DESCRIPTION
NumPy 1.7 or later supports custom business day. 
