### PR TITLE
DOC: Fixed a minor typo

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -160,7 +160,7 @@ and `Good as first PR
 <https://github.com/pydata/pandas/issues?labels=Good+as+first+PR&sort=updated&state=open>`_
 where you could start out.
 
-Or maybe you have an idea of you own, by using pandas, looking for something
+Or maybe you have an idea of your own, by using pandas, looking for something
 in the documentation and thinking 'this can be improved', let's do something
 about that!
 

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -21,7 +21,7 @@ and `Difficulty Novice
 <https://github.com/pydata/pandas/issues?q=is%3Aopen+is%3Aissue+label%3A%22Difficulty+Novice%22>`_
 where you could start out.
 
-Or maybe through using *pandas* you have an idea of you own or are looking for something
+Or maybe through using *pandas* you have an idea of your own or are looking for something
 in the documentation and thinking 'this can be improved'...you can do something
 about it!
 


### PR DESCRIPTION
It also seems that the texts of the `doc/README.rst` and the `doc/source/contributing.rst` have lots of overlap and duplication. Not sure if there are any plans in consolidating these two files but I thought to mention that here 😄 
