### PR TITLE
DOC: actually document float_precision in read_csv

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -269,6 +269,10 @@ thousands : str, default ``None``
   Thousands separator.
 decimal : str, default ``'.'``
   Character to recognize as decimal point. E.g. use ``','`` for European data.
+float_precision : string, default None
+  Specifies which converter the C engine should use for floating-point values.
+  The options are ``None`` for the ordinary converter, ``high`` for the
+  high-precision converter, and ``round_trip`` for the round-trip converter.
 lineterminator : str (length 1), default ``None``
   Character to break file into lines. Only valid with C parser.
 quotechar : str (length 1)

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -183,6 +183,11 @@ thousands : str, default None
     Thousands separator
 decimal : str, default '.'
     Character to recognize as decimal point (e.g. use ',' for European data).
+float_precision : string, default None
+    Specifies which converter the C engine should use for floating-point
+    values. The options are `None` for the ordinary converter,
+    `high` for the high-precision converter, and `round_trip` for the
+    round-trip converter.
 lineterminator : str (length 1), default None
     Character to break file into lines. Only valid with C parser.
 quotechar : str (length 1), optional


### PR DESCRIPTION
So I wasn't 100% correct when I said that `float_precision` was documented <a href="https://github.com/pydata/pandas/issues/12686#issuecomment-222684918">here<a/>.  It was well documented internally for `TextParser` and in a section for `io.rst`, but it wasn't listed formally in the parameters for the `read_csv` documentation.
