### PR TITLE
BUG: RangeIndex accepting length-1 arrays as argument

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -979,6 +979,7 @@ Bug Fixes
 - Bugs in ``Index.difference`` and ``DataFrame.join`` raise in Python3 when using mixed-integer indexes (:issue:`13432`, :issue:`12814`)
 - Bug in ``.to_excel()`` when DataFrame contains a MultiIndex which contains a label with a NaN value (:issue:`13511`)
 - Bug in invalid frequency offset string like "D1", "-2-3H" may not raise ``ValueError (:issue:`13930`)
+- Bug in ``concat`` and ``groupby`` for hierarchical frames with ``RangeIndex`` levels (:issue:`13542`).
 
 - Bug in ``agg()`` function on groupby dataframe changes dtype of ``datetime64[ns]`` column to ``float64`` (:issue:`12821`)
 

--- a/pandas/indexes/range.py
+++ b/pandas/indexes/range.py
@@ -58,15 +58,17 @@ class RangeIndex(Int64Index):
 
         # validate the arguments
         def _ensure_int(value, field):
+            msg = ("RangeIndex(...) must be called with integers,"
+                   " {value} was passed for {field}")
+            if not is_scalar(value):
+                raise TypeError(msg.format(value=type(value).__name__,
+                                           field=field))
             try:
                 new_value = int(value)
                 assert(new_value == value)
-            except (ValueError, AssertionError):
-                raise TypeError("RangeIndex(...) must be called with integers,"
-                                " {value} was passed for {field}".format(
-                                    value=type(value).__name__,
-                                    field=field)
-                                )
+            except (TypeError, ValueError, AssertionError):
+                raise TypeError(msg.format(value=type(value).__name__,
+                                           field=field))
 
             return new_value
 

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -102,7 +102,8 @@ class TestRangeIndex(Numeric, tm.TestCase):
 
         # invalid args
         for i in [Index(['a', 'b']), Series(['a', 'b']), np.array(['a', 'b']),
-                  [], 'foo', datetime(2000, 1, 1, 0, 0), np.arange(0, 10)]:
+                  [], 'foo', datetime(2000, 1, 1, 0, 0), np.arange(0, 10),
+                  np.array([1]), [1]]:
             self.assertRaises(TypeError, lambda: RangeIndex(i))
 
     def test_constructor_same(self):

--- a/pandas/tools/tests/test_concat.py
+++ b/pandas/tools/tests/test_concat.py
@@ -1444,6 +1444,20 @@ bar2,12,13,14,15
         tm.assert_frame_equal(res, exp, check_index_type=True,
                               check_column_type=True)
 
+    def test_concat_multiindex_rangeindex(self):
+        # GH13542
+        # when multi-index levels are RangeIndex objects
+        # there is a bug in concat with objects of len 1
+
+        df = DataFrame(np.random.randn(9, 2))
+        df.index = MultiIndex(levels=[pd.RangeIndex(3), pd.RangeIndex(3)],
+                              labels=[np.repeat(np.arange(3), 3),
+                                      np.tile(np.arange(3), 3)])
+
+        res = concat([df.iloc[[2, 3, 4], :], df.iloc[[5], :]])
+        exp = df.iloc[[2, 3, 4, 5], :]
+        tm.assert_frame_equal(res, exp)
+
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
- [x] closes #13542
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
