### PR TITLE
ENH/COMPAT: update tests for dateutil 2.5.3

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -170,7 +170,6 @@ Other Enhancements
 
 - ``pd.crosstab()`` has gained a ``normalize`` argument for normalizing frequency tables (:issue:`12569`). Examples in the updated docs :ref:`here <reshaping.crosstabulations>`.
 
-
 .. _whatsnew_0181.sparse:
 
 Sparse changes

--- a/pandas/src/inference.pyx
+++ b/pandas/src/inference.pyx
@@ -683,7 +683,7 @@ def maybe_convert_objects(ndarray[object] objects, bint try_float=0,
             seen_float = 1
         elif util.is_datetime64_object(val):
             if convert_datetime:
-                idatetimes[i] = convert_to_tsobject(val, None, None).value
+                idatetimes[i] = convert_to_tsobject(val, None, None, 0, 0).value
                 seen_datetime = 1
             else:
                 seen_object = 1
@@ -712,7 +712,7 @@ def maybe_convert_objects(ndarray[object] objects, bint try_float=0,
         elif PyDateTime_Check(val) or util.is_datetime64_object(val):
             if convert_datetime:
                 seen_datetime = 1
-                idatetimes[i] = convert_to_tsobject(val, None, None).value
+                idatetimes[i] = convert_to_tsobject(val, None, None, 0, 0).value
             else:
                 seen_object = 1
                 break

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -592,8 +592,6 @@ class TestDatetimeParsingWrappers(tm.TestCase):
             self.assertRaises(ValueError, tools.parse_time_string, case)
 
     def test_parsers_dayfirst_yearfirst(self):
-        raise nose.SkipTest("skipping until comprehensive fixes for dateutil, "
-                            "xref #12944")
 
         # https://github.com/dateutil/dateutil/issues/217
         # this issue was closed

--- a/pandas/tslib.pxd
+++ b/pandas/tslib.pxd
@@ -1,6 +1,6 @@
 from numpy cimport ndarray, int64_t
 
-cdef convert_to_tsobject(object, object, object)
+cdef convert_to_tsobject(object, object, object, bint, bint)
 cdef convert_to_timedelta64(object, object, object)
 cpdef object maybe_get_tz(object)
 cdef bint _is_utc(object)


### PR DESCRIPTION
closes #12944 

so this fixes the compat with all dateutils in the test suite
add the `dayfirst` and `yearfirst` args to `Timestamp`. This make testing and compat a lot
easier. xref discussion in #7599 where we didn't implement it, though the feeling was sort of +0.
