### PR TITLE
Fix #12529 / Improve to_clipboard for objects containing unicode

### DIFF
--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -1128,6 +1128,7 @@ Performance Improvements
 Bug Fixes
 ~~~~~~~~~
 
+- Bug in ``to_clipboard`` when called for objects containing unicode without passing an encoding (:issue:`12529`)
 - Bug in ``GroupBy.size`` when data-frame is empty. (:issue:`11699`)
 - Bug in ``Period.end_time`` when a multiple of time period is requested (:issue:`11738`)
 - Regression in ``.clip`` with tz-aware datetimes (:issue:`11838`)

--- a/doc/source/whatsnew/v0.18.0.txt
+++ b/doc/source/whatsnew/v0.18.0.txt
@@ -1128,7 +1128,6 @@ Performance Improvements
 Bug Fixes
 ~~~~~~~~~
 
-- Bug in ``to_clipboard`` when called for objects containing unicode without passing an encoding (:issue:`12529`)
 - Bug in ``GroupBy.size`` when data-frame is empty. (:issue:`11699`)
 - Bug in ``Period.end_time`` when a multiple of time period is requested (:issue:`11738`)
 - Regression in ``.clip`` with tz-aware datetimes (:issue:`11838`)

--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -43,3 +43,5 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
+
+- Bug in ``to_clipboard`` when called for objects containing unicode without passing an encoding (:issue:`12529`)

--- a/pandas/io/clipboard.py
+++ b/pandas/io/clipboard.py
@@ -73,6 +73,9 @@ def to_clipboard(obj, excel=None, sep=None, **kwargs):  # pragma: no cover
       - Linux: xclip, or xsel (with gtk or PyQt4 modules)
       - Windows:
       - OS X:
+      
+    If the object contains unicode and no encoding is passed as keyword 
+    argument, the default locale will be used.
     """
     from pandas.util.clipboard import clipboard_set
     if excel is None:
@@ -84,6 +87,12 @@ def to_clipboard(obj, excel=None, sep=None, **kwargs):  # pragma: no cover
                 sep = '\t'
             buf = StringIO()
             obj.to_csv(buf, sep=sep, **kwargs)
+            clipboard_set(buf.getvalue())
+            return
+        except UnicodeEncodeError:
+            # try again with encoding from locale
+            from locale import getdefaultlocale
+            obj.to_csv(buf, sep=sep, encoding=getdefaultlocale()[1], **kwargs)
             clipboard_set(buf.getvalue())
             return
         except:


### PR DESCRIPTION
Superceded by #14599

---

- [x] closes #12529
- [ ] tests added / passed
- [ ] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

I added the whatsnew entry to 0.18.0.
