### PR TITLE
improves usability of style calls on axis=1 by automatically creating…

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -252,3 +252,5 @@ Bug Fixes
 - Bug in ``groupby`` where ``apply`` returns different result depending on whether first result is ``None`` or not (:issue:`12824`)
 
 - Bug in ``Categorical.remove_unused_categories()`` changes ``.codes`` dtype to platform int (:issue:`13261`)
+
+- Bug in Style calls specifying axis=1 and a subset of id's (:issue:`13273`)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1927,10 +1927,12 @@ def maybe_droplevels(index, key):
 
 def _non_reducing_slice(slice_, axis=0):
     """
-    Ensurse that a slice doesn't reduce to a Series or Scalar.
+    Ensure that a slice doesn't reduce to a Series or Scalar.
 
-    Any user-paseed `subset` should have this called on it
+    Any user-passed `subset` should have this called on it
     to make sure we're always working with DataFrames.
+
+    axis will determine the specification of the IndexSlice
     """
     # default to column slice, like DataFrame
     # ['A', 'B'] -> IndexSlices[:, ['A', 'B']]

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1925,7 +1925,7 @@ def maybe_droplevels(index, key):
     return index
 
 
-def _non_reducing_slice(slice_):
+def _non_reducing_slice(slice_, axis=0):
     """
     Ensurse that a slice doesn't reduce to a Series or Scalar.
 
@@ -1937,7 +1937,10 @@ def _non_reducing_slice(slice_):
     kinds = tuple(list(compat.string_types) + [ABCSeries, np.ndarray, Index,
                                                list])
     if isinstance(slice_, kinds):
-        slice_ = IndexSlice[:, slice_]
+        if axis == 0:
+            slice_ = IndexSlice[:, slice_]
+        elif axis == 1:
+            slice_ = IndexSlice[slice_, :]
 
     def pred(part):
         # true when slice does *not* reduce

--- a/pandas/formats/style.py
+++ b/pandas/formats/style.py
@@ -426,7 +426,7 @@ class Styler(object):
 
     def _apply(self, func, axis=0, subset=None, **kwargs):
         subset = slice(None) if subset is None else subset
-        subset = _non_reducing_slice(subset)
+        subset = _non_reducing_slice(subset, axis)
         if axis is not None:
             result = self.data.loc[subset].apply(func, axis=axis, **kwargs)
         else:
@@ -701,7 +701,7 @@ class Styler(object):
         and ``high * (x.max() - x.min())`` before normalizing.
         """
         subset = _maybe_numeric_slice(self.data, subset)
-        subset = _non_reducing_slice(subset)
+        subset = _non_reducing_slice(subset, axis)
         self.apply(self._background_gradient, cmap=cmap, subset=subset,
                    axis=axis, low=low, high=high)
         return self
@@ -779,7 +779,7 @@ class Styler(object):
         self : Styler
         """
         subset = _maybe_numeric_slice(self.data, subset)
-        subset = _non_reducing_slice(subset)
+        subset = _non_reducing_slice(subset, axis)
         self.apply(self._bar, subset=subset, axis=axis, color=color,
                    width=width)
         return self

--- a/pandas/tests/formats/test_style.py
+++ b/pandas/tests/formats/test_style.py
@@ -556,8 +556,11 @@ class TestStylerMatplotlibDep(TestCase):
                     ._compute().ctx)
         self.assertEqual(result[(1, 0)], ['background-color: #fff7fb'])
 
-        self.assertEqual(df.style.background_gradient(subset=pd.IndexSlice[:, 'A':'B'], axis=0)._compute().ctx,
-                         df.style.background_gradient(subset=['A','B'], axis=0)._compute().ctx)
+        grad = df.style.background_gradient
+        self.assertEqual(
+            grad(subset=pd.IndexSlice[:, 'A':'B'], axis=0)._compute().ctx,
+            grad(subset=['A', 'B'], axis=0)._compute().ctx)
 
-        self.assertEqual(df.style.background_gradient(subset=pd.IndexSlice[0:1, ], axis=1)._compute().ctx,
-                         df.style.background_gradient(subset=[0, 1], axis=1)._compute().ctx)
+        self.assertEqual(
+            grad(subset=pd.IndexSlice[0:1, ], axis=1)._compute().ctx,
+            grad(subset=[0, 1], axis=1)._compute().ctx)

--- a/pandas/tests/formats/test_style.py
+++ b/pandas/tests/formats/test_style.py
@@ -555,3 +555,9 @@ class TestStylerMatplotlibDep(TestCase):
         result = (df.style.background_gradient(subset=pd.IndexSlice[1, 'A'])
                     ._compute().ctx)
         self.assertEqual(result[(1, 0)], ['background-color: #fff7fb'])
+
+        self.assertEqual(df.style.background_gradient(subset=pd.IndexSlice[:, 'A':'B'], axis=0)._compute().ctx,
+                         df.style.background_gradient(subset=['A','B'], axis=0)._compute().ctx)
+
+        self.assertEqual(df.style.background_gradient(subset=pd.IndexSlice[0:1, ], axis=1)._compute().ctx,
+                         df.style.background_gradient(subset=[0, 1], axis=1)._compute().ctx)


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry

… the IndexSlice same as it does for axis=1

```
df = pd.DataFrame(index = ['x', 'y', 'z'])
df['a'] = [1,2,3]
df['b'] = [4,5,6]
df['c'] = [7,8,9]
df

df.style.background_gradient(subset='x', axis=1)
```
# otherwise this throws some vague exception. seems like if you pass in

axis this should just work

`df.style.background_gradient(subset=pd.IndexSlice['x',], axis=1)` #same
as this
