### PR TITLE
ERR: fix error message for to_datetime

### DIFF
--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -2320,7 +2320,7 @@ cpdef array_to_datetime(ndarray[object] values, errors='raise',
                             iresult[i] = NPY_NAT
                             continue
                         elif is_raise:
-                            raise ValueError("time data %r does match format specified" %
+                            raise ValueError("time data %r doesn't match format specified" %
                                              (val,))
                         else:
                             return values


### PR DESCRIPTION
- [x] ~~closes #xxxx~~ There is no issue for this.
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Fixes the error message when the argument to `to_datetime` doesn't match the format specified.
