### PR TITLE
BUG: Fixed float parsing with unit when using pd.to_datetime (GH13834)

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -972,3 +972,4 @@ Bug Fixes
 
 - Bug in ``Index`` raises ``KeyError`` displaying incorrect column when column is not in the df and columns contains duplicate values (:issue:`13822`)
 - Bug in ``Period`` and ``PeriodIndex`` creating wrong dates when frequency has combined offset aliases (:issue:`13874`)
+- Bug in ``pd.to_datetime()`` did not cast floats correctly when ``unit`` was specified, resulting in truncated datetime (:issue:`13845`)

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -745,6 +745,14 @@ class TestTimeSeries(tm.TestCase):
             seconds=t) for t in range(20)] + [NaT])
         assert_series_equal(result, expected)
 
+        # GH13834
+        s = Series([epoch + t for t in np.arange(0, 2, .25)] +
+                   [iNaT]).astype(float)
+        result = to_datetime(s, unit='s')
+        expected = Series([Timestamp('2013-06-09 02:42:28') + timedelta(
+            seconds=t) for t in np.arange(0, 2, .25)] + [NaT])
+        assert_series_equal(result, expected)
+
         s = concat([Series([epoch + t for t in range(20)]
                            ).astype(float), Series([np.nan])],
                    ignore_index=True)

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -2095,7 +2095,7 @@ cpdef array_with_unit_to_datetime(ndarray values, unit, errors='coerce'):
         # if we have nulls that are not type-compat
         # then need to iterate
         try:
-            iresult = values.astype('i8')
+            iresult = values.astype('i8', casting='same_kind', copy=False)
             mask = iresult == iNaT
             iresult[mask] = 0
             fvalues = iresult.astype('f8') * m


### PR DESCRIPTION
- [x] closes #13834 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
