### PR TITLE
Notes about unique vs cat.categories #12278

### DIFF
--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -182,6 +182,18 @@ It's also possible to pass in the categories in a specific order:
     indicate an ordered ``Categorical``.
 
 
+.. note::
+
+    The result of ``Series.unique()`` is not always the same as ``Series.cat.categories``,
+    because ``Series.unique()`` has a couple of guarantees, namely that it returns categories
+    in the order of appearance, and it only includes values that are actually present.
+
+    .. ipython:: python
+
+         s = pd.Series(list('babc')).astype('category', categories=list('abcd'))
+         s.unique()
+         s.cat.categories
+
 Renaming categories
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
- [x] closes #12278
- [ ] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] adding notes about .unique() and .cat.categories (as suggested in [#12278 (comment)](https://github.com/pydata/pandas/issues/12278#issuecomment-182445522))
