### PR TITLE
BUG: Allow 'apply' to be used with non-numpy-dtype DataFrames

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -967,4 +967,7 @@ Bug Fixes
 - Bug in ``.skew`` and ``.kurt`` due to roundoff error for highly similar values (:issue:`11974`)
 
 - Bug in ``buffer_rd_bytes`` src->buffer could be freed more than once if reading failed, causing a segfault (:issue:`12098`)
+
 - Bug in ``crosstab`` where arguments with non-overlapping indexes would return a ``KeyError`` (:issue:`10291`)
+
+- Bug in ``DataFrame.apply`` in which reduction was not being prevented for cases in which ``dtype`` was not a numpy dtype (:issue:`12244`)

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -400,3 +400,19 @@ class TestDataFrameApply(tm.TestCase, TestData):
         result = df.applymap(str)
         for f in ['datetime', 'timedelta']:
             self.assertEqual(result.loc[0, f], str(df.loc[0, f]))
+
+    # See gh-12244
+    def test_apply_non_numpy_dtype(self):
+        df = DataFrame({'dt': pd.date_range(
+            "2015-01-01", periods=3, tz='Europe/Brussels')})
+        result = df.apply(lambda x: x)
+        assert_frame_equal(result, df)
+
+        result = df.apply(lambda x: x + pd.Timedelta('1day'))
+        expected = DataFrame({'dt': pd.date_range(
+            "2015-01-02", periods=3, tz='Europe/Brussels')})
+        assert_frame_equal(result, expected)
+
+        df = DataFrame({'dt': ['a', 'b', 'c', 'a']}, dtype='category')
+        result = df.apply(lambda x: x)
+        assert_frame_equal(result, df)


### PR DESCRIPTION
Addresses issue in #12244 in which a non-numpy-dtype for DataFrame.values causes a `TypeError` to be thrown in the `reduce == True` case for `DataFrame.apply`.  Resolved by first passing `DataFrame.values` through `Series` initialization and taking its `values` attribute, which is an `ndarray` and hence will have a valid `dtype`.  Note that the output of `apply` will still have the original `dtype`.
