### PR TITLE
ENH: Improved error message (issue 13084)

### DIFF
--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -4161,8 +4161,9 @@ def construction_error(tot_items, block_shape, axes, e=None):
         raise e
     if block_shape[0] == 0:
         raise ValueError("Empty data passed with indices specified.")
-    raise ValueError("Shape of passed values is {0}, indices imply {1}".format(
-        passed, implied))
+    raise ValueError("Shape of passed values is {0}, indices imply {1}.\n\
+        This means that at least one of the dataframes contains duplicate \
+        index values.".format(passed, implied))
 
 
 def create_block_manager_from_blocks(blocks, axes):


### PR DESCRIPTION
- [ ] closes #13084 
- [ ] tests passed
- [ ] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew:

As per issue 13084, made it clearer for the user to understand why a concat failed. No additional code was needed. This is because the _verify_integrity method inside the BlockManager class of pandas/core/internals.py already checked that the length of the concat data and index are the same. An alternative option was to pass the error in the e argument of the construction_error method of the SingleBlockManager. The alternative was not performed as there appeared to be no other reason why the shape of the dataframes would be different, as a result using the e argument would result in duplicating code. The method was also not extended to identify the dataframes with duplicate index values to avoid overcomplicating the code. The end user should be able to easily identify the dataframe/s causing the errors
