### PR TITLE
FIX: pivot_table dropna=False drops index level names

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -540,3 +540,4 @@ of columns didn't match the number of series provided (:issue:`12039`).
 
 - Bug in ``.loc`` setitem indexer preventing the use of a TZ-aware DatetimeIndex (:issue:`12050`)
 - Big in ``.style`` indexes and multi-indexes not appearing (:issue:`11655`)
+- Bug in ``pivot_table`` where ``dropna`` argument drops columns and index level names (:issue:`12133`)

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -540,4 +540,4 @@ of columns didn't match the number of series provided (:issue:`12039`).
 
 - Bug in ``.loc`` setitem indexer preventing the use of a TZ-aware DatetimeIndex (:issue:`12050`)
 - Big in ``.style`` indexes and multi-indexes not appearing (:issue:`11655`)
-- Bug in ``pivot_table`` where ``dropna`` argument drops columns and index level names (:issue:`12133`)
+- Bug in ``.pivot_table()`` where ``dropna`` argument drops columns and index level names (:issue:`12133`)

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -126,13 +126,15 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
 
     if not dropna:
         try:
-            m = MultiIndex.from_arrays(cartesian_product(table.index.levels), names=table.index.names)
+            m = MultiIndex.from_arrays(cartesian_product(table.index.levels),
+                                       names=table.index.names)
             table = table.reindex_axis(m, axis=0)
         except AttributeError:
-            pass  # it's a single level
+            pass # it's a single level
 
         try:
-            m = MultiIndex.from_arrays(cartesian_product(table.columns.levels), names=table.columns.names)
+            m = MultiIndex.from_arrays(cartesian_product(table.columns.levels),
+                                       names=table.columns.names)
             table = table.reindex_axis(m, axis=1)
         except AttributeError:
             pass  # it's a single level or a series

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -126,13 +126,13 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
 
     if not dropna:
         try:
-            m = MultiIndex.from_arrays(cartesian_product(table.index.levels))
+            m = MultiIndex.from_arrays(cartesian_product(table.index.levels), names=table.index.names)
             table = table.reindex_axis(m, axis=0)
         except AttributeError:
             pass  # it's a single level
 
         try:
-            m = MultiIndex.from_arrays(cartesian_product(table.columns.levels))
+            m = MultiIndex.from_arrays(cartesian_product(table.columns.levels), names=table.columns.names)
             table = table.reindex_axis(m, axis=1)
         except AttributeError:
             pass  # it's a single level or a series

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -130,7 +130,7 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
                                        names=table.index.names)
             table = table.reindex_axis(m, axis=0)
         except AttributeError:
-            pass # it's a single level
+            pass  # it's a single level
 
         try:
             m = MultiIndex.from_arrays(cartesian_product(table.columns.levels),

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -75,11 +75,10 @@ class TestPivotTable(tm.TestCase):
                         'product': {0: 'a', 1: 'b', 2: 'c', 3: 'd'},
                         'quantity': {0: 2000000, 1: 500000,
                                      2: 1000000, 3: 1000000}})
-        pv_col = df.pivot_table('quantity', 'month', [
-                                'customer', 'product'], dropna=False)
-        pv_ind = df.pivot_table(
-            'quantity', ['customer', 'product'], 'month', dropna=False)
-
+        names1, names2 = ['month'], ['customer', 'product']
+        pv_col = df.pivot_table('quantity', names1, names2, dropna=False)
+        pv_ind = df.pivot_table('quantity', names2, names1, dropna=False)
+    
         m = MultiIndex.from_tuples([(u('A'), u('a')),
                                     (u('A'), u('b')),
                                     (u('A'), u('c')),
@@ -92,7 +91,11 @@ class TestPivotTable(tm.TestCase):
                                     (u('C'), u('b')),
                                     (u('C'), u('c')),
                                     (u('C'), u('d'))])
-
+    
+        assert_equal(pv_col.index.names, names1)
+        assert_equal(pv_ind.columns.names, names1)
+        assert_equal(pv_col.columns.names, names2)
+        assert_equal(pv_ind.index.names, names2)
         assert_equal(pv_col.columns.values, m.values)
         assert_equal(pv_ind.index.values, m.values)
 

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -75,10 +75,11 @@ class TestPivotTable(tm.TestCase):
                         'product': {0: 'a', 1: 'b', 2: 'c', 3: 'd'},
                         'quantity': {0: 2000000, 1: 500000,
                                      2: 1000000, 3: 1000000}})
-        names1, names2 = ['month'], ['customer', 'product']
-        pv_col = df.pivot_table('quantity', names1, names2, dropna=False)
-        pv_ind = df.pivot_table('quantity', names2, names1, dropna=False)
-    
+        pv_col = df.pivot_table('quantity', 'month', [
+                                'customer', 'product'], dropna=False)
+        pv_ind = df.pivot_table(
+            'quantity', ['customer', 'product'], 'month', dropna=False)
+
         m = MultiIndex.from_tuples([(u('A'), u('a')),
                                     (u('A'), u('b')),
                                     (u('A'), u('c')),
@@ -91,13 +92,20 @@ class TestPivotTable(tm.TestCase):
                                     (u('C'), u('b')),
                                     (u('C'), u('c')),
                                     (u('C'), u('d'))])
-    
-        assert_equal(pv_col.index.names, names1)
-        assert_equal(pv_ind.columns.names, names1)
-        assert_equal(pv_col.columns.names, names2)
-        assert_equal(pv_ind.index.names, names2)
+
         assert_equal(pv_col.columns.values, m.values)
         assert_equal(pv_ind.index.values, m.values)
+
+        idx = pd.MultiIndex.from_tuples([(1000000, 201308), (1000000, 201310)],
+                                        names=('quantity', 'month'))
+        tup = (("B", "c"), ("B", "d"), ("C", "c"), ("C", "d"))
+        clm = pd.MultiIndex.from_tuples(tup, names=('customer', 'product'))
+        pv = pd.DataFrame([[50000, np.nan, np.nan, np.nan],
+                           [np.nan, np.nan, np.nan, 30000]],
+                           index=idx, columns=clm)
+        pv_gen = df[2:].pivot_table('amount', ['quantity', 'month'],
+                                    ['customer', 'product'], dropna=False)
+        tm.assert_frame_equal(pv, pv_gen)
 
     def test_pass_array(self):
         result = self.data.pivot_table(

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -96,6 +96,7 @@ class TestPivotTable(tm.TestCase):
         assert_equal(pv_col.columns.values, m.values)
         assert_equal(pv_ind.index.values, m.values)
 
+        #issue 12133, dropna=False arg drops index level names
         idx = pd.MultiIndex.from_tuples([(1000000, 201308), (1000000, 201310)],
                                         names=('quantity', 'month'))
         tup = (("B", "c"), ("B", "d"), ("C", "c"), ("C", "d"))


### PR DESCRIPTION
closes #12133 
level names are lost on `MultiIndex.from_arrays(cartesian_product(table.index.levels))`
