### PR TITLE
BUG: fixed SAS7BDATReader._get_properties

### DIFF
--- a/pandas/io/sas/sas7bdat.py
+++ b/pandas/io/sas/sas7bdat.py
@@ -327,12 +327,13 @@ class SAS7BDATReader(BaseIterator):
                                _os_version_number_length)
         self.os_version = buf.rstrip(b'\x00 ').decode()
 
-        buf = self._read_bytes(
-            _os_name_offset, _os_name_length).rstrip(b'\x00 ')
+        buf = self._read_bytes(_os_name_offset + total_align,
+                               _os_name_length).rstrip(b'\x00 ')
         if len(buf) > 0:
-            self.os_name = buf.rstrip(b'\x00 ').decode()
+            self.os_name = buf.decode()
         else:
-            buf = self._path_or_buf.read(_os_maker_offset, _os_maker_length)
+            buf = self._read_bytes(_os_maker_offset + total_align,
+                                   _os_maker_length)
             self.os_name = buf.rstrip(b'\x00 ').decode()
 
     # Read a single float of the given width (4 or 8).


### PR DESCRIPTION
this fixes a crasher I had in one of my files using SAS7BDATReader.

cc: @kshedden 

self._path_or_buf.read is an obvious mistake

also added + total_align to _os_name_offset and _os_make_offset as they are
present in the original code from Jared Hobbs:
https://bitbucket.org/jaredhobbs/sas7bdat/src/da1faa90d0b15c2c97a2a8eb86c91c58081bdd86/sas7bdat.py?fileviewer=file-view-default#sas7bdat.py-1450
