### PR TITLE
fix for read_html with bs4 failing on table with header and one column

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -344,3 +344,5 @@ Bug Fixes
 
 
 - Bug in ``fill_value`` is ignored if the argument to a binary operator is a constant (:issue `12723`)
+
+- Bug in ``read_html`` when using bs4 flavor and parsing table with a header and only one column (:issue `9178`)

--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -345,4 +345,4 @@ Bug Fixes
 
 - Bug in ``fill_value`` is ignored if the argument to a binary operator is a constant (:issue `12723`)
 
-- Bug in ``read_html`` when using bs4 flavor and parsing table with a header and only one column (:issue `9178`)
+- Bug in ``pd.read_html`` when using bs4 flavor and parsing table with a header and only one column (:issue `9178`)

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -356,14 +356,16 @@ class _HtmlFrameParser(object):
         res = []
         if thead:
             res = lmap(self._text_getter, self._parse_th(thead[0]))
-        return np.atleast_1d(np.array(res).squeeze()) if res and len(res) == 1 else res
+        return np.atleast_1d(
+            np.array(res).squeeze()) if res and len(res) == 1 else res
 
     def _parse_raw_tfoot(self, table):
         tfoot = self._parse_tfoot(table)
         res = []
         if tfoot:
             res = lmap(self._text_getter, self._parse_td(tfoot[0]))
-        return np.atleast_1d(np.array(res).squeeze()) if res and len(res) == 1 else res
+        return np.atleast_1d(
+            np.array(res).squeeze()) if res and len(res) == 1 else res
 
     def _parse_raw_tbody(self, table):
         tbody = self._parse_tbody(table)

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -356,14 +356,14 @@ class _HtmlFrameParser(object):
         res = []
         if thead:
             res = lmap(self._text_getter, self._parse_th(thead[0]))
-        return np.array(res).squeeze() if res and len(res) == 1 else res
+        return np.atleast_1d(np.array(res).squeeze()) if res and len(res) == 1 else res
 
     def _parse_raw_tfoot(self, table):
         tfoot = self._parse_tfoot(table)
         res = []
         if tfoot:
             res = lmap(self._text_getter, self._parse_td(tfoot[0]))
-        return np.array(res).squeeze() if res and len(res) == 1 else res
+        return np.atleast_1d(np.array(res).squeeze()) if res and len(res) == 1 else res
 
     def _parse_raw_tbody(self, table):
         tbody = self._parse_tbody(table)

--- a/pandas/io/tests/test_html.py
+++ b/pandas/io/tests/test_html.py
@@ -419,6 +419,7 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
     def test_header_and_one_column(self):
         """
         Don't fail with bs4 when there is a header and only one column
+        as described in issue #9178
         """
         data = StringIO('''<html>
             <body>
@@ -436,9 +437,9 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
             </table>
             </body>
         </html>''')
-
-        correct_df = DataFrame(data={'Header': 'first'}, index=[0])
-        tm.assert_frame_equal(self.read_html(data)[0], correct_df)
+        expected = DataFrame(data={'Header': 'first'}, index=[0])
+        result = self.read_html(data)[0]
+        tm.assert_frame_equal(result, expected)
 
     def test_tfoot_read(self):
         """

--- a/pandas/io/tests/test_html.py
+++ b/pandas/io/tests/test_html.py
@@ -416,6 +416,30 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
         res2 = self.read_html(StringIO(data2))
         assert_framelist_equal(res1, res2)
 
+    def test_header_and_one_column(self):
+        """
+        Don't fail with bs4 when there is a header and only one column
+        """
+        data = StringIO('''<html>
+            <body>
+             <table>
+                <thead>
+                    <tr>
+                        <th>Header</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>first</td>
+                    </tr>
+                </tbody>
+            </table>
+            </body>
+        </html>''')
+
+        correct_df = DataFrame(data={'Header': 'first'}, index=[0])
+        tm.assert_frame_equal(self.read_html(data)[0], correct_df)
+
     def test_tfoot_read(self):
         """
         Make sure that read_html reads tfoot, containing td or th.


### PR DESCRIPTION
- [x] closes [#9178](https://github.com/pydata/pandas/issues/9178)
- [x] The test is added and passing (while failing before the fix).
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Fix as had been proposed in [PR 9194](https://github.com/pydata/pandas/pull/9194#issuecomment-209849563), but this PR was closed because of tests missing. They are added now.
