### PR TITLE
BUG: Allow assignment by indexing with duplicate column names

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -1201,3 +1201,4 @@ Bug Fixes
 - Bug when initializing categorical series with a scalar value. (:issue:`12336`)
 - Bug when specifying a UTC ``DatetimeIndex`` by setting ``utc=True`` in ``.to_datetime`` (:issue:`11934`)
 - Bug when increasing the buffer size of CSV reader in ``read_csv`` (:issue:`12494`)
+- Bug when setting columns of a ``DataFrame`` with duplicate column names (:issue:`12344`)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -541,7 +541,7 @@ class _NDFrameIndexer(object):
                 if (len(indexer) > info_axis and
                         is_integer(indexer[info_axis]) and
                         all(is_null_slice(idx) for i, idx in enumerate(indexer)
-                            if i != info_axis)):
+                            if i != info_axis) and item_labels.is_unique):
                     self.obj[item_labels[indexer[info_axis]]] = value
                     return
 

--- a/pandas/tests/frame/test_nonunique_indexes.py
+++ b/pandas/tests/frame/test_nonunique_indexes.py
@@ -452,3 +452,19 @@ class TestDataFrameNonuniqueIndexes(tm.TestCase, TestData):
                             dtype=object)
 
         self.assertTrue(np.array_equal(result, expected))
+
+    def test_set_value_by_index(self):
+        # See gh-12344
+        df = DataFrame(np.arange(9).reshape(3, 3).T)
+        df.columns = list('AAA')
+        expected = df.iloc[:, 2]
+
+        df.iloc[:, 0] = 3
+        assert_series_equal(df.iloc[:, 2], expected)
+
+        df = DataFrame(np.arange(9).reshape(3, 3).T)
+        df.columns = [2, float(2), str(2)]
+        expected = df.iloc[:, 1]
+
+        df.iloc[:, 0] = 3
+        assert_series_equal(df.iloc[:, 1], expected)


### PR DESCRIPTION
closes #12344

 in which assignment to columns in `DataFrame` with duplicate column names caused all columns with the same name to be reassigned.  The bug was located <a href="https://github.com/pydata/pandas/blob/master/pandas/core/indexing.py#L545">here</a>.

When you try to index into the DataFrame using `.iloc`, `pandas` will find the corresponding column name (or key) first before setting that key with the given value.  Unfortunately, since all of your columns have the same key name, `pandas` ends up choosing all of the columns corresponding to that name.

This PR introduces a `_set_item_by_index` method for `DataFrame` objects that allows you to bypass that issue by using the indices of the columns to set the columns themselves whenever there are duplicates involved.
