### PR TITLE
TST: Make numpy_array test strict

### DIFF
--- a/pandas/computation/tests/test_eval.py
+++ b/pandas/computation/tests/test_eval.py
@@ -185,6 +185,16 @@ class TestEvalNumexprPandas(tm.TestCase):
                                                  mids, cmp_ops, self.rhses):
             self.check_chained_cmp_op(lhs, cmp1, mid, cmp2, rhs)
 
+    def check_equal(self, result, expected):
+        if isinstance(result, DataFrame):
+            tm.assert_frame_equal(result, expected)
+        elif isinstance(result, Series):
+            tm.assert_series_equal(result, expected)
+        elif isinstance(result, np.ndarray):
+            tm.assert_numpy_array_equal(result, expected)
+        else:
+            self.assertEqual(result, expected)
+
     def check_complex_cmp_op(self, lhs, cmp1, rhs, binop, cmp2):
         skip_these = _scalar_skip
         ex = '(lhs {cmp1} rhs) {binop} (lhs {cmp2} rhs)'.format(cmp1=cmp1,
@@ -218,7 +228,7 @@ class TestEvalNumexprPandas(tm.TestCase):
                 expected = _eval_single_bin(
                     lhs_new, binop, rhs_new, self.engine)
                 result = pd.eval(ex, engine=self.engine, parser=self.parser)
-                tm.assert_numpy_array_equal(result, expected)
+                self.check_equal(result, expected)
 
     def check_chained_cmp_op(self, lhs, cmp1, mid, cmp2, rhs):
         skip_these = _scalar_skip
@@ -249,7 +259,7 @@ class TestEvalNumexprPandas(tm.TestCase):
         else:
             expected = _eval_single_bin(lhs, cmp1, rhs, self.engine)
             result = pd.eval(ex, engine=self.engine, parser=self.parser)
-            tm.assert_numpy_array_equal(result, expected)
+            self.check_equal(result, expected)
 
     def check_binary_arith_op(self, lhs, arith1, rhs):
         ex = 'lhs {0} rhs'.format(arith1)
@@ -293,7 +303,7 @@ class TestEvalNumexprPandas(tm.TestCase):
         if self.engine == 'python':
             res = pd.eval(ex, engine=self.engine, parser=self.parser)
             expected = lhs // rhs
-            tm.assert_numpy_array_equal(res, expected)
+            self.check_equal(res, expected)
         else:
             self.assertRaises(TypeError, pd.eval, ex, local_dict={'lhs': lhs,
                                                                   'rhs': rhs},

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -316,8 +316,8 @@ def array_equivalent(left, right, strict_nan=False):
 
         if not strict_nan:
             # pd.isnull considers NaN and None to be equivalent.
-            return lib.array_equivalent_object(
-                _ensure_object(left.ravel()), _ensure_object(right.ravel()))
+            return lib.array_equivalent_object(_ensure_object(left.ravel()),
+                                               _ensure_object(right.ravel()))
 
         for left_value, right_value in zip(left, right):
             if left_value is tslib.NaT and right_value is not tslib.NaT:

--- a/pandas/io/tests/json/test_pandas.py
+++ b/pandas/io/tests/json/test_pandas.py
@@ -99,8 +99,8 @@ class TestPandasContainer(tm.TestCase):
         assert_frame_equal(df, read_json(df.to_json(orient='split'),
                                          orient='split'))
         unser = read_json(df.to_json(orient='records'), orient='records')
-        self.assertTrue(df.columns.equals(unser.columns))
-        tm.assert_numpy_array_equal(df.values, unser.values)
+        self.assert_index_equal(df.columns, unser.columns)
+        np.testing.assert_equal(df.values, unser.values)
         unser = read_json(df.to_json(orient='values'), orient='values')
         tm.assert_numpy_array_equal(df.values, unser.values)
 
@@ -183,7 +183,8 @@ class TestPandasContainer(tm.TestCase):
                 # index is not captured in this orientation
                 assert_almost_equal(df.values, unser.values,
                                     check_dtype=check_numpy_dtype)
-                self.assertTrue(df.columns.equals(unser.columns))
+                self.assert_index_equal(df.columns, unser.columns,
+                                        exact=check_column_type)
             elif orient == "values":
                 # index and cols are not captured in this orientation
                 if numpy is True and df.shape == (0, 0):
@@ -302,12 +303,10 @@ class TestPandasContainer(tm.TestCase):
 
         # mixed data
         index = pd.Index(['a', 'b', 'c', 'd', 'e'])
-        data = {
-            'A': [0., 1., 2., 3., 4.],
-            'B': [0., 1., 0., 1., 0.],
-            'C': ['foo1', 'foo2', 'foo3', 'foo4', 'foo5'],
-            'D': [True, False, True, False, True]
-        }
+        data = {'A': [0., 1., 2., 3., 4.],
+                'B': [0., 1., 0., 1., 0.],
+                'C': ['foo1', 'foo2', 'foo3', 'foo4', 'foo5'],
+                'D': [True, False, True, False, True]}
         df = DataFrame(data=data, index=index)
         _check_orient(df, "split", check_dtype=False)
         _check_orient(df, "records", check_dtype=False)

--- a/pandas/io/tests/json/test_ujson.py
+++ b/pandas/io/tests/json/test_ujson.py
@@ -1201,19 +1201,19 @@ class PandasJSONTests(TestCase):
         # column indexed
         outp = DataFrame(ujson.decode(ujson.encode(df)))
         self.assertTrue((df == outp).values.all())
-        tm.assert_numpy_array_equal(df.columns, outp.columns)
-        tm.assert_numpy_array_equal(df.index, outp.index)
+        tm.assert_index_equal(df.columns, outp.columns)
+        tm.assert_index_equal(df.index, outp.index)
 
         dec = _clean_dict(ujson.decode(ujson.encode(df, orient="split")))
         outp = DataFrame(**dec)
         self.assertTrue((df == outp).values.all())
-        tm.assert_numpy_array_equal(df.columns, outp.columns)
-        tm.assert_numpy_array_equal(df.index, outp.index)
+        tm.assert_index_equal(df.columns, outp.columns)
+        tm.assert_index_equal(df.index, outp.index)
 
         outp = DataFrame(ujson.decode(ujson.encode(df, orient="records")))
         outp.index = df.index
         self.assertTrue((df == outp).values.all())
-        tm.assert_numpy_array_equal(df.columns, outp.columns)
+        tm.assert_index_equal(df.columns, outp.columns)
 
         outp = DataFrame(ujson.decode(ujson.encode(df, orient="values")))
         outp.index = df.index
@@ -1221,8 +1221,8 @@ class PandasJSONTests(TestCase):
 
         outp = DataFrame(ujson.decode(ujson.encode(df, orient="index")))
         self.assertTrue((df.transpose() == outp).values.all())
-        tm.assert_numpy_array_equal(df.transpose().columns, outp.columns)
-        tm.assert_numpy_array_equal(df.transpose().index, outp.index)
+        tm.assert_index_equal(df.transpose().columns, outp.columns)
+        tm.assert_index_equal(df.transpose().index, outp.index)
 
     def testDataFrameNumpy(self):
         df = DataFrame([[1, 2, 3], [4, 5, 6]], index=[
@@ -1231,21 +1231,21 @@ class PandasJSONTests(TestCase):
         # column indexed
         outp = DataFrame(ujson.decode(ujson.encode(df), numpy=True))
         self.assertTrue((df == outp).values.all())
-        tm.assert_numpy_array_equal(df.columns, outp.columns)
-        tm.assert_numpy_array_equal(df.index, outp.index)
+        tm.assert_index_equal(df.columns, outp.columns)
+        tm.assert_index_equal(df.index, outp.index)
 
         dec = _clean_dict(ujson.decode(ujson.encode(df, orient="split"),
                                        numpy=True))
         outp = DataFrame(**dec)
         self.assertTrue((df == outp).values.all())
-        tm.assert_numpy_array_equal(df.columns, outp.columns)
-        tm.assert_numpy_array_equal(df.index, outp.index)
+        tm.assert_index_equal(df.columns, outp.columns)
+        tm.assert_index_equal(df.index, outp.index)
 
-        outp = DataFrame(ujson.decode(
-            ujson.encode(df, orient="index"), numpy=True))
+        outp = DataFrame(ujson.decode(ujson.encode(df, orient="index"),
+                                      numpy=True))
         self.assertTrue((df.transpose() == outp).values.all())
-        tm.assert_numpy_array_equal(df.transpose().columns, outp.columns)
-        tm.assert_numpy_array_equal(df.transpose().index, outp.index)
+        tm.assert_index_equal(df.transpose().columns, outp.columns)
+        tm.assert_index_equal(df.transpose().index, outp.index)
 
     def testDataFrameNested(self):
         df = DataFrame([[1, 2, 3], [4, 5, 6]], index=[
@@ -1285,20 +1285,20 @@ class PandasJSONTests(TestCase):
         outp = DataFrame(*ujson.decode(ujson.encode(df),
                                        numpy=True, labelled=True))
         self.assertTrue((df.T == outp).values.all())
-        tm.assert_numpy_array_equal(df.T.columns, outp.columns)
-        tm.assert_numpy_array_equal(df.T.index, outp.index)
+        tm.assert_index_equal(df.T.columns, outp.columns)
+        tm.assert_index_equal(df.T.index, outp.index)
 
         outp = DataFrame(*ujson.decode(ujson.encode(df, orient="records"),
                                        numpy=True, labelled=True))
         outp.index = df.index
         self.assertTrue((df == outp).values.all())
-        tm.assert_numpy_array_equal(df.columns, outp.columns)
+        tm.assert_index_equal(df.columns, outp.columns)
 
         outp = DataFrame(*ujson.decode(ujson.encode(df, orient="index"),
                                        numpy=True, labelled=True))
         self.assertTrue((df == outp).values.all())
-        tm.assert_numpy_array_equal(df.columns, outp.columns)
-        tm.assert_numpy_array_equal(df.index, outp.index)
+        tm.assert_index_equal(df.columns, outp.columns)
+        tm.assert_index_equal(df.index, outp.index)
 
     def testSeries(self):
         s = Series([10, 20, 30, 40, 50, 60], name="series",
@@ -1378,42 +1378,46 @@ class PandasJSONTests(TestCase):
         i = Index([23, 45, 18, 98, 43, 11], name="index")
 
         # column indexed
-        outp = Index(ujson.decode(ujson.encode(i)))
-        self.assertTrue(i.equals(outp))
+        outp = Index(ujson.decode(ujson.encode(i)), name='index')
+        tm.assert_index_equal(i, outp)
 
-        outp = Index(ujson.decode(ujson.encode(i), numpy=True))
-        self.assertTrue(i.equals(outp))
+        outp = Index(ujson.decode(ujson.encode(i), numpy=True), name='index')
+        tm.assert_index_equal(i, outp)
 
         dec = _clean_dict(ujson.decode(ujson.encode(i, orient="split")))
         outp = Index(**dec)
-        self.assertTrue(i.equals(outp))
+        tm.assert_index_equal(i, outp)
         self.assertTrue(i.name == outp.name)
 
         dec = _clean_dict(ujson.decode(ujson.encode(i, orient="split"),
                                        numpy=True))
         outp = Index(**dec)
-        self.assertTrue(i.equals(outp))
+        tm.assert_index_equal(i, outp)
         self.assertTrue(i.name == outp.name)
 
-        outp = Index(ujson.decode(ujson.encode(i, orient="values")))
-        self.assertTrue(i.equals(outp))
+        outp = Index(ujson.decode(ujson.encode(i, orient="values")),
+                     name='index')
+        tm.assert_index_equal(i, outp)
 
-        outp = Index(ujson.decode(ujson.encode(
-            i, orient="values"), numpy=True))
-        self.assertTrue(i.equals(outp))
+        outp = Index(ujson.decode(ujson.encode(i, orient="values"),
+                                  numpy=True), name='index')
+        tm.assert_index_equal(i, outp)
 
-        outp = Index(ujson.decode(ujson.encode(i, orient="records")))
-        self.assertTrue(i.equals(outp))
+        outp = Index(ujson.decode(ujson.encode(i, orient="records")),
+                     name='index')
+        tm.assert_index_equal(i, outp)
 
-        outp = Index(ujson.decode(ujson.encode(
-            i, orient="records"), numpy=True))
-        self.assertTrue(i.equals(outp))
+        outp = Index(ujson.decode(ujson.encode(i, orient="records"),
+                                  numpy=True), name='index')
+        tm.assert_index_equal(i, outp)
 
-        outp = Index(ujson.decode(ujson.encode(i, orient="index")))
-        self.assertTrue(i.equals(outp))
+        outp = Index(ujson.decode(ujson.encode(i, orient="index")),
+                     name='index')
+        tm.assert_index_equal(i, outp)
 
-        outp = Index(ujson.decode(ujson.encode(i, orient="index"), numpy=True))
-        self.assertTrue(i.equals(outp))
+        outp = Index(ujson.decode(ujson.encode(i, orient="index"),
+                                  numpy=True), name='index')
+        tm.assert_index_equal(i, outp)
 
     def test_datetimeindex(self):
         from pandas.tseries.index import date_range
@@ -1423,7 +1427,7 @@ class PandasJSONTests(TestCase):
         encoded = ujson.encode(rng, date_unit='ns')
         decoded = DatetimeIndex(np.array(ujson.decode(encoded)))
 
-        self.assertTrue(rng.equals(decoded))
+        tm.assert_index_equal(rng, decoded)
 
         ts = Series(np.random.randn(len(rng)), index=rng)
         decoded = Series(ujson.decode(ujson.encode(ts, date_unit='ns')))

--- a/pandas/io/tests/parser/comment.py
+++ b/pandas/io/tests/parser/comment.py
@@ -19,14 +19,14 @@ class CommentTests(object):
 1,2.,4.#hello world
 5.,NaN,10.0
 """
-        expected = [[1., 2., 4.],
-                    [5., np.nan, 10.]]
+        expected = np.array([[1., 2., 4.],
+                             [5., np.nan, 10.]])
         df = self.read_csv(StringIO(data), comment='#')
-        tm.assert_almost_equal(df.values, expected)
+        tm.assert_numpy_array_equal(df.values, expected)
 
         df = self.read_table(StringIO(data), sep=',', comment='#',
                              na_values=['NaN'])
-        tm.assert_almost_equal(df.values, expected)
+        tm.assert_numpy_array_equal(df.values, expected)
 
     def test_line_comment(self):
         data = """# empty
@@ -35,10 +35,10 @@ A,B,C
 #ignore this line
 5.,NaN,10.0
 """
-        expected = [[1., 2., 4.],
-                    [5., np.nan, 10.]]
+        expected = np.array([[1., 2., 4.],
+                             [5., np.nan, 10.]])
         df = self.read_csv(StringIO(data), comment='#')
-        tm.assert_almost_equal(df.values, expected)
+        tm.assert_numpy_array_equal(df.values, expected)
 
         # check with delim_whitespace=True
         df = self.read_csv(StringIO(data.replace(',', ' ')), comment='#',
@@ -48,11 +48,11 @@ A,B,C
         # custom line terminator is not supported
         # with the Python parser yet
         if self.engine == 'c':
-            expected = [[1., 2., 4.],
-                        [5., np.nan, 10.]]
+            expected = np.array([[1., 2., 4.],
+                                 [5., np.nan, 10.]])
             df = self.read_csv(StringIO(data.replace('\n', '*')),
                                comment='#', lineterminator='*')
-            tm.assert_almost_equal(df.values, expected)
+            tm.assert_numpy_array_equal(df.values, expected)
 
     def test_comment_skiprows(self):
         data = """# empty
@@ -64,9 +64,9 @@ A,B,C
 5.,NaN,10.0
 """
         # this should ignore the first four lines (including comments)
-        expected = [[1., 2., 4.], [5., np.nan, 10.]]
+        expected = np.array([[1., 2., 4.], [5., np.nan, 10.]])
         df = self.read_csv(StringIO(data), comment='#', skiprows=4)
-        tm.assert_almost_equal(df.values, expected)
+        tm.assert_numpy_array_equal(df.values, expected)
 
     def test_comment_header(self):
         data = """# empty
@@ -77,9 +77,9 @@ A,B,C
 5.,NaN,10.0
 """
         # header should begin at the second non-comment line
-        expected = [[1., 2., 4.], [5., np.nan, 10.]]
+        expected = np.array([[1., 2., 4.], [5., np.nan, 10.]])
         df = self.read_csv(StringIO(data), comment='#', header=1)
-        tm.assert_almost_equal(df.values, expected)
+        tm.assert_numpy_array_equal(df.values, expected)
 
     def test_comment_skiprows_header(self):
         data = """# empty
@@ -94,9 +94,9 @@ A,B,C
         # skiprows should skip the first 4 lines (including comments), while
         # header should start from the second non-commented line starting
         # with line 5
-        expected = [[1., 2., 4.], [5., np.nan, 10.]]
+        expected = np.array([[1., 2., 4.], [5., np.nan, 10.]])
         df = self.read_csv(StringIO(data), comment='#', skiprows=4, header=1)
-        tm.assert_almost_equal(df.values, expected)
+        tm.assert_numpy_array_equal(df.values, expected)
 
     def test_custom_comment_char(self):
         data = "a,b,c\n1,2,3#ignore this!\n4,5,6#ignorethistoo"

--- a/pandas/io/tests/parser/common.py
+++ b/pandas/io/tests/parser/common.py
@@ -232,14 +232,14 @@ Klosterdruckerei\tKlosterdruckerei <Kempten> (1609-1805)\tHochfurstliche Buchhan
 6,7,8,9,10
 11,12,13,14,15
 """
-        expected = [[1, 2, 3, 4, 5.],
-                    [6, 7, 8, 9, 10],
-                    [11, 12, 13, 14, 15]]
+        expected = np.array([[1, 2, 3, 4, 5],
+                             [6, 7, 8, 9, 10],
+                             [11, 12, 13, 14, 15]], dtype=np.int64)
         df = self.read_table(StringIO(data), sep=',')
         tm.assert_almost_equal(df.values, expected)
-        self.assert_numpy_array_equal(df.columns,
-                                      ['A', 'B', 'C', 'Unnamed: 3',
-                                       'Unnamed: 4'])
+        self.assert_index_equal(df.columns,
+                                Index(['A', 'B', 'C', 'Unnamed: 3',
+                                       'Unnamed: 4']))
 
     def test_duplicate_columns(self):
         # TODO: add test for condition 'mangle_dupe_cols=False'
@@ -275,7 +275,7 @@ c,4,5
         df = self.read_csv(self.csv1, index_col=0, parse_dates=True)
         df2 = self.read_table(self.csv1, sep=',', index_col=0,
                               parse_dates=True)
-        self.assert_numpy_array_equal(df.columns, ['A', 'B', 'C', 'D'])
+        self.assert_index_equal(df.columns, pd.Index(['A', 'B', 'C', 'D']))
         self.assertEqual(df.index.name, 'index')
         self.assertIsInstance(
             df.index[0], (datetime, np.datetime64, Timestamp))
@@ -286,12 +286,12 @@ c,4,5
         df = self.read_csv(self.csv2, index_col=0, parse_dates=True)
         df2 = self.read_table(self.csv2, sep=',', index_col=0,
                               parse_dates=True)
-        self.assert_numpy_array_equal(df.columns, ['A', 'B', 'C', 'D', 'E'])
-        self.assertIsInstance(
-            df.index[0], (datetime, np.datetime64, Timestamp))
-        self.assertEqual(df.ix[
-                         :, ['A', 'B', 'C', 'D']
-                         ].values.dtype, np.float64)
+        self.assert_index_equal(df.columns,
+                                pd.Index(['A', 'B', 'C', 'D', 'E']))
+        self.assertIsInstance(df.index[0],
+                              (datetime, np.datetime64, Timestamp))
+        self.assertEqual(df.ix[:, ['A', 'B', 'C', 'D']].values.dtype,
+                         np.float64)
         tm.assert_frame_equal(df, df2)
 
     def test_read_table_unicode(self):
@@ -1121,21 +1121,21 @@ A,B,C
 
 -70,.4,1
 """
-        expected = [[1., 2., 4.],
-                    [5., np.nan, 10.],
-                    [-70., .4, 1.]]
+        expected = np.array([[1., 2., 4.],
+                             [5., np.nan, 10.],
+                             [-70., .4, 1.]])
         df = self.read_csv(StringIO(data))
-        tm.assert_almost_equal(df.values, expected)
+        tm.assert_numpy_array_equal(df.values, expected)
         df = self.read_csv(StringIO(data.replace(',', '  ')), sep='\s+')
-        tm.assert_almost_equal(df.values, expected)
-        expected = [[1., 2., 4.],
-                    [np.nan, np.nan, np.nan],
-                    [np.nan, np.nan, np.nan],
-                    [5., np.nan, 10.],
-                    [np.nan, np.nan, np.nan],
-                    [-70., .4, 1.]]
+        tm.assert_numpy_array_equal(df.values, expected)
+        expected = np.array([[1., 2., 4.],
+                             [np.nan, np.nan, np.nan],
+                             [np.nan, np.nan, np.nan],
+                             [5., np.nan, 10.],
+                             [np.nan, np.nan, np.nan],
+                             [-70., .4, 1.]])
         df = self.read_csv(StringIO(data), skip_blank_lines=False)
-        tm.assert_almost_equal(list(df.values), list(expected))
+        tm.assert_numpy_array_equal(df.values, expected)
 
     def test_whitespace_lines(self):
         data = """
@@ -1146,10 +1146,10 @@ A,B,C
   \t    1,2.,4.
 5.,NaN,10.0
 """
-        expected = [[1, 2., 4.],
-                    [5., np.nan, 10.]]
+        expected = np.array([[1, 2., 4.],
+                             [5., np.nan, 10.]])
         df = self.read_csv(StringIO(data))
-        tm.assert_almost_equal(df.values, expected)
+        tm.assert_numpy_array_equal(df.values, expected)
 
     def test_regex_separator(self):
         # see gh-6607

--- a/pandas/io/tests/parser/header.py
+++ b/pandas/io/tests/parser/header.py
@@ -43,14 +43,14 @@ MyColumn
         df_pref = self.read_table(StringIO(data), sep=',', prefix='Field',
                                   header=None)
 
-        expected = [[1, 2, 3, 4, 5.],
-                    [6, 7, 8, 9, 10],
-                    [11, 12, 13, 14, 15]]
+        expected = np.array([[1, 2, 3, 4, 5],
+                             [6, 7, 8, 9, 10],
+                             [11, 12, 13, 14, 15]], dtype=np.int64)
         tm.assert_almost_equal(df_pref.values, expected)
 
-        self.assert_numpy_array_equal(
-            df_pref.columns, ['Field0', 'Field1', 'Field2',
-                              'Field3', 'Field4'])
+        self.assert_index_equal(df_pref.columns,
+                                Index(['Field0', 'Field1', 'Field2',
+                                       'Field3', 'Field4']))
 
     def test_header_with_index_col(self):
         data = """foo,1,2,3
@@ -262,14 +262,14 @@ q,r,s,t,u,v
 
         names = ['foo', 'bar', 'baz', 'quux', 'panda']
         df2 = self.read_table(StringIO(data), sep=',', names=names)
-        expected = [[1, 2, 3, 4, 5.],
-                    [6, 7, 8, 9, 10],
-                    [11, 12, 13, 14, 15]]
+        expected = np.array([[1, 2, 3, 4, 5],
+                             [6, 7, 8, 9, 10],
+                             [11, 12, 13, 14, 15]], dtype=np.int64)
         tm.assert_almost_equal(df.values, expected)
         tm.assert_almost_equal(df.values, df2.values)
 
-        self.assert_numpy_array_equal(df_pref.columns,
-                                      ['X0', 'X1', 'X2', 'X3', 'X4'])
-        self.assert_numpy_array_equal(df.columns, lrange(5))
+        self.assert_index_equal(df_pref.columns,
+                                Index(['X0', 'X1', 'X2', 'X3', 'X4']))
+        self.assert_index_equal(df.columns, Index(lrange(5)))
 
-        self.assert_numpy_array_equal(df2.columns, names)
+        self.assert_index_equal(df2.columns, Index(names))

--- a/pandas/io/tests/parser/na_values.py
+++ b/pandas/io/tests/parser/na_values.py
@@ -37,9 +37,10 @@ foo,bar
 NA,baz
 NaN,nan
 """
-        expected = [['foo', 'bar'], [nan, 'baz'], [nan, nan]]
+        expected = np.array([['foo', 'bar'], [nan, 'baz'], [nan, nan]],
+                            dtype=np.object_)
         df = self.read_csv(StringIO(data))
-        tm.assert_almost_equal(df.values, expected)
+        tm.assert_numpy_array_equal(df.values, expected)
 
     def test_non_string_na_values(self):
         # see gh-3611, na_values that are not a string are an issue
@@ -126,20 +127,20 @@ ignore,this,row
 -1.#IND,5,baz
 7,8,NaN
 """
-        expected = [[1., nan, 3],
-                    [nan, 5, nan],
-                    [7, 8, nan]]
+        expected = np.array([[1., nan, 3],
+                             [nan, 5, nan],
+                             [7, 8, nan]])
 
         df = self.read_csv(StringIO(data), na_values=['baz'], skiprows=[1])
-        tm.assert_almost_equal(df.values, expected)
+        tm.assert_numpy_array_equal(df.values, expected)
 
         df2 = self.read_table(StringIO(data), sep=',', na_values=['baz'],
                               skiprows=[1])
-        tm.assert_almost_equal(df2.values, expected)
+        tm.assert_numpy_array_equal(df2.values, expected)
 
         df3 = self.read_table(StringIO(data), sep=',', na_values='baz',
                               skiprows=[1])
-        tm.assert_almost_equal(df3.values, expected)
+        tm.assert_numpy_array_equal(df3.values, expected)
 
     def test_bool_na_values(self):
         data = """A,B,C

--- a/pandas/io/tests/parser/python_parser_only.py
+++ b/pandas/io/tests/parser/python_parser_only.py
@@ -40,7 +40,8 @@ bar|4|5|6
 baz|7|8|9
 """
         data = self.read_csv(StringIO(text), index_col=0, sep=None)
-        self.assertTrue(data.index.equals(Index(['foo', 'bar', 'baz'])))
+        self.assert_index_equal(data.index,
+                                Index(['foo', 'bar', 'baz'], name='index'))
 
         data2 = self.read_csv(StringIO(text), index_col=0, delimiter='|')
         tm.assert_frame_equal(data, data2)

--- a/pandas/io/tests/parser/test_read_fwf.py
+++ b/pandas/io/tests/parser/test_read_fwf.py
@@ -217,8 +217,8 @@ bar2,12,13,14,15
   1   2.   4  #hello world
   5  NaN  10.0
 """
-        expected = [[1, 2., 4],
-                    [5, np.nan, 10.]]
+        expected = np.array([[1, 2., 4],
+                             [5, np.nan, 10.]])
         df = read_fwf(StringIO(data), colspecs=[(0, 3), (4, 9), (9, 25)],
                       comment='#')
         tm.assert_almost_equal(df.values, expected)
@@ -228,8 +228,8 @@ bar2,12,13,14,15
  1 2,334.0    5
 10   13     10.
 """
-        expected = [[1, 2334., 5],
-                    [10, 13, 10]]
+        expected = np.array([[1, 2334., 5],
+                             [10, 13, 10]])
         df = read_fwf(StringIO(data), colspecs=[(0, 3), (3, 11), (12, 16)],
                       thousands=',')
         tm.assert_almost_equal(df.values, expected)

--- a/pandas/io/tests/parser/test_textreader.py
+++ b/pandas/io/tests/parser/test_textreader.py
@@ -76,8 +76,12 @@ class TestTextReader(tm.TestCase):
                             header=None)
         result = reader.read()
 
-        self.assert_numpy_array_equal(result[0], ['a', 'a', 'a', 'a'])
-        self.assert_numpy_array_equal(result[1], ['b', 'b', 'b', 'b'])
+        self.assert_numpy_array_equal(result[0],
+                                      np.array(['a', 'a', 'a', 'a'],
+                                               dtype=np.object_))
+        self.assert_numpy_array_equal(result[1],
+                                      np.array(['b', 'b', 'b', 'b'],
+                                               dtype=np.object_))
 
     def test_parse_booleans(self):
         data = 'True\nFalse\nTrue\nTrue'
@@ -94,8 +98,10 @@ class TestTextReader(tm.TestCase):
                             header=None)
         result = reader.read()
 
-        self.assert_numpy_array_equal(result[0], ['a', 'a', 'a'])
-        self.assert_numpy_array_equal(result[1], ['b', 'b', 'b'])
+        self.assert_numpy_array_equal(result[0], np.array(['a', 'a', 'a'],
+                                                          dtype=np.object_))
+        self.assert_numpy_array_equal(result[1], np.array(['b', 'b', 'b'],
+                                                          dtype=np.object_))
 
     def test_embedded_newline(self):
         data = 'a\n"hello\nthere"\nthis'
@@ -103,7 +109,7 @@ class TestTextReader(tm.TestCase):
         reader = TextReader(StringIO(data), header=None)
         result = reader.read()
 
-        expected = ['a', 'hello\nthere', 'this']
+        expected = np.array(['a', 'hello\nthere', 'this'], dtype=np.object_)
         self.assert_numpy_array_equal(result[0], expected)
 
     def test_euro_decimal(self):
@@ -113,7 +119,7 @@ class TestTextReader(tm.TestCase):
                             decimal=',', header=None)
         result = reader.read()
 
-        expected = [12345.67, 345.678]
+        expected = np.array([12345.67, 345.678])
         tm.assert_almost_equal(result[0], expected)
 
     def test_integer_thousands(self):
@@ -123,7 +129,7 @@ class TestTextReader(tm.TestCase):
                             thousands=',', header=None)
         result = reader.read()
 
-        expected = [123456, 12500]
+        expected = np.array([123456, 12500], dtype=np.int64)
         tm.assert_almost_equal(result[0], expected)
 
     def test_integer_thousands_alt(self):

--- a/pandas/io/tests/test_html.py
+++ b/pandas/io/tests/test_html.py
@@ -519,7 +519,7 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
                          'Volume', 'Price', 'Chg', '% Chg'])
         nrows = 100
         self.assertEqual(df.shape[0], nrows)
-        self.assertTrue(df.columns.equals(columns))
+        self.assert_index_equal(df.columns, columns)
 
     @tm.slow
     def test_banklist_header(self):

--- a/pandas/io/tests/test_packers.py
+++ b/pandas/io/tests/test_packers.py
@@ -150,7 +150,11 @@ class TestNumpy(TestPackers):
     def test_list_numpy_float(self):
         x = [np.float32(np.random.rand()) for i in range(5)]
         x_rec = self.encode_decode(x)
-        tm.assert_almost_equal(x, x_rec)
+        # current msgpack cannot distinguish list/tuple
+        tm.assert_almost_equal(tuple(x), x_rec)
+
+        x_rec = self.encode_decode(tuple(x))
+        tm.assert_almost_equal(tuple(x), x_rec)
 
     def test_list_numpy_float_complex(self):
         if not hasattr(np, 'complex128'):
@@ -165,7 +169,11 @@ class TestNumpy(TestPackers):
     def test_list_float(self):
         x = [np.random.rand() for i in range(5)]
         x_rec = self.encode_decode(x)
-        tm.assert_almost_equal(x, x_rec)
+        # current msgpack cannot distinguish list/tuple
+        tm.assert_almost_equal(tuple(x), x_rec)
+
+        x_rec = self.encode_decode(tuple(x))
+        tm.assert_almost_equal(tuple(x), x_rec)
 
     def test_list_float_complex(self):
         x = [np.random.rand() for i in range(5)] + \
@@ -217,7 +225,11 @@ class TestNumpy(TestPackers):
     def test_list_mixed(self):
         x = [1.0, np.float32(3.5), np.complex128(4.25), u('foo')]
         x_rec = self.encode_decode(x)
-        tm.assert_almost_equal(x, x_rec)
+        # current msgpack cannot distinguish list/tuple
+        tm.assert_almost_equal(tuple(x), x_rec)
+
+        x_rec = self.encode_decode(tuple(x))
+        tm.assert_almost_equal(tuple(x), x_rec)
 
 
 class TestBasic(TestPackers):
@@ -286,30 +298,30 @@ class TestIndex(TestPackers):
 
         for s, i in self.d.items():
             i_rec = self.encode_decode(i)
-            self.assertTrue(i.equals(i_rec))
+            self.assert_index_equal(i, i_rec)
 
         # datetime with no freq (GH5506)
         i = Index([Timestamp('20130101'), Timestamp('20130103')])
         i_rec = self.encode_decode(i)
-        self.assertTrue(i.equals(i_rec))
+        self.assert_index_equal(i, i_rec)
 
         # datetime with timezone
         i = Index([Timestamp('20130101 9:00:00'), Timestamp(
             '20130103 11:00:00')]).tz_localize('US/Eastern')
         i_rec = self.encode_decode(i)
-        self.assertTrue(i.equals(i_rec))
+        self.assert_index_equal(i, i_rec)
 
     def test_multi_index(self):
 
         for s, i in self.mi.items():
             i_rec = self.encode_decode(i)
-            self.assertTrue(i.equals(i_rec))
+            self.assert_index_equal(i, i_rec)
 
     def test_unicode(self):
         i = tm.makeUnicodeIndex(100)
 
         i_rec = self.encode_decode(i)
-        self.assertTrue(i.equals(i_rec))
+        self.assert_index_equal(i, i_rec)
 
 
 class TestSeries(TestPackers):

--- a/pandas/io/tests/test_pickle.py
+++ b/pandas/io/tests/test_pickle.py
@@ -85,7 +85,7 @@ class TestPickle():
         tm.assert_series_equal(result, expected)
         tm.assert_equal(result.index.freq, expected.index.freq)
         tm.assert_equal(result.index.freq.normalize, False)
-        tm.assert_numpy_array_equal(result > 0, expected > 0)
+        tm.assert_series_equal(result > 0, expected > 0)
 
         # GH 9291
         freq = result.index.freq

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -5280,7 +5280,7 @@ class TestTimezones(Base, tm.TestCase):
         with ensure_clean_store(self.path) as store:
             store['frame'] = frame
             recons = store['frame']
-            self.assertTrue(recons.index.equals(rng))
+            self.assert_index_equal(recons.index, rng)
             self.assertEqual(rng.tz, recons.index.tz)
 
     def test_store_timezone(self):

--- a/pandas/sparse/tests/test_frame.py
+++ b/pandas/sparse/tests/test_frame.py
@@ -97,8 +97,11 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
 
         # constructed zframe from matrix above
         self.assertEqual(self.zframe['A'].fill_value, 0)
-        tm.assert_almost_equal([0, 0, 0, 0, 1, 2, 3, 4, 5, 6],
-                               self.zframe['A'].values)
+        tm.assert_numpy_array_equal(pd.SparseArray([1., 2., 3., 4., 5., 6.]),
+                                    self.zframe['A'].values)
+        tm.assert_numpy_array_equal(np.array([0., 0., 0., 0., 1., 2.,
+                                              3., 4., 5., 6.]),
+                                    self.zframe['A'].to_dense().values)
 
         # construct no data
         sdf = SparseDataFrame(columns=np.arange(10), index=np.arange(10))
@@ -380,8 +383,8 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
 
         res2 = res.set_value('foobar', 'qux', 1.5)
         self.assertIsNot(res2, res)
-        self.assert_numpy_array_equal(res2.columns,
-                                      list(self.frame.columns) + ['qux'])
+        self.assert_index_equal(res2.columns,
+                                pd.Index(list(self.frame.columns) + ['qux']))
         self.assertEqual(res2.get_value('foobar', 'qux'), 1.5)
 
     def test_fancy_index_misc(self):
@@ -407,7 +410,7 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
         subindex = self.frame.index[indexer]
         subframe = self.frame[indexer]
 
-        self.assert_numpy_array_equal(subindex, subframe.index)
+        self.assert_index_equal(subindex, subframe.index)
         self.assertRaises(Exception, self.frame.__getitem__, indexer[:-1])
 
     def test_setitem(self):

--- a/pandas/sparse/tests/test_libsparse.py
+++ b/pandas/sparse/tests/test_libsparse.py
@@ -50,8 +50,10 @@ class TestSparseIndexUnion(tm.TestCase):
             yindex = BlockIndex(TEST_LENGTH, yloc, ylen)
             bresult = xindex.make_union(yindex)
             assert (isinstance(bresult, BlockIndex))
-            tm.assert_numpy_array_equal(bresult.blocs, eloc)
-            tm.assert_numpy_array_equal(bresult.blengths, elen)
+            tm.assert_numpy_array_equal(bresult.blocs,
+                                        np.array(eloc, dtype=np.int32))
+            tm.assert_numpy_array_equal(bresult.blengths,
+                                        np.array(elen, dtype=np.int32))
 
             ixindex = xindex.to_int_index()
             iyindex = yindex.to_int_index()
@@ -411,7 +413,8 @@ class TestBlockIndex(tm.TestCase):
         block = BlockIndex(20, locs, lengths)
         dense = block.to_int_index()
 
-        tm.assert_numpy_array_equal(dense.indices, exp_inds)
+        tm.assert_numpy_array_equal(dense.indices,
+                                    np.array(exp_inds, dtype=np.int32))
 
     def test_to_block_index(self):
         index = BlockIndex(10, [0, 5], [4, 5])

--- a/pandas/sparse/tests/test_panel.py
+++ b/pandas/sparse/tests/test_panel.py
@@ -121,7 +121,8 @@ class TestSparsePanel(tm.TestCase, test_panel.SafeForLongAndSparse,
                 dlp = panel.to_dense().to_frame()
 
                 self.assert_numpy_array_equal(slp.values, dlp.values)
-                self.assertTrue(slp.index.equals(dlp.index))
+                self.assert_index_equal(slp.index, dlp.index,
+                                        check_names=False)
 
             _compare_with_dense(self.panel)
             _compare_with_dense(self.panel.reindex(items=['ItemA']))

--- a/pandas/sparse/tests/test_series.py
+++ b/pandas/sparse/tests/test_series.py
@@ -294,7 +294,7 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
     def test_constructor_nonnan(self):
         arr = [0, 0, 0, nan, nan]
         sp_series = SparseSeries(arr, fill_value=0)
-        tm.assert_numpy_array_equal(sp_series.values.values, arr)
+        tm.assert_numpy_array_equal(sp_series.values.values, np.array(arr))
         self.assertEqual(len(sp_series), 5)
         self.assertEqual(sp_series.shape, (5, ))
 
@@ -726,9 +726,9 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
 
         expected = sp.to_dense().valid()
         expected = expected[expected != 0]
-
-        tm.assert_almost_equal(sp_valid.values, expected.values)
-        self.assertTrue(sp_valid.index.equals(expected.index))
+        exp_arr = pd.SparseArray(expected.values, fill_value=0, kind='block')
+        tm.assert_sp_array_equal(sp_valid.values, exp_arr)
+        self.assert_index_equal(sp_valid.index, expected.index)
         self.assertEqual(len(sp_valid.sp_values), 2)
 
         result = self.bseries.dropna()
@@ -1042,8 +1042,7 @@ class TestSparseSeriesScipyInteraction(tm.TestCase):
         results = (results[0].T, results[2], results[1])
         self._check_results_to_coo(results, check)
 
-    @staticmethod
-    def _check_results_to_coo(results, check):
+    def _check_results_to_coo(self, results, check):
         (A, il, jl) = results
         (A_result, il_result, jl_result) = check
         # convert to dense and compare
@@ -1051,8 +1050,8 @@ class TestSparseSeriesScipyInteraction(tm.TestCase):
         # or compare directly as difference of sparse
         # assert(abs(A - A_result).max() < 1e-12) # max is failing in python
         # 2.6
-        tm.assert_numpy_array_equal(il, il_result)
-        tm.assert_numpy_array_equal(jl, jl_result)
+        self.assertEqual(il, il_result)
+        self.assertEqual(jl, jl_result)
 
     def test_concat(self):
         val1 = np.array([1, 2, np.nan, np.nan, 0, np.nan])

--- a/pandas/stats/tests/test_fama_macbeth.py
+++ b/pandas/stats/tests/test_fama_macbeth.py
@@ -50,7 +50,9 @@ class TestFamaMacBeth(BaseTest):
 
             with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
                 reference = fama_macbeth(y=y2, x=x2, **kwds)
-            assert_almost_equal(reference._stats, result._stats[:, i])
+            # reference._stats is tuple
+            assert_almost_equal(reference._stats, result._stats[:, i],
+                                check_dtype=False)
 
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             static = fama_macbeth(y=y2, x=x2, **kwds)

--- a/pandas/stats/tests/test_ols.py
+++ b/pandas/stats/tests/test_ols.py
@@ -378,7 +378,7 @@ class TestOLSMisc(tm.TestCase):
             model = ols(y=endog, x=exog)
 
         pred = model.y_predict
-        self.assertTrue(pred.index.equals(exog.index))
+        self.assert_index_equal(pred.index, exog.index)
 
     def test_longpanel_series_combo(self):
         wp = tm.makePanel()
@@ -527,13 +527,12 @@ class TestPanelOLS(BaseTest):
         index = x.index.get_level_values(0)
         index = Index(sorted(set(index)))
         exp_index = Index([datetime(2000, 1, 1), datetime(2000, 1, 3)])
-        self.assertTrue
-        (exp_index.equals(index))
+        self.assert_index_equal(exp_index, index)
 
         index = x.index.get_level_values(1)
         index = Index(sorted(set(index)))
         exp_index = Index(['A', 'B'])
-        self.assertTrue(exp_index.equals(index))
+        self.assert_index_equal(exp_index, index)
 
         x = result._x_filtered
         index = x.index.get_level_values(0)
@@ -541,24 +540,22 @@ class TestPanelOLS(BaseTest):
         exp_index = Index([datetime(2000, 1, 1),
                            datetime(2000, 1, 3),
                            datetime(2000, 1, 4)])
-        self.assertTrue(exp_index.equals(index))
+        self.assert_index_equal(exp_index, index)
 
-        assert_almost_equal(result._y.values.flat, [1, 4, 5])
+        # .flat is flatiter instance
+        assert_almost_equal(result._y.values.flat, [1, 4, 5],
+                            check_dtype=False)
 
-        exp_x = [[6, 14, 1],
-                 [9, 17, 1],
-                 [30, 48, 1]]
+        exp_x = np.array([[6, 14, 1], [9, 17, 1],
+                          [30, 48, 1]], dtype=np.float64)
         assert_almost_equal(exp_x, result._x.values)
 
-        exp_x_filtered = [[6, 14, 1],
-                          [9, 17, 1],
-                          [30, 48, 1],
-                          [11, 20, 1],
-                          [12, 21, 1]]
+        exp_x_filtered = np.array([[6, 14, 1], [9, 17, 1], [30, 48, 1],
+                                   [11, 20, 1], [12, 21, 1]], dtype=np.float64)
         assert_almost_equal(exp_x_filtered, result._x_filtered.values)
 
-        self.assertTrue(result._x_filtered.index.levels[0].equals(
-            result.y_fitted.index))
+        self.assert_index_equal(result._x_filtered.index.levels[0],
+                                result.y_fitted.index)
 
     def test_wls_panel(self):
         y = tm.makeTimeDataFrame()
@@ -597,9 +594,11 @@ class TestPanelOLS(BaseTest):
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             result = ols(y=self.panel_y2, x=self.panel_x2, time_effects=True)
 
-        assert_almost_equal(result._y_trans.values.flat, [0, -0.5, 0.5])
+        # .flat is flatiter instance
+        assert_almost_equal(result._y_trans.values.flat, [0, -0.5, 0.5],
+                            check_dtype=False)
 
-        exp_x = [[0, 0], [-10.5, -15.5], [10.5, 15.5]]
+        exp_x = np.array([[0, 0], [-10.5, -15.5], [10.5, 15.5]])
         assert_almost_equal(result._x_trans.values, exp_x)
 
         # _check_non_raw_results(result)
@@ -608,7 +607,9 @@ class TestPanelOLS(BaseTest):
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             result = ols(y=self.panel_y2, x=self.panel_x2, entity_effects=True)
 
-        assert_almost_equal(result._y.values.flat, [1, 4, 5])
+        # .flat is flatiter instance
+        assert_almost_equal(result._y.values.flat, [1, 4, 5],
+                            check_dtype=False)
 
         exp_x = DataFrame([[0., 6., 14., 1.], [0, 9, 17, 1], [1, 30, 48, 1]],
                           index=result._x.index, columns=['FE_B', 'x1', 'x2',
@@ -622,7 +623,9 @@ class TestPanelOLS(BaseTest):
             result = ols(y=self.panel_y2, x=self.panel_x2, entity_effects=True,
                          dropped_dummies={'entity': 'B'})
 
-        assert_almost_equal(result._y.values.flat, [1, 4, 5])
+        # .flat is flatiter instance
+        assert_almost_equal(result._y.values.flat, [1, 4, 5],
+                            check_dtype=False)
         exp_x = DataFrame([[1., 6., 14., 1.], [1, 9, 17, 1], [0, 30, 48, 1]],
                           index=result._x.index, columns=['FE_A', 'x1', 'x2',
                                                           'intercept'],
@@ -634,7 +637,9 @@ class TestPanelOLS(BaseTest):
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             result = ols(y=self.panel_y2, x=self.panel_x2, x_effects=['x1'])
 
-        assert_almost_equal(result._y.values.flat, [1, 4, 5])
+        # .flat is flatiter instance
+        assert_almost_equal(result._y.values.flat, [1, 4, 5],
+                            check_dtype=False)
 
         res = result._x
         exp_x = DataFrame([[0., 0., 14., 1.], [0, 1, 17, 1], [1, 0, 48, 1]],
@@ -648,7 +653,9 @@ class TestPanelOLS(BaseTest):
                          dropped_dummies={'x1': 30})
 
         res = result._x
-        assert_almost_equal(result._y.values.flat, [1, 4, 5])
+        # .flat is flatiter instance
+        assert_almost_equal(result._y.values.flat, [1, 4, 5],
+                            check_dtype=False)
         exp_x = DataFrame([[1., 0., 14., 1.], [0, 1, 17, 1], [0, 0, 48, 1]],
                           columns=['x1_6', 'x1_9', 'x2', 'intercept'],
                           index=res.index, dtype=float)
@@ -660,13 +667,15 @@ class TestPanelOLS(BaseTest):
             result = ols(y=self.panel_y3, x=self.panel_x3,
                          x_effects=['x1', 'x2'])
 
-        assert_almost_equal(result._y.values.flat, [1, 2, 3, 4])
-        exp_x = [[0, 0, 0, 1, 1], [1, 0, 0, 0, 1], [0, 1, 1, 0, 1],
-                 [0, 0, 0, 1, 1]]
+        # .flat is flatiter instance
+        assert_almost_equal(result._y.values.flat, [1, 2, 3, 4],
+                            check_dtype=False)
+        exp_x = np.array([[0, 0, 0, 1, 1], [1, 0, 0, 0, 1], [0, 1, 1, 0, 1],
+                          [0, 0, 0, 1, 1]], dtype=np.float64)
         assert_almost_equal(result._x.values, exp_x)
 
         exp_index = Index(['x1_B', 'x1_C', 'x2_baz', 'x2_foo', 'intercept'])
-        self.assertTrue(exp_index.equals(result._x.columns))
+        self.assert_index_equal(exp_index, result._x.columns)
 
         # _check_non_raw_results(result)
 
@@ -674,14 +683,15 @@ class TestPanelOLS(BaseTest):
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             result = ols(y=self.panel_y3, x=self.panel_x3, x_effects=['x1', 'x2'],
                          dropped_dummies={'x2': 'foo'})
-
-        assert_almost_equal(result._y.values.flat, [1, 2, 3, 4])
-        exp_x = [[0, 0, 0, 0, 1], [1, 0, 1, 0, 1], [0, 1, 0, 1, 1],
-                 [0, 0, 0, 0, 1]]
+        # .flat is flatiter instance
+        assert_almost_equal(result._y.values.flat, [1, 2, 3, 4],
+                            check_dtype=False)
+        exp_x = np.array([[0, 0, 0, 0, 1], [1, 0, 1, 0, 1], [0, 1, 0, 1, 1],
+                          [0, 0, 0, 0, 1]], dtype=np.float64)
         assert_almost_equal(result._x.values, exp_x)
 
         exp_index = Index(['x1_B', 'x1_C', 'x2_bar', 'x2_baz', 'intercept'])
-        self.assertTrue(exp_index.equals(result._x.columns))
+        self.assert_index_equal(exp_index, result._x.columns)
 
         # _check_non_raw_results(result)
 
@@ -914,16 +924,21 @@ class TestOLSFilter(tm.TestCase):
     def testFilterWithSeriesRHS(self):
         (lhs, rhs, weights, rhs_pre,
          index, valid) = _filter_data(self.TS1, {'x1': self.TS2}, None)
-        self.tsAssertEqual(self.TS1, lhs)
-        self.tsAssertEqual(self.TS2[:3], rhs['x1'])
-        self.tsAssertEqual(self.TS2, rhs_pre['x1'])
+        self.tsAssertEqual(self.TS1.astype(np.float64), lhs, check_names=False)
+        self.tsAssertEqual(self.TS2[:3].astype(np.float64), rhs['x1'],
+                           check_names=False)
+        self.tsAssertEqual(self.TS2.astype(np.float64), rhs_pre['x1'],
+                           check_names=False)
 
     def testFilterWithSeriesRHS2(self):
         (lhs, rhs, weights, rhs_pre,
          index, valid) = _filter_data(self.TS2, {'x1': self.TS1}, None)
-        self.tsAssertEqual(self.TS2[:3], lhs)
-        self.tsAssertEqual(self.TS1, rhs['x1'])
-        self.tsAssertEqual(self.TS1, rhs_pre['x1'])
+        self.tsAssertEqual(self.TS2[:3].astype(np.float64), lhs,
+                           check_names=False)
+        self.tsAssertEqual(self.TS1.astype(np.float64), rhs['x1'],
+                           check_names=False)
+        self.tsAssertEqual(self.TS1.astype(np.float64), rhs_pre['x1'],
+                           check_names=False)
 
     def testFilterWithSeriesRHS3(self):
         (lhs, rhs, weights, rhs_pre,
@@ -931,32 +946,32 @@ class TestOLSFilter(tm.TestCase):
         exp_lhs = self.TS3[2:3]
         exp_rhs = self.TS4[2:3]
         exp_rhs_pre = self.TS4[1:]
-        self.tsAssertEqual(exp_lhs, lhs)
-        self.tsAssertEqual(exp_rhs, rhs['x1'])
-        self.tsAssertEqual(exp_rhs_pre, rhs_pre['x1'])
+        self.tsAssertEqual(exp_lhs, lhs, check_names=False)
+        self.tsAssertEqual(exp_rhs, rhs['x1'], check_names=False)
+        self.tsAssertEqual(exp_rhs_pre, rhs_pre['x1'], check_names=False)
 
     def testFilterWithDataFrameRHS(self):
         (lhs, rhs, weights, rhs_pre,
          index, valid) = _filter_data(self.TS1, self.DF1, None)
-        exp_lhs = self.TS1[1:]
+        exp_lhs = self.TS1[1:].astype(np.float64)
         exp_rhs1 = self.TS2[1:3]
-        exp_rhs2 = self.TS4[1:3]
-        self.tsAssertEqual(exp_lhs, lhs)
-        self.tsAssertEqual(exp_rhs1, rhs['x1'])
-        self.tsAssertEqual(exp_rhs2, rhs['x2'])
+        exp_rhs2 = self.TS4[1:3].astype(np.float64)
+        self.tsAssertEqual(exp_lhs, lhs, check_names=False)
+        self.tsAssertEqual(exp_rhs1, rhs['x1'], check_names=False)
+        self.tsAssertEqual(exp_rhs2, rhs['x2'], check_names=False)
 
     def testFilterWithDictRHS(self):
         (lhs, rhs, weights, rhs_pre,
          index, valid) = _filter_data(self.TS1, self.DICT1, None)
-        exp_lhs = self.TS1[1:]
-        exp_rhs1 = self.TS2[1:3]
-        exp_rhs2 = self.TS4[1:3]
-        self.tsAssertEqual(exp_lhs, lhs)
-        self.tsAssertEqual(exp_rhs1, rhs['x1'])
-        self.tsAssertEqual(exp_rhs2, rhs['x2'])
+        exp_lhs = self.TS1[1:].astype(np.float64)
+        exp_rhs1 = self.TS2[1:3].astype(np.float64)
+        exp_rhs2 = self.TS4[1:3].astype(np.float64)
+        self.tsAssertEqual(exp_lhs, lhs, check_names=False)
+        self.tsAssertEqual(exp_rhs1, rhs['x1'], check_names=False)
+        self.tsAssertEqual(exp_rhs2, rhs['x2'], check_names=False)
 
-    def tsAssertEqual(self, ts1, ts2):
-        self.assert_numpy_array_equal(ts1, ts2)
+    def tsAssertEqual(self, ts1, ts2, **kwargs):
+        self.assert_series_equal(ts1, ts2, **kwargs)
 
 
 if __name__ == '__main__':

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -18,12 +18,6 @@ import pandas as pd
 import pandas.core.nanops as nanops
 import pandas.formats.printing as printing
 
-from pandas.util.testing import (assert_almost_equal,
-                                 assert_equal,
-                                 assert_series_equal,
-                                 assert_frame_equal,
-                                 assertRaisesRegexp)
-
 import pandas.util.testing as tm
 from pandas.tests.frame.common import TestData
 
@@ -60,12 +54,12 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         if not check_minp:
             correls = self.frame.corr(method=method)
             exp = self.frame['A'].corr(self.frame['C'], method=method)
-            assert_almost_equal(correls['A']['C'], exp)
+            tm.assert_almost_equal(correls['A']['C'], exp)
         else:
             result = self.frame.corr(min_periods=len(self.frame) - 8)
             expected = self.frame.corr()
             expected.ix['A', 'B'] = expected.ix['B', 'A'] = nan
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
     def test_corr_non_numeric(self):
         tm._skip_if_no_scipy()
@@ -75,7 +69,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         # exclude non-numeric types
         result = self.mixed_frame.corr()
         expected = self.mixed_frame.ix[:, ['A', 'B', 'C', 'D']].corr()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_corr_nooverlap(self):
         tm._skip_if_no_scipy()
@@ -123,14 +117,14 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         expected = DataFrame(np.ones((2, 2)), index=[
                              'a', 'b'], columns=['a', 'b'])
         for meth in ['pearson', 'kendall', 'spearman']:
-            assert_frame_equal(df.corr(meth), expected)
+            tm.assert_frame_equal(df.corr(meth), expected)
 
     def test_cov(self):
         # min_periods no NAs (corner case)
         expected = self.frame.cov()
         result = self.frame.cov(min_periods=len(self.frame))
 
-        assert_frame_equal(expected, result)
+        tm.assert_frame_equal(expected, result)
 
         result = self.frame.cov(min_periods=len(self.frame) + 1)
         self.assertTrue(isnull(result.values).all())
@@ -149,25 +143,25 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         self.frame['B'][:10] = nan
         cov = self.frame.cov()
 
-        assert_almost_equal(cov['A']['C'],
-                            self.frame['A'].cov(self.frame['C']))
+        tm.assert_almost_equal(cov['A']['C'],
+                               self.frame['A'].cov(self.frame['C']))
 
         # exclude non-numeric types
         result = self.mixed_frame.cov()
         expected = self.mixed_frame.ix[:, ['A', 'B', 'C', 'D']].cov()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # Single column frame
         df = DataFrame(np.linspace(0.0, 1.0, 10))
         result = df.cov()
         expected = DataFrame(np.cov(df.values.T).reshape((1, 1)),
                              index=df.columns, columns=df.columns)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         df.ix[0] = np.nan
         result = df.cov()
         expected = DataFrame(np.cov(df.values[1:].T).reshape((1, 1)),
                              index=df.columns, columns=df.columns)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_corrwith(self):
         a = self.tsframe
@@ -180,13 +174,13 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         del b['B']
 
         colcorr = a.corrwith(b, axis=0)
-        assert_almost_equal(colcorr['A'], a['A'].corr(b['A']))
+        tm.assert_almost_equal(colcorr['A'], a['A'].corr(b['A']))
 
         rowcorr = a.corrwith(b, axis=1)
-        assert_series_equal(rowcorr, a.T.corrwith(b.T, axis=0))
+        tm.assert_series_equal(rowcorr, a.T.corrwith(b.T, axis=0))
 
         dropped = a.corrwith(b, axis=0, drop=True)
-        assert_almost_equal(dropped['A'], a['A'].corr(b['A']))
+        tm.assert_almost_equal(dropped['A'], a['A'].corr(b['A']))
         self.assertNotIn('B', dropped)
 
         dropped = a.corrwith(b, axis=1, drop=True)
@@ -199,7 +193,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         df2 = DataFrame(randn(4, 4), index=index[:4], columns=columns)
         correls = df1.corrwith(df2, axis=1)
         for row in index[:4]:
-            assert_almost_equal(correls[row], df1.ix[row].corr(df2.ix[row]))
+            tm.assert_almost_equal(correls[row], df1.ix[row].corr(df2.ix[row]))
 
     def test_corrwith_with_objects(self):
         df1 = tm.makeTimeDataFrame()
@@ -211,17 +205,17 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
         result = df1.corrwith(df2)
         expected = df1.ix[:, cols].corrwith(df2.ix[:, cols])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = df1.corrwith(df2, axis=1)
         expected = df1.ix[:, cols].corrwith(df2.ix[:, cols], axis=1)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_corrwith_series(self):
         result = self.tsframe.corrwith(self.tsframe['A'])
         expected = self.tsframe.apply(self.tsframe['A'].corr)
 
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_corrwith_matches_corrcoef(self):
         df1 = DataFrame(np.arange(10000), columns=['a'])
@@ -229,7 +223,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         c1 = df1.corrwith(df2)['a']
         c2 = np.corrcoef(df1['a'], df2['a'])[0][1]
 
-        assert_almost_equal(c1, c2)
+        tm.assert_almost_equal(c1, c2)
         self.assertTrue(c1 < 1)
 
     def test_bool_describe_in_mixed_frame(self):
@@ -246,14 +240,14 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
                                            10, 20, 30, 40, 50]},
                              index=['count', 'mean', 'std', 'min', '25%',
                                     '50%', '75%', 'max'])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # Top value is a boolean value that is False
         result = df.describe(include=['bool'])
 
         expected = DataFrame({'bool_data': [5, 2, False, 3]},
                              index=['count', 'unique', 'top', 'freq'])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_describe_categorical_columns(self):
         # GH 11558
@@ -310,8 +304,9 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         })
         df.reindex(columns=['bool_data', 'int_data', 'string_data'])
         test = df.sum(axis=0)
-        assert_almost_equal(test.values, [2, 150, 'abcde'])
-        assert_series_equal(test, df.T.sum(axis=1))
+        tm.assert_numpy_array_equal(test.values,
+                                    np.array([2, 150, 'abcde'], dtype=object))
+        tm.assert_series_equal(test, df.T.sum(axis=1))
 
     def test_count(self):
         f = lambda s: notnull(s).sum()
@@ -333,17 +328,17 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         df = DataFrame(index=lrange(10))
         result = df.count(1)
         expected = Series(0, index=df.index)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame(columns=lrange(10))
         result = df.count(0)
         expected = Series(0, index=df.columns)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame()
         result = df.count()
         expected = Series(0, index=[])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_sum(self):
         self._check_stat_op('sum', np.sum, has_numeric_only=True)
@@ -377,7 +372,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
                 expected = getattr(df.astype('f8'), meth)(1)
 
                 if not tm._incompat_bottleneck_version(meth):
-                    assert_series_equal(result, expected)
+                    tm.assert_series_equal(result, expected)
 
     def test_mean(self):
         self._check_stat_op('mean', np.mean, check_dates=True)
@@ -405,12 +400,12 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         # axis = 0
         cummin = self.tsframe.cummin()
         expected = self.tsframe.apply(Series.cummin)
-        assert_frame_equal(cummin, expected)
+        tm.assert_frame_equal(cummin, expected)
 
         # axis = 1
         cummin = self.tsframe.cummin(axis=1)
         expected = self.tsframe.apply(Series.cummin, axis=1)
-        assert_frame_equal(cummin, expected)
+        tm.assert_frame_equal(cummin, expected)
 
         # it works
         df = DataFrame({'A': np.arange(20)}, index=np.arange(20))
@@ -428,12 +423,12 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         # axis = 0
         cummax = self.tsframe.cummax()
         expected = self.tsframe.apply(Series.cummax)
-        assert_frame_equal(cummax, expected)
+        tm.assert_frame_equal(cummax, expected)
 
         # axis = 1
         cummax = self.tsframe.cummax(axis=1)
         expected = self.tsframe.apply(Series.cummax, axis=1)
-        assert_frame_equal(cummax, expected)
+        tm.assert_frame_equal(cummax, expected)
 
         # it works
         df = DataFrame({'A': np.arange(20)}, index=np.arange(20))
@@ -460,11 +455,11 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
         result = self.tsframe.std(ddof=4)
         expected = self.tsframe.apply(lambda x: x.std(ddof=4))
-        assert_almost_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
         result = self.tsframe.var(ddof=4)
         expected = self.tsframe.apply(lambda x: x.var(ddof=4))
-        assert_almost_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
         arr = np.repeat(np.random.random((1, 1000)), 1000, 0)
         result = nanops.nanvar(arr, axis=0)
@@ -489,11 +484,11 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         for meth in methods:
             result = getattr(df1, meth)(axis=1, numeric_only=True)
             expected = getattr(df1[['bar', 'baz']], meth)(axis=1)
-            assert_series_equal(expected, result)
+            tm.assert_series_equal(expected, result)
 
             result = getattr(df2, meth)(axis=1, numeric_only=True)
             expected = getattr(df2[['bar', 'baz']], meth)(axis=1)
-            assert_series_equal(expected, result)
+            tm.assert_series_equal(expected, result)
 
             # df1 has all numbers, df2 has a letter inside
             self.assertRaises(TypeError, lambda: getattr(df1, meth)
@@ -509,12 +504,12 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         # axis = 0
         cumsum = self.tsframe.cumsum()
         expected = self.tsframe.apply(Series.cumsum)
-        assert_frame_equal(cumsum, expected)
+        tm.assert_frame_equal(cumsum, expected)
 
         # axis = 1
         cumsum = self.tsframe.cumsum(axis=1)
         expected = self.tsframe.apply(Series.cumsum, axis=1)
-        assert_frame_equal(cumsum, expected)
+        tm.assert_frame_equal(cumsum, expected)
 
         # works
         df = DataFrame({'A': np.arange(20)}, index=np.arange(20))
@@ -532,12 +527,12 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         # axis = 0
         cumprod = self.tsframe.cumprod()
         expected = self.tsframe.apply(Series.cumprod)
-        assert_frame_equal(cumprod, expected)
+        tm.assert_frame_equal(cumprod, expected)
 
         # axis = 1
         cumprod = self.tsframe.cumprod(axis=1)
         expected = self.tsframe.apply(Series.cumprod, axis=1)
-        assert_frame_equal(cumprod, expected)
+        tm.assert_frame_equal(cumprod, expected)
 
         # fix issue
         cumprod_xs = self.tsframe.cumprod(axis=1)
@@ -574,48 +569,48 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         exp1 = np.apply_along_axis(rankdata, 1, fvals)
         exp1[mask] = np.nan
 
-        assert_almost_equal(ranks0.values, exp0)
-        assert_almost_equal(ranks1.values, exp1)
+        tm.assert_almost_equal(ranks0.values, exp0)
+        tm.assert_almost_equal(ranks1.values, exp1)
 
         # integers
         df = DataFrame(np.random.randint(0, 5, size=40).reshape((10, 4)))
 
         result = df.rank()
         exp = df.astype(float).rank()
-        assert_frame_equal(result, exp)
+        tm.assert_frame_equal(result, exp)
 
         result = df.rank(1)
         exp = df.astype(float).rank(1)
-        assert_frame_equal(result, exp)
+        tm.assert_frame_equal(result, exp)
 
     def test_rank2(self):
         df = DataFrame([[1, 3, 2], [1, 2, 3]])
         expected = DataFrame([[1.0, 3.0, 2.0], [1, 2, 3]]) / 3.0
         result = df.rank(1, pct=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df = DataFrame([[1, 3, 2], [1, 2, 3]])
         expected = df.rank(0) / 2.0
         result = df.rank(0, pct=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df = DataFrame([['b', 'c', 'a'], ['a', 'c', 'b']])
         expected = DataFrame([[2.0, 3.0, 1.0], [1, 3, 2]])
         result = df.rank(1, numeric_only=False)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         expected = DataFrame([[2.0, 1.5, 1.0], [1, 1.5, 2]])
         result = df.rank(0, numeric_only=False)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df = DataFrame([['b', np.nan, 'a'], ['a', 'c', 'b']])
         expected = DataFrame([[2.0, nan, 1.0], [1.0, 3.0, 2.0]])
         result = df.rank(1, numeric_only=False)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         expected = DataFrame([[2.0, nan, 1.0], [1.0, 1.0, 2.0]])
         result = df.rank(0, numeric_only=False)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # f7u12, this does not work without extensive workaround
         data = [[datetime(2001, 1, 5), nan, datetime(2001, 1, 2)],
@@ -627,12 +622,12 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         expected = DataFrame([[2., nan, 1.],
                               [2., 3., 1.]])
         result = df.rank(1, numeric_only=False, ascending=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         expected = DataFrame([[1., nan, 2.],
                               [2., 1., 3.]])
         result = df.rank(1, numeric_only=False, ascending=False)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # mixed-type frames
         self.mixed_frame['datetime'] = datetime.now()
@@ -640,12 +635,12 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
         result = self.mixed_frame.rank(1)
         expected = self.mixed_frame.rank(1, numeric_only=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df = DataFrame({"a": [1e-20, -5, 1e-20 + 1e-40, 10,
                               1e60, 1e80, 1e-30]})
         exp = DataFrame({"a": [3.5, 1., 3.5, 5., 6., 7., 2.]})
-        assert_frame_equal(df.rank(), exp)
+        tm.assert_frame_equal(df.rank(), exp)
 
     def test_rank_na_option(self):
         tm._skip_if_no_scipy()
@@ -665,8 +660,8 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         exp0 = np.apply_along_axis(rankdata, 0, fvals)
         exp1 = np.apply_along_axis(rankdata, 1, fvals)
 
-        assert_almost_equal(ranks0.values, exp0)
-        assert_almost_equal(ranks1.values, exp1)
+        tm.assert_almost_equal(ranks0.values, exp0)
+        tm.assert_almost_equal(ranks1.values, exp1)
 
         # top
         ranks0 = self.frame.rank(na_option='top')
@@ -680,8 +675,8 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         exp0 = np.apply_along_axis(rankdata, 0, fval0)
         exp1 = np.apply_along_axis(rankdata, 1, fval1)
 
-        assert_almost_equal(ranks0.values, exp0)
-        assert_almost_equal(ranks1.values, exp1)
+        tm.assert_almost_equal(ranks0.values, exp0)
+        tm.assert_almost_equal(ranks1.values, exp1)
 
         # descending
 
@@ -694,8 +689,8 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         exp0 = np.apply_along_axis(rankdata, 0, -fvals)
         exp1 = np.apply_along_axis(rankdata, 1, -fvals)
 
-        assert_almost_equal(ranks0.values, exp0)
-        assert_almost_equal(ranks1.values, exp1)
+        tm.assert_almost_equal(ranks0.values, exp0)
+        tm.assert_almost_equal(ranks1.values, exp1)
 
         # descending
 
@@ -711,14 +706,14 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         exp0 = np.apply_along_axis(rankdata, 0, -fval0)
         exp1 = np.apply_along_axis(rankdata, 1, -fval1)
 
-        assert_almost_equal(ranks0.values, exp0)
-        assert_almost_equal(ranks1.values, exp1)
+        tm.assert_numpy_array_equal(ranks0.values, exp0)
+        tm.assert_numpy_array_equal(ranks1.values, exp1)
 
     def test_rank_axis(self):
         # check if using axes' names gives the same result
         df = pd.DataFrame([[2, 1], [4, 3]])
-        assert_frame_equal(df.rank(axis=0), df.rank(axis='index'))
-        assert_frame_equal(df.rank(axis=1), df.rank(axis='columns'))
+        tm.assert_frame_equal(df.rank(axis=0), df.rank(axis='index'))
+        tm.assert_frame_equal(df.rank(axis=1), df.rank(axis='columns'))
 
     def test_sem(self):
         alt = lambda x: np.std(x, ddof=1) / np.sqrt(len(x))
@@ -727,7 +722,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         result = self.tsframe.sem(ddof=4)
         expected = self.tsframe.apply(
             lambda x: x.std(ddof=4) / np.sqrt(len(x)))
-        assert_almost_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
         arr = np.repeat(np.random.random((1, 1000)), 1000, 0)
         result = nanops.nansem(arr, axis=0)
@@ -789,7 +784,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
         kurt = df.kurt()
         kurt2 = df.kurt(level=0).xs('bar')
-        assert_series_equal(kurt, kurt2, check_names=False)
+        tm.assert_series_equal(kurt, kurt2, check_names=False)
         self.assertTrue(kurt.name is None)
         self.assertEqual(kurt2.name, 'bar')
 
@@ -827,26 +822,26 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
             result0 = f(axis=0, skipna=False)
             result1 = f(axis=1, skipna=False)
-            assert_series_equal(result0, frame.apply(wrapper),
-                                check_dtype=check_dtype,
-                                check_less_precise=check_less_precise)
+            tm.assert_series_equal(result0, frame.apply(wrapper),
+                                   check_dtype=check_dtype,
+                                   check_less_precise=check_less_precise)
             # HACK: win32
-            assert_series_equal(result1, frame.apply(wrapper, axis=1),
-                                check_dtype=False,
-                                check_less_precise=check_less_precise)
+            tm.assert_series_equal(result1, frame.apply(wrapper, axis=1),
+                                   check_dtype=False,
+                                   check_less_precise=check_less_precise)
         else:
             skipna_wrapper = alternative
             wrapper = alternative
 
         result0 = f(axis=0)
         result1 = f(axis=1)
-        assert_series_equal(result0, frame.apply(skipna_wrapper),
-                            check_dtype=check_dtype,
-                            check_less_precise=check_less_precise)
+        tm.assert_series_equal(result0, frame.apply(skipna_wrapper),
+                               check_dtype=check_dtype,
+                               check_less_precise=check_less_precise)
         if not tm._incompat_bottleneck_version(name):
-            assert_series_equal(result1, frame.apply(skipna_wrapper, axis=1),
-                                check_dtype=False,
-                                check_less_precise=check_less_precise)
+            exp = frame.apply(skipna_wrapper, axis=1)
+            tm.assert_series_equal(result1, exp, check_dtype=False,
+                                   check_less_precise=check_less_precise)
 
         # check dtypes
         if check_dtype:
@@ -859,7 +854,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         # assert_series_equal(result, comp)
 
         # bad axis
-        assertRaisesRegexp(ValueError, 'No axis named 2', f, axis=2)
+        tm.assertRaisesRegexp(ValueError, 'No axis named 2', f, axis=2)
         # make sure works on mixed-type frame
         getattr(self.mixed_frame, name)(axis=0)
         getattr(self.mixed_frame, name)(axis=1)
@@ -885,20 +880,20 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
                            "C": [8, 8, 8, 9, 9, 9],
                            "D": np.arange(6, dtype='int64'),
                            "E": [8, 8, 1, 1, 3, 3]})
-        assert_frame_equal(df[["A"]].mode(),
-                           pd.DataFrame({"A": [12]}))
+        tm.assert_frame_equal(df[["A"]].mode(),
+                              pd.DataFrame({"A": [12]}))
         expected = pd.Series([], dtype='int64', name='D').to_frame()
-        assert_frame_equal(df[["D"]].mode(), expected)
+        tm.assert_frame_equal(df[["D"]].mode(), expected)
         expected = pd.Series([1, 3, 8], dtype='int64', name='E').to_frame()
-        assert_frame_equal(df[["E"]].mode(), expected)
-        assert_frame_equal(df[["A", "B"]].mode(),
-                           pd.DataFrame({"A": [12], "B": [10.]}))
-        assert_frame_equal(df.mode(),
-                           pd.DataFrame({"A": [12, np.nan, np.nan],
-                                         "B": [10, np.nan, np.nan],
-                                         "C": [8, 9, np.nan],
-                                         "D": [np.nan, np.nan, np.nan],
-                                         "E": [1, 3, 8]}))
+        tm.assert_frame_equal(df[["E"]].mode(), expected)
+        tm.assert_frame_equal(df[["A", "B"]].mode(),
+                              pd.DataFrame({"A": [12], "B": [10.]}))
+        tm.assert_frame_equal(df.mode(),
+                              pd.DataFrame({"A": [12, np.nan, np.nan],
+                                            "B": [10, np.nan, np.nan],
+                                            "C": [8, 9, np.nan],
+                                            "D": [np.nan, np.nan, np.nan],
+                                            "E": [1, 3, 8]}))
 
         # outputs in sorted order
         df["C"] = list(reversed(df["C"]))
@@ -910,7 +905,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
                               "C": [8, 9]}))
         printing.pprint_thing(a)
         printing.pprint_thing(b)
-        assert_frame_equal(a, b)
+        tm.assert_frame_equal(a, b)
         # should work with heterogeneous types
         df = pd.DataFrame({"A": np.arange(6, dtype='int64'),
                            "B": pd.date_range('2011', periods=6),
@@ -918,7 +913,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         exp = pd.DataFrame({"A": pd.Series([], dtype=df["A"].dtype),
                             "B": pd.Series([], dtype=df["B"].dtype),
                             "C": pd.Series([], dtype=df["C"].dtype)})
-        assert_frame_equal(df.mode(), exp)
+        tm.assert_frame_equal(df.mode(), exp)
 
         # and also when not empty
         df.loc[1, "A"] = 0
@@ -929,7 +924,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
                                            dtype=df["B"].dtype),
                             "C": pd.Series(['e'], dtype=df["C"].dtype)})
 
-        assert_frame_equal(df.mode(), exp)
+        tm.assert_frame_equal(df.mode(), exp)
 
     def test_operators_timedelta64(self):
         from datetime import timedelta
@@ -962,8 +957,8 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         result2 = abs(diffs)
         expected = DataFrame(dict(A=df['A'] - df['C'],
                                   B=df['B'] - df['A']))
-        assert_frame_equal(result, expected)
-        assert_frame_equal(result2, expected)
+        tm.assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result2, expected)
 
         # mixed frame
         mixed = diffs.copy()
@@ -982,22 +977,22 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
                            'foo', 1, 1.0,
                            Timestamp('20130101')],
                           index=mixed.columns)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # excludes numeric
         result = mixed.min(axis=1)
         expected = Series([1, 1, 1.], index=[0, 1, 2])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # works when only those columns are selected
         result = mixed[['A', 'B']].min(1)
         expected = Series([timedelta(days=-1)] * 3)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = mixed[['A', 'B']].min()
         expected = Series([timedelta(seconds=5 * 60 + 5),
                            timedelta(days=-1)], index=['A', 'B'])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # GH 3106
         df = DataFrame({'time': date_range('20130102', periods=5),
@@ -1035,13 +1030,13 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         # unit test when have object data
         the_mean = self.mixed_frame.mean(axis=0)
         the_sum = self.mixed_frame.sum(axis=0, numeric_only=True)
-        self.assertTrue(the_sum.index.equals(the_mean.index))
+        self.assert_index_equal(the_sum.index, the_mean.index)
         self.assertTrue(len(the_mean.index) < len(self.mixed_frame.columns))
 
         # xs sum mixed type, just want to know it works...
         the_mean = self.mixed_frame.mean(axis=1)
         the_sum = self.mixed_frame.sum(axis=1, numeric_only=True)
-        self.assertTrue(the_sum.index.equals(the_mean.index))
+        self.assert_index_equal(the_sum.index, the_mean.index)
 
         # take mean of boolean column
         self.frame['bool'] = self.frame['A'] > 0
@@ -1070,8 +1065,8 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         dm = DataFrame(self.mixed_frame._series)
         df = DataFrame(self.mixed_frame._series)
 
-        assert_series_equal(dm.count(), df.count())
-        assert_series_equal(dm.count(1), df.count(1))
+        tm.assert_series_equal(dm.count(), df.count())
+        tm.assert_series_equal(dm.count(1), df.count(1))
 
     def test_cumsum_corner(self):
         dm = DataFrame(np.arange(20).reshape(4, 5),
@@ -1094,9 +1089,9 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
             for axis in [0, 1]:
                 for df in [frame, self.intframe]:
                     result = df.idxmin(axis=axis, skipna=skipna)
-                    expected = df.apply(
-                        Series.idxmin, axis=axis, skipna=skipna)
-                    assert_series_equal(result, expected)
+                    expected = df.apply(Series.idxmin, axis=axis,
+                                        skipna=skipna)
+                    tm.assert_series_equal(result, expected)
 
         self.assertRaises(ValueError, frame.idxmin, axis=2)
 
@@ -1108,9 +1103,9 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
             for axis in [0, 1]:
                 for df in [frame, self.intframe]:
                     result = df.idxmax(axis=axis, skipna=skipna)
-                    expected = df.apply(
-                        Series.idxmax, axis=axis, skipna=skipna)
-                    assert_series_equal(result, expected)
+                    expected = df.apply(Series.idxmax, axis=axis,
+                                        skipna=skipna)
+                    tm.assert_series_equal(result, expected)
 
         self.assertRaises(ValueError, frame.idxmax, axis=2)
 
@@ -1169,18 +1164,18 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
             result0 = f(axis=0, skipna=False)
             result1 = f(axis=1, skipna=False)
-            assert_series_equal(result0, frame.apply(wrapper))
-            assert_series_equal(result1, frame.apply(wrapper, axis=1),
-                                check_dtype=False)  # HACK: win32
+            tm.assert_series_equal(result0, frame.apply(wrapper))
+            tm.assert_series_equal(result1, frame.apply(wrapper, axis=1),
+                                   check_dtype=False)  # HACK: win32
         else:
             skipna_wrapper = alternative
             wrapper = alternative
 
         result0 = f(axis=0)
         result1 = f(axis=1)
-        assert_series_equal(result0, frame.apply(skipna_wrapper))
-        assert_series_equal(result1, frame.apply(skipna_wrapper, axis=1),
-                            check_dtype=False)
+        tm.assert_series_equal(result0, frame.apply(skipna_wrapper))
+        tm.assert_series_equal(result1, frame.apply(skipna_wrapper, axis=1),
+                               check_dtype=False)
 
         # result = f(axis=1)
         # comp = frame.apply(alternative, axis=1).reindex(result.index)
@@ -1230,7 +1225,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
                            'b': list(ascii_lowercase[:10])})
         result = df.nlargest(5, 'a')
         expected = df.sort_values('a', ascending=False).head(5)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_nlargest_multiple_columns(self):
         from string import ascii_lowercase
@@ -1239,7 +1234,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
                            'c': np.random.permutation(10).astype('float64')})
         result = df.nlargest(5, ['a', 'b'])
         expected = df.sort_values(['a', 'b'], ascending=False).head(5)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_nsmallest(self):
         from string import ascii_lowercase
@@ -1247,7 +1242,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
                            'b': list(ascii_lowercase[:10])})
         result = df.nsmallest(5, 'a')
         expected = df.sort_values('a').head(5)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_nsmallest_multiple_columns(self):
         from string import ascii_lowercase
@@ -1256,7 +1251,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
                            'c': np.random.permutation(10).astype('float64')})
         result = df.nsmallest(5, ['a', 'c'])
         expected = df.sort_values(['a', 'c']).head(5)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     # ----------------------------------------------------------------------
     # Isin
@@ -1270,13 +1265,13 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
         result = df.isin(other)
         expected = DataFrame([df.loc[s].isin(other) for s in df.index])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_isin_empty(self):
         df = DataFrame({'A': ['a', 'b', 'c'], 'B': ['a', 'e', 'f']})
         result = df.isin([])
         expected = pd.DataFrame(False, df.index, df.columns)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_isin_dict(self):
         df = DataFrame({'A': ['a', 'b', 'c'], 'B': ['a', 'e', 'f']})
@@ -1286,7 +1281,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         expected.loc[0, 'A'] = True
 
         result = df.isin(d)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # non unique columns
         df = DataFrame({'A': ['a', 'b', 'c'], 'B': ['a', 'e', 'f']})
@@ -1294,7 +1289,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         expected = DataFrame(False, df.index, df.columns)
         expected.loc[0, 'A'] = True
         result = df.isin(d)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_isin_with_string_scalar(self):
         # GH4763
@@ -1314,13 +1309,13 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         result = df1.isin(df2)
         expected['A'].loc[[1, 3]] = True
         expected['B'].loc[[0, 2]] = True
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # partial overlapping columns
         df2.columns = ['A', 'C']
         result = df1.isin(df2)
         expected['B'] = False
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_isin_df_dupe_values(self):
         df1 = DataFrame({'A': [1, 2, 3, 4], 'B': [2, np.nan, 4, 4]})
@@ -1348,7 +1343,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         expected = DataFrame(False, index=df.index, columns=df.columns)
         expected.loc[0] = True
         expected.iloc[1, 1] = True
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_isin_against_series(self):
         df = pd.DataFrame({'A': [1, 2, 3, 4], 'B': [2, np.nan, 4, 4]},
@@ -1358,7 +1353,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         expected['A'].loc['a'] = True
         expected.loc['d'] = True
         result = df.isin(s)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_isin_multiIndex(self):
         idx = MultiIndex.from_tuples([(0, 'a', 'foo'), (0, 'a', 'bar'),
@@ -1374,7 +1369,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         # against regular index
         expected = DataFrame(False, index=df1.index, columns=df1.columns)
         result = df1.isin(df2)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df2.index = idx
         expected = df2.values.astype(np.bool)
@@ -1382,7 +1377,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         expected = DataFrame(expected, columns=['A', 'B'], index=idx)
 
         result = df1.isin(df2)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     # ----------------------------------------------------------------------
     # Row deduplication
@@ -1398,43 +1393,43 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         # single column
         result = df.drop_duplicates('AAA')
         expected = df[:2]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates('AAA', keep='last')
         expected = df.ix[[6, 7]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates('AAA', keep=False)
         expected = df.ix[[]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         self.assertEqual(len(result), 0)
 
         # deprecate take_last
         with tm.assert_produces_warning(FutureWarning):
             result = df.drop_duplicates('AAA', take_last=True)
             expected = df.ix[[6, 7]]
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
         # multi column
         expected = df.ix[[0, 1, 2, 3]]
         result = df.drop_duplicates(np.array(['AAA', 'B']))
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         result = df.drop_duplicates(['AAA', 'B'])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates(('AAA', 'B'), keep='last')
         expected = df.ix[[0, 5, 6, 7]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates(('AAA', 'B'), keep=False)
         expected = df.ix[[0]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # deprecate take_last
         with tm.assert_produces_warning(FutureWarning):
             result = df.drop_duplicates(('AAA', 'B'), take_last=True)
         expected = df.ix[[0, 5, 6, 7]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # consider everything
         df2 = df.ix[:, ['AAA', 'B', 'C']]
@@ -1442,64 +1437,64 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         result = df2.drop_duplicates()
         # in this case only
         expected = df2.drop_duplicates(['AAA', 'B'])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df2.drop_duplicates(keep='last')
         expected = df2.drop_duplicates(['AAA', 'B'], keep='last')
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df2.drop_duplicates(keep=False)
         expected = df2.drop_duplicates(['AAA', 'B'], keep=False)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # deprecate take_last
         with tm.assert_produces_warning(FutureWarning):
             result = df2.drop_duplicates(take_last=True)
         with tm.assert_produces_warning(FutureWarning):
             expected = df2.drop_duplicates(['AAA', 'B'], take_last=True)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # integers
         result = df.drop_duplicates('C')
         expected = df.iloc[[0, 2]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         result = df.drop_duplicates('C', keep='last')
         expected = df.iloc[[-2, -1]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df['E'] = df['C'].astype('int8')
         result = df.drop_duplicates('E')
         expected = df.iloc[[0, 2]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         result = df.drop_duplicates('E', keep='last')
         expected = df.iloc[[-2, -1]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # GH 11376
         df = pd.DataFrame({'x': [7, 6, 3, 3, 4, 8, 0],
                            'y': [0, 6, 5, 5, 9, 1, 2]})
         expected = df.loc[df.index != 3]
-        assert_frame_equal(df.drop_duplicates(), expected)
+        tm.assert_frame_equal(df.drop_duplicates(), expected)
 
         df = pd.DataFrame([[1, 0], [0, 2]])
-        assert_frame_equal(df.drop_duplicates(), df)
+        tm.assert_frame_equal(df.drop_duplicates(), df)
 
         df = pd.DataFrame([[-2, 0], [0, -4]])
-        assert_frame_equal(df.drop_duplicates(), df)
+        tm.assert_frame_equal(df.drop_duplicates(), df)
 
         x = np.iinfo(np.int64).max / 3 * 2
         df = pd.DataFrame([[-x, x], [0, x + 4]])
-        assert_frame_equal(df.drop_duplicates(), df)
+        tm.assert_frame_equal(df.drop_duplicates(), df)
 
         df = pd.DataFrame([[-x, x], [x, x + 4]])
-        assert_frame_equal(df.drop_duplicates(), df)
+        tm.assert_frame_equal(df.drop_duplicates(), df)
 
         # GH 11864
         df = pd.DataFrame([i] * 9 for i in range(16))
         df = df.append([[1] + [0] * 8], ignore_index=True)
 
         for keep in ['first', 'last', False]:
-            assert_equal(df.duplicated(keep=keep).sum(), 0)
+            self.assertEqual(df.duplicated(keep=keep).sum(), 0)
 
     def test_drop_duplicates_for_take_all(self):
         df = DataFrame({'AAA': ['foo', 'bar', 'baz', 'bar',
@@ -1512,28 +1507,28 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         # single column
         result = df.drop_duplicates('AAA')
         expected = df.iloc[[0, 1, 2, 6]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates('AAA', keep='last')
         expected = df.iloc[[2, 5, 6, 7]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates('AAA', keep=False)
         expected = df.iloc[[2, 6]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # multiple columns
         result = df.drop_duplicates(['AAA', 'B'])
         expected = df.iloc[[0, 1, 2, 3, 4, 6]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates(['AAA', 'B'], keep='last')
         expected = df.iloc[[0, 1, 2, 5, 6, 7]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates(['AAA', 'B'], keep=False)
         expected = df.iloc[[0, 1, 2, 6]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_drop_duplicates_tuple(self):
         df = DataFrame({('AA', 'AB'): ['foo', 'bar', 'foo', 'bar',
@@ -1546,27 +1541,27 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         # single column
         result = df.drop_duplicates(('AA', 'AB'))
         expected = df[:2]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates(('AA', 'AB'), keep='last')
         expected = df.ix[[6, 7]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates(('AA', 'AB'), keep=False)
         expected = df.ix[[]]  # empty df
         self.assertEqual(len(result), 0)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # deprecate take_last
         with tm.assert_produces_warning(FutureWarning):
             result = df.drop_duplicates(('AA', 'AB'), take_last=True)
         expected = df.ix[[6, 7]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # multi column
         expected = df.ix[[0, 1, 2, 3]]
         result = df.drop_duplicates((('AA', 'AB'), 'B'))
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_drop_duplicates_NA(self):
         # none
@@ -1580,41 +1575,41 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         # single column
         result = df.drop_duplicates('A')
         expected = df.ix[[0, 2, 3]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates('A', keep='last')
         expected = df.ix[[1, 6, 7]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates('A', keep=False)
         expected = df.ix[[]]  # empty df
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         self.assertEqual(len(result), 0)
 
         # deprecate take_last
         with tm.assert_produces_warning(FutureWarning):
             result = df.drop_duplicates('A', take_last=True)
         expected = df.ix[[1, 6, 7]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # multi column
         result = df.drop_duplicates(['A', 'B'])
         expected = df.ix[[0, 2, 3, 6]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates(['A', 'B'], keep='last')
         expected = df.ix[[1, 5, 6, 7]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates(['A', 'B'], keep=False)
         expected = df.ix[[6]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # deprecate take_last
         with tm.assert_produces_warning(FutureWarning):
             result = df.drop_duplicates(['A', 'B'], take_last=True)
         expected = df.ix[[1, 5, 6, 7]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # nan
         df = DataFrame({'A': ['foo', 'bar', 'foo', 'bar',
@@ -1627,41 +1622,41 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         # single column
         result = df.drop_duplicates('C')
         expected = df[:2]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates('C', keep='last')
         expected = df.ix[[3, 7]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates('C', keep=False)
         expected = df.ix[[]]  # empty df
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         self.assertEqual(len(result), 0)
 
         # deprecate take_last
         with tm.assert_produces_warning(FutureWarning):
             result = df.drop_duplicates('C', take_last=True)
         expected = df.ix[[3, 7]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # multi column
         result = df.drop_duplicates(['C', 'B'])
         expected = df.ix[[0, 1, 2, 4]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates(['C', 'B'], keep='last')
         expected = df.ix[[1, 3, 6, 7]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates(['C', 'B'], keep=False)
         expected = df.ix[[1]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # deprecate take_last
         with tm.assert_produces_warning(FutureWarning):
             result = df.drop_duplicates(['C', 'B'], take_last=True)
         expected = df.ix[[1, 3, 6, 7]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_drop_duplicates_NA_for_take_all(self):
         # none
@@ -1672,30 +1667,30 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         # single column
         result = df.drop_duplicates('A')
         expected = df.iloc[[0, 2, 3, 5, 7]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates('A', keep='last')
         expected = df.iloc[[1, 4, 5, 6, 7]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates('A', keep=False)
         expected = df.iloc[[5, 7]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # nan
 
         # single column
         result = df.drop_duplicates('C')
         expected = df.iloc[[0, 1, 5, 6]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates('C', keep='last')
         expected = df.iloc[[3, 5, 6, 7]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates('C', keep=False)
         expected = df.iloc[[5, 6]]
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_drop_duplicates_inplace(self):
         orig = DataFrame({'A': ['foo', 'bar', 'foo', 'bar',
@@ -1710,19 +1705,19 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         df.drop_duplicates('A', inplace=True)
         expected = orig[:2]
         result = df
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df = orig.copy()
         df.drop_duplicates('A', keep='last', inplace=True)
         expected = orig.ix[[6, 7]]
         result = df
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df = orig.copy()
         df.drop_duplicates('A', keep=False, inplace=True)
         expected = orig.ix[[]]
         result = df
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
         self.assertEqual(len(df), 0)
 
         # deprecate take_last
@@ -1731,26 +1726,26 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
             df.drop_duplicates('A', take_last=True, inplace=True)
         expected = orig.ix[[6, 7]]
         result = df
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # multi column
         df = orig.copy()
         df.drop_duplicates(['A', 'B'], inplace=True)
         expected = orig.ix[[0, 1, 2, 3]]
         result = df
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df = orig.copy()
         df.drop_duplicates(['A', 'B'], keep='last', inplace=True)
         expected = orig.ix[[0, 5, 6, 7]]
         result = df
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df = orig.copy()
         df.drop_duplicates(['A', 'B'], keep=False, inplace=True)
         expected = orig.ix[[0]]
         result = df
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # deprecate take_last
         df = orig.copy()
@@ -1758,7 +1753,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
             df.drop_duplicates(['A', 'B'], take_last=True, inplace=True)
         expected = orig.ix[[0, 5, 6, 7]]
         result = df
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # consider everything
         orig2 = orig.ix[:, ['A', 'B', 'C']].copy()
@@ -1768,19 +1763,19 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         # in this case only
         expected = orig2.drop_duplicates(['A', 'B'])
         result = df2
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df2 = orig2.copy()
         df2.drop_duplicates(keep='last', inplace=True)
         expected = orig2.drop_duplicates(['A', 'B'], keep='last')
         result = df2
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df2 = orig2.copy()
         df2.drop_duplicates(keep=False, inplace=True)
         expected = orig2.drop_duplicates(['A', 'B'], keep=False)
         result = df2
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # deprecate take_last
         df2 = orig2.copy()
@@ -1789,7 +1784,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         with tm.assert_produces_warning(FutureWarning):
             expected = orig2.drop_duplicates(['A', 'B'], take_last=True)
         result = df2
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     # Rounding
 
@@ -1798,26 +1793,26 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
         # Test that rounding an empty DataFrame does nothing
         df = DataFrame()
-        assert_frame_equal(df, df.round())
+        tm.assert_frame_equal(df, df.round())
 
         # Here's the test frame we'll be working with
-        df = DataFrame(
-            {'col1': [1.123, 2.123, 3.123], 'col2': [1.234, 2.234, 3.234]})
+        df = DataFrame({'col1': [1.123, 2.123, 3.123],
+                        'col2': [1.234, 2.234, 3.234]})
 
         # Default round to integer (i.e. decimals=0)
         expected_rounded = DataFrame(
             {'col1': [1., 2., 3.], 'col2': [1., 2., 3.]})
-        assert_frame_equal(df.round(), expected_rounded)
+        tm.assert_frame_equal(df.round(), expected_rounded)
 
         # Round with an integer
         decimals = 2
-        expected_rounded = DataFrame(
-            {'col1': [1.12, 2.12, 3.12], 'col2': [1.23, 2.23, 3.23]})
-        assert_frame_equal(df.round(decimals), expected_rounded)
+        expected_rounded = DataFrame({'col1': [1.12, 2.12, 3.12],
+                                      'col2': [1.23, 2.23, 3.23]})
+        tm.assert_frame_equal(df.round(decimals), expected_rounded)
 
         # This should also work with np.round (since np.round dispatches to
         # df.round)
-        assert_frame_equal(np.round(df, decimals), expected_rounded)
+        tm.assert_frame_equal(np.round(df, decimals), expected_rounded)
 
         # Round with a list
         round_list = [1, 2]
@@ -1828,19 +1823,19 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         expected_rounded = DataFrame(
             {'col1': [1.1, 2.1, 3.1], 'col2': [1.23, 2.23, 3.23]})
         round_dict = {'col1': 1, 'col2': 2}
-        assert_frame_equal(df.round(round_dict), expected_rounded)
+        tm.assert_frame_equal(df.round(round_dict), expected_rounded)
 
         # Incomplete dict
         expected_partially_rounded = DataFrame(
             {'col1': [1.123, 2.123, 3.123], 'col2': [1.2, 2.2, 3.2]})
         partial_round_dict = {'col2': 1}
-        assert_frame_equal(
-            df.round(partial_round_dict), expected_partially_rounded)
+        tm.assert_frame_equal(df.round(partial_round_dict),
+                              expected_partially_rounded)
 
         # Dict with unknown elements
         wrong_round_dict = {'col3': 2, 'col2': 1}
-        assert_frame_equal(
-            df.round(wrong_round_dict), expected_partially_rounded)
+        tm.assert_frame_equal(df.round(wrong_round_dict),
+                              expected_partially_rounded)
 
         # float input to `decimals`
         non_int_round_dict = {'col1': 1, 'col2': 0.5}
@@ -1879,8 +1874,8 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         big_df = df * 100
         expected_neg_rounded = DataFrame(
             {'col1': [110., 210, 310], 'col2': [100., 200, 300]})
-        assert_frame_equal(
-            big_df.round(negative_round_dict), expected_neg_rounded)
+        tm.assert_frame_equal(big_df.round(negative_round_dict),
+                              expected_neg_rounded)
 
         # nan in Series round
         nan_round_Series = Series({'col1': nan, 'col2': 1})
@@ -1899,7 +1894,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
                 df.round(nan_round_Series)
 
         # Make sure this doesn't break existing Series.round
-        assert_series_equal(df['col1'].round(1), expected_rounded['col1'])
+        tm.assert_series_equal(df['col1'].round(1), expected_rounded['col1'])
 
         # named columns
         # GH 11986
@@ -1908,20 +1903,20 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
             {'col1': [1.12, 2.12, 3.12], 'col2': [1.23, 2.23, 3.23]})
         df.columns.name = "cols"
         expected_rounded.columns.name = "cols"
-        assert_frame_equal(df.round(decimals), expected_rounded)
+        tm.assert_frame_equal(df.round(decimals), expected_rounded)
 
         # interaction of named columns & series
-        assert_series_equal(df['col1'].round(decimals),
-                            expected_rounded['col1'])
-        assert_series_equal(df.round(decimals)['col1'],
-                            expected_rounded['col1'])
+        tm.assert_series_equal(df['col1'].round(decimals),
+                               expected_rounded['col1'])
+        tm.assert_series_equal(df.round(decimals)['col1'],
+                               expected_rounded['col1'])
 
     def test_numpy_round(self):
         # See gh-12600
         df = DataFrame([[1.53, 1.36], [0.06, 7.01]])
         out = np.round(df, decimals=0)
         expected = DataFrame([[2., 1.], [0., 7.]])
-        assert_frame_equal(out, expected)
+        tm.assert_frame_equal(out, expected)
 
         msg = "the 'out' parameter is not supported"
         with tm.assertRaisesRegexp(ValueError, msg):
@@ -1935,12 +1930,12 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         round_0 = DataFrame({'col1': [1., 2., 3., 4.],
                              'col2': ['1', 'a', 'c', 'f'],
                              'col3': date_range('20111111', periods=4)})
-        assert_frame_equal(df.round(), round_0)
-        assert_frame_equal(df.round(1), df)
-        assert_frame_equal(df.round({'col1': 1}), df)
-        assert_frame_equal(df.round({'col1': 0}), round_0)
-        assert_frame_equal(df.round({'col1': 0, 'col2': 1}), round_0)
-        assert_frame_equal(df.round({'col3': 1}), df)
+        tm.assert_frame_equal(df.round(), round_0)
+        tm.assert_frame_equal(df.round(1), df)
+        tm.assert_frame_equal(df.round({'col1': 1}), df)
+        tm.assert_frame_equal(df.round({'col1': 0}), round_0)
+        tm.assert_frame_equal(df.round({'col1': 0, 'col2': 1}), round_0)
+        tm.assert_frame_equal(df.round({'col3': 1}), df)
 
     def test_round_issue(self):
         # GH11611
@@ -1950,7 +1945,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
         dfs = pd.concat((df, df), axis=1)
         rounded = dfs.round()
-        self.assertTrue(rounded.index.equals(dfs.index))
+        self.assert_index_equal(rounded.index, dfs.index)
 
         decimals = pd.Series([1, 0, 2], index=['A', 'B', 'A'])
         self.assertRaises(ValueError, df.round, decimals)
@@ -1968,7 +1963,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         # Default round to integer (i.e. decimals=0)
         expected_rounded = DataFrame(
             {'col1': [1., 2., 3.], 'col2': [1., 2., 3.]})
-        assert_frame_equal(round(df), expected_rounded)
+        tm.assert_frame_equal(round(df), expected_rounded)
 
     # Clip
 
@@ -2015,14 +2010,14 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
             mask = ~lb_mask & ~ub_mask
 
             result = clipped_df.loc[lb_mask, i]
-            assert_series_equal(result, lb[lb_mask], check_names=False)
+            tm.assert_series_equal(result, lb[lb_mask], check_names=False)
             self.assertEqual(result.name, i)
 
             result = clipped_df.loc[ub_mask, i]
-            assert_series_equal(result, ub[ub_mask], check_names=False)
+            tm.assert_series_equal(result, ub[ub_mask], check_names=False)
             self.assertEqual(result.name, i)
 
-            assert_series_equal(clipped_df.loc[mask, i], df.loc[mask, i])
+            tm.assert_series_equal(clipped_df.loc[mask, i], df.loc[mask, i])
 
     def test_clip_against_frame(self):
         df = DataFrame(np.random.randn(1000, 2))
@@ -2035,9 +2030,9 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         ub_mask = df >= ub
         mask = ~lb_mask & ~ub_mask
 
-        assert_frame_equal(clipped_df[lb_mask], lb[lb_mask])
-        assert_frame_equal(clipped_df[ub_mask], ub[ub_mask])
-        assert_frame_equal(clipped_df[mask], df[mask])
+        tm.assert_frame_equal(clipped_df[lb_mask], lb[lb_mask])
+        tm.assert_frame_equal(clipped_df[ub_mask], ub[ub_mask])
+        tm.assert_frame_equal(clipped_df[mask], df[mask])
 
     # Matrix-like
 
@@ -2054,15 +2049,15 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         # Check alignment
         b1 = b.reindex(index=reversed(b.index))
         result = a.dot(b)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # Check series argument
         result = a.dot(b['one'])
-        assert_series_equal(result, expected['one'], check_names=False)
+        tm.assert_series_equal(result, expected['one'], check_names=False)
         self.assertTrue(result.name is None)
 
         result = a.dot(b1['one'])
-        assert_series_equal(result, expected['one'], check_names=False)
+        tm.assert_series_equal(result, expected['one'], check_names=False)
         self.assertTrue(result.name is None)
 
         # can pass correct-length arrays
@@ -2070,9 +2065,9 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
         result = a.dot(row)
         exp = a.dot(a.ix[0])
-        assert_series_equal(result, exp)
+        tm.assert_series_equal(result, exp)
 
-        with assertRaisesRegexp(ValueError, 'Dot product shape mismatch'):
+        with tm.assertRaisesRegexp(ValueError, 'Dot product shape mismatch'):
             a.dot(row[:-1])
 
         a = np.random.rand(1, 5)
@@ -2089,7 +2084,8 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         df = DataFrame(randn(3, 4), index=[1, 2, 3], columns=lrange(4))
         df2 = DataFrame(randn(5, 3), index=lrange(5), columns=[1, 2, 3])
 
-        assertRaisesRegexp(ValueError, 'aligned', df.dot, df2)
+        with tm.assertRaisesRegexp(ValueError, 'aligned'):
+            df.dot(df2)
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -221,7 +221,7 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
 
         # pass non-Index
         newFrame = self.frame.reindex(list(self.ts1.index))
-        self.assertTrue(newFrame.index.equals(self.ts1.index))
+        self.assert_index_equal(newFrame.index, self.ts1.index)
 
         # copy with no axes
         result = self.frame.reindex()
@@ -381,7 +381,7 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
         # axis = 0
         other = self.frame.ix[:-5, :3]
         af, bf = self.frame.align(other, axis=0, fill_value=-1)
-        self.assertTrue(bf.columns.equals(other.columns))
+        self.assert_index_equal(bf.columns, other.columns)
         # test fill value
         join_idx = self.frame.index.join(other.index)
         diff_a = self.frame.index.difference(join_idx)
@@ -391,15 +391,15 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
         self.assertTrue((diff_a_vals == -1).all())
 
         af, bf = self.frame.align(other, join='right', axis=0)
-        self.assertTrue(bf.columns.equals(other.columns))
-        self.assertTrue(bf.index.equals(other.index))
-        self.assertTrue(af.index.equals(other.index))
+        self.assert_index_equal(bf.columns, other.columns)
+        self.assert_index_equal(bf.index, other.index)
+        self.assert_index_equal(af.index, other.index)
 
         # axis = 1
         other = self.frame.ix[:-5, :3].copy()
         af, bf = self.frame.align(other, axis=1)
-        self.assertTrue(bf.columns.equals(self.frame.columns))
-        self.assertTrue(bf.index.equals(other.index))
+        self.assert_index_equal(bf.columns, self.frame.columns)
+        self.assert_index_equal(bf.index, other.index)
 
         # test fill value
         join_idx = self.frame.index.join(other.index)
@@ -413,35 +413,35 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
         self.assertTrue((diff_a_vals == -1).all())
 
         af, bf = self.frame.align(other, join='inner', axis=1)
-        self.assertTrue(bf.columns.equals(other.columns))
+        self.assert_index_equal(bf.columns, other.columns)
 
         af, bf = self.frame.align(other, join='inner', axis=1, method='pad')
-        self.assertTrue(bf.columns.equals(other.columns))
+        self.assert_index_equal(bf.columns, other.columns)
 
         # test other non-float types
         af, bf = self.intframe.align(other, join='inner', axis=1, method='pad')
-        self.assertTrue(bf.columns.equals(other.columns))
+        self.assert_index_equal(bf.columns, other.columns)
 
         af, bf = self.mixed_frame.align(self.mixed_frame,
                                         join='inner', axis=1, method='pad')
-        self.assertTrue(bf.columns.equals(self.mixed_frame.columns))
+        self.assert_index_equal(bf.columns, self.mixed_frame.columns)
 
         af, bf = self.frame.align(other.ix[:, 0], join='inner', axis=1,
                                   method=None, fill_value=None)
-        self.assertTrue(bf.index.equals(Index([])))
+        self.assert_index_equal(bf.index, Index([]))
 
         af, bf = self.frame.align(other.ix[:, 0], join='inner', axis=1,
                                   method=None, fill_value=0)
-        self.assertTrue(bf.index.equals(Index([])))
+        self.assert_index_equal(bf.index, Index([]))
 
         # mixed floats/ints
         af, bf = self.mixed_float.align(other.ix[:, 0], join='inner', axis=1,
                                         method=None, fill_value=0)
-        self.assertTrue(bf.index.equals(Index([])))
+        self.assert_index_equal(bf.index, Index([]))
 
         af, bf = self.mixed_int.align(other.ix[:, 0], join='inner', axis=1,
                                       method=None, fill_value=0)
-        self.assertTrue(bf.index.equals(Index([])))
+        self.assert_index_equal(bf.index, Index([]))
 
         # try to align dataframe to series along bad axis
         self.assertRaises(ValueError, self.frame.align, af.ix[0, :3],
@@ -810,10 +810,9 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
         index = Index(['a', 'b', 'c'])
         dm = self.empty.reindex(index=[1, 2, 3])
         reindexed = dm.reindex(columns=index)
-        self.assertTrue(reindexed.columns.equals(index))
+        self.assert_index_equal(reindexed.columns, index)
 
         # ints are weird
-
         smaller = self.intframe.reindex(columns=['A', 'B', 'E'])
         self.assertEqual(smaller['E'].dtype, np.float64)
 

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -505,8 +505,8 @@ starting,ending,measure
                         'd': [None, None, None],
                         'e': [3.14, 0.577, 2.773]})
 
-        self.assert_numpy_array_equal(df._get_numeric_data().columns,
-                                      ['a', 'b', 'e'])
+        self.assert_index_equal(df._get_numeric_data().columns,
+                                pd.Index(['a', 'b', 'e']))
 
     def test_strange_column_corruption_issue(self):
         # (wesm) Unclear how exactly this is related to internal matters

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -24,12 +24,6 @@ from pandas.core.common import PandasError
 import pandas as pd
 import pandas.core.common as com
 import pandas.lib as lib
-
-from pandas.util.testing import (assert_numpy_array_equal,
-                                 assert_series_equal,
-                                 assert_frame_equal,
-                                 assertRaisesRegexp)
-
 import pandas.util.testing as tm
 
 from pandas.tests.frame.common import TestData
@@ -171,16 +165,16 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         index = self.frame.index
 
         df = DataFrame(rec)
-        self.assert_numpy_array_equal(df.columns, rec.dtype.names)
+        self.assert_index_equal(df.columns, pd.Index(rec.dtype.names))
 
         df2 = DataFrame(rec, index=index)
-        self.assert_numpy_array_equal(df2.columns, rec.dtype.names)
-        self.assertTrue(df2.index.equals(index))
+        self.assert_index_equal(df2.columns, pd.Index(rec.dtype.names))
+        self.assert_index_equal(df2.index, index)
 
         rng = np.arange(len(rec))[::-1]
         df3 = DataFrame(rec, index=rng, columns=['C', 'B'])
         expected = DataFrame(rec, index=rng).reindex(columns=['C', 'B'])
-        assert_frame_equal(df3, expected)
+        tm.assert_frame_equal(df3, expected)
 
     def test_constructor_bool(self):
         df = DataFrame({0: np.ones(10, dtype=bool),
@@ -223,6 +217,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         self.assertEqual(len(self.ts2), 25)
 
         tm.assert_series_equal(self.ts1, frame['col1'], check_names=False)
+
         exp = pd.Series(np.concatenate([[np.nan] * 5, self.ts2.values]),
                         index=self.ts1.index, name='col2')
         tm.assert_series_equal(exp, frame['col2'])
@@ -245,7 +240,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         # Length-one dict micro-optimization
         frame = DataFrame({'A': {'1': 1, '2': 2}})
-        self.assert_numpy_array_equal(frame.index, ['1', '2'])
+        self.assert_index_equal(frame.index, pd.Index(['1', '2']))
 
         # empty dict plus index
         idx = Index([0, 1, 2])
@@ -261,7 +256,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         # with dict of empty list and Series
         frame = DataFrame({'A': [], 'B': []}, columns=['A', 'B'])
-        self.assertTrue(frame.index.equals(Index([])))
+        self.assert_index_equal(frame.index, Index([], dtype=np.int64))
 
         # GH10856
         # dict with scalar values should raise error, even if columns passed
@@ -290,37 +285,37 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
     def test_constructor_error_msgs(self):
         msg = "Empty data passed with indices specified."
         # passing an empty array with columns specified.
-        with assertRaisesRegexp(ValueError, msg):
+        with tm.assertRaisesRegexp(ValueError, msg):
             DataFrame(np.empty(0), columns=list('abc'))
 
         msg = "Mixing dicts with non-Series may lead to ambiguous ordering."
         # mix dict and array, wrong size
-        with assertRaisesRegexp(ValueError, msg):
+        with tm.assertRaisesRegexp(ValueError, msg):
             DataFrame({'A': {'a': 'a', 'b': 'b'},
                        'B': ['a', 'b', 'c']})
 
         # wrong size ndarray, GH 3105
         msg = "Shape of passed values is \(3, 4\), indices imply \(3, 3\)"
-        with assertRaisesRegexp(ValueError, msg):
+        with tm.assertRaisesRegexp(ValueError, msg):
             DataFrame(np.arange(12).reshape((4, 3)),
                       columns=['foo', 'bar', 'baz'],
                       index=pd.date_range('2000-01-01', periods=3))
 
         # higher dim raise exception
-        with assertRaisesRegexp(ValueError, 'Must pass 2-d input'):
+        with tm.assertRaisesRegexp(ValueError, 'Must pass 2-d input'):
             DataFrame(np.zeros((3, 3, 3)), columns=['A', 'B', 'C'], index=[1])
 
         # wrong size axis labels
-        with assertRaisesRegexp(ValueError, "Shape of passed values is "
-                                "\(3, 2\), indices imply \(3, 1\)"):
+        with tm.assertRaisesRegexp(ValueError, "Shape of passed values is "
+                                   "\(3, 2\), indices imply \(3, 1\)"):
             DataFrame(np.random.rand(2, 3), columns=['A', 'B', 'C'], index=[1])
 
-        with assertRaisesRegexp(ValueError, "Shape of passed values is "
-                                "\(3, 2\), indices imply \(2, 2\)"):
+        with tm.assertRaisesRegexp(ValueError, "Shape of passed values is "
+                                   "\(3, 2\), indices imply \(2, 2\)"):
             DataFrame(np.random.rand(2, 3), columns=['A', 'B'], index=[1, 2])
 
-        with assertRaisesRegexp(ValueError, 'If using all scalar values, you '
-                                'must pass an index'):
+        with tm.assertRaisesRegexp(ValueError, 'If using all scalar values, '
+                                   'you must pass an index'):
             DataFrame({'a': False, 'b': True})
 
     def test_constructor_with_embedded_frames(self):
@@ -333,10 +328,10 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         str(df2)
 
         result = df2.loc[0, 0]
-        assert_frame_equal(result, df1)
+        tm.assert_frame_equal(result, df1)
 
         result = df2.loc[1, 0]
-        assert_frame_equal(result, df1 + 10)
+        tm.assert_frame_equal(result, df1 + 10)
 
     def test_constructor_subclass_dict(self):
         # Test for passing dict subclass to constructor
@@ -345,11 +340,11 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         df = DataFrame(data)
         refdf = DataFrame(dict((col, dict(compat.iteritems(val)))
                                for col, val in compat.iteritems(data)))
-        assert_frame_equal(refdf, df)
+        tm.assert_frame_equal(refdf, df)
 
         data = tm.TestSubDict(compat.iteritems(data))
         df = DataFrame(data)
-        assert_frame_equal(refdf, df)
+        tm.assert_frame_equal(refdf, df)
 
         # try with defaultdict
         from collections import defaultdict
@@ -360,10 +355,10 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
             dct.update(v.to_dict())
             data[k] = dct
         frame = DataFrame(data)
-        assert_frame_equal(self.frame.sort_index(), frame)
+        tm.assert_frame_equal(self.frame.sort_index(), frame)
 
     def test_constructor_dict_block(self):
-        expected = [[4., 3., 2., 1.]]
+        expected = np.array([[4., 3., 2., 1.]])
         df = DataFrame({'d': [4.], 'c': [3.], 'b': [2.], 'a': [1.]},
                        columns=['d', 'c', 'b', 'a'])
         tm.assert_numpy_array_equal(df.values, expected)
@@ -409,10 +404,10 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         result = DataFrame(data)
         expected = DataFrame(dict((k, list(v))
                                   for k, v in compat.iteritems(data)))
-        assert_frame_equal(result, expected, check_dtype=False)
+        tm.assert_frame_equal(result, expected, check_dtype=False)
 
     def test_constructor_dict_multiindex(self):
-        check = lambda result, expected: assert_frame_equal(
+        check = lambda result, expected: tm.assert_frame_equal(
             result, expected, check_dtype=True, check_index_type=True,
             check_column_type=True, check_names=True)
         d = {('a', 'a'): {('i', 'i'): 0, ('i', 'j'): 1, ('j', 'i'): 2},
@@ -457,9 +452,9 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         result_datetime64 = DataFrame(data_datetime64)
         result_datetime = DataFrame(data_datetime)
         result_Timestamp = DataFrame(data_Timestamp)
-        assert_frame_equal(result_datetime64, expected)
-        assert_frame_equal(result_datetime, expected)
-        assert_frame_equal(result_Timestamp, expected)
+        tm.assert_frame_equal(result_datetime64, expected)
+        tm.assert_frame_equal(result_datetime, expected)
+        tm.assert_frame_equal(result_Timestamp, expected)
 
     def test_constructor_dict_timedelta64_index(self):
         # GH 10160
@@ -482,9 +477,9 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         result_timedelta64 = DataFrame(data_timedelta64)
         result_timedelta = DataFrame(data_timedelta)
         result_Timedelta = DataFrame(data_Timedelta)
-        assert_frame_equal(result_timedelta64, expected)
-        assert_frame_equal(result_timedelta, expected)
-        assert_frame_equal(result_Timedelta, expected)
+        tm.assert_frame_equal(result_timedelta64, expected)
+        tm.assert_frame_equal(result_timedelta, expected)
+        tm.assert_frame_equal(result_Timedelta, expected)
 
     def test_constructor_period(self):
         # PeriodIndex
@@ -510,7 +505,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
                 data.setdefault(col, {})[row] = df.get_value(row, col)
 
         result = DataFrame(data, columns=rng)
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
         data = {}
         for col in df.columns:
@@ -518,7 +513,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
                 data.setdefault(row, {})[col] = df.get_value(row, col)
 
         result = DataFrame(data, index=rng).T
-        assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df)
 
     def _check_basic_constructor(self, empty):
         # mat: 2d matrix with shpae (3, 2) to input. empty - makes sized
@@ -542,27 +537,27 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         # wrong size axis labels
         msg = r'Shape of passed values is \(3, 2\), indices imply \(3, 1\)'
-        with assertRaisesRegexp(ValueError, msg):
+        with tm.assertRaisesRegexp(ValueError, msg):
             DataFrame(mat, columns=['A', 'B', 'C'], index=[1])
         msg = r'Shape of passed values is \(3, 2\), indices imply \(2, 2\)'
-        with assertRaisesRegexp(ValueError, msg):
+        with tm.assertRaisesRegexp(ValueError, msg):
             DataFrame(mat, columns=['A', 'B'], index=[1, 2])
 
         # higher dim raise exception
-        with assertRaisesRegexp(ValueError, 'Must pass 2-d input'):
+        with tm.assertRaisesRegexp(ValueError, 'Must pass 2-d input'):
             DataFrame(empty((3, 3, 3)), columns=['A', 'B', 'C'],
                       index=[1])
 
         # automatic labeling
         frame = DataFrame(mat)
-        self.assert_numpy_array_equal(frame.index, lrange(2))
-        self.assert_numpy_array_equal(frame.columns, lrange(3))
+        self.assert_index_equal(frame.index, pd.Index(lrange(2)))
+        self.assert_index_equal(frame.columns, pd.Index(lrange(3)))
 
         frame = DataFrame(mat, index=[1, 2])
-        self.assert_numpy_array_equal(frame.columns, lrange(3))
+        self.assert_index_equal(frame.columns, pd.Index(lrange(3)))
 
         frame = DataFrame(mat, columns=['A', 'B', 'C'])
-        self.assert_numpy_array_equal(frame.index, lrange(2))
+        self.assert_index_equal(frame.index, pd.Index(lrange(2)))
 
         # 0-length axis
         frame = DataFrame(empty((0, 3)))
@@ -664,7 +659,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         # Ensure mrecarray produces frame identical to dict of masked arrays
         # from GH3479
 
-        assert_fr_equal = functools.partial(assert_frame_equal,
+        assert_fr_equal = functools.partial(tm.assert_frame_equal,
                                             check_index_type=True,
                                             check_column_type=True,
                                             check_frame_type=True)
@@ -738,13 +733,13 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         df = DataFrame({'a': randn(10), 'b': True})
         exp = DataFrame({'a': df['a'].values, 'b': [True] * 10})
 
-        assert_frame_equal(df, exp)
+        tm.assert_frame_equal(df, exp)
         with tm.assertRaisesRegexp(ValueError, 'must pass an index'):
             DataFrame({'a': False, 'b': True})
 
     def test_constructor_DataFrame(self):
         df = DataFrame(self.frame)
-        assert_frame_equal(df, self.frame)
+        tm.assert_frame_equal(df, self.frame)
 
         df_casted = DataFrame(self.frame, dtype=np.int64)
         self.assertEqual(df_casted.values.dtype, np.int64)
@@ -772,17 +767,17 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         # corner, silly
         # TODO: Fix this Exception to be better...
-        with assertRaisesRegexp(PandasError, 'constructor not '
-                                'properly called'):
+        with tm.assertRaisesRegexp(PandasError, 'constructor not '
+                                   'properly called'):
             DataFrame((1, 2, 3))
 
         # can't cast
         mat = np.array(['foo', 'bar'], dtype=object).reshape(2, 1)
-        with assertRaisesRegexp(ValueError, 'cast'):
+        with tm.assertRaisesRegexp(ValueError, 'cast'):
             DataFrame(mat, index=[0, 1], columns=[0], dtype=float)
 
         dm = DataFrame(DataFrame(self.frame._series))
-        assert_frame_equal(dm, self.frame)
+        tm.assert_frame_equal(dm, self.frame)
 
         # int cast
         dm = DataFrame({'A': np.ones(10, dtype=int),
@@ -795,12 +790,12 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
     def test_constructor_empty_list(self):
         df = DataFrame([], index=[])
         expected = DataFrame(index=[])
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         # GH 9939
         df = DataFrame([], columns=['A', 'B'])
         expected = DataFrame({}, columns=['A', 'B'])
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         # Empty generator: list(empty_gen()) == []
         def empty_gen():
@@ -808,7 +803,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
             yield
 
         df = DataFrame(empty_gen(), columns=['A', 'B'])
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     def test_constructor_list_of_lists(self):
         # GH #484
@@ -822,7 +817,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         expected = DataFrame({0: range(10)})
         data = [np.array(x) for x in range(10)]
         result = DataFrame(data)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_constructor_sequence_like(self):
         # GH 3783
@@ -844,25 +839,25 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         columns = ["num", "str"]
         result = DataFrame(l, columns=columns)
         expected = DataFrame([[1, 'a'], [2, 'b']], columns=columns)
-        assert_frame_equal(result, expected, check_dtype=False)
+        tm.assert_frame_equal(result, expected, check_dtype=False)
 
         # GH 4297
         # support Array
         import array
         result = DataFrame.from_items([('A', array.array('i', range(10)))])
         expected = DataFrame({'A': list(range(10))})
-        assert_frame_equal(result, expected, check_dtype=False)
+        tm.assert_frame_equal(result, expected, check_dtype=False)
 
         expected = DataFrame([list(range(10)), list(range(10))])
         result = DataFrame([array.array('i', range(10)),
                             array.array('i', range(10))])
-        assert_frame_equal(result, expected, check_dtype=False)
+        tm.assert_frame_equal(result, expected, check_dtype=False)
 
     def test_constructor_iterator(self):
 
         expected = DataFrame([list(range(10)), list(range(10))])
         result = DataFrame([range(10), range(10)])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_constructor_generator(self):
         # related #2305
@@ -872,12 +867,12 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         expected = DataFrame([list(range(10)), list(range(10))])
         result = DataFrame([gen1, gen2])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         gen = ([i, 'a'] for i in range(10))
         result = DataFrame(gen)
         expected = DataFrame({0: range(10), 1: 'a'})
-        assert_frame_equal(result, expected, check_dtype=False)
+        tm.assert_frame_equal(result, expected, check_dtype=False)
 
     def test_constructor_list_of_dicts(self):
         data = [OrderedDict([['a', 1.5], ['b', 3], ['c', 4], ['d', 6]]),
@@ -890,11 +885,11 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         result = DataFrame(data)
         expected = DataFrame.from_dict(dict(zip(range(len(data)), data)),
                                        orient='index')
-        assert_frame_equal(result, expected.reindex(result.index))
+        tm.assert_frame_equal(result, expected.reindex(result.index))
 
         result = DataFrame([{}])
         expected = DataFrame(index=[0])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_constructor_list_of_series(self):
         data = [OrderedDict([['a', 1.5], ['b', 3.0], ['c', 4.0]]),
@@ -907,7 +902,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
                  Series([1.5, 3, 6], idx, name='y')]
         result = DataFrame(data2)
         expected = DataFrame.from_dict(sdict, orient='index')
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # some unnamed
         data2 = [Series([1.5, 3, 4], idx, dtype='O', name='x'),
@@ -916,7 +911,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         sdict = OrderedDict(zip(['x', 'Unnamed 0'], data))
         expected = DataFrame.from_dict(sdict, orient='index')
-        assert_frame_equal(result.sort_index(), expected)
+        tm.assert_frame_equal(result.sort_index(), expected)
 
         # none named
         data = [OrderedDict([['a', 1.5], ['b', 3], ['c', 4], ['d', 6]]),
@@ -930,14 +925,14 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         result = DataFrame(data)
         sdict = OrderedDict(zip(range(len(data)), data))
         expected = DataFrame.from_dict(sdict, orient='index')
-        assert_frame_equal(result, expected.reindex(result.index))
+        tm.assert_frame_equal(result, expected.reindex(result.index))
 
         result2 = DataFrame(data, index=np.arange(6))
-        assert_frame_equal(result, result2)
+        tm.assert_frame_equal(result, result2)
 
         result = DataFrame([Series({})])
         expected = DataFrame(index=[0])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         data = [OrderedDict([['a', 1.5], ['b', 3.0], ['c', 4.0]]),
                 OrderedDict([['a', 1.5], ['b', 3.0], ['c', 6.0]])]
@@ -948,7 +943,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
                  Series([1.5, 3, 6], idx)]
         result = DataFrame(data2)
         expected = DataFrame.from_dict(sdict, orient='index')
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_constructor_list_of_derived_dicts(self):
         class CustomDict(dict):
@@ -960,19 +955,20 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         result_custom = DataFrame(data_custom)
         result = DataFrame(data)
-        assert_frame_equal(result, result_custom)
+        tm.assert_frame_equal(result, result_custom)
 
     def test_constructor_ragged(self):
         data = {'A': randn(10),
                 'B': randn(8)}
-        with assertRaisesRegexp(ValueError, 'arrays must all be same length'):
+        with tm.assertRaisesRegexp(ValueError,
+                                   'arrays must all be same length'):
             DataFrame(data)
 
     def test_constructor_scalar(self):
         idx = Index(lrange(3))
         df = DataFrame({"a": 0}, index=idx)
         expected = DataFrame({"a": [0, 0, 0]}, index=idx)
-        assert_frame_equal(df, expected, check_dtype=False)
+        tm.assert_frame_equal(df, expected, check_dtype=False)
 
     def test_constructor_Series_copy_bug(self):
         df = DataFrame(self.frame['A'], index=self.frame.index, columns=['A'])
@@ -987,7 +983,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         self.assertTrue(result.index.is_monotonic)
 
         # ordering ambiguous, raise exception
-        with assertRaisesRegexp(ValueError, 'ambiguous ordering'):
+        with tm.assertRaisesRegexp(ValueError, 'ambiguous ordering'):
             DataFrame({'A': ['a', 'b'], 'B': {'a': 'a', 'b': 'b'}})
 
         # this is OK though
@@ -995,12 +991,12 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
                             'B': Series(['a', 'b'], index=['a', 'b'])})
         expected = DataFrame({'A': ['a', 'b'], 'B': ['a', 'b']},
                              index=['a', 'b'])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_constructor_tuples(self):
         result = DataFrame({'A': [(1, 2), (3, 4)]})
         expected = DataFrame({'A': Series([(1, 2), (3, 4)])})
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_constructor_namedtuples(self):
         # GH11181
@@ -1009,43 +1005,43 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         tuples = [named_tuple(1, 3), named_tuple(2, 4)]
         expected = DataFrame({'a': [1, 2], 'b': [3, 4]})
         result = DataFrame(tuples)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # with columns
         expected = DataFrame({'y': [1, 2], 'z': [3, 4]})
         result = DataFrame(tuples, columns=['y', 'z'])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_constructor_orient(self):
         data_dict = self.mixed_frame.T._series
         recons = DataFrame.from_dict(data_dict, orient='index')
         expected = self.mixed_frame.sort_index()
-        assert_frame_equal(recons, expected)
+        tm.assert_frame_equal(recons, expected)
 
         # dict of sequence
         a = {'hi': [32, 3, 3],
              'there': [3, 5, 3]}
         rs = DataFrame.from_dict(a, orient='index')
         xp = DataFrame.from_dict(a).T.reindex(list(a.keys()))
-        assert_frame_equal(rs, xp)
+        tm.assert_frame_equal(rs, xp)
 
     def test_constructor_Series_named(self):
         a = Series([1, 2, 3], index=['a', 'b', 'c'], name='x')
         df = DataFrame(a)
         self.assertEqual(df.columns[0], 'x')
-        self.assertTrue(df.index.equals(a.index))
+        self.assert_index_equal(df.index, a.index)
 
         # ndarray like
         arr = np.random.randn(10)
         s = Series(arr, name='x')
         df = DataFrame(s)
         expected = DataFrame(dict(x=s))
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         s = Series(arr, index=range(3, 13))
         df = DataFrame(s)
         expected = DataFrame({0: s})
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         self.assertRaises(ValueError, DataFrame, s, columns=[1, 2])
 
@@ -1059,12 +1055,12 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         df = DataFrame([s1, arr]).T
         expected = DataFrame({'x': s1, 'Unnamed 0': arr},
                              columns=['x', 'Unnamed 0'])
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         # this is a bit non-intuitive here; the series collapse down to arrays
         df = DataFrame([arr, s1]).T
         expected = DataFrame({1: s1, 0: arr}, columns=[0, 1])
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     def test_constructor_Series_differently_indexed(self):
         # name
@@ -1078,13 +1074,13 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         df1 = DataFrame(s1, index=other_index)
         exp1 = DataFrame(s1.reindex(other_index))
         self.assertEqual(df1.columns[0], 'x')
-        assert_frame_equal(df1, exp1)
+        tm.assert_frame_equal(df1, exp1)
 
         df2 = DataFrame(s2, index=other_index)
         exp2 = DataFrame(s2.reindex(other_index))
         self.assertEqual(df2.columns[0], 0)
-        self.assertTrue(df2.index.equals(other_index))
-        assert_frame_equal(df2, exp2)
+        self.assert_index_equal(df2.index, other_index)
+        tm.assert_frame_equal(df2, exp2)
 
     def test_constructor_manager_resize(self):
         index = list(self.frame.index[:5])
@@ -1092,17 +1088,17 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         result = DataFrame(self.frame._data, index=index,
                            columns=columns)
-        self.assert_numpy_array_equal(result.index, index)
-        self.assert_numpy_array_equal(result.columns, columns)
+        self.assert_index_equal(result.index, Index(index))
+        self.assert_index_equal(result.columns, Index(columns))
 
     def test_constructor_from_items(self):
         items = [(c, self.frame[c]) for c in self.frame.columns]
         recons = DataFrame.from_items(items)
-        assert_frame_equal(recons, self.frame)
+        tm.assert_frame_equal(recons, self.frame)
 
         # pass some columns
         recons = DataFrame.from_items(items, columns=['C', 'B', 'A'])
-        assert_frame_equal(recons, self.frame.ix[:, ['C', 'B', 'A']])
+        tm.assert_frame_equal(recons, self.frame.ix[:, ['C', 'B', 'A']])
 
         # orient='index'
 
@@ -1112,7 +1108,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         recons = DataFrame.from_items(row_items,
                                       columns=self.mixed_frame.columns,
                                       orient='index')
-        assert_frame_equal(recons, self.mixed_frame)
+        tm.assert_frame_equal(recons, self.mixed_frame)
         self.assertEqual(recons['A'].dtype, np.float64)
 
         with tm.assertRaisesRegexp(TypeError,
@@ -1128,7 +1124,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         recons = DataFrame.from_items(row_items,
                                       columns=self.mixed_frame.columns,
                                       orient='index')
-        assert_frame_equal(recons, self.mixed_frame)
+        tm.assert_frame_equal(recons, self.mixed_frame)
         tm.assertIsInstance(recons['foo'][0], tuple)
 
         rs = DataFrame.from_items([('A', [1, 2, 3]), ('B', [4, 5, 6])],
@@ -1136,12 +1132,12 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
                                   columns=['one', 'two', 'three'])
         xp = DataFrame([[1, 2, 3], [4, 5, 6]], index=['A', 'B'],
                        columns=['one', 'two', 'three'])
-        assert_frame_equal(rs, xp)
+        tm.assert_frame_equal(rs, xp)
 
     def test_constructor_mix_series_nonseries(self):
         df = DataFrame({'A': self.frame['A'],
                         'B': list(self.frame['B'])}, columns=['A', 'B'])
-        assert_frame_equal(df, self.frame.ix[:, ['A', 'B']])
+        tm.assert_frame_equal(df, self.frame.ix[:, ['A', 'B']])
 
         with tm.assertRaisesRegexp(ValueError, 'does not match index length'):
             DataFrame({'A': self.frame['A'], 'B': list(self.frame['B'])[:-2]})
@@ -1149,10 +1145,10 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
     def test_constructor_miscast_na_int_dtype(self):
         df = DataFrame([[np.nan, 1], [1, 0]], dtype=np.int64)
         expected = DataFrame([[np.nan, 1], [1, 0]])
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     def test_constructor_iterator_failure(self):
-        with assertRaisesRegexp(TypeError, 'iterator'):
+        with tm.assertRaisesRegexp(TypeError, 'iterator'):
             df = DataFrame(iter([1, 2, 3]))  # noqa
 
     def test_constructor_column_duplicates(self):
@@ -1161,11 +1157,11 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         edf = DataFrame([[8, 5]])
         edf.columns = ['a', 'a']
 
-        assert_frame_equal(df, edf)
+        tm.assert_frame_equal(df, edf)
 
         idf = DataFrame.from_items(
             [('a', [8]), ('a', [5])], columns=['a', 'a'])
-        assert_frame_equal(idf, edf)
+        tm.assert_frame_equal(idf, edf)
 
         self.assertRaises(ValueError, DataFrame.from_items,
                           [('a', [8]), ('a', [5]), ('b', [6])],
@@ -1176,30 +1172,29 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         expected = DataFrame(index=[0, 1], columns=[0, 1], dtype=object)
 
         df = DataFrame(index=[0, 1], columns=[0, 1], dtype=str)
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
         df = DataFrame(index=[0, 1], columns=[0, 1], dtype=np.str_)
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
         df = DataFrame(index=[0, 1], columns=[0, 1], dtype=np.unicode_)
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
         df = DataFrame(index=[0, 1], columns=[0, 1], dtype='U5')
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     def test_constructor_single_value(self):
         # expecting single value upcasting here
         df = DataFrame(0., index=[1, 2, 3], columns=['a', 'b', 'c'])
-        assert_frame_equal(df, DataFrame(np.zeros(df.shape).astype('float64'),
-                                         df.index, df.columns))
+        tm.assert_frame_equal(df,
+                              DataFrame(np.zeros(df.shape).astype('float64'),
+                                        df.index, df.columns))
 
         df = DataFrame(0, index=[1, 2, 3], columns=['a', 'b', 'c'])
-        assert_frame_equal(df, DataFrame(np.zeros(df.shape).astype('int64'),
-                                         df.index, df.columns))
+        tm.assert_frame_equal(df, DataFrame(np.zeros(df.shape).astype('int64'),
+                                            df.index, df.columns))
 
         df = DataFrame('a', index=[1, 2], columns=['a', 'c'])
-        assert_frame_equal(df, DataFrame(np.array([['a', 'a'],
-                                                   ['a', 'a']],
-                                                  dtype=object),
-                                         index=[1, 2],
-                                         columns=['a', 'c']))
+        tm.assert_frame_equal(df, DataFrame(np.array([['a', 'a'], ['a', 'a']],
+                                                     dtype=object),
+                                            index=[1, 2], columns=['a', 'c']))
 
         self.assertRaises(com.PandasError, DataFrame, 'a', [1, 2])
         self.assertRaises(com.PandasError, DataFrame, 'a', columns=['a', 'c'])
@@ -1221,7 +1216,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         expected = Series({'int64': 1, datetime64name: 2, objectname: 2})
         result.sort_index()
         expected.sort_index()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # check with ndarray construction ndim==0 (e.g. we are passing a ndim 0
         # ndarray with a dtype specified)
@@ -1245,7 +1240,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         result.sort_index()
         expected = Series(expected)
         expected.sort_index()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # check with ndarray construction ndim>0
         df = DataFrame({'a': 1., 'b': 2, 'c': 'foo',
@@ -1254,7 +1249,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
                        index=np.arange(10))
         result = df.get_dtype_counts()
         result.sort_index()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # GH 2809
         ind = date_range(start="2000-01-01", freq="D", periods=10)
@@ -1266,7 +1261,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         expected = Series({datetime64name: 1})
         result.sort_index()
         expected.sort_index()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # GH 2810
         ind = date_range(start="2000-01-01", freq="D", periods=10)
@@ -1277,7 +1272,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         expected = Series({datetime64name: 1, objectname: 1})
         result.sort_index()
         expected.sort_index()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # GH 7594
         # don't coerce tz-aware
@@ -1287,12 +1282,12 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         df = DataFrame({'End Date': dt}, index=[0])
         self.assertEqual(df.iat[0, 0], dt)
-        assert_series_equal(df.dtypes, Series(
+        tm.assert_series_equal(df.dtypes, Series(
             {'End Date': 'datetime64[ns, US/Eastern]'}))
 
         df = DataFrame([{'End Date': dt}])
         self.assertEqual(df.iat[0, 0], dt)
-        assert_series_equal(df.dtypes, Series(
+        tm.assert_series_equal(df.dtypes, Series(
             {'End Date': 'datetime64[ns, US/Eastern]'}))
 
         # tz-aware (UTC and other tz's)
@@ -1315,17 +1310,17 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
             {'a': i.to_series(keep_tz=True).reset_index(drop=True)})
         df = DataFrame()
         df['a'] = i
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         df = DataFrame({'a': i})
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         # multiples
         i_no_tz = date_range('1/1/2011', periods=5, freq='10s')
         df = DataFrame({'a': i, 'b': i_no_tz})
         expected = DataFrame({'a': i.to_series(keep_tz=True)
                               .reset_index(drop=True), 'b': i_no_tz})
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     def test_constructor_for_list_with_dtypes(self):
         # TODO(wesm): unused
@@ -1348,39 +1343,39 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         df = DataFrame({'a': [2 ** 31, 2 ** 31 + 1]})
         result = df.get_dtype_counts()
         expected = Series({'int64': 1})
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # GH #2751 (construction with no index specified), make sure we cast to
         # platform values
         df = DataFrame([1, 2])
         result = df.get_dtype_counts()
         expected = Series({'int64': 1})
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame([1., 2.])
         result = df.get_dtype_counts()
         expected = Series({'float64': 1})
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame({'a': [1, 2]})
         result = df.get_dtype_counts()
         expected = Series({'int64': 1})
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame({'a': [1., 2.]})
         result = df.get_dtype_counts()
         expected = Series({'float64': 1})
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame({'a': 1}, index=lrange(3))
         result = df.get_dtype_counts()
         expected = Series({'int64': 1})
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         df = DataFrame({'a': 1.}, index=lrange(3))
         result = df.get_dtype_counts()
         expected = Series({'float64': 1})
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # with object list
         df = DataFrame({'a': [1, 2, 4, 7], 'b': [1.2, 2.3, 5.1, 6.3],
@@ -1392,7 +1387,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
             {'int64': 1, 'float64': 2, datetime64name: 1, objectname: 1})
         result.sort_index()
         expected.sort_index()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_constructor_frame_copy(self):
         cop = DataFrame(self.frame, copy=True)
@@ -1430,7 +1425,8 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
             indexer = np.arange(len(df.columns))[isnull(df.columns)]
 
             if len(indexer) == 1:
-                assert_series_equal(df.iloc[:, indexer[0]], df.loc[:, np.nan])
+                tm.assert_series_equal(df.iloc[:, indexer[0]],
+                                       df.loc[:, np.nan])
 
             # multiple nans should fail
             else:
@@ -1467,17 +1463,17 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         # TODO(wesm): unused
         frame = DataFrame.from_records(arr)  # noqa
 
-        index = np.arange(len(arr))[::-1]
+        index = pd.Index(np.arange(len(arr))[::-1])
         indexed_frame = DataFrame.from_records(arr, index=index)
-        self.assert_numpy_array_equal(indexed_frame.index, index)
+        self.assert_index_equal(indexed_frame.index, index)
 
         # without names, it should go to last ditch
         arr2 = np.zeros((2, 3))
-        assert_frame_equal(DataFrame.from_records(arr2), DataFrame(arr2))
+        tm.assert_frame_equal(DataFrame.from_records(arr2), DataFrame(arr2))
 
         # wrong length
         msg = r'Shape of passed values is \(3, 2\), indices imply \(3, 1\)'
-        with assertRaisesRegexp(ValueError, msg):
+        with tm.assertRaisesRegexp(ValueError, msg):
             DataFrame.from_records(arr, index=index[:-1])
 
         indexed_frame = DataFrame.from_records(arr, index='f1')
@@ -1508,14 +1504,14 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
                         'u': np.array([1.0, 3.0], dtype=np.float32),
                         'y': np.array([2, 4], dtype=np.int64),
                         'z': np.array([2, 4], dtype=np.int32)})
-        assert_frame_equal(df.reindex_like(xp), xp)
+        tm.assert_frame_equal(df.reindex_like(xp), xp)
 
         # no dtypes specified here, so just compare with the default
         arr = [(1.0, 2), (3.0, 4), (5., 6), (7., 8)]
         df = DataFrame.from_records(iter(arr), columns=['x', 'y'],
                                     nrows=2)
-        assert_frame_equal(df, xp.reindex(
-            columns=['x', 'y']), check_dtype=False)
+        tm.assert_frame_equal(df, xp.reindex(columns=['x', 'y']),
+                              check_dtype=False)
 
     def test_from_records_tuples_generator(self):
         def tuple_generator(length):
@@ -1532,7 +1528,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         generator = tuple_generator(10)
         result = DataFrame.from_records(generator, columns=columns_names)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_from_records_lists_generator(self):
         def list_generator(length):
@@ -1549,7 +1545,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         generator = list_generator(10)
         result = DataFrame.from_records(generator, columns=columns_names)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_from_records_columns_not_modified(self):
         tuples = [(1, 2, 3),
@@ -1582,7 +1578,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         expected = DataFrame([(1, 2, 3), (4, 5, 6)],
                              columns=['a', 'b', 'a'])
 
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_from_records_set_index_name(self):
         def create_dict(order_id):
@@ -1607,7 +1603,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         result = DataFrame.from_records(data, columns=['a', 'b'])
         exp = DataFrame(data, columns=['a', 'b'])
-        assert_frame_equal(result, exp)
+        tm.assert_frame_equal(result, exp)
 
         # overlap in index/index_names
 
@@ -1615,7 +1611,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         result = DataFrame.from_records(data, index=['a', 'b', 'c'])
         exp = DataFrame(data, index=['a', 'b', 'c'])
-        assert_frame_equal(result, exp)
+        tm.assert_frame_equal(result, exp)
 
         # GH 2623
         rows = []
@@ -1631,28 +1627,28 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         df2_obj = DataFrame.from_records(rows, columns=['date', 'test'])
         results = df2_obj.get_dtype_counts()
         expected = Series({'datetime64[ns]': 1, 'int64': 1})
-        assert_series_equal(results, expected)
+        tm.assert_series_equal(results, expected)
 
     def test_from_records_empty(self):
         # 3562
         result = DataFrame.from_records([], columns=['a', 'b', 'c'])
         expected = DataFrame(columns=['a', 'b', 'c'])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = DataFrame.from_records([], columns=['a', 'b', 'b'])
         expected = DataFrame(columns=['a', 'b', 'b'])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_from_records_empty_with_nonempty_fields_gh3682(self):
         a = np.array([(1, 2)], dtype=[('id', np.int64), ('value', np.int64)])
         df = DataFrame.from_records(a, index='id')
-        assert_numpy_array_equal(df.index, Index([1], name='id'))
+        tm.assert_index_equal(df.index, Index([1], name='id'))
         self.assertEqual(df.index.name, 'id')
-        assert_numpy_array_equal(df.columns, Index(['value']))
+        tm.assert_index_equal(df.columns, Index(['value']))
 
         b = np.array([], dtype=[('id', np.int64), ('value', np.int64)])
         df = DataFrame.from_records(b, index='id')
-        assert_numpy_array_equal(df.index, Index([], name='id'))
+        tm.assert_index_equal(df.index, Index([], name='id'))
         self.assertEqual(df.index.name, 'id')
 
     def test_from_records_with_datetimes(self):
@@ -1675,14 +1671,14 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
             raise nose.SkipTest("known failure of numpy rec array creation")
 
         result = DataFrame.from_records(recarray)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         # coercion should work too
         arrdata = [np.array([datetime(2005, 3, 1, 0, 0), None])]
         dtypes = [('EXPIRY', '<M8[m]')]
         recarray = np.core.records.fromarrays(arrdata, dtype=dtypes)
         result = DataFrame.from_records(recarray)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_from_records_sequencelike(self):
         df = DataFrame({'A': np.array(np.random.randn(6), dtype=np.float64),
@@ -1728,14 +1724,14 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         result4 = (DataFrame.from_records(lists, columns=columns)
                    .reindex(columns=df.columns))
 
-        assert_frame_equal(result, df, check_dtype=False)
-        assert_frame_equal(result2, df)
-        assert_frame_equal(result3, df)
-        assert_frame_equal(result4, df, check_dtype=False)
+        tm.assert_frame_equal(result, df, check_dtype=False)
+        tm.assert_frame_equal(result2, df)
+        tm.assert_frame_equal(result3, df)
+        tm.assert_frame_equal(result4, df, check_dtype=False)
 
         # tuples is in the order of the columns
         result = DataFrame.from_records(tuples)
-        self.assert_numpy_array_equal(result.columns, lrange(8))
+        tm.assert_index_equal(result.columns, pd.Index(lrange(8)))
 
         # test exclude parameter & we are casting the results here (as we don't
         # have dtype info to recover)
@@ -1744,13 +1740,14 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         exclude = list(set(range(8)) - set(columns_to_test))
         result = DataFrame.from_records(tuples, exclude=exclude)
         result.columns = [columns[i] for i in sorted(columns_to_test)]
-        assert_series_equal(result['C'], df['C'])
-        assert_series_equal(result['E1'], df['E1'].astype('float64'))
+        tm.assert_series_equal(result['C'], df['C'])
+        tm.assert_series_equal(result['E1'], df['E1'].astype('float64'))
 
         # empty case
         result = DataFrame.from_records([], columns=['foo', 'bar', 'baz'])
         self.assertEqual(len(result), 0)
-        self.assert_numpy_array_equal(result.columns, ['foo', 'bar', 'baz'])
+        self.assert_index_equal(result.columns,
+                                pd.Index(['foo', 'bar', 'baz']))
 
         result = DataFrame.from_records([])
         self.assertEqual(len(result), 0)
@@ -1787,24 +1784,24 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
                        .reindex(columns=df.columns))
 
         for r in results:
-            assert_frame_equal(r, df)
+            tm.assert_frame_equal(r, df)
 
     def test_from_records_with_index_data(self):
         df = DataFrame(np.random.randn(10, 3), columns=['A', 'B', 'C'])
 
         data = np.random.randn(10)
         df1 = DataFrame.from_records(df, index=data)
-        assert(df1.index.equals(Index(data)))
+        tm.assert_index_equal(df1.index, Index(data))
 
     def test_from_records_bad_index_column(self):
         df = DataFrame(np.random.randn(10, 3), columns=['A', 'B', 'C'])
 
         # should pass
         df1 = DataFrame.from_records(df, index=['C'])
-        assert(df1.index.equals(Index(df.C)))
+        tm.assert_index_equal(df1.index, Index(df.C))
 
         df1 = DataFrame.from_records(df, index='C')
-        assert(df1.index.equals(Index(df.C)))
+        tm.assert_index_equal(df1.index, Index(df.C))
 
         # should fail
         self.assertRaises(ValueError, DataFrame.from_records, df, index=[2])
@@ -1827,7 +1824,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         result = DataFrame.from_records(recs)
         expected = DataFrame.from_records(tups)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_from_records_len0_with_columns(self):
         # #2633
@@ -1856,20 +1853,20 @@ class TestDataFrameConstructorWithDatetimeTZ(tm.TestCase, TestData):
         df = DataFrame({'A': idx, 'B': dr})
         self.assertTrue(df['A'].dtype, 'M8[ns, US/Eastern')
         self.assertTrue(df['A'].name == 'A')
-        assert_series_equal(df['A'], Series(idx, name='A'))
-        assert_series_equal(df['B'], Series(dr, name='B'))
+        tm.assert_series_equal(df['A'], Series(idx, name='A'))
+        tm.assert_series_equal(df['B'], Series(dr, name='B'))
 
     def test_from_index(self):
 
         # from index
         idx2 = date_range('20130101', periods=3, tz='US/Eastern', name='foo')
         df2 = DataFrame(idx2)
-        assert_series_equal(df2['foo'], Series(idx2, name='foo'))
+        tm.assert_series_equal(df2['foo'], Series(idx2, name='foo'))
         df2 = DataFrame(Series(idx2))
-        assert_series_equal(df2['foo'], Series(idx2, name='foo'))
+        tm.assert_series_equal(df2['foo'], Series(idx2, name='foo'))
 
         idx2 = date_range('20130101', periods=3, tz='US/Eastern')
         df2 = DataFrame(idx2)
-        assert_series_equal(df2[0], Series(idx2, name=0))
+        tm.assert_series_equal(df2[0], Series(idx2, name=0))
         df2 = DataFrame(Series(idx2))
-        assert_series_equal(df2[0], Series(idx2, name=0))
+        tm.assert_series_equal(df2[0], Series(idx2, name=0))

--- a/pandas/tests/frame/test_convert_to.py
+++ b/pandas/tests/frame/test_convert_to.py
@@ -42,19 +42,18 @@ class TestDataFrameConvertTo(tm.TestCase, TestData):
                 self.assertEqual(v2, recons_data[k][k2])
 
         recons_data = DataFrame(test_data).to_dict("sp")
-
         expected_split = {'columns': ['A', 'B'], 'index': ['1', '2', '3'],
                           'data': [[1.0, '1'], [2.0, '2'], [nan, '3']]}
-
-        tm.assert_almost_equal(recons_data, expected_split)
+        tm.assert_dict_equal(recons_data, expected_split)
 
         recons_data = DataFrame(test_data).to_dict("r")
-
         expected_records = [{'A': 1.0, 'B': '1'},
                             {'A': 2.0, 'B': '2'},
                             {'A': nan, 'B': '3'}]
-
-        tm.assert_almost_equal(recons_data, expected_records)
+        tm.assertIsInstance(recons_data, list)
+        self.assertEqual(len(recons_data), 3)
+        for l, r in zip(recons_data, expected_records):
+            tm.assert_dict_equal(l, r)
 
         # GH10844
         recons_data = DataFrame(test_data).to_dict("i")
@@ -78,24 +77,24 @@ class TestDataFrameConvertTo(tm.TestCase, TestData):
         expected_records_mixed = [{'A': tsmp, 'B': 1},
                                   {'A': tsmp, 'B': 2}]
 
-        tm.assert_almost_equal(test_data.to_dict(
-            orient='records'), expected_records)
-        tm.assert_almost_equal(test_data_mixed.to_dict(
-            orient='records'), expected_records_mixed)
+        self.assertEqual(test_data.to_dict(orient='records'),
+                         expected_records)
+        self.assertEqual(test_data_mixed.to_dict(orient='records'),
+                         expected_records_mixed)
 
         expected_series = {
-            'A': Series([tsmp, tsmp]),
-            'B': Series([tsmp, tsmp]),
+            'A': Series([tsmp, tsmp], name='A'),
+            'B': Series([tsmp, tsmp], name='B'),
         }
         expected_series_mixed = {
-            'A': Series([tsmp, tsmp]),
-            'B': Series([1, 2]),
+            'A': Series([tsmp, tsmp], name='A'),
+            'B': Series([1, 2], name='B'),
         }
 
-        tm.assert_almost_equal(test_data.to_dict(
-            orient='series'), expected_series)
-        tm.assert_almost_equal(test_data_mixed.to_dict(
-            orient='series'), expected_series_mixed)
+        tm.assert_dict_equal(test_data.to_dict(orient='series'),
+                             expected_series)
+        tm.assert_dict_equal(test_data_mixed.to_dict(orient='series'),
+                             expected_series_mixed)
 
         expected_split = {
             'index': [0, 1],
@@ -110,10 +109,10 @@ class TestDataFrameConvertTo(tm.TestCase, TestData):
             'columns': ['A', 'B']
         }
 
-        tm.assert_almost_equal(test_data.to_dict(
-            orient='split'), expected_split)
-        tm.assert_almost_equal(test_data_mixed.to_dict(
-            orient='split'), expected_split_mixed)
+        tm.assert_dict_equal(test_data.to_dict(orient='split'),
+                             expected_split)
+        tm.assert_dict_equal(test_data_mixed.to_dict(orient='split'),
+                             expected_split_mixed)
 
     def test_to_dict_invalid_orient(self):
         df = DataFrame({'A': [0, 1]})

--- a/pandas/tests/frame/test_dtypes.py
+++ b/pandas/tests/frame/test_dtypes.py
@@ -496,12 +496,13 @@ class TestDataFrameDatetimeWithTZ(tm.TestCase, TestData):
     def test_astype_str(self):
         # str formatting
         result = self.tzframe.astype(str)
-        expected = np.array([['2013-01-01', '2013-01-01 00:00:00-05:00',
-                              '2013-01-01 00:00:00+01:00'],
-                             ['2013-01-02', 'NaT', 'NaT'],
-                             ['2013-01-03', '2013-01-03 00:00:00-05:00',
-                              '2013-01-03 00:00:00+01:00']], dtype=object)
-        self.assert_numpy_array_equal(result, expected)
+        expected = DataFrame([['2013-01-01', '2013-01-01 00:00:00-05:00',
+                               '2013-01-01 00:00:00+01:00'],
+                              ['2013-01-02', 'NaT', 'NaT'],
+                              ['2013-01-03', '2013-01-03 00:00:00-05:00',
+                               '2013-01-03 00:00:00+01:00']],
+                             columns=self.tzframe.columns)
+        self.assert_frame_equal(result, expected)
 
         result = str(self.tzframe)
         self.assertTrue('0 2013-01-01 2013-01-01 00:00:00-05:00 '

--- a/pandas/tests/frame/test_misc_api.py
+++ b/pandas/tests/frame/test_misc_api.py
@@ -58,7 +58,7 @@ class SharedWithSparse(object):
             for col in self.frame.columns:
                 result = self.frame.get_value(idx, col)
                 expected = self.frame[col][idx]
-                assert_almost_equal(result, expected)
+                tm.assert_almost_equal(result, expected)
 
     def test_join_index(self):
         # left / right
@@ -67,15 +67,15 @@ class SharedWithSparse(object):
         f2 = self.frame.reindex(columns=['C', 'D'])
 
         joined = f.join(f2)
-        self.assertTrue(f.index.equals(joined.index))
+        self.assert_index_equal(f.index, joined.index)
         self.assertEqual(len(joined.columns), 4)
 
         joined = f.join(f2, how='left')
-        self.assertTrue(joined.index.equals(f.index))
+        self.assert_index_equal(joined.index, f.index)
         self.assertEqual(len(joined.columns), 4)
 
         joined = f.join(f2, how='right')
-        self.assertTrue(joined.index.equals(f2.index))
+        self.assert_index_equal(joined.index, f2.index)
         self.assertEqual(len(joined.columns), 4)
 
         # inner
@@ -84,7 +84,7 @@ class SharedWithSparse(object):
         f2 = self.frame.reindex(columns=['C', 'D'])
 
         joined = f.join(f2, how='inner')
-        self.assertTrue(joined.index.equals(f.index.intersection(f2.index)))
+        self.assert_index_equal(joined.index, f.index.intersection(f2.index))
         self.assertEqual(len(joined.columns), 4)
 
         # outer
@@ -148,12 +148,12 @@ class SharedWithSparse(object):
 
     def test_add_prefix_suffix(self):
         with_prefix = self.frame.add_prefix('foo#')
-        expected = ['foo#%s' % c for c in self.frame.columns]
-        self.assert_numpy_array_equal(with_prefix.columns, expected)
+        expected = pd.Index(['foo#%s' % c for c in self.frame.columns])
+        self.assert_index_equal(with_prefix.columns, expected)
 
         with_suffix = self.frame.add_suffix('#foo')
-        expected = ['%s#foo' % c for c in self.frame.columns]
-        self.assert_numpy_array_equal(with_suffix.columns, expected)
+        expected = pd.Index(['%s#foo' % c for c in self.frame.columns])
+        self.assert_index_equal(with_suffix.columns, expected)
 
 
 class TestDataFrameMisc(tm.TestCase, SharedWithSparse, TestData):

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -66,15 +66,17 @@ class TestDataFrameMissingData(tm.TestCase, TestData):
         smaller_frame = frame.dropna()
         assert_series_equal(frame['foo'], original)
         inp_frame1.dropna(inplace=True)
-        self.assert_numpy_array_equal(smaller_frame['foo'], mat[5:])
-        self.assert_numpy_array_equal(inp_frame1['foo'], mat[5:])
+
+        exp = Series(mat[5:], index=self.frame.index[5:], name='foo')
+        tm.assert_series_equal(smaller_frame['foo'], exp)
+        tm.assert_series_equal(inp_frame1['foo'], exp)
 
         samesize_frame = frame.dropna(subset=['bar'])
         assert_series_equal(frame['foo'], original)
         self.assertTrue((frame['bar'] == 5).all())
         inp_frame2.dropna(subset=['bar'], inplace=True)
-        self.assertTrue(samesize_frame.index.equals(self.frame.index))
-        self.assertTrue(inp_frame2.index.equals(self.frame.index))
+        self.assert_index_equal(samesize_frame.index, self.frame.index)
+        self.assert_index_equal(inp_frame2.index, self.frame.index)
 
     def test_dropna(self):
         df = DataFrame(np.random.randn(6, 4))

--- a/pandas/tests/frame/test_mutate_columns.py
+++ b/pandas/tests/frame/test_mutate_columns.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 from pandas.compat import range, lrange
 import numpy as np
 
-from pandas import DataFrame, Series
+from pandas import DataFrame, Series, Index
 
 from pandas.util.testing import (assert_series_equal,
                                  assert_frame_equal,
@@ -123,12 +123,12 @@ class TestDataFrameMutateColumns(tm.TestCase, TestData):
                        columns=['c', 'b', 'a'])
 
         df.insert(0, 'foo', df['a'])
-        self.assert_numpy_array_equal(df.columns, ['foo', 'c', 'b', 'a'])
+        self.assert_index_equal(df.columns, Index(['foo', 'c', 'b', 'a']))
         tm.assert_series_equal(df['a'], df['foo'], check_names=False)
 
         df.insert(2, 'bar', df['c'])
-        self.assert_numpy_array_equal(df.columns,
-                                      ['foo', 'c', 'bar', 'b', 'a'])
+        self.assert_index_equal(df.columns,
+                                Index(['foo', 'c', 'bar', 'b', 'a']))
         tm.assert_almost_equal(df['c'], df['bar'], check_names=False)
 
         # diff dtype

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -741,7 +741,7 @@ class TestDataFrameOperators(tm.TestCase, TestData):
         self.assertTrue(np.isnan(added['D']).all())
 
         self_added = self.frame + self.frame
-        self.assertTrue(self_added.index.equals(self.frame.index))
+        self.assert_index_equal(self_added.index, self.frame.index)
 
         added_rev = frame_copy + self.frame
         self.assertTrue(np.isnan(added['D']).all())
@@ -838,7 +838,7 @@ class TestDataFrameOperators(tm.TestCase, TestData):
         smaller_frame = self.tsframe[:-5]
         smaller_added = smaller_frame.add(ts, axis='index')
 
-        self.assertTrue(smaller_added.index.equals(self.tsframe.index))
+        self.assert_index_equal(smaller_added.index, self.tsframe.index)
 
         smaller_ts = ts[:-5]
         smaller_added2 = self.tsframe.add(smaller_ts, axis='index')

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -79,7 +79,7 @@ class TestDataFrameReshape(tm.TestCase, TestData):
 
         result = df.pivot(index=1, columns=0, values=2)
         repr(result)
-        self.assert_numpy_array_equal(result.columns, ['A', 'B'])
+        self.assert_index_equal(result.columns, Index(['A', 'B'], name=0))
 
     def test_pivot_index_none(self):
         # gh-3962

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -626,7 +626,7 @@ class TestDataFrameToCSV(tm.TestCase, TestData):
             exp = tsframe[:0]
             exp.index = []
 
-            self.assertTrue(recons.columns.equals(exp.columns))
+            self.assert_index_equal(recons.columns, exp.columns)
             self.assertEqual(len(recons), 0)
 
     def test_to_csv_float32_nanrep(self):

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -607,7 +607,7 @@ class Base(object):
             # assuming the 2nd to last item is unique in the data
             item = index_a[-2]
             tm.assert_numpy_array_equal(index_a == item, expected3)
-            tm.assert_numpy_array_equal(series_a == item, expected3)
+            tm.assert_series_equal(series_a == item, Series(expected3))
 
     def test_numpy_ufuncs(self):
         # test ufuncs of numpy 1.9.2. see:

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -48,46 +48,48 @@ class TestCategoricalIndex(Base, tm.TestCase):
 
         # empty
         result = CategoricalIndex(categories=categories)
-        self.assertTrue(result.categories.equals(Index(categories)))
+        self.assert_index_equal(result.categories, Index(categories))
         tm.assert_numpy_array_equal(result.codes, np.array([], dtype='int8'))
         self.assertFalse(result.ordered)
 
         # passing categories
         result = CategoricalIndex(list('aabbca'), categories=categories)
-        self.assertTrue(result.categories.equals(Index(categories)))
-        tm.assert_numpy_array_equal(result.codes, np.array(
-            [0, 0, 1, 1, 2, 0], dtype='int8'))
+        self.assert_index_equal(result.categories, Index(categories))
+        tm.assert_numpy_array_equal(result.codes,
+                                    np.array([0, 0, 1, 1, 2, 0], dtype='int8'))
 
         c = pd.Categorical(list('aabbca'))
         result = CategoricalIndex(c)
-        self.assertTrue(result.categories.equals(Index(list('abc'))))
-        tm.assert_numpy_array_equal(result.codes, np.array(
-            [0, 0, 1, 1, 2, 0], dtype='int8'))
+        self.assert_index_equal(result.categories, Index(list('abc')))
+        tm.assert_numpy_array_equal(result.codes,
+                                    np.array([0, 0, 1, 1, 2, 0], dtype='int8'))
         self.assertFalse(result.ordered)
 
         result = CategoricalIndex(c, categories=categories)
-        self.assertTrue(result.categories.equals(Index(categories)))
-        tm.assert_numpy_array_equal(result.codes, np.array(
-            [0, 0, 1, 1, 2, 0], dtype='int8'))
+        self.assert_index_equal(result.categories, Index(categories))
+        tm.assert_numpy_array_equal(result.codes,
+                                    np.array([0, 0, 1, 1, 2, 0], dtype='int8'))
         self.assertFalse(result.ordered)
 
         ci = CategoricalIndex(c, categories=list('abcd'))
         result = CategoricalIndex(ci)
-        self.assertTrue(result.categories.equals(Index(categories)))
-        tm.assert_numpy_array_equal(result.codes, np.array(
-            [0, 0, 1, 1, 2, 0], dtype='int8'))
+        self.assert_index_equal(result.categories, Index(categories))
+        tm.assert_numpy_array_equal(result.codes,
+                                    np.array([0, 0, 1, 1, 2, 0], dtype='int8'))
         self.assertFalse(result.ordered)
 
         result = CategoricalIndex(ci, categories=list('ab'))
-        self.assertTrue(result.categories.equals(Index(list('ab'))))
-        tm.assert_numpy_array_equal(result.codes, np.array(
-            [0, 0, 1, 1, -1, 0], dtype='int8'))
+        self.assert_index_equal(result.categories, Index(list('ab')))
+        tm.assert_numpy_array_equal(result.codes,
+                                    np.array([0, 0, 1, 1, -1, 0],
+                                             dtype='int8'))
         self.assertFalse(result.ordered)
 
         result = CategoricalIndex(ci, categories=list('ab'), ordered=True)
-        self.assertTrue(result.categories.equals(Index(list('ab'))))
-        tm.assert_numpy_array_equal(result.codes, np.array(
-            [0, 0, 1, 1, -1, 0], dtype='int8'))
+        self.assert_index_equal(result.categories, Index(list('ab')))
+        tm.assert_numpy_array_equal(result.codes,
+                                    np.array([0, 0, 1, 1, -1, 0],
+                                             dtype='int8'))
         self.assertTrue(result.ordered)
 
         # turn me to an Index
@@ -323,7 +325,7 @@ class TestCategoricalIndex(Base, tm.TestCase):
         tm.assert_index_equal(result, ci, exact=True)
 
         result = ci.astype(object)
-        self.assertTrue(result.equals(Index(np.array(ci))))
+        self.assert_index_equal(result, Index(np.array(ci)))
 
         # this IS equal, but not the same class
         self.assertTrue(result.equals(ci))
@@ -352,7 +354,7 @@ class TestCategoricalIndex(Base, tm.TestCase):
             expected = oidx.get_indexer_non_unique(finder)[0]
 
             actual = ci.get_indexer(finder)
-            tm.assert_numpy_array_equal(expected, actual)
+            tm.assert_numpy_array_equal(expected.values, actual, check_dtype=False)
 
     def test_reindex_dtype(self):
         c = CategoricalIndex(['a', 'b', 'c', 'a'])
@@ -401,7 +403,7 @@ class TestCategoricalIndex(Base, tm.TestCase):
 
         for indexer in [idx2, list('abf'), Index(list('abf'))]:
             r1 = idx1.get_indexer(idx2)
-            assert_almost_equal(r1, [0, 1, 2, -1])
+            assert_almost_equal(r1, np.array([0, 1, 2, -1]))
 
         self.assertRaises(NotImplementedError,
                           lambda: idx2.get_indexer(idx1, method='pad'))

--- a/pandas/tests/indexes/test_datetimelike.py
+++ b/pandas/tests/indexes/test_datetimelike.py
@@ -353,7 +353,8 @@ class TestDatetimeIndex(DatetimeLike, tm.TestCase):
 
         rng = date_range('1/1/2000', periods=10)
         result = rng.astype('i8')
-        self.assert_numpy_array_equal(result, rng.asi8)
+        self.assert_index_equal(result, Index(rng.asi8))
+        self.assert_numpy_array_equal(result.values, rng.asi8)
 
     def test_astype_with_tz(self):
 
@@ -532,26 +533,29 @@ class TestDatetimeIndex(DatetimeLike, tm.TestCase):
 
         # time indexing
         idx = pd.date_range('2000-01-01', periods=24, freq='H')
-        tm.assert_numpy_array_equal(idx.get_loc(time(12)), [12])
-        tm.assert_numpy_array_equal(idx.get_loc(time(12, 30)), [])
+        tm.assert_numpy_array_equal(idx.get_loc(time(12)),
+                                    np.array([12], dtype=np.int64))
+        tm.assert_numpy_array_equal(idx.get_loc(time(12, 30)),
+                                    np.array([], dtype=np.int64))
         with tm.assertRaises(NotImplementedError):
             idx.get_loc(time(12, 30), method='pad')
 
     def test_get_indexer(self):
         idx = pd.date_range('2000-01-01', periods=3)
-        tm.assert_numpy_array_equal(idx.get_indexer(idx), [0, 1, 2])
+        tm.assert_numpy_array_equal(idx.get_indexer(idx), np.array([0, 1, 2]))
 
         target = idx[0] + pd.to_timedelta(['-1 hour', '12 hours',
                                            '1 day 1 hour'])
-        tm.assert_numpy_array_equal(idx.get_indexer(target, 'pad'), [-1, 0, 1])
-        tm.assert_numpy_array_equal(
-            idx.get_indexer(target, 'backfill'), [0, 1, 2])
-        tm.assert_numpy_array_equal(
-            idx.get_indexer(target, 'nearest'), [0, 1, 1])
+        tm.assert_numpy_array_equal(idx.get_indexer(target, 'pad'),
+                                    np.array([-1, 0, 1]))
+        tm.assert_numpy_array_equal(idx.get_indexer(target, 'backfill'),
+                                    np.array([0, 1, 2]))
+        tm.assert_numpy_array_equal(idx.get_indexer(target, 'nearest'),
+                                    np.array([0, 1, 1]))
         tm.assert_numpy_array_equal(
             idx.get_indexer(target, 'nearest',
                             tolerance=pd.Timedelta('1 hour')),
-            [0, -1, 1])
+            np.array([0, -1, 1]))
         with tm.assertRaises(ValueError):
             idx.get_indexer(idx[[0]], method='nearest', tolerance='foo')
 
@@ -561,7 +565,7 @@ class TestDatetimeIndex(DatetimeLike, tm.TestCase):
         # round-trip of timezone
         index = date_range('20130101', periods=3, tz='US/Eastern', name='foo')
         unpickled = self.round_trip_pickle(index)
-        self.assertTrue(index.equals(unpickled))
+        self.assert_index_equal(index, unpickled)
 
     def test_reindex_preserves_tz_if_target_is_empty_list_or_array(self):
         # GH7774
@@ -752,7 +756,8 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
 
         idx = period_range('1990', '2009', freq='A')
         result = idx.astype('i8')
-        self.assert_numpy_array_equal(result, idx.values)
+        self.assert_index_equal(result, Index(idx.asi8))
+        self.assert_numpy_array_equal(result.values, idx.values)
 
     def test_astype_raises(self):
         # GH 13149, GH 13209
@@ -843,25 +848,28 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
 
     def test_get_indexer(self):
         idx = pd.period_range('2000-01-01', periods=3).asfreq('H', how='start')
-        tm.assert_numpy_array_equal(idx.get_indexer(idx), [0, 1, 2])
+        tm.assert_numpy_array_equal(idx.get_indexer(idx),
+                                    np.array([0, 1, 2], dtype=np.int_))
 
         target = pd.PeriodIndex(['1999-12-31T23', '2000-01-01T12',
                                  '2000-01-02T01'], freq='H')
-        tm.assert_numpy_array_equal(idx.get_indexer(target, 'pad'), [-1, 0, 1])
-        tm.assert_numpy_array_equal(
-            idx.get_indexer(target, 'backfill'), [0, 1, 2])
-        tm.assert_numpy_array_equal(
-            idx.get_indexer(target, 'nearest'), [0, 1, 1])
-        tm.assert_numpy_array_equal(
-            idx.get_indexer(target, 'nearest', tolerance='1 hour'),
-            [0, -1, 1])
+        tm.assert_numpy_array_equal(idx.get_indexer(target, 'pad'),
+                                    np.array([-1, 0, 1], dtype=np.int_))
+        tm.assert_numpy_array_equal(idx.get_indexer(target, 'backfill'),
+                                    np.array([0, 1, 2], dtype=np.int_))
+        tm.assert_numpy_array_equal(idx.get_indexer(target, 'nearest'),
+                                    np.array([0, 1, 1], dtype=np.int_))
+        tm.assert_numpy_array_equal(idx.get_indexer(target, 'nearest',
+                                                    tolerance='1 hour'),
+                                    np.array([0, -1, 1], dtype=np.int_))
 
         msg = 'Input has different freq from PeriodIndex\\(freq=H\\)'
         with self.assertRaisesRegexp(ValueError, msg):
             idx.get_indexer(target, 'nearest', tolerance='1 minute')
 
-        tm.assert_numpy_array_equal(
-            idx.get_indexer(target, 'nearest', tolerance='1 day'), [0, 1, 1])
+        tm.assert_numpy_array_equal(idx.get_indexer(target, 'nearest',
+                                                    tolerance='1 day'),
+                                    np.array([0, 1, 1], dtype=np.int_))
 
     def test_repeat(self):
         # GH10183
@@ -956,7 +964,8 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
         rng = timedelta_range('1 days', periods=10)
 
         result = rng.astype('i8')
-        self.assert_numpy_array_equal(result, rng.asi8)
+        self.assert_index_equal(result, Index(rng.asi8))
+        self.assert_numpy_array_equal(rng.asi8, result.values)
 
     def test_astype_timedelta64(self):
         # GH 13149, GH 13209
@@ -1005,18 +1014,20 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
 
     def test_get_indexer(self):
         idx = pd.to_timedelta(['0 days', '1 days', '2 days'])
-        tm.assert_numpy_array_equal(idx.get_indexer(idx), [0, 1, 2])
+        tm.assert_numpy_array_equal(idx.get_indexer(idx),
+                                    np.array([0, 1, 2], dtype=np.int_))
 
         target = pd.to_timedelta(['-1 hour', '12 hours', '1 day 1 hour'])
-        tm.assert_numpy_array_equal(idx.get_indexer(target, 'pad'), [-1, 0, 1])
-        tm.assert_numpy_array_equal(
-            idx.get_indexer(target, 'backfill'), [0, 1, 2])
-        tm.assert_numpy_array_equal(
-            idx.get_indexer(target, 'nearest'), [0, 1, 1])
-        tm.assert_numpy_array_equal(
-            idx.get_indexer(target, 'nearest',
-                            tolerance=pd.Timedelta('1 hour')),
-            [0, -1, 1])
+        tm.assert_numpy_array_equal(idx.get_indexer(target, 'pad'),
+                                    np.array([-1, 0, 1], dtype=np.int_))
+        tm.assert_numpy_array_equal(idx.get_indexer(target, 'backfill'),
+                                    np.array([0, 1, 2], dtype=np.int_))
+        tm.assert_numpy_array_equal(idx.get_indexer(target, 'nearest'),
+                                    np.array([0, 1, 1], dtype=np.int_))
+
+        res = idx.get_indexer(target, 'nearest',
+                              tolerance=pd.Timedelta('1 hour'))
+        tm.assert_numpy_array_equal(res, np.array([0, -1, 1], dtype=np.int_))
 
     def test_numeric_compat(self):
 

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -158,6 +158,7 @@ class TestFloat64Index(Numeric, tm.TestCase):
 
     def check_coerce(self, a, b, is_float_index=True):
         self.assertTrue(a.equals(b))
+        self.assert_index_equal(a, b, exact=False)
         if is_float_index:
             self.assertIsInstance(b, Float64Index)
         else:
@@ -282,14 +283,16 @@ class TestFloat64Index(Numeric, tm.TestCase):
 
     def test_get_indexer(self):
         idx = Float64Index([0.0, 1.0, 2.0])
-        tm.assert_numpy_array_equal(idx.get_indexer(idx), [0, 1, 2])
+        tm.assert_numpy_array_equal(idx.get_indexer(idx),
+                                    np.array([0, 1, 2], dtype=np.int_))
 
         target = [-0.1, 0.5, 1.1]
-        tm.assert_numpy_array_equal(idx.get_indexer(target, 'pad'), [-1, 0, 1])
-        tm.assert_numpy_array_equal(
-            idx.get_indexer(target, 'backfill'), [0, 1, 2])
-        tm.assert_numpy_array_equal(
-            idx.get_indexer(target, 'nearest'), [0, 1, 1])
+        tm.assert_numpy_array_equal(idx.get_indexer(target, 'pad'),
+                                    np.array([-1, 0, 1], dtype=np.int_))
+        tm.assert_numpy_array_equal(idx.get_indexer(target, 'backfill'),
+                                    np.array([0, 1, 2], dtype=np.int_))
+        tm.assert_numpy_array_equal(idx.get_indexer(target, 'nearest'),
+                                    np.array([0, 1, 1], dtype=np.int_))
 
     def test_get_loc(self):
         idx = Float64Index([0.0, 1.0, 2.0])
@@ -425,12 +428,12 @@ class TestInt64Index(Numeric, tm.TestCase):
     def test_constructor(self):
         # pass list, coerce fine
         index = Int64Index([-5, 0, 1, 2])
-        expected = np.array([-5, 0, 1, 2], dtype=np.int64)
-        tm.assert_numpy_array_equal(index, expected)
+        expected = Index([-5, 0, 1, 2], dtype=np.int64)
+        tm.assert_index_equal(index, expected)
 
         # from iterable
         index = Int64Index(iter([-5, 0, 1, 2]))
-        tm.assert_numpy_array_equal(index, expected)
+        tm.assert_index_equal(index, expected)
 
         # scalar raise Exception
         self.assertRaises(TypeError, Int64Index, 5)
@@ -438,7 +441,7 @@ class TestInt64Index(Numeric, tm.TestCase):
         # copy
         arr = self.index.values
         new_index = Int64Index(arr, copy=True)
-        tm.assert_numpy_array_equal(new_index, self.index)
+        tm.assert_index_equal(new_index, self.index)
         val = arr[0] + 3000
 
         # this should not change index
@@ -457,7 +460,7 @@ class TestInt64Index(Numeric, tm.TestCase):
         arr = np.array([1, 2, 3, 4], dtype=object)
         index = Int64Index(arr)
         self.assertEqual(index.values.dtype, np.int64)
-        self.assertTrue(index.equals(arr))
+        self.assert_index_equal(index, Index(arr))
 
         # preventing casting
         arr = np.array([1, '2', 3, '4'], dtype=object)
@@ -581,7 +584,7 @@ class TestInt64Index(Numeric, tm.TestCase):
         res, lidx, ridx = self.index.join(other, how='outer',
                                           return_indexers=True)
         noidx_res = self.index.join(other, how='outer')
-        self.assertTrue(res.equals(noidx_res))
+        self.assert_index_equal(res, noidx_res)
 
         eres = Int64Index([0, 1, 2, 4, 5, 6, 7, 8, 10, 12, 14, 16, 18, 25])
         elidx = np.array([0, -1, 1, 2, -1, 3, -1, 4, 5, 6, 7, 8, 9, -1],
@@ -590,7 +593,7 @@ class TestInt64Index(Numeric, tm.TestCase):
                          dtype=np.int_)
 
         tm.assertIsInstance(res, Int64Index)
-        self.assertTrue(res.equals(eres))
+        self.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -598,14 +601,14 @@ class TestInt64Index(Numeric, tm.TestCase):
         res, lidx, ridx = self.index.join(other_mono, how='outer',
                                           return_indexers=True)
         noidx_res = self.index.join(other_mono, how='outer')
-        self.assertTrue(res.equals(noidx_res))
+        self.assert_index_equal(res, noidx_res)
 
         elidx = np.array([0, -1, 1, 2, -1, 3, -1, 4, 5, 6, 7, 8, 9, -1],
                          dtype=np.int64)
         eridx = np.array([-1, 0, 1, -1, 2, -1, 3, -1, -1, 4, -1, -1, -1, 5],
                          dtype=np.int64)
         tm.assertIsInstance(res, Int64Index)
-        self.assertTrue(res.equals(eres))
+        self.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -628,7 +631,7 @@ class TestInt64Index(Numeric, tm.TestCase):
         eridx = np.array([4, 1], dtype=np.int_)
 
         tm.assertIsInstance(res, Int64Index)
-        self.assertTrue(res.equals(eres))
+        self.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -637,12 +640,12 @@ class TestInt64Index(Numeric, tm.TestCase):
                                           return_indexers=True)
 
         res2 = self.index.intersection(other_mono)
-        self.assertTrue(res.equals(res2))
+        self.assert_index_equal(res, res2)
 
         elidx = np.array([1, 6], dtype=np.int64)
         eridx = np.array([1, 4], dtype=np.int64)
         tm.assertIsInstance(res, Int64Index)
-        self.assertTrue(res.equals(eres))
+        self.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -658,7 +661,7 @@ class TestInt64Index(Numeric, tm.TestCase):
                          dtype=np.int_)
 
         tm.assertIsInstance(res, Int64Index)
-        self.assertTrue(res.equals(eres))
+        self.assert_index_equal(res, eres)
         self.assertIsNone(lidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -668,7 +671,7 @@ class TestInt64Index(Numeric, tm.TestCase):
         eridx = np.array([-1, 1, -1, -1, -1, -1, 4, -1, -1, -1],
                          dtype=np.int64)
         tm.assertIsInstance(res, Int64Index)
-        self.assertTrue(res.equals(eres))
+        self.assert_index_equal(res, eres)
         self.assertIsNone(lidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -679,7 +682,7 @@ class TestInt64Index(Numeric, tm.TestCase):
         eres = Index([1, 1, 2, 5, 7, 9])  # 1 is in idx2, so it should be x2
         eridx = np.array([0, 1, 2, 3, -1, -1], dtype=np.int64)
         elidx = np.array([0, 0, 1, 2, 3, 4], dtype=np.int64)
-        self.assertTrue(res.equals(eres))
+        self.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -694,7 +697,7 @@ class TestInt64Index(Numeric, tm.TestCase):
         elidx = np.array([-1, 6, -1, -1, 1, -1], dtype=np.int_)
 
         tm.assertIsInstance(other, Int64Index)
-        self.assertTrue(res.equals(eres))
+        self.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         self.assertIsNone(ridx)
 
@@ -704,7 +707,7 @@ class TestInt64Index(Numeric, tm.TestCase):
         eres = other_mono
         elidx = np.array([-1, 1, -1, -1, 6, -1], dtype=np.int64)
         tm.assertIsInstance(other, Int64Index)
-        self.assertTrue(res.equals(eres))
+        self.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         self.assertIsNone(ridx)
 
@@ -715,7 +718,7 @@ class TestInt64Index(Numeric, tm.TestCase):
         eres = Index([1, 1, 2, 5, 7, 9])  # 1 is in idx2, so it should be x2
         elidx = np.array([0, 1, 2, 3, -1, -1], dtype=np.int64)
         eridx = np.array([0, 0, 1, 2, 3, 4], dtype=np.int64)
-        self.assertTrue(res.equals(eres))
+        self.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -724,28 +727,27 @@ class TestInt64Index(Numeric, tm.TestCase):
 
         outer = self.index.join(other, how='outer')
         outer2 = other.join(self.index, how='outer')
-        expected = Index([0, 2, 3, 4, 6, 7, 8, 10, 12, 14,
-                          16, 18], dtype=object)
-        self.assertTrue(outer.equals(outer2))
-        self.assertTrue(outer.equals(expected))
+        expected = Index([0, 2, 3, 4, 6, 7, 8, 10, 12, 14, 16, 18])
+        self.assert_index_equal(outer, outer2)
+        self.assert_index_equal(outer, expected)
 
         inner = self.index.join(other, how='inner')
         inner2 = other.join(self.index, how='inner')
-        expected = Index([6, 8, 10], dtype=object)
-        self.assertTrue(inner.equals(inner2))
-        self.assertTrue(inner.equals(expected))
+        expected = Index([6, 8, 10])
+        self.assert_index_equal(inner, inner2)
+        self.assert_index_equal(inner, expected)
 
         left = self.index.join(other, how='left')
-        self.assertTrue(left.equals(self.index))
+        self.assert_index_equal(left, self.index.astype(object))
 
         left2 = other.join(self.index, how='left')
-        self.assertTrue(left2.equals(other))
+        self.assert_index_equal(left2, other)
 
         right = self.index.join(other, how='right')
-        self.assertTrue(right.equals(other))
+        self.assert_index_equal(right, other)
 
         right2 = other.join(self.index, how='right')
-        self.assertTrue(right2.equals(self.index))
+        self.assert_index_equal(right2, self.index.astype(object))
 
     def test_join_non_unique(self):
         left = Index([4, 4, 3, 3])
@@ -753,7 +755,7 @@ class TestInt64Index(Numeric, tm.TestCase):
         joined, lidx, ridx = left.join(left, return_indexers=True)
 
         exp_joined = Index([3, 3, 3, 3, 4, 4, 4, 4])
-        self.assertTrue(joined.equals(exp_joined))
+        self.assert_index_equal(joined, exp_joined)
 
         exp_lidx = np.array([2, 2, 3, 3, 0, 0, 1, 1], dtype=np.int_)
         tm.assert_numpy_array_equal(lidx, exp_lidx)
@@ -770,13 +772,14 @@ class TestInt64Index(Numeric, tm.TestCase):
     def test_intersection(self):
         other = Index([1, 2, 3, 4, 5])
         result = self.index.intersection(other)
-        expected = np.sort(np.intersect1d(self.index.values, other.values))
-        tm.assert_numpy_array_equal(result, expected)
+        expected = Index(np.sort(np.intersect1d(self.index.values,
+                                                other.values)))
+        tm.assert_index_equal(result, expected)
 
         result = other.intersection(self.index)
-        expected = np.sort(np.asarray(np.intersect1d(self.index.values,
-                                                     other.values)))
-        tm.assert_numpy_array_equal(result, expected)
+        expected = Index(np.sort(np.asarray(np.intersect1d(self.index.values,
+                                                           other.values))))
+        tm.assert_index_equal(result, expected)
 
     def test_intersect_str_dates(self):
         dt_dates = [datetime(2012, 2, 9), datetime(2012, 2, 22)]
@@ -793,12 +796,12 @@ class TestInt64Index(Numeric, tm.TestCase):
         now = datetime.now()
         other = Index([now + timedelta(i) for i in range(4)], dtype=object)
         result = self.index.union(other)
-        expected = np.concatenate((self.index, other))
-        tm.assert_numpy_array_equal(result, expected)
+        expected = Index(np.concatenate((self.index, other)))
+        tm.assert_index_equal(result, expected)
 
         result = other.union(self.index)
-        expected = np.concatenate((other, self.index))
-        tm.assert_numpy_array_equal(result, expected)
+        expected = Index(np.concatenate((other, self.index)))
+        tm.assert_index_equal(result, expected)
 
     def test_cant_or_shouldnt_cast(self):
         # can't

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -538,8 +538,10 @@ class TestFloatIndexers(tm.TestCase):
 
                     # getitem
                     result = idxr(s)[l]
-                    self.assertTrue(result.equals(expected))
-
+                    if isinstance(s, Series):
+                        self.assert_series_equal(result, expected)
+                    else:
+                        self.assert_frame_equal(result, expected)
                     # setitem
                     s2 = s.copy()
                     idxr(s2)[l] = 0

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -2925,7 +2925,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         df.columns = ['a', 'a', 'b']
         result = df[['b', 'a']].columns
         expected = Index(['b', 'a', 'a'])
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
 
         # across dtypes
         df = DataFrame([[1, 2, 1., 2., 3., 'foo', 'bar']],
@@ -3829,7 +3829,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         index = df.index.copy()
 
         df['A'] = df['A'].astype(np.float64)
-        self.assertTrue(df.index.equals(index))
+        self.assert_index_equal(df.index, index)
 
         # TODO(wesm): unused variables
         # result = df.get_dtype_counts().sort_index()

--- a/pandas/tests/series/test_alter_axes.py
+++ b/pandas/tests/series/test_alter_axes.py
@@ -48,7 +48,7 @@ class TestSeriesAlterAxes(TestData, tm.TestCase):
         # partial dict
         s = Series(np.arange(4), index=['a', 'b', 'c', 'd'], dtype='int64')
         renamed = s.rename({'b': 'foo', 'd': 'bar'})
-        self.assert_numpy_array_equal(renamed.index, ['a', 'foo', 'c', 'bar'])
+        self.assert_index_equal(renamed.index, Index(['a', 'foo', 'c', 'bar']))
 
         # index with name
         renamer = Series(np.arange(4),
@@ -141,7 +141,7 @@ class TestSeriesAlterAxes(TestData, tm.TestCase):
         self.assertEqual(len(rs.columns), 2)
 
         rs = s.reset_index(level=[0, 2], drop=True)
-        self.assertTrue(rs.index.equals(Index(index.get_level_values(1))))
+        self.assert_index_equal(rs.index, Index(index.get_level_values(1)))
         tm.assertIsInstance(rs, Series)
 
     def test_reset_index_range(self):

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -289,8 +289,8 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         mexpected = np.argsort(s.values, kind='mergesort')
         qexpected = np.argsort(s.values, kind='quicksort')
 
-        self.assert_numpy_array_equal(mindexer, mexpected)
-        self.assert_numpy_array_equal(qindexer, qexpected)
+        self.assert_series_equal(mindexer, Series(mexpected))
+        self.assert_series_equal(qindexer, Series(qexpected))
         self.assertFalse(np.array_equal(qindexer, mindexer))
 
     def test_cumsum(self):
@@ -300,24 +300,24 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         self._check_accum_op('cumprod')
 
     def test_cummin(self):
-        self.assert_numpy_array_equal(self.ts.cummin(),
+        self.assert_numpy_array_equal(self.ts.cummin().values,
                                       np.minimum.accumulate(np.array(self.ts)))
         ts = self.ts.copy()
         ts[::2] = np.NaN
         result = ts.cummin()[1::2]
         expected = np.minimum.accumulate(ts.valid())
 
-        self.assert_numpy_array_equal(result, expected)
+        self.assert_series_equal(result, expected)
 
     def test_cummax(self):
-        self.assert_numpy_array_equal(self.ts.cummax(),
+        self.assert_numpy_array_equal(self.ts.cummax().values,
                                       np.maximum.accumulate(np.array(self.ts)))
         ts = self.ts.copy()
         ts[::2] = np.NaN
         result = ts.cummax()[1::2]
         expected = np.maximum.accumulate(ts.valid())
 
-        self.assert_numpy_array_equal(result, expected)
+        self.assert_series_equal(result, expected)
 
     def test_cummin_datetime64(self):
         s = pd.Series(pd.to_datetime(['NaT', '2000-1-2', 'NaT', '2000-1-1',
@@ -489,7 +489,8 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
 
     def _check_accum_op(self, name):
         func = getattr(np, name)
-        self.assert_numpy_array_equal(func(self.ts), func(np.array(self.ts)))
+        self.assert_numpy_array_equal(func(self.ts).values,
+                                      func(np.array(self.ts)))
 
         # with missing values
         ts = self.ts.copy()
@@ -498,7 +499,7 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         result = func(ts)[1::2]
         expected = func(np.array(ts.valid()))
 
-        self.assert_numpy_array_equal(result, expected)
+        self.assert_numpy_array_equal(result.values, expected)
 
     def test_compress(self):
         cond = [True, False, True, False, False]
@@ -1404,13 +1405,13 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         with tm.assert_produces_warning(FutureWarning):
             ts.sort()
 
-        self.assert_numpy_array_equal(ts, self.ts.sort_values())
-        self.assert_numpy_array_equal(ts.index, self.ts.sort_values().index)
+        self.assert_series_equal(ts, self.ts.sort_values())
+        self.assert_index_equal(ts.index, self.ts.sort_values().index)
 
         ts.sort_values(ascending=False, inplace=True)
-        self.assert_numpy_array_equal(ts, self.ts.sort_values(ascending=False))
-        self.assert_numpy_array_equal(ts.index, self.ts.sort_values(
-            ascending=False).index)
+        self.assert_series_equal(ts, self.ts.sort_values(ascending=False))
+        self.assert_index_equal(ts.index,
+                                self.ts.sort_values(ascending=False).index)
 
         # GH 5856/5853
         # Series.sort_values operating on a view
@@ -1513,11 +1514,11 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
 
         result = ts.sort_values()
         self.assertTrue(np.isnan(result[-5:]).all())
-        self.assert_numpy_array_equal(result[:-5], np.sort(vals[5:]))
+        self.assert_numpy_array_equal(result[:-5].values, np.sort(vals[5:]))
 
         result = ts.sort_values(na_position='first')
         self.assertTrue(np.isnan(result[:5]).all())
-        self.assert_numpy_array_equal(result[5:], np.sort(vals[5:]))
+        self.assert_numpy_array_equal(result[5:].values, np.sort(vals[5:]))
 
         # something object-type
         ser = Series(['A', 'B'], [1, 2])

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -160,7 +160,7 @@ class TestSeriesMap(TestData, tm.TestCase):
 
         # function
         result = self.ts.map(lambda x: x * 2)
-        self.assert_numpy_array_equal(result, self.ts * 2)
+        self.assert_series_equal(result, self.ts * 2)
 
         # GH 10324
         a = Series([1, 2, 3, 4])

--- a/pandas/tests/series/test_combine_concat.py
+++ b/pandas/tests/series/test_combine_concat.py
@@ -49,14 +49,14 @@ class TestSeriesCombine(TestData, tm.TestCase):
         # nothing used from the input
         combined = series.combine_first(series_copy)
 
-        self.assert_numpy_array_equal(combined, series)
+        self.assert_series_equal(combined, series)
 
         # Holes filled from input
         combined = series_copy.combine_first(series)
         self.assertTrue(np.isfinite(combined).all())
 
-        self.assert_numpy_array_equal(combined[::2], series[::2])
-        self.assert_numpy_array_equal(combined[1::2], series_copy[1::2])
+        self.assert_series_equal(combined[::2], series[::2])
+        self.assert_series_equal(combined[1::2], series_copy[1::2])
 
         # mixed types
         index = tm.makeStringIndex(20)

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -137,7 +137,7 @@ class TestSeriesConstructors(TestData, tm.TestCase):
         cat = pd.Categorical([0, 1, 2, 0, 1, 2], ['a', 'b', 'c'],
                              fastpath=True)
         res = Series(cat)
-        self.assertTrue(res.values.equals(cat))
+        tm.assert_categorical_equal(res.values, cat)
 
         # GH12574
         self.assertRaises(
@@ -418,8 +418,10 @@ class TestSeriesConstructors(TestData, tm.TestCase):
         result = s.values
         self.assertIsInstance(result, np.ndarray)
         self.assertTrue(result.dtype == 'datetime64[ns]')
-        self.assertTrue(dr.equals(pd.DatetimeIndex(result).tz_localize(
-            'UTC').tz_convert(tz=s.dt.tz)))
+
+        exp = pd.DatetimeIndex(result)
+        exp = exp.tz_localize('UTC').tz_convert(tz=s.dt.tz)
+        self.assert_index_equal(dr, exp)
 
         # indexing
         result = s.iloc[0]

--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -55,7 +55,7 @@ class TestSeriesDtypes(TestData, tm.TestCase):
 
         arr = Series(['1', '2', '3', '4'], dtype=object)
         result = arr.astype(int)
-        self.assert_numpy_array_equal(result, np.arange(1, 5))
+        self.assert_series_equal(result, Series(np.arange(1, 5)))
 
     def test_astype_datetimes(self):
         import pandas.tslib as tslib

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -246,7 +246,7 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         result = s[list(mask)]
         expected = s[mask]
         assert_series_equal(result, expected)
-        self.assert_numpy_array_equal(result.index, s.index[mask])
+        self.assert_index_equal(result.index, s.index[mask])
 
     def test_getitem_boolean_empty(self):
         s = Series([], dtype=np.int64)

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -130,7 +130,7 @@ class TestSeriesIO(TestData, tm.TestCase):
         assert_frame_equal(rs, xp)
 
     def test_to_dict(self):
-        self.assert_numpy_array_equal(Series(self.ts.to_dict()), self.ts)
+        self.assert_series_equal(Series(self.ts.to_dict(), name='ts'), self.ts)
 
     def test_timeseries_periodindex(self):
         # GH2891

--- a/pandas/tests/series/test_misc_api.py
+++ b/pandas/tests/series/test_misc_api.py
@@ -206,7 +206,7 @@ class TestSeriesMisc(TestData, SharedWithSparse, tm.TestCase):
         self.assertIs(getkeys(), self.ts.index)
 
     def test_values(self):
-        self.assert_numpy_array_equal(self.ts, self.ts.values)
+        self.assert_almost_equal(self.ts.values, self.ts, check_dtype=False)
 
     def test_iteritems(self):
         for idx, val in compat.iteritems(self.series):

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -247,16 +247,18 @@ class TestSeriesMissingData(TestData, tm.TestCase):
     def test_fillna(self):
         ts = Series([0., 1., 2., 3., 4.], index=tm.makeDateIndex(5))
 
-        self.assert_numpy_array_equal(ts, ts.fillna(method='ffill'))
+        self.assert_series_equal(ts, ts.fillna(method='ffill'))
 
         ts[2] = np.NaN
 
-        self.assert_numpy_array_equal(ts.fillna(method='ffill'),
-                                      [0., 1., 1., 3., 4.])
-        self.assert_numpy_array_equal(ts.fillna(method='backfill'),
-                                      [0., 1., 3., 3., 4.])
+        exp = Series([0., 1., 1., 3., 4.], index=ts.index)
+        self.assert_series_equal(ts.fillna(method='ffill'), exp)
 
-        self.assert_numpy_array_equal(ts.fillna(value=5), [0., 1., 5., 3., 4.])
+        exp = Series([0., 1., 3., 3., 4.], index=ts.index)
+        self.assert_series_equal(ts.fillna(method='backfill'), exp)
+
+        exp = Series([0., 1., 5., 3., 4.], index=ts.index)
+        self.assert_series_equal(ts.fillna(value=5), exp)
 
         self.assertRaises(ValueError, ts.fillna)
         self.assertRaises(ValueError, self.ts.fillna, value=0, method='ffill')
@@ -488,7 +490,7 @@ class TestSeriesInterpolateData(TestData, tm.TestCase):
         ts_copy[5:10] = np.NaN
 
         linear_interp = ts_copy.interpolate(method='linear')
-        self.assert_numpy_array_equal(linear_interp, ts)
+        self.assert_series_equal(linear_interp, ts)
 
         ord_ts = Series([d.toordinal() for d in self.ts.index],
                         index=self.ts.index).astype(float)
@@ -497,7 +499,7 @@ class TestSeriesInterpolateData(TestData, tm.TestCase):
         ord_ts_copy[5:10] = np.NaN
 
         time_interp = ord_ts_copy.interpolate(method='time')
-        self.assert_numpy_array_equal(time_interp, ord_ts)
+        self.assert_series_equal(time_interp, ord_ts)
 
         # try time interpolation on a non-TimeSeries
         # Only raises ValueError if there are NaNs.

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -1227,8 +1227,9 @@ class TestSeriesOperators(TestData, tm.TestCase):
         # float + int
         int_ts = self.ts.astype(int)[:-5]
         added = self.ts + int_ts
-        expected = self.ts.values[:-5] + int_ts.values
-        self.assert_numpy_array_equal(added[:-5], expected)
+        expected = Series(self.ts.values[:-5] + int_ts.values,
+                          index=self.ts.index[:-5], name='ts')
+        self.assert_series_equal(added[:-5], expected)
 
     def test_operators_reverse_object(self):
         # GH 56

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -492,15 +492,15 @@ class TestSeriesTimeSeries(TestData, tm.TestCase):
 
         daily_ts = ts.asfreq('B')
         monthly_ts = daily_ts.asfreq('BM')
-        self.assert_numpy_array_equal(monthly_ts, ts)
+        self.assert_series_equal(monthly_ts, ts)
 
         daily_ts = ts.asfreq('B', method='pad')
         monthly_ts = daily_ts.asfreq('BM')
-        self.assert_numpy_array_equal(monthly_ts, ts)
+        self.assert_series_equal(monthly_ts, ts)
 
         daily_ts = ts.asfreq(datetools.bday)
         monthly_ts = daily_ts.asfreq(datetools.bmonthEnd)
-        self.assert_numpy_array_equal(monthly_ts, ts)
+        self.assert_series_equal(monthly_ts, ts)
 
         result = ts[:0].asfreq('M')
         self.assertEqual(len(result), 0)

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -102,14 +102,14 @@ class TestFactorize(tm.TestCase):
 
         exp = np.array([0, 0, -1, 1, 2, 3], dtype=np.int_)
         self.assert_numpy_array_equal(labels, exp)
-        exp = np.array(['A', 'B', 3.14, np.inf], dtype=object)
-        self.assert_numpy_array_equal(uniques, exp)
+        exp = pd.Index(['A', 'B', 3.14, np.inf])
+        tm.assert_index_equal(uniques, exp)
 
         labels, uniques = algos.factorize(x, sort=True)
         exp = np.array([2, 2, -1, 3, 0, 1], dtype=np.int_)
         self.assert_numpy_array_equal(labels, exp)
-        exp = np.array([3.14, np.inf, 'A', 'B'], dtype=object)
-        self.assert_numpy_array_equal(uniques, exp)
+        exp = pd.Index([3.14, np.inf, 'A', 'B'])
+        tm.assert_index_equal(uniques, exp)
 
     def test_datelike(self):
 
@@ -121,14 +121,14 @@ class TestFactorize(tm.TestCase):
 
         exp = np.array([0, 0, 0, 1, 1, 0], dtype=np.int_)
         self.assert_numpy_array_equal(labels, exp)
-        exp = np.array([v1.value, v2.value], dtype='M8[ns]')
-        self.assert_numpy_array_equal(uniques, exp)
+        exp = pd.DatetimeIndex([v1, v2])
+        self.assert_index_equal(uniques, exp)
 
         labels, uniques = algos.factorize(x, sort=True)
         exp = np.array([1, 1, 1, 0, 0, 1], dtype=np.int_)
         self.assert_numpy_array_equal(labels, exp)
-        exp = np.array([v2.value, v1.value], dtype='M8[ns]')
-        self.assert_numpy_array_equal(uniques, exp)
+        exp = pd.DatetimeIndex([v2, v1])
+        self.assert_index_equal(uniques, exp)
 
         # period
         v1 = pd.Period('201302', freq='M')
@@ -139,12 +139,12 @@ class TestFactorize(tm.TestCase):
         labels, uniques = algos.factorize(x)
         exp = np.array([0, 0, 0, 1, 1, 0], dtype=np.int_)
         self.assert_numpy_array_equal(labels, exp)
-        self.assert_numpy_array_equal(uniques, pd.PeriodIndex([v1, v2]))
+        self.assert_index_equal(uniques, pd.PeriodIndex([v1, v2]))
 
         labels, uniques = algos.factorize(x, sort=True)
         exp = np.array([0, 0, 0, 1, 1, 0], dtype=np.int_)
         self.assert_numpy_array_equal(labels, exp)
-        self.assert_numpy_array_equal(uniques, pd.PeriodIndex([v1, v2]))
+        self.assert_index_equal(uniques, pd.PeriodIndex([v1, v2]))
 
         # GH 5986
         v1 = pd.to_timedelta('1 day 1 min')
@@ -153,12 +153,12 @@ class TestFactorize(tm.TestCase):
         labels, uniques = algos.factorize(x)
         exp = np.array([0, 1, 0, 0, 1, 1, 0], dtype=np.int_)
         self.assert_numpy_array_equal(labels, exp)
-        self.assert_numpy_array_equal(uniques, pd.to_timedelta([v1, v2]))
+        self.assert_index_equal(uniques, pd.to_timedelta([v1, v2]))
 
         labels, uniques = algos.factorize(x, sort=True)
         exp = np.array([1, 0, 1, 1, 0, 0, 1], dtype=np.int_)
         self.assert_numpy_array_equal(labels, exp)
-        self.assert_numpy_array_equal(uniques, pd.to_timedelta([v2, v1]))
+        self.assert_index_equal(uniques, pd.to_timedelta([v2, v1]))
 
     def test_factorize_nan(self):
         # nan should map to na_sentinel, not reverse_indexer[na_sentinel]

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -287,7 +287,12 @@ class TestExpressions(tm.TestCase):
                                                use_numexpr=True)
                         expected = expr.evaluate(op, op_str, f, f,
                                                  use_numexpr=False)
-                        tm.assert_numpy_array_equal(result, expected.values)
+
+                        if isinstance(result, DataFrame):
+                            tm.assert_frame_equal(result, expected)
+                        else:
+                            tm.assert_numpy_array_equal(result,
+                                                        expected.values)
 
                         result = expr._can_use_numexpr(op, op_str, f2, f2,
                                                        'evaluate')
@@ -325,7 +330,10 @@ class TestExpressions(tm.TestCase):
                                            use_numexpr=True)
                     expected = expr.evaluate(op, op_str, f11, f12,
                                              use_numexpr=False)
-                    tm.assert_numpy_array_equal(result, expected.values)
+                    if isinstance(result, DataFrame):
+                        tm.assert_frame_equal(result, expected)
+                    else:
+                        tm.assert_numpy_array_equal(result, expected.values)
 
                     result = expr._can_use_numexpr(op, op_str, f21, f22,
                                                    'evaluate')

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -1289,7 +1289,7 @@ class TestDataFrame(tm.TestCase, Generic):
 
                 df1 = DataFrame(np.ones(5), index=l0)
                 df1 = getattr(df1, fn)('US/Pacific')
-                self.assertTrue(df1.index.equals(l0_expected))
+                self.assert_index_equal(df1.index, l0_expected)
 
                 # MultiIndex
                 # GH7846
@@ -1297,14 +1297,14 @@ class TestDataFrame(tm.TestCase, Generic):
 
                 df3 = getattr(df2, fn)('US/Pacific', level=0)
                 self.assertFalse(df3.index.levels[0].equals(l0))
-                self.assertTrue(df3.index.levels[0].equals(l0_expected))
-                self.assertTrue(df3.index.levels[1].equals(l1))
+                self.assert_index_equal(df3.index.levels[0], l0_expected)
+                self.assert_index_equal(df3.index.levels[1], l1)
                 self.assertFalse(df3.index.levels[1].equals(l1_expected))
 
                 df3 = getattr(df2, fn)('US/Pacific', level=1)
-                self.assertTrue(df3.index.levels[0].equals(l0))
+                self.assert_index_equal(df3.index.levels[0], l0)
                 self.assertFalse(df3.index.levels[0].equals(l0_expected))
-                self.assertTrue(df3.index.levels[1].equals(l1_expected))
+                self.assert_index_equal(df3.index.levels[1], l1_expected)
                 self.assertFalse(df3.index.levels[1].equals(l1))
 
                 df4 = DataFrame(np.ones(5),
@@ -1313,9 +1313,9 @@ class TestDataFrame(tm.TestCase, Generic):
                 # TODO: untested
                 df5 = getattr(df4, fn)('US/Pacific', level=1)  # noqa
 
-                self.assertTrue(df3.index.levels[0].equals(l0))
+                self.assert_index_equal(df3.index.levels[0], l0)
                 self.assertFalse(df3.index.levels[0].equals(l0_expected))
-                self.assertTrue(df3.index.levels[1].equals(l1_expected))
+                self.assert_index_equal(df3.index.levels[1], l1_expected)
                 self.assertFalse(df3.index.levels[1].equals(l1))
 
         # Bad Inputs

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -706,14 +706,12 @@ class TestSeriesPlots(TestPlotBase):
             expected = np.hstack((1.0e-04, expected, 1.0e+01))
 
         ax = Series([0.1, 0.01, 0.001]).plot(log=True, kind='bar')
-        tm.assert_numpy_array_equal(ax.get_ylim(),
-                                    (0.001, 0.10000000000000001))
+        self.assertEqual(ax.get_ylim(), (0.001, 0.10000000000000001))
         tm.assert_numpy_array_equal(ax.yaxis.get_ticklocs(), expected)
         tm.close()
 
         ax = Series([0.1, 0.01, 0.001]).plot(log=True, kind='barh')
-        tm.assert_numpy_array_equal(ax.get_xlim(),
-                                    (0.001, 0.10000000000000001))
+        self.assertEqual(ax.get_xlim(), (0.001, 0.10000000000000001))
         tm.assert_numpy_array_equal(ax.xaxis.get_ticklocs(), expected)
 
     @slow
@@ -2205,11 +2203,11 @@ class TestDataFramePlots(TestPlotBase):
 
         ax = df.plot.scatter(x='a', y='b', c='c')
         tm.assert_numpy_array_equal(ax.collections[0].get_facecolor()[0],
-                                    (0, 0, 1, 1))
+                                    np.array([0, 0, 1, 1], dtype=np.float64))
 
         ax = df.plot.scatter(x='a', y='b', color='white')
         tm.assert_numpy_array_equal(ax.collections[0].get_facecolor()[0],
-                                    (1, 1, 1, 1))
+                                    np.array([1, 1, 1, 1], dtype=np.float64))
 
     @slow
     def test_plot_bar(self):

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -17,15 +17,19 @@ from pandas.core.internals import (BlockPlacement, SingleBlockManager,
 import pandas.core.algorithms as algos
 import pandas.util.testing as tm
 import pandas as pd
+from pandas import lib
 from pandas.util.testing import (assert_almost_equal, assert_frame_equal,
                                  randn, assert_series_equal)
 from pandas.compat import zip, u
 
 
 def assert_block_equal(left, right):
-    assert_almost_equal(left.values, right.values)
+    tm.assert_numpy_array_equal(left.values, right.values)
     assert (left.dtype == right.dtype)
-    assert_almost_equal(left.mgr_locs, right.mgr_locs)
+    tm.assertIsInstance(left.mgr_locs, lib.BlockPlacement)
+    tm.assertIsInstance(right.mgr_locs, lib.BlockPlacement)
+    tm.assert_numpy_array_equal(left.mgr_locs.as_array,
+                                right.mgr_locs.as_array)
 
 
 def get_numeric_mat(shape):
@@ -207,7 +211,9 @@ class TestBlock(tm.TestCase):
         _check(self.bool_block)
 
     def test_mgr_locs(self):
-        assert_almost_equal(self.fblock.mgr_locs, [0, 2, 4])
+        tm.assertIsInstance(self.fblock.mgr_locs, lib.BlockPlacement)
+        tm.assert_numpy_array_equal(self.fblock.mgr_locs.as_array,
+                                    np.array([0, 2, 4], dtype=np.int64))
 
     def test_attrs(self):
         self.assertEqual(self.fblock.shape, self.fblock.values.shape)
@@ -223,9 +229,10 @@ class TestBlock(tm.TestCase):
         ablock = make_block(avals, ref_cols.get_indexer(['e', 'b']))
         bblock = make_block(bvals, ref_cols.get_indexer(['a', 'd']))
         merged = ablock.merge(bblock)
-        assert_almost_equal(merged.mgr_locs, [0, 1, 2, 3])
-        assert_almost_equal(merged.values[[0, 2]], avals)
-        assert_almost_equal(merged.values[[1, 3]], bvals)
+        tm.assert_numpy_array_equal(merged.mgr_locs.as_array,
+                                    np.array([0, 1, 2, 3], dtype=np.int64))
+        tm.assert_numpy_array_equal(merged.values[[0, 2]], np.array(avals))
+        tm.assert_numpy_array_equal(merged.values[[1, 3]], np.array(bvals))
 
         # TODO: merge with mixed type?
 
@@ -246,17 +253,22 @@ class TestBlock(tm.TestCase):
     def test_delete(self):
         newb = self.fblock.copy()
         newb.delete(0)
-        assert_almost_equal(newb.mgr_locs, [2, 4])
+        tm.assertIsInstance(newb.mgr_locs, lib.BlockPlacement)
+        tm.assert_numpy_array_equal(newb.mgr_locs.as_array,
+                                    np.array([2, 4], dtype=np.int64))
         self.assertTrue((newb.values[0] == 1).all())
 
         newb = self.fblock.copy()
         newb.delete(1)
-        assert_almost_equal(newb.mgr_locs, [0, 4])
+        tm.assertIsInstance(newb.mgr_locs, lib.BlockPlacement)
+        tm.assert_numpy_array_equal(newb.mgr_locs.as_array,
+                                    np.array([0, 4], dtype=np.int64))
         self.assertTrue((newb.values[1] == 2).all())
 
         newb = self.fblock.copy()
         newb.delete(2)
-        assert_almost_equal(newb.mgr_locs, [0, 2])
+        tm.assert_numpy_array_equal(newb.mgr_locs.as_array,
+                                    np.array([0, 2], dtype=np.int64))
         self.assertTrue((newb.values[1] == 1).all())
 
         newb = self.fblock.copy()
@@ -399,9 +411,9 @@ class TestBlockManager(tm.TestCase):
             for i, index in enumerate(self.mgr.axes[1]):
                 res = self.mgr.get_scalar((item, index))
                 exp = self.mgr.get(item, fastpath=False)[i]
-                assert_almost_equal(res, exp)
+                self.assertEqual(res, exp)
                 exp = self.mgr.get(item).internal_values()[i]
-                assert_almost_equal(res, exp)
+                self.assertEqual(res, exp)
 
     def test_get(self):
         cols = Index(list('abc'))
@@ -421,10 +433,14 @@ class TestBlockManager(tm.TestCase):
 
         mgr.set('d', np.array(['foo'] * 3))
         mgr.set('b', np.array(['bar'] * 3))
-        assert_almost_equal(mgr.get('a').internal_values(), [0] * 3)
-        assert_almost_equal(mgr.get('b').internal_values(), ['bar'] * 3)
-        assert_almost_equal(mgr.get('c').internal_values(), [2] * 3)
-        assert_almost_equal(mgr.get('d').internal_values(), ['foo'] * 3)
+        tm.assert_numpy_array_equal(mgr.get('a').internal_values(),
+                                    np.array([0] * 3))
+        tm.assert_numpy_array_equal(mgr.get('b').internal_values(),
+                                    np.array(['bar'] * 3, dtype=np.object_))
+        tm.assert_numpy_array_equal(mgr.get('c').internal_values(),
+                                    np.array([2] * 3))
+        tm.assert_numpy_array_equal(mgr.get('d').internal_values(),
+                                    np.array(['foo'] * 3, dtype=np.object_))
 
     def test_insert(self):
         self.mgr.insert(0, 'inserted', np.arange(N))
@@ -689,8 +705,9 @@ class TestBlockManager(tm.TestCase):
         self.assertEqual(cons.nblocks, 4)
         cons = self.mgr.consolidate().get_numeric_data()
         self.assertEqual(cons.nblocks, 1)
-        assert_almost_equal(cons.blocks[0].mgr_locs,
-                            np.arange(len(cons.items)))
+        tm.assertIsInstance(cons.blocks[0].mgr_locs, lib.BlockPlacement)
+        tm.assert_numpy_array_equal(cons.blocks[0].mgr_locs.as_array,
+                                    np.arange(len(cons.items), dtype=np.int64))
 
     def test_reindex_index(self):
         pass
@@ -786,18 +803,18 @@ class TestBlockManager(tm.TestCase):
             bools.get('bool').internal_values())
 
         bools.set('bool', np.array([True, False, True]))
-        assert_almost_equal(
-            mgr.get('bool', fastpath=False), [True, False, True])
-        assert_almost_equal(
-            mgr.get('bool').internal_values(), [True, False, True])
+        tm.assert_numpy_array_equal(mgr.get('bool', fastpath=False),
+                                    np.array([True, False, True]))
+        tm.assert_numpy_array_equal(mgr.get('bool').internal_values(),
+                                    np.array([True, False, True]))
 
         # Check sharing
         bools2 = mgr.get_bool_data(copy=True)
         bools2.set('bool', np.array([False, True, False]))
-        assert_almost_equal(
-            mgr.get('bool', fastpath=False), [True, False, True])
-        assert_almost_equal(
-            mgr.get('bool').internal_values(), [True, False, True])
+        tm.assert_numpy_array_equal(mgr.get('bool', fastpath=False),
+                                    np.array([True, False, True]))
+        tm.assert_numpy_array_equal(mgr.get('bool').internal_values(),
+                                    np.array([True, False, True]))
 
     def test_unicode_repr_doesnt_raise(self):
         repr(create_mgr(u('b,\u05d0: object')))
@@ -892,8 +909,7 @@ class TestIndexing(object):
             mat_slobj = (slice(None), ) * axis + (slobj, )
             tm.assert_numpy_array_equal(mat[mat_slobj], sliced.as_matrix(),
                                         check_dtype=False)
-            tm.assert_numpy_array_equal(mgr.axes[axis][slobj],
-                                        sliced.axes[axis])
+            tm.assert_index_equal(mgr.axes[axis][slobj], sliced.axes[axis])
 
         for mgr in self.MANAGERS:
             for ax in range(mgr.ndim):
@@ -931,8 +947,8 @@ class TestIndexing(object):
             taken = mgr.take(indexer, axis)
             tm.assert_numpy_array_equal(np.take(mat, indexer, axis),
                                         taken.as_matrix(), check_dtype=False)
-            tm.assert_numpy_array_equal(mgr.axes[axis].take(indexer),
-                                        taken.axes[axis])
+            tm.assert_index_equal(mgr.axes[axis].take(indexer),
+                                  taken.axes[axis])
 
         for mgr in self.MANAGERS:
             for ax in range(mgr.ndim):

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -87,19 +87,19 @@ class TestMultiLevel(tm.TestCase):
                            (1.2, datetime.datetime(2011, 1, 2, tzinfo=tz)),
                            (1.3, datetime.datetime(2011, 1, 3, tzinfo=tz))]
         expected = Index([1.1, 1.2, 1.3] + expected_tuples)
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
 
         result = midx_lv2.append(idx1)
         expected = Index(expected_tuples + [1.1, 1.2, 1.3])
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
 
         result = midx_lv2.append(midx_lv2)
-        expected = MultiIndex.from_arrays([idx1.append(idx1), idx2.append(idx2)
-                                           ])
-        self.assertTrue(result.equals(expected))
+        expected = MultiIndex.from_arrays([idx1.append(idx1),
+                                           idx2.append(idx2)])
+        self.assert_index_equal(result, expected)
 
         result = midx_lv2.append(midx_lv3)
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
 
         result = midx_lv3.append(midx_lv2)
         expected = Index._simple_new(
@@ -107,7 +107,7 @@ class TestMultiLevel(tm.TestCase):
                       (1.2, datetime.datetime(2011, 1, 2, tzinfo=tz), 'B'),
                       (1.3, datetime.datetime(2011, 1, 3, tzinfo=tz), 'C')] +
                      expected_tuples), None)
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
 
     def test_dataframe_constructor(self):
         multi = DataFrame(np.random.randn(4, 4),
@@ -966,9 +966,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
             assert_series_equal(left, right)
             self.assertFalse(left.index.is_unique)
             li, ri = left.index, right.index
-            for i in range(ri.nlevels):
-                tm.assert_numpy_array_equal(li.levels[i], ri.levels[i])
-                tm.assert_numpy_array_equal(li.labels[i], ri.labels[i])
+            tm.assert_index_equal(li, ri)
 
         df = DataFrame(np.arange(12).reshape(4, 3),
                        index=list('abab'),
@@ -1542,8 +1540,8 @@ Thur,Lunch,Yes,51.51,17"""
             # for good measure, groupby detail
             level_index = frame._get_axis(axis).levels[level]
 
-            self.assertTrue(leftside._get_axis(axis).equals(level_index))
-            self.assertTrue(rightside._get_axis(axis).equals(level_index))
+            self.assert_index_equal(leftside._get_axis(axis), level_index)
+            self.assert_index_equal(rightside._get_axis(axis), level_index)
 
             assert_frame_equal(leftside, rightside)
 
@@ -2211,12 +2209,11 @@ Thur,Lunch,Yes,51.51,17"""
                              tz='US/Eastern')
         idx = MultiIndex.from_arrays([idx1, idx2])
 
-        expected1 = pd.DatetimeIndex(
-            ['2013-04-01 9:00', '2013-04-02 9:00', '2013-04-03 9:00'
-             ], tz='Asia/Tokyo')
+        expected1 = pd.DatetimeIndex(['2013-04-01 9:00', '2013-04-02 9:00',
+                                      '2013-04-03 9:00'], tz='Asia/Tokyo')
 
-        self.assertTrue(idx.levels[0].equals(expected1))
-        self.assertTrue(idx.levels[1].equals(idx2))
+        self.assert_index_equal(idx.levels[0], expected1)
+        self.assert_index_equal(idx.levels[1], idx2)
 
         # from datetime combos
         # GH 7888
@@ -2256,18 +2253,20 @@ Thur,Lunch,Yes,51.51,17"""
         df.index = pd.to_datetime(df.pop('datetime'), utc=True)
         df.index = df.index.tz_localize('UTC').tz_convert('US/Pacific')
 
-        expected = pd.DatetimeIndex(
-            ['2011-07-19 07:00:00', '2011-07-19 08:00:00',
-             '2011-07-19 09:00:00'])
+        expected = pd.DatetimeIndex(['2011-07-19 07:00:00',
+                                     '2011-07-19 08:00:00',
+                                     '2011-07-19 09:00:00'], name='datetime')
         expected = expected.tz_localize('UTC').tz_convert('US/Pacific')
 
         df = df.set_index('label', append=True)
-        self.assertTrue(df.index.levels[0].equals(expected))
-        self.assertTrue(df.index.levels[1].equals(pd.Index(['a', 'b'])))
+        self.assert_index_equal(df.index.levels[0], expected)
+        self.assert_index_equal(df.index.levels[1],
+                                pd.Index(['a', 'b'], name='label'))
 
         df = df.swaplevel(0, 1)
-        self.assertTrue(df.index.levels[0].equals(pd.Index(['a', 'b'])))
-        self.assertTrue(df.index.levels[1].equals(expected))
+        self.assert_index_equal(df.index.levels[0],
+                                pd.Index(['a', 'b'], name='label'))
+        self.assert_index_equal(df.index.levels[1], expected)
 
         df = DataFrame(np.random.random(6))
         idx1 = pd.DatetimeIndex(['2011-07-19 07:00:00', '2011-07-19 08:00:00',
@@ -2287,17 +2286,17 @@ Thur,Lunch,Yes,51.51,17"""
         expected1 = pd.DatetimeIndex(['2011-07-19 07:00:00',
                                       '2011-07-19 08:00:00',
                                       '2011-07-19 09:00:00'], tz='US/Eastern')
-        expected2 = pd.DatetimeIndex(
-            ['2012-04-01 09:00', '2012-04-02 09:00'], tz='US/Eastern')
+        expected2 = pd.DatetimeIndex(['2012-04-01 09:00', '2012-04-02 09:00'],
+                                     tz='US/Eastern')
 
-        self.assertTrue(df.index.levels[0].equals(expected1))
-        self.assertTrue(df.index.levels[1].equals(expected2))
-        self.assertTrue(df.index.levels[2].equals(idx3))
+        self.assert_index_equal(df.index.levels[0], expected1)
+        self.assert_index_equal(df.index.levels[1], expected2)
+        self.assert_index_equal(df.index.levels[2], idx3)
 
         # GH 7092
-        self.assertTrue(df.index.get_level_values(0).equals(idx1))
-        self.assertTrue(df.index.get_level_values(1).equals(idx2))
-        self.assertTrue(df.index.get_level_values(2).equals(idx3))
+        self.assert_index_equal(df.index.get_level_values(0), idx1)
+        self.assert_index_equal(df.index.get_level_values(1), idx2)
+        self.assert_index_equal(df.index.get_level_values(2), idx3)
 
     def test_reset_index_datetime(self):
         # GH 3950
@@ -2404,13 +2403,13 @@ Thur,Lunch,Yes,51.51,17"""
         expected1 = pd.period_range('2011-01-01', periods=3, freq='M')
         expected2 = pd.period_range('2013-01-01 09:00', periods=2, freq='H')
 
-        self.assertTrue(df.index.levels[0].equals(expected1))
-        self.assertTrue(df.index.levels[1].equals(expected2))
-        self.assertTrue(df.index.levels[2].equals(idx3))
+        self.assert_index_equal(df.index.levels[0], expected1)
+        self.assert_index_equal(df.index.levels[1], expected2)
+        self.assert_index_equal(df.index.levels[2], idx3)
 
-        self.assertTrue(df.index.get_level_values(0).equals(idx1))
-        self.assertTrue(df.index.get_level_values(1).equals(idx2))
-        self.assertTrue(df.index.get_level_values(2).equals(idx3))
+        self.assert_index_equal(df.index.get_level_values(0), idx1)
+        self.assert_index_equal(df.index.get_level_values(1), idx2)
+        self.assert_index_equal(df.index.get_level_values(2), idx3)
 
     def test_repeat(self):
         # GH 9361

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -929,7 +929,7 @@ class TestNanskewFixedValues(tm.TestCase):
         samples = np.vstack([self.samples,
                              np.nan * np.ones(len(self.samples))])
         skew = nanops.nanskew(samples, axis=1)
-        tm.assert_almost_equal(skew, [self.actual_skew, np.nan])
+        tm.assert_almost_equal(skew, np.array([self.actual_skew, np.nan]))
 
     def test_nans(self):
         samples = np.hstack([self.samples, np.nan])
@@ -979,7 +979,7 @@ class TestNankurtFixedValues(tm.TestCase):
         samples = np.vstack([self.samples,
                              np.nan * np.ones(len(self.samples))])
         kurt = nanops.nankurt(samples, axis=1)
-        tm.assert_almost_equal(kurt, [self.actual_kurt, np.nan])
+        tm.assert_almost_equal(kurt, np.array([self.actual_kurt, np.nan]))
 
     def test_nans(self):
         samples = np.hstack([self.samples, np.nan])

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1086,12 +1086,12 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
         # TODO: unused?
         wp3 = Panel.from_dict(d3)  # noqa
 
-        self.assertTrue(wp.major_axis.equals(self.panel.major_axis))
+        self.assert_index_equal(wp.major_axis, self.panel.major_axis)
         assert_panel_equal(wp, wp2)
 
         # intersect
         wp = Panel.from_dict(d, intersect=True)
-        self.assertTrue(wp.major_axis.equals(itemb.index[5:]))
+        self.assert_index_equal(wp.major_axis, itemb.index[5:])
 
         # use constructor
         assert_panel_equal(Panel(d), Panel.from_dict(d))
@@ -1123,7 +1123,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
         data = dict((k, v.values) for k, v in self.panel.iteritems())
         result = Panel(data)
         exp_major = Index(np.arange(len(self.panel.major_axis)))
-        self.assertTrue(result.major_axis.equals(exp_major))
+        self.assert_index_equal(result.major_axis, exp_major)
 
         result = Panel(data, items=self.panel.items,
                        major_axis=self.panel.major_axis,
@@ -1213,8 +1213,8 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
         df = self.panel['ItemA'][:-5].filter(items=['A', 'B'])
         conformed = self.panel.conform(df)
 
-        assert (conformed.index.equals(self.panel.major_axis))
-        assert (conformed.columns.equals(self.panel.minor_axis))
+        tm.assert_index_equal(conformed.index, self.panel.major_axis)
+        tm.assert_index_equal(conformed.columns, self.panel.minor_axis)
 
     def test_convert_objects(self):
 
@@ -2078,11 +2078,11 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
 
         renamed = self.panel.rename_axis(mapper, axis=0)
         exp = Index(['foo', 'bar', 'baz'])
-        self.assertTrue(renamed.items.equals(exp))
+        self.assert_index_equal(renamed.items, exp)
 
         renamed = self.panel.rename_axis(str.lower, axis=2)
         exp = Index(['a', 'b', 'c', 'd'])
-        self.assertTrue(renamed.minor_axis.equals(exp))
+        self.assert_index_equal(renamed.minor_axis, exp)
 
         # don't copy
         renamed_nocopy = self.panel.rename_axis(mapper, axis=0, copy=False)
@@ -2485,7 +2485,7 @@ class TestLongPanel(tm.TestCase):
         transformed = make_axis_dummies(self.panel, 'minor',
                                         transform=mapping.get)
         self.assertEqual(len(transformed.columns), 2)
-        self.assert_numpy_array_equal(transformed.columns, ['one', 'two'])
+        self.assert_index_equal(transformed.columns, Index(['one', 'two']))
 
         # TODO: test correctness
 
@@ -2578,10 +2578,10 @@ def test_monotonic():
 
 def test_panel_index():
     index = panelm.panel_index([1, 2, 3, 4], [1, 2, 3])
-    expected = MultiIndex.from_arrays([np.tile(
-        [1, 2, 3, 4], 3), np.repeat(
-            [1, 2, 3], 4)])
-    assert (index.equals(expected))
+    expected = MultiIndex.from_arrays([np.tile([1, 2, 3, 4], 3),
+                                       np.repeat([1, 2, 3], 4)],
+                                      names=['time', 'panel'])
+    tm.assert_index_equal(index, expected)
 
 
 def test_import_warnings():

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -733,7 +733,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
         data = dict((k, v.values) for k, v in self.panel4d.iteritems())
         result = Panel4D(data)
         exp_major = Index(np.arange(len(self.panel4d.major_axis)))
-        self.assertTrue(result.major_axis.equals(exp_major))
+        self.assert_index_equal(result.major_axis, exp_major)
 
         result = Panel4D(data,
                          labels=self.panel4d.labels,
@@ -799,9 +799,9 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
         p = self.panel4d['l1'].filter(items=['ItemA', 'ItemB'])
         conformed = self.panel4d.conform(p)
 
-        assert(conformed.items.equals(self.panel4d.labels))
-        assert(conformed.major_axis.equals(self.panel4d.major_axis))
-        assert(conformed.minor_axis.equals(self.panel4d.minor_axis))
+        tm.assert_index_equal(conformed.items, self.panel4d.labels)
+        tm.assert_index_equal(conformed.major_axis, self.panel4d.major_axis)
+        tm.assert_index_equal(conformed.minor_axis, self.panel4d.minor_axis)
 
     def test_reindex(self):
         ref = self.panel4d['l2']
@@ -1085,11 +1085,11 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
 
         renamed = self.panel4d.rename_axis(mapper, axis=0)
         exp = Index(['foo', 'bar', 'baz'])
-        self.assertTrue(renamed.labels.equals(exp))
+        self.assert_index_equal(renamed.labels, exp)
 
         renamed = self.panel4d.rename_axis(str.lower, axis=3)
         exp = Index(['a', 'b', 'c', 'd'])
-        self.assertTrue(renamed.minor_axis.equals(exp))
+        self.assert_index_equal(renamed.minor_axis, exp)
 
         # don't copy
         renamed_nocopy = self.panel4d.rename_axis(mapper, axis=0, copy=False)

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -48,12 +48,12 @@ class TestStringMethods(tm.TestCase):
 
             # indices of each yielded Series should be equal to the index of
             # the original Series
-            tm.assert_numpy_array_equal(s.index, ds.index)
+            tm.assert_index_equal(s.index, ds.index)
 
             for el in s:
                 # each element of the series is either a basestring/str or nan
-                self.assertTrue(isinstance(el, compat.string_types) or isnull(
-                    el))
+                self.assertTrue(isinstance(el, compat.string_types) or
+                                isnull(el))
 
         # desired behavior is to iterate until everything would be nan on the
         # next iter so make sure the last element of the iterator was 'l' in
@@ -95,8 +95,8 @@ class TestStringMethods(tm.TestCase):
         self.assertEqual(s, 'h')
 
     def test_cat(self):
-        one = ['a', 'a', 'b', 'b', 'c', NA]
-        two = ['a', NA, 'b', 'd', 'foo', NA]
+        one = np.array(['a', 'a', 'b', 'b', 'c', NA], dtype=np.object_)
+        two = np.array(['a', NA, 'b', 'd', 'foo', NA], dtype=np.object_)
 
         # single array
         result = strings.str_cat(one)
@@ -121,21 +121,24 @@ class TestStringMethods(tm.TestCase):
 
         # Multiple arrays
         result = strings.str_cat(one, [two], na_rep='NA')
-        exp = ['aa', 'aNA', 'bb', 'bd', 'cfoo', 'NANA']
+        exp = np.array(['aa', 'aNA', 'bb', 'bd', 'cfoo', 'NANA'],
+                       dtype=np.object_)
         self.assert_numpy_array_equal(result, exp)
 
         result = strings.str_cat(one, two)
-        exp = ['aa', NA, 'bb', 'bd', 'cfoo', NA]
+        exp = np.array(['aa', NA, 'bb', 'bd', 'cfoo', NA], dtype=np.object_)
         tm.assert_almost_equal(result, exp)
 
     def test_count(self):
-        values = ['foo', 'foofoo', NA, 'foooofooofommmfoo']
+        values = np.array(['foo', 'foofoo', NA, 'foooofooofommmfoo'],
+                          dtype=np.object_)
 
         result = strings.str_count(values, 'f[o]+')
-        exp = Series([1, 2, NA, 4])
-        tm.assert_almost_equal(result, exp)
+        exp = np.array([1, 2, NA, 4])
+        tm.assert_numpy_array_equal(result, exp)
 
         result = Series(values).str.count('f[o]+')
+        exp = Series([1, 2, NA, 4])
         tm.assertIsInstance(result, Series)
         tm.assert_series_equal(result, exp)
 
@@ -163,61 +166,66 @@ class TestStringMethods(tm.TestCase):
         tm.assert_series_equal(result, exp)
 
     def test_contains(self):
-        values = ['foo', NA, 'fooommm__foo', 'mmm_', 'foommm[_]+bar']
+        values = np.array(['foo', NA, 'fooommm__foo',
+                           'mmm_', 'foommm[_]+bar'], dtype=np.object_)
         pat = 'mmm[_]+'
 
         result = strings.str_contains(values, pat)
-        expected = [False, NA, True, True, False]
-        tm.assert_almost_equal(result, expected)
+        expected = np.array([False, NA, True, True, False], dtype=np.object_)
+        tm.assert_numpy_array_equal(result, expected)
 
         result = strings.str_contains(values, pat, regex=False)
-        expected = [False, NA, False, False, True]
-        tm.assert_almost_equal(result, expected)
+        expected = np.array([False, NA, False, False, True], dtype=np.object_)
+        tm.assert_numpy_array_equal(result, expected)
 
         values = ['foo', 'xyz', 'fooommm__foo', 'mmm_']
         result = strings.str_contains(values, pat)
-        expected = [False, False, True, True]
+        expected = np.array([False, False, True, True])
         self.assertEqual(result.dtype, np.bool_)
-        tm.assert_almost_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         # case insensitive using regex
         values = ['Foo', 'xYz', 'fOOomMm__fOo', 'MMM_']
         result = strings.str_contains(values, 'FOO|mmm', case=False)
-        expected = [True, False, True, True]
-        tm.assert_almost_equal(result, expected)
+        expected = np.array([True, False, True, True])
+        tm.assert_numpy_array_equal(result, expected)
 
         # case insensitive without regex
         result = strings.str_contains(values, 'foo', regex=False, case=False)
-        expected = [True, False, True, False]
-        tm.assert_almost_equal(result, expected)
+        expected = np.array([True, False, True, False])
+        tm.assert_numpy_array_equal(result, expected)
 
         # mixed
         mixed = ['a', NA, 'b', True, datetime.today(), 'foo', None, 1, 2.]
         rs = strings.str_contains(mixed, 'o')
-        xp = Series([False, NA, False, NA, NA, True, NA, NA, NA])
-        tm.assert_almost_equal(rs, xp)
+        xp = np.array([False, NA, False, NA, NA, True, NA, NA, NA],
+                      dtype=np.object_)
+        tm.assert_numpy_array_equal(rs, xp)
 
         rs = Series(mixed).str.contains('o')
+        xp = Series([False, NA, False, NA, NA, True, NA, NA, NA])
         tm.assertIsInstance(rs, Series)
         tm.assert_series_equal(rs, xp)
 
         # unicode
-        values = [u('foo'), NA, u('fooommm__foo'), u('mmm_')]
+        values = np.array([u'foo', NA, u'fooommm__foo', u'mmm_'],
+                          dtype=np.object_)
         pat = 'mmm[_]+'
 
         result = strings.str_contains(values, pat)
-        expected = [False, np.nan, True, True]
-        tm.assert_almost_equal(result, expected)
+        expected = np.array([False, np.nan, True, True], dtype=np.object_)
+        tm.assert_numpy_array_equal(result, expected)
 
         result = strings.str_contains(values, pat, na=False)
-        expected = [False, False, True, True]
-        tm.assert_almost_equal(result, expected)
+        expected = np.array([False, False, True, True])
+        tm.assert_numpy_array_equal(result, expected)
 
-        values = ['foo', 'xyz', 'fooommm__foo', 'mmm_']
+        values = np.array(['foo', 'xyz', 'fooommm__foo', 'mmm_'],
+                          dtype=np.object_)
         result = strings.str_contains(values, pat)
-        expected = [False, False, True, True]
+        expected = np.array([False, False, True, True])
         self.assertEqual(result.dtype, np.bool_)
-        tm.assert_almost_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         # na
         values = Series(['om', 'foo', np.nan])
@@ -232,13 +240,16 @@ class TestStringMethods(tm.TestCase):
         tm.assert_series_equal(result, exp)
 
         # mixed
-        mixed = ['a', NA, 'b', True, datetime.today(), 'foo', None, 1, 2.]
+        mixed = np.array(['a', NA, 'b', True, datetime.today(),
+                          'foo', None, 1, 2.], dtype=np.object_)
         rs = strings.str_startswith(mixed, 'f')
-        xp = Series([False, NA, False, NA, NA, True, NA, NA, NA])
-        tm.assert_almost_equal(rs, xp)
+        xp = np.array([False, NA, False, NA, NA, True, NA, NA, NA],
+                      dtype=np.object_)
+        tm.assert_numpy_array_equal(rs, xp)
 
         rs = Series(mixed).str.startswith('f')
         tm.assertIsInstance(rs, Series)
+        xp = Series([False, NA, False, NA, NA, True, NA, NA, NA])
         tm.assert_series_equal(rs, xp)
 
         # unicode
@@ -262,10 +273,12 @@ class TestStringMethods(tm.TestCase):
         # mixed
         mixed = ['a', NA, 'b', True, datetime.today(), 'foo', None, 1, 2.]
         rs = strings.str_endswith(mixed, 'f')
-        xp = Series([False, NA, False, NA, NA, False, NA, NA, NA])
-        tm.assert_almost_equal(rs, xp)
+        xp = np.array([False, NA, False, NA, NA, False, NA, NA, NA],
+                      dtype=np.object_)
+        tm.assert_numpy_array_equal(rs, xp)
 
         rs = Series(mixed).str.endswith('f')
+        xp = Series([False, NA, False, NA, NA, False, NA, NA, NA])
         tm.assertIsInstance(rs, Series)
         tm.assert_series_equal(rs, xp)
 
@@ -574,7 +587,12 @@ class TestStringMethods(tm.TestCase):
             s_or_idx = klass(['A1', 'A2'])
             result = s_or_idx.str.extract(r'(?P<uno>A)\d', expand=False)
             self.assertEqual(result.name, 'uno')
-            tm.assert_numpy_array_equal(result, klass(['A', 'A']))
+
+            exp = klass(['A', 'A'], name='uno')
+            if klass == Series:
+                tm.assert_series_equal(result, exp)
+            else:
+                tm.assert_index_equal(result, exp)
 
         s = Series(['A1', 'B2', 'C3'])
         # one group, no matches
@@ -713,8 +731,9 @@ class TestStringMethods(tm.TestCase):
             # single group renames series/index properly
             s_or_idx = klass(['A1', 'A2'])
             result_df = s_or_idx.str.extract(r'(?P<uno>A)\d', expand=True)
+            tm.assertIsInstance(result_df, DataFrame)
             result_series = result_df['uno']
-            tm.assert_numpy_array_equal(result_series, klass(['A', 'A']))
+            assert_series_equal(result_series, Series(['A', 'A'], name='uno'))
 
     def test_extract_series(self):
         # extract should give the same result whether or not the
@@ -1422,41 +1441,48 @@ class TestStringMethods(tm.TestCase):
         tm.assert_series_equal(result, Series([4, np.nan, -1, np.nan, -1]))
 
     def test_index(self):
+
+        def _check(result, expected):
+            if isinstance(result, Series):
+                tm.assert_series_equal(result, expected)
+            else:
+                tm.assert_index_equal(result, expected)
+
         for klass in [Series, Index]:
             s = klass(['ABCDEFG', 'BCDEFEF', 'DEFGHIJEF', 'EFGHEF'])
 
             result = s.str.index('EF')
-            tm.assert_numpy_array_equal(result, klass([4, 3, 1, 0]))
+            _check(result, klass([4, 3, 1, 0]))
             expected = np.array([v.index('EF') for v in s.values],
                                 dtype=np.int64)
             tm.assert_numpy_array_equal(result.values, expected)
 
             result = s.str.rindex('EF')
-            tm.assert_numpy_array_equal(result, klass([4, 5, 7, 4]))
+            _check(result, klass([4, 5, 7, 4]))
             expected = np.array([v.rindex('EF') for v in s.values],
                                 dtype=np.int64)
             tm.assert_numpy_array_equal(result.values, expected)
 
             result = s.str.index('EF', 3)
-            tm.assert_numpy_array_equal(result, klass([4, 3, 7, 4]))
+            _check(result, klass([4, 3, 7, 4]))
             expected = np.array([v.index('EF', 3) for v in s.values],
                                 dtype=np.int64)
             tm.assert_numpy_array_equal(result.values, expected)
 
             result = s.str.rindex('EF', 3)
-            tm.assert_numpy_array_equal(result, klass([4, 5, 7, 4]))
+            _check(result, klass([4, 5, 7, 4]))
             expected = np.array([v.rindex('EF', 3) for v in s.values],
                                 dtype=np.int64)
             tm.assert_numpy_array_equal(result.values, expected)
 
             result = s.str.index('E', 4, 8)
-            tm.assert_numpy_array_equal(result, klass([4, 5, 7, 4]))
+            _check(result, klass([4, 5, 7, 4]))
             expected = np.array([v.index('E', 4, 8) for v in s.values],
                                 dtype=np.int64)
             tm.assert_numpy_array_equal(result.values, expected)
 
             result = s.str.rindex('E', 0, 5)
-            tm.assert_numpy_array_equal(result, klass([4, 3, 1, 4]))
+            _check(result, klass([4, 3, 1, 4]))
             expected = np.array([v.rindex('E', 0, 5) for v in s.values],
                                 dtype=np.int64)
             tm.assert_numpy_array_equal(result.values, expected)
@@ -1471,9 +1497,9 @@ class TestStringMethods(tm.TestCase):
         # test with nan
         s = Series(['abcb', 'ab', 'bcbe', np.nan])
         result = s.str.index('b')
-        tm.assert_numpy_array_equal(result, Series([1, 1, 0, np.nan]))
+        tm.assert_series_equal(result, Series([1, 1, 0, np.nan]))
         result = s.str.rindex('b')
-        tm.assert_numpy_array_equal(result, Series([3, 1, 2, np.nan]))
+        tm.assert_series_equal(result, Series([3, 1, 2, np.nan]))
 
     def test_pad(self):
         values = Series(['a', 'b', NA, 'c', NA, 'eeeeee'])
@@ -1558,6 +1584,13 @@ class TestStringMethods(tm.TestCase):
             result = values.str.pad(5, fillchar=5)
 
     def test_translate(self):
+
+        def _check(result, expected):
+            if isinstance(result, Series):
+                tm.assert_series_equal(result, expected)
+            else:
+                tm.assert_index_equal(result, expected)
+
         for klass in [Series, Index]:
             s = klass(['abcdefg', 'abcc', 'cdddfg', 'cdefggg'])
             if not compat.PY3:
@@ -1567,17 +1600,17 @@ class TestStringMethods(tm.TestCase):
                 table = str.maketrans('abc', 'cde')
             result = s.str.translate(table)
             expected = klass(['cdedefg', 'cdee', 'edddfg', 'edefggg'])
-            tm.assert_numpy_array_equal(result, expected)
+            _check(result, expected)
 
             # use of deletechars is python 2 only
             if not compat.PY3:
                 result = s.str.translate(table, deletechars='fg')
                 expected = klass(['cdede', 'cdee', 'eddd', 'ede'])
-                tm.assert_numpy_array_equal(result, expected)
+                _check(result, expected)
 
                 result = s.str.translate(None, deletechars='fg')
                 expected = klass(['abcde', 'abcc', 'cddd', 'cde'])
-                tm.assert_numpy_array_equal(result, expected)
+                _check(result, expected)
             else:
                 with tm.assertRaisesRegexp(
                         ValueError, "deletechars is not a valid argument"):
@@ -1587,7 +1620,7 @@ class TestStringMethods(tm.TestCase):
         s = Series(['a', 'b', 'c', 1.2])
         expected = Series(['c', 'd', 'e', np.nan])
         result = s.str.translate(table)
-        tm.assert_numpy_array_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_center_ljust_rjust(self):
         values = Series(['a', 'b', NA, 'c', NA, 'eeeeee'])
@@ -1985,8 +2018,8 @@ class TestStringMethods(tm.TestCase):
 
         idx = Index(['some_equal_splits', 'with_no_nans'])
         result = idx.str.rsplit('_', expand=True, n=1)
-        exp = MultiIndex.from_tuples([('some_equal', 'splits'), ('with_no',
-                                                                 'nans')])
+        exp = MultiIndex.from_tuples([('some_equal', 'splits'),
+                                      ('with_no', 'nans')])
         tm.assert_index_equal(result, exp)
         self.assertEqual(result.nlevels, 2)
 
@@ -1996,7 +2029,7 @@ class TestStringMethods(tm.TestCase):
         # should preserve name
         s = Series(['a,b', 'c,d'], name='xxx')
         res = s.str.split(',')
-        exp = Series([('a', 'b'), ('c', 'd')], name='xxx')
+        exp = Series([['a', 'b'], ['c', 'd']], name='xxx')
         tm.assert_series_equal(res, exp)
 
         res = s.str.split(',', expand=True)
@@ -2018,60 +2051,60 @@ class TestStringMethods(tm.TestCase):
         values = Series(['a_b_c', 'c_d_e', NA, 'f_g_h'])
 
         result = values.str.partition('_', expand=False)
-        exp = Series([['a', '_', 'b_c'], ['c', '_', 'd_e'], NA, ['f', '_',
-                                                                 'g_h']])
+        exp = Series([('a', '_', 'b_c'), ('c', '_', 'd_e'), NA,
+                      ('f', '_', 'g_h')])
         tm.assert_series_equal(result, exp)
 
         result = values.str.rpartition('_', expand=False)
-        exp = Series([['a_b', '_', 'c'], ['c_d', '_', 'e'], NA, ['f_g', '_',
-                                                                 'h']])
+        exp = Series([('a_b', '_', 'c'), ('c_d', '_', 'e'), NA,
+                      ('f_g', '_', 'h')])
         tm.assert_series_equal(result, exp)
 
         # more than one char
         values = Series(['a__b__c', 'c__d__e', NA, 'f__g__h'])
         result = values.str.partition('__', expand=False)
-        exp = Series([['a', '__', 'b__c'], ['c', '__', 'd__e'], NA, ['f', '__',
-                                                                     'g__h']])
+        exp = Series([('a', '__', 'b__c'), ('c', '__', 'd__e'), NA,
+                      ('f', '__', 'g__h')])
         tm.assert_series_equal(result, exp)
 
         result = values.str.rpartition('__', expand=False)
-        exp = Series([['a__b', '__', 'c'], ['c__d', '__', 'e'], NA,
-                      ['f__g', '__', 'h']])
+        exp = Series([('a__b', '__', 'c'), ('c__d', '__', 'e'), NA,
+                      ('f__g', '__', 'h')])
         tm.assert_series_equal(result, exp)
 
         # None
         values = Series(['a b c', 'c d e', NA, 'f g h'])
         result = values.str.partition(expand=False)
-        exp = Series([['a', ' ', 'b c'], ['c', ' ', 'd e'], NA, ['f', ' ',
-                                                                 'g h']])
+        exp = Series([('a', ' ', 'b c'), ('c', ' ', 'd e'), NA,
+                      ('f', ' ', 'g h')])
         tm.assert_series_equal(result, exp)
 
         result = values.str.rpartition(expand=False)
-        exp = Series([['a b', ' ', 'c'], ['c d', ' ', 'e'], NA, ['f g', ' ',
-                                                                 'h']])
+        exp = Series([('a b', ' ', 'c'), ('c d', ' ', 'e'), NA,
+                      ('f g', ' ', 'h')])
         tm.assert_series_equal(result, exp)
 
         # Not splited
         values = Series(['abc', 'cde', NA, 'fgh'])
         result = values.str.partition('_', expand=False)
-        exp = Series([['abc', '', ''], ['cde', '', ''], NA, ['fgh', '', '']])
+        exp = Series([('abc', '', ''), ('cde', '', ''), NA, ('fgh', '', '')])
         tm.assert_series_equal(result, exp)
 
         result = values.str.rpartition('_', expand=False)
-        exp = Series([['', '', 'abc'], ['', '', 'cde'], NA, ['', '', 'fgh']])
+        exp = Series([('', '', 'abc'), ('', '', 'cde'), NA, ('', '', 'fgh')])
         tm.assert_series_equal(result, exp)
 
         # unicode
-        values = Series([u('a_b_c'), u('c_d_e'), NA, u('f_g_h')])
+        values = Series([u'a_b_c', u'c_d_e', NA, u'f_g_h'])
 
         result = values.str.partition('_', expand=False)
-        exp = Series([[u('a'), u('_'), u('b_c')], [u('c'), u('_'), u('d_e')],
-                      NA, [u('f'), u('_'), u('g_h')]])
+        exp = Series([(u'a', u'_', u'b_c'), (u'c', u'_', u'd_e'),
+                      NA, (u'f', u'_', u'g_h')])
         tm.assert_series_equal(result, exp)
 
         result = values.str.rpartition('_', expand=False)
-        exp = Series([[u('a_b'), u('_'), u('c')], [u('c_d'), u('_'), u('e')],
-                      NA, [u('f_g'), u('_'), u('h')]])
+        exp = Series([(u'a_b', u'_', u'c'), (u'c_d', u'_', u'e'),
+                      NA, (u'f_g', u'_', u'h')])
         tm.assert_series_equal(result, exp)
 
         # compare to standard lib

--- a/pandas/tests/test_tseries.py
+++ b/pandas/tests/test_tseries.py
@@ -36,7 +36,8 @@ class TestTseriesUtil(tm.TestCase):
 
         filler = algos.backfill_int64(old.values, new.values)
 
-        expect_filler = [0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, -1]
+        expect_filler = np.array([0, 0, 1, 1, 1, 1,
+                                  2, 2, 2, 2, 2, -1], dtype=np.int64)
         self.assert_numpy_array_equal(filler, expect_filler)
 
         # corner case
@@ -44,7 +45,7 @@ class TestTseriesUtil(tm.TestCase):
         new = Index(lrange(5, 10))
         filler = algos.backfill_int64(old.values, new.values)
 
-        expect_filler = [-1, -1, -1, -1, -1]
+        expect_filler = np.array([-1, -1, -1, -1, -1], dtype=np.int64)
         self.assert_numpy_array_equal(filler, expect_filler)
 
     def test_pad(self):
@@ -53,14 +54,15 @@ class TestTseriesUtil(tm.TestCase):
 
         filler = algos.pad_int64(old.values, new.values)
 
-        expect_filler = [-1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2]
+        expect_filler = np.array([-1, 0, 0, 0, 0, 1,
+                                  1, 1, 1, 1, 2, 2], dtype=np.int64)
         self.assert_numpy_array_equal(filler, expect_filler)
 
         # corner case
         old = Index([5, 10])
         new = Index(lrange(5))
         filler = algos.pad_int64(old.values, new.values)
-        expect_filler = [-1, -1, -1, -1, -1]
+        expect_filler = np.array([-1, -1, -1, -1, -1], dtype=np.int64)
         self.assert_numpy_array_equal(filler, expect_filler)
 
 
@@ -113,9 +115,9 @@ def test_inner_join_indexer():
     b = np.array([5], dtype=np.int64)
 
     index, ares, bres = algos.inner_join_indexer_int64(a, b)
-    assert_almost_equal(index, [5])
-    assert_almost_equal(ares, [0])
-    assert_almost_equal(bres, [0])
+    tm.assert_numpy_array_equal(index, np.array([5], dtype=np.int64))
+    tm.assert_numpy_array_equal(ares, np.array([0], dtype=np.int64))
+    tm.assert_numpy_array_equal(bres, np.array([0], dtype=np.int64))
 
 
 def test_outer_join_indexer():
@@ -136,9 +138,9 @@ def test_outer_join_indexer():
     b = np.array([5], dtype=np.int64)
 
     index, ares, bres = algos.outer_join_indexer_int64(a, b)
-    assert_almost_equal(index, [5])
-    assert_almost_equal(ares, [0])
-    assert_almost_equal(bres, [0])
+    tm.assert_numpy_array_equal(index, np.array([5], dtype=np.int64))
+    tm.assert_numpy_array_equal(ares, np.array([0], dtype=np.int64))
+    tm.assert_numpy_array_equal(bres, np.array([0], dtype=np.int64))
 
 
 def test_left_join_indexer():
@@ -158,9 +160,9 @@ def test_left_join_indexer():
     b = np.array([5], dtype=np.int64)
 
     index, ares, bres = algos.left_join_indexer_int64(a, b)
-    assert_almost_equal(index, [5])
-    assert_almost_equal(ares, [0])
-    assert_almost_equal(bres, [0])
+    tm.assert_numpy_array_equal(index, np.array([5], dtype=np.int64))
+    tm.assert_numpy_array_equal(ares, np.array([0], dtype=np.int64))
+    tm.assert_numpy_array_equal(bres, np.array([0], dtype=np.int64))
 
 
 def test_left_join_indexer2():
@@ -494,8 +496,8 @@ def test_group_ohlc():
         bins = np.array([6, 12, 20])
         out = np.zeros((3, 4), dtype)
         counts = np.zeros(len(out), dtype=np.int64)
-        labels = com._ensure_int64(np.repeat(
-            np.arange(3), np.diff(np.r_[0, bins])))
+        labels = com._ensure_int64(np.repeat(np.arange(3),
+                                             np.diff(np.r_[0, bins])))
 
         func = getattr(algos, 'group_ohlc_%s' % dtype)
         func(out, counts, obj[:, None], labels)
@@ -505,11 +507,12 @@ def test_group_ohlc():
                 return np.repeat(nan, 4)
             return [group[0], group.max(), group.min(), group[-1]]
 
-        expected = np.array([_ohlc(obj[:6]), _ohlc(obj[6:12]), _ohlc(obj[12:])
-                             ])
+        expected = np.array([_ohlc(obj[:6]), _ohlc(obj[6:12]),
+                             _ohlc(obj[12:])])
 
         assert_almost_equal(out, expected)
-        assert_almost_equal(counts, [6, 6, 8])
+        tm.assert_numpy_array_equal(counts,
+                                    np.array([6, 6, 8], dtype=np.int64))
 
         obj[:6] = nan
         func(out, counts, obj[:, None], labels)

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -12,10 +12,6 @@ from distutils.version import LooseVersion
 import pandas as pd
 from pandas import (Series, DataFrame, Panel, bdate_range, isnull,
                     notnull, concat)
-from pandas.util.testing import (assert_almost_equal, assert_series_equal,
-                                 assert_frame_equal, assert_panel_equal,
-                                 assert_index_equal, assert_numpy_array_equal,
-                                 slow)
 import pandas.core.datetools as datetools
 import pandas.stats.moments as mom
 import pandas.core.window as rwindow
@@ -25,6 +21,13 @@ import pandas.util.testing as tm
 from pandas.compat import range, zip, PY3
 
 N, K = 100, 10
+
+
+def assert_equal(left, right):
+    if isinstance(left, Series):
+        tm.assert_series_equal(left, right)
+    else:
+        tm.assert_frame_equal(left, right)
 
 
 class Base(tm.TestCase):
@@ -94,11 +97,11 @@ class TestApi(Base):
         expected = DataFrame({'A': [np.nan, np.nan, 3, 6, 9],
                               'B': [np.nan, np.nan, 18, 21, 24]},
                              columns=list('AB'))
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         expected = pd.concat([r[['A', 'B']].sum(), df[['C']]], axis=1)
         result = r.sum()
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_agg(self):
         df = DataFrame({'A': range(5), 'B': range(0, 10, 2)})
@@ -115,50 +118,51 @@ class TestApi(Base):
         expected = pd.concat([a_mean, a_std, b_mean, b_std], axis=1)
         expected.columns = pd.MultiIndex.from_product([['A', 'B'], ['mean',
                                                                     'std']])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = r.aggregate({'A': np.mean, 'B': np.std})
 
         expected = pd.concat([a_mean, b_std], axis=1)
-        assert_frame_equal(result, expected, check_like=True)
+        tm.assert_frame_equal(result, expected, check_like=True)
 
         result = r.aggregate({'A': ['mean', 'std']})
         expected = pd.concat([a_mean, a_std], axis=1)
         expected.columns = pd.MultiIndex.from_tuples([('A', 'mean'), ('A',
                                                                       'std')])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = r['A'].aggregate(['mean', 'sum'])
         expected = pd.concat([a_mean, a_sum], axis=1)
         expected.columns = ['mean', 'sum']
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = r.aggregate({'A': {'mean': 'mean', 'sum': 'sum'}})
         expected = pd.concat([a_mean, a_sum], axis=1)
-        expected.columns = pd.MultiIndex.from_tuples([('A', 'mean'), ('A',
-                                                                      'sum')])
-        assert_frame_equal(result, expected, check_like=True)
+        expected.columns = pd.MultiIndex.from_tuples([('A', 'mean'),
+                                                      ('A', 'sum')])
+        tm.assert_frame_equal(result, expected, check_like=True)
 
         result = r.aggregate({'A': {'mean': 'mean',
                                     'sum': 'sum'},
                               'B': {'mean2': 'mean',
                                     'sum2': 'sum'}})
         expected = pd.concat([a_mean, a_sum, b_mean, b_sum], axis=1)
-        expected.columns = pd.MultiIndex.from_tuples([('A', 'mean'), (
-            'A', 'sum'), ('B', 'mean2'), ('B', 'sum2')])
-        assert_frame_equal(result, expected, check_like=True)
+        exp_cols = [('A', 'mean'), ('A', 'sum'), ('B', 'mean2'), ('B', 'sum2')]
+        expected.columns = pd.MultiIndex.from_tuples(exp_cols)
+        tm.assert_frame_equal(result, expected, check_like=True)
 
         result = r.aggregate({'A': ['mean', 'std'], 'B': ['mean', 'std']})
         expected = pd.concat([a_mean, a_std, b_mean, b_std], axis=1)
-        expected.columns = pd.MultiIndex.from_tuples([('A', 'mean'), (
-            'A', 'std'), ('B', 'mean'), ('B', 'std')])
-        assert_frame_equal(result, expected, check_like=True)
+
+        exp_cols = [('A', 'mean'), ('A', 'std'), ('B', 'mean'), ('B', 'std')]
+        expected.columns = pd.MultiIndex.from_tuples(exp_cols)
+        tm.assert_frame_equal(result, expected, check_like=True)
 
         # passed lambda
         result = r.agg({'A': np.sum, 'B': lambda x: np.std(x, ddof=1)})
         rcustom = r['B'].apply(lambda x: np.std(x, ddof=1))
         expected = pd.concat([a_sum, rcustom], axis=1)
-        assert_frame_equal(result, expected, check_like=True)
+        tm.assert_frame_equal(result, expected, check_like=True)
 
     def test_agg_consistency(self):
 
@@ -195,13 +199,13 @@ class TestApi(Base):
             'ra', 'std'), ('rb', 'mean'), ('rb', 'std')])
         result = r[['A', 'B']].agg({'A': {'ra': ['mean', 'std']},
                                     'B': {'rb': ['mean', 'std']}})
-        assert_frame_equal(result, expected, check_like=True)
+        tm.assert_frame_equal(result, expected, check_like=True)
 
         result = r.agg({'A': {'ra': ['mean', 'std']},
                         'B': {'rb': ['mean', 'std']}})
         expected.columns = pd.MultiIndex.from_tuples([('A', 'ra', 'mean'), (
             'A', 'ra', 'std'), ('B', 'rb', 'mean'), ('B', 'rb', 'std')])
-        assert_frame_equal(result, expected, check_like=True)
+        tm.assert_frame_equal(result, expected, check_like=True)
 
     def test_window_with_args(self):
         tm._skip_if_no_scipy()
@@ -213,7 +217,7 @@ class TestApi(Base):
         expected.columns = ['<lambda>', '<lambda>']
         result = r.aggregate([lambda x: x.mean(std=10),
                               lambda x: x.mean(std=.01)])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         def a(x):
             return x.mean(std=10)
@@ -224,7 +228,7 @@ class TestApi(Base):
         expected = pd.concat([r.mean(std=10), r.mean(std=.01)], axis=1)
         expected.columns = ['a', 'b']
         result = r.aggregate([a, b])
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_preserve_metadata(self):
         # GH 10565
@@ -262,7 +266,7 @@ class TestApi(Base):
 
                         expected = getattr(
                             getattr(s, t)(freq='D', **kwargs), op)(how=how)
-                        assert_series_equal(result, expected)
+                        tm.assert_series_equal(result, expected)
 
 
 class TestWindow(Base):
@@ -555,7 +559,7 @@ class Dtype(object):
     def check_dtypes(self, f, f_name, d, d_name, exp):
         roll = d.rolling(window=self.window)
         result = f(roll)
-        assert_almost_equal(result, exp)
+        tm.assert_almost_equal(result, exp)
 
 
 class TestDtype_object(Dtype):
@@ -642,7 +646,7 @@ class DatetimeLike(Dtype):
 
         if f_name == 'count':
             result = f(roll)
-            assert_almost_equal(result, exp)
+            tm.assert_almost_equal(result, exp)
 
         else:
 
@@ -714,11 +718,11 @@ class TestMoments(Base):
 
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             rs = mom.rolling_mean(vals, 5, center=True)
-            assert_almost_equal(xp, rs)
+            tm.assert_almost_equal(xp, rs)
 
         xp = Series(rs)
         rs = Series(vals).rolling(5, center=True).mean()
-        assert_series_equal(xp, rs)
+        tm.assert_series_equal(xp, rs)
 
     def test_cmov_window(self):
         # GH 8238
@@ -731,11 +735,11 @@ class TestMoments(Base):
 
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             rs = mom.rolling_window(vals, 5, 'boxcar', center=True)
-            assert_almost_equal(xp, rs)
+            tm.assert_almost_equal(xp, rs)
 
         xp = Series(rs)
         rs = Series(vals).rolling(5, win_type='boxcar', center=True).mean()
-        assert_series_equal(xp, rs)
+        tm.assert_series_equal(xp, rs)
 
     def test_cmov_window_corner(self):
         # GH 8238
@@ -777,7 +781,7 @@ class TestMoments(Base):
 
         # DataFrame
         rs = DataFrame(vals).rolling(5, win_type='boxcar', center=True).mean()
-        assert_frame_equal(DataFrame(xp), rs)
+        tm.assert_frame_equal(DataFrame(xp), rs)
 
         # invalid method
         with self.assertRaises(AttributeError):
@@ -791,7 +795,7 @@ class TestMoments(Base):
                                                         ], [np.nan, np.nan]])
 
         rs = DataFrame(vals).rolling(5, win_type='boxcar', center=True).sum()
-        assert_frame_equal(DataFrame(xp), rs)
+        tm.assert_frame_equal(DataFrame(xp), rs)
 
     def test_cmov_window_na_min_periods(self):
         tm._skip_if_no_scipy()
@@ -804,7 +808,7 @@ class TestMoments(Base):
         xp = vals.rolling(5, min_periods=4, center=True).mean()
         rs = vals.rolling(5, win_type='boxcar', min_periods=4,
                           center=True).mean()
-        assert_series_equal(xp, rs)
+        tm.assert_series_equal(xp, rs)
 
     def test_cmov_window_regular(self):
         # GH 8238
@@ -837,7 +841,7 @@ class TestMoments(Base):
         for wt in win_types:
             xp = Series(xps[wt])
             rs = Series(vals).rolling(5, win_type=wt, center=True).mean()
-            assert_series_equal(xp, rs)
+            tm.assert_series_equal(xp, rs)
 
     def test_cmov_window_regular_linear_range(self):
         # GH 8238
@@ -854,7 +858,7 @@ class TestMoments(Base):
 
         for wt in win_types:
             rs = Series(vals).rolling(5, win_type=wt, center=True).mean()
-            assert_series_equal(xp, rs)
+            tm.assert_series_equal(xp, rs)
 
     def test_cmov_window_regular_missing_data(self):
         # GH 8238
@@ -887,7 +891,7 @@ class TestMoments(Base):
         for wt in win_types:
             xp = Series(xps[wt])
             rs = Series(vals).rolling(5, win_type=wt, min_periods=3).mean()
-            assert_series_equal(xp, rs)
+            tm.assert_series_equal(xp, rs)
 
     def test_cmov_window_special(self):
         # GH 8238
@@ -914,7 +918,7 @@ class TestMoments(Base):
         for wt, k in zip(win_types, kwds):
             xp = Series(xps[wt])
             rs = Series(vals).rolling(5, win_type=wt, center=True).mean(**k)
-            assert_series_equal(xp, rs)
+            tm.assert_series_equal(xp, rs)
 
     def test_cmov_window_special_linear_range(self):
         # GH 8238
@@ -932,7 +936,7 @@ class TestMoments(Base):
 
         for wt, k in zip(win_types, kwds):
             rs = Series(vals).rolling(5, win_type=wt, center=True).mean(**k)
-            assert_series_equal(xp, rs)
+            tm.assert_series_equal(xp, rs)
 
     def test_rolling_median(self):
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
@@ -946,7 +950,7 @@ class TestMoments(Base):
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             a = np.array([1, 2, 3, 4, 5])
             b = mom.rolling_min(a, window=100, min_periods=1)
-            assert_almost_equal(b, np.ones(len(a)))
+            tm.assert_almost_equal(b, np.ones(len(a)))
 
             self.assertRaises(ValueError, mom.rolling_min, np.array([1, 2, 3]),
                               window=3, min_periods=5)
@@ -958,7 +962,7 @@ class TestMoments(Base):
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             a = np.array([1, 2, 3, 4, 5], dtype=np.float64)
             b = mom.rolling_max(a, window=100, min_periods=1)
-            assert_almost_equal(a, b)
+            tm.assert_almost_equal(a, b)
 
             self.assertRaises(ValueError, mom.rolling_max, np.array([1, 2, 3]),
                               window=3, min_periods=5)
@@ -994,7 +998,8 @@ class TestMoments(Base):
                                     category=RuntimeWarning)
 
             ser = Series([])
-            assert_series_equal(ser, ser.rolling(10).apply(lambda x: x.mean()))
+            tm.assert_series_equal(ser,
+                                   ser.rolling(10).apply(lambda x: x.mean()))
 
             f = lambda x: x[np.isfinite(x)].mean()
 
@@ -1010,10 +1015,10 @@ class TestMoments(Base):
         s = Series([None, None, None])
         result = s.rolling(2, min_periods=0).apply(lambda x: len(x))
         expected = Series([1., 2., 2.])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = s.rolling(2, min_periods=0).apply(len)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_rolling_apply_out_of_bounds(self):
         # #1850
@@ -1026,7 +1031,7 @@ class TestMoments(Base):
 
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             result = mom.rolling_apply(arr, 10, np.sum, min_periods=1)
-        assert_almost_equal(result, result)
+        tm.assert_almost_equal(result, result)
 
     def test_rolling_std(self):
         self._check_moment_func(mom.rolling_std, lambda x: np.std(x, ddof=1),
@@ -1039,13 +1044,13 @@ class TestMoments(Base):
             result = mom.rolling_std(np.array([1., 2., 3., 4., 5.]),
                                      1, min_periods=1)
         expected = np.array([np.nan] * 5)
-        assert_almost_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             result = mom.rolling_std(np.array([1., 2., 3., 4., 5.]),
                                      1, min_periods=1, ddof=0)
         expected = np.zeros(5)
-        assert_almost_equal(result, expected)
+        tm.assert_almost_equal(result, expected)
 
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             result = mom.rolling_std(np.array([np.nan, np.nan, 3., 4., 5.]),
@@ -1159,7 +1164,7 @@ class TestMoments(Base):
                      kwargs)
 
         result = get_result(self.arr, window)
-        assert_almost_equal(result[-1], static_comp(self.arr[-50:]))
+        tm.assert_almost_equal(result[-1], static_comp(self.arr[-50:]))
 
         if preserve_nan:
             assert (np.isnan(result[self._nan_locs]).all())
@@ -1171,7 +1176,7 @@ class TestMoments(Base):
 
         if has_min_periods:
             result = get_result(arr, 50, min_periods=30)
-            assert_almost_equal(result[-1], static_comp(arr[10:-10]))
+            tm.assert_almost_equal(result[-1], static_comp(arr[10:-10]))
 
             # min_periods is working correctly
             result = get_result(arr, 20, min_periods=15)
@@ -1189,10 +1194,10 @@ class TestMoments(Base):
             # min_periods=0
             result0 = get_result(arr, 20, min_periods=0)
             result1 = get_result(arr, 20, min_periods=1)
-            assert_almost_equal(result0, result1)
+            tm.assert_almost_equal(result0, result1)
         else:
             result = get_result(arr, 50)
-            assert_almost_equal(result[-1], static_comp(arr[10:-10]))
+            tm.assert_almost_equal(result[-1], static_comp(arr[10:-10]))
 
         # GH 7925
         if has_center:
@@ -1210,7 +1215,8 @@ class TestMoments(Base):
 
         if test_stable:
             result = get_result(self.arr + 1e9, window)
-            assert_almost_equal(result[-1], static_comp(self.arr[-50:] + 1e9))
+            tm.assert_almost_equal(result[-1],
+                                   static_comp(self.arr[-50:] + 1e9))
 
         # Test window larger than array, #7297
         if test_window:
@@ -1224,14 +1230,15 @@ class TestMoments(Base):
                     self.assertTrue(np.array_equal(nan_mask, np.isnan(
                         expected)))
                     nan_mask = ~nan_mask
-                    assert_almost_equal(result[nan_mask], expected[nan_mask])
+                    tm.assert_almost_equal(result[nan_mask],
+                                           expected[nan_mask])
             else:
                 result = get_result(self.arr, len(self.arr) + 1)
                 expected = get_result(self.arr, len(self.arr))
                 nan_mask = np.isnan(result)
                 self.assertTrue(np.array_equal(nan_mask, np.isnan(expected)))
                 nan_mask = ~nan_mask
-                assert_almost_equal(result[nan_mask], expected[nan_mask])
+                tm.assert_almost_equal(result[nan_mask], expected[nan_mask])
 
     def _check_structures(self, f, static_comp, name=None,
                           has_min_periods=True, has_time_rule=True,
@@ -1283,11 +1290,12 @@ class TestMoments(Base):
             trunc_series = self.series[::2].truncate(prev_date, last_date)
             trunc_frame = self.frame[::2].truncate(prev_date, last_date)
 
-            assert_almost_equal(series_result[-1], static_comp(trunc_series))
+            self.assertAlmostEqual(series_result[-1],
+                                   static_comp(trunc_series))
 
-            assert_series_equal(frame_result.xs(last_date),
-                                trunc_frame.apply(static_comp),
-                                check_names=False)
+            tm.assert_series_equal(frame_result.xs(last_date),
+                                   trunc_frame.apply(static_comp),
+                                   check_names=False)
 
         # GH 7925
         if has_center:
@@ -1326,8 +1334,8 @@ class TestMoments(Base):
             if fill_value is not None:
                 series_xp = series_xp.fillna(fill_value)
                 frame_xp = frame_xp.fillna(fill_value)
-            assert_series_equal(series_xp, series_rs)
-            assert_frame_equal(frame_xp, frame_rs)
+            tm.assert_series_equal(series_xp, series_rs)
+            tm.assert_frame_equal(frame_xp, frame_rs)
 
     def test_ewma(self):
         self._check_ew(mom.ewma, name='mean')
@@ -1347,7 +1355,7 @@ class TestMoments(Base):
                   lambda s: s.ewm(com=2.0, adjust=True, ignore_na=True).mean(),
                   ]:
             result = f(s)
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
         expected = Series([1.0, 1.333333, 2.222222, 4.148148])
         for f in [lambda s: s.ewm(com=2.0, adjust=False).mean(),
@@ -1357,7 +1365,7 @@ class TestMoments(Base):
                                   ignore_na=True).mean(),
                   ]:
             result = f(s)
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
     def test_ewma_nan_handling(self):
         s = Series([1.] + [np.nan] * 5 + [1.])
@@ -1408,11 +1416,11 @@ class TestMoments(Base):
             expected = simple_wma(s, Series(w))
             result = s.ewm(com=com, adjust=adjust, ignore_na=ignore_na).mean()
 
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
             if ignore_na is False:
                 # check that ignore_na defaults to False
                 result = s.ewm(com=com, adjust=adjust).mean()
-                assert_series_equal(result, expected)
+                tm.assert_series_equal(result, expected)
 
     def test_ewmvar(self):
         self._check_ew(mom.ewmvar, name='var')
@@ -1424,7 +1432,7 @@ class TestMoments(Base):
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             A = mom.ewma(self.arr, com=9.5)
             B = mom.ewma(self.arr, span=20)
-            assert_almost_equal(A, B)
+            tm.assert_almost_equal(A, B)
 
             self.assertRaises(ValueError, mom.ewma, self.arr, com=9.5, span=20)
             self.assertRaises(ValueError, mom.ewma, self.arr)
@@ -1433,7 +1441,7 @@ class TestMoments(Base):
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             A = mom.ewma(self.arr, com=13.932726172912965)
             B = mom.ewma(self.arr, halflife=10.0)
-            assert_almost_equal(A, B)
+            tm.assert_almost_equal(A, B)
 
             self.assertRaises(ValueError, mom.ewma, self.arr, span=20,
                               halflife=50)
@@ -1450,9 +1458,9 @@ class TestMoments(Base):
             b = mom.ewma(self.arr, com=0.62014947789973052)
             c = mom.ewma(self.arr, span=2.240298955799461)
             d = mom.ewma(self.arr, halflife=0.721792864318)
-            assert_numpy_array_equal(a, b)
-            assert_numpy_array_equal(a, c)
-            assert_numpy_array_equal(a, d)
+            tm.assert_numpy_array_equal(a, b)
+            tm.assert_numpy_array_equal(a, c)
+            tm.assert_numpy_array_equal(a, d)
 
     def test_ewma_alpha_arg_old_api(self):
         # GH 10789
@@ -1472,9 +1480,9 @@ class TestMoments(Base):
         b = s.ewm(com=0.62014947789973052).mean()
         c = s.ewm(span=2.240298955799461).mean()
         d = s.ewm(halflife=0.721792864318).mean()
-        assert_series_equal(a, b)
-        assert_series_equal(a, c)
-        assert_series_equal(a, d)
+        tm.assert_series_equal(a, b)
+        tm.assert_series_equal(a, c)
+        tm.assert_series_equal(a, d)
 
     def test_ewm_alpha_arg(self):
         # GH 10789
@@ -1516,7 +1524,7 @@ class TestMoments(Base):
             with tm.assert_produces_warning(FutureWarning,
                                             check_stacklevel=False):
                 result = f(arr, 3)
-            assert_almost_equal(result, arr)
+            tm.assert_almost_equal(result, arr)
 
     def _check_ew(self, func, name=None):
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
@@ -1553,16 +1561,16 @@ class TestMoments(Base):
 
             # check series of length 0
             result = func(Series([]), 50, min_periods=min_periods)
-            assert_series_equal(result, Series([]))
+            tm.assert_series_equal(result, Series([]))
 
             # check series of length 1
             result = func(Series([1.]), 50, min_periods=min_periods)
             if func == mom.ewma:
-                assert_series_equal(result, Series([1.]))
+                tm.assert_series_equal(result, Series([1.]))
             else:
                 # ewmstd, ewmvol, ewmvar with bias=False require at least two
                 # values
-                assert_series_equal(result, Series([np.NaN]))
+                tm.assert_series_equal(result, Series([np.NaN]))
 
         # pass in ints
         result2 = func(np.arange(50), span=10)
@@ -1694,8 +1702,6 @@ class TestMomentsConsistency(Base):
             return set(values[notnull(values)].tolist())
 
         for (x, is_constant, no_nans) in self.data:
-            assert_equal = assert_series_equal if isinstance(
-                x, Series) else assert_frame_equal
             count_x = count(x)
             mean_x = mean(x)
 
@@ -1800,7 +1806,7 @@ class TestMomentsConsistency(Base):
                                 assert_equal(cov_x_y, mean_x_times_y -
                                              (mean_x * mean_y))
 
-    @slow
+    @tm.slow
     def test_ewm_consistency(self):
         def _weights(s, com, adjust, ignore_na):
             if isinstance(s, DataFrame):
@@ -1899,7 +1905,7 @@ class TestMomentsConsistency(Base):
                     _variance_debiasing_factors(x, com=com, adjust=adjust,
                                                 ignore_na=ignore_na)))
 
-    @slow
+    @tm.slow
     def test_expanding_consistency(self):
 
         # suppress warnings about empty slices, as we are deliberately testing
@@ -1942,8 +1948,6 @@ class TestMomentsConsistency(Base):
                 # expanding_apply of Series.xyz(), or (b) expanding_apply of
                 # np.nanxyz()
                 for (x, is_constant, no_nans) in self.data:
-                    assert_equal = assert_series_equal if isinstance(
-                        x, Series) else assert_frame_equal
                     functions = self.base_functions
 
                     # GH 8269
@@ -1988,9 +1992,9 @@ class TestMomentsConsistency(Base):
                                         x.iloc[:, i].expanding(
                                             min_periods=min_periods),
                                         name)(x.iloc[:, j])
-                            assert_panel_equal(expanding_f_result, expected)
+                            tm.assert_panel_equal(expanding_f_result, expected)
 
-    @slow
+    @tm.slow
     def test_rolling_consistency(self):
 
         # suppress warnings about empty slices, as we are deliberately testing
@@ -2062,10 +2066,6 @@ class TestMomentsConsistency(Base):
                 # rolling_apply of Series.xyz(), or (b) rolling_apply of
                 # np.nanxyz()
                 for (x, is_constant, no_nans) in self.data:
-
-                    assert_equal = (assert_series_equal
-                                    if isinstance(x, Series) else
-                                    assert_frame_equal)
                     functions = self.base_functions
 
                     # GH 8269
@@ -2116,7 +2116,7 @@ class TestMomentsConsistency(Base):
                                                      min_periods=min_periods,
                                                      center=center),
                                             name)(x.iloc[:, j]))
-                            assert_panel_equal(rolling_f_result, expected)
+                            tm.assert_panel_equal(rolling_f_result, expected)
 
     # binary moments
     def test_rolling_cov(self):
@@ -2124,7 +2124,7 @@ class TestMomentsConsistency(Base):
         B = A + randn(len(A))
 
         result = A.rolling(window=50, min_periods=25).cov(B)
-        assert_almost_equal(result[-1], np.cov(A[-50:], B[-50:])[0, 1])
+        tm.assert_almost_equal(result[-1], np.cov(A[-50:], B[-50:])[0, 1])
 
     def test_rolling_cov_pairwise(self):
         self._check_pairwise_moment('rolling', 'cov', window=10, min_periods=5)
@@ -2134,7 +2134,7 @@ class TestMomentsConsistency(Base):
         B = A + randn(len(A))
 
         result = A.rolling(window=50, min_periods=25).corr(B)
-        assert_almost_equal(result[-1], np.corrcoef(A[-50:], B[-50:])[0, 1])
+        tm.assert_almost_equal(result[-1], np.corrcoef(A[-50:], B[-50:])[0, 1])
 
         # test for correct bias correction
         a = tm.makeTimeSeries()
@@ -2143,7 +2143,7 @@ class TestMomentsConsistency(Base):
         b[:10] = np.nan
 
         result = a.rolling(window=len(a), min_periods=1).corr(b)
-        assert_almost_equal(result[-1], a.corr(b))
+        tm.assert_almost_equal(result[-1], a.corr(b))
 
     def test_rolling_corr_pairwise(self):
         self._check_pairwise_moment('rolling', 'corr', window=10,
@@ -2244,18 +2244,18 @@ class TestMomentsConsistency(Base):
 
             # check series of length 0
             result = func(Series([]), Series([]), 50, min_periods=min_periods)
-            assert_series_equal(result, Series([]))
+            tm.assert_series_equal(result, Series([]))
 
             # check series of length 1
             result = func(
                 Series([1.]), Series([1.]), 50, min_periods=min_periods)
-            assert_series_equal(result, Series([np.NaN]))
+            tm.assert_series_equal(result, Series([np.NaN]))
 
         self.assertRaises(Exception, func, A, randn(50), 20, min_periods=5)
 
     def test_expanding_apply(self):
         ser = Series([])
-        assert_series_equal(ser, ser.expanding().apply(lambda x: x.mean()))
+        tm.assert_series_equal(ser, ser.expanding().apply(lambda x: x.mean()))
 
         def expanding_mean(x, min_periods=1, freq=None):
             return mom.expanding_apply(x, lambda x: x.mean(),
@@ -2267,7 +2267,7 @@ class TestMomentsConsistency(Base):
         s = Series([None, None, None])
         result = s.expanding(min_periods=0).apply(lambda x: len(x))
         expected = Series([1., 2., 3.])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_expanding_apply_args_kwargs(self):
         def mean_w_arg(x, const):
@@ -2277,11 +2277,11 @@ class TestMomentsConsistency(Base):
 
         expected = df.expanding().apply(np.mean) + 20.
 
-        assert_frame_equal(df.expanding().apply(mean_w_arg, args=(20, )),
-                           expected)
-        assert_frame_equal(df.expanding().apply(mean_w_arg,
-                                                kwargs={'const': 20}),
-                           expected)
+        tm.assert_frame_equal(df.expanding().apply(mean_w_arg, args=(20, )),
+                              expected)
+        tm.assert_frame_equal(df.expanding().apply(mean_w_arg,
+                                                   kwargs={'const': 20}),
+                              expected)
 
     def test_expanding_corr(self):
         A = self.series.dropna()
@@ -2291,11 +2291,11 @@ class TestMomentsConsistency(Base):
 
         rolling_result = A.rolling(window=len(A), min_periods=1).corr(B)
 
-        assert_almost_equal(rolling_result, result)
+        tm.assert_almost_equal(rolling_result, result)
 
     def test_expanding_count(self):
         result = self.series.expanding().count()
-        assert_almost_equal(result, self.series.rolling(
+        tm.assert_almost_equal(result, self.series.rolling(
             window=len(self.series)).count())
 
     def test_expanding_quantile(self):
@@ -2304,7 +2304,7 @@ class TestMomentsConsistency(Base):
         rolling_result = self.series.rolling(window=len(self.series),
                                              min_periods=1).quantile(0.5)
 
-        assert_almost_equal(result, rolling_result)
+        tm.assert_almost_equal(result, rolling_result)
 
     def test_expanding_cov(self):
         A = self.series
@@ -2314,7 +2314,7 @@ class TestMomentsConsistency(Base):
 
         rolling_result = A.rolling(window=len(A), min_periods=1).cov(B)
 
-        assert_almost_equal(rolling_result, result)
+        tm.assert_almost_equal(rolling_result, result)
 
     def test_expanding_max(self):
         self._check_expanding(mom.expanding_max, np.max, preserve_nan=False)
@@ -2326,7 +2326,7 @@ class TestMomentsConsistency(Base):
                                             min_periods=1).corr()
 
         for i in result.items:
-            assert_almost_equal(result[i], rolling_result[i])
+            tm.assert_almost_equal(result[i], rolling_result[i])
 
     def test_expanding_corr_pairwise(self):
         result = self.frame.expanding().corr()
@@ -2335,7 +2335,7 @@ class TestMomentsConsistency(Base):
                                             min_periods=1).corr()
 
         for i in result.items:
-            assert_almost_equal(result[i], rolling_result[i])
+            tm.assert_almost_equal(result[i], rolling_result[i])
 
     def test_expanding_cov_diff_index(self):
         # GH 7512
@@ -2343,17 +2343,17 @@ class TestMomentsConsistency(Base):
         s2 = Series([1, 3], index=[0, 2])
         result = s1.expanding().cov(s2)
         expected = Series([None, None, 2.0])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s2a = Series([1, None, 3], index=[0, 1, 2])
         result = s1.expanding().cov(s2a)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s1 = Series([7, 8, 10], index=[0, 1, 3])
         s2 = Series([7, 9, 10], index=[0, 2, 3])
         result = s1.expanding().cov(s2)
         expected = Series([None, None, None, 4.5])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_expanding_corr_diff_index(self):
         # GH 7512
@@ -2361,17 +2361,17 @@ class TestMomentsConsistency(Base):
         s2 = Series([1, 3], index=[0, 2])
         result = s1.expanding().corr(s2)
         expected = Series([None, None, 1.0])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s2a = Series([1, None, 3], index=[0, 1, 2])
         result = s1.expanding().corr(s2a)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s1 = Series([7, 8, 10], index=[0, 1, 3])
         s2 = Series([7, 9, 10], index=[0, 2, 3])
         result = s1.expanding().corr(s2)
         expected = Series([None, None, None, 1.])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_rolling_cov_diff_length(self):
         # GH 7512
@@ -2379,11 +2379,11 @@ class TestMomentsConsistency(Base):
         s2 = Series([1, 3], index=[0, 2])
         result = s1.rolling(window=3, min_periods=2).cov(s2)
         expected = Series([None, None, 2.0])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s2a = Series([1, None, 3], index=[0, 1, 2])
         result = s1.rolling(window=3, min_periods=2).cov(s2a)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_rolling_corr_diff_length(self):
         # GH 7512
@@ -2391,11 +2391,11 @@ class TestMomentsConsistency(Base):
         s2 = Series([1, 3], index=[0, 2])
         result = s1.rolling(window=3, min_periods=2).corr(s2)
         expected = Series([None, None, 1.0])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s2a = Series([1, None, 3], index=[0, 1, 2])
         result = s1.rolling(window=3, min_periods=2).corr(s2a)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_rolling_functions_window_non_shrinkage(self):
         # GH 7764
@@ -2427,10 +2427,10 @@ class TestMomentsConsistency(Base):
         for f in functions:
             try:
                 s_result = f(s)
-                assert_series_equal(s_result, s_expected)
+                tm.assert_series_equal(s_result, s_expected)
 
                 df_result = f(df)
-                assert_frame_equal(df_result, df_expected)
+                tm.assert_frame_equal(df_result, df_expected)
             except (ImportError):
 
                 # scipy needed for rolling_window
@@ -2442,7 +2442,7 @@ class TestMomentsConsistency(Base):
                                 .corr(x, pairwise=True))]
         for f in functions:
             df_result_panel = f(df)
-            assert_panel_equal(df_result_panel, df_expected_panel)
+            tm.assert_panel_equal(df_result_panel, df_expected_panel)
 
     def test_moment_functions_zero_length(self):
         # GH 8056
@@ -2497,13 +2497,13 @@ class TestMomentsConsistency(Base):
         for f in functions:
             try:
                 s_result = f(s)
-                assert_series_equal(s_result, s_expected)
+                tm.assert_series_equal(s_result, s_expected)
 
                 df1_result = f(df1)
-                assert_frame_equal(df1_result, df1_expected)
+                tm.assert_frame_equal(df1_result, df1_expected)
 
                 df2_result = f(df2)
-                assert_frame_equal(df2_result, df2_expected)
+                tm.assert_frame_equal(df2_result, df2_expected)
             except (ImportError):
 
                 # scipy needed for rolling_window
@@ -2520,10 +2520,10 @@ class TestMomentsConsistency(Base):
                      ]
         for f in functions:
             df1_result_panel = f(df1)
-            assert_panel_equal(df1_result_panel, df1_expected_panel)
+            tm.assert_panel_equal(df1_result_panel, df1_expected_panel)
 
             df2_result_panel = f(df2)
-            assert_panel_equal(df2_result_panel, df2_expected_panel)
+            tm.assert_panel_equal(df2_result_panel, df2_expected_panel)
 
     def test_expanding_cov_pairwise_diff_length(self):
         # GH 7512
@@ -2537,10 +2537,10 @@ class TestMomentsConsistency(Base):
         result4 = df1a.expanding().cov(df2a, pairwise=True)[2]
         expected = DataFrame([[-3., -5.], [-6., -10.]], index=['A', 'B'],
                              columns=['X', 'Y'])
-        assert_frame_equal(result1, expected)
-        assert_frame_equal(result2, expected)
-        assert_frame_equal(result3, expected)
-        assert_frame_equal(result4, expected)
+        tm.assert_frame_equal(result1, expected)
+        tm.assert_frame_equal(result2, expected)
+        tm.assert_frame_equal(result3, expected)
+        tm.assert_frame_equal(result4, expected)
 
     def test_expanding_corr_pairwise_diff_length(self):
         # GH 7512
@@ -2554,35 +2554,29 @@ class TestMomentsConsistency(Base):
         result4 = df1a.expanding().corr(df2a, pairwise=True)[2]
         expected = DataFrame([[-1.0, -1.0], [-1.0, -1.0]], index=['A', 'B'],
                              columns=['X', 'Y'])
-        assert_frame_equal(result1, expected)
-        assert_frame_equal(result2, expected)
-        assert_frame_equal(result3, expected)
-        assert_frame_equal(result4, expected)
+        tm.assert_frame_equal(result1, expected)
+        tm.assert_frame_equal(result2, expected)
+        tm.assert_frame_equal(result3, expected)
+        tm.assert_frame_equal(result4, expected)
 
     def test_pairwise_stats_column_names_order(self):
         # GH 7738
         df1s = [DataFrame([[2, 4], [1, 2], [5, 2], [8, 1]], columns=[0, 1]),
-                DataFrame(
-                    [[2, 4], [1, 2], [5, 2], [8, 1]], columns=[1, 0]),
-                DataFrame(
-                    [[2, 4], [1, 2], [5, 2], [8, 1]], columns=[1, 1]),
-                DataFrame(
-                    [[2, 4], [1, 2], [5, 2], [8, 1]], columns=['C', 'C']),
-                DataFrame(
-                    [[2, 4], [1, 2], [5, 2], [8, 1]], columns=[1., 0]),
-                DataFrame(
-                    [[2, 4], [1, 2], [5, 2], [8, 1]], columns=[0., 1]),
-                DataFrame(
-                    [[2, 4], [1, 2], [5, 2], [8, 1]], columns=['C', 1]),
-                DataFrame(
-                    [[2., 4.], [1., 2.], [5., 2.], [8., 1.]], columns=[1, 0.]),
-                DataFrame(
-                    [[2, 4.], [1, 2.], [5, 2.], [8, 1.]], columns=[0, 1.]),
-                DataFrame(
-                    [[2, 4], [1, 2], [5, 2], [8, 1.]], columns=[1., 'X']), ]
-        df2 = DataFrame(
-            [[None, 1, 1], [None, 1, 2], [None, 3, 2], [None, 8, 1]
-             ], columns=['Y', 'Z', 'X'])
+                DataFrame([[2, 4], [1, 2], [5, 2], [8, 1]], columns=[1, 0]),
+                DataFrame([[2, 4], [1, 2], [5, 2], [8, 1]], columns=[1, 1]),
+                DataFrame([[2, 4], [1, 2], [5, 2], [8, 1]],
+                          columns=['C', 'C']),
+                DataFrame([[2, 4], [1, 2], [5, 2], [8, 1]], columns=[1., 0]),
+                DataFrame([[2, 4], [1, 2], [5, 2], [8, 1]], columns=[0., 1]),
+                DataFrame([[2, 4], [1, 2], [5, 2], [8, 1]], columns=['C', 1]),
+                DataFrame([[2., 4.], [1., 2.], [5., 2.], [8., 1.]],
+                          columns=[1, 0.]),
+                DataFrame([[2, 4.], [1, 2.], [5, 2.], [8, 1.]],
+                          columns=[0, 1.]),
+                DataFrame([[2, 4], [1, 2], [5, 2], [8, 1.]],
+                          columns=[1., 'X']), ]
+        df2 = DataFrame([[None, 1, 1], [None, 1, 2],
+                         [None, 3, 2], [None, 8, 1]], columns=['Y', 'Z', 'X'])
         s = Series([1, 1, 3, 8])
 
         # suppress warnings about incomparable objects, as we are deliberately
@@ -2596,11 +2590,13 @@ class TestMomentsConsistency(Base):
             for f in [lambda x: x.cov(), lambda x: x.corr(), ]:
                 results = [f(df) for df in df1s]
                 for (df, result) in zip(df1s, results):
-                    assert_index_equal(result.index, df.columns)
-                    assert_index_equal(result.columns, df.columns)
+                    tm.assert_index_equal(result.index, df.columns)
+                    tm.assert_index_equal(result.columns, df.columns)
                 for i, result in enumerate(results):
                     if i > 0:
-                        self.assert_numpy_array_equal(result, results[0])
+                        # compare internal values, as columns can be different
+                        self.assert_numpy_array_equal(result.values,
+                                                      results[0].values)
 
             # DataFrame with itself, pairwise=True
             for f in [lambda x: x.expanding().cov(pairwise=True),
@@ -2611,12 +2607,13 @@ class TestMomentsConsistency(Base):
                       lambda x: x.ewm(com=3).corr(pairwise=True), ]:
                 results = [f(df) for df in df1s]
                 for (df, result) in zip(df1s, results):
-                    assert_index_equal(result.items, df.index)
-                    assert_index_equal(result.major_axis, df.columns)
-                    assert_index_equal(result.minor_axis, df.columns)
+                    tm.assert_index_equal(result.items, df.index)
+                    tm.assert_index_equal(result.major_axis, df.columns)
+                    tm.assert_index_equal(result.minor_axis, df.columns)
                 for i, result in enumerate(results):
                     if i > 0:
-                        self.assert_numpy_array_equal(result, results[0])
+                        self.assert_numpy_array_equal(result.values,
+                                                      results[0].values)
 
             # DataFrame with itself, pairwise=False
             for f in [lambda x: x.expanding().cov(pairwise=False),
@@ -2627,11 +2624,12 @@ class TestMomentsConsistency(Base):
                       lambda x: x.ewm(com=3).corr(pairwise=False), ]:
                 results = [f(df) for df in df1s]
                 for (df, result) in zip(df1s, results):
-                    assert_index_equal(result.index, df.index)
-                    assert_index_equal(result.columns, df.columns)
+                    tm.assert_index_equal(result.index, df.index)
+                    tm.assert_index_equal(result.columns, df.columns)
                 for i, result in enumerate(results):
                     if i > 0:
-                        self.assert_numpy_array_equal(result, results[0])
+                        self.assert_numpy_array_equal(result.values,
+                                                      results[0].values)
 
             # DataFrame with another DataFrame, pairwise=True
             for f in [lambda x, y: x.expanding().cov(y, pairwise=True),
@@ -2642,12 +2640,13 @@ class TestMomentsConsistency(Base):
                       lambda x, y: x.ewm(com=3).corr(y, pairwise=True), ]:
                 results = [f(df, df2) for df in df1s]
                 for (df, result) in zip(df1s, results):
-                    assert_index_equal(result.items, df.index)
-                    assert_index_equal(result.major_axis, df.columns)
-                    assert_index_equal(result.minor_axis, df2.columns)
+                    tm.assert_index_equal(result.items, df.index)
+                    tm.assert_index_equal(result.major_axis, df.columns)
+                    tm.assert_index_equal(result.minor_axis, df2.columns)
                 for i, result in enumerate(results):
                     if i > 0:
-                        self.assert_numpy_array_equal(result, results[0])
+                        self.assert_numpy_array_equal(result.values,
+                                                      results[0].values)
 
             # DataFrame with another DataFrame, pairwise=False
             for f in [lambda x, y: x.expanding().cov(y, pairwise=False),
@@ -2662,8 +2661,8 @@ class TestMomentsConsistency(Base):
                     if result is not None:
                         expected_index = df.index.union(df2.index)
                         expected_columns = df.columns.union(df2.columns)
-                        assert_index_equal(result.index, expected_index)
-                        assert_index_equal(result.columns, expected_columns)
+                        tm.assert_index_equal(result.index, expected_index)
+                        tm.assert_index_equal(result.columns, expected_columns)
                     else:
                         tm.assertRaisesRegexp(
                             ValueError, "'arg1' columns are not unique", f, df,
@@ -2681,11 +2680,12 @@ class TestMomentsConsistency(Base):
                       lambda x, y: x.ewm(com=3).corr(y), ]:
                 results = [f(df, s) for df in df1s] + [f(s, df) for df in df1s]
                 for (df, result) in zip(df1s, results):
-                    assert_index_equal(result.index, df.index)
-                    assert_index_equal(result.columns, df.columns)
+                    tm.assert_index_equal(result.index, df.index)
+                    tm.assert_index_equal(result.columns, df.columns)
                 for i, result in enumerate(results):
                     if i > 0:
-                        self.assert_numpy_array_equal(result, results[0])
+                        self.assert_numpy_array_equal(result.values,
+                                                      results[0].values)
 
     def test_rolling_skew_edge_cases(self):
 
@@ -2694,19 +2694,19 @@ class TestMomentsConsistency(Base):
         # yields all NaN (0 variance)
         d = Series([1] * 5)
         x = d.rolling(window=5).skew()
-        assert_series_equal(all_nan, x)
+        tm.assert_series_equal(all_nan, x)
 
         # yields all NaN (window too small)
         d = Series(np.random.randn(5))
         x = d.rolling(window=2).skew()
-        assert_series_equal(all_nan, x)
+        tm.assert_series_equal(all_nan, x)
 
         # yields [NaN, NaN, NaN, 0.177994, 1.548824]
         d = Series([-1.50837035, -0.1297039, 0.19501095, 1.73508164, 0.41941401
                     ])
         expected = Series([np.NaN, np.NaN, np.NaN, 0.177994, 1.548824])
         x = d.rolling(window=4).skew()
-        assert_series_equal(expected, x)
+        tm.assert_series_equal(expected, x)
 
     def test_rolling_kurt_edge_cases(self):
 
@@ -2715,25 +2715,25 @@ class TestMomentsConsistency(Base):
         # yields all NaN (0 variance)
         d = Series([1] * 5)
         x = d.rolling(window=5).kurt()
-        assert_series_equal(all_nan, x)
+        tm.assert_series_equal(all_nan, x)
 
         # yields all NaN (window too small)
         d = Series(np.random.randn(5))
         x = d.rolling(window=3).kurt()
-        assert_series_equal(all_nan, x)
+        tm.assert_series_equal(all_nan, x)
 
         # yields [NaN, NaN, NaN, 1.224307, 2.671499]
         d = Series([-1.50837035, -0.1297039, 0.19501095, 1.73508164, 0.41941401
                     ])
         expected = Series([np.NaN, np.NaN, np.NaN, 1.224307, 2.671499])
         x = d.rolling(window=4).kurt()
-        assert_series_equal(expected, x)
+        tm.assert_series_equal(expected, x)
 
     def _check_expanding_ndarray(self, func, static_comp, has_min_periods=True,
                                  has_time_rule=True, preserve_nan=True):
         result = func(self.arr)
 
-        assert_almost_equal(result[10], static_comp(self.arr[:11]))
+        tm.assert_almost_equal(result[10], static_comp(self.arr[:11]))
 
         if preserve_nan:
             assert (np.isnan(result[self._nan_locs]).all())
@@ -2743,7 +2743,7 @@ class TestMomentsConsistency(Base):
         if has_min_periods:
             result = func(arr, min_periods=30)
             assert (np.isnan(result[:29]).all())
-            assert_almost_equal(result[-1], static_comp(arr[:50]))
+            tm.assert_almost_equal(result[-1], static_comp(arr[:50]))
 
             # min_periods is working correctly
             result = func(arr, min_periods=15)
@@ -2758,10 +2758,10 @@ class TestMomentsConsistency(Base):
             # min_periods=0
             result0 = func(arr, min_periods=0)
             result1 = func(arr, min_periods=1)
-            assert_almost_equal(result0, result1)
+            tm.assert_almost_equal(result0, result1)
         else:
             result = func(arr)
-            assert_almost_equal(result[-1], static_comp(arr[:50]))
+            tm.assert_almost_equal(result[-1], static_comp(arr[:50]))
 
     def _check_expanding_structures(self, func):
         series_result = func(self.series)
@@ -2795,7 +2795,7 @@ class TestMomentsConsistency(Base):
                           index=[datetime(1975, 1, i, 0) for i in range(1, 6)])
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             x = series.rolling(window=1, freq='D').max()
-        assert_series_equal(expected, x)
+        tm.assert_series_equal(expected, x)
 
     def test_rolling_max_how_resample(self):
 
@@ -2814,14 +2814,14 @@ class TestMomentsConsistency(Base):
                           index=[datetime(1975, 1, i, 0) for i in range(1, 6)])
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             x = series.rolling(window=1, freq='D').max()
-        assert_series_equal(expected, x)
+        tm.assert_series_equal(expected, x)
 
         # Now specify median (10.0)
         expected = Series([0.0, 1.0, 2.0, 3.0, 10.0],
                           index=[datetime(1975, 1, i, 0) for i in range(1, 6)])
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             x = series.rolling(window=1, freq='D').max(how='median')
-        assert_series_equal(expected, x)
+        tm.assert_series_equal(expected, x)
 
         # Now specify mean (4+10+20)/3
         v = (4.0 + 10.0 + 20.0) / 3.0
@@ -2829,7 +2829,7 @@ class TestMomentsConsistency(Base):
                           index=[datetime(1975, 1, i, 0) for i in range(1, 6)])
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             x = series.rolling(window=1, freq='D').max(how='mean')
-            assert_series_equal(expected, x)
+            tm.assert_series_equal(expected, x)
 
     def test_rolling_min_how_resample(self):
 
@@ -2848,7 +2848,7 @@ class TestMomentsConsistency(Base):
                           index=[datetime(1975, 1, i, 0) for i in range(1, 6)])
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             r = series.rolling(window=1, freq='D')
-            assert_series_equal(expected, r.min())
+            tm.assert_series_equal(expected, r.min())
 
     def test_rolling_median_how_resample(self):
 
@@ -2867,7 +2867,7 @@ class TestMomentsConsistency(Base):
                           index=[datetime(1975, 1, i, 0) for i in range(1, 6)])
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             x = series.rolling(window=1, freq='D').median()
-            assert_series_equal(expected, x)
+            tm.assert_series_equal(expected, x)
 
     def test_rolling_median_memory_error(self):
         # GH11722
@@ -2917,16 +2917,16 @@ class TestGrouperGrouping(tm.TestCase):
         expected = g_mutated.B.apply(lambda x: x.rolling(2).mean())
 
         result = g.rolling(2).mean().B
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = g.rolling(2).B.mean()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = g.B.rolling(2).mean()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = self.frame.B.groupby(self.frame.A).rolling(2).mean()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_getitem_multiple(self):
 
@@ -2937,10 +2937,10 @@ class TestGrouperGrouping(tm.TestCase):
         expected = g_mutated.B.apply(lambda x: x.rolling(2).count())
 
         result = r.B.count()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = r.B.count()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_rolling(self):
         g = self.frame.groupby('A')
@@ -2949,16 +2949,16 @@ class TestGrouperGrouping(tm.TestCase):
         for f in ['sum', 'mean', 'min', 'max', 'count', 'kurt', 'skew']:
             result = getattr(r, f)()
             expected = g.apply(lambda x: getattr(x.rolling(4), f)())
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
         for f in ['std', 'var']:
             result = getattr(r, f)(ddof=1)
             expected = g.apply(lambda x: getattr(x.rolling(4), f)(ddof=1))
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
         result = r.quantile(0.5)
         expected = g.apply(lambda x: x.rolling(4).quantile(0.5))
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_rolling_corr_cov(self):
         g = self.frame.groupby('A')
@@ -2970,14 +2970,14 @@ class TestGrouperGrouping(tm.TestCase):
             def func(x):
                 return getattr(x.rolling(4), f)(self.frame)
             expected = g.apply(func)
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             result = getattr(r.B, f)(pairwise=True)
 
             def func(x):
                 return getattr(x.B.rolling(4), f)(pairwise=True)
             expected = g.apply(func)
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
     def test_rolling_apply(self):
         g = self.frame.groupby('A')
@@ -2986,7 +2986,7 @@ class TestGrouperGrouping(tm.TestCase):
         # reduction
         result = r.apply(lambda x: x.sum())
         expected = g.apply(lambda x: x.rolling(4).apply(lambda y: y.sum()))
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_expanding(self):
         g = self.frame.groupby('A')
@@ -2995,16 +2995,16 @@ class TestGrouperGrouping(tm.TestCase):
         for f in ['sum', 'mean', 'min', 'max', 'count', 'kurt', 'skew']:
             result = getattr(r, f)()
             expected = g.apply(lambda x: getattr(x.expanding(), f)())
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
         for f in ['std', 'var']:
             result = getattr(r, f)(ddof=0)
             expected = g.apply(lambda x: getattr(x.expanding(), f)(ddof=0))
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
         result = r.quantile(0.5)
         expected = g.apply(lambda x: x.expanding().quantile(0.5))
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_expanding_corr_cov(self):
         g = self.frame.groupby('A')
@@ -3016,14 +3016,14 @@ class TestGrouperGrouping(tm.TestCase):
             def func(x):
                 return getattr(x.expanding(), f)(self.frame)
             expected = g.apply(func)
-            assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result, expected)
 
             result = getattr(r.B, f)(pairwise=True)
 
             def func(x):
                 return getattr(x.B.expanding(), f)(pairwise=True)
             expected = g.apply(func)
-            assert_series_equal(result, expected)
+            tm.assert_series_equal(result, expected)
 
     def test_expanding_apply(self):
         g = self.frame.groupby('A')
@@ -3032,4 +3032,4 @@ class TestGrouperGrouping(tm.TestCase):
         # reduction
         result = r.apply(lambda x: x.sum())
         expected = g.apply(lambda x: x.expanding().apply(lambda y: y.sum()))
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tools/tests/test_concat.py
+++ b/pandas/tools/tests/test_concat.py
@@ -266,7 +266,8 @@ class TestConcatenate(tm.TestCase):
                         levels=[level],
                         names=['group_key'])
 
-        self.assert_numpy_array_equal(result.columns.levels[0], level)
+        self.assert_index_equal(result.columns.levels[0],
+                                Index(level, name='group_key'))
         self.assertEqual(result.columns.names[0], 'group_key')
 
     def test_concat_dataframe_keys_bug(self):
@@ -413,7 +414,8 @@ class TestConcatenate(tm.TestCase):
                               ('baz', 'one'), ('baz', 'two')],
                         names=['first', 'second'])
         self.assertEqual(result.index.names, ('first', 'second') + (None,))
-        self.assert_numpy_array_equal(result.index.levels[0], ['baz', 'foo'])
+        self.assert_index_equal(result.index.levels[0],
+                                Index(['baz', 'foo'], name='first'))
 
     def test_concat_keys_levels_no_overlap(self):
         # GH #1406

--- a/pandas/tools/tests/test_tile.py
+++ b/pandas/tools/tests/test_tile.py
@@ -4,7 +4,7 @@ import nose
 import numpy as np
 from pandas.compat import zip
 
-from pandas import Series
+from pandas import Series, Index
 import pandas.util.testing as tm
 from pandas.util.testing import assertRaisesRegexp
 import pandas.core.common as com
@@ -19,32 +19,41 @@ class TestCut(tm.TestCase):
     def test_simple(self):
         data = np.ones(5)
         result = cut(data, 4, labels=False)
-        desired = [1, 1, 1, 1, 1]
+        desired = np.array([1, 1, 1, 1, 1], dtype=np.int64)
         tm.assert_numpy_array_equal(result, desired)
 
     def test_bins(self):
         data = np.array([.2, 1.4, 2.5, 6.2, 9.7, 2.1])
         result, bins = cut(data, 3, retbins=True)
-        tm.assert_numpy_array_equal(result.codes, [0, 0, 0, 1, 2, 0])
-        tm.assert_almost_equal(bins, [0.1905, 3.36666667, 6.53333333, 9.7])
+
+        exp_codes = np.array([0, 0, 0, 1, 2, 0], dtype=np.int8)
+        tm.assert_numpy_array_equal(result.codes, exp_codes)
+        exp = np.array([0.1905, 3.36666667, 6.53333333, 9.7])
+        tm.assert_almost_equal(bins, exp)
 
     def test_right(self):
         data = np.array([.2, 1.4, 2.5, 6.2, 9.7, 2.1, 2.575])
         result, bins = cut(data, 4, right=True, retbins=True)
-        tm.assert_numpy_array_equal(result.codes, [0, 0, 0, 2, 3, 0, 0])
-        tm.assert_almost_equal(bins, [0.1905, 2.575, 4.95, 7.325, 9.7])
+        exp_codes = np.array([0, 0, 0, 2, 3, 0, 0], dtype=np.int8)
+        tm.assert_numpy_array_equal(result.codes, exp_codes)
+        exp = np.array([0.1905, 2.575, 4.95, 7.325, 9.7])
+        tm.assert_numpy_array_equal(bins, exp)
 
     def test_noright(self):
         data = np.array([.2, 1.4, 2.5, 6.2, 9.7, 2.1, 2.575])
         result, bins = cut(data, 4, right=False, retbins=True)
-        tm.assert_numpy_array_equal(result.codes, [0, 0, 0, 2, 3, 0, 1])
-        tm.assert_almost_equal(bins, [0.2, 2.575, 4.95, 7.325, 9.7095])
+        exp_codes = np.array([0, 0, 0, 2, 3, 0, 1], dtype=np.int8)
+        tm.assert_numpy_array_equal(result.codes, exp_codes)
+        exp = np.array([0.2, 2.575, 4.95, 7.325, 9.7095])
+        tm.assert_almost_equal(bins, exp)
 
     def test_arraylike(self):
         data = [.2, 1.4, 2.5, 6.2, 9.7, 2.1]
         result, bins = cut(data, 3, retbins=True)
-        tm.assert_numpy_array_equal(result.codes, [0, 0, 0, 1, 2, 0])
-        tm.assert_almost_equal(bins, [0.1905, 3.36666667, 6.53333333, 9.7])
+        exp_codes = np.array([0, 0, 0, 1, 2, 0], dtype=np.int8)
+        tm.assert_numpy_array_equal(result.codes, exp_codes)
+        exp = np.array([0.1905, 3.36666667, 6.53333333, 9.7])
+        tm.assert_almost_equal(bins, exp)
 
     def test_bins_not_monotonic(self):
         data = [.2, 1.4, 2.5, 6.2, 9.7, 2.1]
@@ -72,14 +81,14 @@ class TestCut(tm.TestCase):
         arr = np.tile(np.arange(0, 1.01, 0.1), 4)
 
         result, bins = cut(arr, 4, retbins=True)
-        ex_levels = ['(-0.001, 0.25]', '(0.25, 0.5]', '(0.5, 0.75]',
-                     '(0.75, 1]']
-        self.assert_numpy_array_equal(result.categories, ex_levels)
+        ex_levels = Index(['(-0.001, 0.25]', '(0.25, 0.5]', '(0.5, 0.75]',
+                           '(0.75, 1]'])
+        self.assert_index_equal(result.categories, ex_levels)
 
         result, bins = cut(arr, 4, retbins=True, right=False)
-        ex_levels = ['[0, 0.25)', '[0.25, 0.5)', '[0.5, 0.75)',
-                     '[0.75, 1.001)']
-        self.assert_numpy_array_equal(result.categories, ex_levels)
+        ex_levels = Index(['[0, 0.25)', '[0.25, 0.5)', '[0.5, 0.75)',
+                           '[0.75, 1.001)'])
+        self.assert_index_equal(result.categories, ex_levels)
 
     def test_cut_pass_series_name_to_factor(self):
         s = Series(np.random.randn(100), name='foo')
@@ -91,9 +100,9 @@ class TestCut(tm.TestCase):
         arr = np.arange(0, 0.73, 0.01)
 
         result = cut(arr, 4, precision=2)
-        ex_levels = ['(-0.00072, 0.18]', '(0.18, 0.36]', '(0.36, 0.54]',
-                     '(0.54, 0.72]']
-        self.assert_numpy_array_equal(result.categories, ex_levels)
+        ex_levels = Index(['(-0.00072, 0.18]', '(0.18, 0.36]',
+                           '(0.36, 0.54]', '(0.54, 0.72]'])
+        self.assert_index_equal(result.categories, ex_levels)
 
     def test_na_handling(self):
         arr = np.arange(0, 0.75, 0.01)
@@ -118,10 +127,10 @@ class TestCut(tm.TestCase):
         result = cut(data, [-np.inf, 2, 4, np.inf])
         result_ser = cut(data_ser, [-np.inf, 2, 4, np.inf])
 
-        ex_categories = ['(-inf, 2]', '(2, 4]', '(4, inf]']
+        ex_categories = Index(['(-inf, 2]', '(2, 4]', '(4, inf]'])
 
-        tm.assert_numpy_array_equal(result.categories, ex_categories)
-        tm.assert_numpy_array_equal(result_ser.cat.categories, ex_categories)
+        tm.assert_index_equal(result.categories, ex_categories)
+        tm.assert_index_equal(result_ser.cat.categories, ex_categories)
         self.assertEqual(result[5], '(4, inf]')
         self.assertEqual(result[0], '(-inf, 2]')
         self.assertEqual(result_ser[5], '(4, inf]')
@@ -135,7 +144,7 @@ class TestCut(tm.TestCase):
         tm.assert_almost_equal(bins, ex_bins)
 
         ex_levels = cut(arr, ex_bins, include_lowest=True)
-        self.assert_numpy_array_equal(labels, ex_levels)
+        self.assert_categorical_equal(labels, ex_levels)
 
     def test_qcut_bounds(self):
         arr = np.random.randn(1000)
@@ -148,7 +157,7 @@ class TestCut(tm.TestCase):
 
         factor = qcut(arr, [0, .25, .5, .75, 1.])
         expected = qcut(arr, 4)
-        self.assertTrue(factor.equals(expected))
+        tm.assert_categorical_equal(factor, expected)
 
     def test_qcut_all_bins_same(self):
         assertRaisesRegexp(ValueError, "edges.*unique", qcut,
@@ -173,7 +182,7 @@ class TestCut(tm.TestCase):
         exp = cut(arr, bins)
         exp.categories = labels
 
-        self.assertTrue(result.equals(exp))
+        tm.assert_categorical_equal(result, exp)
 
     def test_qcut_include_lowest(self):
         values = np.arange(10)
@@ -253,12 +262,14 @@ class TestCut(tm.TestCase):
         # GH 8589
         s = Series(np.arange(4))
         result, bins = cut(s, 2, retbins=True)
-        tm.assert_numpy_array_equal(result.cat.codes.values, [0, 0, 1, 1])
-        tm.assert_almost_equal(bins, [-0.003, 1.5, 3])
+        tm.assert_numpy_array_equal(result.cat.codes.values,
+                                    np.array([0, 0, 1, 1], dtype=np.int8))
+        tm.assert_numpy_array_equal(bins, np.array([-0.003, 1.5, 3]))
 
         result, bins = qcut(s, 2, retbins=True)
-        tm.assert_numpy_array_equal(result.cat.codes.values, [0, 0, 1, 1])
-        tm.assert_almost_equal(bins, [0, 1.5, 3])
+        tm.assert_numpy_array_equal(result.cat.codes.values,
+                                    np.array([0, 0, 1, 1], dtype=np.int8))
+        tm.assert_numpy_array_equal(bins, np.array([0, 1.5, 3]))
 
 
 def curpath():

--- a/pandas/tools/tests/test_util.py
+++ b/pandas/tools/tests/test_util.py
@@ -18,18 +18,21 @@ class TestCartesianProduct(tm.TestCase):
 
     def test_simple(self):
         x, y = list('ABC'), [1, 22]
-        result = cartesian_product([x, y])
-        expected = [np.array(['A', 'A', 'B', 'B', 'C', 'C']),
-                    np.array([1, 22, 1, 22, 1, 22])]
-        tm.assert_numpy_array_equal(result, expected)
+        result1, result2 = cartesian_product([x, y])
+        expected1 = np.array(['A', 'A', 'B', 'B', 'C', 'C'])
+        expected2 = np.array([1, 22, 1, 22, 1, 22])
+        tm.assert_numpy_array_equal(result1, expected1)
+        tm.assert_numpy_array_equal(result2, expected2)
 
     def test_datetimeindex(self):
         # regression test for GitHub issue #6439
         # make sure that the ordering on datetimeindex is consistent
         x = date_range('2000-01-01', periods=2)
-        result = [Index(y).day for y in cartesian_product([x, x])]
-        expected = [np.array([1, 1, 2, 2]), np.array([1, 2, 1, 2])]
-        tm.assert_numpy_array_equal(result, expected)
+        result1, result2 = [Index(y).day for y in cartesian_product([x, x])]
+        expected1 = np.array([1, 1, 2, 2], dtype=np.int32)
+        expected2 = np.array([1, 2, 1, 2], dtype=np.int32)
+        tm.assert_numpy_array_equal(result1, expected1)
+        tm.assert_numpy_array_equal(result2, expected2)
 
 
 class TestLocaleUtils(tm.TestCase):

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -62,7 +62,7 @@ class TestDatetimeIndexOps(Ops):
         self.assertTrue(isinstance(result, Index))
 
         self.assertEqual(result.dtype, object)
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
         self.assertEqual(result.name, expected.name)
         self.assertEqual(idx.tolist(), expected_list)
 
@@ -76,7 +76,7 @@ class TestDatetimeIndexOps(Ops):
         result = idx.asobject
         self.assertTrue(isinstance(result, Index))
         self.assertEqual(result.dtype, object)
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
         self.assertEqual(result.name, expected.name)
         self.assertEqual(idx.tolist(), expected_list)
 
@@ -89,7 +89,7 @@ class TestDatetimeIndexOps(Ops):
         result = idx.asobject
         self.assertTrue(isinstance(result, Index))
         self.assertEqual(result.dtype, object)
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
         self.assertEqual(result.name, expected.name)
         self.assertEqual(idx.tolist(), expected_list)
 
@@ -726,7 +726,7 @@ class TestTimedeltaIndexOps(Ops):
         self.assertTrue(isinstance(result, Index))
 
         self.assertEqual(result.dtype, object)
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
         self.assertEqual(result.name, expected.name)
         self.assertEqual(idx.tolist(), expected_list)
 
@@ -738,7 +738,7 @@ class TestTimedeltaIndexOps(Ops):
         result = idx.asobject
         self.assertTrue(isinstance(result, Index))
         self.assertEqual(result.dtype, object)
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
         self.assertEqual(result.name, expected.name)
         self.assertEqual(idx.tolist(), expected_list)
 
@@ -1489,7 +1489,7 @@ class TestPeriodIndexOps(Ops):
         result = idx.asobject
         self.assertTrue(isinstance(result, Index))
         self.assertEqual(result.dtype, object)
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
         self.assertEqual(result.name, expected.name)
         self.assertEqual(idx.tolist(), expected_list)
 

--- a/pandas/tseries/tests/test_daterange.py
+++ b/pandas/tseries/tests/test_daterange.py
@@ -25,15 +25,16 @@ START, END = datetime(2009, 1, 1), datetime(2010, 1, 1)
 
 
 class TestGenRangeGeneration(tm.TestCase):
+
     def test_generate(self):
         rng1 = list(generate_range(START, END, offset=datetools.bday))
         rng2 = list(generate_range(START, END, time_rule='B'))
-        self.assert_numpy_array_equal(rng1, rng2)
+        self.assertEqual(rng1, rng2)
 
     def test_generate_cday(self):
         rng1 = list(generate_range(START, END, offset=datetools.cday))
         rng2 = list(generate_range(START, END, time_rule='C'))
-        self.assert_numpy_array_equal(rng1, rng2)
+        self.assertEqual(rng1, rng2)
 
     def test_1(self):
         eq_gen_range(dict(start=datetime(2009, 3, 25), periods=2),
@@ -68,8 +69,8 @@ class TestGenRangeGeneration(tm.TestCase):
                                   freq='Q-DEC', tz=None)
         expected2 = DatetimeIndex(expected2_list, dtype='datetime64[ns]',
                                   freq='W-SUN', tz=None)
-        self.assertTrue(result1.equals(expected1))
-        self.assertTrue(result2.equals(expected2))
+        self.assert_index_equal(result1, expected1)
+        self.assert_index_equal(result2, expected2)
 
 
 class TestDateRange(tm.TestCase):
@@ -140,7 +141,7 @@ class TestDateRange(tm.TestCase):
     def test_copy(self):
         cp = self.rng.copy()
         repr(cp)
-        self.assertTrue(cp.equals(self.rng))
+        self.assert_index_equal(cp, self.rng)
 
     def test_repr(self):
         # only really care that it works
@@ -148,7 +149,9 @@ class TestDateRange(tm.TestCase):
 
     def test_getitem(self):
         smaller = self.rng[:5]
-        self.assert_numpy_array_equal(smaller, self.rng.view(np.ndarray)[:5])
+        exp = DatetimeIndex(self.rng.view(np.ndarray)[:5])
+        self.assert_index_equal(smaller, exp)
+
         self.assertEqual(smaller.offset, self.rng.offset)
 
         sliced = self.rng[::5]
@@ -211,7 +214,7 @@ class TestDateRange(tm.TestCase):
         tm.assertIsInstance(the_union, DatetimeIndex)
 
         # order does not matter
-        self.assert_numpy_array_equal(right.union(left), the_union)
+        tm.assert_index_equal(right.union(left), the_union)
 
         # overlapping, but different offset
         rng = date_range(START, END, freq=datetools.bmonthEnd)
@@ -256,13 +259,13 @@ class TestDateRange(tm.TestCase):
         rng1 = rng[10:]
         rng2 = rng[:25]
         the_union = rng1.union(rng2)
-        self.assertTrue(the_union.equals(rng))
+        self.assert_index_equal(the_union, rng)
 
         rng1 = rng[10:]
         rng2 = rng[15:35]
         the_union = rng1.union(rng2)
         expected = rng[10:]
-        self.assertTrue(the_union.equals(expected))
+        self.assert_index_equal(the_union, expected)
 
     def test_intersection(self):
         rng = date_range('1/1/2000', periods=50, freq=datetools.Minute())
@@ -270,24 +273,24 @@ class TestDateRange(tm.TestCase):
         rng2 = rng[:25]
         the_int = rng1.intersection(rng2)
         expected = rng[10:25]
-        self.assertTrue(the_int.equals(expected))
+        self.assert_index_equal(the_int, expected)
         tm.assertIsInstance(the_int, DatetimeIndex)
         self.assertEqual(the_int.offset, rng.offset)
 
         the_int = rng1.intersection(rng2.view(DatetimeIndex))
-        self.assertTrue(the_int.equals(expected))
+        self.assert_index_equal(the_int, expected)
 
         # non-overlapping
         the_int = rng[:10].intersection(rng[10:])
         expected = DatetimeIndex([])
-        self.assertTrue(the_int.equals(expected))
+        self.assert_index_equal(the_int, expected)
 
     def test_intersection_bug(self):
         # GH #771
         a = bdate_range('11/30/2011', '12/31/2011')
         b = bdate_range('12/10/2011', '12/20/2011')
         result = a.intersection(b)
-        self.assertTrue(result.equals(b))
+        self.assert_index_equal(result, b)
 
     def test_summary(self):
         self.rng.summary()
@@ -364,7 +367,7 @@ class TestDateRange(tm.TestCase):
 
         start = datetime(2011, 1, 1)
         exp_values = [start + i * offset for i in range(5)]
-        self.assert_numpy_array_equal(result, DatetimeIndex(exp_values))
+        tm.assert_index_equal(result, DatetimeIndex(exp_values))
 
     def test_range_tz_pytz(self):
         # GH 2906
@@ -494,8 +497,8 @@ class TestDateRange(tm.TestCase):
             if begin == closed[0]:
                 expected_right = closed[1:]
 
-            self.assertTrue(expected_left.equals(left))
-            self.assertTrue(expected_right.equals(right))
+            self.assert_index_equal(expected_left, left)
+            self.assert_index_equal(expected_right, right)
 
     def test_range_closed_with_tz_aware_start_end(self):
         # GH12409
@@ -514,8 +517,8 @@ class TestDateRange(tm.TestCase):
             if begin == closed[0]:
                 expected_right = closed[1:]
 
-            self.assertTrue(expected_left.equals(left))
-            self.assertTrue(expected_right.equals(right))
+            self.assert_index_equal(expected_left, left)
+            self.assert_index_equal(expected_right, right)
 
         # test with default frequency, UTC
         begin = Timestamp('2011/1/1', tz='UTC')
@@ -546,9 +549,9 @@ class TestDateRange(tm.TestCase):
                 expected_right = both_boundary[1:]
                 expected_left = both_boundary[:-1]
 
-            self.assertTrue(right_boundary.equals(expected_right))
-            self.assertTrue(left_boundary.equals(expected_left))
-            self.assertTrue(both_boundary.equals(expected_both))
+            self.assert_index_equal(right_boundary, expected_right)
+            self.assert_index_equal(left_boundary, expected_left)
+            self.assert_index_equal(both_boundary, expected_both)
 
     def test_years_only(self):
         # GH 6961
@@ -570,8 +573,8 @@ class TestDateRange(tm.TestCase):
                                     '2005-01-13 15:45:00'],
                                    dtype='datetime64[ns]', freq='345T',
                                    tz=None)
-        self.assertTrue(result_1.equals(expected_1))
-        self.assertTrue(result_2.equals(expected_2))
+        self.assert_index_equal(result_1, expected_1)
+        self.assert_index_equal(result_2, expected_2)
 
 
 class TestCustomDateRange(tm.TestCase):
@@ -613,7 +616,7 @@ class TestCustomDateRange(tm.TestCase):
     def test_copy(self):
         cp = self.rng.copy()
         repr(cp)
-        self.assertTrue(cp.equals(self.rng))
+        self.assert_index_equal(cp, self.rng)
 
     def test_repr(self):
         # only really care that it works
@@ -621,7 +624,8 @@ class TestCustomDateRange(tm.TestCase):
 
     def test_getitem(self):
         smaller = self.rng[:5]
-        self.assert_numpy_array_equal(smaller, self.rng.view(np.ndarray)[:5])
+        exp = DatetimeIndex(self.rng.view(np.ndarray)[:5])
+        self.assert_index_equal(smaller, exp)
         self.assertEqual(smaller.offset, self.rng.offset)
 
         sliced = self.rng[::5]
@@ -686,7 +690,7 @@ class TestCustomDateRange(tm.TestCase):
         tm.assertIsInstance(the_union, DatetimeIndex)
 
         # order does not matter
-        self.assert_numpy_array_equal(right.union(left), the_union)
+        self.assert_index_equal(right.union(left), the_union)
 
         # overlapping, but different offset
         rng = date_range(START, END, freq=datetools.bmonthEnd)
@@ -731,7 +735,7 @@ class TestCustomDateRange(tm.TestCase):
         a = cdate_range('11/30/2011', '12/31/2011')
         b = cdate_range('12/10/2011', '12/20/2011')
         result = a.intersection(b)
-        self.assertTrue(result.equals(b))
+        self.assert_index_equal(result, b)
 
     def test_summary(self):
         self.rng.summary()
@@ -783,25 +787,25 @@ class TestCustomDateRange(tm.TestCase):
     def test_cdaterange(self):
         rng = cdate_range('2013-05-01', periods=3)
         xp = DatetimeIndex(['2013-05-01', '2013-05-02', '2013-05-03'])
-        self.assertTrue(xp.equals(rng))
+        self.assert_index_equal(xp, rng)
 
     def test_cdaterange_weekmask(self):
         rng = cdate_range('2013-05-01', periods=3,
                           weekmask='Sun Mon Tue Wed Thu')
         xp = DatetimeIndex(['2013-05-01', '2013-05-02', '2013-05-05'])
-        self.assertTrue(xp.equals(rng))
+        self.assert_index_equal(xp, rng)
 
     def test_cdaterange_holidays(self):
         rng = cdate_range('2013-05-01', periods=3, holidays=['2013-05-01'])
         xp = DatetimeIndex(['2013-05-02', '2013-05-03', '2013-05-06'])
-        self.assertTrue(xp.equals(rng))
+        self.assert_index_equal(xp, rng)
 
     def test_cdaterange_weekmask_and_holidays(self):
         rng = cdate_range('2013-05-01', periods=3,
                           weekmask='Sun Mon Tue Wed Thu',
                           holidays=['2013-05-01'])
         xp = DatetimeIndex(['2013-05-02', '2013-05-05', '2013-05-06'])
-        self.assertTrue(xp.equals(rng))
+        self.assert_index_equal(xp, rng)
 
 
 if __name__ == '__main__':

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -4551,7 +4551,7 @@ class TestDST(tm.TestCase):
         for offset, test_values in iteritems(tests):
             first = Timestamp(test_values[0], tz='US/Eastern') + offset()
             second = Timestamp(test_values[1], tz='US/Eastern')
-            self.assertEqual(first, second, str(offset))
+            self.assertEqual(first, second, msg=str(offset))
 
 
 if __name__ == '__main__':

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -26,8 +26,6 @@ from pandas.compat.numpy import np_datetime64_compat
 from pandas import (Series, DataFrame,
                     _np_version_under1p9, _np_version_under1p12)
 from pandas import tslib
-from pandas.util.testing import (assert_index_equal, assert_series_equal,
-                                 assert_almost_equal, assertRaisesRegexp)
 import pandas.util.testing as tm
 
 
@@ -1752,22 +1750,21 @@ class TestPeriodIndex(tm.TestCase):
         result = idx._simple_new(idx.astype('i8'), 'p', freq=idx.freq)
         tm.assert_index_equal(result, idx)
 
-        result = idx._simple_new(
-            [pd.Period('2007-01', freq='M'), pd.Period('2007-02', freq='M')],
-            'p', freq=idx.freq)
-        self.assertTrue(result.equals(idx))
+        result = idx._simple_new([pd.Period('2007-01', freq='M'),
+                                  pd.Period('2007-02', freq='M')],
+                                 'p', freq=idx.freq)
+        self.assert_index_equal(result, idx)
 
-        result = idx._simple_new(
-            np.array([pd.Period('2007-01', freq='M'),
-                      pd.Period('2007-02', freq='M')]),
-            'p', freq=idx.freq)
-        self.assertTrue(result.equals(idx))
+        result = idx._simple_new(np.array([pd.Period('2007-01', freq='M'),
+                                           pd.Period('2007-02', freq='M')]),
+                                 'p', freq=idx.freq)
+        self.assert_index_equal(result, idx)
 
     def test_constructor_simple_new_empty(self):
         # GH13079
         idx = PeriodIndex([], freq='M', name='p')
         result = idx._simple_new(idx, name='p', freq='M')
-        assert_index_equal(result, idx)
+        tm.assert_index_equal(result, idx)
 
     def test_constructor_simple_new_floats(self):
         # GH13079
@@ -1782,7 +1779,7 @@ class TestPeriodIndex(tm.TestCase):
         result = idx._shallow_copy()
         expected = idx
 
-        assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
     def test_constructor_nat(self):
         self.assertRaises(ValueError, period_range, start='NaT',
@@ -1902,7 +1899,7 @@ class TestPeriodIndex(tm.TestCase):
 
         exp = result
         result = ts[24:]
-        assert_series_equal(exp, result)
+        tm.assert_series_equal(exp, result)
 
         ts = ts[10:].append(ts[10:])
         self.assertRaisesRegexp(KeyError,
@@ -1918,7 +1915,7 @@ class TestPeriodIndex(tm.TestCase):
         dt4 = datetime(2012, 4, 20)
 
         rs = ts[dt1:dt4]
-        assert_series_equal(rs, ts)
+        tm.assert_series_equal(rs, ts)
 
     def test_slice_with_negative_step(self):
         ts = Series(np.arange(20),
@@ -1926,9 +1923,9 @@ class TestPeriodIndex(tm.TestCase):
         SLC = pd.IndexSlice
 
         def assert_slices_equivalent(l_slc, i_slc):
-            assert_series_equal(ts[l_slc], ts.iloc[i_slc])
-            assert_series_equal(ts.loc[l_slc], ts.iloc[i_slc])
-            assert_series_equal(ts.ix[l_slc], ts.iloc[i_slc])
+            tm.assert_series_equal(ts[l_slc], ts.iloc[i_slc])
+            tm.assert_series_equal(ts.loc[l_slc], ts.iloc[i_slc])
+            tm.assert_series_equal(ts.ix[l_slc], ts.iloc[i_slc])
 
         assert_slices_equivalent(SLC[Period('2014-10')::-1], SLC[9::-1])
         assert_slices_equivalent(SLC['2014-10'::-1], SLC[9::-1])
@@ -2100,13 +2097,13 @@ class TestPeriodIndex(tm.TestCase):
         df = DataFrame(randn(10, 5), columns=rng)
 
         ts = df[rng[0]]
-        assert_series_equal(ts, df.ix[:, 0])
+        tm.assert_series_equal(ts, df.ix[:, 0])
 
         # GH # 1211
         repr(df)
 
         ts = df['1/1/2000']
-        assert_series_equal(ts, df.ix[:, 0])
+        tm.assert_series_equal(ts, df.ix[:, 0])
 
     def test_indexing(self):
 
@@ -2151,7 +2148,7 @@ class TestPeriodIndex(tm.TestCase):
         exp_index = date_range('1/1/2001', end='12/31/2009', freq='A-DEC')
         result = df.to_timestamp('D', 'end')
         tm.assert_index_equal(result.index, exp_index)
-        assert_almost_equal(result.values, df.values)
+        tm.assert_numpy_array_equal(result.values, df.values)
 
         exp_index = date_range('1/1/2001', end='1/1/2009', freq='AS-JAN')
         result = df.to_timestamp('D', 'start')
@@ -2182,7 +2179,7 @@ class TestPeriodIndex(tm.TestCase):
         exp_index = date_range('1/1/2001', end='12/31/2009', freq='A-DEC')
         result = df.to_timestamp('D', 'end', axis=1)
         tm.assert_index_equal(result.columns, exp_index)
-        assert_almost_equal(result.values, df.values)
+        tm.assert_numpy_array_equal(result.values, df.values)
 
         exp_index = date_range('1/1/2001', end='1/1/2009', freq='AS-JAN')
         result = df.to_timestamp('D', 'start', axis=1)
@@ -2204,7 +2201,7 @@ class TestPeriodIndex(tm.TestCase):
         tm.assert_index_equal(result.columns, exp_index)
 
         # invalid axis
-        assertRaisesRegexp(ValueError, 'axis', df.to_timestamp, axis=2)
+        tm.assertRaisesRegexp(ValueError, 'axis', df.to_timestamp, axis=2)
 
         result1 = df.to_timestamp('5t', axis=1)
         result2 = df.to_timestamp('t', axis=1)
@@ -2224,7 +2221,7 @@ class TestPeriodIndex(tm.TestCase):
 
         result = ts[2007]
         expected = ts[1:3]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         result[:] = 1
         self.assertTrue((ts[1:3] == 1).all())
 
@@ -2234,19 +2231,19 @@ class TestPeriodIndex(tm.TestCase):
 
         result = ts[2007]
         expected = ts[idx == 2007]
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_index_unique(self):
         idx = PeriodIndex([2000, 2007, 2007, 2009, 2009], freq='A-JUN')
         expected = PeriodIndex([2000, 2007, 2009], freq='A-JUN')
-        self.assert_numpy_array_equal(idx.unique(), expected.values)
+        self.assert_index_equal(idx.unique(), expected)
         self.assertEqual(idx.nunique(), 3)
 
         idx = PeriodIndex([2000, 2007, 2007, 2009, 2007], freq='A-JUN',
                           tz='US/Eastern')
         expected = PeriodIndex([2000, 2007, 2009], freq='A-JUN',
                                tz='US/Eastern')
-        self.assert_numpy_array_equal(idx.unique(), expected.values)
+        self.assert_index_equal(idx.unique(), expected)
         self.assertEqual(idx.nunique(), 3)
 
     def test_constructor(self):
@@ -2336,20 +2333,17 @@ class TestPeriodIndex(tm.TestCase):
             Period('2001-01-02'), Period('2001-01-02'),
         ])
 
-        assert_index_equal(index.repeat(2), expected)
+        tm.assert_index_equal(index.repeat(2), expected)
 
     def test_numpy_repeat(self):
         index = period_range('20010101', periods=2)
-        expected = PeriodIndex([
-            Period('2001-01-01'), Period('2001-01-01'),
-            Period('2001-01-02'), Period('2001-01-02'),
-        ])
+        expected = PeriodIndex([Period('2001-01-01'), Period('2001-01-01'),
+                                Period('2001-01-02'), Period('2001-01-02')])
 
-        assert_index_equal(np.repeat(index, 2), expected)
+        tm.assert_index_equal(np.repeat(index, 2), expected)
 
         msg = "the 'axis' parameter is not supported"
-        assertRaisesRegexp(ValueError, msg, np.repeat,
-                           index, 2, axis=1)
+        tm.assertRaisesRegexp(ValueError, msg, np.repeat, index, 2, axis=1)
 
     def test_shift(self):
         pi1 = PeriodIndex(freq='A', start='1/1/2001', end='12/1/2009')
@@ -2598,7 +2592,7 @@ class TestPeriodIndex(tm.TestCase):
 
         idx1 = PeriodIndex(ordinal=[-1, 0, 1], freq='A')
         idx2 = PeriodIndex(ordinal=np.array([-1, 0, 1]), freq='A')
-        tm.assert_numpy_array_equal(idx1, idx2)
+        tm.assert_index_equal(idx1, idx2)
 
     def test_dti_to_period(self):
         dti = DatetimeIndex(start='1/1/2005', end='12/1/2005', freq='M')
@@ -2626,10 +2620,10 @@ class TestPeriodIndex(tm.TestCase):
         s = Series(np.random.rand(len(pi)), index=pi)
         res = s['2010']
         exp = s[0:12]
-        assert_series_equal(res, exp)
+        tm.assert_series_equal(res, exp)
         res = s['2011']
         exp = s[12:24]
-        assert_series_equal(res, exp)
+        tm.assert_series_equal(res, exp)
 
     def test_getitem_day(self):
         # GH 6716
@@ -2655,9 +2649,9 @@ class TestPeriodIndex(tm.TestCase):
                     continue
 
             s = Series(np.random.rand(len(idx)), index=idx)
-            assert_series_equal(s['2013/01'], s[0:31])
-            assert_series_equal(s['2013/02'], s[31:59])
-            assert_series_equal(s['2014'], s[365:])
+            tm.assert_series_equal(s['2013/01'], s[0:31])
+            tm.assert_series_equal(s['2013/02'], s[31:59])
+            tm.assert_series_equal(s['2014'], s[365:])
 
             invalid = ['2013/02/01 9H', '2013/02/01 09:00']
             for v in invalid:
@@ -2683,10 +2677,10 @@ class TestPeriodIndex(tm.TestCase):
 
             s = Series(np.random.rand(len(idx)), index=idx)
 
-            assert_series_equal(s['2013/01/02':], s[1:])
-            assert_series_equal(s['2013/01/02':'2013/01/05'], s[1:5])
-            assert_series_equal(s['2013/02':], s[31:])
-            assert_series_equal(s['2014':], s[365:])
+            tm.assert_series_equal(s['2013/01/02':], s[1:])
+            tm.assert_series_equal(s['2013/01/02':'2013/01/05'], s[1:5])
+            tm.assert_series_equal(s['2013/02':], s[31:])
+            tm.assert_series_equal(s['2014':], s[365:])
 
             invalid = ['2013/02/01 9H', '2013/02/01 09:00']
             for v in invalid:
@@ -2716,10 +2710,10 @@ class TestPeriodIndex(tm.TestCase):
                     continue
 
             s = Series(np.random.rand(len(idx)), index=idx)
-            assert_series_equal(s['2013/01/01 10:00'], s[3600:3660])
-            assert_series_equal(s['2013/01/01 9H'], s[:3600])
+            tm.assert_series_equal(s['2013/01/01 10:00'], s[3600:3660])
+            tm.assert_series_equal(s['2013/01/01 9H'], s[:3600])
             for d in ['2013/01/01', '2013/01', '2013']:
-                assert_series_equal(s[d], s)
+                tm.assert_series_equal(s[d], s)
 
     def test_range_slice_seconds(self):
         # GH 6716
@@ -2741,14 +2735,14 @@ class TestPeriodIndex(tm.TestCase):
 
             s = Series(np.random.rand(len(idx)), index=idx)
 
-            assert_series_equal(s['2013/01/01 09:05':'2013/01/01 09:10'],
-                                s[300:660])
-            assert_series_equal(s['2013/01/01 10:00':'2013/01/01 10:05'],
-                                s[3600:3960])
-            assert_series_equal(s['2013/01/01 10H':], s[3600:])
-            assert_series_equal(s[:'2013/01/01 09:30'], s[:1860])
+            tm.assert_series_equal(s['2013/01/01 09:05':'2013/01/01 09:10'],
+                                   s[300:660])
+            tm.assert_series_equal(s['2013/01/01 10:00':'2013/01/01 10:05'],
+                                   s[3600:3960])
+            tm.assert_series_equal(s['2013/01/01 10H':], s[3600:])
+            tm.assert_series_equal(s[:'2013/01/01 09:30'], s[:1860])
             for d in ['2013/01/01', '2013/01', '2013']:
-                assert_series_equal(s[d:], s)
+                tm.assert_series_equal(s[d:], s)
 
     def test_range_slice_outofbounds(self):
         # GH 5407
@@ -2757,8 +2751,8 @@ class TestPeriodIndex(tm.TestCase):
 
         for idx in [didx, pidx]:
             df = DataFrame(dict(units=[100 + i for i in range(10)]), index=idx)
-            empty = DataFrame(index=idx.__class__(
-                [], freq='D'), columns=['units'])
+            empty = DataFrame(index=idx.__class__([], freq='D'),
+                              columns=['units'])
             empty['units'] = empty['units'].astype('int64')
 
             tm.assert_frame_equal(df['2013/09/01':'2013/09/30'], empty)
@@ -2949,16 +2943,16 @@ class TestPeriodIndex(tm.TestCase):
         result = ts + ts[::2]
         expected = ts + ts
         expected[1::2] = np.nan
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = ts + _permute(ts[::2])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # it works!
         for kind in ['inner', 'outer', 'left', 'right']:
             ts.align(ts[::2], join=kind)
         msg = "Input has different freq=D from PeriodIndex\\(freq=A-DEC\\)"
-        with assertRaisesRegexp(period.IncompatibleFrequency, msg):
+        with tm.assertRaisesRegexp(period.IncompatibleFrequency, msg):
             ts + ts.asfreq('D', how="end")
 
     def test_align_frame(self):
@@ -3158,7 +3152,7 @@ class TestPeriodIndex(tm.TestCase):
         tm.assert_index_equal(result, expected)
 
         result = index.map(lambda x: x.ordinal)
-        exp = [x.ordinal for x in index]
+        exp = np.array([x.ordinal for x in index], dtype=np.int64)
         tm.assert_numpy_array_equal(result, exp)
 
     def test_map_with_string_constructor(self):
@@ -4231,19 +4225,19 @@ class TestSeriesPeriod(tm.TestCase):
     def test_series_comparison_scalars(self):
         val = pd.Period('2000-01-04', freq='D')
         result = self.series > val
-        expected = np.array([x > val for x in self.series])
-        self.assert_numpy_array_equal(result, expected)
+        expected = pd.Series([x > val for x in self.series])
+        tm.assert_series_equal(result, expected)
 
         val = self.series[5]
         result = self.series > val
-        expected = np.array([x > val for x in self.series])
-        self.assert_numpy_array_equal(result, expected)
+        expected = pd.Series([x > val for x in self.series])
+        tm.assert_series_equal(result, expected)
 
     def test_between(self):
         left, right = self.series[[2, 7]]
         result = self.series.between(left, right)
         expected = (self.series >= left) & (self.series <= right)
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     # ---------------------------------------------------------------------
     # NaT support
@@ -4262,7 +4256,7 @@ class TestSeriesPeriod(tm.TestCase):
     def test_NaT_cast(self):
         result = Series([np.nan]).astype('period[D]')
         expected = Series([NaT])
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
     """
 
     def test_set_none_nan(self):

--- a/pandas/tseries/tests/test_plotting.py
+++ b/pandas/tseries/tests/test_plotting.py
@@ -330,7 +330,7 @@ class TestTSPlot(tm.TestCase):
         bts = DataFrame({'a': tm.makeTimeSeries()})
         ax = bts.plot()
         idx = ax.get_lines()[0].get_xdata()
-        tm.assert_numpy_array_equal(bts.index.to_period(), PeriodIndex(idx))
+        tm.assert_index_equal(bts.index.to_period(), PeriodIndex(idx))
 
     @slow
     def test_axis_limits(self):
@@ -1113,7 +1113,7 @@ class TestTSPlot(tm.TestCase):
         fig = plt.figure()
         ax = fig.add_subplot(111)
         lines = ax.plot(x, y, label='Y')
-        tm.assert_numpy_array_equal(DatetimeIndex(lines[0].get_xdata()), x)
+        tm.assert_index_equal(DatetimeIndex(lines[0].get_xdata()), x)
 
     @slow
     def test_mpl_nopandas(self):

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -1418,7 +1418,7 @@ class TestDatetimeIndex(Base, tm.TestCase):
         resampled = ts.resample('5min', base=2).mean()
         exp_rng = date_range('12/31/1999 23:57:00', '1/1/2000 01:57',
                              freq='5min')
-        self.assertTrue(resampled.index.equals(exp_rng))
+        self.assert_index_equal(resampled.index, exp_rng)
 
     def test_resample_base_with_timedeltaindex(self):
 
@@ -1432,8 +1432,8 @@ class TestDatetimeIndex(Base, tm.TestCase):
         exp_without_base = timedelta_range(start='0s', end='25s', freq='2s')
         exp_with_base = timedelta_range(start='5s', end='29s', freq='2s')
 
-        self.assertTrue(without_base.index.equals(exp_without_base))
-        self.assertTrue(with_base.index.equals(exp_with_base))
+        self.assert_index_equal(without_base.index, exp_without_base)
+        self.assert_index_equal(with_base.index, exp_with_base)
 
     def test_resample_categorical_data_with_timedeltaindex(self):
         # GH #12169
@@ -1464,7 +1464,7 @@ class TestDatetimeIndex(Base, tm.TestCase):
 
         result = ts.resample('M', kind='period').mean()
         exp_index = period_range('Jan-2000', 'Dec-2000', freq='M')
-        self.assertTrue(result.index.equals(exp_index))
+        self.assert_index_equal(result.index, exp_index)
 
     def test_period_with_agg(self):
 
@@ -1627,7 +1627,7 @@ class TestDatetimeIndex(Base, tm.TestCase):
 
         result = ts.resample('5t', closed='right', label='left').mean()
         ex_index = date_range('1999-12-31 23:55', periods=4, freq='5t')
-        self.assertTrue(result.index.equals(ex_index))
+        self.assert_index_equal(result.index, ex_index)
 
         len0pts = _simple_pts('2007-01', '2010-05', freq='M')[:0]
         # it works
@@ -2391,7 +2391,7 @@ class TestPeriodIndex(Base, tm.TestCase):
 
         ex_index = date_range(start='1/1/2012 9:30', freq='10min', periods=3)
 
-        self.assertTrue(result.index.equals(ex_index))
+        self.assert_index_equal(result.index, ex_index)
         assert_series_equal(result, exp)
 
     def test_quarterly_resampling(self):
@@ -2760,7 +2760,7 @@ class TestTimeGrouper(tm.TestCase):
 
         # it works!
         result = grouped.apply(f)
-        self.assertTrue(result.index.equals(df.index))
+        self.assert_index_equal(result.index, df.index)
 
     def test_panel_aggregation(self):
         ind = pd.date_range('1/1/2000', periods=100)

--- a/pandas/tseries/tests/test_timeseries_legacy.py
+++ b/pandas/tseries/tests/test_timeseries_legacy.py
@@ -85,7 +85,7 @@ class LegacySupport(object):
 
         ex_index = DatetimeIndex([], freq='B')
 
-        self.assertTrue(result.index.equals(ex_index))
+        self.assert_index_equal(result.index, ex_index)
         tm.assertIsInstance(result.index.freq, offsets.BDay)
         self.assertEqual(len(result), 0)
 
@@ -116,7 +116,7 @@ class LegacySupport(object):
                                    return_indexers=True)
 
             tm.assertIsInstance(ra, DatetimeIndex)
-            self.assertTrue(ra.equals(ea))
+            self.assert_index_equal(ra, ea)
 
             assert_almost_equal(rb, eb)
             assert_almost_equal(rc, ec)
@@ -150,24 +150,24 @@ class LegacySupport(object):
         result = index[:5].union(obj_index[5:])
         expected = index
         tm.assertIsInstance(result, DatetimeIndex)
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
 
         result = index[:10].intersection(obj_index[5:])
         expected = index[5:10]
         tm.assertIsInstance(result, DatetimeIndex)
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
 
         result = index[:10] - obj_index[5:]
         expected = index[:5]
         tm.assertIsInstance(result, DatetimeIndex)
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
 
     def test_index_conversion(self):
         index = self.frame.index
         obj_index = index.asobject
 
         conv = DatetimeIndex(obj_index)
-        self.assertTrue(conv.equals(index))
+        self.assert_index_equal(conv, index)
 
         self.assertRaises(ValueError, DatetimeIndex, ['a', 'b', 'c', 'd'])
 
@@ -188,11 +188,11 @@ class LegacySupport(object):
 
         result = index.union(right)
         expected = Index(np.concatenate([index.asobject, right]))
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
 
         result = index.intersection(right)
         expected = Index([])
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
 
     def test_legacy_time_rules(self):
         rules = [('WEEKDAY', 'B'), ('EOM', 'BM'), ('W@MON', 'W-MON'),
@@ -211,7 +211,7 @@ class LegacySupport(object):
         for old_freq, new_freq in rules:
             old_rng = date_range(start, end, freq=old_freq)
             new_rng = date_range(start, end, freq=new_freq)
-            self.assertTrue(old_rng.equals(new_rng))
+            self.assert_index_equal(old_rng, new_rng)
 
             # test get_legacy_offset_name
             offset = datetools.get_offset(new_freq)

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -263,7 +263,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         self.assertEqual(off, rng.tz)
 
         rng2 = date_range(start, periods=len(rng), tz=off)
-        self.assertTrue(rng.equals(rng2))
+        self.assert_index_equal(rng, rng2)
 
         rng3 = date_range('3/11/2012 05:00:00+07:00',
                           '6/11/2012 05:00:00+07:00')
@@ -287,7 +287,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         rng3 = date_range('3/11/2012 03:00', periods=15, freq='H')
         rng3 = rng3.tz_localize('US/Eastern')
 
-        self.assertTrue(rng.equals(rng3))
+        self.assert_index_equal(rng, rng3)
 
         # DST transition time
         val = rng[0]
@@ -296,14 +296,14 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         self.assertEqual(val.hour, 3)
         self.assertEqual(exp.hour, 3)
         self.assertEqual(val, exp)  # same UTC value
-        self.assertTrue(rng[:2].equals(rng2))
+        self.assert_index_equal(rng[:2], rng2)
 
         # Right before the DST transition
         rng = date_range('3/11/2012 00:00', periods=2, freq='H',
                          tz='US/Eastern')
         rng2 = DatetimeIndex(['3/11/2012 00:00', '3/11/2012 01:00'],
                              tz='US/Eastern')
-        self.assertTrue(rng.equals(rng2))
+        self.assert_index_equal(rng, rng2)
         exp = Timestamp('3/11/2012 00:00', tz='US/Eastern')
         self.assertEqual(exp.hour, 0)
         self.assertEqual(rng[0], exp)
@@ -402,7 +402,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         dr = bdate_range('1/1/2009', '1/1/2010')
         dr_utc = bdate_range('1/1/2009', '1/1/2010', tz=pytz.utc)
         localized = dr.tz_localize(pytz.utc)
-        self.assert_numpy_array_equal(dr_utc, localized)
+        self.assert_index_equal(dr_utc, localized)
 
     def test_with_tz_ambiguous_times(self):
         tz = self.tz('US/Eastern')
@@ -440,22 +440,22 @@ class TestTimeZoneSupportPytz(tm.TestCase):
                  '11/06/2011 02:00', '11/06/2011 03:00']
         di = DatetimeIndex(times)
         localized = di.tz_localize(tz, ambiguous='infer')
-        self.assert_numpy_array_equal(dr, localized)
+        self.assert_index_equal(dr, localized)
         with tm.assert_produces_warning(FutureWarning):
             localized_old = di.tz_localize(tz, infer_dst=True)
-        self.assert_numpy_array_equal(dr, localized_old)
-        self.assert_numpy_array_equal(dr, DatetimeIndex(times, tz=tz,
-                                                        ambiguous='infer'))
+        self.assert_index_equal(dr, localized_old)
+        self.assert_index_equal(dr, DatetimeIndex(times, tz=tz,
+                                                  ambiguous='infer'))
 
         # When there is no dst transition, nothing special happens
         dr = date_range(datetime(2011, 6, 1, 0), periods=10,
                         freq=datetools.Hour())
         localized = dr.tz_localize(tz)
         localized_infer = dr.tz_localize(tz, ambiguous='infer')
-        self.assert_numpy_array_equal(localized, localized_infer)
+        self.assert_index_equal(localized, localized_infer)
         with tm.assert_produces_warning(FutureWarning):
             localized_infer_old = dr.tz_localize(tz, infer_dst=True)
-        self.assert_numpy_array_equal(localized, localized_infer_old)
+        self.assert_index_equal(localized, localized_infer_old)
 
     def test_ambiguous_flags(self):
         # November 6, 2011, fall back, repeat 2 AM hour
@@ -471,20 +471,20 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         di = DatetimeIndex(times)
         is_dst = [1, 1, 0, 0, 0]
         localized = di.tz_localize(tz, ambiguous=is_dst)
-        self.assert_numpy_array_equal(dr, localized)
-        self.assert_numpy_array_equal(dr, DatetimeIndex(times, tz=tz,
-                                                        ambiguous=is_dst))
+        self.assert_index_equal(dr, localized)
+        self.assert_index_equal(dr, DatetimeIndex(times, tz=tz,
+                                                  ambiguous=is_dst))
 
         localized = di.tz_localize(tz, ambiguous=np.array(is_dst))
-        self.assert_numpy_array_equal(dr, localized)
+        self.assert_index_equal(dr, localized)
 
         localized = di.tz_localize(tz,
                                    ambiguous=np.array(is_dst).astype('bool'))
-        self.assert_numpy_array_equal(dr, localized)
+        self.assert_index_equal(dr, localized)
 
         # Test constructor
         localized = DatetimeIndex(times, tz=tz, ambiguous=is_dst)
-        self.assert_numpy_array_equal(dr, localized)
+        self.assert_index_equal(dr, localized)
 
         # Test duplicate times where infer_dst fails
         times += times
@@ -497,7 +497,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         is_dst = np.hstack((is_dst, is_dst))
         localized = di.tz_localize(tz, ambiguous=is_dst)
         dr = dr.append(dr)
-        self.assert_numpy_array_equal(dr, localized)
+        self.assert_index_equal(dr, localized)
 
         # When there is no dst transition, nothing special happens
         dr = date_range(datetime(2011, 6, 1, 0), periods=10,
@@ -505,7 +505,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         is_dst = np.array([1] * 10)
         localized = dr.tz_localize(tz)
         localized_is_dst = dr.tz_localize(tz, ambiguous=is_dst)
-        self.assert_numpy_array_equal(localized, localized_is_dst)
+        self.assert_index_equal(localized, localized_is_dst)
 
         # construction with an ambiguous end-point
         # GH 11626
@@ -531,7 +531,10 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         times = ['11/06/2011 00:00', np.NaN, np.NaN, '11/06/2011 02:00',
                  '11/06/2011 03:00']
         di_test = DatetimeIndex(times, tz='US/Eastern')
-        self.assert_numpy_array_equal(di_test, localized)
+
+        # left dtype is  datetime64[ns, US/Eastern]
+        # right is datetime64[ns, tzfile('/usr/share/zoneinfo/US/Eastern')]
+        self.assert_numpy_array_equal(di_test.values, localized.values)
 
     def test_nonexistent_raise_coerce(self):
         # See issue 13057
@@ -580,7 +583,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
                             tz=self.tzstr('US/Eastern'))
         expected = date_range('1/1/2000', periods=10, tz=self.tz('US/Eastern'))
 
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
 
     def test_take_dont_lose_meta(self):
         tm._skip_if_no_pytz()
@@ -673,7 +676,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         self.assertTrue(self.cmptz(result.tz, self.tz('US/Eastern')))
 
         converted = to_datetime(dates_aware, utc=True)
-        ex_vals = [Timestamp(x).value for x in dates_aware]
+        ex_vals = np.array([Timestamp(x).value for x in dates_aware])
         self.assert_numpy_array_equal(converted.asi8, ex_vals)
         self.assertIs(converted.tz, pytz.utc)
 
@@ -779,10 +782,11 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         self.assertTrue((dr.hour == 0).all())
 
     def test_convert_datetime_list(self):
-        dr = date_range('2012-06-02', periods=10, tz=self.tzstr('US/Eastern'))
+        dr = date_range('2012-06-02', periods=10,
+                        tz=self.tzstr('US/Eastern'), name='foo')
 
         dr2 = DatetimeIndex(list(dr), name='foo')
-        self.assertTrue(dr.equals(dr2))
+        self.assert_index_equal(dr, dr2)
         self.assertEqual(dr.tz, dr2.tz)
         self.assertEqual(dr2.name, 'foo')
 
@@ -845,7 +849,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         idx4 = DatetimeIndex(np.array(arr), tz=self.tzstr('US/Eastern'))
 
         for other in [idx2, idx3, idx4]:
-            self.assertTrue(idx1.equals(other))
+            self.assert_index_equal(idx1, other)
 
     def test_datetimeindex_tz_nat(self):
         idx = to_datetime([Timestamp("2013-1-1", tz=self.tzstr('US/Eastern')),
@@ -1011,7 +1015,7 @@ class TestTimeZones(tm.TestCase):
         conv = rng.tz_localize('US/Pacific')
         exp = date_range('1/1/2011', periods=100, freq='H', tz='US/Pacific')
 
-        self.assertTrue(conv.equals(exp))
+        self.assert_index_equal(conv, exp)
 
     def test_tz_localize_roundtrip(self):
         for tz in self.timezones:
@@ -1143,7 +1147,7 @@ class TestTimeZones(tm.TestCase):
         result = test1.join(test2, how='outer')
         ex_index = test1.index.union(test2.index)
 
-        self.assertTrue(result.index.equals(ex_index))
+        self.assert_index_equal(result.index, ex_index)
         self.assertTrue(result.index.tz.zone == 'US/Central')
 
         # non-overlapping
@@ -1199,11 +1203,11 @@ class TestTimeZones(tm.TestCase):
         ts1 = Series(np.random.randn(len(rng1)), index=rng1)
         ts2 = Series(np.random.randn(len(rng2)), index=rng2)
         ts_result = ts1.append(ts2)
+
         self.assertTrue(ts_result.index.equals(ts1.index.asobject.append(
             ts2.index.asobject)))
 
         # mixed
-
         rng1 = date_range('1/1/2011 01:00', periods=1, freq='H')
         rng2 = lrange(100)
         ts1 = Series(np.random.randn(len(rng1)), index=rng1)
@@ -1280,7 +1284,7 @@ class TestTimeZones(tm.TestCase):
         rng = date_range('03/12/2012 00:00', periods=10, freq='W-FRI',
                          tz='US/Eastern')
         rng2 = DatetimeIndex(data=rng, tz='US/Eastern')
-        self.assertTrue(rng.equals(rng2))
+        self.assert_index_equal(rng, rng2)
 
     def test_normalize_tz(self):
         rng = date_range('1/1/2000 9:30', periods=10, freq='D',
@@ -1289,7 +1293,7 @@ class TestTimeZones(tm.TestCase):
         result = rng.normalize()
         expected = date_range('1/1/2000', periods=10, freq='D',
                               tz='US/Eastern')
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
 
         self.assertTrue(result.is_normalized)
         self.assertFalse(rng.is_normalized)
@@ -1298,7 +1302,7 @@ class TestTimeZones(tm.TestCase):
 
         result = rng.normalize()
         expected = date_range('1/1/2000', periods=10, freq='D', tz='UTC')
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
 
         self.assertTrue(result.is_normalized)
         self.assertFalse(rng.is_normalized)
@@ -1307,7 +1311,7 @@ class TestTimeZones(tm.TestCase):
         rng = date_range('1/1/2000 9:30', periods=10, freq='D', tz=tzlocal())
         result = rng.normalize()
         expected = date_range('1/1/2000', periods=10, freq='D', tz=tzlocal())
-        self.assertTrue(result.equals(expected))
+        self.assert_index_equal(result, expected)
 
         self.assertTrue(result.is_normalized)
         self.assertFalse(rng.is_normalized)
@@ -1324,45 +1328,45 @@ class TestTimeZones(tm.TestCase):
                                       '2010-11-01 07:00'], freq='H', tz=tz)
 
             offset = dates + offsets.Hour(5)
-            self.assertTrue(offset.equals(expected))
+            self.assert_index_equal(offset, expected)
             offset = dates + np.timedelta64(5, 'h')
-            self.assertTrue(offset.equals(expected))
+            self.assert_index_equal(offset, expected)
             offset = dates + timedelta(hours=5)
-            self.assertTrue(offset.equals(expected))
+            self.assert_index_equal(offset, expected)
 
     def test_nat(self):
         # GH 5546
         dates = [NaT]
         idx = DatetimeIndex(dates)
         idx = idx.tz_localize('US/Pacific')
-        self.assertTrue(idx.equals(DatetimeIndex(dates, tz='US/Pacific')))
+        self.assert_index_equal(idx, DatetimeIndex(dates, tz='US/Pacific'))
         idx = idx.tz_convert('US/Eastern')
-        self.assertTrue(idx.equals(DatetimeIndex(dates, tz='US/Eastern')))
+        self.assert_index_equal(idx, DatetimeIndex(dates, tz='US/Eastern'))
         idx = idx.tz_convert('UTC')
-        self.assertTrue(idx.equals(DatetimeIndex(dates, tz='UTC')))
+        self.assert_index_equal(idx, DatetimeIndex(dates, tz='UTC'))
 
         dates = ['2010-12-01 00:00', '2010-12-02 00:00', NaT]
         idx = DatetimeIndex(dates)
         idx = idx.tz_localize('US/Pacific')
-        self.assertTrue(idx.equals(DatetimeIndex(dates, tz='US/Pacific')))
+        self.assert_index_equal(idx, DatetimeIndex(dates, tz='US/Pacific'))
         idx = idx.tz_convert('US/Eastern')
         expected = ['2010-12-01 03:00', '2010-12-02 03:00', NaT]
-        self.assertTrue(idx.equals(DatetimeIndex(expected, tz='US/Eastern')))
+        self.assert_index_equal(idx, DatetimeIndex(expected, tz='US/Eastern'))
 
         idx = idx + offsets.Hour(5)
         expected = ['2010-12-01 08:00', '2010-12-02 08:00', NaT]
-        self.assertTrue(idx.equals(DatetimeIndex(expected, tz='US/Eastern')))
+        self.assert_index_equal(idx, DatetimeIndex(expected, tz='US/Eastern'))
         idx = idx.tz_convert('US/Pacific')
         expected = ['2010-12-01 05:00', '2010-12-02 05:00', NaT]
-        self.assertTrue(idx.equals(DatetimeIndex(expected, tz='US/Pacific')))
+        self.assert_index_equal(idx, DatetimeIndex(expected, tz='US/Pacific'))
 
         idx = idx + np.timedelta64(3, 'h')
         expected = ['2010-12-01 08:00', '2010-12-02 08:00', NaT]
-        self.assertTrue(idx.equals(DatetimeIndex(expected, tz='US/Pacific')))
+        self.assert_index_equal(idx, DatetimeIndex(expected, tz='US/Pacific'))
 
         idx = idx.tz_convert('US/Eastern')
         expected = ['2010-12-01 11:00', '2010-12-02 11:00', NaT]
-        self.assertTrue(idx.equals(DatetimeIndex(expected, tz='US/Eastern')))
+        self.assert_index_equal(idx, DatetimeIndex(expected, tz='US/Eastern'))
 
 
 if __name__ == '__main__':

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -812,8 +812,9 @@ class TestDatetimeParsingWrappers(tm.TestCase):
         self.assert_series_equal(tools.to_time(Series(arg, name="test")),
                                  Series(expected_arr, name="test"))
 
-        self.assert_numpy_array_equal(tools.to_time(np.array(arg)),
-                                      np.array(expected_arr, dtype=np.object_))
+        res = tools.to_time(np.array(arg))
+        self.assertIsInstance(res, list)
+        self.assert_equal(res, expected_arr)
 
     def test_parsers_monthfreq(self):
         cases = {'201101': datetime.datetime(2011, 1, 1, 0, 0),


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`

2 changes to make tests more strict:
- `assert_numpy_array_equal` now checks input is `np.ndarray`
- `assert_almost_equal` now checks inputs are the same class.
