### PR TITLE
API: Index.take inconsistently handle fill_value

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -29,7 +29,6 @@ New features
 Enhancements
 ~~~~~~~~~~~~
 
-
 .. _whatsnew_0181.partial_string_indexing:
 
 Partial string indexing on ``DateTimeIndex`` when part of a ``MultiIndex``
@@ -59,6 +58,14 @@ Other Enhancements
 - ``pd.read_csv()`` now supports opening ZIP files that contains a single CSV, via extension inference or explict ``compression='zip'`` (:issue:`12175`)
 - ``pd.read_csv()`` now supports opening files using xz compression, via extension inference or explicit ``compression='xz'`` is specified; ``xz`` compressions is also supported by ``DataFrame.to_csv`` in the same way (:issue:`11852`)
 - ``pd.read_msgpack()`` now always gives writeable ndarrays even when compression is used (:issue:`12359`).
+- ``Index.take`` now handles ``allow_fill`` and ``fill_value`` consistently (:issue:`12631`)
+
+.. ipython:: python
+
+   idx = pd.Index([1., 2., 3., 4.], dtype='float')
+   idx.take([2, -1])     # default, allow_fill=True, fill_value=None
+   idx.take([2, -1], fill_value=True)
+
 
 .. _whatsnew_0181.api:
 

--- a/pandas/indexes/category.py
+++ b/pandas/indexes/category.py
@@ -459,21 +459,13 @@ class CategoricalIndex(Index, base.PandasDelegate):
 
         return None
 
-    def take(self, indexer, axis=0, allow_fill=True, fill_value=None):
-        """
-        For internal compatibility with numpy arrays.
-
-        # filling must always be None/nan here
-        # but is passed thru internally
-        assert isnull(fill_value)
-
-        See also
-        --------
-        numpy.ndarray.take
-        """
-
-        indexer = com._ensure_platform_int(indexer)
-        taken = self.codes.take(indexer)
+    @Appender(_index_shared_docs['take'])
+    def take(self, indices, axis=0, allow_fill=True, fill_value=None):
+        indices = com._ensure_platform_int(indices)
+        taken = self._assert_take_fillable(self.codes, indices,
+                                           allow_fill=allow_fill,
+                                           fill_value=fill_value,
+                                           na_value=-1)
         return self._create_from_codes(taken)
 
     def delete(self, loc):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1240,6 +1240,34 @@ class TestIndex(Base, tm.TestCase):
         exp = Index([idx[-1], idx[0], idx[1]])
         tm.assert_index_equal(res, exp)
 
+    def test_take_fill_value(self):
+        # GH 12631
+        idx = pd.Index(list('ABC'), name='xxx')
+        result = idx.take(np.array([1, 0, -1]))
+        expected = pd.Index(list('BAC'), name='xxx')
+        tm.assert_index_equal(result, expected)
+
+        # fill_value
+        result = idx.take(np.array([1, 0, -1]), fill_value=True)
+        expected = pd.Index(['B', 'A', np.nan], name='xxx')
+        tm.assert_index_equal(result, expected)
+
+        # allow_fill=False
+        result = idx.take(np.array([1, 0, -1]), allow_fill=False,
+                          fill_value=True)
+        expected = pd.Index(['B', 'A', 'C'], name='xxx')
+        tm.assert_index_equal(result, expected)
+
+        msg = ('When allow_fill=True and fill_value is not None, '
+               'all indices must be >= -1')
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -2]), fill_value=True)
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -5]), fill_value=True)
+
+        with tm.assertRaises(IndexError):
+            idx.take(np.array([1, -5]))
+
     def test_reindex_preserves_name_if_target_is_list_or_ndarray(self):
         # GH6552
         idx = pd.Index([0, 1, 2])

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -708,3 +708,100 @@ class TestCategoricalIndex(Base, tm.TestCase):
         with tm.assertRaisesRegexp(ValueError,
                                    'fill value must be in categories'):
             idx.fillna(2.0)
+
+    def test_take_fill_value(self):
+        # GH 12631
+
+        # numeric category
+        idx = pd.CategoricalIndex([1, 2, 3], name='xxx')
+        result = idx.take(np.array([1, 0, -1]))
+        expected = pd.CategoricalIndex([2, 1, 3], name='xxx')
+        tm.assert_index_equal(result, expected)
+        tm.assert_categorical_equal(result.values, expected.values)
+
+        # fill_value
+        result = idx.take(np.array([1, 0, -1]), fill_value=True)
+        expected = pd.CategoricalIndex([2, 1, np.nan], categories=[1, 2, 3],
+                                       name='xxx')
+        tm.assert_index_equal(result, expected)
+        tm.assert_categorical_equal(result.values, expected.values)
+
+        # allow_fill=False
+        result = idx.take(np.array([1, 0, -1]), allow_fill=False,
+                          fill_value=True)
+        expected = pd.CategoricalIndex([2, 1, 3], name='xxx')
+        tm.assert_index_equal(result, expected)
+        tm.assert_categorical_equal(result.values, expected.values)
+
+        # object category
+        idx = pd.CategoricalIndex(list('CBA'), categories=list('ABC'),
+                                  ordered=True, name='xxx')
+        result = idx.take(np.array([1, 0, -1]))
+        expected = pd.CategoricalIndex(list('BCA'), categories=list('ABC'),
+                                       ordered=True, name='xxx')
+        tm.assert_index_equal(result, expected)
+        tm.assert_categorical_equal(result.values, expected.values)
+
+        # fill_value
+        result = idx.take(np.array([1, 0, -1]), fill_value=True)
+        expected = pd.CategoricalIndex(['B', 'C', np.nan],
+                                       categories=list('ABC'), ordered=True,
+                                       name='xxx')
+        tm.assert_index_equal(result, expected)
+        tm.assert_categorical_equal(result.values, expected.values)
+
+        # allow_fill=False
+        result = idx.take(np.array([1, 0, -1]), allow_fill=False,
+                          fill_value=True)
+        expected = pd.CategoricalIndex(list('BCA'), categories=list('ABC'),
+                                       ordered=True, name='xxx')
+        tm.assert_index_equal(result, expected)
+        tm.assert_categorical_equal(result.values, expected.values)
+
+        msg = ('When allow_fill=True and fill_value is not None, '
+               'all indices must be >= -1')
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -2]), fill_value=True)
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -5]), fill_value=True)
+
+        with tm.assertRaises(IndexError):
+            idx.take(np.array([1, -5]))
+
+    def test_take_fill_value_datetime(self):
+
+        # datetime category
+        idx = pd.DatetimeIndex(['2011-01-01', '2011-02-01', '2011-03-01'],
+                               name='xxx')
+        idx = pd.CategoricalIndex(idx)
+        result = idx.take(np.array([1, 0, -1]))
+        expected = pd.DatetimeIndex(['2011-02-01', '2011-01-01', '2011-03-01'],
+                                    name='xxx')
+        expected = pd.CategoricalIndex(expected)
+        tm.assert_index_equal(result, expected)
+
+        # fill_value
+        result = idx.take(np.array([1, 0, -1]), fill_value=True)
+        expected = pd.DatetimeIndex(['2011-02-01', '2011-01-01', 'NaT'],
+                                    name='xxx')
+        exp_cats = pd.DatetimeIndex(['2011-01-01', '2011-02-01', '2011-03-01'])
+        expected = pd.CategoricalIndex(expected, categories=exp_cats)
+        tm.assert_index_equal(result, expected)
+
+        # allow_fill=False
+        result = idx.take(np.array([1, 0, -1]), allow_fill=False,
+                          fill_value=True)
+        expected = pd.DatetimeIndex(['2011-02-01', '2011-01-01', '2011-03-01'],
+                                    name='xxx')
+        expected = pd.CategoricalIndex(expected)
+        tm.assert_index_equal(result, expected)
+
+        msg = ('When allow_fill=True and fill_value is not None, '
+               'all indices must be >= -1')
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -2]), fill_value=True)
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -5]), fill_value=True)
+
+        with tm.assertRaises(IndexError):
+            idx.take(np.array([1, -5]))

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -343,6 +343,34 @@ class TestFloat64Index(Numeric, tm.TestCase):
         exp = Index([1.0, 'obj', 3.0], name='x')
         self.assert_index_equal(idx.fillna('obj'), exp)
 
+    def test_take_fill_value(self):
+        # GH 12631
+        idx = pd.Float64Index([1., 2., 3.], name='xxx')
+        result = idx.take(np.array([1, 0, -1]))
+        expected = pd.Float64Index([2., 1., 3.], name='xxx')
+        tm.assert_index_equal(result, expected)
+
+        # fill_value
+        result = idx.take(np.array([1, 0, -1]), fill_value=True)
+        expected = pd.Float64Index([2., 1., np.nan], name='xxx')
+        tm.assert_index_equal(result, expected)
+
+        # allow_fill=False
+        result = idx.take(np.array([1, 0, -1]), allow_fill=False,
+                          fill_value=True)
+        expected = pd.Float64Index([2., 1., 3.], name='xxx')
+        tm.assert_index_equal(result, expected)
+
+        msg = ('When allow_fill=True and fill_value is not None, '
+               'all indices must be >= -1')
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -2]), fill_value=True)
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -5]), fill_value=True)
+
+        with tm.assertRaises(IndexError):
+            idx.take(np.array([1, -5]))
+
 
 class TestInt64Index(Numeric, tm.TestCase):
     _holder = Int64Index
@@ -756,6 +784,33 @@ class TestInt64Index(Numeric, tm.TestCase):
         index = Int64Index([1, 2, 3, 4], name='foo')
         taken = index.take([3, 0, 1])
         self.assertEqual(index.name, taken.name)
+
+    def test_take_fill_value(self):
+        # GH 12631
+        idx = pd.Int64Index([1, 2, 3], name='xxx')
+        result = idx.take(np.array([1, 0, -1]))
+        expected = pd.Int64Index([2, 1, 3], name='xxx')
+        tm.assert_index_equal(result, expected)
+
+        # fill_value
+        msg = "Unable to fill values because Int64Index cannot contain NA"
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -1]), fill_value=True)
+
+        # allow_fill=False
+        result = idx.take(np.array([1, 0, -1]), allow_fill=False,
+                          fill_value=True)
+        expected = pd.Int64Index([2, 1, 3], name='xxx')
+        tm.assert_index_equal(result, expected)
+
+        msg = "Unable to fill values because Int64Index cannot contain NA"
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -2]), fill_value=True)
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -5]), fill_value=True)
+
+        with tm.assertRaises(IndexError):
+            idx.take(np.array([1, -5]))
 
     def test_int_name_format(self):
         index = Index(['a', 'b', 'c'], name=0)

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -647,6 +647,33 @@ class TestRangeIndex(Numeric, tm.TestCase):
         taken = index.take([3, 0, 1])
         self.assertEqual(index.name, taken.name)
 
+    def test_take_fill_value(self):
+        # GH 12631
+        idx = pd.RangeIndex(1, 4, name='xxx')
+        result = idx.take(np.array([1, 0, -1]))
+        expected = pd.Int64Index([2, 1, 3], name='xxx')
+        tm.assert_index_equal(result, expected)
+
+        # fill_value
+        msg = "Unable to fill values because RangeIndex cannot contain NA"
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -1]), fill_value=True)
+
+        # allow_fill=False
+        result = idx.take(np.array([1, 0, -1]), allow_fill=False,
+                          fill_value=True)
+        expected = pd.Int64Index([2, 1, 3], name='xxx')
+        tm.assert_index_equal(result, expected)
+
+        msg = "Unable to fill values because RangeIndex cannot contain NA"
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -2]), fill_value=True)
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -5]), fill_value=True)
+
+        with tm.assertRaises(IndexError):
+            idx.take(np.array([1, -5]))
+
     def test_print_unicode_columns(self):
         df = pd.DataFrame({u("\u05d0"): [1, 2, 3],
                            "\u05d1": [4, 5, 6],

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -851,14 +851,6 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
         values[imask] = np.array([formatter(dt) for dt in values[imask]])
         return values
 
-    def take(self, indices, axis=0, allow_fill=True, fill_value=None):
-        """
-        Analogous to ndarray.take
-        """
-        indices = com._ensure_platform_int(indices)
-        taken = self.asi8.take(indices, axis=axis)
-        return self._simple_new(taken, self.name, freq=self.freq)
-
     def append(self, other):
         """
         Append a collection of Index options together

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -1613,6 +1613,38 @@ class TestTimedeltaIndex(tm.TestCase):
             self.assertIsNone(taken.freq)
             self.assertEqual(taken.name, expected.name)
 
+    def test_take_fill_value(self):
+        # GH 12631
+        idx = pd.TimedeltaIndex(['1 days', '2 days', '3 days'],
+                                name='xxx')
+        result = idx.take(np.array([1, 0, -1]))
+        expected = pd.TimedeltaIndex(['2 days', '1 days', '3 days'],
+                                     name='xxx')
+        tm.assert_index_equal(result, expected)
+
+        # fill_value
+        result = idx.take(np.array([1, 0, -1]), fill_value=True)
+        expected = pd.TimedeltaIndex(['2 days', '1 days', 'NaT'],
+                                     name='xxx')
+        tm.assert_index_equal(result, expected)
+
+        # allow_fill=False
+        result = idx.take(np.array([1, 0, -1]), allow_fill=False,
+                          fill_value=True)
+        expected = pd.TimedeltaIndex(['2 days', '1 days', '3 days'],
+                                     name='xxx')
+        tm.assert_index_equal(result, expected)
+
+        msg = ('When allow_fill=True and fill_value is not None, '
+               'all indices must be >= -1')
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -2]), fill_value=True)
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -5]), fill_value=True)
+
+        with tm.assertRaises(IndexError):
+            idx.take(np.array([1, -5]))
+
     def test_isin(self):
 
         index = tm.makeTimedeltaIndex(4)

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -3297,6 +3297,69 @@ class TestDatetimeIndex(tm.TestCase):
                 self.assertEqual(taken.tz, expected.tz)
                 self.assertEqual(taken.name, expected.name)
 
+    def test_take_fill_value(self):
+        # GH 12631
+        idx = pd.DatetimeIndex(['2011-01-01', '2011-02-01', '2011-03-01'],
+                               name='xxx')
+        result = idx.take(np.array([1, 0, -1]))
+        expected = pd.DatetimeIndex(['2011-02-01', '2011-01-01', '2011-03-01'],
+                                    name='xxx')
+        tm.assert_index_equal(result, expected)
+
+        # fill_value
+        result = idx.take(np.array([1, 0, -1]), fill_value=True)
+        expected = pd.DatetimeIndex(['2011-02-01', '2011-01-01', 'NaT'],
+                                    name='xxx')
+        tm.assert_index_equal(result, expected)
+
+        # allow_fill=False
+        result = idx.take(np.array([1, 0, -1]), allow_fill=False,
+                          fill_value=True)
+        expected = pd.DatetimeIndex(['2011-02-01', '2011-01-01', '2011-03-01'],
+                                    name='xxx')
+        tm.assert_index_equal(result, expected)
+
+        msg = ('When allow_fill=True and fill_value is not None, '
+               'all indices must be >= -1')
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -2]), fill_value=True)
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -5]), fill_value=True)
+
+        with tm.assertRaises(IndexError):
+            idx.take(np.array([1, -5]))
+
+    def test_take_fill_value_with_timezone(self):
+        idx = pd.DatetimeIndex(['2011-01-01', '2011-02-01', '2011-03-01'],
+                               name='xxx', tz='US/Eastern')
+        result = idx.take(np.array([1, 0, -1]))
+        expected = pd.DatetimeIndex(['2011-02-01', '2011-01-01', '2011-03-01'],
+                                    name='xxx', tz='US/Eastern')
+        tm.assert_index_equal(result, expected)
+
+        # fill_value
+        result = idx.take(np.array([1, 0, -1]), fill_value=True)
+        expected = pd.DatetimeIndex(['2011-02-01', '2011-01-01', 'NaT'],
+                                    name='xxx', tz='US/Eastern')
+        tm.assert_index_equal(result, expected)
+
+        # allow_fill=False
+        result = idx.take(np.array([1, 0, -1]), allow_fill=False,
+                          fill_value=True)
+        expected = pd.DatetimeIndex(['2011-02-01', '2011-01-01', '2011-03-01'],
+                                    name='xxx', tz='US/Eastern')
+        tm.assert_index_equal(result, expected)
+
+        msg = ('When allow_fill=True and fill_value is not None, '
+               'all indices must be >= -1')
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -2]), fill_value=True)
+        with tm.assertRaisesRegexp(ValueError, msg):
+            idx.take(np.array([1, 0, -5]), fill_value=True)
+
+        with tm.assertRaises(IndexError):
+            idx.take(np.array([1, -5]))
+
     def test_map_bug_1677(self):
         index = DatetimeIndex(['2012-04-25 09:30:00.393000'])
         f = index.asof


### PR DESCRIPTION
- [x] closes #12631
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
