### PR TITLE
PERF: quantile now operates per block boosting perf / fix quantile with nan

### DIFF
--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -423,7 +423,7 @@ class frame_get_dtype_counts(object):
     goal_time = 0.2
 
     def setup(self):
-        self.df = pandas.DataFrame(np.random.randn(10, 10000))
+        self.df = DataFrame(np.random.randn(10, 10000))
 
     def time_frame_get_dtype_counts(self):
         self.df.get_dtype_counts()
@@ -985,3 +985,14 @@ class series_string_vector_slice(object):
 
     def time_series_string_vector_slice(self):
         self.s.str[:5]
+
+
+class frame_quantile_axis1(object):
+    goal_time = 0.2
+
+    def setup(self):
+        self.df = DataFrame(np.random.randn(1000, 3),
+                            columns=list('ABC'))
+
+    def time_frame_quantile_axis1(self):
+        self.df.quantile([0.1, 0.5], axis=1)

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,4 +9,5 @@ coverage:
         branches: null
     changes:
       default:
-        branches: null
+        branches:
+          - master

--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -563,7 +563,6 @@ Performance Improvements
 - Improved speed of SAS reader (:issue:`12656`, :issue:`12961`)
 - Performance improvements in ``.groupby(..).cumcount()`` (:issue:`11039`)
 - Improved memory usage in ``pd.read_csv()`` when using ``skiprows=an_integer`` (:issue:`13005`)
-
 - Improved performance of ``DataFrame.to_sql`` when checking case sensitivity for tables. Now only checks if table has been created correctly when table name is not lower case. (:issue:`12876`)
 - Improved performance of ``Period`` construction and time series plotting (:issue:`12903`, :issue:`11831`).
 - Improved performance of ``.str.encode()`` and ``.str.decode()`` methods (:issue:`13008`)

--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -97,6 +97,9 @@ Performance Improvements
 
 - Improved performance of sparse ``IntIndex.intersect`` (:issue:`13082`)
 - Improved performance of sparse arithmetic with ``BlockIndex`` when the number of blocks are large, though recommended to use ``IntIndex`` in such cases (:issue:`13082`)
+- increased performance of ``DataFrame.quantile()`` as it now operates per-block (:issue:`11623`)
+
+
 
 
 
@@ -110,6 +113,7 @@ Bug Fixes
 
 
 
+- Regression in ``Series.quantile`` with nans (:issue:`13098`)
 
 
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -57,8 +57,6 @@ import pandas.index as _index
 
 from pandas.core.config import get_option
 
-from pandas import _np_version_under1p9
-
 __all__ = ['Series']
 
 _shared_doc_kwargs = dict(
@@ -1349,21 +1347,12 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
 
         self._check_percentile(q)
 
-        if _np_version_under1p9:
-            if interpolation != 'linear':
-                raise ValueError("Interpolation methods other than linear "
-                                 "are not supported in numpy < 1.9.")
+        result = self._data.quantile(qs=q, interpolation=interpolation)
 
-        kwargs = dict()
-        if not _np_version_under1p9:
-            kwargs.update({'interpolation': interpolation})
-
-        result = self._data.quantile(qs=q, **kwargs)
-
-        if com.is_list_like(result):
-            # explicitly use Float64Index to coerce empty result to float dtype
-            index = Float64Index(q)
-            return self._constructor(result, index=index, name=self.name)
+        if com.is_list_like(q):
+            return self._constructor(result,
+                                     index=Float64Index(q),
+                                     name=self.name)
         else:
             # scalar
             return result

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3826,24 +3826,24 @@ class AppendableTable(LegacyTable):
         nrows = self.nrows_expected
 
         # if dropna==True, then drop ALL nan rows
+        masks = []
         if dropna:
 
-            masks = []
             for a in self.values_axes:
 
                 # figure the mask: only do if we can successfully process this
                 # column, otherwise ignore the mask
                 mask = com.isnull(a.data).all(axis=0)
-                masks.append(mask.astype('u1', copy=False))
+                if isinstance(mask, np.ndarray):
+                    masks.append(mask.astype('u1', copy=False))
 
-            # consolidate masks
+        # consolidate masks
+        if len(masks):
             mask = masks[0]
             for m in masks[1:]:
                 mask = mask & m
             mask = mask.ravel()
-
         else:
-
             mask = None
 
         # broadcast the indexes if needed

--- a/pandas/tests/series/test_quantile.py
+++ b/pandas/tests/series/test_quantile.py
@@ -126,6 +126,14 @@ class TestSeriesQuantile(TestData, tm.TestCase):
                                                        interpolation='higher')
 
     def test_quantile_nan(self):
+
+        # GH 13098
+        s = pd.Series([1, 2, 3, 4, np.nan])
+        result = s.quantile(0.5)
+        expected = 2.5
+        self.assertEqual(result, expected)
+
+        # all nan/empty
         cases = [Series([]), Series([np.nan, np.nan])]
 
         for s in cases:

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -2676,7 +2676,7 @@ class TestGroupBy(tm.TestCase):
         trans_expected = ts_grouped.transform(g)
 
         assert_series_equal(apply_result, agg_expected)
-        assert_series_equal(agg_result, agg_expected)
+        assert_series_equal(agg_result, agg_expected, check_names=False)
         assert_series_equal(trans_result, trans_expected)
 
         agg_result = ts_grouped.agg(f, q=80)
@@ -2692,11 +2692,11 @@ class TestGroupBy(tm.TestCase):
         apply_result = df_grouped.apply(DataFrame.quantile, .8)
         expected = df_grouped.quantile(.8)
         assert_frame_equal(apply_result, expected)
-        assert_frame_equal(agg_result, expected)
+        assert_frame_equal(agg_result, expected, check_names=False)
 
         agg_result = df_grouped.agg(f, q=80)
         apply_result = df_grouped.apply(DataFrame.quantile, q=.8)
-        assert_frame_equal(agg_result, expected)
+        assert_frame_equal(agg_result, expected, check_names=False)
         assert_frame_equal(apply_result, expected)
 
     def test_size(self):


### PR DESCRIPTION
closes #11623
closes #13098
There is a slight API change in that the returned Series are now named by the quantile.

this PR

```
In [1]: df = DataFrame(np.random.randn(1000, 3), columns=list('ABC'))

In [2]: %timeit df.quantile([0.1, 0.5], axis=1)
1000 loops, best of 3: 830 µs per loop
```

0.18.1

```
In [3]: df.quantile([0.1, 0.5], axis=1)
In [1]: df = DataFrame(np.random.randn(1000, 3), columns=list('ABC'))

In [2]: %timeit df.quantile([0.1, 0.5], axis=1)
1 loop, best of 3: 317 ms per loop
```
