### PR TITLE
ASV: fix params to be strings (for better repr)

### DIFF
--- a/asv_bench/benchmarks/inference.py
+++ b/asv_bench/benchmarks/inference.py
@@ -139,19 +139,26 @@ class dtype_infer_uint32(object):
 
 
 class to_numeric(object):
+
+    param_names = ['dtype', 'downcast']
+    params = [['string-float', 'string-int', 'string-nint', 'datetime64',
+               'int-list', 'int32'],
+              [None, 'integer', 'signed', 'unsigned', 'float']]
+
     N = 500000
 
-    param_names = ['data', 'downcast']
-    params = [
-        [(['1'] * (N / 2)) + ([2] * (N / 2)),
-         (['-1'] * (N / 2)) + ([2] * (N / 2)),
-         np.repeat(np.array(['1970-01-01', '1970-01-02'],
-                            dtype='datetime64[D]'), N),
-         (['1.1'] * (N / 2)) + ([2] * (N / 2)),
-         ([1] * (N / 2)) + ([2] * (N / 2)),
-         np.repeat(np.int32(1), N)],
-        [None, 'integer', 'signed', 'unsigned', 'float'],
-    ]
+    data_dict = {
+        'string-int': (['1'] * (N / 2)) + ([2] * (N / 2)),
+        'string-nint': (['-1'] * (N / 2)) + ([2] * (N / 2)),
+        'datetime64': np.repeat(np.array(['1970-01-01', '1970-01-02'],
+                                         dtype='datetime64[D]'), N),
+        'string-float': (['1.1'] * (N / 2)) + ([2] * (N / 2)),
+        'int-list': ([1] * (N / 2)) + ([2] * (N / 2)),
+        'int32': np.repeat(np.int32(1), N)
+        }
 
-    def time_to_numeric(self, data, downcast):
-        pd.to_numeric(data, downcast=downcast)
+    def setup(self, dtype, downcast):
+        self.data = self.data_dict[dtype]
+
+    def time_downcast(self, dtype, downcast):
+        pd.to_numeric(self.data, downcast=downcast)


### PR DESCRIPTION
Small fix to using params in asv (otherwise the name was huge, list of 500000 elements)

cc @gfyoung (just so you know I changed this for future reference)
