### PR TITLE
CLN: no return on init

### DIFF
--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -893,10 +893,8 @@ class Expanding(_Rolling_and_Expanding):
 
     def __init__(self, obj, min_periods=1, freq=None, center=False, axis=0,
                  **kwargs):
-        return super(Expanding, self).__init__(obj=obj,
-                                               min_periods=min_periods,
-                                               freq=freq, center=center,
-                                               axis=axis)
+        super(Expanding, self).__init__(obj=obj, min_periods=min_periods,
+                                        freq=freq, center=center, axis=axis)
 
     @property
     def _constructor(self):


### PR DESCRIPTION
`__init__` shouldn't return anything
