### PR TITLE
CLN: Removed outtype in DataFrame.to_dict

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -443,6 +443,7 @@ Removal of prior version deprecations/changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - ``DataFrame.to_csv()`` has dropped the ``engine`` parameter, as was deprecated in 0.17.1 (:issue:`11274`, :issue:`13419`)
+- ``DataFrame.to_dict()`` has dropped the ``outtype`` parameter in favor of ``orient`` (:issue:`13627`, :issue:`8486`)
 
 
 .. _whatsnew_0190.performance:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -818,7 +818,6 @@ class DataFrame(NDFrame):
 
         return cls(data, index=index, columns=columns, dtype=dtype)
 
-    @deprecate_kwarg(old_arg_name='outtype', new_arg_name='orient')
     def to_dict(self, orient='dict'):
         """Convert DataFrame to dictionary.
 


### PR DESCRIPTION
Follows up from #8486 in `0.15.0` by removing `outtype` in `DataFrame.to_dict()`

Fortunately or unfortunately, no tests were written then to test the deprecation, so there was nothing to remove from the test suite this time around.
