### PR TITLE
CLN: Removed the return_type param in StringMethods.split

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -544,6 +544,7 @@ Removal of prior version deprecations/changes
 - ``pd.Categorical`` has dropped the ``levels`` attribute in favour of ``categories`` (:issue:`8376`)
 - ``DataFrame.to_sql()`` has dropped the ``mysql`` option for the ``flavor`` parameter (:issue:`13611`)
 
+- ``str.split`` has dropped the ``return_type`` parameter in favor of ``expand`` (:issue:`13701`)
 - Removal of the legacy time rules (offset aliases), deprecated since 0.17.0 (this has been alias since 0.8.0) (:issue:`13590`)
 
   Previous Behavior:

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -15,7 +15,7 @@ from pandas.core.common import _values_from_object
 from pandas.core.algorithms import take_1d
 import pandas.compat as compat
 from pandas.core.base import AccessorProperty, NoNewAttributesMixin
-from pandas.util.decorators import Appender, deprecate_kwarg
+from pandas.util.decorators import Appender
 import re
 import pandas.lib as lib
 import warnings
@@ -1401,8 +1401,6 @@ class StringMethods(NoNewAttributesMixin):
         result = str_cat(data, others=others, sep=sep, na_rep=na_rep)
         return self._wrap_result(result, use_codes=(not self._is_categorical))
 
-    @deprecate_kwarg('return_type', 'expand', mapping={'series': False,
-                                                       'frame': True})
     @copy(str_split)
     def split(self, pat=None, n=-1, expand=False):
         result = str_split(self._data, pat, n=n)

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -1906,45 +1906,6 @@ class TestStringMethods(tm.TestCase):
 
     def test_split_to_dataframe(self):
         s = Series(['nosplit', 'alsonosplit'])
-
-        with tm.assert_produces_warning(FutureWarning):
-            result = s.str.split('_', return_type='frame')
-
-        exp = DataFrame({0: Series(['nosplit', 'alsonosplit'])})
-        tm.assert_frame_equal(result, exp)
-
-        s = Series(['some_equal_splits', 'with_no_nans'])
-        with tm.assert_produces_warning(FutureWarning):
-            result = s.str.split('_', return_type='frame')
-        exp = DataFrame({0: ['some', 'with'],
-                         1: ['equal', 'no'],
-                         2: ['splits', 'nans']})
-        tm.assert_frame_equal(result, exp)
-
-        s = Series(['some_unequal_splits', 'one_of_these_things_is_not'])
-        with tm.assert_produces_warning(FutureWarning):
-            result = s.str.split('_', return_type='frame')
-        exp = DataFrame({0: ['some', 'one'],
-                         1: ['unequal', 'of'],
-                         2: ['splits', 'these'],
-                         3: [NA, 'things'],
-                         4: [NA, 'is'],
-                         5: [NA, 'not']})
-        tm.assert_frame_equal(result, exp)
-
-        s = Series(['some_splits', 'with_index'], index=['preserve', 'me'])
-        with tm.assert_produces_warning(FutureWarning):
-            result = s.str.split('_', return_type='frame')
-        exp = DataFrame({0: ['some', 'with'], 1: ['splits', 'index']},
-                        index=['preserve', 'me'])
-        tm.assert_frame_equal(result, exp)
-
-        with tm.assertRaisesRegexp(ValueError, "expand must be"):
-            with tm.assert_produces_warning(FutureWarning):
-                s.str.split('_', return_type="some_invalid_type")
-
-    def test_split_to_dataframe_expand(self):
-        s = Series(['nosplit', 'alsonosplit'])
         result = s.str.split('_', expand=True)
         exp = DataFrame({0: Series(['nosplit', 'alsonosplit'])})
         tm.assert_frame_equal(result, exp)
@@ -1973,8 +1934,7 @@ class TestStringMethods(tm.TestCase):
         tm.assert_frame_equal(result, exp)
 
         with tm.assertRaisesRegexp(ValueError, "expand must be"):
-            with tm.assert_produces_warning(FutureWarning):
-                s.str.split('_', return_type="some_invalid_type")
+            s.str.split('_', expand="not_a_boolean")
 
     def test_split_to_multiindex_expand(self):
         idx = Index(['nosplit', 'alsonosplit'])
@@ -1999,8 +1959,7 @@ class TestStringMethods(tm.TestCase):
         self.assertEqual(result.nlevels, 6)
 
         with tm.assertRaisesRegexp(ValueError, "expand must be"):
-            with tm.assert_produces_warning(FutureWarning):
-                idx.str.split('_', return_type="some_invalid_type")
+            idx.str.split('_', expand="not_a_boolean")
 
     def test_rsplit_to_dataframe_expand(self):
         s = Series(['nosplit', 'alsonosplit'])


### PR DESCRIPTION
Continues where #10085 left off by removing the `return_type` parameter for good.
