### PR TITLE
BUG: subclassed .align returns normal DataFrame

### DIFF
--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -597,6 +597,27 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
         assert_frame_equal(expr, res1r)
         assert_frame_equal(expr, res2l)
 
+    def test_align_series_combinations(self):
+        df = pd.DataFrame({'a': [1, 3, 5],
+                           'b': [1, 3, 5]}, index=list('ACE'))
+        s = pd.Series([1, 2, 4], index=list('ABD'), name='x')
+
+        # frame + series
+        res1, res2 = df.align(s, axis=0)
+        exp1 = pd.DataFrame({'a': [1, np.nan, 3, np.nan, 5],
+                             'b': [1, np.nan, 3, np.nan, 5]},
+                            index=list('ABCDE'))
+        exp2 = pd.Series([1, 2, np.nan, 4, np.nan],
+                         index=list('ABCDE'), name='x')
+
+        tm.assert_frame_equal(res1, exp1)
+        tm.assert_series_equal(res2, exp2)
+
+        # series + frame
+        res1, res2 = s.align(df)
+        tm.assert_series_equal(res1, exp2)
+        tm.assert_frame_equal(res2, exp1)
+
     def test_filter(self):
         # items
         filtered = self.frame.filter(['A', 'B', 'E'])

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -2420,7 +2420,7 @@ def test_parallel(num_threads=2, kwargs_list=None):
 
 
 class SubclassedSeries(Series):
-    _metadata = ['testattr']
+    _metadata = ['testattr', 'name']
 
     @property
     def _constructor(self):


### PR DESCRIPTION
- [x] closes #12983
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry

Also fixed a bug which `Series.align(DataFrame)` raises `AttributeError`.

```
pd.Series([1, 2], index=['a', 'b']).align(pd.DataFrame([1, 2], index=['a', 'c']))
# AttributeError: 'Series' object has no attribute 'columns'
```
