### PR TITLE
DOC: add nbformat for notebook conversion

### DIFF
--- a/ci/requirements-2.7_DOC_BUILD.run
+++ b/ci/requirements-2.7_DOC_BUILD.run
@@ -1,6 +1,7 @@
 ipython
 sphinx
 nbconvert
+nbformat
 matplotlib
 scipy
 lxml


### PR DESCRIPTION
The build [here](https://travis-ci.org/pydata/pandas/jobs/138633677#L1866) didn't succeed. Had `nbconvert` in the debs, but not `nbformat`.
