### PR TITLE
Subclassing improvements

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -943,9 +943,15 @@ class IndexOpsMixin(object):
         counts : Series
         """
         from pandas.core.algorithms import value_counts
+        from pandas import Index
+
         result = value_counts(self, sort=sort, ascending=ascending,
                               normalize=normalize, bins=bins, dropna=dropna)
-        return result
+
+        if isinstance(self, Index):
+            return result
+        else:
+            return self._constructor(result)
 
     def unique(self):
         """

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -167,7 +167,7 @@ def _use_inf_as_null(key):
 
 
 def _isnull_ndarraylike(obj):
-  
+
     if isinstance(obj, pd.SparseSeries):
         obj = pd.SparseArray(obj)
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -167,6 +167,9 @@ def _use_inf_as_null(key):
 
 
 def _isnull_ndarraylike(obj):
+  
+    if isinstance(obj, pd.SparseSeries):
+        obj = pd.SparseArray(obj)
 
     values = getattr(obj, 'values', obj)
     dtype = values.dtype

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -197,8 +197,8 @@ def _isnull_ndarraylike(obj):
 
     # box
     if isinstance(obj, gt.ABCSeries):
-        from pandas import Series
-        result = Series(result, index=obj.index, name=obj.name, copy=False)
+        result = obj._constructor(
+            result, index=obj.index, name=obj.name, copy=False)
 
     return result
 
@@ -226,8 +226,8 @@ def _isnull_ndarraylike_old(obj):
 
     # box
     if isinstance(obj, gt.ABCSeries):
-        from pandas import Series
-        result = Series(result, index=obj.index, name=obj.name, copy=False)
+        result = obj._constructor(
+            result, index=obj.index, name=obj.name, copy=False)
 
     return result
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1918,6 +1918,7 @@ class DataFrame(NDFrame):
                     # if we are a copy, mark as such
                     copy = (isinstance(new_values, np.ndarray) and
                             new_values.base is None)
+
                     result = self._constructor_sliced(new_values,
                                                       index=self.columns,
                                                       name=self.index[i],
@@ -4900,7 +4901,7 @@ class DataFrame(NDFrame):
                 if axis == 0:
                     result = com._coerce_to_dtypes(result, self.dtypes)
 
-        return Series(result, index=labels)
+        return self._constructor_sliced(result, index=labels)
 
     def idxmin(self, axis=0, skipna=True):
         """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4903,6 +4903,7 @@ class NDFrame(PandasObject):
             else:
                 return self._constructor_sliced(
                     d, index=stat_index, name=series.name)
+
         def describe_categorical_1d(data):
             names = ['count', 'unique']
             objcounts = data.value_counts()

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -39,6 +39,8 @@ from pandas.core.common import(_possibly_downcast_to_dtype, isnull,
                                _maybe_fill, ABCSeries)
 from pandas.core.config import option_context, is_callable
 
+from pandas.sparse.frame import SparseDataFrame
+
 import pandas.lib as lib
 from pandas.lib import Timestamp
 import pandas.tslib as tslib
@@ -3770,8 +3772,12 @@ class DataFrameGroupBy(NDFrameGroupBy):
         if self.axis == 1:
             result = result.T
 
-        return self.inputconstructor(
-            self._reindex_output(result)._convert(datetime=True))
+        if isinstance(self.inputconstructor(), SparseDataFrame):
+            return DataFrame(
+                self._reindex_output(result)._convert(datetime=True))
+        else:
+            return self.inputconstructor(
+                self._reindex_output(result)._convert(datetime=True))
 
     def _reindex_output(self, result):
         """

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -36,8 +36,9 @@ from pandas.core.common import(_possibly_downcast_to_dtype, isnull,
                                is_categorical_dtype, _values_from_object,
                                is_datetime_or_timedelta_dtype, is_bool,
                                is_bool_dtype, AbstractMethodError,
-                               _maybe_fill)
+                               _maybe_fill, ABCSeries)
 from pandas.core.config import option_context, is_callable
+
 import pandas.lib as lib
 from pandas.lib import Timestamp
 import pandas.tslib as tslib
@@ -340,6 +341,16 @@ class _GroupBy(PandasObject, SelectionMixin):
             if axis != 0:
                 raise ValueError('as_index=False only valid for axis=0')
 
+        self.inputconstructor = obj._constructor
+        if isinstance(obj, ABCSeries):
+            self.inputconstructor_sliced = obj._constructor
+        else:
+            self.inputconstructor_sliced = obj._constructor_sliced
+        if isinstance(obj, Panel):
+            self.inputconstructor_expanddim = obj._constructor
+        else:
+            self.inputconstructor_expanddim = obj._constructor_expanddim
+        self.lenshape = obj.ndim
         self.as_index = as_index
         self.keys = keys
         self.sort = sort
@@ -392,6 +403,38 @@ class _GroupBy(PandasObject, SelectionMixin):
         """ dict {group name -> group indices} """
         self._assure_grouper()
         return self.grouper.indices
+
+    @property
+    def inputconstructor(self):
+        return self._inputconstructor
+
+    @inputconstructor.setter
+    def inputconstructor(self, constructor):
+        self._inputconstructor = constructor
+
+    @property
+    def inputconstructor_sliced(self):
+        return self._inputconstructor_sliced
+
+    @inputconstructor_sliced.setter
+    def inputconstructor_sliced(self, constructor):
+        self._inputconstructor_sliced = constructor
+
+    @property
+    def inputconstructor_expanddim(self):
+        return self._inputconstructor_expanddim
+
+    @inputconstructor_expanddim.setter
+    def inputconstructor_expanddim(self, constructor):
+        self._inputconstructor_expanddim = constructor
+
+    @property
+    def lenshape(self):
+        return self._lenshape
+
+    @lenshape.setter
+    def lenshape(self, lenshape_in):
+        self._lenshape = lenshape_in
 
     def _get_indices(self, names):
         """
@@ -1328,7 +1371,7 @@ class GroupBy(_GroupBy):
 
         index = self._selected_obj.index
         cumcounts = self._cumcount_array(ascending=ascending)
-        return Series(cumcounts, index)
+        return self.inputconstructor_sliced(cumcounts, index)
 
     @Substitution(name='groupby')
     @Appender(_doc_template)
@@ -2603,7 +2646,7 @@ class SeriesGroupBy(GroupBy):
                 result = self._aggregate_named(func_or_funcs, *args, **kwargs)
 
             index = Index(sorted(result), name=self.grouper.names[0])
-            ret = Series(result, index=index)
+            ret = self.inputconstructor(result, index=index)
 
         if not self.as_index:  # pragma: no cover
             print('Warning, ignoring as_index=True')
@@ -2659,19 +2702,25 @@ class SeriesGroupBy(GroupBy):
             if _level:
                 return results
             return list(compat.itervalues(results))[0]
-        return DataFrame(results, columns=columns)
+
+        if self.lenshape == 2:
+            return self.inputconstructor(results, columns=columns)
+        elif self.lenshape == 1:
+            return self.inputconstructor_expanddim(results, columns=columns)
 
     def _wrap_output(self, output, index, names=None):
         """ common agg/transform wrapping logic """
         output = output[self.name]
 
         if names is not None:
-            return DataFrame(output, index=index, columns=names)
+            return self.inputconstructor_expanddim(
+                output, index=index, columns=names)
         else:
             name = self.name
             if name is None:
                 name = self._selected_obj.name
-            return Series(output, index=index, name=name)
+            return self.inputconstructor(
+                output, index=index, name=name)
 
     def _wrap_aggregated_output(self, output, names=None):
         return self._wrap_output(output=output,
@@ -2873,6 +2922,7 @@ class SeriesGroupBy(GroupBy):
             inc[idx] = 1
 
         out = np.add.reduceat(inc, idx).astype('int64', copy=False)
+
         res = out if ids[0] != -1 else out[1:]
         ri = self.grouper.result_index
 
@@ -2881,9 +2931,7 @@ class SeriesGroupBy(GroupBy):
             res, out = np.zeros(len(ri), dtype=out.dtype), res
             res[ids] = out
 
-        return Series(res,
-                      index=ri,
-                      name=self.name)
+        return self.inputconstructor_sliced(res, index=ri, name=self.name)
 
     @deprecate_kwarg('take_last', 'keep',
                      mapping={True: 'last', False: 'first'})
@@ -3024,10 +3072,9 @@ class SeriesGroupBy(GroupBy):
         ids = com._ensure_platform_int(ids)
         out = np.bincount(ids[mask], minlength=ngroups or None)
 
-        return Series(out,
-                      index=self.grouper.result_index,
-                      name=self.name,
-                      dtype='int64')
+        return self.inputconstructor_sliced(
+            out, index=self.grouper.result_index,
+            name=self.name, dtype='int64')
 
     def _apply_to_column_groupbys(self, func):
         """ return a pass thru """
@@ -3141,7 +3188,11 @@ class NDFrameGroupBy(GroupBy):
                         result.columns.levels[0],
                         name=self._selected_obj.columns.name)
                 except:
-                    result = self._aggregate_generic(arg, *args, **kwargs)
+                    if self.lenshape == 2:
+                        result = self.inputconstructor(
+                            self._aggregate_generic(arg, *args, **kwargs))
+                    else:
+                        result = self._aggregate_generic(arg, *args, **kwargs)
 
         if not self.as_index:
             self._insert_inaxis_grouper_inplace(result)
@@ -3719,7 +3770,8 @@ class DataFrameGroupBy(NDFrameGroupBy):
         if self.axis == 1:
             result = result.T
 
-        return self._reindex_output(result)._convert(datetime=True)
+        return self.inputconstructor(
+            self._reindex_output(result)._convert(datetime=True))
 
     def _reindex_output(self, result):
         """

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -784,7 +784,13 @@ def _comp_method_SERIES(op, name, str_rep, masker=False):
             # always return a full value series here
             res = _values_from_object(res)
 
-        res = pd.Series(res, index=self.index, name=self.name, dtype='bool')
+        from pandas.sparse.api import SparseSeries
+        if isinstance(self, SparseSeries):
+            res = pd.Series(
+                res, index=self.index, name=self.name, dtype='bool')
+        else:
+            res = self._constructor(
+                res, index=self.index, name=self.name, dtype='bool')
         return res
 
     return wrapper

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -63,7 +63,7 @@ class _Unstacker(object):
     """
 
     def __init__(self, values, index, level=-1, value_columns=None,
-                 fill_value=None):
+                 fill_value=None, return_type=DataFrame):
 
         self.is_categorical = None
         if values.ndim == 1:
@@ -74,6 +74,7 @@ class _Unstacker(object):
         self.values = values
         self.value_columns = value_columns
         self.fill_value = fill_value
+        self.return_type = return_type
 
         if value_columns is None and values.shape[1] != 1:  # pragma: no cover
             raise ValueError('must pass column labels for multi-column data')
@@ -169,7 +170,7 @@ class _Unstacker(object):
                                              ordered=ordered)
                       for i in range(values.shape[-1])]
 
-        return DataFrame(values, index=index, columns=columns)
+        return self.return_type(values, index=index, columns=columns)
 
     def get_new_values(self):
         values = self.values
@@ -330,8 +331,9 @@ def pivot(self, index=None, columns=None, values=None):
             index = self.index
         else:
             index = self[index]
-        indexed = Series(self[values].values,
-                         index=MultiIndex.from_arrays([index, self[columns]]))
+        indexed = self._constructor_sliced(
+            self[values].values,
+            index=MultiIndex.from_arrays([index, self[columns]]))
         return indexed.unstack(columns)
 
 
@@ -407,7 +409,8 @@ def unstack(obj, level, fill_value=None):
             return obj.T.stack(dropna=False)
     else:
         unstacker = _Unstacker(obj.values, obj.index, level=level,
-                               fill_value=fill_value)
+                               fill_value=fill_value,
+                               return_type=obj._constructor_expanddim)
         return unstacker.get_result()
 
 
@@ -439,8 +442,8 @@ def _unstack_frame(obj, level, fill_value=None):
             newb = make_block(new_values.T, placement=new_placement)
             new_blocks.append(newb)
 
-        result = DataFrame(BlockManager(new_blocks, new_axes))
-        mask_frame = DataFrame(BlockManager(mask_blocks, new_axes))
+        result = obj._constructor(BlockManager(new_blocks, new_axes))
+        mask_frame = obj._constructor(BlockManager(mask_blocks, new_axes))
         return result.ix[:, mask_frame.sum(0) > 0]
     else:
         unstacker = _Unstacker(obj.values, obj.index, level=level,
@@ -509,7 +512,7 @@ def stack(frame, level=-1, dropna=True):
         mask = notnull(new_values)
         new_values = new_values[mask]
         new_index = new_index[mask]
-    return Series(new_values, index=new_index)
+    return frame._constructor_sliced(new_values, index=new_index)
 
 
 def stack_multiple(frame, level, dropna=True):

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -340,6 +340,10 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         expected = Series(0, index=[])
         tm.assert_series_equal(result, expected)
 
+    def test_count_subclassing(self):
+        df = tm.SubclassedDataFrame(data=[[1, 2, np.nan], [2, 3, 4]])
+        tm.assertIsInstance(df.count(), tm.SubclassedSeries)
+
     def test_sum(self):
         self._check_stat_op('sum', np.sum, has_numeric_only=True)
 
@@ -348,6 +352,10 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
                             frame=self.mixed_float.astype('float32'),
                             has_numeric_only=True, check_dtype=False,
                             check_less_precise=True)
+
+    def test_sum_subclassing(self):
+        df = tm.SubclassedDataFrame(data=[[1, 2, 3], [2, 3, 4]])
+        tm.assertIsInstance(df.sum(), tm.SubclassedSeries)
 
     def test_stat_operators_attempt_obj_array(self):
         data = {

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -61,6 +61,13 @@ class TestDataFrameIndexing(tm.TestCase, TestData):
         res = df['@awesome_domain']
         assert_numpy_array_equal(ad, res.values)
 
+    def test_getitem_subclassing(self):
+        df = tm.SubclassedDataFrame(
+            np.random.randn(6, 4),
+            index=list('abcdef'), columns=list('ABCD'))
+        tm.assertIsInstance(df['A'], tm.SubclassedSeries)
+        tm.assertIsInstance(df[['A', 'C']], tm.SubclassedDataFrame)
+
     def test_getitem_dupe_cols(self):
         df = DataFrame([[1, 2, 3], [4, 5, 6]], columns=['a', 'a', 'b'])
         try:

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -247,6 +247,13 @@ class TestDataFrameMissingData(tm.TestCase, TestData):
         result = df.fillna(value={'Date': df['Date2']})
         assert_frame_equal(result, expected)
 
+    def test_fillna_subclassing(self):
+        df = tm.SubclassedDataFrame({'a': [np.nan, 1, 2, np.nan, np.nan],
+                                     'b': ['1', '2', '3', None, None],
+                                    'c': [None, '1', '2', '3', '4']},
+                                    index=list('VWXYZ'))
+        tm.assertIsInstance(df.fillna(0), tm.SubclassedDataFrame)
+
     def test_fillna_dtype_conversion(self):
         # make sure that fillna on an empty frame works
         df = DataFrame(index=["A", "B", "C"], columns=[1, 2, 3, 4, 5])

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -909,6 +909,13 @@ class TestDataFrameOperators(tm.TestCase, TestData):
         test_comp(operator.ge)
         test_comp(operator.le)
 
+    def test_comparison_subclassing(self):
+        df = tm.SubclassedDataFrame({'A': np.random.randn(4),
+                                    'B': np.random.randn(4)})
+        df2 = tm.SubclassedDataFrame({'A': list('abcd'), 'B': list('dcba')})
+        tm.assertIsInstance(df > 0, tm.SubclassedDataFrame)
+        tm.assertIsInstance(df2 == 'a', tm.SubclassedDataFrame)
+
     def test_string_comparison(self):
         df = DataFrame([{"a": 1, "b": "foo"}, {"a": 2, "b": "bar"}])
         mask_a = df.a > 1

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -1381,6 +1381,16 @@ class TestIndexing(tm.TestCase):
         assert_series_equal(result, expected)
         self.assertEqual(result.dtype, object)
 
+    def test_loc_subclassing(self):
+        df = tm.SubclassedDataFrame(
+            data=[[1, 2, 3, 4], [2, 3, 4, 5], [2, 3, 4, 5]],
+            index=list('abc'), columns=list('ABCD'))
+        tm.assertIsInstance(df.loc['a'], tm.SubclassedSeries)
+        tm.assertIsInstance(df.loc[:'b'], tm.SubclassedDataFrame)
+        tm.assertIsInstance(df.loc['a':, 'A'], tm.SubclassedSeries)
+        tm.assertIsInstance(
+            df.loc[['a', 'c'], ['A', 'D']], tm.SubclassedDataFrame)
+
     def test_loc_setitem_consistency(self):
         # GH 6149
         # coerce similary for setitem and loc when rows have a null-slice
@@ -1620,6 +1630,16 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
 
         # trying to use a label
         self.assertRaises(ValueError, df.iloc.__getitem__, tuple(['j', 'D']))
+
+    def test_iloc_getitem_subclassing(self):
+        df = tm.SubclassedDataFrame(
+            data=[[1, 2, 3, 4], [2, 3, 4, 5], [2, 3, 4, 5]])
+        tm.assertIsInstance(df.iloc[1], tm.SubclassedSeries)
+        tm.assertIsInstance(df.iloc[:1], tm.SubclassedDataFrame)
+        tm.assertIsInstance(df.iloc[0:1, 2:3], tm.SubclassedDataFrame)
+        tm.assertIsInstance(df.iloc[[0, 2], [0, 3]], tm.SubclassedDataFrame)
+        tm.assertIsInstance(df.iloc[0:1, :], tm.SubclassedDataFrame)
+        tm.assertIsInstance(df.iloc[:, 0:1], tm.SubclassedDataFrame)
 
     def test_iloc_getitem_panel(self):
 
@@ -2155,6 +2175,10 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
                                        names=['col', 'year'])
         expected = DataFrame({'amount': [222, 333, 444]}, index=index)
         tm.assert_frame_equal(res, expected)
+
+    def test_ix_subclassing(self):
+        df = tm.SubclassedDataFrame([[1, 2, 3, 4], [2, 3, 4, 5], [2, 3, 4, 5]])
+        tm.assertIsInstance(df.ix[1], tm.SubclassedSeries)
 
     def test_ix_weird_slicing(self):
         # http://stackoverflow.com/q/17056560/1240268

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1894,4 +1894,3 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
                            labels=[[1, 1, 0, 0], [0, 1, 0, 2]])
         s = tm.SubclassedSeries(np.arange(4.), index=index)
         tm.assertIsInstance(s.unstack(), tm.SubclassedDataFrame)
-

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1661,6 +1661,10 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         tm.assert_series_equal(result, exp)
         self.assertEqual(result.dtype, np.object)
 
+    def test_apply_subclassing(self):
+        s1 = tm.SubclassedSeries(np.random.randn(6), index=list('abcdef'))
+        tm.assertIsInstance(s1.apply(lambda x: x), tm.SubclassedSeries)
+
     def test_shift_int(self):
         ts = self.ts.astype(int)
         shifted = ts.shift(1)
@@ -1884,3 +1888,10 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
                         index=exp_idx, name='xxx')
         tm.assert_series_equal(s.value_counts(normalize=True), exp)
         tm.assert_series_equal(idx.value_counts(normalize=True), exp)
+
+    def test_unstack_subclassing(self):
+        index = MultiIndex(levels=[['bar', 'foo'], ['one', 'three', 'two']],
+                           labels=[[1, 1, 0, 0], [0, 1, 0, 2]])
+        s = tm.SubclassedSeries(np.arange(4.), index=index)
+        tm.assertIsInstance(s.unstack(), tm.SubclassedDataFrame)
+

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -312,6 +312,11 @@ class TestSeriesMissingData(TestData, tm.TestCase):
             expected = Series([0, 1, val, val, 4], dtype='object')
             assert_series_equal(result, expected)
 
+    def test_fillna_subclassing(self):
+        df = tm.SubclassedSeries([np.nan, 1, 2, np.nan, np.nan],
+                                 index=list('VWXYZ'))
+        tm.assertIsInstance(df.fillna(0), tm.SubclassedSeries)
+
     def test_fillna_bug(self):
         x = Series([nan, 1., nan, 3., nan], ['z', 'a', 'b', 'c', 'd'])
         filled = x.fillna(method='ffill')

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -862,6 +862,12 @@ class TestSeriesOperators(TestData, tm.TestCase):
         expected = -(s == 'a')
         assert_series_equal(result, expected)
 
+    def test_comparison_subclassing(self):
+        s1 = tm.SubclassedSeries(np.random.randn(6), index=list('abcdef'))
+        s2 = tm.SubclassedSeries(data=list('abcdef'))
+        tm.assertIsInstance(s1 > 0, tm.SubclassedSeries)
+        tm.assertIsInstance(s2 == 'a', tm.SubclassedSeries)
+
     def test_comparison_tuples(self):
         # GH11339
         # comparisons vs tuple

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -432,6 +432,10 @@ class TestValueCounts(tm.TestCase):
         expected = Series([1, 1, 1, 1], index=expected_index)
         tm.assert_series_equal(result.sort_index(), expected.sort_index())
 
+    def test_value_counts_subclassing(self):
+        s1 = tm.SubclassedSeries(np.random.randn(6), index=list('abcdef'))
+        tm.assertIsInstance(s1.value_counts(), tm.SubclassedSeries)
+
     def test_value_counts_bins(self):
         s = [1, 2, 3, 4]
         result = algos.value_counts(s, bins=1)

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -3911,6 +3911,16 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
         self.assert_index_equal(df['grade'].cat.categories,
                                 dfx['grade'].cat.categories)
 
+    def test_concat_subclassing(self):
+        s1 = tm.SubclassedSeries(np.random.randn(6), index=list('abcdef'))
+        tm.assertIsInstance(pd.concat([s1, s1]), tm.SubclassedSeries)
+        tm.assertIsInstance(
+            pd.concat([s1, s1], axis=1), tm.SubclassedDataFrame)
+
+        df1 = tm.SubclassedDataFrame(
+            np.random.randn(6, 4), index=list('abcdef'), columns=list('ABCD'))
+        tm.assertIsInstance(pd.concat([df1, df1]), tm.SubclassedDataFrame)
+
     def test_concat_preserve(self):
 
         # GH 8641

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -795,6 +795,12 @@ class TestSeries(tm.TestCase, Generic):
         self.series.describe()
         self.ts.describe()
 
+    def test_describe_subclassing(self):
+        df1 = tm.SubclassedDataFrame([[1, 2], [2, 3]],
+                                     index=list('ab'), columns=list('AB'))
+        tm.assertIsInstance(df1.describe(), tm.SubclassedDataFrame)
+        tm.assertIsInstance(df1['A'].describe(), tm.SubclassedSeries)
+
     def test_describe_objects(self):
         s = Series(['a', 'b', 'b', np.nan, np.nan, np.nan, 'c', 'd', 'a', 'a'])
         result = s.describe()

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -5879,7 +5879,7 @@ class TestGroupBy(tm.TestCase):
              'dtypes', 'ndim', 'diff', 'idxmax', 'idxmin', 'inputconstructor',
              'inputconstructor_sliced', 'inputconstructor_expanddim',
              'lenshape', 'ffill', 'bfill', 'pad', 'backfill', 'rolling',
-	     'expanding'])
+             'expanding'])
 
         self.assertEqual(results, expected)
 

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -743,6 +743,14 @@ class TestGroupBy(tm.TestCase):
         self.assertRaises(ValueError,
                           lambda: g.get_group(('foo', 'bar', 'baz')))
 
+    def test_get_group_subclassing(self):
+        df = tm.SubclassedDataFrame(
+            {'A': ['foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'foo'],
+             'B': ['one', 'one', 'two', 'three', 'two', 'two', 'one', 'three'],
+             'C': np.random.randn(8)})
+        result = df.groupby('A').get_group('foo')
+        tm.assertIsInstance(result, tm.SubclassedDataFrame)
+
     def test_get_group_grouped_by_tuple(self):
         # GH 8121
         df = DataFrame([[(1, ), (1, 2), (1, ), (1, 2)]], index=['ids']).T
@@ -2585,6 +2593,21 @@ class TestGroupBy(tm.TestCase):
         expected = grouped.transform(lambda x: x * 2)
         assert_series_equal(result, expected)
 
+    def test_apply_transform_agg_subclassing(self):
+        df = tm.SubclassedDataFrame(
+            {'A': ['foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'foo'],
+             'B': ['one', 'one', 'two', 'three', 'two', 'two', 'one', 'three'],
+             'C': np.random.randn(8)})
+
+        grouped = df.groupby('A')
+        result_apply = grouped.apply(lambda x: x * 2)
+        result_transform = grouped.transform(lambda x: x * 2)
+        result_agg = grouped.agg(lambda x: 0)
+
+        tm.assertIsInstance(result_apply, tm.SubclassedDataFrame)
+        tm.assertIsInstance(result_transform, tm.SubclassedDataFrame)
+        tm.assertIsInstance(result_agg, tm.SubclassedDataFrame)
+
     def test_apply_multikey_corner(self):
         grouped = self.tsframe.groupby([lambda x: x.year, lambda x: x.month])
 
@@ -2807,6 +2830,14 @@ class TestGroupBy(tm.TestCase):
 
         count_B = df.groupby('A')['B'].count()
         assert_series_equal(count_B, expected['B'])
+
+    def test_count_subclassing(self):
+        df = tm.SubclassedDataFrame(
+            {'A': ['foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'foo'],
+             'B': ['one', 'one', 'two', 'three', 'two', 'two', 'one', 'three'],
+             'C': np.random.randn(8), 'D': np.random.randn(8)})
+        result = df.groupby('A').count()
+        tm.assertIsInstance(result, tm.SubclassedDataFrame)
 
     def test_count_object(self):
         df = pd.DataFrame({'a': ['a'] * 3 + ['b'] * 3, 'c': [2] * 3 + [3] * 3})
@@ -5845,8 +5876,11 @@ class TestGroupBy(tm.TestCase):
              'cumprod', 'tail', 'resample', 'cummin', 'fillna', 'cumsum',
              'cumcount', 'all', 'shift', 'skew', 'bfill', 'ffill', 'take',
              'tshift', 'pct_change', 'any', 'mad', 'corr', 'corrwith', 'cov',
-             'dtypes', 'ndim', 'diff', 'idxmax', 'idxmin',
-             'ffill', 'bfill', 'pad', 'backfill', 'rolling', 'expanding'])
+             'dtypes', 'ndim', 'diff', 'idxmax', 'idxmin', 'inputconstructor',
+             'inputconstructor_sliced', 'inputconstructor_expanddim',
+             'lenshape', 'ffill', 'bfill', 'pad', 'backfill', 'rolling',
+	     'expanding'])
+
         self.assertEqual(results, expected)
 
     def test_lexsort_indexer(self):

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -949,11 +949,11 @@ class _Concatenator(object):
             if (len(non_empties) and (keys is None and names is None and
                                       levels is None and join_axes is None)):
                 objs = non_empties
-                
+
                 for obj in objs:
-                  if not is_sparse(obj):
-                      sample = obj
-                      break
+                    if not is_sparse(obj):
+                        sample = obj
+                        break
 
         if sample is None:
             sample = objs[0]
@@ -1040,8 +1040,9 @@ class _Concatenator(object):
 
     def get_result(self):
 
-        return_types = {'series': self._constructor_series,
-              'frame': self._constructor_frame}
+        return_types = {
+            'series': self._constructor_series,
+            'frame': self._constructor_frame}
 
         # series only
         if self._is_series:

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -18,7 +18,7 @@ from pandas.core.index import (Index, MultiIndex, _get_combined_index,
 from pandas.core.internals import (items_overlap_with_suffix,
                                    concatenate_block_managers)
 from pandas.util.decorators import Appender, Substitution
-from pandas.core.common import ABCSeries
+from pandas.core.common import ABCSeries, is_sparse
 
 import pandas.core.algorithms as algos
 import pandas.core.common as com
@@ -949,7 +949,11 @@ class _Concatenator(object):
             if (len(non_empties) and (keys is None and names is None and
                                       levels is None and join_axes is None)):
                 objs = non_empties
-                sample = objs[0]
+                
+                for obj in objs:
+                  if not is_sparse(obj):
+                      sample = obj
+                      break
 
         if sample is None:
             sample = objs[0]

--- a/pandas/types/concat.py
+++ b/pandas/types/concat.py
@@ -49,14 +49,13 @@ def _get_series_result_type(result, return_types=None):
     return appropriate class of Series concat
     input is either dict or array-like
     """
-    
+
     if return_types is None:
         from pandas.core.frame import DataFrame
         from pandas.core.series import Series
         return_types = {'series': Series,
                         'frame': DataFrame}
 
-    
     if isinstance(result, dict):
         # concat Series with axis 1
         if all(com.is_sparse(c) for c in compat.itervalues(result)):

--- a/pandas/types/concat.py
+++ b/pandas/types/concat.py
@@ -44,27 +44,33 @@ def get_dtype_kinds(l):
     return typs
 
 
-def _get_series_result_type(result):
+def _get_series_result_type(result, return_types=None):
     """
     return appropriate class of Series concat
     input is either dict or array-like
     """
+    
+    if return_types is None:
+        from pandas.core.frame import DataFrame
+        from pandas.core.series import Series
+        return_types = {'series': Series,
+                        'frame': DataFrame}
+
+    
     if isinstance(result, dict):
         # concat Series with axis 1
         if all(com.is_sparse(c) for c in compat.itervalues(result)):
             from pandas.sparse.api import SparseDataFrame
             return SparseDataFrame
         else:
-            from pandas.core.frame import DataFrame
-            return DataFrame
+            return return_types['frame']
 
     elif com.is_sparse(result):
         # concat Series with axis 1
         from pandas.sparse.api import SparseSeries
         return SparseSeries
     else:
-        from pandas.core.series import Series
-        return Series
+        return return_types['series']
 
 
 def _get_frame_result_type(result, objs):


### PR DESCRIPTION
Addresses indexing issues related to subclassing (#11559).

Also made some changes to base, groupby, reshape, strings. 
So for example, if df was a SubclassedDataFrame and s was a SubclassedSeries
`df.groupby('A').apply(lambda x: x)`
and
`s.value_counts()`
would return SubclassedDataFrame and SubclassedSeries instances, respectively.
