### PR TITLE
DOC/BLD: pin IPython version to 4.2.0 (#13639)

### DIFF
--- a/ci/requirements-2.7_DOC_BUILD.run
+++ b/ci/requirements-2.7_DOC_BUILD.run
@@ -1,4 +1,4 @@
-ipython=4
+ipython=4.2.0
 ipykernel
 sphinx
 nbconvert


### PR DESCRIPTION
xref #13639
