### PR TITLE
Correct bool to datetime conversion (behaviour based on int/float processing)

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -245,6 +245,7 @@ Bug Fixes
 - Bug in ``Series`` arithmetic raises ``TypeError`` if it contains datetime-like as ``object`` dtype (:issue:`13043`)
 
 
+- Bug in ``pd.to_datetime`` when passing ``bools``; will now respect the ``errors`` value (:issue:`13176`)
 
 - Bug in ``NaT`` - ``Period`` raises ``AttributeError`` (:issue:`13071`)
 - Bug in ``Period`` addition raises ``TypeError`` if ``Period`` is on right hand side (:issue:`13069`)

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -2292,6 +2292,29 @@ class TestToDatetime(tm.TestCase):
                                     dtype='datetime64[ns, UTC]')
         tm.assert_index_equal(result, expected)
 
+    def test_datetime_bool(self):
+        # GH13176
+        with self.assertRaises(TypeError):
+            to_datetime(False)
+        self.assertTrue(to_datetime(False, errors="coerce") is tslib.NaT)
+        self.assertEqual(to_datetime(False, errors="ignore"), False)
+        with self.assertRaises(TypeError):
+            to_datetime(True)
+        self.assertTrue(to_datetime(True, errors="coerce") is tslib.NaT)
+        self.assertEqual(to_datetime(True, errors="ignore"), True)
+        with self.assertRaises(TypeError):
+            to_datetime([False, datetime.today()])
+        with self.assertRaises(TypeError):
+            to_datetime(['20130101', True])
+        tm.assert_index_equal(to_datetime([0, False, tslib.NaT, 0.0],
+                                          errors="coerce"),
+                              DatetimeIndex([to_datetime(0), tslib.NaT,
+                                             tslib.NaT, to_datetime(0)]))
+        with self.assertRaises(TypeError):
+            pd.to_datetime(bool)
+        with self.assertRaises(TypeError):
+            pd.to_datetime(pd.to_datetime)
+
     def test_unit(self):
         # GH 11758
         # test proper behavior with erros

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -2292,6 +2292,12 @@ cpdef array_to_datetime(ndarray[object] values, errors='raise',
                         iresult[i] = cast_from_unit(val, 'ns')
                     except:
                         iresult[i] = NPY_NAT
+            elif not util.is_string_object(val):
+                if is_coerce:
+                    iresult[i] = NPY_NAT
+                else:
+                    raise TypeError("{0} is not convertible to datetime"
+                                    .format(type(val)))
             else:
                 try:
                     if len(val) == 0 or val in _nat_strings:


### PR DESCRIPTION
- [x] closes #11853
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
