### PR TITLE
BUG: PeriodIndex and Period subtraction error

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -75,3 +75,6 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
+
+- Bug in ``PeriodIndex`` and ``Period`` subtraction raises ``AttributeError`` (:issue:`13071`)
+- Bug in ``NaT`` - ``Period`` raises ``AttributeError`` (:issue:`13071`)

--- a/pandas/tseries/base.py
+++ b/pandas/tseries/base.py
@@ -14,6 +14,7 @@ from pandas.core.common import (is_integer, is_float, is_bool_dtype,
                                 AbstractMethodError)
 import pandas.formats.printing as printing
 import pandas.tslib as tslib
+import pandas._period as _period
 import pandas.lib as lib
 from pandas.core.index import Index
 from pandas.indexes.base import _index_shared_docs
@@ -533,6 +534,9 @@ class DatetimeIndexOpsMixin(object):
     def _sub_datelike(self, other):
         raise AbstractMethodError(self)
 
+    def _sub_period(self, other):
+        return NotImplemented
+
     @classmethod
     def _add_datetimelike_methods(cls):
         """
@@ -591,6 +595,8 @@ class DatetimeIndexOpsMixin(object):
                 return self.shift(-other)
             elif isinstance(other, (tslib.Timestamp, datetime)):
                 return self._sub_datelike(other)
+            elif isinstance(other, _period.Period):
+                return self._sub_period(other)
             else:  # pragma: no cover
                 return NotImplemented
         cls.__sub__ = __sub__


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Similar to #5202. `PeriodIndex` subtraction raises `AttributeError` either side is `Period` (scalar).

```
pd.PeriodIndex(['2011-01', '2011-02'], freq='M') - pd.Period('2011-01', freq='M') 
# AttributeError: 'PeriodIndex' object has no attribute 'ordinal'
```
#### Expected

If `Period(NaT)` is included in either side, result is `Float64Index` to hold `nan`.

```
pd.PeriodIndex(['2011-01', '2011-02'], freq='M') - pd.Period('2011-01', freq='M') 
# Int64Index([0, 1], dtype='int64')

pd.PeriodIndex(['2011-01', 'NaT'], freq='M') - pd.Period('2011-01', freq='M') 
Float64Index([0.0, nan], dtype='float64')
```
