### PR TITLE
COMPAT: extension dtypes (DatetimeTZ, Categorical) are now Singleton cached objects

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -242,7 +242,7 @@ Bug Fixes
 
 - Bug in ``Series`` arithmetic raises ``TypeError`` if it contains datetime-like as ``object`` dtype (:issue:`13043`)
 
-
+- Bug in extension dtype creation where the created types were not is/identical (:issue:`13285`)
 
 - Bug in ``NaT`` - ``Period`` raises ``AttributeError`` (:issue:`13071`)
 - Bug in ``Period`` addition raises ``TypeError`` if ``Period`` is on right hand side (:issue:`13069`)

--- a/pandas/tests/types/test_dtypes.py
+++ b/pandas/tests/types/test_dtypes.py
@@ -45,6 +45,16 @@ class TestCategoricalDtype(Base, tm.TestCase):
     def setUp(self):
         self.dtype = CategoricalDtype()
 
+    def test_hash_vs_equality(self):
+        # make sure that we satisfy is semantics
+        dtype = self.dtype
+        dtype2 = CategoricalDtype()
+        self.assertTrue(dtype == dtype2)
+        self.assertTrue(dtype2 == dtype)
+        self.assertTrue(dtype is dtype2)
+        self.assertTrue(dtype2 is dtype)
+        self.assertTrue(hash(dtype) == hash(dtype2))
+
     def test_equality(self):
         self.assertTrue(is_dtype_equal(self.dtype, 'category'))
         self.assertTrue(is_dtype_equal(self.dtype, CategoricalDtype()))
@@ -87,6 +97,20 @@ class TestDatetimeTZDtype(Base, tm.TestCase):
 
     def setUp(self):
         self.dtype = DatetimeTZDtype('ns', 'US/Eastern')
+
+    def test_hash_vs_equality(self):
+        # make sure that we satisfy is semantics
+        dtype = self.dtype
+        dtype2 = DatetimeTZDtype('ns', 'US/Eastern')
+        dtype3 = DatetimeTZDtype(dtype2)
+        self.assertTrue(dtype == dtype2)
+        self.assertTrue(dtype2 == dtype)
+        self.assertTrue(dtype3 == dtype)
+        self.assertTrue(dtype is dtype2)
+        self.assertTrue(dtype2 is dtype)
+        self.assertTrue(dtype3 is dtype)
+        self.assertTrue(hash(dtype) == hash(dtype2))
+        self.assertTrue(hash(dtype) == hash(dtype3))
 
     def test_construction(self):
         self.assertRaises(ValueError,


### PR DESCRIPTION
allows for proper is / == comparisons
Had this odd semantic difference as these were really different objects (though they DID hash the same)
This doesn't actually affect any user code.

```
In [1]: from pandas.core import common as com

In [2]: t1 = com.DatetimeTZDtype('datetime64[ns, US/Eastern]')

In [3]: t2 = com.DatetimeTZDtype('datetime64[ns, US/Eastern]')

In [4]: t1 == t2
Out[4]: True

In [5]: t1 is t2
Out[5]: False

In [6]: hash(t1)
Out[6]: 5756291921003024619

In [7]: hash(t2)
Out[7]: 5756291921003024619
```
