### PR TITLE
Fix #12169 - Resample category data with timedelta index

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -796,3 +796,5 @@ Bug Fixes
 - Bug in ``.skew`` and ``.kurt`` due to roundoff error for highly similar values (:issue:`11974`)
 
 - Bug in ``buffer_rd_bytes`` src->buffer could be freed more than once if reading failed, causing a segfault (:issue:`12098`)
+
+- Bug in ``df.resample`` on categorical data with TimedeltaIndex (:issue:`12169`)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -177,7 +177,8 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
                                                      default=np.nan)
                         else:
                             data = np.nan
-                    elif isinstance(index, PeriodIndex):
+                    # GH #12169
+                    elif isinstance(index, (PeriodIndex, TimedeltaIndex)):
                         data = ([data.get(i, nan) for i in index]
                                 if data else np.nan)
                     else:

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -519,6 +519,24 @@ class TestSeriesConstructors(TestData, tm.TestCase):
         ser = ser.reindex(index=expected.index)
         check(ser, expected)
 
+    def test_constructor_dict_timedelta_index(self):
+        # GH #12169 : Resample category data with timedelta index
+        # construct Series from dict as data and TimedeltaIndex as index
+        # will result NaN in result Series data
+        expected = Series(
+            data=['A'] * 3,
+            index=pd.to_timedelta([0, 10, 20], unit='s')
+        )
+
+        result = Series(
+            data={pd.to_timedelta(0, unit='s'): 'A',
+                  pd.to_timedelta(10, unit='s'): 'A',
+                  pd.to_timedelta(20, unit='s'): 'A'},
+            index=pd.to_timedelta([0, 10, 20], unit='s')
+        )
+        # this should work
+        assert_series_equal(result, expected)
+
     def test_constructor_subclass_dict(self):
         data = tm.TestSubDict((x, 10.0 * x) for x in range(10))
         series = Series(data)

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -1147,6 +1147,18 @@ class TestResample(tm.TestCase):
         self.assertTrue(without_base.index.equals(exp_without_base))
         self.assertTrue(with_base.index.equals(exp_with_base))
 
+    def test_resample_categorical_data_with_timedeltaindex(self):
+        # GH #12169
+        df = DataFrame({'Group_obj': 'A'},
+                       index=pd.to_timedelta(list(range(20)), unit='s'))
+        df['Group'] = df['Group_obj'].astype('category')
+        result = df.resample('10s').agg(lambda x: (x.value_counts().index[0]))
+        expected = DataFrame({'Group_obj': ['A', 'A'],
+                              'Group': ['A', 'A']},
+                             index=pd.to_timedelta([0, 10], unit='s'))
+        expected = expected.reindex_axis(['Group_obj', 'Group'], 1)
+        tm.assert_frame_equal(result, expected)
+
     def test_resample_daily_anchored(self):
         rng = date_range('1/1/2000 0:00:00', periods=10000, freq='T')
         ts = Series(np.random.randn(len(rng)), index=rng)


### PR DESCRIPTION
closes #12169 
