### PR TITLE
CLN: Fix compile time warnings

### DIFF
--- a/pandas/src/datetime/np_datetime.c
+++ b/pandas/src/datetime/np_datetime.c
@@ -576,7 +576,7 @@ void pandas_datetime_to_datetimestruct(npy_datetime val, PANDAS_DATETIMEUNIT fr,
 }
 
 PANDAS_DATETIMEUNIT get_datetime64_unit(PyObject *obj) {
-    return ((PyDatetimeScalarObject *) obj)->obmeta.base;
+    return (PANDAS_DATETIMEUNIT)((PyDatetimeScalarObject *) obj)->obmeta.base;
 }
 
 

--- a/pandas/src/ujson/python/objToJSON.c
+++ b/pandas/src/ujson/python/objToJSON.c
@@ -493,7 +493,7 @@ static void *NpyDateTimeScalarToJSON(JSOBJ _obj, JSONTypeContext *tc, void *outV
   PyDatetimeScalarObject *obj = (PyDatetimeScalarObject *) _obj;
   PRINTMARK();
 
-  pandas_datetime_to_datetimestruct(obj->obval, obj->obmeta.base, &dts);
+  pandas_datetime_to_datetimestruct(obj->obval, (PANDAS_DATETIMEUNIT)obj->obmeta.base, &dts);
   return PandasDateTimeStructToJSON(&dts, tc, outValue, _outLen);
 }
 


### PR DESCRIPTION
- [x] passes `git diff upstream/master | flake8 --diff`

This commit suppresses these warnings

warning: implicit conversion from enumeration type\
'NPY_DATETIMEUNIT' to different enumeration type\
'PANDAS_DATETIMEUNIT' [-Wenum-conversion]
