### PR TITLE
TST: Move `test_crosstab_margins` to `TestPivotTable`

### DIFF
--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -801,6 +801,26 @@ class TestPivotTable(tm.TestCase):
         expected = pd.DataFrame(table.values, index=ix, columns=cols)
         tm.assert_frame_equal(table, expected)
 
+    def test_categorical_margins(self):
+        # GH 10989
+        df = pd.DataFrame({'x': np.arange(8),
+                           'y': np.arange(8) // 4,
+                           'z': np.arange(8) % 2})
+
+        expected = pd.DataFrame([[1.0, 2.0, 1.5], [5, 6, 5.5], [3, 4, 3.5]])
+        expected.index = Index([0, 1, 'All'], name='y')
+        expected.columns = Index([0, 1, 'All'], name='z')
+
+        data = df.copy()
+        table = data.pivot_table('x', 'y', 'z', margins=True)
+        tm.assert_frame_equal(table, expected)
+
+        data = df.copy()
+        data.y = data.y.astype('category')
+        data.z = data.z.astype('category')
+        table = data.pivot_table('x', 'y', 'z', margins=True)
+        tm.assert_frame_equal(table, expected)
+
 
 class TestCrosstab(tm.TestCase):
 
@@ -918,26 +938,6 @@ class TestCrosstab(tm.TestCase):
                                     ('two', 'dull'), ('two', 'shiny')],
                                    names=['b', 'c'])
         tm.assert_index_equal(res.columns, m)
-
-    def test_categorical_margins(self):
-        # GH 10989
-        df = pd.DataFrame({'x': np.arange(8),
-                           'y': np.arange(8) // 4,
-                           'z': np.arange(8) % 2})
-
-        expected = pd.DataFrame([[1.0, 2.0, 1.5], [5, 6, 5.5], [3, 4, 3.5]])
-        expected.index = Index([0, 1, 'All'], name='y')
-        expected.columns = Index([0, 1, 'All'], name='z')
-
-        data = df.copy()
-        table = data.pivot_table('x', 'y', 'z', margins=True)
-        tm.assert_frame_equal(table, expected)
-
-        data = df.copy()
-        data.y = data.y.astype('category')
-        data.z = data.z.astype('category')
-        table = data.pivot_table('x', 'y', 'z', margins=True)
-        tm.assert_frame_equal(table, expected)
 
     def test_crosstab_no_overlap(self):
         # GS 10291


### PR DESCRIPTION
This test case assert `pivot_table` method.
So it should be defined on `TestPivotTable`.
