### PR TITLE
BUG: GH12896 where extra elements are returned in MultiIndex slicing

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -134,7 +134,7 @@ Bug Fixes
 
 
 
-
+- Bug in ``MultiIndex`` slicing where extra elements were returned when level is non-unique (:issue:`12896`)
 
 
 

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -1761,7 +1761,8 @@ class MultiIndex(Index):
 
             else:
                 m = np.zeros(len(labels), dtype=bool)
-                m[np.in1d(labels, r, assume_unique=True)] = True
+                m[np.in1d(labels, r,
+                          assume_unique=Index(labels).is_unique)] = True
 
             return m
 

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -2334,6 +2334,18 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         self.assertFalse(result.index.is_unique)
         assert_frame_equal(result, expected)
 
+        # GH12896
+        # numpy-implementation dependent bug
+        ints = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12, 13, 14, 14, 16,
+                17, 18, 19, 200000, 200000]
+        n = len(ints)
+        idx = MultiIndex.from_arrays([['a'] * n, ints])
+        result = Series([1] * n, index=idx)
+        result = result.sort_index()
+        result = result.loc[(slice(None), slice(100000))]
+        expected = Series([1] * (n - 2), index=idx[:-2]).sort_index()
+        assert_series_equal(result, expected)
+
     def test_multiindex_slicers_datetimelike(self):
 
         # GH 7429


### PR DESCRIPTION
- [x] closes #12896
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Is this the right way to do this?

cc @MaximilianR 
