### PR TITLE
COMPAT: remove NaT comparison warnings with numpy >= 1.11

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -281,6 +281,7 @@ Bug Fixes
 - Bug in ``.astype()`` of a ``Float64Inde/Int64Index`` to an ``Int64Index`` (:issue:`12881`)
 - Bug in roundtripping an integer based index in ``.to_json()/.read_json()`` when ``orient='index'`` (the default) (:issue:`12866`)
 
+- Compat with >= numpy 1.11 for NaT comparions (:issue:`12969`)
 - Bug in ``.drop()`` with a non-unique ``MultiIndex``. (:issue:`12701`)
 - Bug in ``.concat`` of datetime tz-aware and naive DataFrames (:issue:`12467`)
 - Bug in correctly raising a ``ValueError`` in ``.resample(..).fillna(..)`` when passing a non-string (:issue:`12952`)

--- a/pandas/tests/test_lib.py
+++ b/pandas/tests/test_lib.py
@@ -223,7 +223,8 @@ class Testisscalar(tm.TestCase):
     def test_isscalar_numpy_zerodim_arrays(self):
         for zerodim in [np.array(1), np.array('foobar'),
                         np.array(np.datetime64('2014-01-01')),
-                        np.array(np.timedelta64(1, 'h'))]:
+                        np.array(np.timedelta64(1, 'h')),
+                        np.array(np.datetime64('NaT'))]:
             self.assertFalse(lib.isscalar(zerodim))
             self.assertTrue(lib.isscalar(lib.item_from_zerodim(zerodim)))
 

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -2532,74 +2532,77 @@ class TestDatetimeIndex(tm.TestCase):
             cases = [(fidx1, fidx2), (didx1, didx2), (didx1, darr)]
 
         # Check pd.NaT is handles as the same as np.nan
-        for idx1, idx2 in cases:
+        with tm.assert_produces_warning(None):
+            for idx1, idx2 in cases:
 
-            result = idx1 < idx2
-            expected = np.array([True, False, False, False, True, False])
-            self.assert_numpy_array_equal(result, expected)
+                result = idx1 < idx2
+                expected = np.array([True, False, False, False, True, False])
+                self.assert_numpy_array_equal(result, expected)
 
-            result = idx2 > idx1
-            expected = np.array([True, False, False, False, True, False])
-            self.assert_numpy_array_equal(result, expected)
+                result = idx2 > idx1
+                expected = np.array([True, False, False, False, True, False])
+                self.assert_numpy_array_equal(result, expected)
 
-            result = idx1 <= idx2
-            expected = np.array([True, False, False, False, True, True])
-            self.assert_numpy_array_equal(result, expected)
+                result = idx1 <= idx2
+                expected = np.array([True, False, False, False, True, True])
+                self.assert_numpy_array_equal(result, expected)
 
-            result = idx2 >= idx1
-            expected = np.array([True, False, False, False, True, True])
-            self.assert_numpy_array_equal(result, expected)
+                result = idx2 >= idx1
+                expected = np.array([True, False, False, False, True, True])
+                self.assert_numpy_array_equal(result, expected)
 
-            result = idx1 == idx2
-            expected = np.array([False, False, False, False, False, True])
-            self.assert_numpy_array_equal(result, expected)
+                result = idx1 == idx2
+                expected = np.array([False, False, False, False, False, True])
+                self.assert_numpy_array_equal(result, expected)
 
-            result = idx1 != idx2
-            expected = np.array([True, True, True, True, True, False])
-            self.assert_numpy_array_equal(result, expected)
+                result = idx1 != idx2
+                expected = np.array([True, True, True, True, True, False])
+                self.assert_numpy_array_equal(result, expected)
 
-        for idx1, val in [(fidx1, np.nan), (didx1, pd.NaT)]:
-            result = idx1 < val
-            expected = np.array([False, False, False, False, False, False])
-            self.assert_numpy_array_equal(result, expected)
-            result = idx1 > val
-            self.assert_numpy_array_equal(result, expected)
+        with tm.assert_produces_warning(None):
+            for idx1, val in [(fidx1, np.nan), (didx1, pd.NaT)]:
+                result = idx1 < val
+                expected = np.array([False, False, False, False, False, False])
+                self.assert_numpy_array_equal(result, expected)
+                result = idx1 > val
+                self.assert_numpy_array_equal(result, expected)
 
-            result = idx1 <= val
-            self.assert_numpy_array_equal(result, expected)
-            result = idx1 >= val
-            self.assert_numpy_array_equal(result, expected)
+                result = idx1 <= val
+                self.assert_numpy_array_equal(result, expected)
+                result = idx1 >= val
+                self.assert_numpy_array_equal(result, expected)
 
-            result = idx1 == val
-            self.assert_numpy_array_equal(result, expected)
+                result = idx1 == val
+                self.assert_numpy_array_equal(result, expected)
 
-            result = idx1 != val
-            expected = np.array([True, True, True, True, True, True])
-            self.assert_numpy_array_equal(result, expected)
+                result = idx1 != val
+                expected = np.array([True, True, True, True, True, True])
+                self.assert_numpy_array_equal(result, expected)
 
         # Check pd.NaT is handles as the same as np.nan
-        for idx1, val in [(fidx1, 3), (didx1, datetime(2014, 3, 1))]:
-            result = idx1 < val
-            expected = np.array([True, False, False, False, False, False])
-            self.assert_numpy_array_equal(result, expected)
-            result = idx1 > val
-            expected = np.array([False, False, False, False, True, True])
-            self.assert_numpy_array_equal(result, expected)
+        with tm.assert_produces_warning(None):
+            for idx1, val in [(fidx1, 3), (didx1, datetime(2014, 3, 1))]:
+                result = idx1 < val
+                expected = np.array([True, False, False, False, False, False])
+                self.assert_numpy_array_equal(result, expected)
+                result = idx1 > val
+                expected = np.array([False, False, False, False, True, True])
+                self.assert_numpy_array_equal(result, expected)
 
-            result = idx1 <= val
-            expected = np.array([True, False, True, False, False, False])
-            self.assert_numpy_array_equal(result, expected)
-            result = idx1 >= val
-            expected = np.array([False, False, True, False, True, True])
-            self.assert_numpy_array_equal(result, expected)
+                result = idx1 <= val
+                expected = np.array([True, False, True, False, False, False])
+                self.assert_numpy_array_equal(result, expected)
+                result = idx1 >= val
+                expected = np.array([False, False, True, False, True, True])
+                self.assert_numpy_array_equal(result, expected)
 
-            result = idx1 == val
-            expected = np.array([False, False, True, False, False, False])
-            self.assert_numpy_array_equal(result, expected)
+                result = idx1 == val
+                expected = np.array([False, False, True, False, False, False])
+                self.assert_numpy_array_equal(result, expected)
 
-            result = idx1 != val
-            expected = np.array([True, True, False, True, True, True])
-            self.assert_numpy_array_equal(result, expected)
+                result = idx1 != val
+                expected = np.array([True, True, False, True, True, True])
+                self.assert_numpy_array_equal(result, expected)
 
     def test_map(self):
         rng = date_range('1/1/2000', periods=10)


### PR DESCRIPTION
cc @sinhrks 
