### PR TITLE
mmap error is not always returned in English

### DIFF
--- a/pandas/io/tests/test_common.py
+++ b/pandas/io/tests/test_common.py
@@ -105,7 +105,7 @@ class TestMMapWrapper(tm.TestCase):
             msg = "The parameter is incorrect"
             err = OSError
         else:
-            msg = "Invalid argument"
+            msg = "[Errno 22]"
             err = mmap.error
 
         tm.assertRaisesRegexp(err, msg, common.MMapWrapper, non_file)


### PR DESCRIPTION
Fixes a build error from https://github.com/pydata/pandas/pull/12946 caused by mmap error being returned in Italian when `LOCALE_OVERRIDE="it_IT.UTF-8"`. The test fails with:

`AssertionError: "Invalid argument" does not match "[Errno 22] Argomento non valido"`

``` python
        msg = "Invalid argument"
        tm.assertRaisesRegexp(mmap.error, msg, common.MMapWrapper, non_file)
```

i.e. message is not being matched. Change to match the errno instead as that's the same across languages. 
