### PR TITLE
Fix for #12723: Unexpected behavior with binary operators and fill…

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -321,3 +321,5 @@ Bug Fixes
 - Bug where ``loffset`` argument was not applied when calling ``resample().count()`` on a timeseries (:issue:`12725`)
 - ``pd.read_excel()`` now accepts path objects (e.g. ``pathlib.Path``, ``py.path.local``) for the file path, in line with other ``read_*`` functions (:issue:`12655`)
 - ``pd.read_excel()`` now accepts column names associated with keyword argument ``names``(:issue `12870`)
+
+- Bug in ``fill_value`` is ignored if the argument to a binary operator is a constant (:issue `12723`)

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -933,6 +933,9 @@ def _flex_method_SERIES(op, name, str_rep, default_axis=None, fill_zeros=None,
             return self._binop(self._constructor(other, self.index), op,
                                level=level, fill_value=fill_value)
         else:
+            if fill_value is not None:
+                self = self.fillna(fill_value)
+
             return self._constructor(op(self.values, other),
                                      self.index).__finalize__(self)
 
@@ -1088,6 +1091,9 @@ def _arith_method_FRAME(op, name, str_rep=None, default_axis='columns',
                 raise ValueError("Incompatible argument shape: %s" %
                                  (other.shape, ))
         else:
+            if fill_value is not None:
+                self = self.fillna(fill_value)
+
             return self._combine_const(other, na_op)
 
     f.__name__ = name

--- a/pandas/sparse/tests/test_frame.py
+++ b/pandas/sparse/tests/test_frame.py
@@ -60,6 +60,15 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
 
         self.empty = SparseDataFrame()
 
+    def test_fill_value_when_combine_const(self):
+        # GH12723
+        dat = np.array([0, 1, np.nan, 3, 4, 5], dtype='float')
+        df = SparseDataFrame({'foo': dat}, index=range(6))
+
+        exp = df.fillna(0).add(2)
+        res = df.add(2, fill_value=0)
+        tm.assert_sp_frame_equal(res, exp)
+
     def test_as_matrix(self):
         empty = self.empty.as_matrix()
         self.assertEqual(empty.shape, (0, 0))

--- a/pandas/sparse/tests/test_series.py
+++ b/pandas/sparse/tests/test_series.py
@@ -740,6 +740,14 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
         result = cop2 / cop
         self.assertTrue(np.isnan(result.fill_value))
 
+    def test_fill_value_when_combine_const(self):
+        # GH12723
+        s = SparseSeries([0, 1, np.nan, 3, 4, 5], index=np.arange(6))
+
+        exp = s.fillna(0).add(2)
+        res = s.add(2, fill_value=0)
+        self.assert_series_equal(res, exp)
+
     def test_shift(self):
         series = SparseSeries([nan, 1., 2., 3., nan, nan], index=np.arange(6))
 

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -425,3 +425,19 @@ class TestDataFrameMissingData(tm.TestCase, TestData):
 
         # TODO(wesm): unused?
         result = empty_float.fillna(value=0)  # noqa
+
+    def test_fill_value_when_combine_const(self):
+        # GH12723
+        dat = np.array([0, 1, np.nan, 3, 4, 5], dtype='float')
+        df = DataFrame({'foo': dat}, index=range(6))
+
+        exp = df.fillna(0).add(2)
+        res = df.add(2, fill_value=0)
+        assert_frame_equal(res, exp)
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   # '--with-coverage', '--cover-package=pandas.core']
+                   exit=False)

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -452,3 +452,18 @@ class TestSeriesMissingData(TestData, tm.TestCase):
         ts = self.ts.copy()
         ts.dropna(inplace=True)
         self.assertEqual(ts.name, name)
+
+    def test_fill_value_when_combine_const(self):
+        # GH12723
+        s = Series([0, 1, np.nan, 3, 4, 5])
+
+        exp = s.fillna(0).add(2)
+        res = s.add(2, fill_value=0)
+        assert_series_equal(res, exp)
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   # '--with-coverage', '--cover-package=pandas.core']
+                   exit=False)


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

closes #12723 
