### PR TITLE
CLN: Removed copy parameter in xs_* methods

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -625,6 +625,7 @@ Removal of prior version deprecations/changes
 - ``DataFrame.to_sql()`` has dropped the ``mysql`` option for the ``flavor`` parameter (:issue:`13611`)
 - ``pd.Index`` has dropped the ``diff`` method in favour of ``difference`` (:issue:`13669`)
 
+- ``Series.xs``, ``DataFrame.xs``, ``Panel.xs``, ``Panel.major_xs``, and ``Panel.minor_xs`` have dropped the ``copy`` parameter (:issue:`13781`)
 - ``str.split`` has dropped the ``return_type`` parameter in favor of ``expand`` (:issue:`13701`)
 - Removal of the legacy time rules (offset aliases), deprecated since 0.17.0 (this has been alias since 0.8.0) (:issue:`13590`)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1671,7 +1671,7 @@ class NDFrame(PandasObject):
 
         return result
 
-    def xs(self, key, axis=0, level=None, copy=None, drop_level=True):
+    def xs(self, key, axis=0, level=None, drop_level=True):
         """
         Returns a cross-section (row(s) or column(s)) from the
         Series/DataFrame. Defaults to cross-section on the rows (axis=0).
@@ -1685,8 +1685,6 @@ class NDFrame(PandasObject):
         level : object, defaults to first n levels (n=1 or len(key))
             In case of a key partially contained in a MultiIndex, indicate
             which levels are used. Levels can be referred by label or position.
-        copy : boolean [deprecated]
-            Whether to make a copy of the data
         drop_level : boolean, default True
             If False, returns object with same levels as self.
 
@@ -1742,10 +1740,6 @@ class NDFrame(PandasObject):
         :ref:`MultiIndex Slicers <advanced.mi_slicers>`
 
         """
-        if copy is not None:
-            warnings.warn("copy keyword is deprecated, "
-                          "default is to return a copy or a view if possible")
-
         axis = self._get_axis_number(axis)
         labels = self._get_axis(axis)
         if level is not None:
@@ -1800,9 +1794,9 @@ class NDFrame(PandasObject):
             if not is_list_like(new_values) or self.ndim == 1:
                 return _maybe_box_datetimelike(new_values)
 
-            result = self._constructor_sliced(new_values, index=self.columns,
-                                              name=self.index[loc], copy=copy,
-                                              dtype=new_values.dtype)
+            result = self._constructor_sliced(
+                new_values, index=self.columns,
+                name=self.index[loc], dtype=new_values.dtype)
 
         else:
             result = self.iloc[loc]

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -758,7 +758,7 @@ class Panel(NDFrame):
 
         return self._constructor(result_values, items, major, minor)
 
-    def major_xs(self, key, copy=None):
+    def major_xs(self, key):
         """
         Return slice of panel along major axis
 
@@ -766,8 +766,6 @@ class Panel(NDFrame):
         ----------
         key : object
             Major axis label
-        copy : boolean [deprecated]
-            Whether to make a copy of the data
 
         Returns
         -------
@@ -783,13 +781,9 @@ class Panel(NDFrame):
         :ref:`MultiIndex Slicers <advanced.mi_slicers>`
 
         """
-        if copy is not None:
-            warnings.warn("copy keyword is deprecated, "
-                          "default is to return a copy or a view if possible")
-
         return self.xs(key, axis=self._AXIS_LEN - 2)
 
-    def minor_xs(self, key, copy=None):
+    def minor_xs(self, key):
         """
         Return slice of panel along minor axis
 
@@ -797,8 +791,6 @@ class Panel(NDFrame):
         ----------
         key : object
             Minor axis label
-        copy : boolean [deprecated]
-            Whether to make a copy of the data
 
         Returns
         -------
@@ -814,13 +806,9 @@ class Panel(NDFrame):
         :ref:`MultiIndex Slicers <advanced.mi_slicers>`
 
         """
-        if copy is not None:
-            warnings.warn("copy keyword is deprecated, "
-                          "default is to return a copy or a view if possible")
-
         return self.xs(key, axis=self._AXIS_LEN - 1)
 
-    def xs(self, key, axis=1, copy=None):
+    def xs(self, key, axis=1):
         """
         Return slice of panel along selected axis
 
@@ -829,8 +817,6 @@ class Panel(NDFrame):
         key : object
             Label
         axis : {'items', 'major', 'minor}, default 1/'major'
-        copy : boolean [deprecated]
-            Whether to make a copy of the data
 
         Returns
         -------
@@ -845,10 +831,6 @@ class Panel(NDFrame):
         :ref:`MultiIndex Slicers <advanced.mi_slicers>`
 
         """
-        if copy is not None:
-            warnings.warn("copy keyword is deprecated, "
-                          "default is to return a copy or a view if possible")
-
         axis = self._get_axis_number(axis)
         if axis == 0:
             return self[key]

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -2597,13 +2597,6 @@ def test_panel_index():
     tm.assert_index_equal(index, expected)
 
 
-def test_import_warnings():
-    # GH8152
-    panel = Panel(np.random.rand(3, 3, 3))
-    with assert_produces_warning():
-        panel.major_xs(1, copy=False)
-
-
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
                    exit=False)


### PR DESCRIPTION
Title is self-explanatory.  Picks up where #6919 left off.
