### PR TITLE
BUG: GH12558 where nulls contributed to normalized value_counts

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -43,3 +43,5 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
+
+- Bug in ``value_counts`` when ``normalize=True`` and ``dropna=True`` where nulls still contributed to the normalized count (:issue:`12558`)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -342,7 +342,7 @@ def value_counts(values, sort=True, ascending=False, normalize=False,
         result = result.sort_values(ascending=ascending)
 
     if normalize:
-        result = result / float(values.size)
+        result = result / float(counts.sum())
 
     return result
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -517,6 +517,22 @@ class TestValueCounts(tm.TestCase):
                 pd.Series([10.3, 5., 5., None]).value_counts(dropna=False),
                 pd.Series([2, 1, 1], index=[5., 10.3, np.nan]))
 
+    def test_value_counts_normalized(self):
+        # GH12558
+        s = Series([1, 2, np.nan, np.nan, np.nan])
+        dtypes = (np.float64, np.object, 'M8[ns]')
+        for t in dtypes:
+            s_typed = s.astype(t)
+            result = s_typed.value_counts(normalize=True, dropna=False)
+            expected = Series([0.6, 0.2, 0.2],
+                              index=Series([np.nan, 2.0, 1.0], dtype=t))
+            tm.assert_series_equal(result, expected)
+
+            result = s_typed.value_counts(normalize=True, dropna=True)
+            expected = Series([0.5, 0.5],
+                              index=Series([2.0, 1.0], dtype=t))
+            tm.assert_series_equal(result, expected)
+
 
 class GroupVarTestMixin(object):
 


### PR DESCRIPTION
- [x] closes #12558
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
