### PR TITLE
DOC: Clarify when csv separator is being parsed as regex. Resolves #10208

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -91,9 +91,10 @@ filepath_or_buffer : various
   :class:`~python:io.StringIO`).
 sep : str, defaults to ``','`` for :func:`read_csv`, ``\t`` for :func:`read_table`
   Delimiter to use. If sep is ``None``,
-  will try to automatically determine this. Regular expressions are accepted,
-  use of a regular expression will force use of the python parsing engine and
-  will ignore quotes in the data.
+  will try to automatically determine this. Separators longer than 1 character
+  and different from ``'\s+'`` will be interpreted as regular expressions, will
+  force use of the python parsing engine and will ignore quotes in the data.
+  Regex example: ``'\\r\\t'``.
 delimiter : str, default ``None``
   Alternative argument name for sep.
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -221,8 +221,9 @@ _engine_doc = """engine : {'c', 'python'}, optional
 
 _sep_doc = """sep : str, default {default}
     Delimiter to use. If sep is None, will try to automatically determine
-    this. Regular expressions are accepted and will force use of the python
-    parsing engine and will ignore quotes in the data."""
+    this. Separators longer than 1 character and different from '\s+' will be
+    interpreted as regular expressions, will force use of the python parsing
+    engine and will ignore quotes in the data. Regex example: '\\r\\t'"""
 
 _read_csv_doc = """
 Read CSV (comma-separated) file into DataFrame
@@ -674,7 +675,9 @@ class TextFileReader(BaseIterator):
             elif engine not in ('python', 'python-fwf'):
                 # wait until regex engine integrated
                 fallback_reason = "the 'c' engine does not support"\
-                                  " regex separators"
+                                  " regex separators (separators > 1 char and"\
+                                  " different from '\s+' are"\
+                                  " interpreted as regex)"
                 engine = 'python'
 
         if fallback_reason and engine_specified:


### PR DESCRIPTION
- [x] closes #10208
- [ ] tests added / passed -- only docs, not needed
- [x] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry -- neccessary for docs?
