### PR TITLE
BUG: windows with TemporaryFile an read_csv #13398

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -493,6 +493,7 @@ Bug Fixes
 - Bug in ``pd.read_csv()`` in which the ``nrows`` argument was not properly validated for both engines (:issue:`10476`)
 - Bug in ``pd.read_csv()`` with ``engine='python'`` in which infinities of mixed-case forms were not being interpreted properly (:issue:`13274`)
 - Bug in ``pd.read_csv()`` with ``engine='python'`` in which trailing ``NaN`` values were not being parsed (:issue:`13320`)
+- Bug in ``pd.read_csv()`` with ``engine='python'`` when reading from a tempfile.TemporaryFile on Windows with Python 3 a file with the separator expressed as a regex (:issue:`13398`)
 - Bug in ``pd.read_csv()`` that prevents ``usecols`` kwarg from accepting single-byte unicode strings (:issue:`13219`)
 - Bug in ``pd.read_csv()`` that prevents ``usecols`` from being an empty set (:issue:`13402`)
 - Bug in ``pd.read_csv()`` with ``engine=='c'`` in which null ``quotechar`` was not accepted even though ``quoting`` was specified as ``None`` (:issue:`13411`)

--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -493,7 +493,7 @@ Bug Fixes
 - Bug in ``pd.read_csv()`` in which the ``nrows`` argument was not properly validated for both engines (:issue:`10476`)
 - Bug in ``pd.read_csv()`` with ``engine='python'`` in which infinities of mixed-case forms were not being interpreted properly (:issue:`13274`)
 - Bug in ``pd.read_csv()`` with ``engine='python'`` in which trailing ``NaN`` values were not being parsed (:issue:`13320`)
-- Bug in ``pd.read_csv()`` with ``engine='python'`` when reading from a tempfile.TemporaryFile on Windows with Python 3 a file with the separator expressed as a regex (:issue:`13398`)
+- Bug in ``pd.read_csv()`` with ``engine='python'`` when reading from a tempfile.TemporaryFile on Windows with Python 3, separator expressed as a regex (:issue:`13398`)
 - Bug in ``pd.read_csv()`` that prevents ``usecols`` kwarg from accepting single-byte unicode strings (:issue:`13219`)
 - Bug in ``pd.read_csv()`` that prevents ``usecols`` from being an empty set (:issue:`13402`)
 - Bug in ``pd.read_csv()`` with ``engine=='c'`` in which null ``quotechar`` was not accepted even though ``quoting`` was specified as ``None`` (:issue:`13411`)

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1868,7 +1868,7 @@ class PythonParser(ParserBase):
 
         else:
             def _read():
-                line = next(f)
+                line = f.readline()
                 pat = re.compile(sep)
                 yield pat.split(line.strip())
                 for line in f:

--- a/pandas/io/tests/parser/python_parser_only.py
+++ b/pandas/io/tests/parser/python_parser_only.py
@@ -182,6 +182,6 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         new_file.flush()
         new_file.seek(0)
 
-        result = self.read_csv(new_file, sep=r"\s+", header=None)
+        result = self.read_csv(new_file, sep=r"\s*", header=None)
         expected = DataFrame([[0, 0]])
         tm.assert_frame_equal(result, expected)

--- a/pandas/io/tests/parser/python_parser_only.py
+++ b/pandas/io/tests/parser/python_parser_only.py
@@ -171,3 +171,26 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
             columns=list('abcABC'), index=list('abc'))
         actual = self.read_table(StringIO(data), sep='\s+')
         tm.assert_frame_equal(actual, expected)
+
+    def test_temporary_file(self):
+        # GH13398
+        data1 = """index,A,B,C,D
+foo,2,3,4,5
+bar,7,8,9,10
+baz,12,13,14,15
+qux,12,13,14,15
+foo2,12,13,14,15
+bar2,12,13,14,15
+"""
+        data2 = data1.replace(",", " ")
+
+        from tempfile import TemporaryFile
+        new_file = TemporaryFile("w+")
+        new_file.write(data2)
+        new_file.flush()
+        new_file.seek(0)
+
+        result = self.read_csv(new_file, sep=r"\s+", engine="python")
+        expected = self.read_csv(StringIO(data1))
+        tm.assert_frame_equal(result, expected)
+        

--- a/pandas/io/tests/parser/python_parser_only.py
+++ b/pandas/io/tests/parser/python_parser_only.py
@@ -193,4 +193,3 @@ bar2,12,13,14,15
         result = self.read_csv(new_file, sep=r"\s+", engine="python")
         expected = self.read_csv(StringIO(data1))
         tm.assert_frame_equal(result, expected)
-        

--- a/pandas/io/tests/parser/python_parser_only.py
+++ b/pandas/io/tests/parser/python_parser_only.py
@@ -174,14 +174,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 
     def test_temporary_file(self):
         # GH13398
-        data1 = """index,A,B,C,D
-foo,2,3,4,5
-bar,7,8,9,10
-baz,12,13,14,15
-qux,12,13,14,15
-foo2,12,13,14,15
-bar2,12,13,14,15
-"""
+        data1 = "0,0"
         data2 = data1.replace(",", " ")
 
         from tempfile import TemporaryFile
@@ -190,6 +183,7 @@ bar2,12,13,14,15
         new_file.flush()
         new_file.seek(0)
 
-        result = self.read_csv(new_file, sep=r"\s+", engine="python")
-        expected = self.read_csv(StringIO(data1))
+        result = self.read_csv(new_file, sep=r"\s+", header=None)
+        expected = DataFrame([[0, 0]])
         tm.assert_frame_equal(result, expected)
+

--- a/pandas/io/tests/parser/python_parser_only.py
+++ b/pandas/io/tests/parser/python_parser_only.py
@@ -174,12 +174,11 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 
     def test_temporary_file(self):
         # GH13398
-        data1 = "0,0"
-        data2 = data1.replace(",", " ")
+        data1 = "0 0"
 
         from tempfile import TemporaryFile
         new_file = TemporaryFile("w+")
-        new_file.write(data2)
+        new_file.write(data1)
         new_file.flush()
         new_file.seek(0)
 

--- a/pandas/io/tests/parser/python_parser_only.py
+++ b/pandas/io/tests/parser/python_parser_only.py
@@ -186,4 +186,3 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         result = self.read_csv(new_file, sep=r"\s+", header=None)
         expected = DataFrame([[0, 0]])
         tm.assert_frame_equal(result, expected)
-

--- a/pandas/io/tests/test_common.py
+++ b/pandas/io/tests/test_common.py
@@ -33,7 +33,6 @@ qux,12,13,14,15
 foo2,12,13,14,15
 bar2,12,13,14,15
 """
-    data2 = data1.replace(",", " ")
     
     def test_expand_user(self):
         filename = '~/sometest'
@@ -90,18 +89,6 @@ bar2,12,13,14,15
         tm.assert_frame_equal(first, expected.iloc[[0]])
         expected.index = [0 for i in range(len(expected))]
         tm.assert_frame_equal(concat(it), expected.iloc[1:])
-
-    def test_temporary_file(self):
-        # GH13398
-        from tempfile import TemporaryFile
-        new_file = TemporaryFile("w+")
-        new_file.write(self.data2)
-        new_file.flush()
-        new_file.seek(0)
-
-        result = read_csv(new_file, sep=r"\s+", engine="python")
-        expected = read_csv(StringIO(self.data1))
-        tm.assert_frame_equal(result, expected)
 
 
 class TestMMapWrapper(tm.TestCase):

--- a/pandas/io/tests/test_common.py
+++ b/pandas/io/tests/test_common.py
@@ -11,7 +11,7 @@ import pandas.util.testing as tm
 from pandas.io import common
 from pandas.compat import is_platform_windows, StringIO
 
-from pandas import read_csv, read_table, concat
+from pandas import read_csv, concat
 
 try:
     from pathlib import Path
@@ -33,7 +33,8 @@ qux,12,13,14,15
 foo2,12,13,14,15
 bar2,12,13,14,15
 """
-
+    data2 = data1.replace(",", " ")
+    
     def test_expand_user(self):
         filename = '~/sometest'
         expanded_name = common._expand_user(filename)
@@ -90,14 +91,17 @@ bar2,12,13,14,15
         expected.index = [0 for i in range(len(expected))]
         tm.assert_frame_equal(concat(it), expected.iloc[1:])
 
+    #13398
     def test_temporary_file(self):
         from tempfile import TemporaryFile
         new_file = TemporaryFile("w+")
-        new_file.write("0   0")
+        new_file.write(self.data2)
         new_file.flush()
         new_file.seek(0)
 
-        dataframe = read_table(new_file, sep=r"\s+", header=None, engine="python")
+        result = read_csv(new_file, sep=r"\s+", engine="python")
+        expected = read_csv(StringIO(self.data1))
+        tm.assert_frame_equal(result, expected)
 
 
 class TestMMapWrapper(tm.TestCase):

--- a/pandas/io/tests/test_common.py
+++ b/pandas/io/tests/test_common.py
@@ -11,7 +11,7 @@ import pandas.util.testing as tm
 from pandas.io import common
 from pandas.compat import is_platform_windows, StringIO
 
-from pandas import read_csv, concat
+from pandas import read_csv, read_table, concat
 
 try:
     from pathlib import Path
@@ -89,6 +89,15 @@ bar2,12,13,14,15
         tm.assert_frame_equal(first, expected.iloc[[0]])
         expected.index = [0 for i in range(len(expected))]
         tm.assert_frame_equal(concat(it), expected.iloc[1:])
+
+    def test_temporary_file(self):
+        from tempfile import TemporaryFile
+        new_file = TemporaryFile("w+")
+        new_file.write("0   0")
+        new_file.flush()
+        new_file.seek(0)
+
+        dataframe = read_table(new_file, sep=r"\s+", header=None, engine="python")
 
 
 class TestMMapWrapper(tm.TestCase):

--- a/pandas/io/tests/test_common.py
+++ b/pandas/io/tests/test_common.py
@@ -91,8 +91,8 @@ bar2,12,13,14,15
         expected.index = [0 for i in range(len(expected))]
         tm.assert_frame_equal(concat(it), expected.iloc[1:])
 
-    #13398
     def test_temporary_file(self):
+        # GH13398
         from tempfile import TemporaryFile
         new_file = TemporaryFile("w+")
         new_file.write(self.data2)

--- a/pandas/io/tests/test_common.py
+++ b/pandas/io/tests/test_common.py
@@ -33,7 +33,7 @@ qux,12,13,14,15
 foo2,12,13,14,15
 bar2,12,13,14,15
 """
-    
+
     def test_expand_user(self):
         filename = '~/sometest'
         expanded_name = common._expand_user(filename)


### PR DESCRIPTION
- [ x] closes #13398 
- [ x] no tests added -> could not find location for IO tests?
- [ x] passes `git diff upstream/master | flake8 --diff`

Change the way of reading back to readline (consistent with the test before entering the function)

One failure on Windows 10 (Python 3.5), but expected to fail actually (should probably tag it as well?)

```
======================================================================
FAIL: test_next (pandas.io.tests.test_common.TestMMapWrapper)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "G:\Informatique\pandas\pandas\io\tests\test_common.py", line 139, in test_next   
    self.assertEqual(next_line, line)
AssertionError: 'a,b,c\r\n' != 'a,b,c\n'
- a,b,c
?      -
+ a,b,c
```
