### PR TITLE
TST: add tests for Timestamp.toordinal/fromordinal

### DIFF
--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -255,6 +255,18 @@ class TestTimestamp(tm.TestCase):
                            hour=1, minute=2, second=3, microsecond=999999)),
             repr(Timestamp('2015-11-12 01:02:03.999999')))
 
+    def test_constructor_fromordinal(self):
+        base = datetime.datetime(2000, 1, 1)
+
+        ts = Timestamp.fromordinal(base.toordinal(), freq='D')
+        self.assertEqual(base, ts)
+        self.assertEqual(ts.freq, 'D')
+        self.assertEqual(base.toordinal(), ts.toordinal())
+
+        ts = Timestamp.fromordinal(base.toordinal(), tz='US/Eastern')
+        self.assertEqual(pd.Timestamp('2000-01-01', tz='US/Eastern'), ts)
+        self.assertEqual(base.toordinal(), ts.toordinal())
+
     def test_constructor_offset_depr(self):
         # GH 12160
         with tm.assert_produces_warning(FutureWarning,
@@ -269,6 +281,21 @@ class TestTimestamp(tm.TestCase):
         msg = "Can only specify freq or offset, not both"
         with tm.assertRaisesRegexp(TypeError, msg):
             Timestamp('2011-01-01', offset='D', freq='D')
+
+    def test_constructor_offset_depr_fromordinal(self):
+        # GH 12160
+        base = datetime.datetime(2000, 1, 1)
+
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            ts = Timestamp.fromordinal(base.toordinal(), offset='D')
+        self.assertEqual(pd.Timestamp('2000-01-01'), ts)
+        self.assertEqual(ts.freq, 'D')
+        self.assertEqual(base.toordinal(), ts.toordinal())
+
+        msg = "Can only specify freq or offset, not both"
+        with tm.assertRaisesRegexp(TypeError, msg):
+            Timestamp.fromordinal(base.toordinal(), offset='D', freq='D')
 
     def test_conversion(self):
         # GH 9255

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -235,12 +235,14 @@ class Timestamp(_Timestamp):
     ----------
     ts_input : datetime-like, str, int, float
         Value to be converted to Timestamp
-    offset : str, DateOffset
+    freq : str, DateOffset
         Offset which Timestamp will have
     tz : string, pytz.timezone, dateutil.tz.tzfile or None
         Time zone for time which Timestamp will have.
     unit : string
         numpy unit used for conversion, if ts_input is int or float
+    offset : str, DateOffset
+        Deprecated, use freq
 
     The other two forms mimic the parameters from ``datetime.datetime``. They
     can be passed by either position or keyword, but not both mixed together.
@@ -262,8 +264,21 @@ class Timestamp(_Timestamp):
 
     @classmethod
     def fromordinal(cls, ordinal, freq=None, tz=None, offset=None):
-        """ passed an ordinal, translate and convert to a ts
-            note: by definition there cannot be any tz info on the ordinal itself """
+        """
+        passed an ordinal, translate and convert to a ts
+        note: by definition there cannot be any tz info on the ordinal itself
+
+        Parameters
+        ----------
+        ordinal : int
+            date corresponding to a proleptic Gregorian ordinal
+        freq : str, DateOffset
+            Offset which Timestamp will have
+        tz : string, pytz.timezone, dateutil.tz.tzfile or None
+            Time zone for time which Timestamp will have.
+        offset : str, DateOffset
+            Deprecated, use freq
+        """
         return cls(datetime.fromordinal(ordinal), freq=freq, tz=tz, offset=offset)
 
     @classmethod


### PR DESCRIPTION
- [x] follow-up for #13593
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`

added tests and fixed missed doc change.
