### PR TITLE
BUG: is_normalized returned False for local tz

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -524,3 +524,5 @@ Bug Fixes
 
 
 - Bug in ``Categorical.remove_unused_categories()`` changes ``.codes`` dtype to platform int (:issue:`13261`)
+
+- Bug in ``DatetimeIndex.is_normalized`` returns False for normalized date_range in case of local timezones (:issue:`13459`)

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -18,7 +18,7 @@ from pytz import NonExistentTimeError
 
 import pandas.util.testing as tm
 from pandas.types.api import DatetimeTZDtype
-from pandas.util.testing import assert_frame_equal
+from pandas.util.testing import assert_frame_equal, set_timezone
 from pandas.compat import lrange, zip
 
 try:
@@ -1397,6 +1397,26 @@ class TestTimeZones(tm.TestCase):
 
         self.assertTrue(result.is_normalized)
         self.assertFalse(rng.is_normalized)
+
+    def test_normalize_tz_local(self):
+        # GH 13459
+        from dateutil.tz import tzlocal
+
+        timezones = ['US/Pacific', 'US/Eastern', 'UTC', 'Asia/Kolkata',
+                     'Asia/Shanghai', 'Australia/Canberra']
+
+        for timezone in timezones:
+            with set_timezone(timezone):
+                rng = date_range('1/1/2000 9:30', periods=10, freq='D',
+                                 tz=tzlocal())
+
+                result = rng.normalize()
+                expected = date_range('1/1/2000', periods=10, freq='D',
+                                      tz=tzlocal())
+                self.assert_index_equal(result, expected)
+
+                self.assertTrue(result.is_normalized)
+                self.assertFalse(rng.is_normalized)
 
     def test_tzaware_offset(self):
         dates = date_range('2012-11-01', periods=3, tz='US/Pacific')

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -4810,12 +4810,10 @@ def dates_normalized(ndarray[int64_t] stamps, tz=None):
     elif _is_tzlocal(tz):
         for i in range(n):
             pandas_datetime_to_datetimestruct(stamps[i], PANDAS_FR_ns, &dts)
-            if (dts.min + dts.sec + dts.us) > 0:
-                return False
             dt = datetime(dts.year, dts.month, dts.day, dts.hour, dts.min,
                           dts.sec, dts.us, tz)
             dt = dt + tz.utcoffset(dt)
-            if dt.hour > 0:
+            if (dt.hour + dt.minute + dt.second + dt.microsecond) > 0:
                 return False
     else:
         trans, deltas, typ = _get_dst_info(tz)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -2667,3 +2667,50 @@ def patch(ob, attr, value):
             delattr(ob, attr)
         else:
             setattr(ob, attr, old)
+
+
+@contextmanager
+def set_timezone(tz):
+    """Context manager for temporarily setting a timezone.
+
+    Parameters
+    ----------
+    tz : str
+        A string representing a valid timezone.
+
+    Examples
+    --------
+
+    >>> from datetime import datetime
+    >>> from dateutil.tz import tzlocal
+    >>> tzlocal().tzname(datetime.now())
+    'IST'
+
+    >>> with set_timezone('US/Eastern'):
+    ...     tzlocal().tzname(datetime.now())
+    ...
+    'EDT'
+    """
+    if is_platform_windows():
+        import nose
+        raise nose.SkipTest("timezone setting not supported on windows")
+
+    import os
+    import time
+
+    def setTZ(tz):
+        if tz is None:
+            try:
+                del os.environ['TZ']
+            except:
+                pass
+        else:
+            os.environ['TZ'] = tz
+            time.tzset()
+
+    orig_tz = os.environ.get('TZ')
+    setTZ(tz)
+    try:
+        yield
+    finally:
+        setTZ(orig_tz)


### PR DESCRIPTION
- [x] closes #13459 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

is_normalized returned False for normalized date_range
in case of local timezone 'Asia/Kolkata'
Fixes: #13459
