### PR TITLE
BUG: Fix for .str.replace with invalid input

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -424,3 +424,4 @@ Bug Fixes
 
 
 - Bug in ``Categorical.remove_unused_categories()`` changes ``.codes`` dtype to platform int (:issue:`13261`)
+- Bug in ``.str.replace`` does not raise TypeError for invalid replacement (:issue:`13438`)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -4,7 +4,7 @@ from pandas.compat import zip
 from pandas.core.common import (isnull, notnull, _values_from_object,
                                 is_bool_dtype,
                                 is_list_like, is_categorical_dtype,
-                                is_object_dtype)
+                                is_object_dtype, is_string_like)
 from pandas.core.algorithms import take_1d
 import pandas.compat as compat
 from pandas.core.base import AccessorProperty, NoNewAttributesMixin
@@ -309,6 +309,8 @@ def str_replace(arr, pat, repl, n=-1, case=True, flags=0):
     -------
     replaced : Series/Index of objects
     """
+    if not is_string_like(repl):  # Check whether repl is valid (GH 13438)
+        raise TypeError("repl must be a string")
     use_re = not case or len(pat) > 1 or flags
 
     if use_re:

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -430,6 +430,13 @@ class TestStringMethods(tm.TestCase):
         result = values.str.replace("(?<=\w),(?=\w)", ", ", flags=re.UNICODE)
         tm.assert_series_equal(result, exp)
 
+        # GH 13438
+        for pdClass in (Series, Index):
+            for repl in (None, 3, {'a': 'b'}):
+                for data in (['a', 'b', None], ['a', 'b', 'c', 'ad']):
+                    values = pdClass(data)
+                    self.assertRaises(TypeError, values.str.replace, 'a', repl)
+
     def test_repeat(self):
         values = Series(['a', 'b', NA, 'c', NA, 'd'])
 


### PR DESCRIPTION
- [x] closes #13438
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

.str.replace now raises TypeError when replacement is invalid
