### PR TITLE
ENH: Add support for writing variable labels to Stata files

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -250,6 +250,8 @@ Other enhancements
 - A function :func:`union_categorical` has been added for combining categoricals, see :ref:`Unioning Categoricals<categorical.union>` (:issue:`13361`)
 - ``Series`` has gained the properties ``.is_monotonic``, ``.is_monotonic_increasing``, ``.is_monotonic_decreasing``, similar to ``Index`` (:issue:`13336`)
 
+- ``to_stata`` and ```StataWriter`` can now write variable labels to Stata dta files using a dictionary to make column names to labels (:issue:`13535`, :issue:`13535`)
+
 .. _whatsnew_0190.api:
 
 API changes

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1467,7 +1467,7 @@ class DataFrame(NDFrame):
 
     def to_stata(self, fname, convert_dates=None, write_index=True,
                  encoding="latin-1", byteorder=None, time_stamp=None,
-                 data_label=None):
+                 data_label=None, variable_labels=None):
         """
         A class for writing Stata binary dta files from array-like objects
 
@@ -1480,11 +1480,24 @@ class DataFrame(NDFrame):
             format that you want to use for the dates. Options are
             'tc', 'td', 'tm', 'tw', 'th', 'tq', 'ty'. Column can be either a
             number or a name.
+        write_index : bool
+            Write the index to Stata dataset.
         encoding : str
             Default is latin-1. Note that Stata does not support unicode.
         byteorder : str
             Can be ">", "<", "little", or "big". The default is None which uses
             `sys.byteorder`
+        time_stamp : datetime
+            A date time to use when writing the file.  Can be None, in which
+            case the current time is used.
+        dataset_label : str
+            A label for the data set.  Should be 80 characters or smaller.
+
+        .. versionadded:: 0.19.0
+
+        variable_labels : dict
+            Dictionary containing columns as keys and variable labels as
+            values. Each label must be 80 characters or smaller.
 
         Examples
         --------
@@ -1500,7 +1513,8 @@ class DataFrame(NDFrame):
         writer = StataWriter(fname, self, convert_dates=convert_dates,
                              encoding=encoding, byteorder=byteorder,
                              time_stamp=time_stamp, data_label=data_label,
-                             write_index=write_index)
+                             write_index=write_index,
+                             variable_labels=variable_labels)
         writer.write_file()
 
     @Appender(fmt.docstring_to_string, indents=1)


### PR DESCRIPTION
- [x] closes #13536
- [x] closes #13535
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Add support for writing variable labels
Fix documentation for to_stata
Clean up function name to improve readability

closes #13536
closes #13535
