### PR TITLE
PERF: DataFrame transform

### DIFF
--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -773,6 +773,21 @@ class groupby_transform_series2(object):
     def time_groupby_transform_series2(self):
         self.df.groupby('id')['val'].transform(np.mean)
 
+
+class groupby_transform_dataframe(object):
+    # GH 12737
+    goal_time = 0.2
+
+    def setup(self):
+        self.df = pd.DataFrame({'group': np.repeat(np.arange(1000), 10),
+                                'B': np.nan,
+                                'C': np.nan})
+        self.df.ix[4::10, 'B':'C'] = 5
+
+    def time_groupby_transform_dataframe(self):
+        self.df.groupby('group').transform('first')
+
+
 class groupby_transform_cythonized(object):
     goal_time = 0.2
 

--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -104,7 +104,7 @@ Performance Improvements
 - increased performance of ``DataFrame.quantile()`` as it now operates per-block (:issue:`11623`)
 
 
-
+- Improved performance of ``DataFrameGroupBy.transform`` (:issue:`12737`)
 
 
 .. _whatsnew_0182.bug_fixes:
@@ -123,7 +123,7 @@ Bug Fixes
 
 - Regression in ``Series.quantile`` with nans (also shows up in ``.median()`` and ``.describe()``); furthermore now names the ``Series`` with the quantile (:issue:`13098`, :issue:`13146`)
 
-
+- Bug in ``SeriesGroupBy.transform`` with datetime values and missing groups (:issue:`13191`)
 
 - Bug in ``Series.str.extractall()`` with ``str`` index raises ``ValueError``  (:issue:`13156`)
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2776,7 +2776,7 @@ class SeriesGroupBy(GroupBy):
             func = getattr(self, func)
 
         ids, _, ngroup = self.grouper.group_info
-        cast = self.size().isnull().any()
+        cast = (self.size().fillna(0) > 0).any()
         out = algos.take_1d(func().values, ids)
         if cast:
             out = self._try_cast(out, self.obj)
@@ -3466,7 +3466,7 @@ class NDFrameGroupBy(GroupBy):
         """
         # if there were groups with no observations (Categorical only?)
         # try casting data to original dtype
-        cast = self.size().isnull().any()
+        cast = (self.size().fillna(0) > 0).any()
 
         # for each col, reshape to to size of original frame
         # by take operation

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -3025,8 +3025,7 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
         c = pd.cut(df.a, bins=[0, 10, 20, 30, 40])
 
         result = df.a.groupby(c).transform(sum)
-        tm.assert_series_equal(result, df['a'], check_names=False)
-        self.assertTrue(result.name is None)
+        tm.assert_series_equal(result, df['a'])
 
         tm.assert_series_equal(
             df.a.groupby(c).transform(lambda xs: np.sum(xs)), df['a'])

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -3043,8 +3043,7 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
         c = pd.cut(df.a, bins=[-10, 0, 10, 20, 30, 40])
 
         result = df.a.groupby(c).transform(sum)
-        tm.assert_series_equal(result, df['a'], check_names=False)
-        self.assertTrue(result.name is None)
+        tm.assert_series_equal(result, df['a'])
 
         tm.assert_series_equal(
             df.a.groupby(c).transform(lambda xs: np.sum(xs)), df['a'])

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -1078,6 +1078,12 @@ class TestGroupBy(tm.TestCase):
         expected = expected[['f', 'i']]
         assert_frame_equal(result, expected)
 
+        # dup columns
+        df = pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=['g', 'a', 'a'])
+        result = df.groupby('g').transform('first')
+        expected = df.drop('g', axis=1)
+        assert_frame_equal(result, expected)
+
     def test_transform_broadcast(self):
         grouped = self.ts.groupby(lambda x: x.month)
         result = grouped.transform(np.mean)

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -1051,12 +1051,32 @@ class TestGroupBy(tm.TestCase):
 
         values = np.repeat(grp.mean().values,
                            com._ensure_platform_int(grp.count().values))
-        expected = pd.Series(values, index=df.index)
+        expected = pd.Series(values, index=df.index, name='val')
         result = grp.transform(np.mean)
         assert_series_equal(result, expected)
 
         result = grp.transform('mean')
         assert_series_equal(result, expected)
+
+        # GH 12737
+        df = pd.DataFrame({'grouping': [0, 1, 1, 3], 'f': [1.1, 2.1, 3.1, 4.5],
+                           'd': pd.date_range('2014-1-1', '2014-1-4'),
+                           'i': [1, 2, 3, 4]},
+                          columns=['grouping', 'f', 'i', 'd'])
+        result = df.groupby('grouping').transform('first')
+
+        dates = [pd.Timestamp('2014-1-1'), pd.Timestamp('2014-1-2'),
+                 pd.Timestamp('2014-1-2'), pd.Timestamp('2014-1-4')]
+        expected = pd.DataFrame({'f': [1.1, 2.1, 2.1, 4.5],
+                                 'd': dates,
+                                 'i': [1, 2, 2, 4]},
+                                columns=['f', 'i', 'd'])
+        assert_frame_equal(result, expected)
+
+        # selection
+        result = df.groupby('grouping')[['f', 'i']].transform('first')
+        expected = expected[['f', 'i']]
+        assert_frame_equal(result, expected)
 
     def test_transform_broadcast(self):
         grouped = self.ts.groupby(lambda x: x.month)
@@ -1189,6 +1209,16 @@ class TestGroupBy(tm.TestCase):
 
         result = self.df.groupby('A')['C'].transform('mean')
         expected = self.df.groupby('A')['C'].transform(np.mean)
+        assert_series_equal(result, expected)
+
+    def test_series_fast_transform_date(self):
+        # GH 13191
+        df = pd.DataFrame({'grouping': [np.nan, 1, 1, 3],
+                           'd': pd.date_range('2014-1-1', '2014-1-4')})
+        result = df.groupby('grouping')['d'].transform('first')
+        dates = [pd.NaT, pd.Timestamp('2014-1-2'), pd.Timestamp('2014-1-2'),
+                 pd.Timestamp('2014-1-4')]
+        expected = pd.Series(dates, name='d')
         assert_series_equal(result, expected)
 
     def test_transform_length(self):
@@ -4406,7 +4436,7 @@ class TestGroupBy(tm.TestCase):
 
         df = DataFrame({"A": range(2), "B": [pd.Timestamp('2000-01-1')] * 2})
         result = df.groupby("A")["B"].transform(min)
-        expected = Series([pd.Timestamp('2000-01-1')] * 2)
+        expected = Series([pd.Timestamp('2000-01-1')] * 2, name='B')
         assert_series_equal(result, expected)
 
     def test_groupby_categorical_unequal_len(self):


### PR DESCRIPTION
- [x] closes #12737, 
  closes #13191
- [ ] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

```
    before     after       ratio
  [2de2884 ] [4b352d9 ]
-  164.84ms     1.73ms      0.01  groupby.groupby_transform_dataframe.time_groupby_transform_dataframe
     4.44ms     3.77ms      0.85  groupby.groupby_transform_series.time_groupby_transform_series
     6.40ms     4.76ms      0.74  groupby.groupby_transform_series2.time_groupby_transform_series2
```
