### PR TITLE
COMPAT: compat with released numpy 1.11 for IndexError -> TypeError

### DIFF
--- a/ci/requirements-3.5_OSX.build
+++ b/ci/requirements-3.5_OSX.build
@@ -1,2 +1,2 @@
-numpy
+numpy=1.10.4
 cython

--- a/ci/requirements-3.5_OSX.run
+++ b/ci/requirements-3.5_OSX.run
@@ -1,5 +1,5 @@
 pytz
-numpy
+numpy=1.10.4
 openpyxl
 xlsxwriter
 xlrd

--- a/pandas/compat/numpy_compat.py
+++ b/pandas/compat/numpy_compat.py
@@ -4,19 +4,17 @@ import numpy as np
 from distutils.version import LooseVersion
 from pandas.compat import string_types, string_and_binary_types
 
-# TODO: HACK for NumPy 1.5.1 to suppress warnings
-# is this necessary?
-try:
-    np.seterr(all='ignore')
-except Exception:  # pragma: no cover
-    pass
+# turn off all numpy warnings
+np.seterr(all='ignore')
 
 # numpy versioning
 _np_version = np.version.short_version
-_np_version_under1p8 = LooseVersion(_np_version) < '1.8'
-_np_version_under1p9 = LooseVersion(_np_version) < '1.9'
-_np_version_under1p10 = LooseVersion(_np_version) < '1.10'
-_np_version_under1p11 = LooseVersion(_np_version) < '1.11'
+_nlv = LooseVersion(_np_version)
+_np_version_under1p8 = _nlv < '1.8'
+_np_version_under1p9 = _nlv < '1.9'
+_np_version_under1p10 = _nlv < '1.10'
+_np_version_under1p11 = _nlv < '1.11'
+_np_version_under1p12 = _nlv < '1.12'
 
 if LooseVersion(_np_version) < '1.7.0':
     raise ImportError('this version of pandas is incompatible with '
@@ -67,9 +65,9 @@ def np_array_datetime64_compat(arr, *args, **kwargs):
     return np.array(arr, *args, **kwargs)
 
 __all__ = ['np',
-           '_np_version',
            '_np_version_under1p8',
            '_np_version_under1p9',
            '_np_version_under1p10',
            '_np_version_under1p11',
+           '_np_version_under1p12',
            ]

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1475,10 +1475,10 @@ class IndexCol(StringMixin):
 
     def convert(self, values, nan_rep, encoding):
         """ set the values from this selection: take = take ownership """
-        try:
+
+        # values is a recarray
+        if values.dtype.fields is not None:
             values = values[self.cname]
-        except:
-            pass
 
         values = _maybe_convert(values, self.kind, encoding)
 
@@ -2001,10 +2001,10 @@ class DataCol(IndexCol):
         if we can)
         """
 
-        try:
+        # values is a recarray
+        if values.dtype.fields is not None:
             values = values[self.cname]
-        except:
-            pass
+
         self.set_data(values)
 
         # use the meta if needed
@@ -4057,7 +4057,7 @@ class AppendableFrameTable(AppendableTable):
         if len(frames) == 1:
             df = frames[0]
         else:
-            df = concat(frames, axis=1, verify_integrity=False).consolidate()
+            df = concat(frames, axis=1)
 
         # apply the selection filters & axis orderings
         df = self.process_axes(df, columns=columns)

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -3001,8 +3001,8 @@ class TestHDFStore(Base, tm.TestCase):
         # GH 2931
 
         # make sparse dataframe
-        df = DataFrame(np.random.binomial(
-            n=1, p=.01, size=(1e3, 10))).to_sparse(fill_value=0)
+        arr = np.random.binomial(n=1, p=.01, size=(1000, 10))
+        df = DataFrame(arr).to_sparse(fill_value=0)
 
         # case 1: store uncompressed
         self._check_double_roundtrip(df, tm.assert_frame_equal,
@@ -3015,7 +3015,7 @@ class TestHDFStore(Base, tm.TestCase):
                                      check_frame_type=True)
 
         # set one series to be completely sparse
-        df[0] = np.zeros(1e3)
+        df[0] = np.zeros(1000)
 
         # case 3: store df with completely sparse series uncompressed
         self._check_double_roundtrip(df, tm.assert_frame_equal,

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -26,7 +26,7 @@ from pandas.compat import range, lrange, lmap, zip, text_type, PY3, iteritems
 from pandas.compat.numpy_compat import np_datetime64_compat
 
 from pandas import (Series, DataFrame,
-                    _np_version_under1p9, _np_version_under1p11)
+                    _np_version_under1p9, _np_version_under1p12)
 from pandas import tslib
 from pandas.util.testing import (assert_series_equal, assert_almost_equal,
                                  assertRaisesRegexp)
@@ -2607,8 +2607,9 @@ class TestPeriodIndex(tm.TestCase):
         didx = DatetimeIndex(start='2013/01/01', freq='D', periods=400)
         pidx = PeriodIndex(start='2013/01/01', freq='D', periods=400)
 
-        # changed to TypeError in 1.11
-        exc = IndexError if _np_version_under1p11 else TypeError
+        # changed to TypeError in 1.12
+        # https://github.com/numpy/numpy/pull/6271
+        exc = IndexError if _np_version_under1p12 else TypeError
 
         for idx in [didx, pidx]:
             # slices against index should raise IndexError
@@ -2664,8 +2665,9 @@ class TestPeriodIndex(tm.TestCase):
                              periods=4000)
         pidx = PeriodIndex(start='2013/01/01 09:00:00', freq='S', periods=4000)
 
-        # changed to TypeError in 1.11
-        exc = IndexError if _np_version_under1p11 else TypeError
+        # changed to TypeError in 1.12
+        # https://github.com/numpy/numpy/pull/6271
+        exc = IndexError if _np_version_under1p12 else TypeError
 
         for idx in [didx, pidx]:
             # slices against index should raise IndexError


### PR DESCRIPTION
was a revert of # https://github.com/numpy/numpy/pull/6271

closes #12729
closes #12792 
