### PR TITLE
TST: validation tests for concat of same timezones

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -918,7 +918,7 @@ Bug Fixes
 - Bug in not treating ``NaT`` as a missing value in datetimelikes when factorizing & with ``Categoricals`` (:issue:`12077`)
 - Bug in getitem when the values of a ``Series`` were tz-aware (:issue:`12089`)
 - Bug in ``Series.str.get_dummies`` when one of the variables was 'name' (:issue:`12180`)
-- Bug in ``pd.concat`` while concatenating tz-aware NaT series. (:issue:`11693`, :issue:`11755`)
+- Bug in ``pd.concat`` while concatenating tz-aware NaT series. (:issue:`11693`, :issue:`11755`, :issue:`12217`)
 - Bug in ``pd.read_stata`` with version <= 108 files (:issue:`12232`)
 - Bug in ``Series.resample`` using a frequency of ``Nano`` when the index is a ``DatetimeIndex`` and contains non-zero nanosecond parts (:issue:`12037`)
 

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -1088,6 +1088,49 @@ class TestMerge(tm.TestCase):
         result = concat([x, y], ignore_index=True)
         tm.assert_series_equal(result, expected)
 
+        # 12217
+        # 12306 fixed I think
+
+        # Concat'ing two UTC times
+        first = pd.DataFrame([[datetime(2016, 1, 1)]])
+        first[0] = first[0].dt.tz_localize('UTC')
+
+        second = pd.DataFrame([[datetime(2016, 1, 2)]])
+        second[0] = second[0].dt.tz_localize('UTC')
+
+        result = pd.concat([first, second])
+        self.assertEqual(result[0].dtype, 'datetime64[ns, UTC]')
+
+        # Concat'ing two London times
+        first = pd.DataFrame([[datetime(2016, 1, 1)]])
+        first[0] = first[0].dt.tz_localize('Europe/London')
+
+        second = pd.DataFrame([[datetime(2016, 1, 2)]])
+        second[0] = second[0].dt.tz_localize('Europe/London')
+
+        result = pd.concat([first, second])
+        self.assertEqual(result[0].dtype, 'datetime64[ns, Europe/London]')
+
+        # Concat'ing 2+1 London times
+        first = pd.DataFrame([[datetime(2016, 1, 1)], [datetime(2016, 1, 2)]])
+        first[0] = first[0].dt.tz_localize('Europe/London')
+
+        second = pd.DataFrame([[datetime(2016, 1, 3)]])
+        second[0] = second[0].dt.tz_localize('Europe/London')
+
+        result = pd.concat([first, second])
+        self.assertEqual(result[0].dtype, 'datetime64[ns, Europe/London]')
+
+        # Concat'ing 1+2 London times
+        first = pd.DataFrame([[datetime(2016, 1, 1)]])
+        first[0] = first[0].dt.tz_localize('Europe/London')
+
+        second = pd.DataFrame([[datetime(2016, 1, 2)], [datetime(2016, 1, 3)]])
+        second[0] = second[0].dt.tz_localize('Europe/London')
+
+        result = pd.concat([first, second])
+        self.assertEqual(result[0].dtype, 'datetime64[ns, Europe/London]')
+
     def test_indicator(self):
         # PR #10054. xref #7412 and closes #8790.
         df1 = DataFrame({'col1': [0, 1], 'col_left': [


### PR DESCRIPTION
closes #12217 
xref #12306 which I think fixed
