### PR TITLE
ENH: Series.append now has ignore_index kw

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -249,6 +249,7 @@ Other enhancements
 - ``pd.read_html()`` has gained support for the ``decimal`` option (:issue:`12907`)
 - A function :func:`union_categorical` has been added for combining categoricals, see :ref:`Unioning Categoricals<categorical.union>` (:issue:`13361`)
 - ``Series`` has gained the properties ``.is_monotonic``, ``.is_monotonic_increasing``, ``.is_monotonic_decreasing``, similar to ``Index`` (:issue:`13336`)
+- ``Series.append`` now supports ``ignore_index`` option (:issue:`13677`)
 
 .. _whatsnew_0190.api:
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1511,13 +1511,18 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
     # -------------------------------------------------------------------
     # Combination
 
-    def append(self, to_append, verify_integrity=False):
+    def append(self, to_append, ignore_index=False, verify_integrity=False):
         """
         Concatenate two or more Series.
 
         Parameters
         ----------
         to_append : Series or list/tuple of Series
+        ignore_index : boolean, default False
+            If True, do not use the index labels.
+
+            .. versionadded: 0.19.0
+
         verify_integrity : boolean, default False
             If True, raise Exception on creating index with duplicates
 
@@ -1548,6 +1553,17 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         5    6
         dtype: int64
 
+        With `ignore_index` set to True:
+
+        >>> s1.append(s2, ignore_index=True)
+        0    1
+        1    2
+        2    3
+        3    4
+        4    5
+        5    6
+        dtype: int64
+
         With `verify_integrity` set to True:
 
         >>> s1.append(s2, verify_integrity=True)
@@ -1561,7 +1577,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
             to_concat = [self] + to_append
         else:
             to_concat = [self, to_append]
-        return concat(to_concat, ignore_index=False,
+        return concat(to_concat, ignore_index=ignore_index,
                       verify_integrity=verify_integrity)
 
     def _binop(self, other, func, level=None, fill_value=None):

--- a/pandas/tests/series/test_combine_concat.py
+++ b/pandas/tests/series/test_combine_concat.py
@@ -39,6 +39,27 @@ class TestSeriesCombine(TestData, tm.TestCase):
         result = pieces[0].append(pieces[1:])
         assert_series_equal(result, self.ts)
 
+    def test_append_duplicates(self):
+        # GH 13677
+        s1 = pd.Series([1, 2, 3])
+        s2 = pd.Series([4, 5, 6])
+        exp = pd.Series([1, 2, 3, 4, 5, 6], index=[0, 1, 2, 0, 1, 2])
+        tm.assert_series_equal(s1.append(s2), exp)
+        tm.assert_series_equal(pd.concat([s1, s2]), exp)
+
+        # the result must have RangeIndex
+        exp = pd.Series([1, 2, 3, 4, 5, 6])
+        tm.assert_series_equal(s1.append(s2, ignore_index=True),
+                               exp, check_index_type=True)
+        tm.assert_series_equal(pd.concat([s1, s2], ignore_index=True),
+                               exp, check_index_type=True)
+
+        msg = 'Indexes have overlapping values:'
+        with tm.assertRaisesRegexp(ValueError, msg):
+            s1.append(s2, verify_integrity=True)
+        with tm.assertRaisesRegexp(ValueError, msg):
+            pd.concat([s1, s2], verify_integrity=True)
+
     def test_combine_first(self):
         values = tm.makeIntIndex(20).values.astype(float)
         series = Series(values, index=tm.makeIntIndex(20))


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

not sure if there is any reason we haven't supported...
