### PR TITLE
TST: Add test for skipfooter + decimal in read_csv

### DIFF
--- a/pandas/io/tests/parser/python_parser_only.py
+++ b/pandas/io/tests/parser/python_parser_only.py
@@ -185,3 +185,19 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         result = self.read_csv(new_file, sep=r"\s*", header=None)
         expected = DataFrame([[0, 0]])
         tm.assert_frame_equal(result, expected)
+
+    def test_skipfooter_with_decimal(self):
+        # see gh-6971
+        data = '1#2\n3#4'
+        expected = DataFrame({'a': [1.2, 3.4]})
+
+        result = self.read_csv(StringIO(data), names=['a'],
+                               decimal='#')
+        tm.assert_frame_equal(result, expected)
+
+        # the stray footer line should not mess with the
+        # casting of the first t    wo lines if we skip it
+        data = data + '\nFooter'
+        result = self.read_csv(StringIO(data), names=['a'],
+                               decimal='#', skipfooter=1)
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
Title is self-explanatory.  Only for Python engine because C engine doesn't support `skipfooter` yet.

Closes #6971.
