### PR TITLE
BUG: int dtype for get_dummies

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -371,6 +371,17 @@ Previous versions of pandas would permanently silence numpy's ufunc error handli
 
 After upgrading pandas, you may see *new* ``RuntimeWarnings`` being issued from your code. These are likely legitimate, and the underlying cause likely existed in the code when using previous versions of pandas that simply silenced the warning. Use `numpy.errstate <http://docs.scipy.org/doc/numpy/reference/generated/numpy.errstate.html>`__ around the source of the ``RuntimeWarning`` to control how these conditions are handled.
 
+get_dummies dtypes
+^^^^^^^^^^^^^^^^^^
+
+The ``pd.get_dummies`` function now returns dummy-encoded columns as integers, rather than floats
+
+.. ipython:: python
+
+   pd.get_dummies(['a', 'b', 'a', 'c']).dtypes
+
+Previously, this would have been a DataFrame of float columns (:issue:`8725`).
+
 .. _whatsnew_0190.enhancements.other:
 
 Other enhancements
@@ -477,7 +488,6 @@ API changes
 - ``pd.read_csv()`` in the C engine will now issue a ``ParserWarning`` or raise a ``ValueError`` when ``sep`` encoded is more than one character long (:issue:`14065`)
 - ``DataFrame.values`` will now return ``float64`` with a ``DataFrame`` of mixed ``int64`` and ``uint64`` dtypes, conforming to ``np.find_common_type`` (:issue:`10364`, :issue:`13917`)
 - ``Series.unique()`` with datetime and timezone now returns return array of ``Timestamp`` with timezone (:issue:`13565`)
-
 
 
 .. _whatsnew_0190.api.tolist:

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -1161,14 +1161,17 @@ def _get_dummies_1d(data, prefix, prefix_sep='_', dummy_na=False,
             sp_indices = sp_indices[1:]
             dummy_cols = dummy_cols[1:]
         for col, ixs in zip(dummy_cols, sp_indices):
-            sarr = SparseArray(np.ones(len(ixs)),
-                               sparse_index=IntIndex(N, ixs), fill_value=0)
+            sarr = SparseArray(np.ones(len(ixs), dtype=np.uint8),
+                               sparse_index=IntIndex(N, ixs), fill_value=0,
+                               dtype=np.uint8)
             sparse_series[col] = SparseSeries(data=sarr, index=index)
 
-        return SparseDataFrame(sparse_series, index=index, columns=dummy_cols)
+        out = SparseDataFrame(sparse_series, index=index, columns=dummy_cols,
+                              dtype=np.uint8)
+        return out
 
     else:
-        dummy_mat = np.eye(number_of_cols).take(codes, axis=0)
+        dummy_mat = np.eye(number_of_cols, dtype=np.uint8).take(codes, axis=0)
 
         if not dummy_na:
             # reset NaN GH4446

--- a/pandas/stats/tests/test_ols.py
+++ b/pandas/stats/tests/test_ols.py
@@ -645,6 +645,7 @@ class TestPanelOLS(BaseTest):
         exp_x = DataFrame([[0., 0., 14., 1.], [0, 1, 17, 1], [1, 0, 48, 1]],
                           columns=['x1_30', 'x1_9', 'x2', 'intercept'],
                           index=res.index, dtype=float)
+        exp_x[['x1_30', 'x1_9']] = exp_x[['x1_30', 'x1_9']].astype(np.uint8)
         assert_frame_equal(res, exp_x.reindex(columns=res.columns))
 
     def testWithXEffectsAndDroppedDummies(self):
@@ -659,6 +660,7 @@ class TestPanelOLS(BaseTest):
         exp_x = DataFrame([[1., 0., 14., 1.], [0, 1, 17, 1], [0, 0, 48, 1]],
                           columns=['x1_6', 'x1_9', 'x2', 'intercept'],
                           index=res.index, dtype=float)
+        exp_x[['x1_6', 'x1_9']] = exp_x[['x1_6', 'x1_9']].astype(np.uint8)
 
         assert_frame_equal(res, exp_x.reindex(columns=res.columns))
 

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -2429,18 +2429,18 @@ class TestLongPanel(tm.TestCase):
     def test_axis_dummies(self):
         from pandas.core.reshape import make_axis_dummies
 
-        minor_dummies = make_axis_dummies(self.panel, 'minor')
+        minor_dummies = make_axis_dummies(self.panel, 'minor').astype(np.uint8)
         self.assertEqual(len(minor_dummies.columns),
                          len(self.panel.index.levels[1]))
 
-        major_dummies = make_axis_dummies(self.panel, 'major')
+        major_dummies = make_axis_dummies(self.panel, 'major').astype(np.uint8)
         self.assertEqual(len(major_dummies.columns),
                          len(self.panel.index.levels[0]))
 
         mapping = {'A': 'one', 'B': 'one', 'C': 'two', 'D': 'two'}
 
         transformed = make_axis_dummies(self.panel, 'minor',
-                                        transform=mapping.get)
+                                        transform=mapping.get).astype(np.uint8)
         self.assertEqual(len(transformed.columns), 2)
         self.assert_index_equal(transformed.columns, Index(['one', 'two']))
 
@@ -2450,7 +2450,7 @@ class TestLongPanel(tm.TestCase):
         from pandas.core.reshape import get_dummies, make_axis_dummies
 
         self.panel['Label'] = self.panel.index.labels[1]
-        minor_dummies = make_axis_dummies(self.panel, 'minor')
+        minor_dummies = make_axis_dummies(self.panel, 'minor').astype(np.uint8)
         dummies = get_dummies(self.panel['Label'])
         self.assert_numpy_array_equal(dummies.values, minor_dummies.values)
 

--- a/pandas/tests/test_reshape.py
+++ b/pandas/tests/test_reshape.py
@@ -174,15 +174,15 @@ class TestGetDummies(tm.TestCase):
         s_series = Series(s_list)
         s_series_index = Series(s_list, list('ABC'))
 
-        expected = DataFrame({'a': {0: 1.0,
-                                    1: 0.0,
-                                    2: 0.0},
-                              'b': {0: 0.0,
-                                    1: 1.0,
-                                    2: 0.0},
-                              'c': {0: 0.0,
-                                    1: 0.0,
-                                    2: 1.0}})
+        expected = DataFrame({'a': {0: 1,
+                                    1: 0,
+                                    2: 0},
+                              'b': {0: 0,
+                                    1: 1,
+                                    2: 0},
+                              'c': {0: 0,
+                                    1: 0,
+                                    2: 1}}, dtype=np.uint8)
         assert_frame_equal(get_dummies(s_list, sparse=self.sparse), expected)
         assert_frame_equal(get_dummies(s_series, sparse=self.sparse), expected)
 
@@ -200,7 +200,7 @@ class TestGetDummies(tm.TestCase):
 
         if not self.sparse:
             exp_df_type = DataFrame
-            exp_blk_type = pd.core.internals.FloatBlock
+            exp_blk_type = pd.core.internals.IntBlock
         else:
             exp_df_type = SparseDataFrame
             exp_blk_type = pd.core.internals.SparseBlock
@@ -239,22 +239,24 @@ class TestGetDummies(tm.TestCase):
     def test_include_na(self):
         s = ['a', 'b', np.nan]
         res = get_dummies(s, sparse=self.sparse)
-        exp = DataFrame({'a': {0: 1.0, 1: 0.0, 2: 0.0},
-                         'b': {0: 0.0, 1: 1.0, 2: 0.0}})
+        exp = DataFrame({'a': {0: 1, 1: 0, 2: 0},
+                         'b': {0: 0, 1: 1, 2: 0}}, dtype=np.uint8)
         assert_frame_equal(res, exp)
 
         # Sparse dataframes do not allow nan labelled columns, see #GH8822
         res_na = get_dummies(s, dummy_na=True, sparse=self.sparse)
-        exp_na = DataFrame({nan: {0: 0.0, 1: 0.0, 2: 1.0},
-                            'a': {0: 1.0, 1: 0.0, 2: 0.0},
-                            'b': {0: 0.0, 1: 1.0, 2: 0.0}})
+        exp_na = DataFrame({nan: {0: 0, 1: 0, 2: 1},
+                            'a': {0: 1, 1: 0, 2: 0},
+                            'b': {0: 0, 1: 1, 2: 0}},
+                           dtype=np.uint8)
         exp_na = exp_na.reindex_axis(['a', 'b', nan], 1)
         # hack (NaN handling in assert_index_equal)
         exp_na.columns = res_na.columns
         assert_frame_equal(res_na, exp_na)
 
         res_just_na = get_dummies([nan], dummy_na=True, sparse=self.sparse)
-        exp_just_na = DataFrame(Series(1.0, index=[0]), columns=[nan])
+        exp_just_na = DataFrame(Series(1, index=[0]), columns=[nan],
+                                dtype=np.uint8)
         tm.assert_numpy_array_equal(res_just_na.values, exp_just_na.values)
 
     def test_unicode(self
@@ -264,31 +266,34 @@ class TestGetDummies(tm.TestCase):
         eacute = unicodedata.lookup('LATIN SMALL LETTER E WITH ACUTE')
         s = [e, eacute, eacute]
         res = get_dummies(s, prefix='letter', sparse=self.sparse)
-        exp = DataFrame({'letter_e': {0: 1.0,
-                                      1: 0.0,
-                                      2: 0.0},
-                         u('letter_%s') % eacute: {0: 0.0,
-                                                   1: 1.0,
-                                                   2: 1.0}})
+        exp = DataFrame({'letter_e': {0: 1,
+                                      1: 0,
+                                      2: 0},
+                         u('letter_%s') % eacute: {0: 0,
+                                                   1: 1,
+                                                   2: 1}},
+                        dtype=np.uint8)
         assert_frame_equal(res, exp)
 
     def test_dataframe_dummies_all_obj(self):
         df = self.df[['A', 'B']]
         result = get_dummies(df, sparse=self.sparse)
-        expected = DataFrame({'A_a': [1., 0, 1],
-                              'A_b': [0., 1, 0],
-                              'B_b': [1., 1, 0],
-                              'B_c': [0., 0, 1]})
+        expected = DataFrame({'A_a': [1, 0, 1],
+                              'A_b': [0, 1, 0],
+                              'B_b': [1, 1, 0],
+                              'B_c': [0, 0, 1]}, dtype=np.uint8)
         assert_frame_equal(result, expected)
 
     def test_dataframe_dummies_mix_default(self):
         df = self.df
         result = get_dummies(df, sparse=self.sparse)
         expected = DataFrame({'C': [1, 2, 3],
-                              'A_a': [1., 0, 1],
-                              'A_b': [0., 1, 0],
-                              'B_b': [1., 1, 0],
-                              'B_c': [0., 0, 1]})
+                              'A_a': [1, 0, 1],
+                              'A_b': [0, 1, 0],
+                              'B_b': [1, 1, 0],
+                              'B_c': [0, 0, 1]})
+        cols = ['A_a', 'A_b', 'B_b', 'B_c']
+        expected[cols] = expected[cols].astype(np.uint8)
         expected = expected[['C', 'A_a', 'A_b', 'B_b', 'B_c']]
         assert_frame_equal(result, expected)
 
@@ -299,10 +304,12 @@ class TestGetDummies(tm.TestCase):
                         'C': [1, 2, 3]})
         result = get_dummies(df, prefix=prefixes, sparse=self.sparse)
         expected = DataFrame({'C': [1, 2, 3],
-                              'from_A_a': [1., 0, 1],
-                              'from_A_b': [0., 1, 0],
-                              'from_B_b': [1., 1, 0],
-                              'from_B_c': [0., 0, 1]})
+                              'from_A_a': [1, 0, 1],
+                              'from_A_b': [0, 1, 0],
+                              'from_B_b': [1, 1, 0],
+                              'from_B_c': [0, 0, 1]})
+        cols = expected.columns[1:]
+        expected[cols] = expected[cols].astype(np.uint8)
         expected = expected[['C', 'from_A_a', 'from_A_b', 'from_B_b',
                              'from_B_c']]
         assert_frame_equal(result, expected)
@@ -311,31 +318,37 @@ class TestGetDummies(tm.TestCase):
         # not that you should do this...
         df = self.df
         result = get_dummies(df, prefix='bad', sparse=self.sparse)
-        expected = DataFrame([[1, 1., 0., 1., 0.],
-                              [2, 0., 1., 1., 0.],
-                              [3, 1., 0., 0., 1.]],
-                             columns=['C', 'bad_a', 'bad_b', 'bad_b', 'bad_c'])
+        expected = DataFrame([[1, 1, 0, 1, 0],
+                              [2, 0, 1, 1, 0],
+                              [3, 1, 0, 0, 1]],
+                             columns=['C', 'bad_a', 'bad_b', 'bad_b', 'bad_c'],
+                             dtype=np.uint8)
+        expected = expected.astype({"C": np.int})
         assert_frame_equal(result, expected)
 
     def test_dataframe_dummies_subset(self):
         df = self.df
         result = get_dummies(df, prefix=['from_A'], columns=['A'],
                              sparse=self.sparse)
-        expected = DataFrame({'from_A_a': [1., 0, 1],
-                              'from_A_b': [0., 1, 0],
+        expected = DataFrame({'from_A_a': [1, 0, 1],
+                              'from_A_b': [0, 1, 0],
                               'B': ['b', 'b', 'c'],
                               'C': [1, 2, 3]})
+        cols = ['from_A_a', 'from_A_b']
+        expected[cols] = expected[cols].astype(np.uint8)
         assert_frame_equal(result, expected)
 
     def test_dataframe_dummies_prefix_sep(self):
         df = self.df
         result = get_dummies(df, prefix_sep='..', sparse=self.sparse)
         expected = DataFrame({'C': [1, 2, 3],
-                              'A..a': [1., 0, 1],
-                              'A..b': [0., 1, 0],
-                              'B..b': [1., 1, 0],
-                              'B..c': [0., 0, 1]})
+                              'A..a': [1, 0, 1],
+                              'A..b': [0, 1, 0],
+                              'B..b': [1, 1, 0],
+                              'B..c': [0, 0, 1]})
         expected = expected[['C', 'A..a', 'A..b', 'B..b', 'B..c']]
+        cols = expected.columns[1:]
+        expected[cols] = expected[cols].astype(np.uint8)
         assert_frame_equal(result, expected)
 
         result = get_dummies(df, prefix_sep=['..', '__'], sparse=self.sparse)
@@ -360,11 +373,13 @@ class TestGetDummies(tm.TestCase):
                         'B': ['b', 'b', 'c'],
                         'C': [1, 2, 3]})
         result = get_dummies(df, prefix=prefixes, sparse=self.sparse)
-        expected = DataFrame({'from_A_a': [1., 0, 1],
-                              'from_A_b': [0., 1, 0],
-                              'from_B_b': [1., 1, 0],
-                              'from_B_c': [0., 0, 1],
+        expected = DataFrame({'from_A_a': [1, 0, 1],
+                              'from_A_b': [0, 1, 0],
+                              'from_B_b': [1, 1, 0],
+                              'from_B_c': [0, 0, 1],
                               'C': [1, 2, 3]})
+        cols = ['from_A_a', 'from_A_b', 'from_B_b', 'from_B_c']
+        expected[cols] = expected[cols].astype(np.uint8)
         assert_frame_equal(result, expected)
 
     def test_dataframe_dummies_with_na(self):
@@ -372,12 +387,14 @@ class TestGetDummies(tm.TestCase):
         df.loc[3, :] = [np.nan, np.nan, np.nan]
         result = get_dummies(df, dummy_na=True, sparse=self.sparse)
         expected = DataFrame({'C': [1, 2, 3, np.nan],
-                              'A_a': [1., 0, 1, 0],
-                              'A_b': [0., 1, 0, 0],
-                              'A_nan': [0., 0, 0, 1],
-                              'B_b': [1., 1, 0, 0],
-                              'B_c': [0., 0, 1, 0],
-                              'B_nan': [0., 0, 0, 1]})
+                              'A_a': [1, 0, 1, 0],
+                              'A_b': [0, 1, 0, 0],
+                              'A_nan': [0, 0, 0, 1],
+                              'B_b': [1, 1, 0, 0],
+                              'B_c': [0, 0, 1, 0],
+                              'B_nan': [0, 0, 0, 1]})
+        cols = ['A_a', 'A_b', 'A_nan', 'B_b', 'B_c', 'B_nan']
+        expected[cols] = expected[cols].astype(np.uint8)
         expected = expected[['C', 'A_a', 'A_b', 'A_nan',
                              'B_b', 'B_c', 'B_nan']]
         assert_frame_equal(result, expected)
@@ -391,12 +408,14 @@ class TestGetDummies(tm.TestCase):
         df['cat'] = pd.Categorical(['x', 'y', 'y'])
         result = get_dummies(df, sparse=self.sparse)
         expected = DataFrame({'C': [1, 2, 3],
-                              'A_a': [1., 0, 1],
-                              'A_b': [0., 1, 0],
-                              'B_b': [1., 1, 0],
-                              'B_c': [0., 0, 1],
-                              'cat_x': [1., 0, 0],
-                              'cat_y': [0., 1, 1]})
+                              'A_a': [1, 0, 1],
+                              'A_b': [0, 1, 0],
+                              'B_b': [1, 1, 0],
+                              'B_c': [0, 0, 1],
+                              'cat_x': [1, 0, 0],
+                              'cat_y': [0, 1, 1]})
+        cols = ['A_a', 'A_b', 'B_b', 'B_c', 'cat_x', 'cat_y']
+        expected[cols] = expected[cols].astype(np.uint8)
         expected = expected[['C', 'A_a', 'A_b', 'B_b', 'B_c',
                              'cat_x', 'cat_y']]
         assert_frame_equal(result, expected)
@@ -408,12 +427,12 @@ class TestGetDummies(tm.TestCase):
         s_series = Series(s_list)
         s_series_index = Series(s_list, list('ABC'))
 
-        expected = DataFrame({'b': {0: 0.0,
-                                    1: 1.0,
-                                    2: 0.0},
-                              'c': {0: 0.0,
-                                    1: 0.0,
-                                    2: 1.0}})
+        expected = DataFrame({'b': {0: 0,
+                                    1: 1,
+                                    2: 0},
+                              'c': {0: 0,
+                                    1: 0,
+                                    2: 1}}, dtype=np.uint8)
 
         result = get_dummies(s_list, sparse=self.sparse, drop_first=True)
         assert_frame_equal(result, expected)
@@ -449,19 +468,19 @@ class TestGetDummies(tm.TestCase):
         # Test NA hadling together with drop_first
         s_NA = ['a', 'b', np.nan]
         res = get_dummies(s_NA, sparse=self.sparse, drop_first=True)
-        exp = DataFrame({'b': {0: 0.0,
-                               1: 1.0,
-                               2: 0.0}})
+        exp = DataFrame({'b': {0: 0,
+                               1: 1,
+                               2: 0}}, dtype=np.uint8)
         assert_frame_equal(res, exp)
 
         res_na = get_dummies(s_NA, dummy_na=True, sparse=self.sparse,
                              drop_first=True)
-        exp_na = DataFrame({'b': {0: 0.0,
-                                  1: 1.0,
-                                  2: 0.0},
-                            nan: {0: 0.0,
-                                  1: 0.0,
-                                  2: 1.0}}).reindex_axis(
+        exp_na = DataFrame({'b': {0: 0,
+                                  1: 1,
+                                  2: 0},
+                            nan: {0: 0,
+                                  1: 0,
+                                  2: 1}}, dtype=np.uint8).reindex_axis(
                                       ['b', nan], 1)
         assert_frame_equal(res_na, exp_na)
 
@@ -473,8 +492,8 @@ class TestGetDummies(tm.TestCase):
     def test_dataframe_dummies_drop_first(self):
         df = self.df[['A', 'B']]
         result = get_dummies(df, sparse=self.sparse, drop_first=True)
-        expected = DataFrame({'A_b': [0., 1, 0],
-                              'B_c': [0., 0, 1]})
+        expected = DataFrame({'A_b': [0, 1, 0],
+                              'B_c': [0, 0, 1]}, dtype=np.uint8)
         assert_frame_equal(result, expected)
 
     def test_dataframe_dummies_drop_first_with_categorical(self):
@@ -482,9 +501,11 @@ class TestGetDummies(tm.TestCase):
         df['cat'] = pd.Categorical(['x', 'y', 'y'])
         result = get_dummies(df, sparse=self.sparse, drop_first=True)
         expected = DataFrame({'C': [1, 2, 3],
-                              'A_b': [0., 1, 0],
-                              'B_c': [0., 0, 1],
-                              'cat_y': [0., 1, 1]})
+                              'A_b': [0, 1, 0],
+                              'B_c': [0, 0, 1],
+                              'cat_y': [0, 1, 1]})
+        cols = ['A_b', 'B_c', 'cat_y']
+        expected[cols] = expected[cols].astype(np.uint8)
         expected = expected[['C', 'A_b', 'B_c', 'cat_y']]
         assert_frame_equal(result, expected)
 
@@ -494,10 +515,13 @@ class TestGetDummies(tm.TestCase):
         result = get_dummies(df, dummy_na=True, sparse=self.sparse,
                              drop_first=True)
         expected = DataFrame({'C': [1, 2, 3, np.nan],
-                              'A_b': [0., 1, 0, 0],
-                              'A_nan': [0., 0, 0, 1],
-                              'B_c': [0., 0, 1, 0],
-                              'B_nan': [0., 0, 0, 1]})
+                              'A_b': [0, 1, 0, 0],
+                              'A_nan': [0, 0, 0, 1],
+                              'B_c': [0, 0, 1, 0],
+                              'B_nan': [0, 0, 0, 1]})
+        cols = ['A_b', 'A_nan', 'B_c', 'B_nan']
+        expected[cols] = expected[cols].astype(np.uint8)
+
         expected = expected[['C', 'A_b', 'A_nan', 'B_c', 'B_nan']]
         assert_frame_equal(result, expected)
 
@@ -505,6 +529,37 @@ class TestGetDummies(tm.TestCase):
                              drop_first=True)
         expected = expected[['C', 'A_b', 'B_c']]
         assert_frame_equal(result, expected)
+
+    def test_int_int(self):
+        data = Series([1, 2, 1])
+        result = pd.get_dummies(data)
+        expected = DataFrame([[1, 0], [0, 1], [1, 0]], columns=[1, 2],
+                             dtype=np.uint8)
+        tm.assert_frame_equal(result, expected)
+
+        data = Series(pd.Categorical(['a', 'b', 'a']))
+        result = pd.get_dummies(data)
+        expected = DataFrame([[1, 0], [0, 1], [1, 0]], columns=['a', 'b'],
+                             dtype=np.uint8)
+        tm.assert_frame_equal(result, expected)
+
+    def test_int_df(self):
+        data = DataFrame(
+            {'A': [1, 2, 1],
+             'B': pd.Categorical(['a', 'b', 'a']),
+             'C': [1, 2, 1],
+             'D': [1., 2., 1.]
+             }
+        )
+        columns = ['C', 'D', 'A_1', 'A_2', 'B_a', 'B_b']
+        expected = DataFrame([
+            [1, 1., 1, 0, 1, 0],
+            [2, 2., 0, 1, 0, 1],
+            [1, 1., 1, 0, 1, 0]
+        ], columns=columns)
+        expected[columns[2:]] = expected[columns[2:]].astype(np.uint8)
+        result = pd.get_dummies(data, columns=['A', 'B'])
+        tm.assert_frame_equal(result, expected)
 
 
 class TestGetDummiesSparse(TestGetDummies):


### PR DESCRIPTION
closes #8725

Changes `get_dummies` return columns with `uint8` dtypes instead of coercing to floats if they were alongside other float columns.
