### PR TITLE
BUG: to_dense does not preserve dtype in SparseArray

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -211,3 +211,5 @@ Bug Fixes
 - Bug in ``.describe()`` resets categorical columns information (:issue:`11558`)
 - Bug where ``loffset`` argument was not applied when calling ``resample().count()`` on a timeseries (:issue:`12725`)
 - ``pd.read_excel()`` now accepts path objects (e.g. ``pathlib.Path``, ``py.path.local``) for the file path, in line with other ``read_*`` functions (:issue:`12655`)
+
+- Bug in ``SparseArray.to_dence`` does not preserve ``dtype`` (:issue:`10648`)

--- a/pandas/sparse/array.py
+++ b/pandas/sparse/array.py
@@ -237,7 +237,7 @@ class SparseArray(PandasObject, np.ndarray):
         """
         Dense values
         """
-        output = np.empty(len(self), dtype=np.float64)
+        output = np.empty(len(self), dtype=self.dtype)
         int_index = self.sp_index.to_int_index()
         output.fill(self.fill_value)
         output.put(int_index.indices, self)
@@ -261,8 +261,8 @@ class SparseArray(PandasObject, np.ndarray):
         # fill the nans
         if fill is None:
             fill = self.fill_value
-        if not np.isnan(fill):
-            values[np.isnan(values)] = fill
+        if not com.isnull(fill):
+            values[com.isnull(values)] = fill
 
         return values
 

--- a/pandas/sparse/tests/test_array.py
+++ b/pandas/sparse/tests/test_array.py
@@ -62,6 +62,34 @@ class TestSparseArray(tm.TestCase):
         not_copy.sp_values[:3] = 0
         self.assertTrue((self.arr.sp_values[:3] == 0).all())
 
+    def test_constructor_bool(self):
+        # GH 10648
+        data = np.array([False, False, True, True, False, False])
+        arr = SparseArray(data, fill_value=False, dtype=bool)
+
+        self.assertEqual(arr.dtype, bool)
+        tm.assert_numpy_array_equal(arr.sp_values, np.array([True, True]))
+        tm.assert_numpy_array_equal(arr.sp_values, np.asarray(arr))
+        tm.assert_numpy_array_equal(arr.sp_index.indices, np.array([2, 3]))
+
+        for dense in [arr.to_dense(), arr.values]:
+            self.assertEqual(dense.dtype, bool)
+            tm.assert_numpy_array_equal(dense, data)
+
+    def test_constructor_float32(self):
+        # GH 10648
+        data = np.array([1., np.nan, 3], dtype=np.float32)
+        arr = SparseArray(data, dtype=np.float32)
+
+        self.assertEqual(arr.dtype, np.float32)
+        tm.assert_numpy_array_equal(arr.sp_values, np.array([1, 3]))
+        tm.assert_numpy_array_equal(arr.sp_values, np.asarray(arr))
+        tm.assert_numpy_array_equal(arr.sp_index.indices, np.array([0, 2]))
+
+        for dense in [arr.to_dense(), arr.values]:
+            self.assertEqual(dense.dtype, np.float32)
+            self.assert_numpy_array_equal(dense, data)
+
     def test_astype(self):
         res = self.arr.astype('f8')
         res.sp_values[:3] = 27


### PR DESCRIPTION
- [x] closes #10648
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
