### PR TITLE
BUG: Slicing subclasses of SparseDataFrames.

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -379,6 +379,7 @@ API changes
 - The ``pd.read_json`` and ``DataFrame.to_json`` has gained support for reading and writing json lines with ``lines`` option see :ref:`Line delimited json <io.jsonl>` (:issue:`9180`)
 - ``pd.Timedelta(None)`` is now accepted and will return ``NaT``, mirroring ``pd.Timestamp`` (:issue:`13687`)
 - ``Timestamp``, ``Period``, ``DatetimeIndex``, ``PeriodIndex`` and ``.dt`` accessor have gained a ``.is_leap_year`` property to check whether the date belongs to a leap year. (:issue:`13727`)
+- Subclassed ``SparseDataFrame`` and ``SparseSeries`` now preserve class types when slicing or transposing. (:issue:`13787`)
 
 
 .. _whatsnew_0190.api.tolist:

--- a/pandas/io/tests/test_pickle.py
+++ b/pandas/io/tests/test_pickle.py
@@ -87,8 +87,9 @@ class TestPickle():
         return data
 
     def compare_sp_series_ts(self, res, exp, typ, version):
-        # SparseTimeSeries deprecated in 0.17.0
-        if version and LooseVersion(version) < "0.17.0":
+        # SparseTimeSeries integrated into SparseSeries in 0.12.0
+        # and deprecated in 0.17.0
+        if version and LooseVersion(version) <= "0.12.0":
             tm.assert_sp_series_equal(res, exp, check_series_type=False)
         else:
             tm.assert_sp_series_equal(res, exp)

--- a/pandas/io/tests/test_pickle.py
+++ b/pandas/io/tests/test_pickle.py
@@ -44,8 +44,15 @@ class TestPickle():
             return
 
         if typ.startswith('sp_'):
+            # SparseTimeSeries deprecated in 0.17.0
+            if (typ == "sp_series" and version and
+                    LooseVersion(version) < "0.17.0"):
+                check_kwargs = {"check_series_type": False}
+            else:
+                check_kwargs = {}
+
             comparator = getattr(tm, "assert_%s_equal" % typ)
-            comparator(result, expected, exact_indices=False)
+            comparator(result, expected, exact_indices=False, **check_kwargs)
         elif typ == 'timestamp':
             if expected is pd.NaT:
                 assert result is pd.NaT

--- a/pandas/io/tests/test_pickle.py
+++ b/pandas/io/tests/test_pickle.py
@@ -44,15 +44,8 @@ class TestPickle():
             return
 
         if typ.startswith('sp_'):
-            # SparseTimeSeries deprecated in 0.17.0
-            if (typ == "sp_series" and version and
-                    LooseVersion(version) < "0.17.0"):
-                check_kwargs = {"check_series_type": False}
-            else:
-                check_kwargs = {}
-
             comparator = getattr(tm, "assert_%s_equal" % typ)
-            comparator(result, expected, exact_indices=False, **check_kwargs)
+            comparator(result, expected, exact_indices=False)
         elif typ == 'timestamp':
             if expected is pd.NaT:
                 assert result is pd.NaT
@@ -92,6 +85,13 @@ class TestPickle():
                 comparator = getattr(self, comparator, self.compare_element)
                 comparator(result, expected, typ, version)
         return data
+
+    def compare_sp_series_ts(self, res, exp, typ, version):
+        # SparseTimeSeries deprecated in 0.17.0
+        if version and LooseVersion(version) < "0.17.0":
+            tm.assert_sp_series_equal(res, exp, check_series_type=False)
+        else:
+            tm.assert_sp_series_equal(res, exp)
 
     def compare_series_ts(self, result, expected, typ, version):
         # GH 7748

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -373,7 +373,9 @@ class SparseDataFrame(DataFrame):
             new_index = self.index
             new_columns = self.columns[slobj]
 
-        return self.reindex(index=new_index, columns=new_columns)
+        return self._constructor(data=self.reindex(index=new_index,
+                                                   columns=new_columns))\
+                   .__finalize__(self)
 
     def xs(self, key, axis=0, copy=False):
         """
@@ -519,7 +521,8 @@ class SparseDataFrame(DataFrame):
                 return self
 
         if len(self.index) == 0:
-            return SparseDataFrame(index=index, columns=self.columns)
+            return self._constructor(index=index, columns=self.columns)\
+                       .__finalize__(self)
 
         indexer = self.index.get_indexer(index, method, limit=limit)
         indexer = _ensure_platform_int(indexer)
@@ -540,8 +543,9 @@ class SparseDataFrame(DataFrame):
 
             new_series[col] = new
 
-        return SparseDataFrame(new_series, index=index, columns=self.columns,
-                               default_fill_value=self._default_fill_value)
+        return self._constructor(new_series, index=index, columns=self.columns,
+                                 default_fill_value=self._default_fill_value)\
+                   .__finalize__(self)
 
     def _reindex_columns(self, columns, copy, level, fill_value, limit=None,
                          takeable=False):

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -373,9 +373,9 @@ class SparseDataFrame(DataFrame):
             new_index = self.index
             new_columns = self.columns[slobj]
 
-        return self._constructor(data=self.reindex(index=new_index,
-                                                   columns=new_columns))\
-                   .__finalize__(self)
+        return self._constructor(
+            data=self.reindex(index=new_index,
+                              columns=new_columns)).__finalize__(self)
 
     def xs(self, key, axis=0, copy=False):
         """
@@ -521,8 +521,8 @@ class SparseDataFrame(DataFrame):
                 return self
 
         if len(self.index) == 0:
-            return self._constructor(index=index, columns=self.columns)\
-                       .__finalize__(self)
+            return self._constructor(
+                index=index, columns=self.columns).__finalize__(self)
 
         indexer = self.index.get_indexer(index, method, limit=limit)
         indexer = _ensure_platform_int(indexer)
@@ -543,9 +543,9 @@ class SparseDataFrame(DataFrame):
 
             new_series[col] = new
 
-        return self._constructor(new_series, index=index, columns=self.columns,
-                                 default_fill_value=self._default_fill_value)\
-                   .__finalize__(self)
+        return self._constructor(
+            new_series, index=index, columns=self.columns,
+            default_fill_value=self._default_fill_value).__finalize__(self)
 
     def _reindex_columns(self, columns, copy, level, fill_value, limit=None,
                          takeable=False):

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -188,7 +188,7 @@ class SparseDataFrame(DataFrame):
         return self._init_dict(data, index, columns, dtype)
 
     def __array_wrap__(self, result):
-        return SparseDataFrame(
+        return self._constructor(
             result, index=self.index, columns=self.columns,
             default_kind=self._default_kind,
             default_fill_value=self._default_fill_value).__finalize__(self)
@@ -373,9 +373,7 @@ class SparseDataFrame(DataFrame):
             new_index = self.index
             new_columns = self.columns[slobj]
 
-        return self._constructor(
-            data=self.reindex(index=new_index,
-                              columns=new_columns)).__finalize__(self)
+        return self.reindex(index=new_index, columns=new_columns)
 
     def xs(self, key, axis=0, copy=False):
         """
@@ -409,7 +407,7 @@ class SparseDataFrame(DataFrame):
             raise NotImplementedError("'level' argument is not supported")
 
         if self.empty and other.empty:
-            return SparseDataFrame(index=new_index).__finalize__(self)
+            return self._constructor(index=new_index).__finalize__(self)
 
         new_data = {}
         new_fill_value = None
@@ -560,8 +558,9 @@ class SparseDataFrame(DataFrame):
 
         # TODO: fill value handling
         sdict = dict((k, v) for k, v in compat.iteritems(self) if k in columns)
-        return SparseDataFrame(sdict, index=self.index, columns=columns,
-                               default_fill_value=self._default_fill_value)
+        return self._constructor(
+            sdict, index=self.index, columns=columns,
+            default_fill_value=self._default_fill_value).__finalize__(self)
 
     def _reindex_with_indexers(self, reindexers, method=None, fill_value=None,
                                limit=None, copy=False, allow_dups=False):
@@ -590,8 +589,8 @@ class SparseDataFrame(DataFrame):
             else:
                 new_arrays[col] = self[col]
 
-        return SparseDataFrame(new_arrays, index=index,
-                               columns=columns).__finalize__(self)
+        return self._constructor(new_arrays, index=index,
+                                 columns=columns).__finalize__(self)
 
     def _join_compat(self, other, on=None, how='left', lsuffix='', rsuffix='',
                      sort=False):
@@ -648,7 +647,7 @@ class SparseDataFrame(DataFrame):
         Returns a DataFrame with the rows/columns switched.
         """
         nv.validate_transpose(args, kwargs)
-        return SparseDataFrame(
+        return self._constructor(
             self.values.T, index=self.columns, columns=self.index,
             default_fill_value=self._default_fill_value,
             default_kind=self._default_kind).__finalize__(self)

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -63,11 +63,11 @@ def _arith_method(op, name, str_rep=None, default_axis=None, fill_zeros=None,
                 new_fill_value = op(np.float64(self.fill_value),
                                     np.float64(other))
 
-            return SparseSeries(op(self.sp_values, other),
-                                index=self.index,
-                                sparse_index=self.sp_index,
-                                fill_value=new_fill_value,
-                                name=self.name)
+            return self._constructor(op(self.sp_values, other),
+                                     index=self.index,
+                                     sparse_index=self.sp_index,
+                                     fill_value=new_fill_value,
+                                     name=self.name)
         else:  # pragma: no cover
             raise TypeError('operation with %s not supported' % type(other))
 
@@ -85,7 +85,7 @@ def _sparse_series_op(left, right, op, name):
     new_name = _maybe_match_name(left, right)
 
     result = _sparse_array_op(left, right, op, name)
-    return SparseSeries(result, index=new_index, name=new_name)
+    return left._constructor(result, index=new_index, name=new_name)
 
 
 class SparseSeries(Series):

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -226,7 +226,7 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         tm.assert_equal(ssdf.iloc[:2].testattr, "testattr")
         tm.assert_equal(ssdf[:2].testattr, "testattr")
 
-        tm.assert_sp_series_equal(ssdf.loc[1], 
+        tm.assert_sp_series_equal(ssdf.loc[1],
                                   tm.SubclassedSparseSeries(rows[1]),
                                   check_names=False)
         tm.assert_sp_series_equal(ssdf.iloc[1],

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -210,3 +210,17 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         tm.assert_series_equal(res1, exp2)
         tm.assertIsInstance(res2, tm.SubclassedDataFrame)
         tm.assert_frame_equal(res2, exp1)
+
+    def test_subclass_sparse_slice(self):
+        ssdf = tm.SubclassedSparseDataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        ssdf.testattr = "testattr"
+
+        tm.assertIsInstance(ssdf.loc[:2], tm.SubclassedSparseDataFrame)
+        tm.assertIsInstance(ssdf.iloc[:2], tm.SubclassedSparseDataFrame)
+        tm.assertIsInstance(ssdf[:2], tm.SubclassedSparseDataFrame)
+        tm.assert_equal(ssdf.loc[:2].testattr, "testattr")
+        tm.assert_equal(ssdf.iloc[:2].testattr, "testattr")
+        tm.assert_equal(ssdf[:2].testattr, "testattr")
+
+        tm.assertIsInstance(ssdf.loc[1], tm.SubclassedSparseSeries)
+        tm.assertIsInstance(ssdf.iloc[1], tm.SubclassedSparseSeries)

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -216,14 +216,19 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         ssdf = tm.SubclassedSparseDataFrame(rows)
         ssdf.testattr = "testattr"
 
-        tm.assert_sp_frame_equal(ssdf.loc[:2], tm.SubclassedSparseDataFrame(rows[:3]))
-        tm.assert_sp_frame_equal(ssdf.iloc[:2], tm.SubclassedSparseDataFrame(rows[:2]))
-        tm.assert_sp_frame_equal(ssdf[:2], tm.SubclassedSparseDataFrame(rows[:2]))
+        tm.assert_sp_frame_equal(ssdf.loc[:2],
+                                 tm.SubclassedSparseDataFrame(rows[:3]))
+        tm.assert_sp_frame_equal(ssdf.iloc[:2],
+                                 tm.SubclassedSparseDataFrame(rows[:2]))
+        tm.assert_sp_frame_equal(ssdf[:2],
+                                 tm.SubclassedSparseDataFrame(rows[:2]))
         tm.assert_equal(ssdf.loc[:2].testattr, "testattr")
         tm.assert_equal(ssdf.iloc[:2].testattr, "testattr")
         tm.assert_equal(ssdf[:2].testattr, "testattr")
 
-        tm.assert_sp_series_equal(ssdf.loc[1], tm.SubclassedSparseSeries(rows[1]),
+        tm.assert_sp_series_equal(ssdf.loc[1], 
+                                  tm.SubclassedSparseSeries(rows[1]),
                                   check_names=False)
-        tm.assert_sp_series_equal(ssdf.iloc[1], tm.SubclassedSparseSeries(rows[1]),
+        tm.assert_sp_series_equal(ssdf.iloc[1],
+                                  tm.SubclassedSparseSeries(rows[1]),
                                   check_names=False)

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -212,15 +212,18 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         tm.assert_frame_equal(res2, exp1)
 
     def test_subclass_sparse_slice(self):
-        ssdf = tm.SubclassedSparseDataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        rows = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]
+        ssdf = tm.SubclassedSparseDataFrame(rows)
         ssdf.testattr = "testattr"
 
-        tm.assertIsInstance(ssdf.loc[:2], tm.SubclassedSparseDataFrame)
-        tm.assertIsInstance(ssdf.iloc[:2], tm.SubclassedSparseDataFrame)
-        tm.assertIsInstance(ssdf[:2], tm.SubclassedSparseDataFrame)
+        tm.assert_sp_frame_equal(ssdf.loc[:2], tm.SubclassedSparseDataFrame(rows[:3]))
+        tm.assert_sp_frame_equal(ssdf.iloc[:2], tm.SubclassedSparseDataFrame(rows[:2]))
+        tm.assert_sp_frame_equal(ssdf[:2], tm.SubclassedSparseDataFrame(rows[:2]))
         tm.assert_equal(ssdf.loc[:2].testattr, "testattr")
         tm.assert_equal(ssdf.iloc[:2].testattr, "testattr")
         tm.assert_equal(ssdf[:2].testattr, "testattr")
 
-        tm.assertIsInstance(ssdf.loc[1], tm.SubclassedSparseSeries)
-        tm.assertIsInstance(ssdf.iloc[1], tm.SubclassedSparseSeries)
+        tm.assert_sp_series_equal(ssdf.loc[1], tm.SubclassedSparseSeries(rows[1]),
+                                  check_names=False)
+        tm.assert_sp_series_equal(ssdf.iloc[1], tm.SubclassedSparseSeries(rows[1]),
+                                  check_names=False)

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -232,3 +232,11 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         tm.assert_sp_series_equal(ssdf.iloc[1],
                                   tm.SubclassedSparseSeries(rows[1]),
                                   check_names=False)
+
+    def test_subclass_sparse_transpose(self):
+        ossdf = tm.SubclassedSparseDataFrame([[1, 2, 3],
+                                              [4, 5, 6]])
+        essdf = tm.SubclassedSparseDataFrame([[1, 4],
+                                              [2, 5],
+                                              [3, 6]])
+        tm.assert_sp_frame_equal(ossdf.T, essdf)

--- a/pandas/tests/series/test_subclass.py
+++ b/pandas/tests/series/test_subclass.py
@@ -31,3 +31,27 @@ class TestSeriesSubclassing(tm.TestCase):
         exp = tm.SubclassedDataFrame({'xxx': [1, 2, 3, 4]}, index=list('abcd'))
         tm.assert_frame_equal(res, exp)
         tm.assertIsInstance(res, tm.SubclassedDataFrame)
+
+    def test_subclass_sparse_slice(self):
+        s = tm.SubclassedSparseSeries([1, 2, 3, 4, 5])
+        tm.assert_sp_series_equal(s.loc[1:3],
+                                  tm.SubclassedSparseSeries([2.0, 3.0, 4.0],
+                                                            index=[1, 2, 3]))
+        tm.assert_sp_series_equal(s.iloc[1:3],
+                                  tm.SubclassedSparseSeries([2.0, 3.0],
+                                                            index=[1, 2]))
+        tm.assert_sp_series_equal(s[1:3],
+                                  tm.SubclassedSparseSeries([2.0, 3.0],
+                                                            index=[1, 2]))
+
+    def test_subclass_sparse_addition(self):
+        s1 = tm.SubclassedSparseSeries([1, 3, 5])
+        s2 = tm.SubclassedSparseSeries([-2, 5, 12])
+        tm.assert_sp_series_equal(s1 + s2,
+                                  tm.SubclassedSparseSeries([-1.0, 8.0, 17.0]))
+
+    def test_subclass_sparse_to_frame(self):
+        s = tm.SubclassedSparseSeries([1, 2], index=list('abcd'), name='xxx')
+        res = s.to_frame()
+        exp = tm.SubclassedSparseDataFrame({'xxx': [1, 2]}, index=list('abcd'))
+        tm.assert_sp_frame_equal(res, exp)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1429,7 +1429,10 @@ def assert_sp_series_equal(left, right, exact_indices=True,
     assertIsInstance(left, pd.SparseSeries, '[SparseSeries]')
     assertIsInstance(right, pd.SparseSeries, '[SparseSeries]')
 
-    if check_series_type:
+    # SparseTimeSeries is deprecated, some pickling checks fail on this condition
+    from pandas import SparseTimeSeries
+    if check_series_type and not (isinstance(left, SparseTimeSeries)
+                                  or isinstance(right, SparseTimeSeries)):
         assert_class_equal(left, right, obj=obj)
 
     assert_index_equal(left.index, right.index,

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1322,7 +1322,8 @@ def assert_panelnd_equal(left, right,
                          check_less_precise=False,
                          assert_func=assert_frame_equal,
                          check_names=False,
-                         by_blocks=False):
+                         by_blocks=False,
+                         obj='Panel'):
     """Check that left and right Panels are equal.
 
     Parameters
@@ -1343,6 +1344,9 @@ def assert_panelnd_equal(left, right,
     by_blocks : bool, default False
         Specify how to compare internal data. If False, compare by columns.
         If True, compare by blocks.
+    obj : str, default 'Panel'
+        Specify the object name being compared, internally used to show
+        the appropriate assertion message.
     """
 
     if check_panel_type:
@@ -1404,9 +1408,29 @@ def assert_sp_array_equal(left, right):
 
 
 def assert_sp_series_equal(left, right, exact_indices=True,
-                           check_names=True, obj='SparseSeries'):
+                           check_series_type=True,
+                           check_names=True,
+                           obj='SparseSeries'):
+    """Check that the left and right SparseSeries are equal.
+
+    Parameters
+    ----------
+    left : SparseSeries
+    right : SparseSeries
+    exact_indices : bool, default True
+    check_series_type : bool, default True
+        Whether to check the SparseSeries class is identical.
+    check_names : bool, default True
+        Whether to check the SparseSeries name attribute.
+    obj : str, default 'SparseSeries'
+        Specify the object name being compared, internally used to show
+        the appropriate assertion message.
+    """
     assertIsInstance(left, pd.SparseSeries, '[SparseSeries]')
     assertIsInstance(right, pd.SparseSeries, '[SparseSeries]')
+
+    if check_series_type:
+        assert_class_equal(left, right, obj=obj)
 
     assert_index_equal(left.index, right.index,
                        obj='{0}.index'.format(obj))
@@ -1421,13 +1445,28 @@ def assert_sp_series_equal(left, right, exact_indices=True,
 
 
 def assert_sp_frame_equal(left, right, exact_indices=True,
+                          check_frame_type=True,
                           obj='SparseDataFrame'):
-    """
-    exact: Series SparseIndex objects must be exactly the same, otherwise just
-    compare dense representations
+    """Check that the left and right SparseDataFrame are equal.
+
+    Parameters
+    ----------
+    left : SparseDataFrame
+    right : SparseDataFrame
+    exact_indices : bool, default True
+        SparseSeries SparseIndex objects must be exactly the same,
+        otherwise just compare dense representations.
+    check_frame_type : bool, default True
+        Whether to check the SparseDataFrame class is identical.
+    obj : str, default 'SparseDataFrame'
+        Specify the object name being compared, internally used to show
+        the appropriate assertion message.
     """
     assertIsInstance(left, pd.SparseDataFrame, '[SparseDataFrame]')
     assertIsInstance(right, pd.SparseDataFrame, '[SparseDataFrame]')
+
+    if check_frame_type:
+        assert_class_equal(left, right, obj=obj)
 
     assert_index_equal(left.index, right.index,
                        obj='{0}.index'.format(obj))

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1429,10 +1429,7 @@ def assert_sp_series_equal(left, right, exact_indices=True,
     assertIsInstance(left, pd.SparseSeries, '[SparseSeries]')
     assertIsInstance(right, pd.SparseSeries, '[SparseSeries]')
 
-    # SparseTimeSeries is deprecated, some pickling checks fail on this condition
-    from pandas import SparseTimeSeries
-    if check_series_type and not (isinstance(left, SparseTimeSeries)
-                                  or isinstance(right, SparseTimeSeries)):
+    if check_series_type:
         assert_class_equal(left, right, obj=obj)
 
     assert_index_equal(left.index, right.index,

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -2607,6 +2607,30 @@ class SubclassedDataFrame(DataFrame):
         return SubclassedSeries
 
 
+class SubclassedSparseSeries(pd.SparseSeries):
+    _metadata = ['testattr']
+
+    @property
+    def _constructor(self):
+        return SubclassedSparseSeries
+
+    @property
+    def _constructor_expanddim(self):
+        return SubclassedSparseDataFrame
+
+
+class SubclassedSparseDataFrame(pd.SparseDataFrame):
+    _metadata = ['testattr']
+
+    @property
+    def _constructor(self):
+        return SubclassedSparseDataFrame
+
+    @property
+    def _constructor_sliced(self):
+        return SubclassedSparseSeries
+
+
 @contextmanager
 def patch(ob, attr, value):
     """Temporarily patch an attribute of an object.


### PR DESCRIPTION
- [X] 1 test added & passed
- [X] passes `git diff upstream/master | flake8 --diff`

This changes `SparseDataFrame` to use proper subclassing functionality so slicing of subclasses of `SparseDataFrame` works. Example of a failure that this PR fixes:

``` python
import pandas as pd

class DenseSubclassDF(pd.DataFrame):
    _constructor = property(lambda self: DenseSubclassDF)
    _constructor_sliced = property(lambda self: DenseSubclassS)

class DenseSubclassS(pd.Series):
    _constructor = property(lambda self: DenseSubclassS)
    _constructor_expanddim = property(lambda self: DenseSubclassDF)

class SparseSubclassDF(pd.SparseDataFrame):
    _constructor = property(lambda self: SparseSubclassDF)
    _constructor_sliced = property(lambda self: SparseSubclassS)

class SparseSubclassS(pd.SparseSeries):
    _constructor = property(lambda self: SparseSubclassS)
    _constructor_expanddim = property(lambda self: SparseSubclassDF)

ddf = DenseSubclassDF([[1,2,3], [4,5,6], [7,8,9]])
sdf = SparseSubclassDF([[1,2,3], [4,5,6], [7,8,9]])

print(type(ddf.iloc[0]))  # <class '__main__.DenseSubclassS'>
print(type(ddf.iloc[:2]))  # <class '__main__.DenseSubclassDF'>
print(type(ddf[:2]))  # <class '__main__.DenseSubclassDF'>

# sparse doesn't preserve types
print(type(sdf.iloc[0]))  # <class '__main__.SparseSubclassS'>
print(type(sdf.iloc[:2]))  # <class 'pandas.sparse.frame.SparseDataFrame'>
print(type(sdf[:2]))  # <class 'pandas.sparse.frame.SparseDataFrame'>
```
