### PR TITLE
BUG: date_range breaks with tz-aware start/end dates and closed intervals #12409

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -1022,7 +1022,7 @@ Bug Fixes
 - Bug in ``GroupBy.size`` when data-frame is empty. (:issue:`11699`)
 - Bug in ``Period.end_time`` when a multiple of time period is requested (:issue:`11738`)
 - Regression in ``.clip`` with tz-aware datetimes (:issue:`11838`)
-- Bug in ``date_range`` when the boundaries fell on the frequency (:issue:`11804`)
+- Bug in ``date_range`` when the boundaries fell on the frequency (:issue:`11804`, :issue:`12409`)
 - Bug in consistency of passing nested dicts to ``.groupby(...).agg(...)`` (:issue:`9052`)
 - Accept unicode in ``Timedelta`` constructor (:issue:`11995`)
 - Bug in value label reading for ``StataReader`` when reading incrementally (:issue:`12014`)

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -528,12 +528,12 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
                                                  ambiguous=ambiguous)
                 index = index.view(_NS_DTYPE)
 
-        index = cls._simple_new(index, name=name, freq=offset, tz=tz)
         if not left_closed and len(index) and index[0] == start:
             index = index[1:]
         if not right_closed and len(index) and index[-1] == end:
             index = index[:-1]
 
+        index = cls._simple_new(index, name=name, freq=offset, tz=tz)
         return index
 
     @property

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -497,6 +497,36 @@ class TestDateRange(tm.TestCase):
             self.assertTrue(expected_left.equals(left))
             self.assertTrue(expected_right.equals(right))
 
+    def test_range_closed_with_tz_aware_start_end(self):
+        # GH12409
+        begin = Timestamp('2011/1/1', tz='US/Eastern')
+        end = Timestamp('2014/1/1', tz='US/Eastern')
+
+        for freq in ["3D", "2M", "7W", "3H", "A"]:
+            closed = date_range(begin, end, closed=None, freq=freq)
+            left = date_range(begin, end, closed="left", freq=freq)
+            right = date_range(begin, end, closed="right", freq=freq)
+            expected_left = left
+            expected_right = right
+
+            if end == closed[-1]:
+                expected_left = closed[:-1]
+            if begin == closed[0]:
+                expected_right = closed[1:]
+
+            self.assertTrue(expected_left.equals(left))
+            self.assertTrue(expected_right.equals(right))
+
+        # test with default frequency, UTC
+        begin = Timestamp('2011/1/1', tz='UTC')
+        end = Timestamp('2014/1/1', tz='UTC')
+
+        intervals = ['left', 'right', None]
+        for i in intervals:
+            result = date_range(start=begin, end=end, closed=i)
+            self.assertEqual(result[0], begin)
+            self.assertEqual(result[-1], end)
+
     def test_range_closed_boundary(self):
         # GH 11804
         for closed in ['right', 'left', None]:


### PR DESCRIPTION
- [X] closes #12409 
- [X] tests added / passed
- [X] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry - not added since this fixes a pre-release bug

do comparison for closed intervals on UTC basis prior to tz conversion
added tests for date_range covering case of tz-aware start/end dates with closed ranges
