### PR TITLE
ENH: Improve error message for empty data constructor. #8020

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -869,6 +869,8 @@ Other API Changes
 
 - ``.to_latex`` and ``.to_html`` gain a ``decimal`` parameter like ``.to_csv``; the default is ``'.'`` (:issue:`12031`)
 
+- The error message when constructing a DataFrame with empty data and indices specified has been updated.
+
 
 .. _whatsnew_0180.deprecations:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -411,7 +411,6 @@ class DataFrame(NDFrame):
         values = _prep_ndarray(values, copy=copy)
 
         if dtype is not None:
-
             if values.dtype != dtype:
                 try:
                     values = values.astype(dtype)

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -3875,6 +3875,8 @@ def construction_error(tot_items, block_shape, axes, e=None):
     implied = tuple(map(int, [len(ax) for ax in axes]))
     if passed == implied and e is not None:
         raise e
+    if block_shape[0] == 0:
+        raise ValueError("Empty data passed with indices specified.")
     raise ValueError("Shape of passed values is {0}, indices imply {1}".format(
         passed, implied))
 

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -285,6 +285,11 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         self.assertTrue(pd.isnull(df).values.ravel().all())
 
     def test_constructor_error_msgs(self):
+        msg = "Empty data passed with indices specified."
+        # passing an empty array with columns specified.
+        with assertRaisesRegexp(ValueError, msg):
+            DataFrame(np.empty(0), columns=list('abc'))
+
         msg = "Mixing dicts with non-Series may lead to ambiguous ordering."
         # mix dict and array, wrong size
         with assertRaisesRegexp(ValueError, msg):


### PR DESCRIPTION
- [X] closes #8020
- [X] tests added / passed
- [X] passes `git diff upstream/master | flake8 --diff`
- [X] whatsnew entry
