### PR TITLE
BUG: SparseSeries.value_counts ignores fill_value

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -197,6 +197,7 @@ These changes conform sparse handling to return the correct types and work to ma
 - Bug in ``SparseSeries`` and ``SparseArray`` may have different ``dtype`` from its dense values (:issue:`12908`)
 - Bug in ``SparseSeries.reindex`` incorrectly handle ``fill_value`` (:issue:`12797`)
 - Bug in ``SparseArray.to_frame()`` results in ``DataFrame``, rather than ``SparseDataFrame`` (:issue:`9850`)
+- Bug in ``SparseSeries.value_counts()`` does not count ``fill_value`` (:issue:`6749`)
 - Bug in ``SparseArray.to_dense()`` does not preserve ``dtype`` (:issue:`10648`)
 - Bug in ``SparseArray.to_dense()`` incorrectly handle ``fill_value`` (:issue:`12797`)
 - Bug in ``pd.concat()`` of ``SparseSeries`` results in dense (:issue:`10536`)
@@ -474,6 +475,9 @@ Bug Fixes
 
 
 - Bug in ``value_counts`` when ``normalize=True`` and ``dropna=True`` where nulls still contributed to the normalized count (:issue:`12558`)
+- Bug in ``Series.value_counts()`` loses name if its dtype is category (:issue:`12835`)
+- Bug in ``Series.value_counts()`` loses timezone info (:issue:`12835`)
+- Bug in ``Series.value_counts(normalize=True)`` with ``Categorical`` raises ``UnboundLocalError`` (:issue:`12835`)
 - Bug in ``Panel.fillna()`` ignoring ``inplace=True`` (:issue:`12633`)
 - Bug in ``read_csv`` when specifying ``names``, ``usecols``, and ``parse_dates`` simultaneously with the C engine (:issue:`9755`)
 - Bug in ``read_csv`` when specifying ``delim_whitespace=True`` and ``lineterminator`` simultaneously with the C engine (:issue:`12912`)

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -943,18 +943,6 @@ class IndexOpsMixin(object):
         from pandas.core.algorithms import value_counts
         result = value_counts(self, sort=sort, ascending=ascending,
                               normalize=normalize, bins=bins, dropna=dropna)
-
-        if isinstance(self, gt.ABCPeriodIndex):
-            # preserve freq
-            result.index = self._simple_new(result.index.values,
-                                            freq=self.freq)
-        elif com.is_datetimetz(self):
-            if isinstance(self, gt.ABCDatetimeIndex):
-                tz = self.tz
-            else:
-                tz = self.dt.tz
-            result.index = result.index._simple_new(result.index.values,
-                                                    tz=tz)
         return result
 
     def unique(self):

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -10,6 +10,7 @@ import pandas.lib as lib
 from pandas.util.decorators import (Appender, cache_readonly,
                                     deprecate_kwarg, Substitution)
 from pandas.core.common import AbstractMethodError
+from pandas.types import api as gt
 from pandas.formats.printing import pprint_thing
 
 _shared_docs = dict()
@@ -291,15 +292,15 @@ class SelectionMixin(object):
 
     @property
     def _selection_list(self):
-        if not isinstance(self._selection, (list, tuple, com.ABCSeries,
-                                            com.ABCIndex, np.ndarray)):
+        if not isinstance(self._selection, (list, tuple, gt.ABCSeries,
+                                            gt.ABCIndex, np.ndarray)):
             return [self._selection]
         return self._selection
 
     @cache_readonly
     def _selected_obj(self):
 
-        if self._selection is None or isinstance(self.obj, com.ABCSeries):
+        if self._selection is None or isinstance(self.obj, gt.ABCSeries):
             return self.obj
         else:
             return self.obj[self._selection]
@@ -311,7 +312,7 @@ class SelectionMixin(object):
     @cache_readonly
     def _obj_with_exclusions(self):
         if self._selection is not None and isinstance(self.obj,
-                                                      com.ABCDataFrame):
+                                                      gt.ABCDataFrame):
             return self.obj.reindex(columns=self._selection_list)
 
         if len(self.exclusions) > 0:
@@ -323,7 +324,7 @@ class SelectionMixin(object):
         if self._selection is not None:
             raise Exception('Column(s) %s already selected' % self._selection)
 
-        if isinstance(key, (list, tuple, com.ABCSeries, com.ABCIndex,
+        if isinstance(key, (list, tuple, gt.ABCSeries, gt.ABCIndex,
                             np.ndarray)):
             if len(self.obj.columns.intersection(key)) != len(key):
                 bad_keys = list(set(key).difference(self.obj.columns))
@@ -551,7 +552,7 @@ pandas.DataFrame.%(name)s
             if isinstance(result, list):
                 result = concat(result, keys=keys, axis=1)
             elif isinstance(list(compat.itervalues(result))[0],
-                            com.ABCDataFrame):
+                            gt.ABCDataFrame):
                 result = concat([result[k] for k in keys], keys=keys, axis=1)
             else:
                 from pandas import DataFrame
@@ -940,17 +941,20 @@ class IndexOpsMixin(object):
         counts : Series
         """
         from pandas.core.algorithms import value_counts
-        from pandas.tseries.api import DatetimeIndex, PeriodIndex
         result = value_counts(self, sort=sort, ascending=ascending,
                               normalize=normalize, bins=bins, dropna=dropna)
 
-        if isinstance(self, PeriodIndex):
+        if isinstance(self, gt.ABCPeriodIndex):
             # preserve freq
             result.index = self._simple_new(result.index.values,
                                             freq=self.freq)
-        elif isinstance(self, DatetimeIndex):
-            result.index = self._simple_new(result.index.values,
-                                            tz=getattr(self, 'tz', None))
+        elif com.is_datetimetz(self):
+            if isinstance(self, gt.ABCDatetimeIndex):
+                tz = self.tz
+            else:
+                tz = self.dt.tz
+            result.index = result.index._simple_new(result.index.values,
+                                                    tz=tz)
         return result
 
     def unique(self):

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1728,6 +1728,29 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         tm.assert_series_equal(s.value_counts(normalize=True), exp)
         tm.assert_series_equal(idx.value_counts(normalize=True), exp)
 
+    def test_value_counts_period(self):
+        values = [pd.Period('2011-01', freq='M'),
+                  pd.Period('2011-02', freq='M'),
+                  pd.Period('2011-03', freq='M'),
+                  pd.Period('2011-01', freq='M'),
+                  pd.Period('2011-01', freq='M'),
+                  pd.Period('2011-03', freq='M')]
+
+        exp_idx = pd.PeriodIndex(['2011-01', '2011-03', '2011-02'], freq='M')
+        exp = pd.Series([3, 2, 1], index=exp_idx, name='xxx')
+
+        s = pd.Series(values, name='xxx')
+        tm.assert_series_equal(s.value_counts(), exp)
+        # check DatetimeIndex outputs the same result
+        idx = pd.PeriodIndex(values, name='xxx')
+        tm.assert_series_equal(idx.value_counts(), exp)
+
+        # normalize
+        exp = pd.Series(np.array([3., 2., 1]) / 6.,
+                        index=exp_idx, name='xxx')
+        tm.assert_series_equal(s.value_counts(normalize=True), exp)
+        tm.assert_series_equal(idx.value_counts(normalize=True), exp)
+
     def test_value_counts_categorical_ordered(self):
         # most dtypes are tested in test_base.py
         values = pd.Categorical([1, 2, 3, 1, 1, 3], ordered=True)

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1669,8 +1669,6 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         left = ts.unstack()
         right = DataFrame([[nan, 1], [2, nan]], index=[101, 102],
                           columns=[nan, 3.5])
-        print(left)
-        print(right)
         assert_frame_equal(left, right)
 
         idx = pd.MultiIndex.from_arrays([['cat', 'cat', 'cat', 'dog', 'dog'
@@ -1682,3 +1680,89 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         tpls = [('a', 1), ('a', 2), ('b', nan), ('b', 1)]
         right.index = pd.MultiIndex.from_tuples(tpls)
         assert_frame_equal(ts.unstack(level=0), right)
+
+    def test_value_counts_datetime(self):
+        # most dtypes are tested in test_base.py
+        values = [pd.Timestamp('2011-01-01 09:00'),
+                  pd.Timestamp('2011-01-01 10:00'),
+                  pd.Timestamp('2011-01-01 11:00'),
+                  pd.Timestamp('2011-01-01 09:00'),
+                  pd.Timestamp('2011-01-01 09:00'),
+                  pd.Timestamp('2011-01-01 11:00')]
+
+        exp_idx = pd.DatetimeIndex(['2011-01-01 09:00', '2011-01-01 11:00',
+                                    '2011-01-01 10:00'])
+        exp = pd.Series([3, 2, 1], index=exp_idx, name='xxx')
+
+        s = pd.Series(values, name='xxx')
+        tm.assert_series_equal(s.value_counts(), exp)
+        # check DatetimeIndex outputs the same result
+        idx = pd.DatetimeIndex(values, name='xxx')
+        tm.assert_series_equal(idx.value_counts(), exp)
+
+        # normalize
+        exp = pd.Series(np.array([3., 2., 1]) / 6.,
+                        index=exp_idx, name='xxx')
+        tm.assert_series_equal(s.value_counts(normalize=True), exp)
+        tm.assert_series_equal(idx.value_counts(normalize=True), exp)
+
+    def test_value_counts_datetime_tz(self):
+        values = [pd.Timestamp('2011-01-01 09:00', tz='US/Eastern'),
+                  pd.Timestamp('2011-01-01 10:00', tz='US/Eastern'),
+                  pd.Timestamp('2011-01-01 11:00', tz='US/Eastern'),
+                  pd.Timestamp('2011-01-01 09:00', tz='US/Eastern'),
+                  pd.Timestamp('2011-01-01 09:00', tz='US/Eastern'),
+                  pd.Timestamp('2011-01-01 11:00', tz='US/Eastern')]
+
+        exp_idx = pd.DatetimeIndex(['2011-01-01 09:00', '2011-01-01 11:00',
+                                    '2011-01-01 10:00'], tz='US/Eastern')
+        exp = pd.Series([3, 2, 1], index=exp_idx, name='xxx')
+
+        s = pd.Series(values, name='xxx')
+        tm.assert_series_equal(s.value_counts(), exp)
+        idx = pd.DatetimeIndex(values, name='xxx')
+        tm.assert_series_equal(idx.value_counts(), exp)
+
+        exp = pd.Series(np.array([3., 2., 1]) / 6.,
+                        index=exp_idx, name='xxx')
+        tm.assert_series_equal(s.value_counts(normalize=True), exp)
+        tm.assert_series_equal(idx.value_counts(normalize=True), exp)
+
+    def test_value_counts_categorical_ordered(self):
+        # most dtypes are tested in test_base.py
+        values = pd.Categorical([1, 2, 3, 1, 1, 3], ordered=True)
+
+        exp_idx = pd.CategoricalIndex([1, 3, 2], categories=[1, 2, 3],
+                                      ordered=True)
+        exp = pd.Series([3, 2, 1], index=exp_idx, name='xxx')
+
+        s = pd.Series(values, name='xxx')
+        tm.assert_series_equal(s.value_counts(), exp)
+        # check CategoricalIndex outputs the same result
+        idx = pd.CategoricalIndex(values, name='xxx')
+        tm.assert_series_equal(idx.value_counts(), exp)
+
+        # normalize
+        exp = pd.Series(np.array([3., 2., 1]) / 6.,
+                        index=exp_idx, name='xxx')
+        tm.assert_series_equal(s.value_counts(normalize=True), exp)
+        tm.assert_series_equal(idx.value_counts(normalize=True), exp)
+
+    def test_value_counts_categorical_not_ordered(self):
+        values = pd.Categorical([1, 2, 3, 1, 1, 3], ordered=False)
+
+        exp_idx = pd.CategoricalIndex([1, 3, 2], categories=[1, 2, 3],
+                                      ordered=False)
+        exp = pd.Series([3, 2, 1], index=exp_idx, name='xxx')
+
+        s = pd.Series(values, name='xxx')
+        tm.assert_series_equal(s.value_counts(), exp)
+        # check CategoricalIndex outputs the same result
+        idx = pd.CategoricalIndex(values, name='xxx')
+        tm.assert_series_equal(idx.value_counts(), exp)
+
+        # normalize
+        exp = pd.Series(np.array([3., 2., 1]) / 6.,
+                        index=exp_idx, name='xxx')
+        tm.assert_series_equal(s.value_counts(normalize=True), exp)
+        tm.assert_series_equal(idx.value_counts(normalize=True), exp)

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -2825,16 +2825,25 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
         tm.assert_series_equal(res, exp)
 
     def test_value_counts(self):
-
-        s = pd.Series(pd.Categorical(
-            ["a", "b", "c", "c", "c", "b"], categories=["c", "a", "b", "d"]))
+        # GH 12835
+        cats = pd.Categorical(["a", "b", "c", "c", "c", "b"],
+                              categories=["c", "a", "b", "d"])
+        s = pd.Series(cats, name='xxx')
         res = s.value_counts(sort=False)
-        exp = Series([3, 1, 2, 0],
+        exp = Series([3, 1, 2, 0], name='xxx',
                      index=pd.CategoricalIndex(["c", "a", "b", "d"]))
         tm.assert_series_equal(res, exp)
+
         res = s.value_counts(sort=True)
-        exp = Series([3, 2, 1, 0],
+        exp = Series([3, 2, 1, 0], name='xxx',
                      index=pd.CategoricalIndex(["c", "b", "a", "d"]))
+        tm.assert_series_equal(res, exp)
+
+        # check object dtype handles the Series.name as the same
+        # (tested in test_base.py)
+        s = pd.Series(["a", "b", "c", "c", "c", "b"], name='xxx')
+        res = s.value_counts()
+        exp = Series([3, 2, 1], name='xxx', index=["c", "b", "a"])
         tm.assert_series_equal(res, exp)
 
     def test_value_counts_with_nan(self):

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -2,8 +2,6 @@
 from __future__ import print_function
 import nose
 
-from numpy.testing.decorators import slow
-
 from datetime import datetime
 from numpy import nan
 
@@ -1875,7 +1873,6 @@ class TestGroupBy(tm.TestCase):
             check_nunique(frame, ['jim'])
             check_nunique(frame, ['jim', 'joe'])
 
-    @slow
     def test_series_groupby_value_counts(self):
         from itertools import product
 
@@ -1910,7 +1907,7 @@ class TestGroupBy(tm.TestCase):
 
         days = date_range('2015-08-24', periods=10)
 
-        for n, m in product((100, 10000), (5, 20)):
+        for n, m in product((100, 1000), (5, 20)):
             frame = DataFrame({
                 '1st': np.random.choice(
                     list('abcd'), n),


### PR DESCRIPTION
- [x] closes #6749
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Also fixed an issue which categorical `value_counts` resets name.
