### PR TITLE
BUG: preserve join keys dtype

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1333,6 +1333,7 @@ Modifying and Computations
    Index.max
    Index.reindex
    Index.repeat
+   Index.where
    Index.take
    Index.putmask
    Index.set_names

--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -77,10 +77,19 @@ Other enhancements
 - The ``pd.read_csv()`` with ``engine='python'`` has gained support for the ``decimal`` option (:issue:`12933`)
 
 - ``Index.astype()`` now accepts an optional boolean argument ``copy``, which allows optional copying if the requirements on dtype are satisfied (:issue:`13209`)
+- ``Index`` now supports the ``.where()`` function for same shape indexing (:issue:`13170`)
+
+  .. ipython:: python
+
+     idx = pd.Index(['a', 'b', 'c'])
+     idx.where([True, False, True])
+
 - ``Categorical.astype()`` now accepts an optional boolean argument ``copy``, effective when dtype is categorical (:issue:`13209`)
 - Consistent with the Python API, ``pd.read_csv()`` will now interpret ``+inf`` as positive infinity (:issue:`13274`)
 
 - ``pd.read_html()`` has gained support for the ``decimal`` option (:issue:`12907`)
+
+
 
 .. _whatsnew_0182.api:
 
@@ -118,7 +127,6 @@ New Behavior:
 .. ipython:: python
 
    type(s.tolist()[0])
-
 
 .. _whatsnew_0182.api.promote:
 
@@ -170,6 +178,54 @@ This will now convert integers/floats with the default unit of ``ns``.
 .. ipython:: python
 
    pd.to_datetime([1, 'foo'], errors='coerce')
+
+.. _whatsnew_0182.api.merging:
+
+Merging changes
+^^^^^^^^^^^^^^^
+
+Merging will now preserve the dtype of the join keys (:issue:`8596`)
+
+.. ipython:: python
+
+   df1 = pd.DataFrame({'key': [1], 'v1': [10]})
+   df1
+   df2 = pd.DataFrame({'key': [1, 2], 'v1': [20, 30]})
+   df2
+
+Previous Behavior:
+
+.. code-block:: ipython
+
+   In [5]: pd.merge(df1, df2, how='outer')
+   Out[5]:
+      key    v1
+   0  1.0  10.0
+   1  1.0  20.0
+   2  2.0  30.0
+
+   In [6]: pd.merge(df1, df2, how='outer').dtypes
+   Out[6]:
+   key    float64
+   v1     float64
+   dtype: object
+
+New Behavior:
+
+We are able to preserve the join keys
+
+.. ipython:: python
+
+   pd.merge(df1, df2, how='outer')
+   pd.merge(df1, df2, how='outer').dtypes
+
+Of course if you have missing values that are introduced, then the
+resulting dtype will be upcast (unchanged from previous).
+
+.. ipython:: python
+
+   pd.merge(df1, df2, how='outer', on='key')
+   pd.merge(df1, df2, how='outer', on='key').dtypes
 
 .. _whatsnew_0182.api.other:
 

--- a/pandas/indexes/base.py
+++ b/pandas/indexes/base.py
@@ -465,6 +465,24 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
         nv.validate_repeat(args, kwargs)
         return self._shallow_copy(self._values.repeat(n))
 
+    def where(self, cond, other=None):
+        """
+        .. versionadded:: 0.18.2
+
+        Return an Index of same shape as self and whose corresponding
+        entries are from self where cond is True and otherwise are from
+        other.
+
+        Parameters
+        ----------
+        cond : boolean same length as self
+        other : scalar, or array-like
+        """
+        if other is None:
+            other = self._na_value
+        values = np.where(cond, self.values, other)
+        return self._shallow_copy_with_infer(values, dtype=self.dtype)
+
     def ravel(self, order='C'):
         """
         return an ndarray of the flattened values of the underlying data

--- a/pandas/indexes/category.py
+++ b/pandas/indexes/category.py
@@ -307,6 +307,29 @@ class CategoricalIndex(Index, base.PandasDelegate):
         """ always allow reindexing """
         pass
 
+    def where(self, cond, other=None):
+        """
+        .. versionadded:: 0.18.2
+
+        Return an Index of same shape as self and whose corresponding
+        entries are from self where cond is True and otherwise are from
+        other.
+
+        Parameters
+        ----------
+        cond : boolean same length as self
+        other : scalar, or array-like
+        """
+        if other is None:
+            other = self._na_value
+        values = np.where(cond, self.values, other)
+
+        from pandas.core.categorical import Categorical
+        cat = Categorical(values,
+                          categories=self.categories,
+                          ordered=self.ordered)
+        return self._shallow_copy(cat, **self._get_attributes_dict())
+
     def reindex(self, target, method=None, level=None, limit=None,
                 tolerance=None):
         """

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -1084,6 +1084,10 @@ class MultiIndex(Index):
                                   for label in self.labels], names=self.names,
                           sortorder=self.sortorder, verify_integrity=False)
 
+    def where(self, cond, other=None):
+        raise NotImplementedError(".where is not supported for "
+                                  "MultiIndex operations")
+
     def drop(self, labels, level=None, errors='raise'):
         """
         Make new MultiIndex with passed list of labels deleted

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from pandas import (Series, Index, Float64Index, Int64Index, RangeIndex,
                     MultiIndex, CategoricalIndex, DatetimeIndex,
-                    TimedeltaIndex, PeriodIndex)
+                    TimedeltaIndex, PeriodIndex, notnull)
 from pandas.util.testing import assertRaisesRegexp
 
 import pandas.util.testing as tm
@@ -362,6 +362,18 @@ class Base(object):
         msg = "the 'axis' parameter is not supported"
         tm.assertRaisesRegexp(ValueError, msg, np.repeat,
                               i, rep, axis=0)
+
+    def test_where(self):
+        i = self.create_index()
+        result = i.where(notnull(i))
+        expected = i
+        tm.assert_index_equal(result, expected)
+
+        i2 = i.copy()
+        i2 = pd.Index([np.nan, np.nan] + i[2:].tolist())
+        result = i.where(notnull(i2))
+        expected = i2
+        tm.assert_index_equal(result, expected)
 
     def test_setops_errorcases(self):
         for name, idx in compat.iteritems(self.indices):

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -11,7 +11,7 @@ from pandas.compat import range, PY3
 
 import numpy as np
 
-from pandas import Categorical, compat
+from pandas import Categorical, compat, notnull
 from pandas.util.testing import assert_almost_equal
 import pandas.core.config as cf
 import pandas as pd
@@ -229,6 +229,19 @@ class TestCategoricalIndex(Base, tm.TestCase):
         exp = pd.Categorical([10, 20, 10, 20, 30], categories=[20, 10, 30],
                              ordered=False)
         tm.assert_categorical_equal(result, exp)
+
+    def test_where(self):
+        i = self.create_index()
+        result = i.where(notnull(i))
+        expected = i
+        tm.assert_index_equal(result, expected)
+
+        i2 = i.copy()
+        i2 = pd.CategoricalIndex([np.nan, np.nan] + i[2:].tolist(),
+                                 categories=i.categories)
+        result = i.where(notnull(i2))
+        expected = i2
+        tm.assert_index_equal(result, expected)
 
     def test_append(self):
 

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -78,6 +78,14 @@ class TestMultiIndex(Base, tm.TestCase):
         self.assertTrue((i.labels[0] >= 0).all())
         self.assertTrue((i.labels[1] >= 0).all())
 
+    def test_where(self):
+        i = MultiIndex.from_tuples([('A', 1), ('A', 2)])
+
+        def f():
+            i.where(True)
+
+        self.assertRaises(NotImplementedError, f)
+
     def test_repeat(self):
         reps = 2
         numbers = [1, 2, 3]

--- a/pandas/tests/types/test_types.py
+++ b/pandas/tests/types/test_types.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+import nose
+import numpy as np
+
+from pandas import NaT
+from pandas.types.api import (DatetimeTZDtype, CategoricalDtype,
+                              na_value_for_dtype, pandas_dtype)
+
+
+def test_pandas_dtype():
+
+    assert pandas_dtype('datetime64[ns, US/Eastern]') == DatetimeTZDtype(
+        'datetime64[ns, US/Eastern]')
+    assert pandas_dtype('category') == CategoricalDtype()
+    for dtype in ['M8[ns]', 'm8[ns]', 'object', 'float64', 'int64']:
+        assert pandas_dtype(dtype) == np.dtype(dtype)
+
+
+def test_na_value_for_dtype():
+    for dtype in [np.dtype('M8[ns]'), np.dtype('m8[ns]'),
+                  DatetimeTZDtype('datetime64[ns, US/Eastern]')]:
+        assert na_value_for_dtype(dtype) is NaT
+
+    for dtype in ['u1', 'u2', 'u4', 'u8',
+                  'i1', 'i2', 'i4', 'i8']:
+        assert na_value_for_dtype(np.dtype(dtype)) == 0
+
+    for dtype in ['bool']:
+        assert na_value_for_dtype(np.dtype(dtype)) is False
+
+    for dtype in ['f2', 'f4', 'f8']:
+        assert np.isnan(na_value_for_dtype(np.dtype(dtype)))
+
+    for dtype in ['O']:
+        assert np.isnan(na_value_for_dtype(np.dtype(dtype)))
+
+
+if __name__ == '__main__':
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   exit=False)

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -280,19 +280,28 @@ class _MergeOperation(object):
         return result
 
     def _maybe_add_join_keys(self, result, left_indexer, right_indexer):
-        # insert group keys
+
+        consolidate = False
+
+        left_has_missing = None
+        right_has_missing = None
 
         keys = zip(self.join_names, self.left_on, self.right_on)
         for i, (name, lname, rname) in enumerate(keys):
             if not _should_fill(lname, rname):
                 continue
 
+            take_left, take_right = None, None
+
             if name in result:
+<<<<<<< HEAD
                 key_indexer = result.columns.get_loc(name)
+=======
+>>>>>>> e79b978... Preserve dtype in merge keys when possible
 
                 if left_indexer is not None and right_indexer is not None:
-
                     if name in self.left:
+<<<<<<< HEAD
                         if len(self.left) == 0:
                             continue
 
@@ -316,12 +325,60 @@ class _MergeOperation(object):
                         result.iloc[na_indexer, key_indexer] = (
                             algos.take_1d(self.left_join_keys[i],
                                           left_na_indexer))
+=======
+
+                        if left_has_missing is None:
+                            left_has_missing = any(left_indexer == -1)
+
+                        if left_has_missing:
+                            take_right = self.right_join_keys[i]
+
+                            if result[name].dtype != self.left[name].dtype:
+                                take_left = self.left[name].values
+
+                    elif name in self.right:
+
+                        if right_has_missing is None:
+                            right_has_missing = any(right_indexer == -1)
+
+                        if right_has_missing:
+                            take_left = self.left_join_keys[i]
+
+                            if result[name].dtype != self.right[name].dtype:
+                                take_right = self.right[name].values
+
+>>>>>>> e79b978... Preserve dtype in merge keys when possible
             elif left_indexer is not None \
                     and isinstance(self.left_join_keys[i], np.ndarray):
 
-                if name is None:
-                    name = 'key_%d' % i
+                take_left = self.left_join_keys[i]
+                take_right = self.right_join_keys[i]
 
+            if take_left is not None or take_right is not None:
+
+                if take_left is None:
+                    lvals = result[name].values
+                else:
+                    lfill = take_left.dtype.type()
+                    lvals = com.take_1d(take_left, left_indexer, fill_value=lfill)
+
+                if take_right is None:
+                    rvals = result[name].values
+                else:
+                    rfill = take_right.dtype.type()
+                    rvals = com.take_1d(take_right, right_indexer, fill_value=rfill)
+
+                key_col = np.where(left_indexer != -1, lvals, rvals)
+
+                if name in result:
+                    if result[name].dtype != key_col.dtype:
+                        consolidate = True
+                    result[name] = key_col
+                else:
+                    result.insert(i, name or 'key_%d' % i, key_col)
+                    consolidate = True
+
+<<<<<<< HEAD
                 # a faster way?
                 key_col = algos.take_1d(self.left_join_keys[i], left_indexer)
                 na_indexer = (left_indexer == -1).nonzero()[0]
@@ -329,6 +386,10 @@ class _MergeOperation(object):
                 key_col.put(na_indexer, algos.take_1d(self.right_join_keys[i],
                                                       right_na_indexer))
                 result.insert(i, name, key_col)
+=======
+        if consolidate:
+            result.consolidate(inplace=True)
+>>>>>>> e79b978... Preserve dtype in merge keys when possible
 
     def _get_join_info(self):
         left_ax = self.left._data.axes[self.axis]

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -507,8 +507,8 @@ class TestMerge(tm.TestCase):
 
         result = result.reset_index()
 
-        result['a'] = result['a'].astype(np.float64)
-        result['b'] = result['b'].astype(np.float64)
+        # result['a'] = result['a'].astype(np.float64)
+        # result['b'] = result['b'].astype(np.float64)
 
         assert_frame_equal(result, expected.ix[:, result.columns])
 
@@ -1033,6 +1033,7 @@ class TestMerge(tm.TestCase):
         df2.columns = ['key1', 'foo', 'foo']
         self.assertRaises(ValueError, merge, df, df2)
 
+<<<<<<< HEAD
     def test_merge_on_datetime64tz(self):
 
         # GH11405
@@ -1426,6 +1427,27 @@ class TestMerge(tm.TestCase):
         test5 = df3.merge(df4, on=['col1', 'col2'],
                           how='outer', indicator=True)
         assert_frame_equal(test5, hand_coded_result)
+=======
+    def test_merge_join_key_dtype_cast(self):
+        # #8596
+
+        df1 = DataFrame({'key': [1], 'v1': [10]})
+        df2 = DataFrame({'key': [2], 'v1': [20]})
+        df = merge(df1, df2, how='outer')
+        self.assertEqual(df['key'].dtype, 'int64')
+
+        df1 = DataFrame({'key': [True], 'v1': [1]})
+        df2 = DataFrame({'key': [False],'v1': [0]})
+        df = merge(df1, df2, how='outer')
+        self.assertEqual(df['key'].dtype, 'bool')
+
+        df1 = DataFrame({'val': [1]})
+        df2 = DataFrame({'val': [2]})
+        lkey = np.array([1])
+        rkey = np.array([2])
+        df = merge(df1, df2, left_on=lkey, right_on=rkey, how='outer')
+        self.assertEqual(df['key_0'].dtype, 'int64')
+>>>>>>> e79b978... Preserve dtype in merge keys when possible
 
 
 def _check_merge(x, y):

--- a/pandas/types/api.py
+++ b/pandas/types/api.py
@@ -28,7 +28,11 @@ def pandas_dtype(dtype):
     -------
     np.dtype or a pandas dtype
     """
-    if isinstance(dtype, string_types):
+    if isinstance(dtype, DatetimeTZDtype):
+        return dtype
+    elif isinstance(dtype, CategoricalDtype):
+        return dtype
+    elif isinstance(dtype, string_types):
         try:
             return DatetimeTZDtype.construct_from_string(dtype)
         except TypeError:
@@ -40,3 +44,32 @@ def pandas_dtype(dtype):
             pass
 
     return np.dtype(dtype)
+
+def na_value_for_dtype(dtype):
+    """
+    Return a dtype compat na value
+
+    Parameters
+    ----------
+    dtype : string / dtype
+
+    Returns
+    -------
+    dtype compat na value
+    """
+
+    from pandas.core import common as com
+    from pandas import NaT
+    dtype = pandas_dtype(dtype)
+
+    if (com.is_datetime64_dtype(dtype) or
+        com.is_datetime64tz_dtype(dtype) or
+        com.is_timedelta64_dtype(dtype)):
+        return NaT
+    elif com.is_float_dtype(dtype):
+        return np.nan
+    elif com.is_integer_dtype(dtype):
+        return 0
+    elif com.is_bool_dtype(dtype):
+        return False
+    return np.nan


### PR DESCRIPTION
- closes #8596, preserve join keys dtype
- adds `Index.where` method for all Index types (like `np.where/Series.where`), but preserves dtypes
