### PR TITLE
Numindexname

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -345,7 +345,8 @@ Bug Fixes
 - Bug in ``pd.read_hdf()`` where attempting to load an HDF file with a single dataset, that had one or more categorical columns, failed unless the key argument was set to the name of the dataset. (:issue:`13231`)
 
 
-
+- Bug in various index types, which did not propagate the name of passed index (:issue:`12309`)
+- Bug in ``DatetimeIndex``, which did not honour the ``copy=True`` (:issue:`13205`)
 - Bug in ``MultiIndex`` slicing where extra elements were returned when level is non-unique (:issue:`12896`)
 
 

--- a/pandas/indexes/base.py
+++ b/pandas/indexes/base.py
@@ -376,6 +376,33 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
                 pass
         return Index(values, **attributes)
 
+    def _deepcopy_if_needed(self, orig, copy=False):
+        """
+        .. versionadded:: 0.18.2
+
+        Make a copy of self if data coincides (in memory) with orig.
+        Subclasses should override this if self._base is not an ndarray.
+
+        Parameters
+        ----------
+        orig : ndarray
+            other ndarray to compare self._data against
+        copy : boolean, default False
+            when False, do not run any check, just return self
+
+        Returns
+        -------
+        A copy of self if needed, otherwise self : Index
+        """
+        if copy:
+            # Retrieve the "base objects", i.e. the original memory allocations
+            orig = orig if orig.base is None else orig.base
+            new = self._data if self._data.base is None else self._data.base
+            if orig is new:
+                return self.copy(deep=True)
+
+        return self
+
     def _update_inplace(self, result, **kwargs):
         # guard when called from IndexOpsMixin
         raise TypeError("Index can't be updated inplace")

--- a/pandas/indexes/category.py
+++ b/pandas/indexes/category.py
@@ -46,6 +46,9 @@ class CategoricalIndex(Index, base.PandasDelegate):
         if fastpath:
             return cls._simple_new(data, name=name)
 
+        if name is None and hasattr(data, 'name'):
+            name = data.name
+
         if isinstance(data, com.ABCCategorical):
             data = cls._create_categorical(cls, data, categories, ordered)
         elif isinstance(data, CategoricalIndex):

--- a/pandas/indexes/numeric.py
+++ b/pandas/indexes/numeric.py
@@ -22,6 +22,28 @@ class NumericIndex(Index):
     """
     _is_numeric_dtype = True
 
+    def __new__(cls, data=None, dtype=None, copy=False, name=None,
+                fastpath=False):
+
+        if fastpath:
+            return cls._simple_new(data, name=name)
+
+        # isscalar, generators handled in coerce_to_ndarray
+        data = cls._coerce_to_ndarray(data)
+
+        if issubclass(data.dtype.type, compat.string_types):
+            cls._string_data_error(data)
+
+        if copy or not com.is_dtype_equal(data.dtype, cls._default_dtype):
+            subarr = np.array(data, dtype=cls._default_dtype, copy=copy)
+            cls._assert_safe_casting(data, subarr)
+        else:
+            subarr = data
+
+        if name is None and hasattr(data, 'name'):
+            name = data.name
+        return cls._simple_new(subarr, name=name)
+
     def _maybe_cast_slice_bound(self, label, side, kind):
         """
         This function should be overloaded in subclasses that allow non-trivial
@@ -54,6 +76,15 @@ class NumericIndex(Index):
         except ValueError:
             raise ValueError('tolerance argument for %s must be numeric: %r' %
                              (type(self).__name__, tolerance))
+
+    @classmethod
+    def _assert_safe_casting(cls, data, subarr):
+        """
+        Subclasses need to override this only if the process of casting data
+        from some accepted dtype to the internal dtype(s) bears the risk of
+        truncation (e.g. float to int).
+        """
+        pass
 
 
 class Int64Index(NumericIndex):
@@ -90,29 +121,7 @@ class Int64Index(NumericIndex):
 
     _engine_type = _index.Int64Engine
 
-    def __new__(cls, data=None, dtype=None, copy=False, name=None,
-                fastpath=False, **kwargs):
-
-        if fastpath:
-            return cls._simple_new(data, name=name)
-
-        # isscalar, generators handled in coerce_to_ndarray
-        data = cls._coerce_to_ndarray(data)
-
-        if issubclass(data.dtype.type, compat.string_types):
-            cls._string_data_error(data)
-
-        elif issubclass(data.dtype.type, np.integer):
-            dtype = np.int64
-            subarr = np.array(data, dtype=dtype, copy=copy)
-        else:
-            subarr = np.array(data, dtype=np.int64, copy=copy)
-            if len(data) > 0:
-                if (subarr != data).any():
-                    raise TypeError('Unsafe NumPy casting to integer, you must'
-                                    ' explicitly cast')
-
-        return cls._simple_new(subarr, name=name)
+    _default_dtype = np.int64
 
     @property
     def inferred_type(self):
@@ -166,6 +175,15 @@ class Int64Index(NumericIndex):
         name = self.name if self.name == other.name else None
         return Int64Index(joined, name=name)
 
+    @classmethod
+    def _assert_safe_casting(cls, data, subarr):
+        """
+        Ensure incoming data can be represented as ints.
+        """
+        if not issubclass(data.dtype.type, np.integer):
+            if not np.array_equal(data, subarr):
+                raise TypeError('Unsafe NumPy casting, you must '
+                                'explicitly cast')
 
 Int64Index._add_numeric_methods()
 Int64Index._add_logical_methods()
@@ -200,39 +218,7 @@ class Float64Index(NumericIndex):
     _inner_indexer = _algos.inner_join_indexer_float64
     _outer_indexer = _algos.outer_join_indexer_float64
 
-    def __new__(cls, data=None, dtype=None, copy=False, name=None,
-                fastpath=False, **kwargs):
-
-        if fastpath:
-            return cls._simple_new(data, name)
-
-        data = cls._coerce_to_ndarray(data)
-
-        if issubclass(data.dtype.type, compat.string_types):
-            cls._string_data_error(data)
-
-        if dtype is None:
-            dtype = np.float64
-        dtype = np.dtype(dtype)
-
-        # allow integer / object dtypes to be passed, but coerce to float64
-        if dtype.kind in ['i', 'O', 'f']:
-            dtype = np.float64
-
-        else:
-            raise TypeError("cannot support {0} dtype in "
-                            "Float64Index".format(dtype))
-
-        try:
-            subarr = np.array(data, dtype=dtype, copy=copy)
-        except:
-            raise TypeError('Unsafe NumPy casting, you must explicitly cast')
-
-        # coerce to float64 for storage
-        if subarr.dtype != np.float64:
-            subarr = subarr.astype(np.float64)
-
-        return cls._simple_new(subarr, name)
+    _default_dtype = np.float64
 
     @property
     def inferred_type(self):
@@ -391,7 +377,6 @@ class Float64Index(NumericIndex):
             self._validate_index_level(level)
         return lib.ismember_nans(np.array(self), value_set,
                                  isnull(list(value_set)).any())
-
 
 Float64Index._add_numeric_methods()
 Float64Index._add_logical_methods_disabled()

--- a/pandas/indexes/numeric.py
+++ b/pandas/indexes/numeric.py
@@ -164,12 +164,8 @@ class Int64Index(NumericIndex):
         if self.is_(other):
             return True
 
-        try:
-            return com.array_equivalent(com._values_from_object(self),
-                                        com._values_from_object(other))
-        except TypeError:
-            # e.g. fails in numpy 1.6 with DatetimeIndex #1681
-            return False
+        return com.array_equivalent(com._values_from_object(self),
+                                    com._values_from_object(other))
 
     def _wrap_joined_index(self, joined, other):
         name = self.name if self.name == other.name else None
@@ -325,8 +321,7 @@ class Float64Index(NumericIndex):
                 return False
             left, right = self._values, other._values
             return ((left == right) | (self._isnan & other._isnan)).all()
-        except TypeError:
-            # e.g. fails in numpy 1.6 with DatetimeIndex #1681
+        except (TypeError, ValueError):
             return False
 
     def __contains__(self, other):

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -372,11 +372,13 @@ starting,ending,measure
         ser_starting.index = ser_starting.values
         ser_starting = ser_starting.tz_localize('US/Eastern')
         ser_starting = ser_starting.tz_convert('UTC')
+        ser_starting.index.name = 'starting'
 
         ser_ending = df.ending
         ser_ending.index = ser_ending.values
         ser_ending = ser_ending.tz_localize('US/Eastern')
         ser_ending = ser_ending.tz_convert('UTC')
+        ser_ending.index.name = 'ending'
 
         df.starting = ser_starting.index
         df.ending = ser_ending.index

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -172,6 +172,7 @@ class TestIndex(Base, tm.TestCase):
         df['date'] = ['1-1-1990', '2-1-1990', '3-1-1990', '4-1-1990',
                       '5-1-1990']
         result = DatetimeIndex(df['date'], freq='MS')
+        expected.name = 'date'
         self.assert_index_equal(result, expected)
         self.assertEqual(df['date'].dtype, object)
 

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -507,6 +507,20 @@ class TestCategoricalIndex(Base, tm.TestCase):
         self.assertTrue(ci1.identical(ci1.copy()))
         self.assertFalse(ci1.identical(ci2))
 
+    def test_ensure_copied_data(self):
+        # Check the "copy" argument of each Index.__new__ is honoured
+        # GH12309
+        # Must be tested separately from other indexes because
+        # self.value is not an ndarray
+        _base = lambda ar : ar if ar.base is None else ar.base
+        for index in self.indices.values():
+            result = CategoricalIndex(index.values, copy=True)
+            tm.assert_index_equal(index, result)
+            self.assertIsNot(_base(index.values), _base(result.values))
+
+            result = CategoricalIndex(index.values, copy=False)
+            self.assertIs(_base(index.values), _base(result.values))
+
     def test_equals(self):
 
         ci1 = CategoricalIndex(['a', 'b'], categories=['a', 'b'], ordered=True)

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -169,8 +169,8 @@ class TestFloat64Index(Numeric, tm.TestCase):
         # explicit construction
         index = Float64Index([1, 2, 3, 4, 5])
         self.assertIsInstance(index, Float64Index)
-        self.assertTrue((index.values == np.array(
-            [1, 2, 3, 4, 5], dtype='float64')).all())
+        expected = np.array([1, 2, 3, 4, 5], dtype='float64')
+        self.assert_numpy_array_equal(index.values, expected)
         index = Float64Index(np.array([1, 2, 3, 4, 5]))
         self.assertIsInstance(index, Float64Index)
         index = Float64Index([1., 2, 3, 4, 5])

--- a/pandas/tests/test_testing.py
+++ b/pandas/tests/test_testing.py
@@ -315,6 +315,17 @@ numpy array values are different \\(50\\.0 %\\)
         with assertRaisesRegexp(AssertionError, expected):
             assert_almost_equal(a, b)
 
+    def test_numpy_array_equal_copy_flag(self):
+        a = np.array([1, 2, 3])
+        b = a.copy()
+        c = a.view()
+        expected = 'array\(\[1, 2, 3\]\) is not array\(\[1, 2, 3\]\)'
+        with assertRaisesRegexp(AssertionError, expected):
+            assert_numpy_array_equal(a, b, check_same='same')
+        expected = 'array\(\[1, 2, 3\]\) is array\(\[1, 2, 3\]\)'
+        with assertRaisesRegexp(AssertionError, expected):
+            assert_numpy_array_equal(a, c, check_same='copy')
+
     def test_assert_almost_equal_iterable_message(self):
 
         expected = """Iterable are different

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -225,6 +225,12 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
                 verify_integrity=True, normalize=False,
                 closed=None, ambiguous='raise', dtype=None, **kwargs):
 
+        # This allows to later ensure that the 'copy' parameter is honored:
+        if isinstance(data, Index):
+            ref_to_data = data._data
+        else:
+            ref_to_data = data
+
         if name is None and hasattr(data, 'name'):
             name = data.name
 
@@ -305,7 +311,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
                             raise TypeError("Already tz-aware, use tz_convert "
                                             "to convert.")
 
-                    return data
+                    return data._deepcopy_if_needed(ref_to_data, copy)
 
         if issubclass(data.dtype.type, compat.string_types):
             data = tslib.parse_str_array_to_datetime(data, freq=freq,
@@ -338,10 +344,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         elif data.dtype == _INT64_DTYPE:
             if isinstance(data, Int64Index):
                 raise TypeError('cannot convert Int64Index->DatetimeIndex')
-            if copy:
-                subarr = np.asarray(data, dtype=_NS_DTYPE)
-            else:
-                subarr = data.view(_NS_DTYPE)
+            subarr = data.view(_NS_DTYPE)
         else:
             if isinstance(data, (ABCSeries, Index)):
                 values = data._values
@@ -417,7 +420,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
             if inferred:
                 subarr.offset = to_offset(inferred)
 
-        return subarr
+        return subarr._deepcopy_if_needed(ref_to_data, copy)
 
     @classmethod
     def _generate(cls, start, end, periods, name, offset,

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -225,6 +225,9 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
                 verify_integrity=True, normalize=False,
                 closed=None, ambiguous='raise', dtype=None, **kwargs):
 
+        if name is None and hasattr(data, 'name'):
+            name = data.name
+
         dayfirst = kwargs.pop('dayfirst', None)
         yearfirst = kwargs.pop('yearfirst', None)
 

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -182,6 +182,9 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
                 raise ValueError('Periods must be a number, got %s' %
                                  str(periods))
 
+        if name is None and hasattr(data, 'name'):
+            name = data.name
+
         if data is None:
             if ordinal is not None:
                 data = np.asarray(ordinal, dtype=np.int64)
@@ -190,7 +193,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
                                                  freq, kwargs)
         else:
             ordinal, freq = cls._from_arraylike(data, freq, tz)
-            data = np.array(ordinal, dtype=np.int64, copy=False)
+            data = np.array(ordinal, dtype=np.int64, copy=copy)
 
         return cls._simple_new(data, name=name, freq=freq)
 

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -138,8 +138,9 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
 
         if isinstance(data, TimedeltaIndex) and freq is None and name is None:
             if copy:
-                data = data.copy()
-            return data
+                return data.copy()
+            else:
+                return data._shallow_copy()
 
         freq_infer = False
         if not isinstance(freq, DateOffset):

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -1739,7 +1739,7 @@ class TestTimedeltaIndex(tm.TestCase):
         kinds = 'outer', 'inner', 'left', 'right'
         for kind in kinds:
             joined = index.join(index, how=kind)
-            self.assertIs(index, joined)
+            tm.assert_index_equal(index, joined)
 
     def test_factorize(self):
         idx1 = TimedeltaIndex(['1 day', '1 day', '2 day', '2 day', '3 day',

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -991,7 +991,7 @@ def raise_assert_detail(obj, message, left, right):
 
 def assert_numpy_array_equal(left, right, strict_nan=False,
                              check_dtype=True, err_msg=None,
-                             obj='numpy array'):
+                             obj='numpy array', check_same=None):
     """ Checks that 'np.ndarray' is equivalent
 
     Parameters
@@ -1007,6 +1007,8 @@ def assert_numpy_array_equal(left, right, strict_nan=False,
     obj : str, default 'numpy array'
         Specify object name being compared, internally used to show appropriate
         assertion message
+    check_same : None|'copy'|'same', default None
+        Ensure "left" and "right refer/do not refer to the same memory area
     """
 
     # instance validation
@@ -1015,6 +1017,14 @@ def assert_numpy_array_equal(left, right, strict_nan=False,
     # both classes must be an np.ndarray
     assertIsInstance(left, np.ndarray, '[ndarray] ')
     assertIsInstance(right, np.ndarray, '[ndarray] ')
+
+    def _get_base(obj):
+        return obj.base if getattr(obj, 'base', None) is not None else obj
+
+    if check_same == 'same':
+        assertIs(_get_base(left), _get_base(right))
+    elif check_same == 'copy':
+        assertIsNot(_get_base(left), _get_base(right))
 
     def _raise(left, right, err_msg):
         if err_msg is None:


### PR DESCRIPTION
- [x] closes #12309
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entries: name passing, unsupported `dtype`s, `copy=true` for `DateTimeIndex`

This is a rebased & updated version of #12331

I would say the [last commit](https://github.com/pydata/pandas/pull/13205/commits/cd89efc88afd6fc5b0e973da4338cefdbea52d51) is the most critical one: it exposes the consequences of making numeric indices only support their default `dtype`. By the way: I had interpreted [your comment](https://github.com/pydata/pandas/pull/12331#discussion_r54882912) as "raise if `dtype` is set", but I don't think this is what we want, since it breaks the obj -> str(obj) -> obj roundtrip. So I raise only if `dtype` is not the expected dtype.
