### PR TITLE
BUG: Period and Series/Index comparison raises TypeError

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -148,4 +148,5 @@ Bug Fixes
 
 - Bug in ``NaT`` - ``Period`` raises ``AttributeError`` (:issue:`13071`)
 - Bug in ``Period`` addition raises ``TypeError`` if ``Period`` is on right hand side (:issue:`13069`)
+- Bug in ``Peirod`` and ``Series`` or ``Index`` comparison raises ``TypeError`` (:issue:`13200`)
 - Bug in ``pd.set_eng_float_format()`` that would prevent NaN's from formatting (:issue:`11981`)

--- a/pandas/src/period.pyx
+++ b/pandas/src/period.pyx
@@ -772,6 +772,9 @@ cdef class Period(object):
             if self.ordinal == tslib.iNaT or other.ordinal == tslib.iNaT:
                 return _nat_scalar_rules[op]
             return PyObject_RichCompareBool(self.ordinal, other.ordinal, op)
+        # index/series like
+        elif hasattr(other, '_typ'):
+            return NotImplemented
         else:
             if op == Py_EQ:
                 return NotImplemented


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
  `Period` and `Series/Index` comparison raises `TypeError` if `Period` is on left hand side.

```
# OK
pd.Series([pd.Period('2011-01-01', freq='D')]) > pd.Period('2011-01-01', freq='D')
#0    False
# dtype: bool

# NG
pd.Period('2011-01-01', freq='D') > pd.Series([pd.Period('2011-01-01', freq='D')])
# TypeError: Cannot compare type 'Period' with type 'Series'
```
