### PR TITLE
ENH: PeriodIndex now accepts pd.NaT

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -288,6 +288,7 @@ Other API changes
 - ``Float64Index.astype(int)`` will now raise ``ValueError`` if ``Float64Index`` contains ``NaN`` values (:issue:`13149`)
 - ``TimedeltaIndex.astype(int)`` and ``DatetimeIndex.astype(int)`` will now return ``Int64Index`` instead of ``np.array`` (:issue:`13209`)
 - ``.filter()`` enforces mutual exclusion of the keyword arguments. (:issue:`12399`)
+- ``PeridIndex`` can now accept ``list`` and ``array`` which contains ``pd.NaT`` (:issue:`13430`)
 
 .. _whatsnew_0182.deprecations:
 

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -40,14 +40,6 @@ def _field_accessor(name, alias, docstring=None):
     return property(f)
 
 
-def _get_ordinals(data, freq):
-    f = lambda x: Period(x, freq=freq).ordinal
-    if isinstance(data[0], Period):
-        return period.extract_ordinals(data, freq)
-    else:
-        return lib.map_infer(data, f)
-
-
 def dt64arr_to_periodarr(data, freq, tz):
     if data.dtype != np.dtype('M8[ns]'):
         raise ValueError('Wrong dtype: %s' % data.dtype)
@@ -235,14 +227,9 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
             except (TypeError, ValueError):
                 data = com._ensure_object(data)
 
-                if freq is None and len(data) > 0:
-                    freq = getattr(data[0], 'freq', None)
-
                 if freq is None:
-                    raise ValueError('freq not specified and cannot be '
-                                     'inferred from first element')
-
-                data = _get_ordinals(data, freq)
+                    freq = period.extract_freq(data)
+                data = period.extract_ordinals(data, freq)
         else:
             if isinstance(data, PeriodIndex):
                 if freq is None or freq == data.freq:
@@ -254,12 +241,15 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
                     data = period.period_asfreq_arr(data.values,
                                                     base1, base2, 1)
             else:
-                if freq is None and len(data) > 0:
-                    freq = getattr(data[0], 'freq', None)
+
+                if freq is None and com.is_object_dtype(data):
+                    # must contain Period instance and thus extract ordinals
+                    freq = period.extract_freq(data)
+                    data = period.extract_ordinals(data, freq)
 
                 if freq is None:
-                    raise ValueError('freq not specified and cannot be '
-                                     'inferred from first element')
+                    msg = 'freq not specified and cannot be inferred'
+                    raise ValueError(msg)
 
                 if data.dtype != np.int64:
                     if np.issubdtype(data.dtype, np.datetime64):
@@ -269,7 +259,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
                             data = com._ensure_int64(data)
                         except (TypeError, ValueError):
                             data = com._ensure_object(data)
-                            data = _get_ordinals(data, freq)
+                            data = period.extract_ordinals(data, freq)
 
         return data, freq
 


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Related to #12759. `PeirodIndex` can be created from list/array which contains `pd.NaT`.

currently it raises:

```
pd.PeriodIndex([pd.NaT])
# ValueError: freq not specified and cannot be inferred from first element

pd.PeriodIndex([pd.Period('2011-01', freq='M'), pd.NaT])
# AttributeError: 'NaTType' object has no attribute 'ordinal'
```
