### PR TITLE
BUG: Cast a key to NaT before get loc from Index

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -614,3 +614,5 @@ Bug Fixes
 - Bug in ``groupby`` with ``as_index=False`` returns all NaN's when grouping on multiple columns including a categorical one (:issue:`13204`)
 
 - Bug where ``pd.read_gbq()`` could throw ``ImportError: No module named discovery`` as a result of a naming conflict with another python package called apiclient  (:issue:`13454`)
+
+- Bug in Checking for any NaT-like objects in a `TimedeltaIndex` always returns ``True`` (:issue:`13603`)

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -697,6 +697,10 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         -------
         loc : int
         """
+
+        if isnull(key):
+            key = tslib.NaT
+
         if tolerance is not None:
             # try converting tolerance now, so errors don't get swallowed by
             # the try/except clauses below
@@ -754,7 +758,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
     def _get_string_slice(self, key, use_lhs=True, use_rhs=True):
         freq = getattr(self, 'freqstr',
                        getattr(self, 'inferred_freq', None))
-        if is_integer(key) or is_float(key):
+        if is_integer(key) or is_float(key) or key is tslib.NaT:
             self._invalid_indexer('slice', key)
         loc = self._partial_td_slice(key, freq, use_lhs=use_lhs,
                                      use_rhs=use_rhs)

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -30,6 +30,25 @@ class TestTimedeltas(tm.TestCase):
     def setUp(self):
         pass
 
+    def test_get_loc_nat(self):
+        tidx = TimedeltaIndex(['1 days 01:00:00', 'NaT', '2 days 01:00:00'])
+
+        self.assertEqual(tidx.get_loc(pd.NaT), 1)
+        self.assertEqual(tidx.get_loc(None), 1)
+        self.assertEqual(tidx.get_loc(float('nan')), 1)
+        self.assertEqual(tidx.get_loc(np.nan), 1)
+
+    def test_contains(self):
+        # Checking for any NaT-like objects
+        # GH 13603
+        td = to_timedelta(range(5), unit='d') + pd.offsets.Hour(1)
+        for v in [pd.NaT, None, float('nan'), np.nan]:
+            self.assertFalse((v in td))
+
+        td = to_timedelta([pd.NaT])
+        for v in [pd.NaT, None, float('nan'), np.nan]:
+            self.assertTrue((v in td))
+
     def test_construction(self):
 
         expected = np.timedelta64(10, 'D').astype('m8[ns]').view('i8')


### PR DESCRIPTION
- [x] closes #13603
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

pd.NaT, None, float('nan') and np.nan are
converted NaT in TestTimedeltas.
So we should convert keys if keys are these value.

Fix #13603
