### PR TITLE
BUG: Check for NaN after data conversion to numeric

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -291,6 +291,7 @@ Bug Fixes
 
 
 
+- Bug in ``pd.read_csv()`` with ``engine='python'`` in which ``NaN`` values weren't being detected after data was converted to numeric values (:issue:`13314`)
 - Bug in ``MultiIndex`` slicing where extra elements were returned when level is non-unique (:issue:`12896`)
 
 

--- a/pandas/src/inference.pyx
+++ b/pandas/src/inference.pyx
@@ -596,7 +596,13 @@ def maybe_convert_numeric(object[:] values, set na_values,
         else:
             try:
                 status = floatify(val, &fval, &maybe_int)
-                floats[i] = fval
+
+                if fval in na_values:
+                    floats[i] = complexes[i] = nan
+                    seen_float = True
+                else:
+                    floats[i] = fval
+
                 if not seen_float:
                     if maybe_int:
                         as_int = int(val)

--- a/pandas/tests/test_lib.py
+++ b/pandas/tests/test_lib.py
@@ -188,6 +188,9 @@ class TestMisc(tm.TestCase):
         self.assertFalse(lib.isneginf_scalar(1))
         self.assertFalse(lib.isneginf_scalar('a'))
 
+
+# tests related to functions imported from inference.pyx
+class TestInference(tm.TestCase):
     def test_maybe_convert_numeric_infinities(self):
         # see gh-13274
         infinities = ['inf', 'inF', 'iNf', 'Inf',
@@ -226,6 +229,16 @@ class TestMisc(tm.TestCase):
                     lib.maybe_convert_numeric(
                         np.array(['foo_' + infinity], dtype=object),
                         na_values, maybe_int)
+
+    def test_maybe_convert_numeric_post_floatify_nan(self):
+        # see gh-13314
+        data = np.array(['1.200', '-999.000', '4.500'], dtype=object)
+        expected = np.array([1.2, np.nan, 4.5], dtype=np.float64)
+        nan_values = set([-999, -999.0])
+
+        for coerce_type in (True, False):
+            out = lib.maybe_convert_numeric(data, nan_values, coerce_type)
+            tm.assert_numpy_array_equal(out, expected)
 
 
 class Testisscalar(tm.TestCase):


### PR DESCRIPTION
In an attempt to squash a Python parser bug in which weirdly-formed floats weren't being checked for `nan`, the bug was traced back to a bug in the `maybe_convert_numeric` function of `pandas/src/inference.pyx`.  Added tests for the bug in `test_lib.py` and adjusted the original `nan` tests in `na_values.py` to test all of the engines.
