### PR TITLE
DOC: fix comment on previous versions cythonmagic

### DIFF
--- a/doc/source/enhancingperf.rst
+++ b/doc/source/enhancingperf.rst
@@ -95,7 +95,7 @@ Plain cython
 ~~~~~~~~~~~~
 
 First we're going to need to import the cython magic function to ipython (for
-cython versions >=0.21 you can use ``%load_ext Cython``):
+cython versions  < 0.21 you can use ``%load_ext cythonmagic``):
 
 .. ipython:: python
    :okwarning:


### PR DESCRIPTION
Small thing I just noticed in the docs (the note on the other version was not updated when the example was changed from cythonmagic -> Cython)
