### PR TITLE
Fix #13306: Hour overflow in tz-aware datetime conversions.

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -338,7 +338,7 @@ Bug Fixes
 - Bug in ``.resample(..)`` with a ``PeriodIndex`` not changing its ``freq`` appropriately when empty (:issue:`13067`)
 - Bug in ``.resample(..)`` with a ``PeriodIndex`` not retaining its type or name with an empty ``DataFrame``appropriately when empty (:issue:`13212`)
 - Bug in ``groupby(..).resample(..)`` where passing some keywords would raise an exception (:issue:`13235`)
-
+- Bug in ``.tz-convert`` tz-aware ``DateTimeIndex`` relies on index being sorted for correct results (:issue: `13306`)
 
 
 

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -902,44 +902,86 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
         # check that the time hasn't changed.
         self.assertEqual(ts, ts.tz_convert(dateutil.tz.tzutc()))
 
-    def test_tslib_tz_convert_hour_overflow_dst_bug(self):
+    def test_tz_convert_hour_overflow_dst(self):
         # Regression test for:
         # https://github.com/pydata/pandas/issues/13306
 
         # sorted case US/Eastern -> UTC
-        ts = ['2008-05-12 09:50:00-04:00',
-              '2008-12-12 09:50:35-05:00',
-              '2009-05-12 09:50:32-04:00']
+        ts = ['2008-05-12 09:50:00',
+              '2008-12-12 09:50:35',
+              '2009-05-12 09:50:32']
         tt = to_datetime(ts).tz_localize('US/Eastern')
         ut = tt.tz_convert('UTC')
-        expected = np.array([17, 19, 17], dtype=np.int32)
+        expected = np.array([13, 14, 13], dtype=np.int32)
         self.assert_numpy_array_equal(ut.hour, expected)
 
         # sorted case UTC -> US/Eastern
-        ts = ['2008-05-12 17:50:00',
-              '2008-12-12 19:50:35',
-              '2009-05-12 17:50:32']
+        ts = ['2008-05-12 13:50:00',
+              '2008-12-12 14:50:35',
+              '2009-05-12 13:50:32']
         tt = to_datetime(ts).tz_localize('UTC')
         ut = tt.tz_convert('US/Eastern')
-        expected = np.array([13, 14, 13], dtype=np.int32)
+        expected = np.array([9, 9, 9], dtype=np.int32)
         self.assert_numpy_array_equal(ut.hour, expected)
 
         # unsorted case US/Eastern -> UTC
-        ts = ['2008-05-12 09:50:00-04:00',
-              '2008-12-12 09:50:35-05:00',
-              '2008-05-12 09:50:32-04:00']
+        ts = ['2008-05-12 09:50:00',
+              '2008-12-12 09:50:35',
+              '2008-05-12 09:50:32']
         tt = to_datetime(ts).tz_localize('US/Eastern')
         ut = tt.tz_convert('UTC')
-        expected = np.array([17, 19, 17], dtype=np.int32)
+        expected = np.array([13, 14, 13], dtype=np.int32)
         self.assert_numpy_array_equal(ut.hour, expected)
 
         # unsorted case UTC -> US/Eastern
-        ts = ['2008-05-12 17:50:00',
-              '2008-12-12 19:50:35',
-              '2008-05-12 17:50:32']
+        ts = ['2008-05-12 13:50:00',
+              '2008-12-12 14:50:35',
+              '2008-05-12 13:50:32']
         tt = to_datetime(ts).tz_localize('UTC')
         ut = tt.tz_convert('US/Eastern')
+        expected = np.array([9, 9, 9], dtype=np.int32)
+        self.assert_numpy_array_equal(ut.hour, expected)
+
+    def test_tz_convert_hour_overflow_dst_timestamps(self):
+        # Regression test for:
+        # https://github.com/pydata/pandas/issues/13306
+
+        tz = self.tzstr('US/Eastern')
+
+        # sorted case US/Eastern -> UTC
+        ts = [Timestamp('2008-05-12 09:50:00', tz=tz),
+              Timestamp('2008-12-12 09:50:35', tz=tz),
+              Timestamp('2009-05-12 09:50:32', tz=tz)]
+        tt = to_datetime(ts)
+        ut = tt.tz_convert('UTC')
         expected = np.array([13, 14, 13], dtype=np.int32)
+        self.assert_numpy_array_equal(ut.hour, expected)
+
+        # sorted case UTC -> US/Eastern
+        ts = [Timestamp('2008-05-12 13:50:00', tz='UTC'),
+              Timestamp('2008-12-12 14:50:35', tz='UTC'),
+              Timestamp('2009-05-12 13:50:32', tz='UTC')]
+        tt = to_datetime(ts)
+        ut = tt.tz_convert('US/Eastern')
+        expected = np.array([9, 9, 9], dtype=np.int32)
+        self.assert_numpy_array_equal(ut.hour, expected)
+
+        # unsorted case US/Eastern -> UTC
+        ts = [Timestamp('2008-05-12 09:50:00', tz=tz),
+              Timestamp('2008-12-12 09:50:35', tz=tz),
+              Timestamp('2008-05-12 09:50:32', tz=tz)]
+        tt = to_datetime(ts)
+        ut = tt.tz_convert('UTC')
+        expected = np.array([13, 14, 13], dtype=np.int32)
+        self.assert_numpy_array_equal(ut.hour, expected)
+
+        # unsorted case UTC -> US/Eastern
+        ts = [Timestamp('2008-05-12 13:50:00', tz='UTC'),
+              Timestamp('2008-12-12 14:50:35', tz='UTC'),
+              Timestamp('2008-05-12 13:50:32', tz='UTC')]
+        tt = to_datetime(ts)
+        ut = tt.tz_convert('US/Eastern')
+        expected = np.array([9, 9, 9], dtype=np.int32)
         self.assert_numpy_array_equal(ut.hour, expected)
 
     def test_tslib_tz_convert_trans_pos_plus_1__bug(self):

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -902,6 +902,46 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
         # check that the time hasn't changed.
         self.assertEqual(ts, ts.tz_convert(dateutil.tz.tzutc()))
 
+    def test_tslib_tz_convert_hour_overflow_dst_bug(self):
+        # Regression test for:
+        # https://github.com/pydata/pandas/issues/13306
+
+        # sorted case US/Eastern -> UTC
+        ts = ['2008-05-12 09:50:00-04:00',
+              '2008-12-12 09:50:35-05:00',
+              '2009-05-12 09:50:32-04:00']
+        tt = to_datetime(ts).tz_localize('US/Eastern')
+        ut = tt.tz_convert('UTC')
+        expected = np.array([17, 19, 17], dtype=np.int32)
+        self.assert_numpy_array_equal(ut.hour, expected)
+
+        # sorted case UTC -> US/Eastern
+        ts = ['2008-05-12 17:50:00',
+              '2008-12-12 19:50:35',
+              '2009-05-12 17:50:32']
+        tt = to_datetime(ts).tz_localize('UTC')
+        ut = tt.tz_convert('US/Eastern')
+        expected = np.array([13, 14, 13], dtype=np.int32)
+        self.assert_numpy_array_equal(ut.hour, expected)
+
+        # unsorted case US/Eastern -> UTC
+        ts = ['2008-05-12 09:50:00-04:00',
+              '2008-12-12 09:50:35-05:00',
+              '2008-05-12 09:50:32-04:00']
+        tt = to_datetime(ts).tz_localize('US/Eastern')
+        ut = tt.tz_convert('UTC')
+        expected = np.array([17, 19, 17], dtype=np.int32)
+        self.assert_numpy_array_equal(ut.hour, expected)
+
+        # unsorted case UTC -> US/Eastern
+        ts = ['2008-05-12 17:50:00',
+              '2008-12-12 19:50:35',
+              '2008-05-12 17:50:32']
+        tt = to_datetime(ts).tz_localize('UTC')
+        ut = tt.tz_convert('US/Eastern')
+        expected = np.array([13, 14, 13], dtype=np.int32)
+        self.assert_numpy_array_equal(ut.hour, expected)
+
     def test_tslib_tz_convert_trans_pos_plus_1__bug(self):
         # Regression test for tslib.tz_convert(vals, tz1, tz2).
         # See https://github.com/pydata/pandas/issues/4496 for details.

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -3838,20 +3838,15 @@ def tz_convert(ndarray[int64_t] vals, object tz1, object tz2):
     if (result==NPY_NAT).all():
         return result
 
-    pos = trans.searchsorted(utc_dates[utc_dates!=NPY_NAT][0]) - 1
-    if pos < 0:
-        raise ValueError('First time before start of DST info')
-
-    # TODO: this assumed sortedness :/
-    offset = deltas[pos]
     for i in range(n):
         v = utc_dates[i]
         if vals[i] == NPY_NAT:
             result[i] = vals[i]
         else:
-            while pos + 1 < trans_len and v >= trans[pos + 1]:
-                pos += 1
-                offset = deltas[pos]
+            pos = trans.searchsorted(v, side='right') - 1
+            if pos < 0:
+                raise ValueError('First time before start of DST info')
+            offset = deltas[pos]
             result[i] = v + offset
     return result
 


### PR DESCRIPTION
- [x] closes #13306
- [x] tests passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
      Bug: tz-converting tz-aware DateTimeIndex relied on index being sorted for correct results.
