### PR TITLE
BUG: Groupby.nth includes group key inconsistently #12839

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -313,7 +313,7 @@ Bug Fixes
 
 
 - Bug in ``groupby`` where ``apply`` returns different result depending on whether first result is ``None`` or not (:issue:`12824`)
-
+- Bug in ``groupby(..).nth()`` where the group key is included inconsistently (:issue:`12839`)
 
 
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -457,7 +457,7 @@ class _GroupBy(PandasObject, SelectionMixin):
         else:
             return self.obj[self._selection]
 
-    def _clear_group_selection(self):
+    def _reset_group_selection(self):
         """
         Clear group based selection. Used for methods needing to return info on
         each group regardless of whether a group selection was previously set.
@@ -1417,7 +1417,7 @@ class GroupBy(_GroupBy):
         0  1  2
         2  5  6
         """
-        self._clear_group_selection()
+        self._reset_group_selection()
         mask = self._cumcount_array() < n
         return self._selected_obj[mask]
 
@@ -1444,7 +1444,7 @@ class GroupBy(_GroupBy):
         0  a  1
         2  b  1
         """
-        self._clear_group_selection()
+        self._reset_group_selection()
         mask = self._cumcount_array(ascending=False) < n
         return self._selected_obj[mask]
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -457,6 +457,11 @@ class _GroupBy(PandasObject, SelectionMixin):
         else:
             return self.obj[self._selection]
 
+    def _reset_group_selection(self):
+        if self._group_selection is not None:
+            self._group_selection = None
+            self._reset_cache('_selected_obj')
+
     def _set_selection_from_grouper(self):
         """ we may need create a selection if we have non-level groupers """
         grp = self.grouper
@@ -468,6 +473,7 @@ class _GroupBy(PandasObject, SelectionMixin):
 
             if len(groupers):
                 self._group_selection = ax.difference(Index(groupers)).tolist()
+                self._reset_cache('_selected_obj')
 
     def _set_result_index_ordered(self, result):
         # set the result index on the passed values object and
@@ -1402,6 +1408,7 @@ class GroupBy(_GroupBy):
         0  1  2
         2  5  6
         """
+        self._reset_group_selection()
         mask = self._cumcount_array() < n
         return self._selected_obj[mask]
 
@@ -1428,6 +1435,7 @@ class GroupBy(_GroupBy):
         0  a  1
         2  b  1
         """
+        self._reset_group_selection()
         mask = self._cumcount_array(ascending=False) < n
         return self._selected_obj[mask]
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -95,7 +95,7 @@ def _groupby_function(name, alias, npfunc, numeric_only=True,
     @Appender(_doc_template)
     @Appender(_local_template)
     def f(self):
-        self._set_selection_from_grouper()
+        self._set_group_selection()
         try:
             return self._cython_agg_general(alias, numeric_only=numeric_only)
         except AssertionError as e:
@@ -457,13 +457,21 @@ class _GroupBy(PandasObject, SelectionMixin):
         else:
             return self.obj[self._selection]
 
-    def _reset_group_selection(self):
+    def _clear_group_selection(self):
+        """
+        Clear group based selection. Used for methods needing to return info on
+        each group regardless of whether a group selection was previously set.
+        """
         if self._group_selection is not None:
             self._group_selection = None
+            # GH12839 clear cached selection too when changing group selection
             self._reset_cache('_selected_obj')
 
-    def _set_selection_from_grouper(self):
-        """ we may need create a selection if we have non-level groupers """
+    def _set_group_selection(self):
+        """
+        Create group based selection. Used when selection is not passed
+        directly but instead via a grouper.
+        """
         grp = self.grouper
         if self.as_index and getattr(grp, 'groupings', None) is not None and \
            self.obj.ndim > 1:
@@ -473,6 +481,7 @@ class _GroupBy(PandasObject, SelectionMixin):
 
             if len(groupers):
                 self._group_selection = ax.difference(Index(groupers)).tolist()
+                # GH12839 clear selected obj cache when group selection changes
                 self._reset_cache('_selected_obj')
 
     def _set_result_index_ordered(self, result):
@@ -517,7 +526,7 @@ class _GroupBy(PandasObject, SelectionMixin):
 
         # need to setup the selection
         # as are not passed directly but in the grouper
-        self._set_selection_from_grouper()
+        self._set_group_selection()
 
         f = getattr(self._selected_obj, name)
         if not isinstance(f, types.MethodType):
@@ -985,7 +994,7 @@ class GroupBy(_GroupBy):
         except GroupByError:
             raise
         except Exception:  # pragma: no cover
-            self._set_selection_from_grouper()
+            self._set_group_selection()
             f = lambda x: x.mean(axis=self.axis)
             return self._python_agg_general(f)
 
@@ -1003,7 +1012,7 @@ class GroupBy(_GroupBy):
             raise
         except Exception:  # pragma: no cover
 
-            self._set_selection_from_grouper()
+            self._set_group_selection()
 
             def f(x):
                 if isinstance(x, np.ndarray):
@@ -1046,7 +1055,7 @@ class GroupBy(_GroupBy):
         if ddof == 1:
             return self._cython_agg_general('var')
         else:
-            self._set_selection_from_grouper()
+            self._set_group_selection()
             f = lambda x: x.var(ddof=ddof)
             return self._python_agg_general(f)
 
@@ -1222,7 +1231,7 @@ class GroupBy(_GroupBy):
             raise TypeError("n needs to be an int or a list/set/tuple of ints")
 
         nth_values = np.array(nth_values, dtype=np.intp)
-        self._set_selection_from_grouper()
+        self._set_group_selection()
 
         if not dropna:
             mask = np.in1d(self._cumcount_array(), nth_values) | \
@@ -1330,7 +1339,7 @@ class GroupBy(_GroupBy):
         dtype: int64
         """
 
-        self._set_selection_from_grouper()
+        self._set_group_selection()
 
         index = self._selected_obj.index
         cumcounts = self._cumcount_array(ascending=ascending)
@@ -1408,7 +1417,7 @@ class GroupBy(_GroupBy):
         0  1  2
         2  5  6
         """
-        self._reset_group_selection()
+        self._clear_group_selection()
         mask = self._cumcount_array() < n
         return self._selected_obj[mask]
 
@@ -1435,7 +1444,7 @@ class GroupBy(_GroupBy):
         0  a  1
         2  b  1
         """
-        self._reset_group_selection()
+        self._clear_group_selection()
         mask = self._cumcount_array(ascending=False) < n
         return self._selected_obj[mask]
 

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -379,16 +379,6 @@ class TestGroupBy(tm.TestCase):
         result = g.tail(n=2)
         assert_frame_equal(result, df)
 
-        g = df.groupby('A')
-        g.head()
-        result = g.head(n=2)
-        assert_frame_equal(result, df)
-
-        g = df.groupby('A')
-        g.tail()
-        result = g.tail(n=2)
-        assert_frame_equal(result, df)
-
     def test_grouper_index_types(self):
         # related GH5375
         # groupby misbehaving when using a Floatlike index

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -354,6 +354,41 @@ class TestGroupBy(tm.TestCase):
                                          names=['A', 'B']))
         assert_frame_equal(result, expected)
 
+    def test_group_selection_cache(self):
+        # GH 12839 nth, head, and tail should return same result consistently
+        df = DataFrame([[1, 2], [1, 4], [5, 6]], columns=['A', 'B'])
+        expected = df.iloc[[0, 2]].set_index('A')
+
+        g = df.groupby('A')
+        g.head()
+        result = g.nth(0)
+        assert_frame_equal(result, expected)
+
+        g = df.groupby('A')
+        g.tail()
+        result = g.nth(0)
+        assert_frame_equal(result, expected)
+
+        g = df.groupby('A')
+        g.nth(0)
+        result = g.head(n=2)
+        assert_frame_equal(result, df)
+
+        g = df.groupby('A')
+        g.nth(0)
+        result = g.tail(n=2)
+        assert_frame_equal(result, df)
+
+        g = df.groupby('A')
+        g.head()
+        result = g.head(n=2)
+        assert_frame_equal(result, df)
+
+        g = df.groupby('A')
+        g.tail()
+        result = g.tail(n=2)
+        assert_frame_equal(result, df)
+
     def test_grouper_index_types(self):
         # related GH5375
         # groupby misbehaving when using a Floatlike index

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -360,24 +360,28 @@ class TestGroupBy(tm.TestCase):
         expected = df.iloc[[0, 2]].set_index('A')
 
         g = df.groupby('A')
-        g.head()
-        result = g.nth(0)
-        assert_frame_equal(result, expected)
+        result1 = g.head(n=2)
+        result2 = g.nth(0)
+        assert_frame_equal(result1, df)
+        assert_frame_equal(result2, expected)
 
         g = df.groupby('A')
-        g.tail()
-        result = g.nth(0)
-        assert_frame_equal(result, expected)
+        result1 = g.tail(n=2)
+        result2 = g.nth(0)
+        assert_frame_equal(result1, df)
+        assert_frame_equal(result2, expected)
 
         g = df.groupby('A')
-        g.nth(0)
-        result = g.head(n=2)
-        assert_frame_equal(result, df)
+        result1 = g.nth(0)
+        result2 = g.head(n=2)
+        assert_frame_equal(result1, expected)
+        assert_frame_equal(result2, df)
 
         g = df.groupby('A')
-        g.nth(0)
-        result = g.tail(n=2)
-        assert_frame_equal(result, df)
+        result1 = g.nth(0)
+        result2 = g.tail(n=2)
+        assert_frame_equal(result1, expected)
+        assert_frame_equal(result2, df)
 
     def test_grouper_index_types(self):
         # related GH5375
@@ -6132,7 +6136,7 @@ class TestGroupBy(tm.TestCase):
                 # bit a of hack to make sure the cythonized shift
                 # is equivalent to pre 0.17.1 behavior
                 if op == 'shift':
-                    gb._set_selection_from_grouper()
+                    gb._set_group_selection()
 
                 for (op, args), targop in ops:
                     if op != 'shift' and 'int' not in gb_target:


### PR DESCRIPTION
- [x] closes #12839
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

When the group selection changes, the cache for `_selected_obj` needs to be reset so that `nth`, `head`, and `tail` can return consistent results.
