### PR TITLE
BUG: loffset argument not applied for resample().count() on timeseries

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -169,3 +169,4 @@ Bug Fixes
 - Bug in ``pivot_table`` when ``margins=True`` and ``dropna=True`` where nulls still contributed to margin count (:issue:`12577`)
 - Bug in ``Series.name`` when ``name`` attribute can be a hashable type (:issue:`12610`)
 - Bug in ``.describe()`` resets categorical columns information (:issue:`11558`)
+- Bug where ``loffset`` argument was not applied when calling ``resample().count()`` on a timeseries (:issue:`12725`)

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -374,6 +374,19 @@ class Resampler(_GroupBy):
 
         return self._wrap_result(result)
 
+    def _apply_loffset(self, result):
+        """if loffset if set, offset the result index"""
+        loffset = self.loffset
+        if isinstance(loffset, compat.string_types):
+            loffset = to_offset(self.loffset)
+
+        if isinstance(loffset, (DateOffset, timedelta)) and \
+                isinstance(result.index, DatetimeIndex) and \
+                        len(result.index) > 0:
+            result.index = result.index + loffset
+
+        return result
+
     def _wrap_result(self, result):
         """ potentially wrap any results """
         return result
@@ -572,14 +585,7 @@ class DatetimeIndexResampler(Resampler):
         result = obj.groupby(
             self.grouper, axis=self.axis).aggregate(how, **kwargs)
 
-        loffset = self.loffset
-        if isinstance(loffset, compat.string_types):
-            loffset = to_offset(self.loffset)
-
-        if isinstance(loffset, (DateOffset, timedelta)) and \
-           isinstance(result.index, DatetimeIndex) and \
-           len(result.index) > 0:
-                result.index = result.index + loffset
+        result = self._apply_loffset(result)
 
         return self._wrap_result(result)
 

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -372,6 +372,8 @@ class Resampler(_GroupBy):
             # try to evaluate
             result = grouped.apply(how, *args, **kwargs)
 
+        result = self._apply_loffset(result)
+
         return self._wrap_result(result)
 
     def _apply_loffset(self, result):

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -382,9 +382,12 @@ class Resampler(_GroupBy):
         if isinstance(loffset, compat.string_types):
             loffset = to_offset(self.loffset)
 
-        if isinstance(loffset, (DateOffset, timedelta)) and \
-                isinstance(result.index, DatetimeIndex) and \
-                        len(result.index) > 0:
+        needs_offset = (
+            isinstance(loffset, (DateOffset, timedelta)) and
+            isinstance(result.index, DatetimeIndex) and
+            len(result.index) > 0
+        )
+        if needs_offset:
             result.index = result.index + loffset
 
         return result

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -945,7 +945,10 @@ class TestResample(tm.TestCase):
 
         result = ts.resample('10S', loffset='1s').count()
 
-        expected_index = date_range(start_time, periods=10, freq='10S') + timedelta(seconds=1)
+        expected_index = (
+            date_range(start_time, periods=10, freq='10S') +
+            timedelta(seconds=1)
+        )
         expected = pd.Series(10, index=expected_index)
 
         assert_series_equal(result, expected)

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -938,7 +938,7 @@ class TestResample(tm.TestCase):
         self.assertEqual(result.index[0] - bday, expected.index[0])
 
     def test_resample_loffset_count(self):
-        # GH issue 12725
+        # GH 12725
         start_time = '1/1/2000 00:00:00'
         rng = date_range(start_time, periods=100, freq='S')
         ts = Series(np.random.randn(len(rng)), index=rng)

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -937,6 +937,25 @@ class TestResample(tm.TestCase):
         expected = ser.resample('w-sun', loffset=-bday).last()
         self.assertEqual(result.index[0] - bday, expected.index[0])
 
+    def test_resample_loffset_count(self):
+        # GH issue 12725
+        start_time = '1/1/2000 00:00:00'
+        rng = date_range(start_time, periods=100, freq='S')
+        ts = Series(np.random.randn(len(rng)), index=rng)
+
+        result = ts.resample('10S', loffset='1s').count()
+
+        expected_index = date_range(start_time, periods=10, freq='10S') + timedelta(seconds=1)
+        expected = pd.Series(10, index=expected_index)
+
+        assert_series_equal(result, expected)
+
+        # Same issue should apply to .size() since it goes through
+        #   same code path
+        result = ts.resample('10S', loffset='1s').size()
+
+        assert_series_equal(result, expected)
+
     def test_resample_upsample(self):
         # from daily
         dti = DatetimeIndex(start=datetime(2005, 1, 1),


### PR DESCRIPTION
- [x] closes #12725
- [ ] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

The code to do this already existed in the `_downsample` method, which is called when using functions like `mean`. `max`, etc., but there was nothing in the `_groupby_and_aggregate` method used for `count` and `size`. If we pull out the offset code from the `_downsample` method into a separate method, we can reuse it without duplicating it.
