### PR TITLE
BUG: SparseSeries slicing with Ellipsis raises KeyError

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -82,6 +82,7 @@ These changes conform sparse handling to return the correct types and work to ma
    s.take(0)
    s.take([1, 2, 3])
 
+- Bug in ``SparseSeries.__getitem__`` with ``Ellipsis`` raises ``KeyError`` (:issue:`9467`)
 - Bug in ``SparseSeries.loc[]`` with list-like input raises ``TypeError`` (:issue:`10560`)
 - Bug in ``SparseSeries.iloc[]`` with scalar input may raise ``IndexError`` (:issue:`10560`)
 - Bug in ``SparseSeries.loc[]``, ``.iloc[]`` with ``slice`` returns ``SparseArray``, rather than ``SparseSeries`` (:issue:`10560`)

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -382,15 +382,14 @@ class SparseSeries(Series):
         return self.block.values._get_val_at(loc)
 
     def __getitem__(self, key):
-        """
-
-        """
         try:
             return self._get_val_at(self.index.get_loc(key))
 
         except KeyError:
             if isinstance(key, (int, np.integer)):
                 return self._get_val_at(key)
+            elif key is Ellipsis:
+                return self
             raise Exception('Requested index not in this series!')
 
         except TypeError:

--- a/pandas/sparse/tests/test_indexing.py
+++ b/pandas/sparse/tests/test_indexing.py
@@ -55,6 +55,14 @@ class TestSparseSeriesIndexing(tm.TestCase):
         exp = orig[orig % 2 == 1].to_sparse(fill_value=0)
         tm.assert_sp_series_equal(result, exp)
 
+    def test_getitem_ellipsis(self):
+        # GH 9467
+        s = pd.SparseSeries([1, np.nan, 2, 0, np.nan])
+        tm.assert_sp_series_equal(s[...], s)
+
+        s = pd.SparseSeries([1, np.nan, 2, 0, np.nan], fill_value=0)
+        tm.assert_sp_series_equal(s[...], s)
+
     def test_loc(self):
         orig = pd.Series([1, np.nan, np.nan, 3, np.nan])
         sparse = orig.to_sparse()


### PR DESCRIPTION
- [x] closes #9467
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
