### PR TITLE
CLN: Initialization coincides with mapping, hence with uniqueness check

### DIFF
--- a/pandas/index.pyx
+++ b/pandas/index.pyx
@@ -80,7 +80,7 @@ cdef class IndexEngine:
 
     cdef:
         bint unique, monotonic_inc, monotonic_dec
-        bint initialized, monotonic_check, unique_check
+        bint initialized, monotonic_check
 
     def __init__(self, vgetter, n):
         self.vgetter = vgetter
@@ -91,7 +91,6 @@ cdef class IndexEngine:
         self.monotonic_check = 0
 
         self.unique = 0
-        self.unique_check = 0
         self.monotonic_inc = 0
         self.monotonic_dec = 0
 
@@ -211,8 +210,8 @@ cdef class IndexEngine:
     property is_unique:
 
         def __get__(self):
-            if not self.unique_check:
-                self._do_unique_check()
+            if not self.initialized:
+                self.initialize()
 
             return self.unique == 1
 
@@ -246,9 +245,6 @@ cdef class IndexEngine:
     cdef _get_index_values(self):
         return self.vgetter()
 
-    cdef inline _do_unique_check(self):
-        self._ensure_mapping_populated()
-
     def _call_monotonic(self, values):
         raise NotImplementedError
 
@@ -270,7 +266,6 @@ cdef class IndexEngine:
 
         if len(self.mapping) == len(values):
             self.unique = 1
-            self.unique_check = 1
 
         self.initialized = 1
 


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`

Rebased version of https://github.com/pydata/pandas/pull/10229 which was [actually not](https://github.com/pydata/pandas/pull/10229#issuecomment-131470116) fixed by https://github.com/pydata/pandas/pull/10199.

Nothing particular relevant, just wanted to delete this branch locally and noticed it still applies: you'll judge what to do of it.
