### PR TITLE
BUG: Series/Index contains NaT with object dtype comparison incorrect

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -520,6 +520,8 @@ Bug Fixes
 - Bug in extension dtype creation where the created types were not is/identical (:issue:`13285`)
 
 - Bug in ``NaT`` - ``Period`` raises ``AttributeError`` (:issue:`13071`)
+- Bug in ``Series`` comparison may output incorrect result if rhs contains ``NaT`` (:issue:`9005`)
+- Bug in ``Series`` and ``Index`` comparison may output incorrect result if it contains ``NaT`` with ``object`` dtype (:issue:`13592`)
 - Bug in ``Period`` addition raises ``TypeError`` if ``Period`` is on right hand side (:issue:`13069`)
 - Bug in ``Peirod`` and ``Series`` or ``Index`` comparison raises ``TypeError`` (:issue:`13200`)
 - Bug in ``pd.set_eng_float_format()`` that would prevent NaN's from formatting (:issue:`11981`)

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -27,7 +27,8 @@ from pandas.core.common import (is_list_like, notnull, isnull,
                                 is_integer_dtype, is_categorical_dtype,
                                 is_object_dtype, is_timedelta64_dtype,
                                 is_datetime64_dtype, is_datetime64tz_dtype,
-                                is_bool_dtype, PerformanceWarning, ABCSeries)
+                                is_bool_dtype, PerformanceWarning,
+                                ABCSeries, ABCIndex)
 
 # -----------------------------------------------------------------------------
 # Functions that add arithmetic methods to objects, given arithmetic factory
@@ -664,6 +665,22 @@ def _arith_method_SERIES(op, name, str_rep, fill_zeros=None, default_axis=None,
     return wrapper
 
 
+def _comp_method_OBJECT_ARRAY(op, x, y):
+    if isinstance(y, list):
+        y = lib.list_to_object_array(y)
+    if isinstance(y, (np.ndarray, ABCSeries, ABCIndex)):
+        if not is_object_dtype(y.dtype):
+            y = y.astype(np.object_)
+
+        if isinstance(y, (ABCSeries, ABCIndex)):
+            y = y.values
+
+        result = lib.vec_compare(x, y, op)
+    else:
+        result = lib.scalar_compare(x, y, op)
+    return result
+
+
 def _comp_method_SERIES(op, name, str_rep, masker=False):
     """
     Wrapper function for Series arithmetic operations, to avoid
@@ -680,16 +697,7 @@ def _comp_method_SERIES(op, name, str_rep, masker=False):
             return op(y, x)
 
         if is_object_dtype(x.dtype):
-            if isinstance(y, list):
-                y = lib.list_to_object_array(y)
-
-            if isinstance(y, (np.ndarray, ABCSeries)):
-                if not is_object_dtype(y.dtype):
-                    result = lib.vec_compare(x, y.astype(np.object_), op)
-                else:
-                    result = lib.vec_compare(x, y, op)
-            else:
-                result = lib.scalar_compare(x, y, op)
+            result = _comp_method_OBJECT_ARRAY(op, x, y)
         else:
 
             # we want to compare like types
@@ -713,12 +721,11 @@ def _comp_method_SERIES(op, name, str_rep, masker=False):
                     (not isscalar(y) and needs_i8_conversion(y))):
 
                 if isscalar(y):
+                    mask = isnull(x)
                     y = _index.convert_scalar(x, _values_from_object(y))
                 else:
+                    mask = isnull(x) | isnull(y)
                     y = y.view('i8')
-
-                mask = isnull(x)
-
                 x = x.view('i8')
 
             try:

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -768,12 +768,12 @@ def scalar_compare(ndarray[object] values, object val, object op):
         raise ValueError('Unrecognized operator')
 
     result = np.empty(n, dtype=bool).view(np.uint8)
-    isnull_val = _checknull(val)
+    isnull_val = checknull(val)
 
     if flag == cpython.Py_NE:
         for i in range(n):
             x = values[i]
-            if _checknull(x):
+            if checknull(x):
                 result[i] = True
             elif isnull_val:
                 result[i] = True
@@ -785,7 +785,7 @@ def scalar_compare(ndarray[object] values, object val, object op):
     elif flag == cpython.Py_EQ:
         for i in range(n):
             x = values[i]
-            if _checknull(x):
+            if checknull(x):
                 result[i] = False
             elif isnull_val:
                 result[i] = False
@@ -798,7 +798,7 @@ def scalar_compare(ndarray[object] values, object val, object op):
     else:
         for i in range(n):
             x = values[i]
-            if _checknull(x):
+            if checknull(x):
                 result[i] = False
             elif isnull_val:
                 result[i] = False
@@ -864,7 +864,7 @@ def vec_compare(ndarray[object] left, ndarray[object] right, object op):
             x = left[i]
             y = right[i]
 
-            if _checknull(x) or _checknull(y):
+            if checknull(x) or checknull(y):
                 result[i] = True
             else:
                 result[i] = cpython.PyObject_RichCompareBool(x, y, flag)
@@ -873,7 +873,7 @@ def vec_compare(ndarray[object] left, ndarray[object] right, object op):
             x = left[i]
             y = right[i]
 
-            if _checknull(x) or _checknull(y):
+            if checknull(x) or checknull(y):
                 result[i] = False
             else:
                 result[i] = cpython.PyObject_RichCompareBool(x, y, flag)

--- a/pandas/tseries/base.py
+++ b/pandas/tseries/base.py
@@ -142,7 +142,7 @@ class DatetimeIndexOpsMixin(object):
             other = type(self)(other)
 
         # compare
-        result = getattr(self.asi8, op)(other.asi8)
+        result = op(self.asi8, other.asi8)
 
         # technically we could support bool dtyped Index
         # for now just return the indexing array directly

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -36,7 +36,7 @@ def _td_index_cmp(opname, nat_result=False):
 
     def wrapper(self, other):
         func = getattr(super(TimedeltaIndex, self), opname)
-        if _is_convertible_to_td(other):
+        if _is_convertible_to_td(other) or other is tslib.NaT:
             other = _to_m8(other)
             result = func(other)
             if com.isnull(other):

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -457,6 +457,32 @@ Freq: D"""
             with tm.assertRaises(TypeError):
                 p - idx
 
+    def test_comp_nat(self):
+        left = pd.DatetimeIndex([pd.Timestamp('2011-01-01'), pd.NaT,
+                                 pd.Timestamp('2011-01-03')])
+        right = pd.DatetimeIndex([pd.NaT, pd.NaT, pd.Timestamp('2011-01-03')])
+
+        for l, r in [(left, right), (left.asobject, right.asobject)]:
+            result = l == r
+            expected = np.array([False, False, True])
+            tm.assert_numpy_array_equal(result, expected)
+
+            result = l != r
+            expected = np.array([True, True, False])
+            tm.assert_numpy_array_equal(result, expected)
+
+            expected = np.array([False, False, False])
+            tm.assert_numpy_array_equal(l == pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT == r, expected)
+
+            expected = np.array([True, True, True])
+            tm.assert_numpy_array_equal(l != pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT != l, expected)
+
+            expected = np.array([False, False, False])
+            tm.assert_numpy_array_equal(l < pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT > l, expected)
+
     def test_value_counts_unique(self):
         # GH 7735
         for tz in [None, 'UTC', 'Asia/Tokyo', 'US/Eastern']:
@@ -1236,6 +1262,32 @@ Freq: D"""
         result = td + dt
         expected = Timestamp('20130102')
         self.assertEqual(result, expected)
+
+    def test_comp_nat(self):
+        left = pd.TimedeltaIndex([pd.Timedelta('1 days'), pd.NaT,
+                                 pd.Timedelta('3 days')])
+        right = pd.TimedeltaIndex([pd.NaT, pd.NaT, pd.Timedelta('3 days')])
+
+        for l, r in [(left, right), (left.asobject, right.asobject)]:
+            result = l == r
+            expected = np.array([False, False, True])
+            tm.assert_numpy_array_equal(result, expected)
+
+            result = l != r
+            expected = np.array([True, True, False])
+            tm.assert_numpy_array_equal(result, expected)
+
+            expected = np.array([False, False, False])
+            tm.assert_numpy_array_equal(l == pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT == r, expected)
+
+            expected = np.array([True, True, True])
+            tm.assert_numpy_array_equal(l != pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT != l, expected)
+
+            expected = np.array([False, False, False])
+            tm.assert_numpy_array_equal(l < pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT > l, expected)
 
     def test_value_counts_unique(self):
         # GH 7735
@@ -2037,6 +2089,32 @@ Freq: Q-DEC"""
         tm.assert_index_equal(result, expected)
         rng -= 1
         tm.assert_index_equal(rng, expected)
+
+    def test_comp_nat(self):
+        left = pd.PeriodIndex([pd.Period('2011-01-01'), pd.NaT,
+                               pd.Period('2011-01-03')])
+        right = pd.PeriodIndex([pd.NaT, pd.NaT, pd.Period('2011-01-03')])
+
+        for l, r in [(left, right), (left.asobject, right.asobject)]:
+            result = l == r
+            expected = np.array([False, False, True])
+            tm.assert_numpy_array_equal(result, expected)
+
+            result = l != r
+            expected = np.array([True, True, False])
+            tm.assert_numpy_array_equal(result, expected)
+
+            expected = np.array([False, False, False])
+            tm.assert_numpy_array_equal(l == pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT == r, expected)
+
+            expected = np.array([True, True, True])
+            tm.assert_numpy_array_equal(l != pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT != l, expected)
+
+            expected = np.array([False, False, False])
+            tm.assert_numpy_array_equal(l < pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT > l, expected)
 
     def test_value_counts_unique(self):
         # GH 7735


### PR DESCRIPTION
- [x] closes #9005 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

`Series` and `Index` compares `NaT == NaT` as `True` if it has `object` dtype. 

```
pd.Series([pd.NaT])
#0   NaT
# dtype: datetime64[ns]

# OK
pd.Series([pd.NaT]) == pd.NaT
#0    False
# dtype: bool

# NG in object dtype
pd.Series([pd.NaT], dtype=object) == pd.NaT
#0    True
# dtype: bool

# OK
pd.Index([pd.NaT]) == pd.NaT
array([False], dtype=bool)

# NG in object dtype
pd.Index([pd.NaT], dtype=object) == pd.NaT
# array([ True], dtype=bool)
```
