### PR TITLE
Fixes resampler for grouping kw bug #13235

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -177,3 +177,4 @@ Bug Fixes
 - Bug in ``Peirod`` and ``Series`` or ``Index`` comparison raises ``TypeError`` (:issue:`13200`)
 - Bug in ``pd.set_eng_float_format()`` that would prevent NaN's from formatting (:issue:`11981`)
 - Bug in ``groupby`` where ``apply`` returns different result depending on whether first result is ``None`` or not (:issue:`12824`)
+- Bug in ``groupby(..).resample(..)`` where the ``label`` keyword causes an error (:issue:`13235`)

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -914,8 +914,7 @@ def get_resampler_for_grouping(groupby, rule, how=None, fill_method=None,
     return _maybe_process_deprecations(r,
                                        how=how,
                                        fill_method=fill_method,
-                                       limit=limit,
-                                       **kwargs)
+                                       limit=limit)
 
 
 class TimeGrouper(Grouper):

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -1732,6 +1732,26 @@ class TestDatetimeIndex(Base, tm.TestCase):
             result = df.groupby(pd.Grouper(freq='M', key='A')).count()
             assert_frame_equal(result, expected)
 
+    def test_resample_groupby_with_label(self):
+        # GH 13235
+        index = date_range('2000-01-01', freq='2D', periods=5)
+        df = DataFrame(index=index,
+                       data={'col0': [0, 0, 1, 1, 2], 'col1': [1, 1, 1, 1, 1]}
+                       )
+        result = df.groupby('col0').resample('1W', label='left').sum()
+
+        mi = [np.array([0, 0, 1, 2]),
+              pd.to_datetime(np.array(['1999-12-26', '2000-01-02',
+                                       '2000-01-02', '2000-01-02'])
+                             )
+              ]
+        mindex = pd.MultiIndex.from_arrays(mi, names=['col0', None])
+        expected = DataFrame(data={'col0': [0, 0, 2, 2], 'col1': [1, 1, 2, 1]},
+                             index=mindex
+                             )
+
+        assert_frame_equal(result, expected)
+
     def test_resample_nunique(self):
 
         # GH 12352


### PR DESCRIPTION
- [x] closes #13235
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
