### PR TITLE
BUG: df.pivot_table: margins_name is ignored when there aggfunc is li…

### DIFF
--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -86,7 +86,8 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
             table = pivot_table(data, values=values, index=index,
                                 columns=columns,
                                 fill_value=fill_value, aggfunc=func,
-                                margins=margins)
+                                margins=margins,
+                                dropna=dropna, margins_name=margins_name)
             pieces.append(table)
             keys.append(func.__name__)
         return concat(pieces, keys=keys, axis=1)


### PR DESCRIPTION
- [x ] closes #13354 
- [ ] tests added / passed
- [ ] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry

…st #13354
