### PR TITLE
BUG: Respect usecols even with empty data

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -179,6 +179,45 @@ New Behavior:
     # Output is a DataFrame
     df.groupby(pd.TimeGrouper(key='date', freq='M')).apply(lambda x: x[['value']].sum())
 
+.. _whatsnew_0181.read_csv_exceptions:
+
+Change in ``read_csv`` exceptions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In order to standardize the ``read_csv`` API for both the C and Python engines, both will now raise an
+``EmptyDataError``, a subclass of ``ValueError``, in response to empty columns or header (:issue:`12506`)
+
+Previous behaviour:
+
+.. code-block:: python
+
+   In [1]: df = pd.read_csv(StringIO(''), engine='c')
+   ...
+   ValueError: No columns to parse from file
+
+   In [2]: df = pd.read_csv(StringIO(''), engine='python')
+   ...
+   StopIteration
+
+New behaviour:
+
+.. code-block:: python
+
+   In [1]: df = pd.read_csv(StringIO(''), engine='c')
+   ...
+   pandas.io.common.EmptyDataError: No columns to parse from file
+
+   In [2]: df = pd.read_csv(StringIO(''), engine='python')
+   ...
+   pandas.io.common.EmptyDataError: No columns to parse from file
+
+In addition to this error change, several others have been made as well:
+
+- ``CParserError`` is now a ``ValueError`` instead of just an ``Exception`` (:issue:`12551`)
+- A ``CParserError`` is now raised instead of a generic ``Exception`` in ``read_csv`` when the C engine cannot parse a column
+- A ``ValueError`` is now raised instead of a generic ``Exception`` in ``read_csv`` when the C engine encounters a ``NaN`` value in an integer column
+- A ``ValueError`` is now raised instead of a generic ``Exception`` in ``read_csv`` when ``true_values`` is specified, and the C engine encounters an element in a column containing unencodable bytes
+- ``pandas.parser.OverflowError`` exception has been removed and has been replaced with Python's built-in ``OverflowError`` exception
 
 .. _whatsnew_0181.deprecations:
 

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -56,7 +56,37 @@ _VALID_URLS = set(uses_relative + uses_netloc + uses_params)
 _VALID_URLS.discard('')
 
 
+class CParserError(ValueError):
+    """
+    Exception that is thrown by the C engine when it encounters
+    a parsing error in `pd.read_csv`
+    """
+    pass
+
+
 class DtypeWarning(Warning):
+    """
+    Warning that is raised whenever `pd.read_csv` encounters non-
+    uniform dtypes in a column(s) of a given CSV file
+    """
+    pass
+
+
+class EmptyDataError(ValueError):
+    """
+    Exception that is thrown in `pd.read_csv` (by both the C and
+    Python engines) when empty data or header is encountered
+    """
+    pass
+
+
+class ParserWarning(Warning):
+    """
+    Warning that is raised in `pd.read_csv` whenever it is necessary
+    to change parsers (generally from 'c' to 'python') contrary to the
+    one specified by the user due to lack of support or functionality for
+    parsing particular attributes of a CSV file with the requsted engine
+    """
     pass
 
 

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -13,7 +13,7 @@ import numpy as np
 from pandas.core.frame import DataFrame
 from pandas.io.parsers import TextParser
 from pandas.io.common import (_is_url, _urlopen, _validate_header_arg,
-                              get_filepath_or_buffer)
+                              EmptyDataError, get_filepath_or_buffer)
 from pandas.tseries.period import Period
 from pandas import json
 from pandas.compat import (map, zip, reduce, range, lrange, u, add_metaclass,
@@ -468,7 +468,7 @@ class ExcelFile(object):
                 if not squeeze or isinstance(output[asheetname], DataFrame):
                     output[asheetname].columns = output[
                         asheetname].columns.set_names(header_names)
-            except StopIteration:
+            except EmptyDataError:
                 # No Data, return an empty DataFrame
                 output[asheetname] = DataFrame()
 

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -12,7 +12,8 @@ from distutils.version import LooseVersion
 
 import numpy as np
 
-from pandas.io.common import _is_url, urlopen, parse_url, _validate_header_arg
+from pandas.io.common import (EmptyDataError, _is_url, urlopen,
+                              parse_url, _validate_header_arg)
 from pandas.io.parsers import TextParser
 from pandas.compat import (lrange, lmap, u, string_types, iteritems,
                            raise_with_traceback, binary_type)
@@ -742,7 +743,7 @@ def _parse(flavor, io, match, header, index_col, skiprows,
                                       parse_dates=parse_dates,
                                       tupleize_cols=tupleize_cols,
                                       thousands=thousands))
-        except StopIteration:  # empty table
+        except EmptyDataError:  # empty table
             continue
     return ret
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1255,10 +1255,19 @@ class CParserWrapper(ParserBase):
         except StopIteration:
             if self._first_chunk:
                 self._first_chunk = False
-                return _get_empty_meta(self.orig_names,
-                                       self.index_col,
-                                       self.index_names,
-                                       dtype=self.kwds.get('dtype'))
+
+                index, columns, col_dict = _get_empty_meta(
+                    self.orig_names, self.index_col,
+                    self.index_names, dtype=self.kwds.get('dtype'))
+
+                if self.usecols is not None:
+                    columns = self._filter_usecols(columns)
+
+                col_dict = dict(filter(lambda item: item[0] in columns,
+                                       col_dict.items()))
+
+                return index, columns, col_dict
+
             else:
                 raise
 

--- a/pandas/io/tests/test_html.py
+++ b/pandas/io/tests/test_html.py
@@ -804,3 +804,7 @@ def test_same_ordering():
     dfs_lxml = read_html(filename, index_col=0, flavor=['lxml'])
     dfs_bs4 = read_html(filename, index_col=0, flavor=['bs4'])
     assert_framelist_equal(dfs_lxml, dfs_bs4)
+
+if __name__ == '__main__':
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   exit=False)

--- a/pandas/io/tests/test_parsers.py
+++ b/pandas/io/tests/test_parsers.py
@@ -3807,6 +3807,22 @@ class CParserTests(ParserTests):
             except Exception as e:
                 pass
 
+    def test_read_empty_with_usecols(self):
+        # See gh-12493
+        names = ['Dummy', 'X', 'Dummy_2']
+        usecols = names[1:2] # ['X']
+
+        def check_usecols(stringIO, expected):
+            df = read_csv(stringIO, names=names, usecols=usecols)
+            tm.assert_frame_equal(df, expected)
+
+        expected = DataFrame(columns=usecols,
+                             index=[0], dtype=np.float64)
+        check_usecols(StringIO(',,'), expected)
+
+        expected = DataFrame(columns=usecols)
+        check_usecols(StringIO(''), expected)
+
 
 class TestCParserHighMemory(CParserTests, CompressionTests, tm.TestCase):
     engine = 'c'


### PR DESCRIPTION
closes #12493

 in which the `usecols` argument was not being respected for empty data.  This is because no filtering was applied when the first (and only) chunk was being read.
