### PR TITLE
BUG: fix df concat containing mix of localized and non-localized Timestamps

### DIFF
--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -46,6 +46,28 @@ class TestDataFrameCombineConcat(tm.TestCase, TestData):
         expected = Series(dict(float64=2, float32=2))
         assert_series_equal(results, expected)
 
+    def test_combine_multiple_tzs(self):
+        # GH 12467
+        ts1 = Timestamp('2015-01-01', tz=None)
+        ts2 = Timestamp('2015-01-01', tz='UTC')
+        ts3 = Timestamp('2015-01-01', tz='EST')
+
+        df1 = DataFrame(dict(time=[ts1]))
+        df2 = DataFrame(dict(time=[ts2]))
+        df3 = DataFrame(dict(time=[ts3]))
+
+        results = pd.concat([df1, df2]).reset_index(drop=True)
+        expected = DataFrame(dict(time=[ts1, ts2]), dtype=object)
+        assert_frame_equal(results, expected)
+
+        results = pd.concat([df1, df3]).reset_index(drop=True)
+        expected = DataFrame(dict(time=[ts1, ts3]), dtype=object)
+        assert_frame_equal(results, expected)
+
+        results = pd.concat([df2, df3]).reset_index(drop=True)
+        expected = DataFrame(dict(time=[ts2, ts3]))
+        assert_frame_equal(results, expected)
+
     def test_append_series_dict(self):
         df = DataFrame(np.random.randn(5, 4),
                        columns=['foo', 'bar', 'baz', 'qux'])

--- a/pandas/tseries/common.py
+++ b/pandas/tseries/common.py
@@ -260,7 +260,7 @@ def _concat_compat(to_concat, axis=0, typs=None):
         # if dtype is of datetimetz or timezone
         if x.dtype.kind == _NS_DTYPE.kind:
             if getattr(x, 'tz', None) is not None:
-                x = x.asobject
+                x = x.asobject.values
             else:
                 shape = x.shape
                 x = tslib.ints_to_pydatetime(x.view(np.int64).ravel())
@@ -271,6 +271,8 @@ def _concat_compat(to_concat, axis=0, typs=None):
             x = tslib.ints_to_pytimedelta(x.view(np.int64).ravel())
             x = x.reshape(shape)
 
+        if axis == 1:
+            x = np.atleast_2d(x)
         return x
 
     if typs is None:


### PR DESCRIPTION
BUG: fix issue with concat of localized timestamps
TST: test concat of dataframes with non-None timezone columns
