### PR TITLE
TST: Fix NOQA for flake8 checking in datetools.py

### DIFF
--- a/pandas/core/datetools.py
+++ b/pandas/core/datetools.py
@@ -1,8 +1,8 @@
 """A collection of random tools for dealing with dates in Python"""
 
-from pandas.tseries.tools import *  # noqa
-from pandas.tseries.offsets import *  # noqa
-from pandas.tseries.frequencies import *  # noqa
+from pandas.tseries.tools import *  # flake8: noqa
+from pandas.tseries.offsets import *  # flake8: noqa
+from pandas.tseries.frequencies import *  # flake8: noqa
 
 day = DateOffset()
 bday = BDay()


### PR DESCRIPTION
Recent changes to pyflakes (see <a href="https://github.com/pyflakes/pyflakes/blob/0532189b34086740d7fe553bd87c0a6cf682a93b/pyflakes/checker.py#L544-L546">here</a>) suddenly started raising errors in `datetools.py` due to the star imports at the top, which the `#noqa` was not preventing. The correct syntax is `# flake8: noqa`  <br><br><b>PLEASE MERGE ASAP</b>
