### PR TITLE
BUG: union_categoricals can't handle NaN

### DIFF
--- a/pandas/types/concat.py
+++ b/pandas/types/concat.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas.tslib as tslib
 from pandas import compat
 from pandas.compat import map
+from pandas.core.algorithms import take_1d
 from .common import (is_categorical_dtype,
                      is_sparse,
                      is_datetimetz,
@@ -254,10 +255,15 @@ def union_categoricals(to_union):
 
     new_codes = []
     for c in to_union:
-        indexer = categories.get_indexer(c.categories)
-        new_codes.append(indexer.take(c.codes))
-    codes = np.concatenate(new_codes)
-    return Categorical(codes, categories=categories, ordered=False,
+        if len(c.categories) > 0:
+            indexer = categories.get_indexer(c.categories)
+            new_codes.append(take_1d(indexer, c.codes, fill_value=-1))
+        else:
+            # must be all NaN
+            new_codes.append(c.codes)
+
+    new_codes = np.concatenate(new_codes)
+    return Categorical(new_codes, categories=categories, ordered=False,
                        fastpath=True)
 
 


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew not needed

`union_categoricals` doesn't handle `NaN` properly.

**on current master:**

```
from pandas.types.concat import union_categoricals
union_categoricals([pd.Categorical([np.nan, 1]), pd.Categorical([2, np.nan])])
# [1, 1, 2, 2]
# Categories (2, int64): [1, 2]

union_categoricals([pd.Categorical([np.nan]), pd.Categorical([np.nan])])
# IndexError: cannot do a non-empty take from an empty axes.
```
