### PR TITLE
BUG: revert assert_numpy_array_equal to before c2ea8fb2 (accept non-ndarrays)

### DIFF
--- a/pandas/tests/test_testing.py
+++ b/pandas/tests/test_testing.py
@@ -186,7 +186,7 @@ numpy array shapes are different
             assert_almost_equal(np.array([1, 2]), np.array([3, 4, 5]))
 
         # scalar comparison
-        expected = """Expected type """
+        expected = """: 1 != 2"""
         with assertRaisesRegexp(AssertionError, expected):
             assert_numpy_array_equal(1, 2)
         expected = """expected 2\\.00000 but got 1\\.00000, with decimal 5"""


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`

`assert_numpy_array_equal`'s docstring is at odds with (and the existence of the `obj` argument clashes with) the fact that it's now strict on its arguments being ndrarrays.

There are [practical reasons](https://github.com/pydata/pandas/pull/13205#discussion_r65358471) to allow other kinds of arguments.

On the other hand, I don't see any reason for being strict, but I assume @sinhrks 's [PR](https://github.com/pydata/pandas/pull/13311) had some rationale behind: so a possible solution is an argument `ensure_ndarray=True` which restores the previous behaviour when set to `False`.
