### PR TITLE
API: Deprecate compact_ints and use_unsigned in read_csv

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -176,6 +176,17 @@ low_memory : boolean, default ``True``
   Note that the entire file is read into a single DataFrame regardless,
   use the ``chunksize`` or ``iterator`` parameter to return the data in chunks.
   (Only valid with C parser)
+compact_ints : boolean, default False
+  DEPRECATED: this argument will be removed in a future version
+
+  If ``compact_ints`` is ``True``, then for any column that is of integer dtype, the
+  parser will attempt to cast it as the smallest integer ``dtype`` possible, either
+  signed or unsigned depending on the specification from the ``use_unsigned`` parameter.
+use_unsigned : boolean, default False
+  DEPRECATED: this argument will be removed in a future version
+
+  If integer columns are being compacted (i.e. ``compact_ints=True``), specify whether
+  the column should be compacted to the smallest signed or unsigned integer dtype.
 
 NA and Missing Data Handling
 ++++++++++++++++++++++++++++

--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -292,6 +292,7 @@ Other API changes
 Deprecations
 ^^^^^^^^^^^^
 
+- ``compact_ints`` and ``use_unsigned`` have been deprecated in ``pd.read_csv`` and will be removed in a future version (:issue:`13320`)
 
 .. _whatsnew_0182.performance:
 

--- a/pandas/io/tests/parser/c_parser_only.py
+++ b/pandas/io/tests/parser/c_parser_only.py
@@ -172,28 +172,8 @@ nan 2
         self.assertTrue(sum(precise_errors) <= sum(normal_errors))
         self.assertTrue(max(precise_errors) <= max(normal_errors))
 
-    def test_compact_ints(self):
-        if compat.is_platform_windows() and not self.low_memory:
-            raise nose.SkipTest(
-                "segfaults on win-64, only when all tests are run")
-
-        data = ('0,1,0,0\n'
-                '1,1,0,0\n'
-                '0,1,0,1')
-
-        result = self.read_csv(StringIO(data), delimiter=',', header=None,
-                               compact_ints=True, as_recarray=True)
-        ex_dtype = np.dtype([(str(i), 'i1') for i in range(4)])
-        self.assertEqual(result.dtype, ex_dtype)
-
-        result = self.read_csv(StringIO(data), delimiter=',', header=None,
-                               as_recarray=True, compact_ints=True,
-                               use_unsigned=True)
-        ex_dtype = np.dtype([(str(i), 'u1') for i in range(4)])
-        self.assertEqual(result.dtype, ex_dtype)
-
     def test_compact_ints_as_recarray(self):
-        if compat.is_platform_windows() and self.low_memory:
+        if compat.is_platform_windows():
             raise nose.SkipTest(
                 "segfaults on win-64, only when all tests are run")
 
@@ -201,16 +181,20 @@ nan 2
                 '1,1,0,0\n'
                 '0,1,0,1')
 
-        result = self.read_csv(StringIO(data), delimiter=',', header=None,
-                               compact_ints=True, as_recarray=True)
-        ex_dtype = np.dtype([(str(i), 'i1') for i in range(4)])
-        self.assertEqual(result.dtype, ex_dtype)
+        with tm.assert_produces_warning(
+                FutureWarning, check_stacklevel=False):
+            result = self.read_csv(StringIO(data), delimiter=',', header=None,
+                                   compact_ints=True, as_recarray=True)
+            ex_dtype = np.dtype([(str(i), 'i1') for i in range(4)])
+            self.assertEqual(result.dtype, ex_dtype)
 
-        result = self.read_csv(StringIO(data), delimiter=',', header=None,
-                               as_recarray=True, compact_ints=True,
-                               use_unsigned=True)
-        ex_dtype = np.dtype([(str(i), 'u1') for i in range(4)])
-        self.assertEqual(result.dtype, ex_dtype)
+        with tm.assert_produces_warning(
+                FutureWarning, check_stacklevel=False):
+            result = self.read_csv(StringIO(data), delimiter=',', header=None,
+                                   as_recarray=True, compact_ints=True,
+                                   use_unsigned=True)
+            ex_dtype = np.dtype([(str(i), 'u1') for i in range(4)])
+            self.assertEqual(result.dtype, ex_dtype)
 
     def test_pass_dtype(self):
         data = """\

--- a/pandas/io/tests/parser/common.py
+++ b/pandas/io/tests/parser/common.py
@@ -1330,3 +1330,46 @@ j,-inF"""
         # test with more than a single newline
         data = "\n\n\n"
         self.assertRaises(EmptyDataError, self.read_csv, StringIO(data))
+
+    def test_compact_ints_use_unsigned(self):
+        # see gh-13323
+        data = 'a,b,c\n1,9,258'
+
+        # sanity check
+        expected = DataFrame({
+            'a': np.array([1], dtype=np.int64),
+            'b': np.array([9], dtype=np.int64),
+            'c': np.array([258], dtype=np.int64),
+        })
+        out = self.read_csv(StringIO(data))
+        tm.assert_frame_equal(out, expected)
+
+        expected = DataFrame({
+            'a': np.array([1], dtype=np.int8),
+            'b': np.array([9], dtype=np.int8),
+            'c': np.array([258], dtype=np.int16),
+        })
+
+        # default behaviour for 'use_unsigned'
+        with tm.assert_produces_warning(
+                FutureWarning, check_stacklevel=False):
+            out = self.read_csv(StringIO(data), compact_ints=True)
+            tm.assert_frame_equal(out, expected)
+
+        with tm.assert_produces_warning(
+                FutureWarning, check_stacklevel=False):
+            out = self.read_csv(StringIO(data), compact_ints=True,
+                                use_unsigned=False)
+            tm.assert_frame_equal(out, expected)
+
+        expected = DataFrame({
+            'a': np.array([1], dtype=np.uint8),
+            'b': np.array([9], dtype=np.uint8),
+            'c': np.array([258], dtype=np.uint16),
+        })
+
+        with tm.assert_produces_warning(
+                FutureWarning, check_stacklevel=False):
+            out = self.read_csv(StringIO(data), compact_ints=True,
+                                use_unsigned=True)
+            tm.assert_frame_equal(out, expected)

--- a/pandas/io/tests/parser/test_unsupported.py
+++ b/pandas/io/tests/parser/test_unsupported.py
@@ -117,6 +117,27 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
                 with tm.assertRaisesRegexp(ValueError, msg):
                     read_csv(StringIO(data), engine=engine, **kwargs)
 
+
+class TestDeprecatedFeatures(tm.TestCase):
+    def test_deprecated_args(self):
+        data = '1,2,3'
+
+        # deprecated arguments with non-default values
+        deprecated = {
+            'compact_ints': True,
+            'use_unsigned': True,
+        }
+
+        engines = 'c', 'python'
+
+        for engine in engines:
+            for arg, non_default_val in deprecated.items():
+                with tm.assert_produces_warning(
+                        FutureWarning, check_stacklevel=False):
+                    kwargs = {arg: non_default_val}
+                    read_csv(StringIO(data), engine=engine,
+                             **kwargs)
+
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
                    exit=False)

--- a/pandas/src/inference.pyx
+++ b/pandas/src/inference.pyx
@@ -6,6 +6,20 @@ iNaT = util.get_nat()
 
 cdef bint PY2 = sys.version_info[0] == 2
 
+cdef extern from "headers/stdint.h":
+    enum: UINT8_MAX
+    enum: UINT16_MAX
+    enum: UINT32_MAX
+    enum: UINT64_MAX
+    enum: INT8_MIN
+    enum: INT8_MAX
+    enum: INT16_MIN
+    enum: INT16_MAX
+    enum: INT32_MAX
+    enum: INT32_MIN
+    enum: INT64_MAX
+    enum: INT64_MIN
+
 # core.common import for fast inference checks
 def is_float(object obj):
     return util.is_float_object(obj)
@@ -1240,3 +1254,74 @@ def fast_multiget(dict mapping, ndarray keys, default=np.nan):
             output[i] = default
 
     return maybe_convert_objects(output)
+
+
+def downcast_int64(ndarray[int64_t] arr, object na_values,
+                   bint use_unsigned=0):
+    cdef:
+        Py_ssize_t i, n = len(arr)
+        int64_t mx = INT64_MIN + 1, mn = INT64_MAX
+        int64_t NA = na_values[np.int64]
+        int64_t val
+        ndarray[uint8_t] mask
+        int na_count = 0
+
+    _mask = np.empty(n, dtype=bool)
+    mask = _mask.view(np.uint8)
+
+    for i in range(n):
+        val = arr[i]
+
+        if val == NA:
+            mask[i] = 1
+            na_count += 1
+            continue
+
+        # not NA
+        mask[i] = 0
+
+        if val > mx:
+            mx = val
+
+        if val < mn:
+            mn = val
+
+    if mn >= 0 and use_unsigned:
+        if mx <= UINT8_MAX - 1:
+            result = arr.astype(np.uint8)
+            if na_count:
+                np.putmask(result, _mask, na_values[np.uint8])
+            return result
+
+        if mx <= UINT16_MAX - 1:
+            result = arr.astype(np.uint16)
+            if na_count:
+                np.putmask(result, _mask, na_values[np.uint16])
+            return result
+
+        if mx <= UINT32_MAX - 1:
+            result = arr.astype(np.uint32)
+            if na_count:
+                np.putmask(result, _mask, na_values[np.uint32])
+            return result
+
+    else:
+        if mn >= INT8_MIN + 1 and mx <= INT8_MAX:
+            result = arr.astype(np.int8)
+            if na_count:
+                np.putmask(result, _mask, na_values[np.int8])
+            return result
+
+        if mn >= INT16_MIN + 1 and mx <= INT16_MAX:
+            result = arr.astype(np.int16)
+            if na_count:
+                np.putmask(result, _mask, na_values[np.int16])
+            return result
+
+        if mn >= INT32_MIN + 1 and mx <= INT32_MAX:
+            result = arr.astype(np.int32)
+            if na_count:
+                np.putmask(result, _mask, na_values[np.int32])
+            return result
+
+    return arr

--- a/pandas/tests/test_infer_and_convert.py
+++ b/pandas/tests/test_infer_and_convert.py
@@ -401,6 +401,42 @@ class TestParseSQL(tm.TestCase):
         expected = np.array([1.5, np.nan, 3, 4.2], dtype='f8')
         self.assert_numpy_array_equal(result, expected)
 
+    def test_convert_downcast_int64(self):
+        from pandas.parser import na_values
+
+        arr = np.array([1, 2, 7, 8, 10], dtype=np.int64)
+        expected = np.array([1, 2, 7, 8, 10], dtype=np.int8)
+
+        # default argument
+        result = lib.downcast_int64(arr, na_values)
+        self.assert_numpy_array_equal(result, expected)
+
+        result = lib.downcast_int64(arr, na_values, use_unsigned=False)
+        self.assert_numpy_array_equal(result, expected)
+
+        expected = np.array([1, 2, 7, 8, 10], dtype=np.uint8)
+        result = lib.downcast_int64(arr, na_values, use_unsigned=True)
+        self.assert_numpy_array_equal(result, expected)
+
+        # still cast to int8 despite use_unsigned=True
+        # because of the negative number as an element
+        arr = np.array([1, 2, -7, 8, 10], dtype=np.int64)
+        expected = np.array([1, 2, -7, 8, 10], dtype=np.int8)
+        result = lib.downcast_int64(arr, na_values, use_unsigned=True)
+        self.assert_numpy_array_equal(result, expected)
+
+        arr = np.array([1, 2, 7, 8, 300], dtype=np.int64)
+        expected = np.array([1, 2, 7, 8, 300], dtype=np.int16)
+        result = lib.downcast_int64(arr, na_values)
+        self.assert_numpy_array_equal(result, expected)
+
+        int8_na = na_values[np.int8]
+        int64_na = na_values[np.int64]
+        arr = np.array([int64_na, 2, 3, 10, 15], dtype=np.int64)
+        expected = np.array([int8_na, 2, 3, 10, 15], dtype=np.int8)
+        result = lib.downcast_int64(arr, na_values)
+        self.assert_numpy_array_equal(result, expected)
+
 if __name__ == '__main__':
     import nose
 


### PR DESCRIPTION
Title is self-explanatory.

xref #12686 - I don't quite understand why these are marked (if at all) as internal to the C engine only, as the benefits for having these options accepted for the Python engine is quite clear based on the documentation I added as well.

Implementation simply just calls the already-written function in `pandas/parsers.pyx` - as it isn't specific to the `TextReader` class, crossing over to grab this function from Cython (instead of duplicating in pure Python) seems reasonable while maintaining that separation between the C and Python engines.
