### PR TITLE
CLN: removed setter method of categorical's ordered attribute

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -506,6 +506,7 @@ Removal of prior version deprecations/changes
 
 - ``DataFrame.to_csv()`` has dropped the ``engine`` parameter, as was deprecated in 0.17.1 (:issue:`11274`, :issue:`13419`)
 - ``DataFrame.to_dict()`` has dropped the ``outtype`` parameter in favor of ``orient`` (:issue:`13627`, :issue:`8486`)
+- ``pd.Categorical`` has dropped setting of the ``ordered`` attribute directly in favor of the ``set_ordered`` method (:issue:`13671`)
 - ``pd.Categorical`` has dropped the ``levels`` attribute in favour of ``categories`` (:issue:`8376`)
 
 

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -571,12 +571,6 @@ class Categorical(PandasObject):
 
     _ordered = None
 
-    def _set_ordered(self, value):
-        """ Sets the ordered attribute to the boolean value """
-        warn("Setting 'ordered' directly is deprecated, use 'set_ordered'",
-             FutureWarning, stacklevel=2)
-        self.set_ordered(value, inplace=True)
-
     def set_ordered(self, value, inplace=False):
         """
         Sets the ordered attribute to the boolean value
@@ -624,7 +618,7 @@ class Categorical(PandasObject):
         """ Gets the ordered attribute """
         return self._ordered
 
-    ordered = property(fget=_get_ordered, fset=_set_ordered)
+    ordered = property(fget=_get_ordered)
 
     def set_categories(self, new_categories, ordered=None, rename=False,
                        inplace=False):

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -808,13 +808,12 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         cat2.set_ordered(False, inplace=True)
         self.assertFalse(cat2.ordered)
 
-        # deperecated in v0.16.0
-        with tm.assert_produces_warning(FutureWarning):
-            cat.ordered = False
-            self.assertFalse(cat.ordered)
-        with tm.assert_produces_warning(FutureWarning):
+        # removed in 0.19.0
+        msg = "can\'t set attribute"
+        with tm.assertRaisesRegexp(AttributeError, msg):
             cat.ordered = True
-            self.assertTrue(cat.ordered)
+        with tm.assertRaisesRegexp(AttributeError, msg):
+            cat.ordered = False
 
     def test_set_categories(self):
         cat = Categorical(["a", "b", "c", "a"], ordered=True)


### PR DESCRIPTION
Deprecated back in `0.16.0` <a href="https://github.com/pydata/pandas/pull/9611">here</a>.
