### PR TITLE
BUG: fixes 13822, incorrect KeyError string with non-unique columns w…

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -855,3 +855,4 @@ Bug Fixes
 
 - Bug in ``.to_excel()`` when DataFrame contains a MultiIndex which contains a label with a NaN value (:issue:`13511`)
 - Bug in ``pd.read_csv`` in Python 2.x with non-UTF8 encoded, multi-character separated data (:issue:`3404`)
+- Bug in ``Index`` raises ``KeyError`` displaying incorrect column when column is not in the df and columns contains duplicate values (:issue:`13822`)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1217,7 +1217,9 @@ class _NDFrameIndexer(object):
                     else:
                         (indexer,
                          missing) = labels.get_indexer_non_unique(objarr)
-                        check = indexer
+                        # 'indexer' has dupes, create 'check' using 'missing'
+                        check = np.zeros_like(objarr)
+                        check[missing] = -1
 
                 mask = check == -1
                 if mask.any():

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -1332,6 +1332,15 @@ class TestIndexing(tm.TestCase):
         self.assertEqual(result, 3)
         self.assertRaises(ValueError, lambda: df.at['a', 0])
 
+        # GH 13822, incorrect error string with non-unique columns when missing
+        # column is accessed
+        df = DataFrame({'x': [1.], 'y': [2.], 'z': [3.]})
+        df.columns = ['x', 'x', 'z']
+
+        # Check that we get the correct value in the KeyError
+        self.assertRaisesRegexp(KeyError, "\['y'\] not in index",
+                                lambda: df[['x', 'y', 'z']])
+
     def test_loc_getitem_label_slice(self):
 
         # label slices (with ints)


### PR DESCRIPTION
- [x] closes #13822 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Made changes to fix the bug related to accessing columns in a df with duplicate columns where the KeyError string was returning the wrong column. 

The test that I added passed, but there seems to be a test that won't pass and I wasn't sure what's going on. Even on a clean master, when I run "nosetests pandas/tests/indexing/test_indexing.py" I get "ERROR: test_float64index_slicing_bug (pandas.tests.indexing.test_indexing.TestIndexing)". 
