### PR TITLE
BUG: Fix bug with symmetric difference of two equal MultiIndexes GH12490

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -482,7 +482,7 @@ Bug Fixes
 - Bug in ``pd.read_hdf()`` where attempting to load an HDF file with a single dataset, that had one or more categorical columns, failed unless the key argument was set to the name of the dataset. (:issue:`13231`)
 - Bug in ``.rolling()`` that allowed a negative integer window in contruction of the ``Rolling()`` object, but would later fail on aggregation (:issue:`13383`)
 
-
+- Bug in ``MultiIndex.symmetric_difference`` with two equal MultiIndexes (:issue:`13490`)
 - Bug in various index types, which did not propagate the name of passed index (:issue:`12309`)
 - Bug in ``DatetimeIndex``, which did not honour the ``copy=True`` (:issue:`13205`)
 - Bug in ``DatetimeIndex.is_normalized`` returns incorrectly for normalized date_range in case of local timezones (:issue:`13459`)

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -752,13 +752,6 @@ class TestIndex(Base, tm.TestCase):
         self.assertTrue(tm.equalContents(result, expected))
         self.assertIsNone(result.name)
 
-        # multiIndex
-        idx1 = MultiIndex.from_tuples(self.tuples)
-        idx2 = MultiIndex.from_tuples([('foo', 1), ('bar', 3)])
-        result = idx1.symmetric_difference(idx2)
-        expected = MultiIndex.from_tuples([('bar', 2), ('baz', 3), ('bar', 3)])
-        self.assertTrue(tm.equalContents(result, expected))
-
         # nans:
         # GH #6444, sorting of nans. Make sure the number of nans is right
         # and the correct non-nan values are there. punt on sorting.

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -1353,6 +1353,20 @@ class TestMultiIndex(Base, tm.TestCase):
         assertRaisesRegexp(TypeError, "other must be a MultiIndex or a list"
                            " of tuples", first.difference, [1, 2, 3, 4, 5])
 
+    def test_symmetric_difference(self):
+        idx1 = MultiIndex.from_tuples(self.index, names=('A', 'B'))
+        idx2 = MultiIndex.from_tuples([('foo', 'one'), ('bar', 'one'),
+                                       ('baz', 'two'), ('qux', 'two'),
+                                       ('qux', 'one')], names=('A', 'B'))
+        result = idx1.symmetric_difference(idx2)
+        expected = MultiIndex.from_tuples([('foo', 'two')], names=('A', 'B'))
+        tm.assert_index_equal(result, expected)
+
+        # Test for equal multiIndexes
+        result = self.index.symmetric_difference(self.index)
+        expected = result._create_as_empty()
+        tm.assert_index_equal(result, expected)
+
     def test_from_tuples(self):
         assertRaisesRegexp(TypeError, 'Cannot infer number of levels from'
                            ' empty list', MultiIndex.from_tuples, [])


### PR DESCRIPTION
- [x] closes #13490
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Fixes a bug where the symmetric difference of two equal MultiIndexes would raise a TypeError. MultiIndex used to use the `Index.symmetric_difference`. With this PR it it's own implementation that is more like `MultiIndex.difference`.
