### PR TITLE
DOC: Remove Panel.to_json from docs. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,5 @@ doc/source/vbench
 doc/source/vbench.rst
 doc/source/index.rst
 doc/build/html/index.html
-doc/builddir/
 # Windows specific leftover:
 doc/tmp.sv

--- a/.gitignore
+++ b/.gitignore
@@ -92,5 +92,6 @@ doc/source/vbench
 doc/source/vbench.rst
 doc/source/index.rst
 doc/build/html/index.html
+doc/builddir/
 # Windows specific leftover:
 doc/tmp.sv

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1215,7 +1215,6 @@ Serialization / IO / Conversion
    Panel.to_pickle
    Panel.to_excel
    Panel.to_hdf
-   Panel.to_json
    Panel.to_sparse
    Panel.to_frame
    Panel.to_xarray


### PR DESCRIPTION
- [DOC] closes #12571
  - removed Panel.to_json from docs, as it is not yet implemented. 
