### PR TITLE
BUG: DatetimeIndex raises AttributeError on win

### DIFF
--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -329,9 +329,12 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
                     subarr = tslib.cast_to_nanoseconds(data)
                 else:
                     subarr = data
-        elif data.dtype == _INT64_DTYPE:
+        else:
+            # must be integer dtype otherwise
             if isinstance(data, Int64Index):
                 raise TypeError('cannot convert Int64Index->DatetimeIndex')
+            if data.dtype != _INT64_DTYPE:
+                data = data.astype(np.int64)
             subarr = data.view(_NS_DTYPE)
 
         if isinstance(subarr, DatetimeIndex):

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1520,6 +1520,16 @@ class TestTimeSeries(tm.TestCase):
                                   (rng3, expected3), (rng4, expected4)]:
                 tm.assert_index_equal(rng, expected)
 
+    def test_dti_constructor_small_int(self):
+        # GH 13721
+        exp = DatetimeIndex(['1970-01-01 00:00:00.00000000',
+                             '1970-01-01 00:00:00.00000001',
+                             '1970-01-01 00:00:00.00000002'])
+
+        for dtype in [np.int64, np.int32, np.int16, np.int8]:
+            arr = np.array([0, 10, 20], dtype=dtype)
+            tm.assert_index_equal(DatetimeIndex(arr), exp)
+
     def test_normalize(self):
         rng = date_range('1/1/2000 9:30', periods=10, freq='D')
 


### PR DESCRIPTION
- [x] 1st issue of  #13721
- [x] tests added / passed
  - passed appveyor (2nd job failure is caused by the same test as #13714)
  - https://ci.appveyor.com/project/sinhrks/pandas-2dhxb/build/1.0.375
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] no whatsnew, as it is a regression caused by #13692.
