### PR TITLE
BUG: Block/DTI doesnt handle tzlocal properly

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -480,6 +480,8 @@ Bug Fixes
 - Bug in ``.resample(..)`` with a ``PeriodIndex`` not retaining its type or name with an empty ``DataFrame`` appropriately when empty (:issue:`13212`)
 - Bug in ``groupby(..).resample(..)`` where passing some keywords would raise an exception (:issue:`13235`)
 - Bug in ``.tz_convert`` on a tz-aware ``DateTimeIndex`` that relied on index being sorted for correct results (:issue:`13306`)
+- Bug in ``.tz_localize`` with ``dateutil.tz.tzlocal`` may return incorrect result (:issue:`13583`)
+- Bug in ``DatetimeTZDtype`` dtype with ``dateutil.tz.tzlocal`` cannot be regarded as valid dtype (:issue:`13583`)
 - Bug in ``pd.read_hdf()`` where attempting to load an HDF file with a single dataset, that had one or more categorical columns, failed unless the key argument was set to the name of the dataset. (:issue:`13231`)
 - Bug in ``.rolling()`` that allowed a negative integer window in contruction of the ``Rolling()`` object, but would later fail on aggregation (:issue:`13383`)
 

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -1263,6 +1263,18 @@ class TestMerge(tm.TestCase):
         result = concat([pd.Series(x), pd.Series(y)], ignore_index=True)
         tm.assert_series_equal(result, pd.Series(x + y, dtype='object'))
 
+    def test_concat_tz_series_tzlocal(self):
+        # GH 13583
+        tm._skip_if_no_dateutil()
+        import dateutil
+        x = [pd.Timestamp('2011-01-01', tz=dateutil.tz.tzlocal()),
+             pd.Timestamp('2011-02-01', tz=dateutil.tz.tzlocal())]
+        y = [pd.Timestamp('2012-01-01', tz=dateutil.tz.tzlocal()),
+             pd.Timestamp('2012-02-01', tz=dateutil.tz.tzlocal())]
+        result = concat([pd.Series(x), pd.Series(y)], ignore_index=True)
+        tm.assert_series_equal(result, pd.Series(x + y))
+        self.assertEqual(result.dtype, 'datetime64[ns, tzlocal()]')
+
     def test_concat_period_series(self):
         x = Series(pd.PeriodIndex(['2015-11-01', '2015-12-01'], freq='D'))
         y = Series(pd.PeriodIndex(['2015-10-01', '2016-01-01'], freq='D'))

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -1591,7 +1591,9 @@ cpdef inline object maybe_get_tz(object tz):
     Otherwise, just return tz.
     """
     if isinstance(tz, string_types):
-        if tz.startswith('dateutil/'):
+        if tz == 'tzlocal()':
+            tz = _dateutil_tzlocal()
+        elif tz.startswith('dateutil/'):
             zone = tz[9:]
             tz = _dateutil_gettz(zone)
             # On Python 3 on Windows, the filename is not always set correctly.
@@ -3767,7 +3769,6 @@ def tz_convert(ndarray[int64_t] vals, object tz1, object tz2):
         return np.array([], dtype=np.int64)
 
     # Convert to UTC
-
     if _get_zone(tz1) != 'UTC':
         utc_dates = np.empty(n, dtype=np.int64)
         if _is_tzlocal(tz1):
@@ -3822,7 +3823,7 @@ def tz_convert(ndarray[int64_t] vals, object tz1, object tz2):
                               dts.min, dts.sec, dts.us, tz2)
                 delta = int(total_seconds(_get_utcoffset(tz2, dt))) * 1000000000
                 result[i] = v + delta
-            return result
+        return result
 
     # Convert UTC to other timezone
     trans, deltas, typ = _get_dst_info(tz2)


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Unable to concatenate `Series` with `tzlocal`

```
s = pd.Series([pd.Timestamp('2011-01-01', tz=dateutil.tz.tzlocal())])
s
#0   2011-01-01 00:00:00+09:00
# dtype: datetime64[ns, tzlocal()]

pd.concat([s, s])
# UnknownTimeZoneError: 'tzlocal()'
```

It is caused by 2 issues:
#### 1. `tslib.maybe_get_tz` can't handle `tzlocal`.

```
pd.tslib.maybe_get_tz('tzlocal()')
# UnknownTimeZoneError: 'tzlocal()'
```
#### 2. `DatetimeIndex.tz_localize` may return incorrect result when `tzlocal` is used.

it's internally used in `conat`.

```
pd.DatetimeIndex(['2011-01-01', '2011-01-02'], tz=dateutil.tz.tzlocal()).tz_localize(None)
# DatetimeIndex(['2011-01-01', '1970-01-01'], dtype='datetime64[ns]', freq=None)
```
