### PR TITLE
Make os.linesep default line_terminator in to_clipboard

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1211,7 +1211,7 @@ class NDFrame(PandasObject):
         from pandas.io.pickle import to_pickle
         return to_pickle(self, path)
 
-    def to_clipboard(self, excel=None, sep=None, **kwargs):
+    def to_clipboard(self, excel=True, **kwargs):
         """
         Attempt to write text representation of object to the system clipboard
         This can be pasted into Excel, for example.
@@ -1219,12 +1219,11 @@ class NDFrame(PandasObject):
         Parameters
         ----------
         excel : boolean, defaults to True
-                if True, use the provided separator, writing in a csv
-                format for allowing easy pasting into excel.
+                if True, use '\\t' separator and os.linesep line terminator by
+                default, write to csv format to allow easy pasting into excel.
                 if False, write a string representation of the object
                 to the clipboard
-        sep : optional, defaults to tab
-        other keywords are passed to to_csv
+        other keywords are passed to to_csv or DataFrame.to_string
 
         Notes
         -----
@@ -1234,7 +1233,7 @@ class NDFrame(PandasObject):
           - OS X: none
         """
         from pandas.io import clipboard
-        clipboard.to_clipboard(self, excel=excel, sep=sep, **kwargs)
+        clipboard.to_clipboard(self, excel=excel, **kwargs)
 
     def to_xarray(self):
         """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2552,7 +2552,8 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
 
     def to_csv(self, path=None, index=True, sep=",", na_rep='',
                float_format=None, header=False, index_label=None,
-               mode='w', encoding=None, date_format=None, decimal='.'):
+               mode='w', encoding=None, date_format=None, decimal='.',
+               line_terminator='\n'):
         """
         Write Series to a comma-separated values (csv) file
 
@@ -2584,6 +2585,8 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         decimal: string, default '.'
             Character recognized as decimal separator. E.g. use ',' for
             European data
+        line_terminator : string, default '\\n'
+            The newline character or character sequence to use in the output file
         """
         from pandas.core.frame import DataFrame
         df = DataFrame(self)
@@ -2592,7 +2595,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
                            float_format=float_format, header=header,
                            index_label=index_label, mode=mode,
                            encoding=encoding, date_format=date_format,
-                           decimal=decimal)
+                           decimal=decimal, line_terminator=line_terminator)
         if path is None:
             return result
 

--- a/pandas/io/tests/test_clipboard.py
+++ b/pandas/io/tests/test_clipboard.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import os
+
 import numpy as np
 from numpy.random import randint
 
@@ -79,6 +81,14 @@ class TestClipboard(tm.TestCase):
     def test_round_trip_frame(self):
         for dt in self.data_types:
             self.check_round_trip_frame(dt)
+
+    def test_linesep(self):
+        pd.DataFrame().to_clipboard()
+        ret = pandas.util.clipboard.clipboard_get()
+        assert ret == '""'+os.linesep, "Wrong line separator"
+        pd.Series([0]).to_clipboard(line_terminator="\t")
+        ret = pandas.util.clipboard.clipboard_get()
+        assert ret == "0\t0\t", "Wrong line separator"
 
     def test_read_clipboard_infer_excel(self):
         from textwrap import dedent


### PR DESCRIPTION
closes #11720
- Make os.linesep default line_terminator in to_clipboard
- Add line_terminator kw to Series.to_csv
- Refactor to_clipboard

Observed/fixed problems in to_clipboard:
- try..except: pass
- excel=None, though it defaults to True
- several code paths with return
- sep argument could be passed via kwargs
- "other keywords are passed to to_csv" only if excel=True
- line_terminator kw isn't supported by Series to_csv

Is it ok to to change Series.to_csv api?
Also we need tests, right? But what does `# pragma: no cover` mean?
