### PR TITLE
Allow dtype='category' or dtype=None for Series with Categorical

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -93,3 +93,5 @@ Bug Fixes
 - Bug in ``value_counts`` when ``normalize=True`` and ``dropna=True`` where nulls still contributed to the normalized count (:issue:`12558`)
 
 - Bug in ``CategoricalIndex.get_loc`` returns different result from regular ``Index`` (:issue:`12531`)
+
+- Bug in ``Series`` when Series with Categorical is created with dtype specified (:issue:`12574`)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -32,7 +32,6 @@ from pandas.core.indexing import check_bool_indexer, maybe_convert_indices
 from pandas.core import generic, base
 from pandas.core.internals import SingleBlockManager
 from pandas.core.categorical import Categorical, CategoricalAccessor
-from pandas.core.dtypes import CategoricalDtype
 import pandas.core.strings as strings
 from pandas.tseries.common import (maybe_to_datetimelike,
                                    CombinedDatetimelikeProperties)
@@ -196,9 +195,9 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
                 else:
                     data = data.reindex(index, copy=copy)
             elif isinstance(data, Categorical):
-                # Allow dtype=category only, otherwise error
+                # GH12574: Allow dtype=category only, otherwise error
                 if ((dtype is not None) and
-                        not isinstance(dtype, CategoricalDtype)):
+                        not is_categorical_dtype(dtype)):
                     raise ValueError("cannot specify a dtype with a "
                                      "Categorical unless "
                                      "dtype='category'")

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -32,6 +32,7 @@ from pandas.core.indexing import check_bool_indexer, maybe_convert_indices
 from pandas.core import generic, base
 from pandas.core.internals import SingleBlockManager
 from pandas.core.categorical import Categorical, CategoricalAccessor
+from pandas.core.dtypes import CategoricalDtype
 import pandas.core.strings as strings
 from pandas.tseries.common import (maybe_to_datetimelike,
                                    CombinedDatetimelikeProperties)
@@ -195,9 +196,11 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
                 else:
                     data = data.reindex(index, copy=copy)
             elif isinstance(data, Categorical):
-                if dtype is not None:
+                # Allow dtype=category only, otherwise error
+                if (dtype is not None) and (not isinstance(dtype, CategoricalDtype)):
                     raise ValueError("cannot specify a dtype with a "
-                                     "Categorical")
+                                     "Categorical unless "
+                                     "dtype='category'")
             elif (isinstance(data, types.GeneratorType) or
                   (compat.PY3 and isinstance(data, map))):
                 data = list(data)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -197,7 +197,8 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
                     data = data.reindex(index, copy=copy)
             elif isinstance(data, Categorical):
                 # Allow dtype=category only, otherwise error
-                if (dtype is not None) and (not isinstance(dtype, CategoricalDtype)):
+                if ((dtype is not None) and
+                        not isinstance(dtype, CategoricalDtype)):
                     raise ValueError("cannot specify a dtype with a "
                                      "Categorical unless "
                                      "dtype='category'")

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -139,6 +139,17 @@ class TestSeriesConstructors(TestData, tm.TestCase):
         res = Series(cat)
         self.assertTrue(res.values.equals(cat))
 
+        # GH12574
+        self.assertRaises(
+            ValueError, lambda: Series(pd.Categorical([1, 2, 3]),
+                                       dtype='int64'))
+        cat = Series(pd.Categorical([1, 2, 3]), dtype='category')
+        self.assertTrue(com.is_categorical_dtype(cat))
+        self.assertTrue(com.is_categorical_dtype(cat.dtype))
+        s = Series([1, 2, 3], dtype='category')
+        self.assertTrue(com.is_categorical_dtype(s))
+        self.assertTrue(com.is_categorical_dtype(s.dtype))
+
     def test_constructor_maskedarray(self):
         data = ma.masked_all((3, ), dtype=float)
         result = Series(data)

--- a/pandas/tests/test_dtypes.py
+++ b/pandas/tests/test_dtypes.py
@@ -80,6 +80,13 @@ class TestCategoricalDtype(Base, tm.TestCase):
         self.assertFalse(is_categorical(np.dtype('float64')))
         self.assertFalse(is_categorical(1.0))
 
+    def test_series_with_dtype(self):
+        self.assertRaises(
+            ValueError, lambda: Series(Categorical([1, 2, 3]), dtype='foo'))
+        s = Series(Categorical([1, 2, 3]), dtype='category')
+        self.assertTrue(is_categorical_dtype(s))
+        self.assertTrue(is_categorical_dtype(s.dtype))
+
 
 class TestDatetimeTZDtype(Base, tm.TestCase):
 

--- a/pandas/tests/test_dtypes.py
+++ b/pandas/tests/test_dtypes.py
@@ -80,13 +80,6 @@ class TestCategoricalDtype(Base, tm.TestCase):
         self.assertFalse(is_categorical(np.dtype('float64')))
         self.assertFalse(is_categorical(1.0))
 
-    def test_series_with_dtype(self):
-        self.assertRaises(
-            ValueError, lambda: Series(Categorical([1, 2, 3]), dtype='int64'))
-        s = Series(Categorical([1, 2, 3]), dtype='category')
-        self.assertTrue(is_categorical_dtype(s))
-        self.assertTrue(is_categorical_dtype(s.dtype))
-
 
 class TestDatetimeTZDtype(Base, tm.TestCase):
 

--- a/pandas/tests/test_dtypes.py
+++ b/pandas/tests/test_dtypes.py
@@ -82,7 +82,7 @@ class TestCategoricalDtype(Base, tm.TestCase):
 
     def test_series_with_dtype(self):
         self.assertRaises(
-            ValueError, lambda: Series(Categorical([1, 2, 3]), dtype='foo'))
+            ValueError, lambda: Series(Categorical([1, 2, 3]), dtype='int64'))
         s = Series(Categorical([1, 2, 3]), dtype='category')
         self.assertTrue(is_categorical_dtype(s))
         self.assertTrue(is_categorical_dtype(s.dtype))


### PR DESCRIPTION
Allows user to pass dtype='category' when creating a Series with Categorical, but produces a ValueError is any non-categorical dtype is passed.
- [x] closes #12574
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
