### PR TITLE
ENH: Add Index.str.get_dummies

### DIFF
--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -354,16 +354,27 @@ Methods like ``match``, ``contains``, ``startswith``, and ``endswith`` take
    s4 = pd.Series(['A', 'B', 'C', 'Aaba', 'Baca', np.nan, 'CABA', 'dog', 'cat'])
    s4.str.contains('A', na=False)
 
+.. _text.indicator:
+
 Creating Indicator Variables
 ----------------------------
 
 You can extract dummy variables from string columns.
 For example if they are separated by a ``'|'``:
 
-  .. ipython:: python
+.. ipython:: python
 
-      s = pd.Series(['a', 'a|b', np.nan, 'a|c'])
-      s.str.get_dummies(sep='|')
+    s = pd.Series(['a', 'a|b', np.nan, 'a|c'])
+    s.str.get_dummies(sep='|')
+
+String ``Index`` also supports ``get_dummies`` which returns ``MultiIndex``.
+
+.. versionadded:: 0.18.1
+
+.. ipython:: python
+
+    idx = pd.Index(['a', 'a|b', np.nan, 'a|c'])
+    idx.str.get_dummies(sep='|')
 
 See also :func:`~pandas.get_dummies`.
 

--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -66,6 +66,13 @@ Other Enhancements
    idx.take([2, -1])     # default, allow_fill=True, fill_value=None
    idx.take([2, -1], fill_value=True)
 
+- ``Index`` now supports ``.str.get_dummies()`` which returns ``MultiIndex``, see :ref:`Creating Indicator Variables <text.indicator>` (:issue:`10008`, :issue:`10103`)
+
+.. ipython:: python
+
+   idx = pd.Index(['a|b', 'a|c', 'b|c'])
+   idx.str.get_dummies('|')
+
 
 .. _whatsnew_0181.sparse:
 

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -1237,12 +1237,15 @@ class TestStringMethods(tm.TestCase):
                              columns=list('7ab'))
         tm.assert_frame_equal(result, expected)
 
-        # GH9980
-        # Index.str does not support get_dummies() as it returns a frame
-        with tm.assertRaisesRegexp(TypeError, "not supported"):
-            idx = Index(['a|b', 'a|c', 'b|c'])
-            idx.str.get_dummies('|')
+        # GH9980, GH8028
+        idx = Index(['a|b', 'a|c', 'b|c'])
+        result = idx.str.get_dummies('|')
 
+        expected = MultiIndex.from_tuples([(1, 1, 0), (1, 0, 1),
+                                           (0, 1, 1)], names=('a', 'b', 'c'))
+        tm.assert_index_equal(result, expected)
+
+    def test_get_dummies_with_name_dummy(self):
         # GH 12180
         # Dummies named 'name' should work as expected
         s = Series(['a', 'b,name', 'b'])
@@ -1250,6 +1253,14 @@ class TestStringMethods(tm.TestCase):
         expected = DataFrame([[1, 0, 0], [0, 1, 1], [0, 1, 0]],
                              columns=['a', 'b', 'name'])
         tm.assert_frame_equal(result, expected)
+
+        idx = Index(['a|b', 'name|c', 'b|name'])
+        result = idx.str.get_dummies('|')
+
+        expected = MultiIndex.from_tuples([(1, 1, 0, 0), (0, 0, 1, 1),
+                                           (0, 1, 0, 1)],
+                                          names=('a', 'b', 'c', 'name'))
+        tm.assert_index_equal(result, expected)
 
     def test_join(self):
         values = Series(['a_b_c', 'c_d_e', np.nan, 'f_g_h'])


### PR DESCRIPTION
- [x] closes #10103
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Add `Index.str.get_dummies` which always returns `MultiIndex`.
