### PR TITLE
ENH:read_html() handles tables with multiple header rows #13434

### DIFF
--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -355,7 +355,8 @@ class _HtmlFrameParser(object):
         thead = self._parse_thead(table)
         res = []
         if thead:
-            res = lmap(self._text_getter, self._parse_th(thead[0]))
+            row = self._parse_th(thead[0])[0].find_parent('tr')
+            res = lmap(self._text_getter, self._parse_th(row))
         return np.atleast_1d(
             np.array(res).squeeze()) if res and len(res) == 1 else res
 
@@ -591,7 +592,7 @@ class _LxmlFrameParser(_HtmlFrameParser):
         return table.xpath('.//tfoot')
 
     def _parse_raw_thead(self, table):
-        expr = './/thead//th'
+        expr = './/thead//tr[th][1]//th'
         return [_remove_whitespace(x.text_content()) for x in
                 table.xpath(expr)]
 

--- a/pandas/io/tests/test_html.py
+++ b/pandas/io/tests/test_html.py
@@ -694,6 +694,7 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
             with tm.assertRaises(TypeError):
                 read_html(self.spam_data, header=arg)
 
+
     def test_converters(self):
         # GH 13461
         html_data = """<table>
@@ -759,6 +760,34 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
         expected_df = DataFrame({'a': [np.nan, np.nan]})
         html_df = read_html(html_data, keep_default_na=True)[0]
         tm.assert_frame_equal(expected_df, html_df)
+
+    def test_multiple_header(self):
+        data = StringIO('''<table border="1" class="dataframe">
+            <thead>
+               <tr style="text-align: right;">
+                   <th>Name</th>
+                   <th>Age</th>
+                   <th>Party</th>
+               </tr>
+               <tr>
+                  <th></th>
+                  <th>Gender</th>
+                  <th></th>
+                </tr>
+          </thead>
+          <tbody>
+              <tr>
+                  <th>Hillary</th>
+                  <td>68</td>
+                  <td>D</td>
+             </tr>
+          </tbody>
+          </table>''')
+        expected = DataFrame(columns=["Name", "Age", "Party"],
+                             data=[("Hillary", 68, "D")])
+        result = self.read_html(data)[0]
+        tm.assert_frame_equal(expected, result)
+
 
 
 def _lang_enc(filename):


### PR DESCRIPTION
- [ ] closes #13434 
- [ ] read_html() handles tables with multiple header rows 

Now it produces the following output for the issue
  Unnamed: 0  Age Party
0    Hillary   68     D
1     Bernie   74     D
2     Donald   69     R
