### PR TITLE
DOC: show failing string on numeric parse

### DIFF
--- a/pandas/src/inference.pyx
+++ b/pandas/src/inference.pyx
@@ -686,7 +686,7 @@ def maybe_convert_numeric(object[:] values, set na_values,
                             raise ValueError('integer out of range')
                     else:
                         seen_float = True
-            except:
+            except (TypeError, ValueError):
                 if not coerce_numeric:
                     raise
 

--- a/pandas/src/inference.pyx
+++ b/pandas/src/inference.pyx
@@ -686,9 +686,9 @@ def maybe_convert_numeric(object[:] values, set na_values,
                             raise ValueError('integer out of range')
                     else:
                         seen_float = True
-            except (TypeError, ValueError):
+            except (TypeError, ValueError) as e:
                 if not coerce_numeric:
-                    raise
+                    raise type(e)(e.message + ' in row {}'.format(i))
 
                 floats[i] = nan
                 seen_float = True

--- a/pandas/src/inference.pyx
+++ b/pandas/src/inference.pyx
@@ -688,7 +688,7 @@ def maybe_convert_numeric(object[:] values, set na_values,
                         seen_float = True
             except (TypeError, ValueError) as e:
                 if not coerce_numeric:
-                    raise type(e)(e.message + ' in row {}'.format(i))
+                    raise type(e)(str(e) + ' at array index {}'.format(i))
 
                 floats[i] = nan
                 seen_float = True

--- a/pandas/src/inference.pyx
+++ b/pandas/src/inference.pyx
@@ -688,7 +688,7 @@ def maybe_convert_numeric(object[:] values, set na_values,
                         seen_float = True
             except (TypeError, ValueError) as e:
                 if not coerce_numeric:
-                    raise type(e)(str(e) + ' at array index {}'.format(i))
+                    raise type(e)(str(e) + ' at position {}'.format(i))
 
                 floats[i] = nan
                 seen_float = True

--- a/pandas/src/parse_helper.h
+++ b/pandas/src/parse_helper.h
@@ -66,7 +66,7 @@ int floatify(PyObject* str, double *result, int *maybe_int) {
     return 0;
 
 parsingerror:
-    PyErr_SetString(PyExc_ValueError, "Unable to parse string");
+    PyErr_Format(PyExc_ValueError, "Unable to parse string \"%s\"", data);
     Py_XDECREF(tmp);
     return -1;
 

--- a/pandas/tools/tests/test_util.py
+++ b/pandas/tools/tests/test_util.py
@@ -120,7 +120,7 @@ class TestToNumeric(tm.TestCase):
 
     def test_error(self):
         s = pd.Series([1, -3.14, 'apple'])
-        msg = 'Unable to parse string "apple" at array index 2'
+        msg = 'Unable to parse string "apple" at position 2'
         with tm.assertRaisesRegexp(ValueError, msg):
             to_numeric(s, errors='raise')
 
@@ -133,13 +133,13 @@ class TestToNumeric(tm.TestCase):
         tm.assert_series_equal(res, expected)
 
         s = pd.Series(['orange', 1, -3.14, 'apple'])
-        msg = 'Unable to parse string "orange" at array index 0'
+        msg = 'Unable to parse string "orange" at position 0'
         with tm.assertRaisesRegexp(ValueError, msg):
             to_numeric(s, errors='raise')
 
     def test_error_seen_bool(self):
         s = pd.Series([True, False, 'apple'])
-        msg = 'Unable to parse string "apple" at array index 2'
+        msg = 'Unable to parse string "apple" at position 2'
         with tm.assertRaisesRegexp(ValueError, msg):
             to_numeric(s, errors='raise')
 

--- a/pandas/tools/tests/test_util.py
+++ b/pandas/tools/tests/test_util.py
@@ -120,7 +120,7 @@ class TestToNumeric(tm.TestCase):
 
     def test_error(self):
         s = pd.Series([1, -3.14, 'apple'])
-        msg = 'Unable to parse string "apple"'
+        msg = 'Unable to parse string "apple" in row 2'
         with tm.assertRaisesRegexp(ValueError, msg):
             to_numeric(s, errors='raise')
 
@@ -132,14 +132,14 @@ class TestToNumeric(tm.TestCase):
         expected = pd.Series([1, -3.14, np.nan])
         tm.assert_series_equal(res, expected)
 
-        s = pd.Series([1, -3.14, 'apple', 'orange'])
-        msg = 'Unable to parse string "apple"'
+        s = pd.Series(['orange', 1, -3.14, 'apple'])
+        msg = 'Unable to parse string "orange" in row 0'
         with tm.assertRaisesRegexp(ValueError, msg):
             to_numeric(s, errors='raise')
 
     def test_error_seen_bool(self):
         s = pd.Series([True, False, 'apple'])
-        msg = 'Unable to parse string "apple"'
+        msg = 'Unable to parse string "apple" in row 2'
         with tm.assertRaisesRegexp(ValueError, msg):
             to_numeric(s, errors='raise')
 

--- a/pandas/tools/tests/test_util.py
+++ b/pandas/tools/tests/test_util.py
@@ -120,7 +120,7 @@ class TestToNumeric(tm.TestCase):
 
     def test_error(self):
         s = pd.Series([1, -3.14, 'apple'])
-        msg = 'Unable to parse string "apple" in row 2'
+        msg = 'Unable to parse string "apple" at array index 2'
         with tm.assertRaisesRegexp(ValueError, msg):
             to_numeric(s, errors='raise')
 
@@ -133,13 +133,13 @@ class TestToNumeric(tm.TestCase):
         tm.assert_series_equal(res, expected)
 
         s = pd.Series(['orange', 1, -3.14, 'apple'])
-        msg = 'Unable to parse string "orange" in row 0'
+        msg = 'Unable to parse string "orange" at array index 0'
         with tm.assertRaisesRegexp(ValueError, msg):
             to_numeric(s, errors='raise')
 
     def test_error_seen_bool(self):
         s = pd.Series([True, False, 'apple'])
-        msg = 'Unable to parse string "apple" in row 2'
+        msg = 'Unable to parse string "apple" at array index 2'
         with tm.assertRaisesRegexp(ValueError, msg):
             to_numeric(s, errors='raise')
 

--- a/pandas/tools/tests/test_util.py
+++ b/pandas/tools/tests/test_util.py
@@ -120,7 +120,8 @@ class TestToNumeric(tm.TestCase):
 
     def test_error(self):
         s = pd.Series([1, -3.14, 'apple'])
-        with tm.assertRaises(ValueError):
+        msg = 'Unable to parse string "apple"'
+        with tm.assertRaisesRegexp(ValueError, msg):
             to_numeric(s, errors='raise')
 
         res = to_numeric(s, errors='ignore')
@@ -131,9 +132,15 @@ class TestToNumeric(tm.TestCase):
         expected = pd.Series([1, -3.14, np.nan])
         tm.assert_series_equal(res, expected)
 
+        s = pd.Series([1, -3.14, 'apple', 'orange'])
+        msg = 'Unable to parse string "apple"'
+        with tm.assertRaisesRegexp(ValueError, msg):
+            to_numeric(s, errors='raise')
+
     def test_error_seen_bool(self):
         s = pd.Series([True, False, 'apple'])
-        with tm.assertRaises(ValueError):
+        msg = 'Unable to parse string "apple"'
+        with tm.assertRaisesRegexp(ValueError, msg):
             to_numeric(s, errors='raise')
 
         res = to_numeric(s, errors='ignore')


### PR DESCRIPTION
- [ ] related to #13746
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry not needed?

``` python
# before
In [7]: pd.to_numeric(['a'])
ValueError: Unable to parse string

# after
In [1]: pd.to_numeric(['a'])
ValueError: Unable to parse string "a" at position 0
```
