### PR TITLE
BUG: Fixes KeyError when indexes don't overlap.

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -954,3 +954,4 @@ Bug Fixes
 - Bug in ``.skew`` and ``.kurt`` due to roundoff error for highly similar values (:issue:`11974`)
 
 - Bug in ``buffer_rd_bytes`` src->buffer could be freed more than once if reading failed, causing a segfault (:issue:`12098`)
+- Bug in ``crosstab`` where arguments with non-overlapping indexes would return a KeyError (:issue:`10291`)

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -153,7 +153,7 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
                              margins_name=margins_name)
 
     # discard the top level
-    if values_passed and not values_multi:
+    if values_passed and not values_multi and not table.empty:
         table = table[values[0]]
 
     if len(index) == 0 and len(columns) > 0:
@@ -395,6 +395,9 @@ def crosstab(index, columns, values=None, rownames=None, colnames=None,
     -----
     Any Series passed will have their name attributes used unless row or column
     names for the cross-tabulation are specified
+
+    In the event that there aren't overlapping indexes an empty DataFrame will
+    be returned.
 
     Examples
     --------

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -892,6 +892,17 @@ class TestCrosstab(tm.TestCase):
         table = data.pivot_table('x', 'y', 'z', margins=True)
         tm.assert_frame_equal(table, expected)
 
+    def test_crosstab_no_overlap(self):
+        # GS 10291
+
+        s1 = pd.Series([1, 2, 3], index=[1, 2, 3])
+        s2 = pd.Series([4, 5, 6], index=[4, 5, 6])
+
+        actual = crosstab(s1, s2)
+        expected = pd.DataFrame()
+
+        tm.assert_frame_equal(actual, expected)
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
Closes #10291 
