### PR TITLE
BUG: SparseSeries.shape ignores fill_value

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -134,6 +134,10 @@ Bug Fixes
 
 
 
+
+
+
+
 - Bug in ``value_counts`` when ``normalize=True`` and ``dropna=True`` where nulls still contributed to the normalized count (:issue:`12558`)
 - Bug in ``Panel.fillna()`` ignoring ``inplace=True`` (:issue:`12633`)
 - Bug in ``Series.rename``, ``DataFrame.rename`` and ``DataFrame.rename_axis`` not treating ``Series`` as mappings to relabel (:issue:`12623`).
@@ -147,14 +151,11 @@ Bug Fixes
 
 
 
-
-
-
 - Bug in ``CategoricalIndex.get_loc`` returns different result from regular ``Index`` (:issue:`12531`)
 
 
 
-
+- Bug in ``SparseSeries.shape`` ignores ``fill_value`` (:issue:`10452`)
 
 
 

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -282,6 +282,10 @@ class SparseSeries(Series):
     def __len__(self):
         return len(self.block)
 
+    @property
+    def shape(self):
+        return self._data.shape
+
     def __unicode__(self):
         # currently, unicode is same as repr...fixes infinite loop
         series_rep = Series.__unicode__(self)


### PR DESCRIPTION
- [x] closes #10452
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Based on existing tests / text search, no other metohd depends on current `SparseSeries.shape` (buggy) behavior.
