### PR TITLE
BUG: provide SparseArray creation in a platform independent manner

### DIFF
--- a/pandas/sparse/tests/test_array.py
+++ b/pandas/sparse/tests/test_array.py
@@ -76,6 +76,15 @@ class TestSparseArray(tm.TestCase):
         self.assertEqual(arr.dtype, np.int64)
         self.assertTrue(np.isnan(arr.fill_value))
 
+        # scalar input
+        arr = SparseArray(data=1,
+                          sparse_index=IntIndex(1, [0]),
+                          dtype=None)
+        exp = SparseArray([1], dtype=None)
+        tm.assert_sp_array_equal(arr, exp)
+        self.assertEqual(arr.dtype, np.int64)
+        self.assertTrue(np.isnan(arr.fill_value))
+
         arr = SparseArray(data=[1, 2], sparse_index=IntIndex(4, [1, 2]),
                           fill_value=0, dtype=None)
         exp = SparseArray([0, 1, 2, 0], fill_value=0, dtype=None)


### PR DESCRIPTION
makes creation w/o specifying a dtype choose `np.int64/float64` regardless of the platform. This is similar to how Series works. This only is exposed on windows (as the default ndarray creation is np.int32) rather than np.int64

maybe _should_ use `pandas.core.series._sanitize_array` (but needs some tweeks I think).

cc @sinhrks 
