### PR TITLE
Make pd.read_hdf('data.h5') work when pandas object stored contained categorical columns

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -374,3 +374,6 @@ Bug Fixes
 
 
 - Bug in ``Categorical.remove_unused_categories()`` changes ``.codes`` dtype to platform int (:issue:`13261`)
+
+- Bug in ``pd.read_hdf()`` where attempting to load an HDF file with a single dataset (that had one or more categorical columns) failed unless the key argument was set to the name of the dataset. (:issue:`13231`)
+

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -332,6 +332,8 @@ def read_hdf(path_or_buf, key=None, **kwargs):
     try:
         if key is None:
             groups = store.groups()
+            if len(groups) == 0:
+                raise ValueError('No dataset in HDF file.')
             candidate_only_group = groups[0]
 
             # For the HDF file to have only one dataset, all other groups

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -333,6 +333,7 @@ def read_hdf(path_or_buf, key=None, **kwargs):
         if key is None:
             groups = store.groups()
             candidate_only_group = groups[0]
+
             # For the HDF file to have only one dataset, all other groups
             # should then be metadata groups for that candidate group. (This
             # assumes that the groups() method enumerates parent groups

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -331,11 +331,17 @@ def read_hdf(path_or_buf, key=None, **kwargs):
 
     try:
         if key is None:
-            keys = store.keys()
-            if len(keys) != 1:
-                raise ValueError('key must be provided when HDF file contains '
-                                 'multiple datasets.')
-            key = keys[0]
+            groups = store.groups()
+            candidate_only_group = groups[0]
+            # For the HDF file to have only one dataset, all other groups
+            # should then be metadata groups for that candidate group. (This
+            # assumes that the groups() method enumerates parent groups
+            # before their children.)
+            for group_to_check in groups[1:]:
+                if not _is_metadata_of(group_to_check, candidate_only_group):
+                    raise ValueError('key must be provided when HDF file '
+                                     'contains multiple datasets.')
+            key = candidate_only_group._v_pathname
         return store.select(key, auto_close=auto_close, **kwargs)
     except:
         # if there is an error, close the store
@@ -345,6 +351,20 @@ def read_hdf(path_or_buf, key=None, **kwargs):
             pass
 
         raise
+
+
+def _is_metadata_of(group, parent_group):
+    """Check if a given group is a metadata group for a given parent_group."""
+    if group._v_depth <= parent_group._v_depth:
+        return False
+
+    current = group
+    while current._v_depth > 1:
+        parent = current._v_parent
+        if parent == parent_group and current._v_name == 'meta':
+            return True
+        current = current._v_parent
+    return False
 
 
 class HDFStore(StringMixin):

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -46,8 +46,8 @@ except ImportError:
 
 from distutils.version import LooseVersion
 
-_default_compressor = LooseVersion(tables.__version__) >= '2.2' \
-    and 'blosc' or 'zlib'
+_default_compressor = ('blosc' if LooseVersion(tables.__version__) >= '2.2'
+                       else 'zlib')
 
 _multiprocess_can_split_ = False
 

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -4877,6 +4877,7 @@ class TestHDFStore(Base, tm.TestCase):
         df = DataFrame(np.random.rand(4, 5),
                        index=list('abcd'),
                        columns=list('ABCDE'))
+
         # Categorical dtype not supported for "fixed" format. So no need
         # to test with that dtype in the dataframe here.
         with ensure_clean_path(self.path) as path:
@@ -4890,6 +4891,7 @@ class TestHDFStore(Base, tm.TestCase):
         # GH13231
         df = DataFrame({'i': range(5),
                         'c': Series(list('abacd'), dtype='category')})
+
         with ensure_clean_path(self.path) as path:
             df.to_hdf(path, 'df', mode='a', format='table')
             reread = read_hdf(path)

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -4877,11 +4877,24 @@ class TestHDFStore(Base, tm.TestCase):
         df = DataFrame(np.random.rand(4, 5),
                        index=list('abcd'),
                        columns=list('ABCDE'))
+        # Categorical dtype not supported for "fixed" format. So no need
+        # to test for that.
         with ensure_clean_path(self.path) as path:
             df.to_hdf(path, 'df', mode='a')
             reread = read_hdf(path)
             assert_frame_equal(df, reread)
             df.to_hdf(path, 'df2', mode='a')
+            self.assertRaises(ValueError, read_hdf, path)
+
+    def test_read_nokey_table(self):
+        # GH13231
+        df = DataFrame({'i': range(5),
+                        'c': Series(list('abacd'), dtype='category')})
+        with ensure_clean_path(self.path) as path:
+            df.to_hdf(path, 'df', mode='a', format='table')
+            reread = read_hdf(path)
+            assert_frame_equal(df, reread)
+            df.to_hdf(path, 'df2', mode='a', format='table')
             self.assertRaises(ValueError, read_hdf, path)
 
     def test_read_from_pathlib_path(self):

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -4878,7 +4878,7 @@ class TestHDFStore(Base, tm.TestCase):
                        index=list('abcd'),
                        columns=list('ABCDE'))
         # Categorical dtype not supported for "fixed" format. So no need
-        # to test for that.
+        # to test with that dtype in the dataframe here.
         with ensure_clean_path(self.path) as path:
             df.to_hdf(path, 'df', mode='a')
             reread = read_hdf(path)

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -4899,6 +4899,12 @@ class TestHDFStore(Base, tm.TestCase):
             df.to_hdf(path, 'df2', mode='a', format='table')
             self.assertRaises(ValueError, read_hdf, path)
 
+    def test_read_nokey_empty(self):
+        with ensure_clean_path(self.path) as path:
+            store = HDFStore(path)
+            store.close()
+            self.assertRaises(ValueError, read_hdf, path)
+
     def test_read_from_pathlib_path(self):
 
         # GH11773


### PR DESCRIPTION
- [x] closes #13231 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
