### PR TITLE
BUG: Mixed period cannot be displayed with ValueError

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -44,7 +44,7 @@ Enhancements
 API changes
 ~~~~~~~~~~~
 
-
+- ``Period`` and ``PeriodIndex`` now raises ``IncompatibleFrequency`` error which inherits ``ValueError`` rather than raw ``ValueError`` (:issue:`12615`)
 
 
 
@@ -130,5 +130,6 @@ Bug Fixes
 
 
 
-
 - Bug in ``pivot_table`` when ``margins=True`` and ``dropna=True`` where nulls still contributed to margin count (:issue:`12577`)
+- Bug in printing data which contains ``Period`` with different ``freq`` raises ``ValueError`` (:issue:`12615`)
+

--- a/pandas/core/format.py
+++ b/pandas/core/format.py
@@ -2235,7 +2235,13 @@ class Datetime64Formatter(GenericArrayFormatter):
 
 class PeriodArrayFormatter(IntArrayFormatter):
     def _format_strings(self):
-        values = PeriodIndex(self.values).to_native_types()
+        from pandas.tseries.period import IncompatibleFrequency
+        try:
+            values = PeriodIndex(self.values).to_native_types()
+        except IncompatibleFrequency:
+            # periods may contains different freq
+            values = Index(self.values, dtype='object').to_native_types()
+
         formatter = self.formatter or (lambda x: '%s' % x)
         fmt_values = [formatter(x) for x in values]
         return fmt_values

--- a/pandas/src/period.pyx
+++ b/pandas/src/period.pyx
@@ -452,7 +452,8 @@ def extract_ordinals(ndarray[object] values, freq):
         p = values[i]
         ordinals[i] = p.ordinal
         if p.freqstr != freqstr:
-            raise ValueError(_DIFFERENT_FREQ_INDEX.format(freqstr, p.freqstr))
+            msg = _DIFFERENT_FREQ_INDEX.format(freqstr, p.freqstr)
+            raise IncompatibleFrequency(msg)
 
     return ordinals
 
@@ -627,6 +628,11 @@ cdef ndarray[int64_t] localize_dt64arr_to_period(ndarray[int64_t] stamps,
 _DIFFERENT_FREQ = "Input has different freq={1} from Period(freq={0})"
 _DIFFERENT_FREQ_INDEX = "Input has different freq={1} from PeriodIndex(freq={0})"
 
+
+class IncompatibleFrequency(ValueError):
+    pass
+
+
 cdef class Period(object):
     """
     Represents an period of time
@@ -768,7 +774,7 @@ cdef class Period(object):
             from pandas.tseries.frequencies import get_freq_code as _gfc
             if other.freq != self.freq:
                 msg = _DIFFERENT_FREQ.format(self.freqstr, other.freqstr)
-                raise ValueError(msg)
+                raise IncompatibleFrequency(msg)
             if self.ordinal == tslib.iNaT or other.ordinal == tslib.iNaT:
                 return _nat_scalar_rules[op]
             return PyObject_RichCompareBool(self.ordinal, other.ordinal, op)
@@ -809,7 +815,7 @@ cdef class Period(object):
                     ordinal = self.ordinal + other.n
                 return Period(ordinal=ordinal, freq=self.freq)
             msg = _DIFFERENT_FREQ.format(self.freqstr, other.freqstr)
-            raise ValueError(msg)
+            raise IncompatibleFrequency(msg)
         else: # pragma no cover
             return NotImplemented
 

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -3151,6 +3151,20 @@ $1$,$2$
             df = DataFrame({'col1': [1], 'col2': ['a'], 'col3': [10.1]})
             df.to_csv(engine='python')
 
+    def test_period(self):
+        # GH 12615
+        df = pd.DataFrame({'A': pd.period_range('2013-01',
+                                                periods=4, freq='M'),
+                           'B': [pd.Period('2011-01', freq='M'),
+                                 pd.Period('2011-02-01', freq='D'),
+                                 pd.Period('2011-03-01 09:00', freq='H'),
+                                 pd.Period('2011-04', freq='M')],
+                           'C': list('abcd')})
+        exp = ("        A                B  C\n0 2013-01          2011-01  a\n"
+               "1 2013-02       2011-02-01  b\n2 2013-03 2011-03-01 09:00  c\n"
+               "3 2013-04          2011-04  d")
+        self.assertEqual(str(df), exp)
+
 
 class TestSeriesFormatting(tm.TestCase):
     _multiprocess_can_split_ = True
@@ -3480,6 +3494,27 @@ class TestSeriesFormatting(tm.TestCase):
 
         result = repr(df.ix[0])
         self.assertTrue('2012-01-01' in result)
+
+    def test_period(self):
+        # GH 12615
+        index = pd.period_range('2013-01', periods=6, freq='M')
+        s = Series(np.arange(6), index=index)
+        exp = ("2013-01    0\n2013-02    1\n2013-03    2\n2013-04    3\n"
+               "2013-05    4\n2013-06    5\nFreq: M, dtype: int64")
+        self.assertEqual(str(s), exp)
+
+        s = Series(index)
+        exp = ("0   2013-01\n1   2013-02\n2   2013-03\n3   2013-04\n"
+               "4   2013-05\n5   2013-06\ndtype: object")
+        self.assertEqual(str(s), exp)
+
+        # periods with mixed freq
+        s = Series([pd.Period('2011-01', freq='M'),
+                    pd.Period('2011-02-01', freq='D'),
+                    pd.Period('2011-03-01 09:00', freq='H')])
+        exp = ("0            2011-01\n1         2011-02-01\n"
+               "2   2011-03-01 09:00\ndtype: object")
+        self.assertEqual(str(s), exp)
 
     def test_max_multi_index_display(self):
         # GH 7101

--- a/pandas/tseries/common.py
+++ b/pandas/tseries/common.py
@@ -6,6 +6,7 @@ import numpy as np
 from pandas.core.base import PandasDelegate, NoNewAttributesMixin
 from pandas.core import common as com
 from pandas.tseries.index import DatetimeIndex
+from pandas._period import IncompatibleFrequency    # flake8: noqa
 from pandas.tseries.period import PeriodIndex
 from pandas.tseries.tdi import TimedeltaIndex
 from pandas import tslib

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -6,6 +6,7 @@ from pandas import (Series, Index, Int64Index, Timestamp, DatetimeIndex,
                     PeriodIndex, TimedeltaIndex, Timedelta, timedelta_range,
                     date_range, Float64Index)
 import pandas.tslib as tslib
+import pandas.tseries.period as period
 
 import pandas.util.testing as tm
 
@@ -1617,9 +1618,9 @@ Freq: Q-DEC"""
         for o in [pd.offsets.YearBegin(2), pd.offsets.MonthBegin(1),
                   pd.offsets.Minute(), np.timedelta64(365, 'D'),
                   timedelta(365), Timedelta(days=365)]:
-            msg = 'Input has different freq from PeriodIndex\\(freq=A-DEC\\)'
-            with tm.assertRaisesRegexp(ValueError,
-                                       'Input has different freq from Period'):
+            msg = ('Input has different freq(=.+)? '
+                   'from PeriodIndex\\(freq=A-DEC\\)')
+            with tm.assertRaisesRegexp(period.IncompatibleFrequency, msg):
                 rng + o
 
         rng = pd.period_range('2014-01', '2016-12', freq='M')
@@ -1633,8 +1634,8 @@ Freq: Q-DEC"""
                   pd.offsets.Minute(), np.timedelta64(365, 'D'),
                   timedelta(365), Timedelta(days=365)]:
             rng = pd.period_range('2014-01', '2016-12', freq='M')
-            msg = 'Input has different freq from PeriodIndex\\(freq=M\\)'
-            with tm.assertRaisesRegexp(ValueError, msg):
+            msg = 'Input has different freq(=.+)? from PeriodIndex\\(freq=M\\)'
+            with tm.assertRaisesRegexp(period.IncompatibleFrequency, msg):
                 rng + o
 
         # Tick
@@ -1654,8 +1655,8 @@ Freq: Q-DEC"""
                   pd.offsets.Minute(), np.timedelta64(4, 'h'),
                   timedelta(hours=23), Timedelta('23:00:00')]:
             rng = pd.period_range('2014-05-01', '2014-05-15', freq='D')
-            msg = 'Input has different freq from PeriodIndex\\(freq=D\\)'
-            with tm.assertRaisesRegexp(ValueError, msg):
+            msg = 'Input has different freq(=.+)? from PeriodIndex\\(freq=D\\)'
+            with tm.assertRaisesRegexp(period.IncompatibleFrequency, msg):
                 rng + o
 
         offsets = [pd.offsets.Hour(2), timedelta(hours=2),
@@ -1676,10 +1677,10 @@ Freq: Q-DEC"""
                       np.timedelta64(30, 's'), Timedelta(seconds=30)]:
             rng = pd.period_range('2014-01-01 10:00', '2014-01-05 10:00',
                                   freq='H')
-            msg = 'Input has different freq from PeriodIndex\\(freq=H\\)'
-            with tm.assertRaisesRegexp(ValueError, msg):
+            msg = 'Input has different freq(=.+)? from PeriodIndex\\(freq=H\\)'
+            with tm.assertRaisesRegexp(period.IncompatibleFrequency, msg):
                 result = rng + delta
-            with tm.assertRaisesRegexp(ValueError, msg):
+            with tm.assertRaisesRegexp(period.IncompatibleFrequency, msg):
                 rng += delta
 
         # int
@@ -1745,8 +1746,9 @@ Freq: Q-DEC"""
                   pd.offsets.Minute(), np.timedelta64(365, 'D'),
                   timedelta(365)]:
             rng = pd.period_range('2014', '2024', freq='A')
-            msg = 'Input has different freq from PeriodIndex\\(freq=A-DEC\\)'
-            with tm.assertRaisesRegexp(ValueError, msg):
+            msg = ('Input has different freq(=.+)? '
+                   'from PeriodIndex\\(freq=A-DEC\\)')
+            with tm.assertRaisesRegexp(period.IncompatibleFrequency, msg):
                 rng - o
 
         rng = pd.period_range('2014-01', '2016-12', freq='M')
@@ -1760,8 +1762,8 @@ Freq: Q-DEC"""
                   pd.offsets.Minute(), np.timedelta64(365, 'D'),
                   timedelta(365)]:
             rng = pd.period_range('2014-01', '2016-12', freq='M')
-            msg = 'Input has different freq from PeriodIndex\\(freq=M\\)'
-            with tm.assertRaisesRegexp(ValueError, msg):
+            msg = 'Input has different freq(=.+)? from PeriodIndex\\(freq=M\\)'
+            with tm.assertRaisesRegexp(period.IncompatibleFrequency, msg):
                 rng - o
 
         # Tick
@@ -1780,8 +1782,8 @@ Freq: Q-DEC"""
                   pd.offsets.Minute(), np.timedelta64(4, 'h'),
                   timedelta(hours=23)]:
             rng = pd.period_range('2014-05-01', '2014-05-15', freq='D')
-            msg = 'Input has different freq from PeriodIndex\\(freq=D\\)'
-            with tm.assertRaisesRegexp(ValueError, msg):
+            msg = 'Input has different freq(=.+)? from PeriodIndex\\(freq=D\\)'
+            with tm.assertRaisesRegexp(period.IncompatibleFrequency, msg):
                 rng - o
 
         offsets = [pd.offsets.Hour(2), timedelta(hours=2),
@@ -1801,10 +1803,10 @@ Freq: Q-DEC"""
                       np.timedelta64(30, 's')]:
             rng = pd.period_range('2014-01-01 10:00', '2014-01-05 10:00',
                                   freq='H')
-            msg = 'Input has different freq from PeriodIndex\\(freq=H\\)'
-            with tm.assertRaisesRegexp(ValueError, msg):
+            msg = 'Input has different freq(=.+)? from PeriodIndex\\(freq=H\\)'
+            with tm.assertRaisesRegexp(period.IncompatibleFrequency, msg):
                 result = rng + delta
-            with tm.assertRaisesRegexp(ValueError, msg):
+            with tm.assertRaisesRegexp(period.IncompatibleFrequency, msg):
                 rng += delta
 
         # int

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -2886,12 +2886,16 @@ class TestPeriodIndex(tm.TestCase):
         # raise if different frequencies
         index = period_range('1/1/2000', '1/20/2000', freq='D')
         index2 = period_range('1/1/2000', '1/20/2000', freq='W-WED')
-        self.assertRaises(ValueError, index.union, index2)
+        with tm.assertRaises(period.IncompatibleFrequency):
+            index.union(index2)
 
-        self.assertRaises(ValueError, index.join, index.to_timestamp())
+        msg = 'can only call with other PeriodIndex-ed objects'
+        with tm.assertRaisesRegexp(ValueError, msg):
+            index.join(index.to_timestamp())
 
         index3 = period_range('1/1/2000', '1/20/2000', freq='2D')
-        self.assertRaises(ValueError, index.join, index3)
+        with tm.assertRaises(period.IncompatibleFrequency):
+            index.join(index3)
 
     def test_union_dataframe_index(self):
         rng1 = pd.period_range('1/1/1999', '1/1/2012', freq='M')
@@ -2919,10 +2923,12 @@ class TestPeriodIndex(tm.TestCase):
         # raise if different frequencies
         index = period_range('1/1/2000', '1/20/2000', freq='D')
         index2 = period_range('1/1/2000', '1/20/2000', freq='W-WED')
-        self.assertRaises(ValueError, index.intersection, index2)
+        with tm.assertRaises(period.IncompatibleFrequency):
+            index.intersection(index2)
 
         index3 = period_range('1/1/2000', '1/20/2000', freq='2D')
-        self.assertRaises(ValueError, index.intersection, index3)
+        with tm.assertRaises(period.IncompatibleFrequency):
+            index.intersection(index3)
 
     def test_intersection_cases(self):
         base = period_range('6/1/2000', '6/30/2000', freq='D', name='idx')
@@ -3213,11 +3219,11 @@ class TestPeriodIndex(tm.TestCase):
             self.assertEqual(pidx.searchsorted(p2), 3)
 
             msg = "Input has different freq=H from PeriodIndex"
-            with self.assertRaisesRegexp(ValueError, msg):
+            with self.assertRaisesRegexp(period.IncompatibleFrequency, msg):
                 pidx.searchsorted(pd.Period('2014-01-01', freq='H'))
 
             msg = "Input has different freq=5D from PeriodIndex"
-            with self.assertRaisesRegexp(ValueError, msg):
+            with self.assertRaisesRegexp(period.IncompatibleFrequency, msg):
                 pidx.searchsorted(pd.Period('2014-01-01', freq='5D'))
 
     def test_round_trip(self):
@@ -3535,7 +3541,7 @@ class TestMethods(tm.TestCase):
 
         # incompatible freq
         msg = "Input has different freq from PeriodIndex\(freq=M\)"
-        with tm.assertRaisesRegexp(ValueError, msg):
+        with tm.assertRaisesRegexp(period.IncompatibleFrequency, msg):
             idx + np.array([np.timedelta64(1, 'D')] * 4)
 
         idx = PeriodIndex(['2011-01-01 09:00', '2011-01-01 10:00', 'NaT',
@@ -3551,7 +3557,7 @@ class TestMethods(tm.TestCase):
         self.assert_index_equal(result, exp)
 
         msg = "Input has different freq from PeriodIndex\(freq=H\)"
-        with tm.assertRaisesRegexp(ValueError, msg):
+        with tm.assertRaisesRegexp(period.IncompatibleFrequency, msg):
             idx + np.array([np.timedelta64(1, 's')] * 4)
 
         idx = PeriodIndex(['2011-01-01 09:00:00', '2011-01-01 10:00:00', 'NaT',
@@ -3754,7 +3760,7 @@ class TestComparisons(tm.TestCase):
 
             # different base freq
             msg = "Input has different freq=A-DEC from PeriodIndex"
-            with tm.assertRaisesRegexp(ValueError, msg):
+            with tm.assertRaisesRegexp(period.IncompatibleFrequency, msg):
                 base <= Period('2011', freq='A')
 
             with tm.assertRaisesRegexp(ValueError, msg):
@@ -3763,10 +3769,10 @@ class TestComparisons(tm.TestCase):
 
             # different mult
             msg = "Input has different freq=4M from PeriodIndex"
-            with tm.assertRaisesRegexp(ValueError, msg):
+            with tm.assertRaisesRegexp(period.IncompatibleFrequency, msg):
                 base <= Period('2011', freq='4M')
 
-            with tm.assertRaisesRegexp(ValueError, msg):
+            with tm.assertRaisesRegexp(period.IncompatibleFrequency, msg):
                 idx = PeriodIndex(['2011', '2012', '2013', '2014'], freq='4M')
                 base <= idx
 
@@ -3812,9 +3818,9 @@ class TestComparisons(tm.TestCase):
             diff = PeriodIndex(
                 ['2011-02', '2011-01', '2011-04', 'NaT'], freq='4M')
             msg = "Input has different freq=4M from PeriodIndex"
-            with tm.assertRaisesRegexp(ValueError, msg):
+            with tm.assertRaisesRegexp(period.IncompatibleFrequency, msg):
                 idx1 > diff
-            with tm.assertRaisesRegexp(ValueError, msg):
+            with tm.assertRaisesRegexp(period.IncompatibleFrequency, msg):
                 idx1 == diff
 
 


### PR DESCRIPTION
- [x] closes #xxxx (not reported)
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

```
# we can create Series contains Periods with mixed freq
s = pd.Series([pd.Period('2011-01', freq='M'), pd.Period('2011-02-01', freq='D')])

# print the created Series raises ValueError
print(s)
# ValueError: Input has different freq=D from PeriodIndex(freq=M)
```
