### PR TITLE
TST: assert message shows unnecessary diff

### DIFF
--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1010,14 +1010,15 @@ def raise_assert_detail(obj, message, left, right, diff=None):
     if isinstance(right, np.ndarray):
         right = pprint_thing(right)
 
-    if diff is not None:
-        diff = "\n[diff]: {diff}".format(diff=diff)
-
     msg = """{0} are different
 
 {1}
 [left]:  {2}
-[right]: {3}{4}""".format(obj, message, left, right, diff)
+[right]: {3}""".format(obj, message, left, right)
+
+    if diff is not None:
+        msg = msg + "\n[diff]: {diff}".format(diff=diff)
+
     raise AssertionError(msg)
 
 


### PR DESCRIPTION
- [x] passes `git diff upstream/master | flake8 --diff`

removed unnecessary trailing `None`. 

```
pd.util.testing.assert_index_equal(pd.Index([1, 2, 3]), pd.Index([1 ,2, 4]))
# AssertionError: Index are different
# 
# Index values are different (33.33333 %)
# [left]:  Int64Index([1, 2, 3], dtype='int64')
# [right]: Int64Index([1, 2, 4], dtype='int64')None
```
