### PR TITLE
COMPAT: fixes for numpy compat

### DIFF
--- a/pandas/src/sparse.pyx
+++ b/pandas/src/sparse.pyx
@@ -7,6 +7,15 @@ import numpy as np
 import operator
 import sys
 
+from distutils.version import LooseVersion
+
+# numpy versioning
+_np_version = np.version.short_version
+_np_version_under1p8 = LooseVersion(_np_version) < '1.8'
+_np_version_under1p9 = LooseVersion(_np_version) < '1.9'
+_np_version_under1p10 = LooseVersion(_np_version) < '1.10'
+_np_version_under1p11 = LooseVersion(_np_version) < '1.11'
+
 np.import_array()
 np.import_ufunc()
 
@@ -1001,12 +1010,14 @@ cdef inline float64_t __rdiv(float64_t a, float64_t b):
 
 cdef inline float64_t __floordiv(float64_t a, float64_t b):
     if b == 0:
-        if a > 0:
-            return INF
-        elif a < 0:
-            return -INF
-        else:
-            return NaN
+        # numpy >= 1.11 returns NaN
+        # for a // 0, rather than +-inf
+        if _np_version_under1p11:
+            if a > 0:
+                return INF
+            elif a < 0:
+                return -INF
+        return NaN
     else:
         return a // b
 

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -25,7 +25,8 @@ from numpy.random import randn
 from pandas.compat import range, lrange, lmap, zip, text_type, PY3
 from pandas.compat.numpy_compat import np_datetime64_compat
 
-from pandas import Series, DataFrame, _np_version_under1p9
+from pandas import (Series, DataFrame,
+                    _np_version_under1p9, _np_version_under1p11)
 from pandas import tslib
 from pandas.util.testing import (assert_series_equal, assert_almost_equal,
                                  assertRaisesRegexp)
@@ -2580,12 +2581,15 @@ class TestPeriodIndex(tm.TestCase):
         didx = DatetimeIndex(start='2013/01/01', freq='D', periods=400)
         pidx = PeriodIndex(start='2013/01/01', freq='D', periods=400)
 
+        # changed to TypeError in 1.11
+        exc = IndexError if _np_version_under1p11 else TypeError
+
         for idx in [didx, pidx]:
             # slices against index should raise IndexError
             values = ['2014', '2013/02', '2013/01/02', '2013/02/01 9H',
                       '2013/02/01 09:00']
             for v in values:
-                with tm.assertRaises(IndexError):
+                with tm.assertRaises(exc):
                     idx[v:]
 
             s = Series(np.random.rand(len(idx)), index=idx)
@@ -2597,7 +2601,7 @@ class TestPeriodIndex(tm.TestCase):
 
             invalid = ['2013/02/01 9H', '2013/02/01 09:00']
             for v in invalid:
-                with tm.assertRaises(IndexError):
+                with tm.assertRaises(exc):
                     idx[v:]
 
     def test_getitem_seconds(self):
@@ -2634,12 +2638,15 @@ class TestPeriodIndex(tm.TestCase):
                              periods=4000)
         pidx = PeriodIndex(start='2013/01/01 09:00:00', freq='S', periods=4000)
 
+        # changed to TypeError in 1.11
+        exc = IndexError if _np_version_under1p11 else TypeError
+
         for idx in [didx, pidx]:
             # slices against index should raise IndexError
             values = ['2014', '2013/02', '2013/01/02', '2013/02/01 9H',
                       '2013/02/01 09:00']
             for v in values:
-                with tm.assertRaises(IndexError):
+                with tm.assertRaises(exc):
                     idx[v:]
 
             s = Series(np.random.rand(len(idx)), index=idx)


### PR DESCRIPTION
test_period and slicing exception with nan
compat in sparse for floordiv with 0, now returns NaN rather than inf

closes #12406
