### PR TITLE
BUG: SeriesGroupby.nunique raises an IndexError on empty Series #12553

### DIFF
--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2843,6 +2843,10 @@ class SeriesGroupBy(GroupBy):
     def nunique(self, dropna=True):
         """ Returns number of unique elements in the group """
         ids, _, _ = self.grouper.group_info
+
+        if len(ids) == 0:  # bugfix for 12553
+            return Series(name=self.name)
+
         val = self.obj.get_values()
 
         try:

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -6465,6 +6465,14 @@ def test_decons():
     testit(label_list, shape)
 
 
+def test_nunique_empty_Series():
+    series = Series(name='foo')
+    group = series.groupby(level=0)
+    result = group.nunique()
+    expected = Series(name='foo')
+    assert_series_equal(result, expected)
+
+
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure', '-s'
                          ], exit=False)


### PR DESCRIPTION
Closes #12553
xref #13239 
Made a new pull request to clean up from #12557 
