### PR TITLE
BUG, ENH: Add support for parsing duplicate columns

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -19,10 +19,37 @@ Highlights include:
 New features
 ~~~~~~~~~~~~
 
+.. _whatsnew_0182.enhancements.read_csv_dupe_col_names_support:
 
+``pd.read_csv`` has improved support for duplicate column names
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+:ref:`Duplicate column names <io.dupe_names>` are now supported in ``pd.read_csv()`` whether
+they are in the file or passed in as the ``names`` parameter (:issue:`7160`, :issue:`9424`)
 
+.. ipython :: python
 
+   data = '0,1,2\n3,4,5'
+   names = ['a', 'b', 'a']
+
+Previous behaviour:
+
+.. code-block:: ipython
+
+   In [2]: pd.read_csv(StringIO(data), names=names)
+   Out[2]:
+      a  b  a
+   0  2  1  2
+   1  5  4  5
+
+The first 'a' column contains the same data as the second 'a' column, when it should have
+contained the array ``[0, 3]``.
+
+New behaviour:
+
+.. ipython :: python
+
+   In [2]: pd.read_csv(StringIO(data), names=names)
 
 .. _whatsnew_0182.enhancements.other:
 

--- a/pandas/io/tests/parser/c_parser_only.py
+++ b/pandas/io/tests/parser/c_parser_only.py
@@ -293,23 +293,18 @@ one,two
             {'one': np.empty(0, dtype='u1'), 'one.1': np.empty(0, dtype='f')})
         tm.assert_frame_equal(result, expected, check_index_type=False)
 
-    def test_empty_with_dup_column_pass_dtype_by_names(self):
+    def test_empty_with_dup_column_pass_dtype_by_indexes(self):
+        # see gh-9424
+        expected = pd.concat([Series([], name='one', dtype='u1'),
+                              Series([], name='one.1', dtype='f')], axis=1)
+
         data = 'one,one'
-        result = self.read_csv(
-            StringIO(data), mangle_dupe_cols=False, dtype={'one': 'u1'})
-        expected = pd.concat([Series([], name='one', dtype='u1')] * 2, axis=1)
+        result = self.read_csv(StringIO(data), dtype={0: 'u1', 1: 'f'})
         tm.assert_frame_equal(result, expected, check_index_type=False)
 
-    def test_empty_with_dup_column_pass_dtype_by_indexes(self):
-        # FIXME in gh-9424
-        raise nose.SkipTest(
-            "gh-9424; known failure read_csv with duplicate columns")
-
-        data = 'one,one'
-        result = self.read_csv(
-            StringIO(data), mangle_dupe_cols=False, dtype={0: 'u1', 1: 'f'})
-        expected = pd.concat([Series([], name='one', dtype='u1'),
-                              Series([], name='one', dtype='f')], axis=1)
+        data = ''
+        result = self.read_csv(StringIO(data), names=['one', 'one'],
+                               dtype={0: 'u1', 1: 'f'})
         tm.assert_frame_equal(result, expected, check_index_type=False)
 
     def test_usecols_dtypes(self):

--- a/pandas/io/tests/parser/test_parsers.py
+++ b/pandas/io/tests/parser/test_parsers.py
@@ -84,13 +84,6 @@ class TestCParserLowMemory(BaseParser, CParserTests, tm.TestCase):
 
 
 class TestPythonParser(BaseParser, PythonParserTests, tm.TestCase):
-    """
-    Class for Python parser testing. Unless specifically stated
-    as a PythonParser-specific issue, the goal is to eventually move
-    as many of these tests into ParserTests as soon as the C parser
-    can accept further specific arguments when parsing.
-    """
-
     engine = 'python'
     float_precision_choices = [None]
 

--- a/pandas/io/tests/parser/test_unsupported.py
+++ b/pandas/io/tests/parser/test_unsupported.py
@@ -20,6 +20,16 @@ from pandas.io.parsers import read_csv, read_table
 
 
 class TestUnsupportedFeatures(tm.TestCase):
+    def test_mangle_dupe_cols_false(self):
+        # see gh-12935
+        data = 'a b c\n1 2 3'
+        msg = 'is not supported'
+
+        for engine in ('c', 'python'):
+            with tm.assertRaisesRegexp(ValueError, msg):
+                read_csv(StringIO(data), engine=engine,
+                         mangle_dupe_cols=False)
+
     def test_c_engine(self):
         # see gh-6607
         data = 'a b c\n1 2 3'


### PR DESCRIPTION
Introduces `mappings` and `reverse_map` attributes to the parser in `pandas.io.parsers` that allow it to differentiate between duplicate columns that may be present in a file.

Closes #7160.
Closes #9424.
