### PR TITLE
BUG: loc raises inconsistent error on unsorted MultiIndex

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -233,3 +233,4 @@ Bug Fixes
 - Bug in ``.describe()`` resets categorical columns information (:issue:`11558`)
 - Bug where ``loffset`` argument was not applied when calling ``resample().count()`` on a timeseries (:issue:`12725`)
 - ``pd.read_excel()`` now accepts path objects (e.g. ``pathlib.Path``, ``py.path.local``) for the file path, in line with other ``read_*`` functions (:issue:`12655`)
+- Bug in ``.loc`` raises inconsistent error when called on an unsorted ``MultiIndex`` (:issue:12660)

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -1595,6 +1595,8 @@ class MultiIndex(Index):
         ----------
         key : label or tuple
         level : int/level name or list thereof
+        drop_level : bool
+            drop a level from the index if only a single element is selected
 
         Returns
         -------
@@ -1637,6 +1639,18 @@ class MultiIndex(Index):
         # kludge for #1796
         if isinstance(key, list):
             key = tuple(key)
+
+        # must be lexsorted to at least as many levels as the level parameter,
+        # or the number of items in the key tuple.
+        # Note: level is 0-based
+        required_lexsort_depth = level + 1
+        if isinstance(key, tuple):
+            required_lexsort_depth = max(required_lexsort_depth, len(key))
+        if self.lexsort_depth < required_lexsort_depth:
+            raise KeyError('MultiIndex Slicing requires the index to be '
+                           'fully lexsorted tuple len ({0}), lexsort depth '
+                           '({1})'.format(required_lexsort_depth,
+                                          self.lexsort_depth))
 
         if isinstance(key, tuple) and level == 0:
 

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -2300,6 +2300,36 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
                 'lexsorted tuple len \(2\), lexsort depth \(0\)'):
             df.loc[(slice(None), df.loc[:, ('a', 'bar')] > 5), :]
 
+    def test_multiindex_slicers_raise_key_error(self):
+
+        # GH6134
+        # Test that mi slicers raise a KeyError with the proper error message
+        # on unsorted indices regardless of the invocation method
+        iterables1 = [['a', 'b'], [2, 1]]
+        iterables2 = [['c', 'd'], [4, 3]]
+        rows = pd.MultiIndex.from_product(iterables1,
+                                          names=['row1', 'row2'])
+        columns = pd.MultiIndex.from_product(iterables2,
+                                             names=['col1', 'col2'])
+        df = pd.DataFrame(np.random.randn(4, 4), index=rows, columns=columns)
+
+        # In this example rows are not sorted at all,
+        # columns are sorted to the first level
+        self.assertEqual(df.index.lexsort_depth, 1)
+        self.assertEqual(df.columns.lexsort_depth, 0)
+
+        with tm.assertRaisesRegexp(
+                KeyError,
+                'MultiIndex Slicing requires the index to be fully '
+                'lexsorted tuple len \(\d\), lexsort depth \(\d\)'):
+            df.loc[('a', slice(None)), 'b']
+
+        with tm.assertRaisesRegexp(
+                KeyError,
+                'MultiIndex Slicing requires the index to be fully '
+                'lexsorted tuple len \(\d\), lexsort depth \(\d\)'):
+            df.loc['a', 'b']
+
     def test_multiindex_slicers_non_unique(self):
 
         # GH 7106


### PR DESCRIPTION
- [x] closes #12660 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

.loc was fixed to always raise a KeyError with a helpful error message when called on an unsorted MultiIndex DataFrame

Tests ran fine the last time I checked, but if I run them with the latest upstream now I get a totally unrelated ImportError error - I assume it is not related to my changes. Btw this is my first real contribution to a large open source project, I tried to pay attention to everything but let me know if anything needs to be improved!
