### PR TITLE
BUG: Fix pd.Timedelta(None) to return NaT.

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -755,3 +755,4 @@ Bug Fixes
 - Bug where ``pd.read_gbq()`` could throw ``ImportError: No module named discovery`` as a result of a naming conflict with another python package called apiclient  (:issue:`13454`)
 - Bug in ``Index.union`` returns an incorrect result with a named empty index (:issue:`13432`)
 - Bugs in ``Index.difference`` and ``DataFrame.join`` raise in Python3 when using mixed-integer indexes (:issue:`13432`, :issue:`12814`)
+- Bug in ``pd.Timedelta(None)`` raises ``ValueError``. This is different from ``pd.Timestamp(None)`` (:issue:`13687`)

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -188,6 +188,8 @@ class TestTimedeltas(tm.TestCase):
         self.assertEqual(Timedelta('').value, iNaT)
         self.assertEqual(Timedelta('nat').value, iNaT)
         self.assertEqual(Timedelta('NAT').value, iNaT)
+        self.assertEqual(Timedelta(None).value, iNaT)
+        self.assertEqual(Timedelta(np.nan).value, iNaT)
         self.assertTrue(isnull(Timedelta('nat')))
 
         # offset

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -2592,10 +2592,10 @@ class Timedelta(_Timedelta):
 
     """
 
-    def __new__(cls, object value=None, unit=None, **kwargs):
+    def __new__(cls, object value=_no_input, unit=None, **kwargs):
         cdef _Timedelta td_base
 
-        if value is None:
+        if value is _no_input:
             if not len(kwargs):
                 raise ValueError("cannot construct a Timedelta without a value/unit or descriptive keywords (days,seconds....)")
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Before this commit pd.Timedelta raised ValueError
when None is passed.
This behavior is inconsistent because
- pd.Timestamp(None) and pd.Period(None) return NaT
- pd.Timedelta returns NaT if '', 'nat', 'NAT' or np.nan
  is passed

This PR is related to https://github.com/pydata/pandas/pull/13687#issuecomment-233204955
