### PR TITLE
ENH: implement 'reverse' for grouping

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3765,7 +3765,7 @@ class NDFrame(PandasObject):
         return self.where(subset, threshold, axis=axis)
 
     def groupby(self, by=None, axis=0, level=None, as_index=True, sort=True,
-                group_keys=True, squeeze=False, **kwargs):
+                group_keys=True, squeeze=False, reverse=False, **kwargs):
         """
         Group series using mapper (dict or key function, apply given function
         to group, return result as series) or by a series of columns.
@@ -3794,6 +3794,8 @@ class NDFrame(PandasObject):
         squeeze : boolean, default False
             reduce the dimensionality of the return type if possible,
             otherwise return a consistent type
+        reverse : boolean, default False
+            invert the selection criteria
 
         Examples
         --------
@@ -3818,6 +3820,7 @@ class NDFrame(PandasObject):
         axis = self._get_axis_number(axis)
         return groupby(self, by=by, axis=axis, level=level, as_index=as_index,
                        sort=sort, group_keys=group_keys, squeeze=squeeze,
+                       reverse=reverse,
                        **kwargs)
 
     def asfreq(self, freq, method=None, how=None, normalize=False):
@@ -5058,8 +5061,8 @@ class NDFrame(PandasObject):
             np.putmask(rs.values, mask, np.nan)
         return rs
 
-    def _agg_by_level(self, name, axis=0, level=0, skipna=True, **kwargs):
-        grouped = self.groupby(level=level, axis=axis)
+    def _agg_by_level(self, name, axis=0, level=0, skipna=True, reverse=False, **kwargs):
+        grouped = self.groupby(level=level, axis=axis, reverse=reverse)
         if hasattr(grouped, name) and skipna:
             return getattr(grouped, name)(**kwargs)
         axis = self._get_axis_number(axis)
@@ -5341,6 +5344,7 @@ def _make_stat_function(cls, name, name1, name2, axis_descr, desc, f):
                   axis_descr=axis_descr)
     @Appender(_num_doc)
     def stat_func(self, axis=None, skipna=None, level=None, numeric_only=None,
+            reverse_level=False,
                   **kwargs):
         nv.validate_stat_func(tuple(), kwargs, fname=name)
         if skipna is None:
@@ -5349,6 +5353,7 @@ def _make_stat_function(cls, name, name1, name2, axis_descr, desc, f):
             axis = self._stat_axis_number
         if level is not None:
             return self._agg_by_level(name, axis=axis, level=level,
+                    reverse=reverse_level,
                                       skipna=skipna)
         return self._reduce(f, name, axis=axis, skipna=skipna,
                             numeric_only=numeric_only)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -325,7 +325,21 @@ class _GroupBy(PandasObject, SelectionMixin):
 
     def __init__(self, obj, keys=None, axis=0, level=None,
                  grouper=None, exclusions=None, selection=None, as_index=True,
-                 sort=True, group_keys=True, squeeze=False, **kwargs):
+                 sort=True, group_keys=True, squeeze=False, reverse=False, **kwargs):
+
+        if reverse:
+            if not (isinstance(obj, DataFrame) or isinstance(obj, Series)):
+                raise NotImplementedError(
+                        "reverse not implemented for type: {}".format(type(obj)))
+            if axis != 0 or as_index == False or any(v is not None for v in
+                    (grouper, exclusions, selection)):
+                raise NotImplementedError("reverse not implemented for provided args")
+            if level is not None and keys is None:
+                level = [l for l in obj.index.names if l not in level]
+            elif keys is not None and level is None:
+                keys = [k for k in obj.columns if k not in keys]
+            else:
+                raise NotImplementedError("Unknown behavior when keys and level are provided with 'reverse' set")
 
         self._selection = selection
 


### PR DESCRIPTION
when there are lots of columns of index levels it is more convenient to specify the column or index level that should be merged rather than all of the other columns or index levels

for example a multiindex dataframe

```
df.mean(level=['year', 'month', 'day', 'hour', 'min', 'trial'])
```

can be replaced with

```
df.mean(level='rep', reverse_level=True)
```

or for a flat index dataframe (where the data is in a column named 'result')

```
df.groupby(['year', 'month', 'day', 'hour', 'min', 'trial']).mean()
```

can be replaced with

```
df.groupby(['rep', 'result'], reverse=True)
```

http://stackoverflow.com/questions/16808682/is-there-in-pandas-operation-complementary-opposite-to-groupby
