### PR TITLE
BUG: Fix for .extractall (single group with quantifier) #13382

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -335,6 +335,7 @@ Bug Fixes
 - Bug in ``SeriesGroupBy.transform`` with datetime values and missing groups (:issue:`13191`)
 
 - Bug in ``Series.str.extractall()`` with ``str`` index raises ``ValueError``  (:issue:`13156`)
+- Bug in ``Series.str.extractall()`` with single group and quantifier  (:issue:`13382`)
 
 
 - Bug in ``PeriodIndex`` and ``Period`` subtraction raises ``AttributeError`` (:issue:`13071`)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -708,6 +708,8 @@ def str_extractall(arr, pat, flags=0):
                 subject_key = (subject_key, )
 
             for match_i, match_tuple in enumerate(regex.findall(subject)):
+                if isinstance(match_tuple, compat.string_types):
+                    match_tuple = (match_tuple,)
                 na_tuple = [np.NaN if group == "" else group
                             for group in match_tuple]
                 match_list.append(na_tuple)

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -977,6 +977,20 @@ class TestStringMethods(tm.TestCase):
         e = DataFrame(['a', 'b', 'd', 'c'], i)
         tm.assert_frame_equal(r, e)
 
+    def test_extractall_single_group_with_quantifier(self):
+        # extractall(one un-named group with quantifier) returns
+        # DataFrame with one un-named column (GH13382).
+        s = Series(['ab3', 'abc3', 'd4cd2'], name='series_name')
+        r = s.str.extractall(r'([a-z]+)')
+        i = MultiIndex.from_tuples([
+            (0, 0),
+            (1, 0),
+            (2, 0),
+            (2, 1),
+        ], names=(None, "match"))
+        e = DataFrame(['ab', 'abc', 'd', 'cd'], i)
+        tm.assert_frame_equal(r, e)
+
     def test_extractall_no_matches(self):
         s = Series(['a3', 'b3', 'd4c2'], name='series_name')
         # one un-named group.


### PR DESCRIPTION
- [X] closes #13382
- [X] tests added / passed
- [X] passes `git diff upstream/master | flake8 --diff`
- [X] whatsnew entry

Note that I had to fix it based on this [thread](http://stackoverflow.com/questions/2111759/whats-the-best-practice-for-handling-single-value-tuples-in-python), rather than directly with `[x for x in ['ab']]` as this broke previous tests. 
