### PR TITLE
BUG: .describe lost CategoricalIndex info

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -160,8 +160,6 @@ Bug Fixes
 
 
 
-
-
 - Bug in ``concat`` raises ``AttributeError`` when input data contains tz-aware datetime and timedelta (:issue:`12620`)
 
 
@@ -169,3 +167,4 @@ Bug Fixes
 
 - Bug in ``pivot_table`` when ``margins=True`` and ``dropna=True`` where nulls still contributed to margin count (:issue:`12577`)
 - Bug in ``Series.name`` when ``name`` attribute can be a hashable type (:issue:`12610`)
+- Bug in ``.describe()`` resets categorical columns information (:issue:`11558`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4899,7 +4899,9 @@ class NDFrame(PandasObject):
             for name in idxnames:
                 if name not in names:
                     names.append(name)
+
         d = pd.concat(ldesc, join_axes=pd.Index([names]), axis=1)
+        d.columns = self.columns._shallow_copy(values=d.columns.values)
         d.columns.names = data.columns.names
         return d
 

--- a/pandas/indexes/base.py
+++ b/pandas/indexes/base.py
@@ -327,8 +327,7 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
         result._reset_identity()
         return result
 
-    def _shallow_copy(self, values=None, **kwargs):
-        """
+    _index_shared_docs['_shallow_copy'] = """
         create a new Index with the same class as the caller, don't copy the
         data, use the same object attributes with passed in attributes taking
         precedence
@@ -340,6 +339,8 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
         values : the values to create the new Index, optional
         kwargs : updates the default attributes for this Index
         """
+    @Appender(_index_shared_docs['_shallow_copy'])
+    def _shallow_copy(self, values=None, **kwargs):
         if values is None:
             values = self.values
         attributes = self._get_attributes_dict()

--- a/pandas/indexes/category.py
+++ b/pandas/indexes/category.py
@@ -7,7 +7,7 @@ from pandas.util.decorators import (Appender, cache_readonly,
                                     deprecate_kwarg)
 from pandas.core.missing import _clean_reindex_fill_method
 from pandas.core.config import get_option
-from pandas.indexes.base import Index
+from pandas.indexes.base import Index, _index_shared_docs
 import pandas.core.base as base
 import pandas.core.common as com
 import pandas.indexes.base as ibase
@@ -135,6 +135,19 @@ class CategoricalIndex(Index, base.PandasDelegate):
 
         result._reset_identity()
         return result
+
+    @Appender(_index_shared_docs['_shallow_copy'])
+    def _shallow_copy(self, values=None, categories=None, ordered=None,
+                      **kwargs):
+        # categories and ordered can't be part of attributes,
+        # as these are properties
+        if categories is None:
+            categories = self.categories
+        if ordered is None:
+            ordered = self.ordered
+        return super(CategoricalIndex,
+                     self)._shallow_copy(values=values, categories=categories,
+                                         ordered=ordered, **kwargs)
 
     def _is_dtype_compat(self, other):
         """

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -28,7 +28,8 @@ from pandas.core.common import (isnull, array_equivalent,
 from pandas.core.config import get_option
 
 from pandas.indexes.base import (Index, _ensure_index, _ensure_frozen,
-                                 _get_na_value, InvalidIndexError)
+                                 _get_na_value, InvalidIndexError,
+                                 _index_shared_docs)
 import pandas.indexes.base as ibase
 
 
@@ -381,6 +382,7 @@ class MultiIndex(Index):
     def _shallow_copy_with_infer(self, values=None, **kwargs):
         return self._shallow_copy(values, **kwargs)
 
+    @Appender(_index_shared_docs['_shallow_copy'])
     def _shallow_copy(self, values=None, **kwargs):
         if values is not None:
             if 'name' in kwargs:

--- a/pandas/indexes/range.py
+++ b/pandas/indexes/range.py
@@ -6,7 +6,7 @@ import pandas.index as _index
 
 from pandas import compat
 from pandas.compat import lrange, range
-from pandas.indexes.base import Index
+from pandas.indexes.base import Index, _index_shared_docs
 from pandas.util.decorators import Appender, cache_readonly
 import pandas.core.common as com
 import pandas.indexes.base as ibase
@@ -225,9 +225,8 @@ class RangeIndex(Int64Index):
     def tolist(self):
         return lrange(self._start, self._stop, self._step)
 
+    @Appender(_index_shared_docs['_shallow_copy'])
     def _shallow_copy(self, values=None, **kwargs):
-        """ create a new Index, don't copy the data, use the same object attributes
-            with passed in attributes taking precedence """
         if values is None:
             return RangeIndex(name=self.name, fastpath=True,
                               **dict(self._get_data_as_items()))

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -2768,7 +2768,7 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
             pd.Series([2, 1, 3],
                       index=pd.CategoricalIndex(["a", "b", np.nan])))
 
-        with tm.assert_produces_warning(FutureWarning):
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             s = pd.Series(pd.Categorical(
                 ["a", "b", "a"], categories=["a", "b", np.nan]))
             tm.assert_series_equal(
@@ -2779,7 +2779,7 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
                 pd.Series([2, 1, 0],
                           index=pd.CategoricalIndex(["a", "b", np.nan])))
 
-        with tm.assert_produces_warning(FutureWarning):
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             s = pd.Series(pd.Categorical(
                 ["a", "b", None, "a", None, None], categories=["a", "b", np.nan
                                                                ]))


### PR DESCRIPTION
- [x] closes #11558
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
#11558 is partially fixed by #12531, this PR let `.describe()` to preserve `CategoricalIndex` info. And added explicit test cases derived from #11558.
