### PR TITLE
Raising TypeError on invalid window when using .rolling #12669

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -169,3 +169,4 @@ Bug Fixes
 
 - Bug in ``pivot_table`` when ``margins=True`` and ``dropna=True`` where nulls still contributed to margin count (:issue:`12577`)
 - Bug in ``Series.name`` when ``name`` attribute can be a hashable type (:issue:`12610`)
+- Bug in ``window`` Better error message on invalid window when using .rolling  (:issue:`12669`)

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -1354,6 +1354,8 @@ def _get_center_of_mass(com, span, halflife, alpha):
 
 
 def _offset(window, center):
+    if com.is_float(window):
+        raise TypeError("Window should be of type Integer, given Float")
     if not com.is_integer(window):
         window = len(window)
     offset = (window - 1) / 2. if center else 0

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -761,6 +761,9 @@ class TestMoments(Base):
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             self._check_moment_func(mom.rolling_median, np.median,
                                     name='median')
+        # GH 12669
+        with self.assertRaises(TypeError):
+            pd.DataFrame(np.arange(10)).rolling(2., center=True).median()
 
     def test_rolling_min(self):
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):


### PR DESCRIPTION
- [x] closes #12669
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
