### PR TITLE
CLN: removed unused parameter 'out' from Series.idxmin/idxmax

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1196,7 +1196,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
     def duplicated(self, keep='first'):
         return super(Series, self).duplicated(keep=keep)
 
-    def idxmin(self, axis=None, out=None, skipna=True):
+    def idxmin(self, axis=None, skipna=True):
         """
         Index of first occurrence of minimum of values.
 
@@ -1223,7 +1223,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
             return np.nan
         return self.index[i]
 
-    def idxmax(self, axis=None, out=None, skipna=True):
+    def idxmax(self, axis=None, skipna=True):
         """
         Index of first occurrence of maximum of values.
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry

It seems misleading to have the `out` parameter in the function signature when it is not used:

```
pd.Series.argmin(self, axis=None, out=None, skipna=True)
pd.Series.argmax(self, axis=None, out=None, skipna=True)
```

(unlike the `numpy.argmin/argmax` methods where `out` can be used)
