### PR TITLE
TST: assert_dict_equal to check input type

### DIFF
--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -220,8 +220,14 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         frame = DataFrame({'col1': self.ts1,
                            'col2': self.ts2})
 
-        tm.assert_dict_equal(self.ts1, frame['col1'], compare_keys=False)
-        tm.assert_dict_equal(self.ts2, frame['col2'], compare_keys=False)
+        # col2 is padded with NaN
+        self.assertEqual(len(self.ts1), 30)
+        self.assertEqual(len(self.ts2), 25)
+
+        tm.assert_series_equal(self.ts1, frame['col1'], check_names=False)
+        exp = pd.Series(np.concatenate([[np.nan] * 5, self.ts2.values]),
+                        index=self.ts1.index, name='col2')
+        tm.assert_series_equal(exp, frame['col2'])
 
         frame = DataFrame({'col1': self.ts1,
                            'col2': self.ts2},

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -393,13 +393,17 @@ class TestDataFrameIndexing(tm.TestCase, TestData):
         series = self.frame['A'][::2]
         self.frame['col5'] = series
         self.assertIn('col5', self.frame)
-        tm.assert_dict_equal(series, self.frame['col5'],
-                             compare_keys=False)
+
+        self.assertEqual(len(series), 15)
+        self.assertEqual(len(self.frame), 30)
+
+        exp = np.ravel(np.column_stack((series.values, [np.nan] * 15)))
+        exp = Series(exp, index=self.frame.index, name='col5')
+        tm.assert_series_equal(self.frame['col5'], exp)
 
         series = self.frame['A']
         self.frame['col6'] = series
-        tm.assert_dict_equal(series, self.frame['col6'],
-                             compare_keys=False)
+        tm.assert_series_equal(series, self.frame['col6'], check_names=False)
 
         with tm.assertRaises(KeyError):
             self.frame[randn(len(self.frame) + 1)] = 1

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -724,9 +724,14 @@ class TestDataFrameOperators(tm.TestCase, TestData):
         frame_copy['C'][:5] = nan
 
         added = self.frame + frame_copy
-        tm.assert_dict_equal(added['A'].valid(),
-                             self.frame['A'] * 2,
-                             compare_keys=False)
+
+        indexer = added['A'].valid().index
+        exp = (self.frame['A'] * 2).copy()
+
+        tm.assert_series_equal(added['A'].valid(), exp.loc[indexer])
+
+        exp.loc[~exp.index.isin(indexer)] = np.nan
+        tm.assert_series_equal(added['A'], exp.loc[added['A'].index])
 
         self.assertTrue(
             np.isnan(added['C'].reindex(frame_copy.index)[:5]).all())

--- a/pandas/tests/frame/test_timeseries.py
+++ b/pandas/tests/frame/test_timeseries.py
@@ -120,13 +120,13 @@ class TestDataFrameTimeSeriesMethods(tm.TestCase, TestData):
     def test_shift(self):
         # naive shift
         shiftedFrame = self.tsframe.shift(5)
-        self.assertTrue(shiftedFrame.index.equals(self.tsframe.index))
+        self.assert_index_equal(shiftedFrame.index, self.tsframe.index)
 
         shiftedSeries = self.tsframe['A'].shift(5)
         assert_series_equal(shiftedFrame['A'], shiftedSeries)
 
         shiftedFrame = self.tsframe.shift(-5)
-        self.assertTrue(shiftedFrame.index.equals(self.tsframe.index))
+        self.assert_index_equal(shiftedFrame.index, self.tsframe.index)
 
         shiftedSeries = self.tsframe['A'].shift(-5)
         assert_series_equal(shiftedFrame['A'], shiftedSeries)
@@ -154,10 +154,10 @@ class TestDataFrameTimeSeriesMethods(tm.TestCase, TestData):
         ps = tm.makePeriodFrame()
         shifted = ps.shift(1)
         unshifted = shifted.shift(-1)
-        self.assertTrue(shifted.index.equals(ps.index))
-
-        tm.assert_dict_equal(unshifted.ix[:, 0].valid(), ps.ix[:, 0],
-                             compare_keys=False)
+        self.assert_index_equal(shifted.index, ps.index)
+        self.assert_index_equal(unshifted.index, ps.index)
+        tm.assert_numpy_array_equal(unshifted.ix[:, 0].valid().values,
+                                    ps.ix[:-1, 0].values)
 
         shifted2 = ps.shift(1, 'B')
         shifted3 = ps.shift(1, datetools.bday)

--- a/pandas/tests/series/test_combine_concat.py
+++ b/pandas/tests/series/test_combine_concat.py
@@ -65,8 +65,9 @@ class TestSeriesCombine(TestData, tm.TestCase):
 
         combined = strings.combine_first(floats)
 
-        tm.assert_dict_equal(strings, combined, compare_keys=False)
-        tm.assert_dict_equal(floats[1::2], combined, compare_keys=False)
+        tm.assert_series_equal(strings, combined.loc[index[::2]])
+        tm.assert_series_equal(floats[1::2].astype(object),
+                               combined.loc[index[1::2]])
 
         # corner case
         s = Series([1., 2, 3], index=[0, 1, 2])

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -433,8 +433,8 @@ class TestSeriesMissingData(TestData, tm.TestCase):
 
         result = ts.valid()
         self.assertEqual(len(result), ts.count())
-
-        tm.assert_dict_equal(result, ts, compare_keys=False)
+        tm.assert_series_equal(result, ts[1::2])
+        tm.assert_series_equal(result, ts[pd.notnull(ts)])
 
     def test_isnull(self):
         ser = Series([0, 5.4, 3, nan, -0.001])

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -25,7 +25,10 @@ class TestSeriesTimeSeries(TestData, tm.TestCase):
         shifted = self.ts.shift(1)
         unshifted = shifted.shift(-1)
 
-        tm.assert_dict_equal(unshifted.valid(), self.ts, compare_keys=False)
+        tm.assert_index_equal(shifted.index, self.ts.index)
+        tm.assert_index_equal(unshifted.index, self.ts.index)
+        tm.assert_numpy_array_equal(unshifted.valid().values,
+                                    self.ts.values[:-1])
 
         offset = datetools.bday
         shifted = self.ts.shift(1, freq=offset)
@@ -49,7 +52,9 @@ class TestSeriesTimeSeries(TestData, tm.TestCase):
         ps = tm.makePeriodSeries()
         shifted = ps.shift(1)
         unshifted = shifted.shift(-1)
-        tm.assert_dict_equal(unshifted.valid(), ps, compare_keys=False)
+        tm.assert_index_equal(shifted.index, ps.index)
+        tm.assert_index_equal(unshifted.index, ps.index)
+        tm.assert_numpy_array_equal(unshifted.valid().values, ps.values[:-1])
 
         shifted2 = ps.shift(1, 'B')
         shifted3 = ps.shift(1, datetools.bday)
@@ -77,16 +82,16 @@ class TestSeriesTimeSeries(TestData, tm.TestCase):
 
         # xref 8260
         # with tz
-        s = Series(
-            date_range('2000-01-01 09:00:00', periods=5,
-                       tz='US/Eastern'), name='foo')
+        s = Series(date_range('2000-01-01 09:00:00', periods=5,
+                              tz='US/Eastern'), name='foo')
         result = s - s.shift()
-        assert_series_equal(result, Series(
-            TimedeltaIndex(['NaT'] + ['1 days'] * 4), name='foo'))
+
+        exp = Series(TimedeltaIndex(['NaT'] + ['1 days'] * 4), name='foo')
+        assert_series_equal(result, exp)
 
         # incompat tz
-        s2 = Series(
-            date_range('2000-01-01 09:00:00', periods=5, tz='CET'), name='foo')
+        s2 = Series(date_range('2000-01-01 09:00:00', periods=5,
+                               tz='CET'), name='foo')
         self.assertRaises(ValueError, lambda: s - s2)
 
     def test_tshift(self):

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -131,7 +131,13 @@ def assert_almost_equal(left, right, check_exact=False, **kwargs):
     return _testing.assert_almost_equal(left, right, **kwargs)
 
 
-assert_dict_equal = _testing.assert_dict_equal
+def assert_dict_equal(left, right, compare_keys=True):
+
+    # instance validation
+    assertIsInstance(left, dict, '[dict] ')
+    assertIsInstance(right, dict, '[dict] ')
+
+    return _testing.assert_dict_equal(left, right, compare_keys=compare_keys)
 
 
 def randbool(size=(), p=0.5):


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`

`assert_dict_equal` now checks input is `dict` instance. Fixed some tests which passes `Series` to it.
