### PR TITLE
TST: Fix MMapWrapper init test for Windows

### DIFF
--- a/pandas/io/tests/test_common.py
+++ b/pandas/io/tests/test_common.py
@@ -1,7 +1,6 @@
 """
     Tests for the pandas.io.common functionalities
 """
-import nose
 import mmap
 import os
 from os.path import isabs
@@ -98,15 +97,18 @@ class TestMMapWrapper(tm.TestCase):
                                       'test_mmap.csv')
 
     def test_constructor_bad_file(self):
-        if is_platform_windows():
-            raise nose.SkipTest("skipping construction error messages "
-                                "tests on windows")
-
         non_file = StringIO('I am not a file')
         non_file.fileno = lambda: -1
 
-        msg = "Invalid argument"
-        tm.assertRaisesRegexp(mmap.error, msg, common.MMapWrapper, non_file)
+        # the error raised is different on Windows
+        if is_platform_windows():
+            msg = "The parameter is incorrect"
+            err = OSError
+        else:
+            msg = "Invalid argument"
+            err = mmap.error
+
+        tm.assertRaisesRegexp(err, msg, common.MMapWrapper, non_file)
 
         target = open(self.mmap_file, 'r')
         target.close()


### PR DESCRIPTION
Turns out Windows errors differently when an invalid `fileno` is passed into the `mmap` constructor, so there's no need to skip the test (xref: 9670b31).
