### PR TITLE
DOC: fix slashes in read_csv line_terminator/sep kwargs descriptions

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1306,7 +1306,7 @@ class DataFrame(NDFrame):
                quotechar='"', line_terminator='\n', chunksize=None,
                tupleize_cols=False, date_format=None, doublequote=True,
                escapechar=None, decimal='.', **kwds):
-        """Write DataFrame to a comma-separated values (csv) file
+        r"""Write DataFrame to a comma-separated values (csv) file
 
         Parameters
         ----------
@@ -1343,7 +1343,7 @@ class DataFrame(NDFrame):
             a string representing the compression to use in the output file,
             allowed values are 'gzip', 'bz2', 'xz',
             only used when the first argument is a filename
-        line_terminator : string, default '\\n'
+        line_terminator : string, default ``'\n'``
             The newline character or character sequence to use in the output
             file
         quoting : optional constant from csv module

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -277,11 +277,11 @@ _engine_doc = """engine : {'c', 'python'}, optional
     Parser engine to use. The C engine is faster while the python engine is
     currently more feature-complete."""
 
-_sep_doc = """sep : str, default {default}
+_sep_doc = r"""sep : str, default {default}
     Delimiter to use. If sep is None, will try to automatically determine
-    this. Separators longer than 1 character and different from '\s+' will be
-    interpreted as regular expressions, will force use of the python parsing
-    engine and will ignore quotes in the data. Regex example: '\\r\\t'"""
+    this. Separators longer than 1 character and different from ``'\s+'`` will
+    be interpreted as regular expressions, will force use of the python parsing
+    engine and will ignore quotes in the data. Regex example: ``'\r\t'``"""
 
 _read_csv_doc = """
 Read CSV (comma-separated) file into DataFrame


### PR DESCRIPTION
- [x] closes #13738
- [ ] tests added / passed
- [ ] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry

Added additional '\' characters in order to produce the correct format in the documentation.
