### PR TITLE
Fix to_gbq method when verbose=False

### DIFF
--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -426,9 +426,8 @@ class GbqConnector(object):
         rows = []
         remaining_rows = len(dataframe)
 
-        if self.verbose:
-            total_rows = remaining_rows
-            self._print("\n\n")
+        total_rows = remaining_rows
+        self._print("\n\n")
 
         for index, row in dataframe.reset_index(drop=True).iterrows():
             row_dict = dict()


### PR DESCRIPTION
Currently the `to_gbq` method fails when `verbose=False`, as the printing of progress is done regardless of the value of the `verbose` flag, and therefore `total_rows` gets called without being set. This change suppresses printing of progress when `verbose=False`.
