### PR TITLE
BUG: Preserve timezone in unaligned assignments

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -434,5 +434,4 @@ Bug Fixes
 - ``pd.read_excel()`` now accepts path objects (e.g. ``pathlib.Path``, ``py.path.local``) for the file path, in line with other ``read_*`` functions (:issue:`12655`)
 - ``pd.read_excel()`` now accepts column names associated with keyword argument ``names``(:issue `12870`)
 
-- Bug in ``DataFrame._santize_column`` now preserves Timezone when RHS is a Series (:issue `12981`)
-
+- Bug in ``DataFrame`` timezone lost when assigning tz-aware datetime ``Series`` with alignment (:issue `12981`)

--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -433,3 +433,6 @@ Bug Fixes
 - Bug where ``loffset`` argument was not applied when calling ``resample().count()`` on a timeseries (:issue:`12725`)
 - ``pd.read_excel()`` now accepts path objects (e.g. ``pathlib.Path``, ``py.path.local``) for the file path, in line with other ``read_*`` functions (:issue:`12655`)
 - ``pd.read_excel()`` now accepts column names associated with keyword argument ``names``(:issue `12870`)
+
+- Bug in ``DataFrame._santize_column`` now preserves Timezone when RHS is a Series (:issue `12981`)
+

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2538,7 +2538,7 @@ class DataFrame(NDFrame):
 
                 # GH 4107
                 try:
-                    value = value.reindex(self.index).values
+                    value = value.reindex(self.index)._values
                 except Exception as e:
 
                     # duplicate axis

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -1950,6 +1950,9 @@ class TestDataFrameIndexing(tm.TestCase, TestData):
         df['dates'] = column[[1, 0, 2]]
         assert_series_equal(df['dates'], column)
 
+        df.loc[[0, 1, 2], 'dates'] = column[[1, 0, 2]]
+        assert_series_equal(df['dates'], column)
+
     def test_setitem_datetime_coercion(self):
         # GH 1048
         df = pd.DataFrame({'c': [pd.Timestamp('2010-10-01')] * 3})

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -1940,6 +1940,16 @@ class TestDataFrameIndexing(tm.TestCase, TestData):
         exp = pd.Series([1, 0, 0], name='new_column')
         assert_series_equal(df['new_column'], exp)
 
+    def test_setitem_with_unaligned_tz_aware_datetime_column(self):
+        # GH12981
+        # Assignment of unaligned offset-aware datetime series.
+        # Make sure timezone isn't lost
+        column = pd.Series(pd.date_range('2015-01-01', periods=3, tz='utc'),
+                           name='dates')
+        df = pd.DataFrame({'dates': column})
+        df['dates'] = column[[1, 0, 2]]
+        assert_series_equal(df['dates'], column)
+
     def test_setitem_datetime_coercion(self):
         # GH 1048
         df = pd.DataFrame({'c': [pd.Timestamp('2010-10-01')] * 3})


### PR DESCRIPTION
- [x] closes #12981 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

A fix for #12981.  When doing a slice assign to a DataFrame where the
right-hand-side was timezone-aware datetime Series which required
realignment to perform the assignment, the timezone would be stripped
from the RHS on assignment.
