### PR TITLE
TST: Holiday tests/docs

### DIFF
--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -23,7 +23,7 @@ def next_monday(dt):
 def next_monday_or_tuesday(dt):
     """
     For second holiday of two adjacent ones!
-    1. The first holiday falls on Thursday, the second on Saturday. The one
+    1. The first holiday falls on Friday, the second on Saturday. The one
        on Saturday moves to next Monday
     2. The first holiday falls on Saturday, the second on Sunday. The first one
        moves to next Monday and the second one moves to Tuesday.

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -23,15 +23,16 @@ def next_monday(dt):
 def next_monday_or_tuesday(dt):
     """
     For second holiday of two adjacent ones!
-    If holiday falls on Saturday, use following Monday instead;
-    if holiday falls on Sunday or Monday, use following Tuesday instead
-    (because Monday is already taken by adjacent holiday on the day before)
+    1. The first holiday falls on Thursday, the second on Saturday. The one
+       on Saturday moves to next Monday
+    2. The first holiday falls on Saturday, the second on Sunday. The first one
+       moves to next Monday and the second one moves to Tuesday.
+    3. The first holiday falls on Sunday and the second on Monday. The first
+       one moves to Tuesday.
     """
     dow = dt.weekday()
     if dow == 5 or dow == 6:
         return dt + timedelta(2)
-    elif dow == 0:
-        return dt + timedelta(1)
     return dt
 
 


### PR DESCRIPTION
```
>>> from pandas.tseries.holiday import next_monday_or_tuesday
>>> from pandas.tseries.holiday import AbstractHolidayCalendar
>>>from pandas.tseries.holiday import Holiday
>>>class WrongBoxingDay(AbstractHolidayCalendar):
           rules = [
               Holiday('xmas', month=12, day=25, observance=next_monday_or_tuesday),
               Holiday('boxing day', month=12, day=26, observance=next_monday_or_tuesday),
               ]
>>>import pandas as pd
>>>cal = WrongBoxingDay()
>>>cal.holidays(pd.datetime(2016,12,1), pd.datetime(2016,12,31))
DatetimeIndex(['2016-12-27', '2016-12-27'], dtype='datetime64[ns]', freq=None, tz=None)
```

The next_monday_or_tuesday function in holiday module isn't doing what it is supposed to do.
In the example above, xmas should move to Dec 27 while boxing day should stay on Dec 26, but it was also moved to Dec 27.

This bug still exits in the latest version.

How my commit works is explained in the docstring of the function.
