### PR TITLE
ENH/PERF SparseArray.take indexing

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -81,7 +81,7 @@ These changes conform sparse handling to return the correct types and work to ma
 - Bug in ``SparseSeries.__repr__`` raises ``TypeError`` when it is longer than ``max_rows`` (:issue:`10560`)
 - Bug in ``SparseSeries.shape`` ignores ``fill_value`` (:issue:`10452`)
 - Bug in ``SparseArray.to_dense()`` does not preserve ``dtype`` (:issue:`10648`)
-- ``SparseArray.take`` now returns scalar for scalar input, ``SparseArray`` for others (:issue:`10560`)
+- ``SparseArray.take`` now returns scalar for scalar input, ``SparseArray`` for others. Also now it handles negative indexer as the same rule as ``Index`` (:issue:`10560`, :issue:`12796`)
 
   .. ipython:: python
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -809,9 +809,6 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         self._data = self._data.setitem(indexer=key, value=value)
         self._maybe_update_cacher()
 
-    # help out SparseSeries
-    _get_val_at = ndarray.__getitem__
-
     def repeat(self, reps):
         """
         return a new Series with the values repeated reps times

--- a/pandas/indexes/base.py
+++ b/pandas/indexes/base.py
@@ -1332,7 +1332,7 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
         return indexes
 
     _index_shared_docs['take'] = """
-        return a new Index of the values selected by the indices
+        return a new %(klass)s of the values selected by the indices
 
         For internal compatibility with numpy arrays.
 
@@ -1352,7 +1352,7 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
         numpy.ndarray.take
         """
 
-    @Appender(_index_shared_docs['take'])
+    @Appender(_index_shared_docs['take'] % _index_doc_kwargs)
     def take(self, indices, axis=0, allow_fill=True, fill_value=None):
         indices = com._ensure_platform_int(indices)
         if self._can_hold_na:

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -165,10 +165,10 @@ class SparseSeries(Series):
                 if index is None:
                     index = data.index.view()
                 else:
+
                     data = data.reindex(index, copy=False)
 
             else:
-
                 length = len(index)
 
                 if data == fill_value or (isnull(data) and isnull(fill_value)):
@@ -375,11 +375,6 @@ class SparseSeries(Series):
     def _get_val_at(self, loc):
         """ forward to the array """
         return self.block.values._get_val_at(loc)
-
-    def _slice(self, slobj, axis=0, kind=None):
-        slobj = self.index._convert_slice_indexer(slobj,
-                                                  kind=kind or 'getitem')
-        return self._get_values(slobj)
 
     def __getitem__(self, key):
         """

--- a/pandas/sparse/tests/test_indexing.py
+++ b/pandas/sparse/tests/test_indexing.py
@@ -10,6 +10,51 @@ class TestSparseSeriesIndexing(tm.TestCase):
 
     _multiprocess_can_split_ = True
 
+    def test_getitem(self):
+        orig = pd.Series([1, np.nan, np.nan, 3, np.nan])
+        sparse = orig.to_sparse()
+
+        self.assertEqual(sparse[0], 1)
+        self.assertTrue(np.isnan(sparse[1]))
+        self.assertEqual(sparse[3], 3)
+
+        result = sparse[[1, 3, 4]]
+        exp = orig[[1, 3, 4]].to_sparse()
+        tm.assert_sp_series_equal(result, exp)
+
+        # dense array
+        result = sparse[orig % 2 == 1]
+        exp = orig[orig % 2 == 1].to_sparse()
+        tm.assert_sp_series_equal(result, exp)
+
+        # sparse array (actuary it coerces to normal Series)
+        result = sparse[sparse % 2 == 1]
+        exp = orig[orig % 2 == 1].to_sparse()
+        tm.assert_sp_series_equal(result, exp)
+
+    def test_getitem_fill_value(self):
+        orig = pd.Series([1, np.nan, 0, 3, 0])
+        sparse = orig.to_sparse(fill_value=0)
+
+        self.assertEqual(sparse[0], 1)
+        self.assertTrue(np.isnan(sparse[1]))
+        self.assertEqual(sparse[2], 0)
+        self.assertEqual(sparse[3], 3)
+
+        result = sparse[[1, 3, 4]]
+        exp = orig[[1, 3, 4]].to_sparse(fill_value=0)
+        tm.assert_sp_series_equal(result, exp)
+
+        # dense array
+        result = sparse[orig % 2 == 1]
+        exp = orig[orig % 2 == 1].to_sparse(fill_value=0)
+        tm.assert_sp_series_equal(result, exp)
+
+        # sparse array (actuary it coerces to normal Series)
+        result = sparse[sparse % 2 == 1]
+        exp = orig[orig % 2 == 1].to_sparse(fill_value=0)
+        tm.assert_sp_series_equal(result, exp)
+
     def test_loc(self):
         orig = pd.Series([1, np.nan, np.nan, 3, np.nan])
         sparse = orig.to_sparse()
@@ -59,10 +104,37 @@ class TestSparseSeriesIndexing(tm.TestCase):
         exp = orig.loc[orig % 2 == 1].to_sparse()
         tm.assert_sp_series_equal(result, exp)
 
+    def test_loc_index_fill_value(self):
+        orig = pd.Series([1, np.nan, 0, 3, 0], index=list('ABCDE'))
+        sparse = orig.to_sparse(fill_value=0)
+
+        self.assertEqual(sparse.loc['A'], 1)
+        self.assertTrue(np.isnan(sparse.loc['B']))
+
+        result = sparse.loc[['A', 'C', 'D']]
+        exp = orig.loc[['A', 'C', 'D']].to_sparse(fill_value=0)
+        tm.assert_sp_series_equal(result, exp)
+
+        # dense array
+        result = sparse.loc[orig % 2 == 1]
+        exp = orig.loc[orig % 2 == 1].to_sparse(fill_value=0)
+        tm.assert_sp_series_equal(result, exp)
+
+        # sparse array (actuary it coerces to normal Series)
+        result = sparse.loc[sparse % 2 == 1]
+        exp = orig.loc[orig % 2 == 1].to_sparse(fill_value=0)
+        tm.assert_sp_series_equal(result, exp)
+
     def test_loc_slice(self):
         orig = pd.Series([1, np.nan, np.nan, 3, np.nan])
         sparse = orig.to_sparse()
         tm.assert_sp_series_equal(sparse.loc[2:], orig.loc[2:].to_sparse())
+
+    def test_loc_slice_fill_value(self):
+        orig = pd.Series([1, np.nan, 0, 3, 0])
+        sparse = orig.to_sparse(fill_value=0)
+        tm.assert_sp_series_equal(sparse.loc[2:],
+                                  orig.loc[2:].to_sparse(fill_value=0))
 
     def test_iloc(self):
         orig = pd.Series([1, np.nan, np.nan, 3, np.nan])
@@ -75,13 +147,113 @@ class TestSparseSeriesIndexing(tm.TestCase):
         exp = orig.iloc[[1, 3, 4]].to_sparse()
         tm.assert_sp_series_equal(result, exp)
 
+        result = sparse.iloc[[1, -2, -4]]
+        exp = orig.iloc[[1, -2, -4]].to_sparse()
+        tm.assert_sp_series_equal(result, exp)
+
         with tm.assertRaises(IndexError):
             sparse.iloc[[1, 3, 5]]
+
+    def test_iloc_fill_value(self):
+        orig = pd.Series([1, np.nan, 0, 3, 0])
+        sparse = orig.to_sparse(fill_value=0)
+
+        self.assertEqual(sparse.iloc[3], 3)
+        self.assertTrue(np.isnan(sparse.iloc[1]))
+        self.assertEqual(sparse.iloc[4], 0)
+
+        result = sparse.iloc[[1, 3, 4]]
+        exp = orig.iloc[[1, 3, 4]].to_sparse(fill_value=0)
+        tm.assert_sp_series_equal(result, exp)
 
     def test_iloc_slice(self):
         orig = pd.Series([1, np.nan, np.nan, 3, np.nan])
         sparse = orig.to_sparse()
         tm.assert_sp_series_equal(sparse.iloc[2:], orig.iloc[2:].to_sparse())
+
+    def test_iloc_slice_fill_value(self):
+        orig = pd.Series([1, np.nan, 0, 3, 0])
+        sparse = orig.to_sparse(fill_value=0)
+        tm.assert_sp_series_equal(sparse.iloc[2:],
+                                  orig.iloc[2:].to_sparse(fill_value=0))
+
+    def test_at(self):
+        orig = pd.Series([1, np.nan, np.nan, 3, np.nan])
+        sparse = orig.to_sparse()
+        self.assertEqual(sparse.at[0], orig.at[0])
+        self.assertTrue(np.isnan(sparse.at[1]))
+        self.assertTrue(np.isnan(sparse.at[2]))
+        self.assertEqual(sparse.at[3], orig.at[3])
+        self.assertTrue(np.isnan(sparse.at[4]))
+
+        orig = pd.Series([1, np.nan, np.nan, 3, np.nan],
+                         index=list('abcde'))
+        sparse = orig.to_sparse()
+        self.assertEqual(sparse.at['a'], orig.at['a'])
+        self.assertTrue(np.isnan(sparse.at['b']))
+        self.assertTrue(np.isnan(sparse.at['c']))
+        self.assertEqual(sparse.at['d'], orig.at['d'])
+        self.assertTrue(np.isnan(sparse.at['e']))
+
+    def test_at_fill_value(self):
+        orig = pd.Series([1, np.nan, 0, 3, 0],
+                         index=list('abcde'))
+        sparse = orig.to_sparse(fill_value=0)
+        self.assertEqual(sparse.at['a'], orig.at['a'])
+        self.assertTrue(np.isnan(sparse.at['b']))
+        self.assertEqual(sparse.at['c'], orig.at['c'])
+        self.assertEqual(sparse.at['d'], orig.at['d'])
+        self.assertEqual(sparse.at['e'], orig.at['e'])
+
+    def test_iat(self):
+        orig = pd.Series([1, np.nan, np.nan, 3, np.nan])
+        sparse = orig.to_sparse()
+        self.assertEqual(sparse.iat[0], orig.iat[0])
+        self.assertTrue(np.isnan(sparse.iat[1]))
+        self.assertTrue(np.isnan(sparse.iat[2]))
+        self.assertEqual(sparse.iat[3], orig.iat[3])
+        self.assertTrue(np.isnan(sparse.iat[4]))
+
+        self.assertTrue(np.isnan(sparse.iat[-1]))
+        self.assertEqual(sparse.iat[-5], orig.iat[-5])
+
+    def test_iat_fill_value(self):
+        orig = pd.Series([1, np.nan, 0, 3, 0])
+        sparse = orig.to_sparse()
+        self.assertEqual(sparse.iat[0], orig.iat[0])
+        self.assertTrue(np.isnan(sparse.iat[1]))
+        self.assertEqual(sparse.iat[2], orig.iat[2])
+        self.assertEqual(sparse.iat[3], orig.iat[3])
+        self.assertEqual(sparse.iat[4], orig.iat[4])
+
+        self.assertEqual(sparse.iat[-1], orig.iat[-1])
+        self.assertEqual(sparse.iat[-5], orig.iat[-5])
+
+    def test_take(self):
+        orig = pd.Series([1, np.nan, np.nan, 3, np.nan],
+                         index=list('ABCDE'))
+        sparse = orig.to_sparse()
+
+        tm.assert_sp_series_equal(sparse.take([0]),
+                                  orig.take([0]).to_sparse())
+        tm.assert_sp_series_equal(sparse.take([0, 1, 3]),
+                                  orig.take([0, 1, 3]).to_sparse())
+        tm.assert_sp_series_equal(sparse.take([-1, -2]),
+                                  orig.take([-1, -2]).to_sparse())
+
+    def test_take_fill_value(self):
+        orig = pd.Series([1, np.nan, 0, 3, 0],
+                         index=list('ABCDE'))
+        sparse = orig.to_sparse(fill_value=0)
+
+        tm.assert_sp_series_equal(sparse.take([0]),
+                                  orig.take([0]).to_sparse(fill_value=0))
+
+        exp = orig.take([0, 1, 3]).to_sparse(fill_value=0)
+        tm.assert_sp_series_equal(sparse.take([0, 1, 3]), exp)
+
+        exp = orig.take([-1, -2]).to_sparse(fill_value=0)
+        tm.assert_sp_series_equal(sparse.take([-1, -2]), exp)
 
 
 class TestSparseDataFrameIndexing(tm.TestCase):

--- a/pandas/src/sparse.pyx
+++ b/pandas/src/sparse.pyx
@@ -1,4 +1,4 @@
-from numpy cimport ndarray, int32_t, float64_t
+from numpy cimport ndarray, uint8_t, int32_t, float64_t
 cimport numpy as np
 
 cimport cython
@@ -177,12 +177,21 @@ cdef class IntIndex(SparseIndex):
         return IntIndex(x.length, new_list)
 
     @cython.wraparound(False)
-    cpdef lookup(self, Py_ssize_t index):
+    cpdef int lookup(self, Py_ssize_t index):
+        """
+        Return the internal location if value exists on given index.
+        Return -1 otherwise.
+        """
         cdef:
-            Py_ssize_t res, n, cum_len = 0
+            Py_ssize_t res
             ndarray[int32_t, ndim=1] inds
 
         inds = self.indices
+        if self.npoints == 0:
+            return -1
+        elif index < 0 or self.length <= index:
+            return -1
+
         res = inds.searchsorted(index)
         if res == self.npoints:
             return -1
@@ -190,6 +199,36 @@ cdef class IntIndex(SparseIndex):
             return res
         else:
             return -1
+
+    @cython.wraparound(False)
+    cpdef ndarray[int32_t] lookup_array(self, ndarray[int32_t, ndim=1] indexer):
+        """
+        Vectorized lookup, returns ndarray[int32_t]
+        """
+        cdef:
+            Py_ssize_t n, i, ind_val
+            ndarray[int32_t, ndim=1] inds
+            ndarray[uint8_t, ndim=1, cast=True] mask
+            ndarray[int32_t, ndim=1] masked
+            ndarray[int32_t, ndim=1] res
+            ndarray[int32_t, ndim=1] results
+
+        n = len(indexer)
+        results = np.empty(n, dtype=np.int32)
+        results.fill(-1)
+
+        if self.npoints == 0:
+            return results
+
+        inds = self.indices
+        mask = (inds[0] <= indexer) & (indexer <= inds[len(inds) - 1])
+
+        masked = indexer[mask]
+        res = inds.searchsorted(masked).astype(np.int32)
+
+        res[inds[res] != masked] = -1
+        results[mask] = res
+        return results
 
     cpdef ndarray reindex(self, ndarray[float64_t, ndim=1] values,
                           float64_t fill_value, SparseIndex other_):
@@ -475,11 +514,11 @@ cdef class BlockIndex(SparseIndex):
         '''
         return BlockUnion(self, y.to_block_index()).result
 
-    cpdef lookup(self, Py_ssize_t index):
-        '''
-
-        Returns -1 if not found
-        '''
+    cpdef int lookup(self, Py_ssize_t index):
+        """
+        Return the internal location if value exists on given index.
+        Return -1 otherwise.
+        """
         cdef:
             Py_ssize_t i, cum_len
             ndarray[int32_t, ndim=1] locs, lens
@@ -499,6 +538,36 @@ cdef class BlockIndex(SparseIndex):
             cum_len += lens[i]
 
         return -1
+
+    @cython.wraparound(False)
+    cpdef ndarray[int32_t] lookup_array(self, ndarray[int32_t, ndim=1] indexer):
+        """
+        Vectorized lookup, returns ndarray[int32_t]
+        """
+        cdef:
+            Py_ssize_t n, i, j, ind_val
+            ndarray[int32_t, ndim=1] locs, lens
+            ndarray[int32_t, ndim=1] results
+
+        locs = self.blocs
+        lens = self.blengths
+
+        n = len(indexer)
+        results = np.empty(n, dtype=np.int32)
+        results.fill(-1)
+
+        if self.npoints == 0:
+            return results
+
+        for i from 0 <= i < n:
+            ind_val = indexer[i]
+            if not (ind_val < 0 or self.length <= ind_val):
+                cum_len = 0
+                for j from 0 <= j < self.nblocks:
+                    if ind_val >= locs[j] and ind_val < locs[j] + lens[j]:
+                        results[i] = cum_len + ind_val - locs[j]
+                    cum_len += lens[j]
+        return results
 
     cpdef ndarray reindex(self, ndarray[float64_t, ndim=1] values,
                           float64_t fill_value, SparseIndex other_):

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1209,7 +1209,10 @@ def assert_sp_array_equal(left, right):
     # SparseIndex comparison
     assertIsInstance(left.sp_index, pd._sparse.SparseIndex, '[SparseIndex]')
     assertIsInstance(right.sp_index, pd._sparse.SparseIndex, '[SparseIndex]')
-    assert (left.sp_index.equals(right.sp_index))
+
+    if not left.sp_index.equals(right.sp_index):
+        raise_assert_detail('SparseArray.index', 'index are not equal',
+                            left.sp_index, right.sp_index)
 
     if np.isnan(left.fill_value):
         assert (np.isnan(right.fill_value))


### PR DESCRIPTION
- [x] related to #4400 (not close yet as `SparseDataFrame` indexing test is not sufficient)
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Added more tests for sparse indexing. Fixed followings:
- `SparseArray.take` has optimized logic to omit dense `np.ndarray` creation.
- `SparseSeires.iloc` can work with negative indices. Made `SparseArray.take` to handle negative indices as the same rule as `Index` (#12676)
