### PR TITLE
BUG: Misc fixes for SparseSeries indexing with MI

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -107,6 +107,9 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
+
+- Bug in ``SparseSeries`` with ``MultiIndex`` ``[]`` indexing may raise ``IndexError`` (:issue:`13144`)
+- Bug in ``SparseSeries`` with ``MultiIndex`` ``[]`` indexing result may have normal ``Index`` (:issue:`13144`)
 - Bug in ``SparseDataFrame`` in which ``axis=None`` did not default to ``axis=0`` (:issue:`13048`)
 
 

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -592,7 +592,6 @@ class MultiIndex(Index):
     def get_value(self, series, key):
         # somewhat broken encapsulation
         from pandas.core.indexing import maybe_droplevels
-        from pandas.core.series import Series
 
         # Label-based
         s = _values_from_object(series)
@@ -604,7 +603,8 @@ class MultiIndex(Index):
             new_values = series._values[loc]
             new_index = self[loc]
             new_index = maybe_droplevels(new_index, k)
-            return Series(new_values, index=new_index, name=series.name)
+            return series._constructor(new_values, index=new_index,
+                                       name=series.name).__finalize__(self)
 
         try:
             return self._engine.get_value(s, k)

--- a/pandas/sparse/tests/test_format.py
+++ b/pandas/sparse/tests/test_format.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+
+import numpy as np
+import pandas as pd
+
+import pandas.util.testing as tm
+from pandas.compat import (is_platform_windows,
+                           is_platform_32bit)
+from pandas.core.config import option_context
+
+
+use_32bit_repr = is_platform_windows() or is_platform_32bit()
+
+
+class TestSeriesFormatting(tm.TestCase):
+
+    _multiprocess_can_split_ = True
+
+    def test_sparse_max_row(self):
+        s = pd.Series([1, np.nan, np.nan, 3, np.nan]).to_sparse()
+        result = repr(s)
+        dtype = '' if use_32bit_repr else ', dtype=int32'
+        exp = ("0    1.0\n1    NaN\n2    NaN\n3    3.0\n"
+               "4    NaN\ndtype: float64\nBlockIndex\n"
+               "Block locations: array([0, 3]{0})\n"
+               "Block lengths: array([1, 1]{0})".format(dtype))
+        self.assertEqual(result, exp)
+
+        with option_context("display.max_rows", 3):
+            # GH 10560
+            result = repr(s)
+            exp = ("0    1.0\n    ... \n4    NaN\n"
+                   "dtype: float64\nBlockIndex\n"
+                   "Block locations: array([0, 3]{0})\n"
+                   "Block lengths: array([1, 1]{0})".format(dtype))
+            self.assertEqual(result, exp)
+
+    def test_sparse_mi_max_row(self):
+        idx = pd.MultiIndex.from_tuples([('A', 0), ('A', 1), ('B', 0),
+                                         ('C', 0), ('C', 1), ('C', 2)])
+        s = pd.Series([1, np.nan, np.nan, 3, np.nan, np.nan],
+                      index=idx).to_sparse()
+        result = repr(s)
+        dtype = '' if use_32bit_repr else ', dtype=int32'
+        exp = ("A  0    1.0\n   1    NaN\nB  0    NaN\n"
+               "C  0    3.0\n   1    NaN\n   2    NaN\n"
+               "dtype: float64\nBlockIndex\n"
+               "Block locations: array([0, 3], dtype=int32)\n"
+               "Block lengths: array([1, 1]{0})".format(dtype))
+        self.assertEqual(result, exp)
+
+        with option_context("display.max_rows", 3):
+            # GH 13144
+            result = repr(s)
+            exp = ("A  0    1.0\n       ... \nC  2    NaN\n"
+                   "dtype: float64\nBlockIndex\n"
+                   "Block locations: array([0, 3], dtype=int32)\n"
+                   "Block lengths: array([1, 1]{0})".format(dtype))
+            self.assertEqual(result, exp)

--- a/pandas/sparse/tests/test_series.py
+++ b/pandas/sparse/tests/test_series.py
@@ -1019,6 +1019,15 @@ class TestSparseSeriesScipyInteraction(tm.TestCase):
         check = check.dropna().to_sparse()
         tm.assert_sp_series_equal(ss, check)
 
+    def test_from_coo_long_repr(self):
+        # GH 13114
+        # test it doesn't raise error. Formatting is tested in test_format
+        tm._skip_if_no_scipy()
+        import scipy.sparse
+
+        sparse = SparseSeries.from_coo(scipy.sparse.rand(350, 18))
+        repr(sparse)
+
     def _run_test(self, ss, kwargs, check):
         results = ss.to_coo(**kwargs)
         self._check_results_to_coo(results, check)

--- a/pandas/tests/formats/test_format.py
+++ b/pandas/tests/formats/test_format.py
@@ -3758,25 +3758,6 @@ class TestSeriesFormatting(tm.TestCase):
         exp = '0    0\n    ..\n9    9'
         self.assertEqual(res, exp)
 
-    def test_sparse_max_row(self):
-        s = pd.Series([1, np.nan, np.nan, 3, np.nan]).to_sparse()
-        result = repr(s)
-        dtype = '' if use_32bit_repr else ', dtype=int32'
-        exp = ("0    1.0\n1    NaN\n2    NaN\n3    3.0\n"
-               "4    NaN\ndtype: float64\nBlockIndex\n"
-               "Block locations: array([0, 3]{0})\n"
-               "Block lengths: array([1, 1]{0})".format(dtype))
-        self.assertEqual(result, exp)
-
-        with option_context("display.max_rows", 3):
-            # GH 10560
-            result = repr(s)
-            exp = ("0    1.0\n    ... \n4    NaN\n"
-                   "dtype: float64\nBlockIndex\n"
-                   "Block locations: array([0, 3]{0})\n"
-                   "Block lengths: array([1, 1]{0})".format(dtype))
-            self.assertEqual(result, exp)
-
 
 class TestEngFormatter(tm.TestCase):
     _multiprocess_can_split_ = True


### PR DESCRIPTION
- [x] closes #13144
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Fixed following bugs. These makes `MultiIndex` repr work.

```
orig = pd.Series([1, np.nan, np.nan, 3, np.nan], index=idx)
sparse = orig.to_sparse()
sparse['A']    
# IndexError: Out of bounds access
```

```
# the result must have MultiIndex
sparse.loc['A':]
# (A, 0)    1.0
# (A, 1)    NaN
# (B, 0)    NaN
# (C, 0)    3.0
# (C, 1)    NaN
# dtype: float64
# BlockIndex
# Block locations: array([0, 3], dtype=int32)
# Block lengths: array([1, 1], dtype=int32)
```
