### PR TITLE
ENH: Allow where/mask/Indexers to accept callable

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -13,6 +13,8 @@ Highlights include:
 - ``pd.to_datetime()`` has gained the ability to assemble dates from a ``DataFrame``, see :ref:`here <whatsnew_0181.enhancements.assembling>`
 - Custom business hour offset, see :ref:`here <whatsnew_0181.enhancements.custombusinesshour>`.
 - Many bug fixes in the handling of ``sparse``, see :ref:`here <whatsnew_0181.sparse>`
+- Method chaining improvements, see :ref:`here <whatsnew_0181.enhancements.method_chain>`.
+
 
 .. contents:: What's new in v0.18.1
     :local:
@@ -93,6 +95,66 @@ Now you can do:
 .. ipython:: python
 
    df.groupby('group').resample('1D').ffill()
+
+.. _whatsnew_0181.enhancements.method_chain:
+
+Method chaininng improvements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following methods / indexers now accept ``callable``. It is intended to make
+these more useful in method chains, see :ref:`Selection By Callable <indexing.callable>`.
+(:issue:`11485`, :issue:`12533`)
+
+- ``.where()`` and ``.mask()``
+- ``.loc[]``, ``iloc[]`` and ``.ix[]``
+- ``[]`` indexing
+
+``.where()`` and ``.mask()``
+""""""""""""""""""""""""""""
+
+These can accept a callable as condition and ``other``
+arguments.
+
+.. ipython:: python
+
+   df = pd.DataFrame({'A': [1, 2, 3],
+                      'B': [4, 5, 6],
+                      'C': [7, 8, 9]})
+   df.where(lambda x: x > 4, lambda x: x + 10)
+
+``.loc[]``, ``.iloc[]``, ``.ix[]``
+""""""""""""""""""""""""""""""""""
+
+These can accept a callable, and tuple of callable as a slicer. The callable
+can return valid ``bool`` indexer or anything which is valid for these indexer's input.
+
+.. ipython:: python
+
+   # callable returns bool indexer
+   df.loc[lambda x: x.A >= 2, lambda x: x.sum() > 10]
+
+   # callable returns list of labels
+   df.loc[lambda x: [1, 2], lambda x: ['A', 'B']]
+
+``[]`` indexing
+"""""""""""""""
+
+Finally, you can use a callable in ``[]`` indexing of Series, DataFrame and Panel.
+The callable must return valid input for ``[]`` indexing depending on its
+class and index type.
+
+.. ipython:: python
+
+   df[lambda x: 'A']
+
+Using these methods / indexers, you can chain data selection operations
+without using temporary variable.
+
+.. ipython:: python
+
+   bb = pd.read_csv('data/baseball.csv', index_col='id')
+   (bb.groupby(['year', 'team']).sum()
+      .loc[lambda df: df.r > 100])
 
 .. _whatsnew_0181.partial_string_indexing:
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1843,6 +1843,16 @@ def _get_callable_name(obj):
     return None
 
 
+def _apply_if_callable(maybe_callable, obj, **kwargs):
+    """
+    Evaluate possibly callable input using obj and kwargs if it is callable,
+    otherwise return as it is
+    """
+    if callable(maybe_callable):
+        return maybe_callable(obj, **kwargs)
+    return maybe_callable
+
+
 _string_dtypes = frozenset(map(_get_dtype_from_object, (compat.binary_type,
                                                         compat.text_type)))
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4283,8 +4283,26 @@ class NDFrame(PandasObject):
 
         Parameters
         ----------
-        cond : boolean %(klass)s or array
-        other : scalar or %(klass)s
+        cond : boolean %(klass)s, array or callable
+            If cond is callable, it is computed on the %(klass)s and
+            should return boolean %(klass)s or array.
+            The callable must not change input %(klass)s
+            (though pandas doesn't check it).
+
+            .. versionadded:: 0.18.1
+
+            A callable can be used as cond.
+
+        other : scalar, %(klass)s, or callable
+            If other is callable, it is computed on the %(klass)s and
+            should return scalar or %(klass)s.
+            The callable must not change input %(klass)s
+            (though pandas doesn't check it).
+
+            .. versionadded:: 0.18.1
+
+            A callable can be used as other.
+
         inplace : boolean, default False
             Whether to perform the operation in place on the data
         axis : alignment axis if needed, default None
@@ -4303,6 +4321,9 @@ class NDFrame(PandasObject):
     @Appender(_shared_docs['where'] % dict(_shared_doc_kwargs, cond="True"))
     def where(self, cond, other=np.nan, inplace=False, axis=None, level=None,
               try_cast=False, raise_on_error=True):
+
+        cond = com._apply_if_callable(cond, self)
+        other = com._apply_if_callable(other, self)
 
         if isinstance(cond, NDFrame):
             cond, _ = cond.align(self, join='right', broadcast_axis=1)
@@ -4461,6 +4482,9 @@ class NDFrame(PandasObject):
     @Appender(_shared_docs['where'] % dict(_shared_doc_kwargs, cond="False"))
     def mask(self, cond, other=np.nan, inplace=False, axis=None, level=None,
              try_cast=False, raise_on_error=True):
+
+        cond = com._apply_if_callable(cond, self)
+
         return self.where(~cond, other=other, inplace=inplace, axis=axis,
                           level=level, try_cast=try_cast,
                           raise_on_error=raise_on_error)

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -268,6 +268,8 @@ class Panel(NDFrame):
         return cls(**d)
 
     def __getitem__(self, key):
+        key = com._apply_if_callable(key, self)
+
         if isinstance(self._info_axis, MultiIndex):
             return self._getitem_multilevel(key)
         if not (is_list_like(key) or isinstance(key, slice)):
@@ -567,6 +569,7 @@ class Panel(NDFrame):
         return self._constructor_sliced(values, **d)
 
     def __setitem__(self, key, value):
+        key = com._apply_if_callable(key, self)
         shape = tuple(self.shape)
         if isinstance(value, self._constructor_sliced):
             value = value.reindex(

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -577,6 +577,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         return self._get_values(slobj)
 
     def __getitem__(self, key):
+        key = com._apply_if_callable(key, self)
         try:
             result = self.index.get_value(self, key)
 
@@ -692,6 +693,8 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
             return self._values[indexer]
 
     def __setitem__(self, key, value):
+        key = com._apply_if_callable(key, self)
+
         def setitem(key, value):
             try:
                 self._set_with_engine(key, value)

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -136,6 +136,17 @@ class TestDataFrameEval(tm.TestCase, TestData):
         result = (1 - np.isnan(df)).iloc[0:25]
         assert_frame_equal(result, expected)
 
+    def test_query_non_str(self):
+        # GH 11485
+        df = pd.DataFrame({'A': [1, 2, 3], 'B': ['a', 'b', 'b']})
+
+        msg = "expr must be a string to be evaluated"
+        with tm.assertRaisesRegexp(ValueError, msg):
+            df.query(lambda x: x.B == "b")
+
+        with tm.assertRaisesRegexp(ValueError, msg):
+            df.query(111)
+
 
 class TestDataFrameQueryWithMultiIndex(tm.TestCase):
 

--- a/pandas/tests/indexing/test_callable.py
+++ b/pandas/tests/indexing/test_callable.py
@@ -1,0 +1,275 @@
+# -*- coding: utf-8 -*-
+# pylint: disable-msg=W0612,E1101
+import nose
+
+import numpy as np
+import pandas as pd
+import pandas.util.testing as tm
+
+
+class TestIndexingCallable(tm.TestCase):
+
+    _multiprocess_can_split_ = True
+
+    def test_frame_loc_ix_callable(self):
+        # GH 11485
+        df = pd.DataFrame({'A': [1, 2, 3, 4], 'B': list('aabb'),
+                           'C': [1, 2, 3, 4]})
+        # iloc cannot use boolean Series (see GH3635)
+
+        # return bool indexer
+        res = df.loc[lambda x: x.A > 2]
+        tm.assert_frame_equal(res, df.loc[df.A > 2])
+
+        res = df.ix[lambda x: x.A > 2]
+        tm.assert_frame_equal(res, df.ix[df.A > 2])
+
+        res = df.loc[lambda x: x.A > 2, ]
+        tm.assert_frame_equal(res, df.loc[df.A > 2, ])
+
+        res = df.ix[lambda x: x.A > 2, ]
+        tm.assert_frame_equal(res, df.ix[df.A > 2, ])
+
+        res = df.loc[lambda x: x.B == 'b', :]
+        tm.assert_frame_equal(res, df.loc[df.B == 'b', :])
+
+        res = df.ix[lambda x: x.B == 'b', :]
+        tm.assert_frame_equal(res, df.ix[df.B == 'b', :])
+
+        res = df.loc[lambda x: x.A > 2, lambda x: x.columns == 'B']
+        tm.assert_frame_equal(res, df.loc[df.A > 2, [False, True, False]])
+
+        res = df.ix[lambda x: x.A > 2, lambda x: x.columns == 'B']
+        tm.assert_frame_equal(res, df.ix[df.A > 2, [False, True, False]])
+
+        res = df.loc[lambda x: x.A > 2, lambda x: 'B']
+        tm.assert_series_equal(res, df.loc[df.A > 2, 'B'])
+
+        res = df.ix[lambda x: x.A > 2, lambda x: 'B']
+        tm.assert_series_equal(res, df.ix[df.A > 2, 'B'])
+
+        res = df.loc[lambda x: x.A > 2, lambda x: ['A', 'B']]
+        tm.assert_frame_equal(res, df.loc[df.A > 2, ['A', 'B']])
+
+        res = df.ix[lambda x: x.A > 2, lambda x: ['A', 'B']]
+        tm.assert_frame_equal(res, df.ix[df.A > 2, ['A', 'B']])
+
+        res = df.loc[lambda x: x.A == 2, lambda x: ['A', 'B']]
+        tm.assert_frame_equal(res, df.loc[df.A == 2, ['A', 'B']])
+
+        res = df.ix[lambda x: x.A == 2, lambda x: ['A', 'B']]
+        tm.assert_frame_equal(res, df.ix[df.A == 2, ['A', 'B']])
+
+        # scalar
+        res = df.loc[lambda x: 1, lambda x: 'A']
+        self.assertEqual(res, df.loc[1, 'A'])
+
+        res = df.ix[lambda x: 1, lambda x: 'A']
+        self.assertEqual(res, df.ix[1, 'A'])
+
+    def test_frame_loc_ix_callable_mixture(self):
+        # GH 11485
+        df = pd.DataFrame({'A': [1, 2, 3, 4], 'B': list('aabb'),
+                           'C': [1, 2, 3, 4]})
+
+        res = df.loc[lambda x: x.A > 2, ['A', 'B']]
+        tm.assert_frame_equal(res, df.loc[df.A > 2, ['A', 'B']])
+
+        res = df.ix[lambda x: x.A > 2, ['A', 'B']]
+        tm.assert_frame_equal(res, df.ix[df.A > 2, ['A', 'B']])
+
+        res = df.loc[[2, 3], lambda x: ['A', 'B']]
+        tm.assert_frame_equal(res, df.loc[[2, 3], ['A', 'B']])
+
+        res = df.ix[[2, 3], lambda x: ['A', 'B']]
+        tm.assert_frame_equal(res, df.ix[[2, 3], ['A', 'B']])
+
+        res = df.loc[3, lambda x: ['A', 'B']]
+        tm.assert_series_equal(res, df.loc[3, ['A', 'B']])
+
+        res = df.ix[3, lambda x: ['A', 'B']]
+        tm.assert_series_equal(res, df.ix[3, ['A', 'B']])
+
+    def test_frame_loc_callable(self):
+        # GH 11485
+        df = pd.DataFrame({'X': [1, 2, 3, 4],
+                           'Y': list('aabb')},
+                          index=list('ABCD'))
+
+        # return label
+        res = df.loc[lambda x: ['A', 'C']]
+        tm.assert_frame_equal(res, df.loc[['A', 'C']])
+
+        res = df.loc[lambda x: ['A', 'C'], ]
+        tm.assert_frame_equal(res, df.loc[['A', 'C'], ])
+
+        res = df.loc[lambda x: ['A', 'C'], :]
+        tm.assert_frame_equal(res, df.loc[['A', 'C'], :])
+
+        res = df.loc[lambda x: ['A', 'C'], lambda x: 'X']
+        tm.assert_series_equal(res, df.loc[['A', 'C'], 'X'])
+
+        res = df.loc[lambda x: ['A', 'C'], lambda x: ['X']]
+        tm.assert_frame_equal(res, df.loc[['A', 'C'], ['X']])
+
+        # mixture
+        res = df.loc[['A', 'C'], lambda x: 'X']
+        tm.assert_series_equal(res, df.loc[['A', 'C'], 'X'])
+
+        res = df.loc[['A', 'C'], lambda x: ['X']]
+        tm.assert_frame_equal(res, df.loc[['A', 'C'], ['X']])
+
+        res = df.loc[lambda x: ['A', 'C'], 'X']
+        tm.assert_series_equal(res, df.loc[['A', 'C'], 'X'])
+
+        res = df.loc[lambda x: ['A', 'C'], ['X']]
+        tm.assert_frame_equal(res, df.loc[['A', 'C'], ['X']])
+
+    def test_frame_loc_callable_setitem(self):
+        # GH 11485
+        df = pd.DataFrame({'X': [1, 2, 3, 4],
+                           'Y': list('aabb')},
+                          index=list('ABCD'))
+
+        # return label
+        res = df.copy()
+        res.loc[lambda x: ['A', 'C']] = -20
+        exp = df.copy()
+        exp.loc[['A', 'C']] = -20
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.loc[lambda x: ['A', 'C'], :] = 20
+        exp = df.copy()
+        exp.loc[['A', 'C'], :] = 20
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.loc[lambda x: ['A', 'C'], lambda x: 'X'] = -1
+        exp = df.copy()
+        exp.loc[['A', 'C'], 'X'] = -1
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.loc[lambda x: ['A', 'C'], lambda x: ['X']] = [5, 10]
+        exp = df.copy()
+        exp.loc[['A', 'C'], ['X']] = [5, 10]
+        tm.assert_frame_equal(res, exp)
+
+        # mixture
+        res = df.copy()
+        res.loc[['A', 'C'], lambda x: 'X'] = np.array([-1, -2])
+        exp = df.copy()
+        exp.loc[['A', 'C'], 'X'] = np.array([-1, -2])
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.loc[['A', 'C'], lambda x: ['X']] = 10
+        exp = df.copy()
+        exp.loc[['A', 'C'], ['X']] = 10
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.loc[lambda x: ['A', 'C'], 'X'] = -2
+        exp = df.copy()
+        exp.loc[['A', 'C'], 'X'] = -2
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.loc[lambda x: ['A', 'C'], ['X']] = -4
+        exp = df.copy()
+        exp.loc[['A', 'C'], ['X']] = -4
+        tm.assert_frame_equal(res, exp)
+
+    def test_frame_iloc_callable(self):
+        # GH 11485
+        df = pd.DataFrame({'X': [1, 2, 3, 4],
+                           'Y': list('aabb')},
+                          index=list('ABCD'))
+
+        # return location
+        res = df.iloc[lambda x: [1, 3]]
+        tm.assert_frame_equal(res, df.iloc[[1, 3]])
+
+        res = df.iloc[lambda x: [1, 3], :]
+        tm.assert_frame_equal(res, df.iloc[[1, 3], :])
+
+        res = df.iloc[lambda x: [1, 3], lambda x: 0]
+        tm.assert_series_equal(res, df.iloc[[1, 3], 0])
+
+        res = df.iloc[lambda x: [1, 3], lambda x: [0]]
+        tm.assert_frame_equal(res, df.iloc[[1, 3], [0]])
+
+        # mixture
+        res = df.iloc[[1, 3], lambda x: 0]
+        tm.assert_series_equal(res, df.iloc[[1, 3], 0])
+
+        res = df.iloc[[1, 3], lambda x: [0]]
+        tm.assert_frame_equal(res, df.iloc[[1, 3], [0]])
+
+        res = df.iloc[lambda x: [1, 3], 0]
+        tm.assert_series_equal(res, df.iloc[[1, 3], 0])
+
+        res = df.iloc[lambda x: [1, 3], [0]]
+        tm.assert_frame_equal(res, df.iloc[[1, 3], [0]])
+
+    def test_frame_iloc_callable_setitem(self):
+        # GH 11485
+        df = pd.DataFrame({'X': [1, 2, 3, 4],
+                           'Y': list('aabb')},
+                          index=list('ABCD'))
+
+        # return location
+        res = df.copy()
+        res.iloc[lambda x: [1, 3]] = 0
+        exp = df.copy()
+        exp.iloc[[1, 3]] = 0
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.iloc[lambda x: [1, 3], :] = -1
+        exp = df.copy()
+        exp.iloc[[1, 3], :] = -1
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.iloc[lambda x: [1, 3], lambda x: 0] = 5
+        exp = df.copy()
+        exp.iloc[[1, 3], 0] = 5
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.iloc[lambda x: [1, 3], lambda x: [0]] = 25
+        exp = df.copy()
+        exp.iloc[[1, 3], [0]] = 25
+        tm.assert_frame_equal(res, exp)
+
+        # mixture
+        res = df.copy()
+        res.iloc[[1, 3], lambda x: 0] = -3
+        exp = df.copy()
+        exp.iloc[[1, 3], 0] = -3
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.iloc[[1, 3], lambda x: [0]] = -5
+        exp = df.copy()
+        exp.iloc[[1, 3], [0]] = -5
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.iloc[lambda x: [1, 3], 0] = 10
+        exp = df.copy()
+        exp.iloc[[1, 3], 0] = 10
+        tm.assert_frame_equal(res, exp)
+
+        res = df.copy()
+        res.iloc[lambda x: [1, 3], [0]] = [-5, -5]
+        exp = df.copy()
+        exp.iloc[[1, 3], [0]] = [-5, -5]
+        tm.assert_frame_equal(res, exp)
+
+
+if __name__ == '__main__':
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   exit=False)

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -389,6 +389,18 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         df = pd.DataFrame(rng, index=rng)
         self.assertRaises(TypeError, s.__getitem__, df > 5)
 
+    def test_getitem_callable(self):
+        # GH 12533
+        s = pd.Series(4, index=list('ABCD'))
+        result = s[lambda x: 'A']
+        self.assertEqual(result, s.loc['A'])
+
+        result = s[lambda x: ['A', 'B']]
+        tm.assert_series_equal(result, s.loc[['A', 'B']])
+
+        result = s[lambda x: [True, False, True, True]]
+        tm.assert_series_equal(result, s.iloc[[0, 2, 3]])
+
     def test_setitem_ambiguous_keyerror(self):
         s = Series(lrange(10), index=lrange(0, 20, 2))
 
@@ -412,6 +424,12 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         tmp.iloc[2] = 'zoo'
 
         assert_series_equal(s, tmp)
+
+    def test_setitem_callable(self):
+        # GH 12533
+        s = pd.Series([1, 2, 3, 4], index=list('ABCD'))
+        s[lambda x: 'A'] = -1
+        tm.assert_series_equal(s, pd.Series([-1, 2, 3, 4], index=list('ABCD')))
 
     def test_slice(self):
         numSlice = self.series[10:20]

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -713,6 +713,14 @@ class CheckIndexing(object):
         self._check_view((item, NS, 'C'), comp)
         self._check_view((NS, date, 'C'), comp)
 
+    def test_getitem_callable(self):
+        p = self.panel
+        # GH 12533
+
+        assert_frame_equal(p[lambda x: 'ItemB'], p.loc['ItemB'])
+        assert_panel_equal(p[lambda x: ['ItemB', 'ItemC']],
+                           p.loc[['ItemB', 'ItemC']])
+
     def test_ix_setitem_slice_dataframe(self):
         a = Panel(items=[1, 2, 3], major_axis=[11, 22, 33],
                   minor_axis=[111, 222, 333])


### PR DESCRIPTION
- [x] closes #12533
- [x] closes #11485 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Current impl is very simple like `assign`. Another idea is applying some restriction to return value from `callable` (for example, only allow aligned `DataFrame` or scalar).
