### PR TITLE
BUG: Sparse misc fixes including __repr__

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -81,6 +81,13 @@ API changes
 - ``CParserError`` is now a ``ValueError`` instead of just an ``Exception`` (:issue:`12551`)
 
 - ``pd.show_versions()`` now includes ``pandas_datareader`` version (:issue:`12740`)
+- ``SparseArray.take`` now returns scalar for scalar input, ``SparseArray`` for others (:issue:`10560`)
+
+.. ipython:: python
+
+    s = pd.SparseArray([np.nan, np.nan, 1, 2, 3, np.nan, 4, 5, np.nan, 6])
+    s.take(0)
+    s.take([1, 2, 3])
 
 .. _whatsnew_0181.apply_resample:
 
@@ -211,3 +218,9 @@ Bug Fixes
 - Bug in ``.describe()`` resets categorical columns information (:issue:`11558`)
 - Bug where ``loffset`` argument was not applied when calling ``resample().count()`` on a timeseries (:issue:`12725`)
 - ``pd.read_excel()`` now accepts path objects (e.g. ``pathlib.Path``, ``py.path.local``) for the file path, in line with other ``read_*`` functions (:issue:`12655`)
+
+
+- Bug in ``SparseSeries.loc[]`` with list-like input raises ``TypeError`` (:issue:`10560`)
+- Bug in ``SparseSeries.iloc[]`` with scalar input may raise ``IndexError`` (:issue:`10560`)
+- Bug in ``SparseSeries.loc[]``, ``.iloc[]`` with ``slice`` returns ``SparseArray``, rather than ``SparseSeries`` (:issue:`10560`)
+- Bug in ``SparseSeries.__repr__`` raises ``TypeError`` when it is longer than ``max_rows`` (:issue:`10560`)

--- a/pandas/io/tests/test_pickle.py
+++ b/pandas/io/tests/test_pickle.py
@@ -10,7 +10,6 @@ from distutils.version import LooseVersion
 import pandas as pd
 from pandas import Index
 from pandas.compat import u
-from pandas.sparse.tests import test_sparse
 from pandas.util.misc import is_little_endian
 import pandas
 import pandas.util.testing as tm
@@ -46,7 +45,7 @@ class TestPickle():
             return
 
         if typ.startswith('sp_'):
-            comparator = getattr(test_sparse, "assert_%s_equal" % typ)
+            comparator = getattr(tm, "assert_%s_equal" % typ)
             comparator(result, expected, exact_indices=False)
         else:
             comparator = getattr(tm, "assert_%s_equal" %

--- a/pandas/sparse/array.py
+++ b/pandas/sparse/array.py
@@ -280,10 +280,7 @@ class SparseArray(PandasObject, np.ndarray):
             if isinstance(key, SparseArray):
                 key = np.asarray(key)
             if hasattr(key, '__len__') and len(self) != len(key):
-                indices = self.sp_index
-                if hasattr(indices, 'to_int_index'):
-                    indices = indices.to_int_index()
-                data_slice = self.values.take(indices.indices)[key]
+                return self.take(key)
             else:
                 data_slice = self.values[key]
             return self._constructor(data_slice)
@@ -320,6 +317,11 @@ class SparseArray(PandasObject, np.ndarray):
         """
         if axis:
             raise ValueError("axis must be 0, input was {0}".format(axis))
+
+        if com.is_integer(indices):
+            # return scalar
+            return self[indices]
+
         indices = np.atleast_1d(np.asarray(indices, dtype=int))
 
         # allow -1 to indicate missing values
@@ -344,7 +346,7 @@ class SparseArray(PandasObject, np.ndarray):
             result = np.empty(len(indices))
             result.fill(self.fill_value)
 
-        return result
+        return self._constructor(result)
 
     def __setitem__(self, key, value):
         # if com.is_integer(key):

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -543,9 +543,10 @@ class SparseDataFrame(DataFrame):
                 continue
 
             values = series.values
+            # .take returns SparseArray
             new = values.take(indexer)
-
             if need_mask:
+                new = new.values
                 np.putmask(new, mask, fill_value)
 
             new_series[col] = new

--- a/pandas/sparse/tests/test_indexing.py
+++ b/pandas/sparse/tests/test_indexing.py
@@ -1,0 +1,84 @@
+# pylint: disable-msg=E1101,W0612
+
+import nose  # noqa
+import numpy as np
+import pandas as pd
+import pandas.util.testing as tm
+
+
+class TestSparseSeriesIndexing(tm.TestCase):
+
+    _multiprocess_can_split_ = True
+
+    def test_loc(self):
+        orig = pd.Series([1, np.nan, np.nan, 3, np.nan])
+        sparse = orig.to_sparse()
+
+        self.assertEqual(sparse.loc[0], 1)
+        self.assertTrue(np.isnan(sparse.loc[1]))
+
+        result = sparse.loc[[1, 3, 4]]
+        exp = orig.loc[[1, 3, 4]].to_sparse()
+        tm.assert_sp_series_equal(result, exp)
+
+        # exceeds the bounds
+        result = sparse.loc[[1, 3, 4, 5]]
+        exp = orig.loc[[1, 3, 4, 5]].to_sparse()
+        tm.assert_sp_series_equal(result, exp)
+        # padded with NaN
+        self.assertTrue(np.isnan(result[-1]))
+
+        # dense array
+        result = sparse.loc[orig % 2 == 1]
+        exp = orig.loc[orig % 2 == 1].to_sparse()
+        tm.assert_sp_series_equal(result, exp)
+
+        # sparse array (actuary it coerces to normal Series)
+        result = sparse.loc[sparse % 2 == 1]
+        exp = orig.loc[orig % 2 == 1].to_sparse()
+        tm.assert_sp_series_equal(result, exp)
+
+    def test_loc_index(self):
+        orig = pd.Series([1, np.nan, np.nan, 3, np.nan], index=list('ABCDE'))
+        sparse = orig.to_sparse()
+
+        self.assertEqual(sparse.loc['A'], 1)
+        self.assertTrue(np.isnan(sparse.loc['B']))
+
+        result = sparse.loc[['A', 'C', 'D']]
+        exp = orig.loc[['A', 'C', 'D']].to_sparse()
+        tm.assert_sp_series_equal(result, exp)
+
+        # dense array
+        result = sparse.loc[orig % 2 == 1]
+        exp = orig.loc[orig % 2 == 1].to_sparse()
+        tm.assert_sp_series_equal(result, exp)
+
+        # sparse array (actuary it coerces to normal Series)
+        result = sparse.loc[sparse % 2 == 1]
+        exp = orig.loc[orig % 2 == 1].to_sparse()
+        tm.assert_sp_series_equal(result, exp)
+
+    def test_loc_slice(self):
+        orig = pd.Series([1, np.nan, np.nan, 3, np.nan])
+        sparse = orig.to_sparse()
+        tm.assert_sp_series_equal(sparse.loc[2:], orig.loc[2:].to_sparse())
+
+    def test_iloc(self):
+        orig = pd.Series([1, np.nan, np.nan, 3, np.nan])
+        sparse = orig.to_sparse()
+
+        self.assertEqual(sparse.iloc[3], 3)
+        self.assertTrue(np.isnan(sparse.iloc[2]))
+
+        result = sparse.iloc[[1, 3, 4]]
+        exp = orig.iloc[[1, 3, 4]].to_sparse()
+        tm.assert_sp_series_equal(result, exp)
+
+        with tm.assertRaises(IndexError):
+            sparse.iloc[[1, 3, 5]]
+
+    def test_iloc_slice(self):
+        orig = pd.Series([1, np.nan, np.nan, 3, np.nan])
+        sparse = orig.to_sparse()
+        tm.assert_sp_series_equal(sparse.iloc[2:], orig.iloc[2:].to_sparse())

--- a/pandas/sparse/tests/test_list.py
+++ b/pandas/sparse/tests/test_list.py
@@ -5,13 +5,7 @@ from numpy import nan
 import numpy as np
 
 from pandas.sparse.api import SparseList, SparseArray
-from pandas.util.testing import assert_almost_equal
-
-from .test_sparse import assert_sp_array_equal
-
-
-def assert_sp_list_equal(left, right):
-    assert_sp_array_equal(left.to_array(), right.to_array())
+import pandas.util.testing as tm
 
 
 class TestSparseList(unittest.TestCase):
@@ -26,7 +20,7 @@ class TestSparseList(unittest.TestCase):
         lst1 = SparseList(self.na_data[:5])
         exp = SparseList()
         exp.append(self.na_data[:5])
-        assert_sp_list_equal(lst1, exp)
+        tm.assert_sp_list_equal(lst1, exp)
 
     def test_len(self):
         arr = self.na_data
@@ -46,7 +40,7 @@ class TestSparseList(unittest.TestCase):
         splist.append(arr[6:])
 
         sparr = splist.to_array()
-        assert_sp_array_equal(sparr, SparseArray(arr))
+        tm.assert_sp_array_equal(sparr, SparseArray(arr))
 
     def test_append_zero(self):
         arr = self.zero_data
@@ -56,7 +50,7 @@ class TestSparseList(unittest.TestCase):
         splist.append(arr[6:])
 
         sparr = splist.to_array()
-        assert_sp_array_equal(sparr, SparseArray(arr, fill_value=0))
+        tm.assert_sp_array_equal(sparr, SparseArray(arr, fill_value=0))
 
     def test_consolidate(self):
         arr = self.na_data
@@ -70,11 +64,11 @@ class TestSparseList(unittest.TestCase):
         consol = splist.consolidate(inplace=False)
         self.assertEqual(consol.nchunks, 1)
         self.assertEqual(splist.nchunks, 3)
-        assert_sp_array_equal(consol.to_array(), exp_sparr)
+        tm.assert_sp_array_equal(consol.to_array(), exp_sparr)
 
         splist.consolidate()
         self.assertEqual(splist.nchunks, 1)
-        assert_sp_array_equal(splist.to_array(), exp_sparr)
+        tm.assert_sp_array_equal(splist.to_array(), exp_sparr)
 
     def test_copy(self):
         arr = self.na_data
@@ -87,7 +81,7 @@ class TestSparseList(unittest.TestCase):
         cp = splist.copy()
         cp.append(arr[6:])
         self.assertEqual(splist.nchunks, 2)
-        assert_sp_array_equal(cp.to_array(), exp_sparr)
+        tm.assert_sp_array_equal(cp.to_array(), exp_sparr)
 
     def test_getitem(self):
         arr = self.na_data
@@ -97,8 +91,8 @@ class TestSparseList(unittest.TestCase):
         splist.append(arr[6:])
 
         for i in range(len(arr)):
-            assert_almost_equal(splist[i], arr[i])
-            assert_almost_equal(splist[-i], arr[-i])
+            tm.assert_almost_equal(splist[i], arr[i])
+            tm.assert_almost_equal(splist[-i], arr[-i])
 
 
 if __name__ == '__main__':

--- a/pandas/tests/test_format.py
+++ b/pandas/tests/test_format.py
@@ -3198,6 +3198,7 @@ $1$,$2$
 
 
 class TestSeriesFormatting(tm.TestCase):
+
     _multiprocess_can_split_ = True
 
     def setUp(self):
@@ -3709,6 +3710,24 @@ class TestSeriesFormatting(tm.TestCase):
         res = s.to_string(header=False, max_rows=2)
         exp = '0    0\n    ..\n9    9'
         self.assertEqual(res, exp)
+
+    def test_sparse_max_row(self):
+        s = pd.Series([1, np.nan, np.nan, 3, np.nan]).to_sparse()
+        result = repr(s)
+        exp = ("0    1.0\n1    NaN\n2    NaN\n3    3.0\n"
+               "4    NaN\ndtype: float64\nBlockIndex\n"
+               "Block locations: array([0, 3], dtype=int32)\n"
+               "Block lengths: array([1, 1], dtype=int32)")
+        self.assertEqual(result, exp)
+
+        with option_context("display.max_rows", 3):
+            # GH 10560
+            result = repr(s)
+            exp = ("0    1.0\n    ... \n4    NaN\n"
+                   "dtype: float64\nBlockIndex\n"
+                   "Block locations: array([0, 3], dtype=int32)\n"
+                   "Block lengths: array([1, 1], dtype=int32)")
+            self.assertEqual(result, exp)
 
 
 class TestEngFormatter(tm.TestCase):


### PR DESCRIPTION
- [x] closes #10560
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Fixes following issues.

```
# NG, should be SparseArray (categorized as API change)
a = pd.SparseArray([1, np.nan, np.nan, 3, np.nan])
type(a.take([1, 2]))
# numpy.ndarray

# NG
s = pd.Series([1, np.nan, np.nan, 3, np.nan]).to_sparse()
s.loc[[1, 3]]
# TypeError: reindex() got an unexpected keyword argument 'level'

# NG
s.iloc[2]
# IndexError: index out of bounds

# NG, must be SparseSeries (root cause of 10560)
type(s.iloc[2:])
# pandas.sparse.array.SparseArray
```
