### PR TITLE
BUG: GroupBy with TimeGrouper sorts unstably

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -241,3 +241,5 @@ Bug Fixes
 - Bug in ``.describe()`` resets categorical columns information (:issue:`11558`)
 - Bug where ``loffset`` argument was not applied when calling ``resample().count()`` on a timeseries (:issue:`12725`)
 - ``pd.read_excel()`` now accepts path objects (e.g. ``pathlib.Path``, ``py.path.local``) for the file path, in line with other ``read_*`` functions (:issue:`12655`)
+
+- Bug in ``GroupBy.first()``, ``.last()`` returns incorrect row when ``TimeGrouper`` is used (:issue:`7453`)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -273,7 +273,8 @@ class Grouper(object):
 
         # possibly sort
         if (self.sort or sort) and not ax.is_monotonic:
-            indexer = self.indexer = ax.argsort(kind='quicksort')
+            # use stable sort to suport first, last, nth
+            indexer = self.indexer = ax.argsort(kind='mergesort')
             ax = ax.take(indexer)
             obj = obj.take(indexer, axis=self.axis,
                            convert=False, is_copy=False)


### PR DESCRIPTION
- [x] closes #7453 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Because it may affect to resample perf, alternative idea is to add `TimeGropuper` path to `GroupBy.first` and `last`.
