### PR TITLE
Fixes a missing ".reshape" call

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -1194,7 +1194,7 @@ def _possibly_infer_to_datetimelike(value, convert_dates=False):
             try:
                 return to_timedelta(v)._values.reshape(shape)
             except:
-                return v
+                return v.reshape(shape)
 
         # do a quick inference for perf
         sample = v[:min(3, len(v))]


### PR DESCRIPTION
closes https://github.com/pydata/pandas/issues/13287

Currently, some 2D arrays can go into [_possibly_infer_to_datetimelike](https://github.com/andyljones/pandas/blob/59b9e835d49036cabad19cf2c53140ac9f2eb465/pandas/core/common.py#L1133-L1222) and come out 1D. The issue is that the input is ravelled [at one point](https://github.com/andyljones/pandas/blob/59b9e835d49036cabad19cf2c53140ac9f2eb465/pandas/core/common.py#L1165), but only unravelled back to it's original form [if a certain path it taken through the function](https://github.com/andyljones/pandas/blob/59b9e835d49036cabad19cf2c53140ac9f2eb465/pandas/core/common.py#L1187). This pull request adds the same `.reshape(shape)` call to the _other_ path through the function.
