### PR TITLE
PERF: improve DTI string parse

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -566,6 +566,7 @@ Performance Improvements
 - Improved performance of float64 hash table operations, fixing some very slow indexing and groupby operations in python 3 (:issue:`13166`, :issue:`13334`)
 - Improved performance of ``DataFrameGroupBy.transform`` (:issue:`12737`)
 - Improved performance of ``Index.difference`` (:issue:`12044`)
+- Improved performance of datetime string parsing in ``DatetimeIndex`` (:issue:`13692`)
 
 .. _whatsnew_0190.bug_fixes:
 
@@ -631,6 +632,7 @@ Bug Fixes
 - Bug in checking for any null objects in a ``TimedeltaIndex``, which always returned ``True`` (:issue:`13603`)
 
 
+
 - Bug in ``Series`` arithmetic raises ``TypeError`` if it contains datetime-like as ``object`` dtype (:issue:`13043`)
 
 
@@ -654,6 +656,8 @@ Bug Fixes
 
 - Bug in ``pd.to_numeric`` when ``errors='coerce'`` and input contains non-hashable objects (:issue:`13324`)
 - Bug in invalid ``Timedelta`` arithmetic and comparison may raise ``ValueError`` rather than ``TypeError`` (:issue:`13624`)
+- Bug in invalid datetime parsing in ``to_datetime`` and ``DatetimeIndex`` may raise ``TypeError`` rather than ``ValueError`` (:issue:`11169`, :issue:`11287`)
+- Bug in ``Index`` created with tz-aware ``Timestamp`` and mismatched ``tz`` option incorrectly coerces timezone (:issue:`13692`)
 
 - Bug in ``Categorical.remove_unused_categories()`` changes ``.codes`` dtype to platform int (:issue:`13261`)
 - Bug in ``groupby`` with ``as_index=False`` returns all NaN's when grouping on multiple columns including a categorical one (:issue:`13204`)

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2440,7 +2440,7 @@ def _make_date_converter(date_parser=None, dayfirst=False,
             strs = _concat_date_cols(date_cols)
 
             try:
-                return tools._to_datetime(
+                return tools.to_datetime(
                     _ensure_object(strs),
                     utc=None,
                     box=False,

--- a/pandas/tests/indexes/test_datetimelike.py
+++ b/pandas/tests/indexes/test_datetimelike.py
@@ -170,16 +170,6 @@ class TestDatetimeIndex(DatetimeLike, tm.TestCase):
         self.assert_index_equal(result, exp, exact=True)
         self.assertFalse(isinstance(result, DatetimeIndex))
 
-        # passing tz results in DatetimeIndex
-        result = Index([Timestamp('2011-01-01 10:00'),
-                        Timestamp('2011-01-02 10:00', tz='US/Eastern')],
-                       tz='Asia/Tokyo', name='idx')
-        exp = DatetimeIndex([Timestamp('2011-01-01 19:00'),
-                             Timestamp('2011-01-03 00:00')],
-                            tz='Asia/Tokyo', name='idx')
-        self.assert_index_equal(result, exp, exact=True)
-        self.assertTrue(isinstance(result, DatetimeIndex))
-
         # length = 1
         result = Index([Timestamp('2011-01-01')], name='idx')
         exp = DatetimeIndex([Timestamp('2011-01-01')], name='idx')
@@ -253,17 +243,6 @@ class TestDatetimeIndex(DatetimeLike, tm.TestCase):
         self.assert_index_equal(result, exp, exact=True)
         self.assertFalse(isinstance(result, DatetimeIndex))
 
-        # passing tz results in DatetimeIndex
-        result = Index([pd.NaT, Timestamp('2011-01-01 10:00'),
-                        pd.NaT, Timestamp('2011-01-02 10:00',
-                                          tz='US/Eastern')],
-                       tz='Asia/Tokyo', name='idx')
-        exp = DatetimeIndex([pd.NaT, Timestamp('2011-01-01 19:00'),
-                             pd.NaT, Timestamp('2011-01-03 00:00')],
-                            tz='Asia/Tokyo', name='idx')
-        self.assert_index_equal(result, exp, exact=True)
-        self.assertTrue(isinstance(result, DatetimeIndex))
-
         # all NaT
         result = Index([pd.NaT, pd.NaT], name='idx')
         exp = DatetimeIndex([pd.NaT, pd.NaT], name='idx')
@@ -323,12 +302,13 @@ class TestDatetimeIndex(DatetimeLike, tm.TestCase):
         self.assertTrue(isinstance(result, DatetimeIndex))
 
         # tz mismatch affecting to tz-aware raises TypeError/ValueError
+
         with tm.assertRaises(ValueError):
             DatetimeIndex([Timestamp('2011-01-01 10:00', tz='Asia/Tokyo'),
                            Timestamp('2011-01-02 10:00', tz='US/Eastern')],
                           name='idx')
 
-        with tm.assertRaises(TypeError):
+        with tm.assertRaisesRegexp(TypeError, 'data is already tz-aware'):
             DatetimeIndex([Timestamp('2011-01-01 10:00'),
                            Timestamp('2011-01-02 10:00', tz='US/Eastern')],
                           tz='Asia/Tokyo', name='idx')
@@ -337,6 +317,13 @@ class TestDatetimeIndex(DatetimeLike, tm.TestCase):
             DatetimeIndex([Timestamp('2011-01-01 10:00', tz='Asia/Tokyo'),
                            Timestamp('2011-01-02 10:00', tz='US/Eastern')],
                           tz='US/Eastern', name='idx')
+
+        with tm.assertRaisesRegexp(TypeError, 'data is already tz-aware'):
+            # passing tz should results in DatetimeIndex, then mismatch raises
+            # TypeError
+            Index([pd.NaT, Timestamp('2011-01-01 10:00'),
+                   pd.NaT, Timestamp('2011-01-02 10:00', tz='US/Eastern')],
+                  tz='Asia/Tokyo', name='idx')
 
     def test_construction_base_constructor(self):
         arr = [pd.Timestamp('2011-01-01'), pd.NaT, pd.Timestamp('2011-01-03')]

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -1046,7 +1046,12 @@ class TimeGrouper(Grouper):
         l = []
         for key, group in grouper.get_iterator(self.ax):
             l.extend([key] * len(group))
-        grouper = binner.__class__(l, freq=binner.freq, name=binner.name)
+
+        if isinstance(self.ax, PeriodIndex):
+            grouper = binner.__class__(l, freq=binner.freq, name=binner.name)
+        else:
+            # resampling causes duplicated values, specifying freq is invalid
+            grouper = binner.__class__(l, name=binner.name)
 
         # since we may have had to sort
         # may need to reorder groups here

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -4087,8 +4087,9 @@ class TestDatetime64(tm.TestCase):
 
         # 11314
         # with tz
-        index = date_range(datetime(2015, 10, 1), datetime(
-            2015, 10, 1, 23), freq='H', tz='US/Eastern')
+        index = date_range(datetime(2015, 10, 1),
+                           datetime(2015, 10, 1, 23),
+                           freq='H', tz='US/Eastern')
         df = DataFrame(np.random.randn(24, 1), columns=['a'], index=index)
         new_index = date_range(datetime(2015, 10, 2),
                                datetime(2015, 10, 2, 23),


### PR DESCRIPTION
- [x] closes #11169, closes #11287
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

cleaned up `DatetimeIndex` constructor removing slower string-parsing path.
## Performance Improvement

related to #7599, internally use `to_datetime` always as it tries some fastpath.

```
inp = np.array(['2011-01-01 09:00' for i in range(10000)])

# on current master
%timeit pd.DatetimeIndex(inp)
1 loops, best of 3: 3.41 s per loop
%timeit pd.to_datetime(inp)
100 loops, best of 3: 4.77 ms per loop

# after the PR
%timeit pd.DatetimeIndex(inp)
#100 loops, best of 3: 4.23 ms per loop
%timeit pd.to_datetime(inp)
#100 loops, best of 3: 4.25 ms per loop
```
## Bug Fixes

The cleanup fixed these 2 kind of issues:
#### 1. #11169 and #11287 Invalid string parsing may raise `TypeError`

I met the same issue on travis and fixed with try-except clause (I can't reproduce it on my local Mac). 
#### 2. Index may incorrectly coerces mismatched tz

on current master, `DatetimeIndex` and normal `Index` behaves differently.

```
# OK
pd.DatetimeIndex([pd.Timestamp('2011-01-01', tz='US/Eastern')], tz='US/Pacific')
# TypeError: Already tz-aware, use tz_convert to convert.

# NG, it ignores mismatch and coerce to passed tz
pd.Index([pd.Timestamp('2011-01-01', tz='US/Eastern')], tz='US/Pacific')
DatetimeIndex(['2010-12-31 21:00:00-08:00'], dtype='datetime64[ns, US/Pacific]', freq=None)
```

after the PR both behave the same, showing understandable error.

```
pd.Index([pd.Timestamp('2011-01-01', tz='US/Eastern')], tz='US/Pacific')
# TypeError: data is already tz-aware US/Eastern, unable to set specified tz: US/Pacific

pd.DatetimeIndex([pd.Timestamp('2011-01-01', tz='US/Eastern')], tz='US/Pacific')
# TypeError: data is already tz-aware US/Eastern, unable to set specified tz: US/Pacific
```
