### PR TITLE
ENH: always make ndarrays from msgpack writable

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -37,7 +37,11 @@ Enhancements
 
 
 
+Other Enhancements
+^^^^^^^^^^^^^^^^^^
 
+- ``from_msgpack`` now always gives writeable ndarrays even when compression is
+  used (:issue:`12359`).
 
 .. _whatsnew_0181.api:
 

--- a/pandas/io/packers.py
+++ b/pandas/io/packers.py
@@ -274,15 +274,19 @@ def unconvert(values, dtype, compress=None):
             arr = np.frombuffer(values, dtype=dtype)
             # We are setting the memory owned by a bytes object as mutable.
             # We can do this because we know that no one has a reference to
-            # this object since it was just created in the call to decompress
-            # and we have checked that we have the only reference.
-            # the refcnt reports as 2 instead of 1 because we incref the
-            # values object when we push it on the stack to call getrefcnt.
-            # The 2 references are then the local variable `values` and
-            # TOS.
+            # this object since it was just created in the call to
+            # decompress and we have checked that we have the only
+            # reference. the refcnt reports as 2 instead of 1 because we
+            # incref the values object when we push it on the stack to call
+            # getrefcnt. The 2 references are then the local variable
+            # `values` and TOS.
             arr.flags.writeable = True
             return arr
-        else:
+        elif len(values) > 1:
+            # The empty string and single characters are memoized in many
+            # string creating functions in the capi. This case should not warn
+            # even though we need to make a copy because we are only copying at
+            # most 1 byte.
             warnings.warn(
                 'copying data after decompressing; this may mean that'
                 ' decompress is caching its result',

--- a/pandas/io/tests/test_packers.py
+++ b/pandas/io/tests/test_packers.py
@@ -635,9 +635,46 @@ class TestCompression(TestPackers):
         self._test_compression_warns_when_decompress_caches('zlib')
 
     def test_compression_warns_when_decompress_caches_blosc(self):
-        if not _ZLIB_INSTALLED:
+        if not _BLOSC_INSTALLED:
             raise nose.SkipTest('no blosc')
         self._test_compression_warns_when_decompress_caches('blosc')
+
+    def _test_small_strings_no_warn(self, compress):
+        empty = np.array([], dtype='uint8')
+        with tm.assert_produces_warning(None):
+            empty_unpacked = self.encode_decode(empty, compress=compress)
+
+        np.testing.assert_array_equal(empty_unpacked, empty)
+        self.assertTrue(empty_unpacked.flags.writeable)
+
+        char = np.array([ord(b'a')], dtype='uint8')
+        with tm.assert_produces_warning(None):
+            char_unpacked = self.encode_decode(char, compress=compress)
+
+        np.testing.assert_array_equal(char_unpacked, char)
+        self.assertTrue(char_unpacked.flags.writeable)
+        # if this test fails I am sorry because the interpreter is now in a
+        # bad state where b'a' points to 98 == ord(b'b').
+        char_unpacked[0] = ord(b'b')
+
+        # we compare the ord of bytes b'a' with unicode u'a' because the should
+        # always be the same (unless we were able to mutate the shared
+        # character singleton in which case ord(b'a') == ord(b'b').
+        self.assertEqual(ord(b'a'), ord(u'a'))
+        np.testing.assert_array_equal(
+            char_unpacked,
+            np.array([ord(b'b')], dtype='uint8'),
+        )
+
+    def test_small_strings_no_warn_zlib(self):
+        if not _ZLIB_INSTALLED:
+            raise nose.SkipTest('no zlib')
+        self._test_small_strings_no_warn('zlib')
+
+    def test_small_strings_no_warn_blosc(self):
+        if not _BLOSC_INSTALLED:
+            raise nose.SkipTest('no blosc')
+        self._test_small_strings_no_warn('blosc')
 
     def test_readonly_axis_blosc(self):
         # GH11880

--- a/pandas/io/tests/test_packers.py
+++ b/pandas/io/tests/test_packers.py
@@ -1,6 +1,5 @@
 import nose
 
-from contextlib import contextmanager
 import os
 import datetime
 import numpy as np
@@ -16,7 +15,8 @@ from pandas.io.packers import to_msgpack, read_msgpack
 import pandas.util.testing as tm
 from pandas.util.testing import (ensure_clean, assert_index_equal,
                                  assert_series_equal,
-                                 assert_frame_equal)
+                                 assert_frame_equal,
+                                 patch)
 from pandas.tests.test_panel import assert_panel_equal
 
 import pandas
@@ -57,20 +57,6 @@ def check_arbitrary(a, b):
         assert_index_equal(a, b)
     else:
         assert(a == b)
-
-
-@contextmanager
-def patch(ob, attr, value):
-    noattr = object()  # mark that the attribute never existed
-    old = getattr(ob, attr, noattr)
-    setattr(ob, attr, value)
-    try:
-        yield
-    finally:
-        if old is noattr:
-            delattr(ob, attr)
-        else:
-            setattr(ob, attr, old)
 
 
 class TestPackers(tm.TestCase):

--- a/pandas/util/_move.c
+++ b/pandas/util/_move.c
@@ -1,0 +1,274 @@
+#include <Python.h>
+
+#define COMPILING_IN_PY2 (PY_VERSION_HEX <= 0x03000000)
+
+#if !COMPILING_IN_PY2
+/* alias this because it is not aliased in Python 3 */
+#define PyString_CheckExact PyBytes_CheckExact
+#define PyString_AS_STRING PyBytes_AS_STRING
+#define PyString_GET_SIZE PyBytes_GET_SIZE
+#endif  /* !COMPILING_IN_PY2 */
+
+#ifndef Py_TPFLAGS_HAVE_GETCHARBUFFER
+#define Py_TPFLAGS_HAVE_GETCHARBUFFER 0
+#endif
+
+#ifndef Py_TPFLAGS_HAVE_NEWBUFFER
+#define Py_TPFLAGS_HAVE_NEWBUFFER 0
+#endif
+
+PyObject *badmove;  /* bad move exception class */
+
+typedef struct {
+    PyObject_HEAD
+    /* the bytes that own the buffer we are mutating */
+    PyObject *invalid_bytes;
+} stolenbufobject;
+
+PyTypeObject stolenbuf_type;  /* forward declare type */
+
+static void
+stolenbuf_dealloc(stolenbufobject *self)
+{
+    Py_DECREF(self->invalid_bytes);
+    PyObject_Del(self);
+}
+
+static int
+stolenbuf_getbuffer(stolenbufobject *self, Py_buffer *view, int flags)
+{
+    return PyBuffer_FillInfo(view,
+                             (PyObject*) self,
+                             (void*) PyString_AS_STRING(self->invalid_bytes),
+                             PyString_GET_SIZE(self->invalid_bytes),
+                             0,  /* not readonly */
+                             flags);
+}
+
+#if COMPILING_IN_PY2
+
+static Py_ssize_t
+stolenbuf_getreadwritebuf(stolenbufobject *self, Py_ssize_t segment, void **out)
+{
+    if (segment != 0) {
+        PyErr_SetString(PyExc_SystemError,
+                        "accessing non-existent string segment");
+        return -1;
+    }
+    *out = PyString_AS_STRING(self->invalid_bytes);
+    return PyString_GET_SIZE(self->invalid_bytes);
+}
+
+static Py_ssize_t
+stolenbuf_getsegcount(stolenbufobject *self, Py_ssize_t *len)
+{
+    if (len) {
+        *len = PyString_GET_SIZE(self->invalid_bytes);
+    }
+    return 1;
+}
+
+PyBufferProcs stolenbuf_as_buffer = {
+    (readbufferproc) stolenbuf_getreadwritebuf,
+    (writebufferproc) stolenbuf_getreadwritebuf,
+    (segcountproc) stolenbuf_getsegcount,
+    (charbufferproc) stolenbuf_getreadwritebuf,
+    (getbufferproc) stolenbuf_getbuffer,
+};
+
+#else  /* Python 3 */
+
+PyBufferProcs stolenbuf_as_buffer = {
+    (getbufferproc) stolenbuf_getbuffer,
+    NULL,
+};
+
+#endif  /* COMPILING_IN_PY2 */
+
+static PyObject *
+stolenbuf_new(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    stolenbufobject *ret;
+    PyObject *bytes_rvalue;
+
+    if (kwargs && PyDict_Size(kwargs)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "stolenbuf does not accept keyword arguments");
+        return NULL;
+    }
+
+    if (PyTuple_GET_SIZE(args) != 1) {
+        PyErr_SetString(PyExc_TypeError,
+                        "stolenbuf requires exactly 1 positional argument");
+        return NULL;
+
+    }
+
+    /* pull out the single, positional argument */
+    bytes_rvalue = PyTuple_GET_ITEM(args, 0);
+
+    if (!PyString_CheckExact(bytes_rvalue)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "stolenbuf can only steal from bytes objects");
+        return NULL;
+    }
+
+    if (Py_REFCNT(bytes_rvalue) != 1) {
+        /* there is a reference other than the caller's stack */
+        PyErr_SetObject(badmove, bytes_rvalue);
+        return NULL;
+    }
+
+    if (!(ret = PyObject_New(stolenbufobject, &stolenbuf_type))) {
+        return NULL;
+    }
+
+    /* store the original bytes object in a field that is not
+       exposed to python */
+    Py_INCREF(bytes_rvalue);
+    ret->invalid_bytes = bytes_rvalue;
+    return (PyObject*) ret;
+}
+
+PyDoc_STRVAR(
+    stolenbuf_doc,
+    "Moves a bytes object that is about to be destroyed into a mutable buffer\n"
+    "without copying the data.\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "bytes_rvalue : bytes with 1 refcount.\n"
+    "    The bytes object that you want to move into a mutable buffer. This\n"
+    "    cannot be a named object. It must only have a single reference.\n"
+    "\n"
+    "Returns\n"
+    "-------\n"
+    "buf : stolenbuf\n"
+    "    An object that supports the buffer protocol which can give a mutable\n"
+    "    view of the data that was previously owned by ``bytes_rvalue``.\n"
+    "\n"
+    "Raises\n"
+    "------\n"
+    "BadMove\n"
+    "    Raised when a move is attempted on an object with more than one\n"
+    "    reference.\n"
+    "\n"
+    "Notes\n"
+    "-----\n"
+    "If you want to use this function you are probably wrong.\n");
+
+PyTypeObject stolenbuf_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "pandas.util._move.stolenbuf",              /* tp_name */
+    sizeof(stolenbufobject),                    /* tp_basicsize */
+    0,                                          /* tp_itemsize */
+    (destructor) stolenbuf_dealloc,             /* tp_dealloc */
+    0,                                          /* tp_print */
+    0,                                          /* tp_getattr */
+    0,                                          /* tp_setattr */
+    0,                                          /* tp_reserved */
+    0,                                          /* tp_repr */
+    0,                                          /* tp_as_number */
+    0,                                          /* tp_as_sequence */
+    0,                                          /* tp_as_mapping */
+    0,                                          /* tp_hash */
+    0,                                          /* tp_call */
+    0,                                          /* tp_str */
+    0,                                          /* tp_getattro */
+    0,                                          /* tp_setattro */
+    &stolenbuf_as_buffer,                       /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT |
+    Py_TPFLAGS_HAVE_NEWBUFFER |
+    Py_TPFLAGS_HAVE_GETCHARBUFFER,              /* tp_flags */
+    stolenbuf_doc,                              /* tp_doc */
+    0,                                          /* tp_traverse */
+    0,                                          /* tp_clear */
+    0,                                          /* tp_richcompare */
+    0,                                          /* tp_weaklistoffset */
+    0,                                          /* tp_iter */
+    0,                                          /* tp_iternext */
+    0,                                          /* tp_methods */
+    0,                                          /* tp_members */
+    0,                                          /* tp_getset */
+    0,                                          /* tp_base */
+    0,                                          /* tp_dict */
+    0,                                          /* tp_descr_get */
+    0,                                          /* tp_descr_set */
+    0,                                          /* tp_dictoffset */
+    0,                                          /* tp_init */
+    0,                                          /* tp_alloc */
+    (newfunc) stolenbuf_new,                    /* tp_new */
+};
+
+#define MODULE_NAME "pandas.util._move"
+
+#if !COMPILING_IN_PY2
+PyModuleDef _move_module = {
+    PyModuleDef_HEAD_INIT,
+    MODULE_NAME,
+    NULL,
+    -1,
+};
+#endif  /* !COMPILING_IN_PY2 */
+
+PyDoc_STRVAR(
+    badmove_doc,
+    "Exception used to indicate that a move was attempted on a value with\n"
+    "more than a single reference.\n"
+    "\n"
+    "Parameters\n"
+    "----------\n"
+    "data : any\n"
+    "    The data which was passed to ``_move_into_mutable_buffer``.\n"
+    "\n"
+    "See Also\n"
+    "--------\n"
+    "pandas.util._move.move_into_mutable_buffer\n");
+
+PyMODINIT_FUNC
+#if !COMPILING_IN_PY2
+#define ERROR_RETURN NULL
+PyInit__move(void)
+#else
+#define ERROR_RETURN
+init_move(void)
+#endif  /* !COMPILING_IN_PY2 */
+{
+    PyObject *m;
+
+    if (!(badmove = PyErr_NewExceptionWithDoc("pandas.util._move.BadMove",
+                                              badmove_doc,
+                                              NULL,
+                                              NULL))) {
+        return ERROR_RETURN;
+    }
+
+    if (PyType_Ready(&stolenbuf_type)) {
+        return ERROR_RETURN;
+    }
+
+#if !COMPILING_IN_PY2
+    if (!(m = PyModule_Create(&_move_module)))
+#else
+    if (!(m = Py_InitModule(MODULE_NAME, NULL)))
+#endif  /* !COMPILING_IN_PY2 */
+    {
+        return ERROR_RETURN;
+    }
+
+    if (PyModule_AddObject(m,
+                           "move_into_mutable_buffer",
+                           (PyObject*) &stolenbuf_type)) {
+        Py_DECREF(m);
+        return ERROR_RETURN;
+    }
+
+    if (PyModule_AddObject(m, "BadMove", badmove)) {
+        Py_DECREF(m);
+        return ERROR_RETURN;
+    }
+
+#if !COMPILING_IN_PY2
+    return m;
+#endif  /* !COMPILING_IN_PY2 */
+}

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -2313,3 +2313,55 @@ class SubclassedDataFrame(DataFrame):
     @property
     def _constructor(self):
         return SubclassedDataFrame
+
+
+@contextmanager
+def patch(ob, attr, value):
+    """Temporarily patch an attribute of an object.
+
+    Parameters
+    ----------
+    ob : any
+        The object to patch. This must support attribute assignment for `attr`.
+    attr : str
+        The name of the attribute to patch.
+    value : any
+        The temporary attribute to assign.
+
+    Examples
+    --------
+    >>> class C(object):
+    ...     attribute = 'original'
+    ...
+    >>> C.attribute
+    'original'
+    >>> with patch(C, 'attribute', 'patched'):
+    ...     in_context = C.attribute
+    ...
+    >>> in_context
+    'patched'
+    >>> C.attribute  # the value is reset when the context manager exists
+    'original'
+
+    Correctly replaces attribute when the manager exits with an exception.
+    >>> with patch(C, 'attribute', 'patched'):
+    ...     in_context = C.attribute
+    ...     raise ValueError()
+    Traceback (most recent call last):
+       ...
+    ValueError
+    >>> in_context
+    'patched'
+    >>> C.attribute
+    'original'
+    """
+    noattr = object()  # mark that the attribute never existed
+    old = getattr(ob, attr, noattr)
+    setattr(ob, attr, value)
+    try:
+        yield
+    finally:
+        if old is noattr:
+            delattr(ob, attr)
+        else:
+            setattr(ob, attr, old)

--- a/setup.py
+++ b/setup.py
@@ -532,6 +532,13 @@ ujson_ext = Extension('pandas.json',
 
 extensions.append(ujson_ext)
 
+# extension for pseudo-safely moving bytes into mutable buffers
+_move_ext = Extension('pandas.util._move',
+                      depends=[],
+                      sources=['pandas/util/_move.c'])
+extensions.append(_move_ext)
+
+
 
 if _have_setuptools:
     setuptools_kwargs["test_suite"] = "nose.collector"


### PR DESCRIPTION
Addresses the case where 'compress' was not none. The old implementation
would decompress the data and then call np.frombuffer on a bytes
object. Because a bytes object is not a mutable buffer, the resulting
ndarray had writeable=False. The new implementation ensures that the
pandas is the only owner of this new buffer and then sets it to mutable
without copying it. This means that we don't need to do a copy of the
data coming in AND we can mutate it later. If we are not the only owner
of this data then we just copy it with np.fromstring.
