### PR TITLE
CLN: Check Warnings in test_graphics_others

### DIFF
--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -450,8 +450,9 @@ class TestPlotBase(tm.TestCase):
                     self.assertIsInstance(value.lines, dict)
                 elif return_type == 'dict':
                     line = value['medians'][0]
+                    axes = line.axes if self.mpl_ge_1_5_0 else line.get_axes()
                     if check_ax_title:
-                        self.assertEqual(line.get_axes().get_title(), key)
+                        self.assertEqual(axes.get_title(), key)
                 else:
                     raise AssertionError
 
@@ -910,7 +911,7 @@ class TestSeriesPlots(TestPlotBase):
         subplot(122)
         y.hist()
         fig = gcf()
-        axes = fig.get_axes()
+        axes = fig.axes if self.mpl_ge_1_5_0 else fig.get_axes()
         self.assertEqual(len(axes), 2)
 
     @slow

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -820,10 +820,13 @@ class TestSeriesPlots(TestPlotBase):
         _check_plot_works(self.ts.hist)
         _check_plot_works(self.ts.hist, grid=False)
         _check_plot_works(self.ts.hist, figsize=(8, 10))
-        _check_plot_works(self.ts.hist, filterwarnings='ignore',
-                          by=self.ts.index.month)
-        _check_plot_works(self.ts.hist, filterwarnings='ignore',
-                          by=self.ts.index.month, bins=5)
+        # _check_plot_works adds an ax so catch warning. see GH #13188
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(self.ts.hist,
+                              by=self.ts.index.month)
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(self.ts.hist,
+                              by=self.ts.index.month, bins=5)
 
         fig, ax = self.plt.subplots(1, 1)
         _check_plot_works(self.ts.hist, ax=ax)
@@ -857,32 +860,40 @@ class TestSeriesPlots(TestPlotBase):
     def test_hist_layout_with_by(self):
         df = self.hist_df
 
-        axes = _check_plot_works(df.height.hist, filterwarnings='ignore',
-                                 by=df.gender, layout=(2, 1))
+        # _check_plot_works adds an ax so catch warning. see GH #13188
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.height.hist,
+                                     by=df.gender, layout=(2, 1))
         self._check_axes_shape(axes, axes_num=2, layout=(2, 1))
 
-        axes = _check_plot_works(df.height.hist, filterwarnings='ignore',
-                                 by=df.gender, layout=(3, -1))
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.height.hist,
+                                     by=df.gender, layout=(3, -1))
         self._check_axes_shape(axes, axes_num=2, layout=(3, 1))
 
-        axes = _check_plot_works(df.height.hist, filterwarnings='ignore',
-                                 by=df.category, layout=(4, 1))
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.height.hist,
+                                     by=df.category, layout=(4, 1))
         self._check_axes_shape(axes, axes_num=4, layout=(4, 1))
 
-        axes = _check_plot_works(df.height.hist, filterwarnings='ignore',
-                                 by=df.category, layout=(2, -1))
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.height.hist,
+                                     by=df.category, layout=(2, -1))
         self._check_axes_shape(axes, axes_num=4, layout=(2, 2))
 
-        axes = _check_plot_works(df.height.hist, filterwarnings='ignore',
-                                 by=df.category, layout=(3, -1))
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.height.hist,
+                                     by=df.category, layout=(3, -1))
         self._check_axes_shape(axes, axes_num=4, layout=(3, 2))
 
-        axes = _check_plot_works(df.height.hist, filterwarnings='ignore',
-                                 by=df.category, layout=(-1, 4))
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.height.hist,
+                                     by=df.category, layout=(-1, 4))
         self._check_axes_shape(axes, axes_num=4, layout=(1, 4))
 
-        axes = _check_plot_works(df.height.hist, filterwarnings='ignore',
-                                 by=df.classroom, layout=(2, 2))
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.height.hist,
+                                     by=df.classroom, layout=(2, 2))
         self._check_axes_shape(axes, axes_num=3, layout=(2, 2))
 
         axes = df.height.hist(by=df.category, layout=(4, 2), figsize=(12, 7))
@@ -1300,17 +1311,21 @@ class TestDataFramePlots(TestPlotBase):
     @slow
     def test_plot(self):
         df = self.tdf
-        _check_plot_works(df.plot, filterwarnings='ignore', grid=False)
-        axes = _check_plot_works(df.plot, filterwarnings='ignore',
-                                 subplots=True)
+        _check_plot_works(df.plot, grid=False)
+        # _check_plot_works adds an ax so catch warning. see GH #13188
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.plot,
+                                     subplots=True)
         self._check_axes_shape(axes, axes_num=4, layout=(4, 1))
 
-        axes = _check_plot_works(df.plot, filterwarnings='ignore',
-                                 subplots=True, layout=(-1, 2))
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.plot,
+                                     subplots=True, layout=(-1, 2))
         self._check_axes_shape(axes, axes_num=4, layout=(2, 2))
 
-        axes = _check_plot_works(df.plot, filterwarnings='ignore',
-                                 subplots=True, use_index=False)
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.plot,
+                                     subplots=True, use_index=False)
         self._check_axes_shape(axes, axes_num=4, layout=(4, 1))
 
         df = DataFrame({'x': [1, 2], 'y': [3, 4]})
@@ -1326,8 +1341,8 @@ class TestDataFramePlots(TestPlotBase):
         _check_plot_works(df.plot, xticks=[1, 5, 10])
         _check_plot_works(df.plot, ylim=(-100, 100), xlim=(-100, 100))
 
-        _check_plot_works(df.plot, filterwarnings='ignore',
-                          subplots=True, title='blah')
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(df.plot, subplots=True, title='blah')
 
         # We have to redo it here because _check_plot_works does two plots,
         # once without an ax kwarg and once with an ax kwarg and the new sharex
@@ -2217,7 +2232,9 @@ class TestDataFramePlots(TestPlotBase):
 
         _check_plot_works(df.plot.bar)
         _check_plot_works(df.plot.bar, legend=False)
-        _check_plot_works(df.plot.bar, filterwarnings='ignore', subplots=True)
+        # _check_plot_works adds an ax so catch warning. see GH #13188
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(df.plot.bar, subplots=True)
         _check_plot_works(df.plot.bar, stacked=True)
 
         df = DataFrame(randn(10, 15),
@@ -2433,8 +2450,10 @@ class TestDataFramePlots(TestPlotBase):
         self._check_text_labels(ax.get_yticklabels(), labels)
         self.assertEqual(len(ax.lines), self.bp_n_objects * len(numeric_cols))
 
-        axes = _check_plot_works(df.plot.box, filterwarnings='ignore',
-                                 subplots=True, vert=False, logx=True)
+        # _check_plot_works adds an ax so catch warning. see GH #13188
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.plot.box,
+                                     subplots=True, vert=False, logx=True)
         self._check_axes_shape(axes, axes_num=3, layout=(1, 3))
         self._check_ax_scales(axes, xaxis='log')
         for ax, label in zip(axes, labels):
@@ -2494,8 +2513,9 @@ class TestDataFramePlots(TestPlotBase):
         ax = df.plot(kind='kde', rot=20, fontsize=5)
         self._check_ticks_props(ax, xrot=20, xlabelsize=5, ylabelsize=5)
 
-        axes = _check_plot_works(df.plot, filterwarnings='ignore', kind='kde',
-                                 subplots=True)
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.plot, kind='kde',
+                                     subplots=True)
         self._check_axes_shape(axes, axes_num=4, layout=(4, 1))
 
         axes = df.plot(kind='kde', logy=True, subplots=True)
@@ -2522,8 +2542,9 @@ class TestDataFramePlots(TestPlotBase):
         expected = [pprint_thing(c) for c in df.columns]
         self._check_legend_labels(ax, labels=expected)
 
-        axes = _check_plot_works(df.plot.hist, filterwarnings='ignore',
-                                 subplots=True, logy=True)
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.plot.hist,
+                                     subplots=True, logy=True)
         self._check_axes_shape(axes, axes_num=4, layout=(4, 1))
         self._check_ax_scales(axes, yaxis='log')
 
@@ -2902,8 +2923,9 @@ class TestDataFramePlots(TestPlotBase):
             # Color contains shorthand hex value results in ValueError
             custom_colors = ['#F00', '#00F', '#FF0', '#000', '#FFF']
             # Forced show plot
-            _check_plot_works(df.plot, color=custom_colors, subplots=True,
-                              filterwarnings='ignore')
+            # _check_plot_works adds an ax so catch warning. see GH #13188
+            with tm.assert_produces_warning(UserWarning):
+                _check_plot_works(df.plot, color=custom_colors, subplots=True)
 
         rgba_colors = lmap(cm.jet, np.linspace(0, 1, len(df)))
         for cmap in ['jet', cm.jet]:
@@ -3294,8 +3316,10 @@ class TestDataFramePlots(TestPlotBase):
         ax = _check_plot_works(df.plot.pie, y=2)
         self._check_text_labels(ax.texts, df.index)
 
-        axes = _check_plot_works(df.plot.pie, filterwarnings='ignore',
-                                 subplots=True)
+        # _check_plot_works adds an ax so catch warning. see GH #13188
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.plot.pie,
+                                     subplots=True)
         self.assertEqual(len(axes), len(df.columns))
         for ax in axes:
             self._check_text_labels(ax.texts, df.index)
@@ -3304,9 +3328,10 @@ class TestDataFramePlots(TestPlotBase):
 
         labels = ['A', 'B', 'C', 'D', 'E']
         color_args = ['r', 'g', 'b', 'c', 'm']
-        axes = _check_plot_works(df.plot.pie, filterwarnings='ignore',
-                                 subplots=True, labels=labels,
-                                 colors=color_args)
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.plot.pie,
+                                     subplots=True, labels=labels,
+                                     colors=color_args)
         self.assertEqual(len(axes), len(df.columns))
 
         for ax in axes:
@@ -3362,9 +3387,12 @@ class TestDataFramePlots(TestPlotBase):
             self._check_has_errorbars(ax, xerr=2, yerr=2)
             ax = _check_plot_works(df.plot, xerr=0.2, yerr=0.2, kind=kind)
             self._check_has_errorbars(ax, xerr=2, yerr=2)
-            axes = _check_plot_works(df.plot, filterwarnings='ignore',
-                                     yerr=df_err, xerr=df_err, subplots=True,
-                                     kind=kind)
+            # _check_plot_works adds an ax so catch warning. see GH #13188
+            with tm.assert_produces_warning(UserWarning):
+                axes = _check_plot_works(df.plot,
+                                         yerr=df_err, xerr=df_err,
+                                         subplots=True,
+                                         kind=kind)
             self._check_has_errorbars(axes, xerr=1, yerr=1)
 
         ax = _check_plot_works((df + 1).plot, yerr=df_err,
@@ -3455,8 +3483,11 @@ class TestDataFramePlots(TestPlotBase):
             self._check_has_errorbars(ax, xerr=0, yerr=1)
             ax = _check_plot_works(tdf.plot, yerr=tdf_err, kind=kind)
             self._check_has_errorbars(ax, xerr=0, yerr=2)
-            axes = _check_plot_works(tdf.plot, filterwarnings='ignore',
-                                     kind=kind, yerr=tdf_err, subplots=True)
+            # _check_plot_works adds an ax so catch warning. see GH #13188
+            with tm.assert_produces_warning(UserWarning):
+                axes = _check_plot_works(tdf.plot,
+                                         kind=kind, yerr=tdf_err,
+                                         subplots=True)
             self._check_has_errorbars(axes, xerr=0, yerr=1)
 
     def test_errorbar_asymmetrical(self):

--- a/pandas/tests/test_graphics_others.py
+++ b/pandas/tests/test_graphics_others.py
@@ -150,7 +150,7 @@ class TestSeriesPlots(TestPlotBase):
         subplot(122)
         y.hist()
         fig = gcf()
-        axes = fig.get_axes()
+        axes = fig.axes if self.mpl_ge_1_5_0 else fig.get_axes()
         self.assertEqual(len(axes), 2)
 
     @slow
@@ -242,11 +242,13 @@ class TestDataFramePlots(TestPlotBase):
         # passed ax should be used:
         fig, ax = self.plt.subplots()
         axes = df.boxplot('Col1', by='X', ax=ax)
-        self.assertIs(ax.get_axes(), axes)
+        ax_axes = ax.axes if self.mpl_ge_1_5_0 else ax.get_axes()
+        self.assertIs(ax_axes, axes)
 
         fig, ax = self.plt.subplots()
         axes = df.groupby('Y').boxplot(ax=ax, return_type='axes')
-        self.assertIs(ax.get_axes(), axes['A'])
+        ax_axes = ax.axes if self.mpl_ge_1_5_0 else ax.get_axes()
+        self.assertIs(ax_axes, axes['A'])
 
         # Multiple columns with an ax argument should use same figure
         fig, ax = self.plt.subplots()

--- a/pandas/tests/test_graphics_others.py
+++ b/pandas/tests/test_graphics_others.py
@@ -5,7 +5,6 @@ import nose
 import itertools
 import os
 import string
-import warnings
 from distutils.version import LooseVersion
 
 from pandas import Series, DataFrame, MultiIndex
@@ -61,8 +60,11 @@ class TestSeriesPlots(TestPlotBase):
         _check_plot_works(self.ts.hist)
         _check_plot_works(self.ts.hist, grid=False)
         _check_plot_works(self.ts.hist, figsize=(8, 10))
-        _check_plot_works(self.ts.hist, by=self.ts.index.month)
-        _check_plot_works(self.ts.hist, by=self.ts.index.month, bins=5)
+        # _check_plot_works adds an ax so catch warning. see GH #13188
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(self.ts.hist, by=self.ts.index.month)
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(self.ts.hist, by=self.ts.index.month, bins=5)
 
         fig, ax = self.plt.subplots(1, 1)
         _check_plot_works(self.ts.hist, ax=ax)
@@ -96,29 +98,42 @@ class TestSeriesPlots(TestPlotBase):
     def test_hist_layout_with_by(self):
         df = self.hist_df
 
-        axes = _check_plot_works(df.height.hist, by=df.gender, layout=(2, 1))
+        # _check_plot_works adds an `ax` kwarg to the method call
+        # so we get a warning about an axis being cleared, even
+        # though we don't explicing pass one, see GH #13188
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.height.hist, by=df.gender,
+                                     layout=(2, 1))
         self._check_axes_shape(axes, axes_num=2, layout=(2, 1))
 
-        axes = _check_plot_works(df.height.hist, by=df.gender, layout=(3, -1))
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.height.hist, by=df.gender,
+                                     layout=(3, -1))
         self._check_axes_shape(axes, axes_num=2, layout=(3, 1))
 
-        axes = _check_plot_works(df.height.hist, by=df.category, layout=(4, 1))
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.height.hist, by=df.category,
+                                     layout=(4, 1))
         self._check_axes_shape(axes, axes_num=4, layout=(4, 1))
 
-        axes = _check_plot_works(
-            df.height.hist, by=df.category, layout=(2, -1))
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(
+                df.height.hist, by=df.category, layout=(2, -1))
         self._check_axes_shape(axes, axes_num=4, layout=(2, 2))
 
-        axes = _check_plot_works(
-            df.height.hist, by=df.category, layout=(3, -1))
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(
+                df.height.hist, by=df.category, layout=(3, -1))
         self._check_axes_shape(axes, axes_num=4, layout=(3, 2))
 
-        axes = _check_plot_works(
-            df.height.hist, by=df.category, layout=(-1, 4))
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(
+                df.height.hist, by=df.category, layout=(-1, 4))
         self._check_axes_shape(axes, axes_num=4, layout=(1, 4))
 
-        axes = _check_plot_works(
-            df.height.hist, by=df.classroom, layout=(2, 2))
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(
+                df.height.hist, by=df.classroom, layout=(2, 2))
         self._check_axes_shape(axes, axes_num=3, layout=(2, 2))
 
         axes = df.height.hist(by=df.category, layout=(4, 2), figsize=(12, 7))
@@ -203,18 +218,25 @@ class TestDataFramePlots(TestPlotBase):
         _check_plot_works(df.boxplot, return_type='dict')
         _check_plot_works(df.boxplot, column=[
                           'one', 'two'], return_type='dict')
-        _check_plot_works(df.boxplot, column=['one', 'two'], by='indic')
+        # _check_plot_works adds an ax so catch warning. see GH #13188
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(df.boxplot, column=['one', 'two'],
+                              by='indic')
         _check_plot_works(df.boxplot, column='one', by=['indic', 'indic2'])
-        _check_plot_works(df.boxplot, by='indic')
-        _check_plot_works(df.boxplot, by=['indic', 'indic2'])
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(df.boxplot, by='indic')
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(df.boxplot, by=['indic', 'indic2'])
         _check_plot_works(plotting.boxplot, data=df['one'], return_type='dict')
         _check_plot_works(df.boxplot, notch=1, return_type='dict')
-        _check_plot_works(df.boxplot, by='indic', notch=1)
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(df.boxplot, by='indic', notch=1)
 
         df = DataFrame(np.random.rand(10, 2), columns=['Col1', 'Col2'])
         df['X'] = Series(['A', 'A', 'A', 'A', 'A', 'B', 'B', 'B', 'B', 'B'])
         df['Y'] = Series(['A'] * 10)
-        _check_plot_works(df.boxplot, by='X')
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(df.boxplot, by='X')
 
         # When ax is supplied and required number of axes is 1,
         # passed ax should be used:
@@ -228,8 +250,9 @@ class TestDataFramePlots(TestPlotBase):
 
         # Multiple columns with an ax argument should use same figure
         fig, ax = self.plt.subplots()
-        axes = df.boxplot(column=['Col1', 'Col2'],
-                          by='X', ax=ax, return_type='axes')
+        with tm.assert_produces_warning(UserWarning):
+            axes = df.boxplot(column=['Col1', 'Col2'],
+                              by='X', ax=ax, return_type='axes')
         self.assertIs(axes['Col1'].get_figure(), fig)
 
         # When by is None, check that all relevant lines are present in the
@@ -304,11 +327,13 @@ class TestDataFramePlots(TestPlotBase):
     @slow
     def test_hist_df_legacy(self):
         from matplotlib.patches import Rectangle
-        _check_plot_works(self.hist_df.hist)
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(self.hist_df.hist)
 
         # make sure layout is handled
         df = DataFrame(randn(100, 3))
-        axes = _check_plot_works(df.hist, grid=False)
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.hist, grid=False)
         self._check_axes_shape(axes, axes_num=3, layout=(2, 2))
         self.assertFalse(axes[1, 1].get_visible())
 
@@ -317,17 +342,21 @@ class TestDataFramePlots(TestPlotBase):
 
         # make sure layout is handled
         df = DataFrame(randn(100, 6))
-        axes = _check_plot_works(df.hist, layout=(4, 2))
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.hist, layout=(4, 2))
         self._check_axes_shape(axes, axes_num=6, layout=(4, 2))
 
         # make sure sharex, sharey is handled
-        _check_plot_works(df.hist, sharex=True, sharey=True)
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(df.hist, sharex=True, sharey=True)
 
         # handle figsize arg
-        _check_plot_works(df.hist, figsize=(8, 10))
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(df.hist, figsize=(8, 10))
 
         # check bins argument
-        _check_plot_works(df.hist, bins=5)
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(df.hist, bins=5)
 
         # make sure xlabelsize and xrot are handled
         ser = df[0]
@@ -401,22 +430,30 @@ class TestDataFramePlots(TestPlotBase):
         def scat(**kwds):
             return plotting.scatter_matrix(df, **kwds)
 
-        _check_plot_works(scat)
-        _check_plot_works(scat, marker='+')
-        _check_plot_works(scat, vmin=0)
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(scat)
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(scat, marker='+')
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(scat, vmin=0)
         if _ok_for_gaussian_kde('kde'):
-            _check_plot_works(scat, diagonal='kde')
+            with tm.assert_produces_warning(UserWarning):
+                _check_plot_works(scat, diagonal='kde')
         if _ok_for_gaussian_kde('density'):
-            _check_plot_works(scat, diagonal='density')
-        _check_plot_works(scat, diagonal='hist')
-        _check_plot_works(scat, range_padding=.1)
+            with tm.assert_produces_warning(UserWarning):
+                _check_plot_works(scat, diagonal='density')
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(scat, diagonal='hist')
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(scat, range_padding=.1)
 
         def scat2(x, y, by=None, ax=None, figsize=None):
             return plotting.scatter_plot(df, x, y, by, ax, figsize=None)
 
         _check_plot_works(scat2, x=0, y=1)
         grouper = Series(np.repeat([1, 2, 3, 4, 5], 20), df.index)
-        _check_plot_works(scat2, x=0, y=1, by=grouper)
+        with tm.assert_produces_warning(UserWarning):
+            _check_plot_works(scat2, x=0, y=1, by=grouper)
 
     def test_scatter_matrix_axis(self):
         tm._skip_if_no_scipy()
@@ -607,8 +644,7 @@ class TestDataFrameGroupByPlots(TestPlotBase):
     @slow
     def test_boxplot_legacy(self):
         grouped = self.hist_df.groupby(by='gender')
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
+        with tm.assert_produces_warning(UserWarning):
             axes = _check_plot_works(grouped.boxplot, return_type='axes')
         self._check_axes_shape(list(axes.values()), axes_num=2, layout=(1, 2))
 
@@ -620,7 +656,8 @@ class TestDataFrameGroupByPlots(TestPlotBase):
                        index=MultiIndex.from_tuples(tuples))
 
         grouped = df.groupby(level=1)
-        axes = _check_plot_works(grouped.boxplot, return_type='axes')
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(grouped.boxplot, return_type='axes')
         self._check_axes_shape(list(axes.values()), axes_num=10, layout=(4, 3))
 
         axes = _check_plot_works(grouped.boxplot, subplots=False,
@@ -628,7 +665,8 @@ class TestDataFrameGroupByPlots(TestPlotBase):
         self._check_axes_shape(axes, axes_num=1, layout=(1, 1))
 
         grouped = df.unstack(level=1).groupby(level=0, axis=1)
-        axes = _check_plot_works(grouped.boxplot, return_type='axes')
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(grouped.boxplot, return_type='axes')
         self._check_axes_shape(list(axes.values()), axes_num=3, layout=(2, 2))
 
         axes = _check_plot_works(grouped.boxplot, subplots=False,
@@ -774,18 +812,22 @@ class TestDataFrameGroupByPlots(TestPlotBase):
         self.assertRaises(ValueError, df.boxplot, column=['weight', 'height'],
                           by=df.gender, layout=(-1, -1))
 
-        box = _check_plot_works(df.groupby('gender').boxplot, column='height',
-                                return_type='dict')
+        # _check_plot_works adds an ax so catch warning. see GH #13188
+        with tm.assert_produces_warning(UserWarning):
+            box = _check_plot_works(df.groupby('gender').boxplot,
+                                    column='height', return_type='dict')
         self._check_axes_shape(self.plt.gcf().axes, axes_num=2, layout=(1, 2))
 
-        box = _check_plot_works(df.groupby('category').boxplot,
-                                column='height',
-                                return_type='dict')
+        with tm.assert_produces_warning(UserWarning):
+            box = _check_plot_works(df.groupby('category').boxplot,
+                                    column='height',
+                                    return_type='dict')
         self._check_axes_shape(self.plt.gcf().axes, axes_num=4, layout=(2, 2))
 
         # GH 6769
-        box = _check_plot_works(df.groupby('classroom').boxplot,
-                                column='height', return_type='dict')
+        with tm.assert_produces_warning(UserWarning):
+            box = _check_plot_works(df.groupby('classroom').boxplot,
+                                    column='height', return_type='dict')
         self._check_axes_shape(self.plt.gcf().axes, axes_num=3, layout=(2, 2))
 
         # GH 5897
@@ -803,13 +845,15 @@ class TestDataFrameGroupByPlots(TestPlotBase):
             column=['height', 'weight', 'category'], return_type='dict')
         self._check_axes_shape(self.plt.gcf().axes, axes_num=3, layout=(2, 2))
 
-        box = _check_plot_works(df.groupby('category').boxplot,
-                                column='height',
-                                layout=(3, 2), return_type='dict')
+        with tm.assert_produces_warning(UserWarning):
+            box = _check_plot_works(df.groupby('category').boxplot,
+                                    column='height',
+                                    layout=(3, 2), return_type='dict')
         self._check_axes_shape(self.plt.gcf().axes, axes_num=4, layout=(3, 2))
-        box = _check_plot_works(df.groupby('category').boxplot,
-                                column='height',
-                                layout=(3, -1), return_type='dict')
+        with tm.assert_produces_warning(UserWarning):
+            box = _check_plot_works(df.groupby('category').boxplot,
+                                    column='height',
+                                    layout=(3, -1), return_type='dict')
         self._check_axes_shape(self.plt.gcf().axes, axes_num=4, layout=(3, 2))
 
         box = df.boxplot(column=['height', 'weight', 'category'], by='gender',
@@ -848,8 +892,7 @@ class TestDataFrameGroupByPlots(TestPlotBase):
                                    axes_num=4, layout=(2, 2))
 
         fig, axes = self.plt.subplots(2, 3)
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
+        with tm.assert_produces_warning(UserWarning):
             returned = df.boxplot(column=['height', 'weight', 'category'],
                                   by='gender', return_type='axes', ax=axes[0])
         returned = np.array(list(returned.values()))
@@ -858,8 +901,7 @@ class TestDataFrameGroupByPlots(TestPlotBase):
         self.assertIs(returned[0].figure, fig)
 
         # draw on second row
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
+        with tm.assert_produces_warning(UserWarning):
             returned = df.groupby('classroom').boxplot(
                 column=['height', 'weight', 'category'],
                 return_type='axes', ax=axes[1])
@@ -871,7 +913,8 @@ class TestDataFrameGroupByPlots(TestPlotBase):
         with tm.assertRaises(ValueError):
             fig, axes = self.plt.subplots(2, 3)
             # pass different number of axes from required
-            axes = df.groupby('classroom').boxplot(ax=axes)
+            with tm.assert_produces_warning(UserWarning):
+                axes = df.groupby('classroom').boxplot(ax=axes)
 
     @slow
     def test_grouped_hist_layout(self):
@@ -883,12 +926,14 @@ class TestDataFrameGroupByPlots(TestPlotBase):
         self.assertRaises(ValueError, df.hist, column='height', by=df.category,
                           layout=(-1, -1))
 
-        axes = _check_plot_works(df.hist, column='height', by=df.gender,
-                                 layout=(2, 1))
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.hist, column='height', by=df.gender,
+                                     layout=(2, 1))
         self._check_axes_shape(axes, axes_num=2, layout=(2, 1))
 
-        axes = _check_plot_works(df.hist, column='height', by=df.gender,
-                                 layout=(2, -1))
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.hist, column='height', by=df.gender,
+                                     layout=(2, -1))
         self._check_axes_shape(axes, axes_num=2, layout=(2, 1))
 
         axes = df.hist(column='height', by=df.category, layout=(4, 1))
@@ -904,12 +949,14 @@ class TestDataFrameGroupByPlots(TestPlotBase):
         tm.close()
 
         # GH 6769
-        axes = _check_plot_works(
-            df.hist, column='height', by='classroom', layout=(2, 2))
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(
+                df.hist, column='height', by='classroom', layout=(2, 2))
         self._check_axes_shape(axes, axes_num=3, layout=(2, 2))
 
         # without column
-        axes = _check_plot_works(df.hist, by='classroom')
+        with tm.assert_produces_warning(UserWarning):
+            axes = _check_plot_works(df.hist, by='classroom')
         self._check_axes_shape(axes, axes_num=3, layout=(2, 2))
 
         axes = df.hist(by='gender', layout=(3, 5))

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -3353,7 +3353,8 @@ def _subplots(naxes=None, sharex=False, sharey=False, squeeze=True,
             if sharex or sharey:
                 warnings.warn("When passing multiple axes, sharex and sharey "
                               "are ignored. These settings must be specified "
-                              "when creating axes", UserWarning)
+                              "when creating axes", UserWarning,
+                              stacklevel=4)
             if len(ax) == naxes:
                 fig = ax[0].get_figure()
                 return fig, ax
@@ -3370,7 +3371,8 @@ def _subplots(naxes=None, sharex=False, sharey=False, squeeze=True,
                 return fig, _flatten(ax)
         else:
             warnings.warn("To output multiple subplots, the figure containing "
-                          "the passed axes is being cleared", UserWarning)
+                          "the passed axes is being cleared", UserWarning,
+                          stacklevel=4)
             fig.clear()
 
     nrows, ncols = _get_layout(naxes, layout=layout, layout_type=layout_type)


### PR DESCRIPTION
- [x] closes #13185 maybe
- [x] passes `git diff upstream/master | flake8 --diff`

Also a MatplotlibDeprecationWarning for use of `.get_axes()` vs. `.axes` in some tests.
