### PR TITLE
ENH: DataFrame.style sparsified MultiIndex

### DIFF
--- a/doc/source/html-styling.ipynb
+++ b/doc/source/html-styling.ipynb
@@ -792,6 +792,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# CSS Classes\n",
+    "\n",
+    "Certain CSS classes are attached to cells.\n",
+    "\n",
+    "- Index and Column names include `index_name` and `level<k>` where `k` is its level in a MultiIndex\n",
+    "- Index label cells include\n",
+    "  + `row_heading`\n",
+    "  + `row<n>` where `n` is the numeric position of the row\n",
+    "  + `level<k>` where `k` is the level in a MultiIndex\n",
+    "- Column label cells include\n",
+    "  + `col_heading`\n",
+    "  + `col<n>` where `n` is the numeric position of the column\n",
+    "  + `level<k>` where `k` is the level in a MultiIndex\n",
+    "- Blank cells include `blank`\n",
+    "- Data cells include `data`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Limitations\n",
     "\n",
     "- DataFrame only `(use Series.to_frame().style)`\n",

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -314,6 +314,7 @@ Other enhancements
 - ``Series.append`` now supports the ``ignore_index`` option (:issue:`13677`)
 - ``.to_stata()`` and ``StataWriter`` can now write variable labels to Stata dta files using a dictionary to make column names to labels (:issue:`13535`, :issue:`13536`)
 - ``.to_stata()`` and ``StataWriter`` will automatically convert ``datetime64[ns]`` columns to Stata format ``%tc``, rather than raising a ``ValueError`` (:issue:`12259`)
+- ``DataFrame.style`` will now render sparsified MultiIndexes (:issue:`11655`)
 - ``DataFrame`` has gained support to re-order the columns based on the values
   in a row using ``df.sort_values(by='...', axis=1)`` (:issue:`10806`)
 

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -315,6 +315,7 @@ Other enhancements
 - ``.to_stata()`` and ``StataWriter`` can now write variable labels to Stata dta files using a dictionary to make column names to labels (:issue:`13535`, :issue:`13536`)
 - ``.to_stata()`` and ``StataWriter`` will automatically convert ``datetime64[ns]`` columns to Stata format ``%tc``, rather than raising a ``ValueError`` (:issue:`12259`)
 - ``DataFrame.style`` will now render sparsified MultiIndexes (:issue:`11655`)
+- ``DataFrame.style`` will now show column level names (e.g. ``DataFrame.columns.names``) (:issue:`13775`)
 - ``DataFrame`` has gained support to re-order the columns based on the values
   in a row using ``df.sort_values(by='...', axis=1)`` (:issue:`10806`)
 
@@ -770,8 +771,8 @@ Bug Fixes
 - Bug in ``groupby`` with ``as_index=False`` returns all NaN's when grouping on multiple columns including a categorical one (:issue:`13204`)
 - Bug in ``df.groupby(...)[...]`` where getitem with ``Int64Index`` raised an error (:issue:`13731`)
 
+- Bug in the CSS classes assigned to ``DataFrame.style`` for index names. Previously they were assigned ``"col_heading level<n> col<c>"`` where ``n`` was the number of levels + 1. Now they are assigned ``"index_name level<n>"``, where ``n`` is the correct level for that MultiIndex.
 - Bug where ``pd.read_gbq()`` could throw ``ImportError: No module named discovery`` as a result of a naming conflict with another python package called apiclient  (:issue:`13454`)
 - Bug in ``Index.union`` returns an incorrect result with a named empty index (:issue:`13432`)
 - Bugs in ``Index.difference`` and ``DataFrame.join`` raise in Python3 when using mixed-integer indexes (:issue:`13432`, :issue:`12814`)
-
 - Bug in ``.to_excel()`` when DataFrame contains a MultiIndex which contains a label with a NaN value (:issue:`13511`)


### PR DESCRIPTION
- [x] closes #11655
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

[Notebook comparing `DataFrame._html_repr_` to `DataFrame.style`](https://gist.github.com/609c398f814b4a505bf4f406670e457e)

I think we're identical for non-truncated DataFrames. That' has not been implemented in `Styler` yet.

Along the way I noticed two other things that ended up needing fixing.
1. DataFrame.columns.names were not displayed
2. CSS classes weren't being assigned correctly to row labels.

The fixes ended up being pretty intertwined, so I've put them in a single PR. Unfortunately, the commits are a bit jumbled as well :/
