### PR TITLE
BUG 12800 fixed inconsistent behavior of last_valid_index and first_valid_index

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -237,3 +237,4 @@ Bug Fixes
 - Bug in ``.describe()`` resets categorical columns information (:issue:`11558`)
 - Bug where ``loffset`` argument was not applied when calling ``resample().count()`` on a timeseries (:issue:`12725`)
 - ``pd.read_excel()`` now accepts path objects (e.g. ``pathlib.Path``, ``py.path.local``) for the file path, in line with other ``read_*`` functions (:issue:`12655`)
+- Bug in ``DataFrame`` inconsistent behavior ``last_valid_index()``, ``first_valid_index`` (:issue:`12800`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3766,12 +3766,18 @@ class DataFrame(NDFrame):
         """
         Return label for first non-NA/null value
         """
+        if len(self) == 0:
+            return None
+
         return self.index[self.count(1) > 0][0]
 
     def last_valid_index(self):
         """
         Return label for last non-NA/null value
         """
+        if len(self) == 0:
+            return None
+
         return self.index[self.count(1) > 0][-1]
 
     # ----------------------------------------------------------------------

--- a/pandas/tests/frame/test_timeseries.py
+++ b/pandas/tests/frame/test_timeseries.py
@@ -337,6 +337,7 @@ class TestDataFrameTimeSeriesMethods(tm.TestCase, TestData):
         index = frame.last_valid_index()
         self.assertEqual(index, frame.index[-6])
 
+    # GH #12800
     def test_empty_first_last(self):
         empty_frame = DataFrame()
         self.assertIsNone(empty_frame.last_valid_index())

--- a/pandas/tests/frame/test_timeseries.py
+++ b/pandas/tests/frame/test_timeseries.py
@@ -336,3 +336,8 @@ class TestDataFrameTimeSeriesMethods(tm.TestCase, TestData):
 
         index = frame.last_valid_index()
         self.assertEqual(index, frame.index[-6])
+
+    def test_empty_first_last(self):
+        empty_frame = DataFrame()
+        self.assertIsNone(empty_frame.last_valid_index())
+        self.assertIsNone(empty_frame.first_valid_index())

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -19,7 +19,6 @@ from .common import TestData
 
 
 class TestSeriesTimeSeries(TestData, tm.TestCase):
-
     _multiprocess_can_split_ = True
 
     def test_shift(self):
@@ -222,6 +221,7 @@ class TestSeriesTimeSeries(TestData, tm.TestCase):
 
     def test_getitem_setitem_datetimeindex(self):
         from pandas import date_range
+
         N = 50
         # testing with timezone, GH #2785
         rng = date_range('1/1/1990', periods=N, freq='H', tz='US/Eastern')
@@ -304,6 +304,7 @@ class TestSeriesTimeSeries(TestData, tm.TestCase):
         from pytz import timezone as tz
 
         from pandas import date_range
+
         N = 50
         # testing with timezone, GH #2785
         rng = date_range('1/1/1990', periods=N, freq='H', tz='US/Eastern')
@@ -343,6 +344,7 @@ class TestSeriesTimeSeries(TestData, tm.TestCase):
             x)  # handle special case for utc in dateutil
 
         from pandas import date_range
+
         N = 50
         # testing with timezone, GH #2785
         rng = date_range('1/1/1990', periods=N, freq='H', tz='US/Eastern')
@@ -372,6 +374,7 @@ class TestSeriesTimeSeries(TestData, tm.TestCase):
 
     def test_getitem_setitem_periodindex(self):
         from pandas import period_range
+
         N = 50
         rng = period_range('1/1/1990', periods=N, freq='H')
         ts = Series(np.random.randn(N), index=rng)
@@ -460,6 +463,7 @@ class TestSeriesTimeSeries(TestData, tm.TestCase):
 
     def test_asof_more(self):
         from pandas import date_range
+
         s = Series([nan, nan, 1, 2, nan, nan, 3, 4, 5],
                    index=date_range('1/1/2000', periods=9))
 
@@ -618,6 +622,7 @@ class TestSeriesTimeSeries(TestData, tm.TestCase):
         self.assertTrue(ser.index.is_all_dates)
         self.assertIsInstance(ser.index, DatetimeIndex)
 
+    # GH #12800
     def test_empty_first_last(self):
         empty_frame = Series()
         self.assertIsNone(empty_frame.last_valid_index())

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -617,3 +617,8 @@ class TestSeriesTimeSeries(TestData, tm.TestCase):
             self.assertTrue(ser.is_time_series)
         self.assertTrue(ser.index.is_all_dates)
         self.assertIsInstance(ser.index, DatetimeIndex)
+
+    def test_empty_first_last(self):
+        empty_frame = Series()
+        self.assertIsNone(empty_frame.last_valid_index())
+        self.assertIsNone(empty_frame.first_valid_index())


### PR DESCRIPTION
- [x] closes #12800
- [x] tests added / passed
- [ ] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry
