### PR TITLE
BUG: datetime64[us] arrays with NaT cannot be cast to DatetimeIndex

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -747,6 +747,8 @@ Bug Fixes
 - Bug in invalid datetime parsing in ``to_datetime`` and ``DatetimeIndex`` may raise ``TypeError`` rather than ``ValueError`` (:issue:`11169`, :issue:`11287`)
 - Bug in ``Index`` created with tz-aware ``Timestamp`` and mismatched ``tz`` option incorrectly coerces timezone (:issue:`13692`)
 - Bug in ``DatetimeIndex`` with nanosecond frequency does not include timestamp specified with ``end`` (:issue:`13672`)
+- Bug in ``DatetimeIndex`` may raise ``OutOfBoundsDatetime`` if input ``np.datetime64`` has other unit than ``ns`` (:issue:`9114`)
+
 
 - Bug in ``Categorical.remove_unused_categories()`` changes ``.codes`` dtype to platform int (:issue:`13261`)
 - Bug in ``groupby`` with ``as_index=False`` returns all NaN's when grouping on multiple columns including a categorical one (:issue:`13204`)

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1595,6 +1595,17 @@ class TestTimeSeries(tm.TestCase):
             arr = np.array([0, 10, 20], dtype=dtype)
             tm.assert_index_equal(DatetimeIndex(arr), exp)
 
+    def test_dti_constructor_numpy_timeunits(self):
+        # GH 9114
+        base = pd.to_datetime(['2000-01-01T00:00', '2000-01-02T00:00', 'NaT'])
+
+        for dtype in ['datetime64[h]', 'datetime64[m]', 'datetime64[s]',
+                      'datetime64[ms]', 'datetime64[us]', 'datetime64[ns]']:
+            values = base.values.astype(dtype)
+
+            tm.assert_index_equal(DatetimeIndex(values), base)
+            tm.assert_index_equal(to_datetime(values), base)
+
     def test_normalize(self):
         rng = date_range('1/1/2000 9:30', periods=10, freq='D')
 


### PR DESCRIPTION
- [x] closes #9114
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Fixed by #13692. Added tests.
