### PR TITLE
Remove imp and just use importlib to avoid memory error when importin…

### DIFF
--- a/pandas/util/print_versions.py
+++ b/pandas/util/print_versions.py
@@ -4,6 +4,7 @@ import sys
 import struct
 import subprocess
 import codecs
+import importlib
 
 
 def get_sys_info():
@@ -98,7 +99,6 @@ def show_versions(as_json=False):
     deps_blob = list()
     for (modname, ver_f) in deps:
         try:
-            import importlib
             mod = importlib.import_module(modname)
             ver = ver_f(mod)
             deps_blob.append((modname, ver))

--- a/pandas/util/print_versions.py
+++ b/pandas/util/print_versions.py
@@ -55,7 +55,6 @@ def get_sys_info():
 
 
 def show_versions(as_json=False):
-    import imp
     sys_info = get_sys_info()
 
     deps = [
@@ -99,11 +98,8 @@ def show_versions(as_json=False):
     deps_blob = list()
     for (modname, ver_f) in deps:
         try:
-            try:
-                mod = imp.load_module(modname, *imp.find_module(modname))
-            except (ImportError):
-                import importlib
-                mod = importlib.import_module(modname)
+            import importlib
+            mod = importlib.import_module(modname)
             ver = ver_f(mod)
             deps_blob.append((modname, ver))
         except:


### PR DESCRIPTION
- [ ] closes #13282

Remove imp from pandas.show_versions() to fix memory problem.
