### PR TITLE
TST: fix assert_categorical_equal message

### DIFF
--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -985,7 +985,7 @@ class Categorical(PandasObject):
 
         # Provide compatibility with pre-0.15.0 Categoricals.
         if '_codes' not in state and 'labels' in state:
-            state['_codes'] = state.pop('labels')
+            state['_codes'] = state.pop('labels').astype(np.int8)
         if '_categories' not in state and '_levels' in state:
             state['_categories'] = self._validate_categories(state.pop(
                 '_levels'))

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -320,8 +320,6 @@ class TestSeriesDatetimeValues(TestData, tm.TestCase):
         expected = np.array(['2015/03/01', '2015/03/02', '2015/03/03',
                              '2015/03/04', '2015/03/05'], dtype=np.object_)
         # dtype may be S10 or U10 depending on python version
-        print(result)
-        print(expected)
         self.assert_numpy_array_equal(result, expected, check_dtype=False)
 
         period_index = period_range('20150301', periods=5)

--- a/pandas/tests/test_testing.py
+++ b/pandas/tests/test_testing.py
@@ -65,9 +65,8 @@ class TestAssertAlmostEqual(tm.TestCase):
         self._assert_almost_equal_both({'a': 1, 'b': 2}, {'a': 1, 'b': 2})
 
         self._assert_not_almost_equal_both({'a': 1, 'b': 2}, {'a': 1, 'b': 3})
-        self._assert_not_almost_equal_both(
-            {'a': 1, 'b': 2}, {'a': 1, 'b': 2, 'c': 3}
-        )
+        self._assert_not_almost_equal_both({'a': 1, 'b': 2},
+                                           {'a': 1, 'b': 2, 'c': 3})
         self._assert_not_almost_equal_both({'a': 1}, 1)
         self._assert_not_almost_equal_both({'a': 1}, 'abc')
         self._assert_not_almost_equal_both({'a': 1}, [1, ])
@@ -215,11 +214,11 @@ numpy array values are different \\(66\\.66667 %\\)
 \\[right\\]: \\[1\\.0, nan, 3\\.0\\]"""
 
         with assertRaisesRegexp(AssertionError, expected):
-            assert_numpy_array_equal(
-                np.array([np.nan, 2, 3]), np.array([1, np.nan, 3]))
+            assert_numpy_array_equal(np.array([np.nan, 2, 3]),
+                                     np.array([1, np.nan, 3]))
         with assertRaisesRegexp(AssertionError, expected):
-            assert_almost_equal(
-                np.array([np.nan, 2, 3]), np.array([1, np.nan, 3]))
+            assert_almost_equal(np.array([np.nan, 2, 3]),
+                                np.array([1, np.nan, 3]))
 
         expected = """numpy array are different
 
@@ -339,8 +338,8 @@ Index levels are different
            labels=\\[\\[0, 0, 1, 1\\], \\[0, 1, 2, 3\\]\\]\\)"""
 
         idx1 = pd.Index([1, 2, 3])
-        idx2 = pd.MultiIndex.from_tuples([('A', 1), ('A', 2), ('B', 3), ('B', 4
-                                                                         )])
+        idx2 = pd.MultiIndex.from_tuples([('A', 1), ('A', 2),
+                                          ('B', 3), ('B', 4)])
         with assertRaisesRegexp(AssertionError, expected):
             assert_index_equal(idx1, idx2, exact=False)
 
@@ -350,10 +349,10 @@ MultiIndex level \\[1\\] values are different \\(25\\.0 %\\)
 \\[left\\]:  Int64Index\\(\\[2, 2, 3, 4\\], dtype='int64'\\)
 \\[right\\]: Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)"""
 
-        idx1 = pd.MultiIndex.from_tuples([('A', 2), ('A', 2), ('B', 3), ('B', 4
-                                                                         )])
-        idx2 = pd.MultiIndex.from_tuples([('A', 1), ('A', 2), ('B', 3), ('B', 4
-                                                                         )])
+        idx1 = pd.MultiIndex.from_tuples([('A', 2), ('A', 2),
+                                          ('B', 3), ('B', 4)])
+        idx2 = pd.MultiIndex.from_tuples([('A', 1), ('A', 2),
+                                          ('B', 3), ('B', 4)])
         with assertRaisesRegexp(AssertionError, expected):
             assert_index_equal(idx1, idx2)
         with assertRaisesRegexp(AssertionError, expected):
@@ -434,10 +433,10 @@ MultiIndex level \\[1\\] values are different \\(25\\.0 %\\)
 \\[left\\]:  Int64Index\\(\\[2, 2, 3, 4\\], dtype='int64'\\)
 \\[right\\]: Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)"""
 
-        idx1 = pd.MultiIndex.from_tuples([('A', 2), ('A', 2), ('B', 3), ('B', 4
-                                                                         )])
-        idx2 = pd.MultiIndex.from_tuples([('A', 1), ('A', 2), ('B', 3), ('B', 4
-                                                                         )])
+        idx1 = pd.MultiIndex.from_tuples([('A', 2), ('A', 2),
+                                          ('B', 3), ('B', 4)])
+        idx2 = pd.MultiIndex.from_tuples([('A', 1), ('A', 2),
+                                          ('B', 3), ('B', 4)])
         with assertRaisesRegexp(AssertionError, expected):
             assert_index_equal(idx1, idx2)
         with assertRaisesRegexp(AssertionError, expected):
@@ -672,6 +671,45 @@ class TestIsInstance(tm.TestCase):
         expected = "Input must not be type "
         with assertRaisesRegexp(AssertionError, expected):
             tm.assertNotIsInstance(pd.Series([1]), pd.Series)
+
+
+class TestAssertCategoricalEqual(unittest.TestCase):
+    _multiprocess_can_split_ = True
+
+    def test_categorical_equal_message(self):
+
+        expected = """Categorical\\.categories are different
+
+Categorical\\.categories values are different \\(25\\.0 %\\)
+\\[left\\]:  Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)
+\\[right\\]: Int64Index\\(\\[1, 2, 3, 5\\], dtype='int64'\\)"""
+
+        a = pd.Categorical([1, 2, 3, 4])
+        b = pd.Categorical([1, 2, 3, 5])
+        with assertRaisesRegexp(AssertionError, expected):
+            tm.assert_categorical_equal(a, b)
+
+        expected = """Categorical\\.codes are different
+
+Categorical\\.codes values are different \\(50\\.0 %\\)
+\\[left\\]:  \\[0, 1, 3, 2\\]
+\\[right\\]: \\[0, 1, 2, 3\\]"""
+
+        a = pd.Categorical([1, 2, 4, 3], categories=[1, 2, 3, 4])
+        b = pd.Categorical([1, 2, 3, 4], categories=[1, 2, 3, 4])
+        with assertRaisesRegexp(AssertionError, expected):
+            tm.assert_categorical_equal(a, b)
+
+        expected = """Categorical are different
+
+Attribute "ordered" are different
+\\[left\\]:  False
+\\[right\\]: True"""
+
+        a = pd.Categorical([1, 2, 3, 4], ordered=False)
+        b = pd.Categorical([1, 2, 3, 4], ordered=True)
+        with assertRaisesRegexp(AssertionError, expected):
+            tm.assert_categorical_equal(a, b)
 
 
 class TestRNGContext(unittest.TestCase):

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -903,18 +903,17 @@ def assertNotIsInstance(obj, cls, msg=''):
         raise AssertionError(err_msg.format(msg, cls))
 
 
-def assert_categorical_equal(res, exp):
-    assertIsInstance(res, pd.Categorical, '[Categorical] ')
-    assertIsInstance(exp, pd.Categorical, '[Categorical] ')
+def assert_categorical_equal(left, right, check_dtype=True,
+                             obj='Categorical'):
+    assertIsInstance(left, pd.Categorical, '[Categorical] ')
+    assertIsInstance(right, pd.Categorical, '[Categorical] ')
 
-    assert_index_equal(res.categories, exp.categories)
+    assert_index_equal(left.categories, right.categories,
+                       obj='{0}.categories'.format(obj))
+    assert_numpy_array_equal(left.codes, right.codes, check_dtype=check_dtype,
+                             obj='{0}.codes'.format(obj))
 
-    if not array_equivalent(res.codes, exp.codes):
-        raise AssertionError(
-            'codes not equivalent: {0} vs {1}.'.format(res.codes, exp.codes))
-
-    if res.ordered != exp.ordered:
-        raise AssertionError("ordered not the same")
+    assert_attr_equal('ordered', left, right, obj=obj)
 
 
 def raise_assert_detail(obj, message, left, right):


### PR DESCRIPTION
- [x] stage 1 of #13076
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] no whatsnew as it is internal test method

```
a = pd.Categorical([1, 2, 3, 4])
b = pd.Categorical([1, 2, 3, 5])
tm.assert_categorical_equal(a, b)
# Categorical.categories are different
# ...

a = pd.Categorical([1, 2, 4, 3], categories=[1, 2, 3, 4])
b = pd.Categorical([1, 2, 3, 4], categories=[1, 2, 3, 4])
tm.assert_categorical_equal(a, b)
# Categorical.codes values are different (50.0 %)
# ...
```

This must be after #13088.
