### PR TITLE
BUG: Make dict iterators real iterators, provide "next()" in Python 2

### DIFF
--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -152,32 +152,24 @@ else:
     lmap = builtins.map
     lfilter = builtins.filter
 
+def _iterfactory(what):
+    """Functions to process/iterate on dictionaries' values/keys/items."""
+    iterwhat = "iter%s" % what
+    if PY2:
+        def func(obj, **kw):
+                return getattr(obj, iterwhat)(**kw)
+    else:
+        def func(obj, **kw):
+            return iter(getattr(obj, what)(**kw))
+    return func
 
-def iteritems(obj, **kwargs):
-    """replacement for six's iteritems for Python2/3 compat
-       uses 'iteritems' if available and otherwise uses 'items'.
+iteritems, iterkeys, itervalues = (_iterfactory(what)
+                                   for what in ("items","keys", "values"))
 
-       Passes kwargs to method.
-    """
-    func = getattr(obj, "iteritems", None)
-    if not func:
-        func = obj.items
-    return func(**kwargs)
-
-
-def iterkeys(obj, **kwargs):
-    func = getattr(obj, "iterkeys", None)
-    if not func:
-        func = obj.keys
-    return func(**kwargs)
-
-
-def itervalues(obj, **kwargs):
-    func = getattr(obj, "itervalues", None)
-    if not func:
-        func = obj.values
-    return func(**kwargs)
-
+if PY2:
+    next = lambda it : it.next()
+else:
+    next = next
 
 def bind_method(cls, name, func):
     """Bind a method to class, python 2 and python 3 compatible.

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -152,23 +152,28 @@ else:
     lmap = builtins.map
     lfilter = builtins.filter
 
-def _iterfactory(what):
-    """Functions to process/iterate on dictionaries' values/keys/items."""
-    iterwhat = "iter%s" % what
-    if PY2:
-        def func(obj, **kw):
-                return getattr(obj, iterwhat)(**kw)
-    else:
-        def func(obj, **kw):
-            return iter(getattr(obj, what)(**kw))
-    return func
-
-iteritems, iterkeys, itervalues = (_iterfactory(what)
-                                   for what in ("items","keys", "values"))
 
 if PY2:
+    def iteritems(obj, **kw):
+        return obj.iteritems(**kw)
+
+    def iterkeys(obj, **kw):
+        return obj.iterkeys(**kw)
+
+    def itervalues(obj, **kw):
+        return obj.itervalues(**kw)
+
     next = lambda it : it.next()
 else:
+    def iteritems(obj, **kw):
+        return iter(obj.items(**kw))
+
+    def iterkeys(obj, **kw):
+        return iter(obj.keys(**kw))
+
+    def itervalues(obj, **kw):
+        return iter(obj.values(**kw))
+
     next = next
 
 def bind_method(cls, name, func):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3083,7 +3083,7 @@ class NDFrame(PandasObject):
 
                 # fill in 2d chunks
                 result = dict([(col, s.fillna(method=method, value=value))
-                               for col, s in compat.iteritems(self)])
+                               for col, s in self.iteritems()])
                 return self._constructor.from_dict(result).__finalize__(self)
 
             # 2d or less

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -398,7 +398,7 @@ class Panel(NDFrame):
         y : SparseDataFrame
         """
         from pandas.core.sparse import SparsePanel
-        frames = dict(compat.iteritems(self))
+        frames = dict(self.iteritems())
         return SparsePanel(frames, items=self.items,
                            major_axis=self.major_axis,
                            minor_axis=self.minor_axis, default_kind=kind,
@@ -450,7 +450,7 @@ class Panel(NDFrame):
             writer = path
         kwargs['na_rep'] = na_rep
 
-        for item, df in compat.iteritems(self):
+        for item, df in self.iteritems():
             name = str(item)
             df.to_excel(writer, name, **kwargs)
         writer.save()

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2726,7 +2726,7 @@ class SparsePanelFixed(GenericFixed):
         self.attrs.default_kind = obj.default_kind
         self.write_index('items', obj.items)
 
-        for name, sdf in compat.iteritems(obj):
+        for name, sdf in obj.iteritems():
             key = 'sparse_frame_%s' % name
             if key not in self.group._v_children:
                 node = self._handle.create_group(self.group, key)

--- a/pandas/sparse/panel.py
+++ b/pandas/sparse/panel.py
@@ -392,7 +392,7 @@ class SparsePanel(Panel):
             return self._combinePanel(other, func)
         elif np.isscalar(other):
             new_frames = dict((k, func(v, other))
-                              for k, v in compat.iteritems(self))
+                              for k, v in self.iteritems())
             return self._new_like(new_frames)
 
     def _combineFrame(self, other, func, axis=0):
@@ -469,7 +469,7 @@ class SparsePanel(Panel):
         y : DataFrame
             index -> minor axis, columns -> items
         """
-        slices = dict((k, v.xs(key)) for k, v in compat.iteritems(self))
+        slices = dict((k, v.xs(key)) for k, v in self.iteritems())
         return DataFrame(slices, index=self.minor_axis, columns=self.items)
 
     def minor_xs(self, key):
@@ -486,7 +486,7 @@ class SparsePanel(Panel):
         y : SparseDataFrame
             index -> major axis, columns -> items
         """
-        slices = dict((k, v[key]) for k, v in compat.iteritems(self))
+        slices = dict((k, v[key]) for k, v in self.iteritems())
         return SparseDataFrame(slices, index=self.major_axis,
                                columns=self.items,
                                default_fill_value=self.default_fill_value,

--- a/pandas/sparse/tests/test_sparse.py
+++ b/pandas/sparse/tests/test_sparse.py
@@ -104,7 +104,7 @@ def assert_sp_frame_equal(left, right, exact_indices=True):
 
 
 def assert_sp_panel_equal(left, right, exact_indices=True):
-    for item, frame in compat.iteritems(left):
+    for item, frame in left.iteritems():
         assert (item in right)
         # trade-off?
         assert_sp_frame_equal(frame, right[item], exact_indices=exact_indices)

--- a/pandas/stats/tests/test_fama_macbeth.py
+++ b/pandas/stats/tests/test_fama_macbeth.py
@@ -44,7 +44,7 @@ class TestFamaMacBeth(BaseTest):
             end = index[i + window - 1]
 
             x2 = {}
-            for k, v in compat.iteritems(x):
+            for k, v in x.iteritems():
                 x2[k] = v.truncate(start, end)
             y2 = y.truncate(start, end)
 

--- a/pandas/stats/tests/test_ols.py
+++ b/pandas/stats/tests/test_ols.py
@@ -573,7 +573,7 @@ class TestPanelOLS(BaseTest):
 
         stack_y = y.stack()
         stack_x = DataFrame(dict((k, v.stack())
-                                 for k, v in compat.iteritems(x)))
+                                 for k, v in x.iteritems()))
 
         weights = x.std('items')
         stack_weights = weights.stack()

--- a/pandas/tests/test_compat.py
+++ b/pandas/tests/test_compat.py
@@ -4,7 +4,8 @@ Testing that functions from compat work as expected
 """
 
 from pandas.compat import (range, zip, map, filter, lrange, lzip, lmap,
-                           lfilter, builtins)
+                           lfilter, builtins, iterkeys, itervalues, iteritems,
+                           next)
 import pandas.util.testing as tm
 
 
@@ -61,3 +62,8 @@ class TestBuiltinIterators(tm.TestCase):
         expected = list(builtins.zip(*lst)),
         lengths = 10,
         self.check_result(actual, expected, lengths)
+
+    def test_dict_iterators(self):
+        self.assertEqual(next(itervalues({1: 2})), 2)
+        self.assertEqual(next(iterkeys({1: 2})), 1)
+        self.assertEqual(next(iteritems({1: 2})), (1, 2))

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -318,10 +318,10 @@ class SafeForSparse(object):
     def test_iteritems(self):
         # Test panel.iteritems(), aka panel.iteritems()
         # just test that it works
-        for k, v in compat.iteritems(self.panel):
+        for k, v in self.panel.iteritems():
             pass
 
-        self.assertEqual(len(list(compat.iteritems(self.panel))),
+        self.assertEqual(len(list(self.panel.iteritems())),
                          len(self.panel.items))
 
     @ignore_sparse_panel_future_warning
@@ -1105,7 +1105,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
         assert_panel_equal(result, expected)
 
     def test_constructor_dict_mixed(self):
-        data = dict((k, v.values) for k, v in compat.iteritems(self.panel))
+        data = dict((k, v.values) for k, v in self.panel.iteritems())
         result = Panel(data)
         exp_major = Index(np.arange(len(self.panel.major_axis)))
         self.assertTrue(result.major_axis.equals(exp_major))
@@ -1872,7 +1872,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
         # negative numbers, #2164
         result = self.panel.shift(-1)
         expected = Panel(dict((i, f.shift(-1)[:-1])
-                              for i, f in compat.iteritems(self.panel)))
+                              for i, f in self.panel.iteritems()))
         assert_panel_equal(result, expected)
 
         # mixed dtypes #6959
@@ -2072,7 +2072,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
                 except ImportError:
                     raise nose.SkipTest("need xlwt xlrd openpyxl")
 
-                for item, df in compat.iteritems(self.panel):
+                for item, df in self.panel.iteritems():
                     recdf = reader.parse(str(item), index_col=0)
                     assert_frame_equal(df, recdf)
 
@@ -2092,7 +2092,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
             except ImportError as e:
                 raise nose.SkipTest("cannot write excel file: %s" % e)
 
-            for item, df in compat.iteritems(self.panel):
+            for item, df in self.panel.iteritems():
                 recdf = reader.parse(str(item), index_col=0)
                 assert_frame_equal(df, recdf)
 

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -12,7 +12,6 @@ from pandas.core.panel import Panel
 from pandas.core.panel4d import Panel4D
 from pandas.core.series import remove_na
 import pandas.core.common as com
-from pandas import compat
 
 from pandas.util.testing import (assert_panel_equal,
                                  assert_panel4d_equal,
@@ -232,7 +231,7 @@ class SafeForSparse(object):
     def test_iteritems(self):
         """Test panel4d.iteritems()"""
 
-        self.assertEqual(len(list(compat.iteritems(self.panel4d))),
+        self.assertEqual(len(list(self.panel4d.iteritems())),
                          len(self.panel4d.labels))
 
     def test_combinePanel4d(self):
@@ -731,7 +730,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
         # assert_panel_equal(result, expected)
 
     def test_constructor_dict_mixed(self):
-        data = dict((k, v.values) for k, v in compat.iteritems(self.panel4d))
+        data = dict((k, v.values) for k, v in self.panel4d.iteritems())
         result = Panel4D(data)
         exp_major = Index(np.arange(len(self.panel4d.major_axis)))
         self.assertTrue(result.major_axis.equals(exp_major))

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -2671,7 +2671,7 @@ class TestConcatenate(tm.TestCase):
 
         data_dict = {}
         for p in panels:
-            data_dict.update(compat.iteritems(p))
+            data_dict.update(p.iteritems())
 
         joined = panels[0].join(panels[1:], how='inner')
         expected = Panel.from_dict(data_dict, intersect=True)


### PR DESCRIPTION
Currently, `compat.itervalues` and friends are not real iterators (under Python 3): compare

```
In [3]: next(six.itervalues({1:2}))
Out[3]: 2
```

with 

```
In [4]: next(pd.compat.itervalues({1:2}))
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-177f5d3e9571> in <module>()
----> 1 next(pd.compat.itervalues({1:2}))

TypeError: 'dict_values' object is not an iterator
```

This PR fixes this (it drops support for `**kwargs`: although it is supported by `six`, I fail to see what's the utility, and it's anyway apparently not used in the `pandas` codebase - but if I'm missing something, it is trivial to reintroduce it) and provides `next()` in Python 2.
