### PR TITLE
API/COMPAT: add pydatetime-style positional args to Timestamp constructor

### DIFF
--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -98,6 +98,7 @@ time.
 
    pd.Timestamp(datetime(2012, 5, 1))
    pd.Timestamp('2012-05-01')
+   pd.Timestamp(2012, 5, 1)
 
 However, in many cases it is more natural to associate things like change
 variables with a time span instead. The span represented by ``Period`` can be

--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -38,6 +38,14 @@ Other enhancements
      idx = pd.Index(["a1a2", "b1", "c1"])
      idx.str.extractall("[ab](?P<digit>\d)")
 
+- ``Timestamp``s can now accept positional parameters like :func:`datetime.datetime`:
+
+  .. ipython:: python
+
+    Timestamp(2012, 1, 1)
+
+    Timestamp(2012, 1, 1, 8, 30)
+
 .. _whatsnew_0182.api:
 
 API changes

--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -38,7 +38,7 @@ Other enhancements
      idx = pd.Index(["a1a2", "b1", "c1"])
      idx.str.extractall("[ab](?P<digit>\d)")
 
-- ``Timestamp``s can now accept positional parameters like :func:`datetime.datetime`:
+- ``Timestamp``s can now accept positional and keyword parameters like :func:`datetime.datetime` (:issue:`10758`, :issue:`11630`)
 
   .. ipython:: python
 

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -193,16 +193,14 @@ class TestTimestamp(tm.TestCase):
         with tm.assertRaises(ValueError):
             Timestamp(2000, 1, 32)
 
-        ts = Timestamp(2000, 1, 2)
+        # GH 11630
+        self.assertEqual(
+                repr(Timestamp(2015, 11, 12)),
+                repr(Timestamp('20151112')))
 
-        actual = ts.to_pydatetime()
-        expected = datetime.datetime(2000, 1, 2)
-        self.assertEqual(actual, expected)
-        self.assertEqual(type(actual), type(expected))
-
-        pos_args = [2000, 1, 2, 3, 4, 5, 999999]
-        self.assertEqual(Timestamp(*pos_args).to_pydatetime(),
-                         datetime.datetime(*pos_args))
+        self.assertEqual(
+                repr(Timestamp(2015, 11, 12, 1, 2, 3, 999999)),
+                repr(Timestamp('2015-11-12 01:02:03.999999')))
 
     def test_constructor_keyword(self):
         # GH 10758
@@ -217,25 +215,14 @@ class TestTimestamp(tm.TestCase):
         with tm.assertRaises(ValueError):
             Timestamp(year=2000, month=1, day=32)
 
-        ts = Timestamp(year=2000, month=1, day=2)
+        self.assertEqual(
+                repr(Timestamp(year=2015, month=11, day=12)),
+                repr(Timestamp('20151112')))
 
-        actual = ts.to_pydatetime()
-        expected = datetime.datetime(year=2000, month=1, day=2)
-        self.assertEqual(actual, expected)
-        self.assertEqual(type(actual), type(expected))
-
-        pos_args = [2000, 1, 2, 3, 4, 5, 999999]
-        kw_args = {
-                'year': 2000,
-                'month': 1,
-                'day': 2,
-                'hour': 3,
-                'minute': 4,
-                'second': 5,
-                'microsecond': 999999,
-                }
-        self.assertEqual(Timestamp(**kw_args).to_pydatetime(),
-                         datetime.datetime(**kw_args))
+        self.assertEqual(
+                repr(Timestamp(year=2015, month=11, day=12,
+                    hour=1, minute=2, second=3, microsecond=999999)),
+                repr(Timestamp('2015-11-12 01:02:03.999999')))
 
     def test_conversion(self):
         # GH 9255

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -180,6 +180,36 @@ class TestTimestamp(tm.TestCase):
         with tm.assertRaisesRegexp(ValueError, 'Cannot convert Period'):
             Timestamp(Period('1000-01-01'))
 
+    def test_constructor_positional(self):
+        # GH 10758
+        with tm.assertRaises(TypeError):
+            Timestamp(2000, 1)
+        with tm.assertRaises(ValueError):
+            Timestamp(2000, 0, 1)
+        with tm.assertRaises(ValueError):
+            Timestamp(2000, 13, 1)
+        with tm.assertRaises(ValueError):
+            Timestamp(2000, 1, 0)
+        with tm.assertRaises(ValueError):
+            Timestamp(2000, 1, 32)
+        with tm.assertRaises(TypeError):
+            Timestamp(2000, 1, 1, None)
+        with tm.assertRaises(TypeError):
+            Timestamp(2000, 1, 1, None, None)
+        with tm.assertRaises(TypeError):
+            Timestamp(2000, 1, 1, None, None, None)
+
+        ts = Timestamp(2000, 1, 2)
+
+        actual = ts.to_pydatetime()
+        expected = datetime.datetime(2000, 1, 2)
+        self.assertEqual(actual, expected)
+        self.assertEqual(type(actual), type(expected))
+
+        pos_args = [2000, 1, 2, 3, 4, 5, 999999]
+        self.assertEqual(Timestamp(*pos_args).to_pydatetime(),
+                         datetime.datetime(*pos_args))
+
     def test_conversion(self):
         # GH 9255
         ts = Timestamp('2000-01-01')

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -192,12 +192,6 @@ class TestTimestamp(tm.TestCase):
             Timestamp(2000, 1, 0)
         with tm.assertRaises(ValueError):
             Timestamp(2000, 1, 32)
-        with tm.assertRaises(TypeError):
-            Timestamp(2000, 1, 1, None)
-        with tm.assertRaises(TypeError):
-            Timestamp(2000, 1, 1, None, None)
-        with tm.assertRaises(TypeError):
-            Timestamp(2000, 1, 1, None, None, None)
 
         ts = Timestamp(2000, 1, 2)
 

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -195,12 +195,12 @@ class TestTimestamp(tm.TestCase):
 
         # GH 11630
         self.assertEqual(
-                repr(Timestamp(2015, 11, 12)),
-                repr(Timestamp('20151112')))
+            repr(Timestamp(2015, 11, 12)),
+            repr(Timestamp('20151112')))
 
         self.assertEqual(
-                repr(Timestamp(2015, 11, 12, 1, 2, 3, 999999)),
-                repr(Timestamp('2015-11-12 01:02:03.999999')))
+            repr(Timestamp(2015, 11, 12, 1, 2, 3, 999999)),
+            repr(Timestamp('2015-11-12 01:02:03.999999')))
 
     def test_constructor_keyword(self):
         # GH 10758
@@ -216,13 +216,13 @@ class TestTimestamp(tm.TestCase):
             Timestamp(year=2000, month=1, day=32)
 
         self.assertEqual(
-                repr(Timestamp(year=2015, month=11, day=12)),
-                repr(Timestamp('20151112')))
+            repr(Timestamp(year=2015, month=11, day=12)),
+            repr(Timestamp('20151112')))
 
         self.assertEqual(
-                repr(Timestamp(year=2015, month=11, day=12,
-                    hour=1, minute=2, second=3, microsecond=999999)),
-                repr(Timestamp('2015-11-12 01:02:03.999999')))
+            repr(Timestamp(year=2015, month=11, day=12,
+                           hour=1, minute=2, second=3, microsecond=999999)),
+            repr(Timestamp('2015-11-12 01:02:03.999999')))
 
     def test_conversion(self):
         # GH 9255

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -204,6 +204,39 @@ class TestTimestamp(tm.TestCase):
         self.assertEqual(Timestamp(*pos_args).to_pydatetime(),
                          datetime.datetime(*pos_args))
 
+    def test_constructor_keyword(self):
+        # GH 10758
+        with tm.assertRaises(TypeError):
+            Timestamp(year=2000, month=1)
+        with tm.assertRaises(ValueError):
+            Timestamp(year=2000, month=0, day=1)
+        with tm.assertRaises(ValueError):
+            Timestamp(year=2000, month=13, day=1)
+        with tm.assertRaises(ValueError):
+            Timestamp(year=2000, month=1, day=0)
+        with tm.assertRaises(ValueError):
+            Timestamp(year=2000, month=1, day=32)
+
+        ts = Timestamp(year=2000, month=1, day=2)
+
+        actual = ts.to_pydatetime()
+        expected = datetime.datetime(year=2000, month=1, day=2)
+        self.assertEqual(actual, expected)
+        self.assertEqual(type(actual), type(expected))
+
+        pos_args = [2000, 1, 2, 3, 4, 5, 999999]
+        kw_args = {
+                'year': 2000,
+                'month': 1,
+                'day': 2,
+                'hour': 3,
+                'minute': 4,
+                'second': 5,
+                'microsecond': 999999,
+                }
+        self.assertEqual(Timestamp(**kw_args).to_pydatetime(),
+                         datetime.datetime(**kw_args))
+
     def test_conversion(self):
         # GH 9255
         ts = Timestamp('2000-01-01')

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -202,6 +202,8 @@ class TestTimestamp(tm.TestCase):
             repr(Timestamp(2015, 11, 12, 1, 2, 3, 999999)),
             repr(Timestamp('2015-11-12 01:02:03.999999')))
 
+        self.assertIs(Timestamp(None), pd.NaT)
+
     def test_constructor_keyword(self):
         # GH 10758
         with tm.assertRaises(TypeError):

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -216,6 +216,7 @@ cdef inline bint _is_fixed_offset(object tz):
 
 
 _zero_time = datetime_time(0, 0)
+_no_input = object()
 
 # Python front end to C extension type _Timestamp
 # This serves as the box for datetime64
@@ -230,7 +231,7 @@ class Timestamp(_Timestamp):
     keyword.
 
     Parameters
-    -----------------
+    ----------
     ts_input : datetime-like, str, int, float
         Value to be converted to Timestamp
     offset : str, DateOffset
@@ -240,7 +241,7 @@ class Timestamp(_Timestamp):
     unit : string
         numpy unit used for conversion, if ts_input is int or float
 
-    The other two forms copy the parameters from datetime.datetime. They can
+    The other two forms mimic the parameters from datetime.datetime. They can
     be passed by either position or keyword, but not both mixed together.
 
     :func:`datetime.datetime` Parameters
@@ -310,7 +311,7 @@ class Timestamp(_Timestamp):
         return cls(datetime.combine(date, time))
 
     def __new__(cls,
-            object ts_input=None, object offset=None, tz=None, unit=None,
+            object ts_input=_no_input, object offset=None, tz=None, unit=None,
             year=None, month=None, day=None,
             hour=None, minute=None, second=None, microsecond=None,
             tzinfo=None):
@@ -328,14 +329,14 @@ class Timestamp(_Timestamp):
         # that the second argument is an int.
         # - Nones for the first four (legacy) arguments indicate pydatetime
         # keyword arguments. year, month, and day are required. As a
-        # shortcut, we just check that the first argument is None.
+        # shortcut, we just check that the first argument was not passed.
         #
         # Mixing pydatetime positional and keyword arguments is forbidden!
 
         cdef _TSObject ts
         cdef _Timestamp ts_base
 
-        if ts_input is None:
+        if ts_input is _no_input:
             # User passed keyword arguments.
             return Timestamp(datetime(year, month, day, hour or 0,
                 minute or 0, second or 0, microsecond or 0, tzinfo),

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -214,7 +214,6 @@ cdef inline bint _is_fixed_offset(object tz):
             return 0
     return 1
 
-
 _zero_time = datetime_time(0, 0)
 _no_input = object()
 
@@ -241,22 +240,22 @@ class Timestamp(_Timestamp):
     unit : string
         numpy unit used for conversion, if ts_input is int or float
 
-    The other two forms mimic the parameters from datetime.datetime. They can
-    be passed by either position or keyword, but not both mixed together.
+    The other two forms mimic the parameters from ``datetime.datetime``. They
+    can be passed by either position or keyword, but not both mixed together.
 
     :func:`datetime.datetime` Parameters
-    ------------------------------
+    ------------------------------------
 
     .. versionadded:: 0.18.2
 
     year : int
     month : int
     day : int
-    hour : int [optional]
-    minute : int [optional]
-    second : int [optional]
-    microsecond : int [optional]
-    tzinfo : datetime.tzinfo [optional]
+    hour : int, optional, default is 0
+    minute : int, optional, default is 0
+    second : int, optional, default is 0
+    microsecond : int, optional, default is 0
+    tzinfo : datetime.tzinfo, optional, default is None
     """
 
     @classmethod
@@ -319,17 +318,20 @@ class Timestamp(_Timestamp):
         # four) and positional and keyword parameter names from pydatetime.
         #
         # There are three calling forms:
+        #
         # - In the legacy form, the first parameter, ts_input, is required
-        # and may be datetime-like, str, int, or float. The second parameter,
-        # offset, is optional and may be str or DateOffset.
+        #   and may be datetime-like, str, int, or float. The second
+        #   parameter, offset, is optional and may be str or DateOffset.
+        #
         # - ints in the first, second, and third arguments indicate
-        # pydatetime positional arguments. Only the first 8 arguments
-        # (standing in for year, month, day, hour, minute, second,
-        # microsecond, tzinfo) may be non-None. As a shortcut, we just check
-        # that the second argument is an int.
+        #   pydatetime positional arguments. Only the first 8 arguments
+        #   (standing in for year, month, day, hour, minute, second,
+        #   microsecond, tzinfo) may be non-None. As a shortcut, we just
+        #   check that the second argument is an int.
+        #
         # - Nones for the first four (legacy) arguments indicate pydatetime
-        # keyword arguments. year, month, and day are required. As a
-        # shortcut, we just check that the first argument was not passed.
+        #   keyword arguments. year, month, and day are required. As a
+        #   shortcut, we just check that the first argument was not passed.
         #
         # Mixing pydatetime positional and keyword arguments is forbidden!
 

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -226,10 +226,10 @@ class Timestamp(_Timestamp):
     oriented data structures in pandas.
 
     There are essentially three calling conventions for the constructor. The
-    first, legacy form accepts four parameters. They can be passed by
-    position or keyword.
+    primary form accepts four parameters. They can be passed by position or
+    keyword.
 
-    Legacy Parameters
+    Parameters
     -----------------
     ts_input : datetime-like, str, int, float
         Value to be converted to Timestamp
@@ -243,8 +243,11 @@ class Timestamp(_Timestamp):
     The other two forms copy the parameters from datetime.datetime. They can
     be passed by either position or keyword, but not both mixed together.
 
-    datetime.datetime Parameters
+    :func:`datetime.datetime` Parameters
     ------------------------------
+
+    .. versionadded:: 0.18.2
+
     year : int
     month : int
     day : int

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -225,8 +225,12 @@ class Timestamp(_Timestamp):
     for the entries that make up a DatetimeIndex, and other timeseries
     oriented data structures in pandas.
 
-    Parameters
-    ----------
+    There are essentially three calling conventions for the constructor. The
+    first, legacy form accepts four parameters. They can be passed by
+    position or keyword.
+
+    Legacy Parameters
+    -----------------
     ts_input : datetime-like, str, int, float
         Value to be converted to Timestamp
     offset : str, DateOffset
@@ -235,6 +239,20 @@ class Timestamp(_Timestamp):
         Time zone for time which Timestamp will have.
     unit : string
         numpy unit used for conversion, if ts_input is int or float
+
+    The other two forms copy the parameters from datetime.datetime. They can
+    be passed by either position or keyword, but not both mixed together.
+
+    datetime.datetime Parameters
+    ------------------------------
+    year : int
+    month : int
+    day : int
+    hour : int [optional]
+    minute : int [optional]
+    second : int [optional]
+    microsecond : int [optional]
+    tzinfo : datetime.tzinfo [optional]
     """
 
     @classmethod
@@ -319,7 +337,7 @@ class Timestamp(_Timestamp):
             return Timestamp(datetime(year, month, day, hour or 0,
                 minute or 0, second or 0, microsecond or 0, tzinfo),
                 tz=tzinfo)
-        if is_integer_object(offset):
+        elif is_integer_object(offset):
             # User passed positional arguments:
             #   Timestamp(year, month, day[, hour[, minute[, second[, microsecond[, tzinfo]]]]])
             return Timestamp(datetime(ts_input, offset, tz, unit or 0,


### PR DESCRIPTION
- [X] closes #10758
- [X] tests added / passed
- [X] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

If more tests are desired, please let me know where to put them. Same for the whatsnew entry. This is my first pull request for Pandas.

cc @jreback 
