### PR TITLE
[BUG] Reading multiindex, incorrectly names columns without name.

### DIFF
--- a/pandas/formats/format.py
+++ b/pandas/formats/format.py
@@ -1277,29 +1277,41 @@ class HTMLFormatter(TableFormatter):
 
 
 def _get_level_lengths(levels, sentinel=''):
-    from itertools import groupby
+    """For each index in each level the function returns lengths of indexes.
 
-    def _make_grouper():
-        record = {'count': 0}
+    Parameters
+    ----------
+    levels : list of lists
+        List of values on for level.
+    sentinel : string, optional
+        Value which states that no new index starts on there.
 
-        def grouper(x):
-            if x != sentinel:
-                record['count'] += 1
-            return record['count']
+    Returns
+    ----------
+    Returns list of maps. For each level returns map of indexes (key is index
+    in row and value is length of index).
+    """
+    if len(levels) == 0:
+        return []
 
-        return grouper
+    control = [True for x in levels[0]]
 
     result = []
-    for lev in levels:
-        i = 0
-        f = _make_grouper()
-        recs = {}
-        for key, gpr in groupby(lev, f):
-            values = list(gpr)
-            recs[i] = len(values)
-            i += len(values)
+    for level in levels:
+        last_index = 0
 
-        result.append(recs)
+        lengths = {}
+        for i, key in enumerate(level):
+            if control[i] and key == sentinel:
+                pass
+            else:
+                control[i] = False
+                lengths[last_index] = i - last_index
+                last_index = i
+
+        lengths[last_index] = len(level) - last_index
+
+        result.append(lengths)
 
     return result
 
@@ -1762,7 +1774,6 @@ class ExcelFormatter(object):
         return val
 
     def _format_header_mi(self):
-
         if self.columns.nlevels > 1:
             if not self.index:
                 raise NotImplementedError("Writing to Excel with MultiIndex"

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -726,6 +726,46 @@ class XlrdTests(ReadingTestsBase):
                             header=[0, 1], skiprows=2)
         tm.assert_frame_equal(actual, expected)
 
+    def test_read_excel_multiindex_empty_level(self):
+        # GH 12453
+        _skip_if_no_xlsxwriter()
+        with ensure_clean('.xlsx') as path:
+            df = DataFrame({
+                ('Zero', ''): {0: 0},
+                ('One', 'x'): {0: 1},
+                ('Two', 'X'): {0: 3},
+                ('Two', 'Y'): {0: 7}
+            })
+
+            expected = DataFrame({
+                ('Zero', 'Unnamed: 3_level_1'): {0: 0},
+                ('One', u'x'): {0: 1},
+                ('Two', u'X'): {0: 3},
+                ('Two', u'Y'): {0: 7}
+            })
+
+            df.to_excel(path)
+            actual = pd.read_excel(path, header=[0, 1])
+            tm.assert_frame_equal(actual, expected)
+
+            df = pd.DataFrame({
+                ('Beg', ''): {0: 0},
+                ('Middle', 'x'): {0: 1},
+                ('Tail', 'X'): {0: 3},
+                ('Tail', 'Y'): {0: 7}
+            })
+
+            expected = pd.DataFrame({
+                ('Beg', 'Unnamed: 0_level_1'): {0: 0},
+                ('Middle', u'x'): {0: 1},
+                ('Tail', u'X'): {0: 3},
+                ('Tail', u'Y'): {0: 7}
+            })
+
+            df.to_excel(path)
+            actual = pd.read_excel(path, header=[0, 1])
+            tm.assert_frame_equal(actual, expected)
+
     def test_excel_multindex_roundtrip(self):
         # GH 4679
         _skip_if_no_xlsxwriter()


### PR DESCRIPTION
- [x] closes #12453
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Fixed reading and writing of Multiindex. 
In a situation where Multiindex looked like this:

| One | Two |
| --- | --- |
| X |  |

it was changed to: 

| One | Two |
| --- | --- |
| X | X |
