### PR TITLE
PERF: to_numeric for numeric dtypes

### DIFF
--- a/asv_bench/benchmarks/miscellaneous.py
+++ b/asv_bench/benchmarks/miscellaneous.py
@@ -28,3 +28,25 @@ class misc_cache_readonly(object):
 
     def time_misc_cache_readonly(self):
         self.obj.prop
+
+
+class to_numeric(object):
+    goal_time = 0.2
+
+    def setup(self):
+        self.n = 10000
+        self.float = Series(np.random.randn(self.n * 100))
+        self.numstr = self.float.astype('str')
+        self.str = Series(tm.makeStringIndex(self.n))
+
+    def time_from_float(self):
+        pd.to_numeric(self.float)
+
+    def time_from_numeric_str(self):
+        pd.to_numeric(self.numstr)
+
+    def time_from_str_ignore(self):
+        pd.to_numeric(self.str, errors='ignore')
+
+    def time_from_str_coerce(self):
+        pd.to_numeric(self.str, errors='coerce')

--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -409,6 +409,8 @@ Performance Improvements
 - Improved performance of ``DataFrame.to_sql`` when checking case sensitivity for tables. Now only checks if table has been created correctly when table name is not lower case. (:issue:`12876`)
 - Improved performance of ``Period`` construction and time series plotting (:issue:`12903`, :issue:`11831`).
 - Improved performance of ``.str.encode()`` and ``.str.decode()`` methods (:issue:`13008`)
+- Improved performance of ``to_numeric`` if input is numeric dtype (:issue:`12777`)
+
 
 
 
@@ -516,3 +518,6 @@ Bug Fixes
 - Bug in ``.describe()`` resets categorical columns information (:issue:`11558`)
 - Bug where ``loffset`` argument was not applied when calling ``resample().count()`` on a timeseries (:issue:`12725`)
 - ``pd.read_excel()`` now accepts column names associated with keyword argument ``names`` (:issue:`12870`)
+- Bug in ``to_numeric`` with ``Index`` returns ``np.ndarray``, rather than ``Index`` (:issue:`12777`)
+- Bug in ``to_numeric`` with datetime-like may raise ``TypeError`` (:issue:`12777`)
+- Bug in ``to_numeric`` with scalar raises ``ValueError`` (:issue:`12777`)

--- a/pandas/tools/util.py
+++ b/pandas/tools/util.py
@@ -78,29 +78,52 @@ def to_numeric(arg, errors='raise'):
     >>> pd.to_numeric(s, errors='ignore')
     >>> pd.to_numeric(s, errors='coerce')
     """
+    is_series = False
+    is_index = False
+    is_scalar = False
 
-    index = name = None
     if isinstance(arg, pd.Series):
-        index, name = arg.index, arg.name
+        is_series = True
+        values = arg.values
+    elif isinstance(arg, pd.Index):
+        is_index = True
+        values = arg.asi8
+        if values is None:
+            values = arg.values
     elif isinstance(arg, (list, tuple)):
-        arg = np.array(arg, dtype='O')
+        values = np.array(arg, dtype='O')
+    elif np.isscalar(arg):
+        if com.is_number(arg):
+            return arg
+        is_scalar = True
+        values = np.array([arg], dtype='O')
     elif getattr(arg, 'ndim', 1) > 1:
         raise TypeError('arg must be a list, tuple, 1-d array, or Series')
-
-    conv = arg
-    arg = com._ensure_object(arg)
-
-    coerce_numeric = False if errors in ('ignore', 'raise') else True
-
-    try:
-        conv = lib.maybe_convert_numeric(arg,
-                                         set(),
-                                         coerce_numeric=coerce_numeric)
-    except:
-        if errors == 'raise':
-            raise
-
-    if index is not None:
-        return pd.Series(conv, index=index, name=name)
     else:
-        return conv
+        values = arg
+
+    if com.is_numeric_dtype(values):
+        pass
+    elif com.is_datetime_or_timedelta_dtype(values):
+        values = values.astype(np.int64)
+    else:
+        values = com._ensure_object(values)
+        coerce_numeric = False if errors in ('ignore', 'raise') else True
+
+        try:
+            values = lib.maybe_convert_numeric(values, set(),
+                                               coerce_numeric=coerce_numeric)
+        except:
+            if errors == 'raise':
+                raise
+
+    if is_series:
+        return pd.Series(values, index=arg.index, name=arg.name)
+    elif is_index:
+        # because we want to coerce to numeric if possible,
+        # do not use _shallow_copy_with_infer
+        return Index(values, name=arg.name)
+    elif is_scalar:
+        return values[0]
+    else:
+        return values


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Skip `object` conversion if input is numeric already.

```
-  146.41ms    26.45μs      0.00  miscellaneous.to_numeric.time_from_float
```
