### PR TITLE
docs: add hyperlinks to str.get_dummies

### DIFF
--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -381,6 +381,7 @@ Method Summary
     :meth:`~Series.str.rsplit`,Split strings on delimiter working from the end of the string
     :meth:`~Series.str.get`,Index into each element (retrieve i-th element)
     :meth:`~Series.str.join`,Join strings in each element of the Series with passed separator
+    :meth:`~Series.str.get_dummies`,Split strings on delimiter, returning DataFrame of dummy variables
     :meth:`~Series.str.contains`,Return boolean array if each string contains pattern/regex
     :meth:`~Series.str.replace`,Replace occurrences of pattern/regex with some other string
     :meth:`~Series.str.repeat`,Duplicate values (``s.str.repeat(3)`` equivalent to ``x * 3``)

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -1035,8 +1035,10 @@ def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False,
     2  0  1
     3  0  0
     4  0  0
-    See also ``Series.str.get_dummies``.
 
+    See Also
+    --------
+    Series.str.get_dummies
     """
     from pandas.tools.merge import concat
     from itertools import cycle


### PR DESCRIPTION
The description used in the summary table is the first sentence of
str_get_dummies()'s docstring, edited to match the style of other
summaries.

I tried to build this branch locally – the _Method Summary_ section doesn't render with this change and I can't see why, it looks syntactically correct to me…
