### PR TITLE
BUG: GH12622 where pprint of Timestamp in nested structure fails

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -143,3 +143,5 @@ Bug Fixes
 
 
 - Bug in ``pivot_table`` when ``margins=True`` and ``dropna=True`` where nulls still contributed to margin count (:issue:`12577`)
+
+- Bug in ``Timestamp.__repr__`` that caused ``pprint`` to fail in nested structures (:issue:`12622`)

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -453,6 +453,25 @@ class TestTimestamp(tm.TestCase):
         self.assertTrue(np.isnan(ts.daysinmonth))
         self.assertTrue(np.isnan(ts.days_in_month))
 
+    def test_pprint(self):
+        # GH12622
+        import pprint
+        nested_obj = {'foo': 1,
+                      'bar': [{'w': {'a': Timestamp('2011-01-01')}}] * 10}
+        result = pprint.pformat(nested_obj, width=50)
+        expected = r'''{'bar': [{'w': {'a': Timestamp('2011-01-01 00:00:00')}},
+         {'w': {'a': Timestamp('2011-01-01 00:00:00')}},
+         {'w': {'a': Timestamp('2011-01-01 00:00:00')}},
+         {'w': {'a': Timestamp('2011-01-01 00:00:00')}},
+         {'w': {'a': Timestamp('2011-01-01 00:00:00')}},
+         {'w': {'a': Timestamp('2011-01-01 00:00:00')}},
+         {'w': {'a': Timestamp('2011-01-01 00:00:00')}},
+         {'w': {'a': Timestamp('2011-01-01 00:00:00')}},
+         {'w': {'a': Timestamp('2011-01-01 00:00:00')}},
+         {'w': {'a': Timestamp('2011-01-01 00:00:00')}}],
+ 'foo': 1}'''
+        self.assertEqual(result, expected)
+
 
 class TestDatetimeParsingWrappers(tm.TestCase):
     def test_does_not_convert_mixed_integer(self):


### PR DESCRIPTION
- [x] closes #12622
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

I suspect this is a bug in Cython (I don't think `type(A).func` should be an `instancemethod`).  Not sure if we should use this workaround as we encounter issues in the wild, or do this for all the functions we can think of.
