### PR TITLE
BUG: handle outofbounds datetimes in DatetimeConverter

### DIFF
--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -1222,6 +1222,14 @@ class TestTSPlot(TestPlotBase):
         self.assertEqual(left, ts_irregular.index.min().toordinal())
         self.assertEqual(right, ts_irregular.index.max().toordinal())
 
+    def test_plot_outofbounds_datetime(self):
+        # 2579 - checking this does not raise
+        values = [date(1677, 1, 1), date(1677, 1, 2)]
+        self.plt.plot(values)
+
+        values = [datetime(1677, 1, 1, 12), datetime(1677, 1, 2, 12)]
+        self.plt.plot(values)
+
 
 def _check_plot_works(f, freq=None, series=None, *args, **kwargs):
     import matplotlib.pyplot as plt

--- a/pandas/tseries/converter.py
+++ b/pandas/tseries/converter.py
@@ -216,7 +216,7 @@ class DatetimeConverter(dates.DateConverter):
                 else:
                     values = [_dt_to_float_ordinal(x) for x in values]
             except Exception:
-                pass
+                values = _dt_to_float_ordinal(values)
 
         return values
 

--- a/pandas/tseries/tests/test_converter.py
+++ b/pandas/tseries/tests/test_converter.py
@@ -77,6 +77,24 @@ class TestDateTimeConverter(tm.TestCase):
         rs = self.dtc.convert(datetime(2012, 1, 1, 1, 2, 3), None, None)
         tm.assert_almost_equal(rs, xp, decimals)
 
+    def test_conversion_outofbounds_datetime(self):
+        # 2579
+        values = [date(1677, 1, 1), date(1677, 1, 2)]
+        rs = self.dtc.convert(values, None, None)
+        xp = converter.dates.date2num(values)
+        tm.assert_numpy_array_equal(rs, xp)
+        rs = self.dtc.convert(values[0], None, None)
+        xp = converter.dates.date2num(values[0])
+        self.assertEqual(rs, xp)
+
+        values = [datetime(1677, 1, 1, 12), datetime(1677, 1, 2, 12)]
+        rs = self.dtc.convert(values, None, None)
+        xp = converter.dates.date2num(values)
+        tm.assert_numpy_array_equal(rs, xp)
+        rs = self.dtc.convert(values[0], None, None)
+        xp = converter.dates.date2num(values[0])
+        self.assertEqual(rs, xp)
+
     def test_time_formatter(self):
         self.tc(90000)
 


### PR DESCRIPTION
xref #2579

This at least solves the direct negative consequence (erroring code by importing pandas) of registering our converters by default.
