### PR TITLE
CLN: Removed the flavor parameter in DataFrame.to_sql

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -524,6 +524,7 @@ Deprecations
 - ``Categorical.reshape`` has been deprecated and will be removed in a subsequent release (:issue:`12882`)
 - ``Series.reshape`` has been deprecated and will be removed in a subsequent release (:issue:`12882`)
 
+- ``DataFrame.to_sql()`` has deprecated the ``flavor`` parameter, as it is superfluous when SQLAlchemy is not installed (:issue:`13611`)
 - ``compact_ints`` and ``use_unsigned`` have been deprecated in ``pd.read_csv()`` and will be removed in a future version (:issue:`13320`)
 - ``buffer_lines`` has been deprecated in ``pd.read_csv()`` and will be removed in a future version (:issue:`13360`)
 - ``as_recarray`` has been deprecated in ``pd.read_csv()`` and will be removed in a future version (:issue:`13373`)
@@ -541,6 +542,7 @@ Removal of prior version deprecations/changes
 - ``DataFrame.to_dict()`` has dropped the ``outtype`` parameter in favor of ``orient`` (:issue:`13627`, :issue:`8486`)
 - ``pd.Categorical`` has dropped setting of the ``ordered`` attribute directly in favor of the ``set_ordered`` method (:issue:`13671`)
 - ``pd.Categorical`` has dropped the ``levels`` attribute in favour of ``categories`` (:issue:`8376`)
+- ``DataFrame.to_sql()`` has dropped the ``mysql`` option for the ``flavor`` parameter (:issue:`13611`)
 
 - Removal of the legacy time rules (offset aliases), deprecated since 0.17.0 (this has been alias since 0.8.0) (:issue:`13590`)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1144,7 +1144,7 @@ class NDFrame(PandasObject):
         return packers.to_msgpack(path_or_buf, self, encoding=encoding,
                                   **kwargs)
 
-    def to_sql(self, name, con, flavor='sqlite', schema=None, if_exists='fail',
+    def to_sql(self, name, con, flavor=None, schema=None, if_exists='fail',
                index=True, index_label=None, chunksize=None, dtype=None):
         """
         Write records stored in a DataFrame to a SQL database.
@@ -1155,12 +1155,11 @@ class NDFrame(PandasObject):
             Name of SQL table
         con : SQLAlchemy engine or DBAPI2 connection (legacy mode)
             Using SQLAlchemy makes it possible to use any DB supported by that
-            library.
-            If a DBAPI2 object, only sqlite3 is supported.
-        flavor : {'sqlite', 'mysql'}, default 'sqlite'
-            The flavor of SQL to use. Ignored when using SQLAlchemy engine.
-            'mysql' is deprecated and will be removed in future versions, but
-            it will be further supported through SQLAlchemy engines.
+            library. If a DBAPI2 object, only sqlite3 is supported.
+        flavor : 'sqlite', default None
+            DEPRECATED: this parameter will be removed in a future version,
+            as 'sqlite' is the only supported option if SQLAlchemy is not
+            installed.
         schema : string, default None
             Specify the schema (if database flavor supports this). If None, use
             default schema.

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -41,6 +41,24 @@ class DatabaseError(IOError):
 _SQLALCHEMY_INSTALLED = None
 
 
+def _validate_flavor_parameter(flavor):
+    """
+    Checks whether a database 'flavor' was specified.
+    If not None, produces FutureWarning if 'sqlite' and
+    raises a ValueError if anything else.
+    """
+    if flavor is not None:
+        if flavor == 'sqlite':
+            warnings.warn("the 'flavor' parameter is deprecated "
+                          "and will be removed in a future version, "
+                          "as 'sqlite' is the only supported option "
+                          "when SQLAlchemy is not installed.",
+                          FutureWarning, stacklevel=2)
+        else:
+            raise ValueError("database flavor {flavor} is not "
+                             "supported".format(flavor=flavor))
+
+
 def _is_sqlalchemy_connectable(con):
     global _SQLALCHEMY_INSTALLED
     if _SQLALCHEMY_INSTALLED is None:
@@ -517,7 +535,7 @@ def read_sql(sql, con, index_col=None, coerce_float=True, params=None,
             chunksize=chunksize)
 
 
-def to_sql(frame, name, con, flavor='sqlite', schema=None, if_exists='fail',
+def to_sql(frame, name, con, flavor=None, schema=None, if_exists='fail',
            index=True, index_label=None, chunksize=None, dtype=None):
     """
     Write records stored in a DataFrame to a SQL database.
@@ -532,10 +550,8 @@ def to_sql(frame, name, con, flavor='sqlite', schema=None, if_exists='fail',
         Using SQLAlchemy makes it possible to use any DB supported by that
         library.
         If a DBAPI2 object, only sqlite3 is supported.
-    flavor : {'sqlite', 'mysql'}, default 'sqlite'
-        The flavor of SQL to use. Ignored when using SQLAlchemy connectable.
-        'mysql' is deprecated and will be removed in future versions, but it
-        will be further supported through SQLAlchemy connectables.
+    flavor : 'sqlite', default None
+        DEPRECATED: this parameter will be removed in a future version
     schema : string, default None
         Name of SQL schema in database to write to (if database flavor
         supports this). If None, use default schema (default).
@@ -573,7 +589,7 @@ def to_sql(frame, name, con, flavor='sqlite', schema=None, if_exists='fail',
                       chunksize=chunksize, dtype=dtype)
 
 
-def has_table(table_name, con, flavor='sqlite', schema=None):
+def has_table(table_name, con, flavor=None, schema=None):
     """
     Check if DataBase has named table.
 
@@ -585,10 +601,8 @@ def has_table(table_name, con, flavor='sqlite', schema=None):
         Using SQLAlchemy makes it possible to use any DB supported by that
         library.
         If a DBAPI2 object, only sqlite3 is supported.
-    flavor: {'sqlite', 'mysql'}, default 'sqlite'
-        The flavor of SQL to use. Ignored when using SQLAlchemy connectable.
-        'mysql' is deprecated and will be removed in future versions, but it
-        will be further supported through SQLAlchemy connectables.
+    flavor : 'sqlite', default None
+        DEPRECATED: this parameter will be removed in a future version
     schema : string, default None
         Name of SQL schema in database to write to (if database flavor supports
         this). If None, use default schema (default).
@@ -601,12 +615,6 @@ def has_table(table_name, con, flavor='sqlite', schema=None):
     return pandas_sql.has_table(table_name)
 
 table_exists = has_table
-
-
-_MYSQL_WARNING = ("The 'mysql' flavor with DBAPI connection is deprecated "
-                  "and will be removed in future versions. "
-                  "MySQL will be further supported with SQLAlchemy "
-                  "connectables.")
 
 
 def _engine_builder(con):
@@ -632,15 +640,15 @@ def pandasSQL_builder(con, flavor=None, schema=None, meta=None,
     Convenience function to return the correct PandasSQL subclass based on the
     provided parameters
     """
+    _validate_flavor_parameter(flavor)
+
     # When support for DBAPI connections is removed,
     # is_cursor should not be necessary.
     con = _engine_builder(con)
     if _is_sqlalchemy_connectable(con):
         return SQLDatabase(con, schema=schema, meta=meta)
     else:
-        if flavor == 'mysql':
-            warnings.warn(_MYSQL_WARNING, FutureWarning, stacklevel=3)
-        return SQLiteDatabase(con, flavor, is_cursor=is_cursor)
+        return SQLiteDatabase(con, is_cursor=is_cursor)
 
 
 class SQLTable(PandasObject):
@@ -1035,11 +1043,11 @@ class PandasSQL(PandasObject):
 
     def read_sql(self, *args, **kwargs):
         raise ValueError("PandasSQL must be created with an SQLAlchemy "
-                         "connectable  or connection+sql flavor")
+                         "connectable or sqlite connection")
 
     def to_sql(self, *args, **kwargs):
         raise ValueError("PandasSQL must be created with an SQLAlchemy "
-                         "connectable or connection+sql flavor")
+                         "connectable or sqlite connection")
 
 
 class SQLDatabase(PandasSQL):
@@ -1308,38 +1316,16 @@ class SQLDatabase(PandasSQL):
 
 
 # ---- SQL without SQLAlchemy ---
-# Flavour specific sql strings and handler class for access to DBs without
-# SQLAlchemy installed
-# SQL type convertions for each DB
+# sqlite-specific sql strings and handler class
+# dictionary used for readability purposes
 _SQL_TYPES = {
-    'string': {
-        'mysql': 'VARCHAR (63)',
-        'sqlite': 'TEXT',
-    },
-    'floating': {
-        'mysql': 'DOUBLE',
-        'sqlite': 'REAL',
-    },
-    'integer': {
-        'mysql': 'BIGINT',
-        'sqlite': 'INTEGER',
-    },
-    'datetime': {
-        'mysql': 'DATETIME',
-        'sqlite': 'TIMESTAMP',
-    },
-    'date': {
-        'mysql': 'DATE',
-        'sqlite': 'DATE',
-    },
-    'time': {
-        'mysql': 'TIME',
-        'sqlite': 'TIME',
-    },
-    'boolean': {
-        'mysql': 'BOOLEAN',
-        'sqlite': 'INTEGER',
-    }
+    'string': 'TEXT',
+    'floating': 'REAL',
+    'integer': 'INTEGER',
+    'datetime': 'TIMESTAMP',
+    'date': 'DATE',
+    'time': 'TIME',
+    'boolean': 'INTEGER',
 }
 
 
@@ -1349,22 +1335,6 @@ def _get_unicode_name(name):
     except UnicodeError:
         raise ValueError("Cannot convert identifier to UTF-8: '%s'" % name)
     return uname
-
-
-def _get_valid_mysql_name(name):
-    # Filter for unquoted identifiers
-    # See http://dev.mysql.com/doc/refman/5.0/en/identifiers.html
-    uname = _get_unicode_name(name)
-    if not len(uname):
-        raise ValueError("Empty table or column name specified")
-
-    basere = r'[0-9,a-z,A-Z$_]'
-    for c in uname:
-        if not re.match(basere, c):
-            if not (0x80 < ord(c) < 0xFFFF):
-                raise ValueError("Invalid MySQL identifier '%s'" % uname)
-
-    return '`' + uname + '`'
 
 
 def _get_valid_sqlite_name(name):
@@ -1383,19 +1353,6 @@ def _get_valid_sqlite_name(name):
     if nul_index >= 0:
         raise ValueError('SQLite identifier cannot contain NULs')
     return '"' + uname.replace('"', '""') + '"'
-
-
-# SQL enquote and wildcard symbols
-_SQL_WILDCARD = {
-    'mysql': '%s',
-    'sqlite': '?'
-}
-
-# Validate and return escaped identifier
-_SQL_GET_IDENTIFIER = {
-    'mysql': _get_valid_mysql_name,
-    'sqlite': _get_valid_sqlite_name,
-}
 
 
 _SAFE_NAMES_WARNING = ("The spaces in these column names will not be changed. "
@@ -1428,9 +1385,8 @@ class SQLiteTable(SQLTable):
 
     def insert_statement(self):
         names = list(map(text_type, self.frame.columns))
-        flv = self.pd_sql.flavor
-        wld = _SQL_WILDCARD[flv]  # wildcard char
-        escape = _SQL_GET_IDENTIFIER[flv]
+        wld = '?'  # wildcard char
+        escape = _get_valid_sqlite_name
 
         if self.index is not None:
             [names.insert(0, idx) for idx in self.index[::-1]]
@@ -1460,8 +1416,7 @@ class SQLiteTable(SQLTable):
         if any(map(pat.search, column_names)):
             warnings.warn(_SAFE_NAMES_WARNING, stacklevel=6)
 
-        flv = self.pd_sql.flavor
-        escape = _SQL_GET_IDENTIFIER[flv]
+        escape = _get_valid_sqlite_name
 
         create_tbl_stmts = [escape(cname) + ' ' + ctype
                             for cname, ctype, _ in column_names_and_types]
@@ -1514,7 +1469,7 @@ class SQLiteTable(SQLTable):
         if col_type not in _SQL_TYPES:
             col_type = "string"
 
-        return _SQL_TYPES[col_type][self.pd_sql.flavor]
+        return _SQL_TYPES[col_type]
 
 
 class SQLiteDatabase(PandasSQL):
@@ -1522,25 +1477,17 @@ class SQLiteDatabase(PandasSQL):
     Version of SQLDatabase to support sqlite connections (fallback without
     sqlalchemy). This should only be used internally.
 
-    For now still supports `flavor` argument to deal with 'mysql' database
-    for backwards compatibility, but this will be removed in future versions.
-
     Parameters
     ----------
     con : sqlite connection object
 
     """
 
-    def __init__(self, con, flavor, is_cursor=False):
+    def __init__(self, con, flavor=None, is_cursor=False):
+        _validate_flavor_parameter(flavor)
+
         self.is_cursor = is_cursor
         self.con = con
-        if flavor is None:
-            flavor = 'sqlite'
-        if flavor not in ['sqlite', 'mysql']:
-            raise NotImplementedError("flavors other than SQLite and MySQL "
-                                      "are not supported")
-        else:
-            self.flavor = flavor
 
     @contextmanager
     def run_transaction(self):
@@ -1665,15 +1612,12 @@ class SQLiteDatabase(PandasSQL):
 
     def has_table(self, name, schema=None):
         # TODO(wesm): unused?
-        # escape = _SQL_GET_IDENTIFIER[self.flavor]
+        # escape = _get_valid_sqlite_name
         # esc_name = escape(name)
 
-        wld = _SQL_WILDCARD[self.flavor]
-        flavor_map = {
-            'sqlite': ("SELECT name FROM sqlite_master "
-                       "WHERE type='table' AND name=%s;") % wld,
-            'mysql': "SHOW TABLES LIKE %s" % wld}
-        query = flavor_map.get(self.flavor)
+        wld = '?'
+        query = ("SELECT name FROM sqlite_master "
+                 "WHERE type='table' AND name=%s;") % wld
 
         return len(self.execute(query, [name, ]).fetchall()) > 0
 
@@ -1681,8 +1625,7 @@ class SQLiteDatabase(PandasSQL):
         return None  # not supported in fallback mode
 
     def drop_table(self, name, schema=None):
-        escape = _SQL_GET_IDENTIFIER[self.flavor]
-        drop_sql = "DROP TABLE %s" % escape(name)
+        drop_sql = "DROP TABLE %s" % _get_valid_sqlite_name(name)
         self.execute(drop_sql)
 
     def _create_sql_schema(self, frame, table_name, keys=None, dtype=None):
@@ -1691,7 +1634,7 @@ class SQLiteDatabase(PandasSQL):
         return str(table.sql_schema())
 
 
-def get_schema(frame, name, flavor='sqlite', keys=None, con=None, dtype=None):
+def get_schema(frame, name, flavor=None, keys=None, con=None, dtype=None):
     """
     Get the SQL db table schema for the given frame.
 
@@ -1700,16 +1643,14 @@ def get_schema(frame, name, flavor='sqlite', keys=None, con=None, dtype=None):
     frame : DataFrame
     name : string
         name of SQL table
-    flavor : {'sqlite', 'mysql'}, default 'sqlite'
-        The flavor of SQL to use. Ignored when using SQLAlchemy connectable.
-        'mysql' is deprecated and will be removed in future versions, but it
-        will be further supported through SQLAlchemy engines.
     keys : string or sequence, default: None
         columns to use a primary key
     con: an open SQL database connection object or a SQLAlchemy connectable
         Using SQLAlchemy makes it possible to use any DB supported by that
         library, default: None
         If a DBAPI2 object, only sqlite3 is supported.
+    flavor : 'sqlite', default None
+        DEPRECATED: this parameter will be removed in a future version
     dtype : dict of column name to SQL type, default None
         Optional specifying the datatype for columns. The SQL type should
         be a SQLAlchemy type, or a string for sqlite3 fallback connection.

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -13,7 +13,7 @@ The SQL tests are broken down in different classes:
       common methods, `_TestSQLAlchemyConn` tests the API with a SQLAlchemy
       Connection object. The different tested flavors (sqlite3, MySQL,
       PostgreSQL) derive from the base class
-    - Tests for the fallback mode (`TestSQLiteFallback` and `TestMySQLLegacy`)
+    - Tests for the fallback mode (`TestSQLiteFallback`)
 
 """
 
@@ -526,30 +526,29 @@ class _TestSQLApi(PandasSQLTest):
         self._check_iris_loaded_frame(iris_frame)
 
     def test_to_sql(self):
-        sql.to_sql(self.test_frame1, 'test_frame1', self.conn, flavor='sqlite')
+        sql.to_sql(self.test_frame1, 'test_frame1', self.conn)
         self.assertTrue(
-            sql.has_table('test_frame1', self.conn, flavor='sqlite'),
+            sql.has_table('test_frame1', self.conn),
             'Table not written to DB')
 
     def test_to_sql_fail(self):
         sql.to_sql(self.test_frame1, 'test_frame2',
-                   self.conn, flavor='sqlite', if_exists='fail')
+                   self.conn, if_exists='fail')
         self.assertTrue(
-            sql.has_table('test_frame2', self.conn, flavor='sqlite'),
+            sql.has_table('test_frame2', self.conn),
             'Table not written to DB')
 
         self.assertRaises(ValueError, sql.to_sql, self.test_frame1,
-                          'test_frame2', self.conn, flavor='sqlite',
-                          if_exists='fail')
+                          'test_frame2', self.conn, if_exists='fail')
 
     def test_to_sql_replace(self):
         sql.to_sql(self.test_frame1, 'test_frame3',
-                   self.conn, flavor='sqlite', if_exists='fail')
+                   self.conn, if_exists='fail')
         # Add to table again
         sql.to_sql(self.test_frame1, 'test_frame3',
-                   self.conn, flavor='sqlite', if_exists='replace')
+                   self.conn, if_exists='replace')
         self.assertTrue(
-            sql.has_table('test_frame3', self.conn, flavor='sqlite'),
+            sql.has_table('test_frame3', self.conn),
             'Table not written to DB')
 
         num_entries = len(self.test_frame1)
@@ -560,13 +559,13 @@ class _TestSQLApi(PandasSQLTest):
 
     def test_to_sql_append(self):
         sql.to_sql(self.test_frame1, 'test_frame4',
-                   self.conn, flavor='sqlite', if_exists='fail')
+                   self.conn, if_exists='fail')
 
         # Add to table again
         sql.to_sql(self.test_frame1, 'test_frame4',
-                   self.conn, flavor='sqlite', if_exists='append')
+                   self.conn, if_exists='append')
         self.assertTrue(
-            sql.has_table('test_frame4', self.conn, flavor='sqlite'),
+            sql.has_table('test_frame4', self.conn),
             'Table not written to DB')
 
         num_entries = 2 * len(self.test_frame1)
@@ -576,26 +575,25 @@ class _TestSQLApi(PandasSQLTest):
             num_rows, num_entries, "not the same number of rows as entries")
 
     def test_to_sql_type_mapping(self):
-        sql.to_sql(self.test_frame3, 'test_frame5',
-                   self.conn, flavor='sqlite', index=False)
+        sql.to_sql(self.test_frame3, 'test_frame5', self.conn, index=False)
         result = sql.read_sql("SELECT * FROM test_frame5", self.conn)
 
         tm.assert_frame_equal(self.test_frame3, result)
 
     def test_to_sql_series(self):
         s = Series(np.arange(5, dtype='int64'), name='series')
-        sql.to_sql(s, "test_series", self.conn, flavor='sqlite', index=False)
+        sql.to_sql(s, "test_series", self.conn, index=False)
         s2 = sql.read_sql_query("SELECT * FROM test_series", self.conn)
         tm.assert_frame_equal(s.to_frame(), s2)
 
     def test_to_sql_panel(self):
         panel = tm.makePanel()
         self.assertRaises(NotImplementedError, sql.to_sql, panel,
-                          'test_panel', self.conn, flavor='sqlite')
+                          'test_panel', self.conn)
 
     def test_roundtrip(self):
         sql.to_sql(self.test_frame1, 'test_frame_roundtrip',
-                   con=self.conn, flavor='sqlite')
+                   con=self.conn)
         result = sql.read_sql_query(
             'SELECT * FROM test_frame_roundtrip',
             con=self.conn)
@@ -609,7 +607,7 @@ class _TestSQLApi(PandasSQLTest):
 
     def test_roundtrip_chunksize(self):
         sql.to_sql(self.test_frame1, 'test_frame_roundtrip', con=self.conn,
-                   index=False, flavor='sqlite', chunksize=2)
+                   index=False, chunksize=2)
         result = sql.read_sql_query(
             'SELECT * FROM test_frame_roundtrip',
             con=self.conn)
@@ -764,27 +762,25 @@ class _TestSQLApi(PandasSQLTest):
                    if_exists='replace')
 
     def test_get_schema(self):
-        create_sql = sql.get_schema(self.test_frame1, 'test', 'sqlite',
-                                    con=self.conn)
+        create_sql = sql.get_schema(self.test_frame1, 'test', con=self.conn)
         self.assertTrue('CREATE' in create_sql)
 
     def test_get_schema_dtypes(self):
         float_frame = DataFrame({'a': [1.1, 1.2], 'b': [2.1, 2.2]})
         dtype = sqlalchemy.Integer if self.mode == 'sqlalchemy' else 'INTEGER'
-        create_sql = sql.get_schema(float_frame, 'test', 'sqlite',
+        create_sql = sql.get_schema(float_frame, 'test',
                                     con=self.conn, dtype={'b': dtype})
         self.assertTrue('CREATE' in create_sql)
         self.assertTrue('INTEGER' in create_sql)
 
     def test_get_schema_keys(self):
         frame = DataFrame({'Col1': [1.1, 1.2], 'Col2': [2.1, 2.2]})
-        create_sql = sql.get_schema(frame, 'test', 'sqlite',
-                                    con=self.conn, keys='Col1')
+        create_sql = sql.get_schema(frame, 'test', con=self.conn, keys='Col1')
         constraint_sentence = 'CONSTRAINT test_pk PRIMARY KEY ("Col1")'
         self.assertTrue(constraint_sentence in create_sql)
 
         # multiple columns as key (GH10385)
-        create_sql = sql.get_schema(self.test_frame1, 'test', 'sqlite',
+        create_sql = sql.get_schema(self.test_frame1, 'test',
                                     con=self.conn, keys=['A', 'B'])
         constraint_sentence = 'CONSTRAINT test_pk PRIMARY KEY ("A", "B")'
         self.assertTrue(constraint_sentence in create_sql)
@@ -1044,8 +1040,8 @@ class TestSQLiteFallbackApi(SQLiteMixIn, _TestSQLApi):
         with tm.ensure_clean() as name:
 
             conn = self.connect(name)
-            sql.to_sql(self.test_frame3, "test_frame3_legacy", conn,
-                       flavor="sqlite", index=False)
+            sql.to_sql(self.test_frame3, "test_frame3_legacy",
+                       conn, index=False)
             conn.close()
 
             conn = self.connect(name)
@@ -1067,12 +1063,11 @@ class TestSQLiteFallbackApi(SQLiteMixIn, _TestSQLApi):
         df = DataFrame([[1, 2], [3, 4]], columns=['a', 'b '])  # has a space
         # warns on create table with spaces in names
         with tm.assert_produces_warning():
-            sql.to_sql(df, "test_frame3_legacy", self.conn,
-                       flavor="sqlite", index=False)
+            sql.to_sql(df, "test_frame3_legacy", self.conn, index=False)
 
     def test_get_schema2(self):
         # without providing a connection object (available for backwards comp)
-        create_sql = sql.get_schema(self.test_frame1, 'test', 'sqlite')
+        create_sql = sql.get_schema(self.test_frame1, 'test')
         self.assertTrue('CREATE' in create_sql)
 
     def test_tquery(self):
@@ -1098,7 +1093,7 @@ class TestSQLiteFallbackApi(SQLiteMixIn, _TestSQLApi):
         # Test Timestamp objects (no datetime64 because of timezone) (GH9085)
         df = DataFrame({'time': to_datetime(['201412120154', '201412110254'],
                                             utc=True)})
-        db = sql.SQLiteDatabase(self.conn, self.flavor)
+        db = sql.SQLiteDatabase(self.conn)
         table = sql.SQLiteTable("test_type", db, frame=df)
         schema = table.sql_schema()
         self.assertEqual(self._get_sqlite_column_type(schema, 'time'),
@@ -1908,15 +1903,11 @@ class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest):
 
     def setUp(self):
         self.conn = self.connect()
-        self.pandasSQL = sql.SQLiteDatabase(self.conn, 'sqlite')
+        self.pandasSQL = sql.SQLiteDatabase(self.conn)
 
         self._load_iris_data()
 
         self._load_test1_data()
-
-    def test_invalid_flavor(self):
-        self.assertRaises(
-            NotImplementedError, sql.SQLiteDatabase, self.conn, 'oracle')
 
     def test_read_sql(self):
         self._read_sql_iris()
@@ -1965,7 +1956,7 @@ class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest):
     def test_datetime_date(self):
         # test support for datetime.date
         df = DataFrame([date(2014, 1, 1), date(2014, 1, 2)], columns=["a"])
-        df.to_sql('test_date', self.conn, index=False, flavor=self.flavor)
+        df.to_sql('test_date', self.conn, index=False)
         res = read_sql_query('SELECT * FROM test_date', self.conn)
         if self.flavor == 'sqlite':
             # comes back as strings
@@ -1976,7 +1967,7 @@ class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest):
     def test_datetime_time(self):
         # test support for datetime.time, GH #8341
         df = DataFrame([time(9, 0, 0), time(9, 1, 30)], columns=["a"])
-        df.to_sql('test_time', self.conn, index=False, flavor=self.flavor)
+        df.to_sql('test_time', self.conn, index=False)
         res = read_sql_query('SELECT * FROM test_time', self.conn)
         if self.flavor == 'sqlite':
             # comes back as strings
@@ -2051,128 +2042,20 @@ class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest):
         df = DataFrame([[1, 2], [3, 4]], columns=['a', 'b'])
 
         # Raise error on blank
-        self.assertRaises(ValueError, df.to_sql, "", self.conn,
-                          flavor=self.flavor)
+        self.assertRaises(ValueError, df.to_sql, "", self.conn)
 
         for ndx, weird_name in enumerate(
                 ['test_weird_name]', 'test_weird_name[',
                  'test_weird_name`', 'test_weird_name"', 'test_weird_name\'',
                  '_b.test_weird_name_01-30', '"_b.test_weird_name_01-30"',
                  '99beginswithnumber', '12345', u'\xe9']):
-            df.to_sql(weird_name, self.conn, flavor=self.flavor)
+            df.to_sql(weird_name, self.conn)
             sql.table_exists(weird_name, self.conn)
 
             df2 = DataFrame([[1, 2], [3, 4]], columns=['a', weird_name])
             c_tbl = 'test_weird_col_name%d' % ndx
-            df2.to_sql(c_tbl, self.conn, flavor=self.flavor)
+            df2.to_sql(c_tbl, self.conn)
             sql.table_exists(c_tbl, self.conn)
-
-
-class TestMySQLLegacy(MySQLMixIn, TestSQLiteFallback):
-    """
-    Test the legacy mode against a MySQL database.
-
-    """
-    flavor = 'mysql'
-
-    @classmethod
-    def setUpClass(cls):
-        cls.setup_driver()
-
-        # test connection
-        try:
-            cls.connect()
-        except cls.driver.err.OperationalError:
-            raise nose.SkipTest(
-                "{0} - can't connect to MySQL server".format(cls))
-
-    @classmethod
-    def setup_driver(cls):
-        try:
-            import pymysql
-            cls.driver = pymysql
-        except ImportError:
-            raise nose.SkipTest('pymysql not installed')
-
-    @classmethod
-    def connect(cls):
-        return cls.driver.connect(host='127.0.0.1', user='root', passwd='',
-                                  db='pandas_nosetest')
-
-    def _count_rows(self, table_name):
-        cur = self._get_exec()
-        cur.execute(
-            "SELECT count(*) AS count_1 FROM %s" % table_name)
-        rows = cur.fetchall()
-        return rows[0][0]
-
-    def setUp(self):
-        try:
-            self.conn = self.connect()
-        except self.driver.err.OperationalError:
-            raise nose.SkipTest("Can't connect to MySQL server")
-
-        self.pandasSQL = sql.SQLiteDatabase(self.conn, 'mysql')
-
-        self._load_iris_data()
-        self._load_test1_data()
-
-    def test_a_deprecation(self):
-        with tm.assert_produces_warning(FutureWarning):
-            sql.to_sql(self.test_frame1, 'test_frame1', self.conn,
-                       flavor='mysql')
-        self.assertTrue(
-            sql.has_table('test_frame1', self.conn, flavor='mysql'),
-            'Table not written to DB')
-
-    def _get_index_columns(self, tbl_name):
-        ixs = sql.read_sql_query(
-            "SHOW INDEX IN %s" % tbl_name, self.conn)
-        ix_cols = {}
-        for ix_name, ix_col in zip(ixs.Key_name, ixs.Column_name):
-            if ix_name not in ix_cols:
-                ix_cols[ix_name] = []
-            ix_cols[ix_name].append(ix_col)
-        return list(ix_cols.values())
-
-    # TODO: cruft?
-    # def test_to_sql_save_index(self):
-    #     self._to_sql_save_index()
-
-    #     for ix_name, ix_col in zip(ixs.Key_name, ixs.Column_name):
-    #         if ix_name not in ix_cols:
-    #             ix_cols[ix_name] = []
-    #         ix_cols[ix_name].append(ix_col)
-    #     return ix_cols.values()
-
-    def test_to_sql_save_index(self):
-        self._to_sql_save_index()
-
-    def test_illegal_names(self):
-        df = DataFrame([[1, 2], [3, 4]], columns=['a', 'b'])
-
-        # These tables and columns should be ok
-        for ndx, ok_name in enumerate(['99beginswithnumber', '12345']):
-            df.to_sql(ok_name, self.conn, flavor=self.flavor, index=False,
-                      if_exists='replace')
-            df2 = DataFrame([[1, 2], [3, 4]], columns=['a', ok_name])
-
-            df2.to_sql('test_ok_col_name', self.conn,
-                       flavor=self.flavor, index=False,
-                       if_exists='replace')
-
-        # For MySQL, these should raise ValueError
-        for ndx, illegal_name in enumerate(
-                ['test_illegal_name]', 'test_illegal_name[',
-                 'test_illegal_name`', 'test_illegal_name"',
-                 'test_illegal_name\'', '']):
-            self.assertRaises(ValueError, df.to_sql, illegal_name, self.conn,
-                              flavor=self.flavor, index=False)
-
-            df2 = DataFrame([[1, 2], [3, 4]], columns=['a', illegal_name])
-            self.assertRaises(ValueError, df2.to_sql,
-                              'test_illegal_col_name%d' % ndx,
-                              self.conn, flavor=self.flavor, index=False)
 
 
 # -----------------------------------------------------------------------------
@@ -2228,7 +2111,7 @@ class TestXSQLite(SQLiteMixIn, tm.TestCase):
 
         frame = tm.makeTimeDataFrame()
         frame.ix[0, 0] = np.nan
-        create_sql = sql.get_schema(frame, 'test', 'sqlite')
+        create_sql = sql.get_schema(frame, 'test')
         cur = self.conn.cursor()
         cur.execute(create_sql)
 
@@ -2247,7 +2130,7 @@ class TestXSQLite(SQLiteMixIn, tm.TestCase):
 
     def test_execute(self):
         frame = tm.makeTimeDataFrame()
-        create_sql = sql.get_schema(frame, 'test', 'sqlite')
+        create_sql = sql.get_schema(frame, 'test')
         cur = self.conn.cursor()
         cur.execute(create_sql)
         ins = "INSERT INTO test VALUES (?, ?, ?, ?)"
@@ -2262,7 +2145,7 @@ class TestXSQLite(SQLiteMixIn, tm.TestCase):
 
     def test_schema(self):
         frame = tm.makeTimeDataFrame()
-        create_sql = sql.get_schema(frame, 'test', 'sqlite')
+        create_sql = sql.get_schema(frame, 'test')
         lines = create_sql.splitlines()
         for l in lines:
             tokens = l.split(' ')
@@ -2270,7 +2153,7 @@ class TestXSQLite(SQLiteMixIn, tm.TestCase):
                 self.assertTrue(tokens[1] == 'DATETIME')
 
         frame = tm.makeTimeDataFrame()
-        create_sql = sql.get_schema(frame, 'test', 'sqlite', keys=['A', 'B'],)
+        create_sql = sql.get_schema(frame, 'test', keys=['A', 'B'])
         lines = create_sql.splitlines()
         self.assertTrue('PRIMARY KEY ("A", "B")' in create_sql)
         cur = self.conn.cursor()
@@ -2425,44 +2308,68 @@ class TestXSQLite(SQLiteMixIn, tm.TestCase):
                           frame=df_if_exists_1,
                           con=self.conn,
                           name=table_name,
-                          flavor='sqlite',
                           if_exists='notvalidvalue')
         clean_up(table_name)
 
         # test if_exists='fail'
-        sql.to_sql(frame=df_if_exists_1, con=self.conn, name=table_name,
-                   flavor='sqlite', if_exists='fail')
+        sql.to_sql(frame=df_if_exists_1, con=self.conn,
+                   name=table_name, if_exists='fail')
         self.assertRaises(ValueError,
                           sql.to_sql,
                           frame=df_if_exists_1,
                           con=self.conn,
                           name=table_name,
-                          flavor='sqlite',
                           if_exists='fail')
 
         # test if_exists='replace'
         sql.to_sql(frame=df_if_exists_1, con=self.conn, name=table_name,
-                   flavor='sqlite', if_exists='replace', index=False)
+                   if_exists='replace', index=False)
         self.assertEqual(sql.tquery(sql_select, con=self.conn),
                          [(1, 'A'), (2, 'B')])
         sql.to_sql(frame=df_if_exists_2, con=self.conn, name=table_name,
-                   flavor='sqlite', if_exists='replace', index=False)
+                   if_exists='replace', index=False)
         self.assertEqual(sql.tquery(sql_select, con=self.conn),
                          [(3, 'C'), (4, 'D'), (5, 'E')])
         clean_up(table_name)
 
         # test if_exists='append'
         sql.to_sql(frame=df_if_exists_1, con=self.conn, name=table_name,
-                   flavor='sqlite', if_exists='fail', index=False)
+                   if_exists='fail', index=False)
         self.assertEqual(sql.tquery(sql_select, con=self.conn),
                          [(1, 'A'), (2, 'B')])
         sql.to_sql(frame=df_if_exists_2, con=self.conn, name=table_name,
-                   flavor='sqlite', if_exists='append', index=False)
+                   if_exists='append', index=False)
         self.assertEqual(sql.tquery(sql_select, con=self.conn),
                          [(1, 'A'), (2, 'B'), (3, 'C'), (4, 'D'), (5, 'E')])
         clean_up(table_name)
 
 
+class TestSQLFlavorDeprecation(tm.TestCase):
+    """
+    gh-13611: test that the 'flavor' parameter
+    is appropriately deprecated by checking the
+    functions that directly raise the warning
+    """
+
+    con = 1234  # don't need real connection for this
+    funcs = ['SQLiteDatabase', 'pandasSQL_builder']
+
+    def test_unsupported_flavor(self):
+        msg = 'is not supported'
+
+        for func in self.funcs:
+            tm.assertRaisesRegexp(ValueError, msg, getattr(sql, func),
+                                  self.con, flavor='mysql')
+
+    def test_deprecated_flavor(self):
+        for func in self.funcs:
+            with tm.assert_produces_warning(FutureWarning,
+                                            check_stacklevel=False):
+                getattr(sql, func)(self.con, flavor='sqlite')
+
+
+@unittest.skip("gh-13611: there is no support for MySQL "
+               "if SQLAlchemy is not installed")
 class TestXMySQL(MySQLMixIn, tm.TestCase):
 
     @classmethod
@@ -2531,7 +2438,7 @@ class TestXMySQL(MySQLMixIn, tm.TestCase):
         frame = tm.makeTimeDataFrame()
         frame.ix[0, 0] = np.nan
         drop_sql = "DROP TABLE IF EXISTS test"
-        create_sql = sql.get_schema(frame, 'test', 'mysql')
+        create_sql = sql.get_schema(frame, 'test')
         cur = self.conn.cursor()
         cur.execute(drop_sql)
         cur.execute(create_sql)
@@ -2553,7 +2460,7 @@ class TestXMySQL(MySQLMixIn, tm.TestCase):
         drop_sql = "DROP TABLE IF EXISTS test"
         cur = self.conn.cursor()
         cur.execute(drop_sql)
-        sql.to_sql(frame, name='test', con=self.conn, flavor='mysql')
+        sql.to_sql(frame, name='test', con=self.conn)
         query = "select * from test"
         chunksize = 5
         chunk_gen = pd.read_sql_query(sql=query, con=self.conn,
@@ -2565,7 +2472,7 @@ class TestXMySQL(MySQLMixIn, tm.TestCase):
         _skip_if_no_pymysql()
         frame = tm.makeTimeDataFrame()
         drop_sql = "DROP TABLE IF EXISTS test"
-        create_sql = sql.get_schema(frame, 'test', 'mysql')
+        create_sql = sql.get_schema(frame, 'test')
         cur = self.conn.cursor()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", "Unknown table.*")
@@ -2584,7 +2491,7 @@ class TestXMySQL(MySQLMixIn, tm.TestCase):
     def test_schema(self):
         _skip_if_no_pymysql()
         frame = tm.makeTimeDataFrame()
-        create_sql = sql.get_schema(frame, 'test', 'mysql')
+        create_sql = sql.get_schema(frame, 'test')
         lines = create_sql.splitlines()
         for l in lines:
             tokens = l.split(' ')
@@ -2593,7 +2500,7 @@ class TestXMySQL(MySQLMixIn, tm.TestCase):
 
         frame = tm.makeTimeDataFrame()
         drop_sql = "DROP TABLE IF EXISTS test"
-        create_sql = sql.get_schema(frame, 'test', 'mysql', keys=['A', 'B'],)
+        create_sql = sql.get_schema(frame, 'test', keys=['A', 'B'])
         lines = create_sql.splitlines()
         self.assertTrue('PRIMARY KEY (`A`, `B`)' in create_sql)
         cur = self.conn.cursor()
@@ -2666,8 +2573,7 @@ class TestXMySQL(MySQLMixIn, tm.TestCase):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", "Unknown table.*")
             cur.execute(drop_sql)
-        sql.to_sql(frame, name='test_table',
-                   con=self.conn, flavor='mysql', index=False)
+        sql.to_sql(frame, name='test_table', con=self.conn, index=False)
         result = sql.read_sql("select * from test_table", self.conn)
 
         # HACK! Change this once indexes are handled properly.
@@ -2687,7 +2593,7 @@ class TestXMySQL(MySQLMixIn, tm.TestCase):
             warnings.filterwarnings("ignore", "Unknown table.*")
             cur.execute(drop_sql)
         sql.to_sql(frame2, name='test_table2',
-                   con=self.conn, flavor='mysql', index=False)
+                   con=self.conn, index=False)
         result = sql.read_sql("select * from test_table2", self.conn,
                               index_col='Idx')
         expected = frame.copy()
@@ -2707,7 +2613,7 @@ class TestXMySQL(MySQLMixIn, tm.TestCase):
         cur = self.conn.cursor()
         cur.execute(drop_sql)
         sql.to_sql(frame, name='test_table',
-                   con=self.conn, flavor='mysql', index=False)
+                   con=self.conn, index=False)
         result = sql.tquery("select A from test_table", self.conn)
         expected = Series(frame.A.values, frame.index)  # not to have name
         result = Series(result, frame.index)
@@ -2733,7 +2639,7 @@ class TestXMySQL(MySQLMixIn, tm.TestCase):
         cur = self.conn.cursor()
         cur.execute(drop_sql)
         sql.to_sql(frame, name='test_table',
-                   con=self.conn, flavor='mysql', index=False)
+                   con=self.conn, index=False)
         stmt = 'INSERT INTO test_table VALUES(2.314, -123.1, 1.234, 2.3)'
         self.assertEqual(sql.uquery(stmt, con=self.conn), 1)
 
@@ -2753,7 +2659,7 @@ class TestXMySQL(MySQLMixIn, tm.TestCase):
         _skip_if_no_pymysql()
         df = DataFrame({'From': np.ones(5)})
         sql.to_sql(df, con=self.conn, name='testkeywords',
-                   if_exists='replace', flavor='mysql', index=False)
+                   if_exists='replace', index=False)
 
     def test_if_exists(self):
         _skip_if_no_pymysql()
@@ -2776,39 +2682,37 @@ class TestXMySQL(MySQLMixIn, tm.TestCase):
                           frame=df_if_exists_1,
                           con=self.conn,
                           name=table_name,
-                          flavor='mysql',
                           if_exists='notvalidvalue')
         clean_up(table_name)
 
         # test if_exists='fail'
         sql.to_sql(frame=df_if_exists_1, con=self.conn, name=table_name,
-                   flavor='mysql', if_exists='fail', index=False)
+                   if_exists='fail', index=False)
         self.assertRaises(ValueError,
                           sql.to_sql,
                           frame=df_if_exists_1,
                           con=self.conn,
                           name=table_name,
-                          flavor='mysql',
                           if_exists='fail')
 
         # test if_exists='replace'
         sql.to_sql(frame=df_if_exists_1, con=self.conn, name=table_name,
-                   flavor='mysql', if_exists='replace', index=False)
+                   if_exists='replace', index=False)
         self.assertEqual(sql.tquery(sql_select, con=self.conn),
                          [(1, 'A'), (2, 'B')])
         sql.to_sql(frame=df_if_exists_2, con=self.conn, name=table_name,
-                   flavor='mysql', if_exists='replace', index=False)
+                   if_exists='replace', index=False)
         self.assertEqual(sql.tquery(sql_select, con=self.conn),
                          [(3, 'C'), (4, 'D'), (5, 'E')])
         clean_up(table_name)
 
         # test if_exists='append'
         sql.to_sql(frame=df_if_exists_1, con=self.conn, name=table_name,
-                   flavor='mysql', if_exists='fail', index=False)
+                   if_exists='fail', index=False)
         self.assertEqual(sql.tquery(sql_select, con=self.conn),
                          [(1, 'A'), (2, 'B')])
         sql.to_sql(frame=df_if_exists_2, con=self.conn, name=table_name,
-                   flavor='mysql', if_exists='append', index=False)
+                   if_exists='append', index=False)
         self.assertEqual(sql.tquery(sql_select, con=self.conn),
                          [(1, 'A'), (2, 'B'), (3, 'C'), (4, 'D'), (5, 'E')])
         clean_up(table_name)


### PR DESCRIPTION
Deprecated in `0.14.0`, so way, way overdue.
