### PR TITLE
DEPR: Remove legacy offsets

### DIFF
--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -752,7 +752,7 @@ calculate significantly slower and will raise a ``PerformanceWarning``
    rng + BQuarterEnd()
 
 
-.. _timeseries.alias:
+.. _timeseries.custombusinessdays:
 
 Custom Business Days (Experimental)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -953,6 +953,8 @@ You can use keyword arguments suported by either ``BusinessHour`` and ``CustomBu
     # Monday is skipped because it's a holiday, business hour starts from 10:00
     dt + bhour_mon * 2
 
+.. _timeseries.alias:
+
 Offset Aliases
 ~~~~~~~~~~~~~~
 
@@ -1102,48 +1104,6 @@ it is rolled forward to the next anchor point.
 
    pd.Timestamp('2014-01-01') + MonthBegin(n=0)
    pd.Timestamp('2014-01-31') + MonthEnd(n=0)
-
-.. _timeseries.legacyaliases:
-
-Legacy Aliases
-~~~~~~~~~~~~~~
-Note that prior to v0.8.0, time rules had a slightly different look. These are
-deprecated in v0.17.0, and removed in future version.
-
-.. csv-table::
-    :header: "Legacy Time Rule", "Offset Alias"
-    :widths: 15, 65
-
-    "WEEKDAY", "B"
-    "EOM", "BM"
-    "W\@MON", "W\-MON"
-    "W\@TUE", "W\-TUE"
-    "W\@WED", "W\-WED"
-    "W\@THU", "W\-THU"
-    "W\@FRI", "W\-FRI"
-    "W\@SAT", "W\-SAT"
-    "W\@SUN", "W\-SUN"
-    "Q\@JAN", "BQ\-JAN"
-    "Q\@FEB", "BQ\-FEB"
-    "Q\@MAR", "BQ\-MAR"
-    "A\@JAN", "BA\-JAN"
-    "A\@FEB", "BA\-FEB"
-    "A\@MAR", "BA\-MAR"
-    "A\@APR", "BA\-APR"
-    "A\@MAY", "BA\-MAY"
-    "A\@JUN", "BA\-JUN"
-    "A\@JUL", "BA\-JUL"
-    "A\@AUG", "BA\-AUG"
-    "A\@SEP", "BA\-SEP"
-    "A\@OCT", "BA\-OCT"
-    "A\@NOV", "BA\-NOV"
-    "A\@DEC", "BA\-DEC"
-
-
-As you can see, legacy quarterly and annual frequencies are business quarters
-and business year ends. Please also note the legacy time rule for milliseconds
-``ms`` versus the new offset alias for month start ``MS``. This means that
-offset alias parsing is case sensitive.
 
 .. _timeseries.holiday:
 

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -465,6 +465,17 @@ Removal of prior version deprecations/changes
 - ``DataFrame.to_csv()`` has dropped the ``engine`` parameter, as was deprecated in 0.17.1 (:issue:`11274`, :issue:`13419`)
 - ``DataFrame.to_dict()`` has dropped the ``outtype`` parameter in favor of ``orient`` (:issue:`13627`, :issue:`8486`)
 
+- Removal of the legacy time rules (offset aliases), deprecated since 0.17.0 (this has been alias since 0.8.0) (:issue:`13590`)
+
+  Previous Behavior:
+
+  .. code-block:: ipython
+
+     In [2]: pd.date_range('2016-07-01', freq='W@MON', periods=3)
+     pandas/tseries/frequencies.py:465: FutureWarning: Freq "W@MON" is deprecated, use "W-MON" as alternative.
+     Out[2]: DatetimeIndex(['2016-07-04', '2016-07-11', '2016-07-18'], dtype='datetime64[ns]', freq='W-MON')
+
+  Now legacy time rules raises ``ValueError``. For the list of currently supported offsets, see :ref:`here <timeseries.alias>`
 
 .. _whatsnew_0190.performance:
 

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -160,9 +160,11 @@ class TestDatetimeIndexOps(Ops):
             tm.assert_index_equal(rng.round(freq='H'), expected_rng)
             self.assertEqual(elt.round(freq='H'), expected_elt)
 
-            msg = "Could not evaluate foo"
-            tm.assertRaisesRegexp(ValueError, msg, rng.round, freq='foo')
-            tm.assertRaisesRegexp(ValueError, msg, elt.round, freq='foo')
+            msg = pd.tseries.frequencies._INVALID_FREQ_ERROR
+            with tm.assertRaisesRegexp(ValueError, msg):
+                rng.round(freq='foo')
+            with tm.assertRaisesRegexp(ValueError, msg):
+                elt.round(freq='foo')
 
             msg = "<MonthEnd> is a non-fixed frequency"
             tm.assertRaisesRegexp(ValueError, msg, rng.round, freq='M')
@@ -847,9 +849,11 @@ class TestTimedeltaIndexOps(Ops):
         tm.assert_index_equal(td.round(freq='H'), expected_rng)
         self.assertEqual(elt.round(freq='H'), expected_elt)
 
-        msg = "Could not evaluate foo"
-        tm.assertRaisesRegexp(ValueError, msg, td.round, freq='foo')
-        tm.assertRaisesRegexp(ValueError, msg, elt.round, freq='foo')
+        msg = pd.tseries.frequencies._INVALID_FREQ_ERROR
+        with self.assertRaisesRegexp(ValueError, msg):
+            td.round(freq='foo')
+        with tm.assertRaisesRegexp(ValueError, msg):
+            elt.round(freq='foo')
 
         msg = "<MonthEnd> is a non-fixed frequency"
         tm.assertRaisesRegexp(ValueError, msg, td.round, freq='M')

--- a/pandas/tseries/tests/test_frequencies.py
+++ b/pandas/tseries/tests/test_frequencies.py
@@ -245,10 +245,10 @@ def test_period_str_to_code():
         assert isinstance(aliases, list)
         assert (frequencies._period_str_to_code(freq) == expected)
 
+        msg = frequencies._INVALID_FREQ_ERROR
         for alias in aliases:
-            with tm.assert_produces_warning(FutureWarning,
-                                            check_stacklevel=False):
-                assert (frequencies._period_str_to_code(alias) == expected)
+            with tm.assertRaisesRegexp(ValueError, msg):
+                frequencies._period_str_to_code(alias)
 
     _assert_depr("M", 3000, ["MTH", "MONTH", "MONTHLY"])
 
@@ -699,8 +699,9 @@ class TestFrequencyInference(tm.TestCase):
             s = Series(period_range('2013', periods=10, freq=freq))
             self.assertRaises(TypeError, lambda: frequencies.infer_freq(s))
         for freq in ['Y']:
-            with tm.assert_produces_warning(FutureWarning,
-                                            check_stacklevel=False):
+
+            msg = frequencies._INVALID_FREQ_ERROR
+            with tm.assertRaisesRegexp(ValueError, msg):
                 s = Series(period_range('2013', periods=10, freq=freq))
             self.assertRaises(TypeError, lambda: frequencies.infer_freq(s))
 
@@ -715,17 +716,23 @@ class TestFrequencyInference(tm.TestCase):
         self.assertEqual(inferred, 'D')
 
     def test_legacy_offset_warnings(self):
-        for k, v in compat.iteritems(frequencies._rule_aliases):
-            with tm.assert_produces_warning(FutureWarning):
-                result = frequencies.get_offset(k)
-            exp = frequencies.get_offset(v)
-            self.assertEqual(result, exp)
+        freqs = ['WEEKDAY', 'EOM', 'W@MON', 'W@TUE', 'W@WED', 'W@THU',
+                 'W@FRI', 'W@SAT', 'W@SUN', 'Q@JAN', 'Q@FEB', 'Q@MAR',
+                 'A@JAN', 'A@FEB', 'A@MAR', 'A@APR', 'A@MAY', 'A@JUN',
+                 'A@JUL', 'A@AUG', 'A@SEP', 'A@OCT', 'A@NOV', 'A@DEC',
+                 'WOM@1MON', 'WOM@2MON', 'WOM@3MON', 'WOM@4MON',
+                 'WOM@1TUE', 'WOM@2TUE', 'WOM@3TUE', 'WOM@4TUE',
+                 'WOM@1WED', 'WOM@2WED', 'WOM@3WED', 'WOM@4WED',
+                 'WOM@1THU', 'WOM@2THU', 'WOM@3THU', 'WOM@4THU'
+                 'WOM@1FRI', 'WOM@2FRI', 'WOM@3FRI', 'WOM@4FRI']
 
-            with tm.assert_produces_warning(FutureWarning,
-                                            check_stacklevel=False):
-                idx = date_range('2011-01-01', periods=5, freq=k)
-            exp = date_range('2011-01-01', periods=5, freq=v)
-            self.assert_index_equal(idx, exp)
+        msg = frequencies._INVALID_FREQ_ERROR
+        for freq in freqs:
+            with tm.assertRaisesRegexp(ValueError, msg):
+                frequencies.get_offset(freq)
+
+            with tm.assertRaisesRegexp(ValueError, msg):
+                date_range('2011-01-01', periods=5, freq=freq)
 
 
 MONTHS = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT',

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -448,13 +448,16 @@ class TestPeriodProperties(tm.TestCase):
                  "L": ["MILLISECOND", "MILLISECONDLY", "millisecond"],
                  "U": ["MICROSECOND", "MICROSECONDLY", "microsecond"],
                  "N": ["NANOSECOND", "NANOSECONDLY", "nanosecond"]}
+
+        msg = pd.tseries.frequencies._INVALID_FREQ_ERROR
         for exp, freqs in iteritems(cases):
             for freq in freqs:
+                with self.assertRaisesRegexp(ValueError, msg):
+                    Period('2016-03-01 09:00', freq=freq)
 
-                with tm.assert_produces_warning(FutureWarning,
-                                                check_stacklevel=False):
-                    res = pd.Period('2016-03-01 09:00', freq=freq)
-                self.assertEqual(res, Period('2016-03-01 09:00', freq=exp))
+                # check supported freq-aliases still works
+                p = Period('2016-03-01 09:00', freq=exp)
+                tm.assertIsInstance(p, Period)
 
     def test_repr(self):
         p = Period('Jan-2000')
@@ -665,18 +668,20 @@ class TestPeriodProperties(tm.TestCase):
 
     def test_properties_weekly_legacy(self):
         # Test properties on Periods with daily frequency.
-        with tm.assert_produces_warning(FutureWarning):
-            w_date = Period(freq='WK', year=2007, month=1, day=7)
-        #
+        w_date = Period(freq='W', year=2007, month=1, day=7)
         self.assertEqual(w_date.year, 2007)
         self.assertEqual(w_date.quarter, 1)
         self.assertEqual(w_date.month, 1)
         self.assertEqual(w_date.week, 1)
         self.assertEqual((w_date - 1).week, 52)
         self.assertEqual(w_date.days_in_month, 31)
-        with tm.assert_produces_warning(FutureWarning):
-            exp = Period(freq='WK', year=2012, month=2, day=1)
+
+        exp = Period(freq='W', year=2012, month=2, day=1)
         self.assertEqual(exp.days_in_month, 29)
+
+        msg = pd.tseries.frequencies._INVALID_FREQ_ERROR
+        with self.assertRaisesRegexp(ValueError, msg):
+            Period(freq='WK', year=2007, month=1, day=7)
 
     def test_properties_daily(self):
         # Test properties on Periods with daily frequency.
@@ -826,10 +831,11 @@ class TestPeriodProperties(tm.TestCase):
         self.assertEqual(initial.asfreq(freq="M", how="S"),
                          Period('2013-01', 'M'))
 
-        with self.assertRaisesRegexp(ValueError, "Unknown freqstr"):
+        msg = pd.tseries.frequencies._INVALID_FREQ_ERROR
+        with self.assertRaisesRegexp(ValueError, msg):
             initial.asfreq(freq="MS", how="S")
 
-        with tm.assertRaisesRegexp(ValueError, "Unknown freqstr: MS"):
+        with tm.assertRaisesRegexp(ValueError, msg):
             pd.Period('2013-01', 'MS')
 
         self.assertTrue(_period_code_map.get("MS") is None)
@@ -1129,123 +1135,28 @@ class TestFreqConversion(tm.TestCase):
 
         self.assertEqual(ival_W.asfreq('W'), ival_W)
 
+        msg = pd.tseries.frequencies._INVALID_FREQ_ERROR
+        with self.assertRaisesRegexp(ValueError, msg):
+            ival_W.asfreq('WK')
+
     def test_conv_weekly_legacy(self):
         # frequency conversion tests: from Weekly Frequency
+        msg = pd.tseries.frequencies._INVALID_FREQ_ERROR
+        with self.assertRaisesRegexp(ValueError, msg):
+            Period(freq='WK', year=2007, month=1, day=1)
 
-        with tm.assert_produces_warning(FutureWarning):
-            ival_W = Period(freq='WK', year=2007, month=1, day=1)
-
-        with tm.assert_produces_warning(FutureWarning):
-            ival_WSUN = Period(freq='WK', year=2007, month=1, day=7)
-        with tm.assert_produces_warning(FutureWarning):
-            ival_WSAT = Period(freq='WK-SAT', year=2007, month=1, day=6)
-        with tm.assert_produces_warning(FutureWarning):
-            ival_WFRI = Period(freq='WK-FRI', year=2007, month=1, day=5)
-        with tm.assert_produces_warning(FutureWarning):
-            ival_WTHU = Period(freq='WK-THU', year=2007, month=1, day=4)
-        with tm.assert_produces_warning(FutureWarning):
-            ival_WWED = Period(freq='WK-WED', year=2007, month=1, day=3)
-        with tm.assert_produces_warning(FutureWarning):
-            ival_WTUE = Period(freq='WK-TUE', year=2007, month=1, day=2)
-        with tm.assert_produces_warning(FutureWarning):
-            ival_WMON = Period(freq='WK-MON', year=2007, month=1, day=1)
-
-        ival_WSUN_to_D_start = Period(freq='D', year=2007, month=1, day=1)
-        ival_WSUN_to_D_end = Period(freq='D', year=2007, month=1, day=7)
-        ival_WSAT_to_D_start = Period(freq='D', year=2006, month=12, day=31)
-        ival_WSAT_to_D_end = Period(freq='D', year=2007, month=1, day=6)
-        ival_WFRI_to_D_start = Period(freq='D', year=2006, month=12, day=30)
-        ival_WFRI_to_D_end = Period(freq='D', year=2007, month=1, day=5)
-        ival_WTHU_to_D_start = Period(freq='D', year=2006, month=12, day=29)
-        ival_WTHU_to_D_end = Period(freq='D', year=2007, month=1, day=4)
-        ival_WWED_to_D_start = Period(freq='D', year=2006, month=12, day=28)
-        ival_WWED_to_D_end = Period(freq='D', year=2007, month=1, day=3)
-        ival_WTUE_to_D_start = Period(freq='D', year=2006, month=12, day=27)
-        ival_WTUE_to_D_end = Period(freq='D', year=2007, month=1, day=2)
-        ival_WMON_to_D_start = Period(freq='D', year=2006, month=12, day=26)
-        ival_WMON_to_D_end = Period(freq='D', year=2007, month=1, day=1)
-
-        with tm.assert_produces_warning(FutureWarning):
-            ival_W_end_of_year = Period(freq='WK', year=2007, month=12, day=31)
-        with tm.assert_produces_warning(FutureWarning):
-            ival_W_end_of_quarter = Period(freq='WK', year=2007, month=3,
-                                           day=31)
-        with tm.assert_produces_warning(FutureWarning):
-            ival_W_end_of_month = Period(freq='WK', year=2007, month=1, day=31)
-        ival_W_to_A = Period(freq='A', year=2007)
-        ival_W_to_Q = Period(freq='Q', year=2007, quarter=1)
-        ival_W_to_M = Period(freq='M', year=2007, month=1)
-
-        if Period(freq='D', year=2007, month=12, day=31).weekday == 6:
-            ival_W_to_A_end_of_year = Period(freq='A', year=2007)
-        else:
-            ival_W_to_A_end_of_year = Period(freq='A', year=2008)
-
-        if Period(freq='D', year=2007, month=3, day=31).weekday == 6:
-            ival_W_to_Q_end_of_quarter = Period(freq='Q', year=2007, quarter=1)
-        else:
-            ival_W_to_Q_end_of_quarter = Period(freq='Q', year=2007, quarter=2)
-
-        if Period(freq='D', year=2007, month=1, day=31).weekday == 6:
-            ival_W_to_M_end_of_month = Period(freq='M', year=2007, month=1)
-        else:
-            ival_W_to_M_end_of_month = Period(freq='M', year=2007, month=2)
-
-        ival_W_to_B_start = Period(freq='B', year=2007, month=1, day=1)
-        ival_W_to_B_end = Period(freq='B', year=2007, month=1, day=5)
-        ival_W_to_D_start = Period(freq='D', year=2007, month=1, day=1)
-        ival_W_to_D_end = Period(freq='D', year=2007, month=1, day=7)
-        ival_W_to_H_start = Period(freq='H', year=2007, month=1, day=1, hour=0)
-        ival_W_to_H_end = Period(freq='H', year=2007, month=1, day=7, hour=23)
-        ival_W_to_T_start = Period(freq='Min', year=2007, month=1, day=1,
-                                   hour=0, minute=0)
-        ival_W_to_T_end = Period(freq='Min', year=2007, month=1, day=7,
-                                 hour=23, minute=59)
-        ival_W_to_S_start = Period(freq='S', year=2007, month=1, day=1, hour=0,
-                                   minute=0, second=0)
-        ival_W_to_S_end = Period(freq='S', year=2007, month=1, day=7, hour=23,
-                                 minute=59, second=59)
-
-        self.assertEqual(ival_W.asfreq('A'), ival_W_to_A)
-        self.assertEqual(ival_W_end_of_year.asfreq('A'),
-                         ival_W_to_A_end_of_year)
-        self.assertEqual(ival_W.asfreq('Q'), ival_W_to_Q)
-        self.assertEqual(ival_W_end_of_quarter.asfreq('Q'),
-                         ival_W_to_Q_end_of_quarter)
-        self.assertEqual(ival_W.asfreq('M'), ival_W_to_M)
-        self.assertEqual(ival_W_end_of_month.asfreq('M'),
-                         ival_W_to_M_end_of_month)
-
-        self.assertEqual(ival_W.asfreq('B', 'S'), ival_W_to_B_start)
-        self.assertEqual(ival_W.asfreq('B', 'E'), ival_W_to_B_end)
-
-        self.assertEqual(ival_W.asfreq('D', 'S'), ival_W_to_D_start)
-        self.assertEqual(ival_W.asfreq('D', 'E'), ival_W_to_D_end)
-
-        self.assertEqual(ival_WSUN.asfreq('D', 'S'), ival_WSUN_to_D_start)
-        self.assertEqual(ival_WSUN.asfreq('D', 'E'), ival_WSUN_to_D_end)
-        self.assertEqual(ival_WSAT.asfreq('D', 'S'), ival_WSAT_to_D_start)
-        self.assertEqual(ival_WSAT.asfreq('D', 'E'), ival_WSAT_to_D_end)
-        self.assertEqual(ival_WFRI.asfreq('D', 'S'), ival_WFRI_to_D_start)
-        self.assertEqual(ival_WFRI.asfreq('D', 'E'), ival_WFRI_to_D_end)
-        self.assertEqual(ival_WTHU.asfreq('D', 'S'), ival_WTHU_to_D_start)
-        self.assertEqual(ival_WTHU.asfreq('D', 'E'), ival_WTHU_to_D_end)
-        self.assertEqual(ival_WWED.asfreq('D', 'S'), ival_WWED_to_D_start)
-        self.assertEqual(ival_WWED.asfreq('D', 'E'), ival_WWED_to_D_end)
-        self.assertEqual(ival_WTUE.asfreq('D', 'S'), ival_WTUE_to_D_start)
-        self.assertEqual(ival_WTUE.asfreq('D', 'E'), ival_WTUE_to_D_end)
-        self.assertEqual(ival_WMON.asfreq('D', 'S'), ival_WMON_to_D_start)
-        self.assertEqual(ival_WMON.asfreq('D', 'E'), ival_WMON_to_D_end)
-
-        self.assertEqual(ival_W.asfreq('H', 'S'), ival_W_to_H_start)
-        self.assertEqual(ival_W.asfreq('H', 'E'), ival_W_to_H_end)
-        self.assertEqual(ival_W.asfreq('Min', 'S'), ival_W_to_T_start)
-        self.assertEqual(ival_W.asfreq('Min', 'E'), ival_W_to_T_end)
-        self.assertEqual(ival_W.asfreq('S', 'S'), ival_W_to_S_start)
-        self.assertEqual(ival_W.asfreq('S', 'E'), ival_W_to_S_end)
-
-        with tm.assert_produces_warning(FutureWarning):
-            self.assertEqual(ival_W.asfreq('WK'), ival_W)
+        with self.assertRaisesRegexp(ValueError, msg):
+            Period(freq='WK-SAT', year=2007, month=1, day=6)
+        with self.assertRaisesRegexp(ValueError, msg):
+            Period(freq='WK-FRI', year=2007, month=1, day=5)
+        with self.assertRaisesRegexp(ValueError, msg):
+            Period(freq='WK-THU', year=2007, month=1, day=4)
+        with self.assertRaisesRegexp(ValueError, msg):
+            Period(freq='WK-WED', year=2007, month=1, day=3)
+        with self.assertRaisesRegexp(ValueError, msg):
+            Period(freq='WK-TUE', year=2007, month=1, day=2)
+        with self.assertRaisesRegexp(ValueError, msg):
+            Period(freq='WK-MON', year=2007, month=1, day=1)
 
     def test_conv_business(self):
         # frequency conversion tests: from Business Frequency"
@@ -2895,10 +2806,13 @@ class TestPeriodIndex(tm.TestCase):
             prng = rng.to_period()
             self.assertEqual(prng.freq, 'M')
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            rng = date_range('01-Jan-2012', periods=8, freq='EOM')
+        rng = date_range('01-Jan-2012', periods=8, freq='M')
         prng = rng.to_period()
         self.assertEqual(prng.freq, 'M')
+
+        msg = pd.tseries.frequencies._INVALID_FREQ_ERROR
+        with self.assertRaisesRegexp(ValueError, msg):
+            date_range('01-Jan-2012', periods=8, freq='EOM')
 
     def test_multiples(self):
         result1 = Period('1989', freq='2A')

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -1388,16 +1388,14 @@ class TestTslib(tm.TestCase):
             result = stamp.round(freq=freq)
             self.assertEqual(result, expected)
 
-        for freq, expected in [
-            ('D', Timestamp('2000-01-05 00:00:00')),
-            ('H', Timestamp('2000-01-05 05:00:00')),
-            ('S', Timestamp('2000-01-05 05:09:15'))
-        ]:
+        for freq, expected in [('D', Timestamp('2000-01-05 00:00:00')),
+                               ('H', Timestamp('2000-01-05 05:00:00')),
+                               ('S', Timestamp('2000-01-05 05:09:15'))]:
             _check_round(freq, expected)
 
-        msg = "Could not evaluate"
-        tm.assertRaisesRegexp(ValueError, msg,
-                              stamp.round, 'foo')
+        msg = pd.tseries.frequencies._INVALID_FREQ_ERROR
+        with self.assertRaisesRegexp(ValueError, msg):
+            stamp.round('foo')
 
 
 class TestTimestampOps(tm.TestCase):


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Follow-up of #10951. Remove legacy offsets deprecated in 0.17.0.
