### PR TITLE
DOC: Fix read_stata docstring

### DIFF
--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -89,12 +89,14 @@ DataFrame or StataReader
 Examples
 --------
 Read a Stata dta file:
->> df = pandas.read_stata('filename.dta')
+
+>>> df = pandas.read_stata('filename.dta')
 
 Read a Stata dta file in 10,000 line chunks:
->> itr = pandas.read_stata('filename.dta', chunksize=10000)
->> for chunk in itr:
->>     do_something(chunk)
+
+>>> itr = pandas.read_stata('filename.dta', chunksize=10000)
+>>> for chunk in itr:
+>>>     do_something(chunk)
 """ % (_statafile_processing_params1, _encoding_params,
        _statafile_processing_params2, _chunksize_params,
        _iterator_params)


### PR DESCRIPTION
- [x] passes `git diff upstream/master | flake8 --diff`

Found docstring example is broken:
- http://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_stata.html
