### PR TITLE
COMPAT: .query/.eval should work w/o numexpr being installed if possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,25 +152,29 @@ before_install:
   - export DISPLAY=:99.0
 
 install:
-  - echo "install"
+  - echo "install start"
   - ci/prep_ccache.sh
   - ci/install_travis.sh
   - ci/submit_ccache.sh
+  - echo "install done"
 
 before_script:
   - source activate pandas && pip install codecov
   - ci/install_db.sh
 
 script:
-  - echo "script"
+  - echo "script start"
   - ci/run_build_docs.sh
   - ci/script.sh
   - ci/lint.sh
+  - echo "script done"
 
 after_success:
   - source activate pandas && codecov
 
 after_script:
+  - echo "after_script start"
   - ci/install_test.sh
   - source activate pandas && ci/print_versions.py
   - ci/print_skipped.py /tmp/nosetests.xml
+  - echo "after_script done"

--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -131,6 +131,7 @@ API changes
 
 
 
+- the default for ``.query()/.eval()`` is now ``engine=None`` which will use ``numexpr`` if its installed, else will fallback to the ``python`` engine. This mimics the pre-0.18.1 behavior if ``numexpr`` is installed (and which previously would raise if ``numexpr`` was NOT installed and ``.query()/.eval()`` was used). (:issue:`12749`)
 
 - ``CParserError`` is now a ``ValueError`` instead of just an ``Exception`` (:issue:`12551`)
 - ``read_csv`` no longer allows a combination of strings and integers for the ``usecols`` parameter (:issue:`12678`)

--- a/pandas/computation/eval.py
+++ b/pandas/computation/eval.py
@@ -26,7 +26,19 @@ def _check_engine(engine):
       * If an invalid engine is passed
     ImportError
       * If numexpr was requested but doesn't exist
+
+    Returns
+    -------
+    string engine
+
     """
+
+    if engine is None:
+        if _NUMEXPR_INSTALLED:
+            engine = 'numexpr'
+        else:
+            engine = 'python'
+
     if engine not in _engines:
         raise KeyError('Invalid engine {0!r} passed, valid engines are'
                        ' {1}'.format(engine, list(_engines.keys())))
@@ -40,6 +52,8 @@ def _check_engine(engine):
                               "unsupported version. Cannot use "
                               "engine='numexpr' for query/eval "
                               "if 'numexpr' is not installed")
+
+    return engine
 
 
 def _check_parser(parser):
@@ -131,7 +145,7 @@ def _check_for_locals(expr, stack_level, parser):
                 raise SyntaxError(msg)
 
 
-def eval(expr, parser='pandas', engine='numexpr', truediv=True,
+def eval(expr, parser='pandas', engine=None, truediv=True,
          local_dict=None, global_dict=None, resolvers=(), level=0,
          target=None, inplace=None):
     """Evaluate a Python expression as a string using various backends.
@@ -160,10 +174,11 @@ def eval(expr, parser='pandas', engine='numexpr', truediv=True,
         ``'python'`` parser to retain strict Python semantics.  See the
         :ref:`enhancing performance <enhancingperf.eval>` documentation for
         more details.
-    engine : string, default 'numexpr', {'python', 'numexpr'}
+    engine : string or None, default 'numexpr', {'python', 'numexpr'}
 
         The engine used to evaluate the expression. Supported engines are
 
+        - None         : tries to use ``numexpr``, falls back to ``python``
         - ``'numexpr'``: This default engine evaluates pandas objects using
                          numexpr for large speed ups in complex expressions
                          with large frames.
@@ -230,7 +245,7 @@ def eval(expr, parser='pandas', engine='numexpr', truediv=True,
     first_expr = True
     for expr in exprs:
         expr = _convert_expression(expr)
-        _check_engine(engine)
+        engine = _check_engine(engine)
         _check_parser(parser)
         _check_resolvers(resolvers)
         _check_for_locals(expr, level, parser)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -329,21 +329,16 @@ def _incompat_bottleneck_version(method):
 
 
 def skip_if_no_ne(engine='numexpr'):
-    import nose
-    _USE_NUMEXPR = pd.computation.expressions._USE_NUMEXPR
+    from pandas.computation.expressions import (_USE_NUMEXPR,
+                                                _NUMEXPR_INSTALLED)
 
     if engine == 'numexpr':
-        try:
-            import numexpr as ne
-        except ImportError:
-            raise nose.SkipTest("numexpr not installed")
-
         if not _USE_NUMEXPR:
-            raise nose.SkipTest("numexpr disabled")
-
-        if ne.__version__ < LooseVersion('2.0'):
-            raise nose.SkipTest("numexpr version too low: "
-                                "%s" % ne.__version__)
+            import nose
+            raise nose.SkipTest("numexpr enabled->{enabled}, "
+                                "installed->{installed}".format(
+                                    enabled=_USE_NUMEXPR,
+                                    installed=_NUMEXPR_INSTALLED))
 
 
 def _skip_if_has_locale():


### PR DESCRIPTION
closes #12749
