### PR TITLE
fixes print syntax error in documentation

### DIFF
--- a/doc/source/comparison_with_r.rst
+++ b/doc/source/comparison_with_r.rst
@@ -295,7 +295,7 @@ In ``pandas`` the equivalent expression, using the
    })
 
    grouped = df.groupby(['month','week'])
-   print grouped['x'].agg([np.mean, np.std])
+   print(grouped['x'].agg([np.mean, np.std]))
 
 
 For more details and examples see :ref:`the groupby documentation


### PR DESCRIPTION
fixes the syntax error in the "comparison with R" docs
