### PR TITLE
BUG: Matched Round Signature with NumPy's

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -90,6 +90,7 @@ Performance Improvements
 Bug Fixes
 ~~~~~~~~~
 
+- ``round`` now accepts an ``out`` argument to maintain compatibility with numpy's ``round`` function (:issue:`12600`)
 - Bug in ``Period`` and ``PeriodIndex`` creation raises ``KeyError`` if ``freq="Minute"`` is specified. Note that "Minute" freq is deprecated in v0.17.0, and recommended to use ``freq="T"`` instead (:issue:`11854`)
 - Bug in printing data which contains ``Period`` with different ``freq`` raises ``ValueError`` (:issue:`12615`)
 - Bug in ``Series`` construction with ``Categorical`` and ``dtype='category'`` is specified (:issue:`12574`)
@@ -118,7 +119,20 @@ Bug Fixes
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
 - Bug in ``CategoricalIndex.get_loc`` returns different result from regular ``Index`` (:issue:`12531`)
+
 
 
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -46,6 +46,7 @@ from pandas.compat import (range, map, zip, lrange, lmap, lzip, StringIO, u,
 from pandas import compat
 from pandas.util.decorators import (deprecate, Appender, Substitution,
                                     deprecate_kwarg)
+from pandas.util.validators import validate_args
 
 from pandas.tseries.period import PeriodIndex
 from pandas.tseries.index import DatetimeIndex
@@ -4420,7 +4421,7 @@ class DataFrame(NDFrame):
                      right_index=right_index, sort=sort, suffixes=suffixes,
                      copy=copy, indicator=indicator)
 
-    def round(self, decimals=0, out=None):
+    def round(self, decimals=0, *args):
         """
         Round a DataFrame to a variable number of decimal places.
 
@@ -4471,6 +4472,8 @@ class DataFrame(NDFrame):
         See Also
         --------
         numpy.around
+        Series.round
+
         """
         from pandas.tools.merge import concat
 
@@ -4485,6 +4488,9 @@ class DataFrame(NDFrame):
             if com.is_integer_dtype(s) or com.is_float_dtype(s):
                 return s.round(decimals)
             return s
+
+        validate_args(args, min_length=0, max_length=1,
+                      msg="Inplace rounding is not supported")
 
         if isinstance(decimals, (dict, Series)):
             if isinstance(decimals, Series):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -28,6 +28,7 @@ from pandas.core.common import (isnull, notnull, is_list_like,
                                 AbstractMethodError)
 import pandas.core.nanops as nanops
 from pandas.util.decorators import Appender, Substitution, deprecate_kwarg
+from pandas.util.validators import validate_kwargs
 from pandas.core import config
 
 # goal is to be able to define the docs close to function, while still being
@@ -5231,29 +5232,13 @@ Returns
 %(outname)s : %(name1)s\n"""
 
 
-def _validate_kwargs(fname, kwargs, *compat_args):
-    """
-    Checks whether parameters passed to the
-    **kwargs argument in a 'stat' function 'fname'
-    are valid parameters as specified in *compat_args
-
-    """
-    list(map(kwargs.__delitem__, filter(
-        kwargs.__contains__, compat_args)))
-    if kwargs:
-        bad_arg = list(kwargs)[0]  # first 'key' element
-        raise TypeError(("{fname}() got an unexpected "
-                         "keyword argument '{arg}'".
-                         format(fname=fname, arg=bad_arg)))
-
-
 def _make_stat_function(name, name1, name2, axis_descr, desc, f):
     @Substitution(outname=name, desc=desc, name1=name1, name2=name2,
                   axis_descr=axis_descr)
     @Appender(_num_doc)
     def stat_func(self, axis=None, skipna=None, level=None, numeric_only=None,
                   **kwargs):
-        _validate_kwargs(name, kwargs, 'out', 'dtype')
+        validate_kwargs(name, kwargs, 'out', 'dtype')
         if skipna is None:
             skipna = True
         if axis is None:
@@ -5274,7 +5259,7 @@ def _make_stat_function_ddof(name, name1, name2, axis_descr, desc, f):
     @Appender(_num_ddof_doc)
     def stat_func(self, axis=None, skipna=None, level=None, ddof=1,
                   numeric_only=None, **kwargs):
-        _validate_kwargs(name, kwargs, 'out', 'dtype')
+        validate_kwargs(name, kwargs, 'out', 'dtype')
         if skipna is None:
             skipna = True
         if axis is None:
@@ -5296,7 +5281,7 @@ def _make_cum_function(name, name1, name2, axis_descr, desc, accum_func,
     @Appender("Return cumulative {0} over requested axis.".format(name) +
               _cnum_doc)
     def func(self, axis=None, dtype=None, out=None, skipna=True, **kwargs):
-        _validate_kwargs(name, kwargs, 'out', 'dtype')
+        validate_kwargs(name, kwargs, 'out', 'dtype')
         if axis is None:
             axis = self._stat_axis_number
         else:
@@ -5331,7 +5316,7 @@ def _make_logical_function(name, name1, name2, axis_descr, desc, f):
     @Appender(_bool_doc)
     def logical_func(self, axis=None, bool_only=None, skipna=None, level=None,
                      **kwargs):
-        _validate_kwargs(name, kwargs, 'out', 'dtype')
+        validate_kwargs(name, kwargs, 'out', 'dtype')
         if skipna is None:
             skipna = True
         if axis is None:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -39,6 +39,7 @@ from pandas.tseries.tdi import TimedeltaIndex
 from pandas.tseries.period import PeriodIndex, Period
 from pandas import compat
 from pandas.util.terminal import get_terminal_size
+from pandas.util.validators import validate_args
 from pandas.compat import zip, u, OrderedDict, StringIO
 
 
@@ -1256,7 +1257,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
     argmin = idxmin
     argmax = idxmax
 
-    def round(self, decimals=0):
+    def round(self, decimals=0, *args):
         """
         Round each value in a Series to the given number of decimals.
 
@@ -1274,8 +1275,12 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         See Also
         --------
         numpy.around
+        DataFrame.round
 
         """
+        validate_args(args, min_length=0, max_length=1,
+                      msg="Inplace rounding is not supported")
+
         result = _values_from_object(self).round(decimals)
         result = self._constructor(result, index=self.index).__finalize__(self)
 

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -2060,6 +2060,17 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         assert_series_equal(df.round(decimals)['col1'],
                             expected_rounded['col1'])
 
+    def test_numpy_round(self):
+        # See gh-12600
+        df = DataFrame([[1.53, 1.36], [0.06, 7.01]])
+        out = np.round(df, decimals=0)
+        expected = DataFrame([[2., 1.], [0., 7.]])
+        assert_frame_equal(out, expected)
+
+        msg = "Inplace rounding is not supported"
+        with tm.assertRaisesRegexp(ValueError, msg):
+            np.round(df, decimals=0, out=df)
+
     def test_round_mixed_type(self):
         # GH11885
         df = DataFrame({'col1': [1.1, 2.2, 3.3, 4.4],

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -511,6 +511,17 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         assert_series_equal(result, expected)
         self.assertEqual(result.name, self.ts.name)
 
+    def test_numpy_round(self):
+        # See gh-12600
+        s = Series([1.53, 1.36, 0.06])
+        out = np.round(s, decimals=0)
+        expected = Series([2., 1., 0.])
+        assert_series_equal(out, expected)
+
+        msg = "Inplace rounding is not supported"
+        with tm.assertRaisesRegexp(ValueError, msg):
+            np.round(s, decimals=0, out=s)
+
     def test_built_in_round(self):
         if not compat.PY3:
             raise nose.SkipTest(

--- a/pandas/util/validators.py
+++ b/pandas/util/validators.py
@@ -1,0 +1,97 @@
+"""
+Module that contains many useful utilities
+for validating data or function arguments
+"""
+
+
+def validate_args(args, min_length=0, max_length=None, msg=""):
+    """
+    Checks whether the length of the `*args` argument passed into a function
+    has at least `min_length` arguments. If `max_length` is an integer, checks
+    whether `*args` has at most `max_length` arguments inclusive. Raises a
+    ValueError if any of the aforementioned conditions are False.
+
+    Parameters
+    ----------
+    args: tuple
+        The `*args` parameter passed into a function
+
+    min_length: int, optional
+        The minimum number of arguments that should be contained in the `args`.
+        tuple. This number must be non-negative. The default is '0'.
+
+    max_length: int, optional
+        If not `None`, the maximum number of arguments that should be contained
+        in the `args` parameter. This number must be at least as large as the
+        provided `min_length` value. The default is None.
+
+    msg: str, optional
+        Error message to display when a custom check of args fails. For
+        example, pandas does not support a non-None argument for `out`
+        when rounding a `Series` or `DataFrame` object. `msg` in this
+        case can be "Inplace rounding is not supported".
+
+    Raises
+    ------
+    ValueError if `args` fails to have a length that is at least `min_length`
+    and at most `max_length` inclusive (provided `max_length` is not None)
+
+    """
+    length = len(args)
+
+    if min_length < 0:
+        raise ValueError("'min_length' must be non-negative")
+
+    if max_length is None:
+        if length < min_length:
+            raise ValueError(("expected at least {min_length} arguments "
+                              "but got {length} arguments instead".
+                              format(min_length=min_length, length=length)))
+
+    if min_length > max_length:
+        raise ValueError("'min_length' > 'max_length'")
+
+    if (length < min_length) or (length > max_length):
+        raise ValueError(("expected between {min_length} and {max_length} "
+                          "arguments inclusive but got {length} arguments "
+                          "instead".format(min_length=min_length,
+                                           length=length,
+                                           max_length=max_length)))
+
+    # See gh-12600; this is to allow compatibility with NumPy,
+    # which passes in an 'out' parameter as a positional argument
+    if args:
+        args = list(filter(lambda elt: elt is not None, args))
+
+        if args:
+            raise ValueError(msg)
+
+
+def validate_kwargs(fname, kwargs, *compat_args):
+    """
+    Checks whether parameters passed to the **kwargs argument in a
+    function 'fname' are valid parameters as specified in *compat_args
+
+    Parameters
+    ----------
+    fname: str
+        The name of the function being passed the `**kwargs` parameter
+
+    kwargs: dict
+        The `**kwargs` parameter passed into `fname`
+
+    compat_args: *args
+        A tuple of keys that `kwargs` is allowed to have
+
+    Raises
+    ------
+    ValueError if `kwargs` contains keys not in `compat_args`
+
+    """
+    list(map(kwargs.__delitem__, filter(
+        kwargs.__contains__, compat_args)))
+    if kwargs:
+        bad_arg = list(kwargs)[0]  # first 'key' element
+        raise TypeError(("{fname}() got an unexpected "
+                         "keyword argument '{arg}'".
+                         format(fname=fname, arg=bad_arg)))


### PR DESCRIPTION
Closes #12600 by re-accepting the `out` parameter as a `**kwargs` argument.  Also removes the `out` parameter from the signature for `DataFrame.round` and replaces it with `**kwargs` like its `Series` counterpart.  Furthermore, since `out` is a parameter that is not supported in `pandas`, checks that `out` is `None` and throws an error if it isn't.
