### PR TITLE
ENH: Partial string matching for timestamps with multiindex

### DIFF
--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -422,6 +422,20 @@ We are stopping on the included end-point as it is part of the index
 
       dft.loc['2013-1-15 12:30:00']
 
+DatetimeIndex Partial String Indexing also works on DataFrames with hierarchical indexing (``MultiIndex``). For
+instance:
+
+.. ipython:: python
+
+   dft2 = pd.DataFrame(randn(20,1),
+                    columns=['A'],
+                    index=pd.MultiIndex.from_product([date_range('20130101',
+                                                              periods=10,
+                                                              freq='12H'),
+                                                  ['a', 'b']]))
+   dft2.loc['2013-01-05']
+   dft2 = dft2.swaplevel(0, 1).sort_index()
+   dft2.loc[pd.IndexSlice[:,'2013-01-05'],:]
 
 Datetime Indexing
 ~~~~~~~~~~~~~~~~~

--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -30,6 +30,24 @@ Enhancements
 ~~~~~~~~~~~~
 
 
+Partial string matches on ``DateTimeIndex`` when part of a ``MultiIndex``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Partial string matches on ``DateTimeIndex`` now work when part of a ``MultiIndex`` (:issue:`10331`)
+
+For example:
+
+.. ipython:: python
+
+   dft2 = pd.DataFrame(randn(20,1),
+                    columns=['A'],
+                    index=pd.MultiIndex.from_product([date_range('20130101',
+                                                              periods=10,
+                                                              freq='12H'),
+                                                  ['a', 'b']]))
+   dft2.loc['2013-01-05']
+   dft2 = dft2.swaplevel(0, 1).sort_index()
+   dft2.loc[pd.IndexSlice[:,'2013-01-05'],:]
+
 
 
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1392,8 +1392,33 @@ class _LocIndexer(_LocationIndexer):
 
         return True
 
+    def _get_partial_string_timestamp_match_key(self, key, labels):
+        """Translate any partial string timestamp matches in key, returning the
+        new key (GH 10331)"""
+        if isinstance(labels, MultiIndex):
+            if isinstance(key, compat.string_types) and \
+                    labels.levels[0].is_all_dates:
+                # Convert key '2016-01-01' to
+                # ('2016-01-01'[, slice(None, None, None)]+)
+                key = tuple([key] + [slice(None)] * (len(labels.levels) - 1))
+
+            if isinstance(key, tuple):
+                # Convert (..., '2016-01-01', ...) in tuple to
+                # (..., slice('2016-01-01', '2016-01-01', None), ...)
+                new_key = []
+                for i, component in enumerate(key):
+                    if isinstance(component, compat.string_types) and \
+                            labels.levels[i].is_all_dates:
+                        new_key.append(slice(component, component, None))
+                    else:
+                        new_key.append(component)
+                key = tuple(new_key)
+
+        return key
+
     def _getitem_axis(self, key, axis=0):
         labels = self.obj._get_axis(axis)
+        key = self._get_partial_string_timestamp_match_key(key, labels)
 
         if isinstance(key, slice):
             self._has_valid_type(key, axis)


### PR DESCRIPTION
- [x] closes #10331
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Includes implementation, unit tests, documentation fixes and whatsnew.
