### PR TITLE
DOC: resample warnings

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -637,7 +637,7 @@ Bug Fixes
 - Bug in ``pd.to_datetime()`` when passing invalid datatypes (e.g. bool); will now respect the ``errors`` keyword (:issue:`13176`)
 - Bug in ``pd.to_datetime()`` which overflowed on ``int8``, and ``int16`` dtypes (:issue:`13451`)
 - Bug in extension dtype creation where the created types were not is/identical (:issue:`13285`)
-
+- Bug in ``.resample(..)`` where incorrect warnings were triggered by IPython introspection (:issue:`13618`)
 - Bug in ``NaT`` - ``Period`` raises ``AttributeError`` (:issue:`13071`)
 - Bug in ``Series`` comparison may output incorrect result if rhs contains ``NaT`` (:issue:`9005`)
 - Bug in ``Series`` and ``Index`` comparison may output incorrect result if it contains ``NaT`` with ``object`` dtype (:issue:`13592`)

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -60,12 +60,14 @@ class Resampler(_GroupBy):
                    'loffset', 'base', 'kind']
 
     # API compat of allowed attributes
-    _deprecated_valids = _attributes + ['_ipython_display_', '__doc__',
-                                        '_cache', '_attributes', 'binner',
-                                        'grouper', 'groupby', 'keys',
-                                        'sort', 'kind', 'squeeze',
-                                        'group_keys', 'as_index',
-                                        'exclusions', '_groupby']
+    _deprecated_valids = _attributes + ['__doc__', '_cache', '_attributes',
+                                        'binner', 'grouper', 'groupby',
+                                        'sort', 'kind', 'squeeze', 'keys',
+                                        'group_keys', 'as_index', 'exclusions',
+                                        '_groupby']
+    # don't raise deprecation warning on attributes starting with these
+    # patterns - prevents warnings caused by IPython introspection
+    _deprecated_valid_patterns = ['_ipython', '_repr']
 
     # API compat of disallowed attributes
     _deprecated_invalids = ['iloc', 'loc', 'ix', 'iat', 'at']
@@ -109,9 +111,12 @@ class Resampler(_GroupBy):
             return 'series'
         return 'dataframe'
 
-    def _deprecated(self):
-        warnings.warn(".resample() is now a deferred operation\n"
-                      "use .resample(...).mean() instead of .resample(...)",
+    def _deprecated(self, op):
+        warnings.warn(("\n.resample() is now a deferred operation\n"
+                       "You called {op}(...) on this deferred object "
+                       "which materialized it into a {klass}\nby implicitly "
+                       "taking the mean.  Use .resample(...).mean() "
+                       "instead").format(op=op, klass=self._typ),
                       FutureWarning, stacklevel=3)
         return self.mean()
 
@@ -119,20 +124,20 @@ class Resampler(_GroupBy):
         # op is a string
 
         def _evaluate_numeric_binop(self, other):
-            result = self._deprecated()
+            result = self._deprecated(op)
             return getattr(result, op)(other)
         return _evaluate_numeric_binop
 
-    def _make_deprecated_unary(op):
+    def _make_deprecated_unary(op, name):
         # op is a callable
 
         def _evaluate_numeric_unary(self):
-            result = self._deprecated()
+            result = self._deprecated(name)
             return op(result)
         return _evaluate_numeric_unary
 
     def __array__(self):
-        return self._deprecated().__array__()
+        return self._deprecated('__array__').__array__()
 
     __gt__ = _make_deprecated_binop('__gt__')
     __ge__ = _make_deprecated_binop('__ge__')
@@ -148,10 +153,10 @@ class Resampler(_GroupBy):
     __truediv__ = __rtruediv__ = _make_deprecated_binop('__truediv__')
     if not compat.PY3:
         __div__ = __rdiv__ = _make_deprecated_binop('__div__')
-    __neg__ = _make_deprecated_unary(lambda x: -x)
-    __pos__ = _make_deprecated_unary(lambda x: x)
-    __abs__ = _make_deprecated_unary(lambda x: np.abs(x))
-    __inv__ = _make_deprecated_unary(lambda x: -x)
+    __neg__ = _make_deprecated_unary(lambda x: -x, '__neg__')
+    __pos__ = _make_deprecated_unary(lambda x: x, '__pos__')
+    __abs__ = _make_deprecated_unary(lambda x: np.abs(x), '__abs__')
+    __inv__ = _make_deprecated_unary(lambda x: -x, '__inv__')
 
     def __getattr__(self, attr):
         if attr in self._internal_names_set:
@@ -165,8 +170,12 @@ class Resampler(_GroupBy):
             raise ValueError(".resample() is now a deferred operation\n"
                              "\tuse .resample(...).mean() instead of "
                              ".resample(...)")
-        if attr not in self._deprecated_valids:
-            self = self._deprecated()
+
+        matches_pattern = any(attr.startswith(x) for x
+                              in self._deprecated_valid_patterns)
+        if not matches_pattern and attr not in self._deprecated_valids:
+            self = self._deprecated(attr)
+
         return object.__getattribute__(self, attr)
 
     def __setattr__(self, attr, value):
@@ -182,7 +191,7 @@ class Resampler(_GroupBy):
 
             # compat for deprecated
             if isinstance(self.obj, com.ABCSeries):
-                return self._deprecated()[key]
+                return self._deprecated('__getitem__')[key]
 
             raise
 
@@ -230,7 +239,7 @@ class Resampler(_GroupBy):
     def plot(self, *args, **kwargs):
         # for compat with prior versions, we want to
         # have the warnings shown here and just have this work
-        return self._deprecated().plot(*args, **kwargs)
+        return self._deprecated('plot').plot(*args, **kwargs)
 
     def aggregate(self, arg, *args, **kwargs):
         """

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -168,6 +168,13 @@ class TestResampleAPI(tm.TestCase):
                                             check_stacklevel=False):
                 self.assertIsInstance(getattr(r, op)(2), pd.Series)
 
+        # IPython introspection shouldn't trigger warning GH 13618
+        for op in ['_repr_json', '_repr_latex',
+                   '_ipython_canary_method_should_not_exist_']:
+            r = self.series.resample('H')
+            with tm.assert_produces_warning(None):
+                getattr(r, op, None)
+
         # getitem compat
         df = self.series.to_frame('foo')
 


### PR DESCRIPTION
- [ ] closes #13618, closes #13520
- [ ] tests added / passed
- [ ] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry

Prevents warnings triggered by IPython by matching against `'_repr'` or `'_ipython'`, and expands the `resample` warning message to indicate what caused the deferred object to be materialized.
