### PR TITLE
TST, COMPAT: Make MMapWrapper tests Windows compatible

### DIFF
--- a/pandas/io/tests/test_common.py
+++ b/pandas/io/tests/test_common.py
@@ -138,6 +138,6 @@ class TestMMapWrapper(tm.TestCase):
 
         for line in lines:
             next_line = next(wrapper)
-            self.assertEqual(next_line, line)
+            self.assertEqual(next_line.strip(), line.strip())
 
         self.assertRaises(StopIteration, next, wrapper)


### PR DESCRIPTION
Partially addresses #13721 by addressing the `MMapWrapper` test failure.  The issue was we didn't have control over the newline character, so the test was re-written to give us that control.
