### PR TITLE
BUG: Series.plot() doesn't work with CustomBusinessDay frequency

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -950,6 +950,7 @@ Bug Fixes
 
 
 - Bug in ``.plot`` potentially modifying the ``colors`` input when the number of columns didn't match the number of series provided (:issue:`12039`).
+- Bug in ``Series.plot`` doesn't work with CustomBusinessDay frequency (:issue:`7222`).
 
 - Bug in ``read_excel`` failing to read data with one column when ``squeeze=True`` (:issue:`12157`)
 - Bug in ``.groupby`` where a ``KeyError`` was not raised for a wrong column if there was only one row in the dataframe (:issue:`11741`)

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1270,6 +1270,15 @@ class TestSeriesPlots(TestPlotBase):
         exp = ['P%02d' % i for i in [0, 3, 5, 9]]
         self._check_text_labels(ax.get_xticklabels(), exp)
 
+    def test_custom_business_day_freq(self):
+        # GH7222
+        from pandas.tseries.offsets import CustomBusinessDay
+        s = Series(range(100, 121), index=pd.bdate_range(
+            start='2014-05-01', end='2014-06-01',
+            freq=CustomBusinessDay(holidays=['2014-05-26'])))
+
+        _check_plot_works(s.plot)
+
 
 @tm.mplskip
 class TestDataFramePlots(TestPlotBase):

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -671,6 +671,7 @@ _period_code_map.update({
     "Q": 2000,  # Quarterly - December year end (default quarterly)
     "A": 1000,  # Annual
     "W": 4000,  # Weekly
+    "C": 5000,  # Custom Business Day
 })
 
 


### PR DESCRIPTION
Closes #7222
Missing freqstr 'C' in `_period_code_map`
I found `pandas/tseries/tests/test_frequencies.py:TestFrequencyCode.test_freq_code` cover this change.
