### PR TITLE
BUG:plot.bar misalignment when width=1

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -501,6 +501,7 @@ Bug Fixes
 - Bug in ``concat`` raises ``AttributeError`` when input data contains tz-aware datetime and timedelta (:issue:`12620`)
 - Bug in ``concat`` doesn't handle empty ``Series`` properly (:issue:`11082`)
 
+- Bug in ``.plot.bar`` alginment when ``width`` is specified with ``int`` (:issue:`12979`)
 
 
 - Bug in ``fill_value`` is ignored if the argument to a binary operator is a constant (:issue:`12723`)

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -2034,6 +2034,26 @@ class TestDataFramePlots(TestPlotBase):
                                   position=0.2)
 
     @slow
+    def test_bar_barwidth_position_int(self):
+        # GH 12979
+        df = DataFrame(randn(5, 5))
+
+        for w in [1, 1.]:
+            ax = df.plot.bar(stacked=True, width=w)
+            ticks = ax.xaxis.get_ticklocs()
+            tm.assert_numpy_array_equal(ticks, np.array([0, 1, 2, 3, 4]))
+            self.assertEqual(ax.get_xlim(), (-0.75, 4.75))
+            # check left-edge of bars
+            self.assertEqual(ax.patches[0].get_x(), -0.5)
+            self.assertEqual(ax.patches[-1].get_x(), 3.5)
+
+        self._check_bar_alignment(df, kind='bar', stacked=True, width=1)
+        self._check_bar_alignment(df, kind='barh', stacked=False, width=1)
+        self._check_bar_alignment(df, kind='barh', stacked=True, width=1)
+        self._check_bar_alignment(df, kind='bar', subplots=True, width=1)
+        self._check_bar_alignment(df, kind='barh', subplots=True, width=1)
+
+    @slow
     def test_bar_bottom_left(self):
         df = DataFrame(rand(5, 5))
         ax = df.plot.bar(stacked=False, bottom=1)

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -1,5 +1,7 @@
 # being a bit too dynamic
 # pylint: disable=E1101
+from __future__ import division
+
 import warnings
 import re
 from math import ceil


### PR DESCRIPTION
- [x] closes #12979
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Enabled true division. It also prevents differences between py2 / py3.
