### PR TITLE
COMPAT: use mpl area legend if available

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -849,6 +849,7 @@ Bug Fixes
 - Bug in ``pd.read_csv()``, which caused BOM files to be incorrectly parsed by not ignoring the BOM (:issue:`4793`)
 - Bug in ``io.json.json_normalize()``, where non-ascii keys raised an exception (:issue:`13213`)
 - Bug when passing a not-default-indexed ``Series`` as ``xerr`` or ``yerr`` in ``.plot()`` (:issue:`11858`)
+- Bug in area plot draws legend incorrectly if subplot is enabled or legend is moved after plot (matplotlib 1.5.0 is required to draw area plot legend properly) (issue:`9161`, :issue:`13544`)
 - Bug in matplotlib ``AutoDataFormatter``; this restores the second scaled formatting and re-adds micro-second scaled formatting (:issue:`13131`)
 - Bug in selection from a ``HDFStore`` with a fixed format and ``start`` and/or ``stop`` specified will now return the selected range (:issue:`8287`)
 - Bug in ``Series`` construction from a tuple of integers on windows not returning default dtype (int64) (:issue:`13646`)


### PR DESCRIPTION
- [x] closes #9161, closes #13544
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Do not use area legend workaround if mpl >= 1.5.0 is available. Legends are now displayed properly if mpl >= 1.5.0.
#9161:

```
df = pd.DataFrame(np.random.rand(10, 3))
df.plot(kind='area', subplots=True, sharex=True, legend=True)
```

![index](https://cloud.githubusercontent.com/assets/1696302/16897682/4ee78324-4bf3-11e6-8113-65d68ec28b09.png)
#13544:

```
df = pd.DataFrame(np.random.rand(20, 5), columns=['A', 'B', 'C', 'D', 'E'])
df.plot(kind='area', linewidth=0.1).legend(loc="center left", bbox_to_anchor=(1.02, 0.5))
```

![index2](https://cloud.githubusercontent.com/assets/1696302/16897684/61eb4370-4bf3-11e6-9472-cec27297b7d1.png)
