### PR TITLE
BUG: alignment of CategoricalIndex

### DIFF
--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -225,9 +225,8 @@ class Base(object):
 
             s1 = Series(2, index=first)
             s2 = Series(3, index=second[:-1])
-            if not isinstance(index, CategoricalIndex):  # See GH13365
-                s3 = s1 * s2
-                self.assertEqual(s3.index.name, 'mario')
+            s3 = s1 * s2
+            self.assertEqual(s3.index.name, 'mario')
 
     def test_ensure_copied_data(self):
         # Check the "copy" argument of each Index.__new__ is honoured


### PR DESCRIPTION
- [x] closes #13365
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry

@jreback take this just as a wild guess of how to fix #13365 . If the approach makes sense, I will add tests, whatsnew and some more docs.
