### PR TITLE
BUG: Concat with tz-aware and timedelta raises AttributeError

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -125,10 +125,13 @@ Bug Fixes
 
 
 
-
+- Bug in ``concat`` raises ``AttributeError`` when input data contains tz-aware datetime and timedelta (:issue:`12620`)
 
 
 
 
 
 - Bug in ``pivot_table`` when ``margins=True`` and ``dropna=True`` where nulls still contributed to margin count (:issue:`12577`)
+
+
+

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -2713,7 +2713,7 @@ def _concat_compat(to_concat, axis=0):
     # these are mandated to handle empties as well
     if 'datetime' in typs or 'datetimetz' in typs or 'timedelta' in typs:
         from pandas.tseries.common import _concat_compat
-        return _concat_compat(to_concat, axis=axis)
+        return _concat_compat(to_concat, axis=axis, typs=typs)
 
     elif 'sparse' in typs:
         from pandas.sparse.array import _concat_compat

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -1161,6 +1161,20 @@ class TestMerge(tm.TestCase):
         result = pd.concat([first, second])
         self.assertEqual(result[0].dtype, 'datetime64[ns, Europe/London]')
 
+    def test_concat_tz_series_with_datetimelike(self):
+        # GH 12620
+        # tz and timedelta
+        x = [pd.Timestamp('2011-01-01', tz='US/Eastern'),
+             pd.Timestamp('2011-02-01', tz='US/Eastern')]
+        y = [pd.Timedelta('1 day'), pd.Timedelta('2 day')]
+        result = concat([pd.Series(x), pd.Series(y)], ignore_index=True)
+        tm.assert_series_equal(result, pd.Series(x + y, dtype='object'))
+
+        # tz and period
+        y = [pd.Period('2011-03', freq='M'), pd.Period('2011-04', freq='M')]
+        result = concat([pd.Series(x), pd.Series(y)], ignore_index=True)
+        tm.assert_series_equal(result, pd.Series(x + y, dtype='object'))
+
     def test_concat_period_series(self):
         x = Series(pd.PeriodIndex(['2015-11-01', '2015-12-01'], freq='D'))
         y = Series(pd.PeriodIndex(['2015-10-01', '2016-01-01'], freq='D'))


### PR DESCRIPTION
- [x] closes #12620
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

@jreback 's comment on #12620:

> should be handled at a slightly higher level.

I added number of `dtype` check logic in `tseries/common/_concat_compat`. But it should work on `base/common/_concat_compat`. Lmk which is preferable.
