### PR TITLE
BUG: Added checks for NaN in __call__ of EngFormatter

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -132,3 +132,4 @@ Bug Fixes
 
 - Bug in ``NaT`` - ``Period`` raises ``AttributeError`` (:issue:`13071`)
 - Bug in ``Period`` addition raises ``TypeError`` if ``Period`` is on right hand side (:issue:`13069`)
+- Bug in ``__call__`` of ``EngFormatter`` that would prevent NaN's from formatting (:issue:`11981`)

--- a/pandas/formats/format.py
+++ b/pandas/formats/format.py
@@ -2590,6 +2590,9 @@ class EngFormatter(object):
         import math
         dnum = decimal.Decimal(str(num))
 
+        if decimal.Decimal.is_nan(dnum):
+            return 'NaN'
+
         sign = 1
 
         if dnum < 0:  # pragma: no cover

--- a/pandas/tests/formats/test_format.py
+++ b/pandas/tests/formats/test_format.py
@@ -3925,6 +3925,21 @@ class TestEngFormatter(tm.TestCase):
         result = formatter(0)
         self.assertEqual(result, u(' 0.000'))
 
+    def test_nan(self):
+        # Issue #11981
+
+        formatter = fmt.EngFormatter(accuracy=1, use_eng_prefix=True)
+        result = formatter(np.nan)
+        self.assertEqual(result, u('NaN'))
+
+        df = pd.DataFrame({'a':[1.5, 10.3, 20.5], 
+                           'b':[50.3, 60.67, 70.12],
+                           'c':[100.2, 101.33, 120.33]})
+        pt = df.pivot_table(values='a', index='b', columns='c')
+        fmt.set_eng_float_format(accuracy=1)
+        result = pt.to_string()
+        # Smoke test for Invalid Operation Error, no comparision required
+        self.reset_display_options()
 
 def _three_digit_exp():
     return '%.4g' % 1.7e8 == '1.7e+008'


### PR DESCRIPTION
- [x] closes #11981 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Closes #11981

Updated the v0.18.2 document

In the function `__call__` of EngFormatter check if decimal input is NaN.
