### PR TITLE
BUG: pivot_table always returns a DataFrame

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -771,3 +771,4 @@ Bug Fixes
 - Bug in ``pd.melt()`` where passing a tuple value for ``value_vars`` caused a ``TypeError`` (:issue:`15348`)
 - Bug in ``.eval()`` which caused multiline evals to fail with local variables not on the first line (:issue:`15342`)
 - Bug in ``pd.read_msgpack`` which did not allow to load dataframe with an index of type ``CategoricalIndex`` (:issue:`15487`)
+- Bug in ``pivot_table`` returns ``Series`` in specific circumstance (:issue:`4386`)

--- a/pandas/tests/tools/test_pivot.py
+++ b/pandas/tests/tools/test_pivot.py
@@ -939,6 +939,44 @@ class TestPivotTable(tm.TestCase):
                                 columns=expected_columns)
         tm.assert_frame_equal(result, expected)
 
+    def test_pivot_table_not_series(self):
+        # GH 4386
+        # pivot_table always returns a DataFrame
+        # when values is not list like and columns is None
+        # and aggfunc is not instance of list
+        df = DataFrame({'col1': [3, 4, 5],
+                        'col2': ['C', 'D', 'E'],
+                        'col3': [1, 3, 9]})
+
+        result = df.pivot_table('col1', index=['col3', 'col2'], aggfunc=np.sum)
+        m = MultiIndex.from_arrays([[1, 3, 9],
+                                    ['C', 'D', 'E']],
+                                   names=['col3', 'col2'])
+        expected = DataFrame([3, 4, 5],
+                             index=m, columns=['col1'])
+
+        tm.assert_frame_equal(result, expected)
+
+        result = df.pivot_table(
+            'col1', index='col3', columns='col2', aggfunc=np.sum
+        )
+        expected = DataFrame([[3, np.NaN, np.NaN],
+                              [np.NaN, 4, np.NaN],
+                              [np.NaN, np.NaN, 5]],
+                             index=Index([1, 3, 9], name='col3'),
+                             columns=Index(['C', 'D', 'E'], name='col2'))
+
+        tm.assert_frame_equal(result, expected)
+
+        result = df.pivot_table('col1', index='col3', aggfunc=[np.sum])
+        m = MultiIndex.from_arrays([['sum'],
+                                    ['col1']])
+        expected = DataFrame([3, 4, 5],
+                             index=Index([1, 3, 9], name='col3'),
+                             columns=m)
+
+        tm.assert_frame_equal(result, expected)
+
 
 class TestCrosstab(tm.TestCase):
 

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -169,7 +169,8 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
                              margins_name=margins_name)
 
     # discard the top level
-    if values_passed and not values_multi and not table.empty:
+    if values_passed and not values_multi and not table.empty and \
+       (table.columns.nlevels > 1):
         table = table[values[0]]
 
     if len(index) == 0 and len(columns) > 0:


### PR DESCRIPTION
- [x] closes #4386
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Before this commit, if
- `values` is not list like
- `columns` is `None`
- `aggfunc` is not instance of `list`

`pivot_table` returns a `Series`.

This commit adds checking for `columns.nlevels` is
greater than 1 to prevent from casting `table` to
a `Series`.

This will fix #4386.
