### PR TITLE
BUG: SparseSeries.shift may raise NameError or TypeError

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -109,7 +109,7 @@ These changes conform sparse handling to return the correct types and work to ma
    s.take(0)
    s.take([1, 2, 3])
 
-- Bug in ``SparseSeries.__getitem__`` with ``Ellipsis`` raises ``KeyError`` (:issue:`9467`)
+- Bug in ``SparseSeries[]`` indexing with ``Ellipsis`` raises ``KeyError`` (:issue:`9467`)
 - Bug in ``SparseSeries.loc[]`` with list-like input raises ``TypeError`` (:issue:`10560`)
 - Bug in ``SparseSeries.iloc[]`` with scalar input may raise ``IndexError`` (:issue:`10560`)
 - Bug in ``SparseSeries.loc[]``, ``.iloc[]`` with ``slice`` returns ``SparseArray``, rather than ``SparseSeries`` (:issue:`10560`)
@@ -119,11 +119,13 @@ These changes conform sparse handling to return the correct types and work to ma
 - Bug in ``SparseArray`` pow calculates ``1 ** np.nan`` as ``np.nan`` which must be 1 (:issue:`12910`)
 - Bug in ``SparseSeries.__repr__`` raises ``TypeError`` when it is longer than ``max_rows`` (:issue:`10560`)
 - Bug in ``SparseSeries.shape`` ignores ``fill_value`` (:issue:`10452`)
+- Bug in ``SparseSeries`` and ``SparseArray`` may have different ``dtype`` from its dense values (:issue:`12908`)
 - Bug in ``SparseSeries.reindex`` incorrectly handle ``fill_value`` (:issue:`12797`)
 - Bug in ``SparseArray.to_frame()`` results in ``DataFrame``, rather than ``SparseDataFrame`` (:issue:`9850`)
 - Bug in ``SparseArray.to_dense()`` does not preserve ``dtype`` (:issue:`10648`)
 - Bug in ``SparseArray.to_dense()`` incorrectly handle ``fill_value`` (:issue:`12797`)
 - Bug in ``pd.concat()`` of ``SparseSeries`` results in dense (:issue:`10536`)
+- Bug in ``SparseArray.shift()`` may raise ``NameError`` or ``TypeError`` (:issue:`12908`)
 
 .. _whatsnew_0181.api:
 

--- a/pandas/sparse/array.py
+++ b/pandas/sparse/array.py
@@ -165,6 +165,12 @@ class SparseArray(PandasObject, np.ndarray):
 
     @classmethod
     def _simple_new(cls, data, sp_index, fill_value):
+        if (com.is_integer_dtype(data) and com.is_float(fill_value) and
+           sp_index.ngaps > 0):
+            # if float fill_value is being included in dense repr,
+            # convert values to float
+            data = data.astype(float)
+
         result = data.view(cls)
 
         if not isinstance(sp_index, SparseIndex):

--- a/pandas/sparse/tests/test_series.py
+++ b/pandas/sparse/tests/test_series.py
@@ -91,6 +91,23 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
         self.ziseries2 = SparseSeries(arr, index=index, kind='integer',
                                       fill_value=0)
 
+    def test_constructor_dtype(self):
+        arr = SparseSeries([np.nan, 1, 2, np.nan])
+        self.assertEqual(arr.dtype, np.float64)
+        self.assertTrue(np.isnan(arr.fill_value))
+
+        arr = SparseSeries([np.nan, 1, 2, np.nan], fill_value=0)
+        self.assertEqual(arr.dtype, np.float64)
+        self.assertEqual(arr.fill_value, 0)
+
+        arr = SparseSeries([0, 1, 2, 4], dtype=np.int64)
+        self.assertEqual(arr.dtype, np.int64)
+        self.assertTrue(np.isnan(arr.fill_value))
+
+        arr = SparseSeries([0, 1, 2, 4], fill_value=0, dtype=np.int64)
+        self.assertEqual(arr.dtype, np.int64)
+        self.assertEqual(arr.fill_value, 0)
+
     def test_iteration_and_str(self):
         [x for x in self.bseries]
         str(self.bseries)
@@ -768,6 +785,78 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
 
         f = lambda s: s.shift(2, freq=datetools.bday)
         _dense_series_compare(series, f)
+
+    def test_shift_nan(self):
+        # GH 12908
+        orig = pd.Series([np.nan, 2, np.nan, 4, 0, np.nan, 0])
+        sparse = orig.to_sparse()
+
+        tm.assert_sp_series_equal(sparse.shift(0), orig.shift(0).to_sparse())
+        tm.assert_sp_series_equal(sparse.shift(1), orig.shift(1).to_sparse())
+        tm.assert_sp_series_equal(sparse.shift(2), orig.shift(2).to_sparse())
+        tm.assert_sp_series_equal(sparse.shift(3), orig.shift(3).to_sparse())
+
+        tm.assert_sp_series_equal(sparse.shift(-1), orig.shift(-1).to_sparse())
+        tm.assert_sp_series_equal(sparse.shift(-2), orig.shift(-2).to_sparse())
+        tm.assert_sp_series_equal(sparse.shift(-3), orig.shift(-3).to_sparse())
+        tm.assert_sp_series_equal(sparse.shift(-4), orig.shift(-4).to_sparse())
+
+        sparse = orig.to_sparse(fill_value=0)
+        tm.assert_sp_series_equal(sparse.shift(0),
+                                  orig.shift(0).to_sparse(fill_value=0))
+        tm.assert_sp_series_equal(sparse.shift(1),
+                                  orig.shift(1).to_sparse(fill_value=0))
+        tm.assert_sp_series_equal(sparse.shift(2),
+                                  orig.shift(2).to_sparse(fill_value=0))
+        tm.assert_sp_series_equal(sparse.shift(3),
+                                  orig.shift(3).to_sparse(fill_value=0))
+
+        tm.assert_sp_series_equal(sparse.shift(-1),
+                                  orig.shift(-1).to_sparse(fill_value=0))
+        tm.assert_sp_series_equal(sparse.shift(-2),
+                                  orig.shift(-2).to_sparse(fill_value=0))
+        tm.assert_sp_series_equal(sparse.shift(-3),
+                                  orig.shift(-3).to_sparse(fill_value=0))
+        tm.assert_sp_series_equal(sparse.shift(-4),
+                                  orig.shift(-4).to_sparse(fill_value=0))
+
+    def test_shift_dtype(self):
+        # GH 12908
+        orig = pd.Series([1, 2, 3, 4], dtype=np.int64)
+        sparse = orig.to_sparse()
+
+        tm.assert_sp_series_equal(sparse.shift(0), orig.shift(0).to_sparse())
+        tm.assert_sp_series_equal(sparse.shift(1), orig.shift(1).to_sparse())
+        tm.assert_sp_series_equal(sparse.shift(2), orig.shift(2).to_sparse())
+        tm.assert_sp_series_equal(sparse.shift(3), orig.shift(3).to_sparse())
+
+        tm.assert_sp_series_equal(sparse.shift(-1), orig.shift(-1).to_sparse())
+        tm.assert_sp_series_equal(sparse.shift(-2), orig.shift(-2).to_sparse())
+        tm.assert_sp_series_equal(sparse.shift(-3), orig.shift(-3).to_sparse())
+        tm.assert_sp_series_equal(sparse.shift(-4), orig.shift(-4).to_sparse())
+
+    def test_shift_dtype_fill_value(self):
+        # GH 12908
+        orig = pd.Series([1, 0, 0, 4], dtype=np.int64)
+        sparse = orig.to_sparse(fill_value=0)
+
+        tm.assert_sp_series_equal(sparse.shift(0),
+                                  orig.shift(0).to_sparse(fill_value=0))
+        tm.assert_sp_series_equal(sparse.shift(1),
+                                  orig.shift(1).to_sparse(fill_value=0))
+        tm.assert_sp_series_equal(sparse.shift(2),
+                                  orig.shift(2).to_sparse(fill_value=0))
+        tm.assert_sp_series_equal(sparse.shift(3),
+                                  orig.shift(3).to_sparse(fill_value=0))
+
+        tm.assert_sp_series_equal(sparse.shift(-1),
+                                  orig.shift(-1).to_sparse(fill_value=0))
+        tm.assert_sp_series_equal(sparse.shift(-2),
+                                  orig.shift(-2).to_sparse(fill_value=0))
+        tm.assert_sp_series_equal(sparse.shift(-3),
+                                  orig.shift(-3).to_sparse(fill_value=0))
+        tm.assert_sp_series_equal(sparse.shift(-4),
+                                  orig.shift(-4).to_sparse(fill_value=0))
 
     def test_cumsum(self):
         result = self.bseries.cumsum()


### PR DESCRIPTION
- [x] no existing issue
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Fixed following bugs on current master. Also, moved `TestSparseArrayIndex` to `test_libsparse`
#### 1. shift

```
pd.SparseSeries([1, 2, 3], fill_value=0).shift(1)
# NameError: global name 'kwds' is not defined

pd.SparseSeries([1, 2, 3]).shift(1)
# TypeError: %d format: a number is required, not float
```
#### 2. dtype

```
from pandas.sparse.array import IntIndex
arr = pd.SparseArray([1, 2], sparse_index=IntIndex(4, [1, 2]), dtype=None)
arr.dtype
# dtype('int64')

arr.values
# array([-9223372036854775808,                    1,                    2,
#        -9223372036854775808])

# Expected outputs
arr.dtype
# dtype('float64')

arr.values
# array([ nan,   1.,   2.,  nan])
```
