### PR TITLE
Improve error message for category dtype in HDF5, format="fixed" store.

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2517,7 +2517,9 @@ class GenericFixed(Fixed):
         transposed = False
 
         if com.is_categorical_dtype(value):
-            raise NotImplementedError('Cannot store a category dtype in a HDF5 dataset that uses format="fixed". Use format="table".')
+            raise NotImplementedError('Cannot store a category dtype in '
+                                      'a HDF5 dataset that uses format='
+                                      '"fixed". Use format="table".')
 
         if not empty_array:
             value = value.T

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2517,7 +2517,7 @@ class GenericFixed(Fixed):
         transposed = False
 
         if com.is_categorical_dtype(value):
-            raise NotImplementedError("cannot store a category dtype")
+            raise NotImplementedError('Cannot store a category dtype in a HDF5 dataset that uses format="fixed". Use format="table".')
 
         if not empty_array:
             value = value.T


### PR DESCRIPTION
A more explicit (and helpful) error message would have helped me discover sooner that format="table" supported categorical data.
