### PR TITLE
BUG: Fix subtraction with timezone Series

### DIFF
--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -487,9 +487,9 @@ class _TimeOp(object):
 
                 # with tz, convert to UTC
                 if self.is_datetime64tz_lhs:
-                    lvalues = lvalues.tz_localize(None)
+                    lvalues = lvalues.tz_convert('UTC')
                 if self.is_datetime64tz_rhs:
-                    rvalues = rvalues.tz_localize(None)
+                    rvalues = rvalues.tz_convert('UTC')
 
                 lvalues = lvalues.view(np.int64)
                 rvalues = rvalues.view(np.int64)

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -1375,3 +1375,18 @@ class TestSeriesOperators(TestData, tm.TestCase):
         df['expected'] = df['date'] - df.index.to_series()
         df['result'] = df['date'] - df.index
         assert_series_equal(df['result'], df['expected'], check_names=False)
+
+    # See gh-12290
+    def test_datetime64_single_non_native(self):
+        f = Series([pd.Timestamp('2016-02-08 13:43:14.605000',
+                                 tz='America/Sao_Paulo')])
+        s = Series([pd.Timestamp('2016-02-10 13:43:14.605000',
+                                 tz='America/Sao_Paulo')])
+
+        out = f - s
+        expected = Series(pd.Timedelta('-2days'))
+        assert_series_equal(out, expected)
+
+        out = s - f
+        expected = Series(pd.Timedelta('2days'))
+        assert_series_equal(out, expected)


### PR DESCRIPTION
Addresses issue in #12290 with timezone `Series` subtraction in which single element `Series`
objects containing tz-aware objects would return a timedelta of zero, even though it visually could not be the case.

The bug was traced to the conversion of the contained timezones to UTC, in which the method call was somehow returning `NaT`, even though attempts to replicate that behaviour were unsuccessful. This new
method call fixes the issue and is in some ways more intuitive given the comment above the conversions.
