### PR TITLE
BUG: 13522. Copy index when assigning to a column

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2641,7 +2641,7 @@ class DataFrame(NDFrame):
             from pandas.core.series import _sanitize_index
 
             # turn me into an ndarray
-            value = _sanitize_index(value, self.index, copy=False)
+            value = _sanitize_index(value, self.index, copy=True)
             if not isinstance(value, (np.ndarray, Index)):
                 if isinstance(value, list) and len(value) > 0:
                     value = _possibly_convert_platform(value)


### PR DESCRIPTION
Small change to fix #13522. 

Upgrading from 0.17 to 0.18 caused .copy() to no longer be called.
