### PR TITLE
TST: Test resampling with NaT

### DIFF
--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -1846,6 +1846,32 @@ class TestDatetimeIndex(Base, tm.TestCase):
                                        freq='D', tz='Europe/Paris')),
             'D Frequency')
 
+    def test_resample_with_nat(self):
+        # GH 13020
+        index = DatetimeIndex([pd.NaT,
+                               '1970-01-01 00:00:00',
+                               pd.NaT,
+                               '1970-01-01 00:00:01',
+                               '1970-01-01 00:00:02'])
+        frame = DataFrame([2, 3, 5, 7, 11], index=index)
+
+        index_1s = DatetimeIndex(['1970-01-01 00:00:00',
+                                  '1970-01-01 00:00:01',
+                                  '1970-01-01 00:00:02'])
+        frame_1s = DataFrame([3, 7, 11], index=index_1s)
+        assert_frame_equal(frame.resample('1s').mean(), frame_1s)
+
+        index_2s = DatetimeIndex(['1970-01-01 00:00:00',
+                                  '1970-01-01 00:00:02'])
+        frame_2s = DataFrame([5, 11], index=index_2s)
+        assert_frame_equal(frame.resample('2s').mean(), frame_2s)
+
+        index_3s = DatetimeIndex(['1970-01-01 00:00:00'])
+        frame_3s = DataFrame([7], index=index_3s)
+        assert_frame_equal(frame.resample('3s').mean(), frame_3s)
+
+        assert_frame_equal(frame.resample('60s').mean(), frame_3s)
+
 
 class TestPeriodIndex(Base, tm.TestCase):
     _multiprocess_can_split_ = True


### PR DESCRIPTION
- Closes #13020
- Adds `test_generic.py:TestDataFrame.test_resample_with_nat`
- Passes tests and flake8
- No documentation needed
