### PR TITLE
COMPAT: make read_excel accept path objects for the filepath (#12655)

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -169,3 +169,4 @@ Bug Fixes
 - Bug in ``pivot_table`` when ``margins=True`` and ``dropna=True`` where nulls still contributed to margin count (:issue:`12577`)
 - Bug in ``Series.name`` when ``name`` attribute can be a hashable type (:issue:`12610`)
 - Bug in ``.describe()`` resets categorical columns information (:issue:`11558`)
+- ``read_excel`` now accepts path objects (e.g. ``pathlib.Path``, ``py.path.local``) for the file path, in line with other ``read_*`` functions (:issue:`12655`)

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -528,6 +528,33 @@ class XlrdTests(ReadingTestsBase):
 
         tm.assert_frame_equal(url_table, local_table)
 
+    def test_read_from_pathlib_path(self):
+        tm._skip_if_no_pathlib()
+
+        from pathlib import Path
+
+        str_path = os.path.join(self.dirpath, 'test1' + self.ext)
+        expected = read_excel(str_path, 'Sheet1', index_col=0)
+
+        path_obj = Path(self.dirpath, 'test1' + self.ext)
+        actual = read_excel(path_obj, 'Sheet1', index_col=0)
+
+        tm.assert_frame_equal(expected, actual)
+
+    def test_read_from_py_localpath(self):
+        tm._skip_if_no_localpath()
+
+        from py.path import local as LocalPath
+
+        str_path = os.path.join(self.dirpath, 'test1' + self.ext)
+        expected = read_excel(str_path, 'Sheet1', index_col=0)
+
+        abs_dir = os.path.abspath(self.dirpath)
+        path_obj = LocalPath(abs_dir).join('test1' + self.ext)
+        actual = read_excel(path_obj, 'Sheet1', index_col=0)
+
+        tm.assert_frame_equal(expected, actual)
+
     def test_reader_closes_file(self):
 
         pth = os.path.join(self.dirpath, 'test1' + self.ext)


### PR DESCRIPTION
- [x] closes #12655
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Fairly simple fix overall, since `get_filepath_or_buffer` is already set up to just convert the path objs to string, we can do that first and then just let the existing logic handle it.

Since the libraries that contain the path objects aren't hard dependencies, I'm not sure how to typecheck against them without first using the `_IS_LIBRARY_INSTALLED` checks and then importing if they're installed. Let me know if this should be done differently.
