### PR TITLE
BF(TST): allow AttributeError being raised (in addition to TypeError) from matplotlib

### DIFF
--- a/pandas/tests/test_graphics.py
+++ b/pandas/tests/test_graphics.py
@@ -1330,7 +1330,8 @@ class TestDataFramePlots(TestPlotBase):
         self._check_axes_shape(axes, axes_num=4, layout=(4, 1))
 
         df = DataFrame({'x': [1, 2], 'y': [3, 4]})
-        with tm.assertRaises(TypeError):
+        # mpl >= 1.5.2 (or slightly below) throw AttributError
+        with tm.assertRaises((TypeError, AttributeError)):
             df.plot.line(blarg=True)
 
         df = DataFrame(np.random.rand(10, 3),


### PR DESCRIPTION
Closes #13570
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry: imho not worth it?

origin:  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=827938
