### PR TITLE
BUG: remove_unused_categories dtype coerces to int64

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -184,3 +184,5 @@ Bug Fixes
 
 
 - Bug in ``groupby`` where ``apply`` returns different result depending on whether first result is ``None`` or not (:issue:`12824`)
+
+- Bug in ``Categorical.remove_unused_categories()`` changes ``.codes`` dtype to platform int (:issue:`13261`)

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -883,8 +883,8 @@ class Categorical(PandasObject):
         if idx.size != 0 and idx[0] == -1:  # na sentinel
             idx, inv = idx[1:], inv - 1
 
-        cat._codes = inv
         cat._categories = cat.categories.take(idx)
+        cat._codes = _coerce_indexer_dtype(inv, self._categories)
 
         if not inplace:
             return cat

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -1022,14 +1022,14 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
     def test_remove_unused_categories(self):
         c = Categorical(["a", "b", "c", "d", "a"],
                         categories=["a", "b", "c", "d", "e"])
-        exp_categories_all = np.array(["a", "b", "c", "d", "e"])
-        exp_categories_dropped = np.array(["a", "b", "c", "d"])
+        exp_categories_all = Index(["a", "b", "c", "d", "e"])
+        exp_categories_dropped = Index(["a", "b", "c", "d"])
 
         self.assert_numpy_array_equal(c.categories, exp_categories_all)
 
         res = c.remove_unused_categories()
-        self.assert_numpy_array_equal(res.categories, exp_categories_dropped)
-        self.assert_numpy_array_equal(c.categories, exp_categories_all)
+        self.assert_index_equal(res.categories, exp_categories_dropped)
+        self.assert_index_equal(c.categories, exp_categories_all)
 
         res = c.remove_unused_categories(inplace=True)
         self.assert_numpy_array_equal(c.categories, exp_categories_dropped)
@@ -1039,15 +1039,18 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         c = Categorical(["a", "b", "c", np.nan],
                         categories=["a", "b", "c", "d", "e"])
         res = c.remove_unused_categories()
-        self.assert_numpy_array_equal(res.categories,
-                                      np.array(["a", "b", "c"]))
-        self.assert_numpy_array_equal(c.categories, exp_categories_all)
+        self.assert_index_equal(res.categories,
+                                Index(np.array(["a", "b", "c"])))
+        exp_codes = np.array([0, 1, 2, -1], dtype=np.int8)
+        self.assert_numpy_array_equal(res.codes, exp_codes)
+        self.assert_index_equal(c.categories, exp_categories_all)
 
         val = ['F', np.nan, 'D', 'B', 'D', 'F', np.nan]
         cat = pd.Categorical(values=val, categories=list('ABCDEFG'))
         out = cat.remove_unused_categories()
-        self.assert_numpy_array_equal(out.categories, ['B', 'D', 'F'])
-        self.assert_numpy_array_equal(out.codes, [2, -1, 1, 0, 1, 2, -1])
+        self.assert_index_equal(out.categories, Index(['B', 'D', 'F']))
+        exp_codes = np.array([2, -1, 1, 0, 1, 2, -1], dtype=np.int8)
+        self.assert_numpy_array_equal(out.codes, exp_codes)
         self.assertEqual(out.get_values().tolist(), val)
 
         alpha = list('abcdefghijklmnopqrstuvwxyz')


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

```
c = pd.Categorical(['a', 'b'], categories=['a', 'b', 'c'])
c.codes
# array([0, 1], dtype=int8)

# NG, must be int8 dtype
c = c.remove_unused_categories()
c.codes
# array([0, 1])
```

It is because `np.unique` uses platform int for `unique_inverse`

```
np.unique(np.array([0, 3, 2, 3], dtype=np.int8), return_inverse=True)
(array([0, 2, 3], dtype=int8), array([0, 2, 1, 2]))
```
