### PR TITLE
BUG: Rolling negative window issue fix #13383

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -516,3 +516,4 @@ Bug Fixes
 
 
 - Bug in ``Categorical.remove_unused_categories()`` changes ``.codes`` dtype to platform int (:issue:`13261`)
+- Bug in ``Series.rolling()`` that allowed negative window, but failed on aggregation (:issue:`13383`)

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -321,6 +321,8 @@ class Window(_Window):
         if isinstance(window, (list, tuple, np.ndarray)):
             pass
         elif com.is_integer(window):
+            if window < 0:
+                raise ValueError("window must be non-negative")
             try:
                 import scipy.signal as sig
             except ImportError:
@@ -850,6 +852,8 @@ class Rolling(_Rolling_and_Expanding):
         super(Rolling, self).validate()
         if not com.is_integer(self.window):
             raise ValueError("window must be an integer")
+        elif self.window < 0:
+            raise ValueError("window must be non-negative")
 
     @Substitution(name='rolling')
     @Appender(SelectionMixin._see_also_template)

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -331,6 +331,11 @@ class TestRolling(Base):
             c(window=2, min_periods=1, center=True)
             c(window=2, min_periods=1, center=False)
 
+            # GH 13383
+            c(0)
+            with self.assertRaises(ValueError):
+                c(-1)
+
             # not valid
             for w in [2., 'foo', np.array([2])]:
                 with self.assertRaises(ValueError):
@@ -339,6 +344,15 @@ class TestRolling(Base):
                     c(window=2, min_periods=w)
                 with self.assertRaises(ValueError):
                     c(window=2, min_periods=1, center=w)
+
+    def test_constructor_with_win_type(self):
+        # GH 13383
+        tm._skip_if_no_scipy()
+        for o in [self.series, self.frame]:
+            c = o.rolling
+            c(0, win_type='boxcar')
+            with self.assertRaises(ValueError):
+                c(-1, win_type='boxcar')
 
     def test_numpy_compat(self):
         # see gh-12811


### PR DESCRIPTION
- [x] closes #13383 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Added functionality in validate function of Rolling to ensure that window size is non-negative.
