### PR TITLE
PERF: Improve duplicated perf

### DIFF
--- a/asv_bench/benchmarks/algorithms.py
+++ b/asv_bench/benchmarks/algorithms.py
@@ -7,6 +7,11 @@ class algorithm(object):
 
     def setup(self):
         N = 100000
+
+        self.int_unique = pd.Int64Index(np.arange(N * 5))
+        # cache is_unique
+        self.int_unique.is_unique
+
         self.int = pd.Int64Index(np.arange(N).repeat(5))
         self.float = pd.Float64Index(np.random.randn(N).repeat(5))
 
@@ -15,3 +20,12 @@ class algorithm(object):
 
     def time_float_factorize(self):
         self.int.factorize()
+
+    def time_int_unique_duplicated(self):
+        self.int_unique.duplicated()
+
+    def time_int_duplicated(self):
+        self.int.duplicated()
+
+    def time_float_duplicated(self):
+        self.float.duplicated()

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -650,6 +650,7 @@ Performance Improvements
 
 - Improved performance of float64 hash table operations, fixing some very slow indexing and groupby operations in python 3 (:issue:`13166`, :issue:`13334`)
 - Improved performance of ``DataFrameGroupBy.transform`` (:issue:`12737`)
+- Improved performance of ``Index`` and ``Series`` ``.duplicated`` (:issue:`10235`)
 - Improved performance of ``Index.difference`` (:issue:`12044`)
 - Improved performance of datetime string parsing in ``DatetimeIndex`` (:issue:`13692`)
 - Improved performance of hashing ``Period`` (:issue:`12817`)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -8,7 +8,8 @@ import numpy as np
 
 from pandas import compat, lib, tslib, _np_version_under1p8
 from pandas.types.cast import _maybe_promote
-from pandas.types.generic import ABCPeriodIndex, ABCDatetimeIndex
+from pandas.types.generic import (ABCSeries, ABCIndex, ABCPeriodIndex,
+                                  ABCDatetimeIndex)
 from pandas.types.common import (is_integer_dtype,
                                  is_int64_dtype,
                                  is_categorical_dtype,
@@ -446,6 +447,53 @@ def _value_counts_arraylike(values, dropna=True):
             counts = np.insert(counts, 0, mask.sum())
 
     return keys, counts
+
+
+def duplicated(values, keep='first'):
+    """
+    Return boolean ndarray denoting duplicate values
+
+    Parameters
+    ----------
+    keep : {'first', 'last', False}, default 'first'
+        - ``first`` : Mark duplicates as ``True`` except for the first
+          occurrence.
+        - ``last`` : Mark duplicates as ``True`` except for the last
+          occurrence.
+        - False : Mark all duplicates as ``True``.
+
+    Returns
+    -------
+    duplicated : ndarray
+    """
+
+    dtype = values.dtype
+
+    # no need to revert to original type
+    if is_datetime_or_timedelta_dtype(dtype) or is_datetimetz(dtype):
+        if isinstance(values, (ABCSeries, ABCIndex)):
+            values = values.values.view(np.int64)
+        else:
+            values = values.view(np.int64)
+    elif is_period_arraylike(values):
+        from pandas.tseries.period import PeriodIndex
+        values = PeriodIndex(values).asi8
+    elif is_categorical_dtype(dtype):
+        values = values.values.codes
+    elif isinstance(values, (ABCSeries, ABCIndex)):
+        values = values.values
+
+    if is_integer_dtype(dtype):
+        values = _ensure_int64(values)
+        duplicated = htable.duplicated_int64(values, keep=keep)
+    elif is_float_dtype(dtype):
+        values = _ensure_float64(values)
+        duplicated = htable.duplicated_float64(values, keep=keep)
+    else:
+        values = _ensure_object(values)
+        duplicated = htable.duplicated_object(values, keep=keep)
+
+    return duplicated
 
 
 def mode(values):

--- a/pandas/lib.pyx
+++ b/pandas/lib.pyx
@@ -1394,46 +1394,6 @@ def fast_zip_fillna(list ndarrays, fill_value=pandas_null):
     return result
 
 
-def duplicated(ndarray[object] values, object keep='first'):
-    cdef:
-        Py_ssize_t i, n
-        dict seen = dict()
-        object row
-
-    n = len(values)
-    cdef ndarray[uint8_t] result = np.zeros(n, dtype=np.uint8)
-
-    if keep == 'last':
-        for i from n > i >= 0:
-            row = values[i]
-            if row in seen:
-                result[i] = 1
-            else:
-                seen[row] = i
-                result[i] = 0
-    elif keep == 'first':
-        for i from 0 <= i < n:
-            row = values[i]
-            if row in seen:
-                result[i] = 1
-            else:
-                seen[row] = i
-                result[i] = 0
-    elif keep is False:
-        for i from 0 <= i < n:
-            row = values[i]
-            if row in seen:
-                result[i] = 1
-                result[seen[row]] = 1
-            else:
-                seen[row] = i
-                result[i] = 0
-    else:
-        raise ValueError('keep must be either "first", "last" or False')
-
-    return result.view(np.bool_)
-
-
 def generate_slices(ndarray[int64_t] labels, Py_ssize_t ngroups):
     cdef:
         Py_ssize_t i, group_size, n, start

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -1860,7 +1860,7 @@ class TestMultiIndex(Base, tm.TestCase):
 
         for keep in ['first', 'last', False]:
             left = mi.duplicated(keep=keep)
-            right = pd.lib.duplicated(mi.values, keep=keep)
+            right = pd.hashtable.duplicated_object(mi.values, keep=keep)
             tm.assert_numpy_array_equal(left, right)
 
         # GH5873

--- a/pandas/tests/test_lib.py
+++ b/pandas/tests/test_lib.py
@@ -234,45 +234,6 @@ class TestNullObj(tm.TestCase):
         self._check_behavior(arr, expected)
 
 
-def test_duplicated_with_nas():
-    keys = np.array([0, 1, np.nan, 0, 2, np.nan], dtype=object)
-
-    result = lib.duplicated(keys)
-    expected = [False, False, False, True, False, True]
-    assert (np.array_equal(result, expected))
-
-    result = lib.duplicated(keys, keep='first')
-    expected = [False, False, False, True, False, True]
-    assert (np.array_equal(result, expected))
-
-    result = lib.duplicated(keys, keep='last')
-    expected = [True, False, True, False, False, False]
-    assert (np.array_equal(result, expected))
-
-    result = lib.duplicated(keys, keep=False)
-    expected = [True, False, True, True, False, True]
-    assert (np.array_equal(result, expected))
-
-    keys = np.empty(8, dtype=object)
-    for i, t in enumerate(zip([0, 0, np.nan, np.nan] * 2,
-                              [0, np.nan, 0, np.nan] * 2)):
-        keys[i] = t
-
-    result = lib.duplicated(keys)
-    falses = [False] * 4
-    trues = [True] * 4
-    expected = falses + trues
-    assert (np.array_equal(result, expected))
-
-    result = lib.duplicated(keys, keep='last')
-    expected = trues + falses
-    assert (np.array_equal(result, expected))
-
-    result = lib.duplicated(keys, keep=False)
-    expected = trues + trues
-    assert (np.array_equal(result, expected))
-
-
 if __name__ == '__main__':
     import nose
 


### PR DESCRIPTION
- [x] closes #10235
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

`Index/Series.duplicated` now uses dtype-based logic. Also skip algorithm if `Index.is_unique` is `True` (expected to be cached in practical situation).

**asv:**

```
   before     after       ratio
  [bb6b5e54] [16c6da4f]
-   34.41ms     4.69ms      0.14  algorithms.algorithm.time_int_duplicated
-   53.77ms     5.59ms      0.10  algorithms.algorithm.time_float_duplicated
-   60.22ms    40.20μs      0.00  algorithms.algorithm.time_int_unique_duplicated
SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```

**NOTE:** can create template for htable after #13716.
