### PR TITLE
FIX: revert part of #11770

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -143,7 +143,4 @@ Bug Fixes
 
 
 
-
-
-
-
+- Bug in ``AutoDataFormatter``, restore second scaled formatting and readd musecond scaled formatting (:issue:`13131`)

--- a/pandas/tseries/converter.py
+++ b/pandas/tseries/converter.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from dateutil.relativedelta import relativedelta
 
+import matplotlib
 import matplotlib.units as units
 import matplotlib.dates as dates
 
@@ -22,6 +23,16 @@ import pandas.tseries.tools as tools
 import pandas.tseries.frequencies as frequencies
 from pandas.tseries.frequencies import FreqGroup
 from pandas.tseries.period import Period, PeriodIndex
+
+# constants
+HOURS_PER_DAY = 24.
+MIN_PER_HOUR = 60.
+SEC_PER_MIN = 60.
+
+SEC_PER_HOUR = SEC_PER_MIN * MIN_PER_HOUR
+SEC_PER_DAY = SEC_PER_HOUR * HOURS_PER_DAY
+
+MUSEC_PER_DAY = 1e6 * SEC_PER_DAY
 
 
 def register():
@@ -220,6 +231,13 @@ class PandasAutoDateFormatter(dates.AutoDateFormatter):
         # matplotlib.dates._UTC has no _utcoffset called by pandas
         if self._tz is dates.UTC:
             self._tz._utcoffset = self._tz.utcoffset(None)
+
+        # For mpl > 2.0 the format strings are controlled via rcparams
+        # so do not mess with them.  For mpl < 2.0 change the second
+        # break point and add a musec break point
+        if matplotlib.compare_versions('2.0.0', matplotlib.__version__):
+            self.scaled[1. / SEC_PER_DAY] = '%H:%M:%S'
+            self.scaled[1. / MUSEC_PER_DAY] = '%H:%M:%S.%f'
 
 
 class PandasAutoDateLocator(dates.AutoDateLocator):


### PR DESCRIPTION
Reverts part of:

https://github.com/pydata/pandas/pull/11770

Closes:

https://github.com/matplotlib/matplotlib/issues/6365

The mistake in #11770 was missing that pandas had a 1/us not 1/s
scaled bucket.
