### PR TITLE
COMPAT, TST: allow numpy array comparisons with complex dtypes

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -349,7 +349,24 @@ def array_equivalent(left, right, strict_nan=False):
         right = right.view('i8')
 
     # NaNs cannot occur otherwise.
-    return np.array_equal(left, right)
+    try:
+        return np.array_equal(left, right)
+    except AttributeError:
+        # see gh-13388
+        #
+        # NumPy v1.7.1 has a bug in its array_equal
+        # function that prevents it from correctly
+        # comparing two arrays with complex dtypes.
+        # This bug is corrected in v1.8.0, so remove
+        # this try-except block as soon as we stop
+        # supporting NumPy versions < 1.8.0
+        if not is_dtype_equal(left.dtype, right.dtype):
+            return False
+
+        left = left.tolist()
+        right = right.tolist()
+
+        return left == right
 
 
 def _iterable_not_string(x):

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -832,6 +832,24 @@ def test_is_timedelta():
     assert (not com.is_timedelta64_ns_dtype(tdi.astype('timedelta64[h]')))
 
 
+def test_array_equivalent_compat():
+    # see gh-13388
+    m = np.array([(1, 2), (3, 4)], dtype=[('a', int), ('b', float)])
+    n = np.array([(1, 2), (3, 4)], dtype=[('a', int), ('b', float)])
+    assert (com.array_equivalent(m, n, strict_nan=True))
+    assert (com.array_equivalent(m, n, strict_nan=False))
+
+    m = np.array([(1, 2), (3, 4)], dtype=[('a', int), ('b', float)])
+    n = np.array([(1, 2), (4, 3)], dtype=[('a', int), ('b', float)])
+    assert (not com.array_equivalent(m, n, strict_nan=True))
+    assert (not com.array_equivalent(m, n, strict_nan=False))
+
+    m = np.array([(1, 2), (3, 4)], dtype=[('a', int), ('b', float)])
+    n = np.array([(1, 2), (3, 4)], dtype=[('b', int), ('a', float)])
+    assert (not com.array_equivalent(m, n, strict_nan=True))
+    assert (not com.array_equivalent(m, n, strict_nan=False))
+
+
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
                    exit=False)


### PR DESCRIPTION
Traces back to bug in NumPy `v1.7.1` in which the `array_equivalent` method could not compare NumPy arrays with complicated dtypes. As `pandas` relies on this function to check NumPy array equality during testing, this commit adds a fallback method for doing so.

Closes #13388.
