### PR TITLE
PERF: Improve replace perf

### DIFF
--- a/asv_bench/benchmarks/replace.py
+++ b/asv_bench/benchmarks/replace.py
@@ -32,6 +32,30 @@ class replace_large_dict(object):
         self.s.replace(self.to_rep, inplace=True)
 
 
+class replace_convert(object):
+    goal_time = 0.5
+
+    def setup(self):
+        self.n = (10 ** 3)
+        self.to_ts = dict(((i, pd.Timestamp(i)) for i in range(self.n)))
+        self.to_td = dict(((i, pd.Timedelta(i)) for i in range(self.n)))
+        self.s = Series(np.random.randint(self.n, size=(10 ** 3)))
+        self.df = DataFrame({'A': np.random.randint(self.n, size=(10 ** 3)),
+                             'B': np.random.randint(self.n, size=(10 ** 3))})
+
+    def time_replace_series_timestamp(self):
+        self.s.replace(self.to_ts)
+
+    def time_replace_series_timedelta(self):
+        self.s.replace(self.to_td)
+
+    def time_replace_frame_timestamp(self):
+        self.df.replace(self.to_ts)
+
+    def time_replace_frame_timedelta(self):
+        self.df.replace(self.to_td)
+
+
 class replace_replacena(object):
     goal_time = 0.2
 

--- a/doc/source/whatsnew/v0.19.2.txt
+++ b/doc/source/whatsnew/v0.19.2.txt
@@ -21,6 +21,7 @@ Highlights include:
 Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
+- Improved performance of ``.replace()`` (:issue:`12745`)
 
 .. _whatsnew_0192.bug_fixes:
 


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

When `.replace` is called with `dict`, replacements are done per value. Current impl try to soft convert the dtype in every replacement, but it is enough to be done in the final replacement.
#### Bench

```
-  712.83ms   355.93ms      0.50  replace.replace_convert.time_replace_series_timestamp
-     1.50s   698.21ms      0.46  replace.replace_convert.time_replace_frame_timestamp
-     3.12s   690.48ms      0.22  replace.replace_convert.time_replace_frame_timedelta
-     1.69s   354.83ms      0.21  replace.replace_convert.time_replace_series_timedelta
```
