### PR TITLE
BUG: #12624 where Panel.fillna() ignores inplace=True

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -89,3 +89,5 @@ Bug Fixes
 ~~~~~~~~~
 
 - Bug in ``value_counts`` when ``normalize=True`` and ``dropna=True`` where nulls still contributed to the normalized count (:issue:`12558`)
+
+- Bug in ``Panel.fillna`` was ignoring the ``inplace=True`` option. (:issue:`12624`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3122,7 +3122,8 @@ class NDFrame(PandasObject):
             elif self.ndim == 3:
 
                 # fill in 2d chunks
-                result = dict([(col, s.fillna(method=method, value=value))
+                result = dict([(col, s.fillna(method=method, value=value,
+                                              inplace=inplace))
                                for col, s in self.iteritems()])
                 return self._constructor.from_dict(result).__finalize__(self)
 

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1528,6 +1528,12 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
         p.iloc[0:2, 0:2, 0:2] = np.nan
         self.assertRaises(NotImplementedError, lambda: p.fillna(999, limit=1))
 
+    def test_fillna_inplace(self):
+        panel = self.panel.copy()
+        panel.fillna(method='backfill', inplace=True)
+        assert_frame_equal(panel['ItemA'],
+                           self.panel['ItemA'].fillna(method='backfill'))
+
     def test_ffill_bfill(self):
         assert_panel_equal(self.panel.ffill(),
                            self.panel.fillna(method='ffill'))


### PR DESCRIPTION
- [x] closes #12624 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Fixes #12624

Author: Pedro M Duarte pmd323@gmail.com
