### PR TITLE
TST/CLN: remove np.assert_equal

### DIFF
--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -15,7 +15,12 @@ if [ "$LINT" ]; then
         if [ $? -ne "0" ]; then
             RET=1
         fi
+
     done
+    grep -r --include '*.py' --exclude nosetester.py --exclude testing.py 'numpy.testing' pandas
+    if [ $? = "0" ]; then
+        RET=1
+    fi
 else
     echo "NOT Linting"
 fi

--- a/pandas/io/tests/json/test_pandas.py
+++ b/pandas/io/tests/json/test_pandas.py
@@ -87,7 +87,7 @@ class TestPandasContainer(tm.TestCase):
                                          orient='index'))
         df_unser = read_json(df.to_json(orient='records'), orient='records')
         assert_index_equal(df.columns, df_unser.columns)
-        np.testing.assert_equal(df.values, df_unser.values)
+        tm.assert_numpy_array_equal(df.values, df_unser.values)
 
     def test_frame_non_unique_index(self):
         df = DataFrame([['a', 'b'], ['c', 'd']], index=[1, 1],
@@ -100,9 +100,9 @@ class TestPandasContainer(tm.TestCase):
                                          orient='split'))
         unser = read_json(df.to_json(orient='records'), orient='records')
         self.assertTrue(df.columns.equals(unser.columns))
-        np.testing.assert_equal(df.values, unser.values)
+        tm.assert_numpy_array_equal(df.values, unser.values)
         unser = read_json(df.to_json(orient='values'), orient='values')
-        np.testing.assert_equal(df.values, unser.values)
+        tm.assert_numpy_array_equal(df.values, unser.values)
 
     def test_frame_non_unique_columns(self):
         df = DataFrame([['a', 'b'], ['c', 'd']], index=[1, 2],
@@ -115,7 +115,7 @@ class TestPandasContainer(tm.TestCase):
         assert_frame_equal(df, read_json(df.to_json(orient='split'),
                                          orient='split', dtype=False))
         unser = read_json(df.to_json(orient='values'), orient='values')
-        np.testing.assert_equal(df.values, unser.values)
+        tm.assert_numpy_array_equal(df.values, unser.values)
 
         # GH4377; duplicate columns not processing correctly
         df = DataFrame([['a', 'b'], ['c', 'd']], index=[
@@ -487,7 +487,7 @@ class TestPandasContainer(tm.TestCase):
                                          orient='split', typ='series'))
         unser = read_json(s.to_json(orient='records'),
                           orient='records', typ='series')
-        np.testing.assert_equal(s.values, unser.values)
+        tm.assert_numpy_array_equal(s.values, unser.values)
 
     def test_series_from_json_to_json(self):
 

--- a/pandas/io/tests/json/test_ujson.py
+++ b/pandas/io/tests/json/test_ujson.py
@@ -21,8 +21,6 @@ import pandas.json as ujson
 import pandas.compat as compat
 
 import numpy as np
-from numpy.testing import (assert_array_almost_equal_nulp,
-                           assert_approx_equal)
 from pandas import DataFrame, Series, Index, NaT, DatetimeIndex
 import pandas.util.testing as tm
 
@@ -1015,19 +1013,19 @@ class NumpyJSONTests(TestCase):
             inpt = arr.astype(dtype)
             outp = np.array(ujson.decode(ujson.encode(
                 inpt, double_precision=15)), dtype=dtype)
-            assert_array_almost_equal_nulp(inpt, outp)
+            tm.assert_almost_equal(inpt, outp)
 
     def testFloatMax(self):
         num = np.float(np.finfo(np.float).max / 10)
-        assert_approx_equal(np.float(ujson.decode(
+        tm.assert_almost_equal(np.float(ujson.decode(
             ujson.encode(num, double_precision=15))), num, 15)
 
         num = np.float32(np.finfo(np.float32).max / 10)
-        assert_approx_equal(np.float32(ujson.decode(
+        tm.assert_almost_equal(np.float32(ujson.decode(
             ujson.encode(num, double_precision=15))), num, 15)
 
         num = np.float64(np.finfo(np.float64).max / 10)
-        assert_approx_equal(np.float64(ujson.decode(
+        tm.assert_almost_equal(np.float64(ujson.decode(
             ujson.encode(num, double_precision=15))), num, 15)
 
     def testArrays(self):
@@ -1067,9 +1065,9 @@ class NumpyJSONTests(TestCase):
         arr = np.arange(100.202, 200.202, 1, dtype=np.float32)
         arr = arr.reshape((5, 5, 4))
         outp = np.array(ujson.decode(ujson.encode(arr)), dtype=np.float32)
-        assert_array_almost_equal_nulp(arr, outp)
+        tm.assert_almost_equal(arr, outp)
         outp = ujson.decode(ujson.encode(arr), numpy=True, dtype=np.float32)
-        assert_array_almost_equal_nulp(arr, outp)
+        tm.assert_almost_equal(arr, outp)
 
     def testOdArray(self):
         def will_raise():

--- a/pandas/io/tests/parser/common.py
+++ b/pandas/io/tests/parser/common.py
@@ -10,7 +10,6 @@ from datetime import datetime
 
 import nose
 import numpy as np
-from numpy.testing.decorators import slow
 from pandas.lib import Timestamp
 
 import pandas as pd
@@ -607,7 +606,7 @@ bar"""
         tm.assert_frame_equal(url_table, local_table)
         # TODO: ftp testing
 
-    @slow
+    @tm.slow
     def test_file(self):
 
         # FILE

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -13,7 +13,6 @@ import nose
 
 from numpy import nan
 import numpy as np
-from numpy.testing.decorators import slow
 
 import pandas as pd
 from pandas import DataFrame, Index, MultiIndex
@@ -544,7 +543,7 @@ class XlrdTests(ReadingTestsBase):
         local_table = self.get_exceldf('test1')
         tm.assert_frame_equal(url_table, local_table)
 
-    @slow
+    @tm.slow
     def test_read_from_file_url(self):
 
         # FILE
@@ -1102,9 +1101,9 @@ class ExcelWriterBase(SharedItems):
             tm.assert_frame_equal(self.frame, recons)
             recons = read_excel(reader, 'test2', index_col=0)
             tm.assert_frame_equal(self.tsframe, recons)
-            np.testing.assert_equal(2, len(reader.sheet_names))
-            np.testing.assert_equal('test1', reader.sheet_names[0])
-            np.testing.assert_equal('test2', reader.sheet_names[1])
+            self.assertEqual(2, len(reader.sheet_names))
+            self.assertEqual('test1', reader.sheet_names[0])
+            self.assertEqual('test2', reader.sheet_names[1])
 
     def test_colaliases(self):
         _skip_if_no_xlrd()

--- a/pandas/io/tests/test_ga.py
+++ b/pandas/io/tests/test_ga.py
@@ -7,8 +7,8 @@ import warnings
 import nose
 import pandas as pd
 from pandas import compat
-from pandas.util.testing import network, assert_frame_equal, with_connectivity_check
-from numpy.testing.decorators import slow
+from pandas.util.testing import (network, assert_frame_equal,
+                                 with_connectivity_check, slow)
 import pandas.util.testing as tm
 
 if compat.PY3:

--- a/pandas/io/tests/test_html.py
+++ b/pandas/io/tests/test_html.py
@@ -16,7 +16,6 @@ import nose
 
 import numpy as np
 from numpy.random import rand
-from numpy.testing.decorators import slow
 
 from pandas import (DataFrame, MultiIndex, read_csv, Timestamp, Index,
                     date_range, Series)
@@ -129,7 +128,7 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
 
         assert_framelist_equal(df1, df2)
 
-    @slow
+    @tm.slow
     def test_banklist(self):
         df1 = self.read_html(self.banklist_data, '.*Florida.*',
                              attrs={'id': 'table'})
@@ -289,9 +288,9 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
                 self.read_html('http://www.a23950sdfa908sd.com',
                                match='.*Water.*')
         except ValueError as e:
-            tm.assert_equal(str(e), 'No tables found')
+            self.assertEqual(str(e), 'No tables found')
 
-    @slow
+    @tm.slow
     def test_file_url(self):
         url = self.banklist_data
         dfs = self.read_html(file_path_to_url(url), 'First',
@@ -300,7 +299,7 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
         for df in dfs:
             tm.assertIsInstance(df, DataFrame)
 
-    @slow
+    @tm.slow
     def test_invalid_table_attrs(self):
         url = self.banklist_data
         with tm.assertRaisesRegexp(ValueError, 'No tables found'):
@@ -311,39 +310,39 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
         return self.read_html(self.banklist_data, 'Metcalf',
                               attrs={'id': 'table'}, *args, **kwargs)
 
-    @slow
+    @tm.slow
     def test_multiindex_header(self):
         df = self._bank_data(header=[0, 1])[0]
         tm.assertIsInstance(df.columns, MultiIndex)
 
-    @slow
+    @tm.slow
     def test_multiindex_index(self):
         df = self._bank_data(index_col=[0, 1])[0]
         tm.assertIsInstance(df.index, MultiIndex)
 
-    @slow
+    @tm.slow
     def test_multiindex_header_index(self):
         df = self._bank_data(header=[0, 1], index_col=[0, 1])[0]
         tm.assertIsInstance(df.columns, MultiIndex)
         tm.assertIsInstance(df.index, MultiIndex)
 
-    @slow
+    @tm.slow
     def test_multiindex_header_skiprows_tuples(self):
         df = self._bank_data(header=[0, 1], skiprows=1, tupleize_cols=True)[0]
         tm.assertIsInstance(df.columns, Index)
 
-    @slow
+    @tm.slow
     def test_multiindex_header_skiprows(self):
         df = self._bank_data(header=[0, 1], skiprows=1)[0]
         tm.assertIsInstance(df.columns, MultiIndex)
 
-    @slow
+    @tm.slow
     def test_multiindex_header_index_skiprows(self):
         df = self._bank_data(header=[0, 1], index_col=[0, 1], skiprows=1)[0]
         tm.assertIsInstance(df.index, MultiIndex)
         tm.assertIsInstance(df.columns, MultiIndex)
 
-    @slow
+    @tm.slow
     def test_regex_idempotency(self):
         url = self.banklist_data
         dfs = self.read_html(file_path_to_url(url),
@@ -371,7 +370,7 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
         zz = [df.iloc[0, 0][0:4] for df in dfs]
         self.assertEqual(sorted(zz), sorted(['Repo', 'What']))
 
-    @slow
+    @tm.slow
     def test_thousands_macau_stats(self):
         all_non_nan_table_index = -2
         macau_data = os.path.join(DATA_PATH, 'macau.html')
@@ -381,7 +380,7 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
 
         self.assertFalse(any(s.isnull().any() for _, s in df.iteritems()))
 
-    @slow
+    @tm.slow
     def test_thousands_macau_index_col(self):
         all_non_nan_table_index = -2
         macau_data = os.path.join(DATA_PATH, 'macau.html')
@@ -522,7 +521,7 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
         self.assertEqual(df.shape[0], nrows)
         self.assertTrue(df.columns.equals(columns))
 
-    @slow
+    @tm.slow
     def test_banklist_header(self):
         from pandas.io.html import _remove_whitespace
 
@@ -561,7 +560,7 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
                                                              coerce=True)
         tm.assert_frame_equal(converted, gtnew)
 
-    @slow
+    @tm.slow
     def test_gold_canyon(self):
         gc = 'Gold Canyon'
         with open(self.banklist_data, 'r') as f:
@@ -663,7 +662,7 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
         assert os.path.isfile(data), '%r is not a file' % data
         assert os.path.getsize(data), '%r is an empty file' % data
         result = self.read_html(data, 'Arizona', header=1)[0]
-        nose.tools.assert_equal(result['sq mi'].dtype, np.dtype('float64'))
+        self.assertEqual(result['sq mi'].dtype, np.dtype('float64'))
 
     def test_bool_header_arg(self):
         # GH 6114
@@ -753,7 +752,7 @@ class TestReadHtmlLxml(tm.TestCase, ReadHtmlMixin):
         tm.assertIsInstance(dfs, list)
         tm.assertIsInstance(dfs[0], DataFrame)
 
-    @slow
+    @tm.slow
     def test_fallback_success(self):
         _skip_if_none_of(('bs4', 'html5lib'))
         banklist_data = os.path.join(DATA_PATH, 'banklist.html')
@@ -796,7 +795,7 @@ def get_elements_from_file(url, element='table'):
     return soup.find_all(element)
 
 
-@slow
+@tm.slow
 def test_bs4_finds_tables():
     filepath = os.path.join(DATA_PATH, "spam.html")
     with warnings.catch_warnings():
@@ -811,13 +810,13 @@ def get_lxml_elements(url, element):
     return doc.xpath('.//{0}'.format(element))
 
 
-@slow
+@tm.slow
 def test_lxml_finds_tables():
     filepath = os.path.join(DATA_PATH, "spam.html")
     assert get_lxml_elements(filepath, 'table')
 
 
-@slow
+@tm.slow
 def test_lxml_finds_tbody():
     filepath = os.path.join(DATA_PATH, "spam.html")
     assert get_lxml_elements(filepath, 'tbody')

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -179,7 +179,7 @@ class TestStata(tm.TestCase):
             w = [x for x in w if x.category is UserWarning]
 
             # should get warning for each call to read_dta
-            tm.assert_equal(len(w), 3)
+            self.assertEqual(len(w), 3)
 
         # buggy test because of the NaT comparison on certain platforms
         # Format 113 test fails since it does not support tc and tC formats
@@ -375,7 +375,7 @@ class TestStata(tm.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 original.to_stata(path, None)
                 # should get a warning for that format.
-            tm.assert_equal(len(w), 1)
+            self.assertEqual(len(w), 1)
 
             written_and_read_again = self.read_dta(path)
             tm.assert_frame_equal(
@@ -403,7 +403,7 @@ class TestStata(tm.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 original.to_stata(path, None)
                 # should get a warning for that format.
-                tm.assert_equal(len(w), 1)
+                self.assertEqual(len(w), 1)
 
             written_and_read_again = self.read_dta(path)
             tm.assert_frame_equal(
@@ -904,7 +904,7 @@ class TestStata(tm.TestCase):
         with warnings.catch_warnings(record=True) as w:
             original.to_stata(path)
             # should get a warning for mixed content
-            tm.assert_equal(len(w), 1)
+            self.assertEqual(len(w), 1)
 
     def test_categorical_with_stata_missing_values(self):
         values = [['a' + str(i)] for i in range(120)]
@@ -986,10 +986,10 @@ class TestStata(tm.TestCase):
         for col in parsed_115:
             if not is_categorical_dtype(parsed_115[col]):
                 continue
-            tm.assert_equal(True, parsed_115[col].cat.ordered)
-            tm.assert_equal(True, parsed_117[col].cat.ordered)
-            tm.assert_equal(False, parsed_115_unordered[col].cat.ordered)
-            tm.assert_equal(False, parsed_117_unordered[col].cat.ordered)
+            self.assertEqual(True, parsed_115[col].cat.ordered)
+            self.assertEqual(True, parsed_117[col].cat.ordered)
+            self.assertEqual(False, parsed_115_unordered[col].cat.ordered)
+            self.assertEqual(False, parsed_117_unordered[col].cat.ordered)
 
     def test_read_chunks_117(self):
         files_117 = [self.dta1_117, self.dta2_117, self.dta3_117,

--- a/pandas/io/tests/test_wb.py
+++ b/pandas/io/tests/test_wb.py
@@ -6,7 +6,6 @@ import pandas
 from pandas.compat import u
 from pandas.util.testing import network
 from pandas.util.testing import assert_frame_equal
-from numpy.testing.decorators import slow
 import pandas.util.testing as tm
 
 # deprecated
@@ -15,7 +14,7 @@ with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
 
 class TestWB(tm.TestCase):
 
-    @slow
+    @tm.slow
     @network
     def test_wdi_search(self):
 
@@ -26,7 +25,7 @@ class TestWB(tm.TestCase):
         result = search('gdp.*capita.*constant')
         self.assertTrue(result.name.str.contains('GDP').any())
 
-    @slow
+    @tm.slow
     @network
     def test_wdi_download(self):
 
@@ -55,7 +54,7 @@ class TestWB(tm.TestCase):
         expected.index = result.index
         assert_frame_equal(result, pandas.DataFrame(expected))
 
-    @slow
+    @tm.slow
     @network
     def test_wdi_download_w_retired_indicator(self):
 
@@ -85,7 +84,7 @@ class TestWB(tm.TestCase):
         if len(result) > 0:
             raise nose.SkipTest("Invalid results")
 
-    @slow
+    @tm.slow
     @network
     def test_wdi_download_w_crash_inducing_countrycode(self):
 
@@ -103,7 +102,7 @@ class TestWB(tm.TestCase):
         if len(result) > 0:
             raise nose.SkipTest("Invalid results")
 
-    @slow
+    @tm.slow
     @network
     def test_wdi_get_countries(self):
         result = get_countries()

--- a/pandas/sparse/tests/test_libsparse.py
+++ b/pandas/sparse/tests/test_libsparse.py
@@ -3,7 +3,6 @@ from pandas import Series
 import nose  # noqa
 import numpy as np
 import operator
-from numpy.testing import assert_equal
 import pandas.util.testing as tm
 
 from pandas import compat
@@ -51,14 +50,15 @@ class TestSparseIndexUnion(tm.TestCase):
             yindex = BlockIndex(TEST_LENGTH, yloc, ylen)
             bresult = xindex.make_union(yindex)
             assert (isinstance(bresult, BlockIndex))
-            assert_equal(bresult.blocs, eloc)
-            assert_equal(bresult.blengths, elen)
+            tm.assert_numpy_array_equal(bresult.blocs, eloc)
+            tm.assert_numpy_array_equal(bresult.blengths, elen)
 
             ixindex = xindex.to_int_index()
             iyindex = yindex.to_int_index()
             iresult = ixindex.make_union(iyindex)
             assert (isinstance(iresult, IntIndex))
-            assert_equal(iresult.indices, bresult.to_int_index().indices)
+            tm.assert_numpy_array_equal(iresult.indices,
+                                        bresult.to_int_index().indices)
 
         """
         x: ----
@@ -411,7 +411,7 @@ class TestBlockIndex(tm.TestCase):
         block = BlockIndex(20, locs, lengths)
         dense = block.to_int_index()
 
-        assert_equal(dense.indices, exp_inds)
+        tm.assert_numpy_array_equal(dense.indices, exp_inds)
 
     def test_to_block_index(self):
         index = BlockIndex(10, [0, 5], [4, 5])
@@ -489,7 +489,7 @@ class TestSparseOperators(tm.TestCase):
                                                   ydindex, yfill)
 
             self.assertTrue(rb_index.to_int_index().equals(ri_index))
-            assert_equal(result_block_vals, result_int_vals)
+            tm.assert_numpy_array_equal(result_block_vals, result_int_vals)
 
             # check versus Series...
             xseries = Series(x, xdindex.indices)
@@ -501,8 +501,9 @@ class TestSparseOperators(tm.TestCase):
             series_result = python_op(xseries, yseries)
             series_result = series_result.reindex(ri_index.indices)
 
-            assert_equal(result_block_vals, series_result.values)
-            assert_equal(result_int_vals, series_result.values)
+            tm.assert_numpy_array_equal(result_block_vals,
+                                        series_result.values)
+            tm.assert_numpy_array_equal(result_int_vals, series_result.values)
 
         check_cases(_check_case)
 

--- a/pandas/stats/tests/test_ols.py
+++ b/pandas/stats/tests/test_ols.py
@@ -13,7 +13,6 @@ from pandas import compat
 from distutils.version import LooseVersion
 import nose
 import numpy as np
-from numpy.testing.decorators import slow
 
 from pandas import date_range, bdate_range
 from pandas.core.panel import Panel
@@ -22,7 +21,7 @@ from pandas.stats.api import ols
 from pandas.stats.ols import _filter_data
 from pandas.stats.plm import NonPooledPanelOLS, PanelOLS
 from pandas.util.testing import (assert_almost_equal, assert_series_equal,
-                                 assert_frame_equal, assertRaisesRegexp)
+                                 assert_frame_equal, assertRaisesRegexp, slow)
 import pandas.util.testing as tm
 import pandas.compat as compat
 from .common import BaseTest

--- a/pandas/stats/tests/test_var.py
+++ b/pandas/stats/tests/test_var.py
@@ -1,9 +1,8 @@
 # flake8: noqa
 
 from __future__ import print_function
-from numpy.testing import run_module_suite, assert_equal, TestCase
 
-from pandas.util.testing import assert_almost_equal
+import pandas.util.testing as tm
 
 from pandas.compat import range
 import nose
@@ -33,53 +32,56 @@ DECIMAL_2 = 2
 class CheckVAR(object):
 
     def test_params(self):
-        assert_almost_equal(self.res1.params, self.res2.params, DECIMAL_3)
+        tm.assert_almost_equal(self.res1.params, self.res2.params, DECIMAL_3)
 
     def test_neqs(self):
-        assert_equal(self.res1.neqs, self.res2.neqs)
+        tm.assert_numpy_array_equal(self.res1.neqs, self.res2.neqs)
 
     def test_nobs(self):
-        assert_equal(self.res1.avobs, self.res2.nobs)
+        tm.assert_numpy_array_equal(self.res1.avobs, self.res2.nobs)
 
     def test_df_eq(self):
-        assert_equal(self.res1.df_eq, self.res2.df_eq)
+        tm.assert_numpy_array_equal(self.res1.df_eq, self.res2.df_eq)
 
     def test_rmse(self):
         results = self.res1.results
         for i in range(len(results)):
-            assert_almost_equal(results[i].mse_resid ** .5,
-                                eval('self.res2.rmse_' + str(i + 1)), DECIMAL_6)
+            tm.assert_almost_equal(results[i].mse_resid ** .5,
+                                   eval('self.res2.rmse_' + str(i + 1)),
+                                   DECIMAL_6)
 
     def test_rsquared(self):
         results = self.res1.results
         for i in range(len(results)):
-            assert_almost_equal(results[i].rsquared,
-                                eval('self.res2.rsquared_' + str(i + 1)), DECIMAL_3)
+            tm.assert_almost_equal(results[i].rsquared,
+                                   eval('self.res2.rsquared_' + str(i + 1)),
+                                   DECIMAL_3)
 
     def test_llf(self):
         results = self.res1.results
-        assert_almost_equal(self.res1.llf, self.res2.llf, DECIMAL_2)
+        tm.assert_almost_equal(self.res1.llf, self.res2.llf, DECIMAL_2)
         for i in range(len(results)):
-            assert_almost_equal(results[i].llf,
-                                eval('self.res2.llf_' + str(i + 1)), DECIMAL_2)
+            tm.assert_almost_equal(results[i].llf,
+                                   eval('self.res2.llf_' + str(i + 1)),
+                                   DECIMAL_2)
 
     def test_aic(self):
-        assert_almost_equal(self.res1.aic, self.res2.aic)
+        tm.assert_almost_equal(self.res1.aic, self.res2.aic)
 
     def test_bic(self):
-        assert_almost_equal(self.res1.bic, self.res2.bic)
+        tm.assert_almost_equal(self.res1.bic, self.res2.bic)
 
     def test_hqic(self):
-        assert_almost_equal(self.res1.hqic, self.res2.hqic)
+        tm.assert_almost_equal(self.res1.hqic, self.res2.hqic)
 
     def test_fpe(self):
-        assert_almost_equal(self.res1.fpe, self.res2.fpe)
+        tm.assert_almost_equal(self.res1.fpe, self.res2.fpe)
 
     def test_detsig(self):
-        assert_almost_equal(self.res1.detomega, self.res2.detsig)
+        tm.assert_almost_equal(self.res1.detomega, self.res2.detsig)
 
     def test_bse(self):
-        assert_almost_equal(self.res1.bse, self.res2.bse, DECIMAL_4)
+        tm.assert_almost_equal(self.res1.bse, self.res2.bse, DECIMAL_4)
 
 
 class Foo(object):

--- a/pandas/tests/frame/test_misc_api.py
+++ b/pandas/tests/frame/test_misc_api.py
@@ -391,7 +391,7 @@ class TestDataFrameMisc(tm.TestCase, SharedWithSparse, TestData):
                        index=[[pd.NaT, pd.Timestamp('20130101')], ['a', 'b']])
         res = repr(df)
         exp = '              X\nNaT        a  1\n2013-01-01 b  2'
-        nose.tools.assert_equal(res, exp)
+        self.assertEqual(res, exp)
 
     def test_iterkv_deprecation(self):
         with tm.assert_produces_warning(FutureWarning):

--- a/pandas/tests/frame/test_repr_info.py
+++ b/pandas/tests/frame/test_repr_info.py
@@ -14,7 +14,6 @@ from pandas.compat import StringIO, lrange, u
 import pandas.formats.format as fmt
 import pandas as pd
 
-from numpy.testing.decorators import slow
 import pandas.util.testing as tm
 
 from pandas.tests.frame.common import TestData
@@ -43,7 +42,7 @@ class TestDataFrameReprInfoEtc(tm.TestCase, TestData):
         foo = repr(self.mixed_frame)  # noqa
         self.mixed_frame.info(verbose=False, buf=buf)
 
-    @slow
+    @tm.slow
     def test_repr_mixed_big(self):
         # big mixed
         biggie = DataFrame({'A': np.random.randn(200),
@@ -90,7 +89,7 @@ class TestDataFrameReprInfoEtc(tm.TestCase, TestData):
         with option_context('display.show_dimensions', 'truncate'):
             self.assertFalse("2 rows x 2 columns" in repr(df))
 
-    @slow
+    @tm.slow
     def test_repr_big(self):
         # big one
         biggie = DataFrame(np.zeros((200, 4)), columns=lrange(4),

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -14,14 +14,11 @@ from pandas import (DataFrame, Index, Series, MultiIndex, Timestamp,
 import pandas as pd
 
 from pandas.util.testing import (assert_almost_equal,
-                                 assert_equal,
                                  assert_series_equal,
                                  assert_frame_equal,
                                  ensure_clean,
                                  makeCustomDataframe as mkdf,
-                                 assertRaisesRegexp)
-
-from numpy.testing.decorators import slow
+                                 assertRaisesRegexp, slow)
 import pandas.util.testing as tm
 
 from pandas.tests.frame.common import TestData
@@ -453,7 +450,7 @@ class TestDataFrameToCSV(tm.TestCase, TestData):
         df = DataFrame({0: ['a', 'b', 'c'],
                         1: ['aa', 'bb', 'cc']})
         df['test'] = 'txt'
-        assert_equal(df.to_csv(), df.to_csv(columns=[0, 1, 'test']))
+        self.assertEqual(df.to_csv(), df.to_csv(columns=[0, 1, 'test']))
 
     def test_to_csv_headers(self):
         # GH6186, the presence or absence of `index` incorrectly
@@ -508,8 +505,7 @@ class TestDataFrameToCSV(tm.TestCase, TestData):
             # do not load index
             tsframe.to_csv(path)
             recons = DataFrame.from_csv(path, index_col=None)
-            np.testing.assert_equal(
-                len(recons.columns), len(tsframe.columns) + 2)
+            self.assertEqual(len(recons.columns), len(tsframe.columns) + 2)
 
             # no index
             tsframe.to_csv(path, index=False)

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -358,7 +358,7 @@ class TestFloat64Index(Numeric, tm.TestCase):
         index = Index([1.0, np.nan, 0.2], dtype='object')
         result = index.astype(float)
         expected = Float64Index([1.0, np.nan, 0.2])
-        tm.assert_equal(result.dtype, expected.dtype)
+        self.assertEqual(result.dtype, expected.dtype)
         tm.assert_index_equal(result, expected)
 
     def test_fillna_float64(self):

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -20,14 +20,14 @@ from pandas.core.api import (DataFrame, Index, Series, Panel, isnull,
                              MultiIndex, Timestamp, Timedelta)
 from pandas.util.testing import (assert_almost_equal, assert_series_equal,
                                  assert_frame_equal, assert_panel_equal,
-                                 assert_attr_equal)
+                                 assert_attr_equal, slow)
 from pandas.formats.printing import pprint_thing
 from pandas import concat, lib
 from pandas.core.common import PerformanceWarning
 
 import pandas.util.testing as tm
 from pandas import date_range
-from numpy.testing.decorators import slow
+
 
 _verbose = False
 

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1356,7 +1356,7 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         s = Series([1, 2, 90, 1000, 3e9])
         r = s.searchsorted(30)
         e = 2
-        tm.assert_equal(r, e)
+        self.assertEqual(r, e)
 
         r = s.searchsorted([30])
         e = np.array([2], dtype=np.int64)
@@ -1373,7 +1373,7 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         v = pd.Timestamp('20120102')
         r = s.searchsorted(v)
         e = 1
-        tm.assert_equal(r, e)
+        self.assertEqual(r, e)
 
     def test_search_sorted_datetime64_list(self):
         s = Series(pd.date_range('20120101', periods=10, freq='2D'))

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -1420,7 +1420,7 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
     def test_slicing_directly(self):
         cat = Categorical(["a", "b", "c", "d", "a", "b", "c"])
         sliced = cat[3]
-        tm.assert_equal(sliced, "d")
+        self.assertEqual(sliced, "d")
         sliced = cat[3:5]
         expected = Categorical(["d", "a"], categories=['a', 'b', 'c', 'd'])
         self.assert_numpy_array_equal(sliced._codes, expected._codes)

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -15,10 +15,10 @@ from pandas.computation import expressions as expr
 from pandas import compat
 from pandas.util.testing import (assert_almost_equal, assert_series_equal,
                                  assert_frame_equal, assert_panel_equal,
-                                 assert_panel4d_equal)
+                                 assert_panel4d_equal, slow)
 from pandas.formats.printing import pprint_thing
 import pandas.util.testing as tm
-from numpy.testing.decorators import slow
+
 
 if not expr._USE_NUMEXPR:
     try:

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -21,8 +21,7 @@ from pandas.util.testing import (assertRaisesRegexp,
                                  assert_frame_equal,
                                  assert_panel_equal,
                                  assert_panel4d_equal,
-                                 assert_almost_equal,
-                                 assert_equal)
+                                 assert_almost_equal)
 
 import pandas.util.testing as tm
 
@@ -1346,7 +1345,7 @@ class TestDataFrame(tm.TestCase, Generic):
         df['y'] = [2, 4, 6]
         df.y = 5
 
-        assert_equal(df.y, 5)
+        self.assertEqual(df.y, 5)
         assert_series_equal(df['y'], Series([2, 4, 6], name='y'))
 
     def test_pct_change(self):

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -19,7 +19,7 @@ from pandas.formats.printing import pprint_thing
 import pandas.core.common as com
 import pandas.util.testing as tm
 from pandas.util.testing import (ensure_clean,
-                                 assert_is_valid_plot_return_object)
+                                 assert_is_valid_plot_return_object, slow)
 
 from pandas.core.config import set_option
 
@@ -27,8 +27,6 @@ import numpy as np
 from numpy import random
 from numpy.random import rand, randn
 
-from numpy.testing import assert_allclose
-from numpy.testing.decorators import slow
 import pandas.tools.plotting as plotting
 """
 These tests are for ``Dataframe.plot`` and ``Series.plot``.
@@ -140,7 +138,7 @@ class TestPlotBase(tm.TestCase):
         def check_line(xpl, rsl):
             xpdata = xpl.get_xydata()
             rsdata = rsl.get_xydata()
-            assert_allclose(xpdata, rsdata)
+            tm.assert_almost_equal(xpdata, rsdata)
 
         self.assertEqual(len(xp_lines), len(rs_lines))
         [check_line(xpl, rsl) for xpl, rsl in zip(xp_lines, rs_lines)]

--- a/pandas/tests/test_graphics_others.py
+++ b/pandas/tests/test_graphics_others.py
@@ -11,12 +11,12 @@ from distutils.version import LooseVersion
 from pandas import Series, DataFrame, MultiIndex
 from pandas.compat import range, lmap, lzip
 import pandas.util.testing as tm
+from pandas.util.testing import slow
 
 import numpy as np
 from numpy import random
 from numpy.random import randn
 
-from numpy.testing.decorators import slow
 import pandas.tools.plotting as plotting
 
 from pandas.tests.test_graphics import (TestPlotBase, _check_plot_works,

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -31,7 +31,6 @@ import pandas.core.nanops as nanops
 
 import pandas.util.testing as tm
 import pandas as pd
-from numpy.testing import assert_equal
 
 
 class TestGroupBy(tm.TestCase):
@@ -4621,10 +4620,10 @@ class TestGroupBy(tm.TestCase):
         import pytz
 
         df = pd.DataFrame({'a': [1], 'b': [datetime.now(pytz.utc)]})
-        tm.assert_equal(df['b'][0].tzinfo, pytz.utc)
+        self.assertEqual(df['b'][0].tzinfo, pytz.utc)
         df = pd.DataFrame({'a': [1, 2, 3]})
         df['b'] = datetime.now(pytz.utc)
-        tm.assert_equal(df['b'][0].tzinfo, pytz.utc)
+        self.assertEqual(df['b'][0].tzinfo, pytz.utc)
 
     def test_groupby_with_timegrouper(self):
         # GH 4161
@@ -5855,24 +5854,24 @@ class TestGroupBy(tm.TestCase):
         # orders=True, na_position='last'
         result = _lexsort_indexer(keys, orders=True, na_position='last')
         expected = list(range(5, 105)) + list(range(5)) + list(range(105, 110))
-        assert_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         # orders=True, na_position='first'
         result = _lexsort_indexer(keys, orders=True, na_position='first')
         expected = list(range(5)) + list(range(105, 110)) + list(range(5, 105))
-        assert_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         # orders=False, na_position='last'
         result = _lexsort_indexer(keys, orders=False, na_position='last')
         expected = list(range(104, 4, -1)) + list(range(5)) + list(range(105,
                                                                          110))
-        assert_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         # orders=False, na_position='first'
         result = _lexsort_indexer(keys, orders=False, na_position='first')
         expected = list(range(5)) + list(range(105, 110)) + list(range(104, 4,
                                                                        -1))
-        assert_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_nargsort(self):
         # np.argsort(items) places NaNs last
@@ -5899,53 +5898,53 @@ class TestGroupBy(tm.TestCase):
         result = _nargsort(items, kind='mergesort', ascending=True,
                            na_position='last')
         expected = list(range(5, 105)) + list(range(5)) + list(range(105, 110))
-        assert_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         # mergesort, ascending=True, na_position='first'
         result = _nargsort(items, kind='mergesort', ascending=True,
                            na_position='first')
         expected = list(range(5)) + list(range(105, 110)) + list(range(5, 105))
-        assert_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         # mergesort, ascending=False, na_position='last'
         result = _nargsort(items, kind='mergesort', ascending=False,
                            na_position='last')
         expected = list(range(104, 4, -1)) + list(range(5)) + list(range(105,
                                                                          110))
-        assert_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         # mergesort, ascending=False, na_position='first'
         result = _nargsort(items, kind='mergesort', ascending=False,
                            na_position='first')
         expected = list(range(5)) + list(range(105, 110)) + list(range(104, 4,
                                                                        -1))
-        assert_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         # mergesort, ascending=True, na_position='last'
         result = _nargsort(items2, kind='mergesort', ascending=True,
                            na_position='last')
         expected = list(range(5, 105)) + list(range(5)) + list(range(105, 110))
-        assert_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         # mergesort, ascending=True, na_position='first'
         result = _nargsort(items2, kind='mergesort', ascending=True,
                            na_position='first')
         expected = list(range(5)) + list(range(105, 110)) + list(range(5, 105))
-        assert_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         # mergesort, ascending=False, na_position='last'
         result = _nargsort(items2, kind='mergesort', ascending=False,
                            na_position='last')
         expected = list(range(104, 4, -1)) + list(range(5)) + list(range(105,
                                                                          110))
-        assert_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         # mergesort, ascending=False, na_position='first'
         result = _nargsort(items2, kind='mergesort', ascending=False,
                            na_position='first')
         expected = list(range(5)) + list(range(105, 110)) + list(range(104, 4,
                                                                        -1))
-        assert_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_datetime_count(self):
         df = DataFrame({'a': [1, 2, 3] * 2,

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -873,17 +873,15 @@ class TestNanvarFixedValues(tm.TestCase):
         for axis in range(2):
             for ddof in range(3):
                 var = nanops.nanvar(samples, skipna=True, axis=axis, ddof=ddof)
-                np.testing.assert_array_almost_equal(var[:3],
-                                                     variance[axis, ddof])
-                np.testing.assert_equal(var[3], np.nan)
+                tm.assert_almost_equal(var[:3], variance[axis, ddof])
+                self.assertTrue(np.isnan(var[3]))
 
         # Test nanstd.
         for axis in range(2):
             for ddof in range(3):
                 std = nanops.nanstd(samples, skipna=True, axis=axis, ddof=ddof)
-                np.testing.assert_array_almost_equal(
-                    std[:3], variance[axis, ddof] ** 0.5)
-                np.testing.assert_equal(std[3], np.nan)
+                tm.assert_almost_equal(std[:3], variance[axis, ddof] ** 0.5)
+                self.assertTrue(np.isnan(std[3]))
 
     def test_nanstd_roundoff(self):
         # Regression test for GH 10242 (test data taken from GH 10489). Ensure

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -573,7 +573,7 @@ class TestStringMethods(tm.TestCase):
             # single group renames series/index properly
             s_or_idx = klass(['A1', 'A2'])
             result = s_or_idx.str.extract(r'(?P<uno>A)\d', expand=False)
-            tm.assert_equal(result.name, 'uno')
+            self.assertEqual(result.name, 'uno')
             tm.assert_numpy_array_equal(result, klass(['A', 'A']))
 
         s = Series(['A1', 'B2', 'C3'])
@@ -1105,7 +1105,7 @@ class TestStringMethods(tm.TestCase):
         # (extract) on empty series
 
         tm.assert_series_equal(empty_str, empty.str.cat(empty))
-        tm.assert_equal('', empty.str.cat())
+        self.assertEqual('', empty.str.cat())
         tm.assert_series_equal(empty_str, empty.str.title())
         tm.assert_series_equal(empty_int, empty.str.count('a'))
         tm.assert_series_equal(empty_bool, empty.str.contains('a'))

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -6,7 +6,6 @@ import warnings
 from nose.tools import assert_raises
 from datetime import datetime
 from numpy.random import randn
-from numpy.testing.decorators import slow
 import numpy as np
 from distutils.version import LooseVersion
 
@@ -15,7 +14,8 @@ from pandas import (Series, DataFrame, Panel, bdate_range, isnull,
                     notnull, concat)
 from pandas.util.testing import (assert_almost_equal, assert_series_equal,
                                  assert_frame_equal, assert_panel_equal,
-                                 assert_index_equal, assert_numpy_array_equal)
+                                 assert_index_equal, assert_numpy_array_equal,
+                                 slow)
 import pandas.core.datetools as datetools
 import pandas.stats.moments as mom
 import pandas.core.window as rwindow

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -17,12 +17,12 @@ from pandas import Categorical, Timestamp
 from pandas.util.testing import (assert_frame_equal, assert_series_equal,
                                  assert_almost_equal,
                                  makeCustomDataframe as mkdf,
-                                 assertRaisesRegexp)
+                                 assertRaisesRegexp, slow)
 from pandas import (isnull, DataFrame, Index, MultiIndex, Panel,
                     Series, date_range, read_csv)
 import pandas.algos as algos
 import pandas.util.testing as tm
-from numpy.testing.decorators import slow
+
 
 a_ = np.array
 

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -1,13 +1,12 @@
 from datetime import datetime, date, timedelta
 
 import numpy as np
-from numpy.testing import assert_equal
 
 import pandas as pd
 from pandas import DataFrame, Series, Index, MultiIndex, Grouper
 from pandas.tools.merge import concat
 from pandas.tools.pivot import pivot_table, crosstab
-from pandas.compat import range, u, product
+from pandas.compat import range, product
 import pandas.util.testing as tm
 
 
@@ -80,21 +79,13 @@ class TestPivotTable(tm.TestCase):
         pv_ind = df.pivot_table(
             'quantity', ['customer', 'product'], 'month', dropna=False)
 
-        m = MultiIndex.from_tuples([(u('A'), u('a')),
-                                    (u('A'), u('b')),
-                                    (u('A'), u('c')),
-                                    (u('A'), u('d')),
-                                    (u('B'), u('a')),
-                                    (u('B'), u('b')),
-                                    (u('B'), u('c')),
-                                    (u('B'), u('d')),
-                                    (u('C'), u('a')),
-                                    (u('C'), u('b')),
-                                    (u('C'), u('c')),
-                                    (u('C'), u('d'))])
-
-        assert_equal(pv_col.columns.values, m.values)
-        assert_equal(pv_ind.index.values, m.values)
+        m = MultiIndex.from_tuples([('A', 'a'), ('A', 'b'), ('A', 'c'),
+                                    ('A', 'd'), ('B', 'a'), ('B', 'b'),
+                                    ('B', 'c'), ('B', 'd'), ('C', 'a'),
+                                    ('C', 'b'), ('C', 'c'), ('C', 'd')],
+                                   names=['customer', 'product'])
+        tm.assert_index_equal(pv_col.columns, m)
+        tm.assert_index_equal(pv_ind.index, m)
 
     def test_pass_array(self):
         result = self.data.pivot_table(
@@ -902,8 +893,9 @@ class TestCrosstab(tm.TestCase):
         res = pd.crosstab(a, [b, c], rownames=['a'],
                           colnames=['b', 'c'], dropna=False)
         m = MultiIndex.from_tuples([('one', 'dull'), ('one', 'shiny'),
-                                    ('two', 'dull'), ('two', 'shiny')])
-        assert_equal(res.columns.values, m.values)
+                                    ('two', 'dull'), ('two', 'shiny')],
+                                   names=['b', 'c'])
+        tm.assert_index_equal(res.columns, m)
 
     def test_categorical_margins(self):
         # GH 10989

--- a/pandas/tools/tests/test_util.py
+++ b/pandas/tools/tests/test_util.py
@@ -4,7 +4,6 @@ import codecs
 import nose
 
 import numpy as np
-from numpy.testing import assert_equal
 
 import pandas as pd
 from pandas import date_range, Index
@@ -22,7 +21,7 @@ class TestCartesianProduct(tm.TestCase):
         result = cartesian_product([x, y])
         expected = [np.array(['A', 'A', 'B', 'B', 'C', 'C']),
                     np.array([1, 22, 1, 22, 1, 22])]
-        assert_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_datetimeindex(self):
         # regression test for GitHub issue #6439
@@ -30,7 +29,7 @@ class TestCartesianProduct(tm.TestCase):
         x = date_range('2000-01-01', periods=2)
         result = [Index(y).day for y in cartesian_product([x, x])]
         expected = [np.array([1, 1, 2, 2]), np.array([1, 2, 1, 2])]
-        assert_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
 
 class TestLocaleUtils(tm.TestCase):

--- a/pandas/tseries/tests/test_converter.py
+++ b/pandas/tseries/tests/test_converter.py
@@ -3,7 +3,6 @@ from datetime import datetime, date
 import nose
 
 import numpy as np
-from numpy.testing import assert_almost_equal as np_assert_almost_equal
 from pandas import Timestamp, Period
 from pandas.compat import u
 import pandas.util.testing as tm
@@ -69,14 +68,14 @@ class TestDateTimeConverter(tm.TestCase):
         rs = self.dtc.convert(
             Timestamp('2012-1-1 01:02:03', tz='UTC'), None, None)
         xp = converter.dates.date2num(Timestamp('2012-1-1 01:02:03', tz='UTC'))
-        np_assert_almost_equal(rs, xp, decimals)
+        tm.assert_almost_equal(rs, xp, decimals)
 
         rs = self.dtc.convert(
             Timestamp('2012-1-1 09:02:03', tz='Asia/Hong_Kong'), None, None)
-        np_assert_almost_equal(rs, xp, decimals)
+        tm.assert_almost_equal(rs, xp, decimals)
 
         rs = self.dtc.convert(datetime(2012, 1, 1, 1, 2, 3), None, None)
-        np_assert_almost_equal(rs, xp, decimals)
+        tm.assert_almost_equal(rs, xp, decimals)
 
     def test_time_formatter(self):
         self.tc(90000)
@@ -88,7 +87,7 @@ class TestDateTimeConverter(tm.TestCase):
             dateindex = tm.makeDateIndex(k=10, freq=freq)
             rs = self.dtc.convert(dateindex, None, None)
             xp = converter.dates.date2num(dateindex._mpl_repr())
-            np_assert_almost_equal(rs, xp, decimals)
+            tm.assert_almost_equal(rs, xp, decimals)
 
     def test_resolution(self):
         def _assert_less(ts1, ts2):

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -8,8 +8,6 @@ Parts derived from scikits.timeseries code, original authors:
 
 from datetime import datetime, date, timedelta
 
-from numpy.ma.testutils import assert_equal
-
 from pandas import Timestamp
 from pandas.tseries.frequencies import MONTHS, DAYS, _period_code_map
 from pandas.tseries.period import Period, PeriodIndex, period_range
@@ -625,7 +623,7 @@ class TestPeriodProperties(tm.TestCase):
     def test_properties_annually(self):
         # Test properties on Periods with annually frequency.
         a_date = Period(freq='A', year=2007)
-        assert_equal(a_date.year, 2007)
+        self.assertEqual(a_date.year, 2007)
 
     def test_properties_quarterly(self):
         # Test properties on Periods with daily frequency.
@@ -635,78 +633,78 @@ class TestPeriodProperties(tm.TestCase):
         #
         for x in range(3):
             for qd in (qedec_date, qejan_date, qejun_date):
-                assert_equal((qd + x).qyear, 2007)
-                assert_equal((qd + x).quarter, x + 1)
+                self.assertEqual((qd + x).qyear, 2007)
+                self.assertEqual((qd + x).quarter, x + 1)
 
     def test_properties_monthly(self):
         # Test properties on Periods with daily frequency.
         m_date = Period(freq='M', year=2007, month=1)
         for x in range(11):
             m_ival_x = m_date + x
-            assert_equal(m_ival_x.year, 2007)
+            self.assertEqual(m_ival_x.year, 2007)
             if 1 <= x + 1 <= 3:
-                assert_equal(m_ival_x.quarter, 1)
+                self.assertEqual(m_ival_x.quarter, 1)
             elif 4 <= x + 1 <= 6:
-                assert_equal(m_ival_x.quarter, 2)
+                self.assertEqual(m_ival_x.quarter, 2)
             elif 7 <= x + 1 <= 9:
-                assert_equal(m_ival_x.quarter, 3)
+                self.assertEqual(m_ival_x.quarter, 3)
             elif 10 <= x + 1 <= 12:
-                assert_equal(m_ival_x.quarter, 4)
-            assert_equal(m_ival_x.month, x + 1)
+                self.assertEqual(m_ival_x.quarter, 4)
+            self.assertEqual(m_ival_x.month, x + 1)
 
     def test_properties_weekly(self):
         # Test properties on Periods with daily frequency.
         w_date = Period(freq='W', year=2007, month=1, day=7)
         #
-        assert_equal(w_date.year, 2007)
-        assert_equal(w_date.quarter, 1)
-        assert_equal(w_date.month, 1)
-        assert_equal(w_date.week, 1)
-        assert_equal((w_date - 1).week, 52)
-        assert_equal(w_date.days_in_month, 31)
-        assert_equal(Period(freq='W', year=2012,
-                            month=2, day=1).days_in_month, 29)
+        self.assertEqual(w_date.year, 2007)
+        self.assertEqual(w_date.quarter, 1)
+        self.assertEqual(w_date.month, 1)
+        self.assertEqual(w_date.week, 1)
+        self.assertEqual((w_date - 1).week, 52)
+        self.assertEqual(w_date.days_in_month, 31)
+        self.assertEqual(Period(freq='W', year=2012,
+                                month=2, day=1).days_in_month, 29)
 
     def test_properties_weekly_legacy(self):
         # Test properties on Periods with daily frequency.
         with tm.assert_produces_warning(FutureWarning):
             w_date = Period(freq='WK', year=2007, month=1, day=7)
         #
-        assert_equal(w_date.year, 2007)
-        assert_equal(w_date.quarter, 1)
-        assert_equal(w_date.month, 1)
-        assert_equal(w_date.week, 1)
-        assert_equal((w_date - 1).week, 52)
-        assert_equal(w_date.days_in_month, 31)
+        self.assertEqual(w_date.year, 2007)
+        self.assertEqual(w_date.quarter, 1)
+        self.assertEqual(w_date.month, 1)
+        self.assertEqual(w_date.week, 1)
+        self.assertEqual((w_date - 1).week, 52)
+        self.assertEqual(w_date.days_in_month, 31)
         with tm.assert_produces_warning(FutureWarning):
             exp = Period(freq='WK', year=2012, month=2, day=1)
-        assert_equal(exp.days_in_month, 29)
+        self.assertEqual(exp.days_in_month, 29)
 
     def test_properties_daily(self):
         # Test properties on Periods with daily frequency.
         b_date = Period(freq='B', year=2007, month=1, day=1)
         #
-        assert_equal(b_date.year, 2007)
-        assert_equal(b_date.quarter, 1)
-        assert_equal(b_date.month, 1)
-        assert_equal(b_date.day, 1)
-        assert_equal(b_date.weekday, 0)
-        assert_equal(b_date.dayofyear, 1)
-        assert_equal(b_date.days_in_month, 31)
-        assert_equal(Period(freq='B', year=2012,
-                            month=2, day=1).days_in_month, 29)
+        self.assertEqual(b_date.year, 2007)
+        self.assertEqual(b_date.quarter, 1)
+        self.assertEqual(b_date.month, 1)
+        self.assertEqual(b_date.day, 1)
+        self.assertEqual(b_date.weekday, 0)
+        self.assertEqual(b_date.dayofyear, 1)
+        self.assertEqual(b_date.days_in_month, 31)
+        self.assertEqual(Period(freq='B', year=2012,
+                                month=2, day=1).days_in_month, 29)
         #
         d_date = Period(freq='D', year=2007, month=1, day=1)
         #
-        assert_equal(d_date.year, 2007)
-        assert_equal(d_date.quarter, 1)
-        assert_equal(d_date.month, 1)
-        assert_equal(d_date.day, 1)
-        assert_equal(d_date.weekday, 0)
-        assert_equal(d_date.dayofyear, 1)
-        assert_equal(d_date.days_in_month, 31)
-        assert_equal(Period(freq='D', year=2012, month=2,
-                            day=1).days_in_month, 29)
+        self.assertEqual(d_date.year, 2007)
+        self.assertEqual(d_date.quarter, 1)
+        self.assertEqual(d_date.month, 1)
+        self.assertEqual(d_date.day, 1)
+        self.assertEqual(d_date.weekday, 0)
+        self.assertEqual(d_date.dayofyear, 1)
+        self.assertEqual(d_date.days_in_month, 31)
+        self.assertEqual(Period(freq='D', year=2012, month=2,
+                                day=1).days_in_month, 29)
 
     def test_properties_hourly(self):
         # Test properties on Periods with hourly frequency.
@@ -714,50 +712,50 @@ class TestPeriodProperties(tm.TestCase):
         h_date2 = Period(freq='2H', year=2007, month=1, day=1, hour=0)
 
         for h_date in [h_date1, h_date2]:
-            assert_equal(h_date.year, 2007)
-            assert_equal(h_date.quarter, 1)
-            assert_equal(h_date.month, 1)
-            assert_equal(h_date.day, 1)
-            assert_equal(h_date.weekday, 0)
-            assert_equal(h_date.dayofyear, 1)
-            assert_equal(h_date.hour, 0)
-            assert_equal(h_date.days_in_month, 31)
-            assert_equal(Period(freq='H', year=2012, month=2, day=1,
-                                hour=0).days_in_month, 29)
+            self.assertEqual(h_date.year, 2007)
+            self.assertEqual(h_date.quarter, 1)
+            self.assertEqual(h_date.month, 1)
+            self.assertEqual(h_date.day, 1)
+            self.assertEqual(h_date.weekday, 0)
+            self.assertEqual(h_date.dayofyear, 1)
+            self.assertEqual(h_date.hour, 0)
+            self.assertEqual(h_date.days_in_month, 31)
+            self.assertEqual(Period(freq='H', year=2012, month=2, day=1,
+                                    hour=0).days_in_month, 29)
 
     def test_properties_minutely(self):
         # Test properties on Periods with minutely frequency.
         t_date = Period(freq='Min', year=2007, month=1, day=1, hour=0,
                         minute=0)
         #
-        assert_equal(t_date.quarter, 1)
-        assert_equal(t_date.month, 1)
-        assert_equal(t_date.day, 1)
-        assert_equal(t_date.weekday, 0)
-        assert_equal(t_date.dayofyear, 1)
-        assert_equal(t_date.hour, 0)
-        assert_equal(t_date.minute, 0)
-        assert_equal(t_date.days_in_month, 31)
-        assert_equal(Period(freq='D', year=2012, month=2, day=1, hour=0,
-                            minute=0).days_in_month, 29)
+        self.assertEqual(t_date.quarter, 1)
+        self.assertEqual(t_date.month, 1)
+        self.assertEqual(t_date.day, 1)
+        self.assertEqual(t_date.weekday, 0)
+        self.assertEqual(t_date.dayofyear, 1)
+        self.assertEqual(t_date.hour, 0)
+        self.assertEqual(t_date.minute, 0)
+        self.assertEqual(t_date.days_in_month, 31)
+        self.assertEqual(Period(freq='D', year=2012, month=2, day=1, hour=0,
+                                minute=0).days_in_month, 29)
 
     def test_properties_secondly(self):
         # Test properties on Periods with secondly frequency.
         s_date = Period(freq='Min', year=2007, month=1, day=1, hour=0,
                         minute=0, second=0)
         #
-        assert_equal(s_date.year, 2007)
-        assert_equal(s_date.quarter, 1)
-        assert_equal(s_date.month, 1)
-        assert_equal(s_date.day, 1)
-        assert_equal(s_date.weekday, 0)
-        assert_equal(s_date.dayofyear, 1)
-        assert_equal(s_date.hour, 0)
-        assert_equal(s_date.minute, 0)
-        assert_equal(s_date.second, 0)
-        assert_equal(s_date.days_in_month, 31)
-        assert_equal(Period(freq='Min', year=2012, month=2, day=1, hour=0,
-                            minute=0, second=0).days_in_month, 29)
+        self.assertEqual(s_date.year, 2007)
+        self.assertEqual(s_date.quarter, 1)
+        self.assertEqual(s_date.month, 1)
+        self.assertEqual(s_date.day, 1)
+        self.assertEqual(s_date.weekday, 0)
+        self.assertEqual(s_date.dayofyear, 1)
+        self.assertEqual(s_date.hour, 0)
+        self.assertEqual(s_date.minute, 0)
+        self.assertEqual(s_date.second, 0)
+        self.assertEqual(s_date.days_in_month, 31)
+        self.assertEqual(Period(freq='Min', year=2012, month=2, day=1, hour=0,
+                                minute=0, second=0).days_in_month, 29)
 
     def test_properties_nat(self):
         p_nat = Period('NaT', freq='M')
@@ -894,35 +892,35 @@ class TestFreqConversion(tm.TestCase):
         ival_ANOV_to_D_end = Period(freq='D', year=2007, month=11, day=30)
         ival_ANOV_to_D_start = Period(freq='D', year=2006, month=12, day=1)
 
-        assert_equal(ival_A.asfreq('Q', 'S'), ival_A_to_Q_start)
-        assert_equal(ival_A.asfreq('Q', 'e'), ival_A_to_Q_end)
-        assert_equal(ival_A.asfreq('M', 's'), ival_A_to_M_start)
-        assert_equal(ival_A.asfreq('M', 'E'), ival_A_to_M_end)
-        assert_equal(ival_A.asfreq('W', 'S'), ival_A_to_W_start)
-        assert_equal(ival_A.asfreq('W', 'E'), ival_A_to_W_end)
-        assert_equal(ival_A.asfreq('B', 'S'), ival_A_to_B_start)
-        assert_equal(ival_A.asfreq('B', 'E'), ival_A_to_B_end)
-        assert_equal(ival_A.asfreq('D', 'S'), ival_A_to_D_start)
-        assert_equal(ival_A.asfreq('D', 'E'), ival_A_to_D_end)
-        assert_equal(ival_A.asfreq('H', 'S'), ival_A_to_H_start)
-        assert_equal(ival_A.asfreq('H', 'E'), ival_A_to_H_end)
-        assert_equal(ival_A.asfreq('min', 'S'), ival_A_to_T_start)
-        assert_equal(ival_A.asfreq('min', 'E'), ival_A_to_T_end)
-        assert_equal(ival_A.asfreq('T', 'S'), ival_A_to_T_start)
-        assert_equal(ival_A.asfreq('T', 'E'), ival_A_to_T_end)
-        assert_equal(ival_A.asfreq('S', 'S'), ival_A_to_S_start)
-        assert_equal(ival_A.asfreq('S', 'E'), ival_A_to_S_end)
+        self.assertEqual(ival_A.asfreq('Q', 'S'), ival_A_to_Q_start)
+        self.assertEqual(ival_A.asfreq('Q', 'e'), ival_A_to_Q_end)
+        self.assertEqual(ival_A.asfreq('M', 's'), ival_A_to_M_start)
+        self.assertEqual(ival_A.asfreq('M', 'E'), ival_A_to_M_end)
+        self.assertEqual(ival_A.asfreq('W', 'S'), ival_A_to_W_start)
+        self.assertEqual(ival_A.asfreq('W', 'E'), ival_A_to_W_end)
+        self.assertEqual(ival_A.asfreq('B', 'S'), ival_A_to_B_start)
+        self.assertEqual(ival_A.asfreq('B', 'E'), ival_A_to_B_end)
+        self.assertEqual(ival_A.asfreq('D', 'S'), ival_A_to_D_start)
+        self.assertEqual(ival_A.asfreq('D', 'E'), ival_A_to_D_end)
+        self.assertEqual(ival_A.asfreq('H', 'S'), ival_A_to_H_start)
+        self.assertEqual(ival_A.asfreq('H', 'E'), ival_A_to_H_end)
+        self.assertEqual(ival_A.asfreq('min', 'S'), ival_A_to_T_start)
+        self.assertEqual(ival_A.asfreq('min', 'E'), ival_A_to_T_end)
+        self.assertEqual(ival_A.asfreq('T', 'S'), ival_A_to_T_start)
+        self.assertEqual(ival_A.asfreq('T', 'E'), ival_A_to_T_end)
+        self.assertEqual(ival_A.asfreq('S', 'S'), ival_A_to_S_start)
+        self.assertEqual(ival_A.asfreq('S', 'E'), ival_A_to_S_end)
 
-        assert_equal(ival_AJAN.asfreq('D', 'S'), ival_AJAN_to_D_start)
-        assert_equal(ival_AJAN.asfreq('D', 'E'), ival_AJAN_to_D_end)
+        self.assertEqual(ival_AJAN.asfreq('D', 'S'), ival_AJAN_to_D_start)
+        self.assertEqual(ival_AJAN.asfreq('D', 'E'), ival_AJAN_to_D_end)
 
-        assert_equal(ival_AJUN.asfreq('D', 'S'), ival_AJUN_to_D_start)
-        assert_equal(ival_AJUN.asfreq('D', 'E'), ival_AJUN_to_D_end)
+        self.assertEqual(ival_AJUN.asfreq('D', 'S'), ival_AJUN_to_D_start)
+        self.assertEqual(ival_AJUN.asfreq('D', 'E'), ival_AJUN_to_D_end)
 
-        assert_equal(ival_ANOV.asfreq('D', 'S'), ival_ANOV_to_D_start)
-        assert_equal(ival_ANOV.asfreq('D', 'E'), ival_ANOV_to_D_end)
+        self.assertEqual(ival_ANOV.asfreq('D', 'S'), ival_ANOV_to_D_start)
+        self.assertEqual(ival_ANOV.asfreq('D', 'E'), ival_ANOV_to_D_end)
 
-        assert_equal(ival_A.asfreq('A'), ival_A)
+        self.assertEqual(ival_A.asfreq('A'), ival_A)
 
     def test_conv_quarterly(self):
         # frequency conversion tests: from Quarterly Frequency
@@ -959,30 +957,30 @@ class TestFreqConversion(tm.TestCase):
         ival_QEJUN_to_D_start = Period(freq='D', year=2006, month=7, day=1)
         ival_QEJUN_to_D_end = Period(freq='D', year=2006, month=9, day=30)
 
-        assert_equal(ival_Q.asfreq('A'), ival_Q_to_A)
-        assert_equal(ival_Q_end_of_year.asfreq('A'), ival_Q_to_A)
+        self.assertEqual(ival_Q.asfreq('A'), ival_Q_to_A)
+        self.assertEqual(ival_Q_end_of_year.asfreq('A'), ival_Q_to_A)
 
-        assert_equal(ival_Q.asfreq('M', 'S'), ival_Q_to_M_start)
-        assert_equal(ival_Q.asfreq('M', 'E'), ival_Q_to_M_end)
-        assert_equal(ival_Q.asfreq('W', 'S'), ival_Q_to_W_start)
-        assert_equal(ival_Q.asfreq('W', 'E'), ival_Q_to_W_end)
-        assert_equal(ival_Q.asfreq('B', 'S'), ival_Q_to_B_start)
-        assert_equal(ival_Q.asfreq('B', 'E'), ival_Q_to_B_end)
-        assert_equal(ival_Q.asfreq('D', 'S'), ival_Q_to_D_start)
-        assert_equal(ival_Q.asfreq('D', 'E'), ival_Q_to_D_end)
-        assert_equal(ival_Q.asfreq('H', 'S'), ival_Q_to_H_start)
-        assert_equal(ival_Q.asfreq('H', 'E'), ival_Q_to_H_end)
-        assert_equal(ival_Q.asfreq('Min', 'S'), ival_Q_to_T_start)
-        assert_equal(ival_Q.asfreq('Min', 'E'), ival_Q_to_T_end)
-        assert_equal(ival_Q.asfreq('S', 'S'), ival_Q_to_S_start)
-        assert_equal(ival_Q.asfreq('S', 'E'), ival_Q_to_S_end)
+        self.assertEqual(ival_Q.asfreq('M', 'S'), ival_Q_to_M_start)
+        self.assertEqual(ival_Q.asfreq('M', 'E'), ival_Q_to_M_end)
+        self.assertEqual(ival_Q.asfreq('W', 'S'), ival_Q_to_W_start)
+        self.assertEqual(ival_Q.asfreq('W', 'E'), ival_Q_to_W_end)
+        self.assertEqual(ival_Q.asfreq('B', 'S'), ival_Q_to_B_start)
+        self.assertEqual(ival_Q.asfreq('B', 'E'), ival_Q_to_B_end)
+        self.assertEqual(ival_Q.asfreq('D', 'S'), ival_Q_to_D_start)
+        self.assertEqual(ival_Q.asfreq('D', 'E'), ival_Q_to_D_end)
+        self.assertEqual(ival_Q.asfreq('H', 'S'), ival_Q_to_H_start)
+        self.assertEqual(ival_Q.asfreq('H', 'E'), ival_Q_to_H_end)
+        self.assertEqual(ival_Q.asfreq('Min', 'S'), ival_Q_to_T_start)
+        self.assertEqual(ival_Q.asfreq('Min', 'E'), ival_Q_to_T_end)
+        self.assertEqual(ival_Q.asfreq('S', 'S'), ival_Q_to_S_start)
+        self.assertEqual(ival_Q.asfreq('S', 'E'), ival_Q_to_S_end)
 
-        assert_equal(ival_QEJAN.asfreq('D', 'S'), ival_QEJAN_to_D_start)
-        assert_equal(ival_QEJAN.asfreq('D', 'E'), ival_QEJAN_to_D_end)
-        assert_equal(ival_QEJUN.asfreq('D', 'S'), ival_QEJUN_to_D_start)
-        assert_equal(ival_QEJUN.asfreq('D', 'E'), ival_QEJUN_to_D_end)
+        self.assertEqual(ival_QEJAN.asfreq('D', 'S'), ival_QEJAN_to_D_start)
+        self.assertEqual(ival_QEJAN.asfreq('D', 'E'), ival_QEJAN_to_D_end)
+        self.assertEqual(ival_QEJUN.asfreq('D', 'S'), ival_QEJUN_to_D_start)
+        self.assertEqual(ival_QEJUN.asfreq('D', 'E'), ival_QEJUN_to_D_end)
 
-        assert_equal(ival_Q.asfreq('Q'), ival_Q)
+        self.assertEqual(ival_Q.asfreq('Q'), ival_Q)
 
     def test_conv_monthly(self):
         # frequency conversion tests: from Monthly Frequency
@@ -1009,25 +1007,25 @@ class TestFreqConversion(tm.TestCase):
         ival_M_to_S_end = Period(freq='S', year=2007, month=1, day=31, hour=23,
                                  minute=59, second=59)
 
-        assert_equal(ival_M.asfreq('A'), ival_M_to_A)
-        assert_equal(ival_M_end_of_year.asfreq('A'), ival_M_to_A)
-        assert_equal(ival_M.asfreq('Q'), ival_M_to_Q)
-        assert_equal(ival_M_end_of_quarter.asfreq('Q'), ival_M_to_Q)
+        self.assertEqual(ival_M.asfreq('A'), ival_M_to_A)
+        self.assertEqual(ival_M_end_of_year.asfreq('A'), ival_M_to_A)
+        self.assertEqual(ival_M.asfreq('Q'), ival_M_to_Q)
+        self.assertEqual(ival_M_end_of_quarter.asfreq('Q'), ival_M_to_Q)
 
-        assert_equal(ival_M.asfreq('W', 'S'), ival_M_to_W_start)
-        assert_equal(ival_M.asfreq('W', 'E'), ival_M_to_W_end)
-        assert_equal(ival_M.asfreq('B', 'S'), ival_M_to_B_start)
-        assert_equal(ival_M.asfreq('B', 'E'), ival_M_to_B_end)
-        assert_equal(ival_M.asfreq('D', 'S'), ival_M_to_D_start)
-        assert_equal(ival_M.asfreq('D', 'E'), ival_M_to_D_end)
-        assert_equal(ival_M.asfreq('H', 'S'), ival_M_to_H_start)
-        assert_equal(ival_M.asfreq('H', 'E'), ival_M_to_H_end)
-        assert_equal(ival_M.asfreq('Min', 'S'), ival_M_to_T_start)
-        assert_equal(ival_M.asfreq('Min', 'E'), ival_M_to_T_end)
-        assert_equal(ival_M.asfreq('S', 'S'), ival_M_to_S_start)
-        assert_equal(ival_M.asfreq('S', 'E'), ival_M_to_S_end)
+        self.assertEqual(ival_M.asfreq('W', 'S'), ival_M_to_W_start)
+        self.assertEqual(ival_M.asfreq('W', 'E'), ival_M_to_W_end)
+        self.assertEqual(ival_M.asfreq('B', 'S'), ival_M_to_B_start)
+        self.assertEqual(ival_M.asfreq('B', 'E'), ival_M_to_B_end)
+        self.assertEqual(ival_M.asfreq('D', 'S'), ival_M_to_D_start)
+        self.assertEqual(ival_M.asfreq('D', 'E'), ival_M_to_D_end)
+        self.assertEqual(ival_M.asfreq('H', 'S'), ival_M_to_H_start)
+        self.assertEqual(ival_M.asfreq('H', 'E'), ival_M_to_H_end)
+        self.assertEqual(ival_M.asfreq('Min', 'S'), ival_M_to_T_start)
+        self.assertEqual(ival_M.asfreq('Min', 'E'), ival_M_to_T_end)
+        self.assertEqual(ival_M.asfreq('S', 'S'), ival_M_to_S_start)
+        self.assertEqual(ival_M.asfreq('S', 'E'), ival_M_to_S_end)
 
-        assert_equal(ival_M.asfreq('M'), ival_M)
+        self.assertEqual(ival_M.asfreq('M'), ival_M)
 
     def test_conv_weekly(self):
         # frequency conversion tests: from Weekly Frequency
@@ -1093,43 +1091,45 @@ class TestFreqConversion(tm.TestCase):
         ival_W_to_S_end = Period(freq='S', year=2007, month=1, day=7, hour=23,
                                  minute=59, second=59)
 
-        assert_equal(ival_W.asfreq('A'), ival_W_to_A)
-        assert_equal(ival_W_end_of_year.asfreq('A'), ival_W_to_A_end_of_year)
-        assert_equal(ival_W.asfreq('Q'), ival_W_to_Q)
-        assert_equal(ival_W_end_of_quarter.asfreq('Q'),
-                     ival_W_to_Q_end_of_quarter)
-        assert_equal(ival_W.asfreq('M'), ival_W_to_M)
-        assert_equal(ival_W_end_of_month.asfreq('M'), ival_W_to_M_end_of_month)
+        self.assertEqual(ival_W.asfreq('A'), ival_W_to_A)
+        self.assertEqual(ival_W_end_of_year.asfreq('A'),
+                         ival_W_to_A_end_of_year)
+        self.assertEqual(ival_W.asfreq('Q'), ival_W_to_Q)
+        self.assertEqual(ival_W_end_of_quarter.asfreq('Q'),
+                         ival_W_to_Q_end_of_quarter)
+        self.assertEqual(ival_W.asfreq('M'), ival_W_to_M)
+        self.assertEqual(ival_W_end_of_month.asfreq('M'),
+                         ival_W_to_M_end_of_month)
 
-        assert_equal(ival_W.asfreq('B', 'S'), ival_W_to_B_start)
-        assert_equal(ival_W.asfreq('B', 'E'), ival_W_to_B_end)
+        self.assertEqual(ival_W.asfreq('B', 'S'), ival_W_to_B_start)
+        self.assertEqual(ival_W.asfreq('B', 'E'), ival_W_to_B_end)
 
-        assert_equal(ival_W.asfreq('D', 'S'), ival_W_to_D_start)
-        assert_equal(ival_W.asfreq('D', 'E'), ival_W_to_D_end)
+        self.assertEqual(ival_W.asfreq('D', 'S'), ival_W_to_D_start)
+        self.assertEqual(ival_W.asfreq('D', 'E'), ival_W_to_D_end)
 
-        assert_equal(ival_WSUN.asfreq('D', 'S'), ival_WSUN_to_D_start)
-        assert_equal(ival_WSUN.asfreq('D', 'E'), ival_WSUN_to_D_end)
-        assert_equal(ival_WSAT.asfreq('D', 'S'), ival_WSAT_to_D_start)
-        assert_equal(ival_WSAT.asfreq('D', 'E'), ival_WSAT_to_D_end)
-        assert_equal(ival_WFRI.asfreq('D', 'S'), ival_WFRI_to_D_start)
-        assert_equal(ival_WFRI.asfreq('D', 'E'), ival_WFRI_to_D_end)
-        assert_equal(ival_WTHU.asfreq('D', 'S'), ival_WTHU_to_D_start)
-        assert_equal(ival_WTHU.asfreq('D', 'E'), ival_WTHU_to_D_end)
-        assert_equal(ival_WWED.asfreq('D', 'S'), ival_WWED_to_D_start)
-        assert_equal(ival_WWED.asfreq('D', 'E'), ival_WWED_to_D_end)
-        assert_equal(ival_WTUE.asfreq('D', 'S'), ival_WTUE_to_D_start)
-        assert_equal(ival_WTUE.asfreq('D', 'E'), ival_WTUE_to_D_end)
-        assert_equal(ival_WMON.asfreq('D', 'S'), ival_WMON_to_D_start)
-        assert_equal(ival_WMON.asfreq('D', 'E'), ival_WMON_to_D_end)
+        self.assertEqual(ival_WSUN.asfreq('D', 'S'), ival_WSUN_to_D_start)
+        self.assertEqual(ival_WSUN.asfreq('D', 'E'), ival_WSUN_to_D_end)
+        self.assertEqual(ival_WSAT.asfreq('D', 'S'), ival_WSAT_to_D_start)
+        self.assertEqual(ival_WSAT.asfreq('D', 'E'), ival_WSAT_to_D_end)
+        self.assertEqual(ival_WFRI.asfreq('D', 'S'), ival_WFRI_to_D_start)
+        self.assertEqual(ival_WFRI.asfreq('D', 'E'), ival_WFRI_to_D_end)
+        self.assertEqual(ival_WTHU.asfreq('D', 'S'), ival_WTHU_to_D_start)
+        self.assertEqual(ival_WTHU.asfreq('D', 'E'), ival_WTHU_to_D_end)
+        self.assertEqual(ival_WWED.asfreq('D', 'S'), ival_WWED_to_D_start)
+        self.assertEqual(ival_WWED.asfreq('D', 'E'), ival_WWED_to_D_end)
+        self.assertEqual(ival_WTUE.asfreq('D', 'S'), ival_WTUE_to_D_start)
+        self.assertEqual(ival_WTUE.asfreq('D', 'E'), ival_WTUE_to_D_end)
+        self.assertEqual(ival_WMON.asfreq('D', 'S'), ival_WMON_to_D_start)
+        self.assertEqual(ival_WMON.asfreq('D', 'E'), ival_WMON_to_D_end)
 
-        assert_equal(ival_W.asfreq('H', 'S'), ival_W_to_H_start)
-        assert_equal(ival_W.asfreq('H', 'E'), ival_W_to_H_end)
-        assert_equal(ival_W.asfreq('Min', 'S'), ival_W_to_T_start)
-        assert_equal(ival_W.asfreq('Min', 'E'), ival_W_to_T_end)
-        assert_equal(ival_W.asfreq('S', 'S'), ival_W_to_S_start)
-        assert_equal(ival_W.asfreq('S', 'E'), ival_W_to_S_end)
+        self.assertEqual(ival_W.asfreq('H', 'S'), ival_W_to_H_start)
+        self.assertEqual(ival_W.asfreq('H', 'E'), ival_W_to_H_end)
+        self.assertEqual(ival_W.asfreq('Min', 'S'), ival_W_to_T_start)
+        self.assertEqual(ival_W.asfreq('Min', 'E'), ival_W_to_T_end)
+        self.assertEqual(ival_W.asfreq('S', 'S'), ival_W_to_S_start)
+        self.assertEqual(ival_W.asfreq('S', 'E'), ival_W_to_S_end)
 
-        assert_equal(ival_W.asfreq('W'), ival_W)
+        self.assertEqual(ival_W.asfreq('W'), ival_W)
 
     def test_conv_weekly_legacy(self):
         # frequency conversion tests: from Weekly Frequency
@@ -1208,44 +1208,46 @@ class TestFreqConversion(tm.TestCase):
         ival_W_to_S_end = Period(freq='S', year=2007, month=1, day=7, hour=23,
                                  minute=59, second=59)
 
-        assert_equal(ival_W.asfreq('A'), ival_W_to_A)
-        assert_equal(ival_W_end_of_year.asfreq('A'), ival_W_to_A_end_of_year)
-        assert_equal(ival_W.asfreq('Q'), ival_W_to_Q)
-        assert_equal(ival_W_end_of_quarter.asfreq('Q'),
-                     ival_W_to_Q_end_of_quarter)
-        assert_equal(ival_W.asfreq('M'), ival_W_to_M)
-        assert_equal(ival_W_end_of_month.asfreq('M'), ival_W_to_M_end_of_month)
+        self.assertEqual(ival_W.asfreq('A'), ival_W_to_A)
+        self.assertEqual(ival_W_end_of_year.asfreq('A'),
+                         ival_W_to_A_end_of_year)
+        self.assertEqual(ival_W.asfreq('Q'), ival_W_to_Q)
+        self.assertEqual(ival_W_end_of_quarter.asfreq('Q'),
+                         ival_W_to_Q_end_of_quarter)
+        self.assertEqual(ival_W.asfreq('M'), ival_W_to_M)
+        self.assertEqual(ival_W_end_of_month.asfreq('M'),
+                         ival_W_to_M_end_of_month)
 
-        assert_equal(ival_W.asfreq('B', 'S'), ival_W_to_B_start)
-        assert_equal(ival_W.asfreq('B', 'E'), ival_W_to_B_end)
+        self.assertEqual(ival_W.asfreq('B', 'S'), ival_W_to_B_start)
+        self.assertEqual(ival_W.asfreq('B', 'E'), ival_W_to_B_end)
 
-        assert_equal(ival_W.asfreq('D', 'S'), ival_W_to_D_start)
-        assert_equal(ival_W.asfreq('D', 'E'), ival_W_to_D_end)
+        self.assertEqual(ival_W.asfreq('D', 'S'), ival_W_to_D_start)
+        self.assertEqual(ival_W.asfreq('D', 'E'), ival_W_to_D_end)
 
-        assert_equal(ival_WSUN.asfreq('D', 'S'), ival_WSUN_to_D_start)
-        assert_equal(ival_WSUN.asfreq('D', 'E'), ival_WSUN_to_D_end)
-        assert_equal(ival_WSAT.asfreq('D', 'S'), ival_WSAT_to_D_start)
-        assert_equal(ival_WSAT.asfreq('D', 'E'), ival_WSAT_to_D_end)
-        assert_equal(ival_WFRI.asfreq('D', 'S'), ival_WFRI_to_D_start)
-        assert_equal(ival_WFRI.asfreq('D', 'E'), ival_WFRI_to_D_end)
-        assert_equal(ival_WTHU.asfreq('D', 'S'), ival_WTHU_to_D_start)
-        assert_equal(ival_WTHU.asfreq('D', 'E'), ival_WTHU_to_D_end)
-        assert_equal(ival_WWED.asfreq('D', 'S'), ival_WWED_to_D_start)
-        assert_equal(ival_WWED.asfreq('D', 'E'), ival_WWED_to_D_end)
-        assert_equal(ival_WTUE.asfreq('D', 'S'), ival_WTUE_to_D_start)
-        assert_equal(ival_WTUE.asfreq('D', 'E'), ival_WTUE_to_D_end)
-        assert_equal(ival_WMON.asfreq('D', 'S'), ival_WMON_to_D_start)
-        assert_equal(ival_WMON.asfreq('D', 'E'), ival_WMON_to_D_end)
+        self.assertEqual(ival_WSUN.asfreq('D', 'S'), ival_WSUN_to_D_start)
+        self.assertEqual(ival_WSUN.asfreq('D', 'E'), ival_WSUN_to_D_end)
+        self.assertEqual(ival_WSAT.asfreq('D', 'S'), ival_WSAT_to_D_start)
+        self.assertEqual(ival_WSAT.asfreq('D', 'E'), ival_WSAT_to_D_end)
+        self.assertEqual(ival_WFRI.asfreq('D', 'S'), ival_WFRI_to_D_start)
+        self.assertEqual(ival_WFRI.asfreq('D', 'E'), ival_WFRI_to_D_end)
+        self.assertEqual(ival_WTHU.asfreq('D', 'S'), ival_WTHU_to_D_start)
+        self.assertEqual(ival_WTHU.asfreq('D', 'E'), ival_WTHU_to_D_end)
+        self.assertEqual(ival_WWED.asfreq('D', 'S'), ival_WWED_to_D_start)
+        self.assertEqual(ival_WWED.asfreq('D', 'E'), ival_WWED_to_D_end)
+        self.assertEqual(ival_WTUE.asfreq('D', 'S'), ival_WTUE_to_D_start)
+        self.assertEqual(ival_WTUE.asfreq('D', 'E'), ival_WTUE_to_D_end)
+        self.assertEqual(ival_WMON.asfreq('D', 'S'), ival_WMON_to_D_start)
+        self.assertEqual(ival_WMON.asfreq('D', 'E'), ival_WMON_to_D_end)
 
-        assert_equal(ival_W.asfreq('H', 'S'), ival_W_to_H_start)
-        assert_equal(ival_W.asfreq('H', 'E'), ival_W_to_H_end)
-        assert_equal(ival_W.asfreq('Min', 'S'), ival_W_to_T_start)
-        assert_equal(ival_W.asfreq('Min', 'E'), ival_W_to_T_end)
-        assert_equal(ival_W.asfreq('S', 'S'), ival_W_to_S_start)
-        assert_equal(ival_W.asfreq('S', 'E'), ival_W_to_S_end)
+        self.assertEqual(ival_W.asfreq('H', 'S'), ival_W_to_H_start)
+        self.assertEqual(ival_W.asfreq('H', 'E'), ival_W_to_H_end)
+        self.assertEqual(ival_W.asfreq('Min', 'S'), ival_W_to_T_start)
+        self.assertEqual(ival_W.asfreq('Min', 'E'), ival_W_to_T_end)
+        self.assertEqual(ival_W.asfreq('S', 'S'), ival_W_to_S_start)
+        self.assertEqual(ival_W.asfreq('S', 'E'), ival_W_to_S_end)
 
         with tm.assert_produces_warning(FutureWarning):
-            assert_equal(ival_W.asfreq('WK'), ival_W)
+            self.assertEqual(ival_W.asfreq('WK'), ival_W)
 
     def test_conv_business(self):
         # frequency conversion tests: from Business Frequency"
@@ -1272,25 +1274,25 @@ class TestFreqConversion(tm.TestCase):
         ival_B_to_S_end = Period(freq='S', year=2007, month=1, day=1, hour=23,
                                  minute=59, second=59)
 
-        assert_equal(ival_B.asfreq('A'), ival_B_to_A)
-        assert_equal(ival_B_end_of_year.asfreq('A'), ival_B_to_A)
-        assert_equal(ival_B.asfreq('Q'), ival_B_to_Q)
-        assert_equal(ival_B_end_of_quarter.asfreq('Q'), ival_B_to_Q)
-        assert_equal(ival_B.asfreq('M'), ival_B_to_M)
-        assert_equal(ival_B_end_of_month.asfreq('M'), ival_B_to_M)
-        assert_equal(ival_B.asfreq('W'), ival_B_to_W)
-        assert_equal(ival_B_end_of_week.asfreq('W'), ival_B_to_W)
+        self.assertEqual(ival_B.asfreq('A'), ival_B_to_A)
+        self.assertEqual(ival_B_end_of_year.asfreq('A'), ival_B_to_A)
+        self.assertEqual(ival_B.asfreq('Q'), ival_B_to_Q)
+        self.assertEqual(ival_B_end_of_quarter.asfreq('Q'), ival_B_to_Q)
+        self.assertEqual(ival_B.asfreq('M'), ival_B_to_M)
+        self.assertEqual(ival_B_end_of_month.asfreq('M'), ival_B_to_M)
+        self.assertEqual(ival_B.asfreq('W'), ival_B_to_W)
+        self.assertEqual(ival_B_end_of_week.asfreq('W'), ival_B_to_W)
 
-        assert_equal(ival_B.asfreq('D'), ival_B_to_D)
+        self.assertEqual(ival_B.asfreq('D'), ival_B_to_D)
 
-        assert_equal(ival_B.asfreq('H', 'S'), ival_B_to_H_start)
-        assert_equal(ival_B.asfreq('H', 'E'), ival_B_to_H_end)
-        assert_equal(ival_B.asfreq('Min', 'S'), ival_B_to_T_start)
-        assert_equal(ival_B.asfreq('Min', 'E'), ival_B_to_T_end)
-        assert_equal(ival_B.asfreq('S', 'S'), ival_B_to_S_start)
-        assert_equal(ival_B.asfreq('S', 'E'), ival_B_to_S_end)
+        self.assertEqual(ival_B.asfreq('H', 'S'), ival_B_to_H_start)
+        self.assertEqual(ival_B.asfreq('H', 'E'), ival_B_to_H_end)
+        self.assertEqual(ival_B.asfreq('Min', 'S'), ival_B_to_T_start)
+        self.assertEqual(ival_B.asfreq('Min', 'E'), ival_B_to_T_end)
+        self.assertEqual(ival_B.asfreq('S', 'S'), ival_B_to_S_start)
+        self.assertEqual(ival_B.asfreq('S', 'E'), ival_B_to_S_end)
 
-        assert_equal(ival_B.asfreq('B'), ival_B)
+        self.assertEqual(ival_B.asfreq('B'), ival_B)
 
     def test_conv_daily(self):
         # frequency conversion tests: from Business Frequency"
@@ -1335,36 +1337,39 @@ class TestFreqConversion(tm.TestCase):
         ival_D_to_S_end = Period(freq='S', year=2007, month=1, day=1, hour=23,
                                  minute=59, second=59)
 
-        assert_equal(ival_D.asfreq('A'), ival_D_to_A)
+        self.assertEqual(ival_D.asfreq('A'), ival_D_to_A)
 
-        assert_equal(ival_D_end_of_quarter.asfreq('A-JAN'), ival_Deoq_to_AJAN)
-        assert_equal(ival_D_end_of_quarter.asfreq('A-JUN'), ival_Deoq_to_AJUN)
-        assert_equal(ival_D_end_of_quarter.asfreq('A-DEC'), ival_Deoq_to_ADEC)
+        self.assertEqual(ival_D_end_of_quarter.asfreq('A-JAN'),
+                         ival_Deoq_to_AJAN)
+        self.assertEqual(ival_D_end_of_quarter.asfreq('A-JUN'),
+                         ival_Deoq_to_AJUN)
+        self.assertEqual(ival_D_end_of_quarter.asfreq('A-DEC'),
+                         ival_Deoq_to_ADEC)
 
-        assert_equal(ival_D_end_of_year.asfreq('A'), ival_D_to_A)
-        assert_equal(ival_D_end_of_quarter.asfreq('Q'), ival_D_to_QEDEC)
-        assert_equal(ival_D.asfreq("Q-JAN"), ival_D_to_QEJAN)
-        assert_equal(ival_D.asfreq("Q-JUN"), ival_D_to_QEJUN)
-        assert_equal(ival_D.asfreq("Q-DEC"), ival_D_to_QEDEC)
-        assert_equal(ival_D.asfreq('M'), ival_D_to_M)
-        assert_equal(ival_D_end_of_month.asfreq('M'), ival_D_to_M)
-        assert_equal(ival_D.asfreq('W'), ival_D_to_W)
-        assert_equal(ival_D_end_of_week.asfreq('W'), ival_D_to_W)
+        self.assertEqual(ival_D_end_of_year.asfreq('A'), ival_D_to_A)
+        self.assertEqual(ival_D_end_of_quarter.asfreq('Q'), ival_D_to_QEDEC)
+        self.assertEqual(ival_D.asfreq("Q-JAN"), ival_D_to_QEJAN)
+        self.assertEqual(ival_D.asfreq("Q-JUN"), ival_D_to_QEJUN)
+        self.assertEqual(ival_D.asfreq("Q-DEC"), ival_D_to_QEDEC)
+        self.assertEqual(ival_D.asfreq('M'), ival_D_to_M)
+        self.assertEqual(ival_D_end_of_month.asfreq('M'), ival_D_to_M)
+        self.assertEqual(ival_D.asfreq('W'), ival_D_to_W)
+        self.assertEqual(ival_D_end_of_week.asfreq('W'), ival_D_to_W)
 
-        assert_equal(ival_D_friday.asfreq('B'), ival_B_friday)
-        assert_equal(ival_D_saturday.asfreq('B', 'S'), ival_B_friday)
-        assert_equal(ival_D_saturday.asfreq('B', 'E'), ival_B_monday)
-        assert_equal(ival_D_sunday.asfreq('B', 'S'), ival_B_friday)
-        assert_equal(ival_D_sunday.asfreq('B', 'E'), ival_B_monday)
+        self.assertEqual(ival_D_friday.asfreq('B'), ival_B_friday)
+        self.assertEqual(ival_D_saturday.asfreq('B', 'S'), ival_B_friday)
+        self.assertEqual(ival_D_saturday.asfreq('B', 'E'), ival_B_monday)
+        self.assertEqual(ival_D_sunday.asfreq('B', 'S'), ival_B_friday)
+        self.assertEqual(ival_D_sunday.asfreq('B', 'E'), ival_B_monday)
 
-        assert_equal(ival_D.asfreq('H', 'S'), ival_D_to_H_start)
-        assert_equal(ival_D.asfreq('H', 'E'), ival_D_to_H_end)
-        assert_equal(ival_D.asfreq('Min', 'S'), ival_D_to_T_start)
-        assert_equal(ival_D.asfreq('Min', 'E'), ival_D_to_T_end)
-        assert_equal(ival_D.asfreq('S', 'S'), ival_D_to_S_start)
-        assert_equal(ival_D.asfreq('S', 'E'), ival_D_to_S_end)
+        self.assertEqual(ival_D.asfreq('H', 'S'), ival_D_to_H_start)
+        self.assertEqual(ival_D.asfreq('H', 'E'), ival_D_to_H_end)
+        self.assertEqual(ival_D.asfreq('Min', 'S'), ival_D_to_T_start)
+        self.assertEqual(ival_D.asfreq('Min', 'E'), ival_D_to_T_end)
+        self.assertEqual(ival_D.asfreq('S', 'S'), ival_D_to_S_start)
+        self.assertEqual(ival_D.asfreq('S', 'E'), ival_D_to_S_end)
 
-        assert_equal(ival_D.asfreq('D'), ival_D)
+        self.assertEqual(ival_D.asfreq('D'), ival_D)
 
     def test_conv_hourly(self):
         # frequency conversion tests: from Hourly Frequency"
@@ -1399,25 +1404,25 @@ class TestFreqConversion(tm.TestCase):
         ival_H_to_S_end = Period(freq='S', year=2007, month=1, day=1, hour=0,
                                  minute=59, second=59)
 
-        assert_equal(ival_H.asfreq('A'), ival_H_to_A)
-        assert_equal(ival_H_end_of_year.asfreq('A'), ival_H_to_A)
-        assert_equal(ival_H.asfreq('Q'), ival_H_to_Q)
-        assert_equal(ival_H_end_of_quarter.asfreq('Q'), ival_H_to_Q)
-        assert_equal(ival_H.asfreq('M'), ival_H_to_M)
-        assert_equal(ival_H_end_of_month.asfreq('M'), ival_H_to_M)
-        assert_equal(ival_H.asfreq('W'), ival_H_to_W)
-        assert_equal(ival_H_end_of_week.asfreq('W'), ival_H_to_W)
-        assert_equal(ival_H.asfreq('D'), ival_H_to_D)
-        assert_equal(ival_H_end_of_day.asfreq('D'), ival_H_to_D)
-        assert_equal(ival_H.asfreq('B'), ival_H_to_B)
-        assert_equal(ival_H_end_of_bus.asfreq('B'), ival_H_to_B)
+        self.assertEqual(ival_H.asfreq('A'), ival_H_to_A)
+        self.assertEqual(ival_H_end_of_year.asfreq('A'), ival_H_to_A)
+        self.assertEqual(ival_H.asfreq('Q'), ival_H_to_Q)
+        self.assertEqual(ival_H_end_of_quarter.asfreq('Q'), ival_H_to_Q)
+        self.assertEqual(ival_H.asfreq('M'), ival_H_to_M)
+        self.assertEqual(ival_H_end_of_month.asfreq('M'), ival_H_to_M)
+        self.assertEqual(ival_H.asfreq('W'), ival_H_to_W)
+        self.assertEqual(ival_H_end_of_week.asfreq('W'), ival_H_to_W)
+        self.assertEqual(ival_H.asfreq('D'), ival_H_to_D)
+        self.assertEqual(ival_H_end_of_day.asfreq('D'), ival_H_to_D)
+        self.assertEqual(ival_H.asfreq('B'), ival_H_to_B)
+        self.assertEqual(ival_H_end_of_bus.asfreq('B'), ival_H_to_B)
 
-        assert_equal(ival_H.asfreq('Min', 'S'), ival_H_to_T_start)
-        assert_equal(ival_H.asfreq('Min', 'E'), ival_H_to_T_end)
-        assert_equal(ival_H.asfreq('S', 'S'), ival_H_to_S_start)
-        assert_equal(ival_H.asfreq('S', 'E'), ival_H_to_S_end)
+        self.assertEqual(ival_H.asfreq('Min', 'S'), ival_H_to_T_start)
+        self.assertEqual(ival_H.asfreq('Min', 'E'), ival_H_to_T_end)
+        self.assertEqual(ival_H.asfreq('S', 'S'), ival_H_to_S_start)
+        self.assertEqual(ival_H.asfreq('S', 'E'), ival_H_to_S_end)
 
-        assert_equal(ival_H.asfreq('H'), ival_H)
+        self.assertEqual(ival_H.asfreq('H'), ival_H)
 
     def test_conv_minutely(self):
         # frequency conversion tests: from Minutely Frequency"
@@ -1452,25 +1457,25 @@ class TestFreqConversion(tm.TestCase):
         ival_T_to_S_end = Period(freq='S', year=2007, month=1, day=1, hour=0,
                                  minute=0, second=59)
 
-        assert_equal(ival_T.asfreq('A'), ival_T_to_A)
-        assert_equal(ival_T_end_of_year.asfreq('A'), ival_T_to_A)
-        assert_equal(ival_T.asfreq('Q'), ival_T_to_Q)
-        assert_equal(ival_T_end_of_quarter.asfreq('Q'), ival_T_to_Q)
-        assert_equal(ival_T.asfreq('M'), ival_T_to_M)
-        assert_equal(ival_T_end_of_month.asfreq('M'), ival_T_to_M)
-        assert_equal(ival_T.asfreq('W'), ival_T_to_W)
-        assert_equal(ival_T_end_of_week.asfreq('W'), ival_T_to_W)
-        assert_equal(ival_T.asfreq('D'), ival_T_to_D)
-        assert_equal(ival_T_end_of_day.asfreq('D'), ival_T_to_D)
-        assert_equal(ival_T.asfreq('B'), ival_T_to_B)
-        assert_equal(ival_T_end_of_bus.asfreq('B'), ival_T_to_B)
-        assert_equal(ival_T.asfreq('H'), ival_T_to_H)
-        assert_equal(ival_T_end_of_hour.asfreq('H'), ival_T_to_H)
+        self.assertEqual(ival_T.asfreq('A'), ival_T_to_A)
+        self.assertEqual(ival_T_end_of_year.asfreq('A'), ival_T_to_A)
+        self.assertEqual(ival_T.asfreq('Q'), ival_T_to_Q)
+        self.assertEqual(ival_T_end_of_quarter.asfreq('Q'), ival_T_to_Q)
+        self.assertEqual(ival_T.asfreq('M'), ival_T_to_M)
+        self.assertEqual(ival_T_end_of_month.asfreq('M'), ival_T_to_M)
+        self.assertEqual(ival_T.asfreq('W'), ival_T_to_W)
+        self.assertEqual(ival_T_end_of_week.asfreq('W'), ival_T_to_W)
+        self.assertEqual(ival_T.asfreq('D'), ival_T_to_D)
+        self.assertEqual(ival_T_end_of_day.asfreq('D'), ival_T_to_D)
+        self.assertEqual(ival_T.asfreq('B'), ival_T_to_B)
+        self.assertEqual(ival_T_end_of_bus.asfreq('B'), ival_T_to_B)
+        self.assertEqual(ival_T.asfreq('H'), ival_T_to_H)
+        self.assertEqual(ival_T_end_of_hour.asfreq('H'), ival_T_to_H)
 
-        assert_equal(ival_T.asfreq('S', 'S'), ival_T_to_S_start)
-        assert_equal(ival_T.asfreq('S', 'E'), ival_T_to_S_end)
+        self.assertEqual(ival_T.asfreq('S', 'S'), ival_T_to_S_start)
+        self.assertEqual(ival_T.asfreq('S', 'E'), ival_T_to_S_end)
 
-        assert_equal(ival_T.asfreq('Min'), ival_T)
+        self.assertEqual(ival_T.asfreq('Min'), ival_T)
 
     def test_conv_secondly(self):
         # frequency conversion tests: from Secondly Frequency"
@@ -1504,24 +1509,24 @@ class TestFreqConversion(tm.TestCase):
         ival_S_to_T = Period(freq='Min', year=2007, month=1, day=1, hour=0,
                              minute=0)
 
-        assert_equal(ival_S.asfreq('A'), ival_S_to_A)
-        assert_equal(ival_S_end_of_year.asfreq('A'), ival_S_to_A)
-        assert_equal(ival_S.asfreq('Q'), ival_S_to_Q)
-        assert_equal(ival_S_end_of_quarter.asfreq('Q'), ival_S_to_Q)
-        assert_equal(ival_S.asfreq('M'), ival_S_to_M)
-        assert_equal(ival_S_end_of_month.asfreq('M'), ival_S_to_M)
-        assert_equal(ival_S.asfreq('W'), ival_S_to_W)
-        assert_equal(ival_S_end_of_week.asfreq('W'), ival_S_to_W)
-        assert_equal(ival_S.asfreq('D'), ival_S_to_D)
-        assert_equal(ival_S_end_of_day.asfreq('D'), ival_S_to_D)
-        assert_equal(ival_S.asfreq('B'), ival_S_to_B)
-        assert_equal(ival_S_end_of_bus.asfreq('B'), ival_S_to_B)
-        assert_equal(ival_S.asfreq('H'), ival_S_to_H)
-        assert_equal(ival_S_end_of_hour.asfreq('H'), ival_S_to_H)
-        assert_equal(ival_S.asfreq('Min'), ival_S_to_T)
-        assert_equal(ival_S_end_of_minute.asfreq('Min'), ival_S_to_T)
+        self.assertEqual(ival_S.asfreq('A'), ival_S_to_A)
+        self.assertEqual(ival_S_end_of_year.asfreq('A'), ival_S_to_A)
+        self.assertEqual(ival_S.asfreq('Q'), ival_S_to_Q)
+        self.assertEqual(ival_S_end_of_quarter.asfreq('Q'), ival_S_to_Q)
+        self.assertEqual(ival_S.asfreq('M'), ival_S_to_M)
+        self.assertEqual(ival_S_end_of_month.asfreq('M'), ival_S_to_M)
+        self.assertEqual(ival_S.asfreq('W'), ival_S_to_W)
+        self.assertEqual(ival_S_end_of_week.asfreq('W'), ival_S_to_W)
+        self.assertEqual(ival_S.asfreq('D'), ival_S_to_D)
+        self.assertEqual(ival_S_end_of_day.asfreq('D'), ival_S_to_D)
+        self.assertEqual(ival_S.asfreq('B'), ival_S_to_B)
+        self.assertEqual(ival_S_end_of_bus.asfreq('B'), ival_S_to_B)
+        self.assertEqual(ival_S.asfreq('H'), ival_S_to_H)
+        self.assertEqual(ival_S_end_of_hour.asfreq('H'), ival_S_to_H)
+        self.assertEqual(ival_S.asfreq('Min'), ival_S_to_T)
+        self.assertEqual(ival_S_end_of_minute.asfreq('Min'), ival_S_to_T)
 
-        assert_equal(ival_S.asfreq('S'), ival_S)
+        self.assertEqual(ival_S.asfreq('S'), ival_S)
 
     def test_asfreq_nat(self):
         p = Period('NaT', freq='A')
@@ -2246,52 +2251,52 @@ class TestPeriodIndex(tm.TestCase):
 
     def test_constructor(self):
         pi = PeriodIndex(freq='A', start='1/1/2001', end='12/1/2009')
-        assert_equal(len(pi), 9)
+        self.assertEqual(len(pi), 9)
 
         pi = PeriodIndex(freq='Q', start='1/1/2001', end='12/1/2009')
-        assert_equal(len(pi), 4 * 9)
+        self.assertEqual(len(pi), 4 * 9)
 
         pi = PeriodIndex(freq='M', start='1/1/2001', end='12/1/2009')
-        assert_equal(len(pi), 12 * 9)
+        self.assertEqual(len(pi), 12 * 9)
 
         pi = PeriodIndex(freq='D', start='1/1/2001', end='12/31/2009')
-        assert_equal(len(pi), 365 * 9 + 2)
+        self.assertEqual(len(pi), 365 * 9 + 2)
 
         pi = PeriodIndex(freq='B', start='1/1/2001', end='12/31/2009')
-        assert_equal(len(pi), 261 * 9)
+        self.assertEqual(len(pi), 261 * 9)
 
         pi = PeriodIndex(freq='H', start='1/1/2001', end='12/31/2001 23:00')
-        assert_equal(len(pi), 365 * 24)
+        self.assertEqual(len(pi), 365 * 24)
 
         pi = PeriodIndex(freq='Min', start='1/1/2001', end='1/1/2001 23:59')
-        assert_equal(len(pi), 24 * 60)
+        self.assertEqual(len(pi), 24 * 60)
 
         pi = PeriodIndex(freq='S', start='1/1/2001', end='1/1/2001 23:59:59')
-        assert_equal(len(pi), 24 * 60 * 60)
+        self.assertEqual(len(pi), 24 * 60 * 60)
 
         start = Period('02-Apr-2005', 'B')
         i1 = PeriodIndex(start=start, periods=20)
-        assert_equal(len(i1), 20)
-        assert_equal(i1.freq, start.freq)
-        assert_equal(i1[0], start)
+        self.assertEqual(len(i1), 20)
+        self.assertEqual(i1.freq, start.freq)
+        self.assertEqual(i1[0], start)
 
         end_intv = Period('2006-12-31', 'W')
         i1 = PeriodIndex(end=end_intv, periods=10)
-        assert_equal(len(i1), 10)
-        assert_equal(i1.freq, end_intv.freq)
-        assert_equal(i1[-1], end_intv)
+        self.assertEqual(len(i1), 10)
+        self.assertEqual(i1.freq, end_intv.freq)
+        self.assertEqual(i1[-1], end_intv)
 
         end_intv = Period('2006-12-31', '1w')
         i2 = PeriodIndex(end=end_intv, periods=10)
-        assert_equal(len(i1), len(i2))
+        self.assertEqual(len(i1), len(i2))
         self.assertTrue((i1 == i2).all())
-        assert_equal(i1.freq, i2.freq)
+        self.assertEqual(i1.freq, i2.freq)
 
         end_intv = Period('2006-12-31', ('w', 1))
         i2 = PeriodIndex(end=end_intv, periods=10)
-        assert_equal(len(i1), len(i2))
+        self.assertEqual(len(i1), len(i2))
         self.assertTrue((i1 == i2).all())
-        assert_equal(i1.freq, i2.freq)
+        self.assertEqual(i1.freq, i2.freq)
 
         try:
             PeriodIndex(start=start, end=end_intv)
@@ -2311,12 +2316,12 @@ class TestPeriodIndex(tm.TestCase):
 
         # infer freq from first element
         i2 = PeriodIndex([end_intv, Period('2005-05-05', 'B')])
-        assert_equal(len(i2), 2)
-        assert_equal(i2[0], end_intv)
+        self.assertEqual(len(i2), 2)
+        self.assertEqual(i2[0], end_intv)
 
         i2 = PeriodIndex(np.array([end_intv, Period('2005-05-05', 'B')]))
-        assert_equal(len(i2), 2)
-        assert_equal(i2[0], end_intv)
+        self.assertEqual(len(i2), 2)
+        self.assertEqual(i2[0], end_intv)
 
         # Mixed freq should fail
         vals = [end_intv, Period('2006-12-31', 'w')]
@@ -2352,33 +2357,33 @@ class TestPeriodIndex(tm.TestCase):
 
         tm.assert_index_equal(pi1.shift(0), pi1)
 
-        assert_equal(len(pi1), len(pi2))
-        assert_equal(pi1.shift(1).values, pi2.values)
+        self.assertEqual(len(pi1), len(pi2))
+        self.assert_index_equal(pi1.shift(1), pi2)
 
         pi1 = PeriodIndex(freq='A', start='1/1/2001', end='12/1/2009')
         pi2 = PeriodIndex(freq='A', start='1/1/2000', end='12/1/2008')
-        assert_equal(len(pi1), len(pi2))
-        assert_equal(pi1.shift(-1).values, pi2.values)
+        self.assertEqual(len(pi1), len(pi2))
+        self.assert_index_equal(pi1.shift(-1), pi2)
 
         pi1 = PeriodIndex(freq='M', start='1/1/2001', end='12/1/2009')
         pi2 = PeriodIndex(freq='M', start='2/1/2001', end='1/1/2010')
-        assert_equal(len(pi1), len(pi2))
-        assert_equal(pi1.shift(1).values, pi2.values)
+        self.assertEqual(len(pi1), len(pi2))
+        self.assert_index_equal(pi1.shift(1), pi2)
 
         pi1 = PeriodIndex(freq='M', start='1/1/2001', end='12/1/2009')
         pi2 = PeriodIndex(freq='M', start='12/1/2000', end='11/1/2009')
-        assert_equal(len(pi1), len(pi2))
-        assert_equal(pi1.shift(-1).values, pi2.values)
+        self.assertEqual(len(pi1), len(pi2))
+        self.assert_index_equal(pi1.shift(-1), pi2)
 
         pi1 = PeriodIndex(freq='D', start='1/1/2001', end='12/1/2009')
         pi2 = PeriodIndex(freq='D', start='1/2/2001', end='12/2/2009')
-        assert_equal(len(pi1), len(pi2))
-        assert_equal(pi1.shift(1).values, pi2.values)
+        self.assertEqual(len(pi1), len(pi2))
+        self.assert_index_equal(pi1.shift(1), pi2)
 
         pi1 = PeriodIndex(freq='D', start='1/1/2001', end='12/1/2009')
         pi2 = PeriodIndex(freq='D', start='12/31/2000', end='11/30/2009')
-        assert_equal(len(pi1), len(pi2))
-        assert_equal(pi1.shift(-1).values, pi2.values)
+        self.assertEqual(len(pi1), len(pi2))
+        self.assert_index_equal(pi1.shift(-1), pi2)
 
     def test_shift_nat(self):
         idx = PeriodIndex(['2011-01', '2011-02', 'NaT',
@@ -2496,37 +2501,37 @@ class TestPeriodIndex(tm.TestCase):
 
     def test_period_index_length(self):
         pi = PeriodIndex(freq='A', start='1/1/2001', end='12/1/2009')
-        assert_equal(len(pi), 9)
+        self.assertEqual(len(pi), 9)
 
         pi = PeriodIndex(freq='Q', start='1/1/2001', end='12/1/2009')
-        assert_equal(len(pi), 4 * 9)
+        self.assertEqual(len(pi), 4 * 9)
 
         pi = PeriodIndex(freq='M', start='1/1/2001', end='12/1/2009')
-        assert_equal(len(pi), 12 * 9)
+        self.assertEqual(len(pi), 12 * 9)
 
         start = Period('02-Apr-2005', 'B')
         i1 = PeriodIndex(start=start, periods=20)
-        assert_equal(len(i1), 20)
-        assert_equal(i1.freq, start.freq)
-        assert_equal(i1[0], start)
+        self.assertEqual(len(i1), 20)
+        self.assertEqual(i1.freq, start.freq)
+        self.assertEqual(i1[0], start)
 
         end_intv = Period('2006-12-31', 'W')
         i1 = PeriodIndex(end=end_intv, periods=10)
-        assert_equal(len(i1), 10)
-        assert_equal(i1.freq, end_intv.freq)
-        assert_equal(i1[-1], end_intv)
+        self.assertEqual(len(i1), 10)
+        self.assertEqual(i1.freq, end_intv.freq)
+        self.assertEqual(i1[-1], end_intv)
 
         end_intv = Period('2006-12-31', '1w')
         i2 = PeriodIndex(end=end_intv, periods=10)
-        assert_equal(len(i1), len(i2))
+        self.assertEqual(len(i1), len(i2))
         self.assertTrue((i1 == i2).all())
-        assert_equal(i1.freq, i2.freq)
+        self.assertEqual(i1.freq, i2.freq)
 
         end_intv = Period('2006-12-31', ('w', 1))
         i2 = PeriodIndex(end=end_intv, periods=10)
-        assert_equal(len(i1), len(i2))
+        self.assertEqual(len(i1), len(i2))
         self.assertTrue((i1 == i2).all())
-        assert_equal(i1.freq, i2.freq)
+        self.assertEqual(i1.freq, i2.freq)
 
         try:
             PeriodIndex(start=start, end=end_intv)
@@ -2546,12 +2551,12 @@ class TestPeriodIndex(tm.TestCase):
 
         # infer freq from first element
         i2 = PeriodIndex([end_intv, Period('2005-05-05', 'B')])
-        assert_equal(len(i2), 2)
-        assert_equal(i2[0], end_intv)
+        self.assertEqual(len(i2), 2)
+        self.assertEqual(i2[0], end_intv)
 
         i2 = PeriodIndex(np.array([end_intv, Period('2005-05-05', 'B')]))
-        assert_equal(len(i2), 2)
-        assert_equal(i2[0], end_intv)
+        self.assertEqual(len(i2), 2)
+        self.assertEqual(i2[0], end_intv)
 
         # Mixed freq should fail
         vals = [end_intv, Period('2006-12-31', 'w')]
@@ -3124,9 +3129,9 @@ class TestPeriodIndex(tm.TestCase):
 
         for field in fields:
             field_idx = getattr(periodindex, field)
-            assert_equal(len(periodindex), len(field_idx))
+            self.assertEqual(len(periodindex), len(field_idx))
             for x, val in zip(periods, field_idx):
-                assert_equal(getattr(x, field), val)
+                self.assertEqual(getattr(x, field), val)
 
     def test_is_full(self):
         index = PeriodIndex([2005, 2007, 2009], freq='A')
@@ -3327,8 +3332,8 @@ class TestMethods(tm.TestCase):
     def test_add(self):
         dt1 = Period(freq='D', year=2008, month=1, day=1)
         dt2 = Period(freq='D', year=2008, month=1, day=2)
-        assert_equal(dt1 + 1, dt2)
-        assert_equal(1 + dt1, dt2)
+        self.assertEqual(dt1 + 1, dt2)
+        self.assertEqual(1 + dt1, dt2)
 
     def test_add_pdnat(self):
         p = pd.Period('2011-01', freq='M')

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -4,8 +4,6 @@ import nose
 from pandas.compat import lrange, zip
 
 import numpy as np
-from numpy.testing.decorators import slow
-
 from pandas import Index, Series, DataFrame
 
 from pandas.tseries.index import date_range, bdate_range
@@ -13,7 +11,7 @@ from pandas.tseries.offsets import DateOffset
 from pandas.tseries.period import period_range, Period, PeriodIndex
 from pandas.tseries.resample import DatetimeIndex
 
-from pandas.util.testing import assert_series_equal, ensure_clean
+from pandas.util.testing import assert_series_equal, ensure_clean, slow
 import pandas.util.testing as tm
 
 from pandas.tests.test_graphics import _skip_if_no_scipy_gaussian_kde

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -16,7 +16,6 @@ from pandas import compat, to_timedelta, tslib
 from pandas.tseries.timedeltas import _coerce_scalar_to_timedelta_type as ct
 from pandas.util.testing import (assert_series_equal, assert_frame_equal,
                                  assert_almost_equal, assert_index_equal)
-from numpy.testing import assert_allclose
 from pandas.tseries.offsets import Day, Second
 import pandas.util.testing as tm
 from numpy.random import randn
@@ -1224,7 +1223,7 @@ class TestTimedeltaIndex(tm.TestCase):
                               freq='s')
         expt = [1 * 86400 + 10 * 3600 + 11 * 60 + 12 + 100123456. / 1e9,
                 1 * 86400 + 10 * 3600 + 11 * 60 + 13 + 100123456. / 1e9]
-        assert_allclose(rng.total_seconds(), expt, atol=1e-10, rtol=0)
+        tm.assert_almost_equal(rng.total_seconds(), expt)
 
         # test Series
         s = Series(rng)
@@ -1239,14 +1238,14 @@ class TestTimedeltaIndex(tm.TestCase):
 
         # with both nat
         s = Series([np.nan, np.nan], dtype='timedelta64[ns]')
-        tm.assert_series_equal(s.dt.total_seconds(), Series(
-            [np.nan, np.nan], index=[0, 1]))
+        tm.assert_series_equal(s.dt.total_seconds(),
+                               Series([np.nan, np.nan], index=[0, 1]))
 
     def test_total_seconds_scalar(self):
         # GH 10939
         rng = Timedelta('1 days, 10:11:12.100123456')
         expt = 1 * 86400 + 10 * 3600 + 11 * 60 + 12 + 100123456. / 1e9
-        assert_allclose(rng.total_seconds(), expt, atol=1e-10, rtol=0)
+        tm.assert_almost_equal(rng.total_seconds(), expt)
 
         rng = Timedelta(np.nan)
         self.assertTrue(np.isnan(rng.total_seconds()))

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -5,7 +5,6 @@ import sys
 import warnings
 from datetime import datetime, time, timedelta
 from numpy.random import rand
-from numpy.testing.decorators import slow
 
 import nose
 import numpy as np
@@ -31,7 +30,7 @@ from pandas.core.common import PerformanceWarning
 from pandas.tslib import iNaT
 from pandas.util.testing import (
     assert_frame_equal, assert_series_equal, assert_almost_equal,
-    _skip_if_has_locale)
+    _skip_if_has_locale, slow)
 
 randn = np.random.randn
 
@@ -1110,8 +1109,8 @@ class TestTimeSeries(tm.TestCase):
         index = pd.date_range('20130101', periods=20, name=index_name)
         df = pd.DataFrame([x for x in range(20)], columns=['foo'], index=index)
 
-        tm.assert_equal(index_name, df.index.name)
-        tm.assert_equal(index_name, df.asfreq('10D').index.name)
+        self.assertEqual(index_name, df.index.name)
+        self.assertEqual(index_name, df.asfreq('10D').index.name)
 
     def test_promote_datetime_date(self):
         rng = date_range('1/1/2000', periods=20)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -19,6 +19,7 @@ from contextlib import contextmanager
 from distutils.version import LooseVersion
 
 from numpy.random import randn, rand
+from numpy.testing.decorators import slow     # noqa
 import numpy as np
 
 import pandas as pd


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`

Not to use `np.testing.assert_equal`, as `assert_numpy_array_equal` is more strict to check dtypes.
