### PR TITLE
fmt in TimeFormatter is now changeable

### DIFF
--- a/pandas/tseries/converter.py
+++ b/pandas/tseries/converter.py
@@ -83,9 +83,9 @@ class TimeFormatter(Formatter):
 
     def __init__(self, locs):
         self.locs = locs
+        self.fmt = '%H:%M:%S'
 
     def __call__(self, x, pos=0):
-        fmt = '%H:%M:%S'
         s = int(x)
         ms = int((x - s) * 1e3)
         us = int((x - s) * 1e6 - ms)
@@ -97,7 +97,7 @@ class TimeFormatter(Formatter):
         elif ms != 0:
             fmt += '.%3f'
 
-        return pydt.time(h, m, s, us).strftime(fmt)
+        return pydt.time(h, m, s, us).strftime(self.fmt)
 
 
 # Period Conversion


### PR DESCRIPTION
`datetime.time` objects are useful as index values, e.g. in a data frame
containing data of an experiment lasting a few minutes or hours. When
plotting such data frame, the x-axis ticks are formatted as `'%H:%M:%S'`
as standard. In most cases, either `'%H:%M'` or `'%M:%S'` contains enough
information, and the `'%H:%M:%S'` format is superfluous.

The xticks were formatted based on the fmt variable in the `__call__` method. In this commit, the tick format is saved in the `TimeFormatter.fmt`
variable. This is set in the `__init__` method to `'%H:%M:%S'`, but can
later be changed, e.g.:

```
ax = df.plot()
ax.xaxis.get_major_formatter().fmt = '%M:%S'
```
