### PR TITLE
Add example usage to DataFrame.filter

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -537,6 +537,7 @@ Backwards incompatible API changes
 - the order of keyword arguments to text file parsing functions (``.read_csv()``, ``.read_table()``, ``.read_fwf()``) changed to group related arguments. (:issue:`11555`)
 - ``NaTType.isoformat`` now returns the string ``'NaT`` to allow the result to
   be passed to the constructor of ``Timestamp``. (:issue:`12300`)
+- ``DataFrame.filter()`` enforces mutual exclusion of keyword arguments. (:issue:`12399`)
 
 NaT and Timedelta operations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2357,7 +2357,10 @@ class NDFrame(PandasObject):
 
     def filter(self, items=None, like=None, regex=None, axis=None):
         """
-        Restrict the info axis to set of items or wildcard
+        Subset rows or columns of dataframe according to  labels in the index.
+
+        Note that this routine does not filter a dataframe on its
+        contents. The filter is applied to the labels of the index.
 
         Parameters
         ----------
@@ -2367,18 +2370,56 @@ class NDFrame(PandasObject):
             Keep info axis where "arg in col == True"
         regex : string (regular expression)
             Keep info axis with re.search(regex, col) == True
-        axis : int or None
-            The axis to filter on. By default this is the info axis. The "info
-            axis" is the axis that is used when indexing with ``[]``. For
-            example, ``df = DataFrame({'a': [1, 2, 3, 4]]}); df['a']``. So,
-            the ``DataFrame`` columns are the info axis.
+        axis : int or string axis name
+            The axis to filter on.  By default this is the info axis. The "info
+            axis" is the axis that is used when indexing with ``[]``
+
+        Returns
+        -------
+        same type as input object with filtered info axis
+
+        Examples
+        --------
+        >>> df
+        one  two  three
+        mouse     1    2      3
+        rabbit    4    5      6
+
+        >>> # select columns by name
+        >>> df.filter(items=['one', 'three'])
+        one  three
+        mouse     1      3
+        rabbit    4      6
+
+        >>> # select columns by regular expression
+        >>> df.filter(regex='e$', axis=1)
+        one  three
+        mouse     1      3
+        rabbit    4      6
+
+        >>> # select rows containing 'bbi'
+        >>> df.filter(like='bbi', axis=0)
+        one  two  three
+        rabbit    4    5      6
+
+        See Also
+        --------
+        pandas.DataFrame.select
 
         Notes
         -----
-        Arguments are mutually exclusive, but this is not checked for
+        The ``items``, ``like``, and ``regex`` parameters are
+        enforced to be mutually exclusive.
 
+        ``axis`` defaults to the info axis that is used when indexing
+        with ``[]``.
         """
         import re
+
+        nkw = sum([x is not None for x in [items, like, regex]])
+        if nkw > 1:
+            raise TypeError('Keyword arguments `items`, `like`, or `regex` '
+                            'are mutually exclusive')
 
         if axis is None:
             axis = self._info_axis_name

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -662,7 +662,23 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
 
         # pass in None
         with assertRaisesRegexp(TypeError, 'Must pass'):
+            self.frame.filter()
+        with assertRaisesRegexp(TypeError, 'Must pass'):
             self.frame.filter(items=None)
+        with assertRaisesRegexp(TypeError, 'Must pass'):
+            self.frame.filter(axis=1)
+
+        # test mutually exclusive arguments
+        with assertRaisesRegexp(TypeError, 'mutually exclusive'):
+            self.frame.filter(items=['one', 'three'], regex='e$', like='bbi')
+        with assertRaisesRegexp(TypeError, 'mutually exclusive'):
+            self.frame.filter(items=['one', 'three'], regex='e$', axis=1)
+        with assertRaisesRegexp(TypeError, 'mutually exclusive'):
+            self.frame.filter(items=['one', 'three'], regex='e$')
+        with assertRaisesRegexp(TypeError, 'mutually exclusive'):
+            self.frame.filter(items=['one', 'three'], like='bbi', axis=0)
+        with assertRaisesRegexp(TypeError, 'mutually exclusive'):
+            self.frame.filter(items=['one', 'three'], like='bbi')
 
         # objects
         filtered = self.mixed_frame.filter(like='foo')


### PR DESCRIPTION
Updates doc comments for `DataFrame.filter` and adds usage examples.
Fixed errors identified by `flake8` and correctly rebase my branch before issuing PR.

<dl class="method">
<dt id="pandas.DataFrame.filter">
<code class="descclassname">DataFrame.</code><code class="descname">filter</code><span class="sig-paren">(</span><em>items=None</em>, <em>like=None</em>, <em>regex=None</em>, <em>axis=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pandas.DataFrame.filter" title="Permalink to this definition">¶</a></dt>
<dd><p>Subset rows or columns of dataframe according to  labels in the index.</p>
<p>Note that this routine does not filter a dataframe on its contents. The filter is 
applied to the labels of the index.
This method is a thin veneer on top of <span class="xref std std-ref">DateFrame Select</span></p>
<table class="docutils field-list" frame="void" rules="none">
<colgroup><col class="field-name">
<col class="field-body">
</colgroup><tbody valign="top">
<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><p class="first"><strong>items</strong> : list-like</p>
<blockquote>
<div><p>List of info axis to restrict to (must not all be present)</p>
</div></blockquote>
<p><strong>like</strong> : string</p>
<blockquote>
<div><p>Keep info axis where “arg in col == True”</p>
</div></blockquote>
<p><strong>regex</strong> : string (regular expression)</p>
<blockquote>
<div><p>Keep info axis with re.search(regex, col) == True</p>
</div></blockquote>
<p><strong>axis</strong> : int or None</p>
<blockquote>
<div><p>The axis to filter on.</p>
</div></blockquote>
</td>
</tr>
<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first last">same type as input object with filtered info axis</p>
</td>
</tr>
</tbody>
</table>
<p class="rubric">Notes</p>
<p>The <code class="docutils literal"><span class="pre">items</span></code>, <code class="docutils literal"><span class="pre">like</span></code>, and <code class="docutils literal"><span class="pre">regex</span></code> parameters should be mutually exclusive, but this is not checked.</p>
<p><code class="docutils literal"><span class="pre">axis</span></code> defaults to the info axis that is used when indexing with <code class="docutils literal"><span class="pre">[]</span></code>.</p>
<p class="rubric">Examples</p>
<div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="n">df</span>
<span class="go">        one  two  three</span>
<span class="go">mouse     1    2      3</span>
<span class="go">rabbit    4    5      6</span>
</pre></div>
</div>
<div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="c1"># select columns by name</span>
<span class="gp">&gt;&gt;&gt; </span><span class="n">df</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="n">items</span><span class="o">=</span><span class="p">[</span><span class="s1">'one'</span><span class="p">,</span> <span class="s1">'three'</span><span class="p">])</span>  
<span class="go">        one  three</span>
<span class="go">mouse     1      3</span>
<span class="go">rabbit    4      6</span>
</pre></div>
</div>
<div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="c1"># select columns by regular expression</span>
<span class="gp">&gt;&gt;&gt; </span><span class="n">df</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="n">regex</span><span class="o">=</span><span class="s1">'e$'</span><span class="p">,</span> <span class="n">axis</span><span class="o">=</span><span class="mi">1</span><span class="p">)</span>
<span class="go">        one  three</span>
<span class="go">mouse     1      3</span>
<span class="go">rabbit    4      6</span>
</pre></div>
</div>
<div class="highlight-python"><div class="highlight"><pre><span class="gp">&gt;&gt;&gt; </span><span class="c1"># select rows containing 'bbi'</span>
<span class="gp">&gt;&gt;&gt; </span><span class="n">df</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="n">like</span><span class="o">=</span><span class="s1">'bbi'</span><span class="p">,</span> <span class="n">axis</span><span class="o">=</span><span class="mi">0</span><span class="p">)</span>
<span class="go">        one  two  three</span>
<span class="go">rabbit    4    5      6</span>
</pre></div>
</div>
</dd></dl>
