### PR TITLE
BUG: fix to_records confict with unicode_literals #13172

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -120,6 +120,7 @@ Bug Fixes
 
 
 - Bug in ``.groupby(..).resample(..)`` when the same object is called multiple times (:issue:`13174`)
+- Bug in ``.to_records()`` when index name is unicode string (:issue: `13172`)
 
 
 - Regression in ``Series.quantile`` with nans (also shows up in ``.median()`` and ``.describe()``); furthermore now names the ``Series`` with the quantile (:issue:`13098`, :issue:`13146`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1062,7 +1062,7 @@ class DataFrame(NDFrame):
                         count += 1
             elif index_names[0] is None:
                 index_names = ['index']
-            names = index_names + lmap(str, self.columns)
+            names = lmap(str, index_names) + lmap(str, self.columns)
         else:
             arrays = [self[c].get_values() for c in self.columns]
             names = lmap(str, self.columns)

--- a/pandas/tests/frame/test_convert_to.py
+++ b/pandas/tests/frame/test_convert_to.py
@@ -172,3 +172,11 @@ class TestDataFrameConvertTo(tm.TestCase, TestData):
         df.index.names = ['A', None]
         rs = df.to_records()
         self.assertIn('level_0', rs.dtype.fields)
+
+    def test_to_records_with_unicode_index(self):
+        # GH13172
+        # unicode_literals conflict with to_records
+        result = DataFrame([{u'a': u'x', u'b': 'y'}]).set_index(u'a')\
+            .to_records()
+        expected = np.rec.array([('x', 'y')], dtype=[('a', 'O'), ('b', 'O')])
+        tm.assert_numpy_array_equal(result, expected)


### PR DESCRIPTION
- [ ] closes #13172 
- [ ] tests added / passed
- [ ] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry
