### PR TITLE
DOC: Fix delim_whitespace regex typo.

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -99,7 +99,7 @@ delimiter : str, default ``None``
   Alternative argument name for sep.
 delim_whitespace : boolean, default False
   Specifies whether or not whitespace (e.g. ``' '`` or ``'\t'``)
-  will be used as the delimiter. Equivalent to setting ``sep='\+s'``.
+  will be used as the delimiter. Equivalent to setting ``sep='\s+'``.
   If this option is set to True, nothing should be passed in for the
   ``delimiter`` parameter.
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -55,7 +55,7 @@ delimiter : str, default ``None``
     Alternative argument name for sep.
 delim_whitespace : boolean, default False
     Specifies whether or not whitespace (e.g. ``' '`` or ``'\t'``) will be
-    used as the sep. Equivalent to setting ``sep='\+s'``. If this option
+    used as the sep. Equivalent to setting ``sep='\s+'``. If this option
     is set to True, nothing should be passed in for the ``delimiter``
     parameter.
 


### PR DESCRIPTION
Minor typo in the explanation of delim_whitespace which tripped up a user on SO (although the user should probably have been using `delim_whitespace=True` directly anyhow.)
