### PR TITLE
BUG: df.pivot_table: margins_name ignored when aggfunc is a list

### DIFF
--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -682,3 +682,4 @@ Bug Fixes
 - Bug in ``pd.to_numeric()`` with ``Index`` returns ``np.ndarray``, rather than ``Index`` (:issue:`12777`)
 - Bug in ``pd.to_numeric()`` with datetime-like may raise ``TypeError`` (:issue:`12777`)
 - Bug in ``pd.to_numeric()`` with scalar raises ``ValueError`` (:issue:`12777`)
+- Bug in ``pd.pivot_table()`` where margins_name is ignored when aggfunc is a list (:issue:`13354`)

--- a/doc/source/whatsnew/v0.18.1.txt
+++ b/doc/source/whatsnew/v0.18.1.txt
@@ -682,4 +682,3 @@ Bug Fixes
 - Bug in ``pd.to_numeric()`` with ``Index`` returns ``np.ndarray``, rather than ``Index`` (:issue:`12777`)
 - Bug in ``pd.to_numeric()`` with datetime-like may raise ``TypeError`` (:issue:`12777`)
 - Bug in ``pd.to_numeric()`` with scalar raises ``ValueError`` (:issue:`12777`)
-- Bug in ``pd.pivot_table()`` where margins_name is ignored when aggfunc is a list (:issue:`13354`)

--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -383,4 +383,4 @@ Bug Fixes
 
 
 - Bug in ``Categorical.remove_unused_categories()`` changes ``.codes`` dtype to platform int (:issue:`13261`)
-- Bug in ``pd.pivot_table()`` where margins_name is ignored when aggfunc is a list (:issue:`13354`)
+- Bug in ``pd.pivot_table()`` where ``margins_name`` is ignored when ``aggfunc`` is a list (:issue:`13354`)

--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -383,3 +383,4 @@ Bug Fixes
 
 
 - Bug in ``Categorical.remove_unused_categories()`` changes ``.codes`` dtype to platform int (:issue:`13261`)
+- Bug in ``pd.pivot_table()`` where margins_name is ignored when aggfunc is a list (:issue:`13354`)

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -86,7 +86,7 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
             table = pivot_table(data, values=values, index=index,
                                 columns=columns,
                                 fill_value=fill_value, aggfunc=func,
-                                margins=margins)
+                                margins=margins, margins_name=margins_name)
             pieces.append(table)
             keys.append(func.__name__)
         return concat(pieces, keys=keys, axis=1)

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -781,10 +781,19 @@ class TestPivotTable(tm.TestCase):
 
     def test_pivot_table_margins_name_with_aggfunc_list(self):
         # GH 13354
-        margins_name = 'Weekly'
-        table = self.data.pivot_table(index='A', columns='B', margins=True,
-                              margins_name=margins_name, aggfunc=[np.mean, max])
-        self.assertEqual(table[:][:].index[2], margins_name)
+        margins_name='Weekly'
+        costs = pd.DataFrame({'item':['bacon','cheese','bacon','cheese'],
+                              'cost':[2.5,4.5,3.2,3.3],
+                             'day':['M','M','T','T']})
+        table = costs.pivot_table(index="item",columns="day",margins=True,
+                                margins_name=margins_name,aggfunc=[np.mean,max])
+        ix = pd.Index(['bacon', 'cheese', margins_name], dtype='object', name='item')
+        tups = [('mean', 'cost', 'M'), ('mean', 'cost', 'T'),
+                ('mean', 'cost', margins_name), ('max', 'cost', 'M'),
+                ('max', 'cost', 'T'), ('max', 'cost', margins_name)]
+        cols = pd.MultiIndex.from_tuples(tups, names=[None, None, 'day'])
+        expected = pd.DataFrame(table.values, index=ix, columns=cols)
+        tm.assert_frame_equal(table, expected)
 
 
 class TestCrosstab(tm.TestCase):

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -781,13 +781,19 @@ class TestPivotTable(tm.TestCase):
 
     def test_pivot_table_margins_name_with_aggfunc_list(self):
         # GH 13354
-        margins_name='Weekly'
-        costs = pd.DataFrame({'item':['bacon','cheese','bacon','cheese'],
-                              'cost':[2.5,4.5,3.2,3.3],
-                             'day':['M','M','T','T']})
-        table = costs.pivot_table(index="item",columns="day",margins=True,
-                                margins_name=margins_name,aggfunc=[np.mean,max])
-        ix = pd.Index(['bacon', 'cheese', margins_name], dtype='object', name='item')
+        margins_name = 'Weekly'
+        costs = pd.DataFrame(
+            {'item': ['bacon', 'cheese', 'bacon', 'cheese'],
+             'cost': [2.5, 4.5, 3.2, 3.3],
+             'day': ['M', 'M', 'T', 'T']}
+        )
+        table = costs.pivot_table(
+            index="item", columns="day", margins=True,
+            margins_name=margins_name, aggfunc=[np.mean, max]
+        )
+        ix = pd.Index(
+            ['bacon', 'cheese', margins_name], dtype='object', name='item'
+        )
         tups = [('mean', 'cost', 'M'), ('mean', 'cost', 'T'),
                 ('mean', 'cost', margins_name), ('max', 'cost', 'M'),
                 ('max', 'cost', 'T'), ('max', 'cost', margins_name)]

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -779,6 +779,13 @@ class TestPivotTable(tm.TestCase):
         )
         tm.assert_frame_equal(pivot_values_gen, pivot_values_list)
 
+    def test_pivot_table_margins_name_with_aggfunc_list(self):
+        # GH 13354
+        margins_name = 'Weekly'
+        table = self.data.pivot_table(index='A', columns='B', margins=True,
+                              margins_name=margins_name, aggfunc=[np.mean, max])
+        self.assertEqual(table[:][:].index[2], margins_name)
+
 
 class TestCrosstab(tm.TestCase):
 


### PR DESCRIPTION
- [ ] closes #13354 
- [ ] tests added / passed
- [ ] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry
