### PR TITLE
BUG: Fix argument order in call to super

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -127,7 +127,7 @@ class PandasObject(StringMixin):
 
         # no memory_usage attribute, so fall back to
         # object's 'sizeof'
-        return super(self, PandasObject).__sizeof__()
+        return super(PandasObject, self).__sizeof__()
 
 
 class NoNewAttributesMixin(object):


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`

`super` should have arguments (type, object), not (object, type).

I've run `test_fast.sh` using Python 2.7 and it gives [2 failures](https://github.com/pydata/pandas/files/225866/testfail.txt) relating to language locales (I'm using en_GB). Pretty sure these are unrelated to the commit.
