### PR TITLE
Fix #12037 Error when Resampling using pd.tseries.offsets.Nano as period

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -888,3 +888,5 @@ Bug Fixes
 - Bug in ``.skew`` and ``.kurt`` due to roundoff error for highly similar values (:issue:`11974`)
 
 - Bug in ``buffer_rd_bytes`` src->buffer could be freed more than once if reading failed, causing a segfault (:issue:`12098`)
+
+- Bug in ``Series.resample`` using pd.tseries.offsets.Nano as period when the index is an DatetimeIndex and contains non-zero nanosecond part (:issue:`12037`) 

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -854,8 +854,11 @@ class TimeGrouper(Grouper):
                                        closed=self.closed,
                                        base=self.base)
         tz = ax.tz
-        # do not call replace() because that will swallow the nanosecond part
         # GH #12037
+        # use first/last directly instead of call replace() on them
+        # because replace() will swallow the nanosecond part
+        # thus last bin maybe slightly before the end if the end contains
+        # nanosecond part and lead to `Values falls after last bin` error
         binner = labels = DatetimeIndex(freq=self.freq,
                                         start=first,
                                         end=last,

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -854,9 +854,11 @@ class TimeGrouper(Grouper):
                                        closed=self.closed,
                                        base=self.base)
         tz = ax.tz
+        # do not call replace() because that will swallow the nanosecond part
+        # GH #12037
         binner = labels = DatetimeIndex(freq=self.freq,
-                                        start=first.replace(tzinfo=None),
-                                        end=last.replace(tzinfo=None),
+                                        start=first,
+                                        end=last,
                                         tz=tz,
                                         name=ax.name)
 

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -1224,6 +1224,15 @@ class TestResample(tm.TestCase):
         # it works!
         ts.resample('M')
 
+    def test_nanosecond_resample_error(self):
+        # GH 12307
+        start = 1443707890427
+        indx = pd.date_range(start=pd.to_datetime(start),
+                             periods=10, freq='100n')
+        ts = pd.Series(np.random.randn(len(indx)), index=indx)
+        r = ts.resample(pd.tseries.offsets.Nano(100))
+        r.agg('mean')
+
     def test_resample_anchored_intraday(self):
         # #1471, #1458
 

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -1225,13 +1225,27 @@ class TestResample(tm.TestCase):
         ts.resample('M')
 
     def test_nanosecond_resample_error(self):
-        # GH 12307
+        # GH 12307 - Values falls after last bin when
+        # Resampling using pd.tseries.offsets.Nano as period
         start = 1443707890427
-        indx = pd.date_range(start=pd.to_datetime(start),
-                             periods=10, freq='100n')
-        ts = pd.Series(np.random.randn(len(indx)), index=indx)
+        exp_start = 1443707890400
+        indx = pd.date_range(
+            start=pd.to_datetime(start),
+            periods=10,
+            freq='100n'
+        )
+        ts = pd.Series(range(len(indx)), index=indx)
         r = ts.resample(pd.tseries.offsets.Nano(100))
-        r.agg('mean')
+        result = r.agg('mean')
+
+        exp_indx = pd.date_range(
+            start=pd.to_datetime(exp_start),
+            periods=10,
+            freq='100n'
+        )
+        exp = pd.Series(range(len(exp_indx)), index=exp_indx)
+
+        assert_series_equal(result, exp)
 
     def test_resample_anchored_intraday(self):
         # #1471, #1458


### PR DESCRIPTION
Closes #12037 
