### PR TITLE
BUG/PERF: Sort mixed-int in Py3, fix Index.difference

### DIFF
--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -63,6 +63,27 @@ class index_datetime_union(object):
         self.rng.union(self.rng2)
 
 
+class index_datetime_set_difference(object):
+    goal_time = 0.2
+
+    def setup(self):
+        self.N = 100000
+        self.A = self.N - 20000
+        self.B = self.N + 20000
+        self.idx1 = DatetimeIndex(range(self.N))
+        self.idx2 = DatetimeIndex(range(self.A, self.B))
+        self.idx3 = DatetimeIndex(range(self.N, self.B))
+
+    def time_index_datetime_difference(self):
+        self.idx1.difference(self.idx2)
+
+    def time_index_datetime_difference_disjoint(self):
+        self.idx1.difference(self.idx3)
+
+    def time_index_datetime_symmetric_difference(self):
+        self.idx1.symmetric_difference(self.idx2)
+
+
 class index_float64_boolean_indexer(object):
     goal_time = 0.2
 
@@ -181,6 +202,40 @@ class index_int64_union(object):
 
     def time_index_int64_union(self):
         self.left.union(self.right)
+
+
+class index_int64_set_difference(object):
+    goal_time = 0.2
+
+    def setup(self):
+        self.N = 500000
+        self.options = np.arange(self.N)
+        self.left = Index(self.options.take(
+            np.random.permutation(self.N)[:(self.N // 2)]))
+        self.right = Index(self.options.take(
+            np.random.permutation(self.N)[:(self.N // 2)]))
+
+    def time_index_int64_difference(self):
+        self.left.difference(self.right)
+
+    def time_index_int64_symmetric_difference(self):
+        self.left.symmetric_difference(self.right)
+
+
+class index_str_set_difference(object):
+    goal_time = 0.2
+
+    def setup(self):
+        self.N = 10000
+        self.strs = tm.rands_array(10, self.N)
+        self.left = Index(self.strs[:self.N * 2 // 3])
+        self.right = Index(self.strs[self.N // 3:])
+
+    def time_str_difference(self):
+        self.left.difference(self.right)
+
+    def time_str_symmetric_difference(self):
+        self.left.symmetric_difference(self.right)
 
 
 class index_str_boolean_indexer(object):

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -395,7 +395,7 @@ resulting dtype will be upcast, which is unchanged from previous.
    pd.merge(df1, df2, how='outer', on='key')
    pd.merge(df1, df2, how='outer', on='key').dtypes
 
-.. _whatsnew_0190.describe:
+.. _whatsnew_0190.api.describe:
 
 ``.describe()`` changes
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -484,6 +484,34 @@ New Behavior:
    pd.NaT + 1
    pd.NaT - 1
 
+.. _whatsnew_0190.api.difference:
+
+``Index.difference`` and ``.symmetric_difference`` changes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``Index.difference`` and ``Index.symmetric_difference`` will now, more consistently, treat ``NaN`` values as any other values. (:issue:`13514`)
+
+.. ipython:: python
+
+   idx1 = pd.Index([1, 2, 3, np.nan])
+   idx2 = pd.Index([0, 1, np.nan])
+
+Previous Behavior:
+
+.. code-block:: ipython
+
+   In [3]: idx1.difference(idx2)
+   Out[3]: Float64Index([nan, 2.0, 3.0], dtype='float64')
+
+   In [4]: idx1.symmetric_difference(idx2)
+   Out[4]: Float64Index([0.0, nan, 2.0, 3.0], dtype='float64')
+
+New Behavior:
+
+.. ipython:: python
+
+   idx1.difference(idx2)
+   idx1.symmetric_difference(idx2)
 
 .. _whatsnew_0190.deprecations:
 
@@ -520,7 +548,7 @@ Performance Improvements
 
 - Improved performance of float64 hash table operations, fixing some very slow indexing and groupby operations in python 3 (:issue:`13166`, :issue:`13334`)
 - Improved performance of ``DataFrameGroupBy.transform`` (:issue:`12737`)
-
+- Improved performance of ``Index.difference`` (:issue:`12044`)
 
 .. _whatsnew_0190.bug_fixes:
 
@@ -614,3 +642,5 @@ Bug Fixes
 - Bug in ``groupby`` with ``as_index=False`` returns all NaN's when grouping on multiple columns including a categorical one (:issue:`13204`)
 
 - Bug where ``pd.read_gbq()`` could throw ``ImportError: No module named discovery`` as a result of a naming conflict with another python package called apiclient  (:issue:`13454`)
+- Bug in ``Index.union`` returns an incorrect result with a named empty index (:issue:`13432`)
+- Bugs in ``Index.difference`` and ``DataFrame.join`` raise in Python3 when using mixed-integer indexes (:issue:`13432`, :issue:`12814`)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -163,6 +163,104 @@ def isin(comps, values):
     return f(comps, values)
 
 
+def safe_sort(values, labels=None, na_sentinel=-1, assume_unique=False):
+    """
+    Sort ``values`` and reorder corresponding ``labels``.
+    ``values`` should be unique if ``labels`` is not None.
+    Safe for use with mixed types (int, str), orders ints before strs.
+
+    .. versionadded:: 0.19.0
+
+    Parameters
+    ----------
+    values : list-like
+        Sequence; must be unique if ``labels`` is not None.
+    labels : list_like
+        Indices to ``values``. All out of bound indices are treated as
+        "not found" and will be masked with ``na_sentinel``.
+    na_sentinel : int, default -1
+        Value in ``labels`` to mark "not found".
+        Ignored when ``labels`` is None.
+    assume_unique : bool, default False
+        When True, ``values`` are assumed to be unique, which can speed up
+        the calculation. Ignored when ``labels`` is None.
+
+    Returns
+    -------
+    ordered : ndarray
+        Sorted ``values``
+    new_labels : ndarray
+        Reordered ``labels``; returned when ``labels`` is not None.
+
+    Raises
+    ------
+    TypeError
+        * If ``values`` is not list-like or if ``labels`` is neither None
+        nor list-like
+        * If ``values`` cannot be sorted
+    ValueError
+        * If ``labels`` is not None and ``values`` contain duplicates.
+    """
+    if not is_list_like(values):
+        raise TypeError("Only list-like objects are allowed to be passed to"
+                        "safe_sort as values")
+    values = np.array(values, copy=False)
+
+    def sort_mixed(values):
+        # order ints before strings, safe in py3
+        str_pos = np.array([isinstance(x, string_types) for x in values],
+                           dtype=bool)
+        nums = np.sort(values[~str_pos])
+        strs = np.sort(values[str_pos])
+        return _ensure_object(np.concatenate([nums, strs]))
+
+    sorter = None
+    if compat.PY3 and lib.infer_dtype(values) == 'mixed-integer':
+        # unorderable in py3 if mixed str/int
+        ordered = sort_mixed(values)
+    else:
+        try:
+            sorter = values.argsort()
+            ordered = values.take(sorter)
+        except TypeError:
+            # try this anyway
+            ordered = sort_mixed(values)
+
+    # labels:
+
+    if labels is None:
+        return ordered
+
+    if not is_list_like(labels):
+        raise TypeError("Only list-like objects or None are allowed to be"
+                        "passed to safe_sort as labels")
+    labels = _ensure_platform_int(np.asarray(labels))
+
+    from pandas import Index
+    if not assume_unique and not Index(values).is_unique:
+        raise ValueError("values should be unique if labels is not None")
+
+    if sorter is None:
+        # mixed types
+        (hash_klass, _), values = _get_data_algo(values, _hashtables)
+        t = hash_klass(len(values))
+        t.map_locations(values)
+        sorter = _ensure_platform_int(t.lookup(ordered))
+
+    reverse_indexer = np.empty(len(sorter), dtype=np.int_)
+    reverse_indexer.put(sorter, np.arange(len(sorter)))
+
+    mask = (labels < -len(values)) | (labels >= len(values)) | \
+        (labels == na_sentinel)
+
+    # (Out of bound indices will be masked with `na_sentinel` next, so we may
+    # deal with them here without performance loss using `mode='wrap'`.)
+    new_labels = reverse_indexer.take(labels, mode='wrap')
+    np.putmask(new_labels, mask, na_sentinel)
+
+    return ordered, new_labels
+
+
 def factorize(values, sort=False, order=None, na_sentinel=-1, size_hint=None):
     """
     Encode input values as an enumerated type or categorical variable
@@ -210,33 +308,10 @@ def factorize(values, sort=False, order=None, na_sentinel=-1, size_hint=None):
     uniques = uniques.to_array()
 
     if sort and len(uniques) > 0:
-        try:
-            sorter = uniques.argsort()
-        except:
-            # unorderable in py3 if mixed str/int
-            t = hash_klass(len(uniques))
-            t.map_locations(_ensure_object(uniques))
-
-            # order ints before strings
-            ordered = np.concatenate([
-                np.sort(np.array([e for i, e in enumerate(uniques) if f(e)],
-                                 dtype=object)) for f in
-                [lambda x: not isinstance(x, string_types),
-                 lambda x: isinstance(x, string_types)]])
-            sorter = _ensure_platform_int(t.lookup(
-                _ensure_object(ordered)))
-
-        reverse_indexer = np.empty(len(sorter), dtype=np.int_)
-        reverse_indexer.put(sorter, np.arange(len(sorter)))
-
-        mask = labels < 0
-        labels = reverse_indexer.take(labels)
-        np.putmask(labels, mask, -1)
-
-        uniques = uniques.take(sorter)
+        uniques, labels = safe_sort(uniques, labels, na_sentinel=na_sentinel,
+                                    assume_unique=True)
 
     if is_datetimetz_type:
-
         # reset tz
         uniques = DatetimeIndex(uniques.astype('M8[ns]')).tz_localize(
             values.tz)

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -1877,6 +1877,15 @@ class TestMultiIndex(Base, tm.TestCase):
             self.assertTrue(idx.has_duplicates)
             self.assertEqual(idx.drop_duplicates().names, idx.names)
 
+    def test_get_unique_index(self):
+        idx = self.index[[0, 1, 0, 1, 1, 0, 0]]
+        expected = self.index._shallow_copy(idx[[0, 1]])
+
+        for dropna in [False, True]:
+            result = idx._get_unique_index(dropna=dropna)
+            self.assertTrue(result.unique)
+            self.assert_index_equal(result, expected)
+
     def test_tolist(self):
         result = self.index.tolist()
         exp = list(self.index.values)

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -3210,6 +3210,18 @@ class TestGroupBy(tm.TestCase):
         expected = df.groupby(df[0]).mean()
         assert_frame_equal(result, expected)
 
+    def test_groupby_mixed_type_columns(self):
+        # GH 13432, unorderable types in py3
+        df = DataFrame([[0, 1, 2]], columns=['A', 'B', 0])
+        expected = DataFrame([[1, 2]], columns=['B', 0],
+                             index=Index([0], name='A'))
+
+        result = df.groupby('A').first()
+        tm.assert_frame_equal(result, expected)
+
+        result = df.groupby('A').sum()
+        tm.assert_frame_equal(result, expected)
+
     def test_cython_grouper_series_bug_noncontig(self):
         arr = np.empty((100, 100))
         arr.fill(np.nan)

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1209,16 +1209,12 @@ def _sort_labels(uniques, left, right):
         # tuplesafe
         uniques = Index(uniques).values
 
-    sorter = uniques.argsort()
+    l = len(left)
+    labels = np.concatenate([left, right])
 
-    reverse_indexer = np.empty(len(sorter), dtype=np.int64)
-    reverse_indexer.put(sorter, np.arange(len(sorter)))
-
-    new_left = reverse_indexer.take(_ensure_platform_int(left))
-    np.putmask(new_left, left == -1, -1)
-
-    new_right = reverse_indexer.take(_ensure_platform_int(right))
-    np.putmask(new_right, right == -1, -1)
+    _, new_labels = algos.safe_sort(uniques, labels, na_sentinel=-1)
+    new_labels = _ensure_int64(new_labels)
+    new_left, new_right = new_labels[:l], new_labels[l:]
 
     return new_left, new_right
 

--- a/pandas/tools/tests/test_join.py
+++ b/pandas/tools/tests/test_join.py
@@ -536,6 +536,23 @@ class TestJoin(tm.TestCase):
         joined = left.join(right, on='key', sort=False)
         self.assert_index_equal(joined.index, pd.Index(lrange(4)))
 
+    def test_join_mixed_non_unique_index(self):
+        # GH 12814, unorderable types in py3 with a non-unique index
+        df1 = DataFrame({'a': [1, 2, 3, 4]}, index=[1, 2, 3, 'a'])
+        df2 = DataFrame({'b': [5, 6, 7, 8]}, index=[1, 3, 3, 4])
+        result = df1.join(df2)
+        expected = DataFrame({'a': [1, 2, 3, 3, 4],
+                              'b': [5, np.nan, 6, 7, np.nan]},
+                             index=[1, 2, 3, 3, 'a'])
+        tm.assert_frame_equal(result, expected)
+
+        df3 = DataFrame({'a': [1, 2, 3, 4]}, index=[1, 2, 2, 'a'])
+        df4 = DataFrame({'b': [5, 6, 7, 8]}, index=[1, 2, 3, 4])
+        result = df3.join(df4)
+        expected = DataFrame({'a': [1, 2, 3, 4], 'b': [5, 6, 6, np.nan]},
+                             index=[1, 2, 2, 'a'])
+        tm.assert_frame_equal(result, expected)
+
     def test_mixed_type_join_with_suffix(self):
         # GH #916
         df = DataFrame(np.random.randn(20, 6),


### PR DESCRIPTION
- [x] fixes some issues from #13432
- [x] closes #12044
- [x] closes #12814
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

---
1. Added an internal `safe_sort` to safely sort mixed-integer
   arrays in Python3.
2. Changed Index.difference and Index.symmetric_difference
   in order to:
   - sort mixed-int Indexes (#13432)
   - improve performance (#12044)
3. Fixed DataFrame.join which raised in Python3 with mixed-int
   non-unique indexes (issue with sorting mixed-ints, #12814)
4. Fixed Index.union returning an empty Index when one of
   arguments was a named empty Index (#13432)

Benchmarks (for `index_object` only):

```
]$ asv compare bf47 a02f -f 1.5 -s 
Benchmarks that have improved:
    before     after       ratio
  [bf47    ] [a02f    ]
-  155.66ms    10.32ms      0.07  index_object.index_datetime_set_difference.time_index_datetime_difference
-  154.66ms     2.98ms      0.02  index_object.index_datetime_set_difference.time_index_datetime_difference_disjoint
-  391.45ms    10.65ms      0.03  index_object.index_datetime_set_difference.time_index_datetime_symmetric_difference
-  195.55ms    88.95ms      0.45  index_object.index_int64_set_difference.time_index_int64_difference
-  440.93ms   103.65ms      0.24  index_object.index_int64_set_difference.time_index_int64_symmetric_difference
-    8.77ms     4.88ms      0.56  index_object.index_str_set_difference.time_str_symmetric_difference
```
