### PR TITLE
Remove test plot line blarg

### DIFF
--- a/doc/source/whatsnew/v0.18.2.txt
+++ b/doc/source/whatsnew/v0.18.2.txt
@@ -528,3 +528,5 @@ Bug Fixes
 
 - Bug in ``Categorical.remove_unused_categories()`` changes ``.codes`` dtype to platform int (:issue:`13261`)
 - Bug in ``groupby`` with ``as_index=False`` returns all NaN's when grouping on multiple columns including a categorical one (:issue:`13204`)
+
+- Bug in ``test_graphics`` to pass the tests with matplotlib 1.9.2

--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1329,10 +1329,6 @@ class TestDataFramePlots(TestPlotBase):
                                      subplots=True, use_index=False)
         self._check_axes_shape(axes, axes_num=4, layout=(4, 1))
 
-        df = DataFrame({'x': [1, 2], 'y': [3, 4]})
-        with tm.assertRaises(TypeError):
-            df.plot.line(blarg=True)
-
         df = DataFrame(np.random.rand(10, 3),
                        index=list(string.ascii_letters[:10]))
 


### PR DESCRIPTION
Superceded by #13641

---
- [x] closes #13570 
- [x] tests passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [X] whatsnew entry

The "blarg" argument is propagated to matplotlib and there it raises an
AttributeError (and not a TypeError).
However, since the test doesn't seem to have a rationale, it is removed here.
