### PR TITLE
BUG: groupby apply on selected columns yielding scalar (GH13568)

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -491,6 +491,7 @@ Bug Fixes
 - Bug in ``PeriodIndex`` construction returning a ``float64`` index in some circumstances (:issue:`13067`)
 - Bug in ``.resample(..)`` with a ``PeriodIndex`` not changing its ``freq`` appropriately when empty (:issue:`13067`)
 - Bug in ``.resample(..)`` with a ``PeriodIndex`` not retaining its type or name with an empty ``DataFrame`` appropriately when empty (:issue:`13212`)
+- Bug in ``groupby(..).apply(..)`` when the passed function returns scalar values per group (:issue:`13468`).
 - Bug in ``groupby(..).resample(..)`` where passing some keywords would raise an exception (:issue:`13235`)
 - Bug in ``.tz_convert`` on a tz-aware ``DateTimeIndex`` that relied on index being sorted for correct results (:issue:`13306`)
 - Bug in ``.tz_localize`` with ``dateutil.tz.tzlocal`` may return incorrect result (:issue:`13583`)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -3407,7 +3407,7 @@ class NDFrameGroupBy(GroupBy):
                 # only coerce dates if we find at least 1 datetime
                 coerce = True if any([isinstance(x, Timestamp)
                                       for x in values]) else False
-                return (Series(values, index=key_index, name=self.name)
+                return (Series(values, index=key_index)
                         ._convert(datetime=True,
                                   coerce=coerce))
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -3403,10 +3403,13 @@ class NDFrameGroupBy(GroupBy):
 
                 return self._reindex_output(result)
 
+            # values are not series or array-like but scalars
             else:
                 # only coerce dates if we find at least 1 datetime
                 coerce = True if any([isinstance(x, Timestamp)
                                       for x in values]) else False
+                # self.name not passed through to Series as the result
+                # should not take the name of original selection of columns
                 return (Series(values, index=key_index)
                         ._convert(datetime=True,
                                   coerce=coerce))

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -2584,6 +2584,16 @@ class TestGroupBy(tm.TestCase):
         result = self.df.groupby(['A', 'B'])['C'].apply(len)
         self.assertEqual(result.index.names[:2], ('A', 'B'))
 
+    def test_apply_frame_yield_constant(self):
+        # GH13568
+        result = self.df.groupby(['A', 'B']).apply(len)
+        self.assertTrue(isinstance(result, Series))
+        self.assertIsNone(result.name)
+
+        result = self.df.groupby(['A', 'B'])[['C', 'D']].apply(len)
+        self.assertTrue(isinstance(result, Series))
+        self.assertIsNone(result.name)
+
     def test_apply_frame_to_series(self):
         grouped = self.df.groupby(['A', 'B'])
         result = grouped.apply(len)


### PR DESCRIPTION
- [x] closes #13568
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
