### PR TITLE
Update what's new page with relevant issues for df.query() with in-pl…

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -785,7 +785,7 @@ Changes to eval
 ^^^^^^^^^^^^^^^
 
 In prior versions, new columns assignments in an ``eval`` expression resulted
-in an inplace change to the ``DataFrame``. (:issue:`9297`)
+in an inplace change to the ``DataFrame``. (:issue:`9297`, :issue:`8664`, :issue:`10486`)
 
 .. ipython:: python
 


### PR DESCRIPTION
- [x] closes #10486
- [N/A] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

…ace operator

The relevant issues added are :
BUG: query with invalid dtypes should fallback to python engine #10486
BUG: query modifies the frame when you compare with `=` #8664
