### PR TITLE
PERF: Improved performance for .str.encode/decode

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -412,6 +412,8 @@ Performance Improvements
 
 - Improved performance of ``DataFrame.to_sql`` when checking case sensitivity for tables. Now only checks if table has been created correctly when table name is not lower case. (:issue:`12876`)
 - Improved performance of ``Period`` construction and plotting of ``Period``s. (:issue:`12903`, :issue:`11831`)
+- Improved performance of ``.str.encode()`` and ``.str.decode()`` methods
+
 
 
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -13,6 +13,14 @@ import re
 import pandas.lib as lib
 import warnings
 import textwrap
+import codecs
+
+_cpython_optimized_encoders = (
+    "utf-8", "utf8", "latin-1", "latin1", "iso-8859-1", "mbcs", "ascii"
+)
+_cpython_optimized_decoders = _cpython_optimized_encoders + (
+    "utf-16", "utf-32"
+)
 
 _shared_docs = dict()
 
@@ -1182,7 +1190,12 @@ def str_decode(arr, encoding, errors="strict"):
     -------
     decoded : Series/Index of objects
     """
-    f = lambda x: x.decode(encoding, errors)
+    if encoding in _cpython_optimized_decoders:
+        #CPython optimized implementation
+        f = lambda x: x.decode(encoding, errors)
+    else:
+        decoder = codecs.getdecoder(encoding)
+        f = lambda x: decoder(x, errors)[0]
     return _na_map(f, arr)
 
 
@@ -1200,7 +1213,12 @@ def str_encode(arr, encoding, errors="strict"):
     -------
     encoded : Series/Index of objects
     """
-    f = lambda x: x.encode(encoding, errors)
+    if encoding in _cpython_optimized_encoders:
+        #CPython optimized implementation
+        f = lambda x: x.encode(encoding, errors)
+    else:
+        encoder = codecs.getencoder(encoding)
+        f = lambda x: encoder(x, errors)[0]
     return _na_map(f, arr)
 
 


### PR DESCRIPTION
I need such a patch to read huge `sas` tables encoded in `cp1251`. I'm not experienced enough to determine if such a patch is really needed here, but well.. it gives some speed in certain situations.

Optimize string encoding-decoding, leave default implementation for CPython optimized encodings,
(see https://docs.python.org/3.4/library/codecs.html#standard-encodings)

string

```
import pandas as pd
s1 = pd.Series(pd.util.testing.makeStringIndex(k=100000)).astype('category')
encs = 'utf-8', 'utf-16', 'utf-32', 'latin1', 'iso-8859-1', 'mbcs', 'ascii', 'cp1251', 'cp1252'
for enc in encs:
    s2 = s1.str.encode(enc).astype('category')
    print(enc)
    %timeit s1.str.encode(enc)
    %timeit s2.str.decode(enc)
```

unicode

```
import pandas as pd
s1 = pd.Series(pd.util.testing.makeUnicodeIndex(k=100000)).astype('category')
encs = 'utf-8', 'utf-16', 'utf-32'
for enc in encs:
    s2 = s1.str.encode(enc).astype('category')
    print(enc)
    %timeit s1.str.encode(enc)
    %timeit s2.str.decode(enc)
```

![image](https://cloud.githubusercontent.com/assets/53390/14850902/d7bf3ea2-0c84-11e6-88a8-fbdfc0f6b36f.png)
("10 loops, best of 3: xxx ms per loop")
