### PR TITLE
BUG: Default to stat axis for SparseDataFrame when axis=None

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -76,6 +76,7 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
+- Bug in ``SparseDataFrame`` in which ``axis=None`` did not default to ``axis=0`` (:issue:`13048`)
 
 
 

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -651,6 +651,9 @@ class SparseDataFrame(DataFrame):
 
     @Appender(DataFrame.count.__doc__)
     def count(self, axis=0, **kwds):
+        if axis is None:
+            axis = self._stat_axis_number
+
         return self.apply(lambda x: x.count(), axis=axis)
 
     def cumsum(self, axis=0, *args, **kwargs):
@@ -667,6 +670,10 @@ class SparseDataFrame(DataFrame):
         y : SparseDataFrame
         """
         nv.validate_cumsum(args, kwargs)
+
+        if axis is None:
+            axis = self._stat_axis_number
+
         return self.apply(lambda x: x.cumsum(), axis=axis)
 
     def apply(self, func, axis=0, broadcast=False, reduce=False):

--- a/pandas/sparse/tests/test_series.py
+++ b/pandas/sparse/tests/test_series.py
@@ -2,7 +2,6 @@
 
 import operator
 
-import nose  # noqa
 from numpy import nan
 import numpy as np
 import pandas as pd
@@ -549,6 +548,7 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
     def test_binary_operators(self):
 
         # skipping for now #####
+        import nose
         raise nose.SkipTest("skipping sparse binary operators test")
 
         def _check_inplace_op(iop, op):
@@ -1259,7 +1259,17 @@ class TestSparseSeriesAnalytics(tm.TestCase):
         tm.assertRaisesRegexp(ValueError, msg, np.cumsum,
                               self.zbseries, out=result)
 
+    def test_numpy_func_call(self):
+        # no exception should be raised even though
+        # numpy passes in 'axis=None' or `axis=-1'
+        funcs = ['sum', 'cumsum', 'var', 'mean',
+                 'prod', 'cumprod', 'std', 'argsort',
+                 'argmin', 'argmax', 'min', 'max']
+        for func in funcs:
+            for series in ('bseries', 'zbseries'):
+                getattr(np, func)(getattr(self, series))
+
 if __name__ == '__main__':
-    import nose  # noqa
+    import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
                    exit=False)


### PR DESCRIPTION
Title is self-explanatory.  Closes #13048.
