### PR TITLE
ENH/BUG: str.extractall doesn't support index

### DIFF
--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -281,7 +281,7 @@ Unlike ``extract`` (which returns only the first match),
 
 .. ipython:: python
 
-   s = pd.Series(["a1a2", "b1", "c1"], ["A", "B", "C"])
+   s = pd.Series(["a1a2", "b1", "c1"], index=["A", "B", "C"])
    s
    two_groups = '(?P<letter>[a-z])(?P<digit>[0-9])'
    s.str.extract(two_groups, expand=True)
@@ -312,6 +312,17 @@ then ``extractall(pat).xs(0, level='match')`` gives the same result as
    extractall_result = s.str.extractall(two_groups)
    extractall_result
    extractall_result.xs(0, level="match")
+
+``Index`` also supports ``.str.extractall``. It returns a ``DataFrame`` which has the
+same result as a ``Series.str.extractall`` with a default index (starts from 0).
+
+.. versionadded:: 0.18.2
+
+.. ipython:: python
+
+   pd.Index(["a1a2", "b1", "c1"]).str.extractall(two_groups)
+
+   pd.Series(["a1a2", "b1", "c1"]).str.extractall(two_groups)
 
 
 Testing for Strings that Match or Contain a Pattern

--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -31,7 +31,12 @@ Other enhancements
 
 - The ``.tz_localize()`` method of ``DatetimeIndex`` and ``Timestamp`` has gained the ``errors`` keyword, so you can potentially coerce nonexistent timestamps to ``NaT``. The default behaviour remains to raising a ``NonExistentTimeError`` (:issue:`13057`)
 
+- ``Index`` now supports ``.str.extractall()`` which returns ``DataFrame``, see :ref:`Extract all matches in each subject (extractall) <text.extractall>` (:issue:`10008`, :issue:`13156`)
 
+  .. ipython:: python
+
+     idx = pd.Index(["a1a2", "b1", "c1"])
+     idx.str.extractall("[ab](?P<digit>\d)")
 
 
 .. _whatsnew_0182.api:
@@ -117,6 +122,7 @@ Bug Fixes
 
 
 
+- Bug in ``Series.str.extractall()`` with ``str`` index raises ``ValueError``  (:issue:`13156`)
 
 
 - Bug in ``PeriodIndex`` and ``Period`` subtraction raises ``AttributeError`` (:issue:`13071`)


### PR DESCRIPTION
- [x] closes #10008
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

```
# same output as pd.Series(["a1a2", "b1", "c1"]).str.extractall("[ab](?P<digit>\d)")
idx = pd.Index(["a1a2", "b1", "c1"])
idx.str.extractall("[ab](?P<digit>\d)")
#         digit
#   match      
#0 0         1
#   1         2
#1 0         1
```

**NOTE** Also fixed a bug `Series.str.extractall` raises `ValueError` if its `Index` is `str` with 2 or more characters.

```
s = pd.Series(["a1a2", "b1", "c1"], index=pd.Index(["xx", "yy", "zz"]))
s.str.extractall("[ab](?P<digit>\d)")
# ValueError: Length of names must match number of levels in MultiIndex.
```
