### PR TITLE
CLN: Removed coerce param in pd.to_timedelta and pd.to_datetime

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -62,6 +62,7 @@ Deprecations
 Removal of prior version deprecations/changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- ``pd.to_datetime`` and ``pd.to_timedelta`` have dropped the ``coerce`` parameter in favor of ``errors`` (:issue:`13602`)
 
 
 

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -5514,22 +5514,6 @@ class TestDateTimeIndexToJulianDate(tm.TestCase):
 
 
 class TestDaysInMonth(tm.TestCase):
-    def test_coerce_deprecation(self):
-
-        # deprecation of coerce
-        with tm.assert_produces_warning(FutureWarning):
-            to_datetime('2015-02-29', coerce=True)
-        with tm.assert_produces_warning(FutureWarning):
-            self.assertRaises(ValueError,
-                              lambda: to_datetime('2015-02-29', coerce=False))
-
-        # multiple arguments
-        for e, c in zip(['raise', 'ignore', 'coerce'], [True, False]):
-            with tm.assert_produces_warning(FutureWarning):
-                self.assertRaises(TypeError,
-                                  lambda: to_datetime('2015-02-29', errors=e,
-                                                      coerce=c))
-
     # tests for issue #10154
     def test_day_not_in_month_coerce(self):
         self.assertTrue(isnull(to_datetime('2015-02-29', errors='coerce')))

--- a/pandas/tseries/timedeltas.py
+++ b/pandas/tseries/timedeltas.py
@@ -11,12 +11,9 @@ from pandas.types.common import (_ensure_object,
                                  is_timedelta64_dtype,
                                  is_list_like)
 from pandas.types.generic import ABCSeries, ABCIndexClass
-from pandas.util.decorators import deprecate_kwarg
 
 
-@deprecate_kwarg(old_arg_name='coerce', new_arg_name='errors',
-                 mapping={True: 'coerce', False: 'raise'})
-def to_timedelta(arg, unit='ns', box=True, errors='raise', coerce=None):
+def to_timedelta(arg, unit='ns', box=True, errors='raise'):
     """
     Convert argument to timedelta
 

--- a/pandas/tseries/tools.py
+++ b/pandas/tseries/tools.py
@@ -16,7 +16,6 @@ from pandas.types.generic import (ABCIndexClass, ABCSeries,
 from pandas.types.missing import notnull
 
 import pandas.compat as compat
-from pandas.util.decorators import deprecate_kwarg
 
 _DATEUTIL_LEXER_SPLIT = None
 try:
@@ -175,10 +174,8 @@ def _guess_datetime_format_for_array(arr, **kwargs):
         return _guess_datetime_format(arr[non_nan_elements[0]], **kwargs)
 
 
-@deprecate_kwarg(old_arg_name='coerce', new_arg_name='errors',
-                 mapping={True: 'coerce', False: 'raise'})
 def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
-                utc=None, box=True, format=None, exact=True, coerce=None,
+                utc=None, box=True, format=None, exact=True,
                 unit=None, infer_datetime_format=False):
     """
     Convert argument to datetime.


### PR DESCRIPTION
Deprecated back in `v0.17.0` <a href="https://github.com/pydata/pandas/commit/987b7e7e586b8df1d127406c69e0a9094a1a5322">here</a>.  Seems appropriate to carry though now.
