### PR TITLE
ENH: Make HDFStore iterable

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -246,6 +246,7 @@ Other enhancements
 - ``DataFrame.select_dtypes`` now allows the ``np.float16`` typecode (:issue:`11990`)
 - ``pivot_table()`` now accepts most iterables for the ``values`` parameter (:issue:`12017`)
 - Added Google ``BigQuery`` service account authentication support, which enables authentication on remote servers. (:issue:`11881`). For further details see :ref:`here <io.bigquery_authentication>`
+- ``HDFStore`` is now iterable: ``for k in store`` is equivalent to ``for k in store.keys()`` (:issue: `12221`).
 
 .. _whatsnew_0180.api_breaking:
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -488,6 +488,9 @@ class HDFStore(StringMixin):
         """
         return [n._v_pathname for n in self.groups()]
 
+    def __iter__(self):
+        return iter(self.keys())
+
     def items(self):
         """
         iterate on key->group

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -389,8 +389,15 @@ class TestHDFStore(Base, tm.TestCase):
             store['d'] = tm.makePanel()
             store['foo/bar'] = tm.makePanel()
             self.assertEqual(len(store), 5)
-            self.assertTrue(set(
-                store.keys()) == set(['/a', '/b', '/c', '/d', '/foo/bar']))
+            expected = set(['/a', '/b', '/c', '/d', '/foo/bar'])
+            self.assertTrue(set(store.keys()) == expected)
+            self.assertTrue(set(store) == expected)
+
+    def test_iter_empty(self):
+
+        with ensure_clean_path(self.path) as path:
+            # GH 12221
+            self.assertTrue(list(pd.HDFStore(path)) == [])
 
     def test_repr(self):
 


### PR DESCRIPTION
closes #12221

HDFStore is not an iterator - but being iterable, it can return an iterator of itself (i.e. of `.keys()`).
