### PR TITLE
BUG: resample by BusinessHour raises ValueError

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -341,6 +341,7 @@ Bug Fixes
 - Bug in ``.resample(..)`` with a ``PeriodIndex`` not retaining its type or name with an empty ``DataFrame``appropriately when empty (:issue:`13212`)
 - Bug in ``groupby(..).resample(..)`` where passing some keywords would raise an exception (:issue:`13235`)
 - Bug in ``.tz_convert`` on a tz-aware ``DateTimeIndex`` that relied on index being sorted for correct results (:issue: `13306`)
+- Bug in ``.resample(..)`` with a ``BusinessHour`` raises ``ValueError`` (:issue:`12351`)
 
 
 

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -2297,6 +2297,17 @@ class TestPeriodIndex(Base, tm.TestCase):
         expected = ts.asfreq('H', how='s').reindex(exp_rng)
         assert_series_equal(result, expected)
 
+    def test_resample_hourly_business_hourly(self):
+        ts = pd.Series(index=pd.date_range(start='2016-06-01 03:00:00',
+                                           end='2016-06-03 23:00:00',
+                                           freq='H'))
+        expected = pd.Series(index=pd.date_range(start='2016-05-31 17:00:00',
+                                                 end='2016-06-06 09:00:00',
+                                                 freq='BH'))
+
+        result = ts.resample('BH').mean()
+        assert_series_equal(result, expected)
+
     def test_resample_irregular_sparse(self):
         dr = date_range(start='1/1/2012', freq='5min', periods=1000)
         s = Series(np.array(100), index=dr)


### PR DESCRIPTION
- [x] closes #12351 
- [x] tests added / passed (`TestPeriodIndex.test_resample_hourly_business_hourly`)
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

I did this during pandas sprint at PyCon 2016. Hope this close #12351
Resampling with BusinessHour took much more consideration I guess.
Please review this. Any comments are welcome.
