### PR TITLE
WARN: fix some warnings

### DIFF
--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -212,9 +212,13 @@ class TestDataFrameIndexing(tm.TestCase, TestData):
         assert_frame_equal(subframe_obj, subframe)
 
         # test that Series indexers reindex
-        indexer_obj = indexer_obj.reindex(self.tsframe.index[::-1])
-        subframe_obj = self.tsframe[indexer_obj]
-        assert_frame_equal(subframe_obj, subframe)
+        # we are producing a warning that since the passed boolean
+        # key is not the same as the given index, we will reindex
+        # not sure this is really necessary
+        with tm.assert_produces_warning(UserWarning):
+            indexer_obj = indexer_obj.reindex(self.tsframe.index[::-1])
+            subframe_obj = self.tsframe[indexer_obj]
+            assert_frame_equal(subframe_obj, subframe)
 
         # test df[df > 0]
         for df in [self.tsframe, self.mixed_frame,

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -1197,7 +1197,15 @@ class TestSeriesOperators(TestData, tm.TestCase):
         # TODO: Fix this exception - needs to be fixed! (see GH5035)
         # (previously this was a TypeError because series returned
         # NotImplemented
+
+        # this is an alignment issue; these are equivalent
+        # https://github.com/pydata/pandas/issues/5284
+
+        self.assertRaises(ValueError, lambda: d.__and__(s, axis='columns'))
         self.assertRaises(ValueError, tester, s, d)
+
+        # this is wrong as its not a boolean result
+        # result = d.__and__(s,axis='index')
 
     def test_operators_corner(self):
         series = self.ts

--- a/pandas/tests/test_graphics_others.py
+++ b/pandas/tests/test_graphics_others.py
@@ -425,9 +425,12 @@ class TestDataFramePlots(TestPlotBase):
         with tm.RNGContext(42):
             df = DataFrame(randn(100, 3))
 
-        axes = _check_plot_works(scatter_matrix, filterwarnings='always',
-                                 frame=df, range_padding=.1)
+        # we are plotting multiples on a sub-plot
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(scatter_matrix, filterwarnings='always',
+                                     frame=df, range_padding=.1)
         axes0_labels = axes[0][0].yaxis.get_majorticklabels()
+
         # GH 5662
         expected = ['-2', '-1', '0', '1', '2']
         self._check_text_labels(axes0_labels, expected)
@@ -435,8 +438,11 @@ class TestDataFramePlots(TestPlotBase):
             axes, xlabelsize=8, xrot=90, ylabelsize=8, yrot=0)
 
         df[0] = ((df[0] - 2) / 3)
-        axes = _check_plot_works(scatter_matrix, filterwarnings='always',
-                                 frame=df, range_padding=.1)
+
+        # we are plotting multiples on a sub-plot
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(scatter_matrix, filterwarnings='always',
+                                     frame=df, range_padding=.1)
         axes0_labels = axes[0][0].yaxis.get_majorticklabels()
         expected = ['-1.2', '-1.0', '-0.8', '-0.6', '-0.4', '-0.2', '0.0']
         self._check_text_labels(axes0_labels, expected)


### PR DESCRIPTION
catch warning on reindexing a boolean indexer
add some documentation on a na scalar comparison test warning
remove warning for plotting multiple on a sub-plot

closes #8397 
