### PR TITLE
BLD: Install texlive packages in Travis CI

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -19,7 +19,7 @@ if [ x"$DOC_BUILD" != x"" ]; then
     source activate pandas
     conda install -n pandas -c r r rpy2 --yes
 
-    time sudo apt-get $APT_ARGS install dvipng
+    time sudo apt-get $APT_ARGS install dvipng texlive-latex-base texlive-latex-extra
 
     mv "$TRAVIS_BUILD_DIR"/doc /tmp
     cd /tmp/doc


### PR DESCRIPTION
- Closes #12543
- `texlive-latex-base` needed for `latex`
- `texlive-latex-extra` needed for `utf8x.def`
