### PR TITLE
BUG: Period resample with length=0 doesn't set freq

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -74,3 +74,5 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
+
+- Bug in ``.resample`` empty data with ``PeriodIndex`` doesn't change ``freq`` (:issue:`13067`)

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -790,7 +790,10 @@ class PeriodIndexResampler(DatetimeIndexResampler):
 
         new_index = self._get_new_index()
         if len(new_index) == 0:
-            return self._wrap_result(self._selected_obj.reindex(new_index))
+            result = self._selected_obj
+            if isinstance(self._selected_obj.index, PeriodIndex):
+                result = result.asfreq(self.freq, how=self.convention)
+            return self._wrap_result(result.reindex(new_index))
 
         # Start vs. end of period
         memb = ax.asfreq(self.freq, how=self.convention)

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -2043,17 +2043,18 @@ class TestPeriodIndex(Base, tm.TestCase):
         assert_series_equal(result2, expected)
 
     def test_resample_empty(self):
-
         # GH12771 & GH12868
         index = PeriodIndex(start='2000', periods=0, freq='D', name='idx')
         s = Series(index=index)
 
-        expected_index = PeriodIndex([], name='idx', freq='M')
-        expected = Series(index=expected_index)
+        for freq in ['M', 'D', 'H']:
+            expected_index = PeriodIndex([], name='idx', freq=freq)
+            expected = Series(index=expected_index)
 
-        for method in resample_methods:
-            result = getattr(s.resample('M'), method)()
-            assert_series_equal(result, expected)
+            for method in resample_methods:
+                result = getattr(s.resample(freq), method)()
+                assert_series_equal(result, expected)
+                self.assertEqual(result.index.freq, freq)
 
     def test_resample_count(self):
 


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

given freq is not applied if data is empty.

```
s = pd.Series(index=pd.PeriodIndex([], freq='D'))
s.resample('M').mean()
# Series([], Freq: D, dtype: float64)
```
#### Expected

```
s.resample('M').mean()
# Series([], Freq: M, dtype: float64)
```
