### PR TITLE
TST/BUG: Added more tests for Period(NaT)

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -527,9 +527,12 @@ Previous Behavior:
 
 New Behavior:
 
+These result in ``pd.NaT`` without providing ``freq`` option.
+
 .. ipython:: python
 
    pd.Period('NaT')
+   pd.Period(None)
 
 
 To be compat with ``Period`` addition and subtraction, ``pd.NaT`` now supports addition and subtraction with ``int``. Previously it raises ``ValueError``.
@@ -548,6 +551,7 @@ New Behavior:
 
    pd.NaT + 1
    pd.NaT - 1
+
 
 .. _whatsnew_0190.api.difference:
 
@@ -701,6 +705,8 @@ Bug Fixes
 
 - Bug in ``Series`` arithmetic raises ``TypeError`` if it contains datetime-like as ``object`` dtype (:issue:`13043`)
 
+- Bug ``Series.isnull`` and ``Series.notnull`` ignore ``Period('NaT')``  (:issue:`13737`)
+- Bug ``Series.fillna`` and ``Series.dropna`` don't affect to ``Period('NaT')``  (:issue:`13737`)
 
 - Bug in ``pd.to_datetime()`` when passing invalid datatypes (e.g. bool); will now respect the ``errors`` keyword (:issue:`13176`)
 - Bug in ``pd.to_datetime()`` which overflowed on ``int8``, and ``int16`` dtypes (:issue:`13451`)

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -4294,6 +4294,36 @@ class TestSeriesPeriod(tm.TestCase):
         exp = Series(period_range('1/1/2000', periods=10))
         tm.assert_series_equal(s, exp)
 
+    def test_isnull(self):
+        # GH 13737
+        s = Series([pd.Period('2011-01', freq='M'),
+                    pd.Period('NaT', freq='M')])
+        tm.assert_series_equal(s.isnull(), Series([False, True]))
+        tm.assert_series_equal(s.notnull(), Series([True, False]))
+
+    def test_fillna(self):
+        # GH 13737
+        s = Series([pd.Period('2011-01', freq='M'),
+                    pd.Period('NaT', freq='M')])
+
+        res = s.fillna(pd.Period('2012-01', freq='M'))
+        exp = Series([pd.Period('2011-01', freq='M'),
+                      pd.Period('2012-01', freq='M')])
+        tm.assert_series_equal(res, exp)
+        self.assertEqual(res.dtype, 'object')
+
+        res = s.fillna('XXX')
+        exp = Series([pd.Period('2011-01', freq='M'), 'XXX'])
+        tm.assert_series_equal(res, exp)
+        self.assertEqual(res.dtype, 'object')
+
+    def test_dropna(self):
+        # GH 13737
+        s = Series([pd.Period('2011-01', freq='M'),
+                    pd.Period('NaT', freq='M')])
+        tm.assert_series_equal(s.dropna(),
+                               Series([pd.Period('2011-01', freq='M')]))
+
     def test_series_comparison_scalars(self):
         val = pd.Period('2000-01-04', freq='D')
         result = self.series > val


### PR DESCRIPTION
- [x] follow-up of #12759
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
- because `Period(NaT)` had separate impl until #12579, there were some bugs related to `pd.isnull`. Now all the issues are fixed, thus added explicit tests and what's new. 
- Also updated what's new to describe `Period(None)` (related to #13723).

**0.18.1:**

```
s = pd.Series([pd.Period('2011-01', freq='M'), pd.Period('NaT', freq='M')])
s.isnull()
#0    False
#1    False
# dtype: bool

s.fillna(pd.Period('2012-01', freq='M'))
#0   2011-01
#1       NaT
# dtype: object

s.dropna()
#0   2011-01
#1       NaT
# dtype: object
```
