### PR TITLE
PERF: RangeIndex.is_monotonic_inc/dec

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -649,6 +649,7 @@ Performance Improvements
 - Improved performance of float64 hash table operations, fixing some very slow indexing and groupby operations in python 3 (:issue:`13166`, :issue:`13334`)
 - Improved performance of ``DataFrameGroupBy.transform`` (:issue:`12737`)
 - Improved performance of ``Index.difference`` (:issue:`12044`)
+- Improved performance of ``RangeIndex.is_monotonic_increasing`` and ``is_monotonic_decreasing`` (:issue:`13749`)
 - Improved performance of datetime string parsing in ``DatetimeIndex`` (:issue:`13692`)
 - Improved performance of hashing ``Period`` (:issue:`12817`)
 

--- a/pandas/indexes/range.py
+++ b/pandas/indexes/range.py
@@ -221,6 +221,14 @@ class RangeIndex(Int64Index):
         """ return if the index has unique values """
         return True
 
+    @cache_readonly
+    def is_monotonic_increasing(self):
+        return self._step > 0 or len(self) <= 1
+
+    @cache_readonly
+    def is_monotonic_decreasing(self):
+        return self._step < 0 or len(self) <= 1
+
     @property
     def has_duplicates(self):
         return False

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -315,6 +315,16 @@ class TestRangeIndex(Numeric, tm.TestCase):
         self.assertTrue(index.is_monotonic_increasing)
         self.assertTrue(index.is_monotonic_decreasing)
 
+        index = RangeIndex(2, 1)
+        self.assertTrue(index.is_monotonic)
+        self.assertTrue(index.is_monotonic_increasing)
+        self.assertTrue(index.is_monotonic_decreasing)
+
+        index = RangeIndex(1, 1)
+        self.assertTrue(index.is_monotonic)
+        self.assertTrue(index.is_monotonic_increasing)
+        self.assertTrue(index.is_monotonic_decreasing)
+
     def test_equals(self):
         equiv_pairs = [(RangeIndex(0, 9, 2), RangeIndex(0, 10, 2)),
                        (RangeIndex(0), RangeIndex(1, -1, 3)),


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

as the same as `is_unique`, it should be monotonic by definition

```
%timeit -n 1 -r 1 pd.RangeIndex(0, 1000000).is_monotonic_increasing

# current master
#1 loop, best of 1: 17.2 ms per loop

# this PR
#1 loop, best of 1: 45.1 µs per loop
```
