### PR TITLE
Fine-grained errstate handling

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -7,6 +7,10 @@ This is a major release from 0.18.1 and includes a small number of API changes, 
 enhancements, and performance improvements along with a large number of bug fixes. We recommend that all
 users upgrade to this version.
 
+.. warning::
+
+    pandas >= 0.19.0 will no longer silence numpy ufunc warnings upon import, see :ref:`here <whatsnew_0190.errstate>`. (:issue:`13109`, :issue:`13145`)
+
 Highlights include:
 
 - :func:`merge_asof` for asof-style time-series joining, see :ref:`here <whatsnew_0190.enhancements.asof_merge>`
@@ -356,6 +360,15 @@ For ``MultiIndex``, values are dropped if any level is missing by default. Speci
 Google BigQuery Enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - The :func:`pandas.io.gbq.read_gbq` method has gained the ``dialect`` argument to allow users to specify whether to use BigQuery's legacy SQL or BigQuery's standard SQL. See the :ref:`docs <io.bigquery_reader>` for more details (:issue:`13615`).
+
+.. _whatsnew_0190.errstate:
+
+Fine-grained numpy errstate
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Previous versions of pandas would permanently silence numpy's ufunc error handling when ``pandas`` was imported (:issue:`13109`). Pandas did this in order to silence the warnings that would arise from using numpy ufuncs on missing data, which are usually represented as NaNs. Unfortunately, this silenced legitimate warnings arising in non-pandas code in the application. Starting with 0.19.0, pandas will use the ``numpy.errstate`` context manager to silence these warnings in a more fine-grained manner only around where these operations are actually used in the pandas codebase.
+
+After upgrading pandas, you may see "new" ``RuntimeWarnings`` being issued from your code. These are likely legitimate, and the underlying cause likely existed in the code when using previous versions of pandas that simply silenced the warning. Use `numpy.errstate <http://docs.scipy.org/doc/numpy/reference/generated/numpy.errstate.html>`__ around the source of the ``RuntimeWarning`` to control how these conditions are handled.
 
 .. _whatsnew_0190.enhancements.other:
 

--- a/pandas/compat/numpy/__init__.py
+++ b/pandas/compat/numpy/__init__.py
@@ -5,8 +5,6 @@ import numpy as np
 from distutils.version import LooseVersion
 from pandas.compat import string_types, string_and_binary_types
 
-# turn off all numpy warnings
-np.seterr(all='ignore')
 
 # numpy versioning
 _np_version = np.version.short_version

--- a/pandas/computation/align.py
+++ b/pandas/computation/align.py
@@ -95,8 +95,7 @@ def _align_core(terms):
                 term_axis_size = len(ti.axes[axis])
                 reindexer_size = len(reindexer)
 
-                with np.errstate(divide='ignore'):
-                    ordm = np.log10(abs(reindexer_size - term_axis_size))
+                ordm = np.log10(max(1, abs(reindexer_size - term_axis_size)))
                 if ordm >= 1 and reindexer_size >= 10000:
                     warnings.warn('Alignment difference on axis {0} is larger '
                                   'than an order of magnitude on term {1!r}, '

--- a/pandas/computation/align.py
+++ b/pandas/computation/align.py
@@ -95,7 +95,8 @@ def _align_core(terms):
                 term_axis_size = len(ti.axes[axis])
                 reindexer_size = len(reindexer)
 
-                ordm = np.log10(abs(reindexer_size - term_axis_size))
+                with np.errstate(divide='ignore'):
+                    ordm = np.log10(abs(reindexer_size - term_axis_size))
                 if ordm >= 1 and reindexer_size >= 10000:
                     warnings.warn('Alignment difference on axis {0} is larger '
                                   'than an order of magnitude on term {1!r}, '

--- a/pandas/computation/expressions.py
+++ b/pandas/computation/expressions.py
@@ -59,7 +59,8 @@ def _evaluate_standard(op, op_str, a, b, raise_on_error=True, **eval_kwargs):
     """ standard evaluation """
     if _TEST_MODE:
         _store_test_result(False)
-    return op(a, b)
+    with np.errstate(all='ignore'):
+        return op(a, b)
 
 
 def _can_use_numexpr(op, op_str, a, b, dtype_check):

--- a/pandas/computation/ops.py
+++ b/pandas/computation/ops.py
@@ -523,7 +523,8 @@ class MathCall(Op):
 
     def __call__(self, env):
         operands = [op(env) for op in self.operands]
-        return self.func.func(*operands)
+        with np.errstate(all='ignore'):
+            return self.func.func(*operands)
 
     def __unicode__(self):
         operands = map(str, self.operands)

--- a/pandas/computation/tests/test_eval.py
+++ b/pandas/computation/tests/test_eval.py
@@ -1613,7 +1613,8 @@ class TestMathPythonPython(tm.TestCase):
         for fn in self.unary_fns:
             expr = "{0}(a)".format(fn)
             got = self.eval(expr)
-            expect = getattr(np, fn)(a)
+            with np.errstate(all='ignore'):
+                expect = getattr(np, fn)(a)
             tm.assert_series_equal(got, expect, check_names=False)
 
     def test_binary_functions(self):
@@ -1624,7 +1625,8 @@ class TestMathPythonPython(tm.TestCase):
         for fn in self.binary_fns:
             expr = "{0}(a, b)".format(fn)
             got = self.eval(expr)
-            expect = getattr(np, fn)(a, b)
+            with np.errstate(all='ignore'):
+                expect = getattr(np, fn)(a, b)
             tm.assert_almost_equal(got, expect, check_names=False)
 
     def test_df_use_case(self):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3813,7 +3813,8 @@ class DataFrame(NDFrame):
             this = self[col].values
             that = other[col].values
             if filter_func is not None:
-                mask = ~filter_func(this) | isnull(that)
+                with np.errstate(all='ignore'):
+                    mask = ~filter_func(this) | isnull(that)
             else:
                 if raise_conflict:
                     mask_this = notnull(that)
@@ -4108,7 +4109,8 @@ class DataFrame(NDFrame):
             return self._apply_empty_result(func, axis, reduce, *args, **kwds)
 
         if isinstance(f, np.ufunc):
-            results = f(self.values)
+            with np.errstate(all='ignore'):
+                results = f(self.values)
             return self._constructor(data=results, index=self.index,
                                      columns=self.columns, copy=False)
         else:
@@ -4934,7 +4936,8 @@ class DataFrame(NDFrame):
                                             "type %s not implemented." %
                                             filter_type)
                     raise_with_traceback(e)
-                result = f(data.values)
+                with np.errstate(all='ignore'):
+                    result = f(data.values)
                 labels = data._get_agg_axis(axis)
         else:
             if numeric_only:

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -4369,8 +4369,8 @@ def _get_group_index_sorter(group_index, ngroups):
     count = len(group_index)
     alpha = 0.0  # taking complexities literally; there may be
     beta = 1.0  # some room for fine-tuning these parameters
-    with np.errstate(divide='ignore', invalid='ignore'):
-        do_groupsort = alpha + beta * ngroups < count * np.log(count)
+    do_groupsort = (count > 0 and ((alpha + beta * ngroups) <
+                                   (count * np.log(count))))
     if do_groupsort:
         sorter, _ = _algos.groupsort_indexer(_ensure_int64(group_index),
                                              ngroups)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -678,7 +678,8 @@ class _GroupBy(PandasObject, SelectionMixin):
 
                 @wraps(func)
                 def f(g):
-                    return func(g, *args, **kwargs)
+                    with np.errstate(all='ignore'):
+                        return func(g, *args, **kwargs)
             else:
                 raise ValueError('func must be a callable if args or '
                                  'kwargs are supplied')
@@ -4126,7 +4127,10 @@ def get_group_index(labels, shape, sort, xnull):
         out = stride * labels[0].astype('i8', subok=False, copy=False)
 
         for i in range(1, nlev):
-            stride //= shape[i]
+            if shape[i] == 0:
+                stride = 0
+            else:
+                stride //= shape[i]
             out += labels[i] * stride
 
         if xnull:  # exclude nulls
@@ -4365,7 +4369,9 @@ def _get_group_index_sorter(group_index, ngroups):
     count = len(group_index)
     alpha = 0.0  # taking complexities literally; there may be
     beta = 1.0  # some room for fine-tuning these parameters
-    if alpha + beta * ngroups < count * np.log(count):
+    with np.errstate(divide='ignore', invalid='ignore'):
+        do_groupsort = alpha + beta * ngroups < count * np.log(count)
+    if do_groupsort:
         sorter, _ = _algos.groupsort_indexer(_ensure_int64(group_index),
                                              ngroups)
         return _ensure_platform_int(sorter)

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -348,7 +348,8 @@ class Block(PandasObject):
         """ apply the function to my values; return a block if we are not
         one
         """
-        result = func(self.values, **kwargs)
+        with np.errstate(all='ignore'):
+            result = func(self.values, **kwargs)
         if not isinstance(result, Block):
             result = self.make_block(values=_block_shape(result,
                                                          ndim=self.ndim))
@@ -1156,7 +1157,8 @@ class Block(PandasObject):
 
         # get the result
         try:
-            result = get_result(other)
+            with np.errstate(all='ignore'):
+                result = get_result(other)
 
         # if we have an invalid shape/broadcast error
         # GH4576, so raise instead of allowing to pass through

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -45,7 +45,8 @@ class disallow(object):
                                 'this dtype'.format(
                                     f.__name__.replace('nan', '')))
             try:
-                return f(*args, **kwargs)
+                with np.errstate(invalid='ignore'):
+                    return f(*args, **kwargs)
             except ValueError as e:
                 # we want to transform an object array
                 # ValueError message to the more typical TypeError
@@ -513,7 +514,8 @@ def nanskew(values, axis=None, skipna=True):
     m2 = _zero_out_fperr(m2)
     m3 = _zero_out_fperr(m3)
 
-    result = (count * (count - 1) ** 0.5 / (count - 2)) * (m3 / m2 ** 1.5)
+    with np.errstate(invalid='ignore', divide='ignore'):
+        result = (count * (count - 1) ** 0.5 / (count - 2)) * (m3 / m2 ** 1.5)
 
     dtype = values.dtype
     if is_float_dtype(dtype):
@@ -562,10 +564,11 @@ def nankurt(values, axis=None, skipna=True):
     m2 = adjusted2.sum(axis, dtype=np.float64)
     m4 = adjusted4.sum(axis, dtype=np.float64)
 
-    adj = 3 * (count - 1) ** 2 / ((count - 2) * (count - 3))
-    numer = count * (count + 1) * (count - 1) * m4
-    denom = (count - 2) * (count - 3) * m2**2
-    result = numer / denom - adj
+    with np.errstate(invalid='ignore', divide='ignore'):
+        adj = 3 * (count - 1) ** 2 / ((count - 2) * (count - 3))
+        numer = count * (count + 1) * (count - 1) * m4
+        denom = (count - 2) * (count - 3) * m2**2
+        result = numer / denom - adj
 
     # floating point error
     numer = _zero_out_fperr(numer)
@@ -658,7 +661,8 @@ def _maybe_null_out(result, axis, mask):
 
 def _zero_out_fperr(arg):
     if isinstance(arg, np.ndarray):
-        return np.where(np.abs(arg) < 1e-14, 0, arg)
+        with np.errstate(invalid='ignore'):
+            return np.where(np.abs(arg) < 1e-14, 0, arg)
     else:
         return arg.dtype.type(0) if np.abs(arg) < 1e-14 else arg
 
@@ -760,7 +764,8 @@ def make_nancomp(op):
         ymask = isnull(y)
         mask = xmask | ymask
 
-        result = op(x, y)
+        with np.errstate(all='ignore'):
+            result = op(x, y)
 
         if mask.any():
             if is_bool_dtype(result):

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -582,7 +582,8 @@ def nankurt(values, axis=None, skipna=True):
         if denom == 0:
             return 0
 
-    result = numer / denom - adj
+    with np.errstate(invalid='ignore', divide='ignore'):
+        result = numer / denom - adj
 
     dtype = values.dtype
     if is_float_dtype(dtype):

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -636,7 +636,8 @@ def _arith_method_SERIES(op, name, str_rep, fill_zeros=None, default_axis=None,
 
     def safe_na_op(lvalues, rvalues):
         try:
-            return na_op(lvalues, rvalues)
+            with np.errstate(all='ignore'):
+                return na_op(lvalues, rvalues)
         except Exception:
             if isinstance(rvalues, ABCSeries):
                 if is_object_dtype(rvalues):
@@ -743,7 +744,8 @@ def _comp_method_SERIES(op, name, str_rep, masker=False):
                 x = x.view('i8')
 
             try:
-                result = getattr(x, name)(y)
+                with np.errstate(all='ignore'):
+                    result = getattr(x, name)(y)
                 if result is NotImplemented:
                     raise TypeError("invalid type comparison")
             except AttributeError:
@@ -796,13 +798,15 @@ def _comp_method_SERIES(op, name, str_rep, masker=False):
             # which would then not take categories ordering into account
             # we can go directly to op, as the na_op would just test again and
             # dispatch to it.
-            res = op(self.values, other)
+            with np.errstate(all='ignore'):
+                res = op(self.values, other)
         else:
             values = self.get_values()
             if isinstance(other, (list, np.ndarray)):
                 other = np.asarray(other)
 
-            res = na_op(values, other)
+            with np.errstate(all='ignore'):
+                res = na_op(values, other)
             if isscalar(res):
                 raise TypeError('Could not compare %s type with Series' %
                                 type(other))
@@ -1096,13 +1100,15 @@ def _arith_method_FRAME(op, name, str_rep=None, default_axis='columns',
                 xrav = xrav[mask]
                 yrav = yrav[mask]
                 if np.prod(xrav.shape) and np.prod(yrav.shape):
-                    result[mask] = op(xrav, yrav)
+                    with np.errstate(all='ignore'):
+                        result[mask] = op(xrav, yrav)
             elif hasattr(x, 'size'):
                 result = np.empty(x.size, dtype=x.dtype)
                 mask = notnull(xrav)
                 xrav = xrav[mask]
                 if np.prod(xrav.shape):
-                    result[mask] = op(xrav, y)
+                    with np.errstate(all='ignore'):
+                        result[mask] = op(xrav, y)
             else:
                 raise TypeError("cannot perform operation {op} between "
                                 "objects of type {x} and {y}".format(

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -713,7 +713,8 @@ class Panel(NDFrame):
                                       (str(type(other)), str(type(self))))
 
     def _combine_const(self, other, func):
-        new_values = func(self.values, other)
+        with np.errstate(all='ignore'):
+            new_values = func(self.values, other)
         d = self._construct_axes_dict()
         return self._constructor(new_values, **d)
 
@@ -723,14 +724,15 @@ class Panel(NDFrame):
 
         other = other.reindex(index=index, columns=columns)
 
-        if axis == 0:
-            new_values = func(self.values, other.values)
-        elif axis == 1:
-            new_values = func(self.values.swapaxes(0, 1), other.values.T)
-            new_values = new_values.swapaxes(0, 1)
-        elif axis == 2:
-            new_values = func(self.values.swapaxes(0, 2), other.values)
-            new_values = new_values.swapaxes(0, 2)
+        with np.errstate(all='ignore'):
+            if axis == 0:
+                new_values = func(self.values, other.values)
+            elif axis == 1:
+                new_values = func(self.values.swapaxes(0, 1), other.values.T)
+                new_values = new_values.swapaxes(0, 1)
+            elif axis == 2:
+                new_values = func(self.values.swapaxes(0, 2), other.values)
+                new_values = new_values.swapaxes(0, 2)
 
         return self._constructor(new_values, self.items, self.major_axis,
                                  self.minor_axis)
@@ -744,7 +746,8 @@ class Panel(NDFrame):
         this = self.reindex(items=items, major=major, minor=minor)
         other = other.reindex(items=items, major=major, minor=minor)
 
-        result_values = func(this.values, other.values)
+        with np.errstate(all='ignore'):
+            result_values = func(this.values, other.values)
 
         return self._constructor(result_values, items, major, minor)
 
@@ -1011,7 +1014,8 @@ class Panel(NDFrame):
         # try ufunc like
         if isinstance(f, np.ufunc):
             try:
-                result = np.apply_along_axis(func, axis, self.values)
+                with np.errstate(all='ignore'):
+                    result = np.apply_along_axis(func, axis, self.values)
                 return self._wrap_result(result, axis=axis)
             except (AttributeError):
                 pass
@@ -1113,7 +1117,8 @@ class Panel(NDFrame):
         axis_number = self._get_axis_number(axis_name)
         f = lambda x: op(x, axis=axis_number, skipna=skipna, **kwds)
 
-        result = f(self.values)
+        with np.errstate(all='ignore'):
+            result = f(self.values)
 
         axes = self._get_plane_axes(axis_name)
         if result.ndim == 2 and axis_name != self._info_axis_name:

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -733,10 +733,11 @@ class _Rolling(_Window):
                 def calc(x):
                     return func(x, window, min_periods=self.min_periods)
 
-            if values.ndim > 1:
-                result = np.apply_along_axis(calc, self.axis, values)
-            else:
-                result = calc(values)
+            with np.errstate(all='ignore'):
+                if values.ndim > 1:
+                    result = np.apply_along_axis(calc, self.axis, values)
+                else:
+                    result = calc(values)
 
             if center:
                 result = self._center_window(result, window)
@@ -1617,10 +1618,11 @@ class EWM(_Rolling):
 
             x_values = X._prep_values()
             y_values = Y._prep_values()
-            cov = _cov(x_values, y_values)
-            x_var = _cov(x_values, x_values)
-            y_var = _cov(y_values, y_values)
-            corr = cov / _zsqrt(x_var * y_var)
+            with np.errstate(all='ignore'):
+                cov = _cov(x_values, y_values)
+                x_var = _cov(x_values, x_values)
+                y_var = _cov(y_values, y_values)
+                corr = cov / _zsqrt(x_var * y_var)
             return X._wrap_result(corr)
 
         return _flex_binary_moment(self._selected_obj, other._selected_obj,
@@ -1757,8 +1759,9 @@ def _use_window(minp, window):
 
 
 def _zsqrt(x):
-    result = np.sqrt(x)
-    mask = x < 0
+    with np.errstate(all='ignore'):
+        result = np.sqrt(x)
+        mask = x < 0
 
     from pandas import DataFrame
     if isinstance(x, DataFrame):

--- a/pandas/formats/format.py
+++ b/pandas/formats/format.py
@@ -2099,9 +2099,10 @@ class FloatArrayFormatter(GenericArrayFormatter):
         # this is pretty arbitrary for now
         # large values: more that 8 characters including decimal symbol
         # and first digit, hence > 1e6
-        has_large_values = (abs_vals > 1e6).any()
-        has_small_values = ((abs_vals < 10**(-self.digits)) &
-                            (abs_vals > 0)).any()
+        with np.errstate(invalid='ignore'):
+            has_large_values = (abs_vals > 1e6).any()
+            has_small_values = ((abs_vals < 10**(-self.digits)) &
+                                (abs_vals > 0)).any()
 
         if has_small_values or (too_long and has_large_values):
             float_format = '%% .%de' % self.digits

--- a/pandas/formats/format.py
+++ b/pandas/formats/format.py
@@ -2094,12 +2094,11 @@ class FloatArrayFormatter(GenericArrayFormatter):
         else:
             too_long = False
 
-        abs_vals = np.abs(self.values)
-
-        # this is pretty arbitrary for now
-        # large values: more that 8 characters including decimal symbol
-        # and first digit, hence > 1e6
         with np.errstate(invalid='ignore'):
+            abs_vals = np.abs(self.values)
+            # this is pretty arbitrary for now
+            # large values: more that 8 characters including decimal symbol
+            # and first digit, hence > 1e6
             has_large_values = (abs_vals > 1e6).any()
             has_small_values = ((abs_vals < 10**(-self.digits)) &
                                 (abs_vals > 0)).any()
@@ -2212,9 +2211,10 @@ def format_percentiles(percentiles):
     percentiles = np.asarray(percentiles)
 
     # It checks for np.NaN as well
-    if not is_numeric_dtype(percentiles) or not np.all(percentiles >= 0) \
-            or not np.all(percentiles <= 1):
-        raise ValueError("percentiles should all be in the interval [0,1]")
+    with np.errstate(invalid='ignore'):
+        if not is_numeric_dtype(percentiles) or not np.all(percentiles >= 0) \
+                or not np.all(percentiles <= 1):
+            raise ValueError("percentiles should all be in the interval [0,1]")
 
     percentiles = 100 * percentiles
     int_idx = (percentiles.astype(int) == percentiles)

--- a/pandas/indexes/base.py
+++ b/pandas/indexes/base.py
@@ -3303,9 +3303,11 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
 
                 if is_object_dtype(self) and self.nlevels == 1:
                     # don't pass MultiIndex
-                    result = _comp_method_OBJECT_ARRAY(op, self.values, other)
+                    with np.errstate(all='ignore'):
+                        result = _comp_method_OBJECT_ARRAY(op, self.values, other)
                 else:
-                    result = op(self.values, np.asarray(other))
+                    with np.errstate(all='ignore'):
+                        result = op(self.values, np.asarray(other))
 
                 # technically we could support bool dtyped Index
                 # for now just return the indexing array directly
@@ -3450,7 +3452,9 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
 
                 attrs = self._get_attributes_dict()
                 attrs = self._maybe_update_attributes(attrs)
-                return Index(op(values, other), **attrs)
+                with np.errstate(all='ignore'):
+                    result = op(values, other)
+                return Index(result, **attrs)
 
             return _evaluate_numeric_binop
 

--- a/pandas/indexes/base.py
+++ b/pandas/indexes/base.py
@@ -3304,7 +3304,8 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
                 if is_object_dtype(self) and self.nlevels == 1:
                     # don't pass MultiIndex
                     with np.errstate(all='ignore'):
-                        result = _comp_method_OBJECT_ARRAY(op, self.values, other)
+                        result = _comp_method_OBJECT_ARRAY(
+                            op, self.values, other)
                 else:
                     with np.errstate(all='ignore'):
                         result = op(self.values, np.asarray(other))

--- a/pandas/indexes/range.py
+++ b/pandas/indexes/range.py
@@ -576,7 +576,8 @@ class RangeIndex(Int64Index):
                 try:
                     # alppy if we have an override
                     if step:
-                        rstep = step(self._step, other)
+                        with np.errstate(all='ignore'):
+                            rstep = step(self._step, other)
 
                         # we don't have a representable op
                         # so return a base index
@@ -586,8 +587,9 @@ class RangeIndex(Int64Index):
                     else:
                         rstep = self._step
 
-                    rstart = op(self._start, other)
-                    rstop = op(self._stop, other)
+                    with np.errstate(all='ignore'):
+                        rstart = op(self._start, other)
+                        rstop = op(self._stop, other)
 
                     result = RangeIndex(rstart,
                                         rstop,
@@ -612,7 +614,9 @@ class RangeIndex(Int64Index):
                 if isinstance(other, RangeIndex):
                     other = other.values
 
-                return Index(op(self, other), **attrs)
+                with np.errstate(all='ignore'):
+                    results = op(self, other)
+                return Index(results, **attrs)
 
             return _evaluate_numeric_binop
 

--- a/pandas/sparse/array.py
+++ b/pandas/sparse/array.py
@@ -293,7 +293,8 @@ class SparseArray(PandasObject, np.ndarray):
             ufunc, args, domain = context
             # to apply ufunc only to fill_value (to avoid recursive call)
             args = [getattr(a, 'fill_value', a) for a in args]
-            fill_value = ufunc(self.fill_value, *args[1:])
+            with np.errstate(all='ignore'):
+                fill_value = ufunc(self.fill_value, *args[1:])
         else:
             fill_value = self.fill_value
 

--- a/pandas/sparse/array.py
+++ b/pandas/sparse/array.py
@@ -103,7 +103,7 @@ def _sparse_array_op(left, right, op, name, series=False):
     result_dtype = None
 
     if left.sp_index.ngaps == 0 or right.sp_index.ngaps == 0:
-        with np.seterr(all='ignore'):
+        with np.errstate(all='ignore'):
             result = op(left.get_values(), right.get_values())
             fill = op(_get_fill(left), _get_fill(right))
 
@@ -112,7 +112,7 @@ def _sparse_array_op(left, right, op, name, series=False):
         else:
             index = right.sp_index
     elif left.sp_index.equals(right.sp_index):
-        with np.seterr(all='ignore'):
+        with np.errstate(all='ignore'):
             result = op(left.sp_values, right.sp_values)
             fill = op(_get_fill(left), _get_fill(right))
         index = left.sp_index

--- a/pandas/sparse/array.py
+++ b/pandas/sparse/array.py
@@ -133,7 +133,7 @@ def _sparse_array_op(left, right, op, name, series=False):
             right_sp_values = right.sp_values
 
         sparse_op = getattr(splib, opname)
-        with np.seterr(all='ignore'):
+        with np.errstate(all='ignore'):
             result, index, fill = sparse_op(left_sp_values, left.sp_index,
                                             left.fill_value, right_sp_values,
                                             right.sp_index, right.fill_value)

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -311,7 +311,8 @@ class SparseSeries(Series):
         if isinstance(context, tuple) and len(context) == 3:
             ufunc, args, domain = context
             args = [getattr(a, 'fill_value', a) for a in args]
-            fill_value = ufunc(self.fill_value, *args[1:])
+            with np.errstate(all='ignore'):
+                fill_value = ufunc(self.fill_value, *args[1:])
         else:
             fill_value = self.fill_value
 

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -57,7 +57,8 @@ def _arith_method(op, name, str_rep=None, default_axis=None, fill_zeros=None,
         elif isinstance(other, DataFrame):
             return NotImplemented
         elif is_scalar(other):
-            new_values = op(self.values, other)
+            with np.errstate(all='ignore'):
+                new_values = op(self.values, other)
             return self._constructor(new_values,
                                      index=self.index,
                                      name=self.name)

--- a/pandas/sparse/tests/test_arithmetics.py
+++ b/pandas/sparse/tests/test_arithmetics.py
@@ -14,55 +14,59 @@ class TestSparseArrayArithmetics(tm.TestCase):
         tm.assert_numpy_array_equal(a, b)
 
     def _check_numeric_ops(self, a, b, a_dense, b_dense):
-        # sparse & sparse
-        self._assert((a + b).to_dense(), a_dense + b_dense)
-        self._assert((b + a).to_dense(), b_dense + a_dense)
+        with np.errstate(invalid='ignore', divide='ignore'):
+            # Unfortunately, trying to wrap the computation of each expected
+            # value is with np.errstate() is too tedious.
 
-        self._assert((a - b).to_dense(), a_dense - b_dense)
-        self._assert((b - a).to_dense(), b_dense - a_dense)
+            # sparse & sparse
+            self._assert((a + b).to_dense(), a_dense + b_dense)
+            self._assert((b + a).to_dense(), b_dense + a_dense)
 
-        self._assert((a * b).to_dense(), a_dense * b_dense)
-        self._assert((b * a).to_dense(), b_dense * a_dense)
+            self._assert((a - b).to_dense(), a_dense - b_dense)
+            self._assert((b - a).to_dense(), b_dense - a_dense)
 
-        # pandas uses future division
-        self._assert((a / b).to_dense(), a_dense * 1.0 / b_dense)
-        self._assert((b / a).to_dense(), b_dense * 1.0 / a_dense)
+            self._assert((a * b).to_dense(), a_dense * b_dense)
+            self._assert((b * a).to_dense(), b_dense * a_dense)
 
-        # ToDo: FIXME in GH 13843
-        if not (self._base == pd.Series and a.dtype == 'int64'):
-            self._assert((a // b).to_dense(), a_dense // b_dense)
-            self._assert((b // a).to_dense(), b_dense // a_dense)
+            # pandas uses future division
+            self._assert((a / b).to_dense(), a_dense * 1.0 / b_dense)
+            self._assert((b / a).to_dense(), b_dense * 1.0 / a_dense)
 
-        self._assert((a % b).to_dense(), a_dense % b_dense)
-        self._assert((b % a).to_dense(), b_dense % a_dense)
+            # ToDo: FIXME in GH 13843
+            if not (self._base == pd.Series and a.dtype == 'int64'):
+                self._assert((a // b).to_dense(), a_dense // b_dense)
+                self._assert((b // a).to_dense(), b_dense // a_dense)
 
-        self._assert((a ** b).to_dense(), a_dense ** b_dense)
-        self._assert((b ** a).to_dense(), b_dense ** a_dense)
+            self._assert((a % b).to_dense(), a_dense % b_dense)
+            self._assert((b % a).to_dense(), b_dense % a_dense)
 
-        # sparse & dense
-        self._assert((a + b_dense).to_dense(), a_dense + b_dense)
-        self._assert((b_dense + a).to_dense(), b_dense + a_dense)
+            self._assert((a ** b).to_dense(), a_dense ** b_dense)
+            self._assert((b ** a).to_dense(), b_dense ** a_dense)
 
-        self._assert((a - b_dense).to_dense(), a_dense - b_dense)
-        self._assert((b_dense - a).to_dense(), b_dense - a_dense)
+            # sparse & dense
+            self._assert((a + b_dense).to_dense(), a_dense + b_dense)
+            self._assert((b_dense + a).to_dense(), b_dense + a_dense)
 
-        self._assert((a * b_dense).to_dense(), a_dense * b_dense)
-        self._assert((b_dense * a).to_dense(), b_dense * a_dense)
+            self._assert((a - b_dense).to_dense(), a_dense - b_dense)
+            self._assert((b_dense - a).to_dense(), b_dense - a_dense)
 
-        # pandas uses future division
-        self._assert((a / b_dense).to_dense(), a_dense * 1.0 / b_dense)
-        self._assert((b_dense / a).to_dense(), b_dense * 1.0 / a_dense)
+            self._assert((a * b_dense).to_dense(), a_dense * b_dense)
+            self._assert((b_dense * a).to_dense(), b_dense * a_dense)
 
-        # ToDo: FIXME in GH 13843
-        if not (self._base == pd.Series and a.dtype == 'int64'):
-            self._assert((a // b_dense).to_dense(), a_dense // b_dense)
-            self._assert((b_dense // a).to_dense(), b_dense // a_dense)
+            # pandas uses future division
+            self._assert((a / b_dense).to_dense(), a_dense * 1.0 / b_dense)
+            self._assert((b_dense / a).to_dense(), b_dense * 1.0 / a_dense)
 
-        self._assert((a % b_dense).to_dense(), a_dense % b_dense)
-        self._assert((b_dense % a).to_dense(), b_dense % a_dense)
+            # ToDo: FIXME in GH 13843
+            if not (self._base == pd.Series and a.dtype == 'int64'):
+                self._assert((a // b_dense).to_dense(), a_dense // b_dense)
+                self._assert((b_dense // a).to_dense(), b_dense // a_dense)
 
-        self._assert((a ** b_dense).to_dense(), a_dense ** b_dense)
-        self._assert((b_dense ** a).to_dense(), b_dense ** a_dense)
+            self._assert((a % b_dense).to_dense(), a_dense % b_dense)
+            self._assert((b_dense % a).to_dense(), b_dense % a_dense)
+
+            self._assert((a ** b_dense).to_dense(), a_dense ** b_dense)
+            self._assert((b_dense ** a).to_dense(), b_dense ** a_dense)
 
     def _check_bool_result(self, res):
         tm.assertIsInstance(res, self._klass)
@@ -70,43 +74,47 @@ class TestSparseArrayArithmetics(tm.TestCase):
         self.assertIsInstance(res.fill_value, bool)
 
     def _check_comparison_ops(self, a, b, a_dense, b_dense):
-        # sparse & sparse
-        self._check_bool_result(a == b)
-        self._assert((a == b).to_dense(), a_dense == b_dense)
+        with np.errstate(invalid='ignore'):
+            # Unfortunately, trying to wrap the computation of each expected
+            # value is with np.errstate() is too tedious.
+            #
+            # sparse & sparse
+            self._check_bool_result(a == b)
+            self._assert((a == b).to_dense(), a_dense == b_dense)
 
-        self._check_bool_result(a != b)
-        self._assert((a != b).to_dense(), a_dense != b_dense)
+            self._check_bool_result(a != b)
+            self._assert((a != b).to_dense(), a_dense != b_dense)
 
-        self._check_bool_result(a >= b)
-        self._assert((a >= b).to_dense(), a_dense >= b_dense)
+            self._check_bool_result(a >= b)
+            self._assert((a >= b).to_dense(), a_dense >= b_dense)
 
-        self._check_bool_result(a <= b)
-        self._assert((a <= b).to_dense(), a_dense <= b_dense)
+            self._check_bool_result(a <= b)
+            self._assert((a <= b).to_dense(), a_dense <= b_dense)
 
-        self._check_bool_result(a > b)
-        self._assert((a > b).to_dense(), a_dense > b_dense)
+            self._check_bool_result(a > b)
+            self._assert((a > b).to_dense(), a_dense > b_dense)
 
-        self._check_bool_result(a < b)
-        self._assert((a < b).to_dense(), a_dense < b_dense)
+            self._check_bool_result(a < b)
+            self._assert((a < b).to_dense(), a_dense < b_dense)
 
-        # sparse & dense
-        self._check_bool_result(a == b_dense)
-        self._assert((a == b_dense).to_dense(), a_dense == b_dense)
+            # sparse & dense
+            self._check_bool_result(a == b_dense)
+            self._assert((a == b_dense).to_dense(), a_dense == b_dense)
 
-        self._check_bool_result(a != b_dense)
-        self._assert((a != b_dense).to_dense(), a_dense != b_dense)
+            self._check_bool_result(a != b_dense)
+            self._assert((a != b_dense).to_dense(), a_dense != b_dense)
 
-        self._check_bool_result(a >= b_dense)
-        self._assert((a >= b_dense).to_dense(), a_dense >= b_dense)
+            self._check_bool_result(a >= b_dense)
+            self._assert((a >= b_dense).to_dense(), a_dense >= b_dense)
 
-        self._check_bool_result(a <= b_dense)
-        self._assert((a <= b_dense).to_dense(), a_dense <= b_dense)
+            self._check_bool_result(a <= b_dense)
+            self._assert((a <= b_dense).to_dense(), a_dense <= b_dense)
 
-        self._check_bool_result(a > b_dense)
-        self._assert((a > b_dense).to_dense(), a_dense > b_dense)
+            self._check_bool_result(a > b_dense)
+            self._assert((a > b_dense).to_dense(), a_dense > b_dense)
 
-        self._check_bool_result(a < b_dense)
-        self._assert((a < b_dense).to_dense(), a_dense < b_dense)
+            self._check_bool_result(a < b_dense)
+            self._assert((a < b_dense).to_dense(), a_dense < b_dense)
 
     def _check_logical_ops(self, a, b, a_dense, b_dense):
         # sparse & sparse

--- a/pandas/sparse/tests/test_array.py
+++ b/pandas/sparse/tests/test_array.py
@@ -516,15 +516,17 @@ class TestSparseArray(tm.TestCase):
             tmp = arr1.copy()
             self.assertRaises(NotImplementedError, op, tmp, arr2)
 
-        bin_ops = [operator.add, operator.sub, operator.mul, operator.truediv,
-                   operator.floordiv, operator.pow]
-        for op in bin_ops:
-            _check_op(op, arr1, arr2)
-            _check_op(op, farr1, farr2)
+        with np.errstate(all='ignore'):
+            bin_ops = [operator.add, operator.sub, operator.mul,
+                       operator.truediv, operator.floordiv, operator.pow]
+            for op in bin_ops:
+                _check_op(op, arr1, arr2)
+                _check_op(op, farr1, farr2)
 
-        inplace_ops = ['iadd', 'isub', 'imul', 'itruediv', 'ifloordiv', 'ipow']
-        for op in inplace_ops:
-            _check_inplace_op(getattr(operator, op))
+            inplace_ops = ['iadd', 'isub', 'imul', 'itruediv', 'ifloordiv',
+                           'ipow']
+            for op in inplace_ops:
+                _check_inplace_op(getattr(operator, op))
 
     def test_pickle(self):
         def _check_roundtrip(obj):

--- a/pandas/tests/formats/test_format.py
+++ b/pandas/tests/formats/test_format.py
@@ -1668,7 +1668,7 @@ class TestDataFrameFormatting(tm.TestCase):
 
     def test_repr_corner(self):
         # representing infs poses no problems
-        df = DataFrame({'foo': np.inf * np.empty(10)})
+        df = DataFrame({'foo': [-np.inf, np.inf]})
         repr(df)
 
     def test_frame_info_encoding(self):

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -22,18 +22,19 @@ class TestDataFrameApply(tm.TestCase, TestData):
     _multiprocess_can_split_ = True
 
     def test_apply(self):
-        # ufunc
-        applied = self.frame.apply(np.sqrt)
-        assert_series_equal(np.sqrt(self.frame['A']), applied['A'])
+        with np.errstate(all='ignore'):
+            # ufunc
+            applied = self.frame.apply(np.sqrt)
+            assert_series_equal(np.sqrt(self.frame['A']), applied['A'])
 
-        # aggregator
-        applied = self.frame.apply(np.mean)
-        self.assertEqual(applied['A'], np.mean(self.frame['A']))
+            # aggregator
+            applied = self.frame.apply(np.mean)
+            self.assertEqual(applied['A'], np.mean(self.frame['A']))
 
-        d = self.frame.index[0]
-        applied = self.frame.apply(np.mean, axis=1)
-        self.assertEqual(applied[d], np.mean(self.frame.xs(d)))
-        self.assertIs(applied.index, self.frame.index)  # want this
+            d = self.frame.index[0]
+            applied = self.frame.apply(np.mean, axis=1)
+            self.assertEqual(applied[d], np.mean(self.frame.xs(d)))
+            self.assertIs(applied.index, self.frame.index)  # want this
 
         # invalid axis
         df = DataFrame(
@@ -187,10 +188,11 @@ class TestDataFrameApply(tm.TestCase, TestData):
             _checkit(raw=True)
             _checkit(axis=0, raw=True)
 
-        _check(no_cols, lambda x: x)
-        _check(no_cols, lambda x: x.mean())
-        _check(no_index, lambda x: x)
-        _check(no_index, lambda x: x.mean())
+        with np.errstate(all='ignore'):
+            _check(no_cols, lambda x: x)
+            _check(no_cols, lambda x: x.mean())
+            _check(no_index, lambda x: x)
+            _check(no_index, lambda x: x.mean())
 
         result = no_cols.apply(lambda x: x.mean(), broadcast=True)
         tm.assertIsInstance(result, DataFrame)

--- a/pandas/tests/frame/test_misc_api.py
+++ b/pandas/tests/frame/test_misc_api.py
@@ -207,7 +207,8 @@ class TestDataFrameMisc(tm.TestCase, SharedWithSparse, TestData):
         self.assertIsNone(df2.index.name)
 
     def test_array_interface(self):
-        result = np.sqrt(self.frame)
+        with np.errstate(all='ignore'):
+            result = np.sqrt(self.frame)
         tm.assertIsInstance(result, type(self.frame))
         self.assertIs(result.index, self.frame.index)
         self.assertIs(result.columns, self.frame.columns)

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -217,7 +217,9 @@ class TestDataFrameOperators(tm.TestCase, TestData):
         assert_frame_equal(result, expected)
 
         # numpy has a slightly different (wrong) treatement
-        result2 = DataFrame(p.values % p.values, index=p.index,
+        with np.errstate(all='ignore'):
+            arr = p.values % p.values
+        result2 = DataFrame(arr, index=p.index,
                             columns=p.columns, dtype='float64')
         result2.iloc[0:3, 1] = np.nan
         assert_frame_equal(result2, expected)
@@ -227,8 +229,9 @@ class TestDataFrameOperators(tm.TestCase, TestData):
         assert_frame_equal(result, expected)
 
         # numpy has a slightly different (wrong) treatement
-        result2 = DataFrame(p.values.astype('float64') %
-                            0, index=p.index, columns=p.columns)
+        with np.errstate(all='ignore'):
+            arr = p.values.astype('float64') % 0
+        result2 = DataFrame(arr, index=p.index, columns=p.columns)
         assert_frame_equal(result2, expected)
 
         # not commutative with series
@@ -248,7 +251,9 @@ class TestDataFrameOperators(tm.TestCase, TestData):
                               'second': Series([nan, nan, nan, 1])})
         assert_frame_equal(result, expected)
 
-        result2 = DataFrame(p.values.astype('float') / p.values, index=p.index,
+        with np.errstate(all='ignore'):
+            arr = p.values.astype('float') / p.values
+        result2 = DataFrame(arr, index=p.index,
                             columns=p.columns)
         assert_frame_equal(result2, expected)
 
@@ -258,7 +263,9 @@ class TestDataFrameOperators(tm.TestCase, TestData):
         assert_frame_equal(result, expected)
 
         # numpy has a slightly different (wrong) treatement
-        result2 = DataFrame(p.values.astype('float64') / 0, index=p.index,
+        with np.errstate(all='ignore'):
+            arr = p.values.astype('float64') / 0
+        result2 = DataFrame(arr, index=p.index,
                             columns=p.columns)
         assert_frame_equal(result2, expected)
 

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -929,6 +929,15 @@ class TestDataFrameOperators(tm.TestCase, TestData):
         test_comp(operator.ge)
         test_comp(operator.le)
 
+    def test_comparison_protected_from_errstate(self):
+        missing_df = tm.makeDataFrame()
+        missing_df.iloc[0]['A'] = np.nan
+        with np.errstate(invalid='ignore'):
+            expected = missing_df.values < 0
+        with np.errstate(invalid='raise'):
+            result = (missing_df < 0).values
+        self.assert_numpy_array_equal(result, expected)
+
     def test_string_comparison(self):
         df = DataFrame([{"a": 1, "b": "foo"}, {"a": 2, "b": "bar"}])
         mask_a = df.a > 1

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -712,8 +712,9 @@ class Base(object):
                         func(idx)
                 elif isinstance(idx, (Float64Index, Int64Index)):
                     # coerces to float (e.g. np.sin)
-                    result = func(idx)
-                    exp = Index(func(idx.values), name=idx.name)
+                    with np.errstate(all='ignore'):
+                        result = func(idx)
+                        exp = Index(func(idx.values), name=idx.name)
                     self.assert_index_equal(result, exp)
                     self.assertIsInstance(result, pd.Float64Index)
                 else:

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -709,7 +709,8 @@ class Base(object):
                     # raise TypeError or ValueError (PeriodIndex)
                     # PeriodIndex behavior should be changed in future version
                     with tm.assertRaises(Exception):
-                        func(idx)
+                        with np.errstate(all='ignore'):
+                            func(idx)
                 elif isinstance(idx, (Float64Index, Int64Index)):
                     # coerces to float (e.g. np.sin)
                     with np.errstate(all='ignore'):
@@ -723,7 +724,8 @@ class Base(object):
                         continue
                     else:
                         with tm.assertRaises(Exception):
-                            func(idx)
+                            with np.errstate(all='ignore'):
+                                func(idx)
 
             for func in [np.isfinite, np.isinf, np.isnan, np.signbit]:
                 if isinstance(idx, pd.tseries.base.DatetimeIndexOpsMixin):

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -622,39 +622,40 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         self.assertRaises(NotImplementedError, s.all, bool_only=True)
 
     def test_modulo(self):
+        with np.errstate(all='ignore'):
 
-        # GH3590, modulo as ints
-        p = DataFrame({'first': [3, 4, 5, 8], 'second': [0, 0, 0, 3]})
-        result = p['first'] % p['second']
-        expected = Series(p['first'].values % p['second'].values,
-                          dtype='float64')
-        expected.iloc[0:3] = np.nan
-        assert_series_equal(result, expected)
+            # GH3590, modulo as ints
+            p = DataFrame({'first': [3, 4, 5, 8], 'second': [0, 0, 0, 3]})
+            result = p['first'] % p['second']
+            expected = Series(p['first'].values % p['second'].values,
+                              dtype='float64')
+            expected.iloc[0:3] = np.nan
+            assert_series_equal(result, expected)
 
-        result = p['first'] % 0
-        expected = Series(np.nan, index=p.index, name='first')
-        assert_series_equal(result, expected)
+            result = p['first'] % 0
+            expected = Series(np.nan, index=p.index, name='first')
+            assert_series_equal(result, expected)
 
-        p = p.astype('float64')
-        result = p['first'] % p['second']
-        expected = Series(p['first'].values % p['second'].values)
-        assert_series_equal(result, expected)
+            p = p.astype('float64')
+            result = p['first'] % p['second']
+            expected = Series(p['first'].values % p['second'].values)
+            assert_series_equal(result, expected)
 
-        p = p.astype('float64')
-        result = p['first'] % p['second']
-        result2 = p['second'] % p['first']
-        self.assertFalse(np.array_equal(result, result2))
+            p = p.astype('float64')
+            result = p['first'] % p['second']
+            result2 = p['second'] % p['first']
+            self.assertFalse(np.array_equal(result, result2))
 
-        # GH 9144
-        s = Series([0, 1])
+            # GH 9144
+            s = Series([0, 1])
 
-        result = s % 0
-        expected = Series([nan, nan])
-        assert_series_equal(result, expected)
+            result = s % 0
+            expected = Series([nan, nan])
+            assert_series_equal(result, expected)
 
-        result = 0 % s
-        expected = Series([nan, 0.0])
-        assert_series_equal(result, expected)
+            result = 0 % s
+            expected = Series([nan, 0.0])
+            assert_series_equal(result, expected)
 
     def test_ops_consistency_on_empty(self):
 

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -18,17 +18,18 @@ class TestSeriesApply(TestData, tm.TestCase):
     _multiprocess_can_split_ = True
 
     def test_apply(self):
-        assert_series_equal(self.ts.apply(np.sqrt), np.sqrt(self.ts))
+        with np.errstate(all='ignore'):
+            assert_series_equal(self.ts.apply(np.sqrt), np.sqrt(self.ts))
 
-        # elementwise-apply
-        import math
-        assert_series_equal(self.ts.apply(math.exp), np.exp(self.ts))
+            # elementwise-apply
+            import math
+            assert_series_equal(self.ts.apply(math.exp), np.exp(self.ts))
 
-        # how to handle Series result, #2316
-        result = self.ts.apply(lambda x: Series(
-            [x, x ** 2], index=['x', 'x^2']))
-        expected = DataFrame({'x': self.ts, 'x^2': self.ts ** 2})
-        tm.assert_frame_equal(result, expected)
+            # how to handle Series result, #2316
+            result = self.ts.apply(lambda x: Series(
+                [x, x ** 2], index=['x', 'x^2']))
+            expected = DataFrame({'x': self.ts, 'x^2': self.ts ** 2})
+            tm.assert_frame_equal(result, expected)
 
         # empty series
         s = Series(dtype=object, name='foo', index=pd.Index([], name='bar'))

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -34,7 +34,8 @@ class TestSeriesOperators(TestData, tm.TestCase):
         left[:3] = np.nan
 
         result = nanops.nangt(left, right)
-        expected = (left > right).astype('O')
+        with np.errstate(invalid='ignore'):
+            expected = (left > right).astype('O')
         expected[:3] = np.nan
 
         assert_almost_equal(result, expected)
@@ -81,62 +82,63 @@ class TestSeriesOperators(TestData, tm.TestCase):
         assert_series_equal(-(self.series < 0), ~(self.series < 0))
 
     def test_div(self):
+        with np.errstate(all='ignore'):
+            # no longer do integer div for any ops, but deal with the 0's
+            p = DataFrame({'first': [3, 4, 5, 8], 'second': [0, 0, 0, 3]})
+            result = p['first'] / p['second']
+            expected = Series(
+                p['first'].values.astype(float) / p['second'].values,
+                dtype='float64')
+            expected.iloc[0:3] = np.inf
+            assert_series_equal(result, expected)
 
-        # no longer do integer div for any ops, but deal with the 0's
-        p = DataFrame({'first': [3, 4, 5, 8], 'second': [0, 0, 0, 3]})
-        result = p['first'] / p['second']
-        expected = Series(p['first'].values.astype(float) / p['second'].values,
-                          dtype='float64')
-        expected.iloc[0:3] = np.inf
-        assert_series_equal(result, expected)
+            result = p['first'] / 0
+            expected = Series(np.inf, index=p.index, name='first')
+            assert_series_equal(result, expected)
 
-        result = p['first'] / 0
-        expected = Series(np.inf, index=p.index, name='first')
-        assert_series_equal(result, expected)
+            p = p.astype('float64')
+            result = p['first'] / p['second']
+            expected = Series(p['first'].values / p['second'].values)
+            assert_series_equal(result, expected)
 
-        p = p.astype('float64')
-        result = p['first'] / p['second']
-        expected = Series(p['first'].values / p['second'].values)
-        assert_series_equal(result, expected)
+            p = DataFrame({'first': [3, 4, 5, 8], 'second': [1, 1, 1, 1]})
+            result = p['first'] / p['second']
+            assert_series_equal(result, p['first'].astype('float64'),
+                                check_names=False)
+            self.assertTrue(result.name is None)
+            self.assertFalse(np.array_equal(result, p['second'] / p['first']))
 
-        p = DataFrame({'first': [3, 4, 5, 8], 'second': [1, 1, 1, 1]})
-        result = p['first'] / p['second']
-        assert_series_equal(result, p['first'].astype('float64'),
-                            check_names=False)
-        self.assertTrue(result.name is None)
-        self.assertFalse(np.array_equal(result, p['second'] / p['first']))
+            # inf signing
+            s = Series([np.nan, 1., -1.])
+            result = s / 0
+            expected = Series([np.nan, np.inf, -np.inf])
+            assert_series_equal(result, expected)
 
-        # inf signing
-        s = Series([np.nan, 1., -1.])
-        result = s / 0
-        expected = Series([np.nan, np.inf, -np.inf])
-        assert_series_equal(result, expected)
+            # float/integer issue
+            # GH 7785
+            p = DataFrame({'first': (1, 0), 'second': (-0.01, -0.02)})
+            expected = Series([-0.01, -np.inf])
 
-        # float/integer issue
-        # GH 7785
-        p = DataFrame({'first': (1, 0), 'second': (-0.01, -0.02)})
-        expected = Series([-0.01, -np.inf])
+            result = p['second'].div(p['first'])
+            assert_series_equal(result, expected, check_names=False)
 
-        result = p['second'].div(p['first'])
-        assert_series_equal(result, expected, check_names=False)
+            result = p['second'] / p['first']
+            assert_series_equal(result, expected)
 
-        result = p['second'] / p['first']
-        assert_series_equal(result, expected)
+            # GH 9144
+            s = Series([-1, 0, 1])
 
-        # GH 9144
-        s = Series([-1, 0, 1])
+            result = 0 / s
+            expected = Series([0.0, nan, 0.0])
+            assert_series_equal(result, expected)
 
-        result = 0 / s
-        expected = Series([0.0, nan, 0.0])
-        assert_series_equal(result, expected)
+            result = s / 0
+            expected = Series([-inf, nan, inf])
+            assert_series_equal(result, expected)
 
-        result = s / 0
-        expected = Series([-inf, nan, inf])
-        assert_series_equal(result, expected)
-
-        result = s // 0
-        expected = Series([-inf, nan, inf])
-        assert_series_equal(result, expected)
+            result = s // 0
+            expected = Series([-inf, nan, inf])
+            assert_series_equal(result, expected)
 
     def test_operators(self):
         def _check_op(series, other, op, pos_only=False,
@@ -1432,18 +1434,19 @@ class TestSeriesOperators(TestData, tm.TestCase):
 
             exp_values = []
             for i in range(len(exp_index)):
-                if amask[i]:
-                    if bmask[i]:
-                        exp_values.append(nan)
-                        continue
-                    exp_values.append(op(fill_value, b[i]))
-                elif bmask[i]:
+                with np.errstate(all='ignore'):
                     if amask[i]:
-                        exp_values.append(nan)
-                        continue
-                    exp_values.append(op(a[i], fill_value))
-                else:
-                    exp_values.append(op(a[i], b[i]))
+                        if bmask[i]:
+                            exp_values.append(nan)
+                            continue
+                        exp_values.append(op(fill_value, b[i]))
+                    elif bmask[i]:
+                        if amask[i]:
+                            exp_values.append(nan)
+                            continue
+                        exp_values.append(op(a[i], fill_value))
+                    else:
+                        exp_values.append(op(a[i], b[i]))
 
             result = meth(a, b, fill_value=fill_value)
             expected = Series(exp_values, exp_index)

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -2595,9 +2595,11 @@ class TestGroupBy(tm.TestCase):
 
     def test_apply_series_to_frame(self):
         def f(piece):
+            with np.errstate(invalid='ignore'):
+                logged = np.log(piece)
             return DataFrame({'value': piece,
                               'demeaned': piece - piece.mean(),
-                              'logged': np.log(piece)})
+                              'logged': logged})
 
         dr = bdate_range('1/1/2000', periods=100)
         ts = Series(np.random.randn(100), index=dr)

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -58,12 +58,14 @@ class TestnanopsDataFrame(tm.TestCase):
                     'O'), self.arr_utf.astype('O'), self.arr_date.astype('O'),
             self.arr_tdelta.astype('O')])
 
-        self.arr_nan_nanj = self.arr_nan + self.arr_nan * 1j
-        self.arr_complex_nan = np.vstack([self.arr_complex, self.arr_nan_nanj])
+        with np.errstate(invalid='ignore'):
+            self.arr_nan_nanj = self.arr_nan + self.arr_nan * 1j
+            self.arr_complex_nan = np.vstack([self.arr_complex,
+                                              self.arr_nan_nanj])
 
-        self.arr_nan_infj = self.arr_inf * 1j
-        self.arr_complex_nan_infj = np.vstack([self.arr_complex,
-                                               self.arr_nan_infj])
+            self.arr_nan_infj = self.arr_inf * 1j
+            self.arr_complex_nan_infj = np.vstack([self.arr_complex,
+                                                   self.arr_nan_infj])
 
         self.arr_float_2d = self.arr_float[:, :, 0]
         self.arr_float1_2d = self.arr_float1[:, :, 0]

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -824,12 +824,13 @@ class CheckIndexing(object):
             self.assert_numpy_array_equal(result3.values,
                                           func(self.panel.values, 0))
 
-        test_comp(operator.eq)
-        test_comp(operator.ne)
-        test_comp(operator.lt)
-        test_comp(operator.gt)
-        test_comp(operator.ge)
-        test_comp(operator.le)
+        with np.errstate(invalid='ignore'):
+            test_comp(operator.eq)
+            test_comp(operator.ne)
+            test_comp(operator.lt)
+            test_comp(operator.gt)
+            test_comp(operator.ge)
+            test_comp(operator.le)
 
     def test_get_value(self):
         for item in self.panel.items:
@@ -1186,8 +1187,9 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
 
         # ufunc
         applied = self.panel.apply(np.sqrt)
-        self.assertTrue(assert_almost_equal(applied.values, np.sqrt(
-            self.panel.values)))
+        with np.errstate(invalid='ignore'):
+            expected = np.sqrt(self.panel.values)
+        assert_almost_equal(applied.values, expected)
 
         # ufunc same shape
         result = self.panel.apply(lambda x: x * 2, axis='items')

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -461,12 +461,13 @@ class CheckIndexing(object):
                 self.assert_numpy_array_equal(result3.values,
                                               func(self.panel4d.values, 0))
 
-            test_comp(operator.eq)
-            test_comp(operator.ne)
-            test_comp(operator.lt)
-            test_comp(operator.gt)
-            test_comp(operator.ge)
-            test_comp(operator.le)
+            with np.errstate(invalid='ignore'):
+                test_comp(operator.eq)
+                test_comp(operator.ne)
+                test_comp(operator.lt)
+                test_comp(operator.gt)
+                test_comp(operator.ge)
+                test_comp(operator.le)
 
     def test_major_xs(self):
         ref = self.panel4d['l1']['ItemA']

--- a/pandas/tests/test_util.py
+++ b/pandas/tests/test_util.py
@@ -326,6 +326,16 @@ class TestMove(tm.TestCase):
         self.assertEqual(bytearray(as_stolen_buf), b'test')
 
 
+def test_numpy_errstate_is_default():
+    # The defaults since numpy 1.6.0
+    expected = {'over': 'warn', 'divide': 'warn', 'invalid': 'warn',
+                'under': 'ignore'}
+    import numpy as np
+    from pandas.compat import numpy  # noqa
+    # The errstate should be unchanged after that import.
+    tm.assert_equal(np.geterr(), expected)
+
+
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
                    exit=False)

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -347,7 +347,6 @@ Freq: D"""
         for idx, expected in zip([idx1, idx2, idx3, idx4, idx5, idx6],
                                  [exp1, exp2, exp3, exp4, exp5, exp6]):
             result = idx.summary()
-            print((expected, result))
             self.assertEqual(result, expected)
 
     def test_resolution(self):

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -347,6 +347,7 @@ Freq: D"""
         for idx, expected in zip([idx1, idx2, idx3, idx4, idx5, idx6],
                                  [exp1, exp2, exp3, exp4, exp5, exp6]):
             result = idx.summary()
+            print((expected, result))
             self.assertEqual(result, expected)
 
     def test_resolution(self):


### PR DESCRIPTION
- [x] closes #13109 
- [x] closes #13135
- [x] tests passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

The precise strategy to be taken here is open for discussion. I tried to be reasonably fine-grained rather than slap a generic decorator over everything because it's easier to go that direction than the reverse. The `errstate()` blocks in the tests were added _after_ fixing all of the library code. Unfortunately, these are less fine-grained than I would like because some of the tests have many lines of the form `assert_array_equal(pandas_expression_to_test, expected_raw_numpy_expression)` where `expected_raw_numpy_expression` is what is triggering the warning. It was tedious to try to rewrite all of that to wrap just `expected_raw_numpy_expression`.

I think I got everything exercised by the test suite except for parts of the test suite that are skipped on my machine due to dependencies. We'll see how things go in the CI.

I haven't added any new tests yet. Could do if requested.
