### PR TITLE
BUG: Add  type check for width parameter in str.pad method GH13598

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -614,4 +614,4 @@ Bug Fixes
 - Bug in ``groupby`` with ``as_index=False`` returns all NaN's when grouping on multiple columns including a categorical one (:issue:`13204`)
 
 - Bug where ``pd.read_gbq()`` could throw ``ImportError: No module named discovery`` as a result of a naming conflict with another python package called apiclient  (:issue:`13454`)
-- Bug in ``pandas.Series.str.zfill``, no TypeErrors raised when  ``width`` was not of integer type (:issue:`13598`)
+- Bug in ``pandas.Series.str.zfill``, when ``width`` was not of integer type no ``TypeError`` was raised, which resulted in a series with all NaN values (:issue:`13598`)

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -614,3 +614,4 @@ Bug Fixes
 - Bug in ``groupby`` with ``as_index=False`` returns all NaN's when grouping on multiple columns including a categorical one (:issue:`13204`)
 
 - Bug where ``pd.read_gbq()`` could throw ``ImportError: No module named discovery`` as a result of a naming conflict with another python package called apiclient  (:issue:`13454`)
+- Bug in ``pandas.Series.str.zfill``, no TypeErrors raised when  ``width`` was not of integer type (:issue:`13598`)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -8,7 +8,8 @@ from pandas.types.common import (is_bool_dtype,
                                  is_object_dtype,
                                  is_string_like,
                                  is_list_like,
-                                 is_scalar)
+                                 is_scalar,
+                                 is_integer)
 from pandas.core.common import _values_from_object
 
 from pandas.core.algorithms import take_1d
@@ -914,7 +915,7 @@ def str_pad(arr, width, side='left', fillchar=' '):
     if len(fillchar) != 1:
         raise TypeError('fillchar must be a character, not str')
 
-    if not isinstance(width, compat.integer_types):
+    if not is_integer(width):
         msg = 'width must be of integer type, not {0}'
         raise TypeError(msg.format(type(width).__name__))
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -914,6 +914,10 @@ def str_pad(arr, width, side='left', fillchar=' '):
     if len(fillchar) != 1:
         raise TypeError('fillchar must be a character, not str')
 
+    if not isinstance(width, compat.integer_types):
+        msg = 'width must be of integer type, not {0}'
+        raise TypeError(msg.format(type(width).__name__))
+
     if side == 'left':
         f = lambda x: x.rjust(width, fillchar)
     elif side == 'right':

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -1603,6 +1603,18 @@ class TestStringMethods(tm.TestCase):
                                    "fillchar must be a character, not int"):
             result = values.str.pad(5, fillchar=5)
 
+    def test_pad_width(self):
+
+        values = Series(['1', '22', 'a', 'bb'])
+
+        result = values.str.pad(5, side='left', fillchar='0')
+        expected = Series(['00001', '00022', '0000a', '000bb'])
+        tm.assert_almost_equal(result, expected)
+
+        with tm.assertRaisesRegexp(TypeError,
+                                   "width must be of integer type, not*"):
+            result = values.str.pad('f', fillchar='0')
+
     def test_translate(self):
 
         def _check(result, expected):

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -1605,13 +1605,12 @@ class TestStringMethods(tm.TestCase):
 
     def test_pad_width(self):
         values = Series(['1', '22', 'a', 'bb'])
-        string_methods = Series.str(values)
+        s = Series(values)
 
-        for f_name, f in Series.str.__dict__.items():
-            if f_name in ['center', 'ljust', 'rjust', 'zfill', 'pad']:
-                with tm.assertRaisesRegexp(TypeError,
-                                           "width must be of integer type,*"):
-                    f(string_methods, 'f')
+        for f in ['center', 'ljust', 'rjust', 'zfill', 'pad']:
+            with tm.assertRaisesRegexp(TypeError,
+                                       "width must be of integer type, not*"):
+                getattr(s.str, f)('f')
 
     def test_translate(self):
 

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -1757,6 +1757,33 @@ class TestStringMethods(tm.TestCase):
                                    "fillchar must be a character, not int"):
             result = values.str.rjust(5, fillchar=1)
 
+    def test_center_ljust_rjust_width(self):
+        values = Series(['a', 'bb', 'ccc', NA, 'eeeee'])
+
+        result = values.str.center(4, fillchar='X')
+        expected = Series(['XaXX', 'XbbX', 'cccX', NA, 'eeeee'])
+        tm.assert_almost_equal(result, expected)
+
+        result = values.str.ljust(4, fillchar='X')
+        expected = Series(['aXXX', 'bbXX', 'cccX', NA, 'eeeee'])
+        tm.assert_almost_equal(result, expected)
+
+        result = values.str.rjust(4, fillchar='X')
+        expected = Series(['XXXa', 'XXbb', 'Xccc', NA, 'eeeee'])
+        tm.assert_almost_equal(result, expected)
+
+        with tm.assertRaisesRegexp(TypeError,
+                                   "width must be of integer type, not*"):
+            result = values.str.center('f', fillchar='X')
+
+        with tm.assertRaisesRegexp(TypeError,
+                                   "width must be of integer type, not*"):
+            result = values.str.ljust('f', fillchar='X')
+
+        with tm.assertRaisesRegexp(TypeError,
+                                   "width must be of integer type, not*"):
+            result = values.str.rjust('f', fillchar='X')
+
     def test_zfill(self):
         values = Series(['1', '22', 'aaa', '333', '45678'])
 
@@ -1778,6 +1805,17 @@ class TestStringMethods(tm.TestCase):
         result = values.str.zfill(5)
         expected = Series(['00001', np.nan, '00aaa', np.nan, '45678'])
         tm.assert_series_equal(result, expected)
+
+    def test_zfill_width(self):
+        values = Series(['1', '22', 'ccc', NA, 'eeeee'])
+
+        result = values.str.zfill(5)
+        expected = Series(['00001', '00022', '00ccc', NA, 'eeeee'])
+        tm.assert_almost_equal(result, expected)
+
+        with tm.assertRaisesRegexp(TypeError,
+                                   "width must be of integer type, not*"):
+            result = values.str.zfill('f')
 
     def test_split(self):
         values = Series(['a_b_c', 'c_d_e', NA, 'f_g_h'])

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -1604,16 +1604,14 @@ class TestStringMethods(tm.TestCase):
             result = values.str.pad(5, fillchar=5)
 
     def test_pad_width(self):
-
         values = Series(['1', '22', 'a', 'bb'])
+        string_methods = Series.str(values)
 
-        result = values.str.pad(5, side='left', fillchar='0')
-        expected = Series(['00001', '00022', '0000a', '000bb'])
-        tm.assert_almost_equal(result, expected)
-
-        with tm.assertRaisesRegexp(TypeError,
-                                   "width must be of integer type, not*"):
-            result = values.str.pad('f', fillchar='0')
+        for f_name, f in Series.str.__dict__.items():
+            if f_name in ['center', 'ljust', 'rjust', 'zfill', 'pad']:
+                with tm.assertRaisesRegexp(TypeError,
+                                           "width must be of integer type,*"):
+                    f(string_methods, 'f')
 
     def test_translate(self):
 
@@ -1757,33 +1755,6 @@ class TestStringMethods(tm.TestCase):
                                    "fillchar must be a character, not int"):
             result = values.str.rjust(5, fillchar=1)
 
-    def test_center_ljust_rjust_width(self):
-        values = Series(['a', 'bb', 'ccc', NA, 'eeeee'])
-
-        result = values.str.center(4, fillchar='X')
-        expected = Series(['XaXX', 'XbbX', 'cccX', NA, 'eeeee'])
-        tm.assert_almost_equal(result, expected)
-
-        result = values.str.ljust(4, fillchar='X')
-        expected = Series(['aXXX', 'bbXX', 'cccX', NA, 'eeeee'])
-        tm.assert_almost_equal(result, expected)
-
-        result = values.str.rjust(4, fillchar='X')
-        expected = Series(['XXXa', 'XXbb', 'Xccc', NA, 'eeeee'])
-        tm.assert_almost_equal(result, expected)
-
-        with tm.assertRaisesRegexp(TypeError,
-                                   "width must be of integer type, not*"):
-            result = values.str.center('f', fillchar='X')
-
-        with tm.assertRaisesRegexp(TypeError,
-                                   "width must be of integer type, not*"):
-            result = values.str.ljust('f', fillchar='X')
-
-        with tm.assertRaisesRegexp(TypeError,
-                                   "width must be of integer type, not*"):
-            result = values.str.rjust('f', fillchar='X')
-
     def test_zfill(self):
         values = Series(['1', '22', 'aaa', '333', '45678'])
 
@@ -1805,17 +1776,6 @@ class TestStringMethods(tm.TestCase):
         result = values.str.zfill(5)
         expected = Series(['00001', np.nan, '00aaa', np.nan, '45678'])
         tm.assert_series_equal(result, expected)
-
-    def test_zfill_width(self):
-        values = Series(['1', '22', 'ccc', NA, 'eeeee'])
-
-        result = values.str.zfill(5)
-        expected = Series(['00001', '00022', '00ccc', NA, 'eeeee'])
-        tm.assert_almost_equal(result, expected)
-
-        with tm.assertRaisesRegexp(TypeError,
-                                   "width must be of integer type, not*"):
-            result = values.str.zfill('f')
 
     def test_split(self):
         values = Series(['a_b_c', 'c_d_e', NA, 'f_g_h'])


### PR DESCRIPTION
- [x] closes #13598 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
