### PR TITLE
BUG: Fix describe(): percentiles (#13104), col index (#13288)

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -228,6 +228,75 @@ resulting dtype will be upcast (unchanged from previous).
    pd.merge(df1, df2, how='outer', on='key')
    pd.merge(df1, df2, how='outer', on='key').dtypes
 
+.. _whatsnew_0182.api.describe:
+
+``.describe()`` changes
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Percentile identifiers in the index of a ``.describe()`` output will now be rounded to the least precision that keeps them distinct (:issue:`13104`)
+
+.. ipython:: python
+
+   s = pd.Series([0, 1, 2, 3, 4])
+   df = pd.DataFrame([0, 1, 2, 3, 4])
+
+Previous Behavior:
+
+They were rounded to at most one decimal place, which could raise ``ValueError`` for a data frame.
+
+.. code-block:: ipython
+
+   In [3]: s.describe(percentiles=[0.0001, 0.0005, 0.001, 0.999, 0.9995, 0.9999])
+   Out[3]:
+   count     5.000000
+   mean      2.000000
+   std       1.581139
+   min       0.000000
+   0.0%      0.000400
+   0.1%      0.002000
+   0.1%      0.004000
+   50%       2.000000
+   99.9%     3.996000
+   100.0%    3.998000
+   100.0%    3.999600
+   max       4.000000
+   dtype: float64
+
+   In [4]: df.describe(percentiles=[0.0001, 0.0005, 0.001, 0.999, 0.9995, 0.9999])
+   Out[4]:
+   ...
+   ValueError: cannot reindex from a duplicate axis
+
+New Behavior:
+
+.. ipython:: python
+
+   s.describe(percentiles=[0.0001, 0.0005, 0.001, 0.999, 0.9995, 0.9999])
+   df.describe(percentiles=[0.0001, 0.0005, 0.001, 0.999, 0.9995, 0.9999])
+
+In addition to this, both ``Series.describe()`` and ``DataFrame.describe()`` will now raise ``ValueError`` if passed ``pecentiles`` contain duplicates.
+
+Another bug is fixed that could raise ``TypeError`` when a column index of a data frame contained entries of different types (:issue:`13288`)
+
+.. ipython:: python
+
+   df = pd.DataFrame({'A': list("BCDE"), 0: [1, 2, 3, 4]})
+
+Previous Behavior:
+
+.. code-block:: ipython
+
+   In [8]: df.describe()
+   Out[8]:
+   ...
+   ValueError: Buffer dtype mismatch, expected 'Python object' but got 'long'
+
+New Behavior:
+
+.. ipython:: python
+
+   df.describe()
+
 .. _whatsnew_0182.api.other:
 
 Other API changes

--- a/pandas/formats/format.py
+++ b/pandas/formats/format.py
@@ -6,7 +6,7 @@ from distutils.version import LooseVersion
 import sys
 
 from pandas.core.base import PandasObject
-from pandas.core.common import isnull, notnull
+from pandas.core.common import isnull, notnull, is_numeric_dtype
 from pandas.core.index import Index, MultiIndex, _ensure_index
 from pandas import compat
 from pandas.compat import (StringIO, lzip, range, map, zip, reduce, u,
@@ -2258,6 +2258,67 @@ class CategoricalArrayFormatter(GenericArrayFormatter):
                                   na_rep=self.na_rep, digits=self.digits,
                                   space=self.space, justify=self.justify)
         return fmt_values
+
+
+def format_percentiles(percentiles):
+    """
+    Outputs rounded and formatted percentiles.
+
+    Parameters
+    ----------
+    percentiles : list-like, containing floats from interval [0,1]
+
+    Returns
+    -------
+    formatted : list of strings
+
+    Notes
+    -----
+    Rounding precision is chosen so that: (1) if any two elements of
+    ``percentiles`` differ, they remain different after rounding
+    (2) no entry is *rounded* to 0% or 100%.
+    Any non-integer is always rounded to at least 1 decimal place.
+
+    Examples
+    --------
+    Keeps all entries different after rounding:
+
+    >>> format_percentiles([0.01999, 0.02001, 0.5, 0.666666, 0.9999])
+    ['1.999%', '2.001%', '50%', '66.667%', '99.99%']
+
+    No element is rounded to 0% or 100% (unless already equal to it).
+    Duplicates are allowed:
+
+    >>> format_percentiles([0, 0.5, 0.02001, 0.5, 0.666666, 0.9999])
+    ['0%', '50%', '2.0%', '50%', '66.67%', '99.99%']
+    """
+
+    percentiles = np.asarray(percentiles)
+
+    # It checks for np.NaN as well
+    if not is_numeric_dtype(percentiles) or not np.all(percentiles >= 0) \
+            or not np.all(percentiles <= 1):
+        raise ValueError("percentiles should all be in the interval [0,1]")
+
+    percentiles = 100 * percentiles
+    int_idx = (percentiles.astype(int) == percentiles)
+
+    if np.all(int_idx):
+        out = percentiles.astype(int).astype(str)
+        return [i + '%' for i in out]
+
+    unique_pcts = np.unique(percentiles)
+    to_begin = unique_pcts[0] if unique_pcts[0] > 0 else None
+    to_end = 100 - unique_pcts[-1] if unique_pcts[-1] < 100 else None
+    # Least precision that keeps percentiles unique after rounding
+    prec = -np.floor(np.log10(np.min(
+        np.ediff1d(unique_pcts, to_begin=to_begin, to_end=to_end)
+    ))).astype(int)
+    prec = max(1, prec)
+    out = np.empty_like(percentiles, dtype=object)
+    out[int_idx] = percentiles[int_idx].astype(int).astype(str)
+    out[~int_idx] = percentiles[~int_idx].round(prec).astype(str)
+    return [i + '%' for i in out]
 
 
 def _is_dates_only(values):

--- a/pandas/tests/formats/test_format.py
+++ b/pandas/tests/formats/test_format.py
@@ -4264,6 +4264,21 @@ class TestStringRepTimestamp(tm.TestCase):
             self.assertEqual(f(pd.NaT), 'NaT')
 
 
+def test_format_percentiles():
+    result = fmt.format_percentiles([0.01999, 0.02001, 0.5, 0.666666, 0.9999])
+    expected = ['1.999%', '2.001%', '50%', '66.667%', '99.99%']
+    tm.assert_equal(result, expected)
+
+    result = fmt.format_percentiles([0, 0.5, 0.02001, 0.5, 0.666666, 0.9999])
+    expected = ['0%', '50%', '2.0%', '50%', '66.67%', '99.99%']
+    tm.assert_equal(result, expected)
+
+    tm.assertRaises(ValueError, fmt.format_percentiles, [0.1, np.nan, 0.5])
+    tm.assertRaises(ValueError, fmt.format_percentiles, [-0.001, 0.1, 0.5])
+    tm.assertRaises(ValueError, fmt.format_percentiles, [2, 0.1, 0.5])
+    tm.assertRaises(ValueError, fmt.format_percentiles, [0.1, 0.5, 'a'])
+
+
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
                    exit=False)


### PR DESCRIPTION
- [x] closes #13104, #13288
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

BUG #13104:
- Percentiles are now rounded to the least precision that keeps
  them unique.
- Supplying duplicates in percentiles will raise ValueError.

BUG #13288
- Fixed a column index of the output data frame.
  Previously, if a data frame had a column index of object type and
  the index contained numeric values, the output column index could
  be corrupt. It led to ValueError if the output was displayed.
