### PR TITLE
CLN: Removed the kwds param in to_csv

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -693,6 +693,7 @@ Removal of prior version deprecations/changes
 - ``DataFrame.to_sql()`` has dropped the ``mysql`` option for the ``flavor`` parameter (:issue:`13611`)
 - ``pd.Index`` has dropped the ``diff`` method in favour of ``difference`` (:issue:`13669`)
 
+- ``Series.to_csv`` has dropped the ``nanRep`` parameter in favor of ``na_rep`` (:issue:`13804`)
 - ``Series.xs``, ``DataFrame.xs``, ``Panel.xs``, ``Panel.major_xs``, and ``Panel.minor_xs`` have dropped the ``copy`` parameter (:issue:`13781`)
 - ``str.split`` has dropped the ``return_type`` parameter in favor of ``expand`` (:issue:`13701`)
 - Removal of the legacy time rules (offset aliases), deprecated since 0.17.0 (this has been alias since 0.8.0) (:issue:`13590`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1305,7 +1305,7 @@ class DataFrame(NDFrame):
                mode='w', encoding=None, compression=None, quoting=None,
                quotechar='"', line_terminator='\n', chunksize=None,
                tupleize_cols=False, date_format=None, doublequote=True,
-               escapechar=None, decimal='.', **kwds):
+               escapechar=None, decimal='.'):
         r"""Write DataFrame to a comma-separated values (csv) file
 
         Parameters
@@ -1332,8 +1332,6 @@ class DataFrame(NDFrame):
             sequence should be given if the DataFrame uses MultiIndex.  If
             False do not print fields for index names. Use index_label=False
             for easier importing in R
-        nanRep : None
-            deprecated, use na_rep
         mode : str
             Python write mode, default 'w'
         encoding : string, optional

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2534,8 +2534,8 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         return result
 
     def to_csv(self, path, index=True, sep=",", na_rep='', float_format=None,
-               header=False, index_label=None, mode='w', nanRep=None,
-               encoding=None, date_format=None, decimal='.'):
+               header=False, index_label=None, mode='w', encoding=None,
+               date_format=None, decimal='.'):
         """
         Write Series to a comma-separated values (csv) file
 
@@ -2572,7 +2572,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         # result is only a string if no path provided, otherwise None
         result = df.to_csv(path, index=index, sep=sep, na_rep=na_rep,
                            float_format=float_format, header=header,
-                           index_label=index_label, mode=mode, nanRep=nanRep,
+                           index_label=index_label, mode=mode,
                            encoding=encoding, date_format=date_format,
                            decimal=decimal)
         if path is None:

--- a/pandas/tests/formats/test_format.py
+++ b/pandas/tests/formats/test_format.py
@@ -3139,10 +3139,6 @@ b &       b &     b \\
             df.to_csv(path, quoting=1)  # 1=QUOTE_ALL
             with open(path, 'r') as f:
                 self.assertEqual(f.read(), expected)
-        with tm.ensure_clean('test.csv') as path:
-            df.to_csv(path, quoting=1, engine='python')
-            with open(path, 'r') as f:
-                self.assertEqual(f.read(), expected)
 
         expected = """\
 $$,$col$
@@ -3154,17 +3150,10 @@ $1$,$2$
             df.to_csv(path, quoting=1, quotechar="$")
             with open(path, 'r') as f:
                 self.assertEqual(f.read(), expected)
-        with tm.ensure_clean('test.csv') as path:
-            df.to_csv(path, quoting=1, quotechar="$", engine='python')
-            with open(path, 'r') as f:
-                self.assertEqual(f.read(), expected)
 
         with tm.ensure_clean('test.csv') as path:
             with tm.assertRaisesRegexp(TypeError, 'quotechar'):
                 df.to_csv(path, quoting=1, quotechar=None)
-        with tm.ensure_clean('test.csv') as path:
-            with tm.assertRaisesRegexp(TypeError, 'quotechar'):
-                df.to_csv(path, quoting=1, quotechar=None, engine='python')
 
     def test_to_csv_doublequote(self):
         df = DataFrame({'col': ['a"a', '"bb"']})
@@ -3178,18 +3167,11 @@ $1$,$2$
             df.to_csv(path, quoting=1, doublequote=True)  # QUOTE_ALL
             with open(path, 'r') as f:
                 self.assertEqual(f.read(), expected)
-        with tm.ensure_clean('test.csv') as path:
-            df.to_csv(path, quoting=1, doublequote=True, engine='python')
-            with open(path, 'r') as f:
-                self.assertEqual(f.read(), expected)
 
         from _csv import Error
         with tm.ensure_clean('test.csv') as path:
             with tm.assertRaisesRegexp(Error, 'escapechar'):
                 df.to_csv(path, doublequote=False)  # no escapechar set
-        with tm.ensure_clean('test.csv') as path:
-            with tm.assertRaisesRegexp(Error, 'escapechar'):
-                df.to_csv(path, doublequote=False, engine='python')
 
     def test_to_csv_escapechar(self):
         df = DataFrame({'col': ['a"a', '"bb"']})
@@ -3203,11 +3185,6 @@ $1$,$2$
             df.to_csv(path, quoting=1, doublequote=False, escapechar='\\')
             with open(path, 'r') as f:
                 self.assertEqual(f.read(), expected)
-        with tm.ensure_clean('test.csv') as path:
-            df.to_csv(path, quoting=1, doublequote=False, escapechar='\\',
-                      engine='python')
-            with open(path, 'r') as f:
-                self.assertEqual(f.read(), expected)
 
         df = DataFrame({'col': ['a,a', ',bb,']})
         expected = """\
@@ -3218,10 +3195,6 @@ $1$,$2$
 
         with tm.ensure_clean('test.csv') as path:
             df.to_csv(path, quoting=3, escapechar='\\')  # QUOTE_NONE
-            with open(path, 'r') as f:
-                self.assertEqual(f.read(), expected)
-        with tm.ensure_clean('test.csv') as path:
-            df.to_csv(path, quoting=3, escapechar='\\', engine='python')
             with open(path, 'r') as f:
                 self.assertEqual(f.read(), expected)
 

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -896,7 +896,7 @@ class TestDataFrameToCSV(tm.TestCase, TestData):
         # GH 8215
         # Make sure we return string for consistency with
         # Series.to_csv()
-        csv_str = self.frame.to_csv(path=None)
+        csv_str = self.frame.to_csv(path_or_buf=None)
         self.assertIsInstance(csv_str, str)
         recons = pd.read_csv(StringIO(csv_str), index_col=0)
         assert_frame_equal(self.frame, recons)


### PR DESCRIPTION
We aren't using it anymore with the removal of parameters like `engine`.  Closes #8206.
