### PR TITLE
BUG: Add exception when different number of fields present in file lines

### DIFF
--- a/pandas/src/parser/tokenizer.c
+++ b/pandas/src/parser/tokenizer.c
@@ -537,9 +537,13 @@ static int end_line(parser_t *self) {
             }
 
             while (fields < ex_fields){
-                end_field(self);
-                /* printf("Prior word: %s\n", self->words[self->words_len - 2]); */
-                fields++;
+                self->error_msg = (char*) malloc(100);
+                sprintf(self->error_msg, "Expected %d fields in line %d, saw %d\n",
+                        ex_fields, self->file_lines, fields);
+
+                TRACE(("Error at line %d, %d fields\n", self->file_lines, fields));
+
+                return -1;
             }
         }
 


### PR DESCRIPTION
Addresses issue in #12519 by raising exception when 'filepath_or_buffer'
in 'read_csv' contains different number of fields in input lines.

However, according to tests the behaviour reported in bug is expected (lines 376-390): https://github.com/pydata/pandas/blob/master/pandas/io/tests/test_cparser.py#L376

So should those tests be removed?
