### PR TITLE
DOC: Fixes LaTeX build error

### DIFF
--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -414,6 +414,8 @@ class Resampler(_GroupBy):
 
     def fillna(self, method, limit=None):
         """
+        Fill missing values
+
         Parameters
         ----------
         method : str, method of resampling ('ffill', 'bfill')


### PR DESCRIPTION
The PDF doc build was chocking on the `Parameters` section being the first item.
