### PR TITLE
BUG: Concatenation of DFs with all NaT columns and TZ-aware ones breaks #12396

### DIFF
--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -4911,6 +4911,12 @@ class JoinUnit(object):
                     pass
                 elif getattr(self.block, 'is_sparse', False):
                     pass
+                elif com.is_extension_type(empty_dtype) and \
+                        com.is_datetimetz(empty_dtype):
+                    num_elements = np.prod(self.shape)
+                    # handle timezone-aware all NaT cases
+                    return DatetimeIndex([fill_value] * num_elements,
+                                         dtype=empty_dtype)
                 else:
                     missing_arr = np.empty(self.shape, dtype=empty_dtype)
                     missing_arr.fill(fill_value)

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -4905,18 +4905,16 @@ class JoinUnit(object):
                     if len(values) and values[0] is None:
                         fill_value = None
 
-                if getattr(self.block, 'is_datetimetz', False):
-                    pass
+                if getattr(self.block, 'is_datetimetz', False) \
+                        or com.is_datetimetz(empty_dtype):
+                    # handle timezone-aware all NaT cases
+                    num_elements = np.prod(self.shape)
+                    return DatetimeIndex([fill_value] * num_elements,
+                                         dtype=empty_dtype)
                 elif getattr(self.block, 'is_categorical', False):
                     pass
                 elif getattr(self.block, 'is_sparse', False):
                     pass
-                elif com.is_extension_type(empty_dtype) and \
-                        com.is_datetimetz(empty_dtype):
-                    num_elements = np.prod(self.shape)
-                    # handle timezone-aware all NaT cases
-                    return DatetimeIndex([fill_value] * num_elements,
-                                         dtype=empty_dtype)
                 else:
                     missing_arr = np.empty(self.shape, dtype=empty_dtype)
                     missing_arr.fill(fill_value)

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -2622,12 +2622,12 @@ class TestConcatenate(tm.TestCase):
         result = pd.concat([first, second])
 
         expect = expect.apply(lambda x: x.astype(dtype))
-        assert_frame_equal(result, expect, check_dtype=True)
+        assert_frame_equal(result, expect)
 
         # both sides timezone-aware
         first = first.astype(dtype)
         result = pd.concat([first, second])
-        assert_frame_equal(result, expect, check_dtype=True)
+        assert_frame_equal(result, expect)
 
     def test_concat_keys_and_levels(self):
         df = DataFrame(np.random.randn(1, 3))

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -2540,25 +2540,24 @@ class TestConcatenate(tm.TestCase):
 
         result = pd.concat([first, second], axis=0)
         # upcasts for mixed case
-        assert_frame_equal(result, expect, check_dtype=False)
-        self.assertEqual(result.dtypes[0], dtype)
+        expect = expect.apply(lambda x: x.astype(dtype))
+        assert_frame_equal(result, expect)
 
         # both sides timezone-aware
         second = pd.DataFrame([[pd.NaT]], dtype=dtype)
 
-        result = pd.concat([first, second], axis=0)
         # upcasts to tz-aware
-        assert_frame_equal(result, expect, check_dtype=False)
-        self.assertEqual(result.dtypes[0], dtype)
+        result = pd.concat([first, second], axis=0)
+        assert_frame_equal(result, expect)
 
     def test_concat_NaT_dataframes_all_NaT_axis_1(self):
         # GH 12396
         expect = pd.DataFrame([[pd.NaT, pd.NaT], [pd.NaT, pd.NaT]],
-                              columns=[0, 0])
+                              columns=[0, 1])
 
         # non-timezone aware
         first = pd.DataFrame([[pd.NaT], [pd.NaT]])
-        second = pd.DataFrame([[pd.NaT]])
+        second = pd.DataFrame([[pd.NaT]], columns=[1])
 
         result = pd.concat([first, second], axis=1)
         assert_frame_equal(result, expect)
@@ -2568,21 +2567,17 @@ class TestConcatenate(tm.TestCase):
         first = pd.DataFrame([[pd.NaT], [pd.NaT]], dtype=dtype)
 
         # upcasts result to tz-aware
-        assert_frame_equal(result, expect, check_dtype=False)
+        expect.loc[:, 0] = expect.loc[:, 0].astype(dtype)
         result = pd.concat([first, second], axis=1)
-        self.assertEqual(result.dtypes.iloc[0], dtype)
-        self.assertEqual(result.dtypes.iloc[0], first.dtypes[0])
-        self.assertEqual(result.dtypes.iloc[1], second.dtypes[0])
+        assert_frame_equal(result, expect)
 
         # both sides timezone-aware
-        second = pd.DataFrame([[pd.NaT]], dtype=dtype)
+        second = pd.DataFrame([[pd.NaT]], dtype=dtype, columns=[1])
 
-        result = pd.concat([first, second], axis=1)
-        assert_frame_equal(result, expect, check_dtype=False)
         # upcasts to tz-aware
-        self.assertEqual(result.dtypes.iloc[0], dtype)
-        self.assertEqual(result.dtypes.iloc[0], first.dtypes[0])
-        self.assertEqual(result.dtypes.iloc[1], second.dtypes[0])
+        expect = expect.apply(lambda x: x.astype(dtype))
+        result = pd.concat([first, second], axis=1)
+        assert_frame_equal(result, expect)
 
     def test_concat_NaT_dataframes_mixed_timestamps_and_NaT(self):
         # GH 12396
@@ -2597,17 +2592,14 @@ class TestConcatenate(tm.TestCase):
 
         result = pd.concat([first, second], axis=0)
         assert_frame_equal(result, expect)
-        self.assertEqual(result.dtypes.iloc[0], first.dtypes[0])
 
         # one side timezone-aware
         dtype = DatetimeTZDtype('ns', tz='UTC')
         second = second.apply(lambda x: x.astype(dtype))
 
         result = pd.concat([first, second], axis=0)
-        assert_frame_equal(result, expect, check_dtype=False)
-        # upcasts
-        self.assertEqual(result.dtypes.iloc[0], dtype)
-        self.assertEqual(result.dtypes.iloc[0], second.dtypes[0])
+        expect = expect.apply(lambda x: x.astype(dtype))
+        assert_frame_equal(result, expect)
 
     def test_concat_NaT_series_dataframe_all_NaT(self):
         # GH 12396


### PR DESCRIPTION
- [X] closes #12396
- [X] tests added / passed
- [X] passes `git diff upstream/master | flake8 --diff`
- [X] whatsnew entry
- `concat` to handle tz-aware all NaT/mixed cases
- added unit tests
