### PR TITLE
BUG: Series ops with object dtype may incorrectly fail

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -132,3 +132,6 @@ Bug Fixes
 
 - Bug in ``NaT`` - ``Period`` raises ``AttributeError`` (:issue:`13071`)
 - Bug in ``Period`` addition raises ``TypeError`` if ``Period`` is on right hand side (:issue:`13069`)
+
+- Bug in ``Series`` arithmetic raises ``TypeError`` if it contains datetime-like as ``object`` dtype (:issue:`13043`)
+

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -413,6 +413,38 @@ class TestTimedeltas(tm.TestCase):
         tm.assert_series_equal(expected, td * other)
         tm.assert_series_equal(expected, other * td)
 
+    def test_ops_series_object(self):
+        # GH 13043
+        s = pd.Series([pd.Timestamp('2015-01-01', tz='US/Eastern'),
+                       pd.Timestamp('2015-01-01', tz='Asia/Tokyo')],
+                      name='xxx')
+        self.assertEqual(s.dtype, object)
+
+        exp = pd.Series([pd.Timestamp('2015-01-02', tz='US/Eastern'),
+                         pd.Timestamp('2015-01-02', tz='Asia/Tokyo')],
+                        name='xxx')
+        tm.assert_series_equal(s + pd.Timedelta('1 days'), exp)
+        tm.assert_series_equal(pd.Timedelta('1 days') + s, exp)
+
+        # object series & object series
+        s2 = pd.Series([pd.Timestamp('2015-01-03', tz='US/Eastern'),
+                        pd.Timestamp('2015-01-05', tz='Asia/Tokyo')],
+                       name='xxx')
+        self.assertEqual(s2.dtype, object)
+        exp = pd.Series([pd.Timedelta('2 days'), pd.Timedelta('4 days')],
+                        name='xxx')
+        tm.assert_series_equal(s2 - s, exp)
+        tm.assert_series_equal(s - s2, -exp)
+
+        s = pd.Series([pd.Timedelta('01:00:00'), pd.Timedelta('02:00:00')],
+                      name='xxx', dtype=object)
+        self.assertEqual(s.dtype, object)
+
+        exp = pd.Series([pd.Timedelta('01:30:00'), pd.Timedelta('02:30:00')],
+                        name='xxx')
+        tm.assert_series_equal(s + pd.Timedelta('00:30:00'), exp)
+        tm.assert_series_equal(pd.Timedelta('00:30:00') + s, exp)
+
     def test_compare_timedelta_series(self):
         # regresssion test for GH5963
         s = pd.Series([timedelta(days=1), timedelta(days=2)])


### PR DESCRIPTION
- [x] closes #13043
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

This must be after #13069.
