### PR TITLE
ENH: show_versions to include pandas_datareader

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -72,7 +72,7 @@ API changes
 
 
 - ``CParserError`` is now a ``ValueError`` instead of just an ``Exception`` (:issue:`12551`)
-
+- ``pd.show_versions()`` now includes ``pandas_datareader`` version (:issue:`12740`)
 
 
 

--- a/pandas/util/print_versions.py
+++ b/pandas/util/print_versions.py
@@ -92,7 +92,8 @@ def show_versions(as_json=False):
         ("pymysql", lambda mod: mod.__version__),
         ("psycopg2", lambda mod: mod.__version__),
         ("jinja2", lambda mod: mod.__version__),
-        ("boto", lambda mod: mod.__version__)
+        ("boto", lambda mod: mod.__version__),
+        ("pandas_datareader", lambda mod: mod.__version__)
     ]
 
     deps_blob = list()


### PR DESCRIPTION
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
