### PR TITLE
BUG: Datetime64Formatter not respecting ``formatter``

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -529,4 +529,5 @@ Bug Fixes
 - Bug in ``Categorical.remove_unused_categories()`` changes ``.codes`` dtype to platform int (:issue:`13261`)
 - Bug in ``groupby`` with ``as_index=False`` returns all NaN's when grouping on multiple columns including a categorical one (:issue:`13204`)
 
+- Bug in ``.to_html``, ``.to_latex`` and ``.to_string`` silently ignore custom datetime formatter passed through the ``formatters`` key word (:issue:`10690`)
 - Bug where ``pd.read_gbq()`` could throw ``ImportError: No module named discovery`` as a result of a naming conflict with another python package called apiclient  (:issue:`13454`)

--- a/pandas/formats/format.py
+++ b/pandas/formats/format.py
@@ -2239,8 +2239,12 @@ class Datetime64Formatter(GenericArrayFormatter):
         """ we by definition have DO NOT have a TZ """
 
         values = self.values
+
         if not isinstance(values, DatetimeIndex):
             values = DatetimeIndex(values)
+
+        if self.formatter is not None and callable(self.formatter):
+            return [self.formatter(x) for x in values]
 
         fmt_values = format_array_from_datetime(
             values.asi8.ravel(),


### PR DESCRIPTION
- [x] closes #10690
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

the Datetime64Formatter class did not accept a `formatter` argument, so custom formatters passed in through `df.to_string` or `df.to_html` were silently ignored. 
