### PR TITLE
PERF: don't create the skiprows set if using the c-parser

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -408,7 +408,7 @@ Performance Improvements
 
 - Improved speed of SAS reader (:issue:`12656`)
 - Performance improvements in ``.groupby(..).cumcount()`` (:issue:`11039`)
-
+- Improved memory usage in ``pd.read_csv()`` when using ``skiprows=an_integer`` (:issue:`13005`)
 
 - Improved performance of ``DataFrame.to_sql`` when checking case sensitivity for tables. Now only checks if table has been created correctly when table name is not lower case. (:issue:`12876`)
 - Improved performance of ``Period`` construction and plotting of ``Period``s. (:issue:`12903`, :issue:`11831`)

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -775,9 +775,12 @@ class TextFileReader(BaseIterator):
         # Converting values to NA
         na_values, na_fvalues = _clean_na_values(na_values, keep_default_na)
 
-        if com.is_integer(skiprows):
-            skiprows = lrange(skiprows)
-        skiprows = set() if skiprows is None else set(skiprows)
+        # handle skiprows; this is internally handled by the
+        # c-engine, so only need for python parsers
+        if engine != 'c':
+            if com.is_integer(skiprows):
+                skiprows = lrange(skiprows)
+            skiprows = set() if skiprows is None else set(skiprows)
 
         # put stuff back
         result['names'] = names


### PR DESCRIPTION
```
In [4]: DataFrame(np.random.randn(1000000,1)).to_csv('test.csv',index=False)
```

branch 

```
In [1]: %memit pd.read_csv('test.csv',skiprows=999999)
peak memory: 65.74 MiB, increment: 1.59 MiB

In [2]: %memit pd.read_csv('test.csv',skiprows=999999)
peak memory: 65.89 MiB, increment: 0.22 MiB

In [3]: %memit pd.read_csv('test.csv',skiprows=999999)
peak memory: 65.98 MiB, increment: 0.28 MiB
```

master

```
In [1]: %memit pd.read_csv('test.csv',skiprows=999999)
peak memory: 169.84 MiB, increment: 105.79 MiB

In [2]: %memit pd.read_csv('test.csv',skiprows=999999)
peak memory: 171.27 MiB, increment: 24.11 MiB

In [3]: %memit pd.read_csv('test.csv',skiprows=999999)
peak memory: 173.39 MiB, increment: 24.63 MiB
```
