### PR TITLE
BUG: Respect Filtered Categorical in Crosstab

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -108,6 +108,7 @@ Performance Improvements
 Bug Fixes
 ~~~~~~~~~
 - Bug in ``SparseDataFrame`` in which ``axis=None`` did not default to ``axis=0`` (:issue:`13048`)
+- ``pd.crosstab`` now respects filtered ``Categorical`` objects (:issue:`12298`)
 
 
 

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -439,8 +439,15 @@ def crosstab(index, columns, values=None, rownames=None, colnames=None,
     crosstab : DataFrame
     """
 
-    index = com._maybe_make_list(index)
-    columns = com._maybe_make_list(columns)
+    def _make_list(arr):
+        # see gh-12298
+        if com.is_categorical(arr):
+            arr = Series(list(arr), name=arr.name)
+
+        return com._maybe_make_list(arr)
+
+    index = _make_list(index)
+    columns = _make_list(columns)
 
     rownames = _get_names(index, rownames, prefix='row')
     colnames = _get_names(columns, colnames, prefix='col')

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -1139,6 +1139,29 @@ class TestCrosstab(tm.TestCase):
                                  normalize=False)
         tm.assert_frame_equal(nans, calculated)
 
+    def test_crosstab_filtered_categorical(self):
+        # see gh-12298
+        df = pd.DataFrame({'col0': list('abcabc'),
+                           'col1': [1, 1, 2, 1, 2, 3],
+                           'col2': [1, 1, 0, 1, 1, 0]})
+        data = [[2, 0], [1, 1]]
+        columns = pd.Index([1, 2], name='col1')
+        index = pd.Index(['a', 'b'], name='col0')
+        expected = pd.DataFrame(data, columns=columns, index=index)
+
+        # sanity check
+        filtered = df[df.col2 == 1]
+        result = pd.crosstab(filtered.col0, filtered.col1)
+        tm.assert_frame_equal(result, expected)
+
+        # casting columns to Categorical shouldn't change anything
+        for col in df.columns:
+            df[col] = df[col].astype('category')
+
+        filtered = df[df.col2 == 1]
+        result = pd.crosstab(filtered.col0, filtered.col1)
+        tm.assert_frame_equal(result, expected)
+
     def test_crosstab_errors(self):
         # Issue 12578
 


### PR DESCRIPTION
Closes #12298 by stripping the `Categorical` elements of their original categories so that only their included values are considered during the counting / aggregation.
