### PR TITLE
ENH:  Series between inclusive pair (GH: 12398)

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -417,6 +417,7 @@ Other enhancements
 - ``sys.getsizeof(obj)`` returns the memory usage of a pandas object, including the
   values it contains (:issue:`11597`)
 - ``Series`` gained an ``is_unique`` attribute (:issue:`11946`)
+- ``Series`` method ``between`` now provides ability to set different inclusive endpoints, e.g. series.between(2, 5, inclusive=(True, False)).  (:issue:`12398`)
 - ``DataFrame.quantile`` and ``Series.quantile`` now accept ``interpolation`` keyword (:issue:`10174`).
 - Added ``DataFrame.style.format`` for more flexible formatting of cell values (:issue:`11692`)
 - ``DataFrame.select_dtypes`` now allows the ``np.float16`` typecode (:issue:`11990`)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2475,14 +2475,25 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
             Left boundary
         right : scalar
             Right boundary
+        inclusive : Boolean to indicate whether or not to include both the left
+            and right endpoints (True: a <= series <= b, False: a < series < b)
+            or an iterable boolean pair to set them separately, e.g
+            inclusive=(False, True) for a < series <= b.
 
         Returns
         -------
         is_between : Series
         """
         if inclusive:
-            lmask = self >= left
-            rmask = self <= right
+            try:
+                pair = iter(inclusive)
+                left_inclusive = pair.next()
+                rigt_inclusive = pair.next()
+                lmask = self >= left if left_inclusive else self > left
+                rmask = self <= right if rigt_inclusive else self < right
+            except TypeError:
+                lmask = self >= left
+                rmask = self <= right
         else:
             lmask = self > left
             rmask = self < right

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -393,3 +393,11 @@ class TestSeriesDatetimeValues(TestData, tm.TestCase):
         result = s[s.between(s[3], s[17], inclusive=False)]
         expected = s[5:16].dropna()
         assert_series_equal(result, expected)
+
+        result = s[s.between(s[3], s[17], inclusive=(True, False))]
+        expected = s[3:16].dropna()
+        assert_series_equal(result, expected)
+
+        result = s[s.between(s[3], s[17], inclusive=(False, True))]
+        expected = s[5:18].dropna()
+        assert_series_equal(result, expected)


### PR DESCRIPTION
- [ X  ] closes #12398
- [ X ] tests added / passed
- [ X ] passes `git diff upstream/master | flake8 --diff`
- [ X ] whatsnew entry

Amends pandas.Series.between method to set different inclusive/exclusive endpoints.

inclusive : Boolean to indicate whether or not to include both the left
            and right endpoints (True: a <= series <= b, False: a < series < b),
            or an iterable boolean pair to set them separately, e.g
            inclusive=(False, True) for a < series <= b.
