### PR TITLE
Fix #12373: rolling functions raise ValueError on float32 data

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -1200,3 +1200,5 @@ Bug Fixes
 - Bug when initializing categorical series with a scalar value. (:issue:`12336`)
 - Bug when specifying a UTC ``DatetimeIndex`` by setting ``utc=True`` in ``.to_datetime`` (:issue:`11934`)
 - Bug when increasing the buffer size of CSV reader in ``read_csv`` (:issue:`12494`)
+
+- Bug in ``.rolling`` in which apply on float32 data will raise a ``ValueError`` (:issue:`12373`)

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -149,16 +149,17 @@ class _Window(PandasObject, SelectionMixin):
         if values is None:
             values = getattr(self._selected_obj, 'values', self._selected_obj)
 
-        # coerce dtypes as appropriate
+        # GH #12373 : rolling functions error on float32 data
+        # make sure the data is coerced to float64
         if com.is_float_dtype(values.dtype):
-            pass
+            values = com._ensure_float64(values)
         elif com.is_integer_dtype(values.dtype):
-            values = values.astype(float)
+            values = com._ensure_float64(values)
         elif com.is_timedelta64_dtype(values.dtype):
-            values = values.view('i8').astype(float)
+            values = com._ensure_float64(values.view('i8'))
         else:
             try:
-                values = values.astype(float)
+                values = com._ensure_float64(values)
             except (ValueError, TypeError):
                 raise TypeError("cannot handle this type -> {0}"
                                 "".format(values.dtype))
@@ -457,7 +458,9 @@ class _Rolling(_Window):
 
                 def func(arg, window, min_periods=None):
                     minp = check_minp(min_periods, window)
-                    return cfunc(arg, window, minp, **kwargs)
+                    # GH #12373: rolling functions error on float32 data
+                    return cfunc(com._ensure_float64(arg),
+                                 window, minp, **kwargs)
 
             # calculation function
             if center:
@@ -494,8 +497,31 @@ class _Rolling_and_Expanding(_Rolling):
         obj = self._convert_freq()
         window = self._get_window()
         window = min(window, len(obj)) if not self.center else window
+
+        # GH #12373: rolling functions raise ValueError on float32 data
+        # enables count for timedelta/datatime64 dtypes
+        def maybe_i8conversion1d(obj):
+            if com.needs_i8_conversion(obj):
+                obj = obj.view('i8').astype('float64')
+            return obj
+
+        def maybe_i8conversion(obj):
+            if isinstance(obj, (np.ndarray, pd.Series)):
+                return maybe_i8conversion1d(obj)
+            elif isinstance(obj, pd.DataFrame):
+                print('here')
+                values = obj.values.copy()
+                values = maybe_i8conversion1d(values)
+
+                result = pd.DataFrame(values,
+                                      index=obj.index,
+                                      columns=obj.columns)
+                return result
+            else:
+                return obj
+
         try:
-            converted = np.isfinite(obj).astype(float)
+            converted = np.isfinite(maybe_i8conversion(obj)).astype(float)
         except TypeError:
             converted = np.isfinite(obj.astype(float)).astype(float)
         result = self._constructor(converted, window=window, min_periods=0,
@@ -657,6 +683,10 @@ class _Rolling_and_Expanding(_Rolling):
         window = self._get_window(other)
 
         def _get_cov(X, Y):
+            # GH #12373 : rolling functions error on float32 data
+            # to avoid potential overflow, cast the data to float64
+            X = X.astype('float64')
+            Y = Y.astype('float64')
             mean = lambda x: x.rolling(window, self.min_periods,
                                        center=self.center).mean(**kwargs)
             count = (X + Y).rolling(window=window,

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -498,30 +498,8 @@ class _Rolling_and_Expanding(_Rolling):
         window = self._get_window()
         window = min(window, len(obj)) if not self.center else window
 
-        # GH #12373: rolling functions raise ValueError on float32 data
-        # enables count for timedelta/datatime64 dtypes
-        def maybe_i8conversion1d(obj):
-            if com.needs_i8_conversion(obj):
-                obj = obj.view('i8').astype('float64')
-            return obj
-
-        def maybe_i8conversion(obj):
-            if isinstance(obj, (np.ndarray, pd.Series)):
-                return maybe_i8conversion1d(obj)
-            elif isinstance(obj, pd.DataFrame):
-                print('here')
-                values = obj.values.copy()
-                values = maybe_i8conversion1d(values)
-
-                result = pd.DataFrame(values,
-                                      index=obj.index,
-                                      columns=obj.columns)
-                return result
-            else:
-                return obj
-
         try:
-            converted = np.isfinite(maybe_i8conversion(obj)).astype(float)
+            converted = np.isfinite(obj).astype(float)
         except TypeError:
             converted = np.isfinite(obj.astype(float)).astype(float)
         result = self._constructor(converted, window=window, min_periods=0,

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -297,8 +297,6 @@ class TestDtype(Base):
     window = 2
     # the nan value, timedelta uses tslib.iNaT
     naval = np.nan
-    # Do we construct DataFrame for testing.
-    include_df = True
 
     # Function Name : (function, result_dtype, expectation_dtype)
     funcs = {
@@ -358,14 +356,13 @@ class TestDtype(Base):
     def _create_dtype_data(self, dtype):
         sr1 = Series(range(5), dtype=dtype)
         sr2 = Series(range(10, 0, -2), dtype=dtype)
+        df = DataFrame(np.arange(10).reshape((5, 2)), dtype=dtype)
 
         data = {
             'sr1': sr1,
-            'sr2': sr2
+            'sr2': sr2,
+            'df': df
         }
-        if self.include_df:
-            df = DataFrame(np.arange(10).reshape((5, 2)), dtype=dtype)
-            data['df'] = df
 
         return data
 
@@ -464,9 +461,24 @@ class TestDtype_category(TestDtype):
     dtype = 'category'
     include_df = False
 
+    def _create_dtype_data(self, dtype):
+        sr1 = Series(range(5), dtype=dtype)
+        sr2 = Series(range(10, 0, -2), dtype=dtype)
+
+        data = {
+            'sr1': sr1,
+            'sr2': sr2
+        }
+
+        return data
+
 
 class TestDatetimeLikeDtype(TestDtype):
     dtype = np.dtype('M8[ns]')
+
+    # GH #12373: rolling functions raise ValueError on float32 data
+    def setUp(self):
+        raise nose.SkipTest("Skip rolling on DatetimeLike dtypes.")
 
     def test_dtypes(self):
         with tm.assertRaises(TypeError):
@@ -479,9 +491,6 @@ class TestDtype_timedelta(TestDatetimeLikeDtype):
 
 class TestDtype_datetime64UTC(TestDatetimeLikeDtype):
     dtype = 'datetime64[ns, UTC]'
-    # Turn this to false once DataFrame constructor accept
-    # 'datetime64[ns, UTC]' as dtype
-    include_df = False
 
 
 class TestMoments(Base):

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -16,7 +16,6 @@ from pandas.util.testing import (assert_almost_equal, assert_series_equal,
                                  assert_frame_equal, assert_panel_equal,
                                  assert_index_equal)
 import pandas.core.datetools as datetools
-import pandas.core.common as com
 import pandas.stats.moments as mom
 import pandas.core.window as rwindow
 from pandas.core.base import SpecificationError
@@ -331,21 +330,29 @@ class TestDtype(Base):
             },
             'df': {
                 'count': DataFrame({0: Series([1, 2, 2, 2, 2]),
-                                    1: Series([1, 2, 2, 2, 2])}, dtype='float64'),
+                                    1: Series([1, 2, 2, 2, 2])},
+                                   dtype='float64'),
                 'max': DataFrame({0: Series([np.nan, 2, 4, 6, 8]),
-                                  1: Series([np.nan, 3, 5, 7, 9])}, dtype='float64'),
+                                  1: Series([np.nan, 3, 5, 7, 9])},
+                                 dtype='float64'),
                 'min': DataFrame({0: Series([np.nan, 0, 2, 4, 6]),
-                                  1: Series([np.nan, 1, 3, 5, 7])}, dtype='float64'),
+                                  1: Series([np.nan, 1, 3, 5, 7])},
+                                 dtype='float64'),
                 'sum': DataFrame({0: Series([np.nan, 2, 6, 10, 14]),
-                                  1: Series([np.nan, 4, 8, 12, 16])}, dtype='float64'),
+                                  1: Series([np.nan, 4, 8, 12, 16])},
+                                 dtype='float64'),
                 'mean': DataFrame({0: Series([np.nan, 1, 3, 5, 7]),
-                                  1: Series([np.nan, 2, 4, 6, 8])}, dtype='float64'),
+                                   1: Series([np.nan, 2, 4, 6, 8])},
+                                  dtype='float64'),
                 'std': DataFrame({0: Series([np.nan] + [np.sqrt(2)] * 4),
-                                  1: Series([np.nan] + [np.sqrt(2)] * 4)}, dtype='float64'),
+                                  1: Series([np.nan] + [np.sqrt(2)] * 4)},
+                                 dtype='float64'),
                 'var': DataFrame({0: Series([np.nan, 2, 2, 2, 2]),
-                                  1: Series([np.nan, 2, 2, 2, 2])}, dtype='float64'),
+                                  1: Series([np.nan, 2, 2, 2, 2])},
+                                 dtype='float64'),
                 'median': DataFrame({0: Series([np.nan, 1, 3, 5, 7]),
-                                     1: Series([np.nan, 2, 4, 6, 8])}, dtype='float64'),
+                                     1: Series([np.nan, 2, 4, 6, 8])},
+                                    dtype='float64'),
             }
         }
         return expects

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -295,60 +295,57 @@ class TestDeprecations(Base):
 class TestDtype(Base):
     dtype = None
     window = 2
-    # the nan value, timedelta uses tslib.iNaT
-    naval = np.nan
 
-    # Function Name : (function, result_dtype, expectation_dtype)
     funcs = {
-        'count': (lambda v: v.count(), 'float64', 'float64'),
-        'max': (lambda v: v.max(), 'float64', 'float64'),
-        'min': (lambda v: v.min(), 'float64', 'float64'),
-        'sum': (lambda v: v.sum(), 'float64', 'float64'),
-        'mean': (lambda v: v.mean(), 'float64', 'float64'),
-        'std': (lambda v: v.std(), 'float64', 'float64'),
-        'var': (lambda v: v.var(), 'float64', 'float64'),
-        'median': (lambda v: v.median(), 'float64', 'float64')
+        'count': lambda v: v.count(),
+        'max': lambda v: v.max(),
+        'min': lambda v: v.min(),
+        'sum': lambda v: v.sum(),
+        'mean': lambda v: v.mean(),
+        'std': lambda v: v.std(),
+        'var': lambda v: v.var(),
+        'median': lambda v: v.median()
     }
 
     def get_expects(self):
         expects = {
             'sr1': {
-                'count': Series([1, 2, 2, 2, 2]),
-                'max': Series([self.naval, 1, 2, 3, 4]),
-                'min': Series([self.naval, 0, 1, 2, 3]),
-                'sum': Series([self.naval, 1, 3, 5, 7]),
-                'mean': Series([self.naval, .5, 1.5, 2.5, 3.5]),
-                'std': Series([self.naval] + [np.sqrt(.5)] * 4),
-                'var': Series([self.naval, .5, .5, .5, .5]),
-                'median': Series([self.naval, .5, 1.5, 2.5, 3.5])
+                'count': Series([1, 2, 2, 2, 2], dtype='float64'),
+                'max': Series([np.nan, 1, 2, 3, 4], dtype='float64'),
+                'min': Series([np.nan, 0, 1, 2, 3], dtype='float64'),
+                'sum': Series([np.nan, 1, 3, 5, 7], dtype='float64'),
+                'mean': Series([np.nan, .5, 1.5, 2.5, 3.5], dtype='float64'),
+                'std': Series([np.nan] + [np.sqrt(.5)] * 4, dtype='float64'),
+                'var': Series([np.nan, .5, .5, .5, .5], dtype='float64'),
+                'median': Series([np.nan, .5, 1.5, 2.5, 3.5], dtype='float64')
             },
             'sr2': {
-                'count': Series([1, 2, 2, 2, 2]),
-                'max': Series([self.naval, 10, 8, 6, 4]),
-                'min': Series([self.naval, 8, 6, 4, 2]),
-                'sum': Series([self.naval, 18, 14, 10, 6]),
-                'mean': Series([self.naval, 9, 7, 5, 3]),
-                'std': Series([self.naval] + [np.sqrt(2)] * 4),
-                'var': Series([self.naval, 2, 2, 2, 2]),
-                'median': Series([self.naval, 9, 7, 5, 3])
+                'count': Series([1, 2, 2, 2, 2], dtype='float64'),
+                'max': Series([np.nan, 10, 8, 6, 4], dtype='float64'),
+                'min': Series([np.nan, 8, 6, 4, 2], dtype='float64'),
+                'sum': Series([np.nan, 18, 14, 10, 6], dtype='float64'),
+                'mean': Series([np.nan, 9, 7, 5, 3], dtype='float64'),
+                'std': Series([np.nan] + [np.sqrt(2)] * 4, dtype='float64'),
+                'var': Series([np.nan, 2, 2, 2, 2], dtype='float64'),
+                'median': Series([np.nan, 9, 7, 5, 3], dtype='float64')
             },
             'df': {
                 'count': DataFrame({0: Series([1, 2, 2, 2, 2]),
-                                    1: Series([1, 2, 2, 2, 2])}),
-                'max': DataFrame({0: Series([self.naval, 2, 4, 6, 8]),
-                                  1: Series([self.naval, 3, 5, 7, 9])}),
-                'min': DataFrame({0: Series([self.naval, 0, 2, 4, 6]),
-                                  1: Series([self.naval, 1, 3, 5, 7])}),
-                'sum': DataFrame({0: Series([self.naval, 2, 6, 10, 14]),
-                                  1: Series([self.naval, 4, 8, 12, 16])}),
-                'mean': DataFrame({0: Series([self.naval, 1, 3, 5, 7]),
-                                  1: Series([self.naval, 2, 4, 6, 8])}),
-                'std': DataFrame({0: Series([self.naval] + [np.sqrt(2)] * 4),
-                                  1: Series([self.naval] + [np.sqrt(2)] * 4)}),
-                'var': DataFrame({0: Series([self.naval, 2, 2, 2, 2]),
-                                  1: Series([self.naval, 2, 2, 2, 2])}),
-                'median': DataFrame({0: Series([self.naval, 1, 3, 5, 7]),
-                                     1: Series([self.naval, 2, 4, 6, 8])}),
+                                    1: Series([1, 2, 2, 2, 2])}, dtype='float64'),
+                'max': DataFrame({0: Series([np.nan, 2, 4, 6, 8]),
+                                  1: Series([np.nan, 3, 5, 7, 9])}, dtype='float64'),
+                'min': DataFrame({0: Series([np.nan, 0, 2, 4, 6]),
+                                  1: Series([np.nan, 1, 3, 5, 7])}, dtype='float64'),
+                'sum': DataFrame({0: Series([np.nan, 2, 6, 10, 14]),
+                                  1: Series([np.nan, 4, 8, 12, 16])}, dtype='float64'),
+                'mean': DataFrame({0: Series([np.nan, 1, 3, 5, 7]),
+                                  1: Series([np.nan, 2, 4, 6, 8])}, dtype='float64'),
+                'std': DataFrame({0: Series([np.nan] + [np.sqrt(2)] * 4),
+                                  1: Series([np.nan] + [np.sqrt(2)] * 4)}, dtype='float64'),
+                'var': DataFrame({0: Series([np.nan, 2, 2, 2, 2]),
+                                  1: Series([np.nan, 2, 2, 2, 2])}, dtype='float64'),
+                'median': DataFrame({0: Series([np.nan, 1, 3, 5, 7]),
+                                     1: Series([np.nan, 2, 4, 6, 8])}, dtype='float64'),
             }
         }
         return expects
@@ -374,38 +371,17 @@ class TestDtype(Base):
     def setUp(self):
         self._create_data()
 
-    def _cast_result(self, result, from_dtype, to_dtype):
-        if com.needs_i8_conversion(from_dtype):
-            if isinstance(result, Series):
-                result = result.view('i8')
-            elif isinstance(result, DataFrame):
-                final = []
-                for idx in result:
-                    final.append(Series(result[idx].view('i8')))
-                result = pd.concat(final, axis=1).reindex(
-                    columns=result.columns)
-        return result.astype(to_dtype)
-
     def test_dtypes(self):
         for f_name, d_name in product(self.funcs.keys(), self.data.keys()):
-            # Specify if the results and expectations
-            # need to be coerced to a given dtype
-            # once we changed the return value for roll_<function>,
-            # we should change coerce behavior here accordingly
-            f, res_dtype, exp_dtype = self.funcs[f_name]
+            f = self.funcs[f_name]
             d = self.data[d_name]
             assert_equal = assert_series_equal if isinstance(
                 d, Series) else assert_frame_equal
             exp = self.expects[d_name][f_name]
-            if exp_dtype:
-                exp = exp.astype(com.pandas_dtype(exp_dtype))
 
             roll = d.rolling(window=self.window)
             result = f(roll)
-            if res_dtype:
-                result = self._cast_result(result,
-                                           self.dtype,
-                                           com.pandas_dtype(res_dtype))
+
             assert_equal(result, exp)
 
 

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -460,60 +460,27 @@ class TestDtype_float64(TestDtype):
     dtype = np.float64
 
 
-class TestDtype_timedelta(TestDtype):
-    dtype = np.dtype('m8[ns]')
-    import pandas.tslib as tslib
-    naval = tslib.iNaT
-
-    funcs = {
-        'count': (lambda v: v.count(), None, 'float64'),
-        'max': (lambda v: v.max(), None, 'm8[ns]'),
-        'min': (lambda v: v.min(), None, 'm8[ns]'),
-        'sum': (lambda v: v.sum(), None, 'm8[ns]'),
-        'mean': (lambda v: v.mean(), None, 'm8[ns]'),
-        'std': (lambda v: v.std(), None, 'm8[ns]'),
-        'var': (lambda v: v.var(), None, 'm8[ns]'),
-        'median': (lambda v: v.median(), None, 'm8[ns]')
-    }
-
-
-class TestDtype_datetime64(TestDtype):
-    dtype = np.dtype('M8[ns]')
-
-    # Rolling functions apply to datetime64 returns float64
-    # So we do not need to coerce the results, just coerce expects
-    funcs = {
-        'count': (lambda v: v.count(), None, 'float64'),
-        'max': (lambda v: v.max(), None, 'float64'),
-        'min': (lambda v: v.min(), None, 'float64'),
-        'sum': (lambda v: v.sum(), None, 'float64'),
-        'mean': (lambda v: v.mean(), None, 'float64'),
-        'std': (lambda v: v.std(), None, 'float64'),
-        'var': (lambda v: v.var(), None, 'float64'),
-        'median': (lambda v: v.median(), None, 'float64')
-    }
-
-
-class TestDtype_datetime64UTC(TestDtype):
-    dtype = 'datetime64[ns, UTC]'
-    # Set to True once dtype='datetime64[ns, UTC]' is available
-    # when constructing a DataFrame
-    include_df = False
-
-    funcs = {
-        'count': (lambda v: v.count(), None, 'float64'),
-        'max': (lambda v: v.max(), None, 'float64'),
-        'min': (lambda v: v.min(), None, 'float64'),
-        'sum': (lambda v: v.sum(), None, 'float64'),
-        'mean': (lambda v: v.mean(), None, 'float64'),
-        'std': (lambda v: v.std(), None, 'float64'),
-        'var': (lambda v: v.var(), None, 'float64'),
-        'median': (lambda v: v.median(), None, 'float64')
-    }
-
-
 class TestDtype_category(TestDtype):
     dtype = 'category'
+    include_df = False
+
+
+class TestDatetimeLikeDtype(TestDtype):
+    dtype = np.dtype('M8[ns]')
+
+    def test_dtypes(self):
+        with tm.assertRaises(TypeError):
+            super(TestDatetimeLikeDtype, self).test_dtypes()
+
+
+class TestDtype_timedelta(TestDatetimeLikeDtype):
+    dtype = np.dtype('m8[ns]')
+
+
+class TestDtype_datetime64UTC(TestDatetimeLikeDtype):
+    dtype = 'datetime64[ns, UTC]'
+    # Turn this to false once DataFrame constructor accept
+    # 'datetime64[ns, UTC]' as dtype
     include_df = False
 
 


### PR DESCRIPTION
- [x] closes #12373
- [x] tests added
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry added
- [x] add test for various other dtypes
