### PR TITLE
BUG: Bug in .groupby(..).resample(..) when the same object is called multiple times

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -118,7 +118,7 @@ Bug Fixes
 - Bug when passing a not-default-indexed ``Series`` as ``xerr`` or ``yerr`` in ``.plot()`` (:issue:`11858`)
 
 
-
+- Bug in ``.groupby(..).resample(..)`` when the same object is called multiple times (:issue:`13174`)
 
 
 - Regression in ``Series.quantile`` with nans (also shows up in ``.median()`` and ``.describe()``); furthermore now names the ``Series`` with the quantile (:issue:`13098`, :issue:`13146`)

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -2835,6 +2835,20 @@ class TestGrouperGrouping(tm.TestCase):
         result = self.frame.B.groupby(self.frame.A).rolling(2).mean()
         assert_series_equal(result, expected)
 
+    def test_getitem_multiple(self):
+
+        # GH 13174
+        g = self.frame.groupby('A')
+        r = g.rolling(2)
+        g_mutated = self.frame.groupby('A', mutated=True)
+        expected = g_mutated.B.apply(lambda x: x.rolling(2).count())
+
+        result = r.B.count()
+        assert_series_equal(result, expected)
+
+        result = r.B.count()
+        assert_series_equal(result, expected)
+
     def test_rolling(self):
         g = self.frame.groupby('A')
         r = g.rolling(window=4)

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 import numpy as np
 import warnings
+import copy
 
 import pandas as pd
 from pandas.core.base import AbstractMethodError, GroupByMixin
@@ -592,7 +593,7 @@ class _GroupByMixin(GroupByMixin):
         self._groupby = groupby
         self._groupby.mutated = True
         self._groupby.grouper.mutated = True
-        self.groupby = parent.groupby
+        self.groupby = copy.copy(parent.groupby)
 
     def _apply(self, f, **kwargs):
         """

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -2519,6 +2519,25 @@ class TestResamplerGrouper(tm.TestCase):
         result = g.resample('2s').mean().B
         assert_series_equal(result, expected)
 
+    def test_getitem_multiple(self):
+
+        # GH 13174
+        # multiple calls after selection causing an issue with aliasing
+        data = [{'id': 1, 'buyer': 'A'}, {'id': 2, 'buyer': 'B'}]
+        df = pd.DataFrame(data, index=pd.date_range('2016-01-01', periods=2))
+        r = df.groupby('id').resample('1D')
+        result = r['buyer'].count()
+        expected = pd.Series([1, 1],
+                             index=pd.MultiIndex.from_tuples(
+                                 [(1, pd.Timestamp('2016-01-01')),
+                                  (2, pd.Timestamp('2016-01-02'))],
+                                 names=['id', None]),
+                             name='buyer')
+        assert_series_equal(result, expected)
+
+        result = r['buyer'].count()
+        assert_series_equal(result, expected)
+
     def test_methods(self):
         g = self.frame.groupby('A')
         r = g.resample('2s')


### PR DESCRIPTION
closes #13174
