### PR TITLE
TST/BUG: test unsortable in safe_sort and Categorical (GH13714)

### DIFF
--- a/ci/requirements-2.7.build
+++ b/ci/requirements-2.7.build
@@ -1,4 +1,4 @@
 python-dateutil=2.4.1
 pytz=2013b
-numpy=1.9.3
+numpy
 cython=0.19.1

--- a/ci/requirements-2.7.run
+++ b/ci/requirements-2.7.run
@@ -1,6 +1,6 @@
 python-dateutil=2.4.1
 pytz=2013b
-numpy=1.9.3
+numpy
 xlwt=0.7.5
 numexpr
 pytables

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy.random import RandomState
 from numpy import nan
 import datetime
+from distutils.version import LooseVersion
 
 from pandas import Series, Categorical, CategoricalIndex, Index
 import pandas as pd
@@ -116,6 +117,19 @@ class TestSafeSort(tm.TestCase):
         labels = [0, 1, 2, 3, 0, -1, 1]
         result, result_labels = algos.safe_sort(values, labels)
         expected = np.array([0, 1, 'a', 'b'], dtype=object)
+        expected_labels = np.array([3, 1, 0, 2, 3, -1, 1])
+        tm.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result_labels, expected_labels)
+
+    def test_unsortable(self):
+        # GH 13714
+        arr = np.array([1, 2, datetime.datetime.now(), 0, 3], dtype=object)
+        if compat.PY2 and LooseVersion(np.__version__) >= "1.10":
+            # RuntimeWarning: tp_compare didn't return -1 or -2 for exception
+            with tm.assert_produces_warning(RuntimeWarning):
+                tm.assertRaises(TypeError, algos.safe_sort, arr)
+        else:
+            tm.assertRaises(TypeError, algos.safe_sort, arr)
 
     def test_exceptions(self):
         with tm.assertRaisesRegexp(TypeError,

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -97,18 +97,9 @@ class TestCategorical(tm.TestCase):
         factor = Categorical.from_array(arr, ordered=False)
         self.assertFalse(factor.ordered)
 
-        if compat.PY3:
-            self.assertRaises(
-                TypeError, lambda: Categorical.from_array(arr, ordered=True))
-        else:
-            # this however will raise as cannot be sorted (on PY3 or older
-            # numpies)
-            if LooseVersion(np.__version__) < "1.10":
-                self.assertRaises(
-                    TypeError,
-                    lambda: Categorical.from_array(arr, ordered=True))
-            else:
-                Categorical.from_array(arr, ordered=True)
+        # this however will raise as cannot be sorted
+        self.assertRaises(
+            TypeError, lambda: Categorical.from_array(arr, ordered=True))
 
     def test_is_equal_dtype(self):
 


### PR DESCRIPTION
- [x] closes #13714
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry
- Change test for Categorical.from_array (`test_constructor_unsortable`)
- Add test for safe_sort
- Change 2.7 build to latest numpy

---

`safe_sort` always raises on a mixed int-datetime array. This is the expected behaviour. (But, for numpy >= 1.10 & python2, I still have some doubts whether it's not a manifestation of an undefined behaviour.)
