### PR TITLE
TST: Fix assertNotIsInstance msg

### DIFF
--- a/pandas/tests/test_testing.py
+++ b/pandas/tests/test_testing.py
@@ -627,6 +627,21 @@ DataFrame\\.iloc\\[:, 1\\] values are different \\(33\\.33333 %\\)
                                by_blocks=True)
 
 
+class TestIsInstance(tm.TestCase):
+
+    def test_isinstance(self):
+
+        expected = "Expected type "
+        with assertRaisesRegexp(AssertionError, expected):
+            tm.assertIsInstance(1, pd.Series)
+
+    def test_notisinstance(self):
+
+        expected = "Input must not be type "
+        with assertRaisesRegexp(AssertionError, expected):
+            tm.assertNotIsInstance(pd.Series([1]), pd.Series)
+
+
 class TestRNGContext(unittest.TestCase):
 
     def test_RNGContext(self):

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -868,9 +868,9 @@ def assertIsInstance(obj, cls, msg=''):
     """Test that obj is an instance of cls
     (which can be a class or a tuple of classes,
     as supported by isinstance())."""
-    assert isinstance(obj, cls), (
-        "%sExpected object to be of type %r, found %r instead" % (
-            msg, cls, type(obj)))
+    if not isinstance(obj, cls):
+        err_msg = "{0}Expected type {1}, found {2} instead"
+        raise AssertionError(err_msg.format(msg, cls, type(obj)))
 
 
 def assert_isinstance(obj, class_type_or_tuple, msg=''):
@@ -882,9 +882,9 @@ def assertNotIsInstance(obj, cls, msg=''):
     """Test that obj is not an instance of cls
     (which can be a class or a tuple of classes,
     as supported by isinstance())."""
-    assert not isinstance(obj, cls), (
-        "%sExpected object to be of type %r, found %r instead" % (
-            msg, cls, type(obj)))
+    if isinstance(obj, cls):
+        err_msg = "{0}Input must not be type {1}"
+        raise AssertionError(err_msg.format(msg, cls))
 
 
 def assert_categorical_equal(res, exp):


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`

The current error message below is confusing.

```
tm.assertNotIsInstance(pd.Series([1]), pd.Series)
# AssertionError: Expected object to be of type <class 'pandas.core.series.Series'>, found <class 'pandas.core.series.Series'> instead
```
