### PR TITLE
TST/BUG: Categorical dtypes cause error when attempting stacked bar plot

### DIFF
--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -2101,6 +2101,32 @@ class TestDataFramePlots(TestPlotBase):
         self.assertEqual(result, expected)
 
     @slow
+    def test_bar_categorical(self):
+        # GH 13019
+        df1 = pd.DataFrame(np.random.randn(6, 5),
+                           index=pd.Index(list('ABCDEF')),
+                           columns=pd.Index(list('abcde')))
+        # categorical index must behave the same
+        df2 = pd.DataFrame(np.random.randn(6, 5),
+                           index=pd.CategoricalIndex(list('ABCDEF')),
+                           columns=pd.CategoricalIndex(list('abcde')))
+
+        for df in [df1, df2]:
+            ax = df.plot.bar()
+            ticks = ax.xaxis.get_ticklocs()
+            tm.assert_numpy_array_equal(ticks, np.array([0, 1, 2, 3, 4, 5]))
+            self.assertEqual(ax.get_xlim(), (-0.5, 5.5))
+            # check left-edge of bars
+            self.assertEqual(ax.patches[0].get_x(), -0.25)
+            self.assertEqual(ax.patches[-1].get_x(), 5.15)
+
+            ax = df.plot.bar(stacked=True)
+            tm.assert_numpy_array_equal(ticks, np.array([0, 1, 2, 3, 4, 5]))
+            self.assertEqual(ax.get_xlim(), (-0.5, 5.5))
+            self.assertEqual(ax.patches[0].get_x(), -0.25)
+            self.assertEqual(ax.patches[-1].get_x(), 4.75)
+
+    @slow
     def test_plot_scatter(self):
         df = DataFrame(randn(6, 4),
                        index=list(string.ascii_letters[:6]),


### PR DESCRIPTION
- [x] closes #13019
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
