### PR TITLE
ENH: add missing methods to .dt for Period, resolves #8848

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -431,6 +431,7 @@ Other enhancements
 - ``pivot_table()`` now accepts most iterables for the ``values`` parameter (:issue:`12017`)
 - Added Google ``BigQuery`` service account authentication support, which enables authentication on remote servers. (:issue:`11881`). For further details see :ref:`here <io.bigquery_authentication>`
 - ``HDFStore`` is now iterable: ``for k in store`` is equivalent to ``for k in store.keys()`` (:issue:`12221`).
+- Add missing methods/fields to .dt for Period (:issue:`8848`)
 - The entire codebase has been ``PEP``-ified (:issue:`12096`)
 
 .. _whatsnew_0180.api_breaking:

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -32,8 +32,8 @@ class TestSeriesDatetimeValues(TestData, tm.TestCase):
                        'weekofyear', 'week', 'dayofweek', 'weekday',
                        'dayofyear', 'quarter', 'freq', 'days_in_month',
                        'daysinmonth']
-        ok_for_period = ok_for_base + ['qyear']
-        ok_for_period_methods = ['strftime']
+        ok_for_period = ok_for_base + ['qyear', 'start_time', 'end_time']
+        ok_for_period_methods = ['strftime', 'to_timestamp', 'asfreq']
         ok_for_dt = ok_for_base + ['date', 'time', 'microsecond', 'nanosecond',
                                    'is_month_start', 'is_month_end',
                                    'is_quarter_start', 'is_quarter_end',

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -156,7 +156,8 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
     _datetimelike_ops = ['year', 'month', 'day', 'hour', 'minute', 'second',
                          'weekofyear', 'week', 'dayofweek', 'weekday',
                          'dayofyear', 'quarter', 'qyear', 'freq',
-                         'days_in_month', 'daysinmonth']
+                         'days_in_month', 'daysinmonth',
+                         'to_timestamp', 'asfreq', 'start_time', 'end_time']
     _is_numeric_dtype = False
     _infer_as_myclass = True
 
@@ -497,6 +498,14 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
     days_in_month = _field_accessor(
         'days_in_month', 11, "The number of days in the month")
     daysinmonth = days_in_month
+
+    @property
+    def start_time(self):
+        return self.to_timestamp(how='start')
+
+    @property
+    def end_time(self):
+        return self.to_timestamp(how='end')
 
     def _get_object_array(self):
         freq = self.freq

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -2030,6 +2030,16 @@ class TestPeriodIndex(tm.TestCase):
             ['2011-02-28', 'NaT', '2011-03-31'], name='idx')
         self.assert_index_equal(result, expected)
 
+    def test_start_time(self):
+        index = PeriodIndex(freq='M', start='2016-01-01', end='2016-05-31')
+        expected_index = date_range('2016-01-01', end='2016-05-31', freq='MS')
+        self.assertTrue(index.start_time.equals(expected_index))
+
+    def test_end_time(self):
+        index = PeriodIndex(freq='M', start='2016-01-01', end='2016-05-31')
+        expected_index = date_range('2016-01-01', end='2016-05-31', freq='M')
+        self.assertTrue(index.end_time.equals(expected_index))
+
     def test_as_frame_columns(self):
         rng = period_range('1/1/2000', periods=5)
         df = DataFrame(randn(10, 5), columns=rng)


### PR DESCRIPTION
- [x] closes #8848 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Not 100% complete, but putting this in as a place to house comments:
- I am not sure where to put the whatsnew entry - 0.18.0 or 0.18.1?
- Also not sure if you'd like tests on the actual usage in the .dt accessor, there are actually no tests anywhere in pandas (as far as I can tell) on period_series.dt.\* (as opposed to PeriodIndex). I just added a couple PeriodIndex tests.
