### PR TITLE
CLN: removed the 'diff' method for Index

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -543,6 +543,7 @@ Removal of prior version deprecations/changes
 - ``pd.Categorical`` has dropped setting of the ``ordered`` attribute directly in favor of the ``set_ordered`` method (:issue:`13671`)
 - ``pd.Categorical`` has dropped the ``levels`` attribute in favour of ``categories`` (:issue:`8376`)
 - ``DataFrame.to_sql()`` has dropped the ``mysql`` option for the ``flavor`` parameter (:issue:`13611`)
+- ``pd.Index`` has dropped the ``diff`` method in favour of ``difference`` (:issue:`13669`)
 
 - Removal of the legacy time rules (offset aliases), deprecated since 0.17.0 (this has been alias since 0.8.0) (:issue:`13590`)
 

--- a/pandas/indexes/base.py
+++ b/pandas/indexes/base.py
@@ -1965,8 +1965,6 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
 
         return this._shallow_copy(the_diff, name=result_name)
 
-    diff = deprecate('diff', difference)
-
     def symmetric_difference(self, other, result_name=None):
         """
         Compute the symmetric difference of two Index objects.


### PR DESCRIPTION
Deprecated all the way back in `0.15.0` <a href="https://github.com/pydata/pandas/pull/8227">here</a>.
