### PR TITLE
ENH: allow index to be referenced by name

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -432,6 +432,7 @@ Other enhancements
 - Added Google ``BigQuery`` service account authentication support, which enables authentication on remote servers. (:issue:`11881`). For further details see :ref:`here <io.bigquery_authentication>`
 - ``HDFStore`` is now iterable: ``for k in store`` is equivalent to ``for k in store.keys()`` (:issue:`12221`).
 - The entire codebase has been ``PEP``-ified (:issue:`12096`)
+- Index (or index levels, with a MultiIndex) can now be referenced like column names (:issue:`8162`, :issue:`10816`).
 
 .. _whatsnew_0180.api_breaking:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2025,14 +2025,11 @@ class DataFrame(NDFrame):
                 if self.index.name in key:
                     ix_name = self.index.name
                     ix_ix = key.index(ix_name)
-
-                elif (isinstance(self.index, MultiIndex) and
+                elif (hasattr(self, 'index') and
+                      isinstance(self.index, MultiIndex) and
                       any(item in self.index.names for item in key)):
-                    for item in key:
-                        if item in self.index.names:
-                            ix_name = item
-                            ix_ix = key.index(item)
-
+                    ix_ix, ix_name = next((i, k) for i, k in enumerate(key)
+                                          if k in self.index.names)
                 else:
                     raise
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2070,7 +2070,6 @@ class DataFrame(NDFrame):
         result.insert(ix_ix, ix_name, ix_col)
         return result
 
-
     def query(self, expr, inplace=False, **kwargs):
         """Query the columns of a frame with a boolean expression.
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1313,11 +1313,11 @@ class NDFrame(PandasObject):
                 if hasattr(self, 'index') and self.index.name == item:
                     res = self.index.to_series()
 
-                elif (isinstance(self.index, MultiIndex) and
+                elif (hasattr(self, 'index') and
+                      isinstance(self.index, MultiIndex) and
                       item in self.index.names):
                     res = pd.Series(self.index.get_level_values(item).values,
                                     index=self.index, name=item)
-
                 else:
                     raise
             cache[item] = res

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1310,14 +1310,8 @@ class NDFrame(PandasObject):
                 values = self._data.get(item)
                 res = self._box_item_values(item, values)
             except KeyError:
-                if hasattr(self, 'index') and self.index.name == item:
-                    res = self.index.to_series()
-
-                elif (hasattr(self, 'index') and
-                      isinstance(self.index, MultiIndex) and
-                      item in self.index.names):
-                    res = pd.Series(self.index.get_level_values(item).values,
-                                    index=self.index, name=item)
+                if hasattr(self, 'index') and item in self.index.names:
+                    res = self._get_item_index_name(item)
                 else:
                     raise
             cache[item] = res
@@ -1326,6 +1320,10 @@ class NDFrame(PandasObject):
             # for a chain
             res.is_copy = self.is_copy
         return res
+
+    def _get_item_index_name(self, item):
+        return pd.Series(self.index.get_level_values(item),
+                         index=self.index, name=item)
 
     def _set_as_cached(self, item, cacher):
         """Set the _cacher attribute on the calling object with a weakref to

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1306,8 +1306,20 @@ class NDFrame(PandasObject):
         cache = self._item_cache
         res = cache.get(item)
         if res is None:
-            values = self._data.get(item)
-            res = self._box_item_values(item, values)
+            try:
+                values = self._data.get(item)
+                res = self._box_item_values(item, values)
+            except KeyError:
+                if hasattr(self, 'index') and self.index.name == item:
+                    res = self.index.to_series()
+
+                elif (isinstance(self.index, MultiIndex) and
+                      item in self.index.names):
+                    res = pd.Series(self.index.get_level_values(item).values,
+                                    index=self.index, name=item)
+
+                else:
+                    raise
             cache[item] = res
             res._set_as_cached(item, self)
 
@@ -2623,10 +2635,13 @@ class NDFrame(PandasObject):
         if (name in self._internal_names_set or name in self._metadata or
                 name in self._accessors):
             return object.__getattribute__(self, name)
-        else:
-            if name in self._info_axis:
+        elif (
+            name in self._info_axis or
+            name == self.index.name or
+            (isinstance(self.index, MultiIndex) and name in self.index.names)
+        ):
                 return self[name]
-            return object.__getattribute__(self, name)
+        return object.__getattribute__(self, name)
 
     def __setattr__(self, name, value):
         """After regular attribute access, try setting the name

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2633,11 +2633,7 @@ class NDFrame(PandasObject):
         if (name in self._internal_names_set or name in self._metadata or
                 name in self._accessors):
             return object.__getattribute__(self, name)
-        elif (
-            name in self._info_axis or
-            name == self.index.name or
-            (isinstance(self.index, MultiIndex) and name in self.index.names)
-        ):
+        elif name in self._info_axis or name in self.index.names:
                 return self[name]
         return object.__getattribute__(self, name)
 

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -1853,6 +1853,81 @@ class TestDataFrame(tm.TestCase, Generic):
                            expected,
                            check_index_type=False)
 
+    def test_getitem_index(self):
+        # GH8162
+        idx = pd.Index(list('abc'), name='idx')
+        df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]}, index=idx)
+        expected = pd.Series(['a', 'b', 'c'], index=idx, name='idx')
+
+        assert_series_equal(df['idx'], expected)
+        assert_series_equal(df.idx, expected)
+
+    def test_getitem_index_listlike(self):
+        idx = pd.Index(list('abc'), name='idx')
+        df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]}, index=idx)
+        assert_frame_equal(
+            df[['idx', 'B']],
+            pd.DataFrame([
+                ['a', 4],
+                ['b', 5],
+                ['c', 6],
+            ],
+                columns=['idx', 'B'],
+                index=idx)
+        )
+        assert_frame_equal(
+            df[['idx', 'A', 'B']],
+            pd.DataFrame([
+                ['a', 1, 4],
+                ['b', 2, 5],
+                ['c', 3, 6],
+            ],
+                columns=['idx', 'A', 'B'],
+                index=idx)
+        )
+
+    def test_getitem_multiindex_level(self):
+        # GH10816
+        idx = pd.MultiIndex.from_product([list('abc'), list('fg')],
+                                         names=['lev0', 'lev1'])
+        df = pd.DataFrame({'A': range(6), 'B': range(10, 16)}, index=idx)
+        expected = pd.Series(list('aabbcc'), index=idx, name='lev0')
+
+        assert_series_equal(df['lev0'], expected)
+        assert_series_equal(df.lev0, expected)
+
+    def test_getitem_multiindex_level_listlike(self):
+        idx = pd.MultiIndex.from_product([list('abc'), list('fg')],
+                                         names=['lev0', 'lev1'])
+        df = pd.DataFrame({'A': range(6), 'B': range(10, 16)}, index=idx)
+        assert_frame_equal(
+            df[['A', 'lev1']],
+            pd.DataFrame([
+                [0, 'f'],
+                [1, 'g'],
+                [2, 'f'],
+                [3, 'g'],
+                [4, 'f'],
+                [5, 'g'],
+            ],
+                columns=['A', 'lev1'],
+                index=idx)
+        )
+
+        assert_frame_equal(
+            df[['A', 'B', 'lev1', 'lev0']],
+            pd.DataFrame([
+                [0, 10, 'f', 'a'],
+                [1, 11, 'g', 'a'],
+                [2, 12, 'f', 'b'],
+                [3, 13, 'g', 'b'],
+                [4, 14, 'f', 'c'],
+                [5, 15, 'g', 'c'],
+            ],
+                columns=['A', 'B', 'lev1', 'lev0'],
+                index=idx)
+        )
+
 
 class TestPanel(tm.TestCase, Generic):
     _typ = Panel


### PR DESCRIPTION
- [x] closes #8162 and #10816
- [x] tests added
- [x] tests passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Still missing are groupby support (#5677) and `.loc` support.

Also, I wasn't sure if this deserves more than just a line in whatsnew, so I kept it small for now.

With a standard index:

```
idx = pd.Index(list('abc'), name='idx')

df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]}, index=idx)

df['idx']
Out[4]: 
idx
a    a
b    b
c    c
Name: idx, dtype: object

df.idx
Out[5]: 
idx
a    a
b    b
c    c
Name: idx, dtype: object

df[['idx', 'B']]
Out[6]: 
    idx  B
idx       
a     a  4
b     b  5
c     c  6
```

and with a MultiIndex:

```
idx = pd.MultiIndex.from_product([list('abc'), list('fg')], names=['lev0', 'lev1'])

df = pd.DataFrame({'A': range(6), 'B': range(10, 16)}, index=idx)

df['lev0']
Out[9]: 
lev0  lev1
a     f       a
      g       a
b     f       b
      g       b
c     f       c
      g       c
Name: lev0, dtype: object

df.lev0
Out[10]: 
lev0  lev1
a     f       a
      g       a
b     f       b
      g       b
c     f       c
      g       c
Name: lev0, dtype: object

df[['A', 'lev1']]
Out[11]: 
           A lev1
lev0 lev1        
a    f     0    f
     g     1    g
b    f     2    f
     g     3    g
c    f     4    f
     g     5    g
```
