### PR TITLE
BUG: DataFrame.drop() does nothing for non-unique Datetime MultiIndex

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -211,3 +211,10 @@ Bug Fixes
 - Bug in ``.describe()`` resets categorical columns information (:issue:`11558`)
 - Bug where ``loffset`` argument was not applied when calling ``resample().count()`` on a timeseries (:issue:`12725`)
 - ``pd.read_excel()`` now accepts path objects (e.g. ``pathlib.Path``, ``py.path.local``) for the file path, in line with other ``read_*`` functions (:issue:`12655`)
+
+
+
+
+- Bug in ``DataFrame.drop()`` when the DataFrame had non-unique datetime MultiIndex (:issue:`12701`)
+
+

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1881,8 +1881,7 @@ class NDFrame(PandasObject):
             if level is not None:
                 if not isinstance(axis, MultiIndex):
                     raise AssertionError('axis must be a MultiIndex')
-                indexer = ~lib.ismember(
-                    axis.get_level_values(level).values, set(labels))
+                indexer = ~axis.get_level_values(level).isin(labels)
             else:
                 indexer = ~axis.isin(labels)
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1948,6 +1948,23 @@ Thur,Lunch,Yes,51.51,17"""
         expected = self.frame.ix[[0, 2, 3, 6, 7, 9]].T
         assert_frame_equal(result, expected)
 
+    def test_drop_level_nonunique_datetime(self):
+        # GH 12701
+        idx = pd.Index([2, 3, 4, 4, 5], name='id')
+        idxdt = pd.to_datetime(['201603231400',
+                                '201603231500',
+                                '201603231600',
+                                '201603231600',
+                                '201603231700'])
+        df = DataFrame(np.arange(10).reshape(5, 2),
+                       columns=list('ab'), index=idx)
+        df['tstamp'] = idxdt
+        df = df.set_index('tstamp', append=True)
+        ts = pd.Timestamp('201603231600')
+        result = df.drop(ts, level='tstamp')
+        expected = df.loc[idx != 4]
+        assert_frame_equal(result, expected)
+
     def test_drop_preserve_names(self):
         index = MultiIndex.from_arrays([[0, 0, 0, 1, 1, 1],
                                         [1, 2, 3, 1, 2, 3]],


### PR DESCRIPTION
- [x] closes #12701
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Closes #12701

Follows the suggested fix in the comments to the bug report.
Also added a line in whatsnew and a test.

Regarding the tests it passes the one I added. But I just noticed that plenty others fail and I have yet to find out whether it's caused by this (who knows, it might)
Update: It's the same tests failing on master branch as on this one (phew..). I guess the errors deserve bug reports but that's for another time.
