### PR TITLE
Correct ValueError invalid type promotion exception

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -58,6 +58,9 @@ API changes
 - Calls to ``.sample()`` will respect the random seed set via ``numpy.random.seed(n)`` (:issue:`13161`)
 
 
+- Correct ValueError invalid type promotion exception (:issue:`13234`)
+
+
 .. _whatsnew_0182.api.tolist:
 
 ``Series.tolist()`` will now return Python types

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -336,9 +336,12 @@ class _NDFrameIndexer(object):
                     # this preserves dtype of the value
                     new_values = Series([value])._values
                     if len(self.obj._values):
-                        new_values = np.concatenate([self.obj._values,
-                                                     new_values])
-
+                        try:
+                            new_values = np.concatenate([self.obj._values,
+                                                         new_values])
+                        except TypeError:
+                            new_values = np.concatenate([self.obj.asobject,
+                                                         new_values])
                     self.obj._data = self.obj._constructor(
                         new_values, index=new_index, name=self.obj.name)._data
                     self.obj._maybe_update_cacher(clear=True)

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -287,6 +287,16 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         assert_series_equal(result, expected)
         assert_series_equal(result2, expected)
 
+    def test_type_promotion(self):
+        # GH12599
+        s = pd.Series()
+        s["a"] = pd.Timestamp("2016-01-01")
+        s["b"] = 3.0
+        s["c"] = "foo"
+        expected = Series([pd.Timestamp("2016-01-01"), 3.0, "foo"],
+                          index=["a", "b", "c"])
+        assert_series_equal(s, expected)
+
     def test_getitem_boolean_object(self):
         # using column from DataFrame
 


### PR DESCRIPTION
- [x] closes #12599
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
